### PR TITLE
materialize-bigquery: use JSON type for objects

### DIFF
--- a/materialize-bigquery/.snapshots/TestSQLGeneration
+++ b/materialize-bigquery/.snapshots/TestSQLGeneration
@@ -13,7 +13,7 @@ CREATE TABLE IF NOT EXISTS projectID.dataset.target_table (
 		person_place_ STRING,
 		source_name STRING,
 		`with-dash` STRING,
-		flow_document STRING NOT NULL
+		flow_document JSON NOT NULL
 )
 CLUSTER BY key1, key2, boolean, integer;
 --- End projectID.dataset.target_table createTargetTable ---

--- a/materialize-bigquery/sqlgen.go
+++ b/materialize-bigquery/sqlgen.go
@@ -63,7 +63,7 @@ var bqTypeMapper = sql.ProjectionTypeMapper{
 	sql.BOOLEAN: sql.NewStaticMapper("BOOL"),
 	sql.INTEGER: sql.NewStaticMapper("INT64", sql.WithElementConverter(sql.StdStrToInt())),
 	sql.NUMBER:  sql.NewStaticMapper("BIGNUMERIC", sql.WithElementConverter(sql.StdStrToFloat())),
-	sql.OBJECT:  sql.NewStaticMapper("STRING", sql.WithElementConverter(jsonConverter)),
+	sql.OBJECT:  sql.NewStaticMapper("JSON", sql.WithElementConverter(jsonConverter)),
 	sql.STRING: sql.StringTypeMapper{
 		Fallback: sql.NewStaticMapper("STRING"),
 		WithFormat: map[string]sql.TypeMapper{


### PR DESCRIPTION
**Description:**\

Updates the materialize-bigquery connector to use the `JSON` column type instead of `STRING` for JSON objects. Most notably, this changes the type that's used for the `flow_document` column. The goal is to make it easier to query these columns.

**Workflow steps:**

No change.

**Documentation links affected:** n/a

**Notes for reviewers:**

This is just a draft at the moment, so I can test compatibility.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/676)
<!-- Reviewable:end -->
