### PR TITLE
Minor fixes to source-s3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ build_connectors = $(addprefix $(build_dir)/build-,$(connectors))
 # is matched. This ensures that the connector will be rebuilt if any file within its source
 # directory is modified.
 .SECONDEXPANSION:
-$(build_connectors): $(build_dir)/build-%: $(parser) % go-types $$(shell find % -type f) | $(build_dir)
+$(build_connectors): $(build_dir)/build-%: $(parser) % go-types $(shell find go-types -type f) $$(shell find % -type f) | $(build_dir)
 	cd $* && go build
 	docker build -t ghcr.io/estuary/$*:$(version) --build-arg connector=$* .
 	@# This file is only used so that make can correctly determine if targets need rebuilt

--- a/go-types/filesource/filesource.go
+++ b/go-types/filesource/filesource.go
@@ -229,12 +229,13 @@ func (src Source) Read(args airbyte.ReadCmd) error {
 	if err != nil {
 		return err
 	}
-	var catalog = airbyte.ConfiguredCatalog{
-		// Process all files, unless the parsed catalog says otherwise.
-		Range: shardrange.NewFullRange(),
-	}
+	var catalog = airbyte.ConfiguredCatalog{}
 	if err = args.CatalogFile.Parse(&catalog); err != nil {
 		return fmt.Errorf("parsing configured catalog: %w", err)
+	}
+	if catalog.Range.IsZero() {
+		// Process all files, unless the parsed catalog says otherwise.
+		catalog.Range = shardrange.NewFullRange()
 	}
 
 	var states = make(States)

--- a/go-types/filesource/filesource.go
+++ b/go-types/filesource/filesource.go
@@ -401,7 +401,7 @@ func (r *reader) processObject(ctx context.Context, obj ObjectInfo) error {
 		return r.emit(lines)
 	})
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to parse object %q: %w", obj.Path, err)
 	}
 	r.state.finishPath()
 

--- a/source-s3/main.go
+++ b/source-s3/main.go
@@ -65,6 +65,8 @@ func newS3Store(ctx context.Context, cfg *config) (*s3Store, error) {
 	if cfg.AWSSecretAccessKey != "" {
 		var creds = credentials.NewStaticCredentials(cfg.AWSAccessKeyID, cfg.AWSSecretAccessKey, "")
 		c = c.WithCredentials(creds)
+	} else {
+		c = c.WithCredentials(credentials.AnonymousCredentials)
 	}
 	c = c.WithCredentialsChainVerboseErrors(true)
 


### PR DESCRIPTION
- Use AnonymousCredentials when no credentials are provided in the config. This allows ingestion of data from public buckets.
- Include the object Path in the error message when parsing fails, so that it's easier to track down parse errors.