### PR TITLE
materialize-sql: use `encrow.Shape` for encoding

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -35,6 +35,7 @@ require (
 	github.com/jackc/pgproto3/v2 v2.3.0
 	github.com/jackc/pgtype v1.11.0
 	github.com/jackc/pgx/v4 v4.16.1
+	github.com/klauspost/compress v1.17.2
 	github.com/marcboeker/go-duckdb v1.5.1
 	github.com/mattn/go-sqlite3 v2.0.3+incompatible
 	github.com/microsoft/go-mssqldb v0.19.0
@@ -138,7 +139,6 @@ require (
 	github.com/jackc/puddle v1.2.1 // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
 	github.com/klauspost/asmfmt v1.3.2 // indirect
-	github.com/klauspost/compress v1.15.15 // indirect
 	github.com/klauspost/cpuid/v2 v2.2.3 // indirect
 	github.com/kr/fs v0.1.0 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect

--- a/go.sum
+++ b/go.sum
@@ -303,10 +303,6 @@ github.com/envoyproxy/go-control-plane v0.9.9-0.20210217033140-668b12f5399d/go.m
 github.com/envoyproxy/go-control-plane v0.9.9-0.20210512163311-63b5d3c536b0/go.mod h1:hliV/p42l8fGbc6Y9bQ70uLwIvmJyVE5k4iMKlh8wCQ=
 github.com/envoyproxy/go-control-plane v0.9.10-0.20210907150352-cf90f659a021/go.mod h1:AFq3mo9L8Lqqiid3OhADV3RfLJnjiw63cSpi+fDTRC0=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
-github.com/estuary/flow v0.3.4-0.20230718195208-1aed3cc73e86 h1:Y8KzHCwjvlFP8RHTiUlcEZrEG+pnaohDr1M7qCWT1T4=
-github.com/estuary/flow v0.3.4-0.20230718195208-1aed3cc73e86/go.mod h1:e3dXZ46QzqPQCgJBA8fevk14ecsYbMTejFWycAqWujc=
-github.com/estuary/flow v0.3.8 h1:T0vMPQprEktJpjSwmx6ahr/dSYMJcb+5IaobIaVqplQ=
-github.com/estuary/flow v0.3.8/go.mod h1:0g2acMNbyUpvBVO2zBaeXt3jC7Hr2F2bvTxcKgjXQpo=
 github.com/estuary/flow v0.3.9-0.20231101171501-fcdb1e7d6867 h1:ksUkoodoBfVHL7GcJI8FULXxGLmlQ2BVstdEXeoFUXw=
 github.com/estuary/flow v0.3.9-0.20231101171501-fcdb1e7d6867/go.mod h1:0g2acMNbyUpvBVO2zBaeXt3jC7Hr2F2bvTxcKgjXQpo=
 github.com/evanphx/json-patch/v5 v5.6.0 h1:b91NhWfaz02IuVxO9faSllyAtNXHMPkC5J8sJCLunww=
@@ -611,6 +607,8 @@ github.com/klauspost/compress v1.13.1/go.mod h1:8dP1Hq4DHOhN9w426knH3Rhby4rFm6D8
 github.com/klauspost/compress v1.13.6/go.mod h1:/3/Vjq9QcHkK5uEr5lBEmyoZ1iFhe47etQ6QUkpK6sk=
 github.com/klauspost/compress v1.15.15 h1:EF27CXIuDsYJ6mmvtBRlEuB2UVOqHG1tAXgZ7yIO+lw=
 github.com/klauspost/compress v1.15.15/go.mod h1:ZcK2JAFqKOpnBlxcLsJzYfrS9X1akm9fHZNnD9+Vo/4=
+github.com/klauspost/compress v1.17.2 h1:RlWWUY/Dr4fL8qk9YG7DTZ7PDgME2V4csBXA8L/ixi4=
+github.com/klauspost/compress v1.17.2/go.mod h1:ntbaceVETuRiXiv4DpjP66DpAtAGkEQskQzEyD//IeE=
 github.com/klauspost/cpuid/v2 v2.2.3 h1:sxCkb+qR91z4vsqw4vGGZlDgPz3G7gjaLyK3V8y70BU=
 github.com/klauspost/cpuid/v2 v2.2.3/go.mod h1:RVVoqg1df56z8g3pUjL/3lE5UfnlrJX8tyFgg4nqhuY=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
@@ -875,8 +873,6 @@ go.etcd.io/etcd/client/pkg/v3 v3.5.7 h1:y3kf5Gbp4e4q7egZdn5T7W9TSHUvkClN6u+Rq9mE
 go.etcd.io/etcd/client/pkg/v3 v3.5.7/go.mod h1:o0Abi1MK86iad3YrWhgUsbGx1pmTS+hrORWc2CamuhY=
 go.etcd.io/etcd/client/v3 v3.5.7 h1:u/OhpiuCgYY8awOHlhIhmGIGpxfBU/GZBUP3m/3/Iz4=
 go.etcd.io/etcd/client/v3 v3.5.7/go.mod h1:sOWmj9DZUMyAngS7QQwCyAXXAL6WhgTOPLNS/NabQgw=
-go.gazette.dev/core v0.89.1-0.20230717210749-2615d43e1202 h1:WLYJQre7newMdKrYyv4sKH1DXcy7PieSYJZ6bEZ8iIo=
-go.gazette.dev/core v0.89.1-0.20230717210749-2615d43e1202/go.mod h1:/fdxqReMWKS26yROKEKDY8JlXjwz8TqeEZggpNwb5I0=
 go.gazette.dev/core v0.89.1-0.20231012132739-dfed675b7fd1 h1:oRtrsDKboiCGeG0B6kJvaJ9KVAn7U797oGMGTqdHnwo=
 go.gazette.dev/core v0.89.1-0.20231012132739-dfed675b7fd1/go.mod h1:/fdxqReMWKS26yROKEKDY8JlXjwz8TqeEZggpNwb5I0=
 go.mongodb.org/mongo-driver v1.12.1 h1:nLkghSU8fQNaK7oUmDhQFsnrtcoNy7Z6LVFKsEecqgE=

--- a/go/encrow/encrow.go
+++ b/go/encrow/encrow.go
@@ -13,6 +13,7 @@ type Shape struct {
 	arity    int
 	prefixes []string
 	swizzle  []int
+	flags    json.AppendFlags
 }
 
 // NewShape constructs a new Shape corresponding to the provided field names.
@@ -36,7 +37,14 @@ func NewShape(fields []string) *Shape {
 		arity:    len(sortedNames),
 		prefixes: generatePrefixes(sortedNames),
 		swizzle:  swizzle,
+		// Default flags, unless overridden via SetFlags.
+		flags: json.EscapeHTML | json.SortMapKeys,
 	}
+}
+
+// SetFlags overrides the default flags, if alternate behavior is desired.
+func (s *Shape) SetFlags(flags json.AppendFlags) {
+	s.flags = flags
 }
 
 func generatePrefixes(fields []string) []string {
@@ -69,7 +77,7 @@ func (s *Shape) Encode(buf []byte, values []any) ([]byte, error) {
 	buf = buf[:0]
 	for idx, vidx := range s.swizzle {
 		buf = append(buf, s.prefixes[idx]...)
-		buf, err = json.Append(buf, values[vidx], json.EscapeHTML|json.SortMapKeys)
+		buf, err = json.Append(buf, values[vidx], s.flags)
 		if err != nil {
 			return nil, err
 		}

--- a/materialize-google-pubsub/transactor.go
+++ b/materialize-google-pubsub/transactor.go
@@ -50,7 +50,7 @@ func (t *transactor) Store(it *pm.StoreIterator) (pm.StartCommitFunc, error) {
 
 		msg := &pubsub.Message{
 			Data:        it.RawJSON,
-			OrderingKey: fmt.Sprintf("%d", PackedKeyHash_HH64(it.PackedKey)),
+			OrderingKey: fmt.Sprintf("%08x", PackedKeyHash_HH64(it.PackedKey)),
 		}
 		// Only include an identifier attribute if an identifier has been configured.
 		if binding.identifier != "" {

--- a/materialize-motherduck/driver.go
+++ b/materialize-motherduck/driver.go
@@ -373,7 +373,7 @@ func newTransactor(
 	for _, b := range bindings {
 		t.bindings = append(t.bindings, &binding{
 			target:    b,
-			storeFile: newStagedFile(s3client, cfg.Bucket, cfg.BucketPath, b.Columns()),
+			storeFile: newStagedFile(s3client, cfg.Bucket, cfg.BucketPath, b.ColumnNames()),
 		})
 	}
 

--- a/materialize-redshift/driver.go
+++ b/materialize-redshift/driver.go
@@ -544,8 +544,8 @@ func (t *transactor) addBinding(
 ) error {
 	var b = &binding{
 		target:    target,
-		loadFile:  newStagedFile(client, t.cfg.Bucket, t.cfg.BucketPath, target.KeyPtrs()),
-		storeFile: newStagedFile(client, t.cfg.Bucket, t.cfg.BucketPath, target.Columns()),
+		loadFile:  newStagedFile(client, t.cfg.Bucket, t.cfg.BucketPath, target.KeyNames()),
+		storeFile: newStagedFile(client, t.cfg.Bucket, t.cfg.BucketPath, target.ColumnNames()),
 	}
 
 	// Render templates that require specific S3 "COPY INTO" parameters.

--- a/materialize-redshift/staged_file.go
+++ b/materialize-redshift/staged_file.go
@@ -40,7 +40,7 @@ const (
 // be used by Redshift to load all of the files stored for the current transaction. Returns a
 // function that will delete all stored files, including the manifest file.
 type stagedFile struct {
-	cols     []*sql.Column
+	fields   []string
 	client   *s3.Client
 	uploader *manager.Uploader
 
@@ -64,9 +64,9 @@ type stagedFile struct {
 	started bool
 }
 
-func newStagedFile(client *s3.Client, bucket string, bucketPath string, cols []*sql.Column) *stagedFile {
+func newStagedFile(client *s3.Client, bucket string, bucketPath string, fields []string) *stagedFile {
 	return &stagedFile{
-		cols:   cols,
+		fields: fields,
 		client: client,
 		uploader: manager.NewUploader(client, func(u *manager.Uploader) {
 			// The default concurrency is 5, which will potentially start up 5 separate goroutines
@@ -101,7 +101,7 @@ func (f *stagedFile) start() {
 func (f *stagedFile) newFile(ctx context.Context) {
 	r, w := io.Pipe()
 
-	f.encoder = sql.NewCountingEncoder(w)
+	f.encoder = sql.NewCountingEncoder(w, true, f.fields)
 
 	group, groupCtx := errgroup.WithContext(ctx)
 	f.group = group
@@ -141,22 +141,13 @@ func (f *stagedFile) flushFile() error {
 }
 
 func (f *stagedFile) encodeRow(ctx context.Context, row []interface{}) error {
-	if len(row) != len(f.cols) { // Sanity check
-		return fmt.Errorf("number of headers in row to encode (%d) differs from number of configured headers (%d)", len(row), len(f.cols))
-	}
-
-	d := make(map[string]interface{})
-	for idx := range row {
-		d[f.cols[idx].Field] = row[idx]
-	}
-
 	// May not have an encoder set yet if the previous encodeRow() resulted in flushing the current
 	// file, or for the very first call to encodeRow().
 	if f.encoder == nil {
 		f.newFile(ctx)
 	}
 
-	if err := f.encoder.Encode(d); err != nil {
+	if err := f.encoder.Encode(row); err != nil {
 		return fmt.Errorf("encoding row: %w", err)
 	}
 

--- a/materialize-snowflake/staged_file.go
+++ b/materialize-snowflake/staged_file.go
@@ -224,7 +224,7 @@ func (f *stagedFile) newFile() error {
 		buf:  bufio.NewWriter(file),
 		file: file,
 	}
-	f.encoder = sql.NewCountingEncoder(f.buf)
+	f.encoder = sql.NewCountingEncoder(f.buf, true, nil)
 	f.fileIdx += 1
 
 	return nil

--- a/materialize-sql/encoder.go
+++ b/materialize-sql/encoder.go
@@ -2,11 +2,11 @@ package sql
 
 import (
 	"compress/flate"
-	"compress/gzip"
 	"fmt"
 	"io"
 
 	"github.com/estuary/connectors/go/encrow"
+	"github.com/klauspost/compress/gzip"
 	"github.com/segmentio/encoding/json"
 )
 

--- a/materialize-sql/table_mapping.go
+++ b/materialize-sql/table_mapping.go
@@ -116,6 +116,27 @@ func (t *Table) KeyPtrs() []*Column {
 	return out
 }
 
+// KeyNames returns all key names of the Table as a single slice.
+func (t *Table) KeyNames() []string {
+	keys := t.KeyPtrs()
+	out := make([]string, 0, len(keys))
+	for _, c := range keys {
+		out = append(out, c.Field)
+	}
+	return out
+}
+
+// ColumnNames returns all column names of the Table as a single slice,
+// ordered as Keys, then Values, then the Document.
+func (t *Table) ColumnNames() []string {
+	cols := t.Columns()
+	out := make([]string, 0, len(cols))
+	for _, c := range cols {
+		out = append(out, c.Field)
+	}
+	return out
+}
+
 // ResolveTable maps a TableShape into a Table using the given Dialect.
 func ResolveTable(shape TableShape, dialect Dialect) (Table, error) {
 	var table = Table{

--- a/tests/materialize/materialize-redshift/snapshot.json
+++ b/tests/materialize/materialize-redshift/snapshot.json
@@ -645,6 +645,42 @@
       "num_and_str": 5.1,
       "num_str": 50.1,
       "time": "23:59:59Z"
+    },
+    {
+      "date": null,
+      "datetime": null,
+      "flow_document": "{\"_meta\":{\"uuid\":\"c02bd79a-20e1-11ee-990b-ffd12dfcd47f\"},\"id\":8,\"num_str\":\"NaN\"}",
+      "flow_published_at": "2023-07-12 18:27:25.889321 +0000 UTC",
+      "id": 8,
+      "int_and_str": null,
+      "int_str": null,
+      "num_and_str": null,
+      "num_str": null,
+      "time": null
+    },
+    {
+      "date": null,
+      "datetime": null,
+      "flow_document": "{\"_meta\":{\"uuid\":\"c02bd79a-20e1-11ee-990b-ffd12dfcd47f\"},\"id\":9,\"num_str\":\"Infinity\"}",
+      "flow_published_at": "2023-07-12 18:27:25.889321 +0000 UTC",
+      "id": 9,
+      "int_and_str": null,
+      "int_str": null,
+      "num_and_str": null,
+      "num_str": null,
+      "time": null
+    },
+    {
+      "date": null,
+      "datetime": null,
+      "flow_document": "{\"_meta\":{\"uuid\":\"c02bd79a-20e1-11ee-990b-ffd12dfcd47f\"},\"id\":10,\"num_str\":\"-Infinity\"}",
+      "flow_published_at": "2023-07-12 18:27:25.889321 +0000 UTC",
+      "id": 10,
+      "int_and_str": null,
+      "int_str": null,
+      "num_and_str": null,
+      "num_str": null,
+      "time": null
     }
   ]
 }


### PR DESCRIPTION
**Description:**

Use the optimized `encrow.Shape` for encoding JSON objects, and also optimizations for encoding an array of values for materializations that do that (currently only `materialize-snowflake`).

This is a significant performance improvement when examining _just_ the serialization aspect of the `CountingEncoder`, and shows a 3x improvement in speed of encoding objects, and a ~1.5x improvement for serializing value arrays.

The benchmark outputs below illustrate this, and were run with `compressionLevel = flate.NoCompression` to turn off compression in `CountingEncoder`. The original pre-change code was tested with a slightly modified version of the benchmark included in this PR for compatibility.

_New optimized code, with `compressionLevel = flate.NoCompression`:_
```
go test -v ./materialize-sql/ -bench=. -benchtime=5s -count=3
BenchmarkEncodingObjects
BenchmarkEncodingObjects-10         6801            895722 ns/op
BenchmarkEncodingObjects-10         6858            903788 ns/op
BenchmarkEncodingObjects-10         6705            896007 ns/op
BenchmarkEncodingArrays
BenchmarkEncodingArrays-10          7338            837367 ns/op
BenchmarkEncodingArrays-10          7232            842599 ns/op
BenchmarkEncodingArrays-10          7318            835675 ns/op
```

_Original code, also with `compressionLevel = flate.NoCompression`:_
```
go test -v ./materialize-sql/ -bench=. -benchtime=5s -count=3
BenchmarkEncodingObjects
BenchmarkEncodingObjects-10         2540           2357578 ns/op
BenchmarkEncodingObjects-10         2544           2372622 ns/op
BenchmarkEncodingObjects-10         2546           2386773 ns/op
BenchmarkEncodingArrays
BenchmarkEncodingArrays-10          4599           1305916 ns/op
BenchmarkEncodingArrays-10          4588           1300114 ns/op
BenchmarkEncodingArrays-10          4659           1302175 ns/op
```

Of course, materialization connectors do more than just JSON serialization, and the `CountingEncoder` abstraction also does compression at the `flate.BestSpeed` level. Running the benchmarks with compression enabled shows a lesser benefit, indicating that the work of compression is starting to overshadow the work of JSON serialization. With compression enabled, `CountingEncoder` is about 40% faster at encoding objects, and 15% faster at encoding value arrays with these changes. This is still a decent boost, and I'm hopeful it will provide a noticeable improvement, particularly for materializations handling really large documents or with huge numbers of fields.

_New optimized code, with compression enabled:_
```
go test -v ./materialize-sql/ -bench=. -benchtime=5s -count=3
BenchmarkEncodingObjects
BenchmarkEncodingObjects-10         1660           3500257 ns/op
BenchmarkEncodingObjects-10         1707           3517238 ns/op
BenchmarkEncodingObjects-10         1700           3511234 ns/op
BenchmarkEncodingArrays
BenchmarkEncodingArrays-10          1582           3780298 ns/op
BenchmarkEncodingArrays-10          1580           3783878 ns/op
BenchmarkEncodingArrays-10          1569           3794444 ns/op
```

_Original code, with compression enabled:_
```
go test -v ./materialize-sql/ -bench=. -benchtime=5s -count=3
BenchmarkEncodingObjects
BenchmarkEncodingObjects-10         1213           4960839 ns/op
BenchmarkEncodingObjects-10         1204           4974379 ns/op
BenchmarkEncodingObjects-10         1168           5024522 ns/op
BenchmarkEncodingArrays
BenchmarkEncodingArrays-10          1393           4324955 ns/op
BenchmarkEncodingArrays-10          1407           4342299 ns/op
BenchmarkEncodingArrays-10          1386           4333667 ns/op
```


**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

This was tested using the integration tests for `materialize-bigquery`, `materialize-redshift`, and `materialize-snowflake`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1066)
<!-- Reviewable:end -->
