### PR TITLE
Improve Kafka Schema Even More

### DIFF
--- a/source-kafka/tests/it/snapshots/it__spec_test.snap
+++ b/source-kafka/tests/it/snapshots/it__spec_test.snap
@@ -13,11 +13,16 @@ spec:
           mechanism:
             allOf:
               - $ref: "#/definitions/SaslMechanism"
+            order: 0
             title: Sasl Mechanism
           password:
+            order: 2
+            secret: true
             title: Password
             type: string
           username:
+            order: 1
+            secret: true
             title: Username
             type: string
         required:
@@ -27,7 +32,7 @@ spec:
         title: Authentication
         type: object
       SaslMechanism:
-        description: "The SASL Mechanism describes _how_ to exchange and authenticate clients/servers. For secure communication, TLS is **required** for all supported mechanisms.\n\nFor more information about the Simple Authentication and Security Layer (SASL), see RFC 4422: https://datatracker.ietf.org/doc/html/rfc4422 For more information about Salted Challenge Response Authentication Mechanism (SCRAM), see RFC 7677. https://datatracker.ietf.org/doc/html/rfc7677"
+        description: The SASL Mechanism describes how to exchange and authenticate clients/servers.
         enum:
           - PLAIN
           - SCRAM-SHA-256
@@ -35,32 +40,44 @@ spec:
         title: SASL Mechanism
         type: string
       TlsSettings:
-        description: Controls how should TLS  certificates be found or used.
+        default: system_certificates
+        description: Controls how should TLS certificates be found or used.
         enum:
           - system_certificates
-          - cleartext
         title: TLS Settings
         type: string
     properties:
       authentication:
-        anyOf:
-          - $ref: "#/definitions/Authentication"
-          - type: "null"
         description: "The connection details for authenticating a client connection to Kafka via SASL. When not provided, the client connection will attempt to use PLAINTEXT (insecure) protocol. This must only be used in dev/test environments."
+        oneOf:
+          - allOf:
+              - $ref: "#/definitions/Authentication"
+            title: Enabled
+          - title: Disabled
+            type: "null"
+        order: 1
         title: Authentication
       bootstrap_servers:
         description: The initial servers in the Kafka cluster to initially connect to. The Kafka client will be informed of the rest of the cluster nodes by connecting to one of these nodes.
         items:
+          default:
+            - "localhost:9092"
           type: string
+        order: 0
         title: Bootstrap Servers
         type: array
       tls:
-        allOf:
-          - $ref: "#/definitions/TlsSettings"
-        title: TLS connection settings.
+        description: Controls how should TLS certificates be found or used.
+        oneOf:
+          - allOf:
+              - $ref: "#/definitions/TlsSettings"
+            title: Enabled
+          - title: Disabled
+            type: "null"
+        order: 2
+        title: TLS Settings
     required:
       - bootstrap_servers
-      - tls
     title: Kafka Source Configuration
     type: object
   supported_destination_sync_modes: []

--- a/source-kafka/tests/test-config.json
+++ b/source-kafka/tests/test-config.json
@@ -5,5 +5,5 @@
     "username": "alice",
     "password": "alice-pass"
   },
-  "tls": "cleartext"
+  "tls": null
 }

--- a/tests/source-kafka/setup.sh
+++ b/tests/source-kafka/setup.sh
@@ -13,7 +13,7 @@ export CONNECTOR_CONFIG='{
     "username": "alice",
     "password": "alice-pass"
   },
-  "tls": "cleartext"
+  "tls": null
 }'
 
 root_dir="$(git rev-parse --show-toplevel)"


### PR DESCRIPTION
**Description:**

Explicitly spells out the schema, rather than relying on schema.rs to generate it. When schema.rs supports extension annotations, we can go back to using the generated schema. For now, we need to at least mark
the credentials as `secret: true`.

**Workflow steps:**

1. Update the Kafka connector_tag record to use this tag in Supabase.
2. Wait for the agent to finish updating the connector.
3. Create a new Capture.
4. Select Kafka source.

**Documentation links affected:**

n/a

**Notes for reviewers:**

n/a

