### PR TITLE
source-mysql: Ignore PreviousGTIDsEvent

### DIFF
--- a/source-mysql/replication.go
+++ b/source-mysql/replication.go
@@ -189,6 +189,8 @@ func (rs *mysqlReplicationStream) run(ctx context.Context) error {
 		case *replication.GTIDEvent:
 			logrus.WithField("data", data).Trace("GTID Event")
 			rs.gtidTimestamp = data.OriginalCommitTime()
+		case *replication.PreviousGTIDsEvent:
+			logrus.WithField("gtids", data.GTIDSets).Trace("PreviousGTIDs Event")
 		case *replication.QueryEvent:
 			logrus.WithField("data", data).Trace("Query Event")
 		case *replication.RotateEvent:


### PR DESCRIPTION
**Description:**

This event appears to be related to binlog segment rotation, and is used to establish an understanding of "what came before" a given file. Since we're not currently using/supporting GTID-based cursors, it is safe to ignore these events.

This change is untested (other than verifying that it doesn't break any existing test cases), because it would take nontrivial work to trigger binlog segment rotation and the fix itself is simple enough that it didn't seem worth the effort to set that up.