### PR TITLE
source-sqlserver: Fully support `DATETIME` columns

### DIFF
--- a/source-sqlserver/.snapshots/TestGeneric-SpecResponse
+++ b/source-sqlserver/.snapshots/TestGeneric-SpecResponse
@@ -27,6 +27,13 @@
         "description": "Logical database name to capture from.",
         "order": 3
       },
+      "timezone": {
+        "type": "string",
+        "title": "Time Zone",
+        "description": "The IANA timezone name in which datetime columns will be converted to RFC3339 timestamps. Defaults to UTC if left blank.",
+        "default": "UTC",
+        "order": 4
+      },
       "advanced": {
         "properties": {
           "watermarksTable": {

--- a/source-sqlserver/datatypes.go
+++ b/source-sqlserver/datatypes.go
@@ -78,6 +78,11 @@ func (db *sqlserverDatabase) translateRecordField(columnType interface{}, val in
 			return val.Format("2006-01-02"), nil
 		case "time":
 			return val.Format("15:04:05.9999999"), nil
+		case "datetime", "datetime2", "smalldatetime":
+			// The SQL Server client library translates DATETIME columns into Go time.Time values
+			// in the UTC location. We need to reinterpret the same YYYY-MM-DD HH:MM:SS.NNN values
+			// in the actual user-specified location instead.
+			return time.Date(val.Year(), val.Month(), val.Day(), val.Hour(), val.Minute(), val.Second(), val.Nanosecond(), db.datetimeLocation), nil
 		}
 	}
 	return val, nil

--- a/source-sqlserver/datatypes_test.go
+++ b/source-sqlserver/datatypes_test.go
@@ -12,6 +12,7 @@ import (
 // TestDatatypes tests discovery and value capture with various database column types,
 func TestDatatypes(t *testing.T) {
 	var ctx, tb = context.Background(), sqlserverTestBackend(t)
+	tb.config.Timezone = "America/Chicago" // Interpret DATETIME column values here
 	tests.TestDatatypes(ctx, t, tb, []tests.DatatypeTestCase{
 		{ColumnType: `integer`, ExpectType: `{"type":["integer","null"]}`, InputValue: `123`, ExpectValue: `123`},
 		{ColumnType: `integer not null`, ExpectType: `{"type":"integer"}`, InputValue: `-0451`, ExpectValue: `-451`},
@@ -46,11 +47,9 @@ func TestDatatypes(t *testing.T) {
 		{ColumnType: `time`, ExpectType: `{"type":["string","null"],"format":"time"}`, InputValue: `12:34:54.125`, ExpectValue: `"12:34:54.125"`},
 		{ColumnType: `datetimeoffset`, ExpectType: `{"type":["string","null"],"format":"date-time"}`, InputValue: `1991-08-31T12:34:54.125-06:00`, ExpectValue: `"1991-08-31T12:34:54.125-06:00"`},
 
-		// TODO(wgd): Figure out how we want to handle 'datetime' columns. They're just
-		// as awful as every timezone-unaware datetime type always is.
-		//{ColumnType: `datetime`, ExpectType: `{"type":["","null"]}`, InputValue: ``, ExpectValue: ``},
-		//{ColumnType: `datetime2`, ExpectType: `{"type":["","null"]}`, InputValue: ``, ExpectValue: ``},
-		//{ColumnType: `smalldatetime`, ExpectType: `{"type":["","null"]}`, InputValue: ``, ExpectValue: ``},
+		{ColumnType: `datetime`, ExpectType: `{"type":["string","null"],"format":"date-time"}`, InputValue: `1991-08-31T12:34:56.789`, ExpectValue: `"1991-08-31T12:34:56.79-05:00"`},
+		{ColumnType: `datetime2`, ExpectType: `{"type":["string","null"],"format":"date-time"}`, InputValue: `1991-08-31T12:34:56.789`, ExpectValue: `"1991-08-31T12:34:56.789-05:00"`},
+		{ColumnType: `smalldatetime`, ExpectType: `{"type":["string","null"],"format":"date-time"}`, InputValue: `1991-08-31T12:34:56.789`, ExpectValue: `"1991-08-31T12:35:00-05:00"`},
 
 		{ColumnType: `uniqueidentifier`, ExpectType: `{"type":["string","null"],"format":"uuid"}`, InputValue: `8292f3cb-0cce-41e8-86aa-ae09bcc988e9`, ExpectValue: `"8292f3cb-0cce-41e8-86aa-ae09bcc988e9"`},
 

--- a/source-sqlserver/discovery.go
+++ b/source-sqlserver/discovery.go
@@ -306,5 +306,7 @@ var sqlserverTypeToJSON = map[string]columnSchema{
 
 	"xml": {jsonType: "string"},
 
-	//"datetime": {jsonType: "string", format: "date-time"},
+	"datetime":      {jsonType: "string", format: "date-time"},
+	"datetime2":     {jsonType: "string", format: "date-time"},
+	"smalldatetime": {jsonType: "string", format: "date-time"},
 }

--- a/sqlcapture/timezone.go
+++ b/sqlcapture/timezone.go
@@ -1,0 +1,32 @@
+package sqlcapture
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+	"time"
+)
+
+var timeZoneOffsetRegex = regexp.MustCompile(`^[-+][0-9]{1,2}:[0-9]{2}$`)
+
+var errInvalidTimezone = errors.New("timezone must be a valid IANA timezone name or +HH:MM offset")
+
+// ParseTimezone parses a timezone name or numeric offset into a time.Location.
+func ParseTimezone(tzName string) (*time.Location, error) {
+	// If the time zone setting is a valid IANA zone name then return that.
+	loc, err := time.LoadLocation(tzName)
+	if err == nil {
+		return loc, nil
+	}
+
+	// If it looks like a numeric offset then parse a fixed-offset time zone from that.
+	if timeZoneOffsetRegex.MatchString(tzName) {
+		var t, err = time.Parse("-07:00", tzName)
+		if err != nil {
+			return nil, fmt.Errorf("error parsing %q: %w", tzName, err)
+		}
+		return t.Location(), nil
+	}
+
+	return nil, fmt.Errorf("unknown or invalid timezone %q: %w", tzName, errInvalidTimezone)
+}


### PR DESCRIPTION
**Description:**

Support for the `DATETIME`, `DATETIME2`, and `SMALLDATETIME` columns is added by introducing a new configuration property 'Time Zone' whose value should be an IANA Time Zone name or `-HH:MM` numeric offset, and using that location to interpret the contents of `DATETIME` and friends.

This is basically the same as how we do things in MySQL, except here we're not even trying to autodetect a time zone from the server configuration.

The new time zone property is added at the top level of the configuration so all new users should see it. The default value according to the JSON schema should be `"UTC"` and likewise if the property is empty (as it will be for existing captures) it will default to `"UTC"`.

This fixes https://github.com/estuary/connectors/issues/772

**Workflow steps:**

Existing captures should be unchanged.

New users will no longer be greeted with `error translating column type to JSON schema` warnings when performing discovery, and will be given a hopefully clear input box in the config to change how datetimes are interpreted. If they don't change it from UTC, the captured values will be the same as before (that is, interpreting the YYYY-MM-DD HH:MM:SS.NNN values as UTC) except the schema will at least be useful.

**Documentation links affected:**

https://docs.estuary.dev/reference/Connectors/capture-connectors/sqlserver/

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/777)
<!-- Reviewable:end -->
