### PR TITLE
Update Snowflake

### DIFF
--- a/materialize-snowflake/.snapshots/TestSpecification
+++ b/materialize-snowflake/.snapshots/TestSpecification
@@ -6,32 +6,49 @@
       "user",
       "password",
       "database",
-      "schema"
+      "schema",
+      "region"
     ],
     "properties": {
       "account": {
-        "type": "string"
+        "type": "string",
+        "title": "Account",
+        "description": "The Snowflake account identifier."
       },
       "user": {
-        "type": "string"
+        "type": "string",
+        "title": "User",
+        "description": "The Snowflake user login name."
       },
       "password": {
-        "type": "string"
+        "type": "string",
+        "title": "Password",
+        "description": "The password for the provided user."
       },
       "database": {
-        "type": "string"
+        "type": "string",
+        "title": "Database",
+        "description": "The SQL database to connect to."
       },
       "schema": {
-        "type": "string"
+        "type": "string",
+        "title": "Schema",
+        "description": "The SQL schema to use."
       },
       "warehouse": {
-        "type": "string"
+        "type": "string",
+        "title": "Warehouse",
+        "description": "The Snowflake virutal warehouse used to execute queries."
       },
       "role": {
-        "type": "string"
+        "type": "string",
+        "title": "Role",
+        "description": "The user role used to perform actions."
       },
       "region": {
-        "type": "string"
+        "type": "string",
+        "title": "Region",
+        "description": "The cloud region containing the Snowflake endpoint."
       }
     },
     "additionalProperties": false,

