### PR TITLE
source-mysql: Normalize invalid enum values to ""

### DIFF
--- a/source-mysql/datatype_test.go
+++ b/source-mysql/datatype_test.go
@@ -82,6 +82,7 @@ func TestDatatypes(t *testing.T) {
 		{ColumnType: `enum('sm', 'med', 'lg')`, ExpectType: `{"type":["string","null"],"enum":["sm","med","lg","",null]}`, InputValue: nil, ExpectValue: `null`},
 		{ColumnType: `enum('sm', 'med', 'lg') not null`, ExpectType: `{"type":"string","enum":["sm","med","lg",""]}`, InputValue: "sm", ExpectValue: `"sm"`},
 		{ColumnType: `enum('s,m', 'med', '\'lg\'')`, ExpectType: `{"type":["string","null"],"enum":["s,m","med","'lg'","",null]}`, InputValue: `'lg'`, ExpectValue: `"'lg'"`},
+		{ColumnType: `enum('s,m', 'med', '\'lg\'')`, ExpectType: `{"type":["string","null"],"enum":["s,m","med","'lg'","",null]}`, InputValue: `invalid`, ExpectValue: `""`},
 
 		{ColumnType: "set('a', 'b', 'c')", ExpectType: `{"type":["string","null"]}`, InputValue: "b", ExpectValue: `"b"`},
 		{ColumnType: "set('a', 'b', 'c')", ExpectType: `{"type":["string","null"]}`, InputValue: "a,c", ExpectValue: `"a,c"`},

--- a/source-mysql/discovery.go
+++ b/source-mysql/discovery.go
@@ -301,6 +301,12 @@ func (t *mysqlColumnType) translateRecordField(val interface{}) (interface{}, er
 		if index, ok := val.(int64); ok {
 			if 1 <= index && index <= int64(len(t.EnumValues)) {
 				return t.EnumValues[index-1], nil
+			} else if index == 0 {
+				// Illegal values are represented internally by MySQL as the integer 0.
+				// Backfill queries return this as the empty string, which is our chosen
+				// representation as well, but we have to handle the conversion of replicated
+				// values since they're just provided as the raw integer.
+				return "", nil
 			}
 		} else if bs, ok := val.([]byte); ok {
 			return string(bs), nil

--- a/source-mysql/main_test.go
+++ b/source-mysql/main_test.go
@@ -145,7 +145,7 @@ func (tb *testBackend) Insert(ctx context.Context, t testing.TB, table string, r
 		t.Fatalf("error beginning transaction: %v", err)
 	}
 	var argc = len(rows[0])
-	var query = fmt.Sprintf("INSERT INTO %s VALUES %s", table, argsTuple(argc))
+	var query = fmt.Sprintf("INSERT IGNORE INTO %s VALUES %s", table, argsTuple(argc))
 	for _, row := range rows {
 		if len(row) != argc {
 			t.Fatalf("incorrect number of values in row %q (expected %d)", row, len(rows[0]))


### PR DESCRIPTION
**Description:**

Tweaks value translation logic to normalize invalid enum values to `""`. This happened automatically via backfills, but replication will give us the enum values as an integer and we have to translate `0` as `""` ourselves.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/867)
<!-- Reviewable:end -->
