### PR TITLE
Improvements to Materializations ElasticSearch

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -151,7 +151,7 @@ jobs:
          docker-compose --file infra/docker-compose.yaml up --detach zookeeper
          docker-compose --file infra/docker-compose.yaml up --detach kafka
 
-      - name: ${{ matrix.connector }} integration tests
+      - name: source connector ${{ matrix.connector }} integration tests
         if: |
           contains('
             source-gcs
@@ -168,6 +168,14 @@ jobs:
           AWS_DEFAULT_OUTPUT: json
           POSTGRES_CONNECTION_URI: "postgres://flow:flow@localhost:5432/flow"
         run: CONNECTOR=${{ matrix.connector }} VERSION=test ./tests/run.sh;
+
+      - name: materialize connector ${{ matrix.connector }} integration tests
+        if: |
+          contains('
+            materialize-elasticsearch
+            materialize-s3-parquet
+            ', matrix.connector)
+        run: CONNECTOR=${{ matrix.connector }} VERSION=test tests/materialize/run.sh;
 
       - name: Push ${{ matrix.connector }} image
         uses: docker/build-push-action@v2

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -151,7 +151,7 @@ jobs:
          docker-compose --file infra/docker-compose.yaml up --detach zookeeper
          docker-compose --file infra/docker-compose.yaml up --detach kafka
 
-      - name: source connector ${{ matrix.connector }} integration tests
+      - name: Source connector ${{ matrix.connector }} integration tests
         if: |
           contains('
             source-gcs
@@ -169,7 +169,7 @@ jobs:
           POSTGRES_CONNECTION_URI: "postgres://flow:flow@localhost:5432/flow"
         run: CONNECTOR=${{ matrix.connector }} VERSION=test ./tests/run.sh;
 
-      - name: materialize connector ${{ matrix.connector }} integration tests
+      - name: Materialization connector ${{ matrix.connector }} integration tests
         if: |
           contains('
             materialize-elasticsearch

--- a/materialize-elasticsearch/.snapshots/TestDriverSpec
+++ b/materialize-elasticsearch/.snapshots/TestDriverSpec
@@ -33,7 +33,8 @@
         ],
         "properties": {
           "format": {
-            "type": "string"
+            "type": "string",
+            "description": "Format of the date. See https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-date-format.html."
           }
         },
         "additionalProperties": false,
@@ -45,19 +46,23 @@
         ],
         "properties": {
           "field_type": {
-            "type": "string"
+            "type": "string",
+            "description": "The elastic search field data types. Supported types include: boolean, date, double, geo_point, geo_shape, keyword, long, null, text."
           },
           "date_spec": {
             "$schema": "http://json-schema.org/draft-04/schema#",
-            "$ref": "#/definitions/DateSpec"
+            "$ref": "#/definitions/DateSpec",
+            "description": "Spec of the date field, effective if field_type is 'date'. See https://www.elastic.co/guide/en/elasticsearch/reference/current/date.html"
           },
           "keyword_spec": {
             "$schema": "http://json-schema.org/draft-04/schema#",
-            "$ref": "#/definitions/KeywordSpec"
+            "$ref": "#/definitions/KeywordSpec",
+            "description": "Spec of the keyword field, effective if field_type is 'keyword'. See https://www.elastic.co/guide/en/elasticsearch/reference/current/keyword.html"
           },
           "text_spec": {
             "$schema": "http://json-schema.org/draft-04/schema#",
-            "$ref": "#/definitions/TextSpec"
+            "$ref": "#/definitions/TextSpec",
+            "description": "Spec of the text field, effective if field_type is 'text'."
           }
         },
         "additionalProperties": false,
@@ -70,11 +75,13 @@
         ],
         "properties": {
           "pointer": {
-            "type": "string"
+            "type": "string",
+            "description": "A '/'-delimitated json pointer to the location of the overridden field."
           },
           "es_type": {
             "$schema": "http://json-schema.org/draft-04/schema#",
-            "$ref": "#/definitions/ElasticFieldType"
+            "$ref": "#/definitions/ElasticFieldType",
+            "description": "The overriding elastic search data type of the field."
           }
         },
         "additionalProperties": false,
@@ -86,7 +93,8 @@
         ],
         "properties": {
           "ignore_above": {
-            "type": "integer"
+            "type": "integer",
+            "description": "Strings longer than the ignore_above setting will not be indexed or stored. See https://www.elastic.co/guide/en/elasticsearch/reference/current/ignore-above.html"
           }
         },
         "additionalProperties": false,
@@ -99,10 +107,12 @@
         ],
         "properties": {
           "dual_keyword": {
-            "type": "boolean"
+            "type": "boolean",
+            "description": "Whether or not to specify the field as text/keyword dual field."
           },
           "keyword_ignore_above": {
-            "type": "integer"
+            "type": "integer",
+            "description": "Effective only if DualKeyword is enabled. Strings longer than the ignore_above setting will not be indexed or stored. See https://www.elastic.co/guide/en/elasticsearch/reference/current/ignore-above.html"
           }
         },
         "additionalProperties": false,
@@ -116,7 +126,8 @@
         ],
         "properties": {
           "index": {
-            "type": "string"
+            "type": "string",
+            "description": "Name of the ElasticSearch index to store the materialization results."
           },
           "delta_updates": {
             "type": "boolean"
@@ -130,10 +141,12 @@
           },
           "number_of_shards": {
             "type": "integer",
+            "description": "The number of shards in ElasticSearch index. Must set to be greater than 0.",
             "default": 1
           },
           "number_of_replicas": {
-            "type": "integer"
+            "type": "integer",
+            "description": "The number of replicas in ElasticSearch index. If not set, default to be 0. For single-node clusters, make sure this field is 0, because the Elastic search needs to allocate replicas on different nodes."
           }
         },
         "additionalProperties": false,

--- a/materialize-elasticsearch/driver.go
+++ b/materialize-elasticsearch/driver.go
@@ -51,6 +51,7 @@ func (r resource) Validate() error {
 	return nil
 }
 
