### PR TITLE
source-mysql: Set up test DB user, watermarks table, etc

### DIFF
--- a/source-mysql/docker-compose.yaml
+++ b/source-mysql/docker-compose.yaml
@@ -4,7 +4,11 @@ services:
   db:
     image: 'mysql:latest'
     command: ["--binlog-row-metadata=FULL"]
-    volumes: ["mysql_data:/var/lib/mysql"]
+    volumes:
+      - type: bind
+        source: ./docker-entrypoint-initdb.d/init-user-db.sh
+        target: /docker-entrypoint-initdb.d/init-user-db.sh
+      - mysql_data:/var/lib/mysql
     environment:
       MYSQL_DATABASE: test
       MYSQL_ROOT_PASSWORD: flow

--- a/source-mysql/docker-entrypoint-initdb.d/init-user-db.sh
+++ b/source-mysql/docker-entrypoint-initdb.d/init-user-db.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+set -e
+
+echo "======================================="
+echo "Initializing Database for Flow Captures"
+echo "======================================="
+
+mysql --user="root" --password="flow" --database="test" <<-EOSQL
+    CREATE DATABASE IF NOT EXISTS flow;
+    CREATE TABLE IF NOT EXISTS flow.watermarks (slot INTEGER PRIMARY KEY, watermark TEXT);
+    CREATE USER IF NOT EXISTS flow_capture IDENTIFIED BY 'secret' COMMENT 'User account for Flow MySQL data capture';
+    GRANT REPLICATION CLIENT, REPLICATION SLAVE ON *.* TO 'flow_capture';
+    GRANT SELECT ON *.* TO 'flow_capture';
+    GRANT INSERT, UPDATE, DELETE ON flow.watermarks TO 'flow_capture';
+    SET PERSIST binlog_row_metadata = 'FULL';
+EOSQL


### PR DESCRIPTION
**Description:**

Using `source-mysql/docker-compose.yaml` should ideally result in a test DB set up automatically so that the `source-mysql` unit tests will pass without further manual tweaking.

**Workflow steps:**

```
$ cd connectors/source-mysql
$ docker-compose rm
$ docker volume rm source-mysql_myqsl_data
$ docker-compose up
$ go test -v
```

