### PR TITLE
source-mysql: Support column renaming and repositioning in `ALTER TABLE` queries

### DIFF
--- a/source-mysql/.snapshots/TestAlterTable_ChangeColumn-capture1
+++ b/source-mysql/.snapshots/TestAlterTable_ChangeColumn-capture1
@@ -1,0 +1,10 @@
+# ================================
+# Collection "acmeCo/test/test_altertable_changecolumn_27484562": 2 Documents
+# ================================
+{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"AlterTable_ChangeColumn_27484562","cursor":"binlog.000123:56789:123","txid":"11111111-1111-1111-1111-111111111111:111"}},"data":"ccc","id":3}
+{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"AlterTable_ChangeColumn_27484562","cursor":"binlog.000123:56789:123","txid":"11111111-1111-1111-1111-111111111111:111"}},"data_two":"ddd","id":4}
+# ================================
+# Final State Checkpoint
+# ================================
+{"cursor":"binlog.000123:56789","streams":{"test.altertable_changecolumn_27484562":{"backfilled":2,"key_columns":["id"],"metadata":{"schema":{"columns":["id","data_two"],"types":{"data_two":"varchar","id":"int"}}},"mode":"Active"}}}
+

--- a/source-mysql/.snapshots/TestAlterTable_ChangeColumn-capture2
+++ b/source-mysql/.snapshots/TestAlterTable_ChangeColumn-capture2
@@ -1,0 +1,10 @@
+# ================================
+# Collection "acmeCo/test/test_altertable_changecolumn_27484562": 2 Documents
+# ================================
+{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"AlterTable_ChangeColumn_27484562","cursor":"binlog.000123:56789:123","txid":"11111111-1111-1111-1111-111111111111:111"}},"data_three":"fff","id":6}
+{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"AlterTable_ChangeColumn_27484562","cursor":"binlog.000123:56789:123","txid":"11111111-1111-1111-1111-111111111111:111"}},"data_two":"eee","id":5}
+# ================================
+# Final State Checkpoint
+# ================================
+{"cursor":"binlog.000123:56789","streams":{"test.altertable_changecolumn_27484562":{"backfilled":2,"key_columns":["id"],"metadata":{"schema":{"columns":["data_three","id"],"types":{"data_three":"varchar","id":"int"}}},"mode":"Active"}}}
+

--- a/source-mysql/.snapshots/TestAlterTable_ChangeColumn-capture3
+++ b/source-mysql/.snapshots/TestAlterTable_ChangeColumn-capture3
@@ -1,0 +1,10 @@
+# ================================
+# Collection "acmeCo/test/test_altertable_changecolumn_27484562": 2 Documents
+# ================================
+{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"AlterTable_ChangeColumn_27484562","cursor":"binlog.000123:56789:123","txid":"11111111-1111-1111-1111-111111111111:111"}},"data":"hhh","id":8}
+{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"AlterTable_ChangeColumn_27484562","cursor":"binlog.000123:56789:123","txid":"11111111-1111-1111-1111-111111111111:111"}},"data_three":"ggg","id":7}
+# ================================
+# Final State Checkpoint
+# ================================
+{"cursor":"binlog.000123:56789","streams":{"test.altertable_changecolumn_27484562":{"backfilled":2,"key_columns":["id"],"metadata":{"schema":{"columns":["id","data"],"types":{"data":"text","id":"int"}}},"mode":"Active"}}}
+

--- a/source-mysql/.snapshots/TestAlterTable_ChangeColumn-init
+++ b/source-mysql/.snapshots/TestAlterTable_ChangeColumn-init
@@ -1,0 +1,10 @@
+# ================================
+# Collection "acmeCo/test/test_altertable_changecolumn_27484562": 2 Documents
+# ================================
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"AlterTable_ChangeColumn_27484562","cursor":"backfill:0"}},"data":"aaa","id":1}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"AlterTable_ChangeColumn_27484562","cursor":"backfill:1"}},"data":"bbb","id":2}
+# ================================
+# Final State Checkpoint
+# ================================
+{"cursor":"binlog.000123:56789","streams":{"test.altertable_changecolumn_27484562":{"backfilled":2,"key_columns":["id"],"metadata":{"schema":{"columns":["id","data"],"types":{"data":"text","id":"int"}}},"mode":"Active"}}}
+

