### PR TITLE
materialize-sql: Use github.com/segmentio/encoding/json for encoding

### DIFF
--- a/materialize-sql/encoder.go
+++ b/materialize-sql/encoder.go
@@ -3,9 +3,10 @@ package sql
 import (
 	"compress/flate"
 	"compress/gzip"
-	"encoding/json"
 	"fmt"
 	"io"
+
+	"github.com/segmentio/encoding/json"
 )
 
 const (


### PR DESCRIPTION
**Description:**

The `stagedFile` abstraction used for BigQuery/Snowflake/Redshift materializations uses a `*sql.CountingEncoder` which in turn uses a `json.Encoder` to serialize row contents.

The standard library `encoding/json` package is fairly slow, and the `github.com/segmentio/encoding/json` package is a drop-in replacement which performs 2-3x better in most benchmarks, so swapping out the package used in `materialize-sql/encoder.go` should theoretically give us a noticeable throughput improvement for basically no actual effort.

**Notes for reviewers:**

This change is completely untested, but should be quite safe provided that it builds and passes CI in the first place. I don't have any hard numbers on how much of a bottleneck JSON serialization represents for these materializations, but it's probably not trivial and we have some long-running ones where it should be pretty blatantly obvious if this helps.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1010)
<!-- Reviewable:end -->
