### PR TITLE
materialize-sql: fix deleted columns migration

### DIFF
--- a/materialize-sql/driver.go
+++ b/materialize-sql/driver.go
@@ -214,9 +214,9 @@ func (d *Driver) ApplyUpsert(ctx context.Context, req *pm.ApplyRequest) (*pm.App
 			var allNewFields = bindingSpec.FieldSelection.AllFields()
 
 			// Mark columns that have been removed from field selection as nullable
-			for _, projection := range loadedBinding.Collection.Projections {
+			for _, field := range loadedBinding.FieldSelection.AllFields() {
 				// If the projection is part of the new field selection, just skip
-				if SliceContains(projection.Field, allNewFields) {
+				if SliceContains(field, allNewFields) {
 					continue
 				}
 
@@ -226,7 +226,7 @@ func (d *Driver) ApplyUpsert(ctx context.Context, req *pm.ApplyRequest) (*pm.App
 				}
 				var input = AlterInput{
 					Table:      table,
-					Identifier: endpoint.Identifier(projection.Field),
+					Identifier: endpoint.Identifier(field),
 				}
 				if statement, err := RenderAlterTemplate(input, endpoint.AlterColumnNullableTemplate); err != nil {
 					return nil, err


### PR DESCRIPTION
**Description:**

- collection projections are not semantically the same as field selections, so we should be comparing field selection, not projection

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/627)
<!-- Reviewable:end -->
