### PR TITLE
source-postgres: convert some INFO logs to DEBUG to reduce spam

### DIFF
--- a/source-postgres/replication.go
+++ b/source-postgres/replication.go
@@ -78,7 +78,7 @@ func startReplication(ctx context.Context, conn *pgconn.PgConn, slot, publicatio
 		"startLSN":    startLSN,
 		"publication": publication,
 		"slot":        slot,
-	}).Info("starting replication")
+	}).Debug("starting replication")
 
 	var stream = &replicationStream{
 		replSlot:  slot,

--- a/source-postgres/snapshot.go
+++ b/source-postgres/snapshot.go
@@ -54,7 +54,7 @@ func writeWatermark(ctx context.Context, conn *pgx.Conn, table, slot string) (st
 	}
 	rows.Close()
 
-	logrus.WithField("watermark", wm).Info("wrote watermark")
+	logrus.WithField("watermark", wm).Debug("wrote watermark")
 	return wm, nil
 }
 
@@ -182,11 +182,7 @@ func (s *tableSnapshot) ScanChunk(ctx context.Context, resumeKey []byte) ([]*cha
 		"resumeKey":  base64.StdEncoding.EncodeToString(resumeKey),
 		"txLSN":      s.TransactionLSN(),
 	}
-	if resumeKey == nil {
-		logrus.WithFields(logFields).Info("starting table scan")
-	} else {
-		logrus.WithFields(logFields).Debug("scanning next chunk")
-	}
+	logrus.WithFields(logFields).Debug("scanning table chunk")
 
 	var query = s.buildScanQuery(resumeKey == nil)
 	var args []interface{}


### PR DESCRIPTION
Low priority but also a pretty trivial change.

Just tweaking the `source-postgresql` logging slightly because the `wrote watermark` log messages become overwhelmingly spammy in a large-scale capture. Also demoting a couple of other log messages to `DEBUG` level at the same time because they clutter up unit test output for no good reason.