### PR TITLE
materialize-mongodb: log current database operations

### DIFF
--- a/materialize-mongodb/Dockerfile
+++ b/materialize-mongodb/Dockerfile
@@ -34,5 +34,7 @@ COPY --from=builder /lib/x86_64-linux-gnu/libgcc_s.so.1 /lib/x86_64-linux-gnu/
 USER nonroot:nonroot
 
 LABEL FLOW_RUNTIME_PROTOCOL=materialize
+# Temporarily expose the pprof port for debugging
+EXPOSE 6060
 
 ENTRYPOINT ["/connector/materialize-mongodb"]

--- a/materialize-mongodb/transactor.go
+++ b/materialize-mongodb/transactor.go
@@ -19,6 +19,7 @@ type transactor struct {
 	materialization string
 	fenceCollection *mongo.Collection
 	fence           *fenceRecord
+	debugCancelFunc context.CancelFunc
 
 	client   *mongo.Client
 	bindings []*binding
@@ -143,6 +144,9 @@ func (t *transactor) Store(it *pm.StoreIterator) (pm.StartCommitFunc, error) {
 }
 
 func (t *transactor) Destroy() {
+	if t.debugCancelFunc != nil {
+		t.debugCancelFunc()
+	}
 }
 
 func sanitizeDocument(doc map[string]interface{}) map[string]interface{} {


### PR DESCRIPTION
**Description:**

Adds a periodic logging of current database operations to aid in debugging. This behavior is only enabled if the log level is debug or trace.

**Workflow steps:**

set `shards: { logLevel: 'debug' }` and look for output every 5 minutes in the logs.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/949)
<!-- Reviewable:end -->
