### PR TITLE
Various logging improvements to source-mysql

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -31,6 +31,7 @@ require (
 	github.com/mattn/go-sqlite3 v2.0.3+incompatible
 	github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8 // indirect
 	github.com/prometheus/common v0.31.1 // indirect
+	github.com/siddontang/go-log v0.0.0-20190221022429-1e957dd83bed // indirect
 	github.com/sirupsen/logrus v1.8.1
 	github.com/snowflakedb/gosnowflake v1.6.2
 	github.com/stretchr/testify v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -607,6 +607,8 @@ github.com/siddontang/go v0.0.0-20180604090527-bdc77568d726 h1:xT+JlYxNGqyT+XcU8
 github.com/siddontang/go v0.0.0-20180604090527-bdc77568d726/go.mod h1:3yhqj7WBBfRhbBlzyOC3gUxftwsU0u8gqevxwIHQpMw=
 github.com/siddontang/go-log v0.0.0-20180807004314-8d05993dda07 h1:oI+RNwuC9jF2g2lP0u0cVEEZrc/AYBCuFdvwrLWM/6Q=
 github.com/siddontang/go-log v0.0.0-20180807004314-8d05993dda07/go.mod h1:yFdBgwXP24JziuRl2NMUahT7nGLNOKi1SIiFxMttVD4=
+github.com/siddontang/go-log v0.0.0-20190221022429-1e957dd83bed h1:KMgQoLJGCq1IoZpLZE3AIffh9veYWoVlsvA4ib55TMM=
+github.com/siddontang/go-log v0.0.0-20190221022429-1e957dd83bed/go.mod h1:yFdBgwXP24JziuRl2NMUahT7nGLNOKi1SIiFxMttVD4=
 github.com/sirupsen/logrus v1.0.5/go.mod h1:pMByvHTf9Beacp5x1UXfOR9xyW/9antXMhjMPG0dEzc=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.1/go.mod h1:ni0Sbl8bgC9z8RoU9G6nDWqqs/fq4eDPysMBDgk/93Q=

--- a/source-mysql/replication.go
+++ b/source-mysql/replication.go
@@ -195,7 +195,11 @@ func (rs *mysqlReplicationStream) run(ctx context.Context) error {
 		case *replication.PreviousGTIDsEvent:
 			logrus.WithField("gtids", data.GTIDSets).Trace("PreviousGTIDs Event")
 		case *replication.QueryEvent:
-			logrus.WithField("data", data).Trace("Query Event")
+			// Receiving a query event isn't _necessarily_ a problem, but it could be an indication
+			// that the server's `binlog_format` is not set correctly. Even when it's correctly set
+			// to `ROW`, Query events will still be sent for DDL statements, so we don't want to
+			// return an error here, but we do want these logs to be fairly visible.
+			logrus.WithField("data", data).Info("Query Event")
 		case *replication.RotateEvent:
 			logrus.WithField("data", data).Trace("Rotate Event")
 		case *replication.FormatDescriptionEvent:

--- a/sqlcapture/capture.go
+++ b/sqlcapture/capture.go
@@ -113,6 +113,7 @@ func (c *Capture) Run(ctx context.Context) error {
 			return fmt.Errorf("error performing backfill: %w", err)
 		}
 	}
+	logrus.Debug("finished backfilling tables")
 
 	// Once there is no more backfilling to do, just stream changes forever and emit
 	// state updates on every transaction commit.
@@ -329,6 +330,7 @@ func (c *Capture) emitBuffered(results *resultSet) error {
 }
 
 func (c *Capture) backfillStreams(ctx context.Context, streams []string) (*resultSet, error) {
+	logrus.WithField("streams", streams).Debug("backfilling streams")
 	var results = newResultSet()
 
 	// TODO(wgd): Add a sanity-check assertion that the current watermark value


### PR DESCRIPTION
**Description:**

The go-mysql library uses a separate logging framework, with some pretty
terrible defaults. This adds explicit configuration of that logger so
that it logs to stderr instead of stdout, and so that the log level
matches the level that's used by logrus.

Also adds a few log statements to aid in debugging.

**Workflow steps:** n/a

**Documentation links affected:** n/a

**Notes for reviewers:** n/a

