### PR TITLE
materialize-sqlite: fix build

### DIFF
--- a/materialize-sqlite/Dockerfile
+++ b/materialize-sqlite/Dockerfile
@@ -44,7 +44,7 @@ RUN apt-get update && \
   rm -rf /var/lib/apt && \
   rm -rf /var/lib/dpkg/info/*
 
-RUN pip install https://github.com/simonw/datasette/archive/refs/tags/${DATASETTE_VERSION}.zip && \
+RUN pip install https://github.com/simonw/datasette/archive/refs/tags/${DATASETTE_VERSION}.zip --break-system-packages && \
   find /usr/local/lib -name '__pycache__' | xargs rm -r && \
   rm -rf /root/.cache/pip
 


### PR DESCRIPTION
**Description:**

Using the `--break-system-packages` is (now) required for datasette to be installed as a system-wide python package.

I tried various alternatives for installation like using a virtual environment or `pipx` but could not get them to work. There is almost certainly a way to do it using one of those mechanisms. But using `--break-system-packages` doesn't cause any problems with the connector and is as far as I can tell how it was working before, so I decided to go with that instead of continuing to try to figure out some alternative.

Testing this was a little tricky since https://github.com/estuary/connectors/issues/695 is still an issue. I was able to confirm the datasette application does work with this though by modifying my local flow to run the container with port `8001` exposed and then connecting to that directly, getting around the currently non-functional connector networking.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

N/A

**Notes for reviewers:**

(anything that might help someone review this PR)

