### PR TITLE
materialize-s3-parquet: avoid index out of bound errors

### DIFF
--- a/materialize-s3-parquet/parquet_file_processor.go
+++ b/materialize-s3-parquet/parquet_file_processor.go
@@ -40,10 +40,13 @@ type FileProcessor interface {
 // FileProcessorProxy implements FileProcessor interface.
 // It proxies a file processor with the following additional logic:
 // a) It maintains a ticker, which triggers the Commit() command on the proxied file processor
-//      if no Commit call to the proxied file processor is observed over a given period of time.
-//      It makes sure that no local file remains in local without being uploaded to the cloud.
+//
+//	if no Commit call to the proxied file processor is observed over a given period of time.
+//	It makes sure that no local file remains in local without being uploaded to the cloud.
+//
 // b) It ensures the mutual exclusive access to the proxied file processor between the ticker
-//      and the transactor(via API calls to the proxy).
+//
+//	and the transactor(via API calls to the proxy).
 type FileProcessorProxy struct {
 	ctx context.Context
 
@@ -201,7 +204,7 @@ func NewParquetFileProcessor(
 		}
 
 		var nextSeqNum = 0
-		if nextSeqNumList != nil {
+		if nextSeqNumList != nil && len(nextSeqNumList) > i {
 			nextSeqNum = nextSeqNumList[i]
 		}
 


### PR DESCRIPTION
**Description:**

When a new binding is added to an already-running s3-parquet materialization, we may have cases where the checkpoint's `nextSeqNumList` is shorter than the binding list of the new RPCs. In these cases we can just set `nextSeqNumList` of these additional bindings to start at 0.

This is based on my understanding of [this comment](https://github.com/estuary/connectors/blob/main/materialize-s3-parquet/checkpoint/driver_checkpoint.go#L12-L16) about `NextSeqNumList`:

```
// The sequence number used to name the next files to be uploaded to the cloud.
// To be specific, the next parquet file from the i-th binding is named using the deterministic pattern of
// "<KeyBegin>_<KeyEnd>_<NextSeqNumList[i]>.parquet".
// The NextSeqNumList[i] is increased by 1 after each successful upload from the i-th binding.
NextSeqNumList []int `json:"nextSeqNumList"`
```

**Workflow steps:**

N/A

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/394)
<!-- Reviewable:end -->
