### PR TITLE
source-{mysql,postgres}: Ignore TRUNCATE events

### DIFF
--- a/source-mysql/replication.go
+++ b/source-mysql/replication.go
@@ -488,7 +488,7 @@ func (rs *mysqlReplicationStream) handleQuery(schema, query string) error {
 		}
 	case *sqlparser.TruncateTable:
 		if streamID := resolveTableName(schema, stmt.Table); rs.tableActive(streamID) {
-			return fmt.Errorf("unsupported operation (go.estuary.dev/eVVwet): %s", query)
+			logrus.WithField("table", streamID).Warn("ignoring TRUNCATE on active table")
 		}
 	case *sqlparser.RenameTable:
 		for _, pair := range stmt.TablePairs {

--- a/source-postgres/.snapshots/TestTruncatedTables-capture2
+++ b/source-postgres/.snapshots/TestTruncatedTables-capture2
@@ -1,0 +1,11 @@
+# ================================
+# Collection "acmeCo/test/test_truncatedtables_14026504": 3 Documents
+# ================================
+{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"truncatedtables_14026504","loc":[11111111,11111111,11111111],"txid":111111}},"data":"eleven","id":11}
+{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"truncatedtables_14026504","loc":[11111111,11111111,11111111],"txid":111111}},"data":"ten","id":10}
+{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"truncatedtables_14026504","loc":[11111111,11111111,11111111],"txid":111111}},"data":"twelve","id":12}
+# ================================
+# Final State Checkpoint
+# ================================
+{"cursor":"0/1111111","streams":{"test.truncatedtables_14026504":{"backfilled":3,"key_columns":["id"],"mode":"Active"}}}
+

--- a/source-postgres/.snapshots/TestTruncatedTables-capture2-fails
+++ b/source-postgres/.snapshots/TestTruncatedTables-capture2-fails
@@ -1,9 +1,0 @@
-# ================================
-# Final State Checkpoint
-# ================================
-{"cursor":"0/1111111","streams":{"test.truncatedtables_14026504":{"backfilled":3,"key_columns":["id"],"mode":"Active"}}}
-# ================================
-# Captures Terminated With Errors
-# ================================
-failed to relay messages: error decoding message: unsupported operation TRUNCATE on table "test.truncatedtables_14026504"
-

--- a/source-postgres/capture_test.go
+++ b/source-postgres/capture_test.go
@@ -215,7 +215,8 @@ func TestTruncatedTables(t *testing.T) {
 
 	// Truncating table A will cause the capture to fail though, as it should.
 	tb.Query(ctx, t, fmt.Sprintf("TRUNCATE TABLE %s;", tableA))
-	t.Run("capture2-fails", func(t *testing.T) { tests.VerifiedCapture(ctx, t, cs) })
+	tb.Insert(ctx, t, tableA, [][]interface{}{{10, "ten"}, {11, "eleven"}, {12, "twelve"}})
+	t.Run("capture2", func(t *testing.T) { tests.VerifiedCapture(ctx, t, cs) })
 }
 
 func TestTrickyColumnNames(t *testing.T) {

--- a/source-postgres/replication.go
+++ b/source-postgres/replication.go
@@ -346,7 +346,7 @@ func (s *replicationStream) decodeMessage(lsn pglogrepl.LSN, msg pglogrepl.Messa
 			var relation = s.relations[relID]
 			var streamID = sqlcapture.JoinStreamID(relation.Namespace, relation.RelationName)
 			if s.tableActive(streamID) {
-				return nil, fmt.Errorf("unsupported operation TRUNCATE on table %q", streamID)
+				logrus.WithField("table", streamID).Warn("ignoring TRUNCATE on active table")
 			}
 		}
 		return nil, nil


### PR DESCRIPTION
**Description:**

Table truncation is a bit of a weird middle ground, where its formal semantic meaning is something like "delete all existing rows" but in practice it's often used as a way of expunging old data simply to keep tables small.

In Postgres and MySQL, table truncation is reported as its own event type, distinct from row deletions. And we don't have any good way to convert a truncate event into a sequence of deletions because that would require keeping track of every single row in a table as part of our persistent capture state, which obviously doesn't scale.

So for now the best thing we can do within our data model is to ignore them. The good news is that this is often what the user would like to have happen, but we may need to revisit whether there's any way to model the truncation operation explicitly so that other behaviors could be implemented downstream.

One hacky option would be to add some sort of 'truncation epoch' counter/timestamp in the document metadata, so that after a table has been truncated future capture documents will at least be distinguishable from documents before that most recent truncation. But this requires further discussion and so for now we're doing the easy thing and ignoring them.

This fixes https://github.com/estuary/connectors/issues/830

**Workflow steps:**

Captures will no longer stall if an active table is truncated. Instead they will keep on going and ignore the truncation entirely, other than emitting a warning.

**Documentation links affected:**

We probably need to update the `source-mysql` and `source-postgres` docs.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/855)
<!-- Reviewable:end -->
