### PR TITLE
materialize-{redshift,bigquery}: add "update delay" advanced configuration

### DIFF
--- a/materialize-bigquery/.snapshots/TestSpecification
+++ b/materialize-bigquery/.snapshots/TestSpecification
@@ -46,6 +46,27 @@
         "title": "Billing Project ID",
         "description": "Billing Project ID connected to the BigQuery dataset. Defaults to Project ID if not specified.",
         "order": 6
+      },
+      "advanced": {
+        "properties": {
+          "updateDelay": {
+            "type": "string",
+            "enum": [
+              "15m",
+              "30m",
+              "1h",
+              "2h",
+              "4h"
+            ],
+            "title": "Update Delay",
+            "description": "Potentially reduce compute time by increasing the delay between updates."
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "title": "Advanced Options",
+        "description": "Options for advanced users. You should not typically need to modify these.",
+        "advanced": true
       }
     },
     "type": "object",

--- a/materialize-bigquery/.snapshots/TestSpecification
+++ b/materialize-bigquery/.snapshots/TestSpecification
@@ -52,6 +52,7 @@
           "updateDelay": {
             "type": "string",
             "enum": [
+              "0s",
               "15m",
               "30m",
               "1h",
@@ -59,7 +60,7 @@
               "4h"
             ],
             "title": "Update Delay",
-            "description": "Potentially reduce compute time by increasing the delay between updates."
+            "description": "Potentially reduce compute time by increasing the delay between updates. Defaults to 30 minutes if unset."
           }
         },
         "additionalProperties": false,

--- a/materialize-redshift/.snapshots/TestSpecification
+++ b/materialize-redshift/.snapshots/TestSpecification
@@ -71,6 +71,7 @@
           "updateDelay": {
             "type": "string",
             "enum": [
+              "0s",
               "15m",
               "30m",
               "1h",
@@ -78,7 +79,7 @@
               "4h"
             ],
             "title": "Update Delay",
-            "description": "Potentially reduce active cluster time by increasing the delay between updates."
+            "description": "Potentially reduce active cluster time by increasing the delay between updates. Defaults to 30 minutes if unset."
           }
         },
         "additionalProperties": false,

--- a/materialize-redshift/.snapshots/TestSpecification
+++ b/materialize-redshift/.snapshots/TestSpecification
@@ -66,6 +66,27 @@
         "description": "A prefix that will be used to store objects in S3.",
         "order": 9
       },
