### PR TITLE
materialize-sql: add support for checking prerequisites during validation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/credentials v1.13.15
 	github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.11.14
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.30.5
+	github.com/aws/smithy-go v1.13.5
 	github.com/benbjohnson/clock v1.3.0
 	github.com/bradleyjkemp/cupaloy v2.3.0+incompatible
 	github.com/elastic/go-elasticsearch/v7 v7.17.1
@@ -75,7 +76,6 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/sso v1.12.4 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.14.4 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sts v1.18.5 // indirect
-	github.com/aws/smithy-go v1.13.5 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.1.2 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -243,6 +243,7 @@ github.com/containerd/continuity v0.3.0 h1:nisirsYROK15TAMVukJOUyGJjz4BNQJBVsNvA
 github.com/coreos/go-semver v0.3.0 h1:wkHLiw0WNATZnSG7epLsujiMCgPAc9xhjJ4tgnAxmfM=
 github.com/coreos/go-semver v0.3.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=
 github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
+github.com/coreos/go-systemd v0.0.0-20190719114852-fd7a80b32e1f h1:JOrtw2xFKzlg+cbHpyrpLDmnN1HqhBfnX7WDiW7eG2c=
 github.com/coreos/go-systemd v0.0.0-20190719114852-fd7a80b32e1f/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/coreos/go-systemd/v22 v22.3.2/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
 github.com/coreos/go-systemd/v22 v22.3.3-0.20220203105225-a9a7ef127534 h1:rtAn27wIbmOGUs7RIbVgPEjb31ehTVniDwPGXyMxm5U=

--- a/materialize-bigquery/edc_file.go
+++ b/materialize-bigquery/edc_file.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"path"
-	"strings"
 
 	"cloud.google.com/go/bigquery"
 	"cloud.google.com/go/storage"
@@ -31,10 +30,7 @@ func (t *transactor) NewExternalDataConnectionFile(ctx context.Context, file str
 		return nil, fmt.Errorf("external data connection file only supports json at this time")
 	}
 
