### PR TITLE
materialize-postgres: check for nil in date-time conversion

### DIFF
--- a/materialize-postgres/sqlgen.go
+++ b/materialize-postgres/sqlgen.go
@@ -28,7 +28,14 @@ func PostgresSQLGenerator() sql.Generator {
 					"date-time": sql.ConstColumnType{
 						SQLType: "TIMESTAMPTZ",
 						ValueConverter: func(in interface{}) (interface{}, error) {
-							return time.Parse(time.RFC3339Nano, in.(string))
+							if in == nil { // in case of nullable fields
+								return nil, nil
+							}
+							var v, ok = in.(string)
+							if !ok {
+								return nil, fmt.Errorf("could not convert format: date-time field to string")
+							}
+							return time.Parse(time.RFC3339Nano, v)
 						},
 					},
 				},

--- a/materialize-postgres/sqlgen_test.go
+++ b/materialize-postgres/sqlgen_test.go
@@ -72,3 +72,47 @@ func TestDateTimeColumn(t *testing.T) {
 	_, ok := parsed.(time.Time)
 	require.True(t, ok)
 }
+
+func TestDateTimeColumnNullable(t *testing.T) {
+	var gen = PostgresSQLGenerator()
+	var column = sqlDriver.Column{
+		Name:       "foo",
+		Identifier: "fooi",
+		Comment:    "",
+		PrimaryKey: false,
+		Type:       sqlDriver.STRING,
+		StringType: &sqlDriver.StringTypeInfo{
+			Format: "date-time",
+		},
+		NotNull: false,
+	}
+	var result, err = gen.TypeMappings.GetColumnType(&column)
+	require.NoError(t, err)
+	require.Equal(t, "TIMESTAMPTZ", result.SQLType)
+
+	parsed, err := result.ValueConverter(nil)
+	require.NoError(t, err)
+	// The value returned from the converter must be nil
+	require.Equal(t, nil, parsed)
+}
+
+func TestDateTimeColumnError(t *testing.T) {
+	var gen = PostgresSQLGenerator()
+	var column = sqlDriver.Column{
+		Name:       "foo",
+		Identifier: "fooi",
+		Comment:    "",
+		PrimaryKey: false,
+		Type:       sqlDriver.STRING,
+		StringType: &sqlDriver.StringTypeInfo{
+			Format: "date-time",
+		},
+		NotNull: false,
+	}
+	var result, err = gen.TypeMappings.GetColumnType(&column)
+	require.NoError(t, err)
+	require.Equal(t, "TIMESTAMPTZ", result.SQLType)
+
+	_, err = result.ValueConverter(0)
+	require.EqualError(t, err, "could not convert format: date-time field to string")
+}


### PR DESCRIPTION
**Description:**

- If a field is `format: date-time` but also nullable, our current code panics
- Also adding a better error which helps with troubleshooting

**Workflow steps:**

N/A

**Documentation links affected:**

N/A

**Notes for reviewers:**

N/A

