### PR TITLE
parser: refine projection field collation and variants

### DIFF
--- a/parser/Cargo.lock
+++ b/parser/Cargo.lock
@@ -104,6 +104,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "caseless"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "808dab3318747be122cb31d36de18d4d1c81277a76f8332a02b81a3d73463d7f"
+dependencies = [
+ "regex",
+ "unicode-normalization",
+]
+
+[[package]]
 name = "cc"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -472,6 +482,7 @@ name = "parser"
 version = "0.1.0"
 dependencies = [
  "bytes",
+ "caseless",
  "chardetng",
  "csv",
  "doc",
@@ -490,6 +501,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "unicode-bom",
+ "unicode-normalization",
  "url",
  "uuid",
  "zip",

--- a/parser/Cargo.toml
+++ b/parser/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2018"
 
 [dependencies]
 bytes = "*"
+caseless = "*"
 chardetng = "*"
 csv = "*"
 encoding_rs = {version = "*", features = ["serde"]}
@@ -22,6 +23,7 @@ thiserror = "*"
 tracing = "*"
 tracing-subscriber = "*"
 unicode-bom = "*"
+unicode-normalization = "*"
 url = "*"
 uuid = {version = "*", features = ["v4"]}
 zip = "*"

--- a/parser/src/format/snapshots/parser__format__projection__test__projections_are_built.snap
+++ b/parser/src/format/snapshots/parser__format__projection__test__projections_are_built.snap
@@ -71,7 +71,7 @@ expression: result
             ),
         ],
     },
-    "Bee": TypeInfo {
+    "bee": TypeInfo {
         possible_types: Some(
             "object",
         ),
@@ -82,18 +82,21 @@ expression: result
             ),
         ],
     },
-    "BeeLoc": TypeInfo {
+    "bee loc": TypeInfo {
         possible_types: Some(
-            "integer",
+            "string",
         ),
-        must_exist: true,
+        must_exist: false,
         target_location: [
             Property(
-                "locationa",
+                "bee",
+            ),
+            Property(
+                "loc",
             ),
         ],
     },
-    "BeeRock": TypeInfo {
+    "bee rock": TypeInfo {
         possible_types: Some(
             "object",
         ),
@@ -107,7 +110,7 @@ expression: result
             ),
         ],
     },
-    "BeeRockFlower": TypeInfo {
+    "bee rock flower": TypeInfo {
         possible_types: Some(
             "boolean",
         ),
@@ -121,28 +124,6 @@ expression: result
             ),
             Property(
                 "flower",
-            ),
-        ],
-    },
-    "Locationa": TypeInfo {
-        possible_types: Some(
-            "integer",
-        ),
-        must_exist: true,
-        target_location: [
-            Property(
-                "locationa",
-            ),
-        ],
-    },
-    "bee": TypeInfo {
-        possible_types: Some(
-            "object",
-        ),
-        must_exist: true,
-        target_location: [
-            Property(
-                "bee",
             ),
         ],
     },
@@ -175,51 +156,6 @@ expression: result
         ],
     },
     "bee/rock/flower": TypeInfo {
-        possible_types: Some(
-            "boolean",
-        ),
-        must_exist: false,
-        target_location: [
-            Property(
-                "bee",
-            ),
-            Property(
-                "rock",
-            ),
-            Property(
-                "flower",
-            ),
-        ],
-    },
-    "beeLoc": TypeInfo {
-        possible_types: Some(
-            "string",
-        ),
-        must_exist: false,
-        target_location: [
-            Property(
-                "bee",
-            ),
-            Property(
-                "loc",
-            ),
-        ],
-    },
-    "beeRock": TypeInfo {
-        possible_types: Some(
-            "object",
-        ),
-        must_exist: false,
-        target_location: [
-            Property(
-                "bee",
-            ),
-            Property(
-                "rock",
-            ),
-        ],
-    },
-    "beeRockFlower": TypeInfo {
         possible_types: Some(
             "boolean",
         ),
@@ -281,7 +217,7 @@ expression: result
             ),
         ],
     },
-    "fieldA": TypeInfo {
+    "beeloc": TypeInfo {
         possible_types: Some(
             "integer",
         ),
@@ -292,7 +228,49 @@ expression: result
             ),
         ],
     },
-    "fieldB": TypeInfo {
+    "beerock": TypeInfo {
+        possible_types: Some(
+            "object",
+        ),
+        must_exist: false,
+        target_location: [
+            Property(
+                "bee",
+            ),
+            Property(
+                "rock",
+            ),
+        ],
+    },
+    "beerockflower": TypeInfo {
+        possible_types: Some(
+            "boolean",
+        ),
+        must_exist: false,
+        target_location: [
+            Property(
+                "bee",
+            ),
+            Property(
+                "rock",
+            ),
+            Property(
+                "flower",
+            ),
+        ],
+    },
+    "fielda": TypeInfo {
+        possible_types: Some(
+            "integer",
+        ),
+        must_exist: true,
+        target_location: [
+            Property(
+                "locationa",
+            ),
+        ],
+    },
+    "fieldb": TypeInfo {
         possible_types: None,
         must_exist: false,
         target_location: [


### PR DESCRIPTION
Collate projection fields in the same way that Flow does,
using caseless and Unicode-normalized equality.

Tweak variants which are produced from document locations automatically
drawn from the JSON Schema for /foo/bar
 - foo_bar (joined with underscores)
 - foobar (matches camelCase and TitleCase)
 - "foo bar" (joined with spaces)

For top-level properties like /foo_bar, also allow these to
match "foo bar", where underscore components are joined with spaces.

Finally, in addition to "" also match "NULL", "null", and "nil" to JSON
null.

Issue #32