### PR TITLE
source-{mysql,postgres}: EXPLAIN backfill queries and log result

### DIFF
--- a/source-mysql/backfill.go
+++ b/source-mysql/backfill.go
@@ -27,9 +27,9 @@ func (db *mysqlDatabase) WatermarksTable() string {
 
 func (db *mysqlDatabase) ScanTableChunk(ctx context.Context, info sqlcapture.TableInfo, keyColumns []string, resumeKey []interface{}) ([]sqlcapture.ChangeEvent, error) {
 	var schema, table = info.Schema, info.Name
+	var streamID = sqlcapture.JoinStreamID(schema, table)
 	logrus.WithFields(logrus.Fields{
-		"schema":     schema,
-		"table":      table,
+		"stream":     streamID,
 		"keyColumns": keyColumns,
 		"resumeKey":  resumeKey,
 	}).Debug("scanning table chunk")
@@ -39,8 +39,12 @@ func (db *mysqlDatabase) ScanTableChunk(ctx context.Context, info sqlcapture.Tab
 		columnTypes[name] = column.DataType
 	}
 
-	// Build and execute a query to fetch the next `backfillChunkSize` rows from the database
+	// Build a query to fetch the next `backfillChunkSize` rows from the database.
+	// If this is the first chunk being backfilled, run an `EXPLAIN` on it and log the results
 	var query = db.buildScanQuery(resumeKey == nil, keyColumns, schema, table)
+	db.explainQuery(streamID, query, resumeKey)
+
+	// Execute the backfill query to fetch rows from the database
 	logrus.WithFields(logrus.Fields{"query": query, "args": resumeKey}).Debug("executing query")
 	results, err := db.conn.Execute(query, resumeKey...)
 	if err != nil {
@@ -51,8 +55,7 @@ func (db *mysqlDatabase) ScanTableChunk(ctx context.Context, info sqlcapture.Tab
 	// Process the results into `changeEvent` structs and return them
 	var events []sqlcapture.ChangeEvent
 	logrus.WithFields(logrus.Fields{
-		"schema": schema,
-		"table":  table,
+		"stream": streamID,
 		"rows":   len(results.Values),
 	}).Debug("translating query rows to change events")
 	for _, row := range results.Values {
@@ -103,4 +106,45 @@ func (db *mysqlDatabase) buildScanQuery(start bool, keyColumns []string, schemaN
 	fmt.Fprintf(query, " ORDER BY %s", pkey)
 	fmt.Fprintf(query, " LIMIT %d;", db.config.Advanced.BackfillChunkSize)
 	return query.String()
+}
+
+func (db *mysqlDatabase) explainQuery(streamID, query string, args []interface{}) {
+	// Only EXPLAIN the backfill query once per connector invocation
+	if db.explained == nil {
+		db.explained = make(map[string]struct{})
+	}
+	if _, ok := db.explained[streamID]; ok {
+		return
+	}
+	db.explained[streamID] = struct{}{}
+
+	// Ask the database to EXPLAIN the backfill query
+	var explainQuery = "EXPLAIN " + query
+	logrus.WithFields(logrus.Fields{
+		"id":    streamID,
+		"query": explainQuery,
+	}).Info("explain backfill query")
+	explainResult, err := db.conn.Execute(explainQuery, args...)
+	if err != nil {
+		logrus.WithField("query", explainQuery).Warn("unable to execute query")
+		return
+	}
+	defer explainResult.Close()
+
+	// Log the response, doing a bit of extra work to make it readable
+	for _, row := range explainResult.Values {
+		var result []string
+		for idx, field := range row {
+			var key = string(explainResult.Fields[idx].Name)
+			var val = field.Value()
+			if bs, ok := val.([]byte); ok {
+				val = string(bs)
+			}
+			result = append(result, fmt.Sprintf("%s=%v", key, val))
+		}
+		logrus.WithFields(logrus.Fields{
+			"id":       streamID,
+			"response": result,
+		}).Info("explain backfill query")
+	}
 }

--- a/source-mysql/main.go
+++ b/source-mysql/main.go
@@ -182,6 +182,7 @@ type mysqlDatabase struct {
 	config        *Config
 	conn          *client.Conn
 	defaultSchema string
+	explained     map[string]struct{} // Tracks tables which have had an `EXPLAIN` run on them during this connector invocation
 }
 
 func (db *mysqlDatabase) Connect(ctx context.Context) error {

--- a/source-postgres/main.go
+++ b/source-postgres/main.go
@@ -168,8 +168,9 @@ func configSchema() json.RawMessage {
 }
 
 type postgresDatabase struct {
-	config *Config
-	conn   *pgx.Conn
+	config    *Config
+	conn      *pgx.Conn
+	explained map[string]struct{} // Tracks tables which have had an `EXPLAIN` run on them during this connector invocation
 }
 
 func (db *postgresDatabase) Connect(ctx context.Context) error {


### PR DESCRIPTION
**Description:**

Once per connector restart (per backfilling table), before actually running the backfill query we ask the database to EXPLAIN the query and then log the response.

This should help us diagnose some conditions where backfill queries aren't performing as expected. Any errors which occur during the EXPLAIN process will be logged but not treated as fatal.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/421)
<!-- Reviewable:end -->
