### PR TITLE
improve end-to-end test compatibility

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -106,8 +106,10 @@ jobs:
           VERSION=$(cat ${{ matrix.connector }}/VERSION | tr -d '\n')
           echo ::set-output name=version::${VERSION}
 
-      - name: Download latest Flow release binaries
-        run: ./fetch-flow.sh
+      - name: Download latest Flow release binaries and add them to $PATH
+        run: |
+          ./fetch-flow.sh
+          echo "${PWD}/flow-bin" >> $GITHUB_PATH
 
       - name: Install kafkactl
         if: matrix.connector == 'source-kafka'

--- a/tests/materialize/datasets/ingest.go
+++ b/tests/materialize/datasets/ingest.go
@@ -6,6 +6,7 @@ import (
 	"flag"
 	"fmt"
 	"log"
+	"net"
 	"os"
 	"time"
 
@@ -38,7 +39,11 @@ type pushRpc struct {
 }
 
 func newPushRpc(ctx context.Context, serverAddr string) (*pushRpc, error) {
-	if conn, err := grpc.Dial(serverAddr, grpc.WithInsecure()); err != nil {
+	dialer := func(addr string, t time.Duration) (net.Conn, error) {
+		return net.Dial("unix", addr)
+	}
+
+	if conn, err := grpc.Dial(serverAddr, grpc.WithInsecure(), grpc.WithDialer(dialer)); err != nil {
 		return nil, fmt.Errorf("fail to dial: %w", err)
 	} else if rpc, err := capture.NewRuntimeClient(conn).Push(ctx); err != nil {
 		return nil, fmt.Errorf("failed to create Push rpc: %w", err)

--- a/tests/materialize/materialize-elasticsearch/ingest-data.sh
+++ b/tests/materialize/materialize-elasticsearch/ingest-data.sh
@@ -2,20 +2,20 @@
 set -e
 # Push data to the capture.
 go run ${DATA_INGEST_SCRIPT_PATH} \
-  --server_address=${CONSUMER_ADDRESS} \
+  --server_address=${INGEST_SOCKET_PATH} \
   --capture=${PUSH_CAPTURE_NAME} \
   --binding_num=${BINDING_NUM_DUPLICATED_KEYS} \
   --data_file_path=${DATASET_DUPLICATED_KEYS}
 
 go run ${DATA_INGEST_SCRIPT_PATH} \
-  --server_address=${CONSUMER_ADDRESS} \
+  --server_address=${INGEST_SOCKET_PATH} \
   --capture=${PUSH_CAPTURE_NAME} \
   --binding_num=${BINDING_NUM_DUPLICATED_KEYS} \
   --data_file_path=${DATASET_DUPLICATED_KEYS}
 
 
 go run ${DATA_INGEST_SCRIPT_PATH} \
-  --server_address=${CONSUMER_ADDRESS} \
+  --server_address=${INGEST_SOCKET_PATH} \
   --capture=${PUSH_CAPTURE_NAME} \
   --binding_num=${BINDING_NUM_MULTIPLE_DATATYPES} \
   --data_file_path=${DATASET_MULTIPLE_DATATYPES}

--- a/tests/materialize/materialize-google-sheets/fetch-materialize-results.sh
+++ b/tests/materialize/materialize-google-sheets/fetch-materialize-results.sh
@@ -19,7 +19,7 @@ function exportToJsonl() {
     export SPREADSHEET_ID="1aki_PfFU-RCXCvm4-U0O4QoElZBIC7F9lfR-RBG0CTc"
     export SHEET_NAME="$1"
 
-    go run ${TEST_SCRIPTS_DIR}/materialize-google-sheets/fetch-sheets.go
+    go run ${TEST_BASE_DIR}/materialize-google-sheets/fetch-sheets.go
 }
 
 exportToJsonl "Simple" > "${TEST_DIR}/${result_dir}/simple.jsonl"

--- a/tests/materialize/materialize-google-sheets/ingest-data.sh
+++ b/tests/materialize/materialize-google-sheets/ingest-data.sh
@@ -2,19 +2,19 @@
 set -e
 
 go run ${DATA_INGEST_SCRIPT_PATH} \
-  --server_address=${CONSUMER_ADDRESS} \
+  --server_address=${INGEST_SOCKET_PATH} \
   --capture=${PUSH_CAPTURE_NAME} \
   --binding_num=${BINDING_NUM_SIMPLE} \
   --data_file_path=${DATASET_SIMPLE}
 
 go run ${DATA_INGEST_SCRIPT_PATH} \
-  --server_address=${CONSUMER_ADDRESS} \
+  --server_address=${INGEST_SOCKET_PATH} \
   --capture=${PUSH_CAPTURE_NAME} \
   --binding_num=${BINDING_NUM_DUPLICATED_KEYS} \
   --data_file_path=${DATASET_DUPLICATED_KEYS}
 
 go run ${DATA_INGEST_SCRIPT_PATH} \
-  --server_address=${CONSUMER_ADDRESS} \
+  --server_address=${INGEST_SOCKET_PATH} \
   --capture=${PUSH_CAPTURE_NAME} \
   --binding_num=${BINDING_NUM_MULTIPLE_DATATYPES} \
   --data_file_path=${DATASET_MULTIPLE_DATATYPES}

--- a/tests/materialize/materialize-postgres-rc/ingest-data.sh
+++ b/tests/materialize/materialize-postgres-rc/ingest-data.sh
@@ -2,26 +2,26 @@
 set -e
 
 go run ${DATA_INGEST_SCRIPT_PATH} \
-  --server_address=${CONSUMER_ADDRESS} \
+  --server_address=${INGEST_SOCKET_PATH} \
   --capture=${PUSH_CAPTURE_NAME} \
   --binding_num=${BINDING_NUM_SIMPLE} \
   --data_file_path=${DATASET_SIMPLE}
 
 go run ${DATA_INGEST_SCRIPT_PATH} \
-  --server_address=${CONSUMER_ADDRESS} \
+  --server_address=${INGEST_SOCKET_PATH} \
   --capture=${PUSH_CAPTURE_NAME} \
   --binding_num=${BINDING_NUM_DUPLICATED_KEYS} \
   --data_file_path=${DATASET_DUPLICATED_KEYS}
 
 # Ingest twice to ensure we see multiple capture transactions.
 go run ${DATA_INGEST_SCRIPT_PATH} \
-  --server_address=${CONSUMER_ADDRESS} \
+  --server_address=${INGEST_SOCKET_PATH} \
   --capture=${PUSH_CAPTURE_NAME} \
   --binding_num=${BINDING_NUM_DUPLICATED_KEYS} \
   --data_file_path=${DATASET_DUPLICATED_KEYS}
 
 go run ${DATA_INGEST_SCRIPT_PATH} \
-  --server_address=${CONSUMER_ADDRESS} \
+  --server_address=${INGEST_SOCKET_PATH} \
   --capture=${PUSH_CAPTURE_NAME} \
   --binding_num=${BINDING_NUM_MULTIPLE_DATATYPES} \
   --data_file_path=${DATASET_MULTIPLE_DATATYPES}

--- a/tests/materialize/materialize-s3-parquet/ingest-data.sh
+++ b/tests/materialize/materialize-s3-parquet/ingest-data.sh
@@ -3,13 +3,13 @@ set -e
 
 # Pushing data to the capture.
 go run ${DATA_INGEST_SCRIPT_PATH} \
-  --server_address=${CONSUMER_ADDRESS} \
+  --server_address=${INGEST_SOCKET_PATH} \
   --capture=${PUSH_CAPTURE_NAME} \
   --binding_num=${BINDING_NUM_SIMPLE} \
   --data_file_path=${DATASET_SIMPLE}
 
 go run ${DATA_INGEST_SCRIPT_PATH} \
-  --server_address=${CONSUMER_ADDRESS} \
+  --server_address=${INGEST_SOCKET_PATH} \
   --capture=${PUSH_CAPTURE_NAME} \
   --binding_num=${BINDING_NUM_MULTIPLE_DATATYPES} \
   --data_file_path=${DATASET_MULTIPLE_DATATYPES}
@@ -18,7 +18,7 @@ go run ${DATA_INGEST_SCRIPT_PATH} \
 # Following data will be stored in a new local file.
 sleep 5
 go run ${DATA_INGEST_SCRIPT_PATH} \
-  --server_address=${CONSUMER_ADDRESS} \
+  --server_address=${INGEST_SOCKET_PATH} \
   --capture=${PUSH_CAPTURE_NAME} \
   --binding_num=${BINDING_NUM_SIMPLE} \
   --data_file_path=${DATASET_SIMPLE}

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -10,6 +10,8 @@
 # -m turns on job management, required for our use of `fg` below.
 set -em
 
+command -v flowctl-admin >/dev/null 2>&1 || { echo >&2 "flowctl-admin must be available via PATH, aborting."; exit 1; }
+
 ROOT_DIR="$(git rev-parse --show-toplevel)"
 cd "$ROOT_DIR"
 
@@ -49,16 +51,12 @@ export TESTDIR=$(realpath ${TESTDIR})
 export BROKER_ADDRESS=unix://localhost${TESTDIR}/gazette.sock
 export CONSUMER_ADDRESS=unix://localhost${TESTDIR}/consumer.sock
 
-# Always use the latest development package to verify the mutual integration
-# of connectors and the Flow runtime.
-curl -L --proto '=https' --tlsv1.2 -sSf "https://github.com/estuary/flow/releases/download/dev/flow-x86-linux.tar.gz" | tar -zx -C ${TESTDIR}
-
 # Start an empty local data plane within our TESTDIR as a background job.
 # --poll so that connectors are polled rather than continuously tailed.
 # --sigterm to verify we cleanly tear down the test catalog (otherwise it hangs).
 # --tempdir to use our known TESTDIR rather than creating a new temporary directory.
 # --unix-sockets to create UDS socket files in TESTDIR in well-known locations.
-${TESTDIR}/flowctl-admin temp-data-plane \
+flowctl-admin temp-data-plane \
     --log.level info \
     --network=host \
     --poll \
@@ -92,7 +90,7 @@ trap "kill -s SIGTERM ${DATA_PLANE_PID} && wait ${DATA_PLANE_PID} && ./tests/${C
 export ID_TYPE="${ID_TYPE:-integer}"
 
 # Verify discover works
-${TESTDIR}/flowctl-admin api discover --image="${CONNECTOR_IMAGE}" --network=host --log.level=debug --config=<(echo ${CONNECTOR_CONFIG}) > ${TESTDIR}/discover_output.json || bail "Discover failed."
+flowctl-admin api discover --image="${CONNECTOR_IMAGE}" --network=host --log.level=debug --config=<(echo ${CONNECTOR_CONFIG}) > ${TESTDIR}/discover_output.json || bail "Discover failed."
 cat ${TESTDIR}/discover_output.json | jq ".bindings[] | select(.recommendedName == \"${TEST_STREAM}\") | .documentSchema" > ${TESTDIR}/bindings.json
 
 if [[ -f "tests/${CONNECTOR}/bindings.json" ]]; then
@@ -103,16 +101,16 @@ fi
 cat tests/template.flow.yaml | envsubst > "${CATALOG_SOURCE}"
 
 # Build the catalog.
-${TESTDIR}/flowctl-admin api build --directory ${TESTDIR}/builds --build-id test-build-id --source ${CATALOG_SOURCE} --ts-package --network=host || bail "Build failed."
+flowctl-admin api build --directory ${TESTDIR}/builds --build-id test-build-id --source ${CATALOG_SOURCE} --ts-package --network=host || bail "Build failed."
 
 # Activate the catalog.
-${TESTDIR}/flowctl-admin api activate --build-id test-build-id --all --network=host --log.level info || bail "Activate failed."
+flowctl-admin api activate --build-id test-build-id --all --network=host --log.level info || bail "Activate failed."
 # Wait for a data-flow pass to finish.
-${TESTDIR}/flowctl-admin api await --build-id test-build-id --log.level info || bail "Await failed."
+flowctl-admin api await --build-id test-build-id --log.level info || bail "Await failed."
 # Read out materialization results.
 sqlite3 -header "${OUTPUT_DB}" "select id, canary from test_results;" > "${ACTUAL}"
 # Clean up the activated catalog.
-${TESTDIR}/flowctl-admin api delete --build-id test-build-id --all --log.level info || bail "Delete failed."
+flowctl-admin api delete --build-id test-build-id --all --log.level info || bail "Delete failed."
 
 # Verify actual vs expected results. `diff` will exit 1 if files are different
 diff --suppress-common-lines --side-by-side "${ACTUAL}" "tests/${CONNECTOR}/expected.txt" || bail "Test Failed"


### PR DESCRIPTION
**Description:**

Some adjustments to the end-to-end tests that allow them to more easily be run on non-linux systems (mac):
- Instead of the test script itself specifically downloading `flow` binaries, the test environment must make them available on `$PATH`. As long as the runner has `flowctl-admin` via `$PATH`, the tests can be run.
- The materialization tests were adjusted to use the `flow` binaries directly instead of running the temp data plane inside of container. This seemed to make things much simpler, and is consistent with how the capture tests run. I'm not 100% sure that the tests couldn't be run on mac with this docker container strategy, but I found it much easier to just run the binaries directly.

**Workflow steps:**

These tests should now be runnable on linux and mac, by invoking the test scripts with the appropriate environment variables.

**Documentation links affected:**

N/A

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/365)
<!-- Reviewable:end -->
