### PR TITLE
source-mongodb: incremental backfill

### DIFF
--- a/source-mongodb/.snapshots/TestCapture
+++ b/source-mongodb/.snapshots/TestCapture
@@ -1,0 +1,44 @@
+# ================================
+# Collection "acmeCo/test/collectionOne": 10 Documents
+# ================================
+{"_id":"pk val 0","onlyColumn":"onlyColumn val 0"}
+{"_id":"pk val 1","onlyColumn":"onlyColumn val 1"}
+{"_id":"pk val 2","onlyColumn":"onlyColumn val 2"}
+{"_id":"pk val 3","onlyColumn":"onlyColumn val 3"}
+{"_id":"pk val 4","onlyColumn":"onlyColumn val 4"}
+{"_id":"pk val 5","onlyColumn":"onlyColumn val 5"}
+{"_id":"pk val 6","onlyColumn":"onlyColumn val 6"}
+{"_id":"pk val 7","onlyColumn":"onlyColumn val 7"}
+{"_id":"pk val 8","onlyColumn":"onlyColumn val 8"}
+{"_id":"pk val 9","onlyColumn":"onlyColumn val 9"}
+# ================================
+# Collection "acmeCo/test/collectionThree": 10 Documents
+# ================================
+{"_id":"{\"Subtype\":0,\"Data\":\"cGsgdmFsIDA=\"}","firstColumn":"firstColumn val 0","secondColumn":"secondColumn val 0","thirdColumn":"thirdColumn val 0"}
+{"_id":"{\"Subtype\":0,\"Data\":\"cGsgdmFsIDE=\"}","firstColumn":"firstColumn val 1","secondColumn":"secondColumn val 1","thirdColumn":"thirdColumn val 1"}
+{"_id":"{\"Subtype\":0,\"Data\":\"cGsgdmFsIDI=\"}","firstColumn":"firstColumn val 2","secondColumn":"secondColumn val 2","thirdColumn":"thirdColumn val 2"}
+{"_id":"{\"Subtype\":0,\"Data\":\"cGsgdmFsIDM=\"}","firstColumn":"firstColumn val 3","secondColumn":"secondColumn val 3","thirdColumn":"thirdColumn val 3"}
+{"_id":"{\"Subtype\":0,\"Data\":\"cGsgdmFsIDQ=\"}","firstColumn":"firstColumn val 4","secondColumn":"secondColumn val 4","thirdColumn":"thirdColumn val 4"}
+{"_id":"{\"Subtype\":0,\"Data\":\"cGsgdmFsIDU=\"}","firstColumn":"firstColumn val 5","secondColumn":"secondColumn val 5","thirdColumn":"thirdColumn val 5"}
+{"_id":"{\"Subtype\":0,\"Data\":\"cGsgdmFsIDY=\"}","firstColumn":"firstColumn val 6","secondColumn":"secondColumn val 6","thirdColumn":"thirdColumn val 6"}
+{"_id":"{\"Subtype\":0,\"Data\":\"cGsgdmFsIDc=\"}","firstColumn":"firstColumn val 7","secondColumn":"secondColumn val 7","thirdColumn":"thirdColumn val 7"}
+{"_id":"{\"Subtype\":0,\"Data\":\"cGsgdmFsIDg=\"}","firstColumn":"firstColumn val 8","secondColumn":"secondColumn val 8","thirdColumn":"thirdColumn val 8"}
+{"_id":"{\"Subtype\":0,\"Data\":\"cGsgdmFsIDk=\"}","firstColumn":"firstColumn val 9","secondColumn":"secondColumn val 9","thirdColumn":"thirdColumn val 9"}
+# ================================
+# Collection "acmeCo/test/collectionTwo": 10 Documents
+# ================================
+{"_id":"0","firstColumn":"firstColumn val 0","secondColumn":"secondColumn val 0"}
+{"_id":"1.5","firstColumn":"firstColumn val 1","secondColumn":"secondColumn val 1"}
+{"_id":"2","firstColumn":"firstColumn val 2","secondColumn":"secondColumn val 2"}
+{"_id":"3.5","firstColumn":"firstColumn val 3","secondColumn":"secondColumn val 3"}
+{"_id":"4","firstColumn":"firstColumn val 4","secondColumn":"secondColumn val 4"}
+{"_id":"5.5","firstColumn":"firstColumn val 5","secondColumn":"secondColumn val 5"}
+{"_id":"6","firstColumn":"firstColumn val 6","secondColumn":"secondColumn val 6"}
+{"_id":"7.5","firstColumn":"firstColumn val 7","secondColumn":"secondColumn val 7"}
+{"_id":"8","firstColumn":"firstColumn val 8","secondColumn":"secondColumn val 8"}
+{"_id":"9.5","firstColumn":"firstColumn val 9","secondColumn":"secondColumn val 9"}
+# ================================
+# Final State Checkpoint
+# ================================
+{"resources":{"test.collectionOne":{"backfill_last_id":{"Type":2,"Value":"CQAAAHBrIHZhbCA0AA=="},"backfill_started_at":"2023-09-20T13:39:20.950616+01:00","status":1,"stream_resume_token":"MQAAAAJfZGF0YQAhAAAAODI2NTBBRTdGOTAwMDAwMDBGMkIwNDI5Mjk2RTE0MDQAAA=="},"test.collectionThree":{"backfill_last_id":{"Type":5,"Value":"CAAAAABwayB2YWwgNA=="},"backfill_started_at":"2023-09-20T13:39:20.96171+01:00","status":1,"stream_resume_token":"yQAAAAJfZGF0YQC5AAAAODI2NTBBRTdGOTAwMDAwMDBGMkIwNDJDMDEwMDI5NkU1QTEwMDQwNEFBMUJFRUFEOEE0MTZFQjlBOUE2OUE0QjQ0NzM4NjQ2M0M2RjcwNjU3MjYxNzQ2OTZGNkU1NDc5NzA2NTAwM0M2OTZFNzM2NTcyNzQwMDQ2NjQ2RjYzNzU2RDY1NkU3NDRCNjU3OTAwNDY1QTVGNjk2NDAwNUEwODAwNzA2QjIwNzY2MTZDMjAzOTAwMDAwNAAA"},"test.collectionTwo":{"backfill_last_id":{"Type":16,"Value":"BAAAAA=="},"backfill_started_at":"2023-09-20T13:39:20.95145+01:00","status":1,"stream_resume_token":"MQAAAAJfZGF0YQAhAAAAODI2NTBBRTdGOTAwMDAwMDBGMkIwNDI5Mjk2RTE0MDQAAA=="}}}
+

