### PR TITLE
source-mongodb: fix restarting backfill

### DIFF
--- a/source-mongodb/pull.go
+++ b/source-mongodb/pull.go
@@ -108,7 +108,6 @@ type changeEvent struct {
 	FullDocument  bson.M `bson:"fullDocument"`
 }
 
-const changeStreamFatalErrorCode = 280
 const resumePointGoneErrorMessage = "the resume point may no longer be in the oplog"
 
 func (c *capture) ChangeStream(ctx context.Context, client *mongo.Client, binding int, res resource, backfillFinishedAt *primitive.Timestamp, resumeToken bson.Raw) error {
@@ -116,7 +115,12 @@ func (c *capture) ChangeStream(ctx context.Context, client *mongo.Client, bindin
 
 	var collection = db.Collection(res.Collection)
 
-	log.Debug("listening on changes on collection ", res.Collection)
+	log.WithFields(log.Fields{
+		"database":           res.Database,
+		"collection":         res.Collection,
+		"resumeToken":        resumeToken,
+		"backfillFinishedAt": backfillFinishedAt,
+	}).Info("listening on changes on collection")
 	var eventFilter = bson.D{{"$match", bson.D{{"$or",
 		bson.A{
 			bson.D{{"operationType", "delete"}},
@@ -140,20 +144,11 @@ func (c *capture) ChangeStream(ctx context.Context, client *mongo.Client, bindin
 		// of the collection which can't resume instead of resetting the whole
 		// connector's checkpoint and backfilling everything
 		if e, ok := err.(mongo.ServerError); ok {
-			if e.HasErrorCode(changeStreamFatalErrorCode) && e.HasErrorMessage(resumePointGoneErrorMessage) {
+			if e.HasErrorMessage(resumePointGoneErrorMessage) {
 				if err = c.Output.Checkpoint([]byte("{}"), false); err != nil {
 					return fmt.Errorf("output checkpoint failed: %w", err)
 				}
-
 				return fmt.Errorf("change stream on collection %s cannot resume capture, the connector will restart and run a backfill: %w", res.Collection, err)
-			} else {
-				log.WithFields(log.Fields{
-					"database":                 res.Database,
-					"collection":               res.Collection,
-					"isChangeStreamFatalError": e.HasErrorCode(changeStreamFatalErrorCode),
-					"isResumePointGone":        e.HasErrorMessage(resumePointGoneErrorMessage),
-					"resumeToken":              resumeToken,
-				}).Errorf("mongo server error: %+v", e)
 			}
 		}
 


### PR DESCRIPTION
**Description:**

When a mongodb oplog does not contain enough history to resume from the last resumption checkpoint, the connector attempts to zero out its state and re-start backfilling the collections. The logic to detect this condition didn't seem to be working. The logs showed that the error message did match, but that the error code did not. So this removes the error code check from the condition, to hopefully allow the broken capture to re-start backfilling.

**Workflow steps:**

- have a mongo capture that stops emitting state checkpoints at some point
- wait until the last observed change event falls off the back of the mongo server's oplog 
- start the capture
- Previously, this would cause the capture to repeatedly fail. Now, it should fail once and then re-start backfilling the collections and continue working again.

**Documentation links affected:** n/a

**Notes for reviewers:**

There might sill be another issue lurking here, which this PR doesn't attempt to address. The scenario is if the mongo server has a lot of activity, but for whatever reason the capture doesn't actually emit any documents or state checkpoints. This could maybe be the case if the user is only capturing a subset of collections. In that case, we might not be updating the state checkpoint regularly with the latest observed resumption token, which could lead to the token eventually becoming stale. If that's an issue, then I think we should handle it in a separate PR.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/642)
<!-- Reviewable:end -->
