### PR TITLE
source-mongodb: fix address without schema throwing error

### DIFF
--- a/source-mongodb/main.go
+++ b/source-mongodb/main.go
@@ -59,7 +59,7 @@ func (c *config) ToURI() string {
 	var address = c.Address
 	var uri, err = url.Parse(address)
 
-	if err != nil || uri.Scheme == "" {
+	if err != nil || uri.Scheme == "" || uri.Host == "" {
 		uri = &url.URL{
 			Scheme: "mongodb",
 			Host:   address,


### PR DESCRIPTION
**Description:**

- Apparently if you give a URL with no scheme to `url.Parse`, it actually parses successfully but gives a URL which has `Scheme` equal to the whole address, with an empty `Host` 😁 

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/560)
<!-- Reviewable:end -->
