### PR TITLE
materialize-redshift: handling for long strings as load keys

### DIFF
--- a/materialize-redshift/.snapshots/TestSQLGeneration
+++ b/materialize-redshift/.snapshots/TestSQLGeneration
@@ -36,19 +36,6 @@ COMMENT ON COLUMN "Delta Updates".aValue IS 'A super-awesome value.
 auto-generated projection of JSON at: /aValue with inferred types: [integer]';
 --- End "Delta Updates" createTargetTable ---
 
---- Begin "a-schema".target_table createLoadTable ---
-CREATE TEMPORARY TABLE flow_temp_table_0 (
-	key1 BIGINT,
-	"key!2" BOOLEAN
-);
---- End "a-schema".target_table createLoadTable ---
-
---- Begin "Delta Updates" createLoadTable ---
-CREATE TEMPORARY TABLE flow_temp_table_1 (
-	theKey TEXT
-);
---- End "Delta Updates" createLoadTable ---
-
 --- Begin "a-schema".target_table createStoreTable ---
 CREATE TEMPORARY TABLE flow_temp_table_0 (
 	LIKE "a-schema".target_table
@@ -95,6 +82,32 @@ SELECT 0, r.flow_document
 SELECT * FROM (SELECT -1, CAST(NULL AS SUPER) LIMIT 0) as nodoc
 --- End "Delta Updates" loadQuery ---
 
+--- Begin "a-schema".target_table createLoadTable (no varchar length) ---
+CREATE TEMPORARY TABLE flow_temp_table_0 (
+	key1 BIGINT,
+	"key!2" BOOLEAN
+);
+--- End "a-schema".target_table createLoadTable (no varchar length) ---
+
+--- Begin "Delta Updates" createLoadTable (no varchar length) ---
+CREATE TEMPORARY TABLE flow_temp_table_1 (
+	theKey TEXT
+);
+--- End "Delta Updates" createLoadTable (no varchar length) ---
+
+--- Begin "a-schema".target_table createLoadTable (with varchar length) ---
+CREATE TEMPORARY TABLE flow_temp_table_0 (
+	key1 BIGINT,
+	"key!2" BOOLEAN
+);
+--- End "a-schema".target_table createLoadTable (with varchar length) ---
+
+--- Begin "Delta Updates" createLoadTable (with varchar length) ---
+CREATE TEMPORARY TABLE flow_temp_table_1 (
+	theKey VARCHAR(400)
+);
+--- End "Delta Updates" createLoadTable (with varchar length) ---
+
 --- Begin Fence Update ---
 UPDATE path."To".checkpoints
 	SET   checkpoint = 'AAECAwQFBgcICQ=='
@@ -104,7 +117,7 @@ UPDATE path."To".checkpoints
 	AND   fence     = 123;
 --- End Fence Update ---
 
---- Begin Copy From S3 ---
+--- Begin Copy From S3 With Truncation---
 COPY my_temp_table
 FROM 's3://some_bucket'
 CREDENTIALS 'aws_access_key_id=accessKeyID;aws_secret_access_key=secretKey'
@@ -113,6 +126,14 @@ JSON 'auto ignorecase'
 DATEFORMAT 'auto'
 TIMEFORMAT 'auto'
 TRUNCATECOLUMNS;
---- End Copy From S3 ---
+--- End Copy From S3 With Truncation ---
 
-
+--- Begin Copy From S3 Without Truncation---
+COPY my_temp_table
+FROM 's3://some_bucket'
+CREDENTIALS 'aws_access_key_id=accessKeyID;aws_secret_access_key=secretKey'
+REGION 'us-somewhere-1'
+JSON 'auto ignorecase'
+DATEFORMAT 'auto'
+TIMEFORMAT 'auto';
+--- End Copy From S3 Without Truncation ---


### PR DESCRIPTION
**Description:**

It's possible for collection keys that are strings to be longer than the 255 bytes permitted in a Redshift TEXT column. In this case the load table needs to be created with wider VARCHAR columns to hold the full string value.

We'll keep track of the longest string key values seen for a load transaction, and if it ends up being longer than 255 bytes the load table will be created with all VARCHAR columns wide enough for the longest value seen. Also we will explicitly disable truncation of column values for the load tables, since this could lead to data inconsistency for very long string keys with identical leading 65,535 bytes. That brings along the limitation that string fields used as keys can't be any longer than 65,535 bytes, which doesn't seem totally unreasonable.

**Workflow steps:**

Materialize collections with long string fields that are used as keys.

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/890)
<!-- Reviewable:end -->
