### PR TITLE
materialize-sqlserver: reset needsMerge after transaction

### DIFF
--- a/materialize-sqlserver/driver.go
+++ b/materialize-sqlserver/driver.go
@@ -641,6 +641,9 @@ func (d *transactor) Store(it *pm.StoreIterator) (_ pm.StartCommitFunc, err erro
 				if _, err = txn.ExecContext(ctx, b.tempStoreTruncate); err != nil {
 					return fmt.Errorf("truncating load table: %w", err)
 				}
+
+				// reset the value for next transaction
+				b.needsMerge = false
 			}
 
 			var err error


### PR DESCRIPTION
**Description:**

- reset `needsMerge` after the transaction over
- tested using integration tests: merging process is still working as expected

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1029)
<!-- Reviewable:end -->
