### PR TITLE
Skip Malformed CSV Rows

### DIFF
--- a/parser/Cargo.lock
+++ b/parser/Cargo.lock
@@ -53,10 +53,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
+name = "bit-set"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e11e16035ea35e4e5997b393eacbf6f63983188f7a2ad25bfb13465f5ad59de"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
+
+[[package]]
 name = "bitflags"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
+
+[[package]]
+name = "bitvec"
+version = "0.19.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8942c8d352ae1838c9dda0b0ca2ab657696ef2232a20147cf1b30ae1a9cb4321"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
+]
 
 [[package]]
 name = "bstr"
@@ -216,17 +243,18 @@ dependencies = [
 [[package]]
 name = "doc"
 version = "0.0.0"
-source = "git+https://github.com/estuary/flow#a600bbb2d3be97d7b5f41a6e9e0172b86c9ce697"
+source = "git+https://github.com/estuary/flow#0e2ba8861cd897c6f30e89fce86c68d52bf55ead"
 dependencies = [
+ "fancy-regex",
  "itertools",
  "json",
  "lazy_static",
- "regex",
  "serde",
  "serde_json",
  "serde_yaml",
  "thiserror",
  "tinyvec",
+ "tracing",
  "url",
 ]
 
@@ -265,6 +293,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "fancy-regex"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d6b8560a05112eb52f04b00e5d3790c0dd75d9d980eb8a122fb23b92a623ccf"
+dependencies = [
+ "bit-set",
+ "regex",
+]
+
+[[package]]
 name = "flate2"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -291,6 +329,12 @@ name = "fuchsia-cprng"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
+
+[[package]]
+name = "funty"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fed34cd105917e91daa4da6b3728c47b068749d6a62c59811f06ed2ac71d9da7"
 
 [[package]]
 name = "fxhash"
@@ -374,17 +418,18 @@ checksum = "dd25036021b0de88a0aff6b850051563c6516d0bf53f8638938edbb9de732736"
 [[package]]
 name = "json"
 version = "0.0.0"
-source = "git+https://github.com/estuary/flow#a600bbb2d3be97d7b5f41a6e9e0172b86c9ce697"
+source = "git+https://github.com/estuary/flow#0e2ba8861cd897c6f30e89fce86c68d52bf55ead"
 dependencies = [
+ "bitvec",
+ "fancy-regex",
  "fxhash",
  "itertools",
  "percent-encoding",
- "regex",
  "serde",
  "serde_json",
  "serde_yaml",
  "thiserror",
- "tinyvec",
+ "tracing",
  "url",
 ]
 
@@ -572,6 +617,12 @@ checksum = "c3d0b9745dc2debf507c8422de05d7226cc1f0644216dfdfead988f9b1ab32a7"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "radium"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "941ba9d78d8e2f7ce474c015eea4d9c6d25b6a3327f9832ee29a4de27f91bbb8"
 
 [[package]]
 name = "rand"
@@ -839,6 +890,12 @@ dependencies = [
  "quote",
  "unicode-xid",
 ]
+
+[[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tempdir"
@@ -1114,6 +1171,12 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "wyz"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85e60b0d1b5f99db2556934e21937020776a5d31520bf169e851ac44e6420214"
 
 [[package]]
 name = "yaml-rust"

--- a/parser/src/config/snapshots/parser__config__test__config_schema_is_generated.snap
+++ b/parser/src/config/snapshots/parser__config__test__config_schema_is_generated.snap
@@ -59,6 +59,15 @@ expression: schema
         }
       ]
     },
