### PR TITLE
materialize-google-pubsub: hex-encode ordering key

### DIFF
--- a/materialize-google-pubsub/transactor.go
+++ b/materialize-google-pubsub/transactor.go
@@ -34,7 +34,7 @@ func (t *transactor) Store(it *pm.StoreIterator) (pm.StartCommitFunc, error) {
 
 		msg := &pubsub.Message{
 			Data:        it.RawJSON,
-			OrderingKey: string(it.PackedKey), // Allows for reading of messages for the same key in order.
+			OrderingKey: fmt.Sprintf("%x", it.PackedKey), // Allows for reading of messages for the same key in order.
 		}
 		// Only include an identifier attribute if an identifier has been configured.
 		if binding.identifier != "" {


### PR DESCRIPTION
**Description:**

The packed key can be an arbitrary sequence of bytes, including sequences of non-UTF8 characters when converted to a string. If used as an ordering key, this causes a PubSub error.

Instead, hex-encode the packed key to use as an ordering key, which is always valid UTF8.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

This change to the ordering key could hypothetically result in out of order reading of messages with the same packed key from a materialized topic where the key was originally published previously as a raw string, but then an update gets published again with the hex-encoded string. Since there is only 1 active pubsub materialization and its currently broken because of this issue I don't think it is likely to be an actual problem in practice.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1062)
<!-- Reviewable:end -->
