### PR TITLE
materialize-databricks: UpdateDelay

### DIFF
--- a/materialize-databricks/.snapshots/TestSpecification
+++ b/materialize-databricks/.snapshots/TestSpecification
@@ -56,6 +56,28 @@
         "discriminator": {
           "propertyName": "auth_type"
         }
+      },
+      "advanced": {
+        "properties": {
+          "updateDelay": {
+            "type": "string",
+            "enum": [
+              "0s",
+              "15m",
+              "30m",
+              "1h",
+              "2h",
+              "4h"
+            ],
+            "title": "Update Delay",
+            "description": "Potentially reduce active warehouse time by increasing the delay between updates. Defaults to 30 minutes if unset."
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "title": "Advanced Options",
+        "description": "Options for advanced users. You should not typically need to modify these.",
+        "advanced": true
       }
     },
     "type": "object",

--- a/materialize-databricks/config.go
+++ b/materialize-databricks/config.go
@@ -16,6 +16,12 @@ type config struct {
 	SchemaName  string `json:"schema_name" jsonschema:"title=Schema Name,description=Default schema to materialize to,default=default"`
 
 	Credentials credentialConfig `json:"credentials" jsonschema:"title=Authentication"`
+
+	Advanced advancedConfig `json:"advanced,omitempty" jsonschema:"title=Advanced Options,description=Options for advanced users. You should not typically need to modify these." jsonschema_extras:"advanced=true"`
+}
+
+type advancedConfig struct {
+	UpdateDelay string `json:"updateDelay,omitempty" jsonschema:"title=Update Delay,description=Potentially reduce active warehouse time by increasing the delay between updates. Defaults to 30 minutes if unset.,enum=0s,enum=15m,enum=30m,enum=1h,enum=2h,enum=4h"`
 }
 
 const (

--- a/materialize-databricks/driver.go
+++ b/materialize-databricks/driver.go
@@ -279,12 +279,6 @@ func (c client) PreReqs(ctx context.Context, ep *sql.Endpoint) *sql.PrereqErr {
 		case databricksSql.StateStopping:
 			errs.Err(fmt.Errorf("The selected SQL Warehouse is stopping, please start the SQL warehouse and try again."))
 		}
-
-		if res.AutoStopMins >= 15 {
-			log.Warn(fmt.Sprintf("Auto-stop is configured to be %d minutes for this warehouse, disabling update delay. To save costs you can reduce the auto-stop idle configuration and tune the update delay config of this connector. See docs for more information: https://go.estuary.dev/materialize-databricks", res.AutoStopMins))
-
-			cfg.Advanced.UpdateDelay = "0s"
-		}
 	}
 
 	// Use a reasonable timeout for this connection test. It is not uncommon for a misconfigured
@@ -420,7 +414,7 @@ func newTransactor(
 	if res, err := wsClient.Warehouses.GetById(ctx, warehouseId); err != nil {
 		return nil, fmt.Errorf("get warehouse %q details: %w", warehouseId, err)
 	} else {
-		if res.AutoStopMins >= 15 {
+		if res.AutoStopMins >= 15 && d.updateDelay.Minutes() > 0 {
 			log.Info(fmt.Sprintf("Auto-stop is configured to be %d minutes for this warehouse, disabling update delay. To save costs you can reduce the auto-stop idle configuration and tune the update delay config of this connector. See docs for more information: https://go.estuary.dev/materialize-databricks", res.AutoStopMins))
 
 			d.updateDelay, _ = time.ParseDuration("0s")

--- a/materialize-databricks/driver.go
+++ b/materialize-databricks/driver.go
@@ -16,10 +16,12 @@ import (
 
 	"github.com/databricks/databricks-sdk-go"
 	dbConfig "github.com/databricks/databricks-sdk-go/config"
+	"github.com/databricks/databricks-sdk-go/logger"
 	databricksSql "github.com/databricks/databricks-sdk-go/service/sql"
 	_ "github.com/databricks/databricks-sql-go"
 	driverctx "github.com/databricks/databricks-sql-go/driverctx"
 	dbsqlerr "github.com/databricks/databricks-sql-go/errors"
+	dbsqllog "github.com/databricks/databricks-sql-go/logger"
 	boilerplate "github.com/estuary/connectors/materialize-boilerplate"
 	sql "github.com/estuary/connectors/materialize-sql"
 	pf "github.com/estuary/flow/go/protocols/flow"
@@ -277,6 +279,7 @@ func (c client) PreReqs(ctx context.Context, ep *sql.Endpoint) *sql.PrereqErr {
 		case databricksSql.StateStopping:
 			errs.Err(fmt.Errorf("The selected SQL Warehouse is stopping, please start the SQL warehouse and try again."))
 		}
+
 	}
 
 	// Use a reasonable timeout for this connection test. It is not uncommon for a misconfigured
@@ -860,5 +863,10 @@ func (d *transactor) Destroy() {
 }
 
 func main() {
+	logger.DefaultLogger = &NoOpLogger{}
+	if err := dbsqllog.SetLogLevel("disabled"); err != nil {
+		panic(err)
+	}
+
 	boilerplate.RunMain(newDatabricksDriver())
 }

--- a/materialize-databricks/logger.go
+++ b/materialize-databricks/logger.go
@@ -1,0 +1,18 @@
+package main
+
+import (
+	"context"
+	"github.com/databricks/databricks-sdk-go/logger"
+)
+
+type NoOpLogger struct{}
+
+func (*NoOpLogger) Enabled(ctx context.Context, level logger.Level) bool {
+	return false
+}
+
+func (*NoOpLogger) Tracef(ctx context.Context, format string, v ...any) {}
+func (*NoOpLogger) Debugf(ctx context.Context, format string, v ...any) {}
+func (*NoOpLogger) Infof(ctx context.Context, format string, v ...any)  {}
+func (*NoOpLogger) Warnf(ctx context.Context, format string, v ...any)  {}
+func (*NoOpLogger) Errorf(ctx context.Context, format string, v ...any) {}


### PR DESCRIPTION
**Description:**

- Use `sql.CommitWithDelay` to delay commits as a cost-saving measure.
- Tested by manually running this, and commits are spaced by 30 minutes. It takes about 5 minutes for Pro and Classic type of SQL warehouses to boot up (Serverless SQL Warehouses are supposed to be faster to boot up, but we don't have access to those to test them), but that does not lead to a timeout in our code, as in my tests the connector seems to work fine using this configuration.
- Added logic so that if auto-stop is configured to be more than 15 minutes, we disable Update Delay, since it is not as useful in that scenario.
- Disabled databricks sql and databricks SDK's internal logging facilities so that we can directly control what errors get logged
- Documentation: https://github.com/estuary/flow/pull/1308/files#diff-79327be85e79183cf88e533070c7a9f8a04dbd230e1d328cd7478d981eae8c2f

This is a sample graph of a Databricks materialization task running with this setting:
<img width="747" alt="image" src="https://github.com/estuary/connectors/assets/2807772/afce02a9-1c6a-40fb-a0d2-b58e08697779">

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1123)
<!-- Reviewable:end -->
