### PR TITLE
source-alpaca: add small delay on backfiller recency

### DIFF
--- a/source-alpaca/.snapshots/TestSpec
+++ b/source-alpaca/.snapshots/TestSpec
@@ -22,8 +22,7 @@
           "sip"
         ],
         "title": "Feed",
-        "description": "The feed to pull market data from.",
-        "multiline": true
+        "description": "The feed to pull market data from."
       },
       "symbols": {
         "type": "string",
@@ -35,47 +34,40 @@
         "type": "string",
         "format": "date-time",
         "title": "Start Date",
-        "description": "Get trades starting at this date. Has no effect if changed after the capture has started.",
-        "multiline": true
+        "description": "Get trades starting at this date. Has no effect if changed after the capture has started."
       },
       "advanced": {
         "properties": {
           "is_free_plan": {
             "type": "boolean",
             "title": "Free Plan",
-            "description": "Set this if you are using a free plan. Delays data by 15 minutes.",
-            "multiline": true
+            "description": "Set this if you are using a free plan. Delays data by 15 minutes."
           },
           "stop_date": {
             "type": "string",
             "format": "date-time",
             "title": "Stop Date",
-            "description": "Stop backfilling historical data at this date.",
-            "multiline": true
+            "description": "Stop backfilling historical data at this date."
           },
           "disable_real_time": {
             "type": "boolean",
             "title": "Disable Real-Time Streaming",
-            "description": "Disables real-time streaming via the websocket API. Data will only be collected via the backfill mechanism.",
-            "multiline": true
+            "description": "Disables real-time streaming via the websocket API. Data will only be collected via the backfill mechanism."
           },
           "disable_backfill": {
             "type": "boolean",
             "title": "Disable Historical Data Backfill",
-            "description": "Disables historical data backfill via the historical data API. Data will only be collected via streaming.",
-            "multiline": true
+            "description": "Disables historical data backfill via the historical data API. Data will only be collected via streaming."
           },
           "max_backfill_interval": {
             "type": "string",
             "title": "Maximum Backfill Interval",
-            "description": "The largest time interval that will be requested for backfills. Using smaller intervals may be useful when tracking many symbols. Must be a valid Go duration string.",
-            "multiline": true
+            "description": "The largest time interval that will be requested for backfills. Using smaller intervals may be useful when tracking many symbols. Must be a valid Go duration string."
           },
           "min_backfill_interval": {
             "type": "string",
             "title": "Minimum Backfill Interval",
-            "description": "The smallest time interval that will be requested for backfills after the initial backfill is complete. Must be a valid Go duration string.",
-            "multiline": true
+            "description": "The smallest time interval that will be requested for backfills after the initial backfill is complete. Must be a valid Go duration string."
           }
         },
         "additionalProperties": false,

--- a/source-alpaca/main.go
+++ b/source-alpaca/main.go
@@ -33,9 +33,9 @@ func (r *resource) Validate() error {
 type config struct {
 	ApiKeyID     string         `json:"api_key_id" jsonschema:"title=Alpaca API Key ID,description=Your Alpaca API key ID." jsonschema_extras:"secret=true"`
 	ApiSecretKey string         `json:"api_secret_key" jsonschema:"title=Alpaca API Secret Key,description=Your Alpaca API Secret key." jsonschema_extras:"secret=true"`
-	Feed         string         `json:"feed" jsonschema:"title=Feed,description=The feed to pull market data from.,enum=iex,enum=sip" jsonschema_extras:"multiline=true"`
+	Feed         string         `json:"feed" jsonschema:"title=Feed,description=The feed to pull market data from.,enum=iex,enum=sip"`
 	Symbols      string         `json:"symbols" jsonschema:"title=Symbols,description=Comma separated list of symbols to monitor." jsonschema_extras:"multiline=true"`
-	StartDate    time.Time      `json:"start_date" jsonschema:"title=Start Date,description=Get trades starting at this date. Has no effect if changed after the capture has started." jsonschema_extras:"multiline=true"`
+	StartDate    time.Time      `json:"start_date" jsonschema:"title=Start Date,description=Get trades starting at this date. Has no effect if changed after the capture has started."`
 	Advanced     advancedConfig `json:"advanced,omitempty" jsonschema:"title=Advanced Options,description=Options for advanced users. You should not typically need to modify these." jsonschema_extra:"advanced=true"`
 
 	effectiveMaxBackfillInterval time.Duration
@@ -52,12 +52,12 @@ func (c *config) GetSymbols() []string {
 }
 
 type advancedConfig struct {
-	IsFreePlan          bool      `json:"is_free_plan,omitempty" jsonschema:"title=Free Plan,description=Set this if you are using a free plan. Delays data by 15 minutes." jsonschema_extras:"multiline=true"`
-	StopDate            time.Time `json:"stop_date,omitempty" jsonschema:"title=Stop Date,description=Stop backfilling historical data at this date." jsonschema_extras:"multiline=true"`
-	DisableRealTime     bool      `json:"disable_real_time,omitempty" jsonschema:"title=Disable Real-Time Streaming,description=Disables real-time streaming via the websocket API. Data will only be collected via the backfill mechanism." jsonschema_extras:"multiline=true"`
-	DisableBackfill     bool      `json:"disable_backfill,omitempty" jsonschema:"title=Disable Historical Data Backfill,description=Disables historical data backfill via the historical data API. Data will only be collected via streaming." jsonschema_extras:"multiline=true"`
-	MaxBackfillInterval string    `json:"max_backfill_interval,omitempty" jsonschema:"title=Maximum Backfill Interval,description=The largest time interval that will be requested for backfills. Using smaller intervals may be useful when tracking many symbols. Must be a valid Go duration string." jsonschema_extras:"multiline=true"`
-	MinBackfillInterval string    `json:"min_backfill_interval,omitempty" jsonschema:"title=Minimum Backfill Interval,description=The smallest time interval that will be requested for backfills after the initial backfill is complete. Must be a valid Go duration string." jsonschema_extras:"multiline=true"`
+	IsFreePlan          bool      `json:"is_free_plan,omitempty" jsonschema:"title=Free Plan,description=Set this if you are using a free plan. Delays data by 15 minutes."`
+	StopDate            time.Time `json:"stop_date,omitempty" jsonschema:"title=Stop Date,description=Stop backfilling historical data at this date."`
+	DisableRealTime     bool      `json:"disable_real_time,omitempty" jsonschema:"title=Disable Real-Time Streaming,description=Disables real-time streaming via the websocket API. Data will only be collected via the backfill mechanism."`
+	DisableBackfill     bool      `json:"disable_backfill,omitempty" jsonschema:"title=Disable Historical Data Backfill,description=Disables historical data backfill via the historical data API. Data will only be collected via streaming."`
+	MaxBackfillInterval string    `json:"max_backfill_interval,omitempty" jsonschema:"title=Maximum Backfill Interval,description=The largest time interval that will be requested for backfills. Using smaller intervals may be useful when tracking many symbols. Must be a valid Go duration string."`
+	MinBackfillInterval string    `json:"min_backfill_interval,omitempty" jsonschema:"title=Minimum Backfill Interval,description=The smallest time interval that will be requested for backfills after the initial backfill is complete. Must be a valid Go duration string."`
 }
 
 func (c *config) Validate() error {

--- a/source-alpaca/worker.go
+++ b/source-alpaca/worker.go
@@ -18,6 +18,7 @@ const (
 	emptyCheckpoint         = `{}`
 	defaultCurrency         = "usd"
 	streamerLoggingInterval = 1 * time.Minute
+	backfillDely            = 1 * time.Minute
 )
 
 type tradeDocument struct {
@@ -309,6 +310,10 @@ func getEndDate(freePlan bool, endDate time.Time) time.Time {
 	// Free plans can't get data from within the last 15 minutes.
 	if freePlan {
 		now = now.Add(-1 * 15 * time.Minute)
+	} else {
+		// Slight delay on how recent the backfill can query for to account for instability in very
+		// recently received data on Alpaca's servers.
+		now = now.Add(-1 * backfillDely)
 	}
 
 	return now


### PR DESCRIPTION
**Description:**

This will prevent pulling in unstable data if the historical API is queried at a time very close to
the current instant. I have seen reports that this can result in inconsistent results in rare cases,
due to delays or inconsistent ordering in tick records that stream into the database on the Alpaca
side. This small delay should eliminate that possibility.

Closes https://github.com/estuary/connectors/issues/480

**Workflow steps:**

No user-facing changes.

**Documentation links affected:**

N/A

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/482)
<!-- Reviewable:end -->
