### PR TITLE
source-sqlserver: Stop CI tests on first failure

### DIFF
--- a/source-sqlserver/Dockerfile
+++ b/source-sqlserver/Dockerfile
@@ -20,7 +20,7 @@ COPY source-sqlserver    ./source-sqlserver
 ARG TEST_DATABASE=yes
 ENV TEST_DATABASE=$TEST_DATABASE
 ENV CI_BUILD=yes
-RUN go test -short -v ./source-sqlserver/... -timeout=60m
+RUN go test -short -failfast -v ./source-sqlserver/... -timeout=60m
 
 # Build the connector.
 RUN go build -o ./connector -v ./source-sqlserver/...


### PR DESCRIPTION
**Description:**

We run a lot of tests in CI and they should all pass most of the time, but if a single one fails then it can take a while before we actually learn this and there's really no reason to be waiting that long. So if one fails, stop the test run immediately so we get quicker feedback and/or an opportunity to retry if it looks like flakiness.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/927)
<!-- Reviewable:end -->
