### PR TITLE
pin down openssh-server docker image version

### DIFF
--- a/network-proxy-service/sshforwarding/test_sshd_configs/docker-compose.yaml
+++ b/network-proxy-service/sshforwarding/test_sshd_configs/docker-compose.yaml
@@ -2,7 +2,7 @@ version: "3.7"
 
 services:
   openssh-server:
-    image: lscr.io/linuxserver/openssh-server
+    image: lscr.io/linuxserver/openssh-server:8.6_p1-r3-ls71
     container_name: openssh-server
     volumes:
       - type: bind


### PR DESCRIPTION
**Description:**

A quick fix to make the build green. More work is needed to understand the exact reason that fails the SSH test in CI.


**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

