### PR TITLE
materialize-google-sheet: better error message for PrevRound mismatch

### DIFF
--- a/materialize-google-sheets/transactor.go
+++ b/materialize-google-sheets/transactor.go
@@ -148,7 +148,7 @@ func (d *transactor) Store(it *pm.StoreIterator) error {
 			}
 
 			// Row is being updated or inserted.
-			// It's sheet row index is 1-indexed (due to its header).
+			// Its sheet row index is 1-indexed due to its header.
 			var rowInd = int64(len(next) + 1)
 			var s = stores[si]
 			si++
@@ -159,7 +159,8 @@ func (d *transactor) Store(it *pm.StoreIterator) error {
 				Round:     s.NextRound,
 			})
 
-			// Does a `prev` row exist? If so include its prior version in the prior state.
+			// Does a `prev` row corresponding with this store document exist?
+			// If so include this prior version in the state.
 			if cmp == 0 {
 				s.PrevDoc = prev[pi].Doc
 				s.PrevRound = prev[pi].Round

--- a/materialize-google-sheets/util.go
+++ b/materialize-google-sheets/util.go
@@ -36,7 +36,7 @@ func buildTransactorBindings(
 			case row.NextRound != 0 && row.NextRound <= row.PrevRound:
 				err = fmt.Errorf("NextRound must be greater than PrevRound")
 			case row.PrevRound > loadRound:
-				err = fmt.Errorf("PrevRound must have been committed (less or equal to loadRound)")
+				err = fmt.Errorf("PrevRound must have been committed (less or equal to loadRound). This most commonly happens if there are multiple materializations writing to the same sheet. To ensure consistency, each sheet must be written to by a single materialization only, this includes materializations that have been disabled.")
 			case row.NextRound != 0 && row.NextRound <= loadRound:
 				// NextRound has already committed and is used.
 				rows = append(rows, transactorRow{
@@ -164,6 +164,9 @@ type RowState struct {
 const sentinelValue = `{}`
 
 // loadSheetStates loads the SheetStates of all named `sheetNames`.
+// each row in a sheet has a zero-indexed cell where RowState is written to,
+// this zero-indexed cell is not visible to users when they look at the sheet
+// but we have it available when using the API
 func loadSheetStates(
 	bindings []*pf.MaterializationSpec_Binding,
 	client *sheets.Service,


### PR DESCRIPTION
**Description:**

- Improve error message for the case when `PrevRound > loadRound`
- Some tiny comment improvements
- Solves https://github.com/estuary/connectors/issues/485

**Workflow steps:**

- Materialize to a sheet, disable that materialization, then create another materialization

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/490)
<!-- Reviewable:end -->
