### PR TITLE
materialize-google-pubsub: enable multiple bindings to multiplex on topics

### DIFF
--- a/materialize-google-pubsub/.snapshots/TestSpec
+++ b/materialize-google-pubsub/.snapshots/TestSpec
@@ -87,6 +87,11 @@
         "type": "string",
         "title": "Topic Name",
         "description": "Name of the topic to publish materialized results to."
+      },
+      "identifier": {
+        "type": "string",
+        "title": "Resource Binding Identifier",
+        "description": "Identifier for the resource binding. Each binding must have a unique topic \u0026 identifier pair. Included as \"identifier\" attribute in published messages as \"{topic}/{identifier}\". Defaults to \"default\"."
       }
     },
     "type": "object",

--- a/materialize-google-pubsub/.snapshots/TestSpec
+++ b/materialize-google-pubsub/.snapshots/TestSpec
@@ -91,7 +91,7 @@
       "identifier": {
         "type": "string",
         "title": "Resource Binding Identifier",
-        "description": "Identifier for the resource binding. Each binding must have a unique topic \u0026 identifier pair. Included as \"identifier\" attribute in published messages as \"{topic}/{identifier}\". Defaults to \"default\"."
+        "description": "Optional identifier for the resource binding. Each binding must have a unique topic \u0026 identifier pair. Included as \"identifier\" attribute in published messages if specified."
       }
     },
     "type": "object",


### PR DESCRIPTION
Related to https://github.com/estuary/flow/issues/673, specific to the PubSub materialization

**Description:**

Adds an additional optional field `identifier` to the resource config. This allows for configurations that can materialize multiple collections into the same topic. The `ResourcePath` for each binding must be unique, and providing unique `identifier`s per resource allows for `ResourcePath`s like `mytopic.identifier1`, `mytopic.identifier2` etc.

**Workflow steps:**

Configurations like this will now be possible, where two collections are materialized into the same PubSub topic:

```yaml
materializations:
  bobCo/multi-pubsub:
    endpoint:
      connector:
        image: "materialize-google-pubsub:local"
        config: ../flow/pubsub.config.yaml
    bindings:
      - resource:
          identifier: one
          topic: multiplex-topic
        source: bobCo/greetings1
      - resource:
          identifier: two
          topic: multiplex-topic
        source: bobCo/greetings2
```

The identifier is optional, so binding configurations like this are also possible:

```yaml
    bindings:
      - resource:
          identifier: one
          topic: multiplex-topic
        source: bobCo/greetings1
      - resource:
          identifier: two
          topic: multiplex-topic
        source: bobCo/greetings2
      - resource:
          topic: single-topic
        source: bobCo/greetings1
```

A configuration like this results in a validation error, since the bindings do not all have a unique combination of identifier + topic:
```yaml
    bindings:
      - resource:
          identifier: one
          topic: multiplex-topic
        source: bobCo/greetings1
      - resource:
          identifier: one # Error - identifier + topic are not unique
          topic: multiplex-topic
        source: bobCo/greetings2
      - resource:
          topic: single-topic
        source: bobCo/greetings1
      - resource:
          topic: single-topic # Also error
        source: bobCo/greetings1
```


The identifier is added to the published message as an "attribute", with the key of `identifier`. This will allow consumers to differentiate messages based on this attribute, and could also enable PubSub specific features like [filtering](https://cloud.google.com/pubsub/docs/filtering).

**Documentation links affected:**

The [PubSub connector docs](https://docs.estuary.dev/reference/Connectors/materialization-connectors/google-pubsub/) will need to have this additional field added to them.

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/340)
<!-- Reviewable:end -->
