### PR TITLE
source-sqlserver: Filter included columns from index enumeration

### DIFF
--- a/source-sqlserver/.snapshots/TestIndexIncludedDiscovery
+++ b/source-sqlserver/.snapshots/TestIndexIncludedDiscovery
@@ -1,0 +1,130 @@
+Binding 0:
+{
+    "recommended_name": "test_indexincludeddiscovery_98476798",
+    "resource_config_json": {
+      "mode": "Normal",
+      "namespace": "dbo",
+      "stream": "test_IndexIncludedDiscovery_98476798"
+    },
+    "document_schema_json": {
+      "$defs": {
+        "DboTest_IndexIncludedDiscovery_98476798": {
+          "type": "object",
+          "required": [
+            "k2",
+            "k3"
+          ],
+          "$anchor": "DboTest_IndexIncludedDiscovery_98476798",
+          "properties": {
+            "data": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "k1": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "k2": {
+              "type": "integer"
+            },
+            "k3": {
+              "type": "integer"
+            }
+          }
+        }
+      },
+      "allOf": [
+        {
+          "required": [
+            "_meta"
+          ],
+          "properties": {
+            "_meta": {
+              "type": "object",
+              "required": [
+                "op",
+                "source"
+              ],
+              "properties": {
+                "before": {
+                  "$ref": "#DboTest_IndexIncludedDiscovery_98476798",
+                  "description": "Record state immediately before this change was applied.",
+                  "reduce": {
+                    "strategy": "firstWriteWins"
+                  }
+                },
+                "op": {
+                  "enum": [
+                    "c",
+                    "d",
+                    "u"
+                  ],
+                  "description": "Change operation type: 'c' Create/Insert, 'u' Update, 'd' Delete."
+                },
+                "source": {
+                  "$id": "https://github.com/estuary/connectors/source-sqlserver/sqlserver-source-info",
+                  "properties": {
+                    "ts_ms": {
+                      "type": "integer",
+                      "description": "Unix timestamp (in millis) at which this event was recorded by the database."
+                    },
+                    "schema": {
+                      "type": "string",
+                      "description": "Database schema (namespace) of the event."
+                    },
+                    "snapshot": {
+                      "type": "boolean",
+                      "description": "Snapshot is true if the record was produced from an initial table backfill and unset if produced from the replication log."
+                    },
+                    "table": {
+                      "type": "string",
+                      "description": "Database table of the event."
+                    },
+                    "lsn": {
+                      "type": "string",
+                      "contentEncoding": "base64",
+                      "description": "The LSN at which a CDC event occurred. Only set for CDC events"
+                    },
+                    "seqval": {
+                      "type": "string",
+                      "contentEncoding": "base64",
+                      "description": "Sequence value used to order changes to a row within a transaction. Only set for CDC events"
+                    },
+                    "updateMask": {
+                      "description": "A bit mask with a bit corresponding to each captured column identified for the capture instance. Only set for CDC events"
+                    }
+                  },
+                  "additionalProperties": false,
+                  "type": "object",
+                  "required": [
+                    "schema",
+                    "table",
+                    "lsn",
+                    "seqval"
+                  ]
+                }
+              },
+              "reduce": {
+                "strategy": "merge"
+              }
+            }
+          },
+          "reduce": {
+            "strategy": "merge"
+          }
+        },
+        {
+          "$ref": "#DboTest_IndexIncludedDiscovery_98476798"
+        }
+      ]
+    },
+    "key": [
+      "/k2",
+      "/k3"
+    ]
+  }
+

--- a/source-sqlserver/discovery.go
+++ b/source-sqlserver/discovery.go
@@ -184,7 +184,7 @@ FROM sys.indexes idx
      JOIN sys.tables tbl ON tbl.object_id = idx.object_id
 	 JOIN sys.schemas sch ON sch.schema_id = tbl.schema_id
 	 JOIN sys.index_columns ic ON ic.index_id = idx.index_id AND ic.object_id = tbl.object_id
-WHERE idx.is_unique = 1 AND sch.name NOT IN ('cdc')
+WHERE ic.key_ordinal != 0 AND idx.is_unique = 1 AND sch.name NOT IN ('cdc')
 ORDER BY sch.name, tbl.name, idx.name, ic.key_ordinal
 `
 

--- a/source-sqlserver/discovery_test.go
+++ b/source-sqlserver/discovery_test.go
@@ -45,3 +45,14 @@ func TestSecondaryIndexDiscovery(t *testing.T) {
 		tb.CaptureSpec(ctx, t).VerifyDiscover(ctx, t, regexp.MustCompile(regexp.QuoteMeta(uniqueString)))
 	})
 }
+
+// TestIndexIncludedDiscovery tests discovery when a secondary unique index contains
+// some included non-key columns.
+func TestIndexIncludedDiscovery(t *testing.T) {
+	var tb, ctx = sqlserverTestBackend(t), context.Background()
+	var uniqueID = "98476798"
+	var tableName = tb.CreateTable(ctx, t, uniqueID, "(k1 INTEGER, k2 INTEGER NOT NULL, k3 INTEGER NOT NULL, data TEXT)")
+	var shortName = tableName[strings.Index(tableName, ".")+1:]
+	tb.Query(ctx, t, fmt.Sprintf(`CREATE UNIQUE INDEX %s_k23 ON %s (k2, k3) INCLUDE (k1)`, shortName, tableName))
+	tb.CaptureSpec(ctx, t).VerifyDiscover(ctx, t, regexp.MustCompile(uniqueID))
+}


### PR DESCRIPTION
**Description:**

When we query the system tables to list potential secondary unique indices for discovery, we need to filter out included non-key columns.

This fixes https://github.com/estuary/connectors/issues/773

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/776)
<!-- Reviewable:end -->
