### PR TITLE
materialize-snowflake: allow per-resource schema configuration

### DIFF
--- a/materialize-snowflake/.snapshots/TestSQLGeneration
+++ b/materialize-snowflake/.snapshots/TestSQLGeneration
@@ -1,5 +1,5 @@
---- Begin target_table createTargetTable ---
-  CREATE TABLE IF NOT EXISTS target_table (
+--- Begin "a-schema".target_table createTargetTable ---
+  CREATE TABLE IF NOT EXISTS "a-schema".target_table (
     key1 INTEGER NOT NULL,
     key2 BOOLEAN NOT NULL,
     boolean BOOLEAN,
@@ -11,50 +11,50 @@
     PRIMARY KEY (key1, key2)
   );
 
-  COMMENT ON TABLE target_table IS 'Generated for materialization test/sqlite of collection key/value';
-  COMMENT ON COLUMN target_table.key1 IS 'auto-generated projection of JSON at: /key1 with inferred types: [integer]';
-  COMMENT ON COLUMN target_table.key2 IS 'auto-generated projection of JSON at: /key2 with inferred types: [boolean]';
-  COMMENT ON COLUMN target_table.boolean IS 'auto-generated projection of JSON at: /boolean with inferred types: [boolean]';
-  COMMENT ON COLUMN target_table.integer IS 'auto-generated projection of JSON at: /integer with inferred types: [integer]';
-  COMMENT ON COLUMN target_table.number IS 'auto-generated projection of JSON at: /number with inferred types: [number]';
-  COMMENT ON COLUMN target_table.string IS 'auto-generated projection of JSON at: /string with inferred types: [string]';
-  COMMENT ON COLUMN target_table.flow_document IS 'auto-generated projection of JSON at:  with inferred types: [object]';
-  --- End target_table createTargetTable ---
+  COMMENT ON TABLE "a-schema".target_table IS 'Generated for materialization test/sqlite of collection key/value';
+  COMMENT ON COLUMN "a-schema".target_table.key1 IS 'auto-generated projection of JSON at: /key1 with inferred types: [integer]';
+  COMMENT ON COLUMN "a-schema".target_table.key2 IS 'auto-generated projection of JSON at: /key2 with inferred types: [boolean]';
+  COMMENT ON COLUMN "a-schema".target_table.boolean IS 'auto-generated projection of JSON at: /boolean with inferred types: [boolean]';
+  COMMENT ON COLUMN "a-schema".target_table.integer IS 'auto-generated projection of JSON at: /integer with inferred types: [integer]';
+  COMMENT ON COLUMN "a-schema".target_table.number IS 'auto-generated projection of JSON at: /number with inferred types: [number]';
+  COMMENT ON COLUMN "a-schema".target_table.string IS 'auto-generated projection of JSON at: /string with inferred types: [string]';
+  COMMENT ON COLUMN "a-schema".target_table.flow_document IS 'auto-generated projection of JSON at:  with inferred types: [object]';
+  --- End "a-schema".target_table createTargetTable ---
 
---- Begin target_table loadQuery ---
-SELECT 0, target_table.flow_document
-	FROM target_table
+--- Begin "a-schema".target_table loadQuery ---
+SELECT 0, "a-schema".target_table.flow_document
+	FROM "a-schema".target_table
 	JOIN (
 		SELECT $1[0] AS key1, $1[1] AS key2
 		FROM @flow_v1/00010203-0405-0607-0809-0a0b0c0d0e0f
 	) AS r
-	ON target_table.key1 = r.key1 AND target_table.key2 = r.key2
---- End target_table loadQuery ---
+	ON "a-schema".target_table.key1 = r.key1 AND "a-schema".target_table.key2 = r.key2
+--- End "a-schema".target_table loadQuery ---
 
---- Begin target_table copyInto ---
-	COPY INTO target_table (
+--- Begin "a-schema".target_table copyInto ---
+	COPY INTO "a-schema".target_table (
 		key1, key2, boolean, integer, number, string, flow_document
 	) FROM (
 		SELECT $1[0] AS key1, $1[1] AS key2, $1[2] AS boolean, $1[3] AS integer, $1[4] AS number, $1[5] AS string, $1[6] AS flow_document
 		FROM @flow_v1/00010203-0405-0607-0809-0a0b0c0d0e0f
 	);
---- End target_table copyInto ---
+--- End "a-schema".target_table copyInto ---
 
---- Begin target_table mergeInto ---
-	MERGE INTO target_table
+--- Begin "a-schema".target_table mergeInto ---
+	MERGE INTO "a-schema".target_table AS l
 	USING (
 		SELECT $1[0] AS key1, $1[1] AS key2, $1[2] AS boolean, $1[3] AS integer, $1[4] AS number, $1[5] AS string, $1[6] AS flow_document
 		FROM @flow_v1/00010203-0405-0607-0809-0a0b0c0d0e0f
 	) AS r
-	ON target_table.key1 = r.key1 AND target_table.key2 = r.key2
+	ON l.key1 = r.key1 AND l.key2 = r.key2
 	WHEN MATCHED AND IS_NULL_VALUE(r.flow_document) THEN
 		DELETE
 	WHEN MATCHED THEN
-		UPDATE SET target_table.boolean = r.boolean, target_table.integer = r.integer, target_table.number = r.number, target_table.string = r.string, target_table.flow_document = r.flow_document
+		UPDATE SET l.boolean = r.boolean, l.integer = r.integer, l.number = r.number, l.string = r.string, l.flow_document = r.flow_document
 	WHEN NOT MATCHED THEN
 		INSERT (key1, key2, boolean, integer, number, string, flow_document)
 		VALUES (r.key1, r.key2, r.boolean, r.integer, r.number, r.string, r.flow_document);
---- End target_table mergeInto ---
+--- End "a-schema".target_table mergeInto ---
 
 --- Begin "Delta Updates" createTargetTable ---
   CREATE TABLE IF NOT EXISTS "Delta Updates" (
@@ -82,30 +82,30 @@ SELECT * FROM (SELECT -1, CAST(NULL AS VARIANT) LIMIT 0) as nodoc
 --- End "Delta Updates" copyInto ---
 
 --- Begin "Delta Updates" mergeInto ---
-	MERGE INTO "Delta Updates"
+	MERGE INTO "Delta Updates" AS l
 	USING (
 		SELECT $1[0] AS theKey, $1[1] AS aValue
 		FROM @flow_v1/00010203-0405-0607-0809-0a0b0c0d0e0f
 	) AS r
-	ON "Delta Updates".theKey = r.theKey
+	ON l.theKey = r.theKey
 	WHEN MATCHED THEN
-		UPDATE SET "Delta Updates".aValue = r.aValue
+		UPDATE SET l.aValue = r.aValue
 	WHEN NOT MATCHED THEN
 		INSERT (theKey, aValue)
 		VALUES (r.theKey, r.aValue);
 --- End "Delta Updates" mergeInto ---
 
 --- Begin target_table_no_values_materialized mergeInto ---
-	MERGE INTO target_table_no_values_materialized
+	MERGE INTO target_table_no_values_materialized AS l
 	USING (
 		SELECT $1[0] AS key1, $1[1] AS key2, $1[2] AS flow_document
 		FROM @flow_v1/00010203-0405-0607-0809-0a0b0c0d0e0f
 	) AS r
-	ON target_table_no_values_materialized.key1 = r.key1 AND target_table_no_values_materialized.key2 = r.key2
+	ON l.key1 = r.key1 AND l.key2 = r.key2
 	WHEN MATCHED AND IS_NULL_VALUE(r.flow_document) THEN
 		DELETE
 	WHEN MATCHED THEN
-		UPDATE SET target_table_no_values_materialized.flow_document = r.flow_document
+		UPDATE SET l.flow_document = r.flow_document
 	WHEN NOT MATCHED THEN
 		INSERT (key1, key2, flow_document)
 		VALUES (r.key1, r.key2, r.flow_document);

--- a/materialize-snowflake/.snapshots/TestSpecification
+++ b/materialize-snowflake/.snapshots/TestSpecification
@@ -37,7 +37,7 @@
       "schema": {
         "type": "string",
         "title": "Schema",
-        "description": "The SQL schema to use.",
+        "description": "Database schema for bound collection tables (unless overridden within the binding resource configuration) as well as associated materialization metadata tables.",
         "order": 5
       },
       "warehouse": {
@@ -93,6 +93,11 @@
       "table": {
         "type": "string",
         "x-collection-name": true
+      },
+      "schema": {
+        "type": "string",
+        "title": "Alternative Schema",
+        "description": "Alternative schema for this table (optional)"
       },
       "delta_updates": {
         "type": "boolean"

--- a/materialize-snowflake/sqlgen_test.go
+++ b/materialize-snowflake/sqlgen_test.go
@@ -21,12 +21,15 @@ func TestSQLGeneration(t *testing.T) {
 	require.NoError(t, json.Unmarshal(specJson, &spec))
 
 	var shape1 = sqlDriver.BuildTableShape(spec, 0, tableConfig{
-		Table: "target_table",
-		Delta: false,
+		Schema: "a-schema",
+		Table:  "target_table",
+		Delta:  false,
 	})
 	var shape2 = sqlDriver.BuildTableShape(spec, 1, tableConfig{
-		Table: "Delta Updates",
-		Delta: true,
+		Schema:         "default",
+		Table:          "Delta Updates",
+		Delta:          true,
+		endpointSchema: "default",
 	})
 	shape2.Document = nil // TODO(johnny): this is a bit gross.
 


### PR DESCRIPTION
**Description:**

Snowflake sessions & transactions can span across different schemas. This change allows for resource-level schema configuration, similar to other SQL materializations like materialize-postgres.

Particular attention is given to making the change compatible with existing materializations: If no schema is set for a resource OR the resource schema is the same as the endpoint configuration schema (as will be the case for all existing tasks), the resource path is still just the name of the target table.

Manual testing was done to confirm that tables with alternate schemas than the endpoint configuration get updated & materialized to correctly and can co-exist with tables in other alternate schemas and/or the endpoint configuration schema. Also the "migration" scenario was tested, where a pre-existing materialization was re-published with this new image, with confirmation that it did not re-materialize anything (the old checkpoint still held), both initially and if the schema was explicitly configured to be the same as the endpoint schema, including permutations of capitalizations that Snowflake disregards.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/980)
<!-- Reviewable:end -->
