### PR TITLE
source-dynamodb: fix x-infer-schema annotation for discovered schemas

### DIFF
--- a/source-dynamodb/.snapshots/TestDiscovery-additional_table_without_stream_enabled
+++ b/source-dynamodb/.snapshots/TestDiscovery-additional_table_without_stream_enabled
@@ -81,13 +81,13 @@ Binding 0:
           },
           "reduce": {
             "strategy": "merge"
-          },
-          "x-infer-schema": true
+          }
         },
         {
           "$ref": "#discoverTable"
         }
-      ]
+      ],
+      "x-infer-schema": true
     },
     "key": [
       "/partitionKey"

--- a/source-dynamodb/.snapshots/TestDiscovery-multiple_tables_with_various_types
+++ b/source-dynamodb/.snapshots/TestDiscovery-multiple_tables_with_various_types
@@ -81,13 +81,13 @@ Binding 0:
           },
           "reduce": {
             "strategy": "merge"
-          },
-          "x-infer-schema": true
+          }
         },
         {
           "$ref": "#discoverTable"
         }
-      ]
+      ],
+      "x-infer-schema": true
     },
     "key": [
       "/partitionKey"
@@ -181,13 +181,13 @@ Binding 1:
           },
           "reduce": {
             "strategy": "merge"
-          },
-          "x-infer-schema": true
+          }
         },
         {
           "$ref": "#secondTable"
         }
-      ]
+      ],
+      "x-infer-schema": true
     },
     "key": [
       "/partitionKeyString",
@@ -283,13 +283,13 @@ Binding 2:
           },
           "reduce": {
             "strategy": "merge"
-          },
-          "x-infer-schema": true
+          }
         },
         {
           "$ref": "#thirdTable"
         }
-      ]
+      ],
+      "x-infer-schema": true
     },
     "key": [
       "/partitionKeyBinary",

--- a/source-dynamodb/.snapshots/TestDiscovery-single_table_with_a_partition_key
+++ b/source-dynamodb/.snapshots/TestDiscovery-single_table_with_a_partition_key
@@ -81,13 +81,13 @@ Binding 0:
           },
           "reduce": {
             "strategy": "merge"
-          },
-          "x-infer-schema": true
+          }
         },
         {
           "$ref": "#discoverTable"
         }
-      ]
+      ],
+      "x-infer-schema": true
     },
     "key": [
       "/partitionKey"

--- a/source-dynamodb/discovery.go
+++ b/source-dynamodb/discovery.go
@@ -166,12 +166,12 @@ func (driver) Discover(ctx context.Context, req *pc.Request_Discover) (*pc.Respo
 						"reduce": map[string]interface{}{
 							"strategy": "merge",
 						},
-						"x-infer-schema": true,
 					},
 					Required: []string{"_meta"},
 				},
 				{Ref: "#" + anchor},
 			},
+			Extras: map[string]interface{}{"x-infer-schema": true},
 		}
 
 		rawSchema, err := schema.MarshalJSON()


### PR DESCRIPTION
**Description:**

`x-infer-schema` needs to be a "top level" property in the schema, rather than being nested within the `allOf`.

**Workflow steps:**

Discovered collections from this connector will have the schema inference button enabled in the UI.

**Documentation links affected:**

N/A

**Notes for reviewers:**

Tested with a local stack to make sure the button appears after this change.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/889)
<!-- Reviewable:end -->
