### PR TITLE
materialize-sql: no-op in case of a deletion apply

### DIFF
--- a/materialize-sql/driver.go
+++ b/materialize-sql/driver.go
@@ -110,6 +110,13 @@ func (d *Driver) Apply(ctx context.Context, req *pm.Request_Apply) (*pm.Response
 		err        error
 	)
 
+	if len(req.Materialization.Bindings) == 0 {
+		// Empty bindings means we are deleting the materialization, in this case we
+		// don't have anything to do, so return early
+		return &pm.Response_Applied{ActionDescription: ""}, nil
+	}
+
+
 	if err = req.Validate(); err != nil {
 		return nil, fmt.Errorf("validating request: %w", err)
 	} else if endpoint, err = d.NewEndpoint(ctx, req.Materialization.ConfigJson); err != nil {


### PR DESCRIPTION
**Description:**

- In case of a deletion Apply RPC, we can return early without doing anything. This helps in cases when the user has already deleted their database / table and they just want to delete the materialization. Currently we try to load up the materialization specification from the destination and compare it against bindings... even though there are no bindings!

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/721)
<!-- Reviewable:end -->
