### PR TITLE
filesource: log errors from parser as last logged line

### DIFF
--- a/materialize-boilerplate/boilerplate.go
+++ b/materialize-boilerplate/boilerplate.go
@@ -70,7 +70,7 @@ func RunMain(connector Connector) {
 	var server = ConnectorServer{connector}
 
 	if err := server.Materialize(stream); err != nil {
-		cerrors.LogFinalError(err)
+		cerrors.HandleFinalError(err)
 	}
 	os.Exit(0)
 }

--- a/source-boilerplate/boilerplate.go
+++ b/source-boilerplate/boilerplate.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/binary"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -13,15 +14,14 @@ import (
 	"os/signal"
 	"sync"
 	"syscall"
-	"encoding/hex"
 
-	"github.com/minio/highwayhash"
 	cerrors "github.com/estuary/connectors/go/connector-errors"
 	pc "github.com/estuary/flow/go/protocols/capture"
 	pf "github.com/estuary/flow/go/protocols/flow"
 	protoio "github.com/gogo/protobuf/io"
 	"github.com/gogo/protobuf/jsonpb"
 	"github.com/gogo/protobuf/proto"
+	"github.com/minio/highwayhash"
 	log "github.com/sirupsen/logrus"
 	"google.golang.org/grpc/metadata"
 )
@@ -75,7 +75,7 @@ func RunMain(connector Connector) {
 	var server = ConnectorServer{connector}
 
 	if err := server.Capture(stream); err != nil {
-		cerrors.LogFinalError(err)
+		cerrors.HandleFinalError(err)
 	}
 	os.Exit(0)
 }


### PR DESCRIPTION
**Description:**

When a `filesource` capture is running the parser and the parser fails, the parser logs an error message and exits with status 1. Currently we log something like `"parser failed: exited with status 1"` from the connector as the last log line when this happens.

This changes the connector to not log anything extra when the parser process exits with an error. The responsibility is on the parser to log the details of the error, and the connector shouldn't clobber that will a less useful generic log. This allows the relevant parser error to be picked up as the shard failure reason and shown in the UI.

See also https://github.com/estuary/flow/pull/1084 for a change in the parser to make the message logged on failure include the details of the error.

**Workflow steps:**

Observe better errors shown in the UI when a `filesource` capture fails due to a problem parsing.

**Documentation links affected:**

N/A

**Notes for reviewers:**

The first commit is general cleanup and formatting churn in `filesource.go`. The second commit has the actual changes discussed here.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/762)
<!-- Reviewable:end -->