+    "errorThreshold": {
+      "description": "Allows a percentage of errors to be ignored without failing the entire parsing process. When this limit is exceeded, parsing halts.",
+      "default": null,
+      "allOf": [
+        {
+          "$ref": "#/definitions/errorThreshold"
+        }
+      ]
+    },
     "fileExtensionMappings": {
       "description": "Mappings from file extensions to format identifiers.",
       "default": {},
@@ -202,6 +211,15 @@ expression: schema
       "description": "An encoding scheme, identified by WHATWG label. The list of allowable values is available at: https://encoding.spec.whatwg.org/#names-and-labels",
       "type": "string",
       "pattern": "^[a-z0-9_\\-:]{2,20}$"
+    },
+    "errorThreshold": {
+      "title": "errorThreshold",
+      "description": "The percentage of malformed rows which can be encountered without halting the parsing process. Only the most recent 1000 rows are used to calculate the error rate.",
+      "type": [
+        "integer"
+      ],
+      "maximum": 100.0,
+      "minimum": 0.0
     },
     "format": {
       "title": "format",

--- a/parser/src/format/csv.rs
+++ b/parser/src/format/csv.rs
@@ -1,16 +1,19 @@
 //! Parsers for character-separated formats like csv.
-use super::{Format, Output, ParseError, Parser};
-use crate::config::{
-    csv::{CharacterSeparatedConfig, LineEnding},
-    ParseConfig,
-};
+use super::{Format, Output, ParseError, ParseResult, Parser};
 use crate::format::projection::{build_projections, collate, TypeInfo};
 use crate::input::{detect_encoding, Input};
+use crate::{
+    config::{
+        csv::{CharacterSeparatedConfig, LineEnding},
+        ParseConfig,
+    },
+    ErrorThreshold,
+};
 use csv::{Reader, StringRecord, Terminator};
 use doc::Pointer;
 use json::schema::types;
 use serde_json::Value;
-use std::io;
+use std::{collections::VecDeque, io};
 
 struct CsvParser {
     /// The specific format associated with this parser. Used to lookup the correct configuration
@@ -160,12 +163,15 @@ impl Parser for CsvParser {
         }
         tracing::info!("Resolved column headers: {:?}", columns);
 
-        Ok(Box::new(CsvOutput {
+        let csv_output = CsvOutput {
             headers: columns,
             reader,
             current_row: csv::StringRecord::new(),
             row_num: 0,
-        }))
+        };
+        let iterator =
+            ParseErrorBuffer::new(csv_output, config.error_threshold.unwrap_or_default());
+        Ok(Box::new(iterator))
     }
 }
 
@@ -363,6 +369,108 @@ impl Iterator for CsvOutput {
             Some(self.parse_current_row())
         } else {
             None
+        }
+    }
+}
+
+// How many of the recent records to consider when trying to decide if
+// we've entered a new region of bad data of the file.
+const ERROR_BUFFER_WINDOW_SIZE: usize = 1000;
+
+/// A decorating iterator that tracks parsing errors and absorbs a specified
+/// rate of errors. If that rate is exceeded, then all the errors encountered
+/// are returned. Should not be polled again once an error is returned.
+#[derive(Debug)]
+struct ParseErrorBuffer<I> {
+    /// The iterator we're wrapping.
+    inner: I,
+    /// The amount of errors we can absorb before halting parsing.
+    threshold: ErrorThreshold,
+    /// The number of records we've seen.
+    total_records: usize,
+    /// TODO
+    errors_in_buffer: usize,
+    /// The most recent rows.
+    buffer: VecDeque<ParseResult>,
+}
+
+impl<I: Iterator<Item = ParseResult>> ParseErrorBuffer<I> {
+    pub fn new(inner: I, threshold: ErrorThreshold) -> Self {
+        Self {
+            inner,
+            threshold,
+            total_records: 0,
+            errors_in_buffer: 0,
+            buffer: VecDeque::with_capacity(ERROR_BUFFER_WINDOW_SIZE),
+        }
+    }
+
+    /// Consumes the next item out of the inner iterator and pops the next item
+    /// out of the internal buffer.
+    pub fn advance(&mut self) -> Option<I::Item> {
+        let popped = self.buffer.pop_front();
+        self.buffer_next();
+        if let Some(Err(_)) = popped {
+            self.errors_in_buffer -= 1;
+        }
+        popped
+    }
+
+    /// Returns true when the error buffer contains too many errors.
+    pub fn exceeded(&self) -> bool {
+        if self.total_records == 0 || self.errors_in_buffer == 0 {
+            return false;
+        }
+
+        // If the whole file is smaller than the window size, we only want to
+        // consider the records we have when determining the file's error rate.
+        // Otherwise, we'll use the window size for this calculation.
+        let window_size = usize::min(self.total_records, ERROR_BUFFER_WINDOW_SIZE);
+        let error_rate = self.errors_in_buffer as f64 / window_size as f64;
+
+        self.threshold.exceeded((100.0 * error_rate) as u8)
+    }
+
+    /// Fill up the internal buffer with as many items as we can.
+    pub fn prefill_buffer(&mut self) {
+        while self.buffer.len() < ERROR_BUFFER_WINDOW_SIZE && self.buffer_next() {
+            // Continue buffering
+        }
+    }
+
+    /// Returns true if we successfully added another item to the buffer.
+    fn buffer_next(&mut self) -> bool {
+        if let Some(item) = self.inner.next() {
+            if item.is_err() {
+                self.errors_in_buffer += 1;
+            }
+            self.total_records += 1;
+            self.buffer.push_back(item);
+            true
+        } else {
+            false
+        }
+    }
+}
+
+impl<I: Iterator<Item = ParseResult>> Iterator for ParseErrorBuffer<I> {
+    type Item = I::Item;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.prefill_buffer();
+
+        loop {
+            if self.exceeded() {
+                return Some(Err(ParseError::ErrorLimitExceeded(self.threshold)));
+            } else {
+                let item = self.advance()?;
+                if item.is_ok() {
+                    return Some(item);
+                } else {
+                    tracing::warn!(error=?item.unwrap_err(), "failed to parse row");
+                    continue;
+                }
+            }
         }
     }
 }

