### PR TITLE
materialize-bigquery: set user agent in bigquery client

### DIFF
--- a/materialize-bigquery/bigquery.go
+++ b/materialize-bigquery/bigquery.go
@@ -79,7 +79,9 @@ func (c *config) Validate() error {
 func (c *config) client(ctx context.Context) (*client, error) {
 	var clientOpts []option.ClientOption
 
-	clientOpts = append(clientOpts, option.WithCredentialsJSON(decodeCredentials(c.CredentialsJSON)))
+	clientOpts = append(clientOpts,
+		option.WithCredentialsJSON(decodeCredentials(c.CredentialsJSON)),
+		option.WithUserAgent("Estuary Technologies"))
 
 	// Allow overriding the main 'project_id' with 'billing_project_id' for client operation billing.
 	var billingProjectID = c.BillingProjectID


### PR DESCRIPTION
Sets the User-Agent header in the bigquery client, to enable GCP to track partner attribution.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1118)
<!-- Reviewable:end -->
