### PR TITLE
boilerplate: Check for bufio.ErrBufferFull correctly

### DIFF
--- a/materialize-boilerplate/boilerplate.go
+++ b/materialize-boilerplate/boilerplate.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"context"
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -87,7 +88,7 @@ func (c *cmdCommon) readMsg(m protoValidator) error {
 		if _, err = c.r.Discard(len); err != nil {
 			panic(err)
 		}
-	} else if err != io.ErrShortBuffer {
+	} else if !errors.Is(err, bufio.ErrBufferFull) {
 		return fmt.Errorf("reading message (into buffer): %w", err)
 	} else {
 		// Non-garden path: we must allocate and read a larger buffer.

--- a/materialize-boilerplate/boilerplate.go
+++ b/materialize-boilerplate/boilerplate.go
@@ -72,30 +72,9 @@ func (c *cmdCommon) readMsg(m protoValidator) error {
 
 	var len = int(binary.LittleEndian.Uint32(lengthBytes[:]))
 
-	// Fetch next length-delimited message into a buffer.
-	// In the garden-path case, we decode directly from the
-	// bufio.Reader internal buffer without copying
-	// (having just read the length, the message itself
-	// is probably _already_ in the bufio.Reader buffer).
-	//
-	// If the message is larger than the internal buffer,
-	// we allocate and read it directly.
-	var b, err = c.r.Peek(len)
-
-	if err == nil {
-		// The Discard contract guarantees we won't error.
-		// It's safe to reference |b| until the next Peek.
-		if _, err = c.r.Discard(len); err != nil {
-			panic(err)
-		}
-	} else if !errors.Is(err, bufio.ErrBufferFull) {
-		return fmt.Errorf("reading message (into buffer): %w", err)
-	} else {
-		// Non-garden path: we must allocate and read a larger buffer.
-		b = make([]byte, len)
-		if _, err = io.ReadFull(c.r, b); err != nil {
-			return fmt.Errorf("reading message (directly): %w", err)
-		}
+	var b, err = peekMessage(c.r, len)
+	if err != nil {
+		return err
 	}
 
 	if err := proto.Unmarshal(b, m); err != nil {
@@ -105,6 +84,37 @@ func (c *cmdCommon) readMsg(m protoValidator) error {
 	}
 
 	return nil
+}
+
+func peekMessage(br *bufio.Reader, size int) ([]byte, error) {
+	// Fetch next length-delimited message into a buffer.
+	// In the garden-path case, we decode directly from the
+	// bufio.Reader internal buffer without copying
+	// (having just read the length, the message itself
+	// is probably _already_ in the bufio.Reader buffer).
+	//
+	// If the message is larger than the internal buffer,
+	// we allocate and read it directly.
+	var bs, err = br.Peek(size)
+	if err == nil {
+		// The Discard contract guarantees we won't error.
+		// It's safe to reference |bs| until the next Peek.
+		if _, err = br.Discard(size); err != nil {
+			panic(err)
+		}
+		return bs, nil
+	}
+
+	// Non-garden path: we must allocate and read a larger buffer.
+	if errors.Is(err, bufio.ErrBufferFull) {
+		bs = make([]byte, size)
+		if _, err = io.ReadFull(br, bs); err != nil {
+			return nil, fmt.Errorf("reading message (directly): %w", err)
+		}
+		return bs, nil
+	}
+
+	return nil, fmt.Errorf("reading message (into buffer): %w", err)
 }
 
 type specCmd struct{ cmdCommon }

--- a/materialize-boilerplate/boilerplate_test.go
+++ b/materialize-boilerplate/boilerplate_test.go
@@ -1,0 +1,36 @@
+package boilerplate
+
+import (
+	"bufio"
+	"bytes"
+	"testing"
+)
+
+func TestPeekMessage(t *testing.T) {
+	// Construct a buffered reader with 256kB buffer and a bunch of bytes available to read.
+	const shortMessageSize = 1024
+	const bufferSize = 256 * 1024
+	const longMessageSize = 1024 * 1024
+	const totalDataSize = 8 * longMessageSize
+	var data = make([]byte, totalDataSize)
+	var br = bufio.NewReaderSize(bytes.NewReader(data), bufferSize)
+
+	// Make sure a mix of short and long reads works
+	for i := 0; i < 4; i++ {
+		var bs, err = peekMessage(br, shortMessageSize)
+		if err != nil {
+			t.Fatalf("short message: %v", err)
+		}
+		if len(bs) != shortMessageSize {
+			t.Fatalf("short message: got %d bytes, expected %d", len(bs), shortMessageSize)
+		}
+
+		bs, err = peekMessage(br, longMessageSize)
+		if err != nil {
+			t.Fatalf("long message: %v", err)
+		}
+		if len(bs) != longMessageSize {
+			t.Fatalf("long message: got %d bytes, expected %d", len(bs), longMessageSize)
+		}
+	}
+}

--- a/source-boilerplate/boilerplate.go
+++ b/source-boilerplate/boilerplate.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"context"
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -90,7 +91,7 @@ func (c *cmdCommon) readMsg(m protoValidator) error {
 		if _, err = c.r.Discard(len); err != nil {
 			panic(err)
 		}
-	} else if err != io.ErrShortBuffer {
+	} else if !errors.Is(err, bufio.ErrBufferFull) {
 		return fmt.Errorf("reading message (into buffer): %w", err)
 	} else {
 		// Non-garden path: we must allocate and read a larger buffer.

--- a/source-boilerplate/boilerplate_test.go
+++ b/source-boilerplate/boilerplate_test.go
@@ -1,0 +1,36 @@
+package boilerplate
+
+import (
+	"bufio"
+	"bytes"
+	"testing"
+)
+
+func TestPeekMessage(t *testing.T) {
+	// Construct a buffered reader with 256kB buffer and a bunch of bytes available to read.
+	const shortMessageSize = 1024
+	const bufferSize = 256 * 1024
+	const longMessageSize = 1024 * 1024
+	const totalDataSize = 8 * longMessageSize
+	var data = make([]byte, totalDataSize)
+	var br = bufio.NewReaderSize(bytes.NewReader(data), bufferSize)
+
+	// Make sure a mix of short and long reads works
+	for i := 0; i < 4; i++ {
+		var bs, err = peekMessage(br, shortMessageSize)
+		if err != nil {
+			t.Fatalf("short message: %v", err)
+		}
+		if len(bs) != shortMessageSize {
+			t.Fatalf("short message: got %d bytes, expected %d", len(bs), shortMessageSize)
+		}
+
+		bs, err = peekMessage(br, longMessageSize)
+		if err != nil {
+			t.Fatalf("long message: %v", err)
+		}
+		if len(bs) != longMessageSize {
+			t.Fatalf("long message: got %d bytes, expected %d", len(bs), longMessageSize)
+		}
+	}
+}


### PR DESCRIPTION
**Description:**

Previously the check was for `io.ErrShortBuffer`, which is not actually the error we get when the incoming message is too large for the buffered reader.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/325)
<!-- Reviewable:end -->
