### PR TITLE
source-mysql: Assume `SELECT *` has stable result ordering

### DIFF
--- a/source-mysql/backfill.go
+++ b/source-mysql/backfill.go
@@ -161,14 +161,8 @@ var columnBinaryKeyComparison = map[string]bool{
 }
 
 func (db *mysqlDatabase) keylessScanQuery(info *sqlcapture.DiscoveryInfo, schemaName, tableName string) string {
-	var orderColumns []string
-	for _, name := range info.ColumnNames {
-		orderColumns = append(orderColumns, quoteColumnName(name))
-	}
-
 	var query = new(strings.Builder)
 	fmt.Fprintf(query, "SELECT * FROM `%s`.`%s`", schemaName, tableName)
-	fmt.Fprintf(query, " ORDER BY %s", strings.Join(orderColumns, ", "))
 	fmt.Fprintf(query, " LIMIT %d", db.config.Advanced.BackfillChunkSize)
 	fmt.Fprintf(query, " OFFSET ?;")
 	return query.String()


### PR DESCRIPTION
**Description:**

When performing a keyless backfill query, we essentially just want to paginate the table according to *some* stable ordering but we don't care what that ordering is. In the past we've done this by explicitly saying `ORDER BY <table columns>` to get a specific consistent ordering which we *hoped* would correspond with something the database could actually index on.

This seemed like a reasonable thing to hope for because the DB actually does index rows by their literal primary-key values for a keyed table, and one obvious way to extend that system to tables with no primary key would be to treat the entire row as the key.

However the way that MySQL actually handles this is by assigning every row in a keyless table a secret row ID value (which is actually taken from a global monotonic counter) and indexing on that. Which means that the natural on-disk ordering of a keyless table is its insertion order.

As far as I know there is no way to explicitly request this order for a table, however a naive `SELECT * FROM <table>` will return results in this order in practice.

So because the current behavior can sometimes force a full sort of the entire dataset (and keyless tables are frequently massive append-only datasets where a full sort takes minutes or hours, in which case this stops being a mere performance issue and starts being an issue of the capture being fundamentally broken), we have no choice but to just trust that the database result ordering will be consistent, whatever it is.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/915)
<!-- Reviewable:end -->
