### PR TITLE
source-kinesis: use localstack for integration tests 

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -135,14 +135,6 @@ jobs:
           service_account_key: ${{ secrets.GCP_SERVICE_ACCOUNT_KEY }}
           export_default_credentials: true
 
-      - name: Configure AWS credentials from Test account
-        if: matrix.connector == 'source-kinesis'
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: us-east-2
-
       - name: Login to GitHub package docker registry
         run: |
           echo "${{ secrets.GITHUB_TOKEN }}" | \
@@ -204,10 +196,6 @@ jobs:
             ]'), matrix.connector)
         env:
           GCP_SERVICE_ACCOUNT_KEY: ${{ secrets.GCP_SERVICE_ACCOUNT_KEY }}
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          DEFAULT_AWS_REGION: ${{ secrets.DEFAULT_AWS_REGION }}
-          AWS_DEFAULT_OUTPUT: json
           ROCKSET_API_KEY: ${{ secrets.ROCKSET_API_KEY }}
           MYSQL_DATABASE: test
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -163,6 +163,7 @@ jobs:
             "materialize-dynamodb",
             "materialize-elasticsearch",
             "source-dynamodb",
+            "source-kinesis",
             "source-mysql",
             "source-postgres",
             "source-sftp",

--- a/source-boilerplate/testing/testing.go
+++ b/source-boilerplate/testing/testing.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math"
 	"os"
 	"regexp"
 	"sort"
@@ -158,6 +159,12 @@ func (cs *CaptureSpec) Capture(ctx context.Context, t testing.TB, callback func(
 				Name:       flow.Capture("acmeCo/" + strings.Replace(t.Name(), "/", "-", -1) + "capture"),
 				ConfigJson: endpointSpecJSON,
 				Bindings:   cs.Bindings,
+			},
+			Range: &flow.RangeSpec{
+				KeyBegin:    0,
+				KeyEnd:      math.MaxUint32,
+				RClockBegin: 0,
+				RClockEnd:   math.MaxUint32,
 			},
 		}}
 

--- a/source-kinesis/.snapshots/TestKinesisCapture
+++ b/source-kinesis/.snapshots/TestKinesisCapture
@@ -1,0 +1,18 @@
+# ================================
+# Collection "": 10 Documents
+# ================================
+{"_meta":{"partition_key":"partitionKey-0","sequence_number":"<SEQUENCE_NUM>"},"i":"0"}
+{"_meta":{"partition_key":"partitionKey-1","sequence_number":"<SEQUENCE_NUM>"},"i":"1"}
+{"_meta":{"partition_key":"partitionKey-2","sequence_number":"<SEQUENCE_NUM>"},"i":"2"}
+{"_meta":{"partition_key":"partitionKey-3","sequence_number":"<SEQUENCE_NUM>"},"i":"3"}
+{"_meta":{"partition_key":"partitionKey-4","sequence_number":"<SEQUENCE_NUM>"},"i":"4"}
+{"_meta":{"partition_key":"partitionKey-5","sequence_number":"<SEQUENCE_NUM>"},"i":"5"}
+{"_meta":{"partition_key":"partitionKey-6","sequence_number":"<SEQUENCE_NUM>"},"i":"6"}
+{"_meta":{"partition_key":"partitionKey-7","sequence_number":"<SEQUENCE_NUM>"},"i":"7"}
+{"_meta":{"partition_key":"partitionKey-8","sequence_number":"<SEQUENCE_NUM>"},"i":"8"}
+{"_meta":{"partition_key":"partitionKey-9","sequence_number":"<SEQUENCE_NUM>"},"i":"9"}
+# ================================
+# Final State Checkpoint
+# ================================
+{"test-stream-1":{"shardId-000000000000":"<SEQUENCE_NUM>","shardId-000000000001":"<SEQUENCE_NUM>"},"test-stream-2":{"shardId-000000000000":"<SEQUENCE_NUM>","shardId-000000000001":"<SEQUENCE_NUM>"}}
+

