### PR TITLE
source-sqlserver: Support captures as non-sysadmin user

### DIFF
--- a/source-mysql/replication.go
+++ b/source-mysql/replication.go
@@ -508,7 +508,7 @@ func (rs *mysqlReplicationStream) keyColumns(streamID string) ([]string, bool) {
 	return keyColumns, ok
 }
 
-func (rs *mysqlReplicationStream) ActivateTable(streamID string, keyColumns []string, discovery *sqlcapture.DiscoveryInfo, metadataJSON json.RawMessage) error {
+func (rs *mysqlReplicationStream) ActivateTable(ctx context.Context, streamID string, keyColumns []string, discovery *sqlcapture.DiscoveryInfo, metadataJSON json.RawMessage) error {
 	rs.tables.Lock()
 	defer rs.tables.Unlock()
 

--- a/source-postgres/replication.go
+++ b/source-postgres/replication.go
@@ -577,7 +577,7 @@ func (s *replicationStream) keyColumns(streamID string) ([]string, bool) {
 	return keyColumns, ok
 }
 
-func (s *replicationStream) ActivateTable(streamID string, keyColumns []string, discovery *sqlcapture.DiscoveryInfo, metadataJSON json.RawMessage) error {
+func (s *replicationStream) ActivateTable(ctx context.Context, streamID string, keyColumns []string, discovery *sqlcapture.DiscoveryInfo, metadataJSON json.RawMessage) error {
 	s.tables.Lock()
 	s.tables.active[streamID] = struct{}{}
 	s.tables.keyColumns[streamID] = keyColumns

--- a/source-sqlserver/docker-initdb.sh
+++ b/source-sqlserver/docker-initdb.sh
@@ -13,9 +13,19 @@ USE test;
 GO
 EXEC sys.sp_cdc_enable_db;
 GO
+CREATE LOGIN flow_capture WITH PASSWORD = 'we2rie1E';
+GO
+CREATE USER flow_capture FOR LOGIN flow_capture;
+GO
+GRANT SELECT ON SCHEMA :: dbo TO flow_capture;
+GO
+GRANT SELECT ON SCHEMA :: cdc TO flow_capture;
+GO
 CREATE TABLE dbo.flow_watermarks(slot INTEGER PRIMARY KEY, watermark TEXT);
 GO
-EXEC sys.sp_cdc_enable_table @source_schema = 'dbo', @source_name = 'flow_watermarks', @role_name = 'sa', @capture_instance = 'dbo_flow_watermarks';
+GRANT UPDATE ON dbo.flow_watermarks TO flow_capture;
+GO
+EXEC sys.sp_cdc_enable_table @source_schema = 'dbo', @source_name = 'flow_watermarks', @role_name = 'flow_capture', @capture_instance = 'dbo_flow_watermarks';
 GO
 INSERT INTO dbo.flow_watermarks VALUES (0, 'dummy-value');
 GO

--- a/source-sqlserver/watermarks.go
+++ b/source-sqlserver/watermarks.go
@@ -14,21 +14,41 @@ func (db *sqlserverDatabase) WatermarksTable() string {
 
 func (db *sqlserverDatabase) createWatermarksTable(ctx context.Context) error {
 	var tableName = db.config.Advanced.WatermarksTable
-	log.WithField("table", tableName).Debug("ensuring watermarks table exists")
+	if ok, err := db.watermarksTableExists(ctx); err != nil {
+		return err
+	} else if ok {
+		log.WithField("table", tableName).Debug("watermarks table already exists")
+		return nil
+	}
 
-	const queryPattern = `IF OBJECT_ID('%s', 'U') IS NULL
-	                      BEGIN
+	log.WithField("table", tableName).Debug("creating watermarks table")
+	const queryPattern = `BEGIN
 	                        CREATE TABLE %s(slot INTEGER PRIMARY KEY, watermark TEXT);
 							INSERT INTO %s VALUES (0, '');
 						  END`
 
-	var query = fmt.Sprintf(queryPattern, tableName, tableName, tableName)
+	var query = fmt.Sprintf(queryPattern, tableName, tableName)
 	rows, err := db.conn.QueryContext(ctx, query)
 	if err != nil {
 		return fmt.Errorf("error creating watermarks table: %w", err)
 	}
 	rows.Close()
 	return nil
+}
+
+func (db *sqlserverDatabase) watermarksTableExists(ctx context.Context) (bool, error) {
+	var tableName = db.config.Advanced.WatermarksTable
+	log.WithField("table", tableName).Debug("checking if watermarks table exists")
+
+	rows, err := db.conn.QueryContext(ctx, fmt.Sprintf(`SELECT * FROM %s`, tableName))
+	if err != nil {
+		return false, fmt.Errorf("error reading from watermarks table: %w", err)
+	}
+	defer rows.Close()
+	for rows.Next() {
+		return true, nil
+	}
+	return false, nil
 }
 
 // WriteWatermark writes the provided string into the 'watermarks' table.

--- a/sqlcapture/interface.go
+++ b/sqlcapture/interface.go
@@ -138,7 +138,7 @@ type Database interface {
 // received for that table. It is permitted and necessary to activate some
 // tables before starting replication.
 type ReplicationStream interface {
-	ActivateTable(streamID string, keyColumns []string, info *DiscoveryInfo, metadata json.RawMessage) error
+	ActivateTable(ctx context.Context, streamID string, keyColumns []string, info *DiscoveryInfo, metadata json.RawMessage) error
 
 	StartReplication(ctx context.Context) error
 	Events() <-chan DatabaseEvent


### PR DESCRIPTION
**Description:**

This involved a multitude of little tweaks, including:

  - Editing the database initialization script to create a new 'flow_capture' user with the necessary permissions.
  - Modifying the test suite setup code to use a different user for test manipulations and captures, so that we can create tables and enable CDC as the sysadmin and then use the restricted 'flow_capture' user for captures.
  - Modifying the test suite to enable CDC for newly created tables, so that the 'flow_capture' user doesn't require that permission.
  - Modifying the connector "ensure watermarks table exists" process to use a simple `SELECT * FROM watermarks` to tell if the table exists, because the complex "check if it exists and if not create it" query requires create permissions even when the table already exists.
  - A few other tweaks that came to my attention while I was debugging permissions issues.

After this, a restricted user (with `SELECT` permissions on the `dbo` and `cdc` schemas, `UPDATE` on `dbo.flow_watermarks`, and nothing else) is able to pass the test suite.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/541)
<!-- Reviewable:end -->
