### PR TITLE
source-mysql: Add to the CI build matrix

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -67,6 +67,7 @@ jobs:
           - source-hello-world
           - source-kafka
           - source-kinesis
+          - source-mysql
           - source-postgres
           - source-s3
           - materialize-bigquery
@@ -127,10 +128,14 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: us-east-2
 
-      - name: Start Test PostgreSQL Instance
-        if: matrix.connector == 'source-postgres'
+      - name: Start ${{ matrix.connector }} Test Database
+        if: |
+          contains('
+            source-mysql
+            source-postgres
+            ', matrix.connector)
         run: |
-          docker-compose --file source-postgres/docker-compose.yaml up --detach postgres
+          docker-compose --file ${{ matrix.connector }}/docker-compose.yaml up --detach
 
       - name: Start Open SSH server
         if: matrix.connector == 'source-postgres'
@@ -171,6 +176,7 @@ jobs:
             source-gcs
             source-kafka
             source-kinesis
+            source-mysql
             source-postgres
             source-s3
             ', matrix.connector)
@@ -181,6 +187,12 @@ jobs:
           DEFAULT_AWS_REGION: ${{ secrets.DEFAULT_AWS_REGION }}
           AWS_DEFAULT_OUTPUT: json
           ROCKSET_API_KEY: ${{ secrets.ROCKSET_API_KEY }}
+          MYSQL_DATABASE: test
+          MYSQL_HOST: 127.0.0.1
+          MYSQL_PORT: 3306
+          MYSQL_USER: root
+          MYSQL_PWD: flow
+          MYSQL_SERVERID: 12345
           # Compare to: https://www.postgresql.org/docs/current/libpq-envars.html
           PGDATABASE: flow
           PGHOST: localhost

--- a/tests/source-mysql/setup.sh
+++ b/tests/source-mysql/setup.sh
@@ -7,7 +7,7 @@ export RESOURCE="{ stream: ${TEST_STREAM} }"
 config_json_template='{
     "address": "$MYSQL_HOST:$MYSQL_PORT",
     "user": "$MYSQL_USER",
-    "pass": "$MYSQL_PWD",
+    "password": "$MYSQL_PWD",
     "dbname": "$MYSQL_DATABASE",
     "server_id": $MYSQL_SERVERID
 }'
@@ -25,4 +25,4 @@ function sql {
 sql "DROP TABLE IF EXISTS test.${TEST_STREAM};"
 sql "CREATE TABLE test.${TEST_STREAM} (id INTEGER PRIMARY KEY, canary TEXT);"
 sql "SET GLOBAL local_infile=1;"
-sql "LOAD DATA LOCAL INFILE '${root_dir}/tests/files/b.csv' INTO TABLE ${TEST_STREAM} FIELDS TERMINATED BY ',' LINES TERMINATED BY '\n' IGNORE 1 ROWS;"
+sql "LOAD DATA LOCAL INFILE '${root_dir}/tests/files/b.csv' INTO TABLE ${TEST_STREAM} FIELDS TERMINATED BY ',' OPTIONALLY ENCLOSED BY '\"' LINES TERMINATED BY '\n' IGNORE 1 ROWS;"


### PR DESCRIPTION
**Description:**

Adds the `source-mysql` connector to the CI build matrix and integration test. This should mean both that changes to `source-mysql` will actually be tested on new PRs going forward, and also that `ghcr.io/estuary/source-mysql:dev` will actually work to run the CI-built connector.
