### PR TITLE
source-sqlserver: Fix primary key text collation

### DIFF
--- a/source-sqlserver/.snapshots/TestTextCollation
+++ b/source-sqlserver/.snapshots/TestTextCollation
@@ -8,9 +8,5 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"cursor":"AAAAAAAAAAAAAA==","streams":{"dbo.test_textcollation":{"key_columns":["id"],"mode":"Backfill","scanned":"AkggUgA="}}}
-# ================================
-# Captures Terminated With Errors
-# ================================
-error performing backfill: scan key ordering failure: last="\x02H R\x00", next="\x02-J C\x00"
+{"cursor":"AAAAAAAAAAAAAA==","streams":{"dbo.test_textcollation":{"key_columns":["id"],"mode":"Active"}}}
 

--- a/source-sqlserver/.snapshots/TestTextCollation
+++ b/source-sqlserver/.snapshots/TestTextCollation
@@ -1,0 +1,16 @@
+# ================================
+# Collection "acmeCo/test/test_textcollation": 4 Documents
+# ================================
+{"_meta":{"op":"c","source":{"schema":"dbo","snapshot":true,"table":"test_TextCollation"}},"data":"3","id":"-J C"}
+{"_meta":{"op":"c","source":{"schema":"dbo","snapshot":true,"table":"test_TextCollation"}},"data":"1","id":"AAA"}
+{"_meta":{"op":"c","source":{"schema":"dbo","snapshot":true,"table":"test_TextCollation"}},"data":"2","id":"BBB"}
+{"_meta":{"op":"c","source":{"schema":"dbo","snapshot":true,"table":"test_TextCollation"}},"data":"4","id":"H R"}
+# ================================
+# Final State Checkpoint
+# ================================
+{"cursor":"AAAAAAAAAAAAAA==","streams":{"dbo.test_textcollation":{"key_columns":["id"],"mode":"Backfill","scanned":"AkggUgA="}}}
+# ================================
+# Captures Terminated With Errors
+# ================================
+error performing backfill: scan key ordering failure: last="\x02H R\x00", next="\x02-J C\x00"
+

--- a/source-sqlserver/backfill.go
+++ b/source-sqlserver/backfill.go
@@ -110,12 +110,33 @@ func (db *sqlserverDatabase) ScanTableChunk(ctx context.Context, info *sqlcaptur
 	return events, nil
 }
 
+// The set of column types for which we need to specify a text collation to
+// get sane ordering and comparison of row keys. Represented as a map[string]bool
+// so that it can be combined with the "is the column typename a string" check
+// into one if statement.
+var columnTypeCollatedText = map[string]bool{
+	"char":     true,
+	"varchar":  true,
+	"nchar":    true,
+	"nvarchar": true,
+}
+
 func (db *sqlserverDatabase) buildScanQuery(start bool, keyColumns []string, columnTypes map[string]interface{}, schemaName, tableName string) string {
 	var pkey []string
 	var args []string
 	for idx, colName := range keyColumns {
-		pkey = append(pkey, quoteColumnName(colName))
+		var quotedName = quoteColumnName(colName)
 		args = append(args, fmt.Sprintf("@p%d", idx+1))
+		//
+		if colType, ok := columnTypes[colName].(string); ok && columnTypeCollatedText[colType] {
+			// The Latin1_General_100_BIN2_UTF8 collation basically means "just shut up
+			// and order lexicographically by Unicode code point". And UTF-8 is designed
+			// such that bytewise lexicographic ordering matches Unicode code-point ordering,
+			// so this should hopefully match the internal scan key ordering in all cases.
+			pkey = append(pkey, quotedName+` COLLATE Latin1_General_100_BIN2_UTF8`)
+		} else {
+			pkey = append(pkey, quotedName)
+		}
 	}
 
 	var query = new(strings.Builder)

--- a/source-sqlserver/main_test.go
+++ b/source-sqlserver/main_test.go
@@ -220,3 +220,12 @@ func TestColumnNameQuoting(t *testing.T) {
 	tb.Insert(ctx, t, tableName, [][]any{{0, 0, 0, 0, 0}, {1, 1, 1, 1, 1}, {2, 2, 2, 2, 2}})
 	tests.VerifiedCapture(ctx, t, tb.CaptureSpec(ctx, t, tableName))
 }
+
+func TestTextCollation(t *testing.T) {
+	var tb, ctx = sqlserverTestBackend(t), context.Background()
+	var tableName = tb.CreateTable(ctx, t, "", "(id VARCHAR(8) PRIMARY KEY, data TEXT)")
+	tb.Insert(ctx, t, tableName, [][]any{{"AAA", "1"}, {"BBB", "2"}, {"-J C", "3"}, {"H R", "4"}})
+	var cs = tb.CaptureSpec(ctx, t, tableName)
+	cs.Validator = &st.OrderedCaptureValidator{}
+	tests.VerifiedCapture(ctx, t, cs)
+}


### PR DESCRIPTION
**Description:**

This PR is intended to fix text collation ordering in backfill queries, by explicitly specifying the `Latin1_General_100_BIN2_UTF8` collation order on primary keys whose column type is `{n}{var}char(N)`.

The aforementioned collation basically means "just shut up and sort lexicographically on Unicode code-points" as far as I can tell, and since UTF-8 is designed such that bytewise lexicographic ordering matches Unicode code-point ordering this _should_ mean that backfill query row ordering will exactly match our internal scan key ordering as intended.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/655)
<!-- Reviewable:end -->
