### PR TITLE
github workflows: fix gcloud branch pinning to @v0

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -55,7 +55,7 @@ jobs:
 
       - name: Set up Cloud SDK
         if: matrix.connector == 'source-gcs'
-        uses: google-github-actions/setup-gcloud@master
+        uses: google-github-actions/setup-gcloud@v0
         with:
           project_id: ${{ secrets.GCP_PROJECT_ID }}
           service_account_key: ${{ secrets.GCP_SERVICE_ACCOUNT_KEY }}


### PR DESCRIPTION
See https://github.com/google-github-actions/setup-gcloud/issues/539

**Description:**

GitHub workflows are complaining and failing at the moment because of this: https://github.com/estuary/connectors/runs/5642539364?check_suite_focus=true#step:6:17

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

