### PR TITLE
materialize-pinecone: build input from selected fields

### DIFF
--- a/materialize-pinecone/.snapshots/TestSpecification
+++ b/materialize-pinecone/.snapshots/TestSpecification
@@ -68,12 +68,6 @@
         "title": "Pinecone Namespace",
         "description": "Name of the Pinecone namespace that this collection will materialize vectors into.",
         "x-collection-name": true
-      },
-      "inputProjection": {
-        "type": "string",
-        "title": "Input Projection Name",
-        "description": "Alternate name of the collection projection to use as input for creating the vector embedding. Defaults to 'input'.",
-        "default": "input"
       }
     },
     "type": "object",

--- a/materialize-pinecone/client/client.go
+++ b/materialize-pinecone/client/client.go
@@ -156,6 +156,14 @@ type PineconeIndexResponse struct {
 	IndexFullness float64                `json:"index_fullness"`
 }
 
+type PineconeIndexDescribeResponse struct {
+	Database struct {
+		MetadataConfig struct {
+			Indexed []string `json:"indexed"`
+		} `json:"metadata_config"`
+	} `json:"database"`
+}
+
 type whoamiResponse struct {
 	ProjectName string `json:"project_name"`
 }

--- a/materialize-pinecone/driver.go
+++ b/materialize-pinecone/driver.go
@@ -211,8 +211,8 @@ func (d driver) Validate(ctx context.Context, req *pm.Request_Validate) (*pm.Res
 				constraint.Type = pm.Response_Validated_Constraint_LOCATION_REQUIRED
 				constraint.Reason = "The root document must be materialized"
 			default:
-				constraint.Type = pm.Response_Validated_Constraint_FIELD_FORBIDDEN
-				constraint.Reason = "Cannot materialize this field"
+				constraint.Type = pm.Response_Validated_Constraint_FIELD_OPTIONAL
+				constraint.Reason = "This field can be materializaed"
 			}
 			constraints[projection.Field] = constraint
 		}

--- a/tests/materialize/materialize-pinecone/setup.sh
+++ b/tests/materialize/materialize-pinecone/setup.sh
@@ -19,22 +19,19 @@ config_json_template='{
 resources_json_template='[
   {
     "resource": {
-      "namespace":        "simple",
-      "inputProjection":  "canary"
+      "namespace": "simple"
     },
     "source": "${TEST_COLLECTION_SIMPLE}"
   },
   {
     "resource": {
-      "namespace":        "duplicated-keys",
-      "inputProjection":  "str"
+      "namespace": "duplicated-keys"
     },
     "source": "${TEST_COLLECTION_DUPLICATED_KEYS}"
   },
   {
     "resource": {
-      "namespace":        "multiple-types",
-      "inputProjection":  "str_field"
+      "namespace": "multiple-types"
     },
     "source": "${TEST_COLLECTION_MULTIPLE_DATATYPES}"
   }

