### PR TITLE
source-mongodb: Sanitize +/-Infinity values

### DIFF
--- a/source-mongodb/pull.go
+++ b/source-mongodb/pull.go
@@ -542,6 +542,10 @@ func sanitizeDocument(doc map[string]interface{}) map[string]interface{} {
 			case float64:
 				if math.IsNaN(v) {
 					doc[key] = "NaN"
+				} else if math.IsInf(v, +1) {
+					doc[key] = "Infinity"
+				} else if math.IsInf(v, -1) {
+					doc[key] = "-Infinity"
 				}
 			case map[string]interface{}:
 			case primitive.M:


### PR DESCRIPTION
**Description:**

Same as we do for NaNs, float infinities need to be replaced with a string representation because they have no JSON representation.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1115)
<!-- Reviewable:end -->
