### PR TITLE
source-mysql: Use DB `time_zone` for DATETIME parsing

### DIFF
--- a/source-boilerplate/testing/testing.go
+++ b/source-boilerplate/testing/testing.go
@@ -157,6 +157,7 @@ func (cs *CaptureSpec) Capture(ctx context.Context, t testing.TB, callback func(
 		callback:   callback,
 	}
 	if err := cs.Driver.Pull(adapter); err != nil && !errors.Is(err, context.Canceled) {
+		log.WithField("err", err).Error("capture terminated with error")
 		cs.Errors = append(cs.Errors, err)
 	}
 	cs.Checkpoint = adapter.checkpoint

--- a/source-mysql/backfill.go
+++ b/source-mysql/backfill.go
@@ -63,7 +63,7 @@ func (db *mysqlDatabase) ScanTableChunk(ctx context.Context, info sqlcapture.Tab
 		for idx, val := range row {
 			fields[string(results.Fields[idx].Name)] = val.Value()
 		}
-		if err := translateRecordFields(columnTypes, fields); err != nil {
+		if err := db.translateRecordFields(columnTypes, fields); err != nil {
 			return nil, fmt.Errorf("error backfilling table %q: %w", table, err)
 		}
 

--- a/source-mysql/datatype_test.go
+++ b/source-mysql/datatype_test.go
@@ -107,3 +107,41 @@ func TestDatatypes(t *testing.T) {
 		{ColumnType: "json", ExpectType: `{}`, InputValue: `{"type": "test", "data": 123}`, ExpectValue: `{"data":123,"type":"test"}`},
 	})
 }
+
+func TestDatetimes(t *testing.T) {
+	var ctx = context.Background()
+
+	// In Chicago noon should map to 17:00 or 18:00 UTC in summer/winter respectively due to DST.
+	t.Run("chicago", func(t *testing.T) {
+		TestBackend.Query(ctx, t, "SET GLOBAL time_zone = 'America/Chicago';")
+		tests.TestDatatypes(ctx, t, TestBackend, []tests.DatatypeTestCase{
+			{ColumnType: "datetime", ExpectType: `{"type":["string","null"],"format":"date-time"}`, InputValue: "1991-08-31 12:34:56", ExpectValue: `"1991-08-31T17:34:56Z"`},
+			{ColumnType: "datetime", ExpectType: `{"type":["string","null"],"format":"date-time"}`, InputValue: "1992-01-01 12:34:56", ExpectValue: `"1992-01-01T18:34:56Z"`},
+			{ColumnType: "timestamp", ExpectType: `{"type":["string","null"],"format":"date-time"}`, InputValue: "1991-08-31 12:34:56", ExpectValue: `"1991-08-31T17:34:56Z"`},
+			{ColumnType: "timestamp", ExpectType: `{"type":["string","null"],"format":"date-time"}`, InputValue: "1992-01-01 12:34:56", ExpectValue: `"1992-01-01T18:34:56Z"`},
+		})
+	})
+
+	// In fixed offset UTC-6 noon should always map to 18:00 UTC regardless of the time of the year.
+	t.Run("utc_minus_6", func(t *testing.T) {
+		TestBackend.Query(ctx, t, "SET GLOBAL time_zone = '-6:00';") // Leading zero deliberately omitted to make sure MySQL normalizes it into something we can parse
+		tests.TestDatatypes(ctx, t, TestBackend, []tests.DatatypeTestCase{
+			{ColumnType: "datetime", ExpectType: `{"type":["string","null"],"format":"date-time"}`, InputValue: "1991-08-31 12:34:56", ExpectValue: `"1991-08-31T18:34:56Z"`},
+			{ColumnType: "datetime", ExpectType: `{"type":["string","null"],"format":"date-time"}`, InputValue: "1992-01-01 12:34:56", ExpectValue: `"1992-01-01T18:34:56Z"`},
+			{ColumnType: "timestamp", ExpectType: `{"type":["string","null"],"format":"date-time"}`, InputValue: "1991-08-31 12:34:56", ExpectValue: `"1991-08-31T18:34:56Z"`},
+			{ColumnType: "timestamp", ExpectType: `{"type":["string","null"],"format":"date-time"}`, InputValue: "1992-01-01 12:34:56", ExpectValue: `"1992-01-01T18:34:56Z"`},
+		})
+	})
+
+	// In Manila noon should map to 04:00 UTC regardless of the time of the year, because Philippines
+	// Standard Time stopped observing DST in 1990.
+	t.Run("manila", func(t *testing.T) {
+		TestBackend.Query(ctx, t, "SET GLOBAL time_zone = 'Asia/Manila';")
+		tests.TestDatatypes(ctx, t, TestBackend, []tests.DatatypeTestCase{
+			{ColumnType: "datetime", ExpectType: `{"type":["string","null"],"format":"date-time"}`, InputValue: "1991-08-31 12:34:56", ExpectValue: `"1991-08-31T04:34:56Z"`},
+			{ColumnType: "datetime", ExpectType: `{"type":["string","null"],"format":"date-time"}`, InputValue: "1992-01-01 12:34:56", ExpectValue: `"1992-01-01T04:34:56Z"`},
+			{ColumnType: "timestamp", ExpectType: `{"type":["string","null"],"format":"date-time"}`, InputValue: "1991-08-31 12:34:56", ExpectValue: `"1991-08-31T04:34:56Z"`},
+			{ColumnType: "timestamp", ExpectType: `{"type":["string","null"],"format":"date-time"}`, InputValue: "1992-01-01 12:34:56", ExpectValue: `"1992-01-01T04:34:56Z"`},
+		})
+	})
+}

--- a/source-mysql/datatype_test.go
+++ b/source-mysql/datatype_test.go
@@ -14,6 +14,7 @@ func TestDatatypes(t *testing.T) {
 	// Tell MySQL to act as though we're running in Chicago. This has an effect (in very
 	// different ways) on the processing of DATETIME and TIMESTAMP values.
 	TestBackend.Query(ctx, t, "SET GLOBAL time_zone = 'America/Chicago';")
+	TestBackend.Query(ctx, t, "SET SESSION time_zone = 'America/Chicago';")
 
 	tests.TestDatatypes(ctx, t, TestBackend, []tests.DatatypeTestCase{
 		{ColumnType: "integer", ExpectType: `{"type":["integer","null"]}`, InputValue: 123, ExpectValue: `123`},
@@ -114,6 +115,7 @@ func TestDatetimes(t *testing.T) {
 	// In Chicago noon should map to 17:00 or 18:00 UTC in summer/winter respectively due to DST.
 	t.Run("chicago", func(t *testing.T) {
 		TestBackend.Query(ctx, t, "SET GLOBAL time_zone = 'America/Chicago';")
+		TestBackend.Query(ctx, t, "SET SESSION time_zone = 'America/Chicago';")
 		tests.TestDatatypes(ctx, t, TestBackend, []tests.DatatypeTestCase{
 			{ColumnType: "datetime", ExpectType: `{"type":["string","null"],"format":"date-time"}`, InputValue: "1991-08-31 12:34:56", ExpectValue: `"1991-08-31T17:34:56Z"`},
 			{ColumnType: "datetime", ExpectType: `{"type":["string","null"],"format":"date-time"}`, InputValue: "1992-01-01 12:34:56", ExpectValue: `"1992-01-01T18:34:56Z"`},
@@ -125,6 +127,7 @@ func TestDatetimes(t *testing.T) {
 	// In fixed offset UTC-6 noon should always map to 18:00 UTC regardless of the time of the year.
 	t.Run("utc_minus_6", func(t *testing.T) {
 		TestBackend.Query(ctx, t, "SET GLOBAL time_zone = '-6:00';") // Leading zero deliberately omitted to make sure MySQL normalizes it into something we can parse
+		TestBackend.Query(ctx, t, "SET SESSION time_zone = '-6:00';")
 		tests.TestDatatypes(ctx, t, TestBackend, []tests.DatatypeTestCase{
 			{ColumnType: "datetime", ExpectType: `{"type":["string","null"],"format":"date-time"}`, InputValue: "1991-08-31 12:34:56", ExpectValue: `"1991-08-31T18:34:56Z"`},
 			{ColumnType: "datetime", ExpectType: `{"type":["string","null"],"format":"date-time"}`, InputValue: "1992-01-01 12:34:56", ExpectValue: `"1992-01-01T18:34:56Z"`},
@@ -137,6 +140,7 @@ func TestDatetimes(t *testing.T) {
 	// Standard Time stopped observing DST in 1990.
 	t.Run("manila", func(t *testing.T) {
 		TestBackend.Query(ctx, t, "SET GLOBAL time_zone = 'Asia/Manila';")
+		TestBackend.Query(ctx, t, "SET SESSION time_zone = 'Asia/Manila';")
 		tests.TestDatatypes(ctx, t, TestBackend, []tests.DatatypeTestCase{
 			{ColumnType: "datetime", ExpectType: `{"type":["string","null"],"format":"date-time"}`, InputValue: "1991-08-31 12:34:56", ExpectValue: `"1991-08-31T04:34:56Z"`},
 			{ColumnType: "datetime", ExpectType: `{"type":["string","null"],"format":"date-time"}`, InputValue: "1992-01-01 12:34:56", ExpectValue: `"1992-01-01T04:34:56Z"`},

--- a/source-mysql/main.go
+++ b/source-mysql/main.go
@@ -235,7 +235,9 @@ func (db *mysqlDatabase) connect(ctx context.Context) error {
 		logrus.Warn("capturing DATETIME values will not be permitted")
 	}
 
-	// Set our desired timezone to UTC. This is required for backfills of TIMESTAMP columns to behave consistently.
+	// Set our desired timezone (specifically for the backfill connection, this has
+	// no effect on the database as a whole) to UTC. This is required for backfills of
+	// TIMESTAMP columns to behave consistently, and has no effect on DATETIME columns.
 	if _, err := db.conn.Execute("SET time_zone = '+00:00';"); err != nil {
 		return fmt.Errorf("error setting session time_zone: %w", err)
 	}

--- a/source-mysql/main.go
+++ b/source-mysql/main.go
@@ -238,7 +238,7 @@ func (db *mysqlDatabase) connect(ctx context.Context) error {
 	// Set our desired timezone (specifically for the backfill connection, this has
 	// no effect on the database as a whole) to UTC. This is required for backfills of
 	// TIMESTAMP columns to behave consistently, and has no effect on DATETIME columns.
-	if _, err := db.conn.Execute("SET time_zone = '+00:00';"); err != nil {
+	if _, err := db.conn.Execute("SET SESSION time_zone = '+00:00';"); err != nil {
 		return fmt.Errorf("error setting session time_zone: %w", err)
 	}
 


### PR DESCRIPTION
**Description:**

The DATETIME column type is just a raw 'YYYY-MM-DD HH:MM:SS' value with no explicit frame of reference. In general there's an implicit reference of "the user's local time zone", but we don't necessarily know what that is. And we'd really like to emit captured values as RFC3339 timestamps, so we need to interpret the values *somewhere*.

After this PR we assume that if the database's `time_zone` system variable is set to a IANA zone name or a numeric time offset then that is the location/offset in which a DATETIME should be parsed.

If the `time_zone` variable is set to its default value of `'SYSTEM'` we refuse to translate DATETIMEs, because for some reason the MySQL `system_time_zone` variable only contains the current time offset [1] and not a valid zone name which could be used to interpret historical/future dates.

[1] To be concrete: if the system locale is set to 'America/Los_Angeles' then MySQL's `system_time_zone` will report 'PST' or 'PDT' at different times of the year, rather than something like 'PST8PDT' or 'America/Los_Angeles' which could actually be used to interpret historical data. In addition the strings 'PST' and 'PDT' are not valid IANA time zone names, so we just avoid all that complexity by requiring a valid `time_zone` setting.

**Documentation links affected:**

We should update https://docs.estuary.dev/reference/Connectors/capture-connectors/MySQL/ to discuss our requirement that the `time_zone` system variable be set to a valid time zone name or numeric offset if the user wants to capture `DATETIME` columns. Then https://go.estuary.dev/80J6rX should be updated to link to that particular bit of the docs.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/440)
<!-- Reviewable:end -->
