### PR TITLE
source-mongodb: _meta/op

### DIFF
--- a/source-mongodb/.snapshots/TestCapture
+++ b/source-mongodb/.snapshots/TestCapture
@@ -1,44 +1,65 @@
 # ================================
-# Collection "acmeCo/test/collectionOne": 10 Documents
+# Collection "acmeCo/test/collectionOne": 17 Documents
 # ================================
+{"_id":"pk val 0","_meta":{"deleted":true,"op":"d"}}
+{"_id":"pk val 0","_meta":{"op":"c"},"onlyColumn":"onlyColumn val 0"}
 {"_id":"pk val 0","onlyColumn":"onlyColumn val 0"}
+{"_id":"pk val 1","_meta":{"op":"c"},"onlyColumn":"onlyColumn val 1"}
+{"_id":"pk val 1","_meta":{"op":"u"},"onlyColumn":"onlyColumn val 1","onlyColumn_new":"onlyColumn_new val 0"}
 {"_id":"pk val 1","onlyColumn":"onlyColumn val 1"}
+{"_id":"pk val 2","_meta":{"op":"c"},"onlyColumn":"onlyColumn val 2"}
 {"_id":"pk val 2","onlyColumn":"onlyColumn val 2"}
+{"_id":"pk val 3","_meta":{"op":"c"},"onlyColumn":"onlyColumn val 3"}
 {"_id":"pk val 3","onlyColumn":"onlyColumn val 3"}
+{"_id":"pk val 4","_meta":{"op":"c"},"onlyColumn":"onlyColumn val 4"}
 {"_id":"pk val 4","onlyColumn":"onlyColumn val 4"}
-{"_id":"pk val 5","onlyColumn":"onlyColumn val 5"}
-{"_id":"pk val 6","onlyColumn":"onlyColumn val 6"}
-{"_id":"pk val 7","onlyColumn":"onlyColumn val 7"}
-{"_id":"pk val 8","onlyColumn":"onlyColumn val 8"}
-{"_id":"pk val 9","onlyColumn":"onlyColumn val 9"}
+{"_id":"pk val 5","_meta":{"op":"c"},"onlyColumn":"onlyColumn val 5"}
+{"_id":"pk val 6","_meta":{"op":"c"},"onlyColumn":"onlyColumn val 6"}
+{"_id":"pk val 7","_meta":{"op":"c"},"onlyColumn":"onlyColumn val 7"}
+{"_id":"pk val 8","_meta":{"op":"c"},"onlyColumn":"onlyColumn val 8"}
+{"_id":"pk val 9","_meta":{"op":"c"},"onlyColumn":"onlyColumn val 9"}
 # ================================
-# Collection "acmeCo/test/collectionThree": 10 Documents
+# Collection "acmeCo/test/collectionThree": 17 Documents
 # ================================
+{"_id":"{\"Subtype\":0,\"Data\":\"cGsgdmFsIDA=\"}","_meta":{"deleted":true,"op":"d"}}
+{"_id":"{\"Subtype\":0,\"Data\":\"cGsgdmFsIDA=\"}","_meta":{"op":"c"},"firstColumn":"firstColumn val 0","secondColumn":"secondColumn val 0","thirdColumn":"thirdColumn val 0"}
 {"_id":"{\"Subtype\":0,\"Data\":\"cGsgdmFsIDA=\"}","firstColumn":"firstColumn val 0","secondColumn":"secondColumn val 0","thirdColumn":"thirdColumn val 0"}
+{"_id":"{\"Subtype\":0,\"Data\":\"cGsgdmFsIDE=\"}","_meta":{"op":"c"},"firstColumn":"firstColumn val 1","secondColumn":"secondColumn val 1","thirdColumn":"thirdColumn val 1"}
+{"_id":"{\"Subtype\":0,\"Data\":\"cGsgdmFsIDE=\"}","_meta":{"op":"u"},"firstColumn":"firstColumn val 1","forthColumn_new":"forthColumn_new val 0","secondColumn":"secondColumn val 1","thirdColumn":"thirdColumn val 1"}
 {"_id":"{\"Subtype\":0,\"Data\":\"cGsgdmFsIDE=\"}","firstColumn":"firstColumn val 1","secondColumn":"secondColumn val 1","thirdColumn":"thirdColumn val 1"}
