### PR TITLE
source-postgres: Normalize unrepresentable timestamps to zero

### DIFF
--- a/source-postgres/datatype_test.go
+++ b/source-postgres/datatype_test.go
@@ -59,9 +59,11 @@ func TestDatatypes(t *testing.T) {
 		{ColumnType: `date`, ExpectType: `{"type":["string","null"],"format":"date-time"}`, InputValue: `'January 8, 1999'`, ExpectValue: `"1999-01-08T00:00:00Z"`},
 		{ColumnType: `timestamp`, ExpectType: `{"type":["string","null"],"format":"date-time"}`, InputValue: `'January 8, 1999'`, ExpectValue: `"1999-01-08T00:00:00Z"`},
 		{ColumnType: `timestamp without time zone`, ExpectType: `{"type":["string","null"],"format":"date-time"}`, InputValue: `'January 8, 1999'`, ExpectValue: `"1999-01-08T00:00:00Z"`},
-		{ColumnType: `timestamp`, ExpectType: `{"type":["string","null"],"format":"date-time"}`, InputValue: `'infinity'`, ExpectValue: fmt.Sprintf(`%q`, infinityTimestamp)},
-		{ColumnType: `timestamp`, ExpectType: `{"type":["string","null"],"format":"date-time"}`, InputValue: `'-infinity'`, ExpectValue: fmt.Sprintf(`%q`, negativeInfinityTimestamp)},
+		{ColumnType: `timestamp`, ExpectType: `{"type":["string","null"],"format":"date-time"}`, InputValue: `'infinity'`, ExpectValue: `"9999-12-31T23:59:59Z"`},
+		{ColumnType: `timestamp`, ExpectType: `{"type":["string","null"],"format":"date-time"}`, InputValue: `'-infinity'`, ExpectValue: `"0000-01-01T00:00:00Z"`},
 		{ColumnType: `timestamp`, ExpectType: `{"type":["string","null"],"format":"date-time"}`, InputValue: `'epoch'`, ExpectValue: `"1970-01-01T00:00:00Z"`},
+		{ColumnType: `timestamp`, ExpectType: `{"type":["string","null"],"format":"date-time"}`, InputValue: `'20222-08-31T00:00:00Z'`, ExpectValue: `"0000-01-01T00:00:00Z"`},
+		{ColumnType: `timestamp`, ExpectType: `{"type":["string","null"],"format":"date-time"}`, InputValue: `'January 8, 99 BC'`, ExpectValue: `"0000-01-01T00:00:00Z"`},
 
 		// TODO(wgd): The 'timestamp with time zone' type produces inconsistent results between
 		// table scanning and replication events. They're both valid timestamps, but they differ.


### PR DESCRIPTION
**Description:**

Postgres permits timestamps with years from 4713 BC to 294276 AD, but we serialize timestamps to RFC3339 strings, which can only go from the year 0 AD to 9999 AD.

In general timestamps with years >9999 aren't actually real data, they're typos like `20231`. So instead of trying to get clever, we'll normalize any out-of-range values to `0000-01-01T00:00:00Z`.

An exception is currently made for the special `infinity` timestamp value, which is still translated as `9999-12-31T23:59:59Z`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/933)
<!-- Reviewable:end -->
