### PR TITLE
Assorted `source-postgres` changes

### DIFF
--- a/source-postgres/backfill.go
+++ b/source-postgres/backfill.go
@@ -42,7 +42,7 @@ func scanTableChunk(ctx context.Context, conn *pgx.Conn, streamID string, keyCol
 			return nil, fmt.Errorf("expected %d primary-key values but got %d", len(keyColumns), len(args))
 		}
 	}
-	logrus.WithField("query", query).WithField("args", args).Debug("executing query")
+	logrus.WithFields(logrus.Fields{"query": query, "args": args}).Debug("executing query")
 	rows, err := conn.Query(ctx, query, args...)
 	if err != nil {
 		return nil, fmt.Errorf("unable to execute query %q: %w", query, err)

--- a/source-postgres/capture.go
+++ b/source-postgres/capture.go
@@ -93,7 +93,10 @@ type messageOutput interface {
 // connections, scanning tables, and then streaming replication events until shutdown conditions
 // (if any) are met.
 func RunCapture(ctx context.Context, config *Config, catalog *airbyte.ConfiguredCatalog, state *PersistentState, dest messageOutput) error {
-	logrus.WithField("uri", config.ConnectionURI).WithField("slot", config.SlotName).Info("starting capture")
+	logrus.WithFields(logrus.Fields{
+		"uri":  config.ConnectionURI,
+		"slot": config.SlotName,
+	}).Info("starting capture")
 
 	// Normal database connection used for table scanning
 	var connScan, err = pgx.Connect(ctx, config.ConnectionURI)
@@ -170,7 +173,10 @@ func (c *capture) updateState(ctx context.Context) error {
 		// Print a warning if the two are not the same.
 		var primaryKey = dbPrimaryKeys[streamID]
 		if len(primaryKey) != 0 {
-			logrus.WithField("table", streamID).WithField("key", primaryKey).Debug("queried primary key")
+			logrus.WithFields(logrus.Fields{
+				"table": streamID,
+				"key":   primaryKey,
+			}).Debug("queried primary key")
 		}
 		if len(catalogPrimaryKey) != 0 {
 			if strings.Join(primaryKey, ",") != strings.Join(catalogPrimaryKey, ",") {
@@ -256,7 +262,10 @@ func (c *capture) streamChanges(ctx context.Context) error {
 		}
 		targetWatermark = watermark
 	}
-	logrus.WithField("tail", c.catalog.Tail).WithField("watermark", targetWatermark).Info("streaming until watermark")
+	logrus.WithFields(logrus.Fields{
+		"tail":      c.catalog.Tail,
+		"watermark": targetWatermark,
+	}).Info("streaming until watermark")
 	return c.streamToWatermark(targetWatermark, nil)
 }
 

--- a/source-postgres/capture.go
+++ b/source-postgres/capture.go
@@ -294,8 +294,9 @@ func (c *capture) streamChanges(ctx context.Context) error {
 
 	// Once there is no more backfilling to do, just stream changes forever and emit
 	// state updates on every transaction commit.
-	logrus.Info("all streams active")
-	return c.streamToWatermark("nonexistent-watermark", nil)
+	var targetWatermark = "nonexistent-watermark"
+	logrus.WithField("tail", c.catalog.Tail).WithField("watermark", targetWatermark).Info("streaming until watermark")
+	return c.streamToWatermark(targetWatermark, nil)
 }
 
 func (c *capture) streamToWatermark(watermark string, results *resultSet) error {

--- a/source-postgres/capture_test.go
+++ b/source-postgres/capture_test.go
@@ -186,6 +186,10 @@ func TestIgnoredStreams(t *testing.T) {
 // TestSlotLSNAdvances checks that the `restart_lsn` of a replication slot
 // has advanced after a connector restart.
 func TestSlotLSNAdvances(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode.")
+	}
+
 	var cfg, ctx, state = TestDefaultConfig, longTestContext(t, 30*time.Second), PersistentState{}
 	var table = createTestTable(ctx, t, "one", "(id INTEGER PRIMARY KEY, data TEXT)")
 	var catalog = testCatalog(table)

--- a/source-postgres/capture_test.go
+++ b/source-postgres/capture_test.go
@@ -95,7 +95,7 @@ func TestReplicationUpdates(t *testing.T) {
 	verifiedCapture(ctx, t, &cfg, &catalog, &state, "")
 }
 
-// TestEmptyTable leaves the table empty during the initial table snapshotting
+// TestEmptyTable leaves the table empty during the initial table backfill
 // and only adds data after replication has begun.
 func TestEmptyTable(t *testing.T) {
 	var cfg, ctx = TestDefaultConfig, shortTestContext(t)

--- a/source-postgres/capture_test.go
+++ b/source-postgres/capture_test.go
@@ -226,7 +226,7 @@ func TestSlotLSNAdvances(t *testing.T) {
 	// Capture the current `restart_lsn` of the replication slot prior to our test
 	var beforeLSN pglogrepl.LSN
 	if err := TestDatabase.QueryRow(ctx, `SELECT restart_lsn FROM pg_catalog.pg_replication_slots WHERE slot_name = $1;`, *TestReplicationSlot).Scan(&beforeLSN); err != nil {
-		logrus.WithField("slot", *TestReplicationSlot).WithField("err", err).Error("failed to query restart_lsn")
+		logrus.WithFields(logrus.Fields{"slot": *TestReplicationSlot, "err": err}).Error("failed to query restart_lsn")
 	}
 
 	// Insert some data, get the initial table scan out of the way, and wait long enough
@@ -251,7 +251,7 @@ func TestSlotLSNAdvances(t *testing.T) {
 
 		var afterLSN pglogrepl.LSN
 		if err := TestDatabase.QueryRow(ctx, `SELECT restart_lsn FROM pg_catalog.pg_replication_slots WHERE slot_name = $1;`, *TestReplicationSlot).Scan(&afterLSN); err != nil {
-			logrus.WithField("slot", *TestReplicationSlot).WithField("err", err).Error("failed to query restart_lsn")
+			logrus.WithFields(logrus.Fields{"slot": *TestReplicationSlot, "err": err}).Error("failed to query restart_lsn")
 		}
 		logrus.WithFields(logrus.Fields{"iter": iter, "before": beforeLSN, "after": afterLSN}).Info("checking slot LSN")
 		if afterLSN > beforeLSN {

--- a/source-postgres/datatype_test.go
+++ b/source-postgres/datatype_test.go
@@ -106,6 +106,10 @@ var datatypeTestcases = []datatypeTestcase{
 }
 
 func TestDatatypes(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode.")
+	}
+
 	var cfg, ctx = TestDefaultConfig, context.Background()
 
 	for idx, tc := range datatypeTestcases {

--- a/source-postgres/discovery.go
+++ b/source-postgres/discovery.go
@@ -180,7 +180,7 @@ func getDatabaseTables(ctx context.Context, conn *pgx.Conn) ([]tableInfo, error)
 		if _, ok := tableMap[id]; !ok {
 			continue
 		}
-		logrus.WithField("table", id).WithField("key", key).Debug("queried primary key")
+		logrus.WithFields(logrus.Fields{"table": id, "key": key}).Debug("queried primary key")
 		tableMap[id].PrimaryKey = key
 	}
 

--- a/source-postgres/helpers_test.go
+++ b/source-postgres/helpers_test.go
@@ -102,11 +102,11 @@ func createTestTable(ctx context.Context, t *testing.T, suffix string, tableDef 
 	tableName = strings.ReplaceAll(tableName, "/", "_")
 	tableName = strings.ReplaceAll(tableName, "=", "_")
 
-	logrus.WithField("table", tableName).WithField("cols", tableDef).Info("creating test table")
+	logrus.WithField("table", tableName).WithField("cols", tableDef).Debug("creating test table")
 	dbQueryInternal(ctx, t, fmt.Sprintf(`DROP TABLE IF EXISTS %s;`, tableName))
 	dbQueryInternal(ctx, t, fmt.Sprintf(`CREATE TABLE %s%s;`, tableName, tableDef))
 	t.Cleanup(func() {
-		logrus.WithField("table", tableName).Info("destroying test table")
+		logrus.WithField("table", tableName).Debug("destroying test table")
 		dbQueryInternal(ctx, t, fmt.Sprintf(`DROP TABLE %s;`, tableName))
 	})
 	return tableName
@@ -196,10 +196,10 @@ func dbInsert(ctx context.Context, t *testing.T, table string, rows [][]interfac
 	if err != nil {
 		t.Fatalf("unable to begin transaction: %v", err)
 	}
-	logrus.WithFields(logrus.Fields{"table": table, "count": len(rows), "first": rows[0]}).Info("inserting data")
+	logrus.WithFields(logrus.Fields{"table": table, "count": len(rows), "first": rows[0]}).Debug("inserting data")
 	var query = fmt.Sprintf(`INSERT INTO %s VALUES %s`, table, argsTuple(len(rows[0])))
 	for _, row := range rows {
-		logrus.WithField("table", table).WithField("row", row).Debug("inserting row")
+		logrus.WithField("table", table).WithField("row", row).Trace("inserting row")
 		if len(row) != len(rows[0]) {
 			t.Fatalf("incorrect number of values in row %q (expected %d)", row, len(rows[0]))
 		}

--- a/source-postgres/helpers_test.go
+++ b/source-postgres/helpers_test.go
@@ -47,7 +47,7 @@ func TestMain(m *testing.M) {
 	}
 
 	// Tweak some parameters to make things easier to test on a smaller scale
-	snapshotChunkSize = 16
+	backfillChunkSize = 16
 	replicationBufferSize = 0
 
 	// Open a connection to the database which will be used for creating and

--- a/source-postgres/helpers_test.go
+++ b/source-postgres/helpers_test.go
@@ -54,7 +54,7 @@ func TestMain(m *testing.M) {
 	// tearing down the replication slot.
 	var replConnConfig, err = pgconn.ParseConfig(*TestConnectionURI)
 	if err != nil {
-		logrus.WithField("uri", *TestConnectionURI).WithField("err", err).Fatal("error parsing connection config")
+		logrus.WithFields(logrus.Fields{"uri": *TestConnectionURI, "err": err}).Fatal("error parsing connection config")
 	}
 	replConnConfig.RuntimeParams["replication"] = "database"
 	replConn, err := pgconn.ConnectConfig(ctx, replConnConfig)
@@ -71,7 +71,7 @@ func TestMain(m *testing.M) {
 	TestDefaultConfig.SlotName = *TestReplicationSlot
 	TestDefaultConfig.PublicationName = *TestPublicationName
 	if err := TestDefaultConfig.Validate(); err != nil {
-		logrus.WithField("err", err).WithField("config", TestDefaultConfig).Fatal("error validating test config")
+		logrus.WithFields(logrus.Fields{"err": err, "config": TestDefaultConfig}).Fatal("error validating test config")
 	}
 
 	conn, err := pgx.Connect(ctx, *TestConnectionURI)
@@ -101,7 +101,7 @@ func createTestTable(ctx context.Context, t *testing.T, suffix string, tableDef 
 	tableName = strings.ReplaceAll(tableName, "/", "_")
 	tableName = strings.ReplaceAll(tableName, "=", "_")
 
-	logrus.WithField("table", tableName).WithField("cols", tableDef).Debug("creating test table")
+	logrus.WithFields(logrus.Fields{"table": tableName, "cols": tableDef}).Debug("creating test table")
 	dbQueryInternal(ctx, t, fmt.Sprintf(`DROP TABLE IF EXISTS %s;`, tableName))
 	dbQueryInternal(ctx, t, fmt.Sprintf(`CREATE TABLE %s%s;`, tableName, tableDef))
 	t.Cleanup(func() {
@@ -140,7 +140,7 @@ func testCatalog(streams ...string) airbyte.ConfiguredCatalog {
 // so the source dataset needs to be clean. For test data this should be fine.
 func dbLoadCSV(ctx context.Context, t *testing.T, table string, filename string, limit int) {
 	t.Helper()
-	logrus.WithField("table", table).WithField("file", filename).Info("loading csv")
+	logrus.WithFields(logrus.Fields{"table": table, "file": filename}).Info("loading csv")
 	var file, err = os.Open("testdata/" + filename)
 	if err != nil {
 		t.Fatalf("unable to open CSV file: %q", "testdata/"+filename)
@@ -198,7 +198,7 @@ func dbInsert(ctx context.Context, t *testing.T, table string, rows [][]interfac
 	logrus.WithFields(logrus.Fields{"table": table, "count": len(rows), "first": rows[0]}).Debug("inserting data")
 	var query = fmt.Sprintf(`INSERT INTO %s VALUES %s`, table, argsTuple(len(rows[0])))
 	for _, row := range rows {
-		logrus.WithField("table", table).WithField("row", row).Trace("inserting row")
+		logrus.WithFields(logrus.Fields{"table": table, "row": row}).Trace("inserting row")
 		if len(row) != len(rows[0]) {
 			t.Fatalf("incorrect number of values in row %q (expected %d)", row, len(rows[0]))
 		}
@@ -224,7 +224,7 @@ func argsTuple(argc int) string {
 // dbQuery is a test helper for executing arbitrary queries against TestDatabase
 func dbQuery(ctx context.Context, t *testing.T, query string, args ...interface{}) {
 	t.Helper()
-	logrus.WithField("query", query).WithField("args", args).Debug("executing query")
+	logrus.WithFields(logrus.Fields{"query": query, "args": args}).Debug("executing query")
 	dbQueryInternal(ctx, t, query, args...)
 }
 

--- a/source-postgres/main.go
+++ b/source-postgres/main.go
@@ -16,12 +16,10 @@ func main() {
 // Config tells the connector how to connect to the source database and can
 // optionally be used to customize some other parameters such as polling timeout.
 type Config struct {
-	ConnectionURI      string  `json:"connectionURI"`
-	SlotName           string  `json:"slot_name"`
-	PublicationName    string  `json:"publication_name"`
-	WatermarksTable    string  `json:"watermarks_table"`
-	PollTimeoutSeconds float64 `json:"poll_timeout_seconds"`
-	MaxLifespanSeconds float64 `json:"max_lifespan_seconds"`
+	ConnectionURI   string `json:"connectionURI"`
+	SlotName        string `json:"slot_name"`
+	PublicationName string `json:"publication_name"`
+	WatermarksTable string `json:"watermarks_table"`
 }
 
 // Validate checks that the configuration passes some basic sanity checks, and
@@ -38,9 +36,6 @@ func (c *Config) Validate() error {
 	}
 	if c.WatermarksTable == "" {
 		c.WatermarksTable = "public.flow_watermarks"
-	}
-	if c.PollTimeoutSeconds == 0 {
-		c.PollTimeoutSeconds = 10
 	}
 	return nil
 }
@@ -78,18 +73,6 @@ const configSchema = `{
 			"title":       "Watermarks Table",
 			"description": "The name of the table used for watermark writes during backfills",
 			"default":     "public.flow_watermarks"
-		},
-		"poll_timeout_seconds": {
-			"type":        "number",
-			"title":       "Poll Timeout (seconds)",
-			"description": "When tail=false, controls how long to sit idle before shutting down",
-			"default":     10
-		},
-		"max_lifespan_seconds": {
-			"type":        "number",
-			"title":       "Maximum Connector Lifespan (seconds)",
-			"description": "When nonzero, imposes a maximum runtime after which to unconditionally shut down",
-			"default":     0
 		}
 	},
 	"required": [ "connectionURI" ]

--- a/source-postgres/replication.go
+++ b/source-postgres/replication.go
@@ -53,6 +53,8 @@ type replicationStream struct {
 
 	eventBuf *changeEvent      // A single-element buffer used in between 'receiveMessage' and the output channel
 	events   chan *changeEvent // The channel to which replication events will be written
+
+	cancel context.CancelFunc // Cancel function for the replication goroutine's context
 }
 
 const standbyStatusInterval = 10 * time.Second
@@ -107,13 +109,15 @@ func startReplication(ctx context.Context, conn *pgconn.PgConn, slot, publicatio
 		return nil, fmt.Errorf("unable to start replication: %w", err)
 	}
 
-	go func(ctx context.Context) {
-		var err = stream.run(ctx)
-		close(stream.events)
-		if err != nil && !errors.Is(err, context.Canceled) {
+	var streamCtx, streamCancel = context.WithCancel(ctx)
+	stream.cancel = streamCancel
+	go func() {
+		defer close(stream.events)
+		defer stream.conn.Close(ctx)
+		if err := stream.run(streamCtx); err != nil && !errors.Is(err, context.Canceled) {
 			logrus.WithField("err", err).Fatal("replication stream error")
 		}
-	}(ctx)
+	}()
 
 	return stream, nil
 }
@@ -398,5 +402,6 @@ func (s *replicationStream) sendStandbyStatusUpdate(ctx context.Context) error {
 
 func (s *replicationStream) Close(ctx context.Context) error {
 	logrus.Debug("replication stream close requested")
-	return s.conn.Close(ctx)
+	s.cancel()
+	return nil
 }

--- a/source-postgres/replication.go
+++ b/source-postgres/replication.go
@@ -78,7 +78,7 @@ func startReplication(ctx context.Context, conn *pgconn.PgConn, slot, publicatio
 		"startLSN":    startLSN,
 		"publication": publication,
 		"slot":        slot,
-	}).Info("starting replication")
+	}).Debug("starting replication")
 
 	var stream = &replicationStream{
 		replSlot:  slot,

--- a/source-postgres/snapshot.go
+++ b/source-postgres/snapshot.go
@@ -54,7 +54,7 @@ func writeWatermark(ctx context.Context, conn *pgx.Conn, table, slot string) (st
 	}
 	rows.Close()
 
-	logrus.WithField("watermark", wm).Info("wrote watermark")
+	logrus.WithField("watermark", wm).Debug("wrote watermark")
 	return wm, nil
 }
 
@@ -182,11 +182,7 @@ func (s *tableSnapshot) ScanChunk(ctx context.Context, resumeKey []byte) ([]*cha
 		"resumeKey":  base64.StdEncoding.EncodeToString(resumeKey),
 		"txLSN":      s.TransactionLSN(),
 	}
-	if resumeKey == nil {
-		logrus.WithFields(logFields).Info("starting table scan")
-	} else {
-		logrus.WithFields(logFields).Debug("scanning next chunk")
-	}
+	logrus.WithFields(logFields).Debug("scanning table chunk")
 
 	var query = s.buildScanQuery(resumeKey == nil)
 	var args []interface{}

--- a/source-postgres/snapshot.go
+++ b/source-postgres/snapshot.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 
 	"github.com/google/uuid"
-	"github.com/jackc/pglogrepl"
 	"github.com/jackc/pgx/v4"
 	"github.com/sirupsen/logrus"
 )
@@ -20,17 +19,57 @@ import (
 // `resumeKey` if non-nil. This is the entrypoint to the database-specific portion of the
 // backfill process.
 func scanTableChunk(ctx context.Context, conn *pgx.Conn, streamID string, keyColumns []string, resumeKey []byte) ([]*changeEvent, error) {
-	var snapshot, err = snapshotDatabase(ctx, conn)
-	if err != nil {
-		return nil, fmt.Errorf("error creating database snapshot: %w", err)
-	}
-	defer snapshot.Close(ctx)
+	logrus.WithFields(logrus.Fields{
+		"streamID":   streamID,
+		"keyColumns": keyColumns,
+		"resumeKey":  base64.StdEncoding.EncodeToString(resumeKey),
+	}).Debug("scanning table chunk")
 
-	events, err := snapshot.Table(streamID, keyColumns).ScanChunk(ctx, resumeKey)
-	if err != nil {
-		return nil, fmt.Errorf("error scanning table: %w", err)
-	}
+	// Split "public.foo" tableID into "public" schema and "foo" table name
+	var parts = strings.SplitN(streamID, ".", 2)
+	var schemaName, tableName = parts[0], parts[1]
 
+	// Build and execute a query to fetch the next `snapshotChunkSize` rows from the database
+	var query = buildScanQuery(resumeKey == nil, keyColumns, schemaName, tableName)
+	var args []interface{}
+	if resumeKey != nil {
+		var err error
+		args, err = unpackTuple(resumeKey)
+		if err != nil {
+			return nil, fmt.Errorf("error unpacking encoded tuple: %w", err)
+		}
+		if len(args) != len(keyColumns) {
+			return nil, fmt.Errorf("expected %d primary-key values but got %d", len(keyColumns), len(args))
+		}
+	}
+	logrus.WithField("query", query).WithField("args", args).Debug("executing query")
+	rows, err := conn.Query(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("unable to execute query %q: %w", query, err)
+	}
+	defer rows.Close()
+
+	// Process the results into `changeEvent` structs and return them
+	var cols = rows.FieldDescriptions()
+	var events []*changeEvent
+	for rows.Next() {
+		// Scan the row values and copy into the equivalent map
+		var vals, err = rows.Values()
+		if err != nil {
+			return nil, fmt.Errorf("unable to get row values: %w", err)
+		}
+		var fields = make(map[string]interface{})
+		for idx := range cols {
+			fields[string(cols[idx].Name)] = vals[idx]
+		}
+
+		events = append(events, &changeEvent{
+			Type:      "Insert",
+			Namespace: schemaName,
+			Table:     tableName,
+			Fields:    fields,
+		})
+	}
 	return events, nil
 }
 
@@ -58,93 +97,15 @@ func writeWatermark(ctx context.Context, conn *pgx.Conn, table, slot string) (st
 	return wm, nil
 }
 
-// A databaseSnapshot represents a long-running read transaction which
-// can be used to query the contents of various tables.
-type databaseSnapshot struct {
-	Transaction pgx.Tx
-	TxLSN       pglogrepl.LSN
-}
-
-// A tableSnapshot represents a consistent view of a single table in
-// the database. A TableSnapshot cannot be closed because it's really
-// just a struct combining a DatabaseSnapshot with a specific table
-// name and scanning key.
-type tableSnapshot struct {
-	DB         *databaseSnapshot
-	SchemaName string
-	TableName  string
-	KeyColumns []string
-
-	scanFromQuery string
-}
-
 // snapshotChunkSize controls how many rows will be read from the database in a
 // single query. In normal use it acts like a constant, it's just a variable here
 // so that it can be lowered in tests to exercise chunking behavior more easily.
 var snapshotChunkSize = 4096
 
-func snapshotDatabase(ctx context.Context, conn *pgx.Conn) (*databaseSnapshot, error) {
-	var transaction, err = conn.BeginTx(ctx, pgx.TxOptions{
-		// We could probably get away with `RepeatableRead` isolation here, but
-		// I see no reason not to err on the side of getting the strongest
-		// guarantees that we can, especially since the full scan is not the
-		// normal mode of operation and happens just once per table.
-		IsoLevel:   pgx.Serializable,
-		AccessMode: pgx.ReadOnly,
-	})
-	if err != nil {
-		return nil, fmt.Errorf("unable to begin transaction: %w", err)
-	}
-	var snapshot = &databaseSnapshot{
-		Transaction: transaction,
-	}
-	// TODO(wgd): Empirically this function doesn't have a stable value during our read
-	// transaction, and I don't know what ordering guarantees we might actually have.
-	// Even though this is what Debezium does I remain unconvinced that it actually works
-	// in all circumstances. Revisit this after writing some sort of concurrent-changes
-	// stress test which could reveal problems.
-	if err := transaction.QueryRow(ctx, `SELECT * FROM pg_current_wal_lsn();`).Scan(&snapshot.TxLSN); err != nil {
-		snapshot.Close(ctx)
-		return nil, fmt.Errorf("unable to query transaction LSN: %w", err)
-	}
-	return snapshot, nil
-}
-
-func (s *databaseSnapshot) TransactionLSN() pglogrepl.LSN {
-	return s.TxLSN
-}
-
-func (s *databaseSnapshot) Table(tableID string, keyColumns []string) *tableSnapshot {
-	// Split "public.foo" tableID into "public" schema and "foo" table name
-	var parts = strings.SplitN(tableID, ".", 2)
-	var schemaName, tableName = parts[0], parts[1]
-
-	return &tableSnapshot{
-		DB:         s,
-		SchemaName: schemaName,
-		TableName:  tableName,
-		KeyColumns: keyColumns,
-	}
-}
-
-func (s *databaseSnapshot) Close(ctx context.Context) error {
-	return s.Transaction.Rollback(ctx)
-}
-
-func (s *tableSnapshot) TransactionLSN() pglogrepl.LSN {
-	return s.DB.TransactionLSN()
-}
-
-func (s *tableSnapshot) buildScanQuery(start bool) string {
-	// We cache the query used in start=false cases (ScanFrom) to avoid
-	// redundantly building it over and over for no reason.
-	if !start && s.scanFromQuery != "" {
-		return s.scanFromQuery
-	}
-
+func buildScanQuery(start bool, keyColumns []string, schemaName, tableName string) string {
 	// Construct strings like `(foo, bar, baz)` and `($1, $2, $3)` for use in the query
 	var pkey, args string
-	for idx, colName := range s.KeyColumns {
+	for idx, colName := range keyColumns {
 		if idx > 0 {
 			pkey += ", "
 			args += ", "
@@ -155,77 +116,11 @@ func (s *tableSnapshot) buildScanQuery(start bool) string {
 
 	// Construct the query itself
 	var query = new(strings.Builder)
-	fmt.Fprintf(query, "SELECT * FROM %s.%s", s.SchemaName, s.TableName)
+	fmt.Fprintf(query, "SELECT * FROM %s.%s", schemaName, tableName)
 	if !start {
 		fmt.Fprintf(query, " WHERE (%s) > (%s)", pkey, args)
 	}
 	fmt.Fprintf(query, " ORDER BY (%s)", pkey)
 	fmt.Fprintf(query, " LIMIT %d;", snapshotChunkSize)
-
-	// Cache where applicable and return
-	if !start {
-		s.scanFromQuery = query.String()
-		return s.scanFromQuery
-	}
 	return query.String()
-}
-
-// ScanChunk requests a chunk of rows from the table snapshot, transforms each row into
-// an `Insert` change event and gives it to the provided handler. If `resumeKey` is nil
-// the very first chunk of the table is scanned, otherwise it must contain the final
-// key from a previous chunk, and this chunk will begin immediately after that.
-func (s *tableSnapshot) ScanChunk(ctx context.Context, resumeKey []byte) ([]*changeEvent, error) {
-	var logFields = logrus.Fields{
-		"namespace":  s.SchemaName,
-		"table":      s.TableName,
-		"keyColumns": s.KeyColumns,
-		"resumeKey":  base64.StdEncoding.EncodeToString(resumeKey),
-		"txLSN":      s.TransactionLSN(),
-	}
-	logrus.WithFields(logFields).Debug("scanning table chunk")
-
-	var query = s.buildScanQuery(resumeKey == nil)
-	var args []interface{}
-	if resumeKey != nil {
-		var err error
-		args, err = unpackTuple(resumeKey)
-		if err != nil {
-			return nil, fmt.Errorf("error unpacking encoded tuple: %w", err)
-		}
-		if len(args) != len(s.KeyColumns) {
-			return nil, fmt.Errorf("expected %d primary-key values but got %d", len(s.KeyColumns), len(args))
-		}
-	}
-
-	logrus.WithField("query", query).WithField("args", args).Debug("executing query")
-	rows, err := s.DB.Transaction.Query(ctx, query, args...)
-	if err != nil {
-		return nil, fmt.Errorf("unable to execute query %q: %w", query, err)
-	}
-	defer rows.Close()
-	return s.processResults(ctx, rows)
-}
-
-func (s *tableSnapshot) processResults(ctx context.Context, rows pgx.Rows) ([]*changeEvent, error) {
-	var cols = rows.FieldDescriptions()
-	var events []*changeEvent
-	for rows.Next() {
-		// Scan the row values and copy into the equivalent map
-		var vals, err = rows.Values()
-		if err != nil {
-			return nil, fmt.Errorf("unable to get row values: %w", err)
-		}
-		var fields = make(map[string]interface{})
-		for idx := range cols {
-			fields[string(cols[idx].Name)] = vals[idx]
-		}
-
-		events = append(events, &changeEvent{
-			Type:      "Insert",
-			Namespace: s.SchemaName,
-			Table:     s.TableName,
-			Fields:    fields,
-		})
-	}
-	return events, nil
 }

--- a/source-postgres/testdata/TestCatalogPrimaryKeyOverride_capture1.snapshot
+++ b/source-postgres/testdata/TestCatalogPrimaryKeyOverride_capture1.snapshot
@@ -1,5 +1,4 @@
 {"type":"STATE","state":{"data":{"current_lsn":1234,"streams":{"public.test_catalogprimarykeyoverride":{"mode":"Backfill","key_columns":["fullname","year"]}}}}}
-{"type":"STATE","state":{"data":{"current_lsn":1234,"streams":{"public.test_catalogprimarykeyoverride":{"mode":"Backfill","key_columns":["fullname","year"]}}}}}
 {"type":"RECORD","record":{"stream":"test_catalogprimarykeyoverride","data":{"_change_type":"Insert","fullname":"Alabama","population":1830000,"state":"AL","year":1900},"emitted_at":1234,"namespace":"public"}}
 {"type":"RECORD","record":{"stream":"test_catalogprimarykeyoverride","data":{"_change_type":"Insert","fullname":"Alabama","population":2359000,"state":"AL","year":1920},"emitted_at":1234,"namespace":"public"}}
 {"type":"RECORD","record":{"stream":"test_catalogprimarykeyoverride","data":{"_change_type":"Insert","fullname":"Alabama","population":2845000,"state":"AL","year":1940},"emitted_at":1234,"namespace":"public"}}

--- a/source-postgres/testdata/TestCatalogPrimaryKeyOverride_capture2.snapshot
+++ b/source-postgres/testdata/TestCatalogPrimaryKeyOverride_capture2.snapshot
@@ -1,3 +1,4 @@
+{"type":"STATE","state":{"data":{"current_lsn":1234,"streams":{"public.test_catalogprimarykeyoverride":{"mode":"Active","key_columns":["fullname","year"]}}}}}
 {"type":"RECORD","record":{"stream":"test_catalogprimarykeyoverride","data":{"_change_type":"Insert","fullname":"No Such State","population":1234,"state":"XX","year":1930},"emitted_at":1234,"namespace":"public"}}
 {"type":"RECORD","record":{"stream":"test_catalogprimarykeyoverride","data":{"_change_type":"Insert","fullname":"No Such State","population":12345,"state":"XX","year":1970},"emitted_at":1234,"namespace":"public"}}
 {"type":"RECORD","record":{"stream":"test_catalogprimarykeyoverride","data":{"_change_type":"Insert","fullname":"No Such State","population":123456,"state":"XX","year":1990},"emitted_at":1234,"namespace":"public"}}

--- a/source-postgres/testdata/TestCatalogPrimaryKey_capture1.snapshot
+++ b/source-postgres/testdata/TestCatalogPrimaryKey_capture1.snapshot
@@ -1,5 +1,4 @@
 {"type":"STATE","state":{"data":{"current_lsn":1234,"streams":{"public.test_catalogprimarykey":{"mode":"Backfill","key_columns":["fullname","year"]}}}}}
-{"type":"STATE","state":{"data":{"current_lsn":1234,"streams":{"public.test_catalogprimarykey":{"mode":"Backfill","key_columns":["fullname","year"]}}}}}
 {"type":"RECORD","record":{"stream":"test_catalogprimarykey","data":{"_change_type":"Insert","fullname":"Alabama","population":1830000,"state":"AL","year":1900},"emitted_at":1234,"namespace":"public"}}
 {"type":"RECORD","record":{"stream":"test_catalogprimarykey","data":{"_change_type":"Insert","fullname":"Alabama","population":2359000,"state":"AL","year":1920},"emitted_at":1234,"namespace":"public"}}
 {"type":"RECORD","record":{"stream":"test_catalogprimarykey","data":{"_change_type":"Insert","fullname":"Alabama","population":2845000,"state":"AL","year":1940},"emitted_at":1234,"namespace":"public"}}

--- a/source-postgres/testdata/TestCatalogPrimaryKey_capture2.snapshot
+++ b/source-postgres/testdata/TestCatalogPrimaryKey_capture2.snapshot
@@ -1,3 +1,4 @@
+{"type":"STATE","state":{"data":{"current_lsn":1234,"streams":{"public.test_catalogprimarykey":{"mode":"Active","key_columns":["fullname","year"]}}}}}
 {"type":"RECORD","record":{"stream":"test_catalogprimarykey","data":{"_change_type":"Insert","fullname":"No Such State","population":1234,"state":"XX","year":1930},"emitted_at":1234,"namespace":"public"}}
 {"type":"RECORD","record":{"stream":"test_catalogprimarykey","data":{"_change_type":"Insert","fullname":"No Such State","population":12345,"state":"XX","year":1970},"emitted_at":1234,"namespace":"public"}}
 {"type":"RECORD","record":{"stream":"test_catalogprimarykey","data":{"_change_type":"Insert","fullname":"No Such State","population":123456,"state":"XX","year":1990},"emitted_at":1234,"namespace":"public"}}

--- a/source-postgres/testdata/TestComplexDataset_init.snapshot
+++ b/source-postgres/testdata/TestComplexDataset_init.snapshot
@@ -1,5 +1,4 @@
 {"type":"STATE","state":{"data":{"current_lsn":1234,"streams":{"public.test_complexdataset":{"mode":"Backfill","key_columns":["year","state"]}}}}}
-{"type":"STATE","state":{"data":{"current_lsn":1234,"streams":{"public.test_complexdataset":{"mode":"Backfill","key_columns":["year","state"]}}}}}
 {"type":"RECORD","record":{"stream":"test_complexdataset","data":{"_change_type":"Insert","fullname":"Alabama","population":1830000,"state":"AL","year":1900},"emitted_at":1234,"namespace":"public"}}
 {"type":"RECORD","record":{"stream":"test_complexdataset","data":{"_change_type":"Insert","fullname":"Arkansas","population":1314000,"state":"AR","year":1900},"emitted_at":1234,"namespace":"public"}}
 {"type":"RECORD","record":{"stream":"test_complexdataset","data":{"_change_type":"Insert","fullname":"Arizona","population":124000,"state":"AZ","year":1900},"emitted_at":1234,"namespace":"public"}}

--- a/source-postgres/testdata/TestComplexDataset_restart1.snapshot
+++ b/source-postgres/testdata/TestComplexDataset_restart1.snapshot
@@ -1,5 +1,5 @@
-{"type":"RECORD","record":{"stream":"test_complexdataset","data":{"_change_type":"Insert","fullname":"No Such State","population":1234,"state":"XX","year":1930},"emitted_at":1234,"namespace":"public"}}
 {"type":"STATE","state":{"data":{"current_lsn":1234,"streams":{"public.test_complexdataset":{"mode":"Backfill","key_columns":["year","state"],"scanned":"FgeoAklBAA=="}}}}}
+{"type":"RECORD","record":{"stream":"test_complexdataset","data":{"_change_type":"Insert","fullname":"No Such State","population":1234,"state":"XX","year":1930},"emitted_at":1234,"namespace":"public"}}
 {"type":"STATE","state":{"data":{"current_lsn":1234,"streams":{"public.test_complexdataset":{"mode":"Backfill","key_columns":["year","state"],"scanned":"FgeoAklBAA=="}}}}}
 {"type":"RECORD","record":{"stream":"test_complexdataset","data":{"_change_type":"Insert","fullname":"Idaho","population":671000,"state":"ID","year":1960},"emitted_at":1234,"namespace":"public"}}
 {"type":"RECORD","record":{"stream":"test_complexdataset","data":{"_change_type":"Insert","fullname":"Illinois","population":10086000,"state":"IL","year":1960},"emitted_at":1234,"namespace":"public"}}

--- a/source-postgres/testdata/TestComplexDataset_restart2.snapshot
+++ b/source-postgres/testdata/TestComplexDataset_restart2.snapshot
@@ -1,9 +1,9 @@
+{"type":"STATE","state":{"data":{"current_lsn":1234,"streams":{"public.test_complexdataset":{"mode":"Backfill","key_columns":["year","state"],"scanned":"Fge8AlNDAA=="}}}}}
 {"type":"RECORD","record":{"stream":"test_complexdataset","data":{"_change_type":"Delete","fullname":null,"population":null,"state":"XX","year":1930},"emitted_at":1234,"namespace":"public"}}
 {"type":"RECORD","record":{"stream":"test_complexdataset","data":{"_change_type":"Delete","fullname":null,"population":null,"state":"XX","year":1970},"emitted_at":1234,"namespace":"public"}}
 {"type":"STATE","state":{"data":{"current_lsn":1234,"streams":{"public.test_complexdataset":{"mode":"Backfill","key_columns":["year","state"],"scanned":"Fge8AlNDAA=="}}}}}
 {"type":"RECORD","record":{"stream":"test_complexdataset","data":{"_change_type":"Insert","fullname":"No Such State","population":1234,"state":"XX","year":1930},"emitted_at":1234,"namespace":"public"}}
 {"type":"RECORD","record":{"stream":"test_complexdataset","data":{"_change_type":"Insert","fullname":"No Such State","population":12345,"state":"XX","year":1970},"emitted_at":1234,"namespace":"public"}}
-{"type":"STATE","state":{"data":{"current_lsn":1234,"streams":{"public.test_complexdataset":{"mode":"Backfill","key_columns":["year","state"],"scanned":"Fge8AlNDAA=="}}}}}
 {"type":"STATE","state":{"data":{"current_lsn":1234,"streams":{"public.test_complexdataset":{"mode":"Backfill","key_columns":["year","state"],"scanned":"Fge8AlNDAA=="}}}}}
 {"type":"RECORD","record":{"stream":"test_complexdataset","data":{"_change_type":"Insert","fullname":"South Dakota","population":690851,"state":"SD","year":1980},"emitted_at":1234,"namespace":"public"}}
 {"type":"RECORD","record":{"stream":"test_complexdataset","data":{"_change_type":"Insert","fullname":"Tennessee","population":4600252,"state":"TN","year":1980},"emitted_at":1234,"namespace":"public"}}

--- a/source-postgres/testdata/TestEmptyTable.snapshot
+++ b/source-postgres/testdata/TestEmptyTable.snapshot
@@ -1,3 +1,4 @@
+{"type":"STATE","state":{"data":{"current_lsn":1234,"streams":{"public.test_emptytable":{"mode":"Active","key_columns":["id"]}}}}}
 {"type":"RECORD","record":{"stream":"test_emptytable","data":{"_change_type":"Insert","data":"some","id":1002},"emitted_at":1234,"namespace":"public"}}
 {"type":"RECORD","record":{"stream":"test_emptytable","data":{"_change_type":"Insert","data":"more","id":1000},"emitted_at":1234,"namespace":"public"}}
 {"type":"RECORD","record":{"stream":"test_emptytable","data":{"_change_type":"Insert","data":"rows","id":1001},"emitted_at":1234,"namespace":"public"}}

--- a/source-postgres/testdata/TestEmptyTable_init.snapshot
+++ b/source-postgres/testdata/TestEmptyTable_init.snapshot
@@ -1,3 +1,2 @@
 {"type":"STATE","state":{"data":{"current_lsn":1234,"streams":{"public.test_emptytable":{"mode":"Backfill","key_columns":["id"]}}}}}
-{"type":"STATE","state":{"data":{"current_lsn":1234,"streams":{"public.test_emptytable":{"mode":"Backfill","key_columns":["id"]}}}}}
 {"type":"STATE","state":{"data":{"current_lsn":1234,"streams":{"public.test_emptytable":{"mode":"Active","key_columns":["id"]}}}}}

--- a/source-postgres/testdata/TestIgnoredStreams_capture1.snapshot
+++ b/source-postgres/testdata/TestIgnoredStreams_capture1.snapshot
@@ -1,5 +1,4 @@
 {"type":"STATE","state":{"data":{"current_lsn":1234,"streams":{"public.test_ignoredstreams_one":{"mode":"Backfill","key_columns":["id"]}}}}}
-{"type":"STATE","state":{"data":{"current_lsn":1234,"streams":{"public.test_ignoredstreams_one":{"mode":"Backfill","key_columns":["id"]}}}}}
 {"type":"RECORD","record":{"stream":"test_ignoredstreams_one","data":{"_change_type":"Insert","data":"zero","id":0},"emitted_at":1234,"namespace":"public"}}
 {"type":"RECORD","record":{"stream":"test_ignoredstreams_one","data":{"_change_type":"Insert","data":"one","id":1},"emitted_at":1234,"namespace":"public"}}
 {"type":"RECORD","record":{"stream":"test_ignoredstreams_one","data":{"_change_type":"Insert","data":"two","id":2},"emitted_at":1234,"namespace":"public"}}

--- a/source-postgres/testdata/TestIgnoredStreams_capture2.snapshot
+++ b/source-postgres/testdata/TestIgnoredStreams_capture2.snapshot
@@ -1,3 +1,4 @@
+{"type":"STATE","state":{"data":{"current_lsn":1234,"streams":{"public.test_ignoredstreams_one":{"mode":"Active","key_columns":["id"]}}}}}
 {"type":"RECORD","record":{"stream":"test_ignoredstreams_one","data":{"_change_type":"Insert","data":"six","id":6},"emitted_at":1234,"namespace":"public"}}
 {"type":"STATE","state":{"data":{"current_lsn":1234,"streams":{"public.test_ignoredstreams_one":{"mode":"Active","key_columns":["id"]}}}}}
 {"type":"RECORD","record":{"stream":"test_ignoredstreams_one","data":{"_change_type":"Insert","data":"eight","id":8},"emitted_at":1234,"namespace":"public"}}

--- a/source-postgres/testdata/TestMultipleStreams_capture1.snapshot
+++ b/source-postgres/testdata/TestMultipleStreams_capture1.snapshot
@@ -1,5 +1,4 @@
 {"type":"STATE","state":{"data":{"current_lsn":1234,"streams":{"public.test_multiplestreams_one":{"mode":"Backfill","key_columns":["id"]}}}}}
-{"type":"STATE","state":{"data":{"current_lsn":1234,"streams":{"public.test_multiplestreams_one":{"mode":"Backfill","key_columns":["id"]}}}}}
 {"type":"RECORD","record":{"stream":"test_multiplestreams_one","data":{"_change_type":"Insert","data":"zero","id":0},"emitted_at":1234,"namespace":"public"}}
 {"type":"RECORD","record":{"stream":"test_multiplestreams_one","data":{"_change_type":"Insert","data":"one","id":1},"emitted_at":1234,"namespace":"public"}}
 {"type":"RECORD","record":{"stream":"test_multiplestreams_one","data":{"_change_type":"Insert","data":"two","id":2},"emitted_at":1234,"namespace":"public"}}

--- a/source-postgres/testdata/TestMultipleStreams_capture2.snapshot
+++ b/source-postgres/testdata/TestMultipleStreams_capture2.snapshot
@@ -1,5 +1,4 @@
 {"type":"STATE","state":{"data":{"current_lsn":1234,"streams":{"public.test_multiplestreams_one":{"mode":"Active","key_columns":["id"]},"public.test_multiplestreams_three":{"mode":"Backfill","key_columns":["id"]},"public.test_multiplestreams_two":{"mode":"Backfill","key_columns":["id"]}}}}}
-{"type":"STATE","state":{"data":{"current_lsn":1234,"streams":{"public.test_multiplestreams_one":{"mode":"Active","key_columns":["id"]},"public.test_multiplestreams_three":{"mode":"Backfill","key_columns":["id"]},"public.test_multiplestreams_two":{"mode":"Backfill","key_columns":["id"]}}}}}
 {"type":"RECORD","record":{"stream":"test_multiplestreams_three","data":{"_change_type":"Insert","data":"six","id":6},"emitted_at":1234,"namespace":"public"}}
 {"type":"RECORD","record":{"stream":"test_multiplestreams_three","data":{"_change_type":"Insert","data":"seven","id":7},"emitted_at":1234,"namespace":"public"}}
 {"type":"RECORD","record":{"stream":"test_multiplestreams_three","data":{"_change_type":"Insert","data":"eight","id":8},"emitted_at":1234,"namespace":"public"}}

--- a/source-postgres/testdata/TestMultipleStreams_capture4.snapshot
+++ b/source-postgres/testdata/TestMultipleStreams_capture4.snapshot
@@ -1,3 +1,4 @@
+{"type":"STATE","state":{"data":{"current_lsn":1234,"streams":{"public.test_multiplestreams_one":{"mode":"Active","key_columns":["id"]},"public.test_multiplestreams_three":{"mode":"Active","key_columns":["id"]}}}}}
 {"type":"RECORD","record":{"stream":"test_multiplestreams_one","data":{"_change_type":"Insert","data":"nine","id":9},"emitted_at":1234,"namespace":"public"}}
 {"type":"STATE","state":{"data":{"current_lsn":1234,"streams":{"public.test_multiplestreams_one":{"mode":"Active","key_columns":["id"]},"public.test_multiplestreams_three":{"mode":"Active","key_columns":["id"]}}}}}
 {"type":"RECORD","record":{"stream":"test_multiplestreams_three","data":{"_change_type":"Insert","data":"eleven","id":11},"emitted_at":1234,"namespace":"public"}}

--- a/source-postgres/testdata/TestMultipleStreams_capture5.snapshot
+++ b/source-postgres/testdata/TestMultipleStreams_capture5.snapshot
@@ -1,5 +1,4 @@
 {"type":"STATE","state":{"data":{"current_lsn":1234,"streams":{"public.test_multiplestreams_one":{"mode":"Active","key_columns":["id"]},"public.test_multiplestreams_three":{"mode":"Active","key_columns":["id"]},"public.test_multiplestreams_two":{"mode":"Backfill","key_columns":["id"]}}}}}
-{"type":"STATE","state":{"data":{"current_lsn":1234,"streams":{"public.test_multiplestreams_one":{"mode":"Active","key_columns":["id"]},"public.test_multiplestreams_three":{"mode":"Active","key_columns":["id"]},"public.test_multiplestreams_two":{"mode":"Backfill","key_columns":["id"]}}}}}
 {"type":"RECORD","record":{"stream":"test_multiplestreams_two","data":{"_change_type":"Insert","data":"three","id":3},"emitted_at":1234,"namespace":"public"}}
 {"type":"RECORD","record":{"stream":"test_multiplestreams_two","data":{"_change_type":"Insert","data":"four","id":4},"emitted_at":1234,"namespace":"public"}}
 {"type":"RECORD","record":{"stream":"test_multiplestreams_two","data":{"_change_type":"Insert","data":"five","id":5},"emitted_at":1234,"namespace":"public"}}

--- a/source-postgres/testdata/TestReplicationDeletes.snapshot
+++ b/source-postgres/testdata/TestReplicationDeletes.snapshot
@@ -1,3 +1,4 @@
+{"type":"STATE","state":{"data":{"current_lsn":1234,"streams":{"public.test_replicationdeletes":{"mode":"Active","key_columns":["id"]}}}}}
 {"type":"RECORD","record":{"stream":"test_replicationdeletes","data":{"_change_type":"Insert","data":"some","id":1002},"emitted_at":1234,"namespace":"public"}}
 {"type":"RECORD","record":{"stream":"test_replicationdeletes","data":{"_change_type":"Insert","data":"more","id":1000},"emitted_at":1234,"namespace":"public"}}
 {"type":"RECORD","record":{"stream":"test_replicationdeletes","data":{"_change_type":"Insert","data":"rows","id":1001},"emitted_at":1234,"namespace":"public"}}

--- a/source-postgres/testdata/TestReplicationDeletes_init.snapshot
+++ b/source-postgres/testdata/TestReplicationDeletes_init.snapshot
@@ -1,5 +1,4 @@
 {"type":"STATE","state":{"data":{"current_lsn":1234,"streams":{"public.test_replicationdeletes":{"mode":"Backfill","key_columns":["id"]}}}}}
-{"type":"STATE","state":{"data":{"current_lsn":1234,"streams":{"public.test_replicationdeletes":{"mode":"Backfill","key_columns":["id"]}}}}}
 {"type":"RECORD","record":{"stream":"test_replicationdeletes","data":{"_change_type":"Insert","data":"A","id":0},"emitted_at":1234,"namespace":"public"}}
 {"type":"RECORD","record":{"stream":"test_replicationdeletes","data":{"_change_type":"Insert","data":"bbb","id":1},"emitted_at":1234,"namespace":"public"}}
 {"type":"RECORD","record":{"stream":"test_replicationdeletes","data":{"_change_type":"Insert","data":"CDEFGHIJKLMNOP","id":2},"emitted_at":1234,"namespace":"public"}}

--- a/source-postgres/testdata/TestReplicationInserts.snapshot
+++ b/source-postgres/testdata/TestReplicationInserts.snapshot
@@ -1,3 +1,4 @@
+{"type":"STATE","state":{"data":{"current_lsn":1234,"streams":{"public.test_replicationinserts":{"mode":"Active","key_columns":["id"]}}}}}
 {"type":"RECORD","record":{"stream":"test_replicationinserts","data":{"_change_type":"Insert","data":"some","id":1002},"emitted_at":1234,"namespace":"public"}}
 {"type":"RECORD","record":{"stream":"test_replicationinserts","data":{"_change_type":"Insert","data":"more","id":1000},"emitted_at":1234,"namespace":"public"}}
 {"type":"RECORD","record":{"stream":"test_replicationinserts","data":{"_change_type":"Insert","data":"rows","id":1001},"emitted_at":1234,"namespace":"public"}}

--- a/source-postgres/testdata/TestReplicationInserts_init.snapshot
+++ b/source-postgres/testdata/TestReplicationInserts_init.snapshot
@@ -1,5 +1,4 @@
 {"type":"STATE","state":{"data":{"current_lsn":1234,"streams":{"public.test_replicationinserts":{"mode":"Backfill","key_columns":["id"]}}}}}
-{"type":"STATE","state":{"data":{"current_lsn":1234,"streams":{"public.test_replicationinserts":{"mode":"Backfill","key_columns":["id"]}}}}}
 {"type":"RECORD","record":{"stream":"test_replicationinserts","data":{"_change_type":"Insert","data":"A","id":0},"emitted_at":1234,"namespace":"public"}}
 {"type":"RECORD","record":{"stream":"test_replicationinserts","data":{"_change_type":"Insert","data":"bbb","id":1},"emitted_at":1234,"namespace":"public"}}
 {"type":"RECORD","record":{"stream":"test_replicationinserts","data":{"_change_type":"Insert","data":"CDEFGHIJKLMNOP","id":2},"emitted_at":1234,"namespace":"public"}}

--- a/source-postgres/testdata/TestReplicationUpdates.snapshot
+++ b/source-postgres/testdata/TestReplicationUpdates.snapshot
@@ -1,3 +1,4 @@
+{"type":"STATE","state":{"data":{"current_lsn":1234,"streams":{"public.test_replicationupdates":{"mode":"Active","key_columns":["id"]}}}}}
 {"type":"RECORD","record":{"stream":"test_replicationupdates","data":{"_change_type":"Insert","data":"some","id":1002},"emitted_at":1234,"namespace":"public"}}
 {"type":"RECORD","record":{"stream":"test_replicationupdates","data":{"_change_type":"Insert","data":"more","id":1000},"emitted_at":1234,"namespace":"public"}}
 {"type":"RECORD","record":{"stream":"test_replicationupdates","data":{"_change_type":"Insert","data":"rows","id":1001},"emitted_at":1234,"namespace":"public"}}

--- a/source-postgres/testdata/TestReplicationUpdates_init.snapshot
+++ b/source-postgres/testdata/TestReplicationUpdates_init.snapshot
@@ -1,5 +1,4 @@
 {"type":"STATE","state":{"data":{"current_lsn":1234,"streams":{"public.test_replicationupdates":{"mode":"Backfill","key_columns":["id"]}}}}}
-{"type":"STATE","state":{"data":{"current_lsn":1234,"streams":{"public.test_replicationupdates":{"mode":"Backfill","key_columns":["id"]}}}}}
 {"type":"RECORD","record":{"stream":"test_replicationupdates","data":{"_change_type":"Insert","data":"A","id":0},"emitted_at":1234,"namespace":"public"}}
 {"type":"RECORD","record":{"stream":"test_replicationupdates","data":{"_change_type":"Insert","data":"bbb","id":1},"emitted_at":1234,"namespace":"public"}}
 {"type":"RECORD","record":{"stream":"test_replicationupdates","data":{"_change_type":"Insert","data":"CDEFGHIJKLMNOP","id":2},"emitted_at":1234,"namespace":"public"}}

--- a/source-postgres/testdata/TestSimpleCapture.snapshot
+++ b/source-postgres/testdata/TestSimpleCapture.snapshot
@@ -1,5 +1,4 @@
 {"type":"STATE","state":{"data":{"current_lsn":1234,"streams":{"public.test_simplecapture":{"mode":"Backfill","key_columns":["id"]}}}}}
-{"type":"STATE","state":{"data":{"current_lsn":1234,"streams":{"public.test_simplecapture":{"mode":"Backfill","key_columns":["id"]}}}}}
 {"type":"RECORD","record":{"stream":"test_simplecapture","data":{"_change_type":"Insert","data":"A","id":0},"emitted_at":1234,"namespace":"public"}}
 {"type":"RECORD","record":{"stream":"test_simplecapture","data":{"_change_type":"Insert","data":"bbb","id":1},"emitted_at":1234,"namespace":"public"}}
 {"type":"RECORD","record":{"stream":"test_simplecapture","data":{"_change_type":"Insert","data":"CDEFGHIJKLMNOP","id":2},"emitted_at":1234,"namespace":"public"}}

--- a/source-postgres/testdata/TestSlotLSNAdvances_capture1.snapshot
+++ b/source-postgres/testdata/TestSlotLSNAdvances_capture1.snapshot
@@ -1,5 +1,4 @@
 {"type":"STATE","state":{"data":{"current_lsn":1234,"streams":{"public.test_slotlsnadvances_one":{"mode":"Backfill","key_columns":["id"]}}}}}
-{"type":"STATE","state":{"data":{"current_lsn":1234,"streams":{"public.test_slotlsnadvances_one":{"mode":"Backfill","key_columns":["id"]}}}}}
 {"type":"RECORD","record":{"stream":"test_slotlsnadvances_one","data":{"_change_type":"Insert","data":"zero","id":0},"emitted_at":1234,"namespace":"public"}}
 {"type":"RECORD","record":{"stream":"test_slotlsnadvances_one","data":{"_change_type":"Insert","data":"one","id":1},"emitted_at":1234,"namespace":"public"}}
 {"type":"RECORD","record":{"stream":"test_slotlsnadvances_one","data":{"_change_type":"Insert","data":"two","id":2},"emitted_at":1234,"namespace":"public"}}

--- a/source-postgres/testdata/TestSlotLSNAdvances_capture2.snapshot
+++ b/source-postgres/testdata/TestSlotLSNAdvances_capture2.snapshot
@@ -1,4 +1,0 @@
-{"type":"RECORD","record":{"stream":"test_slotlsnadvances_one","data":{"_change_type":"Insert","data":"three","id":3},"emitted_at":1234,"namespace":"public"}}
-{"type":"RECORD","record":{"stream":"test_slotlsnadvances_one","data":{"_change_type":"Insert","data":"four","id":4},"emitted_at":1234,"namespace":"public"}}
-{"type":"RECORD","record":{"stream":"test_slotlsnadvances_one","data":{"_change_type":"Insert","data":"five","id":5},"emitted_at":1234,"namespace":"public"}}
-{"type":"STATE","state":{"data":{"current_lsn":1234,"streams":{"public.test_slotlsnadvances_one":{"mode":"Active","key_columns":["id"]}}}}}

--- a/source-postgres/testdata/TestSlotLSNAdvances_captureN.snapshot
+++ b/source-postgres/testdata/TestSlotLSNAdvances_captureN.snapshot
@@ -1,0 +1,1 @@
+{"type":"STATE","state":{"data":{"current_lsn":1234,"streams":{"public.test_slotlsnadvances_one":{"mode":"Active","key_columns":["id"]}}}}}

--- a/source-postgres/testdata/TestTailing.snapshot
+++ b/source-postgres/testdata/TestTailing.snapshot
@@ -1,0 +1,16 @@
+{"type":"STATE","state":{"data":{"current_lsn":1234,"streams":{"public.test_tailing":{"mode":"Backfill","key_columns":["id"]}}}}}
+{"type":"STATE","state":{"data":{"current_lsn":1234,"streams":{"public.test_tailing":{"mode":"Backfill","key_columns":["id"]}}}}}
+{"type":"RECORD","record":{"stream":"test_tailing","data":{"_change_type":"Insert","data":"A","id":0},"emitted_at":1234,"namespace":"public"}}
+{"type":"RECORD","record":{"stream":"test_tailing","data":{"_change_type":"Insert","data":"bbb","id":10},"emitted_at":1234,"namespace":"public"}}
+{"type":"RECORD","record":{"stream":"test_tailing","data":{"_change_type":"Insert","data":"CDEFGHIJKLMNOP","id":20},"emitted_at":1234,"namespace":"public"}}
+{"type":"RECORD","record":{"stream":"test_tailing","data":{"_change_type":"Insert","data":"Four","id":30},"emitted_at":1234,"namespace":"public"}}
+{"type":"RECORD","record":{"stream":"test_tailing","data":{"_change_type":"Insert","data":"5","id":40},"emitted_at":1234,"namespace":"public"}}
+{"type":"STATE","state":{"data":{"current_lsn":1234,"streams":{"public.test_tailing":{"mode":"Backfill","key_columns":["id"],"scanned":"FSg="}}}}}
+{"type":"STATE","state":{"data":{"current_lsn":1234,"streams":{"public.test_tailing":{"mode":"Active","key_columns":["id"]}}}}}
+{"type":"RECORD","record":{"stream":"test_tailing","data":{"_change_type":"Insert","data":"asdf","id":5},"emitted_at":1234,"namespace":"public"}}
+{"type":"RECORD","record":{"stream":"test_tailing","data":{"_change_type":"Insert","data":"lots","id":100},"emitted_at":1234,"namespace":"public"}}
+{"type":"STATE","state":{"data":{"current_lsn":1234,"streams":{"public.test_tailing":{"mode":"Active","key_columns":["id"]}}}}}
+{"type":"RECORD","record":{"stream":"test_tailing","data":{"_change_type":"Delete","data":null,"id":20},"emitted_at":1234,"namespace":"public"}}
+{"type":"STATE","state":{"data":{"current_lsn":1234,"streams":{"public.test_tailing":{"mode":"Active","key_columns":["id"]}}}}}
+{"type":"RECORD","record":{"stream":"test_tailing","data":{"_change_type":"Update","data":"updated","id":30},"emitted_at":1234,"namespace":"public"}}
+{"type":"STATE","state":{"data":{"current_lsn":1234,"streams":{"public.test_tailing":{"mode":"Active","key_columns":["id"]}}}}}

--- a/source-postgres/testdata/TestTailing.snapshot
+++ b/source-postgres/testdata/TestTailing.snapshot
@@ -1,5 +1,4 @@
 {"type":"STATE","state":{"data":{"current_lsn":1234,"streams":{"public.test_tailing":{"mode":"Backfill","key_columns":["id"]}}}}}
-{"type":"STATE","state":{"data":{"current_lsn":1234,"streams":{"public.test_tailing":{"mode":"Backfill","key_columns":["id"]}}}}}
 {"type":"RECORD","record":{"stream":"test_tailing","data":{"_change_type":"Insert","data":"A","id":0},"emitted_at":1234,"namespace":"public"}}
 {"type":"RECORD","record":{"stream":"test_tailing","data":{"_change_type":"Insert","data":"bbb","id":10},"emitted_at":1234,"namespace":"public"}}
 {"type":"RECORD","record":{"stream":"test_tailing","data":{"_change_type":"Insert","data":"CDEFGHIJKLMNOP","id":20},"emitted_at":1234,"namespace":"public"}}


### PR DESCRIPTION
I'm not sure what else to title this PR -- it's a bunch of trivial to medium-sized followup changes now that the main watermarks rewrite has been merged, and which I'd like to get out of the way before I get too far into abstracting stuff with interfaces and implementing those interfaces for other databases.

I recommend reviewing this commit-by-commit, as each change is pretty small and self-contained.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/72)
<!-- Reviewable:end -->
