### PR TITLE
change for source mysql

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -80,7 +80,11 @@ jobs:
           docker-compose --file ${{ matrix.connector }}/docker-compose.yaml up --detach
 
       - name: Start Open SSH server
-        if: matrix.connector == 'source-postgres'
+        if: |
+          contains('
+            source-mysql
+            source-postgres
+            ', matrix.connector)
         run: |
           cp -r network-proxy-service/sshforwarding/test_sshd_configs /tmp/test_sshd_configs &&
           docker-compose --file /tmp/test_sshd_configs/docker-compose.yaml up --detach openssh-server
@@ -144,18 +148,9 @@ jobs:
 
         run: CONNECTOR=${{ matrix.connector }} VERSION=local-test-tag ./tests/run.sh;
 
-      - name: Source connector ${{ matrix.connector }} integration tests with SSH forwarding
-        if: |
-          contains('
-            source-postgres
-            ', matrix.connector)
+      - name: Source connector postgres integration tests with SSH forwarding
+        if: matrix.connector == 'source-postgres'
         env:
-          GCP_SERVICE_ACCOUNT_KEY: ${{ secrets.GCP_SERVICE_ACCOUNT_KEY }}
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          DEFAULT_AWS_REGION: ${{ secrets.DEFAULT_AWS_REGION }}
-          AWS_DEFAULT_OUTPUT: json
-
           # Compare to: https://www.postgresql.org/docs/current/libpq-envars.html
           PGDATABASE: flow
           PGHOST: localhost
@@ -167,7 +162,27 @@ jobs:
           SSHENDPOINT: ssh://localhost:2222
           SSHUSER: flowssh
           PRIVATE_KEY_FILE_PATH: network-proxy-service/sshforwarding/test_sshd_configs/keys/id_rsa
-          LOCALPORT: 9876
+          LOCALPORT: 15432
+          SSH_FORWARDING_ENABLED: true
+
+        run: CONNECTOR=${{ matrix.connector }} VERSION=local-test-tag ./tests/run.sh;
+
+
+      - name: Source connector mysql integration tests with SSH forwarding
+        if: matrix.connector == 'source-mysql'
+        env:
+          MYSQL_DATABASE: test
+          MYSQL_HOST: 127.0.0.1
+          MYSQL_PORT: 3306
+          MYSQL_USER: root
+          MYSQL_PWD: flow
+          MYSQL_SERVERID: 12345
+
+          # Based on configs in network-proxy-service/sshforwarding/test_sshd_configs/docker-compose.yaml
+          SSHENDPOINT: ssh://localhost:2222
+          SSHUSER: flowssh
+          PRIVATE_KEY_FILE_PATH: network-proxy-service/sshforwarding/test_sshd_configs/keys/id_rsa
+          LOCALPORT: 13306
           SSH_FORWARDING_ENABLED: true
 
         run: CONNECTOR=${{ matrix.connector }} VERSION=local-test-tag ./tests/run.sh;

--- a/tests/materialize/run.sh
+++ b/tests/materialize/run.sh
@@ -3,7 +3,7 @@
 set -e
 
 # Flow image / container name used in testing.
-FLOW_IMAGE="ghcr.io/estuary/flow:dev"
+FLOW_IMAGE="ghcr.io/estuary/flow:dev-152-g59f8df60"
 # Prefix of the containers running flowctl via Flow image.
 FLOW_CONTAINER_NAME_PREFIX=flowctl-${CONNECTOR}
 

--- a/tests/source-mysql/setup.sh
+++ b/tests/source-mysql/setup.sh
@@ -4,14 +4,42 @@ set -e
 export TEST_STREAM="estuary_test_$(shuf -zer -n6 {a..z} | tr -d '\0')"
 export RESOURCE="{ stream: ${TEST_STREAM} }"
 
-config_json_template='{
-    "address": "$MYSQL_HOST:$MYSQL_PORT",
-    "user": "$MYSQL_USER",
-    "password": "$MYSQL_PWD",
-    "dbname": "$MYSQL_DATABASE",
-    "server_id": $MYSQL_SERVERID
-}'
 
+if [[ "${SSH_FORWARDING_ENABLED}" == "true" ]]
+then
+    if [[ ! -f "${PRIVATE_KEY_FILE_PATH}" ]]; then
+        bail "${PRIVATE_KEY_FILE_PATH} does not exists."
+    fi
+    export PRIVATE_KEY="$(awk '{printf "%s\\n", $0}' ${PRIVATE_KEY_FILE_PATH})"
+
+    config_json_template='{
+        "address": "localhost:$LOCALPORT",
+        "user": "$MYSQL_USER",
+        "password": "$MYSQL_PWD",
+        "dbname": "$MYSQL_DATABASE",
+        "server_id": $MYSQL_SERVERID,
+        "networkProxy": {
+            "sshForwarding": {
+              "sshEndpoint": "$SSHENDPOINT",
+              "user": "$SSHUSER",
+              "forwardHost": "$MYSQL_HOST",
+              "forwardPort": $MYSQL_PORT,
+              "privateKey": "$PRIVATE_KEY",
+              "localPort": $LOCALPORT
+            }
+        }
+    }'
+else
+    config_json_template='{
+        "address": "$MYSQL_HOST:$MYSQL_PORT",
+        "user": "$MYSQL_USER",
+        "password": "$MYSQL_PWD",
+        "dbname": "$MYSQL_DATABASE",
+        "server_id": $MYSQL_SERVERID
+    }'
+fi
+
+echo "$(echo "$config_json_template" | envsubst)"
 export CONNECTOR_CONFIG="$(echo "$config_json_template" | envsubst | jq -c)"
 echo "Connector configuration is: ${CONNECTOR_CONFIG}".
 


### PR DESCRIPTION
**Description:**

Enable `network_proxy` for `source-mysql` connector.
- The first commit made the changes to the connector, so that the networkproxy specifications are included in the connector configuration, and the related infra is ready to start the proxy service when needed.
- The second commit added to an e2e integration test for the connector with SSH forwarding enabled. 

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**
Similar to `source-postgreql`, the users of `source-mysql` connector need to be aware of the[sshforwarding config doc](https://docs.estuary.dev/guides/connect-network/) if they need to set up ssh forwarding serevice.

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

