### PR TITLE
materialize-bigquery: verify dataset, project, and cloud storage bucket

### DIFF
--- a/materialize-bigquery/bigquery.go
+++ b/materialize-bigquery/bigquery.go
@@ -64,6 +64,14 @@ func (c *config) client(ctx context.Context) (*client, error) {
 		return nil, fmt.Errorf("creating cloud storage client: %w", err)
 	}
 
+	if _, err := bigqueryClient.DatasetInProject(c.ProjectID, c.Dataset).Metadata(ctx); err != nil {
+		return nil, fmt.Errorf("validating dataset & project: %w", err)
+	}
+
+	if _, err := cloudStorageClient.Bucket(c.Bucket).Attrs(ctx); err != nil {
+		return nil, fmt.Errorf("validating connection to bucket %q: %w", c.Bucket, err)
+	}
+
 	return &client{
 		bigqueryClient:     bigqueryClient,
 		cloudStorageClient: cloudStorageClient,


### PR DESCRIPTION
**Description:**

This adds a check to make sure the project, dataset, and cloud storage bucket exist with creation of the client. This prevents the materialization from being saved if any of these are invalid.

In the case of an invalid cloud storage bucket previously the materialization could be saved but then a runtime error would occur. With this change, an error will be returned when trying to save the materialization:
```
driver error while validating materialization bobCo/bq-test-1 Caused by: invocation failed: connector failed (exit status: 1) with stderr: building endpoint: creating client: validating connection to bucket "bucket-that-does-not-exist-12341234asdf": storage: bucket doesn't exist
```

An invalid project ID or dataset previously would not be able to be saved, but the error wouldn't occur until the connector tried to do `ApplyUpsert`. The error message in this case wasn't terrible, but a lot less clear than it could be that the inputs weren't going to work, with the relevant error being intermixed with otherwise successful looking informational messages about the connector starting up successfully and connecting to BigQuery.

With this change, errors will be surfaced during validation and should be more clear:

For an invalid project id:
```
driver error while validating materialization bobCo/bq-test-1 Caused by: invocation failed: connector failed (exit status: 1) with stderr: building endpoint: creating client: validating dataset & project: googleapi: Error 404: Project invalid-project-id is not found. Make sure it references valid GCP project that hasn't been deleted.; Project id: invalid-project-id, notFound
```

For an invalid dataset:
```
driver error while validating materialization bobCo/bq-test-1 Caused by: invocation failed: connector failed (exit status: 1) with stderr: building endpoint: creating client: validating dataset & project: googleapi: Error 404: Not found: Dataset estuary-sandbox:baddataset, notFound
```

Closes https://github.com/estuary/connectors/issues/323

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/495)
<!-- Reviewable:end -->
