### PR TITLE
source-mysql-batch: Remove default 'DBName' setting

### DIFF
--- a/source-mysql-batch/.snapshots/TestSpec
+++ b/source-mysql-batch/.snapshots/TestSpec
@@ -26,8 +26,7 @@
           "dbname": {
             "type": "string",
             "title": "Database Name",
-            "description": "The name of database to connect to. In general this shouldn't matter. The connector can discover and capture from all databases it's authorized to access.",
-            "default": "mysql"
+            "description": "The name of database to connect to. In general this shouldn't matter. The connector can discover and capture from all databases it's authorized to access."
           }
         },
         "additionalProperties": false,

--- a/source-mysql-batch/main.go
+++ b/source-mysql-batch/main.go
@@ -26,7 +26,7 @@ type Config struct {
 }
 
 type advancedConfig struct {
-	DBName string `json:"dbname,omitempty" jsonschema:"title=Database Name,default=mysql,description=The name of database to connect to. In general this shouldn't matter. The connector can discover and capture from all databases it's authorized to access."`
+	DBName string `json:"dbname,omitempty" jsonschema:"title=Database Name,description=The name of database to connect to. In general this shouldn't matter. The connector can discover and capture from all databases it's authorized to access."`
 }
 
 // Validate checks that the configuration possesses all required properties.


### PR DESCRIPTION
**Description:**

The default setting for this property should be leaving it unset, not `"mysql"`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/996)
<!-- Reviewable:end -->
