### PR TITLE
source-postgres: Set `publish_via_partition_root` option

### DIFF
--- a/source-postgres/README.md
+++ b/source-postgres/README.md
@@ -83,6 +83,7 @@ CREATE USER flow_capture WITH PASSWORD 'secret' REPLICATION;
 GRANT pg_read_all_data TO flow_capture;
 
 CREATE PUBLICATION flow_publication FOR ALL TABLES;
+ALTER PUBLICATION flow_publication SET (publish_via_partition_root = true);
 
 -- Set WAL level to logical. Note that changing this requires a database
 -- restart to take effect.
@@ -143,3 +144,4 @@ performed automatically by `init-user-db.sh` if you use `docker-compose.yaml`):
     > GRANT SELECT ON ALL TABLES IN SCHEMA test TO flow_capture;
 
     > CREATE PUBLICATION flow_publication FOR ALL TABLES;
+    > ALTER PUBLICATION flow_publication SET (publish_via_partition_root = true);

--- a/source-postgres/docker-entrypoint-initdb.d/init-user-db.sh
+++ b/source-postgres/docker-entrypoint-initdb.d/init-user-db.sh
@@ -12,4 +12,5 @@ psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" <<-E
     GRANT CREATE, USAGE ON SCHEMA public TO flow_capture;
 
     CREATE PUBLICATION flow_publication FOR ALL TABLES;
+    ALTER PUBLICATION flow_publication SET (publish_via_partition_root = true);
 EOSQL


### PR DESCRIPTION
**Description:**

This fixes https://github.com/estuary/connectors/issues/751 (in combination with a Flow docs PR which I'll be merging around the same time)

This commit sets the `publish_via_partition_root` flag everywhere that `source-postgres` executes or documents a `CREATE PUBLICATION` query:

 - When, during prerequisite validation, the connector autocreates a publication it will now also attempt to set the flag. It does this in a followup `ALTER PUBLICATION` query because versions of Postgres <13 don't have this option and we don't want the create query to fail in those cases.
 - The example queries in the README now show it being set.
 - The `init-user-db.sh` script which initializes the CI database for tests will now set it as documented in the README.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/981)
<!-- Reviewable:end -->
