### PR TITLE
materialize-snowflake: store documents in transaction

### DIFF
--- a/materialize-snowflake/snowflake.go
+++ b/materialize-snowflake/snowflake.go
@@ -590,12 +590,12 @@ func (d *transactor) commit(ctx context.Context) error {
 			return err
 		} else if !b.store.mustMerge {
 			// We can issue a faster COPY INTO the target table.
-			if _, err = d.store.conn.ExecContext(ctx, b.store.copyInto); err != nil {
+			if _, err = txn.ExecContext(ctx, b.store.copyInto); err != nil {
 				return fmt.Errorf("copying Store documents into table %q: %w", b.target.Identifier, err)
 			}
 		} else {
 			// We must MERGE into the target table.
-			if _, err = d.store.conn.ExecContext(ctx, b.store.mergeInto); err != nil {
+			if _, err = txn.ExecContext(ctx, b.store.mergeInto); err != nil {
 				return fmt.Errorf("merging Store documents into table %q: %w", b.target.Identifier, err)
 			}
 		}


### PR DESCRIPTION
**Description:**

Fixes an apparent bug where the connector was not using a transaction to actually merge or copy new documents into the target table. The history of code changes does not indicate that this bug is due to a recent change, and with the way operations are ordered it was unlikely to ever cause a problem, especially if materializations were run using only a single shard.

Tested by running the integration tests locally.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

N/A

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/947)
<!-- Reviewable:end -->
