### PR TITLE
source-sqlserver: Properly quote column names in backfill query

### DIFF
--- a/source-sqlserver/.snapshots/TestColumnNameQuoting
+++ b/source-sqlserver/.snapshots/TestColumnNameQuoting
@@ -1,0 +1,11 @@
+# ================================
+# Collection "acmeCo/test/test_columnnamequoting": 3 Documents
+# ================================
+{"CAPITALIZED":0,"_meta":{"op":"c","source":{"schema":"dbo","snapshot":true,"table":"test_ColumnNameQuoting"}},"data":0,"id":0,"type":0,"unique":0}
+{"CAPITALIZED":1,"_meta":{"op":"c","source":{"schema":"dbo","snapshot":true,"table":"test_ColumnNameQuoting"}},"data":1,"id":1,"type":1,"unique":1}
+{"CAPITALIZED":2,"_meta":{"op":"c","source":{"schema":"dbo","snapshot":true,"table":"test_ColumnNameQuoting"}},"data":2,"id":2,"type":2,"unique":2}
+# ================================
+# Final State Checkpoint
+# ================================
+{"cursor":"AAAAAAAAAAAAAA==","streams":{"dbo.test_columnnamequoting":{"key_columns":["id","data","CAPITALIZED","unique","type"],"mode":"Active"}}}
+

--- a/source-sqlserver/main_test.go
+++ b/source-sqlserver/main_test.go
@@ -213,3 +213,10 @@ func TestGeneric(t *testing.T) {
 	var tb = sqlserverTestBackend(t)
 	tests.Run(context.Background(), t, tb)
 }
+
+func TestColumnNameQuoting(t *testing.T) {
+	var tb, ctx = sqlserverTestBackend(t), context.Background()
+	var tableName = tb.CreateTable(ctx, t, "", "([id] INTEGER, [data] INTEGER, [CAPITALIZED] INTEGER, [unique] INTEGER, [type] INTEGER, PRIMARY KEY ([id], [data], [capitalized], [unique], [type]))")
+	tb.Insert(ctx, t, tableName, [][]any{{0, 0, 0, 0, 0}, {1, 1, 1, 1, 1}, {2, 2, 2, 2, 2}})
+	tests.VerifiedCapture(ctx, t, tb.CaptureSpec(ctx, t, tableName))
+}


### PR DESCRIPTION
**Description:**

Per the documentation it's pretty much always safe to wrap a column name in `[brackets]` when constructing a query, so now we will.

It is possible that there are undocumented edge cases of column names which require further character-level escaping, but if such names exist the documentation doesn't mention the possibility, so this should be adequate until/unless we discover that such a name exists.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/639)
<!-- Reviewable:end -->
