### PR TITLE
materialize-bigquery: set user-agent header

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -172,7 +172,10 @@ jobs:
           context: .
           file: ${{ matrix.connector }}/Dockerfile
           load: true
-          build-args: BASE_IMAGE=ghcr.io/estuary/base-image:${{ steps.prep.outputs.tag }}
+          build-args: |
+            BASE_IMAGE=ghcr.io/estuary/base-image:${{ steps.prep.outputs.tag }}
+            VERSION=${{ steps.prep.outputs.version }}
+            TAG=${{ steps.prep.outputs.tag }}
           tags: ghcr.io/estuary/${{ matrix.connector }}:local
           secrets: |
             "rockset_api_key=${{ secrets.ROCKSET_API_KEY }}"

--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,6 @@ require (
 	github.com/evanphx/json-patch/v5 v5.6.0
 	github.com/go-mysql-org/go-mysql v1.5.0
 	github.com/go-sql-driver/mysql v1.6.0
-	github.com/goccy/go-json v0.10.0
 	github.com/gogo/protobuf v1.3.2
 	github.com/google/uuid v1.3.0
 	github.com/iancoleman/orderedmap v0.2.0
@@ -43,6 +42,7 @@ require (
 	github.com/pingcap/errors v0.11.5-0.20201126102027-b0a155152ca3
 	github.com/pkg/sftp v1.13.5
 	github.com/rockset/rockset-go-client v0.15.4
+	github.com/segmentio/encoding v0.3.6
 	github.com/siddontang/go-log v0.0.0-20190221022429-1e957dd83bed
 	github.com/sirupsen/logrus v1.9.0
 	github.com/snowflakedb/gosnowflake v1.6.24
@@ -112,6 +112,7 @@ require (
 	github.com/elastic/elastic-transport-go/v8 v8.0.0-20230329154755-1a3c63de0db6 // indirect
 	github.com/form3tech-oss/jwt-go v3.2.5+incompatible // indirect
 	github.com/gabriel-vasile/mimetype v1.4.2 // indirect
+	github.com/goccy/go-json v0.10.0 // indirect
 	github.com/godbus/dbus v0.0.0-20190726142602-4481cbc300e2 // indirect
 	github.com/golang-sql/civil v0.0.0-20190719163853-cb61b32ac6fe // indirect
 	github.com/golang-sql/sqlexp v0.1.0 // indirect
@@ -159,7 +160,6 @@ require (
 	github.com/rs/zerolog v1.28.0 // indirect
 	github.com/secure-systems-lab/go-securesystemslib v0.4.0 // indirect
 	github.com/segmentio/asm v1.1.3 // indirect
-	github.com/segmentio/encoding v0.3.6 // indirect
 	github.com/shopspring/decimal v1.3.1 // indirect
 	github.com/siddontang/go v0.0.0-20180604090527-bdc77568d726 // indirect
 	github.com/soheilhy/cmux v0.1.5 // indirect

--- a/materialize-bigquery/Dockerfile
+++ b/materialize-bigquery/Dockerfile
@@ -20,10 +20,16 @@ COPY materialize-bigquery    ./materialize-bigquery
 COPY materialize-sql         ./materialize-sql
 COPY testsupport             ./testsupport
 
+# Build parameters for setting the user-agent.
+ARG VERSION="dev"
+ARG TAG="unknown"
+
 # Test and build the connector.
 RUN go test  -tags nozstd -v ./materialize-sql/...
 RUN go test  -tags nozstd -v ./materialize-bigquery/...
-RUN go build -tags nozstd -v -o ./connector ./materialize-bigquery/cmd/connector
+RUN go build \
+    -ldflags="-X github.com/estuary/connectors/materialize-bigquery.Version=$VERSION -X github.com/estuary/connectors/materialize-bigquery.Tag=$TAG" \
+    -tags nozstd -v -o ./connector ./materialize-bigquery/cmd/connector
 
 # Runtime Stage
 ################################################################################

--- a/materialize-bigquery/bigquery.go
+++ b/materialize-bigquery/bigquery.go
@@ -21,6 +21,11 @@ import (
 	"google.golang.org/api/option"
 )
 
+var (
+	Version string
+	Tag     string
+)
+
 // Config represents the endpoint configuration for BigQuery.
 type config struct {
 	ProjectID        string `json:"project_id" jsonschema:"title=Project ID,description=Google Cloud Project ID that owns the BigQuery dataset." jsonschema_extras:"order=0"`
@@ -73,9 +78,16 @@ func (c *config) Validate() error {
 }
 
 func (c *config) client(ctx context.Context) (*client, error) {
+	userAgent := fmt.Sprintf("Estuary/materialize-bigquery-%s-%s (GPN:Estuary Technologies, Inc.;)", Version, Tag)
+	log.WithField("user-agent", userAgent).Debug("setting user-agent header")
+
 	var clientOpts []option.ClientOption
 
-	clientOpts = append(clientOpts, option.WithCredentialsJSON(decodeCredentials(c.CredentialsJSON)))
+	clientOpts = append(
+		clientOpts,
+		option.WithCredentialsJSON(decodeCredentials(c.CredentialsJSON)),
+		option.WithUserAgent(userAgent),
+	)
 
 	// Allow overriding the main 'project_id' with 'billing_project_id' for client operation billing.
 	var billingProjectID = c.BillingProjectID


### PR DESCRIPTION
**Description:**

Sets the user-agent option for the `materialize-bigquery`client, and plumbs through the information from the build in order to populate that user-agent.

The user-agent will look like this, and is (as best I can tell) compatible with the requirements for the Google Partner program: `"Estuary/materialize-bigquery-v1-b4c0562 (GPN:Estuary Technologies, Inc.;)"`

The version tag and commit SHA are provided as docker build args. For simplicity they are provided to all connectors via our CI configuration, although `materialize-bigquery` is the only one that will use them for now.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

N/A

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1015)
<!-- Reviewable:end -->
