### PR TITLE
source-dynamodb: limit concurrent stream data requests

### DIFF
--- a/source-dynamodb/pull.go
+++ b/source-dynamodb/pull.go
@@ -33,6 +33,9 @@ const (
 
 	// Number of concurrent workers to use when backfilling a table.
 	backfillConcurrency = 3
+
+	// Number of stream workers which may concurrently send requests for stream data.
+	streamConcurrency = 5
 )
 
 type table struct {


### PR DESCRIPTION
**Description:**

When streaming from tables with huge numbers of shards where a significant portion of the shards have some non-trivial amount of data available, we can end up buffering an excessive amount of data in memory.

This is because the connector requests data from all shards simultaneously, and must hold on to that data until it can be serialized and drained to the runtime. If data comes in faster than it can be drained, the connector will run out of memory.

Here a semaphore is added, to limit how many workers can simultaneously be processing data.

Tested using the unit tests to ensure no existing functionality is broken. It's not really practical to create a huge dynamodb table to test this with many shards in earnest unfortunately, but it is a pretty straightforward and low risk change, and will be immediately apparent if it takes care of the on-going production issues.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

N/A

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1045)
<!-- Reviewable:end -->
