### PR TITLE
sqlcapture: enhanced handling for unusual identifiers

### DIFF
--- a/source-mysql/.snapshots/TestAlterTable_AddColumnBasic-at_middle
+++ b/source-mysql/.snapshots/TestAlterTable_AddColumnBasic-at_middle
@@ -1,10 +1,10 @@
 # ================================
 # Collection "acmeCo/test/test.altertable_addcolumnbasic_aaa": 2 Documents
 # ================================
-{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"AlterTable_AddColumnBasic_aaa"}},"data":"mmm","extra_end":"extra_end_11","extra_middle":"extra_middle_1","extra_start":"extra_start_11","id":11}
-{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"AlterTable_AddColumnBasic_aaa"}},"data":"nnn","extra_end":"extra_end_12","extra_middle":"extra_middle_2","extra_start":"extra_start_12","id":12}
+{"Extra_MIDDLE":"extra_middle_1","_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"AlterTable_AddColumnBasic_aaa"}},"data":"mmm","extra_end":"extra_end_11","extra_start":"extra_start_11","id":11}
+{"Extra_MIDDLE":"extra_middle_2","_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"AlterTable_AddColumnBasic_aaa"}},"data":"nnn","extra_end":"extra_end_12","extra_start":"extra_start_12","id":12}
 # ================================
 # Final State Checkpoint
 # ================================
-{"cursor":"binlog.000123:56789","streams":{"test.altertable_addcolumnbasic_aaa":{"key_columns":["id"],"metadata":{"schema":{"columns":["extra_start","id","extra_middle","data","extra_end"],"types":{"data":"text","extra_end":"text","extra_middle":"text","extra_start":"text","id":"int"}}},"mode":"Active"}}}
+{"cursor":"binlog.000123:56789","streams":{"test.altertable_addcolumnbasic_aaa":{"key_columns":["id"],"metadata":{"schema":{"columns":["extra_start","id","Extra_MIDDLE","data","extra_end"],"types":{"Extra_MIDDLE":"text","data":"text","extra_end":"text","extra_start":"text","id":"int"}}},"mode":"Active"}}}
 

--- a/source-mysql/.snapshots/TestAlterTable_AddColumnBasic-at_middle_restart
+++ b/source-mysql/.snapshots/TestAlterTable_AddColumnBasic-at_middle_restart
@@ -1,10 +1,10 @@
 # ================================
 # Collection "acmeCo/test/test.altertable_addcolumnbasic_aaa": 2 Documents
 # ================================
-{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"AlterTable_AddColumnBasic_aaa"}},"data":"ooo","extra_end":"extra_end_13","extra_middle":"extra_middle_13","extra_start":"extra_start_13","id":13}
-{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"AlterTable_AddColumnBasic_aaa"}},"data":"ppp","extra_end":"extra_end_14","extra_middle":"extra_middle_14","extra_start":"extra_start_14","id":14}
+{"Extra_MIDDLE":"extra_middle_13","_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"AlterTable_AddColumnBasic_aaa"}},"data":"ooo","extra_end":"extra_end_13","extra_start":"extra_start_13","id":13}
+{"Extra_MIDDLE":"extra_middle_14","_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"AlterTable_AddColumnBasic_aaa"}},"data":"ppp","extra_end":"extra_end_14","extra_start":"extra_start_14","id":14}
 # ================================
 # Final State Checkpoint
 # ================================
-{"cursor":"binlog.000123:56789","streams":{"test.altertable_addcolumnbasic_aaa":{"key_columns":["id"],"metadata":{"schema":{"columns":["extra_start","id","extra_middle","data","extra_end"],"types":{"data":"text","extra_end":"text","extra_middle":"text","extra_start":"text","id":"int"}}},"mode":"Active"}}}
+{"cursor":"binlog.000123:56789","streams":{"test.altertable_addcolumnbasic_aaa":{"key_columns":["id"],"metadata":{"schema":{"columns":["extra_start","id","Extra_MIDDLE","data","extra_end"],"types":{"Extra_MIDDLE":"text","data":"text","extra_end":"text","extra_start":"text","id":"int"}}},"mode":"Active"}}}
 

--- a/source-mysql/.snapshots/TestTrickyColumnNames-backfill
+++ b/source-mysql/.snapshots/TestTrickyColumnNames-backfill
@@ -1,0 +1,15 @@
+# ================================
+# Collection "acmeCo/test/test.trickycolumnnames_fizzed_cupcake_a": 2 Documents
+# ================================
+{"Meta/`wtf`~ID":1,"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"TrickyColumnNames_fizzed_cupcake_a"}},"data":"aaa"}
+{"Meta/`wtf`~ID":2,"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"TrickyColumnNames_fizzed_cupcake_a"}},"data":"bbb"}
+# ================================
+# Collection "acmeCo/test/test.trickycolumnnames_fizzed_cupcake_b": 2 Documents
+# ================================
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"TrickyColumnNames_fizzed_cupcake_b"}},"data":"ccc","table":3}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"TrickyColumnNames_fizzed_cupcake_b"}},"data":"ddd","table":4}
+# ================================
+# Final State Checkpoint
+# ================================
+{"cursor":"binlog.000123:56789","streams":{"test.trickycolumnnames_fizzed_cupcake_a":{"key_columns":["Meta/`wtf`~ID"],"metadata":{"schema":{"columns":["Meta/`wtf`~ID","data"],"types":{"Meta/`wtf`~ID":"int","data":"text"}}},"mode":"Active"},"test.trickycolumnnames_fizzed_cupcake_b":{"key_columns":["table"],"metadata":{"schema":{"columns":["table","data"],"types":{"data":"text","table":"int"}}},"mode":"Active"}}}
+

