### PR TITLE
Rename all connector binaries in their Dockerfiles

### DIFF
--- a/materialize-bigquery/Dockerfile
+++ b/materialize-bigquery/Dockerfile
@@ -40,8 +40,8 @@ WORKDIR /connector
 ENV PATH="/connector:$PATH"
 
 # Bring in the compiled connector artifact from the builder.
-COPY --from=builder /builder/connector ./connector
+COPY --from=builder /builder/connector ./materialize-bigquery
 
 LABEL FLOW_RUNTIME_PROTOCOL=materialize
 
-ENTRYPOINT ["/connector/connector"]
+ENTRYPOINT ["/connector/materialize-bigquery"]

--- a/materialize-elasticsearch/Dockerfile
+++ b/materialize-elasticsearch/Dockerfile
@@ -33,7 +33,7 @@ WORKDIR /connector
 ENV PATH="/connector:$PATH"
 
 # Bring in the compiled connector artifact from the builder.
-COPY --from=builder /builder/connector /connector/
+COPY --from=builder /builder/connector /connector/materialize-elasticsearch
 COPY --from=builder /builder/flow-schemalate /connector/
 COPY --from=builder /lib/x86_64-linux-gnu/libgcc_s.so.1 /lib/x86_64-linux-gnu/
 
@@ -42,4 +42,4 @@ USER nonroot:nonroot
 
 LABEL FLOW_RUNTIME_PROTOCOL=materialize
 
-ENTRYPOINT ["/connector/connector"]
+ENTRYPOINT ["/connector/materialize-elasticsearch"]

--- a/materialize-firebolt/Dockerfile
+++ b/materialize-firebolt/Dockerfile
@@ -32,7 +32,7 @@ WORKDIR /connector
 ENV PATH="/connector:$PATH"
 
 # Bring in the compiled connector artifact from the builder.
-COPY --from=builder /builder/connector /connector/
+COPY --from=builder /builder/connector /connector/materialize-firebolt
 COPY --from=builder /builder/flow-schemalate /connector/
 COPY --from=builder /lib/x86_64-linux-gnu/libgcc_s.so.1 /lib/x86_64-linux-gnu/
 
@@ -41,4 +41,4 @@ USER nonroot:nonroot
 
 LABEL FLOW_RUNTIME_PROTOCOL=materialize
 
-ENTRYPOINT ["/connector/connector"]
+ENTRYPOINT ["/connector/materialize-firebolt"]

--- a/materialize-google-pubsub/Dockerfile
+++ b/materialize-google-pubsub/Dockerfile
@@ -29,11 +29,11 @@ WORKDIR /connector
 ENV PATH="/connector:$PATH"
 
 # Bring in the compiled connector artifact from the builder.
-COPY --from=builder /builder/connector /connector/
+COPY --from=builder /builder/connector /connector/materialize-google-pubsub
 
 # Avoid running the connector as root.
 USER nonroot:nonroot
 
 LABEL FLOW_RUNTIME_PROTOCOL=materialize
 
-ENTRYPOINT ["/connector/connector"]
+ENTRYPOINT ["/connector/materialize-google-pubsub"]

--- a/materialize-google-sheets/Dockerfile
+++ b/materialize-google-sheets/Dockerfile
@@ -33,11 +33,11 @@ WORKDIR /connector
 ENV PATH="/connector:$PATH"
 
 # Bring in the compiled connector artifact from the builder.
-COPY --from=builder /builder/connector ./connector
+COPY --from=builder /builder/connector ./materialize-google-sheets
 
 # Avoid running the connector as root.
 USER nonroot:nonroot
 
 LABEL FLOW_RUNTIME_PROTOCOL=materialize
 
-ENTRYPOINT ["/connector/connector"]
+ENTRYPOINT ["/connector/materialize-google-sheets"]

--- a/materialize-postgres/Dockerfile
+++ b/materialize-postgres/Dockerfile
@@ -33,7 +33,7 @@ FROM ${BASE_IMAGE}
 WORKDIR /connector
 ENV PATH="/connector:$PATH"
 
-COPY --from=builder /builder/connector ./connector
+COPY --from=builder /builder/connector ./materialize-postgres
 COPY --from=ghcr.io/estuary/network-tunnel:dev /flow-network-tunnel /usr/bin/flow-network-tunnel
 
 # Avoid running the connector as root.
@@ -41,4 +41,4 @@ USER nonroot:nonroot
 
 LABEL FLOW_RUNTIME_PROTOCOL=materialize
 
-ENTRYPOINT ["/connector/connector"]
+ENTRYPOINT ["/connector/materialize-postgres"]

