### PR TITLE
connectors: run pprof for go connectors

### DIFF
--- a/materialize-boilerplate/boilerplate.go
+++ b/materialize-boilerplate/boilerplate.go
@@ -13,6 +13,9 @@ import (
 	"os/signal"
 	"syscall"
 
+	"net/http"
+	_ "net/http/pprof"
+
 	cerrors "github.com/estuary/connectors/go/connector-errors"
 	pm "github.com/estuary/flow/go/protocols/materialize"
 	protoio "github.com/gogo/protobuf/io"
@@ -66,6 +69,13 @@ func RunMain(connector Connector) {
 	default:
 		log.WithField("codec", codec).Fatal("invalid FLOW_RUNTIME_CODEC (expected 'json', or 'proto')")
 	}
+
+	go func() {
+		log.WithField("port", 6060).Debug("starting pprof server")
+		if err := http.ListenAndServe("localhost:6060", nil); err != nil {
+			log.WithField("err", err).Info("pprof server shut down unexpectedly")
+		}
+	}()
 
 	var server = ConnectorServer{connector}
 

--- a/source-boilerplate/boilerplate.go
+++ b/source-boilerplate/boilerplate.go
@@ -15,6 +15,9 @@ import (
 	"sync"
 	"syscall"
 
+	"net/http"
+	_ "net/http/pprof"
+
 	cerrors "github.com/estuary/connectors/go/connector-errors"
 	pc "github.com/estuary/flow/go/protocols/capture"
 	pf "github.com/estuary/flow/go/protocols/flow"
@@ -71,6 +74,13 @@ func RunMain(connector Connector) {
 	default:
 		log.WithField("codec", codec).Fatal("invalid FLOW_RUNTIME_CODEC (expected 'json', or 'proto')")
 	}
+
+	go func() {
+		log.WithField("port", 6060).Debug("starting pprof server")
+		if err := http.ListenAndServe("localhost:6060", nil); err != nil {
+			log.WithField("err", err).Info("pprof server shut down unexpectedly")
+		}
+	}()
 
 	var server = ConnectorServer{connector}
 


### PR DESCRIPTION
**Description:**

Runs an HTTP server with `pprof` for go-based materialization and capture connectors.

It runs on port `6060` and is accessible via localhost. So to access the server, you need to be able to exec into the reactor pod running the connector container, and then exec into the container itself. The ergonomics of this are not great but it is still very useful to be able to access the endpoints for pprof.

For example, you can get a stack trace for the connector using a command like this:

```
kubectl exec -it <REACTOR_POD> -- docker exec -it <CONTAINER_NAME> curl http://localhost:9000/debug/pprof/goroutine?debug=1
```

As a next step, we can `EXPOSE` a port in the dockerfiles of these connectors, so that they can be accessed via connector networking. Prior to this we should make sure that the links for these endpoints are not shown to users in a confusing way when they create tasks or view the details of them, since the endpoints are not likely to be useful to users.

**Workflow steps:**

N/A - No user-facing impact

**Documentation links affected:**

N/A

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/850)
<!-- Reviewable:end -->
