### PR TITLE
source-sqlserver: Encode UUID row keys for correct sorting

### DIFF
--- a/source-sqlserver/.snapshots/TestScanKeyTypes-UniqueIdentifier
+++ b/source-sqlserver/.snapshots/TestScanKeyTypes-UniqueIdentifier
@@ -1,0 +1,218 @@
+####################################
+### Capture from Start
+####################################
+# ================================
+# Collection "acmeCo/test/test_scankeytypes_uniqueidentifier_889298060002": 1 Documents
+# ================================
+{"_meta":{"op":"c","source":{"schema":"dbo","snapshot":true,"table":"test_ScanKeyTypes_UniqueIdentifier_889298060002","lsn":"","seqval":"AAAAAAAAAAAAAA=="}},"k":"ffffffff-ffff-ffff-ffff-00ffffffffff","v":"Data 10"}
+# ================================
+# Final State Checkpoint
+# ================================
+{"cursor":"AAAAAAAAAAAAAA==","streams":{"dbo.test_scankeytypes_uniqueidentifier_889298060002":{"backfilled":1,"key_columns":["k"],"mode":"Backfill","scanned":"BQJ1dWlkAAEA/////////////////////wAA"}}}
+
+
+####################################
+### Capture from Key "BQJ1dWlkAAEA/////////////////////wAA"
+####################################
+# ================================
+# Collection "acmeCo/test/test_scankeytypes_uniqueidentifier_889298060002": 1 Documents
+# ================================
+{"_meta":{"op":"c","source":{"schema":"dbo","snapshot":true,"table":"test_ScanKeyTypes_UniqueIdentifier_889298060002","lsn":"","seqval":"AAAAAAAAAAAAAA=="}},"k":"ffffffff-ffff-ffff-ffff-ff00ffffffff","v":"Data 11"}
+# ================================
+# Final State Checkpoint
+# ================================
+{"cursor":"AAAAAAAAAAAAAA==","streams":{"dbo.test_scankeytypes_uniqueidentifier_889298060002":{"backfilled":2,"key_columns":["k"],"mode":"Backfill","scanned":"BQJ1dWlkAAH/AP///////////////////wAA"}}}
+
+
+####################################
+### Capture from Key "BQJ1dWlkAAH/AP///////////////////wAA"
+####################################
+# ================================
+# Collection "acmeCo/test/test_scankeytypes_uniqueidentifier_889298060002": 1 Documents
+# ================================
+{"_meta":{"op":"c","source":{"schema":"dbo","snapshot":true,"table":"test_ScanKeyTypes_UniqueIdentifier_889298060002","lsn":"","seqval":"AAAAAAAAAAAAAA=="}},"k":"ffffffff-ffff-ffff-ffff-ffff00ffffff","v":"Data 12"}
+# ================================
+# Final State Checkpoint
+# ================================
+{"cursor":"AAAAAAAAAAAAAA==","streams":{"dbo.test_scankeytypes_uniqueidentifier_889298060002":{"backfilled":3,"key_columns":["k"],"mode":"Backfill","scanned":"BQJ1dWlkAAH//wD//////////////////wAA"}}}
+
+
+####################################
+### Capture from Key "BQJ1dWlkAAH//wD//////////////////wAA"
+####################################
+# ================================
+# Collection "acmeCo/test/test_scankeytypes_uniqueidentifier_889298060002": 1 Documents
+# ================================
+{"_meta":{"op":"c","source":{"schema":"dbo","snapshot":true,"table":"test_ScanKeyTypes_UniqueIdentifier_889298060002","lsn":"","seqval":"AAAAAAAAAAAAAA=="}},"k":"ffffffff-ffff-ffff-ffff-ffffff00ffff","v":"Data 13"}
+# ================================
+# Final State Checkpoint
+# ================================
+{"cursor":"AAAAAAAAAAAAAA==","streams":{"dbo.test_scankeytypes_uniqueidentifier_889298060002":{"backfilled":4,"key_columns":["k"],"mode":"Backfill","scanned":"BQJ1dWlkAAH///8A/////////////////wAA"}}}
+
+
+####################################
+### Capture from Key "BQJ1dWlkAAH///8A/////////////////wAA"
+####################################
+# ================================
+# Collection "acmeCo/test/test_scankeytypes_uniqueidentifier_889298060002": 1 Documents
+# ================================
+{"_meta":{"op":"c","source":{"schema":"dbo","snapshot":true,"table":"test_ScanKeyTypes_UniqueIdentifier_889298060002","lsn":"","seqval":"AAAAAAAAAAAAAA=="}},"k":"ffffffff-ffff-ffff-ffff-ffffffff00ff","v":"Data 14"}
+# ================================
+# Final State Checkpoint
+# ================================
+{"cursor":"AAAAAAAAAAAAAA==","streams":{"dbo.test_scankeytypes_uniqueidentifier_889298060002":{"backfilled":5,"key_columns":["k"],"mode":"Backfill","scanned":"BQJ1dWlkAAH/////AP///////////////wAA"}}}
+
+
+####################################
+### Capture from Key "BQJ1dWlkAAH/////AP///////////////wAA"
+####################################
+# ================================
+# Collection "acmeCo/test/test_scankeytypes_uniqueidentifier_889298060002": 1 Documents
+# ================================
+{"_meta":{"op":"c","source":{"schema":"dbo","snapshot":true,"table":"test_ScanKeyTypes_UniqueIdentifier_889298060002","lsn":"","seqval":"AAAAAAAAAAAAAA=="}},"k":"ffffffff-ffff-ffff-ffff-ffffffffff00","v":"Data 15"}
+# ================================
+# Final State Checkpoint
+# ================================
+{"cursor":"AAAAAAAAAAAAAA==","streams":{"dbo.test_scankeytypes_uniqueidentifier_889298060002":{"backfilled":6,"key_columns":["k"],"mode":"Backfill","scanned":"BQJ1dWlkAAH//////wD//////////////wAA"}}}
+
+
+####################################
+### Capture from Key "BQJ1dWlkAAH//////wD//////////////wAA"
+####################################
+# ================================
+# Collection "acmeCo/test/test_scankeytypes_uniqueidentifier_889298060002": 1 Documents
+# ================================
+{"_meta":{"op":"c","source":{"schema":"dbo","snapshot":true,"table":"test_ScanKeyTypes_UniqueIdentifier_889298060002","lsn":"","seqval":"AAAAAAAAAAAAAA=="}},"k":"ffffffff-ffff-ffff-00ff-ffffffffffff","v":"Data 8"}
+# ================================
+# Final State Checkpoint
+# ================================
+{"cursor":"AAAAAAAAAAAAAA==","streams":{"dbo.test_scankeytypes_uniqueidentifier_889298060002":{"backfilled":7,"key_columns":["k"],"mode":"Backfill","scanned":"BQJ1dWlkAAH///////8A/////////////wAA"}}}
+
+
+####################################
+### Capture from Key "BQJ1dWlkAAH///////8A/////////////wAA"
+####################################
+# ================================
+# Collection "acmeCo/test/test_scankeytypes_uniqueidentifier_889298060002": 1 Documents
+# ================================
+{"_meta":{"op":"c","source":{"schema":"dbo","snapshot":true,"table":"test_ScanKeyTypes_UniqueIdentifier_889298060002","lsn":"","seqval":"AAAAAAAAAAAAAA=="}},"k":"ffffffff-ffff-ffff-ff00-ffffffffffff","v":"Data 9"}
+# ================================
+# Final State Checkpoint
+# ================================
+{"cursor":"AAAAAAAAAAAAAA==","streams":{"dbo.test_scankeytypes_uniqueidentifier_889298060002":{"backfilled":8,"key_columns":["k"],"mode":"Backfill","scanned":"BQJ1dWlkAAH/////////AP///////////wAA"}}}
+
+
+####################################
+### Capture from Key "BQJ1dWlkAAH/////////AP///////////wAA"
+####################################
+# ================================
+# Collection "acmeCo/test/test_scankeytypes_uniqueidentifier_889298060002": 1 Documents
+# ================================
+{"_meta":{"op":"c","source":{"schema":"dbo","snapshot":true,"table":"test_ScanKeyTypes_UniqueIdentifier_889298060002","lsn":"","seqval":"AAAAAAAAAAAAAA=="}},"k":"ffffffff-ffff-ff00-ffff-ffffffffffff","v":"Data 7"}
+# ================================
+# Final State Checkpoint
+# ================================
+{"cursor":"AAAAAAAAAAAAAA==","streams":{"dbo.test_scankeytypes_uniqueidentifier_889298060002":{"backfilled":9,"key_columns":["k"],"mode":"Backfill","scanned":"BQJ1dWlkAAH//////////wD//////////wAA"}}}
+
+
+####################################
+### Capture from Key "BQJ1dWlkAAH//////////wD//////////wAA"
+####################################
+# ================================
+# Collection "acmeCo/test/test_scankeytypes_uniqueidentifier_889298060002": 1 Documents
+# ================================
+{"_meta":{"op":"c","source":{"schema":"dbo","snapshot":true,"table":"test_ScanKeyTypes_UniqueIdentifier_889298060002","lsn":"","seqval":"AAAAAAAAAAAAAA=="}},"k":"ffffffff-ffff-00ff-ffff-ffffffffffff","v":"Data 6"}
+# ================================
+# Final State Checkpoint
+# ================================
+{"cursor":"AAAAAAAAAAAAAA==","streams":{"dbo.test_scankeytypes_uniqueidentifier_889298060002":{"backfilled":10,"key_columns":["k"],"mode":"Backfill","scanned":"BQJ1dWlkAAH///////////8A/////////wAA"}}}
+
+
+####################################
+### Capture from Key "BQJ1dWlkAAH///////////8A/////////wAA"
+####################################
+# ================================
+# Collection "acmeCo/test/test_scankeytypes_uniqueidentifier_889298060002": 1 Documents
+# ================================
+{"_meta":{"op":"c","source":{"schema":"dbo","snapshot":true,"table":"test_ScanKeyTypes_UniqueIdentifier_889298060002","lsn":"","seqval":"AAAAAAAAAAAAAA=="}},"k":"ffffffff-ff00-ffff-ffff-ffffffffffff","v":"Data 5"}
+# ================================
+# Final State Checkpoint
+# ================================
+{"cursor":"AAAAAAAAAAAAAA==","streams":{"dbo.test_scankeytypes_uniqueidentifier_889298060002":{"backfilled":11,"key_columns":["k"],"mode":"Backfill","scanned":"BQJ1dWlkAAH/////////////AP///////wAA"}}}
+
+
+####################################
+### Capture from Key "BQJ1dWlkAAH/////////////AP///////wAA"
+####################################
+# ================================
+# Collection "acmeCo/test/test_scankeytypes_uniqueidentifier_889298060002": 1 Documents
+# ================================
+{"_meta":{"op":"c","source":{"schema":"dbo","snapshot":true,"table":"test_ScanKeyTypes_UniqueIdentifier_889298060002","lsn":"","seqval":"AAAAAAAAAAAAAA=="}},"k":"ffffffff-00ff-ffff-ffff-ffffffffffff","v":"Data 4"}
+# ================================
+# Final State Checkpoint
+# ================================
+{"cursor":"AAAAAAAAAAAAAA==","streams":{"dbo.test_scankeytypes_uniqueidentifier_889298060002":{"backfilled":12,"key_columns":["k"],"mode":"Backfill","scanned":"BQJ1dWlkAAH//////////////wD//////wAA"}}}
+
+
+####################################
+### Capture from Key "BQJ1dWlkAAH//////////////wD//////wAA"
+####################################
+# ================================
+# Collection "acmeCo/test/test_scankeytypes_uniqueidentifier_889298060002": 1 Documents
+# ================================
+{"_meta":{"op":"c","source":{"schema":"dbo","snapshot":true,"table":"test_ScanKeyTypes_UniqueIdentifier_889298060002","lsn":"","seqval":"AAAAAAAAAAAAAA=="}},"k":"ffffff00-ffff-ffff-ffff-ffffffffffff","v":"Data 3"}
+# ================================
+# Final State Checkpoint
+# ================================
+{"cursor":"AAAAAAAAAAAAAA==","streams":{"dbo.test_scankeytypes_uniqueidentifier_889298060002":{"backfilled":13,"key_columns":["k"],"mode":"Backfill","scanned":"BQJ1dWlkAAH///////////////8A/////wAA"}}}
+
+
+####################################
+### Capture from Key "BQJ1dWlkAAH///////////////8A/////wAA"
+####################################
+# ================================
+# Collection "acmeCo/test/test_scankeytypes_uniqueidentifier_889298060002": 1 Documents
+# ================================
+{"_meta":{"op":"c","source":{"schema":"dbo","snapshot":true,"table":"test_ScanKeyTypes_UniqueIdentifier_889298060002","lsn":"","seqval":"AAAAAAAAAAAAAA=="}},"k":"ffff00ff-ffff-ffff-ffff-ffffffffffff","v":"Data 2"}
+# ================================
+# Final State Checkpoint
+# ================================
+{"cursor":"AAAAAAAAAAAAAA==","streams":{"dbo.test_scankeytypes_uniqueidentifier_889298060002":{"backfilled":14,"key_columns":["k"],"mode":"Backfill","scanned":"BQJ1dWlkAAH/////////////////AP///wAA"}}}
+
+
+####################################
+### Capture from Key "BQJ1dWlkAAH/////////////////AP///wAA"
+####################################
+# ================================
+# Collection "acmeCo/test/test_scankeytypes_uniqueidentifier_889298060002": 1 Documents
+# ================================
+{"_meta":{"op":"c","source":{"schema":"dbo","snapshot":true,"table":"test_ScanKeyTypes_UniqueIdentifier_889298060002","lsn":"","seqval":"AAAAAAAAAAAAAA=="}},"k":"ff00ffff-ffff-ffff-ffff-ffffffffffff","v":"Data 1"}
+# ================================
+# Final State Checkpoint
+# ================================
+{"cursor":"AAAAAAAAAAAAAA==","streams":{"dbo.test_scankeytypes_uniqueidentifier_889298060002":{"backfilled":15,"key_columns":["k"],"mode":"Backfill","scanned":"BQJ1dWlkAAH//////////////////wD//wAA"}}}
+
+
+####################################
+### Capture from Key "BQJ1dWlkAAH//////////////////wD//wAA"
+####################################
+# ================================
+# Collection "acmeCo/test/test_scankeytypes_uniqueidentifier_889298060002": 1 Documents
+# ================================
+{"_meta":{"op":"c","source":{"schema":"dbo","snapshot":true,"table":"test_ScanKeyTypes_UniqueIdentifier_889298060002","lsn":"","seqval":"AAAAAAAAAAAAAA=="}},"k":"00ffffff-ffff-ffff-ffff-ffffffffffff","v":"Data 0"}
+# ================================
+# Final State Checkpoint
+# ================================
+{"cursor":"AAAAAAAAAAAAAA==","streams":{"dbo.test_scankeytypes_uniqueidentifier_889298060002":{"backfilled":16,"key_columns":["k"],"mode":"Backfill","scanned":"BQJ1dWlkAAH///////////////////8A/wAA"}}}
+
+
+####################################
+### Capture from Key "BQJ1dWlkAAH///////////////////8A/wAA"
+####################################
+# ================================
+# Final State Checkpoint
+# ================================
+{"cursor":"AAAAAAAAAAAAAA==","streams":{"dbo.test_scankeytypes_uniqueidentifier_889298060002":{"backfilled":16,"key_columns":["k"],"mode":"Active"}}}
+
+
+

