### PR TITLE
Move parser errorThreshold under csv config

### DIFF
--- a/parser/src/config/mod.rs
+++ b/parser/src/config/mod.rs
@@ -373,11 +373,6 @@ pub struct ParseConfig {
     /// Configures handling of tab-separated values (TSV) format.
     #[serde(default)]
     pub tsv: Option<CharacterSeparatedConfig>,
-
-    /// Allows a percentage of errors to be ignored without failing the entire
-    /// parsing process. When this limit is exceeded, parsing halts.
-    #[serde(default)]
-    pub error_threshold: Option<ErrorThreshold>,
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -461,11 +456,6 @@ impl ParseConfig {
                 self.tsv = Some(other_tsv.clone());
             }
         }
-
-        if other.error_threshold.is_some() {
-            self.error_threshold = other.error_threshold.clone();
-        }
-
         self
     }
 
@@ -491,7 +481,6 @@ impl Default for ParseConfig {
             content_type_mappings: default_content_type_mappings(),
             csv: None,
             tsv: None,
-            error_threshold: None,
         }
     }
 }

--- a/parser/src/config/snapshots/parser__config__test__config_schema_is_generated.snap
+++ b/parser/src/config/snapshots/parser__config__test__config_schema_is_generated.snap
@@ -59,15 +59,6 @@ expression: schema
         }
       ]
     },
-    "errorThreshold": {
-      "description": "Allows a percentage of errors to be ignored without failing the entire parsing process. When this limit is exceeded, parsing halts.",
-      "default": null,
-      "allOf": [
-        {
-          "$ref": "#/definitions/errorThreshold"
-        }
-      ]
-    },
     "fileExtensionMappings": {
       "description": "Mappings from file extensions to format identifiers.",
       "default": {},
@@ -140,6 +131,15 @@ expression: schema
             }
           ]
         },
+        "errorThreshold": {
+          "description": "Allows a percentage of errors to be ignored without failing the entire parsing process. When this limit is exceeded, parsing halts.",
+          "default": null,
+          "allOf": [
+            {
+              "$ref": "#/definitions/errorThreshold"
+            }
+          ]
+        },
         "escape": {
           "description": "The escape character, used to escape quotes within fields.",
           "default": null,
@@ -157,7 +157,7 @@ expression: schema
             "type": "string"
           }
         },
-        "line_ending": {
+        "lineEnding": {
           "description": "The value that terminates a line. Only single-byte values are supported, withe the exception of \"\\r\\n\" (CRLF), which will accept lines terminated by _either_ a carriage return, a newline, or both.",
           "default": null,
           "allOf": [

--- a/parser/src/format/csv.rs
+++ b/parser/src/format/csv.rs
@@ -169,8 +169,10 @@ impl Parser for CsvParser {
             current_row: csv::StringRecord::new(),
             row_num: 0,
         };
-        let iterator =
-            ParseErrorBuffer::new(csv_output, config.error_threshold.unwrap_or_default());
+        let iterator = ParseErrorBuffer::new(
+            csv_output,
+            user_provided_config.error_threshold.unwrap_or_default(),
+        );
         Ok(Box::new(iterator))
     }
 }

--- a/parser/tests/csv_error_absorption_test.rs
+++ b/parser/tests/csv_error_absorption_test.rs
@@ -2,7 +2,7 @@ mod testutil;
 
 use std::io::{Cursor, Seek, Write};
 
-use parser::{ErrorThreshold, Input, ParseConfig};
+use parser::{csv, ErrorThreshold, Input, ParseConfig};
 use testutil::run_test;
 
 #[test]
@@ -112,7 +112,10 @@ impl EphemeralCsv {
     fn parse_config(&self, error_threshold: Option<ErrorThreshold>) -> ParseConfig {
         ParseConfig {
             filename: Some("data.csv".to_owned()),
-            error_threshold: error_threshold,
+            csv: Some(csv::CharacterSeparatedConfig {
+                error_threshold,
+                ..Default::default()
+            }),
             ..Default::default()
         }
     }


### PR DESCRIPTION
The `errorThreshold` was previously defined at the top level of the
parser config, which made it seem like it would apply to all file types.
But it really only applies to csv files at the moment, and it's not
really clear that it even could be applied to many other file formats.
This could be confusing for users who set the top-level `errorThreshold`
and then wonder why their JSON file fails and doesn't respect the
threshold. This moves the `errorThreshold` under the character separated
configuration, so that it's clear that it only applies to that format.

This also renames the `line_ending` config to `lineEnding` to be
consistent with the rest of the naming.