### PR TITLE
materialize-sql: allow materializing nullable collection keys

### DIFF
--- a/materialize-sql/endpoint.go
+++ b/materialize-sql/endpoint.go
@@ -199,7 +199,7 @@ func resolveResourceToExistingBinding(
 	} else if loadedBinding != nil {
 		constraints = ValidateMatchesExisting(resource, loadedBinding, collection)
 	} else {
-		constraints, err = ValidateNewSQLProjections(resource, collection)
+		constraints = ValidateNewSQLProjections(resource, collection)
 	}
 
 	return


### PR DESCRIPTION
**Description:**

The schema inference system currently indicates that all collection fields are nullable, including collection keys. SQL materializations have been enforcing that collection key fields be not-nullable, which results in additional complexity when trying to set up a SQL materialization for a collection with an inferred schema.

This change allows SQL materializations to validate even if the collection keys are nullable. Practically speaking, we do not expect the connector to see a null value for a key, as the minimal write schemas for inferred collections are generated with non-nullable keys.

In the future we would like to enforce this in a more refined way, by allowing nullable keys only if they have a default value. This would ensure that SQL materializations would not see a null value for a key since the default value would always be present.

This was tested manually be creating a materialization from a collection with non-required key fields using the materializations for postgres, bigquery, snowflake, and redshift.

**Workflow steps:**

Materialize collections with keys that are nullable, such as those generated from schema inference. Actually trying to materialize a null value for a key will result in a runtime error, dependent on the endpoint.

**Documentation links affected:**

N/A

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/846)
<!-- Reviewable:end -->