--- a/materialize-rockset/Dockerfile
+++ b/materialize-rockset/Dockerfile
@@ -37,11 +37,11 @@ WORKDIR /connector
 ENV PATH="/connector:$PATH"
 
 # Bring in the compiled connector artifact from the builder.
-COPY --from=builder /builder/connector ./connector
+COPY --from=builder /builder/connector ./materialize-rockset
 
 # Avoid running the connector as root.
 USER nonroot:nonroot
 
 LABEL FLOW_RUNTIME_PROTOCOL=materialize
 
-ENTRYPOINT ["/connector/connector"]
+ENTRYPOINT ["/connector/materialize-rockset"]

--- a/materialize-s3-parquet/Dockerfile
+++ b/materialize-s3-parquet/Dockerfile
@@ -31,11 +31,11 @@ WORKDIR /connector
 ENV PATH="/connector:$PATH"
 
 # Bring in the compiled connector artifact from the builder.
-COPY --from=builder /builder/connector ./connector
+COPY --from=builder /builder/connector ./materialize-s3-parquet
 
 # Avoid running the connector as root.
 USER nonroot:nonroot
 
 LABEL FLOW_RUNTIME_PROTOCOL=materialize
 
-ENTRYPOINT ["/connector/connector"]
+ENTRYPOINT ["/connector/materialize-s3-parquet"]

--- a/materialize-snowflake/Dockerfile
+++ b/materialize-snowflake/Dockerfile
@@ -43,8 +43,8 @@ WORKDIR /connector
 ENV PATH="/connector:$PATH"
 
 # Bring in the compiled connector artifact from the builder.
-COPY --from=builder /builder/connector ./connector
+COPY --from=builder /builder/connector ./materialize-snowflake
 
 LABEL FLOW_RUNTIME_PROTOCOL=materialize
 
-ENTRYPOINT ["/connector/connector"]
+ENTRYPOINT ["/connector/materialize-snowflake"]

--- a/materialize-webhook/Dockerfile
+++ b/materialize-webhook/Dockerfile
@@ -31,11 +31,11 @@ WORKDIR /connector
 ENV PATH="/connector:$PATH"
 
 # Bring in the compiled connector artifact from the builder.
-COPY --from=builder /builder/connector ./connector
+COPY --from=builder /builder/connector ./materialize-webhook
 
 # Avoid running the connector as root.
 USER nonroot:nonroot
 
 LABEL FLOW_RUNTIME_PROTOCOL=materialize
 
-ENTRYPOINT ["/connector/connector"]
+ENTRYPOINT ["/connector/materialize-webhook"]

--- a/source-alpaca/Dockerfile
+++ b/source-alpaca/Dockerfile
@@ -30,7 +30,7 @@ WORKDIR /connector
 ENV PATH="/connector:$PATH"
 
 # Bring in the compiled connector artifact from the builder.
-COPY --from=builder /builder/connector ./connector
+COPY --from=builder /builder/connector ./source-alpaca
 
 LABEL FLOW_RUNTIME_PROTOCOL=capture
 LABEL CONNECTOR_PROTOCOL=flow-capture
@@ -38,4 +38,4 @@ LABEL CONNECTOR_PROTOCOL=flow-capture
 # Avoid running the connector as root.
 USER nonroot:nonroot
 
-ENTRYPOINT ["/connector/connector"]
+ENTRYPOINT ["/connector/source-alpaca"]

--- a/source-firestore/Dockerfile
+++ b/source-firestore/Dockerfile
@@ -36,7 +36,7 @@ COPY flow-bin/flow-parser ./
 COPY flow-bin/flow-schema-inference ./
 
 # Bring in the compiled connector artifact from the builder.
-COPY --from=builder /builder/connector ./connector
+COPY --from=builder /builder/connector ./source-firestore
 
 LABEL FLOW_RUNTIME_PROTOCOL=capture
 LABEL CONNECTOR_PROTOCOL=flow-capture
@@ -44,4 +44,4 @@ LABEL CONNECTOR_PROTOCOL=flow-capture
 # Avoid running the connector as root.
 USER nonroot:nonroot
 
-ENTRYPOINT ["/connector/connector"]
+ENTRYPOINT ["/connector/source-firestore"]

--- a/source-gcs/Dockerfile
+++ b/source-gcs/Dockerfile
@@ -33,13 +33,13 @@ ENV PATH="/connector:$PATH"
 COPY flow-bin/flow-parser ./
 
 # Bring in the compiled connector artifact from the builder.
-COPY --from=builder /builder/connector ./connector
+COPY --from=builder /builder/connector ./source-gcs
 
 # Avoid running the connector as root.
 USER nonroot:nonroot
 
 COPY --from=ghcr.io/estuary/airbyte-to-flow:dev /airbyte-to-flow ./
