### PR TITLE
sqlcapture: Treat Acknowledge with empty count as count=1

### DIFF
--- a/sqlcapture/capture.go
+++ b/sqlcapture/capture.go
@@ -676,7 +676,9 @@ func (c *Capture) handleAcknowledgement(ctx context.Context, count int, replStre
 	c.pending.Lock()
 	defer c.pending.Unlock()
 	if count == 0 {
-		return nil // Zero count isn't permitted in the protocol, but has a sensible meaning of 'ignore it' so let's do that
+		// Originally the Acknowledge message implicitly meant acknowledging one checkpoint,
+		// so in the absence of a count we will continue to interpret it that way.
+		count = 1
 	}
 	if count > len(c.pending.cursors) {
 		return fmt.Errorf("invalid acknowledgement count %d, only %d pending checkpoints", count, len(c.pending.cursors))


### PR DESCRIPTION
**Description:**

This was the original meaning of the message and there's at least one place within Flow that hasn't been updated to set the count yet, so we should continue to treat it as a count of 1 if unset.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/686)
<!-- Reviewable:end -->