--- a/source-mongodb/main.go
+++ b/source-mongodb/main.go
@@ -100,8 +100,8 @@ func (d *driver) Connect(ctx context.Context, cfg config) (*mongo.Client, error)
 		return nil, err
 	}
 
-	if diff, err := OplogTimeDifference(ctx, client); err != nil {
-		return nil, fmt.Errorf("could not read oplog time difference: %w", err)
+	if diff, err := oplogTimeDifference(ctx, client); err != nil {
+		log.WithField("err", err).Warn("could not read oplog time difference")
 	} else {
 		log.WithField("timediff", diff).Debug("read oplog time difference")
 

--- a/source-mongodb/main.go
+++ b/source-mongodb/main.go
@@ -24,6 +24,8 @@ import (
 )
 
 const (
+	// Minimum oplog time difference: see the comment on OplogTimeDifference in
+	// oplog.go
 	minOplogTimediff = 24 * 60 * 60 // 24 hours, in seconds
 )
 

--- a/source-mongodb/main.go
+++ b/source-mongodb/main.go
@@ -101,10 +101,8 @@ func (d *driver) Connect(ctx context.Context, cfg config) (*mongo.Client, error)
 	}
 
 	if diff, err := oplogTimeDifference(ctx, client); err != nil {
-		log.WithField("err", err).Warn("could not read oplog time difference")
+		return nil, fmt.Errorf("could not read oplog, access to oplog is necessary: %w", err)
 	} else {
-		log.WithField("timediff", diff).Debug("read oplog time difference")
-
 		if diff < minOplogTimediff {
 			log.Warn(fmt.Sprintf("the current time difference between oldest and newest records in your oplog is %d seconds. This is smaller than the minimum of 24 hours. Please resize your oplog to be able to safely capture data from your database: https://go.estuary.dev/NurkrE", diff))
 		}

--- a/source-mongodb/main_test.go
+++ b/source-mongodb/main_test.go
@@ -1,0 +1,146 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"testing"
+	"time"
+
+	"github.com/bradleyjkemp/cupaloy"
+	st "github.com/estuary/connectors/source-boilerplate/testing"
+	"github.com/estuary/flow/go/protocols/flow"
+	log "github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCapture(t *testing.T) {
+	database := "test"
+	col1 := "collectionOne"
+	col2 := "collectionTwo"
+	col3 := "collectionThree"
+
+	ctx := context.Background()
+	client, cfg := testClient(t)
+
+	cleanup := func() {
+		dropCollection(ctx, t, client, database, col1)
+		dropCollection(ctx, t, client, database, col2)
+		dropCollection(ctx, t, client, database, col3)
+	}
+	cleanup()
+	t.Cleanup(cleanup)
+
+	stringPkVals := func(idx int) any {
+		return fmt.Sprintf("pk val %d", idx)
+	}
+
+	numberPkVals := func(idx int) any {
+		if idx%2 == 0 {
+			return idx
+		}
+
+		return float64(idx) + 0.5
+	}
+
+	binaryPkVals := func(idx int) any {
+		return []byte(fmt.Sprintf("pk val %d", idx))
+	}
+
+	addTestTableData(ctx, t, client, database, col1, 5, 0, stringPkVals, "onlyColumn")
+	addTestTableData(ctx, t, client, database, col2, 5, 0, numberPkVals, "firstColumn", "secondColumn")
+	addTestTableData(ctx, t, client, database, col3, 5, 0, binaryPkVals, "firstColumn", "secondColumn", "thirdColumn")
+
+	cs := &st.CaptureSpec{
+		Driver:       &driver{},
+		EndpointSpec: &cfg,
+		Checkpoint:   []byte("{}"),
+		// Values returned from individual segment queries will appear to be a random order, but
+		// this is because of how DynamoDB hashes values from the partition key. The returned
+		// orderings are deterministic per segment, but the concurrent processing of segments makes
+		// the overall ordering non-deterministic.
+		Validator:  &st.SortedCaptureValidator{},
+		Sanitizers: commonSanitizers(),
+		Bindings:   bindings(t, database, col1, col2, col3),
+	}
+
+	// Run the capture, stopping it before it has completed the entire backfill.
+	count := 0
+	captureCtx, cancel := context.WithCancel(context.Background())
+	cs.Capture(captureCtx, t, func(msg json.RawMessage) {
+		count++
+		if count == 10 {
+			cancel()
+		}
+	})
+
+	// Run the capture again and let it finish the backfill, resuming from the previous checkpoint.
+	advanceCapture(ctx, t, cs)
+
+	// Run the capture one more time, first adding more data that will be picked up from stream
+	// shards, to verify resumption from stream checkpoints.
+	addTestTableData(ctx, t, client, database, col1, 5, 5, stringPkVals, "onlyColumn")
+	addTestTableData(ctx, t, client, database, col2, 5, 5, numberPkVals, "firstColumn", "secondColumn")
+	addTestTableData(ctx, t, client, database, col3, 5, 5, binaryPkVals, "firstColumn", "secondColumn", "thirdColumn")
+
+	advanceCapture(ctx, t, cs)
+
+	cupaloy.SnapshotT(t, cs.Summary())
+}
+
+func commonSanitizers() map[string]*regexp.Regexp {
+	sanitizers := make(map[string]*regexp.Regexp)
+	for k, v := range st.DefaultSanitizers {
+		sanitizers[k] = v
+	}
+	sanitizers[`<UUID>`] = regexp.MustCompile(`[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}`)
+
+	return sanitizers
+}
+
+func resourceSpecJson(t *testing.T, r resource) json.RawMessage {
+	t.Helper()
+
+	out, err := json.Marshal(r)
+	require.NoError(t, err)
+
+	return out
+}
+
+func bindings(t *testing.T, database string, collections ...string) []*flow.CaptureSpec_Binding {
+	t.Helper()
+
+	out := []*flow.CaptureSpec_Binding{}
+	for _, col := range collections {
+		out = append(out, &flow.CaptureSpec_Binding{
+			ResourceConfigJson: resourceSpecJson(t, resource{Collection: col, Database: database}),
+			ResourcePath:       []string{col},
+			Collection:         flow.CollectionSpec{Name: flow.Collection(fmt.Sprintf("acmeCo/test/%s", col))},
+		})
+	}
+
+	return out
+}
+
+func advanceCapture(ctx context.Context, t testing.TB, cs *st.CaptureSpec) {
+	t.Helper()
+	captureCtx, cancelCapture := context.WithCancel(ctx)
+
+	const shutdownDelay = 100 * time.Millisecond
+	var shutdownWatchdog *time.Timer
+	log.Info("advanceCapture")
+	cs.Capture(captureCtx, t, func(data json.RawMessage) {
+		if shutdownWatchdog == nil {
+			shutdownWatchdog = time.AfterFunc(shutdownDelay, func() {
+				log.WithField("delay", shutdownDelay.String()).Debug("capture shutdown watchdog expired")
+				cancelCapture()
+			})
+		}
+		shutdownWatchdog.Reset(shutdownDelay)
+	})
+
+	for _, e := range cs.Errors {
+		require.NoError(t, e)
+	}
+}

--- a/source-mongodb/oplog.go
+++ b/source-mongodb/oplog.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"context"
+	"fmt"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+)
+
+type oplogRecord struct {
+	Ts primitive.Timestamp `bson:"ts"`
+}
+
+const tsProperty = "ts"
+
+func OplogTimeDifference(ctx context.Context, client *mongo.Client) (uint32, error) {
+	var db = client.Database("local")
+	var oplog = db.Collection("oplog.rs")
+
+	// get latest record
+	var opts = options.FindOne().SetSort(bson.D{{tsProperty, SortDescending}})
+	var latest oplogRecord
+	if err := oplog.FindOne(ctx, bson.D{}, opts).Decode(&latest); err != nil {
+		return 0, fmt.Errorf("querying latest oplog record: %w", err)
+	}
+
+	// get oldest record
+	opts = options.FindOne().SetSort(bson.D{{tsProperty, SortAscending}})
+	var oldest oplogRecord
+	if err := oplog.FindOne(ctx, bson.D{}, opts).Decode(&oldest); err != nil {
+		return 0, fmt.Errorf("querying oldest oplog record: %w", err)
+	}
+
+	return latest.Ts.T - oldest.Ts.T, nil
+}

