### PR TITLE
Add Schema Inference to Kinesis, S3, and GCS Connectors

### DIFF
--- a/filesource/discovery.go
+++ b/filesource/discovery.go
@@ -1,0 +1,266 @@
+package filesource
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"sync"
+
+	"github.com/estuary/flow/go/parser"
+	"github.com/estuary/flow/go/protocols/airbyte"
+	log "github.com/sirupsen/logrus"
+	"golang.org/x/sync/errgroup"
+)
+
+const (
+	// How many files should we sample to run inference against.
+	discoverReadLimit = 10
+	// How many documents should we read from an individual file during discovery.
+	discoverPeekDocuments = 100
+	// Baseline document schema for resource streams we discover if we fail
+	// during the schema-inference step.
+	discoverFallbackSchema = `{
+		"type": "object",
+		"properties": {
+			"_meta": {
+				"type": "object",
+				"properties": {
+					"file": { "type": "string" },
+					"offset": {
+						"type": "integer",
+						"minimum": 0
+					}
+				},
+				"required": ["file", "offset"]
+			}
+		},
+		"required": ["_meta"]
+	}`
+)
+
+func (src Source) Discover(args airbyte.DiscoverCmd) error {
+	var conn, err = newConnector(src, args.ConfigFile)
+	if err != nil {
+		return err
+	}
+	var ctx = context.Background()
+	var root = conn.config.DiscoverRoot()
+	var logEntry = log.WithField("stream", root)
+
+	documents, err := sampleDocuments(ctx, logEntry, conn, root)
+	if err != nil {
+		return fmt.Errorf("sampling documents from bucket: %w", err)
+	}
+
+	schema, err := runInference(ctx, logEntry, documents)
+	if err != nil {
+		// Failing schema inference isn't a fatal error. It just means we can't
+		// auto-generate a schema from the files in this bucket and it's up to
+		// the user to craft their own schema.
+		log.WithField("err", err).Error("failed to infer schema from documents")
+		schema = json.RawMessage(discoverFallbackSchema)
+	}
+
+	return writeCatalogMessage(newStream(root, schema))
+}
+
+func sampleDocuments(ctx context.Context, logEntry *log.Entry, conn *connector, root string) (<-chan json.RawMessage, error) {
+	var (
+		err         error
+		listing     Listing
+		waitGroup   *sync.WaitGroup      = new(sync.WaitGroup)
+		documents   chan json.RawMessage = make(chan json.RawMessage, discoverReadLimit*discoverPeekDocuments)
+		objectCount int                  = 0
+	)
+
+	listing, err = conn.store.List(ctx, Query{Prefix: root, StartAt: "", Recursive: true})
+	if err != nil {
+		return nil, fmt.Errorf("listing bucket: %w", err)
+	}
+
+	for {
+		obj, err := listing.Next()
+		var logEntry = logEntry.WithField("objCount", objectCount).WithField("path", obj.Path)
+
+		if err == io.EOF {
+			break
+		} else if err != nil {
+			return nil, fmt.Errorf("reading bucket listing: %w", err)
+		} else if obj.IsPrefix {
+			logEntry.Trace("Skipping prefix")
+			continue
+		} else if obj.Size == 0 {
+			logEntry.Trace("Skipping empty file")
+			continue
+		}
+
+		objectCount++
+		logEntry.Debug("Discovered object")
+
+		if objectCount < discoverReadLimit {
+			waitGroup.Add(1)
+			go peekAtFile(ctx, waitGroup, conn, obj, documents)
+		} else {
+			logEntry.Info("Reached sampling limit")
+			break
+		}
+	}
+	waitGroup.Wait()
+	close(documents)
+	logEntry.WithField("objectCount", objectCount).Info("bucket sampling successful")
+
+	return documents, nil
+}
+
+func peekAtFile(ctx context.Context, waitGroup *sync.WaitGroup, conn *connector, file ObjectInfo, docCh chan<- json.RawMessage) {
+	defer waitGroup.Done()
+
+	var logEntry = log.WithField("path", file.Path)
+	logEntry.Infof("Peeking at file")
+
+	// Download file
+	rr, file, err := conn.store.Read(ctx, file)
+	if err != nil {
+		logEntry.WithField("err", err).Error("Failed to download file")
+		return
+	}
+	defer rr.Close()
+
+	// Configure the parser
+	var cfg = new(parser.Config)
+	if c := conn.config.ParserConfig(); c != nil {
+		*cfg = c.Copy()
+	}
+	cfg = configureParser(cfg, file)
+
+	// Create the parser config file
+	tmp, err := ioutil.TempFile("", "parser-config-*.json")
+	if err != nil {
+		logEntry.WithField("err", err).Error("Failed creating parser config")
+		return
+	}
+	defer os.Remove(tmp.Name())
+
+	if err = cfg.WriteToFile(tmp); err != nil {
+		logEntry.WithField("err", err).Error("Failed writing parser config")
+		return
+	}
+
+	// Parse documents from the downloaded file
+	var docsSeen = 0
+	err = parser.ParseStream(ctx, tmp.Name(), rr, func(docs []json.RawMessage) error {
+		logEntry.WithField("docsSeen", docsSeen).WithField("count", len(docs)).Debug("Parser produced more documents")
+
+		for _, doc := range docs {
+			docsSeen++
+			if docsSeen < discoverPeekDocuments {
+				docCh <- copyJson(doc)
+			} else {
+				return closeParser
+			}
+		}
+		return nil
+	})
+	if err != nil && err != closeParser {
+		logEntry.WithField("err", err).Error("Failed parsing")
+		return
+	}
+
+	logEntry.Info("Done peeking at file")
+}
+
+var closeParser = fmt.Errorf("caller closed")
+
+func runInference(ctx context.Context, logEntry *log.Entry, docsCh <-chan json.RawMessage) (json.RawMessage, error) {
+	var (
+		err      error
+		errGroup *errgroup.Group
+		schema   = json.RawMessage{}
+		cmd      *exec.Cmd
+		stdin    io.WriteCloser
+		stdout   io.ReadCloser
+	)
+
+	errGroup, ctx = errgroup.WithContext(ctx)
+	cmd = exec.CommandContext(ctx, "flow-schema-inference", "analyze")
+
+	stdin, err = cmd.StdinPipe()
+	if err != nil {
+		return nil, fmt.Errorf("failed to open stdin: %w", err)
+	}
+	stdout, err = cmd.StdoutPipe()
+	if err != nil {
+		return nil, fmt.Errorf("failed to open stdout: %w", err)
+	}
+
+	errGroup.Go(func() error {
+		defer stdin.Close()
+		encoder := json.NewEncoder(stdin)
+
+		for doc := range docsCh {
+			if err := encoder.Encode(doc); err != nil {
+				return fmt.Errorf("failed to encode document: %w", err)
+			}
+		}
+		logEntry.Info("runInference: Done sending documents")
+
+		return nil
+	})
+
+	errGroup.Go(func() error {
+		defer stdout.Close()
+		decoder := json.NewDecoder(stdout)
+
+		if err := decoder.Decode(&schema); err != nil {
+			return fmt.Errorf("failed to decode schema, %w", err)
+		}
+		logEntry.Debug("runInference: Done reading schema")
+
+		return nil
+	})
+
+	logEntry.Info("runInference: launching")
+	err = cmd.Start()
+	if err != nil {
+		return nil, fmt.Errorf("failed to run flow-schema-inference: %w", err)
+	}
+
+	errGroup.Go(cmd.Wait)
+
+	err = errGroup.Wait()
+	if err != nil {
+		return nil, err
+	}
+
+	return schema, nil
+}
+
+func copyJson(doc json.RawMessage) json.RawMessage {
+	var copy = append(json.RawMessage(nil), doc...)
+	return json.RawMessage(copy)
+}
+
+func writeCatalogMessage(streams ...airbyte.Stream) error {
+	return airbyte.NewStdoutEncoder().Encode(airbyte.Message{
+		Type: airbyte.MessageTypeCatalog,
+		Catalog: &airbyte.Catalog{
+			Streams: streams,
+		},
+	})
+}
+
+func newStream(name string, discoveredSchema json.RawMessage) airbyte.Stream {
+	return airbyte.Stream{
+		Name:               name,
+		JSONSchema:         discoveredSchema,
+		SupportedSyncModes: airbyte.AllSyncModes,
+		SourceDefinedPrimaryKey: [][]string{
+			{"_meta", "file"},
+			{"_meta", "offset"},
+		},
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -58,3 +58,5 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	vitess.io/vitess v0.13.1
 )
+
+replace github.com/estuary/flow => github.com/estuary/flow v0.1.1-0.20220719165323-5c9a6a5308d6

--- a/go.sum
+++ b/go.sum
@@ -341,12 +341,8 @@ github.com/envoyproxy/go-control-plane v0.9.9-0.20210512163311-63b5d3c536b0/go.m
 github.com/envoyproxy/go-control-plane v0.9.10-0.20210907150352-cf90f659a021/go.mod h1:AFq3mo9L8Lqqiid3OhADV3RfLJnjiw63cSpi+fDTRC0=
 github.com/envoyproxy/go-control-plane v0.10.2-0.20220325020618-49ff273808a1/go.mod h1:KJwIaB5Mv44NWtYuAOFCVOjcI94vtpEz2JU/D2v6IjE=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
-github.com/estuary/flow v0.1.1-0.20220620170023-ad059626d543 h1:L2UEDCeVXdpvzpIXfQnWxOP9oc8gbKwc8eEODrpRDLE=
-github.com/estuary/flow v0.1.1-0.20220620170023-ad059626d543/go.mod h1:y5iYgzMczu/oTtxYkkpRM/HQZPXwG0+TkP2OGqlR7nc=
-github.com/estuary/flow v0.1.1-0.20220620190230-ad8e29404bc9 h1:q8+qFmpGHdJdx4eE3oKCmAFyaUvN5IZbVvWksjljVnA=
-github.com/estuary/flow v0.1.1-0.20220620190230-ad8e29404bc9/go.mod h1:y5iYgzMczu/oTtxYkkpRM/HQZPXwG0+TkP2OGqlR7nc=
-github.com/estuary/flow v0.1.1-0.20220621175215-bcd2ad59f15b h1:/haYr9PDZG+niNeXlrjYphwSpbkosUupvRT5EYlXOfw=
-github.com/estuary/flow v0.1.1-0.20220621175215-bcd2ad59f15b/go.mod h1:y5iYgzMczu/oTtxYkkpRM/HQZPXwG0+TkP2OGqlR7nc=
+github.com/estuary/flow v0.1.1-0.20220719165323-5c9a6a5308d6 h1:8+KAZ/F30K4Ls2lHahCR6W8PmEYt9HNgS10t/SB+74w=
+github.com/estuary/flow v0.1.1-0.20220719165323-5c9a6a5308d6/go.mod h1:7NlH7dQWZWv2qJsdZqeYLAz2EhMa5EVArEuGR62YjvM=
 github.com/evanphx/json-patch v4.2.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/evanphx/json-patch v4.9.0+incompatible h1:kLcOMZeuLAJvL2BPWLMIj5oaZQobrkAqrL+WFZwQses=
 github.com/evanphx/json-patch v4.9.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=

--- a/schema_inference/inference.go
+++ b/schema_inference/inference.go
@@ -1,0 +1,108 @@
+package schema_inference
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os/exec"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+	"golang.org/x/sync/errgroup"
+)
+
+// How long should we allow reading from each stream to run. Note: empty streams
+// will wait for documents until this timeout triggers.
+const DISCOVER_READ_TIMEOUT = time.Second * 10
+
+// How long should we allow schema inference to run.
+const DISCOVER_INFER_TIMEOUT = time.Second * 5
+
+type Schema = json.RawMessage
+type Document = json.RawMessage
+type DocumentSource = func(ctx context.Context, logEntry *log.Entry) (docCh <-chan Document, count uint, err error)
+
+func Run(ctx context.Context, streamName string, peekFunc DocumentSource) (Schema, error) {
+	var logEntry = log.WithField("stream", streamName)
+	var peekCtx, cancelPeek = context.WithTimeout(ctx, DISCOVER_READ_TIMEOUT)
+	defer cancelPeek()
+
+	docCh, docCount, err := peekFunc(peekCtx, logEntry)
+	if err != nil {
+		return nil, fmt.Errorf("schema discovery for stream `%s` failed: %w", streamName, err)
+	} else if docCount == 0 {
+		return nil, fmt.Errorf("no documents discovered for stream: %v", streamName)
+	}
+
+	logEntry.WithField("count", docCount).Info("Got documents for stream")
+
+	var inferCtx, cancelInfer = context.WithTimeout(ctx, DISCOVER_INFER_TIMEOUT)
+	defer cancelInfer()
+
+	return infer(inferCtx, logEntry, docCh)
+}
+
+func infer(ctx context.Context, logEntry *log.Entry, docsCh <-chan Document) (Schema, error) {
+	var (
+		err      error
+		errGroup *errgroup.Group
+		schema   = json.RawMessage{}
+		cmd      *exec.Cmd
+		stdin    io.WriteCloser
+		stdout   io.ReadCloser
+	)
+
+	errGroup, ctx = errgroup.WithContext(ctx)
+	cmd = exec.CommandContext(ctx, "flow-schema-inference", "analyze")
+
+	stdin, err = cmd.StdinPipe()
+	if err != nil {
+		return nil, fmt.Errorf("failed to open stdin: %w", err)
+	}
+	stdout, err = cmd.StdoutPipe()
+	if err != nil {
+		return nil, fmt.Errorf("failed to open stdout: %w", err)
+	}
+
+	errGroup.Go(func() error {
+		defer stdin.Close()
+		encoder := json.NewEncoder(stdin)
+
+		for doc := range docsCh {
+			if err := encoder.Encode(doc); err != nil {
+				return fmt.Errorf("failed to encode document: %w", err)
+			}
+		}
+		logEntry.Info("runInference: Done sending documents")
+
+		return nil
+	})
+
+	errGroup.Go(func() error {
+		defer stdout.Close()
+		decoder := json.NewDecoder(stdout)
+
+		if err := decoder.Decode(&schema); err != nil {
+			return fmt.Errorf("failed to decode schema, %w", err)
+		}
+		logEntry.Debug("runInference: Done reading schema")
+
+		return nil
+	})
+
+	logEntry.Info("runInference: launching")
+	err = cmd.Start()
+	if err != nil {
+		return nil, fmt.Errorf("failed to run flow-schema-inference: %w", err)
+	}
+
+	errGroup.Go(cmd.Wait)
+
+	err = errGroup.Wait()
+	if err != nil {
+		return nil, err
+	}
+
+	return schema, nil
+}

