### PR TITLE
build: update CI to allow pushing multiple tags from the same dockerfile

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -71,27 +71,31 @@ jobs:
       fail-fast: false
       matrix:
         connector:
-          - source-alpaca
-          - source-gcs
-          - source-hello-world
-          - source-http-file
-          - source-test
-          - source-firestore
-          - source-kafka
-          - source-kinesis
-          - source-mysql
-          - source-postgres
-          - source-s3
-          - materialize-bigquery
-          - materialize-elasticsearch
-          - materialize-firebolt
-          - materialize-google-pubsub
-          - materialize-google-sheets
-          - materialize-postgres
-          - materialize-rockset
-          - materialize-s3-parquet
-          - materialize-snowflake
-          - materialize-webhook
+          - path: source-alpaca
+          - path: source-gcs
+          - path: source-hello-world
+          - path: source-http-file
+          - path: source-test
+          - path: source-firestore
+          - path: source-kafka
+          - path: source-kinesis
+          - path: source-mysql
+            additionalTags:
+              - source-mariadb
+          - path: source-postgres
+          - path: source-s3
+          - path: materialize-bigquery
+          - path: materialize-elasticsearch
+          - path: materialize-firebolt
+          - path: materialize-google-pubsub
+          - path: materialize-google-sheets
+          - path: materialize-postgres
+            additionalTags:
+              - materialize-timescaledb
+          - path: materialize-rockset
+          - path: materialize-s3-parquet
+          - path: materialize-snowflake
+          - path: materialize-webhook
 
     steps:
       - uses: actions/checkout@v2
@@ -103,8 +107,20 @@ jobs:
         run: |
           TAG=$(echo $GITHUB_SHA | head -c7)
           echo ::set-output name=tag::${TAG}
-          VERSION=$(cat ${{ matrix.connector }}/VERSION | tr -d '\n')
-          echo ::set-output name=version::${VERSION}
+
+          VERSION=$(cat ${{ matrix.connector.path }}/VERSION | tr -d '\n')
+          THIS_COMMIT_TAGS=ghcr.io/estuary/${{ matrix.connector.path }}:$TAG
+          THIS_PUSH_TAGS=ghcr.io/estuary/${{ matrix.connector.path }}:dev,ghcr.io/estuary/${{ matrix.connector.path }}:$VERSION
+
+          # Add any additional tags that should be pushed for this connector image.
+          for additional in ${{ join(matrix.connector.additionalTags, ' ') }}
+          do
+              THIS_COMMIT_TAGS+=",${{ format('ghcr.io/estuary/{0}:$TAG', '$additional') }}"
+              THIS_PUSH_TAGS+=",${{ format('ghcr.io/estuary/{0}:dev,ghcr.io/estuary/{1}:$VERSION', '$additional', '$additional') }}"
+          done
+
+          echo ::set-output name=this_commit_tags::${THIS_COMMIT_TAGS}
+          echo ::set-output name=this_push_tags::${THIS_PUSH_TAGS}
 
       - name: Download latest Flow release binaries and add them to $PATH
         run: |
@@ -112,7 +128,7 @@ jobs:
           echo "${PWD}/flow-bin" >> $GITHUB_PATH
 
       - name: Install kafkactl
-        if: matrix.connector == 'source-kafka'
+        if: matrix.connector.path == 'source-kafka'
         env:
           version: 1.20.0
           checksum: ff285ce7eefa956234e65f9ff98160c2c365973ca598187cee81da1377b139d1
@@ -123,7 +139,7 @@ jobs:
           rm "kafkactl_${version}_linux_amd64.deb"
 
       - name: Set up Cloud SDK
-        if: matrix.connector == 'source-gcs'
+        if: matrix.connector.path == 'source-gcs'
         uses: google-github-actions/setup-gcloud@v0
         with:
           project_id: ${{ secrets.GCP_PROJECT_ID }}
@@ -131,7 +147,7 @@ jobs:
           export_default_credentials: true
 
       - name: Configure AWS credentials from Test account
-        if: matrix.connector == 'source-kinesis' || matrix.connector == 'source-s3'
+        if: matrix.connector.path == 'source-kinesis' || matrix.connector.path == 'source-s3'
         uses: aws-actions/configure-aws-credentials@v1
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -153,28 +169,28 @@ jobs:
         run: docker network create flow-test
 
       - name: Start Dockerized test infrastructure
-        if: matrix.connector == 'source-postgres' || matrix.connector == 'source-mysql'
+        if: matrix.connector.path == 'source-postgres' || matrix.connector.path == 'source-mysql'
         run: |
-          docker compose --file ${{ matrix.connector }}/docker-compose.yaml up --wait
+          docker compose --file ${{ matrix.connector.path }}/docker-compose.yaml up --wait
 
-      - name: Build ${{ matrix.connector }} Docker Image
+      - name: Build ${{ matrix.connector.path }} Docker Image
         uses: docker/build-push-action@v2
         with:
           context: .
