### PR TITLE
source-postgres: Quote all column names in backfill queries

### DIFF
--- a/source-postgres/backfill.go
+++ b/source-postgres/backfill.go
@@ -64,14 +64,6 @@ func (db *postgresDatabase) ScanTableChunk(ctx context.Context, info sqlcapture.
 	return events, nil
 }
 
-func quoteColumnNames(names []string) []string {
-	var out []string
-	for _, name := range names {
-		out = append(out, name)
-	}
-	return out
-}
-
 // WriteWatermark writes the provided string into the 'watermarks' table.
 func (db *postgresDatabase) WriteWatermark(ctx context.Context, watermark string) error {
 	logrus.WithField("watermark", watermark).Debug("writing watermark")

--- a/source-postgres/testdata/TestTrickyColumnNames_backfill.snapshot
+++ b/source-postgres/testdata/TestTrickyColumnNames_backfill.snapshot
@@ -1,0 +1,12 @@
+{"type":"STATE","state":{"data":{"cursor":"REDACTED","streams":{"public.test_trickycolumnnames_a":{"mode":"Pending","key_columns":["Meta/\"wtf\"/ID"],"scanned":null},"public.test_trickycolumnnames_b":{"mode":"Pending","key_columns":["table"],"scanned":null}}},"estuary.dev/merge":true}}
+{"type":"STATE","state":{"data":{"cursor":"REDACTED"},"estuary.dev/merge":true}}
+{"type":"STATE","state":{"data":{"cursor":"REDACTED","streams":{"public.test_trickycolumnnames_a":{"mode":"Backfill","key_columns":["Meta/\"wtf\"/ID"],"scanned":null},"public.test_trickycolumnnames_b":{"mode":"Backfill","key_columns":["table"],"scanned":null}}},"estuary.dev/merge":true}}
+{"type":"STATE","state":{"data":{"cursor":"REDACTED"},"estuary.dev/merge":true}}
+{"type":"RECORD","record":{"stream":"test_trickycolumnnames_a","data":{"Meta/\"wtf\"/ID":1,"_meta":{"op":"c","source":{"schema":"public","snapshot":true,"table":"test_trickycolumnnames_a"}},"data":"aaa"},"emitted_at":1234,"namespace":"public"}}
+{"type":"RECORD","record":{"stream":"test_trickycolumnnames_a","data":{"Meta/\"wtf\"/ID":2,"_meta":{"op":"c","source":{"schema":"public","snapshot":true,"table":"test_trickycolumnnames_a"}},"data":"bbb"},"emitted_at":1234,"namespace":"public"}}
+{"type":"RECORD","record":{"stream":"test_trickycolumnnames_b","data":{"_meta":{"op":"c","source":{"schema":"public","snapshot":true,"table":"test_trickycolumnnames_b"}},"data":"ccc","table":3},"emitted_at":1234,"namespace":"public"}}
+{"type":"RECORD","record":{"stream":"test_trickycolumnnames_b","data":{"_meta":{"op":"c","source":{"schema":"public","snapshot":true,"table":"test_trickycolumnnames_b"}},"data":"ddd","table":4},"emitted_at":1234,"namespace":"public"}}
+{"type":"STATE","state":{"data":{"cursor":"REDACTED","streams":{"public.test_trickycolumnnames_a":{"mode":"Backfill","key_columns":["Meta/\"wtf\"/ID"],"scanned":"FQI="},"public.test_trickycolumnnames_b":{"mode":"Backfill","key_columns":["table"],"scanned":"FQQ="}}},"estuary.dev/merge":true}}
+{"type":"STATE","state":{"data":{"cursor":"REDACTED"},"estuary.dev/merge":true}}
+{"type":"STATE","state":{"data":{"cursor":"REDACTED","streams":{"public.test_trickycolumnnames_a":{"mode":"Active","key_columns":["Meta/\"wtf\"/ID"],"scanned":null},"public.test_trickycolumnnames_b":{"mode":"Active","key_columns":["table"],"scanned":null}}},"estuary.dev/merge":true}}
+{"type":"STATE","state":{"data":{"cursor":"REDACTED"},"estuary.dev/merge":true}}

--- a/source-postgres/testdata/TestTrickyColumnNames_discovery_a.snapshot
+++ b/source-postgres/testdata/TestTrickyColumnNames_discovery_a.snapshot
@@ -1,0 +1,114 @@
+{
+  "name": "test_trickycolumnnames_a",
+  "json_schema": {
+    "$defs": {
+      "PublicTest_trickycolumnnames_a": {
+        "type": "object",
+        "required": [
+          "Meta/\"wtf\"/ID"
+        ],
+        "$anchor": "PublicTest_trickycolumnnames_a",
+        "properties": {
+          "Meta/\"wtf\"/ID": {
+            "type": "integer"
+          },
+          "data": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        }
+      }
+    },
+    "allOf": [
+      {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "type": "object",
+            "required": [
+              "op",
+              "source"
+            ],
+            "properties": {
+              "before": {
+                "$ref": "#PublicTest_trickycolumnnames_a",
+                "description": "Record state immediately before this change was applied.",
+                "reduce": {
+                  "strategy": "firstWriteWins"
+                }
+              },
+              "op": {
+                "enum": [
+                  "c",
+                  "d",
+                  "u"
+                ],
+                "description": "Change operation type: 'c' Create/Insert, 'u' Update, 'd' Delete."
+              },
+              "source": {
+                "$id": "https://github.com/estuary/connectors/source-postgres/postgres-source",
+                "properties": {
+                  "ts_ms": {
+                    "type": "integer",
+                    "description": "Unix timestamp (in millis) at which this event was recorded by the database."
+                  },
+                  "schema": {
+                    "type": "string",
+                    "description": "Database schema (namespace) of the event."
+                  },
+                  "snapshot": {
+                    "type": "boolean",
+                    "description": "Snapshot is true if the record was produced from an initial table backfill and unset if produced from the replication log."
+                  },
+                  "table": {
+                    "type": "string",
+                    "description": "Database table of the event."
+                  },
+                  "loc": {
+                    "items": {
+                      "type": "integer"
+                    },
+                    "type": "array",
+                    "maxItems": 3,
+                    "minItems": 3,
+                    "description": "Location of this WAL event as [last Commit.EndLSN; event LSN; current Begin.FinalLSN]. See https://www.postgresql.org/docs/current/protocol-logicalrep-message-formats.html"
+                  }
+                },
+                "additionalProperties": false,
+                "type": "object",
+                "required": [
+                  "schema",
+                  "table"
+                ]
+              }
+            },
+            "reduce": {
+              "strategy": "merge"
+            }
+          }
+        },
+        "reduce": {
+          "strategy": "merge"
+        }
+      },
+      {
+        "$ref": "#PublicTest_trickycolumnnames_a"
+      }
+    ]
+  },
+  "supported_sync_modes": [
+    "incremental",
+    "full_refresh"
+  ],
+  "source_defined_cursor": true,
+  "source_defined_primary_key": [
+    [
+      "Meta/\"wtf\"/ID"
+    ]
+  ],
+  "namespace": "public"
+}

