### PR TITLE
source-postgres: Refactor configuration schema

### DIFF
--- a/source-postgres/README.md
+++ b/source-postgres/README.md
@@ -70,10 +70,9 @@ A minimal `config.json` consists solely of the database connection parameters:
 
 ```json
 {
+  "address": "localhost:5432",
   "database": "flow",
-  "host": "localhost",
   "password": "flow_capture",
-  "port": 5432,
   "user": "flow_capture"
 }
 ```
@@ -129,14 +128,14 @@ this test database. The easy way to build the connector and run those tests is v
 `docker build`:
 
 ```bash
-docker build --network=host -f source-postgres/Dockerfile -t ghcr.io/estuary/source-postgres:dev .
+docker build --network=host -f source-postgres/Dockerfile -t ghcr.io/estuary/source-postgres:local .
 ```
 
 You can also run the resulting connector image manually:
 
 ```bash
 docker run --rm -it --network=host -v <configsDir>:/cfg \
-  ghcr.io/estuary/source-postgres:dev read \
+  ghcr.io/estuary/source-postgres:local read \
   --config=/cfg/config.json \
   --catalog=/cfg/catalog.json \
   --state=/cfg/state.json
@@ -156,12 +155,6 @@ The `go test` suite only tests the connector in isolation. There's another test
 which runs it as part of a Flow catalog:
 
 ```bash
