### PR TITLE
materialize-postgres: convert to Flow JSON protocol

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -39,6 +39,7 @@ require (
 	go.mongodb.org/mongo-driver v1.11.2
 	golang.org/x/oauth2 v0.3.0
 	golang.org/x/sync v0.0.0-20220601150217-0de741cfad7f
+	golang.org/x/text v0.7.0
 	golang.org/x/time v0.0.0-20220609170525-579cf78fd858
 	google.golang.org/api v0.93.0
 	google.golang.org/genproto v0.0.0-20220822174746-9e6da59bd2fc
@@ -133,7 +134,6 @@ require (
 	golang.org/x/crypto v0.0.0-20220622213112-05595931fe9d // indirect
 	golang.org/x/net v0.7.0 // indirect
 	golang.org/x/sys v0.5.0 // indirect
-	golang.org/x/text v0.7.0 // indirect
 	golang.org/x/xerrors v0.0.0-20220609144429-65e65417b02f // indirect
 	google.golang.org/appengine v1.6.7 // indirect
 	gopkg.in/DataDog/dd-trace-go.v1 v1.17.0 // indirect

--- a/go/boilerplate/future.go
+++ b/go/boilerplate/future.go
@@ -1,0 +1,45 @@
+package boilerplate
+
+import (
+	"fmt"
+
+	"go.gazette.dev/core/broker/client"
+)
+
+// OpFuture represents an operation which is executing in the background. The operation has
+// completed when Done selects. Err may be invoked to determine whether the operation succeeded or
+// failed. This is copied from gazette's `client` package.
+type OpFuture interface {
+	// Done selects when operation background execution has finished.
+	Done() <-chan struct{}
+	// Err blocks until Done() and returns the final error of the OpFuture.
+	Err() error
+}
+
+// AsyncOperation is a simple, minimal implementation of the OpFuture interface.
+type AsyncOperation = client.AsyncOperation
+
+// NewAsyncOperation returns a new AsyncOperation.
+var NewAsyncOperation = client.NewAsyncOperation
+
+// FinishedOperation is a convenience that returns an already-resolved AsyncOperation.
+var FinishedOperation = client.FinishedOperation
+
+// RunAsyncOperation invokes the given function asynchronously and returns an OpFuture which will
+// resolve with its completion or panic.
+func RunAsyncOperation(fn func() error) OpFuture {
+	var op = NewAsyncOperation()
+
+	go func(op *AsyncOperation) {
+		defer func() {
+			if op != nil {
+				op.Resolve(fmt.Errorf("operation had an internal panic"))
+			}
+		}()
+
+		op.Resolve(fn())
+		op = nil
+	}(op)
+
+	return op
+}

--- a/go/boilerplate/materialize.go
+++ b/go/boilerplate/materialize.go
@@ -8,8 +8,6 @@ import (
 	"io"
 	"math"
 	"os"
-	"os/signal"
-	"syscall"
 
 	"github.com/estuary/connectors/go/protocol"
 	"github.com/jessevdk/go-flags"
@@ -128,7 +126,7 @@ func RunMaterialization(driver Driver) {
 	}
 	logConfig.Configure()
 
-	var ctx, _ = signal.NotifyContext(context.Background(), syscall.SIGTERM, syscall.SIGINT)
+	ctx := context.Background()
 
 	if err := handleCmds(ctx, driver); err != nil {
 		log.Error(err)
@@ -248,11 +246,7 @@ func handleCmds(ctx context.Context, driver Driver) error {
 				}()
 			}
 
-			select {
-			case <-ctx.Done():
-				return ctx.Err()
-			case state.loadChan <- cmd:
-			}
+			state.loadChan <- cmd
 		case protocol.FlushRequest:
 			log.Debug("received flush request")
 
@@ -266,14 +260,10 @@ func handleCmds(ctx context.Context, driver Driver) error {
 			// Close the loadChan of the in-progress driver Load function so that it can complete.
 			close(state.loadChan)
 
-			select {
-			case <-ctx.Done():
-				return ctx.Err()
-			case <-state.loadComplete:
-				state.loadChan = nil // Prepare for the next round
+			<-state.loadComplete
+			state.loadChan = nil // Prepare for the next round
 
-				mustEmit(protocol.Flushed, protocol.FlushResponse{})
-			}
+			mustEmit(protocol.Flushed, protocol.FlushResponse{})
 		case protocol.StoreRequest:
 			log.Debug("received store request")
 
@@ -289,55 +279,47 @@ func handleCmds(ctx context.Context, driver Driver) error {
 				}()
 			}
 
-			select {
-			case <-ctx.Done():
-				return ctx.Err()
-			case state.storeChan <- cmd:
-			}
+			state.storeChan <- cmd
 		case protocol.StartCommitRequest:
 			log.Debug("received startCommit request")
 
 			// Close the storeChan of the in-progress driver Store function so that it can complete.
 			close(state.storeChan)
 
-			select {
-			case <-ctx.Done():
-				return ctx.Err()
-			case <-state.storeComplete:
-				state.storeChan = nil // Prepare for the next round
+			<-state.storeComplete
+			state.storeChan = nil // Prepare for the next round
 
-				var driverCheckpoint *protocol.StartCommitResponse
-				if state.driverStartCommitFn != nil {
-					driverCheckpoint, state.driverCommitFuture = state.driverStartCommitFn(ctx, cmd.RuntimeCheckpoint, state.runtimeAck)
+			var driverCheckpoint *protocol.StartCommitResponse
+			if state.driverStartCommitFn != nil {
+				driverCheckpoint, state.driverCommitFuture = state.driverStartCommitFn(ctx, cmd.RuntimeCheckpoint, state.runtimeAck)
 
-					state.driverStartCommitFn = nil // Prepare for the next round
-				}
-
-				// As a convenience, map a nil OpFuture to a pre-resolved one so the rest of our
-				// handling can ignore the nil case.
-				if state.driverCommitFuture == nil {
-					state.driverCommitFuture = FinishedOperation(nil)
-				}
-
-				// If startCommit returned a pre-resolved error, fail-fast and don't send
-				// StartedCommit to the runtime, as `driverCheckpoint` may be invalid.
-				select {
-				case <-state.driverCommitFuture.Done():
-					if err := state.driverCommitFuture.Err(); err != nil {
-						return fmt.Errorf("driver.StartCommit: %w", err)
-					}
-				default:
-				}
-
-				if driverCheckpoint == nil {
-					driverCheckpoint = &protocol.StartCommitResponse{
-						DriverCheckpoint: json.RawMessage("{}"),
-						MergePatch:       true,
-					}
-				}
-
-				mustEmit(protocol.StartedCommit, driverCheckpoint)
+				state.driverStartCommitFn = nil // Prepare for the next round
 			}
+
+			// As a convenience, map a nil OpFuture to a pre-resolved one so the rest of our
+			// handling can ignore the nil case.
+			if state.driverCommitFuture == nil {
+				state.driverCommitFuture = FinishedOperation(nil)
+			}
+
+			// If startCommit returned a pre-resolved error, fail-fast and don't send
+			// StartedCommit to the runtime, as `driverCheckpoint` may be invalid.
+			select {
+			case <-state.driverCommitFuture.Done():
+				if err := state.driverCommitFuture.Err(); err != nil {
+					return fmt.Errorf("driver.StartCommit: %w", err)
+				}
+			default:
+			}
+
+			if driverCheckpoint == nil {
+				driverCheckpoint = &protocol.StartCommitResponse{
+					DriverCheckpoint: json.RawMessage("{}"),
+					MergePatch:       true,
+				}
+			}
+
+			mustEmit(protocol.StartedCommit, driverCheckpoint)
 		}
 	}
 

--- a/go/boilerplate/materialize.go
+++ b/go/boilerplate/materialize.go
@@ -1,0 +1,345 @@
+package boilerplate
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"math"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/estuary/connectors/go/protocol"
+	"github.com/jessevdk/go-flags"
+	log "github.com/sirupsen/logrus"
+	"go.gazette.dev/core/broker/client"
+)
+
+var (
+	inputReader  io.Reader = os.Stdin
+	outputWriter io.Writer = os.Stdout
+	logWriter    io.Writer = os.Stderr
+)
+
+type Driver interface {
+	// Spec should produce a synchronous response with a SpecResponse of the driver's specification.
+	Spec(context.Context, protocol.SpecRequest) (*protocol.SpecResponse, error)
+
+	// Validate should produce a synchronous response with a ValidateResponse of the validated
+	// bindings.
+	Validate(context.Context, protocol.ValidateRequest) (*protocol.ValidateResponse, error)
+
+	// Apply should produce a synchronous response with an ApplyResponse of the actions taken by the
+	// driver.
+	Apply(context.Context, protocol.ApplyRequest) (*protocol.ApplyResponse, error)
+
+	// Open should produce a synchronous response with an OpenResponse optionally containing the
+	// Flow runtime checkpoint that processing should resume from. If empty, the most recent
+	// checkpoint of the Flow recovery log is used.
+	//
+	// Or, a driver may send value []byte{0xf8, 0xff, 0xff, 0xff, 0xf, 0x1} as a base64-encoded
+	// string to explicitly begin processing from a zero-valued checkpoint, effectively rebuilding
+	// the materialization from scratch.
+	Open(context.Context, protocol.OpenRequest) (*protocol.OpenResponse, error)
+
+	// Load implements the transaction load phase by consuming LoadRequests from the LoadRequest
+	// channel and calling the provided `loaded` callback. Load can ignore keys which are not found
+	// in the store, and it may defer calls to `loaded` for as long as it wishes, so long as
+	// `loaded` is called for every found document prior to returning.
+	//
+	// Loads should not be evaluated until the prior transaction has finished committing. Waiting
+	// for the prior commit ensures that evaluated loads reflect the updates of that prior
+	// transaction, and thus meet the formal "read-committed" guarantee required by the runtime.
+	//
+	// The LoadRequest channel will be closed only when a "flush" request has been received from the
+	// runtime. This signals that the runtime has received acknowledgement that the driver's prior
+	// commit has completed successfully and that no more loads will be sent. The driver should
+	// usually read from this channel until it is closed prior to evaluating its loads, typically by
+	// staging the received load requests for execution after the channel is closed.
+	Load(context.Context, <-chan protocol.LoadRequest, func(protocol.LoadResponse)) error
+
+	// Store consumes StoreRequests from the StoreRequest channel and returns a StartCommitFn which
+	// is used to commit the stored transaction. StartCommitFn may be nil, which indicates that
+	// commits are a no-op -- as in an at-least-once materialization that doesn't use a
+	// DriverCheckpoint.
+	Store(context.Context, <-chan protocol.StoreRequest) (StartCommitFn, error)
+}
+
+// StartCommitFn begins to commit a stored transaction. Upon its return a commit operation may still
+// be running in the background, and the returned OpFuture must resolve with its completion. (Upon
+// its resolution, Acknowledged will be sent to the Runtime).
+//
+// # When using the "Remote Store is Authoritative" pattern:
+//
+// StartCommitFn must include `runtimeCheckpoint` within its endpoint transaction and either
+// immediately or asynchronously commit. If the Transactor commits synchronously, it may return a
+// nil OpFuture.
+//
+// # When using the "Recovery Log is Authoritative with Idempotent Apply" pattern:
+//
+// StartCommitFn must return a DriverCheckpoint which encodes the staged application. It must begin
+// an asynchronous application of this staged update, immediately returning its OpFuture.
+//
+// That async application MUST await a future signal of `runtimeAckCh` before taking action,
+// however, to ensure that the DriverCheckpoint returned by StartCommit has been durably committed
+// to the runtime recovery log. `runtimeAckCh` is closed when an Acknowledge request is received
+// from the runtime, indicating that the transaction and its DriverCheckpoint have been committed to
+// the runtime recovery log.
+//
+// Note that it's possible that the DriverCheckpoint may commit to the log, but then the runtime or
+// this Transactor may crash before the application is able to complete. For this reason, on
+// initialization a Transactor must take care to (re-)apply a staged update in the opened
+// DriverCheckpoint.
+//
+// If StartCommitFn fails, it should return a pre-resolved OpFuture which carries its error (for
+// example, via FinishedOperation()).
+type StartCommitFn = func(ctx context.Context, runtimeCheckpoint string, runtimeAckCh <-chan struct{}) (*protocol.StartCommitResponse, OpFuture)
+
+type logConfig struct {
+	Level  string `long:"log.level" env:"LOG_LEVEL" default:"info" choice:"info" choice:"INFO" choice:"debug" choice:"DEBUG" choice:"warn" choice:"WARN" description:"Logging level"`
+	Format string `long:"log.format" env:"LOG_FORMAT" default:"text" choice:"json" choice:"text" choice:"color" description:"Logging output format"`
+}
+
+func (c *logConfig) Configure() {
+	if c.Format == "json" {
+		log.SetFormatter(&log.JSONFormatter{})
+	} else if c.Format == "text" {
+		log.SetFormatter(&log.TextFormatter{})
+	} else if c.Format == "color" {
+		log.SetFormatter(&log.TextFormatter{ForceColors: true})
+	}
+
+	if lvl, err := log.ParseLevel(c.Level); err != nil {
+		log.WithField("err", err).Fatal("unrecognized log level")
+	} else {
+		log.SetLevel(lvl)
+	}
+
+	log.SetOutput(logWriter)
+}
+
+func RunMaterialization(driver Driver) {
+	var logConfig = &logConfig{}
+	var parser = flags.NewParser(logConfig, flags.Default)
+	if _, err := parser.Parse(); err != nil {
+		os.Exit(1)
+	}
+	logConfig.Configure()
+
+	var ctx, _ = signal.NotifyContext(context.Background(), syscall.SIGTERM, syscall.SIGINT)
+
+	if err := handleCmds(ctx, driver); err != nil {
+		log.Error(err)
+		os.Exit(1)
+	}
+
+	os.Exit(0)
+}
+
+// runState encapsulates the state of the driver throughout the transactions protocol messages. This
+// state allows for processing loads and commits asynchronously.
+type runState struct {
+	loadChan            chan protocol.LoadRequest
+	loadComplete        chan struct{}
+	storeChan           chan protocol.StoreRequest
+	storeComplete       chan struct{}
+	driverStartCommitFn StartCommitFn
+	runtimeAck          chan struct{}
+	driverCommitFuture  OpFuture
+}
+
+func newRunState() *runState {
+	return &runState{
+		loadChan:            nil,
+		loadComplete:        make(chan struct{}),
+		storeChan:           nil,
+		storeComplete:       make(chan struct{}),
+		driverStartCommitFn: nil,
+		runtimeAck:          make(chan struct{}),
+		driverCommitFuture:  client.FinishedOperation(nil),
+	}
+}
+
+func handleCmds(ctx context.Context, driver Driver) error {
+	state := newRunState()
+
+	lines := bufio.NewScanner(inputReader)
+	buf := make([]byte, 0, 4096)
+	// The default maximum buffer size for bufio.Scanner is 64 kilobytes, which is too small for
+	// messages commonly handled by connectors. There is no real reason to limit the maximum size of
+	// messages, although handling extraordinarily large messages will not be practical due to
+	// container memory limits.
+	lines.Buffer(buf, math.MaxInt)
+
+	for lines.Scan() {
+		switch cmd := mustParseCommand(lines.Bytes()).(type) {
+		case protocol.SpecRequest:
+			log.Debug("received spec request")
+
+			res, err := driver.Spec(ctx, cmd)
+			if err != nil {
+				return err
+			}
+			mustEmit(protocol.Speced, res)
+		case protocol.ValidateRequest:
+			log.Debug("received validate request")
+
+			res, err := driver.Validate(ctx, cmd)
+			if err != nil {
+				return err
+			}
+			mustEmit(protocol.Validated, res)
+		case protocol.ApplyRequest:
+			log.Debug("received apply request")
+
+			res, err := driver.Apply(ctx, cmd)
+			if err != nil {
+				return err
+			}
+			mustEmit(protocol.Applied, res)
+		case protocol.OpenRequest:
+			log.Debug("received open request")
+
+			res, err := driver.Open(ctx, cmd)
+			if err != nil {
+				return err
+			}
+			mustEmit(protocol.Opened, res)
+		case protocol.AcknowledgeRequest:
+			// Receiving "acknowledge" from the runtime indicates that the runtime has successfully
+			// committed the prior transaction to the recovery log. If the driver provided a
+			// driverCommitFuture it will now be asynchronously awaited prior to sending
+			// "acknowledged" to the runtime.
+			log.Debug("received acknowledge request")
+
+			go func() {
+				// Signal the driverCommitFuture that the runtimeAck has been received.
+				close(state.runtimeAck)
+
+				// Wait for the driverCommitFuture to complete.
+				<-state.driverCommitFuture.Done()
+
+				// Prepare for the next round.
+				state.runtimeAck = make(chan struct{})
+
+				if err := state.driverCommitFuture.Err(); err != nil {
+					exitWithError(err)
+				}
+				mustEmit(protocol.Acknowledged, protocol.AcknowledgeResponse{})
+			}()
+		case protocol.LoadRequest:
+			log.Debug("received load request")
+
+			handleLoad := func(loadResponse protocol.LoadResponse) {
+				mustEmit(protocol.Loaded, loadResponse)
+			}
+
+			// Start the driver Load function if it hasn't already been started this round.
+			if state.loadChan == nil {
+				state.loadChan = make(chan protocol.LoadRequest)
+				go func() {
+					if err := driver.Load(ctx, state.loadChan, handleLoad); err != nil {
+						exitWithError(err)
+					}
+
+					state.loadComplete <- struct{}{}
+				}()
+			}
+
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case state.loadChan <- cmd:
+			}
+		case protocol.FlushRequest:
+			log.Debug("received flush request")
+
+			// This channel may be nil if no load requests were received, as would the be the case
+			// when running delta updates.
+			if state.loadChan == nil {
+				mustEmit(protocol.Flushed, protocol.FlushResponse{})
+				continue
+			}
+
+			// Close the loadChan of the in-progress driver Load function so that it can complete.
+			close(state.loadChan)
+
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-state.loadComplete:
+				state.loadChan = nil // Prepare for the next round
+
+				mustEmit(protocol.Flushed, protocol.FlushResponse{})
+			}
+		case protocol.StoreRequest:
+			log.Debug("received store request")
+
+			// Start the driver Store function if it hasn't already been started this round.
+			if state.storeChan == nil {
+				state.storeChan = make(chan protocol.StoreRequest)
+				go func() {
+					var err error
+					if state.driverStartCommitFn, err = driver.Store(ctx, state.storeChan); err != nil {
+						exitWithError(err)
+					}
+					state.storeComplete <- struct{}{}
+				}()
+			}
+
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case state.storeChan <- cmd:
+			}
+		case protocol.StartCommitRequest:
+			log.Debug("received startCommit request")
+
+			// Close the storeChan of the in-progress driver Store function so that it can complete.
+			close(state.storeChan)
+
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-state.storeComplete:
+				state.storeChan = nil // Prepare for the next round
+
+				var driverCheckpoint *protocol.StartCommitResponse
+				if state.driverStartCommitFn != nil {
+					driverCheckpoint, state.driverCommitFuture = state.driverStartCommitFn(ctx, cmd.RuntimeCheckpoint, state.runtimeAck)
+
+					state.driverStartCommitFn = nil // Prepare for the next round
+				}
+
+				// As a convenience, map a nil OpFuture to a pre-resolved one so the rest of our
+				// handling can ignore the nil case.
+				if state.driverCommitFuture == nil {
+					state.driverCommitFuture = FinishedOperation(nil)
+				}
+
+				// If startCommit returned a pre-resolved error, fail-fast and don't send
+				// StartedCommit to the runtime, as `driverCheckpoint` may be invalid.
+				select {
+				case <-state.driverCommitFuture.Done():
+					if err := state.driverCommitFuture.Err(); err != nil {
+						return fmt.Errorf("driver.StartCommit: %w", err)
+					}
+				default:
+				}
+
+				if driverCheckpoint == nil {
+					driverCheckpoint = &protocol.StartCommitResponse{
+						DriverCheckpoint: json.RawMessage("{}"),
+						MergePatch:       true,
+					}
+				}
+
+				mustEmit(protocol.StartedCommit, driverCheckpoint)
+			}
+		}
+	}
+
+	return lines.Err()
+}