+{"_id":"{\"Subtype\":0,\"Data\":\"cGsgdmFsIDI=\"}","_meta":{"op":"c"},"firstColumn":"firstColumn val 2","secondColumn":"secondColumn val 2","thirdColumn":"thirdColumn val 2"}
 {"_id":"{\"Subtype\":0,\"Data\":\"cGsgdmFsIDI=\"}","firstColumn":"firstColumn val 2","secondColumn":"secondColumn val 2","thirdColumn":"thirdColumn val 2"}
+{"_id":"{\"Subtype\":0,\"Data\":\"cGsgdmFsIDM=\"}","_meta":{"op":"c"},"firstColumn":"firstColumn val 3","secondColumn":"secondColumn val 3","thirdColumn":"thirdColumn val 3"}
 {"_id":"{\"Subtype\":0,\"Data\":\"cGsgdmFsIDM=\"}","firstColumn":"firstColumn val 3","secondColumn":"secondColumn val 3","thirdColumn":"thirdColumn val 3"}
+{"_id":"{\"Subtype\":0,\"Data\":\"cGsgdmFsIDQ=\"}","_meta":{"op":"c"},"firstColumn":"firstColumn val 4","secondColumn":"secondColumn val 4","thirdColumn":"thirdColumn val 4"}
 {"_id":"{\"Subtype\":0,\"Data\":\"cGsgdmFsIDQ=\"}","firstColumn":"firstColumn val 4","secondColumn":"secondColumn val 4","thirdColumn":"thirdColumn val 4"}
-{"_id":"{\"Subtype\":0,\"Data\":\"cGsgdmFsIDU=\"}","firstColumn":"firstColumn val 5","secondColumn":"secondColumn val 5","thirdColumn":"thirdColumn val 5"}
-{"_id":"{\"Subtype\":0,\"Data\":\"cGsgdmFsIDY=\"}","firstColumn":"firstColumn val 6","secondColumn":"secondColumn val 6","thirdColumn":"thirdColumn val 6"}
-{"_id":"{\"Subtype\":0,\"Data\":\"cGsgdmFsIDc=\"}","firstColumn":"firstColumn val 7","secondColumn":"secondColumn val 7","thirdColumn":"thirdColumn val 7"}
-{"_id":"{\"Subtype\":0,\"Data\":\"cGsgdmFsIDg=\"}","firstColumn":"firstColumn val 8","secondColumn":"secondColumn val 8","thirdColumn":"thirdColumn val 8"}
-{"_id":"{\"Subtype\":0,\"Data\":\"cGsgdmFsIDk=\"}","firstColumn":"firstColumn val 9","secondColumn":"secondColumn val 9","thirdColumn":"thirdColumn val 9"}
+{"_id":"{\"Subtype\":0,\"Data\":\"cGsgdmFsIDU=\"}","_meta":{"op":"c"},"firstColumn":"firstColumn val 5","secondColumn":"secondColumn val 5","thirdColumn":"thirdColumn val 5"}
+{"_id":"{\"Subtype\":0,\"Data\":\"cGsgdmFsIDY=\"}","_meta":{"op":"c"},"firstColumn":"firstColumn val 6","secondColumn":"secondColumn val 6","thirdColumn":"thirdColumn val 6"}
+{"_id":"{\"Subtype\":0,\"Data\":\"cGsgdmFsIDc=\"}","_meta":{"op":"c"},"firstColumn":"firstColumn val 7","secondColumn":"secondColumn val 7","thirdColumn":"thirdColumn val 7"}
+{"_id":"{\"Subtype\":0,\"Data\":\"cGsgdmFsIDg=\"}","_meta":{"op":"c"},"firstColumn":"firstColumn val 8","secondColumn":"secondColumn val 8","thirdColumn":"thirdColumn val 8"}
+{"_id":"{\"Subtype\":0,\"Data\":\"cGsgdmFsIDk=\"}","_meta":{"op":"c"},"firstColumn":"firstColumn val 9","secondColumn":"secondColumn val 9","thirdColumn":"thirdColumn val 9"}
 # ================================
-# Collection "acmeCo/test/collectionTwo": 10 Documents
+# Collection "acmeCo/test/collectionTwo": 17 Documents
 # ================================
+{"_id":"0","_meta":{"deleted":true,"op":"d"}}
+{"_id":"0","_meta":{"op":"c"},"firstColumn":"firstColumn val 0","secondColumn":"secondColumn val 0"}
 {"_id":"0","firstColumn":"firstColumn val 0","secondColumn":"secondColumn val 0"}
