### PR TITLE
Connector configuration cleanups

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ $(build_dir):
 
 build_connectors = $(addprefix $(build_dir)/build-,$(connectors))
 
-$(build_connectors): $(build_dir)/build-%: $(parser) % | $(build_dir)
+$(build_connectors): $(build_dir)/build-%: $(parser) % go-types | $(build_dir)
 	cd $* && go build
 	docker build -t ghcr.io/estuary/$*:$(version) --build-arg connector=$* .
 	@# This file is only used so that make can correctly determine if targets need rebuilt

--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,11 @@ $(build_dir):
 
 build_connectors = $(addprefix $(build_dir)/build-,$(connectors))
 
-$(build_connectors): $(build_dir)/build-%: $(parser) % go-types | $(build_dir)
+# Second expansion is needed to defer the expansion of $(shell find % -type f) until after the rule
+# is matched. This ensures that the connector will be rebuilt if any file within its source
+# directory is modified.
+.SECONDEXPANSION:
+$(build_connectors): $(build_dir)/build-%: $(parser) % go-types $$(shell find % -type f) | $(build_dir)
 	cd $* && go build
 	docker build -t ghcr.io/estuary/$*:$(version) --build-arg connector=$* .
 	@# This file is only used so that make can correctly determine if targets need rebuilt

--- a/go-types/airbyte/json_test.go
+++ b/go-types/airbyte/json_test.go
@@ -1,0 +1,42 @@
+package airbyte
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestConfiguredCatalogMarshaling(t *testing.T) {
+	var start = `{
+        "streams": [{
+            "stream": {"name": "foo","json_schema":true},
+            "sync_mode": "incremental",
+            "destination_sync_mode": "append",
+            "primary_key": ["/yea", "/boiiii"],
+            "projections": {
+                "space": "/balls",
+                "blazing": "/saddles"
+            }
+        }],
+        "tail": true,
+        "range": {
+            "begin": "00000000",
+            "end": "FFFFFFFF"
+        }
+    }`
+	var resultOne = ConfiguredCatalog{}
+	require.NoError(t, json.Unmarshal([]byte(start), &resultOne))
+
+	// We always serialize using the namespaced fields.
+	var serJson, err = json.Marshal(&resultOne)
+	require.NoError(t, err)
+	require.Contains(t, string(serJson), `"estuary.dev/projections":`)
+	require.Contains(t, string(serJson), `"estuary.dev/tail":`)
+	require.Contains(t, string(serJson), `"estuary.dev/range":`)
+
+	// Deserialize again and assert that we get the same struct value as the first result.
+	var roundTripped = ConfiguredCatalog{}
+	require.NoError(t, json.Unmarshal(serJson, &roundTripped))
+	require.Equal(t, resultOne, roundTripped)
+}

--- a/go-types/shardrange/partition_range.go
+++ b/go-types/shardrange/partition_range.go
@@ -25,6 +25,11 @@ func NewFullRange() Range {
 	}
 }
 
