### PR TITLE
materialize-postgres: do not convert timestamp values, insert as is

### DIFF
--- a/materialize-postgres/sqlgen.go
+++ b/materialize-postgres/sqlgen.go
@@ -3,7 +3,6 @@ package main
 import (
 	"fmt"
 	"strings"
-	"time"
 
 	"github.com/estuary/flow/go/protocols/materialize/sql"
 )
@@ -22,22 +21,12 @@ func PostgresSQLGenerator() sql.Generator {
 			sql.STRING: sql.StringTypeMapping{
 				Default: sql.RawConstColumnType("TEXT"),
 				ByFormat: map[string]sql.TypeMapper{
-					// This format is for RFC3339 timestamps. As of this writing, Flow's schema
-					// validation does not actually validate that String values match their declared
-					// format, so there's no guarantee that the values will parse successfully here.
-					"date-time": sql.ConstColumnType{
-						SQLType: "TIMESTAMPTZ",
-						ValueConverter: func(in interface{}) (interface{}, error) {
-							if in == nil { // in case of nullable fields
-								return nil, nil
-							}
-							var v, ok = in.(string)
-							if !ok {
-								return nil, fmt.Errorf("could not convert format: date-time field to string")
-							}
-							return time.Parse(time.RFC3339Nano, v)
-						},
-					},
+					// According to the JSONSchema spec, this format is for RFC3339 timestamps, however
+					// since it seems a lot of usages of this format point to ISO8601 datetimes
+					// we have decided to support ISO8601 for this format as well.
+					// As of this writing, Flow's schema validation does not actually validate that
+					// String values match their declared format, so there's no guarantee that the values will parse successfully here.
+					"date-time": sql.RawConstColumnType("TIMESTAMPTZ"),
 				},
 			},
 		},

--- a/materialize-postgres/sqlgen_test.go
+++ b/materialize-postgres/sqlgen_test.go
@@ -3,7 +3,6 @@ package main
 import (
 	"database/sql"
 	"testing"
-	"time"
 
 	"github.com/estuary/connectors/testsupport"
 	"github.com/estuary/flow/go/protocols/catalog"
@@ -67,10 +66,8 @@ func TestDateTimeColumn(t *testing.T) {
 	require.Equal(t, "TIMESTAMPTZ", result.SQLType)
 
 	parsed, err := result.ValueConverter("2022-04-04T10:09:08.234567Z")
+	require.Equal(t, "2022-04-04T10:09:08.234567Z", parsed)
 	require.NoError(t, err)
-	// The value returned from the converter must be a time.Time
-	_, ok := parsed.(time.Time)
-	require.True(t, ok)
 }
 
 func TestDateTimeColumnNullable(t *testing.T) {
@@ -94,25 +91,4 @@ func TestDateTimeColumnNullable(t *testing.T) {
 	require.NoError(t, err)
 	// The value returned from the converter must be nil
 	require.Equal(t, nil, parsed)
-}
-
-func TestDateTimeColumnError(t *testing.T) {
-	var gen = PostgresSQLGenerator()
-	var column = sqlDriver.Column{
-		Name:       "foo",
-		Identifier: "fooi",
-		Comment:    "",
-		PrimaryKey: false,
-		Type:       sqlDriver.STRING,
-		StringType: &sqlDriver.StringTypeInfo{
-			Format: "date-time",
-		},
-		NotNull: false,
-	}
-	var result, err = gen.TypeMappings.GetColumnType(&column)
-	require.NoError(t, err)
-	require.Equal(t, "TIMESTAMPTZ", result.SQLType)
-
-	_, err = result.ValueConverter(0)
-	require.EqualError(t, err, "could not convert format: date-time field to string")
 }


### PR DESCRIPTION
**Description:**

- PostgreSQL can handle ISO8601 datetimes itself, so we can instead of parsing the datetime ourselves, just pass it in directly with type: `TIMESTAMPZ` and let postgres handle the conversion.

Solves #184 

**Workflow steps:**

- Use `format: date-time` on a date-time value formatted as ISO8601

**Documentation links affected:**

N/A

**Notes for reviewers:**

(anything that might help someone review this PR)

