### PR TITLE
materialize-redshift: Reinstate pgx/v4/stdlib import

### DIFF
--- a/materialize-redshift/driver.go
+++ b/materialize-redshift/driver.go
@@ -32,6 +32,9 @@ import (
 	log "github.com/sirupsen/logrus"
 	"go.gazette.dev/core/consumer/protocol"
 	"golang.org/x/sync/errgroup"
+
+	// Imported for side-effects (registers the required stdsql driver)
+	_ "github.com/jackc/pgx/v4/stdlib"
 )
 
 const (


### PR DESCRIPTION
**Description:**

This package needs to be imported so that `stdsql.Open("pgx", ...)` works correctly. Currently the connector cannot actually run since this got deleted (presumably by accident) in https://github.com/estuary/connectors/pull/1099

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1113)
<!-- Reviewable:end -->
