### PR TITLE
source-firestore: The discovered key should be /__path__

### DIFF
--- a/source-firestore/discovery.go
+++ b/source-firestore/discovery.go
@@ -227,7 +227,7 @@ func (ds *discoveryState) discoverResource(ctx context.Context, resourcePath str
 			RecommendedName:    pf.Collection(collectionRecommendedName(resourcePath)),
 			ResourceSpecJson:   resourceJSON,
 			DocumentSchemaJson: schema,
-			KeyPtrs:            []string{"/" + firestore.DocumentID},
+			KeyPtrs:            []string{"/" + pathField},
 		}
 		ds.resources.Lock()
 		ds.resources.bindings = append(ds.resources.bindings, binding)


### PR DESCRIPTION
**Description:**

Previously this was `/__name__`, which is basically just the final path element and thus is frequently something like `27` which is not unique, and this caused the obvious sorts of issues now that the whole nested collections thing is live.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/329)
<!-- Reviewable:end -->
