### PR TITLE
source-postgres: Support UUIDs as primary keys

### DIFF
--- a/source-postgres/.snapshots/TestScanKeyTypes-UUID
+++ b/source-postgres/.snapshots/TestScanKeyTypes-UUID
@@ -1,0 +1,49 @@
+####################################
+### Capture from Start
+####################################
+# ================================
+# Collection "test.ScanKeyTypes_UUID": 1 Documents
+# ================================
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"scankeytypes_uuid","loc":[11111111,11111111,11111111]}},"data":"Data 1","key":"4ab4044a-9aab-415c-96c6-17fa338060fa"}
+# ================================
+# Final State Checkpoint
+# ================================
+{"cursor":"0/1111111","streams":{"test.scankeytypes_uuid":{"key_columns":["key"],"mode":"Backfill","scanned":"AUq0BEqaq0FclsYX+jOAYPoA"}}}
+
+
+####################################
+### Capture from Key "AUq0BEqaq0FclsYX+jOAYPoA"
+####################################
+# ================================
+# Collection "test.ScanKeyTypes_UUID": 1 Documents
+# ================================
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"scankeytypes_uuid","loc":[11111111,11111111,11111111]}},"data":"Data 0","key":"66b968a7-aeca-4401-8239-5d57958d1572"}
+# ================================
+# Final State Checkpoint
+# ================================
+{"cursor":"0/1111111","streams":{"test.scankeytypes_uuid":{"key_columns":["key"],"mode":"Backfill","scanned":"AWa5aKeuykQBgjldV5WNFXIA"}}}
+
+
+####################################
+### Capture from Key "AWa5aKeuykQBgjldV5WNFXIA"
+####################################
+# ================================
+# Collection "test.ScanKeyTypes_UUID": 1 Documents
+# ================================
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"scankeytypes_uuid","loc":[11111111,11111111,11111111]}},"data":"Data 2","key":"c32fb585-fc7f-4347-8fe2-97448f4e93cd"}
+# ================================
+# Final State Checkpoint
+# ================================
+{"cursor":"0/1111111","streams":{"test.scankeytypes_uuid":{"key_columns":["key"],"mode":"Backfill","scanned":"AcMvtYX8f0NHj+KXRI9Ok80A"}}}
+
+
+####################################
+### Capture from Key "AcMvtYX8f0NHj+KXRI9Ok80A"
+####################################
+# ================================
+# Final State Checkpoint
+# ================================
+{"cursor":"0/1111111","streams":{"test.scankeytypes_uuid":{"key_columns":["key"],"mode":"Active"}}}
+
+
+

--- a/source-postgres/.snapshots/TestScanKeyTypes-UUID
+++ b/source-postgres/.snapshots/TestScanKeyTypes-UUID
@@ -8,11 +8,11 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"cursor":"0/1111111","streams":{"test.scankeytypes_uuid":{"key_columns":["key"],"mode":"Backfill","scanned":"AUq0BEqaq0FclsYX+jOAYPoA"}}}
+{"cursor":"0/1111111","streams":{"test.scankeytypes_uuid":{"key_columns":["key"],"mode":"Backfill","scanned":"AjRhYjQwNDRhLTlhYWItNDE1Yy05NmM2LTE3ZmEzMzgwNjBmYQA="}}}
 
 
 ####################################
-### Capture from Key "AUq0BEqaq0FclsYX+jOAYPoA"
+### Capture from Key "AjRhYjQwNDRhLTlhYWItNDE1Yy05NmM2LTE3ZmEzMzgwNjBmYQA="
 ####################################
 # ================================
 # Collection "test.ScanKeyTypes_UUID": 1 Documents
@@ -21,11 +21,11 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"cursor":"0/1111111","streams":{"test.scankeytypes_uuid":{"key_columns":["key"],"mode":"Backfill","scanned":"AWa5aKeuykQBgjldV5WNFXIA"}}}
+{"cursor":"0/1111111","streams":{"test.scankeytypes_uuid":{"key_columns":["key"],"mode":"Backfill","scanned":"AjY2Yjk2OGE3LWFlY2EtNDQwMS04MjM5LTVkNTc5NThkMTU3MgA="}}}
 
 
 ####################################
-### Capture from Key "AWa5aKeuykQBgjldV5WNFXIA"
+### Capture from Key "AjY2Yjk2OGE3LWFlY2EtNDQwMS04MjM5LTVkNTc5NThkMTU3MgA="
 ####################################
 # ================================
 # Collection "test.ScanKeyTypes_UUID": 1 Documents
