### PR TITLE
Move connector variant building/pushing into `build_connectors` matrix build

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -112,6 +112,8 @@ jobs:
           echo ::set-output name=tag::${TAG}
           VERSION=$(cat ${{ matrix.connector }}/VERSION | tr -d '\n')
           echo ::set-output name=version::${VERSION}
+          VARIANTS="${{ matrix.connector }} $(cat ${{ matrix.connector }}/VARIANTS 2>/dev/null || true)"
+          echo ::set-output name=variants::${VARIANTS}
 
       - name: Download latest Flow release binaries and add them to $PATH
         run: |
@@ -213,23 +215,25 @@ jobs:
 
         run: CONNECTOR=${{ matrix.connector }} VERSION=local tests/materialize/run.sh;
 
-      - name: Push ${{ matrix.connector }} image with commit SHA tag
-        uses: docker/build-push-action@v2
-        with:
-          context: .
-          build-args: BASE_IMAGE=ghcr.io/estuary/base-image:${{ steps.prep.outputs.tag }}
-          file: ${{ matrix.connector }}/Dockerfile
-          push: true
-          tags: ghcr.io/estuary/${{ matrix.connector }}:${{ steps.prep.outputs.tag }}
+      - name: Push ${{ matrix.connector }} image(s) with commit SHA tag
+        run: |
+          for VARIANT in ${{ steps.prep.outputs.variants }}; do
+            echo "Building and pushing ${VARIANT}:${{ steps.prep.outputs.tag }}...";
+            docker build --build-arg BASE_CONNECTOR=ghcr.io/estuary/${{ matrix.connector }}:local \
+                         --build-arg DOCS_URL=https://go.estuary.dev/${VARIANT} \
+                         --tag ghcr.io/estuary/${VARIANT}:${{ steps.prep.outputs.tag }} \
+                         --file connector-variant.Dockerfile .;
+            docker image push ghcr.io/estuary/${VARIANT}:${{ steps.prep.outputs.tag }};
+          done
 
-      - name: Push ${{ matrix.connector }} image with 'dev' and $VERSION tag
+      - name: Push ${{ matrix.connector }} image(s) with 'dev' and '${{ steps.prep.outputs.version }}' tags
         if: ${{ github.event_name == 'push' }}
-        uses: docker/build-push-action@v2
-        with:
-          context: .
-          file: ${{ matrix.connector }}/Dockerfile
-          push: true # See 'if' above
-          tags: ghcr.io/estuary/${{ matrix.connector }}:dev,ghcr.io/estuary/${{ matrix.connector }}:${{ steps.prep.outputs.version }}
+        run: |
+          for VARIANT in ${{ steps.prep.outputs.variants }}; do
+            docker image tag ghcr.io/estuary/${VARIANT}:${{ steps.prep.outputs.tag }} ghcr.io/estuary/${VARIANT}:dev;
+            docker image tag ghcr.io/estuary/${VARIANT}:${{ steps.prep.outputs.tag }} ghcr.io/estuary/${VARIANT}:${{ steps.prep.outputs.version }};
+            docker image push ghcr.io/estuary/${VARIANT}:dev ghcr.io/estuary/${VARIANT}:${{ steps.prep.outputs.version }};
+          done
 
       - name: Install psql
         if: ${{ github.event_name == 'push' }}
@@ -245,116 +249,9 @@ jobs:
           PGPASSWORD: ${{ secrets.POSTGRES_CONNECTOR_REFRESH_PASSWORD }}
           PGDATABASE: ${{ secrets.POSTGRES_CONNECTOR_REFRESH_DATABASE }}
         run: |
