### PR TITLE
materialize-sql: allow updating fields to make them nullable

### DIFF
--- a/materialize-bigquery/.snapshots/TestSQLGeneration
+++ b/materialize-bigquery/.snapshots/TestSQLGeneration
@@ -3,17 +3,17 @@ flow_temp_table_0--- End projectID.dataset.target_table tempTableName ---
 
 --- Begin projectID.dataset.target_table createTargetTable ---
 CREATE TABLE IF NOT EXISTS projectID.dataset.target_table (
-		key1 INT64,
-		key2 BOOL,
-		boolean BOOL,
-		integer INT64,
-		string STRING,
+		key1 INT64 NOT NULL,
+		key2 BOOL NOT NULL,
+		boolean BOOL NOT NULL,
+		integer INT64 NOT NULL,
+		string STRING NOT NULL,
 		`defAULT` STRING,
 		number BIGNUMERIC,
 		person_place_ STRING,
 		source_name STRING,
 		`with-dash` STRING,
-		flow_document STRING
+		flow_document STRING NOT NULL
 )
 CLUSTER BY key1, key2, boolean, integer;
 --- End projectID.dataset.target_table createTargetTable ---

--- a/materialize-bigquery/bigquery.go
+++ b/materialize-bigquery/bigquery.go
@@ -162,14 +162,15 @@ func newBigQueryDriver() pm.DriverServer {
 			}
 
 			return &sql.Endpoint{
-				Config:              cfg,
-				Dialect:             bqDialect,
-				MetaSpecs:           metaSpecs,
-				MetaCheckpoints:     &metaCheckpoints,
-				Client:              client,
-				CreateTableTemplate: tplCreateTargetTable,
-				NewResource:         newTableConfig,
-				NewTransactor:       newTransactor,
+				Config:                      cfg,
+				Dialect:                     bqDialect,
+				MetaSpecs:                   metaSpecs,
+				MetaCheckpoints:             &metaCheckpoints,
+				Client:                      client,
+				CreateTableTemplate:         tplCreateTargetTable,
+				AlterColumnNullableTemplate: tplAlterColumnNullable,
+				NewResource:                 newTableConfig,
+				NewTransactor:               newTransactor,
 			}, nil
 		},
 	}

--- a/materialize-bigquery/sqlgen.go
+++ b/materialize-bigquery/sqlgen.go
@@ -121,6 +121,12 @@ CLUSTER BY {{ range $ind, $key := $.Keys }}
 	{{- end}};
 {{ end }}
 
+-- Alter column and mark it as nullable
+
+{{ define "alterColumnNullable" }}
+ALTER TABLE {{ $.Table.Identifier }} ALTER COLUMN {{ $.Identifier }} DROP NOT NULL;
+{{ end }}
+
 -- Templated query which joins keys from the load table with the target table,
 -- and returns values. It deliberately skips the trailing semi-colon
 -- as these queries are composed with a UNION ALL.
