### PR TITLE
filesource: use more specific recommended collection names where possible

### DIFF
--- a/filesource/filesource.go
+++ b/filesource/filesource.go
@@ -28,6 +28,9 @@ type Config interface {
 	Validate() error
 	// DiscoverRoot path to use when walking discoverable directories.
 	DiscoverRoot() string
+	// RecommendedName produces a name to use for the discovered
+	// collection for the capture.
+	RecommendedName() string
 	// FilesAreMonotonic is true if files are created or modified in
 	// strictly monotonic, lexicographic order within each and every
 	// captured stream prefix.
@@ -216,7 +219,7 @@ func (src *Source) Discover(ctx context.Context, req *pc.Request_Discover) (*pc.
 	}
 
 	return &pc.Response_Discovered{Bindings: []*pc.Response_Discovered_Binding{{
-		RecommendedName:    "file-data",
+		RecommendedName:    conn.config.RecommendedName(),
 		ResourceConfigJson: resourceJSON,
 		DocumentSchemaJson: json.RawMessage(minimalDocumentSchema),
 		Key:                []string{"/_meta/file", "/_meta/offset"},

--- a/source-gcs/main.go
+++ b/source-gcs/main.go
@@ -43,6 +43,10 @@ func (c config) DiscoverRoot() string {
 	return filesource.PartsToPath(c.Bucket, c.Prefix)
 }
 
+func (c config) RecommendedName() string {
+	return strings.Trim(c.DiscoverRoot(), "/")
+}
+
 func (c config) FilesAreMonotonic() bool {
 	return c.Advanced.AscendingKeys
 }

--- a/source-google-drive/main.go
+++ b/source-google-drive/main.go
@@ -49,6 +49,12 @@ func (c config) DiscoverRoot() string {
 	return folderURLRe.FindStringSubmatch(c.FolderURL)[1]
 }
 
+func (c config) RecommendedName() string {
+	// Google drive folder names are generated strings and are not really human-readable, so this
+	// generic value is used instead.
+	return "file-data"
+}
+
 func (c config) FilesAreMonotonic() bool {
 	return c.Advanced.AscendingKeys
 }

--- a/source-http-file/main.go
+++ b/source-http-file/main.go
@@ -75,6 +75,10 @@ func (c config) DiscoverRoot() string {
 	return name
 }
 
+func (c config) RecommendedName() string {
+	return strings.Trim(c.DiscoverRoot(), "/")
+}
+
 func (c config) FilesAreMonotonic() bool {
 	// Conceptually, if the source files are monotonic, the same file will not be visited again, and only
 	// ascending file names are visited, so we set this to false.

--- a/source-s3/main.go
+++ b/source-s3/main.go
@@ -55,6 +55,10 @@ func (c config) DiscoverRoot() string {
 	return filesource.PartsToPath(c.Bucket, c.Prefix)
 }
 
+func (c config) RecommendedName() string {
+	return strings.Trim(c.DiscoverRoot(), "/")
+}
+
 func (c config) FilesAreMonotonic() bool {
 	return c.Advanced.AscendingKeys
 }

--- a/source-sftp/main.go
+++ b/source-sftp/main.go
@@ -104,6 +104,10 @@ func (c config) DiscoverRoot() string {
 	return c.Directory
 }
 
+func (c config) RecommendedName() string {
+	return strings.Trim(c.DiscoverRoot(), "/")
+}
+
 func (c config) FilesAreMonotonic() bool {
 	return c.Advanced.AscendingKeys
 }


### PR DESCRIPTION
**Description:**

In 7379829 the `RecommendName` for all filesource-based captures was changed to `"file-data"`, to accommodate the new Google Drive capture which uses generated folder names through its API which are not user-friendly, so the more generic default value is better in this case.

All other connectors are capable of producing a more useful recommended name though, and this change allows for individual capture connectors to determine what their output recommended collection name should be to allow for that.

As a result, Google Drive captures will continue to recommend collection names of `"file-data"`, but others will revert back to their previous behavior of recommending a reasonable collection name based on the user's input.

**Workflow steps:**

Create a capture from (for example) an HTTP file reading from `https://jsonplaceholder.typicode.com/comments` and you'll get a recommended collection name of `comments`. 

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1053)
<!-- Reviewable:end -->
