### PR TITLE
sqlcapture: Allow successive row keys to be equal

### DIFF
--- a/source-mysql/.snapshots/TestGeneric-DuplicatedScanKey
+++ b/source-mysql/.snapshots/TestGeneric-DuplicatedScanKey
@@ -1,0 +1,9 @@
+# ================================
+# Final State Checkpoint
+# ================================
+{"cursor":"binlog.000123:56789","streams":{"test.generic_duplicatedscankey":{"key_columns":["id"],"metadata":{"schema":{"columns":["id","data"],"types":{"data":"text","id":"varchar"}}},"mode":"Backfill"}}}
+# ================================
+# Captures Terminated With Errors
+# ================================
+error performing backfill: error buffering scan results for "test.generic_duplicatedscankey": primary key ordering failure: prev="\x01BBB\x00", next="\x01BBB\x00"
+

--- a/source-mysql/.snapshots/TestGeneric-DuplicatedScanKey
+++ b/source-mysql/.snapshots/TestGeneric-DuplicatedScanKey
@@ -1,9 +1,11 @@
 # ================================
+# Collection "acmeCo/test/generic_duplicatedscankey": 3 Documents
+# ================================
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"Generic_DuplicatedScanKey"}},"data":"1","id":"AAA"}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"Generic_DuplicatedScanKey"}},"data":"3","id":"BBB"}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"Generic_DuplicatedScanKey"}},"data":"4","id":"CCC"}
+# ================================
 # Final State Checkpoint
 # ================================
-{"cursor":"binlog.000123:56789","streams":{"test.generic_duplicatedscankey":{"key_columns":["id"],"metadata":{"schema":{"columns":["id","data"],"types":{"data":"text","id":"varchar"}}},"mode":"Backfill"}}}
-# ================================
-# Captures Terminated With Errors
-# ================================
-error performing backfill: error buffering scan results for "test.generic_duplicatedscankey": primary key ordering failure: prev="\x01BBB\x00", next="\x01BBB\x00"
+{"cursor":"binlog.000123:56789","streams":{"test.generic_duplicatedscankey":{"key_columns":["id"],"metadata":{"schema":{"columns":["id","data"],"types":{"data":"text","id":"varchar"}}},"mode":"Active"}}}
 

--- a/source-postgres/.snapshots/TestGeneric-DuplicatedScanKey
+++ b/source-postgres/.snapshots/TestGeneric-DuplicatedScanKey
@@ -1,0 +1,9 @@
+# ================================
+# Final State Checkpoint
+# ================================
+{"cursor":"0/1111111","streams":{"test.generic_duplicatedscankey":{"key_columns":["id"],"mode":"Backfill"}}}
+# ================================
+# Captures Terminated With Errors
+# ================================
+error performing backfill: error buffering scan results for "test.generic_duplicatedscankey": primary key ordering failure: prev="\x02BBB\x00", next="\x02BBB\x00"
+

--- a/source-postgres/.snapshots/TestGeneric-DuplicatedScanKey
+++ b/source-postgres/.snapshots/TestGeneric-DuplicatedScanKey
@@ -1,9 +1,11 @@
 # ================================
+# Collection "acmeCo/test/generic_duplicatedscankey": 3 Documents
+# ================================
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"generic_duplicatedscankey","loc":[11111111,11111111,11111111]}},"data":"1","id":"AAA"}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"generic_duplicatedscankey","loc":[11111111,11111111,11111111]}},"data":"3","id":"BBB"}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"generic_duplicatedscankey","loc":[11111111,11111111,11111111]}},"data":"4","id":"CCC"}
+# ================================
 # Final State Checkpoint
 # ================================
-{"cursor":"0/1111111","streams":{"test.generic_duplicatedscankey":{"key_columns":["id"],"mode":"Backfill"}}}
-# ================================
-# Captures Terminated With Errors
-# ================================
-error performing backfill: error buffering scan results for "test.generic_duplicatedscankey": primary key ordering failure: prev="\x02BBB\x00", next="\x02BBB\x00"
+{"cursor":"0/1111111","streams":{"test.generic_duplicatedscankey":{"key_columns":["id"],"mode":"Active"}}}
 

--- a/source-sqlserver/.snapshots/TestGeneric-DuplicatedScanKey
+++ b/source-sqlserver/.snapshots/TestGeneric-DuplicatedScanKey
@@ -1,9 +1,11 @@
 # ================================
+# Collection "acmeCo/test/test_generic_duplicatedscankey": 3 Documents
+# ================================
+{"_meta":{"op":"c","source":{"schema":"dbo","snapshot":true,"table":"test_Generic_DuplicatedScanKey"}},"data":"1","id":"AAA"}
+{"_meta":{"op":"c","source":{"schema":"dbo","snapshot":true,"table":"test_Generic_DuplicatedScanKey"}},"data":"3","id":"BBB"}
+{"_meta":{"op":"c","source":{"schema":"dbo","snapshot":true,"table":"test_Generic_DuplicatedScanKey"}},"data":"4","id":"CCC"}
+# ================================
 # Final State Checkpoint
 # ================================
