### PR TITLE
source-nativehello: Implement a native gRPC capture

### DIFF
--- a/source-boilerplate/boilerplate.go
+++ b/source-boilerplate/boilerplate.go
@@ -1,0 +1,230 @@
+package boilerplate
+
+import (
+	"bufio"
+	"context"
+	"encoding/binary"
+	"fmt"
+	"io"
+	"os"
+	"os/signal"
+	"syscall"
+
+	pc "github.com/estuary/flow/go/protocols/capture"
+	protoio "github.com/gogo/protobuf/io"
+	"github.com/gogo/protobuf/proto"
+	"github.com/jessevdk/go-flags"
+	"github.com/sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
+	"google.golang.org/grpc/metadata"
+)
+
+// RunMain is the boilerplate main function of a capture connector.
+func RunMain(srv pc.DriverServer) {
+	var parser = flags.NewParser(nil, flags.Default)
+	var ctx, _ = signal.NotifyContext(context.Background(), syscall.SIGTERM, syscall.SIGINT)
+
+	var cmd = cmdCommon{
+		ctx: ctx,
+		srv: srv,
+		r:   bufio.NewReaderSize(os.Stdin, 1<<21), // 2MB buffer.
+		w:   protoio.NewUint32DelimitedWriter(os.Stdout, binary.LittleEndian),
+	}
+
+	parser.AddCommand("spec", "Write the connector specification",
+		"Write the connector specification to stdout, then exit", &specCmd{cmd})
+	parser.AddCommand("validate", "Validate a materialization",
+		"Validate a proposed ValidateRequest read from stdin", &validateCmd{cmd})
+	parser.AddCommand("discover", "Enumerate available streams",
+		"Connect to the target system and enumerate streams available to be captured", &discoverCmd{cmd})
+	parser.AddCommand("apply-upsert", "Apply an insert or update of a materialization",
+		"Apply a proposed insert or update ApplyRequest read from stdin", &applyUpsertCmd{cmd})
+	parser.AddCommand("apply-delete", "Apply a deletion of a materialization",
+		"Apply a proposed delete ApplyRequest read from stdin", &applyDeleteCmd{cmd})
+	parser.AddCommand("pull", "Pull data from the target system",
+		"Connect to the target system and begin pulling data from the selected streams", &pullCmd{cmd})
+
+	var _, err = parser.Parse()
+	if err != nil {
+		os.Exit(1)
+	}
+	os.Exit(0)
+}
+
+type cmdCommon struct {
+	ctx context.Context
+	srv pc.DriverServer
+	r   *bufio.Reader
+	w   protoio.Writer
+}
+
+type protoValidator interface {
+	proto.Message
+	Validate() error
+}
+
+func (c *cmdCommon) readMsg(m protoValidator) error {
+	var lengthBytes [4]byte
+
+	if _, err := io.ReadFull(c.r, lengthBytes[:]); err == io.EOF {
+		return err
+	} else if err != nil {
+		return fmt.Errorf("reading message length: %w", err)
+	}
+
+	var len = int(binary.LittleEndian.Uint32(lengthBytes[:]))
+
+	// Fetch next length-delimited message into a buffer.
+	// In the garden-path case, we decode directly from the
+	// bufio.Reader internal buffer without copying
+	// (having just read the length, the message itself
+	// is probably _already_ in the bufio.Reader buffer).
+	//
+	// If the message is larger than the internal buffer,
+	// we allocate and read it directly.
+	var b, err = c.r.Peek(len)
+
+	if err == nil {
+		// The Discard contract guarantees we won't error.
+		// It's safe to reference |b| until the next Peek.
+		if _, err = c.r.Discard(len); err != nil {
+			panic(err)
+		}
+	} else if err != io.ErrShortBuffer {
+		return fmt.Errorf("reading message (into buffer): %w", err)
+	} else {
+		// Non-garden path: we must allocate and read a larger buffer.
+		b = make([]byte, len)
+		if _, err = io.ReadFull(c.r, b); err != nil {
+			return fmt.Errorf("reading message (directly): %w", err)
+		}
+	}
+
+	if err := proto.Unmarshal(b, m); err != nil {
+		return fmt.Errorf("decoding message: %w", err)
+	} else if err = m.Validate(); err != nil {
+		return fmt.Errorf("validating message: %w", err)
+	}
+
+	return nil
+}
+
+type specCmd struct{ cmdCommon }
+type validateCmd struct{ cmdCommon }
+type discoverCmd struct{ cmdCommon }
+type applyUpsertCmd struct{ cmdCommon }
+type applyDeleteCmd struct{ cmdCommon }
+type pullCmd struct{ cmdCommon }
+
+func (c specCmd) Execute(args []string) error {
+	var req pc.SpecRequest
+	log.Debug("executing Spec subcommand")
+
+	if err := c.readMsg(&req); err != nil {
+		return fmt.Errorf("reading request: %w", err)
+	} else if resp, err := c.srv.Spec(c.ctx, &req); err != nil {
+		return err
+	} else if err = c.w.WriteMsg(resp); err != nil {
+		return fmt.Errorf("writing response: %w", err)
+	}
+	return nil
+}
+
+func (c validateCmd) Execute(args []string) error {
+	var req pc.ValidateRequest
+	log.Debug("executing Validate subcommand")
+
+	if err := c.readMsg(&req); err != nil {
+		return fmt.Errorf("reading request: %w", err)
+	} else if resp, err := c.srv.Validate(c.ctx, &req); err != nil {
+		return err
+	} else if err = c.w.WriteMsg(resp); err != nil {
+		return fmt.Errorf("writing response: %w", err)
+	}
+	return nil
+}
+
+func (c discoverCmd) Execute(args []string) error {
+	var req pc.DiscoverRequest
+	log.Debug("executing Discover subcommand")
+
+	if err := c.readMsg(&req); err != nil {
+		return fmt.Errorf("reading request: %w", err)
+	} else if resp, err := c.srv.Discover(c.ctx, &req); err != nil {
+		return err
+	} else if err = c.w.WriteMsg(resp); err != nil {
+		return fmt.Errorf("writing response: %w", err)
+	}
+	return nil
+}
+
+func (c applyUpsertCmd) Execute(args []string) error {
+	var req pc.ApplyRequest
+
+	if err := c.readMsg(&req); err != nil {
+		return fmt.Errorf("reading request: %w", err)
+	} else if resp, err := c.srv.ApplyUpsert(c.ctx, &req); err != nil {
+		return err
+	} else if err = c.w.WriteMsg(resp); err != nil {
+		return fmt.Errorf("writing response: %w", err)
+	}
+
+	return nil
+}
+
+func (c applyDeleteCmd) Execute(args []string) error {
+	var req pc.ApplyRequest
+
+	if err := c.readMsg(&req); err != nil {
+		return fmt.Errorf("reading request: %w", err)
+	} else if resp, err := c.srv.ApplyDelete(c.ctx, &req); err != nil {
+		// Translate delete errors into a successful response so that task
+		// deletion cannot fail.
+		resp = &pc.ApplyResponse{ActionDescription: err.Error()}
+		logrus.WithFields(logrus.Fields{"error": err}).
+			Error("failed to delete the capture cleanly")
+	} else if err = c.w.WriteMsg(resp); err != nil {
+		return fmt.Errorf("writing response: %w", err)
+	}
+
+	return nil
+}
+
+func (c pullCmd) Execute(args []string) error {
+	log.Debug("executing Pull subcommand")
+	return c.srv.Pull(&pullAdapter{cmdCommon: c.cmdCommon})
+}
+
+// pullAdapter is a pc.Driver_PullServer built from
+// os.Stdin and os.Stdout.
+type pullAdapter struct{ cmdCommon }
+
+func (a *pullAdapter) Context() context.Context {
+	return a.ctx
+}
+
+func (a *pullAdapter) Send(m *pc.PullResponse) error {
+	return a.SendMsg(m)
+}
+func (a *pullAdapter) Recv() (*pc.PullRequest, error) {
+	m := new(pc.PullRequest)
+	if err := a.RecvMsg(m); err != nil {
+		return nil, err
+	}
+	return m, nil
+}
+func (a *pullAdapter) SendMsg(m interface{}) error {
+	return a.w.WriteMsg(m.(proto.Message))
+}
+func (a *pullAdapter) RecvMsg(m interface{}) error {
+	return a.readMsg(m.(protoValidator))
+}
+func (a *pullAdapter) SendHeader(metadata.MD) error {
+	panic("SendHeader is not supported")
+}
+func (a *pullAdapter) SetHeader(metadata.MD) error {
+	panic("SetHeader is not supported")
+}
+func (a *pullAdapter) SetTrailer(metadata.MD) {
+	panic("SetTrailer is not supported")
+}

