### PR TITLE
Materialize date-time strings as snowflake timestamps

### DIFF
--- a/materialize-snowflake/snowflake.go
+++ b/materialize-snowflake/snowflake.go
@@ -190,6 +190,9 @@ func SQLGenerator() sqlDriver.Generator {
 			}
 		},
 	}
+	// This separate declaration should no longer be necessary after this PR lands:
+	// https://github.com/estuary/protocols/pull/13
+	var timestampMapping sqlDriver.TypeMapper = sqlDriver.RawConstColumnType("TIMESTAMP")
 	var typeMappings = sqlDriver.ColumnTypeMapper{
 		sqlDriver.ARRAY:   variantMapper,
 		sqlDriver.BINARY:  sqlDriver.RawConstColumnType("BINARY"),
@@ -199,6 +202,9 @@ func SQLGenerator() sqlDriver.Generator {
 		sqlDriver.OBJECT:  variantMapper,
 		sqlDriver.STRING: sqlDriver.StringTypeMapping{
 			Default: sqlDriver.RawConstColumnType("STRING"),
+			ByFormat: map[string]*sqlDriver.TypeMapper{
+				"date-time": &timestampMapping,
+			},
 		},
 	}
 	var nullable sqlDriver.TypeMapper = sqlDriver.NullableTypeMapping{


### PR DESCRIPTION
If the JSON schema specifies a string `format` of `"date-time"`, then
create a column with type `TIMESTAMP` in Snowflake materializations.
This is a minimal change to support only timestamps in snowflake.
Handling of additional string `format`s, and timestamps in other
databases, is being deferred until after we have some end-to-end testing
that can verify the behavior.