### PR TITLE
source-gcs: Backport https://github.com/estuary/flow/pull/780

### DIFF
--- a/filesource/filesource.go
+++ b/filesource/filesource.go
@@ -12,8 +12,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/estuary/connectors/protocols/airbyte"
 	"github.com/estuary/flow/go/parser"
-	"github.com/estuary/flow/go/protocols/airbyte"
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/sync/errgroup"
 )

--- a/go.mod
+++ b/go.mod
@@ -33,6 +33,7 @@ require (
 	github.com/klauspost/compress v1.15.5 // indirect
 	github.com/mattn/go-ieproxy v0.0.6 // indirect
 	github.com/mattn/go-sqlite3 v2.0.3+incompatible
+	github.com/minio/highwayhash v1.0.2
 	github.com/pierrec/lz4/v4 v4.1.14 // indirect
 	github.com/prometheus/client_golang v1.12.2 // indirect
 	github.com/prometheus/common v0.34.0 // indirect

--- a/protocols/airbyte/args.go
+++ b/protocols/airbyte/args.go
@@ -1,0 +1,154 @@
+package airbyte
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	flags "github.com/jessevdk/go-flags"
+	log "github.com/sirupsen/logrus"
+)
+
+// JSONFile represents a path to a file with JSON contents.
+type JSONFile string
+
+// Parse unmarshals the JSON contents into the given target.
+func (c JSONFile) Parse(target interface{ Validate() error }) error {
+	var r, err = os.Open(string(c))
+	if err != nil {
+		return fmt.Errorf("opening '%s': %w", c, err)
+	}
+
+	var d = json.NewDecoder(r)
+	d.DisallowUnknownFields()
+
+	if err = d.Decode(target); err != nil {
+		return fmt.Errorf("decoding '%s': %w", c, err)
+	} else if err = target.Validate(); err != nil {
+		return fmt.Errorf("validating '%s': %w", c, err)
+	}
+	return nil
+}
+
+type ConfigFile struct {
+	ConfigFile JSONFile `long:"config" description:"Path to connector configuration"`
+}
+
+// Parse delegates to JSONFile.Parse.
+func (c ConfigFile) Parse(target interface{ Validate() error }) error {
+	return c.ConfigFile.Parse(target)
+}
+
+// logConfig configures handling of application log events.
+type logConfig struct {
+	Level  string `long:"log.level" env:"LOG_LEVEL" default:"info" choice:"info" choice:"debug" choice:"warn" description:"Logging level"`
+	Format string `long:"log.format" env:"LOG_FORMAT" default:"text" choice:"json" choice:"text" choice:"color" description:"Logging output format"`
+}
+
+func (cfg *logConfig) setup() {
+	if cfg.Format == "json" {
+		log.SetFormatter(&log.JSONFormatter{})
+	} else if cfg.Format == "text" {
+		log.SetFormatter(&log.TextFormatter{})
+	} else if cfg.Format == "color" {
+		log.SetFormatter(&log.TextFormatter{ForceColors: true})
+	}
+
+	if lvl, err := log.ParseLevel(cfg.Level); err != nil {
+		log.WithField("err", err).Fatal("unrecognized log level")
+	} else {
+		log.SetLevel(lvl)
+	}
+}
+
+type SpecCmd struct {
+	logging    *logConfig
+	actualSpec Spec `no-flag:"y"`
+}
+
+func (c *SpecCmd) Execute(_ []string) error {
+	c.logging.setup()
+	return NewStdoutEncoder().Encode(
+		&Message{
+			Type: MessageTypeSpec,
+			Spec: &c.actualSpec,
+		})
+}
+
+type CheckCmd struct {
+	ConfigFile
+	logging *logConfig
+	doCheck func(CheckCmd) error `no-flag:"y"`
+}
+
+func (c *CheckCmd) Execute(_ []string) error {
+	c.logging.setup()
+	return c.doCheck(*c)
+}
+
+type DiscoverCmd struct {
+	ConfigFile
+	logging    *logConfig
+	doDiscover func(DiscoverCmd) error `no-flag:"y"`
+}
+
+func (c *DiscoverCmd) Execute(_ []string) error {
+	c.logging.setup()
+	return c.doDiscover(*c)
+}
+
+type ReadCmd struct {
+	ConfigFile
+	StateFile   JSONFile `long:"state"`
+	CatalogFile JSONFile `long:"catalog"`
+	logging     *logConfig
+	doRead      func(ReadCmd) error `no-flag:"y"`
+}
+
+func (c *ReadCmd) Execute(_ []string) error {
+	c.logging.setup()
+	return c.doRead(*c)
+}
+
+// RunMain does argument parsing and executes the given subcommand. This function will not return.
+// It will call `os.Exit` with an appropriate exit code.
+func RunMain(spec Spec, doCheck func(CheckCmd) error, doDiscover func(DiscoverCmd) error, doRead func(ReadCmd) error) {
+	var logConfig = &logConfig{}
+	var parser = flags.NewParser(logConfig, flags.Default)
+	var specCmd = SpecCmd{
+		logging:    logConfig,
+		actualSpec: spec,
+	}
+	parser.AddCommand("spec", "prints the spec", "prints the ConnectorDefinition to stdout and exits", &specCmd)
+
+	var checkCmd = CheckCmd{
+		logging: logConfig,
+		doCheck: doCheck,
+	}
+	parser.AddCommand("check", "Checks the connection", "Tries to connect to the external system to validate the connection information", &checkCmd)
+
+	var discoverCmd = DiscoverCmd{
+		logging:    logConfig,
+		doDiscover: doDiscover,
+	}
+	parser.AddCommand("discover", "List Streams that can be captured", "Prints a Catalog enumerating all of the Streams that may be read", &discoverCmd)
+
+	var readCmd = ReadCmd{
+		logging: logConfig,
+		doRead:  doRead,
+	}
+	parser.AddCommand("read", "Read records from the remote system", "Reads records and prints them to stdout", &readCmd)
+
+	// This will actually execute the given subcommand because that's clearly what "parse" means /s.
+	var _, err = parser.Parse()
+	if err != nil {
+		// We don't log the error because flags.Default includes flags.PrintErrors,
+		// and thus Parse() has already done so on our behalf.
+		os.Exit(1)
+	}
+	os.Exit(0)
+}
+
+func NewStdoutEncoder() *json.Encoder {
+	return json.NewEncoder(os.Stdout)
+}

