### PR TITLE
source-mysql: Ignore 'GenericEvent' replication events

### DIFF
--- a/source-mysql/replication.go
+++ b/source-mysql/replication.go
@@ -361,6 +361,8 @@ func (rs *mysqlReplicationStream) run(ctx context.Context) error {
 			}).Trace("Rotate Event")
 		case *replication.FormatDescriptionEvent:
 			logrus.WithField("data", data).Trace("Format Description Event")
+		case *replication.GenericEvent:
+			logrus.WithField("event", event.Header.EventType.String()).Debug("Generic Event")
 		default:
 			return fmt.Errorf("unhandled event type: %q", event.Header.EventType)
 		}


### PR DESCRIPTION
**Description:**

This commit modifies `source-myqsl` to ignore events that the client library represents as `replication.GenericEvent` messages. These are a grab-bag of rare edge cases that we don't care about, with the most common being `SHUTDOWN_EVENT` (which indicates that the MySQL server shut down at some point in the past and then presumably either restarted or failed over to a replica or something).

I've skimmed the code to see what events are classified as `replication.GenericEvent` and I'm fairly sure we can safely ignore all of them.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/437)
<!-- Reviewable:end -->
