### PR TITLE
source-mongodb: filter out system collections from discovery

### DIFF
--- a/source-mongodb/.snapshots/TestCapture
+++ b/source-mongodb/.snapshots/TestCapture
@@ -46,5 +46,5 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"resources":{"test.collectionOne":{"backfill_last_id":{"Type":2,"Value":"CQAAAHBrIHZhbCA0AA=="},"backfill_started_at:"<TIMESTAMP>","status":1,"stream_resume_token":"<STREAM_RESUME_TOKEN>"},"test.collectionThree":{"backfill_last_id":{"Type":5,"Value":"CAAAAABwayB2YWwgNA=="},"backfill_started_at:"<TIMESTAMP>","status":1,"stream_resume_token":"<STREAM_RESUME_TOKEN>"},"test.collectionTwo":{"backfill_last_id":{"Type":16,"Value":"BAAAAA=="},"backfill_started_at:"<TIMESTAMP>","status":1,"stream_resume_token":"<STREAM_RESUME_TOKEN>"}}}
+{"resources":{"test.collectionOne":{"backfill":{"done":true,"last_id":{"Type":2,"Value":"CQAAAHBrIHZhbCA0AA=="},"started_at:"<TIMESTAMP>"}},"test.collectionThree":{"backfill":{"done":true,"last_id":{"Type":5,"Value":"CAAAAABwayB2YWwgNA=="},"started_at:"<TIMESTAMP>"}},"test.collectionTwo":{"backfill":{"done":true,"last_id":{"Type":16,"Value":"BAAAAA=="},"started_at:"<TIMESTAMP>"}}},"stream_resume_token":"<STREAM_RESUME_TOKEN>"}
 

--- a/source-mongodb/discovery.go
+++ b/source-mongodb/discovery.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"reflect"
+	"slices"
 
 	pc "github.com/estuary/flow/go/protocols/capture"
 	pf "github.com/estuary/flow/go/protocols/flow"
@@ -96,11 +97,23 @@ func (d *driver) Discover(ctx context.Context, req *pc.Request_Discover) (*pc.Re
 		return nil, fmt.Errorf("listing collections: %w", err)
 	}
 
+	var systemCollections = []string{
+		"system.views",
+		"system.js",
+		"system.profile",
+		"system.indexes",
+		"system.namespaces",
+		"system.buckets",
+	}
+
 	var bindings = []*pc.Response_Discovered_Binding{}
 	for _, collection := range collections {
 		// Views cannot be used with change streams, so we don't support them for
 		// capturing at the moment
 		if collection.Type == "view" {
+			continue
+		}
+		if slices.Contains(systemCollections, collection.Name) {
 			continue
 		}
 		resourceJSON, err := json.Marshal(resource{Database: db.Name(), Collection: collection.Name})

--- a/source-mongodb/discovery_test.go
+++ b/source-mongodb/discovery_test.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"testing"
 
+	"go.mongodb.org/mongo-driver/mongo"
+	"github.com/stretchr/testify/require"
 	st "github.com/estuary/connectors/source-boilerplate/testing"
 )
 
@@ -34,6 +36,13 @@ func TestDiscover(t *testing.T) {
 
 		return float64(idx) + 0.5
 	}
+
+	// Create a view, this leads to `system.views` being created
+	// but neither the view itself, nor the `system.views` collections must not
+	// show up in the discovered results
+	var db = client.Database(database)
+	err := db.CreateView(ctx, "testView", col1, mongo.Pipeline{})
+	require.NoError(t, err)
 
 	addTestTableData(ctx, t, client, database, col1, 5, 0, stringPkVals, "onlyColumn")
 	addTestTableData(ctx, t, client, database, col2, 5, 0, numberPkVals, "firstColumn", "secondColumn")

--- a/source-mongodb/main_test.go
+++ b/source-mongodb/main_test.go
@@ -109,7 +109,7 @@ func commonSanitizers() map[string]*regexp.Regexp {
 		sanitizers[k] = v
 	}
 	sanitizers[`"stream_resume_token":"<STREAM_RESUME_TOKEN>"`] = regexp.MustCompile(`"stream_resume_token":"[^"]*"`)
-	sanitizers[`"backfill_started_at:"<TIMESTAMP>"`] = regexp.MustCompile(`"backfill_started_at":"((?:(\d{4}-\d{2}-\d{2})T(\d{2}:\d{2}:\d{2}(?:\.\d+)?))(Z|[\+-]\d{2}:\d{2})?)"`)
+	sanitizers[`"started_at:"<TIMESTAMP>"`] = regexp.MustCompile(`"started_at":"((?:(\d{4}-\d{2}-\d{2})T(\d{2}:\d{2}:\d{2}(?:\.\d+)?))(Z|[\+-]\d{2}:\d{2})?)"`)
 
 	return sanitizers
 }


### PR DESCRIPTION
**Description:**

- Filter out [system collections](https://www.mongodb.com/docs/manual/reference/system-collections/) from discovered output
- Updated snapshots for tests 

**Workflow steps:**

- Run a discover on a database which has some of the system collections. The system collections show up when their respective feature is used. For example, `system.views` shows up if there is a view created in that database. `system.profile` shows up if profiling is enabled, etc. These collections should no longer be in the output of discovery.

- Tested both using our existing test suite, and a manual test

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1002)
<!-- Reviewable:end -->
