### PR TITLE
source-postgres: don't allow empty schema in discovery schema selection list

### DIFF
--- a/source-postgres/.snapshots/TestGeneric-SpecResponse
+++ b/source-postgres/.snapshots/TestGeneric-SpecResponse
@@ -75,7 +75,7 @@
             },
             "type": "array",
             "title": "Discovery Schema Selection",
-            "description": "If this is specified only tables in the selected schema(s) will be automatically discovered. Leave blank to discover tables from all schemas."
+            "description": "If this is specified only tables in the selected schema(s) will be automatically discovered. Omit all entries to discover tables from all schemas."
           }
         },
         "additionalProperties": false,

--- a/source-postgres/main.go
+++ b/source-postgres/main.go
@@ -104,7 +104,7 @@ type advancedConfig struct {
 	SkipBackfills     string   `json:"skip_backfills,omitempty" jsonschema:"title=Skip Backfills,description=A comma-separated list of fully-qualified table names which should not be backfilled."`
 	BackfillChunkSize int      `json:"backfill_chunk_size,omitempty" jsonschema:"title=Backfill Chunk Size,default=50000,description=The number of rows which should be fetched from the database in a single backfill query."`
 	SSLMode           string   `json:"sslmode,omitempty" jsonschema:"title=SSL Mode,description=Overrides SSL connection behavior by setting the 'sslmode' parameter.,enum=disable,enum=allow,enum=prefer,enum=require,enum=verify-ca,enum=verify-full"`
-	DiscoverSchemas   []string `json:"discover_schemas,omitempty" jsonschema:"title=Discovery Schema Selection,description=If this is specified only tables in the selected schema(s) will be automatically discovered. Leave blank to discover tables from all schemas."`
+	DiscoverSchemas   []string `json:"discover_schemas,omitempty" jsonschema:"title=Discovery Schema Selection,description=If this is specified only tables in the selected schema(s) will be automatically discovered. Omit all entries to discover tables from all schemas."`
 }
 
 // Validate checks that the configuration possesses all required properties.
@@ -133,6 +133,11 @@ func (c *Config) Validate() error {
 	if c.Advanced.SSLMode != "" {
 		if !slices.Contains([]string{"disable", "allow", "prefer", "require", "verify-ca", "verify-full"}, c.Advanced.SSLMode) {
 			return fmt.Errorf("invalid 'sslmode' configuration: unknown setting %q", c.Advanced.SSLMode)
+		}
+	}
+	for _, s := range c.Advanced.DiscoverSchemas {
+		if len(s) == 0 {
+			return fmt.Errorf("discovery schema selection must not contain any entries that are blank: To discover tables from all schemas, remove all entries from the discovery schema selection list. To discover tables only from specific schemas, provide their names as non-blank entries")
 		}
 	}
 


### PR DESCRIPTION
**Description:**

If an empty schema is provided in the discovery schema selection list, there will be no tables discovered since all of them will be filtered out. This may inadvertently happen if a row is added to the array UI component and then not removed. It is not always obvious to the user in this case that they are actually providing a 0-length string as their schema filter.

Ideally we might have controls that would somehow combine a variable length array of items and the fact that if any of them are there, then they must not be 0 length. I couldn't find an easy way to do this with our use of schema-gen: Newer versions of `github.com/invopop/jsonschema` do allow some control over the format of `items` within an array, but not for setting `minLength` that I could see, and upgrading to one of these newer versions (we are using 0.5 which is quite old) may bring in various other breaking changes that don't seem worth right tackling now.

So the connector will return a validation error if any of the provided schemas are an empty string, with a description on what to do instead.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1003)
<!-- Reviewable:end -->
