### PR TITLE
source-mysql-batch: Streaming queries and default polling interval

### DIFF
--- a/source-mysql-batch/.snapshots/TestSpec
+++ b/source-mysql-batch/.snapshots/TestSpec
@@ -23,6 +23,11 @@
       },
       "advanced": {
         "properties": {
+          "poll": {
+            "type": "string",
+            "title": "Default Poll Interval",
+            "description": "How often to execute fetch queries. Defaults to 24 hours if unset."
+          },
           "dbname": {
             "type": "string",
             "title": "Database Name",
@@ -72,7 +77,7 @@
       "poll": {
         "type": "string",
         "title": "Poll Interval",
-        "description": "How often to execute the fetch query. Defaults to 24 hours if unset.",
+        "description": "How often to execute the fetch query (overrides the connector default setting)",
         "order": 1
       }
     },


### PR DESCRIPTION
**Description:**

When writing the initial implementation of `source-mysql-batch` I mistakenly assumed that the `go-mysql-org/go-mysql` implementation of the `database/sql` driver interface probably used streaming queries.

(This was an easy mistake to make since the `database/sql` result rows abstraction implements an iterator protocol which is clearly intended to allow streaming processing, and the MySQL client library does have methods for streaming query execution. I didn't think about it too hard and forgot about the extra steps we had to take to make streaming result processing work for the MySQL CDC connector.)

This PR replaces the use of `*sql.DB` with the lower-level `*client.Conn` representation and then explicitly uses a streaming query execution method when polling a binding.

It also adds a mutex so that only one binding can be actively executing its query at a time, because doing it that way was simpler than adding connection pooling, and because it's useful operationally to only have one thing at a time going on in the logs, and because this keeps memory usage as low as possible for now.

While I was working on all that, I also went ahead and added a connector-level advanced config option for setting the default polling interval. It can still be overridden on a per-binding basis and defaults to 24 hours if not set anywhere, but now the user can adjust a single number and have that impact all bindings which haven't specified their own polling interval setting.

**Workflow steps:**

Queries with massive resultsets should now work instead of getting the connector OOM-killed.

**Notes for reviewers:**

This is probably not the most elegantly-factored code I could have written, but we needed this fixed ASAP and _functionally_ it should be correct. Any internal plumbing cleanups can be done later as needed.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1001)
<!-- Reviewable:end -->
