### PR TITLE
materialize-snowflake: split internal stage PUTs into smaller files

### DIFF
--- a/materialize-snowflake/sqlgen.go
+++ b/materialize-snowflake/sqlgen.go
@@ -11,7 +11,6 @@ import (
 
 	sql "github.com/estuary/connectors/materialize-sql"
 	"github.com/estuary/flow/go/protocols/fdb/tuple"
-	"github.com/google/uuid"
 )
 
 // For historical reasons, we do not quote identifiers starting with an underscore or any letter,
@@ -251,7 +250,7 @@ FILE_FORMAT = (
 COMMENT = 'Internal stage used by Estuary Flow to stage loaded & stored documents'
 ;`
 
-func RenderTableWithRandomUUIDTemplate(table sql.Table, randomUUID uuid.UUID, tpl *template.Template) (string, error) {
+func RenderTableWithRandomUUIDTemplate(table sql.Table, randomUUID string, tpl *template.Template) (string, error) {
 	var w strings.Builder
 	if err := tpl.Execute(&w, &TableWithUUID{Table: &table, RandomUUID: randomUUID}); err != nil {
 		return "", err

--- a/materialize-snowflake/sqlgen_test.go
+++ b/materialize-snowflake/sqlgen_test.go
@@ -1,10 +1,10 @@
 package main
 
 import (
+	"encoding/json"
+	"os"
 	"strings"
 	"testing"
-	"os"
-	"encoding/json"
 	"text/template"
 
 	"github.com/bradleyjkemp/cupaloy"
@@ -17,7 +17,7 @@ import (
 func TestSQLGeneration(t *testing.T) {
 	var spec *pf.MaterializationSpec
 	var specJson, err = os.ReadFile("testdata/spec.json")
-  require.NoError(t, err)
+	require.NoError(t, err)
 	require.NoError(t, json.Unmarshal(specJson, &spec))
 
 	var shape1 = sqlDriver.BuildTableShape(spec, 0, tableConfig{
@@ -40,7 +40,7 @@ func TestSQLGeneration(t *testing.T) {
 	for _, tbl := range []sqlDriver.Table{table1, table2} {
 		withUUID := TableWithUUID{
 			Table:      &tbl,
-			RandomUUID: uuid.UUID{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15},
+			RandomUUID: uuid.UUID{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15}.String(),
 		}
 
 		for _, tpl := range []*template.Template{
@@ -75,7 +75,7 @@ func TestSQLGeneration(t *testing.T) {
 
 	tableNoValuesWithUUID := TableWithUUID{
 		Table:      &tableNoValues,
-		RandomUUID: uuid.UUID{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15},
+		RandomUUID: uuid.UUID{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15}.String(),
 	}
 
 	snap.WriteString("--- Begin " + "target_table_no_values_materialized mergeInto" + " ---")

--- a/materialize-snowflake/staged_file.go
+++ b/materialize-snowflake/staged_file.go
@@ -1,0 +1,249 @@
+package main
+
+import (
+	"bufio"
+	"context"
+	stdsql "database/sql"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/google/uuid"
+	"golang.org/x/sync/errgroup"
+)
+
+const (
+	// Per https://docs.snowflake.com/en/sql-reference/sql/put#usage-notes data file sizes are
+	// recommended to be in the 100-250 MB range for compressed data. We aren't currently using
+	// compression, but experimentally 250 MB seems to work well enough with uncompressed JSON.
+	fileSizeLimit = 250 * 1024 * 1024
+)
+
+// stagedFile manages uploading a sequence of local files produced by reading from Load/Store
+// iterators to an internal Snowflake stage. The same stagedFile should not be used concurrently
+// across multiple goroutines, but multiple concurrent processes can create their own stagedFile and
+// use them.
+//
+// The data to be staged is split into multiple files for a few reasons:
+//  - To allow for parallel processing within Snowflake
+//  - To enable some amount of concurrency between the network operations for PUTs and the encoding
+//    & writing of JSON data locally
+//  - To prevent any individual file from becoming excessively large, which seems to bog down the
+//    encryption process used within the go-snowflake driver
+//
+// Ideally we would stream directly to the Snowflake internal stage rather than reading from a local
+// disk file, but streaming PUTs do not currently work well and buffer exessive amounts of data
+// in-memory; see https://github.com/estuary/connectors/issues/50.
+//
+// The lifecycle of a staged file for a transaction is as follows:
+//
+// - start: Initializes the local directory for local disk files and clears the Snowflake stage of
+// any staged files from a previous transaction. Starts a worker that will concurrently send files
+// to Snowflake via PUT commands as local files are finished.
+//
+// - encodeRow: Encodes a slice of values as JSON and writes to the current local file. If the local
+// file has reached a size threshold a new file will be started. Finished files are sent to the
+// worker for staging in Snowflake.
+//
+// - flush: Sends the current & final local file to the worker for staging and waits for the worker
+// to complete before returning.
+
+type stagedFile struct {
+	// Random string that will serve as the directory for local files of this binding.
+	uuid string
+
+	// The full directory path of local files for this binding formed by joining tempdir and uuid.
+	dir string
+
+	// Indicates if the stagedFile has been initialized for this transaction yet. Set `true` by
+	// start() and `false` by flush().
+	started bool
+
+	// Index of the current file for this transaction. Starts at 0 and is incremented by 1 for each
+	// new file that is created.
+	fileIdx int
+
+	// References to the current file being written.
+	currentFile *os.File
+	writer      *bufio.Writer
+
+	// Amount of data written to the current file. A new file will be started when
+	// currentFileWritten > fileSizeLimit.
+	currentFileWritten int
+
+	// Per-transaction coordination.
+	putFiles chan string
+	flushed  chan struct{}
+	group    *errgroup.Group
+	groupCtx context.Context // Used to check for group cancellation upon the worker returning an error.
+}
+
+func newStagedFile(tempdir string) *stagedFile {
+	uuid := uuid.NewString()
+
+	return &stagedFile{
+		uuid: uuid,
+		dir:  filepath.Join(tempdir, uuid),
+	}
+}
+
+func (f *stagedFile) start(ctx context.Context, conn *stdsql.Conn) error {
+	if f.started {
+		return nil
+	}
+	f.started = true
+
+	// Create the local working directory for this binding. As a simplification we will always
+	// remove and re-create the directory since it will already exist for transactions beyond the
+	// first one.
+	if err := os.RemoveAll(f.dir); err != nil {
+		return fmt.Errorf("clearing temp dir: %w", err)
+	} else if err := os.Mkdir(f.dir, 0700); err != nil {
+		return fmt.Errorf("creating temp dir: %w", err)
+	}
+
+	// Clear the Snowflake stage directory of any existing files leftover from the last txn.
+	if _, err := conn.ExecContext(ctx, fmt.Sprintf(`REMOVE @flow_v1/%s;`, f.uuid)); err != nil {
+		return fmt.Errorf("clearing stage: %w", err)
+	}
+
+	// Sanity check: Make sure the Snowflake stage directory is really empty. As far as I can tell
+	// if the REMOVE command is successful it means that all files really were removed so
+	// theoretically this is a superfluous check, but the consequences of any lingering files in the
+	// directory are incorrect loaded data and this is a cheap check to be extra sure.
+	if rows, err := conn.QueryContext(ctx, fmt.Sprintf(`LIST @flow_v1/%s;`, f.uuid)); err != nil {
+		return fmt.Errorf("verifying stage empty: %w", err)
+	} else if rows.Next() {
+		return fmt.Errorf("unexpected existing file from LIST @flow_v1/%s", f.uuid)
+	} else {
+		rows.Close()
+	}
+
+	f.fileIdx = 0
+	if err := f.newFile(); err != nil {
+		return fmt.Errorf("creating first local staged file: %w", err)
+	}
+
+	// Reset values used per-transaction.
+	f.currentFileWritten = 0
+	f.flushed = make(chan struct{})
+	f.group, f.groupCtx = errgroup.WithContext(ctx)
+	f.putFiles = make(chan string)
+
+	// Start the putWorker for this transaction.
+	f.group.Go(func() error {
+		return f.putWorker(f.groupCtx, conn, f.putFiles)
+	})
+
+	return nil
+}
+
+func (f *stagedFile) encodeRow(row []interface{}) error {
+	jsonBytes, err := json.Marshal(row)
+	if err != nil {
+		return fmt.Errorf("marshaling row to json: %w", err)
+	}
+
+	// Concurrently start the PUT process for this file and start writing to a new file if the
+	// current file has reached fileSizeLimit.
+	if f.currentFileWritten > 0 && f.currentFileWritten+len(jsonBytes) > fileSizeLimit {
+		if err := f.putFile(); err != nil {
+			return fmt.Errorf("encodeRow putFile: %w", err)
+		} else if err := f.newFile(); err != nil {
+			return fmt.Errorf("encodeRow newFile: %w", err)
+		}
+	}
+
+	written, err := f.writer.Write(jsonBytes)
+	if err != nil {
+		return fmt.Errorf("encodeRow writing bytes: %w", err)
+	}
+	f.currentFileWritten += written
+
+	return nil
+}
+
+func (f *stagedFile) flush() error {
+	if err := f.putFile(); err != nil {
+		return fmt.Errorf("flush putFile: %w", err)
+	}
+
+	close(f.flushed)
+	f.started = false
+
+	// Wait for all outstanding PUT requests to complete.
+	return f.group.Wait()
+}
+
+func (f *stagedFile) putWorker(ctx context.Context, conn *stdsql.Conn, filePaths <-chan string) error {
+	for {
+		var file string
+
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-f.flushed:
+			return nil
+		case f := <-filePaths:
+			file = f
+		}
+
+		query := fmt.Sprintf(
+			// OVERWRITE=TRUE is set here not because we intend to overwrite anything, but rather to
+			// avoid an extra LIST query that setting OVERWRITE=FALSE incurs.
+			`PUT file://%s @flow_v1/%s AUTO_COMPRESS=FALSE SOURCE_COMPRESSION=NONE OVERWRITE=TRUE;`,
+			file, f.uuid,
+		)
+		var source, target, sourceSize, targetSize, sourceCompression, targetCompression, status, message string
+		if err := conn.QueryRowContext(ctx, query).Scan(&source, &target, &sourceSize, &targetSize, &sourceCompression, &targetCompression, &status, &message); err != nil {
+			return fmt.Errorf("putWorker PUT to stage: %w", err)
+		} else if !strings.EqualFold("uploaded", status) {
+			return fmt.Errorf("putWorker PUT to stage unexpected upload status: %s", status)
+		}
+
+		// Once the file has been staged to Snowflake we don't need it locally anymore and can
+		// remove the local copy to manage disk usage.
+		if err := os.Remove(file); err != nil {
+			return fmt.Errorf("putWorker removing local file: %w", err)
+		}
+	}
+}
+
+func (f *stagedFile) newFile() error {
+	filePath := filepath.Join(f.dir, fmt.Sprintf("%d", f.fileIdx))
+
+	file, err := os.Create(filePath)
+	if err != nil {
+		return err
+	}
+
+	f.currentFileWritten = 0
+	f.currentFile = file
+	f.writer = bufio.NewWriter(file)
+
+	f.fileIdx += 1
+
+	return nil
+}
+
+func (f *stagedFile) putFile() error {
+	if err := f.writer.Flush(); err != nil {
+		return fmt.Errorf("flushing writer: %w", err)
+	}
+
+	fname := f.currentFile.Name()
+	if err := f.currentFile.Close(); err != nil {
+		return fmt.Errorf("closing local file: %w", err)
+	}
+
+	select {
+	case <-f.groupCtx.Done():
+		// If the group worker has returned an error and cancelled the group context, return that
+		// rather than the general "context cancelled" error.
+		return f.group.Wait()
+	case f.putFiles <- fname:
+		return nil
+	}
+}

