### PR TITLE
source-mysql: Derive default 'node_id' from capture task name

### DIFF
--- a/source-mysql/main_test.go
+++ b/source-mysql/main_test.go
@@ -53,7 +53,7 @@ func TestMain(m *testing.M) {
 	if err := cfg.Validate(); err != nil {
 		logrus.WithFields(logrus.Fields{"err": err, "config": cfg}).Fatal("error validating test config")
 	}
-	cfg.SetDefaults()
+	cfg.SetDefaults("Test Config")
 
 	var conn, err = client.Connect(cfg.Address, cfg.User, cfg.Password, cfg.Advanced.DBName)
 	if err != nil {

--- a/source-postgres/main.go
+++ b/source-postgres/main.go
@@ -40,7 +40,7 @@ func main() {
 	boilerplate.RunMain(postgresDriver)
 }
 
-func connectPostgres(ctx context.Context, cfg json.RawMessage) (sqlcapture.Database, error) {
+func connectPostgres(ctx context.Context, name string, cfg json.RawMessage) (sqlcapture.Database, error) {
 	var config Config
 	if err := pf.UnmarshalStrict(cfg, &config); err != nil {
 		return nil, fmt.Errorf("error parsing config json: %w", err)

--- a/sqlcapture/main.go
+++ b/sqlcapture/main.go
@@ -44,7 +44,7 @@ type Driver struct {
 	ConfigSchema     json.RawMessage
 	DocumentationURL string
 
-	Connect func(ctx context.Context, cfg json.RawMessage) (Database, error)
+	Connect func(ctx context.Context, name string, cfg json.RawMessage) (Database, error)
 }
 
 // Spec returns the specification definition of this driver.
@@ -73,7 +73,7 @@ func (d *Driver) ApplyDelete(ctx context.Context, req *pc.ApplyRequest) (*pc.App
 
 // Validate that store resources and proposed collection bindings are compatible.
 func (d *Driver) Validate(ctx context.Context, req *pc.ValidateRequest) (*pc.ValidateResponse, error) {
-	var db, err = d.Connect(ctx, req.EndpointSpecJson)
+	var db, err = d.Connect(ctx, string(req.Capture), req.EndpointSpecJson)
 	if err != nil {
 		return nil, fmt.Errorf("error connecting to database: %w", err)
 	}
@@ -98,7 +98,7 @@ func (d *Driver) Validate(ctx context.Context, req *pc.ValidateRequest) (*pc.Val
 
 // Discover returns the set of resources available from this Driver.
 func (d *Driver) Discover(ctx context.Context, req *pc.DiscoverRequest) (*pc.DiscoverResponse, error) {
-	var db, err = d.Connect(ctx, req.EndpointSpecJson)
+	var db, err = d.Connect(ctx, "Flow Discovery", req.EndpointSpecJson)
 	if err != nil {
 		return nil, fmt.Errorf("error connecting to database: %w", err)
 	}
@@ -151,7 +151,7 @@ func (d *Driver) Pull(stream pc.Driver_PullServer) error {
 	}
 
 	var ctx = stream.Context()
-	db, err := d.Connect(ctx, open.Open.Capture.EndpointSpecJson)
+	db, err := d.Connect(ctx, string(open.Open.Capture.Capture), open.Open.Capture.EndpointSpecJson)
 	if err != nil {
 		return fmt.Errorf("error connecting to database: %w", err)
 	}


### PR DESCRIPTION
**Description:**

This PR changes `source-mysql` to derive its default value for `/advanced/node_id` by hashing the task name, where previously it just hard-coded `u32("Flow")` as the default value.

The issue with a hard-coded default is/was that if a user naively creates two captures from the same MySQL host (which may be required if they want to capture from distinct logical databases) the captures will fight each other for the same ID and crash a lot.

But we don't want to just use pure randomization because some DB admins might want us to use a stable ID even if the user doesn't care to specify one. So instead of being truly random this changes the default behavior to use the upper 32 bits of the SHA-256 hash of the capture task name, which is effectively random but also stable for any particular task.

**Notes for reviewers:**

I vaguely recall somebody (maybe @psFried or @jgraettinger ?) was opposed to pure randomization here, and I think the reasoning was that some DB admins might actually care about our capture having a consistent ID? But now that we're using the Flow gRPC protocol we actually have access to the capture task name, so this ought to work, I think.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/456)
<!-- Reviewable:end -->
