### PR TITLE
materialize-redshift: handle async upload errors while encoding rows

### DIFF
--- a/tests/materialize/materialize-redshift/cleanup.sh
+++ b/tests/materialize/materialize-redshift/cleanup.sh
@@ -4,5 +4,21 @@ set -o errexit
 set -o pipefail
 set -o nounset
 
-# TODO(johnny): This mostly works because deleting bindings also drops the tables.
-# But, this script should nuke it from orbit and ensure we get back to a clean state.
+function dropTable() {
+    echo "drop table if exists \"$1\";" | psql postgres://${REDSHIFT_USER}:${REDSHIFT_PASSWORD}@${REDSHIFT_ADDRESS}/${REDSHIFT_DATABASE}
+}
+
+echo "--- Running Cleanup ---"
+
+# Remove materialized tables.
+dropTable "Simple"
+dropTable "duplicate_keys_standard"
+dropTable "duplicate_keys_delta"
+dropTable "duplicate_keys_delta_exclude_flow_doc"
+dropTable "Multiple_Types"
+dropTable "Formatted_Strings"
+
+# Remove the persisted materialization spec & checkpoint for this test materialization so subsequent
+# runs start from scratch.
+echo "delete from FLOW_CHECKPOINTS_V1 where MATERIALIZATION='tests/materialize-redshift/materialize';" | psql postgres://${REDSHIFT_USER}:${REDSHIFT_PASSWORD}@${REDSHIFT_ADDRESS}/${REDSHIFT_DATABASE}
+echo "delete from FLOW_MATERIALIZATIONS_V2 where MATERIALIZATION='tests/materialize-redshift/materialize';" | psql postgres://${REDSHIFT_USER}:${REDSHIFT_PASSWORD}@${REDSHIFT_ADDRESS}/${REDSHIFT_DATABASE}

--- a/tests/materialize/materialize-redshift/fetch.sh
+++ b/tests/materialize/materialize-redshift/fetch.sh
@@ -5,7 +5,7 @@ set -o pipefail
 set -o nounset
 
 function exportToJsonl() {
-  go run "${TEST_BASE_DIR}"/materialize-redshift/fetch-data.go "$1"
+  go run "${TEST_DIR}"/materialize-redshift/fetch-data.go "$1"
 }
 
 exportToJsonl "simple"

