### PR TITLE
source-mysql: Additional logging on binlog expiry check

### DIFF
--- a/source-mysql/prerequisites.go
+++ b/source-mysql/prerequisites.go
@@ -122,11 +122,13 @@ func (db *mysqlDatabase) prerequisiteBinlogExpiry(ctx context.Context) error {
 	// This check can be manually disabled by the user. It's dangerous, but
 	// might be desired in some edge cases.
 	if db.config.Advanced.SkipBinlogRetentionCheck {
+		logrus.Info("skipping binlog retention sanity check")
 		return nil
 	}
 
 	// Sanity-check binlog retention and error out if it's insufficiently long.
 	expiryTime, err := getBinlogExpiry(db.conn)
+	logrus.WithField("expiry", expiryTime.String()).Debug("queried binlog expiry time")
 	if err != nil {
 		return fmt.Errorf("error querying binlog expiry time: %w", err)
 	}


### PR DESCRIPTION
Adds a couple of log messages. These should be useful in general, but I'm adding them right now in order to debug a capture for which the sanity check appears to have not worked as it should.

I believe this change should be very safe, so I intend to YOLO merge it in order to get results that much faster.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/816)
<!-- Reviewable:end -->