--- a/source-sqlserver/.snapshots/TestUUIDCaptureOrder
+++ b/source-sqlserver/.snapshots/TestUUIDCaptureOrder
@@ -1,0 +1,24 @@
+# ================================
+# Collection "acmeCo/test/test_uuidcaptureorder_1794630882": 16 Documents
+# ================================
+{"_meta":{"op":"c","source":{"schema":"dbo","snapshot":true,"table":"test_UUIDCaptureOrder_1794630882","lsn":"","seqval":"AAAAAAAAAAAAAA=="}},"data":"one","id":"ffffffff-ffff-ffff-ffff-00ffffffffff"}
+{"_meta":{"op":"c","source":{"schema":"dbo","snapshot":true,"table":"test_UUIDCaptureOrder_1794630882","lsn":"","seqval":"AAAAAAAAAAAAAA=="}},"data":"two","id":"ffffffff-ffff-ffff-ffff-ff00ffffffff"}
+{"_meta":{"op":"c","source":{"schema":"dbo","snapshot":true,"table":"test_UUIDCaptureOrder_1794630882","lsn":"","seqval":"AAAAAAAAAAAAAA=="}},"data":"three","id":"ffffffff-ffff-ffff-ffff-ffff00ffffff"}
+{"_meta":{"op":"c","source":{"schema":"dbo","snapshot":true,"table":"test_UUIDCaptureOrder_1794630882","lsn":"","seqval":"AAAAAAAAAAAAAA=="}},"data":"four","id":"ffffffff-ffff-ffff-ffff-ffffff00ffff"}
+{"_meta":{"op":"c","source":{"schema":"dbo","snapshot":true,"table":"test_UUIDCaptureOrder_1794630882","lsn":"","seqval":"AAAAAAAAAAAAAA=="}},"data":"five","id":"ffffffff-ffff-ffff-ffff-ffffffff00ff"}
+{"_meta":{"op":"c","source":{"schema":"dbo","snapshot":true,"table":"test_UUIDCaptureOrder_1794630882","lsn":"","seqval":"AAAAAAAAAAAAAA=="}},"data":"six","id":"ffffffff-ffff-ffff-ffff-ffffffffff00"}
+{"_meta":{"op":"c","source":{"schema":"dbo","snapshot":true,"table":"test_UUIDCaptureOrder_1794630882","lsn":"","seqval":"AAAAAAAAAAAAAA=="}},"data":"seven","id":"ffffffff-ffff-ffff-00ff-ffffffffffff"}
+{"_meta":{"op":"c","source":{"schema":"dbo","snapshot":true,"table":"test_UUIDCaptureOrder_1794630882","lsn":"","seqval":"AAAAAAAAAAAAAA=="}},"data":"eight","id":"ffffffff-ffff-ffff-ff00-ffffffffffff"}
+{"_meta":{"op":"c","source":{"schema":"dbo","snapshot":true,"table":"test_UUIDCaptureOrder_1794630882","lsn":"","seqval":"AAAAAAAAAAAAAA=="}},"data":"nine","id":"ffffffff-ffff-ff00-ffff-ffffffffffff"}
+{"_meta":{"op":"c","source":{"schema":"dbo","snapshot":true,"table":"test_UUIDCaptureOrder_1794630882","lsn":"","seqval":"AAAAAAAAAAAAAA=="}},"data":"ten","id":"ffffffff-ffff-00ff-ffff-ffffffffffff"}
+{"_meta":{"op":"c","source":{"schema":"dbo","snapshot":true,"table":"test_UUIDCaptureOrder_1794630882","lsn":"","seqval":"AAAAAAAAAAAAAA=="}},"data":"eleven","id":"ffffffff-ff00-ffff-ffff-ffffffffffff"}
+{"_meta":{"op":"c","source":{"schema":"dbo","snapshot":true,"table":"test_UUIDCaptureOrder_1794630882","lsn":"","seqval":"AAAAAAAAAAAAAA=="}},"data":"twelve","id":"ffffffff-00ff-ffff-ffff-ffffffffffff"}
+{"_meta":{"op":"c","source":{"schema":"dbo","snapshot":true,"table":"test_UUIDCaptureOrder_1794630882","lsn":"","seqval":"AAAAAAAAAAAAAA=="}},"data":"thirteen","id":"ffffff00-ffff-ffff-ffff-ffffffffffff"}
+{"_meta":{"op":"c","source":{"schema":"dbo","snapshot":true,"table":"test_UUIDCaptureOrder_1794630882","lsn":"","seqval":"AAAAAAAAAAAAAA=="}},"data":"fourteen","id":"ffff00ff-ffff-ffff-ffff-ffffffffffff"}
+{"_meta":{"op":"c","source":{"schema":"dbo","snapshot":true,"table":"test_UUIDCaptureOrder_1794630882","lsn":"","seqval":"AAAAAAAAAAAAAA=="}},"data":"fifteen","id":"ff00ffff-ffff-ffff-ffff-ffffffffffff"}
+{"_meta":{"op":"c","source":{"schema":"dbo","snapshot":true,"table":"test_UUIDCaptureOrder_1794630882","lsn":"","seqval":"AAAAAAAAAAAAAA=="}},"data":"sixteen","id":"00ffffff-ffff-ffff-ffff-ffffffffffff"}
+# ================================
+# Final State Checkpoint
+# ================================
+{"cursor":"AAAAAAAAAAAAAA==","streams":{"dbo.test_uuidcaptureorder_1794630882":{"backfilled":16,"key_columns":["id"],"mode":"Active"}}}
+

