### PR TITLE
materialize-sqlserver: add curl to docker so we can inspect pprof

### DIFF
--- a/materialize-sqlserver/Dockerfile
+++ b/materialize-sqlserver/Dockerfile
@@ -29,6 +29,13 @@ RUN go build -tags nozstd -v -o ./connector ./materialize-sqlserver/...
 ################################################################################
 FROM ${BASE_IMAGE}
 
+RUN apt-get update -y \
+     && apt-get install --no-install-recommends -y \
+     ca-certificates \
+     curl \
+     unzip \
+     && rm -rf /var/lib/apt/lists/*
+
 WORKDIR /connector
 ENV PATH="/connector:$PATH"
 


### PR DESCRIPTION
**Description:**

- need `curl` to check pprof of the connector

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1024)
<!-- Reviewable:end -->
