### PR TITLE
{source,materialize}-boilerplate: Support log.level and log.format

### DIFF
--- a/materialize-boilerplate/boilerplate.go
+++ b/materialize-boilerplate/boilerplate.go
@@ -19,22 +19,18 @@ import (
 	"google.golang.org/grpc/metadata"
 )
 
-// TODO: handle the logger properly by setting the log level on logrus
-type Options struct {
-	LogLevel string `long:"log.level" description:"Log level, one of: error, warn, info, debug, trace" default:"info"`
-}
-
 // RunMain is the boilerplate main function of a materialization connector.
 func RunMain(srv pm.DriverServer) {
-	var opts = &Options{""}
-	var parser = flags.NewParser(opts, flags.Default)
+	var logConfig = &logConfig{}
+	var parser = flags.NewParser(logConfig, flags.Default)
 	var ctx, _ = signal.NotifyContext(context.Background(), syscall.SIGTERM, syscall.SIGINT)
 
 	var cmd = cmdCommon{
-		ctx: ctx,
-		srv: srv,
-		r:   bufio.NewReaderSize(os.Stdin, 1<<21), // 2MB buffer.
-		w:   protoio.NewUint32DelimitedWriter(os.Stdout, binary.LittleEndian),
+		ctx:     ctx,
+		srv:     srv,
+		r:       bufio.NewReaderSize(os.Stdin, 1<<21), // 2MB buffer.
+		w:       protoio.NewUint32DelimitedWriter(os.Stdout, binary.LittleEndian),
+		logging: logConfig,
 	}
 
 	parser.AddCommand("spec", "Write the connector specification",
@@ -59,6 +55,30 @@ type cmdCommon struct {
 	srv pm.DriverServer
 	r   *bufio.Reader
 	w   protoio.Writer
+
+	logging *logConfig
+}
+
+// logConfig configures handling of application log events.
+type logConfig struct {
+	Level  string `long:"log.level" env:"LOG_LEVEL" default:"info" choice:"info" choice:"INFO" choice:"debug" choice:"DEBUG" choice:"warn" choice:"WARN" description:"Logging level"`
+	Format string `long:"log.format" env:"LOG_FORMAT" default:"text" choice:"json" choice:"text" choice:"color" description:"Logging output format"`
+}
+
+func (c *logConfig) Configure() {
+	if c.Format == "json" {
+		logrus.SetFormatter(&logrus.JSONFormatter{})
+	} else if c.Format == "text" {
+		logrus.SetFormatter(&logrus.TextFormatter{})
+	} else if c.Format == "color" {
+		logrus.SetFormatter(&logrus.TextFormatter{ForceColors: true})
+	}
+
+	if lvl, err := logrus.ParseLevel(c.Level); err != nil {
+		logrus.WithField("err", err).Fatal("unrecognized log level")
+	} else {
+		logrus.SetLevel(lvl)
+	}
 }
 
 type protoValidator interface {
@@ -129,7 +149,10 @@ type applyDeleteCmd struct{ cmdCommon }
 type transactionsCmd struct{ cmdCommon }
 
 func (c specCmd) Execute(args []string) error {
+	c.cmdCommon.logging.Configure()
+
 	var req pm.SpecRequest
+	logrus.Debug("executing Spec subcommand")
 
 	if err := c.readMsg(&req); err != nil {
 		return fmt.Errorf("reading request: %w", err)
@@ -142,7 +165,10 @@ func (c specCmd) Execute(args []string) error {
 }
 
 func (c validateCmd) Execute(args []string) error {
+	c.cmdCommon.logging.Configure()
+
 	var req pm.ValidateRequest
+	logrus.Debug("executing Validate subcommand")
 
 	if err := c.readMsg(&req); err != nil {
 		return fmt.Errorf("reading request: %w", err)
@@ -155,7 +181,10 @@ func (c validateCmd) Execute(args []string) error {
 }
 
 func (c applyUpsertCmd) Execute(args []string) error {
+	c.cmdCommon.logging.Configure()
+
 	var req pm.ApplyRequest
+	logrus.Debug("executing ApplyUpsert subcommand")
 
 	if err := c.readMsg(&req); err != nil {
 		return fmt.Errorf("reading request: %w", err)
@@ -169,7 +198,10 @@ func (c applyUpsertCmd) Execute(args []string) error {
 }
 
 func (c applyDeleteCmd) Execute(args []string) error {
+	c.cmdCommon.logging.Configure()
+
 	var req pm.ApplyRequest
+	logrus.Debug("executing ApplyDelete subcommand")
 
 	if err := c.readMsg(&req); err != nil {
 		return fmt.Errorf("reading request: %w", err)
@@ -193,6 +225,9 @@ func (c applyDeleteCmd) Execute(args []string) error {
 }
 
 func (c transactionsCmd) Execute(args []string) error {
+	c.cmdCommon.logging.Configure()
+
+	logrus.Debug("executing Transactions subcommand")
 	return c.srv.Transactions(&txnAdapter{cmdCommon: c.cmdCommon})
 }
 

--- a/source-boilerplate/boilerplate.go
+++ b/source-boilerplate/boilerplate.go
@@ -20,8 +20,6 @@ import (
 	"google.golang.org/grpc/metadata"
 )
 
-const ListenTimeoutSeconds = 10
-
 // RunMain is the boilerplate main function of a capture connector.
 func RunMain(srv pc.DriverServer) {
 	var logConfig = &logConfig{}
@@ -29,10 +27,11 @@ func RunMain(srv pc.DriverServer) {
 	var ctx, _ = signal.NotifyContext(context.Background(), syscall.SIGTERM, syscall.SIGINT)
 
 	var cmd = cmdCommon{
-		ctx: ctx,
-		srv: srv,
-		r:   bufio.NewReaderSize(os.Stdin, 1<<21), // 2MB buffer.
-		w:   protoio.NewUint32DelimitedWriter(os.Stdout, binary.LittleEndian),
+		ctx:     ctx,
+		srv:     srv,
+		r:       bufio.NewReaderSize(os.Stdin, 1<<21), // 2MB buffer.
+		w:       protoio.NewUint32DelimitedWriter(os.Stdout, binary.LittleEndian),
+		logging: logConfig,
 	}
 
 	parser.AddCommand("spec", "Write the connector specification",
@@ -59,12 +58,30 @@ type cmdCommon struct {
 	srv pc.DriverServer
 	r   *bufio.Reader
 	w   protoio.Writer
+
+	logging *logConfig
 }
 
 // logConfig configures handling of application log events.
 type logConfig struct {
 	Level  string `long:"log.level" env:"LOG_LEVEL" default:"info" choice:"info" choice:"INFO" choice:"debug" choice:"DEBUG" choice:"warn" choice:"WARN" description:"Logging level"`
 	Format string `long:"log.format" env:"LOG_FORMAT" default:"text" choice:"json" choice:"text" choice:"color" description:"Logging output format"`
+}
+
+func (c *logConfig) Configure() {
+	if c.Format == "json" {
+		log.SetFormatter(&log.JSONFormatter{})
+	} else if c.Format == "text" {
+		log.SetFormatter(&log.TextFormatter{})
+	} else if c.Format == "color" {
+		log.SetFormatter(&log.TextFormatter{ForceColors: true})
+	}
+
+	if lvl, err := log.ParseLevel(c.Level); err != nil {
+		log.WithField("err", err).Fatal("unrecognized log level")
+	} else {
+		log.SetLevel(lvl)
+	}
 }
 
 type protoValidator interface {
@@ -136,6 +153,8 @@ type applyDeleteCmd struct{ cmdCommon }
 type pullCmd struct{ cmdCommon }
 
 func (c specCmd) Execute(args []string) error {
+	c.cmdCommon.logging.Configure()
+
 	var req pc.SpecRequest
 	log.Debug("executing Spec subcommand")
 
@@ -150,6 +169,8 @@ func (c specCmd) Execute(args []string) error {
 }
 
 func (c validateCmd) Execute(args []string) error {
+	c.cmdCommon.logging.Configure()
+
 	var req pc.ValidateRequest
 	log.Debug("executing Validate subcommand")
 
@@ -164,6 +185,8 @@ func (c validateCmd) Execute(args []string) error {
 }
 
 func (c discoverCmd) Execute(args []string) error {
+	c.cmdCommon.logging.Configure()
+
 	var req pc.DiscoverRequest
 	log.Debug("executing Discover subcommand")
 
@@ -178,7 +201,10 @@ func (c discoverCmd) Execute(args []string) error {
 }
 
 func (c applyUpsertCmd) Execute(args []string) error {
+	c.cmdCommon.logging.Configure()
+
 	var req pc.ApplyRequest
+	log.Debug("executing ApplyUpsert subcommand")
 
 	if err := c.readMsg(&req); err != nil {
 		return fmt.Errorf("reading request: %w", err)
@@ -192,7 +218,10 @@ func (c applyUpsertCmd) Execute(args []string) error {
 }
 
 func (c applyDeleteCmd) Execute(args []string) error {
+	c.cmdCommon.logging.Configure()
+
 	var req pc.ApplyRequest
+	log.Debug("executing ApplyDelete subcommand")
 
 	if err := c.readMsg(&req); err != nil {
 		return fmt.Errorf("reading request: %w", err)
@@ -210,6 +239,8 @@ func (c applyDeleteCmd) Execute(args []string) error {
 }
 
 func (c pullCmd) Execute(args []string) error {
+	c.cmdCommon.logging.Configure()
+
 	log.Debug("executing Pull subcommand")
 	return c.srv.Pull(&pullAdapter{cmdCommon: c.cmdCommon})
 }


### PR DESCRIPTION
**Description:**

This commit adds support for specifying log level and format in the same way as our Airbyte captures and various other portions of the Flow codebase work. This lack is currently breaking `source-firestore` after some of the recent "connect over TCP" and "don't put the connector proxy in the execution path" changes caused it to get run directly with a `--log.level` argument.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/388)
<!-- Reviewable:end -->
