### PR TITLE
materialize-bigquery: add logging for connector initialization

### DIFF
--- a/materialize-bigquery/transactor.go
+++ b/materialize-bigquery/transactor.go
@@ -34,6 +34,14 @@ func newTransactor(
 ) (_ pm.Transactor, err error) {
 	cfg := ep.Config.(config)
 
+	log.WithFields(log.Fields{
+		"project_id":  cfg.ProjectID,
+		"dataset":     cfg.Dataset,
+		"region":      cfg.Region,
+		"bucket":      cfg.Bucket,
+		"bucket_path": cfg.BucketPath,
+	}).Info("creating transactor")
+
 	client, err := cfg.client(ctx)
 	if err != nil {
 		return nil, err
@@ -53,6 +61,7 @@ func newTransactor(
 		}
 	}
 
+	log.Info("transactor created successfully")
 	return t, nil
 }
 


### PR DESCRIPTION
**Description:**

We've seen a couple of instances of an apparent deadlock with bigquery materializations, where the materialization will apparently start up and not write out any data, even though it does not exit with an error.

The cause of this is not immediately clear, so I am adding some logging for the startup the connector. We currently only see "opening bigquery" if everything works perfectly which is not very useful. The logs added here might be leaning a little towards overkill in the other direction, but they will only be logged when the connector restarts and should be useful for making sure the connector is able to initialize successfully.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/551)
<!-- Reviewable:end -->
