### PR TITLE
materialize-google-sheets: use spreadsheet URL and not ID

### DIFF
--- a/materialize-google-sheets/util.go
+++ b/materialize-google-sheets/util.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"regexp"
 	"time"
 
 	pf "github.com/estuary/flow/go/protocols/flow"
@@ -210,4 +211,16 @@ func batchRequestWithRetry(
 		return err
 	}
 	panic("not reached")
+}
+
+// Example: https://docs.google.com/spreadsheets/d/1s7S1Abp8kAJEkReV10omef_ETZXKB2vHKPook49HpFk/edit#gid=1649530432
+const sheetsLinkRe = `^https://docs.google.com/spreadsheets/d/([\w\d_\-]+)/`
+
+func parseSheetsID(sheetsURL string) (string, error) {
+	var matches = regexp.MustCompile(sheetsLinkRe).FindStringSubmatch(sheetsURL)
+
+	if len(matches) != 2 || len(matches[1]) == 0 {
+		return "", fmt.Errorf("invalid Google Sheets URL: %s", sheetsURL)
+	}
+	return matches[1], nil
 }

--- a/materialize-google-sheets/util_test.go
+++ b/materialize-google-sheets/util_test.go
@@ -1,0 +1,16 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSheetsIDParsing(t *testing.T) {
+	id, err := parseSheetsID("https://docs.google.com/spreadsheets/d/1s7S1Abp8kAJEkReV10omef_ETZXKB2vHKPook49HpFk/edit#gid=1649530432")
+	require.Nil(t, err)
+	require.Equal(t, "1s7S1Abp8kAJEkReV10omef_ETZXKB2vHKPook49HpFk", id)
+
+	_, err = parseSheetsID("https://github.com/estuary/connectors/issues/245")
+	require.Regexp(t, "invalid Google Sheets URL: .*", err)
+}

--- a/tests/materialize/materialize-google-sheets/setup.sh
+++ b/tests/materialize/materialize-google-sheets/setup.sh
@@ -5,13 +5,12 @@ set -e
 # This spreadsheet lives under the Estuary org and is shared with our CI service account
 # and engineering@. If you're an engineer, feel free to add additional service accounts
 # as needed for your own testing:
-# https://docs.google.com/spreadsheets/d/1aki_PfFU-RCXCvm4-U0O4QoElZBIC7F9lfR-RBG0CTc/edit#gid=0
-export SPREADSHEET_ID="1aki_PfFU-RCXCvm4-U0O4QoElZBIC7F9lfR-RBG0CTc"
+export SPREADSHEET_URL="https://docs.google.com/spreadsheets/d/1aki_PfFU-RCXCvm4-U0O4QoElZBIC7F9lfR-RBG0CTc/edit#gid=0"
 export GCP_SERVICE_ACCOUNT_KEY_QUOTED=$(echo ${GCP_SERVICE_ACCOUNT_KEY} | jq 'tojson')
 
 config_json_template='{
     "googleCredentials": ${GCP_SERVICE_ACCOUNT_KEY_QUOTED},
-    "spreadsheetId": "${SPREADSHEET_ID}"
+    "spreadsheetUrl": "${SPREADSHEET_URL}"
 }'
 
 resources_json_template='[


### PR DESCRIPTION
**Description:**

Switch to using a spreadsheet URL instead of a spreadsheet ID.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

