### PR TITLE
Update documentation URLs for source connectors

### DIFF
--- a/filesource/filesource.go
+++ b/filesource/filesource.go
@@ -44,6 +44,8 @@ type Source struct {
 	NewConfig func() Config
 	// Connect using to the Source's Store using the decoded and validated Config.
 	Connect func(context.Context, Config) (Store, error)
+	// DocumentationURL links to the Source's extended user documentation.
+	DocumentationURL string
 }
 
 // Store is a minimal interface of an binary large object storage service.
@@ -142,6 +144,7 @@ func (src Source) Main() {
 		SupportsIncremental:           true,
 		SupportedDestinationSyncModes: airbyte.AllDestinationSyncModes,
 		ConnectionSpecification:       src.ConfigSchema(parserSpec),
+		DocumentationURL:              src.DocumentationURL,
 	}
 	airbyte.RunMain(spec, src.Check, src.Discover, src.Read)
 }

--- a/source-gcs/main.go
+++ b/source-gcs/main.go
@@ -172,6 +172,7 @@ func main() {
 		}
     }`)
 		},
+		DocumentationURL: "https://go.estuary.dev/source-gcs",
 	}
 
 	src.Main()

--- a/source-hello-world/main.go
+++ b/source-hello-world/main.go
@@ -61,6 +61,7 @@ var spec = airbyte.Spec{
 	SupportsIncremental:           true,
 	SupportedDestinationSyncModes: airbyte.AllDestinationSyncModes,
 	ConnectionSpecification:       json.RawMessage(configSchema),
+	DocumentationURL:              "https://go.estuary.dev/source-hello-world",
 }
 
 func doCheck(args airbyte.CheckCmd) error {

--- a/source-kafka/src/airbyte.rs
+++ b/source-kafka/src/airbyte.rs
@@ -41,17 +41,24 @@ pub enum DestinationSyncMode {
 pub struct Spec<C: JsonSchema> {
     #[serde(rename = "connectionSpecification")]
     connection_specification: ConnectionSpecification<C>,
+    #[serde(rename = "documentationUrl")]
+    documentation_url: String,
     #[serde(rename = "supportsIncremental")]
     supports_incremental: bool,
     supported_destination_sync_modes: Vec<DestinationSyncMode>,
 }
 
 impl<C: JsonSchema> Spec<C> {
-    pub fn new(incremental: bool, sync_modes: Vec<DestinationSyncMode>) -> Self {
+    pub fn new(
+        documentation_url: impl Into<String>,
+        incremental: bool,
+        sync_modes: Vec<DestinationSyncMode>,
+    ) -> Self {
         Self {
             connection_specification: ConnectionSpecification::default(),
             supports_incremental: incremental,
             supported_destination_sync_modes: sync_modes,
+            documentation_url: documentation_url.into(),
         }
     }
 }
@@ -243,7 +250,7 @@ mod test {
     #[test]
     fn serialize_spec_test() {
         let spec: Envelope<Spec<SampleConfig>> =
-            Spec::new(true, vec![DestinationSyncMode::Append]).into();
+            Spec::new("example.com", true, vec![DestinationSyncMode::Append]).into();
 
         let serialized = serde_json::to_string(&spec).expect("to serialize spec to json");
         // TODO: replace with serde_test assertions instead.

--- a/source-kafka/src/lib.rs
+++ b/source-kafka/src/lib.rs
@@ -19,7 +19,8 @@ impl connector::Connector for KafkaConnector {
     type State = state::CheckpointSet;
 
     fn spec(output: &mut dyn Write) -> eyre::Result<()> {
-        let message: airbyte::Spec<configuration::Configuration> = airbyte::Spec::new(true, vec![]);
+        let message: airbyte::Spec<configuration::Configuration> =
+            airbyte::Spec::new("https://go.estuary.dev/source-kafka", true, vec![]);
 
         connector::write_message(output, message)?;
         Ok(())

--- a/source-kinesis/main.go
+++ b/source-kinesis/main.go
@@ -23,6 +23,7 @@ var spec = airbyte.Spec{
 	SupportsIncremental:           true,
 	SupportedDestinationSyncModes: airbyte.AllDestinationSyncModes,
 	ConnectionSpecification:       json.RawMessage(configJSONSchema),
+	DocumentationURL:              "https://go.estuary.dev/source-kinesis",
 }
 
 func doCheck(args airbyte.CheckCmd) error {

--- a/source-s3/main.go
+++ b/source-s3/main.go
@@ -261,6 +261,7 @@ func main() {
 		}
     }`)
 		},
+		DocumentationURL: "https://go.estuary.dev/source-s3",
 	}
 
 	src.Main()


### PR DESCRIPTION
**Description:**

Many of these connectors were missing documentation urls. This field gets extracted by the UI from the connector spec in order to render a contextual link to the connector documentation.

**Workflow steps:**

N/A

**Documentation links affected:**

* I've added shortlinks for all these connectors

**Notes for reviewers:**

N/A

