### PR TITLE
materialize-firebolt: store JSON as marshalled string, allow nested keys

### DIFF
--- a/materialize-firebolt/schemalate/run.go
+++ b/materialize-firebolt/schemalate/run.go
@@ -10,6 +10,7 @@ import (
 	pm "github.com/estuary/flow/go/protocols/materialize"
 	proto "github.com/gogo/protobuf/proto"
 	log "github.com/sirupsen/logrus"
+	"os"
 	"os/exec"
 )
 
@@ -152,6 +153,7 @@ func Run(
 	if err != nil {
 		return nil, fmt.Errorf("fetching output: %w. With stdout %s and stderr: %s", err, out, stderr.String())
 	}
+	os.Stderr.WriteString(stderr.String())
 
 	return out, nil
 }

--- a/materialize-firebolt/transactor.go
+++ b/materialize-firebolt/transactor.go
@@ -163,13 +163,13 @@ func (t *transactor) projectDocument(spec *pf.MaterializationSpec_Binding, keys 
 
 	// Add the keys to the document.
 	for i, value := range keys {
-		var propName = strings.ReplaceAll(spec.FieldSelection.Keys[i], "/", "_")
+		var propName = spec.FieldSelection.Keys[i]
 		document[propName] = value
 	}
 
 	// Add the non-keys to the document.
 	for i, value := range values {
-		var propName = strings.ReplaceAll(spec.FieldSelection.Values[i], "/", "_")
+		var propName = spec.FieldSelection.Values[i]
 
 		if raw, ok := value.([]byte); ok {
 			var nestedObject = make(map[string]interface{})

--- a/materialize-firebolt/transactor.go
+++ b/materialize-firebolt/transactor.go
@@ -175,16 +175,10 @@ func (t *transactor) projectDocument(spec *pf.MaterializationSpec_Binding, keys 
 			var nestedObject = make(map[string]interface{})
 			err := json.Unmarshal(raw, &nestedObject)
 
-			// If we can parse this raw json as an object, we marshal it
-			// so it can be stored as a stringified JSON object, since
-			// Firebolt does not support JSON objects.
+			// If we can parse this raw json as an object, we store it as a
+			// stringified JSON object, since Firebolt does not support JSON objects.
 			if err == nil {
-				obj, err := json.Marshal(nestedObject)
-				if err != nil {
-					return nil, fmt.Errorf("failed to serialize the nested object: %w", err)
-				}
-
-				document[propName] = string(obj)
+				document[propName] = string(raw)
 			} else {
 				document[propName] = json.RawMessage(raw)
 			}


### PR DESCRIPTION
**Description:**

- ~Allows for document keys with `/` to be stored by replacing the `/` with `_` to be compatible with Firebolt~
- In case of JSON objects, marshals them into a string and then stores them as a string to compensate for Firebolt's lack of support for actual JSON objects

**Workflow steps:**

See the other PR https://github.com/estuary/flow/pull/423

**Documentation links affected:**

N/A

**Notes for reviewers:**

See the other PR https://github.com/estuary/flow/pull/423

