### PR TITLE
materialize-sql: schema migration to alter table and add new column

### DIFF
--- a/materialize-bigquery/bigquery.go
+++ b/materialize-bigquery/bigquery.go
@@ -175,6 +175,7 @@ func newBigQueryDriver() pm.DriverServer {
 				Client:                      client,
 				CreateTableTemplate:         tplCreateTargetTable,
 				AlterColumnNullableTemplate: tplAlterColumnNullable,
+				AlterTableAddColumnTemplate: tplAlterTableAddColumn,
 				NewResource:                 newTableConfig,
 				NewTransactor:               newTransactor,
 			}, nil

--- a/materialize-bigquery/sqlgen.go
+++ b/materialize-bigquery/sqlgen.go
@@ -127,6 +127,17 @@ CLUSTER BY {{ range $ind, $key := $.Keys }}
 ALTER TABLE {{ $.Table.Identifier }} ALTER COLUMN {{ $.Identifier }} DROP NOT NULL;
 {{ end }}
 
+-- Alter table and add a new column
+
+{{ define "alterTableAddColumn" }}
+ALTER TABLE {{ $.Table.Identifier }} ADD COLUMN
+	{{ range $ind, $col := $.Table.Columns -}}
+		{{- if (eq $col.Identifier $.Identifier) -}}
+			{{ $col.Identifier }} {{ $col.DDL }}
+		{{- end -}}
+	{{- end }};
+{{ end }}
+
 -- Templated query which joins keys from the load table with the target table,
 -- and returns values. It deliberately skips the trailing semi-colon
 -- as these queries are composed with a UNION ALL.
@@ -274,4 +285,5 @@ UPDATE {{ Identifier $.TablePath }}
 	tplStoreInsert         = tplAll.Lookup("storeInsert")
 	tplStoreUpdate         = tplAll.Lookup("storeUpdate")
 	tplAlterColumnNullable = tplAll.Lookup("alterColumnNullable")
+	tplAlterTableAddColumn = tplAll.Lookup("alterTableAddColumn")
 )

--- a/materialize-postgres/driver.go
+++ b/materialize-postgres/driver.go
@@ -172,6 +172,7 @@ func newPostgresDriver() pm.DriverServer {
 				Client:                      client{uri: cfg.ToURI()},
 				CreateTableTemplate:         tplCreateTargetTable,
 				AlterColumnNullableTemplate: tplAlterColumnNullable,
+				AlterTableAddColumnTemplate: tplAlterTableAddColumn,
 				NewResource:                 newTableConfig,
 				NewTransactor:               newTransactor,
 			}, nil

