### PR TITLE
materialize-mysql: fix escaping issue with DSN

### DIFF
--- a/materialize-mysql/.snapshots/TestConfigURI-IncorrectSSL
+++ b/materialize-mysql/.snapshots/TestConfigURI-IncorrectSSL
@@ -1,2 +1,2 @@
-will:secret1234@tcp(example.com:3306)/somedb?tls=
+will:secret1234@tcp(example.com:3306)/somedb
 invalid 'sslmode' configuration: unknown setting "whoops-this-isnt-right"

--- a/materialize-mysql/driver_test.go
+++ b/materialize-mysql/driver_test.go
@@ -110,6 +110,7 @@ func TestPrereqs(t *testing.T) {
 				Tenant: "tenant",
 			}).Unwrap()
 
+			require.Equal(t, len(tt.want), len(actual))
 			for i := 0; i < len(tt.want); i++ {
 				require.ErrorContains(t, actual[i], tt.want[i])
 			}

--- a/materialize-sqlserver/driver_test.go
+++ b/materialize-sqlserver/driver_test.go
@@ -113,6 +113,7 @@ func TestPrereqs(t *testing.T) {
 				Tenant: "tenant",
 			}).Unwrap()
 
+			require.Equal(t, len(tt.want), len(actual))
 			for i := 0; i < len(tt.want); i++ {
 				require.ErrorContains(t, actual[i], tt.want[i])
 			}


### PR DESCRIPTION
**Description:**

The MySQL driver didn't work with passwords containing special characters because of the URL escaping coming from `uri.String()`. Notably, this was causing Oracle HeatWave materializations to fail with an authentication error because these passwords require special characters. Using the `mysql.Config` to construct the DSN fixes that.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/975)
<!-- Reviewable:end -->
