### PR TITLE
source-firestore: Tweak discovery limit constants

### DIFF
--- a/source-firestore/discovery.go
+++ b/source-firestore/discovery.go
@@ -24,11 +24,11 @@ const (
 	// that an invocation of discoverResource will process. If more collections are
 	// discovered which map to a particular resource, the excess will first pile up
 	// in the buffered channel and then after that they will be silently discarded.
-	discoverMaxCollectionsPerResource = 10
+	discoverMaxCollectionsPerResource = 50
 
 	// discoverMaxDocumentsPerCollection bounds the number of documents which will
 	// be fetched by discoverResource from any one collection.
-	discoverMaxDocumentsPerCollection = 50
+	discoverMaxDocumentsPerCollection = 100
 
 	// discoverMaxConcurrentWorkers bounds the number of concurrent `discoverResource()`
 	// workers which can proceed at any given time.
@@ -259,6 +259,7 @@ func (ds *discoveryState) discoverResource(ctx context.Context, resourcePath str
 		}).Debug("scanning collection")
 
 		var docs = collection.Query.Limit(discoverMaxDocumentsPerCollection).Documents(ctx)
+		defer docs.Stop()
 		for {
 			if err := ctx.Err(); err != nil {
 				return err
@@ -293,6 +294,7 @@ func (ds *discoveryState) discoverResource(ctx context.Context, resourcePath str
 				subResources[resourcePath] = struct{}{}
 			}
 		}
+		docs.Stop()
 	}
 
 	log.WithFields(log.Fields{


### PR DESCRIPTION
**Description:**

With this change discovery on a realistic dataset takes about 8x longer (going from 15s to 2m), but is also much more likely to encounter rare nested sub-collections.

This commit also adds calls to `docs.Stop()` to tell the Firestore client when we're done with a particular DocumentIterator.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/328)
<!-- Reviewable:end -->
