### PR TITLE
materialize-s3-parquet: proper handling for integer->float

### DIFF
--- a/materialize-s3-parquet/parquet_data_converter.go
+++ b/materialize-s3-parquet/parquet_data_converter.go
@@ -150,14 +150,20 @@ func (f *floatStrategy) reflectType() reflect.Type {
 	return reflect.TypeOf(float64(0))
 }
 func (f *floatStrategy) set(t tuple.TupleElement, fldToSet reflect.Value) error {
-	switch v := reflect.ValueOf(t); v.Kind() {
-	case reflect.Float32, reflect.Float64:
+	var v = reflect.ValueOf(t)
+
+	if v.CanFloat() {
 		fldToSet.SetFloat(v.Float())
-		return nil
-	default:
+	} else if v.CanUint() {
+		fldToSet.SetFloat(float64(v.Uint()))
+	} else if v.CanInt() {
+		fldToSet.SetFloat(float64(v.Int()))
+	} else {
 		return fmt.Errorf("invalid float type (%s)", v.Kind().String())
 	}
+	return nil
 }
+
 func newFloatField(name string, optional bool) *pqField {
 	return &pqField{
 		name:         name,
@@ -198,7 +204,7 @@ type jsonStrategy struct{}
 
 func (b *jsonStrategy) tag(name, internalName, repetitionType string) string {
 	return fmt.Sprintf(`{"Tag": "name=%s, inname=%s, type=BYTE_ARRAY, logicaltype=STRING, repetitiontype=%s"}`,
-	name, internalName, repetitionType)
+		name, internalName, repetitionType)
 }
 func (b *jsonStrategy) reflectType() reflect.Type {
 	return reflect.TypeOf("")

--- a/materialize-s3-parquet/parquet_data_converter_test.go
+++ b/materialize-s3-parquet/parquet_data_converter_test.go
@@ -118,6 +118,8 @@ func TestOptionalIntField(t *testing.T) {
 var floatTests = []test{
 	{input: tuple.TupleElement(float32(-11.1234)), expected: float64(-11.1234)},
 	{input: tuple.TupleElement(float64(12.12345678)), expected: float64(12.12345678)},
+	{input: tuple.TupleElement(int64(-1234)), expected: float64(-1234)},
+	{input: tuple.TupleElement(uint32(1234)), expected: float64(1234)},
 }
 
 func TestFloatField(t *testing.T) {
@@ -143,8 +145,8 @@ func TestFloatField(t *testing.T) {
 	var err1 = fld.Set(nil, v)
 	require.EqualError(t, err1, "unexpected nil value to a non-optional field")
 
-	var err2 = fld.Set(tuple.TupleElement(int(0)), v)
-	require.EqualError(t, err2, "invalid float type (int)")
+	var err2 = fld.Set(tuple.TupleElement("whoops"), v)
+	require.EqualError(t, err2, "invalid float type (string)")
 }
 
 func TestOptionalFloatField(t *testing.T) {
@@ -170,8 +172,8 @@ func TestOptionalFloatField(t *testing.T) {
 	fld.Set(nil, v)
 	require.True(t, v.IsNil())
 
-	var actualError = fld.Set(tuple.TupleElement(int(0)), reflect.New(structField.Type).Elem())
-	require.EqualError(t, actualError, "invalid float type (int)")
+	var actualError = fld.Set(tuple.TupleElement("whoops"), reflect.New(structField.Type).Elem())
+	require.EqualError(t, actualError, "invalid float type (string)")
 }
 
 var boolTests = []test{


### PR DESCRIPTION
Properly handle integer instances destined for float (`type: number`) fields.
Integers will be sent / preferred by the runtime if the location parses cleanly as an integer.


**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/766)
<!-- Reviewable:end -->
