### PR TITLE
source-http-ingest: return resource_path in discovered for real

### DIFF
--- a/source-http-ingest/src/lib.rs
+++ b/source-http-ingest/src/lib.rs
@@ -285,11 +285,12 @@ pub async fn write_capture_response(
 }
 
 fn discovered_webhook_collection() -> DiscoveredBinding {
+    let resource_config = ResourceConfig::default();
     DiscoveredBinding {
         disable: false,
-        resource_path: vec![], // TODO: fixme
+        resource_path: resource_config.resource_path(),
         recommended_name: "webhook-data".to_string(),
-        resource_config_json: serde_json::to_string(&ResourceConfig::default()).unwrap(),
+        resource_config_json: serde_json::to_string(&resource_config).unwrap(),
         document_schema_json: serde_json::to_string(&serde_json::json!({
             "type": "object",
             "x-infer-schema": true,

--- a/source-http-ingest/tests/snapshots/test__discover.snap
+++ b/source-http-ingest/tests/snapshots/test__discover.snap
@@ -47,8 +47,12 @@ expression: result
         "recommendedName": "webhook-data",
         "resourceConfig": {
           "idFromHeader": null,
-          "path": null
-        }
+          "path": null,
+          "stream": null
+        },
+        "resourcePath": [
+          "webhook-data"
+        ]
       }
     ]
   }


### PR DESCRIPTION
**Description:**

Apparently _someone_ committed a TODO instead of actually returning the resource path as part of discover. It's fixed now.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1075)
<!-- Reviewable:end -->
