### PR TITLE
source-mongodb: do not set reduce: merge strategy for mongo collections

### DIFF
--- a/source-mongodb/.snapshots/TestDiscover
+++ b/source-mongodb/.snapshots/TestDiscover
@@ -29,14 +29,8 @@ Binding 0:
               "description": "Change operation type: 'c' Create/Insert 'u' Update 'd' Delete."
             }
           },
-          "type": "object",
-          "reduce": {
-            "strategy": "merge"
-          }
+          "type": "object"
         }
-      },
-      "reduce": {
-        "strategy": "merge"
       },
       "x-infer-schema": true
     },
@@ -79,14 +73,8 @@ Binding 1:
               "description": "Change operation type: 'c' Create/Insert 'u' Update 'd' Delete."
             }
           },
-          "type": "object",
-          "reduce": {
-            "strategy": "merge"
-          }
+          "type": "object"
         }
-      },
-      "reduce": {
-        "strategy": "merge"
       },
       "x-infer-schema": true
     },

--- a/source-mongodb/discovery.go
+++ b/source-mongodb/discovery.go
@@ -39,11 +39,6 @@ func generateMinimalSchema() json.RawMessage {
 	var metadataSchema = reflector.ReflectFromType(reflect.TypeOf(documentMetadata{}))
 	metadataSchema.Definitions = nil
 	metadataSchema.AdditionalProperties = nil
-	metadataSchema.Extras = map[string]interface{}{
-		"reduce": map[string]interface{}{
-			"strategy": "merge",
-		},
-	}
 
 	// Wrap metadata into an enclosing object schema with a /_meta property
 	var schema = &jsonschema.Schema{
@@ -58,9 +53,6 @@ func generateMinimalSchema() json.RawMessage {
 				metaProperty: metadataSchema,
 			},
 			"x-infer-schema": true,
-			"reduce": map[string]interface{}{
-				"strategy": "merge",
-			},
 		},
 	}
 


### PR DESCRIPTION
**Description:**

- we initially did this in order to be consistent in behaviour with our sql captures which emit the full document and `_meta/op: "d"`, however the reduction strategy is problematic when it comes to documents that have one of their columns removed in an update, however because of the reduction strategy they retain that column in the materialization. so we have decided to revert this change to just have mongodb emit a document with id and `_meta/op: "d"` that ends up clearing all other columns in the materialization
- Tested by running tests, and manually ran a test where I deleted a field from a document (using `$unset`) and in the materialization the column was set to null.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1081)
<!-- Reviewable:end -->
