### PR TITLE
source-mysql: Ignore query events beginning with `--` comments

### DIFF
--- a/source-mysql/replication.go
+++ b/source-mysql/replication.go
@@ -439,7 +439,7 @@ func decodeRow(streamID string, colNames []string, row []interface{}) (map[strin
 // with the binlog Query Events for some statements like GRANT and CREATE USER.
 // TODO(johnny): SET STATEMENT is not safe in the general case, and we want to re-visit
 // by extracting and ignoring a SET STATEMENT stanza prior to parsing.
-var ignoreQueriesRe = regexp.MustCompile(`(?i)^(BEGIN|COMMIT|GRANT|REVOKE|CREATE USER|CREATE DEFINER|DROP USER|ALTER USER|DROP PROCEDURE|DROP TRIGGER|SET STATEMENT|# |/\*)`)
+var ignoreQueriesRe = regexp.MustCompile(`(?i)^(BEGIN|COMMIT|GRANT|REVOKE|CREATE USER|CREATE DEFINER|DROP USER|ALTER USER|DROP PROCEDURE|DROP TRIGGER|SET STATEMENT|# |/\*|-- )`)
 
 func (rs *mysqlReplicationStream) handleQuery(schema, query string) error {
 	// There are basically three types of query events we might receive:


### PR DESCRIPTION
**Description:**

This is absolutely the wrong way to handle comments in general, but it's at least consistent with how we're mishandling other comment styles at the moment and will unblock a current production capture that's hitting this issue.

In the longer term we should either:

1. Implement proper comment-stripping logic prior to the whole "should we ignore this query" regexp.
2. Convert query parse failures into a warn-and-ignore rather than the current fatal error, and possibly remove the whole "ignore some benign queries via regexp" thing entirely.

The rationale for (2) here is that being strict about parse failures has never, to my knowledge, actually caught a real issue -- the handful of DDL queries which we actually want to produce task failures are also the ones which reliably parse correctly, so this extra strictness is just a source of occasional issues in production.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1033)
<!-- Reviewable:end -->
