### PR TITLE
sqlcapture: Permit source metadata to add properties in future

### DIFF
--- a/source-mysql/.snapshots/TestGeneric-KeylessDiscovery
+++ b/source-mysql/.snapshots/TestGeneric-KeylessDiscovery
@@ -88,7 +88,6 @@ Binding 0:
                       "description": "Cursor value representing the current position in the binlog."
                     }
                   },
-                  "additionalProperties": false,
                   "type": "object",
                   "required": [
                     "schema",

--- a/source-mysql/.snapshots/TestGeneric-SimpleDiscovery
+++ b/source-mysql/.snapshots/TestGeneric-SimpleDiscovery
@@ -88,7 +88,6 @@ Binding 0:
                       "description": "Cursor value representing the current position in the binlog."
                     }
                   },
-                  "additionalProperties": false,
                   "type": "object",
                   "required": [
                     "schema",

--- a/source-mysql/.snapshots/TestPartitionedTable-Discovery
+++ b/source-mysql/.snapshots/TestPartitionedTable-Discovery
@@ -83,7 +83,6 @@ Binding 0:
                       "description": "Cursor value representing the current position in the binlog."
                     }
                   },
-                  "additionalProperties": false,
                   "type": "object",
                   "required": [
                     "schema",

--- a/source-mysql/.snapshots/TestSecondaryIndexDiscovery-index_only
+++ b/source-mysql/.snapshots/TestSecondaryIndexDiscovery-index_only
@@ -89,7 +89,6 @@ Binding 0:
                       "description": "Cursor value representing the current position in the binlog."
                     }
                   },
-                  "additionalProperties": false,
                   "type": "object",
                   "required": [
                     "schema",

--- a/source-mysql/.snapshots/TestSecondaryIndexDiscovery-nonunique_index
+++ b/source-mysql/.snapshots/TestSecondaryIndexDiscovery-nonunique_index
@@ -85,7 +85,6 @@ Binding 0:
                       "description": "Cursor value representing the current position in the binlog."
                     }
                   },
-                  "additionalProperties": false,
                   "type": "object",
                   "required": [
                     "schema",

--- a/source-mysql/.snapshots/TestSecondaryIndexDiscovery-nothing
+++ b/source-mysql/.snapshots/TestSecondaryIndexDiscovery-nothing
@@ -85,7 +85,6 @@ Binding 0:
                       "description": "Cursor value representing the current position in the binlog."
                     }
                   },
-                  "additionalProperties": false,
                   "type": "object",
                   "required": [
                     "schema",

--- a/source-mysql/.snapshots/TestSecondaryIndexDiscovery-nullable_index
+++ b/source-mysql/.snapshots/TestSecondaryIndexDiscovery-nullable_index
@@ -91,7 +91,6 @@ Binding 0:
                       "description": "Cursor value representing the current position in the binlog."
                     }
                   },
-                  "additionalProperties": false,
                   "type": "object",
                   "required": [
                     "schema",

--- a/source-mysql/.snapshots/TestSecondaryIndexDiscovery-pk_and_index
+++ b/source-mysql/.snapshots/TestSecondaryIndexDiscovery-pk_and_index
@@ -85,7 +85,6 @@ Binding 0:
                       "description": "Cursor value representing the current position in the binlog."
                     }
                   },
-                  "additionalProperties": false,
                   "type": "object",
                   "required": [
                     "schema",

--- a/source-mysql/.snapshots/TestTrickyColumnNames-discover
+++ b/source-mysql/.snapshots/TestTrickyColumnNames-discover
@@ -79,7 +79,6 @@ Binding 0:
                       "description": "Cursor value representing the current position in the binlog."
                     }
                   },
-                  "additionalProperties": false,
                   "type": "object",
                   "required": [
                     "schema",
@@ -187,7 +186,6 @@ Binding 1:
                       "description": "Cursor value representing the current position in the binlog."
                     }
                   },
