### PR TITLE
source-postgres: Advanced config option for discovery schemas

### DIFF
--- a/source-postgres/.snapshots/TestGeneric-SpecResponse
+++ b/source-postgres/.snapshots/TestGeneric-SpecResponse
@@ -68,6 +68,14 @@
             ],
             "title": "SSL Mode",
             "description": "Overrides SSL connection behavior by setting the 'sslmode' parameter."
+          },
+          "discover_schemas": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Discovery Schema Selection",
+            "description": "If this is specified only tables in the selected schema(s) will be automatically discovered. Leave blank to discover tables from all schemas."
           }
         },
         "additionalProperties": false,

--- a/source-postgres/main.go
+++ b/source-postgres/main.go
@@ -98,12 +98,13 @@ type Config struct {
 }
 
 type advancedConfig struct {
-	PublicationName   string `json:"publicationName,omitempty" jsonschema:"default=flow_publication,description=The name of the PostgreSQL publication to replicate from."`
-	SlotName          string `json:"slotName,omitempty" jsonschema:"default=flow_slot,description=The name of the PostgreSQL replication slot to replicate from."`
-	WatermarksTable   string `json:"watermarksTable,omitempty" jsonschema:"default=public.flow_watermarks,description=The name of the table used for watermark writes during backfills. Must be fully-qualified in '<schema>.<table>' form."`
-	SkipBackfills     string `json:"skip_backfills,omitempty" jsonschema:"title=Skip Backfills,description=A comma-separated list of fully-qualified table names which should not be backfilled."`
-	BackfillChunkSize int    `json:"backfill_chunk_size,omitempty" jsonschema:"title=Backfill Chunk Size,default=50000,description=The number of rows which should be fetched from the database in a single backfill query."`
-	SSLMode           string `json:"sslmode,omitempty" jsonschema:"title=SSL Mode,description=Overrides SSL connection behavior by setting the 'sslmode' parameter.,enum=disable,enum=allow,enum=prefer,enum=require,enum=verify-ca,enum=verify-full"`
+	PublicationName   string   `json:"publicationName,omitempty" jsonschema:"default=flow_publication,description=The name of the PostgreSQL publication to replicate from."`
+	SlotName          string   `json:"slotName,omitempty" jsonschema:"default=flow_slot,description=The name of the PostgreSQL replication slot to replicate from."`
+	WatermarksTable   string   `json:"watermarksTable,omitempty" jsonschema:"default=public.flow_watermarks,description=The name of the table used for watermark writes during backfills. Must be fully-qualified in '<schema>.<table>' form."`
+	SkipBackfills     string   `json:"skip_backfills,omitempty" jsonschema:"title=Skip Backfills,description=A comma-separated list of fully-qualified table names which should not be backfilled."`
+	BackfillChunkSize int      `json:"backfill_chunk_size,omitempty" jsonschema:"title=Backfill Chunk Size,default=50000,description=The number of rows which should be fetched from the database in a single backfill query."`
+	SSLMode           string   `json:"sslmode,omitempty" jsonschema:"title=SSL Mode,description=Overrides SSL connection behavior by setting the 'sslmode' parameter.,enum=disable,enum=allow,enum=prefer,enum=require,enum=verify-ca,enum=verify-full"`
+	DiscoverSchemas   []string `json:"discover_schemas,omitempty" jsonschema:"title=Discovery Schema Selection,description=If this is specified only tables in the selected schema(s) will be automatically discovered. Leave blank to discover tables from all schemas."`
 }
 
 // Validate checks that the configuration possesses all required properties.


### PR DESCRIPTION
**Description:**

This commit adds a new advanced config option containing a list of strings. If unset the connector will continue to operate as always, but if this list is non-empty then discovery will only return tables in schemas which are part of that list.

I have confirmed that this doesn't break any of our existing test suite and also verified manually that the filtering logic works as expected.

I'm not entirely happy with the field title/description text, I just wrote the first thing that came to mind so we could get this out. I'm also not entirely sure if this array of strings will look good in the UI form or if a single text input for a comma-separated list of schema names might be better.

**Workflow steps:**

Nothing should change by default, but users can now explicitly select the schemas that they want to discover tables within.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/962)
<!-- Reviewable:end -->
