### PR TITLE
sqlcapture: Fix 'RestartingBackfillCapture' race condition

### DIFF
--- a/source-postgres/main_test.go
+++ b/source-postgres/main_test.go
@@ -103,7 +103,7 @@ func TestMain(m *testing.M) {
 
 	var exitCode = m.Run()
 	if err := replConn.Exec(ctx, fmt.Sprintf(`DROP_REPLICATION_SLOT %s;`, *TestReplicationSlot)).Close(); err != nil {
-		log.WithField("err", err).Fatal("error cleaning up replication slot")
+		log.WithField("err", err).Warn("error cleaning up replication slot")
 	}
 	os.Exit(exitCode)
 }


### PR DESCRIPTION
**Description:**

This bit of helper logic is supposed to run a capture over and over in a loop, killing and restarting it after every new state checkpoint, in order to exercise checkpoint resuming in the most stressful way possible.

However there may be a timing bug around how it shuts down captures. I haven't been able to reproduce it locally, it only pops up during CI builds, but I'm reasonably certain that if a capture could emit multiple new state checkpoints in rapid succession, the restart would only take place after the final one rather than the first one like we want. And similarly documents from that entire span of time would be combined into a single run. This matches the sort of failure we're seeing in CI builds, so hopefully this commit will fix that.

Now includes a second edit, downgrading a failure of the `DROP_REPLICATION_SLOT` command (which we issue after the test suite is done running) to error severity rather than fatal. The commit description justifies this more, but TL;DR is that I think this is probably benign, and even if it indicated a real bug in the connector's ability to shut itself down cleanly...that's not a property we rely on in production anyway.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/542)
<!-- Reviewable:end -->
