### PR TITLE
Phil/all resource path pointers

### DIFF
--- a/filesource/filesource.go
+++ b/filesource/filesource.go
@@ -170,6 +170,7 @@ func (src Source) Spec(ctx context.Context, req *pc.Request_Spec) (*pc.Response_
 		ResourceConfigSchemaJson: json.RawMessage(resourceSchema),
 		DocumentationUrl:         src.DocumentationURL,
 		Oauth2:                   src.Oauth2,
+		ResourcePathPointers:     []string{"/stream"},
 	}, nil
 }
 
@@ -223,7 +224,6 @@ func (src *Source) Discover(ctx context.Context, req *pc.Request_Discover) (*pc.
 		ResourceConfigJson: resourceJSON,
 		DocumentSchemaJson: json.RawMessage(minimalDocumentSchema),
 		Key:                []string{"/_meta/file", "/_meta/offset"},
-		ResourcePath:       []string{root},
 	}}}, nil
 }
 

--- a/python/flow_sdk/flow.py
+++ b/python/flow_sdk/flow.py
@@ -52,6 +52,7 @@ class Spec(t.TypedDict):
     resourceConfigSchema: dict
     documentationUrl: str
     oauth2: t.NotRequired[OAuth2]
+    resourcePathPointers: t.List[str]
 
 class ConnectorState(t.TypedDict):
     updated: dict

--- a/python/flow_sdk/shim_airbyte_cdk.py
+++ b/python/flow_sdk/shim_airbyte_cdk.py
@@ -46,6 +46,7 @@ class CaptureShim(Connector):
             "documentationUrl": f"{DOCS_URL if DOCS_URL else spec.documentationUrl}",
             "configSchema": spec.connectionSpecification,
             "resourceConfigSchema": resource_config_schema,
+            "resourcePathPointers": ["/stream", "/namespace"],
         }
 
         # TODO(johnny): Can we map spec.advanced_auth into flow.OAuth2 ?
@@ -105,18 +106,12 @@ class CaptureShim(Connector):
             if self.usesSchemaInference:
                 json_schema["x-infer-schema"] = True
 
-            if ns := config.get("namespace"):
-                resource_path = [ns, config["stream"]]
-            else:
-                resource_path = [config["stream"]]
-
             bindings.append(
                 response.DiscoveredBinding(
                     recommendedName=stream.name,
                     documentSchema=json_schema,
                     resourceConfig=t.cast(dict, config),
                     key=key,
-                    resourcePath=resource_path,
                 )
             )
 

--- a/python/flow_sdk/shim_singer_sdk.py
+++ b/python/flow_sdk/shim_singer_sdk.py
@@ -55,6 +55,7 @@ class CaptureShim(Connector):
             documentationUrl=DOCS_URL if DOCS_URL else "https://docs.estuary.dev",
             configSchema=self.config_schema,
             resourceConfigSchema=resource_config_schema,
+            resourcePathPointers: ["/stream"],
         )
 
         if self.oauth2:
@@ -107,7 +108,6 @@ class CaptureShim(Connector):
                     documentSchema=json_schema,
                     resourceConfig=resourceConfig,
                     key=key,
-                    resourcePath=[entry.tap_stream_id],
                 )
             )
 

--- a/source-alpaca/.snapshots/TestDiscover
+++ b/source-alpaca/.snapshots/TestDiscover
@@ -70,9 +70,6 @@ Binding 0:
       "/Symbol",
       "/Exchange",
       "/Timestamp"
-    ],
-    "resource_path": [
-      "iex"
     ]
   }
 

--- a/source-alpaca/.snapshots/TestSpec
+++ b/source-alpaca/.snapshots/TestSpec
@@ -102,5 +102,8 @@
     ],
     "title": "Resource"
   },
-  "documentation_url": "https://go.estuary.dev/source-alpaca"
+  "documentation_url": "https://go.estuary.dev/source-alpaca",
+  "resource_path_pointers": [
+    "/name"
+  ]
 }

--- a/source-alpaca/driver.go
+++ b/source-alpaca/driver.go
@@ -31,6 +31,7 @@ func (driver) Spec(ctx context.Context, req *pc.Request_Spec) (*pc.Response_Spec
 		ConfigSchemaJson:         json.RawMessage(endpointSchema),
 		ResourceConfigSchemaJson: json.RawMessage(resourceSchema),
 		DocumentationUrl:         "https://go.estuary.dev/source-alpaca",
+		ResourcePathPointers:     []string{"/name"},
 	}, nil
 }
 
@@ -95,7 +96,6 @@ func (driver) Discover(ctx context.Context, req *pc.Request_Discover) (*pc.Respo
 			ResourceConfigJson: resourceJSON,
 			DocumentSchemaJson: documentSchema,
 			Key:                []string{"/ID", "/Symbol", "/Exchange", "/Timestamp"},
-			ResourcePath:       []string{cfg.Feed},
 		}},
 	}, nil
 }

--- a/source-dynamodb/.snapshots/TestDiscovery-additional_table_without_stream_enabled
+++ b/source-dynamodb/.snapshots/TestDiscovery-additional_table_without_stream_enabled
@@ -91,9 +91,6 @@ Binding 0:
     },
     "key": [
       "/partitionKey"
-    ],
-    "resource_path": [
-      "discoverTable"
     ]
   }
 

