### PR TITLE
materialize-bigquery: Don't assume the root document exists

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/brianvoe/gofakeit/v6 v6.9.0
 	github.com/elastic/go-elasticsearch/v7 v7.15.2-0.20211104170009-caf202868441
 	github.com/estuary/flow v0.1.1-0.20211207135900-65dc2d2b030a
-	github.com/estuary/protocols v0.0.0-20211129055338-9259b2dca80a
+	github.com/estuary/protocols v0.0.0-20220120193955-e69c14edbdd1
 	github.com/evanphx/json-patch/v5 v5.5.0
 	github.com/go-mysql-org/go-mysql v1.4.0
 	github.com/gogo/protobuf v1.3.2

--- a/go.sum
+++ b/go.sum
@@ -222,6 +222,8 @@ github.com/estuary/flow v0.1.1-0.20211207135900-65dc2d2b030a h1:gyG0HF6DU3Fyr7O1
 github.com/estuary/flow v0.1.1-0.20211207135900-65dc2d2b030a/go.mod h1:+sYnmqlBjmvd57tTUa35ViG74uwsUZ6r8XWFIacHW8g=
 github.com/estuary/protocols v0.0.0-20211129055338-9259b2dca80a h1:2S/0GAvLKkayZmRTMjIr9uSpJSPYsrqPaKJ4hE1fRr4=
 github.com/estuary/protocols v0.0.0-20211129055338-9259b2dca80a/go.mod h1:HvGdE/2z4CCCn+XcjMujL3AQ2Skc/KKz6ds42UJnwc8=
+github.com/estuary/protocols v0.0.0-20220120193955-e69c14edbdd1 h1:pCvWJ3bSifT5dtcvsqzNtb2xABbkZw+yCbuU3P5ljxE=
+github.com/estuary/protocols v0.0.0-20220120193955-e69c14edbdd1/go.mod h1:HvGdE/2z4CCCn+XcjMujL3AQ2Skc/KKz6ds42UJnwc8=
 github.com/evanphx/json-patch v4.2.0+incompatible h1:fUDGZCv/7iAN7u0puUVhvKCcsR6vRfwrJatElLBEf0I=
 github.com/evanphx/json-patch v4.2.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/evanphx/json-patch/v5 v5.5.0 h1:bAmFiUJ+o0o2B4OiTFeE3MqCOtyo+jjPP9iZ0VRxYUc=

--- a/materialize-bigquery/binding.go
+++ b/materialize-bigquery/binding.go
@@ -30,6 +30,7 @@ type binding struct {
 		mergeFile       *ExternalDataConnectionFile
 		sql             string
 		tempTableName   string // The name the external table we be referenced by
+		hasRootDocument bool   // Whether the root document is included in this binding
 	}
 }
 
