### PR TITLE
source-mysql: Disable database version prerequisite

### DIFF
--- a/source-mysql/prerequisites.go
+++ b/source-mysql/prerequisites.go
@@ -16,11 +16,10 @@ import (
 func (db *mysqlDatabase) SetupPrerequisites(ctx context.Context) []error {
 	var errs []error
 
+	// Our version checking may have been overly conservative, so let's err in the
+	// other direction for a while and disengage the check entirely.
 	if err := db.prerequisiteVersion(ctx); err != nil {
-		// Return early if the database version is incompatible with the connector since additional
-		// errors will be of minimal use.
-		errs = append(errs, err)
-		return errs
+		logrus.WithField("err", err).Warn("database version may be insufficient")
 	}
 
 	for _, prereq := range []func(ctx context.Context) error{


### PR DESCRIPTION
**Description:**

As requested in https://github.com/estuary/connectors/issues/797 this commit disables the "minimum supported version" check until we have a better idea what database versions we can actually support capturing from.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/812)
<!-- Reviewable:end -->