--- a/source-dynamodb/.snapshots/TestDiscovery-multiple_tables_with_various_types
+++ b/source-dynamodb/.snapshots/TestDiscovery-multiple_tables_with_various_types
@@ -91,9 +91,6 @@ Binding 0:
     },
     "key": [
       "/partitionKey"
-    ],
-    "resource_path": [
-      "discoverTable"
     ]
   }
 Binding 1:
@@ -195,9 +192,6 @@ Binding 1:
     "key": [
       "/partitionKeyString",
       "/sortKeyNumber"
-    ],
-    "resource_path": [
-      "secondTable"
     ]
   }
 Binding 2:
@@ -300,9 +294,6 @@ Binding 2:
     "key": [
       "/partitionKeyBinary",
       "/sortKeyBinary"
-    ],
-    "resource_path": [
-      "thirdTable"
     ]
   }
 

--- a/source-dynamodb/.snapshots/TestDiscovery-single_table_with_a_partition_key
+++ b/source-dynamodb/.snapshots/TestDiscovery-single_table_with_a_partition_key
@@ -91,9 +91,6 @@ Binding 0:
     },
     "key": [
       "/partitionKey"
-    ],
-    "resource_path": [
-      "discoverTable"
     ]
   }
 

--- a/source-dynamodb/.snapshots/TestSpec
+++ b/source-dynamodb/.snapshots/TestSpec
@@ -75,5 +75,8 @@
     ],
     "title": "Resource"
   },
-  "documentation_url": "https://go.estuary.dev/source-dynamodb"
+  "documentation_url": "https://go.estuary.dev/source-dynamodb",
+  "resource_path_pointers": [
+    "/table"
+  ]
 }

--- a/source-dynamodb/discovery.go
+++ b/source-dynamodb/discovery.go
@@ -200,7 +200,6 @@ func (driver) Discover(ctx context.Context, req *pc.Request_Discover) (*pc.Respo
 			ResourceConfigJson: resourceJSON,
 			DocumentSchemaJson: rawSchema,
 			Key:                keyPtrs,
-			ResourcePath:       []string{table.name},
 		})
 
 	}

--- a/source-dynamodb/driver.go
+++ b/source-dynamodb/driver.go
@@ -29,6 +29,7 @@ func (driver) Spec(ctx context.Context, req *pc.Request_Spec) (*pc.Response_Spec
 		ConfigSchemaJson:         json.RawMessage(endpointSchema),
 		ResourceConfigSchemaJson: json.RawMessage(resourceSchema),
 		DocumentationUrl:         "https://go.estuary.dev/source-dynamodb",
+		ResourcePathPointers:     []string{"/table"},
 	}, nil
 }
 

--- a/source-firestore/.snapshots/TestDeletions-two
+++ b/source-firestore/.snapshots/TestDeletions-two
@@ -1,9 +1,4 @@
 # ================================
-# Collection "flow_source_tests/*/docs": 2 Documents
-# ================================
-{"_meta":{"path":"projects/project-id-123456/databases/(default)/documents/flow_source_tests/TestDeletions/docs/3","mtime":"<TIMESTAMP>","delete":true}}
-{"_meta":{"path":"projects/project-id-123456/databases/(default)/documents/flow_source_tests/TestDeletions/docs/4","mtime":"<TIMESTAMP>","delete":true}}
-# ================================
 # Final State Checkpoint
 # ================================
 {"Resources":{"flow_source_tests/*/docs":{"Backfill":{"Completed":true,"Cursor":"","MTime":"<TIMESTAMP>","StartAfter":"<TIMESTAMP>"},"ReadTime":"<TIMESTAMP>"}}}

--- a/source-firestore/.snapshots/TestSpec
+++ b/source-firestore/.snapshots/TestSpec
@@ -53,5 +53,8 @@
     ],
     "title": "Firestore Resource Spec"
   },
-  "documentation_url": "https://go.estuary.dev/source-firestore"
+  "documentation_url": "https://go.estuary.dev/source-firestore",
+  "resource_path_pointers": [
+    "/path"
+  ]
 }

--- a/source-firestore/discovery.go
+++ b/source-firestore/discovery.go
@@ -197,7 +197,6 @@ func discoverCollections(ctx context.Context, client *firestore.Client) ([]*pc.R
 			ResourceConfigJson: resourceJSON,
 			DocumentSchemaJson: minimalSchema,
 			Key:                []string{documentPath},
-			ResourcePath:       []string{resourcePath},
 		})
 	}
 

--- a/source-firestore/main.go
+++ b/source-firestore/main.go
@@ -77,6 +77,7 @@ func (driver) Spec(ctx context.Context, req *pc.Request_Spec) (*pc.Response_Spec
 		ConfigSchemaJson:         json.RawMessage(endpointSchema),
 		ResourceConfigSchemaJson: json.RawMessage(resourceSchema),
 		DocumentationUrl:         "https://go.estuary.dev/source-firestore",
+		ResourcePathPointers:     []string{"/path"},
 	}, nil
 }
 

--- a/source-hello-world/main.go
+++ b/source-hello-world/main.go
@@ -74,6 +74,7 @@ func (driver) Spec(ctx context.Context, req *pc.Request_Spec) (*pc.Response_Spec
 		ConfigSchemaJson:         json.RawMessage(endpointSchema),
 		ResourceConfigSchemaJson: json.RawMessage(resourceSchema),
 		DocumentationUrl:         "https://go.estuary.dev/source-hello-world",
+		ResourcePathPointers:     []string{"/name"},
 	}, nil
 }
 