@@ -34,11 +34,11 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"cursor":"0/1111111","streams":{"test.scankeytypes_uuid":{"key_columns":["key"],"mode":"Backfill","scanned":"AcMvtYX8f0NHj+KXRI9Ok80A"}}}
+{"cursor":"0/1111111","streams":{"test.scankeytypes_uuid":{"key_columns":["key"],"mode":"Backfill","scanned":"AmMzMmZiNTg1LWZjN2YtNDM0Ny04ZmUyLTk3NDQ4ZjRlOTNjZAA="}}}
 
 
 ####################################
-### Capture from Key "AcMvtYX8f0NHj+KXRI9Ok80A"
+### Capture from Key "AmMzMmZiNTg1LWZjN2YtNDM0Ny04ZmUyLTk3NDQ4ZjRlOTNjZAA="
 ####################################
 # ================================
 # Final State Checkpoint

--- a/source-postgres/datatype_test.go
+++ b/source-postgres/datatype_test.go
@@ -168,6 +168,7 @@ func TestScanKeyTypes(t *testing.T) {
 		{"VarChar", "VARCHAR(10)", []interface{}{"", "   ", "a", "b", "c", "A", "B", "C", "_a", "_b", "_c"}},
 		{"Char", "CHAR(3)", []interface{}{"   ", "a", "b", "c", "A", "B", "C", "_a", "_b", "_c"}},
 		{"Text", "TEXT", []interface{}{"", "   ", "a", "b", "c", "A", "B", "C", "_a", "_b", "_c"}},
+		{"UUID", "UUID", []interface{}{"66b968a7-aeca-4401-8239-5d57958d1572", "4ab4044a-9aab-415c-96c6-17fa338060fa", "c32fb585-fc7f-4347-8fe2-97448f4e93cd"}},
 	} {
 		t.Run(tc.Name, func(t *testing.T) {
 			var tableName = tb.CreateTable(ctx, t, "", fmt.Sprintf("(key %s PRIMARY KEY, data TEXT)", tc.ColumnType))

--- a/source-postgres/main.go
+++ b/source-postgres/main.go
@@ -240,6 +240,8 @@ func (db *postgresDatabase) EmptySourceMetadata() sqlcapture.SourceMetadata {
 
 func encodeKeyFDB(key, ktype interface{}) (tuple.TupleElement, error) {
 	switch key := key.(type) {
+	case [16]uint8:
+		return key[:], nil
 	case time.Time:
 		return key.Format(sortableRFC3339Nano), nil
 	case pgtype.Numeric:

--- a/source-postgres/main.go
+++ b/source-postgres/main.go
@@ -16,6 +16,7 @@ import (
 	"github.com/estuary/connectors/sqlcapture"
 	"github.com/estuary/flow/go/protocols/fdb/tuple"
 	pf "github.com/estuary/flow/go/protocols/flow"
+	"github.com/google/uuid"
 	"github.com/jackc/pgtype"
 	"github.com/jackc/pgx/v4"
 	"github.com/sirupsen/logrus"
@@ -241,7 +242,11 @@ func (db *postgresDatabase) EmptySourceMetadata() sqlcapture.SourceMetadata {
 func encodeKeyFDB(key, ktype interface{}) (tuple.TupleElement, error) {
 	switch key := key.(type) {
 	case [16]uint8:
-		return key[:], nil
+		var id, err = uuid.FromBytes(key[:])
+		if err != nil {
+			return nil, fmt.Errorf("error parsing uuid: %w", err)
+		}
+		return id.String(), nil
 	case time.Time:
 		return key.Format(sortableRFC3339Nano), nil
 	case pgtype.Numeric:

--- a/sqlcapture/tests/helpers.go
+++ b/sqlcapture/tests/helpers.go
@@ -111,6 +111,9 @@ func RestartingBackfillCapture(ctx context.Context, t testing.TB, cs *st.Capture
 			fmt.Fprintf(summary, "####################################\n")
 			fmt.Fprintf(summary, "### Terminating Capture due to Errors\n")
 			fmt.Fprintf(summary, "####################################\n")
+			for _, err := range cs.Errors {
+				fmt.Fprintf(summary, "%v\n", err)
+			}
 			break
 		}
 		cs.Reset()


### PR DESCRIPTION
**Description:**

Adds support for Postgres captures with UUID columns in the primary key.

The UUID is represented as a `[16]uint8` when we receive it from the Postgres client library, but can be sliced into a `[]uint8` and the client library will accept that later on when we use it as a resume cursor value.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/593)
<!-- Reviewable:end -->
