### PR TITLE
source-mysql: Ignore /* comments like this */

### DIFF
--- a/source-mysql/replication.go
+++ b/source-mysql/replication.go
@@ -407,7 +407,7 @@ func decodeRow(streamID string, colNames []string, row []interface{}) (map[strin
 // with the binlog Query Events for some statements like GRANT and CREATE USER.
 // TODO(johnny): SET STATEMENT is not safe in the general case, and we want to re-visit
 // by extracting and ignoring a SET STATEMENT stanza prior to parsing.
-var ignoreQueriesRe = regexp.MustCompile(`(?i)^(BEGIN|COMMIT|GRANT|REVOKE|CREATE USER|CREATE DEFINER|DROP USER|ALTER USER|DROP PROCEDURE|SET STATEMENT|# )`)
+var ignoreQueriesRe = regexp.MustCompile(`(?i)^(BEGIN|COMMIT|GRANT|REVOKE|CREATE USER|CREATE DEFINER|DROP USER|ALTER USER|DROP PROCEDURE|SET STATEMENT|# |/\*)`)
 
 func (rs *mysqlReplicationStream) handleQuery(schema, query string) error {
 	// There are basically three types of query events we might receive:

--- a/source-mysql/replication_test.go
+++ b/source-mysql/replication_test.go
@@ -1,0 +1,23 @@
+package main
+
+import "testing"
+
+func TestIgnoreQueries(t *testing.T) {
+	var cases = map[string]bool{
+		`# This is a comment`:          true,
+		`/* This is also a comment */`: true,
+		`BEGIN`:                        true,
+		`COMMIT`:                       true,
+
+		`CREATE USER IF NOT EXISTS flow_capture IDENTIFIED BY 'secret1234'`: true,
+
+		`CREATE DATABASE IF NOT EXISTS test`:     false,
+		`INSERT INTO foobar VALUES (1, 'hello')`: false,
+		`DROP TABLE foobar`:                      false,
+	}
+	for input, expect := range cases {
+		if ignoreQueriesRe.MatchString(input) != expect {
+			t.Errorf("ignore result mismath for %q (expected %v)", input, expect)
+		}
+	}
+}


### PR DESCRIPTION
**Description:**

Modifies `source-mysql` to ignore `/* comments like this */` when they're reported as query events via replication.

Also adds a test because this regex is getting long enough to need one even if each individual case is fairly simple.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/710)
<!-- Reviewable:end -->
