### PR TITLE
materialize-redshift: minimize concurrency for upload workers

### DIFF
--- a/materialize-redshift/driver.go
+++ b/materialize-redshift/driver.go
@@ -547,8 +547,9 @@ func (d *transactor) Load(it *pm.LoadIterator, loaded func(int, json.RawMessage)
 			return fmt.Errorf("converting Load key: %w", err)
 		}
 
-		b.loadFile.encodeRow(converted)
-
+		if err := b.loadFile.encodeRow(converted); err != nil {
+			return fmt.Errorf("encoding row for load: %w", err)
+		}
 	}
 	if it.Err() != nil {
 		return it.Err()
@@ -708,8 +709,9 @@ func (d *transactor) Store(it *pm.StoreIterator) (pm.StartCommitFunc, error) {
 			}
 		}
 
-		b.storeFile.encodeRow(converted)
-
+		if err := b.storeFile.encodeRow(converted); err != nil {
+			return nil, fmt.Errorf("encoding row for store: %w", err)
+		}
 	}
 	if it.Err() != nil {
 		return nil, it.Err()

--- a/materialize-redshift/staged_file.go
+++ b/materialize-redshift/staged_file.go
@@ -45,9 +45,11 @@ type stagedFile struct {
 
 func newStagedFile(client *s3.Client, bucket string, bucketPath string, cols []*sql.Column) *stagedFile {
 	return &stagedFile{
-		cols:       cols,
-		client:     client,
-		uploader:   manager.NewUploader(client),
+		cols:   cols,
+		client: client,
+		uploader: manager.NewUploader(client, func(u *manager.Uploader) {
+			u.Concurrency = 1
+		}),
 		bucket:     bucket,
 		bucketPath: bucketPath,
 	}


### PR DESCRIPTION
**Description:**

This configures the S3 uploader to use a single goroutine for uploading a file in attempts to minimize memory usage of the connector.

We already have a fairly high degree of concurrency for uploads just from the fact that many materializations have more than 1 binding - sometimes many more. And each binding actually gets a separate upload thread for both loads and stores.

I am not totally confident that for the kinds of uploads we are doing (with an `io.Reader` and not an `io.ReadSeeker`) that multiple goroutines are used for uploads, but there is some sparse documentation suggesting that memory usage is directly related to the concurrency factor so this seems like it is worth a try.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

N/A

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/835)
<!-- Reviewable:end -->
