### PR TITLE
materialize-bigquery: Add support for 'date' formatted strings

### DIFF
--- a/materialize-bigquery/bigquery.go
+++ b/materialize-bigquery/bigquery.go
@@ -187,6 +187,7 @@ func SQLGenerator() sqlDriver.Generator {
 		sqlDriver.STRING: sqlDriver.StringTypeMapping{
 			Default: sqlDriver.RawConstColumnType("STRING"),
 			ByFormat: map[string]sqlDriver.TypeMapper{
+				"date":      sqlDriver.RawConstColumnType("DATE"),
 				"date-time": sqlDriver.RawConstColumnType("TIMESTAMP"),
 			},
 		},


### PR DESCRIPTION
**Description:**

Adds another case to the BigQuery SQL generator so that date-formatted strings (`{"type": "string", "format": "date"}`) will be translated to the BigQuery `DATE` type rather than `STRING`.

**Workflow steps:**

Specify `"format": "date"` in your JSON schema.

**Documentation links affected:**

None

