### PR TITLE
source-http-file uses a maxBound in the future

### DIFF
--- a/source-gcs/main.go
+++ b/source-gcs/main.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"time"
 
 	"cloud.google.com/go/storage"
 	"github.com/estuary/connectors/filesource"
@@ -173,6 +174,9 @@ func main() {
     }`)
 		},
 		DocumentationURL: "https://go.estuary.dev/source-gcs",
+		// Set the delta to 30 seconds in the past, to guard against new files appearing with a
+		// timestamp that's equal to the `MinBound` in the state.
+		TimeHorizonDelta: time.Second * -30,
 	}
 
 	src.Main()

--- a/source-http-file/main.go
+++ b/source-http-file/main.go
@@ -200,6 +200,13 @@ func main() {
       }`)
 		},
 		DocumentationURL: "https://go.estuary.dev/source-http-file",
+		// Set the delta to far in the future. The scenario that the the `MaxBound` protects agains
+		// is only possible when a listing can return multiple files, which is never the case for
+		// this connector. Setting it in the future allows this connector to fetch files where the
+		// server may set the `Last-Modified` header to the current time when the response is
+		// generated, which could otherwise fall after the `MaxBound`, which is computed prior to
+		// sending any requests.
+		TimeHorizonDelta: time.Hour,
 	}
 
 	src.Main()

--- a/source-s3/main.go
+++ b/source-s3/main.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"
@@ -262,6 +263,9 @@ func main() {
     }`)
 		},
 		DocumentationURL: "https://go.estuary.dev/source-s3",
+		// Set the delta to 30 seconds in the past, to guard against new files appearing with a
+		// timestamp that's equal to the `MinBound` in the state.
+		TimeHorizonDelta: time.Second * -30,
 	}
 
 	src.Main()


### PR DESCRIPTION
**Description:**

The filesource library uses an upper bound on the `Last-Modified`
timestamp during each sweep. This prevented the source-http-file
connector from ingesting files that are updated very frequently because
the `Last-Modified` timestamp would end up falling outside of the
`maxBound`. Additionally, the failure scenario that the `maxBound` is
meant to address in the first place isn't possible with source-http-file
since it only ever ingests a single file.

This commit updates `filesource.Source` to include the delta that's
applied to the current time in order to determine the `maxBound` for
each sweep. This lets source-s3 and source-gcs retain the existing
behavior, while allowing source-http-file to use a positive value so
that frequently updated files can be captured.

**Workflow steps:**

No changes, just use source-http-file with a frequently updating file, and see that it now works.

**Documentation links affected:**

N/A - This change just makes the source-http-file connector work as expected in more cases.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/315)
<!-- Reviewable:end -->
