### PR TITLE
source-*: switch airbyte protocol connectors to use airbyte-to-flow

### DIFF
--- a/source-gcs/Dockerfile
+++ b/source-gcs/Dockerfile
@@ -41,4 +41,8 @@ COPY --from=builder /builder/connector ./connector
 # Avoid running the connector as root.
 USER nonroot:nonroot
 
-ENTRYPOINT ["/connector/connector"]
+COPY --from=ghcr.io/estuary/airbyte-to-flow:dev /airbyte-to-flow ./
+ENTRYPOINT ["/connector/airbyte-to-flow", "--connector-entrypoint", "/connector/connector"]
+
+LABEL FLOW_RUNTIME_PROTOCOL=capture
+LABEL CONNECTOR_PROTOCOL=flow-capture

--- a/source-hello-world/Dockerfile
+++ b/source-hello-world/Dockerfile
@@ -36,4 +36,8 @@ COPY --from=builder /builder/connector ./connector
 # Avoid running the connector as root.
 USER nonroot:nonroot
 
-ENTRYPOINT ["/connector/connector"]
+COPY --from=ghcr.io/estuary/airbyte-to-flow:dev /airbyte-to-flow ./
+ENTRYPOINT ["/connector/airbyte-to-flow", "--connector-entrypoint", "/connector/connector"]
+
+LABEL FLOW_RUNTIME_PROTOCOL=capture
+LABEL CONNECTOR_PROTOCOL=flow-capture

--- a/source-http-file/Dockerfile
+++ b/source-http-file/Dockerfile
@@ -41,4 +41,8 @@ COPY --from=builder /builder/connector ./connector
 # Avoid running the connector as root.
 USER nonroot:nonroot
 
-ENTRYPOINT ["/connector/connector"]
+COPY --from=ghcr.io/estuary/airbyte-to-flow:dev /airbyte-to-flow ./
+ENTRYPOINT ["/connector/airbyte-to-flow", "--connector-entrypoint", "/connector/connector"]
+
+LABEL FLOW_RUNTIME_PROTOCOL=capture
+LABEL CONNECTOR_PROTOCOL=flow-capture

--- a/source-kafka/Dockerfile
+++ b/source-kafka/Dockerfile
@@ -53,4 +53,8 @@ COPY --from=builder /usr/local/cargo/bin/source-kafka ./connector
 # Avoid running the connector as root.
 USER nonroot:nonroot
 
-ENTRYPOINT ["/connector/connector"]
+COPY --from=ghcr.io/estuary/airbyte-to-flow:dev /airbyte-to-flow ./
+ENTRYPOINT ["/connector/airbyte-to-flow", "--connector-entrypoint", "/connector/connector"]
+
+LABEL FLOW_RUNTIME_PROTOCOL=capture
+LABEL CONNECTOR_PROTOCOL=flow-capture

--- a/source-kinesis/Dockerfile
+++ b/source-kinesis/Dockerfile
@@ -40,4 +40,8 @@ COPY --from=builder /builder/connector ./connector
 # Avoid running the connector as root.
 USER nonroot:nonroot
 
-ENTRYPOINT ["/connector/connector"]
+COPY --from=ghcr.io/estuary/airbyte-to-flow:dev /airbyte-to-flow ./
+ENTRYPOINT ["/connector/airbyte-to-flow", "--connector-entrypoint", "/connector/connector"]
+
+LABEL FLOW_RUNTIME_PROTOCOL=capture
+LABEL CONNECTOR_PROTOCOL=flow-capture

--- a/source-mysql/Dockerfile
+++ b/source-mysql/Dockerfile
@@ -40,4 +40,8 @@ COPY --from=builder /builder/connector ./connector
 # Avoid running the connector as root.
 USER nonroot:nonroot
 
