### PR TITLE
materialize-sqlite: fix apply

### DIFF
--- a/materialize-sqlite/sqlgen.go
+++ b/materialize-sqlite/sqlgen.go
@@ -35,6 +35,10 @@ var sqliteDialect = func() sql.Dialect {
 	}
 
 	return sql.Dialect{
+		// TableLocator and ColumnLocator are not used for sqlite, since sqlite re-creates all tables
+		// from scratch every time it starts up.
+		TableLocatorer:  sql.TableLocatorFn(func(path ...string) sql.InfoTableLocation { return sql.InfoTableLocation{} }),
+		ColumnLocatorer: sql.ColumnLocatorFn(func(field string) string { return field }),
 		Identifierer: sql.IdentifierFn(sql.JoinTransform(".",
 			sql.PassThroughTransform(
 				func(s string) bool {


### PR DESCRIPTION
**Description:**

This is a follow-up to #1086 - although materialize-sqlite didn't previously need to do anything in particular with its column alteration methods, it does now need to actually create tables in its client `Apply` method since the materialize-sql framework doesn't do that via `ExecStatements` anymore.

The integration tests for various capture connectors use the `dev` image of `materialize-sqlite`, so those only started failing after #1086 was merged, and will fail until after this PR is merged - including on this PR itself. I did build `materialize-sqlite` with this image locally and verified that the capture integration tests work though. In the future it would probably be a good idea to put together a simple integration test for `materialize-sqlite` since there currently isn't anything.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1096)
<!-- Reviewable:end -->
