### PR TITLE
sqlcapture: Log document contents when JSON serialization fails

### DIFF
--- a/sqlcapture/capture.go
+++ b/sqlcapture/capture.go
@@ -688,8 +688,12 @@ func (c *Capture) emitMessage(out *boilerplate.PullOutput, msg interface{}) erro
 
 		var bs, err = json.Marshal(record)
 		if err != nil {
-			return fmt.Errorf("error serializing table %s.%s record data: %w",
-				sourceCommon.Schema, sourceCommon.Table, err)
+			logrus.WithFields(logrus.Fields{
+				"document": fmt.Sprintf("%#v", record),
+				"stream":   streamID,
+				"err":      err,
+			}).Error("document serialization error")
+			return fmt.Errorf("error serializing document from stream %q: %w", streamID, err)
 		}
 		return out.Documents(int(binding.Index), bs)
 	case *PersistentState:


### PR DESCRIPTION
**Description:**

The hope is that the Go format `%#v` will produce a reasonable rendering of the value that's failing JSON marshalling so we can figure out how exactly things are going wrong in the first place.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/894)
<!-- Reviewable:end -->