--- a/source-sqlserver/datatypes.go
+++ b/source-sqlserver/datatypes.go
@@ -9,22 +9,60 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-// The standard library `time.RFC3339Nano` is wrong for historical reasons, this
-// format string is better because it always uses 9-digit fractional seconds, and
-// thus it can be sorted lexicographically as bytes.
-const sortableRFC3339Nano = "2006-01-02T15:04:05.000000000Z07:00"
+const (
+	// The standard library `time.RFC3339Nano` is wrong for historical reasons, this
+	// format string is better because it always uses 9-digit fractional seconds, and
+	// thus it can be sorted lexicographically as bytes.
+	sortableRFC3339Nano = "2006-01-02T15:04:05.000000000Z07:00"
+
+	// SQL Server sort ordering for `uniqueidentifier` columns is absolutely insane,
+	// so we have to reshuffle the underlying bytes pretty hard to produce a row key
+	// whose bytewise lexicographic ordering matches SQL Server sorting rules.
+	uniqueIdentifierTag = "uuid"
+)
 
 func encodeKeyFDB(key, ktype interface{}) (tuple.TupleElement, error) {
 	switch key := key.(type) {
 	case time.Time:
 		return key.Format(sortableRFC3339Nano), nil
-	default:
-		return key, nil
+	case []byte:
+		switch ktype {
+		case "uniqueidentifier":
+			// SQL Server sorts `uniqueidentifier` columns in a bizarre order, but
+			// by shuffling the bytes here and reversing it when decoding we can get
+			// the serialized form to sort lexicographically. See TestUUIDCaptureOrder
+			// for the test that ensures the encoding works correctly.
+			var enc = make([]byte, 16)
+			copy(enc[0:6], key[10:16])
+			copy(enc[6:8], key[8:10])
+			copy(enc[8:10], key[6:8])
+			copy(enc[10:12], key[4:6])
+			copy(enc[12:16], key[0:4])
+			return tuple.Tuple{uniqueIdentifierTag, enc}, nil
+		}
 	}
+	return key, nil
 }
 
 func decodeKeyFDB(t tuple.TupleElement) (interface{}, error) {
 	switch t := t.(type) {
+	case tuple.Tuple:
+		if len(t) == 0 {
+			return nil, fmt.Errorf("internal error: malformed row key contains empty tuple")
+		}
+		switch t[0] {
+		case uniqueIdentifierTag:
+			// Reverse the shuffling done by encodeKeyFDB
+			var enc, key = t[1].([]byte), make([]byte, 16)
+			copy(key[10:16], enc[0:6])
+			copy(key[8:10], enc[6:8])
+			copy(key[6:8], enc[8:10])
+			copy(key[4:6], enc[10:12])
+			copy(key[0:4], enc[12:16])
+			return key, nil
+		default:
+			return nil, fmt.Errorf("internal error: unknown tuple tag %q", t[0])
+		}
 	default:
 		return t, nil
 	}
@@ -60,7 +98,8 @@ func (db *sqlserverDatabase) translateRecordField(columnType interface{}, val in
 		case "uniqueidentifier":
 			// Words cannot describe how much this infuriates me. Byte-swap
 			// the first eight bytes of the UUID so that values will actually
-			// round-trip correctly.
+			// round-trip correctly from the '00112233-4455-6677-8899-AABBCCDDEEFF'
+			// textual input format to UUIDs serialized as JSON.
 			val[0], val[1], val[2], val[3] = val[3], val[2], val[1], val[0]
 			val[4], val[5] = val[5], val[4]
 			val[6], val[7] = val[7], val[6]

--- a/source-sqlserver/datatypes_test.go
+++ b/source-sqlserver/datatypes_test.go
@@ -69,6 +69,24 @@ func TestScanKeyTypes(t *testing.T) {
 	}{
 		{"Integer", "INTEGER", []any{0, -3, 2, 1723}},
 		{"DateTimeOffset", "DATETIMEOFFSET", []any{"1991-08-31T12:34:54.125-06:00", "1991-08-31T12:34:54.126-06:00", "2000-01-01T01:01:01Z"}},
+		{"UniqueIdentifier", "UNIQUEIDENTIFIER", []any{
+			"00ffffff-ffff-ffff-ffff-ffffffffffff",
+			"ff00ffff-ffff-ffff-ffff-ffffffffffff",
+			"ffff00ff-ffff-ffff-ffff-ffffffffffff",
+			"ffffff00-ffff-ffff-ffff-ffffffffffff",
+			"ffffffff-00ff-ffff-ffff-ffffffffffff",
+			"ffffffff-ff00-ffff-ffff-ffffffffffff",
+			"ffffffff-ffff-00ff-ffff-ffffffffffff",
+			"ffffffff-ffff-ff00-ffff-ffffffffffff",
+			"ffffffff-ffff-ffff-00ff-ffffffffffff",
+			"ffffffff-ffff-ffff-ff00-ffffffffffff",
+			"ffffffff-ffff-ffff-ffff-00ffffffffff",
+			"ffffffff-ffff-ffff-ffff-ff00ffffffff",
+			"ffffffff-ffff-ffff-ffff-ffff00ffffff",
+			"ffffffff-ffff-ffff-ffff-ffffff00ffff",
+			"ffffffff-ffff-ffff-ffff-ffffffff00ff",
+			"ffffffff-ffff-ffff-ffff-ffffffffff00",
+		}},
 	} {
 		t.Run(tc.Name, func(t *testing.T) {
 			var uniqueID = fmt.Sprintf("88929806%04d", idx)


### PR DESCRIPTION
**Description:**

The way that SQL Server orders `uniqueidentifier` columns is completely insane (see also: https://devblogs.microsoft.com/oldnewthing/20190426-00/?p=102450). But by adding some logic to reorder the byte representation we can produce a serialized form that sorts lexicographically, and then invert that shuffle when decoding the key for the next backfill query.

Note that this shuffling is _different_ from what we do to serialize them as JSON UUIDs, because the way in which SQL Server screws up comparisons ordering is _entirely different_ from how we already knew that it screws up endianness between a human-readable `"00112233-4455-6677-8899-AABBCCDDEEFF"` input and the resulting partially-endian-swapped `33 22 11 00 55 44 77 66 88 99 AA BB CC DD EE FF` bytes we get back later on.

**Workflow steps:**

Capturing tables keyed by `uniqueidentifier` might actually work now.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/785)
<!-- Reviewable:end -->
