### PR TITLE
materialize-bigquery: allow per-resource dataset configuration

### DIFF
--- a/materialize-bigquery/.snapshots/TestSpecification
+++ b/materialize-bigquery/.snapshots/TestSpecification
@@ -26,7 +26,7 @@
       "dataset": {
         "type": "string",
         "title": "Dataset",
-        "description": "BigQuery dataset that will be used to store the materialization output.",
+        "description": "BigQuery dataset for bound collection tables (unless overridden within the binding resource configuration) as well as associated materialization metadata tables.",
         "order": 3
       },
       "bucket": {
@@ -89,6 +89,11 @@
         "title": "Table",
         "description": "Table in the BigQuery dataset to store materialized result in.",
         "x-collection-name": true
+      },
+      "dataset": {
+        "type": "string",
+        "title": "Alternative Dataset",
+        "description": "Alternative dataset for this table (optional). Must be located in the region set in the endpoint configuration."
       },
       "delta_updates": {
         "type": "boolean",

--- a/materialize-bigquery/sqlgen_test.go
+++ b/materialize-bigquery/sqlgen_test.go
@@ -23,7 +23,7 @@ func TestSQLGeneration(t *testing.T) {
 		Table:     "target_table",
 		Delta:     false,
 		projectID: "projectID",
-		dataset:   "dataset",
+		Dataset:   "dataset",
 	})
 
 	table, err := sqlDriver.ResolveTable(shape, bqDialect)
@@ -49,7 +49,7 @@ func TestSQLGeneration(t *testing.T) {
 		Table:     "target_table_no_values_materialized",
 		Delta:     false,
 		projectID: "projectID",
-		dataset:   "dataset",
+		Dataset:   "dataset",
 	})
 	tableNoValues, err := sqlDriver.ResolveTable(shapeNoValues, bqDialect)
 	require.NoError(t, err)

--- a/materialize-bigquery/transactor.go
+++ b/materialize-bigquery/transactor.go
@@ -57,13 +57,18 @@ func newTransactor(
 		// The name of the table itself is always the last element of the path.
 		table := binding.TableShape.Path[len(binding.TableShape.Path)-1]
 
+		// The dataset for the table is always the second to last element of the path. Dataset names
+		// can only contain letters, numbers, and underscores, so translateFlowIdentifier is not
+		// needed when using this part of the path directly.
+		dataset := binding.TableShape.Path[len(binding.TableShape.Path)-2]
+
 		// Lookup metadata for the table to build the schema for the external file that will be used
 		// for loading data. Schema definitions from the actual table columns are queried instead of
 		// directly using the dialect's output for JSON schema type to provide some degree in
 		// flexibility in changing the dialect and having it still work for existing tables. As long
 		// as the JSON encoding of the values is the same they may be used for columns that would
 		// have been created differently due to evolution of the dialect's column types.
-		meta, err := client.bigqueryClient.DatasetInProject(cfg.ProjectID, cfg.Dataset).Table(translateFlowIdentifier(table)).Metadata(ctx)
+		meta, err := client.bigqueryClient.DatasetInProject(cfg.ProjectID, dataset).Table(translateFlowIdentifier(table)).Metadata(ctx)
 		if err != nil {
 			return nil, fmt.Errorf("getting table metadata: %w", err)
 		}


### PR DESCRIPTION
**Description:**

BigQuery sessions & transactions can span across different BigQuery datasets. This change allows for resource-level dataset configuration, similar to how other SQL materializations allow for resource-level schema configuration.

Resources already inherited the dataset from the endpoint configuration for constructing queries, and this change makes that configurable rather than only inherited.

See also https://github.com/estuary/connectors/pull/980, which did something like this for Snowflake.

Manual testing was done to confirm that separate bindings can co-exist with different datasets configured than each other + different than the endpoint configured dataset with its metadata tables, and also to confirm that the migration scenario of a prior materialization with no dataset set for the resource can be upgraded to this connector and not re-materialize its tables, and also not re-materialize its tables if the resource dataset is set to the same value as the endpoint dataset.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/992)
<!-- Reviewable:end -->
