### PR TITLE
materialize-redshift: configuration for setting a bucket path

### DIFF
--- a/materialize-redshift/.snapshots/TestSpecification
+++ b/materialize-redshift/.snapshots/TestSpecification
@@ -60,6 +60,12 @@
         "description": "Region of the S3 staging bucket. For optimal performance this should be in the same region as the Redshift database cluster.",
         "order": 8
       },
+      "bucketPath": {
+        "type": "string",
+        "title": "Bucket Path",
+        "description": "A prefix that will be used to store objects in S3.",
+        "order": 9
+      },
       "networkTunnel": {
         "properties": {
           "sshForwarding": {

--- a/materialize-redshift/driver.go
+++ b/materialize-redshift/driver.go
@@ -282,7 +282,7 @@ func prereqs(ctx context.Context, raw json.RawMessage) *sql.PrereqErr {
 
 	var awsErr *awsHttp.ResponseError
 
-	objectDir := path.Join(cfg.BucketPath, cfg.Bucket)
+	objectDir := path.Join(cfg.Bucket, cfg.BucketPath)
 
 	if err := s3file.encodeRow([]interface{}{[]byte("test")}); err != nil {
 		// This won't err immediately until the file is flushed in the case of having the wrong


### PR DESCRIPTION
**Description:**

Adds an optional configuration for `bucketPath`  for storing temp objects in a bucket under a path. This is an identical option as `materialize-bigquery` and was something I overlooked when initially developing the connector.

Closes https://github.com/estuary/connectors/issues/611

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

See https://github.com/estuary/flow/pull/978

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/615)
<!-- Reviewable:end -->
