### PR TITLE
source-{mysql,postgres}: Add 'title' field to specs

### DIFF
--- a/source-mysql/main.go
+++ b/source-mysql/main.go
@@ -20,6 +20,7 @@ import (
 func main() {
 	fixMysqlLogging()
 	var schema = jsonschema.Reflect(&Config{})
+	schema.Title = "MySQL Source Spec"
 	var configSchema, err = schema.MarshalJSON()
 	if err != nil {
 		panic(err)

--- a/source-postgres/main.go
+++ b/source-postgres/main.go
@@ -20,6 +20,7 @@ import (
 
 func main() {
 	var schema = jsonschema.Reflect(&Config{})
+	schema.Title = "PostgreSQL Source Spec"
 	var configSchema, err = schema.MarshalJSON()
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
**Description:**

Adds the field `.spec.connectionSpecification.title` to the `spec` subcommand output for `source-postgres` and `source-mysql`, since apparently that's being used for something in the UI.

This should fix https://github.com/estuary/connectors/issues/186
