### PR TITLE
source-postgres: Truncate oversize string/byte/JSON columns

### DIFF
--- a/source-postgres/.snapshots/TestCaptureOversizedFields
+++ b/source-postgres/.snapshots/TestCaptureOversizedFields
@@ -1,0 +1,9 @@
+# ================================
+# Collection "acmeCo/test/test_captureoversizedfields_64819605": 4 Documents
+# ================================
+Checksum: 239a210f0a60102947975c862914ef87e995e9cc61f22b32ef39235c00d91779
+# ================================
+# Final State Checkpoint
+# ================================
+{"cursor":"0/1111111","streams":{"test.captureoversizedfields_64819605":{"backfilled":4,"key_columns":["id"],"mode":"Active"}}}
+

--- a/source-postgres/.snapshots/TestCaptureOversizedFields
+++ b/source-postgres/.snapshots/TestCaptureOversizedFields
@@ -1,7 +1,7 @@
 # ================================
 # Collection "acmeCo/test/test_captureoversizedfields_64819605": 4 Documents
 # ================================
-Checksum: 239a210f0a60102947975c862914ef87e995e9cc61f22b32ef39235c00d91779
+Checksum: 2ba231d6535812a5c4865e86f3d25af98c99407e9d8f5feea0b24c43be1632ee
 # ================================
 # Final State Checkpoint
 # ================================

--- a/source-postgres/.snapshots/TestCaptureOversizedFields-Replication
+++ b/source-postgres/.snapshots/TestCaptureOversizedFields-Replication
@@ -1,7 +1,7 @@
 # ================================
 # Collection "acmeCo/test/test_captureoversizedfields_64819605": 4 Documents
 # ================================
-Checksum: f992fa0a111a9645d343085fbe880c634827f80bddaca5a74ff4d9a0a1b47399
+Checksum: 7b8ae71a3e0a5309672ddad3381478c4b0ceafc069347af9e094811d18ff91b3
 # ================================
 # Final State Checkpoint
 # ================================

--- a/source-postgres/.snapshots/TestCaptureOversizedFields-Replication
+++ b/source-postgres/.snapshots/TestCaptureOversizedFields-Replication
@@ -1,0 +1,9 @@
+# ================================
+# Collection "acmeCo/test/test_captureoversizedfields_64819605": 4 Documents
+# ================================
+Checksum: f992fa0a111a9645d343085fbe880c634827f80bddaca5a74ff4d9a0a1b47399
+# ================================
+# Final State Checkpoint
+# ================================
+{"cursor":"0/1111111","streams":{"test.captureoversizedfields_64819605":{"backfilled":4,"key_columns":["id"],"mode":"Active"}}}
+

