### PR TITLE
materialize-redshift: default to VARCHAR(MAX) when no MaxLength annotation is available

### DIFF
--- a/materialize-redshift/.snapshots/TestSQLGeneration
+++ b/materialize-redshift/.snapshots/TestSQLGeneration
@@ -26,7 +26,7 @@ COMMENT ON COLUMN "a-schema".target_table.flow_document IS 'auto-generated proje
 
 --- Begin "Delta Updates" createTargetTable ---
 CREATE TABLE IF NOT EXISTS "Delta Updates" (
-	theKey VARCHAR(4096),
+	theKey VARCHAR(MAX),
 	aValue BIGINT
 );
 
@@ -45,7 +45,7 @@ CREATE TEMPORARY TABLE flow_temp_table_0 (
 
 --- Begin "Delta Updates" createLoadTable ---
 CREATE TEMPORARY TABLE flow_temp_table_1 (
-	theKey VARCHAR(4096)
+	theKey VARCHAR(MAX)
 );
 --- End "Delta Updates" createLoadTable ---
 

--- a/materialize-sql/type_mapping.go
+++ b/materialize-sql/type_mapping.go
@@ -328,13 +328,12 @@ func (m ProjectionTypeMapper) MapType(p *Projection) (MappedType, error) {
 	}
 }
 
-// MaxLengthMapper checks if the projection is a STRING type Projection having a MaxLength.
-// If it is, it invokes WithLength with the MaxLength to map the Projection and returns
-// the result. Otherwise, it invokes and returns Fallback.
+// MaxLengthMapper checks if the projection is a STRING type Projection having a MaxLength. If it
+// is, it invokes WithLength to map the Projection and returns the result. Otherwise, it invokes and
+// returns Fallback.
 type MaxLengthMapper struct {
-	WithLength           TypeMapper
-	WithLengthFmtPattern string
-	Fallback             TypeMapper
+	WithLength TypeMapper
+	Fallback   TypeMapper
 }
 
 var _ TypeMapper = MaxLengthMapper{}
@@ -347,7 +346,6 @@ func (m MaxLengthMapper) MapType(p *Projection) (MappedType, error) {
 	} else if mapped, err := m.WithLength.MapType(p); err != nil {
 		return MappedType{}, err
 	} else {
-		mapped.DDL = fmt.Sprintf(mapped.DDL, p.Inference.String_.MaxLength)
 		return mapped, nil
 	}
 }


### PR DESCRIPTION
**Description:**

It is not uncommon for collections to have long strings, and it is currently not common at all for collection schemas to have `maxLength` annotations.

Furthermore, it is not currently practical to expect users to set `maxLength` annotations on schemas discovered from SQL captures etc. as these annotations will be overwritten. This makes materializing long string fields from SQL captures tenuous at best.

The change here is an inverted treatment of redshift string columns: We will create them with the maximum length by default, but respect `maxLength` annotations if they are there for possibly tightening the column limits.

It is possible to alter Redshift columns after the fact to have a shorter length for `VARCHAR`, so excessively long string columns can easily be adjusted after the fact.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

The `materialize-redshift` documentation will need to be updated with this change.

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/810)
<!-- Reviewable:end -->