@@ -115,7 +116,6 @@ func (driver) Discover(ctx context.Context, req *pc.Request_Discover) (*pc.Respo
 			ResourceConfigJson: resourceJSON,
 			DocumentSchemaJson: messageSchema,
 			Key:                []string{"/ts"},
-			ResourcePath:       []string{resourceName},
 		}},
 	}, nil
 }

--- a/source-kafka/Cargo.lock
+++ b/source-kafka/Cargo.lock
@@ -883,7 +883,7 @@ dependencies = [
 [[package]]
 name = "proto-flow"
 version = "0.0.0"
-source = "git+https://github.com/estuary/flow#c03c3d9b5a70a82ce4bfc7c2baa49d3317d06f73"
+source = "git+https://github.com/estuary/flow#9d9e68cfa4a54ce8a8cdc2dd0acaeb7dbefa8d59"
 dependencies = [
  "bytes",
  "pbjson",
@@ -898,7 +898,7 @@ dependencies = [
 [[package]]
 name = "proto-gazette"
 version = "0.0.0"
-source = "git+https://github.com/estuary/flow#c03c3d9b5a70a82ce4bfc7c2baa49d3317d06f73"
+source = "git+https://github.com/estuary/flow#9d9e68cfa4a54ce8a8cdc2dd0acaeb7dbefa8d59"
 dependencies = [
  "bytes",
  "pbjson",

--- a/source-kafka/Cargo.toml
+++ b/source-kafka/Cargo.toml
@@ -27,4 +27,4 @@ tracing-subscriber = "0.2.19"
 #sasl2-sys = { version = "0.1.14", features = ["vendored" ] }
 
 [dev-dependencies]
-insta = { version = "1.8.0", features = ["redactions"] }
+insta = { version = "1.8.0", features = ["redactions", "yaml"] }

--- a/source-kafka/src/lib.rs
+++ b/source-kafka/src/lib.rs
@@ -41,6 +41,7 @@ impl connector::Connector for KafkaConnector {
                 }))?,
                 documentation_url: "https://go.estuary.dev/source-kafka".to_string(),
                 oauth2: None,
+                resource_path_pointers: vec!["/stream".to_string()],
             }),
             ..Default::default()
         };

--- a/source-kafka/tests/it/snapshots/it__check_test.snap
+++ b/source-kafka/tests/it/snapshots/it__check_test.snap
@@ -1,10 +1,6 @@
 ---
 source: tests/it/main.rs
 expression: parse_from_output(&stdout)
-
 ---
-validated:
-  bindings:
-    - resourcePath:
-        - __consumer_offsets
+validated: {}
 

--- a/source-kafka/tests/it/snapshots/it__spec_test.snap
+++ b/source-kafka/tests/it/snapshots/it__spec_test.snap
@@ -1,20 +1,25 @@
 ---
 source: tests/it/main.rs
 expression: parse_from_output(&stdout)
-
 ---
 spec:
   configSchema:
     $schema: "http://json-schema.org/draft-07/schema#"
-    definitions:
-      Authentication:
-        description: The information necessary to connect to Kafka.
+    properties:
+      authentication:
+        description: "The connection details for authenticating a client connection to Kafka via SASL. When not provided, the client connection will attempt to use PLAINTEXT (insecure) protocol. This must only be used in dev/test environments."
+        order: 1
         properties:
           mechanism:
-            allOf:
-              - $ref: "#/definitions/SaslMechanism"
+            default: PLAIN
+            description: The SASL Mechanism describes how to exchange and authenticate clients/servers.
+            enum:
+              - PLAIN
+              - SCRAM-SHA-256
+              - SCRAM-SHA-512
             order: 0
-            title: Sasl Mechanism
+            title: SASL Mechanism
+            type: string
           password:
             order: 2
             secret: true
@@ -31,52 +36,25 @@ spec:
           - username
         title: Authentication
         type: object
-      SaslMechanism:
-        description: The SASL Mechanism describes how to exchange and authenticate clients/servers.
-        enum:
-          - PLAIN
-          - SCRAM-SHA-256
-          - SCRAM-SHA-512
-        title: SASL Mechanism
-        type: string
-      TlsSettings:
-        default: system_certificates
-        description: Controls how should TLS certificates be found or used.
-        enum:
-          - system_certificates
-        title: TLS Settings
-        type: string
-    properties:
-      authentication:
-        description: "The connection details for authenticating a client connection to Kafka via SASL. When not provided, the client connection will attempt to use PLAINTEXT (insecure) protocol. This must only be used in dev/test environments."
-        oneOf:
-          - allOf:
-              - $ref: "#/definitions/Authentication"
-            title: Enabled
-          - title: Disabled
-            type: "null"
-        order: 1
-        title: Authentication
       bootstrap_servers:
+        default:
+          - "localhost:9092"
         description: The initial servers in the Kafka cluster to initially connect to. The Kafka client will be informed of the rest of the cluster nodes by connecting to one of these nodes.
         items:
-          default:
-            - "localhost:9092"
           type: string
         order: 0
         title: Bootstrap Servers
         type: array
       tls:
+        default: system_certificates
         description: Controls how should TLS certificates be found or used.
-        oneOf:
-          - allOf:
-              - $ref: "#/definitions/TlsSettings"
-            title: Enabled
-          - title: Disabled
-            type: "null"
+        enum:
+          - system_certificates
         order: 2
         title: TLS Settings
+        type: string
     required:
+      - authentication
       - bootstrap_servers
     title: Kafka Source Configuration
     type: object
