### PR TITLE
source-dynamodb: parallelize discovery

### DIFF
--- a/source-dynamodb/driver.go
+++ b/source-dynamodb/driver.go
@@ -5,13 +5,10 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
 	schemagen "github.com/estuary/connectors/go/schema-gen"
 	boilerplate "github.com/estuary/connectors/source-boilerplate"
 	pc "github.com/estuary/flow/go/protocols/capture"
 	pf "github.com/estuary/flow/go/protocols/flow"
-	log "github.com/sirupsen/logrus"
 )
 
 type driver struct{}
@@ -41,26 +38,12 @@ func (driver) Validate(ctx context.Context, req *pc.Request_Validate) (*pc.Respo
 		return nil, fmt.Errorf("parsing endpoint config: %w", err)
 	}
 
-	client, err := cfg.toClient(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("creating client: %w", err)
-	}
-
 	var out []*pc.Response_Validated_Binding
 	for _, binding := range req.Bindings {
 		var res resource
 		if err := pf.UnmarshalStrict(binding.ResourceConfigJson, &res); err != nil {
 			return nil, fmt.Errorf("parsing resource config: %w", err)
 		}
-
-		// Sanity-check: Can we run a scan on the table?
-		if _, err := client.db.Scan(ctx, &dynamodb.ScanInput{
-			TableName: aws.String(res.Table),
-			Limit:     aws.Int32(1),
-		}); err != nil {
-			return nil, fmt.Errorf("cannot read from table %s: %w", res.Table, err)
-		}
-		log.WithField("table", res.Table).Debug("validated table scan")
 
 		out = append(out, &pc.Response_Validated_Binding{
 			ResourcePath: []string{res.Table},

--- a/source-dynamodb/pull.go
+++ b/source-dynamodb/pull.go
@@ -128,6 +128,5 @@ func (driver) Pull(open *pc.Request_Open, stream *boilerplate.PullOutput) error 
 		})
 	}
 
-	// TODO: If we error here, do a catch-up read on all streams?
 	return eg.Wait()
 }


### PR DESCRIPTION
**Description:**

The DescribeStreams API has an account-wide limit 10 requests per second, which makes it
difficult to efficiently discover large numbers of tables without hitting that limit, or timing out
the discover.

Because of this, don't run DescribeStream for every discovered table's stream - it's just not
practical.

Also run `discoverTable` operations in parallel, since the DescribeTable API has a limit of 2,500
requests per second. And increase the maximum number of retries the clients will use to allow for a
degree of rate limiting from system backpressure during normal operation.

These changes allow a source with 100's of tables to be successfully discovered, at the expense of
only finding issues with disabled streams when the connector runs rather than during the publication
steps. If streaming is enabled for a table and configured correctly, it's probably not going to be
explicitly disabled, so this seems like a fair trade-off.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/989)
<!-- Reviewable:end -->