--- a/source-mysql/.snapshots/TestTrickyColumnNames-discover
+++ b/source-mysql/.snapshots/TestTrickyColumnNames-discover
@@ -1,0 +1,213 @@
+Binding 0:
+{
+    "recommended_name": "test.trickycolumnnames_fizzed_cupcake_a",
+    "resource_config_json": {
+      "namespace": "test",
+      "stream": "TrickyColumnNames_fizzed_cupcake_a"
+    },
+    "document_schema_json": {
+      "$defs": {
+        "TestTrickyColumnNames_fizzed_cupcake_a": {
+          "type": "object",
+          "required": [
+            "Meta/`wtf`~ID"
+          ],
+          "$anchor": "TestTrickyColumnNames_fizzed_cupcake_a",
+          "properties": {
+            "Meta/`wtf`~ID": {
+              "type": "integer"
+            },
+            "data": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          }
+        }
+      },
+      "allOf": [
+        {
+          "required": [
+            "_meta"
+          ],
+          "properties": {
+            "_meta": {
+              "type": "object",
+              "required": [
+                "op",
+                "source"
+              ],
+              "properties": {
+                "before": {
+                  "$ref": "#TestTrickyColumnNames_fizzed_cupcake_a",
+                  "description": "Record state immediately before this change was applied.",
+                  "reduce": {
+                    "strategy": "firstWriteWins"
+                  }
+                },
+                "op": {
+                  "enum": [
+                    "c",
+                    "d",
+                    "u"
+                  ],
+                  "description": "Change operation type: 'c' Create/Insert, 'u' Update, 'd' Delete."
+                },
+                "source": {
+                  "$id": "https://github.com/estuary/connectors/source-mysql/mysql-source-info",
+                  "properties": {
+                    "ts_ms": {
+                      "type": "integer",
+                      "description": "Unix timestamp (in millis) at which this event was recorded by the database."
+                    },
+                    "schema": {
+                      "type": "string",
+                      "description": "Database schema (namespace) of the event."
+                    },
+                    "snapshot": {
+                      "type": "boolean",
+                      "description": "Snapshot is true if the record was produced from an initial table backfill and unset if produced from the replication log."
+                    },
+                    "table": {
+                      "type": "string",
+                      "description": "Database table of the event."
+                    },
+                    "cursor": {
+                      "type": "string",
+                      "description": "Cursor value representing the current position in the binlog."
+                    }
+                  },
+                  "additionalProperties": false,
+                  "type": "object",
+                  "required": [
+                    "schema",
+                    "table"
+                  ]
+                }
+              },
+              "reduce": {
+                "strategy": "merge"
+              }
+            }
+          },
+          "reduce": {
+            "strategy": "merge"
+          }
+        },
+        {
+          "$ref": "#TestTrickyColumnNames_fizzed_cupcake_a"
+        }
+      ]
+    },
+    "key": [
+      "/Meta~1`wtf`~0ID"
+    ]
+  }
+Binding 1:
+{
+    "recommended_name": "test.trickycolumnnames_fizzed_cupcake_b",
+    "resource_config_json": {
+      "namespace": "test",
+      "stream": "TrickyColumnNames_fizzed_cupcake_b"
+    },
+    "document_schema_json": {
+      "$defs": {
+        "TestTrickyColumnNames_fizzed_cupcake_b": {
+          "type": "object",
+          "required": [
+            "table"
+          ],
+          "$anchor": "TestTrickyColumnNames_fizzed_cupcake_b",
+          "properties": {
+            "data": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "table": {
+              "type": "integer"
+            }
+          }
+        }
+      },
+      "allOf": [
+        {
+          "required": [
+            "_meta"
+          ],
+          "properties": {
+            "_meta": {
+              "type": "object",
+              "required": [
+                "op",
+                "source"
+              ],
+              "properties": {
+                "before": {
+                  "$ref": "#TestTrickyColumnNames_fizzed_cupcake_b",
+                  "description": "Record state immediately before this change was applied.",
+                  "reduce": {
+                    "strategy": "firstWriteWins"
+                  }
+                },
+                "op": {
+                  "enum": [
+                    "c",
+                    "d",
+                    "u"
+                  ],
+                  "description": "Change operation type: 'c' Create/Insert, 'u' Update, 'd' Delete."
+                },
+                "source": {
+                  "$id": "https://github.com/estuary/connectors/source-mysql/mysql-source-info",
+                  "properties": {
+                    "ts_ms": {
+                      "type": "integer",
+                      "description": "Unix timestamp (in millis) at which this event was recorded by the database."
+                    },
+                    "schema": {
+                      "type": "string",
+                      "description": "Database schema (namespace) of the event."
+                    },
+                    "snapshot": {
+                      "type": "boolean",
+                      "description": "Snapshot is true if the record was produced from an initial table backfill and unset if produced from the replication log."
+                    },
+                    "table": {
+                      "type": "string",
+                      "description": "Database table of the event."
+                    },
+                    "cursor": {
+                      "type": "string",
+                      "description": "Cursor value representing the current position in the binlog."
+                    }
+                  },
+                  "additionalProperties": false,
+                  "type": "object",
+                  "required": [
+                    "schema",
+                    "table"
+                  ]
+                }
+              },
+              "reduce": {
+                "strategy": "merge"
+              }
+            }
+          },
+          "reduce": {
+            "strategy": "merge"
+          }
+        },
+        {
+          "$ref": "#TestTrickyColumnNames_fizzed_cupcake_b"
+        }
+      ]
+    },
+    "key": [
+      "/table"
+    ]
+  }
+

