### PR TITLE
source-postgres: Timeout DB connection after 30 seconds

### DIFF
--- a/source-postgres/helpers_test.go
+++ b/source-postgres/helpers_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/estuary/connectors/sqlcapture"
 	"github.com/jackc/pgconn"
@@ -60,6 +61,7 @@ func TestMain(m *testing.M) {
 	if err != nil {
 		logrus.WithFields(logrus.Fields{"uri": *TestConnectionURI, "err": err}).Fatal("error parsing connection config")
 	}
+	replConnConfig.ConnectTimeout = 30 * time.Second
 	replConnConfig.RuntimeParams["replication"] = "database"
 	replConn, err := pgconn.ConnectConfig(ctx, replConnConfig)
 	if err != nil {

--- a/source-postgres/replication.go
+++ b/source-postgres/replication.go
@@ -25,6 +25,9 @@ func (db *postgresDatabase) StartReplication(ctx context.Context, startCursor st
 	if err != nil {
 		return nil, err
 	}
+	if connConfig.ConnectTimeout == 0 {
+		connConfig.ConnectTimeout = 30 * time.Second
+	}
 	connConfig.RuntimeParams["replication"] = "database"
 	conn, err := pgconn.ConnectConfig(ctx, connConfig)
 	if err != nil {


### PR DESCRIPTION
**Description:**

In the absence of this setting the connection will keep trying indefinitely, which in practice means "until the OS TCP connect timeout expires after 4 minutes". This in turn means that even when the target database is completely unreachable and Flow is running the connector in a crash loop, the majority of the time it will look like it's "working" in the UI because the most recent connector run has not yet failed.

I suspect 30 seconds is plenty of time for any non-pathological database setup to connect (and supporting this assertion: the MySQL client-library has a hard-coded 10s deadline already), but this could be made configurable if it ever becomes an issue.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/303)
<!-- Reviewable:end -->
