### PR TITLE
materialize-rockset: remove s3 integration option

### DIFF
--- a/materialize-rockset/.snapshots/TestRocksetDriverSpec-TestResourceSpecSchema
+++ b/materialize-rockset/.snapshots/TestRocksetDriverSpec-TestResourceSpecSchema
@@ -44,43 +44,6 @@
       "type": "object",
       "title": "Advanced Collection Settings",
       "advanced": true
-    },
-    "initializeFromS3": {
-      "properties": {
-        "integration": {
-          "type": "string",
-          "title": "Integration Name",
-          "description": "The name of the integration that was previously created in the Rockset UI"
-        },
-        "bucket": {
-          "type": "string",
-          "title": "Bucket",
-          "description": "The name of the S3 bucket to load data from."
-        },
-        "region": {
-          "type": "string",
-          "title": "Region",
-          "description": "The AWS region in which the bucket resides. Optional."
-        },
-        "pattern": {
-          "type": "string",
-          "title": "Pattern",
-          "description": "A regex that is used to match objects to be ingested"
-        },
-        "prefix": {
-          "type": "string",
-          "title": "Prefix",
-          "description": "Prefix of the data within the S3 bucket. All files under this prefix will be loaded. Optional. Must not be set if 'pattern' is defined."
-        }
-      },
-      "additionalProperties": false,
-      "type": "object",
-      "required": [
-        "integration",
-        "bucket"
-      ],
-      "title": "Backfill from S3",
-      "advanced": true
     }
   },
   "type": "object",

--- a/materialize-rockset/README.md
+++ b/materialize-rockset/README.md
@@ -6,7 +6,7 @@ This is a Flow connector that materializes delta updates of each document into a
 
 Connector images are available at `ghcr.io/estuary/materialize-rockset`.
 
