### PR TITLE
DO NOT MERGE: source-postgres: Lower replication buffer size

### DIFF
--- a/source-postgres/replication.go
+++ b/source-postgres/replication.go
@@ -170,7 +170,7 @@ const standbyStatusInterval = 10 * time.Second
 // replicationStream before it stops receiving further events from PostgreSQL.
 // In normal use it's a constant, it's just a variable so that tests are more
 // likely to exercise blocking sends and backpressure.
-var replicationBufferSize = 1000000
+var replicationBufferSize = 100
 
 func (s *replicationStream) Events() <-chan sqlcapture.ChangeEvent {
 	return s.events


### PR DESCRIPTION
**Description:**

Test PR, please ignore. I just need a CI-built `source-postgres` with the replication buffer made even smaller than it was before.