--- a/source-nativehello/Dockerfile
+++ b/source-nativehello/Dockerfile
@@ -1,0 +1,42 @@
+# Build Stage
+################################################################################
+FROM golang:1.17-buster as builder
+
+WORKDIR /builder
+
+# Download & compile dependencies early. Doing this separately allows for layer
+# caching opportunities when no dependencies are updated.
+COPY go.* ./
+RUN go mod download
+
+# Copy over helper packages that the connector uses and then build them and
+# their transitive dependencies to aid in layer caching.
+COPY go-schema-gen      ./go-schema-gen
+COPY source-boilerplate ./source-boilerplate
+RUN go get -v ./go-schema-gen ./source-boilerplate
+
+# Copy and build and test the connector (there are currently no tests)
+COPY source-nativehello ./source-nativehello
+RUN go build -o ./connector -v ./source-nativehello
+# RUN go test -v ./source-nativehello/...
+
+
+# Runtime Stage
+################################################################################
+FROM ghcr.io/estuary/base-image:v1
+
+WORKDIR /connector
+ENV PATH="/connector:$PATH"
+
+COPY --from=busybox:latest /bin/sh /bin/sh
+
+# Bring in the compiled connector artifact from the builder.
+COPY --from=builder /builder/connector ./connector
+
+LABEL FLOW_RUNTIME_PROTOCOL=capture
+LABEL CONNECTOR_PROTOCOL=flow-capture
+
+# Avoid running the connector as root.
+USER nonroot:nonroot
+
+ENTRYPOINT ["/connector/connector"]