@@ -88,4 +66,6 @@ spec:
         type: string
         x-collection-name: true
     type: object
+  resourcePathPointers:
+    - /stream
 

--- a/source-kinesis/.snapshots/TestSpec
+++ b/source-kinesis/.snapshots/TestSpec
@@ -53,5 +53,8 @@
     ],
     "title": "Kinesis Resource Spec"
   },
-  "documentation_url": "https://go.estuary.dev/source-kinesis"
+  "documentation_url": "https://go.estuary.dev/source-kinesis",
+  "resource_path_pointers": [
+    "/stream"
+  ]
 }

--- a/source-kinesis/discovery.go
+++ b/source-kinesis/discovery.go
@@ -62,7 +62,6 @@ func discoverStreams(ctx context.Context, client *kinesis.Kinesis, streamNames [
 			DocumentSchemaJson: json.RawMessage(bs),
 			ResourceConfigJson: resourceJSON,
 			Key:                []string{fmt.Sprintf("/%s/%s", metaProperty, sequenceNumber), fmt.Sprintf("/%s/%s", metaProperty, partitionKey)},
-			ResourcePath:       []string{name},
 		}
 	}
 

--- a/source-kinesis/main.go
+++ b/source-kinesis/main.go
@@ -43,6 +43,7 @@ func (driver) Spec(ctx context.Context, req *pc.Request_Spec) (*pc.Response_Spec
 		ConfigSchemaJson:         json.RawMessage(endpointSchema),
 		ResourceConfigSchemaJson: json.RawMessage(resourceSchema),
 		DocumentationUrl:         "https://go.estuary.dev/source-kinesis",
+		ResourcePathPointers:     []string{"/stream"},
 	}, nil
 }
 

--- a/source-mongodb/.snapshots/TestDiscover
+++ b/source-mongodb/.snapshots/TestDiscover
@@ -36,10 +36,6 @@ Binding 0:
     },
     "key": [
       "/_id"
-    ],
-    "resource_path": [
-      "test",
-      "collection1"
     ]
   }
 Binding 1:
@@ -80,10 +76,6 @@ Binding 1:
     },
     "key": [
       "/_id"
-    ],
-    "resource_path": [
-      "test",
-      "collection2"
     ]
   }
 

--- a/source-mongodb/.snapshots/TestDiscoverAllDatabases
+++ b/source-mongodb/.snapshots/TestDiscoverAllDatabases
@@ -36,10 +36,6 @@ Binding 0:
     },
     "key": [
       "/_id"
-    ],
-    "resource_path": [
-      "bar",
-      "collection1"
     ]
   }
 Binding 1:
@@ -80,10 +76,6 @@ Binding 1:
     },
     "key": [
       "/_id"
-    ],
-    "resource_path": [
-      "bar",
-      "collection2"
     ]
   }
 Binding 2:
@@ -124,10 +116,6 @@ Binding 2:
     },
     "key": [
       "/_id"
-    ],
-    "resource_path": [
-      "baz",
-      "collection1"
     ]
   }
 Binding 3:
@@ -168,10 +156,6 @@ Binding 3:
     },
     "key": [
       "/_id"
-    ],
-    "resource_path": [
-      "baz",
-      "collection2"
     ]
   }
 Binding 4:
@@ -212,10 +196,6 @@ Binding 4:
     },
     "key": [
       "/_id"
-    ],
-    "resource_path": [
-      "foo",
-      "collection1"
     ]
   }
 Binding 5:
@@ -256,10 +236,6 @@ Binding 5:
     },
     "key": [
       "/_id"
-    ],
-    "resource_path": [
-      "foo",
-      "collection2"
     ]
   }
 

--- a/source-mongodb/.snapshots/TestDiscoverMultipleDatabases
+++ b/source-mongodb/.snapshots/TestDiscoverMultipleDatabases
@@ -36,10 +36,6 @@ Binding 0:
     },
     "key": [
       "/_id"
-    ],
-    "resource_path": [
-      "bar",
-      "collection1"
     ]
   }
 Binding 1:
@@ -80,10 +76,6 @@ Binding 1:
     },
     "key": [
       "/_id"
-    ],
-    "resource_path": [
-      "bar",
-      "collection2"
     ]
   }
 Binding 2:
@@ -124,10 +116,6 @@ Binding 2:
     },
     "key": [
       "/_id"
-    ],
-    "resource_path": [
-      "foo",
-      "collection1"
     ]
   }
 Binding 3:
@@ -168,10 +156,6 @@ Binding 3:
     },
     "key": [
       "/_id"
-    ],
-    "resource_path": [
-      "foo",
-      "collection2"
     ]
   }
 

--- a/source-mongodb/.snapshots/TestSpec
+++ b/source-mongodb/.snapshots/TestSpec
@@ -57,5 +57,9 @@
     ],
     "title": "MongoDB Resource Spec"
   },
-  "documentation_url": "https://go.estuary.dev/source-mongodb"
+  "documentation_url": "https://go.estuary.dev/source-mongodb",
+  "resource_path_pointers": [
+    "/database",
+    "/collection"
+  ]
 }

