### PR TITLE
source-mysql: Another replication diagnostic

### DIFF
--- a/source-mysql/replication.go
+++ b/source-mysql/replication.go
@@ -762,5 +762,6 @@ func (db *mysqlDatabase) ReplicationDiagnostics(ctx context.Context) error {
 	query("SHOW MASTER STATUS;")
 	query("SHOW SLAVE HOSTS;")
 	query("SHOW PROCESSLIST;")
+	query("SHOW BINARY LOGS;")
 	return nil
 }


### PR DESCRIPTION
**Description:**

Adds `SHOW BINARY LOGS` to the MySQL replication diagnostics hook.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/906)
<!-- Reviewable:end -->
