### PR TITLE
source-mysql: Fail cleanly when `SHOW MASTER STATUS` is empty

### DIFF
--- a/source-mysql/replication.go
+++ b/source-mysql/replication.go
@@ -48,6 +48,9 @@ func (db *mysqlDatabase) StartReplication(ctx context.Context, startCursor strin
 		if err != nil {
 			return nil, fmt.Errorf("error getting latest binlog position: %w", err)
 		}
+		if len(results.Values) == 0 {
+			return nil, fmt.Errorf("failed to query latest binlog position (is binary logging enabled on %q?)", host)
+		}
 		var row = results.Values[0]
 		pos.Name = string(row[0].AsString())
 		pos.Pos = uint32(row[1].AsInt64())


### PR DESCRIPTION
**Description:**

When connecting to a read replica where `log_bin = OFF` the query `SHOW MASTER STATUS` will return an empty result set (but no error), which currently panics the connector.

This setup won't actually work, so it's correct to fail here, but the failure should be clean, with an error message that suggests the solution.