--- a/protocols/airbyte/catalog.go
+++ b/protocols/airbyte/catalog.go
@@ -1,0 +1,273 @@
+package airbyte
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+type SyncMode string
+
+const (
+	SyncModeIncremental SyncMode = "incremental"
+	SyncModeFullRefresh SyncMode = "full_refresh"
+)
+
+var AllSyncModes = []SyncMode{SyncModeIncremental, SyncModeFullRefresh}
+
+type Stream struct {
+	Name                    string          `json:"name"`
+	JSONSchema              json.RawMessage `json:"json_schema"`
+	SupportedSyncModes      []SyncMode      `json:"supported_sync_modes"`
+	SourceDefinedCursor     bool            `json:"source_defined_cursor,omitempty"`
+	DefaultCursorField      []string        `json:"default_cursor_field,omitempty"`
+	SourceDefinedPrimaryKey [][]string      `json:"source_defined_primary_key,omitempty"`
+	Namespace               string          `json:"namespace,omitempty"`
+}
+
+func (s *Stream) Validate() error {
+	if len(s.SupportedSyncModes) == 0 {
+		return fmt.Errorf("stream must have at least one supported_sync_modes")
+	}
+	return nil
+}
+
+type DestinationSyncMode string
+
+const (
+	DestinationSyncModeAppend      DestinationSyncMode = "append"
+	DestinationSyncModeOverwrite   DestinationSyncMode = "overwrite"
+	DestinationSyncModeAppendDedup DestinationSyncMode = "append_dedup"
+)
+
+var AllDestinationSyncModes = []DestinationSyncMode{
+	DestinationSyncModeAppend,
+	DestinationSyncModeOverwrite,
+	DestinationSyncModeAppendDedup,
+}
+
+type ConfiguredStream struct {
+	Stream              Stream              `json:"stream"`
+	SyncMode            SyncMode            `json:"sync_mode"`
+	DestinationSyncMode DestinationSyncMode `json:"destination_sync_mode"`
+	CursorField         []string            `json:"cursor_field,omitempty"`
+	PrimaryKey          [][]string          `json:"primary_key,omitempty"`
+	Projections         map[string]string   `json:"estuary.dev/projections"`
+}
+
+// This impl exists solely so that we can allow deserializing either the namespaced or
+// non-namepsaced version of Projections, for the purpose of compatibility.
+func (s *ConfiguredStream) UnmarshalJSON(b []byte) error {
+	var tmp = struct {
+		Stream              Stream              `json:"stream"`
+		SyncMode            SyncMode            `json:"sync_mode"`
+		DestinationSyncMode DestinationSyncMode `json:"destination_sync_mode"`
+		CursorField         []string            `json:"cursor_field,omitempty"`
+		PrimaryKey          [][]string          `json:"primary_key,omitempty"`
+		NSProjections       map[string]string   `json:"estuary.dev/projections"`
+		Projections         map[string]string   `json:"projections"`
+	}{}
+	if err := json.Unmarshal(b, &tmp); err != nil {
+		return err
+	}
+	*s = ConfiguredStream{
+		Stream:              tmp.Stream,
+		SyncMode:            tmp.SyncMode,
+		DestinationSyncMode: tmp.DestinationSyncMode,
+		CursorField:         tmp.CursorField,
+		PrimaryKey:          tmp.PrimaryKey,
+		Projections:         tmp.NSProjections,
+	}
+	if len(s.Projections) == 0 {
+		s.Projections = tmp.Projections
+	}
+	return nil
+}
+
+func (c *ConfiguredStream) Validate() error {
+	var err = c.Stream.Validate()
+	if err != nil {
+		return fmt.Errorf("stream invalid: %w", err)
+	}
+	var syncTypeValid = false
+	for _, m := range c.Stream.SupportedSyncModes {
+		if m == c.SyncMode {
+			syncTypeValid = true
+		}
+	}
+	if !syncTypeValid {
+		return fmt.Errorf("unsupported syncMode: %s", c.SyncMode)
+	}
+	return nil
+}
+
+type Catalog struct {
+	Streams []Stream `json:"streams"`
+}
+
+type ConfiguredCatalog struct {
+	Streams []ConfiguredStream `json:"streams"`
+	Tail    bool               `json:"estuary.dev/tail"`
+	Range   Range              `json:"estuary.dev/range"`
+}
+
+// This impl exists solely so that we can accept either the namespaced or non-namespaced identifiers
+// for tail and range, for the purpose of compatibility.
+func (c *ConfiguredCatalog) UnmarshalJSON(b []byte) error {
+	var tmp = struct {
+		Streams []ConfiguredStream `json:"streams"`
+		NSTail  *bool              `json:"estuary.dev/tail"`
+		Tail    *bool              `json:"tail"`
+		NSRange *Range             `json:"estuary.dev/range"`
+		Range   *Range             `json:"range"`
+	}{}
+	if err := json.Unmarshal(b, &tmp); err != nil {
+		return err
+	}
+	var tail bool
+	if tmp.NSTail != nil {
+		tail = *tmp.NSTail
+	} else if tmp.Tail != nil {
+		tail = *tmp.Tail
+	}
+	var r Range
+	if tmp.NSRange != nil {
+		r = *tmp.NSRange
+	} else if tmp.Range != nil {
+		r = *tmp.Range
+	}
+	*c = ConfiguredCatalog{
+		Streams: tmp.Streams,
+		Tail:    tail,
+		Range:   r,
+	}
+	return nil
+}
+
+func (c *ConfiguredCatalog) Validate() error {
+	if len(c.Streams) == 0 {
+		return fmt.Errorf("catalog must have at least one stream")
+	}
+	for i, s := range c.Streams {
+		if err := s.Validate(); err != nil {
+			return fmt.Errorf("Streams[%d]: %w", i, err)
+		}
+	}
+	if err := c.Range.Validate(); err != nil {
+		return fmt.Errorf("Range: %w", err)
+	}
+	return nil
+}
+
+type Status string
+
+const (
+	StatusSucceeded Status = "SUCCEEDED"
+	StatusFailed    Status = "FAILED"
+)
+
+type ConnectionStatus struct {
+	Status  Status `json:"status"`
+	Message string `json:"message"`
+}
+
+type Record struct {
+	Stream    string          `json:"stream"`
+	Data      json.RawMessage `json:"data"`
+	EmittedAt int64           `json:"emitted_at"`
+	Namespace string          `json:"namespace,omitempty"`
+}
+
+type LogLevel string
+
+const (
+	LogLevelTrace LogLevel = "TRACE"
+	LogLevelDebug LogLevel = "DEBUG"
+	LogLevelInfo  LogLevel = "INFO"
+	LogLevelWarn  LogLevel = "WARN"
+	LogLevelError LogLevel = "ERROR"
+	LogLevelFatal LogLevel = "FATAL"
+)
+
+type Log struct {
+	Level   LogLevel `json:"level"`
+	Message string   `json:"message"`
+}
+
+type State struct {
+	// Data is the actual state associated with the ingestion. This must be a JSON _Object_ in order
+	// to comply with the airbyte specification.
+	Data json.RawMessage `json:"data"`
+	// Merge indicates that Data is an RFC 7396 JSON Merge Patch, and should
+	// be be reduced into the previous state accordingly.
+	Merge bool `json:"estuary.dev/merge,omitempty"`
+}
+
+func (s *State) UnmarshalJSON(b []byte) error {
+	var tmp = struct {
+		Data    json.RawMessage `json:"data"`
+		NSMerge bool            `json:"estuary.dev/merge"`
+		Merge   bool            `json:"merge"`
+	}{}
+	if err := json.Unmarshal(b, &tmp); err != nil {
+		return err
+	}
+
+	s.Data = tmp.Data
+	s.Merge = tmp.NSMerge || tmp.Merge
+
+	return nil
+}
+
+type Spec struct {
+	DocumentationURL        string          `json:"documentationUrl,omitempty"`
+	ChangelogURL            string          `json:"changelogUrl,omitempty"`
+	ConnectionSpecification json.RawMessage `json:"connectionSpecification"`
+	SupportsIncremental     bool            `json:"supportsIncremental,omitempty"`
+
+	// SupportedDestinationSyncModes is ignored by Flow
+	SupportedDestinationSyncModes []DestinationSyncMode `json:"supported_destination_sync_modes,omitempty"`
+	// SupportsNormalization is not currently used or supported by Flow or estuary-developed
+	// connectors
+	SupportsNormalization bool `json:"supportsNormalization,omitempty"`
+	// SupportsDBT is not currently used or supported by Flow or estuary-developed
+	// connectors
+	SupportsDBT bool `json:"supportsDBT,omitempty"`
+	// AuthSpecification is currently used by Flow for specifying the OAuth2Spec
+	// part of SpecResponse in flow protocol, which allows for OAuth2 authorization
+	// for connectors
+	AuthSpecification json.RawMessage `json:"authSpecification,omitempty"`
+	// AdvancedAuth is not currently used or supported by Flow or estuary-developed
+	// connectors.
+	AdvancedAuth json.RawMessage `json:"advanced_auth,omitempty"`
+}
+
+type MessageType string
+
+const (
+	MessageTypeRecord           MessageType = "RECORD"
+	MessageTypeState            MessageType = "STATE"
+	MessageTypeLog              MessageType = "LOG"
+	MessageTypeSpec             MessageType = "SPEC"
+	MessageTypeConnectionStatus MessageType = "CONNECTION_STATUS"
+	MessageTypeCatalog          MessageType = "CATALOG"
+)
+
+type Message struct {
+	Type             MessageType       `json:"type"`
+	Log              *Log              `json:"log,omitempty"`
+	State            *State            `json:"state,omitempty"`
+	Record           *Record           `json:"record,omitempty"`
+	ConnectionStatus *ConnectionStatus `json:"connectionStatus,omitempty"`
+	Spec             *Spec             `json:"spec,omitempty"`
+	Catalog          *Catalog          `json:"catalog,omitempty"`
+}
+
+func NewLogMessage(level LogLevel, msg string, args ...interface{}) Message {
+	return Message{
+		Type: MessageTypeLog,
+		Log: &Log{
+			Level:   level,
+			Message: fmt.Sprintf(msg, args...),
+		},
+	}
+}

