### PR TITLE
source-mongodb: remove tunnel, allow custom schema

### DIFF
--- a/source-mongodb/main.go
+++ b/source-mongodb/main.go
@@ -30,23 +30,12 @@ func (r resource) Validate() error {
 	return nil
 }
 
-type sshForwarding struct {
-	SSHEndpoint string `json:"sshEndpoint" jsonschema:"title=SSH Endpoint,description=Endpoint of the remote SSH server that supports tunneling (in the form of ssh://user@hostname[:port])" jsonschema_extras:"pattern=^ssh://.+@.+$"`
-	PrivateKey  string `json:"privateKey" jsonschema:"title=SSH Private Key,description=Private key to connect to the remote SSH server." jsonschema_extras:"secret=true,multiline=true"`
-}
-
-type tunnelConfig struct {
-	SSHForwarding *sshForwarding `json:"sshForwarding,omitempty" jsonschema:"title=SSH Forwarding"`
-}
-
 // config represents the endpoint configuration for postgres.
 type config struct {
 	Address  string `json:"address" jsonschema:"title=Address,description=Host and port of the database." jsonschema_extras:"order=0"`
 	User     string `json:"user" jsonschema:"title=User,description=Database user to connect as." jsonschema_extras:"order=1"`
 	Password string `json:"password" jsonschema:"title=Password,description=Password for the specified database user." jsonschema_extras:"secret=true,order=2"`
 	Database string `json:"database" jsonschema:"title=Database,description=Name of the database to capture from." jsonschema_extras:"order=3"`
-
-	NetworkTunnel *tunnelConfig `json:"networkTunnel,omitempty" jsonschema:"title=Network Tunnel,description=Connect to your system through an SSH server that acts as a bastion host for your network."`
 }
 
 func (c *config) Validate() error {
@@ -68,16 +57,17 @@ func (c *config) Validate() error {
 // ToURI converts the Config to a DSN string.
 func (c *config) ToURI() string {
 	var address = c.Address
-	// If SSH Tunnel is configured, we are going to create a tunnel from localhost:5432
-	// to address through the bastion server, so we use the tunnel's address
-	if c.NetworkTunnel != nil && c.NetworkTunnel.SSHForwarding != nil && c.NetworkTunnel.SSHForwarding.SSHEndpoint != "" {
-		address = "localhost:27020"
+	var uri, err = url.Parse(address)
+
+	if err != nil || uri.Scheme == "" {
+		uri = &url.URL{
+			Scheme: "mongodb",
+			Host:   address,
+		}
 	}
-	var uri = url.URL{
-		Scheme: "mongodb",
-		Host:   address,
-		User:   url.UserPassword(c.User, c.Password),
-	}
+
+	uri.User = url.UserPassword(c.User, c.Password)
+
 	if c.Database != "" {
 		uri.Path = "/" + c.Database
 	}


### PR DESCRIPTION
**Description:**

- Turns out working out the network tunnel is not as trivial for MongoDB, given that they usually use SRV DNS records and they have some cluster discovery logic that we need to dive into and understand so we can tunnel properly. For now I'm removing network tunnelling since we don't have a request for it.
- On the other hand, when using SRV MongoDB URIs in the format `mongodb+srv://`, the user should be able to specify this custom schema if they want to. This PR covers that.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/554)
<!-- Reviewable:end -->
