### PR TITLE
ci: install postgresql instead of postgresql-client

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -259,7 +259,7 @@ jobs:
 
       - name: Install psql
         if: ${{ github.event_name == 'push' }}
-        run: sudo apt install postgresql-client
+        run: sudo apt install postgresql
 
       - name: Refresh connector tags for ${{ matrix.connector.path }}
         if: ${{ github.event_name == 'push' }}


### PR DESCRIPTION
**Description:**

- Fix CI by installing `postgresql` instead of `postgresql-client` which seems to have been removed from the repositories

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/567)
<!-- Reviewable:end -->
