### PR TITLE
source-postgres: Fix handling of capitalized table names

### DIFF
--- a/source-boilerplate/testing/testing.go
+++ b/source-boilerplate/testing/testing.go
@@ -271,7 +271,7 @@ func (a *pullAdapter) Send(m *pc.PullResponse) error {
 		for _, documents := range a.transaction {
 			var binding string
 			if idx := documents.Binding; 0 <= idx && int(idx) < len(a.bindings) {
-				binding = strings.Join(a.bindings[idx].ResourcePath, "|")
+				binding = strings.Join(a.bindings[idx].ResourcePath, ".")
 			} else {
 				binding = fmt.Sprintf("Invalid Binding %d", idx)
 			}

--- a/source-boilerplate/testing/testing.go
+++ b/source-boilerplate/testing/testing.go
@@ -53,7 +53,18 @@ func (cs *CaptureSpec) Validate(ctx context.Context, t testing.TB) ([]*pc.Valida
 	endpointSpecJSON, err := json.Marshal(cs.EndpointSpec)
 	require.NoError(t, err)
 
-	validation, err := cs.Driver.Validate(ctx, &pc.ValidateRequest{EndpointSpecJson: endpointSpecJSON})
+	var bindings []*pc.ValidateRequest_Binding
+	for _, b := range cs.Bindings {
+		bindings = append(bindings, &pc.ValidateRequest_Binding{
+			ResourceSpecJson: b.ResourceSpecJson,
+			Collection:       b.Collection,
+		})
+	}
+
+	validation, err := cs.Driver.Validate(ctx, &pc.ValidateRequest{
+		EndpointSpecJson: endpointSpecJSON,
+		Bindings:         bindings,
+	})
 	if err != nil {
 		return nil, err
 	}

--- a/source-postgres/.snapshots/TestCapitalizedTables-Capture
+++ b/source-postgres/.snapshots/TestCapitalizedTables-Capture
@@ -1,0 +1,10 @@
+# ================================
+# Collection "test|USERS": 2 Documents
+# ================================
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"USERS","loc":[11111111,11111111,11111111]}},"data":"Alice","id":1}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"USERS","loc":[11111111,11111111,11111111]}},"data":"Bob","id":2}
+# ================================
+# Final State Checkpoint
+# ================================
+{"cursor":"0/1111111","streams":{"test.users":{"key_columns":["id"],"mode":"Active"}}}
+

--- a/source-postgres/.snapshots/TestCapitalizedTables-Capture
+++ b/source-postgres/.snapshots/TestCapitalizedTables-Capture
@@ -1,5 +1,5 @@
 # ================================
-# Collection "test|USERS": 2 Documents
+# Collection "test.USERS": 2 Documents
 # ================================
 {"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"USERS","loc":[11111111,11111111,11111111]}},"data":"Alice","id":1}
 {"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"USERS","loc":[11111111,11111111,11111111]}},"data":"Bob","id":2}

--- a/source-postgres/.snapshots/TestCapitalizedTables-Capture-Replication
+++ b/source-postgres/.snapshots/TestCapitalizedTables-Capture-Replication
@@ -1,5 +1,5 @@
 # ================================
-# Collection "test|USERS": 2 Documents
+# Collection "test.USERS": 2 Documents
 # ================================
 {"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"USERS","loc":[11111111,11111111,11111111]}},"data":"Carol","id":3}
 {"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"USERS","loc":[11111111,11111111,11111111]}},"data":"Dave","id":4}

--- a/source-postgres/.snapshots/TestCapitalizedTables-Capture-Replication
+++ b/source-postgres/.snapshots/TestCapitalizedTables-Capture-Replication
@@ -1,0 +1,10 @@
+# ================================
+# Collection "test|USERS": 2 Documents
+# ================================
+{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"USERS","loc":[11111111,11111111,11111111]}},"data":"Carol","id":3}
+{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"USERS","loc":[11111111,11111111,11111111]}},"data":"Dave","id":4}
+# ================================
+# Final State Checkpoint
+# ================================
+{"cursor":"0/1111111","streams":{"test.users":{"key_columns":["id"],"mode":"Active"}}}
+