+      "advanced": {
+        "properties": {
+          "updateDelay": {
+            "type": "string",
+            "enum": [
+              "15m",
+              "30m",
+              "1h",
+              "2h",
+              "4h"
+            ],
+            "title": "Update Delay",
+            "description": "Potentially reduce active cluster time by increasing the delay between updates."
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "title": "Advanced Options",
+        "description": "Options for advanced users. You should not typically need to modify these.",
+        "advanced": true
+      },
       "networkTunnel": {
         "properties": {
           "sshForwarding": {

--- a/materialize-snowflake/.snapshots/TestSpecification
+++ b/materialize-snowflake/.snapshots/TestSpecification
@@ -57,6 +57,7 @@
           "updateDelay": {
             "type": "string",
             "enum": [
+              "0s",
               "15m",
               "30m",
               "1h",
@@ -64,7 +65,7 @@
               "4h"
             ],
             "title": "Update Delay",
-            "description": "Potentially reduce active warehouse time by increasing the delay between updates."
+            "description": "Potentially reduce active warehouse time by increasing the delay between updates. Defaults to 30 minutes if unset."
           }
         },
         "additionalProperties": false,

--- a/materialize-snowflake/snowflake.go
+++ b/materialize-snowflake/snowflake.go
@@ -39,7 +39,7 @@ type config struct {
 }
 
 type advancedConfig struct {
-	UpdateDelay string `json:"updateDelay,omitempty" jsonschema:"title=Update Delay,description=Potentially reduce active warehouse time by increasing the delay between updates.,enum=15m,enum=30m,enum=1h,enum=2h,enum=4h"`
+	UpdateDelay string `json:"updateDelay,omitempty" jsonschema:"title=Update Delay,description=Potentially reduce active warehouse time by increasing the delay between updates. Defaults to 30 minutes if unset.,enum=0s,enum=15m,enum=30m,enum=1h,enum=2h,enum=4h"`
 }
 
 // ToURI converts the Config to a DSN string.
@@ -117,15 +117,8 @@ func (c *config) Validate() error {
 		}
 	}
 
-	if c.Advanced.UpdateDelay != "" {
-		parsed, err := time.ParseDuration(c.Advanced.UpdateDelay)
-		if err != nil {
-			return fmt.Errorf("could not parse Update Delay '%s': must be a valid Go duration string", c.Advanced.UpdateDelay)
-		}
-
-		if parsed < 0 {
-			return fmt.Errorf("update delay '%s' must not be negative", c.Advanced.UpdateDelay)
-		}
+	if _, err := sql.ParseDelay(c.Advanced.UpdateDelay); err != nil {
+		return err
 	}
 
 	return validHost(c.Host)
@@ -405,13 +398,8 @@ func newTransactor(
 		cfg: cfg,
 	}
 
-	if cfg.Advanced.UpdateDelay != "" {
-		// UpdateDelay has already been validated in (*config).Validate. This parsing is not
-		// expected to fail.
-		d.updateDelay, err = time.ParseDuration(cfg.Advanced.UpdateDelay)
-		if err != nil {
-			return nil, fmt.Errorf("could not parse UpdateDelay '%s'", cfg.Advanced.UpdateDelay)
-		}
+	if d.updateDelay, err = sql.ParseDelay(cfg.Advanced.UpdateDelay); err != nil {
+		return nil, err
 	}
 
 	d.store.fence = &fence
@@ -569,10 +557,7 @@ func (d *transactor) Store(it *pm.StoreIterator) (pm.StartCommitFunc, error) {
 			return nil, pf.FinishedOperation(fmt.Errorf("marshalling checkpoint: %w", err))
 		}
 
-		// Skip the delay on the first round of transactions, which is often an artificially small
-		// transaction, caused by the reading of loads stalling out prematurely when the connector
-		// first starts up.
-		return nil, sql.CommitWithDelay(ctx, d.store.round == 1, d.updateDelay, it.Total, d.commit)
+		return nil, sql.CommitWithDelay(ctx, d.store.round, d.updateDelay, it.Total, d.commit)
 	}, nil
 }
 

--- a/materialize-snowflake/snowflake.go
+++ b/materialize-snowflake/snowflake.go
@@ -569,6 +569,9 @@ func (d *transactor) Store(it *pm.StoreIterator) (pm.StartCommitFunc, error) {
 			return nil, pf.FinishedOperation(fmt.Errorf("marshalling checkpoint: %w", err))
 		}
 
+		// Skip the delay on the first round of transactions, which is often an artificially small
+		// transaction, caused by the reading of loads stalling out prematurely when the connector
+		// first starts up.
 		return nil, sql.CommitWithDelay(ctx, d.store.round == 1, d.updateDelay, it.Total, d.commit)
 	}, nil
 }

--- a/materialize-sql/driver.go
+++ b/materialize-sql/driver.go
@@ -8,14 +8,12 @@ import (
 	"os"
 	"slices"
 	"strings"
-	"time"
 
 	cerrors "github.com/estuary/connectors/go/connector-errors"
 	schemagen "github.com/estuary/connectors/go/schema-gen"
 	boilerplate "github.com/estuary/connectors/materialize-boilerplate"
 	pf "github.com/estuary/flow/go/protocols/flow"
 	pm "github.com/estuary/flow/go/protocols/materialize"
-	log "github.com/sirupsen/logrus"
 	"go.gazette.dev/core/consumer/protocol"
 )
 
@@ -359,68 +357,4 @@ func (d *Driver) NewTransactor(ctx context.Context, open pm.Request_Open) (pm.Tr
 
 func mustGetTenantNameFromTaskName(taskName string) string {
 	return strings.Split(taskName, "/")[0]
-}
-
-// storeThreshold is a somewhat crude indication that a transaction was likely part of a backfill
-// vs. a smaller incremental streaming transaction. If a materialization is configured with a commit
-// delay, it should only apply that delay to transactions that occur after it has fully backfilled
-// from the collection. The idea is that if a transaction stored a lot of documents it's probably
-// part of a backfill.
-var storeThreshold = 5_000_000
-
-// CommitWithDelay wraps a commitFn in an async operation that may add additional delay prior to
-// returning. When used as the returned OpFuture from a materialization utilizing async commits,
-// this can spread out transaction processing and result in fewer, larger transactions which may be
-// desirable to reduce warehouse compute costs or comply with rate limits. The delay is bypassed if
-// the actual commit operation takes longer than the configured delay, or if they number of stored
-// documents is large (see storeThreshold above).
-//
-// Delaying the return from this function delays acknowledgement back to the runtime that the commit
-// has finished. The commit will still apply to the endpoint, but holding back the runtime
-// acknowledgement will delay the start of the next transaction while allowing the runtime to
-// continue combining over documents for the next transaction.
-//
-// It is always possible for a connector to restart between committing to the endpoint and sending
-// the runtime acknowledgement of that commit. The chance of this happening is greater when
-// intentionally adding a delay between these events. When the endpoint is authoritative and
-// persists checkpoints transactionally with updating the state of the view (as is typical with a
-// SQL materialization), what will happen in this case is that when the connector restarts it will
-// read the previously persisted checkpoint and acknowledge it to the runtime then. In this way the
-// materialization will resume from where it left off with respect to the endpoint state.
-func CommitWithDelay(ctx context.Context, skipDelay bool, delay time.Duration, stored int, commitFn func(context.Context) error) pf.OpFuture {
-	return pf.RunAsyncOperation(func() error {
-		started := time.Now()
-
-		if err := commitFn(ctx); err != nil {
-			return err
-		}
-
-		if skipDelay {
-			log.Debug("will not delay commit acknowledge since skipDelay was true")
-			return nil
-		}
-
-		remainingDelay := delay - time.Since(started)
-
-		logEntry := log.WithFields(log.Fields{
-			"stored":          stored,
-			"storedThreshold": storeThreshold,
-			"remainingDelay":  remainingDelay.String(),
-			"configuredDelay": delay.String(),
-		})
-
-		if stored > storeThreshold || remainingDelay <= 0 {
-			logEntry.Debug("will acknowledge commit without further delay")
-			return nil
-		}
-
-		logEntry.Debug("delaying before acknowledging commit")
-
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		case <-time.After(remainingDelay):
-			return nil
-		}
-	})
 }

--- a/materialize-sql/update_delay.go
+++ b/materialize-sql/update_delay.go
@@ -1,0 +1,95 @@
+package sql
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	pf "github.com/estuary/flow/go/protocols/flow"
+	log "github.com/sirupsen/logrus"
+)
+
+const (
+	// Default update delay for materializations opting in to CommitWithDelay to use if no other
+	// delay has been set.
+	defaultUpdateDelay = 30 * time.Minute
+
+	// storeThreshold is a somewhat crude indication that a transaction was likely part of a backfill
+	// vs. a smaller incremental streaming transaction. If a materialization is configured with a commit
+	// delay, it should only apply that delay to transactions that occur after it has fully backfilled
+	// from the collection. The idea is that if a transaction stored a lot of documents it's probably
+	// part of a backfill.
+	storeThreshold = 1_000_000
+)
+
+// CommitWithDelay wraps a commitFn in an async operation that may add additional delay prior to
+// returning. When used as the returned OpFuture from a materialization utilizing async commits,
+// this can spread out transaction processing and result in fewer, larger transactions which may be
+// desirable to reduce warehouse compute costs or comply with rate limits. The delay is bypassed if
+// the actual commit operation takes longer than the configured delay, or if they number of stored
+// documents is large (see storeThreshold above).
+//
+// Delaying the return from this function delays acknowledgement back to the runtime that the commit
+// has finished. The commit will still apply to the endpoint, but holding back the runtime
+// acknowledgement will delay the start of the next transaction while allowing the runtime to
+// continue combining over documents for the next transaction.
+//
+// It is always possible for a connector to restart between committing to the endpoint and sending
+// the runtime acknowledgement of that commit. The chance of this happening is greater when
+// intentionally adding a delay between these events. When the endpoint is authoritative and
+// persists checkpoints transactionally with updating the state of the view (as is typical with a
+// SQL materialization), what will happen in this case is that when the connector restarts it will
+// read the previously persisted checkpoint and acknowledge it to the runtime then. In this way the
+// materialization will resume from where it left off with respect to the endpoint state.
+func CommitWithDelay(ctx context.Context, round int, delay time.Duration, stored int, commitFn func(context.Context) error) pf.OpFuture {
+	return pf.RunAsyncOperation(func() error {
+		started := time.Now()
+
+		if err := commitFn(ctx); err != nil {
+			return err
+		}
+
+		if round == 1 {
+			// Always skip the delay on the first round of transactions, which is often an
+			// artificially small transaction of the immediately-ready documents.
+			log.Debug("will not delay commit acknowledgement of the first transaction")
+			return nil
+		}
+
+		remainingDelay := delay - time.Since(started)
+
+		logEntry := log.WithFields(log.Fields{
+			"stored":          stored,
+			"storedThreshold": storeThreshold,
+			"remainingDelay":  remainingDelay.String(),
+			"configuredDelay": delay.String(),
+		})
+
+		if stored > storeThreshold || remainingDelay <= 0 {
+			logEntry.Debug("will acknowledge commit without further delay")
+			return nil
+		}
+
+		logEntry.Debug("delaying before acknowledging commit")
+
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(remainingDelay):
+			return nil
+		}
+	})
+}
+
+// ParseDelay parses the delay Go duration string, returning and error if it is not valid, the
+// parsed value if it is not an empty string, and the defaultUpdateDelay otherwise.
+func ParseDelay(delay string) (time.Duration, error) {
+	if delay != "" {
+		parsed, err := time.ParseDuration(delay)
+		if err != nil {
+			return 0, fmt.Errorf("could not parse updateDelay '%s': must be a valid Go duration string", delay)
+		}
+		return parsed, nil
+	}
+	return defaultUpdateDelay, nil
+}

