### PR TITLE
sqlcapture: Ignore views and other non-BASE TABLE entities

### DIFF
--- a/source-postgres/discovery.go
+++ b/source-postgres/discovery.go
@@ -3,11 +3,11 @@ package main
 import (
 	"context"
 	"encoding/json"
-	"time"
 	"fmt"
 	"net"
 	"reflect"
 	"strings"
+	"time"
 
 	"github.com/estuary/connectors/sqlcapture"
 	"github.com/invopop/jsonschema"
@@ -53,7 +53,11 @@ func (db *postgresDatabase) DiscoverTables(ctx context.Context) (map[string]*sql
 		var streamID = sqlcapture.JoinStreamID(column.TableSchema, column.TableName)
 		var info, ok = tableMap[streamID]
 		if !ok {
-			info = &sqlcapture.DiscoveryInfo{Schema: column.TableSchema, Name: column.TableName}
+			info = &sqlcapture.DiscoveryInfo{
+				Schema:    column.TableSchema,
+				Name:      column.TableName,
+				BaseTable: true, // PostgreSQL discovery queries only ever list 'BASE TABLE' entities
+			}
 		}
 
 		if info.Columns == nil {

--- a/sqlcapture/capture.go
+++ b/sqlcapture/capture.go
@@ -282,6 +282,23 @@ func (c *Capture) updateState(ctx context.Context) error {
 			return fmt.Errorf("table %q is a configured binding of this capture, but doesn't exist or isn't visible with current permissions", streamID)
 		}
 
+		// Only real tables with table_type = 'BASE TABLE' can be captured via replication.
+		// Discovery should not suggest capturing from views, but there are an unknown
+		// number of preexisting captures which may have views in their bindings, and we
+		// would rather silently start ignoring these rather than making them immediately
+		// be errors.
+		//
+		// This bit of logic is part of a bugfix in August 2023 and we would like to
+		// remove it in the future once it will not break any otherwise-successful
+		// captures.
+		if !discoveryInfo.BaseTable {
+			logrus.WithField("stream", streamID).Warn("automatically ignoring a binding whose type is not `BASE TABLE`")
+			if _, ok := c.State.Streams[streamID]; ok {
+				c.State.Streams[streamID] = &TableState{Mode: TableModeIgnore, dirty: true}
+			}
+			continue
+		}
+
 		// Select the primary key from the first available source. In order of priority:
 		//   - If the resource config specifies a primary key override then we'll use that.
 		//   - Normally we'll use the primary key from the collection spec.

--- a/sqlcapture/interface.go
+++ b/sqlcapture/interface.go
@@ -184,6 +184,7 @@ type DiscoveryInfo struct {
 	Columns     map[string]ColumnInfo // Information about each column of the table.
 	PrimaryKey  []string              // An ordered list of the column names which together form the table's primary key.
 	ColumnNames []string              // The names of all columns, in the table's natural order.
+	BaseTable   bool                  // True if the table type is 'BASE TABLE' and false for views or other not-physical-table entities.
 }
 
 // ColumnInfo holds metadata about a specific column of some table in the


### PR DESCRIPTION
**Description:**

Postgres discovery logic has long ignored views and other entities whose type is not `BASE TABLE`. Unfortunately it looks like MySQL and SQL Server discovery omitted that bit and would happily produce bindings for views, which will never really work properly since they don't have replication events.

This commit changes things so that MySQL and SQL Server discovery should correctly filter these entities, but in such a way that they do not produce an error at capture time for any preexisting captures. Instead views will be silently auto-ignored at capture time.

Hopefully we can unwind some of that logic later on once nobody has any views in their catalogs.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/916)
<!-- Reviewable:end -->
