### PR TITLE
source-mysql: Ignore 'OtherRead' statements

### DIFF
--- a/source-mysql/replication.go
+++ b/source-mysql/replication.go
@@ -524,8 +524,8 @@ func (rs *mysqlReplicationStream) handleQuery(schema, query string) error {
 				return fmt.Errorf("unsupported DML query (go.estuary.dev/IK5EVx): %s", query)
 			}
 		}
-	case *sqlparser.OtherAdmin:
-		// We ignore queries like REPAIR or OPTIMIZE.
+	case *sqlparser.OtherAdmin, *sqlparser.OtherRead:
+		logrus.WithField("query", query).Debug("ignoring benign query")
 	default:
 		return fmt.Errorf("unhandled query (go.estuary.dev/ceqr74): unhandled type %q: %q", reflect.TypeOf(stmt).String(), query)
 	}


### PR DESCRIPTION
**Description:**

Apparently `ANALYZE TABLE` queries show up in the binlog and then get parsed into a `*sqlparser.OtherRead`. These should be entirely ignorable.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/950)
<!-- Reviewable:end -->
