### PR TITLE
source-{gcs,s3}: validate bucket is connectable when creating store

### DIFF
--- a/source-gcs/main.go
+++ b/source-gcs/main.go
@@ -69,6 +69,10 @@ func newGCStore(ctx context.Context, cfg *config) (*gcStore, error) {
 		return nil, fmt.Errorf("creating GCS session: %w", err)
 	}
 
+	if _, err := client.Bucket(cfg.Bucket).Attrs(ctx); err != nil {
+		return nil, fmt.Errorf("validating connection to bucket %q: %w", cfg.Bucket, err)
+	}
+
 	return &gcStore{gcs: client}, nil
 }
 

--- a/source-s3/main.go
+++ b/source-s3/main.go
@@ -87,7 +87,12 @@ func newS3Store(ctx context.Context, cfg *config) (*s3Store, error) {
 		return nil, fmt.Errorf("creating aws config: %w", err)
 	}
 
-	return &s3Store{s3: s3.New(awsSession)}, nil
+	s3Sess := s3.New(awsSession)
+	if _, err := s3Sess.HeadBucketWithContext(ctx, &s3.HeadBucketInput{Bucket: &cfg.Bucket}); err != nil {
+		return nil, fmt.Errorf("validating connection to bucket %q: %w", cfg.Bucket, err)
+	}
+
+	return &s3Store{s3: s3Sess}, nil
 }
 
 func (s *s3Store) List(ctx context.Context, query filesource.Query) (filesource.Listing, error) {


### PR DESCRIPTION
**Description:**

Adds a check to `source-s3` & `source-gcs` to make sure the bucket is connectable when creating the "store object". This happens during the airbyte protocol `Check` command, so an error connecting to the bucket will be surfaced during validation, rather than at runtime. This is particularly important now that we aren't doing any kind of discovery with the cloud storage connectors, since at no point during the setup does it actually connect to the bucket.

Errors that will be returned during validation will look like this for a non-existent bucket:

- `source-s3`: `connecting to store: validating connection to bucket "not-a-real-bucket-as8djf98": NotFound: Not Found`
- `source-gcs`: `connecting to store: validating connection to bucket "not-a-real-bucket-as8djf98": storage: bucket doesn't exist`

Closes https://github.com/estuary/connectors/issues/493

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

N/A

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/494)
<!-- Reviewable:end -->
