### PR TITLE
materialize-snowflake: add application name to connection string

### DIFF
--- a/materialize-snowflake/snowflake.go
+++ b/materialize-snowflake/snowflake.go
@@ -73,6 +73,8 @@ func (c *config) asSnowflakeConfig() sf.Config {
 			"MULTI_STATEMENT_COUNT":  &maxStatementCount,
 			"GO_QUERY_RESULT_FORMAT": &json,
 		},
+		// For the Snowflake partner program.
+		Application: "tenant_EstuaryFlow",
 	}
 }
 


### PR DESCRIPTION
**Description:**

Adds the `Application` parameter to the snowflake connection parameters. This is for the snowflake partner program.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

N/A

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/746)
<!-- Reviewable:end -->