--- a/parser/src/format/projection.rs
+++ b/parser/src/format/projection.rs
@@ -2,7 +2,7 @@
 use crate::config::ParseConfig;
 use caseless::Caseless;
 use doc::inference::{Exists, Shape};
-use doc::{Pointer, Schema, SchemaIndex};
+use doc::{Pointer, Schema, SchemaIndexBuilder};
 use json::schema::build::Error as SchemaBuildError;
 use json::schema::index::Error as SchemaIndexError;
 use json::schema::types;
@@ -66,8 +66,9 @@ pub fn build_projections(config: &ParseConfig) -> Result<BTreeMap<String, TypeIn
         &config.schema
     };
     let schema: Schema = json::schema::build::build_schema(schema_uri.clone(), &schema_json)?;
-    let mut index = SchemaIndex::new();
-    index.add(&schema)?;
+    let mut builder = SchemaIndexBuilder::new();
+    builder.add(&schema)?;
+    let index = builder.into_index();
     let shape = Shape::infer(&schema, &index);
 
     let mut results = BTreeMap::new();

--- a/parser/src/lib.rs
+++ b/parser/src/lib.rs
@@ -3,6 +3,6 @@ mod decorate;
 mod format;
 mod input;
 
-pub use self::config::{csv, Compression, Format, JsonPointer, ParseConfig};
+pub use self::config::{csv, Compression, ErrorThreshold, Format, JsonPointer, ParseConfig};
 pub use self::format::{parse, Output, ParseError, Parser};
 pub use self::input::Input;

--- a/parser/src/main.rs
+++ b/parser/src/main.rs
@@ -112,8 +112,8 @@ where
         match self {
             Ok(t) => t,
             Err(e) => {
-                tracing::debug!("Error details: {:#?}", e);
-                tracing::error!("{}: {}", message, e);
+                tracing::debug!(error_details = ?e, message);
+                tracing::error!(error = %e, message);
                 std::process::exit(1);
             }
         }

