### PR TITLE
source-postgres: Add 'SSL Mode' advanced config option

### DIFF
--- a/source-postgres/.snapshots/TestConfigURI-Basic
+++ b/source-postgres/.snapshots/TestConfigURI-Basic
@@ -1,0 +1,2 @@
+postgres://will:secret1234@example.com:5432/somedb
+config valid

--- a/source-postgres/.snapshots/TestConfigURI-IncorrectSSL
+++ b/source-postgres/.snapshots/TestConfigURI-IncorrectSSL
@@ -1,0 +1,2 @@
+postgres://will:secret1234@example.com:5432/somedb?sslmode=whoops-this-isnt-right
+invalid 'sslmode' configuration: unknown setting "whoops-this-isnt-right"

--- a/source-postgres/.snapshots/TestConfigURI-RequireSSL
+++ b/source-postgres/.snapshots/TestConfigURI-RequireSSL
@@ -1,0 +1,2 @@
+postgres://will:secret1234@example.com:5432/somedb?sslmode=verify-full
+config valid

--- a/source-postgres/.snapshots/TestGeneric-SpecResponse
+++ b/source-postgres/.snapshots/TestGeneric-SpecResponse
@@ -55,6 +55,19 @@
             "title": "Backfill Chunk Size",
             "description": "The number of rows which should be fetched from the database in a single backfill query.",
             "default": 32768
+          },
+          "sslmode": {
+            "type": "string",
+            "enum": [
+              "disable",
+              "allow",
+              "prefer",
+              "require",
+              "verify-ca",
+              "verify-full"
+            ],
+            "title": "SSL Mode",
+            "description": "Overrides SSL connection behavior by setting the 'sslmode' parameter."
           }
         },
         "additionalProperties": false,

--- a/source-postgres/main.go
+++ b/source-postgres/main.go
@@ -102,6 +102,7 @@ type advancedConfig struct {
 	WatermarksTable   string `json:"watermarksTable,omitempty" jsonschema:"default=public.flow_watermarks,description=The name of the table used for watermark writes during backfills. Must be fully-qualified in '<schema>.<table>' form."`
 	SkipBackfills     string `json:"skip_backfills,omitempty" jsonschema:"title=Skip Backfills,description=A comma-separated list of fully-qualified table names which should not be backfilled."`
 	BackfillChunkSize int    `json:"backfill_chunk_size,omitempty" jsonschema:"title=Backfill Chunk Size,default=32768,description=The number of rows which should be fetched from the database in a single backfill query."`
+	SSLMode           string `json:"sslmode,omitempty" jsonschema:"title=SSL Mode,description=Overrides SSL connection behavior by setting the 'sslmode' parameter.,enum=disable,enum=allow,enum=prefer,enum=require,enum=verify-ca,enum=verify-full"`
 }
 
 // Validate checks that the configuration possesses all required properties.
@@ -125,6 +126,11 @@ func (c *Config) Validate() error {
 			if !strings.Contains(skipStreamID, ".") {
 				return fmt.Errorf("invalid 'skipBackfills' configuration: table name %q must be fully-qualified as \"<schema>.<table>\"", skipStreamID)
 			}
+		}
+	}
+	if c.Advanced.SSLMode != "" {
+		if !stringMatches(c.Advanced.SSLMode, []string{"disable", "allow", "prefer", "require", "verify-ca", "verify-full"}) {
+			return fmt.Errorf("invalid 'sslmode' configuration: unknown setting %q", c.Advanced.SSLMode)
 		}
 	}
 
@@ -171,6 +177,13 @@ func (c *Config) ToURI() string {
 	}
 	if c.Database != "" {
 		uri.Path = "/" + c.Database
+	}
+	var params = make(url.Values)
+	if c.Advanced.SSLMode != "" {
+		params.Set("sslmode", c.Advanced.SSLMode)
+	}
+	if len(params) > 0 {
+		uri.RawQuery = params.Encode()
 	}
 	return uri.String()
 }
@@ -283,4 +296,13 @@ func (db *postgresDatabase) ShouldBackfill(streamID string) bool {
 		}
 	}
 	return true
+}
+
+func stringMatches(x string, alts []string) bool {
+	for _, alt := range alts {
+		if x == alt {
+			return true
+		}
+	}
+	return false
 }

--- a/source-postgres/main_test.go
+++ b/source-postgres/main_test.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/bradleyjkemp/cupaloy"
 	st "github.com/estuary/connectors/source-boilerplate/testing"
 	"github.com/estuary/connectors/sqlcapture"
 	"github.com/estuary/connectors/sqlcapture/tests"
@@ -245,4 +246,43 @@ func TestCapitalizedTables(t *testing.T) {
 			tests.VerifiedCapture(ctx, t, cs)
 		})
 	})
+}
+
+func TestConfigURI(t *testing.T) {
+	for name, cfg := range map[string]Config{
+		"Basic": {
+			Address:  "example.com",
+			User:     "will",
+			Password: "secret1234",
+			Database: "somedb",
+		},
+		"RequireSSL": {
+			Address:  "example.com",
+			User:     "will",
+			Password: "secret1234",
+			Database: "somedb",
+			Advanced: advancedConfig{
+				SSLMode: "verify-full",
+			},
+		},
+		"IncorrectSSL": {
+			Address:  "example.com",
+			User:     "will",
+			Password: "secret1234",
+			Database: "somedb",
+			Advanced: advancedConfig{
+				SSLMode: "whoops-this-isnt-right",
+			},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			var valid = "config valid"
+			if err := cfg.Validate(); err != nil {
+				valid = err.Error()
+			}
+			cfg.SetDefaults()
+			var uri = cfg.ToURI()
+			cupaloy.SnapshotT(t, fmt.Sprintf("%s\n%s", uri, valid))
+		})
+	}
 }


### PR DESCRIPTION
**Description:**

Adds a new 'SSL Mode' advanced config option. This is an enumeration which gets directly plumbed through into a libpq connection URI 'sslmode' parameter, which should have the appropriate effect when set.

When this option is left unset the connector behavior should be unchanged.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/753)
<!-- Reviewable:end -->
