### PR TITLE
materialize-snowflake: use streaming json downloader for loads

### DIFF
--- a/materialize-snowflake/snowflake.go
+++ b/materialize-snowflake/snowflake.go
@@ -56,6 +56,7 @@ func (c *config) ToURI() string {
 
 func (c *config) asSnowflakeConfig() sf.Config {
 	var maxStatementCount string = "0"
+	var json string = "json"
 	return sf.Config{
 		Account:   c.Account,
 		Host:      c.Host,
@@ -69,7 +70,8 @@ func (c *config) asSnowflakeConfig() sf.Config {
 			// By default Snowflake expects the number of statements to be provided
 			// with every request. By setting this parameter to zero we are allowing a
 			// variable number of statements to be executed in a single request
-			"MULTI_STATEMENT_COUNT": &maxStatementCount,
+			"MULTI_STATEMENT_COUNT":  &maxStatementCount,
+			"GO_QUERY_RESULT_FORMAT": &json,
 		},
 	}
 }
@@ -390,7 +392,7 @@ func (d *transactor) Load(it *pm.LoadIterator, loaded func(int, json.RawMessage)
 
 	// Issue a join of the target table and (now staged) load keys,
 	// and send results to the |loaded| callback.
-	rows, err := d.load.conn.QueryContext(ctx, loadAllSQL)
+	rows, err := d.load.conn.QueryContext(sf.WithStreamDownloader(ctx), loadAllSQL)
 	if err != nil {
 		return fmt.Errorf("querying Load documents: %w", err)
 	}


### PR DESCRIPTION
**Description:**

The default behavior of the Snowflake driver is to load & parse query results as arrow batches. This causes relatively high memory usage since they are loaded in large chunks and processed as a batch of columns.

This commit changes the connector to use row-oriented JSON results instead. This is accomplished with the parameter `"GO_QUERY_RESULT_FORMAT": "json"`. Furthermore, the Snowflake driver allows for the use of a "stream downloader" with JSON results which enables streaming load results back to the runtime in a memory-efficient way.

The main caveat when using JSON instead of arrow is (alleged) reduced performance. Although worse performance is plausible, this should not have any meaningful impact on our materialization throughput overall. We run loads in parallel with stores, and the merges that accompany loaded results take a far longer time than parsing the loads.

Closes https://github.com/estuary/connectors/issues/709

**Workflow steps:**

Use `materialize-snowflake` for large transactions and observe that it does not use much memory.

In practice I have seen that the connector memory usage is dramatically reduced, where previously it would be pegged out at ~900MB (via `GOMEMLIMIT`, otherwise it would happily spike into multiple GBs) for the entirety of reading the rows iterator, it now remains at 50-100MB, reflecting the fact that little if any data is being buffered in memory.

**Documentation links affected:**

N/A

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/745)
<!-- Reviewable:end -->