--- a/source-nativehello/main.go
+++ b/source-nativehello/main.go
@@ -1,0 +1,292 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"strconv"
+	"strings"
+	"time"
+
+	schemagen "github.com/estuary/connectors/go-schema-gen"
+	boilerplate "github.com/estuary/connectors/source-boilerplate"
+	pc "github.com/estuary/flow/go/protocols/capture"
+	pf "github.com/estuary/flow/go/protocols/flow"
+	log "github.com/sirupsen/logrus"
+	"golang.org/x/sync/errgroup"
+)
+
+func main() {
+	boilerplate.RunMain(new(driver))
+}
+
+type config struct {
+	Rate float32 `json:"rate" jsonschema:"title=Message Rate,description=Message rate in documents per second,default=1"`
+}
+
+func (c config) Validate() error {
+	if c.Rate <= 0 {
+		return fmt.Errorf("message rate must be positive (got %f)", c.Rate)
+	}
+	return nil
+}
+
+type resource struct {
+	Name   string `json:"name" jsonschema:"title=Stream Name,description=Stream name to include in generated documents,default=greetings"`
+	Prefix string `json:"prefix" jsonschema:"title=Message Prefix,description=Constant prefix to add to every message,default=Hello {}"`
+}
+
+func (r resource) Validate() error {
+	return nil
+}
+
+type message struct {
+	Timestamp time.Time `json:"ts" jsonschema:"title=Timestamp,description=The time at which this message was generated"`
+	Message   string    `json:"message" jsonschema:"title=Message,description=A human-readable message"`
+}
+
+type state struct {
+	Cursor int `json:"cursor"` // The last message generated
+}
+
+type capture struct {
+	Stream   pc.Driver_PullServer
+	Bindings []resource
+	Config   config
+	State    state
+	Acks     <-chan *pc.Acknowledge
+}
+
+// driver implements the pc.DriverServer interface.
+type driver struct{}
+
+func (driver) Spec(ctx context.Context, req *pc.SpecRequest) (*pc.SpecResponse, error) {
+	var endpointSchema, err = schemagen.GenerateSchema("Example Source Spec", &config{}).MarshalJSON()
+	if err != nil {
+		return nil, fmt.Errorf("generating endpoint schema: %w", err)
+	}
+
+	resourceSchema, err := schemagen.GenerateSchema("Example Resource Spec", &resource{}).MarshalJSON()
+	if err != nil {
+		return nil, fmt.Errorf("generating resource schema: %w", err)
+	}
+
+	return &pc.SpecResponse{
+		EndpointSpecSchemaJson: json.RawMessage(endpointSchema),
+		ResourceSpecSchemaJson: json.RawMessage(resourceSchema),
+		DocumentationUrl:       "https://go.estuary.dev/source-nativehello",
+	}, nil
+}
+
+func (driver) Validate(ctx context.Context, req *pc.ValidateRequest) (*pc.ValidateResponse, error) {
+	var cfg config
+	if err := pf.UnmarshalStrict(req.EndpointSpecJson, &cfg); err != nil {
+		return nil, fmt.Errorf("parsing endpoint config: %w", err)
+	}
+
+	var out []*pc.ValidateResponse_Binding
+	for _, binding := range req.Bindings {
+		var res resource
+		if err := pf.UnmarshalStrict(binding.ResourceSpecJson, &res); err != nil {
+			return nil, fmt.Errorf("parsing resource config: %w", err)
+		}
+
+		out = append(out, &pc.ValidateResponse_Binding{
+			ResourcePath: []string{res.Name},
+		})
+	}
+	return &pc.ValidateResponse{Bindings: out}, nil
+}
+
+func (driver) Discover(ctx context.Context, req *pc.DiscoverRequest) (*pc.DiscoverResponse, error) {
+	messageSchema, err := schemagen.GenerateSchema("Example Output Record", &message{}).MarshalJSON()
+	if err != nil {
+		return nil, fmt.Errorf("generating message schema: %w", err)
+	}
+
+	resourceJSON, err := json.Marshal(resource{Name: "greetings", Prefix: "Hello {}!"})
+	if err != nil {
+		return nil, fmt.Errorf("serializing resource json: %w", err)
+	}
+
+	return &pc.DiscoverResponse{
+		Bindings: []*pc.DiscoverResponse_Binding{{
+			RecommendedName:    "events",
+			ResourceSpecJson:   resourceJSON,
+			DocumentSchemaJson: messageSchema,
+			KeyPtrs:            []string{"/ts"},
+		}},
+	}, nil
+}
+
+func (d driver) ApplyUpsert(ctx context.Context, req *pc.ApplyRequest) (*pc.ApplyResponse, error) {
+	return d.apply(ctx, req, false)
+}
+
+func (d driver) ApplyDelete(ctx context.Context, req *pc.ApplyRequest) (*pc.ApplyResponse, error) {
+	return d.apply(ctx, req, true)
+}
+
+func (driver) apply(ctx context.Context, req *pc.ApplyRequest, isDelete bool) (*pc.ApplyResponse, error) {
+	return &pc.ApplyResponse{
+		ActionDescription: "this is a dummy capture so nothing happened",
+	}, nil
+}
+
+func (driver) Pull(stream pc.Driver_PullServer) error {
+	log.Debug("connector started")
+
+	var open, err = stream.Recv()
+	if err != nil {
+		return fmt.Errorf("error reading PullRequest: %w", err)
+	} else if open.Open == nil {
+		return fmt.Errorf("expected PullRequest.Open, got %#v", open)
+	}
+
+	var cfg config
+	if err := pf.UnmarshalStrict(open.Open.Capture.EndpointSpecJson, &cfg); err != nil {
+		return fmt.Errorf("parsing endpoint config: %w", err)
+	}
+
+	var checkpoint state
+	if open.Open.DriverCheckpointJson != nil {
+		if err := json.Unmarshal(open.Open.DriverCheckpointJson, &checkpoint); err != nil {
+			return fmt.Errorf("parsing driver checkpoint: %w", err)
+		}
+	}
+
+	var resources []resource
+	for _, binding := range open.Open.Capture.Bindings {
+		var res resource
+		if err := pf.UnmarshalStrict(binding.ResourceSpecJson, &res); err != nil {
+			return fmt.Errorf("parsing resource config: %w", err)
+		}
+		resources = append(resources, res)
+	}
+
+	var capture = &capture{
+		Stream:   stream,
+		Bindings: resources,
+		Config:   cfg,
+		State:    checkpoint,
+	}
+	return capture.Run()
+}
+
+func (c *capture) Run() error {
+	// Spawn a goroutine which will translate gRPC PullRequest.Acknowledge messages
+	// into equivalent messages on a channel. Since the ServerStream interface doesn't
+	// have any sort of polling receive, this is necessary to allow captures to handle
+	// acknowledgements without blocking their own capture progress.
+	var acks = make(chan *pc.Acknowledge)
+	var eg, ctx = errgroup.WithContext(c.Stream.Context())
+	eg.Go(func() error {
+		defer close(acks)
+		for {
+			var msg, err = c.Stream.Recv()
+			if errors.Is(err, io.EOF) {
+				return nil
+			} else if err != nil {
+				return fmt.Errorf("error reading PullRequest: %w", err)
+			} else if msg.Acknowledge == nil {
+				return fmt.Errorf("expected PullRequest.Acknowledge, got %#v", msg)
+			}
+			select {
+			case <-ctx.Done():
+				return nil
+			case acks <- msg.Acknowledge:
+				// Loop and receive another acknowledgement
+			}
+		}
+	})
+	c.Acks = acks
+
+	// Notify Flow that we're starting.
+	log.Debug("sending PullResponse.Opened")
+	if err := c.Stream.Send(&pc.PullResponse{Opened: &pc.PullResponse_Opened{}}); err != nil {
+		return fmt.Errorf("error sending PullResponse.Opened: %w", err)
+	}
+
+	eg.Go(func() error {
+		return c.Capture(ctx)
+	})
+	return eg.Wait()
+}
+
+func (c *capture) EmitDocuments(binding int, docs []*message) error {
+	var arena []byte
+	var ranges []pf.Slice
+	for _, doc := range docs {
+		bs, err := json.Marshal(doc)
+		if err != nil {
+			return fmt.Errorf("error serializing document: %w", err)
+		}
+
+		var begin, end = len(arena), len(arena) + len(bs)
+		arena = append(arena, bs...)
+		ranges = append(ranges, pf.Slice{Begin: uint32(begin), End: uint32(end)})
+	}
+
+	var msg = &pc.PullResponse{
+		Documents: &pc.Documents{
+			Binding:  uint32(binding),
+			Arena:    arena,
+			DocsJson: ranges,
+		},
+	}
+	log.WithField("count", len(docs)).Debug("emitting documents")
+	if err := c.Stream.Send(msg); err != nil {
+		return fmt.Errorf("error sending PullResponse.Documents: %w", err)
+	}
+	return nil
+}
+
+func (c *capture) EmitCheckpoint() error {
+	checkpointJSON, err := json.Marshal(c.State)
+	if err != nil {
+		return fmt.Errorf("error serializing state: %w", err)
+	}
+	var checkpoint = &pc.PullResponse{
+		Checkpoint: &pf.DriverCheckpoint{
+			DriverCheckpointJson: checkpointJSON,
+			Rfc7396MergePatch:    true,
+		},
+	}
+	log.WithField("checkpoint", string(checkpointJSON)).Debug("emitting checkpoint")
+	if err := c.Stream.Send(checkpoint); err != nil {
+		return fmt.Errorf("error sending PullResponse.Checkpoint: %w", err)
+	}
+	return nil
+}
+
+func (c *capture) Capture(ctx context.Context) error {
+	var interval = time.Duration(float64(time.Second) / float64(c.Config.Rate))
+	for {
+		select {
+		case <-ctx.Done():
+			log.Info("shutting down due to context cancellation")
+			return nil
+		case <-c.Acks:
+			log.Debug("received acknowledgement")
+		default:
+		}
+
+		for idx, binding := range c.Bindings {
+			var text = strings.Replace(binding.Prefix, "{}", strconv.Itoa(c.State.Cursor), -1)
+			var doc = &message{
+				Timestamp: time.Now(),
+				Message:   text,
+			}
+			if err := c.EmitDocuments(idx, []*message{doc}); err != nil {
+				return err
+			}
+		}
+		c.State.Cursor++
+		if err := c.EmitCheckpoint(); err != nil {
+			return err
+		}
+		time.Sleep(interval)
+	}
+}


### PR DESCRIPTION
**Description:**

This is a complete proof-of-concept capture connector, similar to `source-hello-world` but with a few tweaks that allowed me to show off the resource spec customization better and made it slightly simpler to implement.

This commit also includes a new `source-boilerplate` package which implements functions analagous to `materialize-boilerplate`. I may end up adding a bit more boilerplate because there's currently no equivalent to `RunTransactions()`, instead each capture has to manage receiving `PullRequest.Acknowledge` messages and sending documents/checkpoints for themselves.

Everything appears to work more or less as it should, but this has not really been battle-tested fully and it's possible that there could be some edge case in the connector lifecycle that doesn't work properly.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/317)
<!-- Reviewable:end -->
