### PR TITLE
source-postgres: Assume keyless backfills are ordered by CTID

### DIFF
--- a/source-postgres/backfill.go
+++ b/source-postgres/backfill.go
@@ -149,7 +149,6 @@ var columnBinaryKeyComparison = map[string]bool{
 func (db *postgresDatabase) keylessScanQuery(info *sqlcapture.DiscoveryInfo, schemaName, tableName string) string {
 	var query = new(strings.Builder)
 	fmt.Fprintf(query, `SELECT * FROM "%s"."%s"`, schemaName, tableName)
-	fmt.Fprintf(query, ` ORDER BY ctid`)
 	fmt.Fprintf(query, ` LIMIT %d`, db.config.Advanced.BackfillChunkSize)
 	fmt.Fprintf(query, ` OFFSET $1;`)
 	return query.String()


### PR DESCRIPTION
**Description:**

Explicitly sorting on CTID is more strictly correct, but in practice can cause backfill queries to take minutes or even hours to execute. There are two ways we could fix this:

  1. Write some additional logic to issue CTID-range queries (for which there *is* a fast path in the Postgres query planner, compared to `ORDER BY ctid LIMIT n OFFSET m` which has no such special casing).
  2. Just assume that results will actually be in order if we omit the `ORDER BY` clause entirely.

Since it's so much simpler, we're opting for option (2) here.

Note that it's not even strictly necessary that the results be in CTID order so long as they're in a *stable* order between backfill queries. And while there's no explicit guarantee of that, in practice it appears to be the case.

**Workflow steps:**

Nothing changes but keyless backfills of massive tables run significantly faster.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/973)
<!-- Reviewable:end -->