--- a/source-mongodb/discovery.go
+++ b/source-mongodb/discovery.go
@@ -1,12 +1,12 @@
 package main
 
 import (
-	"strings"
 	"context"
 	"encoding/json"
 	"fmt"
 	"reflect"
 	"slices"
+	"strings"
 
 	pc "github.com/estuary/flow/go/protocols/capture"
 	pf "github.com/estuary/flow/go/protocols/flow"
@@ -135,7 +135,6 @@ func (d *driver) Discover(ctx context.Context, req *pc.Request_Discover) (*pc.Re
 				ResourceConfigJson: resourceJSON,
 				DocumentSchemaJson: minimalSchema,
 				Key:                []string{"/" + idProperty},
-				ResourcePath:       []string{db.Name(), collection.Name},
 			})
 		}
 	}

--- a/source-mongodb/main.go
+++ b/source-mongodb/main.go
@@ -26,7 +26,7 @@ import (
 const (
 	// Minimum oplog time difference: see the comment on OplogTimeDifference in
 	// oplog.go
-	minOplogTimediffHours = 24
+	minOplogTimediffHours   = 24
 	minOplogTimediffSeconds = minOplogTimediffHours * 60 * 60 // 24 hours, in seconds
 )
 
@@ -105,7 +105,7 @@ type driver struct{}
 
 func (d *driver) Connect(ctx context.Context, cfg config) (*mongo.Client, error) {
 	// Create a new client and connect to the server
-	var opts = options.Client().ApplyURI(cfg.ToURI()).SetCompressors([]string{"zstd","zlib","snappy"})
+	var opts = options.Client().ApplyURI(cfg.ToURI()).SetCompressors([]string{"zstd", "zlib", "snappy"})
 	client, err := mongo.Connect(ctx, opts)
 	if err != nil {
 		return nil, err
@@ -171,6 +171,7 @@ func (driver) Spec(ctx context.Context, req *pc.Request_Spec) (*pc.Response_Spec
 		ConfigSchemaJson:         json.RawMessage(endpointSchema),
 		ResourceConfigSchemaJson: json.RawMessage(resourceSchema),
 		DocumentationUrl:         "https://go.estuary.dev/source-mongodb",
+		ResourcePathPointers:     []string{"/database", "/collection"},
 	}, nil
 }
 

--- a/source-mysql/.snapshots/TestGeneric-KeylessDiscovery
+++ b/source-mysql/.snapshots/TestGeneric-KeylessDiscovery
@@ -116,10 +116,6 @@ Binding 0:
     },
     "key": [
       "/_meta/source/cursor"
-    ],
-    "resource_path": [
-      "test",
-      "Generic_KeylessDiscovery_t32386"
     ]
   }
 

--- a/source-mysql/.snapshots/TestGeneric-SimpleDiscovery
+++ b/source-mysql/.snapshots/TestGeneric-SimpleDiscovery
@@ -115,10 +115,6 @@ Binding 0:
     },
     "key": [
       "/a"
-    ],
-    "resource_path": [
-      "test",
-      "Generic_SimpleDiscovery_49210954"
     ]
   }
 

--- a/source-mysql/.snapshots/TestGeneric-SpecResponse
+++ b/source-mysql/.snapshots/TestGeneric-SpecResponse
@@ -148,5 +148,9 @@
     ],
     "title": "SQL Database Resource Spec"
   },
-  "documentation_url": "https://go.estuary.dev/source-mysql"
+  "documentation_url": "https://go.estuary.dev/source-mysql",
+  "resource_path_pointers": [
+    "/stream",
+    "/namespace"
+  ]
 }

--- a/source-mysql/.snapshots/TestPartitionedTable-Discovery
+++ b/source-mysql/.snapshots/TestPartitionedTable-Discovery
@@ -111,10 +111,6 @@ Binding 0:
     "key": [
       "/grp",
       "/id"
-    ],
-    "resource_path": [
-      "test",
-      "PartitionedTable_83812828"
     ]
   }
 

--- a/source-mysql/.snapshots/TestSecondaryIndexDiscovery-index_only
+++ b/source-mysql/.snapshots/TestSecondaryIndexDiscovery-index_only
@@ -117,10 +117,6 @@ Binding 0:
     "key": [
       "/k2",
       "/k3"
-    ],
-    "resource_path": [
-      "test",
-      "SecondaryIndexDiscovery_index_only_g26313"
     ]
   }
 

--- a/source-mysql/.snapshots/TestSecondaryIndexDiscovery-nonunique_index
+++ b/source-mysql/.snapshots/TestSecondaryIndexDiscovery-nonunique_index
@@ -113,10 +113,6 @@ Binding 0:
     },
     "key": [
       "/_meta/source/cursor"
-    ],
-    "resource_path": [
-      "test",
-      "SecondaryIndexDiscovery_nonunique_index_g22906"
     ]
   }
 

--- a/source-mysql/.snapshots/TestSecondaryIndexDiscovery-nothing
+++ b/source-mysql/.snapshots/TestSecondaryIndexDiscovery-nothing
@@ -113,10 +113,6 @@ Binding 0:
     },
     "key": [
       "/_meta/source/cursor"
-    ],
-    "resource_path": [
-      "test",
-      "SecondaryIndexDiscovery_nothing_g14307"
     ]
   }
 

--- a/source-mysql/.snapshots/TestSecondaryIndexDiscovery-nullable_index
+++ b/source-mysql/.snapshots/TestSecondaryIndexDiscovery-nullable_index
@@ -119,10 +119,6 @@ Binding 0:
     },
     "key": [
       "/_meta/source/cursor"
-    ],
-    "resource_path": [
-      "test",
-      "SecondaryIndexDiscovery_nullable_index_g31990"
     ]
   }
 

