### PR TITLE
tests: fix run.sh file, flowctl-go api spec deprecated, use flowctl raw

### DIFF
--- a/tests/run.sh
+++ b/tests/run.sh
@@ -72,7 +72,17 @@ DATA_PLANE_PID=$!
 trap "kill -s SIGTERM ${DATA_PLANE_PID} && wait ${DATA_PLANE_PID}" EXIT
 
 # Get the spec from the connector and ensure it's valid json.
-flowctl-go api spec --image "${CONNECTOR_IMAGE}" | jq -cM || bail "failed to validate spec"
+cat > "$TESTDIR/spec.yaml" << EOF
+captures:
+  tests/${CONNECTOR}/from-source:
+    endpoint:
+      connector:
+        image: "${CONNECTOR_IMAGE}"
+        config: {}
+    bindings: []
+EOF
+
+flowctl raw spec --source "$TESTDIR/spec.yaml" | jq -cM || bail "failed to validate spec"
 
 # Execute test-specific setup steps.
 echo -e "\nexecuting setup"


### PR DESCRIPTION
**Description:**

- `flowctl-go api spec` has been removed
- replaced it with a call to `flowctl raw spec`

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1138)
<!-- Reviewable:end -->
