### PR TITLE
materialize-snowflake: switch to materialize-sql

### DIFF
--- a/materialize-snowflake/.snapshots/TestSpecification
+++ b/materialize-snowflake/.snapshots/TestSpecification
@@ -70,7 +70,7 @@
     "properties": {
       "table": {
         "type": "string",
-        "x-collection-name": "true"
+        "x-collection-name": true
       },
       "delta_updates": {
         "type": "boolean"

--- a/materialize-snowflake/Dockerfile
+++ b/materialize-snowflake/Dockerfile
@@ -15,8 +15,10 @@ RUN go mod download
 RUN curl -L --proto '=https' --tlsv1.2 -sSf "https://github.com/estuary/flow/releases/download/dev/flow-x86-linux.tar.gz" | tar -zx -C /usr/local/bin/
 
 # Build the connector projects we depend on.
+COPY go-schema-gen           ./go-schema-gen
 COPY materialize-boilerplate ./materialize-boilerplate
 COPY materialize-snowflake   ./materialize-snowflake
+COPY materialize-sql         ./materialize-sql
 COPY testsupport             ./testsupport
 
 # Test and build the connector.

--- a/materialize-snowflake/snowflake.go
+++ b/materialize-snowflake/snowflake.go
@@ -422,7 +422,14 @@ func (d *transactor) Commit(ctx context.Context) error {
 		return fmt.Errorf("evaluating fence template: %w", err)
 	}
 	if _, err := txn.ExecContext(ctx, fenceUpdate.String()); err != nil {
-		return fmt.Errorf("txn.Exec: %w", err)
+		err = fmt.Errorf("txn.Exec: %w", err)
+
+		// Give recommendation to user for resolving timeout issues
+		if strings.Contains(err.Error(), "timeout") {
+			return fmt.Errorf("fence.Update: %w  (ensure LOCK_TIMEOUT and STATEMENT_TIMEOUT_IN_SECONDS are at least ten minutes)", err)
+		}
+
+		return err
 	}
 
 	for _, b := range d.bindings {

--- a/materialize-snowflake/snowflake.go
+++ b/materialize-snowflake/snowflake.go
@@ -115,6 +115,10 @@ func (c tableConfig) DeltaUpdates() bool {
 	return c.Delta
 }
 
+func (c tableConfig) GetAdditionalSql() string {
+	return ""
+}
+
 // The Snowflake driver Params map uses string pointers as values, which is what this is used for.
 var trueString = "true"
 

--- a/materialize-snowflake/snowflake_test.go
+++ b/materialize-snowflake/snowflake_test.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"context"
-	"database/sql"
+	stdsql "database/sql"
 	"encoding/json"
 	"testing"
 
@@ -11,7 +11,7 @@ import (
 	"github.com/estuary/flow/go/protocols/catalog"
 	pf "github.com/estuary/flow/go/protocols/flow"
 	pm "github.com/estuary/flow/go/protocols/materialize"
-	sqlDriver "github.com/estuary/flow/go/protocols/materialize/sql"
+	sql "github.com/estuary/connectors/materialize-sql"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 )
@@ -19,58 +19,64 @@ import (
 func TestQueryGeneration(t *testing.T) {
 	var spec *pf.MaterializationSpec
 	require.NoError(t, testsupport.CatalogExtract(t, "testdata/flow.yaml",
-		func(db *sql.DB) error {
+		func(db *stdsql.DB) error {
 			var err error
 			spec, err = catalog.LoadMaterialization(db, "test/sqlite")
 			return err
 		}))
 
-	var gen = SQLGenerator()
-	var table = sqlDriver.TableForMaterialization("test_table", "", gen.IdentifierRenderer, spec.Bindings[0])
+	var shape1 = sql.BuildTableShape(spec, 0, tableConfig{
+		Table:  "test_table",
+		Delta:  false,
+	})
+	table, err := sql.ResolveTable(shape1, snowflakeDialect)
+	require.NoError(t, err)
 
 	var loadUUID = uuid.UUID{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15}
 	var storeUUID = uuid.UUID{15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1}
 
-	var keyJoinSQL, copyIntoSQL, mergeIntoSQL = BuildSQL(123, table, spec.Bindings[0].FieldSelection, loadUUID, storeUUID)
+	loadQuery, err := RenderTableWithRandomUUIDTemplate(table, loadUUID, tplLoadQuery)
+	require.NoError(t, err)
+	copyInto, err := RenderTableWithRandomUUIDTemplate(table, storeUUID, tplCopyInto)
+	require.NoError(t, err)
+	mergeInto, err := RenderTableWithRandomUUIDTemplate(table, storeUUID, tplMergeInto)
+	require.NoError(t, err)
 
 	// Note the intentional missing semicolon, as this is a subquery.
 	require.Equal(t, `
-		SELECT 123, test_table.flow_document
-		FROM test_table
-		JOIN (
-			SELECT $1[0] AS key1, $1[1] AS key2
-			FROM @flow_v1/00010203-0405-0607-0809-0a0b0c0d0e0f
-		) AS r
-		ON test_table.key1 = r.key1 AND test_table.key2 = r.key2
-		`,
-		keyJoinSQL)
+	SELECT 0, test_table.flow_document
+	FROM test_table
+	JOIN (
+		SELECT $1[0] AS key1, $1[1] AS key2
+		FROM @flow_v1/00010203-0405-0607-0809-0a0b0c0d0e0f
+	) AS r
+	ON test_table.key1 = r.key1 AND test_table.key2 = r.key2`,
+		loadQuery)
 
 	require.Equal(t, `
-		COPY INTO test_table (
-			key1, key2, boolean, integer, number, string, flow_document
-		) FROM (
-			SELECT $1[0] AS key1, $1[1] AS key2, $1[2] AS boolean, $1[3] AS integer, $1[4] AS number, $1[5] AS string, $1[6] AS flow_document
-			FROM @flow_v1/0f0e0d0c-0b0a-0908-0706-050403020100
-		)
-		;`,
-		copyIntoSQL)
+	COPY INTO test_table (
+		key1, key2, boolean, integer, number, string, flow_document
+	) FROM (
+		SELECT $1[0] AS key1, $1[1] AS key2, $1[2] AS boolean, $1[3] AS integer, $1[4] AS number, $1[5] AS string, $1[6] AS flow_document
+		FROM @flow_v1/0f0e0d0c-0b0a-0908-0706-050403020100
+	);`,
+		copyInto)
 
 	require.Equal(t, `
-		MERGE INTO test_table
-		USING (
-			SELECT $1[0] AS key1, $1[1] AS key2, $1[2] AS boolean, $1[3] AS integer, $1[4] AS number, $1[5] AS string, $1[6] AS flow_document
-			FROM @flow_v1/0f0e0d0c-0b0a-0908-0706-050403020100
-		) AS r
-		ON test_table.key1 = r.key1 AND test_table.key2 = r.key2
-		WHEN MATCHED AND IS_NULL_VALUE(r.flow_document) THEN
-			DELETE
-		WHEN MATCHED THEN
-			UPDATE SET test_table.boolean = r.boolean, test_table.integer = r.integer, test_table.number = r.number, test_table.string = r.string, test_table.flow_document = r.flow_document
-		WHEN NOT MATCHED THEN
-			INSERT (key1, key2, boolean, integer, number, string, flow_document)
-			VALUES (r.key1, r.key2, r.boolean, r.integer, r.number, r.string, r.flow_document)
-		;`,
-		mergeIntoSQL)
+	MERGE INTO test_table
+	USING (
+		SELECT $1[0] AS key1, $1[1] AS key2, $1[2] AS boolean, $1[3] AS integer, $1[4] AS number, $1[5] AS string, $1[6] AS flow_document
+		FROM @flow_v1/0f0e0d0c-0b0a-0908-0706-050403020100
+	) AS r
+	ON test_table.key1 = r.key1 AND test_table.key2 = r.key2
+	WHEN MATCHED AND IS_NULL_VALUE(r.flow_document) THEN
+		DELETE
+	WHEN MATCHED THEN
+		UPDATE SET test_table.boolean = r.boolean, test_table.integer = r.integer, test_table.number = r.number, test_table.string = r.string, test_table.flow_document = r.flow_document
+	WHEN NOT MATCHED THEN
+		INSERT (key1, key2, boolean, integer, number, string, flow_document)
+		VALUES (r.key1, r.key2, r.boolean, r.integer, r.number, r.string, r.flow_document);`,
+		mergeInto)
 }
 
 func TestSpecification(t *testing.T) {

--- a/materialize-snowflake/sqlgen.go
+++ b/materialize-snowflake/sqlgen.go
@@ -34,9 +34,9 @@ var snowflakeDialect = func () sql.Dialect {
     sql.NUMBER:  sql.NewStaticMapper("DOUBLE"),
     sql.OBJECT:  variantMapper,
     sql.STRING: sql.StringTypeMapper{
-      Fallback: sql.NewStaticMapper("TEXT"),
+      Fallback: sql.NewStaticMapper("STRING"),
       WithFormat: map[string]sql.TypeMapper{
-        "date-time": sql.NewStaticMapper("TIMESTAMPT"),
+        "date-time": sql.NewStaticMapper("TIMESTAMP"),
       },
     },
   }
@@ -160,17 +160,6 @@ var (
 	);
 {{- end }}
 
-{{ define "selectByKeys" }}
-	SELECT {{ $.Document.Identifier }}
-	FROM {{ $.Identifier }}
-	WHERE
-		{{- range $ind, $key := $.Keys }}
-			{{- if $ind }} AND {{ end -}}
-			{{ $key.Identifier }} = {{ $key.Placeholder }}
-		{{- end -}}
-	;
-{{ end }}
-
 {{ define "updateFence" }}
 EXECUTE IMMEDIATE $$
 DECLARE
@@ -195,7 +184,6 @@ END $$;
   tplLoadQuery         = tplAll.Lookup("loadQuery")
   tplCopyInto          = tplAll.Lookup("copyInto")
   tplMergeInto         = tplAll.Lookup("mergeInto")
-  tplSelectByKeys      = tplAll.Lookup("selectByKeys")
   tplUpdateFence       = tplAll.Lookup("updateFence")
 )
 

--- a/materialize-snowflake/sqlgen.go
+++ b/materialize-snowflake/sqlgen.go
@@ -1,0 +1,217 @@
+package main
+import (
+  "fmt"
+  "strings"
+
+	"encoding/json"
+  sql "github.com/estuary/connectors/materialize-sql"
+	"text/template"
+	"github.com/google/uuid"
+  "github.com/estuary/flow/go/protocols/fdb/tuple"
+)
+
+var jsonConverter sql.ElementConverter = func(te tuple.TupleElement) (interface{}, error) {
+  switch ii := te.(type) {
+  case []byte:
+    return json.RawMessage(ii), nil
+  case json.RawMessage:
+    return ii, nil
+  case nil:
+    return json.RawMessage(nil), nil
+  default:
+    return nil, fmt.Errorf("invalid type %#v for variant", te)
+  }
+}
+
+// snowflakeDialect returns a representation of the Snowflake SQL dialect.
+var snowflakeDialect = func () sql.Dialect {
+  var variantMapper = sql.NewStaticMapper("VARIANT", sql.WithElementConverter(jsonConverter))
+  var typeMappings = sql.ProjectionTypeMapper{
+    sql.ARRAY:   variantMapper,
+    sql.BINARY:  sql.NewStaticMapper("BINARY"),
+    sql.BOOLEAN: sql.NewStaticMapper("BOOLEAN"),
+    sql.INTEGER: sql.NewStaticMapper("INTEGER"),
+    sql.NUMBER:  sql.NewStaticMapper("DOUBLE"),
+    sql.OBJECT:  variantMapper,
+    sql.STRING: sql.StringTypeMapper{
+      Fallback: sql.NewStaticMapper("TEXT"),
+      WithFormat: map[string]sql.TypeMapper{
+        "date-time": sql.NewStaticMapper("TIMESTAMPT"),
+      },
+    },
+  }
+  var nullable sql.TypeMapper = sql.NullableMapper{
+    NotNullText: "NOT NULL",
+    Delegate:       typeMappings,
+  }
+
+  return sql.Dialect{
+		Identifierer:       sql.IdentifierFn(sql.JoinTransform(".", 
+      sql.PassThroughTransform(
+        func(s string) bool {
+          return sql.IsSimpleIdentifier(s) && !sliceContains(strings.ToLower(s), SF_RESERVED_WORDS)
+        },
+        sql.QuoteTransform("\"", "\\\""),
+    ))),
+		Literaler:          sql.LiteralFn(sql.QuoteTransform("'", "''")),
+		Placeholderer: sql.PlaceholderFn(func(_ int) string {
+			return "?"
+		}),
+		TypeMapper: nullable,
+  }
+}()
+
+var (
+  tplAll = sql.MustParseTemplate(snowflakeDialect, "root", `
+  {{ define "temp_name" -}}
+  flow_temp_table_{{ $.Binding }}
+  {{- end }}
+
+  -- Templated creation of a materialized table definition and comments:
+
+  {{ define "createTargetTable" }}
+  CREATE TABLE IF NOT EXISTS {{$.Identifier}} (
+    {{- range $ind, $col := $.Columns }}
+    {{- if $ind }},{{ end }}
+    {{$col.Identifier}} {{$col.DDL}}
+    {{- end }}
+    {{- if not $.DeltaUpdates }},
+
+    PRIMARY KEY (
+      {{- range $ind, $key := $.Keys }}
+      {{- if $ind }}, {{end -}}
+      {{$key.Identifier}}
+      {{- end -}}
+    )
+    {{- end }}
+  );
+
+  COMMENT ON TABLE {{$.Identifier}} IS {{Literal $.Comment}};
+  {{- range $col := .Columns }}
+  COMMENT ON COLUMN {{$.Identifier}}.{{$col.Identifier}} IS {{Literal $col.Comment}};
+  {{- end}}
+  {{ end }}
+
+{{ define "loadQuery" }}
+	SELECT {{ $.Table.Binding }}, {{ $.Table.Identifier }}.{{ $.Table.Document.Identifier }}
+	FROM {{ $.Table.Identifier }}
+	JOIN (
+		SELECT {{ range $ind, $key := $.Table.Keys }}
+		{{- if $ind }}, {{ end -}}
+		$1[{{$ind}}] AS {{$key.Identifier -}}
+		{{- end }}
+		FROM @flow_v1/{{ $.RandomUUID }}
+	) AS r
+	ON {{ range $ind, $key := $.Table.Keys }}
+	{{- if $ind }} AND {{ end -}}
+	{{ $.Table.Identifier }}.{{ $key.Identifier }} = r.{{ $key.Identifier }}
+	{{- end }}
+{{- end }}
+
+{{ define "copyInto" }}
+	COPY INTO {{ $.Table.Identifier }} (
+		{{ range $ind, $key := (AllFields $.Table) }}
+			{{- if $ind }}, {{ end -}}
+			{{$key.Identifier -}}
+		{{- end }}
+	) FROM (
+		SELECT {{ range $ind, $key := (AllFields $.Table) }}
+		{{- if $ind }}, {{ end -}}
+		$1[{{$ind}}] AS {{$key.Identifier -}}
+		{{- end }}
+		FROM @flow_v1/{{ $.RandomUUID }}
+	);
+{{- end }}
+
+
+{{ define "mergeInto" }}
+	MERGE INTO {{ $.Table.Identifier }}
+	USING (
+		SELECT {{ range $ind, $key := (AllFields $.Table) }}
+			{{- if $ind }}, {{ end -}}
+			$1[{{$ind}}] AS {{$key.Identifier -}}
+		{{- end }}
+		FROM @flow_v1/{{ $.RandomUUID }}
+	) AS r
+	ON {{ range $ind, $key := $.Table.Keys }}
+		{{- if $ind }} AND {{ end -}}
+		{{ $.Table.Identifier }}.{{ $key.Identifier }} = r.{{ $key.Identifier }}
+	{{- end }}
+	WHEN MATCHED AND IS_NULL_VALUE(r.{{ $.Table.Document.Identifier }}) THEN
+		DELETE
+	WHEN MATCHED THEN
+		UPDATE SET {{ range $ind, $key := $.Table.Values }}
+		{{- if $ind }}, {{ end -}}
+		{{ $.Table.Identifier }}.{{ $key.Identifier }} = r.{{ $key.Identifier }}
+	{{- end -}}
+	, {{ $.Table.Identifier }}.{{ $.Table.Document.Identifier}} = r.{{ $.Table.Document.Identifier }}
+	WHEN NOT MATCHED THEN
+		INSERT (
+		{{- range $ind, $key := (AllFields $.Table) }}
+			{{- if $ind }}, {{ end -}}
+			{{$key.Identifier -}}
+		{{- end -}}
+	)
+		VALUES (
+		{{- range $ind, $key := (AllFields $.Table) }}
+			{{- if $ind }}, {{ end -}}
+			r.{{$key.Identifier -}}
+		{{- end -}}
+	);
+{{- end }}
+
+
+
+  {{ define "selectByKeys" }}
+    SELECT {{ $.Document.Identifier }}
+    FROM {{ $.Identifier }}
+    WHERE
+      {{- range $ind, $key := $.Keys }}
+        {{- if $ind }} AND {{ end -}}
+        {{ $key.Identifier }} = {{ $key.Placeholder }}
+      {{- end -}}
+    ;
+  {{ end }}
+
+{{ define "updateFence" }}
+DO $$
+BEGIN
+	UPDATE {{ Identifier $.TablePath }}
+		SET   checkpoint = {{ Literal (Base64Std $.Checkpoint) }}
+		WHERE materialization = {{ Literal $.Materialization.String }}
+		AND   key_begin = {{ $.KeyBegin }}
+		AND   key_end   = {{ $.KeyEnd }}
+		AND   fence     = {{ $.Fence }};
+
+	IF NOT FOUND THEN
+		RAISE 'This instance was fenced off by another';
+	END IF;
+END $$;
+{{ end }}
+  `)
+  tplCreateTargetTable = tplAll.Lookup("createTargetTable")
+  tplLoadQuery         = tplAll.Lookup("loadQuery")
+  tplCopyInto          = tplAll.Lookup("copyInto")
+  tplMergeInto         = tplAll.Lookup("mergeInto")
+  tplSelectByKeys      = tplAll.Lookup("selectByKeys")
+  tplUpdateFence       = tplAll.Lookup("updateFence")
+)
+
+var createStageSQL = `
+CREATE STAGE IF NOT EXISTS flow_v1
+FILE_FORMAT = (
+  TYPE = JSON
+  BINARY_FORMAT = BASE64
+)
+COMMENT = 'Internal stage used by Estuary Flow to stage loaded & stored documents'
+;
+{{ end }}`
+
+func RenderTableWithRandomUUIDTemplate(table sql.Table, randomUUID uuid.UUID, tpl *template.Template) (string, error) {
+	var w strings.Builder
+	if err := tpl.Execute(&w, &TableWithUUID { Table: &table, RandomUUID: randomUUID }); err != nil {
+		return "", err
+	}
+	return w.String(), nil
+}
+

--- a/materialize-sql/templating.go
+++ b/materialize-sql/templating.go
@@ -15,6 +15,8 @@ func MustParseTemplate(dialect Dialect, name, body string) *template.Template {
 		// Tweak signature slightly to take TablePath, as dynamic slicing is a bit tricky
 		// in templates and this is most-frequently used with TablePath.Base().
 		"Identifier": func(p TablePath) string { return dialect.Identifier(p...) },
+		// A helper for iterating over all fields of a table
+		"AllFields": func(table Table) []Column { return append(append(append([]Column{}, table.Keys...), table.Values...), *table.Document) },
 	})
 	return template.Must(tpl.Parse(body))
 }


### PR DESCRIPTION
**Description:**

- Switch materialize-snowflake to use the new `materialize-sql` library instead of the deprecated library in flow repository.

**Workflow steps:**

- Same as before

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/469)
<!-- Reviewable:end -->
