### PR TITLE
source-mysql: Add support for ENUM and SET column types

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -35,6 +35,7 @@ require (
 	github.com/klauspost/compress v1.15.5 // indirect
 	github.com/mattn/go-ieproxy v0.0.6 // indirect
 	github.com/mattn/go-sqlite3 v2.0.3+incompatible
+	github.com/mitchellh/mapstructure v1.4.1
 	github.com/pierrec/lz4/v4 v4.1.14 // indirect
 	github.com/prometheus/client_golang v1.12.2 // indirect
 	github.com/prometheus/common v0.34.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -826,6 +826,7 @@ github.com/mitchellh/gox v0.4.0/go.mod h1:Sd9lOJ0+aimLBi73mGofS1ycjY8lL3uZM3JPS4
 github.com/mitchellh/iochan v1.0.0/go.mod h1:JwYml1nuB7xOzsp52dPpHFffvOCDupsG0QubkSMEySY=
 github.com/mitchellh/mapstructure v0.0.0-20160808181253-ca63d7c062ee/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
+github.com/mitchellh/mapstructure v1.4.1 h1:CpVNEelQCZBooIPDn+AR3NpivK/TIKU8bDxdASFVQag=
 github.com/mitchellh/mapstructure v1.4.1/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=

--- a/source-mysql/backfill.go
+++ b/source-mysql/backfill.go
@@ -34,7 +34,7 @@ func (db *mysqlDatabase) ScanTableChunk(ctx context.Context, info sqlcapture.Tab
 		"resumeKey":  resumeKey,
 	}).Debug("scanning table chunk")
 
-	var columnTypes = make(map[string]string)
+	var columnTypes = make(map[string]interface{})
 	for name, column := range info.Columns {
 		columnTypes[name] = column.DataType
 	}