@@ -260,11 +266,12 @@ UPDATE {{ Identifier $.TablePath }}
 	AND fence={{ $.Fence }};
 {{ end }}
 `)
-	tplTempTableName     = tplAll.Lookup("tempTableName")
-	tplCreateTargetTable = tplAll.Lookup("createTargetTable")
-	tplInstallFence      = tplAll.Lookup("installFence")
-	tplUpdateFence       = tplAll.Lookup("updateFence")
-	tplLoadQuery         = tplAll.Lookup("loadQuery")
-	tplStoreInsert       = tplAll.Lookup("storeInsert")
-	tplStoreUpdate       = tplAll.Lookup("storeUpdate")
+	tplTempTableName       = tplAll.Lookup("tempTableName")
+	tplCreateTargetTable   = tplAll.Lookup("createTargetTable")
+	tplInstallFence        = tplAll.Lookup("installFence")
+	tplUpdateFence         = tplAll.Lookup("updateFence")
+	tplLoadQuery           = tplAll.Lookup("loadQuery")
+	tplStoreInsert         = tplAll.Lookup("storeInsert")
+	tplStoreUpdate         = tplAll.Lookup("storeUpdate")
+	tplAlterColumnNullable = tplAll.Lookup("alterColumnNullable")
 )

--- a/materialize-postgres/.snapshots/TestSQLGeneration
+++ b/materialize-postgres/.snapshots/TestSQLGeneration
@@ -1,15 +1,15 @@
 --- Begin "a-schema".target_table createTargetTable ---
 
 CREATE TABLE IF NOT EXISTS "a-schema".target_table (
-		key1 BIGINT,
-		"key!2" BOOLEAN,
+		key1 BIGINT NOT NULL,
+		"key!2" BOOLEAN NOT NULL,
 		"nullableKey" TEXT,
 		"Camel_Case" BIGINT,
 		"a Time" TIMESTAMPTZ,
 		"array" JSON,
 		lower_case BIGINT,
 		"value" TEXT,
-		flow_document JSON,
+		flow_document JSON NOT NULL,
 
 		PRIMARY KEY (key1, "key!2", "nullableKey")
 );
@@ -32,7 +32,7 @@ COMMENT ON COLUMN "a-schema".target_table.flow_document IS 'user-provided projec
 --- Begin "Delta Updates" createTargetTable ---
 
 CREATE TABLE IF NOT EXISTS "Delta Updates" (
-		"theKey" TEXT,
+		"theKey" TEXT NOT NULL,
 		"nullableKey" TEXT,
 		"aValue" BIGINT
 );
@@ -47,8 +47,8 @@ auto-generated projection of JSON at: /aValue with inferred types: [integer]';
 --- Begin "a-schema".target_table createLoadTable ---
 
 CREATE TEMPORARY TABLE flow_temp_table_0 (
-		key1 BIGINT,
-		"key!2" BOOLEAN,
+		key1 BIGINT NOT NULL,
+		"key!2" BOOLEAN NOT NULL,
 		"nullableKey" TEXT
 ) ON COMMIT DROP;
 --- End "a-schema".target_table createLoadTable ---
@@ -56,7 +56,7 @@ CREATE TEMPORARY TABLE flow_temp_table_0 (
 --- Begin "Delta Updates" createLoadTable ---
 
 CREATE TEMPORARY TABLE flow_temp_table_1 (
-		"theKey" TEXT,
+		"theKey" TEXT NOT NULL,
 		"nullableKey" TEXT
 ) ON COMMIT DROP;
 --- End "Delta Updates" createLoadTable ---

--- a/materialize-postgres/driver.go
+++ b/materialize-postgres/driver.go
@@ -165,14 +165,15 @@ func newPostgresDriver() pm.DriverServer {
 			}
 
 			return &sql.Endpoint{
-				Config:              cfg,
-				Dialect:             pgDialect,
-				MetaSpecs:           metaSpecs,
-				MetaCheckpoints:     &metaCheckpoints,
-				Client:              client{uri: cfg.ToURI()},
-				CreateTableTemplate: tplCreateTargetTable,
-				NewResource:         newTableConfig,
-				NewTransactor:       newTransactor,
+				Config:                      cfg,
+				Dialect:                     pgDialect,
+				MetaSpecs:                   metaSpecs,
+				MetaCheckpoints:             &metaCheckpoints,
+				Client:                      client{uri: cfg.ToURI()},
+				CreateTableTemplate:         tplCreateTargetTable,
+				AlterColumnNullableTemplate: tplAlterColumnNullable,
+				NewResource:                 newTableConfig,
+				NewTransactor:               newTransactor,
 			}, nil
 		},
 	}

--- a/materialize-postgres/sqlgen.go
+++ b/materialize-postgres/sqlgen.go
@@ -82,6 +82,12 @@ COMMENT ON COLUMN {{$.Identifier}}.{{$col.Identifier}} IS {{Literal $col.Comment
 {{- end}}
 {{ end }}
 
+-- Alter column and mark it as nullable
+
+{{ define "alterColumnNullable" }}
+ALTER TABLE {{ $.Table.Identifier }} ALTER COLUMN {{ $.Identifier }} DROP NOT NULL;
+{{ end }}
+
 -- Templated creation of a temporary load table:
 
 {{ define "createLoadTable" }}
@@ -243,15 +249,16 @@ BEGIN
 END $$;
 {{ end }}
 `)