+{"_id":"1.5","_meta":{"op":"c"},"firstColumn":"firstColumn val 1","secondColumn":"secondColumn val 1"}
+{"_id":"1.5","_meta":{"op":"u"},"firstColumn":"firstColumn val 1","secondColumn":"secondColumn val 1","thirdColumn_new":"thirdColumn_new val 0"}
 {"_id":"1.5","firstColumn":"firstColumn val 1","secondColumn":"secondColumn val 1"}
+{"_id":"2","_meta":{"op":"c"},"firstColumn":"firstColumn val 2","secondColumn":"secondColumn val 2"}
 {"_id":"2","firstColumn":"firstColumn val 2","secondColumn":"secondColumn val 2"}
+{"_id":"3.5","_meta":{"op":"c"},"firstColumn":"firstColumn val 3","secondColumn":"secondColumn val 3"}
 {"_id":"3.5","firstColumn":"firstColumn val 3","secondColumn":"secondColumn val 3"}
+{"_id":"4","_meta":{"op":"c"},"firstColumn":"firstColumn val 4","secondColumn":"secondColumn val 4"}
 {"_id":"4","firstColumn":"firstColumn val 4","secondColumn":"secondColumn val 4"}
-{"_id":"5.5","firstColumn":"firstColumn val 5","secondColumn":"secondColumn val 5"}
-{"_id":"6","firstColumn":"firstColumn val 6","secondColumn":"secondColumn val 6"}
-{"_id":"7.5","firstColumn":"firstColumn val 7","secondColumn":"secondColumn val 7"}
-{"_id":"8","firstColumn":"firstColumn val 8","secondColumn":"secondColumn val 8"}
-{"_id":"9.5","firstColumn":"firstColumn val 9","secondColumn":"secondColumn val 9"}
+{"_id":"5.5","_meta":{"op":"c"},"firstColumn":"firstColumn val 5","secondColumn":"secondColumn val 5"}
+{"_id":"6","_meta":{"op":"c"},"firstColumn":"firstColumn val 6","secondColumn":"secondColumn val 6"}
+{"_id":"7.5","_meta":{"op":"c"},"firstColumn":"firstColumn val 7","secondColumn":"secondColumn val 7"}
+{"_id":"8","_meta":{"op":"c"},"firstColumn":"firstColumn val 8","secondColumn":"secondColumn val 8"}
+{"_id":"9.5","_meta":{"op":"c"},"firstColumn":"firstColumn val 9","secondColumn":"secondColumn val 9"}
 # ================================
 # Final State Checkpoint
 # ================================
-{"resources":{"test.collectionOne":{"backfill_last_id":{"Type":2,"Value":"CQAAAHBrIHZhbCA0AA=="},"backfill_started_at":"2023-09-20T13:39:20.950616+01:00","status":1,"stream_resume_token":"MQAAAAJfZGF0YQAhAAAAODI2NTBBRTdGOTAwMDAwMDBGMkIwNDI5Mjk2RTE0MDQAAA=="},"test.collectionThree":{"backfill_last_id":{"Type":5,"Value":"CAAAAABwayB2YWwgNA=="},"backfill_started_at":"2023-09-20T13:39:20.96171+01:00","status":1,"stream_resume_token":"yQAAAAJfZGF0YQC5AAAAODI2NTBBRTdGOTAwMDAwMDBGMkIwNDJDMDEwMDI5NkU1QTEwMDQwNEFBMUJFRUFEOEE0MTZFQjlBOUE2OUE0QjQ0NzM4NjQ2M0M2RjcwNjU3MjYxNzQ2OTZGNkU1NDc5NzA2NTAwM0M2OTZFNzM2NTcyNzQwMDQ2NjQ2RjYzNzU2RDY1NkU3NDRCNjU3OTAwNDY1QTVGNjk2NDAwNUEwODAwNzA2QjIwNzY2MTZDMjAzOTAwMDAwNAAA"},"test.collectionTwo":{"backfill_last_id":{"Type":16,"Value":"BAAAAA=="},"backfill_started_at":"2023-09-20T13:39:20.95145+01:00","status":1,"stream_resume_token":"MQAAAAJfZGF0YQAhAAAAODI2NTBBRTdGOTAwMDAwMDBGMkIwNDI5Mjk2RTE0MDQAAA=="}}}
+{"resources":{"test.collectionOne":{"backfill_last_id":{"Type":2,"Value":"CQAAAHBrIHZhbCA0AA=="},"backfill_started_at":"2023-09-20T14:04:27.135832+01:00","status":1,"stream_resume_token":"MQAAAAJfZGF0YQAhAAAAODI2NTBBRUREQjAwMDAwMDI3MkIwNDI5Mjk2RTE0MDQAAA=="},"test.collectionThree":{"backfill_last_id":{"Type":5,"Value":"CAAAAABwayB2YWwgNA=="},"backfill_started_at":"2023-09-20T14:04:27.147338+01:00","status":1,"stream_resume_token":"yQAAAAJfZGF0YQC5AAAAODI2NTBBRUREQjAwMDAwMDI3MkIwNDJDMDEwMDI5NkU1QTEwMDRBMjQyMENEM0RDRjM0NzUwOTk3OUFDMEE5QTk3QUE3NTQ2M0M2RjcwNjU3MjYxNzQ2OTZGNkU1NDc5NzA2NTAwM0M3NTcwNjQ2MTc0NjUwMDQ2NjQ2RjYzNzU2RDY1NkU3NDRCNjU3OTAwNDY1QTVGNjk2NDAwNUEwODAwNzA2QjIwNzY2MTZDMjAzMTAwMDAwNAAA"},"test.collectionTwo":{"backfill_last_id":{"Type":16,"Value":"BAAAAA=="},"backfill_started_at":"2023-09-20T14:04:27.13688+01:00","status":1,"stream_resume_token":"MQAAAAJfZGF0YQAhAAAAODI2NTBBRUREQjAwMDAwMDI3MkIwNDI5Mjk2RTE0MDQAAA=="}}}
 

