### PR TITLE
materialize-redshift: fix build

### DIFF
--- a/materialize-redshift/driver.go
+++ b/materialize-redshift/driver.go
@@ -236,7 +236,7 @@ func newRedshiftDriver() pm.DriverServer {
 			return &sql.Endpoint{
 				Config:                      cfg,
 				Dialect:                     rsDialect,
-				MetaSpecs:                   metaSpecs,
+				MetaSpecs:                   &metaSpecs,
 				MetaCheckpoints:             &metaCheckpoints,
 				Client:                      client{uri: cfg.toURI()},
 				CreateTableTemplate:         tplCreateTargetTable,


### PR DESCRIPTION
Resolves a conflict that was created by merging the new Redshift connector PR out of order with some changes in the materialize-sql package.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/596)
<!-- Reviewable:end -->
