### PR TITLE
source-s3: fix bucket cleanup

### DIFF
--- a/tests/source-s3/cleanup.sh
+++ b/tests/source-s3/cleanup.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-if [[ -n "$TEST_BUCKET" ]]; then
-    echo "Cleaning up bucket: '$TEST_BUCKET'"
-    aws s3 rb "s3://${TEST_BUCKET}" --force
+if [[ -n "$TEST_STREAM" ]]; then
+    echo "Cleaning up bucket: '$TEST_STREAM'"
+    aws s3 rb "s3://${TEST_STREAM}" --force
 fi
 


### PR DESCRIPTION
Simple change to use the correct exported variable for the source-s3 end-to-end test bucket name, so that it gets correctly cleaned up.

**Description:**

(Describe the high level scope of new or changed features)

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/366)
<!-- Reviewable:end -->
