### PR TITLE
source-postgres: Only apply schema filtering to catalog discovery

### DIFF
--- a/sqlcapture/interface.go
+++ b/sqlcapture/interface.go
@@ -185,6 +185,7 @@ type DiscoveryInfo struct {
 	PrimaryKey  []string              // An ordered list of the column names which together form the table's primary key.
 	ColumnNames []string              // The names of all columns, in the table's natural order.
 	BaseTable   bool                  // True if the table type is 'BASE TABLE' and false for views or other not-physical-table entities.
+	OmitBinding bool                  // True if the table should be omitted from discovery catalog generation.
 
 	// UnpredictableKeyOrdering will be true when the connector is unable to guarantee
 	// (for a particular table) that serialized RowKey values will accurately reproduce


### PR DESCRIPTION
**Description:**

We use the same table-discovery logic inside of a capture in order to get various table metadata, and it's possible for a table to be a configured binding even if it's excluded from discovery. Likewise the watermarks table may be accessible and in use even if it's in a schema which has been filtered out, and that shouldn't be an error.

I've verified that this doesn't break the discovery filtering logic or normal captures, however I haven't actually gone to the effort of reproducing a capture which fails because of the old way it worked. I'm fairly confident this will fix it nonetheless.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/963)
<!-- Reviewable:end -->
