### PR TITLE
materialize-google-pubsub: improve memory & create default subscription

### DIFF
--- a/materialize-google-pubsub/.snapshots/TestSpec
+++ b/materialize-google-pubsub/.snapshots/TestSpec
@@ -99,7 +99,7 @@
       "create_default_subscription": {
         "type": "boolean",
         "title": "Create with Default Subscription",
-        "description": "Create a default subscription when creating the topic. Will be created as \"topic-sub\". Has no effect if the topic already exists.",
+        "description": "Create a default subscription when creating the topic. Will be created as \"\u003ctopic\u003e-sub\". Has no effect if the topic already exists.",
         "default": true
       }
     },

--- a/materialize-google-pubsub/.snapshots/TestSpec
+++ b/materialize-google-pubsub/.snapshots/TestSpec
@@ -95,11 +95,18 @@
         "type": "string",
         "title": "Resource Binding Identifier",
         "description": "Optional identifier for the resource binding. Each binding must have a unique topic \u0026 identifier pair. Included as \"identifier\" attribute in published messages if specified."
+      },
+      "create_default_subscription": {
+        "type": "boolean",
+        "title": "Create with Default Subscription",
+        "description": "Create a default subscription when creating the topic. Will be created as \"topic-sub\". Has no effect if the topic already exists.",
+        "default": true
       }
     },
     "type": "object",
     "required": [
-      "topic"
+      "topic",
+      "create_default_subscription"
     ],
     "title": "Google PubSub Topic"
   },