--- a/source-kinesis/.snapshots/TestSpec
+++ b/source-kinesis/.snapshots/TestSpec
@@ -1,0 +1,57 @@
+{
+  "config_schema_json": {
+    "$schema": "http://json-schema.org/draft/2020-12/schema",
+    "$id": "https://github.com/estuary/connectors/source-kinesis/config",
+    "properties": {
+      "region": {
+        "type": "string",
+        "title": "AWS Region",
+        "description": "The name of the AWS region where the Kinesis stream is located"
+      },
+      "awsAccessKeyId": {
+        "type": "string",
+        "title": "AWS Access Key ID",
+        "description": "Part of the AWS credentials that will be used to connect to Kinesis"
+      },
+      "awsSecretAccessKey": {
+        "type": "string",
+        "title": "AWS Secret Access Key",
+        "description": "Part of the AWS credentials that will be used to connect to Kinesis"
+      },
+      "advanced": {
+        "properties": {
+          "endpoint": {
+            "type": "string",
+            "title": "AWS Endpoint",
+            "description": "The AWS endpoint URI to connect to (useful if you're capturing from a kinesis-compatible API that isn't provided by AWS)"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object"
+      }
+    },
+    "type": "object",
+    "required": [
+      "region",
+      "awsAccessKeyId",
+      "awsSecretAccessKey"
+    ],
+    "title": "Kinesis"
+  },
+  "resource_config_schema_json": {
+    "$schema": "http://json-schema.org/draft/2020-12/schema",
+    "$id": "https://github.com/estuary/connectors/source-kinesis/resource",
+    "properties": {
+      "stream": {
+        "type": "string",
+        "title": "Stream Name"
+      }
+    },
+    "type": "object",
+    "required": [
+      "stream"
+    ],
+    "title": "Kinesis Resource Spec"
+  },
+  "documentation_url": "https://go.estuary.dev/source-kinesis"
+}

--- a/source-kinesis/Dockerfile
+++ b/source-kinesis/Dockerfile
@@ -15,12 +15,14 @@ COPY go                 ./go
 COPY source-boilerplate ./source-boilerplate
 COPY source-kinesis     ./source-kinesis
 
-# Run the unit tests.
+# Run automated tests. To skip tests which interact with an external database (kinesis, in this
+# case), specify `--build-arg TEST_DATABASE=no` in the Docker command line.
+ARG TEST_DATABASE=yes
+ENV TEST_DATABASE=$TEST_DATABASE
 RUN go test -v ./source-kinesis/...
 
 # Build the connector.
 RUN go build -o ./connector -v ./source-kinesis/...
-
 
 # Runtime Stage
 ################################################################################

--- a/source-kinesis/capture.go
+++ b/source-kinesis/capture.go
@@ -16,10 +16,10 @@ import (
 )
 
 // readStream starts reading the given kinesis stream, delivering both records and errors from all
-// kinsis shards over the given `resultsCh`. This will continue to read indefinitely.
-// The `wg` is expected to have been incremented once _prior_ to calling this function. It will be
-// further incremented and decremented behind the scenes, but will be decremented back down to the
-// prior value when the read is finished.
+// kinesis shards over the given `resultsCh`. This will continue to read indefinitely. The `wg` is
+// expected to have been incremented once _prior_ to calling this function. It will be further
+// incremented and decremented behind the scenes, but will be decremented back down to the prior
+// value when the read is finished.
 func readStream(ctx context.Context, shardRange *pf.RangeSpec, client *kinesis.Kinesis, bindingIndex int, stream string, state map[string]string, resultsCh chan<- readResult, wg *sync.WaitGroup) {
 
 	var kc = &streamReader{
@@ -398,7 +398,7 @@ func (r *shardReader) readShardIterator(iteratorID string) error {
 		} else {
 			// Are we behind the tip of the shard? If so, then we'll make another request as soon as
 			// we can. If we're caught up with the tip of the shard and there's still no data, then
-			// we'll start applying a backoff so that we can releive some pressure on the network
+			// we'll start applying a backoff so that we can relieve some pressure on the network
 			// when a kinesis shard has a lower data volume.
 			if getRecordsResp.MillisBehindLatest != nil && *getRecordsResp.MillisBehindLatest > 0 {
 				r.noDataBackoff.reset()
@@ -503,7 +503,7 @@ var (
 	START_AT_BEGINNING = "TRIM_HORIZON"
 )
 
-// isContextCanceled returns true if the error is due to a context cancelation.
+// isContextCanceled returns true if the error is due to a context cancellation.
 // The AWS SDK will wrap context.Canceled errors, sometimes in multiple layers,
 // which is what this function is meant to deal with.
 func isContextCanceled(err error) bool {

--- a/source-kinesis/connection.go
+++ b/source-kinesis/connection.go
@@ -12,12 +12,16 @@ import (
 )
 
 // Config represents the fully merged endpoint configuration for Kinesis.
-// It matches the `KinesisConfig` struct in `crates/sources/src/specs.rs`
 type Config struct {
-	Endpoint           string `json:"endpoint,omitempty" jsonschema:"title=AWS Endpoint,description=The AWS endpoint URI to connect to (useful if you're capturing from a kinesis-compatible API that isn't provided by AWS)"`
 	Region             string `json:"region" jsonschema:"title=AWS Region,description=The name of the AWS region where the Kinesis stream is located"`
 	AWSAccessKeyID     string `json:"awsAccessKeyId" jsonschema:"title=AWS Access Key ID,description=Part of the AWS credentials that will be used to connect to Kinesis"`
 	AWSSecretAccessKey string `json:"awsSecretAccessKey" jsonschema:"title=AWS Secret Access Key,description=Part of the AWS credentials that will be used to connect to Kinesis"`
+
+	Advanced advancedConfig `json:"advanced,omitempty"`
+}
+
+type advancedConfig struct {
+	Endpoint string `json:"endpoint,omitempty" jsonschema:"title=AWS Endpoint,description=The AWS endpoint URI to connect to (useful if you're capturing from a kinesis-compatible API that isn't provided by AWS)"`
 }
 
 func (c *Config) Validate() error {
@@ -44,8 +48,8 @@ func connect(config *Config) (*kinesis.Kinesis, error) {
 	if config.Region != "" {
 		c = c.WithRegion(config.Region)
 	}
-	if config.Endpoint != "" {
-		c = c.WithEndpoint(config.Endpoint)
+	if config.Advanced.Endpoint != "" {
+		c = c.WithEndpoint(config.Advanced.Endpoint)
 	}
 
 	awsSession, err := session.NewSession(c)

--- a/source-kinesis/docker-compose.yaml
+++ b/source-kinesis/docker-compose.yaml
@@ -5,8 +5,13 @@ services:
     image: 'localstack/localstack:latest'
     environment:
       - SERVICES=kinesis
-      - KINESIS_ERROR_PROBABILITY=0.2
+      - KINESIS_ERROR_PROBABILITY=0 # This option is interesting, but will likely cause test flakes.
       - KINESIS_LATENCY=5 # ms
+    healthcheck: 
+      test: "AWS_ACCESS_KEY_ID=test AWS_SECRET_ACCESS_KEY=test AWS_DEFAULT_REGION=test aws --endpoint-url=http://localhost:4566 kinesis list-streams"
+      interval: 1s
+      timeout: 1s
+      retries: 60
     ports:
       - 4566:4566
     networks:

--- a/source-kinesis/docker-compose.yaml
+++ b/source-kinesis/docker-compose.yaml
@@ -1,0 +1,18 @@
+version: "3.7"
+
+services:
+  db:
+    image: 'localstack/localstack:latest'
+    environment:
+      - SERVICES=kinesis
+      - KINESIS_ERROR_PROBABILITY=0.2
+      - KINESIS_LATENCY=5 # ms
+    ports:
+      - 4566:4566
+    networks:
+      - flow-test
+
+networks:
+  flow-test:
+    name: flow-test
+    external: true

--- a/source-kinesis/main_test.go
+++ b/source-kinesis/main_test.go
@@ -1,0 +1,21 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/bradleyjkemp/cupaloy"
+	pc "github.com/estuary/flow/go/protocols/capture"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSpec(t *testing.T) {
+	driver := driver{}
+	response, err := driver.Spec(context.Background(), &pc.Request_Spec{})
+	require.NoError(t, err)
+
+	formatted, err := json.MarshalIndent(response, "", "  ")
+	require.NoError(t, err)
+	cupaloy.SnapshotT(t, string(formatted))
+}

--- a/source-kinesis/shard_range_test.go
+++ b/source-kinesis/shard_range_test.go
@@ -14,10 +14,10 @@ const maxKinesisHash = "340282366920938463463374607431768211455"
 
 // Ideally, our behavior will match theirs exactly, although technically our results will be correct
 // even if it is different. If our behavior doesn't match, then there could potentially be
-// pathalogical edge cases where records from partially overlapping kinesis shards get hashed
+// pathological edge cases where records from partially overlapping kinesis shards get hashed
 // disproportionately into a flow capture shard. The AWS docs don't document the particulars around
 // hashing partition keys, other than the fact that they use md5. This test exists to verify that
-// the given partition keys hash into the same kinesis shard that kinsis itself determines. Kinesis
+// the given partition keys hash into the same kinesis shard that kinesis itself determines. Kinesis
 // doesn't expose the actual hashed values, only the unhashed partition key and the shard id that it
 // went into. So this was setup by manually creating a kinesis stream with 2 shards, adding records
 // with the given partition keys and seeing which shard they went into. This can, and possibly

--- a/source-kinesis/testdata/kinesis-config.json
+++ b/source-kinesis/testdata/kinesis-config.json
@@ -1,6 +1,8 @@
 {
-    "region": "local",
-    "endpoint": "http://localhost:4566",
-    "awsAccessKeyId": "x",
-    "awsSecretAccessKey": "x"
+  "region": "local",
+  "awsAccessKeyId": "x",
+  "awsSecretAccessKey": "x",
+  "advanced": {
+    "endpoint": "http://localhost:4566"
+  }
 }

--- a/tests/source-kinesis/cleanup.sh
+++ b/tests/source-kinesis/cleanup.sh
@@ -1,5 +1,3 @@
 #!/bin/bash -e
 
-echo "Deleting kinesis stream: '$TEST_STREAM'"
-aws kinesis delete-stream --stream-name "$TEST_STREAM"
-echo "Successfully deleted kinesis stream"
+docker compose -f source-kinesis/docker-compose.yaml down -v

--- a/tests/source-kinesis/setup.sh
+++ b/tests/source-kinesis/setup.sh
@@ -1,27 +1,38 @@
 #!/bin/bash
 
 set -e
+export AWS_ACCESS_KEY_ID="${AWS_ACCESS_KEY_ID:=test}"
+export AWS_SECRET_ACCESS_KEY="${AWS_SECRET_ACCESS_KEY:=test}"
+export AWS_DEFAULT_REGION="${AWS_DEFAULT_REGION:=test}"
+export KINESIS_ENDPOINT="${KINESIS_ENDPOINT:=http://source-kinesis-db-1.flow-test:4566}"
+
 export TEST_STREAM="estuary-test-$(shuf -zer -n6 {a..z} | tr -d '\0')"
 export RESOURCE="{ \"stream\": \"${TEST_STREAM}\", \"syncMode\": \"incremental\" }"
+
+export KINESIS_LOCAL_ENDPOINT="http://localhost:4566"
 
 config_json_template='{
     "awsAccessKeyId": "$AWS_ACCESS_KEY_ID",
     "awsSecretAccessKey": "$AWS_SECRET_ACCESS_KEY",
-    "region": "${DEFAULT_AWS_REGION}"
+    "region": "${AWS_DEFAULT_REGION}",
+    "advanced": {
+        "endpoint": "${KINESIS_ENDPOINT}"
+    }
 }'
 
 export CONNECTOR_CONFIG="$(echo "$config_json_template" | envsubst | jq -c)"
-root_dir="$(git rev-parse --show-toplevel)"
 
-aws kinesis create-stream --stream-name "$TEST_STREAM" --shard-count 3
+docker compose -f source-kinesis/docker-compose.yaml up --detach --wait
+
+aws kinesis create-stream --stream-name "$TEST_STREAM" --shard-count 3 --endpoint-url "${KINESIS_LOCAL_ENDPOINT}"
 echo "waiting for stream: $TEST_STREAM to exist"
-aws kinesis wait stream-exists --stream-name "$TEST_STREAM"
+aws kinesis wait stream-exists --stream-name "$TEST_STREAM" --endpoint-url "${KINESIS_LOCAL_ENDPOINT}"
 echo "created stream: $TEST_STREAM"
 
-while IFS="" read -r doc || [ -n "$doc" ]
-do
+while IFS="" read -r doc || [ -n "$doc" ]; do
     aws --cli-binary-format base64 kinesis put-record \
         --stream-name "$TEST_STREAM" \
         --partition-key "$(head -c 12 /dev/urandom | base64)" \
-        --data "$(echo "$doc" | base64)"
-done < tests/files/d.jsonl
+        --data "$(echo "$doc" | base64)" \
+        --endpoint-url "${KINESIS_LOCAL_ENDPOINT}"
+done <tests/files/d.jsonl


### PR DESCRIPTION
**Description:**

- Uses `localstack` docker containers for Kinesis integration tests instead of actually calling to the real AWS API.

- Moves the "endpoint" configuration to an advanced option, which is consistent to other AWS captures
and materializations. This is not a field that a user is ever likely to use. There aren't any
existing kinesis captures that use this field, so this is not a breaking change.

- Also cleans up and fixes the set of capture tests for Kinesis, which had gotten into quite a state
of disarray.

Closes https://github.com/estuary/connectors/issues/864

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

N/A

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/956)
<!-- Reviewable:end -->
