### PR TITLE
Explicitly scope Docker layer caching

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -118,8 +118,8 @@ jobs:
           file: ${{ matrix.connector }}/Dockerfile
           load: true
           tags: ghcr.io/estuary/${{ matrix.connector }}:test
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=gha,scope=${{ github.ref }}-${{ matrix.connector }}-cache
+          cache-to: type=gha,scope=${{ github.ref }}-${{ matrix.connector }}-cache,mode=max
 
       - name: Start Dockerized test infrastructure
         if: matrix.connector == 'source-kafka'


### PR DESCRIPTION
It looks like we're running into intermittent problems with concurrent jobs all writing to the same cache entry. The recommended advice for now appears to be "parameterize the scope with your matrix name". I don't know if this is going to be fixed upstream at some point, but I'm curious if this fixes it for us.

I've tested this with `johnny/materializations` merged in. It seems to fix the issue, at least anecdotally. More runs will be the real test. I've had 3 successive, successful builds.