### PR TITLE
source-firestore: support nested collections, use flow protocol

### DIFF
--- a/build-local.sh
+++ b/build-local.sh
@@ -4,4 +4,4 @@ if [[ $# < 1 ]]; then
     echo "Usage: build-local.sh <connector_name>"
     exit 1
 fi
-docker build -t $1:local -f $1/Dockerfile .
+docker buildx build --platform linux/amd64 --load -t $1:local -f $1/Dockerfile .

--- a/schema_inference/inference.go
+++ b/schema_inference/inference.go
@@ -43,12 +43,14 @@ func Run(ctx context.Context, logEntry *log.Entry, docsCh <-chan Document) (Sche
 		defer stdin.Close()
 		encoder := json.NewEncoder(stdin)
 
+		var count int
 		for doc := range docsCh {
+			count++
 			if err := encoder.Encode(doc); err != nil {
 				return fmt.Errorf("failed to encode document: %w", err)
 			}
 		}
-		logEntry.Info("runInference: Done sending documents")
+		logEntry.WithField("count", count).Info("runInference: Done sending documents")
 
 		return nil
 	})

--- a/source-boilerplate/boilerplate.go
+++ b/source-boilerplate/boilerplate.go
@@ -1,0 +1,230 @@
+package boilerplate
+
+import (
+	"bufio"
+	"context"
+	"encoding/binary"
+	"fmt"
+	"io"
+	"os"
+	"os/signal"
+	"syscall"
+
+	pc "github.com/estuary/flow/go/protocols/capture"
+	protoio "github.com/gogo/protobuf/io"
+	"github.com/gogo/protobuf/proto"
+	"github.com/jessevdk/go-flags"
+	"github.com/sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
+	"google.golang.org/grpc/metadata"
+)
+
+// RunMain is the boilerplate main function of a capture connector.
+func RunMain(srv pc.DriverServer) {
+	var parser = flags.NewParser(nil, flags.Default)
+	var ctx, _ = signal.NotifyContext(context.Background(), syscall.SIGTERM, syscall.SIGINT)
+
+	var cmd = cmdCommon{
+		ctx: ctx,
+		srv: srv,
+		r:   bufio.NewReaderSize(os.Stdin, 1<<21), // 2MB buffer.
+		w:   protoio.NewUint32DelimitedWriter(os.Stdout, binary.LittleEndian),
+	}
+
+	parser.AddCommand("spec", "Write the connector specification",
+		"Write the connector specification to stdout, then exit", &specCmd{cmd})
+	parser.AddCommand("validate", "Validate a materialization",
+		"Validate a proposed ValidateRequest read from stdin", &validateCmd{cmd})
+	parser.AddCommand("discover", "Enumerate available streams",
+		"Connect to the target system and enumerate streams available to be captured", &discoverCmd{cmd})
+	parser.AddCommand("apply-upsert", "Apply an insert or update of a materialization",
+		"Apply a proposed insert or update ApplyRequest read from stdin", &applyUpsertCmd{cmd})
+	parser.AddCommand("apply-delete", "Apply a deletion of a materialization",
+		"Apply a proposed delete ApplyRequest read from stdin", &applyDeleteCmd{cmd})
+	parser.AddCommand("pull", "Pull data from the target system",
+		"Connect to the target system and begin pulling data from the selected streams", &pullCmd{cmd})
+
+	var _, err = parser.Parse()
+	if err != nil {
+		os.Exit(1)
+	}
+	os.Exit(0)
+}
+
+type cmdCommon struct {
+	ctx context.Context
+	srv pc.DriverServer
+	r   *bufio.Reader
+	w   protoio.Writer
+}
+
+type protoValidator interface {
+	proto.Message
+	Validate() error
+}
+
+func (c *cmdCommon) readMsg(m protoValidator) error {
+	var lengthBytes [4]byte
+
+	if _, err := io.ReadFull(c.r, lengthBytes[:]); err == io.EOF {
+		return err
+	} else if err != nil {
+		return fmt.Errorf("reading message length: %w", err)
+	}
+
+	var len = int(binary.LittleEndian.Uint32(lengthBytes[:]))
+
+	// Fetch next length-delimited message into a buffer.
+	// In the garden-path case, we decode directly from the
+	// bufio.Reader internal buffer without copying
+	// (having just read the length, the message itself
+	// is probably _already_ in the bufio.Reader buffer).
+	//
+	// If the message is larger than the internal buffer,
+	// we allocate and read it directly.
+	var b, err = c.r.Peek(len)
+
+	if err == nil {
+		// The Discard contract guarantees we won't error.
+		// It's safe to reference |b| until the next Peek.
+		if _, err = c.r.Discard(len); err != nil {
+			panic(err)
+		}
+	} else if err != io.ErrShortBuffer {
+		return fmt.Errorf("reading message (into buffer): %w", err)
+	} else {
+		// Non-garden path: we must allocate and read a larger buffer.
+		b = make([]byte, len)
+		if _, err = io.ReadFull(c.r, b); err != nil {
+			return fmt.Errorf("reading message (directly): %w", err)
+		}
+	}
+
+	if err := proto.Unmarshal(b, m); err != nil {
+		return fmt.Errorf("decoding message: %w", err)
+	} else if err = m.Validate(); err != nil {
+		return fmt.Errorf("validating message: %w", err)
+	}
+
+	return nil
+}
+
+type specCmd struct{ cmdCommon }
+type validateCmd struct{ cmdCommon }
+type discoverCmd struct{ cmdCommon }
+type applyUpsertCmd struct{ cmdCommon }
+type applyDeleteCmd struct{ cmdCommon }
+type pullCmd struct{ cmdCommon }
+
+func (c specCmd) Execute(args []string) error {
+	var req pc.SpecRequest
+	log.Debug("executing Spec subcommand")
+
+	if err := c.readMsg(&req); err != nil {
+		return fmt.Errorf("reading request: %w", err)
+	} else if resp, err := c.srv.Spec(c.ctx, &req); err != nil {
+		return err
+	} else if err = c.w.WriteMsg(resp); err != nil {
+		return fmt.Errorf("writing response: %w", err)
+	}
+	return nil
+}
+
+func (c validateCmd) Execute(args []string) error {
+	var req pc.ValidateRequest
+	log.Debug("executing Validate subcommand")
+
+	if err := c.readMsg(&req); err != nil {
+		return fmt.Errorf("reading request: %w", err)
+	} else if resp, err := c.srv.Validate(c.ctx, &req); err != nil {
+		return err
+	} else if err = c.w.WriteMsg(resp); err != nil {
+		return fmt.Errorf("writing response: %w", err)
+	}
+	return nil
+}
+
+func (c discoverCmd) Execute(args []string) error {
+	var req pc.DiscoverRequest
+	log.Debug("executing Discover subcommand")
+
+	if err := c.readMsg(&req); err != nil {
+		return fmt.Errorf("reading request: %w", err)
+	} else if resp, err := c.srv.Discover(c.ctx, &req); err != nil {
+		return err
+	} else if err = c.w.WriteMsg(resp); err != nil {
+		return fmt.Errorf("writing response: %w", err)
+	}
+	return nil
+}
+
+func (c applyUpsertCmd) Execute(args []string) error {
+	var req pc.ApplyRequest
+
+	if err := c.readMsg(&req); err != nil {
+		return fmt.Errorf("reading request: %w", err)
+	} else if resp, err := c.srv.ApplyUpsert(c.ctx, &req); err != nil {
+		return err
+	} else if err = c.w.WriteMsg(resp); err != nil {
+		return fmt.Errorf("writing response: %w", err)
+	}
+
+	return nil
+}
+
+func (c applyDeleteCmd) Execute(args []string) error {
+	var req pc.ApplyRequest
+
+	if err := c.readMsg(&req); err != nil {
+		return fmt.Errorf("reading request: %w", err)
+	} else if resp, err := c.srv.ApplyDelete(c.ctx, &req); err != nil {
+		// Translate delete errors into a successful response so that task
+		// deletion cannot fail.
+		resp = &pc.ApplyResponse{ActionDescription: err.Error()}
+		logrus.WithFields(logrus.Fields{"error": err}).
+			Error("failed to delete the capture cleanly")
+	} else if err = c.w.WriteMsg(resp); err != nil {
+		return fmt.Errorf("writing response: %w", err)
+	}
+
+	return nil
+}
+
+func (c pullCmd) Execute(args []string) error {
+	log.Debug("executing Pull subcommand")
+	return c.srv.Pull(&pullAdapter{cmdCommon: c.cmdCommon})
+}
+
+// pullAdapter is a pc.Driver_PullServer built from
+// os.Stdin and os.Stdout.
+type pullAdapter struct{ cmdCommon }
+
+func (a *pullAdapter) Context() context.Context {
+	return a.ctx
+}
+
+func (a *pullAdapter) Send(m *pc.PullResponse) error {
+	return a.SendMsg(m)
+}
+func (a *pullAdapter) Recv() (*pc.PullRequest, error) {
+	m := new(pc.PullRequest)
+	if err := a.RecvMsg(m); err != nil {
+		return nil, err
+	}
+	return m, nil
+}
+func (a *pullAdapter) SendMsg(m interface{}) error {
+	return a.w.WriteMsg(m.(proto.Message))
+}
+func (a *pullAdapter) RecvMsg(m interface{}) error {
+	return a.readMsg(m.(protoValidator))
+}
+func (a *pullAdapter) SendHeader(metadata.MD) error {
+	panic("SendHeader is not supported")
+}
+func (a *pullAdapter) SetHeader(metadata.MD) error {
+	panic("SetHeader is not supported")
+}
+func (a *pullAdapter) SetTrailer(metadata.MD) {
+	panic("SetTrailer is not supported")
+}

--- a/source-firestore/Dockerfile
+++ b/source-firestore/Dockerfile
@@ -1,6 +1,6 @@
 # Build Stage
 ################################################################################
-FROM --platform=linux/amd64 golang:1.17-buster as builder
+FROM golang:1.17-buster as builder
 
 WORKDIR /builder
 
@@ -11,14 +11,17 @@ RUN go mod download
 
 # Build the connector projects we depend on.
 COPY schema_inference ./schema_inference
-COPY source-firestore ./source-firestore
+COPY source-boilerplate ./source-boilerplate
 COPY go-schema-gen  ./go-schema-gen
+RUN go get -v ./source-boilerplate ./schema_inference ./go-schema-gen
+
+COPY source-firestore ./source-firestore
 
 # Run the unit tests.
 RUN go test -v ./source-firestore/...
 
 # Build the connector.
-RUN GOARCH=amd64 GOOS=linux go build -o ./connector -v ./source-firestore/*.go
+RUN go build -o ./connector -v ./source-firestore/...
 
 # Runtime Stage
 ################################################################################
@@ -34,6 +37,9 @@ COPY flow-bin/flow-schema-inference ./
 
 # Bring in the compiled connector artifact from the builder.
 COPY --from=builder /builder/connector ./connector
+
+LABEL FLOW_RUNTIME_PROTOCOL=capture
+LABEL CONNECTOR_PROTOCOL=flow-capture
 
 # Avoid running the connector as root.
 USER nonroot:nonroot

--- a/source-firestore/apply.go
+++ b/source-firestore/apply.go
@@ -1,0 +1,20 @@
+package main
+
+import (
+	"context"
+	pc "github.com/estuary/flow/go/protocols/capture"
+)
+
+func (driver) apply(ctx context.Context, req *pc.ApplyRequest, isDelete bool) (*pc.ApplyResponse, error) {
+	return &pc.ApplyResponse{
+		ActionDescription: "",
+	}, nil
+}
+
+func (d driver) ApplyUpsert(ctx context.Context, req *pc.ApplyRequest) (*pc.ApplyResponse, error) {
+	return d.apply(ctx, req, false)
+}
+
+func (d driver) ApplyDelete(ctx context.Context, req *pc.ApplyRequest) (*pc.ApplyResponse, error) {
+	return d.apply(ctx, req, true)
+}

--- a/source-firestore/discovery.go
+++ b/source-firestore/discovery.go
@@ -1,0 +1,201 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	firestore "cloud.google.com/go/firestore"
+	"github.com/estuary/connectors/schema_inference"
+	"github.com/estuary/flow/go/protocols/airbyte"
+	log "github.com/sirupsen/logrus"
+	"golang.org/x/sync/errgroup"
+	"google.golang.org/api/iterator"
+)
+
+const DISCOVER_DOC_LIMIT = 50
+
+type inferenceRequest struct {
+	document   schema_inference.Document
+	collection string
+}
+
+type inferenceProcess struct {
+	docsCh chan schema_inference.Document
+	count  int
+	open   bool
+}
+
+// The collection name must not have slashes in it, otherwise we end up with parent
+// collections being a prefix of the child collections, which is prohibited by flow
+func collectionRecommendedName(name string) string {
+	return strings.ReplaceAll(name, "/*/", "_").ReplaceAll("/", "_")
+}
+
+// Start a channel where we receive documents for each collection
+// if they match an existing collection (e.g. group/*/subgroup), we send the docs to the
+// existing inference channel, otherwise we create a new inference channel for it.
+// Once we receive DISCOVER_DOC_LIMIT documents for each collection, we close the channel for inference
+// and stop writing to it.
+func discoveryRoutine(
+	ctx context.Context,
+	catalog *airbyte.Catalog,
+	eg *errgroup.Group,
+	ch chan inferenceRequest,
+	inferenceChannels map[string]*inferenceProcess,
+) error {
+	for request := range ch {
+		if process, exists := inferenceChannels[request.collection]; !exists {
+			log.WithField("collection", request.collection).Info("created a new inference channel")
+			var docsCh = make(chan schema_inference.Document)
+
+			var logEntry = log.WithField("collection", request.collection)
+			inferenceChannels[request.collection] = &inferenceProcess{
+				docsCh: docsCh,
+				count:  0,
+				open:   true,
+			}
+
+			eg.Go(func() error {
+				var collection = request.collection
+				var err error
+				var schema schema_inference.Schema
+				log.WithField("collection", collection).Info("schema_inference.Run")
+				schema, err = schema_inference.Run(ctx, logEntry, docsCh)
+				if err != nil {
+					return fmt.Errorf("schema inference: %w", err)
+				}
+
+				log.WithField("collection", collection).Info("finished schema inference")
+				catalog.Streams = append(catalog.Streams, airbyte.Stream{
+					Name:                    collection,
+					RecommendedName:         collectionRecommendedName(collection),
+					JSONSchema:              schema,
+					SupportedSyncModes:      []airbyte.SyncMode{airbyte.SyncModeIncremental},
+					SourceDefinedCursor:     true,
+					SourceDefinedPrimaryKey: [][]string{{firestore.DocumentID}},
+				})
+				return nil
+			})
+
+			docsCh <- request.document
+		} else {
+			if process.open {
+				log.WithField("collection", request.collection).WithField("count", process.count).Info("channel exists, sending document")
+				process.docsCh <- request.document
+				process.count = process.count + 1
+				if process.count > DISCOVER_DOC_LIMIT {
+					process.open = false
+					close(process.docsCh)
+				}
+			} else {
+				log.WithField("collection", request.collection).Info("channel is closed")
+			}
+		}
+	}
+
+	return nil
+}
+
+// Go through all collections and discover them recursively. Spawn a discoverRoutine for handling management
+// of inference channels
+func discoverCollections(ctx context.Context, client *firestore.Client, catalog *airbyte.Catalog) error {
+	var collections = client.Collections(ctx)
+	var ch = make(chan inferenceRequest)
+	var firestoreGroup = new(errgroup.Group)
+	var routineGroup = new(errgroup.Group)
+
+	var inferenceChannels = map[string]*inferenceProcess{}
+
+	for {
+		var collection, err = collections.Next()
+		if err == iterator.Done {
+			break
+		} else if err != nil {
+			return err
+		}
+
+		firestoreGroup.Go(func() error {
+			return discoverCollection(ctx, ch, inferenceChannels, catalog, collection)
+		})
+	}
+
+	routineGroup.Go(func() error { return discoveryRoutine(ctx, catalog, routineGroup, ch, inferenceChannels) })
+
+	if err := firestoreGroup.Wait(); err != nil {
+		return err
+	}
+
+	close(ch)
+	for _, process := range inferenceChannels {
+		if process.open {
+			close(process.docsCh)
+		}
+	}
+
+	if err := routineGroup.Wait(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Recursively discover collections
+func discoverCollection(
+	ctx context.Context,
+	ch chan inferenceRequest,
+	inferenceChannels map[string]*inferenceProcess,
+	catalog *airbyte.Catalog,
+	collection *firestore.CollectionRef,
+) error {
+	var process, exists = inferenceChannels[collectionPath(collection.Path)]
+	// if the channel is closed, don't bother reading more documents
+	if exists && !process.open {
+		return nil
+	}
+	log.WithField("collection", collectionPath(collection.Path)).Info("starting discovery of collection")
+	var query = collection.Query.Limit(DISCOVER_DOC_LIMIT)
+	var docs = query.Documents(ctx)
+
+	for {
+		// If at any point the channel is closed, just exit
+		if exists && !process.open {
+			return nil
+		}
+
+		var doc, err = docs.Next()
+		if err == iterator.Done {
+			break
+		} else if err != nil {
+			return err
+		}
+		var data = doc.Data()
+		data[firestore.DocumentID] = doc.Ref.ID
+		data[PATH_FIELD] = doc.Ref.Path
+		docJson, err := json.Marshal(data)
+		log.WithField("collection", collectionPath(collection.Path)).Info("sending inference request")
+		ch <- inferenceRequest{
+			document:   docJson,
+			collection: collectionPath(collection.Path),
+		}
+
+		log.WithField("collection", collectionPath(collection.Path)).Info("iterating over sub collections")
+		var docCollectionsIterator = doc.Ref.Collections(ctx)
+		for {
+			var docCol, err = docCollectionsIterator.Next()
+			if err == iterator.Done {
+				break
+			} else if err != nil {
+				return err
+			}
+
+			err = discoverCollection(ctx, ch, inferenceChannels, catalog, docCol)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}

--- a/source-firestore/discovery.go
+++ b/source-firestore/discovery.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"sort"
 	"strings"
+	"sync"
 
 	firestore "cloud.google.com/go/firestore"
 	firebase "firebase.google.com/go"
@@ -17,19 +19,33 @@ import (
 	"google.golang.org/api/option"
 )
 
-const discoverDocLimit = 50
+const (
+	// discoverMaxCollectionsPerResource bounds the number of distinct collections
+	// that an invocation of discoverResource will process. If more collections are
+	// discovered which map to a particular resource, the excess will first pile up
+	// in the buffered channel and then after that they will be silently discarded.
+	discoverMaxCollectionsPerResource = 10
 
-type inferenceRequest struct {
-	document   schema_inference.Document
-	collection string
-}
+	// discoverMaxDocumentsPerCollection bounds the number of documents which will
+	// be fetched by discoverResource from any one collection.
+	discoverMaxDocumentsPerCollection = 50
 
-type inferenceProcess struct {
-	docsCh chan schema_inference.Document
-	count  int
-	ctx    context.Context
-	cancel context.CancelFunc
-}
+	// discoverMaxConcurrentWorkers bounds the number of concurrent `discoverResource()`
+	// workers which can proceed at any given time.
+	discoverMaxConcurrentWorkers = 32
+)
+
+// placeholderSchema is the maximally-permissive schema that should be satisfied
+// by any Firestore document. It is returned if schema inference fails.
+const placeholderSchema = `{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "required": ["__name__", "__path__"],
+    "properties": {
+        "__name__": { "type": "string" },
+        "__path__": { "type": "string" }
+    }
+}`
 
 // Discover RPC
 func (driver) Discover(ctx context.Context, req *pc.DiscoverRequest) (*pc.DiscoverResponse, error) {
@@ -50,195 +66,245 @@ func (driver) Discover(ctx context.Context, req *pc.DiscoverRequest) (*pc.Discov
 	}
 	defer client.Close()
 
-	var response = &pc.DiscoverResponse{
-		Bindings: []*pc.DiscoverResponse_Binding{},
-	}
-	err = discoverCollections(ctx, client, response)
+	bindings, err := discoverCollections(ctx, client)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("discovery error: %w", err)
 	}
-
-	return response, nil
+	return &pc.DiscoverResponse{
+		Bindings: bindings,
+	}, nil
 }
 
-// The collection name must not have slashes in it, otherwise we end up with parent
-// collections being a prefix of the child collections, which is prohibited by flow
-func collectionRecommendedName(name string) string {
-	return strings.ReplaceAll(strings.ReplaceAll(name, "/*/", "_"), "/", "_")
-}
+type discoveryState struct {
+	// group contains all worker goroutines launched during discovery.
+	group *errgroup.Group
 
-// Start a channel where we receive documents for each collection
-// if they match an existing collection (e.g. group/*/subgroup), we send the docs to the
-// existing inference channel, otherwise we create a new inference channel for it.
-// Once we receive discoverDocLimit documents for each collection, we close the channel for inference
-// and stop writing to it.
-func discoveryRoutine(
-	ctx context.Context,
-	response *pc.DiscoverResponse,
-	eg *errgroup.Group,
-	ch chan inferenceRequest,
-	inferenceChannels map[string]*inferenceProcess,
-) error {
-	for request := range ch {
-		if process, exists := inferenceChannels[request.collection]; !exists {
-			log.WithField("collection", request.collection).Debug("created a new inference channel")
-			var docsCh = make(chan schema_inference.Document)
+	// workerLimit controls the number of concurrent discoverResource
+	// workers which may be active at any given time.
+	workerLimit chan struct{}
 
-			var logEntry = log.WithField("collection", request.collection)
-			var pctx, cancel = context.WithCancel(ctx)
-			inferenceChannels[request.collection] = &inferenceProcess{
-				docsCh: docsCh,
-				count:  0,
-				ctx:    pctx,
-				cancel: cancel,
-			}
-			process = inferenceChannels[request.collection]
-
-			eg.Go(func() error {
-				var collection = request.collection
-				var err error
-				var schema schema_inference.Schema
-				log.WithField("collection", collection).Debug("schema_inference.Run")
-				schema, err = schema_inference.Run(ctx, logEntry, docsCh)
-				if err != nil {
-					return fmt.Errorf("schema inference: %w", err)
-				}
-
-				resourceJSON, err := json.Marshal(resource{Path: collection})
-				if err != nil {
-					return fmt.Errorf("serializing resource json: %w", err)
-				}
-
-				log.WithField("collection", collection).Info("finished schema inference")
-				response.Bindings = append(response.Bindings, &pc.DiscoverResponse_Binding{
-					RecommendedName:    pf.Collection(collectionRecommendedName(collection)),
-					ResourceSpecJson:   resourceJSON,
-					DocumentSchemaJson: schema,
-					KeyPtrs:            []string{"/" + firestore.DocumentID},
-				})
-				return nil
-			})
-			eg.Go(func() error {
-				<-process.ctx.Done()
-				close(process.docsCh)
-				return nil
-			})
-
-			docsCh <- request.document
-		} else {
-			if process.ctx.Err() == nil {
-				log.WithField("collection", request.collection).WithField("count", process.count).Debug("channel exists, sending document")
-				process.docsCh <- request.document
-				process.count = process.count + 1
-				if process.count > discoverDocLimit {
-					process.cancel()
-				}
-			} else {
-				log.WithField("collection", request.collection).Debug("channel is closed")
-			}
-		}
+	// resources contains mutex-guarded state which may be modified from
+	// within the numerous discovery worker goroutines.
+	resources struct {
+		sync.Mutex
+		collections map[string]chan *firestore.CollectionRef
+		bindings    []*pc.DiscoverResponse_Binding
 	}
-
-	return nil
 }
 
-// Go through all collections and discover them recursively. Spawn a discoverRoutine for handling management
-// of inference channels
-func discoverCollections(ctx context.Context, client *firestore.Client, response *pc.DiscoverResponse) error {
+func discoverCollections(ctx context.Context, client *firestore.Client) ([]*pc.DiscoverResponse_Binding, error) {
+	eg, ctx := errgroup.WithContext(ctx)
+	var state = &discoveryState{
+		group:       eg,
+		workerLimit: make(chan struct{}, discoverMaxConcurrentWorkers),
+	}
+	state.resources.collections = make(map[string]chan *firestore.CollectionRef)
+
+	// Request processing of all top-level collections.
 	var collections = client.Collections(ctx)
-	var ch = make(chan inferenceRequest)
-	var firestoreGroup = new(errgroup.Group)
-	var routineGroup = new(errgroup.Group)
-
-	var inferenceChannels = map[string]*inferenceProcess{}
-
 	for {
 		var collection, err = collections.Next()
 		if err == iterator.Done {
 			break
 		} else if err != nil {
-			return err
+			return nil, err
 		}
-
-		firestoreGroup.Go(func() error {
-			return discoverCollection(ctx, ch, inferenceChannels, response, collection)
-		})
+		var resourcePath = state.addCollection(ctx, collection)
+		state.closeResource(resourcePath)
 	}
 
-	routineGroup.Go(func() error { return discoveryRoutine(ctx, response, routineGroup, ch, inferenceChannels) })
-
-	if err := firestoreGroup.Wait(); err != nil {
-		return err
+	// Wait for all workers to terminate, and if they all did so without
+	// error then return the bindings list they put together.
+	if err := eg.Wait(); err != nil {
+		return nil, err
 	}
 
-	close(ch)
-
-	for _, process := range inferenceChannels {
-		process.cancel()
-	}
-
-	if err := routineGroup.Wait(); err != nil {
-		return err
-	}
-
-	return nil
+	// Just to be extra nice, sort the bindings list by recommended name.
+	// Since prefixes sort before their longer versions this approximates
+	// a nice hierarchical interpretation.
+	var bindings = state.resources.bindings
+	sort.Slice(bindings, func(i, j int) bool {
+		return bindings[i].RecommendedName < bindings[j].RecommendedName
+	})
+	return bindings, nil
 }
 
-// Recursively discover collections
-func discoverCollection(
-	ctx context.Context,
-	ch chan inferenceRequest,
-	inferenceChannels map[string]*inferenceProcess,
-	response *pc.DiscoverResponse,
-	collection *firestore.CollectionRef,
-) error {
-	var process, exists = inferenceChannels[collectionToResourcePath(collection.Path)]
-	// if the channel is closed, don't bother reading more documents
-	if exists && process.ctx.Err() != nil {
-		return nil
+// addCollection is called for every new collection during the course of discovery.
+// It maps the new collection to the appropriate resource path (which is the collection
+// path, except with '*' in the place of each document ID portion) and then sends the
+// CollectionRef over a buffered channel to the goroutine tasked with handling that
+// resource.
+//
+// If there is not currently a channel (and goroutine) dedicated to this resource path,
+// a new one will be allocated and added to the map.
+func (ds *discoveryState) addCollection(ctx context.Context, collection *firestore.CollectionRef) string {
+	var resourcePath = collectionToResourcePath(collection.Path)
+	log.WithFields(log.Fields{
+		"fullpath": collection.Path,
+		"resource": resourcePath,
+	}).Trace("discovered collection of resource")
+
+	ds.resources.Lock()
+	defer ds.resources.Unlock()
+
+	// If this is the first collection we've observed which maps to this particular
+	// resource path, initialize process state and spawn a new discovery worker.
+	// Otherwise just reuse the already-started process.
+	collectionsCh, ok := ds.resources.collections[resourcePath]
+	if !ok {
+		log.WithField("resource", resourcePath).Info("discovered resource")
+		collectionsCh = make(chan *firestore.CollectionRef, discoverMaxCollectionsPerResource)
+		ds.resources.collections[resourcePath] = collectionsCh
+		ds.group.Go(func() error { return ds.discoverResource(ctx, resourcePath, collectionsCh) })
 	}
-	log.WithField("collection", collectionToResourcePath(collection.Path)).Info("starting discovery of collection")
-	var query = collection.Query.Limit(discoverDocLimit)
-	var docs = query.Documents(ctx)
 
-	for {
-		// If at any point the channel is closed, just exit
-		if exists && process.ctx.Err() != nil {
-			return nil
+	// Send the new collection to the process that's already handling this
+	// resource if possible. If not possible (the channel buffer is full)
+	// then we ignore this particular collection on the theory that we've
+	// already have plenty of other examples to work with.
+	select {
+	case collectionsCh <- collection:
+		log.WithField("resource", resourcePath).Trace("queued subcollection")
+	default:
+		log.WithField("resource", resourcePath).Trace("buffer full, ignoring subcollection")
+	}
+	return resourcePath
+}
+
+// closeResource is used to indicate that no further collections for a particular
+// resource path will be forthcoming.
+func (ds *discoveryState) closeResource(resourcePath string) {
+	log.WithFields(log.Fields{"resource": resourcePath}).Info("close resource")
+
+	ds.resources.Lock()
+	defer ds.resources.Unlock()
+	if collectionsCh, ok := ds.resources.collections[resourcePath]; ok {
+		close(collectionsCh)
+	}
+}
+
+// discoverResource iterates over each* document of each* collection which maps
+// to a particular resource path. In the process each document is fed into schema
+// inference and also checked for sub-collections, which may in turn be queued up for
+// another discoverResource worker thread (possibly freshly spawned) to process.
+//
+// A single invocation of discoverResource will handle the scanning of every collection
+// with that particular resource path, and so when it terminates we can be certain that
+// no further sub-resources of that path will be found. This allows everything to shut
+// down cleanly when done.
+//
+// *subject to limits
+func (ds *discoveryState) discoverResource(ctx context.Context, resourcePath string, collectionsCh <-chan *firestore.CollectionRef) error {
+	var collectionsCount, documentsCount int
+
+	// Only discoverMaxConcurrentWorkers instances of discoverResource may be
+	// active at any given time.
+	ds.workerLimit <- struct{}{}
+	defer func() { <-ds.workerLimit }()
+
+	// Launch a separate goroutine which will run schema inference while the
+	// main thread of execution in this function feeds it documents. When the
+	// discoverResource() invocation returns the documents channel will be
+	// closed, whereupon schema inference will finish, and the resulting
+	// schema will be added to a new binding for the discovery response.
+	var docsCh = make(chan json.RawMessage)
+	defer close(docsCh)
+	ds.group.Go(func() error {
+		var logEntry = log.WithField("resource", resourcePath)
+		var schema, err = schema_inference.Run(ctx, logEntry, docsCh)
+		if err != nil {
+			// Ideally schema inference shouldn't ever fail, but in the event that
+			// it does we should just use a maximally permissive Firestore document
+			// placeholder and keep going.
+			logEntry.WithField("err", err).Warn("schema inference failed")
+			schema = json.RawMessage(placeholderSchema)
 		}
+		resourceJSON, err := json.Marshal(resource{Path: resourcePath})
+		if err != nil {
+			return fmt.Errorf("error serializing resource json: %w", err)
+		}
+		var binding = &pc.DiscoverResponse_Binding{
+			RecommendedName:    pf.Collection(collectionRecommendedName(resourcePath)),
+			ResourceSpecJson:   resourceJSON,
+			DocumentSchemaJson: schema,
+			KeyPtrs:            []string{"/" + firestore.DocumentID},
+		}
+		ds.resources.Lock()
+		ds.resources.bindings = append(ds.resources.bindings, binding)
+		ds.resources.Unlock()
+		return nil
+	})
 
-		var doc, err = docs.Next()
-		if err == iterator.Done {
+	// Keep track of any resources nested under this one. After we're all done
+	// processing this resource the input channels to the sub-resource workers
+	// will be closed so that they, in turn, can shut down.
+	var subResources = make(map[string]struct{})
+	defer func() {
+		for subResource := range subResources {
+			ds.closeResource(subResource)
+		}
+	}()
+
+	for collection := range collectionsCh {
+		collectionsCount++
+		if collectionsCount > discoverMaxCollectionsPerResource {
 			break
-		} else if err != nil {
+		} else if err := ctx.Err(); err != nil {
 			return err
 		}
-		var data = doc.Data()
-		data[firestore.DocumentID] = doc.Ref.ID
-		data[pathField] = doc.Ref.Path
-		docJson, err := json.Marshal(data)
-		log.WithField("collection", collectionToResourcePath(collection.Path)).Debug("sending inference request")
-		ch <- inferenceRequest{
-			document:   docJson,
-			collection: collectionToResourcePath(collection.Path),
-		}
 
-		log.WithField("collection", collectionToResourcePath(collection.Path)).Debug("iterating over sub collections")
-		var docCollectionsIterator = doc.Ref.Collections(ctx)
+		log.WithFields(log.Fields{
+			"path":     collection.Path,
+			"resource": resourcePath,
+		}).Debug("scanning collection")
+
+		var docs = collection.Query.Limit(discoverMaxDocumentsPerCollection).Documents(ctx)
 		for {
-			var docCol, err = docCollectionsIterator.Next()
+			if err := ctx.Err(); err != nil {
+				return err
+			}
+
+			var doc, err = docs.Next()
 			if err == iterator.Done {
 				break
 			} else if err != nil {
 				return err
 			}
 
-			err = discoverCollection(ctx, ch, inferenceChannels, response, docCol)
+			var data = doc.Data()
+			data[firestore.DocumentID] = doc.Ref.ID
+			data[pathField] = doc.Ref.Path
+			docJSON, err := json.Marshal(data)
 			if err != nil {
-				return err
+				return fmt.Errorf("error marshalling document: %w", err)
+			}
+			docsCh <- docJSON
+			documentsCount++
+
+			var subcollections = doc.Ref.Collections(ctx)
+			for {
+				var subcollection, err = subcollections.Next()
+				if err == iterator.Done {
+					break
+				} else if err != nil {
+					return err
+				}
+				var resourcePath = ds.addCollection(ctx, subcollection)
+				subResources[resourcePath] = struct{}{}
 			}
 		}
 	}
 
+	log.WithFields(log.Fields{
+		"resource":    resourcePath,
+		"documents":   documentsCount,
+		"collections": collectionsCount,
+	}).Info("finished scanning resource")
 	return nil
+}
+
+// The collection name must not have slashes in it, otherwise we end up with parent
+// collections being a prefix of the child collections, which is prohibited by Flow.
+func collectionRecommendedName(name string) string {
+	return strings.ReplaceAll(strings.ReplaceAll(name, "/*/", "_"), "/", "_")
 }

--- a/source-firestore/helpers.go
+++ b/source-firestore/helpers.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+)
+
+const DEFAULT_SCAN_INTERVAL string = "12h"
+const SCAN_INTERVAL_NEVER string = "never"
+const PATH_FIELD = "__path__"
+
+// Nested collections are referred to by their parent document in Firestore
+// e.g. parent_collection/my_doc_id123/nested_collection
+// however in resource spec, we use wildcard /*/ to refer to all nested_collections under parent_collection
+// this function matches collection paths with resource paths
+func collectionMatchesResourcePath(collectionPath string, resourcePath string) bool {
+	return collectionToResourcePath(collectionPath) == resourcePath
+}
+
+// Searches in list of bindings for one that matches the collection path
+func findBindingForCollectionPath(collectionPath string, bindings []resource) int {
+	for index, binding := range bindings {
+		if collectionMatchesResourcePath(collectionPath, binding.Path) {
+			return index
+		}
+	}
+
+	return -1
+}
+
+// Our resource paths are formatted with parent_collection/*/nested_collection
+// in order to query documents for such collections we use Firestore's Collection Groups
+// which operate on the name of the last collection. Note that this name might not be unique
+// so another check is necessary to make sure we do not mix documents from nested collections
+// that have the same ID, but different parent collections
+func getLastCollectionGroupID(resourcePath string) string {
+	var pieces = strings.Split(resourcePath, "/")
+	return pieces[len(pieces)-1]
+}
+
+func isRootCollection(resourcePath string) bool {
+	return !strings.Contains(resourcePath, "/")
+}
+
+// Firestore's original collection path is very verbose, and it includes the parent document ID
+// This function creates a path for a collection which only refers to its parent collections, not documents
+// e.g. projects/hello-flow-mahdi/databases/(default)/documents/group/OLgLVvZnykvFR4ZyqUuS/group
+// becomes group/*/group
+func collectionToResourcePath(collection string) string {
+	// the prefix up to the first "/documents" is unnecessary, so we remove that
+	var parts = strings.SplitN(collection, "/documents/", 2)
+	if len(parts) < 2 {
+		panic(fmt.Sprintf("collection path does not match expectations: %s", collection))
+	}
+	var after = parts[1]
+
+	// we now need to get rid of document references, which appear after every collection name
+	var pieces = strings.Split(after, "/")
+	var cleanedPath = ""
+
+	for i, piece := range pieces {
+		if i%2 == 0 {
+			cleanedPath = cleanedPath + "/*/" + piece
+		}
+	}
+
+	return strings.Trim(cleanedPath, "/*/")
+}

--- a/source-firestore/helpers.go
+++ b/source-firestore/helpers.go
@@ -5,9 +5,9 @@ import (
 	"strings"
 )
 
-const DEFAULT_SCAN_INTERVAL string = "12h"
-const SCAN_INTERVAL_NEVER string = "never"
-const PATH_FIELD = "__path__"
+const defaultScanInterval string = "12h"
+const scanIntervalNever string = "never"
+const pathField = "__path__"
 
 // Nested collections are referred to by their parent document in Firestore
 // e.g. parent_collection/my_doc_id123/nested_collection

--- a/source-firestore/main.go
+++ b/source-firestore/main.go
@@ -31,7 +31,7 @@ func (c *config) Validate() error {
 	if c.CredentialsJSON == "" {
 		return fmt.Errorf("googleCredentials is required")
 	}
-	if c.ScanInterval != "" && c.ScanInterval != SCAN_INTERVAL_NEVER {
+	if c.ScanInterval != "" && c.ScanInterval != scanIntervalNever {
 		var _, err = time.ParseDuration(c.ScanInterval)
 
 		if err != nil {

--- a/source-firestore/main.go
+++ b/source-firestore/main.go
@@ -4,27 +4,20 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"strings"
 	"time"
 
-	firestore "cloud.google.com/go/firestore"
-	firebase "firebase.google.com/go"
 	schemagen "github.com/estuary/connectors/go-schema-gen"
-	"github.com/estuary/flow/go/protocols/airbyte"
-	log "github.com/sirupsen/logrus"
-	"golang.org/x/sync/errgroup"
-	"google.golang.org/api/iterator"
-	"google.golang.org/api/option"
+	boilerplate "github.com/estuary/connectors/source-boilerplate"
+	pc "github.com/estuary/flow/go/protocols/capture"
 )
 
-type State struct {
-	// Last time a full table scan was run, we use this to know if we need to do a full scan
-	// to reach eventual consistency
-	LastScan time.Time
+type resource struct {
+	Path string `json:"path" jsonschema:"title=Path to Collection,description=Supports parent/*/nested to capture all nested collections of parent's children"`
 }
 
-const DEFAULT_SCAN_INTERVAL string = "12h"
-const SCAN_INTERVAL_NEVER string = "never"
+func (r resource) Validate() error {
+	return nil
+}
 
 type config struct {
 	// Service account JSON key to use as Application Default Credentials
@@ -38,7 +31,7 @@ func (c *config) Validate() error {
 	if c.CredentialsJSON == "" {
 		return fmt.Errorf("googleCredentials is required")
 	}
-	if c.ScanInterval != "" {
+	if c.ScanInterval != "" && c.ScanInterval != SCAN_INTERVAL_NEVER {
 		var _, err = time.ParseDuration(c.ScanInterval)
 
 		if err != nil {
@@ -48,356 +41,25 @@ func (c *config) Validate() error {
 	return nil
 }
 
-func (c *State) Validate() error {
-	return nil
-}
+type driver struct{}
 
-func main() {
+func (driver) Spec(ctx context.Context, req *pc.SpecRequest) (*pc.SpecResponse, error) {
 	var endpointSchema, err = schemagen.GenerateSchema("Google Firestore", &config{}).MarshalJSON()
 	if err != nil {
 		fmt.Println(fmt.Errorf("generating endpoint schema: %w", err))
 	}
-
-	var spec = airbyte.Spec{
-		SupportsIncremental:           true,
-		DocumentationURL:              "https://go.estuary.dev/source-firestore",
-		SupportedDestinationSyncModes: airbyte.AllDestinationSyncModes,
-		ConnectionSpecification:       json.RawMessage(endpointSchema),
+	resourceSchema, err := schemagen.GenerateSchema("Firestore Resource Spec", &resource{}).MarshalJSON()
+	if err != nil {
+		return nil, fmt.Errorf("generating resource schema: %w", err)
 	}
 
-	airbyte.RunMain(spec, doCheck, doDiscover, doRead)
+	return &pc.SpecResponse{
+		EndpointSpecSchemaJson: json.RawMessage(endpointSchema),
+		ResourceSpecSchemaJson: json.RawMessage(resourceSchema),
+		DocumentationUrl:       "https://go.estuary.dev/source-firestore",
+	}, nil
 }
 
-func doCheck(args airbyte.CheckCmd) error {
-	var result = &airbyte.ConnectionStatus{
-		Status: airbyte.StatusSucceeded,
-	}
-
-	var cfg config
-	if err := args.ConfigFile.Parse(&cfg); err != nil {
-		result.Status = airbyte.StatusFailed
-		result.Message = err.Error()
-	}
-
-	ctx := context.Background()
-	sa := option.WithCredentialsJSON([]byte(cfg.CredentialsJSON))
-	app, err := firebase.NewApp(ctx, nil, sa)
-	if err != nil {
-		result.Status = airbyte.StatusFailed
-		result.Message = err.Error()
-	}
-
-	client, err := app.Firestore(ctx)
-	if err != nil {
-		result.Status = airbyte.StatusFailed
-		result.Message = err.Error()
-	}
-	defer client.Close()
-
-	return airbyte.NewStdoutEncoder().Encode(airbyte.Message{
-		Type:             airbyte.MessageTypeConnectionStatus,
-		ConnectionStatus: result,
-	})
-}
-
-const PATH_FIELD = "__path__"
-
-// Firestore's original collection path is very verbose, and it includes the parent document ID
-// This function creates a path for a collection which only refers to its parent collections, not documents
-// e.g. projects/hello-flow-mahdi/databases/(default)/documents/group/OLgLVvZnykvFR4ZyqUuS/group
-// becomes group/*/group
-func collectionPath(collection string) string {
-	// the prefix up to the first "/documents" is unnecessary, so we remove that
-	var parts = strings.SplitN(collection, "/documents/", 2)
-	if len(parts) < 2 {
-		panic(fmt.Sprintf("collection path does not match expectations: %s", collection))
-	}
-	var after = parts[1]
-
-	// we now need to get rid of document references, which appear after every collection name
-	var pieces = strings.Split(after, "/")
-	var cleanedPath = ""
-
-	for i, piece := range pieces {
-		if i%2 == 0 {
-			cleanedPath = cleanedPath + "/*/" + piece
-		}
-	}
-
-	return strings.Trim(cleanedPath, "/*/")
-}
-
-func doDiscover(args airbyte.DiscoverCmd) error {
-	var cfg config
-	if err := args.ConfigFile.Parse(&cfg); err != nil {
-		return err
-	}
-
-	ctx := context.Background()
-	sa := option.WithCredentialsJSON([]byte(cfg.CredentialsJSON))
-	app, err := firebase.NewApp(ctx, nil, sa)
-	if err != nil {
-		return err
-	}
-
-	client, err := app.Firestore(ctx)
-	if err != nil {
-		return err
-	}
-	defer client.Close()
-
-	var catalog = new(airbyte.Catalog)
-	err = discoverCollections(ctx, client, catalog)
-	if err != nil {
-		return err
-	}
-
-	var encoder = airbyte.NewStdoutEncoder()
-	return encoder.Encode(airbyte.Message{
-		Type:    airbyte.MessageTypeCatalog,
-		Catalog: catalog,
-	})
-}
-
-type EncoderRequestType int8
-
-const (
-	EncodeDocument EncoderRequestType = 0
-	StateUpdate    EncoderRequestType = 1
-)
-
-// struct sent over channel to encoder
-type encDocument struct {
-	requestType EncoderRequestType
-	doc         []byte
-	streamName  string
-	state       []byte
-}
-
-func doRead(args airbyte.ReadCmd) error {
-	var cfg config
-	var state State
-	var catalog airbyte.ConfiguredCatalog
-
-	if err := args.ConfigFile.Parse(&cfg); err != nil {
-		return err
-	} else if err := args.CatalogFile.Parse(&catalog); err != nil {
-		return err
-	} else if args.StateFile != "" {
-		if err := args.StateFile.Parse(&state); err != nil {
-			return err
-		}
-	}
-
-	var lastScan = state.LastScan
-
-	var scanInterval, _ = time.ParseDuration(DEFAULT_SCAN_INTERVAL)
-	if cfg.ScanInterval != "" && cfg.ScanInterval != SCAN_INTERVAL_NEVER {
-		var err error
-		scanInterval, err = time.ParseDuration(cfg.ScanInterval)
-
-		if err != nil {
-			return fmt.Errorf("parsing scan interval failed: %w", err)
-		}
-	}
-
-	log.WithFields(log.Fields{
-		"last_scan":     lastScan,
-		"scan_interval": scanInterval,
-	}).Info("state check for scan")
-
-	ctx := context.Background()
-	sa := option.WithCredentialsJSON([]byte(cfg.CredentialsJSON))
-	app, err := firebase.NewApp(ctx, nil, sa)
-	if err != nil {
-		return err
-	}
-
-	client, err := app.Firestore(ctx)
-	if err != nil {
-		return err
-	}
-	defer client.Close()
-
-	// The channel where documents will be sent to from different streams
-	// this is here to ensure we write documents sequentially and avoid scrambled outputs
-	var docsCh = make(chan encDocument)
-
-	var eg = new(errgroup.Group)
-
-	// TODO: support nested collections which are in the form of <collection>/<collection>/<collection>/...
-	for _, stream := range catalog.Streams {
-		var streamName = stream.Stream.Name
-
-		var collection = client.Collection(streamName)
-		if cfg.ScanInterval != SCAN_INTERVAL_NEVER {
-			eg.Go(func() error {
-				return fullScan(ctx, lastScan, scanInterval, collection, docsCh, catalog.Tail)
-			})
-		}
-
-		if catalog.Tail {
-			eg.Go(func() error {
-				return listenForChanges(ctx, collection, docsCh)
-			})
-		}
-	}
-
-	eg.Go(func() error {
-		return encodeDocs(docsCh)
-	})
-
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-
-	close(docsCh)
-
-	return nil
-}
-
-func encodeDocs(docsCh chan encDocument) error {
-	var enc = airbyte.NewStdoutEncoder()
-
-	for {
-		encDoc := <-docsCh
-
-		if encDoc.requestType == EncodeDocument {
-			log.WithFields(log.Fields{
-				"doc":        string(encDoc.doc),
-				"streamName": encDoc.streamName,
-			}).Info("encoding doc")
-
-			if err := enc.Encode(&airbyte.Message{
-				Type: airbyte.MessageTypeRecord,
-				Record: &airbyte.Record{
-					Stream:    encDoc.streamName,
-					EmittedAt: time.Now().UTC().UnixNano() / int64(time.Millisecond),
-					Data:      encDoc.doc,
-				},
-			}); err != nil {
-				return err
-			}
-			if err := enc.Encode(airbyte.Message{
-				Type:  airbyte.MessageTypeState,
-				State: &airbyte.State{Data: []byte("{}"), Merge: true},
-			}); err != nil {
-				return err
-			}
-		} else if encDoc.requestType == StateUpdate {
-			if err := enc.Encode(airbyte.Message{
-				Type:  airbyte.MessageTypeState,
-				State: &airbyte.State{Data: encDoc.state},
-			}); err != nil {
-				return err
-			}
-		} else {
-			panic(fmt.Sprintf("unknown EncoderRequestType %v", encDoc.requestType))
-		}
-	}
-}
-
-func listenForChanges(ctx context.Context, collection *firestore.CollectionRef, docsCh chan encDocument) error {
-	var query = collection.Query
-	var snapshotsIterator = query.Snapshots(ctx)
-
-	log.WithFields(log.Fields{
-		"collection": collection.Path,
-	}).Info("listening for changes on collection")
-
-	for {
-		var snapshot, err = snapshotsIterator.Next()
-
-		if err == iterator.Done {
-			break
-		} else if err != nil {
-			return err
-		}
-
-		for _, change := range snapshot.Changes {
-			if change.Kind == firestore.DocumentAdded || change.Kind == firestore.DocumentModified {
-				log.WithFields(log.Fields{
-					"kind": change.Kind,
-					"id":   change.Doc.Ref.ID,
-				}).Info("received change")
-
-				var doc = change.Doc
-				var data = doc.Data()
-				data[firestore.DocumentID] = doc.Ref.ID
-				data[PATH_FIELD] = doc.Ref.Path
-				docJson, err := json.Marshal(data)
-				if err != nil {
-					return err
-				}
-				log.WithFields(log.Fields{
-					"doc": string(docJson),
-					"id":  change.Doc.Ref.ID,
-				}).Info("received change doc")
-				docsCh <- encDocument{
-					requestType: EncodeDocument,
-					streamName:  collectionPath(collection.Path),
-					doc:         docJson,
-				}
-			}
-		}
-	}
-
-	return nil
-}
-
-func fullScan(ctx context.Context, lastScan time.Time, scanInterval time.Duration, collection *firestore.CollectionRef, docsCh chan encDocument, tail bool) error {
-	var nextScan = time.Until(lastScan.Add(scanInterval))
-	// Wait until next scan
-	time.Sleep(nextScan)
-
-	log.WithFields(log.Fields{
-		"collection": collection.Path,
-	}).Info("full scan on collection")
-
-	var query = collection.Query
-	var docsIterator = query.Documents(ctx)
-
-	var scanTime = time.Now()
-	for {
-		var doc, err = docsIterator.Next()
-
-		if err == iterator.Done {
-			break
-		} else if err != nil {
-			return err
-		}
-
-		var data = doc.Data()
-		data[firestore.DocumentID] = doc.Ref.ID
-		data[PATH_FIELD] = doc.Ref.Path
-		docJson, err := json.Marshal(data)
-		if err != nil {
-			return err
-		}
-		docsCh <- encDocument{
-			requestType: EncodeDocument,
-			streamName:  collectionPath(collection.Path),
-			doc:         docJson,
-		}
-	}
-
-	var newState, err = json.Marshal(State{
-		LastScan: scanTime,
-	})
-	if err != nil {
-		return fmt.Errorf("marshalling state: %w", err)
-	}
-	docsCh <- encDocument{
-		requestType: StateUpdate,
-		state:       newState,
-	}
-
-	// If we are not tailing, we close the channel after the full scan
-	// to allow the encoding routine to finish so the connector can exit
-	if !tail {
-		close(docsCh)
-		return nil
-	}
-
-	return fullScan(ctx, scanTime, scanInterval, collection, docsCh, tail)
+func main() {
+	boilerplate.RunMain(new(driver))
 }

--- a/source-firestore/pull.go
+++ b/source-firestore/pull.go
@@ -154,6 +154,7 @@ func (c *capture) Capture(ctx context.Context) error {
 		if isRootCollection(binding.Path) {
 			query = client.Collection(binding.Path).Query
 		} else {
+			// See https://firebase.blog/posts/2019/06/understanding-collection-group-queries
 			query = client.CollectionGroup(getLastCollectionGroupID(binding.Path)).Query
 		}
 

--- a/source-firestore/pull.go
+++ b/source-firestore/pull.go
@@ -1,0 +1,322 @@
+package main
+
+import (
+	firestore "cloud.google.com/go/firestore"
+	"context"
+	"encoding/json"
+	"errors"
+	firebase "firebase.google.com/go"
+	"fmt"
+	pc "github.com/estuary/flow/go/protocols/capture"
+	pf "github.com/estuary/flow/go/protocols/flow"
+	log "github.com/sirupsen/logrus"
+	"golang.org/x/sync/errgroup"
+	"google.golang.org/api/iterator"
+	"google.golang.org/api/option"
+	"io"
+	"time"
+)
+
+type capture struct {
+	Stream   pc.Driver_PullServer
+	Bindings []resource
+	Config   config
+	Acks     <-chan *pc.Acknowledge
+
+	// The channel where documents will be sent to from different streams
+	// this is here to ensure we write documents sequentially and avoid scrambled outputs
+	Output chan emitRequest
+
+	Tail bool
+}
+
+type EmitterRequestType int8
+
+const (
+	EncodeDocument EmitterRequestType = 0
+	StateUpdate    EmitterRequestType = 1
+)
+
+// struct sent over channel to emitter
+type emitRequest struct {
+	requestType EmitterRequestType
+	arena       []byte
+	binding     uint32
+	state       []byte
+}
+
+func (driver) Pull(stream pc.Driver_PullServer) error {
+	log.Debug("connector started")
+
+	var open, err = stream.Recv()
+	if err != nil {
+		return fmt.Errorf("error reading PullRequest: %w", err)
+	} else if open.Open == nil {
+		return fmt.Errorf("expected PullRequest.Open, got %#v", open)
+	}
+
+	var cfg config
+	if err := pf.UnmarshalStrict(open.Open.Capture.EndpointSpecJson, &cfg); err != nil {
+		return fmt.Errorf("parsing endpoint config: %w", err)
+	}
+
+	var resources []resource
+	for _, binding := range open.Open.Capture.Bindings {
+		var res resource
+		if err := pf.UnmarshalStrict(binding.ResourceSpecJson, &res); err != nil {
+			return fmt.Errorf("parsing resource config: %w", err)
+		}
+		resources = append(resources, res)
+	}
+
+	var capture = &capture{
+		Stream:   stream,
+		Bindings: resources,
+		Config:   cfg,
+		Output:   make(chan emitRequest),
+		Tail:     open.Open.Tail,
+	}
+	return capture.Run()
+}
+
+func (c *capture) Run() error {
+	// Spawn a goroutine which will translate gRPC PullRequest.Acknowledge messages
+	// into equivalent messages on a channel. Since the ServerStream interface doesn't
+	// have any sort of polling receive, this is necessary to allow captures to handle
+	// acknowledgements without blocking their own capture progress.
+	var acks = make(chan *pc.Acknowledge)
+	var eg, ctx = errgroup.WithContext(c.Stream.Context())
+	eg.Go(func() error {
+		defer close(acks)
+		for {
+			var msg, err = c.Stream.Recv()
+			if errors.Is(err, io.EOF) {
+				return nil
+			} else if err != nil {
+				return fmt.Errorf("error reading PullRequest: %w", err)
+			} else if msg.Acknowledge == nil {
+				return fmt.Errorf("expected PullRequest.Acknowledge, got %#v", msg)
+			}
+			select {
+			case <-ctx.Done():
+				return nil
+			case acks <- msg.Acknowledge:
+				// Loop and receive another acknowledgement
+			}
+		}
+	})
+	c.Acks = acks
+
+	// Notify Flow that we're starting.
+	log.Debug("sending PullResponse.Opened")
+	if err := c.Stream.Send(&pc.PullResponse{Opened: &pc.PullResponse_Opened{}}); err != nil {
+		return fmt.Errorf("error sending PullResponse.Opened: %w", err)
+	}
+
+	eg.Go(func() error {
+		return c.Capture(ctx)
+	})
+	return eg.Wait()
+}
+
+func (c *capture) Capture(ctx context.Context) error {
+	var scanInterval, _ = time.ParseDuration(DEFAULT_SCAN_INTERVAL)
+	if c.Config.ScanInterval != "" && c.Config.ScanInterval != SCAN_INTERVAL_NEVER {
+		var err error
+		scanInterval, err = time.ParseDuration(c.Config.ScanInterval)
+
+		if err != nil {
+			return fmt.Errorf("parsing scan interval failed: %w", err)
+		}
+	}
+
+	// Listening on snapshots gives you a copy of all documents initially
+	// so in essence it is a full scan. Hence we consider the current moment to be the last scan, and then start from there
+	var lastScan = time.Now()
+
+	sa := option.WithCredentialsJSON([]byte(c.Config.CredentialsJSON))
+	app, err := firebase.NewApp(ctx, nil, sa)
+	if err != nil {
+		return err
+	}
+
+	client, err := app.Firestore(ctx)
+	if err != nil {
+		return err
+	}
+	defer client.Close()
+
+	var eg = new(errgroup.Group)
+
+	for _, binding := range c.Bindings {
+		var groupID = getLastCollectionGroupID(binding.Path)
+		var query firestore.Query
+
+		if isRootCollection(binding.Path) {
+			query = client.Collection(binding.Path).Query
+		} else {
+			query = client.CollectionGroup(getLastCollectionGroupID(binding.Path)).Query
+		}
+
+		if c.Config.ScanInterval != SCAN_INTERVAL_NEVER {
+			log.WithField("group", groupID).Debug("full scan")
+			eg.Go(func() error {
+				return c.FullScan(ctx, lastScan, scanInterval, query)
+			})
+		}
+
+		if c.Tail {
+			log.WithField("group", groupID).Debug("listening for changes")
+			eg.Go(func() error {
+				return c.ListenForChanges(ctx, query)
+			})
+		}
+	}
+
+	eg.Go(func() error {
+		return c.EmitDocuments()
+	})
+
+	if err := eg.Wait(); err != nil {
+		return err
+	}
+
+	close(c.Output)
+
+	return nil
+}
+
+// TODO: listen on all changes on all documents
+func (c *capture) ListenForChanges(ctx context.Context, query firestore.Query) error {
+	var snapshotsIterator = query.Snapshots(ctx)
+
+	for {
+		var snapshot, err = snapshotsIterator.Next()
+
+		if err == iterator.Done {
+			break
+		} else if err != nil {
+			return err
+		}
+
+		for _, change := range snapshot.Changes {
+			if change.Kind == firestore.DocumentAdded || change.Kind == firestore.DocumentModified {
+
+				// Make sure this document matches the binding path
+				var index = findBindingForCollectionPath(change.Doc.Ref.Parent.Path, c.Bindings)
+				log.WithFields(log.Fields{
+					"kind":    change.Kind,
+					"path":    change.Doc.Ref.Path,
+					"p":       collectionToResourcePath(change.Doc.Ref.Parent.Path),
+					"binding": index,
+				}).Debug("received change")
+				if index == -1 {
+					continue
+				}
+
+				var doc = change.Doc
+				var data = doc.Data()
+				data[firestore.DocumentID] = doc.Ref.ID
+				data[PATH_FIELD] = doc.Ref.Path
+				docJson, err := json.Marshal(data)
+				if err != nil {
+					return err
+				}
+				log.WithFields(log.Fields{
+					"doc": string(docJson),
+					"id":  change.Doc.Ref.ID,
+				}).Debug("received change doc")
+				c.Output <- emitRequest{
+					requestType: EncodeDocument,
+					binding:     uint32(index),
+					arena:       docJson,
+				}
+			}
+		}
+	}
+
+	return nil
+}
+
+func (c *capture) FullScan(ctx context.Context, lastScan time.Time, scanInterval time.Duration, query firestore.Query) error {
+	var nextScan = time.Until(lastScan.Add(scanInterval))
+	// Wait until next scan
+	time.Sleep(nextScan)
+
+	var docsIterator = query.Documents(ctx)
+
+	var scanTime = time.Now()
+	for {
+		var doc, err = docsIterator.Next()
+
+		if err == iterator.Done {
+			break
+		} else if err != nil {
+			return err
+		}
+
+		var index = findBindingForCollectionPath(doc.Ref.Parent.Path, c.Bindings)
+		if index == -1 {
+			continue
+		}
+
+		var data = doc.Data()
+		data[firestore.DocumentID] = doc.Ref.ID
+		data[PATH_FIELD] = doc.Ref.Path
+		docJson, err := json.Marshal(data)
+		if err != nil {
+			return err
+		}
+		c.Output <- emitRequest{
+			requestType: EncodeDocument,
+			binding:     uint32(index),
+			arena:       docJson,
+		}
+	}
+
+	// If we are not tailing, we close the channel after the full scan
+	// to allow the encoding routine to finish so the connector can exit
+	if !c.Tail {
+		return nil
+	}
+
+	return c.FullScan(ctx, scanTime, scanInterval, query)
+}
+
+func (c *capture) EmitDocuments() error {
+	for {
+		emitDoc := <-c.Output
+
+		if emitDoc.requestType == EncodeDocument {
+			var msg = &pc.PullResponse{
+				Documents: &pc.Documents{
+					Binding:  emitDoc.binding,
+					Arena:    emitDoc.arena,
+					DocsJson: []pf.Slice{{Begin: 0, End: uint32(len(emitDoc.arena))}},
+				},
+			}
+			if err := c.Stream.Send(msg); err != nil {
+				return err
+			}
+			if err := c.Stream.Send(&pc.PullResponse{
+				Checkpoint: &pf.DriverCheckpoint{
+					DriverCheckpointJson: []byte("{}"),
+					Rfc7396MergePatch:    true,
+				},
+			}); err != nil {
+				return err
+			}
+		} else if emitDoc.requestType == StateUpdate {
+			if err := c.Stream.Send(&pc.PullResponse{
+				Checkpoint: &pf.DriverCheckpoint{
+					DriverCheckpointJson: emitDoc.state,
+					Rfc7396MergePatch:    true,
+				},
+			}); err != nil {
+				return err
+			}
+		} else {
+			panic(fmt.Sprintf("unknown EmitterRequestType %v", emitDoc.requestType))
+		}
+	}
+}

--- a/source-firestore/validate.go
+++ b/source-firestore/validate.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"context"
+	firebase "firebase.google.com/go"
+	"fmt"
+	pc "github.com/estuary/flow/go/protocols/capture"
+	pf "github.com/estuary/flow/go/protocols/flow"
+	"google.golang.org/api/option"
+)
+
+func (driver) Validate(ctx context.Context, req *pc.ValidateRequest) (*pc.ValidateResponse, error) {
+	var cfg config
+	if err := pf.UnmarshalStrict(req.EndpointSpecJson, &cfg); err != nil {
+		return nil, fmt.Errorf("parsing endpoint config: %w", err)
+	}
+
+	// Validate connection to Firestore
+	sa := option.WithCredentialsJSON([]byte(cfg.CredentialsJSON))
+	app, err := firebase.NewApp(ctx, nil, sa)
+	if err != nil {
+		return nil, err
+	}
+
+	client, err := app.Firestore(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer client.Close()
+
+	var out []*pc.ValidateResponse_Binding
+	for _, binding := range req.Bindings {
+		var res resource
+		if err := pf.UnmarshalStrict(binding.ResourceSpecJson, &res); err != nil {
+			return nil, fmt.Errorf("parsing resource config: %w", err)
+		}
+
+		out = append(out, &pc.ValidateResponse_Binding{
+			ResourcePath: []string{res.Path},
+		})
+	}
+
+	return &pc.ValidateResponse{Bindings: out}, nil
+}

--- a/source-nativehello/Dockerfile
+++ b/source-nativehello/Dockerfile
@@ -1,0 +1,42 @@
+# Build Stage
+################################################################################
+FROM golang:1.17-buster as builder
+
+WORKDIR /builder
+
+# Download & compile dependencies early. Doing this separately allows for layer
+# caching opportunities when no dependencies are updated.
+COPY go.* ./
+RUN go mod download
+
+# Copy over helper packages that the connector uses and then build them and
+# their transitive dependencies to aid in layer caching.
+COPY go-schema-gen      ./go-schema-gen
+COPY source-boilerplate ./source-boilerplate
+RUN go get -v ./go-schema-gen ./source-boilerplate
+
+# Copy and build and test the connector (there are currently no tests)
+COPY source-nativehello ./source-nativehello
+RUN go build -o ./connector -v ./source-nativehello
+# RUN go test -v ./source-nativehello/...
+
+
+# Runtime Stage
+################################################################################
+FROM ghcr.io/estuary/base-image:v1
+
+WORKDIR /connector
+ENV PATH="/connector:$PATH"
+
+COPY --from=busybox:latest /bin/sh /bin/sh
+
+# Bring in the compiled connector artifact from the builder.
+COPY --from=builder /builder/connector ./connector
+
+LABEL FLOW_RUNTIME_PROTOCOL=capture
+LABEL CONNECTOR_PROTOCOL=flow-capture
+
+# Avoid running the connector as root.
+USER nonroot:nonroot
+
+ENTRYPOINT ["/connector/connector"]

--- a/source-nativehello/main.go
+++ b/source-nativehello/main.go
@@ -1,0 +1,292 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"strconv"
+	"strings"
+	"time"
+
+	schemagen "github.com/estuary/connectors/go-schema-gen"
+	boilerplate "github.com/estuary/connectors/source-boilerplate"
+	pc "github.com/estuary/flow/go/protocols/capture"
+	pf "github.com/estuary/flow/go/protocols/flow"
+	log "github.com/sirupsen/logrus"
+	"golang.org/x/sync/errgroup"
+)
+
+func main() {
+	boilerplate.RunMain(new(driver))
+}
+
+type config struct {
+	Rate float32 `json:"rate" jsonschema:"title=Message Rate,description=Message rate in documents per second,default=1"`
+}
+
+func (c config) Validate() error {
+	if c.Rate <= 0 {
+		return fmt.Errorf("message rate must be positive (got %f)", c.Rate)
+	}
+	return nil
+}
+
+type resource struct {
+	Name   string `json:"name" jsonschema:"title=Stream Name,description=Stream name to include in generated documents,default=greetings"`
+	Prefix string `json:"prefix" jsonschema:"title=Message Prefix,description=Constant prefix to add to every message,default=Hello {}"`
+}
+
+func (r resource) Validate() error {
+	return nil
+}
+
+type message struct {
+	Timestamp time.Time `json:"ts" jsonschema:"title=Timestamp,description=The time at which this message was generated"`
+	Message   string    `json:"message" jsonschema:"title=Message,description=A human-readable message"`
+}
+
+type state struct {
+	Cursor int `json:"cursor"` // The last message generated
+}
+
+type capture struct {
+	Stream   pc.Driver_PullServer
+	Bindings []resource
+	Config   config
+	State    state
+	Acks     <-chan *pc.Acknowledge
+}
+
+// driver implements the pc.DriverServer interface.
+type driver struct{}
+
+func (driver) Spec(ctx context.Context, req *pc.SpecRequest) (*pc.SpecResponse, error) {
+	var endpointSchema, err = schemagen.GenerateSchema("Example Source Spec", &config{}).MarshalJSON()
+	if err != nil {
+		return nil, fmt.Errorf("generating endpoint schema: %w", err)
+	}
+
+	resourceSchema, err := schemagen.GenerateSchema("Example Resource Spec", &resource{}).MarshalJSON()
+	if err != nil {
+		return nil, fmt.Errorf("generating resource schema: %w", err)
+	}
+
+	return &pc.SpecResponse{
+		EndpointSpecSchemaJson: json.RawMessage(endpointSchema),
+		ResourceSpecSchemaJson: json.RawMessage(resourceSchema),
+		DocumentationUrl:       "https://go.estuary.dev/source-nativehello",
+	}, nil
+}
+
+func (driver) Validate(ctx context.Context, req *pc.ValidateRequest) (*pc.ValidateResponse, error) {
+	var cfg config
+	if err := pf.UnmarshalStrict(req.EndpointSpecJson, &cfg); err != nil {
+		return nil, fmt.Errorf("parsing endpoint config: %w", err)
+	}
+
+	var out []*pc.ValidateResponse_Binding
+	for _, binding := range req.Bindings {
+		var res resource
+		if err := pf.UnmarshalStrict(binding.ResourceSpecJson, &res); err != nil {
+			return nil, fmt.Errorf("parsing resource config: %w", err)
+		}
+
+		out = append(out, &pc.ValidateResponse_Binding{
+			ResourcePath: []string{res.Name},
+		})
+	}
+	return &pc.ValidateResponse{Bindings: out}, nil
+}
+
+func (driver) Discover(ctx context.Context, req *pc.DiscoverRequest) (*pc.DiscoverResponse, error) {
+	messageSchema, err := schemagen.GenerateSchema("Example Output Record", &message{}).MarshalJSON()
+	if err != nil {
+		return nil, fmt.Errorf("generating message schema: %w", err)
+	}
+
+	resourceJSON, err := json.Marshal(resource{Name: "greetings", Prefix: "Hello {}!"})
+	if err != nil {
+		return nil, fmt.Errorf("serializing resource json: %w", err)
+	}
+
+	return &pc.DiscoverResponse{
+		Bindings: []*pc.DiscoverResponse_Binding{{
+			RecommendedName:    "events",
+			ResourceSpecJson:   resourceJSON,
+			DocumentSchemaJson: messageSchema,
+			KeyPtrs:            []string{"/ts"},
+		}},
+	}, nil
+}
+
+func (d driver) ApplyUpsert(ctx context.Context, req *pc.ApplyRequest) (*pc.ApplyResponse, error) {
+	return d.apply(ctx, req, false)
+}
+
+func (d driver) ApplyDelete(ctx context.Context, req *pc.ApplyRequest) (*pc.ApplyResponse, error) {
+	return d.apply(ctx, req, true)
+}
+
+func (driver) apply(ctx context.Context, req *pc.ApplyRequest, isDelete bool) (*pc.ApplyResponse, error) {
+	return &pc.ApplyResponse{
+		ActionDescription: "this is a dummy capture so nothing happened",
+	}, nil
+}
+
+func (driver) Pull(stream pc.Driver_PullServer) error {
+	log.Debug("connector started")
+
+	var open, err = stream.Recv()
+	if err != nil {
+		return fmt.Errorf("error reading PullRequest: %w", err)
+	} else if open.Open == nil {
+		return fmt.Errorf("expected PullRequest.Open, got %#v", open)
+	}
+
+	var cfg config
+	if err := pf.UnmarshalStrict(open.Open.Capture.EndpointSpecJson, &cfg); err != nil {
+		return fmt.Errorf("parsing endpoint config: %w", err)
+	}
+
+	var checkpoint state
+	if open.Open.DriverCheckpointJson != nil {
+		if err := json.Unmarshal(open.Open.DriverCheckpointJson, &checkpoint); err != nil {
+			return fmt.Errorf("parsing driver checkpoint: %w", err)
+		}
+	}
+
+	var resources []resource
+	for _, binding := range open.Open.Capture.Bindings {
+		var res resource
+		if err := pf.UnmarshalStrict(binding.ResourceSpecJson, &res); err != nil {
+			return fmt.Errorf("parsing resource config: %w", err)
+		}
+		resources = append(resources, res)
+	}
+
+	var capture = &capture{
+		Stream:   stream,
+		Bindings: resources,
+		Config:   cfg,
+		State:    checkpoint,
+	}
+	return capture.Run()
+}
+
+func (c *capture) Run() error {
+	// Spawn a goroutine which will translate gRPC PullRequest.Acknowledge messages
+	// into equivalent messages on a channel. Since the ServerStream interface doesn't
+	// have any sort of polling receive, this is necessary to allow captures to handle
+	// acknowledgements without blocking their own capture progress.
+	var acks = make(chan *pc.Acknowledge)
+	var eg, ctx = errgroup.WithContext(c.Stream.Context())
+	eg.Go(func() error {
+		defer close(acks)
+		for {
+			var msg, err = c.Stream.Recv()
+			if errors.Is(err, io.EOF) {
+				return nil
+			} else if err != nil {
+				return fmt.Errorf("error reading PullRequest: %w", err)
+			} else if msg.Acknowledge == nil {
+				return fmt.Errorf("expected PullRequest.Acknowledge, got %#v", msg)
+			}
+			select {
+			case <-ctx.Done():
+				return nil
+			case acks <- msg.Acknowledge:
+				// Loop and receive another acknowledgement
+			}
+		}
+	})
+	c.Acks = acks
+
+	// Notify Flow that we're starting.
+	log.Debug("sending PullResponse.Opened")
+	if err := c.Stream.Send(&pc.PullResponse{Opened: &pc.PullResponse_Opened{}}); err != nil {
+		return fmt.Errorf("error sending PullResponse.Opened: %w", err)
+	}
+
+	eg.Go(func() error {
+		return c.Capture(ctx)
+	})
+	return eg.Wait()
+}
+
+func (c *capture) EmitDocuments(binding int, docs []*message) error {
+	var arena []byte
+	var ranges []pf.Slice
+	for _, doc := range docs {
+		bs, err := json.Marshal(doc)
+		if err != nil {
+			return fmt.Errorf("error serializing document: %w", err)
+		}
+
+		var begin, end = len(arena), len(arena) + len(bs)
+		arena = append(arena, bs...)
+		ranges = append(ranges, pf.Slice{Begin: uint32(begin), End: uint32(end)})
+	}
+
+	var msg = &pc.PullResponse{
+		Documents: &pc.Documents{
+			Binding:  uint32(binding),
+			Arena:    arena,
+			DocsJson: ranges,
+		},
+	}
+	log.WithField("count", len(docs)).Debug("emitting documents")
+	if err := c.Stream.Send(msg); err != nil {
+		return fmt.Errorf("error sending PullResponse.Documents: %w", err)
+	}
+	return nil
+}
+
+func (c *capture) EmitCheckpoint() error {
+	checkpointJSON, err := json.Marshal(c.State)
+	if err != nil {
+		return fmt.Errorf("error serializing state: %w", err)
+	}
+	var checkpoint = &pc.PullResponse{
+		Checkpoint: &pf.DriverCheckpoint{
+			DriverCheckpointJson: checkpointJSON,
+			Rfc7396MergePatch:    true,
+		},
+	}
+	log.WithField("checkpoint", string(checkpointJSON)).Debug("emitting checkpoint")
+	if err := c.Stream.Send(checkpoint); err != nil {
+		return fmt.Errorf("error sending PullResponse.Checkpoint: %w", err)
+	}
+	return nil
+}
+
+func (c *capture) Capture(ctx context.Context) error {
+	var interval = time.Duration(float64(time.Second) / float64(c.Config.Rate))
+	for {
+		select {
+		case <-ctx.Done():
+			log.Info("shutting down due to context cancellation")
+			return nil
+		case <-c.Acks:
+			log.Debug("received acknowledgement")
+		default:
+		}
+
+		for idx, binding := range c.Bindings {
+			var text = strings.Replace(binding.Prefix, "{}", strconv.Itoa(c.State.Cursor), -1)
+			var doc = &message{
+				Timestamp: time.Now(),
+				Message:   text,
+			}
+			if err := c.EmitDocuments(idx, []*message{doc}); err != nil {
+				return err
+			}
+		}
+		c.State.Cursor++
+		if err := c.EmitCheckpoint(); err != nil {
+			return err
+		}
+		time.Sleep(interval)
+	}
+}


### PR DESCRIPTION
**Description:**

- Support nested collectons for source-firestore by discovering them using a wildcard notation:
```
captures:
  acmeCo/source-firestore:
    endpoint:
      connector:
        image: source-firestore:local
        config: source-firestore.config.yaml
    bindings:
      - resource:
          path: orgs/*/runs/*/runResults/*/queryResults
        target: acmeCo/orgs_runs_runResults_queryResults
      - resource:
          path: orgs/*/runs/*/runResults
        target: acmeCo/orgs_runs_runResults
      - resource:
          path: orgs/*/runs
        target: acmeCo/orgs_runs
      - resource:
          path: orgs
        target: acmeCo/orgs
```
- I realised while working on this PR that actually it is not possible for us to not fully scan Firestore whenever we boot up. The process of listening on changes of a query always includes a copy of all documents upfront: https://stackoverflow.com/questions/52955433/can-cloud-firestore-onsnapshot-only-trigger-on-changes-and-not-get-the-initia#
- As a result, I updated the code to remove the need for LastScan state: we scan once when we boot up, and then every `ScanInterval` after that as long as we are awake
- Refactored the code to use native Flow protocol, thanks to @willdonnelly's PR: https://github.com/estuary/connectors/pull/317
- The discovery process is quite complicated since we need to traverse in nested structures, that's the part that took most of the work
- Updated the `build-local.sh` script to work on M1 mac by using `docker buildx`

**Workflow steps:**

- ```flowctl discover --image source-firestore:local```

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/319)
<!-- Reviewable:end -->
