### PR TITLE
materialize-redshift: use separate ping context for testing database connectivity

### DIFF
--- a/materialize-redshift/driver.go
+++ b/materialize-redshift/driver.go
@@ -230,12 +230,12 @@ func prereqs(ctx context.Context, ep *sql.Endpoint) *sql.PrereqErr {
 	// Use a reasonable timeout for this connection test. It is not uncommon for a misconfigured
 	// connection (wrong host, wrong port, etc.) to hang for several minutes on Ping and we want to
 	// bail out well before then.
-	ctx, cancel := context.WithTimeout(ctx, 20*time.Second)
+	pingCtx, cancel := context.WithTimeout(ctx, 20*time.Second)
 	defer cancel()
 
 	if db, err := stdsql.Open("pgx", cfg.toURI()); err != nil {
 		errs.Err(err)
-	} else if err := db.PingContext(ctx); err != nil {
+	} else if err := db.PingContext(pingCtx); err != nil {
 		// Provide a more user-friendly representation of some common error causes.
 		var pgErr *pgconn.PgError
 		var netConnErr *net.DNSError


### PR DESCRIPTION
**Description:**

If the connection attempt times out, we don't want to have the context cancelled for all remaining validation tasks.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

N/A

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/807)
<!-- Reviewable:end -->
