### PR TITLE
materialize-{bigquery,redshift,snowflake}: add INFO level logs for jobs

### DIFF
--- a/materialize-redshift/driver.go
+++ b/materialize-redshift/driver.go
@@ -930,16 +930,20 @@ func (d *transactor) commit(ctx context.Context, fenceUpdate string, hasUpdates 
 				return fmt.Errorf("creating store table: %w", err)
 			}
 
+			log.WithField("table", b.target.Identifier).Info("store: starting merging data into table")
 			if _, err := txn.Exec(ctx, b.copyIntoMergeTableSQL); err != nil {
 				return handleCopyIntoErr(ctx, txn, d.cfg.Bucket, b.storeFile.prefix, b.target.Identifier, err)
 			} else if _, err := txn.Exec(ctx, b.mergeIntoSQL); err != nil {
 				return fmt.Errorf("merging to table '%s': %w", b.target.Identifier, err)
 			}
+			log.WithField("table", b.target.Identifier).Info("store: finished merging data into table")
 		} else {
+			log.WithField("table", b.target.Identifier).Info("store: starting direct copying data into table")
 			// Can copy directly into the target table since all values are new.
 			if _, err := txn.Exec(ctx, b.copyIntoTargetTableSQL); err != nil {
 				return handleCopyIntoErr(ctx, txn, d.cfg.Bucket, b.storeFile.prefix, b.target.Identifier, err)
 			}
+			log.WithField("table", b.target.Identifier).Info("store: finishing direct copying data into table")
 		}
 	}
 


### PR DESCRIPTION
**Description:**

- add info level logging at boundary of different sections of long-running jobs in bigquery, redshift and snowflake to help us troubleshoot issues when they arise

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1072)
<!-- Reviewable:end -->
