### PR TITLE
materialize-snowflake: add host to config & remove region

### DIFF
--- a/materialize-snowflake/.snapshots/TestSpecification
+++ b/materialize-snowflake/.snapshots/TestSpecification
@@ -8,6 +8,11 @@
         "title": "Account",
         "description": "The Snowflake account identifier."
       },
+      "host": {
+        "type": "string",
+        "title": "Host URL",
+        "description": "The Snowflake Host used for the connection. Example: orgname-accountname.snowflakecomputing.com (do not include the protocol)."
+      },
       "user": {
         "type": "string",
         "title": "User",
@@ -32,38 +37,22 @@
       "warehouse": {
         "type": "string",
         "title": "Warehouse",
-        "description": "The Snowflake virutal warehouse used to execute queries."
+        "description": "The Snowflake virtual warehouse used to execute queries."
       },
       "role": {
         "type": "string",
         "title": "Role",
         "description": "The user role used to perform actions."
-      },
-      "cloud_provider": {
-        "type": "string",
-        "enum": [
-          "aws",
-          "azure",
-          "gcp"
-        ],
-        "title": "Cloud Provider",
-        "description": "The cloud provider where the Snowflake endpoint is hosted."
-      },
-      "region": {
-        "type": "string",
-        "title": "Region",
-        "description": "The cloud region containing the Snowflake endpoint."
       }
     },
     "type": "object",
     "required": [
       "account",
+      "host",
       "user",
       "password",
       "database",
-      "schema",
-      "cloud_provider",
-      "region"
+      "schema"
     ],
     "title": "SQL Connection"
   },

--- a/materialize-snowflake/snowflake.go
+++ b/materialize-snowflake/snowflake.go
@@ -22,39 +22,37 @@ import (
 // config represents the endpoint configuration for snowflake.
 // It must match the one defined for the source specs (flow.yaml) in Rust.
 type config struct {
-	Account       string `json:"account" jsonschema:"title=Account,description=The Snowflake account identifier."`
-	User          string `json:"user" jsonschema:"title=User,description=The Snowflake user login name."`
-	Password      string `json:"password" jsonschema:"title=Password,description=The password for the provided user." jsonschema_extras:"secret=true"`
-	Database      string `json:"database" jsonschema:"title=Database,description=The SQL database to connect to."`
-	Schema        string `json:"schema" jsonschema:"title=Schema,description=The SQL schema to use."`
-	Warehouse     string `json:"warehouse,omitempty" jsonschema:"title=Warehouse,description=The Snowflake virutal warehouse used to execute queries."`
-	Role          string `json:"role,omitempty" jsonschema:"title=Role,description=The user role used to perform actions."`
-	CloudProvider string `json:"cloud_provider" jsonschema:"enum=aws,enum=azure,enum=gcp,title=Cloud Provider,description=The cloud provider where the Snowflake endpoint is hosted."`
-	Region        string `json:"region" jsonschema:"title=Region,description=The cloud region containing the Snowflake endpoint."`
+	Account   string `json:"account" jsonschema:"title=Account,description=The Snowflake account identifier."`
+	Host      string `json:"host" jsonschema:"title=Host URL,description=The Snowflake Host used for the connection. Example: orgname-accountname.snowflakecomputing.com (do not include the protocol)."`
+	User      string `json:"user" jsonschema:"title=User,description=The Snowflake user login name."`
+	Password  string `json:"password" jsonschema:"title=Password,description=The password for the provided user." jsonschema_extras:"secret=true"`
+	Database  string `json:"database" jsonschema:"title=Database,description=The SQL database to connect to."`
+	Schema    string `json:"schema" jsonschema:"title=Schema,description=The SQL schema to use."`
+	Warehouse string `json:"warehouse,omitempty" jsonschema:"title=Warehouse,description=The Snowflake virtual warehouse used to execute queries."`
+	Role      string `json:"role,omitempty" jsonschema:"title=Role,description=The user role used to perform actions."`
 }
 
 func (c *config) asSnowflakeConfig() sf.Config {
 	return sf.Config{
 		Account:   c.Account,
+		Host:      c.Host,
 		User:      c.User,
 		Password:  c.Password,
 		Database:  c.Database,
 		Schema:    c.Schema,
 		Warehouse: c.Warehouse,
 		Role:      c.Role,
-		Region:    c.Region + "." + c.CloudProvider,
 	}
 }
 
 func (c *config) Validate() error {
 	var requiredProperties = [][]string{
 		{"account", c.Account},
+		{"host", c.Host},
 		{"user", c.User},
 		{"password", c.Password},
 		{"database", c.Database},
 		{"schema", c.Schema},
-		{"region", c.Region},
-		{"cloud_provider", c.CloudProvider},
 	}
 	for _, req := range requiredProperties {
 		if req[1] == "" {
@@ -120,11 +118,10 @@ func newSnowflakeDriver() *sqlDriver.Driver {
 			}
 
 			log.WithFields(log.Fields{
-				"account":   parsed.Account,
-				"database":  parsed.Database,
-				"role":      parsed.Role,
-				"user":      parsed.User,
-				"warehouse": parsed.Warehouse,
+				"host":     parsed.Host,
+				"user":     parsed.User,
+				"database": parsed.Database,
+				"schema":   parsed.Schema,
 			}).Info("opening Snowflake")
 
 			db, err := sql.Open("snowflake", dsn)


### PR DESCRIPTION
**Description:**

This fixes the issues seen in #334 when materializing into snowflake on AWS providers. The host for AWS providers is not consistently any combination of account/region/provider for AWS (see [list](https://docs.snowflake.com/en/user-guide/admin-account-identifier.html#non-vps-account-locator-formats-by-cloud-platform-and-region)), so we can't reliably build a URL just from those values.

Fortunately, the snowflake client allows explicitly specifying a "host" value, which bypasses all of the idiosyncrasies of building the host from account/region/provider. This also allows for connecting with the [preferred account identifier format](https://docs.snowflake.com/en/user-guide/admin-account-identifier.html#format-1-preferred-account-name-in-your-organization), which uses the account name and org name, and is easily obtainable from the snowflake UI.

**Workflow steps:**

I was able to materialize into my snowflake account on `us-west-2` using a materialization schema like the following:

```
  examples/<materialization name>:
    endpoint:
        connector:
            config:
              host: <orgname>-<accountname>.snowflakecomputing.com
              account: <accountname>
              user: <my user>
              password: <my user's password>
              database: <database>
              schema: <schema>
              warehouse: <warehouse>
            image: materialize-snowflake:local
    bindings:
      - resource:
          table: <table>
        source: examples/<source collection>
```

**Documentation links affected:**

https://github.com/estuary/flow/blob/master/site/docs/reference/Connectors/materialization-connectors/Snowflake.md will need updated according to this change to show the new/changed configuration values.

**Notes for reviewers:**

- Cloud provider is removed as a configuration since it is not needed or used at all.
- Region is also removed. Providing a region + host results in invalid URLs from the go-snowflake client. The region parameter is noted as being deprecated in the [snowflake client godocs](https://pkg.go.dev/github.com/snowflakedb/gosnowflake#hdr-Connection_Parameters).
- A value for account is still required, which I find interesting. But the client will throw an error if "account" is not provided, so we'll keep it as a required configuration value here.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/335)
<!-- Reviewable:end -->
