### PR TITLE
Phil/bq bucket validation

### DIFF
--- a/materialize-bigquery/.snapshots/TestSpecification
+++ b/materialize-bigquery/.snapshots/TestSpecification
@@ -6,7 +6,6 @@
       "dataset",
       "region",
       "bucket",
-      "bucket_path",
       "credentials_json"
     ],
     "properties": {

--- a/materialize-bigquery/bigquery.go
+++ b/materialize-bigquery/bigquery.go
@@ -47,7 +47,7 @@ type config struct {
 	Dataset          string     `json:"dataset" jsonschema:"title=Dataset,description=BigQuery dataset that will be used to store the materialization output."`
 	Region           string     `json:"region" jsonschema:"title=Region,description=Region where both the Bucket and the BigQuery dataset is located. They both need to be within the same region."`
 	Bucket           string     `json:"bucket" jsonschema:"title=Bucket,description=Google Cloud Storage bucket that is going to be used to store specfications & temporary data before merging into BigQuery."`
-	BucketPath       string     `json:"bucket_path" jsonschema:"title=Bucket Path,description=A prefix that will be used to store objects to Google Cloud Storage's bucket."`
+	BucketPath       string     `json:"bucket_path,omitempty" jsonschema:"title=Bucket Path,description=A prefix that will be used to store objects to Google Cloud Storage's bucket."`
 	CredentialsJSON  credential `json:"credentials_json" jsonschema:"title=Credentials,description=Google Cloud Service Account JSON credentials in base64 format." jsonschema_extras:"secret=true,multiline=true"`
 }
 

--- a/materialize-bigquery/transactor.go
+++ b/materialize-bigquery/transactor.go
@@ -141,7 +141,7 @@ func (t *transactor) Store(it *pm.StoreIterator) error {
 	for it.Next() {
 		var b = t.bindings[it.Binding]
 
-		// Check to see if we have a keyFile open already in gcs for this binding and if not, create one.
+		// Check to see if we have a mergeFile open already in gcs for this binding and if not, create one.
 		if b.store.mergeFile == nil {
 			b.store.mergeFile, err = t.ep.NewExternalDataConnectionFile(
 				ctx,


### PR DESCRIPTION
**Description:**

Fixes #292 

Previously, if a bigquery materialization had a bucket path that started
with a `/`, it would silently fail to materialize any data. This fixes
the object key generation to handle the presence of the /. This allows
configurations with `bucket_path: /` to work, since users seem inclined
to use / instead of leaving it empty.

Additionally, this makes `bucket_path` optional, instead of required. It was always allowed to be empty, so having it be required just seemed a little silly. There's also no way to specify an empty string via the UI, so this means you don't have to set it if you just want to use the root of the bucket.

**Workflow steps:** no change

**Documentation links affected:**

The table in the  [Bigquery docs](https://docs.estuary.dev/reference/Connectors/materialization-connectors/BigQuery/) will need updated to reflect that `bucket_path` is no longer required.

**Notes for reviewers:** n/a

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/293)
<!-- Reviewable:end -->
