### PR TITLE
source-mongodb: log change stream error details

### DIFF
--- a/source-mongodb/pull.go
+++ b/source-mongodb/pull.go
@@ -146,6 +146,14 @@ func (c *capture) ChangeStream(ctx context.Context, client *mongo.Client, bindin
 				}
 
 				return fmt.Errorf("change stream on collection %s cannot resume capture, the connector will restart and run a backfill: %w", res.Collection, err)
+			} else {
+				log.WithFields(log.Fields{
+					"database":                 res.Database,
+					"collection":               res.Collection,
+					"isChangeStreamFatalError": e.HasErrorCode(changeStreamFatalErrorCode),
+					"isResumePointGone":        e.HasErrorMessage(resumePointGoneErrorMessage),
+					"resumeToken":              resumeToken,
+				}).Errorf("mongo server error: %+v", e)
 			}
 		}
 


### PR DESCRIPTION
Adds a bit of additional logging when encountering a server error while reading the change stream. This is to help diagnose an issue with a capture running in production.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/641)
<!-- Reviewable:end -->
