### PR TITLE
source-postgres: handle nullable columns with array types

### DIFF
--- a/source-postgres/datatype_test.go
+++ b/source-postgres/datatype_test.go
@@ -10,7 +10,8 @@ import (
 	"github.com/estuary/connectors/sqlcapture/tests"
 )
 
-const arraySchemaPattern = `{"required":["dimensions","elements"],"type":"object","properties":{"dimensions":{"type":"array","items":{"type":"integer"}},"elements":{"type":"array","items":%s}}}`
+const arraySchemaPatternNotNullable = `{"required":["dimensions","elements"],"type":"object","properties":{"dimensions":{"type":"array","items":{"type":"integer"}},"elements":{"type":"array","items":%s}}}`
+const arraySchemaPattern = `{"required":["dimensions","elements"],"type":["object","null"],"properties":{"dimensions":{"type":"array","items":{"type":"integer"}},"elements":{"type":"array","items":%s}}}`
 
 // TestDatatypes runs the generic datatype discovery and round-tripping test on various datatypes.
 func TestDatatypes(t *testing.T) {
@@ -102,7 +103,9 @@ func TestDatatypes(t *testing.T) {
 		{ColumnType: `integer[3][3]`, ExpectType: fmt.Sprintf(arraySchemaPattern, `{"type":["integer","null"]}`), InputValue: `{{1,2,3},{4,5,6},{7,8,9}}`, ExpectValue: `{"dimensions":[3,3],"elements":[1,2,3,4,5,6,7,8,9]}`},
 
 		// Sanity-check various types of array for discovery and round-tripping
+		{ColumnType: `bigint ARRAY NOT NULL`, ExpectType: fmt.Sprintf(arraySchemaPatternNotNullable, `{"type":["integer","null"]}`), InputValue: `{1,2,null,4}`, ExpectValue: `{"dimensions":[4],"elements":[1,2,null,4]}`},
 		{ColumnType: `bigint ARRAY`, ExpectType: fmt.Sprintf(arraySchemaPattern, `{"type":["integer","null"]}`), InputValue: `{1,2,null,4}`, ExpectValue: `{"dimensions":[4],"elements":[1,2,null,4]}`},
+		{ColumnType: `bigint ARRAY`, ExpectType: fmt.Sprintf(arraySchemaPattern, `{"type":["integer","null"]}`), InputValue: nil, ExpectValue: `null`},
 		{ColumnType: `boolean ARRAY`, ExpectType: fmt.Sprintf(arraySchemaPattern, `{"type":["boolean","null"]}`), InputValue: `{true, false, null, true}`, ExpectValue: `{"dimensions":[4],"elements":[true,false,null,true]}`},
 		{ColumnType: `bytea ARRAY`, ExpectType: fmt.Sprintf(arraySchemaPattern, `{"type":["string","null"],"contentEncoding":"base64"}`), InputValue: `{abcd, efgh}`, ExpectValue: `{"dimensions":[2],"elements":["YWJjZA==","ZWZnaA=="]}`},
 		{ColumnType: `varchar(12) ARRAY`, ExpectType: fmt.Sprintf(arraySchemaPattern, `{"type":["string","null"]}`), InputValue: `{foo, bar}`, ExpectValue: `{"dimensions":[2],"elements":["foo","bar"]}`},


### PR DESCRIPTION
**Description:**

A captured table column may be an array type and be nullable, in which case the column might contain arrays or `null`. We would previously discover these columns as `{"type":["object"]}` which would disallow any `null` values to be captured from the table. We were also applying the column nullability to the items in the array. But it is not possible for a column array to be declared with non-nullable items in Postgres in a way that we can currently check for, as it requires additional constraints on the table.

This changes discovers for nullable array columns to have a type like `{"type":["object","null"]}` which will allow nullable array columns to be captured when the columns contain `null`.

Closes https://github.com/estuary/connectors/issues/684

**Workflow steps:**

Capture from a database with tables with nullable array columns and see that it now works when they contain `null` values.

**Documentation links affected:**

N/A

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/688)
<!-- Reviewable:end -->
