### PR TITLE
refactor: consolidate "slice contains" logic

### DIFF
--- a/go/pkg/slices/slices.go
+++ b/go/pkg/slices/slices.go
@@ -1,0 +1,11 @@
+package slices
+
+func Contains[T comparable](elems []T, v T) bool {
+	for _, elem := range elems {
+		if elem == v {
+			return true
+		}
+	}
+
+	return false
+}

--- a/materialize-bigquery/sqlgen.go
+++ b/materialize-bigquery/sqlgen.go
@@ -6,6 +6,7 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/estuary/connectors/go/pkg/slices"
 	sql "github.com/estuary/connectors/materialize-sql"
 	"github.com/estuary/flow/go/protocols/fdb/tuple"
 )
@@ -85,7 +86,7 @@ var bqDialect = func() sql.Dialect {
 				func(s string) bool {
 					// Note: The BigQuery reserved words list must be in all-caps, as they are
 					// listed in the BigQuery docs. Quoting must be applied regardless of case.
-					return simpleIdentifierRegexp.MatchString(s) && !sql.SliceContains(strings.ToUpper(s), BQ_RESERVED_WORDS)
+					return simpleIdentifierRegexp.MatchString(s) && !slices.Contains(BQ_RESERVED_WORDS, strings.ToUpper(s))
 				},
 				sql.QuoteTransform("`", "\\`"),
 			)))),

--- a/materialize-firebolt/.snapshots/TestDriverSpec
+++ b/materialize-firebolt/.snapshots/TestDriverSpec
@@ -91,7 +91,8 @@
           "dimension"
         ],
         "title": "Table Type",
-        "description": "Type of the Firebolt table to store materialized results in. See https://docs.firebolt.io/working-with-tables.html for more details."
+        "description": "Type of the Firebolt table to store materialized results in. See https://docs.firebolt.io/working-with-tables.html for more details.",
+        "default": "fact"
       }
     },
     "type": "object",

