### PR TITLE
source-postgres: Bare minimum of user type support

### DIFF
--- a/source-postgres/.snapshots/TestUserTypes-Domain-Capture
+++ b/source-postgres/.snapshots/TestUserTypes-Domain-Capture
@@ -1,0 +1,10 @@
+# ================================
+# Collection "test.UserTypes_Domain_bandoleer": 2 Documents
+# ================================
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"usertypes_domain_bandoleer","loc":[11111111,11111111,11111111]}},"id":1,"value":"hello"}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"usertypes_domain_bandoleer","loc":[11111111,11111111,11111111]}},"id":2,"value":"world"}
+# ================================
+# Final State Checkpoint
+# ================================
+{"cursor":"0/1111111","streams":{"test.usertypes_domain_bandoleer":{"key_columns":["id"],"mode":"Active"}}}
+

--- a/source-postgres/.snapshots/TestUserTypes-Domain-Capture-Replication
+++ b/source-postgres/.snapshots/TestUserTypes-Domain-Capture-Replication
@@ -1,0 +1,11 @@
+# ================================
+# Collection "test.UserTypes_Domain_bandoleer": 3 Documents
+# ================================
+{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"usertypes_domain_bandoleer","loc":[11111111,11111111,11111111]}},"id":3,"value":"foo"}
+{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"usertypes_domain_bandoleer","loc":[11111111,11111111,11111111]}},"id":4,"value":"bar"}
+{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"usertypes_domain_bandoleer","loc":[11111111,11111111,11111111]}},"id":5,"value":"baz"}
+# ================================
+# Final State Checkpoint
+# ================================
+{"cursor":"0/1111111","streams":{"test.usertypes_domain_bandoleer":{"key_columns":["id"],"mode":"Active"}}}
+

--- a/source-postgres/.snapshots/TestUserTypes-Domain-Discovery
+++ b/source-postgres/.snapshots/TestUserTypes-Domain-Discovery
@@ -1,0 +1,115 @@
+Binding 0:
+{
+    "recommended_name": "usertypes_domain_bandoleer",
+    "resource_spec_json": {
+      "namespace": "test",
+      "stream": "usertypes_domain_bandoleer",
+      "primary_key": [
+        "id"
+      ]
+    },
+    "document_schema_json": {
+      "$defs": {
+        "TestUsertypes_domain_bandoleer": {
+          "type": "object",
+          "required": [
+            "id"
+          ],
+          "$anchor": "TestUsertypes_domain_bandoleer",
+          "properties": {
+            "id": {
+              "type": "integer"
+            },
+            "value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          }
+        }
+      },
+      "allOf": [
+        {
+          "required": [
+            "_meta"
+          ],
+          "properties": {
+            "_meta": {
+              "type": "object",
+              "required": [
+                "op",
+                "source"
+              ],
+              "properties": {
+                "before": {
+                  "$ref": "#TestUsertypes_domain_bandoleer",
+                  "description": "Record state immediately before this change was applied.",
+                  "reduce": {
+                    "strategy": "firstWriteWins"
+                  }
+                },
+                "op": {
+                  "enum": [
+                    "c",
+                    "d",
+                    "u"
+                  ],
+                  "description": "Change operation type: 'c' Create/Insert, 'u' Update, 'd' Delete."
+                },
+                "source": {
+                  "$id": "https://github.com/estuary/connectors/source-postgres/postgres-source",
+                  "properties": {
+                    "ts_ms": {
+                      "type": "integer",
+                      "description": "Unix timestamp (in millis) at which this event was recorded by the database."
+                    },
+                    "schema": {
+                      "type": "string",
+                      "description": "Database schema (namespace) of the event."
+                    },
+                    "snapshot": {
+                      "type": "boolean",
+                      "description": "Snapshot is true if the record was produced from an initial table backfill and unset if produced from the replication log."
+                    },
+                    "table": {
+                      "type": "string",
+                      "description": "Database table of the event."
+                    },
+                    "loc": {
+                      "items": {
+                        "type": "integer"
+                      },
+                      "type": "array",
+                      "maxItems": 3,
+                      "minItems": 3,
+                      "description": "Location of this WAL event as [last Commit.EndLSN; event LSN; current Begin.FinalLSN]. See https://www.postgresql.org/docs/current/protocol-logicalrep-message-formats.html"
+                    }
+                  },
+                  "additionalProperties": false,
+                  "type": "object",
+                  "required": [
+                    "schema",
+                    "table"
+                  ]
+                }
+              },
+              "reduce": {
+                "strategy": "merge"
+              }
+            }
+          },
+          "reduce": {
+            "strategy": "merge"
+          }
+        },
+        {
+          "$ref": "#TestUsertypes_domain_bandoleer"
+        }
+      ]
+    },
+    "key_ptrs": [
+      "/id"
+    ]
+  }
+

--- a/source-postgres/.snapshots/TestUserTypes-Enum-Capture
+++ b/source-postgres/.snapshots/TestUserTypes-Enum-Capture
@@ -1,0 +1,11 @@
+# ================================
+# Collection "test.UserTypes_Enum_terror": 3 Documents
+# ================================
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"usertypes_enum_terror","loc":[11111111,11111111,11111111]}},"id":1,"value":"red"}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"usertypes_enum_terror","loc":[11111111,11111111,11111111]}},"id":2,"value":"green"}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"usertypes_enum_terror","loc":[11111111,11111111,11111111]}},"id":3,"value":"blue"}
+# ================================
+# Final State Checkpoint
+# ================================
+{"cursor":"0/1111111","streams":{"test.usertypes_enum_terror":{"key_columns":["id"],"mode":"Active"}}}
+

