### PR TITLE
materialize-postgres: use debian image and install openssh

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,8 +11,60 @@ on:
     branches: [main]
 
 jobs:
+  build_base_image:
+    runs-on: ubuntu-20.04
+    strategy:
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Prepare
+        id: prep
+        run: |
+          TAG=$(echo $GITHUB_SHA | head -c7)
+          echo ::set-output name=tag::${TAG}
+
+      - name: Login to GitHub package docker registry
+        run: |
+          echo "${{ secrets.GITHUB_TOKEN }}" | \
+            docker login --username ${{ github.actor }} --password-stdin ghcr.io
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+        with:
+          driver-opts: |
+            network=host
+
+      - name: Build base-image Docker Image
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: base-image/Dockerfile
+          load: true
+          tags: ghcr.io/estuary/base-image:local-test-tag
+
+      - name: Push base-image image
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: base-image/Dockerfile
+          push: true
+          tags: ghcr.io/estuary/base-image:${{ steps.prep.outputs.tag }}
+
+      - name: Push base-image image with 'dev' tag
+        if: ${{ github.event_name == 'push' }}
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: base-image/Dockerfile
+          push: true # See 'if' above
+          tags: ghcr.io/estuary/base-image:dev,ghcr.io/estuary/base-image:v1
+
   build_connectors:
     runs-on: ubuntu-20.04
+    needs: build_base_image
     strategy:
       fail-fast: false
       matrix:

--- a/base-image/Dockerfile
+++ b/base-image/Dockerfile
@@ -1,0 +1,15 @@
+FROM --platform=linux/amd64 debian:stable-slim as debian
+
+RUN apt-get update && apt-get install -y openssh-client ca-certificates
+
+# Create a non-privileged "nonroot" user.
+RUN useradd nonroot --create-home --shell /usr/sbin/nologin
+RUN chown nonroot /home/nonroot
+
+USER nonroot:nonroot
+
+RUN mkdir /home/nonroot/.ssh
+RUN chmod 700 /home/nonroot/.ssh
+RUN chmod 755 /home/nonroot
+
+USER root

--- a/materialize-bigquery/Dockerfile
+++ b/materialize-bigquery/Dockerfile
@@ -23,14 +23,11 @@ RUN go build -tags nozstd -v -o ./connector ./materialize-bigquery/...
 
 # Runtime Stage
 ################################################################################
