### PR TITLE
materialize-bigquery: verify that credentials are valid JSON

### DIFF
--- a/materialize-bigquery/bigquery_test.go
+++ b/materialize-bigquery/bigquery_test.go
@@ -157,14 +157,6 @@ func TestPrereqs(t *testing.T) {
 			want: nil,
 		},
 		{
-			name: "can't parse credentials",
-			cfg: func(cfg config) *config {
-				cfg.CredentialsJSON = cfg.CredentialsJSON + "wrong"
-				return &cfg
-			},
-			want: []error{fmt.Errorf("cannot parse JSON credentials")},
-		},
-		{
 			name: "bucket doesn't exist",
 			cfg: func(cfg config) *config {
 				cfg.Bucket = nonExistentBucket
@@ -176,8 +168,13 @@ func TestPrereqs(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			cfg := tt.cfg(cfg)
+			client, err := cfg.client(context.Background())
+			require.NoError(t, err)
+
 			require.Equal(t, tt.want, prereqs(context.Background(), &sql.Endpoint{
-				Config: tt.cfg(cfg),
+				Config: cfg,
+				Client: client,
 				Tenant: "tenant",
 			}).Unwrap())
 		})


### PR DESCRIPTION
**Description:**

Verify that the configured credentials are valid JSON, to provide a more instructive error message than `bigquery.NewClient` provides if given credentials that are not formatted as JSON.

Closes https://github.com/estuary/connectors/issues/822

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/847)
<!-- Reviewable:end -->
