### PR TITLE
materialize-sql: don't use numeric types for numeric formatted strings that are primary keys

### DIFF
--- a/materialize-mysql/sqlgen.go
+++ b/materialize-mysql/sqlgen.go
@@ -24,8 +24,14 @@ var mysqlDialect = func(tzLocation *time.Location) sql.Dialect {
 				Delegate:   sql.NewStaticMapper("LONGTEXT"),
 			},
 			WithFormat: map[string]sql.TypeMapper{
-				"integer":   sql.NewStaticMapper("NUMERIC(65,0)", sql.WithElementConverter(sql.StdStrToInt())),
-				"number":    sql.NewStaticMapper("DOUBLE PRECISION", sql.WithElementConverter(sql.StdStrToFloat())),
+				"integer": sql.PrimaryKeyMapper{
+					PrimaryKey: sql.NewStaticMapper("VARCHAR(256)"),
+					Delegate:   sql.NewStaticMapper("NUMERIC(65,0)", sql.WithElementConverter(sql.StdStrToInt())),
+				},
+				"number": sql.PrimaryKeyMapper{
+					PrimaryKey: sql.NewStaticMapper("VARCHAR(256)"),
+					Delegate:   sql.NewStaticMapper("DOUBLE PRECISION", sql.WithElementConverter(sql.StdStrToFloat())),
+				},
 				"date":      sql.NewStaticMapper("DATE"),
 				"date-time": sql.NewStaticMapper("DATETIME(6)", sql.WithElementConverter(rfc3339ToTZ(tzLocation))),
 				"time":      sql.NewStaticMapper("TIME(6)", sql.WithElementConverter(rfc3339TimeToTZ(tzLocation))),

--- a/materialize-postgres/sqlgen.go
+++ b/materialize-postgres/sqlgen.go
@@ -20,8 +20,14 @@ var pgDialect = func() sql.Dialect {
 		sql.STRING: sql.StringTypeMapper{
 			Fallback: sql.NewStaticMapper("TEXT"),
 			WithFormat: map[string]sql.TypeMapper{
-				"integer":   sql.NewStaticMapper("NUMERIC"),
-				"number":    sql.NewStaticMapper("DECIMAL"),
+				"integer": sql.PrimaryKeyMapper{
+					PrimaryKey: sql.NewStaticMapper("TEXT"),
+					Delegate:   sql.NewStaticMapper("NUMERIC"),
+				},
+				"number": sql.PrimaryKeyMapper{
+					PrimaryKey: sql.NewStaticMapper("TEXT"),
+					Delegate:   sql.NewStaticMapper("DECIMAL"),
+				},
 				"date":      sql.NewStaticMapper("DATE", sql.WithElementConverter(sql.ClampDate())),
 				"date-time": sql.NewStaticMapper("TIMESTAMPTZ", sql.WithElementConverter(sql.ClampDatetime())),
 				"duration":  sql.NewStaticMapper("INTERVAL"),

--- a/materialize-snowflake/sqlgen.go
+++ b/materialize-snowflake/sqlgen.go
@@ -46,8 +46,14 @@ var snowflakeDialect = func() sql.Dialect {
 		sql.STRING: sql.StringTypeMapper{
 			Fallback: sql.NewStaticMapper("STRING"),
 			WithFormat: map[string]sql.TypeMapper{
-				"integer":   sql.NewStaticMapper("INTEGER", sql.WithElementConverter(sql.StdStrToInt())), // Equivalent to NUMBER(38,0)
-				"number":    sql.NewStaticMapper("DOUBLE", sql.WithElementConverter(sql.StdStrToFloat())),
+				"integer": sql.PrimaryKeyMapper{
+					PrimaryKey: sql.NewStaticMapper("STRING"),
+					Delegate:   sql.NewStaticMapper("INTEGER", sql.WithElementConverter(sql.StdStrToInt())), // Equivalent to NUMBER(38,0)
+				},
+				"number": sql.PrimaryKeyMapper{
+					PrimaryKey: sql.NewStaticMapper("STRING"),
+					Delegate:   sql.NewStaticMapper("DOUBLE", sql.WithElementConverter(sql.StdStrToFloat())),
+				},
 				"date":      sql.NewStaticMapper("DATE"),
 				"date-time": sql.NewStaticMapper("TIMESTAMP"),
 			},

--- a/materialize-sql/type_mapping.go
+++ b/materialize-sql/type_mapping.go
@@ -92,7 +92,7 @@ func (p *Projection) AsFlatType() (_ FlatType, mustExist bool) {
 
 	// Compatible numeric formatted strings can be materialized as either integers or numbers,
 	// depending on the format string.
-	if _, ok := validate.AsFormattedNumeric(&p.Projection); ok {
+	if _, ok := validate.AsFormattedNumeric(&p.Projection); ok && !p.IsPrimaryKey {
 		return STRING, mustExist
 	}
 

--- a/materialize-sqlite/sqlgen.go
+++ b/materialize-sqlite/sqlgen.go
@@ -18,8 +18,14 @@ var sqliteDialect = func() sql.Dialect {
 		sql.STRING: sql.StringTypeMapper{
 			Fallback: sql.NewStaticMapper("TEXT"),
 			WithFormat: map[string]sql.TypeMapper{
-				"integer": sql.NewStaticMapper("INTEGER"),
-				"number":  sql.NewStaticMapper("REAL"),
+				"integer": sql.PrimaryKeyMapper{
+					PrimaryKey: sql.NewStaticMapper("TEXT"),
+					Delegate:   sql.NewStaticMapper("INTEGER"),
+				},
+				"number": sql.PrimaryKeyMapper{
+					PrimaryKey: sql.NewStaticMapper("TEXT"),
+					Delegate:   sql.NewStaticMapper("REAL"),
+				},
 			},
 		},
 	}

--- a/materialize-sqlserver/sqlgen.go
+++ b/materialize-sqlserver/sqlgen.go
@@ -69,8 +69,14 @@ var sqlServerDialect = func(collation string) sql.Dialect {
 				Delegate:   sql.NewStaticMapper(textType),
 			},
 			WithFormat: map[string]sql.TypeMapper{
-				"integer":   sql.NewStaticMapper("BIGINT", sql.WithElementConverter(strToInt())),
-				"number":    sql.NewStaticMapper("DOUBLE PRECISION", sql.WithElementConverter(sql.StdStrToFloat())),
+				"integer": sql.PrimaryKeyMapper{
+					PrimaryKey: sql.NewStaticMapper(textPKType),
+					Delegate:   sql.NewStaticMapper("BIGINT", sql.WithElementConverter(strToInt())),
+				},
+				"number": sql.PrimaryKeyMapper{
+					PrimaryKey: sql.NewStaticMapper(textPKType),
+					Delegate:   sql.NewStaticMapper("DOUBLE PRECISION", sql.WithElementConverter(sql.StdStrToFloat())),
+				},
 				"date":      sql.NewStaticMapper("DATE"),
 				"date-time": sql.NewStaticMapper("DATETIME2", sql.WithElementConverter(rfc3339ToUTC())),
 				"time":      sql.NewStaticMapper("TIME", sql.WithElementConverter(rfc3339TimeToUTC())),


### PR DESCRIPTION
**Description:**

Fixes an oversight from #946: We historically have not converted strings with integer or number format to their equivalent numeric type if they are collection keys, and need to continue to not do that. This is mostly because "number" types are usually converted to floats, which cannot be used as table primary keys.

It could possibly be argued that strings formatted as integers should be able to be materialized as integer primary keys. There's an option for that for (new) connectors going forward, but for now we need to keep the behavior the same to maintain compatibility. It may also be possible to change this later with some kind of table introspection, where the connector is able to convert types based on the actual table columns, but that would take significantly more thought.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/960)
<!-- Reviewable:end -->
