### PR TITLE
source-test: add option to fail after N messages

### DIFF
--- a/source-hello-world/main.go
+++ b/source-hello-world/main.go
@@ -118,6 +118,9 @@ func doRead(args airbyte.ReadCmd) error {
 	var enc = airbyte.NewStdoutEncoder()
 	var now = time.Now()
 	for {
+		if state.Cursor >= config.Greetings {
+			return fmt.Errorf("a horrible, no good error was returned!")
+		}
 		if state.Cursor >= config.Greetings && !catalog.Tail {
 			return nil // All done.
 		}

--- a/source-test/main.go
+++ b/source-test/main.go
@@ -11,6 +11,7 @@ import (
 type Config struct {
 	Greetings int  `json:"greetings"`
 	SkipState bool `json:"skip_state"`
+	FailAfter int  `json:"fail_after"`
 }
 
 type State struct {
@@ -47,6 +48,11 @@ const configSchema = `{
       "title": "Skip sending an Airbyte state message",
       "description": "Some Airbyte connectors do not send a state message. This option can be used to emulate those cases",
       "default": false
+    },
+    "fail_after": {
+      "type": ["integer", "null"],
+      "title": "Fail after sending N number of greetings",
+      "description": "Fail after sending N number of greetings"
     }
 	}
 }`
@@ -127,6 +133,9 @@ func doRead(args airbyte.ReadCmd) error {
 	var enc = airbyte.NewStdoutEncoder()
 	var now = time.Now()
 	for {
+		if config.FailAfter != 0 && state.Cursor >= config.FailAfter {
+			return fmt.Errorf("a horrible, no good error!")
+		}
 		if state.Cursor >= config.Greetings && !catalog.Tail {
 			return nil // All done.
 		}


### PR DESCRIPTION
**Description:**

- Add an option to make the source fail after sending N messages

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

