### PR TITLE
source-alpaca: set a minimum start date

### DIFF
--- a/source-alpaca/.snapshots/TestSpec
+++ b/source-alpaca/.snapshots/TestSpec
@@ -34,7 +34,7 @@
         "type": "string",
         "format": "date-time",
         "title": "Start Date",
-        "description": "Get trades starting at this date. Has no effect if changed after the capture has started."
+        "description": "Get trades starting at this date. Has no effect if changed after the capture has started. Must be no earlier than 2016-01-01T00:00:00Z."
       },
       "advanced": {
         "properties": {

--- a/source-alpaca/driver_test.go
+++ b/source-alpaca/driver_test.go
@@ -26,9 +26,9 @@ func TestDiscover(t *testing.T) {
 	// can always test it as part of the normal unit tests.
 	t.Setenv("TEST_DATABASE", "yes")
 
-	startDate, err := time.Parse(time.RFC3339Nano, "2006-01-02T15:04:05.999999999Z")
+	startDate, err := time.Parse(time.RFC3339Nano, "2019-01-02T15:04:05.999999999Z")
 	require.NoError(t, err)
-	endDate, err := time.Parse(time.RFC3339Nano, "2007-02-03T15:04:05.999999999Z")
+	endDate, err := time.Parse(time.RFC3339Nano, "2019-02-03T15:04:05.999999999Z")
 	require.NoError(t, err)
 
 	capture := captureSpec(t, []string{"trades"}, []string{"AAPL"}, startDate, endDate, nil)

--- a/source-alpaca/main_test.go
+++ b/source-alpaca/main_test.go
@@ -34,6 +34,9 @@ func TestConfigValidate(t *testing.T) {
 	missingStart := valid
 	missingStart.StartDate = time.Time{}
 
+	tooEarlyStartDate := valid
+	tooEarlyStartDate.StartDate = time.Unix(0, minStartTimeNanos).Add(-1 * time.Second)
+
 	wrongFeed := valid
 	wrongFeed.Feed = "otherThing"
 
@@ -64,6 +67,11 @@ func TestConfigValidate(t *testing.T) {
 			name:   "missing start date",
 			config: missingStart,
 			want:   fmt.Errorf("must provide a value for start_date"),
+		},
+		{
+			name:   "start date too early",
+			config: tooEarlyStartDate,
+			want:   fmt.Errorf("start_date must not be before 2016-01-01T00:00:00Z"),
 		},
 		{
 			name:   "invalid feed",


### PR DESCRIPTION
**Description:**

Data is not available from the historical Alpaca APIs until 01-01-2016. If somebody puts in a start time way before that, the connector will churn through a potentially large amount of empty time ranges while backfilling and take a long time to actually start producing data. This adds a constraint to the configuration that a start date no earlier than 01-01-2016 can be used.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

See https://github.com/estuary/flow/pull/964

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/574)
<!-- Reviewable:end -->
