### PR TITLE
source-{mysql,postgres,sqlserver}: Implement secondary index discovery

### DIFF
--- a/source-mysql/.snapshots/TestSecondaryIndexDiscovery-index_only
+++ b/source-mysql/.snapshots/TestSecondaryIndexDiscovery-index_only
@@ -9,6 +9,10 @@ Binding 0:
       "$defs": {
         "TestSecondaryIndexDiscovery_index_only_g26313": {
           "type": "object",
+          "required": [
+            "k2",
+            "k3"
+          ],
           "$anchor": "TestSecondaryIndexDiscovery_index_only_g26313",
           "properties": {
             "data": {
@@ -105,6 +109,10 @@ Binding 0:
           "$ref": "#TestSecondaryIndexDiscovery_index_only_g26313"
         }
       ]
-    }
+    },
+    "key": [
+      "/k2",
+      "/k3"
+    ]
   }
 

--- a/source-mysql/.snapshots/TestSecondaryIndexDiscovery-index_only
+++ b/source-mysql/.snapshots/TestSecondaryIndexDiscovery-index_only
@@ -1,0 +1,110 @@
+Binding 0:
+{
+    "recommended_name": "secondaryindexdiscovery_index_only_g26313",
+    "resource_config_json": {
+      "namespace": "test",
+      "stream": "SecondaryIndexDiscovery_index_only_g26313"
+    },
+    "document_schema_json": {
+      "$defs": {
+        "TestSecondaryIndexDiscovery_index_only_g26313": {
+          "type": "object",
+          "$anchor": "TestSecondaryIndexDiscovery_index_only_g26313",
+          "properties": {
+            "data": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "k1": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "k2": {
+              "type": "integer"
+            },
+            "k3": {
+              "type": "integer"
+            }
+          }
+        }
+      },
+      "allOf": [
+        {
+          "required": [
+            "_meta"
+          ],
+          "properties": {
+            "_meta": {
+              "type": "object",
+              "required": [
+                "op",
+                "source"
+              ],
+              "properties": {
+                "before": {
+                  "$ref": "#TestSecondaryIndexDiscovery_index_only_g26313",
+                  "description": "Record state immediately before this change was applied.",
+                  "reduce": {
+                    "strategy": "firstWriteWins"
+                  }
+                },
+                "op": {
+                  "enum": [
+                    "c",
+                    "d",
+                    "u"
+                  ],
+                  "description": "Change operation type: 'c' Create/Insert, 'u' Update, 'd' Delete."
+                },
+                "source": {
+                  "$id": "https://github.com/estuary/connectors/source-mysql/mysql-source-info",
+                  "properties": {
+                    "ts_ms": {
+                      "type": "integer",
+                      "description": "Unix timestamp (in millis) at which this event was recorded by the database."
+                    },
+                    "schema": {
+                      "type": "string",
+                      "description": "Database schema (namespace) of the event."
+                    },
+                    "snapshot": {
+                      "type": "boolean",
+                      "description": "Snapshot is true if the record was produced from an initial table backfill and unset if produced from the replication log."
+                    },
+                    "table": {
+                      "type": "string",
+                      "description": "Database table of the event."
+                    },
+                    "cursor": {
+                      "type": "string",
+                      "description": "Cursor value representing the current position in the binlog."
+                    }
+                  },
+                  "additionalProperties": false,
+                  "type": "object",
+                  "required": [
+                    "schema",
+                    "table"
+                  ]
+                }
+              },
+              "reduce": {
+                "strategy": "merge"
+              }
+            }
+          },
+          "reduce": {
+            "strategy": "merge"
+          }
+        },
+        {
+          "$ref": "#TestSecondaryIndexDiscovery_index_only_g26313"
+        }
+      ]
+    }
+  }
+

--- a/source-mysql/.snapshots/TestSecondaryIndexDiscovery-nonunique_index
+++ b/source-mysql/.snapshots/TestSecondaryIndexDiscovery-nonunique_index
@@ -1,0 +1,110 @@
+Binding 0:
+{
+    "recommended_name": "secondaryindexdiscovery_nonunique_index_g22906",
+    "resource_config_json": {
+      "namespace": "test",
+      "stream": "SecondaryIndexDiscovery_nonunique_index_g22906"
+    },
+    "document_schema_json": {
+      "$defs": {
+        "TestSecondaryIndexDiscovery_nonunique_index_g22906": {
+          "type": "object",
+          "$anchor": "TestSecondaryIndexDiscovery_nonunique_index_g22906",
+          "properties": {
+            "data": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "k1": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "k2": {
+              "type": "integer"
+            },
+            "k3": {
+              "type": "integer"
+            }
+          }
+        }
+      },
+      "allOf": [
+        {
+          "required": [
+            "_meta"
+          ],
+          "properties": {
+            "_meta": {
+              "type": "object",
+              "required": [
+                "op",
+                "source"
+              ],
+              "properties": {
+                "before": {
+                  "$ref": "#TestSecondaryIndexDiscovery_nonunique_index_g22906",
+                  "description": "Record state immediately before this change was applied.",
+                  "reduce": {
+                    "strategy": "firstWriteWins"
+                  }
+                },
+                "op": {
+                  "enum": [
+                    "c",
+                    "d",
+                    "u"
+                  ],
+                  "description": "Change operation type: 'c' Create/Insert, 'u' Update, 'd' Delete."
+                },
+                "source": {
+                  "$id": "https://github.com/estuary/connectors/source-mysql/mysql-source-info",
+                  "properties": {
+                    "ts_ms": {
+                      "type": "integer",
+                      "description": "Unix timestamp (in millis) at which this event was recorded by the database."
+                    },
+                    "schema": {
+                      "type": "string",
+                      "description": "Database schema (namespace) of the event."
+                    },
+                    "snapshot": {
+                      "type": "boolean",
+                      "description": "Snapshot is true if the record was produced from an initial table backfill and unset if produced from the replication log."
+                    },
+                    "table": {
+                      "type": "string",
+                      "description": "Database table of the event."
+                    },
+                    "cursor": {
+                      "type": "string",
+                      "description": "Cursor value representing the current position in the binlog."
+                    }
+                  },
+                  "additionalProperties": false,
+                  "type": "object",
+                  "required": [
+                    "schema",
+                    "table"
+                  ]
+                }
+              },
+              "reduce": {
+                "strategy": "merge"
+              }
+            }
+          },
+          "reduce": {
+            "strategy": "merge"
+          }
+        },
+        {
+          "$ref": "#TestSecondaryIndexDiscovery_nonunique_index_g22906"
+        }
+      ]
+    }
+  }
+

