### PR TITLE
filesource: switch to flow protocol

### DIFF
--- a/build-local.sh
+++ b/build-local.sh
@@ -9,6 +9,6 @@ docker buildx build \
   --cache-from=type=local,src=.docker-cache \
   --platform linux/amd64 \
   --load \
-  -t $1:local \
+  -t ghcr.io/estuary/$1:local \
   -f $1/Dockerfile \
   .

--- a/filesource/filesource.go
+++ b/filesource/filesource.go
@@ -197,7 +197,7 @@ func (src *Source) Discover(ctx context.Context, req *pc.Request_Discover) (*pc.
 	resourceJSON, err := json.Marshal(resource{Stream: root})
 
 	return &pc.Response_Discovered{Bindings: []*pc.Response_Discovered_Binding{{
-		RecommendedName:    pf.Collection(root),
+		RecommendedName:    pf.Collection(strings.Trim(root, "/")),
 		ResourceConfigJson: resourceJSON,
 		DocumentSchemaJson: json.RawMessage(minimalDocumentSchema),
 		Key:                []string{"/_meta/file", "/_meta/offset"},

--- a/filesource/filesource.go
+++ b/filesource/filesource.go
@@ -351,7 +351,7 @@ func (r *reader) shouldSkip(obj ObjectInfo) (_ bool, reason string) {
 		return true, "regex not matched"
 	}
 	// Is it outside of our responsible key range?
-	if !boilerplate.IncludesHwHash(r.range_, []byte(obj.Path)) {
+	if !boilerplate.RangeIncludesHwHash(r.range_, []byte(obj.Path)) {
 		return true, "path not in range"
 	}
 

--- a/filesource/filesource.go
+++ b/filesource/filesource.go
@@ -186,22 +186,22 @@ func (src *Source) Discover(ctx context.Context, req *pc.Request_Discover) (*pc.
 		return nil, fmt.Errorf("parsing config json: %w", err)
 	}
 
-  store, err := src.Connect(ctx, cfg)
+	store, err := src.Connect(ctx, cfg)
 	if err != nil {
 		return nil, fmt.Errorf("connecting to store: %w", err)
 	}
 
 	var conn = connector{config: cfg, store: store}
 
-  var root = conn.config.DiscoverRoot()
-  resourceJSON, err := json.Marshal(resource{Stream: root})
+	var root = conn.config.DiscoverRoot()
+	resourceJSON, err := json.Marshal(resource{Stream: root})
 
 	return &pc.Response_Discovered{Bindings: []*pc.Response_Discovered_Binding{{
-			RecommendedName:    pf.Collection(root),
-			ResourceConfigJson: resourceJSON,
-			DocumentSchemaJson: json.RawMessage(minimalDocumentSchema),
-			Key:                []string{"/_meta/file", "/_meta/offset"},
-  }}}, nil
+		RecommendedName:    pf.Collection(root),
+		ResourceConfigJson: resourceJSON,
+		DocumentSchemaJson: json.RawMessage(minimalDocumentSchema),
+		Key:                []string{"/_meta/file", "/_meta/offset"},
+	}}}, nil
 }
 
 // Pull is a very long lived RPC through which the Flow runtime and a
@@ -214,7 +214,7 @@ func (src *Source) Pull(open *pc.Request_Open, stream *boilerplate.PullOutput) e
 
 	var ctx = stream.Context()
 
-  store, err := src.Connect(ctx, cfg)
+	store, err := src.Connect(ctx, cfg)
 	if err != nil {
 		return fmt.Errorf("connecting to store: %w", err)
 	}
@@ -244,7 +244,7 @@ func (src *Source) Pull(open *pc.Request_Open, stream *boilerplate.PullOutput) e
 		return err
 	}
 
