### PR TITLE
Phil/mongo backfills

### DIFF
--- a/source-mongodb/main.go
+++ b/source-mongodb/main.go
@@ -112,7 +112,9 @@ func (d *driver) Connect(ctx context.Context, cfg config) (*mongo.Client, error)
 	}
 
 	if retention, err := oplogMinRetentionHours(ctx, client); err != nil || retention == 0 {
-		log.WithField("err", err).Warn("checking oplogMinRetentionHours failed, using an alternative method to approximate oplog size, this might not be accurate.")
+		// We want to avoid the Info log being interpreted as an error by users
+		log.WithField("error", err).Debug("oplog retention check failed (this is usually OK)")
+		log.Infof("falling back to less accurate oplog size estimation")
 
 		if diff, err := oplogTimeDifference(ctx, client); err != nil {
 			return nil, fmt.Errorf("could not read oplog, access to oplog is necessary. Consider giving the user access to read the local database https://go.estuary.dev/NurkrE: %w", err)

--- a/source-mongodb/pull.go
+++ b/source-mongodb/pull.go
@@ -5,20 +5,20 @@ import (
 	"encoding/json"
 	"fmt"
 	"math"
-	"time"
 	"slices"
+	"time"
 
 	boilerplate "github.com/estuary/connectors/source-boilerplate"
 	pc "github.com/estuary/flow/go/protocols/capture"
 	pf "github.com/estuary/flow/go/protocols/flow"
 	log "github.com/sirupsen/logrus"
 
-	"golang.org/x/sync/semaphore"
-	"golang.org/x/sync/errgroup"
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/options"
+	"golang.org/x/sync/errgroup"
+	"golang.org/x/sync/semaphore"
 )
 
 // Limit the number of backfills running concurrently to avoid
@@ -55,7 +55,7 @@ func (d *driver) Pull(open *pc.Request_Open, stream *boilerplate.PullOutput) err
 	}()
 
 	var c = capture{
-		cfg: cfg,
+		cfg:    cfg,
 		Output: stream,
 	}
 
@@ -129,7 +129,7 @@ func (d *driver) Pull(open *pc.Request_Open, stream *boilerplate.PullOutput) err
 }
 
 type capture struct {
-	cfg config
+	cfg    config
 	Output *boilerplate.PullOutput
 }
 
@@ -148,8 +148,8 @@ func (s *captureState) Validate() error {
 type backfillState struct {
 	Done bool `json:"done,omitempty"`
 
-	StartedAt time.Time `json:"started_at,omitempty"`
-	LastId bson.RawValue `json:"last_id,omitempty"`
+	StartedAt time.Time     `json:"started_at,omitempty"`
+	LastId    bson.RawValue `json:"last_id,omitempty"`
 }
 
 type resourceState struct {
@@ -160,7 +160,7 @@ type docKey struct {
 	Id interface{} `bson:"_id"`
 }
 type namespace struct {
-	Database string `bson:"db"`
+	Database   string `bson:"db"`
 	Collection string `bson:"coll"`
 }
 type changeEvent struct {
@@ -383,8 +383,8 @@ func (c *capture) ChangeStream(ctx context.Context, client *mongo.Client, resour
 const BackfillBatchSize = 50000
 
 const (
-	NaturalSort = "$natural"
-	SortAscending = 1
+	NaturalSort    = "$natural"
+	SortAscending  = 1
 	SortDescending = -1
 )
 
@@ -416,8 +416,8 @@ func (c *capture) BackfillCollection(ctx context.Context, sp *semaphore.Weighted
 
 	log.WithFields(log.Fields{
 		"collection": res.Collection,
-		"opts": opts,
-		"filter": filter,
+		"opts":       opts,
+		"filter":     filter,
 	}).Info("backfilling documents in collection")
 
 	cursor, err := collection.Find(ctx, filter, opts)
@@ -520,6 +520,7 @@ func resourceId(res resource) string {
 func eventResourceId(ev changeEvent) string {
 	return fmt.Sprintf("%s.%s", ev.Ns.Database, ev.Ns.Collection)
 }
+
 // MongoDB considers datetimes outside of the 0-9999 year range to be _unsafe_
 // so we enforce this constraint in our connector.
 // see https://www.mongodb.com/docs/manual/reference/method/Date/#behavior


### PR DESCRIPTION
Fixes a bug that prevented the connector from backfilling more than 10 bindings due to failing to release the backfill semaphore. See individual commit messages for details. Also discussed [in slack](https://estuaryworkspace.slack.com/archives/C03Q2NRFKDL/p1702297940720339) and on VC.