### PR TITLE
source-mysql: Always include `""` as possible ENUM value

### DIFF
--- a/source-mysql/datatype_test.go
+++ b/source-mysql/datatype_test.go
@@ -79,9 +79,9 @@ func TestDatatypes(t *testing.T) {
 		{ColumnType: "mediumblob", ExpectType: `{"type":["string","null"],"contentEncoding":"base64"}`, InputValue: []byte{0x12, 0x34, 0x56, 0x78}, ExpectValue: `"EjRWeA=="`},
 		{ColumnType: "longblob", ExpectType: `{"type":["string","null"],"contentEncoding":"base64"}`, InputValue: []byte{0x12, 0x34, 0x56, 0x78}, ExpectValue: `"EjRWeA=="`},
 
-		{ColumnType: `enum('sm', 'med', 'lg')`, ExpectType: `{"type":["string","null"],"enum":["sm","med","lg",null]}`, InputValue: nil, ExpectValue: `null`},
-		{ColumnType: `enum('sm', 'med', 'lg') not null`, ExpectType: `{"type":"string","enum":["sm","med","lg"]}`, InputValue: "sm", ExpectValue: `"sm"`},
-		{ColumnType: `enum('s,m', 'med', '\'lg\'')`, ExpectType: `{"type":["string","null"],"enum":["s,m","med","'lg'",null]}`, InputValue: `'lg'`, ExpectValue: `"'lg'"`},
+		{ColumnType: `enum('sm', 'med', 'lg')`, ExpectType: `{"type":["string","null"],"enum":["sm","med","lg","",null]}`, InputValue: nil, ExpectValue: `null`},
+		{ColumnType: `enum('sm', 'med', 'lg') not null`, ExpectType: `{"type":"string","enum":["sm","med","lg",""]}`, InputValue: "sm", ExpectValue: `"sm"`},
+		{ColumnType: `enum('s,m', 'med', '\'lg\'')`, ExpectType: `{"type":["string","null"],"enum":["s,m","med","'lg'","",null]}`, InputValue: `'lg'`, ExpectValue: `"'lg'"`},
 
 		{ColumnType: "set('a', 'b', 'c')", ExpectType: `{"type":["string","null"]}`, InputValue: "b", ExpectValue: `"b"`},
 		{ColumnType: "set('a', 'b', 'c')", ExpectType: `{"type":["string","null"]}`, InputValue: "a,c", ExpectValue: `"a,c"`},

--- a/source-mysql/discovery.go
+++ b/source-mysql/discovery.go
@@ -264,7 +264,7 @@ func getColumns(ctx context.Context, conn *client.Conn) ([]sqlcapture.ColumnInfo
 		var typeName = string(row[5].AsString())
 		var dataType interface{}
 		if typeName == "enum" {
-			dataType = &mysqlColumnType{Type: "enum", EnumValues: parseEnumValues(string(row[6].AsString()))}
+			dataType = &mysqlColumnType{Type: "enum", EnumValues: append(parseEnumValues(string(row[6].AsString())), "")}
 		} else if typeName == "set" {
 			dataType = &mysqlColumnType{Type: "set", EnumValues: parseEnumValues(string(row[6].AsString()))}
 		} else {


### PR DESCRIPTION
**Description:**

Apparently MySQL will never actually guarantee that your ENUM column doesn't contain illegal values. Note that this is distinct from nullability, an `ENUM(...) NOT NULL` column can still contain error values which will be represented by the empty string when you retrieve them.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/821)
<!-- Reviewable:end -->
