### PR TITLE
source-firestore: Deduplicate discovered resources

### DIFF
--- a/source-firestore/.snapshots/TestDiscovery
+++ b/source-firestore/.snapshots/TestDiscovery
@@ -1,226 +1,177 @@
 Binding 0:
 {
     "recommended_name": "flow_source_tests",
-    "resource_spec_json": {
+    "resource_config_json": {
       "path": "flow_source_tests",
       "backfillMode": "async"
     },
     "document_schema_json": {
-      "allOf": [
-        {
-          "$schema": "http://json-schema.org/draft-07/schema#",
-          "type": "object",
-          "required": [
-            "testName"
-          ],
+      "type": "object",
+      "required": [
+        "_meta"
+      ],
+      "properties": {
+        "_meta": {
+          "$schema": "http://json-schema.org/draft/2020-12/schema",
+          "$id": "https://github.com/estuary/connectors/source-firestore/document-metadata",
           "properties": {
-            "testName": {
-              "type": "string"
-            }
-          }
-        },
-        {
-          "type": "object",
-          "required": [
-            "_meta"
-          ],
-          "properties": {
-            "_meta": {
-              "$schema": "http://json-schema.org/draft/2020-12/schema",
-              "$id": "https://github.com/estuary/connectors/source-firestore/document-metadata",
-              "properties": {
-                "path": {
-                  "type": "string",
-                  "title": "Document Path",
-                  "description": "Fully qualified document path including Project ID and database name."
-                },
-                "ctime": {
-                  "type": "string",
-                  "format": "date-time",
-                  "title": "Create Time",
-                  "description": "The time at which the document was created. Unset if the document is deleted."
-                },
-                "mtime": {
-                  "type": "string",
-                  "format": "date-time",
-                  "title": "Update Time",
-                  "description": "The time at which the document was most recently updated (or deleted)."
-                },
-                "delete": {
-                  "type": "boolean",
-                  "title": "Delete Flag",
-                  "description": "True if the document has been deleted"
-                }
-              },
-              "type": "object",
-              "required": [
-                "path",
-                "mtime"
-              ]
+            "path": {
+              "type": "string",
+              "title": "Document Path",
+              "description": "Fully qualified document path including Project ID and database name."
+            },
+            "ctime": {
+              "type": "string",
+              "format": "date-time",
+              "title": "Create Time",
+              "description": "The time at which the document was created. Unset if the document is deleted."
+            },
+            "mtime": {
+              "type": "string",
+              "format": "date-time",
+              "title": "Update Time",
+              "description": "The time at which the document was most recently updated (or deleted)."
+            },
+            "delete": {
+              "type": "boolean",
+              "title": "Delete Flag",
+              "description": "True if the document has been deleted"
             }
           },
-          "reduce": {
-            "key": [
-              "/_meta/mtime"
-            ],
-            "strategy": "maximize"
-          }
+          "type": "object",
+          "required": [
+            "path",
+            "mtime"
+          ]
         }
-      ]
+      },
+      "reduce": {
+        "key": [
+          "/_meta/mtime"
+        ],
+        "strategy": "maximize"
+      },
+      "x-infer-schema": true
     },
-    "key_ptrs": [
+    "key": [
       "/_meta/path"
     ]
   }
 Binding 1:
 {
     "recommended_name": "flow_source_tests_users",
-    "resource_spec_json": {
+    "resource_config_json": {
       "path": "flow_source_tests/*/users",
       "backfillMode": "async"
     },
     "document_schema_json": {
-      "allOf": [
-        {
-          "$schema": "http://json-schema.org/draft-07/schema#",
-          "type": "object",
-          "required": [
-            "name"
-          ],
+      "type": "object",
+      "required": [
+        "_meta"
+      ],
+      "properties": {
+        "_meta": {
+          "$schema": "http://json-schema.org/draft/2020-12/schema",
+          "$id": "https://github.com/estuary/connectors/source-firestore/document-metadata",
           "properties": {
-            "name": {
-              "type": "string"
-            }
-          }
-        },
-        {
-          "type": "object",
-          "required": [
-            "_meta"
-          ],
-          "properties": {
-            "_meta": {
-              "$schema": "http://json-schema.org/draft/2020-12/schema",
-              "$id": "https://github.com/estuary/connectors/source-firestore/document-metadata",
-              "properties": {
-                "path": {
-                  "type": "string",
-                  "title": "Document Path",
-                  "description": "Fully qualified document path including Project ID and database name."
-                },
-                "ctime": {
-                  "type": "string",
-                  "format": "date-time",
-                  "title": "Create Time",
-                  "description": "The time at which the document was created. Unset if the document is deleted."
-                },
-                "mtime": {
-                  "type": "string",
-                  "format": "date-time",
-                  "title": "Update Time",
-                  "description": "The time at which the document was most recently updated (or deleted)."
-                },
-                "delete": {
-                  "type": "boolean",
-                  "title": "Delete Flag",
-                  "description": "True if the document has been deleted"
-                }
-              },
-              "type": "object",
-              "required": [
-                "path",
-                "mtime"
-              ]
+            "path": {
+              "type": "string",
+              "title": "Document Path",
+              "description": "Fully qualified document path including Project ID and database name."
+            },
+            "ctime": {
+              "type": "string",
+              "format": "date-time",
+              "title": "Create Time",
+              "description": "The time at which the document was created. Unset if the document is deleted."
+            },
+            "mtime": {
+              "type": "string",
+              "format": "date-time",
+              "title": "Update Time",
+              "description": "The time at which the document was most recently updated (or deleted)."
+            },
+            "delete": {
+              "type": "boolean",
+              "title": "Delete Flag",
+              "description": "True if the document has been deleted"
             }
           },
-          "reduce": {
-            "key": [
-              "/_meta/mtime"
-            ],
-            "strategy": "maximize"
-          }
+          "type": "object",
+          "required": [
+            "path",
+            "mtime"
+          ]
         }
-      ]
+      },
+      "reduce": {
+        "key": [
+          "/_meta/mtime"
+        ],
+        "strategy": "maximize"
+      },
+      "x-infer-schema": true
     },
-    "key_ptrs": [
+    "key": [
       "/_meta/path"
     ]
   }
 Binding 2:
 {
     "recommended_name": "flow_source_tests_users_docs",
-    "resource_spec_json": {
+    "resource_config_json": {
       "path": "flow_source_tests/*/users/*/docs",
       "backfillMode": "async"
     },
     "document_schema_json": {
-      "allOf": [
-        {
-          "$schema": "http://json-schema.org/draft-07/schema#",
-          "type": "object",
-          "required": [
-            "asdf",
-            "foo"
-          ],
+      "type": "object",
+      "required": [
+        "_meta"
+      ],
+      "properties": {
+        "_meta": {
+          "$schema": "http://json-schema.org/draft/2020-12/schema",
+          "$id": "https://github.com/estuary/connectors/source-firestore/document-metadata",
           "properties": {
-            "asdf": {
-              "type": "integer"
+            "path": {
+              "type": "string",
+              "title": "Document Path",
+              "description": "Fully qualified document path including Project ID and database name."
             },
-            "foo": {
-              "type": "string"
-            }
-          }
-        },
-        {
-          "type": "object",
-          "required": [
-            "_meta"
-          ],
-          "properties": {
-            "_meta": {
-              "$schema": "http://json-schema.org/draft/2020-12/schema",
-              "$id": "https://github.com/estuary/connectors/source-firestore/document-metadata",
-              "properties": {
-                "path": {
-                  "type": "string",
-                  "title": "Document Path",
-                  "description": "Fully qualified document path including Project ID and database name."
-                },
-                "ctime": {
-                  "type": "string",
-                  "format": "date-time",
-                  "title": "Create Time",
-                  "description": "The time at which the document was created. Unset if the document is deleted."
-                },
-                "mtime": {
-                  "type": "string",
-                  "format": "date-time",
-                  "title": "Update Time",
-                  "description": "The time at which the document was most recently updated (or deleted)."
-                },
-                "delete": {
-                  "type": "boolean",
-                  "title": "Delete Flag",
-                  "description": "True if the document has been deleted"
-                }
-              },
-              "type": "object",
-              "required": [
-                "path",
-                "mtime"
-              ]
+            "ctime": {
+              "type": "string",
+              "format": "date-time",
+              "title": "Create Time",
+              "description": "The time at which the document was created. Unset if the document is deleted."
+            },
+            "mtime": {
+              "type": "string",
+              "format": "date-time",
+              "title": "Update Time",
+              "description": "The time at which the document was most recently updated (or deleted)."
+            },
+            "delete": {
+              "type": "boolean",
+              "title": "Delete Flag",
+              "description": "True if the document has been deleted"
             }
           },
-          "reduce": {
-            "key": [
-              "/_meta/mtime"
-            ],
-            "strategy": "maximize"
-          }
+          "type": "object",
+          "required": [
+            "path",
+            "mtime"
+          ]
         }
-      ]
+      },
+      "reduce": {
+        "key": [
+          "/_meta/mtime"
+        ],
+        "strategy": "maximize"
+      },
+      "x-infer-schema": true
     },
-    "key_ptrs": [
+    "key": [
       "/_meta/path"
     ]
   }

--- a/source-firestore/main_test.go
+++ b/source-firestore/main_test.go
@@ -218,9 +218,13 @@ func TestDiscovery(t *testing.T) {
 	var ctx = testContext(t, 300*time.Second)
 	var client = testFirestoreClient(ctx, t)
 	client.Upsert(ctx, t, "users/1", `{"name": "Will"}`)
-	client.Upsert(ctx, t, "users/1/docs/2", `{"foo": "bar", "asdf": 123}`)
+	client.Upsert(ctx, t, "users/2", `{"name": "Alice"}`)
+	client.Upsert(ctx, t, "users/1/docs/1", `{"foo": "bar", "asdf": 123}`)
+	client.Upsert(ctx, t, "users/1/docs/2", `{"foo": "bar", "asdf": 456}`)
+	client.Upsert(ctx, t, "users/2/docs/3", `{"foo": "baz", "asdf": 789}`)
+	client.Upsert(ctx, t, "users/2/docs/4", `{"foo": "baz", "asdf": 1000}`)
 	time.Sleep(1 * time.Second)
-	simpleCapture(t).Discover(ctx, t, regexp.MustCompile(regexp.QuoteMeta("flow_source_tests")))
+	simpleCapture(t).VerifyDiscover(ctx, t, regexp.MustCompile(regexp.QuoteMeta("flow_source_tests")))
 }
 
 func testContext(t testing.TB, duration time.Duration) context.Context {


### PR DESCRIPTION
**Description:**

When there are multiple nested collections mapping to the same resource path, such as `foo/1/bar` and `foo/2/bar` mapping to `foo/*/bar`, we only want to emit one discovered binding at the end.

This used to happen as a side-effect of how we launched schema inference workers for each distinct resource path, and I think we accidentally lost that behavior as a side effect of the change which removed schema inference.

This issue was hit by a user in production. I tweaked `TestDiscovery` to make sure it was exercising the issue, fixed it in the obvious manner, and then verified that `TestDiscovery` output changed and only contains one copy of the binding again. That's the full extent of the testing or thought I've put into this change though, so it's possible I've missed something.

(Note that the `TestDiscovery` snapshot shows a pretty large diff because it was never updated after the removing-schema-inference or protocol-refactoring changes -- I'm pretty sure that's all irrelevant and should be ignored, the only important thing for the purposes of this PR is that the set of discovered bindings is the same.)