### PR TITLE
source-mysql: decompose range query to make it easier to optimize

### DIFF
--- a/sqlcapture/resultset.go
+++ b/sqlcapture/resultset.go
@@ -116,13 +116,13 @@ func (r *resultSet) Patch(streamID string, event *ChangeEvent) error {
 	// Ignore mutations occurring after the end of the current resultset, unless this
 	// is the final resultset which will complete the backfill.
 	if !chunk.complete && compareTuples(event.RowKey, chunk.scanned) > 0 {
-		if logrus.IsLevelEnabled(logrus.DebugLevel) {
+		if logrus.IsLevelEnabled(logrus.TraceLevel) {
 			logrus.WithFields(logrus.Fields{
 				"stream":   streamID,
 				"op":       event.Operation,
 				"rowKey":   base64.StdEncoding.EncodeToString(event.RowKey),
 				"chunkEnd": base64.StdEncoding.EncodeToString(chunk.scanned),
-			}).Debug("filtering change")
+			}).Trace("filtering change")
 		}
 		return nil
 	}


### PR DESCRIPTION
Instead of using "(key_one, key_two) > (123, 'bar')" constructions, use "key_one > 123 OR (key_one = 123 AND key_two > 'bar')". MySQL and MariaDB's optimizer is able to make better use of this form.

Also:

* Lower a spammy log to trace level.
* Attempt to use ANALYZE rather than EXPLAIN for the backfill query, as its output is more accurate.

**Description:**

(Describe the high level scope of new or changed features)

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/517)
<!-- Reviewable:end -->