-FROM debian:bullseye-slim
+FROM ghcr.io/estuary/base-image:v1
 
 RUN apt-get update -y \
  && apt-get install --no-install-recommends -y ca-certificates \
  && rm -rf /var/lib/apt/lists/*
-
-# Create a non-privileged "nonroot" user.
-RUN useradd nonroot --create-home --shell /usr/sbin/nologin
 
 # Avoid running the connector as root.
 USER nonroot:nonroot

--- a/materialize-elasticsearch/Dockerfile
+++ b/materialize-elasticsearch/Dockerfile
@@ -25,7 +25,7 @@ RUN go build -tags nozstd -v -o ./connector ./materialize-elasticsearch
 
 # Runtime Stage
 ################################################################################
-FROM gcr.io/distroless/cc-debian11
+FROM ghcr.io/estuary/base-image:v1
 
 WORKDIR /connector
 ENV PATH="/connector:$PATH"

--- a/materialize-firebolt/Dockerfile
+++ b/materialize-firebolt/Dockerfile
@@ -24,7 +24,7 @@ RUN go build -tags nozstd -v -o ./connector ./materialize-firebolt
 
 # Runtime Stage
 ################################################################################
-FROM --platform=linux/amd64 gcr.io/distroless/cc-debian11
+FROM ghcr.io/estuary/base-image:v1
 
 WORKDIR /connector
 ENV PATH="/connector:$PATH"

--- a/materialize-google-sheets/Dockerfile
+++ b/materialize-google-sheets/Dockerfile
@@ -24,7 +24,7 @@ RUN go build -tags nozstd -v -o ./connector ./materialize-google-sheets
 
 # Runtime Stage
 ################################################################################
-FROM gcr.io/distroless/base-debian11
+FROM ghcr.io/estuary/base-image:v1
 
 WORKDIR /connector
 ENV PATH="/connector:$PATH"

--- a/materialize-postgres/Dockerfile
+++ b/materialize-postgres/Dockerfile
@@ -18,14 +18,12 @@ COPY materialize-postgres    ./materialize-postgres
 COPY testsupport             ./testsupport
 
 # Test and build the connector.
-#RUN go test  -tags nozstd -v ./materialize-postgres/...
+RUN go test  -tags nozstd -v ./materialize-postgres/...
 RUN go build -tags nozstd -v -o ./connector ./materialize-postgres/...
 
 # Runtime Stage
 ################################################################################
-FROM --platform=linux/amd64 debian:stable-slim as debian
-
-RUN apt-get update && apt-get install -y openssh-client
+FROM ghcr.io/estuary/base-image:v1
 
 WORKDIR /connector
 ENV PATH="/connector:$PATH"
@@ -33,8 +31,6 @@ ENV PATH="/connector:$PATH"
 COPY --from=builder /builder/connector ./connector
 
 # Avoid running the connector as root.
-COPY --from=gcr.io/distroless/cc-debian11 /etc/passwd /etc/passwd
-COPY --from=gcr.io/distroless/cc-debian11 /etc/group /etc/group
 USER nonroot:nonroot
 
 LABEL FLOW_RUNTIME_PROTOCOL=materialize

--- a/materialize-postgres/Dockerfile
+++ b/materialize-postgres/Dockerfile
@@ -18,20 +18,23 @@ COPY materialize-postgres    ./materialize-postgres
 COPY testsupport             ./testsupport
 
 # Test and build the connector.
-RUN go test  -tags nozstd -v ./materialize-postgres/...
+#RUN go test  -tags nozstd -v ./materialize-postgres/...
 RUN go build -tags nozstd -v -o ./connector ./materialize-postgres/...
 
 # Runtime Stage
 ################################################################################
-FROM --platform=linux/amd64 gcr.io/distroless/cc-debian11
+FROM --platform=linux/amd64 debian:stable-slim as debian
+
+RUN apt-get update && apt-get install -y openssh-client
 
 WORKDIR /connector
 ENV PATH="/connector:$PATH"
 
-# Bring in the compiled connector artifact from the builder.
 COPY --from=builder /builder/connector ./connector
 
 # Avoid running the connector as root.
+COPY --from=gcr.io/distroless/cc-debian11 /etc/passwd /etc/passwd
+COPY --from=gcr.io/distroless/cc-debian11 /etc/group /etc/group
 USER nonroot:nonroot
 
 LABEL FLOW_RUNTIME_PROTOCOL=materialize

--- a/materialize-rockset/Dockerfile
+++ b/materialize-rockset/Dockerfile
@@ -29,7 +29,7 @@ RUN go build -tags nozstd -v -o ./connector ./materialize-rockset/cmd/connector/
 
 # Runtime Stage
 ################################################################################
-FROM gcr.io/distroless/base-debian11
+FROM ghcr.io/estuary/base-image:v1
 
 WORKDIR /connector
 ENV PATH="/connector:$PATH"

--- a/materialize-s3-parquet/Dockerfile
+++ b/materialize-s3-parquet/Dockerfile
@@ -23,7 +23,7 @@ RUN go build -tags nozstd -v -o ./connector ./materialize-s3-parquet
 
 # Runtime Stage
 ################################################################################
-FROM gcr.io/distroless/base-debian11
+FROM ghcr.io/estuary/base-image:v1
 
 WORKDIR /connector
 ENV PATH="/connector:$PATH"

--- a/materialize-snowflake/Dockerfile
+++ b/materialize-snowflake/Dockerfile
@@ -23,7 +23,7 @@ RUN go build -tags nozstd -v -o ./connector ./materialize-snowflake/...
 
 # Runtime Stage
 ################################################################################
-FROM debian:bullseye-slim
+FROM ghcr.io/estuary/base-image:v1
 
 RUN apt-get update -y \
  && apt-get install --no-install-recommends -y \
@@ -31,9 +31,6 @@ RUN apt-get update -y \
       curl \
       unzip \
  && rm -rf /var/lib/apt/lists/*
-
-# Create a non-privileged "nonroot" user.
-RUN useradd nonroot --create-home --shell /usr/sbin/nologin
 
 # Avoid running the connector as root.
 USER nonroot:nonroot

--- a/materialize-webhook/Dockerfile
+++ b/materialize-webhook/Dockerfile
@@ -23,7 +23,7 @@ RUN go build -tags nozstd -v -o ./connector ./materialize-webhook/...
 
 # Runtime Stage
 ################################################################################
-FROM gcr.io/distroless/base-debian11
+FROM ghcr.io/estuary/base-image:v1
 
 WORKDIR /connector
 ENV PATH="/connector:$PATH"

--- a/source-gcs/Dockerfile
+++ b/source-gcs/Dockerfile
@@ -22,12 +22,10 @@ RUN go build -o ./connector -v ./source-gcs/...
 
 # Runtime Stage
 ################################################################################
-FROM gcr.io/distroless/base-debian10
+FROM ghcr.io/estuary/base-image:v1
 
 WORKDIR /connector
 ENV PATH="/connector:$PATH"
-
-COPY --from=busybox:latest /bin/sh /bin/sh
 
 # Grab the statically-built parser cli.
 COPY flow-bin/flow-parser ./

--- a/source-hello-world/Dockerfile
+++ b/source-hello-world/Dockerfile
@@ -21,7 +21,7 @@ RUN go build -o ./connector -v ./source-hello-world/...
 
 # Runtime Stage
 ################################################################################
-FROM gcr.io/distroless/base-debian10
+FROM ghcr.io/estuary/base-image:v1
 
 WORKDIR /connector
 ENV PATH="/connector:$PATH"

--- a/source-kafka/Dockerfile
+++ b/source-kafka/Dockerfile
@@ -33,7 +33,7 @@ RUN touch src/main.rs \
 
 # Runtime Stage
 ################################################################################
-FROM gcr.io/distroless/cc-debian10
+FROM ghcr.io/estuary/base-image:v1
 
 WORKDIR /connector
 ENV PATH="/connector:$PATH"

--- a/source-kinesis/Dockerfile
+++ b/source-kinesis/Dockerfile
@@ -21,7 +21,7 @@ RUN go build -o ./connector -v ./source-kinesis/...
 
 # Runtime Stage
 ################################################################################
-FROM gcr.io/distroless/base-debian10
+FROM ghcr.io/estuary/base-image:v1
 
 WORKDIR /connector
 ENV PATH="/connector:$PATH"

--- a/source-mysql/Dockerfile
+++ b/source-mysql/Dockerfile
@@ -23,7 +23,7 @@ RUN go build -o ./connector -v ./source-mysql/...
 
 # Runtime Stage
 ################################################################################
-FROM gcr.io/distroless/base-debian10
+FROM ghcr.io/estuary/base-image:v1
 
 WORKDIR /connector
 ENV PATH="/connector:$PATH"

--- a/source-postgres/Dockerfile
+++ b/source-postgres/Dockerfile
@@ -24,7 +24,7 @@ RUN go build -o ./connector -v ./source-postgres/...
 
 # Runtime Stage
 ################################################################################
-FROM gcr.io/distroless/base-debian10
+FROM ghcr.io/estuary/base-image:v1
 
 WORKDIR /connector
 ENV PATH="/connector:$PATH"

--- a/source-s3/Dockerfile
+++ b/source-s3/Dockerfile
@@ -23,7 +23,7 @@ RUN go build -o ./connector -v ./source-s3/...
 
 # Runtime Stage
 ################################################################################
-FROM gcr.io/distroless/base-debian10
+FROM ghcr.io/estuary/base-image:v1
 
 WORKDIR /connector
 ENV PATH="/connector:$PATH"

--- a/source-test/Dockerfile
+++ b/source-test/Dockerfile
@@ -21,7 +21,7 @@ RUN go build -o ./connector -v ./source-test/...
 
 # Runtime Stage
 ################################################################################
-FROM gcr.io/distroless/base-debian10
+FROM ghcr.io/estuary/base-image:v1
 
 WORKDIR /connector
 ENV PATH="/connector:$PATH"


### PR DESCRIPTION
**Description:**

- Added a new `base-image` which sets up OpenSSH and nonroot user, and I'm using that as the base of runtime stage for all other connector images.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

