### PR TITLE
go.mod: Upgrade Flow dependency to latest

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/bradleyjkemp/cupaloy v2.3.0+incompatible
 	github.com/brianvoe/gofakeit/v6 v6.16.0
 	github.com/elastic/go-elasticsearch/v7 v7.17.1
-	github.com/estuary/flow v0.1.5-0.20221007131251-5f24d1137ec0
+	github.com/estuary/flow v0.1.6-0.20221108191318-280052b31c5f
 	github.com/evanphx/json-patch/v5 v5.6.0
 	github.com/go-mysql-org/go-mysql v1.5.0
 	github.com/gogo/protobuf v1.3.2

--- a/go.sum
+++ b/go.sum
@@ -359,6 +359,8 @@ github.com/estuary/flow v0.1.5-0.20221007123219-9cea913c64cd h1:+4FZqQaHqoCq+EjC
 github.com/estuary/flow v0.1.5-0.20221007123219-9cea913c64cd/go.mod h1:dHlTdu5vRYgKgaqRZzjTWLqs7Z21xf41DvwEBlcD3KM=
 github.com/estuary/flow v0.1.5-0.20221007131251-5f24d1137ec0 h1:TST2UUylfokVB+4y3qh0rAPv473JdWBQj5SHtfYZklI=
 github.com/estuary/flow v0.1.5-0.20221007131251-5f24d1137ec0/go.mod h1:dHlTdu5vRYgKgaqRZzjTWLqs7Z21xf41DvwEBlcD3KM=
+github.com/estuary/flow v0.1.6-0.20221108191318-280052b31c5f h1:7JHOU+3PPQMcAWQCDKWq08yQ+dy4OS3Nk81/xS6ugwc=
+github.com/estuary/flow v0.1.6-0.20221108191318-280052b31c5f/go.mod h1:dHlTdu5vRYgKgaqRZzjTWLqs7Z21xf41DvwEBlcD3KM=
 github.com/evanphx/json-patch v4.2.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/evanphx/json-patch v4.9.0+incompatible h1:kLcOMZeuLAJvL2BPWLMIj5oaZQobrkAqrL+WFZwQses=
 github.com/evanphx/json-patch v4.9.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=


### PR DESCRIPTION
**Description:**

This picks up the recent protocols/airbyte change which allows the `--log.level` flag to occur at any position in the command line (https://github.com/estuary/flow/pull/780).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/412)
<!-- Reviewable:end -->
