### PR TITLE
source-mongodb: enable capturing from shared database instances

### DIFF
--- a/source-mongodb/.snapshots/TestCapture
+++ b/source-mongodb/.snapshots/TestCapture
@@ -46,5 +46,5 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"resources":{"test.collectionOne":{"backfill":{"done":true,"last_id":{"Type":2,"Value":"CQAAAHBrIHZhbCA0AA=="},"started_at":"<TIMESTAMP>"}},"test.collectionThree":{"backfill":{"done":true,"last_id":{"Type":5,"Value":"CAAAAABwayB2YWwgNA=="},"started_at":"<TIMESTAMP>"}},"test.collectionTwo":{"backfill":{"done":true,"last_id":{"Type":16,"Value":"BAAAAA=="},"started_at":"<TIMESTAMP>"}}},"stream_resume_token":"<STREAM_RESUME_TOKEN>"}
+{"oplog_empty_before_backfill":false,"resources":{"test.collectionOne":{"backfill":{"done":true,"last_id":{"Type":2,"Value":"CQAAAHBrIHZhbCA0AA=="},"started_at":"<TIMESTAMP>"}},"test.collectionThree":{"backfill":{"done":true,"last_id":{"Type":5,"Value":"CAAAAABwayB2YWwgNA=="},"started_at":"<TIMESTAMP>"}},"test.collectionTwo":{"backfill":{"done":true,"last_id":{"Type":16,"Value":"BAAAAA=="},"started_at":"<TIMESTAMP>"}}},"stream_resume_token":"<STREAM_RESUME_TOKEN>"}
 

--- a/source-mongodb/discovery.go
+++ b/source-mongodb/discovery.go
@@ -83,6 +83,10 @@ func (d *driver) Discover(ctx context.Context, req *pc.Request_Discover) (*pc.Re
 		}
 	}()
 
+	if _, err = checkOplog(ctx, client); err != nil {
+		return nil, err
+	}
+
 	var systemDatabases = []string{"config", "local"}
 
 	var databaseNames []string

