### PR TITLE
source-postgres: discover enum & range types as strings

### DIFF
--- a/source-postgres/.snapshots/TestUserTypes-Range-Capture
+++ b/source-postgres/.snapshots/TestUserTypes-Range-Capture
@@ -1,0 +1,10 @@
+# ================================
+# Collection "acmeCo/test/test.usertypes_range_morsel": 2 Documents
+# ================================
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"usertypes_range_morsel","loc":[11111111,11111111,11111111]}},"id":1,"value":"(1,2]"}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"usertypes_range_morsel","loc":[11111111,11111111,11111111]}},"id":2,"value":"[3,)"}
+# ================================
+# Final State Checkpoint
+# ================================
+{"cursor":"0/1111111","streams":{"test.usertypes_range_morsel":{"key_columns":["id"],"mode":"Active"}}}
+

--- a/source-postgres/.snapshots/TestUserTypes-Range-Capture-Replication
+++ b/source-postgres/.snapshots/TestUserTypes-Range-Capture-Replication
@@ -1,0 +1,10 @@
+# ================================
+# Collection "acmeCo/test/test.usertypes_range_morsel": 2 Documents
+# ================================
+{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"usertypes_range_morsel","loc":[11111111,11111111,11111111]}},"id":3,"value":"(,4]"}
+{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"usertypes_range_morsel","loc":[11111111,11111111,11111111]}},"id":4,"value":"[5,6)"}
+# ================================
+# Final State Checkpoint
+# ================================
+{"cursor":"0/1111111","streams":{"test.usertypes_range_morsel":{"key_columns":["id"],"mode":"Active"}}}
+

