### PR TITLE
source-{mysql,postgres}: Add 'DocumentationURL' to spec output

### DIFF
--- a/source-mysql/main.go
+++ b/source-mysql/main.go
@@ -32,6 +32,7 @@ func main() {
 	var spec = airbyte.Spec{
 		SupportsIncremental:     true,
 		ConnectionSpecification: json.RawMessage(configSchema),
+		DocumentationURL:        "https://docs.estuary.dev/reference/Connectors/capture-connectors/MySQL/",
 	}
 
 	sqlcapture.AirbyteMain(spec, func(configFile airbyte.ConfigFile) (sqlcapture.Database, error) {

--- a/source-postgres/main.go
+++ b/source-postgres/main.go
@@ -26,6 +26,7 @@ func main() {
 	var spec = airbyte.Spec{
 		SupportsIncremental:     true,
 		ConnectionSpecification: json.RawMessage(configSchema),
+		DocumentationURL:        "https://docs.estuary.dev/reference/Connectors/capture-connectors/PostgreSQL/",
 	}
 
 	sqlcapture.AirbyteMain(spec, func(configFile airbyte.ConfigFile) (sqlcapture.Database, error) {


### PR DESCRIPTION
**Description:**

Adds `"documentationUrl"` to the `spec` output for `source-mysql` and `source-postgres`.