--- a/source-mysql/datatype_test.go
+++ b/source-mysql/datatype_test.go
@@ -66,9 +66,9 @@ func TestDatatypes(t *testing.T) {
 		{ColumnType: "mediumblob", ExpectType: `{"type":["string","null"],"contentEncoding":"base64"}`, InputValue: []byte{0x12, 0x34, 0x56, 0x78}, ExpectValue: `"EjRWeA=="`},
 		{ColumnType: "longblob", ExpectType: `{"type":["string","null"],"contentEncoding":"base64"}`, InputValue: []byte{0x12, 0x34, 0x56, 0x78}, ExpectValue: `"EjRWeA=="`},
 
-		{ColumnType: `enum('sm', 'med', 'lg')`, ExpectType: `{"type":["string","null"],"enum":["sm","med","lg"]}`, InputValue: nil, ExpectValue: `null`},
-		{ColumnType: `enum('sm', 'med', 'lg')`, ExpectType: `{"type":["string","null"],"enum":["sm","med","lg"]}`, InputValue: "sm", ExpectValue: `"sm"`},
-		{ColumnType: `enum('s,m', 'med', '\'lg\'')`, ExpectType: `{"type":["string","null"],"enum":["s,m","med","'lg'"]}`, InputValue: `'lg'`, ExpectValue: `"'lg'"`},
+		{ColumnType: `enum('sm', 'med', 'lg')`, ExpectType: `{"type":["string","null"],"enum":["sm","med","lg",null]}`, InputValue: nil, ExpectValue: `null`},
+		{ColumnType: `enum('sm', 'med', 'lg') not null`, ExpectType: `{"type":"string","enum":["sm","med","lg"]}`, InputValue: "sm", ExpectValue: `"sm"`},
+		{ColumnType: `enum('s,m', 'med', '\'lg\'')`, ExpectType: `{"type":["string","null"],"enum":["s,m","med","'lg'",null]}`, InputValue: `'lg'`, ExpectValue: `"'lg'"`},
 
 		{ColumnType: "set('a', 'b', 'c')", ExpectType: `{"type":["string","null"]}`, InputValue: "b", ExpectValue: `"b"`},
 		{ColumnType: "set('a', 'b', 'c')", ExpectType: `{"type":["string","null"]}`, InputValue: "a,c", ExpectValue: `"a,c"`},

--- a/source-mysql/datatype_test.go
+++ b/source-mysql/datatype_test.go
@@ -66,13 +66,12 @@ func TestDatatypes(t *testing.T) {
 		{ColumnType: "mediumblob", ExpectType: `{"type":["string","null"],"contentEncoding":"base64"}`, InputValue: []byte{0x12, 0x34, 0x56, 0x78}, ExpectValue: `"EjRWeA=="`},
 		{ColumnType: "longblob", ExpectType: `{"type":["string","null"],"contentEncoding":"base64"}`, InputValue: []byte{0x12, 0x34, 0x56, 0x78}, ExpectValue: `"EjRWeA=="`},
 
-		// TODO(wgd): Enums are reported differently in backfills vs replication. Backfill queries return
-		// the string value of the column, while replicated change events appear to hold an integer index.
-		// {ColumnType: "enum('small', 'medium', 'large')", ExpectType: `{"type":["string","null"]}`, InputValue: "medium", ExpectValue: `"medium"`},
+		{ColumnType: `enum('sm', 'med', 'lg')`, ExpectType: `{"type":["string","null"],"enum":["sm","med","lg"]}`, InputValue: nil, ExpectValue: `null`},
+		{ColumnType: `enum('sm', 'med', 'lg')`, ExpectType: `{"type":["string","null"],"enum":["sm","med","lg"]}`, InputValue: "sm", ExpectValue: `"sm"`},
+		{ColumnType: `enum('s,m', 'med', '\'lg\'')`, ExpectType: `{"type":["string","null"],"enum":["s,m","med","'lg'"]}`, InputValue: `'lg'`, ExpectValue: `"'lg'"`},
 
-		// TODO(wgd): Sets are reported differently in backfills vs replication. Backfill queries return
-		// the string value of the column, while replicated change events appear to hold a bitfield integer.
-		// {ColumnType: "SET('one', 'two')", ExpectType: `{"type":["string","null"]}`, InputValue: "one,two", ExpectValue: `"one,two"`},
+		{ColumnType: "set('a', 'b', 'c')", ExpectType: `{"type":["string","null"]}`, InputValue: "b", ExpectValue: `"b"`},
+		{ColumnType: "set('a', 'b', 'c')", ExpectType: `{"type":["string","null"]}`, InputValue: "a,c", ExpectValue: `"a,c"`},
 
 		{ColumnType: "date", ExpectType: `{"type":["string","null"]}`, InputValue: "1991-08-31", ExpectValue: `"1991-08-31"`},
 		{ColumnType: "datetime", ExpectType: `{"type":["string","null"]}`, InputValue: "1991-08-31 12:34:56", ExpectValue: `"1991-08-31 12:34:56"`},

--- a/source-mysql/discovery.go
+++ b/source-mysql/discovery.go
@@ -100,7 +100,14 @@ func (db *mysqlDatabase) TranslateDBToJSONType(column sqlcapture.ColumnInfo) (*j
 		schema.nullable = column.IsNullable
 		schema.extras = make(map[string]interface{})
 		if columnType.Type == "enum" {
-			schema.extras["enum"] = columnType.EnumValues
+			var options []interface{}
+			for _, val := range columnType.EnumValues {
+				options = append(options, val)
+			}
+			if column.IsNullable {
+				options = append(options, nil)
+			}
+			schema.extras["enum"] = options
 		}
 		// TODO(wgd): Is there a good way to describe possible SET values
 		// as a JSON schema? Currently discovery just says 'string'.

--- a/source-postgres/discovery.go
+++ b/source-postgres/discovery.go
@@ -84,7 +84,10 @@ func (db *postgresDatabase) DiscoverTables(ctx context.Context) (map[string]sqlc
 // TranslateDBToJSONType returns JSON schema information about the provided database column type.
 func (db *postgresDatabase) TranslateDBToJSONType(column sqlcapture.ColumnInfo) (*jsonschema.Schema, error) {
 	// If the column type looks like `_foo` then it's an array of elements of type `foo`.
-	var columnType = column.DataType
+	var columnType, ok = column.DataType.(string)
+	if !ok {
+		return nil, fmt.Errorf("unhandled PostgreSQL type %q", columnType)
+	}
 	var arrayColumn = false
 	if strings.HasPrefix(columnType, "_") {
 		columnType = strings.TrimPrefix(columnType, "_")
@@ -92,7 +95,7 @@ func (db *postgresDatabase) TranslateDBToJSONType(column sqlcapture.ColumnInfo) 
 	}
 
 	// Translate the basic value/element type into a JSON Schema type
-	var colSchema, ok = postgresTypeToJSON[columnType]
+	colSchema, ok := postgresTypeToJSON[columnType]
 	if !ok {
 		return nil, fmt.Errorf("unhandled PostgreSQL type %q", columnType)
 	}

--- a/sqlcapture/interface.go
+++ b/sqlcapture/interface.go
@@ -153,11 +153,11 @@ type TableInfo struct {
 // database, and is used during discovery to automatically generate catalog
 // information.
 type ColumnInfo struct {
-	Name        string  // The name of the column.
-	Index       int     // The ordinal position of this column in a row.
-	TableName   string  // The name of the table to which this column belongs.
-	TableSchema string  // The schema of the table to which this column belongs.
-	IsNullable  bool    // True if the column can contain nulls.
-	DataType    string  // The PostgreSQL type name of this column.
-	Description *string // Stored PostgreSQL description of the column, if any.
+	Name        string      // The name of the column.
+	Index       int         // The ordinal position of this column in a row.
+	TableName   string      // The name of the table to which this column belongs.
+	TableSchema string      // The schema of the table to which this column belongs.
+	IsNullable  bool        // True if the column can contain nulls.
+	DataType    interface{} // The datatype of this column. May be a string name or a more complex struct.
+	Description *string     // Stored description of the column, if any.
 }


### PR DESCRIPTION
**Description:**

This change required some tweaks to the plumbing around column types. Previously the `DataType` of a column was represented as a string with values like `"int"` or `"text"`, but representing the possible values of an enum column required richer metadata. This was accomplished in a backwards-compatible way by turning the string into an `interface{}` value, and leaving the majority
of column types as a string. Thus the JSON-serialized type names included in state checkpoints are unchanged for other types.

Then a new `mysqlColumnType` struct was defined with an `EnumValues` array and a `Type` property. Currently this is only used for enum and set, but if any other types required richer metadata in the future the same struct can be extended. After deserializing table metadata from state checkpoints during startup, this struct will have gotten turned into a `map[string]interface{}` so a bit of additional logic uses the `mapstructure` package to turn that back into a usable struct.

(It should be noted that the `TestDatatypes` test cases already exercise the state checkpoint metadata round-tripping behavior
because of how they're written, so no new logic was added but that's still being checked).

There's also some new logic to parse a column type name such as `enum('foo', 'a,b,c', 'baz')` into `["foo", "a,b,c", "baz"]`. I'm still not entirely happy with how that part looks, but I believe it should handle all edge cases in practice.

In addition, discovery can now produce useful JSON-schemas for `ENUM` columns, but I don't believe there's a good way to do the same for `SET`, since the default MySQL representation for a set column's value is a comma-separated string like `"foo,bar,baz"` and so I've elected to convert the replicated bitfield version into that form as well.

**Workflow steps:**

Discovery and captures of MySQL tables with `ENUM` and `SET` columns should now work better. Specifically the discovered schema will be more useful and no longer contain a complaint about unrecognized types, and captured values will be useful strings instead of an inconsistent mix of human-readable strings (from backfills) and integer indices/bitfields (from replication).

**Documentation links affected:**

None, to my knowledge.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/282)
<!-- Reviewable:end -->