-  grp, ctx := errgroup.WithContext(ctx)
+	grp, ctx := errgroup.WithContext(ctx)
 	for i, binding := range open.Capture.Bindings {
 		// Stream names represent an absolute path prefix to capture.
 		var res resource
@@ -258,8 +258,8 @@ func (src *Source) Pull(open *pc.Request_Open, stream *boilerplate.PullOutput) e
 
 		var r = &reader{
 			connector: &conn,
-      binding:   i,
-      stream:    stream,
+			binding:   i,
+			stream:    stream,
 			pathRe:    pathRe,
 			prefix:    prefix,
 			schema:    binding.Collection.WriteSchemaJson,
@@ -296,8 +296,8 @@ type reader struct {
 	prefix string
 	schema json.RawMessage
 	state  State
-  binding int
-  stream *boilerplate.PullOutput
+	binding int
+	stream *boilerplate.PullOutput
 	range_ *pf.RangeSpec
 
 	shared struct {
@@ -308,7 +308,7 @@ type reader struct {
 
 func (r *reader) sweep(ctx context.Context) error {
 	log.Info(fmt.Sprintf("sweeping %s starting at %q, from %s through %s",
-		r.prefix, r.state.Path, r.state.MinBound, r.state.MaxBound))
+	r.prefix, r.state.Path, r.state.MinBound, r.state.MaxBound))
 
 	var listing, err = r.store.List(ctx, Query{
 		Prefix:    r.prefix,
@@ -337,7 +337,7 @@ func (r *reader) sweep(ctx context.Context) error {
 	}
 
 	log.Info(fmt.Sprintf("completed sweep of %s from %s through %s",
-		r.prefix, r.state.MinBound, r.state.MaxBound))
+	r.prefix, r.state.MinBound, r.state.MaxBound))
 	r.state.finishSweep(r.config.FilesAreMonotonic())
 
 	// Write a final checkpoint to mark the completion of the sweep.
@@ -437,9 +437,9 @@ func (r *reader) emit(lines []json.RawMessage) error {
 	defer r.shared.mu.Unlock()
 	r.shared.states[r.prefix] = r.state
 
-  if encodedCheckpoint, err := json.Marshal(r.shared.states); err != nil {
-    return err
-  } else if err := r.stream.Checkpoint(encodedCheckpoint, true); err != nil {
+	if encodedCheckpoint, err := json.Marshal(r.shared.states); err != nil {
+		return err
+	} else if err := r.stream.Checkpoint(encodedCheckpoint, true); err != nil {
 		return err
 	}
 

--- a/filesource/filesource.go
+++ b/filesource/filesource.go
@@ -129,7 +129,7 @@ type connector struct {
 }
 
 type resource struct {
-	Stream   string `json:"stream" jsonschema:"title=Stream to capture from"`
+	Stream   string `json:"stream" jsonschema:"title=Stream to capture from" jsonschema_extras="x-collection-name=true"`
   SyncMode string `json:"syncMode"`
 }
 

--- a/filesource/filesource.go
+++ b/filesource/filesource.go
@@ -130,6 +130,7 @@ type connector struct {
 
 type resource struct {
 	Stream   string `json:"stream" jsonschema:"title=Stream to capture from"`
+  SyncMode string `json:"syncMode"`
 }
 
 func (r resource) Validate() error {
@@ -242,6 +243,10 @@ func (src *Source) Pull(open *pc.Request_Open, stream *boilerplate.PullOutput) e
 		if pathRe, err = regexp.Compile(r); err != nil {
 			return fmt.Errorf("building regex: %w", err)
 		}
+	}
+
+	if err := stream.Ready(false); err != nil {
+		return err
 	}
 
   grp, ctx := errgroup.WithContext(ctx)

--- a/filesource/state.go
+++ b/filesource/state.go
@@ -23,22 +23,22 @@ func (p States) Validate() error {
 // State of a captured file prefix.
 type State struct {
 	// Exclusive lower bound modification time of files processed in this sweep.
-	MinBound time.Time `json:"minBound,omitempty"`
+	MinBound time.Time `json:"minBound"`
 	// MaxBound is the exclusive upper-bound of files being processed in this sweep.
 	// If MaxBound is nil, then this state checkpoint was generated after the completion
 	// of a prior sweep and before the commencement of the next one.
-	MaxBound *time.Time `json:"maxBound,omitempty"`
+	MaxBound *time.Time `json:"maxBound"`
 	// Maximum modification time of any object processed during this sweep,
 	// or nil if no files have been processed so far.
 	// The MaxMod of a current sweep becomes the MinBound of the next sweep.
-	MaxMod *time.Time `json:"maxMod,omitempty"`
+	MaxMod *time.Time `json:"maxMod"`
 
 	// Base path which is currently being processed, or was last processed (if Complete).
-	Path string `json:"path,omitempty"`
+	Path string `json:"path"`
 	// Number of records from the file at |Path| which have been emitted.
-	Records int `json:"records,omitempty"`
+	Records int `json:"records"`
 	// Whether the file at |Path| is complete.
-	Complete bool `json:"complete,omitempty"`
+	Complete bool `json:"complete"`
 
 	// skip is used for crash recovery. It's the number of records of the current
 	// Path which we'll skip, to seek to the point of prior maximum progres.

--- a/source-boilerplate/boilerplate.go
+++ b/source-boilerplate/boilerplate.go
@@ -384,34 +384,34 @@ func hwHashPartition(partitionId []byte) uint32 {
 	return uint32(highwayhash.Sum64(partitionId, highwayHashKey) >> 32)
 }
 
-func RangeIncludesHwHash(range_ *pf.RangeSpec, partitionID []byte) bool {
+func RangeIncludesHwHash(r *pf.RangeSpec, partitionID []byte) bool {
 	var hashed = hwHashPartition(partitionID)
-	return hashed >= range_.KeyBegin && hashed <= range_.KeyEnd
+	return RangeIncludes(r, hashed)
 }
 
 func RangeIncludes(r *pf.RangeSpec, hash uint32) bool {
 	return hash >= r.KeyBegin && hash <= r.KeyEnd
 }
 
-// RangeOverlap is the result of checking whether one Range overlaps another.
-type RangeOverlap int
+// RangeContain is the result of checking whether one Range contains another.
+type RangeContain int
 
 const (
-	NoRangeOverlap      RangeOverlap = 0
-	PartialRangeOverlap RangeOverlap = 1
-	FullRangeOverlap    RangeOverlap = 2
+	NoRangeContain      RangeContain = 0
+	PartialRangeContain RangeContain = 1
+	FullRangeContain    RangeContain = 2
 )
 
-func RangesOverlap(rangeOne *pf.RangeSpec, rangeTwo *pf.RangeSpec) RangeOverlap {
+func RangeContained(rangeOne *pf.RangeSpec, rangeTwo *pf.RangeSpec) RangeContain {
 	var includesBegin = RangeIncludes(rangeOne, rangeTwo.KeyBegin)
 	var includesEnd = RangeIncludes(rangeOne, rangeTwo.KeyEnd)
 
 	if includesBegin && includesEnd {
-		return FullRangeOverlap
+		return FullRangeContain
 	} else if includesBegin != includesEnd {
-		return PartialRangeOverlap
+		return PartialRangeContain
 	} else {
-		return NoRangeOverlap
+		return NoRangeContain
 	}
 }
 

--- a/source-gcs/Dockerfile
+++ b/source-gcs/Dockerfile
@@ -13,6 +13,7 @@ RUN go mod download
 
 COPY go         ./go
 COPY filesource ./filesource
+COPY source-boilerplate ./source-boilerplate
 COPY source-gcs ./source-gcs
 
 # Run the unit tests.
@@ -38,9 +39,7 @@ COPY --from=builder /builder/connector ./source-gcs
 # Avoid running the connector as root.
 USER nonroot:nonroot
 
-COPY --from=ghcr.io/estuary/airbyte-to-flow:dev /airbyte-to-flow ./
-ENTRYPOINT ["/connector/airbyte-to-flow", "--connector-entrypoint", "/connector/source-gcs"]
+ENTRYPOINT ["/connector/source-gcs"]
 
 LABEL FLOW_RUNTIME_PROTOCOL=capture
 LABEL CONNECTOR_PROTOCOL=flow-capture
-LABEL FLOW_RUNTIME_CODEC=json

--- a/source-gcs/main.go
+++ b/source-gcs/main.go
@@ -59,7 +59,7 @@ type gcStore struct {
 	gcs *storage.Client
 }
 
-func newGCStore(ctx context.Context, cfg *config) (*gcStore, error) {
+func newGCStore(ctx context.Context, cfg config) (*gcStore, error) {
 
 	var opt option.ClientOption
 	if cfg.GoogleCredentials != "" {
@@ -83,7 +83,7 @@ func newGCStore(ctx context.Context, cfg *config) (*gcStore, error) {
 // validateBucket verifies that we can list objects in the bucket and read an object in the bucket.
 // This is done in a way that requires only storage.objects.list and storage.objects.get since these
 // are the permissions required by the connector.
-func validateBucket(ctx context.Context, cfg *config, client *storage.Client) error {
+func validateBucket(ctx context.Context, cfg config, client *storage.Client) error {
 	iter := client.Bucket(cfg.Bucket).Objects(ctx, &storage.Query{
 		Prefix: cfg.Prefix,
 	})
@@ -172,7 +172,6 @@ func (s *gcStore) Read(ctx context.Context, obj filesource.ObjectInfo) (io.ReadC
 }
 
 func main() {
-
 	var src = filesource.Source{
     NewConfig: func(raw json.RawMessage) (filesource.Config, error) {
       var cfg config
@@ -182,7 +181,7 @@ func main() {
       return cfg, nil
     },
 		Connect: func(ctx context.Context, cfg filesource.Config) (filesource.Store, error) {
-			return newGCStore(ctx, cfg.(*config))
+			return newGCStore(ctx, cfg.(config))
 		},
 		ConfigSchema: func(parserSchema json.RawMessage) json.RawMessage {
 			return json.RawMessage(`{

--- a/source-http-file/Dockerfile
+++ b/source-http-file/Dockerfile
@@ -13,6 +13,7 @@ RUN go mod download
 
 COPY go               ./go
 COPY filesource       ./filesource
+COPY source-boilerplate ./source-boilerplate
 COPY source-http-file ./source-http-file
 
 # Run the unit tests.
@@ -38,9 +39,7 @@ COPY --from=builder /builder/connector ./source-http-file
 # Avoid running the connector as root.
 USER nonroot:nonroot
 
-COPY --from=ghcr.io/estuary/airbyte-to-flow:dev /airbyte-to-flow ./
-ENTRYPOINT ["/connector/airbyte-to-flow", "--connector-entrypoint", "/connector/source-http-file"]
+ENTRYPOINT ["/connector/source-http-file"]
 
 LABEL FLOW_RUNTIME_PROTOCOL=capture
 LABEL CONNECTOR_PROTOCOL=flow-capture
-LABEL FLOW_RUNTIME_CODEC=json

--- a/source-kinesis/Dockerfile
+++ b/source-kinesis/Dockerfile
@@ -11,8 +11,9 @@ WORKDIR /builder
 COPY go.* ./
 RUN go mod download
 
-COPY go             ./go
-COPY source-kinesis ./source-kinesis
+COPY go                 ./go
+COPY source-boilerplate ./source-boilerplate
+COPY source-kinesis     ./source-kinesis
 
 # Run the unit tests.
 RUN go test -v ./source-kinesis/...
@@ -36,9 +37,7 @@ COPY --from=builder /builder/connector ./source-kinesis
 # Avoid running the connector as root.
 USER nonroot:nonroot
 
-COPY --from=ghcr.io/estuary/airbyte-to-flow:dev /airbyte-to-flow ./
-ENTRYPOINT ["/connector/airbyte-to-flow", "--connector-entrypoint", "/connector/source-kinesis"]
+ENTRYPOINT ["/connector/source-kinesis"]
 
 LABEL FLOW_RUNTIME_PROTOCOL=capture
 LABEL CONNECTOR_PROTOCOL=flow-capture
-LABEL FLOW_RUNTIME_CODEC=json

--- a/source-kinesis/capture.go
+++ b/source-kinesis/capture.go
@@ -9,7 +9,8 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/kinesis"
-	"github.com/estuary/flow/go/protocols/airbyte"
+	pf "github.com/estuary/flow/go/protocols/flow"
+	boilerplate "github.com/estuary/connectors/source-boilerplate"
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/time/rate"
 )
@@ -19,11 +20,12 @@ import (
 // The `wg` is expected to have been incremented once _prior_ to calling this function. It will be
 // further incremented and decremented behind the scenes, but will be decremented back down to the
 // prior value when the read is finished.
-func readStream(ctx context.Context, shardRange airbyte.Range, client *kinesis.Kinesis, stream string, state map[string]string, resultsCh chan<- readResult, wg *sync.WaitGroup) {
+func readStream(ctx context.Context, shardRange *pf.RangeSpec, client *kinesis.Kinesis, idx int, stream string, state map[string]string, resultsCh chan<- readResult, wg *sync.WaitGroup) {
 
 	var kc = &streamReader{
 		client:         client,
 		ctx:            ctx,
+		idx:            idx,
 		stream:         stream,
 		shardRange:     shardRange,
 		dataCh:         resultsCh,
@@ -40,6 +42,7 @@ func readStream(ctx context.Context, shardRange airbyte.Range, client *kinesis.K
 		select {
 		case resultsCh <- readResult{
 			source: &recordSource{
+				idx: idx,
 				stream: stream,
 			},
 			err: err,
@@ -55,8 +58,9 @@ func readStream(ctx context.Context, shardRange airbyte.Range, client *kinesis.K
 type streamReader struct {
 	client             *kinesis.Kinesis
 	ctx                context.Context
+	idx                int
 	stream             string
-	shardRange         airbyte.Range
+	shardRange         *pf.RangeSpec
 	dataCh             chan<- readResult
 	waitGroup          *sync.WaitGroup
 	readingShards      map[string]bool
@@ -69,6 +73,7 @@ type streamReader struct {
 }
 
 type recordSource struct {
+	idx     int
 	stream  string
 	shardID string
 }
@@ -210,7 +215,7 @@ func (kc *streamReader) startReadingShardByID(shardID string) {
 			select {
 			case <-kc.ctx.Done():
 			case kc.dataCh <- readResult{
-				source: &recordSource{stream: kc.stream, shardID: shardID},
+				source: &recordSource{idx: kc.idx, stream: kc.stream, shardID: shardID},
 				err:    err,
 			}:
 			}
@@ -231,8 +236,8 @@ func (kc *streamReader) newShardReader(shardID string, getShard func(string) (*k
 	var logEntry = log.WithFields(log.Fields{
 		"kinesisStream":     kc.stream,
 		"kinesisShardId":    *shard.ShardId,
-		"captureRangeStart": kc.shardRange.Begin,
-		"captureRangeEnd":   kc.shardRange.End,
+		"captureRangeStart": kc.shardRange.KeyBegin,
+		"captureRangeEnd":   kc.shardRange.KeyEnd,
 	})
 	var source = &recordSource{
 		stream:  kc.stream,
@@ -242,8 +247,8 @@ func (kc *streamReader) newShardReader(shardID string, getShard func(string) (*k
 	if err != nil {
 		return nil, fmt.Errorf("parsing kinesis shard range: %w", err)
 	}
-	var rangeResult = kc.shardRange.Overlaps(kinesisRange)
-	if rangeResult == airbyte.NoRangeOverlap {
+	var rangeResult = boilerplate.RangesOverlap(kc.shardRange, &kinesisRange)
+	if rangeResult == boilerplate.NoRangeOverlap {
 		logEntry.Info("Will not read kinesis shard because it falls outside of our hash range")
 		return nil, nil
 	}
@@ -267,7 +272,7 @@ func (kc *streamReader) newShardReader(shardID string, getShard func(string) (*k
 
 	return &shardReader{
 		rangeOverlap:      rangeResult,
-		kinesisShardRange: kinesisRange,
+		kinesisShardRange: &kinesisRange,
 		parent:            kc,
 		source:            source,
 		lastSequenceID:    kc.shardSequences[*shard.ShardId],
@@ -296,10 +301,10 @@ func isMissingResource(err error) bool {
 
 // A reader of an individual kinesis shard.
 type shardReader struct {
-	rangeOverlap airbyte.RangeOverlap
+	rangeOverlap boilerplate.RangeOverlap
 	// The key hash range of the kinesis shard, which has been translated from 128bit to the 32bit
 	// space.
-	kinesisShardRange airbyte.Range
+	kinesisShardRange *pf.RangeSpec
 	parent            *streamReader
 	source            *recordSource
 	lastSequenceID    string
@@ -413,7 +418,7 @@ func (r *shardReader) readShardIterator(iteratorID string) error {
 // Extracts the records from a response, filtering the records if necessary due to claiming partial
 // ownership over the kinesis shard.
 func (r *shardReader) extractRecords(resp *kinesis.GetRecordsOutput) []json.RawMessage {
-	if r.rangeOverlap == airbyte.PartialRangeOverlap {
+	if r.rangeOverlap == boilerplate.PartialRangeOverlap {
 		var result []json.RawMessage
 		for _, rec := range resp.Records {
 			var keyHash = hashPartitionKey(*rec.PartitionKey)

--- a/source-kinesis/connection.go
+++ b/source-kinesis/connection.go
@@ -14,10 +14,10 @@ import (
 // Config represents the fully merged endpoint configuration for Kinesis.
 // It matches the `KinesisConfig` struct in `crates/sources/src/specs.rs`
 type Config struct {
-	Endpoint           string `json:"endpoint"`
-	Region             string `json:"region"`
-	AWSAccessKeyID     string `json:"awsAccessKeyId"`
-	AWSSecretAccessKey string `json:"awsSecretAccessKey"`
+	Endpoint           string `json:"endpoint,omitempty" jsonschema:"title=AWS Endpoint" jsonschema_description="The AWS endpoint URI to connect to, useful if you're capturing from a kinesis-compatible API that isn't provided by AWS"`
+	Region             string `json:"region" jsonschema:"title=AWS Region,description=The name of the AWS region where the Kinesis stream is located"`
+	AWSAccessKeyID     string `json:"awsAccessKeyId" jsonschema:"title=AWS Access Key ID,description=Part of the AWS credentials that will be used to connect to Kinesis"`
+	AWSSecretAccessKey string `json:"awsSecretAccessKey" jsonschema:"title=AWS Secret Access Key,description=Part of the AWS credentials that will be used to connect to Kinesis"`
 }
 
 func (c *Config) Validate() error {
@@ -32,45 +32,6 @@ func (c *Config) Validate() error {
 	}
 	return nil
 }
-
-var configJSONSchema = `{
-	"$schema": "http://json-schema.org/draft-07/schema#",
-	"title":   "Kinesis Source Spec",
-	"type":    "object",
-	"required": [
-		"region",
-		"awsAccessKeyId",
-		"awsSecretAccessKey"
-	],
-	"properties": {
-		"awsAccessKeyId": {
-			"type":        "string",
-			"title":       "AWS Access Key ID",
-			"description": "Part of the AWS credentials that will be used to connect to Kinesis",
-			"order": 0
-
-		},
-		"awsSecretAccessKey": {
-			"type":        "string",
-			"title":       "AWS Secret Access Key",
-			"description": "Part of the AWS credentials that will be used to connect to Kinesis",
-			"secret":      true,
-			"order":       1
-		},
-		"region": {
-			"type":        "string",
-			"title":       "AWS Region",
-			"description": "The name of the AWS region where the Kinesis stream is located",
-			"order":       2
-		},
-		"endpoint": {
-			"type":        "string",
-			"title":       "AWS Endpoint",
-			"description": "The AWS endpoint URI to connect to, useful if you're capturing from a kinesis-compatible API that isn't provided by AWS",
-			"order":       3
-		}
-	}
-}`
 
 func connect(config *Config) (*kinesis.Kinesis, error) {
 	var err = config.Validate()

--- a/source-kinesis/main.go
+++ b/source-kinesis/main.go
@@ -166,7 +166,7 @@ func (d *driver) Pull(open *pc.Request_Open, stream *boilerplate.PullOutput) err
 			break
 		}
 		for _, record := range next.records {
-			if err = stream.Documents(next.source.idx, record); err != nil {
+			if err = stream.Documents(next.source.bindingIndex, record); err != nil {
 				break
 			}
 		}

--- a/source-kinesis/shard_range_test.go
+++ b/source-kinesis/shard_range_test.go
@@ -65,28 +65,28 @@ func TestShardRangeTranslation(t *testing.T) {
 	require.Equal(t, uint32(20), result.KeyEnd)
 }
 
-func TestShardRangeOverlaps(t *testing.T) {
-	testRangeOverlap(t, boilerplate.FullRangeOverlap, 0, math.MaxUint32, "0", maxKinesisHash)
-	testRangeOverlap(t, boilerplate.FullRangeOverlap, 0, math.MaxUint32, "1", maxKinesisHash)
-	testRangeOverlap(t, boilerplate.PartialRangeOverlap, 1, math.MaxUint32, "0", maxKinesisHash)
+func TestShardRangeContains(t *testing.T) {
+	testRangeContain(t, boilerplate.FullRangeContain, 0, math.MaxUint32, "0", maxKinesisHash)
+	testRangeContain(t, boilerplate.FullRangeContain, 0, math.MaxUint32, "1", maxKinesisHash)
+	testRangeContain(t, boilerplate.PartialRangeContain, 1, math.MaxUint32, "0", maxKinesisHash)
 	// This huge number is equivalent to 5 << 96, so this case is testing the boundary where the
 	// kinesis range begin is the same as the flow range exclusive end.
-	testRangeOverlap(t, boilerplate.PartialRangeOverlap, 0, 5, "396140812571321687967719751680", maxKinesisHash)
-	testRangeOverlap(t, boilerplate.NoRangeOverlap, 0, 5, "475368975085586025561263702016", maxKinesisHash)
+	testRangeContain(t, boilerplate.PartialRangeContain, 0, 5, "396140812571321687967719751680", maxKinesisHash)
+	testRangeContain(t, boilerplate.NoRangeContain, 0, 5, "475368975085586025561263702016", maxKinesisHash)
 
 	// This huge number is equivalent to 20 << 96, so should partially overlap
-	testRangeOverlap(t, boilerplate.PartialRangeOverlap, 10, 20, "1584563250285286751870879006720", maxKinesisHash)
-	testRangeOverlap(t, boilerplate.FullRangeOverlap, 20, 20, "1584563250285286751870879006720", "1584563250285286751870879006721")
+	testRangeContain(t, boilerplate.PartialRangeContain, 10, 20, "1584563250285286751870879006720", maxKinesisHash)
+	testRangeContain(t, boilerplate.FullRangeContain, 20, 20, "1584563250285286751870879006720", "1584563250285286751870879006721")
 }
 
-func testRangeOverlap(t *testing.T, expected boilerplate.RangeOverlap, flowBegin, flowEnd uint32, kinesisBegin, kinesisEnd string) {
+func testRangeContain(t *testing.T, expected boilerplate.RangeContain, flowBegin, flowEnd uint32, kinesisBegin, kinesisEnd string) {
 	var flowRange = &pf.RangeSpec{
 		KeyBegin: flowBegin,
 		KeyEnd:   flowEnd,
 	}
 	var kinesisRange, err = parseKinesisShardRange(kinesisBegin, kinesisEnd)
 	require.NoError(t, err, "failed to convert kinesis hash key range")
-	var result = boilerplate.RangesOverlap(flowRange, &kinesisRange)
+	var result = boilerplate.RangeContained(flowRange, &kinesisRange)
 
 	require.Equalf(t, expected, result, "flowRange: %#v, kinesisRange: %s-%s, translatedKinesisRange: %#v", flowRange, kinesisBegin, kinesisEnd, kinesisRange)
 }

--- a/source-s3/Dockerfile
+++ b/source-s3/Dockerfile
@@ -13,6 +13,7 @@ RUN go mod download
 
 COPY go         ./go
 COPY filesource ./filesource
+COPY source-boilerplate ./source-boilerplate
 COPY source-s3  ./source-s3
 
 # Run the unit tests.
@@ -41,9 +42,7 @@ COPY --from=builder /builder/connector ./source-s3
 # Avoid running the connector as root.
 USER nonroot:nonroot
 
-COPY --from=ghcr.io/estuary/airbyte-to-flow:dev /airbyte-to-flow ./
-ENTRYPOINT ["/connector/airbyte-to-flow", "--connector-entrypoint", "/connector/source-s3"]
+ENTRYPOINT ["/connector/source-s3"]
 
 LABEL FLOW_RUNTIME_PROTOCOL=capture
 LABEL CONNECTOR_PROTOCOL=flow-capture
-LABEL FLOW_RUNTIME_CODEC=json

--- a/source-sftp/Dockerfile
+++ b/source-sftp/Dockerfile
@@ -13,6 +13,7 @@ RUN go mod download
 
 COPY go           ./go
 COPY filesource   ./filesource
+COPY source-boilerplate ./source-boilerplate
 COPY source-sftp  ./source-sftp
 
 RUN go test -v ./filesource/...
@@ -39,9 +40,7 @@ COPY --from=builder /builder/connector ./source-sftp
 # Avoid running the connector as root.
 USER nonroot:nonroot
 
-COPY --from=ghcr.io/estuary/airbyte-to-flow:dev /airbyte-to-flow ./
-ENTRYPOINT ["/connector/airbyte-to-flow", "--connector-entrypoint", "/connector/source-sftp"]
+ENTRYPOINT ["/connector/source-sftp"]
 
 LABEL FLOW_RUNTIME_PROTOCOL=capture
 LABEL CONNECTOR_PROTOCOL=flow-capture
-LABEL FLOW_RUNTIME_CODEC=json

--- a/source-sftp/main.go
+++ b/source-sftp/main.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/estuary/connectors/filesource"
+	pf "github.com/estuary/flow/go/protocols/flow"
 	schemagen "github.com/estuary/connectors/go/schema-gen"
 	"github.com/estuary/flow/go/parser"
 	"github.com/pkg/sftp"
@@ -69,7 +70,7 @@ func (advancedConfig) GetFieldDocString(fieldName string) string {
 	}
 }
 
-func (c *config) Validate() error {
+func (c config) Validate() error {
 	var requiredProperties = [][]string{
 		{"username", c.Username},
 		{"password", c.Password},
@@ -98,23 +99,23 @@ func (c *config) Validate() error {
 	return nil
 }
 
-func (c *config) DiscoverRoot() string {
+func (c config) DiscoverRoot() string {
 	return c.Directory
 }
 
-func (c *config) FilesAreMonotonic() bool {
+func (c config) FilesAreMonotonic() bool {
 	return c.Advanced.AscendingKeys
 }
 
-func (c *config) ParserConfig() *parser.Config {
+func (c config) ParserConfig() *parser.Config {
 	return c.Parser
 }
 
-func (c *config) PathRegex() string {
+func (c config) PathRegex() string {
 	return c.MatchFiles
 }
 
-func newSftpSource(ctx context.Context, cfg *config) (filesource.Store, error) {
+func newSftpSource(ctx context.Context, cfg config) (filesource.Store, error) {
 	sshConfig := ssh.ClientConfig{
 		User:            cfg.Username,
 		Auth:            []ssh.AuthMethod{},
@@ -366,9 +367,15 @@ func (f *sftpFile) Close() error {
 
 func main() {
 	var src = filesource.Source{
-		NewConfig: func() filesource.Config { return new(config) },
+    NewConfig: func(raw json.RawMessage) (filesource.Config, error) {
+      var cfg config
+      if err := pf.UnmarshalStrict(raw, &cfg); err != nil {
+        return nil, fmt.Errorf("parsing config json: %w", err)
+      }
+      return cfg, nil
+    },
 		Connect: func(ctx context.Context, cfg filesource.Config) (filesource.Store, error) {
-			return newSftpSource(ctx, cfg.(*config))
+			return newSftpSource(ctx, cfg.(config))
 		},
 		ConfigSchema:     configSchema,
 		DocumentationURL: "https://go.estuary.dev/source-sftp",


### PR DESCRIPTION
**Description:**

- Switch `filesource` and the connectors that use it `source-gcs`, `source-s3`, `source-http-file` and `source-sftp` to flow protocol

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/726)
<!-- Reviewable:end -->
