### PR TITLE
materialize-pinecone: decode openai api response error messages

### DIFF
--- a/materialize-pinecone/client/client.go
+++ b/materialize-pinecone/client/client.go
@@ -87,7 +87,7 @@ func (c *OpenAiClient) CreateEmbeddings(ctx context.Context, input []string) ([]
 	}
 	defer res.Body.Close()
 
-	if res.StatusCode == http.StatusTooManyRequests {
+	if res.StatusCode != http.StatusOK {
 		var errorBody openAiEmbeddingsError
 		if err := json.NewDecoder(res.Body).Decode(&errorBody); err != nil {
 			log.WithField("error", err).Warn("could not decode error response body")
@@ -96,9 +96,7 @@ func (c *OpenAiClient) CreateEmbeddings(ctx context.Context, input []string) ([]
 		} else {
 			log.WithField("errorBody", errorBody).Warn("errorBody error message was empty")
 		}
-	}
 
-	if res.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("OpenAiClient CreateEmbeddings unexpected status: %s", res.Status)
 	}
 


### PR DESCRIPTION
**Description:**

Try to decode the error message from any OpenAI API response that isn't OK. We've observed a couple of non-OK response codes now and they seem to follow the same structure for the error message.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

N/A

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/800)
<!-- Reviewable:end -->
