### PR TITLE
Jshearer/materialize slack

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -118,6 +118,7 @@ jobs:
           - materialize-sqlite
           - materialize-webhook
           - materialize-sqlserver
+          - materialize-slack
         include:
           - connector: source-criteo
             connector_type: capture

--- a/go.mod
+++ b/go.mod
@@ -159,6 +159,7 @@ require (
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.3.2 // indirect
 	github.com/googleapis/gax-go/v2 v2.12.4 // indirect
+	github.com/gorilla/websocket v1.5.0 // indirect
 	github.com/grpc-ecosystem/go-grpc-middleware v1.4.0 // indirect
 	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0 // indirect
 	github.com/gsterjov/go-libsecret v0.0.0-20161001094733-a6f4afe4910c // indirect
@@ -202,6 +203,7 @@ require (
 	github.com/shopspring/decimal v1.3.1 // indirect
 	github.com/siddontang/go v0.0.0-20180604090527-bdc77568d726 // indirect
 	github.com/siddontang/go-log v0.0.0-20190221022429-1e957dd83bed // indirect
+	github.com/slack-go/slack v0.14.0 // indirect
 	github.com/spf13/afero v1.11.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/tidwall/match v1.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -484,6 +484,7 @@ github.com/google/go-cmp v0.5.3/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.7/go.mod h1:n+brtR0CgQNWTVd5ZUFpTBC8YFBDLK/h/bpaJ8/DtOE=
 github.com/google/go-cmp v0.5.8/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=

--- a/go.sum
+++ b/go.sum
@@ -402,6 +402,7 @@ github.com/go-sql-driver/mysql v1.5.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LB
 github.com/go-sql-driver/mysql v1.8.1 h1:LedoTUt/eveggdHS9qUFC1EFSa8bU2+1pZjSRpvNJ1Y=
 github.com/go-sql-driver/mysql v1.8.1/go.mod h1:wEBSXgmK//2ZFJyE+qWnIsVGmvmEKlqwuVSjsCm7DZg=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
+github.com/go-test/deep v1.0.4/go.mod h1:wGDj63lr65AM2AQyKZd/NYHGb0R+1RLqB8NKt3aSFNA=
 github.com/gobwas/httphead v0.0.0-20180130184737-2c6c146eadee h1:s+21KNqlpePfkah2I+gwHF8xmJWRjooY+5248k6m4A0=
 github.com/gobwas/httphead v0.0.0-20180130184737-2c6c146eadee/go.mod h1:L0fX3K22YWvt/FAX9NnzrNzcI4wNYi9Yku4O0LKYflo=
 github.com/gobwas/pool v0.2.0 h1:QEmUOlnSjWtnpRGHF3SauEiOsy82Cup83Vf2LcMlnc8=
@@ -791,6 +792,8 @@ github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6Mwd
 github.com/sirupsen/logrus v1.7.0/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
 github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ=
 github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
+github.com/slack-go/slack v0.14.0 h1:6c0UTfbRnvRssZUsZ2qe0Iu07VAMPjRqOa6oX8ewF4k=
+github.com/slack-go/slack v0.14.0/go.mod h1:hlGi5oXA+Gt+yWTPP0plCdRKmjsDxecdHxYQdlMQKOw=
 github.com/snowflakedb/gosnowflake v1.10.0 h1:5hBGKa/jJEhciokzgJcz5xmLNlJ8oUm8vhfu5tg82tM=
 github.com/snowflakedb/gosnowflake v1.10.0/go.mod h1:WC4eGUOH3K9w3pLsdwZsdawIwtWgse4kZPPqNG0Ky/k=
 github.com/soheilhy/cmux v0.1.5 h1:jjzc5WVemNEDTLwv9tlmemhC73tI08BNOIGwBOo10Js=

--- a/materialize-slack/CHANGELOG.md
+++ b/materialize-slack/CHANGELOG.md
@@ -1,0 +1,4 @@
+# materialize-slack
+
+## v1, 2022-07-27
+- Beginning of changelog.

--- a/materialize-slack/Dockerfile
+++ b/materialize-slack/Dockerfile
@@ -2,7 +2,7 @@ ARG BASE_IMAGE=ghcr.io/estuary/base-image:v1
 
 # Build Stage
 ################################################################################
-FROM golang:1.17-bullseye as builder
+FROM --platform=linux/amd64 golang:1.20-bullseye as builder
 
 WORKDIR /builder
 
@@ -12,10 +12,9 @@ COPY go.* ./
 RUN go mod download
 
 # Build the connector projects we depend on.
+COPY go                        ./go
 COPY materialize-boilerplate   ./materialize-boilerplate
 COPY materialize-slack         ./materialize-slack
-COPY go/schema-gen             ./go/schema-gen
-COPY go/connector-errors       ./go/connector-errors
 
 # Test and build the connector.
 RUN go test  -tags nozstd -v ./materialize-slack/...

--- a/materialize-slack/Dockerfile
+++ b/materialize-slack/Dockerfile
@@ -14,7 +14,8 @@ RUN go mod download
 # Build the connector projects we depend on.
 COPY materialize-boilerplate   ./materialize-boilerplate
 COPY materialize-slack         ./materialize-slack
-COPY go-schema-gen             ./go-schema-gen
+COPY go/schema-gen             ./go/schema-gen
+COPY go/connector-errors       ./go/connector-errors
 
 # Test and build the connector.
 RUN go test  -tags nozstd -v ./materialize-slack/...

--- a/materialize-slack/Dockerfile
+++ b/materialize-slack/Dockerfile
@@ -1,0 +1,38 @@
+ARG BASE_IMAGE=ghcr.io/estuary/base-image:v1
+
+# Build Stage
+################################################################################
+FROM golang:1.17-bullseye as builder
+
+WORKDIR /builder
+
+# Download & compile dependencies early. Doing this separately allows for layer
+# caching opportunities when no dependencies are updated.
+COPY go.* ./
+RUN go mod download
+
+# Build the connector projects we depend on.
+COPY materialize-boilerplate   ./materialize-boilerplate
+COPY materialize-slack         ./materialize-slack
+COPY go-schema-gen             ./go-schema-gen
+
+# Test and build the connector.
+RUN go test  -tags nozstd -v ./materialize-slack/...
+RUN go build -tags nozstd -v -o ./connector ./materialize-slack
+
+# Runtime Stage
+################################################################################
+FROM ${BASE_IMAGE}
+
+WORKDIR /connector
+ENV PATH="/connector:$PATH"
+
+# Bring in the compiled connector artifact from the builder.
+COPY --from=builder /builder/connector ./connector
+
+# Avoid running the connector as root.
+USER nonroot:nonroot
+
+LABEL FLOW_RUNTIME_PROTOCOL=materialize
+
+ENTRYPOINT ["/connector/connector"]

--- a/materialize-slack/Dockerfile
+++ b/materialize-slack/Dockerfile
@@ -2,7 +2,7 @@ ARG BASE_IMAGE=ghcr.io/estuary/base-image:v1
 
 # Build Stage
 ################################################################################
-FROM --platform=linux/amd64 golang:1.20-bullseye as builder
+FROM --platform=linux/amd64 golang:1.22-bullseye as builder
 
 WORKDIR /builder
 

--- a/materialize-slack/README.md
+++ b/materialize-slack/README.md
@@ -1,0 +1,5 @@
+Flow Slack Materialization Connector
+====================================
+
+This is a Flow materialization connector which sends messages to
+Slack channels.

--- a/materialize-slack/auth.go
+++ b/materialize-slack/auth.go
@@ -30,10 +30,9 @@ func (c *CredentialConfig) validateClientCreds() error {
 	return nil
 }
 
-func (c *CredentialConfig) SlackAPI(config SlackSenderConfig) *SlackAPI {
+func (c *CredentialConfig) SlackAPI() *SlackAPI {
 	return &SlackAPI{
-		Client:       *slack.New(c.AccessToken),
-		SenderConfig: config,
+		Client: *slack.New(c.AccessToken),
 	}
 }
 

--- a/materialize-slack/auth.go
+++ b/materialize-slack/auth.go
@@ -11,11 +11,11 @@ import (
 
 type CredentialConfig struct {
 	// Provided by runtime
-	ClientID     string `json:"client_id,omitempty" jsonschema_extras:"secret=true"`
-	ClientSecret string `json:"client_secret,omitempty" jsonschema_extras:"secret=true"`
+	ClientID     string `json:"client_id" jsonschema_extras:"required,secret=true"`
+	ClientSecret string `json:"client_secret" jsonschema_extras:"required,secret=true"`
 
 	// Extracted by us in AccessTokenResponseJsonMap
-	AccessToken string `json:"access_token,omitempty" jsonschema_extras:"secret=true"`
+	AccessToken string `json:"access_token" jsonschema_extras:"required,secret=true"`
 }
 
 func (c *CredentialConfig) validateClientCreds() error {

--- a/materialize-slack/auth.go
+++ b/materialize-slack/auth.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	pf "github.com/estuary/flow/go/protocols/flow"
+)
+
+type CredentialConfig struct {
+	// Provided by runtime
+	ClientID     string `json:"client_id,omitempty"`
+	ClientSecret string `json:"client_secret,omitempty"`
+
+	// Extracted by us in AccessTokenResponseJsonMap
+	AccessToken string `json:"access_token,omitempty"`
+}
+
+func (c *CredentialConfig) validateClientCreds() error {
+	if c.AccessToken == "" {
+		return fmt.Errorf("missing access token for oauth2")
+	} else if c.ClientID == "" {
+		return fmt.Errorf("missing client ID for oauth2")
+	} else if c.ClientSecret == "" {
+		return fmt.Errorf("missing client secret for oauth2")
+	}
+
+	return nil
+}
+
+func (c *CredentialConfig) SlackAPI(config SlackSenderConfig) *SlackAPI {
+	return &SlackAPI{
+		Token:        c.AccessToken,
+		SenderConfig: config,
+	}
+}
+
+const AUTH_URL_TEMPLATE_FORMAT_STR = "https://slack.com/oauth/v2/authorize?client_id={{#urlencode}}{{{ client_id }}}{{/urlencode}}&redirect_uri={{#urlencode}}{{{ redirect_uri }}}{{/urlencode}}&response_type=code&state={{#urlencode}}{{{ state }}}{{/urlencode}}&scope={{#urlencode}}%s{{/urlencode}}"
+
+func Spec(scopes ...string) *pf.OAuth2 {
+	return &pf.OAuth2{
+		Provider:               "slack",
+		AuthUrlTemplate:        fmt.Sprintf(AUTH_URL_TEMPLATE_FORMAT_STR, strings.Join(scopes, " ")),
+		AccessTokenUrlTemplate: "https://slack.com/api/oauth.v2.access",
+		AccessTokenBody:        "grant_type=authorization_code&client_id={{#urlencode}}{{{ client_id }}}{{/urlencode}}&client_secret={{#urlencode}}{{{ client_secret }}}{{/urlencode}}&redirect_uri={{#urlencode}}{{{ redirect_uri }}}{{/urlencode}}&code={{#urlencode}}{{{ code }}}{{/urlencode}}",
+		AccessTokenHeadersJsonMap: map[string]json.RawMessage{
+			"content-type": json.RawMessage(`"application/x-www-form-urlencoded"`),
+		},
+		AccessTokenResponseJsonMap: map[string]json.RawMessage{
+			"access_token": json.RawMessage(`"/access_token"`),
+		},
+	}
+}

--- a/materialize-slack/auth.go
+++ b/materialize-slack/auth.go
@@ -6,15 +6,16 @@ import (
 	"strings"
 
 	pf "github.com/estuary/flow/go/protocols/flow"
+	"github.com/slack-go/slack"
 )
 
 type CredentialConfig struct {
 	// Provided by runtime
-	ClientID     string `json:"client_id,omitempty"`
-	ClientSecret string `json:"client_secret,omitempty"`
+	ClientID     string `json:"client_id,omitempty" jsonschema_extras:"secret=true"`
+	ClientSecret string `json:"client_secret,omitempty" jsonschema_extras:"secret=true"`
 
 	// Extracted by us in AccessTokenResponseJsonMap
-	AccessToken string `json:"access_token,omitempty"`
+	AccessToken string `json:"access_token,omitempty" jsonschema_extras:"secret=true"`
 }
 
 func (c *CredentialConfig) validateClientCreds() error {
@@ -31,7 +32,7 @@ func (c *CredentialConfig) validateClientCreds() error {
 
 func (c *CredentialConfig) SlackAPI(config SlackSenderConfig) *SlackAPI {
 	return &SlackAPI{
-		Token:        c.AccessToken,
+		Client:       *slack.New(c.AccessToken),
 		SenderConfig: config,
 	}
 }

--- a/materialize-slack/main.go
+++ b/materialize-slack/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"strings"
@@ -211,23 +210,24 @@ type binding struct {
 func buildDocument(b *binding, keys, values tuple.Tuple) map[string]interface{} {
 	var document = make(map[string]interface{})
 
-	// Add the `_id` field to the document. This is required by Rockset.
-	document["_id"] = base64.RawStdEncoding.EncodeToString(keys.Pack())
-
 	// Add the keys to the document.
 	for i, value := range keys {
-		var propName = b.spec.FieldSelection.Keys[i]
-		document[propName] = value
+		if i < len(b.spec.FieldSelection.Keys) {
+			var propName = b.spec.FieldSelection.Keys[i]
+			document[propName] = value
+		}
 	}
 
 	// Add the non-keys to the document.
 	for i, value := range values {
-		var propName = b.spec.FieldSelection.Values[i]
+		if i < len(b.spec.FieldSelection.Values) {
+			var propName = b.spec.FieldSelection.Values[i]
 
-		if raw, ok := value.([]byte); ok {
-			document[propName] = json.RawMessage(raw)
-		} else {
-			document[propName] = value
+			if raw, ok := value.([]byte); ok {
+				document[propName] = json.RawMessage(raw)
+			} else {
+				document[propName] = value
+			}
 		}
 	}
 	return document

--- a/materialize-slack/main.go
+++ b/materialize-slack/main.go
@@ -272,10 +272,6 @@ func (t *transactor) Store(it *pm.StoreIterator) (pm.StartCommitFunc, error) {
 		// Accept messages from at most 10 minutes in the past
 		if time.Since(ts).Minutes() < 10 {
 			if err := t.api.PostMessage(b.resource.Channel, text, blocksParsed.BlockSet, b.resource.SenderConfig); err != nil {
-				serializedBlocks, marshal_err := json.Marshal(blocksParsed)
-				if marshal_err == nil {
-					log.Warn(fmt.Sprintf("Parse Blocks: %+v", string(serializedBlocks)))
-				}
 				log.Warn(fmt.Errorf("error sending message: %w", err))
 			}
 			// rate limiting at home:

--- a/materialize-slack/main.go
+++ b/materialize-slack/main.go
@@ -1,0 +1,293 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	schemagen "github.com/estuary/connectors/go-schema-gen"
+	boilerplate "github.com/estuary/connectors/materialize-boilerplate"
+	"github.com/estuary/flow/go/protocols/fdb/tuple"
+	pf "github.com/estuary/flow/go/protocols/flow"
+	pm "github.com/estuary/flow/go/protocols/materialize"
+	log "github.com/sirupsen/logrus"
+)
+
+// driver implements the pm.DriverServer interface.
+type driver struct{}
+
+type config struct {
+	BearerToken string `json:"token" jsonschema:"title=Bearer Token,description=The Slack API authentication token."`
+}
+
+// Validate returns an error if the config is not well-formed.
+func (c config) Validate() error {
+	if c.BearerToken == "" {
+		return fmt.Errorf("missing required Slack API authentication token")
+	}
+	return nil
+}
+
+func (c config) buildAPI() (*slackAPI, error) {
+	var api = &slackAPI{Token: c.BearerToken}
+	if err := api.AuthTest(); err != nil {
+		return nil, fmt.Errorf("error verifying authentication: %w", err)
+	}
+	return api, nil
+}
+
+type resource struct {
+	Channel string `json:"channel" jsonschema:"title=Channel,description=The name of the channel to post messages to (or a raw channel ID like \"id:C123456\")"`
+}
+
+func (r resource) Validate() error {
+	if r.Channel == "" {
+		return fmt.Errorf("missing required channel name/id")
+	}
+	return nil
+}
+
+type driverCheckpoint struct {
+	LastMessage time.Time `json:"last_message"`
+}
+
+func (c driverCheckpoint) Validate() error {
+	return nil
+}
+
+func (driver) Spec(ctx context.Context, req *pm.SpecRequest) (*pm.SpecResponse, error) {
+	log.Debug("handling Spec request")
+
+	endpointSchema, err := schemagen.GenerateSchema("Slack Connection", &config{}).MarshalJSON()
+	if err != nil {
+		return nil, fmt.Errorf("generating endpoint schema: %w", err)
+	}
+
+	resourceSchema, err := schemagen.GenerateSchema("Slack Channel", &resource{}).MarshalJSON()
+	if err != nil {
+		return nil, fmt.Errorf("generating resource schema: %w", err)
+	}
+
+	return &pm.SpecResponse{
+		EndpointSpecSchemaJson: json.RawMessage(endpointSchema),
+		ResourceSpecSchemaJson: json.RawMessage(resourceSchema),
+		DocumentationUrl:       "https://go.estuary.dev/materialize-slack",
+	}, nil
+}
+
+func (driver) Validate(ctx context.Context, req *pm.ValidateRequest) (*pm.ValidateResponse, error) {
+	log.Debug("handling Validate request")
+
+	var cfg config
+	if err := pf.UnmarshalStrict(req.EndpointSpecJson, &cfg); err != nil {
+		return nil, err
+	}
+
+	var api, err = cfg.buildAPI()
+	if err != nil {
+		return nil, err
+	}
+
+	var out []*pm.ValidateResponse_Binding
+	for _, binding := range req.Bindings {
+		var res resource
+		if err := pf.UnmarshalStrict(binding.ResourceSpecJson, &res); err != nil {
+			return nil, fmt.Errorf("parsing resource config: %w", err)
+		}
+		if _, err := api.GetChannelID(res.Channel); err != nil {
+			return nil, fmt.Errorf("")
+		}
+
+		var constraints = make(map[string]*pm.Constraint)
+		for _, projection := range binding.Collection.Projections {
+			constraints[projection.Field] = &pm.Constraint{
+				Type:   pm.Constraint_FIELD_OPTIONAL,
+				Reason: "All fields other than 'ts' and 'message' will be ignored",
+			}
+		}
+		constraints["ts"] = &pm.Constraint{
+			Type:   pm.Constraint_LOCATION_REQUIRED,
+			Reason: "The Slack materialization requires a message timestamp",
+		}
+		constraints["message"] = &pm.Constraint{
+			Type:   pm.Constraint_LOCATION_REQUIRED,
+			Reason: "The Slack materialization requires message text",
+		}
+
+		out = append(out, &pm.ValidateResponse_Binding{
+			Constraints:  constraints,
+			DeltaUpdates: true,
+			ResourcePath: []string{res.Channel},
+		})
+	}
+
+	return &pm.ValidateResponse{Bindings: out}, nil
+}
+
+func (d driver) ApplyUpsert(ctx context.Context, req *pm.ApplyRequest) (*pm.ApplyResponse, error) {
+	log.Debug("handling ApplyUpsert request")
+	return &pm.ApplyResponse{ActionDescription: "materialize-slack does not create channels"}, nil
+}
+
+func (d driver) ApplyDelete(ctx context.Context, req *pm.ApplyRequest) (*pm.ApplyResponse, error) {
+	log.Debug("handling ApplyDelete request")
+	return &pm.ApplyResponse{ActionDescription: "materialize-slack does not delete channels"}, nil
+}
+
+// Transactions implements the DriverServer interface.
+func (driver) Transactions(stream pm.Driver_TransactionsServer) error {
+	log.Debug("handling Transactions request")
+
+	var open, err = stream.Recv()
+	if err != nil {
+		return fmt.Errorf("read Open: %w", err)
+	} else if open.Open == nil {
+		return fmt.Errorf("expected Open, got %#v", open)
+	}
+
+	var cfg config
+	if err = pf.UnmarshalStrict(open.Open.Materialization.EndpointSpecJson, &cfg); err != nil {
+		return fmt.Errorf("parsing endpoint config: %w", err)
+	}
+
+	var checkpoint driverCheckpoint
+	if err = pf.UnmarshalStrict(open.Open.DriverCheckpointJson, &checkpoint); err != nil {
+		return fmt.Errorf("parsing driver checkpoint: %w", err)
+	}
+	if checkpoint.LastMessage.IsZero() {
+		checkpoint.LastMessage = time.Now()
+	}
+
+	api, err := cfg.buildAPI()
+	if err != nil {
+		return err
+	}
+
+	var bindings []*binding
+	for _, b := range open.Open.Materialization.Bindings {
+		var fields = append(append([]string{}, b.FieldSelection.Keys...), b.FieldSelection.Values...)
+		var fieldIndices = make(map[string]int)
+		for idx, field := range fields {
+			fieldIndices[field] = idx
+		}
+
+		tsIndex, ok := fieldIndices["ts"]
+		if !ok {
+			return fmt.Errorf("no index found for field 'ts' in %q binding", b.ResourcePath[0])
+		}
+		msgIndex, ok := fieldIndices["message"]
+		if !ok {
+			return fmt.Errorf("no index found for field 'message' in %q binding", b.ResourcePath[0])
+		}
+		bindings = append(bindings, &binding{
+			channel:  b.ResourcePath[0],
+			tsIndex:  tsIndex,
+			msgIndex: msgIndex,
+		})
+	}
+
+	var transactor = &transactor{
+		api:         api,
+		lastMessage: checkpoint.LastMessage,
+		bindings:    bindings,
+	}
+
+	if err = stream.Send(&pm.TransactionResponse{
+		Opened: &pm.TransactionResponse_Opened{FlowCheckpoint: nil},
+	}); err != nil {
+		return fmt.Errorf("sending Opened: %w", err)
+	}
+
+	var logEntry = log.WithField("materialization", "slack")
+	logEntry.Debug("running transactions")
+	return pm.RunTransactions(stream, transactor, logEntry)
+}
+
+type transactor struct {
+	api         *slackAPI
+	bindings    []*binding
+	lastMessage time.Time
+}
+
+type binding struct {
+	channel  string
+	tsIndex  int
+	msgIndex int
+}
+
+func (transactor) Load(it *pm.LoadIterator, priorCommittedCh <-chan struct{}, priorAcknowledgedCh <-chan struct{}, loaded func(binding int, doc json.RawMessage) error) error {
+	log.Debug("handling Load operation")
+	return fmt.Errorf("this materialization only supports delta-updates")
+}
+
+func (t *transactor) Prepare(context.Context, pm.TransactionRequest_Prepare) (pf.DriverCheckpoint, error) {
+	log.Debug("handling Prepare operation")
+	var checkpoint = driverCheckpoint{LastMessage: t.lastMessage}
+	var bs, err = json.Marshal(&checkpoint)
+	if err != nil {
+		return pf.DriverCheckpoint{}, fmt.Errorf("error marshalling driver checkpoint: %w", err)
+	}
+	return pf.DriverCheckpoint{
+		DriverCheckpointJson: json.RawMessage(bs),
+		Rfc7396MergePatch:    true,
+	}, nil
+}
+
+func (t *transactor) Store(it *pm.StoreIterator) error {
+	log.Debug("handling Store operation")
+
+	var vals []tuple.TupleElement
+	for it.Next() {
+		// Concatenate key and non-key fields because we don't care
+		vals = append(append(vals[:0], it.Key...), it.Values...)
+
+		var b = t.bindings[it.Binding]
+
+		log.WithField("binding", fmt.Sprintf("%#v", b)).WithField("vals", fmt.Sprintf("%#v", vals)).Debug("storing document")
+
+		// Extract timestamp and message fields from the document
+		tsStr, ok := vals[b.tsIndex].(string)
+		if !ok {
+			return fmt.Errorf("timestamp field is not a string, instead got %#v", vals[b.tsIndex])
+		}
+		msg, ok := vals[b.msgIndex].(string)
+		if !ok {
+			return fmt.Errorf("message field is not a string, instead got %#v", vals[b.msgIndex])
+		}
+
+		// Parse the timstamp as a time.Time
+		ts, err := time.Parse(time.RFC3339Nano, tsStr)
+		if err != nil {
+			return fmt.Errorf("invalid timestamp %q", tsStr)
+		}
+
+		if ts.After(t.lastMessage) {
+			if err := t.api.PostMessage(b.channel, msg); err != nil {
+				return fmt.Errorf("error sending message: %w", err)
+			}
+			t.lastMessage = ts
+		}
+	}
+	return nil
+}
+
+func (transactor) Commit(context.Context) error {
+	log.Debug("handling Commit operation")
+	return nil
+}
+
+func (transactor) Acknowledge(context.Context) error {
+	log.Debug("handling Acknowledge operation")
+	return nil
+}
+
+func (transactor) Destroy() {
+	log.Debug("handling Destroy operation")
+}
+
+func main() {
+	log.SetLevel(log.DebugLevel)
+	log.Info("connector starting")
+	boilerplate.RunMain(new(driver))
+}

--- a/materialize-slack/main.go
+++ b/materialize-slack/main.go
@@ -53,8 +53,6 @@ func (r resource) Validate() error {
 }
 
 func (driver) Spec(ctx context.Context, req *pm.Request_Spec) (*pm.Response_Spec, error) {
-	log.Debug("handling Spec request")
-
 	endpointSchema, err := schemagen.GenerateSchema("Slack Connection", &config{}).MarshalJSON()
 	if err != nil {
 		return nil, fmt.Errorf("generating endpoint schema: %w", err)
@@ -74,8 +72,6 @@ func (driver) Spec(ctx context.Context, req *pm.Request_Spec) (*pm.Response_Spec
 }
 
 func (driver) Validate(ctx context.Context, req *pm.Request_Validate) (*pm.Response_Validated, error) {
-	log.Debug("handling Validate request")
-
 	var cfg config
 	if err := pf.UnmarshalStrict(req.ConfigJson, &cfg); err != nil {
 		return nil, err

--- a/materialize-slack/main.go
+++ b/materialize-slack/main.go
@@ -317,14 +317,6 @@ func (t *transactor) Store(it *pm.StoreIterator) (pm.StartCommitFunc, error) {
 	}, nil
 }
 
-func (transactor) Commit(context.Context) error {
-	return nil
-}
-
-func (transactor) Acknowledge(context.Context) error {
-	return nil
-}
-
 func (transactor) Destroy() {
 }
 

--- a/materialize-slack/main.go
+++ b/materialize-slack/main.go
@@ -121,6 +121,9 @@ func (driver) Validate(ctx context.Context, req *pm.Request_Validate) (*pm.Respo
 		if constraints["text"] == nil {
 			return nil, fmt.Errorf("'text' field required")
 		}
+		if constraints["ts"] == nil {
+			return nil, fmt.Errorf("'ts' field required")
+		}
 
 		out = append(out, &pm.Response_Validated_Binding{
 			Constraints:  constraints,
@@ -179,8 +182,7 @@ func (driver) NewTransactor(ctx context.Context, open pm.Request_Open) (pm.Trans
 	var bindings []*binding
 	for _, b := range open.Materialization.Bindings {
 		var res resource
-		err = json.Unmarshal(b.ResourceConfigJson, &res)
-		if err != nil {
+		if err := json.Unmarshal(b.ResourceConfigJson, &res); err != nil {
 			return nil, nil, fmt.Errorf("unable to parse resource config: %w", err)
 		}
 		bindings = append(bindings, &binding{
@@ -245,7 +247,7 @@ func (t *transactor) Store(it *pm.StoreIterator) (pm.StartCommitFunc, error) {
 		var parsed = buildDocument(b, it.Key, it.Values)
 		var tsStr, tsOk = parsed["ts"].(string)
 		var text, textOk = parsed["text"].(string)
-		var blocks, blocksOk = parsed["blocks"].(json.RawMessage)
+		var blocks = parsed["blocks"].(json.RawMessage)
 
 		if !tsOk {
 			return nil, fmt.Errorf("missing timestamp")
@@ -262,31 +264,25 @@ func (t *transactor) Store(it *pm.StoreIterator) (pm.StartCommitFunc, error) {
 		}
 
 		var blocksParsed slack.Blocks
-		if blocksOk {
-			// Is this jank? This should really be taken care of by the
-			// serialization logic in slack.Block, but it can't be _that_
-			// bad to do it here... right? see below:
-			// https://api.slack.com/reference/surfaces/formatting#escaping
-			var escaped_blocks = string(blocks)
-			escaped_blocks = strings.ReplaceAll(escaped_blocks, "&", "&amp;")
-			escaped_blocks = strings.ReplaceAll(escaped_blocks, "<", "&lt;")
-			escaped_blocks = strings.ReplaceAll(escaped_blocks, ">", "&gt;")
 
-			err = json.Unmarshal([]byte(escaped_blocks), &blocksParsed)
+		// Is this jank? This should really be taken care of by the
+		// serialization logic in slack.Block, but it can't be _that_
+		// bad to do it here... right? see below:
+		// https://api.slack.com/reference/surfaces/formatting#escaping
+		var escaped_blocks = string(blocks)
+		escaped_blocks = strings.ReplaceAll(escaped_blocks, "&", "&amp;")
+		escaped_blocks = strings.ReplaceAll(escaped_blocks, "<", "&lt;")
+		escaped_blocks = strings.ReplaceAll(escaped_blocks, ">", "&gt;")
 
-			if err != nil {
-				return nil, fmt.Errorf("invalid blocks value %q, %q: %w", reflect.TypeOf(blocks), string(blocks), err)
-			}
-		} else {
-			log.Warn(fmt.Sprintf("Blocks apparently NOT okay: %+v", reflect.TypeOf(parsed["blocks"])))
+		if err := json.Unmarshal([]byte(escaped_blocks), &blocksParsed); err != nil {
+			return nil, fmt.Errorf("invalid blocks value %q, %q: %w", reflect.TypeOf(blocks), string(blocks), err)
 		}
 
 		// Accept messages from at most 10 minutes in the past
 		if time.Since(ts).Minutes() < 10 {
 			if err := t.api.PostMessage(b.resource.Channel, text, blocksParsed.BlockSet, b.resource.SenderConfig); err != nil {
-				log.Warn(fmt.Errorf("error sending message: %w", err))
+				return nil, fmt.Errorf("error sending message (%q): %w", ts, err)
 			}
-			// rate limiting at home:
 			time.Sleep(time.Second * 10)
 		} else {
 			log.Warn(fmt.Sprintf("Ignoring message from the past: %q", ts))
@@ -300,7 +296,5 @@ func (transactor) Destroy() {
 }
 
 func main() {
-	log.SetLevel(log.DebugLevel)
-	log.Info("connector starting")
 	boilerplate.RunMain(new(driver))
 }

--- a/materialize-slack/slack.go
+++ b/materialize-slack/slack.go
@@ -17,8 +17,6 @@ type SlackSenderConfig struct {
 type SlackAPI struct {
 	Client slack.Client // Bearer token for authentication
 
-	SenderConfig SlackSenderConfig
-
 	channelIDs map[string]string // Cache for channel Name->ID mappings
 }
 
@@ -33,7 +31,7 @@ func (api *SlackAPI) AuthTest() error {
 
 // PostMessage sends a simple message to the specified channel name or ID.
 // If the channel is specified by ID it should be prefixed like `id:C1234`.
-func (api *SlackAPI) PostMessage(channel, text string, blocks []slack.Block) error {
+func (api *SlackAPI) PostMessage(channel, text string, blocks []slack.Block, config SlackSenderConfig) error {
 	var channelID, err = api.GetChannelID(channel)
 	if err != nil {
 		return fmt.Errorf("error getting channel id: %w", err)
@@ -43,9 +41,9 @@ func (api *SlackAPI) PostMessage(channel, text string, blocks []slack.Block) err
 		channelID,
 		slack.MsgOptionText(text, false),
 		slack.MsgOptionBlocks(blocks...),
-		slack.MsgOptionUsername(api.SenderConfig.DisplayName),
-		slack.MsgOptionIconEmoji(api.SenderConfig.LogoEmoji),
-		slack.MsgOptionIconURL(api.SenderConfig.LogoPicture),
+		slack.MsgOptionUsername(config.DisplayName),
+		slack.MsgOptionIconEmoji(config.LogoEmoji),
+		slack.MsgOptionIconURL(config.LogoPicture),
 	)
 	if err != nil {
 		return err

--- a/materialize-slack/slack.go
+++ b/materialize-slack/slack.go
@@ -1,0 +1,130 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"strings"
+)
+
+type slackAPI struct {
+	Token string // Bearer token for authentication
+
+	channelIDs map[string]string // Cache for channel Name->ID mappings
+}
+
+type slackAuthTestResponse struct {
+	Okay  bool   `json:"ok"`
+	Error string `json:"error"`
+}
+
+// AuthTest invokes the `auth.test` method of the Slack API and returns an error if the test fails.
+func (api *slackAPI) AuthTest() error {
+	var resp slackAuthTestResponse
+	if err := api.request("GET", "auth.test", nil, &resp); err != nil {
+		return err
+	}
+	if !resp.Okay {
+		return fmt.Errorf("slack api error %q", resp.Error)
+	}
+	return nil
+}
+
+type slackPostMessageRequest struct {
+	Channel string `json:"channel"` // The channel ID to post to
+	Text    string `json:"text"`    // The message to post
+}
+
+type slackPostMessageResponse struct {
+	Okay  bool   `json:"ok"`
+	Error string `json:"error"` // Error type, if not okay
+}
+
+// PostMessage sends a simple message to the specified channel name or ID.
+// If the channel is specified by ID it should be prefixed like `id:C1234`.
+func (api *slackAPI) PostMessage(channel, message string) error {
+	var channelID, err = api.GetChannelID(channel)
+	if err != nil {
+		return fmt.Errorf("error getting channel id: %w", err)
+	}
+
+	var req = slackPostMessageRequest{Channel: channelID, Text: message}
+	var resp slackPostMessageResponse
+	if err := api.request("POST", "chat.postMessage", &req, &resp); err != nil {
+		return err
+	}
+	if !resp.Okay {
+		return fmt.Errorf("slack api error %q", resp.Error)
+	}
+	return nil
+}
+
+type slackListChannelsResponse struct {
+	Okay     bool                     `json:"ok"`
+	Error    string                   `json:"error"`
+	Channels []slackListChannelsEntry `json:"channels"`
+}
+
+type slackListChannelsEntry struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
+func (api *slackAPI) GetChannelID(name string) (string, error) {
+	if strings.HasPrefix(name, "id:") {
+		return strings.TrimPrefix(name, "id:"), nil
+	}
+
+	if api.channelIDs == nil {
+		log.Println("fetching channels list...")
+
+		var resp slackListChannelsResponse
+		if err := api.request("GET", "conversations.list", nil, &resp); err != nil {
+			return "", fmt.Errorf("error listing channels: %w", err)
+		}
+		if !resp.Okay {
+			return "", fmt.Errorf("slack api error %q", resp.Error)
+		}
+
+		api.channelIDs = make(map[string]string)
+		for _, channel := range resp.Channels {
+			log.Printf("  + channel %q with id %q", channel.Name, channel.ID)
+			api.channelIDs[channel.Name] = channel.ID
+		}
+	}
+
+	var id, ok = api.channelIDs[name]
+	if !ok {
+		return "", fmt.Errorf("channel %q not found", name)
+	}
+	return id, nil
+}
+
+func (api *slackAPI) request(httpMethod, funcName string, req, resp interface{}) error {
+	reqBytes, err := json.Marshal(req)
+	if err != nil {
+		return fmt.Errorf("error serializing %q request to JSON: %w", funcName, err)
+	}
+	reqObject, err := http.NewRequest(httpMethod, "https://slack.com/api/"+funcName, bytes.NewReader(reqBytes))
+	if err != nil {
+		return fmt.Errorf("error constructing %q request object: %w", funcName, err)
+	}
+	reqObject.Header.Set("Content-Type", "application/json")
+	reqObject.Header.Set("Authorization", "Bearer "+api.Token)
+	respObject, err := http.DefaultClient.Do(reqObject)
+	if err != nil {
+		return fmt.Errorf("error performing %q request: %w", funcName, err)
+	}
+	defer respObject.Body.Close()
+	respBytes, err := ioutil.ReadAll(respObject.Body)
+	if err != nil {
+		return fmt.Errorf("error reading %q response body: %w", funcName, err)
+	}
+	if err := json.Unmarshal(respBytes, resp); err != nil {
+		return fmt.Errorf("error deserializing %q response from JSON: %w", funcName, err)
+	}
+	return nil
+}

--- a/materialize-slack/slack.go
+++ b/materialize-slack/slack.go
@@ -2,9 +2,9 @@ package main
 
 import (
 	"fmt"
-	"log"
 	"strings"
 
+	log "github.com/sirupsen/logrus"
 	slack "github.com/slack-go/slack"
 )
 
@@ -45,21 +45,7 @@ func (api *SlackAPI) PostMessage(channel, text string, blocks []slack.Block, con
 		slack.MsgOptionIconEmoji(config.LogoEmoji),
 		slack.MsgOptionIconURL(config.LogoPicture),
 	)
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
-type slackListChannelsResponse struct {
-	Okay     bool                     `json:"ok"`
-	Error    string                   `json:"error"`
-	Channels []slackListChannelsEntry `json:"channels"`
-}
-
-type slackListChannelsEntry struct {
-	ID   string `json:"id"`
-	Name string `json:"name"`
+	return err
 }
 
 func (api *SlackAPI) GetChannelID(name string) (string, error) {
@@ -68,7 +54,6 @@ func (api *SlackAPI) GetChannelID(name string) (string, error) {
 	}
 
 	if api.channelIDs == nil {
-		log.Println("fetching channels list...")
 		var channels []slack.Channel
 		var cursor string
 
@@ -116,15 +101,6 @@ func (api *SlackAPI) ConversationInfo(name string) (*slack.Channel, error) {
 	}
 
 	return resp, nil
-}
-
-type slackJoinChannelRequest struct {
-	Channel string `json:"channel"` // The channel ID to join
-}
-
-type slackJoinChannelResponse struct {
-	Okay  bool   `json:"ok"`
-	Error string `json:"error"`
 }
 
 func (api *SlackAPI) JoinChannel(name string) error {

--- a/materialize-slack/slack.go
+++ b/materialize-slack/slack.go
@@ -79,7 +79,7 @@ func (api *SlackAPI) GetChannelID(name string) (string, error) {
 			if err != nil {
 				return "", err
 			}
-			if len(found_channels) > 0 {
+			if nextCursor != "" {
 				channels = append(channels, found_channels...)
 				cursor = nextCursor
 			} else {

--- a/materialize-slack/slack.go
+++ b/materialize-slack/slack.go
@@ -74,7 +74,7 @@ func (api *SlackAPI) GetChannelID(name string) (string, error) {
 
 		api.channelIDs = make(map[string]string)
 		for _, channel := range channels {
-			log.Printf("  + channel %q with id %q", channel.Name, channel.ID)
+			log.WithFields(log.Fields{"channel": channel.Name, "id": channel.ID}).Info("joining channel")
 			api.channelIDs[channel.Name] = channel.ID
 		}
 	}


### PR DESCRIPTION
**Description:**

This fleshes out the Slack materialization connector that @willdonnelly originally wrote for one of our hackathons.

It automatically deals with joining channels when needed, and lets you specify a username and profile picture to communicate as. It also supports rich messages via Slack's `blocks` API

**Note:**
One thing I don't love is the config schema, which results in the following UI:
<img width="942" alt="Screen Shot 2023-05-19 at 13 36 05" src="https://github.com/estuary/connectors/assets/4368270/adbf6d73-a5e0-4f97-917a-f51c24abbdd9">
By default, `Sender Config` is collapsed. This comes from 
```go
type config struct {
	SenderConfig SlackSenderConfig `json:"sender_config" jsonschema:"title=Slack Config"`
	Credentials  CredentialConfig  `json:"credentials" jsonschema:"title=Authentication" jsonschema_extras:"x-oauth2-provider=slack"`
}
```
I had to extract `SlackSenderConfig` because it was used in a few different places. What I really want is the equivalent to [Serde's flatten attribute](https://serde.rs/attr-flatten.html), but I can't figure out a way to get Go to do the same thing. Any ideas?


<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/722)
<!-- Reviewable:end -->
