### PR TITLE
sqlcapture: DEBUG-log the results of startup table discovery

### DIFF
--- a/sqlcapture/capture.go
+++ b/sqlcapture/capture.go
@@ -139,6 +139,13 @@ func (c *Capture) Run(ctx context.Context) (err error) {
 	if err != nil {
 		return fmt.Errorf("error discovering database tables: %w", err)
 	}
+	for streamID, discoveryInfo := range c.discovery {
+		logrus.WithFields(logrus.Fields{
+			"table":      streamID,
+			"primaryKey": discoveryInfo.PrimaryKey,
+			"columns":    discoveryInfo.Columns,
+		}).Debug("discovered table")
+	}
 
 	if err := c.updateState(ctx); err != nil {
 		return fmt.Errorf("error updating capture state: %w", err)


### PR DESCRIPTION
**Description:**

Sometimes it would be pretty convenient if we could turn on debug logs in production and see the full list of all tables discovered and their columns and the types of those columns.

Since by default we're only running at INFO level in production this should be fine, although it will make test output noisier.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1130)
<!-- Reviewable:end -->
