### PR TITLE
materialize-firebolt: fix prefix without trailing slash causing issues

### DIFF
--- a/materialize-firebolt/config.go
+++ b/materialize-firebolt/config.go
@@ -13,7 +13,7 @@ type config struct {
 	AWSSecretKey string `json:"aws_secret_key,omitempty" jsonschema:"title=AWS Secret Key"`
 	AWSRegion    string `json:"aws_region,omitempty" jsonschema:"title=AWS Region"`
 	S3Bucket     string `json:"s3_bucket" jsonschema:"title=S3 Bucket"`
-	S3Prefix     string `json:"s3_prefix,omitempty" jsonschema:"title=S3 Prefix"`
+	S3Prefix     string `json:"s3_prefix,omitempty" jsonschema:"title=S3 Prefix,default=/"`
 }
 
 func (c config) Validate() error {
@@ -50,7 +50,7 @@ func (config) GetFieldDocString(fieldName string) string {
 	case "S3Bucket":
 		return "Name of S3 bucket where the intermediate files for external table will be stored."
 	case "S3Prefix":
-		return "A prefix for files stored in the bucket."
+		return "A prefix for files stored in the bucket, must not have a trailing slash. Example: /my-prefix."
 	case "AWSKeyId":
 		return "AWS Key ID for accessing the S3 bucket."
 	case "AWSSecretKey":

--- a/materialize-firebolt/config.go
+++ b/materialize-firebolt/config.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"strings"
 )
 
 type config struct {
@@ -50,7 +51,7 @@ func (config) GetFieldDocString(fieldName string) string {
 	case "S3Bucket":
 		return "Name of S3 bucket where the intermediate files for external table will be stored."
 	case "S3Prefix":
-		return "A prefix for files stored in the bucket, must not have a trailing slash. Example: /my-prefix."
+		return "A prefix for files stored in the bucket. Example: my-prefix."
 	case "AWSKeyId":
 		return "AWS Key ID for accessing the S3 bucket."
 	case "AWSSecretKey":
@@ -89,4 +90,9 @@ func (resource) GetFieldDocString(fieldName string) string {
 	default:
 		return ""
 	}
+}
+
+// Removes leading and trailing slashes from prefix
+func CleanPrefix(prefix string) string {
+	return strings.TrimRight(strings.TrimLeft(prefix, "/"), "/")
 }

--- a/materialize-firebolt/spec.go
+++ b/materialize-firebolt/spec.go
@@ -12,6 +12,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/s3/s3manager"
 	pf "github.com/estuary/flow/go/protocols/flow"
 	proto "github.com/gogo/protobuf/proto"
+	"strings"
 )
 
 // LoadSpec loads existing spec from S3 and create a map of it by table name
@@ -23,7 +24,8 @@ func LoadSpec(cfg config, materialization string) (map[string]*pf.Materializatio
 	sess := session.Must(session.NewSession(&awsConfig))
 	downloader := s3manager.NewDownloader(sess)
 	buf := aws.NewWriteAtBuffer([]byte{})
-	existingSpecKey := fmt.Sprintf("%s%s.flow.materialization_spec", cfg.S3Prefix, materialization)
+
+	existingSpecKey := strings.TrimLeft(fmt.Sprintf("%s/%s.flow.materialization_spec", cfg.S3Prefix, materialization), "/")
 
 	var existing pf.MaterializationSpec
 
@@ -68,7 +70,7 @@ func WriteSpec(cfg config, materialization *pf.MaterializationSpec, version stri
 	if err != nil {
 		return fmt.Errorf("marshalling materialization spec: %w", err)
 	}
-	specKey := fmt.Sprintf("%s%s.flow.materialization_spec", cfg.S3Prefix, materialization.Materialization)
+	specKey := strings.TrimLeft(fmt.Sprintf("%s/%s.flow.materialization_spec", cfg.S3Prefix, materialization.Materialization), "/")
 
 	_, err = uploader.Upload(&s3manager.UploadInput{
 		Bucket: &cfg.S3Bucket,
@@ -93,7 +95,7 @@ func CleanSpec(cfg config, materialization string) error {
 	}
 	sess := session.Must(session.NewSession(&awsConfig))
 	svc := s3.New(sess)
-	specKey := fmt.Sprintf("%s%s.flow.materialization_spec", cfg.S3Prefix, materialization)
+	specKey := strings.TrimLeft(fmt.Sprintf("%s/%s.flow.materialization_spec", cfg.S3Prefix, materialization), "/")
 	_, err := svc.DeleteObject(&s3.DeleteObjectInput{
 		Bucket: &cfg.S3Bucket,
 		Key:    &specKey,

--- a/materialize-firebolt/spec.go
+++ b/materialize-firebolt/spec.go
@@ -12,7 +12,6 @@ import (
 	"github.com/aws/aws-sdk-go/service/s3/s3manager"
 	pf "github.com/estuary/flow/go/protocols/flow"
 	proto "github.com/gogo/protobuf/proto"
-	"strings"
 )
 
 // LoadSpec loads existing spec from S3 and create a map of it by table name
@@ -25,7 +24,7 @@ func LoadSpec(cfg config, materialization string) (map[string]*pf.Materializatio
 	downloader := s3manager.NewDownloader(sess)
 	buf := aws.NewWriteAtBuffer([]byte{})
 
-	existingSpecKey := strings.TrimLeft(fmt.Sprintf("%s/%s.flow.materialization_spec", cfg.S3Prefix, materialization), "/")
+	existingSpecKey := fmt.Sprintf("%s/%s.flow.materialization_spec", CleanPrefix(cfg.S3Prefix), materialization)
 
 	var existing pf.MaterializationSpec
 
@@ -70,7 +69,7 @@ func WriteSpec(cfg config, materialization *pf.MaterializationSpec, version stri
 	if err != nil {
 		return fmt.Errorf("marshalling materialization spec: %w", err)
 	}
-	specKey := strings.TrimLeft(fmt.Sprintf("%s/%s.flow.materialization_spec", cfg.S3Prefix, materialization.Materialization), "/")
+	specKey := fmt.Sprintf("%s/%s.flow.materialization_spec", CleanPrefix(cfg.S3Prefix), materialization.Materialization)
 
 	_, err = uploader.Upload(&s3manager.UploadInput{
 		Bucket: &cfg.S3Bucket,
@@ -95,7 +94,7 @@ func CleanSpec(cfg config, materialization string) error {
 	}
 	sess := session.Must(session.NewSession(&awsConfig))
 	svc := s3.New(sess)
-	specKey := strings.TrimLeft(fmt.Sprintf("%s/%s.flow.materialization_spec", cfg.S3Prefix, materialization), "/")
+	specKey := fmt.Sprintf("%s/%s.flow.materialization_spec", CleanPrefix(cfg.S3Prefix), materialization)
 	_, err := svc.DeleteObject(&s3.DeleteObjectInput{
 		Bucket: &cfg.S3Bucket,
 		Key:    &specKey,

--- a/materialize-firebolt/transactor.go
+++ b/materialize-firebolt/transactor.go
@@ -234,7 +234,9 @@ func (t *transactor) Store(it *pm.StoreIterator) error {
 	}
 
 	for _, pipe := range pipes {
-		pipe.Close()
+		if pipe != nil {
+			pipe.Close()
+		}
 	}
 
 	if err := g.Wait(); err != nil {

--- a/materialize-firebolt/transactor.go
+++ b/materialize-firebolt/transactor.go
@@ -81,7 +81,7 @@ func (d driver) Transactions(stream pm.Driver_TransactionsServer) error {
 		awsSecretKey: cfg.AWSSecretKey,
 		awsRegion:    cfg.AWSRegion,
 		bucket:       cfg.S3Bucket,
-		prefix:       strings.TrimLeft(fmt.Sprintf("%s/%s/", cfg.S3Prefix, open.Open.Materialization.Materialization.String()), "/"),
+		prefix:       fmt.Sprintf("%s/%s/", CleanPrefix(cfg.S3Prefix), open.Open.Materialization.Materialization.String()),
 	}
 
 	if err = stream.Send(&pm.TransactionResponse{


### PR DESCRIPTION
**Description:**

- If a `prefix` was given without a trailing slash, it would cause issues such as:
```
{"timestamp":"2022-05-12T18:55:50.509439286Z","level":"INFO","message":"invoke connector /connector/connector, [\\"apply-upsert\\"]"}
running external table creation query: response error code 500, Could not access the data source. Please make sure the engine and bucket are on the same AWS region.
```
- This will fix that case as it ensures there is a slash between the prefix and the spec filename. This is consistent with how we handle the prefix in other places of the connector. I also added a note to the JSON schema that the value must now be without a trailing slash.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

