### PR TITLE
Adding Google Cloud SQL variants for mysql, sqlserver and postgres

### DIFF
--- a/materialize-mysql/VARIANTS
+++ b/materialize-mysql/VARIANTS
@@ -1,3 +1,4 @@
 materialize-amazon-aurora-mysql
 materialize-mariadb
 materialize-mysql-heatwave
+materialize-google-cloud-sql-mysql

--- a/materialize-postgres/VARIANTS
+++ b/materialize-postgres/VARIANTS
@@ -1,3 +1,4 @@
 materialize-timescaledb
 materialize-alloydb
 materialize-amazon-aurora-postgres
+materialize-google-cloud-sql-postgres

--- a/materialize-sqlserver/VARIANTS
+++ b/materialize-sqlserver/VARIANTS
@@ -1,1 +1,2 @@
 materialize-google-cloud-sql-mysql
+materialize-azure-sqlserver

--- a/materialize-sqlserver/VARIANTS
+++ b/materialize-sqlserver/VARIANTS
@@ -1,0 +1,1 @@
+materialize-google-cloud-sql-mysql

--- a/materialize-sqlserver/VARIANTS
+++ b/materialize-sqlserver/VARIANTS
@@ -1,2 +1,2 @@
-materialize-google-cloud-sql-mysql
+materialize-google-cloud-sql-sqlserver
 materialize-azure-sqlserver

--- a/source-mysql/VARIANTS
+++ b/source-mysql/VARIANTS
@@ -1,2 +1,3 @@
 source-mariadb
 source-amazon-aurora-mysql
+source-google-cloud-sql-mysql

--- a/source-postgres/VARIANTS
+++ b/source-postgres/VARIANTS
@@ -1,2 +1,3 @@
 source-alloydb
 source-amazon-aurora-postgres
+source-google-cloud-sql-postgres

--- a/source-sqlserver/VARIANTS
+++ b/source-sqlserver/VARIANTS
@@ -1,1 +1,2 @@
 source-azure-sqlserver
+materialize-google-cloud-sql-sqlserver

--- a/source-sqlserver/VARIANTS
+++ b/source-sqlserver/VARIANTS
@@ -1,2 +1,2 @@
 source-azure-sqlserver
-materialize-google-cloud-sql-sqlserver
+source-google-cloud-sql-sqlserver


### PR DESCRIPTION
**Description:**

Adding Google Cloud SQL variants for mysql, sqlserver and postgres

This is required for their new partner program.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1016)
<!-- Reviewable:end -->
