### PR TITLE
materialize-mongodb: delete collection when a binding is removed

### DIFF
--- a/materialize-mongodb/driver.go
+++ b/materialize-mongodb/driver.go
@@ -126,12 +126,7 @@ func (d driver) ApplyUpsert(ctx context.Context, req *pm.ApplyRequest) (*pm.Appl
 
 	var newCollections []string
 	for _, binding := range req.Materialization.Bindings {
-		var r resource
-		if err := pf.UnmarshalStrict(binding.ResourceSpecJson, &r); err != nil {
-			return nil, fmt.Errorf("parsing resource config: %w", err)
-		}
-
-		newCollections = append(newCollections, r.Collection)
+		newCollections = append(newCollections, binding.ResourcePath[1])
 	}
 
 	existing, err := d.LoadSpec(ctx, cfg, string(req.Materialization.Materialization))
@@ -141,7 +136,8 @@ func (d driver) ApplyUpsert(ctx context.Context, req *pm.ApplyRequest) (*pm.Appl
 
 	var actions []string
 	if existing != nil {
-		for collection, _ := range existing {
+		for _, binding := range existing.Bindings {
+			var collection = binding.ResourcePath[1]
 			// A binding that has been removed
 			if !SliceContains(collection, newCollections) {
 				if !req.DryRun {

--- a/materialize-mongodb/spec.go
+++ b/materialize-mongodb/spec.go
@@ -20,7 +20,7 @@ type SavedSpec struct {
 }
 
 // LoadSpec loads existing spec from spec collection and create a map of it by table name
-func (d driver) LoadSpec(ctx context.Context, cfg config, materialization string) (map[string]*pf.MaterializationSpec_Binding, error) {
+func (d driver) LoadSpec(ctx context.Context, cfg config, materialization string) (*pf.MaterializationSpec, error) {
 	var client, err = d.connect(ctx, cfg)
 	if err != nil {
 		return nil, fmt.Errorf("connecting to database: %w", err)
@@ -44,17 +44,7 @@ func (d driver) LoadSpec(ctx context.Context, cfg config, materialization string
 		return nil, fmt.Errorf("parsing existing materialization spec: %w", err)
 	}
 
-	bindingsByTable := make(map[string]*pf.MaterializationSpec_Binding)
-
-	for _, binding := range existing.Bindings {
-		var r resource
-		if err := pf.UnmarshalStrict(binding.ResourceSpecJson, &r); err != nil {
-			return nil, fmt.Errorf("parsing resource config: %w", err)
-		}
-		bindingsByTable[r.Collection] = binding
-	}
-
-	return bindingsByTable, nil
+	return &existing, nil
 }
 
 func (d driver) WriteSpec(ctx context.Context, cfg config, materialization *pf.MaterializationSpec, version string) error {

--- a/materialize-mongodb/spec.go
+++ b/materialize-mongodb/spec.go
@@ -1,0 +1,94 @@
+package main
+
+import (
+	"fmt"
+	"context"
+
+	pf "github.com/estuary/flow/go/protocols/flow"
+	proto "github.com/gogo/protobuf/proto"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo/options"
+	"go.mongodb.org/mongo-driver/mongo"
+)
+
+const specCollection = "flow_materializations"
+
+type SavedSpec struct {
+	Id   string `bson:"uuid"`
+	Spec []byte `bson:"spec"`
+}
+
+// LoadSpec loads existing spec from spec collection and create a map of it by table name
+func (d driver) LoadSpec(ctx context.Context, cfg config, materialization string) (map[string]*pf.MaterializationSpec_Binding, error) {
+	var client, err = d.connect(ctx, cfg)
+	if err != nil {
+		return nil, fmt.Errorf("connecting to database: %w", err)
+	}
+
+	var collection = client.Database(cfg.Database).Collection(specCollection)
+
+	var s SavedSpec
+
+	err = collection.FindOne(ctx, bson.D{{idField, bson.D{{"$eq", materialization}}}}).Decode(&s)
+	if err != nil {
+		if err == mongo.ErrNoDocuments {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("could not find spec: %w", err)
+	}
+
+	var existing pf.MaterializationSpec
+	err = proto.Unmarshal(s.Spec, &existing)
+	if err != nil {
+		return nil, fmt.Errorf("parsing existing materialization spec: %w", err)
+	}
+
+	bindingsByTable := make(map[string]*pf.MaterializationSpec_Binding)
+
+	for _, binding := range existing.Bindings {
+		var r resource
+		if err := pf.UnmarshalStrict(binding.ResourceSpecJson, &r); err != nil {
+			return nil, fmt.Errorf("parsing resource config: %w", err)
+		}
+		bindingsByTable[r.Collection] = binding
+	}
+
+	return bindingsByTable, nil
+}
+
+func (d driver) WriteSpec(ctx context.Context, cfg config, materialization *pf.MaterializationSpec, version string) error {
+	var client, err = d.connect(ctx, cfg)
+	if err != nil {
+		return fmt.Errorf("connecting to database: %w", err)
+	}
+	var collection = client.Database(cfg.Database).Collection(specCollection)
+
+	bs, err := proto.Marshal(materialization)
+	if err != nil {
+		return fmt.Errorf("encoding existing materialization spec: %w", err)
+	}
+
+	opts := options.Replace().SetUpsert(true)
+	_, err = collection.ReplaceOne(ctx, bson.D{{idField, string(materialization.Materialization)}}, bson.D{{"spec", bs}}, opts)
+	if err != nil {
+		return fmt.Errorf("upserting spec: %w", err)
+	}
+
+	return nil
+}
+
+func (d driver) CleanSpec(ctx context.Context, cfg config, materialization string) error {
+	var client, err = d.connect(ctx, cfg)
+	if err != nil {
+		return fmt.Errorf("connecting to database: %w", err)
+	}
+	var collection = client.Database(cfg.Database).Collection(specCollection)
+
+	_, err = collection.DeleteOne(ctx, bson.D{{idField, materialization}})
+	if err != nil {
+		return fmt.Errorf("cleaning up spec: %w", err)
+	}
+
+	return nil
+}


### PR DESCRIPTION
**Description:**

- persist last materialization spec in `flow_materializations` collection
- when a binding is removed, remove its corresponding collection

**Workflow steps:**

- add a binding, then remove it. the collection will be dropped.

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/628)
<!-- Reviewable:end -->