--- a/protocols/airbyte/json_test.go
+++ b/protocols/airbyte/json_test.go
@@ -1,0 +1,62 @@
+package airbyte
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestConfiguredCatalogMarshaling(t *testing.T) {
+	var start = `{
+        "streams": [{
+            "stream": {"name": "foo","json_schema":true},
+            "sync_mode": "incremental",
+            "destination_sync_mode": "append",
+            "primary_key": [["/yea"], ["/boiiii"]],
+            "projections": {
+                "space": "/balls",
+                "blazing": "/saddles"
+            }
+        }],
+        "tail": true,
+        "range": {
+            "begin": "00000000",
+            "end": "FFFFFFFF"
+        }
+    }`
+	var resultOne = ConfiguredCatalog{}
+	require.NoError(t, json.Unmarshal([]byte(start), &resultOne))
+
+	// We always serialize using the namespaced fields.
+	var serJson, err = json.Marshal(&resultOne)
+	require.NoError(t, err)
+	require.Contains(t, string(serJson), `"estuary.dev/projections":`)
+	require.Contains(t, string(serJson), `"estuary.dev/tail":`)
+	require.Contains(t, string(serJson), `"estuary.dev/range":`)
+
+	// Deserialize again and assert that we get the same struct value as the first result.
+	var roundTripped = ConfiguredCatalog{}
+	require.NoError(t, json.Unmarshal(serJson, &roundTripped))
+	require.Equal(t, resultOne, roundTripped)
+}
+
+func TestStateMarshaling(t *testing.T) {
+	var nsFixture = `{"data":{"42":42},"estuary.dev/merge":true}`
+	var noNSFixture = `{"data":{"42":42},"merge":true}`
+	var expect = State{
+		Data:  json.RawMessage(`{"42":42}`),
+		Merge: true,
+	}
+
+	for _, fixture := range []string{nsFixture, noNSFixture} {
+		var state State
+		require.NoError(t, json.Unmarshal([]byte(fixture), &state))
+		require.Equal(t, expect, state)
+	}
+
+	// We serialize using the namespaced fields.
+	var b, err = json.Marshal(expect)
+	require.Equal(t, nsFixture, string(b))
+	require.NoError(t, err)
+}