--- a/source-postgres/.snapshots/TestCapitalizedTables-Discover
+++ b/source-postgres/.snapshots/TestCapitalizedTables-Discover
@@ -1,0 +1,112 @@
+Binding 0:
+{
+    "recommended_name": "users",
+    "resource_spec_json": {
+      "namespace": "test",
+      "stream": "USERS",
+      "primary_key": [
+        "id"
+      ]
+    },
+    "document_schema_json": {
+      "$defs": {
+        "TestUSERS": {
+          "type": "object",
+          "required": [
+            "id"
+          ],
+          "$anchor": "TestUSERS",
+          "properties": {
+            "data": {
+              "type": "string"
+            },
+            "id": {
+              "type": "integer"
+            }
+          }
+        }
+      },
+      "allOf": [
+        {
+          "required": [
+            "_meta"
+          ],
+          "properties": {
+            "_meta": {
+              "type": "object",
+              "required": [
+                "op",
+                "source"
+              ],
+              "properties": {
+                "before": {
+                  "$ref": "#TestUSERS",
+                  "description": "Record state immediately before this change was applied.",
+                  "reduce": {
+                    "strategy": "firstWriteWins"
+                  }
+                },
+                "op": {
+                  "enum": [
+                    "c",
+                    "d",
+                    "u"
+                  ],
+                  "description": "Change operation type: 'c' Create/Insert, 'u' Update, 'd' Delete."
+                },
+                "source": {
+                  "$id": "https://github.com/estuary/connectors/source-postgres/postgres-source",
+                  "properties": {
+                    "ts_ms": {
+                      "type": "integer",
+                      "description": "Unix timestamp (in millis) at which this event was recorded by the database."
+                    },
+                    "schema": {
+                      "type": "string",
+                      "description": "Database schema (namespace) of the event."
+                    },
+                    "snapshot": {
+                      "type": "boolean",
+                      "description": "Snapshot is true if the record was produced from an initial table backfill and unset if produced from the replication log."
+                    },
+                    "table": {
+                      "type": "string",
+                      "description": "Database table of the event."
+                    },
+                    "loc": {
+                      "items": {
+                        "type": "integer"
+                      },
+                      "type": "array",
+                      "maxItems": 3,
+                      "minItems": 3,
+                      "description": "Location of this WAL event as [last Commit.EndLSN; event LSN; current Begin.FinalLSN]. See https://www.postgresql.org/docs/current/protocol-logicalrep-message-formats.html"
+                    }
+                  },
+                  "additionalProperties": false,
+                  "type": "object",
+                  "required": [
+                    "schema",
+                    "table"
+                  ]
+                }
+              },
+              "reduce": {
+                "strategy": "merge"
+              }
+            }
+          },
+          "reduce": {
+            "strategy": "merge"
+          }
+        },
+        {
+          "$ref": "#TestUSERS"
+        }
+      ]
+    },
+    "key_ptrs": [
+      "/id"
+    ]
+  }
+

