### PR TITLE
materialize-google-sheets: handle sheets out of order with bindings

### DIFF
--- a/tests/materialize/materialize-google-sheets/fetch-materialize-results.sh
+++ b/tests/materialize/materialize-google-sheets/fetch-materialize-results.sh
@@ -1,8 +1,7 @@
 #!/bin/bash
 set -e
 
-if [ $# -ne 1 ]
-then
+if [ $# -ne 1 ]; then
     echo "execution using: $0 <test-output-jsonl-dir>"
     exit 1
 fi
@@ -15,13 +14,11 @@ result_dir="$1"
 sleep 2
 
 function exportToJsonl() {
-    # TODO(johnny): Consolidate with declaration in setup.sh?
-    export SPREADSHEET_ID="1aki_PfFU-RCXCvm4-U0O4QoElZBIC7F9lfR-RBG0CTc"
     export SHEET_NAME="$1"
 
     go run ${TEST_BASE_DIR}/materialize-google-sheets/fetch-sheets.go
 }
 
-exportToJsonl "Simple" > "${TEST_DIR}/${result_dir}/simple.jsonl"
-exportToJsonl "duplicate_keys" > "${TEST_DIR}/${result_dir}/duplicated-keys-non-delta.jsonl"
-exportToJsonl "Multiple Types" > "${TEST_DIR}/${result_dir}/multiple-data-types.jsonl"
+exportToJsonl "Simple" >"${TEST_DIR}/${result_dir}/simple.jsonl"
+exportToJsonl "duplicate_keys" >"${TEST_DIR}/${result_dir}/duplicated-keys-non-delta.jsonl"
+exportToJsonl "Multiple Types" >"${TEST_DIR}/${result_dir}/multiple-data-types.jsonl"

--- a/tests/materialize/materialize-google-sheets/setup.sh
+++ b/tests/materialize/materialize-google-sheets/setup.sh
@@ -5,7 +5,8 @@ set -e
 # This spreadsheet lives under the Estuary org and is shared with our CI service account
 # and engineering@. If you're an engineer, feel free to add additional service accounts
 # as needed for your own testing:
-export SPREADSHEET_URL="https://docs.google.com/spreadsheets/d/1aki_PfFU-RCXCvm4-U0O4QoElZBIC7F9lfR-RBG0CTc/edit#gid=0"
+export SPREADSHEET_ID="1aki_PfFU-RCXCvm4-U0O4QoElZBIC7F9lfR-RBG0CTc"
+export SPREADSHEET_URL="https://docs.google.com/spreadsheets/d/${SPREADSHEET_ID}/edit#gid=0"
 export GCP_SERVICE_ACCOUNT_KEY_QUOTED=$(echo ${GCP_SERVICE_ACCOUNT_KEY} | jq 'tojson')
 
 config_json_template='{


### PR DESCRIPTION
**Description:**

This removes the strict requirement that sheets be returned from the google sheets API in exactly the same order as bindings are listed. This allows for the user to re-arrange sheets in their spreadsheet and have the materialization continue to work.

Closes https://github.com/estuary/connectors/issues/616

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

N/A

**Notes for reviewers:**

(anything that might help someone review this PR)

