### PR TITLE
source-mysql-batch: Persist `LastPolled` timestamp

### DIFF
--- a/source-mysql-batch/.snapshots/TestBasicCapture
+++ b/source-mysql-batch/.snapshots/TestBasicCapture
@@ -254,5 +254,5 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"Streams":{"test_basic_capture_826935":{"CursorNames":["id"],"CursorValues":[249]}}}
+{"Streams":{"test_basic_capture_826935":{"CursorNames":["id"],"CursorValues":[249],"LastPolled":"<TIMESTAMP>"}}}
 

--- a/source-mysql-batch/driver.go
+++ b/source-mysql-batch/driver.go
@@ -588,10 +588,16 @@ func (c *capture) poll(ctx context.Context, bindingIndex int, tmpl *template.Tem
 	// Sleep until it's been more than <pollInterval> since the last iteration,
 	// then update the "Last Polled" timestamp.
 	if !state.LastPolled.IsZero() && time.Since(state.LastPolled) < pollInterval {
+		var sleepDuration = time.Until(state.LastPolled.Add(pollInterval))
+		log.WithFields(log.Fields{
+			"name": res.Name,
+			"wait": sleepDuration,
+			"poll": pollInterval,
+		}).Info("waiting for next poll")
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
-		case <-time.After(time.Until(state.LastPolled.Add(pollInterval))):
+		case <-time.After(sleepDuration):
 		}
 	}
 	log.WithField("name", res.Name).Info("ready to poll")


### PR DESCRIPTION
**Description:**

Adds a `LastPolled` property to the per-stream state checkpoints and uses that to implement polling after consistent intervals even across task restarts.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1032)
<!-- Reviewable:end -->
