### PR TITLE
source-postgres: Fix column discovery when lacking permissions

### DIFF
--- a/source-postgres/.snapshots/TestDiscoveryWithoutPermissions
+++ b/source-postgres/.snapshots/TestDiscoveryWithoutPermissions
@@ -1,0 +1,106 @@
+Binding 0:
+{
+    "recommended_name": "discoverywithoutpermissions_117535",
+    "resource_config_json": {
+      "namespace": "public",
+      "stream": "discoverywithoutpermissions_117535"
+    },
+    "document_schema_json": {
+      "$defs": {
+        "PublicDiscoverywithoutpermissions_117535": {
+          "type": "object",
+          "required": [
+            "id"
+          ],
+          "$anchor": "PublicDiscoverywithoutpermissions_117535",
+          "properties": {}
+        }
+      },
+      "allOf": [
+        {
+          "required": [
+            "_meta"
+          ],
+          "properties": {
+            "_meta": {
+              "type": "object",
+              "required": [
+                "op",
+                "source"
+              ],
+              "properties": {
+                "before": {
+                  "$ref": "#PublicDiscoverywithoutpermissions_117535",
+                  "description": "Record state immediately before this change was applied.",
+                  "reduce": {
+                    "strategy": "firstWriteWins"
+                  }
+                },
+                "op": {
+                  "enum": [
+                    "c",
+                    "d",
+                    "u"
+                  ],
+                  "description": "Change operation type: 'c' Create/Insert, 'u' Update, 'd' Delete."
+                },
+                "source": {
+                  "$id": "https://github.com/estuary/connectors/source-postgres/postgres-source",
+                  "properties": {
+                    "ts_ms": {
+                      "type": "integer",
+                      "description": "Unix timestamp (in millis) at which this event was recorded by the database."
+                    },
+                    "schema": {
+                      "type": "string",
+                      "description": "Database schema (namespace) of the event."
+                    },
+                    "snapshot": {
+                      "type": "boolean",
+                      "description": "Snapshot is true if the record was produced from an initial table backfill and unset if produced from the replication log."
+                    },
+                    "table": {
+                      "type": "string",
+                      "description": "Database table of the event."
+                    },
+                    "loc": {
+                      "items": {
+                        "type": "integer"
+                      },
+                      "type": "array",
+                      "maxItems": 3,
+                      "minItems": 3,
+                      "description": "Location of this WAL event as [last Commit.EndLSN; event LSN; current Begin.FinalLSN]. See https://www.postgresql.org/docs/current/protocol-logicalrep-message-formats.html"
+                    },
+                    "txid": {
+                      "type": "integer",
+                      "description": "The 32-bit transaction ID assigned by Postgres to the commit which produced this change."
+                    }
+                  },
+                  "type": "object",
+                  "required": [
+                    "schema",
+                    "table",
+                    "loc"
+                  ]
+                }
+              },
+              "reduce": {
+                "strategy": "merge"
+              }
+            }
+          },
+          "reduce": {
+            "strategy": "merge"
+          }
+        },
+        {
+          "$ref": "#PublicDiscoverywithoutpermissions_117535"
+        }
+      ]
+    },
+    "key": [
+      "/id"
+    ]
+  }
+

--- a/source-postgres/.snapshots/TestDiscoveryWithoutPermissions
+++ b/source-postgres/.snapshots/TestDiscoveryWithoutPermissions
@@ -13,7 +13,17 @@ Binding 0:
             "id"
           ],
           "$anchor": "PublicDiscoverywithoutpermissions_117535",
-          "properties": {}
+          "properties": {
+            "data": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "id": {
+              "type": "integer"
+            }
+          }
         }
       },
       "allOf": [

--- a/source-postgres/discovery_test.go
+++ b/source-postgres/discovery_test.go
@@ -113,3 +113,16 @@ func TestPartitionedTableDiscovery(t *testing.T) {
 
 	tb.CaptureSpec(ctx, t).VerifyDiscover(ctx, t, regexp.MustCompile(uniqueID))
 }
+
+func TestDiscoveryWithoutPermissions(t *testing.T) {
+	var tb, ctx = postgresTestBackend(t), context.Background()
+
+	var uniqueID = "117535"
+	var tableName = strings.ToLower(fmt.Sprintf("public.%s_%s", strings.TrimPrefix(t.Name(), "Test"), uniqueID))
+	var tableDef = "(id INTEGER PRIMARY KEY, data TEXT)"
+	tb.Query(ctx, t, fmt.Sprintf(`DROP TABLE IF EXISTS %s;`, tableName))
+	t.Cleanup(func() { tb.Query(ctx, t, fmt.Sprintf(`DROP TABLE IF EXISTS %s;`, tableName)) })
+	tb.Query(ctx, t, fmt.Sprintf(`CREATE TABLE %s %s;`, tableName, tableDef))
+
+	tb.CaptureSpec(ctx, t).VerifyDiscover(ctx, t, regexp.MustCompile(uniqueID))
+}


### PR DESCRIPTION
**Description:**

This commit replaces the old column-discovery query with a drop-in replacement which uses various `pg_catalog` tables instead of `information_schema.columns` and thereby avoids the `has_column_privilege()` check which is part of that view.

Previously it was possible for the capture user to have sufficient permissions to discover a table and its primary key, but the column-discovery query would return no information. This would result in a generated schema like:

```
{
  "schema": {
    "$defs": {
      "foobar": {
        "type": "object",
        "required": [ "id" ],
        "$anchor": "foobar",
        "properties": {}
      }
    },
    "allOf": [
      { ...the usual _meta portion of the schema... },
      { "$ref": "#foobar" }
    ]
  },
  "key": [ "/id" ]
}
```

And because that schema doesn't constrain the primary-key types in any way this would result in a very ugly `location /id accepts "array", "boolean", "null", "number", "object", "string" in schema file://flow.json#[...], but locations used as keys may only be null-able integers, strings, or booleans` error (for every table impacted).

This PR fixes that by using the underlying `pg_catalog` information instead, which avoids any "does the user have access to this column" checks and means that we can generate correct schemas even when we don't have access to the table itself. Which means that at the end of the day the user will get a much friendler `user "flow_capture" cannot read from table "public.foobar"` error at publication time.

**Workflow steps:**

In theory nothing should change for any preexisting captures or any future captures which have adequate permissions.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/971)
<!-- Reviewable:end -->
