### PR TITLE
materialize-postgres: be more explicit about the default port

### DIFF
--- a/materialize-postgres/.snapshots/TestSpecification
+++ b/materialize-postgres/.snapshots/TestSpecification
@@ -6,7 +6,7 @@
       "address": {
         "type": "string",
         "title": "Address",
-        "description": "Host and port of the database.",
+        "description": "Host and port of the database (in the form of host[:port]). Port 5432 is used as the default if no specific port is provided.",
         "order": 0
       },
       "user": {

--- a/materialize-postgres/config_test.go
+++ b/materialize-postgres/config_test.go
@@ -27,6 +27,12 @@ func TestPostgresConfig(t *testing.T) {
 	uri = minimal.ToURI()
 	require.Equal(t, "postgres://youser:shmassword@post.toast:1234?statement_cache_mode=describe", uri)
 
+	var noPort = validConfig
+	noPort.Address = "post.toast"
+	require.NoError(t, noPort.Validate())
+	uri = noPort.ToURI()
+	require.Equal(t, "postgres://youser:shmassword@post.toast:5432/namegame?statement_cache_mode=describe", uri)
+
 	var noAddress = validConfig
 	noAddress.Address = ""
 	require.Error(t, noAddress.Validate(), "expected validation error")


### PR DESCRIPTION
**Description:**

If no port is specified with the host, the connector will currently use 5432. This is buried in the [inner workings of pgx](https://github.com/jackc/pgconn/blob/1e1135688ea919f66b9425b5bfe06f14ef1e5285/defaults.go#L16) and not made clear to the user. This changes the messaging that the user sees and makes setting the port explicit in our connector code so that it is stable going forward.

**Workflow steps:**

Use a postgres materialization as before with no port specified and observe that it still works. No behavior is actually changed with this PR.

**Documentation links affected:**

N/A

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/661)
<!-- Reviewable:end -->
