### PR TITLE
source-test: "exit_after" instead of tail

### DIFF
--- a/source-test/main.go
+++ b/source-test/main.go
@@ -12,6 +12,7 @@ type Config struct {
 	Greetings        int              `json:"greetings"`
 	SkipState        bool             `json:"skip_state"`
 	FailAfter        int              `json:"fail_after"`
+	ExitAfter        int              `json:"exit_after"`
 	OAuthCredentials oauthCredentials `json:"credentials"`
 }
 
@@ -61,6 +62,11 @@ const configSchema = `{
       "type": ["integer", "null"],
       "title": "Fail after sending N number of greetings",
       "description": "Fail after sending N number of greetings"
+    },
+    "exit_after": {
+      "type": ["integer", "null"],
+      "title": "Exit after sending N number of greetings",
+      "description": "Exit after sending N number of greetings"
     },
     "credentials": {
       "type": "object",
@@ -181,7 +187,7 @@ func doRead(args airbyte.ReadCmd) error {
 		if config.FailAfter != 0 && state.Cursor >= config.FailAfter {
 			return fmt.Errorf("a horrible, no good error!")
 		}
-		if state.Cursor >= config.Greetings && !catalog.Tail {
+		if config.ExitAfter != 0 && state.Cursor >= config.ExitAfter {
 			return nil // All done.
 		}
 
@@ -219,8 +225,6 @@ func doRead(args airbyte.ReadCmd) error {
 			}
 		}
 
-		if catalog.Tail {
-			now = <-time.After(time.Millisecond * 500)
-		}
+		now = <-time.After(time.Millisecond * 500)
 	}
 }


### PR DESCRIPTION
**Description:**

- Remove use of `catalog.Tail` option
- Introduce `exit_after` option to ask connector to exit after N rows
- This makes the `greetings` option pretty much useless. I'm still keeping it around so we don't break things but we can remove that option once we know no one is using it.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/429)
<!-- Reviewable:end -->
