### PR TITLE
materialize-postgres: handle materializations with no values materialized

### DIFF
--- a/materialize-postgres/.snapshots/TestSQLGeneration
+++ b/materialize-postgres/.snapshots/TestSQLGeneration
@@ -160,6 +160,15 @@ EXECUTE update_0--- End "a-schema".target_table execStoreUpdate ---
 --- Begin "Delta Updates" execStoreUpdate ---
 EXECUTE update_1--- End "Delta Updates" execStoreUpdate ---
 
+--- Begin target_table_no_values_materialized storeUpdate ---
+
+PREPARE update_2 AS
+UPDATE target_table_no_values_materialized SET
+		flow_document = $3
+	 WHERE key1 = $1
+	 AND   key2 = $2;
+--- End target_table_no_values_materialized storeUpdate ---
+
 --- Begin Fence Install ---
 
 with

--- a/materialize-postgres/sqlgen.go
+++ b/materialize-postgres/sqlgen.go
@@ -187,7 +187,8 @@ UPDATE {{$.Identifier}} SET
 		{{- if $ind }},{{ end }}
 		{{ $val.Identifier}} = {{ $val.Placeholder }}
 	{{- end }}
-	{{- if $.Document }},
+	{{- if $.Document -}}
+		{{ if $.Values }},{{ end }}
 		{{ $.Document.Identifier }} = {{ $.Document.Placeholder }}
 	{{- end -}}
 	{{ range $ind, $key := $.Keys }}

--- a/materialize-postgres/sqlgen_test.go
+++ b/materialize-postgres/sqlgen_test.go
@@ -69,6 +69,18 @@ func TestSQLGeneration(t *testing.T) {
 		}
 	}
 
+	var shapeNoValues = sqlDriver.BuildTableShape(spec, 2, tableConfig{
+		Schema: "",
+		Table:  "target_table_no_values_materialized",
+		Delta:  false,
+	})
+	tableNoValues, err := sqlDriver.ResolveTable(shapeNoValues, pgDialect)
+	require.NoError(t, err)
+
+	snap.WriteString("--- Begin " + "target_table_no_values_materialized storeUpdate" + " ---\n")
+	require.NoError(t, tplPrepStoreUpdate.Execute(&snap, &tableNoValues))
+	snap.WriteString("--- End " + "target_table_no_values_materialized storeUpdate" + " ---\n\n")
+
 	var fence = sqlDriver.Fence{
 		TablePath:       sqlDriver.TablePath{"path", "To", "checkpoints"},
 		Checkpoint:      []byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9},

--- a/materialize-postgres/testdata/flow.yaml
+++ b/materialize-postgres/testdata/flow.yaml
@@ -29,6 +29,15 @@ collections:
       required: [theKey, nullableKey]
     key: [/theKey, /nullableKey]
 
+  no_values:
+    schema:
+      type: object
+      properties:
+        key1: { type: integer }
+        key2: { type: boolean }
+      required: [key1, key2]
+    key: [/key1, /key2]
+
 materializations:
   test/sqlite:
     endpoint:
@@ -46,6 +55,10 @@ materializations:
         resource:
           table: "Delta Updates"
           #deltaUpdates: true
+
+      - source: no_values
+        resource:
+          table: "No Values"
 
 storageMappings:
   "": { stores: [{ provider: S3, bucket: a-bucket }] }


### PR DESCRIPTION
**Description:**

Fixes an invalid query that could occur when a load query is done if no value fields are materialized. This is possible if all the fields materialized by a collection are keys and only the `flow_document` is updated.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

N/A

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/588)
<!-- Reviewable:end -->
