### PR TITLE
increase schema inference sampling limit to 40k

### DIFF
--- a/filesource/discovery.go
+++ b/filesource/discovery.go
@@ -16,7 +16,7 @@ import (
 )
 
 // How many documents should we read from an individual file during discovery.
-const DISCOVER_DOC_LIMIT = 1000
+const DISCOVER_DOC_LIMIT = 40000
 
 // Baseline document schema for resource streams we discover if we fail
 // during the schema-inference step.


### PR DESCRIPTION
**Description:**

Try increasing the maximum number of documents that we use for schema inference, to hopefully result in more accurate schemas.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/302)
<!-- Reviewable:end -->
