### PR TITLE
source-firestore: Reduce backfill chunk size

### DIFF
--- a/source-firestore/pull.go
+++ b/source-firestore/pull.go
@@ -361,7 +361,7 @@ func (c *capture) Run(ctx context.Context) error {
 	return nil
 }
 
-const backfillChunkSize = 4096
+const backfillChunkSize = 1024
 
 func (c *capture) BackfillAsync(ctx context.Context, client *firestore.Client, collectionID string, resumeState *backfillState) error {
 	var logEntry = log.WithFields(log.Fields{"collection": collectionID})


### PR DESCRIPTION
**Description:**

We're seeing Firestore captures failing in production due to excessive memory usage, and this is the dumbest hammer that we have to potentially reduce memory usage so it's worth trying.

In general our backfills tend to be constrained by journal append rate limits and RTTs to Firestore are fairly low, so this isn't expected to have a large impact on throughput in general.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/463)
<!-- Reviewable:end -->
