### PR TITLE
materialize-rockset: spec update indicating api key requirements

### DIFF
--- a/materialize-rockset/.snapshots/TestRocksetDriverSpec-TestEndpointSpecSchema
+++ b/materialize-rockset/.snapshots/TestRocksetDriverSpec-TestEndpointSpecSchema
@@ -5,7 +5,8 @@
     "api_key": {
       "type": "string",
       "title": "Rockset API Key",
-      "description": "The key used to authenticate to the Rockset API",
+      "description": "The key used to authenticate to the Rockset API. Must have role of admin or member.",
+      "multiline": true,
       "secret": true
     }
   },

--- a/materialize-rockset/.snapshots/TestRocksetDriverSpec-TestEndpointSpecSchema
+++ b/materialize-rockset/.snapshots/TestRocksetDriverSpec-TestEndpointSpecSchema
@@ -1,1 +1,17 @@
-{"$schema":"http://json-schema.org/draft/2020-12/schema","$id":"https://github.com/estuary/connectors/materialize-rockset/config","properties":{"api_key":{"type":"string","title":"Rockset API Key","description":"The key used to authenticate to the Rockset API","secret":true}},"type":"object","required":["api_key"],"title":"Rockset Endpoint"}
+{
+  "$schema": "http://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/estuary/connectors/materialize-rockset/config",
+  "properties": {
+    "api_key": {
+      "type": "string",
+      "title": "Rockset API Key",
+      "description": "The key used to authenticate to the Rockset API",
+      "secret": true
+    }
+  },
+  "type": "object",
+  "required": [
+    "api_key"
+  ],
+  "title": "Rockset Endpoint"
+}

