### PR TITLE
materializations: fix a couple of bugs with `information_schema` querying

### DIFF
--- a/materialize-postgres/sqlgen_test.go
+++ b/materialize-postgres/sqlgen_test.go
@@ -141,3 +141,38 @@ func TestDateTimeColumn(t *testing.T) {
 	require.Equal(t, "2022-04-04T10:09:08.234567Z", parsed)
 	require.NoError(t, err)
 }
+
+func TestTruncatedIdentifier(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "no truncation",
+			input: "hello",
+			want:  "hello",
+		},
+		{
+			name:  "truncate ASCII",
+			input: strings.Repeat("a", 64),
+			want:  strings.Repeat("a", 63),
+		},
+		{
+			name:  "truncate UTF-8",
+			input: strings.Repeat("a", 61) + "码",
+			want:  strings.Repeat("a", 61),
+		},
+		{
+			name:  "empty input",
+			input: "",
+			want:  "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, truncatedIdentifier(tt.input))
+		})
+	}
+}


### PR DESCRIPTION
**Description:**

- Adds truncation to the column and table locators for reading data from the `information_schema` view for `materialize-postgres`, since Postgres automatically truncates identifiers over 63 bytes in length.
- Qualifies `information_schema` as `system.information_schema` in `materialize-databricks`, since that is needed for some deployments of Databricks.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1109)
<!-- Reviewable:end -->
