### PR TITLE
source-firestore: Retry temporary failures during discovery

### DIFF
--- a/source-firestore/helpers.go
+++ b/source-firestore/helpers.go
@@ -3,6 +3,9 @@ package main
 import (
 	"fmt"
 	"strings"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 type collectionGroupID = string
@@ -51,4 +54,13 @@ func collectionToResourcePath(collection string) resourcePath {
 //	=> "users/*/messages"
 func documentToResourcePath(documentPath string) resourcePath {
 	return collectionToResourcePath(documentPath)
+}
+
+func retryableStatus(err error) bool {
+	var code = status.Code(err)
+	return code == codes.Unknown ||
+		code == codes.DeadlineExceeded ||
+		code == codes.ResourceExhausted ||
+		code == codes.Internal ||
+		code == codes.Unavailable
 }


### PR DESCRIPTION
**Description:**

This adds a check for "retryable" status code errors when discovery fetches documents from Firestore, and retries them using a very simple exponential-backoff+jitter strategy up to a maximum of 5 retries. Hopefully this makes discovery a lot more robust.

This **doesn't** add retrying to the subcollection-checking part of discovery, or to the actual pull operation, but I expect to add at least the pull RPC retries in the near future.

Also I haven't tested the new backoff code to make sure it works as intended, although I have run the existing test suite and verified that it doesn't obviously break things.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/374)
<!-- Reviewable:end -->
