### PR TITLE
materialize-postgres: remove null bytes from string values

### DIFF
--- a/materialize-postgres/sqlgen.go
+++ b/materialize-postgres/sqlgen.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	sql "github.com/estuary/connectors/materialize-sql"
+	"github.com/estuary/flow/go/protocols/fdb/tuple"
 )
 
 var pgDialect = func() sql.Dialect {
@@ -18,7 +19,16 @@ var pgDialect = func() sql.Dialect {
 		sql.BINARY:   sql.NewStaticMapper("BYTEA"),
 		sql.MULTIPLE: sql.NewStaticMapper("JSON", sql.WithElementConverter(sql.JsonBytesConverter)),
 		sql.STRING: sql.StringTypeMapper{
-			Fallback: sql.NewStaticMapper("TEXT"),
+			Fallback: sql.NewStaticMapper("TEXT", sql.WithElementConverter(func(te tuple.TupleElement) (interface{}, error) {
+				s, ok := te.(string)
+				if !ok {
+					return nil, fmt.Errorf("converting string incompatible type: %T", s)
+				}
+
+				// Postgres doesn't allow fields with null bytes, so they must be stripped out if
+				// present.
+				return strings.ReplaceAll(s, "\u0000", ""), nil
+			})),
 			WithFormat: map[string]sql.TypeMapper{
 				"integer": sql.PrimaryKeyMapper{
 					PrimaryKey: sql.NewStaticMapper("TEXT"),


### PR DESCRIPTION
**Description:**

`materialize-postgres` does not allow string values to have the null byte sequence "\u0000" anywhere in them. This changes `materialize-postgres` to strip these values out of materialized string fields.

Completely removing the "\u0000" (replacing with "") seemed most consistent with other systems that do handle strings with null bytes, like Snowflake and BigQuery, since they completely strip out the null bytes rather than replacing them with some sentinel like a space etc.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