--- a/source-mysql/.snapshots/TestSecondaryIndexDiscovery-nothing
+++ b/source-mysql/.snapshots/TestSecondaryIndexDiscovery-nothing
@@ -1,0 +1,110 @@
+Binding 0:
+{
+    "recommended_name": "secondaryindexdiscovery_nothing_g14307",
+    "resource_config_json": {
+      "namespace": "test",
+      "stream": "SecondaryIndexDiscovery_nothing_g14307"
+    },
+    "document_schema_json": {
+      "$defs": {
+        "TestSecondaryIndexDiscovery_nothing_g14307": {
+          "type": "object",
+          "$anchor": "TestSecondaryIndexDiscovery_nothing_g14307",
+          "properties": {
+            "data": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "k1": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "k2": {
+              "type": "integer"
+            },
+            "k3": {
+              "type": "integer"
+            }
+          }
+        }
+      },
+      "allOf": [
+        {
+          "required": [
+            "_meta"
+          ],
+          "properties": {
+            "_meta": {
+              "type": "object",
+              "required": [
+                "op",
+                "source"
+              ],
+              "properties": {
+                "before": {
+                  "$ref": "#TestSecondaryIndexDiscovery_nothing_g14307",
+                  "description": "Record state immediately before this change was applied.",
+                  "reduce": {
+                    "strategy": "firstWriteWins"
+                  }
+                },
+                "op": {
+                  "enum": [
+                    "c",
+                    "d",
+                    "u"
+                  ],
+                  "description": "Change operation type: 'c' Create/Insert, 'u' Update, 'd' Delete."
+                },
+                "source": {
+                  "$id": "https://github.com/estuary/connectors/source-mysql/mysql-source-info",
+                  "properties": {
+                    "ts_ms": {
+                      "type": "integer",
+                      "description": "Unix timestamp (in millis) at which this event was recorded by the database."
+                    },
+                    "schema": {
+                      "type": "string",
+                      "description": "Database schema (namespace) of the event."
+                    },
+                    "snapshot": {
+                      "type": "boolean",
+                      "description": "Snapshot is true if the record was produced from an initial table backfill and unset if produced from the replication log."
+                    },
+                    "table": {
+                      "type": "string",
+                      "description": "Database table of the event."
+                    },
+                    "cursor": {
+                      "type": "string",
+                      "description": "Cursor value representing the current position in the binlog."
+                    }
+                  },
+                  "additionalProperties": false,
+                  "type": "object",
+                  "required": [
+                    "schema",
+                    "table"
+                  ]
+                }
+              },
+              "reduce": {
+                "strategy": "merge"
+              }
+            }
+          },
+          "reduce": {
+            "strategy": "merge"
+          }
+        },
+        {
+          "$ref": "#TestSecondaryIndexDiscovery_nothing_g14307"
+        }
+      ]
+    }
+  }
+

--- a/source-mysql/.snapshots/TestSecondaryIndexDiscovery-nullable_index
+++ b/source-mysql/.snapshots/TestSecondaryIndexDiscovery-nullable_index
@@ -1,0 +1,116 @@
+Binding 0:
+{
+    "recommended_name": "secondaryindexdiscovery_nullable_index_g31990",
+    "resource_config_json": {
+      "namespace": "test",
+      "stream": "SecondaryIndexDiscovery_nullable_index_g31990"
+    },
+    "document_schema_json": {
+      "$defs": {
+        "TestSecondaryIndexDiscovery_nullable_index_g31990": {
+          "type": "object",
+          "$anchor": "TestSecondaryIndexDiscovery_nullable_index_g31990",
+          "properties": {
+            "data": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "k1": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "k2": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "k3": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            }
+          }
+        }
+      },
+      "allOf": [
+        {
+          "required": [
+            "_meta"
+          ],
+          "properties": {
+            "_meta": {
+              "type": "object",
+              "required": [
+                "op",
+                "source"
+              ],
+              "properties": {
+                "before": {
+                  "$ref": "#TestSecondaryIndexDiscovery_nullable_index_g31990",
+                  "description": "Record state immediately before this change was applied.",
+                  "reduce": {
+                    "strategy": "firstWriteWins"
+                  }
+                },
+                "op": {
+                  "enum": [
+                    "c",
+                    "d",
+                    "u"
+                  ],
+                  "description": "Change operation type: 'c' Create/Insert, 'u' Update, 'd' Delete."
+                },
+                "source": {
+                  "$id": "https://github.com/estuary/connectors/source-mysql/mysql-source-info",
+                  "properties": {
+                    "ts_ms": {
+                      "type": "integer",
+                      "description": "Unix timestamp (in millis) at which this event was recorded by the database."
+                    },
+                    "schema": {
+                      "type": "string",
+                      "description": "Database schema (namespace) of the event."
+                    },
+                    "snapshot": {
+                      "type": "boolean",
+                      "description": "Snapshot is true if the record was produced from an initial table backfill and unset if produced from the replication log."
+                    },
+                    "table": {
+                      "type": "string",
+                      "description": "Database table of the event."
+                    },
+                    "cursor": {
+                      "type": "string",
+                      "description": "Cursor value representing the current position in the binlog."
+                    }
+                  },
+                  "additionalProperties": false,
+                  "type": "object",
+                  "required": [
+                    "schema",
+                    "table"
+                  ]
+                }
+              },
+              "reduce": {
+                "strategy": "merge"
+              }
+            }
+          },
+          "reduce": {
+            "strategy": "merge"
+          }
+        },
+        {
+          "$ref": "#TestSecondaryIndexDiscovery_nullable_index_g31990"
+        }
+      ]
+    }
+  }
+

--- a/source-mysql/.snapshots/TestSecondaryIndexDiscovery-pk_and_index
+++ b/source-mysql/.snapshots/TestSecondaryIndexDiscovery-pk_and_index
@@ -1,0 +1,113 @@
+Binding 0:
+{
+    "recommended_name": "secondaryindexdiscovery_pk_and_index_g14228",
+    "resource_config_json": {
+      "namespace": "test",
+      "stream": "SecondaryIndexDiscovery_pk_and_index_g14228"
+    },
+    "document_schema_json": {
+      "$defs": {
+        "TestSecondaryIndexDiscovery_pk_and_index_g14228": {
+          "type": "object",
+          "required": [
+            "k1"
+          ],
+          "$anchor": "TestSecondaryIndexDiscovery_pk_and_index_g14228",
+          "properties": {
+            "data": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "k1": {
+              "type": "integer"
+            },
+            "k2": {
+              "type": "integer"
+            },
+            "k3": {
+              "type": "integer"
+            }
+          }
+        }
+      },
+      "allOf": [
+        {
+          "required": [
+            "_meta"
+          ],
+          "properties": {
+            "_meta": {
+              "type": "object",
+              "required": [
+                "op",
+                "source"
+              ],
+              "properties": {
+                "before": {
+                  "$ref": "#TestSecondaryIndexDiscovery_pk_and_index_g14228",
+                  "description": "Record state immediately before this change was applied.",
+                  "reduce": {
+                    "strategy": "firstWriteWins"
+                  }
+                },
+                "op": {
+                  "enum": [
+                    "c",
+                    "d",
+                    "u"
+                  ],
+                  "description": "Change operation type: 'c' Create/Insert, 'u' Update, 'd' Delete."
+                },
+                "source": {
+                  "$id": "https://github.com/estuary/connectors/source-mysql/mysql-source-info",
+                  "properties": {
+                    "ts_ms": {
+                      "type": "integer",
+                      "description": "Unix timestamp (in millis) at which this event was recorded by the database."
+                    },
+                    "schema": {
+                      "type": "string",
+                      "description": "Database schema (namespace) of the event."
+                    },
+                    "snapshot": {
+                      "type": "boolean",
+                      "description": "Snapshot is true if the record was produced from an initial table backfill and unset if produced from the replication log."
+                    },
+                    "table": {
+                      "type": "string",
+                      "description": "Database table of the event."
+                    },
+                    "cursor": {
+                      "type": "string",
+                      "description": "Cursor value representing the current position in the binlog."
+                    }
+                  },
+                  "additionalProperties": false,
+                  "type": "object",
+                  "required": [
+                    "schema",
+                    "table"
+                  ]
+                }
+              },
+              "reduce": {
+                "strategy": "merge"
+              }
+            }
+          },
+          "reduce": {
+            "strategy": "merge"
+          }
+        },
+        {
+          "$ref": "#TestSecondaryIndexDiscovery_pk_and_index_g14228"
+        }
+      ]
+    },
+    "key": [
+      "/k1"
+    ]
+  }
+

--- a/source-mysql/discovery_test.go
+++ b/source-mysql/discovery_test.go
@@ -8,50 +8,8 @@ import (
 	"testing"
 )
 
