### PR TITLE
source-firestore: Lower backfill chunk size to 1024->256

### DIFF
--- a/source-firestore/pull.go
+++ b/source-firestore/pull.go
@@ -41,7 +41,7 @@ const retryInterval = 300 * time.Second
 const progressLogInterval = 10000
 
 const (
-	backfillChunkSize   = 1024
+	backfillChunkSize   = 256
 	concurrentBackfills = 2
 )
 


### PR DESCRIPTION
**Description:**

This makes it 4x harder for a collection of massive documents to make the connector get OOM killed. Though it can always still happen so long as we're using `(*DocumentIterator).GetAll()` so we might want to reconsider that in the future.

Going to YOLO merge this because it's just tweaking an integer constant and I'm doing a bit of debugging-in-production here.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/827)
<!-- Reviewable:end -->
