### PR TITLE
Fix parser handling of overflowing numberic values

### DIFF
--- a/parser/src/format/projection.rs
+++ b/parser/src/format/projection.rs
@@ -11,9 +11,8 @@ use std::collections::BTreeMap;
 /// Information known about a specific location within a JSON document.
 #[derive(Debug, Clone, PartialEq)]
 pub struct TypeInfo {
-    /// The possible JSON types for this location. If the types are unknown, this will be
-    /// `types::INVALID`.
-    pub possible_types: types::Set,
+    /// The possible JSON types for this location, if any type information could be inferred.
+    pub possible_types: Option<types::Set>,
     pub must_exist: bool,
     pub target_location: Pointer,
 }
@@ -23,7 +22,7 @@ impl TypeInfo {
         TypeInfo {
             target_location,
             must_exist: exists == Exists::Must,
-            possible_types: shape.type_,
+            possible_types: Some(shape.type_),
         }
     }
 }
@@ -85,7 +84,7 @@ pub fn build_projections(config: &ParseConfig) -> Result<BTreeMap<String, TypeIn
             TypeInfo {
                 target_location,
                 must_exist: false,
-                possible_types: types::INVALID,
+                possible_types: None,
             }
         };
         results.insert(field.clone(), projection);

--- a/parser/src/format/projection.rs
+++ b/parser/src/format/projection.rs
@@ -11,6 +11,8 @@ use std::collections::BTreeMap;
 /// Information known about a specific location within a JSON document.
 #[derive(Debug, Clone, PartialEq)]
 pub struct TypeInfo {
+    /// The possible JSON types for this location. If the types are unknown, this will be
+    /// `types::INVALID`.
     pub possible_types: types::Set,
     pub must_exist: bool,
     pub target_location: Pointer,
@@ -78,12 +80,12 @@ pub fn build_projections(config: &ParseConfig) -> Result<BTreeMap<String, TypeIn
             tracing::warn!(
                 field = field.as_str(),
                 pointer = pointer.as_ref(),
-                "could not locate projection within schema, so allowing any type"
+                "could not locate projection within schema"
             );
             TypeInfo {
                 target_location,
                 must_exist: false,
-                possible_types: types::ANY,
+                possible_types: types::INVALID,
             }
         };
         results.insert(field.clone(), projection);

