### PR TITLE
source-firestore: Log number of docs read before catchup failure

### DIFF
--- a/source-firestore/pull.go
+++ b/source-firestore/pull.go
@@ -596,7 +596,7 @@ func (c *capture) StreamChanges(ctx context.Context, client *firestore_v1.Client
 				}
 			case firestore_pb.TargetChange_REMOVE:
 				if catchupStreaming && time.Since(catchupStarted) > 5*time.Minute {
-					logEntry.Warn("replication failed to catch up in time, collection suspended until restart (go.estuary.dev/YRDsKd)")
+					logEntry.WithField("docs", numDocuments).Warn("replication failed to catch up in time, collection suspended until restart (go.estuary.dev/YRDsKd)")
 					return nil
 				}
 				if tc.Cause != nil {


### PR DESCRIPTION
**Description:**

I believe something screwy may be occurring in at least some of these cases and we're failing to catch up because Firestore is not actually sending us anything. But it's hard to be sure just from reading the debug-level logs because there's still plenty of change events from other collections, so logging the actual counter value on catchup failure should make this more blatantly obvious if it happens.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/912)
<!-- Reviewable:end -->
