### PR TITLE
source-firestore: Provide enum options for `backfillMode`

### DIFF
--- a/source-firestore/.snapshots/TestSpec
+++ b/source-firestore/.snapshots/TestSpec
@@ -33,8 +33,13 @@
       },
       "backfillMode": {
         "type": "string",
+        "enum": [
+          "async",
+          "none",
+          "sync"
+        ],
         "title": "Backfill Mode",
-        "description": "Configures the handling of data already in the collection. Options are sync/async/none."
+        "description": "Configures the handling of data already in the collection. Refer to go.estuary.dev/source-firestore for details or just stick with 'async'"
       }
     },
     "type": "object",

--- a/source-firestore/main.go
+++ b/source-firestore/main.go
@@ -21,7 +21,7 @@ const (
 
 type resource struct {
 	Path         string       `json:"path" jsonschema:"title=Path to Collection,description=Supports parent/*/nested to capture all nested collections of parent's children"`
-	BackfillMode backfillMode `json:"backfillMode" jsonschema:"title=Backfill Mode,description=Configures the handling of data already in the collection. Options are sync/async/none."`
+	BackfillMode backfillMode `json:"backfillMode" jsonschema:"title=Backfill Mode,description=Configures the handling of data already in the collection. Refer to go.estuary.dev/source-firestore for details or just stick with 'async',enum=async,enum=none,enum=sync"`
 }
 
 func (r resource) Validate() error {


### PR DESCRIPTION
**Description:**

Provides enum options for the `backfillMode` resource property, and tweaks the description to be a bit more user-friendly.

This fixes https://github.com/estuary/connectors/issues/408

**Workflow steps:**

The resource editing part of the "Create a Capture" flow in the UI should be a bit friendlier now.

**Documentation links affected:**

I added go.estuary.dev/source-firestore pointing to https://docs.estuary.dev/reference/Connectors/capture-connectors/google-firestore/

We need to update the docs sometime soon to describe the current state of the connector. At a minimum that means describing the `backfillMode` setting, but it might be good to have some discussion of how the Firestore data model maps to Flow collections, like what I wrote in [the README](https://github.com/estuary/connectors/blob/main/source-firestore/README.md) but ideally a bit more coherent.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/409)
<!-- Reviewable:end -->
