### PR TITLE
source-mysql: Downgrade spammy log message from INFO to TRACE

### DIFF
--- a/source-mysql/discovery.go
+++ b/source-mysql/discovery.go
@@ -218,7 +218,7 @@ func (t *mysqlColumnType) translateRecordField(val interface{}) (interface{}, er
 	logrus.WithFields(logrus.Fields{
 		"type":  fmt.Sprintf("%#v", t),
 		"value": fmt.Sprintf("%#v", val),
-	}).Info("translating record field")
+	}).Trace("translating record field")
 
 	switch t.Type {
 	case "enum":


### PR DESCRIPTION
**Description:**

Somebody (who might be past me) left this log message at `INFO` level, which means that we're getting one spam message per enum value translated. For a table using enums this means at least one message per row, and that's terrible.

Downgrade it to `TRACE` level.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/416)
<!-- Reviewable:end -->
