### PR TITLE
return the error when network tunnel Start() fails

### DIFF
--- a/materialize-postgres/driver.go
+++ b/materialize-postgres/driver.go
@@ -158,10 +158,8 @@ func newPostgresDriver() pm.DriverServer {
 
 				// FIXME/question: do we need to shut down the tunnel manually if it is a child process?
 				// at the moment tunnel.Stop is not being called anywhere, but if the connector shuts down, the child process also shuts down.
-				err = tunnel.Start()
-
-				if err != nil {
-					log.WithField("error", err).Error("network tunnel error")
+				if err := tunnel.Start(); err != nil {
+					return nil, fmt.Errorf("error starting network tunnel: %w", err)
 				}
 			}
 

--- a/materialize-redshift/driver.go
+++ b/materialize-redshift/driver.go
@@ -226,10 +226,8 @@ func newRedshiftDriver() pm.DriverServer {
 				}
 				var tunnel = sshConfig.CreateTunnel()
 
-				err = tunnel.Start()
-
-				if err != nil {
-					log.WithField("error", err).Error("network tunnel error")
+				if err := tunnel.Start(); err != nil {
+					return nil, fmt.Errorf("error starting network tunnel: %w", err)
 				}
 			}
 

--- a/source-mysql/main.go
+++ b/source-mysql/main.go
@@ -76,10 +76,8 @@ func connectMySQL(ctx context.Context, name string, cfg json.RawMessage) (sqlcap
 
 		// FIXME/question: do we need to shut down the tunnel manually if it is a child process?
 		// at the moment tunnel.Stop is not being called anywhere, but if the connector shuts down, the child process also shuts down.
-		err = tunnel.Start()
-
-		if err != nil {
-			logrus.WithField("error", err).Error("network tunnel error")
+		if err := tunnel.Start(); err != nil {
+			return nil, fmt.Errorf("error starting network tunnel: %w", err)
 		}
 	}
 

--- a/source-postgres/main.go
+++ b/source-postgres/main.go
@@ -71,10 +71,8 @@ func connectPostgres(ctx context.Context, name string, cfg json.RawMessage) (sql
 
 		// FIXME/question: do we need to shut down the tunnel manually if it is a child process?
 		// at the moment tunnel.Stop is not being called anywhere, but if the connector shuts down, the child process also shuts down.
-		err = tunnel.Start()
-
-		if err != nil {
-			logrus.WithField("error", err).Error("network tunnel error")
+		if err := tunnel.Start(); err != nil {
+			return nil, fmt.Errorf("error starting network tunnel: %w", err)
 		}
 	}
 

--- a/source-sqlserver/main.go
+++ b/source-sqlserver/main.go
@@ -160,7 +160,7 @@ func connectSQLServer(ctx context.Context, name string, cfg json.RawMessage) (sq
 		// FIXME/question: do we need to shut down the tunnel manually if it is a child process?
 		// at the moment tunnel.Stop is not being called anywhere, but if the connector shuts down, the child process also shuts down.
 		if err := tunnel.Start(); err != nil {
-			log.WithField("error", err).Error("network tunnel error")
+			return nil, fmt.Errorf("error starting network tunnel: %w", err)
 		}
 	}
 


### PR DESCRIPTION
**Description:**

Previously this would just be logged and then execution would continue onwards and attempt to connect to localhost, which is confusing and results in sub-optimal error messages for the user.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/601)
<!-- Reviewable:end -->
