### PR TITLE
source-postgres: Ignore 'ParameterStatus' messages

### DIFF
--- a/source-postgres/replication.go
+++ b/source-postgres/replication.go
@@ -533,6 +533,11 @@ func (s *replicationStream) receiveMessage(ctx context.Context) (pglogrepl.LSN, 
 		}
 
 		switch msg := msg.(type) {
+		case *pgproto3.ParameterStatus:
+			logrus.WithFields(logrus.Fields{
+				"name":  msg.Name,
+				"value": msg.Value,
+			}).Debug("ignoring parameter status message")
 		case *pgproto3.CopyData:
 			switch msg.Data[0] {
 			case pglogrepl.PrimaryKeepaliveMessageByteID:
@@ -557,7 +562,7 @@ func (s *replicationStream) receiveMessage(ctx context.Context) (pglogrepl.LSN, 
 				return 0, nil, fmt.Errorf("unknown CopyData message: %v", msg)
 			}
 		default:
-			return 0, nil, fmt.Errorf("unexpected message: %v", msg)
+			return 0, nil, fmt.Errorf("unexpected message: %#v", msg)
 		}
 	}
 }


### PR DESCRIPTION
**Description:**

These are rare but I believe they might be able to cause the capture to fail just because we don't expect to see that message. They're irrelevant to us, so ignore them.

Also tweaks the 'unexpected message' error to use '%#v' which will hopefully tell us the actual type name so next time I won't have to simply guess what the offending message was.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/803)
<!-- Reviewable:end -->