--- a/source-postgres/testdata/TestTrickyColumnNames_discovery_b.snapshot
+++ b/source-postgres/testdata/TestTrickyColumnNames_discovery_b.snapshot
@@ -1,0 +1,114 @@
+{
+  "name": "test_trickycolumnnames_b",
+  "json_schema": {
+    "$defs": {
+      "PublicTest_trickycolumnnames_b": {
+        "type": "object",
+        "required": [
+          "table"
+        ],
+        "$anchor": "PublicTest_trickycolumnnames_b",
+        "properties": {
+          "data": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "table": {
+            "type": "integer"
+          }
+        }
+      }
+    },
+    "allOf": [
+      {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "type": "object",
+            "required": [
+              "op",
+              "source"
+            ],
+            "properties": {
+              "before": {
+                "$ref": "#PublicTest_trickycolumnnames_b",
+                "description": "Record state immediately before this change was applied.",
+                "reduce": {
+                  "strategy": "firstWriteWins"
+                }
+              },
+              "op": {
+                "enum": [
+                  "c",
+                  "d",
+                  "u"
+                ],
+                "description": "Change operation type: 'c' Create/Insert, 'u' Update, 'd' Delete."
+              },
+              "source": {
+                "$id": "https://github.com/estuary/connectors/source-postgres/postgres-source",
+                "properties": {
+                  "ts_ms": {
+                    "type": "integer",
+                    "description": "Unix timestamp (in millis) at which this event was recorded by the database."
+                  },
+                  "schema": {
+                    "type": "string",
+                    "description": "Database schema (namespace) of the event."
+                  },
+                  "snapshot": {
+                    "type": "boolean",
+                    "description": "Snapshot is true if the record was produced from an initial table backfill and unset if produced from the replication log."
+                  },
+                  "table": {
+                    "type": "string",
+                    "description": "Database table of the event."
+                  },
+                  "loc": {
+                    "items": {
+                      "type": "integer"
+                    },
+                    "type": "array",
+                    "maxItems": 3,
+                    "minItems": 3,
+                    "description": "Location of this WAL event as [last Commit.EndLSN; event LSN; current Begin.FinalLSN]. See https://www.postgresql.org/docs/current/protocol-logicalrep-message-formats.html"
+                  }
+                },
+                "additionalProperties": false,
+                "type": "object",
+                "required": [
+                  "schema",
+                  "table"
+                ]
+              }
+            },
+            "reduce": {
+              "strategy": "merge"
+            }
+          }
+        },
+        "reduce": {
+          "strategy": "merge"
+        }
+      },
+      {
+        "$ref": "#PublicTest_trickycolumnnames_b"
+      }
+    ]
+  },
+  "supported_sync_modes": [
+    "incremental",
+    "full_refresh"
+  ],
+  "source_defined_cursor": true,
+  "source_defined_primary_key": [
+    [
+      "table"
+    ]
+  ],
+  "namespace": "public"
+}

