### PR TITLE
source-mongodb: order on $natural instead of ts

### DIFF
--- a/source-mongodb/oplog.go
+++ b/source-mongodb/oplog.go
@@ -15,7 +15,7 @@ type oplogRecord struct {
 	Ts primitive.Timestamp `bson:"ts"`
 }
 
-const tsProperty = "ts"
+const naturalSort = "$natural"
 
 // Oplog time difference: the time difference is measured as the
 // difference between the latest and the oldest record in a MongoDB oplog, and
@@ -28,14 +28,14 @@ func oplogTimeDifference(ctx context.Context, client *mongo.Client) (uint32, err
 	var oplog = db.Collection("oplog.rs")
 
 	// get latest record
-	var opts = options.FindOne().SetSort(bson.D{{tsProperty, SortDescending}})
+	var opts = options.FindOne().SetSort(bson.D{{naturalSort, SortDescending}})
 	var latest oplogRecord
 	if err := oplog.FindOne(ctx, bson.D{}, opts).Decode(&latest); err != nil {
 		return 0, fmt.Errorf("querying latest oplog record: %w", err)
 	}
 
 	// get oldest record
-	opts = options.FindOne().SetSort(bson.D{{tsProperty, SortAscending}})
+	opts = options.FindOne().SetSort(bson.D{{naturalSort, SortAscending}})
 	var oldest oplogRecord
 	if err := oplog.FindOne(ctx, bson.D{}, opts).Decode(&oldest); err != nil {
 		return 0, fmt.Errorf("querying oldest oplog record: %w", err)
@@ -53,7 +53,7 @@ func oplogHasTimestamp(ctx context.Context, client *mongo.Client, ts time.Time) 
 	var oplog = db.Collection("oplog.rs")
 
 	// get oldest record
-	var opts = options.FindOne().SetSort(bson.D{{tsProperty, SortAscending}})
+	var opts = options.FindOne().SetSort(bson.D{{naturalSort, SortAscending}})
 	var oldest oplogRecord
 	if err := oplog.FindOne(ctx, bson.D{}, opts).Decode(&oldest); err != nil {
 		return fmt.Errorf("querying oldest oplog record: %w", err)


### PR DESCRIPTION
**Description:**

there are no indexes defined on the oplog.rs collection, and the recommendation is to use the $natural order (the order by which records are written to disk) in order to read from this collection. This works for oplog.rs since there are only insertions, and never updates, so the $natural order is the order in which records have been inserted. There are performance implications for using any sort other than $natural since all documents must be scanned for those sorts.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/978)
<!-- Reviewable:end -->
