### PR TITLE
materialize-postgres: add config to run additional sql on table creation

### DIFF
--- a/materialize-bigquery/bigquery.go
+++ b/materialize-bigquery/bigquery.go
@@ -77,7 +77,7 @@ func (c *config) DatasetPath(path ...string) sql.TablePath {
 }
 
 type tableConfig struct {
-  Table     string `json:"table" jsonschema:"title=Table,description=Table in the BigQuery dataset to store materialized result in." jsonschema_extras:"x-collection-name=true"`
+	Table     string `json:"table" jsonschema:"title=Table,description=Table in the BigQuery dataset to store materialized result in." jsonschema_extras:"x-collection-name=true"`
 	Delta     bool   `json:"delta_updates,omitempty" jsonschema:"default=false,title=Delta Update,description=Should updates to this table be done via delta updates. Defaults is false."`
 	projectID string
 	dataset   string
@@ -100,6 +100,10 @@ func (c tableConfig) Validate() error {
 // Path returns the sqlDriver.ResourcePath for a table.
 func (c tableConfig) Path() sql.TablePath {
 	return []string{c.projectID, c.dataset, c.Table}
+}
+
+func (c tableConfig) GetAdditionalSql() string {
+	return ""
 }
 
 // DeltaUpdates returns if BigQuery is in DeltaUpdates mode or not.

--- a/materialize-postgres/.snapshots/TestSpecification
+++ b/materialize-postgres/.snapshots/TestSpecification
@@ -91,6 +91,12 @@
         "title": "Alternative Schema",
         "description": "Alternative schema for this table (optional)"
       },
+      "additional_table_create_sql": {
+        "type": "string",
+        "title": "Additional Table Create SQL",
+        "description": "Additional SQL statement(s) to be run in the same transaction that creates the table.",
+        "multiline": true
+      },
       "delta_updates": {
         "type": "boolean",
         "title": "Delta Update",

--- a/materialize-postgres/driver.go
+++ b/materialize-postgres/driver.go
@@ -79,9 +79,10 @@ func (c *config) ToURI() string {
 }
 
 type tableConfig struct {
-	Table  string `json:"table" jsonschema:"title=Table,description=Name of the database table" jsonschema_extras:"x-collection-name=true"`
-	Schema string `json:"schema,omitempty" jsonschema:"title=Alternative Schema,description=Alternative schema for this table (optional)"`
-	Delta  bool   `json:"delta_updates,omitempty" jsonschema:"default=false,title=Delta Update,description=Should updates to this table be done via delta updates. Default is false."`
+	Table         string `json:"table" jsonschema:"title=Table,description=Name of the database table" jsonschema_extras:"x-collection-name=true"`
+	Schema        string `json:"schema,omitempty" jsonschema:"title=Alternative Schema,description=Alternative schema for this table (optional)"`
+	AdditionalSql string `json:"additional_table_create_sql,omitempty" jsonschema:"title=Additional Table Create SQL,description=Additional SQL statement(s) to be run in the same transaction that creates the table." jsonschema_extras:"multiline=true"`
+	Delta         bool   `json:"delta_updates,omitempty" jsonschema:"default=false,title=Delta Update,description=Should updates to this table be done via delta updates. Default is false."`
 }
 
 func newTableConfig(ep *sql.Endpoint) sql.Resource {
@@ -105,6 +106,10 @@ func (c tableConfig) Path() sql.TablePath {
 		return []string{c.Schema, c.Table}
 	}
 	return []string{c.Table}
+}
+
+func (c tableConfig) GetAdditionalSql() string {
+	return c.AdditionalSql
 }
 
 func (c tableConfig) DeltaUpdates() bool {
@@ -186,7 +191,10 @@ func (c client) FetchSpecAndVersion(ctx context.Context, specs sql.Table, materi
 	return
 }
 
+// ExecStatements is used for the DDL statements of ApplyUpsert and ApplyDelete. Postgres supports
+// transactional DDL statements, so the statements are wrapped in a transaction.
 func (c client) ExecStatements(ctx context.Context, statements []string) error {
+	statements = append(append([]string{"begin;"}, statements...), "commit;")
 	return c.withDB(func(db *stdsql.DB) error { return sql.StdSQLExecStatements(ctx, db, statements) })
 }
 

--- a/materialize-sql/driver.go
+++ b/materialize-sql/driver.go
@@ -160,6 +160,10 @@ func (d *Driver) ApplyUpsert(ctx context.Context, req *pm.ApplyRequest) (*pm.App
 		} else {
 			statements = append(statements, statement)
 		}
+
+		if shape.AdditionalSql != "" {
+			statements = append(statements, shape.AdditionalSql)
+		}
 	}
 
 	// Insert or update the materialization specification.

--- a/materialize-sql/endpoint.go
+++ b/materialize-sql/endpoint.go
@@ -28,6 +28,8 @@ type Resource interface {
 	Validate() error
 	// Path returns the fully qualified name of the resource, as '.'-separated components.
 	Path() TablePath
+	// Get any user-defined additional SQL to be executed transactionally with table creation.
+	GetAdditionalSql() string
 	// DeltaUpdates is true if the resource should be materialized using delta updates.
 	DeltaUpdates() bool
 }

--- a/materialize-sql/table_mapping.go
+++ b/materialize-sql/table_mapping.go
@@ -21,6 +21,8 @@ type TableShape struct {
 	Source pf.Collection
 	// Comment for this table.
 	Comment string
+	// User-defined additional SQL to be executed transactionally with table creation.
+	AdditionalSql string
 	// The table is operating in delta-updates mode (instead of a standard materialization).
 	DeltaUpdates bool
 
@@ -166,14 +168,15 @@ func BuildTableShape(spec *pf.MaterializationSpec, index int, resource Resource)
 	)
 
 	return TableShape{
-		Path:         resource.Path(),
-		Binding:      index,
-		Source:       binding.Collection.Collection,
-		Comment:      comment,
-		DeltaUpdates: resource.DeltaUpdates(),
-		Keys:         keys,
-		Values:       values,
-		Document:     document,
+		Path:          resource.Path(),
+		Binding:       index,
+		Source:        binding.Collection.Collection,
+		Comment:       comment,
+		AdditionalSql: resource.GetAdditionalSql(),
+		DeltaUpdates:  resource.DeltaUpdates(),
+		Keys:          keys,
+		Values:        values,
+		Document:      document,
 	}
 }
 


### PR DESCRIPTION
**Description:**

Adds an optional resource-level configuration for the user to provide additional SQL statements to be executed when creating a table as part of `ApplyUpsert`. This could be used for things like converting a table to a TimescaleDB hypertable before any data is written to it, creating additional indexes, etc.

Closes #476

**Workflow steps:**

As an example for materializing to TimescaleDB where you want the table that the materialization is going to create to be created as a hypertable, you would add this SQL statement to the config:
```sql
SELECT create_hypertable('flow_created_table_name', 'timestamp_column');
```

**Documentation links affected:**

The postgres materialization docs will need updated with this new configuration. An example for creating a hypertable would be helpful under a TimescaleDB-specific heading.

**Notes for reviewers:**

For the TimescaleDB hypertable simple case, this is a less-direct way of making that possible than something like a checkbox that would cause the connector to use an alternative table creation schema that would automatically include the hypertable statement. We are opting to use the slightly less user-friendly raw SQL input configuration since it is higher leverage: It may be useful for other SQL materializations and cases beyond simple hypertables. For example, a regular postgres materialization might have use for creating additional indexes on created tables. A TimescaleDB materialization might want to create _distributed_ hypertables and/or include some of the numerous options that are possible with hypertable creation - these would not be practical for use to exhaustively maintain as individual connector config. And it makes it possible to include the necessary behaviors in a single postgres connector as opposed to forking into a TimescaleDB connector with legitimately different code.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/481)
<!-- Reviewable:end -->