--- a/parser/tests/csv_error_absorption_test.rs
+++ b/parser/tests/csv_error_absorption_test.rs
@@ -1,0 +1,125 @@
+mod testutil;
+
+use std::io::{Cursor, Seek, Write};
+
+use parser::{ErrorThreshold, Input, ParseConfig};
+use testutil::run_test;
+
+#[test]
+fn no_tolerance_for_errors_test() {
+    let mut csv = EphemeralCsv::default();
+    let config = csv.parse_config(None);
+
+    csv.write_rows(1, &|_i| "n,n_squared".to_owned());
+    csv.write_rows(500, &|i| format!("{},{}", i, i * i));
+    run_test(&config, csv.as_input()).assert_success(500);
+
+    csv.write_rows(1, &|i| format!("{},{},unexpected-column!", i, i * i));
+    run_test(&config, csv.as_input()).assert_failure(0);
+}
+
+#[test]
+fn smaller_than_window_test() {
+    let mut csv = EphemeralCsv::default();
+    let config = csv.parse_config(ErrorThreshold::new(10).unwrap().into());
+
+    csv.write_rows(1, &|_i| "n,n_squared".to_owned());
+    csv.write_rows(500, &|i| format!("{},{}", i, i * i));
+    csv.write_rows(55, &|i| format!("{},{},unexpected-column!", i, i * i));
+    // 555 total rows seen, 55 / 555 = 9.9% => still okay
+    run_test(&config, csv.as_input()).assert_success(500);
+
+    csv.write_rows(1, &|i| format!("{},{},unexpected-column!", i, i * i));
+    // 556 total rows seen, 56 / 556 = 10.0% => too high!
+    run_test(&config, csv.as_input()).assert_failure(0);
+}
+
+#[test]
+fn larger_than_window_test() {
+    let mut csv = EphemeralCsv::default();
+    let config = csv.parse_config(ErrorThreshold::new(10).unwrap().into());
+
+    csv.write_rows(1, &|_i| "n,n_squared".to_owned());
+    csv.write_rows(1000, &|i| format!("{},{}", i, i * i));
+    csv.write_rows(99, &|i| format!("{},{},unexpected-column!", i, i * i));
+    // More than 1000 records seen, so only consider the last 1000.
+    // 99 / 1000 = 9.9% => still okay
+    run_test(&config, csv.as_input()).assert_success(1000);
+
+    csv.write_rows(1, &|i| format!("{},{},unexpected-column!", i, i * i));
+    // 100 / 1000 = 10.0% => too high, but the first 100 good rows have already been output
+    run_test(&config, csv.as_input()).assert_failure(100);
+}
+
+#[test]
+fn occasional_bad_data_test() {
+    let mut csv = EphemeralCsv::default();
+    let config = csv.parse_config(ErrorThreshold::new(25).unwrap().into());
+
+    csv.write_rows(1, &|_i| "n,n_squared".to_owned());
+
+    // We'll write every 5th row as bad data. This is a 20% error rate, under
+    // our 25% threshold, so we'll succeed and output 800 good rows.
+    csv.write_rows(1000, &|i| {
+        if i % 5 == 0 {
+            format!("{},{},unexpected-column!", i, i * i)
+        } else {
+            format!("{},{}", i, i * i)
+        }
+    });
+    run_test(&config, csv.as_input()).assert_success(800);
+
+    // Increase the error rate to 100%. 200 errors are in the buffer. 250 will
+    // cross the threshold. As we write these Bad rows, Good rows from the first
+    // 1000 will fall out of the other side of the buffer, but so will some of
+    // the old Bad rows. If we want to end up with 25% of 1000 inside the
+    // window, we'll need to account for 1/5 of the old errors dropping out.
+    // 200 + 60 - 12 = 248 + 3 = 251. 63 new Bad rows put us over the threshold.
+    csv.write_rows(63, &|i| format!("{},{},unexpected-column!", i, i * i));
+
+    // However, the front of the queue is still filled with 80% Good rows to
+    // output. As we slide the buffer window, 4/5 rows are Good and will be
+    // output despite reading only Bad rows. 1063 total rows were processed
+    // before the threshold is exceeded. Of the first 63 that might have been
+    // output, 63 * 80% = 50 would be Good rows that were output.
+    run_test(&config, csv.as_input()).assert_failure(50);
+}
+
+#[derive(Debug)]
+struct EphemeralCsv {
+    data: Cursor<Vec<u8>>,
+}
+
+impl Default for EphemeralCsv {
+    fn default() -> Self {
+        Self {
+            data: Cursor::new(Vec::default()),
+        }
+    }
+}
+
+impl EphemeralCsv {
+    fn write_rows<'c>(&mut self, n: usize, row_generator: &'c dyn Fn(usize) -> String) {
+        for i in 0..n {
+            let content = row_generator(i);
+            self.data
+                .write(content.as_bytes())
+                .expect("to write to buffer");
+            self.data.write(b"\n").expect("to write newline to buffer");
+        }
+    }
+
+    fn parse_config(&self, error_threshold: Option<ErrorThreshold>) -> ParseConfig {
+        ParseConfig {
+            filename: Some("data.csv".to_owned()),
+            error_threshold: error_threshold,
+            ..Default::default()
+        }
+    }
+
+    fn as_input(&self) -> Input {
+        let mut data = self.data.clone();
+        data.rewind().expect("to replay from the beginning");
+        Input::Stream(Box::new(data))
+    }
+}

