### PR TITLE
go.mod: bump flow pin

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/bradleyjkemp/cupaloy v2.3.0+incompatible
 	github.com/brianvoe/gofakeit/v6 v6.16.0
 	github.com/elastic/go-elasticsearch/v7 v7.17.1
-	github.com/estuary/flow v0.1.1-0.20220907213741-76a5db8f40a4
+	github.com/estuary/flow v0.1.5-0.20221007131251-5f24d1137ec0
 	github.com/evanphx/json-patch/v5 v5.6.0
 	github.com/go-mysql-org/go-mysql v1.5.0
 	github.com/gogo/protobuf v1.3.2

--- a/go.sum
+++ b/go.sum
@@ -355,6 +355,10 @@ github.com/envoyproxy/go-control-plane v0.10.2-0.20220325020618-49ff273808a1/go.
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/estuary/flow v0.1.1-0.20220907213741-76a5db8f40a4 h1:FGsChgGOi5lV8hT1L6/wdFeU1+I3DP3JNHdVp7FVjIU=
 github.com/estuary/flow v0.1.1-0.20220907213741-76a5db8f40a4/go.mod h1:dHlTdu5vRYgKgaqRZzjTWLqs7Z21xf41DvwEBlcD3KM=
+github.com/estuary/flow v0.1.5-0.20221007123219-9cea913c64cd h1:+4FZqQaHqoCq+EjC1lX0bwgWPKwkCYEbBudAoSX3Qu8=
+github.com/estuary/flow v0.1.5-0.20221007123219-9cea913c64cd/go.mod h1:dHlTdu5vRYgKgaqRZzjTWLqs7Z21xf41DvwEBlcD3KM=
+github.com/estuary/flow v0.1.5-0.20221007131251-5f24d1137ec0 h1:TST2UUylfokVB+4y3qh0rAPv473JdWBQj5SHtfYZklI=
+github.com/estuary/flow v0.1.5-0.20221007131251-5f24d1137ec0/go.mod h1:dHlTdu5vRYgKgaqRZzjTWLqs7Z21xf41DvwEBlcD3KM=
 github.com/evanphx/json-patch v4.2.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/evanphx/json-patch v4.9.0+incompatible h1:kLcOMZeuLAJvL2BPWLMIj5oaZQobrkAqrL+WFZwQses=
 github.com/evanphx/json-patch v4.9.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=

--- a/materialize-rockset/driver_test.go
+++ b/materialize-rockset/driver_test.go
@@ -72,7 +72,7 @@ func TestRocksetDriverValidate(t *testing.T) {
 		{
 			Ptr:            "/id",
 			Field:          "id",
-			UserProvided:   true,
+			Explicit:       true,
 			IsPartitionKey: true,
 			IsPrimaryKey:   true,
 			Inference:      pf.Inference{Types: []string{"string"}},
@@ -80,7 +80,7 @@ func TestRocksetDriverValidate(t *testing.T) {
 		{
 			Ptr:            "/foo",
 			Field:          "foo",
-			UserProvided:   true,
+			Explicit:       true,
 			IsPartitionKey: true,
 			IsPrimaryKey:   true,
 			Inference:      pf.Inference{Types: []string{"object"}},
@@ -153,7 +153,7 @@ func TestRocksetDriverApply(t *testing.T) {
 		{
 			Ptr:            "/id",
 			Field:          "id",
-			UserProvided:   true,
+			Explicit:       true,
 			IsPartitionKey: true,
 			IsPrimaryKey:   true,
 			Inference:      pf.Inference{},

--- a/materialize-sql/type_mapping.go
+++ b/materialize-sql/type_mapping.go
@@ -45,7 +45,7 @@ func BuildProjections(spec *pf.MaterializationSpec_Binding) (keys, values []Proj
 		}
 
 		var source = "auto-generated"
-		if p.UserProvided {
+		if p.Explicit {
 			source = "user-provided"
 		}
 		p.Comment = fmt.Sprintf("%s projection of JSON at: %s with inferred types: %s",


### PR DESCRIPTION
Updates the pin for flow. One item of note is that the protocol field "user_provided" was renamed to "explicit" in https://github.com/estuary/flow/pull/672.

**Description:**

(Describe the high level scope of new or changed features)

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/371)
<!-- Reviewable:end -->
