### PR TITLE
Revert TCP connectors back to stdio

### DIFF
--- a/materialize-bigquery/Dockerfile
+++ b/materialize-bigquery/Dockerfile
@@ -41,6 +41,5 @@ ENV PATH="/connector:$PATH"
 COPY --from=builder /builder/connector ./connector
 
 LABEL FLOW_RUNTIME_PROTOCOL=materialize
-LABEL FLOW_TCP_PORT=2222
 
 ENTRYPOINT ["/connector/connector"]

--- a/materialize-boilerplate/boilerplate.go
+++ b/materialize-boilerplate/boilerplate.go
@@ -7,11 +7,9 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"net"
 	"os"
 	"os/signal"
 	"syscall"
-	"time"
 
 	pm "github.com/estuary/flow/go/protocols/materialize"
 	protoio "github.com/gogo/protobuf/io"
@@ -26,34 +24,17 @@ type Options struct {
 	LogLevel string `long:"log.level" description:"Log level, one of: error, warn, info, debug, trace" default:"info"`
 }
 
-const ListenTimeoutSeconds = 10
-
 // RunMain is the boilerplate main function of a materialization connector.
 func RunMain(srv pm.DriverServer) {
 	var opts = &Options{""}
 	var parser = flags.NewParser(opts, flags.Default)
 	var ctx, _ = signal.NotifyContext(context.Background(), syscall.SIGTERM, syscall.SIGINT)
 
-	var conn net.Conn
-	server, err := net.ListenTCP("tcp", &net.TCPAddr{
-		IP:   net.IPv4(0, 0, 0, 0),
-		Port: 2222,
-	})
-	if err != nil {
-		logrus.WithFields(logrus.Fields{"error": err}).
-			Fatal("failed to start tcp server")
-	}
-	server.SetDeadline(time.Now().Add(ListenTimeoutSeconds * time.Second))
-	if conn, err = server.Accept(); err != nil {
-		logrus.WithFields(logrus.Fields{"error": err}).
-			Fatal("failed to accept connection on tcp server")
-	}
-
 	var cmd = cmdCommon{
 		ctx: ctx,
 		srv: srv,
-		r:   bufio.NewReaderSize(conn, 1<<21), // 2MB buffer.
-		w:   protoio.NewUint32DelimitedWriter(conn, binary.LittleEndian),
+		r:   bufio.NewReaderSize(os.Stdin, 1<<21), // 2MB buffer.
+		w:   protoio.NewUint32DelimitedWriter(os.Stdout, binary.LittleEndian),
 	}
 
 	parser.AddCommand("spec", "Write the connector specification",
@@ -67,8 +48,7 @@ func RunMain(srv pm.DriverServer) {
 	parser.AddCommand("transactions", "Run materialization transactions",
 		"Run a stream of transactions read from stdin", &transactionsCmd{cmd})
 
-	_, err = parser.Parse()
-	if err != nil {
+	if _, err := parser.Parse(); err != nil {
 		os.Exit(1)
 	}
 	os.Exit(0)

--- a/materialize-elasticsearch/Dockerfile
+++ b/materialize-elasticsearch/Dockerfile
@@ -41,6 +41,5 @@ COPY --from=builder /lib/x86_64-linux-gnu/libgcc_s.so.1 /lib/x86_64-linux-gnu/
 USER nonroot:nonroot
 
 LABEL FLOW_RUNTIME_PROTOCOL=materialize
-LABEL FLOW_TCP_PORT=2222
 
 ENTRYPOINT ["/connector/connector"]

--- a/materialize-firebolt/Dockerfile
+++ b/materialize-firebolt/Dockerfile
@@ -40,6 +40,5 @@ COPY --from=builder /lib/x86_64-linux-gnu/libgcc_s.so.1 /lib/x86_64-linux-gnu/
 USER nonroot:nonroot
 
 LABEL FLOW_RUNTIME_PROTOCOL=materialize
-LABEL FLOW_TCP_PORT=2222
 
 ENTRYPOINT ["/connector/connector"]

--- a/materialize-google-pubsub/Dockerfile
+++ b/materialize-google-pubsub/Dockerfile
@@ -35,6 +35,5 @@ COPY --from=builder /builder/connector /connector/
 USER nonroot:nonroot
 
 LABEL FLOW_RUNTIME_PROTOCOL=materialize
-LABEL FLOW_TCP_PORT=2222
 
 ENTRYPOINT ["/connector/connector"]

--- a/materialize-google-sheets/Dockerfile
+++ b/materialize-google-sheets/Dockerfile
@@ -39,6 +39,5 @@ COPY --from=builder /builder/connector ./connector
 USER nonroot:nonroot
 
 LABEL FLOW_RUNTIME_PROTOCOL=materialize
-LABEL FLOW_TCP_PORT=2222
 
 ENTRYPOINT ["/connector/connector"]

--- a/materialize-postgres-rc/Dockerfile
+++ b/materialize-postgres-rc/Dockerfile
@@ -40,6 +40,5 @@ COPY --from=ghcr.io/estuary/network-tunnel:dev /flow-network-tunnel /usr/bin/flo
 USER nonroot:nonroot
 
 LABEL FLOW_RUNTIME_PROTOCOL=materialize
-LABEL FLOW_TCP_PORT=2222
 
 ENTRYPOINT ["/connector/connector"]

--- a/materialize-postgres/Dockerfile
+++ b/materialize-postgres/Dockerfile
@@ -38,6 +38,5 @@ COPY --from=ghcr.io/estuary/network-tunnel:dev /flow-network-tunnel /usr/bin/flo
 USER nonroot:nonroot
 
 LABEL FLOW_RUNTIME_PROTOCOL=materialize
-LABEL FLOW_TCP_PORT=2222
 
 ENTRYPOINT ["/connector/connector"]

--- a/materialize-rockset/Dockerfile
+++ b/materialize-rockset/Dockerfile
@@ -43,6 +43,5 @@ COPY --from=builder /builder/connector ./connector
 USER nonroot:nonroot
 
 LABEL FLOW_RUNTIME_PROTOCOL=materialize
-LABEL FLOW_TCP_PORT=2222
 
 ENTRYPOINT ["/connector/connector"]

--- a/materialize-s3-parquet/Dockerfile
+++ b/materialize-s3-parquet/Dockerfile
@@ -37,6 +37,5 @@ COPY --from=builder /builder/connector ./connector
 USER nonroot:nonroot
 
 LABEL FLOW_RUNTIME_PROTOCOL=materialize
-LABEL FLOW_TCP_PORT=2222
 
 ENTRYPOINT ["/connector/connector"]

--- a/materialize-snowflake/Dockerfile
+++ b/materialize-snowflake/Dockerfile
@@ -44,6 +44,5 @@ ENV PATH="/connector:$PATH"
 COPY --from=builder /builder/connector ./connector
 
 LABEL FLOW_RUNTIME_PROTOCOL=materialize
-LABEL FLOW_TCP_PORT=2222
 
 ENTRYPOINT ["/connector/connector"]

--- a/materialize-webhook/Dockerfile
+++ b/materialize-webhook/Dockerfile
@@ -37,6 +37,5 @@ COPY --from=builder /builder/connector ./connector
 USER nonroot:nonroot
 
 LABEL FLOW_RUNTIME_PROTOCOL=materialize
-LABEL FLOW_TCP_PORT=2222
 
 ENTRYPOINT ["/connector/connector"]

--- a/source-firestore/Dockerfile
+++ b/source-firestore/Dockerfile
@@ -40,7 +40,6 @@ COPY --from=builder /builder/connector ./connector
 
 LABEL FLOW_RUNTIME_PROTOCOL=capture
 LABEL CONNECTOR_PROTOCOL=flow-capture
-LABEL FLOW_TCP_PORT=2222
 
 # Avoid running the connector as root.
 USER nonroot:nonroot

--- a/source-gcs/Dockerfile
+++ b/source-gcs/Dockerfile
@@ -43,4 +43,3 @@ USER nonroot:nonroot
 
 COPY --from=ghcr.io/estuary/airbyte-to-flow:dev /airbyte-to-flow ./airbyte-to-flow
 ENTRYPOINT ["/connector/airbyte-to-flow", "--connector-entrypoint", "/connector/connector"]
-LABEL FLOW_TCP_PORT=2222

--- a/source-gcs/Dockerfile
+++ b/source-gcs/Dockerfile
@@ -41,5 +41,4 @@ COPY --from=builder /builder/connector ./connector
 # Avoid running the connector as root.
 USER nonroot:nonroot
 
-COPY --from=ghcr.io/estuary/airbyte-to-flow:dev /airbyte-to-flow ./airbyte-to-flow
-ENTRYPOINT ["/connector/airbyte-to-flow", "--connector-entrypoint", "/connector/connector"]
+ENTRYPOINT ["/connector/connector"]

--- a/source-hello-world/Dockerfile
+++ b/source-hello-world/Dockerfile
@@ -38,4 +38,3 @@ USER nonroot:nonroot
 
 COPY --from=ghcr.io/estuary/airbyte-to-flow:dev /airbyte-to-flow ./airbyte-to-flow
 ENTRYPOINT ["/connector/airbyte-to-flow", "--connector-entrypoint", "/connector/connector"]
-LABEL FLOW_TCP_PORT=2222

--- a/source-hello-world/Dockerfile
+++ b/source-hello-world/Dockerfile
@@ -36,5 +36,4 @@ COPY --from=builder /builder/connector ./connector
 # Avoid running the connector as root.
 USER nonroot:nonroot
 
-COPY --from=ghcr.io/estuary/airbyte-to-flow:dev /airbyte-to-flow ./airbyte-to-flow
-ENTRYPOINT ["/connector/airbyte-to-flow", "--connector-entrypoint", "/connector/connector"]
+ENTRYPOINT ["/connector/connector"]

--- a/source-http-file/Dockerfile
+++ b/source-http-file/Dockerfile
@@ -43,4 +43,3 @@ USER nonroot:nonroot
 
 COPY --from=ghcr.io/estuary/airbyte-to-flow:dev /airbyte-to-flow ./airbyte-to-flow
 ENTRYPOINT ["/connector/airbyte-to-flow", "--connector-entrypoint", "/connector/connector"]
-LABEL FLOW_TCP_PORT=2222

--- a/source-http-file/Dockerfile
+++ b/source-http-file/Dockerfile
@@ -41,5 +41,4 @@ COPY --from=builder /builder/connector ./connector
 # Avoid running the connector as root.
 USER nonroot:nonroot
 
-COPY --from=ghcr.io/estuary/airbyte-to-flow:dev /airbyte-to-flow ./airbyte-to-flow
-ENTRYPOINT ["/connector/airbyte-to-flow", "--connector-entrypoint", "/connector/connector"]
+ENTRYPOINT ["/connector/connector"]

--- a/source-kinesis/Dockerfile
+++ b/source-kinesis/Dockerfile
@@ -40,5 +40,4 @@ COPY --from=builder /builder/connector ./connector
 # Avoid running the connector as root.
 USER nonroot:nonroot
 
-COPY --from=ghcr.io/estuary/airbyte-to-flow:dev /airbyte-to-flow ./airbyte-to-flow
-ENTRYPOINT ["/connector/airbyte-to-flow", "--connector-entrypoint", "/connector/connector"]
+ENTRYPOINT ["/connector/connector"]

--- a/source-kinesis/Dockerfile
+++ b/source-kinesis/Dockerfile
@@ -42,4 +42,3 @@ USER nonroot:nonroot
 
 COPY --from=ghcr.io/estuary/airbyte-to-flow:dev /airbyte-to-flow ./airbyte-to-flow
 ENTRYPOINT ["/connector/airbyte-to-flow", "--connector-entrypoint", "/connector/connector"]
-LABEL FLOW_TCP_PORT=2222

--- a/source-mysql/Dockerfile
+++ b/source-mysql/Dockerfile
@@ -40,5 +40,4 @@ COPY --from=builder /builder/connector ./connector
 # Avoid running the connector as root.
 USER nonroot:nonroot
 
-COPY --from=ghcr.io/estuary/airbyte-to-flow:dev /airbyte-to-flow ./airbyte-to-flow
-ENTRYPOINT ["/connector/airbyte-to-flow", "--connector-entrypoint", "/connector/connector"]
+ENTRYPOINT ["/connector/connector"]

--- a/source-mysql/Dockerfile
+++ b/source-mysql/Dockerfile
@@ -42,4 +42,3 @@ USER nonroot:nonroot
 
 COPY --from=ghcr.io/estuary/airbyte-to-flow:dev /airbyte-to-flow ./airbyte-to-flow
 ENTRYPOINT ["/connector/airbyte-to-flow", "--connector-entrypoint", "/connector/connector"]
-LABEL FLOW_TCP_PORT=2222

--- a/source-nativehello/Dockerfile
+++ b/source-nativehello/Dockerfile
@@ -39,5 +39,4 @@ LABEL CONNECTOR_PROTOCOL=flow-capture
 # Avoid running the connector as root.
 USER nonroot:nonroot
 
-COPY --from=ghcr.io/estuary/airbyte-to-flow:dev /airbyte-to-flow ./airbyte-to-flow
-ENTRYPOINT ["/connector/airbyte-to-flow", "--connector-entrypoint", "/connector/connector"]
+ENTRYPOINT ["/connector/connector"]

--- a/source-nativehello/Dockerfile
+++ b/source-nativehello/Dockerfile
@@ -35,11 +35,9 @@ COPY --from=builder /builder/connector ./connector
 
 LABEL FLOW_RUNTIME_PROTOCOL=capture
 LABEL CONNECTOR_PROTOCOL=flow-capture
-LABEL FLOW_TCP_PORT=2222
 
 # Avoid running the connector as root.
 USER nonroot:nonroot
 
 COPY --from=ghcr.io/estuary/airbyte-to-flow:dev /airbyte-to-flow ./airbyte-to-flow
 ENTRYPOINT ["/connector/airbyte-to-flow", "--connector-entrypoint", "/connector/connector"]
-LABEL FLOW_TCP_PORT=2222

--- a/source-postgres/Dockerfile
+++ b/source-postgres/Dockerfile
@@ -42,5 +42,4 @@ COPY --from=ghcr.io/estuary/network-tunnel:dev /flow-network-tunnel /usr/bin/flo
 # Avoid running the connector as root.
 USER nonroot:nonroot
 
-COPY --from=ghcr.io/estuary/airbyte-to-flow:dev /airbyte-to-flow ./airbyte-to-flow
-ENTRYPOINT ["/connector/airbyte-to-flow", "--connector-entrypoint", "/connector/connector"]
+ENTRYPOINT ["/connector/connector"]

--- a/source-postgres/Dockerfile
+++ b/source-postgres/Dockerfile
@@ -44,4 +44,3 @@ USER nonroot:nonroot
 
 COPY --from=ghcr.io/estuary/airbyte-to-flow:dev /airbyte-to-flow ./airbyte-to-flow
 ENTRYPOINT ["/connector/airbyte-to-flow", "--connector-entrypoint", "/connector/connector"]
-LABEL FLOW_TCP_PORT=2222

--- a/source-s3/Dockerfile
+++ b/source-s3/Dockerfile
@@ -44,5 +44,4 @@ COPY --from=builder /builder/connector ./connector
 # Avoid running the connector as root.
 USER nonroot:nonroot
 
-COPY --from=ghcr.io/estuary/airbyte-to-flow:dev /airbyte-to-flow ./airbyte-to-flow
-ENTRYPOINT ["/connector/airbyte-to-flow", "--connector-entrypoint", "/connector/connector"]
+ENTRYPOINT ["/connector/connector"]

--- a/source-s3/Dockerfile
+++ b/source-s3/Dockerfile
@@ -46,4 +46,3 @@ USER nonroot:nonroot
 
 COPY --from=ghcr.io/estuary/airbyte-to-flow:dev /airbyte-to-flow ./airbyte-to-flow
 ENTRYPOINT ["/connector/airbyte-to-flow", "--connector-entrypoint", "/connector/connector"]
-LABEL FLOW_TCP_PORT=2222

--- a/tests/source-gcs/bindings.json
+++ b/tests/source-gcs/bindings.json
@@ -1,7 +1,18 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "required": [
+    "_meta",
+    "canary",
+    "id"
+  ],
   "properties": {
     "_meta": {
+      "type": "object",
+      "required": [
+        "file",
+        "offset"
+      ],
       "properties": {
         "file": {
           "type": "string"
@@ -9,12 +20,7 @@
         "offset": {
           "type": "integer"
         }
-      },
-      "required": [
-        "file",
-        "offset"
-      ],
-      "type": "object"
+      }
     },
     "canary": {
       "type": "string"
@@ -22,11 +28,5 @@
     "id": {
       "type": "string"
     }
-  },
-  "required": [
-    "_meta",
-    "canary",
-    "id"
-  ],
-  "type": "object"
+  }
 }

--- a/tests/source-kinesis/bindings.json
+++ b/tests/source-kinesis/bindings.json
@@ -1,5 +1,11 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "required": [
+    "canary",
+    "foo",
+    "id"
+  ],
   "properties": {
     "canary": {
       "type": "string"
@@ -14,11 +20,5 @@
     "id": {
       "type": "integer"
     }
-  },
-  "required": [
-    "canary",
-    "foo",
-    "id"
-  ],
-  "type": "object"
+  }
 }


### PR DESCRIPTION
**Description:**

This commit removes the `FLOW_TCP_PORT=2222` label from all Dockerfiles, removes the bit of code that opened a TCP port from source-boilerplate and materialize-boilerplate, and instead goes back to using os.Stdin and os.Stdout for those.

Unfortunately the logic changes to the boilerplate packages have to be made for all connectors at once, so this change has a fairly large blast radius if something is overlooked, but I don't think that can be helped.

**Workflow steps:**

In theory everything keeps working, and some of the current connector breakage is fixed for the moment.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/396)
<!-- Reviewable:end -->
