### PR TITLE
materialize-snowflake: batch table creation and run batches concurrently

### DIFF
--- a/materialize-sql/driver.go
+++ b/materialize-sql/driver.go
@@ -134,7 +134,6 @@ func (d *Driver) Apply(ctx context.Context, req *pm.Request_Apply) (*pm.Response
 		tableShapes = append(tableShapes, *endpoint.MetaCheckpoints)
 	}
 
-	var statements []string
 	var executedColumnModifications []string
 
 	for bindingIndex, bindingSpec := range req.Materialization.Bindings {
@@ -228,6 +227,8 @@ func (d *Driver) Apply(ctx context.Context, req *pm.Request_Apply) (*pm.Response
 		tableShapes = append(tableShapes, tableShape)
 	}
 
+	// Build a list of table creation statements, followed by the spec update statement.
+	var statements []string
 	for _, shape := range tableShapes {
 		var table, err = ResolveTable(shape, endpoint.Dialect)
 		if err != nil {


### PR DESCRIPTION
**Description:**

Creating hundreds of tables in a single apply operation takes quite a while when run using a single statement. This change creates batches of table creation statements and runs them with concurrent workers.

Snowflake does not support DDL statements in transactions, so there's no reason to run them as part of a transaction. We just need to make sure the materialization spec update happens only after all of the table alterations are complete.

With this strategy, we can create several hundred tables within the 5 minute timeout period allowed for an Apply RPC.

**Workflow steps:**

Create a materialization with up to ~300 bound collections. For testing purposes I used 400 tables. The Apply action takes 1-2 minutes with this many tables. I was also able to materialize documents from all of these collections to each of the 400 created tables.

**Documentation links affected:**

N/A

**Notes for reviewers:**

N/A

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/876)
<!-- Reviewable:end -->
