### PR TITLE
materialize-pinecone: allow empty namespaces and enforce a single binding with empty namespace for starter plans

### DIFF
--- a/materialize-pinecone/.snapshots/TestSpecification
+++ b/materialize-pinecone/.snapshots/TestSpecification
@@ -66,14 +66,11 @@
       "namespace": {
         "type": "string",
         "title": "Pinecone Namespace",
-        "description": "Name of the Pinecone namespace that this collection will materialize vectors into.",
+        "description": "Name of the Pinecone namespace that this collection will materialize vectors into. For Pinecone starter plans, leave blank to use no namespace. Only a single binding can have a blank namespace, and Pinecone starter plans can only materialize a single binding.",
         "x-collection-name": true
       }
     },
     "type": "object",
-    "required": [
-      "namespace"
-    ],
     "title": "Pinecone Collection"
   },
   "documentation_url": "https://go.estuary.dev/materialize-pinecone"

--- a/materialize-pinecone/client/client.go
+++ b/materialize-pinecone/client/client.go
@@ -166,6 +166,7 @@ type PineconeIndexDescribeResponse struct {
 		MetadataConfig struct {
 			Indexed []string `json:"indexed"`
 		} `json:"metadata_config"`
+		PodType string `json:"pod_type"`
 	} `json:"database"`
 }
 

--- a/tests/materialize/materialize-pinecone/fetch-data.go
+++ b/tests/materialize/materialize-pinecone/fetch-data.go
@@ -109,7 +109,7 @@ func main() {
 	// The vectors themselves are very long and the floating point values of any point in the vector
 	// may vary between invocations, so there's no real way to snapshot the output. The flag
 	// print-vectors can be used to output the vectors instead of masking their values for local
-	// testing. You can get a decent qualitiative idea of if a vector is wrong by how many of its
+	// testing. You can get a decent qualitative idea of if a vector is wrong by how many of its
 	// points are different and how different they are.
 	if !*printVectors {
 		for idx := range out.Matches {


### PR DESCRIPTION
**Description:**

Pinecone free tier starter pods can't use namespaces, we need to not use a namespace when the target index pod is a "starter". This means that an index on a starter pod can also only have a single binding.

**Workflow steps:**

Do a materialization on a Pinecone free tier account with a starter plan pod. This will succeed if you have a single binding with an empty (empty string) for the namespace.

**Documentation links affected:**

Pinecone materialization docs should be updated with this change.

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/951)
<!-- Reviewable:end -->