--- a/tests/materialize/materialize-redshift/snapshot.json
+++ b/tests/materialize/materialize-redshift/snapshot.json
@@ -1,0 +1,565 @@
+{
+  "applied": {
+    "actionDescription": "\nCREATE TABLE IF NOT EXISTS flow_materializations_v2 (\n\tmaterialization VARCHAR(4096),\n\tversion VARCHAR(4096),\n\tspec VARBYTE(1024000)\n);\n\nCOMMENT ON TABLE flow_materializations_v2 IS 'This table is the source of truth for all materializations into this system.';\nCOMMENT ON COLUMN flow_materializations_v2.materialization IS 'The name of the materialization.';\nCOMMENT ON COLUMN flow_materializations_v2.version IS 'Version of the materialization.';\nCOMMENT ON COLUMN flow_materializations_v2.spec IS 'Specification of the materialization, encoded as base64 protobuf.';\n\n\nCREATE TABLE IF NOT EXISTS flow_checkpoints_v1 (\n\tmaterialization VARCHAR(4096),\n\tkey_begin BIGINT,\n\tkey_end BIGINT,\n\tfence BIGINT,\n\tcheckpoint VARBYTE(1024000)\n);\n\nCOMMENT ON TABLE flow_checkpoints_v1 IS 'This table holds Flow processing checkpoints used for exactly-once processing of materializations';\nCOMMENT ON COLUMN flow_checkpoints_v1.materialization IS 'The name of the materialization.';\nCOMMENT ON COLUMN flow_checkpoints_v1.key_begin IS 'The inclusive lower-bound key hash covered by this checkpoint.';\nCOMMENT ON COLUMN flow_checkpoints_v1.key_end IS 'The inclusive upper-bound key hash covered by this checkpoint.';\nCOMMENT ON COLUMN flow_checkpoints_v1.fence IS 'This nonce is used to uniquely identify unique process assignments of a shard and prevent them from conflicting.';\nCOMMENT ON COLUMN flow_checkpoints_v1.checkpoint IS 'Checkpoint of the Flow consumer shard, encoded as base64 protobuf.';\n\n\nCREATE TABLE IF NOT EXISTS simple (\n\tid BIGINT,\n\tcanary VARCHAR(4096),\n\tflow_published_at TIMESTAMPTZ,\n\tflow_document SUPER\n);\n\nCOMMENT ON TABLE simple IS 'Generated for materialization tests/materialize-redshift/materialize of collection tests/simple';\nCOMMENT ON COLUMN simple.id IS 'auto-generated projection of JSON at: /id with inferred types: [integer]';\nCOMMENT ON COLUMN simple.canary IS 'auto-generated projection of JSON at: /canary with inferred types: [string]';\nCOMMENT ON COLUMN simple.flow_published_at IS 'Flow Publication Time\nFlow publication date-time of this document\nauto-generated projection of JSON at: /_meta/uuid with inferred types: [string]';\nCOMMENT ON COLUMN simple.flow_document IS 'auto-generated projection of JSON at:  with inferred types: [object]';\n\n\nCREATE TABLE IF NOT EXISTS duplicate_keys_standard (\n\tid BIGINT,\n\tflow_published_at TIMESTAMPTZ,\n\tint BIGINT,\n\tstr VARCHAR(4096),\n\tflow_document SUPER\n);\n\nCOMMENT ON TABLE duplicate_keys_standard IS 'Generated for materialization tests/materialize-redshift/materialize of collection tests/duplicated-keys';\nCOMMENT ON COLUMN duplicate_keys_standard.id IS 'auto-generated projection of JSON at: /id with inferred types: [integer]';\nCOMMENT ON COLUMN duplicate_keys_standard.flow_published_at IS 'Flow Publication Time\nFlow publication date-time of this document\nauto-generated projection of JSON at: /_meta/uuid with inferred types: [string]';\nCOMMENT ON COLUMN duplicate_keys_standard.int IS 'auto-generated projection of JSON at: /int with inferred types: [integer]';\nCOMMENT ON COLUMN duplicate_keys_standard.str IS 'auto-generated projection of JSON at: /str with inferred types: [string]';\nCOMMENT ON COLUMN duplicate_keys_standard.flow_document IS 'auto-generated projection of JSON at:  with inferred types: [object]';\n\n\nCREATE TABLE IF NOT EXISTS duplicate_keys_delta (\n\tid BIGINT,\n\tflow_published_at TIMESTAMPTZ,\n\tint BIGINT,\n\tstr VARCHAR(4096),\n\tflow_document SUPER\n);\n\nCOMMENT ON TABLE duplicate_keys_delta IS 'Generated for materialization tests/materialize-redshift/materialize of collection tests/duplicated-keys';\nCOMMENT ON COLUMN duplicate_keys_delta.id IS 'auto-generated projection of JSON at: /id with inferred types: [integer]';\nCOMMENT ON COLUMN duplicate_keys_delta.flow_published_at IS 'Flow Publication Time\nFlow publication date-time of this document\nauto-generated projection of JSON at: /_meta/uuid with inferred types: [string]';\nCOMMENT ON COLUMN duplicate_keys_delta.int IS 'auto-generated projection of JSON at: /int with inferred types: [integer]';\nCOMMENT ON COLUMN duplicate_keys_delta.str IS 'auto-generated projection of JSON at: /str with inferred types: [string]';\nCOMMENT ON COLUMN duplicate_keys_delta.flow_document IS 'auto-generated projection of JSON at:  with inferred types: [object]';\n\n\nCREATE TABLE IF NOT EXISTS duplicate_keys_delta_exclude_flow_doc (\n\tid BIGINT,\n\tflow_published_at TIMESTAMPTZ,\n\tint BIGINT,\n\tstr VARCHAR(4096)\n);\n\nCOMMENT ON TABLE duplicate_keys_delta_exclude_flow_doc IS 'Generated for materialization tests/materialize-redshift/materialize of collection tests/duplicated-keys';\nCOMMENT ON COLUMN duplicate_keys_delta_exclude_flow_doc.id IS 'auto-generated projection of JSON at: /id with inferred types: [integer]';\nCOMMENT ON COLUMN duplicate_keys_delta_exclude_flow_doc.flow_published_at IS 'Flow Publication Time\nFlow publication date-time of this document\nauto-generated projection of JSON at: /_meta/uuid with inferred types: [string]';\nCOMMENT ON COLUMN duplicate_keys_delta_exclude_flow_doc.int IS 'auto-generated projection of JSON at: /int with inferred types: [integer]';\nCOMMENT ON COLUMN duplicate_keys_delta_exclude_flow_doc.str IS 'auto-generated projection of JSON at: /str with inferred types: [string]';\n\n\nCREATE TABLE IF NOT EXISTS multiple_types (\n\tid BIGINT,\n\tarray_int SUPER,\n\tbool_field BOOLEAN,\n\tfloat_field DOUBLE PRECISION,\n\tflow_published_at TIMESTAMPTZ,\n\tnested SUPER,\n\tnullable_int BIGINT,\n\tstr_field VARCHAR(4096),\n\tflow_document SUPER\n);\n\nCOMMENT ON TABLE multiple_types IS 'Generated for materialization tests/materialize-redshift/materialize of collection tests/multiple-data-types';\nCOMMENT ON COLUMN multiple_types.id IS 'auto-generated projection of JSON at: /id with inferred types: [integer]';\nCOMMENT ON COLUMN multiple_types.array_int IS 'auto-generated projection of JSON at: /array_int with inferred types: [array]';\nCOMMENT ON COLUMN multiple_types.bool_field IS 'auto-generated projection of JSON at: /bool_field with inferred types: [boolean]';\nCOMMENT ON COLUMN multiple_types.float_field IS 'auto-generated projection of JSON at: /float_field with inferred types: [number]';\nCOMMENT ON COLUMN multiple_types.flow_published_at IS 'Flow Publication Time\nFlow publication date-time of this document\nauto-generated projection of JSON at: /_meta/uuid with inferred types: [string]';\nCOMMENT ON COLUMN multiple_types.nested IS 'auto-generated projection of JSON at: /nested with inferred types: [object]';\nCOMMENT ON COLUMN multiple_types.nullable_int IS 'auto-generated projection of JSON at: /nullable_int with inferred types: [integer null]';\nCOMMENT ON COLUMN multiple_types.str_field IS 'auto-generated projection of JSON at: /str_field with inferred types: [string]';\nCOMMENT ON COLUMN multiple_types.flow_document IS 'auto-generated projection of JSON at:  with inferred types: [object]';\n\n\nCREATE TABLE IF NOT EXISTS formatted_strings (\n\tid BIGINT,\n\tflow_published_at TIMESTAMPTZ,\n\tint_and_str BIGINT,\n\tint_str BIGINT,\n\tnum_and_str DOUBLE PRECISION,\n\tnum_str DOUBLE PRECISION,\n\tflow_document SUPER\n);\n\nCOMMENT ON TABLE formatted_strings IS 'Generated for materialization tests/materialize-redshift/materialize of collection tests/formatted-strings';\nCOMMENT ON COLUMN formatted_strings.id IS 'auto-generated projection of JSON at: /id with inferred types: [integer]';\nCOMMENT ON COLUMN formatted_strings.flow_published_at IS 'Flow Publication Time\nFlow publication date-time of this document\nauto-generated projection of JSON at: /_meta/uuid with inferred types: [string]';\nCOMMENT ON COLUMN formatted_strings.int_and_str IS 'auto-generated projection of JSON at: /int_and_str with inferred types: [integer string]';\nCOMMENT ON COLUMN formatted_strings.int_str IS 'auto-generated projection of JSON at: /int_str with inferred types: [string]';\nCOMMENT ON COLUMN formatted_strings.num_and_str IS 'auto-generated projection of JSON at: /num_and_str with inferred types: [number string]';\nCOMMENT ON COLUMN formatted_strings.num_str IS 'auto-generated projection of JSON at: /num_str with inferred types: [string]';\nCOMMENT ON COLUMN formatted_strings.flow_document IS 'auto-generated projection of JSON at:  with inferred types: [object]';\n\nINSERT INTO flow_materializations_v2 (version, spec, materialization) VALUES ('test', '(a-base64-encoded-value)', 'tests/materialize-redshift/materialize');"
+  }
+}
+{
+  "opened": {
+    "runtimeCheckpoint": {}
+  }
+}
+{
+  "acknowledged": {}
+}
+{
+  "flushed": {}
+}
+{
+  "startedCommit": {}
+}
+{
+  "acknowledged": {}
+}
+{
+  "loaded": {
+    "binding": 1,
+    "doc": {
+      "_meta": {
+        "uuid": "75c06bd6-20e0-11ee-990b-ffd12dfcd47f"
+      },
+      "id": 1,
+      "int": 1,
+      "str": "str 1"
+    }
+  }
+}
+{
+  "loaded": {
+    "binding": 1,
+    "doc": {
+      "_meta": {
+        "uuid": "7dbe8ebc-20e0-11ee-990b-ffd12dfcd47f"
+      },
+      "id": 2,
+      "int": 2,
+      "str": "str 2"
+    }
+  }
+}
+{
+  "loaded": {
+    "binding": 1,
+    "doc": {
+      "_meta": {
+        "uuid": "8bbf898a-20e0-11ee-990b-ffd12dfcd47f"
+      },
+      "id": 3,
+      "int": 3,
+      "str": "str 3"
+    }
+  }
+}
+{
+  "loaded": {
+    "binding": 1,
+    "doc": {
+      "_meta": {
+        "uuid": "9b994ae4-20e0-11ee-990b-ffd12dfcd47f"
+      },
+      "id": 4,
+      "int": 4,
+      "str": "str 4"
+    }
+  }
+}
+{
+  "loaded": {
+    "binding": 1,
+    "doc": {
+      "_meta": {
+        "uuid": "bcef4bc6-20e0-11ee-990b-ffd12dfcd47f"
+      },
+      "id": 5,
+      "int": 5,
+      "str": "str 5"
+    }
+  }
+}
+{
+  "loaded": {
+    "binding": 4,
+    "doc": {
+      "_meta": {
+        "uuid": "5fc54530-20e1-11ee-990b-ffd12dfcd47f"
+      },
+      "array_int": [
+        61,
+        62
+      ],
+      "bool_field": true,
+      "float_field": 6.6,
+      "id": 6,
+      "nested": {
+        "id": "i6"
+      },
+      "nullable_int": 6,
+      "str_field": "str6"
+    }
+  }
+}
+{
+  "loaded": {
+    "binding": 4,
+    "doc": {
+      "_meta": {
+        "uuid": "64b39506-20e1-11ee-990b-ffd12dfcd47f"
+      },
+      "array_int": [
+        71,
+        72
+      ],
+      "bool_field": false,
+      "float_field": 7.7,
+      "id": 7,
+      "nested": {
+        "id": "i7"
+      },
+      "nullable_int": null,
+      "str_field": "str7"
+    }
+  }
+}
+{
+  "loaded": {
+    "binding": 4,
+    "doc": {
+      "_meta": {
+        "uuid": "6acb8444-20e1-11ee-990b-ffd12dfcd47f"
+      },
+      "array_int": [
+        81,
+        82
+      ],
+      "bool_field": true,
+      "float_field": 8.8,
+      "id": 8,
+      "nested": {
+        "id": "i8"
+      },
+      "nullable_int": 8,
+      "str_field": "str8"
+    }
+  }
+}
+{
+  "loaded": {
+    "binding": 4,
+    "doc": {
+      "_meta": {
+        "uuid": "6ff68e0a-20e1-11ee-990b-ffd12dfcd47f"
+      },
+      "array_int": [
+        91,
+        92
+      ],
+      "bool_field": false,
+      "float_field": 9.9,
+      "id": 9,
+      "nested": {
+        "id": "i9"
+      },
+      "nullable_int": null,
+      "str_field": "str9"
+    }
+  }
+}
+{
+  "loaded": {
+    "binding": 4,
+    "doc": {
+      "_meta": {
+        "uuid": "75679e4c-20e1-11ee-990b-ffd12dfcd47f"
+      },
+      "array_int": [
+        1,
+        2
+      ],
+      "bool_field": true,
+      "float_field": 10.1,
+      "id": 10,
+      "nested": {
+        "id": "i10"
+      },
+      "nullable_int": 10,
+      "str_field": "str10"
+    }
+  }
+}
+{
+  "flushed": {}
+}
+{
+  "startedCommit": {}
+}
+{
+  "acknowledged": {}
+}
+{
+  "canary": "amputation's",
+  "flow_published_at": "2023-07-12T14:18:11.537199-04:00",
+  "id": 1
+}
+{
+  "canary": "armament's",
+  "flow_published_at": "2023-07-12T14:18:24.946758-04:00",
+  "id": 2
+}
+{
+  "canary": "splatters",
+  "flow_published_at": "2023-07-12T14:18:48.441281-04:00",
+  "id": 3
+}
+{
+  "canary": "strengthen",
+  "flow_published_at": "2023-07-12T14:19:15.034186-04:00",
+  "id": 4
+}
+{
+  "canary": "Kringle's",
+  "flow_published_at": "2023-07-12T14:19:57.165604-04:00",
+  "id": 5
+}
+{
+  "canary": "grosbeak's",
+  "flow_published_at": "2023-07-12T14:20:10.962631-04:00",
+  "id": 6
+}
+{
+  "canary": "pieced",
+  "flow_published_at": "2023-07-12T14:22:35.841647-04:00",
+  "id": 7
+}
+{
+  "canary": "roaches",
+  "flow_published_at": "2023-07-12T14:22:49.755893-04:00",
+  "id": 8
+}
+{
+  "canary": "devilish",
+  "flow_published_at": "2023-07-12T14:25:35.173533-04:00",
+  "id": 9
+}
+{
+  "canary": "glucose's",
+  "flow_published_at": "2023-07-12T14:25:45.520064-04:00",
+  "id": 10
+}
+{
+  "flow_published_at": "2023-07-12T14:26:01.560712-04:00",
+  "id": 1,
+  "int": 6,
+  "str": "str 6"
+}
+{
+  "flow_published_at": "2023-07-12T14:26:14.215494-04:00",
+  "id": 2,
+  "int": 7,
+  "str": "str 7"
+}
+{
+  "flow_published_at": "2023-07-12T14:26:23.495167-04:00",
+  "id": 3,
+  "int": 8,
+  "str": "str 8"
+}
+{
+  "flow_published_at": "2023-07-12T14:26:33.697752-04:00",
+  "id": 4,
+  "int": 9,
+  "str": "str 9"
+}
+{
+  "flow_published_at": "2023-07-12T14:26:42.518724-04:00",
+  "id": 5,
+  "int": 10,
+  "str": "str 10"
+}
+{
+  "flow_published_at": "2023-07-12T14:18:11.537199-04:00",
+  "id": 1,
+  "int": 1,
+  "str": "str 1"
+}
+{
+  "flow_published_at": "2023-07-12T14:26:01.560712-04:00",
+  "id": 1,
+  "int": 6,
+  "str": "str 6"
+}
+{
+  "flow_published_at": "2023-07-12T14:18:24.946758-04:00",
+  "id": 2,
+  "int": 2,
+  "str": "str 2"
+}
+{
+  "flow_published_at": "2023-07-12T14:26:14.215494-04:00",
+  "id": 2,
+  "int": 7,
+  "str": "str 7"
+}
+{
+  "flow_published_at": "2023-07-12T14:18:48.441281-04:00",
+  "id": 3,
+  "int": 3,
+  "str": "str 3"
+}
+{
+  "flow_published_at": "2023-07-12T14:26:23.495167-04:00",
+  "id": 3,
+  "int": 8,
+  "str": "str 8"
+}
+{
+  "flow_published_at": "2023-07-12T14:19:15.034186-04:00",
+  "id": 4,
+  "int": 4,
+  "str": "str 4"
+}
+{
+  "flow_published_at": "2023-07-12T14:26:33.697752-04:00",
+  "id": 4,
+  "int": 9,
+  "str": "str 9"
+}
+{
+  "flow_published_at": "2023-07-12T14:20:10.962631-04:00",
+  "id": 5,
+  "int": 5,
+  "str": "str 5"
+}
+{
+  "flow_published_at": "2023-07-12T14:26:42.518724-04:00",
+  "id": 5,
+  "int": 10,
+  "str": "str 10"
+}
+{
+  "flow_published_at": "2023-07-12T14:18:11.537199-04:00",
+  "id": 1,
+  "int": 1,
+  "str": "str 1"
+}
+{
+  "flow_published_at": "2023-07-12T14:26:01.560712-04:00",
+  "id": 1,
+  "int": 6,
+  "str": "str 6"
+}
+{
+  "flow_published_at": "2023-07-12T14:18:24.946758-04:00",
+  "id": 2,
+  "int": 2,
+  "str": "str 2"
+}
+{
+  "flow_published_at": "2023-07-12T14:26:14.215494-04:00",
+  "id": 2,
+  "int": 7,
+  "str": "str 7"
+}
+{
+  "flow_published_at": "2023-07-12T14:18:48.441281-04:00",
+  "id": 3,
+  "int": 3,
+  "str": "str 3"
+}
+{
+  "flow_published_at": "2023-07-12T14:26:23.495167-04:00",
+  "id": 3,
+  "int": 8,
+  "str": "str 8"
+}
+{
+  "flow_published_at": "2023-07-12T14:19:15.034186-04:00",
+  "id": 4,
+  "int": 4,
+  "str": "str 4"
+}
+{
+  "flow_published_at": "2023-07-12T14:26:33.697752-04:00",
+  "id": 4,
+  "int": 9,
+  "str": "str 9"
+}
+{
+  "flow_published_at": "2023-07-12T14:20:10.962631-04:00",
+  "id": 5,
+  "int": 5,
+  "str": "str 5"
+}
+{
+  "flow_published_at": "2023-07-12T14:26:42.518724-04:00",
+  "id": 5,
+  "int": 10,
+  "str": "str 10"
+}
+{
+  "array_int": "[11,12]",
+  "bool_field": false,
+  "float_field": 1.1,
+  "flow_published_at": "2023-07-12T14:23:50.55822-04:00",
+  "id": 1,
+  "nested": "{\"id\":\"i1\"}",
+  "nullable_int": null,
+  "str_field": "str1"
+}
+{
+  "array_int": "[21,22]",
+  "bool_field": true,
+  "float_field": 2.2,
+  "flow_published_at": "2023-07-12T14:24:09.67518-04:00",
+  "id": 2,
+  "nested": "{\"id\":\"i2\"}",
+  "nullable_int": 2,
+  "str_field": "str2"
+}
+{
+  "array_int": "[31,32]",
+  "bool_field": false,
+  "float_field": 3.3,
+  "flow_published_at": "2023-07-12T14:24:19.384-04:00",
+  "id": 3,
+  "nested": "{\"id\":\"i3\"}",
+  "nullable_int": null,
+  "str_field": "str3"
+}
+{
+  "array_int": "[41,42]",
+  "bool_field": true,
+  "float_field": 4.4,
+  "flow_published_at": "2023-07-12T14:24:28.397025-04:00",
+  "id": 4,
+  "nested": "{\"id\":\"i4\"}",
+  "nullable_int": 4,
+  "str_field": "str4"
+}
+{
+  "array_int": "[51,52]",
+  "bool_field": false,
+  "float_field": 5.5,
+  "flow_published_at": "2023-07-12T14:24:36.112031-04:00",
+  "id": 5,
+  "nested": "{\"id\":\"i5\"}",
+  "nullable_int": null,
+  "str_field": "str5"
+}
+{
+  "array_int": "[61,62]",
+  "bool_field": true,
+  "float_field": 66.66,
+  "flow_published_at": "2023-07-12T14:28:27.194541-04:00",
+  "id": 6,
+  "nested": "{\"id\":\"i6\"}",
+  "nullable_int": 6,
+  "str_field": "str6 v2"
+}
+{
+  "array_int": "[71,72]",
+  "bool_field": false,
+  "float_field": 77.77,
+  "flow_published_at": "2023-07-12T14:28:38.169062-04:00",
+  "id": 7,
+  "nested": "{\"id\":\"i7\"}",
+  "nullable_int": null,
+  "str_field": "str7 v2"
+}
+{
+  "array_int": "[81,82]",
+  "bool_field": true,
+  "float_field": 88.88,
+  "flow_published_at": "2023-07-12T14:28:48.465279-04:00",
+  "id": 8,
+  "nested": "{\"id\":\"i8\"}",
+  "nullable_int": 8,
+  "str_field": "str8 v2"
+}
+{
+  "array_int": "[91,92]",
+  "bool_field": false,
+  "float_field": 99.99,
+  "flow_published_at": "2023-07-12T14:28:55.677252-04:00",
+  "id": 9,
+  "nested": "{\"id\":\"i9\"}",
+  "nullable_int": null,
+  "str_field": "str9 v2"
+}
+{
+  "array_int": "[1,2]",
+  "bool_field": true,
+  "float_field": 1010.101,
+  "flow_published_at": "2023-07-12T14:29:04.671352-04:00",
+  "id": 10,
+  "nested": "{\"id\":\"i10\"}",
+  "nullable_int": 10,
+  "str_field": "str10 v2"
+}
+{
+  "flow_published_at": "2023-07-12T14:27:01.912219-04:00",
+  "id": 1,
+  "int_and_str": 1,
+  "int_str": 10,
+  "num_and_str": 1.1,
+  "num_str": 10.1
+}
+{
+  "flow_published_at": "2023-07-12T14:27:12.35461-04:00",
+  "id": 2,
+  "int_and_str": 2,
+  "int_str": 20,
+  "num_and_str": 2.1,
+  "num_str": 20.1
+}
+{
+  "flow_published_at": "2023-07-12T14:18:11.537199-04:00",
+  "id": 3,
+  "int_and_str": 3,
+  "int_str": 30,
+  "num_and_str": 3.1,
+  "num_str": 30.1
+}
+{
+  "flow_published_at": "2023-07-12T14:18:48.441281-04:00",
+  "id": 4,
+  "int_and_str": 4,
+  "int_str": 40,
+  "num_and_str": 4.1,
+  "num_str": 40.1
+}
+{
+  "flow_published_at": "2023-07-12T14:27:25.889321-04:00",
+  "id": 5,
+  "int_and_str": 5,
+  "int_str": 50,
+  "num_and_str": 5.1,
+  "num_str": 50.1
+}
+{
+  "applied": {
+    "actionDescription": "\nCREATE TABLE IF NOT EXISTS flow_materializations_v2 (\n\tmaterialization VARCHAR(4096),\n\tversion VARCHAR(4096),\n\tspec VARBYTE(1024000)\n);\n\nCOMMENT ON TABLE flow_materializations_v2 IS 'This table is the source of truth for all materializations into this system.';\nCOMMENT ON COLUMN flow_materializations_v2.materialization IS 'The name of the materialization.';\nCOMMENT ON COLUMN flow_materializations_v2.version IS 'Version of the materialization.';\nCOMMENT ON COLUMN flow_materializations_v2.spec IS 'Specification of the materialization, encoded as base64 protobuf.';\n\n\nCREATE TABLE IF NOT EXISTS flow_checkpoints_v1 (\n\tmaterialization VARCHAR(4096),\n\tkey_begin BIGINT,\n\tkey_end BIGINT,\n\tfence BIGINT,\n\tcheckpoint VARBYTE(1024000)\n);\n\nCOMMENT ON TABLE flow_checkpoints_v1 IS 'This table holds Flow processing checkpoints used for exactly-once processing of materializations';\nCOMMENT ON COLUMN flow_checkpoints_v1.materialization IS 'The name of the materialization.';\nCOMMENT ON COLUMN flow_checkpoints_v1.key_begin IS 'The inclusive lower-bound key hash covered by this checkpoint.';\nCOMMENT ON COLUMN flow_checkpoints_v1.key_end IS 'The inclusive upper-bound key hash covered by this checkpoint.';\nCOMMENT ON COLUMN flow_checkpoints_v1.fence IS 'This nonce is used to uniquely identify unique process assignments of a shard and prevent them from conflicting.';\nCOMMENT ON COLUMN flow_checkpoints_v1.checkpoint IS 'Checkpoint of the Flow consumer shard, encoded as base64 protobuf.';\n\nUPDATE flow_materializations_v2 SET version = 'test', spec = '(a-base64-encoded-value)' WHERE materialization = 'tests/materialize-redshift/materialize';"
+  }
+}
+{
+  "opened": {
+    "runtimeCheckpoint": {
+      "sources": {
+        "a/read/journal;suffix": {
+          "readThrough": "1"
+        }
+      }
+    }
+  }
+}
+{
+  "acknowledged": {}
+}


### PR DESCRIPTION
**Description:**

There is a possible deadlock if the uploader goroutine exits with an error in the midst of calls to `encodeRow`. In this case the pipe will never be read to the call to write to the pipe via `(*stagedFile).encoder.Encode` will block indefinitely.

The fix is to close the write end of the pipe on error from the uploader. There is also some handling for routing the error from the uploader goroutine to the call to `encodeRow` so that it can be surfaced as the connector's exit error.

Additionally I have fixed/updated the end-to-end tests, which were used to test this change.

**Workflow steps:**

Run the materialization with the chance of deadlock. This could happen, for example, if the S3 bucket were removed in the middle of a transaction, or made unavailable for some other reason.

**Documentation links affected:**

N/A

**Notes for reviewers:**

(anything that might help someone review this PR)

