### PR TITLE
source-mysql: Don't group username/password in config

### DIFF
--- a/source-mysql/main_test.go
+++ b/source-mysql/main_test.go
@@ -39,11 +39,9 @@ func TestMain(m *testing.M) {
 
 	// Initialize test config and database connection
 	var cfg = Config{
-		Address: *dbAddress,
-		Login: loginConfig{
-			User:     *dbUser,
-			Password: *dbPassword,
-		},
+		Address:  *dbAddress,
+		User:     *dbUser,
+		Password: *dbPassword,
 		Advanced: advancedConfig{
 			DBName: *dbName,
 		},
@@ -53,7 +51,7 @@ func TestMain(m *testing.M) {
 	}
 	cfg.SetDefaults()
 
-	var conn, err = client.Connect(cfg.Address, cfg.Login.User, cfg.Login.Password, cfg.Advanced.DBName)
+	var conn, err = client.Connect(cfg.Address, cfg.User, cfg.Password, cfg.Advanced.DBName)
 	if err != nil {
 		logrus.WithField("err", err).Fatal("error connecting to database")
 	}

--- a/source-mysql/replication.go
+++ b/source-mysql/replication.go
@@ -30,8 +30,8 @@ func (db *mysqlDatabase) StartReplication(ctx context.Context, startCursor strin
 		Flavor:   "mysql", // TODO(wgd): See what happens if we change this and run against MariaDB?
 		Host:     host,
 		Port:     uint16(port),
-		User:     db.config.Login.User,
-		Password: db.config.Login.Password,
+		User:     db.config.User,
+		Password: db.config.Password,
 	})
 
 	var pos mysql.Position


### PR DESCRIPTION
**Description:**

As discussed on Slack the other day [1] a nested object is rendered as a separate tab in the web UI. Travis was of the opinion (paraphrased) that all basic details should be scalar properties of the root configuration so that they all appear in the 'Basic Information' tab.

[1] https://app.slack.com/client/T0120UQAX7X/C012S5U0WP2/thread/C012S5U0WP2-1654034026.249709

**Workflow steps:**

This tweaks the configuration of `source-mysql`, hopefully for the better.

**Documentation links affected:**

I'll submit a PR for https://docs.estuary.dev/reference/Connectors/capture-connectors/MySQL/ if/when this is merged.