--- a/source-mongodb/.snapshots/TestCapture
+++ b/source-mongodb/.snapshots/TestCapture
@@ -1,8 +1,8 @@
 # ================================
 # Collection "acmeCo/test/collectionOne": 17 Documents
 # ================================
-{"_id":"pk val 0","_meta":{"deleted":true,"op":"d"}}
 {"_id":"pk val 0","_meta":{"op":"c"},"onlyColumn":"onlyColumn val 0"}
+{"_id":"pk val 0","_meta":{"op":"d"}}
 {"_id":"pk val 0","onlyColumn":"onlyColumn val 0"}
 {"_id":"pk val 1","_meta":{"op":"c"},"onlyColumn":"onlyColumn val 1"}
 {"_id":"pk val 1","_meta":{"op":"u"},"onlyColumn":"onlyColumn val 1","onlyColumn_new":"onlyColumn_new val 0"}
@@ -21,8 +21,8 @@
 # ================================
 # Collection "acmeCo/test/collectionThree": 17 Documents
 # ================================
-{"_id":"{\"Subtype\":0,\"Data\":\"cGsgdmFsIDA=\"}","_meta":{"deleted":true,"op":"d"}}
 {"_id":"{\"Subtype\":0,\"Data\":\"cGsgdmFsIDA=\"}","_meta":{"op":"c"},"firstColumn":"firstColumn val 0","secondColumn":"secondColumn val 0","thirdColumn":"thirdColumn val 0"}
+{"_id":"{\"Subtype\":0,\"Data\":\"cGsgdmFsIDA=\"}","_meta":{"op":"d"}}
 {"_id":"{\"Subtype\":0,\"Data\":\"cGsgdmFsIDA=\"}","firstColumn":"firstColumn val 0","secondColumn":"secondColumn val 0","thirdColumn":"thirdColumn val 0"}
 {"_id":"{\"Subtype\":0,\"Data\":\"cGsgdmFsIDE=\"}","_meta":{"op":"c"},"firstColumn":"firstColumn val 1","secondColumn":"secondColumn val 1","thirdColumn":"thirdColumn val 1"}
 {"_id":"{\"Subtype\":0,\"Data\":\"cGsgdmFsIDE=\"}","_meta":{"op":"u"},"firstColumn":"firstColumn val 1","forthColumn_new":"forthColumn_new val 0","secondColumn":"secondColumn val 1","thirdColumn":"thirdColumn val 1"}
@@ -41,8 +41,8 @@
 # ================================
 # Collection "acmeCo/test/collectionTwo": 17 Documents
 # ================================
-{"_id":"0","_meta":{"deleted":true,"op":"d"}}
 {"_id":"0","_meta":{"op":"c"},"firstColumn":"firstColumn val 0","secondColumn":"secondColumn val 0"}
