### PR TITLE
source-kafka: include servers connecting to in error message

### DIFF
--- a/source-kafka/src/lib.rs
+++ b/source-kafka/src/lib.rs
@@ -50,7 +50,7 @@ impl connector::Connector for KafkaConnector {
     fn validate(output: &mut dyn Write, validate: request::Validate) -> eyre::Result<()> {
         let config = Self::Config::parse(&validate.config_json)?;
         let consumer = kafka::consumer_from_config(&config)?;
-        let message = kafka::test_connection(&consumer, validate.bindings)?;
+        let message = kafka::test_connection(&config, &consumer, validate.bindings)?;
 
         connector::write_message(output, message)?;
         Ok(())
@@ -59,7 +59,7 @@ impl connector::Connector for KafkaConnector {
     fn discover(output: &mut dyn Write, discover: request::Discover) -> eyre::Result<()> {
         let config = Self::Config::parse(&discover.config_json)?;
         let consumer = kafka::consumer_from_config(&config)?;
-        let metadata = kafka::fetch_metadata(&consumer)?;
+        let metadata = kafka::fetch_metadata(&config, &consumer)?;
         let bindings = kafka::available_streams(&metadata);
         let message = Response {
             discovered: Some(response::Discovered {
@@ -91,7 +91,7 @@ impl connector::Connector for KafkaConnector {
         persisted_state: Option<Self::State>,
     ) -> eyre::Result<()> {
         let consumer = kafka::consumer_from_config(&config)?;
-        let metadata = kafka::fetch_metadata(&consumer)?;
+        let metadata = kafka::fetch_metadata(&config, &consumer)?;
 
         let mut checkpoints = state::CheckpointSet::reconcile_catalog_state(
             &metadata,


### PR DESCRIPTION
**Description:**

- include the broker servers connecting to in the error message of `fetch_metadata`, since this error is commonly caused by the wrong broker being configured

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/741)
<!-- Reviewable:end -->
