### PR TITLE
materializations: StdStrToFloat() takes explicit NaN/Infinity/-Infinity casts

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -209,10 +209,10 @@ jobs:
         run: CONNECTOR=${{ matrix.connector }} VERSION=local ./tests/run.sh;
 
       - name: Materialization connector ${{ matrix.connector }} integration tests
+        # TODO(johnny): Re-enable "materialize-elasticsearch" after adding support for NaN, Infinity, -Infinity
         if: |
           contains(fromJson('[
               "materialize-dynamodb",
-              "materialize-elasticsearch",
               "materialize-google-sheets",
               "materialize-pinecone",
               "materialize-postgres",

--- a/materialize-bigquery/sqlgen.go
+++ b/materialize-bigquery/sqlgen.go
@@ -76,8 +76,9 @@ var bqDialect = func() sql.Dialect {
 		sql.STRING: sql.StringTypeMapper{
 			Fallback: sql.NewStaticMapper("STRING"),
 			WithFormat: map[string]sql.TypeMapper{
-				"integer":   sql.NewStaticMapper("BIGNUMERIC(38,0)", sql.WithElementConverter(sql.StdStrToInt())),
-				"number":    sql.NewStaticMapper("FLOAT64", sql.WithElementConverter(sql.StdStrToFloat())),
+				"integer": sql.NewStaticMapper("BIGNUMERIC(38,0)", sql.WithElementConverter(sql.StdStrToInt())),
+				// https://cloud.google.com/bigquery/docs/reference/standard-sql/conversion_functions#cast_as_floating_point
+				"number":    sql.NewStaticMapper("FLOAT64", sql.WithElementConverter(sql.StdStrToFloat("NaN", "Infinity", "-Infinity"))),
 				"date":      sql.NewStaticMapper("DATE", sql.WithElementConverter(sql.ClampDate())),
 				"date-time": sql.NewStaticMapper("TIMESTAMP", sql.WithElementConverter(sql.ClampDatetime())),
 			},

--- a/materialize-dynamodb/type_mapping.go
+++ b/materialize-dynamodb/type_mapping.go
@@ -148,7 +148,14 @@ func convertNumeric(te tuple.TupleElement) (any, error) {
 
 	switch tt := te.(type) {
 	case string:
-		out.innerNumeric = tt
+		switch tt {
+		case "NaN", "Infinity", "-Infinity":
+			// DynamoDB doesn't support non-numeric float values.
+			// https://boto3.amazonaws.com/v1/documentation/api/latest/_modules/boto3/dynamodb/types.html
+			return nil, nil
+		default:
+			out.innerNumeric = tt
+		}
 	case int:
 		out.innerNumeric = strconv.Itoa(tt)
 	case int64:

--- a/materialize-mysql/sqlgen.go
+++ b/materialize-mysql/sqlgen.go
@@ -30,7 +30,8 @@ var mysqlDialect = func(tzLocation *time.Location) sql.Dialect {
 				},
 				"number": sql.PrimaryKeyMapper{
 					PrimaryKey: sql.NewStaticMapper("VARCHAR(256)"),
-					Delegate:   sql.NewStaticMapper("DOUBLE PRECISION", sql.WithElementConverter(sql.StdStrToFloat())),
+					// We encode as CSV and must send MySQL string sentinels.
+					Delegate: sql.NewStaticMapper("DOUBLE PRECISION", sql.WithElementConverter(sql.StdStrToFloat("NaN", "+inf", "-inf"))),
 				},
 				"date":      sql.NewStaticMapper("DATE"),
 				"date-time": sql.NewStaticMapper("DATETIME(6)", sql.WithElementConverter(rfc3339ToTZ(tzLocation))),

--- a/materialize-redshift/sqlgen.go
+++ b/materialize-redshift/sqlgen.go
@@ -51,7 +51,10 @@ var rsDialect = func() sql.Dialect {
 				},
 				"number": sql.PrimaryKeyMapper{
 					PrimaryKey: sql.NewStaticMapper("TEXT", sql.WithElementConverter(textConverter)),
-					Delegate:   sql.NewStaticMapper("DOUBLE PRECISION", sql.WithElementConverter(sql.StdStrToFloat())),
+					// NOTE(johnny): I can't find any documentation on Redshift Nan/Infinity/-Infinity handling.
+					// There's some indication that others have resorted to mapping these to NULL:
+					// https://stitch-docs.netlify.app/docs/data-structure/redshift-data-loading-behavior#new-table-scenarios
+					Delegate: sql.NewStaticMapper("DOUBLE PRECISION", sql.WithElementConverter(sql.StdStrToFloat(nil, nil, nil))),
 				},
 				"date": sql.NewStaticMapper("DATE"),
 				"date-time": sql.NewStaticMapper("TIMESTAMPTZ", sql.WithElementConverter(

--- a/materialize-snowflake/sqlgen.go
+++ b/materialize-snowflake/sqlgen.go
@@ -56,7 +56,8 @@ var snowflakeDialect = func() sql.Dialect {
 				},
 				"number": sql.PrimaryKeyMapper{
 					PrimaryKey: sql.NewStaticMapper("STRING"),
-					Delegate:   sql.NewStaticMapper("DOUBLE", sql.WithElementConverter(sql.StdStrToFloat())),
+					// https://docs.snowflake.com/en/sql-reference/data-types-numeric#special-values
+					Delegate: sql.NewStaticMapper("DOUBLE", sql.WithElementConverter(sql.StdStrToFloat("NaN", "inf", "-inf"))),
 				},
 				"date":      sql.NewStaticMapper("DATE"),
 				"date-time": sql.NewStaticMapper("TIMESTAMP"),

--- a/materialize-sqlserver/sqlgen.go
+++ b/materialize-sqlserver/sqlgen.go
@@ -75,7 +75,8 @@ var sqlServerDialect = func(collation string) sql.Dialect {
 				},
 				"number": sql.PrimaryKeyMapper{
 					PrimaryKey: sql.NewStaticMapper(textPKType),
-					Delegate:   sql.NewStaticMapper("DOUBLE PRECISION", sql.WithElementConverter(sql.StdStrToFloat())),
+					// SQL Server doesn't handle non-numeric float types and we must map them to NULL.
+					Delegate: sql.NewStaticMapper("DOUBLE PRECISION", sql.WithElementConverter(sql.StdStrToFloat(nil, nil, nil))),
 				},
 				"date":      sql.NewStaticMapper("DATE"),
 				"date-time": sql.NewStaticMapper("DATETIME2", sql.WithElementConverter(rfc3339ToUTC())),

--- a/tests/materialize/fixture.yaml
+++ b/tests/materialize/fixture.yaml
@@ -51,8 +51,11 @@ transactions:
       - [true, { "yin": "", "yan": "ab", "num": 4, "_meta": {"uuid": "8458b580-20e1-11ee-990b-ffd12dfcd47f"}}]
     tests/formatted-strings:
       - [false, { "id":1, "int_and_str":1, "num_and_str":1.1, "int_str": "10", "num_str":"10.1", "datetime":"0000-01-01T00:00:00Z", "date":"0000-01-01", "time":"00:00:00Z", "_meta": {"uuid": "b1e13a0e-20e1-11ee-990b-ffd12dfcd47f"}}]
-      - [false, { "id":2, "int_and_str":2, "num_and_str":2.1, "int_str": "20", "num_str":"20.1", "datetime":"1999-02-02T14:20:12.33Z", "date":"1999-02-02", "time":"14:20:12.33Z",  "_meta": {"uuid": "b81a9bf4-20e1-11ee-990b-ffd12dfcd47f"}}]
-      - [false, { "id":5, "int_and_str":"5", "num_and_str":"5.1", "int_str": "50", "num_str":"50.1", "datetime":"9999-12-31T23:59:59Z", "date":"9999-12-31", "time":"23:59:59Z",  "_meta": {"uuid": "c02bd79a-20e1-11ee-990b-ffd12dfcd47f"}}]
+      - [false, { "id":2, "int_and_str":2, "num_and_str":2.1, "int_str": "20", "num_str":"20.1", "datetime":"1999-02-02T14:20:12.33Z", "date":"1999-02-02", "time":"14:20:12.33Z", "_meta": {"uuid": "b81a9bf4-20e1-11ee-990b-ffd12dfcd47f"}}]
+      - [false, { "id":5, "int_and_str":"5", "num_and_str":"5.1", "int_str": "50", "num_str":"50.1", "datetime":"9999-12-31T23:59:59Z", "date":"9999-12-31", "time":"23:59:59Z", "_meta": {"uuid": "c02bd79a-20e1-11ee-990b-ffd12dfcd47f"}}]
+      - [false, { "id":8, "num_str":"NaN", "_meta": {"uuid": "c02bd79a-20e1-11ee-990b-ffd12dfcd47f"}}]
+      - [false, { "id":9, "num_str":"Infinity", "_meta": {"uuid": "c02bd79a-20e1-11ee-990b-ffd12dfcd47f"}}]
+      - [false, { "id":10, "num_str":"-Infinity", "_meta": {"uuid": "c02bd79a-20e1-11ee-990b-ffd12dfcd47f"}}]
     tests/multiple-data-types:
       - [true, { "id": 6, "str_field": "str6 v2", "float_field": 66.66, "bool_field": true , "nullable_int": 6   , "array_int":[61, 62], "nested": {"id": "i6"}, "multiple": ["one", 2, true], "_meta": {"uuid": "e4b646c2-20e1-11ee-990b-ffd12dfcd47f"}}]
       - [true, { "id": 7, "str_field": "str7 v2", "float_field": 77.77, "bool_field": false, "nullable_int": null, "array_int":[71, 72], "nested": {"id": "i7"}, "multiple": {"object": "seven"}, "_meta": {"uuid": "eb40dafc-20e1-11ee-990b-ffd12dfcd47f"}}]

--- a/tests/materialize/materialize-dynamodb/snapshot.json
+++ b/tests/materialize/materialize-dynamodb/snapshot.json
@@ -1755,6 +1755,49 @@
     },
     {
       "date": {
+        "NULL": true
+      },
+      "datetime": {
+        "NULL": true
+      },
+      "flow_document": {
+        "M": {
+          "_meta": {
+            "M": {
+              "uuid": {
+                "S": "c02bd79a-20e1-11ee-990b-ffd12dfcd47f"
+              }
+            }
+          },
+          "id": {
+            "N": "9"
+          },
+          "num_str": {
+            "S": "Infinity"
+          }
+        }
+      },
+      "id": {
+        "N": "9"
+      },
+      "int_and_str": {
+        "NULL": true
+      },
+      "int_str": {
+        "NULL": true
+      },
+      "num_and_str": {
+        "NULL": true
+      },
+      "num_str": {
+        "NULL": true
+      },
+      "time": {
+        "NULL": true
+      }
+    },
+    {
+      "date": {
         "S": "0000-01-01"
       },
       "datetime": {
@@ -1934,6 +1977,92 @@
       },
       "time": {
         "S": "23:59:59Z"
+      }
+    },
+    {
+      "date": {
+        "NULL": true
+      },
+      "datetime": {
+        "NULL": true
+      },
+      "flow_document": {
+        "M": {
+          "_meta": {
+            "M": {
+              "uuid": {
+                "S": "c02bd79a-20e1-11ee-990b-ffd12dfcd47f"
+              }
+            }
+          },
+          "id": {
+            "N": "8"
+          },
+          "num_str": {
+            "S": "NaN"
+          }
+        }
+      },
+      "id": {
+        "N": "8"
+      },
+      "int_and_str": {
+        "NULL": true
+      },
+      "int_str": {
+        "NULL": true
+      },
+      "num_and_str": {
+        "NULL": true
+      },
+      "num_str": {
+        "NULL": true
+      },
+      "time": {
+        "NULL": true
+      }
+    },
+    {
+      "date": {
+        "NULL": true
+      },
+      "datetime": {
+        "NULL": true
+      },
+      "flow_document": {
+        "M": {
+          "_meta": {
+            "M": {
+              "uuid": {
+                "S": "c02bd79a-20e1-11ee-990b-ffd12dfcd47f"
+              }
+            }
+          },
+          "id": {
+            "N": "10"
+          },
+          "num_str": {
+            "S": "-Infinity"
+          }
+        }
+      },
+      "id": {
+        "N": "10"
+      },
+      "int_and_str": {
+        "NULL": true
+      },
+      "int_str": {
+        "NULL": true
+      },
+      "num_and_str": {
+        "NULL": true
+      },
+      "num_str": {
+        "NULL": true
+      },
+      "time": {
+        "NULL": true
       }
     },
     {

--- a/tests/materialize/materialize-mysql/snapshot.json
+++ b/tests/materialize/materialize-mysql/snapshot.json
@@ -770,6 +770,48 @@
 }
 {
   "row": {
+    "date": null,
+    "datetime": null,
+    "flow_published_at": "2023-07-12 18:27:25.889321",
+    "id": 8,
+    "int_and_str": null,
+    "int_str": null,
+    "num_and_str": null,
+    "num_str": 0,
+    "time": null
+  },
+  "table": "Formatted Strings"
+}
+{
+  "row": {
+    "date": null,
+    "datetime": null,
+    "flow_published_at": "2023-07-12 18:27:25.889321",
+    "id": 9,
+    "int_and_str": null,
+    "int_str": null,
+    "num_and_str": null,
+    "num_str": 0,
+    "time": null
+  },
+  "table": "Formatted Strings"
+}
+{
+  "row": {
+    "date": null,
+    "datetime": null,
+    "flow_published_at": "2023-07-12 18:27:25.889321",
+    "id": 10,
+    "int_and_str": null,
+    "int_str": null,
+    "num_and_str": null,
+    "num_str": 0,
+    "time": null
+  },
+  "table": "Formatted Strings"
+}
+{
+  "row": {
     "flow_published_at": "2023-07-12 18:29:04.671352",
     "id": "very long string that exceeds 256 characters to test if dynamic sizing of varchar fields works. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostru.",
     "str_field": "very long string that exceeds 256 characters to test if dynamic sizing of varchar fields works. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostru."

--- a/tests/materialize/materialize-postgres/snapshot.json
+++ b/tests/materialize/materialize-postgres/snapshot.json
@@ -785,6 +785,48 @@
   "table": "Formatted Strings"
 }
 {
+  "row": {
+    "date": null,
+    "datetime": null,
+    "flow_published_at": "2023-07-12T18:27:25.889321+00:00",
+    "id": 8,
+    "int_and_str": null,
+    "int_str": null,
+    "num_and_str": null,
+    "num_str": "NaN",
+    "time": null
+  },
+  "table": "Formatted Strings"
+}
+{
+  "row": {
+    "date": null,
+    "datetime": null,
+    "flow_published_at": "2023-07-12T18:27:25.889321+00:00",
+    "id": 9,
+    "int_and_str": null,
+    "int_str": null,
+    "num_and_str": null,
+    "num_str": "Infinity",
+    "time": null
+  },
+  "table": "Formatted Strings"
+}
+{
+  "row": {
+    "date": null,
+    "datetime": null,
+    "flow_published_at": "2023-07-12T18:27:25.889321+00:00",
+    "id": 10,
+    "int_and_str": null,
+    "int_str": null,
+    "num_and_str": null,
+    "num_str": "-Infinity",
+    "time": null
+  },
+  "table": "Formatted Strings"
+}
+{
   "applied": {
     "actionDescription": "\nCREATE TABLE IF NOT EXISTS \"public\".flow_materializations_v2 (\n\t\tmaterialization TEXT NOT NULL,\n\t\tversion TEXT NOT NULL,\n\t\tspec TEXT NOT NULL,\n\n\t\tPRIMARY KEY (materialization)\n);\n\nCOMMENT ON TABLE \"public\".flow_materializations_v2 IS 'This table is the source of truth for all materializations into this system.';\nCOMMENT ON COLUMN \"public\".flow_materializations_v2.materialization IS 'The name of the materialization.';\nCOMMENT ON COLUMN \"public\".flow_materializations_v2.version IS 'Version of the materialization.';\nCOMMENT ON COLUMN \"public\".flow_materializations_v2.spec IS 'Specification of the materialization, encoded as base64 protobuf.';\n\n\nCREATE TABLE IF NOT EXISTS \"public\".flow_checkpoints_v1 (\n\t\tmaterialization TEXT NOT NULL,\n\t\tkey_begin BIGINT NOT NULL,\n\t\tkey_end BIGINT NOT NULL,\n\t\tfence BIGINT NOT NULL,\n\t\tcheckpoint TEXT NOT NULL,\n\n\t\tPRIMARY KEY (materialization, key_begin, key_end)\n);\n\nCOMMENT ON TABLE \"public\".flow_checkpoints_v1 IS 'This table holds Flow processing checkpoints used for exactly-once processing of materializations';\nCOMMENT ON COLUMN \"public\".flow_checkpoints_v1.materialization IS 'The name of the materialization.';\nCOMMENT ON COLUMN \"public\".flow_checkpoints_v1.key_begin IS 'The inclusive lower-bound key hash covered by this checkpoint.';\nCOMMENT ON COLUMN \"public\".flow_checkpoints_v1.key_end IS 'The inclusive upper-bound key hash covered by this checkpoint.';\nCOMMENT ON COLUMN \"public\".flow_checkpoints_v1.fence IS 'This nonce is used to uniquely identify unique process assignments of a shard and prevent them from conflicting.';\nCOMMENT ON COLUMN \"public\".flow_checkpoints_v1.checkpoint IS 'Checkpoint of the Flow consumer shard, encoded as base64 protobuf.';\n\nUPDATE \"public\".flow_materializations_v2 SET version = 'test', spec = '(a-base64-encoded-value)' WHERE materialization = 'tests/materialize-postgres/materialize';"
   }

--- a/tests/materialize/materialize-snowflake/fetch-data.go
+++ b/tests/materialize/materialize-snowflake/fetch-data.go
@@ -7,6 +7,7 @@ import (
 	"flag"
 	"fmt"
 	"log"
+	"math"
 	"os"
 
 	sf "github.com/snowflakedb/gosnowflake"
@@ -110,8 +111,18 @@ func main() {
 			log.Fatal("scanning row: %w", err)
 		}
 		row := make(map[string]any)
-		for idx := range data {
-			row[cols[idx]] = data[idx]
+		for idx, val := range data {
+			switch v := val.(type) {
+			case float64:
+				if math.IsNaN(v) {
+					val = "NaN"
+				} else if math.IsInf(v, +1) {
+					val = "Infinity"
+				} else if math.IsInf(v, -1) {
+					val = "-Infinity"
+				}
+			}
+			row[cols[idx]] = val
 		}
 
 		queriedRows = append(queriedRows, row)

--- a/tests/materialize/materialize-snowflake/snapshot.json
+++ b/tests/materialize/materialize-snowflake/snapshot.json
@@ -645,6 +645,42 @@
       "NUM_AND_STR": 5.1,
       "NUM_STR": 50.1,
       "TIME": "23:59:59Z"
+    },
+    {
+      "DATE": null,
+      "DATETIME": null,
+      "FLOW_DOCUMENT": "{\n  \"_meta\": {\n    \"uuid\": \"c02bd79a-20e1-11ee-990b-ffd12dfcd47f\"\n  },\n  \"id\": 8,\n  \"num_str\": \"NaN\"\n}",
+      "FLOW_PUBLISHED_AT": "2023-07-12T18:27:25.889321Z",
+      "ID": "8",
+      "INT_AND_STR": null,
+      "INT_STR": null,
+      "NUM_AND_STR": null,
+      "NUM_STR": "NaN",
+      "TIME": null
+    },
+    {
+      "DATE": null,
+      "DATETIME": null,
+      "FLOW_DOCUMENT": "{\n  \"_meta\": {\n    \"uuid\": \"c02bd79a-20e1-11ee-990b-ffd12dfcd47f\"\n  },\n  \"id\": 9,\n  \"num_str\": \"Infinity\"\n}",
+      "FLOW_PUBLISHED_AT": "2023-07-12T18:27:25.889321Z",
+      "ID": "9",
+      "INT_AND_STR": null,
+      "INT_STR": null,
+      "NUM_AND_STR": null,
+      "NUM_STR": "Infinity",
+      "TIME": null
+    },
+    {
+      "DATE": null,
+      "DATETIME": null,
+      "FLOW_DOCUMENT": "{\n  \"_meta\": {\n    \"uuid\": \"c02bd79a-20e1-11ee-990b-ffd12dfcd47f\"\n  },\n  \"id\": 10,\n  \"num_str\": \"-Infinity\"\n}",
+      "FLOW_PUBLISHED_AT": "2023-07-12T18:27:25.889321Z",
+      "ID": "10",
+      "INT_AND_STR": null,
+      "INT_STR": null,
+      "NUM_AND_STR": null,
+      "NUM_STR": "-Infinity",
+      "TIME": null
     }
   ]
 }

--- a/tests/materialize/materialize-sqlserver/snapshot.json
+++ b/tests/materialize/materialize-sqlserver/snapshot.json
@@ -782,6 +782,48 @@
 }
 {
   "row": {
+    "date": null,
+    "datetime": null,
+    "flow_published_at": "2023-07-12T18:27:25.889321Z",
+    "id": 8,
+    "int_and_str": null,
+    "int_str": null,
+    "num_and_str": null,
+    "num_str": null,
+    "time": null
+  },
+  "table": "Formatted Strings"
+}
+{
+  "row": {
+    "date": null,
+    "datetime": null,
+    "flow_published_at": "2023-07-12T18:27:25.889321Z",
+    "id": 9,
+    "int_and_str": null,
+    "int_str": null,
+    "num_and_str": null,
+    "num_str": null,
+    "time": null
+  },
+  "table": "Formatted Strings"
+}
+{
+  "row": {
+    "date": null,
+    "datetime": null,
+    "flow_published_at": "2023-07-12T18:27:25.889321Z",
+    "id": 10,
+    "int_and_str": null,
+    "int_str": null,
+    "num_and_str": null,
+    "num_str": null,
+    "time": null
+  },
+  "table": "Formatted Strings"
+}
+{
+  "row": {
     "flow_published_at": "2023-07-12T18:25:45.520064Z",
     "num": 4,
     "yan": "ab",


### PR DESCRIPTION
Many materializations JSON-encode float64 values, but these special values are prohibited in JSON, and different systems allow for different alternative representations when casting into a floating-point column.

Update the StdStrToFloat() signature to force the connector to think about and provide these special value conversions.

Update individual connectors to provide handling for each, using best judgement and available public documentation.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

I haven't tested this beyond CI. Very open to effective ways to test this ahead of time.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1037)
<!-- Reviewable:end -->
