### PR TITLE
source-postgres: Exclude child partitions from discovery

### DIFF
--- a/source-boilerplate/testing/testing.go
+++ b/source-boilerplate/testing/testing.go
@@ -86,6 +86,9 @@ func (cs *CaptureSpec) VerifyDiscover(ctx context.Context, t testing.TB, matcher
 		io.Copy(summary, bytes.NewReader(bs))
 		fmt.Fprintf(summary, "\n")
 	}
+	if len(bindings) == 0 {
+		fmt.Fprintf(summary, "(no output)")
+	}
 
 	cupaloy.SnapshotT(t, summary.String())
 }

--- a/source-postgres/.snapshots/TestDiscoveryExcludesSystemSchemas
+++ b/source-postgres/.snapshots/TestDiscoveryExcludesSystemSchemas
@@ -1,0 +1,1 @@
+(no output)

--- a/source-postgres/.snapshots/TestPartitionedTableDiscovery
+++ b/source-postgres/.snapshots/TestPartitionedTableDiscovery
@@ -1,0 +1,118 @@
+Binding 0:
+{
+    "recommended_name": "test_partitionedtablediscovery_27339326",
+    "resource_config_json": {
+      "mode": "Normal",
+      "namespace": "test",
+      "stream": "partitionedtablediscovery_27339326"
+    },
+    "document_schema_json": {
+      "$defs": {
+        "TestPartitionedtablediscovery_27339326": {
+          "type": "object",
+          "required": [
+            "logdate"
+          ],
+          "$anchor": "TestPartitionedtablediscovery_27339326",
+          "properties": {
+            "logdate": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          }
+        }
+      },
+      "allOf": [
+        {
+          "required": [
+            "_meta"
+          ],
+          "properties": {
+            "_meta": {
+              "type": "object",
+              "required": [
+                "op",
+                "source"
+              ],
+              "properties": {
+                "before": {
+                  "$ref": "#TestPartitionedtablediscovery_27339326",
+                  "description": "Record state immediately before this change was applied.",
+                  "reduce": {
+                    "strategy": "firstWriteWins"
+                  }
+                },
+                "op": {
+                  "enum": [
+                    "c",
+                    "d",
+                    "u"
+                  ],
+                  "description": "Change operation type: 'c' Create/Insert, 'u' Update, 'd' Delete."
+                },
+                "source": {
+                  "$id": "https://github.com/estuary/connectors/source-postgres/postgres-source",
+                  "properties": {
+                    "ts_ms": {
+                      "type": "integer",
+                      "description": "Unix timestamp (in millis) at which this event was recorded by the database."
+                    },
+                    "schema": {
+                      "type": "string",
+                      "description": "Database schema (namespace) of the event."
+                    },
+                    "snapshot": {
+                      "type": "boolean",
+                      "description": "Snapshot is true if the record was produced from an initial table backfill and unset if produced from the replication log."
+                    },
+                    "table": {
+                      "type": "string",
+                      "description": "Database table of the event."
+                    },
+                    "loc": {
+                      "items": {
+                        "type": "integer"
+                      },
+                      "type": "array",
+                      "maxItems": 3,
+                      "minItems": 3,
+                      "description": "Location of this WAL event as [last Commit.EndLSN; event LSN; current Begin.FinalLSN]. See https://www.postgresql.org/docs/current/protocol-logicalrep-message-formats.html"
+                    },
+                    "txid": {
+                      "type": "integer",
+                      "description": "The 32-bit transaction ID assigned by Postgres to the commit which produced this change."
+                    }
+                  },
+                  "type": "object",
+                  "required": [
+                    "schema",
+                    "table",
+                    "loc"
+                  ]
+                }
+              },
+              "reduce": {
+                "strategy": "merge"
+              }
+            }
+          },
+          "reduce": {
+            "strategy": "merge"
+          }
+        },
+        {
+          "$ref": "#TestPartitionedtablediscovery_27339326"
+        }
+      ]
+    },
+    "key": [
+      "/logdate"
+    ]
+  }
+


### PR DESCRIPTION
**Description:**

This partially addresses https://github.com/estuary/connectors/issues/751 (specifically point #2) but the other bits of polish (documentation updates and better error messages) are still needed at some point.

This commit factors out table-enumeration from column-listing for simplicity (because the query was starting to get hard to follow) and to match what we did for MySQL and SQL Server just yesterday.

The new table-enumeration query is completely different from the old one but I believe it returns the same set of tables as before, minus child partitions. I ran a couple of the discovery tests to spot-check the results and added a couple new ones, so I think it is correct.

As with the other connectors, the column-listing query no longer tries to also filter for table eligibility. Its only job is to list every column of every table in the database.

**Workflow steps:**

Child partitions of a partitioned table should no longer be returned by discovery, which means that blindly refreshing the bindings of a capture should be safe in more circumstances.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/917)
<!-- Reviewable:end -->
