### PR TITLE
source-postgres: Ignore the 'cron' schema

### DIFF
--- a/source-mysql/discovery.go
+++ b/source-mysql/discovery.go
@@ -75,14 +75,6 @@ func (db *mysqlDatabase) DiscoverTables(ctx context.Context) (map[string]sqlcapt
 		}
 	}
 
-	// If there are zero tables, or there's one table but it's the
-	// watermarks table, log a warning.
-	var _, watermarksPresent = tableMap[db.WatermarksTable()]
-	if len(tableMap) == 0 || len(tableMap) == 1 && watermarksPresent {
-		logrus.Warn("no tables discovered")
-		logrus.Warn("note that source-mysql will not discover tables in the system schemas 'information_schema', 'mysql', 'performance_schema', or 'sys'")
-	}
-
 	return tableMap, nil
 }
 

--- a/source-postgres/discovery.go
+++ b/source-postgres/discovery.go
@@ -323,6 +323,7 @@ const queryDiscoverColumns = `
 		c.table_schema != 'information_schema' AND
 		c.table_schema != 'pg_internal' AND
 		c.table_schema != 'catalog_history' AND
+		c.table_schema != 'cron' AND
 		t.table_type = 'BASE TABLE'
   ORDER BY
 		c.table_schema,

--- a/sqlcapture/discovery.go
+++ b/sqlcapture/discovery.go
@@ -20,6 +20,12 @@ func DiscoverCatalog(ctx context.Context, db Database) ([]*pc.DiscoverResponse_B
 		return nil, err
 	}
 
+	// If there are zero tables (or there's one table but it's the watermarks table) log a warning.
+	var _, watermarksPresent = tables[db.WatermarksTable()]
+	if len(tables) == 0 || len(tables) == 1 && watermarksPresent {
+		logrus.Warn("no tables discovered; note that tables in system schemas will not be discovered and must be added manually if desired")
+	}
+
 	// Shared schema of the embedded "source" property.
 	var sourceSchema = (&jsonschema.Reflector{
 		ExpandedStruct: true,


### PR DESCRIPTION
**Description:**

This PR tweaks `source-postgres` discovery logic to ignore tables in the `cron` schema, which is added by the `pg_cron` extension and generally isn't something the user actually intends to capture.

Also moves the warning when no tables are discovered from the source-mysql discovery code into the generic sqlcapture discovery code so that source-postgres will warn as well.

**Workflow steps:**

It will now be safe to blindly click through the discover-and-publish workflow in the UI when `pg_cron` is installed.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/455)
<!-- Reviewable:end -->
