### PR TITLE
source-postgres: handle infinity values for timestamp fields

### DIFF
--- a/source-postgres/datatype_test.go
+++ b/source-postgres/datatype_test.go
@@ -58,6 +58,9 @@ func TestDatatypes(t *testing.T) {
 		{ColumnType: `date`, ExpectType: `{"type":["string","null"],"format":"date-time"}`, InputValue: `'January 8, 1999'`, ExpectValue: `"1999-01-08T00:00:00Z"`},
 		{ColumnType: `timestamp`, ExpectType: `{"type":["string","null"],"format":"date-time"}`, InputValue: `'January 8, 1999'`, ExpectValue: `"1999-01-08T00:00:00Z"`},
 		{ColumnType: `timestamp without time zone`, ExpectType: `{"type":["string","null"],"format":"date-time"}`, InputValue: `'January 8, 1999'`, ExpectValue: `"1999-01-08T00:00:00Z"`},
+		{ColumnType: `timestamp`, ExpectType: `{"type":["string","null"],"format":"date-time"}`, InputValue: `'infinity'`, ExpectValue: fmt.Sprintf(`%q`, infinityTimestamp)},
+		{ColumnType: `timestamp`, ExpectType: `{"type":["string","null"],"format":"date-time"}`, InputValue: `'-infinity'`, ExpectValue: fmt.Sprintf(`%q`, negativeInfinityTimestamp)},
+		{ColumnType: `timestamp`, ExpectType: `{"type":["string","null"],"format":"date-time"}`, InputValue: `'epoch'`, ExpectValue: `"1970-01-01T00:00:00Z"`},
 
 		// TODO(wgd): The 'timestamp with time zone' type produces inconsistent results between
 		// table scanning and replication events. They're both valid timestamps, but they differ.


### PR DESCRIPTION
**Description:**

Convert infinity and negative infinity to their best equivalent RFC3339 timestamp fields of `"9999-12-31T23:59:59"` and `"0000-01-01T00:00:00Z"`, respectively. Previously these were output from the connector as the integer values `1` and `-1`.

Closes https://github.com/estuary/connectors/issues/780

**Workflow steps:**

Capture from a table with `infinity` or `-infinity` and it will work without a schema violation.

**Documentation links affected:**

N/A

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/781)
<!-- Reviewable:end -->
