### PR TITLE
materialize-bigquery: don't try to validate bucket existence with met…

### DIFF
--- a/materialize-bigquery/bigquery.go
+++ b/materialize-bigquery/bigquery.go
@@ -68,10 +68,6 @@ func (c *config) client(ctx context.Context) (*client, error) {
 		return nil, fmt.Errorf("validating dataset & project: %w", err)
 	}
 
-	if _, err := cloudStorageClient.Bucket(c.Bucket).Attrs(ctx); err != nil {
-		return nil, fmt.Errorf("validating connection to bucket %q: %w", c.Bucket, err)
-	}
-
 	return &client{
 		bigqueryClient:     bigqueryClient,
 		cloudStorageClient: cloudStorageClient,


### PR DESCRIPTION
…adata check

This check was requiring bucket metadata access, which is a different permission than the connector should normally need.

**Description:**

(Describe the high level scope of new or changed features)

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/502)
<!-- Reviewable:end -->