--- a/source-mysql/.snapshots/TestTrickyColumnNames-replication
+++ b/source-mysql/.snapshots/TestTrickyColumnNames-replication
@@ -1,0 +1,15 @@
+# ================================
+# Collection "acmeCo/test/test.trickycolumnnames_fizzed_cupcake_a": 2 Documents
+# ================================
+{"Meta/`wtf`~ID":5,"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"TrickyColumnNames_fizzed_cupcake_a"}},"data":"eee"}
+{"Meta/`wtf`~ID":6,"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"TrickyColumnNames_fizzed_cupcake_a"}},"data":"fff"}
+# ================================
+# Collection "acmeCo/test/test.trickycolumnnames_fizzed_cupcake_b": 2 Documents
+# ================================
+{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"TrickyColumnNames_fizzed_cupcake_b"}},"data":"ggg","table":7}
+{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"TrickyColumnNames_fizzed_cupcake_b"}},"data":"hhh","table":8}
+# ================================
+# Final State Checkpoint
+# ================================
+{"cursor":"binlog.000123:56789","streams":{"test.trickycolumnnames_fizzed_cupcake_a":{"key_columns":["Meta/`wtf`~ID"],"metadata":{"schema":{"columns":["Meta/`wtf`~ID","data"],"types":{"Meta/`wtf`~ID":"int","data":"text"}}},"mode":"Active"},"test.trickycolumnnames_fizzed_cupcake_b":{"key_columns":["table"],"metadata":{"schema":{"columns":["table","data"],"types":{"data":"text","table":"int"}}},"mode":"Active"}}}
+

--- a/source-mysql/.snapshots/TestTrickyTableNames-Capture
+++ b/source-mysql/.snapshots/TestTrickyTableNames-Capture
@@ -1,0 +1,10 @@
+# ================================
+# Collection "acmeCo/test/users____": 2 Documents
+# ================================
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"UsErS!@#$"}},"data":"Alice","id":1}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"UsErS!@#$"}},"data":"Bob","id":2}
+# ================================
+# Final State Checkpoint
+# ================================
+{"cursor":"binlog.000123:56789","streams":{"test.users!@#$":{"key_columns":["id"],"metadata":{"schema":{"columns":["id","data"],"types":{"data":"text","id":"int"}}},"mode":"Active"}}}
+

