### PR TITLE
source-mysql: Add a couple of debug log messages

### DIFF
--- a/source-mysql/backfill.go
+++ b/source-mysql/backfill.go
@@ -50,6 +50,11 @@ func (db *mysqlDatabase) ScanTableChunk(ctx context.Context, info sqlcapture.Tab
 
 	// Process the results into `changeEvent` structs and return them
 	var events []sqlcapture.ChangeEvent
+	logrus.WithFields(logrus.Fields{
+		"schema": schema,
+		"table":  table,
+		"rows":   len(results.Values),
+	}).Debug("translating query rows to change events")
 	for _, row := range results.Values {
 		var fields = make(map[string]interface{})
 		for idx, val := range row {

--- a/sqlcapture/resultset.go
+++ b/sqlcapture/resultset.go
@@ -45,6 +45,10 @@ func (r *resultSet) Buffer(streamID string, keyColumns []string, events []Change
 	}
 
 	// Otherwise add the new row to the `rows` map and update `scanned`.
+	logrus.WithFields(logrus.Fields{
+		"stream": streamID,
+		"count":  len(events),
+	}).Debug("buffering chunk of backfill data")
 	for _, event := range events {
 		var bs, err = encodeRowKey(chunk.keyColumns, event.After, db)
 		if err != nil {


### PR DESCRIPTION
**Description:**

Adds a couple more debug log messages. We're observing one backfill in production which appears to hang for **a very very long time** on each backfill query, and it would be useful to know for certain that the query itself is the part taking all that time (as opposed to the result value processing).

And happily, now that the final couple of "make log levels work" PRs have landed, we can actually turn on debug logging in production via `flowctl-admin shards edit`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/420)
<!-- Reviewable:end -->
