### PR TITLE
go-auth: update oauth templates to mustache

### DIFF
--- a/go-auth/google/spec.go
+++ b/go-auth/google/spec.go
@@ -8,14 +8,14 @@ import (
 	pf "github.com/estuary/flow/go/protocols/flow"
 )
 
-const AUTH_URL_TEMPLATE_FORMAT_STR = "https://accounts.google.com/o/oauth2/auth?access_type=offline&prompt=consent&client_id={{ client_id }}&redirect_uri={{ redirect_uri }}&response_type=code&scope=%s&state={{ state }}"
+const AUTH_URL_TEMPLATE_FORMAT_STR = "https://accounts.google.com/o/oauth2/auth?access_type=offline&prompt=consent&client_id={{#urlencode}}{{{ client_id }}}{{/urlencode}}&redirect_uri={{#urlencode}}{{{ redirect_uri }}}{{/urlencode}}&response_type=code&scope={{#urlencode}}%s{{/urlencode}}&state={{#urlencode}}{{{ state }}}{{/urlencode}}"
 
 func Spec(scopes ...string) *pf.OAuth2Spec {
 	return &pf.OAuth2Spec{
 		Provider:                   "google",
 		AuthUrlTemplate:            fmt.Sprintf(AUTH_URL_TEMPLATE_FORMAT_STR, strings.Join(scopes, " ")),
 		AccessTokenUrlTemplate:     "https://oauth2.googleapis.com/token",
-		AccessTokenBody:            "{\"grant_type\": \"authorization_code\", \"client_id\": \"{{ client_id }}\", \"client_secret\": \"{{ client_secret }}\", \"redirect_uri\": \"{{ redirect_uri }}\", \"code\": \"{{ code }}\"}",
+		AccessTokenBody:            "{\"grant_type\": \"authorization_code\", \"client_id\": \"{{{ client_id }}}\", \"client_secret\": \"{{{ client_secret }}}\", \"redirect_uri\": \"{{{ redirect_uri }}}\", \"code\": \"{{{ code }}}\"}",
 		AccessTokenResponseMapJson: json.RawMessage("{\"refresh_token\": \"/refresh_token\"}"),
 	}
 }

--- a/materialize-google-pubsub/.snapshots/TestSpec
+++ b/materialize-google-pubsub/.snapshots/TestSpec
@@ -105,9 +105,9 @@
   "documentation_url": "https://go.estuary.dev/materialize-google-pubsub",
   "oauth2_spec": {
     "provider": "google",
-    "auth_url_template": "https://accounts.google.com/o/oauth2/auth?access_type=offline\u0026prompt=consent\u0026client_id={{ client_id }}\u0026redirect_uri={{ redirect_uri }}\u0026response_type=code\u0026scope=https://www.googleapis.com/auth/pubsub\u0026state={{ state }}",
+    "auth_url_template": "https://accounts.google.com/o/oauth2/auth?access_type=offline\u0026prompt=consent\u0026client_id={{#urlencode}}{{{ client_id }}}{{/urlencode}}\u0026redirect_uri={{#urlencode}}{{{ redirect_uri }}}{{/urlencode}}\u0026response_type=code\u0026scope={{#urlencode}}https://www.googleapis.com/auth/pubsub{{/urlencode}}\u0026state={{#urlencode}}{{{ state }}}{{/urlencode}}",
     "access_token_url_template": "https://oauth2.googleapis.com/token",
-    "access_token_body": "{\"grant_type\": \"authorization_code\", \"client_id\": \"{{ client_id }}\", \"client_secret\": \"{{ client_secret }}\", \"redirect_uri\": \"{{ redirect_uri }}\", \"code\": \"{{ code }}\"}",
+    "access_token_body": "{\"grant_type\": \"authorization_code\", \"client_id\": \"{{{ client_id }}}\", \"client_secret\": \"{{{ client_secret }}}\", \"redirect_uri\": \"{{{ redirect_uri }}}\", \"code\": \"{{{ code }}}\"}",
     "access_token_response_map_json": {
       "refresh_token": "/refresh_token"
     }

--- a/materialize-google-sheets/.snapshots/TestSpec
+++ b/materialize-google-sheets/.snapshots/TestSpec
@@ -100,9 +100,9 @@
   "documentation_url": "https://go.estuary.dev/materialize-google-sheets",
   "oauth2_spec": {
     "provider": "google",
-    "auth_url_template": "https://accounts.google.com/o/oauth2/auth?access_type=offline\u0026prompt=consent\u0026client_id={{ client_id }}\u0026redirect_uri={{ redirect_uri }}\u0026response_type=code\u0026scope=https://www.googleapis.com/auth/spreadsheets\u0026state={{ state }}",
+    "auth_url_template": "https://accounts.google.com/o/oauth2/auth?access_type=offline\u0026prompt=consent\u0026client_id={{#urlencode}}{{{ client_id }}}{{/urlencode}}\u0026redirect_uri={{#urlencode}}{{{ redirect_uri }}}{{/urlencode}}\u0026response_type=code\u0026scope={{#urlencode}}https://www.googleapis.com/auth/spreadsheets{{/urlencode}}\u0026state={{#urlencode}}{{{ state }}}{{/urlencode}}",
     "access_token_url_template": "https://oauth2.googleapis.com/token",
-    "access_token_body": "{\"grant_type\": \"authorization_code\", \"client_id\": \"{{ client_id }}\", \"client_secret\": \"{{ client_secret }}\", \"redirect_uri\": \"{{ redirect_uri }}\", \"code\": \"{{ code }}\"}",
+    "access_token_body": "{\"grant_type\": \"authorization_code\", \"client_id\": \"{{{ client_id }}}\", \"client_secret\": \"{{{ client_secret }}}\", \"redirect_uri\": \"{{{ redirect_uri }}}\", \"code\": \"{{{ code }}}\"}",
     "access_token_response_map_json": {
       "refresh_token": "/refresh_token"
     }


### PR DESCRIPTION
**Description:**

- Migrate OAuth templates to the new mustache format, this connector was left behind when we did the migration in https://github.com/estuary/flow/pull/841

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/465)
<!-- Reviewable:end -->
