### PR TITLE
source-{mysql,postgres,sqlserver}: Backfill chunk size 50,000

### DIFF
--- a/source-mysql/.snapshots/TestGeneric-SpecResponse
+++ b/source-mysql/.snapshots/TestGeneric-SpecResponse
@@ -64,7 +64,7 @@
             "type": "integer",
             "title": "Backfill Chunk Size",
             "description": "The number of rows which should be fetched from the database in a single backfill query.",
-            "default": 32768
+            "default": 50000
           }
         },
         "additionalProperties": false,

--- a/source-mysql/main.go
+++ b/source-mysql/main.go
@@ -127,7 +127,7 @@ type advancedConfig struct {
 	SkipBinlogRetentionCheck bool   `json:"skip_binlog_retention_check,omitempty" jsonschema:"title=Skip Binlog Retention Sanity Check,default=false,description=Bypasses the 'dangerously short binlog retention' sanity check at startup. Only do this if you understand the danger and have a specific need."`
 	NodeID                   uint32 `json:"node_id,omitempty" jsonschema:"title=Node ID,description=Node ID for the capture. Each node in a replication cluster must have a unique 32-bit ID. The specific value doesn't matter so long as it is unique. If unset or zero the connector will pick a value."`
 	SkipBackfills            string `json:"skip_backfills,omitempty" jsonschema:"title=Skip Backfills,description=A comma-separated list of fully-qualified table names which should not be backfilled."`
-	BackfillChunkSize        int    `json:"backfill_chunk_size,omitempty" jsonschema:"title=Backfill Chunk Size,default=32768,description=The number of rows which should be fetched from the database in a single backfill query."`
+	BackfillChunkSize        int    `json:"backfill_chunk_size,omitempty" jsonschema:"title=Backfill Chunk Size,default=50000,description=The number of rows which should be fetched from the database in a single backfill query."`
 }
 
 // Validate checks that the configuration possesses all required properties.
@@ -184,7 +184,7 @@ func (c *Config) SetDefaults(name string) {
 		c.Advanced.NodeID &= 0x7FFFFFFF // Clear MSB because watermark writes use the node ID as an integer key
 	}
 	if c.Advanced.BackfillChunkSize <= 0 {
-		c.Advanced.BackfillChunkSize = 32768
+		c.Advanced.BackfillChunkSize = 50000
 	}
 
 	// The address config property should accept a host or host:port

--- a/source-postgres/.snapshots/TestGeneric-SpecResponse
+++ b/source-postgres/.snapshots/TestGeneric-SpecResponse
@@ -54,7 +54,7 @@
             "type": "integer",
             "title": "Backfill Chunk Size",
             "description": "The number of rows which should be fetched from the database in a single backfill query.",
-            "default": 32768
+            "default": 50000
           },
           "sslmode": {
             "type": "string",

--- a/source-postgres/main.go
+++ b/source-postgres/main.go
@@ -102,7 +102,7 @@ type advancedConfig struct {
 	SlotName          string `json:"slotName,omitempty" jsonschema:"default=flow_slot,description=The name of the PostgreSQL replication slot to replicate from."`
 	WatermarksTable   string `json:"watermarksTable,omitempty" jsonschema:"default=public.flow_watermarks,description=The name of the table used for watermark writes during backfills. Must be fully-qualified in '<schema>.<table>' form."`
 	SkipBackfills     string `json:"skip_backfills,omitempty" jsonschema:"title=Skip Backfills,description=A comma-separated list of fully-qualified table names which should not be backfilled."`
-	BackfillChunkSize int    `json:"backfill_chunk_size,omitempty" jsonschema:"title=Backfill Chunk Size,default=32768,description=The number of rows which should be fetched from the database in a single backfill query."`
+	BackfillChunkSize int    `json:"backfill_chunk_size,omitempty" jsonschema:"title=Backfill Chunk Size,default=50000,description=The number of rows which should be fetched from the database in a single backfill query."`
 	SSLMode           string `json:"sslmode,omitempty" jsonschema:"title=SSL Mode,description=Overrides SSL connection behavior by setting the 'sslmode' parameter.,enum=disable,enum=allow,enum=prefer,enum=require,enum=verify-ca,enum=verify-full"`
 }
 
@@ -152,7 +152,7 @@ func (c *Config) SetDefaults() {
 		c.Advanced.WatermarksTable = "public.flow_watermarks"
 	}
 	if c.Advanced.BackfillChunkSize <= 0 {
-		c.Advanced.BackfillChunkSize = 32768
+		c.Advanced.BackfillChunkSize = 50000
 	}
 
 	// The address config property should accept a host or host:port

--- a/source-sqlserver/.snapshots/TestGeneric-SpecResponse
+++ b/source-sqlserver/.snapshots/TestGeneric-SpecResponse
@@ -50,7 +50,7 @@
             "type": "integer",
             "title": "Backfill Chunk Size",
             "description": "The number of rows which should be fetched from the database in a single backfill query.",
-            "default": 4096
+            "default": 50000
           }
         },
         "additionalProperties": false,

--- a/source-sqlserver/main.go
+++ b/source-sqlserver/main.go
@@ -48,7 +48,7 @@ type Config struct {
 type advancedConfig struct {
 	WatermarksTable   string `json:"watermarksTable,omitempty" jsonschema:"default=dbo.flow_watermarks,description=The name of the table used for watermark writes during backfills. Must be fully-qualified in '<schema>.<table>' form."`
 	SkipBackfills     string `json:"skip_backfills,omitempty" jsonschema:"title=Skip Backfills,description=A comma-separated list of fully-qualified table names which should not be backfilled."`
-	BackfillChunkSize int    `json:"backfill_chunk_size,omitempty" jsonschema:"title=Backfill Chunk Size,default=4096,description=The number of rows which should be fetched from the database in a single backfill query."`
+	BackfillChunkSize int    `json:"backfill_chunk_size,omitempty" jsonschema:"title=Backfill Chunk Size,default=50000,description=The number of rows which should be fetched from the database in a single backfill query."`
 }
 
 type tunnelConfig struct {
@@ -101,7 +101,7 @@ func (c *Config) SetDefaults() {
 		c.Advanced.WatermarksTable = "dbo.flow_watermarks"
 	}
 	if c.Advanced.BackfillChunkSize <= 0 {
-		c.Advanced.BackfillChunkSize = 32768
+		c.Advanced.BackfillChunkSize = 50000
 	}
 	if c.Timezone == "" {
 		c.Timezone = "UTC"


### PR DESCRIPTION
**Description:**

Subsequent to https://github.com/estuary/connectors/pull/898 which removed the large in-memory buffer of backfill results (and thus made connector memory usage independent of backfill chunk size) and some Slack discussion about why we still don't want to set this to 1M or something absurd, we decided to bump this up to "something greater than 32,768 but less than 65,536"

Despite the fact that we've been using powers of two for this in the past there's no actual technical requirement or performance related reason that it be a power of two, and a sum of powers such as `48*1024 = 49,152` isn't as instantly recognizable anyway, so I figure we might as well make it look nice to less technical users and have instead increased the default to 50,000 here.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/900)
<!-- Reviewable:end -->