-ENTRYPOINT ["/connector/airbyte-to-flow", "--connector-entrypoint", "/connector/connector"]
+ENTRYPOINT ["/connector/airbyte-to-flow", "--connector-entrypoint", "/connector/source-gcs"]
 
 LABEL FLOW_RUNTIME_PROTOCOL=capture
 LABEL CONNECTOR_PROTOCOL=flow-capture

--- a/source-hello-world/Dockerfile
+++ b/source-hello-world/Dockerfile
@@ -31,13 +31,13 @@ ENV PATH="/connector:$PATH"
 COPY --from=busybox:latest /bin/sh /bin/sh
 
 # Bring in the compiled connector artifact from the builder.
-COPY --from=builder /builder/connector ./connector
+COPY --from=builder /builder/connector ./source-hello-world
 
 # Avoid running the connector as root.
 USER nonroot:nonroot
 
 COPY --from=ghcr.io/estuary/airbyte-to-flow:dev /airbyte-to-flow ./
-ENTRYPOINT ["/connector/airbyte-to-flow", "--connector-entrypoint", "/connector/connector"]
+ENTRYPOINT ["/connector/airbyte-to-flow", "--connector-entrypoint", "/connector/source-hello-world"]
 
 LABEL FLOW_RUNTIME_PROTOCOL=capture
 LABEL CONNECTOR_PROTOCOL=flow-capture

--- a/source-http-file/Dockerfile
+++ b/source-http-file/Dockerfile
@@ -36,13 +36,13 @@ COPY flow-bin/flow-parser ./
 COPY flow-bin/flow-schema-inference ./
 
 # Bring in the compiled connector artifact from the builder.
-COPY --from=builder /builder/connector ./connector
+COPY --from=builder /builder/connector ./source-http-file
 
 # Avoid running the connector as root.
 USER nonroot:nonroot
 
 COPY --from=ghcr.io/estuary/airbyte-to-flow:dev /airbyte-to-flow ./
-ENTRYPOINT ["/connector/airbyte-to-flow", "--connector-entrypoint", "/connector/connector"]
+ENTRYPOINT ["/connector/airbyte-to-flow", "--connector-entrypoint", "/connector/source-http-file"]
 
 LABEL FLOW_RUNTIME_PROTOCOL=capture
 LABEL CONNECTOR_PROTOCOL=flow-capture

--- a/source-kafka/Dockerfile
+++ b/source-kafka/Dockerfile
@@ -48,13 +48,13 @@ COPY --from=builder /usr/lib/x86_64-linux-gnu/sasl2/libsasldb.so* /usr/lib/x86_6
 COPY --from=builder /usr/lib/x86_64-linux-gnu/libsasl2.so.2* /usr/lib/x86_64-linux-gnu/
 
 # Copy in the connector artifact.
-COPY --from=builder /usr/local/cargo/bin/source-kafka ./connector
+COPY --from=builder /usr/local/cargo/bin/source-kafka ./source-kafka
 
 # Avoid running the connector as root.
 USER nonroot:nonroot
 
 COPY --from=ghcr.io/estuary/airbyte-to-flow:dev /airbyte-to-flow ./
-ENTRYPOINT ["/connector/airbyte-to-flow", "--connector-entrypoint", "/connector/connector"]
+ENTRYPOINT ["/connector/airbyte-to-flow", "--connector-entrypoint", "/connector/source-kafka"]
 
 LABEL FLOW_RUNTIME_PROTOCOL=capture
 LABEL CONNECTOR_PROTOCOL=flow-capture

--- a/source-kinesis/Dockerfile
+++ b/source-kinesis/Dockerfile
@@ -35,13 +35,13 @@ COPY flow-bin/flow-schema-inference ./
 COPY --from=busybox:latest /bin/sh /bin/sh
 
 # Bring in the compiled connector artifact from the builder.
-COPY --from=builder /builder/connector ./connector
+COPY --from=builder /builder/connector ./source-kinesis
 
 # Avoid running the connector as root.
 USER nonroot:nonroot
 
 COPY --from=ghcr.io/estuary/airbyte-to-flow:dev /airbyte-to-flow ./
-ENTRYPOINT ["/connector/airbyte-to-flow", "--connector-entrypoint", "/connector/connector"]
+ENTRYPOINT ["/connector/airbyte-to-flow", "--connector-entrypoint", "/connector/source-kinesis"]
 
 LABEL FLOW_RUNTIME_PROTOCOL=capture
 LABEL CONNECTOR_PROTOCOL=flow-capture