--- a/parser/src/format/snapshots/parser__format__projection__test__projections_are_built.snap
+++ b/parser/src/format/snapshots/parser__format__projection__test__projections_are_built.snap
@@ -251,7 +251,7 @@ expression: result
         ],
     },
     "fieldB": TypeInfo {
-        possible_types: "array", "boolean", "null", "number", "object", "string",
+        possible_types: ,
         must_exist: false,
         target_location: [
             Property(

--- a/parser/src/format/snapshots/parser__format__projection__test__projections_are_built.snap
+++ b/parser/src/format/snapshots/parser__format__projection__test__projections_are_built.snap
@@ -5,7 +5,9 @@ expression: result
 ---
 {
     "/bee": TypeInfo {
-        possible_types: "object",
+        possible_types: Some(
+            "object",
+        ),
         must_exist: true,
         target_location: [
             Property(
@@ -14,7 +16,9 @@ expression: result
         ],
     },
     "/bee/loc": TypeInfo {
-        possible_types: "string",
+        possible_types: Some(
+            "string",
+        ),
         must_exist: false,
         target_location: [
             Property(
@@ -26,7 +30,9 @@ expression: result
         ],
     },
     "/bee/rock": TypeInfo {
-        possible_types: "object",
+        possible_types: Some(
+            "object",
+        ),
         must_exist: false,
         target_location: [
             Property(
@@ -38,7 +44,9 @@ expression: result
         ],
     },
     "/bee/rock/flower": TypeInfo {
-        possible_types: "boolean",
+        possible_types: Some(
+            "boolean",
+        ),
         must_exist: false,
         target_location: [
             Property(
@@ -53,7 +61,9 @@ expression: result
         ],
     },
     "/locationa": TypeInfo {
-        possible_types: "integer",
+        possible_types: Some(
+            "integer",
+        ),
         must_exist: true,
         target_location: [
             Property(
@@ -62,7 +72,9 @@ expression: result
         ],
     },
     "Bee": TypeInfo {
-        possible_types: "object",
+        possible_types: Some(
+            "object",
+        ),
         must_exist: true,
         target_location: [
             Property(
@@ -71,7 +83,9 @@ expression: result
         ],
     },
     "BeeLoc": TypeInfo {
-        possible_types: "integer",
+        possible_types: Some(
+            "integer",
+        ),
         must_exist: true,
         target_location: [
             Property(
@@ -80,7 +94,9 @@ expression: result
         ],
     },
     "BeeRock": TypeInfo {
-        possible_types: "object",
+        possible_types: Some(
+            "object",
+        ),
         must_exist: false,
         target_location: [
             Property(
@@ -92,7 +108,9 @@ expression: result
         ],
     },
     "BeeRockFlower": TypeInfo {
-        possible_types: "boolean",
+        possible_types: Some(
+            "boolean",
+        ),
         must_exist: false,
         target_location: [
             Property(
@@ -107,7 +125,9 @@ expression: result
         ],
     },
     "Locationa": TypeInfo {
-        possible_types: "integer",
+        possible_types: Some(
+            "integer",
+        ),
         must_exist: true,
         target_location: [
             Property(
@@ -116,7 +136,9 @@ expression: result
         ],
     },
     "bee": TypeInfo {
-        possible_types: "object",
+        possible_types: Some(
+            "object",
+        ),
         must_exist: true,
         target_location: [
             Property(
@@ -125,7 +147,9 @@ expression: result
         ],
     },
     "bee/loc": TypeInfo {
-        possible_types: "string",
+        possible_types: Some(
+            "string",
+        ),
         must_exist: false,
         target_location: [
             Property(
@@ -137,7 +161,9 @@ expression: result
         ],
     },
     "bee/rock": TypeInfo {
-        possible_types: "object",
+        possible_types: Some(
+            "object",
+        ),
         must_exist: false,
         target_location: [
             Property(
@@ -149,7 +175,9 @@ expression: result
         ],
     },
     "bee/rock/flower": TypeInfo {
-        possible_types: "boolean",
+        possible_types: Some(
+            "boolean",
+        ),
         must_exist: false,
         target_location: [
             Property(
@@ -164,7 +192,9 @@ expression: result
         ],
     },
     "beeLoc": TypeInfo {
-        possible_types: "string",
+        possible_types: Some(
+            "string",
+        ),
         must_exist: false,
         target_location: [
             Property(
@@ -176,7 +206,9 @@ expression: result
         ],
     },
     "beeRock": TypeInfo {
-        possible_types: "object",
+        possible_types: Some(
+            "object",
+        ),
         must_exist: false,
         target_location: [
             Property(
@@ -188,7 +220,9 @@ expression: result
         ],
     },
     "beeRockFlower": TypeInfo {
-        possible_types: "boolean",
+        possible_types: Some(
+            "boolean",
+        ),
         must_exist: false,
         target_location: [
             Property(
@@ -203,7 +237,9 @@ expression: result
         ],
     },
     "bee_loc": TypeInfo {
-        possible_types: "string",
+        possible_types: Some(
+            "string",
+        ),
         must_exist: false,
         target_location: [
             Property(
@@ -215,7 +251,9 @@ expression: result
         ],
     },
     "bee_rock": TypeInfo {
-        possible_types: "object",
+        possible_types: Some(
+            "object",
+        ),
         must_exist: false,
         target_location: [
             Property(
@@ -227,7 +265,9 @@ expression: result
         ],
     },
     "bee_rock_flower": TypeInfo {
-        possible_types: "boolean",
+        possible_types: Some(
+            "boolean",
+        ),
         must_exist: false,
         target_location: [
             Property(
@@ -242,7 +282,9 @@ expression: result
         ],
     },
     "fieldA": TypeInfo {
-        possible_types: "integer",
+        possible_types: Some(
+            "integer",
+        ),
         must_exist: true,
         target_location: [
             Property(
@@ -251,7 +293,7 @@ expression: result
         ],
     },
     "fieldB": TypeInfo {
-        possible_types: ,
+        possible_types: None,
         must_exist: false,
         target_location: [
             Property(
@@ -263,7 +305,9 @@ expression: result
         ],
     },
     "locationa": TypeInfo {
-        possible_types: "integer",
+        possible_types: Some(
+            "integer",
+        ),
         must_exist: true,
         target_location: [
             Property(

--- a/parser/src/input/mod.rs
+++ b/parser/src/input/mod.rs
@@ -106,6 +106,10 @@ impl Input {
         if resolved_encoding.is_utf8() {
             Ok(input)
         } else {
+            tracing::debug!(
+                "transcoding from '{}' into utf-8",
+                resolved_encoding.encoding().name()
+            );
             let reader = self::encoding::TranscodingReader::with_buffer_size(
                 input.into_stream(),
                 resolved_encoding,

--- a/parser/tests/examples/valid-big-nums.csv
+++ b/parser/tests/examples/valid-big-nums.csv
@@ -1,0 +1,4 @@
+ride_id,rideable_type,started_at,ended_at,start_station_name,start_station_id,end_station_name,end_station_id,start_lat,start_lng,end_lat,end_lng,member_casual
+41668E5136117226,docked_bike,2021-02-17 21:02:52,2021-02-17 21:27:45,Vesey Pl & River Terrace,5297.02,W 44 St & 11 Ave,6756.05,40.715337,-74.016583,40.762009,-73.996975,member
+27645122E0710202,docked_bike,2021-02-15 04:34:16,2021-02-15 04:38:56,Madison St & Clinton St,5190.07,E 2 St & Avenue A,5553.10,40.71269,-73.987763,40.72307749068673,-73.98583620786667,member
+328543E267201124,docked_bike,2021-02-14 16:07:35,2021-02-14 16:31:30,Fulton St & Broadway,5175.08,E 2 St & Avenue A,5553.10,40.711066,-74.009447,40.72307749068673,-73.98583620786667,member

--- a/parser/tests/examples/valid-mixed-types.csv
+++ b/parser/tests/examples/valid-mixed-types.csv
@@ -1,0 +1,5 @@
+int_or_string,bool_or_string
+5,true
+6,foo
+bar,false
+baz,qux


### PR DESCRIPTION
- Parser now will refuse to parse numberic values that overflow the
  common 64bit numberic types.
- Parser no longer defaults inferred type information to allow any type,
  and instead returns `types::INVALID` when no type information is known.