### PR TITLE
source-postgres: Lower a couple of buffer-size tuning constants

### DIFF
--- a/source-postgres/replication.go
+++ b/source-postgres/replication.go
@@ -187,7 +187,7 @@ const standbyStatusInterval = 10 * time.Second
 // The buffer is much larger for PostgreSQL than for most other databases, because
 // empirically this helps us to cope with spikes of intense load which can otherwise
 // cause the database to cut us off.
-var replicationBufferSize = 64 * 1024 // Assuming change events average ~2kB then 64k * 2kB = 128MB
+var replicationBufferSize = 16 * 1024 // Assuming change events average ~2kB then 16k * 2kB = 32MB
 
 func (s *replicationStream) Events() <-chan sqlcapture.DatabaseEvent {
 	return s.events

--- a/sqlcapture/capture.go
+++ b/sqlcapture/capture.go
@@ -96,7 +96,7 @@ const (
 	streamProgressInterval = 60 * time.Second        // After `streamProgressInterval` the replication streaming code may log a progress report.
 )
 
-const emitterBufferSize = 64 * 1024 // Assuming change events average ~2kB then 64k * 2kB = 128MB
+const emitterBufferSize = 4096 // Assuming change events average ~2kB then 4k * 2kB = 8MB
 
 // Run is the top level entry point of the capture process.
 func (c *Capture) Run(ctx context.Context) (err error) {


### PR DESCRIPTION
**Description:**

The previous change which made only one table get a chunk backfilled at a time didn't impact memory usage nearly as much as expected, so while that's still probably a good move in general it implies that we're gobbling up memory somewhere else instead.

There are two other notable "buffers" inside of a SQL capture, so let's try reducing the size of both of those buffers and see if that makes any difference.

Both of these are sized primarily for performance -- connector operation remains correct even if the channels were unbuffered, so it should be entirely safe to make them smaller.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/650)
<!-- Reviewable:end -->
