### PR TITLE
BigQuery: Add JSONSchema attribute in annotation for UI Form

### DIFF
--- a/materialize-bigquery/.snapshots/TestSpecification
+++ b/materialize-bigquery/.snapshots/TestSpecification
@@ -48,7 +48,15 @@
       }
     },
     "additionalProperties": false,
-    "type": "object"
+    "type": "object",
+    "definitions": {
+      "credential": {
+        "type": "string",
+        "title": "Credentials",
+        "description": "Google Cloud Service Account JSON credentials in base64 format.",
+        "secret": true
+      }
+    }
   },
   "resource_spec_schema_json": {
     "$schema": "http://json-schema.org/draft-04/schema#",

--- a/materialize-bigquery/.snapshots/TestSpecification
+++ b/materialize-bigquery/.snapshots/TestSpecification
@@ -2,7 +2,6 @@
   "endpoint_spec_schema_json": {
     "$schema": "http://json-schema.org/draft-04/schema#",
     "required": [
-      "billing_project_id",
       "project_id",
       "dataset",
       "region",

--- a/materialize-bigquery/.snapshots/TestSpecification
+++ b/materialize-bigquery/.snapshots/TestSpecification
@@ -2,35 +2,50 @@
   "endpoint_spec_schema_json": {
     "$schema": "http://json-schema.org/draft-04/schema#",
     "required": [
+      "billing_project_id",
       "project_id",
       "dataset",
+      "region",
       "bucket",
-      "bucket_path"
+      "bucket_path",
+      "credentials_json"
     ],
     "properties": {
       "billing_project_id": {
-        "type": "string"
+        "type": "string",
+        "title": "Billing Project ID",
+        "description": "Billing Project ID connected to the BigQuery dataset. It can be the same value as Project ID."
       },
       "project_id": {
-        "type": "string"
+        "type": "string",
+        "title": "Project ID",
+        "description": "Google Cloud Project ID that owns the BigQuery dataset."
       },
       "dataset": {
-        "type": "string"
+        "type": "string",
+        "title": "Dataset",
+        "description": "BigQuery dataset that will be used to store the materialization output."
       },
       "region": {
-        "type": "string"
+        "type": "string",
+        "title": "Region",
+        "description": "Region where both the Bucket and the BigQuery dataset is located. They both need to be within the same region."
       },
       "bucket": {
-        "type": "string"
+        "type": "string",
+        "title": "Bucket",
+        "description": "Google Cloud Storage bucket that is going to be used to store specfications \u0026 temporary data before merging into BigQuery."
       },
       "bucket_path": {
-        "type": "string"
-      },
-      "credentials_file": {
-        "type": "string"
+        "type": "string",
+        "title": "Bucket Path",
+        "description": "A prefix that will be used to store objects to Google Cloud Storage's bucket."
       },
       "credentials_json": {
-        "type": "string"
+        "type": "string",
+        "title": "Credentials",
+        "description": "Google Cloud Service Account JSON credentials in base64 format.",
+        "secret": "true"
       }
     },
     "additionalProperties": false,
@@ -43,10 +58,14 @@
     ],
     "properties": {
       "table": {
-        "type": "string"
+        "type": "string",
+        "title": "Table",
+        "description": "Table in the BigQuery dataset to store materialized result in."
       },
       "delta_updates": {
-        "type": "boolean"
+        "type": "boolean",
+        "title": "Delta Update",
+        "description": "Should updates to this table be done via delta updates. Defaults is false."
       }
     },
     "additionalProperties": false,

--- a/materialize-bigquery/.snapshots/TestSpecification
+++ b/materialize-bigquery/.snapshots/TestSpecification
@@ -44,7 +44,7 @@
         "type": "string",
         "title": "Credentials",
         "description": "Google Cloud Service Account JSON credentials in base64 format.",
-        "secret": "true"
+        "secret": true
       }
     },
     "additionalProperties": false,

--- a/materialize-bigquery/bigquery.go
+++ b/materialize-bigquery/bigquery.go
@@ -39,7 +39,7 @@ func (credential) JSONSchemaType() *jsonschema.Type {
 
 // Config represents the endpoint configuration for BigQuery.
 type config struct {
-	BillingProjectID string     `json:"billing_project_id" jsonschema:"title=Billing Project ID,description=Billing Project ID connected to the BigQuery dataset. It can be the same value as Project ID."`
+	BillingProjectID string     `json:"billing_project_id,omitempty" jsonschema:"title=Billing Project ID,description=Billing Project ID connected to the BigQuery dataset. It can be the same value as Project ID."`
 	ProjectID        string     `json:"project_id" jsonschema:"title=Project ID,description=Google Cloud Project ID that owns the BigQuery dataset."`
 	Dataset          string     `json:"dataset" jsonschema:"title=Dataset,description=BigQuery dataset that will be used to store the materialization output."`
 	Region           string     `json:"region" jsonschema:"title=Region,description=Region where both the Bucket and the BigQuery dataset is located. They both need to be within the same region."`

--- a/materialize-bigquery/bigquery.go
+++ b/materialize-bigquery/bigquery.go
@@ -26,15 +26,18 @@ type credential string
 
 func (credential) JSONSchemaType() *jsonschema.Type {
 	ty := &jsonschema.Type{
-		Type:        "string",
-		Title:       "Credentials",
-		Description: "Google Cloud Service Account JSON credentials in base64 format.",
+		Type:  "string",
+		Title: "Credentials",
 		Extras: map[string]interface{}{
 			"secret": true,
 		},
 	}
 
 	return ty
+}
+
+func (credential) Name() string {
+	return "credential"
 }
 
 // Config represents the endpoint configuration for BigQuery.
@@ -45,7 +48,7 @@ type config struct {
 	Region           string     `json:"region" jsonschema:"title=Region,description=Region where both the Bucket and the BigQuery dataset is located. They both need to be within the same region."`
 	Bucket           string     `json:"bucket" jsonschema:"title=Bucket,description=Google Cloud Storage bucket that is going to be used to store specfications & temporary data before merging into BigQuery."`
 	BucketPath       string     `json:"bucket_path" jsonschema:"title=Bucket Path,description=A prefix that will be used to store objects to Google Cloud Storage's bucket."`
-	CredentialsJSON  credential `json:"credentials_json"`
+	CredentialsJSON  credential `json:"credentials_json" jsonschema_description:"Google Cloud Service Account JSON credentials in base64 format."`
 }
 
 func (c *config) Validate() error {

--- a/materialize-bigquery/bigquery_test.go
+++ b/materialize-bigquery/bigquery_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"log"
 	"testing"
 
 	"github.com/bradleyjkemp/cupaloy"
@@ -68,6 +69,7 @@ func TestSpecification(t *testing.T) {
 		Spec(context.Background(), &pm.SpecRequest{EndpointType: pf.EndpointType_AIRBYTE_SOURCE})
 	require.NoError(t, err)
 
+	log.Print(resp)
 	formatted, err := json.MarshalIndent(resp, "", "  ")
 	require.NoError(t, err)
 

--- a/materialize-bigquery/bigquery_test.go
+++ b/materialize-bigquery/bigquery_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
-	"log"
 	"testing"
 
 	"github.com/bradleyjkemp/cupaloy"
@@ -69,7 +68,6 @@ func TestSpecification(t *testing.T) {
 		Spec(context.Background(), &pm.SpecRequest{EndpointType: pf.EndpointType_AIRBYTE_SOURCE})
 	require.NoError(t, err)
 
-	log.Print(resp)
 	formatted, err := json.MarshalIndent(resp, "", "  ")
 	require.NoError(t, err)
 


### PR DESCRIPTION
JSONSchema needs to include some extra attributes to be presented to the
UI so the forms are properly built.

The added logic will have the test failed until
https://github.com/estuary/flow/pull/496 merges and the connector is
rebased to include the new version of the sqlDriver.

The reason for this is because the the DoNotReference needs to be enable
otherwise the test fails and the Schema is formulated in a different
way.

This should be a safe backward compatible fix.

Close #206 