### PR TITLE
source-postgres-batch: Order query results by xmin

### DIFF
--- a/source-postgres-batch/main.go
+++ b/source-postgres-batch/main.go
@@ -99,9 +99,9 @@ func connectPostgres(ctx context.Context, configJSON json.RawMessage) (*sql.DB, 
 }
 
 const tableQueryTemplateTemplate = `{{if .IsFirstQuery -}}
-  SELECT xmin AS txid, * FROM %[1]s;
+  SELECT xmin AS txid, * FROM %[1]s ORDER BY xmin::text::bigint;
 {{- else -}}
-  SELECT xmin AS txid, * FROM %[1]s WHERE xmin::text::bigint > $1;
+  SELECT xmin AS txid, * FROM %[1]s WHERE xmin::text::bigint > $1 ORDER BY xmin::text::bigint;
 {{- end}}`
 
 // This is currently unused, but is a useful example of how the function


### PR DESCRIPTION
**Description:**

During the rewriting I guess I accidentally removed the query clause `ORDER BY xmin::text::bigint`. But we still need that, since the `WHERE xmin > $1` part only works if we can assume that the last value of the previous iteration was also the largest `xmin` value. Which I think is generally true by default, but we shouldn't assume that.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/879)
<!-- Reviewable:end -->