--- a/source-gcs/Dockerfile
+++ b/source-gcs/Dockerfile
@@ -10,6 +10,7 @@ COPY go.* ./
 RUN go mod download
 
 # Build the connector projects we depend on.
+COPY schema_inference ./schema_inference
 COPY filesource ./filesource
 COPY source-gcs ./source-gcs
 

--- a/source-gcs/Dockerfile
+++ b/source-gcs/Dockerfile
@@ -29,6 +29,8 @@ ENV PATH="/connector:$PATH"
 
 # Grab the statically-built parser cli.
 COPY flow-bin/flow-parser ./
+# Grab the statically-built schema-inference cli.
+COPY flow-bin/flow-schema-inference ./
 
 # Bring in the compiled connector artifact from the builder.
 COPY --from=builder /builder/connector ./connector

--- a/source-http-file/Dockerfile
+++ b/source-http-file/Dockerfile
@@ -10,6 +10,7 @@ COPY go.* ./
 RUN go mod download
 
 # Build the connector projects we depend on.
+COPY schema_inference ./schema_inference
 COPY filesource ./filesource
 COPY source-http-file ./source-http-file
 
@@ -29,6 +30,8 @@ ENV PATH="/connector:$PATH"
 
 # Grab the statically-built parser cli.
 COPY flow-bin/flow-parser ./