-          echo "UPDATE connector_tags SET job_status='{\"type\": \"queued\"}'
-                  WHERE connector_id IN (
-                    SELECT id FROM connectors WHERE image_name='ghcr.io/estuary/${{ matrix.connector }}'
-                  )
-                  AND
-                  image_tag IN (':${{ steps.prep.outputs.version }}', ':dev');" | psql
-
-  build_variants:
-    runs-on: ubuntu-20.04
-    needs: build_connectors
-    strategy:
-      fail-fast: false
-      matrix:
-        variant:
-          # Additional image variants, which are built by extending existing "base" dockerfiles and
-          # tagged as `tag`. The `docsURL` value is provided to the connector as an environment
-          # variable to override the default value. Currently only SQL capture and SQL
-          # materialization connectors support being built as variants in this way.
-          - tag: source-mariadb
-            base: source-mysql
-            docsURL: "https://go.estuary.dev/source-mariadb"
-          - tag: source-amazon-aurora-mysql
-            base: source-mysql
-            docsURL: "https://go.estuary.dev/source-amazon-aurora-mysql"
-          - tag: source-alloydb
-            base: source-postgres
-            docsURL: "https://go.estuary.dev/source-alloydb"
-          - tag: source-amazon-aurora-postgres
-            base: source-postgres
-            docsURL: "https://go.estuary.dev/source-amazon-aurora-postgres"
-          - tag: source-azure-sqlserver
-            base: source-sqlserver
-            docsURL: "https://go.estuary.dev/source-azure-sqlserver"
-          - tag: materialize-timescaledb
-            base: materialize-postgres
-            docsURL: "https://go.estuary.dev/materialize-timescaledb"
-          - tag: materialize-alloydb
-            base: materialize-postgres
-            docsURL: "https://go.estuary.dev/materialize-alloydb"
-          - tag: materialize-amazon-aurora-postgres
-            base: materialize-postgres
-            docsURL: "https://go.estuary.dev/materialize-amazon-aurora-postgres"
-          - tag: source-cosmosdb-mongodb
-            base: source-mongodb
-            docsURL: "https://go.estuary.dev/source-mongodb"
-          - tag: materialize-cosmosdb-mongodb
-            base: materialize-mongodb
-            docsURL: "https://go.estuary.dev/source-mongodb"
-
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-
-      - name: Prepare
-        id: prep
-        run: |
-          TAG=$(echo $GITHUB_SHA | head -c7)
-          echo ::set-output name=tag::${TAG}
-          VERSION=$(cat ${{ matrix.variant.base }}/VERSION | tr -d '\n')
-          echo ::set-output name=version::${VERSION}
-
-      - name: Login to GitHub package docker registry
-        run: |
-          echo "${{ secrets.GITHUB_TOKEN }}" | \
-            docker login --username ${{ github.actor }} --password-stdin ghcr.io
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
-
-      - name: Push ${{ matrix.variant.tag }} image with commit SHA tag
-        uses: docker/build-push-action@v2
-        with:
-          context: .
-          build-args: |
-            BASE_CONNECTOR=ghcr.io/estuary/${{ matrix.variant.base }}:${{ steps.prep.outputs.tag }}
-            DOCS_URL=${{ matrix.variant.docsURL }}
-          file: connector-variant.Dockerfile
-          push: true
-          tags: ghcr.io/estuary/${{ matrix.variant.tag }}:${{ steps.prep.outputs.tag }}
-
-      - name: Push ${{ matrix.variant.tag }} image with 'dev' and $VERSION tag
-        if: ${{ github.event_name == 'push' }}
-        uses: docker/build-push-action@v2
-        with:
-          context: .
-          build-args: |
-            BASE_CONNECTOR=ghcr.io/estuary/${{ matrix.variant.base }}:${{ steps.prep.outputs.tag }}
-            DOCS_URL=${{ matrix.variant.docsURL }}
-          file: connector-variant.Dockerfile
-          push: true # See 'if' above
-          tags: ghcr.io/estuary/${{ matrix.variant.tag }}:dev,ghcr.io/estuary/${{ matrix.variant.tag }}:${{ steps.prep.outputs.version }}
-
-      - name: Install psql
-        if: ${{ github.event_name == 'push' }}
-        run: |
-          sudo apt update
-          sudo apt install postgresql
-
-      - name: Refresh connector tags for ${{ matrix.variant.tag }}
-        if: ${{ github.event_name == 'push' }}
-        env:
-          PGHOST: ${{ secrets.POSTGRES_CONNECTOR_REFRESH_HOST }}
-          PGUSER: ${{ secrets.POSTGRES_CONNECTOR_REFRESH_USER }}
-          PGPASSWORD: ${{ secrets.POSTGRES_CONNECTOR_REFRESH_PASSWORD }}
-          PGDATABASE: ${{ secrets.POSTGRES_CONNECTOR_REFRESH_DATABASE }}
-        run: |
-          echo "UPDATE connector_tags SET job_status='{\"type\": \"queued\"}'
-                  WHERE connector_id IN (
-                    SELECT id FROM connectors WHERE image_name='ghcr.io/estuary/${{ matrix.variant.tag }}'
-                  )
-                  AND
-                  image_tag IN (':${{ steps.prep.outputs.version }}', ':dev');" | psql
+          for VARIANT in ${{ steps.prep.outputs.variants }}; do
+            echo "UPDATE connector_tags SET job_status='{\"type\": \"queued\"}'
+                    WHERE connector_id IN (
+                      SELECT id FROM connectors WHERE image_name='ghcr.io/estuary/${VARIANT}'
+                    ) AND image_tag IN (':${{ steps.prep.outputs.version }}', ':dev');" | psql;
+          done

