### PR TITLE
elasticsearch materialization connector

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -69,6 +69,7 @@ jobs:
           - materialize-elasticsearch
           - materialize-postgres
           - materialize-snowflake
+          - materialize-s3-parquet
           - materialize-webhook
 
     steps:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,7 +7,7 @@ on:
     branches: [main]
 
 jobs:
-  build_parser:
+  build_rust_releases:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
@@ -31,21 +31,29 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             parser/target/
+            materialize-elasticsearch/schemabuilder/target/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
-      - name: Test Parser
-        run: cargo test --manifest-path=parser/Cargo.toml --locked
+      - name: Test Rust Apps
+        run: |
+          cargo test --manifest-path=parser/Cargo.toml --locked
+          cargo test --manifest-path=materialize-elasticsearch/schemabuilder/Cargo.toml --locked
 
-      - name: Build Parser
-        run: cargo build --manifest-path=parser/Cargo.toml --locked --release --target=x86_64-unknown-linux-musl
+      - name: Build Rust Apps
+        run: |
+          cargo build --manifest-path=parser/Cargo.toml --locked --release --target=x86_64-unknown-linux-musl
+          cargo build --manifest-path=materialize-elasticsearch/schemabuilder/Cargo.toml --locked --release --target=x86_64-unknown-linux-musl
 
-      - uses: actions/upload-artifact@v1
+      - name: Upload Rust Apps
+        uses: actions/upload-artifact@v2
         with:
-          name: parser_binary
-          path: parser/target/x86_64-unknown-linux-musl/release/parser
+          name: rust_binary
+          path: |
+            parser/target/x86_64-unknown-linux-musl/release/parser
+            materialize-elasticsearch/schemabuilder/target/x86_64-unknown-linux-musl/release/schema-builder
 
   build_connectors:
-    needs: build_parser
+    needs: build_rust_releases
     runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
@@ -57,10 +65,11 @@ jobs:
           - source-kinesis
           - source-postgres
           - source-s3
+          - materialize-bigquery
+          - materialize-elasticsearch
           - materialize-postgres
           - materialize-snowflake
           - materialize-webhook
-          - materialize-bigquery
 
     steps:
       - uses: actions/checkout@v2
@@ -73,14 +82,16 @@ jobs:
           TAG=$(echo $GITHUB_SHA | head -c7)
           echo ::set-output name=tag::${TAG}
 
-      - uses: actions/download-artifact@v1
+      - uses: actions/download-artifact@v2
         with:
-          name: parser_binary
-          path: parser/target/x86_64-unknown-linux-musl/release/
+          name: rust_binary
 
       # Downloaded artifacts lose their prior permission settings
-      - name: Adjust parser permissions
-        run: chmod +x parser/target/x86_64-unknown-linux-musl/release/parser
+      - name: Adjust rust binary permissions
+        run: |
+          chmod +x \
+          parser/target/x86_64-unknown-linux-musl/release/parser \
+          materialize-elasticsearch/schemabuilder/target/x86_64-unknown-linux-musl/release/schema-builder
 
       - name: Install kafkactl
         if: matrix.connector == 'source-kafka'

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/benbjohnson/clock v1.1.0
 	github.com/bradleyjkemp/cupaloy v2.3.0+incompatible
 	github.com/brianvoe/gofakeit/v6 v6.9.0
+	github.com/elastic/go-elasticsearch/v7 v7.15.2-0.20211104170009-caf202868441
 	github.com/estuary/flow v0.1.1-0.20211014150201-5fb28e9026f9
 	github.com/estuary/protocols v0.0.0-20211129055338-9259b2dca80a
 	github.com/gogo/protobuf v1.3.2