-func TestDiscoveryComplex(t *testing.T) {
-	var tb, ctx = postgresTestBackend(t), context.Background()
-
-	const uniqueString = "cheap_oxygenation"
-	var tableName = tb.CreateTable(ctx, t, uniqueString, `(
-		k1             INTEGER NOT NULL,
-		foo            TEXT,
-		real_          REAL NOT NULL,
-		"Bounded Text" VARCHAR(255),
-		k2             TEXT,
-		doc            JSON,
-		"doc/bin"      JSONB NOT NULL,
-		PRIMARY KEY(k2, k1)
-	)`)
-	tb.Query(ctx, t, fmt.Sprintf("COMMENT ON COLUMN %s.foo IS 'This is a text field!';", tableName))
-	tb.Query(ctx, t, fmt.Sprintf("COMMENT ON COLUMN %s.k1 IS 'I think this is a key ?';", tableName))
-
-	tb.CaptureSpec(ctx, t).VerifyDiscover(ctx, t, regexp.MustCompile(regexp.QuoteMeta(uniqueString)))
-}
-
-func TestDiscoveryCapitalization(t *testing.T) {
-	var tb, ctx = postgresTestBackend(t), context.Background()
-	var tablePrefix = strings.TrimPrefix(t.Name(), "Test")
-	var tableA = tablePrefix + "_AaAaA"                  // Name contains capital letters and will be quoted
-	var tableB = tablePrefix + "_BbBbB"                  // Name contains capital letters and will not be quoted
-	var tableC = strings.ToLower(tablePrefix + "_CcCcC") // Name is all lowercase and will be quoted
-
-	var cleanup = func() {
-		tb.Query(ctx, t, fmt.Sprintf(`DROP TABLE IF EXISTS "%s"."%s";`, testSchemaName, tableA))
-		tb.Query(ctx, t, fmt.Sprintf(`DROP TABLE IF EXISTS "%s".%s;`, testSchemaName, tableB))
-		tb.Query(ctx, t, fmt.Sprintf(`DROP TABLE IF EXISTS "%s"."%s";`, testSchemaName, tableC))
-	}
-	cleanup()
-	t.Cleanup(cleanup)
-
-	tb.Query(ctx, t, fmt.Sprintf(`CREATE TABLE "%s"."%s" (id INTEGER PRIMARY KEY, data TEXT);`, testSchemaName, tableA))
-	tb.Query(ctx, t, fmt.Sprintf(`CREATE TABLE "%s".%s (id INTEGER PRIMARY KEY, data TEXT);`, testSchemaName, tableB))
-	tb.Query(ctx, t, fmt.Sprintf(`CREATE TABLE "%s"."%s" (id INTEGER PRIMARY KEY, data TEXT);`, testSchemaName, tableC))
-
-	tb.CaptureSpec(ctx, t).VerifyDiscover(ctx, t, regexp.MustCompile(fmt.Sprintf(`(?i:%s)`, regexp.QuoteMeta(tablePrefix))))
-}
-
 func TestSecondaryIndexDiscovery(t *testing.T) {
-	var tb, ctx = postgresTestBackend(t), context.Background()
+	var tb, ctx = mysqlTestBackend(t), context.Background()
 
 	t.Run("pk_and_index", func(t *testing.T) {
 		var uniqueString = "g14228"

--- a/source-postgres/.snapshots/TestSecondaryIndexDiscovery-index_only
+++ b/source-postgres/.snapshots/TestSecondaryIndexDiscovery-index_only
@@ -1,0 +1,115 @@
+Binding 0:
+{
+    "recommended_name": "secondaryindexdiscovery_index_only_g26313",
+    "resource_config_json": {
+      "namespace": "test",
+      "stream": "secondaryindexdiscovery_index_only_g26313"
+    },
+    "document_schema_json": {
+      "$defs": {
+        "TestSecondaryindexdiscovery_index_only_g26313": {
+          "type": "object",
+          "$anchor": "TestSecondaryindexdiscovery_index_only_g26313",
+          "properties": {
+            "data": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "k1": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "k2": {
+              "type": "integer"
+            },
+            "k3": {
+              "type": "integer"
+            }
+          }
+        }
+      },
+      "allOf": [
+        {
+          "required": [
+            "_meta"
+          ],
+          "properties": {
+            "_meta": {
+              "type": "object",
+              "required": [
+                "op",
+                "source"
+              ],
+              "properties": {
+                "before": {
+                  "$ref": "#TestSecondaryindexdiscovery_index_only_g26313",
+                  "description": "Record state immediately before this change was applied.",
+                  "reduce": {
+                    "strategy": "firstWriteWins"
+                  }
+                },
+                "op": {
+                  "enum": [
+                    "c",
+                    "d",
+                    "u"
+                  ],
+                  "description": "Change operation type: 'c' Create/Insert, 'u' Update, 'd' Delete."
+                },
+                "source": {
+                  "$id": "https://github.com/estuary/connectors/source-postgres/postgres-source",
+                  "properties": {
+                    "ts_ms": {
+                      "type": "integer",
+                      "description": "Unix timestamp (in millis) at which this event was recorded by the database."
+                    },
+                    "schema": {
+                      "type": "string",
+                      "description": "Database schema (namespace) of the event."
+                    },
+                    "snapshot": {
+                      "type": "boolean",
+                      "description": "Snapshot is true if the record was produced from an initial table backfill and unset if produced from the replication log."
+                    },
+                    "table": {
+                      "type": "string",
+                      "description": "Database table of the event."
+                    },
+                    "loc": {
+                      "items": {
+                        "type": "integer"
+                      },
+                      "type": "array",
+                      "maxItems": 3,
+                      "minItems": 3,
+                      "description": "Location of this WAL event as [last Commit.EndLSN; event LSN; current Begin.FinalLSN]. See https://www.postgresql.org/docs/current/protocol-logicalrep-message-formats.html"
+                    }
+                  },
+                  "additionalProperties": false,
+                  "type": "object",
+                  "required": [
+                    "schema",
+                    "table"
+                  ]
+                }
+              },
+              "reduce": {
+                "strategy": "merge"
+              }
+            }
+          },
+          "reduce": {
+            "strategy": "merge"
+          }
+        },
+        {
+          "$ref": "#TestSecondaryindexdiscovery_index_only_g26313"
+        }
+      ]
+    }
+  }
+

--- a/source-postgres/.snapshots/TestSecondaryIndexDiscovery-index_only
+++ b/source-postgres/.snapshots/TestSecondaryIndexDiscovery-index_only
@@ -9,6 +9,10 @@ Binding 0:
       "$defs": {
         "TestSecondaryindexdiscovery_index_only_g26313": {
           "type": "object",
+          "required": [
+            "k2",
+            "k3"
+          ],
           "$anchor": "TestSecondaryindexdiscovery_index_only_g26313",
           "properties": {
             "data": {
@@ -110,6 +114,10 @@ Binding 0:
           "$ref": "#TestSecondaryindexdiscovery_index_only_g26313"
         }
       ]
-    }
+    },
+    "key": [
+      "/k2",
+      "/k3"
+    ]
   }
 

--- a/source-postgres/.snapshots/TestSecondaryIndexDiscovery-nonunique_index
+++ b/source-postgres/.snapshots/TestSecondaryIndexDiscovery-nonunique_index
@@ -1,0 +1,115 @@
+Binding 0:
+{
+    "recommended_name": "secondaryindexdiscovery_nonunique_index_g22906",
+    "resource_config_json": {
+      "namespace": "test",
+      "stream": "secondaryindexdiscovery_nonunique_index_g22906"
+    },
+    "document_schema_json": {
+      "$defs": {
+        "TestSecondaryindexdiscovery_nonunique_index_g22906": {
+          "type": "object",
+          "$anchor": "TestSecondaryindexdiscovery_nonunique_index_g22906",
+          "properties": {
+            "data": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "k1": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "k2": {
+              "type": "integer"
+            },
+            "k3": {
+              "type": "integer"
+            }
+          }
+        }
+      },
+      "allOf": [
+        {
+          "required": [
+            "_meta"
+          ],
+          "properties": {
+            "_meta": {
+              "type": "object",
+              "required": [
+                "op",
+                "source"
+              ],
+              "properties": {
+                "before": {
+                  "$ref": "#TestSecondaryindexdiscovery_nonunique_index_g22906",
+                  "description": "Record state immediately before this change was applied.",
+                  "reduce": {
+                    "strategy": "firstWriteWins"
+                  }
+                },
+                "op": {
+                  "enum": [
+                    "c",
+                    "d",
+                    "u"
+                  ],
+                  "description": "Change operation type: 'c' Create/Insert, 'u' Update, 'd' Delete."
+                },
+                "source": {
+                  "$id": "https://github.com/estuary/connectors/source-postgres/postgres-source",
+                  "properties": {
+                    "ts_ms": {
+                      "type": "integer",
+                      "description": "Unix timestamp (in millis) at which this event was recorded by the database."
+                    },
+                    "schema": {
+                      "type": "string",
+                      "description": "Database schema (namespace) of the event."
+                    },
+                    "snapshot": {
+                      "type": "boolean",
+                      "description": "Snapshot is true if the record was produced from an initial table backfill and unset if produced from the replication log."
+                    },
+                    "table": {
+                      "type": "string",
+                      "description": "Database table of the event."
+                    },
+                    "loc": {
+                      "items": {
+                        "type": "integer"
+                      },
+                      "type": "array",
+                      "maxItems": 3,
+                      "minItems": 3,
+                      "description": "Location of this WAL event as [last Commit.EndLSN; event LSN; current Begin.FinalLSN]. See https://www.postgresql.org/docs/current/protocol-logicalrep-message-formats.html"
+                    }
+                  },
+                  "additionalProperties": false,
+                  "type": "object",
+                  "required": [
+                    "schema",
+                    "table"
+                  ]
+                }
+              },
+              "reduce": {
+                "strategy": "merge"
+              }
+            }
+          },
+          "reduce": {
+            "strategy": "merge"
+          }
+        },
+        {
+          "$ref": "#TestSecondaryindexdiscovery_nonunique_index_g22906"
+        }
+      ]
+    }
+  }
+

--- a/source-postgres/.snapshots/TestSecondaryIndexDiscovery-nothing
+++ b/source-postgres/.snapshots/TestSecondaryIndexDiscovery-nothing
@@ -1,0 +1,115 @@
+Binding 0:
+{
+    "recommended_name": "secondaryindexdiscovery_nothing_g14307",
+    "resource_config_json": {
+      "namespace": "test",
+      "stream": "secondaryindexdiscovery_nothing_g14307"
+    },
+    "document_schema_json": {
+      "$defs": {
+        "TestSecondaryindexdiscovery_nothing_g14307": {
+          "type": "object",
+          "$anchor": "TestSecondaryindexdiscovery_nothing_g14307",
+          "properties": {
+            "data": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "k1": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "k2": {
+              "type": "integer"
+            },
+            "k3": {
+              "type": "integer"
+            }
+          }
+        }
+      },
+      "allOf": [
+        {
+          "required": [
+            "_meta"
+          ],
+          "properties": {
+            "_meta": {
+              "type": "object",
+              "required": [
+                "op",
+                "source"
+              ],
+              "properties": {
+                "before": {
+                  "$ref": "#TestSecondaryindexdiscovery_nothing_g14307",
+                  "description": "Record state immediately before this change was applied.",
+                  "reduce": {
+                    "strategy": "firstWriteWins"
+                  }
+                },
+                "op": {
+                  "enum": [
+                    "c",
+                    "d",
+                    "u"
+                  ],
+                  "description": "Change operation type: 'c' Create/Insert, 'u' Update, 'd' Delete."
+                },
+                "source": {
+                  "$id": "https://github.com/estuary/connectors/source-postgres/postgres-source",
+                  "properties": {
+                    "ts_ms": {
+                      "type": "integer",
+                      "description": "Unix timestamp (in millis) at which this event was recorded by the database."
+                    },
+                    "schema": {
+                      "type": "string",
+                      "description": "Database schema (namespace) of the event."
+                    },
+                    "snapshot": {
+                      "type": "boolean",
+                      "description": "Snapshot is true if the record was produced from an initial table backfill and unset if produced from the replication log."
+                    },
+                    "table": {
+                      "type": "string",
+                      "description": "Database table of the event."
+                    },
+                    "loc": {
+                      "items": {
+                        "type": "integer"
+                      },
+                      "type": "array",
+                      "maxItems": 3,
+                      "minItems": 3,
+                      "description": "Location of this WAL event as [last Commit.EndLSN; event LSN; current Begin.FinalLSN]. See https://www.postgresql.org/docs/current/protocol-logicalrep-message-formats.html"
+                    }
+                  },
+                  "additionalProperties": false,
+                  "type": "object",
+                  "required": [
+                    "schema",
+                    "table"
+                  ]
+                }
+              },
+              "reduce": {
+                "strategy": "merge"
+              }
+            }
+          },
+          "reduce": {
+            "strategy": "merge"
+          }
+        },
+        {
+          "$ref": "#TestSecondaryindexdiscovery_nothing_g14307"
+        }
+      ]
+    }
+  }
+

--- a/source-postgres/.snapshots/TestSecondaryIndexDiscovery-nullable_index
+++ b/source-postgres/.snapshots/TestSecondaryIndexDiscovery-nullable_index
@@ -1,0 +1,121 @@
+Binding 0:
+{
+    "recommended_name": "secondaryindexdiscovery_nullable_index_g31990",
+    "resource_config_json": {
+      "namespace": "test",
+      "stream": "secondaryindexdiscovery_nullable_index_g31990"
+    },
+    "document_schema_json": {
+      "$defs": {
+        "TestSecondaryindexdiscovery_nullable_index_g31990": {
+          "type": "object",
+          "$anchor": "TestSecondaryindexdiscovery_nullable_index_g31990",
+          "properties": {
+            "data": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "k1": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "k2": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "k3": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            }
+          }
+        }
+      },
+      "allOf": [
+        {
+          "required": [
+            "_meta"
+          ],
+          "properties": {
+            "_meta": {
+              "type": "object",
+              "required": [
+                "op",
+                "source"
+              ],
+              "properties": {
+                "before": {
+                  "$ref": "#TestSecondaryindexdiscovery_nullable_index_g31990",
+                  "description": "Record state immediately before this change was applied.",
+                  "reduce": {
+                    "strategy": "firstWriteWins"
+                  }
+                },
+                "op": {
+                  "enum": [
+                    "c",
+                    "d",
+                    "u"
+                  ],
+                  "description": "Change operation type: 'c' Create/Insert, 'u' Update, 'd' Delete."
+                },
+                "source": {
+                  "$id": "https://github.com/estuary/connectors/source-postgres/postgres-source",
+                  "properties": {
+                    "ts_ms": {
+                      "type": "integer",
+                      "description": "Unix timestamp (in millis) at which this event was recorded by the database."
+                    },
+                    "schema": {
+                      "type": "string",
+                      "description": "Database schema (namespace) of the event."
+                    },
+                    "snapshot": {
+                      "type": "boolean",
+                      "description": "Snapshot is true if the record was produced from an initial table backfill and unset if produced from the replication log."
+                    },
+                    "table": {
+                      "type": "string",
+                      "description": "Database table of the event."
+                    },
+                    "loc": {
+                      "items": {
+                        "type": "integer"
+                      },
+                      "type": "array",
+                      "maxItems": 3,
+                      "minItems": 3,
+                      "description": "Location of this WAL event as [last Commit.EndLSN; event LSN; current Begin.FinalLSN]. See https://www.postgresql.org/docs/current/protocol-logicalrep-message-formats.html"
+                    }
+                  },
+                  "additionalProperties": false,
+                  "type": "object",
+                  "required": [
+                    "schema",
+                    "table"
+                  ]
+                }
+              },
+              "reduce": {
+                "strategy": "merge"
+              }
+            }
+          },
+          "reduce": {
+            "strategy": "merge"
+          }
+        },
+        {
+          "$ref": "#TestSecondaryindexdiscovery_nullable_index_g31990"
+        }
+      ]
+    }
+  }
+

--- a/source-postgres/.snapshots/TestSecondaryIndexDiscovery-pk_and_index
+++ b/source-postgres/.snapshots/TestSecondaryIndexDiscovery-pk_and_index
@@ -1,0 +1,118 @@
+Binding 0:
+{
+    "recommended_name": "secondaryindexdiscovery_pk_and_index_g14228",
+    "resource_config_json": {
+      "namespace": "test",
+      "stream": "secondaryindexdiscovery_pk_and_index_g14228"
+    },
+    "document_schema_json": {
+      "$defs": {
+        "TestSecondaryindexdiscovery_pk_and_index_g14228": {
+          "type": "object",
+          "required": [
+            "k1"
+          ],
+          "$anchor": "TestSecondaryindexdiscovery_pk_and_index_g14228",
+          "properties": {
+            "data": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "k1": {
+              "type": "integer"
+            },
+            "k2": {
+              "type": "integer"
+            },
+            "k3": {
+              "type": "integer"
+            }
+          }
+        }
+      },
+      "allOf": [
+        {
+          "required": [
+            "_meta"
+          ],
+          "properties": {
+            "_meta": {
+              "type": "object",
+              "required": [
+                "op",
+                "source"
+              ],
+              "properties": {
+                "before": {
+                  "$ref": "#TestSecondaryindexdiscovery_pk_and_index_g14228",
+                  "description": "Record state immediately before this change was applied.",
+                  "reduce": {
+                    "strategy": "firstWriteWins"
+                  }
+                },
+                "op": {
+                  "enum": [
+                    "c",
+                    "d",
+                    "u"
+                  ],
+                  "description": "Change operation type: 'c' Create/Insert, 'u' Update, 'd' Delete."
+                },
+                "source": {
+                  "$id": "https://github.com/estuary/connectors/source-postgres/postgres-source",
+                  "properties": {
+                    "ts_ms": {
+                      "type": "integer",
+                      "description": "Unix timestamp (in millis) at which this event was recorded by the database."
+                    },
+                    "schema": {
+                      "type": "string",
+                      "description": "Database schema (namespace) of the event."
+                    },
+                    "snapshot": {
+                      "type": "boolean",
+                      "description": "Snapshot is true if the record was produced from an initial table backfill and unset if produced from the replication log."
+                    },
+                    "table": {
+                      "type": "string",
+                      "description": "Database table of the event."
+                    },
+                    "loc": {
+                      "items": {
+                        "type": "integer"
+                      },
+                      "type": "array",
+                      "maxItems": 3,
+                      "minItems": 3,
+                      "description": "Location of this WAL event as [last Commit.EndLSN; event LSN; current Begin.FinalLSN]. See https://www.postgresql.org/docs/current/protocol-logicalrep-message-formats.html"
+                    }
+                  },
+                  "additionalProperties": false,
+                  "type": "object",
+                  "required": [
+                    "schema",
+                    "table"
+                  ]
+                }
+              },
+              "reduce": {
+                "strategy": "merge"
+              }
+            }
+          },
+          "reduce": {
+            "strategy": "merge"
+          }
+        },
+        {
+          "$ref": "#TestSecondaryindexdiscovery_pk_and_index_g14228"
+        }
+      ]
+    },
+    "key": [
+      "/k1"
+    ]
+  }
+

--- a/source-postgres/discovery.go
+++ b/source-postgres/discovery.go
@@ -26,6 +26,10 @@ func (db *postgresDatabase) DiscoverTables(ctx context.Context) (map[string]*sql
 	if err != nil {
 		return nil, fmt.Errorf("unable to list database primary keys: %w", err)
 	}
+	secondaryIndexes, err := getSecondaryIndexes(ctx, db.conn)
+	if err != nil {
+		return nil, fmt.Errorf("unable to list database secondary indexes: %w", err)
+	}
 
 	// Column descriptions just add a bit of user-friendliness. They're so unimportant
 	// that failure to list them shouldn't even be a fatal error.
@@ -68,6 +72,7 @@ func (db *postgresDatabase) DiscoverTables(ctx context.Context) (map[string]*sql
 			tableMap[streamID] = info
 		}
 	}
+
 	for streamID, key := range primaryKeys {
 		// The `getColumns()` query implements the "exclude system schemas" logic,
 		// so here we ignore primary key information for tables we don't care about.
@@ -75,11 +80,48 @@ func (db *postgresDatabase) DiscoverTables(ctx context.Context) (map[string]*sql
 		if !ok {
 			continue
 		}
-		logrus.WithFields(logrus.Fields{"table": streamID, "key": key}).Trace("queried primary key")
+		logrus.WithFields(logrus.Fields{
+			"table": streamID,
+			"key":   key,
+		}).Trace("queried primary key")
 		info.PrimaryKey = key
 		tableMap[streamID] = info
 	}
+
+	// For tables which have no primary key but have a valid secondary index,
+	// fill in that secondary index as the 'primary key' for our purposes.
+	for streamID, indexColumns := range secondaryIndexes {
+		var info, ok = tableMap[streamID]
+		if !ok || info.PrimaryKey != nil {
+			continue
+		}
+		for _, columns := range indexColumns {
+			// Test that for each column the value is non-nullable
+			if columnsNonNullable(info.Columns, columns) {
+				logrus.WithFields(logrus.Fields{
+					"table": streamID,
+					"index": columns,
+				}).Trace("using unique secondary index as primary key")
+				info.PrimaryKey = columns
+				break
+			} else {
+				logrus.WithFields(logrus.Fields{
+					"table": streamID,
+					"index": columns,
+				}).Trace("cannot use secondary index because some of its columns are nullable")
+			}
+		}
+	}
 	return tableMap, nil
+}
+
+func columnsNonNullable(columnsInfo map[string]sqlcapture.ColumnInfo, columnNames []string) bool {
+	for _, columnName := range columnNames {
+		if columnsInfo[columnName].IsNullable {
+			return false
+		}
+	}
+	return true
 }
 
 // TranslateDBToJSONType returns JSON schema information about the provided database column type.
@@ -387,6 +429,54 @@ func getPrimaryKeys(ctx context.Context, conn *pgx.Conn) (map[string][]string, e
 			return nil
 		})
 	return keys, err