--- a/tests/materialize/materialize-snowflake/cleanup.sh
+++ b/tests/materialize/materialize-snowflake/cleanup.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+set -e
+
+function dropTable() {
+    go run ${TEST_DIR}/materialize-snowflake/fetch-data.go --delete "$1"
+}
+
+# Remove materialized tables.
+dropTable "Simple"
+dropTable "duplicate_keys_standard"
+dropTable "duplicate_keys_delta"
+dropTable "duplicate_keys_delta_exclude_flow_doc"
+dropTable "\"Multiple Types\""
+dropTable "\"Formatted Strings\""
+
+# Remove the persisted materialization spec & checkpoint for this test materialization so subsequent
+# runs start from scratch.
+go run ${TEST_DIR}/materialize-snowflake/fetch-data.go --delete-specs notable

--- a/tests/materialize/materialize-snowflake/fetch-data.go
+++ b/tests/materialize/materialize-snowflake/fetch-data.go
@@ -1,0 +1,119 @@
+package main
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+
+	sf "github.com/snowflakedb/gosnowflake"
+)
+
+func mustDSN() string {
+	var maxStatementCount string = "0"
+
+	conf := sf.Config{
+		Params: map[string]*string{
+			// By default Snowflake expects the number of statements to be provided
+			// with every request. By setting this parameter to zero we are allowing a
+			// variable number of statements to be executed in a single request
+			"MULTI_STATEMENT_COUNT": &maxStatementCount,
+		},
+	}
+
+	for _, prop := range []struct {
+		key  string
+		dest *string
+	}{
+		{"SNOWFLAKE_HOST", &conf.Host},
+		{"SNOWFLAKE_ACCOUNT", &conf.Account},
+		{"SNOWFLAKE_USER", &conf.User},
+		{"SNOWFLAKE_PASSWORD", &conf.Password},
+		{"SNOWFLAKE_DATABASE", &conf.Database},
+		{"SNOWFLAKE_SCHEMA", &conf.Schema},
+	} {
+		*prop.dest = os.Getenv(prop.key)
+	}
+
+	dsn, err := sf.DSN(&conf)
+	if err != nil {
+		panic(err)
+	}
+
+	return dsn
+}
+
+var deleteTable = flag.Bool("delete", false, "delete the table instead of dumping its contents")
+var deleteSpecs = flag.Bool("delete-specs", false, "stored materialize checkpoint and specs")
+
+func main() {
+	flag.Parse()
+
+	tables := flag.Args()
+	if len(tables) != 1 {
+		log.Fatal("must provide single table name as an argument")
+	}
+
+	ctx := context.Background()
+
+	db, err := sql.Open("snowflake", mustDSN())
+	if err != nil {
+		log.Fatal(fmt.Errorf("opening snowflake: %w", err))
+	} else if err := db.PingContext(ctx); err != nil {
+		log.Fatal(fmt.Errorf("connecting to snowflake: %w", err))
+	}
+
+	// Handle cleanup cases of for dropping a table and deleting the stored materialization spec &
+	// checkpoint if flags were provided.
+	if *deleteTable {
+		query := fmt.Sprintf("DROP TABLE %s;", tables[0])
+		if _, err := db.ExecContext(ctx, query); err != nil {
+			fmt.Println(fmt.Errorf("could not drop table %s: %w", tables[0], err))
+		}
+		fmt.Printf("dropped table %s\n", tables[0])
+		os.Exit(0)
+	} else if *deleteSpecs {
+		query := "delete from FLOW_CHECKPOINTS_V1 where MATERIALIZATION='tests/materialize-snowflake/materialize';delete from FLOW_MATERIALIZATIONS_V2 where MATERIALIZATION='tests/materialize-snowflake/materialize';"
+		if _, err := db.ExecContext(ctx, query); err != nil {
+			fmt.Println(fmt.Errorf("could not delete stored materialization spec/checkpoint: %w", err))
+		}
+		fmt.Println("deleted stored materialization spec & checkpoint")
+		os.Exit(0)
+	}
+
+	query := fmt.Sprintf("SELECT * FROM %s ORDER BY id;", tables[0])
+
+	rows, err := db.QueryContext(ctx, query)
+	if err != nil {
+		log.Fatal(fmt.Errorf("queryContext: %w", err))
+	}
+
+	cols, err := rows.Columns()
+	if err != nil {
+		log.Fatal(fmt.Errorf("getting columns: %w", err))
+	}
+
+	data := make([]interface{}, len(cols))
+	ptrs := make([]interface{}, len(cols))
+	for i := range data {
+		ptrs[i] = &data[i]
+	}
+
+	queriedRows := [][]interface{}{}
+
+	for rows.Next() {
+		if err = rows.Scan(ptrs...); err != nil {
+			log.Fatal("scanning row: %w", err)
+		}
+		queriedRows = append(queriedRows, append([]interface{}{}, data...))
+	}
+	rows.Close()
+
+	var enc = json.NewEncoder(os.Stdout)
+	for _, row := range queriedRows {
+		enc.Encode(row)
+	}
+}

