### PR TITLE
sqlcapture: Replace our slices package with the standard one

### DIFF
--- a/source-sqlserver/discovery.go
+++ b/source-sqlserver/discovery.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"slices"
 	"strings"
 
-	"github.com/estuary/connectors/go/pkg/slices"
 	"github.com/estuary/connectors/sqlcapture"
 	"github.com/invopop/jsonschema"
 	log "github.com/sirupsen/logrus"

--- a/sqlcapture/main.go
+++ b/sqlcapture/main.go
@@ -5,10 +5,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"slices"
 	"strings"
 
 	cerrors "github.com/estuary/connectors/go/connector-errors"
-	"github.com/estuary/connectors/go/pkg/slices"
 	schemagen "github.com/estuary/connectors/go/schema-gen"
 	boilerplate "github.com/estuary/connectors/source-boilerplate"
 	pc "github.com/estuary/flow/go/protocols/capture"


### PR DESCRIPTION
**Description:**

Just fixing a race between my collations work PR and Will Baker's update to Go 1.21

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/926)
<!-- Reviewable:end -->