+}
+
+const queryDiscoverSecondaryIndices = `
+SELECT r.table_schema, r.table_name, r.index_name, (r.index_keys).n, r.column_name
+FROM (
+  SELECT tn.nspname AS table_schema,
+         tc.relname AS table_name,
+	     ic.relname AS index_name,
+	     information_schema._pg_expandarray(ix.indkey) AS index_keys,
+		 a.attnum AS column_number,
+		 a.attname AS column_name
+  FROM pg_catalog.pg_index ix
+       JOIN pg_catalog.pg_class ic ON (ic.oid = ix.indexrelid)
+	   JOIN pg_catalog.pg_class tc ON (tc.oid = ix.indrelid)
+	   JOIN pg_catalog.pg_namespace tn ON (tn.oid = tc.relnamespace)
+	   JOIN pg_catalog.pg_attribute a ON (a.attrelid = tc.oid)
+  WHERE ix.indisunique AND ix.indexprs IS NULL AND tc.relkind = 'r'
+    AND NOT ix.indisprimary
+  ORDER BY tc.relname, ic.relname
+) r
+WHERE r.column_number = (r.index_keys).x
+ORDER BY r.table_schema, r.table_name, r.index_name, (r.index_keys).n
+`
+
+func getSecondaryIndexes(ctx context.Context, conn *pgx.Conn) (map[string]map[string][]string, error) {
+	logrus.Debug("listing secondary indexes")
+
+	// Run the 'list secondary indexes' query and aggregate results into
+	// a `map[StreamID]map[IndexName][]ColumnName`
+	var streamIndexColumns = make(map[string]map[string][]string)
+	var tableSchema, tableName, indexName, columnName string
+	var keySequence int
+	var _, err = conn.QueryFunc(ctx, queryDiscoverSecondaryIndices, nil,
+		[]interface{}{&tableSchema, &tableName, &indexName, &keySequence, &columnName},
+		func(r pgx.QueryFuncRow) error {
+			var streamID = sqlcapture.JoinStreamID(tableSchema, tableName)
+			var indexColumns = streamIndexColumns[streamID]
+			if indexColumns == nil {
+				indexColumns = make(map[string][]string)
+				streamIndexColumns[streamID] = indexColumns
+			}
+			indexColumns[indexName] = append(indexColumns[indexName], columnName)
+			if len(indexColumns[indexName]) != keySequence {
+				return fmt.Errorf("internal error: secondary index key ordering failure: index %q on stream %q: column %q appears out of order", indexName, streamID, columnName)
+			}
+			return nil
+		})
+	return streamIndexColumns, err
 }
 
 const queryColumnDescriptions = `

--- a/source-sqlserver/.snapshots/TestSecondaryIndexDiscovery-index_only
+++ b/source-sqlserver/.snapshots/TestSecondaryIndexDiscovery-index_only
@@ -9,6 +9,10 @@ Binding 0:
       "$defs": {
         "DboTest_SecondaryIndexDiscovery_index_only_g26313": {
           "type": "object",
+          "required": [
+            "k2",
+            "k3"
+          ],
           "$anchor": "DboTest_SecondaryIndexDiscovery_index_only_g26313",
           "properties": {
             "data": {
@@ -112,6 +116,10 @@ Binding 0:
           "$ref": "#DboTest_SecondaryIndexDiscovery_index_only_g26313"
         }
       ]
-    }
+    },
+    "key": [
+      "/k2",
+      "/k3"
+    ]
   }
 

--- a/source-sqlserver/.snapshots/TestSecondaryIndexDiscovery-index_only
+++ b/source-sqlserver/.snapshots/TestSecondaryIndexDiscovery-index_only
@@ -1,0 +1,117 @@
+Binding 0:
+{
+    "recommended_name": "test_secondaryindexdiscovery_index_only_g26313",
+    "resource_config_json": {
+      "namespace": "dbo",
+      "stream": "test_SecondaryIndexDiscovery_index_only_g26313"
+    },
+    "document_schema_json": {
+      "$defs": {
+        "DboTest_SecondaryIndexDiscovery_index_only_g26313": {
+          "type": "object",
+          "$anchor": "DboTest_SecondaryIndexDiscovery_index_only_g26313",
+          "properties": {
+            "data": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "k1": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "k2": {
+              "type": "integer"
+            },
+            "k3": {
+              "type": "integer"
+            }
+          }
+        }
+      },
+      "allOf": [
+        {
+          "required": [
+            "_meta"
+          ],
+          "properties": {
+            "_meta": {
+              "type": "object",
+              "required": [
+                "op",
+                "source"
+              ],
+              "properties": {
+                "before": {
+                  "$ref": "#DboTest_SecondaryIndexDiscovery_index_only_g26313",
+                  "description": "Record state immediately before this change was applied.",
+                  "reduce": {
+                    "strategy": "firstWriteWins"
+                  }
+                },
+                "op": {
+                  "enum": [
+                    "c",
+                    "d",
+                    "u"
+                  ],
+                  "description": "Change operation type: 'c' Create/Insert, 'u' Update, 'd' Delete."
+                },
+                "source": {
+                  "$id": "https://github.com/estuary/connectors/source-sqlserver/sqlserver-source-info",
+                  "properties": {
+                    "ts_ms": {
+                      "type": "integer",
+                      "description": "Unix timestamp (in millis) at which this event was recorded by the database."
+                    },
+                    "schema": {
+                      "type": "string",
+                      "description": "Database schema (namespace) of the event."
+                    },
+                    "snapshot": {
+                      "type": "boolean",
+                      "description": "Snapshot is true if the record was produced from an initial table backfill and unset if produced from the replication log."
+                    },
+                    "table": {
+                      "type": "string",
+                      "description": "Database table of the event."
+                    },
+                    "lsn": {
+                      "type": "string",
+                      "contentEncoding": "base64",
+                      "description": "The LSN at which a CDC event occurred. Only set for CDC events"
+                    },
+                    "seqval": {
+                      "description": "Sequence value used to order changes to a row within a transaction. Only set for CDC events"
+                    },
+                    "updateMask": {
+                      "description": "A bit mask with a bit corresponding to each captured column identified for the capture instance. Only set for CDC events"
+                    }
+                  },
+                  "additionalProperties": false,
+                  "type": "object",
+                  "required": [
+                    "schema",
+                    "table"
+                  ]
+                }
+              },
+              "reduce": {
+                "strategy": "merge"
+              }
+            }
+          },
+          "reduce": {
+            "strategy": "merge"
+          }
+        },
+        {
+          "$ref": "#DboTest_SecondaryIndexDiscovery_index_only_g26313"
+        }
+      ]
+    }
+  }
+

--- a/source-sqlserver/.snapshots/TestSecondaryIndexDiscovery-nonunique_index
+++ b/source-sqlserver/.snapshots/TestSecondaryIndexDiscovery-nonunique_index
@@ -1,0 +1,117 @@
+Binding 0:
+{
+    "recommended_name": "test_secondaryindexdiscovery_nonunique_index_g22906",
+    "resource_config_json": {
+      "namespace": "dbo",
+      "stream": "test_SecondaryIndexDiscovery_nonunique_index_g22906"
+    },
+    "document_schema_json": {
+      "$defs": {
+        "DboTest_SecondaryIndexDiscovery_nonunique_index_g22906": {
+          "type": "object",
+          "$anchor": "DboTest_SecondaryIndexDiscovery_nonunique_index_g22906",
+          "properties": {
+            "data": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "k1": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "k2": {
+              "type": "integer"
+            },
+            "k3": {
+              "type": "integer"
+            }
+          }
+        }
+      },
+      "allOf": [
+        {
+          "required": [
+            "_meta"
+          ],
+          "properties": {
+            "_meta": {
+              "type": "object",
+              "required": [
+                "op",
+                "source"
+              ],
+              "properties": {
+                "before": {
+                  "$ref": "#DboTest_SecondaryIndexDiscovery_nonunique_index_g22906",
+                  "description": "Record state immediately before this change was applied.",
+                  "reduce": {
+                    "strategy": "firstWriteWins"
+                  }
+                },
+                "op": {
+                  "enum": [
+                    "c",
+                    "d",
+                    "u"
+                  ],
+                  "description": "Change operation type: 'c' Create/Insert, 'u' Update, 'd' Delete."
+                },
+                "source": {
+                  "$id": "https://github.com/estuary/connectors/source-sqlserver/sqlserver-source-info",
+                  "properties": {
+                    "ts_ms": {
+                      "type": "integer",
+                      "description": "Unix timestamp (in millis) at which this event was recorded by the database."
+                    },
+                    "schema": {
+                      "type": "string",
+                      "description": "Database schema (namespace) of the event."
+                    },
+                    "snapshot": {
+                      "type": "boolean",
+                      "description": "Snapshot is true if the record was produced from an initial table backfill and unset if produced from the replication log."
+                    },
+                    "table": {
+                      "type": "string",
+                      "description": "Database table of the event."
+                    },
+                    "lsn": {
+                      "type": "string",
+                      "contentEncoding": "base64",
+                      "description": "The LSN at which a CDC event occurred. Only set for CDC events"
+                    },
+                    "seqval": {
+                      "description": "Sequence value used to order changes to a row within a transaction. Only set for CDC events"
+                    },
+                    "updateMask": {
+                      "description": "A bit mask with a bit corresponding to each captured column identified for the capture instance. Only set for CDC events"
+                    }
+                  },
+                  "additionalProperties": false,
+                  "type": "object",
+                  "required": [
+                    "schema",
+                    "table"
+                  ]
+                }
+              },
+              "reduce": {
+                "strategy": "merge"
+              }
+            }
+          },
+          "reduce": {
+            "strategy": "merge"
+          }
+        },
+        {
+          "$ref": "#DboTest_SecondaryIndexDiscovery_nonunique_index_g22906"
+        }
+      ]
+    }
+  }
+

--- a/source-sqlserver/.snapshots/TestSecondaryIndexDiscovery-nothing
+++ b/source-sqlserver/.snapshots/TestSecondaryIndexDiscovery-nothing
@@ -1,0 +1,117 @@
+Binding 0:
+{
+    "recommended_name": "test_secondaryindexdiscovery_nothing_g14307",
+    "resource_config_json": {
+      "namespace": "dbo",
+      "stream": "test_SecondaryIndexDiscovery_nothing_g14307"
+    },
+    "document_schema_json": {
+      "$defs": {
+        "DboTest_SecondaryIndexDiscovery_nothing_g14307": {
+          "type": "object",
+          "$anchor": "DboTest_SecondaryIndexDiscovery_nothing_g14307",
+          "properties": {
+            "data": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "k1": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "k2": {
+              "type": "integer"
+            },
+            "k3": {
+              "type": "integer"
+            }
+          }
+        }
+      },
+      "allOf": [
+        {
+          "required": [
+            "_meta"
+          ],
+          "properties": {
+            "_meta": {
+              "type": "object",
+              "required": [
+                "op",
+                "source"
+              ],
+              "properties": {
+                "before": {
+                  "$ref": "#DboTest_SecondaryIndexDiscovery_nothing_g14307",
+                  "description": "Record state immediately before this change was applied.",
+                  "reduce": {
+                    "strategy": "firstWriteWins"
+                  }
+                },
+                "op": {
+                  "enum": [
+                    "c",
+                    "d",
+                    "u"
+                  ],
+                  "description": "Change operation type: 'c' Create/Insert, 'u' Update, 'd' Delete."
+                },
+                "source": {
+                  "$id": "https://github.com/estuary/connectors/source-sqlserver/sqlserver-source-info",
+                  "properties": {
+                    "ts_ms": {
+                      "type": "integer",
+                      "description": "Unix timestamp (in millis) at which this event was recorded by the database."
+                    },
+                    "schema": {
+                      "type": "string",
+                      "description": "Database schema (namespace) of the event."
+                    },
+                    "snapshot": {
+                      "type": "boolean",
+                      "description": "Snapshot is true if the record was produced from an initial table backfill and unset if produced from the replication log."
+                    },
+                    "table": {
+                      "type": "string",
+                      "description": "Database table of the event."
+                    },
+                    "lsn": {
+                      "type": "string",
+                      "contentEncoding": "base64",
+                      "description": "The LSN at which a CDC event occurred. Only set for CDC events"
+                    },
+                    "seqval": {
+                      "description": "Sequence value used to order changes to a row within a transaction. Only set for CDC events"
+                    },
+                    "updateMask": {
+                      "description": "A bit mask with a bit corresponding to each captured column identified for the capture instance. Only set for CDC events"
+                    }
+                  },
+                  "additionalProperties": false,
+                  "type": "object",
+                  "required": [
+                    "schema",
+                    "table"
+                  ]
+                }
+              },
+              "reduce": {
+                "strategy": "merge"
+              }
+            }
+          },
+          "reduce": {
+            "strategy": "merge"
+          }
+        },
+        {
+          "$ref": "#DboTest_SecondaryIndexDiscovery_nothing_g14307"
+        }
+      ]
+    }
+  }
+

--- a/source-sqlserver/.snapshots/TestSecondaryIndexDiscovery-nullable_index
+++ b/source-sqlserver/.snapshots/TestSecondaryIndexDiscovery-nullable_index
@@ -1,0 +1,123 @@
+Binding 0:
+{
+    "recommended_name": "test_secondaryindexdiscovery_nullable_index_g31990",
+    "resource_config_json": {
+      "namespace": "dbo",
+      "stream": "test_SecondaryIndexDiscovery_nullable_index_g31990"
+    },
+    "document_schema_json": {
+      "$defs": {
+        "DboTest_SecondaryIndexDiscovery_nullable_index_g31990": {
+          "type": "object",
+          "$anchor": "DboTest_SecondaryIndexDiscovery_nullable_index_g31990",
+          "properties": {
+            "data": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "k1": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "k2": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "k3": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            }
+          }
+        }
+      },
+      "allOf": [
+        {
+          "required": [
+            "_meta"
+          ],
+          "properties": {
+            "_meta": {
+              "type": "object",
+              "required": [
+                "op",
+                "source"
+              ],
+              "properties": {
+                "before": {
+                  "$ref": "#DboTest_SecondaryIndexDiscovery_nullable_index_g31990",
+                  "description": "Record state immediately before this change was applied.",
+                  "reduce": {
+                    "strategy": "firstWriteWins"
+                  }
+                },
+                "op": {
+                  "enum": [
+                    "c",
+                    "d",
+                    "u"
+                  ],
+                  "description": "Change operation type: 'c' Create/Insert, 'u' Update, 'd' Delete."
+                },
+                "source": {
+                  "$id": "https://github.com/estuary/connectors/source-sqlserver/sqlserver-source-info",
+                  "properties": {
+                    "ts_ms": {
+                      "type": "integer",
+                      "description": "Unix timestamp (in millis) at which this event was recorded by the database."
+                    },
+                    "schema": {
+                      "type": "string",
+                      "description": "Database schema (namespace) of the event."
+                    },
+                    "snapshot": {
+                      "type": "boolean",
+                      "description": "Snapshot is true if the record was produced from an initial table backfill and unset if produced from the replication log."
+                    },
+                    "table": {
+                      "type": "string",
+                      "description": "Database table of the event."
+                    },
+                    "lsn": {
+                      "type": "string",
+                      "contentEncoding": "base64",
+                      "description": "The LSN at which a CDC event occurred. Only set for CDC events"
+                    },
+                    "seqval": {
+                      "description": "Sequence value used to order changes to a row within a transaction. Only set for CDC events"
+                    },
+                    "updateMask": {
+                      "description": "A bit mask with a bit corresponding to each captured column identified for the capture instance. Only set for CDC events"
+                    }
+                  },
+                  "additionalProperties": false,
+                  "type": "object",
+                  "required": [
+                    "schema",
+                    "table"
+                  ]
+                }
+              },
+              "reduce": {
+                "strategy": "merge"
+              }
+            }
+          },
+          "reduce": {
+            "strategy": "merge"
+          }
+        },
+        {
+          "$ref": "#DboTest_SecondaryIndexDiscovery_nullable_index_g31990"
+        }
+      ]
+    }
+  }
+

--- a/source-sqlserver/.snapshots/TestSecondaryIndexDiscovery-pk_and_index
+++ b/source-sqlserver/.snapshots/TestSecondaryIndexDiscovery-pk_and_index
@@ -1,0 +1,120 @@
+Binding 0:
+{
+    "recommended_name": "test_secondaryindexdiscovery_pk_and_index_g14228",
+    "resource_config_json": {
+      "namespace": "dbo",
+      "stream": "test_SecondaryIndexDiscovery_pk_and_index_g14228"
+    },
+    "document_schema_json": {
+      "$defs": {
+        "DboTest_SecondaryIndexDiscovery_pk_and_index_g14228": {
+          "type": "object",
+          "required": [
+            "k1"
+          ],
+          "$anchor": "DboTest_SecondaryIndexDiscovery_pk_and_index_g14228",
+          "properties": {
+            "data": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "k1": {
+              "type": "integer"
+            },
+            "k2": {
+              "type": "integer"
+            },
+            "k3": {
+              "type": "integer"
+            }
+          }
+        }
+      },
+      "allOf": [
+        {
+          "required": [
+            "_meta"
+          ],
+          "properties": {
+            "_meta": {
+              "type": "object",
+              "required": [
+                "op",
+                "source"
+              ],
+              "properties": {
+                "before": {
+                  "$ref": "#DboTest_SecondaryIndexDiscovery_pk_and_index_g14228",
+                  "description": "Record state immediately before this change was applied.",
+                  "reduce": {
+                    "strategy": "firstWriteWins"
+                  }
+                },
+                "op": {
+                  "enum": [
+                    "c",
+                    "d",
+                    "u"
+                  ],
+                  "description": "Change operation type: 'c' Create/Insert, 'u' Update, 'd' Delete."
+                },
+                "source": {
+                  "$id": "https://github.com/estuary/connectors/source-sqlserver/sqlserver-source-info",
+                  "properties": {
+                    "ts_ms": {
+                      "type": "integer",
+                      "description": "Unix timestamp (in millis) at which this event was recorded by the database."
+                    },
+                    "schema": {
+                      "type": "string",
+                      "description": "Database schema (namespace) of the event."
+                    },
+                    "snapshot": {
+                      "type": "boolean",
+                      "description": "Snapshot is true if the record was produced from an initial table backfill and unset if produced from the replication log."
+                    },
+                    "table": {
+                      "type": "string",
+                      "description": "Database table of the event."
+                    },
+                    "lsn": {
+                      "type": "string",
+                      "contentEncoding": "base64",
+                      "description": "The LSN at which a CDC event occurred. Only set for CDC events"
+                    },
+                    "seqval": {
+                      "description": "Sequence value used to order changes to a row within a transaction. Only set for CDC events"
+                    },
+                    "updateMask": {
+                      "description": "A bit mask with a bit corresponding to each captured column identified for the capture instance. Only set for CDC events"
+                    }
+                  },
+                  "additionalProperties": false,
+                  "type": "object",
+                  "required": [
+                    "schema",
+                    "table"
+                  ]
+                }
+              },
+              "reduce": {
+                "strategy": "merge"
+              }
+            }
+          },
+          "reduce": {
+            "strategy": "merge"
+          }
+        },
+        {
+          "$ref": "#DboTest_SecondaryIndexDiscovery_pk_and_index_g14228"
+        }
+      ]
+    },
+    "key": [
+      "/k1"
+    ]
+  }
+

--- a/source-sqlserver/discovery_test.go
+++ b/source-sqlserver/discovery_test.go
@@ -8,50 +8,8 @@ import (
 	"testing"
 )
 
-func TestDiscoveryComplex(t *testing.T) {
-	var tb, ctx = postgresTestBackend(t), context.Background()
-
-	const uniqueString = "cheap_oxygenation"
-	var tableName = tb.CreateTable(ctx, t, uniqueString, `(
-		k1             INTEGER NOT NULL,
-		foo            TEXT,
-		real_          REAL NOT NULL,
-		"Bounded Text" VARCHAR(255),
-		k2             TEXT,
-		doc            JSON,
-		"doc/bin"      JSONB NOT NULL,
-		PRIMARY KEY(k2, k1)
-	)`)
-	tb.Query(ctx, t, fmt.Sprintf("COMMENT ON COLUMN %s.foo IS 'This is a text field!';", tableName))
-	tb.Query(ctx, t, fmt.Sprintf("COMMENT ON COLUMN %s.k1 IS 'I think this is a key ?';", tableName))
-
-	tb.CaptureSpec(ctx, t).VerifyDiscover(ctx, t, regexp.MustCompile(regexp.QuoteMeta(uniqueString)))
-}
-
-func TestDiscoveryCapitalization(t *testing.T) {
-	var tb, ctx = postgresTestBackend(t), context.Background()
-	var tablePrefix = strings.TrimPrefix(t.Name(), "Test")
-	var tableA = tablePrefix + "_AaAaA"                  // Name contains capital letters and will be quoted
-	var tableB = tablePrefix + "_BbBbB"                  // Name contains capital letters and will not be quoted
-	var tableC = strings.ToLower(tablePrefix + "_CcCcC") // Name is all lowercase and will be quoted
-
-	var cleanup = func() {
-		tb.Query(ctx, t, fmt.Sprintf(`DROP TABLE IF EXISTS "%s"."%s";`, testSchemaName, tableA))
-		tb.Query(ctx, t, fmt.Sprintf(`DROP TABLE IF EXISTS "%s".%s;`, testSchemaName, tableB))
-		tb.Query(ctx, t, fmt.Sprintf(`DROP TABLE IF EXISTS "%s"."%s";`, testSchemaName, tableC))
-	}
-	cleanup()
-	t.Cleanup(cleanup)
-
-	tb.Query(ctx, t, fmt.Sprintf(`CREATE TABLE "%s"."%s" (id INTEGER PRIMARY KEY, data TEXT);`, testSchemaName, tableA))
-	tb.Query(ctx, t, fmt.Sprintf(`CREATE TABLE "%s".%s (id INTEGER PRIMARY KEY, data TEXT);`, testSchemaName, tableB))
-	tb.Query(ctx, t, fmt.Sprintf(`CREATE TABLE "%s"."%s" (id INTEGER PRIMARY KEY, data TEXT);`, testSchemaName, tableC))
-
-	tb.CaptureSpec(ctx, t).VerifyDiscover(ctx, t, regexp.MustCompile(fmt.Sprintf(`(?i:%s)`, regexp.QuoteMeta(tablePrefix))))
-}
-
 func TestSecondaryIndexDiscovery(t *testing.T) {
-	var tb, ctx = postgresTestBackend(t), context.Background()
+	var tb, ctx = sqlserverTestBackend(t), context.Background()
 
 	t.Run("pk_and_index", func(t *testing.T) {
 		var uniqueString = "g14228"

--- a/source-sqlserver/main_test.go
+++ b/source-sqlserver/main_test.go
@@ -203,7 +203,7 @@ func (tb *testBackend) Delete(ctx context.Context, t testing.TB, table string, w
 
 func (tb *testBackend) Query(ctx context.Context, t testing.TB, query string, args ...any) {
 	t.Helper()
-	var _, err = tb.control.ExecContext(ctx, query)
+	var _, err = tb.control.ExecContext(ctx, query, args...)
 	require.NoError(t, err)
 }
 


### PR DESCRIPTION
**Description:**

This PR extends the stream discovery logic for SQL database captures to autoselect a secondary index as the collection/backfill key under the specific circumstances where the table has no primary key, but it _does_ have a unique index made up of non-nullable columns.

This is useful because it means that in some setups things will "just work" where previously they required manual intervention, and it may be an easier request in some cases to ask the user to create another index on a table as opposed to defining a primary key.

**Workflow steps:**

Create a table which has no primary key (but has some `NOT NULL` columns), and define a secondary index on those columns using `CREATE UNIQUE INDEX`. Discovery will now identify the existence of a suitable index and use that as the suggested collection key.

Because of the way this was written the preexisting primary-key discovery logic which is fairly well battle-tested at this point will take precedence and the new secondary index discovery results will only be used if the primary key is unset.

**Documentation links affected:**

I'm not certain what the existing docs for the SQL captures say about primary keys but we might want to revisit that. Or we might wait, since the next step is going to be supporting backfills from unkeyed tables at which point we'll have to rewrite that portion of the docs anyway for completeness.

**Notes for reviewers:**

I think overall this is a decent change, but there are a few things I went back and forth on, so I might as well call them out here:
1. In theory we _could_ remove the primary-key discovery logic entirely and just rely on the unique index discovery, since basically every SQL database implements primary keys as a nice facade over unique indexes and non-nullable constraints in the first place. I have chosen not to do that here because the primary-key discovery queries are pretty well tested at this point and leaving that in place gives me confidence this change won't break anything important, and also because if we removed it we'd need some _other_ mechanism to make sure we pick the "official" primary key if one exists.
2. I'm not super happy with the `map[string]map[string][]string` manipulation that actually processes the database query response, but I took a few stabs at writing this more cleanly and it feels like this data munging is still _just short_ of the point where defining structures and methods and whatnot is worth doing. I've tried to make it fairly clear what's happening with variable naming and comments instead.
3. AFAIK the long-term plan is to allow unique indexes involving nullable columns _so long as they aren't actually null in practice_. However the extra internal safeguards to make sure nulls never actually occur in the keys are a bit involved and have some implications on other backfill behavior, so I figured we should start with the thing that can be guaranteed to work for now, implement the safety checks as part of other work on backfills that I'm about to do, and then remove the ~10 lines of discovery logic that filters out indexes with nullable columns after that.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/665)
<!-- Reviewable:end -->
