### PR TITLE
source-mysql: add timezone configuration

### DIFF
--- a/source-mysql/.snapshots/TestGeneric-SpecResponse
+++ b/source-mysql/.snapshots/TestGeneric-SpecResponse
@@ -24,6 +24,12 @@
         "order": 2,
         "secret": true
       },
+      "timezone": {
+        "type": "string",
+        "title": "Timezone",
+        "description": "Timezone to use when capturing datetime columns. Should normally be left blank to use the database's 'time_zone' system variable. Only required if the 'time_zone' system variable cannot be set and columns with type datetime are being captured. Must be a valid IANA time zone name or +HH:MM offset. Takes precedence over the 'time_zone' system variable if both are set (go.estuary.dev/80J6rX).",
+        "order": 3
+      },
       "advanced": {
         "properties": {
           "watermarks_table": {

--- a/source-mysql/discovery.go
+++ b/source-mysql/discovery.go
@@ -173,7 +173,7 @@ func (db *mysqlDatabase) translateRecordFields(columnTypes map[string]interface{
 
 const mysqlTimestampLayout = "2006-01-02 15:04:05"
 
-var errDatabaseTimezoneUnknown = errors.New("system variable 'time_zone' must contain a valid IANA time zone name or +HH:MM offset (go.estuary.dev/80J6rX)")
+var errDatabaseTimezoneUnknown = errors.New("system variable 'time_zone' or timezone from capture configuration must contain a valid IANA time zone name or +HH:MM offset (go.estuary.dev/80J6rX)")
 
 func (db *mysqlDatabase) translateRecordField(columnType interface{}, val interface{}) (interface{}, error) {
 	if columnType == nil {

--- a/source-mysql/prerequisites.go
+++ b/source-mysql/prerequisites.go
@@ -206,7 +206,7 @@ func (db *mysqlDatabase) SetupTablePrerequisites(ctx context.Context, schema, ta
 			WHERE data_type='datetime' AND table_schema='%s' AND table_name='%s';
 		`, schema, table))
 		if err != nil {
-			return fmt.Errorf("time_zone system variable not set and could not validate that table %q does not contain DATETIME columns: %w", streamID, err)
+			return fmt.Errorf("db.datetimeLocation not set and could not validate that table %q does not contain DATETIME columns: %w", streamID, err)
 		}
 
 		var datetimeCols []string
@@ -216,7 +216,7 @@ func (db *mysqlDatabase) SetupTablePrerequisites(ctx context.Context, schema, ta
 		results.Close()
 
 		if len(datetimeCols) > 0 {
-			return fmt.Errorf("system variable 'time_zone' must be set to capture datetime columns [%s] from table %q", strings.Join(datetimeCols, ", "), streamID)
+			return fmt.Errorf("system variable 'time_zone' must be set or capture configured with a valid timezone to capture datetime columns [%s] from table %q", strings.Join(datetimeCols, ", "), streamID)
 		}
 	}
 


### PR DESCRIPTION
**Description:**

There are some MySQL-based setups where it is difficult to set the `'time_zone'` system variable. This adds a configuration value to allow for configuring a timezone as part of the capture that will be used for `datetime` columns when the the `'time_zone'` system variable cannot be set on the database by the user.

Closes https://github.com/estuary/connectors/issues/714

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

Will need to update the mysql capture docs to reflect this new configuration parameter and describe its usage.

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/715)
<!-- Reviewable:end -->
