### PR TITLE
materialize-bigquery: use schema from table for edc file

### DIFF
--- a/materialize-bigquery/.snapshots/TestSQLGeneration
+++ b/materialize-bigquery/.snapshots/TestSQLGeneration
@@ -9,7 +9,7 @@ CREATE TABLE IF NOT EXISTS projectID.dataset.target_table (
 		integer INT64 NOT NULL,
 		string STRING NOT NULL,
 		`defAULT` STRING,
-		number BIGNUMERIC,
+		number FLOAT64,
 		person_place_ STRING,
 		source_name STRING,
 		`with-dash` STRING,

--- a/materialize-bigquery/bigquery.go
+++ b/materialize-bigquery/bigquery.go
@@ -78,13 +78,11 @@ func (c *config) client(ctx context.Context) (*client, error) {
 	if err != nil {
 		return nil, fmt.Errorf("creating bigquery client: %w", err)
 	}
-	log.WithField("projectID", billingProjectID).Info("bigquery client successfully created")
 
 	cloudStorageClient, err := storage.NewClient(ctx, clientOpts...)
 	if err != nil {
 		return nil, fmt.Errorf("creating cloud storage client: %w", err)
 	}
-	log.Info("cloud storage client successfully created")
 
 	return &client{
 		bigqueryClient:     bigqueryClient,

--- a/materialize-bigquery/sqlgen.go
+++ b/materialize-bigquery/sqlgen.go
@@ -45,6 +45,12 @@ func identifierSanitizer(delegate func(string) string) func(string) string {
 	}
 }
 
+// translateFlowIdentifier returns the column or table name that will be created for a given
+// collection name or field name, without any quoting applied.
+func translateFlowIdentifier(f string) string {
+	return identifierSanitizerRegexp.ReplaceAllString(f, "_")
+}
+
 var jsonConverter sql.ElementConverter = func(te tuple.TupleElement) (interface{}, error) {
 	switch ii := te.(type) {
 	case []byte:

--- a/materialize-bigquery/sqlgen.go
+++ b/materialize-bigquery/sqlgen.go
@@ -69,7 +69,7 @@ var bqTypeMapper = sql.ProjectionTypeMapper{
 	sql.BINARY:  sql.NewStaticMapper("BYTES"),
 	sql.BOOLEAN: sql.NewStaticMapper("BOOL"),
 	sql.INTEGER: sql.NewStaticMapper("INT64", sql.WithElementConverter(sql.StdStrToInt())),
-	sql.NUMBER:  sql.NewStaticMapper("BIGNUMERIC", sql.WithElementConverter(sql.StdStrToFloat())),
+	sql.NUMBER:  sql.NewStaticMapper("FLOAT64", sql.WithElementConverter(sql.StdStrToFloat())),
 	sql.OBJECT:  sql.NewStaticMapper("STRING", sql.WithElementConverter(jsonConverter)),
 	sql.STRING: sql.StringTypeMapper{
 		Fallback: sql.NewStaticMapper("STRING"),

--- a/tests/materialize/materialize-bigquery/cleanup.sh
+++ b/tests/materialize/materialize-bigquery/cleanup.sh
@@ -2,5 +2,16 @@
 
 set -e
 
-# TODO(johnny): This mostly works because deleting bindings also drops the tables.
-# But, this script should nuke it from orbit and ensure we get back to a clean state.
+function dropTable() {
+    go run ${TEST_DIR}/materialize-bigquery/fetch-data.go --delete "$1"
+}
+
+# Remove materialized tables.
+dropTable "simple"
+dropTable "duplicate_keys"
+dropTable "multiple_types"
+dropTable "formatted_strings"
+
+# Remove the persisted materialization spec & checkpoint for this test materialization so subsequent
+# runs start from scratch.
+go run ${TEST_DIR}/materialize-bigquery/fetch-data.go --delete-specs notable

--- a/tests/materialize/materialize-bigquery/snapshot.json
+++ b/tests/materialize/materialize-bigquery/snapshot.json
@@ -1,6 +1,6 @@
 {
   "applied": {
-    "actionDescription": "CREATE TABLE IF NOT EXISTS `estuary-theatre`.testing.flow_materializations_v2 (\n\t\tmaterialization STRING NOT NULL,\n\t\tversion STRING NOT NULL,\n\t\tspec STRING NOT NULL\n)\nCLUSTER BY materialization;\n\nCREATE TABLE IF NOT EXISTS `estuary-theatre`.testing.flow_checkpoints_v1 (\n\t\tmaterialization STRING NOT NULL,\n\t\tkey_begin INT64 NOT NULL,\n\t\tkey_end INT64 NOT NULL,\n\t\tfence INT64 NOT NULL,\n\t\tcheckpoint STRING NOT NULL\n)\nCLUSTER BY materialization, key_begin, key_end;\n\nCREATE TABLE IF NOT EXISTS `estuary-theatre`.testing.simple (\n\t\tid INT64 NOT NULL,\n\t\tcanary STRING NOT NULL,\n\t\tflow_published_at TIMESTAMP NOT NULL,\n\t\tflow_document STRING NOT NULL\n)\nCLUSTER BY id;\n\nCREATE TABLE IF NOT EXISTS `estuary-theatre`.testing.duplicate_keys (\n\t\tid INT64 NOT NULL,\n\t\tflow_published_at TIMESTAMP NOT NULL,\n\t\tint INT64,\n\t\tstr STRING NOT NULL,\n\t\tflow_document STRING NOT NULL\n)\nCLUSTER BY id;\n\nCREATE TABLE IF NOT EXISTS `estuary-theatre`.testing.multiple_types (\n\t\tid INT64 NOT NULL,\n\t\tarray_int STRING,\n\t\tbool_field BOOL,\n\t\tfloat_field BIGNUMERIC,\n\t\tflow_published_at TIMESTAMP NOT NULL,\n\t\tnested STRING,\n\t\tnullable_int INT64,\n\t\tstr_field STRING NOT NULL,\n\t\tflow_document STRING NOT NULL\n)\nCLUSTER BY id;\n\nCREATE TABLE IF NOT EXISTS `estuary-theatre`.testing.formatted_strings (\n\t\tid INT64 NOT NULL,\n\t\tflow_published_at TIMESTAMP NOT NULL,\n\t\tint_and_str INT64,\n\t\tint_str INT64,\n\t\tnum_and_str BIGNUMERIC,\n\t\tnum_str BIGNUMERIC,\n\t\tflow_document STRING NOT NULL\n)\nCLUSTER BY id;\n\nINSERT INTO `estuary-theatre`.testing.flow_materializations_v2 (version, spec, materialization) VALUES ('test', '(a-base64-encoded-value)', 'tests/materialize-bigquery/materialize');"
+    "actionDescription": "CREATE TABLE IF NOT EXISTS `estuary-theatre`.testing.flow_materializations_v2 (\n\t\tmaterialization STRING NOT NULL,\n\t\tversion STRING NOT NULL,\n\t\tspec STRING NOT NULL\n)\nCLUSTER BY materialization;\n\nCREATE TABLE IF NOT EXISTS `estuary-theatre`.testing.flow_checkpoints_v1 (\n\t\tmaterialization STRING NOT NULL,\n\t\tkey_begin INT64 NOT NULL,\n\t\tkey_end INT64 NOT NULL,\n\t\tfence INT64 NOT NULL,\n\t\tcheckpoint STRING NOT NULL\n)\nCLUSTER BY materialization, key_begin, key_end;\n\nCREATE TABLE IF NOT EXISTS `estuary-theatre`.testing.simple (\n\t\tid INT64 NOT NULL,\n\t\tcanary STRING NOT NULL,\n\t\tflow_published_at TIMESTAMP NOT NULL,\n\t\tflow_document STRING NOT NULL\n)\nCLUSTER BY id;\n\nCREATE TABLE IF NOT EXISTS `estuary-theatre`.testing.duplicate_keys (\n\t\tid INT64 NOT NULL,\n\t\tflow_published_at TIMESTAMP NOT NULL,\n\t\tint INT64,\n\t\tstr STRING NOT NULL,\n\t\tflow_document STRING NOT NULL\n)\nCLUSTER BY id;\n\nCREATE TABLE IF NOT EXISTS `estuary-theatre`.testing.multiple_types (\n\t\tid INT64 NOT NULL,\n\t\tarray_int STRING,\n\t\tbool_field BOOL,\n\t\tfloat_field FLOAT64,\n\t\tflow_published_at TIMESTAMP NOT NULL,\n\t\tnested STRING,\n\t\tnullable_int INT64,\n\t\tstr_field STRING NOT NULL,\n\t\tflow_document STRING NOT NULL\n)\nCLUSTER BY id;\n\nCREATE TABLE IF NOT EXISTS `estuary-theatre`.testing.formatted_strings (\n\t\tid INT64 NOT NULL,\n\t\tflow_published_at TIMESTAMP NOT NULL,\n\t\tint_and_str INT64,\n\t\tint_str INT64,\n\t\tnum_and_str FLOAT64,\n\t\tnum_str FLOAT64,\n\t\tflow_document STRING NOT NULL\n)\nCLUSTER BY id;\n\nINSERT INTO `estuary-theatre`.testing.flow_materializations_v2 (version, spec, materialization) VALUES ('test', '(a-base64-encoded-value)', 'tests/materialize-bigquery/materialize');"
   }
 }
 {
@@ -303,7 +303,7 @@
   1,
   "[11,12]",
   false,
-  "11/10",
+  1.1,
   "2023-07-12T18:23:50.55822Z",
   "{\"id\":\"i1\"}",
   null,
@@ -314,7 +314,7 @@
   2,
   "[21,22]",
   true,
-  "11/5",
+  2.2,
   "2023-07-12T18:24:09.67518Z",
   "{\"id\":\"i2\"}",
   2,
@@ -325,7 +325,7 @@
   3,
   "[31,32]",
   false,
-  "33/10",
+  3.3,
   "2023-07-12T18:24:19.384Z",
   "{\"id\":\"i3\"}",
   null,
@@ -336,7 +336,7 @@
   4,
   "[41,42]",
   true,
-  "22/5",
+  4.4,
   "2023-07-12T18:24:28.397025Z",
   "{\"id\":\"i4\"}",
   4,
@@ -347,7 +347,7 @@
   5,
   "[51,52]",
   false,
-  "11/2",
+  5.5,
   "2023-07-12T18:24:36.112031Z",
   "{\"id\":\"i5\"}",
   null,
@@ -358,7 +358,7 @@
   6,
   "[61,62]",
   true,
-  "3333/50",
+  66.66,
   "2023-07-12T18:28:27.194541Z",
   "{\"id\":\"i6\"}",
   6,
@@ -369,7 +369,7 @@
   7,
   "[71,72]",
   false,
-  "7777/100",
+  77.77,
   "2023-07-12T18:28:38.169062Z",
   "{\"id\":\"i7\"}",
   null,
@@ -380,7 +380,7 @@
   8,
   "[81,82]",
   true,
-  "2222/25",
+  88.88,
   "2023-07-12T18:28:48.465279Z",
   "{\"id\":\"i8\"}",
   8,
@@ -391,7 +391,7 @@
   9,
   "[91,92]",
   false,
-  "9999/100",
+  99.99,
   "2023-07-12T18:28:55.677252Z",
   "{\"id\":\"i9\"}",
   null,
@@ -402,7 +402,7 @@
   10,
   "[1,2]",
   true,
-  "1010101/1000",
+  1010.101,
   "2023-07-12T18:29:04.671352Z",
   "{\"id\":\"i10\"}",
   10,
@@ -414,8 +414,8 @@
   "2023-07-12T18:27:01.912219Z",
   1,
   10,
-  "11/10",
-  "101/10",
+  1.1,
+  10.1,
   "{\"_meta\":{\"uuid\":\"b1e13a0e-20e1-11ee-990b-ffd12dfcd47f\"},\"id\":1,\"int_and_str\":1,\"int_str\":\"10\",\"num_and_str\":1.1,\"num_str\":\"10.1\"}"
 ]
 [
@@ -423,8 +423,8 @@
   "2023-07-12T18:27:12.35461Z",
   2,
   20,
-  "21/10",
-  "201/10",
+  2.1,
+  20.1,
   "{\"_meta\":{\"uuid\":\"b81a9bf4-20e1-11ee-990b-ffd12dfcd47f\"},\"id\":2,\"int_and_str\":2,\"int_str\":\"20\",\"num_and_str\":2.1,\"num_str\":\"20.1\"}"
 ]
 [
@@ -432,8 +432,8 @@
   "2023-07-12T18:18:11.537199Z",
   3,
   30,
-  "31/10",
-  "301/10",
+  3.1,
+  30.1,
   "{\"_meta\":{\"uuid\":\"75c06bd6-20e0-11ee-990b-ffd12dfcd47f\"},\"id\":3,\"int_and_str\":3,\"int_str\":\"30\",\"num_and_str\":3.1,\"num_str\":\"30.1\"}"
 ]
 [
@@ -441,8 +441,8 @@
   "2023-07-12T18:18:48.441281Z",
   4,
   40,
-  "41/10",
-  "401/10",
+  4.1,
+  40.1,
   "{\"_meta\":{\"uuid\":\"8bbf898a-20e0-11ee-990b-ffd12dfcd47f\"},\"id\":4,\"int_and_str\":\"4\",\"int_str\":\"40\",\"num_and_str\":\"4.1\",\"num_str\":\"40.1\"}"
 ]
 [
@@ -450,8 +450,8 @@
   "2023-07-12T18:27:25.889321Z",
   5,
   50,
-  "51/10",
-  "501/10",
+  5.1,
+  50.1,
   "{\"_meta\":{\"uuid\":\"c02bd79a-20e1-11ee-990b-ffd12dfcd47f\"},\"id\":5,\"int_and_str\":\"5\",\"int_str\":\"50\",\"num_and_str\":\"5.1\",\"num_str\":\"50.1\"}"
 ]
 {

--- a/tests/materialize/materialize-bigquery/snapshot.json
+++ b/tests/materialize/materialize-bigquery/snapshot.json
@@ -1,6 +1,6 @@
 {
   "applied": {
-    "actionDescription": "CREATE TABLE IF NOT EXISTS `estuary-theatre`.testing.flow_materializations_v2 (\n\t\tmaterialization STRING NOT NULL,\n\t\tversion STRING NOT NULL,\n\t\tspec STRING NOT NULL\n)\nCLUSTER BY materialization;\n\nCREATE TABLE IF NOT EXISTS `estuary-theatre`.testing.flow_checkpoints_v1 (\n\t\tmaterialization STRING NOT NULL,\n\t\tkey_begin INT64 NOT NULL,\n\t\tkey_end INT64 NOT NULL,\n\t\tfence INT64 NOT NULL,\n\t\tcheckpoint STRING NOT NULL\n)\nCLUSTER BY materialization, key_begin, key_end;\n\nCREATE TABLE IF NOT EXISTS `estuary-theatre`.testing.simple (\n\t\tid INT64 NOT NULL,\n\t\tcanary STRING NOT NULL,\n\t\tflow_document STRING NOT NULL\n)\nCLUSTER BY id;\n\nCREATE TABLE IF NOT EXISTS `estuary-theatre`.testing.duplicate_keys (\n\t\tid INT64 NOT NULL,\n\t\tint INT64,\n\t\tstr STRING NOT NULL,\n\t\tflow_document STRING NOT NULL\n)\nCLUSTER BY id;\n\nCREATE TABLE IF NOT EXISTS `estuary-theatre`.testing.multiple_types (\n\t\tid INT64 NOT NULL,\n\t\tarray_int STRING,\n\t\tbool_field BOOL,\n\t\tfloat_field BIGNUMERIC,\n\t\tnested STRING,\n\t\tnullable_int INT64,\n\t\tstr_field STRING NOT NULL,\n\t\tflow_document STRING NOT NULL\n)\nCLUSTER BY id;\n\nCREATE TABLE IF NOT EXISTS `estuary-theatre`.testing.formatted_strings (\n\t\tid INT64 NOT NULL,\n\t\tint_and_str INT64,\n\t\tint_str INT64,\n\t\tnum_and_str BIGNUMERIC,\n\t\tnum_str BIGNUMERIC,\n\t\tflow_document STRING NOT NULL\n)\nCLUSTER BY id;\n\nINSERT INTO `estuary-theatre`.testing.flow_materializations_v2 (version, spec, materialization) VALUES ('test', '(a-base64-encoded-value)', 'tests/materialize-bigquery/materialize');"
+    "actionDescription": "CREATE TABLE IF NOT EXISTS `estuary-theatre`.testing.flow_materializations_v2 (\n\t\tmaterialization STRING NOT NULL,\n\t\tversion STRING NOT NULL,\n\t\tspec STRING NOT NULL\n)\nCLUSTER BY materialization;\n\nCREATE TABLE IF NOT EXISTS `estuary-theatre`.testing.flow_checkpoints_v1 (\n\t\tmaterialization STRING NOT NULL,\n\t\tkey_begin INT64 NOT NULL,\n\t\tkey_end INT64 NOT NULL,\n\t\tfence INT64 NOT NULL,\n\t\tcheckpoint STRING NOT NULL\n)\nCLUSTER BY materialization, key_begin, key_end;\n\nCREATE TABLE IF NOT EXISTS `estuary-theatre`.testing.simple (\n\t\tid INT64 NOT NULL,\n\t\tcanary STRING NOT NULL,\n\t\tflow_published_at TIMESTAMP NOT NULL,\n\t\tflow_document STRING NOT NULL\n)\nCLUSTER BY id;\n\nCREATE TABLE IF NOT EXISTS `estuary-theatre`.testing.duplicate_keys (\n\t\tid INT64 NOT NULL,\n\t\tflow_published_at TIMESTAMP NOT NULL,\n\t\tint INT64,\n\t\tstr STRING NOT NULL,\n\t\tflow_document STRING NOT NULL\n)\nCLUSTER BY id;\n\nCREATE TABLE IF NOT EXISTS `estuary-theatre`.testing.multiple_types (\n\t\tid INT64 NOT NULL,\n\t\tarray_int STRING,\n\t\tbool_field BOOL,\n\t\tfloat_field BIGNUMERIC,\n\t\tflow_published_at TIMESTAMP NOT NULL,\n\t\tnested STRING,\n\t\tnullable_int INT64,\n\t\tstr_field STRING NOT NULL,\n\t\tflow_document STRING NOT NULL\n)\nCLUSTER BY id;\n\nCREATE TABLE IF NOT EXISTS `estuary-theatre`.testing.formatted_strings (\n\t\tid INT64 NOT NULL,\n\t\tflow_published_at TIMESTAMP NOT NULL,\n\t\tint_and_str INT64,\n\t\tint_str INT64,\n\t\tnum_and_str BIGNUMERIC,\n\t\tnum_str BIGNUMERIC,\n\t\tflow_document STRING NOT NULL\n)\nCLUSTER BY id;\n\nINSERT INTO `estuary-theatre`.testing.flow_materializations_v2 (version, spec, materialization) VALUES ('test', '(a-base64-encoded-value)', 'tests/materialize-bigquery/materialize');"
   }
 }
 {
@@ -24,6 +24,9 @@
   "loaded": {
     "binding": 1,
     "doc": {
+      "_meta": {
+        "uuid": "75c06bd6-20e0-11ee-990b-ffd12dfcd47f"
+      },
       "id": 1,
       "int": 1,
       "str": "str 1"
@@ -34,6 +37,9 @@
   "loaded": {
     "binding": 1,
     "doc": {
+      "_meta": {
+        "uuid": "7dbe8ebc-20e0-11ee-990b-ffd12dfcd47f"
+      },
       "id": 2,
       "int": 2,
       "str": "str 2"
@@ -44,6 +50,9 @@
   "loaded": {
     "binding": 1,
     "doc": {
+      "_meta": {
+        "uuid": "8bbf898a-20e0-11ee-990b-ffd12dfcd47f"
+      },
       "id": 3,
       "int": 3,
       "str": "str 3"
@@ -54,6 +63,9 @@
   "loaded": {
     "binding": 1,
     "doc": {
+      "_meta": {
+        "uuid": "9b994ae4-20e0-11ee-990b-ffd12dfcd47f"
+      },
       "id": 4,
       "int": 4,
       "str": "str 4"
@@ -64,6 +76,9 @@
   "loaded": {
     "binding": 1,
     "doc": {
+      "_meta": {
+        "uuid": "bcef4bc6-20e0-11ee-990b-ffd12dfcd47f"
+      },
       "id": 5,
       "int": 5,
       "str": "str 5"
@@ -74,25 +89,9 @@
   "loaded": {
     "binding": 2,
     "doc": {
-      "array_int": [
-        1,
-        2
-      ],
-      "bool_field": true,
-      "float_field": 10.1,
-      "id": 10,
-      "nested": {
-        "id": "i10"
+      "_meta": {
+        "uuid": "5fc54530-20e1-11ee-990b-ffd12dfcd47f"
       },
-      "nullable_int": 10,
-      "str_field": "str10"
-    }
-  }
-}
-{
-  "loaded": {
-    "binding": 2,
-    "doc": {
       "array_int": [
         61,
         62
@@ -112,6 +111,9 @@
   "loaded": {
     "binding": 2,
     "doc": {
+      "_meta": {
+        "uuid": "64b39506-20e1-11ee-990b-ffd12dfcd47f"
+      },
       "array_int": [
         71,
         72
@@ -131,6 +133,9 @@
   "loaded": {
     "binding": 2,
     "doc": {
+      "_meta": {
+        "uuid": "6acb8444-20e1-11ee-990b-ffd12dfcd47f"
+      },
       "array_int": [
         81,
         82
@@ -150,6 +155,9 @@
   "loaded": {
     "binding": 2,
     "doc": {
+      "_meta": {
+        "uuid": "6ff68e0a-20e1-11ee-990b-ffd12dfcd47f"
+      },
       "array_int": [
         91,
         92
@@ -166,6 +174,28 @@
   }
 }
 {
+  "loaded": {
+    "binding": 2,
+    "doc": {
+      "_meta": {
+        "uuid": "75679e4c-20e1-11ee-990b-ffd12dfcd47f"
+      },
+      "array_int": [
+        1,
+        2
+      ],
+      "bool_field": true,
+      "float_field": 10.1,
+      "id": 10,
+      "nested": {
+        "id": "i10"
+      },
+      "nullable_int": 10,
+      "str_field": "str10"
+    }
+  }
+}
+{
   "flushed": {}
 }
 {
@@ -177,222 +207,252 @@
 [
   1,
   "amputation's",
-  "{\"canary\":\"amputation's\",\"id\":1}"
+  "2023-07-12T18:18:11.537199Z",
+  "{\"_meta\":{\"uuid\":\"75c06bd6-20e0-11ee-990b-ffd12dfcd47f\"},\"canary\":\"amputation's\",\"id\":1}"
 ]
 [
   2,
   "armament's",
-  "{\"canary\":\"armament's\",\"id\":2}"
+  "2023-07-12T18:18:24.946758Z",
+  "{\"_meta\":{\"uuid\":\"7dbe8ebc-20e0-11ee-990b-ffd12dfcd47f\"},\"canary\":\"armament's\",\"id\":2}"
 ]
 [
   3,
   "splatters",
-  "{\"canary\":\"splatters\",\"id\":3}"
+  "2023-07-12T18:18:48.441281Z",
+  "{\"_meta\":{\"uuid\":\"8bbf898a-20e0-11ee-990b-ffd12dfcd47f\"},\"canary\":\"splatters\",\"id\":3}"
 ]
 [
   4,
   "strengthen",
-  "{\"canary\":\"strengthen\",\"id\":4}"
+  "2023-07-12T18:19:15.034186Z",
+  "{\"_meta\":{\"uuid\":\"9b994ae4-20e0-11ee-990b-ffd12dfcd47f\"},\"canary\":\"strengthen\",\"id\":4}"
 ]
 [
   5,
   "Kringle's",
-  "{\"canary\":\"Kringle's\",\"id\":5}"
+  "2023-07-12T18:19:57.165604Z",
+  "{\"_meta\":{\"uuid\":\"b4b60968-20e0-11ee-990b-ffd12dfcd47f\"},\"canary\":\"Kringle's\",\"id\":5}"
 ]
 [
   6,
   "grosbeak's",
-  "{\"canary\":\"grosbeak's\",\"id\":6}"
+  "2023-07-12T18:20:10.962631Z",
+  "{\"_meta\":{\"uuid\":\"bcef4bc6-20e0-11ee-990b-ffd12dfcd47f\"},\"canary\":\"grosbeak's\",\"id\":6}"
 ]
 [
   7,
   "pieced",
-  "{\"canary\":\"pieced\",\"id\":7}"
+  "2023-07-12T18:22:35.841647Z",
+  "{\"_meta\":{\"uuid\":\"134a1456-20e1-11ee-990b-ffd12dfcd47f\"},\"canary\":\"pieced\",\"id\":7}"
 ]
 [
   8,
   "roaches",
-  "{\"canary\":\"roaches\",\"id\":8}"
+  "2023-07-12T18:22:49.755893Z",
+  "{\"_meta\":{\"uuid\":\"1b953992-20e1-11ee-990b-ffd12dfcd47f\"},\"canary\":\"roaches\",\"id\":8}"
 ]
 [
   9,
   "devilish",
-  "{\"canary\":\"devilish\",\"id\":9}"
+  "2023-07-12T18:25:35.173533Z",
+  "{\"_meta\":{\"uuid\":\"7e2df422-20e1-11ee-990b-ffd12dfcd47f\"},\"canary\":\"devilish\",\"id\":9}"
 ]
 [
   10,
   "glucose's",
-  "{\"canary\":\"glucose's\",\"id\":10}"
+  "2023-07-12T18:25:45.520064Z",
+  "{\"_meta\":{\"uuid\":\"8458b580-20e1-11ee-990b-ffd12dfcd47f\"},\"canary\":\"glucose's\",\"id\":10}"
 ]
 [
   1,
+  "2023-07-12T18:26:01.560712Z",
   6,
   "str 6",
-  "{\"id\":1,\"int\":6,\"str\":\"str 6\"}"
+  "{\"_meta\":{\"uuid\":\"8de85150-20e1-11ee-990b-ffd12dfcd47f\"},\"id\":1,\"int\":6,\"str\":\"str 6\"}"
 ]
 [
   2,
+  "2023-07-12T18:26:14.215494Z",
   7,
   "str 7",
-  "{\"id\":2,\"int\":7,\"str\":\"str 7\"}"
+  "{\"_meta\":{\"uuid\":\"957348bc-20e1-11ee-990b-ffd12dfcd47f\"},\"id\":2,\"int\":7,\"str\":\"str 7\"}"
 ]
 [
   3,
+  "2023-07-12T18:26:23.495167Z",
   8,
   "str 8",
-  "{\"id\":3,\"int\":8,\"str\":\"str 8\"}"
+  "{\"_meta\":{\"uuid\":\"9afb3ff6-20e1-11ee-990b-ffd12dfcd47f\"},\"id\":3,\"int\":8,\"str\":\"str 8\"}"
 ]
 [
   4,
+  "2023-07-12T18:26:33.697752Z",
   9,
   "str 9",
-  "{\"id\":4,\"int\":9,\"str\":\"str 9\"}"
+  "{\"_meta\":{\"uuid\":\"a1100a70-20e1-11ee-990b-ffd12dfcd47f\"},\"id\":4,\"int\":9,\"str\":\"str 9\"}"
 ]
 [
   5,
+  "2023-07-12T18:26:42.518724Z",
   10,
   "str 10",
-  "{\"id\":5,\"int\":10,\"str\":\"str 10\"}"
+  "{\"_meta\":{\"uuid\":\"a65203a8-20e1-11ee-990b-ffd12dfcd47f\"},\"id\":5,\"int\":10,\"str\":\"str 10\"}"
 ]
 [
   1,
   "[11,12]",
   false,
   "11/10",
+  "2023-07-12T18:23:50.55822Z",
   "{\"id\":\"i1\"}",
   null,
   "str1",
-  "{\"array_int\":[11,12],\"bool_field\":false,\"float_field\":1.1,\"id\":1,\"nested\":{\"id\":\"i1\"},\"nullable_int\":null,\"str_field\":\"str1\"}"
+  "{\"_meta\":{\"uuid\":\"3fd2ec78-20e1-11ee-990b-ffd12dfcd47f\"},\"array_int\":[11,12],\"bool_field\":false,\"float_field\":1.1,\"id\":1,\"nested\":{\"id\":\"i1\"},\"nullable_int\":null,\"str_field\":\"str1\"}"
 ]
 [
   2,
   "[21,22]",
   true,
   "11/5",
+  "2023-07-12T18:24:09.67518Z",
   "{\"id\":\"i2\"}",
   2,
   "str2",
-  "{\"array_int\":[21,22],\"bool_field\":true,\"float_field\":2.2,\"id\":2,\"nested\":{\"id\":\"i2\"},\"nullable_int\":2,\"str_field\":\"str2\"}"
+  "{\"_meta\":{\"uuid\":\"4b37f0b8-20e1-11ee-990b-ffd12dfcd47f\"},\"array_int\":[21,22],\"bool_field\":true,\"float_field\":2.2,\"id\":2,\"nested\":{\"id\":\"i2\"},\"nullable_int\":2,\"str_field\":\"str2\"}"
 ]
 [
   3,
   "[31,32]",
   false,
   "33/10",
+  "2023-07-12T18:24:19.384Z",
   "{\"id\":\"i3\"}",
   null,
   "str3",
-  "{\"array_int\":[31,32],\"bool_field\":false,\"float_field\":3.3,\"id\":3,\"nested\":{\"id\":\"i3\"},\"nullable_int\":null,\"str_field\":\"str3\"}"
+  "{\"_meta\":{\"uuid\":\"51016380-20e1-11ee-990b-ffd12dfcd47f\"},\"array_int\":[31,32],\"bool_field\":false,\"float_field\":3.3,\"id\":3,\"nested\":{\"id\":\"i3\"},\"nullable_int\":null,\"str_field\":\"str3\"}"
 ]
 [
   4,
   "[41,42]",
   true,
   "22/5",
+  "2023-07-12T18:24:28.397025Z",
   "{\"id\":\"i4\"}",
   4,
   "str4",
-  "{\"array_int\":[41,42],\"bool_field\":true,\"float_field\":4.4,\"id\":4,\"nested\":{\"id\":\"i4\"},\"nullable_int\":4,\"str_field\":\"str4\"}"
+  "{\"_meta\":{\"uuid\":\"5660aaca-20e1-11ee-990b-ffd12dfcd47f\"},\"array_int\":[41,42],\"bool_field\":true,\"float_field\":4.4,\"id\":4,\"nested\":{\"id\":\"i4\"},\"nullable_int\":4,\"str_field\":\"str4\"}"
 ]
 [
   5,
   "[51,52]",
   false,
   "11/2",
+  "2023-07-12T18:24:36.112031Z",
   "{\"id\":\"i5\"}",
   null,
   "str5",
-  "{\"array_int\":[51,52],\"bool_field\":false,\"float_field\":5.5,\"id\":5,\"nested\":{\"id\":\"i5\"},\"nullable_int\":null,\"str_field\":\"str5\"}"
+  "{\"_meta\":{\"uuid\":\"5af9e236-20e1-11ee-990b-ffd12dfcd47f\"},\"array_int\":[51,52],\"bool_field\":false,\"float_field\":5.5,\"id\":5,\"nested\":{\"id\":\"i5\"},\"nullable_int\":null,\"str_field\":\"str5\"}"
 ]
 [
   6,
   "[61,62]",
   true,
   "3333/50",
+  "2023-07-12T18:28:27.194541Z",
   "{\"id\":\"i6\"}",
   6,
   "str6 v2",
-  "{\"array_int\":[61,62],\"bool_field\":true,\"float_field\":66.66,\"id\":6,\"nested\":{\"id\":\"i6\"},\"nullable_int\":6,\"str_field\":\"str6 v2\"}"
+  "{\"_meta\":{\"uuid\":\"e4b646c2-20e1-11ee-990b-ffd12dfcd47f\"},\"array_int\":[61,62],\"bool_field\":true,\"float_field\":66.66,\"id\":6,\"nested\":{\"id\":\"i6\"},\"nullable_int\":6,\"str_field\":\"str6 v2\"}"
 ]
 [
   7,
   "[71,72]",
   false,
   "7777/100",
+  "2023-07-12T18:28:38.169062Z",
   "{\"id\":\"i7\"}",
   null,
   "str7 v2",
-  "{\"array_int\":[71,72],\"bool_field\":false,\"float_field\":77.77,\"id\":7,\"nested\":{\"id\":\"i7\"},\"nullable_int\":null,\"str_field\":\"str7 v2\"}"
+  "{\"_meta\":{\"uuid\":\"eb40dafc-20e1-11ee-990b-ffd12dfcd47f\"},\"array_int\":[71,72],\"bool_field\":false,\"float_field\":77.77,\"id\":7,\"nested\":{\"id\":\"i7\"},\"nullable_int\":null,\"str_field\":\"str7 v2\"}"
 ]
 [
   8,
   "[81,82]",
   true,
   "2222/25",
+  "2023-07-12T18:28:48.465279Z",
   "{\"id\":\"i8\"}",
   8,
   "str8 v2",
-  "{\"array_int\":[81,82],\"bool_field\":true,\"float_field\":88.88,\"id\":8,\"nested\":{\"id\":\"i8\"},\"nullable_int\":8,\"str_field\":\"str8 v2\"}"
+  "{\"_meta\":{\"uuid\":\"f163eef6-20e1-11ee-990b-ffd12dfcd47f\"},\"array_int\":[81,82],\"bool_field\":true,\"float_field\":88.88,\"id\":8,\"nested\":{\"id\":\"i8\"},\"nullable_int\":8,\"str_field\":\"str8 v2\"}"
 ]
 [
   9,
   "[91,92]",
   false,
   "9999/100",
+  "2023-07-12T18:28:55.677252Z",
   "{\"id\":\"i9\"}",
   null,
   "str9 v2",
-  "{\"array_int\":[91,92],\"bool_field\":false,\"float_field\":99.99,\"id\":9,\"nested\":{\"id\":\"i9\"},\"nullable_int\":null,\"str_field\":\"str9 v2\"}"
+  "{\"_meta\":{\"uuid\":\"f5b064a8-20e1-11ee-990b-ffd12dfcd47f\"},\"array_int\":[91,92],\"bool_field\":false,\"float_field\":99.99,\"id\":9,\"nested\":{\"id\":\"i9\"},\"nullable_int\":null,\"str_field\":\"str9 v2\"}"
 ]
 [
   10,
   "[1,2]",
   true,
   "1010101/1000",
+  "2023-07-12T18:29:04.671352Z",
   "{\"id\":\"i10\"}",
   10,
   "str10 v2",
-  "{\"array_int\":[1,2],\"bool_field\":true,\"float_field\":1010.101,\"id\":10,\"nested\":{\"id\":\"i10\"},\"nullable_int\":10,\"str_field\":\"str10 v2\"}"
+  "{\"_meta\":{\"uuid\":\"fb0cc8b0-20e1-11ee-990b-ffd12dfcd47f\"},\"array_int\":[1,2],\"bool_field\":true,\"float_field\":1010.101,\"id\":10,\"nested\":{\"id\":\"i10\"},\"nullable_int\":10,\"str_field\":\"str10 v2\"}"
 ]
 [
   1,
+  "2023-07-12T18:27:01.912219Z",
   1,
   10,
   "11/10",
   "101/10",
-  "{\"id\":1,\"int_and_str\":1,\"int_str\":\"10\",\"num_and_str\":1.1,\"num_str\":\"10.1\"}"
+  "{\"_meta\":{\"uuid\":\"b1e13a0e-20e1-11ee-990b-ffd12dfcd47f\"},\"id\":1,\"int_and_str\":1,\"int_str\":\"10\",\"num_and_str\":1.1,\"num_str\":\"10.1\"}"
 ]
 [
   2,
+  "2023-07-12T18:27:12.35461Z",
   2,
   20,
   "21/10",
   "201/10",
-  "{\"id\":2,\"int_and_str\":2,\"int_str\":\"20\",\"num_and_str\":2.1,\"num_str\":\"20.1\"}"
+  "{\"_meta\":{\"uuid\":\"b81a9bf4-20e1-11ee-990b-ffd12dfcd47f\"},\"id\":2,\"int_and_str\":2,\"int_str\":\"20\",\"num_and_str\":2.1,\"num_str\":\"20.1\"}"
 ]
 [
   3,
+  "2023-07-12T18:18:11.537199Z",
   3,
   30,
   "31/10",
   "301/10",
-  "{\"id\":3,\"int_and_str\":3,\"int_str\":\"30\",\"num_and_str\":3.1,\"num_str\":\"30.1\"}"
+  "{\"_meta\":{\"uuid\":\"75c06bd6-20e0-11ee-990b-ffd12dfcd47f\"},\"id\":3,\"int_and_str\":3,\"int_str\":\"30\",\"num_and_str\":3.1,\"num_str\":\"30.1\"}"
 ]
 [
   4,
+  "2023-07-12T18:18:48.441281Z",
   4,
   40,
   "41/10",
   "401/10",
-  "{\"id\":4,\"int_and_str\":\"4\",\"int_str\":\"40\",\"num_and_str\":\"4.1\",\"num_str\":\"40.1\"}"
+  "{\"_meta\":{\"uuid\":\"8bbf898a-20e0-11ee-990b-ffd12dfcd47f\"},\"id\":4,\"int_and_str\":\"4\",\"int_str\":\"40\",\"num_and_str\":\"4.1\",\"num_str\":\"40.1\"}"
 ]
 [
   5,
+  "2023-07-12T18:27:25.889321Z",
   5,
   50,
   "51/10",
   "501/10",
-  "{\"id\":5,\"int_and_str\":\"5\",\"int_str\":\"50\",\"num_and_str\":\"5.1\",\"num_str\":\"50.1\"}"
+  "{\"_meta\":{\"uuid\":\"c02bd79a-20e1-11ee-990b-ffd12dfcd47f\"},\"id\":5,\"int_and_str\":\"5\",\"int_str\":\"50\",\"num_and_str\":\"5.1\",\"num_str\":\"50.1\"}"
 ]
 {
   "applied": {


### PR DESCRIPTION
**Description:**

Instead of defining the external file schema from our current dialect definitions, introspect the exist table columns to build a schema that is ensured to be compatible with the table. This way we can change the dialect and as long as the JSON encoding of the values is the same, the loads from the external file will still work.

This allows for changing the materialized column for JSON type `number` to be a `FLOAT64`, and for it to be backward-compatible with existing `BIGNUMERIC` columns.

This was tested by setting up a materialization on the old connector with a `number` type in the schema, materializing a bit of data, switching to the version of the connector from this PR, and then materializing some more data. Also, for the column introspection to EDC schema part, I tested with a variety of "challenging" field and table names, with various mixes of capitalization and special characters.

**Workflow steps:**

Materialize JSON fields of type `number` and get `FLOAT64` columns, which are capable of storing larger values (at reduced precision).

**Documentation links affected:**

N/A

**Notes for reviewers:**

This is a step toward changing object and array column types to `JSON` in bigquery, but doesn't quite get there. The JSON encoding for these values actually must be different than it is currently: Right now we encode them as a string, which would get loaded into a Bigquery `JSON` column as a string, rather than its JSON interpretation. And we can't change the encoding to be JSON bytes because it would break existing materializations.

It should be possible to use the table schema introspection used here to figure out if an existing table has column types of `STRING` or `JSON` for corresponding flow field types of `object` or `array`, and use an alternate encoding depending on the existing table. That wasn't looking like it would be an easy thing to do so I'm holding off for now.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/859)
<!-- Reviewable:end -->
