### PR TITLE
MongoDB: assortment of issues

### DIFF
--- a/source-mongodb/discovery.go
+++ b/source-mongodb/discovery.go
@@ -98,6 +98,11 @@ func (d *driver) Discover(ctx context.Context, req *pc.Request_Discover) (*pc.Re
 
 	var bindings = []*pc.Response_Discovered_Binding{}
 	for _, collection := range collections {
+		// Views cannot be used with change streams, so we don't support them for
+		// capturing at the moment
+		if collection.Type == "view" {
+			continue
+		}
 		resourceJSON, err := json.Marshal(resource{Database: db.Name(), Collection: collection.Name})
 		if err != nil {
 			return nil, fmt.Errorf("serializing resource json: %w", err)

--- a/source-mongodb/pull.go
+++ b/source-mongodb/pull.go
@@ -54,7 +54,7 @@ func (d *driver) Pull(open *pc.Request_Open, stream *boilerplate.PullOutput) err
 		Output: stream,
 	}
 
-	eg, ctx := errgroup.WithContext(ctx)
+	eg, egCtx := errgroup.WithContext(ctx)
 
 	if err := c.Output.Ready(false); err != nil {
 		return err
@@ -78,11 +78,7 @@ func (d *driver) Pull(open *pc.Request_Open, stream *boilerplate.PullOutput) err
 		}
 
 		eg.Go(func() error {
-			var e = c.ChangeStream(ctx, client, idx, res, backfillFinishedAt, resState)
-			if e != nil {
-				log.WithField("error", e).WithField("collection", res.Collection).WithField("database", res.Database).Error("ChangeStream error")
-			}
-			return e
+			return c.ChangeStream(egCtx, client, idx, res, backfillFinishedAt, resState)
 		})
 	}
 


### PR DESCRIPTION
**Description:**

- Views cannot be used with `ChangeStream`, so we should exclude them from discovery process
- When sanitizing documents, we were not matching against `primitive.M` for nested objects (although `primitive.M` is a type alias for `map[string]interface{}` but it requires matching explicitly), so nested objects were not being sanitized, leading to `NaN` errors
- `ChangeStream` errors were not being surfaced properly, which lead to confusion when a `ChangeStream` would fail

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/697)
<!-- Reviewable:end -->