-	tplCreateLoadTable   = tplAll.Lookup("createLoadTable")
-	tplCreateTargetTable = tplAll.Lookup("createTargetTable")
-	tplExecLoadInsert    = tplAll.Lookup("execLoadInsert")
-	tplExecStoreInsert   = tplAll.Lookup("execStoreInsert")
-	tplExecStoreUpdate   = tplAll.Lookup("execStoreUpdate")
-	tplLoadQuery         = tplAll.Lookup("loadQuery")
-	tplPrepLoadInsert    = tplAll.Lookup("prepLoadInsert")
-	tplPrepStoreInsert   = tplAll.Lookup("prepStoreInsert")
-	tplPrepStoreUpdate   = tplAll.Lookup("prepStoreUpdate")
-	tplInstallFence      = tplAll.Lookup("installFence")
-	tplUpdateFence       = tplAll.Lookup("updateFence")
+	tplCreateLoadTable     = tplAll.Lookup("createLoadTable")
+	tplCreateTargetTable   = tplAll.Lookup("createTargetTable")
+	tplExecLoadInsert      = tplAll.Lookup("execLoadInsert")
+	tplExecStoreInsert     = tplAll.Lookup("execStoreInsert")
+	tplExecStoreUpdate     = tplAll.Lookup("execStoreUpdate")
+	tplLoadQuery           = tplAll.Lookup("loadQuery")
+	tplPrepLoadInsert      = tplAll.Lookup("prepLoadInsert")
+	tplPrepStoreInsert     = tplAll.Lookup("prepStoreInsert")
+	tplPrepStoreUpdate     = tplAll.Lookup("prepStoreUpdate")
+	tplInstallFence        = tplAll.Lookup("installFence")
+	tplUpdateFence         = tplAll.Lookup("updateFence")
+	tplAlterColumnNullable = tplAll.Lookup("alterColumnNullable")
 )

--- a/materialize-postgres/sqlgen_test.go
+++ b/materialize-postgres/sqlgen_test.go
@@ -99,7 +99,7 @@ func TestDateTimeColumn(t *testing.T) {
 		},
 	})
 	require.NoError(t, err)
-	require.Equal(t, "TIMESTAMPTZ", mapped.DDL)
+	require.Equal(t, "TIMESTAMPTZ NOT NULL", mapped.DDL)
 
 	parsed, err := mapped.Converter("2022-04-04T10:09:08.234567Z")
 	require.Equal(t, "2022-04-04T10:09:08.234567Z", parsed)

--- a/materialize-snowflake/snowflake.go
+++ b/materialize-snowflake/snowflake.go
@@ -156,14 +156,15 @@ func newSnowflakeDriver() *sql.Driver {
 			var metaSpecs, metaCheckpoints = sql.MetaTables(metaBase)
 
 			return &sql.Endpoint{
-				Config:              parsed,
-				Dialect:             snowflakeDialect,
-				MetaSpecs:           metaSpecs,
-				MetaCheckpoints:     &metaCheckpoints,
-				Client:              client{uri: dsn},
-				CreateTableTemplate: tplCreateTargetTable,
-				NewResource:         newTableConfig,
-				NewTransactor:       newTransactor,
+				Config:                      parsed,
+				Dialect:                     snowflakeDialect,
+				MetaSpecs:                   metaSpecs,
+				MetaCheckpoints:             &metaCheckpoints,
+				Client:                      client{uri: dsn},
+				CreateTableTemplate:         tplCreateTargetTable,
+				AlterColumnNullableTemplate: tplAlterColumnNullable,
+				NewResource:                 newTableConfig,
+				NewTransactor:               newTransactor,
 			}, nil
 		},
 	}

