### PR TITLE
Variants of DB connecters for Amazon RDS

### DIFF
--- a/materialize-mysql/VARIANTS
+++ b/materialize-mysql/VARIANTS
@@ -2,3 +2,4 @@ materialize-amazon-aurora-mysql
 materialize-mariadb
 materialize-mysql-heatwave
 materialize-google-cloud-sql-mysql
+Materialize-amazon-rds-mysql

--- a/materialize-mysql/VARIANTS
+++ b/materialize-mysql/VARIANTS
@@ -2,4 +2,5 @@ materialize-amazon-aurora-mysql
 materialize-mariadb
 materialize-mysql-heatwave
 materialize-google-cloud-sql-mysql
-Materialize-amazon-rds-mysql
+materialize-amazon-rds-mysql
+materialize-amazon-rds-mariadb

--- a/materialize-postgres/VARIANTS
+++ b/materialize-postgres/VARIANTS
@@ -2,3 +2,4 @@ materialize-timescaledb
 materialize-alloydb
 materialize-amazon-aurora-postgres
 materialize-google-cloud-sql-postgres
+materialize-amazon-rds-postgres

--- a/materialize-sqlserver/VARIANTS
+++ b/materialize-sqlserver/VARIANTS
@@ -1,2 +1,3 @@
 materialize-google-cloud-sql-sqlserver
 materialize-azure-sqlserver
+materialize-amazon-rds-sqlserver

--- a/source-mysql/VARIANTS
+++ b/source-mysql/VARIANTS
@@ -2,3 +2,4 @@ source-mariadb
 source-amazon-aurora-mysql
 source-google-cloud-sql-mysql
 source-amazon-rds-mysql
+source-amazon-rds-mariadb

--- a/source-mysql/VARIANTS
+++ b/source-mysql/VARIANTS
@@ -1,3 +1,4 @@
 source-mariadb
 source-amazon-aurora-mysql
 source-google-cloud-sql-mysql
+source-amazon-rds-mysql

--- a/source-postgres/VARIANTS
+++ b/source-postgres/VARIANTS
@@ -1,3 +1,4 @@
 source-alloydb
 source-amazon-aurora-postgres
 source-google-cloud-sql-postgres
+Source-amazon-rds-postgres

--- a/source-postgres/VARIANTS
+++ b/source-postgres/VARIANTS
@@ -1,4 +1,4 @@
 source-alloydb
 source-amazon-aurora-postgres
 source-google-cloud-sql-postgres
-Source-amazon-rds-postgres
+source-amazon-rds-postgres

--- a/source-sqlserver/VARIANTS
+++ b/source-sqlserver/VARIANTS
@@ -1,2 +1,3 @@
 source-azure-sqlserver
 source-google-cloud-sql-sqlserver
+Source-amazon-rds-sqlserver

--- a/source-sqlserver/VARIANTS
+++ b/source-sqlserver/VARIANTS
@@ -1,3 +1,3 @@
 source-azure-sqlserver
 source-google-cloud-sql-sqlserver
-Source-amazon-rds-sqlserver
+source-amazon-rds-sqlserver


### PR DESCRIPTION
Amazon RDS Source Connectors:

- MySQL
- PostgreSQL
- SQL Server
- MariaDB

Amazon RDS Materialization Connectors:

- MySQL
- PostgreSQL
- SQL Server
- MariaDB

Docs for all sources/materializations have been created

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1040)
<!-- Reviewable:end -->
