### PR TITLE
source-postgres-batch: Only allocate `cursorValues` if there's data

### DIFF
--- a/source-postgres-batch/driver.go
+++ b/source-postgres-batch/driver.go
@@ -528,9 +528,6 @@ func (c *capture) poll(ctx context.Context, bindingIndex int, tmpl *template.Tem
 		columnPointers[i] = &columnValues[i]
 	}
 
-	if len(cursorValues) != len(cursorNames) {
-		cursorValues = make([]any, len(cursorNames))
-	}
 	var count int
 	for rows.Next() {
 		if err := rows.Scan(columnPointers...); err != nil {
@@ -559,6 +556,11 @@ func (c *capture) poll(ctx context.Context, bindingIndex int, tmpl *template.Tem
 			return nil, fmt.Errorf("error emitting checkpoint: %w", err)
 		}
 
+		if len(cursorValues) != len(cursorNames) {
+			// Allocate a new values list if needed. This is done inside of the loop, so
+			// an empty result set will be a no-op even when the previous state is nil.
+			cursorValues = make([]any, len(cursorNames))
+		}
 		for i, name := range columnNames {
 			resultRow[name] = columnValues[i]
 		}


### PR DESCRIPTION
**Description:**

Allocating outside the loop means that the first polling iteration on an empty table will transform a cursor `nil` into `[]any{nil}` (of appropriate length) which is counted as "not the first query" the next time we try polling.

We'd prefer to instead keep running the "start" query until the first time it produces data, so that allocation is moved inside the loop where it will only be executed the first time it's actually needed.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/987)
<!-- Reviewable:end -->