--- a/materialize-rockset/.snapshots/TestRocksetDriverSpec-TestResourceSpecSchema
+++ b/materialize-rockset/.snapshots/TestRocksetDriverSpec-TestResourceSpecSchema
@@ -1,1 +1,119 @@
-{"$schema":"http://json-schema.org/draft/2020-12/schema","$id":"https://github.com/estuary/connectors/materialize-rockset/resource","properties":{"workspace":{"type":"string","title":"Workspace","description":"The name of the Rockset workspace (will be created if it does not exist)"},"collection":{"type":"string","title":"Rockset Collection","description":"The name of the Rockset collection (will be created if it does not exist)"},"initializeFromS3":{"properties":{"integration":{"type":"string","title":"Integration Name","description":"The name of the integration that was previously created in the Rockset UI"},"bucket":{"type":"string","title":"Bucket","description":"The name of the S3 bucket to load data from."},"region":{"type":"string","title":"Region","description":"The AWS region in which the bucket resides. Optional."},"pattern":{"type":"string","title":"Pattern","description":"A regex that is used to match objects to be ingested"},"prefix":{"type":"string","title":"Prefix","description":"Prefix of the data within the S3 bucket. All files under this prefix will be loaded. Optional. Must not be set if 'pattern' is defined."}},"additionalProperties":false,"type":"object","required":["integration","bucket"],"title":"Backfill from S3","advanced":true},"advancedCollectionSettings":{"properties":{"retention_secs":{"type":"integer","title":"Retention Period","description":"Number of seconds after which data is purged based on event time"},"event_time_info":{"properties":{"field":{"type":"string","title":"Field Name","description":"Name of the field containing the event time"},"format":{"type":"string","enum":["milliseconds_since_epoch","seconds_since_epoch"],"title":"Format","description":"Format of the time field"},"time_zone":{"type":"string","title":"Timezone","description":"Default timezone"}},"additionalProperties":false,"type":"object","required":["field"],"title":"Event Time Info"},"clustering_key":{"items":{"properties":{"field_name":{"type":"string","title":"Field Name","description":"The name of a field"}},"additionalProperties":false,"type":"object"},"type":"array","title":"Clustering Key","description":"List of clustering fields"},"insert_only":{"type":"boolean","title":"Insert Only","description":"If true disallows updates and deletes. The materialization will fail if there are documents with duplicate keys.","default":false}},"additionalProperties":false,"type":"object","title":"Advanced Collection Settings","advanced":true}},"type":"object","title":"Rockset Collection"}
+{
+  "$schema": "http://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/estuary/connectors/materialize-rockset/resource",
+  "properties": {
+    "workspace": {
+      "type": "string",
+      "title": "Workspace",
+      "description": "The name of the Rockset workspace (will be created if it does not exist)"
+    },
+    "collection": {
+      "type": "string",
+      "title": "Rockset Collection",
+      "description": "The name of the Rockset collection (will be created if it does not exist)"
+    },
+    "initializeFromS3": {
+      "properties": {
+        "integration": {
+          "type": "string",
+          "title": "Integration Name",
+          "description": "The name of the integration that was previously created in the Rockset UI"
+        },
+        "bucket": {
+          "type": "string",
+          "title": "Bucket",
+          "description": "The name of the S3 bucket to load data from."
+        },
+        "region": {
+          "type": "string",
+          "title": "Region",
+          "description": "The AWS region in which the bucket resides. Optional."
+        },
+        "pattern": {
+          "type": "string",
+          "title": "Pattern",
+          "description": "A regex that is used to match objects to be ingested"
+        },
+        "prefix": {
+          "type": "string",
+          "title": "Prefix",
+          "description": "Prefix of the data within the S3 bucket. All files under this prefix will be loaded. Optional. Must not be set if 'pattern' is defined."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "integration",
+        "bucket"
+      ],
+      "title": "Backfill from S3",
+      "advanced": true
+    },
+    "advancedCollectionSettings": {
+      "properties": {
+        "retention_secs": {
+          "type": "integer",
+          "title": "Retention Period",
+          "description": "Number of seconds after which data is purged based on event time"
+        },
+        "event_time_info": {
+          "properties": {
+            "field": {
+              "type": "string",
+              "title": "Field Name",
+              "description": "Name of the field containing the event time"
+            },
+            "format": {
+              "type": "string",
+              "enum": [
+                "milliseconds_since_epoch",
+                "seconds_since_epoch"
+              ],
+              "title": "Format",
+              "description": "Format of the time field"
+            },
+            "time_zone": {
+              "type": "string",
+              "title": "Timezone",
+              "description": "Default timezone"
+            }
+          },
+          "additionalProperties": false,
+          "type": "object",
+          "required": [
+            "field"
+          ],
+          "title": "Event Time Info"
+        },
+        "clustering_key": {
+          "items": {
+            "properties": {
+              "field_name": {
+                "type": "string",
+                "title": "Field Name",
+                "description": "The name of a field"
+              }
+            },
+            "additionalProperties": false,
+            "type": "object"
+          },
+          "type": "array",
+          "title": "Clustering Key",
+          "description": "List of clustering fields"
+        },
+        "insert_only": {
+          "type": "boolean",
+          "title": "Insert Only",
+          "description": "If true disallows updates and deletes. The materialization will fail if there are documents with duplicate keys.",
+          "default": false
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "title": "Advanced Collection Settings",
+      "advanced": true
+    }
+  },
+  "type": "object",
+  "title": "Rockset Collection"
+}

--- a/materialize-rockset/driver.go
+++ b/materialize-rockset/driver.go
@@ -10,6 +10,7 @@ import (
 	"regexp"
 	"strings"
 	"time"
+
 	// importing tzdata is required so that time.LoadLocation can be used to validate timezones
 	// without requiring timezone packages to be installed on the system.
 	_ "time/tzdata"
@@ -25,7 +26,7 @@ import (
 
 type config struct {
 	// Credentials used to authenticate with the Rockset API.
-	ApiKey string `json:"api_key" jsonschema:"title=Rockset API Key,description=The key used to authenticate to the Rockset API" jsonschema_extras:"secret=true"`
+	ApiKey string `json:"api_key" jsonschema:"title=Rockset API Key,description=The key used to authenticate to the Rockset API. Must have role of admin or member." jsonschema_extras:"secret=true,multiline=true"`
 }
 
 func (c *config) Validate() error {

--- a/materialize-rockset/driver_test.go
+++ b/materialize-rockset/driver_test.go
@@ -43,10 +43,14 @@ func TestRocksetDriverSpec(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Run("TestEndpointSpecSchema", func(t *testing.T) {
-		cupaloy.SnapshotT(t, string(response.EndpointSpecSchemaJson))
+		formatted, err := json.MarshalIndent(response.EndpointSpecSchemaJson, "", "  ")
+		require.NoError(t, err)
+		cupaloy.SnapshotT(t, string(formatted))
 	})
 	t.Run("TestResourceSpecSchema", func(t *testing.T) {
-		cupaloy.SnapshotT(t, string(response.ResourceSpecSchemaJson))
+		formatted, err := json.MarshalIndent(response.ResourceSpecSchemaJson, "", "  ")
+		require.NoError(t, err)
+		cupaloy.SnapshotT(t, string(formatted))
 	})
 }
 


### PR DESCRIPTION
**Description:**

This updates the connector spec for the API key field to clarify that it must have admin or member roles. A read-only key won't work.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

The `materialize-rockset` docs should be updated along these same lines.

**Notes for reviewers:**

I updated the spec snapshots to be pretty-printed. The first commit does only that, and the second commit makes the actual change.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/442)
<!-- Reviewable:end -->
