### PR TITLE
materialize-snowflake: fail validation if there is no active warehouse

### DIFF
--- a/materialize-snowflake/.snapshots/TestSpecification
+++ b/materialize-snowflake/.snapshots/TestSpecification
@@ -43,7 +43,7 @@
       "warehouse": {
         "type": "string",
         "title": "Warehouse",
-        "description": "The Snowflake virtual warehouse used to execute queries.",
+        "description": "The Snowflake virtual warehouse used to execute queries. Uses the default warehouse for the Snowflake user if left blank.",
         "order": 6
       },
       "role": {


### PR DESCRIPTION
**Description:**

If the Snowflake user does not have a default warehouse set for their account and there are multiple possible warehouses, there will be no active warehouse if one is not set in the endpoint configuration.

Currently we pass validation in this case and later fail during apply. This change verifies that there is an active warehouse for the endpoint configuration during validation.

Closes https://github.com/estuary/connectors/issues/942

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/959)
<!-- Reviewable:end -->
