### PR TITLE
materialize-bigquery: use FLOAT64 for format: number

### DIFF
--- a/materialize-bigquery/.snapshots/TestSQLGeneration
+++ b/materialize-bigquery/.snapshots/TestSQLGeneration
@@ -9,7 +9,7 @@ CREATE TABLE IF NOT EXISTS projectID.dataset.target_table (
 		integer INT64 NOT NULL,
 		string STRING NOT NULL,
 		`defAULT` STRING,
-		number BIGNUMERIC,
+		number FLOAT64,
 		person_place_ STRING,
 		source_name STRING,
 		`with-dash` STRING,

--- a/materialize-bigquery/sqlgen.go
+++ b/materialize-bigquery/sqlgen.go
@@ -63,7 +63,7 @@ var bqTypeMapper = sql.ProjectionTypeMapper{
 	sql.BINARY:  sql.NewStaticMapper("BYTES"),
 	sql.BOOLEAN: sql.NewStaticMapper("BOOL"),
 	sql.INTEGER: sql.NewStaticMapper("INT64", sql.WithElementConverter(sql.StdStrToInt())),
-	sql.NUMBER:  sql.NewStaticMapper("BIGNUMERIC", sql.WithElementConverter(sql.StdStrToFloat())),
+	sql.NUMBER:  sql.NewStaticMapper("FLOAT64", sql.WithElementConverter(sql.StdStrToFloat())),
 	sql.OBJECT:  sql.NewStaticMapper("STRING", sql.WithElementConverter(jsonConverter)),
 	sql.STRING: sql.StringTypeMapper{
 		Fallback: sql.NewStaticMapper("STRING"),


### PR DESCRIPTION
**Description:**

- FLOAT64 can represent a larger range of values than BIGNUMERIC, and although BIGNUMERIC is better suited to loss-less numerics, in case of `format: number`, they will be processed using a double representation, which means we don't gain anything from using BIGNUMERIC here.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/854)
<!-- Reviewable:end -->