--- a/tests/materialize/materialize-bigquery/setup.sh
+++ b/tests/materialize/materialize-bigquery/setup.sh
@@ -15,7 +15,10 @@ config_json_template='{
    "dataset":           "$DATASET",
    "region":            "$REGION",
    "bucket":            "$BUCKET",
-   "credentials_json":  $GCP_SERVICE_ACCOUNT_KEY_QUOTED
+   "credentials_json":  $GCP_SERVICE_ACCOUNT_KEY_QUOTED,
+   "advanced": {
+      "updateDelay": "0s"
+    }
 }'
 
 resources_json_template='[

--- a/tests/materialize/materialize-redshift/setup.sh
+++ b/tests/materialize/materialize-redshift/setup.sh
@@ -21,7 +21,10 @@ config_json_template='{
    "bucket":              "$REDSHIFT_BUCKET",
    "awsAccessKeyId":      "$AWS_ACCESS_KEY_ID",
    "awsSecretAccessKey":  "$AWS_SECRET_ACCESS_KEY",
-   "region":              "$AWS_REGION"
+   "region":              "$AWS_REGION",
+   "advanced": {
+      "updateDelay": "0s"
+    }
 }'
 
 resources_json_template='[

--- a/tests/materialize/materialize-snowflake/setup.sh
+++ b/tests/materialize/materialize-snowflake/setup.sh
@@ -19,7 +19,10 @@ config_json_template='{
    "password":  "$SNOWFLAKE_PASSWORD",
    "database":  "$SNOWFLAKE_DATABASE",
    "schema":    "$SNOWFLAKE_SCHEMA",
-   "warehouse": "$SNOWFLAKE_WAREHOUSE"
+   "warehouse": "$SNOWFLAKE_WAREHOUSE",
+   "advanced": {
+      "updateDelay": "0s"
+    }
 }'
 
 resources_json_template='[


### PR DESCRIPTION
**Description:**

Adds an "update delay" configuration to BigQuery and Redshift, identical to the one Snowflake has (see https://github.com/estuary/connectors/commit/66a370c84b27e3f64fa4f83662d1fa5d23b86e59).

Also sets a default delay of 30 minutes unless otherwise configured, and lowers the store threshold for skipping the delay to 1 million documents.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

Docs will need updated for both connectors to reflect the additional configuration option

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/932)
<!-- Reviewable:end -->
