### PR TITLE
source-firestore: Restart failed streams, skipping ahead to the current time

### DIFF
--- a/source-firestore/.snapshots/TestAddedBindingSameGroup-one
+++ b/source-firestore/.snapshots/TestAddedBindingSameGroup-one
@@ -6,5 +6,5 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"Resources":{"flow_source_tests/*/users/*/docs":{"ReadTime":"<TIMESTAMP>"}}}
+{"Resources":{"flow_source_tests/*/users/*/docs":{"Backfill":{"Completed":true,"Cursor":"","MTime":"<TIMESTAMP>","StartAfter":"<TIMESTAMP>"},"ReadTime":"<TIMESTAMP>"}}}
 

--- a/source-firestore/.snapshots/TestAddedBindingSameGroup-two
+++ b/source-firestore/.snapshots/TestAddedBindingSameGroup-two
@@ -6,12 +6,14 @@
 {"_meta":{"path":"projects/project-id-123456/databases/(default)/documents/flow_source_tests/TestAddedBindingSameGroup/groups/3/docs/7","ctime":"<TIMESTAMP>","mtime":"<TIMESTAMP>"},"data":7}
 {"_meta":{"path":"projects/project-id-123456/databases/(default)/documents/flow_source_tests/TestAddedBindingSameGroup/groups/3/docs/8","ctime":"<TIMESTAMP>","mtime":"<TIMESTAMP>"},"data":8}
 # ================================
-# Collection "flow_source_tests/*/users/*/docs": 2 Documents
+# Collection "flow_source_tests/*/users/*/docs": 4 Documents
 # ================================
+{"_meta":{"path":"projects/project-id-123456/databases/(default)/documents/flow_source_tests/TestAddedBindingSameGroup/users/1/docs/1","ctime":"<TIMESTAMP>","mtime":"<TIMESTAMP>"},"data":1}
+{"_meta":{"path":"projects/project-id-123456/databases/(default)/documents/flow_source_tests/TestAddedBindingSameGroup/users/1/docs/2","ctime":"<TIMESTAMP>","mtime":"<TIMESTAMP>"},"data":2}
 {"_meta":{"path":"projects/project-id-123456/databases/(default)/documents/flow_source_tests/TestAddedBindingSameGroup/users/1/docs/3","ctime":"<TIMESTAMP>","mtime":"<TIMESTAMP>"},"data":3}
 {"_meta":{"path":"projects/project-id-123456/databases/(default)/documents/flow_source_tests/TestAddedBindingSameGroup/users/1/docs/4","ctime":"<TIMESTAMP>","mtime":"<TIMESTAMP>"},"data":4}
 # ================================
 # Final State Checkpoint
 # ================================
-{"Resources":{"flow_source_tests/*/groups/*/docs":{"ReadTime":"<TIMESTAMP>"},"flow_source_tests/*/users/*/docs":{"ReadTime":"<TIMESTAMP>"}}}
+{"Resources":{"flow_source_tests/*/groups/*/docs":{"Backfill":{"Completed":true,"Cursor":"","MTime":"<TIMESTAMP>","StartAfter":"<TIMESTAMP>"},"ReadTime":"<TIMESTAMP>"},"flow_source_tests/*/users/*/docs":{"Backfill":{"Completed":true,"Cursor":"","MTime":"<TIMESTAMP>","StartAfter":"<TIMESTAMP>"},"ReadTime":"<TIMESTAMP>"}}}
 

--- a/source-firestore/.snapshots/TestBindingDeletion-one
+++ b/source-firestore/.snapshots/TestBindingDeletion-one
@@ -24,5 +24,5 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"Resources":{"flow_source_tests/*/docs":{"ReadTime":"<TIMESTAMP>"}}}
+{"Resources":{"flow_source_tests/*/docs":{"Backfill":{"Completed":true,"Cursor":"","MTime":"<TIMESTAMP>","StartAfter":"<TIMESTAMP>"},"ReadTime":"<TIMESTAMP>"}}}
 

--- a/source-firestore/.snapshots/TestBindingDeletion-three
+++ b/source-firestore/.snapshots/TestBindingDeletion-three
@@ -24,5 +24,5 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"Resources":{"flow_source_tests/*/docs":{"ReadTime":"<TIMESTAMP>"}}}
+{"Resources":{"flow_source_tests/*/docs":{"Backfill":{"Completed":true,"Cursor":"","MTime":"<TIMESTAMP>","StartAfter":"<TIMESTAMP>"},"ReadTime":"<TIMESTAMP>"}}}
 