-          file: ${{ matrix.connector }}/Dockerfile
+          file: ${{ matrix.connector.path }}/Dockerfile
           load: true
           build-args: BASE_IMAGE=ghcr.io/estuary/base-image:${{ steps.prep.outputs.tag }}
-          tags: ghcr.io/estuary/${{ matrix.connector }}:local
+          tags: ghcr.io/estuary/${{ matrix.connector.path }}:local
           secrets: |
             "rockset_api_key=${{ secrets.ROCKSET_API_KEY }}"
 
       - name: Start Dockerized test infrastructure
-        if: matrix.connector == 'source-kafka'
+        if: matrix.connector.path == 'source-kafka'
         run: |
           docker compose --file infra/docker-compose.yaml up --detach zookeeper
           docker compose --file infra/docker-compose.yaml up --detach kafka
 
-      - name: Source connector ${{ matrix.connector }} integration tests
+      - name: Source connector ${{ matrix.connector.path }} integration tests
         if: |
           contains(fromJson('[
             "source-gcs",
@@ -183,7 +199,7 @@ jobs:
             "source-mysql",
             "source-postgres",
             "source-s3"
-            ]'), matrix.connector)
+            ]'), matrix.connector.path)
         env:
           GCP_SERVICE_ACCOUNT_KEY: ${{ secrets.GCP_SERVICE_ACCOUNT_KEY }}
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -193,35 +209,35 @@ jobs:
           ROCKSET_API_KEY: ${{ secrets.ROCKSET_API_KEY }}
           MYSQL_DATABASE: test
 
-        run: CONNECTOR=${{ matrix.connector }} VERSION=local ./tests/run.sh;
+        run: CONNECTOR=${{ matrix.connector.path }} VERSION=local ./tests/run.sh;
 
-      - name: Materialization connector ${{ matrix.connector }} integration tests
+      - name: Materialization connector ${{ matrix.connector.path }} integration tests
         if: |
           contains(fromJson('[
               "materialize-elasticsearch",
               "materialize-google-sheets",
               "materialize-postgres",
               "materialize-s3-parquet"
-            ]'), matrix.connector)
+            ]'), matrix.connector.path)
         env:
           GCP_SERVICE_ACCOUNT_KEY: ${{ secrets.GCP_SERVICE_ACCOUNT_KEY }}
 
-        run: CONNECTOR=${{ matrix.connector }} VERSION=local tests/materialize/run.sh;
+        run: CONNECTOR=${{ matrix.connector.path }} VERSION=local tests/materialize/run.sh;
 
-      - name: Push ${{ matrix.connector }} image
+      - name: Push ${{ matrix.connector.path }} image with commit SHA tag
         uses: docker/build-push-action@v2
         with:
           context: .
           build-args: BASE_IMAGE=ghcr.io/estuary/base-image:${{ steps.prep.outputs.tag }}
-          file: ${{ matrix.connector }}/Dockerfile
+          file: ${{ matrix.connector.path }}/Dockerfile
           push: true
-          tags: ghcr.io/estuary/${{ matrix.connector }}:${{ steps.prep.outputs.tag }}
+          tags: ${{ steps.prep.outputs.this_commit_tags }}
 
-      - name: Push ${{ matrix.connector }} image with 'dev' tag
+      - name: Push ${{ matrix.connector.path }} image with 'dev' tag
         if: ${{ github.event_name == 'push' }}
         uses: docker/build-push-action@v2
         with:
           context: .
-          file: ${{ matrix.connector }}/Dockerfile
+          file: ${{ matrix.connector.path }}/Dockerfile
           push: true # See 'if' above
-          tags: ghcr.io/estuary/${{ matrix.connector }}:dev,ghcr.io/estuary/${{ matrix.connector }}:${{ steps.prep.outputs.version }}
+          tags: ${{ steps.prep.outputs.this_push_tags }}


### PR DESCRIPTION
**Description:**

This is a CI change that will allow for easily pushing an image with a different tag from a single dockerfile build. This will allow us to have a specific tag for `source-mariadb`, `materialize-timescaledb`, etc. The images themselves are identical (they have the same digests) as their root `source-mysql` and `materialize-postgres`, they just have a different tag.

The variant images will be published on merges to `main` with the same version tag as their root connector.

Closes https://github.com/estuary/connectors/issues/422

**Workflow steps:**

Additional tags for any image can be configured in `ci.yaml` in a similar way. Multiple additional tags can be specified to be built from a single connector.

**Documentation links affected:**

This PR will end up creating two new connectors: `source-mariadb` and `materialize-timescaledb`. I'd think we should have a docs page for each of these, but the docs should just link to `source-mysql` and `materialize-postgres` (respectively), with clarification on those docs pages that the same configuration applies.

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/479)
<!-- Reviewable:end -->
