### PR TITLE
source-mysql: Support `ALTER TABLE foo CHANGE ...` sometimes

### DIFF
--- a/source-mysql/.snapshots/TestAlterTable_Unsupported-capture2-fails
+++ b/source-mysql/.snapshots/TestAlterTable_Unsupported-capture2-fails
@@ -5,5 +5,5 @@
 # ================================
 # Captures Terminated With Errors
 # ================================
-error processing query event: unsupported column alteration (go.estuary.dev/eVVwet): ALTER TABLE test.AlterTable_Unsupported_28221107 MODIFY COLUMN data INTEGER
+error processing query event: unsupported query "ALTER TABLE test.AlterTable_Unsupported_28221107 CHANGE COLUMN data data2 INTEGER": cannot currently process column renaming
 

--- a/source-mysql/.snapshots/TestAlterTable_Unsupported-capture3-fails
+++ b/source-mysql/.snapshots/TestAlterTable_Unsupported-capture3-fails
@@ -5,5 +5,5 @@
 # ================================
 # Captures Terminated With Errors
 # ================================
-error processing query event: unsupported column alteration (go.estuary.dev/eVVwet): ALTER TABLE test.AlterTable_Unsupported_28221107 MODIFY COLUMN data INTEGER
+error processing query event: unsupported query "ALTER TABLE test.AlterTable_Unsupported_28221107 CHANGE COLUMN data data2 INTEGER": cannot currently process column renaming
 

--- a/source-mysql/.snapshots/TestAlterTable_Unsupported-capture5
+++ b/source-mysql/.snapshots/TestAlterTable_Unsupported-capture5
@@ -1,10 +1,10 @@
 # ================================
 # Collection "acmeCo/test/test_altertable_unsupported_28221107": 2 Documents
 # ================================
-{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"AlterTable_Unsupported_28221107","cursor":"backfill:0"}},"data":30,"id":3}
-{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"AlterTable_Unsupported_28221107","cursor":"backfill:1"}},"data":40,"id":4}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"AlterTable_Unsupported_28221107","cursor":"backfill:0"}},"data2":30,"id":3}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"AlterTable_Unsupported_28221107","cursor":"backfill:1"}},"data2":40,"id":4}
 # ================================
 # Final State Checkpoint
 # ================================
-{"cursor":"binlog.000123:56789","streams":{"test.altertable_unsupported_17220185":{"backfilled":2,"key_columns":["id"],"metadata":{"schema":{"columns":["id","data"],"types":{"data":"text","id":"int"}}},"mode":"Active"},"test.altertable_unsupported_28221107":{"backfilled":2,"key_columns":["id"],"metadata":{"schema":{"columns":["id","data"],"types":{"data":"int","id":"int"}}},"mode":"Active"}}}
+{"cursor":"binlog.000123:56789","streams":{"test.altertable_unsupported_17220185":{"backfilled":2,"key_columns":["id"],"metadata":{"schema":{"columns":["id","data"],"types":{"data":"text","id":"int"}}},"mode":"Active"},"test.altertable_unsupported_28221107":{"backfilled":2,"key_columns":["id"],"metadata":{"schema":{"columns":["id","data2"],"types":{"data":"text","data2":"int","id":"int"}}},"mode":"Active"}}}
 

--- a/source-mysql/.snapshots/TestAlterTable_Unsupported-capture6
+++ b/source-mysql/.snapshots/TestAlterTable_Unsupported-capture6
@@ -1,10 +1,10 @@
 # ================================
 # Collection "acmeCo/test/test_altertable_unsupported_31129906": 2 Documents
 # ================================
-{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"AlterTable_Unsupported_31129906","cursor":"backfill:0"}},"data":1,"id":5}
-{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"AlterTable_Unsupported_31129906","cursor":"backfill:1"}},"data":0,"id":6}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"AlterTable_Unsupported_31129906","cursor":"backfill:0"}},"data3":1,"id":5}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"AlterTable_Unsupported_31129906","cursor":"backfill:1"}},"data3":0,"id":6}
 # ================================
 # Final State Checkpoint
 # ================================
-{"cursor":"binlog.000123:56789","streams":{"test.altertable_unsupported_17220185":{"backfilled":2,"key_columns":["id"],"metadata":{"schema":{"columns":["id","data"],"types":{"data":"text","id":"int"}}},"mode":"Active"},"test.altertable_unsupported_28221107":{"backfilled":2,"key_columns":["id"],"metadata":{"schema":{"columns":["id","data"],"types":{"data":"int","id":"int"}}},"mode":"Active"},"test.altertable_unsupported_31129906":{"backfilled":2,"key_columns":["id"],"metadata":{"schema":{"columns":["id","data"],"types":{"data":"tinyint","id":"int"}}},"mode":"Active"}}}
+{"cursor":"binlog.000123:56789","streams":{"test.altertable_unsupported_17220185":{"backfilled":2,"key_columns":["id"],"metadata":{"schema":{"columns":["id","data"],"types":{"data":"text","id":"int"}}},"mode":"Active"},"test.altertable_unsupported_28221107":{"backfilled":2,"key_columns":["id"],"metadata":{"schema":{"columns":["id","data2"],"types":{"data":"text","data2":"int","id":"int"}}},"mode":"Active"},"test.altertable_unsupported_31129906":{"backfilled":2,"key_columns":["id"],"metadata":{"schema":{"columns":["id","data3"],"types":{"data3":"tinyint","id":"int"}}},"mode":"Active"}}}
 

