### PR TITLE
materialize-bigquery: use direct equality for load query

### DIFF
--- a/materialize-bigquery/.snapshots/TestSQLGeneration
+++ b/materialize-bigquery/.snapshots/TestSQLGeneration
@@ -22,11 +22,11 @@ CLUSTER BY key1, key2, boolean, integer;
 SELECT 0, l.flow_document
 	FROM projectID.dataset.target_table AS l
 	JOIN flow_temp_table_0 AS r
-		 ON l.key1 is not distinct from r.key1
-		 AND l.key2 is not distinct from r.key2
-		 AND l.boolean is not distinct from r.boolean
-		 AND l.integer is not distinct from r.integer
-		 AND l.string is not distinct from r.string
+		 ON l.key1 = r.key1
+		 AND l.key2 = r.key2
+		 AND l.boolean = r.boolean
+		 AND l.integer = r.integer
+		 AND l.string = r.string
 
 --- End projectID.dataset.target_table loadQuery ---
 

--- a/materialize-bigquery/sqlgen.go
+++ b/materialize-bigquery/sqlgen.go
@@ -149,7 +149,7 @@ SELECT {{ $.Binding }}, l.{{$.Document.Identifier}}
 	JOIN {{ template "tempTableName" . }} AS r
 	{{- range $ind, $key := $.Keys }}
 		{{ if $ind }} AND {{ else }} ON {{ end -}}
-		l.{{ $key.Identifier }} is not distinct from r.{{ $key.Identifier }}
+		l.{{ $key.Identifier }} = r.{{ $key.Identifier }}
 	{{- end }}
 {{ else }}
 SELECT -1, NULL LIMIT 0


### PR DESCRIPTION
**Description:**

Uses direct equality for loads, rather than "is not distinct from".

We've been observing poor load query performance on even modestly sized data sets, making the
connector essentially unusable for these cases. Some quick testing has revealed that using `=` for
comparision in the load query instead of "is not distinct from" makes a tremendous difference in the
performance of the load query join.

This change means that we will not be able to use nullable keys with the connector. For the moment
this is acceptable since it is only very recently that nullable keys were allowed in the runtime and
there are no current bigquery materializations using nullable keys. We will likely be pursuing a
different path for nullable keys involving default values in the future, so long term the direct
equality comparision should continue to work.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

Note that using `=` for load query equality is how Snowflake does it as well: https://github.com/estuary/connectors/blob/34fc559f37853dea2a31abd75c50cf81b8b3e6e2/materialize-snowflake/sqlgen.go#L137-L158 It is possible that Snowflake would have needed to use [`is [not] distinct from`](https://docs.snowflake.com/en/sql-reference/functions/is-distinct-from) to support nullable keys (with unknown performance implications), but it had never been updated for that.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/660)
<!-- Reviewable:end -->