--- a/source-postgres/backfill.go
+++ b/source-postgres/backfill.go
@@ -135,7 +135,7 @@ func (db *postgresDatabase) buildScanQuery(start bool, keyColumns []string, colu
 
 	// Construct the query itself
 	var query = new(strings.Builder)
-	fmt.Fprintf(query, "SELECT * FROM %s.%s", schemaName, tableName)
+	fmt.Fprintf(query, `SELECT * FROM "%s"."%s"`, schemaName, tableName)
 	if !start {
 		fmt.Fprintf(query, ` WHERE (%s) > (%s)`, strings.Join(pkey, ", "), strings.Join(args, ", "))
 	}

--- a/source-postgres/replication.go
+++ b/source-postgres/replication.go
@@ -210,7 +210,10 @@ func (s *replicationStream) StartReplication(ctx context.Context) error {
 		if errors.Is(err, context.Canceled) {
 			err = nil
 		}
-		s.conn.Close(ctx)
+		// Always take up to 1 second to notify the database that we're done
+		var closeCtx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
+		s.conn.Close(closeCtx)
+		cancel()
 		close(s.events)
 		s.errCh <- err
 	}()

--- a/sqlcapture/main.go
+++ b/sqlcapture/main.go
@@ -119,7 +119,6 @@ func (d *Driver) Validate(ctx context.Context, req *pc.ValidateRequest) (*pc.Val
 		}
 
 		var streamID = JoinStreamID(res.Namespace, res.Stream)
-
 		if _, ok := discoveredTables[streamID]; !ok {
 			return nil, fmt.Errorf("could not find or access table %s", res.Stream)
 		}

--- a/sqlcapture/tests/helpers.go
+++ b/sqlcapture/tests/helpers.go
@@ -117,17 +117,17 @@ func ResourceBindings(t testing.TB, streamIDs ...string) []*flow.CaptureSpec_Bin
 	t.Helper()
 	var bindings []*flow.CaptureSpec_Binding
 	for _, streamID := range streamIDs {
-		var parts = strings.SplitN(streamID, ".", 2)
+		var nameParts = strings.SplitN(streamID, ".", 2)
 		var bs, err = json.Marshal(sqlcapture.Resource{
-			Namespace: parts[0],
-			Stream:    parts[1],
+			Namespace: nameParts[0],
+			Stream:    nameParts[1],
 		})
 		if err != nil {
 			t.Fatalf("error marshalling resource json: %v", err)
 		}
 		bindings = append(bindings, &flow.CaptureSpec_Binding{
 			ResourceSpecJson: bs,
-			ResourcePath:     []string{streamID},
+			ResourcePath:     nameParts,
 		})
 	}
 	return bindings

--- a/sqlcapture/tests/tests.go
+++ b/sqlcapture/tests/tests.go
@@ -179,7 +179,7 @@ func testCatalogPrimaryKey(ctx context.Context, t *testing.T, tb TestBackend) {
 	require.NoError(t, err)
 	cs.Bindings = append(cs.Bindings, &flow.CaptureSpec_Binding{
 		ResourceSpecJson: specJSON,
-		ResourcePath:     []string{tableName},
+		ResourcePath:     nameParts,
 	})
 
 	t.Run("capture1", func(t *testing.T) { VerifiedCapture(ctx, t, cs) })
@@ -207,7 +207,7 @@ func testCatalogPrimaryKeyOverride(ctx context.Context, t *testing.T, tb TestBac
 	require.NoError(t, err)
 	cs.Bindings = append(cs.Bindings, &flow.CaptureSpec_Binding{
 		ResourceSpecJson: specJSON,
-		ResourcePath:     []string{tableName},
+		ResourcePath:     nameParts,
 	})
 
 	t.Run("capture1", func(t *testing.T) { VerifiedCapture(ctx, t, cs) })


### PR DESCRIPTION
**Description:**

This fixes a couple of bugs when interacting with tables whose names explicity capitalized, for example the one you get by running `CREATE TABLE "USERS" (id INTEGER PRIMARY KEY, name TEXT);`.

It also adds a new test 'TestCapitalizedTables' which exercises discovery, validation, and capturing from a table named `"USERS"` (with quotes, meaning that it will actually be capitalized on the PostgreSQL side).

Also adds a bonus commit which I _think_ fixes CI build flakiness around the final `DROP_REPLICATION_SLOT` performed during tests. (Added in this PR because its CI builds were consistently failing, and either adding that change fixed it or it's just random and I got lucky)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/536)
<!-- Reviewable:end -->
