### PR TITLE
source-kafka: remove leftover `message` from document schema

### DIFF
--- a/source-kafka/src/kafka.rs
+++ b/source-kafka/src/kafka.rs
@@ -109,9 +109,6 @@ pub fn available_streams(metadata: &Metadata) -> Vec<response::discovered::Bindi
                             }
                         },
                         "required": ["partition", "offset"]
-                    },
-                    "message": {
-                        "type": "object"
                     }
                 },
                 "required": ["_meta"]


### PR DESCRIPTION
**Description:**

- this is a leftover from when we used to emit the message as a separate object, but now it is flattened (following suite of all other connectors)

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/720)
<!-- Reviewable:end -->
