### PR TITLE
filesource schema discovery & source-http-file streaming

### DIFF
--- a/filesource/filesource.go
+++ b/filesource/filesource.go
@@ -96,13 +96,13 @@ type ObjectInfo struct {
 	IsPrefix bool
 	// ContentSum is an implementation-defined content sum.
 	ContentSum string
-	// Size of the object, in bytes.
+	// Size of the object, in bytes, or -1 if unbounded or unknown.
 	Size int64
 	// ContentType of the object, if known.
 	ContentType string
 	// ContentEncoding of the object, if known.
 	ContentEncoding string
-	// ModTime of the objection.
+	// ModTime of the object.
 	ModTime time.Time
 }
 
@@ -214,16 +214,12 @@ func (src Source) Read(args airbyte.ReadCmd) error {
 		state.startSweep(horizon)
 
 		var r = &reader{
-			connector:   conn,
-			pathRe:      pathRe,
-			prefix:      prefix,
-			projections: make(map[string]parser.JsonPointer),
-			range_:      catalog.Range,
-			schema:      stream.Stream.JSONSchema,
-			state:       state,
-		}
-		for k, v := range stream.Projections {
-			r.projections[k] = parser.JsonPointer(v)
+			connector: conn,
+			pathRe:    pathRe,
+			prefix:    prefix,
+			range_:    catalog.Range,
+			schema:    stream.Stream.JSONSchema,
+			state:     state,
 		}
 
 		r.shared.mu = sharedMu
@@ -244,12 +240,11 @@ func (src Source) Read(args airbyte.ReadCmd) error {
 type reader struct {
 	*connector
 
-	pathRe      *regexp.Regexp
-	prefix      string
-	projections map[string]parser.JsonPointer
-	range_      airbyte.Range
-	schema      json.RawMessage
-	state       State
+	pathRe *regexp.Regexp
+	prefix string
+	range_ airbyte.Range
+	schema json.RawMessage
+	state  State
 
 	shared struct {
 		mu     *sync.Mutex

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/bradleyjkemp/cupaloy v2.3.0+incompatible
 	github.com/brianvoe/gofakeit/v6 v6.16.0
 	github.com/elastic/go-elasticsearch/v7 v7.17.1
-	github.com/estuary/flow v0.1.1-0.20220621175215-bcd2ad59f15b
+	github.com/estuary/flow v0.1.1-0.20220817221148-d68d91a3b3c1
 	github.com/evanphx/json-patch/v5 v5.6.0
 	github.com/go-mysql-org/go-mysql v1.5.0
 	github.com/gogo/protobuf v1.3.2
@@ -60,5 +60,3 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	vitess.io/vitess v0.13.1
 )
-
-replace github.com/estuary/flow => github.com/estuary/flow v0.1.1-0.20220719165323-5c9a6a5308d6

--- a/go.sum
+++ b/go.sum
@@ -346,8 +346,8 @@ github.com/envoyproxy/go-control-plane v0.9.9-0.20210512163311-63b5d3c536b0/go.m
 github.com/envoyproxy/go-control-plane v0.9.10-0.20210907150352-cf90f659a021/go.mod h1:AFq3mo9L8Lqqiid3OhADV3RfLJnjiw63cSpi+fDTRC0=
 github.com/envoyproxy/go-control-plane v0.10.2-0.20220325020618-49ff273808a1/go.mod h1:KJwIaB5Mv44NWtYuAOFCVOjcI94vtpEz2JU/D2v6IjE=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
-github.com/estuary/flow v0.1.1-0.20220719165323-5c9a6a5308d6 h1:8+KAZ/F30K4Ls2lHahCR6W8PmEYt9HNgS10t/SB+74w=
-github.com/estuary/flow v0.1.1-0.20220719165323-5c9a6a5308d6/go.mod h1:7NlH7dQWZWv2qJsdZqeYLAz2EhMa5EVArEuGR62YjvM=
+github.com/estuary/flow v0.1.1-0.20220817221148-d68d91a3b3c1 h1:US4qVEmTnhUInwPPBesyJ2eSSC+mWiLl7AfeFu4xfzs=
+github.com/estuary/flow v0.1.1-0.20220817221148-d68d91a3b3c1/go.mod h1:dHlTdu5vRYgKgaqRZzjTWLqs7Z21xf41DvwEBlcD3KM=
 github.com/evanphx/json-patch v4.2.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/evanphx/json-patch v4.9.0+incompatible h1:kLcOMZeuLAJvL2BPWLMIj5oaZQobrkAqrL+WFZwQses=
 github.com/evanphx/json-patch v4.9.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=

--- a/materialize-bigquery/.snapshots/TestSpecification
+++ b/materialize-bigquery/.snapshots/TestSpecification
@@ -1,13 +1,7 @@
 {
   "endpoint_spec_schema_json": {
-    "$schema": "http://json-schema.org/draft-04/schema#",
-    "required": [
-      "project_id",
-      "dataset",
-      "region",
-      "bucket",
-      "credentials_json"
-    ],
+    "$schema": "http://json-schema.org/draft/2020-12/schema",
+    "$id": "https://github.com/estuary/connectors/materialize-bigquery/config",
     "properties": {
       "billing_project_id": {
         "type": "string",
@@ -48,13 +42,18 @@
       }
     },
     "type": "object",
+    "required": [
+      "project_id",
+      "dataset",
+      "region",
+      "bucket",
+      "credentials_json"
+    ],
     "title": "SQL Connection"
   },
   "resource_spec_schema_json": {
-    "$schema": "http://json-schema.org/draft-04/schema#",
-    "required": [
-      "table"
-    ],
+    "$schema": "http://json-schema.org/draft/2020-12/schema",
+    "$id": "https://github.com/estuary/connectors/materialize-bigquery/table-config",
     "properties": {
       "table": {
         "type": "string",
@@ -64,10 +63,14 @@
       "delta_updates": {
         "type": "boolean",
         "title": "Delta Update",
-        "description": "Should updates to this table be done via delta updates. Defaults is false."
+        "description": "Should updates to this table be done via delta updates. Defaults is false.",
+        "default": false
       }
     },
     "type": "object",
+    "required": [
+      "table"
+    ],
     "title": "SQL Table"
   },
   "documentation_url": "https://go.estuary.dev/materialize-bigquery"

--- a/materialize-postgres/.snapshots/TestSpecification
+++ b/materialize-postgres/.snapshots/TestSpecification
@@ -1,11 +1,7 @@
 {
   "endpoint_spec_schema_json": {
-    "$schema": "http://json-schema.org/draft-04/schema#",
-    "required": [
-      "address",
-      "user",
-      "password"
-    ],
+    "$schema": "http://json-schema.org/draft/2020-12/schema",
+    "$id": "https://github.com/estuary/connectors/materialize-postgres/config",
     "properties": {
       "address": {
         "type": "string",
@@ -30,19 +26,25 @@
       }
     },
     "type": "object",
+    "required": [
+      "address",
+      "user",
+      "password"
+    ],
     "title": "SQL Connection"
   },
   "resource_spec_schema_json": {
-    "$schema": "http://json-schema.org/draft-04/schema#",
-    "required": [
-      "table"
-    ],
+    "$schema": "http://json-schema.org/draft/2020-12/schema",
+    "$id": "https://github.com/estuary/connectors/materialize-postgres/table-config",
     "properties": {
       "table": {
         "type": "string"
       }
     },
     "type": "object",
+    "required": [
+      "table"
+    ],
     "title": "SQL Table"
   },
   "documentation_url": "https://go.estuary.dev/materialize-postgresql"

--- a/materialize-snowflake/.snapshots/TestSpecification
+++ b/materialize-snowflake/.snapshots/TestSpecification
@@ -1,15 +1,7 @@
 {
   "endpoint_spec_schema_json": {
-    "$schema": "http://json-schema.org/draft-04/schema#",
-    "required": [
-      "account",
-      "user",
-      "password",
-      "database",
-      "schema",
-      "cloud_provider",
-      "region"
-    ],
+    "$schema": "http://json-schema.org/draft/2020-12/schema",
+    "$id": "https://github.com/estuary/connectors/materialize-snowflake/config",
     "properties": {
       "account": {
         "type": "string",
@@ -48,12 +40,12 @@
         "description": "The user role used to perform actions."
       },
       "cloud_provider": {
+        "type": "string",
         "enum": [
           "aws",
           "azure",
           "gcp"
         ],
-        "type": "string",
         "title": "Cloud Provider",
         "description": "The cloud provider where the Snowflake endpoint is hosted."
       },
@@ -64,13 +56,20 @@
       }
     },
     "type": "object",
+    "required": [
+      "account",
+      "user",
+      "password",
+      "database",
+      "schema",
+      "cloud_provider",
+      "region"
+    ],
     "title": "SQL Connection"
   },
   "resource_spec_schema_json": {
-    "$schema": "http://json-schema.org/draft-04/schema#",
-    "required": [
-      "table"
-    ],
+    "$schema": "http://json-schema.org/draft/2020-12/schema",
+    "$id": "https://github.com/estuary/connectors/materialize-snowflake/table-config",
     "properties": {
       "table": {
         "type": "string"
@@ -80,6 +79,9 @@
       }
     },
     "type": "object",
+    "required": [
+      "table"
+    ],
     "title": "SQL Table"
   },
   "documentation_url": "https://go.estuary.dev/materialize-snowflake"


### PR DESCRIPTION
**Description:**

Make `filesource` connector discover work _better_, though still not _great_.

source-http-file supports unbounded real-time streams, such as wikipedia recent changes.

**Workflow steps:**

* (Optional) Use the new "Headers" tab of source-http-file to provide additional headers to be sent with the request.

* Start using source-http-file with streaming data sources, like wikimedia's recent changes, that previously did not work.

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/321)
<!-- Reviewable:end -->
