### PR TITLE
source-postgres: Reword "unknown column type" discovery warning

### DIFF
--- a/source-postgres/.snapshots/TestUserTypes-Enum-Discovery
+++ b/source-postgres/.snapshots/TestUserTypes-Enum-Discovery
@@ -18,7 +18,7 @@ Binding 0:
               "type": "integer"
             },
             "value": {
-              "description": "ERROR: could not translate column type \"userenum\" to JSON schema: unhandled PostgreSQL type \"userenum\""
+              "description": "using catch-all schema: unable to translate PostgreSQL type \"userenum\" into JSON schema"
             }
           }
         }

--- a/source-postgres/.snapshots/TestUserTypes-Tuple-Discovery
+++ b/source-postgres/.snapshots/TestUserTypes-Tuple-Discovery
@@ -18,7 +18,7 @@ Binding 0:
               "type": "integer"
             },
             "value": {
-              "description": "ERROR: could not translate column type \"usertuple\" to JSON schema: unhandled PostgreSQL type \"usertuple\""
+              "description": "using catch-all schema: unable to translate PostgreSQL type \"usertuple\" into JSON schema"
             }
           }
         }

--- a/source-postgres/discovery.go
+++ b/source-postgres/discovery.go
@@ -129,7 +129,7 @@ func (db *postgresDatabase) TranslateDBToJSONType(column sqlcapture.ColumnInfo) 
 	// If the column type looks like `_foo` then it's an array of elements of type `foo`.
 	var columnType, ok = column.DataType.(string)
 	if !ok {
-		return nil, fmt.Errorf("unhandled PostgreSQL type %q", columnType)
+		return nil, fmt.Errorf("unable to translate PostgreSQL type %q into JSON schema", columnType)
 	}
 	var arrayColumn = false
 	if strings.HasPrefix(columnType, "_") {
@@ -140,7 +140,7 @@ func (db *postgresDatabase) TranslateDBToJSONType(column sqlcapture.ColumnInfo) 
 	// Translate the basic value/element type into a JSON Schema type
 	colSchema, ok := postgresTypeToJSON[columnType]
 	if !ok {
-		return nil, fmt.Errorf("unhandled PostgreSQL type %q", columnType)
+		return nil, fmt.Errorf("unable to translate PostgreSQL type %q into JSON schema", columnType)
 	}
 	colSchema.nullable = column.IsNullable
 	var jsonType = colSchema.toType()

--- a/sqlcapture/discovery.go
+++ b/sqlcapture/discovery.go
@@ -57,7 +57,7 @@ func DiscoverCatalog(ctx context.Context, db Database) ([]*pc.Response_Discovere
 				// Logging an error from the connector is nice, but can be swallowed by `flowctl-go`.
 				// Putting an error in the generated schema is ugly, but makes the failure visible.
 				properties[column.Name] = &jsonschema.Schema{
-					Description: fmt.Sprintf("ERROR: could not translate column type %q to JSON schema: %v", column.DataType, err),
+					Description: fmt.Sprintf("using catch-all schema: %v", err),
 				}
 			} else {
 				properties[column.Name] = jsonType


### PR DESCRIPTION
**Description:**

Rewords the "unknown column type" discovery failure messaging. Previously this message was a very scary `"ERROR: could not ..."` message which could mislead users into thinking the situation was a lot worse than it really is. After this change the message will look something like:

    "columnName": {
        "description": "using catch-all schema: unable to translate PostgreSQL type \"userenum\" into JSON schema"
    }

Which should hopefully give them the (correct) impression that they can just continue onwards and things will work so long as they don't need a more precise schema for that column.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/670)
<!-- Reviewable:end -->
