### PR TITLE
source-firestore: Add 'initTimestamp' resource property

### DIFF
--- a/source-firestore/.snapshots/TestSpec
+++ b/source-firestore/.snapshots/TestSpec
@@ -39,7 +39,11 @@
           "sync"
         ],
         "title": "Backfill Mode",
-        "description": "Configures the handling of data already in the collection. Refer to go.estuary.dev/source-firestore for details or just stick with 'async'"
+        "description": "Configures the handling of data already in the collection. Refer to go.estuary.dev/source-firestore for details or just stick with 'async'. Has no effect if changed after a binding is added."
+      },
+      "initTimestamp": {
+        "type": "string",
+        "description": "Optionally overrides the initial replication timestamp (which is either Zero or Now depending on the backfill mode). Has no effect if changed after a binding is added."
       }
     },
     "type": "object",

--- a/source-firestore/pull.go
+++ b/source-firestore/pull.go
@@ -172,6 +172,13 @@ func initResourceStates(prevStates map[string]*resourceState, resourceBindings [
 			default:
 				return nil, fmt.Errorf("invalid backfill mode %q for %q", resource.BackfillMode, resource.Path)
 			}
+			if resource.InitTimestamp != "" {
+				if ts, err := time.Parse(time.RFC3339Nano, resource.InitTimestamp); err != nil {
+					return nil, fmt.Errorf("invalid initTimestamp value %q: %w", resource.InitTimestamp, err)
+				} else {
+					state.ReadTime = ts
+				}
+			}
 		}
 		states[resource.Path] = state
 	}


### PR DESCRIPTION
**Description:**

This is vaguely analagous to how we've used path regexes on filesource captures in the past, as a mechanism for kicking a malfunctioning capture back into the state we need it to be in.

In this particular case, what this allows is taking a collection binding for which replication streaming is failing and removing it from the catalog, and then at a later date we can either re- add it with *the same* timestamp that it used to have, or we can add it with some later timestamp if we need to fiddle around with things manually.

**Workflow steps:**

Nothing should change by default, but now it's possible to manually tweak the initial replication cursor timestamp when adding a capture binding (and **only** when first adding it, the state is authoritative and this new property just impacts the default/initialization behavior, so changes after that point have no effect).

**Documentation links affected:**

I would recommend we not document this particular knob at the moment, but if we do want to mention it that will need to go in https://go.estuary.dev/source-firestore

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/426)
<!-- Reviewable:end -->