--- a/source-mongodb/oplog.go
+++ b/source-mongodb/oplog.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/mongo"
@@ -41,4 +42,27 @@ func oplogTimeDifference(ctx context.Context, client *mongo.Client) (uint32, err
 	}
 
 	return latest.Ts.T - oldest.Ts.T, nil
+}
+
+// Check whether the timestamp ts is included in the oplog. This check is
+// necessary to make sure that when we set StartAtOperationTime, that timestamp
+// is actually available in the oplog. If it is not available, the driver will
+// not error, and we will lose some events without knowing
+func oplogHasTimestamp(ctx context.Context, client *mongo.Client, ts time.Time) error {
+	var db = client.Database("local")
+	var oplog = db.Collection("oplog.rs")
+
+	// get oldest record
+	var opts = options.FindOne().SetSort(bson.D{{tsProperty, SortAscending}})
+	var oldest oplogRecord
+	if err := oplog.FindOne(ctx, bson.D{}, opts).Decode(&oldest); err != nil {
+		return fmt.Errorf("querying oldest oplog record: %w", err)
+	}
+	var oldestTs = time.Unix(int64(oldest.Ts.T), 0)
+
+	if oldestTs.After(ts) {
+		return fmt.Errorf("oplog's oldest record is for %s, but the last checkpoint requires reading changes since %s. This is usually due to a small oplog storage available. Please resize your oplog to be able to safely capture data from your database: https://go.estuary.dev/NurkrE. After resizing your uplog, you can remove the binding for this collection add it back to trigger a backfill.", oldestTs.String(), ts.String())
+	}
+
+	return nil
 }

