### PR TITLE
materialize-sql: create all non-pks as nullable

### DIFF
--- a/materialize-bigquery/.snapshots/TestSQLGeneration
+++ b/materialize-bigquery/.snapshots/TestSQLGeneration
@@ -12,7 +12,7 @@ CREATE TABLE IF NOT EXISTS `projectID`.`dataset`.`target_table` (
 		`person_place_` STRING,
 		`source.name` STRING,
 		`with-dash` STRING,
-		`flow_document` STRING NOT NULL
+		`flow_document` STRING
 )
 CLUSTER BY `key1`, `key2`, `boolean`, `integer`;
 --- End `projectID`.`dataset`.`target_table` createTargetTable ---

--- a/materialize-bigquery/.snapshots/TestSQLGeneration
+++ b/materialize-bigquery/.snapshots/TestSQLGeneration
@@ -3,11 +3,11 @@ flow_temp_table_0--- End `projectID`.`dataset`.`target_table` tempTableName ---
 
 --- Begin `projectID`.`dataset`.`target_table` createTargetTable ---
 CREATE TABLE IF NOT EXISTS `projectID`.`dataset`.`target_table` (
-		`key1` INT64 NOT NULL,
-		`key2` BOOL NOT NULL,
-		`boolean` BOOL NOT NULL,
-		`integer` INT64 NOT NULL,
-		`string` STRING NOT NULL,
+		`key1` INT64,
+		`key2` BOOL,
+		`boolean` BOOL,
+		`integer` INT64,
+		`string` STRING,
 		`number` BIGNUMERIC,
 		`person_place_` STRING,
 		`source.name` STRING,

--- a/materialize-postgres/.snapshots/TestSQLGeneration
+++ b/materialize-postgres/.snapshots/TestSQLGeneration
@@ -1,9 +1,9 @@
 --- Begin "a-schema".target_table createTargetTable ---
 
 CREATE TABLE IF NOT EXISTS "a-schema".target_table (
-		key1 BIGINT NOT NULL,
-		"key!2" BOOLEAN NOT NULL,
-		"nullableKey" TEXT NOT NULL,
+		key1 BIGINT,
+		"key!2" BOOLEAN,
+		"nullableKey" TEXT,
 		"Camel_Case" BIGINT,
 		"a Time" TIMESTAMPTZ,
 		"array" JSON,
@@ -32,8 +32,8 @@ COMMENT ON COLUMN "a-schema".target_table.flow_document IS 'user-provided projec
 --- Begin "Delta Updates" createTargetTable ---
 
 CREATE TABLE IF NOT EXISTS "Delta Updates" (
-		"theKey" TEXT NOT NULL,
-		"nullableKey" TEXT NOT NULL,
+		"theKey" TEXT,
+		"nullableKey" TEXT,
 		"aValue" BIGINT
 );
 
@@ -47,17 +47,17 @@ auto-generated projection of JSON at: /aValue with inferred types: [integer]';
 --- Begin "a-schema".target_table createLoadTable ---
 
 CREATE TEMPORARY TABLE flow_temp_table_0 (
-		key1 BIGINT NOT NULL,
-		"key!2" BOOLEAN NOT NULL,
-		"nullableKey" TEXT NOT NULL
+		key1 BIGINT,
+		"key!2" BOOLEAN,
+		"nullableKey" TEXT
 ) ON COMMIT DROP;
 --- End "a-schema".target_table createLoadTable ---
 
 --- Begin "Delta Updates" createLoadTable ---
 
 CREATE TEMPORARY TABLE flow_temp_table_1 (
-		"theKey" TEXT NOT NULL,
-		"nullableKey" TEXT NOT NULL
+		"theKey" TEXT,
+		"nullableKey" TEXT
 ) ON COMMIT DROP;
 --- End "Delta Updates" createLoadTable ---
 

--- a/materialize-postgres/.snapshots/TestSQLGeneration
+++ b/materialize-postgres/.snapshots/TestSQLGeneration
@@ -3,13 +3,13 @@
 CREATE TABLE IF NOT EXISTS "a-schema".target_table (
 		key1 BIGINT NOT NULL,
 		"key!2" BOOLEAN NOT NULL,
-		"nullableKey" TEXT,
+		"nullableKey" TEXT NOT NULL,
 		"Camel_Case" BIGINT,
 		"a Time" TIMESTAMPTZ,
 		"array" JSON,
 		lower_case BIGINT,
 		"value" TEXT,
-		flow_document JSON NOT NULL,
+		flow_document JSON,
 
 		PRIMARY KEY (key1, "key!2", "nullableKey")
 );
@@ -33,7 +33,7 @@ COMMENT ON COLUMN "a-schema".target_table.flow_document IS 'user-provided projec
 
 CREATE TABLE IF NOT EXISTS "Delta Updates" (
 		"theKey" TEXT NOT NULL,
-		"nullableKey" TEXT,
+		"nullableKey" TEXT NOT NULL,
 		"aValue" BIGINT
 );
 
@@ -49,7 +49,7 @@ auto-generated projection of JSON at: /aValue with inferred types: [integer]';
 CREATE TEMPORARY TABLE flow_temp_table_0 (
 		key1 BIGINT NOT NULL,
 		"key!2" BOOLEAN NOT NULL,
-		"nullableKey" TEXT
+		"nullableKey" TEXT NOT NULL
 ) ON COMMIT DROP;
 --- End "a-schema".target_table createLoadTable ---
 
@@ -57,7 +57,7 @@ CREATE TEMPORARY TABLE flow_temp_table_0 (
 
 CREATE TEMPORARY TABLE flow_temp_table_1 (
 		"theKey" TEXT NOT NULL,
-		"nullableKey" TEXT
+		"nullableKey" TEXT NOT NULL
 ) ON COMMIT DROP;
 --- End "Delta Updates" createLoadTable ---
 

--- a/materialize-postgres/sqlgen_test.go
+++ b/materialize-postgres/sqlgen_test.go
@@ -99,7 +99,7 @@ func TestDateTimeColumn(t *testing.T) {
 		},
 	})
 	require.NoError(t, err)
-	require.Equal(t, "TIMESTAMPTZ NOT NULL", mapped.DDL)
+	require.Equal(t, "TIMESTAMPTZ", mapped.DDL)
 
 	parsed, err := mapped.Converter("2022-04-04T10:09:08.234567Z")
 	require.Equal(t, "2022-04-04T10:09:08.234567Z", parsed)

--- a/materialize-sql/.snapshots/TestTableTemplate
+++ b/materialize-sql/.snapshots/TestTableTemplate
@@ -3,8 +3,8 @@
 			materialization TEXT NOT NULL,
 			key_begin BIGINT NOT NULL,
 			key_end BIGINT NOT NULL,
-			fence BIGINT NOT NULL,
-			checkpoint TEXT NOT NULL,
+			fence BIGINT,
+			checkpoint TEXT,
 			PRIMARY KEY (materialization, key_begin, key_end)
 		
 	);