--- a/materialize-snowflake/sqlgen.go
+++ b/materialize-snowflake/sqlgen.go
@@ -102,6 +102,12 @@ var (
   {{- end}}
   {{ end }}
 
+-- Alter column and mark it as nullable
+
+{{ define "alterColumnNullable" }}
+ALTER TABLE {{ $.Table.Identifier }} ALTER COLUMN {{ $.Identifier }} DROP NOT NULL;
+{{ end }}
+
 {{ define "loadQuery" }}
 	SELECT {{ $.Table.Binding }}, {{ $.Table.Identifier }}.{{ $.Table.Document.Identifier }}
 	FROM {{ $.Table.Identifier }}
@@ -190,11 +196,12 @@ BEGIN
 END $$;
 {{ end }}
   `)
-	tplCreateTargetTable = tplAll.Lookup("createTargetTable")
-	tplLoadQuery         = tplAll.Lookup("loadQuery")
-	tplCopyInto          = tplAll.Lookup("copyInto")
-	tplMergeInto         = tplAll.Lookup("mergeInto")
-	tplUpdateFence       = tplAll.Lookup("updateFence")
+	tplCreateTargetTable   = tplAll.Lookup("createTargetTable")
+	tplLoadQuery           = tplAll.Lookup("loadQuery")
+	tplCopyInto            = tplAll.Lookup("copyInto")
+	tplMergeInto           = tplAll.Lookup("mergeInto")
+	tplUpdateFence         = tplAll.Lookup("updateFence")
+	tplAlterColumnNullable = tplAll.Lookup("alterColumnNullable")
 )
 
 var createStageSQL = `

--- a/materialize-sql/.snapshots/TestAlterColumnNullableTemplate
+++ b/materialize-sql/.snapshots/TestAlterColumnNullableTemplate
@@ -1,0 +1,3 @@
+
+  ALTER TABLE one."reserved".checkpoints ALTER COLUMN id DROP NOT NULL;
+  

--- a/materialize-sql/driver.go
+++ b/materialize-sql/driver.go
@@ -150,8 +150,12 @@ func (d *Driver) ApplyUpsert(ctx context.Context, req *pm.ApplyRequest) (*pm.App
 			// are marked as such
 			for _, field := range bindingSpec.FieldSelection.Values {
 				var p = bindingSpec.Collection.GetProjection(field)
+				var previousProjection = loadedBinding.Collection.GetProjection(field)
 
-				if p.Inference.Exists != pf.Inference_MUST {
+				var previousNullable = previousProjection.Inference.Exists != pf.Inference_MUST || SliceContains("null", p.Inference.Types)
+				var newNullable = p.Inference.Exists != pf.Inference_MUST || SliceContains("null", p.Inference.Types)
+
+				if !previousNullable && newNullable {
 					var table, err = ResolveTable(tableShape, endpoint.Dialect)
 					if err != nil {
 						return nil, err

--- a/materialize-sql/endpoint.go
+++ b/materialize-sql/endpoint.go
@@ -72,6 +72,8 @@ type Endpoint struct {
 	Client Client
 	// CreateTableTemplate evaluates a Table into an endpoint statement which creates it.
 	CreateTableTemplate *template.Template
+	// AlterFieldNullable alters a column and marks it as nullable
+	AlterColumnNullableTemplate *template.Template
 
 	// NewResource returns an uninitialized or partially-initialized Resource
 	// which will be parsed into and validated from a resource configuration.

--- a/materialize-sql/templating.go
+++ b/materialize-sql/templating.go
@@ -30,3 +30,16 @@ func RenderTableTemplate(table Table, tpl *template.Template) (string, error) {
 	}
 	return w.String(), nil
 }
+
+type AlterColumnNullableInput struct {
+	Table Table
+	Identifier string
+}
+
+func RenderAlterColumnNullableTemplate(input AlterColumnNullableInput, tpl *template.Template) (string, error) {
+	var w strings.Builder
+	if err := tpl.Execute(&w, &input); err != nil {
+		return "", err
+	}
+	return w.String(), nil
+}

--- a/materialize-sql/templating_test.go
+++ b/materialize-sql/templating_test.go
@@ -80,3 +80,20 @@ func TestTableTemplate(t *testing.T) {
 	require.NoError(t, err)
 	cupaloy.SnapshotT(t, out)
 }
+
+func TestAlterColumnNullableTemplate(t *testing.T) {
+	var (
+		shape      = FlowCheckpointsTable("one", "reserved", "checkpoints")
+		dialect    = newTestDialect()
+		table, err = ResolveTable(shape, dialect)
+	)
+	assert.NoError(t, err)
+
+	var tpl = MustParseTemplate(dialect, "template", `
+  ALTER TABLE {{ $.Table.Identifier }} ALTER COLUMN {{ $.Identifier }} DROP NOT NULL;
+  `)
+
+  out, err := RenderAlterColumnNullableTemplate(AlterColumnNullableInput { Table: table, Identifier: "id" }, tpl)
+	require.NoError(t, err)
+	cupaloy.SnapshotT(t, out)
+}

--- a/materialize-sql/type_mapping.go
+++ b/materialize-sql/type_mapping.go
@@ -184,16 +184,9 @@ var _ TypeMapper = NullableMapper{}
 func (m NullableMapper) MapType(p *Projection) (mapped MappedType, err error) {
 	if mapped, err = m.Delegate.MapType(p); err != nil {
 		return
-	}
-	// We are temporarily creating all non-pk columns as nullable, this is to allow
-	// fields to be made nullable from a collection without causing issues. Once we
-	// support automatic schema migration of tables to mark fields as nullable
-	// after creation, we can revert back to the more strict behaviour,
-	// see: https://github.com/estuary/connectors/issues/447
-	// note that for primary keys we are leaving it up to the engine to decide
-	// whether they can be nullable or not (e.g. postgres will assume not
-	// null for primary keys)
-	if !p.IsPrimaryKey && m.NullableText != "" {
+	} else if _, notNull := p.AsFlatType(); notNull && m.NotNullText != "" {
+		mapped.DDL += " " + m.NotNullText
+	} else if m.NullableText != "" {
 		mapped.DDL += " " + m.NullableText
 	}
 

--- a/materialize-sql/validate.go
+++ b/materialize-sql/validate.go
@@ -134,21 +134,11 @@ func checkTypeError(field string, existing *pf.CollectionSpec, proposed *pf.Coll
 	// The new projection is allowed to contain fewer types than the original, though, since that
 	// will always work with the original database schema.
 	for _, pt := range proposedProjection.Inference.Types {
-		if !SliceContains(pt, existingProjection.Inference.Types) {
+		if !SliceContains(pt, existingProjection.Inference.Types) && pt != "null" {
 			return fmt.Sprintf("The proposed projection may contain the type '%s', which is not part of the original projection", pt)
 		}
 	}
 
-	// If the existing projection must exist, then so must the proposed. This is because this field
-	// is used to determine whether a column may contain nulls. So if the existing column cannot
-	// contain null, then we can't allow the new projection to possible be null. But if the existing
-	// column is nullable, then it won't matter if the new one is or not since the column will be
-	// unconstrained.
-	if existingProjection.Inference.Exists == pf.Inference_MUST &&
-		!SliceContains("null", existingProjection.Inference.Types) &&
-		proposedProjection.Inference.Exists != pf.Inference_MUST {
-		return "The existing projection must exist and be non-null, so the new projection must also exist"
-	}
 	return ""
 }
 


### PR DESCRIPTION
**Description:**

- Allow updating a collection to make a field nullable in `materialize-sql` connectors

**Workflow steps:**

- Create a materialization with non-nullable fields
- Update those fields to make them nullable
- The connector should update your destination database to mark those columns as nullable

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/522)
<!-- Reviewable:end -->
