### PR TITLE
source-mysql: require passwords be no longer that 32 characters in length

### DIFF
--- a/source-mysql/main.go
+++ b/source-mysql/main.go
@@ -140,6 +140,9 @@ func (c *Config) Validate() error {
 			return fmt.Errorf("missing '%s'", req[0])
 		}
 	}
+	if len(c.Password) > 32 {
+		return fmt.Errorf("passwords used as part of replication cannot exceed 32 characters in length due to an internal limitation in MySQL: password length of %d characters is too long, please use a shorter password", len(c.Password))
+	}
 	if c.Advanced.WatermarksTable != "" && !strings.Contains(c.Advanced.WatermarksTable, ".") {
 		return fmt.Errorf("invalid 'watermarksTable' configuration: table name %q must be fully-qualified as \"<schema>.<table>\"", c.Advanced.WatermarksTable)
 	}


### PR DESCRIPTION
**Description:**

Passwords used as part of replication in MySQL can't be longer than 32 characters in length, so this adds a validation check explaining that if the user has supplied a password that is too long.

This impacts both MySQL and MariaDB since they use the same connector. MariaDB doesn't actually have this limitation, but unless we did a lot more work to differentiate between MySQL and MariaDB this is the best we can do for now.

Closes https://github.com/estuary/connectors/issues/691

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

We should update the docs for MySQL and MariaDB.

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/699)
<!-- Reviewable:end -->
