### PR TITLE
source-mysql: Ignore SAVEPOINT query events as benign

### DIFF
--- a/source-mysql/replication.go
+++ b/source-mysql/replication.go
@@ -445,6 +445,7 @@ func (rs *mysqlReplicationStream) handleQuery(schema, query string) error {
 	switch stmt := stmt.(type) {
 	case *sqlparser.CreateDatabase:
 	case *sqlparser.CreateTable:
+	case *sqlparser.Savepoint:
 		logrus.WithField("query", query).Trace("ignoring benign query")
 	case *sqlparser.AlterTable:
 		if streamID := resolveTableName(schema, stmt.Table); rs.tableActive(streamID) {


### PR DESCRIPTION
**Description:**

I'm unsure why/how `SAVEPOINT` would show up as a query event at all, but it's not inherently a problem. Now a `ROLLBACK` might be a bigger concern, but we'll deal with that if it comes up.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/787)
<!-- Reviewable:end -->
