### PR TITLE
source-mysql: Ignore `DROP FUNCTION` query events

### DIFF
--- a/source-mysql/replication.go
+++ b/source-mysql/replication.go
@@ -450,7 +450,7 @@ func decodeRow(streamID string, colNames []string, row []interface{}) (map[strin
 // with the binlog Query Events for some statements like GRANT and CREATE USER.
 // TODO(johnny): SET STATEMENT is not safe in the general case, and we want to re-visit
 // by extracting and ignoring a SET STATEMENT stanza prior to parsing.
-var ignoreQueriesRe = regexp.MustCompile(`(?i)^(BEGIN|COMMIT|GRANT|REVOKE|CREATE USER|CREATE DEFINER|DROP USER|ALTER USER|DROP PROCEDURE|DROP TRIGGER|SET STATEMENT|# |/\*|-- )`)
+var ignoreQueriesRe = regexp.MustCompile(`(?i)^(BEGIN|COMMIT|GRANT|REVOKE|CREATE USER|CREATE DEFINER|DROP USER|ALTER USER|DROP PROCEDURE|DROP FUNCTION|DROP TRIGGER|SET STATEMENT|# |/\*|-- )`)
 
 func (rs *mysqlReplicationStream) handleQuery(ctx context.Context, schema, query string) error {
 	// There are basically three types of query events we might receive:


### PR DESCRIPTION
**Description:**

Another one that can't be parsed by the Vitess query parser.

I'm just about at the point of recommending we turn query parse failures into a benign log-and-ignore, since this has never once been a real issue -- the queries we actually need to handle or forbid are parsed correctly, and these failures are just a bunch of edge cases we don't care about. But that's more work than just adding another prefix string into the ignores regexp, so it can wait until after the production issue is unblocked.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1106)
<!-- Reviewable:end -->