--- a/source-postgres/.snapshots/TestUserTypes-Enum-Capture-Replication
+++ b/source-postgres/.snapshots/TestUserTypes-Enum-Capture-Replication
@@ -1,0 +1,11 @@
+# ================================
+# Collection "test.UserTypes_Enum_terror": 3 Documents
+# ================================
+{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"usertypes_enum_terror","loc":[11111111,11111111,11111111]}},"id":4,"value":"blue"}
+{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"usertypes_enum_terror","loc":[11111111,11111111,11111111]}},"id":5,"value":"red"}
+{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"usertypes_enum_terror","loc":[11111111,11111111,11111111]}},"id":6,"value":"green"}
+# ================================
+# Final State Checkpoint
+# ================================
+{"cursor":"0/1111111","streams":{"test.usertypes_enum_terror":{"key_columns":["id"],"mode":"Active"}}}
+

--- a/source-postgres/.snapshots/TestUserTypes-Enum-Discovery
+++ b/source-postgres/.snapshots/TestUserTypes-Enum-Discovery
@@ -1,0 +1,112 @@
+Binding 0:
+{
+    "recommended_name": "usertypes_enum_terror",
+    "resource_spec_json": {
+      "namespace": "test",
+      "stream": "usertypes_enum_terror",
+      "primary_key": [
+        "id"
+      ]
+    },
+    "document_schema_json": {
+      "$defs": {
+        "TestUsertypes_enum_terror": {
+          "type": "object",
+          "required": [
+            "id"
+          ],
+          "$anchor": "TestUsertypes_enum_terror",
+          "properties": {
+            "id": {
+              "type": "integer"
+            },
+            "value": {
+              "description": "ERROR: could not translate column type \"userenum\" to JSON schema: unhandled PostgreSQL type \"userenum\""
+            }
+          }
+        }
+      },
+      "allOf": [
+        {
+          "required": [
+            "_meta"
+          ],
+          "properties": {
+            "_meta": {
+              "type": "object",
+              "required": [
+                "op",
+                "source"
+              ],
+              "properties": {
+                "before": {
+                  "$ref": "#TestUsertypes_enum_terror",
+                  "description": "Record state immediately before this change was applied.",
+                  "reduce": {
+                    "strategy": "firstWriteWins"
+                  }
+                },
+                "op": {
+                  "enum": [
+                    "c",
+                    "d",
+                    "u"
+                  ],
+                  "description": "Change operation type: 'c' Create/Insert, 'u' Update, 'd' Delete."
+                },
+                "source": {
+                  "$id": "https://github.com/estuary/connectors/source-postgres/postgres-source",
+                  "properties": {
+                    "ts_ms": {
+                      "type": "integer",
+                      "description": "Unix timestamp (in millis) at which this event was recorded by the database."
+                    },
+                    "schema": {
+                      "type": "string",
+                      "description": "Database schema (namespace) of the event."
+                    },
+                    "snapshot": {
+                      "type": "boolean",
+                      "description": "Snapshot is true if the record was produced from an initial table backfill and unset if produced from the replication log."
+                    },
+                    "table": {
+                      "type": "string",
+                      "description": "Database table of the event."
+                    },
+                    "loc": {
+                      "items": {
+                        "type": "integer"
+                      },
+                      "type": "array",
+                      "maxItems": 3,
+                      "minItems": 3,
+                      "description": "Location of this WAL event as [last Commit.EndLSN; event LSN; current Begin.FinalLSN]. See https://www.postgresql.org/docs/current/protocol-logicalrep-message-formats.html"
+                    }
+                  },
+                  "additionalProperties": false,
+                  "type": "object",
+                  "required": [
+                    "schema",
+                    "table"
+                  ]
+                }
+              },
+              "reduce": {
+                "strategy": "merge"
+              }
+            }
+          },
+          "reduce": {
+            "strategy": "merge"
+          }
+        },
+        {
+          "$ref": "#TestUsertypes_enum_terror"
+        }
+      ]
+    },
+    "key_ptrs": [
+      "/id"
+    ]
+  }
+

