### PR TITLE
firebolt: upload files using pipes instead of bytes

### DIFF
--- a/materialize-firebolt/transactor.go
+++ b/materialize-firebolt/transactor.go
@@ -196,7 +196,7 @@ func (t *transactor) Store(it *pm.StoreIterator) error {
 	var uploader = s3manager.NewUploader(sess)
 
 	var pipes = make([]*io.PipeWriter, len(t.bindings))
-	g, ctx := errgroup.WithContext(context.Background())
+	g, ctx := errgroup.WithContext(it.Context())
 
 	for it.Next() {
 		var doc, err = t.projectDocument(t.bindings[it.Binding].spec, it.Key, it.Values)


### PR DESCRIPTION
**Description:**

- Changes the way the files are uploaded to use pipes instead of `append(bytes)`
- See the discussion [here](https://github.com/estuary/connectors/pull/146#discussion_r834665869) for the motivation behind this PR

**Workflow steps:**

N/A

**Documentation links affected:**

N/A

**Notes for reviewers:**

See https://github.com/estuary/connectors/pull/146#discussion_r834665869