--- a/tests/materialize/materialize-pinecone/snapshot.json
+++ b/tests/materialize/materialize-pinecone/snapshot.json
@@ -30,8 +30,7 @@
     {
       "id": "FQE",
       "metadata": {
-        "canary": "amputation's",
-        "id": 1
+        "flow_document": "{\"canary\":\"amputation's\",\"id\":1}"
       },
       "score": 0,
       "values": "<VECTOR>"
@@ -39,8 +38,7 @@
     {
       "id": "FQI",
       "metadata": {
-        "canary": "armament's",
-        "id": 2
+        "flow_document": "{\"canary\":\"armament's\",\"id\":2}"
       },
       "score": 0,
       "values": "<VECTOR>"
@@ -48,8 +46,7 @@
     {
       "id": "FQM",
       "metadata": {
-        "canary": "splatters",
-        "id": 3
+        "flow_document": "{\"canary\":\"splatters\",\"id\":3}"
       },
       "score": 0,
       "values": "<VECTOR>"
@@ -57,8 +54,7 @@
     {
       "id": "FQQ",
       "metadata": {
-        "canary": "strengthen",
-        "id": 4
+        "flow_document": "{\"canary\":\"strengthen\",\"id\":4}"
       },
       "score": 0,
       "values": "<VECTOR>"
@@ -66,8 +62,7 @@
     {
       "id": "FQU",
       "metadata": {
-        "canary": "Kringle's",
-        "id": 5
+        "flow_document": "{\"canary\":\"Kringle's\",\"id\":5}"
       },
       "score": 0,
       "values": "<VECTOR>"
@@ -75,8 +70,7 @@
     {
       "id": "FQY",
       "metadata": {
-        "canary": "grosbeak's",
-        "id": 6
+        "flow_document": "{\"canary\":\"grosbeak's\",\"id\":6}"
       },
       "score": 0,
       "values": "<VECTOR>"
@@ -84,8 +78,7 @@
     {
       "id": "FQc",
       "metadata": {
-        "canary": "pieced",
-        "id": 7
+        "flow_document": "{\"canary\":\"pieced\",\"id\":7}"
       },
       "score": 0,
       "values": "<VECTOR>"
@@ -93,8 +86,7 @@
     {
       "id": "FQg",
       "metadata": {
-        "canary": "roaches",
-        "id": 8
+        "flow_document": "{\"canary\":\"roaches\",\"id\":8}"
       },
       "score": 0,
       "values": "<VECTOR>"
@@ -102,8 +94,7 @@
     {
       "id": "FQk",
       "metadata": {
-        "canary": "devilish",
-        "id": 9
+        "flow_document": "{\"canary\":\"devilish\",\"id\":9}"
       },
       "score": 0,
       "values": "<VECTOR>"
@@ -111,8 +102,7 @@
     {
       "id": "FQo",
       "metadata": {
-        "canary": "glucose's",
-        "id": 10
+        "flow_document": "{\"canary\":\"glucose's\",\"id\":10}"
       },
       "score": 0,
       "values": "<VECTOR>"
@@ -126,9 +116,7 @@
     {
       "id": "FQE",
       "metadata": {
-        "id": 1,
-        "int": 6,
-        "str": "str 6"
+        "flow_document": "{\"id\":1,\"int\":6,\"str\":\"str 6\"}"
       },
       "score": 0,
       "values": "<VECTOR>"
@@ -136,9 +124,7 @@
     {
       "id": "FQI",
       "metadata": {
-        "id": 2,
-        "int": 7,
-        "str": "str 7"
+        "flow_document": "{\"id\":2,\"int\":7,\"str\":\"str 7\"}"
       },
       "score": 0,
       "values": "<VECTOR>"
@@ -146,9 +132,7 @@
     {
       "id": "FQM",
       "metadata": {
-        "id": 3,
-        "int": 8,
-        "str": "str 8"
+        "flow_document": "{\"id\":3,\"int\":8,\"str\":\"str 8\"}"
       },
       "score": 0,
       "values": "<VECTOR>"
@@ -156,9 +140,7 @@
     {
       "id": "FQQ",
       "metadata": {
-        "id": 4,
-        "int": 9,
-        "str": "str 9"
+        "flow_document": "{\"id\":4,\"int\":9,\"str\":\"str 9\"}"
       },
       "score": 0,
       "values": "<VECTOR>"
@@ -166,9 +148,7 @@
     {
       "id": "FQU",
       "metadata": {
-        "id": 5,
-        "int": 10,
-        "str": "str 10"
+        "flow_document": "{\"id\":5,\"int\":10,\"str\":\"str 10\"}"
       },
       "score": 0,
       "values": "<VECTOR>"
@@ -182,11 +162,7 @@
     {
       "id": "FQE",
       "metadata": {
-        "bool_field": false,
-        "float_field": 1.1,
-        "id": 1,
-        "nested/id": "i1",
-        "str_field": "str1"
+        "flow_document": "{\"array_int\":[11,12],\"bool_field\":false,\"float_field\":1.1,\"id\":1,\"nested\":{\"id\":\"i1\"},\"nullable_int\":null,\"str_field\":\"str1\"}"
       },
       "score": 0,
       "values": "<VECTOR>"
@@ -194,12 +170,7 @@
     {
       "id": "FQI",
       "metadata": {
-        "bool_field": true,
-        "float_field": 2.2,
-        "id": 2,
-        "nested/id": "i2",
-        "nullable_int": 2,
-        "str_field": "str2"
+        "flow_document": "{\"array_int\":[21,22],\"bool_field\":true,\"float_field\":2.2,\"id\":2,\"nested\":{\"id\":\"i2\"},\"nullable_int\":2,\"str_field\":\"str2\"}"
       },
       "score": 0,
       "values": "<VECTOR>"
@@ -207,11 +178,7 @@
     {
       "id": "FQM",
       "metadata": {
-        "bool_field": false,
-        "float_field": 3.3,
-        "id": 3,
-        "nested/id": "i3",
-        "str_field": "str3"
+        "flow_document": "{\"array_int\":[31,32],\"bool_field\":false,\"float_field\":3.3,\"id\":3,\"nested\":{\"id\":\"i3\"},\"nullable_int\":null,\"str_field\":\"str3\"}"
       },
       "score": 0,
       "values": "<VECTOR>"
@@ -219,12 +186,7 @@
     {
       "id": "FQQ",
       "metadata": {
-        "bool_field": true,
-        "float_field": 4.4,
-        "id": 4,
-        "nested/id": "i4",
-        "nullable_int": 4,
-        "str_field": "str4"
+        "flow_document": "{\"array_int\":[41,42],\"bool_field\":true,\"float_field\":4.4,\"id\":4,\"nested\":{\"id\":\"i4\"},\"nullable_int\":4,\"str_field\":\"str4\"}"
       },
       "score": 0,
       "values": "<VECTOR>"
@@ -232,11 +194,7 @@
     {
       "id": "FQU",
       "metadata": {
-        "bool_field": false,
-        "float_field": 5.5,
-        "id": 5,
-        "nested/id": "i5",
-        "str_field": "str5"
+        "flow_document": "{\"array_int\":[51,52],\"bool_field\":false,\"float_field\":5.5,\"id\":5,\"nested\":{\"id\":\"i5\"},\"nullable_int\":null,\"str_field\":\"str5\"}"
       },
       "score": 0,
       "values": "<VECTOR>"
@@ -244,12 +202,7 @@
     {
       "id": "FQY",
       "metadata": {
-        "bool_field": true,
-        "float_field": 66.66,
-        "id": 6,
-        "nested/id": "i6",
-        "nullable_int": 6,
-        "str_field": "str6 v2"
+        "flow_document": "{\"array_int\":[61,62],\"bool_field\":true,\"float_field\":66.66,\"id\":6,\"nested\":{\"id\":\"i6\"},\"nullable_int\":6,\"str_field\":\"str6 v2\"}"
       },
       "score": 0,
       "values": "<VECTOR>"
@@ -257,11 +210,7 @@
     {
       "id": "FQc",
       "metadata": {
-        "bool_field": false,
-        "float_field": 77.77,
-        "id": 7,
-        "nested/id": "i7",
-        "str_field": "str7 v2"
+        "flow_document": "{\"array_int\":[71,72],\"bool_field\":false,\"float_field\":77.77,\"id\":7,\"nested\":{\"id\":\"i7\"},\"nullable_int\":null,\"str_field\":\"str7 v2\"}"
       },
       "score": 0,
       "values": "<VECTOR>"
@@ -269,12 +218,7 @@
     {
       "id": "FQg",
       "metadata": {
-        "bool_field": true,
-        "float_field": 88.88,
-        "id": 8,
-        "nested/id": "i8",
-        "nullable_int": 8,
-        "str_field": "str8 v2"
+        "flow_document": "{\"array_int\":[81,82],\"bool_field\":true,\"float_field\":88.88,\"id\":8,\"nested\":{\"id\":\"i8\"},\"nullable_int\":8,\"str_field\":\"str8 v2\"}"
       },
       "score": 0,
       "values": "<VECTOR>"
@@ -282,11 +226,7 @@
     {
       "id": "FQk",
       "metadata": {
-        "bool_field": false,
-        "float_field": 99.99,
-        "id": 9,
-        "nested/id": "i9",
-        "str_field": "str9 v2"
+        "flow_document": "{\"array_int\":[91,92],\"bool_field\":false,\"float_field\":99.99,\"id\":9,\"nested\":{\"id\":\"i9\"},\"nullable_int\":null,\"str_field\":\"str9 v2\"}"
       },
       "score": 0,
       "values": "<VECTOR>"
@@ -294,12 +234,7 @@
     {
       "id": "FQo",
       "metadata": {
-        "bool_field": true,
-        "float_field": 1010.101,
-        "id": 10,
-        "nested/id": "i10",
-        "nullable_int": 10,
-        "str_field": "str10 v2"
+        "flow_document": "{\"array_int\":[1,2],\"bool_field\":true,\"float_field\":1010.101,\"id\":10,\"nested\":{\"id\":\"i10\"},\"nullable_int\":10,\"str_field\":\"str10 v2\"}"
       },
       "score": 0,
       "values": "<VECTOR>"


### PR DESCRIPTION
**Description:**

We previously required a single string field as input for the embedding with the idea that it may
already exist in a collection, or be produced by a derivation.

This changes the connector to build an input from the selected fields of the materialization. The
input is arranged as "key: value" pairs on newlines with the value being the stringified
JSON-encoded of the field value. Since only scalar types are permitted this results in a reasonable
representation of the input data.

The embedding input or any other fields are no longer included as metadata, and only flow_document
is included as metadata so that it may be obtained from the results of a vector query.

**Workflow steps:**

Materializing to pinecone without needing a field called `input`, or explicitly setting one. You can still use field selection to exclude fields if you want.

**Documentation links affected:**

The connector docs will need updated.

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/786)
<!-- Reviewable:end -->
