### PR TITLE
materialize-mongodb: don't use transactions

### DIFF
--- a/materialize-dynamodb/transactor.go
+++ b/materialize-dynamodb/transactor.go
@@ -268,7 +268,7 @@ func (t *transactor) loadWorker(ctx context.Context, loaded func(i int, doc json
 				}
 
 				// BatchGetItem returns without error if at least one of the requests was successful.
-				// The items that the get request was not succesful for are returned as UnprocessedKeys,
+				// The items that the get request was not successful for are returned as UnprocessedKeys,
 				// and must be retried. Items are unprocessed if getting them would exceed rate limits
 				// for the table.
 				batch = res.UnprocessedKeys

--- a/materialize-mongodb/driver.go
+++ b/materialize-mongodb/driver.go
@@ -187,7 +187,7 @@ func (d driver) NewTransactor(ctx context.Context, open pm.Request_Open) (pm.Tra
 
 	var materialization = string(open.Materialization.Name)
 	var filter = bson.D{{
-		"materialization", bson.D{{"$eq", materialization}},
+		Key: "materialization", Value: bson.D{{Key: "$eq", Value: materialization}},
 	}}
 
 	var fence fenceRecord
@@ -200,7 +200,7 @@ func (d driver) NewTransactor(ctx context.Context, open pm.Request_Open) (pm.Tra
 		}
 	}
 
-	var bump = bson.D{{"$inc", bson.D{{"fence", 1}}}}
+	var bump = bson.D{{Key: "$inc", Value: bson.D{{Key: "fence", Value: 1}}}}
 	var updateOpts = options.FindOneAndUpdate().SetReturnDocument(options.After)
 	if err = fenceCollection.FindOneAndUpdate(ctx, filter, bump, updateOpts).Decode(&fence); err != nil {
 		return nil, nil, fmt.Errorf("bumping fence: %w", err)

--- a/materialize-mongodb/driver.go
+++ b/materialize-mongodb/driver.go
@@ -176,8 +176,8 @@ func (d driver) NewTransactor(ctx context.Context, open pm.Request_Open) (pm.Tra
 		var collection = client.Database(cfg.Database).Collection(res.Collection)
 
 		bindings = append(bindings, &binding{
-			collection: collection,
-			res:        res,
+			collection:   collection,
+			deltaUpdates: b.DeltaUpdates,
 		})
 	}
 

--- a/materialize-mongodb/spec.go
+++ b/materialize-mongodb/spec.go
@@ -30,7 +30,7 @@ func (d driver) LoadSpec(ctx context.Context, cfg config, materialization string
 
 	var s SavedSpec
 
-	err = collection.FindOne(ctx, bson.D{{idField, bson.D{{"$eq", materialization}}}}).Decode(&s)
+	err = collection.FindOne(ctx, bson.D{{Key: idField, Value: bson.D{{Key: "$eq", Value: materialization}}}}).Decode(&s)
 	if err != nil {
 		if err == mongo.ErrNoDocuments {
 			return nil, nil
@@ -60,7 +60,7 @@ func (d driver) WriteSpec(ctx context.Context, cfg config, materialization *pf.M
 	}
 
 	opts := options.Replace().SetUpsert(true)
-	_, err = collection.ReplaceOne(ctx, bson.D{{idField, string(materialization.Name)}}, bson.D{{"spec", bs}}, opts)
+	_, err = collection.ReplaceOne(ctx, bson.D{{Key: idField, Value: string(materialization.Name)}}, bson.D{{Key: "spec", Value: bs}}, opts)
 	if err != nil {
 		return fmt.Errorf("upserting spec: %w", err)
 	}
@@ -75,7 +75,7 @@ func (d driver) CleanSpec(ctx context.Context, cfg config, materialization strin
 	}
 	var collection = client.Database(cfg.Database).Collection(specCollection)
 
-	_, err = collection.DeleteOne(ctx, bson.D{{idField, materialization}})
+	_, err = collection.DeleteOne(ctx, bson.D{{Key: idField, Value: materialization}})
 	if err != nil {
 		return fmt.Errorf("cleaning up spec: %w", err)
 	}

--- a/materialize-mongodb/transactor.go
+++ b/materialize-mongodb/transactor.go
@@ -46,7 +46,7 @@ func (t *transactor) Load(it *pm.LoadIterator, loaded func(int, json.RawMessage)
 		var collection = t.bindings[it.Binding].collection
 
 		var ctx = context.Background()
-		var cur, err = collection.Find(ctx, bson.D{{idField, bson.D{{"$eq", key}}}})
+		var cur, err = collection.Find(ctx, bson.D{{Key: idField, Value: bson.D{{Key: "$eq", Value: key}}}})
 		defer cur.Close(ctx)
 		if err != nil {
 			return fmt.Errorf("finding document in collection: %w", err)
@@ -105,7 +105,7 @@ func (t *transactor) Store(it *pm.StoreIterator) (pm.StartCommitFunc, error) {
 
 		if it.Exists {
 			var opts = options.Replace()
-			_, err := binding.collection.ReplaceOne(tx, bson.D{{idField, bson.D{{"$eq", key}}}}, doc, opts)
+			_, err := binding.collection.ReplaceOne(tx, bson.D{{Key: idField, Value: bson.D{{Key: "$eq", Value: key}}}}, doc, opts)
 			if err != nil {
 				return nil, fmt.Errorf("upserting document into collection %s: %w", binding.collection.Name(), err)
 			}
@@ -117,7 +117,7 @@ func (t *transactor) Store(it *pm.StoreIterator) (pm.StartCommitFunc, error) {
 		}
 	}
 
-	var filter = bson.D{{"materialization", bson.D{{"$eq", t.fence.Materialization}}}, {"fence", bson.D{{"$eq", t.fence.Fence}}}}
+	var filter = bson.D{{Key: "materialization", Value: bson.D{{Key: "$eq", Value: t.fence.Materialization}}}, {Key: "fence", Value: bson.D{{Key: "$eq", Value: t.fence.Fence}}}}
 	var fence fenceRecord
 	if err = t.fenceCollection.FindOne(tx, filter, options.FindOne()).Decode(&fence); err != nil {
 		return nil, fmt.Errorf("finding fence: %w", err)
@@ -130,7 +130,7 @@ func (t *transactor) Store(it *pm.StoreIterator) (pm.StartCommitFunc, error) {
 		}
 
 		return nil, pf.RunAsyncOperation(func() error {
-			var bump = bson.D{{"$set", bson.D{{"checkpoint", checkpointBytes}}}}
+			var bump = bson.D{{Key: "$set", Value: bson.D{{Key: "checkpoint", Value: checkpointBytes}}}}
 			var updateOpts = options.Update()
 			if _, err = t.fenceCollection.UpdateOne(ctx, filter, bump, updateOpts); err != nil {
 				return fmt.Errorf("updating checkpoint: %w", err)

--- a/materialize-mongodb/transactor.go
+++ b/materialize-mongodb/transactor.go
@@ -7,10 +7,26 @@ import (
 	"math"
 
 	pm "github.com/estuary/flow/go/protocols/materialize"
+	"github.com/sirupsen/logrus"
+	"golang.org/x/sync/errgroup"
 
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/options"
+)
+
+const (
+	idField = "_id"
+
+	batchByteLimit = 5 * 1024 * 1024
+
+	// MongoDB docs recommend limiting this to "10's" of values, see
+	// https://www.mongodb.com/docs/manual/reference/operator/query/in/#-in
+	loadBatchSize = 100
+
+	// The default batchWriteLimit is 100,000 documents. Practically speaking we will be limited to
+	// less than that to keep connector memory usage reasonable.
+	storeBatchSize = 10_000
 )
 
 type transactor struct {
@@ -19,90 +35,248 @@ type transactor struct {
 }
 
 type binding struct {
-	collection *mongo.Collection
-	res        resource
+	collection   *mongo.Collection
+	deltaUpdates bool
 }
 
-var idField = "_id"
-
 func (t *transactor) Load(it *pm.LoadIterator, loaded func(int, json.RawMessage) error) error {
+	ctx := it.Context()
 	it.WaitForAcknowledged()
 
-	for it.Next() {
-		var key = fmt.Sprintf("%x", it.PackedKey) // Hex-encode.
-		var collection = t.bindings[it.Binding].collection
+	sendBatches := make(chan loadBatch)
 
-		var ctx = context.Background()
-		if err := func() error { // Closure for the deferred cur.Close()
-			var cur, err = collection.Find(ctx, bson.D{{Key: idField, Value: bson.D{{Key: "$eq", Value: key}}}})
-			if err != nil {
-				return fmt.Errorf("finding document in collection: %w", err)
-			}
-			defer cur.Close(ctx)
-			if !cur.Next(ctx) {
-				return nil
-			}
+	group, groupCtx := errgroup.WithContext(ctx)
+	group.Go(func() error {
+		return t.loadWorker(groupCtx, loaded, sendBatches)
+	})
 
-			var doc bson.M
-
-			if err = cur.Decode(&doc); err != nil {
-				return fmt.Errorf("decoding document in collection %s: %w", collection.Name(), err)
-			}
-			doc = sanitizeDocument(doc)
-
-			js, err := json.Marshal(doc)
-			if err != nil {
-				return fmt.Errorf("encoding document in collection %s as json: %w", collection.Name(), err)
-			}
-
-			if err := loaded(it.Binding, js); err != nil {
-				return fmt.Errorf("sending loaded: %w", err)
-			}
-
+	sendBatch := func(binding int, batch []string) error {
+		select {
+		case <-groupCtx.Done():
+			return group.Wait()
+		case sendBatches <- loadBatch{binding: binding, keys: batch}:
 			return nil
-		}(); err != nil {
-			return err
 		}
 	}
 
-	return it.Err()
+	batches := make([][]string, len(t.bindings))
+	// Approximate the size of the batch in memory based on the length of the packed key as a
+	// protection against huge document keys running the connector out of memory.
+	batchSizes := make([]int, len(t.bindings))
+
+	for it.Next() {
+		key := fmt.Sprintf("%x", it.PackedKey) // Hex-encode
+
+		batches[it.Binding] = append(batches[it.Binding], key)
+		batchSizes[it.Binding] += len(it.PackedKey)
+
+		if len(batches[it.Binding]) == loadBatchSize || batchSizes[it.Binding] >= batchByteLimit {
+			if err := sendBatch(it.Binding, batches[it.Binding]); err != nil {
+				return err
+			}
+			batches[it.Binding] = nil
+			batchSizes[it.Binding] = 0
+		}
+	}
+
+	// Drain residual batch items.
+	for bindingIdx, batch := range batches {
+		if len(batch) > 0 {
+			if err := sendBatch(bindingIdx, batch); err != nil {
+				return err
+			}
+		}
+	}
+
+	close(sendBatches)
+	return group.Wait()
 }
 
 func (t *transactor) Store(it *pm.StoreIterator) (pm.StartCommitFunc, error) {
 	var ctx = it.Context()
 
+	sendBatches := make(chan storeBatch)
+
+	group, groupCtx := errgroup.WithContext(ctx)
+	group.Go(func() error {
+		return t.storeWorker(groupCtx, sendBatches)
+	})
+
+	var batch []mongo.WriteModel
+	// Approximate the size of the batch in memory based on the length of the document JSON as a
+	// protection against huge documents running the connector out of memory.
+	batchSize := 0
+	lastBinding := -1
+
+	sendBatch := func() error {
+		select {
+		case <-groupCtx.Done():
+			return group.Wait()
+		case sendBatches <- storeBatch{binding: lastBinding, models: batch}:
+			batch = nil
+			batchSize = 0
+			return nil
+		}
+	}
+
 	for it.Next() {
-		var key = fmt.Sprintf("%x", it.PackedKey) // Hex-encode.
-		binding := t.bindings[it.Binding]
+		if lastBinding != -1 && (lastBinding != it.Binding || len(batch) == storeBatchSize || batchSize >= batchByteLimit) {
+			if err := sendBatch(); err != nil {
+				return nil, err
+			}
+		}
+
+		key := fmt.Sprintf("%x", it.PackedKey) // Hex-encode
 
 		var doc bson.M
 		if err := json.Unmarshal(it.RawJSON, &doc); err != nil {
 			return nil, fmt.Errorf("bson unmarshalling json doc: %w", err)
 		}
-		// In case of delta updates, we don't want to set the _id. We want
-		// MongoDB to generate a new _id for each record we insert
-		if !binding.res.DeltaUpdates {
+		// In case of delta updates, we don't want to set the _id. We want MongoDB to generate a new
+		// _id for each record we insert
+		if !t.bindings[it.Binding].deltaUpdates {
 			doc[idField] = key
 		}
 
+		var m mongo.WriteModel
 		if it.Exists {
-			var opts = options.Replace()
-			_, err := binding.collection.ReplaceOne(ctx, bson.D{{Key: idField, Value: bson.D{{Key: "$eq", Value: key}}}}, doc, opts)
-			if err != nil {
-				return nil, fmt.Errorf("upserting document into collection %s: %w", binding.collection.Name(), err)
+			m = &mongo.ReplaceOneModel{
+				Filter:      bson.D{{Key: idField, Value: bson.D{{Key: "$eq", Value: key}}}},
+				Replacement: doc,
 			}
 		} else {
-			_, err := binding.collection.InsertOne(ctx, doc, options.InsertOne())
-			if err != nil {
-				return nil, fmt.Errorf("inserting document into collection %s: %w", binding.collection.Name(), err)
+			m = &mongo.InsertOneModel{Document: doc}
+		}
+
+		batch = append(batch, m)
+		batchSize += len(it.RawJSON)
+		lastBinding = it.Binding
+	}
+
+	// Drain the last batch.
+	if err := sendBatch(); err != nil {
+		return nil, err
+	}
+
+	close(sendBatches)
+	return nil, group.Wait()
+}
+
+func (t *transactor) Destroy() {}
+
+type loadBatch struct {
+	binding int
+	keys    []string
+}
+
+func (t *transactor) loadWorker(
+	ctx context.Context,
+	loaded func(i int, doc json.RawMessage) error,
+	batches <-chan loadBatch,
+) error {
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case batch, ok := <-batches:
+			if !ok {
+				return nil
+			}
+
+			if err := func() error { // Closure for the deferred cur.Close()
+				collection := t.bindings[batch.binding].collection
+				cur, err := collection.Find(ctx, bson.D{{
+					Key:   idField,
+					Value: bson.D{{Key: "$in", Value: batch.keys}},
+				}})
+				if err != nil {
+					return fmt.Errorf("finding document in collection: %w", err)
+				}
+				defer cur.Close(ctx)
+
+				for cur.Next(ctx) {
+					var doc bson.M
+					if err = cur.Decode(&doc); err != nil {
+						return fmt.Errorf("decoding document in collection %s: %w", collection.Name(), err)
+					}
+
+					js, err := json.Marshal(sanitizeDocument(doc))
+					if err != nil {
+						return fmt.Errorf("encoding document in collection %s as json: %w", collection.Name(), err)
+					} else if err := loaded(batch.binding, js); err != nil {
+						return fmt.Errorf("sending loaded: %w", err)
+					}
+				}
+
+				return nil
+			}(); err != nil {
+				return err
 			}
 		}
 	}
-
-	return nil, nil
 }
 
-func (t *transactor) Destroy() {
+type storeBatch struct {
+	binding int
+	models  []mongo.WriteModel
+}
+
+func (t *transactor) storeWorker(
+	ctx context.Context,
+	batches <-chan storeBatch,
+) error {
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case batch, ok := <-batches:
+			if !ok {
+				return nil
+			}
+
+			var expectModified, expectInserted int64
+			for _, m := range batch.models {
+				switch m.(type) {
+				case *mongo.ReplaceOneModel:
+					expectModified++
+				case *mongo.InsertOneModel:
+					expectInserted++
+				default:
+					return fmt.Errorf("invalid model type: %T", m)
+				}
+			}
+
+			collection := t.bindings[batch.binding].collection
+
+			// Ordered operations are not needed since each key can only be seen a single time in a
+			// Flow transaction. Turning this off supposedly allows for optimizations by the server.
+			res, err := collection.BulkWrite(ctx, batch.models, options.BulkWrite().SetOrdered(false))
+			if err != nil {
+				return fmt.Errorf("bulk write for collection %s: %w", collection.Name(), err)
+			}
+
+			// Sanity check the result of the bulk write operation.
+			if res.ModifiedCount != expectModified || res.InsertedCount != expectInserted {
+				logrus.WithFields(logrus.Fields{
+					"deleted":        res.DeletedCount,
+					"inserted":       res.InsertedCount,
+					"matched":        res.MatchedCount,
+					"modified":       res.ModifiedCount,
+					"upserted":       res.UpsertedCount,
+					"expectModified": expectModified,
+					"expectInserted": expectInserted,
+				}).Warn("bulk write counts")
+
+				return fmt.Errorf(
+					"unexpected bulkWrite counts: got %d modified vs %d expected, %d inserted vs %d expected",
+					res.UpsertedCount,
+					expectModified,
+					res.InsertedCount,
+					expectInserted,
+				)
+			}
+		}
+	}
 }
 
 func sanitizeDocument(doc map[string]interface{}) map[string]interface{} {

--- a/tests/materialize/materialize-mongodb/fetch.sh
+++ b/tests/materialize/materialize-mongodb/fetch.sh
@@ -7,14 +7,14 @@ set -o nounset
 function exportToJsonl() {
 	projections=${2:-"{'_meta':0}"}
 	docker exec \
-    materialize-mongodb-mongo-1 mongosh test \
+		materialize-mongodb-mongo-1 mongosh test \
 		--username flow \
 		--password flow \
 		--json=canonical \
 		--quiet \
-		--eval="db.$1.find({}, $projections).toArray()"  | jq -S '{ index: "$1", rows: . }'
+		--eval="db.$1.find({}, $projections).toArray()" | jq -S "{ index: \"$1\", rows: . }"
 }
 
-exportToJsonl "Simple" 
-exportToJsonl "duplicate_keys_standard" 
+exportToJsonl "Simple"
+exportToJsonl "duplicate_keys_standard"
 exportToJsonl "duplicate_keys_delta" "{'_meta':0,'_id':0}"

--- a/tests/materialize/materialize-mongodb/setup.sh
+++ b/tests/materialize/materialize-mongodb/setup.sh
@@ -7,7 +7,7 @@ set -o nounset
 docker compose -f materialize-mongodb/docker-compose.yaml create
 docker compose -f materialize-mongodb/docker-compose.yaml up --detach
 
-# Copying and permissining the key after launching the container is a bit of a race
+# Copying and permissioning the key after launching the container is a bit of a race
 # condition but somehow there is no good way to get a key *copied* into a container
 # and editing the copy's permissions/ownership without first running the container,
 # so we're relying on MongoDB taking longer to start up than it takes us to run these
@@ -20,20 +20,19 @@ set +e
 # need to wait some seconds before the replication server is set up
 sleep 5
 docker exec materialize-mongodb-mongo-1 \
-	mongosh \
-	-u flow \
-	-p flow \
-	--eval 'rs.initiate()'
+  mongosh \
+  -u flow \
+  -p flow \
+  --eval 'rs.initiate()'
 
 sleep 1
 
 docker exec materialize-mongodb-mongo-1 \
-	mongosh \
-	-u flow \
-	-p flow \
-	--eval 'db.createUser({ user: "flow", pwd: "flow", roles: [{ role: "readWrite", db: "test" }] })'
+  mongosh \
+  -u flow \
+  -p flow \
+  --eval 'db.createUser({ user: "flow", pwd: "flow", roles: [{ role: "readWrite", db: "test" }] })'
 set -e
-
 
 config_json_template='{
    "address":  "materialize-mongodb-mongo-1",

--- a/tests/materialize/materialize-mongodb/setup.sh
+++ b/tests/materialize/materialize-mongodb/setup.sh
@@ -44,12 +44,6 @@ config_json_template='{
 resources_json_template='[
   {
     "resource": {
-      "collection": "Simple"
-    },
-    "source": "${TEST_COLLECTION_SIMPLE}"
-  },
-  {
-    "resource": {
       "collection": "duplicate_keys_standard"
     },
     "source": "${TEST_COLLECTION_DUPLICATED_KEYS}"
@@ -60,6 +54,12 @@ resources_json_template='[
       "delta_updates": true
     },
     "source": "${TEST_COLLECTION_DUPLICATED_KEYS}"
+  },
+  {
+    "resource": {
+      "collection": "Simple"
+    },
+    "source": "${TEST_COLLECTION_SIMPLE}"
   }
 ]'
 

--- a/tests/materialize/materialize-mongodb/snapshot.json
+++ b/tests/materialize/materialize-mongodb/snapshot.json
@@ -2,9 +2,7 @@
   "applied": {}
 }
 {
-  "opened": {
-    "runtimeCheckpoint": {}
-  }
+  "opened": {}
 }
 {
   "acknowledged": {}
@@ -326,15 +324,7 @@
   "applied": {}
 }
 {
-  "opened": {
-    "runtimeCheckpoint": {
-      "sources": {
-        "a/read/journal;suffix": {
-          "readThrough": "1"
-        }
-      }
-    }
-  }
+  "opened": {}
 }
 {
   "acknowledged": {}

--- a/tests/materialize/materialize-mongodb/snapshot.json
+++ b/tests/materialize/materialize-mongodb/snapshot.json
@@ -18,7 +18,6 @@
 }
 {
   "loaded": {
-    "binding": 1,
     "doc": {
       "_id": "1501",
       "_meta": {
@@ -32,7 +31,6 @@
 }
 {
   "loaded": {
-    "binding": 1,
     "doc": {
       "_id": "1502",
       "_meta": {
@@ -46,7 +44,6 @@
 }
 {
   "loaded": {
-    "binding": 1,
     "doc": {
       "_id": "1503",
       "_meta": {
@@ -60,7 +57,6 @@
 }
 {
   "loaded": {
-    "binding": 1,
     "doc": {
       "_id": "1504",
       "_meta": {
@@ -74,7 +70,6 @@
 }
 {
   "loaded": {
-    "binding": 1,
     "doc": {
       "_id": "1505",
       "_meta": {
@@ -96,7 +91,7 @@
   "acknowledged": {}
 }
 {
-  "index": "$1",
+  "index": "Simple",
   "rows": [
     {
       "_id": "1501",
@@ -171,7 +166,7 @@
   ]
 }
 {
-  "index": "$1",
+  "index": "duplicate_keys_standard",
   "rows": [
     {
       "_id": "1501",
@@ -226,7 +221,7 @@
   ]
 }
 {
-  "index": "$1",
+  "index": "duplicate_keys_delta",
   "rows": [
     {
       "id": {


### PR DESCRIPTION
**Description:**

In practice we have seen problems with using MongoDB transactions for storing documents related to a
low default transaction timeout on MongoDB servers, and high memory usage on the server for large
transactions, which is probably why there is a fairly low default transaction timeout.

This converts the connector to an "at least once" style of materialization, forgoing the use of
transactions. With these changes, the materialization will work with unbounded Flow transaction
sizes, and be able to achieve "at least once" semantics in the general case, and "effectively once"
when idempotent reductions are used.

This PR also updates the connector to use bulk operations for loads and stores, which is a significant
performance improvement. Loads are done using the `find` operation with a reasonably sized list of 
IDs to retrieve. Stores are done using the `bulkWrite` operation.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

`materialize-mongodb` docs should be updated.

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/952)
<!-- Reviewable:end -->
