### PR TITLE
source-s3: use context for file listing

### DIFF
--- a/source-s3/main.go
+++ b/source-s3/main.go
@@ -172,13 +172,13 @@ func (l *s3Listing) Next() (filesource.ObjectInfo, error) {
 			}, nil
 		}
 
-		if err := l.poll(l.ctx); err != nil {
+		if err := l.poll(); err != nil {
 			return filesource.ObjectInfo{}, err
 		}
 	}
 }
 
-func (l *s3Listing) poll(ctx context.Context) error {
+func (l *s3Listing) poll() error {
 	var input = l.input
 
 	if l.output.Prefix == nil {
@@ -190,7 +190,7 @@ func (l *s3Listing) poll(ctx context.Context) error {
 		input.ContinuationToken = l.output.NextContinuationToken
 	}
 
-	if out, err := l.s3.ListObjectsV2WithContext(ctx, &input); err != nil {
+	if out, err := l.s3.ListObjectsV2WithContext(l.ctx, &input); err != nil {
 		return err
 	} else {
 		l.output = *out


### PR DESCRIPTION
Closes https://github.com/estuary/connectors/issues/345

**Description:**

Threads the context through to the `source-s3` connector `List` operation. https://github.com/estuary/connectors/pull/344 accomplished the same thing for `Read`. This will allow for better handling of context cancellations or timeouts.

**Workflow steps:**

Should be minimal observable impact. This will eliminate the potential for very large and/or slow file listings to lock up schema discovery indefinitely.

**Documentation links affected:**

N/A

**Notes for reviewers:**

I had initially thought this would take more work to get done, but it turned out to be pretty simple with the `filesource.ListingFunc` adapter already available. There wasn't much possible improvement I could see from refactoring the existing iterator code.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/350)
<!-- Reviewable:end -->