--- a/source-mysql/.snapshots/TestSecondaryIndexDiscovery-pk_and_index
+++ b/source-mysql/.snapshots/TestSecondaryIndexDiscovery-pk_and_index
@@ -112,10 +112,6 @@ Binding 0:
     },
     "key": [
       "/k1"
-    ],
-    "resource_path": [
-      "test",
-      "SecondaryIndexDiscovery_pk_and_index_g14228"
     ]
   }
 

--- a/source-mysql/.snapshots/TestTrickyColumnNames-discover
+++ b/source-mysql/.snapshots/TestTrickyColumnNames-discover
@@ -106,10 +106,6 @@ Binding 0:
     },
     "key": [
       "/Meta~1`wtf`~0ID"
-    ],
-    "resource_path": [
-      "test",
-      "TrickyColumnNames_14055203"
     ]
   }
 Binding 1:
@@ -220,10 +216,6 @@ Binding 1:
     },
     "key": [
       "/table"
-    ],
-    "resource_path": [
-      "test",
-      "TrickyColumnNames_28395292"
     ]
   }
 

--- a/source-mysql/.snapshots/TestTrickyTableNames-Discover
+++ b/source-mysql/.snapshots/TestTrickyTableNames-Discover
@@ -103,10 +103,6 @@ Binding 0:
     },
     "key": [
       "/id"
-    ],
-    "resource_path": [
-      "test",
-      "UsErS!@#$"
     ]
   }
 

--- a/source-postgres/.snapshots/TestCapitalizedTables-Discover
+++ b/source-postgres/.snapshots/TestCapitalizedTables-Discover
@@ -108,10 +108,6 @@ Binding 0:
     },
     "key": [
       "/id"
-    ],
-    "resource_path": [
-      "test",
-      "USERS"
     ]
   }
 

--- a/source-postgres/.snapshots/TestDiscoveryCapitalization
+++ b/source-postgres/.snapshots/TestDiscoveryCapitalization
@@ -111,10 +111,6 @@ Binding 0:
     },
     "key": [
       "/id"
-    ],
-    "resource_path": [
-      "test",
-      "DiscoveryCapitalization_AaAaA"
     ]
   }
 Binding 1:
@@ -230,10 +226,6 @@ Binding 1:
     },
     "key": [
       "/id"
-    ],
-    "resource_path": [
-      "test",
-      "discoverycapitalization_bbbbb"
     ]
   }
 Binding 2:
@@ -349,10 +341,6 @@ Binding 2:
     },
     "key": [
       "/id"
-    ],
-    "resource_path": [
-      "test",
-      "discoverycapitalization_ccccc"
     ]
   }
 

--- a/source-postgres/.snapshots/TestDiscoveryComplex
+++ b/source-postgres/.snapshots/TestDiscoveryComplex
@@ -129,10 +129,6 @@ Binding 0:
     "key": [
       "/k2",
       "/k1"
-    ],
-    "resource_path": [
-      "test",
-      "discoverycomplex_cheap_oxygenation"
     ]
   }
 

--- a/source-postgres/.snapshots/TestDiscoveryWithoutPermissions
+++ b/source-postgres/.snapshots/TestDiscoveryWithoutPermissions
@@ -111,10 +111,6 @@ Binding 0:
     },
     "key": [
       "/id"
-    ],
-    "resource_path": [
-      "public",
-      "discoverywithoutpermissions_117535"
     ]
   }
 

--- a/source-postgres/.snapshots/TestGeneric-KeylessDiscovery
+++ b/source-postgres/.snapshots/TestGeneric-KeylessDiscovery
@@ -123,10 +123,6 @@ Binding 0:
       "/_meta/source/loc/0",
       "/_meta/source/loc/1",
       "/_meta/source/loc/2"
-    ],
-    "resource_path": [
-      "test",
-      "generic_keylessdiscovery_t32386"
     ]
   }
 

--- a/source-postgres/.snapshots/TestGeneric-SimpleDiscovery
+++ b/source-postgres/.snapshots/TestGeneric-SimpleDiscovery
@@ -120,10 +120,6 @@ Binding 0:
     },
     "key": [
       "/a"
-    ],
-    "resource_path": [
-      "test",
-      "generic_simplediscovery_49210954"
     ]
   }
 

--- a/source-postgres/.snapshots/TestGeneric-SpecResponse
+++ b/source-postgres/.snapshots/TestGeneric-SpecResponse
@@ -160,5 +160,9 @@
     ],
     "title": "SQL Database Resource Spec"
   },
-  "documentation_url": "https://go.estuary.dev/source-postgresql"
+  "documentation_url": "https://go.estuary.dev/source-postgresql",
+  "resource_path_pointers": [
+    "/stream",
+    "/namespace"
+  ]
 }

--- a/source-postgres/.snapshots/TestPartitionedTableDiscovery
+++ b/source-postgres/.snapshots/TestPartitionedTableDiscovery
@@ -112,10 +112,6 @@ Binding 0:
     },
     "key": [
       "/logdate"
-    ],
-    "resource_path": [
-      "test",
-      "partitionedtablediscovery_27339326"
     ]
   }
 

--- a/source-postgres/.snapshots/TestSecondaryIndexDiscovery-index_only
+++ b/source-postgres/.snapshots/TestSecondaryIndexDiscovery-index_only
@@ -122,10 +122,6 @@ Binding 0:
     "key": [
       "/k2",
       "/k3"
-    ],
-    "resource_path": [
-      "test",
-      "secondaryindexdiscovery_index_only_g26313"
     ]
   }
 