--- a/source-firestore/.snapshots/TestBindingDeletion-two
+++ b/source-firestore/.snapshots/TestBindingDeletion-two
@@ -1,5 +1,5 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"Resources":{"flow_source_tests/*/other":{"ReadTime":"<TIMESTAMP>"}}}
+{"Resources":{"flow_source_tests/*/other":{"Backfill":{"Completed":true,"Cursor":"","MTime":"<TIMESTAMP>","StartAfter":"<TIMESTAMP>"},"ReadTime":"<TIMESTAMP>"}}}
 

--- a/source-firestore/.snapshots/TestDeletions-one
+++ b/source-firestore/.snapshots/TestDeletions-one
@@ -6,5 +6,5 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"Resources":{"flow_source_tests/*/docs":{"ReadTime":"<TIMESTAMP>"}}}
+{"Resources":{"flow_source_tests/*/docs":{"Backfill":{"Completed":true,"Cursor":"","MTime":"<TIMESTAMP>","StartAfter":"<TIMESTAMP>"},"ReadTime":"<TIMESTAMP>"}}}
 

--- a/source-firestore/.snapshots/TestDeletions-two
+++ b/source-firestore/.snapshots/TestDeletions-two
@@ -6,5 +6,5 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"Resources":{"flow_source_tests/*/docs":{"ReadTime":"<TIMESTAMP>"}}}
+{"Resources":{"flow_source_tests/*/docs":{"Backfill":{"Completed":true,"Cursor":"","MTime":"<TIMESTAMP>","StartAfter":"<TIMESTAMP>"},"ReadTime":"<TIMESTAMP>"}}}
 

--- a/source-firestore/.snapshots/TestManySmallWrites-one
+++ b/source-firestore/.snapshots/TestManySmallWrites-one
@@ -29,5 +29,5 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"Resources":{"flow_source_tests/*/users/*/docs":{"ReadTime":"<TIMESTAMP>"}}}
+{"Resources":{"flow_source_tests/*/users/*/docs":{"Backfill":{"Completed":true,"Cursor":"","MTime":"<TIMESTAMP>","StartAfter":"<TIMESTAMP>"},"ReadTime":"<TIMESTAMP>"}}}
 

--- a/source-firestore/.snapshots/TestManySmallWrites-two
+++ b/source-firestore/.snapshots/TestManySmallWrites-two
@@ -29,5 +29,5 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"Resources":{"flow_source_tests/*/users/*/docs":{"ReadTime":"<TIMESTAMP>"}}}
+{"Resources":{"flow_source_tests/*/users/*/docs":{"Backfill":{"Completed":true,"Cursor":"","MTime":"<TIMESTAMP>","StartAfter":"<TIMESTAMP>"},"ReadTime":"<TIMESTAMP>"}}}
 

--- a/source-firestore/.snapshots/TestMultipleWatches-one
+++ b/source-firestore/.snapshots/TestMultipleWatches-one
@@ -85,5 +85,5 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"Resources":{"flow_source_tests/*/users/*/docs":{"ReadTime":"<TIMESTAMP>"},"flow_source_tests/*/users/*/notes":{"ReadTime":"<TIMESTAMP>"},"flow_source_tests/*/users/*/tasks":{"ReadTime":"<TIMESTAMP>"}}}
+{"Resources":{"flow_source_tests/*/users/*/docs":{"Backfill":{"Completed":true,"Cursor":"","MTime":"<TIMESTAMP>","StartAfter":"<TIMESTAMP>"},"ReadTime":"<TIMESTAMP>"},"flow_source_tests/*/users/*/notes":{"Backfill":{"Completed":true,"Cursor":"","MTime":"<TIMESTAMP>","StartAfter":"<TIMESTAMP>"},"ReadTime":"<TIMESTAMP>"},"flow_source_tests/*/users/*/tasks":{"Backfill":{"Completed":true,"Cursor":"","MTime":"<TIMESTAMP>","StartAfter":"<TIMESTAMP>"},"ReadTime":"<TIMESTAMP>"}}}
 