--- a/materialize-sql/.snapshots/TestTableTemplate
+++ b/materialize-sql/.snapshots/TestTableTemplate
@@ -1,8 +1,8 @@
 
 	CREATE TABLE one."reserved".checkpoints (
-			materialization TEXT NOT NULL,
-			key_begin BIGINT NOT NULL,
-			key_end BIGINT NOT NULL,
+			materialization TEXT,
+			key_begin BIGINT,
+			key_end BIGINT,
 			fence BIGINT,
 			checkpoint TEXT,
 			PRIMARY KEY (materialization, key_begin, key_end)

--- a/materialize-sql/table_mapping.go
+++ b/materialize-sql/table_mapping.go
@@ -128,6 +128,7 @@ func ResolveTable(shape TableShape, dialect Dialect) (Table, error) {
 	}
 
 	for _, key := range shape.Keys {
+		key.IsPrimaryKey = true
 		table.Keys = append(table.Keys, Column{Projection: key})
 	}
 	for _, val := range shape.Values {

--- a/materialize-sql/type_mapping.go
+++ b/materialize-sql/type_mapping.go
@@ -184,11 +184,18 @@ var _ TypeMapper = NullableMapper{}
 func (m NullableMapper) MapType(p *Projection) (mapped MappedType, err error) {
 	if mapped, err = m.Delegate.MapType(p); err != nil {
 		return
-	} else if _, notNull := p.AsFlatType(); notNull && m.NotNullText != "" {
+	}
+	// We are temporarily creating all non-pk columns as nullable, this is to allow
+	// fields to be made nullable from a collection without causing issues. Once we
+	// support automatic schema migration of tables to mark fields as nullable
+	// after creation, we can revert back to the more strict behaviour,
+	// see: https://github.com/estuary/connectors/issues/447
+	if p.IsPrimaryKey && m.NotNullText != "" {
 		mapped.DDL += " " + m.NotNullText
 	} else if m.NullableText != "" {
 		mapped.DDL += " " + m.NullableText
 	}
+
 	return
 }
 

--- a/materialize-sql/type_mapping.go
+++ b/materialize-sql/type_mapping.go
@@ -190,9 +190,10 @@ func (m NullableMapper) MapType(p *Projection) (mapped MappedType, err error) {
 	// support automatic schema migration of tables to mark fields as nullable
 	// after creation, we can revert back to the more strict behaviour,
 	// see: https://github.com/estuary/connectors/issues/447
-	if p.IsPrimaryKey && m.NotNullText != "" {
-		mapped.DDL += " " + m.NotNullText
-	} else if m.NullableText != "" {
+	// note that for primary keys we are leaving it up to the engine to decide
+	// whether they can be nullable or not (e.g. postgres will assume not
+	// null for primary keys)
+	if !p.IsPrimaryKey && m.NullableText != "" {
 		mapped.DDL += " " + m.NullableText
 	}
 


### PR DESCRIPTION
**Description:**

- All columns except primary keys are made as nullable. this is to allow fields to be made nullable from a collection without causing issues. Once we support automatic schema migration of tables to mark fields as nullable after creation, we can revert back to the more strict behaviour, see: https://github.com/estuary/connectors/issues/447

**Workflow steps:**

- Create a new SQL materialization with non-pk fields that are not marked as nullable, but they will still be created as nullable

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/458)
<!-- Reviewable:end -->
