### PR TITLE
source-{mysql,postgres,sqlserver}: Ask nicely to use less RAM

### DIFF
--- a/source-mysql/Dockerfile
+++ b/source-mysql/Dockerfile
@@ -48,6 +48,10 @@ COPY --from=builder /builder/connector ./source-mysql
 # Avoid running the connector as root.
 USER nonroot:nonroot
 
+# Ask the Go runtime to keep heap size below 900MiB. Our real memory limit is
+# 1GiB so this is 10% headroom as recommended in https://go.dev/doc/gc-guide
+ENV GOMEMLIMIT=900MiB
+
 ENTRYPOINT ["/connector/source-mysql"]
 
 LABEL FLOW_RUNTIME_PROTOCOL=capture

--- a/source-postgres/Dockerfile
+++ b/source-postgres/Dockerfile
@@ -52,6 +52,10 @@ COPY --from=ghcr.io/estuary/network-tunnel:dev /flow-network-tunnel /usr/bin/flo
 # Avoid running the connector as root.
 USER nonroot:nonroot
 
+# Ask the Go runtime to keep heap size below 900MiB. Our real memory limit is
+# 1GiB so this is 10% headroom as recommended in https://go.dev/doc/gc-guide
+ENV GOMEMLIMIT=900MiB
+
 ENTRYPOINT ["/connector/source-postgres"]
 
 LABEL FLOW_RUNTIME_PROTOCOL=capture

--- a/source-sqlserver/Dockerfile
+++ b/source-sqlserver/Dockerfile
@@ -51,6 +51,10 @@ COPY --from=ghcr.io/estuary/network-tunnel:dev /flow-network-tunnel /usr/bin/flo
 # Avoid running the connector as root.
 USER nonroot:nonroot
 
+# Ask the Go runtime to keep heap size below 900MiB. Our real memory limit is
+# 1GiB so this is 10% headroom as recommended in https://go.dev/doc/gc-guide
+ENV GOMEMLIMIT=900MiB
+
 ENTRYPOINT ["/connector/source-sqlserver"]
 
 LABEL FLOW_RUNTIME_PROTOCOL=capture


### PR DESCRIPTION
**Description:**

New in Go 1.19, the `GOMEMLIMIT` environment variable is added for use-cases such as "the deployment of a web service into containers with a fixed amount of available memory".

I suspect that in at least some cases we OOM during large backfills not because we have >1GiB of *live* data, but rather because the Go GC correctly deduces that we'd get better throughput if we used >1GiB of heap before running a GC cycle. And really, if we don't inform it about our 1GiB memory limit that's a choice it is correct in making.

So, uh, maybe let's try asking it to pretty please keep the Go heap below 900MiB if it can?

**Notes for reviewers:**

In theory we might want to move this into the base connector image at some point in the future, but I figured limiting it to just SQL captures was better for the moment.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/651)
<!-- Reviewable:end -->
