### PR TITLE
materialize-bigquery: use DatasetInProject for table metadata

### DIFF
--- a/materialize-bigquery/transactor.go
+++ b/materialize-bigquery/transactor.go
@@ -62,7 +62,7 @@ func newTransactor(
 		// flexibility in changing the dialect and having it still work for existing tables. As long
 		// as the JSON encoding of the values is the same they may be used for columns that would
 		// have been created differently due to evolution of the dialect's column types.
-		meta, err := client.bigqueryClient.Dataset(cfg.Dataset).Table(translateFlowIdentifier(table)).Metadata(ctx)
+		meta, err := client.bigqueryClient.DatasetInProject(cfg.ProjectID, cfg.Dataset).Table(translateFlowIdentifier(table)).Metadata(ctx)
 		if err != nil {
 			return nil, fmt.Errorf("getting table metadata: %w", err)
 		}


### PR DESCRIPTION
**Description:**

If an alternate billing project ID has been set, we need to use the configured project ID for querying table metadata.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/874)
<!-- Reviewable:end -->
