### PR TITLE
add missing "type" property to credentials configurations

### DIFF
--- a/go-auth/google/.snapshots/TestConfigSchema
+++ b/go-auth/google/.snapshots/TestConfigSchema
@@ -56,6 +56,7 @@
       "title": "Service Account Key"
     }
   ],
+  "type": "object",
   "title": "Test Config Schema",
   "description": "Google API Credentials",
   "default": {

--- a/go-auth/google/config.go
+++ b/go-auth/google/config.go
@@ -152,5 +152,6 @@ func (CredentialConfig) JSONSchema() *jsonschema.Schema {
 		Extras: map[string]interface{}{
 			"discriminator": map[string]string{"propertyName": "auth_type"},
 		},
+		Type: "object",
 	}
 }

--- a/materialize-google-pubsub/.snapshots/TestSpec
+++ b/materialize-google-pubsub/.snapshots/TestSpec
@@ -64,6 +64,7 @@
             "title": "Service Account Key"
           }
         ],
+        "type": "object",
         "title": "Authentication",
         "default": {
           "auth_type": "Client"

--- a/materialize-google-sheets/.snapshots/TestSpec
+++ b/materialize-google-sheets/.snapshots/TestSpec
@@ -64,6 +64,7 @@
             "title": "Service Account Key"
           }
         ],
+        "type": "object",
         "title": "Authentication",
         "default": {
           "auth_type": "Client"

--- a/source-http-file/main.go
+++ b/source-http-file/main.go
@@ -190,6 +190,7 @@ func main() {
 			"credentials": {
 			"title": "Credentials",
 			"description": "User credentials, if required to access the data at the HTTP URL.",
+			"type": "object",
 			"oneOf": [{
 				"type": "object",
 				"title": "Basic Authentication",


### PR DESCRIPTION
**Description:**

Part of https://github.com/estuary/connectors/issues/467

Recent changes to UI rendering to be more strict about not rendering invalid specs have illuminated the fact that on a few connectors the `credentials`-type of configs don't have the required `type: object` key/value. This fixes that so they render properly in the UI again.

Applies to `materialize-google-pubsub`, `materialize-google-sheets`, and `source-http-file`. `source-http-file` still has some rendering problems with the parser config that will need to be handled in the flow repo.

`source-kafka` also has rendering problems, but this PR is not addressing those.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

N/A

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/483)
<!-- Reviewable:end -->