--- a/materialize-mongodb/VARIANTS
+++ b/materialize-mongodb/VARIANTS
@@ -1,0 +1,1 @@
+materialize-cosmosdb-mongodb

--- a/materialize-mongodb/docker-compose.yaml
+++ b/materialize-mongodb/docker-compose.yaml
@@ -7,10 +7,6 @@ services:
     command: ["--replSet", "rs0", "--keyFile", "/etc/ssl/sample.key"]
     networks:
       - flow-test
-    volumes:
-      - type: bind
-        source: ./sample.key
-        target: /etc/ssl/sample.key
 
 networks:
   flow-test:

--- a/materialize-postgres/VARIANTS
+++ b/materialize-postgres/VARIANTS
@@ -1,0 +1,3 @@
+materialize-timescaledb
+materialize-alloydb
+materialize-amazon-aurora-postgres

--- a/source-mongodb/VARIANTS
+++ b/source-mongodb/VARIANTS
@@ -1,0 +1,1 @@
+source-cosmosdb-mongodb

--- a/source-mysql/VARIANTS
+++ b/source-mysql/VARIANTS
@@ -1,0 +1,2 @@
+source-mariadb
+source-amazon-aurora-mysql

--- a/source-postgres/VARIANTS
+++ b/source-postgres/VARIANTS
@@ -1,0 +1,2 @@
+source-alloydb
+source-amazon-aurora-postgres

--- a/source-sqlserver/VARIANTS
+++ b/source-sqlserver/VARIANTS
@@ -1,0 +1,1 @@
+source-azure-sqlserver


### PR DESCRIPTION
**Description:**

This PR modifies the CI workflow configuration to remove the `build_variants` step and instead merges the variant building-and-pushing steps into the main `build_connectors` matrix build. This means that flake in one connector (say, `source-kafka`) should no longer impact our ability to build and push another connector variant (such as `source-amazon-aurora-mysql`).

The new process for building and pushing variants is just a shell command featuring a `for VARIANT in ${...}` loop, with the list of variant names coming from the file `${CONNECTOR}/VARIANTS`. Because of the looping we can no longer use `docker/build-push-action` to manage this, but honestly I think just running `docker build` / `docker tag` / `docker push` is more comprehensible anyway.

For simplicity the "real name" of a connector is also added to this list, so all the variants are on equal footing and get built/pushed/updated by the same code. The only meaningful differences are that we'll now be explicitly setting the `DOCS_URL` override in all cases, and the URL must always be `https://go.estuary.dev/${VARIANT}`, which was mostly the case already and I have created the few additional shortlinks required to make it universally true.

I'm ... _reasonably_ confident that this might just work on the first try (the commithash-tagged pushes are working on the draft CI builds), but if not I intend to fast-follow with fixes (probably unreviewed unless they get really complicated) until it appears to be working.

**Workflow steps:**

Ideally nothing should change.

**Documentation links affected:**

I have created a few new shortlinks so that every connector-variant name is a valid shortlink:

- http://go.estuary.dev/source-http-ingest
- http://go.estuary.dev/materialize-postgres
- http://go.estuary.dev/source-cosmosdb-mongodb
- http://go.estuary.dev/materialize-cosmosdb-mongodb

With the exception of http://go.estuary.dev/materialize-webhook, which I have not created because AFAICT there is no suitable documentation for this connector at present.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/729)
<!-- Reviewable:end -->
