### PR TITLE
source-mysql: Use SSL when connecting to MySQL

### DIFF
--- a/source-mysql/main.go
+++ b/source-mysql/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"crypto/tls"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -136,7 +137,13 @@ func (db *mysqlDatabase) Connect(ctx context.Context) error {
 	}).Info("initializing connector")
 
 	// Normal database connection used for table scanning
-	var conn, err = client.Connect(db.config.Address, db.config.User, db.config.Password, db.config.Advanced.DBName)
+	var conn, err = client.Connect(db.config.Address, db.config.User, db.config.Password, db.config.Advanced.DBName, func(c *client.Conn) {
+		// TODO(wgd): Consider adding an optional 'serverName' config parameter which
+		// if set makes this false and sets 'ServerName' so it will be verified properly.
+		c.SetTLSConfig(&tls.Config{
+			InsecureSkipVerify: true,
+		})
+	})
 	if err != nil {
 		return fmt.Errorf("unable to connect to database: %w", err)
 	}

--- a/source-mysql/replication.go
+++ b/source-mysql/replication.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"crypto/tls"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -47,6 +48,8 @@ func (db *mysqlDatabase) StartReplication(ctx context.Context, startCursor strin
 		Port:     uint16(port),
 		User:     db.config.User,
 		Password: db.config.Password,
+		// TODO(wgd): Maybe add 'serverName' checking as described over in Connect()
+		TLSConfig: &tls.Config{InsecureSkipVerify: true},
 	})
 
 	var pos mysql.Position


### PR DESCRIPTION
**Description:**

This commit modifies `source-mysql` to use SSL for its connections to the MySQL database. I kind of figured that was the default, but apparently not.

This is done for both the normal/backfill connection and the replication connection. I'm not sure if there needs to be some sort of fallback to not-SSL if SSL connections fail, but my inclination is to just require SSL if possible, and if we see that approach failing in the future we can add fallback logic.

Currently the 'InsecureSkipVerify' TLS configuration is set to true, which means that there's no specific server name which the
SSL certificate is required to match. This means that an active MitM could theoretically intercept the connection (which is why it's called "Insecure" in the option name), but in many cases (such as right now, when I'm running MySQL locally for testing) there may not *be* a server name to verify, so for now I'm skipping that. In the future we could add a `serverName` or `sslServerName` config option, and if set then we could verify that particular name against the certificate.

**Workflow steps:**

Ideally this shouldn't change anything user-visible, except now connections won't fail when the database requires SSL.

