### PR TITLE
source-mysql-batch: Optimize document serialization

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -158,6 +158,8 @@ require (
 	github.com/prometheus/procfs v0.9.0 // indirect
 	github.com/rs/zerolog v1.28.0 // indirect
 	github.com/secure-systems-lab/go-securesystemslib v0.4.0 // indirect
+	github.com/segmentio/asm v1.1.3 // indirect
+	github.com/segmentio/encoding v0.3.6 // indirect
 	github.com/shopspring/decimal v1.3.1 // indirect
 	github.com/siddontang/go v0.0.0-20180604090527-bdc77568d726 // indirect
 	github.com/soheilhy/cmux v0.1.5 // indirect

--- a/go.sum
+++ b/go.sum
@@ -750,6 +750,10 @@ github.com/seborama/govcr v4.5.0+incompatible/go.mod h1:EgcISudCCYDLzbiAImJ8i7kk
 github.com/secure-systems-lab/go-securesystemslib v0.3.1/go.mod h1:o8hhjkbNl2gOamKUA/eNW3xUrntHT9L4W89W1nfj43U=
 github.com/secure-systems-lab/go-securesystemslib v0.4.0 h1:b23VGrQhTA8cN2CbBw7/FulN9fTtqYUdS5+Oxzt+DUE=
 github.com/secure-systems-lab/go-securesystemslib v0.4.0/go.mod h1:FGBZgq2tXWICsxWQW1msNf49F0Pf2Op5Htayx335Qbs=
+github.com/segmentio/asm v1.1.3 h1:WM03sfUOENvvKexOLp+pCqgb/WDjsi7EK8gIsICtzhc=
+github.com/segmentio/asm v1.1.3/go.mod h1:Ld3L4ZXGNcSLRg4JBsZ3//1+f/TjYl0Mzen/DQy1EJg=
+github.com/segmentio/encoding v0.3.6 h1:E6lVLyDPseWEulBmCmAKPanDd3jiyGDo5gMcugCRwZQ=
+github.com/segmentio/encoding v0.3.6/go.mod h1:n0JeuIqEQrQoPDGsjo8UNd1iA0U8d8+oHAA4E3G3OxM=
 github.com/shopspring/decimal v0.0.0-20180709203117-cd690d0c9e24/go.mod h1:M+9NzErvs504Cn4c5DxATwIqPbtswREoFCre64PpcG4=
 github.com/shopspring/decimal v1.2.0/go.mod h1:DKyhrW/HYNuLGql+MJL6WCR6knT2jwCFRcu2hWCYk4o=
 github.com/shopspring/decimal v1.3.1 h1:2Usl1nmF/WZucqkFZhnfFYxxxu8LG21F6nPQBE5gKV8=
@@ -1129,6 +1133,7 @@ golang.org/x/sys v0.0.0-20210819135213-f52c844e1c1c/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20210823070655-63515b42dcdf/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210908233432-aa78b53d3365/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210927094055-39ccf1dd6fa6/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20211110154304-99a53858aa08/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211124211545-fe61309f8881/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220224120231-95c6836cb0e7/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/go/encrow/encrow.go
+++ b/go/encrow/encrow.go
@@ -1,0 +1,78 @@
+// Package encrow provides a JSON encoder optimized for SQL table rows.
+package encrow
+
+import (
+	"fmt"
+	"sort"
+
+	"github.com/segmentio/encoding/json"
+)
+
+// A Shape represents the structure of a particular document.
+type Shape struct {
+	arity    int
+	prefixes []string
+	swizzle  []int
+}
+
+// NewShape constructs a new Shape corresponding to the provided field names.
+func NewShape(fields []string) *Shape {
+	// Construct a list of swizzle indices which order the fields by name.
+	var swizzle = make([]int, len(fields))
+	for i := 0; i < len(fields); i++ {
+		swizzle[i] = i
+	}
+	sort.Slice(swizzle, func(i, j int) bool {
+		return fields[swizzle[i]] < fields[swizzle[j]]
+	})
+
+	// Sort names
+	var sortedNames = make([]string, len(fields))
+	for i, j := range swizzle {
+		sortedNames[i] = fields[j]
+	}
+
+	return &Shape{
+		arity:    len(sortedNames),
+		prefixes: generatePrefixes(sortedNames),
+		swizzle:  swizzle,
+	}
+}
+
+func generatePrefixes(fields []string) []string {
+	var prefixes []string
+	for idx, fieldName := range fields {
+		var quotedFieldName, err = json.Marshal(fieldName)
+		if err != nil {
+			panic(fmt.Errorf("error escaping field name %q: %w", fieldName, err))
+		}
+		if idx == 0 {
+			prefixes = append(prefixes, fmt.Sprintf("{%s:", quotedFieldName))
+		} else {
+			prefixes = append(prefixes, fmt.Sprintf(",%s:", quotedFieldName))
+		}
+	}
+	return prefixes
+}
+
+// Encode serializes a list of values into the specified shape.
+func (s *Shape) Encode(values []any) ([]byte, error) {
+	var err error
+	if len(values) != s.arity {
+		return nil, fmt.Errorf("incorrect row arity: expected %d but got %d", s.arity, len(values))
+	}
+	if s.arity == 0 {
+		return []byte("{}"), nil
+	}
+
+	var bs []byte
+	for idx, vidx := range s.swizzle {
+		bs = append(bs, s.prefixes[idx]...)
+		bs, err = json.Append(bs, values[vidx], json.EscapeHTML|json.SortMapKeys)
+		if err != nil {
+			return nil, err
+		}
+	}
+	bs = append(bs, '}')
+	return bs, nil
+}

--- a/go/encrow/encrow.go
+++ b/go/encrow/encrow.go
@@ -55,8 +55,9 @@ func generatePrefixes(fields []string) []string {
 	return prefixes
 }
 
-// Encode serializes a list of values into the specified shape.
-func (s *Shape) Encode(values []any) ([]byte, error) {
+// Encode serializes a list of values into the specified shape. If a buffer slice
+// is provided it will be truncated and reused.
+func (s *Shape) Encode(buf []byte, values []any) ([]byte, error) {
 	var err error
 	if len(values) != s.arity {
 		return nil, fmt.Errorf("incorrect row arity: expected %d but got %d", s.arity, len(values))
@@ -65,14 +66,14 @@ func (s *Shape) Encode(values []any) ([]byte, error) {
 		return []byte("{}"), nil
 	}
 
-	var bs []byte
+	buf = buf[:0]
 	for idx, vidx := range s.swizzle {
-		bs = append(bs, s.prefixes[idx]...)
-		bs, err = json.Append(bs, values[vidx], json.EscapeHTML|json.SortMapKeys)
+		buf = append(buf, s.prefixes[idx]...)
+		buf, err = json.Append(buf, values[vidx], json.EscapeHTML|json.SortMapKeys)
 		if err != nil {
 			return nil, err
 		}
 	}
-	bs = append(bs, '}')
-	return bs, nil
+	buf = append(buf, '}')
+	return buf, nil
 }

--- a/go/encrow/encrow_test.go
+++ b/go/encrow/encrow_test.go
@@ -1,0 +1,128 @@
+package encrow
+
+import (
+	"fmt"
+	"io"
+	"math/rand"
+	"testing"
+	"time"
+
+	stdjson "encoding/json"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+)
+
+const benchmarkDatasetSize = 1000
+
+func BenchmarkStandardSerialization(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		b.StopTimer()
+		var names, values = benchmarkDataset(benchmarkDatasetSize)
+		b.StartTimer()
+
+		for _, row := range values {
+			var fields = make(map[string]any)
+			for idx, val := range row {
+				fields[names[idx]] = val
+			}
+			var bs, err = stdjson.Marshal(fields)
+			require.NoError(b, err)
+			io.Discard.Write(bs)
+		}
+	}
+}
+
+func BenchmarkShapeSerialization(b *testing.B) {
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		b.StopTimer()
+		var names, values = benchmarkDataset(benchmarkDatasetSize)
+		b.StartTimer()
+
+		var s *Shape
+		for _, row := range values {
+			if s == nil {
+				s = NewShape(names)
+			}
+			var bs, err = s.Encode(row)
+			require.NoError(b, err)
+			io.Discard.Write(bs)
+		}
+	}
+}
+
+func TestSerializationEquivalence(t *testing.T) {
+	var names, values = benchmarkDataset(benchmarkDatasetSize)
+	for _, row := range values {
+		checkEquivalence(t, names, row)
+	}
+}
+
+func FuzzSerialization(f *testing.F) {
+	f.Add(`{"id": 123}`)
+	f.Add(`{"data": "foobar", "moredata": "xyzzy"}`)
+	f.Add(`{"boolval": true}`)
+	f.Add(`{"val": null}`)
+	f.Add(`{"val": "2023-10-10T21:16:45Z"}`)
+	f.Add(`{"val": "2023-10-10T21:16:45-06:00"}`)
+	f.Add(`{"nested": {"object": "value"}}`)
+
+	f.Fuzz(func(t *testing.T, input string) {
+		// Decode input string as a valid object
+		var obj map[string]any
+		if err := stdjson.Unmarshal([]byte(input), &obj); err != nil {
+			t.SkipNow()
+		}
+
+		// Decompose object into separate lists of names and values
+		var names []string
+		var vals []any
+		for name, val := range obj {
+			names = append(names, name)
+			vals = append(vals, val)
+		}
+
+		// Check equivalence of standard JSON serialization and optimized serialization
+		checkEquivalence(t, names, vals)
+	})
+}
+
+func checkEquivalence(t *testing.T, names []string, values []any) {
+	var fields = make(map[string]any)
+	for idx, val := range values {
+		fields[names[idx]] = val
+	}
+	standardBytes, err := stdjson.Marshal(fields)
+	require.NoError(t, err)
+
+	var shape = NewShape(names)
+	shapeBytes, err := shape.Encode(values)
+	require.NoError(t, err)
+
+	require.Equal(t, string(standardBytes), string(shapeBytes))
+}
+
+func benchmarkDataset(size int) ([]string, [][]any) {
+	var names = []string{"id", "type", "ctime", "mtime", "name", "description", "sequenceNumber", "state", "version", "intParamA", "intParamB", "intParamC", "intParamD"}
+	var values [][]any
+	for i := 0; i < size; i++ {
+		var row = []any{
+			uuid.New().String(),
+			[]string{"event", "action", "item", "unknown"}[rand.Intn(4)],
+			time.Now().Add(-time.Duration(rand.Intn(10000000)+50000000) * time.Second),
+			time.Now().Add(-time.Duration(rand.Intn(10000000)+10000000) * time.Second),
+			fmt.Sprintf("Row Number %d", i),
+			fmt.Sprintf("An object representing some row in a synthetic dataset. This one is row number %d.", i),
+			i,
+			[]string{"new", "in-progress", "completed"}[rand.Intn(3)],
+			rand.Intn(3),
+			rand.Intn(1000000000),
+			rand.Intn(1000000000),
+			rand.Intn(1000000000),
+			rand.Intn(1000000000),
+		}
+		values = append(values, row)
+	}
+	return names, values
+}

--- a/source-mysql-batch/driver.go
+++ b/source-mysql-batch/driver.go
@@ -556,6 +556,7 @@ func (c *capture) poll(ctx context.Context, bindingIndex int, tmpl *template.Tem
 	var shape *encrow.Shape
 	var cursorIndices []int
 	var rowValues []any
+	var serializedDocument []byte
 
 	if err := stmt.ExecuteSelectStreaming(&result, func(row []mysql.FieldValue) error {
 		if shape == nil {
@@ -593,10 +594,10 @@ func (c *capture) poll(ctx context.Context, bindingIndex int, tmpl *template.Tem
 			rowValues[idx+1] = translatedValue
 		}
 
-		var bs, err = shape.Encode(rowValues)
+		serializedDocument, err = shape.Encode(serializedDocument, rowValues)
 		if err != nil {
 			return fmt.Errorf("error serializing document: %w", err)
-		} else if err := c.Output.Documents(bindingIndex, bs); err != nil {
+		} else if err := c.Output.Documents(bindingIndex, serializedDocument); err != nil {
 			return fmt.Errorf("error emitting document: %w", err)
 		} else if err := c.Output.Checkpoint(json.RawMessage(`{}`), true); err != nil {
 			return fmt.Errorf("error emitting checkpoint: %w", err)


### PR DESCRIPTION
**Description:**

This adds a new helper package `./go/encrow` for serializing tabular data such as we get from SQL queries, and modifies `source-mysql-batch` to use this new package.

The helper package is more efficient than using the standard library `encoding/json` to serialize a `map[string]any` for two reasons:

1. The top level of document serialization is specialized to only work on objects with a specific arity and list of property names. This is represented with a new `encrow.Shape` abstraction.
2. Serializing the individual values of each document is done with the github.com/segmentio/encoding/json package, which is a micro-optimized JSON encoder/decoder package intended as a faster drop-in replacement for the stdlib one.

The specialization alone resulted in about a 3x speedup even while still using the stdlib encoder for each field value. Adding the segmentio JSON encoder provided another 2x speedup on top of that.

Benchmark results for demonstration (measuring single core performance on my laptop):

    $ GOMAXPROCS=1 go test -v ./go/encrow/ -bench=. -benchtime=30s -count=3
    cpu: 11th Gen Intel(R) Core(TM) i7-1185G7 @ 3.00GHz
    BenchmarkStandardSerialization
    BenchmarkStandardSerialization      4982           7267985 ns/op
    BenchmarkStandardSerialization      4867           7644533 ns/op
    BenchmarkStandardSerialization      4099           8395409 ns/op
    BenchmarkShapeSerialization
    BenchmarkShapeSerialization        26900           1334689 ns/op
    BenchmarkShapeSerialization        26907           1337353 ns/op
    BenchmarkShapeSerialization        27273           1327145 ns/op

I have written a normal test and a fuzz test which attempt to verify that for every possible object mapping keys to values, the output of the new encoder exactly matches the standard library encoder. This turned up one bug (now fixed) in how an object with zero properties was serialized, and other than that I have seen no failures after a decently large amount of fuzzing.

So as far as I can tell this ought to be a pretty straightforward improvement to throughput. Currently just for `source-mysql-batch` but this same package can be used for all our SQL captures in the future.

**Workflow steps:**

Nothing changes, `source-mysql-batch` captures run up to 6x faster.

**Notes for reviewers:**

I'm not 100% settled on this design, but I was just playing around with approaches to optimizing our JSON serialization of result rows and this seems to work pretty well, as demonstrated in the benchmark results included up above.

It would be even simpler (literally a one-line code change) to just drop in the segmentio JSON encoder instead of the standard library one but skip all the "shape optimization" stuff, however the custom code I wrote for specializing the object shape really does provide a noticeable improvement (about 2x) even on top of that.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1005)
<!-- Reviewable:end -->
