### PR TITLE
source-firestore: Increase discovery retries from 5 to 9

### DIFF
--- a/source-firestore/discovery.go
+++ b/source-firestore/discovery.go
@@ -216,9 +216,9 @@ func (ds *discoveryState) discoverCollectionGroup(ctx context.Context, group str
 		if err == iterator.Done {
 			break
 		} else if err != nil && retryableStatus(err) {
-			// Exponential backoff: 100ms, 200ms, 400ms, 800ms, 1.6s plus [0,100ms) jitter
+			// Exponential backoff: 100ms, 200ms, 400ms, 800ms, 1.6s, ..., 25.6s plus [0,100ms) jitter
 			retries++
-			if retryLimit := 5; retries >= retryLimit {
+			if retryLimit := 9; retries >= retryLimit {
 				return fmt.Errorf("error fetching documents from group %q: retry limit (%d) reached: %w", group, retryLimit, err)
 			}
 			time.Sleep(time.Duration((1<<retries)*50+rand.Intn(100)) * time.Millisecond)


### PR DESCRIPTION
Adding a bit of retry logic seemed to help a little, but we're still seeing discovery fail half the time. The maximum backoff after 5 retries was only 1.6s though, so let's try just making the number bigger.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/375)
<!-- Reviewable:end -->
