### PR TITLE
ci: push image with version if not already exists

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,5 +1,9 @@
 name: CI
 
+concurrency: 
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 on:
   push:
     branches: [main]
@@ -166,4 +170,4 @@ jobs:
           context: .
           file: ${{ matrix.connector }}/Dockerfile
           push: true # See 'if' above
-          tags: ghcr.io/estuary/${{ matrix.connector }}:dev
+          tags: ghcr.io/estuary/${{ matrix.connector }}:dev,ghcr.io/estuary/${{ matrix.connector }}:v1


### PR DESCRIPTION
**Description:**

- Publish images with a version _IF NOT ALREADY EXISTING_. This is important to avoid accidentally overriding the last version. Version must always be bumped if we want to publish a new version. The `dev` tag will continue to be overriden every time we push.

**Workflow steps:**

Run main branch github action

**Documentation links affected:**

N/A

**Notes for reviewers:**

(anything that might help someone review this PR)

