### PR TITLE
materialize-bigquery: extend retry duration

### DIFF
--- a/materialize-bigquery/query.go
+++ b/materialize-bigquery/query.go
@@ -50,7 +50,7 @@ func (c client) runQuery(ctx context.Context, query *bigquery.Query) (*bigquery.
 	var job *bigquery.Job
 	var err error
 	for attempt := 0; attempt < maxAttempts; attempt++ {
-		job, err := query.Run(ctx)
+		job, err = query.Run(ctx)
 		if err != nil {
 			return nil, fmt.Errorf("run: %w", err)
 		}
@@ -59,7 +59,8 @@ func (c client) runQuery(ctx context.Context, query *bigquery.Query) (*bigquery.
 		// there might still have been an error reported by `status.Err()`. We always want both the
 		// err and the status so that we can check both. When `err != nil`, the status may still
 		// have some helpful info to log.
-		status, err := job.Wait(ctx)
+		var status *bigquery.JobStatus
+		status, err = job.Wait(ctx)
 		if status == nil {
 			status = job.LastStatus()
 		}
@@ -118,7 +119,7 @@ func (c client) runQuery(ctx context.Context, query *bigquery.Query) (*bigquery.
 
 		return job, nil
 	}
-	log.WithField("error", err).Error("job failed, exhausted retries")
+
 	return job, fmt.Errorf("exhausted retries: %w", err)
 }
 


### PR DESCRIPTION
**Description:**

The retry duration was previously limited to just a few seconds, which was causing frequent task failures when more than one materialization shard operate in the same dataset (either because of a split shard, or separate materializations).

It's pretty gross, but the only way to determine if an error is a result of one of these concurrent update failures is to substring match the error message itself, since the googleapi package doesn't break things down enough to match them in any other way.

This extends the retry duration out to several minutes with a decent amount of backoff between attempts to give the shard a chance to complete its operations when running concurrently with other shards in the same dataset, but limits retrying only to errors related to concurrent accesses via substring matches on the error messages, or if the error is a known retryable error due to short-term rate limits.

I tested this by running two materializations concurrently in the same dataset and observing that they would occasionally hit the retry logic and need to retry a few times, but would eventually be successful.

Closes https://github.com/estuary/connectors/issues/111

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

n/a

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/742)
<!-- Reviewable:end -->
