### PR TITLE
fix: Resource config schemas need a `type`

### DIFF
--- a/python/flow_sdk/shim_airbyte_cdk.py
+++ b/python/flow_sdk/shim_airbyte_cdk.py
@@ -244,7 +244,7 @@ resource_config_schema = {
     "type": "object",
     "properties": {
         "stream": {"type": "string"},
-        "syncMode": {"enum": ["incremental", "full_refresh"]},
+        "syncMode": {"type": "string", "enum": ["incremental", "full_refresh"]},
         "namespace": {"type": "string"},
         "cursorField": {
             "type": "array",

--- a/python/flow_sdk/shim_singer_sdk.py
+++ b/python/flow_sdk/shim_singer_sdk.py
@@ -225,7 +225,7 @@ resource_config_schema = {
     "type": "object",
     "properties": {
         "stream": {"type": "string"},
-        "syncMode": {"enum": ["incremental", "full_refresh"]},
+        "syncMode": {"type": "string", "enum": ["incremental", "full_refresh"]},
         "namespace": {"type": "string"},
         "cursorField": {
             "type": "array",


### PR DESCRIPTION
**Description:**

The resource config schemas generated by these connectors seem to be invalid according to the UI. I believe this should fix it
![Screen Shot 2023-11-10 at 11 38 15](https://github.com/estuary/connectors/assets/4368270/f9a8d236-e6c8-4e31-97ce-6a7fd55dc0a7)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1067)
<!-- Reviewable:end -->
