### PR TITLE
Infer schema for source-http-ingest collections

### DIFF
--- a/source-http-ingest/src/lib.rs
+++ b/source-http-ingest/src/lib.rs
@@ -246,6 +246,7 @@ fn discovered_webhook_collection() -> DiscoveredBinding {
         resource_config: to_raw_value(&ResourceConfig::default()).unwrap(),
         document_schema: to_raw_value(&serde_json::json!({
             "type": "object",
+            "x-infer-schema": true,
             "properties": {
                 "_meta": {
                     "type": "object",

--- a/source-http-ingest/src/server.rs
+++ b/source-http-ingest/src/server.rs
@@ -335,7 +335,12 @@ pub fn openapi_spec<'a>(
     for binding in bindings.iter() {
         let url_path = ensure_slash_prefix(binding.resource_path[0].as_str());
 
-        let raw_schema = binding.collection.schema.as_ref().unwrap();
+        let raw_schema = binding
+            .collection
+            .write_schema
+            .as_ref()
+            .or(binding.collection.schema.as_ref())
+            .unwrap();
         let openapi_schema = serde_json::from_str::<openapi::Schema>(raw_schema.get())
             .context("deserializing collection schema")?;
 

--- a/source-http-ingest/tests/snapshots/test__discover.snap
+++ b/source-http-ingest/tests/snapshots/test__discover.snap
@@ -1,0 +1,55 @@
+---
+source: tests/test.rs
+expression: result
+---
+{
+  "discovered": {
+    "bindings": [
+      {
+        "documentSchema": {
+          "properties": {
+            "_meta": {
+              "description": "These fields are automatically added by the connector, and do not need to be specified in the request body",
+              "properties": {
+                "headers": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "HTTP headers that were sent with the request will get added here. Headers that are known to be sensitive or not useful will not be included",
+                  "type": "object"
+                },
+                "receivedAt": {
+                  "description": "Timestamp of when the request was received by the connector",
+                  "format": "date-time",
+                  "type": "string"
+                },
+                "webhookId": {
+                  "description": "The id of the webhook request, which is automatically added by the connector",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "webhookId",
+                "receivedAt"
+              ],
+              "type": "object"
+            }
+          },
+          "required": [
+            "_meta"
+          ],
+          "type": "object",
+          "x-infer-schema": true
+        },
+        "key": [
+          "/_meta/webhookId"
+        ],
+        "recommendedName": "webhook-data",
+        "resourceConfig": {
+          "idFromHeader": null,
+          "path": null
+        }
+      }
+    ]
+  }
+}


### PR DESCRIPTION
**Description:**

Updates the discovered binding in source-http-ingest to add the `x-infer-schema` annotation to the discovered 'webhook-data' collection. This just seemed like an obvious omission, since the json schema permits almost any valid json object.

**Workflow steps:**

Just setup a new capture using the source-http-ingest connector, and bask in the joy of automatically inferred json schemas.

**Documentation links affected:**

@oliviamiannone is this something we should document explicitly for each connector? I'm a little uncertain. Happy to update the docs if you think we should.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/622)
<!-- Reviewable:end -->