-PGDATABASE=flow \
-PGHOST=localhost \
-PGPASSWORD=flow \
-PGPORT=5432 \
-PGUSER=flow \
-CONNECTOR=source-postgres \
-VERSION=dev \
-./tests/run.sh
+$ docker build -t ghcr.io/estuary/source-postgres:local -f source-postgres/Dockerfile . --network=host
+$ PGDATABASE=flow PGHOST=localhost PGPASSWORD=flow PGPORT=5432 PGUSER=flow CONNECTOR=source-postgres VERSION=local ./tests/run.sh
 ```

--- a/source-postgres/backfill.go
+++ b/source-postgres/backfill.go
@@ -64,17 +64,17 @@ func (db *postgresDatabase) ScanTableChunk(ctx context.Context, schema, table st
 func (db *postgresDatabase) WriteWatermark(ctx context.Context, watermark string) error {
 	logrus.WithField("watermark", watermark).Debug("writing watermark")
 
-	var query = fmt.Sprintf("CREATE TABLE IF NOT EXISTS %s (slot TEXT PRIMARY KEY, watermark TEXT);", db.config.WatermarksTable)
+	var query = fmt.Sprintf("CREATE TABLE IF NOT EXISTS %s (slot TEXT PRIMARY KEY, watermark TEXT);", db.config.Advanced.WatermarksTable)
 	rows, err := db.conn.Query(ctx, query)
 	if err != nil {
 		return fmt.Errorf("error creating watermarks table: %w", err)
 	}
 	rows.Close()
 
-	query = fmt.Sprintf(`INSERT INTO %s (slot, watermark) VALUES ($1,$2) ON CONFLICT (slot) DO UPDATE SET watermark = $2;`, db.config.WatermarksTable)
-	rows, err = db.conn.Query(ctx, query, db.config.SlotName, watermark)
+	query = fmt.Sprintf(`INSERT INTO %s (slot, watermark) VALUES ($1,$2) ON CONFLICT (slot) DO UPDATE SET watermark = $2;`, db.config.Advanced.WatermarksTable)
+	rows, err = db.conn.Query(ctx, query, db.config.Advanced.SlotName, watermark)
 	if err != nil {
-		return fmt.Errorf("error upserting new watermark for slot %q: %w", db.config.SlotName, err)
+		return fmt.Errorf("error upserting new watermark for slot %q: %w", db.config.Advanced.SlotName, err)
 	}
 	rows.Close()
 	return nil
@@ -82,7 +82,7 @@ func (db *postgresDatabase) WriteWatermark(ctx context.Context, watermark string
 
 // WatermarksTable returns the name of the table to which WriteWatermarks writes UUIDs.
 func (db *postgresDatabase) WatermarksTable() string {
-	return db.config.WatermarksTable
+	return db.config.Advanced.WatermarksTable
 }
 
 // backfillChunkSize controls how many rows will be read from the database in a

--- a/source-postgres/helpers_test.go
+++ b/source-postgres/helpers_test.go
@@ -63,13 +63,13 @@ func TestMain(m *testing.M) {
 	}
 
 	// Initialize test config and database connection
-	TestDefaultConfig.Database = replConnConfig.Database
 	TestDefaultConfig.Address = fmt.Sprintf("%s:%d", replConnConfig.Host, replConnConfig.Port)
-	TestDefaultConfig.Password = replConnConfig.Password
+	TestDefaultConfig.Database = replConnConfig.Database
 	TestDefaultConfig.User = replConnConfig.User
+	TestDefaultConfig.Password = replConnConfig.Password
 
-	TestDefaultConfig.SlotName = *TestReplicationSlot
-	TestDefaultConfig.PublicationName = *TestPublicationName
+	TestDefaultConfig.Advanced.SlotName = *TestReplicationSlot
+	TestDefaultConfig.Advanced.PublicationName = *TestPublicationName
 
 	if err := TestDefaultConfig.Validate(); err != nil {
 		logrus.WithFields(logrus.Fields{"err": err, "config": TestDefaultConfig}).Fatal("error validating test config")

--- a/source-postgres/helpers_test.go
+++ b/source-postgres/helpers_test.go
@@ -64,9 +64,8 @@ func TestMain(m *testing.M) {
 
 	// Initialize test config and database connection
 	TestDefaultConfig.Database = replConnConfig.Database
-	TestDefaultConfig.Host = replConnConfig.Host
+	TestDefaultConfig.Address = fmt.Sprintf("%s:%d", replConnConfig.Host, replConnConfig.Port)
 	TestDefaultConfig.Password = replConnConfig.Password
-	TestDefaultConfig.Port = replConnConfig.Port
 	TestDefaultConfig.User = replConnConfig.User
 
 	TestDefaultConfig.SlotName = *TestReplicationSlot

--- a/source-postgres/replication.go
+++ b/source-postgres/replication.go
@@ -45,7 +45,7 @@ func (db *postgresDatabase) StartReplication(ctx context.Context, startCursor st
 		startLSN = sysident.XLogPos
 	}
 
-	var slot, publication = db.config.SlotName, db.config.PublicationName
+	var slot, publication = db.config.Advanced.SlotName, db.config.Advanced.PublicationName
 
 	logrus.WithFields(logrus.Fields{
 		"startLSN":    startLSN,

--- a/tests/source-postgres/setup.sh
+++ b/tests/source-postgres/setup.sh
@@ -4,38 +4,12 @@ set -e
 export TEST_STREAM="estuary_test_$(shuf -zer -n6 {a..z} | tr -d '\0')"
 export RESOURCE="{ stream: ${TEST_STREAM} }"
 
-if [[ "${SSH_FORWARDING_ENABLED}" == "true" ]]
-then
-    if [[ ! -f "${PRIVATE_KEY_FILE_PATH}" ]]; then
-        bail "${PRIVATE_KEY_FILE_PATH} does not exists."
-    fi
-    export PRIVATE_KEY="$(awk '{printf "%s\\n", $0}' ${PRIVATE_KEY_FILE_PATH})"
-    config_json_template='{
-        "database": "$PGDATABASE",
-        "host":     "localhost",
-        "port":     $LOCALPORT,
-        "password": "$PGPASSWORD",
-        "user":     "$PGUSER",
-        "networkTunnel": {
-            "sshForwarding": {
-              "sshEndpoint": "$SSHENDPOINT",
-              "user": "$SSHUSER",
-              "forwardHost": "$PGHOST",
-              "forwardPort": $PGPORT,
-              "privateKey": "$PRIVATE_KEY",
-              "localPort": $LOCALPORT
-            }
-        }
-    }'
-else
-    config_json_template='{
-       "database": "$PGDATABASE",
-       "host":     "$PGHOST",
-       "password": "$PGPASSWORD",
-       "port":     $PGPORT,
-       "user":     "$PGUSER"
-     }'
-fi
+config_json_template='{
+   "address":  "$PGHOST:$PGPORT",
+   "database": "$PGDATABASE",
+   "password": "$PGPASSWORD",
+   "user":     "$PGUSER"
+}'
 
 export CONNECTOR_CONFIG="$(echo "$config_json_template" | envsubst | jq -c)"
 echo "Connector configuration is: ${CONNECTOR_CONFIG}".


### PR DESCRIPTION
**Description:**

This PR moves several settings (watermarks table, replication slot, publication) into an 'Advanced' subsection, and merges the `host` and `port` properties into a single `address` field for simplicity. This should make creating PostgreSQL captures much more pleasant in the web UI.

Merging this will require a bit of care to not break existing captures, but to my knowledge there's only one of those that's really important to not break.

**Workflow steps:**

The names and locations of various configuration values have changed, but the actual information is the same.

**Documentation links affected:**

I'll send out a PR for https://docs.estuary.dev/reference/Connectors/capture-connectors/PostgreSQL/ once this is merged.