+// GetFieldDocString implements the jsonschema.customSchemaGetFieldDocString interface.
 func (resource) GetFieldDocString(fieldName string) string {
 	switch fieldName {
 	case "Index":

--- a/materialize-elasticsearch/driver.go
+++ b/materialize-elasticsearch/driver.go
@@ -36,11 +36,7 @@ type resource struct {
 	DeltaUpdates  bool                          `json:"delta_updates"`
 	FieldOverides []schemabuilder.FieldOverride `json:"field_overrides"`
 
-	// The number of shards in ElasticSearch index. Must set to be greater than 0.
-	NumOfShards int `json:"number_of_shards,omitempty" jsonschema:"default=1"`
-	// The number of replicas in ElasticSearch index. If not set, default to be 0.
-	// For single-node clusters, make sure this field is 0, because the
-	// Elastic search needs to allocate replicas on different nodes.
+	NumOfShards   int `json:"number_of_shards,omitempty" jsonschema:"default=1"`
 	NumOfReplicas int `json:"number_of_replicas,omitempty"`
 }
 
@@ -53,6 +49,21 @@ func (r resource) Validate() error {
 		return fmt.Errorf("number_of_shards is missing or non-positive")
 	}
 	return nil
+}
+
+func (resource) GetFieldDocString(fieldName string) string {
+	switch fieldName {
+	case "Index":
+		return "Name of the ElasticSearch index to store the materialization results."
+	case "NumOfShards":
+		return "The number of shards in ElasticSearch index. Must set to be greater than 0."
+	case "NumOfReplicas":
+		return "The number of replicas in ElasticSearch index. If not set, default to be 0. " +
+			"For single-node clusters, make sure this field is 0, because the " +
+			"Elastic search needs to allocate replicas on different nodes."
+	default:
+		return ""
+	}
 }
 
 // driver implements the DriverServer interface.

--- a/materialize-elasticsearch/schemabuilder/run.go
+++ b/materialize-elasticsearch/schemabuilder/run.go
@@ -16,6 +16,7 @@ type DateSpec struct {
 	Format string `json:"format"`
 }
 
+// GetFieldDocString implements the jsonschema.customSchemaGetFieldDocString interface.
 func (DateSpec) GetFieldDocString(fieldName string) string {
 	switch fieldName {
 	case "Format":
@@ -31,6 +32,7 @@ type KeywordSpec struct {
 	IgnoreAbove int `json:"ignore_above"`
 }
 
+// GetFieldDocString implements the jsonschema.customSchemaGetFieldDocString interface.
 func (KeywordSpec) GetFieldDocString(fieldName string) string {
 	switch fieldName {
 	case "IgnoreAbove":
@@ -47,6 +49,7 @@ type TextSpec struct {
 	KeywordIgnoreAbove int  `json:"keyword_ignore_above"`
 }
 
+// GetFieldDocString implements the jsonschema.customSchemaGetFieldDocString interface.
 func (TextSpec) GetFieldDocString(fieldName string) string {
 	switch fieldName {
 	case "DualKeyword":
@@ -71,6 +74,7 @@ type ElasticFieldType struct {
 	TextSpec    TextSpec    `json:"text_spec,omitempty"`
 }
 
+// GetFieldDocString implements the jsonschema.customSchemaGetFieldDocString interface.
 func (ElasticFieldType) GetFieldDocString(fieldName string) string {
 	switch fieldName {
 	case "FieldType":
@@ -123,6 +127,7 @@ type FieldOverride struct {
 	EsType  ElasticFieldType `json:"es_type"`
 }
 
+// GetFieldDocString implements the jsonschema.customSchemaGetFieldDocString interface.
 func (FieldOverride) GetFieldDocString(fieldName string) string {
 	switch fieldName {
 	case "Pointer":

--- a/materialize-elasticsearch/schemabuilder/run.go
+++ b/materialize-elasticsearch/schemabuilder/run.go
@@ -12,38 +12,81 @@ import (
 const ProgramName = "schema-builder"
 
 // DateSpec configures a date field in elastic search schema.
-// https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-date-format.html
 type DateSpec struct {
 	Format string `json:"format"`
 }
 
+func (DateSpec) GetFieldDocString(fieldName string) string {
+	switch fieldName {
+	case "Format":
+		return "Format of the date. " +
+			"See https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-date-format.html."
+	default:
+		return ""
+	}
+}
+
 // KeywordSpec configures a keyword field for elastic search schema.
 type KeywordSpec struct {
-	//https://www.elastic.co/guide/en/elasticsearch/reference/current/ignore-above.html
 	IgnoreAbove int `json:"ignore_above"`
+}
+
+func (KeywordSpec) GetFieldDocString(fieldName string) string {
+	switch fieldName {
+	case "IgnoreAbove":
+		return "Strings longer than the ignore_above setting will not be indexed or stored. " +
+			"See https://www.elastic.co/guide/en/elasticsearch/reference/current/ignore-above.html"
+	default:
+		return ""
+	}
 }
 
 // TextSpec configures a text field for elastic search schema.
 type TextSpec struct {
-	// Whether or not to specify the field as text/keyword dual field.
-	DualKeyword bool `json:"dual_keyword"`
+	DualKeyword        bool `json:"dual_keyword"`
+	KeywordIgnoreAbove int  `json:"keyword_ignore_above"`
+}
 
-	// https://www.elastic.co/guide/en/elasticsearch/reference/current/ignore-above.html
-	// effective only if DualKeyword is enabled.
-	KeywordIgnoreAbove int `json:"keyword_ignore_above"`
+func (TextSpec) GetFieldDocString(fieldName string) string {
+	switch fieldName {
+	case "DualKeyword":
+		return "Whether or not to specify the field as text/keyword dual field."
+
+	case "KeywordIgnoreAbove":
+		return "Effective only if DualKeyword is enabled. Strings longer than the ignore_above setting will not be indexed or stored. " +
+			"See https://www.elastic.co/guide/en/elasticsearch/reference/current/ignore-above.html"
+	default:
+		return ""
+	}
 }
 
 // ElasticFieldType specifies the type to override the field with.
 type ElasticFieldType struct {
-	// The elastic search field data types.
-	// Supported types include: boolean, date, double, geo_point, geo_shape, keyword, long, null, text
+	// A snake_case string corresponding to a enum type of ESBasicType
+	// defined in src/elastic_search_data_types.rs
 	FieldType string `json:"field_type"`
-	// Spec of the date field, effective if field_type is "date"
-	DateSpec DateSpec `json:"date_spec,omitempty"`
-	// Spec of the keyword field, effective if field_type if "keyword"
+
+	DateSpec    DateSpec    `json:"date_spec,omitempty"`
 	KeywordSpec KeywordSpec `json:"keyword_spec,omitempty"`
-	// Spec of the text field, effective if FieldType is "text"
-	TextSpec TextSpec `json:"text_spec,omitempty"`
+	TextSpec    TextSpec    `json:"text_spec,omitempty"`
+}
+
+func (ElasticFieldType) GetFieldDocString(fieldName string) string {
+	switch fieldName {
+	case "FieldType":
+		return "The elastic search field data types. " +
+			"Supported types include: boolean, date, double, geo_point, geo_shape, keyword, long, null, text."
+	case "DateSpec":
+		return "Spec of the date field, effective if field_type is 'date'. " +
+			"See https://www.elastic.co/guide/en/elasticsearch/reference/current/date.html"
+	case "KeywordSpec":
+		return "Spec of the keyword field, effective if field_type is 'keyword'. " +
+			"See https://www.elastic.co/guide/en/elasticsearch/reference/current/keyword.html"
+	case "TextSpec":
+		return "Spec of the text field, effective if field_type is 'text'."
+	default:
+		return ""
+	}
 }
 
 // MarshalJSON provides customized marshalJSON of ElasticFieldType
@@ -76,10 +119,19 @@ func (e ElasticFieldType) MarshalJSON() ([]byte, error) {
 // FieldOverride specifies which field in the resulting elastic search schema
 // and how it is overridden.
 type FieldOverride struct {
-	// A '/'-delimitated json pointer to the location of the overridden field.
-	Pointer string `json:"pointer"`
-	// The overriding elastic search data type of the field.
-	EsType ElasticFieldType `json:"es_type"`
+	Pointer string           `json:"pointer"`
+	EsType  ElasticFieldType `json:"es_type"`
+}
+
+func (FieldOverride) GetFieldDocString(fieldName string) string {
+	switch fieldName {
+	case "Pointer":
+		return "A '/'-delimitated json pointer to the location of the overridden field."
+	case "EsType":
+		return "The overriding elastic search data type of the field."
+	default:
+		return ""
+	}
 }
 
 // Input provides the input data for schema builder.

--- a/tests/materialize/datasets/duplicated-keys.jsonl
+++ b/tests/materialize/datasets/duplicated-keys.jsonl
@@ -1,0 +1,10 @@
+{ "id": 1, "int": 1, "str": "str 1" }
+{ "id": 2, "int": 2, "str": "str 2" }
+{ "id": 3, "int": 3, "str": "str 3" }
+{ "id": 4, "int": 4, "str": "str 4" }
+{ "id": 5, "int": 5, "str": "str 5" }
+{ "id": 1, "int": 6, "str": "str 6" }
+{ "id": 2, "int": 7, "str": "str 7" }
+{ "id": 3, "int": 8, "str": "str 8" }
+{ "id": 4, "int": 9, "str": "str 9" }
+{ "id": 5, "int": 10, "str": "str 10" }

--- a/tests/materialize/datasets/ingest.go
+++ b/tests/materialize/datasets/ingest.go
@@ -72,6 +72,10 @@ func (p *pushRpc) SendDocuments(dataFilePath string, bindingNum int) error {
 		docs = append(docs, arena.Add(scanner.Bytes()))
 	}
 
+	if err := scanner.Err(); err != nil {
+		fmt.Errorf("scan input: %w", err)
+	}
+
 	return p.rpc.Send(&capture.PushRequest{
 		Documents: &capture.Documents{
 			Binding:  uint32(bindingNum),

--- a/tests/materialize/datasets/ingest.go
+++ b/tests/materialize/datasets/ingest.go
@@ -1,0 +1,130 @@
+package main
+
+import (
+	"bufio"
+	"context"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"time"
+
+	"github.com/estuary/protocols/capture"
+	"github.com/estuary/protocols/flow"
+	"google.golang.org/grpc"
+)
+
+type config struct {
+	serverAddr   string
+	captureName  string
+	bindingNum   int
+	dataFilePath string
+}
+
+func parseConfig() *config {
+	var cfg config
+	flag.StringVar(&cfg.serverAddr, "server_address", "localhost:9000", "address of the consumer server for data ingestion.")
+	flag.StringVar(&cfg.captureName, "capture", "capture/ingest", "name of the catalog capture to receive data.")
+	flag.IntVar(&cfg.bindingNum, "binding_num", 0, "the number of binding for data ingestion.")
+	flag.StringVar(&cfg.dataFilePath, "data_file_path", "./data.jsonl", "path to th jsonl file that contains a list of json data to be ingested.")
+
+	flag.Parse()
+	return &cfg
+}
+
+type pushRpc struct {
+	rpc  capture.Runtime_PushClient
+	conn *grpc.ClientConn
+}
+
+func newPushRpc(ctx context.Context, serverAddr string) (*pushRpc, error) {
+	if conn, err := grpc.Dial(serverAddr, grpc.WithInsecure()); err != nil {
+		return nil, fmt.Errorf("fail to dial: %w", err)
+	} else if rpc, err := capture.NewRuntimeClient(conn).Push(ctx); err != nil {
+		return nil, fmt.Errorf("failed to create Push rpc: %w", err)
+	} else {
+		return &pushRpc{
+			conn: conn,
+			rpc:  rpc,
+		}, nil
+	}
+}
+
+func (p *pushRpc) Open(captureName string) error {
+	return p.rpc.Send(&capture.PushRequest{
+		Open: &capture.PushRequest_Open{
+			Capture: flow.Capture(captureName),
+		},
+	})
+}
+
+func (p *pushRpc) SendDocuments(dataFilePath string, bindingNum int) error {
+	var file, err = os.Open(dataFilePath)
+	if err != nil {
+		return fmt.Errorf("open file: %w", err)
+	}
+	var scanner = bufio.NewScanner(file)
+	scanner.Split(bufio.ScanLines)
+
+	var arena flow.Arena
+	var docs []flow.Slice
+	for scanner.Scan() {
+		docs = append(docs, arena.Add(scanner.Bytes()))
+	}
+
+	return p.rpc.Send(&capture.PushRequest{
+		Documents: &capture.Documents{
+			Binding:  uint32(bindingNum),
+			Arena:    arena,
+			DocsJson: docs,
+		},
+	})
+}
+
+func (p *pushRpc) Checkpoint() error {
+	return p.rpc.Send(&capture.PushRequest{
+		Checkpoint: &flow.DriverCheckpoint{},
+	})
+}
+
+func (p *pushRpc) Acknowledge() error {
+	var resp, err = p.rpc.Recv()
+	if err != nil {
+		return fmt.Errorf("failed in receiving response, %+v", err)
+	} else if err = resp.Validate(); err != nil {
+		return fmt.Errorf("failed in validating response, %+v", err)
+	}
+	return nil
+}
+
+func (p *pushRpc) Close() {
+	p.conn.Close()
+}
+
+func logAndExit(err error) {
+	log.Fatalf("execution failed: %v", err)
+	os.Exit(1)
+}
+
+func main() {
+	var cfg = parseConfig()
+
+	var ctx, cancel = context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+
+	var rpc, err = newPushRpc(ctx, cfg.serverAddr)
+	if err != nil {
+		logAndExit(fmt.Errorf("execution failed: %w", err))
+	}
+	defer rpc.Close()
+
+	if err := rpc.Open(cfg.captureName); err != nil {
+		logAndExit(fmt.Errorf("open request: %w", err))
+	} else if err := rpc.SendDocuments(cfg.dataFilePath, cfg.bindingNum); err != nil {
+		logAndExit(fmt.Errorf("send documents: %w", err))
+	} else if err := rpc.Checkpoint(); err != nil {
+		logAndExit(fmt.Errorf("checkpoint: %w", err))
+	} else if err := rpc.Acknowledge(); err != nil {
+		logAndExit(fmt.Errorf("acknowledge: %w", err))
+	}
+}

--- a/tests/materialize/datasets/ingest.go
+++ b/tests/materialize/datasets/ingest.go
@@ -61,7 +61,7 @@ func (p *pushRpc) Open(captureName string) error {
 func (p *pushRpc) SendDocuments(dataFilePath string, bindingNum int) error {
 	var file, err = os.Open(dataFilePath)
 	if err != nil {
-		return fmt.Errorf("open file: %w", err)
+		return fmt.Errorf("open file %s: %w", dataFilePath, err)
 	}
 	var scanner = bufio.NewScanner(file)
 	scanner.Split(bufio.ScanLines)

--- a/tests/materialize/flow.json.template
+++ b/tests/materialize/flow.json.template
@@ -11,6 +11,20 @@
        },
        "key": ["/id"]
     },
+    "${TEST_COLLECTION_DUPLICATED_KEYS}": {
+       "schema": {
+          "properties": {
+           "id": { "type": "integer" },
+           "int": { "type": "integer", "reduce": {"strategy": "sum"} },
+           "str": { "type": "string" }
+          },
+          "required": ["id"],
+          "type": "object",
+          "reduce": { "strategy": "merge" }
+       },
+       "key": ["/id"]
+    },
+ 
     "${TEST_COLLECTION_MULTIPLE_DATATYPES}": {
        "schema": {
        "properties": {
@@ -34,6 +48,7 @@
       "endpoint": { "ingest": {} },
       "bindings": [
         { "target": "${TEST_COLLECTION_SIMPLE}", "resource": { "name": "${TEST_COLLECTION_SIMPLE}" } },
+        { "target": "${TEST_COLLECTION_DUPLICATED_KEYS}", "resource": { "name": "${TEST_COLLECTION_DUPLICATED_KEYS}" } },
         { "target": "${TEST_COLLECTION_MULTIPLE_DATATYPES}", "resource": { "name": "${TEST_COLLECTION_MULTIPLE_DATATYPES}" } },
       ]
     },

--- a/tests/materialize/flow.json.template
+++ b/tests/materialize/flow.json.template
@@ -29,6 +29,16 @@
     }
   },
 
+  "captures": {
+    "${PUSH_CAPTURE_NAME}" : {
+      "endpoint": { "ingest": {} },
+      "bindings": [
+        { "target": "${TEST_COLLECTION_SIMPLE}", "resource": { "name": "${TEST_COLLECTION_SIMPLE}" } },
+        { "target": "${TEST_COLLECTION_MULTIPLE_DATATYPES}", "resource": { "name": "${TEST_COLLECTION_MULTIPLE_DATATYPES}" } },
+      ]
+    },
+  },
+
   "materializations": {
     "tests/${CONNECTOR}/materialize": {
       "endpoint": {
@@ -38,6 +48,14 @@
         }
       },
       "bindings": ${RESOURCES_CONFIG}
+    }
+  },
+
+  "storageMappings": {
+    "": {
+      "stores": [
+        { "provider": "S3", "bucket": "a-bucket" }
+      ]
     }
   }
 }

--- a/tests/materialize/flowctl/build-and-activate.sh
+++ b/tests/materialize/flowctl/build-and-activate.sh
@@ -1,9 +1,8 @@
 #!/bin/bash
 #
-# This script builds and activates the test catalog.
 set -e
 
-echo "start build-and-activate.sh"
+echo "building and activating the testing catalog via build-and-activate.sh"
 
 flowctl api build \
   --directory "${TEST_DIR}"/build \

--- a/tests/materialize/flowctl/build-and-activate.sh
+++ b/tests/materialize/flowctl/build-and-activate.sh
@@ -1,8 +1,18 @@
 #!/bin/bash
 #
 # This script builds and activates the test catalog.
-
 set -e
 
-flowctl api build --directory ${TEST_DIR}/build --build-id ${BUILD_ID} --source ${TEST_DIR}/${CATALOG} --ts-package
-flowctl api activate --build-id ${BUILD_ID} --all
+echo "start build-and-activate.sh"
+
+
+flowctl api build \
+  --directory "${TEST_DIR}"/build \
+  --build-id "${BUILD_ID}" \
+  --source "file://${TEST_DIR}/${CATALOG}" \
+  --log.level debug
+
+flowctl api activate \
+  --build-id "${BUILD_ID}" \
+  --log.level debug \
+  --all

--- a/tests/materialize/flowctl/build-and-activate.sh
+++ b/tests/materialize/flowctl/build-and-activate.sh
@@ -5,7 +5,6 @@ set -e
 
 echo "start build-and-activate.sh"
 
-
 flowctl api build \
   --directory "${TEST_DIR}"/build \
   --build-id "${BUILD_ID}" \

--- a/tests/materialize/flowctl/build-and-activate.sh
+++ b/tests/materialize/flowctl/build-and-activate.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+#
+# This script builds and activates the test catalog.
+
+set -e
+
+flowctl api build --directory ${TEST_DIR}/build --build-id ${BUILD_ID} --source ${TEST_DIR}/${CATALOG} --ts-package
+flowctl api activate --build-id ${BUILD_ID} --all

--- a/tests/materialize/flowctl/combine.sh
+++ b/tests/materialize/flowctl/combine.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+#
+# This script runs inside Flow docker container to start a temp docker container.
+
+set -e
+
+IFS=" " read -r -a args <<< "$1"
+if [[ ${#args[@]} -ne 3 ]]; then
+        echo "Usage: $0 <collection> <input-file-name> <output-file-name>"
+fi
+
+flowctl combine \
+    --collection "${args[0]}" \
+    --source "file://${TEST_DIR}/${CATALOG}" \
+    --log.level=debug \
+    < "${TEST_DIR}/${args[1]}" \
+    > "${TEST_DIR}/${args[2]}"

--- a/tests/materialize/flowctl/combine.sh
+++ b/tests/materialize/flowctl/combine.sh
@@ -3,15 +3,19 @@
 # This script runs inside Flow docker container to start a temp docker container.
 
 set -e
+echo "start combine.sh"
 
 IFS=" " read -r -a args <<< "$1"
 if [[ ${#args[@]} -ne 3 ]]; then
-        echo "Usage: $0 <collection> <input-file-name> <output-file-name>"
+    echo "Usage: $0 <collection> <input-file-name> <output-file-name>"
+    exit 1
 fi
 
+cat "${TEST_DIR}/${args[1]}" \
+ 
 flowctl combine \
     --collection "${args[0]}" \
     --source "file://${TEST_DIR}/${CATALOG}" \
-    --log.level=debug \
+    --log.level debug \
     < "${TEST_DIR}/${args[1]}" \
     > "${TEST_DIR}/${args[2]}"

--- a/tests/materialize/flowctl/combine.sh
+++ b/tests/materialize/flowctl/combine.sh
@@ -1,9 +1,8 @@
 #!/bin/bash
 #
-# This script runs inside Flow docker container to start a temp docker container.
 
 set -e
-echo "start combine.sh"
+echo "combining results via combine.sh"
 
 IFS=" " read -r -a args <<< "$1"
 if [[ ${#args[@]} -ne 3 ]]; then

--- a/tests/materialize/flowctl/combine.sh
+++ b/tests/materialize/flowctl/combine.sh
@@ -11,8 +11,6 @@ if [[ ${#args[@]} -ne 3 ]]; then
     exit 1
 fi
 
-cat "${TEST_DIR}/${args[1]}" \
- 
 flowctl combine \
     --collection "${args[0]}" \
     --source "file://${TEST_DIR}/${CATALOG}" \

--- a/tests/materialize/flowctl/delete.sh
+++ b/tests/materialize/flowctl/delete.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+#
+# This script builds and activates the test catalog.
+
+set -e
+flowctl api delete --build-id ${BUILD_ID} --all

--- a/tests/materialize/flowctl/delete.sh
+++ b/tests/materialize/flowctl/delete.sh
@@ -1,9 +1,8 @@
 #!/bin/bash
 #
-# This script builds and activates the test catalog.
 
 set -e
-echo "start delete.sh"
+echo "deleting the testing catalog via delete.sh"
 
 flowctl api delete \
   --build-id ${BUILD_ID} \

--- a/tests/materialize/flowctl/delete.sh
+++ b/tests/materialize/flowctl/delete.sh
@@ -3,4 +3,9 @@
 # This script builds and activates the test catalog.
 
 set -e
-flowctl api delete --build-id ${BUILD_ID} --all
+echo "start delete.sh"
+
+flowctl api delete \
+  --build-id ${BUILD_ID} \
+  --log.level debug \
+  --all

--- a/tests/materialize/flowctl/temp-data-plane.sh
+++ b/tests/materialize/flowctl/temp-data-plane.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 #
-# This script runs inside Flow docker container to start a temp docker container.
 
 set -e
-echo "start temp-data-plane.sh"
+echo "starting a temp data plane via temp-data-plane.sh"
+
 flowctl temp-data-plane \
     --sigterm \
     --tempdir "${TEST_DIR}" \

--- a/tests/materialize/flowctl/temp-data-plane.sh
+++ b/tests/materialize/flowctl/temp-data-plane.sh
@@ -3,7 +3,8 @@
 # This script runs inside Flow docker container to start a temp docker container.
 
 set -e
-
+echo "start temp-data-plane.sh"
 flowctl temp-data-plane \
     --sigterm \
-    --tempdir ${TEST_DIR}
+    --tempdir "${TEST_DIR}" \
+    --log.level debug

--- a/tests/materialize/flowctl/temp-data-plane.sh
+++ b/tests/materialize/flowctl/temp-data-plane.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+#
+# This script runs inside Flow docker container to start a temp docker container.
+
+set -e
+
+flowctl temp-data-plane \
+    --sigterm \
+    --tempdir ${TEST_DIR}

--- a/tests/materialize/materialize-elasticsearch/cleanup.sh
+++ b/tests/materialize/materialize-elasticsearch/cleanup.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 set -e
 
-docker rm -f ${TEST_ES_CONTAINER_NAME}
+docker rm -f "${TEST_ES_CONTAINER_NAME}"

--- a/tests/materialize/materialize-elasticsearch/cleanup.sh
+++ b/tests/materialize/materialize-elasticsearch/cleanup.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -e
+
+docker rm -f ${TEST_ES_CONTAINER_NAME}

--- a/tests/materialize/materialize-elasticsearch/expected/duplicated-keys-delta.jsonl
+++ b/tests/materialize/materialize-elasticsearch/expected/duplicated-keys-delta.jsonl
@@ -1,0 +1,10 @@
+{"id":1,"int":7,"str":"str 6"}
+{"id":1,"int":7,"str":"str 6"}
+{"id":2,"int":9,"str":"str 7"}
+{"id":2,"int":9,"str":"str 7"}
+{"id":3,"int":11,"str":"str 8"}
+{"id":3,"int":11,"str":"str 8"}
+{"id":4,"int":13,"str":"str 9"}
+{"id":4,"int":13,"str":"str 9"}
+{"id":5,"int":15,"str":"str 10"}
+{"id":5,"int":15,"str":"str 10"}

--- a/tests/materialize/materialize-elasticsearch/expected/duplicated-keys-non-delta.jsonl
+++ b/tests/materialize/materialize-elasticsearch/expected/duplicated-keys-non-delta.jsonl
@@ -1,0 +1,5 @@
+{"id":1,"int":14,"str":"str 6"}
+{"id":2,"int":18,"str":"str 7"}
+{"id":3,"int":22,"str":"str 8"}
+{"id":4,"int":26,"str":"str 9"}
+{"id":5,"int":30,"str":"str 10"}

--- a/tests/materialize/materialize-elasticsearch/expected/multiple-data-types.jsonl
+++ b/tests/materialize/materialize-elasticsearch/expected/multiple-data-types.jsonl
@@ -1,0 +1,10 @@
+{"array_int":[11,12],"bool_field":false,"float_field":1.1,"id":1,"nested":{"id":"i1"},"nullable_int":null,"str_field":"str1"}
+{"array_int":[21,22],"bool_field":true,"float_field":2.2,"id":2,"nested":{"id":"i2"},"nullable_int":2,"str_field":"str2"}
+{"array_int":[31,32],"bool_field":false,"float_field":3.3,"id":3,"nested":{"id":"i3"},"nullable_int":null,"str_field":"str3"}
+{"array_int":[41,42],"bool_field":true,"float_field":4.4,"id":4,"nested":{"id":"i4"},"nullable_int":4,"str_field":"str4"}
+{"array_int":[51,52],"bool_field":false,"float_field":5.5,"id":5,"nested":{"id":"i5"},"nullable_int":null,"str_field":"str5"}
+{"array_int":[61,62],"bool_field":true,"float_field":6.6,"id":6,"nested":{"id":"i6"},"nullable_int":6,"str_field":"str6"}
+{"array_int":[71,72],"bool_field":false,"float_field":7.7,"id":7,"nested":{"id":"i7"},"nullable_int":null,"str_field":"str7"}
+{"array_int":[81,82],"bool_field":true,"float_field":8.8,"id":8,"nested":{"id":"i8"},"nullable_int":8,"str_field":"str8"}
+{"array_int":[91,92],"bool_field":false,"float_field":9.9,"id":9,"nested":{"id":"i9"},"nullable_int":null,"str_field":"str9"}
+{"array_int":[1,2],"bool_field":true,"float_field":10.1,"id":10,"nested":{"id":"i10"},"nullable_int":10,"str_field":"str10"}

--- a/tests/materialize/materialize-elasticsearch/fetch-materialize-results.sh
+++ b/tests/materialize/materialize-elasticsearch/fetch-materialize-results.sh
@@ -17,6 +17,7 @@ function exportIndexToJsonl() {
     local index="$1"
     local sort_by="$2"
     local jsonl_path="$3"
+
     curl -s "${TEST_ES_ENDPOINT}/${index}/_search" \
     | jq -c "[.hits | .hits[] | ._source | del(._meta)] | sort_by(.${sort_by}) | .[]" \
     > "${jsonl_path}"

--- a/tests/materialize/materialize-elasticsearch/fetch-materialize-results.sh
+++ b/tests/materialize/materialize-elasticsearch/fetch-materialize-results.sh
@@ -10,6 +10,7 @@ fi
 # The relative path to ${TEST_DIR} to store final results.
 result_dir="$1"
 
+# Wait for enough long to have data available for fetching.
 sleep 2
 
 # Read all docs from elastic search indices to jsonl output.

--- a/tests/materialize/materialize-elasticsearch/fetch-materialize-results.sh
+++ b/tests/materialize/materialize-elasticsearch/fetch-materialize-results.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+set -e
+
+if [ $# -ne 1 ]
+then
+    echo "execution using: $0 <test-output-jsonl-dir>"
+    exit 1
+fi
+
+# The relative path to ${TEST_DIR} to store final results.
+result_dir="$1"
+
+sleep 2
+
+# Read all docs from elastic search indices to jsonl output.
+function exportIndexToJsonl() {
+    local index="$1"
+    local sort_by="$2"
+    local jsonl_path="$3"
+    curl -s "${TEST_ES_ENDPOINT}/${index}/_search" \
+    | jq -c "[.hits | .hits[] | ._source | del(._meta)] | sort_by(.${sort_by}) | .[]" \
+    > "${jsonl_path}"
+}
+
+exportIndexToJsonl "${TEST_ES_INDEX_DUPLICATED_KEYS_DELTA}" id "${TEST_DIR}/${result_dir}/duplicated-keys-delta.jsonl"
+exportIndexToJsonl "${TEST_ES_INDEX_DUPLICATED_KEYS_NON_DELTA}" id "${TEST_DIR}/${result_dir}/duplicated-keys-non-delta.jsonl"
+exportIndexToJsonl "${TEST_ES_INDEX_MULTIPLE_DATA_TYPES}" id "${TEST_DIR}/${result_dir}/multiple-data-types.jsonl"

--- a/tests/materialize/materialize-elasticsearch/ingest-data.sh
+++ b/tests/materialize/materialize-elasticsearch/ingest-data.sh
@@ -5,18 +5,18 @@ set -e
 go run ${DATA_INGEST_SCRIPT_PATH} \
   --server_address=${CONSUMER_ADDRESS} \
   --capture=${PUSH_CAPTURE_NAME} \
-  --binding_num=${BINDING_NUM_SIMPLE} \
-  --data_file_path=${DATASET_SIMPLE}
+  --binding_num=${BINDING_NUM_DUPLICATED_KEYS} \
+  --data_file_path=${DATASET_DUPLICATED_KEYS}
+
+go run ${DATA_INGEST_SCRIPT_PATH} \
+  --server_address=${CONSUMER_ADDRESS} \
+  --capture=${PUSH_CAPTURE_NAME} \
+  --binding_num=${BINDING_NUM_DUPLICATED_KEYS} \
+  --data_file_path=${DATASET_DUPLICATED_KEYS}
+
 
 go run ${DATA_INGEST_SCRIPT_PATH} \
   --server_address=${CONSUMER_ADDRESS} \
   --capture=${PUSH_CAPTURE_NAME} \
   --binding_num=${BINDING_NUM_MULTIPLE_DATATYPES} \
   --data_file_path=${DATASET_MULTIPLE_DATATYPES}
-
-sleep 5
-go run ${DATA_INGEST_SCRIPT_PATH} \
-  --server_address=${CONSUMER_ADDRESS} \
-  --capture=${PUSH_CAPTURE_NAME} \
-  --binding_num=${BINDING_NUM_SIMPLE} \
-  --data_file_path=${DATASET_SIMPLE}

--- a/tests/materialize/materialize-elasticsearch/ingest-data.sh
+++ b/tests/materialize/materialize-elasticsearch/ingest-data.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 set -e
-
-# Pushing data to the capture.
+# Push data to the capture.
 go run ${DATA_INGEST_SCRIPT_PATH} \
   --server_address=${CONSUMER_ADDRESS} \
   --capture=${PUSH_CAPTURE_NAME} \

--- a/tests/materialize/materialize-elasticsearch/setup.sh
+++ b/tests/materialize/materialize-elasticsearch/setup.sh
@@ -6,19 +6,23 @@ export TEST_ES_INDEX_DUPLICATED_KEYS_DELTA="index-duplicated-keys-delta"
 export TEST_ES_INDEX_DUPLICATED_KEYS_NON_DELTA="index-duplicated-keys-non-delta"
 export TEST_ES_INDEX_MULTIPLE_DATA_TYPES="index-multiple-data-types"
 
-# local elasticsearch docker container name.
-export TEST_ES_CONTAINER_NAME=test-es
+# local elasticsearch container name.
+export TEST_ES_CONTAINER_NAME=test-elastic-search
 
 # Endpoint to access elastic search.
 export TEST_ES_ENDPOINT=http://localhost:9200
 
 # start local elasticsearch.
 function startElasticsearch() {
-    docker run -d --rm --name "${TEST_ES_CONTAINER_NAME}" --network=host --env "discovery.type=single-node" docker.elastic.co/elasticsearch/elasticsearch:7.15.2
-    
+    docker run -d \
+      --rm \
+      --name "${TEST_ES_CONTAINER_NAME}" \
+      --env "discovery.type=single-node" \
+      --network=host \
+      docker.elastic.co/elasticsearch/elasticsearch:7.15.2
     for i in {1..20}; do
         # Wait until the elastic search is ready for serving.
-        if curl -o /dev/null -s -I -f ${TEST_ES_ENDPOINT}; then
+        if curl -o /dev/null -s -I -f "${TEST_ES_ENDPOINT}";  then
             echo "elastic server started successfully."
             return 0
         fi

--- a/tests/materialize/materialize-elasticsearch/setup.sh
+++ b/tests/materialize/materialize-elasticsearch/setup.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+set -e
+
+# Elastic index names.
+export TEST_ES_INDEX_DUPLICATED_KEYS_DELTA="index-duplicated-keys-delta"
+export TEST_ES_INDEX_DUPLICATED_KEYS_NON_DELTA="index-duplicated-keys-non-delta"
+export TEST_ES_INDEX_MULTIPLE_DATA_TYPES="index-multiple-data-types"
+
+# local elasticsearch docker container name.
+export TEST_ES_CONTAINER_NAME=test-es
+
+# Endpoint to access elastic search.
+export TEST_ES_ENDPOINT=http://localhost:9200
+
+# start local elasticsearch.
+function startElasticsearch() {
+    docker run -d --rm --name "${TEST_ES_CONTAINER_NAME}" --network=host --env "discovery.type=single-node" docker.elastic.co/elasticsearch/elasticsearch:7.15.2
+    
+    for i in {1..20}; do
+        # Wait until the elastic search is ready for serving.
+        if curl -o /dev/null -s -I -f ${TEST_ES_ENDPOINT}; then
+            echo "elastic server started successfully."
+            return 0
+        fi
+        echo "Not ready, retrying ${i}."
+        sleep 3
+    done
+    return 1
+}
+
+startElasticsearch || bail "failed to start the elastic search service after 60s."
+
+
+config_json_template='{
+    "endpoint": "${TEST_ES_ENDPOINT}"
+}'
+
+resources_json_template='[
+  {
+    "resource": {
+      "index": "${TEST_ES_INDEX_DUPLICATED_KEYS_DELTA}",
+      "number_of_shards": 1,
+      "delta_updates": true
+    },
+    "source": "${TEST_COLLECTION_DUPLICATED_KEYS}"
+  },
+  {
+    "resource": {
+      "index": "${TEST_ES_INDEX_DUPLICATED_KEYS_NON_DELTA}",
+      "number_of_shards": 1,
+      "delta_updates": false
+    },
+    "source": "${TEST_COLLECTION_DUPLICATED_KEYS}"
+  },
+  {
+    "resource": {
+      "index": "${TEST_ES_INDEX_MULTIPLE_DATA_TYPES}",
+      "number_of_shards": 1,
+      "delta_updates":false
+    },
+    "source": "${TEST_COLLECTION_MULTIPLE_DATATYPES}"
+  }
+]'
+
+CONNECTOR_CONFIG="$(echo "$config_json_template" | envsubst | jq -c)"
+export CONNECTOR_CONFIG
+
+RESOURCES_CONFIG="$(echo "$resources_json_template" | envsubst | jq -c)"
+export RESOURCES_CONFIG

--- a/tests/materialize/materialize-s3-parquet/cleanup.sh
+++ b/tests/materialize/materialize-s3-parquet/cleanup.sh
@@ -1,7 +1,4 @@
 #!/bin/bash
 set -e
 
-if [[ -n "${TEST_BUCKET}" ]]; then
-    echo "Cleaning up bucket: '${TEST_BUCKET}'"
-    aws s3 rb "s3://${TEST_BUCKET}" --force
-fi
+docker rm -f "${LOCALSTACK_CONTAINER_NAME}"

--- a/tests/materialize/materialize-s3-parquet/fetch-materialize-results.sh
+++ b/tests/materialize/materialize-s3-parquet/fetch-materialize-results.sh
@@ -10,18 +10,17 @@ fi
 # The relative path to ${TEST_DIR} to store final results.
 result_dir="$1"
 
-# Wait until all the data has been uploaded to s3.
+# Wait long enough to have all the data uploaded to s3.
 sleep 5
 
-# The path of dir relative to ${TEST_DIR} for storing temp files.
+# The dir relative to ${TEST_DIR} for storing temp files.
 tmp_dir=tmp
 mkdir -p "$(realpath "${TEST_DIR}"/${tmp_dir})"
 
 # Sync data to local.
-aws s3 sync s3://"${TEST_BUCKET}" "${TEST_DIR}/${tmp_dir}/" --endpoint-url "${LOCALSTACK_ENDPOINT}" \
+aws s3 sync s3://"${TEST_BUCKET}" "${TEST_DIR}/${tmp_dir}/" --endpoint-url "${LOCALSTACK_S3_ENDPOINT}" \
     || bail "syncing data from s3 failed"
 
-find "${TEST_DIR}/${tmp_dir}"
 # Read all the pq data as jsonl output.
 function exportParquetToJson() {
     local pq_path="${TEST_DIR}"/"$1"
@@ -36,7 +35,7 @@ function exportParquetToJson() {
     fi
 
     for pq_file in ${pq_files}; do
-        docker run --rm -it -v "${pq_path}":/data \
+        docker run --rm -v "${pq_path}":/data \
            nathanhowell/parquet-tools cat -json /data/"${pq_file}" >> "${jsonl_path}" \
            || bail "generating jsonl failed"
  

--- a/tests/materialize/materialize-s3-parquet/fetch-materialize-results.sh
+++ b/tests/materialize/materialize-s3-parquet/fetch-materialize-results.sh
@@ -17,11 +17,11 @@ sleep 5
 tmp_dir=tmp
 mkdir -p "$(realpath "${TEST_DIR}"/${tmp_dir})"
 
-
 # Sync data to local.
-aws s3 sync s3://"${TEST_BUCKET}" "${TEST_DIR}/${tmp_dir}" \
+aws s3 sync s3://"${TEST_BUCKET}" "${TEST_DIR}/${tmp_dir}/" --endpoint-url "${LOCALSTACK_ENDPOINT}" \
     || bail "syncing data from s3 failed"
 
+find "${TEST_DIR}/${tmp_dir}"
 # Read all the pq data as jsonl output.
 function exportParquetToJson() {
     local pq_path="${TEST_DIR}"/"$1"

--- a/tests/materialize/materialize-s3-parquet/ingest-data.sh
+++ b/tests/materialize/materialize-s3-parquet/ingest-data.sh
@@ -14,6 +14,8 @@ go run ${DATA_INGEST_SCRIPT_PATH} \
   --binding_num=${BINDING_NUM_MULTIPLE_DATATYPES} \
   --data_file_path=${DATASET_MULTIPLE_DATATYPES}
 
+# Wait long enough so that the temp data in the local caches are all committed to S3.
+# Following data will be stored in a new local file.
 sleep 5
 go run ${DATA_INGEST_SCRIPT_PATH} \
   --server_address=${CONSUMER_ADDRESS} \

--- a/tests/materialize/materialize-s3-parquet/setup.sh
+++ b/tests/materialize/materialize-s3-parquet/setup.sh
@@ -2,16 +2,22 @@
 set -e
 
 export LOCALSTACK_CONTAINER_NAME=localstack
-export LOCALSTACK_ENDPOINT=http://localhost:4566
+# with virtual host based addressing https://github.com/localstack/localstack/pull/3690/files
+export LOCALSTACK_S3_ENDPOINT=http://s3.localhost.localstack.cloud:4566
 
-export TEST_AWS_REGION=us-east-1
+# Dummy configs for awscli to access localstack.
+export AWS_ACCESS_KEY_ID=test_key
+export AWS_SECRET_ACCESS_KEY=test_secret
+export AWS_DEFAULT_REGION=us-east-1
+
 export TEST_BUCKET="test-bucket"
-export TEST_PATH_PREFIX_SIMPLE="simple"
-export TEST_PATH_PREFIX_MULTIPLE_DATATYPES="/multiple-datatypes"
+export TEST_PATH_PREFIX_SIMPLE="${CONNECTOR}/simple"
+export TEST_PATH_PREFIX_MULTIPLE_DATATYPES="${CONNECTOR}/multiple-datatypes"
 
 function startLocalStack() {
     docker run -d \
       --rm \
+      --user 0 \
       --name="${LOCALSTACK_CONTAINER_NAME}" \
       --network=host \
       --env "SERVICES=s3" \
@@ -19,7 +25,7 @@ function startLocalStack() {
 
     for i in {1..20}; do
         # Wait until the elastic search is ready for serving.
-        if curl -o /dev/null -s -I -f "${LOCALSTACK_ENDPOINT}";  then
+        if aws s3 ls --endpoint-url "${LOCALSTACK_S3_ENDPOINT}";  then
             echo "localstack started successfully."
             return 0
         fi
@@ -30,28 +36,28 @@ function startLocalStack() {
     docker logs "${LOCALSTACK_CONTAINER_NAME}"
     return 1
 }
-startLocalStack || bail "failed to start localstack"
+startLocalStack || bail "failed to start localstack."
 
-aws s3 mb "s3://${TEST_BUCKET}" --endpoint "${LOCALSTACK_ENDPOINT}"
+aws s3 mb "s3://${TEST_BUCKET}" --endpoint "${LOCALSTACK_S3_ENDPOINT}"
 
 config_json_template='{
     "bucket": "${TEST_BUCKET}",
-    "region": "${TEST_AWS_REGION}",
-    "endpoint": "${LOCALSTACK_ENDPOINT}",
+    "region": "${AWS_DEFAULT_REGION}",
+    "endpoint": "${LOCALSTACK_S3_ENDPOINT}",
     "uploadIntervalInSeconds": 2
 }'
 
 resources_json_template='[
   {
     "resource": {
-      "pathPrefix": "${TEST_BUCKET}/${TEST_PATH_PREFIX_SIMPLE}",
+      "pathPrefix": "${TEST_PATH_PREFIX_SIMPLE}",
       "compressionType": "snappy"
     },
     "source": "${TEST_COLLECTION_SIMPLE}"
   },
   {
     "resource": {
-      "pathPrefix": "${TEST_BUCKET}/${TEST_PATH_PREFIX_MULTIPLE_DATATYPES}",
+      "pathPrefix": "${TEST_PATH_PREFIX_MULTIPLE_DATATYPES}",
       "compressionType": "none"
     },
     "source": "${TEST_COLLECTION_MULTIPLE_DATATYPES}"

--- a/tests/materialize/materialize-s3-parquet/setup.sh
+++ b/tests/materialize/materialize-s3-parquet/setup.sh
@@ -1,32 +1,57 @@
 #!/bin/bash
 set -e
 
-TEST_BUCKET="estuary-test-$(shuf -zer -n6 {a..z} | tr -d '\0')"
-export TEST_BUCKET
-export TEST_PATH_PREFIX_SIMPLE="${CONNECTOR}/simple"
-export TEST_PATH_PREFIX_MULTIPLE_DATATYPES="${CONNECTOR}/multiple-datatypes"
+export LOCALSTACK_CONTAINER_NAME=localstack
+export LOCALSTACK_ENDPOINT=http://localhost:4566
 
-aws s3api create-bucket --bucket "${TEST_BUCKET}"
+export TEST_AWS_REGION=us-east-1
+export TEST_BUCKET="test-bucket"
+export TEST_PATH_PREFIX_SIMPLE="simple"
+export TEST_PATH_PREFIX_MULTIPLE_DATATYPES="/multiple-datatypes"
+
+function startLocalStack() {
+    docker run -d \
+      --rm \
+      --name="${LOCALSTACK_CONTAINER_NAME}" \
+      --network=host \
+      --env "SERVICES=s3" \
+      localstack/localstack
+
+    for i in {1..20}; do
+        # Wait until the elastic search is ready for serving.
+        if curl -o /dev/null -s -I -f "${LOCALSTACK_ENDPOINT}";  then
+            echo "localstack started successfully."
+            return 0
+        fi
+        echo "Not ready, retrying ${i}."
+        sleep 3
+    done
+    echo "Localstack logs:"
+    docker logs "${LOCALSTACK_CONTAINER_NAME}"
+    return 1
+}
+startLocalStack || bail "failed to start localstack"
+
+aws s3 mb "s3://${TEST_BUCKET}" --endpoint "${LOCALSTACK_ENDPOINT}"
 
 config_json_template='{
-    "awsAccessKeyId": "${AWS_ACCESS_KEY_ID}",
-    "awsSecretAccessKey": "${AWS_SECRET_ACCESS_KEY}",
     "bucket": "${TEST_BUCKET}",
-    "region": "${DEFAULT_AWS_REGION}",
+    "region": "${TEST_AWS_REGION}",
+    "endpoint": "${LOCALSTACK_ENDPOINT}",
     "uploadIntervalInSeconds": 2
 }'
 
 resources_json_template='[
   {
     "resource": {
-      "pathPrefix": "${TEST_PATH_PREFIX_SIMPLE}",
+      "pathPrefix": "${TEST_BUCKET}/${TEST_PATH_PREFIX_SIMPLE}",
       "compressionType": "snappy"
     },
     "source": "${TEST_COLLECTION_SIMPLE}"
   },
   {
     "resource": {
-      "pathPrefix": "${TEST_PATH_PREFIX_MULTIPLE_DATATYPES}",
+      "pathPrefix": "${TEST_BUCKET}/${TEST_PATH_PREFIX_MULTIPLE_DATATYPES}",
       "compressionType": "none"
     },
     "source": "${TEST_COLLECTION_MULTIPLE_DATATYPES}"

--- a/tests/materialize/run.sh
+++ b/tests/materialize/run.sh
@@ -95,9 +95,9 @@ function runFlowctl() {
         --mount type=bind,source=/var/run/docker.sock,target=/var/run/docker.sock \
         --mount type=bind,source="${TEST_SCRIPTS_DIR}",target=${test_scripts_dir_target} \
         --mount type=bind,source="${TEST_DIR}",target=${test_dir_target} \
-        --env BROKER_ADDRESS=http://${BROKER_ADDRESS} \
-        --env CONSUMER_ADDRESS=http://${CONSUMER_ADDRESS} \
-        --env TEST_DIR=${test_dir_target} \
+        --env BROKER_ADDRESS="http://${BROKER_ADDRESS}" \
+        --env CONSUMER_ADDRESS="http://${CONSUMER_ADDRESS}" \
+        --env TEST_DIR="${test_dir_target}" \
         --env BUILDS_ROOT="file://${test_dir_target}/build/" \
         --env BUILD_ID=run-test-"${CONNECTOR}" \
         --env CATALOG \

--- a/tests/materialize/run.sh
+++ b/tests/materialize/run.sh
@@ -2,17 +2,24 @@
 
 set -e
 
-ROOT_DIR="$(git rev-parse --show-toplevel)"
-cd "$ROOT_DIR"
-
 # Flow image / container name used in testing.
-FLOW_IMAGE="ghcr.io/estuary/flow:v0.1.0-464-gfe2bfe4"
-FLOW_CONTAINER_NAME="flow-test"
+FLOW_IMAGE="ghcr.io/estuary/flow:dev"
+# Prefix of the containers running flowctl via Flow image.
+FLOW_CONTAINER_NAME_PREFIX=flowctl-${CONNECTOR}
+
+# The docker image of the connector to be tested.
+# The connector image needs to be available to envsubst.
+export CONNECTOR_IMAGE="ghcr.io/estuary/${CONNECTOR}:${VERSION}"
 
 function bail() {
     echo "$@" 1>&2
     # Output logs for debugging if the execution fails for any reason.
-    docker logs ${FLOW_CONTAINER_NAME} || true
+    for name in $(docker ps -a -f name=${FLOW_CONTAINER_NAME_PREFIX} -q); do
+        echo -e "\nlogs from container ${name}"
+        docker logs "${name}"
+    done
+
+    echo "test failed..."
     exit 1
 }
 export -f bail
@@ -20,98 +27,104 @@ export -f bail
 test -n "${CONNECTOR}" || bail "must specify CONNECTOR env variable"
 test -n "${VERSION}" || bail "must specify VERSION env variable"
 
+# The directory of the connectors github repo.
+ROOT_DIR="$(git rev-parse --show-toplevel)"
+
+# The dir of materialize tests.
+TEST_SCRIPTS_DIR="${ROOT_DIR}/tests/materialize"
+
 # The dir containing test scripts of the connector.
-CONNECTOR_TEST_SCRIPTS_DIR="tests/materialize/${CONNECTOR}"
+CONNECTOR_TEST_SCRIPTS_DIR="${TEST_SCRIPTS_DIR}/${CONNECTOR}"
 
-# The connector image needs to be available to envsubst
-export CONNECTOR_IMAGE="ghcr.io/estuary/${CONNECTOR}:${VERSION}"
+# Export envvars to be shared by all scripts.
 
-# Prepare test directory.
-TEST_DIR=".build/tests/${CONNECTOR}"
-# Ensure we start with an empty dir, since the flowctl_develop directory will go here.
-# Unfortunately, we can't just delete it, since the flowctl container is running as root, and so
-# all the files it creates will be owned by root. This isn't an issue in CI, since this directory
-# won't exist as long as we do a clean checkout, but for local runs, I'd rather error out than to
-# run 'sudo rm'.
-if [[ -d "${TEST_DIR}" ]]; then
-    bail "The test directory '${TEST_DIR}' must not already exist prior to a test run"
-fi
-mkdir -p "${TEST_DIR}"
+# A directory for hosting temp files generated during the test executions.
+export TEST_DIR="$(mktemp -d -t "${CONNECTOR}"-XXXXXX)"
 
-# The path of catalog specification.
-CATALOG="${TEST_DIR}/materialize-test.flow.yaml"
+# Broker and consumer addresses of Flow services.
+export BROKER_ADDRESS=localhost:8080
+export CONSUMER_ADDRESS=localhost:9000
 
+# The path to the data ingestion go script.
+export DATA_INGEST_SCRIPT_PATH="${TEST_SCRIPTS_DIR}/datasets/ingest.go"
 
+# The file name of catalog specification.
+# The file is located in ${TEST_DIR}
+export CATALOG="materialize-test.flow.yaml"
 
-# Export a few envvars to be shared with the testing scripts with connector-specific logic.
+# The name of the test capture for pushing data into collections.
+export PUSH_CAPTURE_NAME=test/ingest
+
+# A few envvars related to test data and collections.
+# They are used by the connector-specific script of `ingest-data.sh`.
 # 1. the names of prepared flow collections.
 export TEST_COLLECTION_SIMPLE="tests/${CONNECTOR}/simple"
 export TEST_COLLECTION_MULTIPLE_DATATYPES="tests/${CONNECTOR}/multiple-datatypes"
 
-# 2. the local paths of test datasets that matches the test collections.
+# 2. the paths of test datasets that matches the test collections.
 # - a dataset that matches the schema of TEST_COLLECTION_SIMPLE.
-export DATASET_SIMPLE="tests/materialize/datasets/simple.jsonl"
+export DATASET_SIMPLE="${ROOT_DIR}/tests/materialize/datasets/simple.jsonl"
 # - a dataset that matches the schema of TEST_COLLECTION_MULTIPLE_DATATYPES.
-export DATASET_MULTIPLE_DATATYPES="tests/materialize/datasets/multiple-datatypes.jsonl"
+export DATASET_MULTIPLE_DATATYPES="${ROOT_DIR}/tests/materialize/datasets/multiple-datatypes.jsonl"
 
-# 3. websocket URLs for ingesting data.
-WEBSOCKET_URL_PREFIX=ws://localhost:8080/ingest
-# URL for ingesting data to TEST_COLLECTION_SIMPLE.
-export WEBSOCKET_URL_SIMPLE=${WEBSOCKET_URL_PREFIX}/${TEST_COLLECTION_SIMPLE}
-# URL for ingesting data to TEST_COLLECTION_MULTIPLE_DATATYPES.
-export WEBSOCKET_URL_MULTIPLE_DATATYPES=${WEBSOCKET_URL_PREFIX}/${TEST_COLLECTION_MULTIPLE_DATATYPES}
+# 3. the binding number of datasets in the push capture.
+export BINDING_NUM_SIMPLE=0
+export BINDING_NUM_MULTIPLE_DATATYPES=1
 
-# Start the catalog for testing.
-function startFlow() {
+# Util function to run flowctl command via docker.
+function runFlowctl() {
+    local script="$1"
+    local args=$2
+    local detached
+    if [[ "$3" == true ]]; then
+      detached="-d"
+    fi
+
+    local test_dir_target=/home/flow/tests/temp
+    local test_scripts_dir_target=/home/flow/scripts
     # Run as root, not the flow user, since the user within the container needs to access the
     # docker socket.
-    docker run  -d --rm -it \
-        --name "${FLOW_CONTAINER_NAME}" \
+    docker run ${detached:+"$detached"} \
+        --name "${FLOW_CONTAINER_NAME_PREFIX}-${script}-${EPOCHREALTIME}" \
         --user 0  \
-        --mount type=bind,source=/tmp,target=/tmp \
         --mount type=bind,source=/var/run/docker.sock,target=/var/run/docker.sock \
-        --mount type=bind,source="$(pwd)",target=/home/flow/project \
+        --mount type=bind,source="${TEST_SCRIPTS_DIR}",target=${test_scripts_dir_target} \
+        --mount type=bind,source="${TEST_DIR}",target=${test_dir_target} \
+        --env BROKER_ADDRESS=http://${BROKER_ADDRESS} \
+        --env CONSUMER_ADDRESS=http://${CONSUMER_ADDRESS} \
+        --env TEST_DIR=${test_dir_target} \
+        --env BUILDS_ROOT="file://${test_dir_target}/build/" \
+        --env BUILD_ID=run-test-${CONNECTOR} \
+        --env CATALOG \
         --network=host \
         "${FLOW_IMAGE}" \
-        flowctl develop --source "${CATALOG}" --directory "${TEST_DIR}" \
-        || bail "flowctl develop failed"
-    for i in {1..20}; do
-        # Wait until the server is ready for serving.
-        # TODO (jixiang) consider checking a status endpoint?
-        if docker logs ${FLOW_CONTAINER_NAME} | grep -q "Listening at: "; then
-            echo "server starts successfully."
-            return
-        fi
-        echo "Not ready, retrying ${i}."
-        sleep 3
-    done
-
-    bail "flowctl develop failed to start the server after 60s."
+        "${test_scripts_dir_target}/flowctl/${script}" \
+        "${args}" \
+        >/dev/null 2>&1
 }
 
-# Util function fur running the `flowctl combine` to combine the results.
+# Util function for running the `flowctl combine` to combine the results.
 function combineResults() {
-    # The name collection name specified in the catalog.
+    # The collection name specified in the catalog.
     local collection="$1"
-    local input_jsonl_path="$2"
-    local output_jsonl_path="$3"
-
-    docker run -i \
-        --user 0 \
-        --mount type=bind,source="$(pwd)",target=/home/flow/project \
-        --mount type=bind,source=/var/run/docker.sock,target=/var/run/docker.sock \
-        "${FLOW_IMAGE}" \
-        flowctl combine --source "${CATALOG}" --directory "${TEST_DIR}" --collection "${collection}" \
-        <"${input_jsonl_path}" >"${output_jsonl_path}" \
-       || bail "flowctl combine failed"
+    # The input jsonl file contains json docs of the specified collection.
+    local input_file_name="$2"
+    # The output jsonl file of the combined results.
+    local output_file_name="$3"
+    runFlowctl "combine.sh" "${collection} ${input_file_name} ${output_file_name}" false || bail "combine results failed."
 }
-# Export the function to be avialble to connector testing scripts.
+# Export the function to be avialble to connector-specific testing scripts.
 export -f combineResults
 
 function cleanup() {
     echo -e "\nexecuting cleanup"
+
+    runFlowctl delete.sh "" false || true
+
     source "${CONNECTOR_TEST_SCRIPTS_DIR}/cleanup.sh" || true
-    docker rm -f ${FLOW_CONTAINER_NAME} || true
+    for name in $(docker ps -a -f name=${FLOW_CONTAINER_NAME_PREFIX} -q); do
+        docker rm -f "${name}"
+    done
 }
 trap cleanup EXIT
 
@@ -127,38 +140,41 @@ if [[ -z "${RESOURCES_CONFIG}" ]]; then
 fi
 
 echo -e "\ngenerating catalog"
-envsubst < tests/materialize/flow.json.template | yq eval -P | \
+envsubst < ${ROOT_DIR}/tests/materialize/flow.json.template | yq eval -P | \
 sed "s/CONNECTOR_CONFIG_PLACEHOLDER/${CONNECTOR_CONFIG}/g" \
-> "${CATALOG}" || bail "generating ${CATALOG} failed."
+> "${TEST_DIR}/${CATALOG}" || bail "generating ${CATALOG} failed."
 
-echo -e "\nstart testing flow"
-startFlow
+echo -e "\nstarting temp data plane"
+runFlowctl temp-data-plane.sh "" true || bail "starting temp data plane."
+
+echo -e "\nbuilding and activating test catalog"
+runFlowctl build-and-activate.sh "" false || bail "building and activating test catalog failed."
 
 echo -e "\nexecuting ingest-data"
 source "${CONNECTOR_TEST_SCRIPTS_DIR}/ingest-data.sh" || bail "ingest data failed."
 
+# The relative path to ${TEST_DIR} for storing result files.
+result_dir=result_jsonl
+mkdir -p "$(realpath "${TEST_DIR}"/"${result_dir}")"
+
 echo -e "\nexecuting fetch-materialize-results"
-TMP_DIR="$(realpath "${TEST_DIR}/result_data")"
-TEST_OUTPUT_JSONL_DIR="$(realpath "${TEST_DIR}/result_jsonl")"
-mkdir -p "${TMP_DIR}" "${TEST_OUTPUT_JSONL_DIR}"
-source "${CONNECTOR_TEST_SCRIPTS_DIR}/fetch-materialize-results.sh" "${TMP_DIR}" "${TEST_OUTPUT_JSONL_DIR}" \
+source "${CONNECTOR_TEST_SCRIPTS_DIR}/fetch-materialize-results.sh" ${result_dir}\
     || bail "fetching test results failed."
 
-
-echo -e "\ncomparing acutal v.s. expected"
+echo -e "\ncomparing actual v.s. expected"
 # The dir that contains all the files expected from the output.
 EXPECTED_DIR="${CONNECTOR_TEST_SCRIPTS_DIR}/expected/"
 
 # Make sure all expected files has their corresponding files in the actual output directory.
 for f in "${EXPECTED_DIR}"/*; do
     filename="$(basename "${f}")"
-    if [[ ! -f "${TEST_OUTPUT_JSONL_DIR}/${filename}" ]]; then
-        bail "expected file ${TEST_OUTPUT_JSONL_DIR}/${filename} is missing in the actual output."
+    if [[ ! -f "${TEST_DIR}/${result_dir}/${filename}" ]]; then
+        bail "expected file ${result_dir}/${filename} is missing in the actual output."
     fi
 done
 
 # Make sure all files in the actual output directory are same as expected.
-for f in "${TEST_OUTPUT_JSONL_DIR}"/*; do
+for f in "${TEST_DIR}/${result_dir}"/*; do
     expected="${EXPECTED_DIR}/$(basename "${f}")"
     if [[ ! -f ${expected} ]]; then
         bail "${f} in the actual output is not expected."


### PR DESCRIPTION
The PR improved the materialization elastic search connector.
1. it exports the descriptions of the connect specifications in the spec responses.
2. it adds integration tests to it. As the ingest to flow mechanism has been changed recently, the change also involves changes to the materialization testing infrastructure, and the existing integration test for `s3-parquet.`

The changes are structured roughly in a sequence of commits.
- `data ingest script` adds a new script to ingest data to Flow captures via `Push` mechnism.
- `test infra change and s3-parquet` changes the testing infrastructure to use the new ingest script and switched the existing test to work with the new infra.
- `elasticsearch tests` adds the integration test for elastic search.
- `hook with github workflow` enables the integration tests to be triggered in github workflow.
- `change elastic search jsonschema descriptions` implements requirement 1.