### PR TITLE
materialize-snowflake: separate MERGE and COPY INTO queries for stores

### DIFF
--- a/materialize-snowflake/snowflake.go
+++ b/materialize-snowflake/snowflake.go
@@ -320,10 +320,10 @@ type binding struct {
 	}
 	// Variables accessed by Prepare, Store, and Commit.
 	store struct {
-		stage     *stagedFile
-		mergeInto string
-		copyInto  string
-		mustMerge bool
+		insertStage *stagedFile
+		mergeStage  *stagedFile
+		mergeInto   string
+		copyInto    string
 	}
 }
 
@@ -337,16 +337,17 @@ func (t *transactor) addBinding(ctx context.Context, target sql.Table) error {
 	var err error
 	d.target = target
 
-	d.load.stage = newStagedFile(os.TempDir())
-	d.store.stage = newStagedFile(os.TempDir())
+	d.load.stage = newStagedFile(os.TempDir(), "load")
+	d.store.insertStage = newStagedFile(os.TempDir(), "insert")
+	d.store.mergeStage = newStagedFile(os.TempDir(), "merge")
 
 	if d.load.loadQuery, err = RenderTableWithRandomUUIDTemplate(target, d.load.stage.uuid, tplLoadQuery); err != nil {
 		return fmt.Errorf("loadQuery template: %w", err)
 	}
-	if d.store.copyInto, err = RenderTableWithRandomUUIDTemplate(target, d.store.stage.uuid, tplCopyInto); err != nil {
+	if d.store.copyInto, err = RenderTableWithRandomUUIDTemplate(target, d.store.insertStage.uuid, tplCopyInto); err != nil {
 		return fmt.Errorf("copyInto template: %w", err)
 	}
-	if d.store.mergeInto, err = RenderTableWithRandomUUIDTemplate(target, d.store.stage.uuid, tplMergeInto); err != nil {
+	if d.store.mergeInto, err = RenderTableWithRandomUUIDTemplate(target, d.store.mergeStage.uuid, tplMergeInto); err != nil {
 		return fmt.Errorf("mergeInto template: %w", err)
 	}
 
@@ -417,16 +418,17 @@ func (d *transactor) Store(it *pm.StoreIterator) (pm.StartCommitFunc, error) {
 	for it.Next() {
 		var b = d.bindings[it.Binding]
 
-		if err := b.store.stage.start(it.Context(), d.store.conn); err != nil {
+		stage := b.store.insertStage
+		if it.Exists {
+			stage = b.store.mergeStage
+		}
+
+		if err := stage.start(it.Context(), d.store.conn); err != nil {
 			return nil, err
 		} else if converted, err := b.target.ConvertAll(it.Key, it.Values, it.RawJSON); err != nil {
 			return nil, fmt.Errorf("converting Store: %w", err)
-		} else if err = b.store.stage.encodeRow(converted); err != nil {
+		} else if err = stage.encodeRow(converted); err != nil {
 			return nil, fmt.Errorf("encoding Store to scratch file: %w", err)
-		}
-
-		if it.Exists {
-			b.store.mustMerge = true
 		}
 	}
 
@@ -463,24 +465,21 @@ func (d *transactor) commit(ctx context.Context) error {
 	}
 
 	for _, b := range d.bindings {
-		if !b.store.stage.started {
-			// No table update required
-		} else if err := b.store.stage.flush(); err != nil {
-			return err
-		} else if !b.store.mustMerge {
-			// We can issue a faster COPY INTO the target table.
-			if _, err = d.store.conn.ExecContext(ctx, b.store.copyInto); err != nil {
+		if b.store.insertStage.started {
+			if err := b.store.insertStage.flush(); err != nil {
+				return fmt.Errorf("flushing insert stage: %w", err)
+			} else if _, err = d.store.conn.ExecContext(ctx, b.store.copyInto); err != nil {
 				return fmt.Errorf("copying Store documents: %w", err)
-			}
-		} else {
-			// We must MERGE into the target table.
-			if _, err = d.store.conn.ExecContext(ctx, b.store.mergeInto); err != nil {
-				return fmt.Errorf("merging Store documents: %w", err)
 			}
 		}
 
-		// Reset for next transaction.
-		b.store.mustMerge = false
+		if b.store.mergeStage.started {
+			if err := b.store.mergeStage.flush(); err != nil {
+				return fmt.Errorf("flushing merge stage: %w", err)
+			} else if _, err = d.store.conn.ExecContext(ctx, b.store.mergeInto); err != nil {
+				return fmt.Errorf("merging Store documents: %w", err)
+			}
+		}
 	}
 
 	if err = txn.Commit(); err != nil {

--- a/materialize-snowflake/staged_file.go
+++ b/materialize-snowflake/staged_file.go
@@ -80,8 +80,8 @@ type stagedFile struct {
 	groupCtx context.Context // Used to check for group cancellation upon the worker returning an error.
 }
 
-func newStagedFile(tempdir string) *stagedFile {
-	uuid := uuid.NewString()
+func newStagedFile(tempdir string, suffix string) *stagedFile {
+	uuid := uuid.NewString() + "_" + suffix
 
 	return &stagedFile{
 		uuid: uuid,


### PR DESCRIPTION
**Description:**

For standard updates materializations Flow uses load queries to determine which keys already exist in the database, and this information is available to the connector during the store phase.

COPY INTO queries are much more efficient than MERGE queries, and we can use the knowledge of which keys already exist when storing new records to issue separate COPY INTO vs. MERGE queries within the same transaction for files staged as new records vs. updates.

The hope is that for cases where a standard updates materialization is storing mostly new rows with relatively few updates in each transaction that this will reduce the time for store phases to complete. On such materializations of large data sets we have observed that the MERGE queries take a long time to complete, and the goal here is to reduce the amount of data processed by the MERGE query and reduce overall time of the store phase.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

N/A

**Notes for reviewers:**

It is difficult to do realistic benchmarking for the scale of data that this change would be beneficial for. I did see modest improvements (~15% time savings) when doing a test materialization with 20 million records into a table where 10 million of those records already existed. I hope that the benefit is greater for larger tables where there is a higher ratio of inserts to updates, which are more like _almost_ delta updates with just a few actual updates sprinkled in.

For testing, I ran the integration tests manually with the new connector image and also verified that the resulting 20 million row tables mentioned above for benchmarking were identical when produced by the original and this new connector version.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/732)
<!-- Reviewable:end -->