--- a/source-mysql/.snapshots/TestAlterTable_ModifyColumn-capture1
+++ b/source-mysql/.snapshots/TestAlterTable_ModifyColumn-capture1
@@ -1,0 +1,10 @@
+# ================================
+# Collection "acmeCo/test/test_altertable_modifycolumn_13419621": 2 Documents
+# ================================
+{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"AlterTable_ModifyColumn_13419621","cursor":"binlog.000123:56789:123","txid":"11111111-1111-1111-1111-111111111111:111"}},"data":"ccc","id":3,"tag":"C"}
+{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"AlterTable_ModifyColumn_13419621","cursor":"binlog.000123:56789:123","txid":"11111111-1111-1111-1111-111111111111:111"}},"data":"ddd","id":4,"tag":"D"}
+# ================================
+# Final State Checkpoint
+# ================================
+{"cursor":"binlog.000123:56789","streams":{"test.altertable_modifycolumn_13419621":{"backfilled":2,"key_columns":["id"],"metadata":{"schema":{"columns":["id","tag","data"],"types":{"data":"text","id":"int","tag":"varchar"}}},"mode":"Active"}}}
+

--- a/source-mysql/.snapshots/TestAlterTable_ModifyColumn-capture2
+++ b/source-mysql/.snapshots/TestAlterTable_ModifyColumn-capture2
@@ -1,0 +1,10 @@
+# ================================
+# Collection "acmeCo/test/test_altertable_modifycolumn_13419621": 2 Documents
+# ================================
+{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"AlterTable_ModifyColumn_13419621","cursor":"binlog.000123:56789:123","txid":"11111111-1111-1111-1111-111111111111:111"}},"data":"eee","id":5,"tag":"E"}
+{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"AlterTable_ModifyColumn_13419621","cursor":"binlog.000123:56789:123","txid":"11111111-1111-1111-1111-111111111111:111"}},"data":"fff","id":6,"tag":"F"}
+# ================================
+# Final State Checkpoint
+# ================================
+{"cursor":"binlog.000123:56789","streams":{"test.altertable_modifycolumn_13419621":{"backfilled":2,"key_columns":["id"],"metadata":{"schema":{"columns":["tag","id","data"],"types":{"data":"text","id":"int","tag":"varchar"}}},"mode":"Active"}}}
+

--- a/source-mysql/.snapshots/TestAlterTable_ModifyColumn-capture3
+++ b/source-mysql/.snapshots/TestAlterTable_ModifyColumn-capture3
@@ -1,0 +1,10 @@
+# ================================
+# Collection "acmeCo/test/test_altertable_modifycolumn_13419621": 2 Documents
+# ================================
+{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"AlterTable_ModifyColumn_13419621","cursor":"binlog.000123:56789:123","txid":"11111111-1111-1111-1111-111111111111:111"}},"data":"ggg","id":7,"tag":"G"}
+{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"AlterTable_ModifyColumn_13419621","cursor":"binlog.000123:56789:123","txid":"11111111-1111-1111-1111-111111111111:111"}},"data":"hhh","id":8,"tag":"H"}
+# ================================
+# Final State Checkpoint
+# ================================
+{"cursor":"binlog.000123:56789","streams":{"test.altertable_modifycolumn_13419621":{"backfilled":2,"key_columns":["id"],"metadata":{"schema":{"columns":["id","data","tag"],"types":{"data":"text","id":"int","tag":"text"}}},"mode":"Active"}}}
+