--- a/tests/materialize/materialize-snowflake/fetch.sh
+++ b/tests/materialize/materialize-snowflake/fetch.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+set -o errexit
+set -o pipefail
+set -o nounset
+
+function exportToJsonl() {
+  go run ${TEST_DIR}/materialize-snowflake/fetch-data.go "$1"
+}
+
+exportToJsonl "Simple"
+exportToJsonl "duplicate_keys_standard"
+exportToJsonl "duplicate_keys_delta"
+exportToJsonl "duplicate_keys_delta_exclude_flow_doc"
+exportToJsonl "\"Multiple Types\""
+exportToJsonl "\"Formatted Strings\""

--- a/tests/materialize/materialize-snowflake/setup.sh
+++ b/tests/materialize/materialize-snowflake/setup.sh
@@ -1,0 +1,88 @@
+#!/bin/bash
+
+set -o errexit
+set -o pipefail
+set -o nounset
+
+export SNOWFLAKE_HOST="${SNOWFLAKE_HOST}"
+export SNOWFLAKE_ACCOUNT="${SNOWFLAKE_ACCOUNT}"
+export SNOWFLAKE_USER="${SNOWFLAKE_USER}"
+export SNOWFLAKE_PASSWORD="${SNOWFLAKE_PASSWORD}"
+export SNOWFLAKE_DATABASE="${SNOWFLAKE_DATABASE}"
+export SNOWFLAKE_SCHEMA="${SNOWFLAKE_SCHEMA}"
+
+config_json_template='{
+   "host":      "$SNOWFLAKE_HOST",
+   "account":   "$SNOWFLAKE_ACCOUNT",
+   "user":      "$SNOWFLAKE_USER",
+   "password":  "$SNOWFLAKE_PASSWORD",
+   "database":  "$SNOWFLAKE_DATABASE",
+   "schema":    "$SNOWFLAKE_SCHEMA"
+}'
+
+resources_json_template='[
+  {
+    "resource": {
+      "table": "Simple"
+    },
+    "source": "${TEST_COLLECTION_SIMPLE}"
+  },
+  {
+    "resource": {
+      "table": "duplicate_keys_standard"
+    },
+    "source": "${TEST_COLLECTION_DUPLICATED_KEYS}"
+  },
+  {
+    "resource": {
+      "table": "duplicate_keys_delta",
+      "delta_updates": true
+    },
+    "source": "${TEST_COLLECTION_DUPLICATED_KEYS}"
+  },
+  {
+    "resource": {
+      "table": "duplicate_keys_delta_exclude_flow_doc",
+      "delta_updates": true
+    },
+    "source": "${TEST_COLLECTION_DUPLICATED_KEYS}",
+    "fields": {
+      "recommended": true,
+      "exclude": [
+        "flow_document" 
+      ]
+    }
+  },
+  {
+    "resource": {
+      "table": "Multiple Types"
+    },
+    "source": "${TEST_COLLECTION_MULTIPLE_DATATYPES}",
+    "fields": {
+      "recommended": true,
+      "exclude": ["nested/id"],
+      "include": {
+        "nested": {},
+        "array_int": {}
+      }
+    }
+  },
+  {
+    "resource": {
+      "table": "Formatted Strings"
+    },
+    "source": "${TEST_COLLECTION_FORMATTED_STRINGS}",
+    "fields": {
+      "recommended": true,
+      "include": {
+        "int_and_str": {},
+        "num_and_str": {},
+        "int_str": {},
+        "num_str": {}
+      }
+    }
+  }
+]'
+
+export CONNECTOR_CONFIG="$(echo "$config_json_template" | envsubst | jq -c)"
+export RESOURCES_CONFIG="$(echo "$resources_json_template" | envsubst | jq -c)"