--- a/parser/tests/happy_path_test.rs
+++ b/parser/tests/happy_path_test.rs
@@ -1,9 +1,10 @@
 mod testutil;
 
+use std::fs::{self};
+use std::path::PathBuf;
+
 use parser::{JsonPointer, ParseConfig};
 use serde_json::json;
-use std::fs;
-use std::path::PathBuf;
 use testutil::{input_for_file, run_test};
 
 #[test]
@@ -32,9 +33,7 @@ fn csv_requires_explicit_quote() {
 
     {
         let input = input_for_file(path);
-        let output = run_test(&no_quote, input);
-        assert_eq!(1, output.exit_code);
-        assert!(output.parsed.is_empty());
+        run_test(&no_quote, input).assert_failure(0);
     }
 
     let with_quote = ParseConfig {
@@ -47,8 +46,7 @@ fn csv_requires_explicit_quote() {
     };
     let same_input = input_for_file(path);
     let output = run_test(&with_quote, same_input);
-    assert_eq!(0, output.exit_code);
-    assert_eq!(1, output.parsed.len());
+    output.assert_success(1);
     // Confirm the number of columns as a way of confirming that we're using the correct quote in
     // the parse configuration.
     assert_eq!(206, output.parsed[0].as_object().unwrap().len());

--- a/parser/tests/testutil.rs
+++ b/parser/tests/testutil.rs
@@ -1,5 +1,9 @@
 //! Common functions and types for writing end-to-end tests of the parser CLI.
 
+// Functions in this file are only run in tests, which don't count for coverage.
+// This prevents "unused function" warnings from being emitted.
+#![allow(dead_code)]
+
 use parser::{Input, ParseConfig};
 use serde_json::Value;
 use std::fs::File;
@@ -16,6 +20,30 @@ pub struct CommandResult {
     pub parsed: Vec<Value>,
     pub raw_stdout: String,
     pub exit_code: i32,
+}
+
+impl CommandResult {
+    pub fn assert_success(&self, parsed_rows: usize) {
+        assert_eq!(
+            parsed_rows,
+            self.parsed.len(),
+            "expected to output {} records, but instead got {} records",
+            parsed_rows,
+            self.parsed.len()
+        );
+        assert_eq!(self.exit_code, 0, "expected parsing to succeed");
+    }
+
+    pub fn assert_failure(&self, parsed_rows: usize) {
+        assert_eq!(
+            parsed_rows,
+            self.parsed.len(),
+            "expected to output {} records, but instead got {} records",
+            parsed_rows,
+            self.parsed.len()
+        );
+        assert_eq!(self.exit_code, 1, "expected parsing to fail");
+    }
 }
 
 /// Returns the path to the parser executable, accounting for


### PR DESCRIPTION
Adds the ability to configure an `errorThreshold` as part of the Parser's configuration. This allows it to be threaded through from the Capture's configuration within the Flow catalog. The Parser will absorb the parsing errors it encounters until the threshold is exceeded, at which point it returns all the errors it as seen thus far.