--- a/source-mysql/.snapshots/TestAlterTable_ModifyColumn-capture4
+++ b/source-mysql/.snapshots/TestAlterTable_ModifyColumn-capture4
@@ -1,0 +1,10 @@
+# ================================
+# Collection "acmeCo/test/test_altertable_modifycolumn_13419621": 2 Documents
+# ================================
+{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"AlterTable_ModifyColumn_13419621","cursor":"binlog.000123:56789:123","txid":"11111111-1111-1111-1111-111111111111:111"}},"data":"iii","id":9,"tag":"I"}
+{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"AlterTable_ModifyColumn_13419621","cursor":"binlog.000123:56789:123","txid":"11111111-1111-1111-1111-111111111111:111"}},"data":"jjj","id":10,"tag":"J"}
+# ================================
+# Final State Checkpoint
+# ================================
+{"cursor":"binlog.000123:56789","streams":{"test.altertable_modifycolumn_13419621":{"backfilled":2,"key_columns":["id"],"metadata":{"schema":{"columns":["id","tag","data"],"types":{"data":"text","id":"int","tag":"text"}}},"mode":"Active"}}}
+

--- a/source-mysql/.snapshots/TestAlterTable_ModifyColumn-init
+++ b/source-mysql/.snapshots/TestAlterTable_ModifyColumn-init
@@ -1,0 +1,10 @@
+# ================================
+# Collection "acmeCo/test/test_altertable_modifycolumn_13419621": 2 Documents
+# ================================
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"AlterTable_ModifyColumn_13419621","cursor":"backfill:0"}},"data":"aaa","id":1,"tag":"A"}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"AlterTable_ModifyColumn_13419621","cursor":"backfill:1"}},"data":"bbb","id":2,"tag":"B"}
+# ================================
+# Final State Checkpoint
+# ================================
+{"cursor":"binlog.000123:56789","streams":{"test.altertable_modifycolumn_13419621":{"backfilled":2,"key_columns":["id"],"metadata":{"schema":{"columns":["id","tag","data"],"types":{"data":"text","id":"int","tag":"text"}}},"mode":"Active"}}}
+

--- a/source-mysql/.snapshots/TestAlterTable_RenameColumn-capture1
+++ b/source-mysql/.snapshots/TestAlterTable_RenameColumn-capture1
@@ -1,0 +1,10 @@
+# ================================
+# Collection "acmeCo/test/test_altertable_renamecolumn_73330825": 2 Documents
+# ================================
+{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"AlterTable_RenameColumn_73330825","cursor":"binlog.000123:56789:123","txid":"11111111-1111-1111-1111-111111111111:111"}},"data":"ccc","id":3}
+{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"AlterTable_RenameColumn_73330825","cursor":"binlog.000123:56789:123","txid":"11111111-1111-1111-1111-111111111111:111"}},"data_two":"ddd","id":4}
+# ================================
+# Final State Checkpoint
+# ================================
+{"cursor":"binlog.000123:56789","streams":{"test.altertable_renamecolumn_73330825":{"backfilled":2,"key_columns":["id"],"metadata":{"schema":{"columns":["id","data_two"],"types":{"data_two":"text","id":"int"}}},"mode":"Active"}}}
+

--- a/source-mysql/.snapshots/TestAlterTable_RenameColumn-capture2
+++ b/source-mysql/.snapshots/TestAlterTable_RenameColumn-capture2
@@ -1,0 +1,10 @@
+# ================================
+# Collection "acmeCo/test/test_altertable_renamecolumn_73330825": 2 Documents
+# ================================
+{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"AlterTable_RenameColumn_73330825","cursor":"binlog.000123:56789:123","txid":"11111111-1111-1111-1111-111111111111:111"}},"data":"fff","id":6}
+{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"AlterTable_RenameColumn_73330825","cursor":"binlog.000123:56789:123","txid":"11111111-1111-1111-1111-111111111111:111"}},"data_two":"eee","id":5}
+# ================================
+# Final State Checkpoint
+# ================================
+{"cursor":"binlog.000123:56789","streams":{"test.altertable_renamecolumn_73330825":{"backfilled":2,"key_columns":["id"],"metadata":{"schema":{"columns":["id","data"],"types":{"data":"text","id":"int"}}},"mode":"Active"}}}
+