--- a/source-mysql/.snapshots/TestTrickyTableNames-Capture-Replication
+++ b/source-mysql/.snapshots/TestTrickyTableNames-Capture-Replication
@@ -1,0 +1,10 @@
+# ================================
+# Collection "acmeCo/test/users____": 2 Documents
+# ================================
+{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"UsErS!@#$"}},"data":"Carol","id":3}
+{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"UsErS!@#$"}},"data":"Dave","id":4}
+# ================================
+# Final State Checkpoint
+# ================================
+{"cursor":"binlog.000123:56789","streams":{"test.users!@#$":{"key_columns":["id"],"metadata":{"schema":{"columns":["id","data"],"types":{"data":"text","id":"int"}}},"mode":"Active"}}}
+

--- a/source-mysql/.snapshots/TestTrickyTableNames-Discover
+++ b/source-mysql/.snapshots/TestTrickyTableNames-Discover
@@ -1,0 +1,104 @@
+Binding 0:
+{
+    "recommended_name": "test.users____",
+    "resource_config_json": {
+      "namespace": "test",
+      "stream": "UsErS!@#$"
+    },
+    "document_schema_json": {
+      "$defs": {
+        "TestUsErS!@#$": {
+          "type": "object",
+          "required": [
+            "id"
+          ],
+          "$anchor": "TestUsErS!@#$",
+          "properties": {
+            "data": {
+              "type": "string"
+            },
+            "id": {
+              "type": "integer"
+            }
+          }
+        }
+      },
+      "allOf": [
+        {
+          "required": [
+            "_meta"
+          ],
+          "properties": {
+            "_meta": {
+              "type": "object",
+              "required": [
+                "op",
+                "source"
+              ],
+              "properties": {
+                "before": {
+                  "$ref": "#TestUsErS!@#$",
+                  "description": "Record state immediately before this change was applied.",
+                  "reduce": {
+                    "strategy": "firstWriteWins"
+                  }
+                },
+                "op": {
+                  "enum": [
+                    "c",
+                    "d",
+                    "u"
+                  ],
+                  "description": "Change operation type: 'c' Create/Insert, 'u' Update, 'd' Delete."
+                },
+                "source": {
+                  "$id": "https://github.com/estuary/connectors/source-mysql/mysql-source-info",
+                  "properties": {
+                    "ts_ms": {
+                      "type": "integer",
+                      "description": "Unix timestamp (in millis) at which this event was recorded by the database."
+                    },
+                    "schema": {
+                      "type": "string",
+                      "description": "Database schema (namespace) of the event."
+                    },
+                    "snapshot": {
+                      "type": "boolean",
+                      "description": "Snapshot is true if the record was produced from an initial table backfill and unset if produced from the replication log."
+                    },
+                    "table": {
+                      "type": "string",
+                      "description": "Database table of the event."
+                    },
+                    "cursor": {
+                      "type": "string",
+                      "description": "Cursor value representing the current position in the binlog."
+                    }
+                  },
+                  "additionalProperties": false,
+                  "type": "object",
+                  "required": [
+                    "schema",
+                    "table"
+                  ]
+                }
+              },
+              "reduce": {
+                "strategy": "merge"
+              }
+            }
+          },
+          "reduce": {
+            "strategy": "merge"
+          }
+        },
+        {
+          "$ref": "#TestUsErS!@#$"
+        }
+      ]
+    },
+    "key": [
+      "/id"
+    ]
+  }
+