--- a/source-mongodb/oplog.go
+++ b/source-mongodb/oplog.go
@@ -5,10 +5,11 @@ import (
 	"fmt"
 	"time"
 
+	log "github.com/sirupsen/logrus"
 	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/options"
-	"go.mongodb.org/mongo-driver/bson/primitive"
 )
 
 type serverStatus struct {
@@ -19,6 +20,9 @@ type oplogTruncation struct {
 	OplogMinRetentionHours int `bson:"oplogMinRetentionHours"`
 }
 
+// oplogMinRetentionHours queries for the configured minimum retention period of the oplog.
+// Note that this can fail due to lack of permissions, even when we have sufficient permissions
+// to read the oplog.
 func oplogMinRetentionHours(ctx context.Context, client *mongo.Client) (int, error) {
 	var db = client.Database("admin")
 
@@ -36,31 +40,53 @@ type oplogRecord struct {
 	Ts primitive.Timestamp `bson:"ts"`
 }
 
-// Oplog time difference: the time difference is measured as the
-// difference between the latest and the oldest record in a MongoDB oplog, and
-// it is used as a measure of how long do oplog records stay in the oplog.
-// Note that this value can fluctuate depending on the density of oplog
-// records during a period, so continuously monitoring this value is necessary
-// and a single value is not representative
-func oplogTimeDifference(ctx context.Context, client *mongo.Client) (uint32, error) {
+// checkOplog ensures that we can read from the oplog, and does some best-effort checks of
+// the oplog retention.
+func checkOplog(ctx context.Context, client *mongo.Client) (time.Time, error) {
+	var retention, err = oplogMinRetentionHours(ctx, client)
+	if err != nil {
+		// We may not have permission to check the oplog retention period, and that's ok.
+		// We want to avoid the Info log being interpreted as an error by users
+		log.WithField("error", err).Debug("oplog retention check failed (this is usually OK)")
+		log.Infof("unable to determine oplog retention period, so assuming it is sufficient")
+	} else if retention == 0 {
+		// Not all users will have the power to change this setting, so trying not to be too
+		// forcefull in recommending that it is set.
+		log.Infof("oplog does not have a minimum retention period set. It is recommended that production servers use a minimum retention period of at least 24 hours")
+	} else if retention < minOplogTimediffHours {
+		log.Infof("oplog retention period is lower than 24 hours, please consider setting your oplog minimum retention period to a minimum of 24 hours, and ideally more: https://go.estuary.dev/NurkrE")
+	}
+
+	// Try to determine the timestamp of the oldest entry in the oplog. This serves two purposes:
+	// One, it ensures that we have sufficient permissions to read the oplog. Two, we can use it
+	// as a "goodenuf" proxy for the configured retention period in case we weren't able to
+	// determine that.
+	oldestEntryTime, err := oldestOplogEntry(ctx, client)
+	if err != nil && err != mongo.ErrNoDocuments {
+		return oldestEntryTime, fmt.Errorf("unable to query the MongoDB oplog. Please ensure that the user has access to read the 'local' database and query the 'oplog.rs' collection: %w", err)
+	} else if err == mongo.ErrNoDocuments {
+		// If this is a shared instance, such as an entry-level Atlas server, this is normal.
+		log.Warn("no readable entries found in the MongoDB oplog (this may be normal if capturing from a shared server such as Atlas M0)")
+	} else if retention == 0 && time.Now().UTC().Sub(oldestEntryTime).Seconds() < minOplogTimediffSeconds {
+		log.Warn(fmt.Sprintf("the age of the oldest readable entry in the oplog is %s, which may indicate that the oplog size is too small to ensure data consistency. This is an approximation and might not be representative of your oplog size. Please ensure your oplog is sufficiently large to be able to safely capture data from your database: https://go.estuary.dev/NurkrE", time.Now().UTC().Sub(oldestEntryTime)))
+	}
+
+	return oldestEntryTime, nil
+}
+
+// oldestOplogEntry queries the oplog for the oldest entry it contains. It returns
+// a zero-valued time and `mongo.ErrNoDocuments` if the oplog contains no entries.
+func oldestOplogEntry(ctx context.Context, client *mongo.Client) (time.Time, error) {
 	var db = client.Database("local")
 	var oplog = db.Collection("oplog.rs")
 
-	// get latest record
-	var opts = options.FindOne().SetSort(bson.D{{NaturalSort, SortDescending}})
-	var latest oplogRecord
-	if err := oplog.FindOne(ctx, bson.D{}, opts).Decode(&latest); err != nil {
-		return 0, fmt.Errorf("querying latest oplog record: %w", err)
-	}
-
-	// get oldest record
-	opts = options.FindOne().SetSort(bson.D{{NaturalSort, SortAscending}})
+	var opts = options.FindOne().SetSort(bson.D{{NaturalSort, SortAscending}})
 	var oldest oplogRecord
-	if err := oplog.FindOne(ctx, bson.D{}, opts).Decode(&oldest); err != nil {
-		return 0, fmt.Errorf("querying oldest oplog record: %w", err)
+	var err = oplog.FindOne(ctx, bson.D{}, opts).Decode(&oldest)
+	if err != nil {
+		return time.Time{}, err
 	}
-
-	return latest.Ts.T - oldest.Ts.T, nil
+	return time.Unix(int64(oldest.Ts.T), 0).UTC(), err
 }
 
 // Check whether the timestamp ts is included in the oplog. This check is

--- a/source-mongodb/pull_test.go
+++ b/source-mongodb/pull_test.go
@@ -1,0 +1,64 @@
+package main
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCheckBackfillState(t *testing.T) {
+	// Starting fresh, with an empty oplog
+	var state = &captureState{}
+	var oldestOplogEntry time.Time
+
+	var updated, restartReason = checkBackfillState(state, oldestOplogEntry)
+	require.True(t, updated)
+	require.Equal(t, "", restartReason)
+	require.True(t, *state.OplogEmptyBeforeBackfill)
+
+	// Starting fresh with a non-empty oplog
+	state = &captureState{}
+	oldestOplogEntry = time.Unix(5000, 0).UTC()
+	updated, restartReason = checkBackfillState(state, oldestOplogEntry)
+	require.True(t, updated)
+	require.Equal(t, "", restartReason)
+	require.False(t, *state.OplogEmptyBeforeBackfill)
+
+	// Resuming an in progress backfill, which started after the oldest oplog
+	// event and had previously observed the non-empty oplog
+	state.Resources = map[string]resourceState{
+		"testdb.testcollection": {
+			Backfill: backfillState{
+				Done:      false,
+				StartedAt: time.Unix(6000, 0),
+			},
+		},
+	}
+	updated, restartReason = checkBackfillState(state, oldestOplogEntry)
+	require.False(t, updated)
+	require.Equal(t, "", restartReason)
+	require.False(t, *state.OplogEmptyBeforeBackfill)
+
+	// Resuming an in progress backfill, which started before the oldest oplog event
+	oldestOplogEntry = time.Unix(8000, 0).UTC()
+	updated, restartReason = checkBackfillState(state, oldestOplogEntry)
+	require.False(t, updated)
+	require.Equal(t, "the oldest event in the mongodb oplog (1970-01-01 02:13:20 +0000 UTC) is more recent than the starting time of the backfill", restartReason)
+
+	// Resuming an in progress backfill, which had previously observed a non-empty oplog
+	// and now observes an empty oplog
+	oldestOplogEntry = time.Time{}
+	updated, restartReason = checkBackfillState(state, oldestOplogEntry)
+	require.False(t, updated)
+	require.Equal(t, "previously non-empty change stream is now empty", restartReason)
+
+	// Resuming an in progress backfill, which had previously observed an empty oplog
+	// and now again observes it being empty
+	var superHighTechTrue = true
+	state.OplogEmptyBeforeBackfill = &superHighTechTrue
+	updated, restartReason = checkBackfillState(state, oldestOplogEntry)
+	require.False(t, updated)
+	require.Equal(t, "", restartReason)
+	require.True(t, *state.OplogEmptyBeforeBackfill)
+}


### PR DESCRIPTION
**Description:**

The current approach to mongodb backfills relies on time-based checks to ensure that we haven't missed any replication events that happen during a backfill. These checks caused problems for captures from shared database servers, like the entry-level instances on MongoDB Atlas.  Such shared servers don't provide unlimited access to the oplog, since the oplog itself is shared by many users. This raises the possibility that querying the oplog can potentially return no events, in the case that it gets filled with events that we aren't authorized to read.

This commit changes the behavior around oplog checks to account for that possibility, with the ultimate goal of being able to robustly capture from the sorts of cheap/free instances that users are likely to test with.

It's no longer necessarily considered a terminal error if we observe no events in the oplog.  We check the oplog before starting the backfill, and persist a boolean that says whether we've observed any events in the oplog. After the backfill is complete, we once again check if there's any events in the oplog. If there were previously events in the oplog, and after the backfill there are none, then we consider that to indicate a possible loss of consistency and start over.

We still check the timestamp of the oldest oplog entry, as before, and ensure that it's older than the start time of the backfill.  The only difference is that we now allow skipping this check in the specific case that the oplog contained zero entries before we started the backfill.

This all required some fairly significant refactoring, and I tried to improve both test coverage and readability along the way.

**Workflow steps:**

- Create a free-tier instance on MongoDB Atlas, but don't add any data
- Setup a capture
- It works!

**Documentation links affected:**

TODO: still checking to see if there's stuff in the docs that should be updated

**Notes for reviewers:**

Discussed in [this Slack thread](https://estuaryworkspace.slack.com/archives/C03Q2NRFKDL/p1702402565306109)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1128)
<!-- Reviewable:end -->
