### PR TITLE
source-postgres and source-mysql: Validate watermarksTable value

### DIFF
--- a/source-mysql/main.go
+++ b/source-mysql/main.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/alecthomas/jsonschema"
 	"github.com/estuary/connectors/sqlcapture"
@@ -67,7 +68,7 @@ type Config struct {
 	DBName   string `json:"dbname" jsonschema:"description=Name of the database to connect to."`
 	ServerID int    `json:"server_id" jsonschema:"description=Server ID for replication."`
 
-	WatermarksTable string `json:"watermarks_table,omitempty" jsonschema:"default=flow.watermarks,description=The name of the table used for watermark writes during backfills."`
+	WatermarksTable string `json:"watermarks_table,omitempty" jsonschema:"default=flow.watermarks,description=The name of the table used for watermark writes during backfills. Must be fully-qualified in '<schema>.<table>' form."`
 }
 
 // Validate checks that the configuration possesses all required properties.
@@ -82,6 +83,9 @@ func (c *Config) Validate() error {
 		if req[1] == "" {
 			return fmt.Errorf("missing '%s'", req[0])
 		}
+	}
+	if c.WatermarksTable != "" && !strings.Contains(c.WatermarksTable, ".") {
+		return fmt.Errorf("config parameter 'watermarksTable' must be fully-qualified as '<schema>.<table>': %q", c.WatermarksTable)
 	}
 	if c.ServerID == 0 {
 		return fmt.Errorf("missing 'server_id'")


### PR DESCRIPTION
**Description:**

The config parameter 'watermarksTable' must be fully-qualified in `'<schema>.<table>'` form in order for the watermark-change detection logic to work properly.

This change improves things slightly by mentioning that fact in the description (and thus in the placeholder config.yaml generated by `flowctl discover`) and validating that (if it's set at all) the watermarksTable property must contain a period. It's not perfect, but it should blunt that rough edge a bit for now.

This would probably have helped with https://github.com/estuary/flow/issues/398