### PR TITLE
source-sqlserver: Support `hierarchyid` column type

### DIFF
--- a/source-sqlserver/datatypes_test.go
+++ b/source-sqlserver/datatypes_test.go
@@ -54,6 +54,8 @@ func TestDatatypes(t *testing.T) {
 		{ColumnType: `uniqueidentifier`, ExpectType: `{"type":["string","null"],"format":"uuid"}`, InputValue: `8292f3cb-0cce-41e8-86aa-ae09bcc988e9`, ExpectValue: `"8292f3cb-0cce-41e8-86aa-ae09bcc988e9"`},
 
 		{ColumnType: `xml`, ExpectType: `{"type":["string","null"]}`, InputValue: `<hello>world</hello>`, ExpectValue: `"\u003chello\u003eworld\u003c/hello\u003e"`},
+
+		{ColumnType: `hierarchyid`, ExpectType: `{"type":["string","null"],"contentEncoding":"base64"}`, InputValue: `/1/2/3/`, ExpectValue: `"W14="`},
 	})
 }
 

--- a/source-sqlserver/discovery.go
+++ b/source-sqlserver/discovery.go
@@ -309,4 +309,6 @@ var sqlserverTypeToJSON = map[string]columnSchema{
 	"datetime":      {jsonType: "string", format: "date-time"},
 	"datetime2":     {jsonType: "string", format: "date-time"},
 	"smalldatetime": {jsonType: "string", format: "date-time"},
+
+	"hierarchyid": {jsonType: "string", contentEncoding: "base64"},
 }


### PR DESCRIPTION
**Description:**

The `hierarchyid` column type is a weird one. It's an ultra- compact representation of an arbitrary node position within a tree, encoded using an undocumented variable-length binary code of some sort.

When we receive these values from the SQL Server client library they're still in their `[]byte` form, and given that (as far as I can determine) there is no publically available documentation [1] of this binary representation I don't think we should be in the business of decoding them.

So this change amounts to telling our discovery logic that a `hierarchyid` column will be serialized into a base64 string and calling it a day.

This fixes https://github.com/estuary/connectors/issues/771

[1] The best documentation I could find about the actual encoding of this data was https://web.archive.org/web/20210304123429/http://www.adammil.net/blog/v100_how_the_SQL_Server_hierarchyid_data_type_works_kind_of_.html

**Workflow steps:**

One less column type producing scary warnings during discovery.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/778)
<!-- Reviewable:end -->