--- a/source-postgres/.snapshots/TestUserTypes-Tuple-Capture
+++ b/source-postgres/.snapshots/TestUserTypes-Tuple-Capture
@@ -1,0 +1,10 @@
+# ================================
+# Collection "test.UserTypes_Tuple_byways": 2 Documents
+# ================================
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"usertypes_tuple_byways","loc":[11111111,11111111,11111111]}},"id":1,"value":"(1234,5678,\" 'hello'\")"}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"usertypes_tuple_byways","loc":[11111111,11111111,11111111]}},"id":2,"value":"(3456,9876,\" 'world'\")"}
+# ================================
+# Final State Checkpoint
+# ================================
+{"cursor":"0/1111111","streams":{"test.usertypes_tuple_byways":{"key_columns":["id"],"mode":"Active"}}}
+

--- a/source-postgres/.snapshots/TestUserTypes-Tuple-Capture-Replication
+++ b/source-postgres/.snapshots/TestUserTypes-Tuple-Capture-Replication
@@ -1,0 +1,10 @@
+# ================================
+# Collection "test.UserTypes_Tuple_byways": 2 Documents
+# ================================
+{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"usertypes_tuple_byways","loc":[11111111,11111111,11111111]}},"id":3,"value":"(34,64,\" 'asdf'\")"}
+{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"usertypes_tuple_byways","loc":[11111111,11111111,11111111]}},"id":4,"value":"(83,12,\" 'fdsa'\")"}
+# ================================
+# Final State Checkpoint
+# ================================
+{"cursor":"0/1111111","streams":{"test.usertypes_tuple_byways":{"key_columns":["id"],"mode":"Active"}}}
+

