### PR TITLE
materialize-sql: handle strings formatted as integers with decimals of 0

### DIFF
--- a/materialize-snowflake/sqlgen.go
+++ b/materialize-snowflake/sqlgen.go
@@ -36,6 +36,14 @@ var jsonConverter sql.ElementConverter = func(te tuple.TupleElement) (interface{
 
 // Snowflake INTEGER values support up to 38 digits, which is more than an int64.
 func strToSfInt(str string) (interface{}, error) {
+	// Strings ending in a 0 decimal part like "1.0" or "3.00" are considered valid as integers per
+	// JSON specification so we must handle this possibility here. Anything after the decimal is
+	// discarded on the assumption that Flow has validated the data and verified that the decimal
+	// component is all 0's.
+	if idx := strings.Index(str, "."); idx != -1 {
+		str = str[:idx]
+	}
+
 	var i big.Int
 	out, ok := i.SetString(str, 10)
 	if !ok {

--- a/materialize-snowflake/sqlgen_test.go
+++ b/materialize-snowflake/sqlgen_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"math/big"
 	"os"
 	"strings"
 	"testing"
@@ -95,4 +96,38 @@ func TestSQLGeneration(t *testing.T) {
 	snap.WriteString("--- End Fence Update ---\n")
 
 	cupaloy.SnapshotT(t, snap.String())
+}
+
+func TestStrToSfInt(t *testing.T) {
+	for _, tt := range []struct {
+		input string
+		want  string
+	}{
+		{
+			input: "11.0",
+			want:  "11",
+		},
+		{
+			input: "11.0000000",
+			want:  "11",
+		},
+		{
+			input: "1",
+			want:  "1",
+		},
+		{
+			input: "-3",
+			want:  "-3",
+		},
+		{
+			input: "-14.0",
+			want:  "-14",
+		},
+	} {
+		t.Run(tt.input, func(t *testing.T) {
+			got, err := strToSfInt(tt.input)
+			require.NoError(t, err)
+			require.Equal(t, tt.want, got.(*big.Int).String())
+		})
+	}
 }

--- a/materialize-sql/type_mapping_test.go
+++ b/materialize-sql/type_mapping_test.go
@@ -192,3 +192,37 @@ func TestAsFlatType(t *testing.T) {
 		})
 	}
 }
+
+func TestStdStrToInt(t *testing.T) {
+	for _, tt := range []struct {
+		input string
+		want  int64
+	}{
+		{
+			input: "11.0",
+			want:  11,
+		},
+		{
+			input: "11.0000000",
+			want:  11,
+		},
+		{
+			input: "1",
+			want:  1,
+		},
+		{
+			input: "-3",
+			want:  -3,
+		},
+		{
+			input: "-14.0",
+			want:  -14,
+		},
+	} {
+		t.Run(tt.input, func(t *testing.T) {
+			got, err := StdStrToInt()(tt.input)
+			require.NoError(t, err)
+			require.Equal(t, tt.want, got.(int64))
+		})
+	}
+}


### PR DESCRIPTION
**Description:**

Strings ending in a 0 decimal part like "1.0" or "3.00" are considered valid as integers per JSON specification (see https://github.com/estuary/flow/pull/1069) so we must handle that possibility in SQL materializations that convert these string values to integers. Anything after the decimal is discarded on the assumption that Flow has validated the data and verified that the decimal component is all 0's.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/844)
<!-- Reviewable:end -->