--- a/materialize-firebolt/config.go
+++ b/materialize-firebolt/config.go
@@ -65,7 +65,7 @@ func (config) GetFieldDocString(fieldName string) string {
 
 type resource struct {
 	Table     string `json:"table" jsonschema:"title=Table" jsonschema_extras:"x-collection-name=true"`
-	TableType string `json:"table_type" jsonschema:"title=Table Type,enum=fact,enum=dimension",default=fact`
+	TableType string `json:"table_type" jsonschema:"title=Table Type,enum=fact,enum=dimension,default=fact"`
 }
 
 func (r resource) Validate() error {

--- a/materialize-firebolt/driver.go
+++ b/materialize-firebolt/driver.go
@@ -177,13 +177,4 @@ func (d driver) Apply(ctx context.Context, req *pm.Request_Apply) (*pm.Response_
 	return &pm.Response_Applied{ActionDescription: fmt.Sprint("created tables: ", strings.Join(tables, ","))}, nil
 }
 
-func SliceContains(expected string, actual []string) bool {
-	for _, ty := range actual {
-		if ty == expected {
-			return true
-		}
-	}
-	return false
-}
-
 func main() { boilerplate.RunMain(new(driver)) }

--- a/materialize-mongodb/driver.go
+++ b/materialize-mongodb/driver.go
@@ -240,15 +240,6 @@ func resolveResourceConfig(specJson json.RawMessage) (resource, error) {
 	return res, nil
 }
 
-func SliceContains(expected string, actual []string) bool {
-	for _, ty := range actual {
-		if ty == expected {
-			return true
-		}
-	}
-	return false
-}
-
 func main() {
 	boilerplate.RunMain(driver{})
 }

--- a/materialize-postgres/driver.go
+++ b/materialize-postgres/driver.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	networkTunnel "github.com/estuary/connectors/go/network-tunnel"
+	"github.com/estuary/connectors/go/pkg/slices"
 	boilerplate "github.com/estuary/connectors/materialize-boilerplate"
 	sql "github.com/estuary/connectors/materialize-sql"
 	pf "github.com/estuary/flow/go/protocols/flow"
@@ -73,7 +74,7 @@ func (c *config) Validate() error {
 	}
 
 	if c.Advanced.SSLMode != "" {
-		if !stringMatches(c.Advanced.SSLMode, []string{"disable", "allow", "prefer", "require", "verify-ca", "verify-full"}) {
+		if !slices.Contains([]string{"disable", "allow", "prefer", "require", "verify-ca", "verify-full"}, c.Advanced.SSLMode) {
 			return fmt.Errorf("invalid 'sslmode' configuration: unknown setting %q", c.Advanced.SSLMode)
 		}
 	}
@@ -549,13 +550,4 @@ func sendBatch(ctx context.Context, txn pgx.Tx, batch *pgx.Batch) error {
 	*batch = newBatch
 
 	return nil
-}
-
-func stringMatches(x string, alts []string) bool {
-	for _, alt := range alts {
-		if x == alt {
-			return true
-		}
-	}
-	return false
 }

--- a/materialize-postgres/sqlgen.go
+++ b/materialize-postgres/sqlgen.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/estuary/connectors/go/pkg/slices"
 	sql "github.com/estuary/connectors/materialize-sql"
 )
 
@@ -38,7 +39,7 @@ var pgDialect = func() sql.Dialect {
 		Identifierer: sql.IdentifierFn(sql.JoinTransform(".",
 			sql.PassThroughTransform(
 				func(s string) bool {
-					return sql.IsSimpleIdentifier(s) && !sql.SliceContains(strings.ToLower(s), PG_RESERVED_WORDS)
+					return sql.IsSimpleIdentifier(s) && !slices.Contains(PG_RESERVED_WORDS, strings.ToLower(s))
 				},
 				sql.QuoteTransform("\"", "\\\""),
 			))),

--- a/materialize-redshift/sqlgen.go
+++ b/materialize-redshift/sqlgen.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/estuary/connectors/go/pkg/slices"
 	sql "github.com/estuary/connectors/materialize-sql"
 	"github.com/estuary/flow/go/protocols/fdb/tuple"
 )
@@ -92,7 +93,7 @@ var rsDialect = func() sql.Dialect {
 		Identifierer: sql.IdentifierFn(sql.JoinTransform(".",
 			sql.PassThroughTransform(
 				func(s string) bool {
-					return simpleIdentifierRegexp.MatchString(s) && !sql.SliceContains(strings.ToLower(s), REDSHIFT_RESERVED_WORDS)
+					return simpleIdentifierRegexp.MatchString(s) && !slices.Contains(REDSHIFT_RESERVED_WORDS, strings.ToLower(s))
 				},
 				sql.QuoteTransform("\"", "\"\""),
 			))),

--- a/materialize-snowflake/sqlgen.go
+++ b/materialize-snowflake/sqlgen.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"text/template"
 
+	"github.com/estuary/connectors/go/pkg/slices"
 	sql "github.com/estuary/connectors/materialize-sql"
 	"github.com/estuary/flow/go/protocols/fdb/tuple"
 )
@@ -74,7 +75,7 @@ var snowflakeDialect = func() sql.Dialect {
 		Identifierer: sql.IdentifierFn(sql.JoinTransform(".",
 			sql.PassThroughTransform(
 				func(s string) bool {
-					return simpleIdentifierRegexp.MatchString(s) && !sql.SliceContains(strings.ToLower(s), SF_RESERVED_WORDS)
+					return simpleIdentifierRegexp.MatchString(s) && !slices.Contains(SF_RESERVED_WORDS, strings.ToLower(s))
 				},
 				sql.QuoteTransform("\"", "\\\""),
 			))),

--- a/source-kinesis/connection.go
+++ b/source-kinesis/connection.go
@@ -14,7 +14,7 @@ import (
 // Config represents the fully merged endpoint configuration for Kinesis.
 // It matches the `KinesisConfig` struct in `crates/sources/src/specs.rs`
 type Config struct {
-	Endpoint           string `json:"endpoint,omitempty" jsonschema:"title=AWS Endpoint" jsonschema_description="The AWS endpoint URI to connect to, useful if you're capturing from a kinesis-compatible API that isn't provided by AWS"`
+	Endpoint           string `json:"endpoint,omitempty" jsonschema:"title=AWS Endpoint,description=The AWS endpoint URI to connect to (useful if you're capturing from a kinesis-compatible API that isn't provided by AWS)"`
 	Region             string `json:"region" jsonschema:"title=AWS Region,description=The name of the AWS region where the Kinesis stream is located"`
 	AWSAccessKeyID     string `json:"awsAccessKeyId" jsonschema:"title=AWS Access Key ID,description=Part of the AWS credentials that will be used to connect to Kinesis"`
 	AWSSecretAccessKey string `json:"awsSecretAccessKey" jsonschema:"title=AWS Secret Access Key,description=Part of the AWS credentials that will be used to connect to Kinesis"`

--- a/source-kinesis/discovery.go
+++ b/source-kinesis/discovery.go
@@ -5,43 +5,43 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"github.com/aws/aws-sdk-go/service/kinesis"
 	pc "github.com/estuary/flow/go/protocols/capture"
 	pf "github.com/estuary/flow/go/protocols/flow"
 	"github.com/invopop/jsonschema"
-	"github.com/aws/aws-sdk-go/service/kinesis"
 )
 
 const (
-	metaProperty  = "_meta"
+	metaProperty   = "_meta"
 	sequenceNumber = "sequence_number"
-	partitionKey = "partition_key"
+	partitionKey   = "partition_key"
 )
 
 // Provides a default schema to use for collections.
 var minimalSchema = &jsonschema.Schema{
-		Type:                 "object",
-		Required:             []string{metaProperty},
-		AdditionalProperties: nil,
-		Extras: map[string]interface{}{
-			"x-infer-schema": true,
+	Type:                 "object",
+	Required:             []string{metaProperty},
+	AdditionalProperties: nil,
+	Extras: map[string]interface{}{
+		"x-infer-schema": true,
 
-			"properties": map[string]*jsonschema.Schema{
-				metaProperty: &jsonschema.Schema{
-					Type: "object",
-					Required: []string{sequenceNumber, partitionKey},
-					Extras: map[string]interface{}{
-						"properties": map[string]*jsonschema.Schema{
-							sequenceNumber: &jsonschema.Schema{
-								Type: "string",
-							},
-							partitionKey: &jsonschema.Schema{
-								Type: "string",
-							},
+		"properties": map[string]*jsonschema.Schema{
+			metaProperty: {
+				Type:     "object",
+				Required: []string{sequenceNumber, partitionKey},
+				Extras: map[string]interface{}{
+					"properties": map[string]*jsonschema.Schema{
+						sequenceNumber: {
+							Type: "string",
+						},
+						partitionKey: {
+							Type: "string",
 						},
 					},
 				},
 			},
 		},
+	},
 }
 
 func discoverStreams(ctx context.Context, client *kinesis.Kinesis, streamNames []string) []*pc.Response_Discovered_Binding {
@@ -59,10 +59,10 @@ func discoverStreams(ctx context.Context, client *kinesis.Kinesis, streamNames [
 			panic(fmt.Errorf("serializing resource json: %w", err))
 		}
 		streams[i] = &pc.Response_Discovered_Binding{
-			RecommendedName:     pf.Collection(name),
-			DocumentSchemaJson:  json.RawMessage(bs),
-			ResourceConfigJson:  resourceJSON,
-			Key: []string{fmt.Sprintf("/%s/%s", metaProperty, sequenceNumber), fmt.Sprintf("/%s/%s", metaProperty, partitionKey)},
+			RecommendedName:    pf.Collection(name),
+			DocumentSchemaJson: json.RawMessage(bs),
+			ResourceConfigJson: resourceJSON,
+			Key:                []string{fmt.Sprintf("/%s/%s", metaProperty, sequenceNumber), fmt.Sprintf("/%s/%s", metaProperty, partitionKey)},
 		}
 	}
 

--- a/source-mongodb/main.go
+++ b/source-mongodb/main.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	cerrors "github.com/estuary/connectors/go/connector-errors"
+	"github.com/estuary/connectors/go/pkg/slices"
 	schemagen "github.com/estuary/connectors/go/schema-gen"
 	boilerplate "github.com/estuary/connectors/source-boilerplate"
 	pc "github.com/estuary/flow/go/protocols/capture"
@@ -172,7 +173,7 @@ func (d *driver) Validate(ctx context.Context, req *pc.Request_Validate) (*pc.Re
 			return nil, fmt.Errorf("error parsing resource config: %w", err)
 		}
 
-		if !SliceContains(res.Database, existingDatabases) {
+		if !slices.Contains(existingDatabases, res.Database) {
 			return nil, fmt.Errorf("database %s does not exist", res.Database)
 		}
 
@@ -183,7 +184,7 @@ func (d *driver) Validate(ctx context.Context, req *pc.Request_Validate) (*pc.Re
 			return nil, fmt.Errorf("listing collections in database %s: %w", db.Name(), err)
 		}
 
-		if !SliceContains(res.Collection, collections) {
+		if !slices.Contains(collections, res.Collection) {
 			return nil, fmt.Errorf("could not find collection %s in database %s", res.Collection, db.Name())
 		}
 
@@ -219,13 +220,4 @@ func (d *driver) Apply(ctx context.Context, req *pc.Request_Apply) (*pc.Response
 
 func main() {
 	boilerplate.RunMain(new(driver))
-}
-
-func SliceContains(expected string, actual []string) bool {
-	for _, ty := range actual {
-		if ty == expected {
-			return true
-		}
-	}
-	return false
 }

--- a/source-postgres/main.go
+++ b/source-postgres/main.go
@@ -12,6 +12,7 @@ import (
 
 	cerrors "github.com/estuary/connectors/go/connector-errors"
 	networkTunnel "github.com/estuary/connectors/go/network-tunnel"
+	"github.com/estuary/connectors/go/pkg/slices"
 	schemagen "github.com/estuary/connectors/go/schema-gen"
 	boilerplate "github.com/estuary/connectors/source-boilerplate"
 	"github.com/estuary/connectors/sqlcapture"
@@ -129,7 +130,7 @@ func (c *Config) Validate() error {
 		}
 	}
 	if c.Advanced.SSLMode != "" {
-		if !stringMatches(c.Advanced.SSLMode, []string{"disable", "allow", "prefer", "require", "verify-ca", "verify-full"}) {
+		if !slices.Contains([]string{"disable", "allow", "prefer", "require", "verify-ca", "verify-full"}, c.Advanced.SSLMode) {
 			return fmt.Errorf("invalid 'sslmode' configuration: unknown setting %q", c.Advanced.SSLMode)
 		}
 	}
@@ -296,13 +297,4 @@ func (db *postgresDatabase) ShouldBackfill(streamID string) bool {
 		}
 	}
 	return true
-}
-
-func stringMatches(x string, alts []string) bool {
-	for _, alt := range alts {
-		if x == alt {
-			return true
-		}
-	}
-	return false
 }


### PR DESCRIPTION
**Description:**

We have a similar function for determining if a slice contains an element copied in many connectors. This consolidates that into a common function that can be used amongst all connectors.

There are also a few minor cleanups that I noticed while updating these function call sites.

I changed the function signature of our previous standard "slice contains" function to take the slice first and then the element to look for, which is the reverse of how it was. This seems more in line with similar functions, like the one in [golang.org/x/exp](https://pkg.go.dev/golang.org/x/exp/slices#Contains).

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

N/A

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/770)
<!-- Reviewable:end -->
