### PR TITLE
Add titles to generated Kafka spec schema

### DIFF
--- a/source-hello-world/main.go
+++ b/source-hello-world/main.go
@@ -39,7 +39,7 @@ const configSchema = `{
 			"type":        "integer",
 			"title":       "Number of Greetings",
 			"description": "Number of greeting documents to produce when running in non-tailing mode",
-			"default":     "1000"
+			"default":     1000
 		}
 	}
 }`

--- a/source-kafka/src/configuration.rs
+++ b/source-kafka/src/configuration.rs
@@ -17,21 +17,25 @@ pub enum Error {
     NoBootstrapServersGiven,
 }
 
-/// # Kafka Connector Configuration
+/// # Kafka Source Configuration
 #[derive(Deserialize, Default, JsonSchema, Serialize)]
 pub struct Configuration {
+    /// # Bootstrap Servers
+    ///
     /// The initial servers in the Kafka cluster to initially connect to. The Kafka
     /// client will be informed of the rest of the cluster nodes by connecting to
     /// one of these nodes.
     #[schemars(with = "Vec<String>")]
     pub bootstrap_servers: Vec<BootstrapServer>,
 
+    /// # Authentication
+    ///
     /// The connection details for authenticating a client connection to Kafka via SASL.
     /// When not provided, the client connection will attempt to use PLAINTEXT
     /// (insecure) protocol. This must only be used in dev/test environments.
     pub authentication: Option<Authentication>,
 
-    /// The TLS connection settings.
+    /// # TLS connection settings.
     pub tls: TlsSettings,
 }
 
@@ -138,6 +142,8 @@ impl<'de> Visitor<'de> for BootstrapServerVisitor {
     }
 }
 
+/// # SASL Mechanism
+///
 /// The SASL Mechanism describes _how_ to exchange and authenticate
 /// clients/servers. For secure communication, TLS is **required** for all
 /// supported mechanisms.
@@ -170,14 +176,22 @@ impl Display for SaslMechanism {
     }
 }
 
+/// # Authentication
+///
 /// The information necessary to connect to Kafka.
 #[derive(Debug, Deserialize, JsonSchema, Serialize)]
 pub struct Authentication {
+    /// # Sasl Mechanism
     pub mechanism: SaslMechanism,
+    /// # Username
     pub username: String,
+    /// # Password
     pub password: String,
 }
 
+/// # TLS Settings
+///
+/// Controls how should TLS certificates be found or used.
 #[derive(Debug, Deserialize, JsonSchema, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum TlsSettings {

--- a/source-kafka/tests/it/snapshots/it__spec_test.snap
+++ b/source-kafka/tests/it/snapshots/it__spec_test.snap
@@ -11,15 +11,20 @@ spec:
         description: The information necessary to connect to Kafka.
         properties:
           mechanism:
-            $ref: "#/definitions/SaslMechanism"
+            allOf:
+              - $ref: "#/definitions/SaslMechanism"
+            title: Sasl Mechanism
           password:
+            title: Password
             type: string
           username:
+            title: Username
             type: string
         required:
           - mechanism
           - password
           - username
+        title: Authentication
         type: object
       SaslMechanism:
         description: "The SASL Mechanism describes _how_ to exchange and authenticate clients/servers. For secure communication, TLS is **required** for all supported mechanisms.\n\nFor more information about the Simple Authentication and Security Layer (SASL), see RFC 4422: https://datatracker.ietf.org/doc/html/rfc4422 For more information about Salted Challenge Response Authentication Mechanism (SCRAM), see RFC 7677. https://datatracker.ietf.org/doc/html/rfc7677"
@@ -27,11 +32,14 @@ spec:
           - PLAIN
           - SCRAM-SHA-256
           - SCRAM-SHA-512
+        title: SASL Mechanism
         type: string
       TlsSettings:
+        description: Controls how should TLS  certificates be found or used.
         enum:
           - system_certificates
           - cleartext
+        title: TLS Settings
         type: string
     properties:
       authentication:
@@ -39,19 +47,21 @@ spec:
           - $ref: "#/definitions/Authentication"
           - type: "null"
         description: "The connection details for authenticating a client connection to Kafka via SASL. When not provided, the client connection will attempt to use PLAINTEXT (insecure) protocol. This must only be used in dev/test environments."
+        title: Authentication
       bootstrap_servers:
         description: The initial servers in the Kafka cluster to initially connect to. The Kafka client will be informed of the rest of the cluster nodes by connecting to one of these nodes.
         items:
           type: string
+        title: Bootstrap Servers
         type: array
       tls:
         allOf:
           - $ref: "#/definitions/TlsSettings"
-        description: The TLS connection settings.
+        title: TLS connection settings.
     required:
       - bootstrap_servers
       - tls
-    title: Kafka Connector Configuration
+    title: Kafka Source Configuration
     type: object
   supported_destination_sync_modes: []
   supportsIncremental: true


### PR DESCRIPTION
**Description:**

Schemars will render "title" attributes if you use a Markdown heading in the doc comment. This should make it easier to render UI for some of these elements.

**Workflow steps:**

N/A

**Documentation links affected:**

N/A

**Notes for reviewers:**

The snapshot of the spec output is probably the main thing to look at. Otherwise it's just tweaking comments.

