### PR TITLE
source-postgres: Make watermarks permissions error reporting work

### DIFF
--- a/source-postgres/backfill.go
+++ b/source-postgres/backfill.go
@@ -155,11 +155,10 @@ func (db *postgresDatabase) ScanTableChunk(ctx context.Context, info *sqlcapture
 func (db *postgresDatabase) WriteWatermark(ctx context.Context, watermark string) error {
 	logrus.WithField("watermark", watermark).Debug("writing watermark")
 	var query = fmt.Sprintf(`INSERT INTO %s (slot, watermark) VALUES ($1,$2) ON CONFLICT (slot) DO UPDATE SET watermark = $2;`, db.config.Advanced.WatermarksTable)
-	var rows, err = db.conn.Query(ctx, query, db.config.Advanced.SlotName, watermark)
+	var _, err = db.conn.Exec(ctx, query, db.config.Advanced.SlotName, watermark)
 	if err != nil {
 		return fmt.Errorf("error upserting new watermark for slot %q: %w", db.config.Advanced.SlotName, err)
 	}
-	rows.Close()
 	return nil
 }
 

--- a/source-postgres/prerequisites.go
+++ b/source-postgres/prerequisites.go
@@ -189,10 +189,12 @@ func (db *postgresDatabase) prerequisiteWatermarksTable(ctx context.Context) err
 	if err := db.WriteWatermark(ctx, "existence-check"); err == nil {
 		logEntry.Debug("watermarks table already exists")
 		return nil
+	} else {
+		logEntry.WithField("err", err).Warn("error writing to watermarks table")
 	}
 
 	// If we can create the watermarks table and then write a watermark, that also works
-	logEntry.Info("watermarks table doesn't exist, attempting to create it")
+	logEntry.Info("attempting to create watermarks table")
 	var _, err = db.conn.Exec(ctx, fmt.Sprintf("CREATE TABLE IF NOT EXISTS %s (slot TEXT PRIMARY KEY, watermark TEXT);", table))
 	if err == nil {
 		if err := db.WriteWatermark(ctx, "existence-check"); err == nil {


### PR DESCRIPTION
**Description:**

Previously it was possible in some cases to set up the watermarks table such that the capture user didn't have permission to update the table *and yet those failures weren't reported* which is bad.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1052)
<!-- Reviewable:end -->
