### PR TITLE
Fix Tamper check for SSH test server

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -141,7 +141,11 @@ jobs:
         if: matrix.connector == 'source-postgres'
         run: |
           cp -r network-proxy-service/sshforwarding/test_sshd_configs /tmp/test_sshd_configs &&
-          docker-compose --file /tmp/test_sshd_configs/docker-compose.yaml up --detach openssh-server
+          cd /tmp/test_sshd_configs &&
+          sudo chown -R root config/custom-cont-init.d &&
+          docker-compose up --detach openssh-server &&
+          sleep 1 &&
+          docker-compose logs openssh-server
 
       - name: Login to GitHub package docker registry
         run: |

--- a/network-proxy-service/sshforwarding/test_sshd_configs/docker-compose.yaml
+++ b/network-proxy-service/sshforwarding/test_sshd_configs/docker-compose.yaml
@@ -2,7 +2,7 @@ version: "3.7"
 
 services:
   openssh-server:
-    image: lscr.io/linuxserver/openssh-server:8.6_p1-r3-ls71
+    image: lscr.io/linuxserver/openssh-server
     container_name: openssh-server
     volumes:
       - type: bind


### PR DESCRIPTION
**Description:**

The linuxserver base image added a [Tamper check](https://github.com/linuxserver/docker-baseimage-alpine/commit/9184ab8abe289dbaf0f096a89f44a25a722dba1a) to move non-root scripts to a temp directory. And this breaks the OpenSSH test server, b/c its initialization scripts are not executed if its owner is not `root`.

The pr fixes the owner issue to make the test pass on latest ssh server image. 
**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

