### PR TITLE
materialize-elasticsearch: don't retry errors during Validate

### DIFF
--- a/materialize-elasticsearch/driver_test.go
+++ b/materialize-elasticsearch/driver_test.go
@@ -54,7 +54,7 @@ func TestApply(t *testing.T) {
 	secondResourceJson, err := json.Marshal(secondResource)
 	require.NoError(t, err)
 
-	client, err := cfg.toClient()
+	client, err := cfg.toClient(false)
 	require.NoError(t, err)
 
 	bp_test.RunApplyTestCases(


### PR DESCRIPTION
**Description:**

We have a pretty long retry duration setup for allowing extended retries of retryable errors for data-related operations, but this does not work well when performing connectivity checks.

A prime example is if the server is using a self-signed certificate, which we currently do not support. This will return a 5xx error that is currently retried, and will result in a timeout cancellation and mask the real error.

We could theoretically try to discriminate errors even further to decide which ones to retry, but for now it seems generally safer to fail fast when doing validation connectivity checks and allow the user to be the retry mechanism.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/965)
<!-- Reviewable:end -->