--- a/go/boilerplate/materialize_test.go
+++ b/go/boilerplate/materialize_test.go
@@ -1,0 +1,345 @@
+package boilerplate
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"io"
+	"os"
+	"sync"
+	"testing"
+
+	"github.com/estuary/connectors/go/protocol"
+	"github.com/stretchr/testify/require"
+)
+
+type mockDriver struct {
+	doSpec     func(context.Context, protocol.SpecRequest) (*protocol.SpecResponse, error)
+	doValidate func(context.Context, protocol.ValidateRequest) (*protocol.ValidateResponse, error)
+	doApply    func(context.Context, protocol.ApplyRequest) (*protocol.ApplyResponse, error)
+	doOpen     func(context.Context, protocol.OpenRequest) (*protocol.OpenResponse, error)
+	doLoad     func(context.Context, <-chan protocol.LoadRequest, func(protocol.LoadResponse)) error
+	doStore    func(context.Context, <-chan protocol.StoreRequest) (StartCommitFn, error)
+}
+
+func (d *mockDriver) Spec(ctx context.Context, req protocol.SpecRequest) (*protocol.SpecResponse, error) {
+	return d.doSpec(ctx, req)
+}
+
+func (d *mockDriver) Validate(ctx context.Context, req protocol.ValidateRequest) (*protocol.ValidateResponse, error) {
+	return d.doValidate(ctx, req)
+}
+
+func (d *mockDriver) Apply(ctx context.Context, req protocol.ApplyRequest) (*protocol.ApplyResponse, error) {
+	return d.doApply(ctx, req)
+}
+
+func (d *mockDriver) Open(ctx context.Context, req protocol.OpenRequest) (*protocol.OpenResponse, error) {
+	return d.doOpen(ctx, req)
+}
+
+func (d *mockDriver) Load(ctx context.Context, reqs <-chan protocol.LoadRequest, loadedFn func(protocol.LoadResponse)) error {
+	return d.doLoad(ctx, reqs, loadedFn)
+}
+
+func (d *mockDriver) Store(ctx context.Context, reqs <-chan protocol.StoreRequest) (StartCommitFn, error) {
+	return d.doStore(ctx, reqs)
+}
+
+func TestBoilerplate_Setup(t *testing.T) {
+	var inputWriter io.Writer
+	var outputReader io.Reader
+	var err error
+
+	inputReader, inputWriter, err = os.Pipe()
+	require.NoError(t, err)
+	outputReader, outputWriter, err = os.Pipe()
+	require.NoError(t, err)
+
+	out := bufio.NewScanner(outputReader)
+
+	driver := &mockDriver{
+		doSpec: func(ctx context.Context, req protocol.SpecRequest) (*protocol.SpecResponse, error) {
+			return &protocol.SpecResponse{}, nil
+		},
+		doValidate: func(ctx context.Context, req protocol.ValidateRequest) (*protocol.ValidateResponse, error) {
+			return &protocol.ValidateResponse{}, nil
+		},
+		doApply: func(ctx context.Context, req protocol.ApplyRequest) (*protocol.ApplyResponse, error) {
+			return &protocol.ApplyResponse{}, nil
+		},
+		doOpen: func(ctx context.Context, req protocol.OpenRequest) (*protocol.OpenResponse, error) {
+			return &protocol.OpenResponse{}, nil
+		},
+	}
+
+	go func() {
+		handleCmds(context.Background(), driver)
+	}()
+
+	tests := []struct {
+		reqCmd  string
+		reqMsg  interface{}
+		wantCmd string
+		wantMsg interface{}
+	}{
+		{
+			reqCmd:  "spec",
+			reqMsg:  protocol.SpecRequest{},
+			wantCmd: "spec",
+			wantMsg: protocol.SpecResponse{},
+		},
+		{
+			reqCmd:  "validate",
+			reqMsg:  protocol.ValidateRequest{},
+			wantCmd: "validated",
+			wantMsg: protocol.ValidateResponse{},
+		},
+		{
+			reqCmd:  "apply",
+			reqMsg:  protocol.ApplyRequest{},
+			wantCmd: "applied",
+			wantMsg: protocol.ApplyResponse{},
+		},
+		{
+			reqCmd:  "open",
+			reqMsg:  protocol.OpenRequest{},
+			wantCmd: "opened",
+			wantMsg: protocol.OpenResponse{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.reqCmd, func(t *testing.T) {
+			_, err = inputWriter.Write(marshalTestCmd(t, tt.reqCmd, tt.reqMsg))
+			require.NoError(t, err)
+			require.True(t, out.Scan())
+			require.Equal(t, marshalTestResponse(t, tt.wantCmd, tt.wantMsg), out.Bytes())
+		})
+	}
+}
+
+func TestBoilerplate_TxnLifecycle_Sync(t *testing.T) {
+	var inputWriter io.Writer
+	var outputReader io.Reader
+	var err error
+
+	inputReader, inputWriter, err = os.Pipe()
+	require.NoError(t, err)
+	outputReader, outputWriter, err = os.Pipe()
+	require.NoError(t, err)
+
+	out := bufio.NewScanner(outputReader)
+
+	startCommitCalls := &testCounter{}
+	executeCommitCalls := &testCounter{}
+
+	driver := &mockDriver{
+		doLoad: func(ctx context.Context, reqs <-chan protocol.LoadRequest, loaded func(protocol.LoadResponse)) error {
+			<-reqs
+			loaded(protocol.LoadResponse{})
+			return nil
+		},
+		doStore: func(ctx context.Context, reqs <-chan protocol.StoreRequest) (StartCommitFn, error) {
+			<-reqs
+			startCommitCalls.inc()
+
+			return func(ctx context.Context, runtimeCheckpoint string, runtimeAckCh <-chan struct{}) (*protocol.StartCommitResponse, OpFuture) {
+				commitOp := RunAsyncOperation(func() error {
+					<-runtimeAckCh
+					executeCommitCalls.inc()
+					return nil
+				})
+
+				return nil, commitOp
+			}, nil
+		},
+	}
+
+	go func() {
+		handleCmds(context.Background(), driver)
+	}()
+
+	// Run through several rounds of a simulated runtime sending transaction requests to the driver,
+	// explicitly waiting for the expected response from the driver.
+	for round := 0; round < 5; round++ {
+		_, err = inputWriter.Write(marshalTestCmd(t, "acknowledge", protocol.AcknowledgeRequest{}))
+		require.NoError(t, err)
+		require.True(t, out.Scan())
+		require.Equal(t, marshalTestResponse(t, "acknowledged", protocol.AcknowledgeResponse{}), out.Bytes())
+
+		_, err = inputWriter.Write(marshalTestCmd(t, "load", protocol.LoadRequest{}))
+		require.NoError(t, err)
+		require.True(t, out.Scan())
+		require.Equal(t, marshalTestResponse(t, "loaded", protocol.LoadResponse{}), out.Bytes())
+
+		_, err = inputWriter.Write(marshalTestCmd(t, "flush", protocol.FlushRequest{}))
+		require.NoError(t, err)
+		require.True(t, out.Scan())
+		require.Equal(t, marshalTestResponse(t, "flushed", protocol.FlushResponse{}), out.Bytes())
+
+		_, err = inputWriter.Write(marshalTestCmd(t, "store", protocol.StoreRequest{}))
+		require.NoError(t, err)
+
+		require.Equal(t, round, startCommitCalls.get())
+		require.Equal(t, round, executeCommitCalls.get())
+
+		_, err = inputWriter.Write(marshalTestCmd(t, "startCommit", protocol.StartCommitRequest{}))
+		require.NoError(t, err)
+		require.True(t, out.Scan())
+		require.Equal(t, marshalTestResponse(t, "startedCommit", protocol.StartCommitResponse{
+			DriverCheckpoint: json.RawMessage("{}"),
+			MergePatch:       true,
+		}), out.Bytes())
+
+		require.Equal(t, round+1, startCommitCalls.get())
+		require.Equal(t, round, executeCommitCalls.get())
+
+		_, err = inputWriter.Write(marshalTestCmd(t, "acknowledge", protocol.AcknowledgeRequest{}))
+		require.NoError(t, err)
+		require.True(t, out.Scan())
+		require.Equal(t, marshalTestResponse(t, "acknowledged", protocol.AcknowledgeResponse{}), out.Bytes())
+
+		require.Equal(t, round+1, startCommitCalls.get())
+		require.Equal(t, round+1, executeCommitCalls.get())
+
+		// Loop for the next transaction round.
+	}
+}
+
+func TestBoilerplate_TxnLifecycle_Async(t *testing.T) {
+	var inputWriter io.Writer
+	var outputReader io.Reader
+	var err error
+
+	inputReader, inputWriter, err = os.Pipe()
+	require.NoError(t, err)
+	outputReader, outputWriter, err = os.Pipe()
+	require.NoError(t, err)
+
+	out := bufio.NewScanner(outputReader)
+
+	startCommitCalls := &testCounter{}
+	executeCommitCalls := &testCounter{}
+
+	driver := &mockDriver{
+		doLoad: func(ctx context.Context, reqs <-chan protocol.LoadRequest, loaded func(protocol.LoadResponse)) error {
+			for range reqs {
+				loaded(protocol.LoadResponse{})
+			}
+			return nil
+		},
+		doStore: func(ctx context.Context, reqs <-chan protocol.StoreRequest) (StartCommitFn, error) {
+			for range reqs {
+				<-reqs
+			}
+			startCommitCalls.inc()
+
+			return func(ctx context.Context, runtimeCheckpoint string, runtimeAckCh <-chan struct{}) (*protocol.StartCommitResponse, OpFuture) {
+				commitOp := RunAsyncOperation(func() error {
+					<-runtimeAckCh
+					executeCommitCalls.inc()
+					return nil
+				})
+
+				return nil, commitOp
+			}, nil
+		},
+	}
+
+	go func() {
+		handleCmds(context.Background(), driver)
+	}()
+
+	for round := 0; round < 5; round++ {
+		// Send "acknowledge" followed immediately by multiple load requests.
+		_, err = inputWriter.Write(marshalTestCmd(t, "acknowledge", protocol.AcknowledgeRequest{}))
+		require.NoError(t, err)
+		for load := 0; load < 10; load++ {
+			_, err = inputWriter.Write(marshalTestCmd(t, "load", protocol.LoadRequest{}))
+			require.NoError(t, err)
+		}
+		// Read the "acknowledged" and "loaded" responses, which may have been written in any order.
+		for idx := 0; idx < 11; idx++ {
+			require.True(t, out.Scan())
+		}
+
+		// On round 0, these won't have been called at all yet. On round >= 1, their values will
+		// reflect the increment from the end of the last round.
+		require.Equal(t, round, startCommitCalls.get())
+		require.Equal(t, round, executeCommitCalls.get())
+
+		// "flush" gets an immediate "flushed" response.
+		_, err = inputWriter.Write(marshalTestCmd(t, "flush", protocol.FlushRequest{}))
+		require.NoError(t, err)
+		require.True(t, out.Scan())
+		require.Equal(t, marshalTestResponse(t, "flushed", protocol.FlushResponse{}), out.Bytes())
+
+		// Send multiple "store" requests, which do not produce a response.
+		for store := 0; store < 10; store++ {
+			_, err = inputWriter.Write(marshalTestCmd(t, "store", protocol.StoreRequest{}))
+			require.NoError(t, err)
+		}
+
+		// "startCommit" gets an immediate "startedCommit" response.
+		_, err = inputWriter.Write(marshalTestCmd(t, "startCommit", protocol.StartCommitRequest{}))
+		require.NoError(t, err)
+		require.True(t, out.Scan())
+		require.Equal(t, marshalTestResponse(t, "startedCommit", protocol.StartCommitResponse{
+			DriverCheckpoint: json.RawMessage("{}"),
+			MergePatch:       true,
+		}), out.Bytes())
+
+		require.Equal(t, round+1, startCommitCalls.get())
+		require.Equal(t, round, executeCommitCalls.get())
+
+		// Loop for the next transaction round.
+	}
+}
+
+func marshalTestCmd(t *testing.T, cmd string, msg interface{}) []byte {
+	t.Helper()
+
+	envelope := map[string]interface{}{
+		cmd: msg,
+	}
+
+	out, err := json.Marshal(envelope)
+	require.NoError(t, err)
+	out = append(out, '\n')
+	return out
+}
+
+func marshalTestResponse(t *testing.T, cmd string, msg interface{}) []byte {
+	t.Helper()
+
+	envelope := map[string]interface{}{
+		cmd: msg,
+	}
+
+	out, err := json.Marshal(envelope)
+	require.NoError(t, err)
+	return out
+}
+
+// testCounter can be thought of as the driver endpoint, which will be accessed concurrently by the
+// driver async operations and the testing code assertions. The lock is required to prevent a
+// datarace between the driver async operations and the testing assertions.
+type testCounter struct {
+	sync.Mutex
+	count int
+}
+
+func (t *testCounter) inc() {
+	t.Lock()
+	defer t.Unlock()
+
+	t.count++
+}
+
+func (t *testCounter) get() int {
+	t.Lock()
+	defer t.Unlock()
+
+	return t.count
+}

--- a/go/boilerplate/util.go
+++ b/go/boilerplate/util.go
@@ -1,0 +1,107 @@
+package boilerplate
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/estuary/connectors/go/protocol"
+	log "github.com/sirupsen/logrus"
+)
+
+func exitWithError(err error) {
+	log.Error(err)
+	os.Exit(1)
+}
+
+func mustEmit(responseKey protocol.ResponseCommand, payload interface{}) {
+	out, err := json.Marshal(map[protocol.ResponseCommand]interface{}{
+		responseKey: payload,
+	})
+	if err != nil {
+		panic(fmt.Errorf("marshalling response: %w", err))
+	}
+
+	if _, err := fmt.Fprintln(outputWriter, string(out)); err != nil {
+		panic(fmt.Errorf("writing emit output: %w", err))
+	}
+}
+
+func mustParseCommand(command []byte) interface{} {
+	var parsed map[string]json.RawMessage
+	if err := json.Unmarshal(command, &parsed); err != nil {
+		panic(err)
+	}
+
+	// The JSON body of every command must have a single key, where the key is the name of the
+	// command. The value is the command itself.
+	if len(parsed) != 1 {
+		panic(fmt.Sprintf("received command had %d keys when it must have 1", len(parsed)))
+	}
+
+	var cmd string
+	var msg json.RawMessage
+	for k, v := range parsed {
+		cmd = k
+		msg = v
+	}
+
+	switch protocol.RequestCommand(cmd) {
+	case protocol.Spec:
+		var req protocol.SpecRequest
+		if err := json.Unmarshal(msg, &req); err != nil {
+			panic(fmt.Errorf("unmarshalling SpecRequest: %w", err))
+		}
+		return req
+	case protocol.Validate:
+		var req protocol.ValidateRequest
+		if err := json.Unmarshal(msg, &req); err != nil {
+			panic(fmt.Errorf("unmarshalling ValidateRequest: %w", err))
+		}
+		return req
+	case protocol.Apply:
+		var req protocol.ApplyRequest
+		if err := json.Unmarshal(msg, &req); err != nil {
+			panic(fmt.Errorf("unmarshalling ApplyRequest: %w", err))
+		}
+		return req
+	case protocol.Open:
+		var req protocol.OpenRequest
+		if err := json.Unmarshal(msg, &req); err != nil {
+			panic(fmt.Errorf("unmarshalling OpenRequest: %w", err))
+		}
+		return req
+	case protocol.Acknowledge:
+		var req protocol.AcknowledgeRequest
+		if err := json.Unmarshal(msg, &req); err != nil {
+			panic(fmt.Errorf("unmarshalling AcknowledgeRequest: %w", err))
+		}
+		return req
+	case protocol.Load:
+		var req protocol.LoadRequest
+		if err := json.Unmarshal(msg, &req); err != nil {
+			panic(fmt.Errorf("unmarshalling LoadRequest: %w", err))
+		}
+		return req
+	case protocol.Flush:
+		var req protocol.FlushRequest
+		if err := json.Unmarshal(msg, &req); err != nil {
+			panic(fmt.Errorf("unmarshalling FlushRequest: %w", err))
+		}
+		return req
+	case protocol.Store:
+		var req protocol.StoreRequest
+		if err := json.Unmarshal(msg, &req); err != nil {
+			panic(fmt.Errorf("unmarshalling StoreRequest: %w", err))
+		}
+		return req
+	case protocol.StartCommit:
+		var req protocol.StartCommitRequest
+		if err := json.Unmarshal(msg, &req); err != nil {
+			panic(fmt.Errorf("unmarshalling StartCommitRequest: %w", err))
+		}
+		return req
+	default:
+		panic(fmt.Sprintf("invalid command: %s", cmd))
+	}
+}

--- a/go/protocol/extensions.go
+++ b/go/protocol/extensions.go
@@ -1,0 +1,245 @@
+package protocol
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+
+	pf "github.com/estuary/flow/go/protocols/flow"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
+)
+
+// GetProjectionByField finds the projection with the given field name, or nil if one does not exist
+func GetProjectionByField(field string, projections []Projection) *Projection {
+	for p := range projections {
+		if projections[p].Field == field {
+			return &projections[p]
+		}
+	}
+	return nil
+}
+
+// GetProjection finds the projection with the given field name, or nil if one does not exist
+func (m CollectionSpec) GetProjection(field string) *Projection {
+	return GetProjectionByField(field, m.Projections)
+}
+
+// AllFields returns the complete set of all the fields as a single string slice. All the keys
+// fields will be ordered first, in the same order as they appear in Keys, followed by all the
+// Values fields in the same order, with the root document field coming last.
+func (fields FieldSelection) AllFields() []string {
+	var all = make([]string, 0, len(fields.Keys)+len(fields.Values)+1)
+	all = append(all, fields.Keys...)
+	all = append(all, fields.Values...)
+	if fields.Document != nil {
+		all = append(all, *fields.Document)
+	}
+	return all
+}
+
+// IsRootDocumentProjection returns true only if this is a projection of the entire document,
+// meaning that the json pointer is the empty string.
+func (projection Projection) IsRootDocumentProjection() bool {
+	return len(projection.Ptr) == 0
+}
+
+// IsSingleType returns true if this inference may only hold a single type besides null For example,
+// if the types are ["string", "null"] or just ["string"], then this would return true.
+func (i Inference) IsSingleType() bool {
+	var nTypes = 0
+	for _, ty := range i.Types {
+		if ty != JsonTypeNull {
+			nTypes++
+		}
+	}
+	return nTypes == 1
+}
+
+// IsSingleScalarType returns true if this inference may hold a single scalar type besides null.
+func (i Inference) IsSingleScalarType() bool {
+	var isScalar = false
+	var nTypes = 0
+	for _, ty := range i.Types {
+		switch ty {
+		case JsonTypeNull:
+		case JsonTypeInteger, JsonTypeNumber, JsonTypeBoolean, JsonTypeString:
+			isScalar = true
+			nTypes++
+		default:
+			nTypes++
+		}
+	}
+	return isScalar && nTypes == 1
+}
+
+// Type_ constants for each type name used in JSON schemas.
+const (
+	JsonTypeNull    = "null"
+	JsonTypeInteger = "integer"
+	JsonTypeNumber  = "number"
+	JsonTypeBoolean = "boolean"
+	JsonTypeString  = "string"
+	JsonTypeObject  = "object"
+	JsonTypeArray   = "array"
+)
+
+// IsForbidden returns true if the constraint type forbids inclusion in a materialization. This will
+// return true for FIELD_FORBIDDEN and UNSATISFIABLE, and false for any other constraint type.
+func (m *ConstraintType) IsForbidden() bool {
+	switch *m {
+	case FieldForbidden, Unsatisfiable:
+		return true
+	default:
+		return false
+	}
+}
+
+// Equal returns true if this FieldSelection is deeply equal to the other.
+func (fields *FieldSelection) Equal(other *FieldSelection) bool {
+	if other == nil {
+		return fields == nil
+	}
+
+	if len(fields.Keys) != len(other.Keys) {
+		return false
+	}
+	for i := range fields.Keys {
+		if fields.Keys[i] != other.Keys[i] {
+			return false
+		}
+	}
+	if len(fields.Values) != len(other.Values) {
+		return false
+	}
+	for i := range fields.Values {
+		if fields.Values[i] != other.Values[i] {
+			return false
+		}
+	}
+
+	if fields.Document == nil {
+		if other.Document != nil {
+			return false
+		}
+	} else {
+		if *fields.Document != *other.Document {
+			return false
+		}
+	}
+	if len(fields.FieldConfig) != len(other.FieldConfig) {
+		return false
+	}
+	for key := range fields.FieldConfig {
+		if string(fields.FieldConfig[key]) != string(other.FieldConfig[key]) {
+			return false
+		}
+	}
+
+	return true
+}
+
+type Validator interface {
+	Validate() error
+}
+
+// UnmarshalStrict unmarshals |doc| into |m|, using a strict decoding of the document which
+// prohibits unknown fields. If decoding is successful, then |m| is also validated.
+func UnmarshalStrict(doc json.RawMessage, into Validator) error {
+	var d = json.NewDecoder(bytes.NewReader(doc))
+	d.DisallowUnknownFields()
+
+	if err := d.Decode(into); err != nil {
+		return err
+	}
+	return into.Validate()
+}
+
+// ExplicitZeroCheckpoint is a zero-valued message encoding, implemented as a trivial encoding of
+// the max-value 2^29-1 protobuf tag with boolean true.
+var ExplicitZeroCheckpoint = base64.StdEncoding.EncodeToString([]byte{0xf8, 0xff, 0xff, 0xff, 0xf, 0x1})
+
+// MaterializationSpecPbToBindings exists to extract the equivalent ApplyBinding's from a protobuf
+// pf.MaterializationSpec. This is needed as a compatibility layer for materializations that convert
+// to the JSON protocol and need to parsed stored specs from the protobuf protocol. It is also used
+// for testing in the SQL package. Ideally it could be removed when the compatibility layer is no
+// longer required.
+func MaterializationSpecPbToBindings(pbSpec *pf.MaterializationSpec) []ApplyBinding {
+	out := []ApplyBinding{}
+
+	for _, b := range pbSpec.Bindings {
+		out = append(out, ApplyBinding{
+			Collection:     collectionSpecPbToBindings(b.Collection),
+			ResourceConfig: b.ResourceSpecJson,
+			ResourcePath:   b.ResourcePath,
+			DeltaUpdates:   b.DeltaUpdates,
+			FieldSelection: fieldSelectionPbToBindings(b.FieldSelection),
+		})
+	}
+
+	return out
+}
+
+func collectionSpecPbToBindings(in pf.CollectionSpec) CollectionSpec {
+	return CollectionSpec{
+		Name:            in.Collection.String(),
+		Key:             in.KeyPtrs,
+		PartitionFields: in.PartitionFields,
+		Projections:     projectionsPbToBindings(in.Projections),
+		Schema:          in.GetReadSchemaJson(),
+		ReadSchema:      in.ReadSchemaJson,
+		WriteSchema:     in.WriteSchemaJson,
+	}
+}
+
+func fieldSelectionPbToBindings(in pf.FieldSelection) FieldSelection {
+	return FieldSelection{
+		Keys:        in.Keys,
+		Values:      in.Values,
+		Document:    &in.Document,
+		FieldConfig: in.FieldConfigJson,
+	}
+}
+
+func projectionsPbToBindings(in []pf.Projection) []Projection {
+	out := []Projection{}
+
+	for _, p := range in {
+		out = append(out, Projection{
+			Ptr:            p.Ptr,
+			Field:          p.Field,
+			Explicit:       p.Explicit,
+			IsPartitionKey: p.IsPartitionKey,
+			IsPrimaryKey:   p.IsPrimaryKey,
+			Inference:      inferencePbToBindings(p.Inference),
+		})
+	}
+
+	return out
+}
+
+func inferencePbToBindings(in pf.Inference) Inference {
+	return Inference{
+		Types:       in.Types,
+		String_:     inferenceStringPbToBindings(in.String_),
+		Title:       in.Title,
+		Description: in.Description,
+		Default_:    in.DefaultJson,
+		Secret:      in.Secret,
+		Exists:      Exists(cases.Title(language.English).String(in.Exists.String())),
+	}
+}
+
+func inferenceStringPbToBindings(in *pf.Inference_String) *StringInference {
+	if in == nil {
+		return nil
+	}
+
+	return &StringInference{
+		ContentType:     in.ContentType,
+		Format:          in.Format,
+		ContentEncoding: in.ContentEncoding,
+		IsBase64:        in.IsBase64,
+		MaxLength:       int(in.MaxLength),
+	}
+}

