### PR TITLE
Remove Docker layer caching

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -122,8 +122,6 @@ jobs:
           file: ${{ matrix.connector }}/Dockerfile
           load: true
           tags: ghcr.io/estuary/${{ matrix.connector }}:test
-          cache-from: type=gha,scope=${{ github.ref }}-${{ matrix.connector }}-cache
-          cache-to: type=gha,scope=${{ github.ref }}-${{ matrix.connector }}-cache,mode=max
 
       - name: Start Dockerized test infrastructure
         if: matrix.connector == 'source-kafka'


### PR DESCRIPTION
This has proved to be less reliable than initially hoped. Let's see how long the builds are now that they are parallelized. The job parallelism may prove to be fast enough in practice.