### PR TITLE
source-mysql: Handle RDS binlog configuration query errors

### DIFF
--- a/source-mysql/prerequisites.go
+++ b/source-mysql/prerequisites.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -232,9 +233,15 @@ func getBinlogExpiry(conn *client.Conn) (time.Duration, error) {
 	// When running on Amazon RDS MySQL there's an RDS-specific configuration
 	// for binlog retention, so that takes precedence if it exists.
 	rdsRetentionHours, err := queryNumericVariable(conn, `SELECT name, value FROM mysql.rds_configuration WHERE name = 'binlog retention hours';`)
-	logrus.WithFields(logrus.Fields{"hours": rdsRetentionHours, "err": err}).Debug("queried RDS-specific binlog retention setting")
-	if err == nil {
-		return time.Duration(rdsRetentionHours) * time.Hour, nil
+	logrus.WithFields(logrus.Fields{"hours": rdsRetentionHours, "err": fmt.Sprintf("%#v", err)}).Debug("queried RDS-specific binlog retention setting")
+	var merr = new(mysql.MyError)
+	if err == nil || !errors.As(err, &merr) || merr.Code != mysql.ER_NO_SUCH_TABLE {
+		// On RDS either the error will be nil *or* it will be some sort of permission-denied
+		// error. In either case we want to return the result and the error.
+		//
+		// On vanilla MySQL the error should always be "no such table", so in that case we
+		// will continue on to check the vanilla MySQL config variables.
+		return time.Duration(rdsRetentionHours) * time.Hour, err
 	}
 
 	// The newer 'binlog_expire_logs_seconds' variable takes priority if it exists and is nonzero.


### PR DESCRIPTION
**Description:**

Previously we assumed that an error when querying the table `mysql.rds_configuration` must be "No Such Table" and would proceed to query the vanilla MySQL config variables next.

But apparently it's possible for the capture user to simply not have permission to access `rds_configuration` on an RDS MySQL database. In that case our binlog expiry sanity check will misbehave and basically fail-open. This is bad for the user, since we need to ensure that binlog segments won't be instantly deleted in the event of an error.

(Note that they can still enable the 'skip binlog retention sanity check' config option in lieu of granting permissions to this table, if that's a problem)

**Workflow steps:**

After this change, users running RDS MySQL with a setup where the `flow_capture` user is not authorized to read the `mysql.rds_configuration` table will be rejected at capture validation time, rather than being permitted to create a capture when it's quite possible that their binlog retention time is set to zero.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/818)
<!-- Reviewable:end -->
