### PR TITLE
source-dynamodb: adjust debug logging

### DIFF
--- a/source-dynamodb/stream.go
+++ b/source-dynamodb/stream.go
@@ -33,8 +33,10 @@ func (c *capture) streamTable(ctx context.Context, t *table) error {
 			// On initial startup the workers will have not have been started yet.
 			if workersStop != nil {
 				log.WithFields(log.Fields{
-					"table":  t.tableName,
-					"stream": t.streamArn,
+					"table":            t.tableName,
+					"stream":           t.streamArn,
+					"numInitialShards": len(initialShards),
+					"numCurrentShards": len(currentShards),
 				}).Debug("shard topology changed")
 
 				// Signal the workers to stop.
@@ -130,7 +132,7 @@ func (c *capture) pruneShards(tableName string, activeShards map[string]streamTy
 				log.WithFields(log.Fields{
 					"table":   tableName,
 					"shardId": id,
-				}).Info("pruning fully-read shard from capture state since it no longer exists")
+				}).Debug("pruning fully-read shard from capture state since it no longer exists")
 				prune = append(prune, id)
 			} else {
 				// Shard is gone but we didn't get to completely read it. This is an error since it


### PR DESCRIPTION
**Description:**

Info level logging for pruning a fully read shard is pretty spammy since it is directly redundant with having fully read the shard, so make that a debug log. Also add shard counts to the debug logging for a shard topology change.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/991)
<!-- Reviewable:end -->
