### PR TITLE
materialize-firebolt: mark config secrets in jsonschema

### DIFF
--- a/materialize-firebolt/config.go
+++ b/materialize-firebolt/config.go
@@ -8,9 +8,9 @@ type config struct {
 	EngineURL    string `json:"engine_url" jsonschema:"title=Engine URL,example=engine-name.organisation.region.app.firebolt.io"`
 	Database     string `json:"database" jsonschema:"title=Database"`
 	Username     string `json:"username" jsonschema:"title=Username"`
-	Password     string `json:"password" jsonschema:"title=Password"`
+	Password     string `json:"password" jsonschema_extras:"secret=true" jsonschema:"title=Password"`
 	AWSKeyId     string `json:"aws_key_id,omitempty" jsonschema:"title=AWS Key ID"`
-	AWSSecretKey string `json:"aws_secret_key,omitempty" jsonschema:"title=AWS Secret Key"`
+	AWSSecretKey string `json:"aws_secret_key,omitempty" jsonschema_extras:"secret=true" jsonschema:"title=AWS Secret Key"`
 	AWSRegion    string `json:"aws_region,omitempty" jsonschema:"title=AWS Region"`
 	S3Bucket     string `json:"s3_bucket" jsonschema:"title=S3 Bucket"`
 	S3Prefix     string `json:"s3_prefix,omitempty" jsonschema:"title=S3 Prefix"`

--- a/materialize-firebolt/firebolt/firebolt.go
+++ b/materialize-firebolt/firebolt/firebolt.go
@@ -132,6 +132,10 @@ func (c *Client) Query(query string) (*QueryResponse, error) {
 		return nil, fmt.Errorf("reading response of query failed: %w", err)
 	}
 
+	if resp.StatusCode == 503 {
+		return nil, fmt.Errorf("Received 503 error when trying to connect to the engine. Please make sure your engine `%s` is up and running. It is advised that you set your engine to \"Always On\" in Firebolt to avoid auto-stopping of your engine.", c.config.EngineURL)
+	}
+
 	if resp.StatusCode >= 400 {
 		return nil, fmt.Errorf("response error code %d, %s", resp.StatusCode, respBuf)
 	}


### PR DESCRIPTION
**Description:**

- Mark `password` and `aws_secret` as secrets in JSONSchema
- Give a better error message in case of 503: make sure the engine is up and running

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