--- a/source-postgres/.snapshots/TestUserTypes-Range-Discovery
+++ b/source-postgres/.snapshots/TestUserTypes-Range-Discovery
@@ -1,18 +1,18 @@
 Binding 0:
 {
-    "recommended_name": "test.usertypes_enum_terror",
+    "recommended_name": "test.usertypes_range_morsel",
     "resource_config_json": {
       "namespace": "test",
-      "stream": "usertypes_enum_terror"
+      "stream": "usertypes_range_morsel"
     },
     "document_schema_json": {
       "$defs": {
-        "TestUsertypes_enum_terror": {
+        "TestUsertypes_range_morsel": {
           "type": "object",
           "required": [
             "id"
           ],
-          "$anchor": "TestUsertypes_enum_terror",
+          "$anchor": "TestUsertypes_range_morsel",
           "properties": {
             "id": {
               "type": "integer"
@@ -40,7 +40,7 @@ Binding 0:
               ],
               "properties": {
                 "before": {
-                  "$ref": "#TestUsertypes_enum_terror",
+                  "$ref": "#TestUsertypes_range_morsel",
                   "description": "Record state immediately before this change was applied.",
                   "reduce": {
                     "strategy": "firstWriteWins"
@@ -101,7 +101,7 @@ Binding 0:
           }
         },
         {
-          "$ref": "#TestUsertypes_enum_terror"
+          "$ref": "#TestUsertypes_range_morsel"
         }
       ]
     },

--- a/source-postgres/datatype_test.go
+++ b/source-postgres/datatype_test.go
@@ -118,7 +118,13 @@ func TestDatatypes(t *testing.T) {
 		{ColumnType: `text ARRAY`, ExpectType: fmt.Sprintf(arraySchemaPattern, `{"type":["string","null"]}`), InputValue: []interface{}{`Hello, world!`, `asdf`}, ExpectValue: `{"dimensions":[2],"elements":["Hello, world!","asdf"]}`},
 		{ColumnType: `uuid ARRAY`, ExpectType: fmt.Sprintf(arraySchemaPattern, `{"type":["string","null"],"format":"uuid"}`), InputValue: []interface{}{`a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11`}, ExpectValue: `{"dimensions":[1],"elements":["a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11"]}`},
 
-		// TODO(wgd): Add enumeration test case?
+		// Built-in range types.
+		{ColumnType: `int4range`, ExpectType: `{"type":["string","null"]}`, InputValue: `[1,5)`, ExpectValue: `"[1,5)"`},
+		{ColumnType: `int8range`, ExpectType: `{"type":["string","null"]}`, InputValue: `[,]`, ExpectValue: `"(,)"`},
+		{ColumnType: `numrange`, ExpectType: `{"type":["string","null"]}`, InputValue: `(1.1,5.5]`, ExpectValue: `"(11e-1,55e-1]"`},
+		{ColumnType: `tsrange`, ExpectType: `{"type":["string","null"]}`, InputValue: `[2010-01-01 11:30,2010-01-01 15:00)`, ExpectValue: `"[2010-01-01 11:30:00,2010-01-01 15:00:00)"`},
+		{ColumnType: `tstzrange`, ExpectType: `{"type":["string","null"]}`, InputValue: `[2010-01-01 11:30,2010-01-01 15:00)`, ExpectValue: `"[2010-01-01 11:30:00Z,2010-01-01 15:00:00Z)"`},
+		{ColumnType: `daterange`, ExpectType: `{"type":["string","null"]}`, InputValue: `(2010-01-01,2010-01-02]`, ExpectValue: `"[2010-01-02,2010-01-03)"`},
 	})
 }
 

--- a/source-postgres/main_test.go
+++ b/source-postgres/main_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/estuary/flow/go/protocols/flow"
 	"github.com/jackc/pgx/v4"
 	"github.com/jackc/pgx/v4/pgxpool"
-	"github.com/sirupsen/logrus"
 	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 )
@@ -59,7 +58,7 @@ func postgresTestBackend(t testing.TB) *testBackend {
 	// Open control connection
 	var ctx = context.Background()
 	var controlURI = fmt.Sprintf(`postgres://%s:%s@%s/%s`, *dbControlUser, *dbControlPass, *dbAddress, *dbName)
-	logrus.WithFields(logrus.Fields{
+	log.WithFields(log.Fields{
 		"user": *dbControlUser,
 		"addr": *dbAddress,
 	}).Info("opening control connection")


### PR DESCRIPTION
**Description:**

This changes discovery for range (user-defined and built-in) and enum (which are always user-defined) columns to output a JSON schema with `string` fields for these columns. They will continue to be output in their text form.

Postgres enum type values are represented as string labels. There is an underlying integer value corresponding to the string label values, but that seems less useful to capture. The enum type in Postgres restricts inputs to just its set of labels, and JSON schema supports a similar concept with the `enum` keyword. However I am opting to _not_ attempt to cast the Postgres enum values into a corresponding JSON schema enum. This is mostly because it would make dealing with additions to the Postgres enum difficult: We would need a mechanism for re-discovering and updating the collection write schema if a new value were added to an allowable Postgres enum. In the future a system may exist where schema violations trigger a re-discovery & publication for the target collection (we've been talking about building this recently, even). It would be possible at that point to apply the same restrictions to the collection JSON schema enum as the Postgres enum if desired, although I'm not sure how useful it would be.

Ranges are a little less straight-forward, but I can't see a better representation for them than Postgres' text form. As an example, a column that accepts ranges of integers can be of type `int4range` and a value like `[1,5)` can be inserted into it. This value is "integers greater than or equal to 1 but less than 5" - it includes information about the upper and lower bounds being inclusive/exclusive. JSON schema does have keywords for `minimum`, `exclusiveMinimum` etc. for numeric types but this does not conceptually map to Postgres ranges where it is the values that describe the range rather than the column type, and Postgres has more range types than just numeric values.

Absent here is any modified handling for user-defined composite or "tuple" types. The text form of these is actually pretty bad and looks something like `"('strVal', 1, false)"`. In principal it would be possible to handle these better. `pgx v5` includes methods for loading information for custom types and registering it with the connection's type registry to allow composite types to be loaded as `map[string]interface{}`, where the string key is the name of the composite type "field" and the value is the value. See https://stackoverflow.com/a/75713614 for an example of this. Conceptually, discovery could find user-defined composite types and register them, and replication could watch for type messages and register new types if they appear. It's not obvious to me that implementing this would be worth the effort at the moment so I'm leaving that as a future TODO if the need arises.

Part of https://github.com/estuary/connectors/issues/544

**Workflow steps:**

Discovery on tables with `enum` or `range` types will produce collection schemas with `string` types. Discovery for composite types will continue to produce a schema with no type and a warning message in the description.

**Documentation links affected:**

N/A

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/675)
<!-- Reviewable:end -->
