### PR TITLE
source-postgres: Add DEBUG logs for a production issue

### DIFF
--- a/source-postgres/replication.go
+++ b/source-postgres/replication.go
@@ -339,6 +339,7 @@ func (s *replicationStream) decodeMessage(lsn pglogrepl.LSN, msg pglogrepl.Messa
 				Location: [3]pglogrepl.LSN{s.lastTxnEndLSN, lsn, 0},
 			},
 		}
+		logrus.WithField("lsn", s.lastTxnEndLSN).Debug("commit event")
 		return event, nil
 	case *pglogrepl.TruncateMessage:
 		for _, relID := range msg.RelationIDs {
@@ -603,6 +604,7 @@ func (s *replicationStream) ActivateTable(ctx context.Context, streamID string, 
 // advance the "Restart LSN" to the same point, but so long as you ignore the details
 // things will work out in the end.
 func (s *replicationStream) Acknowledge(ctx context.Context, cursor string) error {
+	logrus.WithField("cursor", cursor).Debug("advancing acknowledged LSN")
 	var lsn, err = pglogrepl.ParseLSN(cursor)
 	if err != nil {
 		return fmt.Errorf("error parsing acknowledge cursor: %w", err)


### PR DESCRIPTION
**Description:**

In automated tests the new LSN acknowledgement code seems to work, but in production our capture from our own Supabase instance is not advancing the replication slot LSN. We need more visibility here to narrow down the problem.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/685)
<!-- Reviewable:end -->
