### PR TITLE
materialize-pinecone: verify that embeddings model exists during validate

### DIFF
--- a/materialize-pinecone/driver.go
+++ b/materialize-pinecone/driver.go
@@ -163,8 +163,8 @@ func (d driver) Validate(ctx context.Context, req *pm.Request_Validate) (*pm.Res
 			textEmbeddingAda002VectorLength,
 			textEmbeddingAda002,
 		)
-	} else if err := cfg.openAiClient().Ping(ctx); err != nil {
-		return nil, fmt.Errorf("connecting to OpenAI: %w", err)
+	} else if err := cfg.openAiClient().VerifyModelExists(ctx); err != nil {
+		return nil, err
 	}
 
 	// Log a warning message if the 'flow_document' metadata field has not been excluded from


### PR DESCRIPTION
**Description:**

Users may specify their own embeddings model to use, and currently if it does not exist the connector will fail when it first runs and tries to create an embedding for a document.

This change allows the connector to validate that the embedding model is one recognized by OpenAI.

Closes https://github.com/estuary/connectors/issues/801

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/848)
<!-- Reviewable:end -->