--- a/materialize-google-pubsub/driver.go
+++ b/materialize-google-pubsub/driver.go
@@ -59,8 +59,9 @@ func (c *config) client(ctx context.Context) (*pubsub.Client, error) {
 }
 
 type resource struct {
-	TopicName  string `json:"topic" jsonschema:"title=Topic Name" jsonschema_extras:"x-collection-name=true"`
-	Identifier string `json:"identifier,omitempty" jsonschema:"title=Resource Binding Identifier"`
+	TopicName                 string `json:"topic" jsonschema:"title=Topic Name" jsonschema_extras:"x-collection-name=true"`
+	Identifier                string `json:"identifier,omitempty" jsonschema:"title=Resource Binding Identifier"`
+	CreateDefaultSubscription bool   `json:"create_default_subscription" jsonschema:"title=Create with Default Subscription,default=true"`
 }
 
 func (resource) GetFieldDocString(fieldName string) string {
@@ -70,6 +71,8 @@ func (resource) GetFieldDocString(fieldName string) string {
 			fmt.Sprintf("Included as %q attribute in published messages if specified.", IDENTIFIER_ATTRIBUTE_KEY)
 	case "TopicName":
 		return "Name of the topic to publish materialized results to."
+	case "CreateDefaultSubscription":
+		return "Create a default subscription when creating the topic. Will be created as \"topic-sub\". Has no effect if the topic already exists."
 	default:
 		return ""
 	}
@@ -194,7 +197,7 @@ func (d driver) ApplyUpsert(ctx context.Context, req *pm.ApplyRequest) (*pm.Appl
 	}
 
 	checkedTopics := make(map[string]struct{})
-	var newTopics []string
+	var newTopics []resource
 	for _, b := range req.Materialization.Bindings {
 		res, err := resolveResourceConfig(b.ResourceSpecJson)
 		if err != nil {
@@ -213,26 +216,40 @@ func (d driver) ApplyUpsert(ctx context.Context, req *pm.ApplyRequest) (*pm.Appl
 		}
 
 		if !exists {
-			newTopics = append(newTopics, res.TopicName)
+			newTopics = append(newTopics, res)
 		}
 	}
 
-	action := ""
-	if len(newTopics) > 0 {
-		action = fmt.Sprintf("created topics: %s", strings.Join(newTopics, ","))
-	}
+	actions := []string{}
+	for _, topic := range newTopics {
+		var t *pubsub.Topic
+		var s *pubsub.Subscription
 
-	if !req.DryRun {
-		for _, topicName := range newTopics {
-			_, err := client.CreateTopic(ctx, topicName)
+		if req.DryRun {
+			// No-op, but record the action that would have been taken.
+			actions = append(actions, fmt.Sprintf("to create topic %s", t.ID()))
+			if topic.CreateDefaultSubscription {
+				actions = append(actions, fmt.Sprintf("to create subscription %s for topic %s", s.ID(), t.ID()))
+			}
+		} else {
+			t, err = client.CreateTopic(ctx, topic.TopicName)
 			if err != nil {
 				return nil, fmt.Errorf("pubsub apply create topic error: %w", err)
+			}
+			actions = append(actions, fmt.Sprintf("created topic %s", t.ID()))
+
+			if topic.CreateDefaultSubscription {
+				s, err = client.CreateSubscription(ctx, fmt.Sprintf("%s-sub", topic.TopicName), pubsub.SubscriptionConfig{Topic: t})
+				if err != nil {
+					return nil, fmt.Errorf("pubsub apply create default subscription: %w", err)
+				}
+				actions = append(actions, fmt.Sprintf("created subscription %s for topic %s", s.ID(), t.ID()))
 			}
 		}
 	}
 
 	return &pm.ApplyResponse{
-		ActionDescription: action,
+		ActionDescription: strings.Join(actions, ", "),
 	}, nil
 }
 

--- a/materialize-google-pubsub/driver.go
+++ b/materialize-google-pubsub/driver.go
@@ -332,6 +332,11 @@ func (d driver) Transactions(stream pm.Driver_TransactionsServer) error {
 			}
 			t := client.Topic(res.TopicName)
 
+			// Have calls to publish block when the number of queued messages exceeds the default limit
+			// of 1000, per topic. This bounds the connector memory usage when the store iterator is
+			// read from faster than the rate of publishing.
+			t.PublishSettings.FlowControlSettings.LimitExceededBehavior = pubsub.FlowControlBlock
+
 			// Allows for the reading of messages in-order with a provided ordering key. See
 			// https://cloud.google.com/pubsub/docs/ordering
 			t.EnableMessageOrdering = true

--- a/materialize-google-pubsub/driver.go
+++ b/materialize-google-pubsub/driver.go
@@ -72,7 +72,7 @@ func (resource) GetFieldDocString(fieldName string) string {
 	case "TopicName":
 		return "Name of the topic to publish materialized results to."
 	case "CreateDefaultSubscription":
-		return "Create a default subscription when creating the topic. Will be created as \"topic-sub\". Has no effect if the topic already exists."
+		return "Create a default subscription when creating the topic. Will be created as \"<topic>-sub\". Has no effect if the topic already exists."
 	default:
 		return ""
 	}

--- a/materialize-google-pubsub/transactor.go
+++ b/materialize-google-pubsub/transactor.go
@@ -40,6 +40,8 @@ func (t *transactor) Store(it *pm.StoreIterator) (pm.StartCommitFunc, error) {
 			msg.Attributes = map[string]string{IDENTIFIER_ATTRIBUTE_KEY: binding.identifier}
 		}
 
+		// Blocks if the maximum number of messages are queue'd, since
+		// topic.PublishSettings.FlowControlSettings.LimitExceededBehavior = pubsub.FlowControlBlock
 		res := binding.topic.Publish(ctx, msg)
 
 		errGroup.Go(func() error {


### PR DESCRIPTION
**Description:**

Two improvements to pubsub in this PR:

- The first commit provides a config option to create a default subscription when `ApplyUpsert` creates a topic. This is almost always going to be what should happen, otherwise the initially published messages will be dropped since there is no subscription. It is by default `true`. This closes https://github.com/estuary/connectors/issues/497
- The second commit sets the underlying PubSub client to block if its message queue is full. The default behavior was to never block, and this meant that if the store iterator could be read from faster than publish messages could be completed (network bound), unbounded in-memory buffering could occur. The PubSub client handles concurrently sending requests already, with a batch size of 100 and a queue limit of 1000, so this shouldn't have any real impact on connector performance.

**Workflow steps:**

Use the connector like before, possibly configuring the default subscription option.

**Documentation links affected:**

PubSub connector docs will need updated with the new config option.

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/498)
<!-- Reviewable:end -->