--- a/materialize-postgres/sqlgen.go
+++ b/materialize-postgres/sqlgen.go
@@ -88,6 +88,17 @@ COMMENT ON COLUMN {{$.Identifier}}.{{$col.Identifier}} IS {{Literal $col.Comment
 ALTER TABLE {{ $.Table.Identifier }} ALTER COLUMN {{ $.Identifier }} DROP NOT NULL;
 {{ end }}
 
+-- Alter table and add a new column
+
+{{ define "alterTableAddColumn" }}
+ALTER TABLE {{ $.Table.Identifier }} ADD COLUMN
+	{{ range $ind, $col := $.Table.Columns -}}
+		{{- if (eq $col.Identifier $.Identifier) -}}
+			{{ $col.Identifier }} {{ $col.DDL }}
+		{{- end -}}
+	{{- end }};
+{{ end }}
+
 -- Templated creation of a temporary load table:
 
 {{ define "createLoadTable" }}
@@ -261,4 +272,5 @@ END $$;
 	tplInstallFence        = tplAll.Lookup("installFence")
 	tplUpdateFence         = tplAll.Lookup("updateFence")
 	tplAlterColumnNullable = tplAll.Lookup("alterColumnNullable")
+	tplAlterTableAddColumn = tplAll.Lookup("alterTableAddColumn")
 )

--- a/materialize-snowflake/snowflake.go
+++ b/materialize-snowflake/snowflake.go
@@ -163,6 +163,7 @@ func newSnowflakeDriver() *sql.Driver {
 				Client:                      client{uri: dsn},
 				CreateTableTemplate:         tplCreateTargetTable,
 				AlterColumnNullableTemplate: tplAlterColumnNullable,
+				AlterTableAddColumnTemplate: tplAlterTableAddColumn,
 				NewResource:                 newTableConfig,
 				NewTransactor:               newTransactor,
 			}, nil

--- a/materialize-snowflake/sqlgen.go
+++ b/materialize-snowflake/sqlgen.go
@@ -123,6 +123,17 @@ var (
 ALTER TABLE {{ $.Table.Identifier }} ALTER COLUMN {{ $.Identifier }} DROP NOT NULL;
 {{ end }}
 
+-- Alter table and add a new column
+
+{{ define "alterTableAddColumn" }}
+ALTER TABLE {{ $.Table.Identifier }} ADD COLUMN
+	{{ range $ind, $col := $.Table.Columns -}}
+		{{- if (eq $col.Identifier $.Identifier) -}}
+			{{ $col.Identifier }} {{ $col.DDL }}
+		{{- end -}}
+	{{- end }};
+{{ end }}
+
 {{ define "loadQuery" }}
 	SELECT {{ $.Table.Binding }}, {{ $.Table.Identifier }}.{{ $.Table.Document.Identifier }}
 	FROM {{ $.Table.Identifier }}
@@ -217,6 +228,7 @@ END $$;
 	tplMergeInto           = tplAll.Lookup("mergeInto")
 	tplUpdateFence         = tplAll.Lookup("updateFence")
 	tplAlterColumnNullable = tplAll.Lookup("alterColumnNullable")
+	tplAlterTableAddColumn = tplAll.Lookup("alterTableAddColumn")
 )
 
 var createStageSQL = `

--- a/materialize-sql/.snapshots/TestAlterTableAddColumnTemplate
+++ b/materialize-sql/.snapshots/TestAlterTableAddColumnTemplate
@@ -1,0 +1,4 @@
+
+	ALTER TABLE one."reserved".checkpoints ADD COLUMN
+		checkpoint TEXT NOT NULL;
+  

--- a/materialize-sql/driver.go
+++ b/materialize-sql/driver.go
@@ -143,7 +143,7 @@ func (d *Driver) ApplyUpsert(ctx context.Context, req *pm.ApplyRequest) (*pm.App
 			// fields in the request is identical to the current fields.
 			return nil, fmt.Errorf(
 				"the set of binding %s fields in the request differs from the existing fields,"+
-					"which is disallowed because this driver only supports autoamtic migration for adding new fields. "+
+					"which is disallowed because this driver only supports automatic migration for adding new fields. "+
 					"Request fields: %s , Existing fields: %s",
 				collection,
 				bindingSpec.FieldSelection.String(),

--- a/materialize-sql/endpoint.go
+++ b/materialize-sql/endpoint.go
@@ -74,6 +74,9 @@ type Endpoint struct {
 	CreateTableTemplate *template.Template
 	// AlterFieldNullable alters a column and marks it as nullable
 	AlterColumnNullableTemplate *template.Template
+	// AlterTableAddColumn alters a table and adds a new column (usually with
+	// default null value)
+	AlterTableAddColumnTemplate *template.Template
 
 	// NewResource returns an uninitialized or partially-initialized Resource
 	// which will be parsed into and validated from a resource configuration.
@@ -145,7 +148,7 @@ func resolveResourceToExistingBinding(
 		// key and can no longer be loaded correctly by a standard materialization.
 		err = fmt.Errorf("cannot disable delta-updates binding of collection %s", collection.Collection)
 	} else if loadedBinding != nil {
-		constraints = ValidateMatchesExisting(loadedBinding, collection)
+		constraints = ValidateMatchesExisting(resource, loadedBinding, collection)
 	} else {
 		constraints = ValidateNewSQLProjections(resource, collection)
 	}

--- a/materialize-sql/templating.go
+++ b/materialize-sql/templating.go
@@ -31,12 +31,12 @@ func RenderTableTemplate(table Table, tpl *template.Template) (string, error) {
 	return w.String(), nil
 }
 
-type AlterColumnNullableInput struct {
+type AlterInput struct {
 	Table Table
 	Identifier string
 }
 
-func RenderAlterColumnNullableTemplate(input AlterColumnNullableInput, tpl *template.Template) (string, error) {
+func RenderAlterTemplate(input AlterInput, tpl *template.Template) (string, error) {
 	var w strings.Builder
 	if err := tpl.Execute(&w, &input); err != nil {
 		return "", err

--- a/materialize-sql/templating_test.go
+++ b/materialize-sql/templating_test.go
@@ -93,7 +93,29 @@ func TestAlterColumnNullableTemplate(t *testing.T) {
   ALTER TABLE {{ $.Table.Identifier }} ALTER COLUMN {{ $.Identifier }} DROP NOT NULL;
   `)
 
