### PR TITLE
source-kinesis: remove local schema inference, use x-infer-schema: true

### DIFF
--- a/source-kinesis/discovery.go
+++ b/source-kinesis/discovery.go
@@ -4,150 +4,43 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"sync"
-	"time"
 
+	"github.com/invopop/jsonschema"
 	"github.com/aws/aws-sdk-go/service/kinesis"
-	"github.com/estuary/connectors/schema_inference"
 	"github.com/estuary/flow/go/protocols/airbyte"
-	log "github.com/sirupsen/logrus"
 )
 
-// How many documents to read from each stream. A higher number gives us more
-// opportunity to spot variation in the document stream at the expense of having
-// to process more possibly-redundant documents.
-const DISCOVER_MAX_DOCS_PER_STREAM = 100
+const (
+	metaProperty  = "_meta"
+)
 
-// How long should we allow reading from each stream to run. Note: empty streams
-// will wait for documents until this timeout triggers.
-const DISCOVER_READ_TIMEOUT = time.Second * 10
-
-// How long should we allow schema inference to run.
-const DISCOVER_INFER_TIMEOUT = time.Second * 5
-
-// Provides a default schema to use when we encounter an issue with schema inference.
-var DISCOVER_FALLBACK_SCHEMA = schema_inference.Schema(`{"type":"object"}`)
+// Provides a default schema to use for collections.
+var minimalSchema = &jsonschema.Schema{
+		Type:                 "object",
+		Required:             []string{metaProperty},
+		AdditionalProperties: nil,
+		Extras: map[string]interface{}{
+			"x-infer-schema": true,
+		},
+}
 
 func discoverStreams(ctx context.Context, client *kinesis.Kinesis, streamNames []string) []airbyte.Stream {
-	var waitGroup = new(sync.WaitGroup)
-	var streams = make(chan airbyte.Stream, len(streamNames))
+	var streams = make([]airbyte.Stream, len(streamNames))
+
+	// Marshal schema to JSON
+	bs, err := json.Marshal(minimalSchema)
+	if err != nil {
+		panic(fmt.Errorf("error generating schema: %v", err))
+	}
 
 	for i, name := range streamNames {
-		waitGroup.Add(1)
-
-		go func(i int, name string) {
-			defer waitGroup.Done()
-
-			schema, err := runInference(ctx, client, name)
-			if err == schema_inference.NO_DOCUMENTS_FOUND {
-				// An empty stream is a world full of possibilities.
-				schema = DISCOVER_FALLBACK_SCHEMA
-			} else if err != nil {
-				// If we encounter an error discovering the schema we skip the
-				// stream. If the user expects it to be there, they'll need to
-				// investigate what is causing the stream to be causing errors.
-				// Otherwise, this simply omits unreadable streams from the
-				// discover output.
-				log.WithField("stream", name).Error(err.Error())
-				return
-			}
-
-			streams <- airbyte.Stream{
-				Name:                name,
-				JSONSchema:          schema,
-				SupportedSyncModes:  []airbyte.SyncMode{airbyte.SyncModeIncremental},
-				SourceDefinedCursor: true,
-			}
-		}(i, name)
-	}
-
-	waitGroup.Wait()
-	close(streams)
-
-	return collect(streams, len(streamNames))
-}
-
-func runInference(ctx context.Context, client *kinesis.Kinesis, streamName string) (schema_inference.Schema, error) {
-	var logEntry = log.WithField("stream", streamName)
-	var peekCtx, cancelPeek = context.WithTimeout(ctx, DISCOVER_READ_TIMEOUT)
-	defer cancelPeek()
-
-	docCh, docCount, err := peekAtStream(peekCtx, client, streamName, DISCOVER_MAX_DOCS_PER_STREAM)
-
-	if err != nil {
-		return nil, fmt.Errorf("schema discovery for stream `%s` failed: %w", streamName, err)
-	} else if docCount == 0 {
-		return nil, schema_inference.NO_DOCUMENTS_FOUND
-	}
-
-	logEntry.WithField("count", docCount).Info("Got documents for stream")
-
-	var inferCtx, cancelInfer = context.WithTimeout(ctx, DISCOVER_INFER_TIMEOUT)
-	defer cancelInfer()
-
-	return schema_inference.Run(inferCtx, logEntry, docCh)
-}
-
-func peekAtStream(ctx context.Context, client *kinesis.Kinesis, streamName string, peekAtMost uint) (<-chan schema_inference.Document, uint, error) {
-	var (
-		err         error
-		cancel      context.CancelFunc
-		dataCh      chan readResult      = make(chan readResult, 8)
-		shardRange  airbyte.Range        = airbyte.NewFullRange()
-		streamState map[string]string    = make(map[string]string)
-		waitGroup   *sync.WaitGroup      = new(sync.WaitGroup)
-		docs        chan json.RawMessage = make(chan schema_inference.Document, peekAtMost)
-		docCount    uint                 = 0
-	)
-
-	ctx, cancel = context.WithCancel(ctx)
-	defer cancel()
-
-	waitGroup.Add(1)
-	go readStream(ctx, shardRange, client, streamName, streamState, dataCh, waitGroup)
-	go closeChannelWhenDone(dataCh, waitGroup)
-	defer close(docs)
-
-outerLoop:
-	for {
-		select {
-		case <-ctx.Done():
-			break outerLoop
-		case next, more := <-dataCh:
-			if !more {
-				break outerLoop
-			} else if next.err != nil {
-				// We'll log any errors to stderr, as any problems we encounter now are not
-				// necessarily fatal errors for discovery.
-				log.Errorf("peekAtStream failed due to error: %v", next.err)
-				return nil, 0, next.err
-			}
-
-			for _, record := range next.records {
-				select {
-				case docs <- record:
-					// Ok, keep going
-				default:
-					// We've filled up our buffer for this stream
-					break outerLoop
-				}
-				docCount++
-
-				if docCount >= peekAtMost {
-					// We've peeked at enough documents
-					break outerLoop
-				}
-			}
+		streams[i] = airbyte.Stream{
+			Name:                name,
+			JSONSchema:          json.RawMessage(bs),
+			SupportedSyncModes:  []airbyte.SyncMode{airbyte.SyncModeIncremental},
+			SourceDefinedCursor: true,
 		}
 	}
 
-	return docs, docCount, err
-}
-
-func collect(ch <-chan airbyte.Stream, size int) []airbyte.Stream {
-	var collected = make([]airbyte.Stream, 0, size)
-	for stream := range ch {
-		collected = append(collected, stream)
-	}
-	return collected
+	return streams
 }

--- a/source-kinesis/discovery.go
+++ b/source-kinesis/discovery.go
@@ -12,6 +12,8 @@ import (
 
 const (
 	metaProperty  = "_meta"
+	sequenceNumber = "sequence_number"
+	partitionKey = "partition_key"
 )
 
 // Provides a default schema to use for collections.
@@ -21,6 +23,23 @@ var minimalSchema = &jsonschema.Schema{
 		AdditionalProperties: nil,
 		Extras: map[string]interface{}{
 			"x-infer-schema": true,
+
+			"properties": map[string]*jsonschema.Schema{
+				metaProperty: &jsonschema.Schema{
+					Type: "object",
+					Required: []string{sequenceNumber, partitionKey},
+					Extras: map[string]interface{}{
+						"properties": map[string]*jsonschema.Schema{
+							sequenceNumber: &jsonschema.Schema{
+								Type: "string",
+							},
+							partitionKey: &jsonschema.Schema{
+								Type: "string",
+							},
+						},
+					},
+				},
+			},
 		},
 }
 
@@ -38,6 +57,7 @@ func discoverStreams(ctx context.Context, client *kinesis.Kinesis, streamNames [
 			Name:                name,
 			JSONSchema:          json.RawMessage(bs),
 			SupportedSyncModes:  []airbyte.SyncMode{airbyte.SyncModeIncremental},
+			SourceDefinedPrimaryKey: [][]string{{metaProperty, sequenceNumber}, {metaProperty, partitionKey}},
 			SourceDefinedCursor: true,
 		}
 	}

--- a/tests/source-kinesis/bindings.json
+++ b/tests/source-kinesis/bindings.json
@@ -1,4 +1,21 @@
 {
+  "properties": {
+    "_meta": {
+      "properties": {
+        "partition_key": {
+          "type": "string"
+        },
+        "sequence_number": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "sequence_number",
+        "partition_key"
+      ],
+      "type": "object"
+    }
+  },
   "required": [
     "_meta"
   ],

--- a/tests/source-kinesis/bindings.json
+++ b/tests/source-kinesis/bindings.json
@@ -1,24 +1,7 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
-  "properties": {
-    "canary": {
-      "type": "string"
-    },
-    "foo": {
-      "type": [
-        "boolean",
-        "integer",
-        "string"
-      ]
-    },
-    "id": {
-      "type": "integer"
-    }
-  },
   "required": [
-    "canary",
-    "foo",
-    "id"
+    "_meta"
   ],
-  "type": "object"
+  "type": "object",
+  "x-infer-schema": true
 }


### PR DESCRIPTION
**Description:**

- source-kinesis: remove local schema inference, use `x-infer-schema: true` instead
- Added `sequence_number` and `partition_key` to form a key for each record received from Kinesis, this is based on the docs: "SequenceNumber is the unique identifier of the record within its shard." and "PartitionKey identifies which shard in the stream the data record is assigned to.", which I take to mean a combination of two forms a unique identifier of each record.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/510)
<!-- Reviewable:end -->