+{"_id":"0","_meta":{"op":"d"}}
 {"_id":"0","firstColumn":"firstColumn val 0","secondColumn":"secondColumn val 0"}
 {"_id":"1.5","_meta":{"op":"c"},"firstColumn":"firstColumn val 1","secondColumn":"secondColumn val 1"}
 {"_id":"1.5","_meta":{"op":"u"},"firstColumn":"firstColumn val 1","secondColumn":"secondColumn val 1","thirdColumn_new":"thirdColumn_new val 0"}
@@ -61,5 +61,5 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"resources":{"test.collectionOne":{"backfill_last_id":{"Type":2,"Value":"CQAAAHBrIHZhbCA0AA=="},"backfill_started_at":"2023-09-20T14:04:27.135832+01:00","status":1,"stream_resume_token":"MQAAAAJfZGF0YQAhAAAAODI2NTBBRUREQjAwMDAwMDI3MkIwNDI5Mjk2RTE0MDQAAA=="},"test.collectionThree":{"backfill_last_id":{"Type":5,"Value":"CAAAAABwayB2YWwgNA=="},"backfill_started_at":"2023-09-20T14:04:27.147338+01:00","status":1,"stream_resume_token":"yQAAAAJfZGF0YQC5AAAAODI2NTBBRUREQjAwMDAwMDI3MkIwNDJDMDEwMDI5NkU1QTEwMDRBMjQyMENEM0RDRjM0NzUwOTk3OUFDMEE5QTk3QUE3NTQ2M0M2RjcwNjU3MjYxNzQ2OTZGNkU1NDc5NzA2NTAwM0M3NTcwNjQ2MTc0NjUwMDQ2NjQ2RjYzNzU2RDY1NkU3NDRCNjU3OTAwNDY1QTVGNjk2NDAwNUEwODAwNzA2QjIwNzY2MTZDMjAzMTAwMDAwNAAA"},"test.collectionTwo":{"backfill_last_id":{"Type":16,"Value":"BAAAAA=="},"backfill_started_at":"2023-09-20T14:04:27.13688+01:00","status":1,"stream_resume_token":"MQAAAAJfZGF0YQAhAAAAODI2NTBBRUREQjAwMDAwMDI3MkIwNDI5Mjk2RTE0MDQAAA=="}}}
+{"resources":{"test.collectionOne":{"backfill_last_id":{"Type":2,"Value":"CQAAAHBrIHZhbCA0AA=="},"backfill_started_at":"2023-09-20T15:05:51.067604+01:00","status":1,"stream_resume_token":"MQAAAAJfZGF0YQAhAAAAODI2NTBBRkMzRjAwMDAwMDI3MkIwNDI5Mjk2RTE0MDQAAA=="},"test.collectionThree":{"backfill_last_id":{"Type":5,"Value":"CAAAAABwayB2YWwgNA=="},"backfill_started_at":"2023-09-20T15:05:51.080508+01:00","status":1,"stream_resume_token":"yQAAAAJfZGF0YQC5AAAAODI2NTBBRkMzRjAwMDAwMDI3MkIwNDJDMDEwMDI5NkU1QTEwMDQ5N0NFOTM2ODUzM0U0REFDQkE4QUI2NzNDNUZEQ0Q0MzQ2M0M2RjcwNjU3MjYxNzQ2OTZGNkU1NDc5NzA2NTAwM0M3NTcwNjQ2MTc0NjUwMDQ2NjQ2RjYzNzU2RDY1NkU3NDRCNjU3OTAwNDY1QTVGNjk2NDAwNUEwODAwNzA2QjIwNzY2MTZDMjAzMTAwMDAwNAAA"},"test.collectionTwo":{"backfill_last_id":{"Type":16,"Value":"BAAAAA=="},"backfill_started_at":"2023-09-20T15:05:51.06847+01:00","status":1,"stream_resume_token":"MQAAAAJfZGF0YQAhAAAAODI2NTBBRkMzRjAwMDAwMDI3MkIwNDI5Mjk2RTE0MDQAAA=="}}}
 

