### PR TITLE
source-alpaca: revert temporary fix for long, empty backfills

### DIFF
--- a/source-alpaca/worker.go
+++ b/source-alpaca/worker.go
@@ -239,21 +239,11 @@ func (c *alpacaWorker) doBackfill(ctx context.Context, startLimit, endLimit time
 
 		docsChan := make(chan tradeDocument)
 
-		// TODO(whb): This is a temporary hack to handle a long-running backfill.
-		minCheckpointDate := func(t time.Time) time.Time {
-			minTime, _ := time.Parse(time.RFC3339Nano, "2020-08-01T00:00:00Z")
-			if t.Before(minTime) {
-				return minTime
-			} else {
-				return t
-			}
-		}
-
 		eg := errgroup.Group{}
 		eg.Go(func() error {
 			checkpoint := captureState{
 				BackfilledUntil: map[string]time.Time{
-					c.resourceName: minCheckpointDate(end),
+					c.resourceName: end,
 				},
 			}
 


### PR DESCRIPTION
**Description:**

This reverts a couple of commits for `source-alpaca` that were used to unblock a capture that was doing a long backfill over a time period that was not generating data.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

N/A

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/573)
<!-- Reviewable:end -->
