### PR TITLE
source-test: option to skip the state message

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,6 +15,7 @@ jobs:
         connector:
           - source-gcs
           - source-hello-world
+          - source-test
           - source-kafka
           - source-kinesis
           - source-mysql

--- a/source-hello-world/main.go
+++ b/source-hello-world/main.go
@@ -87,15 +87,22 @@ func doCheck(args airbyte.CheckCmd) error {
 }
 
 func doDiscover(args airbyte.DiscoverCmd) error {
-	if err := args.ConfigFile.Parse(new(Config)); err != nil {
+	var config Config
+
+	if err := args.ConfigFile.Parse(&config); err != nil {
 		return err
+	}
+
+	var syncModes = []airbyte.SyncMode{airbyte.SyncModeIncremental}
+	if config.SkipState {
+		syncModes := []airbyte.SyncMode{airbyte.SyncModeFullRefresh}
 	}
 
 	var catalog = new(airbyte.Catalog)
 	catalog.Streams = append(catalog.Streams, airbyte.Stream{
 		Name:                    "greetings",
 		JSONSchema:              json.RawMessage(greetingSchema),
-		SupportedSyncModes:      []airbyte.SyncMode{airbyte.SyncModeIncremental},
+		SupportedSyncModes:      syncModes,
 		SourceDefinedCursor:     true,
 		SourceDefinedPrimaryKey: [][]string{{"count"}},
 	})

--- a/source-test/Dockerfile
+++ b/source-test/Dockerfile
@@ -1,0 +1,35 @@
+# Build Stage
+################################################################################
+FROM golang:1.17-buster as builder
+
+WORKDIR /builder
+
+# Download & compile dependencies early. Doing this separately allows for layer
+# caching opportunities when no dependencies are updated.
+COPY go.* ./
+RUN go mod download
+
+# Build the connector projects we depend on.
+COPY source-test ./source-test
+
+# Run the unit tests.
+RUN go test -v ./source-test/...
+
+# Build the connector.
+RUN go build -o ./connector -v ./source-test/...
+
+
+# Runtime Stage
+################################################################################
+FROM gcr.io/distroless/base-debian10
+
+WORKDIR /connector
+ENV PATH="/connector:$PATH"
+
+# Bring in the compiled connector artifact from the builder.
+COPY --from=builder /builder/connector ./connector
+
+# Avoid running the connector as root.
+USER nonroot:nonroot
+
+ENTRYPOINT ["/connector/connector"]

--- a/source-test/main.go
+++ b/source-test/main.go
@@ -9,7 +9,8 @@ import (
 )
 
 type Config struct {
-	Greetings int `json:"greetings"`
+	Greetings int  `json:"greetings"`
+	SkipState bool `json:"skip_state"`
 }
 
 type State struct {
@@ -29,7 +30,7 @@ func (c *State) Validate() error {
 
 const configSchema = `{
 	"$schema": "http://json-schema.org/draft-07/schema#",
-	"title":   "Hello World Source Spec",
+	"title":   "Test Source Spec",
 	"type":    "object",
 	"required": [
 		"greetings"
@@ -40,7 +41,13 @@ const configSchema = `{
 			"title":       "Number of Greetings",
 			"description": "Number of greeting documents to produce when running in non-tailing mode",
 			"default":     1000
-		}
+		},
+    "skip_state": {
+      "type": "boolean",
+      "title": "Skip sending an Airbyte state message",
+      "description": "Some Airbyte connectors do not send a state message. This option can be used to emulate those cases",
+      "default": false
+    }
 	}
 }`
 
@@ -80,7 +87,9 @@ func doCheck(args airbyte.CheckCmd) error {
 }
 
 func doDiscover(args airbyte.DiscoverCmd) error {
-	if err := args.ConfigFile.Parse(new(Config)); err != nil {
+	var config Config
+
+	if err := args.ConfigFile.Parse(&config); err != nil {
 		return err
 	}
 
@@ -145,13 +154,15 @@ func doRead(args airbyte.ReadCmd) error {
 			return err
 		}
 
-		if b, err = json.Marshal(state); err != nil {
-			return err
-		} else if err = enc.Encode(airbyte.Message{
-			Type:  airbyte.MessageTypeState,
-			State: &airbyte.State{Data: b},
-		}); err != nil {
-			return err
+		if !config.SkipState {
+			if b, err = json.Marshal(state); err != nil {
+				return err
+			} else if err = enc.Encode(airbyte.Message{
+				Type:  airbyte.MessageTypeState,
+				State: &airbyte.State{Data: b},
+			}); err != nil {
+				return err
+			}
 		}
 
 		if catalog.Tail {


### PR DESCRIPTION
**Description:**

- I copied `source-hello-world` to `source-test` to have a source we can use for our internal testing by implementing weird behaviours in it
- Add an option to `source-test` which would allow us to skip the state message to test this end-to-end.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

N/A

**Notes for reviewers:**

(anything that might help someone review this PR)

