### PR TITLE
source-mongodb: validate mongodb+srv:// address to ensure no port

### DIFF
--- a/source-mongodb/main.go
+++ b/source-mongodb/main.go
@@ -51,6 +51,12 @@ func (c *config) Validate() error {
 		}
 	}
 
+	var uri, err = url.Parse(c.Address)
+	// mongodb+srv:// urls do not support port
+	if err == nil && uri.Scheme == "mongodb+srv" && uri.Port() != "" {
+		return fmt.Errorf("`mongodb+srv://` addresses do not support specifying the port.")
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
**Description:**

- Validate `mongodb+srv://` addresses to ensure no port is specified, since port values are not supported on this scheme.
- This leads to a better UX by giving a better error message when users specify the port by mistake

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/561)
<!-- Reviewable:end -->
