### PR TITLE
better field ordering for connectors

### DIFF
--- a/materialize-bigquery/.snapshots/TestSpecification
+++ b/materialize-bigquery/.snapshots/TestSpecification
@@ -3,51 +3,58 @@
     "$schema": "http://json-schema.org/draft/2020-12/schema",
     "$id": "https://github.com/estuary/connectors/materialize-bigquery/config",
     "properties": {
-      "billing_project_id": {
-        "type": "string",
-        "title": "Billing Project ID",
-        "description": "Billing Project ID connected to the BigQuery dataset. It can be the same value as Project ID."
-      },
       "project_id": {
         "type": "string",
         "title": "Project ID",
-        "description": "Google Cloud Project ID that owns the BigQuery dataset."
-      },
-      "dataset": {
-        "type": "string",
-        "title": "Dataset",
-        "description": "BigQuery dataset that will be used to store the materialization output."
-      },
-      "region": {
-        "type": "string",
-        "title": "Region",
-        "description": "Region where both the Bucket and the BigQuery dataset is located. They both need to be within the same region."
-      },
-      "bucket": {
-        "type": "string",
-        "title": "Bucket",
-        "description": "Google Cloud Storage bucket that is going to be used to store specfications \u0026 temporary data before merging into BigQuery."
-      },
-      "bucket_path": {
-        "type": "string",
-        "title": "Bucket Path",
-        "description": "A prefix that will be used to store objects to Google Cloud Storage's bucket."
+        "description": "Google Cloud Project ID that owns the BigQuery dataset.",
+        "order": "0"
       },
       "credentials_json": {
         "type": "string",
         "title": "Credentials",
         "description": "Google Cloud Service Account JSON credentials in base64 format.",
         "multiline": true,
+        "order": "1",
         "secret": true
+      },
+      "region": {
+        "type": "string",
+        "title": "Region",
+        "description": "Region where both the Bucket and the BigQuery dataset is located. They both need to be within the same region.",
+        "order": "2"
+      },
+      "dataset": {
+        "type": "string",
+        "title": "Dataset",
+        "description": "BigQuery dataset that will be used to store the materialization output.",
+        "order": "3"
+      },
+      "bucket": {
+        "type": "string",
+        "title": "Bucket",
+        "description": "Google Cloud Storage bucket that is going to be used to store specfications \u0026 temporary data before merging into BigQuery.",
+        "order": "4"
+      },
+      "bucket_path": {
+        "type": "string",
+        "title": "Bucket Path",
+        "description": "A prefix that will be used to store objects to Google Cloud Storage's bucket.",
+        "order": "5"
+      },
+      "billing_project_id": {
+        "type": "string",
+        "title": "Billing Project ID",
+        "description": "Billing Project ID connected to the BigQuery dataset. Defaults to Project ID if not specified.",
+        "order": "6"
       }
     },
     "type": "object",
     "required": [
       "project_id",
-      "dataset",
+      "credentials_json",
       "region",
-      "bucket",
-      "credentials_json"
+      "dataset",
+      "bucket"
     ],
     "title": "SQL Connection"
   },

