### PR TITLE
source-{mysql,postgres}: Lower buffer-size constants

### DIFF
--- a/source-mysql/.snapshots/TestGeneric-SpecResponse
+++ b/source-mysql/.snapshots/TestGeneric-SpecResponse
@@ -57,7 +57,7 @@
             "type": "integer",
             "title": "Backfill Chunk Size",
             "description": "The number of rows which should be fetched from the database in a single backfill query.",
-            "default": 131072
+            "default": 4096
           }
         },
         "additionalProperties": false,

--- a/source-mysql/main.go
+++ b/source-mysql/main.go
@@ -125,7 +125,7 @@ type advancedConfig struct {
 	SkipBinlogRetentionCheck bool   `json:"skip_binlog_retention_check,omitempty" jsonschema:"title=Skip Binlog Retention Sanity Check,default=false,description=Bypasses the 'dangerously short binlog retention' sanity check at startup. Only do this if you understand the danger and have a specific need."`
 	NodeID                   uint32 `json:"node_id,omitempty" jsonschema:"title=Node ID,description=Node ID for the capture. Each node in a replication cluster must have a unique 32-bit ID. The specific value doesn't matter so long as it is unique. If unset or zero the connector will pick a value."`
 	SkipBackfills            string `json:"skip_backfills,omitempty" jsonschema:"title=Skip Backfills,description=A comma-separated list of fully-qualified table names which should not be backfilled."`
-	BackfillChunkSize        int    `json:"backfill_chunk_size,omitempty" jsonschema:"title=Backfill Chunk Size,default=131072,description=The number of rows which should be fetched from the database in a single backfill query."`
+	BackfillChunkSize        int    `json:"backfill_chunk_size,omitempty" jsonschema:"title=Backfill Chunk Size,default=4096,description=The number of rows which should be fetched from the database in a single backfill query."`
 }
 
 // Validate checks that the configuration possesses all required properties.
@@ -167,7 +167,7 @@ func (c *Config) SetDefaults() {
 		c.Advanced.NodeID = 0x476C6F77 // "Flow"
 	}
 	if c.Advanced.BackfillChunkSize <= 0 {
-		c.Advanced.BackfillChunkSize = 128 * 1024
+		c.Advanced.BackfillChunkSize = 4096
 	}
 
 	// The address config property should accept a host or host:port

--- a/source-postgres/.snapshots/TestGeneric-SpecResponse
+++ b/source-postgres/.snapshots/TestGeneric-SpecResponse
@@ -48,6 +48,12 @@
             "type": "string",
             "title": "Skip Backfills",
             "description": "A comma-separated list of fully-qualified table names which should not be backfilled."
+          },
+          "backfill_chunk_size": {
+            "type": "integer",
+            "title": "Backfill Chunk Size",
+            "description": "The number of rows which should be fetched from the database in a single backfill query.",
+            "default": 4096
           }
         },
         "additionalProperties": false,

