### PR TITLE
materialize-sql: log tables that were found if a table that should exist isn't found

### DIFF
--- a/materialize-sql/apply_actions.go
+++ b/materialize-sql/apply_actions.go
@@ -135,6 +135,13 @@ func (e *ExistingColumns) hasColumn(schema, table, column string) (bool, error) 
 		// This _probably_ shouldn't ever happen, but might if the user dropped a table without
 		// removing the binding for it from their spec *and* is doing something that would require
 		// altering the table.
+		foundTables := []string{}
+		for schema, tableCols := range e.tables {
+			for table := range tableCols {
+				foundTables = append(foundTables, fmt.Sprintf("%s.%s", schema, table))
+			}
+		}
+		log.WithField("foundTables", foundTables).Info("tables found in endpoint")
 		return false, fmt.Errorf("table '%s.%s' not found in destination, but binding still exists", schema, table)
 	}
 


### PR DESCRIPTION
**Description:**

There have been a couple of cases where a table that should exist in the endpoint hasn't been found in the `ExistingTables` struct formed from the `INFORMATION_SCHEMA` query. This adds some logging to hopefully help figure out what is going on, by showing the tables that were found.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1108)
<!-- Reviewable:end -->
