### PR TITLE
source-sqlserver: Increase backfill chunk size to 32k

### DIFF
--- a/source-sqlserver/main.go
+++ b/source-sqlserver/main.go
@@ -91,7 +91,7 @@ func (c *Config) SetDefaults() {
 		c.Advanced.WatermarksTable = "dbo.flow_watermarks"
 	}
 	if c.Advanced.BackfillChunkSize <= 0 {
-		c.Advanced.BackfillChunkSize = 4096
+		c.Advanced.BackfillChunkSize = 32768
 	}
 
 	// The address config property should accept a host or host:port


### PR DESCRIPTION
**Description:**

When performing backfills we alternate reading chunks from the database tables, performing a watermark write, and then waiting for that write to show up via CDC. This means that backfill throughput is capped at <ChunkSize> / <WatermarkLatency>.

This is true of all SQL captures, but in general the latency from watermark write to CDC event is milliseconds on other databases. SQL Server is special and uses a separate agent process which polls the WAL every 5s by default. This means that we can backfill at most <ChunkSize>/5 rows per second from any one table.

Let's stop the immediate pain by increasing the chunk size 8x, taking us from ~816 docs/sec to ~6.5k docs/sec.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/635)
<!-- Reviewable:end -->