--- a/tests/materialize/materialize-snowflake/snapshot.json
+++ b/tests/materialize/materialize-snowflake/snapshot.json
@@ -1,0 +1,525 @@
+{
+  "applied": {
+    "actionDescription": "\n  CREATE TABLE IF NOT EXISTS flow_materializations_v2 (\n    materialization STRING NOT NULL,\n    version STRING NOT NULL,\n    spec STRING NOT NULL,\n\n    PRIMARY KEY (materialization)\n  );\n\n  COMMENT ON TABLE flow_materializations_v2 IS 'This table is the source of truth for all materializations into this system.';\n  COMMENT ON COLUMN flow_materializations_v2.materialization IS 'The name of the materialization.';\n  COMMENT ON COLUMN flow_materializations_v2.version IS 'Version of the materialization.';\n  COMMENT ON COLUMN flow_materializations_v2.spec IS 'Specification of the materialization, encoded as base64 protobuf.';\n  \n\n  CREATE TABLE IF NOT EXISTS flow_checkpoints_v1 (\n    materialization STRING NOT NULL,\n    key_begin INTEGER NOT NULL,\n    key_end INTEGER NOT NULL,\n    fence INTEGER NOT NULL,\n    checkpoint STRING NOT NULL,\n\n    PRIMARY KEY (materialization, key_begin, key_end)\n  );\n\n  COMMENT ON TABLE flow_checkpoints_v1 IS 'This table holds Flow processing checkpoints used for exactly-once processing of materializations';\n  COMMENT ON COLUMN flow_checkpoints_v1.materialization IS 'The name of the materialization.';\n  COMMENT ON COLUMN flow_checkpoints_v1.key_begin IS 'The inclusive lower-bound key hash covered by this checkpoint.';\n  COMMENT ON COLUMN flow_checkpoints_v1.key_end IS 'The inclusive upper-bound key hash covered by this checkpoint.';\n  COMMENT ON COLUMN flow_checkpoints_v1.fence IS 'This nonce is used to uniquely identify unique process assignments of a shard and prevent them from conflicting.';\n  COMMENT ON COLUMN flow_checkpoints_v1.checkpoint IS 'Checkpoint of the Flow consumer shard, encoded as base64 protobuf.';\n  \n\n  CREATE TABLE IF NOT EXISTS Simple (\n    id INTEGER NOT NULL,\n    canary STRING NOT NULL,\n    flow_document VARIANT NOT NULL,\n\n    PRIMARY KEY (id)\n  );\n\n  COMMENT ON TABLE Simple IS 'Generated for materialization tests/materialize-snowflake/materialize of collection tests/simple';\n  COMMENT ON COLUMN Simple.id IS 'auto-generated projection of JSON at: /id with inferred types: [integer]';\n  COMMENT ON COLUMN Simple.canary IS 'auto-generated projection of JSON at: /canary with inferred types: [string]';\n  COMMENT ON COLUMN Simple.flow_document IS 'auto-generated projection of JSON at:  with inferred types: [object]';\n  \n\n  CREATE TABLE IF NOT EXISTS duplicate_keys_standard (\n    id INTEGER NOT NULL,\n    int INTEGER,\n    str STRING,\n    flow_document VARIANT NOT NULL,\n\n    PRIMARY KEY (id)\n  );\n\n  COMMENT ON TABLE duplicate_keys_standard IS 'Generated for materialization tests/materialize-snowflake/materialize of collection tests/duplicated-keys';\n  COMMENT ON COLUMN duplicate_keys_standard.id IS 'auto-generated projection of JSON at: /id with inferred types: [integer]';\n  COMMENT ON COLUMN duplicate_keys_standard.int IS 'auto-generated projection of JSON at: /int with inferred types: [integer]';\n  COMMENT ON COLUMN duplicate_keys_standard.str IS 'auto-generated projection of JSON at: /str with inferred types: [string]';\n  COMMENT ON COLUMN duplicate_keys_standard.flow_document IS 'auto-generated projection of JSON at:  with inferred types: [object]';\n  \n\n  CREATE TABLE IF NOT EXISTS duplicate_keys_delta (\n    id INTEGER NOT NULL,\n    int INTEGER,\n    str STRING,\n    flow_document VARIANT NOT NULL\n  );\n\n  COMMENT ON TABLE duplicate_keys_delta IS 'Generated for materialization tests/materialize-snowflake/materialize of collection tests/duplicated-keys';\n  COMMENT ON COLUMN duplicate_keys_delta.id IS 'auto-generated projection of JSON at: /id with inferred types: [integer]';\n  COMMENT ON COLUMN duplicate_keys_delta.int IS 'auto-generated projection of JSON at: /int with inferred types: [integer]';\n  COMMENT ON COLUMN duplicate_keys_delta.str IS 'auto-generated projection of JSON at: /str with inferred types: [string]';\n  COMMENT ON COLUMN duplicate_keys_delta.flow_document IS 'auto-generated projection of JSON at:  with inferred types: [object]';\n  \n\n  CREATE TABLE IF NOT EXISTS duplicate_keys_delta_exclude_flow_doc (\n    id INTEGER NOT NULL,\n    int INTEGER,\n    str STRING\n  );\n\n  COMMENT ON TABLE duplicate_keys_delta_exclude_flow_doc IS 'Generated for materialization tests/materialize-snowflake/materialize of collection tests/duplicated-keys';\n  COMMENT ON COLUMN duplicate_keys_delta_exclude_flow_doc.id IS 'auto-generated projection of JSON at: /id with inferred types: [integer]';\n  COMMENT ON COLUMN duplicate_keys_delta_exclude_flow_doc.int IS 'auto-generated projection of JSON at: /int with inferred types: [integer]';\n  COMMENT ON COLUMN duplicate_keys_delta_exclude_flow_doc.str IS 'auto-generated projection of JSON at: /str with inferred types: [string]';\n  \n\n  CREATE TABLE IF NOT EXISTS \"Multiple Types\" (\n    id INTEGER NOT NULL,\n    array_int VARIANT,\n    bool_field BOOLEAN,\n    float_field DOUBLE,\n    nested VARIANT,\n    nullable_int INTEGER,\n    str_field STRING,\n    flow_document VARIANT NOT NULL,\n\n    PRIMARY KEY (id)\n  );\n\n  COMMENT ON TABLE \"Multiple Types\" IS 'Generated for materialization tests/materialize-snowflake/materialize of collection tests/multiple-data-types';\n  COMMENT ON COLUMN \"Multiple Types\".id IS 'auto-generated projection of JSON at: /id with inferred types: [integer]';\n  COMMENT ON COLUMN \"Multiple Types\".array_int IS 'auto-generated projection of JSON at: /array_int with inferred types: [array]';\n  COMMENT ON COLUMN \"Multiple Types\".bool_field IS 'auto-generated projection of JSON at: /bool_field with inferred types: [boolean]';\n  COMMENT ON COLUMN \"Multiple Types\".float_field IS 'auto-generated projection of JSON at: /float_field with inferred types: [number]';\n  COMMENT ON COLUMN \"Multiple Types\".nested IS 'auto-generated projection of JSON at: /nested with inferred types: [object]';\n  COMMENT ON COLUMN \"Multiple Types\".nullable_int IS 'auto-generated projection of JSON at: /nullable_int with inferred types: [integer null]';\n  COMMENT ON COLUMN \"Multiple Types\".str_field IS 'auto-generated projection of JSON at: /str_field with inferred types: [string]';\n  COMMENT ON COLUMN \"Multiple Types\".flow_document IS 'auto-generated projection of JSON at:  with inferred types: [object]';\n  \n\n  CREATE TABLE IF NOT EXISTS \"Formatted Strings\" (\n    id INTEGER NOT NULL,\n    int_and_str INTEGER,\n    int_str INTEGER,\n    num_and_str DOUBLE,\n    num_str DOUBLE,\n    flow_document VARIANT NOT NULL,\n\n    PRIMARY KEY (id)\n  );\n\n  COMMENT ON TABLE \"Formatted Strings\" IS 'Generated for materialization tests/materialize-snowflake/materialize of collection tests/formatted-strings';\n  COMMENT ON COLUMN \"Formatted Strings\".id IS 'auto-generated projection of JSON at: /id with inferred types: [integer]';\n  COMMENT ON COLUMN \"Formatted Strings\".int_and_str IS 'auto-generated projection of JSON at: /int_and_str with inferred types: [integer string]';\n  COMMENT ON COLUMN \"Formatted Strings\".int_str IS 'auto-generated projection of JSON at: /int_str with inferred types: [string]';\n  COMMENT ON COLUMN \"Formatted Strings\".num_and_str IS 'auto-generated projection of JSON at: /num_and_str with inferred types: [number string]';\n  COMMENT ON COLUMN \"Formatted Strings\".num_str IS 'auto-generated projection of JSON at: /num_str with inferred types: [string]';\n  COMMENT ON COLUMN \"Formatted Strings\".flow_document IS 'auto-generated projection of JSON at:  with inferred types: [object]';\n  \nINSERT INTO flow_materializations_v2 (version, spec, materialization) VALUES ('test', '(a-base64-encoded-value)', 'tests/materialize-snowflake/materialize');"
+  }
+}
+{
+  "opened": {
+    "runtimeCheckpoint": {}
+  }
+}
+{
+  "acknowledged": {}
+}
+{
+  "flushed": {}
+}
+{
+  "startedCommit": {}
+}
+{
+  "acknowledged": {}
+}
+{
+  "loaded": {
+    "binding": 1,
+    "doc": {
+      "id": 1,
+      "int": 1,
+      "str": "str 1"
+    }
+  }
+}
+{
+  "loaded": {
+    "binding": 1,
+    "doc": {
+      "id": 2,
+      "int": 2,
+      "str": "str 2"
+    }
+  }
+}
+{
+  "loaded": {
+    "binding": 1,
+    "doc": {
+      "id": 3,
+      "int": 3,
+      "str": "str 3"
+    }
+  }
+}
+{
+  "loaded": {
+    "binding": 1,
+    "doc": {
+      "id": 4,
+      "int": 4,
+      "str": "str 4"
+    }
+  }
+}
+{
+  "loaded": {
+    "binding": 1,
+    "doc": {
+      "id": 5,
+      "int": 5,
+      "str": "str 5"
+    }
+  }
+}
+{
+  "loaded": {
+    "binding": 4,
+    "doc": {
+      "array_int": [
+        1,
+        2
+      ],
+      "bool_field": true,
+      "float_field": 10.1,
+      "id": 10,
+      "nested": {
+        "id": "i10"
+      },
+      "nullable_int": 10,
+      "str_field": "str10"
+    }
+  }
+}
+{
+  "loaded": {
+    "binding": 4,
+    "doc": {
+      "array_int": [
+        61,
+        62
+      ],
+      "bool_field": true,
+      "float_field": 6.6,
+      "id": 6,
+      "nested": {
+        "id": "i6"
+      },
+      "nullable_int": 6,
+      "str_field": "str6"
+    }
+  }
+}
+{
+  "loaded": {
+    "binding": 4,
+    "doc": {
+      "array_int": [
+        71,
+        72
+      ],
+      "bool_field": false,
+      "float_field": 7.7,
+      "id": 7,
+      "nested": {
+        "id": "i7"
+      },
+      "nullable_int": null,
+      "str_field": "str7"
+    }
+  }
+}
+{
+  "loaded": {
+    "binding": 4,
+    "doc": {
+      "array_int": [
+        81,
+        82
+      ],
+      "bool_field": true,
+      "float_field": 8.8,
+      "id": 8,
+      "nested": {
+        "id": "i8"
+      },
+      "nullable_int": 8,
+      "str_field": "str8"
+    }
+  }
+}
+{
+  "loaded": {
+    "binding": 4,
+    "doc": {
+      "array_int": [
+        91,
+        92
+      ],
+      "bool_field": false,
+      "float_field": 9.9,
+      "id": 9,
+      "nested": {
+        "id": "i9"
+      },
+      "nullable_int": null,
+      "str_field": "str9"
+    }
+  }
+}
+{
+  "flushed": {}
+}
+{
+  "startedCommit": {}
+}
+{
+  "acknowledged": {}
+}
+[
+  "1",
+  "amputation's",
+  "{\n  \"canary\": \"amputation's\",\n  \"id\": 1\n}"
+]
+[
+  "2",
+  "armament's",
+  "{\n  \"canary\": \"armament's\",\n  \"id\": 2\n}"
+]
+[
+  "3",
+  "splatters",
+  "{\n  \"canary\": \"splatters\",\n  \"id\": 3\n}"
+]
+[
+  "4",
+  "strengthen",
+  "{\n  \"canary\": \"strengthen\",\n  \"id\": 4\n}"
+]
+[
+  "5",
+  "Kringle's",
+  "{\n  \"canary\": \"Kringle's\",\n  \"id\": 5\n}"
+]
+[
+  "6",
+  "grosbeak's",
+  "{\n  \"canary\": \"grosbeak's\",\n  \"id\": 6\n}"
+]
+[
+  "7",
+  "pieced",
+  "{\n  \"canary\": \"pieced\",\n  \"id\": 7\n}"
+]
+[
+  "8",
+  "roaches",
+  "{\n  \"canary\": \"roaches\",\n  \"id\": 8\n}"
+]
+[
+  "9",
+  "devilish",
+  "{\n  \"canary\": \"devilish\",\n  \"id\": 9\n}"
+]
+[
+  "10",
+  "glucose's",
+  "{\n  \"canary\": \"glucose's\",\n  \"id\": 10\n}"
+]
+[
+  "1",
+  "6",
+  "str 6",
+  "{\n  \"id\": 1,\n  \"int\": 6,\n  \"str\": \"str 6\"\n}"
+]
+[
+  "2",
+  "7",
+  "str 7",
+  "{\n  \"id\": 2,\n  \"int\": 7,\n  \"str\": \"str 7\"\n}"
+]
+[
+  "3",
+  "8",
+  "str 8",
+  "{\n  \"id\": 3,\n  \"int\": 8,\n  \"str\": \"str 8\"\n}"
+]
+[
+  "4",
+  "9",
+  "str 9",
+  "{\n  \"id\": 4,\n  \"int\": 9,\n  \"str\": \"str 9\"\n}"
+]
+[
+  "5",
+  "10",
+  "str 10",
+  "{\n  \"id\": 5,\n  \"int\": 10,\n  \"str\": \"str 10\"\n}"
+]
+[
+  "1",
+  "1",
+  "str 1",
+  "{\n  \"id\": 1,\n  \"int\": 1,\n  \"str\": \"str 1\"\n}"
+]
+[
+  "1",
+  "6",
+  "str 6",
+  "{\n  \"id\": 1,\n  \"int\": 6,\n  \"str\": \"str 6\"\n}"
+]
+[
+  "2",
+  "2",
+  "str 2",
+  "{\n  \"id\": 2,\n  \"int\": 2,\n  \"str\": \"str 2\"\n}"
+]
+[
+  "2",
+  "7",
+  "str 7",
+  "{\n  \"id\": 2,\n  \"int\": 7,\n  \"str\": \"str 7\"\n}"
+]
+[
+  "3",
+  "3",
+  "str 3",
+  "{\n  \"id\": 3,\n  \"int\": 3,\n  \"str\": \"str 3\"\n}"
+]
+[
+  "3",
+  "8",
+  "str 8",
+  "{\n  \"id\": 3,\n  \"int\": 8,\n  \"str\": \"str 8\"\n}"
+]
+[
+  "4",
+  "4",
+  "str 4",
+  "{\n  \"id\": 4,\n  \"int\": 4,\n  \"str\": \"str 4\"\n}"
+]
+[
+  "4",
+  "9",
+  "str 9",
+  "{\n  \"id\": 4,\n  \"int\": 9,\n  \"str\": \"str 9\"\n}"
+]
+[
+  "5",
+  "5",
+  "str 5",
+  "{\n  \"id\": 5,\n  \"int\": 5,\n  \"str\": \"str 5\"\n}"
+]
+[
+  "5",
+  "10",
+  "str 10",
+  "{\n  \"id\": 5,\n  \"int\": 10,\n  \"str\": \"str 10\"\n}"
+]
+[
+  "1",
+  "1",
+  "str 1"
+]
+[
+  "1",
+  "6",
+  "str 6"
+]
+[
+  "2",
+  "2",
+  "str 2"
+]
+[
+  "2",
+  "7",
+  "str 7"
+]
+[
+  "3",
+  "3",
+  "str 3"
+]
+[
+  "3",
+  "8",
+  "str 8"
+]
+[
+  "4",
+  "4",
+  "str 4"
+]
+[
+  "4",
+  "9",
+  "str 9"
+]
+[
+  "5",
+  "5",
+  "str 5"
+]
+[
+  "5",
+  "10",
+  "str 10"
+]
+[
+  "1",
+  "[\n  11,\n  12\n]",
+  false,
+  1.1,
+  "{\n  \"id\": \"i1\"\n}",
+  null,
+  "str1",
+  "{\n  \"array_int\": [\n    11,\n    12\n  ],\n  \"bool_field\": false,\n  \"float_field\": 1.1,\n  \"id\": 1,\n  \"nested\": {\n    \"id\": \"i1\"\n  },\n  \"nullable_int\": null,\n  \"str_field\": \"str1\"\n}"
+]
+[
+  "2",
+  "[\n  21,\n  22\n]",
+  true,
+  2.2,
+  "{\n  \"id\": \"i2\"\n}",
+  "2",
+  "str2",
+  "{\n  \"array_int\": [\n    21,\n    22\n  ],\n  \"bool_field\": true,\n  \"float_field\": 2.2,\n  \"id\": 2,\n  \"nested\": {\n    \"id\": \"i2\"\n  },\n  \"nullable_int\": 2,\n  \"str_field\": \"str2\"\n}"
+]
+[
+  "3",
+  "[\n  31,\n  32\n]",
+  false,
+  3.3,
+  "{\n  \"id\": \"i3\"\n}",
+  null,
+  "str3",
+  "{\n  \"array_int\": [\n    31,\n    32\n  ],\n  \"bool_field\": false,\n  \"float_field\": 3.3,\n  \"id\": 3,\n  \"nested\": {\n    \"id\": \"i3\"\n  },\n  \"nullable_int\": null,\n  \"str_field\": \"str3\"\n}"
+]
+[
+  "4",
+  "[\n  41,\n  42\n]",
+  true,
+  4.4,
+  "{\n  \"id\": \"i4\"\n}",
+  "4",
+  "str4",
+  "{\n  \"array_int\": [\n    41,\n    42\n  ],\n  \"bool_field\": true,\n  \"float_field\": 4.4,\n  \"id\": 4,\n  \"nested\": {\n    \"id\": \"i4\"\n  },\n  \"nullable_int\": 4,\n  \"str_field\": \"str4\"\n}"
+]
+[
+  "5",
+  "[\n  51,\n  52\n]",
+  false,
+  5.5,
+  "{\n  \"id\": \"i5\"\n}",
+  null,
+  "str5",
+  "{\n  \"array_int\": [\n    51,\n    52\n  ],\n  \"bool_field\": false,\n  \"float_field\": 5.5,\n  \"id\": 5,\n  \"nested\": {\n    \"id\": \"i5\"\n  },\n  \"nullable_int\": null,\n  \"str_field\": \"str5\"\n}"
+]
+[
+  "6",
+  "[\n  61,\n  62\n]",
+  true,
+  66.66,
+  "{\n  \"id\": \"i6\"\n}",
+  "6",
+  "str6 v2",
+  "{\n  \"array_int\": [\n    61,\n    62\n  ],\n  \"bool_field\": true,\n  \"float_field\": 66.66,\n  \"id\": 6,\n  \"nested\": {\n    \"id\": \"i6\"\n  },\n  \"nullable_int\": 6,\n  \"str_field\": \"str6 v2\"\n}"
+]
+[
+  "7",
+  "[\n  71,\n  72\n]",
+  false,
+  77.77,
+  "{\n  \"id\": \"i7\"\n}",
+  null,
+  "str7 v2",
+  "{\n  \"array_int\": [\n    71,\n    72\n  ],\n  \"bool_field\": false,\n  \"float_field\": 77.77,\n  \"id\": 7,\n  \"nested\": {\n    \"id\": \"i7\"\n  },\n  \"nullable_int\": null,\n  \"str_field\": \"str7 v2\"\n}"
+]
+[
+  "8",
+  "[\n  81,\n  82\n]",
+  true,
+  88.88,
+  "{\n  \"id\": \"i8\"\n}",
+  "8",
+  "str8 v2",
+  "{\n  \"array_int\": [\n    81,\n    82\n  ],\n  \"bool_field\": true,\n  \"float_field\": 88.88,\n  \"id\": 8,\n  \"nested\": {\n    \"id\": \"i8\"\n  },\n  \"nullable_int\": 8,\n  \"str_field\": \"str8 v2\"\n}"
+]
+[
+  "9",
+  "[\n  91,\n  92\n]",
+  false,
+  99.99,
+  "{\n  \"id\": \"i9\"\n}",
+  null,
+  "str9 v2",
+  "{\n  \"array_int\": [\n    91,\n    92\n  ],\n  \"bool_field\": false,\n  \"float_field\": 99.99,\n  \"id\": 9,\n  \"nested\": {\n    \"id\": \"i9\"\n  },\n  \"nullable_int\": null,\n  \"str_field\": \"str9 v2\"\n}"
+]
+[
+  "10",
+  "[\n  1,\n  2\n]",
+  true,
+  1010.101,
+  "{\n  \"id\": \"i10\"\n}",
+  "10",
+  "str10 v2",
+  "{\n  \"array_int\": [\n    1,\n    2\n  ],\n  \"bool_field\": true,\n  \"float_field\": 1010.101,\n  \"id\": 10,\n  \"nested\": {\n    \"id\": \"i10\"\n  },\n  \"nullable_int\": 10,\n  \"str_field\": \"str10 v2\"\n}"
+]
+[
+  "1",
+  "1",
+  "10",
+  1.1,
+  10.1,
+  "{\n  \"id\": 1,\n  \"int_and_str\": 1,\n  \"int_str\": \"10\",\n  \"num_and_str\": 1.1,\n  \"num_str\": \"10.1\"\n}"
+]
+[
+  "2",
+  "2",
+  "20",
+  2.1,
+  20.1,
+  "{\n  \"id\": 2,\n  \"int_and_str\": 2,\n  \"int_str\": \"20\",\n  \"num_and_str\": 2.1,\n  \"num_str\": \"20.1\"\n}"
+]
+[
+  "3",
+  "3",
+  "30",
+  3.1,
+  30.1,
+  "{\n  \"id\": 3,\n  \"int_and_str\": 3,\n  \"int_str\": \"30\",\n  \"num_and_str\": 3.1,\n  \"num_str\": \"30.1\"\n}"
+]
+[
+  "4",
+  "4",
+  "40",
+  4.1,
+  40.1,
+  "{\n  \"id\": 4,\n  \"int_and_str\": \"4\",\n  \"int_str\": \"40\",\n  \"num_and_str\": \"4.1\",\n  \"num_str\": \"40.1\"\n}"
+]
+[
+  "5",
+  "5",
+  "50",
+  5.1,
+  50.1,
+  "{\n  \"id\": 5,\n  \"int_and_str\": \"5\",\n  \"int_str\": \"50\",\n  \"num_and_str\": \"5.1\",\n  \"num_str\": \"50.1\"\n}"
+]
+{
+  "applied": {
+    "actionDescription": "\n  CREATE TABLE IF NOT EXISTS flow_materializations_v2 (\n    materialization STRING NOT NULL,\n    version STRING NOT NULL,\n    spec STRING NOT NULL,\n\n    PRIMARY KEY (materialization)\n  );\n\n  COMMENT ON TABLE flow_materializations_v2 IS 'This table is the source of truth for all materializations into this system.';\n  COMMENT ON COLUMN flow_materializations_v2.materialization IS 'The name of the materialization.';\n  COMMENT ON COLUMN flow_materializations_v2.version IS 'Version of the materialization.';\n  COMMENT ON COLUMN flow_materializations_v2.spec IS 'Specification of the materialization, encoded as base64 protobuf.';\n  \n\n  CREATE TABLE IF NOT EXISTS flow_checkpoints_v1 (\n    materialization STRING NOT NULL,\n    key_begin INTEGER NOT NULL,\n    key_end INTEGER NOT NULL,\n    fence INTEGER NOT NULL,\n    checkpoint STRING NOT NULL,\n\n    PRIMARY KEY (materialization, key_begin, key_end)\n  );\n\n  COMMENT ON TABLE flow_checkpoints_v1 IS 'This table holds Flow processing checkpoints used for exactly-once processing of materializations';\n  COMMENT ON COLUMN flow_checkpoints_v1.materialization IS 'The name of the materialization.';\n  COMMENT ON COLUMN flow_checkpoints_v1.key_begin IS 'The inclusive lower-bound key hash covered by this checkpoint.';\n  COMMENT ON COLUMN flow_checkpoints_v1.key_end IS 'The inclusive upper-bound key hash covered by this checkpoint.';\n  COMMENT ON COLUMN flow_checkpoints_v1.fence IS 'This nonce is used to uniquely identify unique process assignments of a shard and prevent them from conflicting.';\n  COMMENT ON COLUMN flow_checkpoints_v1.checkpoint IS 'Checkpoint of the Flow consumer shard, encoded as base64 protobuf.';\n  \nUPDATE flow_materializations_v2 SET version = 'test', spec = '(a-base64-encoded-value)' WHERE materialization = 'tests/materialize-snowflake/materialize';"
+  }
+}
+{
+  "opened": {
+    "runtimeCheckpoint": {
+      "sources": {
+        "a/read/journal;suffix": {
+          "readThrough": "1"
+        }
+      }
+    }
+  }
+}
+{
+  "acknowledged": {}
+}


