### PR TITLE
sqlcapture: Tweak discovery logic so it works nicer in the UI

### DIFF
--- a/source-mysql/.snapshots/TestGeneric-SimpleDiscovery
+++ b/source-mysql/.snapshots/TestGeneric-SimpleDiscovery
@@ -1,9 +1,12 @@
 Binding 0:
 {
-    "recommended_name": "test.generic_simplediscovery_magnanimous_outshine",
+    "recommended_name": "generic_simplediscovery_magnanimous_outshine",
     "resource_spec_json": {
       "namespace": "test",
-      "stream": "Generic_SimpleDiscovery_magnanimous_outshine"
+      "stream": "Generic_SimpleDiscovery_magnanimous_outshine",
+      "primary_key": [
+        "a"
+      ]
     },
     "document_schema_json": {
       "$defs": {

--- a/source-postgres/.snapshots/TestDiscoveryComplex
+++ b/source-postgres/.snapshots/TestDiscoveryComplex
@@ -1,9 +1,13 @@
 Binding 0:
 {
-    "recommended_name": "test.discoverycomplex_cheap_oxygenation",
+    "recommended_name": "discoverycomplex_cheap_oxygenation",
     "resource_spec_json": {
       "namespace": "test",
-      "stream": "discoverycomplex_cheap_oxygenation"
+      "stream": "discoverycomplex_cheap_oxygenation",
+      "primary_key": [
+        "k2",
+        "k1"
+      ]
     },
     "document_schema_json": {
       "$defs": {

--- a/source-postgres/.snapshots/TestGeneric-SimpleDiscovery
+++ b/source-postgres/.snapshots/TestGeneric-SimpleDiscovery
@@ -1,9 +1,12 @@
 Binding 0:
 {
-    "recommended_name": "test.generic_simplediscovery_magnanimous_outshine",
+    "recommended_name": "generic_simplediscovery_magnanimous_outshine",
     "resource_spec_json": {
       "namespace": "test",
-      "stream": "generic_simplediscovery_magnanimous_outshine"
+      "stream": "generic_simplediscovery_magnanimous_outshine",
+      "primary_key": [
+        "a"
+      ]
     },
     "document_schema_json": {
       "$defs": {

--- a/source-postgres/.snapshots/TestTrickyColumnNames-discover
+++ b/source-postgres/.snapshots/TestTrickyColumnNames-discover
@@ -1,9 +1,12 @@
 Binding 0:
 {
-    "recommended_name": "test.trickycolumnnames_fizzed_cupcake_a",
+    "recommended_name": "trickycolumnnames_fizzed_cupcake_a",
     "resource_spec_json": {
       "namespace": "test",
-      "stream": "trickycolumnnames_fizzed_cupcake_a"
+      "stream": "trickycolumnnames_fizzed_cupcake_a",
+      "primary_key": [
+        "Meta/\"wtf\"/ID"
+      ]
     },
     "document_schema_json": {
       "$defs": {
@@ -111,10 +114,13 @@ Binding 0:
   }
 Binding 1:
 {
-    "recommended_name": "test.trickycolumnnames_fizzed_cupcake_b",
+    "recommended_name": "trickycolumnnames_fizzed_cupcake_b",
     "resource_spec_json": {
       "namespace": "test",
-      "stream": "trickycolumnnames_fizzed_cupcake_b"
+      "stream": "trickycolumnnames_fizzed_cupcake_b",
+      "primary_key": [
+        "table"
+      ]
     },
     "document_schema_json": {
       "$defs": {

--- a/sqlcapture/discovery.go
+++ b/sqlcapture/discovery.go
@@ -130,8 +130,9 @@ func DiscoverCatalog(ctx context.Context, db Database) ([]*pc.DiscoverResponse_B
 		}
 
 		var res = Resource{
-			Namespace: table.Schema,
-			Stream:    table.Name,
+			Namespace:  table.Schema,
+			Stream:     table.Name,
+			PrimaryKey: table.PrimaryKey,
 		}
 		resourceSpecJSON, err := json.Marshal(res)
 		if err != nil {
@@ -150,6 +151,5 @@ func DiscoverCatalog(ctx context.Context, db Database) ([]*pc.DiscoverResponse_B
 }
 
 func recommendedStreamName(schema, table string) string {
-	var streamID = JoinStreamID(schema, table)
-	return streamID
+	return strings.ToLower(table)
 }


### PR DESCRIPTION
**Description:**

In the transition to the Flow gRPC protocol the recommended stream name got changed from `table_name` to `schema.table_name` so this reverts that.

Also the resource config schema now describes a property for the primary key, but this has two issues:
 1. A `[]string` property looks kind of ugly in the UI.
 2. It defaults to empty, which makes it a lot more confusing to the user.

So this commit fills that in. Thus in the common case of a single primary key column the UI will at least show a single text box with the name of that column, so hopefully the user will get the idea.

**Workflow steps:**

Nothing changes for the user except hopefully the dashboard UI is less confusing once we upgrade to the v3 connector.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/443)
<!-- Reviewable:end -->
