### PR TITLE
source-firestore: Stop setting `additionalProperties: false`

### DIFF
--- a/source-firestore/.snapshots/TestDiscovery
+++ b/source-firestore/.snapshots/TestDiscovery
@@ -3,7 +3,7 @@ Binding 0:
     "recommended_name": "flow_source_tests",
     "resource_spec_json": {
       "path": "flow_source_tests",
-      "backfillMode": "sync"
+      "backfillMode": "async"
     },
     "document_schema_json": {
       "allOf": [
@@ -52,7 +52,6 @@ Binding 0:
                   "description": "True if the document has been deleted"
                 }
               },
-              "additionalProperties": false,
               "type": "object",
               "required": [
                 "path",
@@ -78,7 +77,7 @@ Binding 1:
     "recommended_name": "flow_source_tests_users",
     "resource_spec_json": {
       "path": "flow_source_tests/*/users",
-      "backfillMode": "sync"
+      "backfillMode": "async"
     },
     "document_schema_json": {
       "allOf": [
@@ -127,7 +126,6 @@ Binding 1:
                   "description": "True if the document has been deleted"
                 }
               },
-              "additionalProperties": false,
               "type": "object",
               "required": [
                 "path",
@@ -153,7 +151,7 @@ Binding 2:
     "recommended_name": "flow_source_tests_users_docs",
     "resource_spec_json": {
       "path": "flow_source_tests/*/users/*/docs",
-      "backfillMode": "sync"
+      "backfillMode": "async"
     },
     "document_schema_json": {
       "allOf": [
@@ -206,7 +204,6 @@ Binding 2:
                   "description": "True if the document has been deleted"
                 }
               },
-              "additionalProperties": false,
               "type": "object",
               "required": [
                 "path",

--- a/source-firestore/discovery.go
+++ b/source-firestore/discovery.go
@@ -65,6 +65,7 @@ func generateMinimalSchema() json.RawMessage {
 	}
 	var metadataSchema = reflector.ReflectFromType(reflect.TypeOf(documentMetadata{}))
 	metadataSchema.Definitions = nil
+	metadataSchema.AdditionalProperties = nil
 
 	// Wrap metadata into an enclosing object schema with a /_meta property
 	// and a 'maximize by timestamp' reduction strategy.


### PR DESCRIPTION
**Description:**

I thought this had been fixed previously, but apparently we're still generating collection schemas which forbid additional properties of the `/_meta` object, which then immediately breaks because Flow adds `/_meta/uuid`.

**Workflow steps:**

Doing a simple "create capture via discovery then materialize it" setup in the UI should actually work without any manual schema editing.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/407)
<!-- Reviewable:end -->
