### PR TITLE
source-mysql-batch: Less collision prone numbered placeholders

### DIFF
--- a/source-mysql-batch/.snapshots/TestQueryTemplate-SubsequentOneCursor
+++ b/source-mysql-batch/.snapshots/TestQueryTemplate-SubsequentOneCursor
@@ -1,1 +1,1 @@
-SELECT * FROM `test`.`foobar` WHERE (`ka` > :0) ORDER BY `ka`;
+SELECT * FROM `test`.`foobar` WHERE (`ka` > @flow_cursor_value[0]) ORDER BY `ka`;

--- a/source-mysql-batch/.snapshots/TestQueryTemplate-SubsequentThreeCursor
+++ b/source-mysql-batch/.snapshots/TestQueryTemplate-SubsequentThreeCursor
@@ -1,1 +1,1 @@
-SELECT * FROM `test`.`foobar` WHERE (`ka` > :0) OR (`ka` = :0 AND `kb` > :1) OR (`ka` = :0 AND `kb` = :1 AND `kc` > :2) ORDER BY `ka`, `kb`, `kc`;
+SELECT * FROM `test`.`foobar` WHERE (`ka` > @flow_cursor_value[0]) OR (`ka` = @flow_cursor_value[0] AND `kb` > @flow_cursor_value[1]) OR (`ka` = @flow_cursor_value[0] AND `kb` = @flow_cursor_value[1] AND `kc` > @flow_cursor_value[2]) ORDER BY `ka`, `kb`, `kc`;

--- a/source-mysql-batch/.snapshots/TestQueryTemplate-SubsequentTwoCursor
+++ b/source-mysql-batch/.snapshots/TestQueryTemplate-SubsequentTwoCursor
@@ -1,1 +1,1 @@
-SELECT * FROM `test`.`foobar` WHERE (`ka` > :0) OR (`ka` = :0 AND `kb` > :1) ORDER BY `ka`, `kb`;
+SELECT * FROM `test`.`foobar` WHERE (`ka` > @flow_cursor_value[0]) OR (`ka` = @flow_cursor_value[0] AND `kb` > @flow_cursor_value[1]) ORDER BY `ka`, `kb`;

--- a/source-mysql-batch/driver.go
+++ b/source-mysql-batch/driver.go
@@ -522,8 +522,8 @@ func (c *capture) worker(ctx context.Context, bindingIndex int, res *Resource) e
 var queryPlaceholderRegexp = regexp.MustCompile(`([?]|:[0-9]+|@flow_cursor_value\[[0-9]+\])`)
 
 // expandQueryPlaceholders simulates numbered query placeholders in MySQL by replacing
-// each numbered placeholder `:N` with a question mark while replacing the input list
-// of argument values into an output list corresponding to the usage sequence.
+// each numbered placeholder `@flow_cursor_value[N]` with a question mark while replacing
+// the input list of argument values into an output list corresponding to the usage sequence.
 func expandQueryPlaceholders(query string, argvals []any) (string, []any, error) {
 	var errReturn error
 	var argseq []any

--- a/source-mysql-batch/main.go
+++ b/source-mysql-batch/main.go
@@ -131,9 +131,9 @@ const tableQueryTemplateTemplate = `{{/*****************************************
 	  {{- if eq $i 0}} WHERE ({{else}}) OR ({{end -}}
       {{- range $j, $n := $.CursorFields -}}
 		{{- if lt $j $i -}}
-		  {{$n}} = :{{$j}} AND {{end -}}
+		  {{$n}} = @flow_cursor_value[{{$j}}] AND {{end -}}
 	  {{- end -}}
-	  {{$k}} > :{{$i}}
+	  {{$k}} > @flow_cursor_value[{{$i}}]
 	{{- end -}}
 	) ORDER BY {{range $i, $k := $.CursorFields}}{{if gt $i 0}}, {{end}}{{$k}}{{end -}}
 	;

--- a/source-mysql-batch/main_test.go
+++ b/source-mysql-batch/main_test.go
@@ -81,7 +81,7 @@ func TestQueryTemplate(t *testing.T) {
 }
 
 func TestQueryPlaceholderExpansion(t *testing.T) {
-	var querySource = `SELECT * FROM "test"."foobar" WHERE (ka > :0) OR (ka = :0 AND kb > :1) OR (ka = :0 AND kb = :1 AND kc > :2) OR (x > ?) OR (y > ?);`
+	var querySource = `SELECT * FROM "test"."foobar" WHERE (ka > @flow_cursor_value[0]) OR (ka = @flow_cursor_value[0] AND kb > @flow_cursor_value[1]) OR (ka = @flow_cursor_value[0] AND kb = @flow_cursor_value[1] AND kc > @flow_cursor_value[2]) OR (x > ?) OR (y > ?);`
 	var argvals = []any{1, "two", 3.0, "xval", "yval"}
 	var query, args, err = expandQueryPlaceholders(querySource, argvals)
 	require.NoError(t, err)

--- a/source-mysql-batch/main_test.go
+++ b/source-mysql-batch/main_test.go
@@ -83,7 +83,8 @@ func TestQueryTemplate(t *testing.T) {
 func TestQueryPlaceholderExpansion(t *testing.T) {
 	var querySource = `SELECT * FROM "test"."foobar" WHERE (ka > :0) OR (ka = :0 AND kb > :1) OR (ka = :0 AND kb = :1 AND kc > :2) OR (x > ?) OR (y > ?);`
 	var argvals = []any{1, "two", 3.0, "xval", "yval"}
-	var query, args = expandQueryPlaceholders(querySource, argvals)
+	var query, args, err = expandQueryPlaceholders(querySource, argvals)
+	require.NoError(t, err)
 	var buf = new(strings.Builder)
 	fmt.Fprintf(buf, "Query: %s\n\n---\n", query)
 	for i, arg := range args {


### PR DESCRIPTION
**Description:**

The previous implementation of numbered placeholders used the syntax `:N` which proved to be a dumb design decision since that appears as a substring of every timestamp.

(Note that this isn't *quite* as dumb as it sounds because the garden path for most users has them using the default query template which has no such issue, the only time this comes up is if you customize the query template and hard-code a specific timestamp as part of one of the queries. Unfortunately that's not a super uncommon thing to want to do, as specifying an initial cursor value for the first query is the obvious way to avoid backfilling a bunch of historical data)

The new placeholder syntax added in this PR looks like `@flow_cursor_value[N]` which ought to be substantially less collision prone. It might still be a good idea to make this substitution logic actually tokenize the input query (at least enough to avoid doing replacements within strings) but this should be solid enough in practice, I suspect.

After this PR both placeholder syntaxes are supported, so that there can be a convenient time window to change over existing uses to the new syntax. Once nothing is using the old syntax it can be removed by deleting the relevant regexp clause and chunk of expansion code.

While I was editing this logic, I also went ahead and added proper error returns and a check for out-of-range parameter indices, so if things fail in the future we should get a proper error message rather than a Go panic.

**Workflow steps:**

No user action is required. Future captures will just work with `@flow_cursor_value[N]` syntax. Preexisting captures will need to be updated to use that syntax in the future, and I intend to do that after this is live.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1036)
<!-- Reviewable:end -->
