### PR TITLE
airbyte-to-flow: use airbyte-to-flow:dev for all connectors that use airbyte-to-flow

### DIFF
--- a/source-gcs/Dockerfile
+++ b/source-gcs/Dockerfile
@@ -38,7 +38,7 @@ COPY --from=builder /builder/connector ./source-gcs
 # Avoid running the connector as root.
 USER nonroot:nonroot
 
-COPY --from=ghcr.io/estuary/airbyte-to-flow:eb2f96a /airbyte-to-flow ./
+COPY --from=ghcr.io/estuary/airbyte-to-flow:dev /airbyte-to-flow ./
 ENTRYPOINT ["/connector/airbyte-to-flow", "--connector-entrypoint", "/connector/source-gcs"]
 
 LABEL FLOW_RUNTIME_PROTOCOL=capture

--- a/source-hello-world/Dockerfile
+++ b/source-hello-world/Dockerfile
@@ -36,7 +36,7 @@ COPY --from=builder /builder/connector ./source-hello-world
 # Avoid running the connector as root.
 USER nonroot:nonroot
 
-COPY --from=ghcr.io/estuary/airbyte-to-flow:eb2f96a /airbyte-to-flow ./
+COPY --from=ghcr.io/estuary/airbyte-to-flow:dev /airbyte-to-flow ./
 ENTRYPOINT ["/connector/airbyte-to-flow", "--connector-entrypoint", "/connector/source-hello-world"]
 
 LABEL FLOW_RUNTIME_PROTOCOL=capture

--- a/source-http-file/Dockerfile
+++ b/source-http-file/Dockerfile
@@ -38,7 +38,7 @@ COPY --from=builder /builder/connector ./source-http-file
 # Avoid running the connector as root.
 USER nonroot:nonroot
 
-COPY --from=ghcr.io/estuary/airbyte-to-flow:eb2f96a /airbyte-to-flow ./
+COPY --from=ghcr.io/estuary/airbyte-to-flow:dev /airbyte-to-flow ./
 ENTRYPOINT ["/connector/airbyte-to-flow", "--connector-entrypoint", "/connector/source-http-file"]
 
 LABEL FLOW_RUNTIME_PROTOCOL=capture

--- a/source-kafka/Dockerfile
+++ b/source-kafka/Dockerfile
@@ -53,7 +53,7 @@ COPY --from=builder /usr/local/cargo/bin/source-kafka ./source-kafka
 # Avoid running the connector as root.
 USER nonroot:nonroot
 
-COPY --from=ghcr.io/estuary/airbyte-to-flow:eb2f96a /airbyte-to-flow ./
+COPY --from=ghcr.io/estuary/airbyte-to-flow:dev /airbyte-to-flow ./
 ENTRYPOINT ["/connector/airbyte-to-flow", "--connector-entrypoint", "/connector/source-kafka"]
 
 LABEL FLOW_RUNTIME_PROTOCOL=capture

--- a/source-kinesis/Dockerfile
+++ b/source-kinesis/Dockerfile
@@ -36,7 +36,7 @@ COPY --from=builder /builder/connector ./source-kinesis
 # Avoid running the connector as root.
 USER nonroot:nonroot
 
-COPY --from=ghcr.io/estuary/airbyte-to-flow:eb2f96a /airbyte-to-flow ./
+COPY --from=ghcr.io/estuary/airbyte-to-flow:dev /airbyte-to-flow ./
 ENTRYPOINT ["/connector/airbyte-to-flow", "--connector-entrypoint", "/connector/source-kinesis"]
 
 LABEL FLOW_RUNTIME_PROTOCOL=capture

--- a/source-s3/Dockerfile
+++ b/source-s3/Dockerfile
@@ -41,7 +41,7 @@ COPY --from=builder /builder/connector ./source-s3
 # Avoid running the connector as root.
 USER nonroot:nonroot
 
-COPY --from=ghcr.io/estuary/airbyte-to-flow:eb2f96a /airbyte-to-flow ./
+COPY --from=ghcr.io/estuary/airbyte-to-flow:dev /airbyte-to-flow ./
 ENTRYPOINT ["/connector/airbyte-to-flow", "--connector-entrypoint", "/connector/source-s3"]
 
 LABEL FLOW_RUNTIME_PROTOCOL=capture


### PR DESCRIPTION
**Description:**

We had this temporarily pinned to a specific build to ease the transition to the new flow protocols, but that's done now so we can move back to the dev image for airbyte-to-flow.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/646)
<!-- Reviewable:end -->
