### PR TITLE
source-dynamodb: pin dynamodb-local image used in testing

### DIFF
--- a/source-dynamodb/docker-compose.yaml
+++ b/source-dynamodb/docker-compose.yaml
@@ -2,7 +2,7 @@ version: '3.7'
 
 services:
   db:
-    image: "amazon/dynamodb-local:latest"
+    image: "amazon/dynamodb-local:2.1.0"
     command: "-jar DynamoDBLocal.jar -sharedDb"
     ports:
       - "8000:8000"


### PR DESCRIPTION
**Description:**

The latest `dynamodb-local:2.2.0` image seems to break our tests, somehow not returning any results from streams. I do not believe this is representative in a change in the actual DynamoDB API (clearly our connector still works at capturing from streams; we've changed nothing), so I am pinning the testing `dynamodb-local` image to `2.1.0`, which continues to work with our tests.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1142)
<!-- Reviewable:end -->