--- a/source-postgres/capture_test.go
+++ b/source-postgres/capture_test.go
@@ -455,6 +455,10 @@ func TestCaptureCapitalization(t *testing.T) {
 }
 
 func TestCaptureOversizedFields(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
+
 	var tb, ctx = postgresTestBackend(t), context.Background()
 	var uniqueID = "64819605"
 	var tableName = tb.CreateTable(ctx, t, uniqueID, "(id INTEGER PRIMARY KEY, tdata TEXT, bdata BYTEA, jdata JSON, jbdata JSONB)")

--- a/source-postgres/discovery.go
+++ b/source-postgres/discovery.go
@@ -21,7 +21,7 @@ const (
 	infinityTimestamp         = "9999-12-31T23:59:59Z"
 	negativeInfinityTimestamp = "0000-01-01T00:00:00Z"
 	RFC3339TimeFormat         = "15:04:05.999999999Z07:00"
-	truncateColumnThreshold   = 1 * 1024 * 1024 // Arbitrarily selected value
+	truncateColumnThreshold   = 8 * 1024 * 1024 // Arbitrarily selected value
 )
 
 // DiscoverTables queries the database for information about tables available for capture.

--- a/source-postgres/discovery.go
+++ b/source-postgres/discovery.go
@@ -21,6 +21,7 @@ const (
 	infinityTimestamp         = "9999-12-31T23:59:59Z"
 	negativeInfinityTimestamp = "0000-01-01T00:00:00Z"
 	RFC3339TimeFormat         = "15:04:05.999999999Z07:00"
+	truncateColumnThreshold   = 1 * 1024 * 1024 // Arbitrarily selected value
 )
 
 // DiscoverTables queries the database for information about tables available for capture.
@@ -225,14 +226,20 @@ func translateRecordFields(table *sqlcapture.DiscoveryInfo, f map[string]interfa
 	return nil
 }
 
+func oversizePlaceholderJSON(orig []byte) json.RawMessage {
+	return json.RawMessage(fmt.Sprintf(`{"flow_truncated":true,"original_size":%d}`, len(orig)))
+}
+
 // translateRecordField "translates" a value from the PostgreSQL driver into
 // an appropriate JSON-encodeable output format. As a concrete example, the
 // PostgreSQL `cidr` type becomes a `*net.IPNet`, but the default JSON
 // marshalling of a `net.IPNet` isn't a great fit and we'd prefer to use
 // the `String()` method to get the usual "192.168.100.0/24" notation.
 func translateRecordField(column *sqlcapture.ColumnInfo, val interface{}) (interface{}, error) {
+	var columnName = "<unknown>"
 	var dataType interface{}
 	if column != nil {
+		columnName = column.Name
 		dataType = column.DataType
 	}
 
@@ -250,8 +257,45 @@ func translateRecordField(column *sqlcapture.ColumnInfo, val interface{}) (inter
 			fmt.Fprintf(s, "%02x", x[i])
 		}
 		return s.String(), nil
+	case string:
+		if len(x) > truncateColumnThreshold {
+			return x[:truncateColumnThreshold], nil
+		}
+		return x, nil
+	case []byte:
+		if len(x) > truncateColumnThreshold {
+			return x[:truncateColumnThreshold], nil
+		}
+		return x, nil
+	case map[string]any:
+		var bs, err = json.Marshal(x)
+		if err != nil {
+			return nil, fmt.Errorf("error reserializing json column %q: %w", columnName, err)
+		}
+		if len(bs) > truncateColumnThreshold {
+			return oversizePlaceholderJSON(bs), nil
+		}
+		return json.RawMessage(bs), nil
+	case pgtype.Text:
+		if len(x.String) > truncateColumnThreshold {
+			return x.String[:truncateColumnThreshold], nil
+		}
+		return x.String, nil
 	case pgtype.Bytea:
+		if len(x.Bytes) > truncateColumnThreshold {
+			return x.Bytes[:truncateColumnThreshold], nil
+		}
 		return x.Bytes, nil
+	case pgtype.JSON:
+		if len(x.Bytes) > truncateColumnThreshold {
+			return oversizePlaceholderJSON(x.Bytes), nil
+		}
+		return json.RawMessage(x.Bytes), nil
+	case pgtype.JSONB:
+		if len(x.Bytes) > truncateColumnThreshold {
+			return oversizePlaceholderJSON(x.Bytes), nil
+		}
+		return json.RawMessage(x.Bytes), nil
 	case pgtype.Float4:
 		return x.Float, nil
 	case pgtype.Float8:


### PR DESCRIPTION
**Description:**

Adds some code to truncate overly large (defined here as >1MiB, an arbitrarily chosen value which should be large enough for most reasonable purposes and small enough that even several such fields is still within the Flow document size limits) string/byte/JSON columns coming from Postgres.

This logic isn't bulletproof: I'm sure there are plenty of other column types which could in theory cause trouble, including array columns. But this handles the four most common column types which could contain megabytes of data, and in practice it will probably be sufficient for now.

In the longer term, this truncation function should be made a part of the common `sqlcapture` logic and should be done as part of the final JSON serialization of a change event, so that it will apply to every possible value type in all three databases.

But that's a bit more complicated and I wanted to get the minimum useful version of this feature out sooner.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1054)
<!-- Reviewable:end -->
