### PR TITLE
materialize-google-sheets: Fix row/column limitations

### DIFF
--- a/materialize-google-sheets/main.go
+++ b/materialize-google-sheets/main.go
@@ -307,6 +307,10 @@ func (driver) Transactions(stream pm.Driver_TransactionsServer) error {
 		return fmt.Errorf("recovering sheet states: %w", err)
 	}
 
+	if err := writeSheetSentinels(stream.Context(), svc, cfg.spreadsheetID(), states); err != nil {
+		return fmt.Errorf("writing sheet sentinels: %w", err)
+	}
+
 	bindings, err := buildTransactorBindings(
 		open.Open.Materialization.Bindings,
 		checkpoint.Round,

--- a/materialize-google-sheets/main.go
+++ b/materialize-google-sheets/main.go
@@ -238,6 +238,21 @@ func (driver) apply(ctx context.Context, req *pm.ApplyRequest, isDelete bool) (*
 						Rows:    []*sheets.RowData{{Values: headers}},
 					},
 				},
+				// Hide the first column, which contains Flow internal data
+				&sheets.Request{
+					UpdateDimensionProperties: &sheets.UpdateDimensionPropertiesRequest{
+						Range: &sheets.DimensionRange{
+							SheetId:    sheetID,
+							Dimension:  "COLUMNS",
+							StartIndex: 0,
+							EndIndex:   1,
+						},
+						Properties: &sheets.DimensionProperties{
+							HiddenByUser: true,
+						},
+						Fields: "hiddenByUser",
+					},
+				},
 			)
 		} else if exists && isDelete {
 			description += fmt.Sprintf("Deleted sheet %q.\n", res.Sheet)

--- a/materialize-google-sheets/main.go
+++ b/materialize-google-sheets/main.go
@@ -224,6 +224,10 @@ func (driver) apply(ctx context.Context, req *pm.ApplyRequest, isDelete bool) (*
 						Properties: &sheets.SheetProperties{
 							Title:   res.Sheet,
 							SheetId: sheetID,
+							GridProperties: &sheets.GridProperties{
+								ColumnCount:    int64(len(headers)),
+								FrozenRowCount: 1,
+							},
 						},
 					},
 				},


### PR DESCRIPTION
**Description:**

This PR tweaks the startup behavior of the Google Sheets materialization in ways that I think make it more user-friendly, and in the process fixes the issues that led to materializations crashing when run with >26 fields or when they reached >1000 rows.

The row count limit was a weird one, because our use of `InsertRange` requests in the transactor _should have_ resulted in every new output row adding itself to the sheet. But in practice there's some trickery going on, and somehow it's still possible to hit row count limits when appending a new row to the very end of a full sheet. To fix this, we now maintain a "sentinel" row after all our data rows, identified by the value `{}` in the `flow_document` column.

The column limit was much simpler: by default a sheet has 26 columns, and so trying to write more values than this is an error and we needed to resize the sheet to match the number of columns we wanted to write.

Finally I've added a couple of minor UX improvements while I was touching related portions of the code. After these changes, the header row is now "Frozen" so it acts more header-y, and the first column (`flow_document`) is collapsed by default so it doesn't frighten off any users.

**Workflow steps:**

Materializations with more than 25 fields should now work, as should materializations of >1000 rows.

Also users may see column header names automagically getting filled in, since previously they were only written out when a nonexistent sheet was created by the connector.

**Notes for reviewers:**

Now that I've finished writing everything I'm second-guessing the choice to move horizontal-resizing and header-row-writing from the Apply handler to Transactions startup time. I think I still prefer it this way personally, it seems a bit cleaner to have Apply just create a very default-looking sheet where necessary and then do the same initialization at every startup regardless of whether it's a new sheet or a preexisting one, but I'd be happy to move it back if you think that would be better.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/330)
<!-- Reviewable:end -->
