### PR TITLE
source-firestore: Translate NaNs to the string "NaN"

### DIFF
--- a/source-firestore/pull.go
+++ b/source-firestore/pull.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math"
 	"sync"
 	"time"
 
@@ -577,6 +578,9 @@ func translateValue(val *firestore_pb.Value) (interface{}, error) {
 	case *firestore_pb.Value_IntegerValue:
 		return val.IntegerValue, nil
 	case *firestore_pb.Value_DoubleValue:
+		if math.IsNaN(val.DoubleValue) {
+			return "NaN", nil
+		}
 		return val.DoubleValue, nil
 	case *firestore_pb.Value_TimestampValue:
 		return val.TimestampValue.AsTime(), nil


### PR DESCRIPTION
**Description:**

The Firestore data model is not quite JSON (for instance it has distinct types for timestamps, document references, and lat/long points), so we already do some conversion before serializing to JSON for output.

It turns out there's another subtle difference: Firestore documents can contain NaN floats, but NaN isn't a valid JSON value. In order to avoid losing data we just convert it into the string `"NaN"` instead.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/379)
<!-- Reviewable:end -->
