### PR TITLE
schema-inference: fix race condition

### DIFF
--- a/schema_inference/inference.go
+++ b/schema_inference/inference.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 	"os/exec"
-	"time"
 
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/sync/errgroup"
@@ -58,11 +57,6 @@ func Run(ctx context.Context, logEntry *log.Entry, docsCh <-chan Document) (Sche
 
 	errGroup.Go(func() error {
 		decoder := json.NewDecoder(stdout)
-
-		// Simulate a delay to reliably reproduce the race condition - the async call to cmd.Wait
-		// below will have already closed stdout by the time the rest of this runs, resulting in an
-		// error trying to decode.
-		time.Sleep(5 * time.Second)
 
 		if err := decoder.Decode(&schema); err != nil {
 			return fmt.Errorf("failed to decode schema, %w", err)

--- a/schema_inference/inference.go
+++ b/schema_inference/inference.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"os/exec"
+	"time"
 
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/sync/errgroup"
@@ -58,6 +59,11 @@ func Run(ctx context.Context, logEntry *log.Entry, docsCh <-chan Document) (Sche
 	errGroup.Go(func() error {
 		defer stdout.Close()
 		decoder := json.NewDecoder(stdout)
+
+		// Simulate a delay to reliably reproduce the race condition - the async call to cmd.Wait
+		// below will have already closed stdout by the time the rest of this runs, resulting in an
+		// error trying to decode.
+		time.Sleep(5 * time.Second)
 
 		if err := decoder.Decode(&schema); err != nil {
 			return fmt.Errorf("failed to decode schema, %w", err)


### PR DESCRIPTION
Closes https://github.com/estuary/connectors/issues/341

**Description:**

This fixes a race condition in handling the stdin/out pipes from running schema inference. It has been consistently causing the `source-kinesis` test to fail in an intermittent way. See [recent example](https://github.com/estuary/connectors/actions/runs/3094509636/jobs/5008268197).

Why is only the kinesis test failing? Apparently only `source-firestore` and `source-kinesis` use this code path, and `source-firestore` doesn't have an integration test that verifies bindings like the `source-kinesis` test. Although this change is primarily motivated by the desire to stop the test from flaking, I would imagine this could cause intermittent issues with discovery for both of these connectors in production.

The relevant line from the logs of failing tests is `"failed to decode schema, read |0: file already closed\"`. This arises from the inference code trying to read from a `stdout` that has already been closed by the concurrent call to `cmd.Wait`.

**Workflow steps:**

Run discovery with either `source-kinesis` or `source-firestore`.

**Documentation links affected:**

N/A

**Notes for reviewers:**

The PR commit history illustrates forcing the failure to occur and then the fix:
- https://github.com/estuary/connectors/pull/349/commits/052bd84b4909b2c4da4621810db3ab071de98c6b adds a simulated delay to the existing code to make the failure inevitable
- https://github.com/estuary/connectors/pull/349/commits/5f2a6bf290f696cbc8bb89186a5721b0190d5835 fixes the race condition. The tests pass even with the artificial delay in place.
- https://github.com/estuary/connectors/pull/349/commits/3463fbed2e1e1dcb149212b591244be682fb6fc5 removes the artificial delay with the fix remaining in place.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/349)
<!-- Reviewable:end -->
