### PR TITLE
sqlcapture: Run replication diagnostics on unexpected idle

### DIFF
--- a/source-postgres/replication.go
+++ b/source-postgres/replication.go
@@ -644,3 +644,8 @@ func (s *replicationStream) Close(ctx context.Context) error {
 	s.cancel()
 	return <-s.errCh
 }
+
+func (db *postgresDatabase) ReplicationDiagnostics(ctx context.Context) error {
+	// TODO: Run some useful diagnostics queries for Postgres replication and log the results
+	return nil
+}

--- a/source-sqlserver/replication.go
+++ b/source-sqlserver/replication.go
@@ -420,3 +420,8 @@ func splitStreamID(streamID string) (string, string) {
 	var bits = strings.SplitN(streamID, ".", 2)
 	return bits[0], bits[1]
 }
+
+func (db *sqlserverDatabase) ReplicationDiagnostics(ctx context.Context) error {
+	// TODO: Run some useful diagnostics queries for SQL Server replication and log the results
+	return nil
+}

--- a/sqlcapture/interface.go
+++ b/sqlcapture/interface.go
@@ -153,6 +153,11 @@ type Database interface {
 	// SetupTablePrerequisites is like SetupPrerequisites but for any table-specific
 	// verification or setup that needs to be performed.
 	SetupTablePrerequisites(ctx context.Context, schema, table string) error
+
+	// Called when replication appears to not be progressing as it should, this
+	// function provides a hook for database-specific diagnostic information to
+	// be logged.
+	ReplicationDiagnostics(ctx context.Context) error
 }
 
 // ReplicationStream represents the process of receiving change events


### PR DESCRIPTION
**Description:**

When no replication events have been processed for over a minute but we're expecting to observe a watermark that we wrote, something has gone badly wrong between the database and the connector. Let's make this sort of failure a bit more debuggable by running a database-specific 'ReplicationDiagnostics' hook which executes various diagnostic queries and logs the results.

Currently only implements diagnostic queries for MySQL. For other databases this is a no-op and leaves us no worse off than before.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/904)
<!-- Reviewable:end -->
