### PR TITLE
ci: pin flow version until parser changes get greenlight

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -125,7 +125,7 @@ jobs:
 
       - name: Download latest Flow release binaries and add them to $PATH
         run: |
-          ./fetch-flow.sh
+          FLOW_RELEASE=v0.3.7 ./fetch-flow.sh
           echo "${PWD}/flow-bin" >> $GITHUB_PATH
 
       - name: Set up Cloud SDK


### PR DESCRIPTION
**Description:**

- The recently merged parser changes https://github.com/estuary/flow/pull/1201 have the potential of being backward-incompatible. We are working on finding a path for releasing this change, until then we should refrain from releasing these changes. This pull-request pins the version of flow used in our CI to avoid using the latest `dev` version.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1008)
<!-- Reviewable:end -->