--- a/source-mysql/.snapshots/TestAlterTable_RenameColumn-init
+++ b/source-mysql/.snapshots/TestAlterTable_RenameColumn-init
@@ -1,0 +1,10 @@
+# ================================
+# Collection "acmeCo/test/test_altertable_renamecolumn_73330825": 2 Documents
+# ================================
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"AlterTable_RenameColumn_73330825","cursor":"backfill:0"}},"data":"aaa","id":1}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"AlterTable_RenameColumn_73330825","cursor":"backfill:1"}},"data":"bbb","id":2}
+# ================================
+# Final State Checkpoint
+# ================================
+{"cursor":"binlog.000123:56789","streams":{"test.altertable_renamecolumn_73330825":{"backfilled":2,"key_columns":["id"],"metadata":{"schema":{"columns":["id","data"],"types":{"data":"text","id":"int"}}},"mode":"Active"}}}
+

--- a/source-mysql/.snapshots/TestAlterTable_Unsupported-capture2-fails
+++ b/source-mysql/.snapshots/TestAlterTable_Unsupported-capture2-fails
@@ -1,9 +1,10 @@
 # ================================
+# Collection "acmeCo/test/test_altertable_unsupported_28221107": 2 Documents
+# ================================
+{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"AlterTable_Unsupported_28221107","cursor":"binlog.000123:56789:123","txid":"11111111-1111-1111-1111-111111111111:111"}},"data2":30,"id":3}
+{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"AlterTable_Unsupported_28221107","cursor":"binlog.000123:56789:123","txid":"11111111-1111-1111-1111-111111111111:111"}},"data2":40,"id":4}
+# ================================
 # Final State Checkpoint
 # ================================
-{"cursor":"binlog.000123:56789","streams":{"test.altertable_unsupported_17220185":{"backfilled":2,"key_columns":["id"],"metadata":{"schema":{"columns":["id","data"],"types":{"data":"text","id":"int"}}},"mode":"Active"},"test.altertable_unsupported_28221107":{"backfilled":0,"key_columns":["id"],"metadata":{"schema":{"columns":["id","data"],"types":{"data":"text","id":"int"}}},"mode":"Active"}}}
-# ================================
-# Captures Terminated With Errors
-# ================================
-error processing query event: unsupported query "ALTER TABLE test.AlterTable_Unsupported_28221107 CHANGE COLUMN data data2 INTEGER": cannot currently process column renaming
+{"cursor":"binlog.000123:56789","streams":{"test.altertable_unsupported_17220185":{"backfilled":2,"key_columns":["id"],"metadata":{"schema":{"columns":["id","data"],"types":{"data":"text","id":"int"}}},"mode":"Active"},"test.altertable_unsupported_28221107":{"backfilled":0,"key_columns":["id"],"metadata":{"schema":{"columns":["id","data2"],"types":{"data2":"integer","id":"int"}}},"mode":"Active"}}}
 

--- a/source-mysql/.snapshots/TestAlterTable_Unsupported-capture3-fails
+++ b/source-mysql/.snapshots/TestAlterTable_Unsupported-capture3-fails
@@ -1,9 +1,5 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"cursor":"binlog.000123:56789","streams":{"test.altertable_unsupported_17220185":{"backfilled":2,"key_columns":["id"],"metadata":{"schema":{"columns":["id","data"],"types":{"data":"text","id":"int"}}},"mode":"Active"},"test.altertable_unsupported_28221107":{"backfilled":0,"key_columns":["id"],"metadata":{"schema":{"columns":["id","data"],"types":{"data":"text","id":"int"}}},"mode":"Active"}}}
-# ================================
-# Captures Terminated With Errors
-# ================================
-error processing query event: unsupported query "ALTER TABLE test.AlterTable_Unsupported_28221107 CHANGE COLUMN data data2 INTEGER": cannot currently process column renaming
+{"cursor":"binlog.000123:56789","streams":{"test.altertable_unsupported_17220185":{"backfilled":2,"key_columns":["id"],"metadata":{"schema":{"columns":["id","data"],"types":{"data":"text","id":"int"}}},"mode":"Active"},"test.altertable_unsupported_28221107":{"backfilled":0,"key_columns":["id"],"metadata":{"schema":{"columns":["id","data2"],"types":{"data2":"integer","id":"int"}}},"mode":"Active"}}}
 