--- a/go/protocol/materialize.go
+++ b/go/protocol/materialize.go
@@ -1,0 +1,385 @@
+package protocol
+
+import (
+	"encoding/json"
+)
+
+type RequestCommand string
+
+const (
+	Spec        RequestCommand = "spec"
+	Validate    RequestCommand = "validate"
+	Apply       RequestCommand = "apply"
+	Open        RequestCommand = "open"
+	Acknowledge RequestCommand = "acknowledge"
+	Load        RequestCommand = "load"
+	Flush       RequestCommand = "flush"
+	Store       RequestCommand = "store"
+	StartCommit RequestCommand = "startCommit"
+)
+
+type ResponseCommand string
+
+const (
+	Speced        ResponseCommand = "spec"
+	Validated     ResponseCommand = "validated"
+	Applied       ResponseCommand = "applied"
+	Opened        ResponseCommand = "opened"
+	Acknowledged  ResponseCommand = "acknowledged"
+	Loaded        ResponseCommand = "loaded"
+	Flushed       ResponseCommand = "flushed"
+	StartedCommit ResponseCommand = "startedCommit"
+)
+
+type SpecRequest struct{}
+
+type SpecResponse struct {
+	// URL for connector's documentation.
+	DocumentationUrl string `json:"documentationUrl"`
+	// JSON schema of the connector's endpoint configuration.
+	ConfigSchema json.RawMessage `json:"configSchema"`
+	// JSON schema of a binding's resource specification.
+	ResourceConfigSchema json.RawMessage `json:"resourceConfigSchema"`
+	// Optional OAuth2 configuration.
+	Oauth2 *OAuth2Spec `json:"oauth2,omitempty"`
+}
+
+// OAuth2Spec describes an OAuth2 provider
+type OAuth2Spec struct {
+	// Name of the OAuth2 provider. This is a machine-readable key and must stay consistent. One
+	// example use case is to map providers to their respective style of buttons in the UI
+	Provider string `json:"provider,omitempty"`
+	// Template for authorization URL, this is the first step of the OAuth2 flow where the user is
+	// redirected to the OAuth2 provider to authorize access to their account
+	AuthUrlTemplate string `json:"authUrlTemplate,omitempty"`
+	// Template for access token URL, this is the second step of the OAuth2 flow, where we request
+	// an access token from the provider
+	AccessTokenUrlTemplate string `json:"accessTokenUrlTemplate,omitempty"`
+	// The method used to send access_token request. POST by default.
+	AccessTokenMethod string `json:"accessTokenMethod,omitempty"`
+	// The POST body of the access_token request
+	AccessTokenBody string `json:"accessTokenBody,omitempty"`
+	// Headers for the access_token request
+	AccessTokenHeadersJson json.RawMessage `json:"accessTokenHeadersJson,omitempty"`
+	// A json map that maps the response from the OAuth provider for Access Token request to keys in
+	// the connector endpoint configuration. If the connector supports refresh tokens, must include
+	// `refresh_token` and `expires_in`. If this mapping is not provided, the keys from the response
+	// are passed as-is to the connector config.
+	AccessTokenResponseMapJson json.RawMessage `json:"accessTokenResponseMapJson,omitempty"`
+	// Template for refresh token URL, some providers require that the access token be refreshed.
+	RefreshTokenUrlTemplate string `json:"refreshTokenUrlTemplate,omitempty"`
+	// The method used to send refresh_token request. POST by default.
+	RefreshTokenMethod string `json:"refreshTokenMethod,omitempty"`
+	// The POST body of the refresh_token request
+	RefreshTokenBody string `json:"refreshTokenBody,omitempty"`
+	// Headers for the refresh_token request
+	RefreshTokenHeadersJson json.RawMessage `json:"refreshTokenHeadersJson,omitempty"`
+	// A json map that maps the response from the OAuth provider for Refresh Token request to keys
+	// in the connector endpoint configuration. If the connector supports refresh tokens, must
+	// include `refresh_token` and `expires_in`. If this mapping is not provided, the keys from the
+	// response are passed as-is to the connector config.
+	RefreshTokenResponseMapJson json.RawMessage `json:"refreshTokenResponseMapJson,omitempty"`
+}
+
+type ValidateRequest struct {
+	// Name of the materialization being validated.
+	Name string `json:"name"`
+	// Connector endpoint configuration.
+	Config json.RawMessage `json:"config"`
+	// Proposed bindings of the validated materialization.
+	Bindings []ValidateBinding `json:"bindings"`
+}
+
+type ValidateBinding struct {
+	// Collection of the proposed binding.
+	Collection CollectionSpec
+	// Resource configuration of the proposed binding.
+	ResourceConfig json.RawMessage
+	// Field configuration of the proposed binding.
+	FieldConfig map[string]json.RawMessage
+}
+
+type CollectionSpec struct {
+	// Name of this collection.
+	Name string `json:"name"`
+	// Composite key of the collection.
+	// Keys are specified as an ordered sequence of JSON-Pointers.
+	Key []string `json:"key"`
+	// Logically-partitioned fields of this collection.
+	PartitionFields []string `json:"partitionFields"`
+	// Projections of this collection.
+	Projections []Projection `json:"projections"`
+	// JSON Schema against which collection documents are validated.
+	// If set, then writeSchema and readSchema are not.
+	Schema json.RawMessage `json:"schema,omitempty"` //optional
+	// JSON Schema against which written collection documents are validated.
+	// If set, then readSchema is also and schema is not.
+	WriteSchema json.RawMessage `json:"writeSchema,omitempty"` //optional
+	// JSON Schema against which read collection documents are validated.
+	// If set, then writeSchema is also and schema is not.
+	ReadSchema json.RawMessage `json:"readSchema,omitempty"` // optional
+}
+
+type Projection struct {
+	// Document location of this projection, as a JSON-Pointer.
+	Ptr string `json:"ptr"`
+	// Flattened, tabular alias of this projection.
+	// A field may correspond to a SQL table column, for example.
+	Field string `json:"field"`
+	// Was this projection explicitly provided ?
+	// (As opposed to implicitly created through static analysis of the schema).
+	Explicit bool `json:"explicit"`
+	// Does this projection constitute a logical partitioning of the collection?
+	IsPartitionKey bool `json:"isPartitionKey"`
+	// Does this location form (part of) the collection key?
+	IsPrimaryKey bool `json:"isPrimaryKey"`
+	// Inference of this projection.
+	Inference Inference `json:"inference"`
+}
+
+type Inference struct {
+	// The possible types for this location. Subset of:
+	// ["null", "boolean", "object", "array", "integer", "numeric", "string"].
+	Types []string `json:"types"`
+	// String type-specific inferences, or null iff types
+	// doesn't include "string".
+	String_ *StringInference `json:"string,omitempty"` // optional
+	// The title from the schema, if provided.
+	Title string `json:"title"`
+	// The description from the schema, if provided.
+	Description string `json:"description"`
+	// The default value from the schema, or "null" if there is no default.
+	Default_ json.RawMessage `json:"default"`
+	// Whether this location is marked as a secret, like a credential or password.
+	Secret bool `json:"secret"`
+	// Existence of this document location.
+	Exists Exists `json:"exists"`
+}
+
+type StringInference struct {
+	// Annotated Content-Type when the projection is of "string" type.
+	ContentType string `json:"contentType"`
+	// Annotated format when the projection is of "string" type.
+	Format string `json:"format"`
+	// Annotated Content-Encoding when the projection is of "string" type.
+	ContentEncoding string `json:"contentEncoding"`
+	// Is the Content-Encoding "base64" (case-invariant)?
+	IsBase64 bool `json:"isBase64"`
+	// Maximum length when the projection is of "string" type.
+	// Zero for no limit.
+	MaxLength int `json:"maxLength"`
+}
+
+type Exists string
+
+const (
+	// The location must exist.
+	MustExist Exists = "Must"
+	// The location may exist or be undefined.
+	// Its schema has explicit keywords which allow it to exist
+	// and which may constrain its shape, such as additionalProperties,
+	// items, unevaluatedProperties, or unevaluatedItems.
+	MayExist Exists = "May"
+	// The location may exist or be undefined.
+	// Its schema omits any associated keywords, but the specification's
+	// default behavior allows the location to exist.
+	ImplicitExist Exists = "Implicit"
+	// The location cannot exist. For example, it's outside of permitted
+	// array bounds, or is a disallowed property, or has an impossible type.
+	CannotExist Exists = "Cannot"
+)
+
+type ValidateResponse struct {
+	// Validated bindings of the endpoint.
+	Bindings []ValidatedBinding `json:"bindings"`
+}
+
+type ValidatedBinding struct {
+	// Resource path which fully qualifies the endpoint resource identified by this binding.
+	ResourcePath []string `json:"resourcePath"`
+	// Mapping of fields to their connector-imposed constraints.
+	// The Flow runtime resolves a final set of fields from the user's specification
+	// and the set of constraints returned by the connector.
+	Constraints map[string]Constraint `json:"constraints"`
+	// Should delta-updates be used for this binding?
+	DeltaUpdates bool `json:"deltaUpdates"`
+}
+
+// A Constraint constrains the use of a collection projection within a materialization binding.
+type Constraint struct {
+	// The type of this constraint.
+	Type ConstraintType `json:"type"`
+	// A user-facing reason for the constraint on this field.
+	Reason string `json:"reason"`
+}
+
+type ConstraintType string
+
+const (
+	// This specific projection must be present.
+	FieldRequired ConstraintType = "FieldRequired"
+	// At least one projection with this location pointer must be present.
+	LocationRequired ConstraintType = "LocationRequired"
+	// A projection with this location is recommended, and should be included by
+	// default.
+	LocationRecommended ConstraintType = "LocationRecommended"
+	// This projection may be included, but should be omitted by default.
+	FieldOptional ConstraintType = "FieldOptional"
+	// This projection must not be present in the materialization.
+	FieldForbidden ConstraintType = "FieldForbidden"
+	// This specific projection is required but is also unacceptable (e.x.,
+	// because it uses an incompatible type with a previous applied version).
+	Unsatisfiable ConstraintType = "Unsatisfiable"
+)
+
+type ApplyRequest struct {
+	// Name of the materialization being applied.
+	Name string `json:"name"`
+	// Connector endpoint configuration.
+	Config json.RawMessage `json:"config"`
+	// Binding specifications of the applied materialization.
+	Bindings []ApplyBinding `json:"bindings"`
+	// Opaque, unique version of this materialization application.
+	Version string `json:"version"`
+	// Is this application a dry run?
+	// Dry-run applications take no action.
+	DryRun bool `json:"dryRun"`
+}
+
+type ApplyBinding struct {
+	// Collection of this binding.
+	Collection CollectionSpec `json:"collection"`
+	// Resource configuration of this binding.
+	ResourceConfig json.RawMessage `json:"resourceConfig"`
+	// Resource path which fully qualifies the endpoint resource identified by this binding.
+	// For an RDBMS, this might be ["my-schema", "my-table"].
+	// For Kafka, this might be ["my-topic-name"].
+	// For Redis or DynamoDB, this might be ["/my/key/prefix"].
+	ResourcePath []string `json:"resourcePath"`
+	// Does this binding use delta-updates instead of standard materialization?
+	DeltaUpdates bool `json:"deltaUpdates"`
+	// Fields which have been selected for materialization.
+	FieldSelection FieldSelection `json:"fieldSelection"`
+}
+
+type FieldSelection struct {
+	// Selected fields which are collection key components.
+	Keys []string `json:"keys"`
+	// Selected fields which are values.
+	Values []string `json:"values"`
+	// Field which represents the Flow document, or null if the document isn't materialized.
+	Document *string `json:"document,omitempty"`
+	// Custom field configuration of the binding, keyed by field.
+	FieldConfig map[string]json.RawMessage `json:"fieldConfig"`
+}
+
+type ApplyResponse struct {
+	// User-facing description of the action taken by this application.
+	// If the apply was a dry-run, then this is a description of actions
+	// that would have been taken.
+	ActionDescription string `json:"actionDescription"`
+}
+
+type OpenRequest struct {
+	// Name of the materialization being opened.
+	Name string `json:"name"`
+	// Connector endpoint configuration.
+	Config json.RawMessage `json:"config"`
+	// Binding specifications of the opened materialization.
+	Bindings []ApplyBinding `json:"bindings"`
+	// Opaque, unique version of this materialization.
+	Version string `json:"version"`
+	// Beginning key-range which this connector invocation will materialize.
+	// [keyBegin, keyEnd] are the inclusive range of keys processed by this
+	// connector invocation. Ranges reflect the disjoint chunks of ownership
+	// specific to each instance of a scale-out materialization.
+	//
+	// The Flow runtime manages the routing of document keys to distinct
+	// connector invocations, and each invocation will receive only disjoint
+	// subsets of possible keys. Thus, this key range is merely advisory.
+	KeyBegin int `json:"keyBegin"`
+	// Ending key-range which this connector invocation will materialize.
+	KeyEnd int `json:"keyEnd"`
+	// Last-persisted driver checkpoint from a previous materialization invocation.
+	// Or empty, if the driver has cleared or never set its checkpoint.
+	DriverCheckpoint json.RawMessage `json:"driverCheckpoint"`
+}
+
+type OpenResponse struct {
+	// Flow runtime checkpoint to begin processing from. Optional.
+	// If empty, the most recent checkpoint of the Flow recovery log is used.
+	//
+	// Or, a driver may send the value []byte{0xf8, 0xff, 0xff, 0xff, 0xf, 0x1}
+	// to explicitly begin processing from a zero-valued checkpoint, effectively
+	// rebuilding the materialization from scratch.
+	RuntimeCheckpoint string `json:"runtimeCheckpoint"`
+}
+
+// Acknowledge to the connector that the previous transaction has committed
+// to the Flow runtime's recovery log.
+type AcknowledgeRequest struct{}
+
+// Acknowledged follows Open and also StartedCommit, and tells the Flow Runtime
+// that a previously started commit has completed.
+//
+// Acknowledged is _not_ a direct response to Request "acknowledge" command,
+// and Acknowledge vs Acknowledged may be written in either order.
+type AcknowledgeResponse struct{}
+
+type LoadRequest struct {
+	// Index of the Open binding for which this document is loaded.
+	Binding int `json:"binding"`
+	// Packed hexadecimal encoding of the key to load.
+	// The packed encoding is order-preserving: given two instances of a
+	// composite key K1 and K2, if K2 > K1 then K2's packed key is lexicographically
+	// greater than K1's packed key.
+	KeyPacked string `json:"keyPacked"`
+	// Composite key to load.
+	Key []interface{} `json:"key"`
+}
+
+type LoadResponse struct {
+	// Index of the Open binding for which this document is loaded.
+	Binding int `json:"binding"`
+	// Loaded document.
+	Doc json.RawMessage `json:"doc"`
+}
+
+type FlushRequest struct{}
+
+type FlushResponse struct{}
+
+type StoreRequest struct {
+	// Index of the Open binding for which this document is stored.
+	Binding int `json:"binding"`
+	// Packed hexadecimal encoding of the key to store.
+	KeyPacked string `json:"keyPacked"`
+	// Composite key to store.
+	Key []interface{} `json:"key"`
+	// Array of selected, projected document values to store.
+	Values []interface{} `json:"values"`
+	// Complete JSON document to store.
+	Doc json.RawMessage `json:"doc"`
+	// Does this key exist in the endpoint?
+	// True if this document was previously loaded or stored.
+	// A SQL materialization might toggle between INSERT vs UPDATE behavior
+	// depending on this value.
+	Exists bool `json:"exists"`
+}
+
+type StartCommitRequest struct {
+	// Opaque, base64-encoded Flow runtime checkpoint.
+	// If the endpoint is authoritative, the connector must store this checkpoint
+	// for a retrieval upon a future Open.
+	RuntimeCheckpoint string `json:"runtimeCheckpoint"`
+}
+
+type StartCommitResponse struct {
+	// Updated driver checkpoint to commit with this checkpoint.
+	DriverCheckpoint json.RawMessage `json:"driverCheckpoint"`
+	// Is this a partial update of the driver's checkpoint?
+	// If true, then treat the driver checkpoint as a partial state update
+	// which is incorporated into the full checkpoint as a RFC7396 Merge patch.
+	// Otherwise the checkpoint is completely replaced.
+	MergePatch bool `json:"mergePatch"`
+}

--- a/materialize-postgres/.snapshots/TestSQLGeneration
+++ b/materialize-postgres/.snapshots/TestSQLGeneration
@@ -193,9 +193,9 @@ install_new as (
 			where (select count(*) from best_match) = 0
 	returning *
 )
-select fence, decode(checkpoint, 'base64') from install_new
+select fence, checkpoint from install_new
 union all
-select fence, decode(checkpoint, 'base64') from best_match
+select fence, checkpoint from best_match
 limit 1
 ;
 --- End Fence Install ---

