### PR TITLE
BigQuery: Fix applyUpsert when a table exists

### DIFF
--- a/materialize-bigquery/endpoint.go
+++ b/materialize-bigquery/endpoint.go
@@ -167,10 +167,13 @@ func (e *Endpoint) CreateTableStatement(table *sqlDriver.Table) (string, error) 
 	if table.Temporary {
 		builder.WriteString("TEMPORARY ")
 	}
-	builder.WriteString("TABLE ")
-	if table.IfNotExists {
-		builder.WriteString("IF NOT EXISTS ")
-	}
+
+	// Ignoring the table.IfNotExists because we need to
+	// include it here otherwise, the statement would fail if the table exists
+	// and since create gets called multiple time, if one table exists and another doesn't,
+	// bigquery's table aren't fully configured and the connector fails when starting the transactor.
+	builder.WriteString("TABLE IF NOT EXISTS")
+
 	builder.WriteString(table.Identifier)
 	builder.WriteString(" (\n\t")
 


### PR DESCRIPTION
When an upsert happens, I believe that by default it will try to run a query like:

```sql
BEGIN TRANSACTION
CREATE TABLE abc ...;
CREATE TABLE def ....;
COMMIT;
```

Because the `CREATE` statement doesn't include `IF NOT EXISTS`, if one of the table already exists, all the other one won't be created. By forcing the `IF NOT EXISTS`, it allows for all remaining table that does not exist to be created.

I cannot be 100% certain this is the root cause, but I think that's why
a connector can fail during bootup. ApplyUpsert starts by trying to
create all tables for internal uses (_flow_*) and for projections.

When creating those tables, if one of them exists, it will return an
error, and as a result the subsequent table aren't created, which cause
the connector to fail when it starts the transactor and wants to commit
data to the data storage.
