### PR TITLE
source-mysql: Translate TIMESTAMP/DATETIME to RFC3339 strings

### DIFF
--- a/source-mysql/main.go
+++ b/source-mysql/main.go
@@ -218,6 +218,11 @@ func (db *mysqlDatabase) Connect(ctx context.Context) error {
 		return fmt.Errorf("unable to connect to database: %w", err)
 	}
 
+	// Set our desired timezone to UTC. This is required for backfills of timestamp columns to behave consistently.
+	if _, err := db.conn.Execute("SET time_zone = '+00:00';"); err != nil {
+		return fmt.Errorf("error setting session time_zone: %w", err)
+	}
+
 	// Sanity-check binlog retention and error out if it's insufficiently long.
 	// By doing this during the Connect operation it will occur both during
 	// actual captures and when performing discovery/config validation, which

--- a/source-mysql/replication.go
+++ b/source-mysql/replication.go
@@ -91,6 +91,8 @@ func (db *mysqlDatabase) StartReplication(ctx context.Context, startCursor strin
 		Password: db.config.Password,
 		// TODO(wgd): Maybe add 'serverName' checking as described over in Connect()
 		TLSConfig: &tls.Config{InsecureSkipVerify: true},
+		// Request that timestamp values coming via replication be interpreted as UTC.
+		TimestampStringLocation: time.UTC,
 	}
 
 	logrus.WithFields(logrus.Fields{"pos": pos}).Info("starting replication")


### PR DESCRIPTION
**Description:**

Previously they were captured as strings in MySQL's preferred timestamp format (`YYYY-MM-DD HH:MM:SS`). This commit changes things so that they are instead (`YYYY-MM-DDTHH:MM:SSZ`).

Note that MySQL TIMESTAMP / DATETIME columns don't actually store any useful time zone information. A TIMESTAMP is defined as being converted to UTC for storage, so we rely on the DB to get that right and just request that it give us the values in UTC as well. For the DATETIME column type we don't even have that assurance, so treating them as UTC is probably wrong but it's still the best we can do.

I'm torn on whether this change requires a version bump. All we previously said was "it's a string" so changing the format is _technically legal_, I think? It would make things a lot easier if we can fix this without a version bump, because then it's simple to go ahead and merge this prior to the big gRPC migration PR that'll be merged in the near future.

**Workflow steps:**

The `TIMESTAMP` and `DATETIME` column types will now be discovered as `type: string, format: date-time` instead of just `type: string` and captured values are emitted as valid RFC3339 timestamps.

**Documentation links affected:**

None, I don't think we document current behavior at this level of detail.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/433)
<!-- Reviewable:end -->
