### PR TITLE
materialize-bigquery: validate region metadata of dataset

### DIFF
--- a/materialize-bigquery/query.go
+++ b/materialize-bigquery/query.go
@@ -73,8 +73,7 @@ func (c client) runQuery(ctx context.Context, query *bigquery.Query) (*bigquery.
 			// since these errors may actually be terminal.
 			if e, ok := err.(*googleapi.Error); ok {
 				if e.Code == 404 {
-					logEntry.Warn("project, dataset, or table was not found")
-					return nil, errNotFound
+					return nil, err
 				} else if e.Code != 400 {
 					logEntry.Error("job failed")
 					return nil, err // The error isn't considered retryable


### PR DESCRIPTION
**Description:**

If the dataset is found in the project, it still may not be in the same region as the configuration states, even though it can perform the trivial query I had previously used to check this. The trivial query was really just checking that the configured region was actually a region, and not that it was the _correct_ region.

This adds a check specifically for the dataset region. It must be the same as the one in the configuration or a clear error message is returned.

I also tweaked the error messaging and logging when querying the meta tables. They would previously log warnings that things couldn't be found. With this change there will be the typical "info" log when applying the materialization if this is the first time the tables are being created.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

N/A

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/619)
<!-- Reviewable:end -->
