### PR TITLE
Update references `flowctl` -> `flowctl-admin`

### DIFF
--- a/flowsim/testcat/testcat.go
+++ b/flowsim/testcat/testcat.go
@@ -129,7 +129,7 @@ func (ep TestEndpointFlowSync) MarshalYAML() (interface{}, error) {
 	}, nil
 }
 
-// BuildMaterializationSpecs invokes `flowctl check` to build the named |source|
+// BuildMaterializationSpecs invokes `flowctl-admin check` to build the named |source|
 // catalog and returns its MaterializationSpecs.  It converts the
 // materialization to SQLite to not require docker container to exist.  Once
 // complete it puts back the original materialization without the connector
@@ -183,14 +183,14 @@ func BuildMaterializationSpecs(ctx context.Context, tc *TestCatalog) ([]*flow.Ma
 
 	const buildId string = "built-catalog"
 
-	// Invoke flowctl to compile the catalog.
-	var cmd = exec.Command("flowctl", "api", "build", "--directory", workdir, "--source", file.Name(), "--build-id", buildId)
+	// Invoke flowctl-admin to compile the catalog.
+	var cmd = exec.Command("flowctl-admin", "api", "build", "--directory", workdir, "--source", file.Name(), "--build-id", buildId)
 	cmd.Stdout, cmd.Stderr = os.Stdout, os.Stderr
 	if err = cmd.Run(); err != nil {
 		logrus.Error("dumping catalog")
 		dump, _ := os.ReadFile(file.Name())
 		fmt.Print(string(dump))
-		return nil, fmt.Errorf("running flowctl check: %w", err)
+		return nil, fmt.Errorf("running flowctl-admin check: %w", err)
 	}
 
 	var builtMaterializations []*flow.MaterializationSpec

--- a/materialize-google-sheets/Dockerfile
+++ b/materialize-google-sheets/Dockerfile
@@ -9,8 +9,8 @@ WORKDIR /builder
 COPY go.* ./
 RUN go mod download
 
-# Copy in a recent `flowctl` for usage by tests.
-COPY --from=ghcr.io/estuary/flow:dev /usr/local/bin/flowctl /usr/local/bin/flowctl
+# Copy in a recent `flowctl-admin` for usage by tests.
+COPY --from=ghcr.io/estuary/flow:dev /usr/local/bin/flowctl-admin /usr/local/bin/flowctl-admin
 
 # Build the connector projects we depend on.
 COPY materialize-boilerplate   ./materialize-boilerplate

--- a/materialize-rockset/README.md
+++ b/materialize-rockset/README.md
@@ -87,7 +87,7 @@ The [materialize-s3-parquet](../materialize-s3-parquet/) connector can be used t
               prefix: example/s3-prefix/
           source: example/flow/collection
   ```
-5. When you activate the new materialization, the connector will create the Rockset collection using the given integration, and wait for it to ingest all of the data from S3 before it continues. During this time, the Flow shards will remain in `STANDBY` status, so `flowctl deploy` is expected to block until the bulk ingestion completes. Once this completes, the materialize-rockset connector will automatically switch over to using the write API.
+5. When you activate the new materialization, the connector will create the Rockset collection using the given integration, and wait for it to ingest all of the data from S3 before it continues. During this time, the Flow shards will remain in `STANDBY` status, so `flowctl-admin deploy` is expected to block until the bulk ingestion completes. Once this completes, the materialize-rockset connector will automatically switch over to using the write API.
 
 ## Potential improvements
 

--- a/materialize-s3-parquet/Dockerfile
+++ b/materialize-s3-parquet/Dockerfile
@@ -9,8 +9,8 @@ WORKDIR /builder
 COPY go.* ./
 RUN go mod download
 
-# Copy in a recent `flowctl` for usage by tests.
-COPY --from=ghcr.io/estuary/flow:dev /usr/local/bin/flowctl /usr/local/bin/flowctl
+# Copy in a recent `flowctl-admin` for usage by tests.
+COPY --from=ghcr.io/estuary/flow:dev /usr/local/bin/flowctl-admin /usr/local/bin/flowctl-admin
 
 # Build the connector projects we depend on.
 COPY materialize-boilerplate ./materialize-boilerplate

--- a/materialize-webhook/Dockerfile
+++ b/materialize-webhook/Dockerfile
@@ -9,8 +9,8 @@ WORKDIR /builder
 COPY go.* ./
 RUN go mod download
 
-# Copy in a recent `flowctl` for usage by tests.
-COPY --from=ghcr.io/estuary/flow:dev /usr/local/bin/flowctl /usr/local/bin/flowctl
+# Copy in a recent `flowctl-admin` for usage by tests.
+COPY --from=ghcr.io/estuary/flow:dev /usr/local/bin/flowctl-admin /usr/local/bin/flowctl-admin
 
 # Build the connector projects we depend on.
 COPY materialize-boilerplate ./materialize-boilerplate

--- a/source-kafka/README.md
+++ b/source-kafka/README.md
@@ -4,7 +4,7 @@ This is an [Airbyte Specification-compatible](https://docs.airbyte.io/understand
 
 ## Getting Started
 
-To get started using this connector with Estuary Flow, run `flowctl discover --image ghcr.io/estuary/source-kafka:TAG`.
+To get started using this connector with Estuary Flow, run `flowctl-admin discover --image ghcr.io/estuary/source-kafka:TAG`.
 
 The remainder of this README is geared toward developers who wish to contribute or integrate the connector in other projects.
 

--- a/sqlcapture/discovery.go
+++ b/sqlcapture/discovery.go
@@ -51,7 +51,7 @@ func DiscoverCatalog(ctx context.Context, db Database) (*airbyte.Catalog, error)
 					"type":  column.DataType,
 				}).Warn("error translating column type to JSON schema")
 
-				// Logging an error from the connector is nice, but can be swallowed by `flowctl`.
+				// Logging an error from the connector is nice, but can be swallowed by `flowctl-admin`.
 				// Putting an error in the generated schema is ugly, but makes the failure visible.
 				properties[column.Name] = &jsonschema.Type{
 					Description: fmt.Sprintf("ERROR: could not translate column type %q to JSON schema: %v", column.DataType, err),

--- a/tests/materialize/flowctl-admin/build-and-activate.sh
+++ b/tests/materialize/flowctl-admin/build-and-activate.sh
@@ -4,14 +4,14 @@ set -e
 
 echo "building and activating the testing catalog via build-and-activate.sh"
 
-flowctl api build \
+flowctl-admin api build \
   --directory "${TEST_DIR}"/builds \
   --build-id "${BUILD_ID}" \
   --source "file://${TEST_DIR}/${CATALOG}" \
   --network host \
   --log.level debug
 
-flowctl api activate \
+flowctl-admin api activate \
   --build-id "${BUILD_ID}" \
   --network host \
   --log.level debug \

--- a/tests/materialize/flowctl-admin/combine.sh
+++ b/tests/materialize/flowctl-admin/combine.sh
@@ -10,7 +10,7 @@ if [[ ${#args[@]} -ne 3 ]]; then
     exit 1
 fi
 
-flowctl combine \
+flowctl-admin combine \
     --collection "${args[0]}" \
     --source "file://${TEST_DIR}/${CATALOG}" \
     --log.level debug \

--- a/tests/materialize/flowctl-admin/delete.sh
+++ b/tests/materialize/flowctl-admin/delete.sh
@@ -4,7 +4,7 @@
 set -e
 echo "deleting the testing catalog via delete.sh"
 
-flowctl api delete \
+flowctl-admin api delete \
   --build-id ${BUILD_ID} \
   --log.level debug \
   --all

--- a/tests/materialize/flowctl-admin/temp-data-plane.sh
+++ b/tests/materialize/flowctl-admin/temp-data-plane.sh
@@ -4,7 +4,7 @@
 set -e
 echo "starting a temp data plane via temp-data-plane.sh"
 
-flowctl temp-data-plane \
+flowctl-admin temp-data-plane \
     --sigterm \
     --tempdir "${TEST_DIR}" \
     --network host \

--- a/testsupport/build_catalog.go
+++ b/testsupport/build_catalog.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// CatalogExtract invokes `flowctl` to build the named catalog
+// CatalogExtract invokes `flowctl-admin` to build the named catalog
 // |sourcePath|, and then invokes the callback with its build
 // output database.
 func CatalogExtract(t *testing.T, sourcePath string, fn func(*sql.DB) error) error {
@@ -20,7 +20,7 @@ func CatalogExtract(t *testing.T, sourcePath string, fn func(*sql.DB) error) err
 
 	var tempdir = t.TempDir()
 	var cmd = exec.Command(
-		"flowctl",
+		"flowctl-admin",
 		"api",
 		"build",
 		"--build-id", "catalog",


### PR DESCRIPTION
**Description:**

We recently split out a new `flowctl` tool which interacts with the control plane, rather than the data plane directly. Instead, the old `flowctl` was renamed `flowctl-admin`. This updates the connector tests and docs to use `flowctl-admin` as it still contains the commands and behavior they expect.


**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/296)
<!-- Reviewable:end -->
