### PR TITLE
source-bigquery-batch: Minor adjustments

### DIFF
--- a/source-bigquery-batch/driver.go
+++ b/source-bigquery-batch/driver.go
@@ -563,8 +563,8 @@ func (c *capture) poll(ctx context.Context, bindingIndex int, tmpl *template.Tem
 		var sleepDuration = time.Until(state.LastPolled.Add(pollInterval))
 		log.WithFields(log.Fields{
 			"name": res.Name,
-			"wait": sleepDuration,
-			"poll": pollInterval,
+			"wait": sleepDuration.String(),
+			"poll": pollInterval.String(),
 		}).Info("waiting for next poll")
 		select {
 		case <-ctx.Done():
@@ -572,7 +572,11 @@ func (c *capture) poll(ctx context.Context, bindingIndex int, tmpl *template.Tem
 		case <-time.After(sleepDuration):
 		}
 	}
-	log.WithField("name", res.Name).Info("ready to poll")
+	log.WithFields(log.Fields{
+		"name": res.Name,
+		"poll": pollInterval.String(),
+		"prev": state.LastPolled.Format(time.RFC3339Nano),
+	}).Info("ready to poll")
 	var pollTime = time.Now().UTC()
 	state.LastPolled = pollTime
 

--- a/source-bigquery-batch/driver.go
+++ b/source-bigquery-batch/driver.go
@@ -66,6 +66,9 @@ func (r Resource) Validate() error {
 	if _, err := template.New("query").Parse(r.Template); err != nil {
 		return fmt.Errorf("error parsing template: %w", err)
 	}
+	if slices.Contains(r.Cursor, "") {
+		return fmt.Errorf("cursor column names can't be empty (got %q)", r.Cursor)
+	}
 	if r.PollInterval != "" {
 		if _, err := time.ParseDuration(r.PollInterval); err != nil {
 			return fmt.Errorf("invalid poll interval %q: %w", r.PollInterval, err)

--- a/source-mysql-batch/driver.go
+++ b/source-mysql-batch/driver.go
@@ -67,6 +67,9 @@ func (r Resource) Validate() error {
 	if _, err := template.New("query").Parse(r.Template); err != nil {
 		return fmt.Errorf("error parsing template: %w", err)
 	}
+	if slices.Contains(r.Cursor, "") {
+		return fmt.Errorf("cursor column names can't be empty (got %q)", r.Cursor)
+	}
 	if r.PollInterval != "" {
 		if _, err := time.ParseDuration(r.PollInterval); err != nil {
 			return fmt.Errorf("invalid poll interval %q: %w", r.PollInterval, err)

--- a/source-mysql-batch/driver.go
+++ b/source-mysql-batch/driver.go
@@ -615,8 +615,8 @@ func (c *capture) poll(ctx context.Context, bindingIndex int, tmpl *template.Tem
 		var sleepDuration = time.Until(state.LastPolled.Add(pollInterval))
 		log.WithFields(log.Fields{
 			"name": res.Name,
-			"wait": sleepDuration,
-			"poll": pollInterval,
+			"wait": sleepDuration.String(),
+			"poll": pollInterval.String(),
 		}).Info("waiting for next poll")
 		select {
 		case <-ctx.Done():
@@ -624,7 +624,11 @@ func (c *capture) poll(ctx context.Context, bindingIndex int, tmpl *template.Tem
 		case <-time.After(sleepDuration):
 		}
 	}
-	log.WithField("name", res.Name).Info("ready to poll")
+	log.WithFields(log.Fields{
+		"name": res.Name,
+		"poll": pollInterval.String(),
+		"prev": state.LastPolled.Format(time.RFC3339Nano),
+	}).Info("ready to poll")
 	var pollTime = time.Now().UTC()
 	state.LastPolled = pollTime
 


### PR DESCRIPTION
**Description:**

Adds a small check so that resource specs with empty cursor column names will be rejected at startup. Also throws in a couple of logging tweaks inspired by trying to read a capture task's logs yesterday, and moves the polled-at timestamp update so that it occurs _after_ acquiring the "only update one binding at a time" mutex which is obviously more correct.

These changes are made to `source-bigquery-batch` and `source-mysql-batch` for consistency. The analagous changes for batch Postgres have been added to the "bring source-postgres-batch back to feature parity" PR.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1089)
<!-- Reviewable:end -->
