### PR TITLE
source-sqlserver: Fix primary-key discovery query

### DIFF
--- a/source-sqlserver/.snapshots/TestDiscoveryIrrelevantConstraints
+++ b/source-sqlserver/.snapshots/TestDiscoveryIrrelevantConstraints
@@ -1,0 +1,125 @@
+Binding 0:
+{
+    "recommended_name": "test_discoveryirrelevantconstraints_g21962",
+    "resource_config_json": {
+      "mode": "Normal",
+      "namespace": "dbo",
+      "stream": "test_DiscoveryIrrelevantConstraints_g21962"
+    },
+    "document_schema_json": {
+      "$defs": {
+        "DboTest_DiscoveryIrrelevantConstraints_g21962": {
+          "type": "object",
+          "required": [
+            "id"
+          ],
+          "$anchor": "DboTest_DiscoveryIrrelevantConstraints_g21962",
+          "properties": {
+            "data": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "foo": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "id": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "allOf": [
+        {
+          "required": [
+            "_meta"
+          ],
+          "properties": {
+            "_meta": {
+              "type": "object",
+              "required": [
+                "op",
+                "source"
+              ],
+              "properties": {
+                "before": {
+                  "$ref": "#DboTest_DiscoveryIrrelevantConstraints_g21962",
+                  "description": "Record state immediately before this change was applied.",
+                  "reduce": {
+                    "strategy": "firstWriteWins"
+                  }
+                },
+                "op": {
+                  "enum": [
+                    "c",
+                    "d",
+                    "u"
+                  ],
+                  "description": "Change operation type: 'c' Create/Insert, 'u' Update, 'd' Delete."
+                },
+                "source": {
+                  "$id": "https://github.com/estuary/connectors/source-sqlserver/sqlserver-source-info",
+                  "properties": {
+                    "ts_ms": {
+                      "type": "integer",
+                      "description": "Unix timestamp (in millis) at which this event was recorded by the database."
+                    },
+                    "schema": {
+                      "type": "string",
+                      "description": "Database schema (namespace) of the event."
+                    },
+                    "snapshot": {
+                      "type": "boolean",
+                      "description": "Snapshot is true if the record was produced from an initial table backfill and unset if produced from the replication log."
+                    },
+                    "table": {
+                      "type": "string",
+                      "description": "Database table of the event."
+                    },
+                    "lsn": {
+                      "type": "string",
+                      "contentEncoding": "base64",
+                      "description": "The LSN at which a CDC event occurred. Only set for CDC events"
+                    },
+                    "seqval": {
+                      "type": "string",
+                      "contentEncoding": "base64",
+                      "description": "Sequence value used to order changes to a row within a transaction. Only set for CDC events"
+                    },
+                    "updateMask": {
+                      "description": "A bit mask with a bit corresponding to each captured column identified for the capture instance. Only set for CDC events"
+                    }
+                  },
+                  "additionalProperties": false,
+                  "type": "object",
+                  "required": [
+                    "schema",
+                    "table",
+                    "lsn",
+                    "seqval"
+                  ]
+                }
+              },
+              "reduce": {
+                "strategy": "merge"
+              }
+            }
+          },
+          "reduce": {
+            "strategy": "merge"
+          }
+        },
+        {
+          "$ref": "#DboTest_DiscoveryIrrelevantConstraints_g21962"
+        }
+      ]
+    },
+    "key": [
+      "/id"
+    ]
+  }
+

--- a/source-sqlserver/discovery.go
+++ b/source-sqlserver/discovery.go
@@ -139,9 +139,11 @@ func getColumns(ctx context.Context, conn *sql.DB) ([]sqlcapture.ColumnInfo, err
 }
 
 const queryDiscoverPrimaryKeys = `
-SELECT table_schema, table_name, column_name, ordinal_position
-  FROM information_schema.key_column_usage
-  ORDER BY table_schema, table_name, ordinal_position;
+SELECT kcu.table_schema, kcu.table_name, kcu.column_name, kcu.ordinal_position
+  FROM information_schema.key_column_usage kcu
+  JOIN information_schema.table_constraints tcs ON tcs.constraint_name = kcu.constraint_name
+  WHERE tcs.constraint_type = 'PRIMARY KEY'
+  ORDER BY kcu.table_schema, kcu.table_name, kcu.ordinal_position;
 `
 
 func getPrimaryKeys(ctx context.Context, conn *sql.DB) (map[string][]string, error) {

--- a/source-sqlserver/main_test.go
+++ b/source-sqlserver/main_test.go
@@ -229,3 +229,12 @@ func TestTextCollation(t *testing.T) {
 	cs.Validator = &st.OrderedCaptureValidator{}
 	tests.VerifiedCapture(ctx, t, cs)
 }
+
+// TestDiscoveryIrrelevantConstraints verifies that discovery works correctly
+// even when there are other non-primary-key constraints on a table.
+func TestDiscoveryIrrelevantConstraints(t *testing.T) {
+	var tb, ctx = sqlserverTestBackend(t), context.Background()
+	var uniqueString = "g21962"
+	tb.CreateTable(ctx, t, uniqueString, "(id VARCHAR(8) PRIMARY KEY, foo INTEGER UNIQUE, data TEXT)")
+	tb.CaptureSpec(ctx, t).VerifyDiscover(ctx, t, regexp.MustCompile(regexp.QuoteMeta(uniqueString)))
+}


### PR DESCRIPTION
**Description:**

Previously the query would misbehave in the presence of other non-primary-key constraints on the table (such as UNIQUE or foreign key constraints) because it simply wasn't checking for the 'PRIMARY KEY' constraint type specifically.

This commit fixes that bug and adds a test case which previously would have failed with a `primary key ordering failure` message.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/743)
<!-- Reviewable:end -->