@@ -116,19 +117,25 @@ func newBinding(generator sqlDriver.Generator, bindingPos int, targetName string
 
 	b.load.tempTableName = fmt.Sprintf("%s_load_%d", tempTableNamePrefix, bindingPos)
 
-	// SELECT documents joined with the external table of keys to load
-	b.load.sql = fmt.Sprintf(`
+	if spec.DeltaUpdates {
+		// TODO(wgd): Can we fill in some appropriate placeholder SQL that will always
+		// yield an empty result set?
+		b.load.sql = `THIS SHOULD NEVER BE EXECUTED`
+	} else {
+		// SELECT documents joined with the external table of keys to load
+		b.load.sql = fmt.Sprintf(`
 		SELECT %d, l.%s
 			FROM %s AS l
 			JOIN %s AS r
 			ON %s
 		`,
-		bindingPos,
-		tableDef.GetColumn(spec.FieldSelection.Document).Identifier,
-		tableDef.Identifier,
-		b.load.tempTableName,
-		strings.Join(pkJoins, " AND "),
-	)
+			bindingPos,
+			tableDef.GetColumn(spec.FieldSelection.Document).Identifier,
+			tableDef.Identifier,
+			b.load.tempTableName,
+			strings.Join(pkJoins, " AND "),
+		)
+	}
 
 	// BINDING STORES: Store is done via upserts using a merge query against an external table.
 
@@ -166,12 +173,9 @@ func newBinding(generator sqlDriver.Generator, bindingPos int, targetName string
 		rColIdentifiers = append(rColIdentifiers, fmt.Sprintf("r.%s", col.Identifier))
 	}
 
-	// Updates for all columns minus the primary keys plus the document field.
-	var lrUpdates []string
-	for _, colName := range append(spec.FieldSelection.Values, spec.FieldSelection.Document) {
-		var col = tableDef.GetColumn(colName)
-		lrUpdates = append(lrUpdates, fmt.Sprintf("l.%s = r.%s", col.Identifier, col.Identifier))
-	}
+	// If a field is selected whose document pointer is the root document, then Store()
+	// will need to include the root document in the set of values being written.
+	b.store.hasRootDocument = spec.FieldSelection.Document != ""
 
 	b.store.tempTableName = fmt.Sprintf("%s_store_%d", tempTableNamePrefix, bindingPos)
 
@@ -187,6 +191,13 @@ func newBinding(generator sqlDriver.Generator, bindingPos int, targetName string
 			b.store.tempTableName,
 		)
 	} else {
+		// Updates for all columns minus the primary keys plus the document field.
+		var lrUpdates []string
+		for _, colName := range append(spec.FieldSelection.Values, spec.FieldSelection.Document) {
+			var col = tableDef.GetColumn(colName)
+			lrUpdates = append(lrUpdates, fmt.Sprintf("l.%s = r.%s", col.Identifier, col.Identifier))
+		}
+
 		// Perform merge query to update existing values.
 		b.store.sql = fmt.Sprintf(`
 		MERGE INTO %s AS l

--- a/materialize-bigquery/binding.go
+++ b/materialize-bigquery/binding.go
@@ -118,9 +118,9 @@ func newBinding(generator sqlDriver.Generator, bindingPos int, targetName string
 	b.load.tempTableName = fmt.Sprintf("%s_load_%d", tempTableNamePrefix, bindingPos)
 
 	if spec.DeltaUpdates {
-		// TODO(wgd): Can we fill in some appropriate placeholder SQL that will always
-		// yield an empty result set?
-		b.load.sql = `THIS SHOULD NEVER BE EXECUTED`
+		// We should never issue a load query in delta updates mode, so just in case
+		// that happens we'll hopefully produce a reasonable error message with this.
+		b.load.sql = `ASSERT false AS 'Load queries should never be executed in Delta Updates mode.'`
 	} else {
 		// SELECT documents joined with the external table of keys to load
 		b.load.sql = fmt.Sprintf(`

--- a/materialize-bigquery/transactor.go
+++ b/materialize-bigquery/transactor.go
@@ -152,9 +152,11 @@ func (t *transactor) Store(it *pm.StoreIterator) error {
 		}
 
 		// Convert all the values to database appropriate ones and store them in the GCS file.
-		if converted, err := b.store.paramsConverter.Convert(
-			append(append(it.Key, it.Values...), it.RawJSON),
-		); err != nil {
+		var vals = append(it.Key, it.Values...) // TODO(wgd): Was destructive reuse of `it.Key` intentional here?
+		if b.store.hasRootDocument {
+			vals = append(vals, it.RawJSON)
+		}
+		if converted, err := b.store.paramsConverter.Convert(vals); err != nil {
 			return fmt.Errorf("converting Store: %w", err)
 		} else if err = b.store.mergeFile.WriteRow(converted); err != nil {
 			return fmt.Errorf("encoding Store to scratch file: %w", err)

--- a/materialize-bigquery/transactor.go
+++ b/materialize-bigquery/transactor.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"cloud.google.com/go/bigquery"
+	"github.com/estuary/protocols/fdb/tuple"
 	pf "github.com/estuary/protocols/flow"
 	pm "github.com/estuary/protocols/materialize"
 	log "github.com/sirupsen/logrus"
@@ -136,6 +137,7 @@ func (t *transactor) Store(it *pm.StoreIterator) error {
 
 	// Iterate through all the new values to store.
 	var err error
+	var vals []tuple.TupleElement
 	for it.Next() {
 		var b = t.bindings[it.Binding]
 
@@ -152,7 +154,7 @@ func (t *transactor) Store(it *pm.StoreIterator) error {
 		}
 
 		// Convert all the values to database appropriate ones and store them in the GCS file.
-		var vals = append(it.Key, it.Values...) // TODO(wgd): Was destructive reuse of `it.Key` intentional here?
+		vals = append(append(vals[:0], it.Key...), it.Values...)
 		if b.store.hasRootDocument {
 			vals = append(vals, it.RawJSON)
 		}


### PR DESCRIPTION
**Description:**

Subsequent to https://github.com/estuary/protocols/pull/22 (which relaxes the requirement so that a binding for the root document is only `RECOMMENDED` in delta-updates mode), we still need to modify the actual connectors to work with this configuration.

This PR tweaks the BigQuery materialization so that it doesn't assume the existence of a binding for the root document when in
delta-updates mode.

**Workflow steps:**

Once this all works, a catalog entry like:

```yaml
materializations:
  wgd/example/to-bigquery:
    endpoint:
      connector:
        image: ghcr.io/estuary/materialize-bigquery:dev
        config: wgd-materialize-bigquery.config.yaml
    bindings:
      - source: wgd/example/data
        resource: 
          table: "example_table"
          delta_updates: true
        fields:
          recommended: true
          exclude: ["flow_document"]
```

Should be possible. Nothing should change in cases where `flow_document` is not excluded or `delta_updates` is false.

**Documentation links affected:**

I do not believe the `flow_document` field is discussed in our documentation at present, so no changes here.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/104)
<!-- Reviewable:end -->
