### PR TITLE
source-postgres: add table to publication error message update

### DIFF
--- a/source-postgres/prerequisites.go
+++ b/source-postgres/prerequisites.go
@@ -228,7 +228,7 @@ func (db *postgresDatabase) addTableToPublication(ctx context.Context, pubName s
 	logEntry.Info("attempting to add table to publication")
 
 	if _, err := db.conn.Exec(ctx, fmt.Sprintf(`ALTER PUBLICATION "%s" ADD TABLE "%s"."%s";`, pubName, schema, table)); err != nil {
-		return fmt.Errorf("could not add table %s.%s to publication %s", schema, table, pubName)
+		return fmt.Errorf("table %s.%s is not in publication %s and couldn't be added automatically", schema, table, pubName)
 	}
 
 	logEntry.Info("added table to publication")


### PR DESCRIPTION
**Description:**

This changes the error message in the case that a captured table is not part of the configured publication and can't be automatically added to it. For now it's consistent with other prerequisite check errors and carries with it an implication that the user will have to do something manually since the connector couldn't do it automatically.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

N/A

**Notes for reviewers:**

(anything that might help someone review this PR)

