### PR TITLE
source-kinesis: switch to flow protocol

### DIFF
--- a/filesource/filesource.go
+++ b/filesource/filesource.go
@@ -357,7 +357,7 @@ func (r *reader) shouldSkip(obj ObjectInfo) (_ bool, reason string) {
 		return true, "regex not matched"
 	}
 	// Is it outside of our responsible key range?
-	if !boilerplate.IncludesHwHash(r.range_, []byte(obj.Path)) {
+	if !boilerplate.RangeIncludesHwHash(r.range_, []byte(obj.Path)) {
 		return true, "path not in range"
 	}
 

--- a/source-boilerplate/boilerplate.go
+++ b/source-boilerplate/boilerplate.go
@@ -384,34 +384,34 @@ func hwHashPartition(partitionId []byte) uint32 {
 	return uint32(highwayhash.Sum64(partitionId, highwayHashKey) >> 32)
 }
 
-func RangeIncludesHwHash(range_ *pf.RangeSpec, partitionID []byte) bool {
+func RangeIncludesHwHash(r *pf.RangeSpec, partitionID []byte) bool {
 	var hashed = hwHashPartition(partitionID)
-	return hashed >= range_.KeyBegin && hashed <= range_.KeyEnd
+	return RangeIncludes(r, hashed)
 }
 
 func RangeIncludes(r *pf.RangeSpec, hash uint32) bool {
 	return hash >= r.KeyBegin && hash <= r.KeyEnd
 }
 
-// RangeOverlap is the result of checking whether one Range overlaps another.
-type RangeOverlap int
+// RangeContain is the result of checking whether one Range contains another.
+type RangeContain int
 
 const (
-	NoRangeOverlap      RangeOverlap = 0
-	PartialRangeOverlap RangeOverlap = 1
-	FullRangeOverlap    RangeOverlap = 2
+	NoRangeContain      RangeContain = 0
+	PartialRangeContain RangeContain = 1
+	FullRangeContain    RangeContain = 2
 )
 
-func RangesOverlap(rangeOne *pf.RangeSpec, rangeTwo *pf.RangeSpec) RangeOverlap {
+func RangeContained(rangeOne *pf.RangeSpec, rangeTwo *pf.RangeSpec) RangeContain {
 	var includesBegin = RangeIncludes(rangeOne, rangeTwo.KeyBegin)
 	var includesEnd = RangeIncludes(rangeOne, rangeTwo.KeyEnd)
 
 	if includesBegin && includesEnd {
-		return FullRangeOverlap
+		return FullRangeContain
 	} else if includesBegin != includesEnd {
-		return PartialRangeOverlap
+		return PartialRangeContain
 	} else {
-		return NoRangeOverlap
+		return NoRangeContain
 	}
 }
 

--- a/source-kinesis/Dockerfile
+++ b/source-kinesis/Dockerfile
@@ -11,8 +11,9 @@ WORKDIR /builder
 COPY go.* ./
 RUN go mod download
 
-COPY go             ./go
-COPY source-kinesis ./source-kinesis
+COPY go                 ./go
+COPY source-boilerplate ./source-boilerplate
+COPY source-kinesis     ./source-kinesis
 
 # Run the unit tests.
 RUN go test -v ./source-kinesis/...
@@ -36,9 +37,7 @@ COPY --from=builder /builder/connector ./source-kinesis
 # Avoid running the connector as root.
 USER nonroot:nonroot
 
-COPY --from=ghcr.io/estuary/airbyte-to-flow:dev /airbyte-to-flow ./
-ENTRYPOINT ["/connector/airbyte-to-flow", "--connector-entrypoint", "/connector/source-kinesis"]
+ENTRYPOINT ["/connector/source-kinesis"]
 
 LABEL FLOW_RUNTIME_PROTOCOL=capture
 LABEL CONNECTOR_PROTOCOL=flow-capture
-LABEL FLOW_RUNTIME_CODEC=json

--- a/source-kinesis/capture.go
+++ b/source-kinesis/capture.go
@@ -9,7 +9,8 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/kinesis"
-	"github.com/estuary/flow/go/protocols/airbyte"
+	pf "github.com/estuary/flow/go/protocols/flow"
+	boilerplate "github.com/estuary/connectors/source-boilerplate"
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/time/rate"
 )
@@ -19,11 +20,12 @@ import (
 // The `wg` is expected to have been incremented once _prior_ to calling this function. It will be
 // further incremented and decremented behind the scenes, but will be decremented back down to the
 // prior value when the read is finished.
-func readStream(ctx context.Context, shardRange airbyte.Range, client *kinesis.Kinesis, stream string, state map[string]string, resultsCh chan<- readResult, wg *sync.WaitGroup) {
+func readStream(ctx context.Context, shardRange *pf.RangeSpec, client *kinesis.Kinesis, idx int, stream string, state map[string]string, resultsCh chan<- readResult, wg *sync.WaitGroup) {
 
 	var kc = &streamReader{
 		client:         client,
 		ctx:            ctx,
+		idx:            idx,
 		stream:         stream,
 		shardRange:     shardRange,
 		dataCh:         resultsCh,
@@ -40,6 +42,7 @@ func readStream(ctx context.Context, shardRange airbyte.Range, client *kinesis.K
 		select {
 		case resultsCh <- readResult{
 			source: &recordSource{
+				idx: idx,
 				stream: stream,
 			},
 			err: err,
@@ -55,8 +58,9 @@ func readStream(ctx context.Context, shardRange airbyte.Range, client *kinesis.K
 type streamReader struct {
 	client             *kinesis.Kinesis
 	ctx                context.Context
+	idx                int
 	stream             string
-	shardRange         airbyte.Range
+	shardRange         *pf.RangeSpec
 	dataCh             chan<- readResult
 	waitGroup          *sync.WaitGroup
 	readingShards      map[string]bool
@@ -69,6 +73,7 @@ type streamReader struct {
 }
 
 type recordSource struct {
+	idx     int
 	stream  string
 	shardID string
 }
@@ -210,7 +215,7 @@ func (kc *streamReader) startReadingShardByID(shardID string) {
 			select {
 			case <-kc.ctx.Done():
 			case kc.dataCh <- readResult{
-				source: &recordSource{stream: kc.stream, shardID: shardID},
+				source: &recordSource{idx: kc.idx, stream: kc.stream, shardID: shardID},
 				err:    err,
 			}:
 			}
@@ -231,8 +236,8 @@ func (kc *streamReader) newShardReader(shardID string, getShard func(string) (*k
 	var logEntry = log.WithFields(log.Fields{
 		"kinesisStream":     kc.stream,
 		"kinesisShardId":    *shard.ShardId,
-		"captureRangeStart": kc.shardRange.Begin,
-		"captureRangeEnd":   kc.shardRange.End,
+		"captureRangeStart": kc.shardRange.KeyBegin,
+		"captureRangeEnd":   kc.shardRange.KeyEnd,
 	})
 	var source = &recordSource{
 		stream:  kc.stream,
@@ -242,8 +247,8 @@ func (kc *streamReader) newShardReader(shardID string, getShard func(string) (*k
 	if err != nil {
 		return nil, fmt.Errorf("parsing kinesis shard range: %w", err)
 	}
-	var rangeResult = kc.shardRange.Overlaps(kinesisRange)
-	if rangeResult == airbyte.NoRangeOverlap {
+	var rangeResult = boilerplate.RangesOverlap(kc.shardRange, &kinesisRange)
+	if rangeResult == boilerplate.NoRangeOverlap {
 		logEntry.Info("Will not read kinesis shard because it falls outside of our hash range")
 		return nil, nil
 	}
@@ -267,7 +272,7 @@ func (kc *streamReader) newShardReader(shardID string, getShard func(string) (*k
 
 	return &shardReader{
 		rangeOverlap:      rangeResult,
-		kinesisShardRange: kinesisRange,
+		kinesisShardRange: &kinesisRange,
 		parent:            kc,
 		source:            source,
 		lastSequenceID:    kc.shardSequences[*shard.ShardId],
@@ -296,10 +301,10 @@ func isMissingResource(err error) bool {
 
 // A reader of an individual kinesis shard.
 type shardReader struct {
-	rangeOverlap airbyte.RangeOverlap
+	rangeOverlap boilerplate.RangeOverlap
 	// The key hash range of the kinesis shard, which has been translated from 128bit to the 32bit
 	// space.
-	kinesisShardRange airbyte.Range
+	kinesisShardRange *pf.RangeSpec
 	parent            *streamReader
 	source            *recordSource
 	lastSequenceID    string
@@ -413,7 +418,7 @@ func (r *shardReader) readShardIterator(iteratorID string) error {
 // Extracts the records from a response, filtering the records if necessary due to claiming partial
 // ownership over the kinesis shard.
 func (r *shardReader) extractRecords(resp *kinesis.GetRecordsOutput) []json.RawMessage {
-	if r.rangeOverlap == airbyte.PartialRangeOverlap {
+	if r.rangeOverlap == boilerplate.PartialRangeOverlap {
 		var result []json.RawMessage
 		for _, rec := range resp.Records {
 			var keyHash = hashPartitionKey(*rec.PartitionKey)

--- a/source-kinesis/connection.go
+++ b/source-kinesis/connection.go
@@ -14,10 +14,10 @@ import (
 // Config represents the fully merged endpoint configuration for Kinesis.
 // It matches the `KinesisConfig` struct in `crates/sources/src/specs.rs`
 type Config struct {
-	Endpoint           string `json:"endpoint"`
-	Region             string `json:"region"`
-	AWSAccessKeyID     string `json:"awsAccessKeyId"`
-	AWSSecretAccessKey string `json:"awsSecretAccessKey"`
+	Endpoint           string `json:"endpoint,omitempty" jsonschema:"title=AWS Endpoint" jsonschema_description="The AWS endpoint URI to connect to, useful if you're capturing from a kinesis-compatible API that isn't provided by AWS"`
+	Region             string `json:"region" jsonschema:"title=AWS Region,description=The name of the AWS region where the Kinesis stream is located"`
+	AWSAccessKeyID     string `json:"awsAccessKeyId" jsonschema:"title=AWS Access Key ID,description=Part of the AWS credentials that will be used to connect to Kinesis"`
+	AWSSecretAccessKey string `json:"awsSecretAccessKey" jsonschema:"title=AWS Secret Access Key,description=Part of the AWS credentials that will be used to connect to Kinesis"`
 }
 
 func (c *Config) Validate() error {
@@ -32,45 +32,6 @@ func (c *Config) Validate() error {
 	}
 	return nil
 }
-
-var configJSONSchema = `{
-	"$schema": "http://json-schema.org/draft-07/schema#",
-	"title":   "Kinesis Source Spec",
-	"type":    "object",
-	"required": [
-		"region",
-		"awsAccessKeyId",
-		"awsSecretAccessKey"
-	],
-	"properties": {
-		"awsAccessKeyId": {
-			"type":        "string",
-			"title":       "AWS Access Key ID",
-			"description": "Part of the AWS credentials that will be used to connect to Kinesis",
-			"order": 0
-
-		},
-		"awsSecretAccessKey": {
-			"type":        "string",
-			"title":       "AWS Secret Access Key",
-			"description": "Part of the AWS credentials that will be used to connect to Kinesis",
-			"secret":      true,
-			"order":       1
-		},
-		"region": {
-			"type":        "string",
-			"title":       "AWS Region",
-			"description": "The name of the AWS region where the Kinesis stream is located",
-			"order":       2
-		},
-		"endpoint": {
-			"type":        "string",
-			"title":       "AWS Endpoint",
-			"description": "The AWS endpoint URI to connect to, useful if you're capturing from a kinesis-compatible API that isn't provided by AWS",
-			"order":       3
-		}
-	}
-}`
 
 func connect(config *Config) (*kinesis.Kinesis, error) {
 	var err = config.Validate()

--- a/source-kinesis/main.go
+++ b/source-kinesis/main.go
@@ -166,7 +166,7 @@ func (d *driver) Pull(open *pc.Request_Open, stream *boilerplate.PullOutput) err
 			break
 		}
 		for _, record := range next.records {
-			if err = stream.Documents(next.source.idx, record); err != nil {
+			if err = stream.Documents(next.source.bindingIndex, record); err != nil {
 				break
 			}
 		}

--- a/source-kinesis/shard_range_test.go
+++ b/source-kinesis/shard_range_test.go
@@ -65,28 +65,28 @@ func TestShardRangeTranslation(t *testing.T) {
 	require.Equal(t, uint32(20), result.KeyEnd)
 }
 
-func TestShardRangeOverlaps(t *testing.T) {
-	testRangeOverlap(t, boilerplate.FullRangeOverlap, 0, math.MaxUint32, "0", maxKinesisHash)
-	testRangeOverlap(t, boilerplate.FullRangeOverlap, 0, math.MaxUint32, "1", maxKinesisHash)
-	testRangeOverlap(t, boilerplate.PartialRangeOverlap, 1, math.MaxUint32, "0", maxKinesisHash)
+func TestShardRangeContains(t *testing.T) {
+	testRangeContain(t, boilerplate.FullRangeContain, 0, math.MaxUint32, "0", maxKinesisHash)
+	testRangeContain(t, boilerplate.FullRangeContain, 0, math.MaxUint32, "1", maxKinesisHash)
+	testRangeContain(t, boilerplate.PartialRangeContain, 1, math.MaxUint32, "0", maxKinesisHash)
 	// This huge number is equivalent to 5 << 96, so this case is testing the boundary where the
 	// kinesis range begin is the same as the flow range exclusive end.
-	testRangeOverlap(t, boilerplate.PartialRangeOverlap, 0, 5, "396140812571321687967719751680", maxKinesisHash)
-	testRangeOverlap(t, boilerplate.NoRangeOverlap, 0, 5, "475368975085586025561263702016", maxKinesisHash)
+	testRangeContain(t, boilerplate.PartialRangeContain, 0, 5, "396140812571321687967719751680", maxKinesisHash)
+	testRangeContain(t, boilerplate.NoRangeContain, 0, 5, "475368975085586025561263702016", maxKinesisHash)
 
 	// This huge number is equivalent to 20 << 96, so should partially overlap
-	testRangeOverlap(t, boilerplate.PartialRangeOverlap, 10, 20, "1584563250285286751870879006720", maxKinesisHash)
-	testRangeOverlap(t, boilerplate.FullRangeOverlap, 20, 20, "1584563250285286751870879006720", "1584563250285286751870879006721")
+	testRangeContain(t, boilerplate.PartialRangeContain, 10, 20, "1584563250285286751870879006720", maxKinesisHash)
+	testRangeContain(t, boilerplate.FullRangeContain, 20, 20, "1584563250285286751870879006720", "1584563250285286751870879006721")
 }
 
-func testRangeOverlap(t *testing.T, expected boilerplate.RangeOverlap, flowBegin, flowEnd uint32, kinesisBegin, kinesisEnd string) {
+func testRangeContain(t *testing.T, expected boilerplate.RangeContain, flowBegin, flowEnd uint32, kinesisBegin, kinesisEnd string) {
 	var flowRange = &pf.RangeSpec{
 		KeyBegin: flowBegin,
 		KeyEnd:   flowEnd,
 	}
 	var kinesisRange, err = parseKinesisShardRange(kinesisBegin, kinesisEnd)
 	require.NoError(t, err, "failed to convert kinesis hash key range")
-	var result = boilerplate.RangesOverlap(flowRange, &kinesisRange)
+	var result = boilerplate.RangeContained(flowRange, &kinesisRange)
 
 	require.Equalf(t, expected, result, "flowRange: %#v, kinesisRange: %s-%s, translatedKinesisRange: %#v", flowRange, kinesisBegin, kinesisEnd, kinesisRange)
 }


### PR DESCRIPTION
**Description:**

- Switch `source-kinesis` to flow protocol and use `source-boilerplate`
- Pull-request is based on #726 

**Workflow steps:**

- Create a capture for Kinesis and generate data to be sent to it

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/728)
<!-- Reviewable:end -->
