### PR TITLE
materialize-pinecone: return error message from rate limit error message response

### DIFF
--- a/materialize-pinecone/Dockerfile
+++ b/materialize-pinecone/Dockerfile
@@ -16,7 +16,7 @@ COPY materialize-boilerplate ./materialize-boilerplate
 COPY materialize-pinecone    ./materialize-pinecone
 
 # Test and build the connector.
-# RUN go test  -tags nozstd -v ./materialize-pinecone/...
+RUN go test  -tags nozstd -v ./materialize-pinecone/...
 RUN go build -tags nozstd -v -o ./connector ./materialize-pinecone
 
 # Runtime Stage


### PR DESCRIPTION
**Description:**

When a 429 "Too Many Requests" response is received from the OpenAI API, we retry since this is usually a rate limit error that exponential backoff while remedy. It is also possible for this response code to be received if a quota is exceed.

Either way, the API response contains some useful information in its JSON body, and we can extract that and return the API error message in the connector error.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

N/A

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/764)
<!-- Reviewable:end -->
