### PR TITLE
materialize-sql: don't try to drop nullability on columns that don't exist

### DIFF
--- a/materialize-sql/apply_actions_test.go
+++ b/materialize-sql/apply_actions_test.go
@@ -188,7 +188,7 @@ func TestFilterActions(t *testing.T) {
 				},
 			},
 			want:    ApplyActions{},
-			wantErr: true,
+			wantErr: false,
 		},
 		{
 			name: "alter table drop nullability on a table that doesn't exist",


### PR DESCRIPTION
**Description:**

If a pre-existing table doesn't have all of the columns in the field selection for a binding, we currently don't error on Apply and also don't add the columns. It then may be necessary to exclude that column from the field selection, which is currently impossible since we try to check if the existing column is nullable when removing it from the field selection.

So instead of erroring, just don't try to drop the nullability constraint on columns that don't exist.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1114)
<!-- Reviewable:end -->
