### PR TITLE
materialize-bigquery: allow base64 credentials to validate if valid json

### DIFF
--- a/materialize-bigquery/bigquery.go
+++ b/materialize-bigquery/bigquery.go
@@ -51,7 +51,7 @@ func (c *config) Validate() error {
 	// Sanity check: Are the provided credentials valid JSON? A common error is to upload
 	// credentials that are not valid JSON, and the resulting error is fairly cryptic if fed
 	// directly to bigquery.NewClient.
-	if !json.Valid([]byte(c.CredentialsJSON)) {
+	if !json.Valid(decodeCredentials(c.CredentialsJSON)) {
 		return fmt.Errorf("service account credentials must be valid JSON, and the provided credentials were not")
 	}
 


### PR DESCRIPTION
**Description:**

Hotfix to https://github.com/estuary/connectors/pull/847 - we do have some legacy tasks that were setup with base64-encoded credentials, and already have a compatibility layer for these.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/852)
<!-- Reviewable:end -->