--- a/source-postgres/testdata/TestTrickyColumnNames_replication.snapshot
+++ b/source-postgres/testdata/TestTrickyColumnNames_replication.snapshot
@@ -1,0 +1,7 @@
+{"type":"STATE","state":{"data":{"cursor":"REDACTED"},"estuary.dev/merge":true}}
+{"type":"RECORD","record":{"stream":"test_trickycolumnnames_a","data":{"Meta/\"wtf\"/ID":5,"_meta":{"op":"c","source":{"schema":"public","table":"test_trickycolumnnames_a"}},"data":"eee"},"emitted_at":1234,"namespace":"public"}}
+{"type":"RECORD","record":{"stream":"test_trickycolumnnames_a","data":{"Meta/\"wtf\"/ID":6,"_meta":{"op":"c","source":{"schema":"public","table":"test_trickycolumnnames_a"}},"data":"fff"},"emitted_at":1234,"namespace":"public"}}
+{"type":"STATE","state":{"data":{"cursor":"REDACTED"},"estuary.dev/merge":true}}
+{"type":"RECORD","record":{"stream":"test_trickycolumnnames_b","data":{"_meta":{"op":"c","source":{"schema":"public","table":"test_trickycolumnnames_b"}},"data":"ggg","table":7},"emitted_at":1234,"namespace":"public"}}
+{"type":"RECORD","record":{"stream":"test_trickycolumnnames_b","data":{"_meta":{"op":"c","source":{"schema":"public","table":"test_trickycolumnnames_b"}},"data":"hhh","table":8},"emitted_at":1234,"namespace":"public"}}
+{"type":"STATE","state":{"data":{"cursor":"REDACTED"},"estuary.dev/merge":true}}


### PR DESCRIPTION
**Description:**

This change adds a test of several difficult column names which require quoting in PostgreSQL:

  * A primary key column named `table`, which is a reserved word and thus an error if not quoted.
  * A primary key column named `Meta/"wtf"/ID`, which contains two different special characters (and double quotes in particular, which require special handling) as well as capital letters.

The tricky column names are made primary keys, because we need to be able to give them *back* to Postgres when performing backfill queries, but the test also exercises discovery, and captures via backfill and replication, just to make sure the names are handled correctly throughout the capture.

This should fix https://github.com/estuary/connectors/issues/314

**Workflow steps:**

Column names containing special characters and reserved words should already have worked outside of the primary key, but now captures with such a column name in the primary key should work correctly too. And there's a test to make sure it keeps working.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/324)
<!-- Reviewable:end -->