-                  "additionalProperties": false,
                   "type": "object",
                   "required": [
                     "schema",

--- a/source-mysql/.snapshots/TestTrickyTableNames-Discover
+++ b/source-mysql/.snapshots/TestTrickyTableNames-Discover
@@ -76,7 +76,6 @@ Binding 0:
                       "description": "Cursor value representing the current position in the binlog."
                     }
                   },
-                  "additionalProperties": false,
                   "type": "object",
                   "required": [
                     "schema",

--- a/source-postgres/.snapshots/TestCapitalizedTables-Discover
+++ b/source-postgres/.snapshots/TestCapitalizedTables-Discover
@@ -81,7 +81,6 @@ Binding 0:
                       "description": "Location of this WAL event as [last Commit.EndLSN; event LSN; current Begin.FinalLSN]. See https://www.postgresql.org/docs/current/protocol-logicalrep-message-formats.html"
                     }
                   },
-                  "additionalProperties": false,
                   "type": "object",
                   "required": [
                     "schema",

--- a/source-postgres/.snapshots/TestDiscoveryCapitalization
+++ b/source-postgres/.snapshots/TestDiscoveryCapitalization
@@ -84,7 +84,6 @@ Binding 0:
                       "description": "Location of this WAL event as [last Commit.EndLSN; event LSN; current Begin.FinalLSN]. See https://www.postgresql.org/docs/current/protocol-logicalrep-message-formats.html"
                     }
                   },
-                  "additionalProperties": false,
                   "type": "object",
                   "required": [
                     "schema",
@@ -197,7 +196,6 @@ Binding 1:
                       "description": "Location of this WAL event as [last Commit.EndLSN; event LSN; current Begin.FinalLSN]. See https://www.postgresql.org/docs/current/protocol-logicalrep-message-formats.html"
                     }
                   },
-                  "additionalProperties": false,
                   "type": "object",
                   "required": [
                     "schema",
@@ -310,7 +308,6 @@ Binding 2:
                       "description": "Location of this WAL event as [last Commit.EndLSN; event LSN; current Begin.FinalLSN]. See https://www.postgresql.org/docs/current/protocol-logicalrep-message-formats.html"
                     }
                   },
-                  "additionalProperties": false,
                   "type": "object",
                   "required": [
                     "schema",

--- a/source-postgres/.snapshots/TestDiscoveryComplex
+++ b/source-postgres/.snapshots/TestDiscoveryComplex
@@ -101,7 +101,6 @@ Binding 0:
                       "description": "Location of this WAL event as [last Commit.EndLSN; event LSN; current Begin.FinalLSN]. See https://www.postgresql.org/docs/current/protocol-logicalrep-message-formats.html"
                     }
                   },
-                  "additionalProperties": false,
                   "type": "object",
                   "required": [
                     "schema",

--- a/source-postgres/.snapshots/TestGeneric-KeylessDiscovery
+++ b/source-postgres/.snapshots/TestGeneric-KeylessDiscovery
@@ -93,7 +93,6 @@ Binding 0:
                       "description": "Location of this WAL event as [last Commit.EndLSN; event LSN; current Begin.FinalLSN]. See https://www.postgresql.org/docs/current/protocol-logicalrep-message-formats.html"
                     }
                   },
-                  "additionalProperties": false,
                   "type": "object",
                   "required": [
                     "schema",

--- a/source-postgres/.snapshots/TestGeneric-SimpleDiscovery
+++ b/source-postgres/.snapshots/TestGeneric-SimpleDiscovery
@@ -93,7 +93,6 @@ Binding 0:
                       "description": "Location of this WAL event as [last Commit.EndLSN; event LSN; current Begin.FinalLSN]. See https://www.postgresql.org/docs/current/protocol-logicalrep-message-formats.html"
                     }
                   },
