### PR TITLE
materialize-sql: check fieldSelection to determine new field additions

### DIFF
--- a/materialize-sql/driver.go
+++ b/materialize-sql/driver.go
@@ -173,7 +173,7 @@ func (d *Driver) ApplyUpsert(ctx context.Context, req *pm.ApplyRequest) (*pm.App
 				var previousProjection = loadedBinding.Collection.GetProjection(field)
 
 				// Make sure new columns are added to the table
-				if previousProjection == nil {
+				if !SliceContains(field, loadedBinding.FieldSelection.Values) {
 					var table, err = ResolveTable(tableShape, endpoint.Dialect)
 					if err != nil {
 						return nil, err


### PR DESCRIPTION
**Description:**

- we were using the collection projection to determine if a field is new, however if a field was not previously selected for this materialization, but now it is, it still counts as a new column.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/630)
<!-- Reviewable:end -->
