### PR TITLE
source-mysql: Ignore many benign table alterations

### DIFF
--- a/source-mysql/.snapshots/TestAlterTable_Unsupported-capture2-fails
+++ b/source-mysql/.snapshots/TestAlterTable_Unsupported-capture2-fails
@@ -5,5 +5,5 @@
 # ================================
 # Captures Terminated With Errors
 # ================================
-error processing query event: unsupported operation (go.estuary.dev/eVVwet): ALTER TABLE test.AlterTable_Unsupported_28221107 MODIFY COLUMN data INTEGER
+error processing query event: unsupported column alteration (go.estuary.dev/eVVwet): ALTER TABLE test.AlterTable_Unsupported_28221107 MODIFY COLUMN data INTEGER
 

--- a/source-mysql/.snapshots/TestAlterTable_Unsupported-capture3-fails
+++ b/source-mysql/.snapshots/TestAlterTable_Unsupported-capture3-fails
@@ -5,5 +5,5 @@
 # ================================
 # Captures Terminated With Errors
 # ================================
-error processing query event: unsupported operation (go.estuary.dev/eVVwet): ALTER TABLE test.AlterTable_Unsupported_28221107 MODIFY COLUMN data INTEGER
+error processing query event: unsupported column alteration (go.estuary.dev/eVVwet): ALTER TABLE test.AlterTable_Unsupported_28221107 MODIFY COLUMN data INTEGER
 


### PR DESCRIPTION
**Description:**

I have examined the parser AST structs and have added explicit failure cases for the types of table alteration which I believe might possibly be an error, then changed the default to ignore any of the other 14 alteration types that we don't need to care about because they're totally irrelevant to our capture.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/870)
<!-- Reviewable:end -->
