### PR TITLE
Revert "materialize-snowflake: separate MERGE and COPY INTO queries"

### DIFF
--- a/materialize-snowflake/staged_file.go
+++ b/materialize-snowflake/staged_file.go
@@ -80,8 +80,8 @@ type stagedFile struct {
 	groupCtx context.Context // Used to check for group cancellation upon the worker returning an error.
 }
 
-func newStagedFile(tempdir string, suffix string) *stagedFile {
-	uuid := uuid.NewString() + "_" + suffix
+func newStagedFile(tempdir string) *stagedFile {
+	uuid := uuid.NewString()
 
 	return &stagedFile{
 		uuid: uuid,


### PR DESCRIPTION
This reverts commit 0bea66d44d84a5dfe787fe53a1c9f1e3407419f4.

The change did not end up making any actual improvements when observed with actual tasks in production. Reverting this to return the code to its original, simpler form.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/744)
<!-- Reviewable:end -->