--- a/source-postgres/.snapshots/TestSecondaryIndexDiscovery-nonunique_index
+++ b/source-postgres/.snapshots/TestSecondaryIndexDiscovery-nonunique_index
@@ -120,10 +120,6 @@ Binding 0:
       "/_meta/source/loc/0",
       "/_meta/source/loc/1",
       "/_meta/source/loc/2"
-    ],
-    "resource_path": [
-      "test",
-      "secondaryindexdiscovery_nonunique_index_g22906"
     ]
   }
 

--- a/source-postgres/.snapshots/TestSecondaryIndexDiscovery-nothing
+++ b/source-postgres/.snapshots/TestSecondaryIndexDiscovery-nothing
@@ -120,10 +120,6 @@ Binding 0:
       "/_meta/source/loc/0",
       "/_meta/source/loc/1",
       "/_meta/source/loc/2"
-    ],
-    "resource_path": [
-      "test",
-      "secondaryindexdiscovery_nothing_g14307"
     ]
   }
 

--- a/source-postgres/.snapshots/TestSecondaryIndexDiscovery-nullable_index
+++ b/source-postgres/.snapshots/TestSecondaryIndexDiscovery-nullable_index
@@ -126,10 +126,6 @@ Binding 0:
       "/_meta/source/loc/0",
       "/_meta/source/loc/1",
       "/_meta/source/loc/2"
-    ],
-    "resource_path": [
-      "test",
-      "secondaryindexdiscovery_nullable_index_g31990"
     ]
   }
 

--- a/source-postgres/.snapshots/TestSecondaryIndexDiscovery-pk_and_index
+++ b/source-postgres/.snapshots/TestSecondaryIndexDiscovery-pk_and_index
@@ -117,10 +117,6 @@ Binding 0:
     },
     "key": [
       "/k1"
-    ],
-    "resource_path": [
-      "test",
-      "secondaryindexdiscovery_pk_and_index_g14228"
     ]
   }
 

--- a/source-postgres/.snapshots/TestTrickyColumnNames-discover
+++ b/source-postgres/.snapshots/TestTrickyColumnNames-discover
@@ -111,10 +111,6 @@ Binding 0:
     },
     "key": [
       "/Meta~1\"wtf\"~0ID"
-    ],
-    "resource_path": [
-      "test",
-      "trickycolumnnames_39256824"
     ]
   }
 Binding 1:
@@ -230,10 +226,6 @@ Binding 1:
     },
     "key": [
       "/table"
-    ],
-    "resource_path": [
-      "test",
-      "trickycolumnnames_42531495"
     ]
   }
 

--- a/source-postgres/.snapshots/TestUserTypes-Domain-Discovery
+++ b/source-postgres/.snapshots/TestUserTypes-Domain-Discovery
@@ -111,10 +111,6 @@ Binding 0:
     },
     "key": [
       "/id"
-    ],
-    "resource_path": [
-      "test",
-      "usertypes_domain_68961947"
     ]
   }
 

--- a/source-postgres/.snapshots/TestUserTypes-Enum-Discovery
+++ b/source-postgres/.snapshots/TestUserTypes-Enum-Discovery
@@ -111,10 +111,6 @@ Binding 0:
     },
     "key": [
       "/id"
-    ],
-    "resource_path": [
-      "test",
-      "usertypes_enum_64812435"
     ]
   }
 

--- a/source-postgres/.snapshots/TestUserTypes-Range-Discovery
+++ b/source-postgres/.snapshots/TestUserTypes-Range-Discovery
@@ -111,10 +111,6 @@ Binding 0:
     },
     "key": [
       "/id"
-    ],
-    "resource_path": [
-      "test",
-      "usertypes_range_91324557"
     ]
   }
 

--- a/source-postgres/.snapshots/TestUserTypes-Tuple-Discovery
+++ b/source-postgres/.snapshots/TestUserTypes-Tuple-Discovery
@@ -108,10 +108,6 @@ Binding 0:
     },
     "key": [
       "/id"
-    ],
-    "resource_path": [
-      "test",
-      "usertypes_tuple_51424093"
     ]
   }
 

--- a/source-sqlserver/.snapshots/TestDiscoveryIrrelevantConstraints
+++ b/source-sqlserver/.snapshots/TestDiscoveryIrrelevantConstraints
@@ -118,10 +118,6 @@ Binding 0:
     },
     "key": [
       "/id"
-    ],
-    "resource_path": [
-      "dbo",
-      "test_DiscoveryIrrelevantConstraints_44516719"
     ]
   }
 

--- a/source-sqlserver/.snapshots/TestGeneric-KeylessDiscovery
+++ b/source-sqlserver/.snapshots/TestGeneric-KeylessDiscovery
@@ -123,10 +123,6 @@ Binding 0:
     "key": [
       "/_meta/source/lsn",
       "/_meta/source/seqval"
-    ],
-    "resource_path": [
-      "dbo",
-      "test_Generic_KeylessDiscovery_t32386"
     ]
   }
 

--- a/source-sqlserver/.snapshots/TestGeneric-SimpleDiscovery
+++ b/source-sqlserver/.snapshots/TestGeneric-SimpleDiscovery
@@ -121,10 +121,6 @@ Binding 0:
     },
     "key": [
       "/a"
-    ],
-    "resource_path": [
-      "dbo",
-      "test_Generic_SimpleDiscovery_49210954"
     ]
   }
 