-ENTRYPOINT ["/connector/connector"]
+COPY --from=ghcr.io/estuary/airbyte-to-flow:dev /airbyte-to-flow ./
+ENTRYPOINT ["/connector/airbyte-to-flow", "--connector-entrypoint", "/connector/connector"]
+
+LABEL FLOW_RUNTIME_PROTOCOL=capture
+LABEL CONNECTOR_PROTOCOL=flow-capture

--- a/source-postgres/Dockerfile
+++ b/source-postgres/Dockerfile
@@ -42,4 +42,8 @@ COPY --from=ghcr.io/estuary/network-tunnel:dev /flow-network-tunnel /usr/bin/flo
 # Avoid running the connector as root.
 USER nonroot:nonroot
 
-ENTRYPOINT ["/connector/connector"]
+COPY --from=ghcr.io/estuary/airbyte-to-flow:dev /airbyte-to-flow ./
+ENTRYPOINT ["/connector/airbyte-to-flow", "--connector-entrypoint", "/connector/connector"]
+
+LABEL FLOW_RUNTIME_PROTOCOL=capture
+LABEL CONNECTOR_PROTOCOL=flow-capture

--- a/source-s3/Dockerfile
+++ b/source-s3/Dockerfile
@@ -44,4 +44,8 @@ COPY --from=builder /builder/connector ./connector
 # Avoid running the connector as root.
 USER nonroot:nonroot
 
-ENTRYPOINT ["/connector/connector"]
+COPY --from=ghcr.io/estuary/airbyte-to-flow:dev /airbyte-to-flow ./
+ENTRYPOINT ["/connector/airbyte-to-flow", "--connector-entrypoint", "/connector/connector"]
+
+LABEL FLOW_RUNTIME_PROTOCOL=capture
+LABEL CONNECTOR_PROTOCOL=flow-capture

--- a/source-test/Dockerfile
+++ b/source-test/Dockerfile
@@ -36,4 +36,8 @@ COPY --from=builder /builder/connector ./connector
 # Avoid running the connector as root.
 USER nonroot:nonroot
 
-ENTRYPOINT ["/connector/connector"]
+COPY --from=ghcr.io/estuary/airbyte-to-flow:dev /airbyte-to-flow ./
+ENTRYPOINT ["/connector/airbyte-to-flow", "--connector-entrypoint", "/connector/connector"]
+
+LABEL FLOW_RUNTIME_PROTOCOL=capture
+LABEL CONNECTOR_PROTOCOL=flow-capture

--- a/tests/source-gcs/bindings.json
+++ b/tests/source-gcs/bindings.json
@@ -1,18 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "type": "object",
-  "required": [
-    "_meta",
-    "canary",
-    "id"
-  ],
   "properties": {
     "_meta": {
-      "type": "object",
-      "required": [
-        "file",
-        "offset"
-      ],
       "properties": {
         "file": {
           "type": "string"
@@ -20,7 +9,12 @@
         "offset": {
           "type": "integer"
         }
-      }
+      },
+      "required": [
+        "file",
+        "offset"
+      ],
+      "type": "object"
     },
     "canary": {
       "type": "string"
@@ -28,5 +22,11 @@
     "id": {
       "type": "string"
     }
-  }
+  },
+  "required": [
+    "_meta",
+    "canary",
+    "id"
+  ],
+  "type": "object"
 }

--- a/tests/source-kinesis/bindings.json
+++ b/tests/source-kinesis/bindings.json
@@ -1,11 +1,5 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "type": "object",
-  "required": [
-    "canary",
-    "foo",
-    "id"
-  ],
   "properties": {
     "canary": {
       "type": "string"
@@ -20,5 +14,11 @@
     "id": {
       "type": "integer"
     }
-  }
+  },
+  "required": [
+    "canary",
+    "foo",
+    "id"
+  ],
+  "type": "object"
 }


### PR DESCRIPTION
**Description:**

- Switches connectors that use airbyte protocol to use latest version of airbyte-to-flow which communicates over stdio

**Workflow steps:**

N/A

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/405)
<!-- Reviewable:end -->