-                  "additionalProperties": false,
                   "type": "object",
                   "required": [
                     "schema",

--- a/source-postgres/.snapshots/TestSecondaryIndexDiscovery-index_only
+++ b/source-postgres/.snapshots/TestSecondaryIndexDiscovery-index_only
@@ -94,7 +94,6 @@ Binding 0:
                       "description": "Location of this WAL event as [last Commit.EndLSN; event LSN; current Begin.FinalLSN]. See https://www.postgresql.org/docs/current/protocol-logicalrep-message-formats.html"
                     }
                   },
-                  "additionalProperties": false,
                   "type": "object",
                   "required": [
                     "schema",

--- a/source-postgres/.snapshots/TestSecondaryIndexDiscovery-nonunique_index
+++ b/source-postgres/.snapshots/TestSecondaryIndexDiscovery-nonunique_index
@@ -90,7 +90,6 @@ Binding 0:
                       "description": "Location of this WAL event as [last Commit.EndLSN; event LSN; current Begin.FinalLSN]. See https://www.postgresql.org/docs/current/protocol-logicalrep-message-formats.html"
                     }
                   },
-                  "additionalProperties": false,
                   "type": "object",
                   "required": [
                     "schema",

--- a/source-postgres/.snapshots/TestSecondaryIndexDiscovery-nothing
+++ b/source-postgres/.snapshots/TestSecondaryIndexDiscovery-nothing
@@ -90,7 +90,6 @@ Binding 0:
                       "description": "Location of this WAL event as [last Commit.EndLSN; event LSN; current Begin.FinalLSN]. See https://www.postgresql.org/docs/current/protocol-logicalrep-message-formats.html"
                     }
                   },
-                  "additionalProperties": false,
                   "type": "object",
                   "required": [
                     "schema",

--- a/source-postgres/.snapshots/TestSecondaryIndexDiscovery-nullable_index
+++ b/source-postgres/.snapshots/TestSecondaryIndexDiscovery-nullable_index
@@ -96,7 +96,6 @@ Binding 0:
                       "description": "Location of this WAL event as [last Commit.EndLSN; event LSN; current Begin.FinalLSN]. See https://www.postgresql.org/docs/current/protocol-logicalrep-message-formats.html"
                     }
                   },
-                  "additionalProperties": false,
                   "type": "object",
                   "required": [
                     "schema",

--- a/source-postgres/.snapshots/TestSecondaryIndexDiscovery-pk_and_index
+++ b/source-postgres/.snapshots/TestSecondaryIndexDiscovery-pk_and_index
@@ -90,7 +90,6 @@ Binding 0:
                       "description": "Location of this WAL event as [last Commit.EndLSN; event LSN; current Begin.FinalLSN]. See https://www.postgresql.org/docs/current/protocol-logicalrep-message-formats.html"
                     }
                   },
-                  "additionalProperties": false,
                   "type": "object",
                   "required": [
                     "schema",

--- a/source-postgres/.snapshots/TestTrickyColumnNames-discover
+++ b/source-postgres/.snapshots/TestTrickyColumnNames-discover
@@ -84,7 +84,6 @@ Binding 0:
                       "description": "Location of this WAL event as [last Commit.EndLSN; event LSN; current Begin.FinalLSN]. See https://www.postgresql.org/docs/current/protocol-logicalrep-message-formats.html"
                     }
                   },
-                  "additionalProperties": false,
                   "type": "object",
                   "required": [
                     "schema",
@@ -197,7 +196,6 @@ Binding 1:
                       "description": "Location of this WAL event as [last Commit.EndLSN; event LSN; current Begin.FinalLSN]. See https://www.postgresql.org/docs/current/protocol-logicalrep-message-formats.html"
                     }
                   },