+// IsZeroed returns true if the begin and end are both 0
+func (r Range) IsZeroed() bool {
+	return r.Begin == 0 && r.End == 0
+}
+
 func (r Range) MarshalJSON() ([]byte, error) {
 	var tmp = struct {
 		Begin string `json:"begin"`

--- a/go-types/shardrange/partition_range.go
+++ b/go-types/shardrange/partition_range.go
@@ -25,8 +25,8 @@ func NewFullRange() Range {
 	}
 }
 
-// IsZeroed returns true if the begin and end are both 0
-func (r Range) IsZeroed() bool {
+// IsZero returns true if the begin and end are both 0
+func (r Range) IsZero() bool {
 	return r.Begin == 0 && r.End == 0
 }
 

--- a/source-kinesis/capture_test.go
+++ b/source-kinesis/capture_test.go
@@ -88,19 +88,17 @@ func TestKinesisCaptureWithShardOverlap(t *testing.T) {
 	var ctx, cancelFunc = context.WithCancel(context.Background())
 	defer cancelFunc()
 
-	var shard1Conf = conf
-	shard1Conf.ShardRange = &shardrange.Range{
+	var shard1Range = shardrange.Range{
 		Begin: 0,
 		End:   math.MaxUint32 / 2,
 	}
-	go readStream(ctx, shard1Conf, client, stream, nil, dataCh)
+	go readStream(ctx, shard1Range, client, stream, nil, dataCh)
 
-	var shard2Conf = conf
-	shard2Conf.ShardRange = &shardrange.Range{
+	var shard2Range = shardrange.Range{
 		Begin: math.MaxUint32 / 2,
 		End:   math.MaxUint32,
 	}
-	go readStream(ctx, shard2Conf, client, stream, nil, dataCh)
+	go readStream(ctx, shard2Range, client, stream, nil, dataCh)
 
 	var partitionKeys = []string{"furst", "sekund", "thuurd", "phorth"}
 	var sequencNumbers = make(map[string]string)

--- a/source-kinesis/connection.go
+++ b/source-kinesis/connection.go
@@ -40,33 +40,33 @@ var configJSONSchema = `{
 	"required": [
 		"region",
 		"awsAccessKeyId",
-		"awsSecretAccessKey",
+		"awsSecretAccessKey"
 	],
 	"properties": {
 		"region": {
 			"type":        "string",
 			"title":       "AWS Region",
 			"description": "The name of the AWS region where the Kinesis stream is located",
-			"default":     "us-east-1",
+			"default":     "us-east-1"
 		},
 		"endpoint": {
 			"type":        "string",
 			"title":       "AWS Endpoint",
-			"description": "The AWS endpoint URI to connect to, useful if you're capturing from a kinesis-compatible API that isn't provided by AWS",
+			"description": "The AWS endpoint URI to connect to, useful if you're capturing from a kinesis-compatible API that isn't provided by AWS"
 		},
 		"awsAccessKeyId": {
 			"type":        "string",
 			"title":       "AWS Access Key ID",
 			"description": "Part of the AWS credentials that will be used to connect to Kinesis",
-			"default":     "example-aws-access-key-id",
+			"default":     "example-aws-access-key-id"
 		},
 		"awsSecretAccessKey": {
 			"type":        "string",
 			"title":       "AWS Secret Access Key",
 			"description": "Part of the AWS credentials that will be used to connect to Kinesis",
-			"default":     "example-aws-secret-access-key",
+			"default":     "example-aws-secret-access-key"
 		}
-	},
+	}
 }`
 
 func connect(config *Config) (*kinesis.Kinesis, error) {

--- a/source-kinesis/connection.go
+++ b/source-kinesis/connection.go
@@ -8,18 +8,16 @@ import (
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/kinesis"
-	"github.com/estuary/connectors/go-types/shardrange"
 	log "github.com/sirupsen/logrus"
 )
 
 // Config represents the fully merged endpoint configuration for Kinesis.
 // It matches the `KinesisConfig` struct in `crates/sources/src/specs.rs`
 type Config struct {
-	ShardRange         *shardrange.Range `json:"shardRange"`
-	Endpoint           string            `json:"endpoint"`
-	Region             string            `json:"region"`
-	AWSAccessKeyID     string            `json:"awsAccessKeyId"`
-	AWSSecretAccessKey string            `json:"awsSecretAccessKey"`
+	Endpoint           string `json:"endpoint"`
+	Region             string `json:"region"`
+	AWSAccessKeyID     string `json:"awsAccessKeyId"`
+	AWSSecretAccessKey string `json:"awsSecretAccessKey"`
 }
 
 func (c *Config) Validate() error {
@@ -67,24 +65,7 @@ var configJSONSchema = `{
 			"title":       "AWS Secret Access Key",
 			"description": "Part of the AWS credentials that will be used to connect to Kinesis",
 			"default":     "example-aws-secret-access-key",
-		},
-		"shardRange": {
-			"type": "object",
-			"properties": {
-				"end": {
-					"type":        "string",
-					"pattern":     "^[0-9a-fA-F]{8}$",
-					"title":       "Partition range begin",
-					"description": "Unsigned 32 bit integer represented as a hexidecimal string, which is used to determine which partitions this instance will be responsible for",
-				},
-				"begin": {
-					"type":        "string",
-					"pattern":     "^[0-9a-fA-F]{8}$",
-					"title":       "Partition range begin",
-					"description": "Unsigned 32 bit integer represented as a hexidecimal string, which is used to determine which partitions this instance will be responsible for",
-				},
-			},
-		},
+		}
 	},
 }`
 

--- a/source-kinesis/main.go
+++ b/source-kinesis/main.go
@@ -130,7 +130,7 @@ func readStreamsTo(ctx context.Context, args airbyte.ReadCmd, output io.Writer) 
 	log.WithField("streamCount", len(catalog.Streams)).Info("Starting to read stream(s)")
 
 	var shardRange = catalog.Range
-	if shardRange.IsZeroed() {
+	if shardRange.IsZero() {
 		log.Info("using full shard range since no range was given in the catalog")
 		shardRange = shardrange.NewFullRange()
 	}

--- a/source-s3/connection.go
+++ b/source-s3/connection.go
@@ -38,14 +38,14 @@ func (c *Config) Validate() error {
 }
 
 func configJSONSchema(parserSchema json.RawMessage) json.RawMessage {
-	return json.RawMessage(fmt.Sprintf(`
+	return json.RawMessage(fmt.Sprintf(`{
 		"$schema": "http://json-schema.org/draft-07/schema#",
 		"title":   "S3 Source Spec",
 		"type":    "object",
-		"required": {
+		"required": [
 			"awsAccessKeyId",
 			"awsSecretAccessKey"
-		},
+		],
 		"properties": {
 			"bucket": {
 				"type":        "string",
@@ -63,7 +63,7 @@ func configJSONSchema(parserSchema json.RawMessage) json.RawMessage {
 				"format":      "regex",
 				"description": "Filter applied to all object keys under the prefix. If provided, only objects whose key (relative to the prefix) matches this regex will be read. For example, you can use \".*\\.json\" to only capture json files."
 			},
-			"parser": parserSchema,
+			"parser": %s,
 			"region": {
 				"type":        "string",
 				"title":       "AWS Region",
@@ -86,26 +86,9 @@ func configJSONSchema(parserSchema json.RawMessage) json.RawMessage {
 				"title":       "AWS Secret Access Key",
 				"description": "Part of the AWS credentials that will be used to connect to S3",
 				"default":     "example-aws-secret-access-key"
-			},
-			"shardRange": {
-				"type": "object",
-				"properties": {
-					"end": {
-						"type":        "string",
-						"pattern":     "^[0-9a-fA-F]{8}$",
-						"title":       "Partition range begin",
-						"description": "Unsigned 32 bit integer represented as a hexidecimal string, which is used to determine which partitions this instance will be responsible for"
-					}
-					"begin": {
-						"type":        "string",
-						"pattern":     "^[0-9a-fA-F]{8}$",
-						"title":       "Partition range begin",
-						"description": "Unsigned 32 bit integer represented as a hexidecimal string, which is used to determine which partitions this instance will be responsible for"
-					}
-				}
 			}
 		}
-    `))
+    }`, string(parserSchema)))
 }
 
 func connect(ctx context.Context, config *Config) (*s3.S3, error) {

--- a/source-s3/connection.go
+++ b/source-s3/connection.go
@@ -11,21 +11,17 @@ import (
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/estuary/connectors/go-types/airbyte"
 	"github.com/estuary/connectors/go-types/parser"
-	"github.com/estuary/connectors/go-types/shardrange"
-	log "github.com/sirupsen/logrus"
 )
 
 type Config struct {
-	// TODO: move shard range out of config
-	ShardRange         *shardrange.Range `json:"shardRange"`
-	Endpoint           string            `json:"endpoint"`
-	Bucket             string            `json:"bucket"`
-	Prefix             string            `json:"prefix"`
-	MatchKeys          string            `json:"matchKeys"`
-	Region             string            `json:"region"`
-	AWSAccessKeyID     string            `json:"awsAccessKeyId"`
-	AWSSecretAccessKey string            `json:"awsSecretAccessKey"`
-	Parser             *parser.Config    `json:"parser"`
+	Endpoint           string         `json:"endpoint"`
+	Bucket             string         `json:"bucket"`
+	Prefix             string         `json:"prefix"`
+	MatchKeys          string         `json:"matchKeys"`
+	Region             string         `json:"region"`
+	AWSAccessKeyID     string         `json:"awsAccessKeyId"`
+	AWSSecretAccessKey string         `json:"awsSecretAccessKey"`
+	Parser             *parser.Config `json:"parser"`
 }
 
 func (c *Config) Validate() error {
@@ -140,13 +136,6 @@ func parseConfigAndConnect(ctx context.Context, configFile airbyte.ConfigFile) (
 	if err != nil {
 		err = fmt.Errorf("parsing config file: %w", err)
 		return
-	}
-	// If the partition range was not included in the configuration, then we'll assume the full
-	// range.
-	if config.ShardRange == nil {
-		log.Info("Assuming full partition range since no partitionRange was included in the configuration")
-		var fullRange = shardrange.NewFullRange()
-		config.ShardRange = &fullRange
 	}
 	client, err = connect(ctx, &config)
 	if err != nil {

--- a/source-s3/main.go
+++ b/source-s3/main.go
@@ -156,7 +156,7 @@ func doRead(args airbyte.ReadCmd) error {
 	}
 
 	var shardRange = catalog.Range
-	if shardRange.IsZeroed() {
+	if shardRange.IsZero() {
 		log.Info("Assuming full partition range since no partitionRange was included in the catalog")
 		shardRange = shardrange.NewFullRange()
 	}


### PR DESCRIPTION
This PR addresses a few different issues:

- Add `projections` to `ConfiguredStream` and pass them through to the parser configuration in the S3 connector
- Namespace `ConfiguredStream.projections` and `ConfiguredCatalog.tail | range` with `estuary.dev/` prefix, but still accept the un-prefixed field names as well. The intent will be to do away with the prefix if and when these are merged into the airbyte spec.
- Fixes a few issues I found with the `spec` subcommands panicing due to invalid json.
- Add missing pre-requisites to connector build makefile tasks