### PR TITLE
source-mongodb: run tests in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -66,7 +66,7 @@ jobs:
 
   build_connectors:
     runs-on: ubuntu-20.04
-    needs: build_base_image
+    # needs: build_base_image
     strategy:
       fail-fast: false
       matrix:
@@ -160,11 +160,17 @@ jobs:
             "source-mysql",
             "source-postgres",
             "source-sftp",
-            "source-sqlserver"
+            "source-sqlserver",
+            "source-mongodb"
             ]'), matrix.connector)
         run: |
           docker compose --file ${{ matrix.connector }}/docker-compose.yaml up --wait
           docker logs ${{ matrix.connector }}-db-1
+
+      - name: Test setup
+        if: matrix.connector == 'source-mongodb'
+        run: |
+          bash source-mongodb/docker-compose-init.sh
 
       - name: Build ${{ matrix.connector }} Docker Image
         uses: docker/build-push-action@v2

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -66,7 +66,7 @@ jobs:
 
   build_connectors:
     runs-on: ubuntu-20.04
-    # needs: build_base_image
+    needs: build_base_image
     strategy:
       fail-fast: false
       matrix:

--- a/source-mongodb/.snapshots/TestCapture
+++ b/source-mongodb/.snapshots/TestCapture
@@ -46,5 +46,5 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"resources":{"test.collectionOne":{"backfill":{"done":true,"last_id":{"Type":2,"Value":"CQAAAHBrIHZhbCA0AA=="},"started_at:"<TIMESTAMP>"}},"test.collectionThree":{"backfill":{"done":true,"last_id":{"Type":5,"Value":"CAAAAABwayB2YWwgNA=="},"started_at:"<TIMESTAMP>"}},"test.collectionTwo":{"backfill":{"done":true,"last_id":{"Type":16,"Value":"BAAAAA=="},"started_at:"<TIMESTAMP>"}}},"stream_resume_token":"<STREAM_RESUME_TOKEN>"}
+{"resources":{"test.collectionOne":{"backfill":{"done":true,"last_id":{"Type":2,"Value":"CQAAAHBrIHZhbCA0AA=="},"started_at":"<TIMESTAMP>"}},"test.collectionThree":{"backfill":{"done":true,"last_id":{"Type":5,"Value":"CAAAAABwayB2YWwgNA=="},"started_at":"<TIMESTAMP>"}},"test.collectionTwo":{"backfill":{"done":true,"last_id":{"Type":16,"Value":"BAAAAA=="},"started_at":"<TIMESTAMP>"}}},"stream_resume_token":"<STREAM_RESUME_TOKEN>"}
 

--- a/source-mongodb/.snapshots/TestCapture
+++ b/source-mongodb/.snapshots/TestCapture
@@ -1,48 +1,48 @@
 # ================================
 # Collection "acmeCo/test/collectionOne": 12 Documents
 # ================================
-{"_id":"pk val 0","_meta":{"op":"c"},"onlyColumn":"onlyColumn val 0"}
+{"_id":"pk val 0","_meta":{"op":"c"},"onlyColumn":{"array":["a","b","c"],"float":1.23,"int":1,"str":"onlyColumn val 0"}}
 {"_id":"pk val 0","_meta":{"op":"d"}}
-{"_id":"pk val 1","_meta":{"op":"c"},"onlyColumn":"onlyColumn val 1"}
-{"_id":"pk val 1","_meta":{"op":"u"},"onlyColumn":"onlyColumn val 1","onlyColumn_new":"onlyColumn_new val 0"}
-{"_id":"pk val 2","_meta":{"op":"c"},"onlyColumn":"onlyColumn val 2"}
-{"_id":"pk val 3","_meta":{"op":"c"},"onlyColumn":"onlyColumn val 3"}
-{"_id":"pk val 4","_meta":{"op":"c"},"onlyColumn":"onlyColumn val 4"}
-{"_id":"pk val 5","_meta":{"op":"c"},"onlyColumn":"onlyColumn val 5"}
-{"_id":"pk val 6","_meta":{"op":"c"},"onlyColumn":"onlyColumn val 6"}
-{"_id":"pk val 7","_meta":{"op":"c"},"onlyColumn":"onlyColumn val 7"}
-{"_id":"pk val 8","_meta":{"op":"c"},"onlyColumn":"onlyColumn val 8"}
-{"_id":"pk val 9","_meta":{"op":"c"},"onlyColumn":"onlyColumn val 9"}
+{"_id":"pk val 1","_meta":{"op":"c"},"onlyColumn":{"array":["a","b","c"],"float":1.23,"int":1,"str":"onlyColumn val 1"}}
+{"_id":"pk val 1","_meta":{"op":"u"},"onlyColumn":{"array":["a","b","c"],"float":1.23,"int":1,"str":"onlyColumn val 1"},"onlyColumn_new":"onlyColumn_new val 0"}
+{"_id":"pk val 2","_meta":{"op":"c"},"onlyColumn":{"array":["a","b","c"],"float":1.23,"int":1,"str":"onlyColumn val 2"}}
+{"_id":"pk val 3","_meta":{"op":"c"},"onlyColumn":{"array":["a","b","c"],"float":1.23,"int":1,"str":"onlyColumn val 3"}}
+{"_id":"pk val 4","_meta":{"op":"c"},"onlyColumn":{"array":["a","b","c"],"float":1.23,"int":1,"str":"onlyColumn val 4"}}
+{"_id":"pk val 5","_meta":{"op":"c"},"onlyColumn":{"array":["a","b","c"],"float":1.23,"int":1,"str":"onlyColumn val 5"}}
+{"_id":"pk val 6","_meta":{"op":"c"},"onlyColumn":{"array":["a","b","c"],"float":1.23,"int":1,"str":"onlyColumn val 6"}}
+{"_id":"pk val 7","_meta":{"op":"c"},"onlyColumn":{"array":["a","b","c"],"float":1.23,"int":1,"str":"onlyColumn val 7"}}
+{"_id":"pk val 8","_meta":{"op":"c"},"onlyColumn":{"array":["a","b","c"],"float":1.23,"int":1,"str":"onlyColumn val 8"}}
+{"_id":"pk val 9","_meta":{"op":"c"},"onlyColumn":{"array":["a","b","c"],"float":1.23,"int":1,"str":"onlyColumn val 9"}}
 # ================================
 # Collection "acmeCo/test/collectionThree": 12 Documents
 # ================================
-{"_id":"{\"Subtype\":0,\"Data\":\"cGsgdmFsIDA=\"}","_meta":{"op":"c"},"firstColumn":"firstColumn val 0","secondColumn":"secondColumn val 0","thirdColumn":"thirdColumn val 0"}
+{"_id":"{\"Subtype\":0,\"Data\":\"cGsgdmFsIDA=\"}","_meta":{"op":"c"},"firstColumn":{"array":["a","b","c"],"float":1.23,"int":1,"str":"firstColumn val 0"},"secondColumn":{"array":["a","b","c"],"float":1.23,"int":1,"str":"secondColumn val 0"},"thirdColumn":{"array":["a","b","c"],"float":1.23,"int":1,"str":"thirdColumn val 0"}}
 {"_id":"{\"Subtype\":0,\"Data\":\"cGsgdmFsIDA=\"}","_meta":{"op":"d"}}
-{"_id":"{\"Subtype\":0,\"Data\":\"cGsgdmFsIDE=\"}","_meta":{"op":"c"},"firstColumn":"firstColumn val 1","secondColumn":"secondColumn val 1","thirdColumn":"thirdColumn val 1"}
-{"_id":"{\"Subtype\":0,\"Data\":\"cGsgdmFsIDE=\"}","_meta":{"op":"u"},"firstColumn":"firstColumn val 1","forthColumn_new":"forthColumn_new val 0","secondColumn":"secondColumn val 1","thirdColumn":"thirdColumn val 1"}
-{"_id":"{\"Subtype\":0,\"Data\":\"cGsgdmFsIDI=\"}","_meta":{"op":"c"},"firstColumn":"firstColumn val 2","secondColumn":"secondColumn val 2","thirdColumn":"thirdColumn val 2"}
-{"_id":"{\"Subtype\":0,\"Data\":\"cGsgdmFsIDM=\"}","_meta":{"op":"c"},"firstColumn":"firstColumn val 3","secondColumn":"secondColumn val 3","thirdColumn":"thirdColumn val 3"}
-{"_id":"{\"Subtype\":0,\"Data\":\"cGsgdmFsIDQ=\"}","_meta":{"op":"c"},"firstColumn":"firstColumn val 4","secondColumn":"secondColumn val 4","thirdColumn":"thirdColumn val 4"}
-{"_id":"{\"Subtype\":0,\"Data\":\"cGsgdmFsIDU=\"}","_meta":{"op":"c"},"firstColumn":"firstColumn val 5","secondColumn":"secondColumn val 5","thirdColumn":"thirdColumn val 5"}
-{"_id":"{\"Subtype\":0,\"Data\":\"cGsgdmFsIDY=\"}","_meta":{"op":"c"},"firstColumn":"firstColumn val 6","secondColumn":"secondColumn val 6","thirdColumn":"thirdColumn val 6"}
-{"_id":"{\"Subtype\":0,\"Data\":\"cGsgdmFsIDc=\"}","_meta":{"op":"c"},"firstColumn":"firstColumn val 7","secondColumn":"secondColumn val 7","thirdColumn":"thirdColumn val 7"}
-{"_id":"{\"Subtype\":0,\"Data\":\"cGsgdmFsIDg=\"}","_meta":{"op":"c"},"firstColumn":"firstColumn val 8","secondColumn":"secondColumn val 8","thirdColumn":"thirdColumn val 8"}
-{"_id":"{\"Subtype\":0,\"Data\":\"cGsgdmFsIDk=\"}","_meta":{"op":"c"},"firstColumn":"firstColumn val 9","secondColumn":"secondColumn val 9","thirdColumn":"thirdColumn val 9"}
+{"_id":"{\"Subtype\":0,\"Data\":\"cGsgdmFsIDE=\"}","_meta":{"op":"c"},"firstColumn":{"array":["a","b","c"],"float":1.23,"int":1,"str":"firstColumn val 1"},"secondColumn":{"array":["a","b","c"],"float":1.23,"int":1,"str":"secondColumn val 1"},"thirdColumn":{"array":["a","b","c"],"float":1.23,"int":1,"str":"thirdColumn val 1"}}
+{"_id":"{\"Subtype\":0,\"Data\":\"cGsgdmFsIDE=\"}","_meta":{"op":"u"},"firstColumn":{"array":["a","b","c"],"float":1.23,"int":1,"str":"firstColumn val 1"},"forthColumn_new":"forthColumn_new val 0","secondColumn":{"array":["a","b","c"],"float":1.23,"int":1,"str":"secondColumn val 1"},"thirdColumn":{"array":["a","b","c"],"float":1.23,"int":1,"str":"thirdColumn val 1"}}
+{"_id":"{\"Subtype\":0,\"Data\":\"cGsgdmFsIDI=\"}","_meta":{"op":"c"},"firstColumn":{"array":["a","b","c"],"float":1.23,"int":1,"str":"firstColumn val 2"},"secondColumn":{"array":["a","b","c"],"float":1.23,"int":1,"str":"secondColumn val 2"},"thirdColumn":{"array":["a","b","c"],"float":1.23,"int":1,"str":"thirdColumn val 2"}}
+{"_id":"{\"Subtype\":0,\"Data\":\"cGsgdmFsIDM=\"}","_meta":{"op":"c"},"firstColumn":{"array":["a","b","c"],"float":1.23,"int":1,"str":"firstColumn val 3"},"secondColumn":{"array":["a","b","c"],"float":1.23,"int":1,"str":"secondColumn val 3"},"thirdColumn":{"array":["a","b","c"],"float":1.23,"int":1,"str":"thirdColumn val 3"}}
+{"_id":"{\"Subtype\":0,\"Data\":\"cGsgdmFsIDQ=\"}","_meta":{"op":"c"},"firstColumn":{"array":["a","b","c"],"float":1.23,"int":1,"str":"firstColumn val 4"},"secondColumn":{"array":["a","b","c"],"float":1.23,"int":1,"str":"secondColumn val 4"},"thirdColumn":{"array":["a","b","c"],"float":1.23,"int":1,"str":"thirdColumn val 4"}}
+{"_id":"{\"Subtype\":0,\"Data\":\"cGsgdmFsIDU=\"}","_meta":{"op":"c"},"firstColumn":{"array":["a","b","c"],"float":1.23,"int":1,"str":"firstColumn val 5"},"secondColumn":{"array":["a","b","c"],"float":1.23,"int":1,"str":"secondColumn val 5"},"thirdColumn":{"array":["a","b","c"],"float":1.23,"int":1,"str":"thirdColumn val 5"}}
+{"_id":"{\"Subtype\":0,\"Data\":\"cGsgdmFsIDY=\"}","_meta":{"op":"c"},"firstColumn":{"array":["a","b","c"],"float":1.23,"int":1,"str":"firstColumn val 6"},"secondColumn":{"array":["a","b","c"],"float":1.23,"int":1,"str":"secondColumn val 6"},"thirdColumn":{"array":["a","b","c"],"float":1.23,"int":1,"str":"thirdColumn val 6"}}
+{"_id":"{\"Subtype\":0,\"Data\":\"cGsgdmFsIDc=\"}","_meta":{"op":"c"},"firstColumn":{"array":["a","b","c"],"float":1.23,"int":1,"str":"firstColumn val 7"},"secondColumn":{"array":["a","b","c"],"float":1.23,"int":1,"str":"secondColumn val 7"},"thirdColumn":{"array":["a","b","c"],"float":1.23,"int":1,"str":"thirdColumn val 7"}}
+{"_id":"{\"Subtype\":0,\"Data\":\"cGsgdmFsIDg=\"}","_meta":{"op":"c"},"firstColumn":{"array":["a","b","c"],"float":1.23,"int":1,"str":"firstColumn val 8"},"secondColumn":{"array":["a","b","c"],"float":1.23,"int":1,"str":"secondColumn val 8"},"thirdColumn":{"array":["a","b","c"],"float":1.23,"int":1,"str":"thirdColumn val 8"}}
+{"_id":"{\"Subtype\":0,\"Data\":\"cGsgdmFsIDk=\"}","_meta":{"op":"c"},"firstColumn":{"array":["a","b","c"],"float":1.23,"int":1,"str":"firstColumn val 9"},"secondColumn":{"array":["a","b","c"],"float":1.23,"int":1,"str":"secondColumn val 9"},"thirdColumn":{"array":["a","b","c"],"float":1.23,"int":1,"str":"thirdColumn val 9"}}
 # ================================
 # Collection "acmeCo/test/collectionTwo": 12 Documents
 # ================================
-{"_id":"0","_meta":{"op":"c"},"firstColumn":"firstColumn val 0","secondColumn":"secondColumn val 0"}
+{"_id":"0","_meta":{"op":"c"},"firstColumn":{"array":["a","b","c"],"float":1.23,"int":1,"str":"firstColumn val 0"},"secondColumn":{"array":["a","b","c"],"float":1.23,"int":1,"str":"secondColumn val 0"}}
 {"_id":"0","_meta":{"op":"d"}}
-{"_id":"1.5","_meta":{"op":"c"},"firstColumn":"firstColumn val 1","secondColumn":"secondColumn val 1"}
-{"_id":"1.5","_meta":{"op":"u"},"firstColumn":"firstColumn val 1","secondColumn":"secondColumn val 1","thirdColumn_new":"thirdColumn_new val 0"}
-{"_id":"2","_meta":{"op":"c"},"firstColumn":"firstColumn val 2","secondColumn":"secondColumn val 2"}
-{"_id":"3.5","_meta":{"op":"c"},"firstColumn":"firstColumn val 3","secondColumn":"secondColumn val 3"}
-{"_id":"4","_meta":{"op":"c"},"firstColumn":"firstColumn val 4","secondColumn":"secondColumn val 4"}
-{"_id":"5.5","_meta":{"op":"c"},"firstColumn":"firstColumn val 5","secondColumn":"secondColumn val 5"}
-{"_id":"6","_meta":{"op":"c"},"firstColumn":"firstColumn val 6","secondColumn":"secondColumn val 6"}
-{"_id":"7.5","_meta":{"op":"c"},"firstColumn":"firstColumn val 7","secondColumn":"secondColumn val 7"}
-{"_id":"8","_meta":{"op":"c"},"firstColumn":"firstColumn val 8","secondColumn":"secondColumn val 8"}
-{"_id":"9.5","_meta":{"op":"c"},"firstColumn":"firstColumn val 9","secondColumn":"secondColumn val 9"}
+{"_id":"1.5","_meta":{"op":"c"},"firstColumn":{"array":["a","b","c"],"float":1.23,"int":1,"str":"firstColumn val 1"},"secondColumn":{"array":["a","b","c"],"float":1.23,"int":1,"str":"secondColumn val 1"}}
+{"_id":"1.5","_meta":{"op":"u"},"firstColumn":{"array":["a","b","c"],"float":1.23,"int":1,"str":"firstColumn val 1"},"secondColumn":{"array":["a","b","c"],"float":1.23,"int":1,"str":"secondColumn val 1"},"thirdColumn_new":"thirdColumn_new val 0"}
+{"_id":"2","_meta":{"op":"c"},"firstColumn":{"array":["a","b","c"],"float":1.23,"int":1,"str":"firstColumn val 2"},"secondColumn":{"array":["a","b","c"],"float":1.23,"int":1,"str":"secondColumn val 2"}}
+{"_id":"3.5","_meta":{"op":"c"},"firstColumn":{"array":["a","b","c"],"float":1.23,"int":1,"str":"firstColumn val 3"},"secondColumn":{"array":["a","b","c"],"float":1.23,"int":1,"str":"secondColumn val 3"}}
+{"_id":"4","_meta":{"op":"c"},"firstColumn":{"array":["a","b","c"],"float":1.23,"int":1,"str":"firstColumn val 4"},"secondColumn":{"array":["a","b","c"],"float":1.23,"int":1,"str":"secondColumn val 4"}}
+{"_id":"5.5","_meta":{"op":"c"},"firstColumn":{"array":["a","b","c"],"float":1.23,"int":1,"str":"firstColumn val 5"},"secondColumn":{"array":["a","b","c"],"float":1.23,"int":1,"str":"secondColumn val 5"}}
+{"_id":"6","_meta":{"op":"c"},"firstColumn":{"array":["a","b","c"],"float":1.23,"int":1,"str":"firstColumn val 6"},"secondColumn":{"array":["a","b","c"],"float":1.23,"int":1,"str":"secondColumn val 6"}}
+{"_id":"7.5","_meta":{"op":"c"},"firstColumn":{"array":["a","b","c"],"float":1.23,"int":1,"str":"firstColumn val 7"},"secondColumn":{"array":["a","b","c"],"float":1.23,"int":1,"str":"secondColumn val 7"}}
+{"_id":"8","_meta":{"op":"c"},"firstColumn":{"array":["a","b","c"],"float":1.23,"int":1,"str":"firstColumn val 8"},"secondColumn":{"array":["a","b","c"],"float":1.23,"int":1,"str":"secondColumn val 8"}}
+{"_id":"9.5","_meta":{"op":"c"},"firstColumn":{"array":["a","b","c"],"float":1.23,"int":1,"str":"firstColumn val 9"},"secondColumn":{"array":["a","b","c"],"float":1.23,"int":1,"str":"secondColumn val 9"}}
 # ================================
 # Final State Checkpoint
 # ================================

--- a/source-mongodb/Dockerfile
+++ b/source-mongodb/Dockerfile
@@ -14,6 +14,8 @@ COPY source-boilerplate ./source-boilerplate
 COPY source-mongodb     ./source-mongodb
 
 # Run the unit tests.
+ARG TEST_DATABASE=yes
+ENV TEST_DATABASE=$TEST_DATABASE
 RUN go test -v ./source-mongodb/...
 
 # Build the connector.

--- a/source-mongodb/docker-compose-init.sh
+++ b/source-mongodb/docker-compose-init.sh
@@ -1,8 +1,7 @@
 function mongosh() {
-	echo "$@" | docker exec -i source-mongodb-mongo-1 mongosh -u flow -p flow
+	echo "$@" | docker exec -i source-mongodb-db-1 mongosh -u flow -p flow admin
 }
 
 mongosh 'rs.initiate()'
-mongosh 'db.createUser({"user": "flow", "pwd": "flow", "roles": ["readAnyDatabase", "readWrite"]})'
 sleep 3
 mongosh 'cfg = rs.conf(); cfg.members[0].host="localhost:27017"; rs.reconfig(cfg);'

--- a/source-mongodb/docker-compose.yaml
+++ b/source-mongodb/docker-compose.yaml
@@ -1,16 +1,23 @@
 version: "3.7"
 
 services:
-  mongo:
+  db:
     image: 'mongo:latest'
     environment: {"MONGO_INITDB_ROOT_USERNAME": "flow", "MONGO_INITDB_ROOT_PASSWORD": "flow"}
-    command: ["--replSet", "rs0", "--keyFile", "/etc/ssl/sample.key"]
+    command: "mongod --bind_ip_all --replSet rs0 --keyFile /etc/ssl/sample.key"
+    entrypoint: ["bash", "-c", "chmod 400 /etc/ssl/sample.key; chown 999:999 /etc/ssl/sample.key; exec docker-entrypoint.sh $@"]
     ports:
       - "27017:27017"
     networks:
       - flow-test
     volumes:
       - ${PWD}/source-mongodb/sample.key:/etc/ssl/sample.key
+    healthcheck:
+      test: ["CMD","mongosh", "--eval", "db.adminCommand('ping')"]
+      interval: 5s
+      timeout: 5s
+      retries: 3
+      start_period: 5s
 
 networks:
   flow-test:

--- a/source-mongodb/main.go
+++ b/source-mongodb/main.go
@@ -48,6 +48,17 @@ type config struct {
 	User     string `json:"user" jsonschema:"title=User,description=Database user to connect as." jsonschema_extras:"order=1"`
 	Password string `json:"password" jsonschema:"title=Password,description=Password for the specified database user." jsonschema_extras:"secret=true,order=2"`
 	Database string `json:"database" jsonschema:"title=Database,description=Name of the database to capture from." jsonschema_extras:"order=3"`
+
+	// We still don't have any exposed advanced configurations
+	Advanced advancedConfig `json:"advanced" jsonschema:"-"`
+}
+
+type advancedConfig struct {
+	// The default value of -5m is useful for production use cases, but when
+	// running our test suite we don't want to wait 5 minutes, so we use this
+	// configuration in our test suite to disable oplog safety buffer. Note that
+	// this is not exposed to users using the `jsonschema:"-"` stanza.
+	OplogSafetyBuffer string `json:"oplogSafetyBuffer" jsonschema:"-"`
 }
 
 func (c *config) Validate() error {

--- a/source-mongodb/main_test.go
+++ b/source-mongodb/main_test.go
@@ -109,7 +109,7 @@ func commonSanitizers() map[string]*regexp.Regexp {
 		sanitizers[k] = v
 	}
 	sanitizers[`"stream_resume_token":"<STREAM_RESUME_TOKEN>"`] = regexp.MustCompile(`"stream_resume_token":"[^"]*"`)
-	sanitizers[`"started_at:"<TIMESTAMP>"`] = regexp.MustCompile(`"started_at":"((?:(\d{4}-\d{2}-\d{2})T(\d{2}:\d{2}:\d{2}(?:\.\d+)?))(Z|[\+-]\d{2}:\d{2})?)"`)
+	sanitizers[`"started_at":"<TIMESTAMP>"`] = regexp.MustCompile(`"started_at":"((?:(\d{4}-\d{2}-\d{2})T(\d{2}:\d{2}:\d{2}(?:\.\d+)?))(Z|[\+-]\d{2}:\d{2})?)"`)
 
 	return sanitizers
 }

--- a/source-mongodb/test_util.go
+++ b/source-mongodb/test_util.go
@@ -33,6 +33,9 @@ func testClient(t *testing.T) (*mongo.Client, config) {
 		User: *user,
 		Password: *password,
 		Database: *database,
+		Advanced: advancedConfig{
+			OplogSafetyBuffer: "0",
+		},
 	}
 
 	var d = driver{}

--- a/source-mongodb/test_util.go
+++ b/source-mongodb/test_util.go
@@ -13,7 +13,7 @@ import (
 )
 
 var (
-	address   = flag.String("address", "mongodb://localhost", "MongoDB instance address")
+	address   = flag.String("address", "mongodb://localhost?authSource=admin", "MongoDB instance address")
 	user      = flag.String("user", "flow", "Username")
 	password  = flag.String("password", "flow", "Password")
 	database  = flag.String("database", "test", "Database name")
@@ -71,7 +71,12 @@ func addTestTableData(
 		item["_id"] = pkData(idx)
 
 		for _, col := range cols {
-			item[col] = fmt.Sprintf("%s val %d", col, idx)
+			item[col] = map[string]interface{}{
+				"str": fmt.Sprintf("%s val %d", col, idx),
+				"array": []string{"a", "b", "c"},
+				"int": 1,
+				"float": 1.23,
+			}
 		}
 
 		log.WithField("data", item).WithField("col", collection).Info("inserting data")


### PR DESCRIPTION
**Description:**

- Some changes to run the MongoDB integration tests in the CI, this requires us to have a way to disable the `oplogSafetyBuffer` check since we don't want to wait 5 minutes.
- Updated the data we use as fixtures in our tests to include objects, arrays, integers, floats and strings. This would help us spot an issue like the encoding bug we recently faced.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1007)
<!-- Reviewable:end -->
