### PR TITLE
source-mysql: Ignore `DROP TRIGGER` query events via regex

### DIFF
--- a/source-mysql/replication.go
+++ b/source-mysql/replication.go
@@ -438,7 +438,7 @@ func decodeRow(streamID string, colNames []string, row []interface{}) (map[strin
 // with the binlog Query Events for some statements like GRANT and CREATE USER.
 // TODO(johnny): SET STATEMENT is not safe in the general case, and we want to re-visit
 // by extracting and ignoring a SET STATEMENT stanza prior to parsing.
-var ignoreQueriesRe = regexp.MustCompile(`(?i)^(BEGIN|COMMIT|GRANT|REVOKE|CREATE USER|CREATE DEFINER|DROP USER|ALTER USER|DROP PROCEDURE|SET STATEMENT|# |/\*)`)
+var ignoreQueriesRe = regexp.MustCompile(`(?i)^(BEGIN|COMMIT|GRANT|REVOKE|CREATE USER|CREATE DEFINER|DROP USER|ALTER USER|DROP PROCEDURE|DROP TRIGGER|SET STATEMENT|# |/\*)`)
 
 func (rs *mysqlReplicationStream) handleQuery(schema, query string) error {
 	// There are basically three types of query events we might receive:
@@ -461,7 +461,7 @@ func (rs *mysqlReplicationStream) handleQuery(schema, query string) error {
 
 	var stmt, err = sqlparser.Parse(query)
 	if err != nil {
-		return fmt.Errorf("parsing query %q: %w", query, err)
+		return fmt.Errorf("unable to parse query %q: %w", query, err)
 	}
 	logrus.WithField("stmt", fmt.Sprintf("%#v", stmt)).Debug("parsed query")
 


### PR DESCRIPTION
**Description:**

These don't parse successfully (at least in some cases) but we also don't care about them.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/934)
<!-- Reviewable:end -->
