### PR TITLE
source-sqlserver: Add support for datetimes as keys

### DIFF
--- a/source-sqlserver/.snapshots/TestScanKeyTypes-DateTimeOffset
+++ b/source-sqlserver/.snapshots/TestScanKeyTypes-DateTimeOffset
@@ -1,0 +1,49 @@
+####################################
+### Capture from Start
+####################################
+# ================================
+# Collection "acmeCo/test/test_scankeytypes_datetimeoffset": 1 Documents
+# ================================
+{"_meta":{"op":"c","source":{"schema":"dbo","snapshot":true,"table":"test_ScanKeyTypes_DateTimeOffset"}},"k":"<TIMESTAMP>","v":"Data 0"}
+# ================================
+# Final State Checkpoint
+# ================================
+{"cursor":"AAAAAAAAAAAAAA==","streams":{"dbo.test_scankeytypes_datetimeoffset":{"key_columns":["k"],"mode":"Backfill","scanned":"AjE5OTEtMDgtMzFUMTI6MzQ6NTQuMTI1MDAwMDAwLTA2OjAwAA=="}}}
+
+
+####################################
+### Capture from Key "AjE5OTEtMDgtMzFUMTI6MzQ6NTQuMTI1MDAwMDAwLTA2OjAwAA=="
+####################################
+# ================================
+# Collection "acmeCo/test/test_scankeytypes_datetimeoffset": 1 Documents
+# ================================
+{"_meta":{"op":"c","source":{"schema":"dbo","snapshot":true,"table":"test_ScanKeyTypes_DateTimeOffset"}},"k":"<TIMESTAMP>","v":"Data 1"}
+# ================================
+# Final State Checkpoint
+# ================================
+{"cursor":"AAAAAAAAAAAAAA==","streams":{"dbo.test_scankeytypes_datetimeoffset":{"key_columns":["k"],"mode":"Backfill","scanned":"AjE5OTEtMDgtMzFUMTI6MzQ6NTQuMTI2MDAwMDAwLTA2OjAwAA=="}}}
+
+
+####################################
+### Capture from Key "AjE5OTEtMDgtMzFUMTI6MzQ6NTQuMTI2MDAwMDAwLTA2OjAwAA=="
+####################################
+# ================================
+# Collection "acmeCo/test/test_scankeytypes_datetimeoffset": 1 Documents
+# ================================
+{"_meta":{"op":"c","source":{"schema":"dbo","snapshot":true,"table":"test_ScanKeyTypes_DateTimeOffset"}},"k":"<TIMESTAMP>","v":"Data 2"}
+# ================================
+# Final State Checkpoint
+# ================================
+{"cursor":"AAAAAAAAAAAAAA==","streams":{"dbo.test_scankeytypes_datetimeoffset":{"key_columns":["k"],"mode":"Backfill","scanned":"AjIwMDAtMDEtMDFUMDE6MDE6MDEuMDAwMDAwMDAwWgA="}}}
+
+
+####################################
+### Capture from Key "AjIwMDAtMDEtMDFUMDE6MDE6MDEuMDAwMDAwMDAwWgA="
+####################################
+# ================================
+# Final State Checkpoint
+# ================================
+{"cursor":"AAAAAAAAAAAAAA==","streams":{"dbo.test_scankeytypes_datetimeoffset":{"key_columns":["k"],"mode":"Active"}}}
+
+
+

--- a/source-sqlserver/.snapshots/TestScanKeyTypes-Integer
+++ b/source-sqlserver/.snapshots/TestScanKeyTypes-Integer
@@ -1,0 +1,62 @@
+####################################
+### Capture from Start
+####################################
+# ================================
+# Collection "acmeCo/test/test_scankeytypes_integer": 1 Documents
+# ================================
+{"_meta":{"op":"c","source":{"schema":"dbo","snapshot":true,"table":"test_ScanKeyTypes_Integer"}},"k":-3,"v":"Data 1"}
+# ================================
+# Final State Checkpoint
+# ================================
+{"cursor":"AAAAAAAAAAAAAA==","streams":{"dbo.test_scankeytypes_integer":{"key_columns":["k"],"mode":"Backfill","scanned":"E/w="}}}
+
+
+####################################
+### Capture from Key "E/w="
+####################################
+# ================================
+# Collection "acmeCo/test/test_scankeytypes_integer": 1 Documents
+# ================================
+{"_meta":{"op":"c","source":{"schema":"dbo","snapshot":true,"table":"test_ScanKeyTypes_Integer"}},"k":0,"v":"Data 0"}
+# ================================
+# Final State Checkpoint
+# ================================
+{"cursor":"AAAAAAAAAAAAAA==","streams":{"dbo.test_scankeytypes_integer":{"key_columns":["k"],"mode":"Backfill","scanned":"FA=="}}}
+
+
+####################################
+### Capture from Key "FA=="
+####################################
+# ================================
+# Collection "acmeCo/test/test_scankeytypes_integer": 1 Documents
+# ================================
+{"_meta":{"op":"c","source":{"schema":"dbo","snapshot":true,"table":"test_ScanKeyTypes_Integer"}},"k":2,"v":"Data 2"}
+# ================================
+# Final State Checkpoint
+# ================================
+{"cursor":"AAAAAAAAAAAAAA==","streams":{"dbo.test_scankeytypes_integer":{"key_columns":["k"],"mode":"Backfill","scanned":"FQI="}}}
+
+
+####################################
+### Capture from Key "FQI="
+####################################
+# ================================
+# Collection "acmeCo/test/test_scankeytypes_integer": 1 Documents
+# ================================
+{"_meta":{"op":"c","source":{"schema":"dbo","snapshot":true,"table":"test_ScanKeyTypes_Integer"}},"k":1723,"v":"Data 3"}
+# ================================
+# Final State Checkpoint
+# ================================
+{"cursor":"AAAAAAAAAAAAAA==","streams":{"dbo.test_scankeytypes_integer":{"key_columns":["k"],"mode":"Backfill","scanned":"Fga7"}}}
+
+
+####################################
+### Capture from Key "Fga7"
+####################################
+# ================================
+# Final State Checkpoint
+# ================================
+{"cursor":"AAAAAAAAAAAAAA==","streams":{"dbo.test_scankeytypes_integer":{"key_columns":["k"],"mode":"Active"}}}
+
+
+