--- a/source-postgres/.snapshots/TestUserTypes-Tuple-Discovery
+++ b/source-postgres/.snapshots/TestUserTypes-Tuple-Discovery
@@ -1,0 +1,112 @@
+Binding 0:
+{
+    "recommended_name": "usertypes_tuple_byways",
+    "resource_spec_json": {
+      "namespace": "test",
+      "stream": "usertypes_tuple_byways",
+      "primary_key": [
+        "id"
+      ]
+    },
+    "document_schema_json": {
+      "$defs": {
+        "TestUsertypes_tuple_byways": {
+          "type": "object",
+          "required": [
+            "id"
+          ],
+          "$anchor": "TestUsertypes_tuple_byways",
+          "properties": {
+            "id": {
+              "type": "integer"
+            },
+            "value": {
+              "description": "ERROR: could not translate column type \"usertuple\" to JSON schema: unhandled PostgreSQL type \"usertuple\""
+            }
+          }
+        }
+      },
+      "allOf": [
+        {
+          "required": [
+            "_meta"
+          ],
+          "properties": {
+            "_meta": {
+              "type": "object",
+              "required": [
+                "op",
+                "source"
+              ],
+              "properties": {
+                "before": {
+                  "$ref": "#TestUsertypes_tuple_byways",
+                  "description": "Record state immediately before this change was applied.",
+                  "reduce": {
+                    "strategy": "firstWriteWins"
+                  }
+                },
+                "op": {
+                  "enum": [
+                    "c",
+                    "d",
+                    "u"
+                  ],
+                  "description": "Change operation type: 'c' Create/Insert, 'u' Update, 'd' Delete."
+                },
+                "source": {
+                  "$id": "https://github.com/estuary/connectors/source-postgres/postgres-source",
+                  "properties": {
+                    "ts_ms": {
+                      "type": "integer",
+                      "description": "Unix timestamp (in millis) at which this event was recorded by the database."
+                    },
+                    "schema": {
+                      "type": "string",
+                      "description": "Database schema (namespace) of the event."
+                    },
+                    "snapshot": {
+                      "type": "boolean",
+                      "description": "Snapshot is true if the record was produced from an initial table backfill and unset if produced from the replication log."
+                    },
+                    "table": {
+                      "type": "string",
+                      "description": "Database table of the event."
+                    },
+                    "loc": {
+                      "items": {
+                        "type": "integer"
+                      },
+                      "type": "array",
+                      "maxItems": 3,
+                      "minItems": 3,
+                      "description": "Location of this WAL event as [last Commit.EndLSN; event LSN; current Begin.FinalLSN]. See https://www.postgresql.org/docs/current/protocol-logicalrep-message-formats.html"
+                    }
+                  },
+                  "additionalProperties": false,
+                  "type": "object",
+                  "required": [
+                    "schema",
+                    "table"
+                  ]
+                }
+              },
+              "reduce": {
+                "strategy": "merge"
+              }
+            }
+          },
+          "reduce": {
+            "strategy": "merge"
+          }
+        },
+        {
+          "$ref": "#TestUsertypes_tuple_byways"
+        }
+      ]
+    },
+    "key_ptrs": [
+      "/id"
+    ]
+  }
+

--- a/source-postgres/replication.go
+++ b/source-postgres/replication.go
@@ -309,6 +309,13 @@ func (s *replicationStream) decodeMessage(lsn pglogrepl.LSN, msg pglogrepl.Messa
 	case *pglogrepl.RelationMessage:
 		s.relations[msg.RelationID] = msg
 		return nil, nil
+	case *pglogrepl.TypeMessage:
+		logrus.WithFields(logrus.Fields{
+			"datatype":  msg.DataType,
+			"namespace": msg.Namespace,
+			"name":      msg.Name,
+		}).Trace("user type definition")
+		return nil, nil
 	case *pglogrepl.BeginMessage:
 		if s.nextTxnFinalLSN != 0 {
 			return nil, fmt.Errorf("got BEGIN message while another transaction in progress")


### PR DESCRIPTION
**Description:**

This PR represents the bare minimum we can do to make the use of user-defined types not fail a capture. Concretely, this changes `Type` messages from logical replication to no longer be an error, and adds some tests verifying correct-ish behavior on domain, enum, and tuple types.

There are still a lot of rough edges:

  1. Discovery only "works" to the extent that it doesn't crash. The discovered JSON type for a column of user- defined type is `{description: "<error>"}`, meaning that it accepts anything but complains about it if you look at the schema.
  2. Tuple types aren't serialized especially well as JSON. Rather than becoming a JSON array or object, they are just emitted as a JSON string whose contents is the Postgres text-form representation of the value.
  3. There are two other sorts of user-defined type in Postgres: 'ranges' and 'scalars'. These are not currently tested at all, but in the case of ranges it appears to behave pretty much like a tuple.

**Documentation links affected:**

None, there's some additional rough spots I'd like to work on before we actually _tell_ people we support user types.

**Notes for reviewers:**

Uploaded as-is just in case we need to get a capture unblocked ASAP. More work will occur next week to try and get user types to a state we're actually happy with.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/539)
<!-- Reviewable:end -->
