### PR TITLE
materialize-elasticsearch: mark field overrides as optional

### DIFF
--- a/materialize-elasticsearch/.snapshots/TestDriverSpec
+++ b/materialize-elasticsearch/.snapshots/TestDriverSpec
@@ -29,8 +29,7 @@
     "$schema": "http://json-schema.org/draft-04/schema#",
     "required": [
       "index",
-      "delta_updates",
-      "field_overrides"
+      "delta_updates"
     ],
     "properties": {
       "index": {

--- a/materialize-elasticsearch/driver.go
+++ b/materialize-elasticsearch/driver.go
@@ -34,7 +34,7 @@ func (c config) Validate() error {
 type resource struct {
 	Index         string                        `json:"index"`
 	DeltaUpdates  bool                          `json:"delta_updates"`
-	FieldOverides []schemabuilder.FieldOverride `json:"field_overrides"`
+	FieldOverides []schemabuilder.FieldOverride `json:"field_overrides,omitempty"`
 
 	NumOfShards   int `json:"number_of_shards,omitempty" jsonschema:"default=1"`
 	NumOfReplicas int `json:"number_of_replicas,omitempty"`


### PR DESCRIPTION
**Description:**

- Field overrides are not actually required, they can be omitted

**Workflow steps:**

- `flowctl api spec --image ghcr.io/estuary/materialize-elasticsearch` and this field should no longer be required.

**Documentation links affected:**

See: https://github.com/estuary/flow/pull/588

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/290)
<!-- Reviewable:end -->