-  out, err := RenderAlterColumnNullableTemplate(AlterColumnNullableInput { Table: table, Identifier: "id" }, tpl)
+  out, err := RenderAlterTemplate(AlterInput { Table: table, Identifier: "id" }, tpl)
+	require.NoError(t, err)
+	cupaloy.SnapshotT(t, out)
+}
+
+func TestAlterTableAddColumnTemplate(t *testing.T) {
+	var (
+		shape      = FlowCheckpointsTable("one", "reserved", "checkpoints")
+		dialect    = newTestDialect()
+		table, err = ResolveTable(shape, dialect)
+	)
+	assert.NoError(t, err)
+
+	var tpl = MustParseTemplate(dialect, "template", `
+	ALTER TABLE {{ $.Table.Identifier }} ADD COLUMN
+		{{ range $ind, $col := $.Table.Columns -}}
+			{{- if (eq $col.Identifier $.Identifier) -}}
+				{{ $col.Identifier }} {{ $col.DDL }}
+			{{- end -}}
+		{{- end }};
+  `)
+
+  out, err := RenderAlterTemplate(AlterInput { Table: table, Identifier: "checkpoint" }, tpl)
 	require.NoError(t, err)
 	cupaloy.SnapshotT(t, out)
 }

--- a/materialize-sql/validate.go
+++ b/materialize-sql/validate.go
@@ -111,9 +111,8 @@ func ValidateMatchesExisting(resource Resource, existing *pf.MaterializationSpec
 
 		constraints[field] = constraint
 	}
-	// We'll loop through the proposed projections and forbid any that aren't already in our map.
-	// This is done solely so that we can supply a descriptive reason, since any fields we fail to
-	// mention are implicitly forbidden.
+	// We'll loop through the proposed projections and create a new constraint for
+	// fields that are not among our existing binding projections
 	for _, proj := range proposed.Projections {
 		if _, ok := constraints[proj.Field]; !ok {
 			var constraint = validateNewProjection(resource, &proj)

--- a/materialize-sqlite/sqlgen.go
+++ b/materialize-sqlite/sqlgen.go
@@ -88,6 +88,17 @@ var (
   );
   {{ end }}
 
+	-- Alter table and add a new column
+
+	{{ define "alterTableAddColumn" }}
+	ALTER TABLE {{ $.Table.Identifier }} ADD COLUMN
+		{{ range $ind, $col := $.Table.Columns -}}
+			{{- if (eq $col.Identifier $.Identifier) -}}
+				{{ $col.Identifier }} {{ $col.DDL }}
+			{{- end -}}
+		{{- end }};
+	{{ end }}
+
   -- Load
   {{ define "loadQuery" }}
   {{ if $.Document -}}
@@ -147,15 +158,17 @@ var (
   ;
   {{ end }}
   `)
-  tplCreateTargetTable = tplAll.Lookup("createTargetTable")
-  tplCreateLoadTable   = tplAll.Lookup("createLoadTable")
+  tplCreateTargetTable   = tplAll.Lookup("createTargetTable")
+  tplCreateLoadTable     = tplAll.Lookup("createLoadTable")
 
-  tplLoadInsert        = tplAll.Lookup("loadInsert")
-  tplLoadQuery         = tplAll.Lookup("loadQuery")
-  tplLoadTruncate      = tplAll.Lookup("loadTruncate")
+  tplLoadInsert          = tplAll.Lookup("loadInsert")
+  tplLoadQuery           = tplAll.Lookup("loadQuery")
+  tplLoadTruncate        = tplAll.Lookup("loadTruncate")
 
-  tplStoreInsert       = tplAll.Lookup("storeInsert")
-  tplStoreUpdate       = tplAll.Lookup("storeUpdate")
+  tplStoreInsert         = tplAll.Lookup("storeInsert")
+  tplStoreUpdate         = tplAll.Lookup("storeUpdate")
+
+	tplAlterTableAddColumn = tplAll.Lookup("alterTableAddColumn")
 )
 
 const createStageSQL = `


### PR DESCRIPTION
**Description:**

- Allow new fields to be added to bindings, and in turn add new columns to existing tables for `materialize-sql` connectors. I've tested `materialize-postgres` so far.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/581)
<!-- Reviewable:end -->