--- a/source-mysql/backfill.go
+++ b/source-mysql/backfill.go
@@ -139,7 +139,7 @@ func (db *mysqlDatabase) buildScanQuery(start bool, keyColumns []string, columnT
 
 	// Construct the query itself.
 	var query = new(strings.Builder)
-	fmt.Fprintf(query, "SELECT * FROM %s.%s", schemaName, tableName)
+	fmt.Fprintf(query, "SELECT * FROM `%s`.`%s`", schemaName, tableName)
 
 	if !start {
 		for i := 0; i != len(pkey); i++ {

--- a/source-mysql/capture_test.go
+++ b/source-mysql/capture_test.go
@@ -2,10 +2,15 @@ package main
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
 	"regexp"
 	"testing"
 
+	"github.com/estuary/connectors/sqlcapture"
 	"github.com/estuary/connectors/sqlcapture/tests"
+	"github.com/estuary/flow/go/protocols/flow"
+	"github.com/stretchr/testify/require"
 )
 
 func TestTrickyColumnNames(t *testing.T) {
@@ -31,4 +36,36 @@ func TestTrickyColumnNames(t *testing.T) {
 	tb.Insert(ctx, t, tableA, [][]interface{}{{5, "eee"}, {6, "fff"}})
 	tb.Insert(ctx, t, tableB, [][]interface{}{{7, "ggg"}, {8, "hhh"}})
 	t.Run("replication", func(t *testing.T) { tests.VerifiedCapture(ctx, t, cs) })
+}
+
+func TestTrickyTableNames(t *testing.T) {
+	var tb, ctx = mysqlTestBackend(t), context.Background()
+	tb.Query(ctx, t, fmt.Sprintf("DROP TABLE IF EXISTS `%s`.`UsErS!@#$`", testSchemaName))
+	tb.Query(ctx, t, fmt.Sprintf("CREATE TABLE `%s`.`UsErS!@#$` (id INTEGER PRIMARY KEY, data TEXT NOT NULL)", testSchemaName))
+	var cs = tb.CaptureSpec(ctx, t)
+	t.Run("Discover", func(t *testing.T) {
+		cs.VerifyDiscover(ctx, t, regexp.MustCompile(`(?i:users)`))
+	})
+	var resourceSpecJSON, err = json.Marshal(sqlcapture.Resource{
+		Namespace: testSchemaName,
+		Stream:    "UsErS!@#$",
+	})
+	require.NoError(t, err)
+	cs.Bindings = []*flow.CaptureSpec_Binding{{
+		Collection:         flow.CollectionSpec{Name: flow.Collection("acmeCo/test/users____")},
+		ResourceConfigJson: resourceSpecJSON,
+		ResourcePath:       []string{testSchemaName, "UsErS!@#$"},
+	}}
+	t.Run("Validate", func(t *testing.T) {
+		var _, err = cs.Validate(ctx, t)
+		require.NoError(t, err)
+	})
+	t.Run("Capture", func(t *testing.T) {
+		tb.Query(ctx, t, fmt.Sprintf("INSERT INTO `%s`.`UsErS!@#$` VALUES (1, 'Alice'), (2, 'Bob')", testSchemaName))
+		tests.VerifiedCapture(ctx, t, cs)
+		t.Run("Replication", func(t *testing.T) {
+			tb.Query(ctx, t, fmt.Sprintf("INSERT INTO `%s`.`UsErS!@#$` VALUES (3, 'Carol'), (4, 'Dave')", testSchemaName))
+			tests.VerifiedCapture(ctx, t, cs)
+		})
+	})
 }

--- a/source-mysql/capture_test.go
+++ b/source-mysql/capture_test.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"context"
+	"regexp"
+	"testing"
+
+	"github.com/estuary/connectors/sqlcapture/tests"
+)
+
+func TestTrickyColumnNames(t *testing.T) {
+	// Create a table with some 'difficult' column names (a reserved word, a capitalized
+	// name, and one containing special characters which also happens to be the primary key).
+	var tb, ctx = mysqlTestBackend(t), context.Background()
+	const uniqueString = "fizzed_cupcake"
+	var tableA = tb.CreateTable(ctx, t, uniqueString+"_a", "(`Meta/``wtf``~ID` INTEGER PRIMARY KEY, data TEXT)")
+	var tableB = tb.CreateTable(ctx, t, uniqueString+"_b", "(`table` INTEGER PRIMARY KEY, data TEXT)")
+	tb.Insert(ctx, t, tableA, [][]interface{}{{1, "aaa"}, {2, "bbb"}})
+	tb.Insert(ctx, t, tableB, [][]interface{}{{3, "ccc"}, {4, "ddd"}})
+
+	// Discover the catalog and verify that the table schemas looks correct
+	t.Run("discover", func(t *testing.T) {
+		tb.CaptureSpec(ctx, t).VerifyDiscover(ctx, t, regexp.MustCompile(regexp.QuoteMeta(uniqueString)))
+	})
+
+	// Perform an initial backfill
+	var cs = tb.CaptureSpec(ctx, t, tableA, tableB)
+	t.Run("backfill", func(t *testing.T) { tests.VerifiedCapture(ctx, t, cs) })
+
+	// Add more data and read it via replication
+	tb.Insert(ctx, t, tableA, [][]interface{}{{5, "eee"}, {6, "fff"}})
+	tb.Insert(ctx, t, tableB, [][]interface{}{{7, "ggg"}, {8, "hhh"}})
+	t.Run("replication", func(t *testing.T) { tests.VerifiedCapture(ctx, t, cs) })
+}

--- a/source-mysql/main_test.go
+++ b/source-mysql/main_test.go
@@ -279,8 +279,8 @@ func TestAlterTable_AddColumnBasic(t *testing.T) {
 	})
 	t.Run("at_first_restart", func(t *testing.T) { tests.VerifiedCapture(ctx, t, cs) })
 
-	// Can add a column in the middle of the table.
-	tb.Query(ctx, t, fmt.Sprintf("ALTER TABLE %s ADD COLUMN extra_middle TEXT AFTER id;", table))
+	// Can add a column in the middle of the table, and case sensitivity is not a problem.
+	tb.Query(ctx, t, fmt.Sprintf("ALTER TABLE %s ADD COLUMN Extra_MIDDLE TEXT AFTER id;", table))
 	tb.Insert(ctx, t, table, [][]interface{}{
 		{"extra_start_11", 11, "extra_middle_1", "mmm", "extra_end_11"},
 		{"extra_start_12", 12, "extra_middle_2", "nnn", "extra_end_12"},

--- a/source-mysql/prerequisites.go
+++ b/source-mysql/prerequisites.go
@@ -114,7 +114,7 @@ func (db *mysqlDatabase) prerequisiteUserPermissions(ctx context.Context) error 
 func (db *mysqlDatabase) SetupTablePrerequisites(ctx context.Context, schema, table string) error {
 	var streamID = sqlcapture.JoinStreamID(schema, table)
 
-	results, err := db.conn.Execute(fmt.Sprintf(`SELECT * FROM %s.%s LIMIT 0;`, schema, table))
+	results, err := db.conn.Execute(fmt.Sprintf("SELECT * FROM `%s`.`%s` LIMIT 0;", schema, table))
 	if err != nil {
 		return fmt.Errorf("user %q cannot read from table %q", db.config.User, streamID)
 	}

--- a/source-postgres/.snapshots/TestTrickyColumnNames-backfill
+++ b/source-postgres/.snapshots/TestTrickyColumnNames-backfill
@@ -1,8 +1,8 @@
 # ================================
 # Collection "acmeCo/test/test.trickycolumnnames_fizzed_cupcake_a": 2 Documents
 # ================================
-{"Meta/\"wtf\"/ID":1,"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"trickycolumnnames_fizzed_cupcake_a","loc":[11111111,11111111,11111111]}},"data":"aaa"}
-{"Meta/\"wtf\"/ID":2,"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"trickycolumnnames_fizzed_cupcake_a","loc":[11111111,11111111,11111111]}},"data":"bbb"}
+{"Meta/\"wtf\"~ID":1,"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"trickycolumnnames_fizzed_cupcake_a","loc":[11111111,11111111,11111111]}},"data":"aaa"}
+{"Meta/\"wtf\"~ID":2,"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"trickycolumnnames_fizzed_cupcake_a","loc":[11111111,11111111,11111111]}},"data":"bbb"}
 # ================================
 # Collection "acmeCo/test/test.trickycolumnnames_fizzed_cupcake_b": 2 Documents
 # ================================
@@ -11,5 +11,5 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"cursor":"0/1111111","streams":{"test.trickycolumnnames_fizzed_cupcake_a":{"key_columns":["Meta/\"wtf\"/ID"],"mode":"Active"},"test.trickycolumnnames_fizzed_cupcake_b":{"key_columns":["table"],"mode":"Active"}}}
+{"cursor":"0/1111111","streams":{"test.trickycolumnnames_fizzed_cupcake_a":{"key_columns":["Meta/\"wtf\"~ID"],"mode":"Active"},"test.trickycolumnnames_fizzed_cupcake_b":{"key_columns":["table"],"mode":"Active"}}}
 

--- a/source-postgres/.snapshots/TestTrickyColumnNames-discover
+++ b/source-postgres/.snapshots/TestTrickyColumnNames-discover
@@ -10,11 +10,11 @@ Binding 0:
         "TestTrickycolumnnames_fizzed_cupcake_a": {
           "type": "object",
           "required": [
-            "Meta/\"wtf\"/ID"
+            "Meta/\"wtf\"~ID"
           ],
           "$anchor": "TestTrickycolumnnames_fizzed_cupcake_a",
           "properties": {
-            "Meta/\"wtf\"/ID": {
+            "Meta/\"wtf\"~ID": {
               "type": "integer"
             },
             "data": {
@@ -106,7 +106,7 @@ Binding 0:
       ]
     },
     "key": [
-      "/Meta/\"wtf\"/ID"
+      "/Meta~1\"wtf\"~0ID"
     ]
   }
 Binding 1:

--- a/source-postgres/.snapshots/TestTrickyColumnNames-replication
+++ b/source-postgres/.snapshots/TestTrickyColumnNames-replication
@@ -1,8 +1,8 @@
 # ================================
 # Collection "acmeCo/test/test.trickycolumnnames_fizzed_cupcake_a": 2 Documents
 # ================================
-{"Meta/\"wtf\"/ID":5,"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"trickycolumnnames_fizzed_cupcake_a","loc":[11111111,11111111,11111111]}},"data":"eee"}
-{"Meta/\"wtf\"/ID":6,"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"trickycolumnnames_fizzed_cupcake_a","loc":[11111111,11111111,11111111]}},"data":"fff"}
+{"Meta/\"wtf\"~ID":5,"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"trickycolumnnames_fizzed_cupcake_a","loc":[11111111,11111111,11111111]}},"data":"eee"}
+{"Meta/\"wtf\"~ID":6,"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"trickycolumnnames_fizzed_cupcake_a","loc":[11111111,11111111,11111111]}},"data":"fff"}
 # ================================
 # Collection "acmeCo/test/test.trickycolumnnames_fizzed_cupcake_b": 2 Documents
 # ================================
@@ -11,5 +11,5 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"cursor":"0/1111111","streams":{"test.trickycolumnnames_fizzed_cupcake_a":{"key_columns":["Meta/\"wtf\"/ID"],"mode":"Active"},"test.trickycolumnnames_fizzed_cupcake_b":{"key_columns":["table"],"mode":"Active"}}}
+{"cursor":"0/1111111","streams":{"test.trickycolumnnames_fizzed_cupcake_a":{"key_columns":["Meta/\"wtf\"~ID"],"mode":"Active"},"test.trickycolumnnames_fizzed_cupcake_b":{"key_columns":["table"],"mode":"Active"}}}
 

--- a/source-postgres/capture_test.go
+++ b/source-postgres/capture_test.go
@@ -211,7 +211,7 @@ func TestTrickyColumnNames(t *testing.T) {
 	// name, and one containing special characters which also happens to be the primary key).
 	var tb, ctx = postgresTestBackend(t), context.Background()
 	const uniqueString = "fizzed_cupcake"
-	var tableA = tb.CreateTable(ctx, t, uniqueString+"_a", `("Meta/""wtf""/ID" INTEGER PRIMARY KEY, data TEXT)`)
+	var tableA = tb.CreateTable(ctx, t, uniqueString+"_a", `("Meta/""wtf""~ID" INTEGER PRIMARY KEY, data TEXT)`)
 	var tableB = tb.CreateTable(ctx, t, uniqueString+"_b", `("table" INTEGER PRIMARY KEY, data TEXT)`)
 	tb.Insert(ctx, t, tableA, [][]interface{}{{1, "aaa"}, {2, "bbb"}})
 	tb.Insert(ctx, t, tableB, [][]interface{}{{3, "ccc"}, {4, "ddd"}})

--- a/sqlcapture/capture.go
+++ b/sqlcapture/capture.go
@@ -272,10 +272,8 @@ func (c *Capture) updateState(ctx context.Context) error {
 			primaryKey = binding.Resource.PrimaryKey
 			logrus.WithFields(logrus.Fields{"stream": streamID, "key": primaryKey}).Debug("using resource primary key")
 		} else if len(binding.CollectionKey) > 0 {
-			// TODO(wgd): This logic isn't correct for all possible column names, but
-			// I need to implement a unit test demonstrating that issue first.
 			for _, ptr := range binding.CollectionKey {
-				primaryKey = append(primaryKey, strings.TrimPrefix(ptr, "/"))
+				primaryKey = append(primaryKey, collectionKeyToPrimaryKey(ptr))
 			}
 			logrus.WithFields(logrus.Fields{"stream": streamID, "key": primaryKey}).Debug("using collection primary key")
 		} else if len(discoveryInfo.PrimaryKey) > 0 {

--- a/sqlcapture/discovery_test.go
+++ b/sqlcapture/discovery_test.go
@@ -73,3 +73,31 @@ func TestRecommendedCatalogName(t *testing.T) {
 		})
 	}
 }
+
+func TestKeyRoundTrip(t *testing.T) {
+	for _, pk := range []string{
+		"standard",
+		"with/slash",
+		"with~tilde",
+		"/start",
+		"~start",
+		"end/",
+		"end~",
+		"has~0escape~1already",
+		"~/",
+		"~0~1",
+		"~1~0",
+		"~~01",
+		"~~10",
+		"~01~",
+		"~0",
+		"~1",
+		"~",
+		"/",
+		"",
+	} {
+		t.Run(pk, func(t *testing.T) {
+			require.Equal(t, pk, collectionKeyToPrimaryKey(primaryKeyToCollectionKey(pk)))
+		})
+	}
+}

--- a/sqlcapture/discovery_test.go
+++ b/sqlcapture/discovery_test.go
@@ -1,0 +1,75 @@
+package sqlcapture
+
+import (
+	"path"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRecommendedCatalogName(t *testing.T) {
+	tests := []struct {
+		schema string
+		table  string
+		want   string
+	}{
+		{
+			schema: "something",
+			table:  "typical",
+			want:   "something.typical",
+		},
+		{
+			schema: "Capital",
+			table:  "LetterS",
+			want:   "capital.letters",
+		},
+		{
+			schema: "for$bidden",
+			table:  "char%s",
+			want:   "for_bidden.char_s",
+		},
+		{
+			schema: "schema",
+			table:  "/table",
+			want:   "schema._table",
+		},
+		{
+			schema: "path-like",
+			table:  "/../this",
+			want:   "path-like._.._this",
+		},
+		{
+			schema: "@",
+			table:  "!",
+			want:   "_._",
+		},
+		{
+			schema: ".",
+			table:  "/",
+			want:   ".._",
+		},
+		{
+			schema: ".",
+			table:  "", // This should not be possible, but even if it were it would not be a problem as a collection name.
+			want:   "..",
+		},
+		{
+			schema: "/",
+			table:  "./",
+			want:   "_.._",
+		},
+		{
+			schema: "multiple////",
+			table:  "slashes",
+			want:   "multiple____.slashes",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.schema+"."+tt.table, func(t *testing.T) {
+			got := recommendedCatalogName(tt.schema, tt.table)
+			require.Equal(t, path.Clean(got), got)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}


### PR DESCRIPTION
**Description:**

This set of changes improves handling for unusually named tables and primary key columns.

The cross-cutting change to `sqlcapture` for unusual table names is related to recommended Flow collection names on discovery. Flow collection names are allowed only a specific set of characters and have certain requirements for "path-like" sequences like `/../` due to their inclusion in Gazette journal paths. A database like Postgres can have just about any character in a table name (if it is quoted) which can lead to invalid recommended collection names if these table names are used as-is in collection names. The change here applies a simple sanitization where the disallowed characters and any occurrences of a `/` character are replaced with `_`. This closes https://github.com/estuary/connectors/issues/353: `source-postgres` had previously been updated to always quote table names when constructing queries, and the discovery output for strangely named tables will now be acceptable as well.

Another current issue is that primary key columns containing `~` and/or `/` characters are discovered and recommended as collection keys as-is with a `/` prepended to them to turn them into a JSON pointer. But JSON pointers are a hierarchical reference to a location within a JSON document and any occurrences of `~` or `/` in the pointer have special meaning in that sense. The change to `sqlcapture` here handles escaping these characters per RFC6901 so that they can be used as valid collection keys. This closes https://github.com/estuary/connectors/issues/620.

A couple of specific changes were made along with these to `source-mysql`. This connector will now quote key column names and table identifiers when constructing queries similar to `source-postgres`. This allows `source-mysql` to capture from databases with key columns or tables named with [characters that require quoting](https://dev.mysql.com/doc/refman/8.0/en/identifiers.html), which includes any of the kinds of names this PR is addressing. 

**Workflow steps:**

Discover & capture on databases containing identifiers with special characters.

**Documentation links affected:**

N/A

**Notes for reviewers:**

Much of the impact from this PR involves interacting with the actual flow runtime and its naming requirements, so along with the tests included here I did a fair amount of manual testing with SQL captures, particularly with `source-mysql` which did not previously do much in the way of identifier quoting.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/672)
<!-- Reviewable:end -->