--- a/protocols/airbyte/partition_range.go
+++ b/protocols/airbyte/partition_range.go
@@ -1,0 +1,144 @@
+package airbyte
+
+import (
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"math"
+	"strconv"
+
+	"github.com/minio/highwayhash"
+)
+
+// Range is the parsed shard labels that determine the range of partitions that this shard
+// will be responsible for. The range is inclusive on both sides.
+type Range struct {
+	Begin uint32
+	End   uint32
+}
+
+// NewFullRange returns a Range that covers the entire uint32 space.
+func NewFullRange() Range {
+	return Range{
+		Begin: 0,
+		End:   math.MaxUint32,
+	}
+}
+
+// IsZero returns true if the begin and end are both 0
+func (r Range) IsZero() bool {
+	return r.Begin == 0 && r.End == 0
+}
+
+func (r Range) MarshalJSON() ([]byte, error) {
+	var tmp = struct {
+		Begin string `json:"begin"`
+		End   string `json:"end"`
+	}{
+		Begin: fmt.Sprintf("%08x", r.Begin),
+		End:   fmt.Sprintf("%08x", r.End),
+	}
+	return json.Marshal(tmp)
+}
+
+func (r *Range) UnmarshalJSON(bytes []byte) error {
+	var tmp = struct{ Begin, End string }{}
+	if err := json.Unmarshal(bytes, &tmp); err != nil {
+		return err
+	}
+
+	if tmp.Begin != "" {
+		begin, err := strconv.ParseUint(tmp.Begin, 16, 32)
+		if err != nil {
+			return fmt.Errorf("parsing partition range 'begin': %w", err)
+		}
+		r.Begin = uint32(begin)
+	}
+	if tmp.End != "" {
+		end, err := strconv.ParseUint(tmp.End, 16, 32)
+		if err != nil {
+			return fmt.Errorf("parsing partition range 'end': %w", err)
+		}
+		r.End = uint32(end)
+	}
+	return nil
+}
+
+func (r Range) Validate() error {
+	if r.Begin > r.End {
+		return fmt.Errorf("expected Begin <= End")
+	}
+	return nil
+}
+
+func (r Range) Includes(hash uint32) bool {
+	return hash >= r.Begin && hash <= r.End
+}
+
+// Intersection returns the intersection of two overlapping PartitionRanges. If the ranges do not
+// overlap, this function will panic.
+func (r Range) Intersection(other Range) Range {
+	var result = r
+	if other.Begin > r.Begin {
+		result.Begin = other.Begin
+	}
+	if other.End < r.End {
+		result.End = other.End
+	}
+	if result.Begin > result.End {
+		panic("intersected partition ranges that do not overlap")
+	}
+	return result
+}
+
+// IncludesHwHash determines whether the given partition id is included in this partition range.
+// This uses a stable hash function (Highway hash) that is guaranteed never to change.
+func (r Range) IncludesHwHash(partitionID []byte) bool {
+	var hashed = hwHashPartition(partitionID)
+	return r.Includes(hashed)
+}
+
+// highwayHashKey is a fixed 32 bytes (as required by HighwayHash) read from /dev/random.
+// DO NOT MODIFY this value, as it is required to have consistent hash results.
+var highwayHashKey, _ = hex.DecodeString("332757d16f0fb1cf2d4f676f85e34c6a8b85aa58f42bb081449d8eb2e4ed529f")
+
+func hwHashPartition(partitionId []byte) uint32 {
+	return uint32(highwayhash.Sum64(partitionId, highwayHashKey) >> 32)
+}
+
+// RangeOverlap is the result of checking whether one Range overlaps another.
+type RangeOverlap int
+
+const (
+	NoRangeOverlap      RangeOverlap = 0
+	PartialRangeOverlap RangeOverlap = 1
+	FullRangeOverlap    RangeOverlap = 2
+)
+
+func (rr RangeOverlap) String() string {
+	switch rr {
+	case NoRangeOverlap:
+		return "NoRangeOverlap"
+	case PartialRangeOverlap:
+		return "PartialRangeOverlap"
+	case FullRangeOverlap:
+		return "FullRangeOverlap"
+	default:
+		return fmt.Sprintf("invalid OverlapResult(%d)", int(rr))
+	}
+}
+
+// Overlaps checks whether `other` overlaps this Range. Note that this is *not* reflexive. For example:
+// [1-10].Overlaps([4-6]) == FullRangeOverlap
+// But [4-6].Overlaps([1-10]) == PartialRangeOverlap
+func (r Range) Overlaps(other Range) RangeOverlap {
+	var includesBegin = r.Includes(other.Begin)
+	var includesEnd = r.Includes(other.End)
+	if includesBegin && includesEnd {
+		return FullRangeOverlap
+	} else if includesBegin != includesEnd {
+		return PartialRangeOverlap
+	} else {
+		return NoRangeOverlap
+	}
+}