--- a/source-mysql/Dockerfile
+++ b/source-mysql/Dockerfile
@@ -42,12 +42,12 @@ COPY --from=busybox:latest /bin/sh /bin/sh
 
 # Bring in the compiled connector artifact from the builder.
 COPY --from=ghcr.io/estuary/network-tunnel:dev /flow-network-tunnel /usr/bin/flow-network-tunnel
-COPY --from=builder /builder/connector ./connector
+COPY --from=builder /builder/connector ./source-mysql
 
 # Avoid running the connector as root.
 USER nonroot:nonroot
 
-ENTRYPOINT ["/connector/connector"]
+ENTRYPOINT ["/connector/source-mysql"]
 
 LABEL FLOW_RUNTIME_PROTOCOL=capture
 LABEL CONNECTOR_PROTOCOL=flow-capture

--- a/source-nativehello/Dockerfile
+++ b/source-nativehello/Dockerfile
@@ -31,7 +31,7 @@ ENV PATH="/connector:$PATH"
 COPY --from=busybox:latest /bin/sh /bin/sh
 
 # Bring in the compiled connector artifact from the builder.
-COPY --from=builder /builder/connector ./connector
+COPY --from=builder /builder/connector ./source-nativehello
 
 LABEL FLOW_RUNTIME_PROTOCOL=capture
 LABEL CONNECTOR_PROTOCOL=flow-capture
@@ -39,4 +39,4 @@ LABEL CONNECTOR_PROTOCOL=flow-capture
 # Avoid running the connector as root.
 USER nonroot:nonroot
 
-ENTRYPOINT ["/connector/connector"]
+ENTRYPOINT ["/connector/source-nativehello"]

--- a/source-postgres/Dockerfile
+++ b/source-postgres/Dockerfile
@@ -43,14 +43,14 @@ ENV PATH="/connector:$PATH"
 COPY --from=busybox:latest /bin/sh /bin/sh
 
 # Bring in the compiled connector artifacts from the builder.
-COPY --from=builder /builder/connector ./
+COPY --from=builder /builder/connector ./source-postgres
 COPY --from=builder /lib/x86_64-linux-gnu/libgcc_s.so.1 /lib/x86_64-linux-gnu/
 COPY --from=ghcr.io/estuary/network-tunnel:dev /flow-network-tunnel /usr/bin/flow-network-tunnel
 
 # Avoid running the connector as root.
 USER nonroot:nonroot
 
-ENTRYPOINT ["/connector/connector"]
+ENTRYPOINT ["/connector/source-postgres"]
 
 LABEL FLOW_RUNTIME_PROTOCOL=capture
 LABEL CONNECTOR_PROTOCOL=flow-capture

--- a/source-s3/Dockerfile
+++ b/source-s3/Dockerfile
@@ -36,13 +36,13 @@ COPY --from=busybox:latest /bin/sh /bin/sh
 COPY flow-bin/flow-parser ./
 
 # Bring in the compiled connector artifact from the builder.
-COPY --from=builder /builder/connector ./connector
+COPY --from=builder /builder/connector ./source-s3
 
 # Avoid running the connector as root.
 USER nonroot:nonroot
 
 COPY --from=ghcr.io/estuary/airbyte-to-flow:dev /airbyte-to-flow ./
-ENTRYPOINT ["/connector/airbyte-to-flow", "--connector-entrypoint", "/connector/connector"]
+ENTRYPOINT ["/connector/airbyte-to-flow", "--connector-entrypoint", "/connector/source-s3"]
 
 LABEL FLOW_RUNTIME_PROTOCOL=capture
 LABEL CONNECTOR_PROTOCOL=flow-capture

--- a/source-test/Dockerfile
+++ b/source-test/Dockerfile
@@ -31,13 +31,13 @@ ENV PATH="/connector:$PATH"
 COPY --from=busybox:latest /bin/sh /bin/sh
 
 # Bring in the compiled connector artifact from the builder.
-COPY --from=builder /builder/connector ./connector
+COPY --from=builder /builder/connector ./source-test
 
 # Avoid running the connector as root.
 USER nonroot:nonroot
 
 COPY --from=ghcr.io/estuary/airbyte-to-flow:dev /airbyte-to-flow ./
-ENTRYPOINT ["/connector/airbyte-to-flow", "--connector-entrypoint", "/connector/connector"]
+ENTRYPOINT ["/connector/airbyte-to-flow", "--connector-entrypoint", "/connector/source-test"]
 
 LABEL FLOW_RUNTIME_PROTOCOL=capture
 LABEL CONNECTOR_PROTOCOL=flow-capture


### PR DESCRIPTION
**Description:**

All we get from our current OOM-kill monitoring is the name of the process that got killed, so having them all be named "connector" is *rather unhelpful*. This should make OOM-kill events marginally easier to track down.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/519)
<!-- Reviewable:end -->
