### PR TITLE
source-mysql: Fix inconsistencies between MySQL and MariaDB

### DIFF
--- a/source-mysql/datatype_test.go
+++ b/source-mysql/datatype_test.go
@@ -75,7 +75,10 @@ func TestDatatypes(t *testing.T) {
 
 		{ColumnType: "date", ExpectType: `{"type":["string","null"]}`, InputValue: "1991-08-31", ExpectValue: `"1991-08-31"`},
 		{ColumnType: "datetime", ExpectType: `{"type":["string","null"]}`, InputValue: "1991-08-31 12:34:56", ExpectValue: `"1991-08-31 12:34:56"`},
+
+		// This test fails on MariaDB because it truncates fractional seconds rather than rounding (see also: https://jira.mariadb.org/browse/MDEV-16991).
 		{ColumnType: "datetime", ExpectType: `{"type":["string","null"]}`, InputValue: "1991-08-31 12:34:56.987654", ExpectValue: `"1991-08-31 12:34:57"`},
+
 		// TODO(wgd): Timestamps are reported differently in backfills vs replication because backfill
 		// queries do time-zone conversion while the replicated events appear to be un-converted.
 		// {ColumnType: "timestamp", ExpectType: `{"type":["string","null"]}`, InputValue: "1991-08-31 12:34:56", ExpectValue: `"1991-08-31 12:34:56"`},
@@ -83,6 +86,9 @@ func TestDatatypes(t *testing.T) {
 		{ColumnType: "time", ExpectType: `{"type":["string","null"]}`, InputValue: "765:43:21", ExpectValue: `"765:43:21"`},
 		{ColumnType: "year", ExpectType: `{"type":["integer","null"]}`, InputValue: "2003", ExpectValue: `2003`},
 
+		// This test fails on MariaDB, because the 'JSON' column type is just an alias for LONGTEXT
+		// and will result in the original input JSON being captured as a string. See also:
+		// https://mariadb.com/kb/en/json-data-type/#differences-between-mysql-json-strings-and-mariadb-json-strings
 		{ColumnType: "json", ExpectType: `{}`, InputValue: `{"type": "test", "data": 123}`, ExpectValue: `{"data":123,"type":"test"}`},
 	})
 }

--- a/source-mysql/docker-compose.yaml
+++ b/source-mysql/docker-compose.yaml
@@ -3,7 +3,10 @@ version: "3.7"
 services:
   db:
     image: 'mysql:latest'
-    command: ["--binlog-row-metadata=FULL"]
+    command: []
+    ## Alternative setup for testing MariaDB:
+    # image: 'mariadb:latest'
+    # command: [ "--log-bin", "--binlog-format=ROW" ]
     ports:
       - "3306:3306"
     volumes:

--- a/source-mysql/docker-entrypoint-initdb.d/init-user-db.sh
+++ b/source-mysql/docker-entrypoint-initdb.d/init-user-db.sh
@@ -8,9 +8,8 @@ echo "======================================="
 mysql --user="root" --password="flow" --database="test" <<-EOSQL
     CREATE DATABASE IF NOT EXISTS flow;
     CREATE TABLE IF NOT EXISTS flow.watermarks (slot INTEGER PRIMARY KEY, watermark TEXT);
-    CREATE USER IF NOT EXISTS flow_capture IDENTIFIED BY 'secret' COMMENT 'User account for Flow MySQL data capture';
+    CREATE USER IF NOT EXISTS flow_capture IDENTIFIED BY 'secret';
     GRANT REPLICATION CLIENT, REPLICATION SLAVE ON *.* TO 'flow_capture';
     GRANT SELECT ON *.* TO 'flow_capture';
     GRANT INSERT, UPDATE, DELETE ON flow.watermarks TO 'flow_capture';
-    SET PERSIST binlog_row_metadata = 'FULL';
 EOSQL

--- a/source-mysql/replication.go
+++ b/source-mysql/replication.go
@@ -378,7 +378,7 @@ func decodeRow(streamID string, colNames []string, row []interface{}) (map[strin
 // prefix matching to detect many types of query that we just completely
 // don't care about. This is good, because the Vitess SQL parser disagrees
 // with the binlog Query Events for some statements like GRANT and CREATE USER.
-var ignoreQueriesRe = regexp.MustCompile(`^(BEGIN|COMMIT|GRANT|CREATE USER|DROP USER)`)
+var ignoreQueriesRe = regexp.MustCompile(`^(BEGIN|COMMIT|GRANT|CREATE USER|DROP USER|# )`)
 
 func (rs *mysqlReplicationStream) handleQuery(schema, query string) error {
 	// There are basically three types of query events we might receive:


### PR DESCRIPTION
**Description:**

This PR tweaks a handful of minor details of `source-mysql` so that it should be able to successfully capture from MariaDB v10.3 and up. Currently there are still a few failures in the automated test suite:

  - The `datetime` datatype round trip test fails because MariaDB truncates fractional seconds instead of rounding.
  - The `json` datatype round trip test fails because MariaDB has `JSON` as an alias for the `LONGTEXT` column type, so discovery and captures will just treat that as a string.
  - The `TestBinlogExpirySanityCheck` test fails on older versions of MariaDB (but not latest) because the `binlog_expire_logs_seconds` system variable doesn't exist and the test code wants to modify that. However the sanity check itself should still work on those DB versions, it will simply fall back to looking at `expire_logs_days` like it should.

**Workflow steps:**

After this is merged, it should be possible to perform discovery and captures against a MariaDB instance using the same `ghcr.io/estuary/source-mysql:v2` connector that we currently offer in the web UI.

Our test suite exercises enough of the core capture behavior that I'm confident that ought to work reliably, however there could be other edge cases around query event parsing and datatype edge cases which we won't encounter until this is run against a real production database.

**Documentation links affected:**

We should probably tweak https://docs.estuary.dev/reference/Connectors/capture-connectors/MySQL/ to mention somewhere that MariaDB is also supported.

