### PR TITLE
materialize-sql: make `_meta/` fields optional instead of recommended

### DIFF
--- a/materialize-sql/validate.go
+++ b/materialize-sql/validate.go
@@ -101,6 +101,9 @@ func validateNewProjection(resource Resource, projection pf.Projection) *pm.Resp
 	case projection.IsRootDocumentProjection():
 		constraint.Type = pm.Response_Validated_Constraint_LOCATION_REQUIRED
 		constraint.Reason = "The root document must be materialized"
+	case strings.HasPrefix(projection.Field, "_meta/") && projection.Inference.IsSingleType():
+		constraint.Type = pm.Response_Validated_Constraint_FIELD_OPTIONAL
+		constraint.Reason = "Metadata fields fields are able to be materialized"
 	case projection.Inference.IsSingleScalarType() || flatType == INTEGER || flatType == NUMBER:
 		constraint.Type = pm.Response_Validated_Constraint_LOCATION_RECOMMENDED
 		constraint.Reason = "The projection has a single scalar type"


### PR DESCRIPTION
**Description:**

Captures often produce collections with various `_meta/` fields. We have received feedback that these are usually not desirable to materialize by default, so this PR changes them to be optional rather than recommended.

A couple of notes:
- Existing materializations that included these fields will not be affected, since locations that are part of an existing materialization spec are validated as [recommended](https://github.com/estuary/connectors/blob/7a4dc720eb292418c3ab3e319e0e85a86eea3ba4/materialize-sql/validate.go#L154-L157)
- Some captures use part of `_meta` for the collection key, like filesource captures. This change does not affect that either, since collection keys will still be validated as "required" preferentially.

I manually tested this by creating a new materialization from a collection produced by a postgres capture and it did not create `_meta` columns. I also tested an existing materialization from a postgres capture that did include `_meta` columns and made sure it still worked with this new image.

**Workflow steps:**

New SQL materializations will not create columns for scalar `_meta/...` fields unless they are explicitly included in the field selection. Ideally we'd have a better field selection experience since these fields may be desirable sometimes (like information about if a change event was a delete) but until then field selection can still be configured by editing the spec directly.

**Documentation links affected:**

N/A

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/792)
<!-- Reviewable:end -->
