### PR TITLE
Remove `tail`

### DIFF
--- a/source-firestore/pull.go
+++ b/source-firestore/pull.go
@@ -104,7 +104,6 @@ func (driver) Pull(stream pc.Driver_PullServer) error {
 			Resources: updatedResourceStates,
 		},
 		Output: &boilerplate.PullOutput{Stream: stream},
-		Tail:   open.Open.Tail,
 	}
 	return capture.Run(stream.Context())
 }
@@ -114,7 +113,6 @@ type capture struct {
 	Config   config
 	State    *captureState
 	Output   *boilerplate.PullOutput
-	Tail     bool
 }
 
 type captureState struct {
@@ -571,10 +569,6 @@ func (c *capture) StreamChanges(ctx context.Context, client *firestore_v1.Client
 						return err
 					} else if err := c.Output.Checkpoint(checkpointJSON, true); err != nil {
 						return err
-					}
-					// In polling mode (tests), shut down the capture once caught up
-					if !c.Tail {
-						return nil
 					}
 				}
 			case firestore_pb.TargetChange_ADD:

--- a/source-hello-world/main.go
+++ b/source-hello-world/main.go
@@ -9,7 +9,6 @@ import (
 )
 
 type Config struct {
-	Greetings int `json:"greetings"`
 }
 
 type State struct {
@@ -17,9 +16,6 @@ type State struct {
 }
 
 func (c *Config) Validate() error {
-	if c.Greetings == 0 {
-		return fmt.Errorf("missing greetings")
-	}
 	return nil
 }
 
@@ -35,12 +31,6 @@ const configSchema = `{
 		"greetings"
 	],
 	"properties": {
-		"greetings": {
-			"type":        "integer",
-			"title":       "Number of Greetings",
-			"description": "Number of greeting documents to produce when running in non-tailing mode",
-			"default":     1000
-		}
 	}
 }`
 
@@ -119,10 +109,6 @@ func doRead(args airbyte.ReadCmd) error {
 	var enc = airbyte.NewStdoutEncoder()
 	var now = time.Now()
 	for {
-		if state.Cursor >= config.Greetings && !catalog.Tail {
-			return nil // All done.
-		}
-
 		var b, err = json.Marshal(struct {
 			Count   int    `json:"count"`
 			Message string `json:"message"`
@@ -155,8 +141,6 @@ func doRead(args airbyte.ReadCmd) error {
 			return err
 		}
 
-		if catalog.Tail {
-			now = <-time.After(time.Millisecond * 500)
-		}
+		now = <-time.After(time.Millisecond * 500)
 	}
 }

--- a/source-kinesis/discovery.go
+++ b/source-kinesis/discovery.go
@@ -94,7 +94,6 @@ func peekAtStream(ctx context.Context, client *kinesis.Kinesis, streamName strin
 		cancel      context.CancelFunc
 		dataCh      chan readResult      = make(chan readResult, 8)
 		shardRange  airbyte.Range        = airbyte.NewFullRange()
-		stopAt      time.Time            = time.Now()
 		streamState map[string]string    = make(map[string]string)
 		waitGroup   *sync.WaitGroup      = new(sync.WaitGroup)
 		docs        chan json.RawMessage = make(chan schema_inference.Document, peekAtMost)
@@ -105,7 +104,7 @@ func peekAtStream(ctx context.Context, client *kinesis.Kinesis, streamName strin
 	defer cancel()
 
 	waitGroup.Add(1)
-	go readStream(ctx, shardRange, client, streamName, streamState, dataCh, &stopAt, waitGroup)
+	go readStream(ctx, shardRange, client, streamName, streamState, dataCh, waitGroup)
 	go closeChannelWhenDone(dataCh, waitGroup)
 	defer close(docs)
 

--- a/source-kinesis/main.go
+++ b/source-kinesis/main.go
@@ -131,14 +131,6 @@ func readStreamsTo(ctx context.Context, args airbyte.ReadCmd, output io.Writer) 
 		shardRange = airbyte.NewFullRange()
 	}
 
-	var stopAt *time.Time
-	if !catalog.Tail {
-		var t = time.Now().UTC()
-		log.Infof("reading in non-tailing mode until: %v", t)
-		stopAt = &t
-	} else {
-		log.Info("reading indefinitely because tail==true")
-	}
 	var waitGroup = new(sync.WaitGroup)
 	for _, stream := range catalog.Streams {
 		streamState, err := copyStreamState(stateMap, stream.Stream.Name)
@@ -147,7 +139,7 @@ func readStreamsTo(ctx context.Context, args airbyte.ReadCmd, output io.Writer) 
 			return fmt.Errorf("invalid state for stream %s: %w", stream.Stream.Name, err)
 		}
 		waitGroup.Add(1)
-		go readStream(ctx, shardRange, client, stream.Stream.Name, streamState, dataCh, stopAt, waitGroup)
+		go readStream(ctx, shardRange, client, stream.Stream.Name, streamState, dataCh, waitGroup)
 	}
 
 	go closeChannelWhenDone(dataCh, waitGroup)

--- a/sqlcapture/main.go
+++ b/sqlcapture/main.go
@@ -175,7 +175,6 @@ func (d *Driver) Pull(stream pc.Driver_PullServer) error {
 		Bindings: bindings,
 		State:    state,
 		Output:   &boilerplate.PullOutput{Stream: stream},
-		Tail:     open.Open.Tail,
 		Database: db,
 	}
 	return c.Run(ctx)


### PR DESCRIPTION
**Description:**

- Remove use of `tail` when running e2e tests, and instead periodically check lines of output against expected lines, and once we reach the same number of lines we compare them one final time to see if the test passes or not
- Remove code that handled non-tailing mode from various connectors

**Workflow steps:**

N/A, supposed to be seamless, unless you were using `--poll`, which now connectors won't handle

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/430)
<!-- Reviewable:end -->
