### PR TITLE
materialize-mongodb: simplify test setup

### DIFF
--- a/materialize-mongodb/docker-compose.yaml
+++ b/materialize-mongodb/docker-compose.yaml
@@ -3,8 +3,17 @@ version: "3.7"
 services:
   mongo:
     image: 'mongo:latest'
-    environment: {"MONGO_INITDB_ROOT_USERNAME": "flow", "MONGO_INITDB_ROOT_PASSWORD": "flow"}
-    command: ["--replSet", "rs0", "--keyFile", "/etc/ssl/sample.key"]
+    environment: 
+      MONGO_INITDB_ROOT_USERNAME: "flow"
+      MONGO_INITDB_ROOT_PASSWORD: "flow"
+      MONGO_INITDB_DATABASE: "test"
+    healthcheck:
+      test: echo 'db.runCommand("ping").ok' | mongosh localhost:27017/test --quiet
+      interval: 1s
+      timeout: 1s
+      retries: 60
+    ports:
+      - "27017:27017"
     networks:
       - flow-test
 

--- a/tests/materialize/materialize-mongodb/cleanup.sh
+++ b/tests/materialize/materialize-mongodb/cleanup.sh
@@ -4,4 +4,4 @@ set -o errexit
 set -o pipefail
 set -o nounset
 
-docker compose --file  ./materialize-mongodb/docker-compose.yaml down || true
+docker compose --file ./materialize-mongodb/docker-compose.yaml down || true

--- a/tests/materialize/materialize-mongodb/fetch.sh
+++ b/tests/materialize/materialize-mongodb/fetch.sh
@@ -10,6 +10,7 @@ function exportToJsonl() {
 		materialize-mongodb-mongo-1 mongosh test \
 		--username flow \
 		--password flow \
+		--authenticationDatabase admin \
 		--json=canonical \
 		--quiet \
 		--eval="db.$1.find({}, $projections).toArray()" | jq -S "{ index: \"$1\", rows: . }"

--- a/tests/materialize/materialize-mongodb/setup.sh
+++ b/tests/materialize/materialize-mongodb/setup.sh
@@ -4,38 +4,10 @@ set -o errexit
 set -o pipefail
 set -o nounset
 
-docker compose -f materialize-mongodb/docker-compose.yaml create
-docker compose -f materialize-mongodb/docker-compose.yaml up --detach
-
-# Copying and permissioning the key after launching the container is a bit of a race
-# condition but somehow there is no good way to get a key *copied* into a container
-# and editing the copy's permissions/ownership without first running the container,
-# so we're relying on MongoDB taking longer to start up than it takes us to run these
-# commands.
-docker cp materialize-mongodb/sample.key materialize-mongodb-mongo-1:/etc/ssl/sample.key
-docker exec materialize-mongodb-mongo-1 chmod 400 /etc/ssl/sample.key
-docker exec materialize-mongodb-mongo-1 chown mongodb /etc/ssl/sample.key
-
-set +e
-# need to wait some seconds before the replication server is set up
-sleep 5
-docker exec materialize-mongodb-mongo-1 \
-  mongosh \
-  -u flow \
-  -p flow \
-  --eval 'rs.initiate()'
-
-sleep 1
-
-docker exec materialize-mongodb-mongo-1 \
-  mongosh \
-  -u flow \
-  -p flow \
-  --eval 'db.createUser({ user: "flow", pwd: "flow", roles: [{ role: "readWrite", db: "test" }] })'
-set -e
+docker compose -f materialize-mongodb/docker-compose.yaml up -d --wait
 
 config_json_template='{
-   "address":  "materialize-mongodb-mongo-1",
+   "address":  "mongodb://materialize-mongodb-mongo-1.flow-test:27017?authSource=admin",
    "database": "test",
    "password": "flow",
    "user":     "flow"


### PR DESCRIPTION
**Description:**

Since it turns out we can't actually use MongoDB transactions, we don't need to use a MongoDB cluster with a replica set, and can instead use a single node for our test setup. This removes some flakiness from the automated tests, and should make it easier to get a local MongoDB running with the compose file.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/961)
<!-- Reviewable:end -->
