### PR TITLE
materialize-snowflake: sql fixes for delta_updates and no selected values

### DIFF
--- a/materialize-snowflake/.snapshots/TestSQLGeneration
+++ b/materialize-snowflake/.snapshots/TestSQLGeneration
@@ -21,22 +21,8 @@
   COMMENT ON COLUMN target_table.flow_document IS 'user-provided projection of JSON at:  with inferred types: [object]';
   --- End target_table createTargetTable ---
 
---- Begin "Delta Updates" createTargetTable ---
-  CREATE TABLE IF NOT EXISTS "Delta Updates" (
-    theKey STRING NOT NULL,
-    nullableKey STRING NOT NULL,
-    aValue INTEGER
-  );
-
-  COMMENT ON TABLE "Delta Updates" IS 'Generated for materialization test/sqlite of collection delta/updates';
-  COMMENT ON COLUMN "Delta Updates".theKey IS 'auto-generated projection of JSON at: /theKey with inferred types: [string]';
-  COMMENT ON COLUMN "Delta Updates".nullableKey IS 'auto-generated projection of JSON at: /nullableKey with inferred types: [string]';
-  COMMENT ON COLUMN "Delta Updates".aValue IS 'A super-awesome value.
-auto-generated projection of JSON at: /aValue with inferred types: [integer]';
-  --- End "Delta Updates" createTargetTable ---
-
 --- Begin target_table loadQuery ---
