### PR TITLE
source-test: add authSpec for google

### DIFF
--- a/source-test/main.go
+++ b/source-test/main.go
@@ -66,6 +66,13 @@ const greetingSchema = `{
 	"required": ["count", "message"]
 }`
 
+const oauthSpec = `{
+  "provider": "google",
+  "authUrlTemplate": "https://accounts.google.com/o/oauth2/auth?access_type=offline&client_id={{ client_id }}&redirect_uri={{ redirect_uri }}&response_type=code&scope=email&state={{ state }}",
+  "accessTokenUrlTemplate": "https://oauth2.googleapis.com/token",
+  "accessTokenBody": "{\"grant_type\": \"authorization_code\", \"client_id\": \"{{ client_id }}\", \"client_secret\": \"{{ client_secret }}\", \"redirect_uri\": \"{{ redirect_uri }}\", \"code\": \"{{ code }}\"}"
+}`
+
 func main() {
 	airbyte.RunMain(spec, doCheck, doDiscover, doRead)
 }
@@ -74,6 +81,7 @@ var spec = airbyte.Spec{
 	SupportsIncremental:           true,
 	SupportedDestinationSyncModes: airbyte.AllDestinationSyncModes,
 	ConnectionSpecification:       json.RawMessage(configSchema),
+	AuthSpecification:             json.RawMessage(oauthSpec),
 }
 
 func doCheck(args airbyte.CheckCmd) error {


### PR DESCRIPTION
**Description:**

- Adds auth_specification to source-test for google OAuth2
- To be tested with https://github.com/estuary/flow/pull/570

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/281)
<!-- Reviewable:end -->
