### PR TITLE
source-mysql-batch: Tweaks to work nicer in the UI

### DIFF
--- a/source-mysql-batch/.snapshots/TestSpec
+++ b/source-mysql-batch/.snapshots/TestSpec
@@ -51,13 +51,15 @@
       "name": {
         "type": "string",
         "title": "Name",
-        "description": "The unique name of this resource."
+        "description": "The unique name of this resource.",
+        "order": 0
       },
       "template": {
         "type": "string",
         "title": "Query Template",
         "description": "The query template (pkg.go.dev/text/template) which will be rendered and then executed.",
-        "multiline": true
+        "multiline": true,
+        "order": 3
       },
       "cursor": {
         "items": {
@@ -65,19 +67,20 @@
         },
         "type": "array",
         "title": "Cursor Columns",
-        "description": "The names of columns which should be persisted between query executions as a cursor."
+        "description": "The names of columns which should be persisted between query executions as a cursor.",
+        "order": 2
       },
       "poll": {
         "type": "string",
         "title": "Poll Interval",
-        "description": "How often to execute the fetch query. Defaults to 24 hours if unset."
+        "description": "How often to execute the fetch query. Defaults to 24 hours if unset.",
+        "order": 1
       }
     },
     "type": "object",
     "required": [
       "name",
-      "template",
-      "cursor"
+      "template"
     ],
     "title": "Batch SQL Resource Spec"
   },

--- a/source-mysql-batch/driver.go
+++ b/source-mysql-batch/driver.go
@@ -36,10 +36,10 @@ type BatchSQLDriver struct {
 
 // Resource represents the capture configuration of a single resource binding.
 type Resource struct {
-	Name         string   `json:"name" jsonschema:"title=Name,description=The unique name of this resource."`
-	Template     string   `json:"template" jsonschema:"title=Query Template,description=The query template (pkg.go.dev/text/template) which will be rendered and then executed." jsonschema_extras:"multiline=true"`
-	Cursor       []string `json:"cursor" jsonschema:"title=Cursor Columns,description=The names of columns which should be persisted between query executions as a cursor."`
-	PollInterval string   `json:"poll,omitempty" jsonschema:"title=Poll Interval,description=How often to execute the fetch query. Defaults to 24 hours if unset."`
+	Name         string   `json:"name" jsonschema:"title=Name,description=The unique name of this resource." jsonschema_extras:"order=0"`
+	Template     string   `json:"template" jsonschema:"title=Query Template,description=The query template (pkg.go.dev/text/template) which will be rendered and then executed." jsonschema_extras:"multiline=true,order=3"`
+	Cursor       []string `json:"cursor,omitempty" jsonschema:"title=Cursor Columns,description=The names of columns which should be persisted between query executions as a cursor." jsonschema_extras:"order=2"`
+	PollInterval string   `json:"poll,omitempty" jsonschema:"title=Poll Interval,description=How often to execute the fetch query. Defaults to 24 hours if unset." jsonschema_extras:"order=1"`
 }
 
 // Validate checks that the resource spec possesses all required properties.


### PR DESCRIPTION
**Description:**

Tweaks a the resource config schema metadata so it should look nicer in the UI, and hopefully with the cursor no longer marked as required the generated bindings from discovery won't fail the form validation.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/990)
<!-- Reviewable:end -->
