### PR TITLE
Revert "materialize-sql: recommend string field locations that are formatted as numeric"

### DIFF
--- a/materialize-sql/validate.go
+++ b/materialize-sql/validate.go
@@ -75,11 +75,11 @@ func validateNewProjection(resource Resource, projection *pf.Projection) *pm.Res
 	case projection.IsRootDocumentProjection():
 		constraint.Type = pm.Response_Validated_Constraint_LOCATION_REQUIRED
 		constraint.Reason = "The root document must be materialized"
-	case projection.Inference.IsSingleScalarType() || len(effectiveJsonTypes(projection)) == 1:
+	case projection.Inference.IsSingleScalarType():
 		constraint.Type = pm.Response_Validated_Constraint_LOCATION_RECOMMENDED
 		constraint.Reason = "The projection has a single scalar type"
 
-	case projection.Inference.IsSingleType():
+	case projection.Inference.IsSingleType() || len(effectiveJsonTypes(projection)) == 1:
 		constraint.Type = pm.Response_Validated_Constraint_FIELD_OPTIONAL
 		constraint.Reason = "This field is able to be materialized"
 	default:


### PR DESCRIPTION
Reverts estuary/connectors#719

This ended up breaking materializations that use `recommended: true` in their field selections. The problem is that it now recommends fields that are `type: object` or `type: array`. So I'm reverting for now, and we can revisit the original problem later.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/724)
<!-- Reviewable:end -->
