### PR TITLE
materialize-bigquery: config from endpoint is a pointer

### DIFF
--- a/materialize-bigquery/bigquery.go
+++ b/materialize-bigquery/bigquery.go
@@ -97,8 +97,8 @@ type tableConfig struct {
 
 func newTableConfig(ep *sql.Endpoint) sql.Resource {
 	return &tableConfig{
-		projectID: ep.Config.(config).ProjectID,
-		dataset:   ep.Config.(config).Dataset,
+		projectID: ep.Config.(*config).ProjectID,
+		dataset:   ep.Config.(*config).Dataset,
 	}
 }
 
@@ -149,8 +149,8 @@ func newBigQueryDriver() *sql.Driver {
 		EndpointSpecType: config{},
 		ResourceSpecType: tableConfig{},
 		NewEndpoint: func(ctx context.Context, raw json.RawMessage, tenant string) (*sql.Endpoint, error) {
-			cfg := config{}
-			if err := pf.UnmarshalStrict(raw, &cfg); err != nil {
+			var cfg = new(config)
+			if err := pf.UnmarshalStrict(raw, cfg); err != nil {
 				return nil, fmt.Errorf("parsing endpoint configuration: %w", err)
 			}
 

--- a/materialize-bigquery/transactor.go
+++ b/materialize-bigquery/transactor.go
@@ -32,7 +32,7 @@ func newTransactor(
 	fence sql.Fence,
 	bindings []sql.Table,
 ) (_ pm.Transactor, err error) {
-	cfg := ep.Config.(config)
+	cfg := ep.Config.(*config)
 
 	log.WithFields(log.Fields{
 		"project_id":  cfg.ProjectID,


### PR DESCRIPTION
**Description:**

This makes materialize-bigquery provide its config to the endpoint as a pointer, to be consistent with the other sql materializations.

Automated tests pass (ran manually) and also I am able to create a materialization through the UI with this change, whereas before it would error.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/759)
<!-- Reviewable:end -->
