### PR TITLE
schema-gen: use integers for ordering values

### DIFF
--- a/go-schema-gen/.snapshots/TestGenerateSchema
+++ b/go-schema-gen/.snapshots/TestGenerateSchema
@@ -1,0 +1,45 @@
+{
+  "$schema": "http://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/estuary/connectors/go-schema-gen/test-config",
+  "properties": {
+    "password": {
+      "type": "string",
+      "title": "Password",
+      "description": "Secret password.",
+      "order": 1,
+      "secret": true
+    },
+    "username": {
+      "type": "string",
+      "title": "Username",
+      "description": "Test user.",
+      "order": 0
+    },
+    "advanced": {
+      "properties": {
+        "long_advanced": {
+          "type": "string",
+          "title": "Example",
+          "description": "Some long description.",
+          "multiline": true
+        },
+        "secret_advanced": {
+          "type": "string",
+          "title": "Secret Advanced",
+          "description": "Some secret advanced config with ordering.",
+          "order": 0,
+          "secret": true
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "advanced": true
+    }
+  },
+  "type": "object",
+  "required": [
+    "password",
+    "username"
+  ],
+  "title": "Test Schema"
+}

--- a/go-schema-gen/generate.go
+++ b/go-schema-gen/generate.go
@@ -2,6 +2,7 @@ package schemagen
 
 import (
 	"reflect"
+	"strconv"
 
 	"github.com/invopop/jsonschema"
 )
@@ -23,28 +24,60 @@ func GenerateSchema(title string, configObject interface{}) *jsonschema.Schema {
 	schema.AdditionalProperties = nil // Unset means additional properties are permitted on the root object, as they should be
 	schema.Definitions = nil          // Since no references are used, these definitions are just noise
 	schema.Title = title
-	fixSchemaFlagBools(schema, "secret", "advanced", "multiline")
+	walkSchema(
+		schema,
+		fixSchemaFlagBools(schema, "secret", "advanced", "multiline"),
+		fixSchemaOrderingStrings,
+	)
+
 	return schema
 }
 
-func fixSchemaFlagBools(t *jsonschema.Schema, flagKeys ...string) {
-	if t.Properties != nil {
-		for _, key := range t.Properties.Keys() {
-			if p, ok := t.Properties.Get(key); ok {
+// walkSchema invokes visit on every property of the root schema, and then traverses each of these
+// sub-schemas recursively. The visit function should modify the provided schema in-place to
+// accomplish the desired transformation.
+func walkSchema(root *jsonschema.Schema, visits ...func(t *jsonschema.Schema)) {
+	if root.Properties != nil {
+		for _, key := range root.Properties.Keys() {
+			if p, ok := root.Properties.Get(key); ok {
 				if p, ok := p.(*jsonschema.Schema); ok {
-					fixSchemaFlagBools(p, flagKeys...)
+					for _, visit := range visits {
+						visit(p)
+					}
+
+					walkSchema(p, visits...)
 				}
 			}
 		}
 	}
+}
+
+func fixSchemaFlagBools(t *jsonschema.Schema, flagKeys ...string) func(t *jsonschema.Schema) {
+	return func(t *jsonschema.Schema) {
+		for key, val := range t.Extras {
+			for _, flag := range flagKeys {
+				if key != flag {
+					continue
+				} else if val == "true" {
+					t.Extras[key] = true
+				} else if val == "false" {
+					t.Extras[key] = false
+				}
+			}
+		}
+	}
+}
+
+func fixSchemaOrderingStrings(t *jsonschema.Schema) {
 	for key, val := range t.Extras {
-		for _, flag := range flagKeys {
-			if key != flag {
-				continue
-			} else if val == "true" {
-				t.Extras[key] = true
-			} else if val == "false" {
-				t.Extras[key] = false
+		if key == "order" {
+			if str, ok := val.(string); ok {
+				converted, err := strconv.Atoi(str)
+				if err != nil {
+					// Don't try to convert strings that don't look like integers.
+					continue
+				}
+				t.Extras[key] = converted
 			}
 		}
 	}

--- a/go-schema-gen/generate_test.go
+++ b/go-schema-gen/generate_test.go
@@ -1,0 +1,25 @@
+package schemagen
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/bradleyjkemp/cupaloy"
+	"github.com/stretchr/testify/require"
+)
+
+type testConfig struct {
+	Password string `json:"password" jsonschema:"title=Password,description=Secret password." jsonschema_extras:"secret=true,order=1"`
+	Username string `json:"username" jsonschema:"title=Username,description=Test user." jsonschema_extras:"order=0"`
+	Advanced struct {
+		LongAdvanced          string `json:"long_advanced,omitempty" jsonschema:"title=Example,description=Some long description." jsonschema_extras:"multiline=true"`
+		SecretOrderedAdvanced string `json:"secret_advanced,omitempty" jsonschema:"title=Secret Advanced,description=Some secret advanced config with ordering." jsonschema_extras:"secret=true,order=0"`
+	} `json:"advanced,omitempty" jsonschema_extras:"advanced=true"`
+}
+
+func TestGenerateSchema(t *testing.T) {
+	got := GenerateSchema("Test Schema", testConfig{})
+	formatted, err := json.MarshalIndent(got, "", "  ")
+	require.NoError(t, err)
+	cupaloy.SnapshotT(t, formatted)
+}


### PR DESCRIPTION
**Description:**

This will map our generated schema to use integer types for "order" fields. It is necessary because of the handling of "order" fields in flow: https://github.com/estuary/flow/blob/b2f26e1435f37a1cb7d71055381a1f8faf4d0940/crates/doc/src/annotation.rs#L65-L68

As part of merging this, I will also update the mirrored code in the flow repository: https://github.com/estuary/flow/blob/master/go/protocols/materialize/go-schema-gen/generate.go

**Workflow steps:**

`jsonschema_extras` can include values like `order=0` and have the generated schema correctly represent the order value as an integer.

**Documentation links affected:**

N/A

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/370)
<!-- Reviewable:end -->
