### PR TITLE
source-kafka: fix config field names

### DIFF
--- a/source-kafka/src/configuration.rs
+++ b/source-kafka/src/configuration.rs
@@ -234,7 +234,9 @@ pub enum Credentials {
     },
 
     AWS {
+        #[serde(rename="aws_access_key_id")]
         access_key_id: String,
+        #[serde(rename="aws_secret_access_key")]
         secret_access_key: String,
         region: String,
     }

--- a/source-kafka/src/configuration.rs
+++ b/source-kafka/src/configuration.rs
@@ -85,7 +85,6 @@ impl JsonSchema for Configuration {
                                 "const": "UserPassword"
                             },
                             "mechanism": {
-                                "default": "PLAIN",
                                 "description": "The SASL Mechanism describes how to exchange and authenticate clients/servers.",
                                 "enum": [
                                     "PLAIN",

--- a/source-kafka/src/kafka.rs
+++ b/source-kafka/src/kafka.rs
@@ -312,7 +312,7 @@ fn parse_message<'m>(msg: &'m BorrowedMessage<'m>) -> Result<serde_json::Value, 
     })
 }
 
-static KAFKA_INTERNAL_TOPICS: [&str; 1] = ["__consumer_offsets"];
+static KAFKA_INTERNAL_TOPICS: [&str; 2] = ["__consumer_offsets", "__amazon_msk_canary"];
 
 fn reject_internal_topics(topic: &&MetadataTopic) -> bool {
     !KAFKA_INTERNAL_TOPICS.contains(&topic.name())


### PR DESCRIPTION
**Description:**

- The JSONSchema and the configuration are not linked by code, and in the JSONSchema the credential keys are `aws_access_key_id` and `aws_secret_access_key`, however in the code the struct has `access_key_id` and `secret_access_key`. I had not hit this issue in my tests since I used a local, manually prepared configuration file, but I noticed the discrepancy when trying this out on the UI
- Also removed `PLAIN` as the default `mechanism`, since when you first open the jsonform, it defaults to `PLAIN`, and if you switch to AWS IAM, the default value stays in somehow and becomes part of the config, which is confusing because the user will see it in their config, but in reality it has no effect when using IAM.
- Exclude `__amazon_msk_canary` from discovered bindings since it seems to cause an endless loop of this error:
```
SASL authentication error: SaslAuthenticateRequest failed
```
Although I am not entirely sure if this is specific to this stream or might happen on other streams. I have one stream of data that seems to be doing okay with (I tried increasing the load on this stream and it seems to be fine). What's interesting is in case of `__amazon_msk_canary`, we are able to capture a lot of events, and then the connector fails. I'm assuming there are authentication limitations for accessing this internal topic.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1143)
<!-- Reviewable:end -->
