### PR TITLE
Phil/postgres datetime

### DIFF
--- a/materialize-postgres/driver.go
+++ b/materialize-postgres/driver.go
@@ -103,7 +103,7 @@ func newPostgresDriver() pm.DriverServer {
 			if err != nil {
 				return nil, fmt.Errorf("opening Postgres database: %w", err)
 			}
-			return sqlDriver.NewStdEndpoint(parsed, db, sqlDriver.PostgresSQLGenerator(), sqlDriver.DefaultFlowTables("")), nil
+			return sqlDriver.NewStdEndpoint(parsed, db, PostgresSQLGenerator(), sqlDriver.DefaultFlowTables("")), nil
 		},
 		NewTransactor: func(
 			ctx context.Context,

--- a/materialize-postgres/sqlgen.go
+++ b/materialize-postgres/sqlgen.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/estuary/flow/go/protocols/materialize/sql"
+)
+
+// PostgresSQLGenerator returns a SQLGenerator for the postgresql SQL dialect.
+func PostgresSQLGenerator() sql.Generator {
+	var typeMappings sql.TypeMapper = sql.NullableTypeMapping{
+		NotNullText: "NOT NULL",
+		Inner: sql.ColumnTypeMapper{
+			sql.INTEGER: sql.RawConstColumnType("BIGINT"),
+			sql.NUMBER:  sql.RawConstColumnType("DOUBLE PRECISION"),
+			sql.BOOLEAN: sql.RawConstColumnType("BOOLEAN"),
+			sql.OBJECT:  sql.RawConstColumnType("JSON"),
+			sql.ARRAY:   sql.RawConstColumnType("JSON"),
+			sql.BINARY:  sql.RawConstColumnType("BYTEA"),
+			sql.STRING: sql.StringTypeMapping{
+				Default: sql.RawConstColumnType("TEXT"),
+			},
+		},
+	}
+
+	return sql.Generator{
+		CommentRenderer:    sql.LineCommentRenderer(),
+		IdentifierRenderer: sql.NewRenderer(nil, sql.DoubleQuotesWrapper(), sql.DefaultUnwrappedIdentifiers),
+		ValueRenderer:      sql.NewRenderer(sql.DefaultQuoteSanitizer, sql.SingleQuotesWrapper(), nil),
+		Placeholder:        PostgresParameterPlaceholder,
+		TypeMappings:       typeMappings,
+	}
+}
+
+// PostgresParameterPlaceholder returns $N style parameters where N is the parameter number
+// starting at 1.
+func PostgresParameterPlaceholder(parameterIndex int) string {
+	// parameterIndex starts at 0, but postgres parameters start at $1
+	return fmt.Sprintf("$%d", parameterIndex+1)
+}

--- a/materialize-postgres/sqlgen.go
+++ b/materialize-postgres/sqlgen.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/estuary/flow/go/protocols/materialize/sql"
 )
@@ -19,6 +20,17 @@ func PostgresSQLGenerator() sql.Generator {
 			sql.BINARY:  sql.RawConstColumnType("BYTEA"),
 			sql.STRING: sql.StringTypeMapping{
 				Default: sql.RawConstColumnType("TEXT"),
+				ByFormat: map[string]sql.TypeMapper{
+					// This format is for RFC3339 timestamps. As of this writing, Flow's schema
+					// validation does not actually validate that String values match their declared
+					// format, so there's no guarantee that the values will parse successfully here.
+					"date-time": sql.ConstColumnType{
+						SQLType: "TIMESTAMPTZ",
+						ValueConverter: func(in interface{}) (interface{}, error) {
+							return time.Parse(time.RFC3339Nano, in.(string))
+						},
+					},
+				},
 			},
 		},
 	}


### PR DESCRIPTION
**Description:**

- Migrates the `PostgresSQLGenerator` from the Flow repo into the connectors repo.
- Adds support for materializing `date-time` string values as `TIMESTAMPTZ` columns.

**WARNING:** Once this is merged, the `:dev` tag will start to use this new behavior, which would break any existing materializations that are using `TEXT` for timestamps. To my knowledge, there are no existing materializations that will be affected, so it may not be an issue at all. If there are any affected materializations, then I _think_ that the best way to handle this is to pin their images to a specific tag. As of this writing, this would be `ghcr.io/estuary/materialize-postgres:16bb090`, which is the most recent build. We'd need to switch over to that image _before_ this PR is merged.

**Workflow steps:**

No change to workflows, but now if you have a JSON schema that specifies `{"type": "string", "format": "date-time"}`, those fields will end up as `TIMESTAMPTZ` columns instead of `TEXT`.

**Documentation links affected:**

None, since we haven't yet documented materialization type mapping.

**Notes for reviewers:**

This is intended to be pretty minimal, and to only address the immediate need. In particular, it doesn't address the issues of how we should be testing these, or allowing for customization.