### PR TITLE
source-postgres: Increase replication event buffer size

### DIFF
--- a/source-postgres/replication.go
+++ b/source-postgres/replication.go
@@ -170,7 +170,7 @@ const standbyStatusInterval = 10 * time.Second
 // replicationStream before it stops receiving further events from PostgreSQL.
 // In normal use it's a constant, it's just a variable so that tests are more
 // likely to exercise blocking sends and backpressure.
-var replicationBufferSize = 1024
+var replicationBufferSize = 1000000
 
 func (s *replicationStream) Events() <-chan sqlcapture.ChangeEvent {
 	return s.events


### PR DESCRIPTION
**Description:**

Empirically this makes the connector more able to tolerate large spikes of changes without failing, and to recover better when the cursor LSN is very far behind the latest WAL entries.

However the exact reason that this *needs* to be so large is still unknown. Ideally the buffer should be unnecessary, the only reason it exists at all was to help keep the data rate smoother from the perspective of the source DB, and larger spikes should be handled just fine by ordinary TCP pushback to the walsender.

But in at least one scenario (Google Cloud SQL instance, being hammered at thousands of QPS using `sysbench-tpcc`, and captured by a connector with access via SSH forwarding) some part of that backpressure chain is breaking down and leading to persistent failures, so we should turn up the one knob that is currently known to make it better.