--- a/source-sqlserver/.snapshots/TestGeneric-SpecResponse
+++ b/source-sqlserver/.snapshots/TestGeneric-SpecResponse
@@ -135,5 +135,9 @@
     ],
     "title": "SQL Database Resource Spec"
   },
-  "documentation_url": "https://go.estuary.dev/source-sqlserver"
+  "documentation_url": "https://go.estuary.dev/source-sqlserver",
+  "resource_path_pointers": [
+    "/stream",
+    "/namespace"
+  ]
 }

--- a/source-sqlserver/.snapshots/TestIndexIncludedDiscovery
+++ b/source-sqlserver/.snapshots/TestIndexIncludedDiscovery
@@ -123,10 +123,6 @@ Binding 0:
     "key": [
       "/k2",
       "/k3"
-    ],
-    "resource_path": [
-      "dbo",
-      "test_IndexIncludedDiscovery_98476798"
     ]
   }
 

--- a/source-sqlserver/.snapshots/TestSecondaryIndexDiscovery-index_only
+++ b/source-sqlserver/.snapshots/TestSecondaryIndexDiscovery-index_only
@@ -123,10 +123,6 @@ Binding 0:
     "key": [
       "/k2",
       "/k3"
-    ],
-    "resource_path": [
-      "dbo",
-      "test_SecondaryIndexDiscovery_index_only_g26313"
     ]
   }
 

--- a/source-sqlserver/.snapshots/TestSecondaryIndexDiscovery-nonunique_index
+++ b/source-sqlserver/.snapshots/TestSecondaryIndexDiscovery-nonunique_index
@@ -120,10 +120,6 @@ Binding 0:
     "key": [
       "/_meta/source/lsn",
       "/_meta/source/seqval"
-    ],
-    "resource_path": [
-      "dbo",
-      "test_SecondaryIndexDiscovery_nonunique_index_g22906"
     ]
   }
 

--- a/source-sqlserver/.snapshots/TestSecondaryIndexDiscovery-nothing
+++ b/source-sqlserver/.snapshots/TestSecondaryIndexDiscovery-nothing
@@ -120,10 +120,6 @@ Binding 0:
     "key": [
       "/_meta/source/lsn",
       "/_meta/source/seqval"
-    ],
-    "resource_path": [
-      "dbo",
-      "test_SecondaryIndexDiscovery_nothing_g14307"
     ]
   }
 

--- a/source-sqlserver/.snapshots/TestSecondaryIndexDiscovery-nullable_index
+++ b/source-sqlserver/.snapshots/TestSecondaryIndexDiscovery-nullable_index
@@ -126,10 +126,6 @@ Binding 0:
     "key": [
       "/_meta/source/lsn",
       "/_meta/source/seqval"
-    ],
-    "resource_path": [
-      "dbo",
-      "test_SecondaryIndexDiscovery_nullable_index_g31990"
     ]
   }
 

--- a/source-sqlserver/.snapshots/TestSecondaryIndexDiscovery-pk_and_index
+++ b/source-sqlserver/.snapshots/TestSecondaryIndexDiscovery-pk_and_index
@@ -118,10 +118,6 @@ Binding 0:
     },
     "key": [
       "/k1"
-    ],
-    "resource_path": [
-      "dbo",
-      "test_SecondaryIndexDiscovery_pk_and_index_g14228"
     ]
   }
 

--- a/source-sqlserver/.snapshots/TestVarcharKeyDiscovery
+++ b/source-sqlserver/.snapshots/TestVarcharKeyDiscovery
@@ -112,10 +112,6 @@ Binding 0:
     },
     "key": [
       "/id"
-    ],
-    "resource_path": [
-      "dbo",
-      "test_VarcharKeyDiscovery_42325208"
     ]
   }
 

--- a/source-test/main.go
+++ b/source-test/main.go
@@ -143,6 +143,7 @@ func (connector) Spec(context.Context, *pc.Request_Spec) (*pc.Response_Spec, err
 				"refresh_token": json.RawMessage(`"/refresh_token"`),
 			},
 		},
+		ResourcePathPointers: []string{"/stream"},
 	}, nil
 }
 

--- a/sqlcapture/discovery.go
+++ b/sqlcapture/discovery.go
@@ -175,7 +175,6 @@ func DiscoverCatalog(ctx context.Context, db Database) ([]*pc.Response_Discovere
 			ResourceConfigJson: resourceSpecJSON,
 			DocumentSchemaJson: rawSchema,
 			Key:                keyPointers,
-			ResourcePath:       []string{res.Namespace, res.Stream},
 		})
 
 	}

--- a/sqlcapture/main.go
+++ b/sqlcapture/main.go
@@ -134,6 +134,7 @@ func (d *Driver) Spec(ctx context.Context, req *pc.Request_Spec) (*pc.Response_S
 		ConfigSchemaJson:         d.ConfigSchema,
 		ResourceConfigSchemaJson: json.RawMessage(resourceSchema),
 		DocumentationUrl:         docsURLFromEnv(d.DocumentationURL),
+		ResourcePathPointers:     []string{"/stream", "/namespace"},
 	}, nil
 }
 


### PR DESCRIPTION
**Description:**

Updates all remaining capture connectors in this repo to return `resource_path_pointers` as part of their `spec` response. This allows them to take advantage of the new discover merge behavior, which merges bindings based on the extracted resource paths.

I removed the `ResourcePath` from the Discovered responses as part of this, since those were only recently introduced. I didn't remove the resourcePath from the Validated responses, since our validation logic still requires them.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1087)
<!-- Reviewable:end -->