--- a/materialize-bigquery/bigquery.go
+++ b/materialize-bigquery/bigquery.go
@@ -23,13 +23,13 @@ func main() {
 
 // Config represents the endpoint configuration for BigQuery.
 type config struct {
-	BillingProjectID string `json:"billing_project_id,omitempty" jsonschema:"title=Billing Project ID,description=Billing Project ID connected to the BigQuery dataset. It can be the same value as Project ID."`
-	ProjectID        string `json:"project_id" jsonschema:"title=Project ID,description=Google Cloud Project ID that owns the BigQuery dataset."`
-	Dataset          string `json:"dataset" jsonschema:"title=Dataset,description=BigQuery dataset that will be used to store the materialization output."`
-	Region           string `json:"region" jsonschema:"title=Region,description=Region where both the Bucket and the BigQuery dataset is located. They both need to be within the same region."`
-	Bucket           string `json:"bucket" jsonschema:"title=Bucket,description=Google Cloud Storage bucket that is going to be used to store specfications & temporary data before merging into BigQuery."`
-	BucketPath       string `json:"bucket_path,omitempty" jsonschema:"title=Bucket Path,description=A prefix that will be used to store objects to Google Cloud Storage's bucket."`
-	CredentialsJSON  string `json:"credentials_json" jsonschema:"title=Credentials,description=Google Cloud Service Account JSON credentials in base64 format." jsonschema_extras:"secret=true,multiline=true"`
+	ProjectID        string `json:"project_id" jsonschema:"title=Project ID,description=Google Cloud Project ID that owns the BigQuery dataset." jsonschema_extras:"order=0"`
+	CredentialsJSON  string `json:"credentials_json" jsonschema:"title=Credentials,description=Google Cloud Service Account JSON credentials in base64 format." jsonschema_extras:"secret=true,multiline=true,order=1"`
+	Region           string `json:"region" jsonschema:"title=Region,description=Region where both the Bucket and the BigQuery dataset is located. They both need to be within the same region." jsonschema_extras:"order=2"`
+	Dataset          string `json:"dataset" jsonschema:"title=Dataset,description=BigQuery dataset that will be used to store the materialization output." jsonschema_extras:"order=3"`
+	Bucket           string `json:"bucket" jsonschema:"title=Bucket,description=Google Cloud Storage bucket that is going to be used to store specfications & temporary data before merging into BigQuery." jsonschema_extras:"order=4"`
+	BucketPath       string `json:"bucket_path,omitempty" jsonschema:"title=Bucket Path,description=A prefix that will be used to store objects to Google Cloud Storage's bucket." jsonschema_extras:"order=5"`
+	BillingProjectID string `json:"billing_project_id,omitempty" jsonschema:"title=Billing Project ID,description=Billing Project ID connected to the BigQuery dataset. Defaults to Project ID if not specified." jsonschema_extras:"order=6"`
 }
 
 func (c *config) Validate() error {

--- a/materialize-elasticsearch/.snapshots/TestDriverSpec
+++ b/materialize-elasticsearch/.snapshots/TestDriverSpec
@@ -6,17 +6,20 @@
       "endpoint": {
         "type": "string",
         "title": "Endpoint",
-        "description": "Endpoint host or URL. If using Elastic Cloud"
+        "description": "Endpoint host or URL. If using Elastic Cloud this follows the format https://CLUSTER_ID.REGION.CLOUD_PLATFORM.DOMAIN:PORT",
+        "order": "0"
       },
       "username": {
         "type": "string",
         "title": "Username",
-        "description": "User to connect to the endpoint."
+        "description": "User to connect to the endpoint.",
+        "order": "1"
       },
       "password": {
         "type": "string",
         "title": "Password",
         "description": "Password to connect to the endpoint.",
+        "order": "2",
         "secret": true
       }
     },

--- a/materialize-elasticsearch/driver.go
+++ b/materialize-elasticsearch/driver.go
@@ -19,9 +19,9 @@ import (
 )
 
 type config struct {
-	Endpoint string `json:"endpoint" jsonschema:"title=Endpoint,description=Endpoint host or URL. If using Elastic Cloud, this follows the format https://CLUSTER_ID.REGION.CLOUD_PLATFORM.DOMAIN:PORT"`
-	Username string `json:"username,omitempty" jsonschema:"title=Username,description=User to connect to the endpoint."`
-	Password string `json:"password,omitempty" jsonschema:"title=Password,description=Password to connect to the endpoint." jsonschema_extras:"secret=true"`
+	Endpoint string `json:"endpoint" jsonschema:"title=Endpoint,description=Endpoint host or URL. If using Elastic Cloud this follows the format https://CLUSTER_ID.REGION.CLOUD_PLATFORM.DOMAIN:PORT" jsonschema_extras:"order=0"`
+	Username string `json:"username,omitempty" jsonschema:"title=Username,description=User to connect to the endpoint." jsonschema_extras:"order=1"`
+	Password string `json:"password,omitempty" jsonschema:"title=Password,description=Password to connect to the endpoint." jsonschema_extras:"secret=true,order=2"`
 }
 
 func (c config) Validate() error {

--- a/materialize-firebolt/.snapshots/TestDriverSpec
+++ b/materialize-firebolt/.snapshots/TestDriverSpec
@@ -1,0 +1,104 @@
+{
+  "endpoint_spec_schema_json": {
+    "$schema": "http://json-schema.org/draft/2020-12/schema",
+    "$id": "https://github.com/estuary/connectors/materialize-firebolt/config",
+    "properties": {
+      "engine_url": {
+        "type": "string",
+        "title": "Engine URL",
+        "description": "Engine URL of the Firebolt database, in the format: `\u003cengine-name\u003e.\u003corganisation\u003e.\u003cregion\u003e.app.firebolt.io`.",
+        "examples": [
+          "engine-name.organisation.region.app.firebolt.io"
+        ],
+        "order": "0"
+      },
+      "username": {
+        "type": "string",
+        "title": "Username",
+        "description": "Firebolt username.",
+        "order": "1"
+      },
+      "password": {
+        "type": "string",
+        "title": "Password",
+        "description": "Firebolt password.",
+        "order": "2",
+        "secret": true
+      },
+      "database": {
+        "type": "string",
+        "title": "Database",
+        "description": "Name of the Firebolt database.",
+        "order": "3"
+      },
+      "s3_bucket": {
+        "type": "string",
+        "title": "S3 Bucket",
+        "description": "Name of S3 bucket where the intermediate files for external table will be stored.",
+        "order": "4"
+      },
+      "s3_prefix": {
+        "type": "string",
+        "title": "S3 Prefix",
+        "description": "A prefix for files stored in the bucket. Example: my-prefix.",
+        "default": "/",
+        "order": "5"
+      },
+      "aws_key_id": {
+        "type": "string",
+        "title": "AWS Key ID",
+        "description": "AWS Key ID for accessing the S3 bucket.",
+        "order": "6"
+      },
+      "aws_secret_key": {
+        "type": "string",
+        "title": "AWS Secret Key",
+        "description": "AWS Secret Key for accessing the S3 bucket.",
+        "order": "7",
+        "secret": true
+      },
+      "aws_region": {
+        "type": "string",
+        "title": "AWS Region",
+        "description": "AWS Region the bucket is in.",
+        "order": "8"
+      }
+    },
+    "type": "object",
+    "required": [
+      "engine_url",
+      "username",
+      "password",
+      "database",
+      "s3_bucket"
+    ],
+    "title": "Firebolt Connection"
+  },
+  "resource_spec_schema_json": {
+    "$schema": "http://json-schema.org/draft/2020-12/schema",
+    "$id": "https://github.com/estuary/connectors/materialize-firebolt/resource",
+    "properties": {
+      "table": {
+        "type": "string",
+        "title": "Table",
+        "description": "Name of the Firebolt table to store materialized results in. The external table will be named after this table with an `_external` suffix."
+      },
+      "table_type": {
+        "type": "string",
+        "enum": [
+          "fact",
+          "dimension"
+        ],
+        "title": "Table Type",
+        "description": "Type of the Firebolt table to store materialized results in. See https://docs.firebolt.io/working-with-tables.html for more details."
+      }
+    },
+    "type": "object",
+    "required": [
+      "table",
+      "table_type"
+    ],
+    "title": "Firebolt Table"
+  },
+  "documentation_url": "https://go.estuary.dev/materialize-firebolt"
+}

--- a/materialize-firebolt/config.go
+++ b/materialize-firebolt/config.go
@@ -6,15 +6,15 @@ import (
 )
 
 type config struct {
-	EngineURL    string `json:"engine_url" jsonschema:"title=Engine URL,example=engine-name.organisation.region.app.firebolt.io"`
-	Database     string `json:"database" jsonschema:"title=Database"`
-	Username     string `json:"username" jsonschema:"title=Username"`
-	Password     string `json:"password" jsonschema_extras:"secret=true" jsonschema:"title=Password"`
-	AWSKeyId     string `json:"aws_key_id,omitempty" jsonschema:"title=AWS Key ID"`
-	AWSSecretKey string `json:"aws_secret_key,omitempty" jsonschema_extras:"secret=true" jsonschema:"title=AWS Secret Key"`
-	AWSRegion    string `json:"aws_region,omitempty" jsonschema:"title=AWS Region"`
-	S3Bucket     string `json:"s3_bucket" jsonschema:"title=S3 Bucket"`
-	S3Prefix     string `json:"s3_prefix,omitempty" jsonschema:"title=S3 Prefix,default=/"`
+	EngineURL    string `json:"engine_url" jsonschema:"title=Engine URL,example=engine-name.organisation.region.app.firebolt.io" jsonschema_extras:"order=0"`
+	Username     string `json:"username" jsonschema:"title=Username" jsonschema_extras:"order=1"`
+	Password     string `json:"password" jsonschema:"title=Password" jsonschema_extras:"secret=true,order=2"`
+	Database     string `json:"database" jsonschema:"title=Database" jsonschema_extras:"order=3"`
+	S3Bucket     string `json:"s3_bucket" jsonschema:"title=S3 Bucket" jsonschema_extras:"order=4"`
+	S3Prefix     string `json:"s3_prefix,omitempty" jsonschema:"title=S3 Prefix,default=/" jsonschema_extras:"order=5"`
+	AWSKeyId     string `json:"aws_key_id,omitempty" jsonschema:"title=AWS Key ID" jsonschema_extras:"order=6"`
+	AWSSecretKey string `json:"aws_secret_key,omitempty" jsonschema:"title=AWS Secret Key" jsonschema_extras:"secret=true,order=7"`
+	AWSRegion    string `json:"aws_region,omitempty" jsonschema:"title=AWS Region" jsonschema_extras:"order=8"`
 }
 
 func (c config) Validate() error {

--- a/materialize-firebolt/config_test.go
+++ b/materialize-firebolt/config_test.go
@@ -1,0 +1,21 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/bradleyjkemp/cupaloy"
+	pf "github.com/estuary/flow/go/protocols/flow"
+	pm "github.com/estuary/flow/go/protocols/materialize"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDriverSpec(t *testing.T) {
+	var drv = driver{}
+	var resp, err1 = drv.Spec(context.Background(), &pm.SpecRequest{EndpointType: pf.EndpointType_FLOW_SINK})
+	require.NoError(t, err1)
+	var formatted, err2 = json.MarshalIndent(resp, "", "  ")
+	require.NoError(t, err2)
+	cupaloy.SnapshotT(t, formatted)
+}

--- a/materialize-postgres/.snapshots/TestSpecification
+++ b/materialize-postgres/.snapshots/TestSpecification
@@ -6,23 +6,27 @@
       "address": {
         "type": "string",
         "title": "Address",
-        "description": "Host and port of the database."
+        "description": "Host and port of the database.",
+        "order": "0"
       },
       "user": {
         "type": "string",
         "title": "User",
-        "description": "Database user to connect as."
+        "description": "Database user to connect as.",
+        "order": "1"
       },
       "password": {
         "type": "string",
         "title": "Password",
         "description": "Password for the specified database user.",
+        "order": "2",
         "secret": true
       },
       "database": {
         "type": "string",
         "title": "Database",
-        "description": "Name of the logical database to materialize to."
+        "description": "Name of the logical database to materialize to.",
+        "order": "3"
       }
     },
     "type": "object",

--- a/materialize-postgres/driver.go
+++ b/materialize-postgres/driver.go
@@ -21,10 +21,10 @@ import (
 // config represents the endpoint configuration for postgres.
 // It must match the one defined for the source specs (flow.yaml) in Rust.
 type config struct {
-	Address  string `json:"address" jsonschema:"title=Address,description=Host and port of the database."`
-	User     string `json:"user" jsonschema:"title=User,description=Database user to connect as."`
-	Password string `json:"password" jsonschema:"title=Password,description=Password for the specified database user." jsonschema_extras:"secret=true"`
-	Database string `json:"database,omitempty" jsonschema:"title=Database,description=Name of the logical database to materialize to."`
+	Address  string `json:"address" jsonschema:"title=Address,description=Host and port of the database." jsonschema_extras:"order=0"`
+	User     string `json:"user" jsonschema:"title=User,description=Database user to connect as." jsonschema_extras:"order=1"`
+	Password string `json:"password" jsonschema:"title=Password,description=Password for the specified database user." jsonschema_extras:"secret=true,order=2"`
+	Database string `json:"database,omitempty" jsonschema:"title=Database,description=Name of the logical database to materialize to." jsonschema_extras:"order=3"`
 }
 
 // Validate the configuration.

--- a/materialize-s3-parquet/.snapshots/TestS3ParquetDriverSpec
+++ b/materialize-s3-parquet/.snapshots/TestS3ParquetDriverSpec
@@ -6,28 +6,33 @@
       "awsAccessKeyId": {
         "type": "string",
         "title": "Access Key ID",
-        "description": "AWS credential used to connect to S3."
+        "description": "AWS credential used to connect to S3.",
+        "order": "0"
       },
       "awsSecretAccessKey": {
         "type": "string",
         "title": "Secret Access Key",
         "description": "AWS credential used to connect to S3.",
+        "order": "1",
         "secret": true
-      },
-      "bucket": {
-        "type": "string",
-        "title": "Bucket",
-        "description": "Name of the S3 bucket."
       },
       "region": {
         "type": "string",
         "title": "Region",
-        "description": "The name of the AWS region where the S3 bucket is located."
+        "description": "The name of the AWS region where the S3 bucket is located.",
+        "order": "2"
+      },
+      "bucket": {
+        "type": "string",
+        "title": "Bucket",
+        "description": "Name of the S3 bucket.",
+        "order": "3"
       },
       "uploadIntervalInSeconds": {
         "type": "integer",
         "title": "Upload Interval in Seconds",
-        "description": "Time interval, in seconds, at which to upload data from Flow to S3."
+        "description": "Time interval, in seconds, at which to upload data from Flow to S3.",
+        "order": "4"
       },
       "advanced": {
         "properties": {
@@ -47,8 +52,8 @@
     "required": [
       "awsAccessKeyId",
       "awsSecretAccessKey",
-      "bucket",
       "region",
+      "bucket",
       "uploadIntervalInSeconds"
     ],
     "title": "S3 Connection"

--- a/materialize-s3-parquet/driver.go
+++ b/materialize-s3-parquet/driver.go
@@ -19,15 +19,15 @@ import (
 )
 
 type config struct {
-	AWSAccessKeyID     string `json:"awsAccessKeyId" jsonschema:"title=Access Key ID"`
-	AWSSecretAccessKey string `json:"awsSecretAccessKey" jsonschema:"title=Secret Access Key" jsonschema_extras:"secret=true"`
-	Bucket             string `json:"bucket" jsonschema:"title=Bucket"`
-	Region             string `json:"region" jsonschema:"title=Region"`
+	AWSAccessKeyID     string `json:"awsAccessKeyId" jsonschema:"title=Access Key ID" jsonschema_extras:"order=0"`
+	AWSSecretAccessKey string `json:"awsSecretAccessKey" jsonschema:"title=Secret Access Key" jsonschema_extras:"secret=true,order=1"`
+	Region             string `json:"region" jsonschema:"title=Region" jsonschema_extras:"order=2"`
+	Bucket             string `json:"bucket" jsonschema:"title=Bucket" jsonschema_extras:"order=3"`
 	// The driver batches materialization results to local files first,
 	// and uploads the local files to cloud (S3) on a schedule specified by
 	// UploadIntervalInSeconds, which is the mimimal wait time (in seconds) between two
 	// consecutive upload-to-cloud actions.
-	UploadIntervalInSeconds int            `json:"uploadIntervalInSeconds" jsonschema:"title=Upload Interval in Seconds"`
+	UploadIntervalInSeconds int            `json:"uploadIntervalInSeconds" jsonschema:"title=Upload Interval in Seconds" jsonschema_extras:"order=4"`
 	Advanced                advancedConfig `json:"advanced,omitempty" jsonschema_extras:"advanced=true"`
 }
 

--- a/materialize-snowflake/.snapshots/TestSpecification
+++ b/materialize-snowflake/.snapshots/TestSpecification
@@ -3,52 +3,60 @@
     "$schema": "http://json-schema.org/draft/2020-12/schema",
     "$id": "https://github.com/estuary/connectors/materialize-snowflake/config",
     "properties": {
-      "account": {
-        "type": "string",
-        "title": "Account",
-        "description": "The Snowflake account identifier."
-      },
       "host": {
         "type": "string",
         "title": "Host URL",
-        "description": "The Snowflake Host used for the connection. Example: orgname-accountname.snowflakecomputing.com (do not include the protocol)."
+        "description": "The Snowflake Host used for the connection. Example: orgname-accountname.snowflakecomputing.com (do not include the protocol).",
+        "order": "0"
+      },
+      "account": {
+        "type": "string",
+        "title": "Account",
+        "description": "The Snowflake account identifier.",
+        "order": "1"
       },
       "user": {
         "type": "string",
         "title": "User",
-        "description": "The Snowflake user login name."
+        "description": "The Snowflake user login name.",
+        "order": "2"
       },
       "password": {
         "type": "string",
         "title": "Password",
         "description": "The password for the provided user.",
+        "order": "3",
         "secret": true
       },
       "database": {
         "type": "string",
         "title": "Database",
-        "description": "The SQL database to connect to."
+        "description": "The SQL database to connect to.",
+        "order": "4"
       },
       "schema": {
         "type": "string",
         "title": "Schema",
-        "description": "The SQL schema to use."
+        "description": "The SQL schema to use.",
+        "order": "5"
       },
       "warehouse": {
         "type": "string",
         "title": "Warehouse",
-        "description": "The Snowflake virtual warehouse used to execute queries."
+        "description": "The Snowflake virtual warehouse used to execute queries.",
+        "order": "6"
       },
       "role": {
         "type": "string",
         "title": "Role",
-        "description": "The user role used to perform actions."
+        "description": "The user role used to perform actions.",
+        "order": "7"
       }
     },
     "type": "object",
     "required": [
-      "account",
       "host",
+      "account",
       "user",
       "password",
       "database",

--- a/materialize-snowflake/snowflake.go
+++ b/materialize-snowflake/snowflake.go
@@ -22,14 +22,14 @@ import (
 // config represents the endpoint configuration for snowflake.
 // It must match the one defined for the source specs (flow.yaml) in Rust.
 type config struct {
-	Account   string `json:"account" jsonschema:"title=Account,description=The Snowflake account identifier."`
-	Host      string `json:"host" jsonschema:"title=Host URL,description=The Snowflake Host used for the connection. Example: orgname-accountname.snowflakecomputing.com (do not include the protocol)."`
-	User      string `json:"user" jsonschema:"title=User,description=The Snowflake user login name."`
-	Password  string `json:"password" jsonschema:"title=Password,description=The password for the provided user." jsonschema_extras:"secret=true"`
-	Database  string `json:"database" jsonschema:"title=Database,description=The SQL database to connect to."`
-	Schema    string `json:"schema" jsonschema:"title=Schema,description=The SQL schema to use."`
-	Warehouse string `json:"warehouse,omitempty" jsonschema:"title=Warehouse,description=The Snowflake virtual warehouse used to execute queries."`
-	Role      string `json:"role,omitempty" jsonschema:"title=Role,description=The user role used to perform actions."`
+	Host      string `json:"host" jsonschema:"title=Host URL,description=The Snowflake Host used for the connection. Example: orgname-accountname.snowflakecomputing.com (do not include the protocol)." jsonschema_extras:"order=0"`
+	Account   string `json:"account" jsonschema:"title=Account,description=The Snowflake account identifier." jsonschema_extras:"order=1"`
+	User      string `json:"user" jsonschema:"title=User,description=The Snowflake user login name." jsonschema_extras:"order=2"`
+	Password  string `json:"password" jsonschema:"title=Password,description=The password for the provided user." jsonschema_extras:"secret=true,order=3"`
+	Database  string `json:"database" jsonschema:"title=Database,description=The SQL database to connect to." jsonschema_extras:"order=4"`
+	Schema    string `json:"schema" jsonschema:"title=Schema,description=The SQL schema to use." jsonschema_extras:"order=5"`
+	Warehouse string `json:"warehouse,omitempty" jsonschema:"title=Warehouse,description=The Snowflake virtual warehouse used to execute queries." jsonschema_extras:"order=6"`
+	Role      string `json:"role,omitempty" jsonschema:"title=Role,description=The user role used to perform actions." jsonschema_extras:"order=7"`
 }
 
 func (c *config) asSnowflakeConfig() sf.Config {

--- a/source-gcs/main.go
+++ b/source-gcs/main.go
@@ -148,28 +148,32 @@ func main() {
 			"bucket"
 		],
 		"properties": {
-			"bucket": {
-				"type":        "string",
-				"title":       "Bucket",
-				"description": "Name of the Google Cloud Storage bucket"
-			},
 			"googleCredentials": {
 				"type":        "string",
 				"title":       "Google Service Account",
 				"description": "Service account JSON key to use as Application Default Credentials",
 				"multiline":   true,
-				"secret":      true
+				"secret":      true,
+				"order":       0
+			},
+			"bucket": {
+				"type":        "string",
+				"title":       "Bucket",
+				"description": "Name of the Google Cloud Storage bucket",
+				"order":       1
+			},
+			"prefix": {
+				"type":        "string",
+				"title":       "Prefix",
+				"description": "Prefix within the bucket to capture from",
+				"order":       2
 			},
 			"matchKeys": {
 				"type":        "string",
 				"title":       "Match Keys",
 				"format":      "regex",
-				"description": "Filter applied to all object keys under the prefix. If provided, only objects whose key (relative to the prefix) matches this regex will be read. For example, you can use \".*\\.json\" to only capture json files."
-			},
-			"prefix": {
-				"type":        "string",
-				"title":       "Prefix",
-				"description": "Prefix within the bucket to capture from"
+				"description": "Filter applied to all object keys under the prefix. If provided, only objects whose key (relative to the prefix) matches this regex will be read. For example, you can use \".*\\.json\" to only capture json files.",
+				"order":       3
 			},
 			"advanced": {
 				"properties": {

--- a/source-kinesis/connection.go
+++ b/source-kinesis/connection.go
@@ -43,30 +43,31 @@ var configJSONSchema = `{
 		"awsSecretAccessKey"
 	],
 	"properties": {
-		"region": {
-			"type":        "string",
-			"title":       "AWS Region",
-			"description": "The name of the AWS region where the Kinesis stream is located",
-			"default":     "us-east-1"
-		},
-		"endpoint": {
-			"type":        "string",
-			"title":       "AWS Endpoint",
-			"description": "The AWS endpoint URI to connect to, useful if you're capturing from a kinesis-compatible API that isn't provided by AWS"
-		},
 		"awsAccessKeyId": {
 			"type":        "string",
 			"title":       "AWS Access Key ID",
 			"description": "Part of the AWS credentials that will be used to connect to Kinesis",
-			"default":     "example-aws-access-key-id",
-			"secret": true
+			"order": 0
+
 		},
 		"awsSecretAccessKey": {
 			"type":        "string",
 			"title":       "AWS Secret Access Key",
 			"description": "Part of the AWS credentials that will be used to connect to Kinesis",
-			"default":     "example-aws-secret-access-key",
-			"secret": true
+			"secret":      true,
+			"order":       1
+		},
+		"region": {
+			"type":        "string",
+			"title":       "AWS Region",
+			"description": "The name of the AWS region where the Kinesis stream is located",
+			"order":       2
+		},
+		"endpoint": {
+			"type":        "string",
+			"title":       "AWS Endpoint",
+			"description": "The AWS endpoint URI to connect to, useful if you're capturing from a kinesis-compatible API that isn't provided by AWS",
+			"order":       3
 		}
 	}
 }`

--- a/source-kinesis/main.go
+++ b/source-kinesis/main.go
@@ -18,7 +18,6 @@ func main() {
 	airbyte.RunMain(spec, doCheck, doDiscover, doRead)
 }
 
-// TODO: update docs link to kinesis connector-specific docs after they are written
 var spec = airbyte.Spec{
 	SupportsIncremental:           true,
 	SupportedDestinationSyncModes: airbyte.AllDestinationSyncModes,

--- a/source-mysql/main.go
+++ b/source-mysql/main.go
@@ -69,9 +69,9 @@ func fixMysqlLogging() {
 // Config tells the connector how to connect to the source database and
 // capture changes from it.
 type Config struct {
-	Address  string         `json:"address" jsonschema:"title=Server Address,description=The host or host:port at which the database can be reached."`
-	User     string         `json:"user" jsonschema:"title=Login Username,default=flow_capture,description=The database user to authenticate as."`
-	Password string         `json:"password" jsonschema:"title=Login Password,description=Password for the specified database user." jsonschema_extras:"secret=true"`
+	Address  string         `json:"address" jsonschema:"title=Server Address,description=The host or host:port at which the database can be reached." jsonschema_extras:"order=0"`
+	User     string         `json:"user" jsonschema:"title=Login Username,default=flow_capture,description=The database user to authenticate as." jsonschema_extras:"order=1"`
+	Password string         `json:"password" jsonschema:"title=Login Password,description=Password for the specified database user." jsonschema_extras:"secret=true,order=2"`
 	Advanced advancedConfig `json:"advanced,omitempty" jsonschema:"title=Advanced Options,description=Options for advanced users. You should not typically need to modify these." jsonschema_extra:"advanced=true"`
 }
 

--- a/source-postgres/main.go
+++ b/source-postgres/main.go
@@ -42,10 +42,10 @@ func main() {
 
 // Config tells the connector how to connect to and interact with the source database.
 type Config struct {
-	Address  string         `json:"address" jsonschema:"title=Server Address,description=The host or host:port at which the database can be reached."`
-	Database string         `json:"database" jsonschema:"default=postgres,description=Logical database name to capture from."`
-	User     string         `json:"user" jsonschema:"default=flow_capture,description=The database user to authenticate as."`
-	Password string         `json:"password" jsonschema:"description=Password for the specified database user." jsonschema_extras:"secret=true"`
+	Address  string         `json:"address" jsonschema:"title=Server Address,description=The host or host:port at which the database can be reached." jsonschema_extras:"order=0"`
+	User     string         `json:"user" jsonschema:"default=flow_capture,description=The database user to authenticate as." jsonschema_extras:"order=1"`
+	Password string         `json:"password" jsonschema:"description=Password for the specified database user." jsonschema_extras:"secret=true,order=2"`
+	Database string         `json:"database" jsonschema:"default=postgres,description=Logical database name to capture from." jsonschema_extras:"order=3"`
 	Advanced advancedConfig `json:"advanced,omitempty" jsonschema:"title=Advanced Options,description=Options for advanced users. You should not typically need to modify these." jsonschema_extra:"advanced=true"`
 }
 

--- a/source-s3/main.go
+++ b/source-s3/main.go
@@ -223,35 +223,40 @@ func main() {
 			"awsAccessKeyId": {
 				"type":        "string",
 				"title":       "AWS Access Key ID",
-				"description": "Part of the AWS credentials that will be used to connect to S3. Required unless the bucket is public and allows anonymous listings and reads."
+				"description": "Part of the AWS credentials that will be used to connect to S3. Required unless the bucket is public and allows anonymous listings and reads.",
+				"order": 0
 			},
 			"awsSecretAccessKey": {
 				"type":        "string",
 				"title":       "AWS Secret Access Key",
 				"description": "Part of the AWS credentials that will be used to connect to S3. Required unless the bucket is public and allows anonymous listings and reads.",
-				"secret":      true
+				"secret":      true,
+				"order":       1
+			},
+			"region": {
+				"type":        "string",
+				"title":       "AWS Region",
+				"description": "The name of the AWS region where the S3 bucket is located.",
+				"order":       2
 			},
 			"bucket": {
 				"type":        "string",
 				"title":       "Bucket",
-				"description": "Name of the S3 bucket"
+				"description": "Name of the S3 bucket",
+				"order":       3
+			},
+			"prefix": {
+				"type":        "string",
+				"title":       "Prefix",
+				"description": "Prefix within the bucket to capture from.",
+				"order":       4
 			},
 			"matchKeys": {
 				"type":        "string",
 				"title":       "Match Keys",
 				"format":      "regex",
-				"description": "Filter applied to all object keys under the prefix. If provided, only objects whose absolute path matches this regex will be read. For example, you can use \".*\\.json\" to only capture json files."
-			},
-			"prefix": {
-				"type":        "string",
-				"title":       "Prefix",
-				"description": "Prefix within the bucket to capture from."
-			},
-			"region": {
-				"type":        "string",
-				"title":       "AWS Region",
-				"description": "The name of the AWS region where the S3 bucket is located. \"us-east-1\" is a popular default you can try, if you're unsure what to put here.",
-				"default":     "us-east-1"
+				"description": "Filter applied to all object keys under the prefix. If provided, only objects whose absolute path matches this regex will be read. For example, you can use \".*\\.json\" to only capture json files.",
+				"order":       5
 			},
 			"advanced": {
 				"properties": {


### PR DESCRIPTION
Closes https://github.com/estuary/connectors/issues/360

**Description:**

Adds ordering properties to fields in various connectors. The specific ordering is what seemed reasonable to me, and I'd be open to alternative suggestions. My general thought process for ordering things was to put them in this order:

1. Basic connection information, like a database URL
2. Authentication, in the form of user/password or service account credentials
3. The remaining connector configurations, ordered logically where possible, with "optional" fields generally coming last

The poster child for this algorithm is the configuration for the Postgres connector, which will appear in the order of:
```
address
user
password
database
```

The configs don't always map to that baseline perfectly, so I tried to get as close as possible.

**Workflow steps:**

Build the connector images, update the database records, and view the configs in the UI.

**Documentation links affected:**

As I have initially proposed it:
- `source-s3` for the removal of the default value for "region" and the suggestion to try us-east-1 if you're not sure
- `source-kinesis` for the removal of the default values for "region", "awsAccessKeyId", and "awsSecretAccessKey"
- `materialize-bigquery` for a small change in the description of "billing_project_id"

**Notes for reviewers:**

It may be interesting to note which connectors I did not update:
- `materialize-google-pubsub`, `materialize-google-sheets`, and `materialize-rockset` only have a single configuration value so there is no need to specify ordering
- `source-firestore` has some work going on with it already so I didn't want to create merge conflicts; this one can be updated later
- `source-kafka` already has ordering

Also see inline comments for specific notes about things I have changed not directly related to ordering.


<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/361)
<!-- Reviewable:end -->