--- a/materialize-snowflake/.snapshots/TestSpecification
+++ b/materialize-snowflake/.snapshots/TestSpecification
@@ -24,7 +24,8 @@
       "password": {
         "type": "string",
         "title": "Password",
-        "description": "The password for the provided user."
+        "description": "The password for the provided user.",
+        "secret": "true"
       },
       "database": {
         "type": "string",

--- a/materialize-snowflake/.snapshots/TestSpecification
+++ b/materialize-snowflake/.snapshots/TestSpecification
@@ -7,6 +7,7 @@
       "password",
       "database",
       "schema",
+      "cloud_provider",
       "region"
     ],
     "properties": {
@@ -44,6 +45,16 @@
         "type": "string",
         "title": "Role",
         "description": "The user role used to perform actions."
+      },
+      "cloud_provider": {
+        "enum": [
+          "aws",
+          "azure",
+          "gcp"
+        ],
+        "type": "string",
+        "title": "Cloud Provider",
+        "description": "The cloud provider where the Snowflake endpoint is hosted."
       },
       "region": {
         "type": "string",

--- a/materialize-snowflake/Dockerfile
+++ b/materialize-snowflake/Dockerfile
@@ -41,30 +41,6 @@ USER nonroot:nonroot
 WORKDIR /connector
 ENV PATH="/connector:$PATH"
 
-# Install snowsql, which is required by the connector.
-# This must be done as the nonroot user, since snowsql always puts its actual binaries in ~/.snowsql.
-# LC_ALL and LANG are required at runtime by the snowsql cli
-# The DEST and LOGIN_SHELL vars are needed by the installer in order to run in non-interactive mode.
-# The VERSION vars are only here to make version updates easier.
-# The PATH must be modified to include the install location, since .profile will not be loaded.
-ENV LC_ALL=C.UTF-8 \
-    LANG=C.UTF-8 \
-    SNOWSQL_DEST=/home/nonroot/bin \
-    SNOWSQL_LOGIN_SHELL=/home/nonroot/.profile \
-    SNOWSQL_MINOR_VERSION=1.2 \
-    SNOWSQL_FULL_VERSION=1.2.14 \
-    SNOWSQL_SHA256=1afb83a22b9ccb2f8e84c2abe861da503336cb3b882fcc2e8399f86ac76bc2a9 \
-    PATH="/home/nonroot/bin:${PATH}"
-RUN curl -o /tmp/snowsql-${SNOWSQL_FULL_VERSION}-linux_x86_64.bash \
-  https://sfc-repo.snowflakecomputing.com/snowsql/bootstrap/${SNOWSQL_MINOR_VERSION}/linux_x86_64/snowsql-${SNOWSQL_FULL_VERSION}-linux_x86_64.bash \
-  && echo "${SNOWSQL_SHA256} /tmp/snowsql-${SNOWSQL_FULL_VERSION}-linux_x86_64.bash" | sha256sum -c - \
-  && touch ${SNOWSQL_LOGIN_SHELL} \
-  && bash /tmp/snowsql-${SNOWSQL_FULL_VERSION}-linux_x86_64.bash \
-  && rm -f /tmp/snowsql-${SNOWSQL_FULL_VERSION}-linux_x86_64.bash \
-  # Defying all reason and expectations, _this_ is what actually installs snowsql.
-  # It will print a help message as if there was a problem, but it works as long as it exits 0.
-  && snowsql -v ${SNOWSQL_FULL_VERSION}
-
 # Bring in the compiled connector artifact from the builder.
 COPY --from=builder /builder/connector ./connector
 

--- a/materialize-snowflake/snowflake.go
+++ b/materialize-snowflake/snowflake.go
@@ -22,14 +22,14 @@ import (
 // config represents the endpoint configuration for snowflake.
 // It must match the one defined for the source specs (flow.yaml) in Rust.
 type config struct {
-	Account   string `json:"account"`
-	User      string `json:"user"`
-	Password  string `json:"password"`
-	Database  string `json:"database"`
-	Schema    string `json:"schema"`
-	Warehouse string `json:"warehouse,omitempty"`
-	Role      string `json:"role,omitempty"`
-	Region    string `json:"region,omitempty"`
+	Account   string `json:"account" jsonschema:"title=Account,description=The Snowflake account identifier."`
+	User      string `json:"user" jsonschema:"title=User,description=The Snowflake user login name."`
+	Password  string `json:"password" jsonschema:"title=Password,description=The password for the provided user."`
+	Database  string `json:"database" jsonschema:"title=Database,description=The SQL database to connect to."`
+	Schema    string `json:"schema" jsonschema:"title=Schema,description=The SQL schema to use."`
+	Warehouse string `json:"warehouse,omitempty" jsonschema:"title=Warehouse,description=The Snowflake virutal warehouse used to execute queries."`
+	Role      string `json:"role,omitempty" jsonschema:"title=Role,description=The user role used to perform actions."`
+	Region    string `json:"region" jsonschema:"title=Region,description=The cloud region containing the Snowflake endpoint."`
 }
 
 func (c *config) asSnowflakeConfig() sf.Config {

--- a/materialize-snowflake/snowflake.go
+++ b/materialize-snowflake/snowflake.go
@@ -32,7 +32,7 @@ type config struct {
 	Region    string `json:"region,omitempty"`
 }
 
-func (c config) asSnowflakeConfig() sf.Config {
+func (c *config) asSnowflakeConfig() sf.Config {
 	return sf.Config{
 		Account:   c.Account,
 		User:      c.User,
@@ -45,15 +45,19 @@ func (c config) asSnowflakeConfig() sf.Config {
 	}
 }
 
-func (c config) Validate() error {
-	if c.Account == "" {
-		return fmt.Errorf("expected account")
+func (c *config) Validate() error {
+	var requiredProperties = [][]string{
+		{"account", c.Account},
+		{"user", c.User},
+		{"password", c.Password},
+		{"database", c.Database},
+		{"schema", c.Schema},
+		{"region", c.Region},
 	}
-	if c.Database == "" {
-		return fmt.Errorf("expected database")
-	}
-	if c.Schema == "" {
-		return fmt.Errorf("expected schema")
+	for _, req := range requiredProperties {
+		if req[1] == "" {
+			return fmt.Errorf("missing '%s'", req[0])
+		}
 	}
 	return nil
 }

--- a/materialize-snowflake/snowflake.go
+++ b/materialize-snowflake/snowflake.go
@@ -24,7 +24,7 @@ import (
 type config struct {
 	Account       string `json:"account" jsonschema:"title=Account,description=The Snowflake account identifier."`
 	User          string `json:"user" jsonschema:"title=User,description=The Snowflake user login name."`
-	Password      string `json:"password" jsonschema:"title=Password,description=The password for the provided user."`
+	Password      string `json:"password" jsonschema:"title=Password,description=The password for the provided user." jsonschema_extras:"secret=true"`
 	Database      string `json:"database" jsonschema:"title=Database,description=The SQL database to connect to."`
 	Schema        string `json:"schema" jsonschema:"title=Schema,description=The SQL schema to use."`
 	Warehouse     string `json:"warehouse,omitempty" jsonschema:"title=Warehouse,description=The Snowflake virutal warehouse used to execute queries."`

--- a/materialize-snowflake/snowflake.go
+++ b/materialize-snowflake/snowflake.go
@@ -22,14 +22,15 @@ import (
 // config represents the endpoint configuration for snowflake.
 // It must match the one defined for the source specs (flow.yaml) in Rust.
 type config struct {
-	Account   string `json:"account" jsonschema:"title=Account,description=The Snowflake account identifier."`
-	User      string `json:"user" jsonschema:"title=User,description=The Snowflake user login name."`
-	Password  string `json:"password" jsonschema:"title=Password,description=The password for the provided user."`
-	Database  string `json:"database" jsonschema:"title=Database,description=The SQL database to connect to."`
-	Schema    string `json:"schema" jsonschema:"title=Schema,description=The SQL schema to use."`
-	Warehouse string `json:"warehouse,omitempty" jsonschema:"title=Warehouse,description=The Snowflake virutal warehouse used to execute queries."`
-	Role      string `json:"role,omitempty" jsonschema:"title=Role,description=The user role used to perform actions."`
-	Region    string `json:"region" jsonschema:"title=Region,description=The cloud region containing the Snowflake endpoint."`
+	Account       string `json:"account" jsonschema:"title=Account,description=The Snowflake account identifier."`
+	User          string `json:"user" jsonschema:"title=User,description=The Snowflake user login name."`
+	Password      string `json:"password" jsonschema:"title=Password,description=The password for the provided user."`
+	Database      string `json:"database" jsonschema:"title=Database,description=The SQL database to connect to."`
+	Schema        string `json:"schema" jsonschema:"title=Schema,description=The SQL schema to use."`
+	Warehouse     string `json:"warehouse,omitempty" jsonschema:"title=Warehouse,description=The Snowflake virutal warehouse used to execute queries."`
+	Role          string `json:"role,omitempty" jsonschema:"title=Role,description=The user role used to perform actions."`
+	CloudProvider string `json:"cloud_provider" jsonschema:"enum=aws,enum=azure,enum=gcp,title=Cloud Provider,description=The cloud provider where the Snowflake endpoint is hosted."`
+	Region        string `json:"region" jsonschema:"title=Region,description=The cloud region containing the Snowflake endpoint."`
 }
 
 func (c *config) asSnowflakeConfig() sf.Config {
@@ -41,7 +42,7 @@ func (c *config) asSnowflakeConfig() sf.Config {
 		Schema:    c.Schema,
 		Warehouse: c.Warehouse,
 		Role:      c.Role,
-		Region:    c.Region,
+		Region:    c.Region + "." + c.CloudProvider,
 	}
 }
 
@@ -53,6 +54,7 @@ func (c *config) Validate() error {
 		{"database", c.Database},
 		{"schema", c.Schema},
 		{"region", c.Region},
+		{"cloud_provider", c.CloudProvider},
 	}
 	for _, req := range requiredProperties {
 		if req[1] == "" {


### PR DESCRIPTION
**Description:**

This fixes a few different things within `materialize-snowflake`.
1. Adds a separate field for `CloudProvider`, which fixes #210.
2. Replaces snowsql cli dependency with the snowflake go library.
3. Adds titles and descriptions to all the configuration fields.
4. Marks the `Password` field as secret.

![Screenshot 2022-06-09 at 15-32-11 Flow · Create Materialization](https://user-images.githubusercontent.com/119613/172936154-bc312679-65af-4a8a-9d7d-9c1877e31e6e.png)


**Workflow steps:**

N/A

**Documentation links affected:**

This is a breaking change in the Snowflake config. Currently there are no running Snowflake materializations, so this is a good time to sneak this change in.

I'm going to make a PR shortly against the Flow docs to add the `CloudProvider` field.

**Notes for reviewers:**

Commit by commit view is probably best.

