### PR TITLE
source-mysql-batch: Remove redundant 24h default poll interval

### DIFF
--- a/source-mysql-batch/driver.go
+++ b/source-mysql-batch/driver.go
@@ -458,11 +458,8 @@ func (c *capture) worker(ctx context.Context, bindingIndex int, res *Resource) e
 	}
 
 	// Polling interval can be configured per binding. If unset, falls back to the
-	// connector global polling interval. If that's also unset, falls back to 24h.
-	var pollStr = "24h"
-	if c.Config.Advanced.PollInterval != "" {
-		pollStr = c.Config.Advanced.PollInterval
-	}
+	// connector global polling interval.
+	var pollStr = c.Config.Advanced.PollInterval
 	if res.PollInterval != "" {
 		pollStr = res.PollInterval
 	}


### PR DESCRIPTION
**Description:**

Just a minor cleanup pointed out in https://github.com/estuary/connectors/pull/1001, since the `SetDefaults()` logic fills in a default polling interval of `"24h"` we can assume the config property is non-empty later on.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1004)
<!-- Reviewable:end -->
