### PR TITLE
materialize-databricks: check status of warehouse in prereqs

### DIFF
--- a/materialize-databricks/config.go
+++ b/materialize-databricks/config.go
@@ -2,34 +2,32 @@ package main
 
 import (
 	"fmt"
-	"strings"
-	"net/url"
-	"github.com/invopop/jsonschema"
 	"github.com/iancoleman/orderedmap"
+	"github.com/invopop/jsonschema"
+	"net/url"
+	"strings"
 )
 
 // config represents the endpoint configuration for sql server.
 type config struct {
-	Address     string           `json:"address" jsonschema:"title=Address,description=Host and port of the SQL warehouse (in the form of host[:port]). Port 443 is used as the default if no specific port is provided." jsonschema_extras:"order=0"`
-	HTTPPath    string           `json:"http_path" jsonschema:"title=HTTP path,description=HTTP path of your SQL warehouse"`
-	CatalogName string           `json:"catalog_name" jsonschema:"title=Catalog Name,description=Name of your Unity Catalog."`
-	SchemaName  string           `json:"schema_name" jsonschema:"title=Schema Name,description=Default schema to materialize to,default=default"`
+	Address     string `json:"address" jsonschema:"title=Address,description=Host and port of the SQL warehouse (in the form of host[:port]). Port 443 is used as the default if no specific port is provided." jsonschema_extras:"order=0"`
+	HTTPPath    string `json:"http_path" jsonschema:"title=HTTP path,description=HTTP path of your SQL warehouse"`
+	CatalogName string `json:"catalog_name" jsonschema:"title=Catalog Name,description=Name of your Unity Catalog."`
+	SchemaName  string `json:"schema_name" jsonschema:"title=Schema Name,description=Default schema to materialize to,default=default"`
 
 	Credentials credentialConfig `json:"credentials" jsonschema:"title=Authentication"`
-
 }
 
 const (
 	// TODO: support Azure, GCP and OAuth authentication
-	PAT_AUTH_TYPE  = "PAT" // personal access token
+	PAT_AUTH_TYPE = "PAT" // personal access token
 )
 
 type credentialConfig struct {
-	AuthType            string `json:"auth_type"`
+	AuthType string `json:"auth_type"`
 
 	PersonalAccessToken string `json:"personal_access_token"`
 }
