### PR TITLE
source-firestore: Improve change streaming reliability (hopefully)

### DIFF
--- a/source-firestore/pull.go
+++ b/source-firestore/pull.go
@@ -36,7 +36,7 @@ const watchTargetID = 1245678
 
 // Non-permanent failures like Unavailable or ResourceExhausted can be retried
 // after a little while.
-const retryInterval = 300 * time.Second
+const retryInterval = 60 * time.Second
 
 // Log progress messages after every N documents on a particular stream
 const progressLogInterval = 10000


### PR DESCRIPTION
**Description:**

This PR makes several changes which I hope should all contribute to making change streaming more reliable.

To recap: The fundamental challenge that `source-firestore` grapples with frequently is that when we first open a `Listen` RPC for some stream, **we must catch up to the present time within 10 minutes at most** or else Firestore will cut us off and we won't even have an updated resume cursor for our trouble.

This PR does several things which should hopefully make it more likely that we'll get and remain caught up:

- A `WaitGroup` is added which keeps track of the number of replication workers which are _not_ currently caught up. Backfill workers consult this wait group before requesting any data and block unless/until it reaches zero. This should avoid situations where backfill work competes with streaming catchup for limited throughput.
- The change-streaming retry interval is decreased from 5 minutes to 1 minute. This means that in the event of a retryable interruption of streaming, there will be 5x less data accumulated before we resume.
- The change-streaming retry behavior is tweaked to more closely resemble the connector-restart behavior, by incrementing the relevant WaitGroup again and requesting a resume from the most recent consistent point. I'm actually not entirely sure how the old behavior worked at all, since whenever it retried it would send _the same exact Listen RPC_ again. Possibly this only ever worked because the connector itself got restarted occasionally as well.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/909)
<!-- Reviewable:end -->
