### PR TITLE
source-s3: get object with context

### DIFF
--- a/source-s3/main.go
+++ b/source-s3/main.go
@@ -112,7 +112,7 @@ func (s *s3Store) List(_ context.Context, query filesource.Query) (filesource.Li
 	}, nil
 }
 
-func (s *s3Store) Read(_ context.Context, obj filesource.ObjectInfo) (io.ReadCloser, filesource.ObjectInfo, error) {
+func (s *s3Store) Read(ctx context.Context, obj filesource.ObjectInfo) (io.ReadCloser, filesource.ObjectInfo, error) {
 	var bucket, key = filesource.PathToParts(obj.Path)
 
 	var getInput = s3.GetObjectInput{
@@ -120,7 +120,7 @@ func (s *s3Store) Read(_ context.Context, obj filesource.ObjectInfo) (io.ReadClo
 		Key:               aws.String(key),
 		IfUnmodifiedSince: &obj.ModTime,
 	}
-	resp, err := s.s3.GetObject(&getInput)
+	resp, err := s.s3.GetObjectWithContext(ctx, &getInput)
 	if err != nil {
 		return nil, filesource.ObjectInfo{}, err
 	}


### PR DESCRIPTION
**Description:**

Uses the passed-in context for `source-s3` `(*s3Store).Read`. This way the retrieving of objects can respect context timeouts.

Most notably, there is a timeout specified for [schema discovery](https://github.com/estuary/connectors/blob/353d119f03a004c6777fae7df67ffdd5b8f33c22/filesource/discovery.go#L111-L119), and without this timeout, it is possible that a single extremely large file will take an excessive amount of time to process.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

Along these same lines, the `List` method doesn't use the provided context. Updating `List` to use a context would be a bit more complicated. I created a separate issue for that work, which isn't causing any immediate problems but might be good to take care of at some point: https://github.com/estuary/connectors/issues/345

Also, while investigating discovery from relatively large files, I found our parsing & _possibly_ inference processes surprisingly slow. If the parsing and inference were much faster, this particular context deadline would be less important, although still useful to have. I have some details to still work out for this, and have created a placeholder for an issue related to this potential optimization: https://github.com/estuary/flow/issues/681

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/344)
<!-- Reviewable:end -->