-The connector configuration must specify a [Rockset API key](https://rockset.com/docs/iam/#api-keys), which can be created in the [Rockset console](https://console.rockset.com/apikeys).
+The connector configuration must specify a [Rockset API key](https://rockset.com/docs/iam/#api-keys), which can be created in the [Rockset console](https://console.rockset.com/apikeys). You must also specify a [Region base URL](https://rockset.com/docs/rest-api/#introduction) where you desired deployment is active.
 
 For each Flow collection you'd like to materialize, add a binding with the names of the target Rockset workspace and collection. Both the workspace and collection will be created automatically by the connector if they don't already exist.
 
@@ -19,8 +19,8 @@ materializations:
       connector:
         image: ghcr.io/estuary/materialize-rockset:dev
         config:
+          region_base_url: <ex: api.usw2a1.rockset.com>
           api_key: <your rockset API key here>
-          max_concurrent_requests: 5
     bindings:
       - resource:
           workspace: <your rockset workspace name>
@@ -28,78 +28,6 @@ materializations:
         source: example/flow/collection
 ```
 
-## Bulk ingestion for large backfills of historical data
-
-If you have a large amount of historical data, then Rockset is capable of doing a "bulk ingestion" from S3, and this
-connector supports that in several ways. In the `resource` of each binding, you may optionally specify
-`initializeFromS3` with the name of an S3 `integration` in Rockset. If you do, then the connector will create the
-collection with the given integration, and it will wait for the integration to process all objects in the S3 bucket
-before it writes any additional data using Rockset's write API. This is to ensure that documents are always written to
-Rockset in the proper order.
-
-The [materialize-s3-parquet](../materialize-s3-parquet/) connector can be used to materialize historical data into S3 in order to facilitate backfilling large collections in Rockset. If this is done, then the materialize-rockset connector can properly pick up where the materialize-s3-parquet connector leaves off. The procedure for doing this is as follows, for the example Flow collection `example/flow/collection`:
-
-1. Follow the [instructions here](https://rockset.com/docs/amazon-s3/#create-an-s3-integration) to create the integration, but _do not create the Rockset collection yet_.
-2. Create and activate a materialization of `example/flow/collection` into a unique prefix within an S3 bucket of your choosing.
-  ```yaml
-  materializations:
-    example/toRockset:
-      endpoint:
-        connector:
-          image: ghcr.io/estuary/materialize-s3-parquet:dev
-          config:
-            bucket: example-s3-bucket
-            region: us-east-1
-            awsAccessKeyId: <your key>
-            awsSecretAccessKey: <your secret>
-            uploadIntervalInSeconds: 300
-      bindings:
-        - resource:
-            pathPrefix: example/s3-prefix/
-          source: example/flow/collection
-  ```
-3. You'll need to decide when the S3 materialization is caught up enough to switch over to using the Rockset write API. Once you're ready to make the switch, disable the S3 materialization by setting the shards to disabled in the yaml and re-deploying. This is necessary in order to ensure correct ordering of documents written to Rockset. (see note below on potential improvements)
-  ```yaml
-  materializations:
-    example/toRockset:
-      shards:
-        disable: true
-      # ...the remainder of the materialization yaml remains the same as above
-  ```
-4. Switch the materialization to use the `materialize-rockset` connector, and re-enable the shards. Here you'll provide the name of the Rockset S3 integration you created above, as well as the bucket and prefix that you previously materialized into. **It's critical that the name of the materialization remains the same as it was for materializing into S3.** Also note that just deleting `disable: true` is enough to cause shards to re-enable once this is deployed.
-  ```yaml
-  materializations:
-    example/toRockset:
-      endpoint:
-        connector:
-          image: ghcr.io/estuary/materialize-rockset:dev
-          config:
-            api_key: <your rockset API key here>
-            max_concurrent_requests: 5
-      bindings:
-        - resource:
-            workspace: <your rockset workspace name>
-            collection: <your rockset collection name>
-            initializeFromS3:
-              integration: <rockset integration name>
-              bucket: example-s3-bucket
-              region: us-east-1
-              prefix: example/s3-prefix/
-          source: example/flow/collection
-  ```
-5. When you activate the new materialization, the connector will create the Rockset collection using the given integration, and wait for it to ingest all of the data from S3 before it continues. During this time, the Flow shards will remain in `STANDBY` status, so `flowctl-go deploy` is expected to block until the bulk ingestion completes. Once this completes, the materialize-rockset connector will automatically switch over to using the write API.
-
 ## Potential improvements
 
-There are a number of additional parameters that users may want to control when creating Rockset collections. The following parameters from the [Rockset API docs](https://rockset.com/docs/rest-api/#createcollection) seem like potential candidates for inclusion in the connector/resource configs.
-
-```
-retention_secs
-time_partition_resolution_secs
-event_time_info
-field_mappings
-field_mapping_query
-clustering_key
-field_schemas
-inverted_index_group_encoding_options
-```
+Rockset supports a [`field_mapping_query`](https://rockset.com/docs/rest-api/#createcollection) when creating a collection. This can allow for specifying things like `_event_time` mappings and custom field mappings. This is not currently supported by the Flow materialization, but could be a potential enhancement in the future.

--- a/materialize-rockset/driver_test.go
+++ b/materialize-rockset/driver_test.go
@@ -2,9 +2,11 @@ package materialize_rockset
 
 import (
 	"context"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"log"
+	"math/rand"
 	"os"
 	"testing"
 	"time"
@@ -225,13 +227,21 @@ func testConfig() config {
 }
 
 func randWorkspace() string {
-	return fmt.Sprintf("automated-tests-%s", RandString(6))
+	return fmt.Sprintf("automated-tests-%s", randString(6))
 }
 
 func randCollection() string {
-	return fmt.Sprintf("c-%s", RandString(6))
+	return fmt.Sprintf("c-%s", randString(6))
 }
 
 func fetchApiKey() string {
 	return os.Getenv("ROCKSET_API_KEY")
+}
+
+func randString(len int) string {
+	var buffer = make([]byte, len)
+	if _, err := rand.Read(buffer); err != nil {
+		panic("failed to generate random string")
+	}
+	return hex.EncodeToString(buffer)
 }

--- a/materialize-rockset/rockset.go
+++ b/materialize-rockset/rockset.go
@@ -3,10 +3,7 @@ package materialize_rockset
 import (
 	"context"
 	"fmt"
-	"math/rand"
-	"time"
 
-	"github.com/relvacode/iso8601"
 	rockset "github.com/rockset/rockset-go-client"
 	rtypes "github.com/rockset/rockset-go-client/openapi"
 	"github.com/rockset/rockset-go-client/option"
@@ -52,29 +49,12 @@ func ensureCollectionExists(ctx context.Context, client *rockset.RockClient, res
 	if existingCollection, err := getCollection(ctx, client, resource.Workspace, resource.Collection); err != nil {
 		return false, err
 	} else if existingCollection != nil {
-		// This collection exists within Rockset already, so just validate that
-		// it has the required integration.  Collection definitions in Rockset
-		// are immutable, so there's no way to add an integration to an existing
-		// collection.  Thus, if the integration named in the resource
-		// configuration does not exist, it must be returned as an error.
-		if resource.InitializeFromS3 != nil && GetS3IntegrationSource(existingCollection, resource.InitializeFromS3.Integration) == nil {
-			return false, fmt.Errorf("expected collection '%s' to have a source with an integration named '%s', but no such integration source exists", resource.Collection, resource.InitializeFromS3.Integration)
-		}
 		return false, nil
 	} else {
 		// This collection does not exist within Rockset yet, so we should create it.
 		var err = createCollection(ctx, client, resource)
 		return err == nil, err
 	}
-}
-
-func GetS3IntegrationSource(collection *rtypes.Collection, integrationName string) *rtypes.SourceS3 {
-	for _, source := range collection.Sources {
-		if source.GetIntegrationName() == integrationName {
-			return source.S3
-		}
-	}
-	return nil
 }
 
 func getCollection(ctx context.Context, client *rockset.RockClient, workspace string, collection string) (*rtypes.Collection, error) {
@@ -91,10 +71,6 @@ func getCollection(ctx context.Context, client *rockset.RockClient, workspace st
 
 func createCollection(ctx context.Context, client *rockset.RockClient, resource *resource) error {
 	var opts []option.CollectionOption
-
-	if resource.InitializeFromS3 != nil {
-		opts = append(opts, resource.InitializeFromS3.toOpt())
-	}
 
 	if advanced := resource.AdvancedCollectionSettings; advanced != nil {
 		if advanced.RetentionSecs != nil {
@@ -117,106 +93,3 @@ func createCollection(ctx context.Context, client *rockset.RockClient, resource 
 	}
 	return nil
 }
-
-// awaitCollectionReady blocks until the given Rockset collection has a READY status AND has completed
-// ingestion of all the files in the cloud storage bucket for the given integration. This is required in order to
-// successfully hand off from a cloud storage materailization while preserving the ingestion order of documents.
-// Basically, we need to wait until all the documents in the cloud storage bucket have been ingested before we can start
-// using the write API, or else an earlier document from cloud storage may overwrite the one we ingest using the write
-// API.
-func awaitCollectionReady(ctx context.Context, client *rockset.RockClient, workspace, collectionName, integration string) error {
-	for {
-		if ctx.Err() != nil {
-			return ctx.Err()
-		}
-		var collection, err = getCollection(ctx, client, workspace, collectionName)
-		if err != nil {
-			return err
-		}
-		if collection == nil {
-			return fmt.Errorf("rockset collection '%s' does not exist or has been deleted", collectionName)
-		}
-
-		var ready = isStatusReady(collection)
-
-		// We'll check to see if a collection has made no progress and emit a specific warning in that case.  If a
-		// Rockset collection isn't using a large enough instance, then it'll silently refuse to actually use the
-		// integration that was configured. This is a really easy mistake to make, and there doesn't appear to be a way
-		// to actually detect the instance size via the API, so we'll try to log a helpful warning if the collection
-		// goes too long without downloading any of the objects from cloud storage.
-		var bulkIngestStalled = false
-		collectionAge, err := getCollectionAge(collection)
-		if err != nil {
-			return err
-		}
-		// If an integration was specified, then we need to _also_ wait for that integration to fully process all of its
-		// files. Technically, this will already be the case if there was enough data in the source bucket to trigger a
-		// "bulk load", because in that case Rockset will not set the status to READY until after all the files have
-		// been uploaded. BUT, if the source bucket didn't contain enough data to trigger the "bulk load", then the
-		// status may be set to READY before all of the source files have been processed. This condition is a guard
-		// against ingesting data out of order in that specific case.
-		if integration != "" {
-			var source = GetS3IntegrationSource(collection, integration)
-			if source == nil {
-				return fmt.Errorf("expected collection '%s' to have a compatible cloud-storage integration named '%s', but no such source exists", collectionName, integration)
-			}
-			ready = ready && *source.ObjectCountTotal == *source.ObjectCountDownloaded
-			bulkIngestStalled = *source.ObjectCountTotal > 0 && *source.ObjectCountDownloaded == 0 && collectionAge > time.Minute*5
-		}
-
-		var logEntry = log.WithFields(log.Fields{
-			"rocksetWorkspace":  workspace,
-			"rocksetCollection": collection,
-		})
-		if ready {
-			logEntry.Info("Rockset collection is ready to accept writes")
-			return nil
-		} else if bulkIngestStalled {
-			logEntry.Warn("Rockset collection integration has not made any progress. Is your Rockset virtual instance large enough to support bulk ingestion?")
-		} else {
-			logEntry.Info("Rockset collection is not yet ready to accept writes (will retry)")
-		}
-
-		time.Sleep(nextIngestCompletionBackoff(collectionAge))
-	}
-}
-
-func getCollectionAge(collection *rtypes.Collection) (time.Duration, error) {
-	if createdAt, err := getCollectionCreationTime(collection); err != nil {
-		return 0, err
-	} else {
-		return time.Since(createdAt), nil
-	}
-}
-
-func getCollectionCreationTime(collection *rtypes.Collection) (time.Time, error) {
-	if collection != nil && collection.CreatedAt != nil {
-		return iso8601.ParseString(*collection.CreatedAt)
-	} else {
-		return time.Time{}, fmt.Errorf("missing CreatedAt time in collection")
-	}
-}
-
-func isStatusReady(collection *rtypes.Collection) bool {
-	if collection != nil && collection.Status != nil {
-		return (*collection.Status) == STATUS_READY
-	} else {
-		return false
-	}
-}
-
-func nextIngestCompletionBackoff(timeSinceCreation time.Duration) time.Duration {
-	var baseSeconds = 30
-	// If we've been waiting _this_ long, we might as well slow down a little to
-	// avoid getting rate limited by the Rockset API in cases where there's a
-	// lot of shards with a lot of bindings all waiting.
-	if timeSinceCreation > time.Hour {
-		baseSeconds = 90
-	}
-	// Add a significant random jitter, so that requests for multiple bindings
-	// don't all get sent at the same time and run into rate limits.
-	baseSeconds += rand.Intn(30)
-	return time.Second * time.Duration(baseSeconds)
-}
-
-const STATUS_READY = "READY"


### PR DESCRIPTION
**Description:**

This removes the s3 integration option from the Rockset materialization. It was not functional in its current state, difficult to use, and likely to result in corrupt Rockset collections since Rockset's S3 integration does not guarantee ordering.

There was also some refactoring & simplification possible since the newer Rockset client we are now using provides a built-in method for waiting for a Rockset collection to be ready to accept writes, so that bit of code was removed from our connector.

I tested this locally with some test data sets and everything still worked like before.

Closes https://github.com/estuary/connectors/issues/506

**Workflow steps:**

Use the connector like before, but now you won't see the S3 integration configuration.

**Documentation links affected:**

Update Rockset docs to remove the remaining "initializeFromS3" configuration options. Most of the S3 integration stuff has already been removed from Rockset.

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/516)
<!-- Reviewable:end -->