--- a/source-mongodb/oplog.go
+++ b/source-mongodb/oplog.go
@@ -16,6 +16,12 @@ type oplogRecord struct {
 
 const tsProperty = "ts"
 
+// Oplog time difference: the time difference is measured as the
+// difference between the latest and the oldest record in a MongoDB oplog, and
+// it is used as a measure of how long do oplog records stay in the oplog.
+// Note that this value can fluctuate depending on the density of oplog
+// records during a period, so continuously monitoring this value is necessary
+// and a single value is not representative
 func OplogTimeDifference(ctx context.Context, client *mongo.Client) (uint32, error) {
 	var db = client.Database("local")
 	var oplog = db.Collection("oplog.rs")

--- a/source-mongodb/oplog.go
+++ b/source-mongodb/oplog.go
@@ -22,7 +22,7 @@ const tsProperty = "ts"
 // Note that this value can fluctuate depending on the density of oplog
 // records during a period, so continuously monitoring this value is necessary
 // and a single value is not representative
-func OplogTimeDifference(ctx context.Context, client *mongo.Client) (uint32, error) {
+func oplogTimeDifference(ctx context.Context, client *mongo.Client) (uint32, error) {
 	var db = client.Database("local")
 	var oplog = db.Collection("oplog.rs")
 

--- a/source-mongodb/pull.go
+++ b/source-mongodb/pull.go
@@ -379,10 +379,8 @@ func (c *capture) BackfillCollection(ctx context.Context, client *mongo.Client, 
 			}
 
 			if diff, err := oplogTimeDifference(ctx, client); err != nil {
-				log.WithField("err", err).Warn("could not read oplog time difference")
+				return fmt.Errorf("could not read oplog, access to oplog is necessary: %w", err)
 			} else {
-				log.WithField("timediff", diff).Debug("read oplog time difference")
-
 				// TODO: This is just spamming logs, but users won't see these logs. Should we
 				// just error after seeing this error for a while?
 				if diff < minOplogTimediff {

--- a/source-mongodb/pull.go
+++ b/source-mongodb/pull.go
@@ -388,6 +388,11 @@ func (c *capture) BackfillCollection(ctx context.Context, client *mongo.Client, 
 		}
 	}
 
+
+	if err := cursor.Err(); err != nil {
+		return fmt.Errorf("cursor error for backfill %s: %w", res.Collection, err)
+	}
+
 	state.Status = StatusStreaming
 	var checkpoint = captureState{
 		Resources: map[string]resourceState{
@@ -401,10 +406,6 @@ func (c *capture) BackfillCollection(ctx context.Context, client *mongo.Client, 
 	}
 	if err = c.Output.Checkpoint(checkpointJson, true); err != nil {
 		return fmt.Errorf("sending checkpoint failed: %w", err)
-	}
-
-	if err := cursor.Err(); err != nil {
-		return fmt.Errorf("cursor error for backfill %s: %w", res.Collection, err)
 	}
 
 	return nil

--- a/source-mongodb/pull.go
+++ b/source-mongodb/pull.go
@@ -374,8 +374,8 @@ func (c *capture) BackfillCollection(ctx context.Context, client *mongo.Client, 
 				return fmt.Errorf("output checkpoint failed: %w", err)
 			}
 
-			if diff, err := OplogTimeDifference(ctx, client); err != nil {
-				return fmt.Errorf("could not read oplog time difference: %w", err)
+			if diff, err := oplogTimeDifference(ctx, client); err != nil {
+				log.WithField("err", err).Warn("could not read oplog time difference")
 			} else {
 				log.WithField("timediff", diff).Debug("read oplog time difference")
 

--- a/source-mongodb/test_util.go
+++ b/source-mongodb/test_util.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"testing"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+	"go.mongodb.org/mongo-driver/mongo"
+)
+
+var (
+	address   = flag.String("address", "mongodb://localhost", "MongoDB instance address")
+	user      = flag.String("user", "flow", "Username")
+	password  = flag.String("password", "flow", "Password")
+	database  = flag.String("database", "test", "Database name")
+)
+
+func testClient(t *testing.T) (*mongo.Client, config) {
+	t.Helper()
+	if os.Getenv("TEST_DATABASE") != "yes" {
+		t.Skipf("skipping %q: ${TEST_DATABASE} != \"yes\"", t.Name())
+		return nil, config{}
+	}
+
+	ctx := context.Background()
+
+	config := config{
+		Address: *address,
+		User: *user,
+		Password: *password,
+		Database: *database,
+	}
+
+	var d = driver{}
+	client, err := d.Connect(ctx, config)
+	require.NoError(t, err)
+
+	return client, config
+}
+
+func dropCollection(ctx context.Context, t *testing.T, client *mongo.Client, database string, collection string) {
+	t.Helper()
+
+	var db = client.Database(database)
+	var col = db.Collection(collection)
+	err := col.Drop(ctx)
+
+	require.NoError(t, err)
+}
+
+func addTestTableData(
+	ctx context.Context,
+	t *testing.T,
+	c *mongo.Client,
+	database string,
+	collection string,
+	numItems int,
+	startAtItem int,
+	pkData func(int) any,
+	cols ...string,
+) {
+	var db = c.Database(database)
+	var col = db.Collection(collection)
+
+	for idx := startAtItem; idx < startAtItem+numItems; idx++ {
+		item := make(map[string]any)
+		item["_id"] = pkData(idx)
+
+		for _, col := range cols {
+			item[col] = fmt.Sprintf("%s val %d", col, idx)
+		}
+
+		log.WithField("data", item).WithField("col", collection).Info("inserting data")
+		_, err := col.InsertOne(ctx, item)
+		require.NoError(t, err)
+	}
+}


### PR DESCRIPTION
**Description:**

- A new checkpoint structure which allows distinguishing between Backfill and Streaming states, and tracks last backfilled item, timestamp of backfill start, and resume token for streaming
- Converts old checkpoints to the new model
- Use `RawValue` for storing `BackfillLastId` so that we can be sure that we are not losing the original value of the `_id` during decoding and encoding processes of mongodb driver and/or checkpoint

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/955)
<!-- Reviewable:end -->
