### PR TITLE
SQL capture benchmarks and some throughput improvements

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -698,6 +698,7 @@ github.com/jackc/puddle v0.0.0-20190608224051-11cab39313c9/go.mod h1:m4B5Dj62Y0f
 github.com/jackc/puddle v1.1.0/go.mod h1:m4B5Dj62Y0fbyuIc15OsIqK0+JU8nkqQjsgx7dvjSWk=
 github.com/jackc/puddle v1.1.1/go.mod h1:m4B5Dj62Y0fbyuIc15OsIqK0+JU8nkqQjsgx7dvjSWk=
 github.com/jackc/puddle v1.1.3/go.mod h1:m4B5Dj62Y0fbyuIc15OsIqK0+JU8nkqQjsgx7dvjSWk=
+github.com/jackc/puddle v1.2.1 h1:gI8os0wpRXFd4FiAY2dWiqRK037tjj3t7rKFeO4X5iw=
 github.com/jackc/puddle v1.2.1/go.mod h1:m4B5Dj62Y0fbyuIc15OsIqK0+JU8nkqQjsgx7dvjSWk=
 github.com/jcmturner/gofork v0.0.0-20180107083740-2aebee971930/go.mod h1:MK8+TM0La+2rjBD4jE12Kj1pCCxK7d2LK/UM3ncEo0o=
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=