+# Grab the statically-built schema-inference cli.
+COPY flow-bin/flow-schema-inference ./
 
 # Bring in the compiled connector artifact from the builder.
 COPY --from=builder /builder/connector ./connector

--- a/source-kinesis/Dockerfile
+++ b/source-kinesis/Dockerfile
@@ -26,6 +26,9 @@ FROM ghcr.io/estuary/base-image:v1
 WORKDIR /connector
 ENV PATH="/connector:$PATH"
 
+# Grab the statically-built schema-inference cli.
+COPY flow-bin/flow-schema-inference ./
+
 COPY --from=busybox:latest /bin/sh /bin/sh
 
 # Bring in the compiled connector artifact from the builder.

--- a/source-kinesis/Dockerfile
+++ b/source-kinesis/Dockerfile
@@ -10,6 +10,7 @@ COPY go.* ./
 RUN go mod download
 
 # Build the connector projects we depend on.
+COPY schema_inference ./schema_inference
 COPY source-kinesis ./source-kinesis
 
 # Run the unit tests.

--- a/source-kinesis/discovery.go
+++ b/source-kinesis/discovery.go
@@ -1,0 +1,212 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os/exec"
+	"sync"
+	"time"
+
+	"github.com/aws/aws-sdk-go/service/kinesis"
+	"github.com/estuary/flow/go/protocols/airbyte"
+	log "github.com/sirupsen/logrus"
+	"golang.org/x/sync/errgroup"
+)
+
+// How long should we allow reading from each stream to run. Note: empty streams
+// will wait for documents until this timeout triggers.
+const DISCOVER_READ_TIMEOUT = time.Second * 10
+
+// How long should we allow schema inference to run.
+const DISCOVER_INFER_TIMEOUT = time.Second * 5
+
+// How many documents to read from each stream. A higher number gives us more
+// opportunity to spot variation in the document stream at the expense of having
+// to process more possibly-redundant documents.
+const DISCOVER_MAX_DOCS_PER_STREAM = 100
+
+// Provides a default schema to use when we encounter an issue with schema inference.
+var FALLBACK_SCHEMA = json.RawMessage(`{"type":"object"}`)
+
+func discoverStreams(ctx context.Context, client *kinesis.Kinesis, streamNames []string) []airbyte.Stream {
+	var waitGroup = new(sync.WaitGroup)
+	var streams = make([]airbyte.Stream, len(streamNames))
+
+	for i, name := range streamNames {
+		waitGroup.Add(1)
+
+		go func(i int, name string) {
+			defer waitGroup.Done()
+
+			schema, err := discoverSchema(ctx, client, name)
+			if err != nil {
+				// If we encounter an error discovering the schema, output a
+				// very basic schema rather than failing discovery. If this
+				// looks wrong to the user, they can investigate, but ultimately
+				// not every stream will contain json documents.
+				log.WithField("stream", name).Error(err.Error())
+				schema = &FALLBACK_SCHEMA
+			}
+
+			streams[i] = airbyte.Stream{
+				Name:                name,
+				JSONSchema:          *schema,
+				SupportedSyncModes:  []airbyte.SyncMode{airbyte.SyncModeIncremental},
+				SourceDefinedCursor: true,
+			}
+		}(i, name)
+	}
+
+	waitGroup.Wait()
+
+	return streams
+}
+
+func discoverSchema(ctx context.Context, client *kinesis.Kinesis, streamName string) (*json.RawMessage, error) {
+	var logEntry = log.WithField("stream", streamName)
+	var peekCtx, cancelPeek = context.WithTimeout(ctx, DISCOVER_READ_TIMEOUT)
+	defer cancelPeek()
+
+	var docCh, docCount, err = peekAtStream(peekCtx, client, streamName, DISCOVER_MAX_DOCS_PER_STREAM)
+	if err != nil {
+		return nil, fmt.Errorf("schema discovery for stream `%s` failed: %w", streamName, err)
+	} else if docCount == 0 {
+		return nil, fmt.Errorf("no documents discovered for stream: %v", streamName)
+	}
+
+	logEntry.WithField("count", docCount).Info("Got documents for stream")
+
+	var inferCtx, cancelInfer = context.WithTimeout(ctx, DISCOVER_INFER_TIMEOUT)
+	defer cancelInfer()
+
+	var schema *json.RawMessage
+	schema, err = runInference(inferCtx, logEntry, docCh)
+	if err != nil {
+		return nil, fmt.Errorf("failed to infer schema for stream `%s`: %w", streamName, err)
+	}
+
+	return schema, nil
+}
+
+func runInference(ctx context.Context, logEntry *log.Entry, docsCh chan json.RawMessage) (*json.RawMessage, error) {
+	var (
+		err      error
+		errGroup *errgroup.Group
+		schema   = new(json.RawMessage)
+		cmd      *exec.Cmd
+		stdin    io.WriteCloser
+		stdout   io.ReadCloser
+	)
+
+	errGroup, ctx = errgroup.WithContext(ctx)
+	cmd = exec.CommandContext(ctx, "flow-schema-inference", "analyze")
+
+	stdin, err = cmd.StdinPipe()
+	if err != nil {
+		return nil, fmt.Errorf("failed to open stdin: %w", err)
+	}
+	stdout, err = cmd.StdoutPipe()
+	if err != nil {
+		return nil, fmt.Errorf("failed to open stdout: %w", err)
+	}
+
+	errGroup.Go(func() error {
+		defer stdin.Close()
+		encoder := json.NewEncoder(stdin)
+
+		for doc := range docsCh {
+			if err := encoder.Encode(doc); err != nil {
+				return fmt.Errorf("failed to encode document: %w", err)
+			}
+		}
+		logEntry.Info("runInference: Done sending documents")
+
+		return nil
+	})
+
+	errGroup.Go(func() error {
+		defer stdout.Close()
+		decoder := json.NewDecoder(stdout)
+
+		if err := decoder.Decode(schema); err != nil {
+			return fmt.Errorf("failed to decode schema, %w", err)
+		}
+		logEntry.Debug("runInference: Done reading schema")
+
+		return nil
+	})
+
+	logEntry.Info("runInference: launching")
+	err = cmd.Start()
+	if err != nil {
+		return nil, fmt.Errorf("failed to run flow-schema-inference: %w", err)
+	}
+
+	errGroup.Go(cmd.Wait)
+
+	err = errGroup.Wait()
+	if err != nil {
+		return nil, err
+	}
+
+	return schema, nil
+}
+
+func peekAtStream(ctx context.Context, client *kinesis.Kinesis, streamName string, peekAtMost uint) (chan json.RawMessage, uint, error) {
+	var (
+		err         error
+		cancel      context.CancelFunc
+		dataCh      chan readResult      = make(chan readResult, 8)
+		shardRange  airbyte.Range        = airbyte.NewFullRange()
+		stopAt      time.Time            = time.Now()
+		streamState map[string]string    = make(map[string]string)
+		waitGroup   *sync.WaitGroup      = new(sync.WaitGroup)
+		docs        chan json.RawMessage = make(chan json.RawMessage, peekAtMost)
+		docCount    uint                 = 0
+	)
+
+	ctx, cancel = context.WithCancel(ctx)
+	defer cancel()
+
+	waitGroup.Add(1)
+	go readStream(ctx, shardRange, client, streamName, streamState, dataCh, &stopAt, waitGroup)
+	go closeChannelWhenDone(dataCh, waitGroup)
+	defer close(docs)
+
+outerLoop:
+	for {
+		select {
+		case <-ctx.Done():
+			break outerLoop
+		case next, more := <-dataCh:
+			if !more {
+				break outerLoop
+			} else if next.err != nil {
+				// We'll log any errors to stderr, as any problems we encounter now are not
+				// necessarily fatal errors for discovery.
+				log.Errorf("peekAtStream failed due to error: %v", next.err)
+				return nil, 0, next.err
+			}
+
+			for _, record := range next.records {
+				select {
+				case docs <- record:
+					// Ok, keep going
+				default:
+					// We've filled up our buffer for this stream
+					break outerLoop
+				}
+				docCount++
+
+				if docCount >= peekAtMost {
+					// We've peeked at enough documents
+					break outerLoop
+				}
+			}
+		}
+	}
+
+	return docs, docCount, err
+}

