### PR TITLE
ci: Fix 'docker image push' arguments

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -232,7 +232,8 @@ jobs:
           for VARIANT in ${{ steps.prep.outputs.variants }}; do
             docker image tag ghcr.io/estuary/${VARIANT}:${{ steps.prep.outputs.tag }} ghcr.io/estuary/${VARIANT}:dev;
             docker image tag ghcr.io/estuary/${VARIANT}:${{ steps.prep.outputs.tag }} ghcr.io/estuary/${VARIANT}:${{ steps.prep.outputs.version }};
-            docker image push ghcr.io/estuary/${VARIANT}:dev ghcr.io/estuary/${VARIANT}:${{ steps.prep.outputs.version }};
+            docker image push ghcr.io/estuary/${VARIANT}:dev;
+            docker image push ghcr.io/estuary/${VARIANT}:${{ steps.prep.outputs.version }};
           done
 
       - name: Install psql


### PR DESCRIPTION
**Description:**

Apparently you can only specify one image/tag to push per invocation of that command, for some reason.

This is a fast-follow bugfix for the untestable portion of https://github.com/estuary/connectors/pull/729

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/731)
<!-- Reviewable:end -->
