### PR TITLE
materialize-*: add x-collection-name to resource spec schemas

### DIFF
--- a/go-schema-gen/generate.go
+++ b/go-schema-gen/generate.go
@@ -26,7 +26,7 @@ func GenerateSchema(title string, configObject interface{}) *jsonschema.Schema {
 	schema.Title = title
 	walkSchema(
 		schema,
-		fixSchemaFlagBools(schema, "secret", "advanced", "multiline"),
+		fixSchemaFlagBools(schema, "secret", "advanced", "multiline", "x-collection-name"),
 		fixSchemaOrderingStrings,
 	)
 

--- a/materialize-bigquery/.snapshots/TestSpecification
+++ b/materialize-bigquery/.snapshots/TestSpecification
@@ -65,7 +65,8 @@
       "table": {
         "type": "string",
         "title": "Table",
-        "description": "Table in the BigQuery dataset to store materialized result in."
+        "description": "Table in the BigQuery dataset to store materialized result in.",
+        "x-collection-name": true
       },
       "delta_updates": {
         "type": "boolean",

--- a/materialize-bigquery/bigquery.go
+++ b/materialize-bigquery/bigquery.go
@@ -77,7 +77,7 @@ func (c *config) DatasetPath(path ...string) sql.TablePath {
 }
 
 type tableConfig struct {
-	Table     string `json:"table" jsonschema:"title=Table,description=Table in the BigQuery dataset to store materialized result in."`
+  Table     string `json:"table" jsonschema:"title=Table,description=Table in the BigQuery dataset to store materialized result in." jsonschema_extras:"x-collection-name=true"`
 	Delta     bool   `json:"delta_updates,omitempty" jsonschema:"default=false,title=Delta Update,description=Should updates to this table be done via delta updates. Defaults is false."`
 	projectID string
 	dataset   string

--- a/materialize-elasticsearch/.snapshots/TestDriverSpec
+++ b/materialize-elasticsearch/.snapshots/TestDriverSpec
@@ -35,7 +35,8 @@
     "properties": {
       "index": {
         "type": "string",
-        "description": "Name of the ElasticSearch index to store the materialization results."
+        "description": "Name of the ElasticSearch index to store the materialization results.",
+        "x-collection-name": true
       },
       "delta_updates": {
         "type": "boolean",

--- a/materialize-elasticsearch/driver.go
+++ b/materialize-elasticsearch/driver.go
@@ -32,7 +32,7 @@ func (c config) Validate() error {
 }
 
 type resource struct {
-	Index         string                        `json:"index"`
+	Index         string                        `json:"index" jsonschema_extras:"x-collection-name=true"`
 	DeltaUpdates  bool                          `json:"delta_updates" jsonschema:"default=false"`
 	FieldOverides []schemabuilder.FieldOverride `json:"field_overrides,omitempty"`
 

--- a/materialize-firebolt/.snapshots/TestDriverSpec
+++ b/materialize-firebolt/.snapshots/TestDriverSpec
@@ -81,7 +81,8 @@
       "table": {
         "type": "string",
         "title": "Table",
-        "description": "Name of the Firebolt table to store materialized results in. The external table will be named after this table with an `_external` suffix."
+        "description": "Name of the Firebolt table to store materialized results in. The external table will be named after this table with an `_external` suffix.",
+        "x-collection-name": true
       },
       "table_type": {
         "type": "string",

--- a/materialize-firebolt/config.go
+++ b/materialize-firebolt/config.go
@@ -64,8 +64,8 @@ func (config) GetFieldDocString(fieldName string) string {
 }
 
 type resource struct {
-	Table     string `json:"table" jsonschema:"title=Table"`
-	TableType string `json:"table_type" jsonschema:"title=Table Type,enum=fact,enum=dimension"`
+	Table     string `json:"table" jsonschema:"title=Table" jsonschema_extras:"x-collection-name=true"`
+	TableType string `json:"table_type" jsonschema:"title=Table Type,enum=fact,enum=dimension",default=fact`
 }
 
 func (r resource) Validate() error {

--- a/materialize-google-pubsub/.snapshots/TestSpec
+++ b/materialize-google-pubsub/.snapshots/TestSpec
@@ -87,7 +87,8 @@
       "topic": {
         "type": "string",
         "title": "Topic Name",
-        "description": "Name of the topic to publish materialized results to."
+        "description": "Name of the topic to publish materialized results to.",
+        "x-collection-name": true
       },
       "identifier": {
         "type": "string",

--- a/materialize-google-pubsub/driver.go
+++ b/materialize-google-pubsub/driver.go
@@ -60,7 +60,7 @@ func (c *config) client(ctx context.Context) (*pubsub.Client, error) {
 }
 
 type resource struct {
-	TopicName  string `json:"topic" jsonschema:"title=Topic Name"`
+	TopicName  string `json:"topic" jsonschema:"title=Topic Name" jsonschema_extras:"x-collection-name=true"`
 	Identifier string `json:"identifier,omitempty" jsonschema:"title=Resource Binding Identifier"`
 }
 

--- a/materialize-google-sheets/.snapshots/TestSpec
+++ b/materialize-google-sheets/.snapshots/TestSpec
@@ -87,7 +87,8 @@
       "sheet": {
         "type": "string",
         "title": "Sheet Name",
-        "description": "Name of the spreadsheet sheet to materialize into."
+        "description": "Name of the spreadsheet sheet to materialize into.",
+        "x-collection-name": true
       }
     },
     "type": "object",

--- a/materialize-google-sheets/main.go
+++ b/materialize-google-sheets/main.go
@@ -69,7 +69,7 @@ func (c config) buildService(ctx context.Context) (*sheets.Service, error) {
 }
 
 type resource struct {
-	Sheet string `json:"sheet" jsonschema:"title=Sheet Name"`
+	Sheet string `json:"sheet" jsonschema:"title=Sheet Name" jsonschema_extras:"x-collection-name=true"`
 }
 
 func (resource) GetFieldDocString(fieldName string) string {

--- a/materialize-postgres/.snapshots/TestSpecification
+++ b/materialize-postgres/.snapshots/TestSpecification
@@ -83,7 +83,8 @@
       "table": {
         "type": "string",
         "title": "Table",
-        "description": "Name of the database table"
+        "description": "Name of the database table",
+        "x-collection-name": true
       },
       "schema": {
         "type": "string",

--- a/materialize-postgres/driver.go
+++ b/materialize-postgres/driver.go
@@ -79,7 +79,7 @@ func (c *config) ToURI() string {
 }
 
 type tableConfig struct {
-	Table  string `json:"table" jsonschema:"title=Table,description=Name of the database table"`
+	Table  string `json:"table" jsonschema:"title=Table,description=Name of the database table" jsonschema_extras:"x-collection-name=true"`
 	Schema string `json:"schema,omitempty" jsonschema:"title=Alternative Schema,description=Alternative schema for this table (optional)"`
 	Delta  bool   `json:"delta_updates,omitempty" jsonschema:"default=false,title=Delta Update,description=Should updates to this table be done via delta updates. Default is false."`
 }

--- a/materialize-rockset/.snapshots/TestRocksetDriverSpec-TestResourceSpecSchema
+++ b/materialize-rockset/.snapshots/TestRocksetDriverSpec-TestResourceSpecSchema
@@ -10,7 +10,8 @@
     "collection": {
       "type": "string",
       "title": "Rockset Collection",
-      "description": "The name of the Rockset collection (will be created if it does not exist)"
+      "description": "The name of the Rockset collection (will be created if it does not exist)",
+      "x-collection-name": true
     },
     "initializeFromS3": {
       "properties": {

--- a/materialize-rockset/driver.go
+++ b/materialize-rockset/driver.go
@@ -112,7 +112,7 @@ func (s *collectionSettings) Validate() error {
 type resource struct {
 	Workspace string `json:"workspace,omitempty" jsonschema:"title=Workspace,description=The name of the Rockset workspace (will be created if it does not exist)"`
 	// The name of the Rockset collection (will be created if it does not exist)
-	Collection string `json:"collection,omitempty" jsonschema:"title=Rockset Collection,description=The name of the Rockset collection (will be created if it does not exist)"`
+	Collection string `json:"collection,omitempty" jsonschema:"title=Rockset Collection,description=The name of the Rockset collection (will be created if it does not exist)" jsonschema_extras:"x-collection-name=true"`
 	// Configures the rockset collection to bulk load an initial data set from an S3 bucket, before
 	// transitioning to using the write API for ongoing data. If a previous version of this
 	// materialization wrote files into S3 in order to more quickly backfill historical data, then

--- a/materialize-s3-parquet/.snapshots/TestS3ParquetDriverSpec
+++ b/materialize-s3-parquet/.snapshots/TestS3ParquetDriverSpec
@@ -63,7 +63,8 @@
     "$id": "https://github.com/estuary/connectors/materialize-s3-parquet/resource",
     "properties": {
       "pathPrefix": {
-        "type": "string"
+        "type": "string",
+        "x-collection-name": true
       },
       "compressionType": {
         "type": "string"

--- a/materialize-s3-parquet/driver.go
+++ b/materialize-s3-parquet/driver.go
@@ -86,7 +86,7 @@ func (c config) Validate() error {
 
 // resource specifies a materialization destinaion in S3, and the resulting parquet file configuration.
 type resource struct {
-	PathPrefix string `json:"pathPrefix"`
+	PathPrefix string `json:"pathPrefix" jsonschema_extras:"x-collection-name=true"`
 	// The method used for compressing data in parquet.
 	CompressionType string `json:"compressionType,omitempty"`
 }

--- a/materialize-snowflake/.snapshots/TestSpecification
+++ b/materialize-snowflake/.snapshots/TestSpecification
@@ -69,7 +69,8 @@
     "$id": "https://github.com/estuary/connectors/materialize-snowflake/table-config",
     "properties": {
       "table": {
-        "type": "string"
+        "type": "string",
+        "x-collection-name": "true"
       },
       "delta_updates": {
         "type": "boolean"

--- a/materialize-snowflake/snowflake.go
+++ b/materialize-snowflake/snowflake.go
@@ -65,7 +65,7 @@ func (c *config) Validate() error {
 type tableConfig struct {
 	base *config
 
-	Table string `json:"table"`
+	Table string `json:"table" jsonschema_extras:"x-collection-name=true"`
 	Delta bool   `json:"delta_updates,omitempty"`
 }
 


### PR DESCRIPTION
**Description:**

- Add `x-collection-name` annotation to materialization resource spec schemas, which will be used by the UI to fill in the collection name automatically

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

N/A

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/441)
<!-- Reviewable:end -->
