### PR TITLE
source-mysql: Allow ALTER TABLE to drop key constraints

### DIFF
--- a/source-mysql/replication.go
+++ b/source-mysql/replication.go
@@ -538,7 +538,7 @@ func (rs *mysqlReplicationStream) handleAlterTable(stmt *sqlparser.AlterTable, q
 		// in ways we don't currently support, so the default behavior can be to log and ignore.
 		case *sqlparser.AlterColumn, *sqlparser.ChangeColumn, *sqlparser.ModifyColumn, *sqlparser.RenameColumn:
 			return fmt.Errorf("unsupported column alteration (go.estuary.dev/eVVwet): %s", query)
-		case *sqlparser.DropKey, *sqlparser.RenameTableName:
+		case *sqlparser.RenameTableName:
 			return fmt.Errorf("unsupported table alteration (go.estuary.dev/eVVwet): %s", query)
 		case *sqlparser.AddColumns:
 			insertAt := len(meta.Schema.Columns)


### PR DESCRIPTION
**Description:**

We don't care about non-primary key constraints at all, and I think it's safe to allow dropping the primary key constraint too, since we do support capturing from tables without a primary key in the first place.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/871)
<!-- Reviewable:end -->
