### PR TITLE
Update Singer shim to emit state checkpoints

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -28,6 +28,9 @@ A Python connector is composed of a few critical pieces:
   ).main()
   ```
 
+### Requirements
+In order to build python connectors, you will need to install [Poetry](https://python-poetry.org/docs/#installation).
+
 ## Pulling an open-source connector in tree
 While using existing builds of open-source connectors is all well and good, there will come a time in every connector's life that we need to make changes to it. Before deciding to pull a connector in-tree, first make sure that the version of the connector you're going to pull is licensed to allow this usage, and that you have its location in the origin repository. Then, the connector can be imported like so
 

--- a/python/flow_sdk/shim_singer_sdk.py
+++ b/python/flow_sdk/shim_singer_sdk.py
@@ -181,6 +181,18 @@ class CaptureShim(Connector):
             elif message.type == singer.SingerMessageType.STATE:
                 state = t.cast(singer.StateMessage, message)
                 logger.debug("stream state", state)
+                # The Meltano SDK manages any stream-specific state for us.
+                # See their docs on this here: https://sdk.meltano.com/en/latest/implementation/state.html
+                emit(
+                    Response(
+                        checkpoint=response.Checkpoint(
+                            state=flow.ConnectorState(
+                                updated=state.to_dict(),
+                                mergePatch=False
+                            )
+                        )
+                    )
+                )
             else:
                 raise RuntimeError("unexpected singer_sdk Message", message)
 
@@ -212,7 +224,9 @@ class CaptureShim(Connector):
                 )
                 continue
 
+            delegate.logger.info("Syncing stream '%s'.", stream.name)
             stream.sync()
+            # This is where we tell the Meltano SDK to do any final state emits if neccesary
             stream.finalize_state_progress_markers()
 
         # this second loop is needed for all streams to print out their costs

--- a/source-criteo/source_criteo/tap_criteo/schemas/v2020.07/campaign.json
+++ b/source-criteo/source_criteo/tap_criteo/schemas/v2020.07/campaign.json
@@ -16,12 +16,7 @@
       "type": "array",
       "items": {
         "$id": "#/properties/categories/items",
-        "anyOf": [
-          {
-            "$id": "#/properties/categories/items/anyOf/0",
-            "type": "integer"
-          }
-        ]
+        "type": "integer"
       }
     },
     "budgetId": {

--- a/source-criteo/source_criteo/tap_criteo/streams/reports.py
+++ b/source-criteo/source_criteo/tap_criteo/streams/reports.py
@@ -39,7 +39,7 @@ analytics_type_mappings = {
     "Clicks": {"type": "integer"},
     "Displays": {"type": "integer"},
     "Visits": {"type": "integer"},
-    "AdvertiserCost": {"type": "number"},
+    "AdvertiserCost": {"type": ["number", "string"], "format": "number"},
     "SalesClientAttribution": {"type": "integer"},
     "SalesAllClientAttribution": {"type": "integer"},
     "SalesPc30d": {"type": "integer"},

--- a/source-criteo/source_criteo/tap_criteo/tap.py
+++ b/source-criteo/source_criteo/tap_criteo/tap.py
@@ -33,8 +33,8 @@ class TapCriteo(Tap):
     name = "tap-criteo"
 
     config_jsonschema = th.PropertiesList(
-        th.Property("client_id", th.StringType, required=True),
-        th.Property("client_secret", th.StringType, required=True),
+        th.Property("client_id", th.StringType, required=True, secret=True),
+        th.Property("client_secret", th.StringType, required=True, secret=True),
         th.Property("advertiser_ids", th.ArrayType(th.StringType), required=True),
         th.Property("start_date", th.DateTimeType, required=True),
         th.Property(

--- a/source-shopify/connector_config.yaml
+++ b/source-shopify/connector_config.yaml
@@ -1,8 +1,8 @@
-authentication:
+credentials:
     auth_type: oauth
-    client_id_sops: ENC[AES256_GCM,data:Dz4Qy8X2xpnkCgM8Ewr0RyPRj1kMEJxnuiNjH11s5RI=,iv:iU1gO2hVVW7rSm1Xa1B1PXU3Xqtrui/sifUPxFj1Rss=,tag:M89jBnWBrCmbwjObHlHLlQ==,type:str]
-    client_secret_sops: ENC[AES256_GCM,data:5RUqkJsI86uWLwPklvRFsvR8l91nYFYXCL+GgJrwg0s=,iv:Qpim/W39Z0GTKj6BG02iqDGGwhOtEyzXlaj0Yf+BR3A=,tag:LvC+sxiVP9V+EgnwZ/Bd+g==,type:str]
-    access_token_sops: ENC[AES256_GCM,data:uVjw8ht1bBLVUV4qoeXa4n+trIzX2884+I3VFOej2QTBZV3GlVM=,iv:pYFevosDigVVus2b0s5wJTRoo0JyP/jvxiz5dBivLWk=,tag:lfXde+QOun5w6PEnkmL4Aw==,type:str]
+    client_id_sops: ENC[AES256_GCM,data:th4bA5vmEOeij1OdYBO+KgL7YnpBOQOT4KR4E5t+NxA=,iv:8ETc1D93AvAcoYbjqog4CTvq51znj1dF8hG4DRwfMnk=,tag:tBOQ24wIYyucWhX5fsR65A==,type:str]
+    client_secret_sops: ENC[AES256_GCM,data:40lB5n+kfple9tQOiNkvCQTa4VzeKq6Y21F11YVWj6c=,iv:5NNEL56+Hs8S5Y4dRoaa8zygrcCTH0ppbTuQEzKESms=,tag:+fOcS0m6Ii4M7J6SEaDumg==,type:str]
+    access_token_sops: ENC[AES256_GCM,data:sgQspKJjwgzJGJFCEe9qJKrqmGtexNjXx6HKsZ40RZYTs9ZE1g8=,iv:nqWGZquM6nM0/7H+QX08G4N00v2e03J6GXNGajNlSVE=,tag:QnAUNo47EWl12lEb7g6tCQ==,type:str]
 store: estuary-testing-1
 sops:
     kms: []
@@ -13,8 +13,8 @@ sops:
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2023-11-09T18:24:17Z"
-    mac: ENC[AES256_GCM,data:6Lzdo9tvfvCYhSaAdY+clBOw7xYff+34a+7XcfgRCFswGBKMybY4zkzGU/6S4ucj4kTv+WbKswDSYtritypu4ngYiJCrUjSpWljagSAfspa7p2YAIMOYjr2WH1vPsYsSMP4VILx/cbYsoUvvXLOB4X7mSV+sKGB4dEtV1Ex7DO8=,iv:L36KEQyzCIPopPW7Tpc8H6VPddvQZO2Ikl/APAhrdvs=,tag:O8x7owWQvMqi8iIDB1hsAQ==,type:str]
+    lastmodified: "2023-11-15T22:16:10Z"
+    mac: ENC[AES256_GCM,data:+lMIjMuBGsrN6NGlKROjdbOMdRTeDtjdqqiibKezFw2/Hizm/s11N2M9pNu2E4zMUwwi7yOQUTYjtBXedVVJijuCmjkN/vGuikvxWUHkvyurWcfCmxNGRnt7uJKi1b4vSDgozxbVJeyw9LT9wzJlBAUm63EKSXssstW1JEF8yDA=,iv:a6mO2jNIZw5hpasIvTM3yadzfBI8kq4tVkHWTm0Uu0o=,tag:TnU+QkOSuN1rmauWd095Ag==,type:str]
     pgp: []
     encrypted_suffix: _sops
     version: 3.7.3

--- a/source-shopify/source_shopify/tap_shopify/client.py
+++ b/source-shopify/source_shopify/tap_shopify/client.py
@@ -35,7 +35,7 @@ class tap_shopifyStream(RESTStream):
         return tap_shopifyAuthenticator(
             self,
             key="X-Shopify-Access-Token",
-            value=str(self.config["authentication"]["access_token"]),
+            value=str(self.config["credentials"]["access_token"]),
             location="header",
         )
 

--- a/source-shopify/source_shopify/tap_shopify/tap.py
+++ b/source-shopify/source_shopify/tap_shopify/tap.py
@@ -44,44 +44,66 @@ class Tap_Shopify(Tap):
 
     config_jsonschema = th.PropertiesList(
         th.Property(
-            "authentication",
+            "credentials",
             th.CustomType(
                 {
-                    **th.DiscriminatedUnion(
-                        "auth_type", 
-                        oauth=th.PropertiesList(
-                            th.Property(
-                                "client_id",
-                                th.StringType,
-                                required=True,
-                                secret=True
-                            ),
-                            th.Property(
-                                "client_secret",
-                                th.StringType,
-                                required=True,
-                                secret=True
-                            ),
-                            th.Property(
-                                "access_token",
-                                th.StringType,
-                                required=True,
-                                secret=True
-                            )
-                        ),
-                        access_token=th.PropertiesList(
-                            th.Property(
-                                "access_token",
-                                th.StringType,
-                                required=True,
-                                description="The access token to authenticate with the Shopify API",
-                            ),
-                        )
-                    ).to_dict(),
                     "type": "object",
+                    "description": "Credentials for connecting to the Shopify API",
                     "discriminator": {
                         "propertyName": "auth_type"
-                    }
+                    },
+                    "oneOf": [
+                        {
+                            "type": "object",
+                            "title": "Shopify OAuth",
+                            "x-oauth2-provider": "shopify",
+                            "properties": {
+                                "auth_type": {
+                                    "type": "string",
+                                    "const": "oauth",
+                                    "description": "Discriminator for object of type 'oauth'."
+                                },
+                                "client_id": {
+                                    "type": "string",
+                                    "secret": True
+                                },
+                                "client_secret": {
+                                    "type": "string",
+                                    "secret": True
+                                },
+                                "access_token": {
+                                    "type": "string",
+                                    "secret": True
+                                }
+                            },
+                            "required": [
+                                "auth_type",
+                                "client_id",
+                                "client_secret",
+                                "access_token"
+                            ]
+                        },
+                        {
+                            "type": "object",
+                            "title": "Access Token",
+                            "properties": {
+                                "auth_type": {
+                                    "type": "string",
+                                    "const": "access_token",
+                                    "description": "Discriminator for object of type 'access_token'."
+                                },
+                                "access_token": {
+                                    "type": ["string"],
+                                    "description": "The access token to authenticate with the Shopify API",
+                                    "secret": True
+                                }
+                            },
+                            "required": [
+                                "auth_type",
+                                "access_token"
+                            ]
+                        }
+                    ]
                 },
             ),
             required=True
@@ -104,7 +126,8 @@ class Tap_Shopify(Tap):
             "admin_url",
             th.StringType,
             description=(
-                "The Admin url for your Shopify store " + "(overrides 'store' property)"
+                "The Admin url for your Shopify store " +
+                "(overrides 'store' property)"
             ),
         ),
         th.Property(


### PR DESCRIPTION
**Description:**

We don't have to do any multiplexing of stream-specific state for Singer as far as I can tell because the Meltano SDK manages mapping stream-specific into keys in the `"bookmarks"` state-key under the hood. All we have to do is persist the state values, and provide the latest state to the `Tap()` constructor when restarting.

Also update specs for `source-criteo` and `source-shopify` to make them work better in the UI

**Note:** Airbyte state is more complex and I'm still researching how to handle it, so this just covers Singer state for the moment.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1079)
<!-- Reviewable:end -->
