### PR TITLE
materialize-sql: validate required fields in collection projections

### DIFF
--- a/materialize-sql/endpoint.go
+++ b/materialize-sql/endpoint.go
@@ -184,7 +184,7 @@ func resolveResourceToExistingBinding(
 	} else if loadedBinding != nil {
 		constraints = ValidateMatchesExisting(resource, loadedBinding, collection)
 	} else {
-		constraints = ValidateNewSQLProjections(resource, collection)
+		constraints, err = ValidateNewSQLProjections(resource, collection)
 	}
 
 	return

--- a/materialize-sql/validate.go
+++ b/materialize-sql/validate.go
@@ -33,13 +33,20 @@ func ValidateSelectedFields(constraints map[string]*pm.Response_Validated_Constr
 	for field, constraint := range constraints {
 		switch constraint.Type {
 		case pm.Response_Validated_Constraint_FIELD_REQUIRED:
+			var projection = proposed.Collection.GetProjection(field)
 			if !SliceContains(field, allFields) {
 				return fmt.Errorf("Required field '%s' is missing. It is required because: %s", field, constraint.Reason)
+			}
+			if projection == nil || projection.Inference.Exists != pf.Inference_MUST {
+				return fmt.Errorf("Required field '%s' is marked as optional in collection schema. It is required because: %s", field, constraint.Reason)
 			}
 		case pm.Response_Validated_Constraint_LOCATION_REQUIRED:
 			var projection = proposed.Collection.GetProjection(field)
 			if !includedPointers[projection.Ptr] {
-				return fmt.Errorf("The materialization must include a projections of location '%s', but no such projection is included", projection.Ptr)
+				return fmt.Errorf("The materialization must include a projections of location '%s', but no such projection is included. It is required because: %s", projection.Ptr, constraint.Reason)
+			}
+			if projection == nil || projection.Inference.Exists != pf.Inference_MUST {
+				return fmt.Errorf("The materialization must include a projection of location '%s', but no such projection is included. It is required because: %s", field, constraint.Reason)
 			}
 		}
 	}
@@ -51,13 +58,24 @@ func ValidateSelectedFields(constraints map[string]*pm.Response_Validated_Constr
 // **new** materialization (one that is not running and has never been Applied). Note that this will
 // "recommend" all projections of single scalar types, which is what drives the default field
 // selection in flowctl.
-func ValidateNewSQLProjections(resource Resource, proposed *pf.CollectionSpec) map[string]*pm.Response_Validated_Constraint {
+func ValidateNewSQLProjections(resource Resource, proposed *pf.CollectionSpec) (map[string]*pm.Response_Validated_Constraint, error) {
 	var constraints = make(map[string]*pm.Response_Validated_Constraint)
 	for _, projection := range proposed.Projections {
 		var constraint = validateNewProjection(resource, projection)
 		constraints[projection.Field] = constraint
+
+		switch constraint.Type {
+		case pm.Response_Validated_Constraint_FIELD_REQUIRED:
+			if projection.Inference.Exists != pf.Inference_MUST {
+				return nil, fmt.Errorf("Required field '%s' is marked as optional in collection schema. It is required because: %s", projection.Field, constraint.Reason)
+			}
+		case pm.Response_Validated_Constraint_LOCATION_REQUIRED:
+			if projection.Inference.Exists != pf.Inference_MUST {
+				return nil, fmt.Errorf("The materialization must include a projection of location '%s', but no such projection is included. It is required because: %s", projection.Field, constraint.Reason)
+			}
+		}
 	}
-	return constraints
+	return constraints, nil
 }
 
 func validateNewProjection(resource Resource, projection pf.Projection) *pm.Response_Validated_Constraint {


### PR DESCRIPTION
**Description:**

- validate that required fields are marked as `Exists.MUST` in projections during `Validate` and `Apply`

**Workflow steps:**

- Validate a capture with a key that's optional according to document schema of the collection

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/739)
<!-- Reviewable:end -->
