### PR TITLE
source-mysql: lower logging for insufficient database version to debug level

### DIFF
--- a/source-mysql/prerequisites.go
+++ b/source-mysql/prerequisites.go
@@ -19,7 +19,7 @@ func (db *mysqlDatabase) SetupPrerequisites(ctx context.Context) []error {
 	// Our version checking may have been overly conservative, so let's err in the
 	// other direction for a while and disengage the check entirely.
 	if err := db.prerequisiteVersion(ctx); err != nil {
-		logrus.WithField("err", err).Warn("database version may be insufficient")
+		logrus.WithField("err", err).Debug("database version may be insufficient")
 	}
 
 	for _, prereq := range []func(ctx context.Context) error{


### PR DESCRIPTION
**Description:**

We don't enforce a minimum version for `source-mysql`, and will currently log a warning if the detected version is too low.

We've seen various versions of MySQL work, but don't have an exact limit on what should be supported, and don't fail validation on this error. Logging a warning can be confusing if there are other errors that actually cause the capture to fail validation, so this changes the log level to DEBUG so it doesn't normally show up.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1116)
<!-- Reviewable:end -->