-	// If BucketPath starts with a /, then so will the result of the Join. Trim the leading / so
-	// that we don't end up with repeated / chars in the URI and so that the object key does not
-	// start with a /.
-	objectKey := strings.TrimPrefix(path.Join(t.bucketPath, file), "/")
+	objectKey := path.Join(t.bucketPath, file)
 
 	f := &ExternalDataConnectionFile{
 		URI:       fmt.Sprintf("gs://%s/%s", t.bucket, objectKey),

--- a/materialize-redshift/driver_test.go
+++ b/materialize-redshift/driver_test.go
@@ -13,43 +13,46 @@ import (
 	sql "github.com/estuary/connectors/materialize-sql"
 	pf "github.com/estuary/flow/go/protocols/flow"
 	pm "github.com/estuary/flow/go/protocols/materialize"
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 )
 
+func mustGetCfg(t *testing.T) config {
+	if os.Getenv("TESTDB") != "yes" {
+		t.Skipf("skipping %q: ${TESTDB} != \"yes\"", t.Name())
+		return config{}
+	}
+
+	out := config{}
+
+	for _, prop := range []struct {
+		key  string
+		dest *string
+	}{
+		{"REDSHIFT_ADDRESS", &out.Address},
+		{"REDSHIFT_USER", &out.User},
+		{"REDSHIFT_PASSWORD", &out.Password},
+		{"REDSHIFT_DATABASE", &out.Database},
+		{"REDSHIFT_BUCKET", &out.Bucket},
+		{"AWS_ACCESS_KEY_ID", &out.AWSAccessKeyID},
+		{"AWS_SECRET_ACCESS_KEY", &out.AWSSecretAccessKey},
+		{"AWS_REGION", &out.Region},
+	} {
+		*prop.dest = os.Getenv(prop.key)
+	}
+
+	if err := out.Validate(); err != nil {
+		t.Fatal(err)
+	}
+
+	return out
+}
+
 func TestFencingCases(t *testing.T) {
 	// Because of the number of round-trips required for this test to run it is not run normally.
-	// Enable it via the RUN_FENCE_TESTS environment variable. It will take several minutes for this
-	// test to complete (you should run it with a sufficient -timeout value).
-	if os.Getenv("RUN_FENCE_TESTS") != "yes" {
-		t.Skipf("skipping %q: ${RUN_FENCE_TESTS} != \"yes\"", t.Name())
-	}
-
-	address, ok := os.LookupEnv("REDSHIFT_ADDRESS")
-	if !ok {
-		t.Fatal("missing REDSHIFT_ADDRESS environment variable")
-	}
-
-	user, ok := os.LookupEnv("REDSHIFT_USER")
-	if !ok {
-		t.Fatal("missing REDSHIFT_USER environment variable")
-	}
-
-	password, ok := os.LookupEnv("REDSHIFT_PASSWORD")
-	if !ok {
-		t.Fatal("missing REDSHIFT_PASSWORD environment variable")
-	}
-
-	database, ok := os.LookupEnv("REDSHIFT_DATABASE")
-	if !ok {
-		t.Fatal("missing REDSHIFT_DATABASE environment variable")
-	}
-
-	cfg := config{
-		Address:  address,
-		User:     user,
-		Password: password,
-		Database: database,
-	}
+	// Enable it via the TESTDB environment variable. It will take several minutes for this test to
+	// complete (you should run it with a sufficient -timeout value).
+	cfg := mustGetCfg(t)
 
 	client := client{uri: cfg.toURI()}
 
@@ -80,6 +83,104 @@ func TestFencingCases(t *testing.T) {
 			return
 		},
 	)
+}
+
+func TestPrereqs(t *testing.T) {
+	// These tests assume that the configuration obtained from environment variables forms a valid
+	// config that could be used to materialize into Redshift. Various parameters of the
+	// configuration are then manipulated to test assertions for incorrect configs.
+
+	cfg := mustGetCfg(t)
+
+	nonExistentBucket := uuid.NewString()
+
+	tests := []struct {
+		name string
+		cfg  func(config) config
+		want []error
+	}{
+		{
+			name: "valid",
+			cfg:  func(cfg config) config { return cfg },
+			want: nil,
+		},
+		{
+			name: "wrong username",
+			cfg: func(cfg config) config {
+				cfg.User = "wrong" + cfg.User
+				return cfg
+			},
+			want: []error{fmt.Errorf("incorrect username or password")},
+		},
+		{
+			name: "wrong password",
+			cfg: func(cfg config) config {
+				cfg.Password = "wrong" + cfg.Password
+				return cfg
+			},
+			want: []error{fmt.Errorf("incorrect username or password")},
+		},
+		{
+			name: "wrong database",
+			cfg: func(cfg config) config {
+				cfg.Database = "wrong" + cfg.Database
+				return cfg
+			},
+			want: []error{fmt.Errorf("database %q does not exist", "wrong"+cfg.Database)},
+		},
+		{
+			name: "wrong address",
+			cfg: func(cfg config) config {
+				cfg.Address = "wrong." + cfg.Address
+				return cfg
+			},
+			want: []error{fmt.Errorf("host at address %q cannot be found", "wrong."+cfg.Address)},
+		},
+		{
+			name: "bucket doesn't exist",
+			cfg: func(cfg config) config {
+				cfg.Bucket = nonExistentBucket
+				return cfg
+			},
+			want: []error{fmt.Errorf("bucket %q does not exist", nonExistentBucket)},
+		},
+		{
+			name: "unauthorized to bucket: access key id",
+			cfg: func(cfg config) config {
+				cfg.AWSAccessKeyID = "wrong" + cfg.AWSAccessKeyID
+				return cfg
+			},
+			want: []error{fmt.Errorf("not authorized to write to bucket %q", cfg.Bucket)},
+		},
+		{
+			name: "unauthorized to bucket: secret access key",
+			cfg: func(cfg config) config {
+				cfg.AWSSecretAccessKey = "wrong" + cfg.AWSSecretAccessKey
+				return cfg
+			},
+			want: []error{fmt.Errorf("not authorized to write to bucket %q", cfg.Bucket)},
+		},
+		{
+			name: "database problem and bucket problem",
+			cfg: func(cfg config) config {
+				cfg.Database = "wrong" + cfg.Database
+				cfg.Bucket = nonExistentBucket
+				return cfg
+			},
+			want: []error{
+				fmt.Errorf("database %q does not exist", "wrong"+cfg.Database),
+				fmt.Errorf("bucket %q does not exist", nonExistentBucket),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rawBytes, err := json.Marshal(tt.cfg(cfg))
+			require.NoError(t, err)
+			require.Equal(t, tt.want, prereqs(context.Background(), rawBytes).Unwrap())
+		})
+	}
 }
 
 func TestSpecification(t *testing.T) {

--- a/materialize-snowflake/.snapshots/TestSpecification
+++ b/materialize-snowflake/.snapshots/TestSpecification
@@ -6,7 +6,7 @@
       "host": {
         "type": "string",
         "title": "Host URL",
-        "description": "The Snowflake Host used for the connection. Example: orgname-accountname.snowflakecomputing.com (do not include the protocol).",
+        "description": "The Snowflake Host used for the connection. Must include the account identifier and end in .snowflakecomputing.com. Example: orgname-accountname.snowflakecomputing.com (do not include the protocol).",
         "order": 0
       },
       "account": {

--- a/materialize-snowflake/snowflake_test.go
+++ b/materialize-snowflake/snowflake_test.go
@@ -2,14 +2,48 @@ package main
 
 import (
 	"context"
+	stdsql "database/sql"
 	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
 	"testing"
 
 	"github.com/bradleyjkemp/cupaloy"
+	sql "github.com/estuary/connectors/materialize-sql"
 	pf "github.com/estuary/flow/go/protocols/flow"
 	pm "github.com/estuary/flow/go/protocols/materialize"
 	"github.com/stretchr/testify/require"
 )
+
+func mustGetCfg(t *testing.T) config {
+	if os.Getenv("TESTDB") != "yes" {
+		t.Skipf("skipping %q: ${TESTDB} != \"yes\"", t.Name())
+		return config{}
+	}
+
+	out := config{}
+
+	for _, prop := range []struct {
+		key  string
+		dest *string
+	}{
+		{"SNOWFLAKE_HOST", &out.Host},
+		{"SNOWFLAKE_ACCOUNT", &out.Account},
+		{"SNOWFLAKE_USER", &out.User},
+		{"SNOWFLAKE_PASSWORD", &out.Password},
+		{"SNOWFLAKE_DATABASE", &out.Database},
+		{"SNOWFLAKE_SCHEMA", &out.Schema},
+	} {
+		*prop.dest = os.Getenv(prop.key)
+	}
+
+	if err := out.Validate(); err != nil {
+		t.Fatal(err)
+	}
+
+	return out
+}
 
 func TestSpecification(t *testing.T) {
 	var resp, err = newSnowflakeDriver().
@@ -20,4 +54,121 @@ func TestSpecification(t *testing.T) {
 	require.NoError(t, err)
 
 	cupaloy.SnapshotT(t, formatted)
+}
+
+func TestFencingCases(t *testing.T) {
+	// Because of the number of round-trips required for this test to run it is not run normally.
+	// Enable it via the TESTDB environment variable. It will take several minutes for this test to
+	// complete (you should run it with a sufficient -timeout value).
+	cfg := mustGetCfg(t)
+
+	client := client{uri: cfg.ToURI()}
+
+	ctx := context.Background()
+
+	sql.RunFenceTestCases(t,
+		sql.FenceSnapshotPath,
+		client,
+		[]string{"temp_test_fencing_checkpoints"},
+		snowflakeDialect,
+		tplCreateTargetTable,
+		func(table sql.Table, fence sql.Fence) error {
+			var err = client.withDB(func(db *stdsql.DB) error {
+				var fenceUpdate strings.Builder
+				if err := tplUpdateFence.Execute(&fenceUpdate, fence); err != nil {
+					return fmt.Errorf("evaluating fence template: %w", err)
+				}
+				var _, err = db.Exec(fenceUpdate.String())
+				return err
+			})
+			return err
+		},
+		func(table sql.Table) (out string, err error) {
+			err = client.withDB(func(db *stdsql.DB) error {
+				out, err = sql.StdDumpTable(ctx, db, table)
+				return err
+			})
+			return
+		},
+	)
+}
+
+func TestPrereqs(t *testing.T) {
+	// These tests assume that the configuration obtained from environment variables forms a valid
+	// config that could be used to materialize into Snowflake. Various parameters of the
+	// configuration are then manipulated to test assertions for incorrect configs.
+
+	cfg := mustGetCfg(t)
+
+	tests := []struct {
+		name string
+		cfg  func(config) config
+		want []error
+	}{
+		{
+			name: "valid",
+			cfg:  func(cfg config) config { return cfg },
+			want: nil,
+		},
+		{
+			name: "wrong account identifier in host",
+			cfg: func(cfg config) config {
+				cfg.Host = "wrong.snowflakecomputing.com"
+				return cfg
+			},
+			want: []error{fmt.Errorf("incorrect account identifier %q in host URL", "wrong")},
+		},
+		{
+			name: "wrong username",
+			cfg: func(cfg config) config {
+				cfg.User = "wrong" + cfg.User
+				return cfg
+			},
+			want: []error{fmt.Errorf("incorrect username or password")},
+		},
+		{
+			name: "wrong password",
+			cfg: func(cfg config) config {
+				cfg.Password = "wrong" + cfg.Password
+				return cfg
+			},
+			want: []error{fmt.Errorf("incorrect username or password")},
+		},
+		{
+			name: "wrong role",
+			cfg: func(cfg config) config {
+				cfg.Role = "wrong" + cfg.Role
+				return cfg
+			},
+			want: []error{fmt.Errorf("role %q does not exist", "wrong"+cfg.Role)},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rawBytes, err := json.Marshal(tt.cfg(cfg))
+			require.NoError(t, err)
+			require.Equal(t, tt.want, prereqs(context.Background(), rawBytes).Unwrap())
+		})
+	}
+}
+
+func TestValidHost(t *testing.T) {
+	for _, tt := range []struct {
+		host string
+		want bool
+	}{
+		{"orgname-accountname.snowflakecomputing.com", true},
+		{"identifer.snowflakecomputing.com", true},
+		{"ORGNAME-accountname.snowFLAKEcomputing.coM", true},
+		{"orgname-accountname.aws.us-east-2.snowflakecomputing.com", true},
+		{"http://orgname-accountname.snowflakecomputing.com", false},
+		{"https://orgname-accountname.snowflakecomputing.com", false},
+		{"orgname:accountname.snowflakecomputing.com", false},
+		{"orgname-accountname.snowflakecomputin.com", false},
+	} {
+		t.Run(tt.host, func(t *testing.T) {
+			require.Equal(t, tt.want, validHost(tt.host))
+		})
+	}
 }

--- a/materialize-sql/driver.go
+++ b/materialize-sql/driver.go
@@ -71,6 +71,8 @@ func (d *Driver) Validate(ctx context.Context, req *pm.ValidateRequest) (*pm.Val
 		return nil, fmt.Errorf("validating request: %w", err)
 	} else if endpoint, err = d.NewEndpoint(ctx, req.EndpointSpecJson); err != nil {
 		return nil, fmt.Errorf("building endpoint: %w", err)
+	} else if prereqErrs := endpoint.CheckPrerequisites(ctx, req.EndpointSpecJson); prereqErrs.Len() != 0 {
+		return nil, prereqErrs
 	} else if loadedSpec, _, err = loadSpec(ctx, endpoint, req.Materialization); err != nil {
 		return nil, fmt.Errorf("loading current applied materialization spec: %w", err)
 	}

--- a/materialize-sql/std_sql.go
+++ b/materialize-sql/std_sql.go
@@ -6,6 +6,7 @@ import (
 	"encoding/base64"
 	"encoding/hex"
 	"fmt"
+	"strconv"
 	"strings"
 
 	pf "github.com/estuary/flow/go/protocols/flow"
@@ -247,8 +248,12 @@ func (col *anyColumn) Scan(i interface{}) error {
 	case []byte:
 		sval = string(ii)
 	case string:
-		// Redshift checkpoint columns have an additional layer of hex encoding.
-		if hexBytes, err := hex.DecodeString(ii); err == nil {
+		if _, err := strconv.Atoi(ii); err == nil {
+			// Snowflake integer value columns scan into an interface{} with a concrete type of
+			// string.
+			sval = fmt.Sprint(i)
+		} else if hexBytes, err := hex.DecodeString(ii); err == nil {
+			// Redshift checkpoint columns have an additional layer of hex encoding.
 			sval = string(hexBytes)
 		} else {
 			sval = fmt.Sprint(i)


### PR DESCRIPTION
**Description:**

Adds a "prerequisites" check to sql materializations that is invoked during `Validate` calls.

Currently there are some ad-hoc validations that occur during `NewEndpoint`. These are not comprehensive, and not including them in `Validate` means that they don't run during `Test` invocations. The comprehensive validations are more involved and moving them from `NewEndpoint` to `Validate` is also nice since they won't have to run every time the connector starts up, and are only run when a change to the materialization is being considered.

I generally tried to interpret errors for common user-error cases and return clear & helpful error messages for these cases. This does not always work as well as I'd like depending on what the client library gives us, but overall I think we will have things covered pretty well here.

There is the potential for multiple errors to be independently evaluated for some materializations. In this case we will report as many errors as possible rather than stopping on the first one. This is really only the case for redshift and bigquery which use staging buckets and have the potential for separate client configuration and cloud storage configuration errors.

Also not that there is a small tweak to the snowflake configuration validation: We will now only accept host URLs ending in `.snowflakecomputing.com`. It has never been possible for the materialization to work with anything other than `*.snowflakecomputing.com`, but now the connector will validate that specifically when parsing the configuration. This helps eliminate a lot of possible configuration errors that would have to otherwise be validated in the prereq check for the connector.

**Workflow steps:**

Use connectors like before, but have better error messages when trying to publish them.

**Documentation links affected:**

I'll take a look at the snowflake docs and see if there is anything that needs updated there.

**Notes for reviewers:**

(anything that might help someone review this PR)

