### PR TITLE
materialize-bigquery: Don't sanitize hyphens, they're allowed

### DIFF
--- a/materialize-bigquery/bigquery.go
+++ b/materialize-bigquery/bigquery.go
@@ -158,8 +158,8 @@ func newBigQueryDriver() *sqlDriver.Driver {
 	}
 }
 
-// Bigquery only allows underscore, letters and numbers for identifiers. Convert everything to underscore.
-var identifierSanitizerRegexp = regexp.MustCompile(`[^\._0-9a-zA-Z]`)
+// Bigquery only allows underscore, letters, numbers, and sometimes hyphens for identifiers. Convert everything else to underscore.
+var identifierSanitizerRegexp = regexp.MustCompile(`[^\-\._0-9a-zA-Z]`)
 
 func identifierSanitizer(text string) string {
 	return identifierSanitizerRegexp.ReplaceAllString(text, "_")


### PR DESCRIPTION
**Description:**

Allow hyphens to occur in table identifiers. Otherwise `project-name.dataset.table` gets sanitized to `project_name.dataset.table` and merge queries fail because that doesn't exist.