--- a/protocols/airbyte/partition_range_test.go
+++ b/protocols/airbyte/partition_range_test.go
@@ -1,0 +1,55 @@
+package airbyte
+
+import (
+	"encoding/json"
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestPartitionRangeOverlap(t *testing.T) {
+	for _, testCase := range []struct {
+		expected                 RangeOverlap
+		flowStart, flowEnd       uint32
+		kinesisStart, kinesisEnd uint32
+	}{
+		{FullRangeOverlap, 0, math.MaxUint32, 0, math.MaxUint32},
+		{FullRangeOverlap, 0, math.MaxUint32, 5, 5},
+		{PartialRangeOverlap, 5, 6, 4, 5},
+		{FullRangeOverlap, 4, 6, 6, 6},
+		{NoRangeOverlap, 0, 5, 9, 10},
+		{NoRangeOverlap, 6, 8, 0, 0},
+	} {
+		var flowRange = Range{
+			Begin: testCase.flowStart,
+			End:   testCase.flowEnd,
+		}
+		var kinesisRange = Range{
+			Begin: testCase.kinesisStart,
+			End:   testCase.kinesisEnd,
+		}
+
+		if o := flowRange.Overlaps(kinesisRange); o != testCase.expected {
+			t.Logf("expected %#v, but got %#v", testCase.expected, o)
+			t.Fail()
+		}
+	}
+}
+
+func TestRangeRoundTrip(t *testing.T) {
+	var rng = Range{
+		Begin: 12345,
+		End:   678910,
+	}
+	require.NoError(t, rng.Validate())
+
+	var b, err = json.Marshal(rng)
+	require.NoError(t, err)
+	require.Equal(t, `{"begin":"00003039","end":"000a5bfe"}`, string(b))
+
+	var rng2 Range
+	require.NoError(t, json.Unmarshal(b, &rng2))
+	require.NoError(t, rng2.Validate())
+	require.Equal(t, rng, rng2)
+}


### PR DESCRIPTION
**Description:**

This isn't a simple cherry-pick because the 'protocols/airbyte' helper package lives in the Flow repository, and bumping the entire version of that has a bunch of undesired side effects.

So instead, I'm taking the lazy way out and copy-pasting the whole 'protocols/airbyte' package over, then modifying source-gcs to use the new copy. This appears to work as desired with minimal side effects, and while it's not the most maintainable in the long run we will hopefully not be maintaining this backport branch very long.

