### PR TITLE
source-mysql: Ignore all 'FLUSH' query events in replication

### DIFF
--- a/source-mysql/replication.go
+++ b/source-mysql/replication.go
@@ -466,10 +466,8 @@ func (rs *mysqlReplicationStream) handleQuery(schema, query string) error {
 	logrus.WithField("stmt", fmt.Sprintf("%#v", stmt)).Debug("parsed query")
 
 	switch stmt := stmt.(type) {
-	case *sqlparser.CreateDatabase:
-	case *sqlparser.CreateTable:
-	case *sqlparser.Savepoint:
-		logrus.WithField("query", query).Trace("ignoring benign query")
+	case *sqlparser.CreateDatabase, *sqlparser.CreateTable, *sqlparser.Savepoint, *sqlparser.Flush:
+		logrus.WithField("query", query).Debug("ignoring benign query")
 	case *sqlparser.AlterTable:
 		if streamID := resolveTableName(schema, stmt.Table); rs.tableActive(streamID) {
 			logrus.WithFields(logrus.Fields{


### PR DESCRIPTION
**Description:**

All `FLUSH FOO` queries should be entirely irrelevant to our capture connector.

Also fixes the logging of these benign queries so that they'll be visible at DEBUG level if we need to see them.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/842)
<!-- Reviewable:end -->
