### PR TITLE
connectors: push to ghcr.io with 'dev' tag

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -163,3 +163,12 @@ jobs:
           file: ${{ matrix.connector }}/Dockerfile
           push: true
           tags: ghcr.io/estuary/${{ matrix.connector }}:${{ steps.prep.outputs.tag }}
+
+      - name: Push ${{ matrix.connector }} image with 'dev' tag
+        if: ${{ github.event_name == 'push' }}
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ${{ matrix.connector }}/Dockerfile
+          push: true # See 'if' above
+          tags: ghcr.io/estuary/${{ matrix.connector }}:dev


### PR DESCRIPTION
This is a hackish copy-paste so now there are two build-push-action instances, but it's still the most elegant way I could figure out to express "always upload with the SHA tag (including for PRs), but only use 'dev' tag when `main` has a new build".

If the "push SHA-tagged version for PRs" behavior isn't intentional the two actions could be combined instead.

GitHub Actions are confusing and terrible though, so I have no idea if this will actually work.