### PR TITLE
materialize-snowflake: report table names on store errors for copy & merge

### DIFF
--- a/materialize-snowflake/snowflake.go
+++ b/materialize-snowflake/snowflake.go
@@ -560,12 +560,12 @@ func (d *transactor) commit(ctx context.Context) error {
 		} else if !b.store.mustMerge {
 			// We can issue a faster COPY INTO the target table.
 			if _, err = d.store.conn.ExecContext(ctx, b.store.copyInto); err != nil {
-				return fmt.Errorf("copying Store documents: %w", err)
+				return fmt.Errorf("copying Store documents into table %q: %w", b.target.Identifier, err)
 			}
 		} else {
 			// We must MERGE into the target table.
 			if _, err = d.store.conn.ExecContext(ctx, b.store.mergeInto); err != nil {
-				return fmt.Errorf("merging Store documents: %w", err)
+				return fmt.Errorf("merging Store documents into table %q: %w", b.target.Identifier, err)
 			}
 		}
 


### PR DESCRIPTION
**Description:**

Adds the name of the table to the error message for a failed copy or merge operation during the Store phase.

One way this operation can fail is if the size of a single JSON document exceeds the maximum allowable by Snowflake. It is currently difficult to tell which collection a very large document is coming from, since Snowflake does not return the name of the table with its error message.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/893)
<!-- Reviewable:end -->