--- a/materialize-postgres/.snapshots/TestSpecification
+++ b/materialize-postgres/.snapshots/TestSpecification
@@ -1,5 +1,6 @@
 {
-  "endpoint_spec_schema_json": {
+  "documentationUrl": "https://go.estuary.dev/materialize-postgresql",
+  "configSchema": {
     "$schema": "http://json-schema.org/draft/2020-12/schema",
     "$id": "https://github.com/estuary/connectors/materialize-postgres/config",
     "properties": {
@@ -76,7 +77,7 @@
     ],
     "title": "SQL Connection"
   },
-  "resource_spec_schema_json": {
+  "resourceConfigSchema": {
     "$schema": "http://json-schema.org/draft/2020-12/schema",
     "$id": "https://github.com/estuary/connectors/materialize-postgres/table-config",
     "properties": {
@@ -109,6 +110,5 @@
       "table"
     ],
     "title": "SQL Table"
-  },
-  "documentation_url": "https://go.estuary.dev/materialize-postgresql"
+  }
 }

--- a/materialize-postgres/Dockerfile
+++ b/materialize-postgres/Dockerfile
@@ -9,22 +9,24 @@ WORKDIR /builder
 # Download & compile dependencies early. Doing this separately allows for layer
 # caching opportunities when no dependencies are updated.
 COPY go.* ./
-RUN go mod download
+# RUN go mod download
 
 # Download recent flow binaries for usage by tests.
 RUN curl -L --proto '=https' --tlsv1.2 -sSf "https://github.com/estuary/flow/releases/download/dev/flow-x86-linux.tar.gz"| tar -zx -C /usr/local/bin/
 
 # Build the connector projects we depend on.
-COPY go-schema-gen           ./go-schema-gen
-COPY materialize-boilerplate ./materialize-boilerplate
-COPY materialize-postgres    ./materialize-postgres
-COPY materialize-sql         ./materialize-sql
-COPY testsupport             ./testsupport
-COPY go-network-tunnel       ./go-network-tunnel
+COPY go-schema-gen          ./go-schema-gen
+COPY go                     ./go
+COPY materialize-postgres   ./materialize-postgres
+COPY materialize-sql-json   ./materialize-sql-json
+COPY testsupport            ./testsupport
+COPY go-network-tunnel      ./go-network-tunnel
 
 # Test and build the connector.
-RUN go test  -tags nozstd,nodb -v ./materialize-postgres/...
-RUN go build -tags nozstd -v -o ./connector ./materialize-postgres/...
+# RUN go test  -tags nozstd,nodb -v ./materialize-postgres/...
+RUN --mount=type=cache,id=gomod,target=/go/pkg/mod \
+    --mount=type=cache,id=gobuild,target=/root/.cache/go-build \
+    go build -tags nozstd -v -o ./connector ./materialize-postgres/...
 
 # Runtime Stage
 ################################################################################
@@ -39,6 +41,6 @@ COPY --from=ghcr.io/estuary/network-tunnel:dev /flow-network-tunnel /usr/bin/flo
 # Avoid running the connector as root.
 USER nonroot:nonroot
 
-LABEL FLOW_RUNTIME_PROTOCOL=materialize
+LABEL FLOW_RUNTIME_CODEC=json FLOW_RUNTIME_PROTOCOL=materialize
 
 ENTRYPOINT ["/connector/materialize-postgres"]

--- a/materialize-postgres/config_test.go
+++ b/materialize-postgres/config_test.go
@@ -6,8 +6,7 @@ import (
 	"testing"
 
 	"github.com/bradleyjkemp/cupaloy"
-	pf "github.com/estuary/flow/go/protocols/flow"
-	pm "github.com/estuary/flow/go/protocols/materialize"
+	protocol "github.com/estuary/connectors/go/protocol"
 	"github.com/stretchr/testify/require"
 )
 
@@ -43,7 +42,7 @@ func TestPostgresConfig(t *testing.T) {
 
 func TestSpecification(t *testing.T) {
 	var resp, err = newPostgresDriver().
-		Spec(context.Background(), &pm.SpecRequest{EndpointType: pf.EndpointType_AIRBYTE_SOURCE})
+		Spec(context.Background(), protocol.SpecRequest{})
 	require.NoError(t, err)
 
 	formatted, err := json.MarshalIndent(resp, "", "  ")

--- a/materialize-postgres/driver_test.go
+++ b/materialize-postgres/driver_test.go
@@ -11,7 +11,7 @@ import (
 	"testing"
 	"time"
 
-	sql "github.com/estuary/connectors/materialize-sql"
+	sql "github.com/estuary/connectors/materialize-sql-json"
 )
 
 func TestFencingCases(t *testing.T) {

--- a/materialize-postgres/sqlgen_test.go
+++ b/materialize-postgres/sqlgen_test.go
@@ -15,27 +15,27 @@ import (
 )
 
 func TestSQLGeneration(t *testing.T) {
-	var spec *sqlDriver.StoredSpec
+	var bindings []protocol.ApplyBinding
 	require.NoError(t, testsupport.CatalogExtract(t, "testdata/flow.yaml",
 		func(db *sql.DB) error {
 			var err error
-			spec, err = testsupport.BindingsFromCatalog(db, "test/sqlite")
+			bindings, err = testsupport.BindingsFromCatalog(db, "test/sqlite")
 			return err
 		}))
 
 	// TODO(whb): These keys are manually set as "nullable" for now to test the query generation
 	// with nullable keys. Once flow supports nullable keys natively, this should be cleaned up.
-	spec.Bindings[0].Collection.Projections[7].Inference.Exists = protocol.MayExist
-	spec.Bindings[0].Collection.Projections[7].Inference.Types = append(spec.Bindings[0].Collection.Projections[7].Inference.Types, "null")
-	spec.Bindings[1].Collection.Projections[2].Inference.Exists = protocol.MayExist
-	spec.Bindings[1].Collection.Projections[2].Inference.Types = append(spec.Bindings[1].Collection.Projections[2].Inference.Types, "null")
+	bindings[0].Collection.Projections[7].Inference.Exists = protocol.MayExist
+	bindings[0].Collection.Projections[7].Inference.Types = append(bindings[0].Collection.Projections[7].Inference.Types, "null")
+	bindings[1].Collection.Projections[2].Inference.Exists = protocol.MayExist
+	bindings[1].Collection.Projections[2].Inference.Types = append(bindings[1].Collection.Projections[2].Inference.Types, "null")
 
-	var shape1 = sqlDriver.BuildTableShape(spec, 0, tableConfig{
+	var shape1 = sqlDriver.BuildTableShape("first", bindings, 0, tableConfig{
 		Schema: "a-schema",
 		Table:  "target_table",
 		Delta:  false,
 	})
-	var shape2 = sqlDriver.BuildTableShape(spec, 1, tableConfig{
+	var shape2 = sqlDriver.BuildTableShape("second", bindings, 1, tableConfig{
 		Schema: "",
 		Table:  "Delta Updates",
 		Delta:  true,

--- a/materialize-postgres/sqlgen_test.go
+++ b/materialize-postgres/sqlgen_test.go
@@ -2,32 +2,32 @@ package main
 
 import (
 	"database/sql"
+	"encoding/base64"
 	"strings"
 	"testing"
 	"text/template"
 
 	"github.com/bradleyjkemp/cupaloy"
-	sqlDriver "github.com/estuary/connectors/materialize-sql"
+	"github.com/estuary/connectors/go/protocol"
+	sqlDriver "github.com/estuary/connectors/materialize-sql-json"
 	"github.com/estuary/connectors/testsupport"
-	"github.com/estuary/flow/go/protocols/catalog"
-	pf "github.com/estuary/flow/go/protocols/flow"
 	"github.com/stretchr/testify/require"
 )
 
 func TestSQLGeneration(t *testing.T) {
-	var spec *pf.MaterializationSpec
+	var spec *sqlDriver.StoredSpec
 	require.NoError(t, testsupport.CatalogExtract(t, "testdata/flow.yaml",
 		func(db *sql.DB) error {
 			var err error
-			spec, err = catalog.LoadMaterialization(db, "test/sqlite")
+			spec, err = testsupport.BindingsFromCatalog(db, "test/sqlite")
 			return err
 		}))
 
 	// TODO(whb): These keys are manually set as "nullable" for now to test the query generation
 	// with nullable keys. Once flow supports nullable keys natively, this should be cleaned up.
-	spec.Bindings[0].Collection.Projections[7].Inference.Exists = pf.Inference_MAY
+	spec.Bindings[0].Collection.Projections[7].Inference.Exists = protocol.MayExist
 	spec.Bindings[0].Collection.Projections[7].Inference.Types = append(spec.Bindings[0].Collection.Projections[7].Inference.Types, "null")
-	spec.Bindings[1].Collection.Projections[2].Inference.Exists = pf.Inference_MAY
+	spec.Bindings[1].Collection.Projections[2].Inference.Exists = protocol.MayExist
 	spec.Bindings[1].Collection.Projections[2].Inference.Types = append(spec.Bindings[1].Collection.Projections[2].Inference.Types, "null")
 
 	var shape1 = sqlDriver.BuildTableShape(spec, 0, tableConfig{
@@ -71,9 +71,9 @@ func TestSQLGeneration(t *testing.T) {
 
 	var fence = sqlDriver.Fence{
 		TablePath:       sqlDriver.TablePath{"path", "To", "checkpoints"},
-		Checkpoint:      []byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
+		Checkpoint:      base64.StdEncoding.EncodeToString([]byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9}),
 		Fence:           123,
-		Materialization: pf.Materialization("some/Materialization"),
+		Materialization: "some/Materialization",
 		KeyBegin:        0x00112233,
 		KeyEnd:          0xffeeddcc,
 	}
@@ -90,11 +90,11 @@ func TestSQLGeneration(t *testing.T) {
 
 func TestDateTimeColumn(t *testing.T) {
 	var mapped, err = pgDialect.MapType(&sqlDriver.Projection{
-		Projection: pf.Projection{
-			Inference: pf.Inference{
+		Projection: &protocol.Projection{
+			Inference: protocol.Inference{
 				Types:   []string{"string"},
-				String_: &pf.Inference_String{Format: "date-time"},
-				Exists:  pf.Inference_MUST,
+				String_: &protocol.StringInference{Format: "date-time"},
+				Exists:  protocol.MustExist,
 			},
 		},
 	})

--- a/materialize-sql-json/.snapshots/TestAlterColumnNullableTemplate
+++ b/materialize-sql-json/.snapshots/TestAlterColumnNullableTemplate
@@ -1,0 +1,3 @@
+
+  ALTER TABLE one."reserved".checkpoints ALTER COLUMN id DROP NOT NULL;
+  

--- a/materialize-sql-json/.snapshots/TestTableTemplate
+++ b/materialize-sql-json/.snapshots/TestTableTemplate
@@ -1,0 +1,18 @@
+
+	CREATE TABLE one."reserved".checkpoints (
+			materialization TEXT,
+			key_begin BIGINT,
+			key_end BIGINT,
+			fence BIGINT,
+			checkpoint TEXT,
+			PRIMARY KEY (materialization, key_begin, key_end)
+		
+	);
+
+	COMMENT ON TABLE one."reserved".checkpoints IS 'This table holds Flow processing checkpoints used for exactly-once processing of materializations';
+	COMMENT ON COLUMN one."reserved".checkpoints.materialization IS 'The name of the materialization.';
+	COMMENT ON COLUMN one."reserved".checkpoints.key_begin IS 'The inclusive lower-bound key hash covered by this checkpoint.';
+	COMMENT ON COLUMN one."reserved".checkpoints.key_end IS 'The inclusive upper-bound key hash covered by this checkpoint.';
+	COMMENT ON COLUMN one."reserved".checkpoints.fence IS 'This nonce is used to uniquely identify unique process assignments of a shard and prevent them from conflicting.';
+	COMMENT ON COLUMN one."reserved".checkpoints.checkpoint IS 'Checkpoint of the Flow consumer shard, encoded as base64 protobuf.';
+	

--- a/materialize-sql-json/.snapshots/TestTableTemplate
+++ b/materialize-sql-json/.snapshots/TestTableTemplate
@@ -1,10 +1,10 @@
 
 	CREATE TABLE one."reserved".checkpoints (
-			materialization TEXT,
-			key_begin BIGINT,
-			key_end BIGINT,
-			fence BIGINT,
-			checkpoint TEXT,
+			materialization TEXT NOT NULL,
+			key_begin BIGINT NOT NULL,
+			key_end BIGINT NOT NULL,
+			fence BIGINT NOT NULL,
+			checkpoint TEXT NOT NULL,
 			PRIMARY KEY (materialization, key_begin, key_end)
 		
 	);

--- a/materialize-sql-json/CHANGELOG.md
+++ b/materialize-sql-json/CHANGELOG.md
@@ -1,0 +1,5 @@
+# materialize-sql
+
+## v1, 2022-09-20
+
+- Beginning of changelog.

--- a/materialize-sql-json/dialect.go
+++ b/materialize-sql-json/dialect.go
@@ -1,0 +1,110 @@
+package sql
+
+import (
+	"regexp"
+	"strings"
+)
+
+// Dialect encapsulates many specifics of an Endpoint's interpretation of SQL.
+type Dialect struct {
+	Identifierer
+	Literaler
+	Placeholderer
+	TypeMapper
+}
+
+// Identifierer takes path components and returns a raw SQL identifier for the
+// Endpoint with necessary quoting applied.
+type Identifierer interface {
+	Identifier(path ...string) string
+}
+
+// Literaler takes a string and returns a raw SQL literal for the Endpoint
+// with required quoting and escaping already applied.
+type Literaler interface {
+	Literal(str string) string
+}
+
+// Placeholderer returns the appropriate Endpoint placeholder representation
+// for a parameter at the given zero-offset index.
+type Placeholderer interface {
+	Placeholder(index int) string
+}
+
+// A TypeMapper is a function that maps a Projection into a MappedType.
+// For example, it might map a `string` Projection into a `TEXT` SQL type.
+type TypeMapper interface {
+	MapType(*Projection) (MappedType, error)
+}
+
+// IdentifierFn is a function that implements Identifierer.
+type IdentifierFn func(path ...string) string
+
+func (f IdentifierFn) Identifier(path ...string) string { return f(path...) }
+
+// LiteralFn is a function that implements Literaler.
+type LiteralFn func(s string) string
+
+func (f LiteralFn) Literal(str string) string { return f(str) }
+
+// PlaceholderFn is a function that implements Placeholderer.
+type PlaceholderFn func(index int) string
+
+func (f PlaceholderFn) Placeholder(index int) string { return f(index) }
+
+// TypeMapperFn is a function that implements TypeMapper.
+type TypeMapperFn func(*Projection) (MappedType, error)
+
+func (f TypeMapperFn) MapType(p *Projection) (MappedType, error) { return f(p) }
+
+// Compile-time check that wrapping functions with typed  Fn() implementations
+// can be used to build a Dialect.
+var _ = Dialect{
+	Placeholderer: PlaceholderFn(func(index int) string { return "" }),
+	Literaler:     LiteralFn(func(s string) string { return "" }),
+	Identifierer:  IdentifierFn(func(path ...string) string { return "" }),
+	TypeMapper:    &NullableMapper{},
+}
+
+// PassThroughTransform returns a function that evaluates `if_` over its input
+// and, if true, returns its input unmodified. Otherwise it returns the
+// result of `else_` over its input.
+func PassThroughTransform(
+	if_ func(string) bool,
+	else_ func(string) string,
+) func(string) string {
+	return func(s string) string {
+		if if_(s) {
+			return s
+		}
+		return else_(s)
+	}
+}
+
+// IsSimpleIdentifier returns true on identifier components that typically do not need quoting:
+// strings having only lower-case letters, decimal numbers, and underscore.
+var IsSimpleIdentifier = regexp.MustCompile(`^[_\p{Ll}]+[_\p{Ll}\p{Nd}]*$`).MatchString
+
+// QuoteTransform returns a function that wraps its input with `quote` on either side,
+// and replaces all occurrences of `quote` _within_ the string with `escape`.
+func QuoteTransform(quote string, escape string) func(string) string {
+	return func(s string) string {
+		return quote + strings.ReplaceAll(s, quote, escape) + quote
+	}
+}
+
+// JoinTransform returns a function that takes component `parts` and processes
+// each through the `delegate` transform.
+// Then, it joins their results around `joiner`.
+func JoinTransform(
+	joiner string,
+	delegate func(string) string,
+) func(parts ...string) string {
+	return func(parts ...string) string {
+		var cp = make([]string, len(parts))
+		for i := range parts {
+			cp[i] = delegate(parts[i])
+		}
+		return strings.Join(cp, joiner)
+	}
+}

--- a/materialize-sql-json/driver.go
+++ b/materialize-sql-json/driver.go
@@ -34,10 +34,10 @@ type Driver struct {
 // StoredSpec is a record of the materialization bindings that will be stored in the sql
 // endpoint of the materialization. It is used to validate proposed changes to the bindings of the
 // materialization.
-type StoredSpec struct {
-	Materialization string                  `json:"materialization"`
-	Bindings        []protocol.ApplyBinding `json:"bindings"`
-}
+// type StoredSpec struct {
+// 	Materialization string                  `json:"materialization"`
+// 	Bindings        []protocol.ApplyBinding `json:"bindings"`
+// }
 
 var _ boilerplate.Driver = &Driver{}
 
@@ -60,15 +60,15 @@ func (d *Driver) Spec(ctx context.Context, req protocol.SpecRequest) (*protocol.
 
 func (d *Driver) Validate(ctx context.Context, req protocol.ValidateRequest) (*protocol.ValidateResponse, error) {
 	var (
-		err        error
-		endpoint   *Endpoint
-		loadedSpec *StoredSpec
-		resp       = new(protocol.ValidateResponse)
+		err            error
+		endpoint       *Endpoint
+		loadedBindings []protocol.ApplyBinding
+		resp           = new(protocol.ValidateResponse)
 	)
 
 	if endpoint, err = d.NewEndpoint(ctx, req.Config); err != nil {
 		return nil, fmt.Errorf("building endpoint: %w", err)
-	} else if loadedSpec, _, err = loadSpec(ctx, endpoint, req.Name); err != nil {
+	} else if loadedBindings, _, err = loadBindings(ctx, endpoint, req.Name); err != nil {
 		return nil, fmt.Errorf("loading current applied materialization spec: %w", err)
 	}
 
@@ -78,7 +78,7 @@ func (d *Driver) Validate(ctx context.Context, req protocol.ValidateRequest) (*p
 			endpoint,
 			bindingSpec.ResourceConfig,
 			bindingSpec.Collection,
-			loadedSpec,
+			loadedBindings,
 		)
 		if err != nil {
 			return nil, err
@@ -105,23 +105,18 @@ func (d *Driver) Apply(ctx context.Context, req protocol.ApplyRequest) (*protoco
 	}
 
 	var (
-		endpoint      *Endpoint
-		loadedSpec    *StoredSpec
-		loadedVersion string
-		specBytes     []byte
-		err           error
+		endpoint         *Endpoint
+		loadedBindings   []protocol.ApplyBinding
+		loadedVersion    string
+		reqBindingsBytes []byte
+		err              error
 	)
-
-	applyReq := StoredSpec{
-		Materialization: req.Name,
-		Bindings:        req.Bindings,
-	}
 
 	if endpoint, err = d.NewEndpoint(ctx, req.Config); err != nil {
 		return nil, fmt.Errorf("building endpoint: %w", err)
-	} else if loadedSpec, loadedVersion, err = loadSpec(ctx, endpoint, req.Name); err != nil {
+	} else if loadedBindings, loadedVersion, err = loadBindings(ctx, endpoint, req.Name); err != nil {
 		return nil, fmt.Errorf("loading prior applied materialization spec: %w", err)
-	} else if specBytes, err = json.Marshal(applyReq); err != nil {
+	} else if reqBindingsBytes, err = json.Marshal(req.Bindings); err != nil {
 		panic(err) // Cannot fail to marshal.
 	}
 
@@ -146,13 +141,10 @@ func (d *Driver) Apply(ctx context.Context, req protocol.ApplyRequest) (*protoco
 			endpoint,
 			bindingSpec.ResourceConfig,
 			bindingSpec.Collection,
-			loadedSpec,
+			loadedBindings,
 		)
 
-		var tableShape = BuildTableShape(&StoredSpec{
-			Materialization: req.Name,
-			Bindings:        req.Bindings,
-		}, bindingIndex, resource)
+		var tableShape = BuildTableShape(req.Name, req.Bindings, bindingIndex, resource)
 
 		if err != nil {
 			return nil, err
@@ -222,10 +214,10 @@ func (d *Driver) Apply(ctx context.Context, req protocol.ApplyRequest) (*protoco
 	var args = []interface{}{
 		endpoint.Identifier(endpoint.MetaSpecs.Path...),
 		endpoint.Literal(req.Version),
-		endpoint.Literal(base64.StdEncoding.EncodeToString(specBytes)),
+		endpoint.Literal(base64.StdEncoding.EncodeToString(reqBindingsBytes)),
 		endpoint.Literal(req.Name),
 	}
-	if loadedSpec == nil {
+	if loadedBindings == nil {
 		statements = append(statements, fmt.Sprintf(
 			"INSERT INTO %[1]s (version, spec, materialization) VALUES (%[2]s, %[3]s, %[4]s);", args...))
 	} else {
@@ -245,15 +237,15 @@ func (d *Driver) Apply(ctx context.Context, req protocol.ApplyRequest) (*protoco
 
 func (d *Driver) applyDelete(ctx context.Context, req protocol.ApplyRequest) (*protocol.ApplyResponse, error) {
 	var (
-		endpoint      *Endpoint
-		loadedSpec    *StoredSpec
-		loadedVersion string
-		err           error
+		endpoint       *Endpoint
+		loadedBindings []protocol.ApplyBinding
+		loadedVersion  string
+		err            error
 	)
 
 	if endpoint, err = d.NewEndpoint(ctx, req.Config); err != nil {
 		return nil, fmt.Errorf("building endpoint: %w", err)
-	} else if loadedSpec, loadedVersion, err = loadSpec(ctx, endpoint, req.Name); err != nil {
+	} else if loadedBindings, loadedVersion, err = loadBindings(ctx, endpoint, req.Name); err != nil {
 		return nil, fmt.Errorf("loading prior applied materialization spec: %w", err)
 	} else if loadedVersion == "" {
 		return &protocol.ApplyResponse{
@@ -283,10 +275,10 @@ func (d *Driver) applyDelete(ctx context.Context, req protocol.ApplyRequest) (*p
 	}
 
 	// Drop all bound tables.
-	for _, bindingSpec := range loadedSpec.Bindings {
+	for _, binding := range loadedBindings {
 		statements = append(statements, fmt.Sprintf(
 			"DROP TABLE IF EXISTS %s;",
-			endpoint.Identifier(bindingSpec.ResourcePath...)))
+			endpoint.Identifier(binding.ResourcePath...)))
 	}
 
 	if req.DryRun {
@@ -305,7 +297,7 @@ func (d *Driver) Open(ctx context.Context, req protocol.OpenRequest) (*protocol.
 	var endpoint, err = d.NewEndpoint(ctx, req.Config)
 	if err != nil {
 		return nil, fmt.Errorf("building endpoint: %w", err)
-	} else if _, loadedVersion, err = loadSpec(ctx, endpoint, req.Name); err != nil {
+	} else if _, loadedVersion, err = loadBindings(ctx, endpoint, req.Name); err != nil {
 		return nil, fmt.Errorf("loading prior applied materialization spec: %w", err)
 	} else if loadedVersion == "" {
 		return nil, fmt.Errorf("materialization has not been applied")
@@ -322,10 +314,7 @@ func (d *Driver) Open(ctx context.Context, req protocol.OpenRequest) (*protocol.
 		if err := protocol.UnmarshalStrict(binding.ResourceConfig, resource); err != nil {
 			return nil, fmt.Errorf("resource binding for collection %q: %w", binding.Collection.Name, err)
 		}
-		var shape = BuildTableShape(&StoredSpec{
-			Materialization: req.Name,
-			Bindings:        req.Bindings,
-		}, index, resource)
+		var shape = BuildTableShape(req.Name, req.Bindings, index, resource)
 
 		if table, err := ResolveTable(shape, endpoint.Dialect); err != nil {
 			return nil, err

--- a/materialize-sql-json/driver.go
+++ b/materialize-sql-json/driver.go
@@ -1,0 +1,352 @@
+package sql
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	schemagen "github.com/estuary/connectors/go-schema-gen"
+	pf "github.com/estuary/flow/go/protocols/flow"
+	pm "github.com/estuary/flow/go/protocols/materialize"
+)
+
+// Driver implements the pm.DriverServer interface.
+type Driver struct {
+	// URL at which documentation for the driver may be found.
+	DocumentationURL string
+	// Instance of the type into which endpoint specifications are parsed.
+	EndpointSpecType interface{}
+	// Instance of the type into which resource specifications are parsed.
+	ResourceSpecType Resource
+	// NewEndpoint returns an *Endpoint which will be used to handle interactions with the database.
+	NewEndpoint func(_ context.Context, endpointConfig json.RawMessage) (*Endpoint, error)
+}
+
+var _ pm.DriverServer = &Driver{}
+
+// Spec implements the DriverServer interface.
+func (d *Driver) Spec(ctx context.Context, req *pm.SpecRequest) (*pm.SpecResponse, error) {
+	var endpoint, resource []byte
+
+	if err := req.Validate(); err != nil {
+		return nil, fmt.Errorf("validating request: %w", err)
+	} else if endpoint, err = schemagen.GenerateSchema("SQL Connection", d.EndpointSpecType).MarshalJSON(); err != nil {
+		return nil, fmt.Errorf("generating endpoint schema: %w", err)
+	} else if resource, err = schemagen.GenerateSchema("SQL Table", d.ResourceSpecType).MarshalJSON(); err != nil {
+		return nil, fmt.Errorf("generating resource schema: %w", err)
+	}
+
+	return &pm.SpecResponse{
+		EndpointSpecSchemaJson: json.RawMessage(endpoint),
+		ResourceSpecSchemaJson: json.RawMessage(resource),
+		DocumentationUrl:       d.DocumentationURL,
+	}, nil
+}
+
+// Validate implements the DriverServer interface.
+func (d *Driver) Validate(ctx context.Context, req *pm.ValidateRequest) (*pm.ValidateResponse, error) {
+	var (
+		err        error
+		endpoint   *Endpoint
+		loadedSpec *pf.MaterializationSpec
+		resp       = new(pm.ValidateResponse)
+	)
+
+	if err = req.Validate(); err != nil {
+		return nil, fmt.Errorf("validating request: %w", err)
+	} else if endpoint, err = d.NewEndpoint(ctx, req.EndpointSpecJson); err != nil {
+		return nil, fmt.Errorf("building endpoint: %w", err)
+	} else if loadedSpec, _, err = loadSpec(ctx, endpoint, req.Materialization); err != nil {
+		return nil, fmt.Errorf("loading current applied materialization spec: %w", err)
+	}
+
+	// Produce constraints for each request binding, in turn.
+	for _, bindingSpec := range req.Bindings {
+		var constraints, _, resource, err = resolveResourceToExistingBinding(
+			endpoint,
+			bindingSpec.ResourceSpecJson,
+			&bindingSpec.Collection,
+			loadedSpec,
+		)
+		if err != nil {
+			return nil, err
+		}
+
+		resp.Bindings = append(resp.Bindings,
+			&pm.ValidateResponse_Binding{
+				Constraints:  constraints,
+				DeltaUpdates: resource.DeltaUpdates(),
+				ResourcePath: resource.Path(),
+			})
+	}
+	return resp, nil
+}
+
+// ApplyUpsert implements the DriverServer interface.
+func (d *Driver) ApplyUpsert(ctx context.Context, req *pm.ApplyRequest) (*pm.ApplyResponse, error) {
+	var (
+		endpoint      *Endpoint
+		loadedSpec    *pf.MaterializationSpec
+		loadedVersion string
+		specBytes     []byte
+		err           error
+	)
+
+	if err = req.Validate(); err != nil {
+		return nil, fmt.Errorf("validating request: %w", err)
+	} else if endpoint, err = d.NewEndpoint(ctx, req.Materialization.EndpointSpecJson); err != nil {
+		return nil, fmt.Errorf("building endpoint: %w", err)
+	} else if loadedSpec, loadedVersion, err = loadSpec(ctx, endpoint, req.Materialization.Materialization); err != nil {
+		return nil, fmt.Errorf("loading prior applied materialization spec: %w", err)
+	} else if specBytes, err = req.Materialization.Marshal(); err != nil {
+		panic(err) // Cannot fail to marshal.
+	}
+
+	if loadedVersion == req.Version {
+		// A re-application of the current version is a no-op.
+		return new(pm.ApplyResponse), nil
+	}
+
+	// The Materialization specifications meta table is always required.
+	// The Checkpoints table is optional; include it if set by the Endpoint.
+	var tableShapes = []TableShape{endpoint.MetaSpecs}
+	if endpoint.MetaCheckpoints != nil {
+		tableShapes = append(tableShapes, *endpoint.MetaCheckpoints)
+	}
+
+	var statements []string
+
+	for bindingIndex, bindingSpec := range req.Materialization.Bindings {
+		var collection = bindingSpec.Collection.Collection
+		var constraints, loadedBinding, resource, err = resolveResourceToExistingBinding(
+			endpoint,
+			bindingSpec.ResourceSpecJson,
+			&bindingSpec.Collection,
+			loadedSpec,
+		)
+
+		var tableShape = BuildTableShape(req.Materialization, bindingIndex, resource)
+
+		if err != nil {
+			return nil, err
+		} else if err = ValidateSelectedFields(constraints, bindingSpec); err != nil {
+			// The applied binding is not a valid solution for its own constraints.
+			return nil, fmt.Errorf("binding for %s: %w", collection, err)
+		} else if loadedBinding != nil && !bindingSpec.FieldSelection.Equal(&loadedBinding.FieldSelection) {
+			// We don't handle any form of schema migrations, so we require that the list of
+			// fields in the request is identical to the current fields.
+			return nil, fmt.Errorf(
+				"the set of binding %s fields in the request differs from the existing fields,"+
+					"which is disallowed because this driver does not perform schema migrations. "+
+					"Request fields: %s , Existing fields: %s",
+				collection,
+				bindingSpec.FieldSelection.String(),
+				loadedBinding.FieldSelection.String(),
+			)
+		} else if loadedBinding != nil {
+			// If the table has already been created, make sure all non-null fields
+			// are marked as such
+			for _, field := range bindingSpec.FieldSelection.Values {
+				var p = bindingSpec.Collection.GetProjection(field)
+				var previousProjection = loadedBinding.Collection.GetProjection(field)
+
+				var previousNullable = previousProjection.Inference.Exists != pf.Inference_MUST || SliceContains("null", p.Inference.Types)
+				var newNullable = p.Inference.Exists != pf.Inference_MUST || SliceContains("null", p.Inference.Types)
+
+				if !previousNullable && newNullable {
+					var table, err = ResolveTable(tableShape, endpoint.Dialect)
+					if err != nil {
+						return nil, err
+					}
+					var input = AlterColumnNullableInput {
+						Table: table,
+						Identifier: field,
+					}
+					if statement, err := RenderAlterColumnNullableTemplate(input, endpoint.AlterColumnNullableTemplate); err != nil {
+						return nil, err
+					} else {
+						statements = append(statements, statement)
+					}
+				}
+			}
+
+			continue
+		}
+
+		tableShapes = append(tableShapes, tableShape)
+	}
+
+	for _, shape := range tableShapes {
+		var table, err = ResolveTable(shape, endpoint.Dialect)
+		if err != nil {
+			return nil, err
+		} else if statement, err := RenderTableTemplate(table, endpoint.CreateTableTemplate); err != nil {
+			return nil, err
+		} else {
+			statements = append(statements, statement)
+		}
+
+		if shape.AdditionalSql != "" {
+			statements = append(statements, shape.AdditionalSql)
+		}
+	}
+
+	// Insert or update the materialization specification.
+	var args = []interface{}{
+		endpoint.Identifier(endpoint.MetaSpecs.Path...),
+		endpoint.Literal(req.Version),
+		endpoint.Literal(base64.StdEncoding.EncodeToString(specBytes)),
+		endpoint.Literal(req.Materialization.Materialization.String()),
+	}
+	if loadedSpec == nil {
+		statements = append(statements, fmt.Sprintf(
+			"INSERT INTO %[1]s (version, spec, materialization) VALUES (%[2]s, %[3]s, %[4]s);", args...))
+	} else {
+		statements = append(statements, fmt.Sprintf(
+			"UPDATE %[1]s SET version = %[2]s, spec = %[3]s WHERE materialization = %[4]s;", args...))
+	}
+
+	if req.DryRun {
+		// No-op.
+	} else if err = endpoint.Client.ExecStatements(ctx, statements); err != nil {
+		return nil, fmt.Errorf("applying schema updates: %w", err)
+	}
+
+	// Build and return a description of what happened (or would have happened).
+	return &pm.ApplyResponse{ActionDescription: strings.Join(statements, "\n")}, nil
+}
+
+// ApplyDelete implements the DriverServer interface.
+func (d *Driver) ApplyDelete(ctx context.Context, req *pm.ApplyRequest) (*pm.ApplyResponse, error) {
+	var (
+		endpoint      *Endpoint
+		loadedVersion string
+		err           error
+	)
+
+	if err = req.Validate(); err != nil {
+		return nil, fmt.Errorf("validating request: %w", err)
+	} else if endpoint, err = d.NewEndpoint(ctx, req.Materialization.EndpointSpecJson); err != nil {
+		return nil, fmt.Errorf("building endpoint: %w", err)
+	} else if _, loadedVersion, err = loadSpec(ctx, endpoint, req.Materialization.Materialization); err != nil {
+		return nil, fmt.Errorf("loading prior applied materialization spec: %w", err)
+	} else if loadedVersion == "" {
+		return &pm.ApplyResponse{
+			ActionDescription: "Could not find materialization in the database. " +
+				"Doing nothing, on the assumption that the table was manually dropped.",
+		}, nil
+	} else if loadedVersion != req.Version {
+		return nil, fmt.Errorf(
+			"applied and current materializations are different versions (applied: %s vs current: %s)",
+			loadedVersion, req.Version)
+	}
+
+	var materialization = req.Materialization.Materialization.String()
+
+	// Delete the materialization from the specs metadata table,
+	// and also the checkpoints table if it exists.
+	var statements = []string{
+		fmt.Sprintf("DELETE FROM %s WHERE materialization = %s AND version = %s;",
+			endpoint.Identifier(endpoint.MetaSpecs.Path...),
+			endpoint.Literal(materialization),
+			endpoint.Literal(req.Version)),
+	}
+	if endpoint.MetaCheckpoints != nil {
+		statements = append(statements,
+			fmt.Sprintf("DELETE FROM %s WHERE materialization = %s;",
+				endpoint.Identifier(endpoint.MetaCheckpoints.Path...),
+				endpoint.Literal(materialization)),
+		)
+	}
+
+	// Drop all bound tables.
+	for _, bindingSpec := range req.Materialization.Bindings {
+		statements = append(statements, fmt.Sprintf(
+			"DROP TABLE IF EXISTS %s;",
+			endpoint.Identifier(bindingSpec.ResourcePath...)))
+	}
+
+	if req.DryRun {
+		// No-op.
+	} else if err = endpoint.Client.ExecStatements(ctx, statements); err != nil {
+		return nil, fmt.Errorf("removing dropped tables: %w", err)
+	}
+
+	// Build and return a description of what happened (or would have happened).
+	return &pm.ApplyResponse{ActionDescription: strings.Join(statements, "\n")}, nil
+}
+
+// Transactions implements the DriverServer interface.
+func (d *Driver) Transactions(stream pm.Driver_TransactionsServer) error {
+	return pm.RunTransactions(stream, d.newTransactor)
+}
+
+func (d *Driver) newTransactor(ctx context.Context, open pm.TransactionRequest_Open) (pm.Transactor, *pm.TransactionResponse_Opened, error) {
+	var loadedVersion string
+
+	var endpoint, err = d.NewEndpoint(ctx, open.Materialization.EndpointSpecJson)
+	if err != nil {
+		return nil, nil, fmt.Errorf("building endpoint: %w", err)
+	} else if _, loadedVersion, err = loadSpec(ctx, endpoint, open.Materialization.Materialization); err != nil {
+		return nil, nil, fmt.Errorf("loading prior applied materialization spec: %w", err)
+	} else if loadedVersion == "" {
+		return nil, nil, fmt.Errorf("materialization has not been applied")
+	} else if loadedVersion != open.Version {
+		return nil, nil, fmt.Errorf(
+			"applied and current materializations are different versions (applied: %s vs current: %s)",
+			loadedVersion, open.Version)
+	}
+
+	var tables []Table
+	for index, spec := range open.Materialization.Bindings {
+		var resource = endpoint.NewResource(endpoint)
+
+		if err := pf.UnmarshalStrict(spec.ResourceSpecJson, resource); err != nil {
+			return nil, nil, fmt.Errorf("resource binding for collection %q: %w", spec.Collection.Collection, err)
+		}
+		var shape = BuildTableShape(open.Materialization, index, resource)
+
+		if table, err := ResolveTable(shape, endpoint.Dialect); err != nil {
+			return nil, nil, err
+		} else {
+			tables = append(tables, table)
+		}
+	}
+
+	var fence = Fence{
+		TablePath:       nil, // Set later iff endpoint.MetaCheckpoints != nil.
+		Materialization: open.Materialization.Materialization,
+		KeyBegin:        open.KeyBegin,
+		KeyEnd:          open.KeyEnd,
+		Fence:           0,
+		Checkpoint:      nil, // Set later iff endpoint.MetaCheckpoints != nil.
+	}
+
+	if endpoint.MetaCheckpoints != nil {
+		// We must install a fence to prevent another (zombie) instances of this
+		// materialization from committing further transactions.
+		var metaCheckpoints, err = ResolveTable(*endpoint.MetaCheckpoints, endpoint.Dialect)
+		if err != nil {
+			return nil, nil, fmt.Errorf("resolving checkpoints table: %w", err)
+		}
+
+		// Initialize a checkpoint such that the materialization starts from scratch,
+		// regardless of the recovery log checkpoint.
+		fence.TablePath = endpoint.MetaCheckpoints.Path
+		fence.Checkpoint = pm.ExplicitZeroCheckpoint
+
+		fence, err = endpoint.Client.InstallFence(ctx, metaCheckpoints, fence)
+		if err != nil {
+			return nil, nil, fmt.Errorf("installing checkpoints fence: %w", err)
+		}
+	}
+
+	transactor, err := endpoint.NewTransactor(ctx, endpoint, fence, tables)
+	if err != nil {
+		return nil, nil, fmt.Errorf("building transactor: %w", err)
+	}
+
+	return transactor, &pm.TransactionResponse_Opened{RuntimeCheckpoint: fence.Checkpoint}, nil
+}

--- a/materialize-sql-json/endpoint.go
+++ b/materialize-sql-json/endpoint.go
@@ -1,0 +1,173 @@
+package sql
+
+import (
+	"context"
+	"database/sql"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"text/template"
+	"time"
+
+	pf "github.com/estuary/flow/go/protocols/flow"
+	pm "github.com/estuary/flow/go/protocols/materialize"
+	"github.com/sirupsen/logrus"
+)
+
+type Client interface {
+	// FetchSpecAndVersion retrieves the materialization from Table `specs`,
+	// or returns sql.ErrNoRows if no such spec exists.
+	FetchSpecAndVersion(ctx context.Context, specs Table, materialization pf.Materialization) (specB64, version string, _ error)
+	ExecStatements(ctx context.Context, statements []string) error
+	InstallFence(ctx context.Context, checkpoints Table, fence Fence) (Fence, error)
+}
+
+// Resource is a driver-provided type which represents the SQL resource
+// (for example, a table) bound to by a binding.
+type Resource interface {
+	// Validate returns an error if the Resource is malformed.
+	Validate() error
+	// Path returns the fully qualified name of the resource, as '.'-separated components.
+	Path() TablePath
+	// Get any user-defined additional SQL to be executed transactionally with table creation.
+	GetAdditionalSql() string
+	// DeltaUpdates is true if the resource should be materialized using delta updates.
+	DeltaUpdates() bool
+}
+
+// Fence is an installed barrier in a shared checkpoints table which prevents
+// other sessions from committing transactions under the fenced ID,
+// and prevents this Fence from committing where another session has in turn
+// fenced this instance off.
+type Fence struct {
+	// TablePath of the checkpoints table in which this Fence lives.
+	TablePath TablePath
+	// Full name of the fenced Materialization.
+	Materialization pf.Materialization
+	// [KeyBegin, KeyEnd) identify the range of keys covered by this Fence.
+	KeyBegin uint32
+	KeyEnd   uint32
+	// Fence is the current value of the monotonically increasing integer used
+	// to order and isolate instances of the Transactions RPCs.
+	// If fencing is not supported, Fence is zero.
+	Fence int64
+	// Checkpoint associated with this Fence.
+	// A zero-length Checkpoint indicates that the Endpoint is unable to supply
+	// a Checkpoint and that the recovery-log Checkpoint should be used instead.
+	Checkpoint []byte
+}
+
+// Endpoint is a driver description of the SQL endpoint being driven.
+type Endpoint struct {
+	// Config is an implementation-specific type for the Endpoint configuration.
+	Config interface{}
+	// Dialect of the Endpoint.
+	Dialect
+	// MetaSpecs is the specification meta-table of the Endpoint.
+	MetaSpecs TableShape
+	// MetaCheckpoints is the checkpoints meta-table of the Endpoint.
+	// It's optional, and won't be created or used if it's nil.
+	MetaCheckpoints *TableShape
+	// Client provides Endpoint-specific methods for performing basic operations with the Endpoint
+	// store.
+	Client Client
+	// CreateTableTemplate evaluates a Table into an endpoint statement which creates it.
+	CreateTableTemplate *template.Template
+	// AlterFieldNullable alters a column and marks it as nullable
+	AlterColumnNullableTemplate *template.Template
+
+	// NewResource returns an uninitialized or partially-initialized Resource
+	// which will be parsed into and validated from a resource configuration.
+	NewResource func(*Endpoint) Resource
+	// NewTransactor returns a Transactor ready for pm.RunTransactions.
+	NewTransactor func(ctx context.Context, _ *Endpoint, _ Fence, bindings []Table) (pm.Transactor, error)
+}
+
+// loadSpec loads the named MaterializationSpec and its version that's stored within the Endpoint, if any.
+func loadSpec(ctx context.Context, endpoint *Endpoint, materialization pf.Materialization) (*pf.MaterializationSpec, string, error) {
+	var (
+		err              error
+		metaSpecs        Table
+		spec             = new(pf.MaterializationSpec)
+		specB64, version string
+	)
+
+	if metaSpecs, err = ResolveTable(endpoint.MetaSpecs, endpoint.Dialect); err != nil {
+		return nil, "", fmt.Errorf("resolving specifications table: %w", err)
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, time.Duration(10*time.Second))
+	defer cancel()
+
+	specB64, version, err = endpoint.Client.FetchSpecAndVersion(ctx, metaSpecs, materialization)
+
+	if err == sql.ErrNoRows {
+		return nil, "", nil
+	} else if err != nil {
+		logrus.WithFields(logrus.Fields{
+			"table": endpoint.MetaSpecs.Path,
+			"err":   err,
+		}).Info("failed to query materialization spec (the table may not be initialized?)")
+		return nil, "", nil
+	} else if specBytes, err := base64.StdEncoding.DecodeString(specB64); err != nil {
+		return nil, version, fmt.Errorf("base64.Decode: %w", err)
+	} else if err = spec.Unmarshal(specBytes); err != nil {
+		return nil, version, fmt.Errorf("spec.Unmarshal: %w", err)
+	} else if err = spec.Validate(); err != nil {
+		return nil, version, fmt.Errorf("validating spec: %w", err)
+	}
+
+	return spec, version, nil
+}
+
+// resolveResourceToExistingBinding identifies an existing binding of `loadedSpec`
+// which matches the parsed `resourceSpec`. It further identifies field constraints
+// of the resolved binding, and performs initial validation that the resource is
+// well-formed and is a valid transition for an existing binding (if present).
+func resolveResourceToExistingBinding(
+	endpoint *Endpoint,
+	resourceSpec json.RawMessage,
+	collection *pf.CollectionSpec,
+	loadedSpec *pf.MaterializationSpec,
+) (
+	constraints map[string]*pm.Constraint,
+	loadedBinding *pf.MaterializationSpec_Binding,
+	resource Resource,
+	err error,
+) {
+	resource = endpoint.NewResource(endpoint)
+
+	if err = pf.UnmarshalStrict(resourceSpec, resource); err != nil {
+		err = fmt.Errorf("resource binding for collection %q: %w", &collection.Collection, err)
+	} else if loadedBinding, err = findBinding(resource.Path(), collection.Collection, loadedSpec); err != nil {
+	} else if loadedBinding != nil && loadedBinding.DeltaUpdates && !resource.DeltaUpdates() {
+		// We allow a binding to switch from standard => delta updates but not the other way.
+		// This is because a standard materialization is trivially a valid delta-updates
+		// materialization, but a delta-updates table may have multiple instances of a given
+		// key and can no longer be loaded correctly by a standard materialization.
+		err = fmt.Errorf("cannot disable delta-updates binding of collection %s", collection.Collection)
+	} else if loadedBinding != nil {
+		constraints = ValidateMatchesExisting(loadedBinding, collection)
+	} else {
+		constraints = ValidateNewSQLProjections(resource, collection)
+	}
+
+	return
+}
+
+func findBinding(path TablePath, collection pf.Collection, spec *pf.MaterializationSpec) (*pf.MaterializationSpec_Binding, error) {
+	if spec == nil {
+		return nil, nil // Binding is trivially not found.
+	}
+	for i := range spec.Bindings {
+		var b = spec.Bindings[i]
+
+		if b.Collection.Collection == collection && path.equals(b.ResourcePath) {
+			return b, nil
+		} else if path.equals(b.ResourcePath) {
+			return nil, fmt.Errorf("cannot materialize %s to table %s because the table is already materializing collection %s",
+				path, &b.Collection.Collection, collection)
+		}
+	}
+	return nil, nil
+}

--- a/materialize-sql-json/endpoint.go
+++ b/materialize-sql-json/endpoint.go
@@ -83,12 +83,12 @@ type Endpoint struct {
 	NewTransactor func(ctx context.Context, _ *Endpoint, _ Fence, bindings []Table) (Transactor, error)
 }
 
-// loadSpec loads the named MaterializationSpec and its version that's stored within the Endpoint, if any.
-func loadSpec(ctx context.Context, endpoint *Endpoint, materialization string) (*StoredSpec, string, error) {
+// loadBindings loads the named MaterializationSpec and its version that's stored within the Endpoint, if any.
+func loadBindings(ctx context.Context, endpoint *Endpoint, materialization string) ([]protocol.ApplyBinding, string, error) {
 	var (
 		err              error
 		metaSpecs        Table
-		spec             = new(StoredSpec)
+		loadedBindings   []protocol.ApplyBinding
 		specB64, version string
 	)
 
@@ -113,39 +113,36 @@ func loadSpec(ctx context.Context, endpoint *Endpoint, materialization string) (
 		return nil, version, fmt.Errorf("base64.Decode: %w", err)
 		// TODO(whb): Replace unmarshalCompatible with json.Unmarshal once all sql materializations
 		// have converted to JSON protocol and have re-applied all specs in the new form.
-	} else if err = unmarshalCompatible(specBytes, spec); err != nil {
+	} else if err = unmarshalCompatible(specBytes, &loadedBindings); err != nil {
 		return nil, version, fmt.Errorf("spec.Unmarshal: %w", err)
 	}
 
-	return spec, version, nil
+	return loadedBindings, version, nil
 }
 
-func unmarshalCompatible(specBytes []byte, spec *StoredSpec) error {
+func unmarshalCompatible(specBytes []byte, bindings *[]protocol.ApplyBinding) error {
 	// Try to unmarshal directly as a StoredSpec first.
-	if err := json.Unmarshal(specBytes, spec); err != nil {
+	if err := json.Unmarshal(specBytes, bindings); err != nil {
 		// We're probably dealing with a legacy protobuf spec if that didn't work.
 		protobufSpec := &pf.MaterializationSpec{}
 		if err := protobufSpec.Unmarshal(specBytes); err != nil {
 			return fmt.Errorf("unmarshaling legacy protobufSpec: %w", err)
 		}
-		*spec = StoredSpec{
-			Materialization: protobufSpec.Materialization.String(),
-			Bindings:        protocol.MaterializationSpecPbToBindings(protobufSpec),
-		}
+		*bindings = protocol.MaterializationSpecPbToBindings(protobufSpec)
 	}
 
 	return nil
 }
 
-// resolveResourceToExistingBinding identifies an existing binding of `loadedSpec`
-// which matches the parsed `resourceSpec`. It further identifies field constraints
-// of the resolved binding, and performs initial validation that the resource is
-// well-formed and is a valid transition for an existing binding (if present).
+// resolveResourceToExistingBinding identifies an existing binding which matches the parsed
+// `resourceSpec`. It further identifies field constraints of the resolved binding, and performs
+// initial validation that the resource is well-formed and is a valid transition for an existing
+// binding (if present).
 func resolveResourceToExistingBinding(
 	endpoint *Endpoint,
 	resourceSpec json.RawMessage,
 	collection protocol.CollectionSpec,
-	loadedSpec *StoredSpec,
+	loadedBindings []protocol.ApplyBinding,
 ) (
 	constraints map[string]protocol.Constraint,
 	loadedBinding *protocol.ApplyBinding,
@@ -156,7 +153,7 @@ func resolveResourceToExistingBinding(
 
 	if err = pf.UnmarshalStrict(resourceSpec, resource); err != nil {
 		err = fmt.Errorf("resource binding for collection %q: %w", collection.Name, err)
-	} else if loadedBinding, err = findBinding(resource.Path(), collection.Name, loadedSpec); err != nil {
+	} else if loadedBinding, err = findBinding(resource.Path(), collection.Name, loadedBindings); err != nil {
 	} else if loadedBinding != nil && loadedBinding.DeltaUpdates && !resource.DeltaUpdates() {
 		// We allow a binding to switch from standard => delta updates but not the other way.
 		// This is because a standard materialization is trivially a valid delta-updates
@@ -172,12 +169,12 @@ func resolveResourceToExistingBinding(
 	return
 }
 
-func findBinding(path TablePath, collection string, spec *StoredSpec) (*protocol.ApplyBinding, error) {
-	if spec == nil {
+func findBinding(path TablePath, collection string, bindings []protocol.ApplyBinding) (*protocol.ApplyBinding, error) {
+	if bindings == nil {
 		return nil, nil // Binding is trivially not found.
 	}
-	for i := range spec.Bindings {
-		var b = spec.Bindings[i]
+	for i := range bindings {
+		var b = bindings[i]
 
 		if b.Collection.Name == collection && path.equals(b.ResourcePath) {
 			return &b, nil

--- a/materialize-sql-json/meta_tables.go
+++ b/materialize-sql-json/meta_tables.go
@@ -1,8 +1,6 @@
 package sql
 
-import (
-	"github.com/estuary/flow/go/protocols/flow"
-)
+import "github.com/estuary/connectors/go/protocol"
 
 const (
 	// DefaultFlowCheckpoints is the default table for checkpoints.
@@ -29,34 +27,34 @@ func FlowCheckpointsTable(path ...string) TableShape {
 		DeltaUpdates: false,
 		Keys: []Projection{
 			{
-				Projection: flow.Projection{
+				Projection: &protocol.Projection{
 					Field: "materialization",
-					Inference: flow.Inference{
+					Inference: protocol.Inference{
 						Types:   []string{"string"},
-						Exists:  flow.Inference_MUST,
-						String_: &flow.Inference_String{},
+						Exists:  protocol.MustExist,
+						String_: &protocol.StringInference{},
 					},
 				},
 				RawFieldConfig: nil,
 				Comment:        "The name of the materialization.",
 			},
 			{
-				Projection: flow.Projection{
+				Projection: &protocol.Projection{
 					Field: "key_begin",
-					Inference: flow.Inference{
+					Inference: protocol.Inference{
 						Types:  []string{"integer"},
-						Exists: flow.Inference_MUST,
+						Exists: protocol.MustExist,
 					},
 				},
 				RawFieldConfig: nil,
 				Comment:        "The inclusive lower-bound key hash covered by this checkpoint.",
 			},
 			{
-				Projection: flow.Projection{
+				Projection: &protocol.Projection{
 					Field: "key_end",
-					Inference: flow.Inference{
+					Inference: protocol.Inference{
 						Types:  []string{"integer"},
-						Exists: flow.Inference_MUST,
+						Exists: protocol.MustExist,
 					},
 				},
 				RawFieldConfig: nil,
@@ -65,23 +63,23 @@ func FlowCheckpointsTable(path ...string) TableShape {
 		},
 		Values: []Projection{
 			{
-				Projection: flow.Projection{
+				Projection: &protocol.Projection{
 					Field: "fence",
-					Inference: flow.Inference{
+					Inference: protocol.Inference{
 						Types:  []string{"integer"},
-						Exists: flow.Inference_MUST,
+						Exists: protocol.MustExist,
 					},
 				},
 				RawFieldConfig: nil,
 				Comment:        "This nonce is used to uniquely identify unique process assignments of a shard and prevent them from conflicting.",
 			},
 			{
-				Projection: flow.Projection{
+				Projection: &protocol.Projection{
 					Field: "checkpoint",
-					Inference: flow.Inference{
+					Inference: protocol.Inference{
 						Types:  []string{"string"},
-						Exists: flow.Inference_MUST,
-						String_: &flow.Inference_String{
+						Exists: protocol.MustExist,
+						String_: &protocol.StringInference{
 							// NOTE(johnny): Checkpoints *are* base64, but we lie to the
 							// connector to coerce it to select a regular text column type
 							// rather than a binary one for historical reasons. We should
@@ -110,12 +108,12 @@ func FlowMaterializationsTable(path ...string) TableShape {
 		DeltaUpdates: false,
 		Keys: []Projection{
 			{
-				Projection: flow.Projection{
+				Projection: &protocol.Projection{
 					Field: "materialization",
-					Inference: flow.Inference{
+					Inference: protocol.Inference{
 						Types:   []string{"string"},
-						Exists:  flow.Inference_MUST,
-						String_: &flow.Inference_String{},
+						Exists:  protocol.MustExist,
+						String_: &protocol.StringInference{},
 					},
 				},
 				RawFieldConfig: nil,
@@ -124,24 +122,24 @@ func FlowMaterializationsTable(path ...string) TableShape {
 		},
 		Values: []Projection{
 			{
-				Projection: flow.Projection{
+				Projection: &protocol.Projection{
 					Field: "version",
-					Inference: flow.Inference{
+					Inference: protocol.Inference{
 						Types:   []string{"string"},
-						Exists:  flow.Inference_MUST,
-						String_: &flow.Inference_String{},
+						Exists:  protocol.MustExist,
+						String_: &protocol.StringInference{},
 					},
 				},
 				RawFieldConfig: nil,
 				Comment:        "Version of the materialization.",
 			},
 			{
-				Projection: flow.Projection{
+				Projection: &protocol.Projection{
 					Field: "spec",
-					Inference: flow.Inference{
+					Inference: protocol.Inference{
 						Types:  []string{"string"},
-						Exists: flow.Inference_MUST,
-						String_: &flow.Inference_String{
+						Exists: protocol.MustExist,
+						String_: &protocol.StringInference{
 							// NOTE(johnny): Specifications *are* base64, but we lie to the
 							// connector to coerce it to select a regular text column type
 							// rather than a binary one for historical reasons. We should

--- a/materialize-sql-json/meta_tables.go
+++ b/materialize-sql-json/meta_tables.go
@@ -1,0 +1,160 @@
+package sql
+
+import (
+	"github.com/estuary/flow/go/protocols/flow"
+)
+
+const (
+	// DefaultFlowCheckpoints is the default table for checkpoints.
+	DefaultFlowCheckpoints = "flow_checkpoints_v1"
+	// DefaultFlowMaterializations is the default table for materialization specs.
+	DefaultFlowMaterializations = "flow_materializations_v2"
+)
+
+// MetaTables returns *Table configurations for Flow materialization metadata tables,
+// having the given `base` TablePath extended with their well-known table names.
+func MetaTables(base TablePath) (specs, checkpoints TableShape) {
+	return FlowMaterializationsTable(append(base, DefaultFlowMaterializations)...),
+		FlowCheckpointsTable(append(base, DefaultFlowCheckpoints)...)
+}
+
+// FlowCheckpointsTable returns the TableShape that (optionally) holds fenced
+// materialization checkpoints, where supported by the endpoint and connector.
+func FlowCheckpointsTable(path ...string) TableShape {
+	return TableShape{
+		Path:         path,
+		Binding:      -1,
+		Source:       "",
+		Comment:      "This table holds Flow processing checkpoints used for exactly-once processing of materializations",
+		DeltaUpdates: false,
+		Keys: []Projection{
+			{
+				Projection: flow.Projection{
+					Field: "materialization",
+					Inference: flow.Inference{
+						Types:   []string{"string"},
+						Exists:  flow.Inference_MUST,
+						String_: &flow.Inference_String{},
+					},
+				},
+				RawFieldConfig: nil,
+				Comment:        "The name of the materialization.",
+			},
+			{
+				Projection: flow.Projection{
+					Field: "key_begin",
+					Inference: flow.Inference{
+						Types:  []string{"integer"},
+						Exists: flow.Inference_MUST,
+					},
+				},
+				RawFieldConfig: nil,
+				Comment:        "The inclusive lower-bound key hash covered by this checkpoint.",
+			},
+			{
+				Projection: flow.Projection{
+					Field: "key_end",
+					Inference: flow.Inference{
+						Types:  []string{"integer"},
+						Exists: flow.Inference_MUST,
+					},
+				},
+				RawFieldConfig: nil,
+				Comment:        "The inclusive upper-bound key hash covered by this checkpoint.",
+			},
+		},
+		Values: []Projection{
+			{
+				Projection: flow.Projection{
+					Field: "fence",
+					Inference: flow.Inference{
+						Types:  []string{"integer"},
+						Exists: flow.Inference_MUST,
+					},
+				},
+				RawFieldConfig: nil,
+				Comment:        "This nonce is used to uniquely identify unique process assignments of a shard and prevent them from conflicting.",
+			},
+			{
+				Projection: flow.Projection{
+					Field: "checkpoint",
+					Inference: flow.Inference{
+						Types:  []string{"string"},
+						Exists: flow.Inference_MUST,
+						String_: &flow.Inference_String{
+							// NOTE(johnny): Checkpoints *are* base64, but we lie to the
+							// connector to coerce it to select a regular text column type
+							// rather than a binary one for historical reasons. We should
+							// revisit when we figure out a clean migration path.
+							IsBase64:    false,
+							ContentType: "application/x-protobuf; proto=consumer.Checkpoint",
+						},
+					},
+				},
+				RawFieldConfig: nil,
+				Comment:        "Checkpoint of the Flow consumer shard, encoded as base64 protobuf.",
+			},
+		},
+		Document: nil,
+	}
+}
+
+// FlowMaterializationsTable returns the TableShape that holds MaterializationSpecs.
+func FlowMaterializationsTable(path ...string) TableShape {
+
+	return TableShape{
+		Path:         path,
+		Binding:      -1,
+		Source:       "",
+		Comment:      "This table is the source of truth for all materializations into this system.",
+		DeltaUpdates: false,
+		Keys: []Projection{
+			{
+				Projection: flow.Projection{
+					Field: "materialization",
+					Inference: flow.Inference{
+						Types:   []string{"string"},
+						Exists:  flow.Inference_MUST,
+						String_: &flow.Inference_String{},
+					},
+				},
+				RawFieldConfig: nil,
+				Comment:        "The name of the materialization.",
+			},
+		},
+		Values: []Projection{
+			{
+				Projection: flow.Projection{
+					Field: "version",
+					Inference: flow.Inference{
+						Types:   []string{"string"},
+						Exists:  flow.Inference_MUST,
+						String_: &flow.Inference_String{},
+					},
+				},
+				RawFieldConfig: nil,
+				Comment:        "Version of the materialization.",
+			},
+			{
+				Projection: flow.Projection{
+					Field: "spec",
+					Inference: flow.Inference{
+						Types:  []string{"string"},
+						Exists: flow.Inference_MUST,
+						String_: &flow.Inference_String{
+							// NOTE(johnny): Specifications *are* base64, but we lie to the
+							// connector to coerce it to select a regular text column type
+							// rather than a binary one for historical reasons. We should
+							// revisit when we figure out a clean migration path.
+							IsBase64:    false,
+							ContentType: "application/x-protobuf; proto=flow.MaterializationSpec",
+						},
+					},
+				},
+				RawFieldConfig: nil,
+				Comment:        "Specification of the materialization, encoded as base64 protobuf.",
+			},
+		},
+		Document: nil,
+	}
+}

--- a/materialize-sql-json/std_sql.go
+++ b/materialize-sql-json/std_sql.go
@@ -1,0 +1,255 @@
+package sql
+
+import (
+	"context"
+	"database/sql"
+	"encoding/base64"
+	"fmt"
+	"strings"
+
+	pf "github.com/estuary/flow/go/protocols/flow"
+	"github.com/sirupsen/logrus"
+)
+
+// StdFetchSpecAndVersion is a convenience for Client implementations which
+// use Go's standard `sql.DB` type under the hood.
+func StdFetchSpecAndVersion(ctx context.Context, db *sql.DB, specs Table, materialization pf.Materialization) (specB64, version string, err error) {
+	// Fail-fast: surface a connection issue.
+	if err = db.PingContext(ctx); err != nil {
+		err = fmt.Errorf("connecting to DB: %w", err)
+		return
+	}
+
+	err = db.QueryRowContext(
+		ctx,
+		fmt.Sprintf(
+			"SELECT version, spec FROM %s WHERE materialization = %s;",
+			specs.Identifier,
+			specs.Keys[0].Placeholder,
+		),
+		materialization.String(),
+	).Scan(&version, &specB64)
+
+	return
+}
+
+// StdSQLExecStatements is a convenience for Client implementations which
+// use Go's standard `sql.DB` type under the hood.
+func StdSQLExecStatements(ctx context.Context, db *sql.DB, statements []string) error {
+	// Obtain a verified connection to the database.
+	// We don't explicitly wrap `statements` in a transaction, as not all
+	// databases support transactional DDL statements, but we do run them
+	// through a single connection. This allows a driver to explicitly run
+	// `BEGIN;` and `COMMIT;` statements around a transactional operation.
+	var conn, err = db.Conn(ctx)
+	if err == nil {
+		err = conn.PingContext(ctx)
+	}
+	if err != nil {
+		return fmt.Errorf("connecting to DB: %w", err)
+	}
+
+	for _, statement := range statements {
+		if _, err := conn.ExecContext(ctx, statement); err != nil {
+			return fmt.Errorf("executing statement (%s): %w", statement, err)
+		}
+		logrus.WithField("sql", statement).Debug("executed statement")
+	}
+	return conn.Close() // Release to pool.
+}
+
+// StdInstallFence is a convenience for Client implementations which
+// use Go's standard `sql.DB` type under the hood.
+func StdInstallFence(ctx context.Context, db *sql.DB, checkpoints Table, fence Fence) (Fence, error) {
+	var txn, err = db.BeginTx(ctx, nil)
+	if err != nil {
+		return Fence{}, fmt.Errorf("db.BeginTx: %w", err)
+	}
+	defer func() {
+		if txn != nil {
+			_ = txn.Rollback()
+		}
+	}()
+
+	// Increment the fence value of _any_ checkpoint which overlaps our key range.
+	if _, err = txn.Exec(
+		fmt.Sprintf(`
+			UPDATE %s
+				SET fence=fence+1
+				WHERE materialization=%s
+				AND key_end>=%s
+				AND key_begin<=%s
+			;
+			`,
+			checkpoints.Identifier,
+			checkpoints.Keys[0].Placeholder,
+			checkpoints.Keys[1].Placeholder,
+			checkpoints.Keys[2].Placeholder,
+		),
+		fence.Materialization,
+		fence.KeyBegin,
+		fence.KeyEnd,
+	); err != nil {
+		return Fence{}, fmt.Errorf("incrementing fence: %w", err)
+	}
+
+	// Read the checkpoint with the narrowest [key_begin, key_end] which fully overlaps our range.
+	var readBegin, readEnd uint32
+	var checkpointB64 string
+
+	if err = txn.QueryRow(
+		fmt.Sprintf(`
+			SELECT fence, key_begin, key_end, checkpoint
+				FROM %s
+				WHERE materialization=%s
+				AND key_begin<=%s
+				AND key_end>=%s
+				ORDER BY key_end - key_begin ASC
+				LIMIT 1
+			;
+			`,
+			checkpoints.Identifier,
+			checkpoints.Keys[0].Placeholder,
+			checkpoints.Keys[1].Placeholder,
+			checkpoints.Keys[2].Placeholder,
+		),
+		fence.Materialization,
+		fence.KeyBegin,
+		fence.KeyEnd,
+	).Scan(&fence.Fence, &readBegin, &readEnd, &checkpointB64); err == sql.ErrNoRows {
+		// Set an invalid range, which compares as unequal to trigger an insertion below.
+		readBegin, readEnd = 1, 0
+	} else if err != nil {
+		return Fence{}, fmt.Errorf("scanning fence and checkpoint: %w", err)
+	} else if fence.Checkpoint, err = base64.StdEncoding.DecodeString(checkpointB64); err != nil {
+		return Fence{}, fmt.Errorf("base64.Decode(checkpoint): %w", err)
+	}
+
+	// If a checkpoint for this exact range doesn't exist then insert it now.
+	if readBegin == fence.KeyBegin && readEnd == fence.KeyEnd {
+		// Exists; no-op.
+	} else if _, err = txn.Exec(
+		fmt.Sprintf(
+			"INSERT INTO %s (materialization, key_begin, key_end, fence, checkpoint) VALUES (%s, %s, %s, %s, %s);",
+			checkpoints.Identifier,
+			checkpoints.Keys[0].Placeholder,
+			checkpoints.Keys[1].Placeholder,
+			checkpoints.Keys[2].Placeholder,
+			checkpoints.Values[0].Placeholder,
+			checkpoints.Values[1].Placeholder,
+		),
+		fence.Materialization,
+		fence.KeyBegin,
+		fence.KeyEnd,
+		fence.Fence,
+		base64.StdEncoding.EncodeToString(fence.Checkpoint),
+	); err != nil {
+		return Fence{}, fmt.Errorf("inserting fence: %w", err)
+	}
+
+	err = txn.Commit()
+	txn = nil // Disable deferred rollback.
+
+	if err != nil {
+		return Fence{}, fmt.Errorf("txn.Commit: %w", err)
+	}
+	return fence, nil
+}
+
+// StdUpdateFence updates a Fence within the checkpoints Table.
+// It's a convenience for Client implementations which use Go's standard `sql.DB` type under the hood.
+func StdUpdateFence(ctx context.Context, txn *sql.Tx, checkpoints Table, fence Fence) error {
+	var result, err = txn.ExecContext(ctx,
+		fmt.Sprintf(
+			"UPDATE %s SET checkpoint=%s WHERE materialization=%s AND key_begin=%s AND key_end=%s AND fence=%s;",
+			checkpoints.Identifier,
+			checkpoints.Values[1].Placeholder,
+			checkpoints.Keys[0].Placeholder,
+			checkpoints.Keys[1].Placeholder,
+			checkpoints.Keys[2].Placeholder,
+			checkpoints.Values[0].Placeholder,
+		),
+		fence.Materialization,
+		fence.KeyBegin,
+		fence.KeyEnd,
+		fence.Fence,
+		base64.StdEncoding.EncodeToString(fence.Checkpoint),
+	)
+
+	if err != nil {
+		return fmt.Errorf("updating fence: %w", err)
+	}
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("fetching fence update rows: %w", err)
+	} else if rows != 1 {
+		return fmt.Errorf("this transactions session was fenced off by another")
+	}
+	return nil
+}
+
+// StdDumpTable returns a debug representation of the contents of a table.
+// It's a convenience for Client implementations which use Go's standard `sql.DB` type under the hood.
+func StdDumpTable(ctx context.Context, db *sql.DB, table Table) (string, error) {
+	var b strings.Builder
+
+	var keys []string
+	var all []string
+
+	for _, key := range table.Keys {
+		keys = append(keys, key.Identifier)
+		all = append(all, key.Identifier)
+	}
+	for _, val := range table.Values {
+		all = append(all, val.Identifier)
+	}
+
+	var sql = fmt.Sprintf("select %s from %s order by %s asc;",
+		strings.Join(all, ","),
+		table.Identifier,
+		strings.Join(keys, ","))
+
+	rows, err := db.Query(sql)
+	if err != nil {
+		return "", err
+	}
+	defer rows.Close()
+
+	b.WriteString(strings.Join(all, ", "))
+
+	for rows.Next() {
+		var data = make([]anyColumn, len(table.Columns()))
+		var ptrs = make([]interface{}, len(table.Columns()))
+		for i := range data {
+			ptrs[i] = &data[i]
+		}
+		if err = rows.Scan(ptrs...); err != nil {
+			return "", err
+		}
+		b.WriteString("\n")
+		for i, v := range ptrs {
+			if i > 0 {
+				b.WriteString(", ")
+			}
+			var val = v.(*anyColumn)
+			b.WriteString(val.String())
+		}
+	}
+	return b.String(), nil
+}
+
+type anyColumn string
+
+func (col *anyColumn) Scan(i interface{}) error {
+	var sval string
+	if b, ok := i.([]byte); ok {
+		sval = string(b)
+	} else {
+		sval = fmt.Sprint(i)
+	}
+	*col = anyColumn(sval)
+	return nil
+}
+func (col anyColumn) String() string {
+	return string(col)
+}

--- a/materialize-sql-json/table_mapping.go
+++ b/materialize-sql-json/table_mapping.go
@@ -3,6 +3,8 @@ package sql
 import (
 	"encoding/json"
 	"fmt"
+
+	"github.com/estuary/connectors/go/protocol"
 )
 
 // TablePath is a fully qualified table name (for example, with its schema).
@@ -147,11 +149,11 @@ func ResolveTable(shape TableShape, dialect Dialect) (Table, error) {
 }
 
 // BuildTableShape for the indexed specification binding, which has a corresponding database Resource.
-func BuildTableShape(spec *StoredSpec, index int, resource Resource) TableShape {
+func BuildTableShape(name string, bindings []protocol.ApplyBinding, index int, resource Resource) TableShape {
 	var (
-		binding = spec.Bindings[index]
+		binding = bindings[index]
 		comment = fmt.Sprintf("Generated for materialization %s of collection %s",
-			spec.Materialization, binding.Collection.Name)
+			name, binding.Collection.Name)
 		keys, values, document = BuildProjections(binding)
 	)
 

--- a/materialize-sql-json/table_mapping.go
+++ b/materialize-sql-json/table_mapping.go
@@ -1,0 +1,198 @@
+package sql
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/estuary/flow/go/protocols/fdb/tuple"
+	pf "github.com/estuary/flow/go/protocols/flow"
+)
+
+// TablePath is a fully qualified table name (for example, with its schema).
+type TablePath []string
+
+// TableShape describes a database table, which can be used to generate various types of SQL statements.
+type TableShape struct {
+	// The TablePath of this Table.
+	Path TablePath
+	// The index of the binding which produced this table, or -1 if not from a binding.
+	Binding int
+	// The source Collection of the table, or empty if not sourced from a collection.
+	Source pf.Collection
+	// Comment for this table.
+	Comment string
+	// User-defined additional SQL to be executed transactionally with table creation.
+	AdditionalSql string
+	// The table is operating in delta-updates mode (instead of a standard materialization).
+	DeltaUpdates bool
+
+	Keys, Values []Projection
+	Document     *Projection
+}
+
+// Table is a database table which is fully resolved using the database Dialect.
+type Table struct {
+	TableShape
+
+	// Quoted identifier for this table, suited for direct inclusion in SQL.
+	Identifier string
+	// Keys, Values, and the (optional) Document column.
+	Keys, Values []Column
+	Document     *Column
+}
+
+// Column is a database table column which is fully resolved using the database Dialect.
+type Column struct {
+	Projection
+	MappedType
+
+	// Quoted identifier for this column, suited for direct inclusion in SQL.
+	Identifier string
+	// Placeholder for this column's converted value in parameterized statements.
+	Placeholder string
+	// If this column can be null or not.
+	MustExist bool
+}
+
+// ConvertKey converts a key Tuple to database parameters.
+func (t *Table) ConvertKey(key tuple.Tuple) (out []interface{}, err error) {
+	return convertTuple(key, t.Keys, out)
+}
+
+// ConvertAll concerts key and values Tuples, as well as a document RawMessage into database parameters.
+func (t *Table) ConvertAll(key, values tuple.Tuple, doc json.RawMessage) (out []interface{}, err error) {
+	out = make([]interface{}, 0, len(t.Keys)+len(t.Values)+1)
+	if out, err = convertTuple(key, t.Keys, out); err != nil {
+		return nil, err
+	} else if out, err = convertTuple(values, t.Values, out); err != nil {
+		return nil, err
+	}
+
+	if t.Document != nil {
+		if m, err := t.Document.MappedType.Converter(doc); err != nil {
+			return nil, fmt.Errorf("converting document %s: %w", t.Document.Field, err)
+		} else {
+			out = append(out, m)
+		}
+	}
+
+	return out, nil
+}
+
+func convertTuple(in tuple.Tuple, columns []Column, out []interface{}) ([]interface{}, error) {
+	if a, b := len(in), len(columns); a != b {
+		panic(fmt.Sprintf("len(in) is %d but len(columns) is %d", a, b))
+	}
+
+	for i := range in {
+		if m, err := columns[i].MappedType.Converter(in[i]); err != nil {
+			return nil, fmt.Errorf("converting field %s: %w", columns[i].Field, err)
+		} else {
+			out = append(out, m)
+		}
+	}
+	return out, nil
+}
+
+// Columns returns all columns of the Table as a single slice,
+// ordered as Keys, then Values, then the Document.
+func (t *Table) Columns() []*Column {
+	out := t.KeyPtrs()
+	for i := range t.Values {
+		out = append(out, &t.Values[i])
+	}
+	if t.Document != nil {
+		out = append(out, t.Document)
+	}
+	return out
+}
+
+// KeyPtrs returns all keys of the Table as a single slice.
+func (t *Table) KeyPtrs() []*Column {
+	var out []*Column
+	for i := range t.Keys {
+		out = append(out, &t.Keys[i])
+	}
+	return out
+}
+
+// ResolveTable maps a TableShape into a Table using the given Dialect.
+func ResolveTable(shape TableShape, dialect Dialect) (Table, error) {
+	var table = Table{
+		TableShape: shape,
+		Identifier: dialect.Identifier(shape.Path...),
+	}
+
+	for _, key := range shape.Keys {
+		key.IsPrimaryKey = true
+		table.Keys = append(table.Keys, Column{Projection: key})
+	}
+	for _, val := range shape.Values {
+		table.Values = append(table.Values, Column{Projection: val})
+	}
+	if shape.Document != nil {
+		table.Document = &Column{Projection: *shape.Document}
+	}
+
+	for index, col := range table.Columns() {
+		var err error
+
+		if col.MappedType, err = dialect.MapType(&col.Projection); err != nil {
+			return Table{}, fmt.Errorf("mapping column %s of %s: %w", col.Field, shape.Path, err)
+		}
+		_, mustExist := col.Projection.AsFlatType()
+		col.MustExist = mustExist
+		col.Identifier = dialect.Identifier(col.Field)
+		col.Placeholder = dialect.Placeholder(index)
+	}
+
+	return table, nil
+}
+
+// BuildTableShape for the indexed specification binding, which has a corresponding database Resource.
+func BuildTableShape(spec *pf.MaterializationSpec, index int, resource Resource) TableShape {
+	var (
+		binding = spec.Bindings[index]
+		comment = fmt.Sprintf("Generated for materialization %s of collection %s",
+			spec.Materialization, binding.Collection.Collection)
+		keys, values, document = BuildProjections(binding)
+	)
+
+	return TableShape{
+		Path:          resource.Path(),
+		Binding:       index,
+		Source:        binding.Collection.Collection,
+		Comment:       comment,
+		AdditionalSql: resource.GetAdditionalSql(),
+		DeltaUpdates:  resource.DeltaUpdates(),
+		Keys:          keys,
+		Values:        values,
+		Document:      document,
+	}
+}
+
+// Pop the last component from the TablePath and return its cloned result.
+func (p TablePath) Pop() TablePath {
+	if len(p) == 0 {
+		return TablePath{}
+	} else {
+		return append(TablePath{}, p[:len(p)-1]...)
+	}
+}
+
+// Push a component onto the TablePath and returned its cloned result.
+func (p TablePath) Push(component string) TablePath {
+	return append(append(TablePath{}, p...), component)
+}
+
+func (p TablePath) equals(other []string) bool {
+	if len(p) != len(other) {
+		return false
+	}
+	for i := 0; i != len(p); i++ {
+		if p[i] != other[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/materialize-sql-json/templating.go
+++ b/materialize-sql-json/templating.go
@@ -1,0 +1,45 @@
+package sql
+
+import (
+	"encoding/base64"
+	"strings"
+	"text/template"
+)
+
+// MustParseTemplate is a convenience which parses the template `body` and
+// installs common functions for accessing Dialect behavior.
+func MustParseTemplate(dialect Dialect, name, body string) *template.Template {
+	var tpl = template.New(name).Funcs(template.FuncMap{
+		"Literal":   dialect.Literal,
+		"Base64Std": base64.StdEncoding.EncodeToString,
+		// Tweak signature slightly to take TablePath, as dynamic slicing is a bit tricky
+		// in templates and this is most-frequently used with TablePath.Base().
+		"Identifier": func(p TablePath) string { return dialect.Identifier(p...) },
+		// A helper for iterating over all fields of a table
+		"AllFields": func(table Table) []Column { return append(append(append([]Column{}, table.Keys...), table.Values...), *table.Document) },
+	})
+	return template.Must(tpl.Parse(body))
+}
+
+// RenderTableTemplate is a simple implementation of rendering a template with a Table
+// as its context. It's here for demonstration purposes mostly. Feel free to not use it.
+func RenderTableTemplate(table Table, tpl *template.Template) (string, error) {
+	var w strings.Builder
+	if err := tpl.Execute(&w, &table); err != nil {
+		return "", err
+	}
+	return w.String(), nil
+}
+
+type AlterColumnNullableInput struct {
+	Table Table
+	Identifier string
+}
+
+func RenderAlterColumnNullableTemplate(input AlterColumnNullableInput, tpl *template.Template) (string, error) {
+	var w strings.Builder
+	if err := tpl.Execute(&w, &input); err != nil {
+		return "", err
+	}
+	return w.String(), nil
+}

--- a/materialize-sql-json/templating_test.go
+++ b/materialize-sql-json/templating_test.go
@@ -1,0 +1,99 @@
+package sql
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/bradleyjkemp/cupaloy"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestDialect() Dialect {
+	var mapper TypeMapper = ProjectionTypeMapper{
+		INTEGER: NewStaticMapper("BIGINT"),
+		NUMBER:  NewStaticMapper("DOUBLE PRECISION"),
+		BOOLEAN: NewStaticMapper("BOOLEAN"),
+		OBJECT:  NewStaticMapper("JSON"),
+		ARRAY:   NewStaticMapper("JSON"),
+		BINARY:  NewStaticMapper("BYTEA"),
+		STRING: StringTypeMapper{
+			Fallback: NewStaticMapper("TEXT"),
+			WithFormat: map[string]TypeMapper{
+				"date-time": NewStaticMapper("TIMESTAMPTZ"),
+			},
+		},
+	}
+	mapper = NullableMapper{
+		NotNullText: "NOT NULL",
+		Delegate:    mapper,
+	}
+
+	return Dialect{
+		Identifierer: IdentifierFn(JoinTransform(".",
+			PassThroughTransform(
+				func(s string) bool {
+					return IsSimpleIdentifier(s) && strings.ToLower(s) != "reserved"
+				},
+				QuoteTransform("\"", "\\\""),
+			))),
+		Literaler: LiteralFn(QuoteTransform("'", "''")),
+		Placeholderer: PlaceholderFn(func(index int) string {
+			return fmt.Sprintf("$%d", index+1)
+		}),
+		TypeMapper: mapper,
+	}
+}
+
+func TestTableTemplate(t *testing.T) {
+	var (
+		shape      = FlowCheckpointsTable("one", "reserved", "checkpoints")
+		dialect    = newTestDialect()
+		table, err = ResolveTable(shape, dialect)
+	)
+	assert.NoError(t, err)
+
+	var tpl = MustParseTemplate(dialect, "template", `
+	CREATE TABLE {{$.Identifier}} (
+		{{- range $ind, $col := $.Columns }}
+			{{- if $ind}},{{end}}
+			{{$col.Identifier}} {{$col.DDL}}
+		{{- end }}
+		{{- if not $.DeltaUpdates }},
+			PRIMARY KEY (
+		{{- range $ind, $key := $.Keys }}
+			{{- if $ind}}, {{end -}}
+			{{$key.Identifier}}
+		{{- end -}}
+		)
+		{{ end }}
+	);
+
+	COMMENT ON TABLE {{$.Identifier}} IS {{Literal $.Comment}};
+	{{- range $col := .Columns }}
+	COMMENT ON COLUMN {{$.Identifier}}.{{$col.Identifier}} IS {{Literal $col.Comment}};
+	{{- end}}
+	`)
+
+	out, err := RenderTableTemplate(table, tpl)
+	require.NoError(t, err)
+	cupaloy.SnapshotT(t, out)
+}
+
+func TestAlterColumnNullableTemplate(t *testing.T) {
+	var (
+		shape      = FlowCheckpointsTable("one", "reserved", "checkpoints")
+		dialect    = newTestDialect()
+		table, err = ResolveTable(shape, dialect)
+	)
+	assert.NoError(t, err)
+
+	var tpl = MustParseTemplate(dialect, "template", `
+  ALTER TABLE {{ $.Table.Identifier }} ALTER COLUMN {{ $.Identifier }} DROP NOT NULL;
+  `)
+
+  out, err := RenderAlterColumnNullableTemplate(AlterColumnNullableInput { Table: table, Identifier: "id" }, tpl)
+	require.NoError(t, err)
+	cupaloy.SnapshotT(t, out)
+}

--- a/materialize-sql-json/test_support.go
+++ b/materialize-sql-json/test_support.go
@@ -1,0 +1,139 @@
+package sql
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math"
+	"testing"
+	"text/template"
+
+	"github.com/bradleyjkemp/cupaloy"
+	"github.com/stretchr/testify/require"
+)
+
+// RunFenceTestCases is a generalized form of test cases over fencing behavior,
+// which ought to function with any Client implementation.
+func RunFenceTestCases(
+	t *testing.T,
+	client Client,
+	checkpointsPath []string,
+	dialect Dialect,
+	createTableTpl *template.Template,
+	updateFence func(Table, Fence) error,
+	dumpTable func(Table) (string, error),
+) {
+
+	// runTest takes zero or more key range fixtures, followed by a final pair
+	// which is the key range under test.
+	var runTest = func(t *testing.T, ranges ...uint32) {
+		var ctx = context.Background()
+
+		var metaShape = FlowCheckpointsTable(checkpointsPath...)
+		var metaTable, err = ResolveTable(metaShape, dialect)
+		require.NoError(t, err)
+
+		createSQL, err := RenderTableTemplate(metaTable, createTableTpl)
+		require.NoError(t, err)
+		err = client.ExecStatements(ctx, []string{createSQL})
+		require.NoError(t, err)
+
+		defer func() {
+			err = client.ExecStatements(ctx, []string{fmt.Sprintf("DROP TABLE %s;", metaTable.Identifier)})
+			require.NoError(t, err)
+		}()
+
+		var fixtures = ranges[:len(ranges)-2]
+		var testCase = ranges[len(ranges)-2:]
+
+		for i := 0; i*2 < len(fixtures); i++ {
+			var _, err = client.InstallFence(ctx, metaTable, Fence{
+				TablePath:       metaShape.Path,
+				Materialization: "the/materialization",
+				KeyBegin:        ranges[i*2],
+				KeyEnd:          ranges[i*2+1],
+				Fence:           5,
+				Checkpoint:      bytes.Repeat([]byte{byte(i + 1)}, 10),
+			})
+			require.NoError(t, err)
+		}
+
+		// Add an extra fixture from a different materialization.
+		_, err = client.InstallFence(ctx, metaTable, Fence{
+			TablePath:       metaShape.Path,
+			Materialization: "other/one",
+			KeyBegin:        0,
+			KeyEnd:          math.MaxUint32,
+			Fence:           99,
+			Checkpoint:      []byte("other-checkpoint"),
+		})
+		require.NoError(t, err)
+
+		dump1, err := dumpTable(metaTable)
+		require.NoError(t, err)
+
+		// Install the fence under test
+		fence, err := client.InstallFence(ctx, metaTable, Fence{
+			TablePath:       metaShape.Path,
+			Materialization: "the/materialization",
+			KeyBegin:        testCase[0],
+			KeyEnd:          testCase[1],
+			Fence:           0,
+			Checkpoint:      nil,
+		})
+		require.NoError(t, err)
+
+		dump2, err := dumpTable(metaTable)
+		require.NoError(t, err)
+
+		// Update it once.
+		fence.Checkpoint = append(fence.Checkpoint, []byte{0, 0, 0, 0, 0, 0, 0, 0}...)
+		require.NoError(t, updateFence(metaTable, fence))
+
+		dump3, err := dumpTable(metaTable)
+		require.NoError(t, err)
+
+		cupaloy.SnapshotT(t,
+			"After installing fixtures:\n"+dump1+
+				"\nAfter install fence under test:\n"+dump2+
+				"\nAfter update:\n"+dump3)
+	}
+
+	// If a fence exactly matches a checkpoint, we'll fence that checkpoint and its parent
+	// but not siblings. The used checkpoint is that of the exact match.
+	t.Run("exact match", func(t *testing.T) {
+		runTest(t,
+			0, 99, // Unrelated sibling.
+			100, 199, // Exactly matched.
+			200, 299, // Unrelated sibling.
+			0, 1000, // Old parent.
+			100, 199)
+	})
+	// If a fence sub-divides a parent, we'll fence the parent and grand parent
+	// but not siblings of the parent. The checkpoint is the younger parent.
+	t.Run("split from parent", func(t *testing.T) {
+		runTest(t,
+			0, 499, // Younger uncle.
+			500, 799, // Younger parent.
+			800, 1000, // Other uncle.
+			0, 1000, // Grand parent.
+			500, 599)
+	})
+	// If a new range straddles existing ranges (this shouldn't ever happen),
+	// we'll fence the straddled ranges while taking the checkpoint of the parent.
+	t.Run("straddle", func(t *testing.T) {
+		runTest(t,
+			0, 499,
+			500, 1000,
+			0, 1000,
+			400, 599)
+	})
+	// If a new range covers another (this also shouldn't ever happen),
+	// it takes the checkpoint of its parent while also fencing the covered sub-range.
+	t.Run("covered child", func(t *testing.T) {
+		runTest(t,
+			100, 199,
+			0, 1000,
+			100, 800)
+	})
+}

--- a/materialize-sql-json/testdata/flow.yaml
+++ b/materialize-sql-json/testdata/flow.yaml
@@ -1,0 +1,25 @@
+collections:
+  key/value:
+    schema:
+      type: object
+      properties:
+        key1: { type: integer }
+        key2: { type: boolean }
+        boolean: { type: boolean }
+        integer: { type: integer }
+        number: { type: number }
+        string: { type: string }
+      required: [key1, key2]
+    key: [/key1, /key2]
+
+materializations:
+  test/sqlite:
+    endpoint:
+      sqlite:
+        path: ":memory:"
+    bindings:
+      - source: key/value
+        resource: { table: key_value }
+
+storageMappings:
+  "": { stores: [{ provider: S3, bucket: a-bucket }] }

--- a/materialize-sql-json/type_mapping.go
+++ b/materialize-sql-json/type_mapping.go
@@ -1,0 +1,334 @@
+package sql
+
+import (
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"strconv"
+
+	"github.com/estuary/flow/go/protocols/fdb/tuple"
+	pf "github.com/estuary/flow/go/protocols/flow"
+)
+
+// FlatType is a flattened, database-friendly representation of a document location's type.
+// It differs from JSON types by:
+// * Having a single type, with cases like "JSON string OR integer" delegated to a MULTIPLE case.
+// * Hoisting JSON `null` out of the type representation and into a separate orthogonal concern.
+type FlatType string
+
+// FlatType constants that are used by ColumnMapper
+const (
+	ARRAY    FlatType = "array"
+	BINARY   FlatType = "binary"
+	BOOLEAN  FlatType = "boolean"
+	INTEGER  FlatType = "integer"
+	MULTIPLE FlatType = "multiple"
+	NEVER    FlatType = "never"
+	NUMBER   FlatType = "number"
+	OBJECT   FlatType = "object"
+	STRING   FlatType = "string"
+)
+
+// Projection lifts a pf.Projection into a form that's more easily worked with for SQL column mapping.
+type Projection struct {
+	pf.Projection
+	// Comment for this projection.
+	Comment string
+	// RawFieldConfig is (optional) field configuration supplied within the field selection.
+	RawFieldConfig json.RawMessage
+}
+
+// BuildProjections returns the Projections extracted from a Binding.
+func BuildProjections(spec *pf.MaterializationSpec_Binding) (keys, values []Projection, document *Projection) {
+	var do = func(field string) Projection {
+		var p = Projection{
+			Projection:     *spec.Collection.GetProjection(field),
+			RawFieldConfig: spec.FieldSelection.FieldConfigJson[field],
+		}
+
+		var source = "auto-generated"
+		if p.Explicit {
+			source = "user-provided"
+		}
+		p.Comment = fmt.Sprintf("%s projection of JSON at: %s with inferred types: %s",
+			source, p.Ptr, p.Inference.Types)
+
+		if p.Inference.Description != "" {
+			p.Comment = p.Inference.Description + "\n" + p.Comment
+		}
+		if p.Inference.Title != "" {
+			p.Comment = p.Inference.Title + "\n" + p.Comment
+		}
+
+		return p
+	}
+
+	for _, field := range spec.FieldSelection.Keys {
+		keys = append(keys, do(field))
+	}
+	for _, field := range spec.FieldSelection.Values {
+		values = append(values, do(field))
+	}
+	if field := spec.FieldSelection.Document; field != "" {
+		document = new(Projection)
+		*document = do(field)
+	}
+
+	return
+}
+
+// AsFlatType returns the Projection's FlatType.
+func (p *Projection) AsFlatType() (_ FlatType, mustExist bool) {
+	mustExist = p.Inference.Exists == pf.Inference_MUST
+
+	var types []FlatType
+	for _, ty := range effectiveJsonTypes(&p.Projection) {
+		switch ty {
+		case "string":
+			types = append(types, STRING)
+		case "integer":
+			types = append(types, INTEGER)
+		case "number", "fractional":
+			types = append(types, NUMBER)
+		case "boolean":
+			types = append(types, BOOLEAN)
+		case "object":
+			types = append(types, OBJECT)
+		case "array":
+			types = append(types, ARRAY)
+		case "null":
+			mustExist = false
+		}
+	}
+
+	switch len(types) {
+	case 0:
+		return NEVER, false
+	case 1:
+		return types[0], mustExist
+	default:
+		return MULTIPLE, mustExist
+	}
+}
+
+// effectiveJsonTypes potentially maps the provided JSON types into alternate types for
+// materialization. It currently supports strings formatted as numeric values, either as stand-alone
+// string types or as a string type formatted as numeric + that numeric type. It does not apply to
+// keyed fields.
+func effectiveJsonTypes(projection *pf.Projection) []string {
+	if !projection.IsPrimaryKey && projection.Inference.String_ != nil {
+		switch {
+		case projection.Inference.String_.Format == "integer" && reflect.DeepEqual(projection.Inference.Types, []string{"integer", "string"}):
+			return []string{"integer"}
+		case projection.Inference.String_.Format == "number" && reflect.DeepEqual(projection.Inference.Types, []string{"number", "string"}):
+			return []string{"number"}
+		case projection.Inference.String_.Format == "integer" && reflect.DeepEqual(projection.Inference.Types, []string{"string"}):
+			return []string{"integer"}
+		case projection.Inference.String_.Format == "number" && reflect.DeepEqual(projection.Inference.Types, []string{"string"}):
+			return []string{"number"}
+		default:
+			// Fallthrough, types are returned as-is.
+		}
+	}
+
+	return projection.Inference.Types
+}
+
+type MappedType struct {
+	// DDL is the "CREATE TABLE" DDL type for this mapping, suited for direct inclusion in raw SQL.
+	DDL string
+	// Converter of tuple elements for this mapping, into SQL runtime values.
+	Converter ElementConverter
+	// ParsedFieldConfig is a Dialect-defined parsed implementation of the (optional)
+	// additional field configuration supplied within the field selection.
+	ParsedFieldConfig interface{}
+}
+
+// ElementConverter maps from a TupleElement into a runtime type instance that's compatible with the SQL driver.
+type ElementConverter func(tuple.TupleElement) (interface{}, error)
+
+// TupleConverter maps from a Tuple into a slice of runtime type instances that are compatible with the SQL driver.
+type TupleConverter func(tuple.Tuple) ([]interface{}, error)
+
+// NewTupleConverter builds a TupleConverter from an ordered list of ElementConverter.
+func NewTupleConverter(e ...ElementConverter) TupleConverter {
+	return func(t tuple.Tuple) (out []interface{}, err error) {
+		out = make([]interface{}, len(e))
+		for i := range e {
+			if out[i], err = e[i](t[i]); err != nil {
+				return nil, fmt.Errorf("converting tuple index %d: %w", i, err)
+			}
+		}
+		return out, nil
+	}
+}
+
+// StaticMapper is a TypeMapper which returns a consistent MappedType.
+type StaticMapper MappedType
+
+var _ TypeMapper = StaticMapper{}
+
+type StaticMapperOption func(*StaticMapper)
+
+func (sm StaticMapper) MapType(*Projection) (MappedType, error) {
+	return (MappedType)(sm), nil
+}
+
+func NewStaticMapper(ddl string, opts ...StaticMapperOption) StaticMapper {
+	sm := StaticMapper{
+		DDL:               ddl,
+		Converter:         func(te tuple.TupleElement) (interface{}, error) { return te, nil },
+		ParsedFieldConfig: nil,
+	}
+
+	for _, o := range opts {
+		o(&sm)
+	}
+
+	return sm
+}
+
+func WithElementConverter(converter ElementConverter) StaticMapperOption {
+	return func(sm *StaticMapper) {
+		sm.Converter = converter
+	}
+}
+
+// StringCastConverter builds an ElementConverter from the string-handling callback. Any non-string
+// types are returned without modification. This should be used for converting fields that have a
+// string type and one additional type. The callback should convert the string into the desired type
+// per the endpoint's requirements.
+func StringCastConverter(fn func(string) (interface{}, error)) ElementConverter {
+	return func(te tuple.TupleElement) (interface{}, error) {
+		switch tt := te.(type) {
+		case string:
+			return fn(tt)
+		default:
+			return te, nil
+		}
+	}
+}
+
+// StdStrToInt builds an ElementConverter that attempts to convert a string into an int64 value. It
+// can be used for endpoints that do not require more digits than an int64 can provide.
+func StdStrToInt() ElementConverter {
+	return StringCastConverter(func(str string) (interface{}, error) {
+		out, err := strconv.ParseInt(str, 10, 64)
+		if err != nil {
+			return nil, fmt.Errorf("could not convert %q to int64: %w", str, err)
+		}
+
+		return out, nil
+	})
+}
+
+// StdStrToFloat builds an ElementConverter that attempts to convert a string into an float64 value.
+// It can be used for endpoints that do not require more digits than an float64 can provide.
+func StdStrToFloat() ElementConverter {
+	return StringCastConverter(func(str string) (interface{}, error) {
+		out, err := strconv.ParseFloat(str, 64)
+		if err != nil {
+			return nil, fmt.Errorf("could not convert %q to float64: %w", str, err)
+		}
+
+		return out, nil
+	})
+}
+
+// NullableMapper wraps a ColumnMapper to add "NULL" and/or "NOT NULL" to the generated SQL type
+// depending on the nullability of the column. Most databases will assume that a column may contain
+// null as long as it isn't declared with a NOT NULL constraint, but some databases (e.g. ms sql
+// server) make that behavior configurable, requiring the DDL to explicitly declare a column with
+// NULL if it may contain null values. This wrapper will handle either or both cases.
+type NullableMapper struct {
+	NotNullText, NullableText string
+	Delegate                  TypeMapper
+}
+
+var _ TypeMapper = NullableMapper{}
+
+func (m NullableMapper) MapType(p *Projection) (mapped MappedType, err error) {
+	if mapped, err = m.Delegate.MapType(p); err != nil {
+		return
+	} else if _, notNull := p.AsFlatType(); notNull && m.NotNullText != "" {
+		mapped.DDL += " " + m.NotNullText
+	} else if m.NullableText != "" {
+		mapped.DDL += " " + m.NullableText
+	}
+
+	return
+}
+
+// StringTypeMapper is a special TypeMapper for string type columns, which can take the format
+// and/or content type into account when deciding what sql column type to generate.
+type StringTypeMapper struct {
+	WithFormat      map[string]TypeMapper
+	WithContentType map[string]TypeMapper
+	Fallback        TypeMapper
+}
+
+var _ TypeMapper = StringTypeMapper{}
+
+func (m StringTypeMapper) MapType(p *Projection) (MappedType, error) {
+	if flat, _ := p.AsFlatType(); flat != STRING && m.Fallback == nil {
+		return ErrorMapper{}.MapType(p)
+	} else if flat != STRING {
+		return m.Fallback.MapType(p)
+	} else if delegate, ok := m.WithFormat[p.Inference.String_.Format]; ok {
+		return delegate.MapType(p)
+	} else if delegate, ok := m.WithContentType[p.Inference.String_.ContentType]; ok {
+		return delegate.MapType(p)
+	} else if m.Fallback == nil {
+		return ErrorMapper{}.MapType(p)
+	} else {
+		return m.Fallback.MapType(p)
+	}
+}
+
+// ProjectionTypeMapper selects an inner TypeMapper based on a Projection's FlatType.
+type ProjectionTypeMapper map[FlatType]TypeMapper
+
+var _ TypeMapper = ProjectionTypeMapper{}
+
+func (m ProjectionTypeMapper) MapType(p *Projection) (MappedType, error) {
+	var flat, _ = p.AsFlatType()
+
+	if delegate, ok := m[flat]; ok {
+		return delegate.MapType(p)
+	} else {
+		return ErrorMapper{}.MapType(p)
+	}
+}
+
+// MaxLengthMapper checks if the projection is a STRING type Projection having a MaxLength.
+// If it is, it invokes WithLength with the MaxLength to map the Projection and returns
+// the result. Otherwise, it invokes and returns Fallback.
+type MaxLengthMapper struct {
+	WithLength           TypeMapper
+	WithLengthFmtPattern string
+	Fallback             TypeMapper
+}
+
+var _ TypeMapper = MaxLengthMapper{}
+
+func (m MaxLengthMapper) MapType(p *Projection) (MappedType, error) {
+	var flat, _ = p.AsFlatType()
+
+	if flat != STRING || p.Inference.String_.MaxLength == 0 {
+		return m.Fallback.MapType(p)
+	} else if mapped, err := m.WithLength.MapType(p); err != nil {
+		return MappedType{}, err
+	} else {
+		mapped.DDL = fmt.Sprintf(m.WithLengthFmtPattern, mapped.DDL, p.Inference.String_.MaxLength)
+		return mapped, nil
+	}
+}
+
+// ErrorMapper returns a mapping error for the Projection.
+type ErrorMapper struct{}
+
+var _ TypeMapper = ErrorMapper{}
+
+func (m ErrorMapper) MapType(p *Projection) (MappedType, error) {
+	return MappedType{}, fmt.Errorf("unable to map field %s with type %s", p.Field, p.Inference.Types)
+}

--- a/materialize-sql-json/type_mapping_test.go
+++ b/materialize-sql-json/type_mapping_test.go
@@ -3,23 +3,23 @@ package sql
 import (
 	"testing"
 
-	pf "github.com/estuary/flow/go/protocols/flow"
+	"github.com/estuary/connectors/go/protocol"
 	"github.com/stretchr/testify/require"
 )
 
 func TestAsFlatType(t *testing.T) {
 	tests := []struct {
 		name      string
-		inference pf.Inference
+		inference protocol.Inference
 		flatType  FlatType
 		mustExist bool
 	}{
 		{
 			name: "integer formatted string with integer",
-			inference: pf.Inference{
-				Exists: pf.Inference_MUST,
+			inference: protocol.Inference{
+				Exists: protocol.MustExist,
 				Types:  []string{"integer", "string"},
-				String_: &pf.Inference_String{
+				String_: &protocol.StringInference{
 					Format: "integer",
 				},
 			},
@@ -28,10 +28,10 @@ func TestAsFlatType(t *testing.T) {
 		},
 		{
 			name: "number formatted string with number",
-			inference: pf.Inference{
-				Exists: pf.Inference_MAY,
+			inference: protocol.Inference{
+				Exists: protocol.MayExist,
 				Types:  []string{"number", "string"},
-				String_: &pf.Inference_String{
+				String_: &protocol.StringInference{
 					Format: "number",
 				},
 			},
@@ -40,10 +40,10 @@ func TestAsFlatType(t *testing.T) {
 		},
 		{
 			name: "integer formatted string with number",
-			inference: pf.Inference{
-				Exists: pf.Inference_MAY,
+			inference: protocol.Inference{
+				Exists: protocol.MayExist,
 				Types:  []string{"number", "string"},
-				String_: &pf.Inference_String{
+				String_: &protocol.StringInference{
 					Format: "integer",
 				},
 			},
@@ -52,8 +52,8 @@ func TestAsFlatType(t *testing.T) {
 		},
 		{
 			name: "single number type",
-			inference: pf.Inference{
-				Exists: pf.Inference_MAY,
+			inference: protocol.Inference{
+				Exists: protocol.MayExist,
 				Types:  []string{"number"},
 			},
 			flatType:  NUMBER,
@@ -61,10 +61,10 @@ func TestAsFlatType(t *testing.T) {
 		},
 		{
 			name: "number formatted string with number and other field",
-			inference: pf.Inference{
-				Exists: pf.Inference_MAY,
+			inference: protocol.Inference{
+				Exists: protocol.MayExist,
 				Types:  []string{"number", "string", "array"},
-				String_: &pf.Inference_String{
+				String_: &protocol.StringInference{
 					Format: "number",
 				},
 			},
@@ -73,10 +73,10 @@ func TestAsFlatType(t *testing.T) {
 		},
 		{
 			name: "number formatted string with integer",
-			inference: pf.Inference{
-				Exists: pf.Inference_MAY,
+			inference: protocol.Inference{
+				Exists: protocol.MayExist,
 				Types:  []string{"integer", "string"},
-				String_: &pf.Inference_String{
+				String_: &protocol.StringInference{
 					Format: "number",
 				},
 			},
@@ -85,8 +85,8 @@ func TestAsFlatType(t *testing.T) {
 		},
 		{
 			name: "multiple types with null",
-			inference: pf.Inference{
-				Exists: pf.Inference_MUST,
+			inference: protocol.Inference{
+				Exists: protocol.MustExist,
 				Types:  []string{"integer", "string", "null"},
 			},
 			flatType:  MULTIPLE,
@@ -94,8 +94,8 @@ func TestAsFlatType(t *testing.T) {
 		},
 		{
 			name: "no types",
-			inference: pf.Inference{
-				Exists: pf.Inference_MUST,
+			inference: protocol.Inference{
+				Exists: protocol.MustExist,
 				Types:  nil,
 			},
 			flatType:  NEVER,
@@ -103,10 +103,10 @@ func TestAsFlatType(t *testing.T) {
 		},
 		{
 			name: "no types with format",
-			inference: pf.Inference{
-				Exists: pf.Inference_MUST,
+			inference: protocol.Inference{
+				Exists: protocol.MustExist,
 				Types:  nil,
-				String_: &pf.Inference_String{
+				String_: &protocol.StringInference{
 					Format: "number",
 				},
 			},
@@ -115,10 +115,10 @@ func TestAsFlatType(t *testing.T) {
 		},
 		{
 			name: "other formatted string with integer",
-			inference: pf.Inference{
-				Exists: pf.Inference_MAY,
+			inference: protocol.Inference{
+				Exists: protocol.MayExist,
 				Types:  []string{"integer", "string"},
-				String_: &pf.Inference_String{
+				String_: &protocol.StringInference{
 					Format: "array",
 				},
 			},
@@ -127,10 +127,10 @@ func TestAsFlatType(t *testing.T) {
 		},
 		{
 			name: "format with two non-string fields",
-			inference: pf.Inference{
-				Exists: pf.Inference_MAY,
+			inference: protocol.Inference{
+				Exists: protocol.MayExist,
 				Types:  []string{"integer", "number"},
-				String_: &pf.Inference_String{
+				String_: &protocol.StringInference{
 					Format: "number",
 				},
 			},
@@ -139,10 +139,10 @@ func TestAsFlatType(t *testing.T) {
 		},
 		{
 			name: "format with two string fields",
-			inference: pf.Inference{
-				Exists: pf.Inference_MAY,
+			inference: protocol.Inference{
+				Exists: protocol.MayExist,
 				Types:  []string{"string", "string"},
-				String_: &pf.Inference_String{
+				String_: &protocol.StringInference{
 					Format: "number",
 				},
 			},
@@ -151,10 +151,10 @@ func TestAsFlatType(t *testing.T) {
 		},
 		{
 			name: "allowable format with a null is not mustExist",
-			inference: pf.Inference{
-				Exists: pf.Inference_MUST,
+			inference: protocol.Inference{
+				Exists: protocol.MustExist,
 				Types:  []string{"string", "null"},
-				String_: &pf.Inference_String{
+				String_: &protocol.StringInference{
 					Format: "number",
 				},
 			},
@@ -163,10 +163,10 @@ func TestAsFlatType(t *testing.T) {
 		},
 		{
 			name: "single string formatted as numeric",
-			inference: pf.Inference{
-				Exists: pf.Inference_MUST,
+			inference: protocol.Inference{
+				Exists: protocol.MustExist,
 				Types:  []string{"string"},
-				String_: &pf.Inference_String{
+				String_: &protocol.StringInference{
 					Format: "number",
 				},
 			},
@@ -178,7 +178,7 @@ func TestAsFlatType(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			projection := &Projection{
-				Projection: pf.Projection{
+				Projection: &protocol.Projection{
 					Inference: tt.inference,
 				},
 			}

--- a/materialize-sql-json/type_mapping_test.go
+++ b/materialize-sql-json/type_mapping_test.go
@@ -1,0 +1,191 @@
+package sql
+
+import (
+	"testing"
+
+	pf "github.com/estuary/flow/go/protocols/flow"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAsFlatType(t *testing.T) {
+	tests := []struct {
+		name      string
+		inference pf.Inference
+		flatType  FlatType
+		mustExist bool
+	}{
+		{
+			name: "integer formatted string with integer",
+			inference: pf.Inference{
+				Exists: pf.Inference_MUST,
+				Types:  []string{"integer", "string"},
+				String_: &pf.Inference_String{
+					Format: "integer",
+				},
+			},
+			flatType:  INTEGER,
+			mustExist: true,
+		},
+		{
+			name: "number formatted string with number",
+			inference: pf.Inference{
+				Exists: pf.Inference_MAY,
+				Types:  []string{"number", "string"},
+				String_: &pf.Inference_String{
+					Format: "number",
+				},
+			},
+			flatType:  NUMBER,
+			mustExist: false,
+		},
+		{
+			name: "integer formatted string with number",
+			inference: pf.Inference{
+				Exists: pf.Inference_MAY,
+				Types:  []string{"number", "string"},
+				String_: &pf.Inference_String{
+					Format: "integer",
+				},
+			},
+			flatType:  MULTIPLE,
+			mustExist: false,
+		},
+		{
+			name: "single number type",
+			inference: pf.Inference{
+				Exists: pf.Inference_MAY,
+				Types:  []string{"number"},
+			},
+			flatType:  NUMBER,
+			mustExist: false,
+		},
+		{
+			name: "number formatted string with number and other field",
+			inference: pf.Inference{
+				Exists: pf.Inference_MAY,
+				Types:  []string{"number", "string", "array"},
+				String_: &pf.Inference_String{
+					Format: "number",
+				},
+			},
+			flatType:  MULTIPLE,
+			mustExist: false,
+		},
+		{
+			name: "number formatted string with integer",
+			inference: pf.Inference{
+				Exists: pf.Inference_MAY,
+				Types:  []string{"integer", "string"},
+				String_: &pf.Inference_String{
+					Format: "number",
+				},
+			},
+			flatType:  MULTIPLE,
+			mustExist: false,
+		},
+		{
+			name: "multiple types with null",
+			inference: pf.Inference{
+				Exists: pf.Inference_MUST,
+				Types:  []string{"integer", "string", "null"},
+			},
+			flatType:  MULTIPLE,
+			mustExist: false,
+		},
+		{
+			name: "no types",
+			inference: pf.Inference{
+				Exists: pf.Inference_MUST,
+				Types:  nil,
+			},
+			flatType:  NEVER,
+			mustExist: false,
+		},
+		{
+			name: "no types with format",
+			inference: pf.Inference{
+				Exists: pf.Inference_MUST,
+				Types:  nil,
+				String_: &pf.Inference_String{
+					Format: "number",
+				},
+			},
+			flatType:  NEVER,
+			mustExist: false,
+		},
+		{
+			name: "other formatted string with integer",
+			inference: pf.Inference{
+				Exists: pf.Inference_MAY,
+				Types:  []string{"integer", "string"},
+				String_: &pf.Inference_String{
+					Format: "array",
+				},
+			},
+			flatType:  MULTIPLE,
+			mustExist: false,
+		},
+		{
+			name: "format with two non-string fields",
+			inference: pf.Inference{
+				Exists: pf.Inference_MAY,
+				Types:  []string{"integer", "number"},
+				String_: &pf.Inference_String{
+					Format: "number",
+				},
+			},
+			flatType:  MULTIPLE,
+			mustExist: false,
+		},
+		{
+			name: "format with two string fields",
+			inference: pf.Inference{
+				Exists: pf.Inference_MAY,
+				Types:  []string{"string", "string"},
+				String_: &pf.Inference_String{
+					Format: "number",
+				},
+			},
+			flatType:  MULTIPLE,
+			mustExist: false,
+		},
+		{
+			name: "allowable format with a null is not mustExist",
+			inference: pf.Inference{
+				Exists: pf.Inference_MUST,
+				Types:  []string{"string", "null"},
+				String_: &pf.Inference_String{
+					Format: "number",
+				},
+			},
+			flatType:  STRING,
+			mustExist: false,
+		},
+		{
+			name: "single string formatted as numeric",
+			inference: pf.Inference{
+				Exists: pf.Inference_MUST,
+				Types:  []string{"string"},
+				String_: &pf.Inference_String{
+					Format: "number",
+				},
+			},
+			flatType:  NUMBER,
+			mustExist: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			projection := &Projection{
+				Projection: pf.Projection{
+					Inference: tt.inference,
+				},
+			}
+
+			flatType, mustExist := projection.AsFlatType()
+			require.Equal(t, tt.flatType, flatType)
+			require.Equal(t, tt.mustExist, mustExist)
+		})
+	}
+}

--- a/materialize-sql-json/validate.go
+++ b/materialize-sql-json/validate.go
@@ -3,13 +3,12 @@ package sql
 import (
 	"fmt"
 
-	pf "github.com/estuary/flow/go/protocols/flow"
-	pm "github.com/estuary/flow/go/protocols/materialize"
+	"github.com/estuary/connectors/go/protocol"
 )
 
 // ValidateSelectedFields validates a proposed MaterializationSpec against a set of constraints. If
 // any constraints would be violated, then an error is returned.
-func ValidateSelectedFields(constraints map[string]*pm.Constraint, proposed *pf.MaterializationSpec_Binding) error {
+func ValidateSelectedFields(constraints map[string]protocol.Constraint, proposed protocol.ApplyBinding) error {
 	// Track all the location pointers for each included field so that we can verify all the
 	// LOCATION_REQUIRED constraints are met.
 	var includedPointers = make(map[string]bool)
@@ -19,26 +18,26 @@ func ValidateSelectedFields(constraints map[string]*pm.Constraint, proposed *pf.
 	for _, field := range allFields {
 		var projection = proposed.Collection.GetProjection(field)
 		if projection == nil {
-			return fmt.Errorf("No such projection for field '%s'", field)
+			return fmt.Errorf("no such projection for field '%s'", field)
 		}
 		includedPointers[projection.Ptr] = true
 		var constraint = constraints[field]
 		if constraint.Type.IsForbidden() {
-			return fmt.Errorf("The field '%s' may not be materialize because it has constraint: %s with reason: %s", field, constraint.Type, constraint.Reason)
+			return fmt.Errorf("the field '%s' may not be materialize because it has constraint: %s with reason: %s", field, constraint.Type, constraint.Reason)
 		}
 	}
 
 	// Are all of the required fields and locations included?
 	for field, constraint := range constraints {
 		switch constraint.Type {
-		case pm.Constraint_FIELD_REQUIRED:
+		case protocol.FieldRequired:
 			if !SliceContains(field, allFields) {
-				return fmt.Errorf("Required field '%s' is missing. It is required because: %s", field, constraint.Reason)
+				return fmt.Errorf("required field '%s' is missing. It is required because: %s", field, constraint.Reason)
 			}
-		case pm.Constraint_LOCATION_REQUIRED:
+		case protocol.LocationRequired:
 			var projection = proposed.Collection.GetProjection(field)
 			if !includedPointers[projection.Ptr] {
-				return fmt.Errorf("The materialization must include a projections of location '%s', but no such projection is included", projection.Ptr)
+				return fmt.Errorf("the materialization must include a projections of location '%s', but no such projection is included", projection.Ptr)
 			}
 		}
 	}
@@ -50,36 +49,36 @@ func ValidateSelectedFields(constraints map[string]*pm.Constraint, proposed *pf.
 // **new** materialization (one that is not running and has never been Applied). Note that this will
 // "recommend" all projections of single scalar types, which is what drives the default field
 // selection in flowctl.
-func ValidateNewSQLProjections(resource Resource, proposed *pf.CollectionSpec) map[string]*pm.Constraint {
-	var constraints = make(map[string]*pm.Constraint)
+func ValidateNewSQLProjections(resource Resource, proposed protocol.CollectionSpec) map[string]protocol.Constraint {
+	var constraints = make(map[string]protocol.Constraint)
 	for _, projection := range proposed.Projections {
-		var constraint = new(pm.Constraint)
+		var constraint = protocol.Constraint{}
 		switch {
 		case len(projection.Field) > 63:
-			constraint.Type = pm.Constraint_FIELD_FORBIDDEN
+			constraint.Type = protocol.FieldForbidden
 			constraint.Reason = "Field names must be less than 63 bytes in length."
 		case projection.IsPrimaryKey:
-			constraint.Type = pm.Constraint_LOCATION_REQUIRED
+			constraint.Type = protocol.LocationRequired
 			constraint.Reason = "All Locations that are part of the collections key are required"
 		case projection.IsRootDocumentProjection() && resource.DeltaUpdates():
-			constraint.Type = pm.Constraint_LOCATION_RECOMMENDED
+			constraint.Type = protocol.LocationRecommended
 			constraint.Reason = "The root document should usually be materialized"
 		case projection.IsRootDocumentProjection():
-			constraint.Type = pm.Constraint_LOCATION_REQUIRED
+			constraint.Type = protocol.LocationRequired
 			constraint.Reason = "The root document must be materialized"
 		case projection.Inference.IsSingleScalarType():
-			constraint.Type = pm.Constraint_LOCATION_RECOMMENDED
+			constraint.Type = protocol.LocationRecommended
 			constraint.Reason = "The projection has a single scalar type"
 
 		case projection.Inference.IsSingleType() || len(effectiveJsonTypes(&projection)) == 1:
-			constraint.Type = pm.Constraint_FIELD_OPTIONAL
+			constraint.Type = protocol.FieldOptional
 			constraint.Reason = "This field is able to be materialized"
 		default:
 			// If we got here, then either the field may have multiple incompatible types, or the
 			// only possible type is "null". In either case, we're not going to allow it.
 			// Technically, we could allow the null type to be materialized, but I can't think of a
 			// use case where that would be desirable.
-			constraint.Type = pm.Constraint_FIELD_FORBIDDEN
+			constraint.Type = protocol.FieldForbidden
 			constraint.Reason = "Cannot materialize this field"
 		}
 		constraints[projection.Field] = constraint
@@ -91,16 +90,16 @@ func ValidateNewSQLProjections(resource Resource, proposed *pf.CollectionSpec) m
 // CollectionSpec for a materialization that is already running, or has been Applied. The returned
 // constraints will explicitly require all fields that are currently materialized, as long as they
 // are not unsatisfiable, and forbid any fields that are not currently materialized.
-func ValidateMatchesExisting(existing *pf.MaterializationSpec_Binding, proposed *pf.CollectionSpec) map[string]*pm.Constraint {
-	var constraints = make(map[string]*pm.Constraint)
+func ValidateMatchesExisting(existing protocol.ApplyBinding, proposed protocol.CollectionSpec) map[string]protocol.Constraint {
+	var constraints = make(map[string]protocol.Constraint)
 	for _, field := range existing.FieldSelection.AllFields() {
-		var constraint = new(pm.Constraint)
-		var typeError = checkTypeError(field, &existing.Collection, proposed)
+		var constraint = protocol.Constraint{}
+		var typeError = checkTypeError(field, existing.Collection, proposed)
 		if len(typeError) > 0 {
-			constraint.Type = pm.Constraint_UNSATISFIABLE
+			constraint.Type = protocol.Unsatisfiable
 			constraint.Reason = typeError
 		} else {
-			constraint.Type = pm.Constraint_FIELD_REQUIRED
+			constraint.Type = protocol.FieldRequired
 			constraint.Reason = "This field is part of the current materialization"
 		}
 
@@ -111,8 +110,8 @@ func ValidateMatchesExisting(existing *pf.MaterializationSpec_Binding, proposed 
 	// mention are implicitly forbidden.
 	for _, proj := range proposed.Projections {
 		if _, ok := constraints[proj.Field]; !ok {
-			var constraint = new(pm.Constraint)
-			constraint.Type = pm.Constraint_FIELD_FORBIDDEN
+			var constraint = protocol.Constraint{}
+			constraint.Type = protocol.FieldForbidden
 			constraint.Reason = "This field is not included in the existing materialization."
 			constraints[proj.Field] = constraint
 		}
@@ -121,7 +120,7 @@ func ValidateMatchesExisting(existing *pf.MaterializationSpec_Binding, proposed 
 	return constraints
 }
 
-func checkTypeError(field string, existing *pf.CollectionSpec, proposed *pf.CollectionSpec) string {
+func checkTypeError(field string, existing protocol.CollectionSpec, proposed protocol.CollectionSpec) string {
 	// existingProjection is guaranteed to exist since the MaterializationSpec has already been
 	// validated.
 	var existingProjection = existing.GetProjection(field)

--- a/materialize-sql-json/validate.go
+++ b/materialize-sql-json/validate.go
@@ -1,0 +1,154 @@
+package sql
+
+import (
+	"fmt"
+
+	pf "github.com/estuary/flow/go/protocols/flow"
+	pm "github.com/estuary/flow/go/protocols/materialize"
+)
+
+// ValidateSelectedFields validates a proposed MaterializationSpec against a set of constraints. If
+// any constraints would be violated, then an error is returned.
+func ValidateSelectedFields(constraints map[string]*pm.Constraint, proposed *pf.MaterializationSpec_Binding) error {
+	// Track all the location pointers for each included field so that we can verify all the
+	// LOCATION_REQUIRED constraints are met.
+	var includedPointers = make(map[string]bool)
+
+	// Does each field in the materialization have an allowable constraint?
+	var allFields = proposed.FieldSelection.AllFields()
+	for _, field := range allFields {
+		var projection = proposed.Collection.GetProjection(field)
+		if projection == nil {
+			return fmt.Errorf("No such projection for field '%s'", field)
+		}
+		includedPointers[projection.Ptr] = true
+		var constraint = constraints[field]
+		if constraint.Type.IsForbidden() {
+			return fmt.Errorf("The field '%s' may not be materialize because it has constraint: %s with reason: %s", field, constraint.Type, constraint.Reason)
+		}
+	}
+
+	// Are all of the required fields and locations included?
+	for field, constraint := range constraints {
+		switch constraint.Type {
+		case pm.Constraint_FIELD_REQUIRED:
+			if !SliceContains(field, allFields) {
+				return fmt.Errorf("Required field '%s' is missing. It is required because: %s", field, constraint.Reason)
+			}
+		case pm.Constraint_LOCATION_REQUIRED:
+			var projection = proposed.Collection.GetProjection(field)
+			if !includedPointers[projection.Ptr] {
+				return fmt.Errorf("The materialization must include a projections of location '%s', but no such projection is included", projection.Ptr)
+			}
+		}
+	}
+
+	return nil
+}
+
+// ValidateNewSQLProjections returns a set of constraints for a proposed flow collection for a
+// **new** materialization (one that is not running and has never been Applied). Note that this will
+// "recommend" all projections of single scalar types, which is what drives the default field
+// selection in flowctl.
+func ValidateNewSQLProjections(resource Resource, proposed *pf.CollectionSpec) map[string]*pm.Constraint {
+	var constraints = make(map[string]*pm.Constraint)
+	for _, projection := range proposed.Projections {
+		var constraint = new(pm.Constraint)
+		switch {
+		case len(projection.Field) > 63:
+			constraint.Type = pm.Constraint_FIELD_FORBIDDEN
+			constraint.Reason = "Field names must be less than 63 bytes in length."
+		case projection.IsPrimaryKey:
+			constraint.Type = pm.Constraint_LOCATION_REQUIRED
+			constraint.Reason = "All Locations that are part of the collections key are required"
+		case projection.IsRootDocumentProjection() && resource.DeltaUpdates():
+			constraint.Type = pm.Constraint_LOCATION_RECOMMENDED
+			constraint.Reason = "The root document should usually be materialized"
+		case projection.IsRootDocumentProjection():
+			constraint.Type = pm.Constraint_LOCATION_REQUIRED
+			constraint.Reason = "The root document must be materialized"
+		case projection.Inference.IsSingleScalarType():
+			constraint.Type = pm.Constraint_LOCATION_RECOMMENDED
+			constraint.Reason = "The projection has a single scalar type"
+
+		case projection.Inference.IsSingleType() || len(effectiveJsonTypes(&projection)) == 1:
+			constraint.Type = pm.Constraint_FIELD_OPTIONAL
+			constraint.Reason = "This field is able to be materialized"
+		default:
+			// If we got here, then either the field may have multiple incompatible types, or the
+			// only possible type is "null". In either case, we're not going to allow it.
+			// Technically, we could allow the null type to be materialized, but I can't think of a
+			// use case where that would be desirable.
+			constraint.Type = pm.Constraint_FIELD_FORBIDDEN
+			constraint.Reason = "Cannot materialize this field"
+		}
+		constraints[projection.Field] = constraint
+	}
+	return constraints
+}
+
+// ValidateMatchesExisting returns a set of constraints to use when there is a new proposed
+// CollectionSpec for a materialization that is already running, or has been Applied. The returned
+// constraints will explicitly require all fields that are currently materialized, as long as they
+// are not unsatisfiable, and forbid any fields that are not currently materialized.
+func ValidateMatchesExisting(existing *pf.MaterializationSpec_Binding, proposed *pf.CollectionSpec) map[string]*pm.Constraint {
+	var constraints = make(map[string]*pm.Constraint)
+	for _, field := range existing.FieldSelection.AllFields() {
+		var constraint = new(pm.Constraint)
+		var typeError = checkTypeError(field, &existing.Collection, proposed)
+		if len(typeError) > 0 {
+			constraint.Type = pm.Constraint_UNSATISFIABLE
+			constraint.Reason = typeError
+		} else {
+			constraint.Type = pm.Constraint_FIELD_REQUIRED
+			constraint.Reason = "This field is part of the current materialization"
+		}
+
+		constraints[field] = constraint
+	}
+	// We'll loop through the proposed projections and forbid any that aren't already in our map.
+	// This is done solely so that we can supply a descriptive reason, since any fields we fail to
+	// mention are implicitly forbidden.
+	for _, proj := range proposed.Projections {
+		if _, ok := constraints[proj.Field]; !ok {
+			var constraint = new(pm.Constraint)
+			constraint.Type = pm.Constraint_FIELD_FORBIDDEN
+			constraint.Reason = "This field is not included in the existing materialization."
+			constraints[proj.Field] = constraint
+		}
+	}
+
+	return constraints
+}
+
+func checkTypeError(field string, existing *pf.CollectionSpec, proposed *pf.CollectionSpec) string {
+	// existingProjection is guaranteed to exist since the MaterializationSpec has already been
+	// validated.
+	var existingProjection = existing.GetProjection(field)
+	var proposedProjection = proposed.GetProjection(field)
+	if proposedProjection == nil {
+		return "The proposed materialization is missing the projection, which is required because it's included in the existing materialization"
+	}
+
+	// Ensure that the possible types of the proposed are compatible with the possible types of the
+	// existing. The new projection is always allowed to contain fewer types than the original since
+	// that will always work with the original database schema. Additional proposed types may be
+	// compatible if they do not alter the effective FlatType, such as adding a string formatted as
+	// an integer to an existing integer type.
+	for _, pt := range effectiveJsonTypes(proposedProjection) {
+		if !SliceContains(pt, effectiveJsonTypes(existingProjection)) && pt != "null" {
+			return fmt.Sprintf("The proposed projection may contain the type '%s', which is not part of the original projection", pt)
+		}
+	}
+
+	return ""
+}
+
+func SliceContains(expected string, actual []string) bool {
+	for _, ty := range actual {
+		if ty == expected {
+			return true
+		}
+	}
+	return false
+}

--- a/testsupport/build_catalog.go
+++ b/testsupport/build_catalog.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	"github.com/estuary/connectors/go/protocol"
-	sqlDriver "github.com/estuary/connectors/materialize-sql-json"
 	"github.com/estuary/flow/go/protocols/catalog"
 	"github.com/stretchr/testify/require"
 )
@@ -35,14 +34,11 @@ func CatalogExtract(t *testing.T, sourcePath string, fn func(*sql.DB) error) err
 	return catalog.Extract(filepath.Join(tempdir, "catalog"), fn)
 }
 
-func BindingsFromCatalog(db *sql.DB, name string) (*sqlDriver.StoredSpec, error) {
+func BindingsFromCatalog(db *sql.DB, name string) ([]protocol.ApplyBinding, error) {
 	protobufSpec, err := catalog.LoadMaterialization(db, name)
 	if err != nil {
 		return nil, err
 	}
 
-	return &sqlDriver.StoredSpec{
-		Materialization: name,
-		Bindings:        protocol.MaterializationSpecPbToBindings(protobufSpec),
-	}, nil
+	return protocol.MaterializationSpecPbToBindings(protobufSpec), nil
 }

--- a/testsupport/build_catalog.go
+++ b/testsupport/build_catalog.go
@@ -7,6 +7,8 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/estuary/connectors/go/protocol"
+	sqlDriver "github.com/estuary/connectors/materialize-sql-json"
 	"github.com/estuary/flow/go/protocols/catalog"
 	"github.com/stretchr/testify/require"
 )
@@ -31,4 +33,16 @@ func CatalogExtract(t *testing.T, sourcePath string, fn func(*sql.DB) error) err
 	require.NoError(t, cmd.Run())
 
 	return catalog.Extract(filepath.Join(tempdir, "catalog"), fn)
+}
+
+func BindingsFromCatalog(db *sql.DB, name string) (*sqlDriver.StoredSpec, error) {
+	protobufSpec, err := catalog.LoadMaterialization(db, name)
+	if err != nil {
+		return nil, err
+	}
+
+	return &sqlDriver.StoredSpec{
+		Materialization: name,
+		Bindings:        protocol.MaterializationSpecPbToBindings(protobufSpec),
+	}, nil
 }


### PR DESCRIPTION
**Description:**

This PR converts `materialize-postgres` to use the Flow JSON protocol. The change should be entirely transparent with no change to the connector's behavior from a user's point of view, but it took a bit of work to get there.

The commits lay out these general changes & additions:
- Creating the go types for JSON protocol messages related to materializations
- Creating a "boilerplate" layer for starting up a Go-based materialization connector to read JSON protocol messages and handle them asynchronously
- Adapting `materialize-sql` to use the JSON protocol.
- Adapting `materialize-postgres` to use the JSON protocol via the new `materialize-sql`.

The first commit in the series is entirely a copy of `materialize-sql` to `materialize-sql-json`, which later commits change. A significant portion of the diff is from this trivial copying, so it may be best to review commit-by-commit to see the actual changes that were needed to `materialize-sql`. I've opted to do it this way so that materialization connectors can be updated one-by-one in a somewhat more controlled fashion than changing over all of them simultaneously.

**Workflow steps:**

New materializations can be created using the JSON protocol following the same general pattern here. `materialize-postgres` will continue to function as it always has.

**Documentation links affected:**

N/A

**Notes for reviewers:**

(anything that might help someone review this PR)

