### PR TITLE
adding json annotation

### DIFF
--- a/filesource/filesource.go
+++ b/filesource/filesource.go
@@ -465,7 +465,7 @@ func (r *reader) emit(lines []json.RawMessage) error {
 	var stateWrapper = &struct {
 		Type  airbyte.MessageType `json:"type"`
 		State struct {
-			Data States
+			Data States `json:"data"`
 		} `json:"state,omitempty"`
 	}{
 		Type: airbyte.MessageTypeState,


### PR DESCRIPTION
**Description:**

Without the json-field annotation, the `Data` field in the struct `State`  of `filesource.go`  is serialized as `Data` with capitalized `D`. This is inconsistent with the [specification](https://github.com/estuary/flow/blob/master/go/protocols/airbyte/catalog.go#L199) in the protocol, which requires an uninitialized `d`.    
Go  is flexible to handle the inconsistency during deserialization, but Rust has more strict checking imposed, and the work to allow `case_insensitive` checking is still [on-going](https://github.com/serde-rs/serde/pull/1902). So it might be easier to fix the json annotation here, unless there is any other considerations.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

