### PR TITLE
source-postgres: don't create FOR ALL TABLES publication

### DIFF
--- a/source-postgres/prerequisites.go
+++ b/source-postgres/prerequisites.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/estuary/connectors/sqlcapture"
 	"github.com/sirupsen/logrus"
@@ -17,6 +18,7 @@ func (db *postgresDatabase) SetupPrerequisites(ctx context.Context) []error {
 		db.prerequisiteReplicationSlot,
 		db.prerequisitePublication,
 		db.prerequisiteWatermarksTable,
+		db.prerequisiteWatermarksInPublication,
 	} {
 		if err := prereq(ctx); err != nil {
 			errs = append(errs, err)
@@ -84,11 +86,7 @@ func (db *postgresDatabase) prerequisitePublication(ctx context.Context) error {
 	}
 
 	logEntry.Info("attempting to create publication")
-	// TODO(wgd): We would like to stop using 'FOR ALL TABLES' at some point in the future
-	// (see https://github.com/estuary/connectors/issues/460), but this whole prerequisite-
-	// checking branch has gotten complicated enough already, so for now we'll keep doing
-	// this the same as before.
-	if _, err := db.conn.Exec(ctx, fmt.Sprintf(`CREATE PUBLICATION %s FOR ALL TABLES;`, pubName)); err != nil {
+	if _, err := db.conn.Exec(ctx, fmt.Sprintf(`CREATE PUBLICATION "%s";`, pubName)); err != nil {
 		return fmt.Errorf("publication %q doesn't exist and couldn't be created", pubName)
 	}
 
@@ -121,6 +119,22 @@ func (db *postgresDatabase) prerequisiteWatermarksTable(ctx context.Context) err
 	return fmt.Errorf("user %q cannot write to the watermarks table %q", db.config.User, table)
 }
 
+func (db *postgresDatabase) prerequisiteWatermarksInPublication(ctx context.Context) error {
+	// The watermarks table must be present in the publication. This assumes that the watermarks
+	// table and publication have already attempted to be created if they don't exist. If either the
+	// watermarks table or publication doesn't exist another error will be generated here which is a
+	// bit redundant.
+
+	var pubName = db.config.Advanced.PublicationName
+	var watermarks = db.config.Advanced.WatermarksTable
+
+	// (*Config).Validate() has previously verified that this value contains a period. The first
+	// part is the schema and the second part is the table.
+	tableParts := strings.Split(watermarks, ".")
+
+	return db.addTableToPublication(ctx, pubName, tableParts[0], tableParts[1])
+}
+
 func (db *postgresDatabase) SetupTablePrerequisites(ctx context.Context, schema, table string) error {
 	var rows, err = db.conn.Query(ctx, fmt.Sprintf(`SELECT * FROM "%s"."%s" LIMIT 0;`, schema, table))
 	rows.Close()
@@ -128,5 +142,47 @@ func (db *postgresDatabase) SetupTablePrerequisites(ctx context.Context, schema,
 		var streamID = sqlcapture.JoinStreamID(schema, table)
 		return fmt.Errorf("user %q cannot read from table %q", db.config.User, streamID)
 	}
+
+	return db.addTableToPublication(ctx, db.config.Advanced.PublicationName, schema, table)
+}
+
+// addTableToPublication adds a table to a publication if it isn't already part of that publication.
+func (db *postgresDatabase) addTableToPublication(ctx context.Context, pubName string, schema string, table string) error {
+	var logEntry = logrus.WithFields(logrus.Fields{
+		"publication": pubName,
+		"schema":      schema,
+		"table":       table,
+	})
+
+	// The table may have already been added to the publication by a previous invocation, or the
+	// publication was created as FOR ALL TABLES. In either case it will show up in this query, and
+	// we won't try to add it to the publication again.
+	var count int
+	if err := db.conn.QueryRow(ctx, fmt.Sprintf(`
+		SELECT COUNT(*) FROM pg_catalog.pg_publication_tables 
+		WHERE
+			pubname = '%s' AND
+			schemaname = '%s' AND
+			tablename = '%s';
+		`,
+		pubName,
+		schema,
+		table,
+	)).Scan(&count); err != nil {
+		return fmt.Errorf("error querying publications: %w", err)
+	}
+	if count == 1 {
+		logEntry.Debug("table is already part of publication")
+		return nil
+	}
+
+	logEntry.Info("attempting to add table to publication")
+
+	if _, err := db.conn.Exec(ctx, fmt.Sprintf(`ALTER PUBLICATION "%s" ADD TABLE "%s"."%s";`, pubName, schema, table)); err != nil {
+		return fmt.Errorf("could not add table %s.%s to publication %s", schema, table, pubName)
+	}
+
+	logEntry.Info("added table to publication")
+
 	return nil
 }


### PR DESCRIPTION
**Description:**

Up until now `source-postgres` has tried to create a "FOR ALL TABLES" publication if the configured publication did not exist. Creating this publication can cause problems for non-captured tables if those tables do not have a primary key and also do not have a replica identity. In this case the tables can no longer process updates and deletes, since they are included in the FOR ALL TABLES publication and these actions require a table that is part of a publication to have a replica identity. In short, we do not want our capture to have any side effects on non-captured tables.

With this change we'll instead create an "empty" publication at first if one doesn't already exist and ensure all required tables are part of it (including both captured tables and the watermarks table), adding them if they aren't part of it if possible and producing an error if any table is not part of the publication and can't be added to it.

Closes https://github.com/estuary/connectors/issues/460

**Workflow steps:**

Create a capture on a database with non-capture tables. These non-captured tables won't be added to the publication group. Only tables that are part of the capture are added, including any new tables that are later added to the capture.

**Documentation links affected:**

We should update the `source-postgres` docs. It currently has guidance to create a "FOR ALL TABLES" publication and should instead say to create a publication only for the captured tables if setting up the publication manually.

**Notes for reviewers:**

I don't like adding even more queries that have to run for every bound table every time the connector starts. But we were already doing a `SELECT * LIMIT 0 ...` to verify that we could read from every table so I don't think this change is going to make a huge difference on startup time.

Also note one other potential gotcha that didn't turn out to be that bad: backwards compatibility. Some existing connectors will have had the "FOR ALL TABLES" publication created. This still works just fine though since the connector will see that the publication exists and not try to re-create it, and also the tables will show up in the `SELECT COUNT(*) FROM pg_catalog.pg_publication_tables` just as if they were added explicitly. I did some testing with migrating captures made from the current `:dev` connector to this one and everything worked as expected.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/690)
<!-- Reviewable:end -->
