### PR TITLE
update vitess dependency to fix source-mysql compilation error

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -64,7 +64,7 @@ require (
 	google.golang.org/genproto v0.0.0-20230913181813-007df8e322eb
 	google.golang.org/grpc v1.59.0
 	google.golang.org/protobuf v1.31.0
-	vitess.io/vitess v0.13.3
+	vitess.io/vitess v0.15.3
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -1574,3 +1574,5 @@ rsc.io/sampler v1.3.0/go.mod h1:T1hPZKmBbMNahiBKFy5HrXp6adAjACjK9JXDnKaTXpA=
 sigs.k8s.io/yaml v1.2.0/go.mod h1:yfXDCHCao9+ENCvLSE62v9VSji2MKu5jeNfTrofGhJc=
 vitess.io/vitess v0.13.3 h1:AJKQvoS7LE4whuePZq8WZ9H7M/LzEGIKCpuve+EjA9Q=
 vitess.io/vitess v0.13.3/go.mod h1:ZMLpsNhCdp0HrWMLtUrfOp/czjXrg0MmdmxYtSK8avc=
+vitess.io/vitess v0.15.3 h1:oUKxu7duyz2kYokQSH80psvWU1J3jhJbOYdSF7MMrRc=
+vitess.io/vitess v0.15.3/go.mod h1:s1C7K4tuiCFz3L+GnLFHx/2hrFY1Gyk57lXS5VAEr04=


### PR DESCRIPTION
The `vitess.io/vitess` dependency had been downgraded by commit 4ac67f38. That broke source-mysql due to a symbol that was removed. This bumps that dependency back up to the previous version.

