### PR TITLE
materialize-google-sheets: Use InsertDimension to add rows

### DIFF
--- a/materialize-google-sheets/transactor.go
+++ b/materialize-google-sheets/transactor.go
@@ -164,18 +164,18 @@ func (d *transactor) Store(it *pm.StoreIterator) error {
 				s.PrevDoc = prev[pi].Doc
 				s.PrevRound = prev[pi].Round
 				pi++
-			} else if l := len(addRows); l != 0 && addRows[l-1].InsertRange.Range.EndRowIndex == rowInd {
+			} else if l := len(addRows); l != 0 && addRows[l-1].InsertDimension.Range.EndIndex == rowInd {
 				// We're inserting a new row, and we can extend a current run of added rows.
-				addRows[l-1].InsertRange.Range.EndRowIndex++
+				addRows[l-1].InsertDimension.Range.EndIndex++
 			} else {
 				// We must start a new run of added rows.
 				addRows = append(addRows, &sheets.Request{
-					InsertRange: &sheets.InsertRangeRequest{
-						ShiftDimension: "ROWS",
-						Range: &sheets.GridRange{
-							SheetId:       d.bindings[bindInd].UserSheetId,
-							StartRowIndex: rowInd,
-							EndRowIndex:   rowInd + 1,
+					InsertDimension: &sheets.InsertDimensionRequest{
+						Range: &sheets.DimensionRange{
+							SheetId:    d.bindings[bindInd].UserSheetId,
+							Dimension:  "ROWS",
+							StartIndex: rowInd,
+							EndIndex:   rowInd + 1,
 						},
 					},
 				})


### PR DESCRIPTION
**Description:**

Previously we used `InsertRangeRequest` with a `GridRange` that didn't specify columns (and thus applied to all columns), but
apparently that seemingly-inconsequential difference was the cause of all our insert-row-limit woes.

I think what's going on is `InsertRange` is intended to shift cell contents horizontally or vertically to make room for a rectangle of new data. This is why we generally observed the sheet filling up, and it would only start growing after reaching the end. But even after adding a sentinel row at the bottom this didn't work right when bulk inserting a ton of data all at once.

So instead we'll use `InsertDimension`, which I think is basically the API counterpart to the "Insert a Row Here" action you get when you right-click in Google Sheets, and works much more reliably.

I have verified that after this change I can insert at least 1.7k rows in a single batch operation, when the sheet only had exactly 1k blank rows before the bulk insert, and afterwards it will still have exactly 1k blank rows after the inserted data.

**Workflow steps:**

Maybe users will finally stop getting `Attempting to write row: 1001, beyond the last requested row of: 1000` errors.