### PR DESCRIPTION
**Description:**

We've been uploading data as one large file per binding to Snowflake for staging data, and that has resulted in a few problems:
- Most significantly, the `gosnowflake` driver seems to get bogged down encrypting these files when they are multiple gigabytes in size, which is typical for a non-trivial transaction duration.
- The upload for large files apparently fails entirely if they are too large under some circumstances, resulting in an endless loop of extremely long encryption followed by failed uploads.
- Snowflake can process many small files in parallel, which should offer performance improvement vs. a single large file

This changes the file staging to split the data up into a series of smaller files which are then collectively queried together. The PUTs to Snowflake internal stages can be completed concurrently with populating additional local files, and the smaller local file sizes allow for much faster encryption.

The performance benefits will be evident when running "catch up" materializations on larger datasets. Some rough benchmarking I did with a ~10GB dataset indicates a 2-3x improvement over the current version, with the new version using a 5 minute `maxTxnDuration` and the current version using a 1 second `maxTxnDuration`. This may seem like a strange comparison, but the current version crashes under extended transactions and actually performs best when it using the smallest possible transactions. 10 GB really isn't much in the grand scheme of things, and I expect more of a benefit on even larger datasets.

To test this change, I created a new integration test for `materialize-snowflake` and verified that the snapshot output is identical with the current and new versions. I also verified that the table data in the endpoint for the previously mentioned ~10GB test dataset is the same whether materialized by the old or new version using a variety of different transaction sizes.

**Workflow steps:**

Use snowflake like before, but see it function well with larger transactions.

**Documentation links affected:**

N/A

**Notes for reviewers:**

An interesting note about the concurrent PUT worker is that it seemed pretty balanced with reading data from the Flow iterators with just a single worker. So there would not be any benefit to running more than worker per binding that I could see, and it keeps things a little simpler.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/706)
<!-- Reviewable:end -->
