### PR TITLE
source-mysql: Downgrade EXPLAIN error logging to WARN

### DIFF
--- a/source-mysql/backfill.go
+++ b/source-mysql/backfill.go
@@ -231,7 +231,7 @@ func (db *mysqlDatabase) explainQuery(streamID, query string, args []interface{}
 		logrus.WithFields(logrus.Fields{
 			"query": query,
 			"err":   err,
-		}).Error("unable to explain query")
+		}).Warn("unable to explain query")
 		return
 	}
 	defer explainResult.Close()


### PR DESCRIPTION
**Description:**

The failure of our `EXPLAIN ...` queries is entirely benign. That whole piece of logic is just to help us with debugging backfill query behavior, and if the explain queries all fail we will just shrug and keep going.

So in my opinion `WARN` severity is more appropriate than `ERROR` here.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/892)
<!-- Reviewable:end -->