--- a/source-mongodb/discovery.go
+++ b/source-mongodb/discovery.go
@@ -24,10 +24,12 @@ const idProperty = "_id"
 const (
 	metaProperty    = "_meta"
 	deletedProperty = "deleted"
+	opProperty      = "op"
 )
 
 type documentMetadata struct {
-	Deleted bool `json:"deleted,omitempty" jsonschema:"title=Delete Flag,description=True if the document has been deleted, unset otherwise."`
+	Deleted bool `json:"deleted,omitempty" jsonschema:"title=Delete Flag (deprecated, use op instead),description=True if the document has been deleted, unset otherwise."`
+	Op bool `json:"op,omitempty" jsonschema:"title=Change Operation,description=Change operation type: 'c' Create/Insert, 'u' Update, 'd' Delete."`
 }
 
 func generateMinimalSchema() json.RawMessage {

--- a/source-mongodb/discovery.go
+++ b/source-mongodb/discovery.go
@@ -23,12 +23,10 @@ const idProperty = "_id"
 
 const (
 	metaProperty    = "_meta"
-	deletedProperty = "deleted"
 	opProperty      = "op"
 )
 
 type documentMetadata struct {
-	Deleted bool `json:"deleted,omitempty" jsonschema:"title=Delete Flag (deprecated, use op instead),description=True if the document has been deleted, unset otherwise."`
 	Op bool `json:"op,omitempty" jsonschema:"title=Change Operation,description=Change operation type: 'c' Create/Insert, 'u' Update, 'd' Delete."`
 }
 

--- a/source-mongodb/main_test.go
+++ b/source-mongodb/main_test.go
@@ -86,6 +86,20 @@ func TestCapture(t *testing.T) {
 
 	advanceCapture(ctx, t, cs)
 
+	// Delete some records
+	deleteData(ctx, t, client, database, col1, stringPkVals(0))
+	deleteData(ctx, t, client, database, col2, numberPkVals(0))
+	deleteData(ctx, t, client, database, col3, binaryPkVals(0))
+
+	advanceCapture(ctx, t, cs)
+
+	// Update records
+	updateData(ctx, t, client, database, col1, stringPkVals(1), "onlyColumn_new")
+	updateData(ctx, t, client, database, col2, numberPkVals(1), "thirdColumn_new")
+	updateData(ctx, t, client, database, col3, binaryPkVals(1), "forthColumn_new")
+
+	advanceCapture(ctx, t, cs)
+
 	cupaloy.SnapshotT(t, cs.Summary())
 }
 
@@ -129,7 +143,6 @@ func advanceCapture(ctx context.Context, t testing.TB, cs *st.CaptureSpec) {
 
 	const shutdownDelay = 100 * time.Millisecond
 	var shutdownWatchdog *time.Timer
-	log.Info("advanceCapture")
 	cs.Capture(captureCtx, t, func(data json.RawMessage) {
 		if shutdownWatchdog == nil {
 			shutdownWatchdog = time.AfterFunc(shutdownDelay, func() {

--- a/source-mongodb/pull.go
+++ b/source-mongodb/pull.go
@@ -251,7 +251,6 @@ func (c *capture) ChangeStream(ctx context.Context, client *mongo.Client, bindin
 			var doc = map[string]interface{}{
 				idProperty: ev.DocumentKey.Id,
 				metaProperty: map[string]interface{}{
-					deletedProperty: true,
 					opProperty: "d",
 				},
 			}

--- a/source-mongodb/test_util.go
+++ b/source-mongodb/test_util.go
@@ -79,3 +79,41 @@ func addTestTableData(
 		require.NoError(t, err)
 	}
 }
+
+func deleteData(
+	ctx context.Context,
+	t *testing.T,
+	c *mongo.Client,
+	database string,
+	collection string,
+	id any,
+) {
+	var db = c.Database(database)
+	var col = db.Collection(collection)
+
+	_, err := col.DeleteOne(ctx, map[string]any{"_id": id})
+
+	require.NoError(t, err)
+}
+
+func updateData(
+	ctx context.Context,
+	t *testing.T,
+	c *mongo.Client,
+	database string,
+	collection string,
+	id any,
+	cols ...string,
+) {
+	var db = c.Database(database)
+	var col = db.Collection(collection)
+
+	var item = make(map[string]any)
+	for _, col := range cols {
+		item[col] = fmt.Sprintf("%s val %d", col, 0)
+	}
+
+	_, err := col.UpdateOne(ctx, map[string]any{"_id": id}, map[string]any{ "$set": item })
+
+	require.NoError(t, err)
+}


### PR DESCRIPTION
**Description:**

- Add `_meta/op` to source-mongodb documents
- The tests helped find another issue, when emitting deleted documents we were not stringifying the `_id` the same way we do for other events, so there was a discrepancy there, fixed it.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/966)
<!-- Reviewable:end -->