--- a/source-firestore/.snapshots/TestMultipleWatches-two
+++ b/source-firestore/.snapshots/TestMultipleWatches-two
@@ -85,5 +85,5 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"Resources":{"flow_source_tests/*/users/*/docs":{"ReadTime":"<TIMESTAMP>"},"flow_source_tests/*/users/*/notes":{"ReadTime":"<TIMESTAMP>"},"flow_source_tests/*/users/*/tasks":{"ReadTime":"<TIMESTAMP>"}}}
+{"Resources":{"flow_source_tests/*/users/*/docs":{"Backfill":{"Completed":true,"Cursor":"","MTime":"<TIMESTAMP>","StartAfter":"<TIMESTAMP>"},"ReadTime":"<TIMESTAMP>"},"flow_source_tests/*/users/*/notes":{"Backfill":{"Completed":true,"Cursor":"","MTime":"<TIMESTAMP>","StartAfter":"<TIMESTAMP>"},"ReadTime":"<TIMESTAMP>"},"flow_source_tests/*/users/*/tasks":{"Backfill":{"Completed":true,"Cursor":"","MTime":"<TIMESTAMP>","StartAfter":"<TIMESTAMP>"},"ReadTime":"<TIMESTAMP>"}}}
 

--- a/source-firestore/.snapshots/TestSimpleCapture-one
+++ b/source-firestore/.snapshots/TestSimpleCapture-one
@@ -10,5 +10,5 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"Resources":{"flow_source_tests/*/docs":{"ReadTime":"<TIMESTAMP>"}}}
+{"Resources":{"flow_source_tests/*/docs":{"Backfill":{"Completed":true,"Cursor":"","MTime":"<TIMESTAMP>","StartAfter":"<TIMESTAMP>"},"ReadTime":"<TIMESTAMP>"}}}
 

--- a/source-firestore/.snapshots/TestSimpleCapture-two
+++ b/source-firestore/.snapshots/TestSimpleCapture-two
@@ -10,5 +10,5 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"Resources":{"flow_source_tests/*/docs":{"ReadTime":"<TIMESTAMP>"}}}
+{"Resources":{"flow_source_tests/*/docs":{"Backfill":{"Completed":true,"Cursor":"","MTime":"<TIMESTAMP>","StartAfter":"<TIMESTAMP>"},"ReadTime":"<TIMESTAMP>"}}}
 

--- a/source-firestore/main_test.go
+++ b/source-firestore/main_test.go
@@ -267,6 +267,7 @@ func simpleBindings(t testing.TB, names ...string) []*flow.CaptureSpec_Binding {
 	for _, name := range names {
 		var path = "flow_source_tests/*/" + name
 		bindings = append(bindings, &flow.CaptureSpec_Binding{
+			Collection:         flow.CollectionSpec{Name: flow.Collection(path)},
 			ResourceConfigJson: json.RawMessage(fmt.Sprintf(`{"path": %q, "backfillMode": "async"}`, path)),
 			ResourcePath:       []string{path},
 		})

--- a/source-firestore/pull.go
+++ b/source-firestore/pull.go
@@ -677,6 +677,9 @@ func (c *capture) StreamChanges(ctx context.Context, client *firestore_v1.Client
 					} else if err := c.Output.Checkpoint(checkpointJSON, true); err != nil {
 						return err
 					}
+					time.AfterFunc(backfillRestartDelay+time.Hour, func() {
+						logEntry.Fatal("forcing connector restart to establish consistency")
+					})
 					target.ResumeType = &firestore_pb.Target_ReadTime{ReadTime: timestamppb.New(time.Now())}
 					listenClient = nil
 				}


### PR DESCRIPTION
**Description:**

Modifies `source-firestore` so that when a change stream fails to catch up in time it will:

1. Immediately skip ahead to the current time and continue streaming changes from there.
2. Set a new 'Inconsistent' flag on the resource state, indicating that the output is no longer guaranteed to be perfectly consistent with the source dataset.
3. Fire off a sneaky timer in the background which will force a connector restart after a good long while, which gives the connector an opportunity to re-establish consistency at startup (and avoids the complexity of cancelling and restarting backfills at arbitrary times).

In addition, the connector will now trigger a new backfill of any inconsistent bindings the next time the connector restarts, while also skipping the change stream ahead again to maximize the chance that it remains caught up. Backfills are now rate-limited so that at least `backfillRestartDelay` (currently 6 hours) must elapse since the start of the previous backfill before the next one begins.

**Workflow steps:**

Maybe high-volume Firestore collections will actually work reliably. We'll see.

**Notes for reviewers:**

I'm not super happy with this code, but it's what I've got right now. I think there's a decent chance it will solve the problem for the moment, and I really don't want to do the level of rewrite that seems to be necessary to actually do this better.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/936)
<!-- Reviewable:end -->
