### PR TITLE
Use "local" Docker layer caching strategy

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -115,6 +115,17 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
 
+      # TODO: Look into using the direct "gha" cache again when
+      # https://github.com/docker/buildx/issues/681 is fixed.
+      - name: Setup Docker Layer Cache
+        uses: actions/cache@v2
+        with:
+          path: /tmp/buildx-cache
+          key: buildx-cache-${{ matrix.connector }}-${{ github.base_ref }}-${{ github.head_ref }}
+          restore-keys: |
+            buildx-cache-${{ matrix.connector }}-${{ github.base_ref }}
+            buildx-cache-${{ matrix.connector }}
+
       - name: Build ${{ matrix.connector }} Docker Image
         uses: docker/build-push-action@v2
         with:
@@ -122,8 +133,8 @@ jobs:
           file: ${{ matrix.connector }}/Dockerfile
           load: true
           tags: ghcr.io/estuary/${{ matrix.connector }}:test
-          cache-from: type=gha,scope=${{ github.ref }}-${{ matrix.connector }}-cache
-          cache-to: type=gha,scope=${{ github.ref }}-${{ matrix.connector }}-cache,mode=max
+          cache-from: type=local,src=/tmp/buildx-cache
+          cache-to: type=local,dest=/tmp/buildx-cache-new,mode=max
 
       - name: Start Dockerized test infrastructure
         if: matrix.connector == 'source-kafka'
@@ -153,3 +164,11 @@ jobs:
           file: ${{ matrix.connector }}/Dockerfile
           push: true
           tags: ghcr.io/estuary/${{ matrix.connector }}:${{ steps.prep.outputs.tag }}
+
+      # This can probably be removed when the underlying buildx issue is resolved.
+      # https://github.com/docker/build-push-action/issues/252
+      # https://github.com/moby/buildkit/issues/1896
+      - name: Overwrite Docker Layer Cache
+        run: |
+          rm -rf /tmp/buildx-cache
+          mv /tmp/buildx-cache-new /tmp/buildx-cache


### PR DESCRIPTION
The native integration with the GitHub Actions Cache appears to be pretty flaky. There are several (possibly unrelated) issues with buildx that appear to prevent it from working reliably.

Let's try using the GitHub "cache" action to save/restore the layers as normal files.

Once again, the testing is a bit anecdotal. I built this, re-ran the workflow manually several times, pushed a cache-busting change, and then reverted it. Each time, the build seems to have passed as expected.