### PR TITLE
filesource: add test for switching between monotonic and non-monotonic sweeps

### DIFF
--- a/filesource/state_test.go
+++ b/filesource/state_test.go
@@ -287,7 +287,7 @@ func TestMonotonicChanges(t *testing.T) {
 		Complete: true,
 	}, s)
 
-	// Next sweep will finish NOT in monotonic mode.
+	// Next sweep will finish in non-monotonic mode.
 	s.startSweep(*ts(30))
 
 	// Doesn't re-process files, because the state records the "highest" seen path.
@@ -350,6 +350,13 @@ func TestMonotonicChanges(t *testing.T) {
 	skip, reason = s.shouldSkip("fff", *ts(33))
 	require.True(t, skip)
 	require.Equal(t, "state.Path == obj.Path && Complete", reason)
+
+	// Edge case: Lexicographically later file with earlier mod time still does not get re-processed
+	// since MinBound is retained, even though it is not incremented.
+	skip, reason = s.shouldSkip("ggg", *ts(1))
+	require.True(t, skip)
+	require.Equal(t, "!modTime.After(MinBound)", reason)
+
 }
 
 func ts(i int64) *time.Time {

--- a/filesource/state_test.go
+++ b/filesource/state_test.go
@@ -234,6 +234,107 @@ func TestSuccessfulSweeps(t *testing.T) {
 	}, s2)
 }
 
+// TestMonotonicChanges shows that sweeps initially run in monotonic mode and later run in
+// non-monotonic mode will not re-process previously processed files.
+func TestMonotonicChanges(t *testing.T) {
+	var s State
+
+	s.startSweep(*ts(10))
+	require.NoError(t, s.Validate())
+
+	// Process some lexicographic files. The path will be stored in the state if running as
+	// monotonic.
+	require.True(t, s.startPath("aaa", *ts(5)))
+	require.True(t, s.startPath("bbb", *ts(6)))
+	s.finishPath()
+	verify(t, State{
+		MaxBound: ts(10),
+		MaxMod:   ts(6),
+		Path:     "bbb",
+		Complete: true,
+	}, s)
+
+	// Running in monotonic mode to begin with
+	s.finishSweep(true)
+	verify(t, State{
+		MinBound: time.Time{}, // Min bound is never incremented.
+		MaxBound: nil,
+		MaxMod:   ts(6),
+		Path:     "bbb",
+		Complete: true,
+	}, s)
+
+	// Process a couple more files.
+	s.startSweep(*ts(20))
+	require.NoError(t, s.Validate())
+	require.True(t, s.startPath("ccc", *ts(12)))
+	require.True(t, s.startPath("ddd", *ts(13)))
+	s.finishPath()
+	verify(t, State{
+		MaxBound: ts(20),
+		MaxMod:   ts(13),
+		Path:     "ddd",
+		Complete: true,
+	}, s)
+
+	// Still in monotonic mode.
+	s.finishSweep(true)
+	verify(t, State{
+		MinBound: time.Time{}, // Min bound is never incremented.
+		MaxBound: nil,
+		MaxMod:   ts(13),
+		Path:     "ddd",
+		Complete: true,
+	}, s)
+
+	// Next sweep will finish NOT in monotonic mode.
+	s.startSweep(*ts(30))
+
+	// Doesn't re-process files, because the state records the "highest" seen path.
+	skip, reason := s.shouldSkip("bbb", *ts(5))
+	require.True(t, skip)
+	require.Equal(t, "state.Path > obj.Path", reason)
+	skip, reason = s.shouldSkip("ccc", *ts(13))
+	require.True(t, skip)
+	require.Equal(t, "state.Path > obj.Path", reason)
+
+	require.True(t, s.startPath("eee", *ts(23)))
+	s.finishPath()
+	verify(t, State{
+		MaxBound: ts(30),
+		MaxMod:   ts(23),
+		Path:     "eee",
+		Complete: true,
+	}, s)
+
+	// Finish this sweep in non-monotonic mode.
+	s.finishSweep(false)
+	verify(t, State{
+		MinBound: *ts(23), // Min bound is now updated
+		MaxBound: nil,
+		MaxMod:   nil,
+		Path:     "",
+		Complete: false,
+	}, s)
+
+	s.startSweep(*ts(40))
+
+	// Still does not re-process files, but now its based on the MinBound.
+	skip, reason = s.shouldSkip("aaa", *ts(5))
+	require.True(t, skip)
+	require.Equal(t, "!modTime.After(MinBound)", reason)
+	skip, reason = s.shouldSkip("ccc", *ts(12))
+	require.True(t, skip)
+	require.Equal(t, "!modTime.After(MinBound)", reason)
+	skip, reason = s.shouldSkip("eee", *ts(23))
+	require.True(t, skip)
+	require.Equal(t, "!modTime.After(MinBound)", reason)
+
+	// Will process newer files.
+	skip, _ = s.shouldSkip("fff", *ts(33))
+	require.False(t, skip)
+}
+
 func ts(i int64) *time.Time {
 	var out = time.Unix(i, 0)
 	return &out

--- a/filesource/state_test.go
+++ b/filesource/state_test.go
@@ -337,8 +337,15 @@ func TestMonotonicChanges(t *testing.T) {
 	require.True(t, s.startPath("fff", *ts(33)))
 	s.finishPath()
 
-	// Switch back to monotonic
+	// Switch back to monotonic.
 	s.finishSweep(true)
+	verify(t, State{
+		MinBound: *ts(23), // Min bound is still there, but not incremented.
+		MaxBound: nil,
+		MaxMod:   ts(33),
+		Path:     "fff",
+		Complete: true,
+	}, s)
 
 	// Continues to not re-process files.
 	skip, reason = s.shouldSkip("aaa", *ts(5))
@@ -356,7 +363,6 @@ func TestMonotonicChanges(t *testing.T) {
 	skip, reason = s.shouldSkip("ggg", *ts(1))
 	require.True(t, skip)
 	require.Equal(t, "!modTime.After(MinBound)", reason)
-
 }
 
 func ts(i int64) *time.Time {

--- a/filesource/state_test.go
+++ b/filesource/state_test.go
@@ -333,6 +333,23 @@ func TestMonotonicChanges(t *testing.T) {
 	// Will process newer files.
 	skip, _ = s.shouldSkip("fff", *ts(33))
 	require.False(t, skip)
+
+	require.True(t, s.startPath("fff", *ts(33)))
+	s.finishPath()
+
+	// Switch back to monotonic
+	s.finishSweep(true)
+
+	// Continues to not re-process files.
+	skip, reason = s.shouldSkip("aaa", *ts(5))
+	require.True(t, skip)
+	require.Equal(t, "state.Path > obj.Path", reason)
+	skip, reason = s.shouldSkip("ccc", *ts(12))
+	require.True(t, skip)
+	require.Equal(t, "state.Path > obj.Path", reason)
+	skip, reason = s.shouldSkip("fff", *ts(33))
+	require.True(t, skip)
+	require.Equal(t, "state.Path == obj.Path && Complete", reason)
 }
 
 func ts(i int64) *time.Time {


### PR DESCRIPTION
This unit test shows that files do not get re-processed by the filesource state machine when sweeps are alternatively completed in monotonic and non-monotonic modes. Although the `MinBound` is not updated when finishing a sweep in monotonic mode, the `Path` is tracked which results in lexicographically "older" files being skipped. In non-monotonic mode, the `MinBound` is updated when finishing a sweep which precludes files older than what has already been seen.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/337)
<!-- Reviewable:end -->
