### PR TITLE
source-mysql: Warn about system schemas on empty discovery

### DIFF
--- a/source-mysql/discovery.go
+++ b/source-mysql/discovery.go
@@ -55,6 +55,15 @@ func (db *mysqlDatabase) DiscoverTables(ctx context.Context) (map[string]sqlcapt
 			}).Debug("discovered table")
 		}
 	}
+
+	// If there are zero tables, or there's one table but it's the
+	// watermarks table, log a warning.
+	var _, watermarksPresent = tableMap[db.WatermarksTable()]
+	if len(tableMap) == 0 || len(tableMap) == 1 && watermarksPresent {
+		logrus.Warn("no tables discovered")
+		logrus.Warn("note that source-mysql will not discover tables in the system schemas 'information_schema', 'mysql', 'performance_schema', or 'sys'")
+	}
+
 	return tableMap, nil
 }
 


### PR DESCRIPTION
**Description:**

The MySQL connector will not discover tables in the system schemas `information_schema`, `mysql`, `performance_schema`,
or `sys`. This could be confusing to the user, especially since the lack of any 'default user schema' makes it kind of tempting to put tables in the 'mysql' schema if one doesn't know any better. Or it could happen by accident, if you just give `--database=mysql` to the MySQL CLI and then forget to `USE <schema>` or give a fully-qualified name.

For now let's do the simplest possible fix, and emit a warning when the discovery result is empty. After this change, running discovery on an empty MySQL instance gives the following output:

    INFO[0000] initializing connector                        addr="207.148.12.34:3306" dbName=mysql serverID=1198288759 user=flow_capture
    WARN[0000] no tables discovered
    WARN[0000] note that source-mysql will not discover tables in the system schemas 'information_schema', 'mysql', 'performance_schema', or 'sys'

This will probably need to be improved in the future, because it should be possible to capture these tables -- we just don't want the discovered catalog to suggest them. But the currently-out-for-review MySQL table metadata changes require tables to be present in the discovery results in order to initialize the table metadata, so that suggests that either:

 1. The `DiscoverTables()` method should give us everything unfiltered, and then for the `discover` subcommand alone we can filter out various "hidden" stuff.
 2. Change it to `DiscoverTables(includeSystem bool)` so that we can communicate the two different uses and either include or filter out all that junk as appropriate.

**Workflow steps:**

Run discovery on an empty database, or one where you've added tables to the `mysql` system schema.