### PR TITLE
source-firestore: Logging tweaks

### DIFF
--- a/schema_inference/inference.go
+++ b/schema_inference/inference.go
@@ -51,7 +51,7 @@ func Run(ctx context.Context, logEntry *log.Entry, docsCh <-chan Document) (Sche
 				return fmt.Errorf("failed to encode document: %w", err)
 			}
 		}
-		logEntry.WithField("count", count).Info("runInference: Done sending documents")
+		logEntry.WithField("count", count).Debug("runInference: Done sending documents")
 
 		return nil
 	})
@@ -67,7 +67,7 @@ func Run(ctx context.Context, logEntry *log.Entry, docsCh <-chan Document) (Sche
 		return nil
 	})
 
-	logEntry.Info("runInference: launching")
+	logEntry.Debug("runInference: launching")
 	err = cmd.Start()
 	if err != nil {
 		return nil, fmt.Errorf("failed to run flow-schema-inference: %w", err)

--- a/source-firestore/discovery.go
+++ b/source-firestore/discovery.go
@@ -114,6 +114,7 @@ func (driver) Discover(ctx context.Context, req *pc.DiscoverRequest) (*pc.Discov
 	if err != nil {
 		return nil, fmt.Errorf("discovery error: %w", err)
 	}
+	log.WithField("collections", len(bindings)).Info("discovery complete")
 	return &pc.DiscoverResponse{
 		Bindings: bindings,
 	}, nil
@@ -172,7 +173,7 @@ func (ds *discoveryState) processCollection(ctx context.Context, coll *firestore
 	ds.shared.Lock()
 	defer ds.shared.Unlock()
 	if _, ok := ds.shared.groups[coll.ID]; !ok {
-		log.WithField("group", coll.ID).Info("discovered new collection group")
+		log.WithField("group", coll.ID).Debug("discovered new collection group")
 		ds.shared.groups[coll.ID] = struct{}{}
 		ds.workers.Go(func() error {
 			var err = ds.discoverCollectionGroup(ctx, coll.ID)
@@ -197,10 +198,10 @@ func (ds *discoveryState) processCollection(ctx context.Context, coll *firestore
 // by groups rather than individual collections massively improves discovery speed.
 func (ds *discoveryState) discoverCollectionGroup(ctx context.Context, group string) error {
 	var logEntry = log.WithField("group", group)
-	logEntry.Info("scanning collection group")
+	logEntry.Debug("scanning collection group")
 
 	defer func() {
-		logEntry.Info("finished scanning group")
+		logEntry.Debug("finished scanning group")
 		ds.closeInferenceGroup(group)
 	}()
 


### PR DESCRIPTION
**Description:**

Downgrades several spammy `INFO` level logs during discovery to `DEBUG` level, including the ones that come from the schema inference package.

Also adds a new `INFO` level message at the end of discovery to positively confirm when it terminates successfully.

**Workflow steps:**

Nothing changes, except that in the case of failures we might actually get to see the error.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/373)
<!-- Reviewable:end -->
