### PR TITLE
materialize-snowflake: set GOMEMLIMIT=900mb

### DIFF
--- a/base-image/Dockerfile
+++ b/base-image/Dockerfile
@@ -12,4 +12,8 @@ RUN mkdir /home/nonroot/.ssh
 RUN chmod 700 /home/nonroot/.ssh
 RUN chmod 755 /home/nonroot
 
+# Ask the Go runtime to keep heap size below 900MiB. Our real memory limit is
+# 1GiB so this is 10% headroom as recommended in https://go.dev/doc/gc-guide
+ENV GOMEMLIMIT=900MiB
+
 USER root

--- a/source-mysql/Dockerfile
+++ b/source-mysql/Dockerfile
@@ -42,10 +42,6 @@ COPY --from=builder /builder/connector ./source-mysql
 # Avoid running the connector as root.
 USER nonroot:nonroot
 
-# Ask the Go runtime to keep heap size below 900MiB. Our real memory limit is
-# 1GiB so this is 10% headroom as recommended in https://go.dev/doc/gc-guide
-ENV GOMEMLIMIT=900MiB
-
 ENTRYPOINT ["/connector/source-mysql"]
 
 LABEL FLOW_RUNTIME_PROTOCOL=capture

--- a/source-postgres/Dockerfile
+++ b/source-postgres/Dockerfile
@@ -46,10 +46,6 @@ COPY --from=ghcr.io/estuary/network-tunnel:dev /flow-network-tunnel /usr/bin/flo
 # Avoid running the connector as root.
 USER nonroot:nonroot
 
-# Ask the Go runtime to keep heap size below 900MiB. Our real memory limit is
-# 1GiB so this is 10% headroom as recommended in https://go.dev/doc/gc-guide
-ENV GOMEMLIMIT=900MiB
-
 ENTRYPOINT ["/connector/source-postgres"]
 
 LABEL FLOW_RUNTIME_PROTOCOL=capture

--- a/source-sqlserver/Dockerfile
+++ b/source-sqlserver/Dockerfile
@@ -43,10 +43,6 @@ COPY --from=ghcr.io/estuary/network-tunnel:dev /flow-network-tunnel /usr/bin/flo
 # Avoid running the connector as root.
 USER nonroot:nonroot
 
-# Ask the Go runtime to keep heap size below 900MiB. Our real memory limit is
-# 1GiB so this is 10% headroom as recommended in https://go.dev/doc/gc-guide
-ENV GOMEMLIMIT=900MiB
-
 ENTRYPOINT ["/connector/source-sqlserver"]
 
 LABEL FLOW_RUNTIME_PROTOCOL=capture


### PR DESCRIPTION
**Description:**

Sets an advisory limit via environment variable in the `materialize-snowflake` dockerfile as a workaround to the memory issues documented in https://github.com/estuary/connectors/issues/709.

This actually seems to work very well in practice and will keep the connector memory right at 900mb when reading load query results for the datasets I have tried it with. This is certainly not an ideal amount of memory to use (we'd like it to use a lot less), and for that I have some initial thoughts in the previously linked issue.

~I'm opting not to make this a global setting via the base image at the moment, since I'd generally prefer to know about high memory use from other connectors via our OOM kill alerts, even if they are something that could be remedied by more active GC, so that we can know to optimize them.~ Actually ended up setting this for all connectors, see comments.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

N/A

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/708)
<!-- Reviewable:end -->
