### PR TITLE
materialize-bigquery: retry errors when response suggests retrying

### DIFF
--- a/materialize-bigquery/query.go
+++ b/materialize-bigquery/query.go
@@ -91,6 +91,7 @@ func (c client) runQuery(ctx context.Context, query *bigquery.Query) (*bigquery.
 			if e, ok := err.(*googleapi.Error); ok {
 				if strings.Contains(err.Error(), "Transaction is aborted due to concurrent update against table") ||
 					strings.Contains(err.Error(), "Could not serialize access to table") ||
+					strings.Contains(err.Error(), "The job encountered an error during execution. Retrying the job may solve the problem.") ||
 					(len(e.Errors) == 1 && e.Errors[0].Reason == "jobRateLimitExceeded") {
 					backoff *= math.Pow(2, 1+rand.Float64())
 					delay := time.Duration(backoff * float64(time.Millisecond))


### PR DESCRIPTION
**Description:**

Bigquery sometimes responds with a 400 status error and provides no specific reason for the error, but the error response suggests that retrying might solve the problem. We have seen that retrying does indeed solve the problem when the connector is restarted via the shard supervisor. This change makes these errors be automatically retried.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

N/A

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/768)
<!-- Reviewable:end -->
