### PR TITLE
make airbyte and sqlcapture resource_path_pointers match validate

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -211,7 +211,7 @@ jobs:
       - name: Start Dockerized test infrastructure
         if: matrix.connector == 'source-kafka'
         run: |
-          docker compose --file infra/docker-compose.yaml up --detach
+          docker compose --file infra/docker-compose.yaml up --wait
 
       - name: Source connector ${{ matrix.connector }} integration tests
         if: |

--- a/python/flow_sdk/shim_airbyte_cdk.py
+++ b/python/flow_sdk/shim_airbyte_cdk.py
@@ -46,7 +46,7 @@ class CaptureShim(Connector):
             "documentationUrl": f"{DOCS_URL if DOCS_URL else spec.documentationUrl}",
             "configSchema": spec.connectionSpecification,
             "resourceConfigSchema": resource_config_schema,
-            "resourcePathPointers": ["/stream", "/namespace"],
+            "resourcePathPointers": ["/namespace", "/stream"],
         }
 
         # TODO(johnny): Can we map spec.advanced_auth into flow.OAuth2 ?

--- a/source-mysql/.snapshots/TestGeneric-SpecResponse
+++ b/source-mysql/.snapshots/TestGeneric-SpecResponse
@@ -150,7 +150,7 @@
   },
   "documentation_url": "https://go.estuary.dev/source-mysql",
   "resource_path_pointers": [
-    "/stream",
-    "/namespace"
+    "/namespace",
+    "/stream"
   ]
 }

--- a/source-postgres/.snapshots/TestGeneric-SpecResponse
+++ b/source-postgres/.snapshots/TestGeneric-SpecResponse
@@ -162,7 +162,7 @@
   },
   "documentation_url": "https://go.estuary.dev/source-postgresql",
   "resource_path_pointers": [
-    "/stream",
-    "/namespace"
+    "/namespace",
+    "/stream"
   ]
 }

--- a/source-sqlserver/.snapshots/TestGeneric-SpecResponse
+++ b/source-sqlserver/.snapshots/TestGeneric-SpecResponse
@@ -137,7 +137,7 @@
   },
   "documentation_url": "https://go.estuary.dev/source-sqlserver",
   "resource_path_pointers": [
-    "/stream",
-    "/namespace"
+    "/namespace",
+    "/stream"
   ]
 }

--- a/sqlcapture/main.go
+++ b/sqlcapture/main.go
@@ -134,7 +134,7 @@ func (d *Driver) Spec(ctx context.Context, req *pc.Request_Spec) (*pc.Response_S
 		ConfigSchemaJson:         d.ConfigSchema,
 		ResourceConfigSchemaJson: json.RawMessage(resourceSchema),
 		DocumentationUrl:         docsURLFromEnv(d.DocumentationURL),
-		ResourcePathPointers:     []string{"/stream", "/namespace"},
+		ResourcePathPointers:     []string{"/namespace", "/stream"},
 	}, nil
 }
 


### PR DESCRIPTION
**Description:**

The `resource_path_pointers` used by the sqlcapture and airbyte connectors didn't match the order of the properties in the `resource_path` that's returned by the Validate RPC.  This doesn't cause any problems, because we never actually compare the two. But we have plans to, and it's just weird if they don't match. There's also little risk of changing the order of `resource_path_pointers` at this stage because they're only used for discover merge. So I'd like to make sure they're all consistent before it becomes difficult to change.

Also rolls up a few commits to update the proto-flow dependency for source-kafka and source-http-ingest. These are Rust connectors, and the Rust JSON deserialization does not allow unrecognized fields. So this update is required in order to make these connectors work with the latest changes on flow's master branch.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1098)
<!-- Reviewable:end -->