@@ -27,6 +28,7 @@ require (
 	github.com/jessevdk/go-flags v1.5.0
 	github.com/klauspost/compress v1.13.6 // indirect
 	github.com/mattn/go-sqlite3 v2.0.3+incompatible
+	github.com/meirf/gopart v0.0.0-20180520194036-37e9492a85a8
 	github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8 // indirect
 	github.com/prometheus/common v0.31.1 // indirect
 	github.com/sirupsen/logrus v1.8.1

--- a/go.mod
+++ b/go.mod
@@ -28,7 +28,6 @@ require (
 	github.com/jessevdk/go-flags v1.5.0
 	github.com/klauspost/compress v1.13.6 // indirect
 	github.com/mattn/go-sqlite3 v2.0.3+incompatible
-	github.com/meirf/gopart v0.0.0-20180520194036-37e9492a85a8
 	github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8 // indirect
 	github.com/prometheus/common v0.31.1 // indirect
 	github.com/sirupsen/logrus v1.8.1

--- a/go.sum
+++ b/go.sum
@@ -216,8 +216,6 @@ github.com/docker/spdystream v0.0.0-20160310174837-449fdfce4d96/go.mod h1:Qh8CwZ
 github.com/dustin/go-humanize v0.0.0-20171111073723-bb3d318650d4/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/dustinkirkland/golang-petname v0.0.0-20191129215211-8e5a1ed0cff0/go.mod h1:V+Qd57rJe8gd4eiGzZyg4h54VLHmYVVw54iMnlAMrF8=
-github.com/elastic/go-elasticsearch/v7 v7.15.1 h1:Wd8RLHb5D8xPBU8vGlnLXyflkso9G+rCmsXjqH8LLQQ=
-github.com/elastic/go-elasticsearch/v7 v7.15.1/go.mod h1:OJ4wdbtDNk5g503kvlHLyErCgQwwzmDtaFC4XyOxXA4=
 github.com/elastic/go-elasticsearch/v7 v7.15.2-0.20211104170009-caf202868441 h1:16ZnvyxVecguRnzozLkpnGhgT6/Y/3aiqRuCcp9f0KE=
 github.com/elastic/go-elasticsearch/v7 v7.15.2-0.20211104170009-caf202868441/go.mod h1:OJ4wdbtDNk5g503kvlHLyErCgQwwzmDtaFC4XyOxXA4=
 github.com/elazarl/goproxy v0.0.0-20170405201442-c4fc26588b6e/go.mod h1:/Zj4wYkgs4iZTTu3o/KG3Itv/qCCa8VVMlb3i9OVuzc=
@@ -555,8 +553,6 @@ github.com/mattn/go-sqlite3 v2.0.3+incompatible h1:gXHsfypPkaMZrKbD5209QV9jbUTJK
 github.com/mattn/go-sqlite3 v2.0.3+incompatible/go.mod h1:FPy6KqzDD04eiIsT53CuJW3U88zkxoIYsOqkbpncsNc=
 github.com/matttproud/golang_protobuf_extensions v1.0.1 h1:4hp9jkHxhMHkqkrB3Ix0jegS5sx/RkqARlsWZ6pIwiU=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
-github.com/meirf/gopart v0.0.0-20180520194036-37e9492a85a8 h1:7TJiWD1knYDpOAPyFBoKqoyvlsa+UwDw0kv0jVN5Mrk=
-github.com/meirf/gopart v0.0.0-20180520194036-37e9492a85a8/go.mod h1:Uz8uoD6o+eQN19hr6Yro/qKvW+KP6olFq+PK/Nn7gCE=
 github.com/minio/highwayhash v1.0.2 h1:Aak5U0nElisjDCfPSG79Tgzkn2gl66NxOMspRrKnA/g=
 github.com/minio/highwayhash v1.0.2/go.mod h1:BQskDq+xkJ12lmlUUi7U0M5Swg3EWR+dLTk+kldvVxY=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=

--- a/go.sum
+++ b/go.sum
@@ -216,6 +216,10 @@ github.com/docker/spdystream v0.0.0-20160310174837-449fdfce4d96/go.mod h1:Qh8CwZ
 github.com/dustin/go-humanize v0.0.0-20171111073723-bb3d318650d4/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/dustinkirkland/golang-petname v0.0.0-20191129215211-8e5a1ed0cff0/go.mod h1:V+Qd57rJe8gd4eiGzZyg4h54VLHmYVVw54iMnlAMrF8=
+github.com/elastic/go-elasticsearch/v7 v7.15.1 h1:Wd8RLHb5D8xPBU8vGlnLXyflkso9G+rCmsXjqH8LLQQ=
+github.com/elastic/go-elasticsearch/v7 v7.15.1/go.mod h1:OJ4wdbtDNk5g503kvlHLyErCgQwwzmDtaFC4XyOxXA4=
+github.com/elastic/go-elasticsearch/v7 v7.15.2-0.20211104170009-caf202868441 h1:16ZnvyxVecguRnzozLkpnGhgT6/Y/3aiqRuCcp9f0KE=
+github.com/elastic/go-elasticsearch/v7 v7.15.2-0.20211104170009-caf202868441/go.mod h1:OJ4wdbtDNk5g503kvlHLyErCgQwwzmDtaFC4XyOxXA4=
 github.com/elazarl/goproxy v0.0.0-20170405201442-c4fc26588b6e/go.mod h1:/Zj4wYkgs4iZTTu3o/KG3Itv/qCCa8VVMlb3i9OVuzc=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
@@ -551,6 +555,8 @@ github.com/mattn/go-sqlite3 v2.0.3+incompatible h1:gXHsfypPkaMZrKbD5209QV9jbUTJK
 github.com/mattn/go-sqlite3 v2.0.3+incompatible/go.mod h1:FPy6KqzDD04eiIsT53CuJW3U88zkxoIYsOqkbpncsNc=
 github.com/matttproud/golang_protobuf_extensions v1.0.1 h1:4hp9jkHxhMHkqkrB3Ix0jegS5sx/RkqARlsWZ6pIwiU=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
+github.com/meirf/gopart v0.0.0-20180520194036-37e9492a85a8 h1:7TJiWD1knYDpOAPyFBoKqoyvlsa+UwDw0kv0jVN5Mrk=
+github.com/meirf/gopart v0.0.0-20180520194036-37e9492a85a8/go.mod h1:Uz8uoD6o+eQN19hr6Yro/qKvW+KP6olFq+PK/Nn7gCE=
 github.com/minio/highwayhash v1.0.2 h1:Aak5U0nElisjDCfPSG79Tgzkn2gl66NxOMspRrKnA/g=
 github.com/minio/highwayhash v1.0.2/go.mod h1:BQskDq+xkJ12lmlUUi7U0M5Swg3EWR+dLTk+kldvVxY=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=

--- a/materialize-elasticsearch/.snapshots/TestDriverSpec
+++ b/materialize-elasticsearch/.snapshots/TestDriverSpec
@@ -5,18 +5,16 @@
     "definitions": {
       "config": {
         "required": [
-          "endpoint",
-          "Username",
-          "Password"
+          "endpoint"
         ],
         "properties": {
           "endpoint": {
             "type": "string"
           },
-          "Username": {
+          "username": {
             "type": "string"
           },
-          "Password": {
+          "password": {
             "type": "string"
           }
         },

--- a/materialize-elasticsearch/.snapshots/TestDriverSpec
+++ b/materialize-elasticsearch/.snapshots/TestDriverSpec
@@ -129,7 +129,8 @@
             "type": "array"
           },
           "number_of_shards": {
-            "type": "integer"
+            "type": "integer",
+            "default": 1
           },
           "number_of_replicas": {
             "type": "integer"

--- a/materialize-elasticsearch/.snapshots/TestDriverSpec
+++ b/materialize-elasticsearch/.snapshots/TestDriverSpec
@@ -127,6 +127,12 @@
               "$ref": "#/definitions/FieldOverride"
             },
             "type": "array"
+          },
+          "number_of_shards": {
+            "type": "integer"
+          },
+          "number_of_replicas": {
+            "type": "integer"
           }
         },
         "additionalProperties": false,

--- a/materialize-elasticsearch/.snapshots/TestDriverSpec
+++ b/materialize-elasticsearch/.snapshots/TestDriverSpec
@@ -1,0 +1,140 @@
+{
+  "endpoint_spec_schema_json": {
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "$ref": "#/definitions/config",
+    "definitions": {
+      "config": {
+        "required": [
+          "endpoint",
+          "Username",
+          "Password"
+        ],
+        "properties": {
+          "endpoint": {
+            "type": "string"
+          },
+          "Username": {
+            "type": "string"
+          },
+          "Password": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object"
+      }
+    }
+  },
+  "resource_spec_schema_json": {
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "$ref": "#/definitions/resource",
+    "definitions": {
+      "DateSpec": {
+        "required": [
+          "format"
+        ],
+        "properties": {
+          "format": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object"
+      },
+      "ElasticFieldType": {
+        "required": [
+          "field_type"
+        ],
+        "properties": {
+          "field_type": {
+            "type": "string"
+          },
+          "date_spec": {
+            "$schema": "http://json-schema.org/draft-04/schema#",
+            "$ref": "#/definitions/DateSpec"
+          },
+          "keyword_spec": {
+            "$schema": "http://json-schema.org/draft-04/schema#",
+            "$ref": "#/definitions/KeywordSpec"
+          },
+          "text_spec": {
+            "$schema": "http://json-schema.org/draft-04/schema#",
+            "$ref": "#/definitions/TextSpec"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object"
+      },
+      "FieldOverride": {
+        "required": [
+          "pointer",
+          "es_type"
+        ],
+        "properties": {
+          "pointer": {
+            "type": "string"
+          },
+          "es_type": {
+            "$schema": "http://json-schema.org/draft-04/schema#",
+            "$ref": "#/definitions/ElasticFieldType"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object"
+      },
+      "KeywordSpec": {
+        "required": [
+          "ignore_above"
+        ],
+        "properties": {
+          "ignore_above": {
+            "type": "integer"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object"
+      },
+      "TextSpec": {
+        "required": [
+          "dual_keyword",
+          "keyword_ignore_above"
+        ],
+        "properties": {
+          "dual_keyword": {
+            "type": "boolean"
+          },
+          "keyword_ignore_above": {
+            "type": "integer"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object"
+      },
+      "resource": {
+        "required": [
+          "index",
+          "delta_updates",
+          "field_overrides"
+        ],
+        "properties": {
+          "index": {
+            "type": "string"
+          },
+          "delta_updates": {
+            "type": "boolean"
+          },
+          "field_overrides": {
+            "items": {
+              "$schema": "http://json-schema.org/draft-04/schema#",
+              "$ref": "#/definitions/FieldOverride"
+            },
+            "type": "array"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object"
+      }
+    }
+  },
+  "documentation_url": "https://docs.estuary.dev#FIXME"
+}

--- a/materialize-elasticsearch/Dockerfile
+++ b/materialize-elasticsearch/Dockerfile
@@ -1,0 +1,39 @@
+# Build Stage
+################################################################################
+FROM golang:1.17-bullseye as builder
+
+WORKDIR /builder
+
+# Download & compile dependencies early. Doing this separately allows for layer
+# caching opportunities when no dependencies are updated.
+COPY go.* ./
+RUN go mod download
+
+# Build the connector projects we depend on.
+COPY materialize-boilerplate ./materialize-boilerplate
+COPY materialize-elasticsearch ./materialize-elasticsearch
+
+# Copy schema-builder binary.
+COPY materialize-elasticsearch/schemabuilder/target/x86_64-unknown-linux-musl/release/schema-builder ./schema-builder
+
+ENV PATH="/builder:$PATH"
+# Test and build the connector.
+RUN go test  -tags nozstd -v ./materialize-elasticsearch/...
+RUN go build -tags nozstd -v -o ./connector ./materialize-elasticsearch
+
+# Runtime Stage
+################################################################################
+FROM gcr.io/distroless/base-debian11
+
+WORKDIR /connector
+ENV PATH="/connector:$PATH"
+
+# Bring in the compiled connector artifact from the builder.
+COPY --from=builder /builder/connector /connector/connector
+COPY --from=builder /builder/schema-builder /connector/schema-builder
+COPY --from=builder /lib/x86_64-linux-gnu/libgcc_s.so.1 /lib/x86_64-linux-gnu/
+
+# Avoid running the connector as root.
+USER nonroot:nonroot
+
+ENTRYPOINT ["/connector/connector"]

--- a/materialize-elasticsearch/driver.go
+++ b/materialize-elasticsearch/driver.go
@@ -1,0 +1,317 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/alecthomas/jsonschema"
+	"github.com/elastic/go-elasticsearch/v7/esutil"
+	boilerplate "github.com/estuary/connectors/materialize-boilerplate"
+	"github.com/estuary/connectors/materialize-elasticsearch/schemabuilder"
+	"github.com/estuary/protocols/fdb/tuple"
+	pf "github.com/estuary/protocols/flow"
+	pm "github.com/estuary/protocols/materialize"
+	"github.com/meirf/gopart"
+	log "github.com/sirupsen/logrus"
+)
+
+type config struct {
+	Endpoint string `json:"endpoint"`
+	Username string `json:"username,omitempty"`
+	Password string `json:"password,omitempty"`
+}
+
+func (c config) Validate() error {
+	if c.Endpoint == "" {
+		return fmt.Errorf("missing Endpoint")
+	}
+	return nil
+}
+
+type resource struct {
+	Index         string                        `json:"index"`
+	DeltaUpdates  bool                          `json:"delta_updates"`
+	FieldOverides []schemabuilder.FieldOverride `json:"field_overrides"`
+}
+
+func (r resource) Validate() error {
+	if r.Index == "" {
+		return fmt.Errorf("missing Index")
+	}
+	return nil
+}
+
+// driver implements the DriverServer interface.
+type driver struct{}
+
+func (driver) Spec(ctx context.Context, req *pm.SpecRequest) (*pm.SpecResponse, error) {
+	endpointSchema, err := jsonschema.Reflect(&config{}).MarshalJSON()
+	if err != nil {
+		return nil, fmt.Errorf("generating endpoint schema: %w", err)
+	}
+
+	resourceSchema, err := jsonschema.Reflect(&resource{}).MarshalJSON()
+	if err != nil {
+		return nil, fmt.Errorf("generating resource schema: %w", err)
+	}
+
+	return &pm.SpecResponse{
+		EndpointSpecSchemaJson: json.RawMessage(endpointSchema),
+		ResourceSpecSchemaJson: json.RawMessage(resourceSchema),
+		DocumentationUrl:       "https://docs.estuary.dev#FIXME",
+	}, nil
+}
+
+func (driver) Validate(ctx context.Context, req *pm.ValidateRequest) (*pm.ValidateResponse, error) {
+	var cfg config
+	if err := pf.UnmarshalStrict(req.EndpointSpecJson, &cfg); err != nil {
+		return nil, fmt.Errorf("parsing endpoint config: %w", err)
+	}
+
+	var out []*pm.ValidateResponse_Binding
+	for _, binding := range req.Bindings {
+		var res resource
+		if err := pf.UnmarshalStrict(binding.ResourceSpecJson, &res); err != nil {
+			return nil, fmt.Errorf("parsing resource config: %w", err)
+		}
+
+		// Make sure the specified resource is valid to build
+		if _, err := schemabuilder.RunSchemaBuilder(
+			binding.Collection.SchemaJson,
+			res.FieldOverides,
+		); err != nil {
+			return nil, fmt.Errorf("building elastic search schema: %w", err)
+		}
+
+		var constraints = make(map[string]*pm.Constraint)
+
+		for _, projection := range binding.Collection.Projections {
+			var constraint = &pm.Constraint{}
+			switch {
+			case projection.IsRootDocumentProjection():
+				constraint.Type = pm.Constraint_FIELD_REQUIRED
+				constraint.Reason = "The root document is needed."
+			default:
+				constraint.Type = pm.Constraint_FIELD_OPTIONAL
+				constraint.Reason = "Non root document fields are not required."
+			}
+			constraints[projection.Field] = constraint
+		}
+		out = append(out, &pm.ValidateResponse_Binding{
+			Constraints:  constraints,
+			DeltaUpdates: res.DeltaUpdates,
+			ResourcePath: []string{res.Index},
+		})
+	}
+
+	return &pm.ValidateResponse{Bindings: out}, nil
+}
+
+func (driver) ApplyUpsert(ctx context.Context, req *pm.ApplyRequest) (*pm.ApplyResponse, error) {
+	if err := req.Validate(); err != nil {
+		return nil, fmt.Errorf("validating request: %w", err)
+	}
+	var cfg config
+	if err := pf.UnmarshalStrict(req.Materialization.EndpointSpecJson, &cfg); err != nil {
+		return nil, fmt.Errorf("parsing endpoint config: %w", err)
+	}
+
+	var elasticSearch, err = NewElasticSearch(cfg.Endpoint, cfg.Username, cfg.Password)
+	if err != nil {
+		return nil, fmt.Errorf("creating elasticSearch: %w", err)
+	}
+
+	var indices []string
+	for _, binding := range req.Materialization.Bindings {
+		var res resource
+		if err := pf.UnmarshalStrict(binding.ResourceSpecJson, &res); err != nil {
+			return nil, fmt.Errorf("parsing resource config: %w", err)
+		}
+
+		var elasticSearchSchema, err = schemabuilder.RunSchemaBuilder(
+			binding.Collection.SchemaJson,
+			res.FieldOverides,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("building elastic search schema: %w", err)
+		}
+
+		if err = elasticSearch.CreateIndex(res.Index, elasticSearchSchema); err != nil {
+			return nil, fmt.Errorf("creating elastic search index: %w", err)
+		}
+		indices = append(indices, res.Index)
+	}
+
+	return &pm.ApplyResponse{ActionDescription: fmt.Sprint("created indices: ", strings.Join(indices, ","))}, nil
+}
+
+// ApplyDelete is a no-op.
+func (driver) ApplyDelete(ctx context.Context, req *pm.ApplyRequest) (*pm.ApplyResponse, error) {
+	return &pm.ApplyResponse{}, nil
+}
+
+// Transactions implements the DriverServer interface.
+func (d driver) Transactions(stream pm.Driver_TransactionsServer) error {
+
+	var open, err = stream.Recv()
+	if err != nil {
+		return fmt.Errorf("read Open: %w", err)
+	} else if open.Open == nil {
+		return fmt.Errorf("expected Open, got %#v", open)
+	}
+
+	var cfg config
+	if err := pf.UnmarshalStrict(open.Open.Materialization.EndpointSpecJson, &cfg); err != nil {
+		return fmt.Errorf("parsing endpoint config: %w", err)
+	}
+
+	var elasticSearch *ElasticSearch
+	elasticSearch, err = NewElasticSearch(cfg.Endpoint, cfg.Username, cfg.Password)
+	if err != nil {
+		return fmt.Errorf("creating elastic search client: %w", err)
+	}
+
+	var bindings []*binding
+	for _, b := range open.Open.Materialization.Bindings {
+		var res resource
+		if err := pf.UnmarshalStrict(b.ResourceSpecJson, &res); err != nil {
+			return fmt.Errorf("parsing resource config: %w", err)
+		}
+		bindings = append(bindings,
+			&binding{
+				index:        res.Index,
+				deltaUpdates: res.DeltaUpdates,
+			})
+	}
+
+	var transactor = &transactor{
+		elasticSearch:    elasticSearch,
+		bindings:         bindings,
+		bulkIndexerItems: []*esutil.BulkIndexerItem{},
+	}
+
+	if err = stream.Send(&pm.TransactionResponse{
+		Opened: &pm.TransactionResponse_Opened{},
+	}); err != nil {
+		return fmt.Errorf("sending Opened: %w", err)
+	}
+
+	var log = log.WithField(
+		"materialization",
+		fmt.Sprintf("mat-elasticsearch-%d-%d", open.Open.KeyBegin, open.Open.KeyEnd),
+	)
+	return pm.RunTransactions(stream, transactor, log)
+}
+
+type binding struct {
+	index        string
+	deltaUpdates bool
+}
+
+type transactor struct {
+	elasticSearch    *ElasticSearch
+	bindings         []*binding
+	bulkIndexerItems []*esutil.BulkIndexerItem
+}
+
+const loadByIdBatchSize = 1000
+
+func (t *transactor) Load(it *pm.LoadIterator, _ <-chan struct{}, _ <-chan struct{}, loaded func(int, json.RawMessage) error) error {
+	log.Debug("Load started")
+	var loadingIdsByBinding = map[int][]string{}
+
+	for it.Next() {
+		var b = t.bindings[it.Binding]
+		if b.deltaUpdates {
+			panic("Load should not be called for delta updates.")
+		}
+		loadingIdsByBinding[it.Binding] = append(loadingIdsByBinding[it.Binding], documentId(it.Key))
+	}
+
+	for binding, ids := range loadingIdsByBinding {
+		var b = t.bindings[binding]
+		for idxRange := range gopart.Partition(len(ids), loadByIdBatchSize) {
+			var docs, err = t.elasticSearch.SearchByIds(b.index, ids[idxRange.Low:idxRange.High])
+			if err != nil {
+				return fmt.Errorf("Load docs by ids: %w", err)
+			}
+
+			log.Debug(fmt.Sprintf("loaded num of docs: %d", len(docs)))
+			for _, doc := range docs {
+				if err = loaded(binding, doc); err != nil {
+					return fmt.Errorf("callback: %w", err)
+				}
+			}
+		}
+	}
+
+	return nil
+}
+
+func (t *transactor) Prepare(_ context.Context, _ pm.TransactionRequest_Prepare) (pf.DriverCheckpoint, error) {
+	log.Debug("Prepare Started.")
+	if len(t.bulkIndexerItems) != 0 {
+		panic("non-empty bulkIndexerItems") // Invariant: previous call is finished.
+	}
+	return pf.DriverCheckpoint{}, nil
+}
+
+func (t *transactor) Store(it *pm.StoreIterator) error {
+	log.Debug("Store started.")
+	var lastErr error = nil
+	for it.Next() {
+		var b = t.bindings[it.Binding]
+		var action, docId = "create", ""
+		if !b.deltaUpdates {
+			action, docId = "index", documentId(it.Key)
+		}
+
+		var item = &esutil.BulkIndexerItem{
+			Index:      t.bindings[it.Binding].index,
+			Action:     action,
+			DocumentID: docId,
+			Body:       bytes.NewReader(it.RawJSON),
+			OnFailure: func(_ context.Context, _ esutil.BulkIndexerItem, r esutil.BulkIndexerResponseItem, e error) {
+				log.Error(fmt.Sprintf("failed with response: %+v, error: %v", r, e))
+				lastErr = fmt.Errorf("store items: %+v, %w", r, e)
+			},
+		}
+
+		t.bulkIndexerItems = append(t.bulkIndexerItems, item)
+	}
+
+	return lastErr
+}
+
+func (t *transactor) Commit(ctx context.Context) error {
+	log.Debug(fmt.Sprintf("Commit started. Commiting %d items", len(t.bulkIndexerItems)))
+	defer func() { t.bulkIndexerItems = t.bulkIndexerItems[:0] }()
+
+	if err := t.elasticSearch.Commit(ctx, t.bulkIndexerItems); err != nil {
+		return fmt.Errorf("commit: %w", err)
+	}
+
+	for _, b := range t.bindings {
+		// Using Flush instead of Refresh to make sure the data are persisted.
+		if err := t.elasticSearch.Flush(b.index); err != nil {
+			return fmt.Errorf("commit flush: %w", err)
+		}
+	}
+	return nil
+}
+
+func (t *transactor) Acknowledge(context.Context) error {
+	return nil
+}
+
+func documentId(tuple tuple.Tuple) string {
+	return base64.RawStdEncoding.EncodeToString(tuple.Pack())
+}
+
+func (t *transactor) Destroy() {}
+
+func main() { boilerplate.RunMain(new(driver)) }

--- a/materialize-elasticsearch/driver.go
+++ b/materialize-elasticsearch/driver.go
@@ -156,7 +156,6 @@ func (driver) ApplyDelete(ctx context.Context, req *pm.ApplyRequest) (*pm.ApplyR
 
 // Transactions implements the DriverServer interface.
 func (d driver) Transactions(stream pm.Driver_TransactionsServer) error {
-
 	var open, err = stream.Recv()
 	if err != nil {
 		return fmt.Errorf("read Open: %w", err)
@@ -221,7 +220,6 @@ type transactor struct {
 const loadByIdBatchSize = 1000
 
 func (t *transactor) Load(it *pm.LoadIterator, _ <-chan struct{}, _ <-chan struct{}, loaded func(int, json.RawMessage) error) error {
-	log.Debug("Load started")
 	var loadingIdsByBinding = map[int][]string{}
 
 	for it.Next() {
@@ -240,7 +238,6 @@ func (t *transactor) Load(it *pm.LoadIterator, _ <-chan struct{}, _ <-chan struc
 				return fmt.Errorf("Load docs by ids: %w", err)
 			}
 
-			log.Debug(fmt.Sprintf("loaded num of docs: %d", len(docs)))
 			for _, doc := range docs {
 				if err = loaded(binding, doc); err != nil {
 					return fmt.Errorf("callback: %w", err)
@@ -253,7 +250,6 @@ func (t *transactor) Load(it *pm.LoadIterator, _ <-chan struct{}, _ <-chan struc
 }
 
 func (t *transactor) Prepare(_ context.Context, _ pm.TransactionRequest_Prepare) (pf.DriverCheckpoint, error) {
-	log.Debug("Prepare Started.")
 	if len(t.bulkIndexerItems) != 0 {
 		panic("non-empty bulkIndexerItems") // Invariant: previous call is finished.
 	}
@@ -261,7 +257,6 @@ func (t *transactor) Prepare(_ context.Context, _ pm.TransactionRequest_Prepare)
 }
 
 func (t *transactor) Store(it *pm.StoreIterator) error {
-	log.Debug("Store started.")
 	var lastErr error = nil
 	for it.Next() {
 		var b = t.bindings[it.Binding]
@@ -288,7 +283,6 @@ func (t *transactor) Store(it *pm.StoreIterator) error {
 }
 
 func (t *transactor) Commit(ctx context.Context) error {
-	log.Debug(fmt.Sprintf("Commit started. Commiting %d items", len(t.bulkIndexerItems)))
 	defer func() { t.bulkIndexerItems = t.bulkIndexerItems[:0] }()
 
 	if err := t.elasticSearch.Commit(ctx, t.bulkIndexerItems); err != nil {

--- a/materialize-elasticsearch/driver.go
+++ b/materialize-elasticsearch/driver.go
@@ -37,9 +37,9 @@ type resource struct {
 	FieldOverides []schemabuilder.FieldOverride `json:"field_overrides"`
 
 	// The number of shards in ElasticSearch index. Must set to be greater than 0.
-	NumOfShards int `json:"number_of_shards,omitempty"`
+	NumOfShards int `json:"number_of_shards,omitempty" jsonschema:"default=1"`
 	// The number of replicas in ElasticSearch index. If not set, default to be 0.
-	// For single-node clusters, make sure this field is 0, b/c the
+	// For single-node clusters, make sure this field is 0, because the
 	// Elastic search needs to allocate replicas on different nodes.
 	NumOfReplicas int `json:"number_of_replicas,omitempty"`
 }
@@ -189,10 +189,14 @@ func (driver) ApplyDelete(ctx context.Context, req *pm.ApplyRequest) (*pm.ApplyR
 		}
 		indices = append(indices, res.Index)
 	}
+
+	if req.DryRun {
+		return &pm.ApplyResponse{ActionDescription: fmt.Sprint("to delete indices: ", strings.Join(indices, ","))}, nil
+	}
+
 	if err = elasticSearch.DeleteIndices(indices); err != nil {
 		return nil, fmt.Errorf("deleting elastic search index: %w", err)
 	}
-
 	return &pm.ApplyResponse{ActionDescription: fmt.Sprint("deleted indices: ", strings.Join(indices, ","))}, nil
 }
 

--- a/materialize-elasticsearch/driver_test.go
+++ b/materialize-elasticsearch/driver_test.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/bradleyjkemp/cupaloy"
+	sb "github.com/estuary/connectors/materialize-elasticsearch/schemabuilder"
+	pf "github.com/estuary/protocols/flow"
+	pm "github.com/estuary/protocols/materialize"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConfig(t *testing.T) {
+	var validConfig = config{
+		Endpoint: "testEndpoint",
+		Username: "testUsername",
+		Password: "testPassword",
+	}
+
+	require.NoError(t, validConfig.Validate())
+
+	var missingEndpoint = validConfig
+	missingEndpoint.Endpoint = ""
+	require.Error(t, missingEndpoint.Validate(), "expected validation error")
+}
+
+func TestResource(t *testing.T) {
+	var validResource = resource{
+		Index:        "testIndex",
+		DeltaUpdates: true,
+		FieldOverides: []sb.FieldOverride{
+			{
+				Pointer: "/test_pointer",
+				EsType:  sb.ElasticFieldType{FieldType: "test_field_type"},
+			},
+		},
+	}
+	require.NoError(t, validResource.Validate())
+
+	var missingIndex = validResource
+	missingIndex.Index = ""
+	require.Error(t, missingIndex.Validate(), "expected validation error")
+}
+
+func TestDriverSpec(t *testing.T) {
+	var drv = driver{}
+	var resp, err1 = drv.Spec(context.Background(), &pm.SpecRequest{EndpointType: pf.EndpointType_FLOW_SINK})
+	require.NoError(t, err1)
+	var formatted, err2 = json.MarshalIndent(resp, "", "  ")
+	require.NoError(t, err2)
+	cupaloy.SnapshotT(t, formatted)
+}

--- a/materialize-elasticsearch/driver_test.go
+++ b/materialize-elasticsearch/driver_test.go
@@ -30,6 +30,7 @@ func TestResource(t *testing.T) {
 	pf.UnmarshalStrict(json.RawMessage(`{
 		"index":        "testIndex",
 		"delta_updates": true,
+		"number_of_shards": 1,
 		"field_overides": [
 			{
 				"pointer": "/test_pointer",
@@ -38,12 +39,16 @@ func TestResource(t *testing.T) {
 		]
 	}`), &validResourceA)
 	require.NoError(t, validResourceA.Validate())
-	require.Equal(t, 0, validResourceA.GetNumOfReplicas())
-	require.Equal(t, 1, validResourceA.GetNumOfShards())
+	require.Equal(t, 1, validResourceA.NumOfShards)
+	require.Equal(t, 0, validResourceA.NumOfReplicas)
 
 	var missingIndex = validResourceA
 	missingIndex.Index = ""
 	require.Error(t, missingIndex.Validate(), "expected validation error")
+
+	var invalidShards = validResourceA
+	invalidShards.NumOfShards = 0
+	require.Error(t, invalidShards.Validate(), "expected validation error")
 
 	var validResourceB resource
 	pf.UnmarshalStrict(json.RawMessage(`{
@@ -53,8 +58,8 @@ func TestResource(t *testing.T) {
 		"number_of_replicas": 4
 	}`), &validResourceB)
 	require.NoError(t, validResourceB.Validate())
-	require.Equal(t, 3, validResourceB.GetNumOfShards())
-	require.Equal(t, 4, validResourceB.GetNumOfReplicas())
+	require.Equal(t, 3, validResourceB.NumOfShards)
+	require.Equal(t, 4, validResourceB.NumOfReplicas)
 }
 
 func TestDriverSpec(t *testing.T) {

--- a/materialize-elasticsearch/elasticsearch.go
+++ b/materialize-elasticsearch/elasticsearch.go
@@ -86,7 +86,7 @@ func (es *ElasticSearch) CreateIndex(index string, numOfShards int, numOfReplica
 			// If inconsistent schema of the index is detected, user needs to decide
 			// either removing the existing index or renaming the new index. As a mapping cannot
 			// be modified after creation.
-			return fmt.Errorf("check index mapping: %w", mappingErr)
+			return mappingErr
 		} else if settings, settingErr := es.getIndexSettings(index); settingErr != nil {
 			return fmt.Errorf("get index setting: %w", settingErr)
 		} else if settings.Index.NumOfShards != numOfShardsStr {

--- a/materialize-elasticsearch/elasticsearch.go
+++ b/materialize-elasticsearch/elasticsearch.go
@@ -23,7 +23,7 @@ type ElasticSearch struct {
 	client *elasticsearch.Client
 }
 
-func NewElasticSearch(endpoint string, username string, password string) (*ElasticSearch, error) {
+func newElasticSearch(endpoint string, username string, password string) (*ElasticSearch, error) {
 	var client, err = elasticsearch.NewClient(
 		elasticsearch.Config{
 			Addresses: []string{endpoint},

--- a/materialize-elasticsearch/elasticsearch.go
+++ b/materialize-elasticsearch/elasticsearch.go
@@ -63,7 +63,7 @@ func (es *ElasticSearch) DeleteIndices(indices []string) error {
 // CreateIndex creates a new es index and sets its mappings to be schemaJSON,
 // if the index does not exist. Otherwise,
 // 1. if the new index has a different mapping (or num_of_shards spec) from the existing index,
-//    the API stops with an error, b/c the mapping and num_of_shards cannot be changed after creation.
+//    the API stops with an error, because the mapping and num_of_shards cannot be changed after creation.
 // 2. if the new index has a different num_of_replica spec from the existing index,
 //    the API resets the setting to match the new.
 func (es *ElasticSearch) CreateIndex(index string, numOfShards int, numOfReplicas int, schemaJSON json.RawMessage, dryRun bool) error {

--- a/materialize-elasticsearch/elasticsearch.go
+++ b/materialize-elasticsearch/elasticsearch.go
@@ -84,7 +84,7 @@ func (es *ElasticSearch) CreateIndex(index string, numOfShards int, numOfReplica
 		// The index exists, make sure it is compatible to the requested.
 		if mappingErr := es.checkIndexMapping(index, schema); mappingErr != nil {
 			// If inconsistent schema of the index is detected, user needs to decide
-			// either removing the existing index or renaming the new index. As mapping cannot
+			// either removing the existing index or renaming the new index. As a mapping cannot
 			// be modified after creation.
 			return fmt.Errorf("check index mapping: %w", mappingErr)
 		} else if settings, settingErr := es.getIndexSettings(index); settingErr != nil {
@@ -92,7 +92,7 @@ func (es *ElasticSearch) CreateIndex(index string, numOfShards int, numOfReplica
 		} else if settings.Index.NumOfShards != numOfShardsStr {
 			// Same as a schema, the number of shards cannot be changed after creation.
 			return fmt.Errorf(
-				"%s: expected number of shards (%d) is inconsistent with the existing number of shards (%s). Try 1) change the number of shard in spec, 2) rename the index or 3) use `flowctl api delete` to delete the existing index.",
+				"%s: expected number of shards (%d) is inconsistent with the existing number of shards (%s). Try one of the followings: 1) change the number of shard in spec, 2) rename the index, or 3) delete the existing index.",
 				index, numOfShards, settings.Index.NumOfShards,
 			)
 		} else if settings.Index.NumOfReplicas != numOfReplicasStr {
@@ -274,7 +274,7 @@ func (es *ElasticSearch) checkIndexMapping(index string, schema map[string]inter
 	var b = schema["properties"]
 
 	if !reflect.DeepEqual(a, b) {
-		return fmt.Errorf("schema inconsistent. Try rename the index, or use `flowctl api delete` to delete the existing index and restart. Details: existing: %v, new: %v", a, b)
+		return fmt.Errorf("schema inconsistent. Try rename the index, or delete the existing index and restart. Details: existing: %v, new: %v", a, b)
 	}
 	return nil
 }

--- a/materialize-elasticsearch/elasticsearch.go
+++ b/materialize-elasticsearch/elasticsearch.go
@@ -1,0 +1,227 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"reflect"
+	"strings"
+	"time"
+
+	// TODO(jixiang): test the driver with es version v8, and AWS OpenSearch in addition to Elastic cloud.
+	//                extend the API as needed.
+	elasticsearch "github.com/elastic/go-elasticsearch/v7"
+	"github.com/elastic/go-elasticsearch/v7/esapi"
+	"github.com/elastic/go-elasticsearch/v7/esutil"
+	log "github.com/sirupsen/logrus"
+)
+
+// ElasticSearch provides APIs for interacting with ElasticSearch service.
+type ElasticSearch struct {
+	client *elasticsearch.Client
+}
+
+func NewElasticSearch(endpoint string, username string, password string) (*ElasticSearch, error) {
+	var client, err = elasticsearch.NewClient(
+		elasticsearch.Config{
+			Addresses: []string{endpoint},
+			Username:  username,
+			Password:  password,
+		},
+	)
+	if err != nil {
+		return nil, fmt.Errorf("creating client: %w", err)
+	}
+
+	return &ElasticSearch{client: client}, nil
+}
+
+func (es *ElasticSearch) CreateIndex(index string, schemaJSON json.RawMessage) error {
+	var schema = make(map[string]interface{})
+	var err = json.Unmarshal(schemaJSON, &schema)
+	if err != nil {
+		return fmt.Errorf("unmarshal schemaJSON: %w", err)
+	}
+
+	resp, err := es.client.Indices.Exists([]string{index})
+	defer closeResponse(resp)
+
+	if err != nil {
+		return fmt.Errorf("index exists check error: %w", err)
+	} else if resp.StatusCode == 200 {
+		// The index exists, make sure it is the same as requested.
+		return es.checkIndexMapping(index, schema)
+	} else if resp.StatusCode != 404 {
+		return fmt.Errorf("index exists: invalid response status code %d", resp.StatusCode)
+	}
+
+	// The index does not exist, create a new one.
+
+	// Disable dynamic mapping.
+	schema["dynamic"] = false
+
+	body, err := json.Marshal(map[string]interface{}{"mappings": schema})
+	if err != nil {
+		return fmt.Errorf("create index marshal mappings: %w", err)
+	}
+
+	createResp, err := es.client.Indices.Create(
+		index,
+		es.client.Indices.Create.WithBody(bytes.NewReader(body)),
+		es.client.Indices.Create.WithWaitForActiveShards("all"),
+	)
+	defer closeResponse(createResp)
+	if err = es.parseErrorResp(err, createResp); err != nil {
+		return fmt.Errorf("create indices: %w", err)
+	}
+
+	return nil
+}
+
+func (es *ElasticSearch) Commit(ctx context.Context, items []*esutil.BulkIndexerItem) error {
+	if len(items) == 0 {
+		return nil
+	}
+
+	var bi, err = esutil.NewBulkIndexer(esutil.BulkIndexerConfig{
+		Client: es.client,
+		OnError: func(_ context.Context, err error) {
+			log.Error(fmt.Sprintf("indexer: %v", err))
+		},
+		WaitForActiveShards: "all",
+		// Disable automatic flushing, which is triggered by bi.Close call.
+		FlushInterval: 100 * time.Hour,
+	})
+	if err != nil {
+		return fmt.Errorf("building bulkIndexer: %w", err)
+	}
+
+	for _, item := range items {
+		if err = bi.Add(ctx, *item); err != nil {
+			return fmt.Errorf("adding item: %w", err)
+		}
+	}
+
+	return bi.Close(ctx)
+}
+
+func (es *ElasticSearch) SearchByIds(index string, ids []string) ([]json.RawMessage, error) {
+	if len(ids) == 0 {
+		return []json.RawMessage{}, nil
+	}
+
+	var resp, err = es.client.Search(
+		es.client.Search.WithIndex(index),
+		es.client.Search.WithBody(es.buildIDQuery(ids)),
+		es.client.Search.WithSize(len(ids)),
+	)
+	defer closeResponse(resp)
+	if err = es.parseErrorResp(err, resp); err != nil {
+		return nil, fmt.Errorf("search by ids: %w", err)
+	}
+
+	var r = struct {
+		Hits struct {
+			Hits []struct {
+				ID     string          `json:"_id"`
+				Source json.RawMessage `json:"_source"`
+			} `json:"hits"`
+		} `json:"hits"`
+	}{}
+
+	if err := json.NewDecoder(resp.Body).Decode(&r); err != nil {
+		return nil, fmt.Errorf("decoding response: %w", err)
+	}
+
+	var results = make([]json.RawMessage, 0, len(r.Hits.Hits))
+	for _, hit := range r.Hits.Hits {
+		results = append(results, hit.Source)
+	}
+	return results, nil
+}
+
+func (es *ElasticSearch) Flush(index string) error {
+	var resp, err = es.client.Indices.Flush(
+		es.client.Indices.Flush.WithIndex(index),
+	)
+	defer closeResponse(resp)
+	if err = es.parseErrorResp(err, resp); err != nil {
+		return fmt.Errorf("flush: %w", err)
+	}
+
+	return nil
+}
+
+func (es *ElasticSearch) checkIndexMapping(index string, schema map[string]interface{}) error {
+	var resp, err = es.client.Indices.GetMapping(
+		es.client.Indices.GetMapping.WithIndex(index),
+	)
+	defer closeResponse(resp)
+	if err = es.parseErrorResp(err, resp); err != nil {
+		return fmt.Errorf("get index mapping: %w", err)
+	}
+
+	var r = map[string]struct {
+		Mappings struct {
+			Properties map[string]interface{} `json:"properties"`
+		} `json:"mappings"`
+	}{}
+
+	if err := json.NewDecoder(resp.Body).Decode(&r); err != nil {
+		return fmt.Errorf("check index mapping decode: %w", err)
+	}
+
+	var a map[string]interface{}
+	if m, exist := r[index]; exist {
+		a = m.Mappings.Properties
+	} else {
+		a = map[string]interface{}{}
+	}
+
+	var b = schema["properties"]
+
+	if !reflect.DeepEqual(a, b) {
+		return fmt.Errorf("schema inconsistent. existing: %v, new: %v", a, b)
+	}
+	return nil
+}
+
+func (es *ElasticSearch) parseErrorResp(err error, resp *esapi.Response) error {
+	if err != nil {
+		return fmt.Errorf("response err: %w", err)
+	}
+
+	if resp.IsError() {
+		var e map[string]interface{}
+		if err := json.NewDecoder(resp.Body).Decode(&e); err != nil {
+			return fmt.Errorf("decode error: %w", err)
+		}
+		return fmt.Errorf("error response [%s] %s", resp.Status(), resp.String())
+	}
+	return nil
+}
+
+func (es *ElasticSearch) buildIDQuery(ids []string) io.Reader {
+	var quotedIds = make([]string, len(ids))
+	for i, id := range ids {
+		quotedIds[i] = fmt.Sprintf("%q", id)
+	}
+
+	var queryBody = fmt.Sprintf(`{
+		"query": {
+			"ids" : {
+			  "values" : [%s]
+			}
+		  }
+	}`, strings.Join(quotedIds, ","))
+
+	return strings.NewReader(queryBody)
+}
+
+func closeResponse(response *esapi.Response) {
+	if response != nil && response.Body != nil {
+		response.Body.Close()
+	}
+}

--- a/materialize-elasticsearch/schemabuilder/.snapshots/TestRunSchemaBuilder_NullOverrides
+++ b/materialize-elasticsearch/schemabuilder/.snapshots/TestRunSchemaBuilder_NullOverrides
@@ -1,0 +1,1 @@
+{"properties":{"arr":{"properties":{"one":{"type":"keyword","ignore_above":256},"two":{"type":"long"}}},"bit":{"type":"boolean"},"int":{"type":"long"},"len":{"type":"long"},"str":{"type":"keyword","ignore_above":256}}}

--- a/materialize-elasticsearch/schemabuilder/Cargo.lock
+++ b/materialize-elasticsearch/schemabuilder/Cargo.lock
@@ -74,7 +74,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 [[package]]
 name = "doc"
 version = "0.0.0"
-source = "git+https://github.com/estuary/flow#12d958d7929a124162cc4aa6745c46a0a5ccd07c"
+source = "git+https://github.com/estuary/flow#912722dcd4f3712429ff1e6f1a260976f8afa610"
 dependencies = [
  "fancy-regex",
  "itertools",
@@ -182,7 +182,7 @@ checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
 [[package]]
 name = "json"
 version = "0.0.0"
-source = "git+https://github.com/estuary/flow#12d958d7929a124162cc4aa6745c46a0a5ccd07c"
+source = "git+https://github.com/estuary/flow#912722dcd4f3712429ff1e6f1a260976f8afa610"
 dependencies = [
  "bitvec",
  "fancy-regex",
@@ -441,9 +441,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99beeb0daeac2bd1e86ac2c21caddecb244b39a093594da1a661ec2060c7aedd"
+checksum = "41effe7cfa8af36f439fac33861b66b049edc6f9a32331e2312660529c1c24ad"
 dependencies = [
  "itoa",
  "libc",

--- a/materialize-elasticsearch/schemabuilder/run.go
+++ b/materialize-elasticsearch/schemabuilder/run.go
@@ -90,12 +90,16 @@ type Input struct {
 
 // MarshalJSON provides customized marshalJSON of Input
 func (s Input) MarshalJSON() ([]byte, error) {
+	var overrides = s.overrides
+	if overrides == nil {
+		overrides = []FieldOverride{}
+	}
 	var output = struct {
 		SchemaJSONBase64 string          `json:"schema_json_base64"`
 		Overrides        []FieldOverride `json:"overrides"`
 	}{
 		SchemaJSONBase64: base64.StdEncoding.EncodeToString(s.SchemaJSON),
-		Overrides:        s.overrides,
+		Overrides:        overrides,
 	}
 	return json.Marshal(output)
 }

--- a/materialize-elasticsearch/schemabuilder/run.go
+++ b/materialize-elasticsearch/schemabuilder/run.go
@@ -35,14 +35,14 @@ type TextSpec struct {
 
 // ElasticFieldType specifies the type to override the field with.
 type ElasticFieldType struct {
-	// A snake_case string corresponding to a enum type of ESBasicType
-	// defined in src/elastic_search_data_types.rs
+	// The elastic search field data types.
+	// Supported types include: boolean, date, double, geo_point, geo_shape, keyword, long, null, text
 	FieldType string `json:"field_type"`
-	// Effective if FieldType is "date"
+	// Spec of the date field, effective if field_type is "date"
 	DateSpec DateSpec `json:"date_spec,omitempty"`
-	// Effective if FieldType is "keyword"
+	// Spec of the keyword field, effective if field_type if "keyword"
 	KeywordSpec KeywordSpec `json:"keyword_spec,omitempty"`
-	// Effective if FieldType is "text"
+	// Spec of the text field, effective if FieldType is "text"
 	TextSpec TextSpec `json:"text_spec,omitempty"`
 }
 

--- a/materialize-elasticsearch/schemabuilder/run_test.go
+++ b/materialize-elasticsearch/schemabuilder/run_test.go
@@ -52,6 +52,13 @@ func TestRunSchemaBuilder_NoOverrides(t *testing.T) {
 	cupaloy.SnapshotT(t, result)
 }
 
+func TestRunSchemaBuilder_NullOverrides(t *testing.T) {
+	result, err := RunSchemaBuilder(json.RawMessage(schemaJSON), nil)
+	require.NoError(t, err)
+
+	cupaloy.SnapshotT(t, result)
+}
+
 func TestRunSchemaBuilder_WithOverrides(t *testing.T) {
 	var dateFieldOverride FieldOverride
 	require.NoError(t, json.Unmarshal(
@@ -79,11 +86,8 @@ func TestRunSchemaBuilder_WithOverrides(t *testing.T) {
 }
 
 func TestRunSchemaBuilder_Errors(t *testing.T) {
-	_, e := RunSchemaBuilder(json.RawMessage("{}"), []FieldOverride{})
-	require.Contains(t, e.Error(), "a valid $id field in the input json schema is missing.")
-
 	var corruptedSchema = "corrupted schema"
-	_, e = RunSchemaBuilder(json.RawMessage(corruptedSchema), []FieldOverride{})
+	_, e := RunSchemaBuilder(json.RawMessage(corruptedSchema), []FieldOverride{})
 	require.Contains(t, e.Error(), "Failed generating elastic search schema based on input")
 
 	var badOverrides = []FieldOverride{

--- a/materialize-elasticsearch/schemabuilder/src/elastic_search_data_types.rs
+++ b/materialize-elasticsearch/schemabuilder/src/elastic_search_data_types.rs
@@ -12,6 +12,8 @@ pub enum ESBasicType {
         format: String,
     }, // refer to the comments of DateSpec in ../run.go for details.
     Double,
+    GeoPoint, // refer to https://www.elastic.co/guide/en/elasticsearch/reference/current/geo-point.html to see the format of geo_point data.
+    GeoShape, // refer to https://www.elastic.co/guide/en/elasticsearch/reference/current/geo-shape.html to see the format of geo_shape data.
     Keyword {
         ignore_above: u16,
     }, // refer to the comments of KeywordSpec in ../run.go for details.

--- a/materialize-elasticsearch/schemabuilder/src/elastic_search_schema_builder.rs
+++ b/materialize-elasticsearch/schemabuilder/src/elastic_search_schema_builder.rs
@@ -4,11 +4,13 @@ use super::errors::*;
 use doc::inference::{ArrayShape, ObjShape, Shape};
 use doc::Annotation;
 use indexmap::IndexMap;
-use json::schema::{self, index::IndexBuilder, keywords, types};
+use json::schema::{self, index::IndexBuilder, types};
 use serde_json::json;
-use serde_json::Value::{self, Object};
+use serde_json::Value;
 
 pub const DEFAULT_IGNORE_ABOVE: u16 = 256;
+// TODO(jixiang) replace the bundle url with https://estuary.dev/api/collections/<name>/<build-id>/schema for managed services.
+pub const FAKE_BUNDLE_URL: &str = "https://fake-bundle-schema.estuary.io";
 
 pub fn build_elastic_schema(schema_json: &[u8]) -> Result<ESFieldType, Error> {
     build_elastic_schema_with_overrides(schema_json, &[])
@@ -18,9 +20,11 @@ pub fn build_elastic_schema_with_overrides(
     schema_json: &[u8],
     es_type_overrides: &[ESTypeOverride],
 ) -> Result<ESFieldType, Error> {
-    let schema: Value = serde_json::from_slice(schema_json)?;
+    // parse should not fail on the hard-coded url.
+    let schema_uri = url::Url::parse(FAKE_BUNDLE_URL).unwrap();
 
-    let schema = schema::build::build_schema::<Annotation>(get_schema_uri(&schema)?, &schema)?;
+    let schema: Value = serde_json::from_slice(schema_json)?;
+    let schema = schema::build::build_schema::<Annotation>(schema_uri, &schema)?;
 
     let mut index = IndexBuilder::new();
     index.add(&schema)?;
@@ -42,17 +46,6 @@ pub fn build_elastic_schema_with_overrides(
     } else {
         Ok(built)
     }
-}
-
-fn get_schema_uri(schema: &Value) -> Result<url::Url, Error> {
-    if let Object(obj) = schema {
-        if let Some(schema_uri_value) = obj.get(keywords::ID) {
-            if let Some(schema_uri) = schema_uri_value.as_str() {
-                return Ok(url::Url::parse(&schema_uri)?);
-            }
-        }
-    }
-    Err(Error::MissingOrInvalidIdField())
 }
 
 fn build_from_shape(shape: &Shape) -> Result<ESFieldType, Error> {
@@ -170,53 +163,32 @@ mod tests {
             Error::SchemaJsonParsing { .. }
         ));
 
-        assert!(matches!(
-            build_elastic_schema(b"{}").unwrap_err(),
-            Error::MissingOrInvalidIdField { .. }
-        ));
-
-        assert!(matches!(
-            build_elastic_schema(br#"{"$id": null}"#).unwrap_err(),
-            Error::MissingOrInvalidIdField { .. }
-        ));
-
-        assert!(matches!(
-            build_elastic_schema(br#"{"$id": 123}"#).unwrap_err(),
-            Error::MissingOrInvalidIdField { .. }
-        ));
-
-        assert!(matches!(
-            build_elastic_schema(br#"{"$id": "123"}"#).unwrap_err(),
-            Error::UrlParsing { .. }
-        ));
-
-        let empty_schema_json = br#" { "$id": "https://test" } "#;
+        let empty_schema_json = br#" { } "#;
         check_schema_error_error(
             &build_elastic_schema(empty_schema_json).unwrap_err(),
             UNSUPPORTED_MULTIPLE_OR_UNSPECIFIED_TYPES,
         );
 
-        let multiple_types_schema_json =
-            br#"{"$id": "https://test", "type": ["integer", "string"]}"#;
+        let multiple_types_schema_json = br#"{"type": ["integer", "string"]}"#;
         check_schema_error_error(
             &build_elastic_schema(multiple_types_schema_json).unwrap_err(),
             UNSUPPORTED_MULTIPLE_OR_UNSPECIFIED_TYPES,
         );
 
-        let int_schema_json = br#"{"$id": "https://test", "type": "integer"}"#;
+        let int_schema_json = br#"{"type": "integer"}"#;
         check_schema_error_error(
             &build_elastic_schema(int_schema_json).unwrap_err(),
             UNSUPPORTED_NON_ARRAY_OR_OBJECTS,
         );
 
-        let multiple_field_types_schema_json = br#" { "$id": "https://test", "type": "object", "properties": { "mul_type": {"type": ["boolean", "integer"] } } }"#;
+        let multiple_field_types_schema_json = br#" {"type": "object", "properties": { "mul_type": {"type": ["boolean", "integer"] } } }"#;
         check_schema_error_error(
             &build_elastic_schema(multiple_field_types_schema_json).unwrap_err(),
             UNSUPPORTED_MULTIPLE_OR_UNSPECIFIED_TYPES,
         );
 
         let object_additional_field_schema_json = br#"
-          {"$id": "https://test", "type": "object", "additionalProperties": {"type": "integer"}, "properties": {"int": {"type": "integer"}}}
+          {"type": "object", "additionalProperties": {"type": "integer"}, "properties": {"int": {"type": "integer"}}}
         "#;
         check_schema_error_error(
             &build_elastic_schema(object_additional_field_schema_json).unwrap_err(),
@@ -224,14 +196,13 @@ mod tests {
         );
 
         let tuple_field_schema_json =
-            br#"{"$id": "https://test", "type": "array", "items": [{"type": "string"}, {"type": "integer"}]}"#;
+            br#"{"type": "array", "items": [{"type": "string"}, {"type": "integer"}]}"#;
         check_schema_error_error(
             &build_elastic_schema(tuple_field_schema_json).unwrap_err(),
             UNSUPPORTED_TUPLE,
         );
 
-        let simple_array_schema_json =
-            br#"{"$id": "https://test", "type": "array", "items": {"type": "string"}}"#;
+        let simple_array_schema_json = br#"{"type": "array", "items": {"type": "string"}}"#;
         check_schema_error_error(
             &build_elastic_schema(simple_array_schema_json).unwrap_err(),
             UNSUPPORTED_NON_ARRAY_OR_OBJECTS,
@@ -242,7 +213,6 @@ mod tests {
     fn test_build_elastic_search_schema_all_types() {
         let schema_json = br#"
         {
-            "$id": "https://test",
             "properties":{
                 "str": {"type": "string"},
                 "str_or_null": {"type": ["string", "null"] },
@@ -346,7 +316,6 @@ mod tests {
     fn test_build_elastic_search_schema_with_override() {
         let schema_json = br#"
         {
-            "$id": "https://test",
             "properties":{
                 "str": {"type": "string"},
                 "enum": {"enum": [1,2,3]},

--- a/materialize-elasticsearch/schemabuilder/src/elastic_search_schema_builder.rs
+++ b/materialize-elasticsearch/schemabuilder/src/elastic_search_schema_builder.rs
@@ -20,8 +20,8 @@ pub fn build_elastic_schema_with_overrides(
     schema_json: &[u8],
     es_type_overrides: &[ESTypeOverride],
 ) -> Result<ESFieldType, Error> {
-    // parse should not fail on the hard-coded url.
-    let schema_uri = url::Url::parse(FAKE_BUNDLE_URL).unwrap();
+    let schema_uri =
+        url::Url::parse(FAKE_BUNDLE_URL).expect("parse should not fail on hard-coded url");
 
     let schema: Value = serde_json::from_slice(schema_json)?;
     let schema = schema::build::build_schema::<Annotation>(schema_uri, &schema)?;

--- a/materialize-elasticsearch/schemabuilder/src/errors.rs
+++ b/materialize-elasticsearch/schemabuilder/src/errors.rs
@@ -22,10 +22,6 @@ pub enum Error {
     SchemaBuildError(#[from] json::schema::BuildError),
     #[error("failed indexing schema")]
     SchemaIndexError(#[from] json::schema::index::Error),
-    #[error("failed parsing schema_json.$id as a url.")]
-    UrlParsing(#[from] url::ParseError),
-    #[error("a valid $id field in the input json schema is missing.")]
-    MissingOrInvalidIdField(),
     #[error("unsupported Flow schema in elastic search, details: {message}, shape: {shape:?}")]
     UnSupportedError {
         message: &'static str,


### PR DESCRIPTION
related issue: #57 

The PR creates the elastic search materialize connector.
The connector focuses on materializing raw flow documents into elastic search service.
The document schema of  elastic search is constructed from flow schema using the existing [schema builder](https://github.com/estuary/connectors/tree/main/materialize-elasticsearch/schemabuilder). 

Some TODOs of the work including 1. manual testing of the driver on different versions and managed services, and see the performances when data load is very heavy. 2. Add integration tests to it, which depends on the testing framework to be switched to work with the new Flow.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/76)
<!-- Reviewable:end -->
