### PR TITLE
encode pgtype.numeric ids

### DIFF
--- a/source-mysql/main.go
+++ b/source-mysql/main.go
@@ -128,8 +128,8 @@ func (db *mysqlDatabase) EncodeKeyFDB(key interface{}) (tuple.TupleElement, erro
 	return key, nil
 }
 
-func (db *mysqlDatabase) DecodeKeyFDB(t tuple.TupleElement) interface{} {
-	return t
+func (db *mysqlDatabase) DecodeKeyFDB(t tuple.TupleElement) (interface{}, error) {
+	return t, nil
 }
 
 // mysqlSourceInfo is source metadata for data capture events.

--- a/source-mysql/main.go
+++ b/source-mysql/main.go
@@ -8,6 +8,7 @@ import (
 	"github.com/alecthomas/jsonschema"
 	"github.com/estuary/connectors/sqlcapture"
 	"github.com/estuary/flow/go/protocols/airbyte"
+	"github.com/estuary/flow/go/protocols/fdb/tuple"
 	"github.com/go-mysql-org/go-mysql/client"
 	"github.com/sirupsen/logrus"
 )
@@ -121,6 +122,14 @@ func (db *mysqlDatabase) DefaultSchema(ctx context.Context) (string, error) {
 
 func (db *mysqlDatabase) EmptySourceMetadata() sqlcapture.SourceMetadata {
 	return &mysqlSourceInfo{}
+}
+
+func (db *mysqlDatabase) EncodeKeyFDB(key interface{}) (tuple.TupleElement, error) {
+	return key, nil
+}
+
+func (db *mysqlDatabase) DecodeKeyFDB(t tuple.TupleElement) interface{} {
+	return t
 }
 
 // mysqlSourceInfo is source metadata for data capture events.

--- a/source-postgres/fdbutils.go
+++ b/source-postgres/fdbutils.go
@@ -1,0 +1,115 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/estuary/flow/go/protocols/fdb/tuple"
+	"github.com/jackc/pgtype"
+)
+
+const numericKey = "N"
+
+// EncodePgNumericKeyFDB encodes a pgtype.Numeric value to an FDB tuple.
+func EncodePgNumericKeyFDB(key pgtype.Numeric) (tuple.Tuple, error) {
+	if encodedKey, err := encodePgNumeric(key); err != nil {
+		return nil, fmt.Errorf("encode pgtype.Numeric: %w", err)
+	} else if encodedBinary, err := key.EncodeBinary(nil, nil); err != nil {
+		return nil, fmt.Errorf("encode binary pgtype Numeric: %w", err)
+	} else {
+		return tuple.Tuple{numericKey, encodedKey, encodedBinary}, nil
+	}
+}
+
+// DecodeFDBTuple decodes the input TupleElement to its original value.
+// Return nil if the input cannot be decoded.
+func DecodeFDBTuple(t tuple.TupleElement) interface{} {
+	switch t := t.(type) {
+	case tuple.Tuple:
+		if len(t) == 3 {
+			if key, ok := t[0].(string); ok && key == numericKey {
+				if b, ok := t[2].([]byte); ok {
+					var n pgtype.Numeric
+					if err := n.DecodeBinary(nil, b); err == nil {
+						return n
+					}
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func encodePgNumeric(n pgtype.Numeric) (tuple.Tuple, error) {
+	if n.Status == pgtype.Null {
+		return nil, errors.New("Null value in Numeric Key Field")
+	} else if n.Status == pgtype.Undefined {
+		return nil, errors.New("Undefined value in Numeric Key Field")
+	} else if n.NaN {
+		return nil, errors.New("NaN value in a Numeric Key Field ")
+	}
+
+	// Conceptually, a pgtype.Numeric is encoded into a tuple of (exponents, fraction),
+	// in which exponents is an int, and fraction is a slice of bytes.
+	// It is ensured the encoded tuple preserves the order of the original numeric values
+	// based on `int` and `byte slice` ordering on both components, respectively.
+
+	// For positive numbers, the fraction is converted from the string of digits in the input without
+	// leading or trailing zeros, and the `exponents`` is set properly to make sure
+	// the represented value = 10 ^ (exponents) * 0.fraction.
+	//   E.g. 0.0041 is represetned by (exp = -2, fraction="41"),
+	//    and 3.14 is represented by (exp = 1, fraction="314")
+
+	// For negative numbers, suppose its absolute value is encoded as (expAbs, fracAbs),
+	// and the encoding result of the number is (-expAbs, invertNegfraction("-fracAbs")),
+	// see func invertNegfraction for details.
+
+	// In order for the encoding to preserve orders properly, we need to make sure the
+	// exponents of positive numbers are always positive. and this is done by adding a
+	// bias to the encoded exponents, and use the biasedExponents in ordering.
+
+	// According to https://www.postgresql.org/docs/current/datatype-numeric.html,
+	// the lowest value of exponent is -16382. Set the bias to be 20000,
+	// to make sure the biasedExponent of positive n is always positive.
+	const exponentBias = 20000
+
+	// Encoding for 0.
+	var biasedExponent int = 0
+	var fractionBytes []byte = nil
+
+	if n.Int.Sign() == 1 {
+		var str = n.Int.String()
+		biasedExponent = len(str) + int(n.Exp) + exponentBias
+		fractionBytes = []byte(strings.TrimRight(str, "0"))
+	} else if n.Int.Sign() == -1 {
+		var str = n.Int.String()
+		biasedExponent = -(len(str) - 1 + int(n.Exp) + exponentBias)
+		fractionBytes = invertNegfraction(strings.TrimRight(str, "0"))
+	}
+
+	return []tuple.TupleElement{biasedExponent, fractionBytes}, nil
+}
+
+func invertNegfraction(digits string) []byte {
+	// The input digits string represents a negative integer, and starts with the `-` sign.
+	// The function performs the following operations:
+	// 1. remove the `-` sign, which is redundant.
+	// 2. invert each digits to make sure the order between the encoded byte slices is consistent with
+	//    the order between the negative values.
+	//    This is done by replacing each digit x with (9 - x). (replace '0' with '9', '1' with '8', ..., '9' with '0').
+	// 3. add an sentinel value `0x3a` (ASCII of ":") at the end of the encoded byte slice, to make sure the order of
+	//    the encoded byte slices are consistent between a negative value and its prefixes. E.g.
+	//    "-123" (encoded as "876:") is greater than "-1234" (encoded as "8765:").
+	const sentinel = 0x3a
+	var b = []byte(digits)
+	for i := 1; i < len(b); i++ {
+		b[i-1] = '9' - b[i] + '0'
+	}
+
+	if len(b) > 0 {
+		b[len(b)-1] = sentinel
+	}
+
+	return b
+}

--- a/source-postgres/fdbutils_test.go
+++ b/source-postgres/fdbutils_test.go
@@ -1,0 +1,126 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math/big"
+	"testing"
+
+	"github.com/estuary/flow/go/protocols/fdb/tuple"
+	"github.com/jackc/pgtype"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEncodePgNumeric(t *testing.T) {
+	var testCases = []struct {
+		input    pgtype.Numeric
+		expected tuple.Tuple
+	}{
+		{
+			pgtype.Numeric{Status: pgtype.Present, Int: big.NewInt(1), Exp: 0},
+			[]tuple.TupleElement{20001, []byte("1")}, // "1e0"
+		},
+		{
+			pgtype.Numeric{Status: pgtype.Present, Int: big.NewInt(1), Exp: -16382},
+			[]tuple.TupleElement{3619, []byte("1")}, // "1e-16382"
+		},
+		{
+			pgtype.Numeric{Status: pgtype.Present, Int: big.NewInt(12309), Exp: -6},
+			[]tuple.TupleElement{19999, []byte("12309")}, // "12309e-6"
+		},
+		{
+			pgtype.Numeric{Status: pgtype.Present, Int: big.NewInt(123400), Exp: 3},
+			[]tuple.TupleElement{20009, []byte("1234")}, // "123400e3"
+		},
+		{
+			pgtype.Numeric{Status: pgtype.Present, Int: big.NewInt(0), Exp: 0},
+			[]tuple.TupleElement{0, []byte(nil)}, // "0e0"
+		},
+		{
+			pgtype.Numeric{Status: pgtype.Present, Int: big.NewInt(-1), Exp: 0},
+			[]tuple.TupleElement{-20001, []byte("8:")}, // "-1e0"
+		},
+		{
+			pgtype.Numeric{Status: pgtype.Present, Int: big.NewInt(-1), Exp: -16382},
+			[]tuple.TupleElement{-3619, []byte("8:")}, // "-1e-1"
+		},
+		{
+			pgtype.Numeric{Status: pgtype.Present, Int: big.NewInt(-12309), Exp: -6},
+			[]tuple.TupleElement{-19999, []byte("87690:")}, // "-12309e-6"
+		},
+		{
+			pgtype.Numeric{Status: pgtype.Present, Int: big.NewInt(-123400), Exp: 3},
+			[]tuple.TupleElement{-20009, []byte("8765:")}, // "-123400e3"
+		},
+	}
+
+	for _, test := range testCases {
+		var actual, err = encodePgNumeric(test.input)
+		require.NoError(t, err)
+		require.Equal(t, test.expected, actual)
+	}
+}
+
+func TestEncodeAndDecodePgNumericKeyFDB(t *testing.T) {
+	var k = 20000
+	var resumeKeyIndex = 100
+	var ctx, tableName, testCases = buildNumericKeyTestCases(t, k)
+
+	var preEncoded []byte
+	for i := 0; i < len(testCases); i++ {
+		tp, err := EncodePgNumericKeyFDB(testCases[i])
+		require.NoError(t, err)
+
+		// Make sure the encoded preserves the order.
+		var encoded = tp.Pack()
+		if i > 0 {
+			var message = fmt.Sprintf("Comparing %+v, %+v", testCases[i-1], testCases[i])
+			require.Equal(t, -1, bytes.Compare(preEncoded, encoded), message)
+		}
+		preEncoded = encoded
+
+		// Make sure decode returns the original value.
+		var decoded = DecodeFDBTuple(tp)
+		require.Equal(t, testCases[i], decoded, fmt.Sprintf("Testing: %+v", testCases[i]))
+
+		// Make sure the decoded element can be used in resume query.
+		if i == resumeKeyIndex {
+			var query = fmt.Sprintf("SELECT count(1) FROM %s WHERE id < $1;", tableName)
+			var n int
+			require.NoError(t, TestDatabase.QueryRow(ctx, query, decoded).Scan(&n))
+			require.Equal(t, n, resumeKeyIndex)
+		}
+	}
+}
+
+// populates a database table with random numeric ids, and
+// returns the db tableName, and a list of pgtype.Numeric numbers in ascending order extracted from the table.
+func buildNumericKeyTestCases(t *testing.T, k int) (ctx context.Context, tableName string, testCases []pgtype.Numeric) {
+	ctx = context.Background()
+	var tb = TestBackend
+	tableName = tb.CreateTable(ctx, t, "", "(id NUMERIC PRIMARY KEY)")
+
+	tb.Query(ctx, t, fmt.Sprintf(
+		`INSERT INTO %[1]s(id) 
+		 (SELECT (random() * 2 * %[2]d) - %[2]d
+		   FROM generate_series(1, %[2]d))
+		 ON CONFLICT (id) DO NOTHING;`,
+		tableName, k),
+	)
+
+	var rows, err = TestDatabase.Query(ctx, fmt.Sprintf("SELECT id FROM %s ORDER BY id;", tableName))
+	require.NoError(t, err)
+	defer rows.Close()
+
+	testCases = make([]pgtype.Numeric, 0, k)
+	for rows.Next() {
+		var id pgtype.Numeric
+		err = rows.Scan(&id)
+		require.NoError(t, err)
+
+		testCases = append(testCases, id)
+	}
+
+	return
+}

--- a/source-postgres/fdbutils_test.go
+++ b/source-postgres/fdbutils_test.go
@@ -69,7 +69,7 @@ func TestEncodeAndDecodePgNumericKeyFDB(t *testing.T) {
 
 	var preEncoded []byte
 	for i := 0; i < len(testCases); i++ {
-		tp, err := EncodePgNumericKeyFDB(testCases[i])
+		tp, err := encodePgNumericKeyFDB(testCases[i])
 		require.NoError(t, err)
 
 		// Make sure the encoded preserves the order.
@@ -81,7 +81,7 @@ func TestEncodeAndDecodePgNumericKeyFDB(t *testing.T) {
 		preEncoded = encoded
 
 		// Make sure decode returns the original value.
-		var decoded = DecodeFDBTuple(tp)
+		var decoded = maybeDecodePgNumericTuple(tp)
 		require.Equal(t, testCases[i], decoded, fmt.Sprintf("Testing: %+v", testCases[i]))
 
 		// Make sure the decoded element can be used in resume query.

--- a/source-postgres/main.go
+++ b/source-postgres/main.go
@@ -10,6 +10,8 @@ import (
 	np "github.com/estuary/connectors/network-proxy-service"
 	"github.com/estuary/connectors/sqlcapture"
 	"github.com/estuary/flow/go/protocols/airbyte"
+	"github.com/estuary/flow/go/protocols/fdb/tuple"
+	"github.com/jackc/pgtype"
 	"github.com/jackc/pgx/v4"
 	"github.com/sirupsen/logrus"
 )
@@ -140,4 +142,20 @@ func (db *postgresDatabase) DefaultSchema(ctx context.Context) (string, error) {
 
 func (db *postgresDatabase) EmptySourceMetadata() sqlcapture.SourceMetadata {
 	return &postgresSource{}
+}
+
+func (db *postgresDatabase) EncodeKeyFDB(key interface{}) (tuple.TupleElement, error) {
+	switch key := key.(type) {
+	case pgtype.Numeric:
+		return EncodePgNumericKeyFDB(key)
+	default:
+		return key, nil
+	}
+}
+
+func (db *postgresDatabase) DecodeKeyFDB(t tuple.TupleElement) interface{} {
+	if d := DecodeFDBTuple(t); d != nil {
+		return d
+	}
+	return t
 }

--- a/sqlcapture/capture.go
+++ b/sqlcapture/capture.go
@@ -299,7 +299,7 @@ func (c *Capture) streamToWatermark(replStream ReplicationStream, watermark stri
 			if err := c.handleChangeEvent(event); err != nil {
 				return fmt.Errorf("error handling replication event: %w", err)
 			}
-		} else if err := results.Patch(streamID, event, c.Database); err != nil {
+		} else if err := results.Patch(streamID, event, rowKey); err != nil {
 			return fmt.Errorf("error patching resultset: %w", err)
 		}
 	}

--- a/sqlcapture/interface.go
+++ b/sqlcapture/interface.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/alecthomas/jsonschema"
+	"github.com/estuary/flow/go/protocols/fdb/tuple"
 )
 
 // ChangeOp encodes a change operation type.
@@ -106,6 +107,12 @@ type Database interface {
 	DefaultSchema(ctx context.Context) (string, error)
 	// Returns an empty instance of the source-specific metadata (used for JSON schema generation).
 	EmptySourceMetadata() SourceMetadata
+	// EncodeRowKeyForFDB converts a key as necessary to produce a TupleElement,
+	// which is encoded as part of a FoundationDB serialized tuple.
+	// Make sure the conversion is partial-order-preserving.
+	EncodeKeyFDB(key interface{}) (tuple.TupleElement, error)
+	// DecodeKeyFDB decodes the result of `EncodeKeyFDB` to its original form.
+	DecodeKeyFDB(t tuple.TupleElement) interface{}
 }
 
 // ReplicationStream represents the process of receiving change events

--- a/sqlcapture/interface.go
+++ b/sqlcapture/interface.go
@@ -112,7 +112,7 @@ type Database interface {
 	// Make sure the conversion is partial-order-preserving.
 	EncodeKeyFDB(key interface{}) (tuple.TupleElement, error)
 	// DecodeKeyFDB decodes the result of `EncodeKeyFDB` to its original form.
-	DecodeKeyFDB(t tuple.TupleElement) interface{}
+	DecodeKeyFDB(t tuple.TupleElement) (interface{}, error)
 }
 
 // ReplicationStream represents the process of receiving change events

--- a/sqlcapture/resultset.go
+++ b/sqlcapture/resultset.go
@@ -102,7 +102,7 @@ func (r *resultSet) Scanned(streamID string) []byte {
 // Patch modifies the buffered results to include the effect of the provided
 // changeEvent. This may simply mean ignoring the event, if it occured on a
 // table which is not in the resultSet or for a row which is not yet included.
-func (r *resultSet) Patch(streamID string, event ChangeEvent, db Database) error {
+func (r *resultSet) Patch(streamID string, event ChangeEvent, rowKey []byte) error {
 	// If a particular table is not represented in the backfill result-set then
 	// patching its changes is a no-op.
 	if r == nil {
@@ -113,20 +113,14 @@ func (r *resultSet) Patch(streamID string, event ChangeEvent, db Database) error
 		return nil
 	}
 
-	var bs, err = encodeRowKey(chunk.keyColumns, event.KeyFields(), db)
-	if err != nil {
-		return fmt.Errorf("error encoding patch key: %w", err)
-	}
-	var rowKey = string(bs)
-
 	// Ignore mutations occurring after the end of the current resultset, unless this
 	// is the final resultset which will complete the backfill.
-	if !chunk.complete && compareTuples([]byte(rowKey), chunk.scanned) > 0 {
+	if !chunk.complete && compareTuples(rowKey, chunk.scanned) > 0 {
 		if logrus.IsLevelEnabled(logrus.DebugLevel) {
 			logrus.WithFields(logrus.Fields{
 				"stream":   streamID,
 				"op":       event.Operation,
-				"rowKey":   base64.StdEncoding.EncodeToString([]byte(rowKey)),
+				"rowKey":   base64.StdEncoding.EncodeToString(rowKey),
 				"chunkEnd": base64.StdEncoding.EncodeToString(chunk.scanned),
 			}).Debug("filtering change")
 		}
@@ -140,16 +134,16 @@ func (r *resultSet) Patch(streamID string, event ChangeEvent, db Database) error
 	// all such inconsistencies by the time the next watermark is reached.
 	switch event.Operation {
 	case InsertOp:
-		chunk.rows[rowKey] = event
+		chunk.rows[string(rowKey)] = event
 	case UpdateOp:
-		chunk.rows[rowKey] = ChangeEvent{
+		chunk.rows[string(rowKey)] = ChangeEvent{
 			Operation: InsertOp,
 			Source:    event.Source,
 			Before:    nil,
 			After:     event.After,
 		}
 	case DeleteOp:
-		delete(chunk.rows, rowKey)
+		delete(chunk.rows, string(rowKey))
 	default:
 		return fmt.Errorf("patched invalid change type %q", event.Operation)
 	}

--- a/sqlcapture/resultset.go
+++ b/sqlcapture/resultset.go
@@ -29,7 +29,7 @@ func newResultSet() *resultSet {
 // Buffer appends new "Insert" events to the buffered range for the specified stream. An
 // empty list of events indicates that the stream is completed, and thus the *range* of the
 // buffer now extends to infinity.
-func (r *resultSet) Buffer(streamID string, keyColumns []string, events []ChangeEvent) error {
+func (r *resultSet) Buffer(streamID string, keyColumns []string, events []ChangeEvent, db Database) error {
 	var chunk, ok = r.streams[streamID]
 	if !ok {
 		chunk = &backfillChunk{keyColumns: keyColumns, rows: make(map[string]ChangeEvent)}
@@ -46,7 +46,7 @@ func (r *resultSet) Buffer(streamID string, keyColumns []string, events []Change
 
 	// Otherwise add the new row to the `rows` map and update `scanned`.
 	for _, event := range events {
-		var bs, err = encodeRowKey(chunk.keyColumns, event.After)
+		var bs, err = encodeRowKey(chunk.keyColumns, event.After, db)
 		if err != nil {
 			return fmt.Errorf("error encoding row key: %w", err)
 		}
@@ -102,7 +102,7 @@ func (r *resultSet) Scanned(streamID string) []byte {
 // Patch modifies the buffered results to include the effect of the provided
 // changeEvent. This may simply mean ignoring the event, if it occured on a
 // table which is not in the resultSet or for a row which is not yet included.
-func (r *resultSet) Patch(streamID string, event ChangeEvent) error {
+func (r *resultSet) Patch(streamID string, event ChangeEvent, db Database) error {
 	// If a particular table is not represented in the backfill result-set then
 	// patching its changes is a no-op.
 	if r == nil {
@@ -113,7 +113,7 @@ func (r *resultSet) Patch(streamID string, event ChangeEvent) error {
 		return nil
 	}
 
-	var bs, err = encodeRowKey(chunk.keyColumns, event.KeyFields())
+	var bs, err = encodeRowKey(chunk.keyColumns, event.KeyFields(), db)
 	if err != nil {
 		return fmt.Errorf("error encoding patch key: %w", err)
 	}

--- a/sqlcapture/tests/tests.go
+++ b/sqlcapture/tests/tests.go
@@ -1,18 +1,11 @@
 package tests
 
 import (
-	"bytes"
 	"context"
-	"fmt"
-	"math"
-	"math/big"
 	"testing"
 	"time"
 
 	"github.com/estuary/connectors/sqlcapture"
-	"github.com/estuary/flow/go/protocols/fdb/tuple"
-	"github.com/jackc/pgtype"
-	"github.com/stretchr/testify/require"
 )
 
 // Run executes the generic SQL capture test suite
@@ -30,7 +23,6 @@ func Run(ctx context.Context, t *testing.T, tb TestBackend) {
 	t.Run("ComplexDataset", func(t *testing.T) { testComplexDataset(ctx, t, tb) })
 	t.Run("CatalogPrimaryKey", func(t *testing.T) { testCatalogPrimaryKey(ctx, t, tb) })
 	t.Run("CatalogPrimaryKeyOverride", func(t *testing.T) { testCatalogPrimaryKeyOverride(ctx, t, tb) })
-	t.Run("TestEncodePgNumeric", func(t *testing.T) { testEncodePgNumeric(t) })
 }
 
 // testSimpleDiscovery creates a new table in the database, performs stream discovery,
@@ -246,135 +238,4 @@ func testCatalogPrimaryKeyOverride(ctx context.Context, t *testing.T, tb TestBac
 		{1990, "XX", "No Such State", 123456},
 	})
 	VerifiedCapture(ctx, t, tb, &catalog, &state, "capture2")
-}
-
-func testEncodePgNumeric(t *testing.T) {
-	var testCases = []struct {
-		input    pgtype.Numeric
-		expected tuple.Tuple
-	}{
-		// Positives.
-		{
-			pgtype.Numeric{Status: pgtype.Present, Int: big.NewInt(1), Exp: 0},
-			[]tuple.TupleElement{20001, []byte("1")}, // "1e0"
-		},
-		{
-			pgtype.Numeric{Status: pgtype.Present, Int: big.NewInt(2), Exp: 0},
-			[]tuple.TupleElement{20001, []byte("2")}, // "2e0"
-		},
-
-		{
-			pgtype.Numeric{Status: pgtype.Present, Int: big.NewInt(1), Exp: -1},
-			[]tuple.TupleElement{20000, []byte("1")}, // "1e-1"
-		},
-		{
-			pgtype.Numeric{Status: pgtype.Present, Int: big.NewInt(1), Exp: -5},
-			[]tuple.TupleElement{19996, []byte("1")}, // "1e-5"
-		},
-		{
-			pgtype.Numeric{Status: pgtype.Present, Int: big.NewInt(12309), Exp: -6},
-			[]tuple.TupleElement{19999, []byte("12309")}, // "12309e-6"
-		},
-		{
-			pgtype.Numeric{Status: pgtype.Present, Int: big.NewInt(1230), Exp: 0},
-			[]tuple.TupleElement{20004, []byte("123")}, // "1230e0"
-		},
-		{
-			pgtype.Numeric{Status: pgtype.Present, Int: big.NewInt(123400), Exp: 3},
-			[]tuple.TupleElement{20009, []byte("1234")}, // "123400e3"
-		},
-		{
-			pgtype.Numeric{Status: pgtype.Present, Int: big.NewInt(12300), Exp: -2},
-			[]tuple.TupleElement{20003, []byte("123")}, // "12300e-2"
-		},
-		{
-			pgtype.Numeric{Status: pgtype.Present, Int: big.NewInt(12300), Exp: -5},
-			[]tuple.TupleElement{20000, []byte("123")}, // "12300e-5"
-		},
-		{
-			pgtype.Numeric{Status: pgtype.Present, Int: big.NewInt(12300), Exp: -10},
-			[]tuple.TupleElement{19995, []byte("123")}, // "12300e-10"
-		},
-		// Zeros.
-		{
-			pgtype.Numeric{Status: pgtype.Present, Int: big.NewInt(0), Exp: 0},
-			[]tuple.TupleElement{0, []byte(nil)}, // "0e0"
-		},
-		{
-			pgtype.Numeric{Status: pgtype.Present, Int: big.NewInt(-0), Exp: 2},
-			[]tuple.TupleElement{0, []byte(nil)}, // "0e2"
-		},
-		{
-			pgtype.Numeric{Status: pgtype.Present, Int: big.NewInt(0), Exp: -2},
-			[]tuple.TupleElement{0, []byte(nil)}, // "0e-2"
-		},
-		// Negatives.
-		{
-			pgtype.Numeric{Status: pgtype.Present, Int: big.NewInt(-1), Exp: 0},
-			[]tuple.TupleElement{-20001, []byte("8:")}, // "-1e0"
-		},
-		{
-			pgtype.Numeric{Status: pgtype.Present, Int: big.NewInt(-2), Exp: 0},
-			[]tuple.TupleElement{-20001, []byte("7:")}, // "-2e0"
-		},
-
-		{
-			pgtype.Numeric{Status: pgtype.Present, Int: big.NewInt(-1), Exp: -1},
-			[]tuple.TupleElement{-20000, []byte("8:")}, // "-1e-1"
-		},
-		{
-			pgtype.Numeric{Status: pgtype.Present, Int: big.NewInt(-1), Exp: -5},
-			[]tuple.TupleElement{-19996, []byte("8:")}, // "-1e-5"
-		},
-		{
-			pgtype.Numeric{Status: pgtype.Present, Int: big.NewInt(-12309), Exp: -6},
-			[]tuple.TupleElement{-19999, []byte("87690:")}, // "-12309e-6"
-		},
-
-		{
-			pgtype.Numeric{Status: pgtype.Present, Int: big.NewInt(-1230), Exp: -0},
-			[]tuple.TupleElement{-20004, []byte("876:")}, // "-1230e0"
-		},
-		{
-			pgtype.Numeric{Status: pgtype.Present, Int: big.NewInt(-123400), Exp: 3},
-			[]tuple.TupleElement{-20009, []byte("8765:")}, // "-123400e3"
-		},
-		{
-			pgtype.Numeric{Status: pgtype.Present, Int: big.NewInt(-12300), Exp: -2},
-			[]tuple.TupleElement{-20003, []byte("876:")}, // "-12300e-2"
-		},
-		{
-			pgtype.Numeric{Status: pgtype.Present, Int: big.NewInt(-12300), Exp: -5},
-			[]tuple.TupleElement{-20000, []byte("876:")}, // "-12300e-5"
-		},
-		{
-			pgtype.Numeric{Status: pgtype.Present, Int: big.NewInt(-12300), Exp: -10},
-			[]tuple.TupleElement{-19995, []byte("876:")}, // "-12300e-10"
-		},
-	}
-	for _, test := range testCases {
-		var actual, err = sqlcapture.EncodePgNumeric(test.input)
-		require.NoError(t, err)
-		require.Equal(t, test.expected, actual)
-	}
-
-	for p1 := 0; p1 < len(testCases); p1++ {
-		for p2 := 0; p2 < len(testCases); p2++ {
-			var f1, f2 float64
-			require.NoError(t, testCases[p1].input.AssignTo(&f1))
-			require.NoError(t, testCases[p2].input.AssignTo(&f2))
-
-			var t1 = tuple.Tuple(testCases[p1].expected).Pack()
-			var t2 = tuple.Tuple(testCases[p2].expected).Pack()
-
-			var message = fmt.Sprintf("Comparing %+v, %+v", testCases[p1], testCases[p2])
-			if math.Abs(f1-f2) < 1e-9 { // Almost equal.
-				require.Equal(t, 0, bytes.Compare(t1, t2), message)
-			} else if f1 > f2 {
-				require.Equal(t, 1, bytes.Compare(t1, t2), message)
-			} else {
-				require.Equal(t, -1, bytes.Compare(t1, t2), message)
-			}
-		}
-	}
 }

--- a/sqlcapture/tuples.go
+++ b/sqlcapture/tuples.go
@@ -2,10 +2,15 @@ package sqlcapture
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/estuary/flow/go/protocols/fdb/tuple"
+	"github.com/jackc/pgtype"
 )
+
+const numericKey = "N"
 
 // encodeRowKey extracts the appropriate key-fields by name from a map and encodes
 // them as a FoundationDB serialized tuple.
@@ -33,6 +38,14 @@ func packTuple(xs []interface{}) (bs []byte, err error) {
 		switch x := x.(type) {
 		case int32:
 			t = append(t, int(x))
+		case pgtype.Numeric:
+			if encodedKey, err := EncodePgNumeric(x); err != nil {
+				return nil, fmt.Errorf("encode pgtype.Numeric: %w", err)
+			} else if encodedBinary, err := x.EncodeBinary(nil, nil); err != nil {
+				return nil, fmt.Errorf("encode binary pgtype Numeric: %w", err)
+			} else {
+				t = append(t, tuple.Tuple{numericKey, encodedKey, encodedBinary})
+			}
 		default:
 			t = append(t, x)
 		}
@@ -60,11 +73,95 @@ func unpackTuple(bs []byte) ([]interface{}, error) {
 	}
 	var xs []interface{}
 	for _, elem := range t {
+		switch elem := elem.(type) {
+		case tuple.Tuple:
+			if len(elem) == 3 {
+				if key, ok := elem[0].(string); ok && key == numericKey {
+					xs = append(xs, elem[2])
+					continue
+				}
+			}
+		}
 		xs = append(xs, elem)
 	}
+
 	return xs, nil
 }
 
 func compareTuples(xs, ys []byte) int {
 	return bytes.Compare(xs, ys)
+}
+
+func reverseNegfraction(digits string) []byte {
+	// The input digits string represents a negative integer, and starts with the `-` sign.
+	// The function performs the following operations:
+	// 1. remove the `-` sign, which is redundant.
+	// 2. reverse each digits to make sure the order between the encoded byte slices is consistent with
+	//    the order between the negative values.
+	//    This is done by replacing each digit x with (9 - x). (replace '0' with '9', '1' with '8', ..., '9' with '0').
+	// 3. Add an sentinel value `0x3a` (ASCII of ":") at the end of the encoded byte slice, to make sure the order of
+	//    encoded byte slices are consistent between a negative value and its prefixes. E.g.
+	//    "-123" (encoded as "876:") is greater than "-1234" (encoded as "8765:").
+
+	const sentinel = 0x3a
+	var b = []byte(digits)
+	for i := 1; i < len(b); i++ {
+		b[i-1] = 0x69 - b[i] // '9' - b[i] + '0'
+	}
+
+	if len(b) > 0 {
+		b[len(b)-1] = sentinel
+	}
+
+	return b
+}
+
+func EncodePgNumeric(n pgtype.Numeric) (tuple.Tuple, error) {
+	if n.Status == pgtype.Null {
+		return nil, errors.New("Null value in Numeric Key Field")
+	} else if n.Status == pgtype.Undefined {
+		return nil, errors.New("Undefined value in Numeric Key Field")
+	} else if n.NaN {
+		return nil, errors.New("NaN value in a Numeric Key Field ")
+	}
+
+	// Conceptually, a pgtype.Numeric is encoded into a tuple of (exponents, fraction),
+	// in which exponents is an int, and fraction is a slice of bytes.
+	// It is ensured the encoded tuple preserves the order of the original numeric value
+	// based on `int` and `byte slice` ordering on both components, respectively.
+
+	// For positive numbers, the fraction is converted from the string of digits in the input without
+	// leading or trailing zeros. and the exponents is set properly to make sure
+	// the represented value = 10 ^ (exponents) * 0.fraction.
+	//   E.g. 0.0041 is represetned by (exp = -2, fraction="41"),
+	//    and 3.14 is represented by (exp = 1, fraction="314")
+
+	// For negative numbers, suppose its absolute value is encoded as (expAbs, fracAbs),
+	// and encoding result of the number is (-expAbs, reverseNegfraction("-fracAbs")),
+	// see func reverseNegfraction for details.
+
+	// In order for the encoding to preserve orders properly, we need to make sure the
+	// exponents of positive numbers are always positive. and this is done by adding a
+	// bias to the encoded exponents, and use the biasedExponents in ordering.
+
+	// According to https://www.postgresql.org/docs/current/datatype-numeric.html,
+	// the lowest value of exponent is -16382. Set the bias to be 20000,
+	// to make sure the biasedExponent of positive n is always positive.
+	const exponentBias = 20000
+
+	// Encoding for 0.
+	var biasedExponent int = 0
+	var fractionBytes []byte = nil
+
+	if n.Int.Sign() == 1 {
+		var str = n.Int.String()
+		biasedExponent = len(str) + int(n.Exp) + exponentBias
+		fractionBytes = []byte(strings.TrimRight(str, "0"))
+	} else if n.Int.Sign() == -1 {
+		var str = n.Int.String()
+		biasedExponent = -(len(str) - 1 + int(n.Exp) + exponentBias)
+		fractionBytes = reverseNegfraction(strings.TrimRight(str, "0"))
+	}
+
+	return []tuple.TupleElement{biasedExponent, fractionBytes}, nil
 }

--- a/sqlcapture/tuples.go
+++ b/sqlcapture/tuples.go
@@ -2,22 +2,20 @@ package sqlcapture
 
 import (
 	"bytes"
-	"errors"
 	"fmt"
-	"strings"
 
 	"github.com/estuary/flow/go/protocols/fdb/tuple"
-	"github.com/jackc/pgtype"
 )
-
-const numericKey = "N"
 
 // encodeRowKey extracts the appropriate key-fields by name from a map and encodes
 // them as a FoundationDB serialized tuple.
-func encodeRowKey(key []string, fields map[string]interface{}) ([]byte, error) {
+func encodeRowKey(key []string, fields map[string]interface{}, db Database) ([]byte, error) {
 	var xs = make([]interface{}, len(key))
+	var err error
 	for i, elem := range key {
-		xs[i] = fields[elem]
+		if xs[i], err = db.EncodeKeyFDB(fields[elem]); err != nil {
+			return nil, fmt.Errorf("encode row key: %w", err)
+		}
 	}
 	return packTuple(xs)
 }
@@ -38,14 +36,6 @@ func packTuple(xs []interface{}) (bs []byte, err error) {
 		switch x := x.(type) {
 		case int32:
 			t = append(t, int(x))
-		case pgtype.Numeric:
-			if encodedKey, err := EncodePgNumeric(x); err != nil {
-				return nil, fmt.Errorf("encode pgtype.Numeric: %w", err)
-			} else if encodedBinary, err := x.EncodeBinary(nil, nil); err != nil {
-				return nil, fmt.Errorf("encode binary pgtype Numeric: %w", err)
-			} else {
-				t = append(t, tuple.Tuple{numericKey, encodedKey, encodedBinary})
-			}
 		default:
 			t = append(t, x)
 		}
@@ -66,23 +56,14 @@ func packTuple(xs []interface{}) (bs []byte, err error) {
 	return tuple.Tuple(t).Pack(), nil
 }
 
-func unpackTuple(bs []byte) ([]interface{}, error) {
+func unpackTuple(bs []byte, db Database) ([]interface{}, error) {
 	var t, err = tuple.Unpack(bs)
 	if err != nil {
 		return nil, err
 	}
 	var xs []interface{}
 	for _, elem := range t {
-		switch elem := elem.(type) {
-		case tuple.Tuple:
-			if len(elem) == 3 {
-				if key, ok := elem[0].(string); ok && key == numericKey {
-					xs = append(xs, elem[2])
-					continue
-				}
-			}
-		}
-		xs = append(xs, elem)
+		xs = append(xs, db.DecodeKeyFDB(elem))
 	}
 
 	return xs, nil
@@ -90,78 +71,4 @@ func unpackTuple(bs []byte) ([]interface{}, error) {
 
 func compareTuples(xs, ys []byte) int {
 	return bytes.Compare(xs, ys)
-}
-
-func reverseNegfraction(digits string) []byte {
-	// The input digits string represents a negative integer, and starts with the `-` sign.
-	// The function performs the following operations:
-	// 1. remove the `-` sign, which is redundant.
-	// 2. reverse each digits to make sure the order between the encoded byte slices is consistent with
-	//    the order between the negative values.
-	//    This is done by replacing each digit x with (9 - x). (replace '0' with '9', '1' with '8', ..., '9' with '0').
-	// 3. Add an sentinel value `0x3a` (ASCII of ":") at the end of the encoded byte slice, to make sure the order of
-	//    encoded byte slices are consistent between a negative value and its prefixes. E.g.
-	//    "-123" (encoded as "876:") is greater than "-1234" (encoded as "8765:").
-
-	const sentinel = 0x3a
-	var b = []byte(digits)
-	for i := 1; i < len(b); i++ {
-		b[i-1] = 0x69 - b[i] // '9' - b[i] + '0'
-	}
-
-	if len(b) > 0 {
-		b[len(b)-1] = sentinel
-	}
-
-	return b
-}
-
-func EncodePgNumeric(n pgtype.Numeric) (tuple.Tuple, error) {
-	if n.Status == pgtype.Null {
-		return nil, errors.New("Null value in Numeric Key Field")
-	} else if n.Status == pgtype.Undefined {
-		return nil, errors.New("Undefined value in Numeric Key Field")
-	} else if n.NaN {
-		return nil, errors.New("NaN value in a Numeric Key Field ")
-	}
-
-	// Conceptually, a pgtype.Numeric is encoded into a tuple of (exponents, fraction),
-	// in which exponents is an int, and fraction is a slice of bytes.
-	// It is ensured the encoded tuple preserves the order of the original numeric value
-	// based on `int` and `byte slice` ordering on both components, respectively.
-
-	// For positive numbers, the fraction is converted from the string of digits in the input without
-	// leading or trailing zeros. and the exponents is set properly to make sure
-	// the represented value = 10 ^ (exponents) * 0.fraction.
-	//   E.g. 0.0041 is represetned by (exp = -2, fraction="41"),
-	//    and 3.14 is represented by (exp = 1, fraction="314")
-
-	// For negative numbers, suppose its absolute value is encoded as (expAbs, fracAbs),
-	// and encoding result of the number is (-expAbs, reverseNegfraction("-fracAbs")),
-	// see func reverseNegfraction for details.
-
-	// In order for the encoding to preserve orders properly, we need to make sure the
-	// exponents of positive numbers are always positive. and this is done by adding a
-	// bias to the encoded exponents, and use the biasedExponents in ordering.
-
-	// According to https://www.postgresql.org/docs/current/datatype-numeric.html,
-	// the lowest value of exponent is -16382. Set the bias to be 20000,
-	// to make sure the biasedExponent of positive n is always positive.
-	const exponentBias = 20000
-
-	// Encoding for 0.
-	var biasedExponent int = 0
-	var fractionBytes []byte = nil
-
-	if n.Int.Sign() == 1 {
-		var str = n.Int.String()
-		biasedExponent = len(str) + int(n.Exp) + exponentBias
-		fractionBytes = []byte(strings.TrimRight(str, "0"))
-	} else if n.Int.Sign() == -1 {
-		var str = n.Int.String()
-		biasedExponent = -(len(str) - 1 + int(n.Exp) + exponentBias)
-		fractionBytes = reverseNegfraction(strings.TrimRight(str, "0"))
-	}
-
-	return []tuple.TupleElement{biasedExponent, fractionBytes}, nil
 }

--- a/sqlcapture/tuples.go
+++ b/sqlcapture/tuples.go
@@ -63,7 +63,11 @@ func unpackTuple(bs []byte, db Database) ([]interface{}, error) {
 	}
 	var xs []interface{}
 	for _, elem := range t {
-		xs = append(xs, db.DecodeKeyFDB(elem))
+		if decoded, err := db.DecodeKeyFDB(elem); err != nil {
+			return nil, fmt.Errorf("unpack tuple: %w", err)
+		} else {
+			xs = append(xs, decoded)
+		}
 	}
 
 	return xs, nil


### PR DESCRIPTION
**Description:**

Per discussions, adding the logic to transform the numeric fields in keys in to a tuple, to make sure 1. the tuple conforms to the FoundationDB tuple format. 2. The fdb-encoded byte slice preserve the order of the original numeric value.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:*
(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

