### PR TITLE
source-postgres: remove parens from ORDER BY

### DIFF
--- a/source-postgres/backfill.go
+++ b/source-postgres/backfill.go
@@ -139,7 +139,7 @@ func (db *postgresDatabase) buildScanQuery(start bool, keyColumns []string, colu
 	if !start {
 		fmt.Fprintf(query, ` WHERE (%s) > (%s)`, strings.Join(pkey, ", "), strings.Join(args, ", "))
 	}
-	fmt.Fprintf(query, ` ORDER BY (%s)`, strings.Join(pkey, ", "))
+	fmt.Fprintf(query, ` ORDER BY %s`, strings.Join(pkey, ", "))
 	fmt.Fprintf(query, " LIMIT %d;", db.config.Advanced.BackfillChunkSize)
 	return query.String()
 }


### PR DESCRIPTION
**Description:**

This removes the parens from around the column names in the `ORDER BY` of the backfill queries for source-postgres. I ran `EXPLAIN` on some backfill queries and found that, at least in this circumstance, postgres would refuse to use an index when the column names were surrounded with parens, while it would use them as expected if the parens were left off. In this case, we were querying by `(a, b)`, where `a` had a primary key index, and `b` had a secondary btree index. The parens in the `WHERE` clause did not seem to have any effect, though.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/648)
<!-- Reviewable:end -->
