### PR TITLE
Allow underscores in Rockset names

### DIFF
--- a/materialize-rockset/driver.go
+++ b/materialize-rockset/driver.go
@@ -122,7 +122,7 @@ func (r *resource) SetDefaults() {
 
 func validateRocksetName(field string, value string) error {
 	// Alphanumeric or dash
-	if match, err := regexp.MatchString("\\A[[:alnum:]-]+\\z", value); err != nil {
+	if match, err := regexp.MatchString("\\A[[:alnum:]_-]+\\z", value); err != nil {
 		return fmt.Errorf("malformed regexp: %v", err)
 	} else if !match {
 		return fmt.Errorf("%s must be alphanumeric. got: %s", field, value)

--- a/materialize-rockset/driver_test.go
+++ b/materialize-rockset/driver_test.go
@@ -30,7 +30,7 @@ func TestRocksetResource(t *testing.T) {
 	var too_ascii = resource{Workspace: "must only include letters and numbers", Collection: "widgets"}
 	require.Error(t, too_ascii.Validate())
 
-	var valid = resource{Workspace: "testing", Collection: "widgets"}
+	var valid = resource{Workspace: "testing-33", Collection: "widgets_1"}
 	require.Nil(t, valid.Validate())
 }
 


### PR DESCRIPTION
**Description:**

Rockset allows underscores, but our validation regex was disallowing
them. This just updates the validation regex to match underscores.


**Workflow steps:** n/a

**Documentation links affected:** n/a

**Notes for reviewers:** n/a

