### PR TITLE
materialize-sql: improve error message when a collection key is optional

### DIFF
--- a/materialize-sql/validate.go
+++ b/materialize-sql/validate.go
@@ -72,7 +72,7 @@ func ValidateNewSQLProjections(resource Resource, proposed *pf.CollectionSpec) (
 			}
 		case pm.Response_Validated_Constraint_LOCATION_REQUIRED:
 			if projection.Inference.Exists != pf.Inference_MUST {
-				return nil, fmt.Errorf("The materialization must include a projection of location '%s', but no such projection is included. It is required because: %s", projection.Field, constraint.Reason)
+				return nil, fmt.Errorf("Required location '%s' is marked as optional in collection schema. It is required because: %s", projection.Field, constraint.Reason)
 			}
 		}
 	}


### PR DESCRIPTION
**Description:**

SQL materializations currently have the constraint that all components of the collection key be marked as required in the collection schema. If this is not the case, we should report as such in the error message returned upon publication for the locations that are part of the key. Previously we had a somewhat confusing error message in this case that seemed to indicate that the locations weren't in the schema at all.

In the near future we will make optional collection keys able to be materialized by SQL materializations if they have a default value set. But for now this error message should help clarify immediate uses where the collection schema is imcompatible.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/843)
<!-- Reviewable:end -->