--- a/source-mysql/.snapshots/TestAlterTable_Unsupported-capture4
+++ b/source-mysql/.snapshots/TestAlterTable_Unsupported-capture4
@@ -1,5 +1,5 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"cursor":"binlog.000123:56789","streams":{"test.altertable_unsupported_17220185":{"backfilled":2,"key_columns":["id"],"metadata":{"schema":{"columns":["id","data"],"types":{"data":"text","id":"int"}}},"mode":"Active"},"test.altertable_unsupported_28221107":{"backfilled":0,"metadata":{"schema":{"columns":["id","data"],"types":{"data":"text","id":"int"}}},"mode":"Ignore"}}}
+{"cursor":"binlog.000123:56789","streams":{"test.altertable_unsupported_17220185":{"backfilled":2,"key_columns":["id"],"metadata":{"schema":{"columns":["id","data"],"types":{"data":"text","id":"int"}}},"mode":"Active"},"test.altertable_unsupported_28221107":{"backfilled":0,"metadata":{"schema":{"columns":["id","data2"],"types":{"data2":"integer","id":"int"}}},"mode":"Ignore"}}}
 

--- a/source-mysql/.snapshots/TestAlterTable_Unsupported-capture5
+++ b/source-mysql/.snapshots/TestAlterTable_Unsupported-capture5
@@ -6,5 +6,5 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"cursor":"binlog.000123:56789","streams":{"test.altertable_unsupported_17220185":{"backfilled":2,"key_columns":["id"],"metadata":{"schema":{"columns":["id","data"],"types":{"data":"text","id":"int"}}},"mode":"Active"},"test.altertable_unsupported_28221107":{"backfilled":2,"key_columns":["id"],"metadata":{"schema":{"columns":["id","data2"],"types":{"data":"text","data2":"int","id":"int"}}},"mode":"Active"}}}
+{"cursor":"binlog.000123:56789","streams":{"test.altertable_unsupported_17220185":{"backfilled":2,"key_columns":["id"],"metadata":{"schema":{"columns":["id","data"],"types":{"data":"text","id":"int"}}},"mode":"Active"},"test.altertable_unsupported_28221107":{"backfilled":2,"key_columns":["id"],"metadata":{"schema":{"columns":["id","data2"],"types":{"data2":"int","id":"int"}}},"mode":"Active"}}}
 

--- a/source-mysql/.snapshots/TestAlterTable_Unsupported-capture6
+++ b/source-mysql/.snapshots/TestAlterTable_Unsupported-capture6
@@ -6,5 +6,5 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"cursor":"binlog.000123:56789","streams":{"test.altertable_unsupported_17220185":{"backfilled":2,"key_columns":["id"],"metadata":{"schema":{"columns":["id","data"],"types":{"data":"text","id":"int"}}},"mode":"Active"},"test.altertable_unsupported_28221107":{"backfilled":2,"key_columns":["id"],"metadata":{"schema":{"columns":["id","data2"],"types":{"data":"text","data2":"int","id":"int"}}},"mode":"Active"},"test.altertable_unsupported_31129906":{"backfilled":2,"key_columns":["id"],"metadata":{"schema":{"columns":["id","data3"],"types":{"data3":"tinyint","id":"int"}}},"mode":"Active"}}}
+{"cursor":"binlog.000123:56789","streams":{"test.altertable_unsupported_17220185":{"backfilled":2,"key_columns":["id"],"metadata":{"schema":{"columns":["id","data"],"types":{"data":"text","id":"int"}}},"mode":"Active"},"test.altertable_unsupported_28221107":{"backfilled":2,"key_columns":["id"],"metadata":{"schema":{"columns":["id","data2"],"types":{"data2":"int","id":"int"}}},"mode":"Active"},"test.altertable_unsupported_31129906":{"backfilled":2,"key_columns":["id"],"metadata":{"schema":{"columns":["id","data3"],"types":{"data3":"tinyint","id":"int"}}},"mode":"Active"}}}
 


### PR DESCRIPTION
**Description:**

Adds (full) support for the `CHANGE COLUMN`, `MODIFY COLUMN`, and `RENAME COLUMN` clauses in an `ALTER TABLE` query, as well as some additional test cases verifying that these work as intended.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1069)
<!-- Reviewable:end -->
