### PR TITLE
wgd/sqlcapture-logging

### DIFF
--- a/source-mysql/replication.go
+++ b/source-mysql/replication.go
@@ -54,9 +54,10 @@ func (db *mysqlDatabase) StartReplication(ctx context.Context, startCursor strin
 		var row = results.Values[0]
 		pos.Name = string(row[0].AsString())
 		pos.Pos = uint32(row[1].AsInt64())
-		logrus.WithField("pos", pos).Info("initialized binlog position")
+		logrus.WithField("pos", pos).Debug("initialized binlog position")
 	}
 
+	logrus.WithFields(logrus.Fields{"pos": pos}).Info("starting replication")
 	streamer, err := syncer.StartSync(pos)
 	if err != nil {
 		return nil, fmt.Errorf("error starting binlog sync: %w", err)

--- a/source-postgres/replication.go
+++ b/source-postgres/replication.go
@@ -51,7 +51,7 @@ func (db *postgresDatabase) StartReplication(ctx context.Context, startCursor st
 		"startLSN":    startLSN,
 		"publication": publication,
 		"slot":        slot,
-	}).Debug("starting replication")
+	}).Info("starting replication")
 
 	var stream = &replicationStream{
 		replSlot:        slot,

--- a/sqlcapture/capture.go
+++ b/sqlcapture/capture.go
@@ -98,6 +98,7 @@ func (c *Capture) Run(ctx context.Context) error {
 	// updating the state to reflect catalog changes, and then later it is
 	// plumbed through so that value translation can take column types into
 	// account.
+	logrus.Info("discovering tables")
 	c.discovery, err = c.Database.DiscoverTables(ctx)
 	if err != nil {
 		return fmt.Errorf("error discovering database tables: %w", err)
@@ -136,10 +137,6 @@ func (c *Capture) Run(ctx context.Context) error {
 		}
 		targetWatermark = watermark
 	}
-	logrus.WithFields(logrus.Fields{
-		"tail":      c.Catalog.Tail,
-		"watermark": targetWatermark,
-	}).Info("streaming until watermark")
 	return c.streamToWatermark(replStream, targetWatermark, nil)
 }
 
@@ -240,7 +237,7 @@ func (c *Capture) updateState(ctx context.Context) error {
 }
 
 func (c *Capture) streamToWatermark(replStream ReplicationStream, watermark string, results *resultSet) error {
-	logrus.WithField("watermark", watermark).Debug("streaming to watermark")
+	logrus.WithField("watermark", watermark).Info("streaming to watermark")
 	var watermarksTable = c.Database.WatermarksTable()
 	var watermarkReached = false
 	for event := range replStream.Events() {
@@ -336,7 +333,7 @@ func (c *Capture) emitBuffered(results *resultSet) error {
 }
 
 func (c *Capture) backfillStreams(ctx context.Context, streams []string) (*resultSet, error) {
-	logrus.WithField("streams", streams).Debug("backfilling streams")
+	logrus.WithField("streams", streams).Info("backfilling streams")
 	var results = newResultSet()
 
 	// TODO(wgd): Add a sanity-check assertion that the current watermark value


### PR DESCRIPTION
**Description:**

Tweaks log levels and adds some new messages so that `source-postgres` and `source-mysql` captures will indicate more fine-grained status when looking at `flowctl logs`.

The most substantial part of this change is some new logic in `streamToWatermark` which will log `"replication stream idle"` after 60s elapses without any replication events being received, and which will log `"replication stream progress"` upon receiving a replication event if it hasn't already logged progress in the past 60s.