### PR TITLE
source-dynamodb: fail-fast if stream workers error

### DIFF
--- a/source-dynamodb/stream.go
+++ b/source-dynamodb/stream.go
@@ -86,6 +86,11 @@ func (c *capture) streamTable(ctx context.Context, t *table) error {
 		select {
 		case <-time.After(t.shardMonitorDelay):
 			continue
+		case <-workersCtx.Done():
+			// Fail fast if any shard tree workers encounter an error. workersCtx is guaranteed to
+			// be non-nil here since the first pass of the loop will always create an initial worker
+			// group.
+			return fmt.Errorf("streamTable: %w", workers.Wait())
 		case <-ctx.Done():
 			return ctx.Err()
 		}


### PR DESCRIPTION
**Description:**

Fixes a defect where a stream worker error would only be detected when the shard topology changes, rather than immediately.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/999)
<!-- Reviewable:end -->