-{"cursor":"AAAAAAAAAAAAAA==","streams":{"dbo.test_generic_duplicatedscankey":{"key_columns":["id"],"mode":"Backfill"}}}
-# ================================
-# Captures Terminated With Errors
-# ================================
-error performing backfill: error buffering scan results for "dbo.test_generic_duplicatedscankey": primary key ordering failure: prev="\x02BBB\x00", next="\x02BBB\x00"
+{"cursor":"AAAAAAAAAAAAAA==","streams":{"dbo.test_generic_duplicatedscankey":{"key_columns":["id"],"mode":"Active"}}}
 

--- a/source-sqlserver/.snapshots/TestGeneric-DuplicatedScanKey
+++ b/source-sqlserver/.snapshots/TestGeneric-DuplicatedScanKey
@@ -1,0 +1,9 @@
+# ================================
+# Final State Checkpoint
+# ================================
+{"cursor":"AAAAAAAAAAAAAA==","streams":{"dbo.test_generic_duplicatedscankey":{"key_columns":["id"],"mode":"Backfill"}}}
+# ================================
+# Captures Terminated With Errors
+# ================================
+error performing backfill: error buffering scan results for "dbo.test_generic_duplicatedscankey": primary key ordering failure: prev="\x02BBB\x00", next="\x02BBB\x00"
+

--- a/sqlcapture/capture.go
+++ b/sqlcapture/capture.go
@@ -510,7 +510,7 @@ func (c *Capture) backfillStreams(ctx context.Context, streams []string) (*resul
 		if err != nil {
 			return nil, fmt.Errorf("error scanning table %q: %w", streamID, err)
 		}
-		if len(events) > 0 && compareTuples(streamState.Scanned, events[0].RowKey) >= 0 {
+		if len(events) > 0 && compareTuples(streamState.Scanned, events[0].RowKey) > 0 {
 			// Sanity check that the DB must always return rows whose serialized
 			// key value is greater than the previous cursor value. This together
 			// with the check in resultset.go ensures that the scan key always

--- a/sqlcapture/resultset.go
+++ b/sqlcapture/resultset.go
@@ -50,7 +50,7 @@ func (r *resultSet) Buffer(streamID string, events []*ChangeEvent) error {
 	}).Debug("buffering chunk of backfill data")
 	for _, event := range events {
 		var bs = event.RowKey
-		if chunk.scanned != nil && compareTuples(chunk.scanned, bs) >= 0 {
+		if chunk.scanned != nil && compareTuples(chunk.scanned, bs) > 0 {
 			// It's important for correctness that the ordering of serialized primary keys matches
 			// the ordering that PostgreSQL uses. Since we're already serializing every result row's
 			// key this is a good place to opportunistically check that invariant.

--- a/sqlcapture/tests/tests.go
+++ b/sqlcapture/tests/tests.go
@@ -35,6 +35,7 @@ func Run(ctx context.Context, t *testing.T, tb TestBackend) {
 	t.Run("CatalogPrimaryKeyOverride", func(t *testing.T) { testCatalogPrimaryKeyOverride(ctx, t, tb) })
 	t.Run("MissingTable", func(t *testing.T) { testMissingTable(ctx, t, tb) })
 	t.Run("StressCorrectness", func(t *testing.T) { testStressCorrectness(ctx, t, tb) })
+	t.Run("DuplicatedScanKey", func(t *testing.T) { testDuplicatedScanKey(ctx, t, tb) })
 	//t.Run("ComplexDataset", func(t *testing.T) { testComplexDataset(ctx, t, tb) })
 }
 
@@ -233,6 +234,14 @@ func testMissingTable(ctx context.Context, t *testing.T, tb TestBackend) {
 	var binding2 = BindingReplace(binding1, "one", "two")
 	var cs = tb.CaptureSpec(ctx, t)
 	cs.Bindings = []*flow.CaptureSpec_Binding{binding1, binding2}
+	VerifiedCapture(ctx, t, cs)
+}
+
+func testDuplicatedScanKey(ctx context.Context, t *testing.T, tb TestBackend) {
+	var tableName = tb.CreateTable(ctx, t, "", "(id VARCHAR(8), data TEXT)")
+	tb.Insert(ctx, t, tableName, [][]any{{"AAA", "1"}, {"BBB", "2"}, {"BBB", "3"}, {"CCC", "4"}})
+	var cs = tb.CaptureSpec(ctx, t, tableName)
+	cs.Bindings[0].Collection.Key = []string{"id"}
 	VerifiedCapture(ctx, t, cs)
 }
 


### PR DESCRIPTION
**Description:**

In the past we required that successive row keys be strictly greater than previous rows. But since it's possible to capture from tables without a primary key or any other form of uniqueness constraint on the backfill key columns, there are legitimate situations where we might observe successive keys being exactly equal.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/657)
<!-- Reviewable:end -->