-
 
 func (c *credentialConfig) Validate() error {
 	switch c.AuthType {
@@ -63,7 +61,7 @@ func (credentialConfig) JSONSchema() *jsonschema.Schema {
 		Description: "Personal Access Token,description=Your personal access token for accessing the SQL warehouse",
 		Type:        "string",
 		Extras: map[string]interface{}{
-			"secret":    true,
+			"secret": true,
 		},
 	})
 
@@ -111,15 +109,15 @@ func (c *config) ToURI() string {
 
 	var params = make(url.Values)
 	params.Add("catalog", c.CatalogName)
+	params.Add("schema", c.SchemaName)
 	params.Add("userAgentEntry", "Estuary Technologies Flow")
 
 	var uri = url.URL{
-		Host: address,
-		Path: c.HTTPPath,
-		User: url.UserPassword("token", c.Credentials.PersonalAccessToken),
+		Host:     address,
+		Path:     c.HTTPPath,
+		User:     url.UserPassword("token", c.Credentials.PersonalAccessToken),
 		RawQuery: params.Encode(),
 	}
 
 	return strings.TrimLeft(uri.String(), "/")
 }
-

--- a/materialize-databricks/config_test.go
+++ b/materialize-databricks/config_test.go
@@ -12,24 +12,24 @@ import (
 
 func TestDatabricksConfig(t *testing.T) {
 	var validConfig = config{
-		Address:  "db-something.cloud.databricks.com:400",
+		Address:     "db-something.cloud.databricks.com:400",
 		CatalogName: "mycatalog",
-		HTTPPath: "/sql/1.0/warehouses/someid",
+		HTTPPath:    "/sql/1.0/warehouses/someid",
 		Credentials: credentialConfig{
-			AuthType: "PAT",
+			AuthType:            "PAT",
 			PersonalAccessToken: "secret",
 		},
 		SchemaName: "default",
 	}
 	require.NoError(t, validConfig.Validate())
 	var uri = validConfig.ToURI()
-	require.Equal(t, "token:secret@db-something.cloud.databricks.com:400/sql/1.0/warehouses/someid?catalog=mycatalog&userAgentEntry=Estuary+Technologies+Flow", uri)
+	require.Equal(t, "token:secret@db-something.cloud.databricks.com:400/sql/1.0/warehouses/someid?catalog=mycatalog&schema=default&userAgentEntry=Estuary+Technologies+Flow", uri)
 
 	var noPort = validConfig
 	noPort.Address = "db-something.cloud.databricks.com"
 	require.NoError(t, noPort.Validate())
 	uri = noPort.ToURI()
-	require.Equal(t, "token:secret@db-something.cloud.databricks.com:443/sql/1.0/warehouses/someid?catalog=mycatalog&userAgentEntry=Estuary+Technologies+Flow", uri)
+	require.Equal(t, "token:secret@db-something.cloud.databricks.com:443/sql/1.0/warehouses/someid?catalog=mycatalog&schema=default&userAgentEntry=Estuary+Technologies+Flow", uri)
 
 	var noAddress = validConfig
 	noAddress.Address = ""

--- a/tests/materialize/materialize-databricks/checks.sh
+++ b/tests/materialize/materialize-databricks/checks.sh
@@ -1,0 +1,2 @@
+# cleanup the snapshot by replacing uuids with a placeholder so that the test is reproducible
+sed -i '' 's/.\{36\}\.json/<uuid>/g' ${SNAPSHOT}

--- a/tests/materialize/materialize-databricks/snapshot.json
+++ b/tests/materialize/materialize-databricks/snapshot.json
@@ -1,6 +1,6 @@
 {
   "applied": {
-    "actionDescription": "\nCREATE TABLE IF NOT EXISTS flow_materializations_v2 (\n  materialization STRING NOT NULL COMMENT 'The name of the materialization.',\n  version STRING NOT NULL COMMENT 'Version of the materialization.',\n  spec STRING NOT NULL COMMENT 'Specification of the materialization, encoded as base64 protobuf.'\n) COMMENT 'This table is the source of truth for all materializations into this system.';\n\n\nCREATE TABLE IF NOT EXISTS `default`.simple (\n  id BIGINT NOT NULL COMMENT 'auto-generated projection of JSON at: /id with inferred types: [integer]',\n  canary STRING NOT NULL COMMENT 'auto-generated projection of JSON at: /canary with inferred types: [string]',\n  flow_published_at TIMESTAMP NOT NULL COMMENT 'Flow Publication Time\nFlow publication date-time of this document\nauto-generated projection of JSON at: /_meta/uuid with inferred types: [string]',\n  flow_document STRING NOT NULL COMMENT 'auto-generated projection of JSON at:  with inferred types: [object]'\n) COMMENT 'Generated for materialization tests/materialize-databricks/materialize of collection tests/simple';\n\n\nCREATE TABLE IF NOT EXISTS `default`.duplicate_keys_standard (\n  id BIGINT NOT NULL COMMENT 'auto-generated projection of JSON at: /id with inferred types: [integer]',\n  flow_published_at TIMESTAMP NOT NULL COMMENT 'Flow Publication Time\nFlow publication date-time of this document\nauto-generated projection of JSON at: /_meta/uuid with inferred types: [string]',\n  int BIGINT COMMENT 'auto-generated projection of JSON at: /int with inferred types: [integer]',\n  str STRING NOT NULL COMMENT 'auto-generated projection of JSON at: /str with inferred types: [string]',\n  flow_document STRING NOT NULL COMMENT 'auto-generated projection of JSON at:  with inferred types: [object]'\n) COMMENT 'Generated for materialization tests/materialize-databricks/materialize of collection tests/duplicated-keys';\n\n\nCREATE TABLE IF NOT EXISTS `default`.duplicate_keys_delta (\n  id BIGINT NOT NULL COMMENT 'auto-generated projection of JSON at: /id with inferred types: [integer]',\n  flow_published_at TIMESTAMP NOT NULL COMMENT 'Flow Publication Time\nFlow publication date-time of this document\nauto-generated projection of JSON at: /_meta/uuid with inferred types: [string]',\n  int BIGINT COMMENT 'auto-generated projection of JSON at: /int with inferred types: [integer]',\n  str STRING NOT NULL COMMENT 'auto-generated projection of JSON at: /str with inferred types: [string]',\n  flow_document STRING NOT NULL COMMENT 'auto-generated projection of JSON at:  with inferred types: [object]'\n) COMMENT 'Generated for materialization tests/materialize-databricks/materialize of collection tests/duplicated-keys';\n\n\nCREATE TABLE IF NOT EXISTS `default`.duplicate_keys_delta_exclude_flow_doc (\n  id BIGINT NOT NULL COMMENT 'auto-generated projection of JSON at: /id with inferred types: [integer]',\n  flow_published_at TIMESTAMP NOT NULL COMMENT 'Flow Publication Time\nFlow publication date-time of this document\nauto-generated projection of JSON at: /_meta/uuid with inferred types: [string]',\n  int BIGINT COMMENT 'auto-generated projection of JSON at: /int with inferred types: [integer]',\n  str STRING NOT NULL COMMENT 'auto-generated projection of JSON at: /str with inferred types: [string]'\n) COMMENT 'Generated for materialization tests/materialize-databricks/materialize of collection tests/duplicated-keys';\n\n\nCREATE TABLE IF NOT EXISTS `default`.multiple_types (\n  id BIGINT NOT NULL COMMENT 'auto-generated projection of JSON at: /id with inferred types: [integer]',\n  array_int STRING COMMENT 'auto-generated projection of JSON at: /array_int with inferred types: [array]',\n  bool_field BOOLEAN COMMENT 'auto-generated projection of JSON at: /bool_field with inferred types: [boolean]',\n  float_field DOUBLE COMMENT 'auto-generated projection of JSON at: /float_field with inferred types: [number]',\n  flow_published_at TIMESTAMP NOT NULL COMMENT 'Flow Publication Time\nFlow publication date-time of this document\nauto-generated projection of JSON at: /_meta/uuid with inferred types: [string]',\n  multiple STRING COMMENT 'auto-generated projection of JSON at: /multiple with inferred types: [array boolean null number object string]',\n  nested STRING COMMENT 'auto-generated projection of JSON at: /nested with inferred types: [object]',\n  nullable_int BIGINT COMMENT 'auto-generated projection of JSON at: /nullable_int with inferred types: [integer null]',\n  str_field STRING NOT NULL COMMENT 'auto-generated projection of JSON at: /str_field with inferred types: [string]',\n  flow_document STRING NOT NULL COMMENT 'auto-generated projection of JSON at:  with inferred types: [object]'\n) COMMENT 'Generated for materialization tests/materialize-databricks/materialize of collection tests/multiple-data-types';\n\n\nCREATE TABLE IF NOT EXISTS `default`.formatted_strings (\n  id BIGINT NOT NULL COMMENT 'auto-generated projection of JSON at: /id with inferred types: [integer]',\n  date DATE COMMENT 'auto-generated projection of JSON at: /date with inferred types: [string]',\n  datetime TIMESTAMP COMMENT 'auto-generated projection of JSON at: /datetime with inferred types: [string]',\n  flow_published_at TIMESTAMP NOT NULL COMMENT 'Flow Publication Time\nFlow publication date-time of this document\nauto-generated projection of JSON at: /_meta/uuid with inferred types: [string]',\n  int_and_str BIGINT COMMENT 'auto-generated projection of JSON at: /int_and_str with inferred types: [integer string]',\n  int_str BIGINT COMMENT 'auto-generated projection of JSON at: /int_str with inferred types: [string]',\n  num_and_str DOUBLE COMMENT 'auto-generated projection of JSON at: /num_and_str with inferred types: [number string]',\n  num_str DOUBLE COMMENT 'auto-generated projection of JSON at: /num_str with inferred types: [string]',\n  time STRING COMMENT 'auto-generated projection of JSON at: /time with inferred types: [string]',\n  flow_document STRING NOT NULL COMMENT 'auto-generated projection of JSON at:  with inferred types: [object]'\n) COMMENT 'Generated for materialization tests/materialize-databricks/materialize of collection tests/formatted-strings';\n\nINSERT INTO flow_materializations_v2 (version, spec, materialization) VALUES ('test', '(a-base64-encoded-value)', 'tests/materialize-databricks/materialize');"
+    "actionDescription": "\nCREATE TABLE IF NOT EXISTS `default`.simple (\n  id BIGINT NOT NULL COMMENT 'auto-generated projection of JSON at: /id with inferred types: [integer]',\n  canary STRING NOT NULL COMMENT 'auto-generated projection of JSON at: /canary with inferred types: [string]',\n  flow_published_at TIMESTAMP NOT NULL COMMENT 'Flow Publication Time\nFlow publication date-time of this document\nauto-generated projection of JSON at: /_meta/uuid with inferred types: [string]',\n  flow_document STRING NOT NULL COMMENT 'auto-generated projection of JSON at:  with inferred types: [object]'\n) COMMENT 'Generated for materialization tests/materialize-databricks/materialize of collection tests/simple';\n\n\nCREATE TABLE IF NOT EXISTS `default`.duplicate_keys_standard (\n  id BIGINT NOT NULL COMMENT 'auto-generated projection of JSON at: /id with inferred types: [integer]',\n  flow_published_at TIMESTAMP NOT NULL COMMENT 'Flow Publication Time\nFlow publication date-time of this document\nauto-generated projection of JSON at: /_meta/uuid with inferred types: [string]',\n  int BIGINT COMMENT 'auto-generated projection of JSON at: /int with inferred types: [integer]',\n  str STRING NOT NULL COMMENT 'auto-generated projection of JSON at: /str with inferred types: [string]',\n  flow_document STRING NOT NULL COMMENT 'auto-generated projection of JSON at:  with inferred types: [object]'\n) COMMENT 'Generated for materialization tests/materialize-databricks/materialize of collection tests/duplicated-keys';\n\n\nCREATE TABLE IF NOT EXISTS `default`.duplicate_keys_delta (\n  id BIGINT NOT NULL COMMENT 'auto-generated projection of JSON at: /id with inferred types: [integer]',\n  flow_published_at TIMESTAMP NOT NULL COMMENT 'Flow Publication Time\nFlow publication date-time of this document\nauto-generated projection of JSON at: /_meta/uuid with inferred types: [string]',\n  int BIGINT COMMENT 'auto-generated projection of JSON at: /int with inferred types: [integer]',\n  str STRING NOT NULL COMMENT 'auto-generated projection of JSON at: /str with inferred types: [string]',\n  flow_document STRING NOT NULL COMMENT 'auto-generated projection of JSON at:  with inferred types: [object]'\n) COMMENT 'Generated for materialization tests/materialize-databricks/materialize of collection tests/duplicated-keys';\n\n\nCREATE TABLE IF NOT EXISTS `default`.duplicate_keys_delta_exclude_flow_doc (\n  id BIGINT NOT NULL COMMENT 'auto-generated projection of JSON at: /id with inferred types: [integer]',\n  flow_published_at TIMESTAMP NOT NULL COMMENT 'Flow Publication Time\nFlow publication date-time of this document\nauto-generated projection of JSON at: /_meta/uuid with inferred types: [string]',\n  int BIGINT COMMENT 'auto-generated projection of JSON at: /int with inferred types: [integer]',\n  str STRING NOT NULL COMMENT 'auto-generated projection of JSON at: /str with inferred types: [string]'\n) COMMENT 'Generated for materialization tests/materialize-databricks/materialize of collection tests/duplicated-keys';\n\n\nCREATE TABLE IF NOT EXISTS `default`.multiple_types (\n  id BIGINT NOT NULL COMMENT 'auto-generated projection of JSON at: /id with inferred types: [integer]',\n  array_int STRING COMMENT 'auto-generated projection of JSON at: /array_int with inferred types: [array]',\n  bool_field BOOLEAN COMMENT 'auto-generated projection of JSON at: /bool_field with inferred types: [boolean]',\n  float_field DOUBLE COMMENT 'auto-generated projection of JSON at: /float_field with inferred types: [number]',\n  flow_published_at TIMESTAMP NOT NULL COMMENT 'Flow Publication Time\nFlow publication date-time of this document\nauto-generated projection of JSON at: /_meta/uuid with inferred types: [string]',\n  multiple STRING COMMENT 'auto-generated projection of JSON at: /multiple with inferred types: [array boolean null number object string]',\n  nested STRING COMMENT 'auto-generated projection of JSON at: /nested with inferred types: [object]',\n  nullable_int BIGINT COMMENT 'auto-generated projection of JSON at: /nullable_int with inferred types: [integer null]',\n  str_field STRING NOT NULL COMMENT 'auto-generated projection of JSON at: /str_field with inferred types: [string]',\n  flow_document STRING NOT NULL COMMENT 'auto-generated projection of JSON at:  with inferred types: [object]'\n) COMMENT 'Generated for materialization tests/materialize-databricks/materialize of collection tests/multiple-data-types';\n\n\nCREATE TABLE IF NOT EXISTS `default`.formatted_strings (\n  id BIGINT NOT NULL COMMENT 'auto-generated projection of JSON at: /id with inferred types: [integer]',\n  date DATE COMMENT 'auto-generated projection of JSON at: /date with inferred types: [string]',\n  datetime TIMESTAMP COMMENT 'auto-generated projection of JSON at: /datetime with inferred types: [string]',\n  flow_published_at TIMESTAMP NOT NULL COMMENT 'Flow Publication Time\nFlow publication date-time of this document\nauto-generated projection of JSON at: /_meta/uuid with inferred types: [string]',\n  int_and_str BIGINT COMMENT 'auto-generated projection of JSON at: /int_and_str with inferred types: [integer string]',\n  int_str BIGINT COMMENT 'auto-generated projection of JSON at: /int_str with inferred types: [string]',\n  num_and_str DOUBLE COMMENT 'auto-generated projection of JSON at: /num_and_str with inferred types: [number string]',\n  num_str DOUBLE COMMENT 'auto-generated projection of JSON at: /num_str with inferred types: [string]',\n  time STRING COMMENT 'auto-generated projection of JSON at: /time with inferred types: [string]',\n  flow_document STRING NOT NULL COMMENT 'auto-generated projection of JSON at:  with inferred types: [object]'\n) COMMENT 'Generated for materialization tests/materialize-databricks/materialize of collection tests/formatted-strings';\n\nINSERT INTO `default`.flow_materializations_v2 (version, spec, materialization) VALUES ('test', '(a-base64-encoded-value)', 'tests/materialize-databricks/materialize');"
   }
 }
 {
@@ -17,20 +17,20 @@
     "state": {
       "updated": {
         "Queries": [
-          "\n\tCOPY INTO `default`.formatted_strings FROM (\n    SELECT\n\t\tid::BIGINT\n, date::DATE\n, datetime::TIMESTAMP\n, flow_published_at::TIMESTAMP\n, int_and_str::BIGINT\n, int_str::BIGINT\n, num_and_str::DOUBLE\n, num_str::DOUBLE\n, time\n, flow_document\n\n  FROM '/Volumes/main/default/flow_staging/flow_temp_tables'\n\t)\n  FILEFORMAT = JSON\n  FILES = ('f2dc9b7f-1f38-4c75-a563-4edae66825f5.json')\n  FORMAT_OPTIONS ( 'mode' = 'FAILFAST' )\n  ;\n",
-          "\n\tCOPY INTO `default`.duplicate_keys_delta_exclude_flow_doc FROM (\n    SELECT\n\t\tid::BIGINT\n, flow_published_at::TIMESTAMP\n, int::BIGINT\n, str\n\n  FROM '/Volumes/main/default/flow_staging/flow_temp_tables'\n\t)\n  FILEFORMAT = JSON\n  FILES = ('0267ced6-f828-4a92-9264-9304057508e6.json')\n  FORMAT_OPTIONS ( 'mode' = 'FAILFAST' )\n  ;\n",
-          "\n\tCOPY INTO `default`.duplicate_keys_standard FROM (\n    SELECT\n\t\tid::BIGINT\n, flow_published_at::TIMESTAMP\n, int::BIGINT\n, str\n, flow_document\n\n  FROM '/Volumes/main/default/flow_staging/flow_temp_tables'\n\t)\n  FILEFORMAT = JSON\n  FILES = ('ceb890c1-5bc6-4e36-9dc4-d4ea9af3e806.json')\n  FORMAT_OPTIONS ( 'mode' = 'FAILFAST' )\n  ;\n",
-          "\n\tCOPY INTO `default`.multiple_types FROM (\n    SELECT\n\t\tid::BIGINT\n, array_int\n, bool_field::BOOLEAN\n, float_field::DOUBLE\n, flow_published_at::TIMESTAMP\n, multiple\n, nested\n, nullable_int::BIGINT\n, str_field\n, flow_document\n\n  FROM '/Volumes/main/default/flow_staging/flow_temp_tables'\n\t)\n  FILEFORMAT = JSON\n  FILES = ('d675f0a5-4f54-4c87-9a38-cc87111deb4d.json')\n  FORMAT_OPTIONS ( 'mode' = 'FAILFAST' )\n  ;\n",
-          "\n\tCOPY INTO `default`.duplicate_keys_delta FROM (\n    SELECT\n\t\tid::BIGINT\n, flow_published_at::TIMESTAMP\n, int::BIGINT\n, str\n, flow_document\n\n  FROM '/Volumes/main/default/flow_staging/flow_temp_tables'\n\t)\n  FILEFORMAT = JSON\n  FILES = ('095ab95b-1d4d-491d-9d19-68b0e7d012db.json')\n  FORMAT_OPTIONS ( 'mode' = 'FAILFAST' )\n  ;\n",
-          "\n\tCOPY INTO `default`.simple FROM (\n    SELECT\n\t\tid::BIGINT\n, canary\n, flow_published_at::TIMESTAMP\n, flow_document\n\n  FROM '/Volumes/main/default/flow_staging/flow_temp_tables'\n\t)\n  FILEFORMAT = JSON\n  FILES = ('8376f2fa-286f-4876-aac5-29e7a944961c.json')\n  FORMAT_OPTIONS ( 'mode' = 'FAILFAST' )\n  ;\n"
+          "\n\tCOPY INTO `default`.duplicate_keys_delta_exclude_flow_doc FROM (\n    SELECT\n\t\tid::BIGINT, flow_published_at::TIMESTAMP, int::BIGINT, str::STRING\n  FROM '/Volumes/main/default/flow_staging/flow_temp_tables'\n\t)\n  FILEFORMAT = JSON\n  FILES = ('<uuid>')\n  FORMAT_OPTIONS ( 'mode' = 'FAILFAST', 'ignoreMissingFiles' = 'false' )\n\tCOPY_OPTIONS ( 'mergeSchema' = 'true' )\n  ;\n",
+          "\n\tCOPY INTO `default`.formatted_strings FROM (\n    SELECT\n\t\tid::BIGINT, date::DATE, datetime::TIMESTAMP, flow_published_at::TIMESTAMP, int_and_str::BIGINT, int_str::BIGINT, num_and_str::DOUBLE, num_str::DOUBLE, time::STRING, flow_document::STRING\n  FROM '/Volumes/main/default/flow_staging/flow_temp_tables'\n\t)\n  FILEFORMAT = JSON\n  FILES = ('<uuid>')\n  FORMAT_OPTIONS ( 'mode' = 'FAILFAST', 'ignoreMissingFiles' = 'false' )\n\tCOPY_OPTIONS ( 'mergeSchema' = 'true' )\n  ;\n",
+          "\n\tCOPY INTO `default`.duplicate_keys_delta FROM (\n    SELECT\n\t\tid::BIGINT, flow_published_at::TIMESTAMP, int::BIGINT, str::STRING, flow_document::STRING\n  FROM '/Volumes/main/default/flow_staging/flow_temp_tables'\n\t)\n  FILEFORMAT = JSON\n  FILES = ('<uuid>')\n  FORMAT_OPTIONS ( 'mode' = 'FAILFAST', 'ignoreMissingFiles' = 'false' )\n\tCOPY_OPTIONS ( 'mergeSchema' = 'true' )\n  ;\n",
+          "\n\tCOPY INTO `default`.duplicate_keys_standard FROM (\n    SELECT\n\t\tid::BIGINT, flow_published_at::TIMESTAMP, int::BIGINT, str::STRING, flow_document::STRING\n  FROM '/Volumes/main/default/flow_staging/flow_temp_tables'\n\t)\n  FILEFORMAT = JSON\n  FILES = ('<uuid>')\n  FORMAT_OPTIONS ( 'mode' = 'FAILFAST', 'ignoreMissingFiles' = 'false' )\n\tCOPY_OPTIONS ( 'mergeSchema' = 'true' )\n  ;\n",
+          "\n\tCOPY INTO `default`.simple FROM (\n    SELECT\n\t\tid::BIGINT, canary::STRING, flow_published_at::TIMESTAMP, flow_document::STRING\n  FROM '/Volumes/main/default/flow_staging/flow_temp_tables'\n\t)\n  FILEFORMAT = JSON\n  FILES = ('<uuid>')\n  FORMAT_OPTIONS ( 'mode' = 'FAILFAST', 'ignoreMissingFiles' = 'false' )\n\tCOPY_OPTIONS ( 'mergeSchema' = 'true' )\n  ;\n",
+          "\n\tCOPY INTO `default`.multiple_types FROM (\n    SELECT\n\t\tid::BIGINT, array_int::STRING, bool_field::BOOLEAN, float_field::DOUBLE, flow_published_at::TIMESTAMP, multiple::STRING, nested::STRING, nullable_int::BIGINT, str_field::STRING, flow_document::STRING\n  FROM '/Volumes/main/default/flow_staging/flow_temp_tables'\n\t)\n  FILEFORMAT = JSON\n  FILES = ('<uuid>')\n  FORMAT_OPTIONS ( 'mode' = 'FAILFAST', 'ignoreMissingFiles' = 'false' )\n\tCOPY_OPTIONS ( 'mergeSchema' = 'true' )\n  ;\n"
         ],
         "ToDelete": [
-          "/Volumes/main/default/flow_staging/flow_temp_tables/f2dc9b7f-1f38-4c75-a563-4edae66825f5.json",
-          "/Volumes/main/default/flow_staging/flow_temp_tables/0267ced6-f828-4a92-9264-9304057508e6.json",
-          "/Volumes/main/default/flow_staging/flow_temp_tables/ceb890c1-5bc6-4e36-9dc4-d4ea9af3e806.json",
-          "/Volumes/main/default/flow_staging/flow_temp_tables/d675f0a5-4f54-4c87-9a38-cc87111deb4d.json",
-          "/Volumes/main/default/flow_staging/flow_temp_tables/095ab95b-1d4d-491d-9d19-68b0e7d012db.json",
-          "/Volumes/main/default/flow_staging/flow_temp_tables/8376f2fa-286f-4876-aac5-29e7a944961c.json"
+          "/Volumes/main/default/flow_staging/flow_temp_tables/<uuid>",
+          "/Volumes/main/default/flow_staging/flow_temp_tables/<uuid>",
+          "/Volumes/main/default/flow_staging/flow_temp_tables/<uuid>",
+          "/Volumes/main/default/flow_staging/flow_temp_tables/<uuid>",
+          "/Volumes/main/default/flow_staging/flow_temp_tables/<uuid>",
+          "/Volumes/main/default/flow_staging/flow_temp_tables/<uuid>"
         ]
       }
     }
@@ -231,22 +231,22 @@
     "state": {
       "updated": {
         "Queries": [
-          "\n\tCOPY INTO `default`.formatted_strings FROM (\n    SELECT\n\t\tid::BIGINT\n, date::DATE\n, datetime::TIMESTAMP\n, flow_published_at::TIMESTAMP\n, int_and_str::BIGINT\n, int_str::BIGINT\n, num_and_str::DOUBLE\n, num_str::DOUBLE\n, time\n, flow_document\n\n  FROM '/Volumes/main/default/flow_staging/flow_temp_tables'\n\t)\n  FILEFORMAT = JSON\n  FILES = ('30fe284a-fe74-4c1b-98de-7f8db8d3d60a.json')\n  FORMAT_OPTIONS ( 'mode' = 'FAILFAST' )\n  ;\n",
-          "\n\tCOPY INTO `default`.simple FROM (\n    SELECT\n\t\tid::BIGINT\n, canary\n, flow_published_at::TIMESTAMP\n, flow_document\n\n  FROM '/Volumes/main/default/flow_staging/flow_temp_tables'\n\t)\n  FILEFORMAT = JSON\n  FILES = ('995e1322-ebe5-477e-a1e2-1c8eb8b9d1ce.json')\n  FORMAT_OPTIONS ( 'mode' = 'FAILFAST' )\n  ;\n",
-          "\n\tCOPY INTO `default`.duplicate_keys_delta FROM (\n    SELECT\n\t\tid::BIGINT\n, flow_published_at::TIMESTAMP\n, int::BIGINT\n, str\n, flow_document\n\n  FROM '/Volumes/main/default/flow_staging/flow_temp_tables'\n\t)\n  FILEFORMAT = JSON\n  FILES = ('ec9454e2-ce23-40e8-9372-9c1c98a6074a.json')\n  FORMAT_OPTIONS ( 'mode' = 'FAILFAST' )\n  ;\n",
-          "\n\tCOPY INTO `default`.duplicate_keys_delta_exclude_flow_doc FROM (\n    SELECT\n\t\tid::BIGINT\n, flow_published_at::TIMESTAMP\n, int::BIGINT\n, str\n\n  FROM '/Volumes/main/default/flow_staging/flow_temp_tables'\n\t)\n  FILEFORMAT = JSON\n  FILES = ('9016bf45-ebf7-4590-a0c5-1f179c104374.json')\n  FORMAT_OPTIONS ( 'mode' = 'FAILFAST' )\n  ;\n",
-          "\n\tMERGE INTO `default`.duplicate_keys_standard AS l\n\tUSING flow_temp_store_table_00000000_00000000_1 AS r\n\tON l.id = r.id::BIGINT\n\n\tAND r._metadata_file_name IN ('5a1fbe5e-2d7d-4a10-9af7-dac2f4e6d0e0.json')\n\tWHEN MATCHED AND r.flow_document <=> NULL THEN\n\t\tDELETE\n\tWHEN MATCHED THEN\n\t\tUPDATE SET l.flow_published_at = r.flow_published_at::TIMESTAMP\n, l.int = r.int::BIGINT\n, l.str = r.str\n, l.flow_document = r.flow_document\n\tWHEN NOT MATCHED THEN\n\t\tINSERT (id, flow_published_at, int, str, flow_document)\n\t\tVALUES (r.id::BIGINT\n, r.flow_published_at::TIMESTAMP\n, r.int::BIGINT\n, r.str\n, r.flow_document\n);\n",
-          "\nDROP TABLE IF EXISTS flow_temp_store_table_00000000_00000000_1\n",
-          "\n\tMERGE INTO `default`.multiple_types AS l\n\tUSING flow_temp_store_table_00000000_00000000_4 AS r\n\tON l.id = r.id::BIGINT\n\n\tAND r._metadata_file_name IN ('6bb64474-44a5-4b0f-9a56-d22dcbab92f2.json')\n\tWHEN MATCHED AND r.flow_document <=> NULL THEN\n\t\tDELETE\n\tWHEN MATCHED THEN\n\t\tUPDATE SET l.array_int = r.array_int\n, l.bool_field = r.bool_field::BOOLEAN\n, l.float_field = r.float_field::DOUBLE\n, l.flow_published_at = r.flow_published_at::TIMESTAMP\n, l.multiple = r.multiple\n, l.nested = r.nested\n, l.nullable_int = r.nullable_int::BIGINT\n, l.str_field = r.str_field\n, l.flow_document = r.flow_document\n\tWHEN NOT MATCHED THEN\n\t\tINSERT (id, array_int, bool_field, float_field, flow_published_at, multiple, nested, nullable_int, str_field, flow_document)\n\t\tVALUES (r.id::BIGINT\n, r.array_int\n, r.bool_field::BOOLEAN\n, r.float_field::DOUBLE\n, r.flow_published_at::TIMESTAMP\n, r.multiple\n, r.nested\n, r.nullable_int::BIGINT\n, r.str_field\n, r.flow_document\n);\n",
-          "\nDROP TABLE IF EXISTS flow_temp_store_table_00000000_00000000_4\n"
+          "\n\tCOPY INTO `default`.formatted_strings FROM (\n    SELECT\n\t\tid::BIGINT, date::DATE, datetime::TIMESTAMP, flow_published_at::TIMESTAMP, int_and_str::BIGINT, int_str::BIGINT, num_and_str::DOUBLE, num_str::DOUBLE, time::STRING, flow_document::STRING\n  FROM '/Volumes/main/default/flow_staging/flow_temp_tables'\n\t)\n  FILEFORMAT = JSON\n  FILES = ('<uuid>')\n  FORMAT_OPTIONS ( 'mode' = 'FAILFAST', 'ignoreMissingFiles' = 'false' )\n\tCOPY_OPTIONS ( 'mergeSchema' = 'true' )\n  ;\n",
+          "\n\tCOPY INTO `default`.duplicate_keys_delta_exclude_flow_doc FROM (\n    SELECT\n\t\tid::BIGINT, flow_published_at::TIMESTAMP, int::BIGINT, str::STRING\n  FROM '/Volumes/main/default/flow_staging/flow_temp_tables'\n\t)\n  FILEFORMAT = JSON\n  FILES = ('<uuid>')\n  FORMAT_OPTIONS ( 'mode' = 'FAILFAST', 'ignoreMissingFiles' = 'false' )\n\tCOPY_OPTIONS ( 'mergeSchema' = 'true' )\n  ;\n",
+          "\n\tCOPY INTO `default`.duplicate_keys_delta FROM (\n    SELECT\n\t\tid::BIGINT, flow_published_at::TIMESTAMP, int::BIGINT, str::STRING, flow_document::STRING\n  FROM '/Volumes/main/default/flow_staging/flow_temp_tables'\n\t)\n  FILEFORMAT = JSON\n  FILES = ('<uuid>')\n  FORMAT_OPTIONS ( 'mode' = 'FAILFAST', 'ignoreMissingFiles' = 'false' )\n\tCOPY_OPTIONS ( 'mergeSchema' = 'true' )\n  ;\n",
+          "\n\tCOPY INTO `default`.simple FROM (\n    SELECT\n\t\tid::BIGINT, canary::STRING, flow_published_at::TIMESTAMP, flow_document::STRING\n  FROM '/Volumes/main/default/flow_staging/flow_temp_tables'\n\t)\n  FILEFORMAT = JSON\n  FILES = ('<uuid>')\n  FORMAT_OPTIONS ( 'mode' = 'FAILFAST', 'ignoreMissingFiles' = 'false' )\n\tCOPY_OPTIONS ( 'mergeSchema' = 'true' )\n  ;\n",
+          "\n\tMERGE INTO `default`.duplicate_keys_standard AS l\n\tUSING `flow_temp_store_table_00000000_00000000_1_duplicate_keys_standard` AS r\n\tON l.id = r.id::BIGINT\n\tAND r._metadata_file_name IN ('<uuid>')\n\tWHEN MATCHED AND r.flow_document <=> NULL THEN\n\t\tDELETE\n\tWHEN MATCHED THEN\n\t\tUPDATE SET l.flow_published_at = r.flow_published_at::TIMESTAMP, l.int = r.int::BIGINT, l.str = r.str::STRING, l.flow_document = r.flow_document\n\tWHEN NOT MATCHED THEN\n\t\tINSERT (id, flow_published_at, int, str, flow_document)\n\t\tVALUES (r.id::BIGINT, r.flow_published_at::TIMESTAMP, r.int::BIGINT, r.str::STRING, r.flow_document::STRING);\n",
+          "\nDROP TABLE IF EXISTS `flow_temp_store_table_00000000_00000000_1_duplicate_keys_standard`\n",
+          "\n\tMERGE INTO `default`.multiple_types AS l\n\tUSING `flow_temp_store_table_00000000_00000000_4_multiple_types` AS r\n\tON l.id = r.id::BIGINT\n\tAND r._metadata_file_name IN ('<uuid>')\n\tWHEN MATCHED AND r.flow_document <=> NULL THEN\n\t\tDELETE\n\tWHEN MATCHED THEN\n\t\tUPDATE SET l.array_int = r.array_int::STRING, l.bool_field = r.bool_field::BOOLEAN, l.float_field = r.float_field::DOUBLE, l.flow_published_at = r.flow_published_at::TIMESTAMP, l.multiple = r.multiple::STRING, l.nested = r.nested::STRING, l.nullable_int = r.nullable_int::BIGINT, l.str_field = r.str_field::STRING, l.flow_document = r.flow_document\n\tWHEN NOT MATCHED THEN\n\t\tINSERT (id, array_int, bool_field, float_field, flow_published_at, multiple, nested, nullable_int, str_field, flow_document)\n\t\tVALUES (r.id::BIGINT, r.array_int::STRING, r.bool_field::BOOLEAN, r.float_field::DOUBLE, r.flow_published_at::TIMESTAMP, r.multiple::STRING, r.nested::STRING, r.nullable_int::BIGINT, r.str_field::STRING, r.flow_document::STRING);\n",
+          "\nDROP TABLE IF EXISTS `flow_temp_store_table_00000000_00000000_4_multiple_types`\n"
         ],
         "ToDelete": [
-          "/Volumes/main/default/flow_staging/flow_temp_tables/30fe284a-fe74-4c1b-98de-7f8db8d3d60a.json",
-          "/Volumes/main/default/flow_staging/flow_temp_tables/995e1322-ebe5-477e-a1e2-1c8eb8b9d1ce.json",
-          "/Volumes/main/default/flow_staging/flow_temp_tables/5a1fbe5e-2d7d-4a10-9af7-dac2f4e6d0e0.json",
-          "/Volumes/main/default/flow_staging/flow_temp_tables/ec9454e2-ce23-40e8-9372-9c1c98a6074a.json",
-          "/Volumes/main/default/flow_staging/flow_temp_tables/9016bf45-ebf7-4590-a0c5-1f179c104374.json",
-          "/Volumes/main/default/flow_staging/flow_temp_tables/6bb64474-44a5-4b0f-9a56-d22dcbab92f2.json"
+          "/Volumes/main/default/flow_staging/flow_temp_tables/<uuid>",
+          "/Volumes/main/default/flow_staging/flow_temp_tables/<uuid>",
+          "/Volumes/main/default/flow_staging/flow_temp_tables/<uuid>",
+          "/Volumes/main/default/flow_staging/flow_temp_tables/<uuid>",
+          "/Volumes/main/default/flow_staging/flow_temp_tables/<uuid>",
+          "/Volumes/main/default/flow_staging/flow_temp_tables/<uuid>"
         ]
       }
     }
@@ -397,56 +397,6 @@
 }
 {
   "row": {
-    "flow_document": "{\"_meta\":{\"uuid\":\"8de85150-20e1-11ee-990b-ffd12dfcd47f\"},\"id\":1,\"int\":6,\"str\":\"str 6\"}",
-    "flow_published_at": "2023-07-12 18:26:01.560712+00:00",
-    "id": 1,
-    "int": 6,
-    "str": "str 6"
-  },
-  "table": "`main`.default.duplicate_keys_delta"
-}
-{
-  "row": {
-    "flow_document": "{\"_meta\":{\"uuid\":\"957348bc-20e1-11ee-990b-ffd12dfcd47f\"},\"id\":2,\"int\":7,\"str\":\"str 7\"}",
-    "flow_published_at": "2023-07-12 18:26:14.215494+00:00",
-    "id": 2,
-    "int": 7,
-    "str": "str 7"
-  },
-  "table": "`main`.default.duplicate_keys_delta"
-}
-{
-  "row": {
-    "flow_document": "{\"_meta\":{\"uuid\":\"9afb3ff6-20e1-11ee-990b-ffd12dfcd47f\"},\"id\":3,\"int\":8,\"str\":\"str 8\"}",
-    "flow_published_at": "2023-07-12 18:26:23.495167+00:00",
-    "id": 3,
-    "int": 8,
-    "str": "str 8"
-  },
-  "table": "`main`.default.duplicate_keys_delta"
-}
-{
-  "row": {
-    "flow_document": "{\"_meta\":{\"uuid\":\"a1100a70-20e1-11ee-990b-ffd12dfcd47f\"},\"id\":4,\"int\":9,\"str\":\"str 9\"}",
-    "flow_published_at": "2023-07-12 18:26:33.697752+00:00",
-    "id": 4,
-    "int": 9,
-    "str": "str 9"
-  },
-  "table": "`main`.default.duplicate_keys_delta"
-}
-{
-  "row": {
-    "flow_document": "{\"_meta\":{\"uuid\":\"a65203a8-20e1-11ee-990b-ffd12dfcd47f\"},\"id\":5,\"int\":10,\"str\":\"str 10\"}",
-    "flow_published_at": "2023-07-12 18:26:42.518724+00:00",
-    "id": 5,
-    "int": 10,
-    "str": "str 10"
-  },
-  "table": "`main`.default.duplicate_keys_delta"
-}
-{
-  "row": {
     "flow_document": "{\"_meta\":{\"uuid\":\"75c06bd6-20e0-11ee-990b-ffd12dfcd47f\"},\"id\":1,\"int\":1,\"str\":\"str 1\"}",
     "flow_published_at": "2023-07-12 18:18:11.537199+00:00",
     "id": 1,
@@ -492,6 +442,56 @@
     "id": 5,
     "int": 5,
     "str": "str 5"
+  },
+  "table": "`main`.default.duplicate_keys_delta"
+}
+{
+  "row": {
+    "flow_document": "{\"_meta\":{\"uuid\":\"8de85150-20e1-11ee-990b-ffd12dfcd47f\"},\"id\":1,\"int\":6,\"str\":\"str 6\"}",
+    "flow_published_at": "2023-07-12 18:26:01.560712+00:00",
+    "id": 1,
+    "int": 6,
+    "str": "str 6"
+  },
+  "table": "`main`.default.duplicate_keys_delta"
+}
+{
+  "row": {
+    "flow_document": "{\"_meta\":{\"uuid\":\"957348bc-20e1-11ee-990b-ffd12dfcd47f\"},\"id\":2,\"int\":7,\"str\":\"str 7\"}",
+    "flow_published_at": "2023-07-12 18:26:14.215494+00:00",
+    "id": 2,
+    "int": 7,
+    "str": "str 7"
+  },
+  "table": "`main`.default.duplicate_keys_delta"
+}
+{
+  "row": {
+    "flow_document": "{\"_meta\":{\"uuid\":\"9afb3ff6-20e1-11ee-990b-ffd12dfcd47f\"},\"id\":3,\"int\":8,\"str\":\"str 8\"}",
+    "flow_published_at": "2023-07-12 18:26:23.495167+00:00",
+    "id": 3,
+    "int": 8,
+    "str": "str 8"
+  },
+  "table": "`main`.default.duplicate_keys_delta"
+}
+{
+  "row": {
+    "flow_document": "{\"_meta\":{\"uuid\":\"a1100a70-20e1-11ee-990b-ffd12dfcd47f\"},\"id\":4,\"int\":9,\"str\":\"str 9\"}",
+    "flow_published_at": "2023-07-12 18:26:33.697752+00:00",
+    "id": 4,
+    "int": 9,
+    "str": "str 9"
+  },
+  "table": "`main`.default.duplicate_keys_delta"
+}
+{
+  "row": {
+    "flow_document": "{\"_meta\":{\"uuid\":\"a65203a8-20e1-11ee-990b-ffd12dfcd47f\"},\"id\":5,\"int\":10,\"str\":\"str 10\"}",
+    "flow_published_at": "2023-07-12 18:26:42.518724+00:00",
+    "id": 5,
+    "int": 10,
+    "str": "str 10"
   },
   "table": "`main`.default.duplicate_keys_delta"
 }


### PR DESCRIPTION
**Description:**

- The best practice for Databricks integrations is to check the status of the warehouse and give a human-readable error if the status is not active. I've updated the code to give such error in PreReqs, and I've reduced the timeout so that we don't have jobs waiting a long time for warehouses. Warehouses take around 5 minutes to start, and we don't want to hang the UI for 5 minutes waiting for the warehouse to come online. We still will ping the warehouse, which will initiate its booting up, but we will let the user know that the warehouse is not started yet, so they have to wait.
- Added `SchemName` parameter name to connection string, this ensures that temporary tables created are in that schema. I tested this by changing the schema in config and running the new connector, the temporary tables are created in the configured schema.
- Updated the integration tests `checks.sh` file to clean uuids from the snapshot to make the test more reproducible.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1121)
<!-- Reviewable:end -->
