### PR TITLE
BigQuery: Add support for JSON Form

### DIFF
--- a/materialize-bigquery/.snapshots/TestSpecification
+++ b/materialize-bigquery/.snapshots/TestSpecification
@@ -52,5 +52,5 @@
     "additionalProperties": false,
     "type": "object"
   },
-  "documentation_url": "https://docs.estuary.dev/#FIXME"
+  "documentation_url": "https://go.estuary.dev/materialize-bigquery"
 }

--- a/materialize-bigquery/.snapshots/TestSpecification
+++ b/materialize-bigquery/.snapshots/TestSpecification
@@ -30,10 +30,7 @@
         "type": "string"
       },
       "credentials_json": {
-        "type": "string",
-        "media": {
-          "binaryEncoding": "base64"
-        }
+        "type": "string"
       }
     },
     "additionalProperties": false,

--- a/materialize-bigquery/bigquery.go
+++ b/materialize-bigquery/bigquery.go
@@ -114,7 +114,7 @@ func (c tableConfig) DeltaUpdates() bool {
 // newBigQueryDriver creates a new Driver for BigQuery.
 func newBigQueryDriver() *sqlDriver.Driver {
 	return &sqlDriver.Driver{
-		DocumentationURL: "https://docs.estuary.dev/#FIXME",
+		DocumentationURL: "https://go.estuary.dev/materialize-bigquery",
 		EndpointSpecType: &config{},
 		ResourceSpecType: &tableConfig{},
 		NewResource: func(endpoint sqlDriver.Endpoint) sqlDriver.Resource {

--- a/materialize-bigquery/bigquery.go
+++ b/materialize-bigquery/bigquery.go
@@ -29,7 +29,7 @@ type config struct {
 	Bucket           string `json:"bucket"`
 	BucketPath       string `json:"bucket_path"`
 	CredentialsFile  string `json:"credentials_file,omitempty"`
-	CredentialsJSON  []byte `json:"credentials_json,omitempty"`
+	CredentialsJSON  string `json:"credentials_json,omitempty"`
 }
 
 func (*config) GetFieldDocString(fieldname string) string {
@@ -140,7 +140,7 @@ func newBigQueryDriver() *sqlDriver.Driver {
 			if parsed.CredentialsFile != "" {
 				clientOpts = append(clientOpts, option.WithCredentialsFile(parsed.CredentialsFile))
 			} else if len(parsed.CredentialsJSON) != 0 {
-				clientOpts = append(clientOpts, option.WithCredentialsJSON(parsed.CredentialsJSON))
+				clientOpts = append(clientOpts, option.WithCredentialsJSON([]byte(parsed.CredentialsJSON)))
 			}
 
 			// Allow overriding the main 'project_id' with 'billing_project_id' for client operation billing.

--- a/materialize-bigquery/bigquery.go
+++ b/materialize-bigquery/bigquery.go
@@ -32,6 +32,29 @@ type config struct {
 	CredentialsJSON  []byte `json:"credentials_json,omitempty"`
 }
 
+func (*config) GetFieldDocString(fieldname string) string {
+	switch fieldname {
+	case "BillingProjectID":
+		return "Billing Project ID connected to the BigQuery dataset. It can be the same value as Project ID."
+	case "ProjectID":
+		return "Google Cloud Project ID that owns the BigQuery dataset."
+	case "Dataset":
+		return "BigQuery dataset that will be used to store the materialization output."
+	case "Region":
+		return "Region where both the Bucket and the BigQuery dataset is located. They both need to be within the same region."
+	case "Bucket":
+		return "Google Cloud Storage bucket that is going to be used to store specfications & temporary data before merging into BigQuery."
+	case "BucketPath":
+		return "A prefix that will be used to store objects to Google Cloud Storage's bucket."
+	case "CredentialsFile":
+		return "URI that points to a JSON Credentials for Google Clouse Service."
+	case "CredentialsJSON":
+		return "Google Cloud Service Account JSON credentials in base64 format."
+	default:
+		return ""
+	}
+}
+
 func (c *config) Validate() error {
 	if c.ProjectID == "" {
 		return fmt.Errorf("expected project_id")
@@ -65,6 +88,17 @@ func (c *tableConfig) Validate() error {
 		return fmt.Errorf("expected table")
 	}
 	return nil
+}
+
+func (*tableConfig) GetFieldDocString(fieldname string) string {
+	switch fieldname {
+	case "Table":
+		return "Table in the BigQuery dataset to store materialized result in."
+	case "Delta":
+		return "Should updates to this table be done via delta updates. Defaults is false."
+	default:
+		return ""
+	}
 }
 
 // Path returns the sqlDriver.ResourcePath for a table.

--- a/materialize-bigquery/bigquery.go
+++ b/materialize-bigquery/bigquery.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"regexp"
@@ -140,7 +141,11 @@ func newBigQueryDriver() *sqlDriver.Driver {
 			if parsed.CredentialsFile != "" {
 				clientOpts = append(clientOpts, option.WithCredentialsFile(parsed.CredentialsFile))
 			} else if len(parsed.CredentialsJSON) != 0 {
-				clientOpts = append(clientOpts, option.WithCredentialsJSON([]byte(parsed.CredentialsJSON)))
+				credentials, err := base64.StdEncoding.DecodeString(parsed.CredentialsJSON)
+				if err != nil {
+					return nil, fmt.Errorf("failed to decode the JSON Credentials. Expected base64 content: %w", err)
+				}
+				clientOpts = append(clientOpts, option.WithCredentialsJSON(credentials))
 			}
 
 			// Allow overriding the main 'project_id' with 'billing_project_id' for client operation billing.


### PR DESCRIPTION
**Description:**
The UI depends on values provided to the connector to show information
and create the actual form.

Also made a change to the CredentialsJSON field to be a string instead of a byte[] slice because a byte slice would get encoded in JSONSchema differently that is incompatible with how flow deals with the data: https://github.com/invopop/jsonschema/blob/297bb072302c4423669838e04bb7705277e50224/reflect.go#L417-L419

I believe the changes here are backward compatible since string and byte slice can be cast to each type in any direction.

This should fix some issues with the UI showing an error message trying to get test the BQ materialization:

```json
{
    "error": "SchemaBuild",
    "description": "failed to build json schema: at keyword 'media' of schema 'request://schema#/properties/credentials_json': unexpected keyword 'media'"
}
```

(Describe the high level scope of new or changed features)

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

