### PR TITLE
materialize-snowflake: handle "date" formatted strings

### DIFF
--- a/materialize-snowflake/sqlgen.go
+++ b/materialize-snowflake/sqlgen.go
@@ -60,6 +60,7 @@ var snowflakeDialect = func() sql.Dialect {
 		sql.STRING: sql.StringTypeMapper{
 			Fallback: sql.NewStaticMapper("STRING"),
 			WithFormat: map[string]sql.TypeMapper{
+				"date":      sql.NewStaticMapper("DATE"),
 				"date-time": sql.NewStaticMapper("TIMESTAMP"),
 			},
 		},


### PR DESCRIPTION
**Description:**

Handle strings with format `date` as Snowflake [`DATE` type](https://docs.snowflake.com/en/sql-reference/data-types-datetime#date) columns.

Fortunately this is a very simple change since the text encoding that Snowflake accepts for `DATE` types matches Flow's `date` format, so it is fully backward-compatible. 

I tested backward-compatibility for this by:
1. creating a materialization with `date`s on the current connector (`date` column(s) created as  in Snowflake with type `STRING`)
2. materializing some `date`-formatted string values
3. changing the image of the connector to the new one, built with this change
4. materializing some more `date`-formatted string values and observing that the materialization still worked (values still materialized into `STRING` columns)

A new materialization will create the columns as `DATE` types in Snowflake tables and materialize the values as `DATE`s via Snowflake parsing the encoded strings as `DATE` instead of `STRING`.

Closes https://github.com/estuary/connectors/issues/734

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

N/A

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/735)
<!-- Reviewable:end -->
