### PR TITLE
materialize-sql: fix numeric format strings as recommended and handle nullable

### DIFF
--- a/materialize-sql/type_mapping.go
+++ b/materialize-sql/type_mapping.go
@@ -112,16 +112,24 @@ func (p *Projection) AsFlatType() (_ FlatType, mustExist bool) {
 }
 
 // effectiveJsonTypes potentially maps the provided JSON types into alternate types for
-// materialization. It currently supports strings formatted as numeric values, either as stand-alone
-// string types or as a string type formatted as numeric + that numeric type. It does not apply to
-// keyed fields.
+// materialization. It currently supports potentially nullable strings formatted as numeric values,
+// either as stand-alone string types or as a string type formatted as numeric + that numeric type.
+// It does not apply to keyed fields.
 func effectiveJsonTypes(projection *pf.Projection) []string {
 	if !projection.IsPrimaryKey && projection.Inference.String_ != nil {
 		switch {
+		case projection.Inference.String_.Format == "integer" && reflect.DeepEqual(projection.Inference.Types, []string{"integer", "null", "string"}):
+			return []string{"integer", "null"}
+		case projection.Inference.String_.Format == "number" && reflect.DeepEqual(projection.Inference.Types, []string{"null", "number", "string"}):
+			return []string{"null", "number"}
 		case projection.Inference.String_.Format == "integer" && reflect.DeepEqual(projection.Inference.Types, []string{"integer", "string"}):
 			return []string{"integer"}
 		case projection.Inference.String_.Format == "number" && reflect.DeepEqual(projection.Inference.Types, []string{"number", "string"}):
 			return []string{"number"}
+		case projection.Inference.String_.Format == "integer" && reflect.DeepEqual(projection.Inference.Types, []string{"null", "string"}):
+			return []string{"integer", "null"}
+		case projection.Inference.String_.Format == "number" && reflect.DeepEqual(projection.Inference.Types, []string{"null", "string"}):
+			return []string{"null", "number"}
 		case projection.Inference.String_.Format == "integer" && reflect.DeepEqual(projection.Inference.Types, []string{"string"}):
 			return []string{"integer"}
 		case projection.Inference.String_.Format == "number" && reflect.DeepEqual(projection.Inference.Types, []string{"string"}):

--- a/materialize-sql/type_mapping_test.go
+++ b/materialize-sql/type_mapping_test.go
@@ -84,15 +84,6 @@ func TestAsFlatType(t *testing.T) {
 			mustExist: false,
 		},
 		{
-			name: "multiple types with null",
-			inference: pf.Inference{
-				Exists: pf.Inference_MUST,
-				Types:  []string{"integer", "string", "null"},
-			},
-			flatType:  MULTIPLE,
-			mustExist: false,
-		},
-		{
 			name: "no types",
 			inference: pf.Inference{
 				Exists: pf.Inference_MUST,
@@ -150,19 +141,31 @@ func TestAsFlatType(t *testing.T) {
 			mustExist: false,
 		},
 		{
-			name: "allowable format with a null is not mustExist",
+			name: "nullable string and numeric formatted as numeric",
 			inference: pf.Inference{
-				Exists: pf.Inference_MUST,
-				Types:  []string{"string", "null"},
+				Exists: pf.Inference_MAY,
+				Types:  []string{"integer", "null", "string"},
+				String_: &pf.Inference_String{
+					Format: "integer",
+				},
+			},
+			flatType:  INTEGER,
+			mustExist: false,
+		},
+		{
+			name: "nullable string formatted as numeric",
+			inference: pf.Inference{
+				Exists: pf.Inference_MAY,
+				Types:  []string{"null", "string"},
 				String_: &pf.Inference_String{
 					Format: "number",
 				},
 			},
-			flatType:  STRING,
+			flatType:  NUMBER,
 			mustExist: false,
 		},
 		{
-			name: "single string formatted as numeric",
+			name: "non-nullable single string formatted as numeric",
 			inference: pf.Inference{
 				Exists: pf.Inference_MUST,
 				Types:  []string{"string"},


### PR DESCRIPTION
**Description:**

This PR accomplishes 2 things:
- Originally in 9e6b387 there was a change intended to make string fields formatted as numeric (integer or number) be included in the "recommended" fields. That change inadvertently also cause object and array fields, or indeed ANY field with a single type, to also be recommended. This new version of that change will only recommend fields that map to a `FlatType` of `INTEGER` or `NUMBER` to accomplish the original goal without including other unintended single-type fields.
- Updates the `effectiveJsonTypes` mapping to handle nullable strings formatted as numeric in addition to non-nullable fields of this kind, which closes https://github.com/estuary/connectors/issues/723. These fields will also be recommended by default now.

**Workflow steps:**

Materialize string type fields formatted as numeric, either nullable or required, and see that they are included in the recommended fields by default. Object and array type fields with a single type are not. I tested with a couple of representative SQL materializations (postgres and snowflake) with this `readSchema` to confirm the intended behavior:

```yaml
properties:
  key:
    type: integer
  array:
    type: array
  obj:
    type: object
  stringAsIntegerNotRequired:
    format: integer
    type: string
  stringAsIntegerRequired:
    format: integer
    type: string
  stringAsNumberNotRequired:
    format: number
    type: string
  stringAsNumberRequired:
    format: number
    type: string
  stringIntegerAsIntegerNotRequired:
    format: integer
    type:
      - string
      - integer
  stringIntegerAsIntegerRequired:
    format: integer
    type:
      - string
      - integer
  stringNumberAsNumberNotRequired:
    format: number
    type:
      - string
      - number
  stringNumberAsNumberRequired:
    format: number
    type:
      - string
      - number
required:
  - key
  - stringIntegerAsIntegerRequired
  - stringAsIntegerRequired
  - stringNumberAsNumberRequired
  - stringAsNumberRequired
  - obj
  - array
type: object
```

**Documentation links affected:**

N/A

**Notes for reviewers:**

The extended checks in `effectiveJsonTypes` are a little verbose but I couldn't think of a more concise way to do it that didn't involve what I thought would be a confusing amount of indirection, so I kept it very explicit.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/725)
<!-- Reviewable:end -->
