### PR TITLE
Remove stray test error

### DIFF
--- a/source-hello-world/main.go
+++ b/source-hello-world/main.go
@@ -118,9 +118,6 @@ func doRead(args airbyte.ReadCmd) error {
 	var enc = airbyte.NewStdoutEncoder()
 	var now = time.Now()
 	for {
-		if state.Cursor >= config.Greetings {
-			return fmt.Errorf("a horrible, no good error was returned!")
-		}
 		if state.Cursor >= config.Greetings && !catalog.Tail {
 			return nil // All done.
 		}


### PR DESCRIPTION
**Description:**
This was accidentally added in https://github.com/estuary/connectors/pull/264. Similar behavior is in source-test, but this just causes the hello world connector to crash after a bit.

**Workflow steps:**

N/A

**Documentation links affected:**

N/A

**Notes for reviewers:**

N/A