--- a/source-kinesis/discovery.go
+++ b/source-kinesis/discovery.go
@@ -4,23 +4,14 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
-	"os/exec"
 	"sync"
 	"time"
 
 	"github.com/aws/aws-sdk-go/service/kinesis"
+	"github.com/estuary/connectors/schema_inference"
 	"github.com/estuary/flow/go/protocols/airbyte"
 	log "github.com/sirupsen/logrus"
-	"golang.org/x/sync/errgroup"
 )
-
-// How long should we allow reading from each stream to run. Note: empty streams
-// will wait for documents until this timeout triggers.
-const DISCOVER_READ_TIMEOUT = time.Second * 10
-
-// How long should we allow schema inference to run.
-const DISCOVER_INFER_TIMEOUT = time.Second * 5
 
 // How many documents to read from each stream. A higher number gives us more
 // opportunity to spot variation in the document stream at the expense of having
@@ -28,7 +19,7 @@ const DISCOVER_INFER_TIMEOUT = time.Second * 5
 const DISCOVER_MAX_DOCS_PER_STREAM = 100
 
 // Provides a default schema to use when we encounter an issue with schema inference.
-var FALLBACK_SCHEMA = json.RawMessage(`{"type":"object"}`)
+var DISCOVER_FALLBACK_SCHEMA = json.RawMessage(`{"type":"object"}`)
 
 func discoverStreams(ctx context.Context, client *kinesis.Kinesis, streamNames []string) []airbyte.Stream {
 	var waitGroup = new(sync.WaitGroup)
@@ -47,12 +38,12 @@ func discoverStreams(ctx context.Context, client *kinesis.Kinesis, streamNames [
 				// looks wrong to the user, they can investigate, but ultimately
 				// not every stream will contain json documents.
 				log.WithField("stream", name).Error(err.Error())
-				schema = &FALLBACK_SCHEMA
+				schema = DISCOVER_FALLBACK_SCHEMA
 			}
 
 			streams[i] = airbyte.Stream{
 				Name:                name,
-				JSONSchema:          *schema,
+				JSONSchema:          schema,
 				SupportedSyncModes:  []airbyte.SyncMode{airbyte.SyncModeIncremental},
 				SourceDefinedCursor: true,
 			}
@@ -64,25 +55,10 @@ func discoverStreams(ctx context.Context, client *kinesis.Kinesis, streamNames [
 	return streams
 }
 
-func discoverSchema(ctx context.Context, client *kinesis.Kinesis, streamName string) (*json.RawMessage, error) {
-	var logEntry = log.WithField("stream", streamName)
-	var peekCtx, cancelPeek = context.WithTimeout(ctx, DISCOVER_READ_TIMEOUT)
-	defer cancelPeek()
-
-	var docCh, docCount, err = peekAtStream(peekCtx, client, streamName, DISCOVER_MAX_DOCS_PER_STREAM)
-	if err != nil {
-		return nil, fmt.Errorf("schema discovery for stream `%s` failed: %w", streamName, err)
-	} else if docCount == 0 {
-		return nil, fmt.Errorf("no documents discovered for stream: %v", streamName)
-	}
-
-	logEntry.WithField("count", docCount).Info("Got documents for stream")
-
-	var inferCtx, cancelInfer = context.WithTimeout(ctx, DISCOVER_INFER_TIMEOUT)
-	defer cancelInfer()
-
-	var schema *json.RawMessage
-	schema, err = runInference(inferCtx, logEntry, docCh)
+func discoverSchema(ctx context.Context, client *kinesis.Kinesis, streamName string) (json.RawMessage, error) {
+	schema, err := schema_inference.Run(ctx, streamName, func(ctx context.Context, logEntry *log.Entry) (<-chan json.RawMessage, uint, error) {
+		return peekAtStream(ctx, client, streamName, DISCOVER_MAX_DOCS_PER_STREAM)
+	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to infer schema for stream `%s`: %w", streamName, err)
 	}
@@ -90,71 +66,7 @@ func discoverSchema(ctx context.Context, client *kinesis.Kinesis, streamName str
 	return schema, nil
 }
 
-func runInference(ctx context.Context, logEntry *log.Entry, docsCh chan json.RawMessage) (*json.RawMessage, error) {
-	var (
-		err      error
-		errGroup *errgroup.Group
-		schema   = new(json.RawMessage)
-		cmd      *exec.Cmd
-		stdin    io.WriteCloser
-		stdout   io.ReadCloser
-	)
-
-	errGroup, ctx = errgroup.WithContext(ctx)
-	cmd = exec.CommandContext(ctx, "flow-schema-inference", "analyze")
-
-	stdin, err = cmd.StdinPipe()
-	if err != nil {
-		return nil, fmt.Errorf("failed to open stdin: %w", err)
-	}
-	stdout, err = cmd.StdoutPipe()
-	if err != nil {
-		return nil, fmt.Errorf("failed to open stdout: %w", err)
-	}
-
-	errGroup.Go(func() error {
-		defer stdin.Close()
-		encoder := json.NewEncoder(stdin)
-
-		for doc := range docsCh {
-			if err := encoder.Encode(doc); err != nil {
-				return fmt.Errorf("failed to encode document: %w", err)
-			}
-		}
-		logEntry.Info("runInference: Done sending documents")
-
-		return nil
-	})
-
-	errGroup.Go(func() error {
-		defer stdout.Close()
-		decoder := json.NewDecoder(stdout)
-
-		if err := decoder.Decode(schema); err != nil {
-			return fmt.Errorf("failed to decode schema, %w", err)
-		}
-		logEntry.Debug("runInference: Done reading schema")
-
-		return nil
-	})
-
-	logEntry.Info("runInference: launching")
-	err = cmd.Start()
-	if err != nil {
-		return nil, fmt.Errorf("failed to run flow-schema-inference: %w", err)
-	}
-
-	errGroup.Go(cmd.Wait)
-
-	err = errGroup.Wait()
-	if err != nil {
-		return nil, err
-	}
-
-	return schema, nil
-}
-
-func peekAtStream(ctx context.Context, client *kinesis.Kinesis, streamName string, peekAtMost uint) (chan json.RawMessage, uint, error) {
+func peekAtStream(ctx context.Context, client *kinesis.Kinesis, streamName string, peekAtMost uint) (<-chan json.RawMessage, uint, error) {
 	var (
 		err         error
 		cancel      context.CancelFunc

--- a/source-kinesis/main.go
+++ b/source-kinesis/main.go
@@ -68,24 +68,16 @@ func discoverCatalog(config airbyte.ConfigFile) (*airbyte.Catalog, error) {
 	if err != nil {
 		return nil, err
 	}
+
 	var ctx = context.Background()
 	streamNames, err := listAllStreams(ctx, client)
 	if err != nil {
 		return nil, err
 	}
 
-	var catalog = &airbyte.Catalog{
-		Streams: make([]airbyte.Stream, len(streamNames)),
-	}
-	for i, name := range streamNames {
-		catalog.Streams[i] = airbyte.Stream{
-			Name:                name,
-			JSONSchema:          json.RawMessage(`{"type":"object"}`),
-			SupportedSyncModes:  []airbyte.SyncMode{airbyte.SyncModeIncremental},
-			SourceDefinedCursor: true,
-		}
-	}
-	return catalog, nil
+	streams := discoverStreams(ctx, client, streamNames)
+
+	return &airbyte.Catalog{Streams: streams}, nil
 }
 
 func updateState(state map[string]map[string]string, source *recordSource, sequenceNumber string) {

--- a/source-s3/Dockerfile
+++ b/source-s3/Dockerfile
@@ -10,6 +10,7 @@ COPY go.* ./
 RUN go mod download
 
 # Build the connector projects we depend on.
+COPY schema_inference ./schema_inference
 COPY filesource ./filesource
 COPY source-s3 ./source-s3
 

--- a/source-s3/Dockerfile
+++ b/source-s3/Dockerfile
@@ -32,6 +32,8 @@ COPY --from=busybox:latest /bin/sh /bin/sh
 
 # Grab the statically-built parser cli.
 COPY flow-bin/flow-parser ./
+# Grab the statically-built schema-inference cli.
+COPY flow-bin/flow-schema-inference ./
 
 # Bring in the compiled connector artifact from the builder.
 COPY --from=builder /builder/connector ./connector

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -92,7 +92,7 @@ trap "kill -s SIGTERM ${DATA_PLANE_PID} && wait ${DATA_PLANE_PID} && ./tests/${C
 export ID_TYPE="${ID_TYPE:-integer}"
 
 # Verify discover works
-${TESTDIR}/flowctl api discover --image="${CONNECTOR_IMAGE}" --log.level=debug --config=<(echo ${CONNECTOR_CONFIG}) > ${TESTDIR}/discover_output.json || bail "Discover failed."
+${TESTDIR}/flowctl api discover --image="${CONNECTOR_IMAGE}" --network=host --log.level=debug --config=<(echo ${CONNECTOR_CONFIG}) > ${TESTDIR}/discover_output.json || bail "Discover failed."
 cat ${TESTDIR}/discover_output.json | jq ".bindings[] | select(.recommendedName == \"${TEST_STREAM}\") | .documentSchema" > ${TESTDIR}/bindings.json
 
 if [[ -f "tests/${CONNECTOR}/bindings.json" ]]; then

--- a/tests/source-gcs/bindings.json
+++ b/tests/source-gcs/bindings.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "required": [
+    "_meta",
+    "canary",
+    "id"
+  ],
+  "properties": {
+    "_meta": {
+      "type": "object",
+      "required": [
+        "file",
+        "offset"
+      ],
+      "properties": {
+        "file": {
+          "type": "string"
+        },
+        "offset": {
+          "type": "integer"
+        }
+      }
+    },
+    "canary": {
+      "type": "string"
+    },
+    "id": {
+      "type": "string"
+    }
+  }
+}

--- a/tests/source-gcs/setup.sh
+++ b/tests/source-gcs/setup.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 set -e
-export TEST_BUCKET="estuary-test-$(shuf -zer -n6 {a..z} | tr -d '\0')"
-export RESOURCE="{ stream: ${TEST_BUCKET} }"
+export TEST_STREAM="estuary-test-$(shuf -zer -n6 {a..z} | tr -d '\0')"
+export RESOURCE="{ stream: ${TEST_STREAM} }"
 # set ID_TYPE to string because parsing CSV files will always result in string values.
 export ID_TYPE=string
 
@@ -10,19 +10,19 @@ export GCP_SERVICE_ACCOUNT_KEY_QUOTED=$(echo ${GCP_SERVICE_ACCOUNT_KEY} | jq 'to
 
 config_json_template='{
     "googleCredentials": ${GCP_SERVICE_ACCOUNT_KEY_QUOTED},
-    "bucket": "${TEST_BUCKET}"
+    "bucket": "${TEST_STREAM}"
 }'
 
 export CONNECTOR_CONFIG="$(echo "$config_json_template" | envsubst | jq -c)"
 
-gsutil mb -p "$GCP_PROJECT_ID" "gs://${TEST_BUCKET}"
+gsutil mb -p "$GCP_PROJECT_ID" "gs://${TEST_STREAM}"
 
 root_dir="$(git rev-parse --show-toplevel)"
 
 # We need to exclude the json file from the test because the `id` property there is an integer, and
 # this connector expects it to be a string.
 for file in $(find ${root_dir}/tests/files -type f -name '*.csv*'); do
-    gsutil cp ${file} gs://${TEST_BUCKET}/testprefix/$(basename $file)
+    gsutil cp ${file} gs://${TEST_STREAM}/testprefix/$(basename $file)
 done
 
 sleep_seconds=30

--- a/tests/source-kinesis/bindings.json
+++ b/tests/source-kinesis/bindings.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "required": [
+    "canary",
+    "foo",
+    "id"
+  ],
+  "properties": {
+    "canary": {
+      "type": "string"
+    },
+    "foo": {
+      "type": [
+        "boolean",
+        "integer",
+        "string"
+      ]
+    },
+    "id": {
+      "type": "integer"
+    }
+  }
+}

--- a/tests/source-kinesis/setup.sh
+++ b/tests/source-kinesis/setup.sh
@@ -25,4 +25,3 @@ do
         --partition-key "$(head -c 12 /dev/urandom | base64)" \
         --data "$(echo "$doc" | base64)"
 done < tests/files/d.jsonl
-

--- a/tests/source-s3/setup.sh
+++ b/tests/source-s3/setup.sh
@@ -2,32 +2,32 @@
 
 set -e
 
-export TEST_BUCKET="estuary-test-$(shuf -zer -n6 {a..z} | tr -d '\0')"
-export RESOURCE="{ stream: ${TEST_BUCKET} }"
+export TEST_STREAM="estuary-test-$(shuf -zer -n6 {a..z} | tr -d '\0')"
+export RESOURCE="{ stream: ${TEST_STREAM} }"
 # set ID_TYPE to string because parsing CSV files will always result in string values.
 export ID_TYPE=string
 
 config_json_template='{
     "awsAccessKeyId": "$AWS_ACCESS_KEY_ID",
     "awsSecretAccessKey": "$AWS_SECRET_ACCESS_KEY",
-    "bucket": "${TEST_BUCKET}",
+    "bucket": "${TEST_STREAM}",
     "region": "${DEFAULT_AWS_REGION}"
 }'
 
 export CONNECTOR_CONFIG="$(echo "$config_json_template" | envsubst | jq -c)"
 
-aws s3api create-bucket --bucket $TEST_BUCKET --create-bucket-configuration LocationConstraint="${DEFAULT_AWS_REGION}"
+aws s3api create-bucket --bucket $TEST_STREAM --create-bucket-configuration LocationConstraint="${DEFAULT_AWS_REGION}"
 
 root_dir="$(git rev-parse --show-toplevel)"
 
 # We need to exclude the json file from the test because the `id` property there is an integer, and
 # this connector expects it to be a string.
 for file in $(find ${root_dir}/tests/files -type f -name '*.csv*'); do
-    aws s3 cp ${file} s3://${TEST_BUCKET}/testprefix/$(basename $file)
+    aws s3 cp ${file} s3://${TEST_STREAM}/testprefix/$(basename $file)
 done
 
 # add an empty prefix to ensure that it gets filtered out
-aws s3api put-object --bucket "$TEST_BUCKET" --key "testprefix/"
+aws s3api put-object --bucket "$TEST_STREAM" --key "testprefix/"
 
 sleep_seconds=30
 echo "Sleeping for ${sleep_seconds} seconds to account for filesource clock delta"


### PR DESCRIPTION
**Description:**

Kinesis, S3, and GCS do not provide any facilities to introspect on the data in its streams/files. This leads to a lackluster user experience, as the discovered bindings all have an empty json schema. This means to get the most value out of Flow, the user needs to author a json schema from scratch. This is less than ideal.

Instead, we'll have these connectors use the `flow-schema-inference` tool to generate simple schemas from the data we read from the streams themselves. Not all of these will be maximally useful, but it's a great start for a user just trying the system. A more advanced user can always edit these schemas with more useful annotations.

**Workflow steps:** (Kinesis example)

1. Login to the AWS CLI.
1. Create a Kinesis stream
1. Seed that stream with some documents
1. Open the UI
1. Select AWS Kinesis as your source
1. Enter your AWS credentials
1. Generate your catalog
1. Admire the what a nice schema you have

Alternatively, you can use the CLI:
```bash
flowctl-go api discover --image=ghcr.io/estuary/source-kinesis:v1 --config=source-kinesis/kinesis-config.json | jq
```

**Picture Worth At Least 1000 words**:

![Screenshot 2022-06-27 at 17-23-16 Flow · Create Capture](https://user-images.githubusercontent.com/119613/176037986-b9703bc6-5e76-46e4-9888-3f43ea87b2ad.png)


**Documentation links affected:**

None. This is an entirely behind the scenes enhancement. Using the Kinesis, S3, and GCS connectors should just get a little better for users.

**Notes for reviewers:**

N/A

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/278)
<!-- Reviewable:end -->
