### PR TITLE
source-s3: use localstack for integration tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -137,7 +137,7 @@ jobs:
           export_default_credentials: true
 
       - name: Configure AWS credentials from Test account
-        if: matrix.connector == 'source-kinesis' || matrix.connector == 'source-s3'
+        if: matrix.connector == 'source-kinesis'
         uses: aws-actions/configure-aws-credentials@v1
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/source-s3/main.go
+++ b/source-s3/main.go
@@ -84,7 +84,7 @@ func newS3Store(ctx context.Context, cfg *config) (*s3Store, error) {
 		c = c.WithRegion(cfg.Region)
 	}
 	if cfg.Advanced.Endpoint != "" {
-		c = c.WithEndpoint(cfg.Advanced.Endpoint)
+		c = c.WithEndpoint(cfg.Advanced.Endpoint).WithS3ForcePathStyle(true)
 	}
 
 	awsSession, err := session.NewSession(c)
@@ -325,7 +325,7 @@ func main() {
 		DocumentationURL: "https://go.estuary.dev/source-s3",
 		// Set the delta to 30 seconds in the past, to guard against new files appearing with a
 		// timestamp that's equal to the `MinBound` in the state.
-		TimeHorizonDelta:    time.Second * -30,
+		TimeHorizonDelta: time.Second * -30,
 	}
 
 	src.Main()

--- a/tests/source-gcs/expected.txt
+++ b/tests/source-gcs/expected.txt
@@ -1,14 +1,6 @@
 id|canary
 1|misidentifying
 10|inmates
-2|sourness's
-3|Sims's
-4|withhold
-5|rectangle's
-6|invertebrates
-7|antibiotics
-8|nursery's
-9|Tabitha's
 11|amputation's
 12|armament's
 13|splatters
@@ -18,6 +10,7 @@ id|canary
 17|pieced
 18|roaches
 19|devilish
+2|sourness's
 20|glucose's
 211|everybody
 212|Vietcong
@@ -29,3 +22,10 @@ id|canary
 218|testamentary
 219|northbound
 220|horrible
+3|Sims's
+4|withhold
+5|rectangle's
+6|invertebrates
+7|antibiotics
+8|nursery's
+9|Tabitha's

--- a/tests/source-s3/cleanup.sh
+++ b/tests/source-s3/cleanup.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-if [[ -n "$TEST_STREAM" ]]; then
-    echo "Cleaning up bucket: '$TEST_STREAM'"
-    aws s3 rb "s3://${TEST_STREAM}" --force
-fi
+set -e
 
+docker stop "${LOCALSTACK_CONTAINER_NAME}"

--- a/tests/source-s3/expected.txt
+++ b/tests/source-s3/expected.txt
@@ -1,14 +1,6 @@
 id|canary
 1|misidentifying
 10|inmates
-2|sourness's
-3|Sims's
-4|withhold
-5|rectangle's
-6|invertebrates
-7|antibiotics
-8|nursery's
-9|Tabitha's
 11|amputation's
 12|armament's
 13|splatters
@@ -18,6 +10,7 @@ id|canary
 17|pieced
 18|roaches
 19|devilish
+2|sourness's
 20|glucose's
 211|everybody
 212|Vietcong
@@ -29,3 +22,10 @@ id|canary
 218|testamentary
 219|northbound
 220|horrible
+3|Sims's
+4|withhold
+5|rectangle's
+6|invertebrates
+7|antibiotics
+8|nursery's
+9|Tabitha's

--- a/tests/source-s3/setup.sh
+++ b/tests/source-s3/setup.sh
@@ -7,27 +7,61 @@ export RESOURCE="{ \"stream\": \"${TEST_STREAM}\", \"syncMode\": \"incremental\"
 # set ID_TYPE to string because parsing CSV files will always result in string values.
 export ID_TYPE=string
 
+export LOCALSTACK_CONTAINER_NAME=localstack
+export LOCALSTACK_S3_ENDPOINT=http://${LOCALSTACK_CONTAINER_NAME}.flow-test:4566
+export LOCALSTACK_S3_LOCAL_ENDPOINT=http://localhost:4566
+
+# Dummy configs for awscli to access localstack.
+export AWS_ACCESS_KEY_ID=test_key
+export AWS_SECRET_ACCESS_KEY=test_secret
+export AWS_DEFAULT_REGION=us-east-1
+
 config_json_template='{
-    "awsAccessKeyId": "$AWS_ACCESS_KEY_ID",
-    "awsSecretAccessKey": "$AWS_SECRET_ACCESS_KEY",
+    "awsAccessKeyId": "${AWS_ACCESS_KEY_ID}",
+    "awsSecretAccessKey": "${AWS_SECRET_ACCESS_KEY}",
     "bucket": "${TEST_STREAM}",
-    "region": "${DEFAULT_AWS_REGION}"
+    "region": "${AWS_DEFAULT_REGION}",
+    "advanced": {
+      "endpoint": "${LOCALSTACK_S3_ENDPOINT}"
+    }
 }'
 
 export CONNECTOR_CONFIG="$(echo "$config_json_template" | envsubst | jq -c)"
 
-aws s3api create-bucket --bucket $TEST_STREAM --create-bucket-configuration LocationConstraint="${DEFAULT_AWS_REGION}"
+# Start localstack to emulate AWS S3 for testing.
+docker run -d \
+    --rm \
+    --user 0 \
+    --network "flow-test" \
+    --publish 4566:4566 \
+    --name="${LOCALSTACK_CONTAINER_NAME}" \
+    --env "SERVICES=s3" \
+    localstack/localstack
+
+for i in {1..20}; do
+    # Wait until the local stack is ready for serving.
+    if aws s3 ls --endpoint-url "${LOCALSTACK_S3_LOCAL_ENDPOINT}"; then
+        echo "localstack started successfully."
+        break
+    fi
+    echo "Not ready, retrying ${i}."
+    sleep 3
+done
+echo "Localstack logs:"
+docker logs "${LOCALSTACK_CONTAINER_NAME}"
+
+aws s3 mb "s3://${TEST_STREAM}" --endpoint "${LOCALSTACK_S3_LOCAL_ENDPOINT}"
 
 root_dir="$(git rev-parse --show-toplevel)"
 
 # We need to exclude the json file from the test because the `id` property there is an integer, and
 # this connector expects it to be a string.
 for file in $(find ${root_dir}/tests/files -type f -name '*.csv*'); do
-    aws s3 cp ${file} s3://${TEST_STREAM}/testprefix/$(basename $file)
+    aws s3 cp ${file} s3://${TEST_STREAM}/testprefix/$(basename $file) --endpoint "${LOCALSTACK_S3_LOCAL_ENDPOINT}"
 done
 
 # add an empty prefix to ensure that it gets filtered out
-aws s3api put-object --bucket "$TEST_STREAM" --key "testprefix/"
+aws s3api put-object --bucket "$TEST_STREAM" --key "testprefix/" --endpoint "${LOCALSTACK_S3_LOCAL_ENDPOINT}"
 
 sleep_seconds=30
 echo "Sleeping for ${sleep_seconds} seconds to account for filesource clock delta"


### PR DESCRIPTION
**Description:**

Updates the `source-s3` integration tests to use localstack instead of an actual S3 bucket so they can run reliably.

Also adjusts some test output ordering for `source-s3` and `source-gcs`. Apparently the new sqlite materialization has a slightly different idea of what order these are output in.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

N/A

**Notes for reviewers:**

There was a small adjustment needed to the `source-s3` connector to get non-AWS endpoints to work.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/663)
<!-- Reviewable:end -->