--- a/source-sqlserver/datatypes.go
+++ b/source-sqlserver/datatypes.go
@@ -9,12 +9,25 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
+// The standard library `time.RFC3339Nano` is wrong for historical reasons, this
+// format string is better because it always uses 9-digit fractional seconds, and
+// thus it can be sorted lexicographically as bytes.
+const sortableRFC3339Nano = "2006-01-02T15:04:05.000000000Z07:00"
+
 func encodeKeyFDB(key, ktype interface{}) (tuple.TupleElement, error) {
-	return key, nil
+	switch key := key.(type) {
+	case time.Time:
+		return key.Format(sortableRFC3339Nano), nil
+	default:
+		return key, nil
+	}
 }
 
 func decodeKeyFDB(t tuple.TupleElement) (interface{}, error) {
-	return t, nil
+	switch t := t.(type) {
+	default:
+		return t, nil
+	}
 }
 
 func (db *sqlserverDatabase) translateRecordFields(columnTypes map[string]interface{}, f map[string]interface{}) error {

--- a/source-sqlserver/datatypes_test.go
+++ b/source-sqlserver/datatypes_test.go
@@ -2,8 +2,10 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
+	"github.com/bradleyjkemp/cupaloy"
 	"github.com/estuary/connectors/sqlcapture/tests"
 )
 
@@ -54,4 +56,30 @@ func TestDatatypes(t *testing.T) {
 
 		{ColumnType: `xml`, ExpectType: `{"type":["string","null"]}`, InputValue: `<hello>world</hello>`, ExpectValue: `"\u003chello\u003eworld\u003c/hello\u003e"`},
 	})
+}
+
+func TestScanKeyTypes(t *testing.T) {
+	var ctx, tb = context.Background(), sqlserverTestBackend(t)
+	for _, tc := range []struct {
+		Name       string
+		ColumnType string
+		Values     []interface{}
+	}{
+		{"Integer", "INTEGER", []any{0, -3, 2, 1723}},
+		{"DateTimeOffset", "DATETIMEOFFSET", []any{"1991-08-31T12:34:54.125-06:00", "1991-08-31T12:34:54.126-06:00", "2000-01-01T01:01:01Z"}},
+	} {
+		t.Run(tc.Name, func(t *testing.T) {
+			var tableName = tb.CreateTable(ctx, t, "", fmt.Sprintf("(k %s PRIMARY KEY, v TEXT)", tc.ColumnType))
+			var rows [][]interface{}
+			for idx, val := range tc.Values {
+				rows = append(rows, []interface{}{val, fmt.Sprintf("Data %d", idx)})
+			}
+			tb.Insert(ctx, t, tableName, rows)
+
+			var cs = tb.CaptureSpec(ctx, t, tableName)
+			cs.EndpointSpec.(*Config).Advanced.BackfillChunkSize = 1
+			var summary, _ = tests.RestartingBackfillCapture(ctx, t, cs)
+			cupaloy.SnapshotT(t, summary)
+		})
+	}
 }


### PR DESCRIPTION
**Description:**

This copies the 'TestScanKeyTypes' test to `source-sqlserver` with a test case for `datetimeoffset` columns.

Then the `encodeKeyFDB` function is modified to make this pass by serializing `time.Time` values coming from the database driver using the `sortableRFC3339Nano` format string. No decoding is required, as the string format can be used directly as an input to subsequent backfill queries.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/640)
<!-- Reviewable:end -->
