### PR TITLE
source-{mysql,postgres}: Remove default address from spec

### DIFF
--- a/source-mysql/main.go
+++ b/source-mysql/main.go
@@ -68,7 +68,7 @@ func fixMysqlLogging() {
 // Config tells the connector how to connect to the source database and
 // capture changes from it.
 type Config struct {
-	Address  string         `json:"address" jsonschema:"title=Server Address,default=127.0.0.1:3306,description=The host or host:port at which the database can be reached."`
+	Address  string         `json:"address" jsonschema:"title=Server Address,description=The host or host:port at which the database can be reached."`
 	User     string         `json:"user" jsonschema:"title=Login Username,default=flow_capture,description=The database user to authenticate as."`
 	Password string         `json:"password" jsonschema:"title=Login Password,description=Password for the specified database user." jsonschema_extras:"secret=true"`
 	Advanced advancedConfig `json:"advanced,omitempty" jsonschema:"title=Advanced Options,description=Options for advanced users. You should not typically need to modify these." jsonschema_extra:"advanced=true"`

--- a/source-postgres/main.go
+++ b/source-postgres/main.go
@@ -41,7 +41,7 @@ func main() {
 
 // Config tells the connector how to connect to and interact with the source database.
 type Config struct {
-	Address  string         `json:"address" jsonschema:"title=Server Address,default=127.0.0.1:5432,description=The host or host:port at which the database can be reached."`
+	Address  string         `json:"address" jsonschema:"title=Server Address,description=The host or host:port at which the database can be reached."`
 	Database string         `json:"database" jsonschema:"default=postgres,description=Logical database name to capture from."`
 	User     string         `json:"user" jsonschema:"default=flow_capture,description=The database user to authenticate as."`
 	Password string         `json:"password" jsonschema:"description=Password for the specified database user." jsonschema_extras:"secret=true"`


### PR DESCRIPTION
**Description:**

In almost every case the user should be forced to fill this in, so having an incorrect default is just a bit of unnecessary friction.