-	SELECT 0, target_table.flow_document
+SELECT 0, target_table.flow_document
 	FROM target_table
 	JOIN (
 		SELECT $1[0] AS key1, $1[1] AS key2
@@ -69,6 +55,47 @@ auto-generated projection of JSON at: /aValue with inferred types: [integer]';
 		INSERT (key1, key2, boolean, integer, number, string, flow_document)
 		VALUES (r.key1, r.key2, r.boolean, r.integer, r.number, r.string, r.flow_document);
 --- End target_table mergeInto ---
+
+--- Begin "Delta Updates" createTargetTable ---
+  CREATE TABLE IF NOT EXISTS "Delta Updates" (
+    theKey STRING NOT NULL,
+    nullableKey STRING NOT NULL,
+    aValue INTEGER
+  );
+
+  COMMENT ON TABLE "Delta Updates" IS 'Generated for materialization test/sqlite of collection delta/updates';
+  COMMENT ON COLUMN "Delta Updates".theKey IS 'auto-generated projection of JSON at: /theKey with inferred types: [string]';
+  COMMENT ON COLUMN "Delta Updates".nullableKey IS 'auto-generated projection of JSON at: /nullableKey with inferred types: [string]';
+  COMMENT ON COLUMN "Delta Updates".aValue IS 'A super-awesome value.
+auto-generated projection of JSON at: /aValue with inferred types: [integer]';
+  --- End "Delta Updates" createTargetTable ---
+
+--- Begin "Delta Updates" loadQuery ---
+SELECT * FROM (SELECT -1, CAST(NULL AS VARIANT) LIMIT 0) as nodoc
+--- End "Delta Updates" loadQuery ---
+
+--- Begin "Delta Updates" copyInto ---
+	COPY INTO "Delta Updates" (
+		theKey, nullableKey, aValue
+	) FROM (
+		SELECT $1[0] AS theKey, $1[1] AS nullableKey, $1[2] AS aValue
+		FROM @flow_v1/00010203-0405-0607-0809-0a0b0c0d0e0f
+	);
+--- End "Delta Updates" copyInto ---
+
+--- Begin "Delta Updates" mergeInto ---
+	MERGE INTO "Delta Updates"
+	USING (
+		SELECT $1[0] AS theKey, $1[1] AS nullableKey, $1[2] AS aValue
+		FROM @flow_v1/00010203-0405-0607-0809-0a0b0c0d0e0f
+	) AS r
+	ON "Delta Updates".theKey = r.theKey AND "Delta Updates".nullableKey = r.nullableKey
+	WHEN MATCHED THEN
+		UPDATE SET "Delta Updates".aValue = r.aValue
+	WHEN NOT MATCHED THEN
+		INSERT (theKey, nullableKey, aValue)
+		VALUES (r.theKey, r.nullableKey, r.aValue);
+--- End "Delta Updates" mergeInto ---
 
 --- Begin target_table_no_values_materialized mergeInto ---
 	MERGE INTO target_table_no_values_materialized

--- a/materialize-snowflake/.snapshots/TestSQLGeneration
+++ b/materialize-snowflake/.snapshots/TestSQLGeneration
@@ -107,7 +107,7 @@ SELECT * FROM (SELECT -1, CAST(NULL AS VARIANT) LIMIT 0) as nodoc
 	WHEN MATCHED AND IS_NULL_VALUE(r.flow_document) THEN
 		DELETE
 	WHEN MATCHED THEN
-		UPDATE SET , target_table_no_values_materialized.flow_document = r.flow_document
+		UPDATE SET target_table_no_values_materialized.flow_document = r.flow_document
 	WHEN NOT MATCHED THEN
 		INSERT (key1, key2, flow_document)
 		VALUES (r.key1, r.key2, r.flow_document);

--- a/materialize-snowflake/.snapshots/TestSQLGeneration
+++ b/materialize-snowflake/.snapshots/TestSQLGeneration
@@ -1,0 +1,108 @@
+--- Begin target_table createTargetTable ---
+  CREATE TABLE IF NOT EXISTS target_table (
+    key1 INTEGER NOT NULL,
+    key2 BOOLEAN NOT NULL,
+    boolean BOOLEAN,
+    integer INTEGER,
+    number DOUBLE,
+    string STRING,
+    flow_document VARIANT NOT NULL,
+
+    PRIMARY KEY (key1, key2)
+  );
+
+  COMMENT ON TABLE target_table IS 'Generated for materialization test/sqlite of collection key/value';
+  COMMENT ON COLUMN target_table.key1 IS 'auto-generated projection of JSON at: /key1 with inferred types: [integer]';
+  COMMENT ON COLUMN target_table.key2 IS 'auto-generated projection of JSON at: /key2 with inferred types: [boolean]';
+  COMMENT ON COLUMN target_table.boolean IS 'auto-generated projection of JSON at: /boolean with inferred types: [boolean]';
+  COMMENT ON COLUMN target_table.integer IS 'auto-generated projection of JSON at: /integer with inferred types: [integer]';
+  COMMENT ON COLUMN target_table.number IS 'auto-generated projection of JSON at: /number with inferred types: [number]';
+  COMMENT ON COLUMN target_table.string IS 'auto-generated projection of JSON at: /string with inferred types: [string]';
+  COMMENT ON COLUMN target_table.flow_document IS 'user-provided projection of JSON at:  with inferred types: [object]';
+  --- End target_table createTargetTable ---
+
+--- Begin "Delta Updates" createTargetTable ---
+  CREATE TABLE IF NOT EXISTS "Delta Updates" (
+    theKey STRING NOT NULL,
+    nullableKey STRING NOT NULL,
+    aValue INTEGER
+  );
+
+  COMMENT ON TABLE "Delta Updates" IS 'Generated for materialization test/sqlite of collection delta/updates';
+  COMMENT ON COLUMN "Delta Updates".theKey IS 'auto-generated projection of JSON at: /theKey with inferred types: [string]';
+  COMMENT ON COLUMN "Delta Updates".nullableKey IS 'auto-generated projection of JSON at: /nullableKey with inferred types: [string]';
+  COMMENT ON COLUMN "Delta Updates".aValue IS 'A super-awesome value.
+auto-generated projection of JSON at: /aValue with inferred types: [integer]';
+  --- End "Delta Updates" createTargetTable ---
+
+--- Begin target_table loadQuery ---
+	SELECT 0, target_table.flow_document
+	FROM target_table
+	JOIN (
+		SELECT $1[0] AS key1, $1[1] AS key2
+		FROM @flow_v1/00010203-0405-0607-0809-0a0b0c0d0e0f
+	) AS r
+	ON target_table.key1 = r.key1 AND target_table.key2 = r.key2
+--- End target_table loadQuery ---
+
+--- Begin target_table copyInto ---
+	COPY INTO target_table (
+		key1, key2, boolean, integer, number, string, flow_document
+	) FROM (
+		SELECT $1[0] AS key1, $1[1] AS key2, $1[2] AS boolean, $1[3] AS integer, $1[4] AS number, $1[5] AS string, $1[6] AS flow_document
+		FROM @flow_v1/00010203-0405-0607-0809-0a0b0c0d0e0f
+	);
+--- End target_table copyInto ---
+
+--- Begin target_table mergeInto ---
+	MERGE INTO target_table
+	USING (
+		SELECT $1[0] AS key1, $1[1] AS key2, $1[2] AS boolean, $1[3] AS integer, $1[4] AS number, $1[5] AS string, $1[6] AS flow_document
+		FROM @flow_v1/00010203-0405-0607-0809-0a0b0c0d0e0f
+	) AS r
+	ON target_table.key1 = r.key1 AND target_table.key2 = r.key2
+	WHEN MATCHED AND IS_NULL_VALUE(r.flow_document) THEN
+		DELETE
+	WHEN MATCHED THEN
+		UPDATE SET target_table.boolean = r.boolean, target_table.integer = r.integer, target_table.number = r.number, target_table.string = r.string, target_table.flow_document = r.flow_document
+	WHEN NOT MATCHED THEN
+		INSERT (key1, key2, boolean, integer, number, string, flow_document)
+		VALUES (r.key1, r.key2, r.boolean, r.integer, r.number, r.string, r.flow_document);
+--- End target_table mergeInto ---
+
+--- Begin target_table_no_values_materialized mergeInto ---
+	MERGE INTO target_table_no_values_materialized
+	USING (
+		SELECT $1[0] AS key1, $1[1] AS key2, $1[2] AS flow_document
+		FROM @flow_v1/00010203-0405-0607-0809-0a0b0c0d0e0f
+	) AS r
+	ON target_table_no_values_materialized.key1 = r.key1 AND target_table_no_values_materialized.key2 = r.key2
+	WHEN MATCHED AND IS_NULL_VALUE(r.flow_document) THEN
+		DELETE
+	WHEN MATCHED THEN
+		UPDATE SET , target_table_no_values_materialized.flow_document = r.flow_document
+	WHEN NOT MATCHED THEN
+		INSERT (key1, key2, flow_document)
+		VALUES (r.key1, r.key2, r.flow_document);
+--- End target_table_no_values_materialized mergeInto ---
+
+--- Begin Fence Update ---
+EXECUTE IMMEDIATE $$
+DECLARE
+    fenced_excp EXCEPTION (-20002, 'This instance was fenced off by another');
+BEGIN
+	UPDATE path."To".checkpoints
+		SET   checkpoint = 'AAECAwQFBgcICQ=='
+		WHERE materialization = 'some/Materialization'
+		AND   key_begin = 1122867
+		AND   key_end   = 4293844428
+		AND   fence     = 123;
+
+	IF (SQLNOTFOUND = true) THEN
+		RAISE fenced_excp;
+	END IF;
+
+  RETURN SQLROWCOUNT;
+END $$;
+--- End Fence Update ---
+

--- a/materialize-snowflake/snowflake.go
+++ b/materialize-snowflake/snowflake.go
@@ -6,6 +6,7 @@ import (
 	stdsql "database/sql"
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -523,4 +524,10 @@ func (f *scratchFile) put(ctx context.Context, conn *stdsql.Conn, cfg *config) e
 	return nil
 }
 
-func main() { boilerplate.RunMain(newSnowflakeDriver()) }
+func main() {
+	// gosnowflake also uses logrus for logging and the logs it produces may be confusing when
+	// intermixed with our connector logs. We disable the gosnowflake logger here and log as needed
+	// when handling errors from the sql driver.
+	sf.GetLogger().SetOutput(io.Discard)
+	boilerplate.RunMain(newSnowflakeDriver())
+}

--- a/materialize-snowflake/snowflake_test.go
+++ b/materialize-snowflake/snowflake_test.go
@@ -2,82 +2,14 @@ package main
 
 import (
 	"context"
-	stdsql "database/sql"
 	"encoding/json"
 	"testing"
 
 	"github.com/bradleyjkemp/cupaloy"
-	sql "github.com/estuary/connectors/materialize-sql"
-	"github.com/estuary/connectors/testsupport"
-	"github.com/estuary/flow/go/protocols/catalog"
 	pf "github.com/estuary/flow/go/protocols/flow"
 	pm "github.com/estuary/flow/go/protocols/materialize"
-	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 )
-
-func TestQueryGeneration(t *testing.T) {
-	var spec *pf.MaterializationSpec
-	require.NoError(t, testsupport.CatalogExtract(t, "testdata/flow.yaml",
-		func(db *stdsql.DB) error {
-			var err error
-			spec, err = catalog.LoadMaterialization(db, "test/sqlite")
-			return err
-		}))
-
-	var shape1 = sql.BuildTableShape(spec, 0, tableConfig{
-		Table: "testTable",
-		Delta: false,
-	})
-	table, err := sql.ResolveTable(shape1, snowflakeDialect)
-	require.NoError(t, err)
-
-	var loadUUID = uuid.UUID{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15}
-	var storeUUID = uuid.UUID{15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1}
-
-	loadQuery, err := RenderTableWithRandomUUIDTemplate(table, loadUUID, tplLoadQuery)
-	require.NoError(t, err)
-	copyInto, err := RenderTableWithRandomUUIDTemplate(table, storeUUID, tplCopyInto)
-	require.NoError(t, err)
-	mergeInto, err := RenderTableWithRandomUUIDTemplate(table, storeUUID, tplMergeInto)
-	require.NoError(t, err)
-
-	// Note the intentional missing semicolon, as this is a subquery.
-	require.Equal(t, `
-	SELECT 0, testTable.flow_document
-	FROM testTable
-	JOIN (
-		SELECT $1[0] AS key1, $1[1] AS key2
-		FROM @flow_v1/00010203-0405-0607-0809-0a0b0c0d0e0f
-	) AS r
-	ON testTable.key1 = r.key1 AND testTable.key2 = r.key2`,
-		loadQuery)
-
-	require.Equal(t, `
-	COPY INTO testTable (
-		key1, key2, boolean, integer, number, string, flow_document
-	) FROM (
-		SELECT $1[0] AS key1, $1[1] AS key2, $1[2] AS boolean, $1[3] AS integer, $1[4] AS number, $1[5] AS string, $1[6] AS flow_document
-		FROM @flow_v1/0f0e0d0c-0b0a-0908-0706-050403020100
-	);`,
-		copyInto)
-
-	require.Equal(t, `
-	MERGE INTO testTable
-	USING (
-		SELECT $1[0] AS key1, $1[1] AS key2, $1[2] AS boolean, $1[3] AS integer, $1[4] AS number, $1[5] AS string, $1[6] AS flow_document
-		FROM @flow_v1/0f0e0d0c-0b0a-0908-0706-050403020100
-	) AS r
-	ON testTable.key1 = r.key1 AND testTable.key2 = r.key2
-	WHEN MATCHED AND IS_NULL_VALUE(r.flow_document) THEN
-		DELETE
-	WHEN MATCHED THEN
-		UPDATE SET testTable.boolean = r.boolean, testTable.integer = r.integer, testTable.number = r.number, testTable.string = r.string, testTable.flow_document = r.flow_document
-	WHEN NOT MATCHED THEN
-		INSERT (key1, key2, boolean, integer, number, string, flow_document)
-		VALUES (r.key1, r.key2, r.boolean, r.integer, r.number, r.string, r.flow_document);`,
-		mergeInto)
-}
 
 func TestSpecification(t *testing.T) {
 	var resp, err = newSnowflakeDriver().

--- a/materialize-snowflake/sqlgen.go
+++ b/materialize-snowflake/sqlgen.go
@@ -196,7 +196,7 @@ SELECT * FROM (SELECT -1, CAST(NULL AS VARIANT) LIMIT 0) as nodoc
 		{{ $.Table.Identifier }}.{{ $key.Identifier }} = r.{{ $key.Identifier }}
 	{{- end -}}
 	{{- if $.Table.Document -}}
-	, {{ $.Table.Identifier }}.{{ $.Table.Document.Identifier}} = r.{{ $.Table.Document.Identifier }}
+	{{ if $.Table.Values }}, {{ end }}{{ $.Table.Identifier }}.{{ $.Table.Document.Identifier}} = r.{{ $.Table.Document.Identifier }}
 	{{- end }}
 	WHEN NOT MATCHED THEN
 		INSERT (

--- a/materialize-snowflake/sqlgen.go
+++ b/materialize-snowflake/sqlgen.go
@@ -148,7 +148,7 @@ ALTER TABLE {{ $.Table.Identifier }} ADD COLUMN
 	{{- if $ind }} AND {{ end -}}
 	{{ $.Table.Identifier }}.{{ $key.Identifier }} = r.{{ $key.Identifier }}
 	{{- end }}
-{{- end }}
+{{ end }}
 
 {{ define "copyInto" }}
 	COPY INTO {{ $.Table.Identifier }} (
@@ -163,7 +163,7 @@ ALTER TABLE {{ $.Table.Identifier }} ADD COLUMN
 		{{- end }}
 		FROM @flow_v1/{{ $.RandomUUID }}
 	);
-{{- end }}
+{{ end }}
 
 
 {{ define "mergeInto" }}
@@ -200,7 +200,7 @@ ALTER TABLE {{ $.Table.Identifier }} ADD COLUMN
 			r.{{$key.Identifier -}}
 		{{- end -}}
 	);
-{{- end }}
+{{ end }}
 
 {{ define "updateFence" }}
 EXECUTE IMMEDIATE $$

--- a/materialize-snowflake/sqlgen_test.go
+++ b/materialize-snowflake/sqlgen_test.go
@@ -1,0 +1,102 @@
+package main
+
+import (
+	"database/sql"
+	"strings"
+	"testing"
+	"text/template"
+
+	"github.com/bradleyjkemp/cupaloy"
+	sqlDriver "github.com/estuary/connectors/materialize-sql"
+	"github.com/estuary/connectors/testsupport"
+	"github.com/estuary/flow/go/protocols/catalog"
+	pf "github.com/estuary/flow/go/protocols/flow"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSQLGeneration(t *testing.T) {
+	var spec *pf.MaterializationSpec
+	require.NoError(t, testsupport.CatalogExtract(t, "testdata/flow.yaml",
+		func(db *sql.DB) error {
+			var err error
+			spec, err = catalog.LoadMaterialization(db, "test/sqlite")
+			return err
+		}))
+
+	var shape1 = sqlDriver.BuildTableShape(spec, 0, tableConfig{
+		Table: "target_table",
+		Delta: false,
+	})
+	var shape2 = sqlDriver.BuildTableShape(spec, 1, tableConfig{
+		Table: "Delta Updates",
+		Delta: true,
+	})
+	shape2.Document = nil // TODO(johnny): this is a bit gross.
+
+	table1, err := sqlDriver.ResolveTable(shape1, snowflakeDialect)
+	require.NoError(t, err)
+	table2, err := sqlDriver.ResolveTable(shape2, snowflakeDialect)
+	require.NoError(t, err)
+
+	var snap strings.Builder
+
+	for _, tbl := range []sqlDriver.Table{table1, table2} {
+		withUUID := TableWithUUID{
+			Table:      &tbl,
+			RandomUUID: uuid.UUID{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15},
+		}
+
+		for _, tpl := range []*template.Template{
+			tplCreateTargetTable,
+		} {
+			var testcase = tbl.Identifier + " " + tpl.Name()
+
+			snap.WriteString("--- Begin " + testcase + " ---")
+			require.NoError(t, tpl.Execute(&snap, &tbl))
+			snap.WriteString("--- End " + testcase + " ---\n\n")
+		}
+
+		for _, tpl := range []*template.Template{
+			tplLoadQuery,
+			tplCopyInto,
+			tplMergeInto,
+		} {
+			var testcase = tbl.Identifier + " " + tpl.Name()
+
+			snap.WriteString("--- Begin " + testcase + " ---")
+			require.NoError(t, tpl.Execute(&snap, &withUUID))
+			snap.WriteString("--- End " + testcase + " ---\n\n")
+		}
+	}
+
+	var shapeNoValues = sqlDriver.BuildTableShape(spec, 2, tableConfig{
+		Table: "target_table_no_values_materialized",
+		Delta: false,
+	})
+	tableNoValues, err := sqlDriver.ResolveTable(shapeNoValues, snowflakeDialect)
+	require.NoError(t, err)
+
+	tableNoValuesWithUUID := TableWithUUID{
+		Table:      &tableNoValues,
+		RandomUUID: uuid.UUID{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15},
+	}
+
+	snap.WriteString("--- Begin " + "target_table_no_values_materialized mergeInto" + " ---")
+	require.NoError(t, tplMergeInto.Execute(&snap, &tableNoValuesWithUUID))
+	snap.WriteString("--- End " + "target_table_no_values_materialized mergeInto" + " ---\n\n")
+
+	var fence = sqlDriver.Fence{
+		TablePath:       sqlDriver.TablePath{"path", "To", "checkpoints"},
+		Checkpoint:      []byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
+		Fence:           123,
+		Materialization: pf.Materialization("some/Materialization"),
+		KeyBegin:        0x00112233,
+		KeyEnd:          0xffeeddcc,
+	}
+	snap.WriteString("--- Begin Fence Update ---")
+	require.NoError(t, tplUpdateFence.Execute(&snap, fence))
+	snap.WriteString("--- End Fence Update ---\n")
+
+	cupaloy.SnapshotT(t, snap.String())
+}

--- a/materialize-snowflake/testdata/flow.yaml
+++ b/materialize-snowflake/testdata/flow.yaml
@@ -12,6 +12,27 @@ collections:
       required: [key1, key2]
     key: [/key1, /key2]
 
+  delta/updates:
+    schema:
+      type: object
+      properties:
+        theKey: { type: string }
+        nullableKey: { type: string }
+        aValue:
+          type: integer
+          description: A super-awesome value.
+      required: [theKey, nullableKey]
+    key: [/theKey, /nullableKey]
+
+  no_values:
+    schema:
+      type: object
+      properties:
+        key1: { type: integer }
+        key2: { type: boolean }
+      required: [key1, key2]
+    key: [/key1, /key2]
+
 materializations:
   test/sqlite:
     endpoint:
@@ -20,6 +41,10 @@ materializations:
     bindings:
       - source: key/value
         resource: { table: key_value }
+      - source: delta/updates
+        resource: { table: "Delta Updates" }
+      - source: no_values
+        resource: { table: "No Values" }
 
 storageMappings:
   "": { stores: [{ provider: S3, bucket: a-bucket }] }

--- a/materialize-sql/templating.go
+++ b/materialize-sql/templating.go
@@ -15,8 +15,6 @@ func MustParseTemplate(dialect Dialect, name, body string) *template.Template {
 		// Tweak signature slightly to take TablePath, as dynamic slicing is a bit tricky
 		// in templates and this is most-frequently used with TablePath.Base().
 		"Identifier": func(p TablePath) string { return dialect.Identifier(p...) },
-		// A helper for iterating over all fields of a table
-		"AllFields": func(table Table) []Column { return append(append(append([]Column{}, table.Keys...), table.Values...), *table.Document) },
 	})
 	return template.Must(tpl.Parse(body))
 }
@@ -32,7 +30,7 @@ func RenderTableTemplate(table Table, tpl *template.Template) (string, error) {
 }
 
 type AlterInput struct {
-	Table Table
+	Table      Table
 	Identifier string
 }
 


### PR DESCRIPTION
**Description:**

Fixes a couple of edge cases for the generated sql queries in `materialize-snowflake`:
- When a binding is configured with `delta_updates` and `flow_document` is excluded as a field
- When there are no non-key fields selected, AKA there are no value fields being materialized

Both of these are uncommon but can happen, and we've seen examples of them with other connectors.

Closes https://github.com/estuary/connectors/issues/589

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

N/A

**Notes for reviewers:**

The first commit is purely a refactoring of the sql generation tests to make it easier to see the diffs from the next couple of changes which are what actually modify the generated queries.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/590)
<!-- Reviewable:end -->
