### PR TITLE
materialize-postgres: use standalone network-tunnel

### DIFF
--- a/materialize-postgres/.snapshots/TestSpecification
+++ b/materialize-postgres/.snapshots/TestSpecification
@@ -27,6 +27,37 @@
         "title": "Database",
         "description": "Name of the logical database to materialize to.",
         "order": 3
+      },
+      "networkTunnel": {
+        "properties": {
+          "sshForwarding": {
+            "properties": {
+              "sshEndpoint": {
+                "type": "string",
+                "title": "SSH Endpoint",
+                "description": "Endpoint of the remote SSH server that supports tunneling"
+              },
+              "privateKey": {
+                "type": "string",
+                "title": "SSH Private Key",
+                "description": "Private key to connect to the remote SSH server.",
+                "multiline": true,
+                "secret": true
+              }
+            },
+            "additionalProperties": false,
+            "type": "object",
+            "required": [
+              "sshEndpoint",
+              "privateKey"
+            ],
+            "title": "SSH Forwarding"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "title": "Network Tunnel",
+        "description": "Connect to your system through an SSH server that acts as a bastion host for your network."
       }
     },
     "type": "object",

--- a/materialize-postgres/Dockerfile
+++ b/materialize-postgres/Dockerfile
@@ -18,6 +18,7 @@ RUN curl -L --proto '=https' --tlsv1.2 -sSf "https://github.com/estuary/flow/rel
 COPY materialize-boilerplate ./materialize-boilerplate
 COPY materialize-postgres    ./materialize-postgres
 COPY testsupport             ./testsupport
+COPY go-network-tunnel       ./go-network-tunnel
 
 # Test and build the connector.
 RUN go test  -tags nozstd -v ./materialize-postgres/...
@@ -31,6 +32,7 @@ WORKDIR /connector
 ENV PATH="/connector:$PATH"
 
 COPY --from=builder /builder/connector ./connector
+COPY --from=ghcr.io/estuary/network-tunnel:dev /flow-network-tunnel /usr/bin/flow-network-tunnel
 
 # Avoid running the connector as root.
 USER nonroot:nonroot

--- a/materialize-postgres/driver.go
+++ b/materialize-postgres/driver.go
@@ -5,9 +5,11 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"net"
 	"net/url"
 	"strings"
 
+	networkTunnel "github.com/estuary/connectors/go-network-tunnel"
 	boilerplate "github.com/estuary/connectors/materialize-boilerplate"
 	pf "github.com/estuary/flow/go/protocols/flow"
 	pm "github.com/estuary/flow/go/protocols/materialize"
@@ -18,6 +20,15 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
+type sshForwarding struct {
+	SshEndpoint string `json:"sshEndpoint" jsonschema:"title=SSH Endpoint,description=Endpoint of the remote SSH server that supports tunneling, in the form of ssh://user@hostname[:port]"`
+	PrivateKey  string `json:"privateKey" jsonschema:"title=SSH Private Key,description=Private key to connect to the remote SSH server." jsonschema_extras:"secret=true,multiline=true"`
+}
+
+type tunnelConfig struct {
+	SshForwarding *sshForwarding `json:"sshForwarding,omitempty" jsonschema:"title=SSH Forwarding"`
+}
+
 // config represents the endpoint configuration for postgres.
 // It must match the one defined for the source specs (flow.yaml) in Rust.
 type config struct {
@@ -25,6 +36,8 @@ type config struct {
 	User     string `json:"user" jsonschema:"title=User,description=Database user to connect as." jsonschema_extras:"order=1"`
 	Password string `json:"password" jsonschema:"title=Password,description=Password for the specified database user." jsonschema_extras:"secret=true,order=2"`
 	Database string `json:"database,omitempty" jsonschema:"title=Database,description=Name of the logical database to materialize to." jsonschema_extras:"order=3"`
+
+	NetworkTunnel *tunnelConfig `json:"networkTunnel,omitempty" jsonschema:"title=Network Tunnel,description=Connect to your system through an SSH server that acts as a bastion host for your network."`
 }
 
 // Validate the configuration.
@@ -45,6 +58,11 @@ func (c *config) Validate() error {
 // ToURI converts the Config to a DSN string.
 func (c *config) ToURI() string {
 	var address = c.Address
+	// If SSH Tunnel is configured, we are going to create a tunnel from localhost:5432
+	// to address through the bastion server, so we use the tunnel's address
+	if c.NetworkTunnel != nil && c.NetworkTunnel.SshForwarding != nil && c.NetworkTunnel.SshForwarding.SshEndpoint != "" {
+		address = "localhost:5432"
+	}
 	var uri = url.URL{
 		Scheme: "postgres",
 		Host:   address,
@@ -83,22 +101,47 @@ func newPostgresDriver() pm.DriverServer {
 		ResourceSpecType: new(tableConfig),
 		NewResource:      func(sqlDriver.Endpoint) sqlDriver.Resource { return new(tableConfig) },
 		NewEndpoint: func(ctx context.Context, raw json.RawMessage) (sqlDriver.Endpoint, error) {
-			var parsed = new(config)
-			if err := pf.UnmarshalStrict(raw, parsed); err != nil {
+			var cfg = new(config)
+			if err := pf.UnmarshalStrict(raw, cfg); err != nil {
 				return nil, fmt.Errorf("parsing Postgresql configuration: %w", err)
 			}
 
 			log.WithFields(log.Fields{
-				"database": parsed.Database,
-				"address":  parsed.Address,
-				"user":     parsed.User,
+				"database": cfg.Database,
+				"address":  cfg.Address,
+				"user":     cfg.User,
 			}).Info("opening database")
 
-			db, err := sql.Open("pgx", parsed.ToURI())
+			// If SSH Endpoint is configured, then try to start a tunnel before establishing connections
+			if cfg.NetworkTunnel != nil && cfg.NetworkTunnel.SshForwarding != nil && cfg.NetworkTunnel.SshForwarding.SshEndpoint != "" {
+				host, port, err := net.SplitHostPort(cfg.Address)
+				if err != nil {
+					return nil, fmt.Errorf("splitting address to host and port: %w", err)
+				}
+
+				var sshConfig = &networkTunnel.SshConfig{
+					SshEndpoint: cfg.NetworkTunnel.SshForwarding.SshEndpoint,
+					PrivateKey:  []byte(cfg.NetworkTunnel.SshForwarding.PrivateKey),
+					ForwardHost: host,
+					ForwardPort: port,
+					LocalPort:   "5432",
+				}
+				var tunnel = sshConfig.CreateTunnel()
+
+				// FIXME/question: do we need to shut down the tunnel manually if it is a child process?
+				// at the moment tunnel.Stop is not being called anywhere, but if the connector shuts down, the child process also shuts down.
+				err = tunnel.Start()
+
+				if err != nil {
+					log.WithField("error", err).Error("network tunnel error")
+				}
+			}
+
+			db, err := sql.Open("pgx", cfg.ToURI())
 			if err != nil {
 				return nil, fmt.Errorf("opening Postgres database: %w", err)
 			}
-			return sqlDriver.NewStdEndpoint(parsed, db, PostgresSQLGenerator(), sqlDriver.DefaultFlowTables("")), nil
+			return sqlDriver.NewStdEndpoint(cfg, db, PostgresSQLGenerator(), sqlDriver.DefaultFlowTables("")), nil
 		},
 		NewTransactor: func(
 			ctx context.Context,
@@ -160,6 +203,8 @@ type transactor struct {
 		fence *sqlDriver.StdFence
 	}
 	bindings []*binding
+
+	tunnel networkTunnel.SshTunnel
 }
 
 type binding struct {


### PR DESCRIPTION
**Description:**

- Add standalone network-tunnel to `materialize-postgres`

**Workflow steps:**

```
address: "999.290.265.259:5432"
database: "postgres"
networkTunnel:
  sshForwarding:
    privateKey: <YOUR KEY>
    sshEndpoint: "ssh://user@endpoint"
password: "password"
user: "postgres"
```

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/383)
<!-- Reviewable:end -->