-                  "additionalProperties": false,
                   "type": "object",
                   "required": [
                     "schema",

--- a/source-postgres/.snapshots/TestUserTypes-Domain-Discovery
+++ b/source-postgres/.snapshots/TestUserTypes-Domain-Discovery
@@ -84,7 +84,6 @@ Binding 0:
                       "description": "Location of this WAL event as [last Commit.EndLSN; event LSN; current Begin.FinalLSN]. See https://www.postgresql.org/docs/current/protocol-logicalrep-message-formats.html"
                     }
                   },
-                  "additionalProperties": false,
                   "type": "object",
                   "required": [
                     "schema",

--- a/source-postgres/.snapshots/TestUserTypes-Enum-Discovery
+++ b/source-postgres/.snapshots/TestUserTypes-Enum-Discovery
@@ -84,7 +84,6 @@ Binding 0:
                       "description": "Location of this WAL event as [last Commit.EndLSN; event LSN; current Begin.FinalLSN]. See https://www.postgresql.org/docs/current/protocol-logicalrep-message-formats.html"
                     }
                   },
-                  "additionalProperties": false,
                   "type": "object",
                   "required": [
                     "schema",

--- a/source-postgres/.snapshots/TestUserTypes-Range-Discovery
+++ b/source-postgres/.snapshots/TestUserTypes-Range-Discovery
@@ -84,7 +84,6 @@ Binding 0:
                       "description": "Location of this WAL event as [last Commit.EndLSN; event LSN; current Begin.FinalLSN]. See https://www.postgresql.org/docs/current/protocol-logicalrep-message-formats.html"
                     }
                   },
-                  "additionalProperties": false,
                   "type": "object",
                   "required": [
                     "schema",

--- a/source-postgres/.snapshots/TestUserTypes-Tuple-Discovery
+++ b/source-postgres/.snapshots/TestUserTypes-Tuple-Discovery
@@ -81,7 +81,6 @@ Binding 0:
                       "description": "Location of this WAL event as [last Commit.EndLSN; event LSN; current Begin.FinalLSN]. See https://www.postgresql.org/docs/current/protocol-logicalrep-message-formats.html"
                     }
                   },
-                  "additionalProperties": false,
                   "type": "object",
                   "required": [
                     "schema",

--- a/source-sqlserver/.snapshots/TestDiscoveryIrrelevantConstraints
+++ b/source-sqlserver/.snapshots/TestDiscoveryIrrelevantConstraints
@@ -94,7 +94,6 @@ Binding 0:
                       "description": "A bit mask with a bit corresponding to each captured column identified for the capture instance. Only set for CDC events"
                     }
                   },
-                  "additionalProperties": false,
                   "type": "object",
                   "required": [
                     "schema",

--- a/source-sqlserver/.snapshots/TestGeneric-KeylessDiscovery
+++ b/source-sqlserver/.snapshots/TestGeneric-KeylessDiscovery
@@ -97,7 +97,6 @@ Binding 0:
                       "description": "A bit mask with a bit corresponding to each captured column identified for the capture instance. Only set for CDC events"
                     }
                   },
-                  "additionalProperties": false,
                   "type": "object",
                   "required": [
                     "schema",

--- a/source-sqlserver/.snapshots/TestGeneric-SimpleDiscovery
+++ b/source-sqlserver/.snapshots/TestGeneric-SimpleDiscovery
@@ -97,7 +97,6 @@ Binding 0:
                       "description": "A bit mask with a bit corresponding to each captured column identified for the capture instance. Only set for CDC events"
                     }
                   },
-                  "additionalProperties": false,
                   "type": "object",
                   "required": [
                     "schema",

--- a/source-sqlserver/.snapshots/TestIndexIncludedDiscovery
+++ b/source-sqlserver/.snapshots/TestIndexIncludedDiscovery
@@ -98,7 +98,6 @@ Binding 0:
                       "description": "A bit mask with a bit corresponding to each captured column identified for the capture instance. Only set for CDC events"
                     }
                   },
