### PR TITLE
materialize-bigquery: Allow setting billing_project_id separately

### DIFF
--- a/materialize-bigquery/.snapshots/TestSpecification
+++ b/materialize-bigquery/.snapshots/TestSpecification
@@ -8,6 +8,9 @@
       "bucket_path"
     ],
     "properties": {
+      "billing_project_id": {
+        "type": "string"
+      },
       "project_id": {
         "type": "string"
       },


### PR DESCRIPTION
**Description:**

This change adds a new `billing_project_id` configuration parameter (optional, defaults to `project_id` if unset) which will be given to BigQuery (via `bigquery.NewClient`) for billing purposes.

However once we do this, all queries will "conveniently" use that project ID as the default for their own name resolution. To fix that and make the two concepts properly decoupled I had to change a couple places where table names are assembled from "dataset.table" to a fully-qualified "project_id.dataset.table".

I have verified that this works well enough to get through the previously-failing validation step during a catalog build, but haven't tried running the full catalog with this change yet.

**Workflow steps:**

Specify `billing_project_id` in a BigQuery materialization config.