--- a/source-mysql/discovery.go
+++ b/source-mysql/discovery.go
@@ -264,25 +264,25 @@ func getColumns(ctx context.Context, conn *client.Conn) ([]sqlcapture.ColumnInfo
 
 	var columns []sqlcapture.ColumnInfo
 	for _, row := range results.Values {
-		var typeName = string(row[5].AsString())
-		var dataType interface{}
-		if typeName == "enum" {
-			dataType = &mysqlColumnType{Type: "enum", EnumValues: append(parseEnumValues(string(row[6].AsString())), "")}
-		} else if typeName == "set" {
-			dataType = &mysqlColumnType{Type: "set", EnumValues: parseEnumValues(string(row[6].AsString()))}
-		} else {
-			dataType = typeName
-		}
 		columns = append(columns, sqlcapture.ColumnInfo{
 			TableSchema: string(row[0].AsString()),
 			TableName:   string(row[1].AsString()),
 			Index:       int(row[2].AsInt64()),
 			Name:        string(row[3].AsString()),
 			IsNullable:  string(row[4].AsString()) != "NO",
-			DataType:    dataType,
+			DataType:    parseDataType(string(row[5].AsString()), string(row[6].AsString())),
 		})
 	}
 	return columns, err
+}
+
+func parseDataType(typeName, fullColumnType string) any {
+	if typeName == "enum" {
+		return &mysqlColumnType{Type: "enum", EnumValues: append(parseEnumValues(fullColumnType), "")}
+	} else if typeName == "set" {
+		return &mysqlColumnType{Type: "set", EnumValues: parseEnumValues(fullColumnType)}
+	}
+	return typeName
 }
 
 type mysqlColumnType struct {

--- a/source-mysql/main_test.go
+++ b/source-mysql/main_test.go
@@ -204,11 +204,11 @@ func TestAlterTable_Unsupported(t *testing.T) {
 	t.Run("init", func(t *testing.T) { tests.VerifiedCapture(ctx, t, cs) })
 
 	// Altering tableC, which is not being captured, should be fine
-	tb.Query(ctx, t, fmt.Sprintf("ALTER TABLE %s MODIFY COLUMN data INTEGER;", tableC))
+	tb.Query(ctx, t, fmt.Sprintf("ALTER TABLE %s CHANGE COLUMN data data2 INTEGER;", tableC))
 	t.Run("capture1", func(t *testing.T) { tests.VerifiedCapture(ctx, t, cs) })
 
 	// Altering tableB, which is being captured, should result in an error
-	tb.Query(ctx, t, fmt.Sprintf("ALTER TABLE %s MODIFY COLUMN data INTEGER;", tableB))
+	tb.Query(ctx, t, fmt.Sprintf("ALTER TABLE %s CHANGE COLUMN data data2 INTEGER;", tableB))
 	tb.Insert(ctx, t, tableB, [][]interface{}{{3, 30}, {4, 40}})
 	t.Run("capture2-fails", func(t *testing.T) { tests.VerifiedCapture(ctx, t, cs) })
 
@@ -227,7 +227,7 @@ func TestAlterTable_Unsupported(t *testing.T) {
 	// is added to the capture *when it was also altered after the last state
 	// checkpoint*. This should still work, because tables only become active
 	// after the first stream-to-watermark operation.
-	tb.Query(ctx, t, fmt.Sprintf("ALTER TABLE %s MODIFY COLUMN data BOOL;", tableC))
+	tb.Query(ctx, t, fmt.Sprintf("ALTER TABLE %s CHANGE COLUMN data2 data3 BOOL;", tableC))
 	tb.Insert(ctx, t, tableC, [][]interface{}{{5, true}, {6, false}})
 	cs.Bindings = tests.DiscoverBindings(ctx, t, tb, regexp.MustCompile(uniqueA), regexp.MustCompile(uniqueB), regexp.MustCompile(uniqueC))
 	t.Run("capture6", func(t *testing.T) { tests.VerifiedCapture(ctx, t, cs) })


### PR DESCRIPTION
**Description:**

This commit adds support for `ALTER TABLE foo CHANGE COLUMN` and `ALTER TABLE foo MODIFY COLUMN` queries in cases which don't actually rename or reposition the columns. It's possible in theory to add support for renaming/repositioning (since the effects are basically the equivalent of a DROP / ADD sequence) but I have opted to omit that part in order to get a quick fix together for the simple case.

I also factored out the datatype parsing in discovery into a separate function, because I thought it was the same logic as we use in replication event processing. It turns out the two functions are subtly different but I think the code looks nicer factored-out so I'm hesitant to revert it even though it's a completely unrelated change.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/887)
<!-- Reviewable:end -->