-                  "additionalProperties": false,
                   "type": "object",
                   "required": [
                     "schema",

--- a/source-sqlserver/.snapshots/TestSecondaryIndexDiscovery-index_only
+++ b/source-sqlserver/.snapshots/TestSecondaryIndexDiscovery-index_only
@@ -98,7 +98,6 @@ Binding 0:
                       "description": "A bit mask with a bit corresponding to each captured column identified for the capture instance. Only set for CDC events"
                     }
                   },
-                  "additionalProperties": false,
                   "type": "object",
                   "required": [
                     "schema",

--- a/source-sqlserver/.snapshots/TestSecondaryIndexDiscovery-nonunique_index
+++ b/source-sqlserver/.snapshots/TestSecondaryIndexDiscovery-nonunique_index
@@ -94,7 +94,6 @@ Binding 0:
                       "description": "A bit mask with a bit corresponding to each captured column identified for the capture instance. Only set for CDC events"
                     }
                   },
-                  "additionalProperties": false,
                   "type": "object",
                   "required": [
                     "schema",

--- a/source-sqlserver/.snapshots/TestSecondaryIndexDiscovery-nothing
+++ b/source-sqlserver/.snapshots/TestSecondaryIndexDiscovery-nothing
@@ -94,7 +94,6 @@ Binding 0:
                       "description": "A bit mask with a bit corresponding to each captured column identified for the capture instance. Only set for CDC events"
                     }
                   },
-                  "additionalProperties": false,
                   "type": "object",
                   "required": [
                     "schema",

--- a/source-sqlserver/.snapshots/TestSecondaryIndexDiscovery-nullable_index
+++ b/source-sqlserver/.snapshots/TestSecondaryIndexDiscovery-nullable_index
@@ -100,7 +100,6 @@ Binding 0:
                       "description": "A bit mask with a bit corresponding to each captured column identified for the capture instance. Only set for CDC events"
                     }
                   },
-                  "additionalProperties": false,
                   "type": "object",
                   "required": [
                     "schema",

--- a/source-sqlserver/.snapshots/TestSecondaryIndexDiscovery-pk_and_index
+++ b/source-sqlserver/.snapshots/TestSecondaryIndexDiscovery-pk_and_index
@@ -94,7 +94,6 @@ Binding 0:
                       "description": "A bit mask with a bit corresponding to each captured column identified for the capture instance. Only set for CDC events"
                     }
                   },
-                  "additionalProperties": false,
                   "type": "object",
                   "required": [
                     "schema",

--- a/sqlcapture/discovery.go
+++ b/sqlcapture/discovery.go
@@ -29,8 +29,9 @@ func DiscoverCatalog(ctx context.Context, db Database) ([]*pc.Response_Discovere
 
 	// Shared schema of the embedded "source" property.
 	var sourceSchema = (&jsonschema.Reflector{
-		ExpandedStruct: true,
-		DoNotReference: true,
+		ExpandedStruct:            true,
+		DoNotReference:            true,
+		AllowAdditionalProperties: true,
 	}).Reflect(db.EmptySourceMetadata())
 	sourceSchema.Version = ""
 


### PR DESCRIPTION
**Description:**

See https://github.com/estuary/connectors/pull/802 for the immediate motivation here, we want to add `xid` and `gtid` metadata properties to Postgres and MySQL captures.

Currently the presence of an `additionalProperties: false` clause kind of paints us into a corner where adding new metadata is a really heavyweight operation requiring either a connector version bump or fiddling with all production schemas.

As discussed during standup today, I would like to bite this bullet now by removing the `additionalProperties: false` clause and then modifying collection schemas in production to effectively pretend that clause had never been there.

Since the connector alone controls what properties are going to be present in the metadata object, it changes very rarely, and also in general if we add new metadata we probably want it to be treated as an opt-in nice-to-have thing rather than using the fancy "fail schema validation and rerun discovery and propagate changes" flow we're working on, so just not saying anything and implicitly permitting additional properties seems like the right choice for this specific part of the schema.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/805)
<!-- Reviewable:end -->