--- a/source-postgres/backfill.go
+++ b/source-postgres/backfill.go
@@ -97,7 +97,7 @@ func (db *postgresDatabase) WatermarksTable() string {
 // backfillChunkSize controls how many rows will be read from the database in a
 // single query. In normal use it acts like a constant, it's just a variable here
 // so that it can be lowered in tests to exercise chunking behavior more easily.
-var backfillChunkSize = 128 * 1024
+var backfillChunkSize = 4096
 
 func (db *postgresDatabase) buildScanQuery(start bool, keyColumns []string, schemaName, tableName string) string {
 	// Construct strings like `(foo, bar, baz)` and `($1, $2, $3)` for use in the query

--- a/source-postgres/backfill.go
+++ b/source-postgres/backfill.go
@@ -94,11 +94,6 @@ func (db *postgresDatabase) WatermarksTable() string {
 	return db.config.Advanced.WatermarksTable
 }
 
-// backfillChunkSize controls how many rows will be read from the database in a
-// single query. In normal use it acts like a constant, it's just a variable here
-// so that it can be lowered in tests to exercise chunking behavior more easily.
-var backfillChunkSize = 4096
-
 func (db *postgresDatabase) buildScanQuery(start bool, keyColumns []string, schemaName, tableName string) string {
 	// Construct strings like `(foo, bar, baz)` and `($1, $2, $3)` for use in the query
 	var pkey, args string
@@ -118,7 +113,7 @@ func (db *postgresDatabase) buildScanQuery(start bool, keyColumns []string, sche
 		fmt.Fprintf(query, " WHERE (%s) > (%s)", pkey, args)
 	}
 	fmt.Fprintf(query, " ORDER BY (%s)", pkey)
-	fmt.Fprintf(query, " LIMIT %d;", backfillChunkSize)
+	fmt.Fprintf(query, " LIMIT %d;", db.config.Advanced.BackfillChunkSize)
 	return query.String()
 }
 

--- a/source-postgres/main.go
+++ b/source-postgres/main.go
@@ -91,10 +91,11 @@ type Config struct {
 }
 
 type advancedConfig struct {
-	PublicationName string `json:"publicationName,omitempty" jsonschema:"default=flow_publication,description=The name of the PostgreSQL publication to replicate from."`
-	SlotName        string `json:"slotName,omitempty" jsonschema:"default=flow_slot,description=The name of the PostgreSQL replication slot to replicate from."`
-	WatermarksTable string `json:"watermarksTable,omitempty" jsonschema:"default=public.flow_watermarks,description=The name of the table used for watermark writes during backfills. Must be fully-qualified in '<schema>.<table>' form."`
-	SkipBackfills   string `json:"skip_backfills,omitempty" jsonschema:"title=Skip Backfills,description=A comma-separated list of fully-qualified table names which should not be backfilled."`
+	PublicationName   string `json:"publicationName,omitempty" jsonschema:"default=flow_publication,description=The name of the PostgreSQL publication to replicate from."`
+	SlotName          string `json:"slotName,omitempty" jsonschema:"default=flow_slot,description=The name of the PostgreSQL replication slot to replicate from."`
+	WatermarksTable   string `json:"watermarksTable,omitempty" jsonschema:"default=public.flow_watermarks,description=The name of the table used for watermark writes during backfills. Must be fully-qualified in '<schema>.<table>' form."`
+	SkipBackfills     string `json:"skip_backfills,omitempty" jsonschema:"title=Skip Backfills,description=A comma-separated list of fully-qualified table names which should not be backfilled."`
+	BackfillChunkSize int    `json:"backfill_chunk_size,omitempty" jsonschema:"title=Backfill Chunk Size,default=4096,description=The number of rows which should be fetched from the database in a single backfill query."`
 }
 
 // Validate checks that the configuration possesses all required properties.
@@ -136,6 +137,9 @@ func (c *Config) SetDefaults() {
 	}
 	if c.Advanced.WatermarksTable == "" {
 		c.Advanced.WatermarksTable = "public.flow_watermarks"
+	}
+	if c.Advanced.BackfillChunkSize <= 0 {
+		c.Advanced.BackfillChunkSize = 4096
 	}
 
 	// The address config property should accept a host or host:port

--- a/source-postgres/main_test.go
+++ b/source-postgres/main_test.go
@@ -109,9 +109,9 @@ func lowerTuningParameters(t testing.TB) {
 
 	// Within the scope of a single test, adjust some tuning parameters so that it's
 	// easier to exercise backfill chunking and replication buffering behavior.
-	var prevChunkSize = backfillChunkSize
-	t.Cleanup(func() { backfillChunkSize = prevChunkSize })
-	backfillChunkSize = 16
+	var prevChunkSize = TestBackend.cfg.Advanced.BackfillChunkSize
+	t.Cleanup(func() { TestBackend.cfg.Advanced.BackfillChunkSize = prevChunkSize })
+	TestBackend.cfg.Advanced.BackfillChunkSize = 16
 
 	var prevBufferSize = replicationBufferSize
 	t.Cleanup(func() { replicationBufferSize = prevBufferSize })

--- a/source-postgres/replication.go
+++ b/source-postgres/replication.go
@@ -198,7 +198,11 @@ const standbyStatusInterval = 10 * time.Second
 // replicationStream before it stops receiving further events from PostgreSQL.
 // In normal use it's a constant, it's just a variable so that tests are more
 // likely to exercise blocking sends and backpressure.
-var replicationBufferSize = 1000000
+//
+// The buffer is much larger for PostgreSQL than for most other databases, because
+// empirically this helps us to cope with spikes of intense load which can otherwise
+// cause the database to cut us off.
+var replicationBufferSize = 64 * 1024 // Assuming change events average ~2kB then 64k * 2kB = 128MB
 
 func (s *replicationStream) Events() <-chan sqlcapture.ChangeEvent {
 	return s.events

--- a/sqlcapture/capture.go
+++ b/sqlcapture/capture.go
@@ -95,7 +95,7 @@ const (
 	streamProgressInterval = 60 * time.Second        // After `streamProgressInterval` the replication streaming code may log a progress report.
 )
 
-const emitterBufferSize = 4 * 1024 * 1024
+const emitterBufferSize = 64 * 1024 // Assuming change events average ~2kB then 64k * 2kB = 128MB
 
 // Run is the top level entry point of the capture process.
 func (c *Capture) Run(ctx context.Context) (err error) {


### PR DESCRIPTION
**Description:**

This PR lowers various buffer-size tuning constants in `source-mysql` and `source-postgres` so that we can expect captures to actually work properly within the 1GiB connector memory limits. This comes at the cost of lowered throughput in some possible setups, but in the common case the hit shouldn't be too terrible.

Also this PR makes the backfill chunk size an advanced config property of `source-postgres` the same way we already did for MySQL, just for consistency.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/446)
<!-- Reviewable:end -->
