### PR TITLE
source-mysql: Translate empty `json` columns as `null`

### DIFF
--- a/source-mysql/discovery.go
+++ b/source-mysql/discovery.go
@@ -200,6 +200,9 @@ func (db *mysqlDatabase) translateRecordField(columnType interface{}, val interf
 			case "blob", "tinyblob", "mediumblob", "longblob":
 				return val, nil
 			case "json":
+				if len(val) == 0 {
+					return nil, nil
+				}
 				return json.RawMessage(val), nil
 			case "timestamp":
 				// Per the MySQL docs:


### PR DESCRIPTION
**Description:**

The empty string is not valid JSON and so if we somehow got an empty string from a `json` column and made it a `json.RawMessage` it would fail later on when we tried to serialize it.

We have reason to believe that this can happen, and if it does in fact happen it seems reasonable to translate the empty string into JSON `null`.

(See https://bugs.mysql.com/bug.php?id=98496 for one way that this sort of situation could arise)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/860)
<!-- Reviewable:end -->
