### PR TITLE
source-mongodb: use one document to infer type of _id

### DIFF
--- a/source-mongodb/pull.go
+++ b/source-mongodb/pull.go
@@ -277,15 +277,7 @@ func sanitizeDocument(doc map[string]interface{}) map[string]interface{} {
 	for key, value := range doc {
 		// Make sure `_id` is always captured as string
 		if key == "_id" {
-			switch value.(type) {
-				case string:
-				default:
-					var j, err = json.Marshal(value)
-					if err != nil {
-						panic(fmt.Sprintf("could not marshal interface{} to json: %s", err))
-					}
-					doc[key] = string(j)
-			}
+			doc[key] = idToString(value)
 		} else {
 			switch v := value.(type) {
 			case float64:
@@ -299,4 +291,19 @@ func sanitizeDocument(doc map[string]interface{}) map[string]interface{} {
 	}
 
 	return doc
+}
+
+func idToString(value interface{}) string {
+	switch v := value.(type) {
+		case string:
+			return v
+		case primitive.ObjectID:
+			return v.Hex()
+	}
+
+	var j, err = json.Marshal(value)
+	if err != nil {
+		panic(fmt.Sprintf("could not marshal interface{} to json: %s", err))
+	}
+	return string(j)
 }

--- a/source-mongodb/pull.go
+++ b/source-mongodb/pull.go
@@ -275,16 +275,28 @@ func resourceId(res resource) string {
 
 func sanitizeDocument(doc map[string]interface{}) map[string]interface{} {
 	for key, value := range doc {
-		switch v := value.(type) {
-		case float64:
-			if math.IsNaN(v) {
-				doc[key] = "NaN"
+		// Make sure `_id` is always captured as string
+		if key == "_id" {
+			switch value.(type) {
+				case string:
+				default:
+					var j, err = json.Marshal(value)
+					if err != nil {
+						panic(fmt.Sprintf("could not marshal interface{} to json: %s", err))
+					}
+					doc[key] = string(j)
 			}
-		case map[string]interface{}:
-			doc[key] = sanitizeDocument(v)
+		} else {
+			switch v := value.(type) {
+			case float64:
+				if math.IsNaN(v) {
+					doc[key] = "NaN"
+				}
+			case map[string]interface{}:
+				doc[key] = sanitizeDocument(v)
+			}
 		}
 	}
 
 	return doc
 }
-


### PR DESCRIPTION
**Description:**

- Look for one document in each collection during discover to infer type of `_id`, currently supporting `integer` and `number` (I doubt anyone uses this). We previously had a customer who had numerical IDs.
- Resolves #592 

**Workflow steps:**

- Create a collection with integer `_id` and run discover

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/608)
<!-- Reviewable:end -->
