### PR TITLE
source-mysql: Ignore ALTER COLUMN table alterations

### DIFF
--- a/source-mysql/replication.go
+++ b/source-mysql/replication.go
@@ -546,7 +546,7 @@ func (rs *mysqlReplicationStream) handleAlterTable(stmt *sqlparser.AlterTable, q
 		switch alter := alterOpt.(type) {
 		// These should be all of the table alterations which might possibly impact our capture
 		// in ways we don't currently support, so the default behavior can be to log and ignore.
-		case *sqlparser.AlterColumn, *sqlparser.RenameColumn:
+		case *sqlparser.RenameColumn:
 			return fmt.Errorf("unsupported column alteration (go.estuary.dev/eVVwet): %s", query)
 		case *sqlparser.RenameTableName:
 			return fmt.Errorf("unsupported table alteration (go.estuary.dev/eVVwet): %s", query)


### PR DESCRIPTION
**Description:**

A while back I made a list of all the table alterations which seemed like they could possibly be an issue, and made those all explicit errors so the default could be to ignore unhandled alterations (since there are a ton of benign ones).

This list was a little bit over-broad, and as far as I can see there is no way for an `ALTER COLUMN` clause to ever be a problem (since they just modify column defaults and a couple of other properties we don't care about) so these should be ignored as well.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/958)
<!-- Reviewable:end -->