--- a/source-mysql/backfill.go
+++ b/source-mysql/backfill.go
@@ -80,7 +80,7 @@ func (db *mysqlDatabase) ScanTableChunk(ctx context.Context, info sqlcapture.Tab
 // backfillChunkSize controls how many rows will be read from the database in a
 // single query. In normal use it acts like a constant, it's just a variable here
 // so that it can be lowered in tests to exercise chunking behavior more easily.
-var backfillChunkSize = 4096
+var backfillChunkSize = 128 * 1024
 
 func buildScanQuery(start bool, keyColumns []string, schemaName, tableName string) string {
 	// Construct strings like `(foo, bar, baz)` and `(?, ?, ?)` for use in the query

--- a/source-mysql/main_test.go
+++ b/source-mysql/main_test.go
@@ -110,7 +110,7 @@ type mysqlTestBackend struct {
 	cfg  Config
 }
 
-func (tb *mysqlTestBackend) CreateTable(ctx context.Context, t *testing.T, suffix string, tableDef string) string {
+func (tb *mysqlTestBackend) CreateTable(ctx context.Context, t testing.TB, suffix string, tableDef string) string {
 	t.Helper()
 
 	var tableName = "test_" + strings.TrimPrefix(t.Name(), "Test")
@@ -131,7 +131,7 @@ func (tb *mysqlTestBackend) CreateTable(ctx context.Context, t *testing.T, suffi
 	return tableName
 }
 
-func (tb *mysqlTestBackend) Insert(ctx context.Context, t *testing.T, table string, rows [][]interface{}) {
+func (tb *mysqlTestBackend) Insert(ctx context.Context, t testing.TB, table string, rows [][]interface{}) {
 	t.Helper()
 	if len(rows) == 0 {
 		return
@@ -160,17 +160,17 @@ func argsTuple(argc int) string {
 	return tuple + ")"
 }
 
-func (tb *mysqlTestBackend) Update(ctx context.Context, t *testing.T, table string, whereCol string, whereVal interface{}, setCol string, setVal interface{}) {
+func (tb *mysqlTestBackend) Update(ctx context.Context, t testing.TB, table string, whereCol string, whereVal interface{}, setCol string, setVal interface{}) {
 	t.Helper()
 	tb.Query(ctx, t, fmt.Sprintf("UPDATE %s SET %s = ? WHERE %s = ?;", table, setCol, whereCol), setVal, whereVal)
 }
 
-func (tb *mysqlTestBackend) Delete(ctx context.Context, t *testing.T, table string, whereCol string, whereVal interface{}) {
+func (tb *mysqlTestBackend) Delete(ctx context.Context, t testing.TB, table string, whereCol string, whereVal interface{}) {
 	t.Helper()
 	tb.Query(ctx, t, fmt.Sprintf("DELETE FROM %s WHERE %s = ?;", table, whereCol), whereVal)
 }
 
-func (tb *mysqlTestBackend) Query(ctx context.Context, t *testing.T, query string, args ...interface{}) {
+func (tb *mysqlTestBackend) Query(ctx context.Context, t testing.TB, query string, args ...interface{}) {
 	t.Helper()
 	logrus.WithFields(logrus.Fields{"query": query, "args": args}).Debug("executing query")
 	var result, err = tb.conn.Execute(query, args...)

--- a/source-mysql/main_test.go
+++ b/source-mysql/main_test.go
@@ -36,6 +36,7 @@ func TestMain(m *testing.M) {
 		}
 		logrus.SetLevel(level)
 	}
+	fixMysqlLogging()
 
 	// Initialize test config and database connection
 	var cfg = Config{

--- a/source-postgres/backfill.go
+++ b/source-postgres/backfill.go
@@ -92,7 +92,7 @@ func (db *postgresDatabase) WatermarksTable() string {
 // backfillChunkSize controls how many rows will be read from the database in a
 // single query. In normal use it acts like a constant, it's just a variable here
 // so that it can be lowered in tests to exercise chunking behavior more easily.
-var backfillChunkSize = 4096
+var backfillChunkSize = 128 * 1024
 
 func buildScanQuery(start bool, keyColumns []string, schemaName, tableName string) string {
 	// Construct strings like `(foo, bar, baz)` and `($1, $2, $3)` for use in the query

--- a/source-postgres/capture_test.go
+++ b/source-postgres/capture_test.go
@@ -210,7 +210,7 @@ func TestSkipBackfills(t *testing.T) {
 	// Set up three tables with some data in them, a catalog which captures all three,
 	// but a configuration which specifies that tables A and C should skip backfilling
 	// and only capture new changes.
-	var tb, ctx = &postgresTestBackend{conn: TestDatabase, cfg: TestDefaultConfig}, context.Background()
+	var tb, ctx = &postgresTestBackend{pool: TestDatabase, cfg: TestDefaultConfig}, context.Background()
 	var tableA = tb.CreateTable(ctx, t, "aaa", "(id INTEGER PRIMARY KEY, data TEXT)")
 	var tableB = tb.CreateTable(ctx, t, "bbb", "(id INTEGER PRIMARY KEY, data TEXT)")
 	var tableC = tb.CreateTable(ctx, t, "ccc", "(id INTEGER PRIMARY KEY, data TEXT)")

--- a/source-postgres/capture_test.go
+++ b/source-postgres/capture_test.go
@@ -16,6 +16,7 @@ import (
 
 // TestGeneric runs the generic sqlcapture test suite.
 func TestGeneric(t *testing.T) {
+	lowerTuningParameters(t)
 	tests.Run(context.Background(), t, TestBackend)
 }
 
@@ -87,6 +88,7 @@ func TestToastColumns(t *testing.T) {
 // "chunks", two connector restarts at different points in the initial table scan, and
 // some concurrent modifications to row ranges already-scanned and not-yet-scanned.
 func TestComplexDataset(t *testing.T) {
+	lowerTuningParameters(t)
 	var tb, ctx = TestBackend, context.Background()
 	var tableName = tb.CreateTable(ctx, t, "", "(year INTEGER, state TEXT, fullname TEXT, population INTEGER, PRIMARY KEY (year, state))")
 	var catalog, state = tests.ConfiguredCatalog(ctx, t, tb, tableName), sqlcapture.PersistentState{}

--- a/source-postgres/helpers_test.go
+++ b/source-postgres/helpers_test.go
@@ -109,7 +109,7 @@ type postgresTestBackend struct {
 // CreateTable is a test helper for creating a new database table and returning the
 // name of the new table. The table is named "test_<testName>", or "test_<testName>_<suffix>"
 // if the suffix is non-empty.
-func (tb *postgresTestBackend) CreateTable(ctx context.Context, t *testing.T, suffix string, tableDef string) string {
+func (tb *postgresTestBackend) CreateTable(ctx context.Context, t testing.TB, suffix string, tableDef string) string {
 	t.Helper()
 
 	var tableName = "test_" + strings.TrimPrefix(t.Name(), "Test")
@@ -130,7 +130,7 @@ func (tb *postgresTestBackend) CreateTable(ctx context.Context, t *testing.T, su
 	return tableName
 }
 
-func (tb *postgresTestBackend) Insert(ctx context.Context, t *testing.T, table string, rows [][]interface{}) {
+func (tb *postgresTestBackend) Insert(ctx context.Context, t testing.TB, table string, rows [][]interface{}) {
 	t.Helper()
 
 	if len(rows) < 1 {
@@ -158,17 +158,17 @@ func (tb *postgresTestBackend) Insert(ctx context.Context, t *testing.T, table s
 	}
 }
 
-func (tb *postgresTestBackend) Update(ctx context.Context, t *testing.T, table string, whereCol string, whereVal interface{}, setCol string, setVal interface{}) {
+func (tb *postgresTestBackend) Update(ctx context.Context, t testing.TB, table string, whereCol string, whereVal interface{}, setCol string, setVal interface{}) {
 	t.Helper()
 	tb.Query(ctx, t, fmt.Sprintf("UPDATE %s SET %s = $1 WHERE %s = $2;", table, setCol, whereCol), setVal, whereVal)
 }
 
-func (tb *postgresTestBackend) Delete(ctx context.Context, t *testing.T, table string, whereCol string, whereVal interface{}) {
+func (tb *postgresTestBackend) Delete(ctx context.Context, t testing.TB, table string, whereCol string, whereVal interface{}) {
 	t.Helper()
 	tb.Query(ctx, t, fmt.Sprintf("DELETE FROM %s WHERE %s = $1;", table, whereCol), whereVal)
 }
 
-func (tb *postgresTestBackend) Query(ctx context.Context, t *testing.T, query string, args ...interface{}) {
+func (tb *postgresTestBackend) Query(ctx context.Context, t testing.TB, query string, args ...interface{}) {
 	t.Helper()
 	logrus.WithFields(logrus.Fields{"query": query, "args": args}).Debug("executing query")
 	var rows, err = tb.conn.Query(ctx, query, args...)

--- a/source-postgres/helpers_test.go
+++ b/source-postgres/helpers_test.go
@@ -52,10 +52,6 @@ func TestMain(m *testing.M) {
 		logrus.SetLevel(level)
 	}
 
-	// Tweak some parameters to make things easier to test on a smaller scale
-	backfillChunkSize = 16
-	replicationBufferSize = 0
-
 	// Open a connection to the database which will be used for creating and
 	// tearing down the replication slot.
 	var replConnConfig, err = pgconn.ParseConfig(*TestConnectionURI)

--- a/source-postgres/throughput_test.go
+++ b/source-postgres/throughput_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/estuary/flow/go/protocols/airbyte"
 	"github.com/google/uuid"
 	"github.com/sirupsen/logrus"
+	"golang.org/x/sync/errgroup"
 )
 
 // To run these benchmarks:
@@ -27,11 +28,11 @@ import (
 // several tables with a bunch of synthetic data and benchmark how long it
 // takes to capture the data (via Backfill and Replication, respectively).
 //
-// In both cases the tests will run 10 capture iterations and spread the
-// data across 10 tables, with the benchmark 'N' parameter controlling the
-// number of rows in each table. However the number of rows is 'N/100' so
-// that the 'ns/op' measurement will reflect the marginal cost of a single
-// row-capture via each mechanism.
+// In both cases the tests will run one capture, spreading the data across
+// 10 tables, with the benchmark 'N' parameter controlling the number of
+// rows in each table. To be precise, the number of rows is set to N*100,
+// so each 'op' in the 'ns/op' measurement reflects the marginal cost of
+// 1,000 row-captures.
 //
 // These benchmarks have a rather high setup cost, so the default `benchtime`
 // target of one second isn't nearly enough. Aim for at least 30 seconds to
@@ -40,11 +41,9 @@ import (
 //     $ LOG_LEVEL=warn go test -run=NoTests -bench=. -benchtime=30s ./source-postgres/
 //     $ LOG_LEVEL=warn go test -run=NoTests -bench=. -benchtime=30s -memprofile memprofile.out -cpuprofile profile.out ./source-postgres/
 //
-func BenchmarkBackfill(b *testing.B) { benchmarkBackfills(b, 10, 10, b.N/100) }
+func BenchmarkBackfill(b *testing.B) { benchmarkBackfills(b, 1, 10, b.N*100) }
 
-// This benchmark varies the row count with increasing N, so the 'ns/op'
-// value directly reflects the marginal time taken to capture one row.
-func BenchmarkReplication(b *testing.B) { benchmarkReplication(b, 10, 10, b.N/100) }
+func BenchmarkReplication(b *testing.B) { benchmarkReplication(b, 1, 10, b.N*100) }
 
 func benchmarkBackfills(b *testing.B, iterations, numTables, rowsPerTable int) {
 	b.StopTimer()
@@ -52,16 +51,21 @@ func benchmarkBackfills(b *testing.B, iterations, numTables, rowsPerTable int) {
 
 	// Set up multiple tables full of data
 	logrus.WithFields(logrus.Fields{
-		"tables":       numTables,
+		"rows":         rowsPerTable * numTables,
 		"rowsPerTable": rowsPerTable,
+		"tables":       numTables,
 	}).Info("initializing tables")
 
 	var tb, ctx = TestBackend, context.Background()
 	var tables []string
+	var grp errgroup.Group
 	for i := 0; i < numTables; i++ {
 		var table = tb.CreateTable(ctx, b, fmt.Sprintf("table%d", i), "(id INTEGER PRIMARY KEY, uid TEXT, name TEXT, status INTEGER, modified DATE, foo_id INTEGER, padding TEXT)")
 		tables = append(tables, table)
-		populateTable(ctx, b, tb, table, rowsPerTable)
+		grp.Go(func() error { return populateTable(ctx, b, tb, table, rowsPerTable) })
+	}
+	if err := grp.Wait(); err != nil {
+		b.Fatalf("error populating tables: %v", err)
 	}
 	var catalog = tests.ConfiguredCatalog(ctx, b, tb, tables...)
 	var dummyOutput = &benchmarkMessageOutput{Inner: json.NewEncoder(io.Discard)}
@@ -100,9 +104,12 @@ func benchmarkReplication(b *testing.B, iterations, numTables, rowsPerTable int)
 		b.Fatalf("capture failed with error: %v", err)
 	}
 
+	var grp errgroup.Group
 	for _, table := range tables {
-		populateTable(ctx, b, tb, table, rowsPerTable)
+		var table = table
+		grp.Go(func() error { return populateTable(ctx, b, tb, table, rowsPerTable) })
 	}
+	grp.Wait()
 
 	for i := 0; i < iterations; i++ {
 		var state = tests.CopyState(initialState)
@@ -119,14 +126,15 @@ func benchmarkReplication(b *testing.B, iterations, numTables, rowsPerTable int)
 	}
 }
 
-func populateTable(ctx context.Context, t testing.TB, tb tests.TestBackend, table string, numRows int) {
+func populateTable(ctx context.Context, t testing.TB, tb tests.TestBackend, table string, numRows int) error {
 	t.Helper()
 
-	const chunkSize = 4096
+	const chunkSize = 65536
 
+	var columnNames = []string{"id", "uid", "name", "status", "modified", "foo_id", "padding"}
 	var buffer [][]interface{}
 	for i := 0; i < numRows; i++ {
-		var date = time.Unix(683640000+rand.Int63n(974764800), 0).Format("2006-01-02")
+		var date = time.Unix(683640000+rand.Int63n(974764800), 0)
 		var padding = strings.Repeat("PADDING.", rand.Intn(33))
 		buffer = append(buffer, []interface{}{
 			// Total size: 192 +/- 132 bytes per row
@@ -139,13 +147,14 @@ func populateTable(ctx context.Context, t testing.TB, tb tests.TestBackend, tabl
 			padding,                     // (0-256) Variable amount of padding
 		})
 		if len(buffer) >= chunkSize {
-			tb.Insert(ctx, t, table, buffer)
+			tb.Insert(ctx, t, table, columnNames, buffer)
 			buffer = nil
 		}
 	}
 	if len(buffer) > 0 {
-		tb.Insert(ctx, t, table, buffer)
+		tb.Insert(ctx, t, table, columnNames, buffer)
 	}
+	return nil
 }
 
 type benchmarkMessageOutput struct {

--- a/source-postgres/throughput_test.go
+++ b/source-postgres/throughput_test.go
@@ -1,0 +1,165 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"math/rand"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/estuary/connectors/sqlcapture"
+	"github.com/estuary/connectors/sqlcapture/tests"
+	"github.com/estuary/flow/go/protocols/airbyte"
+	"github.com/google/uuid"
+	"github.com/sirupsen/logrus"
+)
+
+// To run these benchmarks:
+//
+//     $ LOG_LEVEL=warn go test -run=NoTests -bench=. -benchtime=120s ./source-postgres/
+//     $ LOG_LEVEL=warn go test -run=NoTests -bench=. -benchtime=120s -memprofile memprofile.out -cpuprofile profile.out ./source-postgres/
+//
+
+// The benchmarks 'BenchmarkBackfill' and 'BenchmarkReplication' initialize
+// several tables with a bunch of synthetic data and benchmark how long it
+// takes to capture the data (via Backfill and Replication, respectively).
+//
+// In both cases the tests will run 10 capture iterations and spread the
+// data across 10 tables, with the benchmark 'N' parameter controlling the
+// number of rows in each table. However the number of rows is 'N/100' so
+// that the 'ns/op' measurement will reflect the marginal cost of a single
+// row-capture via each mechanism.
+//
+// These benchmarks have a rather high setup cost, so the default `benchtime`
+// target of one second isn't nearly enough. Aim for at least 30 seconds to
+// get useful numbers (and 300 seconds for perfect accuracy):
+//
+//     $ LOG_LEVEL=warn go test -run=NoTests -bench=. -benchtime=30s ./source-postgres/
+//     $ LOG_LEVEL=warn go test -run=NoTests -bench=. -benchtime=30s -memprofile memprofile.out -cpuprofile profile.out ./source-postgres/
+//
+func BenchmarkBackfill(b *testing.B) { benchmarkBackfills(b, 10, 10, b.N/100) }
+
+// This benchmark varies the row count with increasing N, so the 'ns/op'
+// value directly reflects the marginal time taken to capture one row.
+func BenchmarkReplication(b *testing.B) { benchmarkReplication(b, 10, 10, b.N/100) }
+
+func benchmarkBackfills(b *testing.B, iterations, numTables, rowsPerTable int) {
+	b.StopTimer()
+	b.ResetTimer()
+
+	// Set up multiple tables full of data
+	logrus.WithFields(logrus.Fields{
+		"tables":       numTables,
+		"rowsPerTable": rowsPerTable,
+	}).Info("initializing tables")
+
+	var tb, ctx = TestBackend, context.Background()
+	var tables []string
+	for i := 0; i < numTables; i++ {
+		var table = tb.CreateTable(ctx, b, fmt.Sprintf("table%d", i), "(id INTEGER PRIMARY KEY, uid TEXT, name TEXT, status INTEGER, modified DATE, foo_id INTEGER, padding TEXT)")
+		tables = append(tables, table)
+		populateTable(ctx, b, tb, table, rowsPerTable)
+	}
+	var catalog = tests.ConfiguredCatalog(ctx, b, tb, tables...)
+	var dummyOutput = &benchmarkMessageOutput{Inner: json.NewEncoder(io.Discard)}
+
+	logrus.WithField("iterations", iterations).Info("running backfill benchmark")
+	for i := 0; i < iterations; i++ {
+		var state = sqlcapture.PersistentState{}
+		b.StartTimer()
+		if err := sqlcapture.RunCapture(ctx, tb.GetDatabase(), &catalog, &state, dummyOutput); err != nil {
+			b.Fatalf("capture failed with error: %v", err)
+		}
+		b.StopTimer()
+		var expectedRecords = numTables * rowsPerTable
+		if dummyOutput.Total != expectedRecords {
+			b.Fatalf("incorrect document count: got %d, expected %d", dummyOutput.Total, expectedRecords)
+		}
+		dummyOutput.Reset()
+	}
+}
+
+func benchmarkReplication(b *testing.B, iterations, numTables, rowsPerTable int) {
+	b.StopTimer()
+	b.ResetTimer()
+
+	var tb, ctx = TestBackend, context.Background()
+	var tables []string
+	for i := 0; i < numTables; i++ {
+		var table = tb.CreateTable(ctx, b, fmt.Sprintf("table%d", i), "(id INTEGER PRIMARY KEY, uid TEXT, name TEXT, status INTEGER, modified DATE, foo_id INTEGER, padding TEXT)")
+		tables = append(tables, table)
+	}
+	var catalog = tests.ConfiguredCatalog(ctx, b, tb, tables...)
+	var dummyOutput = &benchmarkMessageOutput{Inner: json.NewEncoder(io.Discard)}
+
+	var initialState = sqlcapture.PersistentState{}
+	if err := sqlcapture.RunCapture(ctx, tb.GetDatabase(), &catalog, &initialState, dummyOutput); err != nil {
+		b.Fatalf("capture failed with error: %v", err)
+	}
+
+	for _, table := range tables {
+		populateTable(ctx, b, tb, table, rowsPerTable)
+	}
+
+	for i := 0; i < iterations; i++ {
+		var state = tests.CopyState(initialState)
+		b.StartTimer()
+		if err := sqlcapture.RunCapture(ctx, tb.GetDatabase(), &catalog, &state, dummyOutput); err != nil {
+			b.Fatalf("capture failed with error: %v", err)
+		}
+		b.StopTimer()
+		var expectedRecords = numTables * rowsPerTable
+		if dummyOutput.Total != expectedRecords {
+			b.Fatalf("incorrect document count: got %d, expected %d", dummyOutput.Total, expectedRecords)
+		}
+		dummyOutput.Reset()
+	}
+}
+
+func populateTable(ctx context.Context, t testing.TB, tb tests.TestBackend, table string, numRows int) {
+	t.Helper()
+
+	const chunkSize = 4096
+
+	var buffer [][]interface{}
+	for i := 0; i < numRows; i++ {
+		var date = time.Unix(683640000+rand.Int63n(974764800), 0).Format("2006-01-02")
+		var padding = strings.Repeat("PADDING.", rand.Intn(33))
+		buffer = append(buffer, []interface{}{
+			// Total size: 192 +/- 132 bytes per row
+			i,                           // (4) Serial Integer Primary Key
+			uuid.New().String(),         // (36) Random UUID as a string
+			fmt.Sprintf("Thing #%d", i), // (8-16) Human readable name
+			100 + rand.Intn(400),        // (4) Integer status code
+			date,                        // (4) Random YYYY-MM-DD date within the past 30 years
+			rand.Int31(),                // (4) Random integer ID
+			padding,                     // (0-256) Variable amount of padding
+		})
+		if len(buffer) >= chunkSize {
+			tb.Insert(ctx, t, table, buffer)
+			buffer = nil
+		}
+	}
+	if len(buffer) > 0 {
+		tb.Insert(ctx, t, table, buffer)
+	}
+}
+
+type benchmarkMessageOutput struct {
+	Total int
+	Inner sqlcapture.MessageOutput
+}
+
+func (m *benchmarkMessageOutput) Reset() {
+	m.Total = 0
+}
+
+func (m *benchmarkMessageOutput) Encode(v interface{}) error {
+	if msg, ok := v.(airbyte.Message); ok && msg.Type == airbyte.MessageTypeRecord {
+		m.Total++
+	}
+	return m.Inner.Encode(v)
+}

--- a/sqlcapture/capture.go
+++ b/sqlcapture/capture.go
@@ -101,7 +101,7 @@ const (
 	streamProgressInterval = 60 * time.Second        // After `streamProgressInterval` the replication streaming code may log a progress report.
 )
 
-const emitterBufferSize = 1 * 1024 * 1024
+const emitterBufferSize = 4 * 1024 * 1024
 
 // Run is the top level entry point of the capture process.
 func (c *Capture) Run(ctx context.Context) (err error) {

--- a/sqlcapture/resultset.go
+++ b/sqlcapture/resultset.go
@@ -58,13 +58,13 @@ func (r *resultSet) Buffer(streamID string, keyColumns []string, events []Change
 		}
 		chunk.rows[string(bs)] = event
 		chunk.scanned = bs
-		if logrus.IsLevelEnabled(logrus.DebugLevel) {
+		if logrus.IsLevelEnabled(logrus.TraceLevel) {
 			logrus.WithFields(logrus.Fields{
 				"stream":   streamID,
 				"op":       event.Operation,
 				"rowKey":   base64.StdEncoding.EncodeToString(bs),
 				"chunkEnd": base64.StdEncoding.EncodeToString(chunk.scanned),
-			}).Debug("buffered scan result")
+			}).Trace("buffered scan result")
 		}
 	}
 	return nil

--- a/sqlcapture/tests/interface.go
+++ b/sqlcapture/tests/interface.go
@@ -19,13 +19,13 @@ type TestBackend interface {
 	// name. If `suffix` is non-empty it should be included at the end of the new table's
 	// name. The table will be registered with `t.Cleanup()` to be deleted at the end of
 	// the current test.
-	CreateTable(ctx context.Context, t *testing.T, suffix string, tableDef string) string
+	CreateTable(ctx context.Context, t testing.TB, suffix string, tableDef string) string
 	// Insert adds all provided rows to the specified table in a single transaction.
-	Insert(ctx context.Context, t *testing.T, table string, rows [][]interface{})
+	Insert(ctx context.Context, t testing.TB, table string, rows [][]interface{})
 	// Update modifies preexisting rows to a new value.
-	Update(ctx context.Context, t *testing.T, table string, whereCol string, whereVal interface{}, setCol string, setVal interface{})
+	Update(ctx context.Context, t testing.TB, table string, whereCol string, whereVal interface{}, setCol string, setVal interface{})
 	// Delete removes preexisting rows.
-	Delete(ctx context.Context, t *testing.T, table string, whereCol string, whereVal interface{})
+	Delete(ctx context.Context, t testing.TB, table string, whereCol string, whereVal interface{})
 	// GetDatabase returns a new sqlcapture.Database which can be used to perform
 	// discovery and captures.
 	GetDatabase() sqlcapture.Database

--- a/sqlcapture/tests/tests.go
+++ b/sqlcapture/tests/tests.go
@@ -66,7 +66,7 @@ func testTailing(ctx context.Context, t *testing.T, tb TestBackend) {
 	// Run the capture
 	var captureCtx, cancelCapture = context.WithCancel(ctx)
 	go VerifiedCapture(captureCtx, t, tb, &catalog, &state, "")
-	time.Sleep(1 * time.Second)
+	time.Sleep(2 * time.Second)
 
 	// Some more changes occurring after the backfill completes
 	tb.Insert(ctx, t, tableName, [][]interface{}{{5, "asdf"}, {100, "lots"}})


### PR DESCRIPTION
**Description:**

This PR adds `go test`-able benchmarks `BenchmarkBackfill` and `BenchmarkReplication` to `source-postgres` and `source-mysql`. These benchmarks take care of initializing the test database with a bunch of rows of synthetic data and then time a capture of that data. They do their best to exclude all of the necessary setup and teardown work from the actual benchmark timing, so that the reported `ns/op` measurements should accurately reflect the marginal cost of capturing a certain amount of data. See "Workflow steps" for more details on how to run those.

In addition, this PR includes several changes motivated by running these benchmarks in a setup with significant (~45ms) DB<->Capture latency:

- Optimizes the `source-postgres` handling of column descriptions during discovery. Previously this was a separate query run in a loop for every column of every discovered table, which added up and made things _very slow_ when run on large databases with nonzero ping. This speeds up connector startup against cloud-hosted DB instances by ~10 seconds, and has a very noticeable impact on test suite runs.
- Increases the backfill chunk size by a factor of 32x. This alone makes backfills substantially faster in setups with nontrivial latency.
- Performs JSON serialization and writing-to-stdout in a separate goroutine for state checkpoints and record output, with a substantial channel buffer acting as a work queue. This allows the primary backfill loop to immediately go start fetching the next chunk of rows, with serialization work taking place while we're waiting on more data from the network.
  - I believe that JSON serialization is still a significant bottleneck at present (primarily because at the end of the benchmark a noticeable amount of time is spent waiting for the worker thread to finish draining the queue), however optimizing this further is probably more effort than it's worth right now.

**Workflow steps:**

The new benchmarks can be invoked like:

```
$ LOG_LEVEL=warn go test -run=None -bench=. -benchtime=1000x -timeout=0 ./source-mysql/ --db_addr=<hostport> --db_password=<secret>
$ LOG_LEVEL=warn go test -run=None -bench=. -benchtime=1000x -timeout=0 ./source-postgres/ --test_connection_uri=postgres://flow_capture:<secret>@<hostport>/postgres
```

For these tests, the unit of work (what `go test` reports as `1 op`) is 1,000 rows of a synthetic dataset, divided evenly across 10 tables. The synthetic data weighs in at an average 192 bytes with significant variability (+/- 132 bytes), so the `12345678 ns/op` values reported by `go test` can be turned into a sustained throughput estimate like `192kB / 12345678 ns = 123 Mbps`.

**Notes for reviewers:**

I did a bit of cleaning-up of individual commits, but the overall sequence of work here is basically as I did it. Let me know if you'd prefer to have the capture optimizations pulled out into a separate PR from the test-refactoring and benchmark-writing part.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/306)
<!-- Reviewable:end -->
