### PR TITLE
source-mysql: Limit number of connection retry attempts

### DIFF
--- a/source-mysql/replication.go
+++ b/source-mysql/replication.go
@@ -72,6 +72,8 @@ func (db *mysqlDatabase) ReplicationStream(ctx context.Context, startCursor stri
 		TLSConfig: &tls.Config{InsecureSkipVerify: true},
 		// Request that timestamp values coming via replication be interpreted as UTC.
 		TimestampStringLocation: time.UTC,
+		// Limit connection retries so unreachability eventually bubbles up into task failure.
+		MaxReconnectAttempts: 10,
 	}
 
 	logrus.WithFields(logrus.Fields{"pos": pos}).Info("starting replication")


### PR DESCRIPTION
**Description:**

Apparently if the SSH tunnel breaks it's possible for the capture to get stuck trying to reconnect indefinitely, which will never work because the SSH process has shut down and won't be restarted.

Conveniently there's an option 'MaxReconnectAttempts' which places a finite limit on the number of connection retries the MySQL client library will perform, so that connection attempts failing will eventually become task failures and get retried at a higher level.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/700)
<!-- Reviewable:end -->
