### PR TITLE
source-mongodb: remove `noTimeout` option from cursor

### DIFF
--- a/source-mongodb/pull.go
+++ b/source-mongodb/pull.go
@@ -404,7 +404,7 @@ func (c *capture) BackfillCollection(ctx context.Context, sp *semaphore.Weighted
 	// explicitly by { $natural: 1 }, then the database will disregard any indices
 	// and do a full collection scan.
 	// See https://www.mongodb.com/docs/manual/reference/method/cursor.hint
-	var opts = options.Find().SetBatchSize(BackfillBatchSize).SetHint(bson.M{"_id": 1}).SetNoCursorTimeout(true)
+	var opts = options.Find().SetBatchSize(BackfillBatchSize).SetHint(bson.M{"_id": 1})
 	var filter = bson.D{}
 	if state.Backfill.LastId.Validate() == nil {
 		var v interface{}


### PR DESCRIPTION
**Description:**

- We were using `noTimeout` option on a _backfill_ cursor, which is pretty much useless as backfill cursors are not supposed to be idle at all
- We have realised that `noTimeout` cursors are disabled on free tier: [see here](https://www.mongodb.com/docs/atlas/reference/free-shared-limitations/#operational-limitations)
- So I'm removing this option to allow free tier users to use our connector
- Tested using integration tests

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1038)
<!-- Reviewable:end -->
