### PR TITLE
source-mysql: Log unhandled replication statement types

### DIFF
--- a/source-mysql/replication.go
+++ b/source-mysql/replication.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"reflect"
 	"regexp"
 	"strconv"
 	"strings"
@@ -526,7 +527,7 @@ func (rs *mysqlReplicationStream) handleQuery(schema, query string) error {
 	case *sqlparser.OtherAdmin:
 		// We ignore queries like REPAIR or OPTIMIZE.
 	default:
-		return fmt.Errorf("unhandled query (go.estuary.dev/ceqr74): %s", query)
+		return fmt.Errorf("unhandled query (go.estuary.dev/ceqr74): unhandled type %q: %q", reflect.TypeOf(stmt).String(), query)
 	}
 
 	return nil


### PR DESCRIPTION
**Description:**

Just a small error-reporting tweak: Adds the name of the unhandled statement-node type to the resulting error message.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/948)
<!-- Reviewable:end -->
