### PR TITLE
source-mysql: Handle zero timestamps with fractional seconds

### DIFF
--- a/source-mysql/datatype_test.go
+++ b/source-mysql/datatype_test.go
@@ -101,6 +101,7 @@ func TestDatatypes(t *testing.T) {
 		{ColumnType: "datetime", ExpectType: `{"type":["string","null"],"format":"date-time"}`, InputValue: "1992-01-01 12:34:56", ExpectValue: `"1992-01-01T18:34:56Z"`},
 		// Handle the special "zero" value datetime by converting it to a valid sentinel RFC3339 datetime.
 		{ColumnType: "datetime", ExpectType: `{"type":["string","null"],"format":"date-time"}`, InputValue: "0000-00-00 00:00:00", ExpectValue: `"0001-01-01T00:00:00Z"`},
+		{ColumnType: "datetime(6)", ExpectType: `{"type":["string","null"],"format":"date-time"}`, InputValue: "0000-00-00 00:00:00", ExpectValue: `"0001-01-01T00:00:00Z"`},
 
 		// The TIMESTAMP column type will be converted by MySQL from the local time zone (which as mentioned
 		// above was set to 'America/Chicago' and acts as UTC-5 or UTC-6 depending on the date) to UTC for

--- a/source-mysql/discovery.go
+++ b/source-mysql/discovery.go
@@ -211,7 +211,10 @@ func (db *mysqlDatabase) translateRecordField(columnType interface{}, val interf
 				// it could it wouldn't be a valid RFC3339 timestamp. Since this is the
 				// "your data is junk" sentinel value we replace it with a similar one
 				// that actually is a valid RFC3339 timestamp.
-				if string(val) == "0000-00-00 00:00:00" {
+				//
+				// MySQL doesn't allow timestamp values with a zero YYYY-MM-DD to have
+				// nonzero fractional seconds, so a simple prefix match can be used.
+				if strings.HasPrefix(string(val), "0000-00-00 00:00:00") {
 					return "0001-01-01T00:00:00Z", nil
 				}
 
@@ -224,7 +227,7 @@ func (db *mysqlDatabase) translateRecordField(columnType interface{}, val interf
 				// See note above in the "timestamp" case about replacing this default sentinel
 				// value with a valid RFC3339 timestamp sentinel value. The same reasoning applies
 				// here for "datetime".
-				if string(val) == "0000-00-00 00:00:00" {
+				if strings.HasPrefix(string(val), "0000-00-00 00:00:00") {
 					return "0001-01-01T00:00:00Z", nil
 				}
 				if db.datetimeLocation == nil {


### PR DESCRIPTION
**Description:**

These values occur if you have a column with a type such as `timestamp(6)` and insert the all-zeroes time into them.

We can handle this by just doing a prefix match for the zero `YYYY-MM-DD HH:mm:SS` part, since MySQL won't allow you to insert a value like `0000-00-00 00:00:00.123456` anyway -- the zero month/day are only allowed if it's the zero timestamp, so no information is lost by just doing a simple prefix match and replacing with a constant `0001-01-01T00:00:00Z` instead.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/811)
<!-- Reviewable:end -->
