### PR TITLE
connectors: verify that addresses do not contain leading or trailing spaces

### DIFF
--- a/go/util/util.go
+++ b/go/util/util.go
@@ -1,0 +1,16 @@
+package util
+
+import (
+	"fmt"
+	"strings"
+)
+
+// CheckEndpointSpaces checks for extraneous leading or trailing whitespace and returns an error if
+// there are any. It should be used as part of validation that an endpoint URL/address is
+// well-formed.
+func CheckEndpointSpaces(fieldName string, ep string) error {
+	if strings.TrimSpace(ep) != ep {
+		return fmt.Errorf("'%s' must not contain leading or trailing spaces", fieldName)
+	}
+	return nil
+}

--- a/materialize-elasticsearch/driver.go
+++ b/materialize-elasticsearch/driver.go
@@ -16,6 +16,7 @@ import (
 	cerrors "github.com/estuary/connectors/go/connector-errors"
 	networkTunnel "github.com/estuary/connectors/go/network-tunnel"
 	schemagen "github.com/estuary/connectors/go/schema-gen"
+	"github.com/estuary/connectors/go/util"
 	boilerplate "github.com/estuary/connectors/materialize-boilerplate"
 	"github.com/estuary/connectors/materialize-boilerplate/validate"
 	pf "github.com/estuary/flow/go/protocols/flow"
@@ -199,11 +200,13 @@ func (c *credentials) Validate() error {
 
 func (c config) Validate() error {
 	if c.Endpoint == "" {
-		return fmt.Errorf("missing Endpoint")
+		return fmt.Errorf("missing endpoint")
 	} else if !strings.HasPrefix(c.Endpoint, "http://") && !strings.HasPrefix(c.Endpoint, "https://") {
 		return fmt.Errorf("endpoint '%s' is invalid: must start with either http:// or https://", c.Endpoint)
 	} else if c.Advanced.Replicas != nil && *c.Advanced.Replicas < 0 {
 		return fmt.Errorf("number_of_replicas cannot be negative")
+	} else if err := util.CheckEndpointSpaces("endpoint", c.Endpoint); err != nil {
+		return err
 	}
 
 	return c.Credentials.Validate()

--- a/materialize-firebolt/config.go
+++ b/materialize-firebolt/config.go
@@ -3,6 +3,8 @@ package main
 import (
 	"fmt"
 	"strings"
+
+	"github.com/estuary/connectors/go/util"
 )
 
 type config struct {
@@ -32,6 +34,9 @@ func (c config) Validate() error {
 	}
 	if c.S3Bucket == "" {
 		return fmt.Errorf("missing required bucket")
+	}
+	if err := util.CheckEndpointSpaces("engine_url", c.EngineURL); err != nil {
+		return err
 	}
 	return nil
 }

--- a/materialize-mongodb/config.go
+++ b/materialize-mongodb/config.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 
 	"net/url"
+
+	"github.com/estuary/connectors/go/util"
 )
 
 type config struct {
@@ -24,6 +26,10 @@ func (c *config) Validate() error {
 		if req[1] == "" {
 			return fmt.Errorf("missing '%s'", req[0])
 		}
+	}
+
+	if err := util.CheckEndpointSpaces("address", c.Address); err != nil {
+		return err
 	}
 
 	var uri, err = url.Parse(c.Address)

--- a/materialize-postgres/driver.go
+++ b/materialize-postgres/driver.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	networkTunnel "github.com/estuary/connectors/go/network-tunnel"
+	"github.com/estuary/connectors/go/util"
 	boilerplate "github.com/estuary/connectors/materialize-boilerplate"
 	sql "github.com/estuary/connectors/materialize-sql"
 	pf "github.com/estuary/flow/go/protocols/flow"
@@ -71,6 +72,10 @@ func (c *config) Validate() error {
 		if req[1] == "" {
 			return fmt.Errorf("missing '%s'", req[0])
 		}
+	}
+
+	if err := util.CheckEndpointSpaces("address", c.Address); err != nil {
+		return err
 	}
 
 	if c.Advanced.SSLMode != "" {

--- a/materialize-redshift/driver.go
+++ b/materialize-redshift/driver.go
@@ -22,6 +22,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	awsHttp "github.com/aws/smithy-go/transport/http"
 	networkTunnel "github.com/estuary/connectors/go/network-tunnel"
+	"github.com/estuary/connectors/go/util"
 	sql "github.com/estuary/connectors/materialize-sql"
 	pf "github.com/estuary/flow/go/protocols/flow"
 	pm "github.com/estuary/flow/go/protocols/materialize"
@@ -104,6 +105,10 @@ func (c *config) Validate() error {
 		if req[1] == "" {
 			return fmt.Errorf("missing '%s'", req[0])
 		}
+	}
+
+	if err := util.CheckEndpointSpaces("address", c.Address); err != nil {
+		return err
 	}
 
 	if c.BucketPath != "" {

--- a/source-mongodb/main.go
+++ b/source-mongodb/main.go
@@ -11,6 +11,7 @@ import (
 
 	cerrors "github.com/estuary/connectors/go/connector-errors"
 	schemagen "github.com/estuary/connectors/go/schema-gen"
+	"github.com/estuary/connectors/go/util"
 	boilerplate "github.com/estuary/connectors/source-boilerplate"
 	pc "github.com/estuary/flow/go/protocols/capture"
 	pf "github.com/estuary/flow/go/protocols/flow"
@@ -53,6 +54,10 @@ func (c *config) Validate() error {
 		if req[1] == "" {
 			return fmt.Errorf("missing '%s'", req[0])
 		}
+	}
+
+	if err := util.CheckEndpointSpaces("address", c.Address); err != nil {
+		return err
 	}
 
 	var uri, err = url.Parse(c.Address)

--- a/source-mysql/main.go
+++ b/source-mysql/main.go
@@ -16,6 +16,7 @@ import (
 	cerrors "github.com/estuary/connectors/go/connector-errors"
 	networkTunnel "github.com/estuary/connectors/go/network-tunnel"
 	schemagen "github.com/estuary/connectors/go/schema-gen"
+	"github.com/estuary/connectors/go/util"
 	boilerplate "github.com/estuary/connectors/source-boilerplate"
 	"github.com/estuary/connectors/sqlcapture"
 	"github.com/estuary/flow/go/protocols/fdb/tuple"
@@ -149,6 +150,9 @@ func (c *Config) Validate() error {
 		if _, err := sqlcapture.ParseTimezone(c.Timezone); err != nil {
 			return err
 		}
+	}
+	if err := util.CheckEndpointSpaces("address", c.Address); err != nil {
+		return err
 	}
 
 	if c.Advanced.WatermarksTable != "" && !strings.Contains(c.Advanced.WatermarksTable, ".") {

--- a/source-postgres-batch/main.go
+++ b/source-postgres-batch/main.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	schemagen "github.com/estuary/connectors/go/schema-gen"
+	"github.com/estuary/connectors/go/util"
 	boilerplate "github.com/estuary/connectors/source-boilerplate"
 	pf "github.com/estuary/flow/go/protocols/flow"
 	log "github.com/sirupsen/logrus"
@@ -41,6 +42,9 @@ func (c *Config) Validate() error {
 		if req[1] == "" {
 			return fmt.Errorf("missing '%s'", req[0])
 		}
+	}
+	if err := util.CheckEndpointSpaces("address", c.Address); err != nil {
+		return err
 	}
 	return nil
 }

--- a/source-postgres/main.go
+++ b/source-postgres/main.go
@@ -14,6 +14,7 @@ import (
 	cerrors "github.com/estuary/connectors/go/connector-errors"
 	networkTunnel "github.com/estuary/connectors/go/network-tunnel"
 	schemagen "github.com/estuary/connectors/go/schema-gen"
+	"github.com/estuary/connectors/go/util"
 	boilerplate "github.com/estuary/connectors/source-boilerplate"
 	"github.com/estuary/connectors/sqlcapture"
 	"github.com/estuary/flow/go/protocols/fdb/tuple"
@@ -117,6 +118,10 @@ func (c *Config) Validate() error {
 		if req[1] == "" {
 			return fmt.Errorf("missing '%s'", req[0])
 		}
+	}
+
+	if err := util.CheckEndpointSpaces("address", c.Address); err != nil {
+		return err
 	}
 
 	if c.Advanced.WatermarksTable != "" && !strings.Contains(c.Advanced.WatermarksTable, ".") {

--- a/source-sftp/main.go
+++ b/source-sftp/main.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/estuary/connectors/filesource"
 	schemagen "github.com/estuary/connectors/go/schema-gen"
+	"github.com/estuary/connectors/go/util"
 	"github.com/estuary/flow/go/parser"
 	pf "github.com/estuary/flow/go/protocols/flow"
 	"github.com/pkg/sftp"
@@ -73,6 +74,7 @@ func (advancedConfig) GetFieldDocString(fieldName string) string {
 
 func (c config) Validate() error {
 	var requiredProperties = [][]string{
+		{"address", c.Address},
 		{"username", c.Username},
 		{"password", c.Password},
 		{"directory", c.Directory},
@@ -81,6 +83,10 @@ func (c config) Validate() error {
 		if req[1] == "" {
 			return fmt.Errorf("missing '%s'", req[0])
 		}
+	}
+
+	if err := util.CheckEndpointSpaces("address", c.Address); err != nil {
+		return err
 	}
 
 	if c.Directory != path.Clean(c.Directory) {

--- a/source-sqlserver/main.go
+++ b/source-sqlserver/main.go
@@ -14,6 +14,7 @@ import (
 	cerrors "github.com/estuary/connectors/go/connector-errors"
 	networkTunnel "github.com/estuary/connectors/go/network-tunnel"
 	schemagen "github.com/estuary/connectors/go/schema-gen"
+	"github.com/estuary/connectors/go/util"
 	boilerplate "github.com/estuary/connectors/source-boilerplate"
 	"github.com/estuary/connectors/sqlcapture"
 	pf "github.com/estuary/flow/go/protocols/flow"
@@ -74,6 +75,9 @@ func (c *Config) Validate() error {
 		}
 	}
 
+	if err := util.CheckEndpointSpaces("address", c.Address); err != nil {
+		return err
+	}
 	if c.Timezone != "" {
 		if _, err := sqlcapture.ParseTimezone(c.Timezone); err != nil {
 			return err


### PR DESCRIPTION
**Description:**

Adds a check for various connectors for endpoint address/URLs that might contain leading or trailing spaces, since this is something that has come up more than once and can be kind of hard to debug.

Creating a separate package for such a simple check feels like a bit of overkill, but it lets us have a single point to change the wording of the error message if we want to in the future.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/938)
<!-- Reviewable:end -->
