### PR TITLE
source-dynamodb: map explicit NULL for fields that existed in prior documents

### DIFF
--- a/source-dynamodb/.snapshots/TestCaptureOperations
+++ b/source-dynamodb/.snapshots/TestCaptureOperations
@@ -5,7 +5,7 @@
 {"_meta":{"eventId":"<UUID>","op":"c","approximateCreationDateTime":"<TIMESTAMP>"},"pk":"backfill","string":"value"}
 {"_meta":{"eventId":"<UUID>","op":"c","approximateCreationDateTime":"<TIMESTAMP>"},"pk":"stream","string":"initial"}
 {"_meta":{"eventId":"<UUID>","op":"u","approximateCreationDateTime":"<TIMESTAMP>","before":{"pk":"stream","string":"initial"}},"pk":"stream","string":"updated"}
-{"_meta":{"eventId":"<UUID>","op":"d","approximateCreationDateTime":"<TIMESTAMP>","before":{"pk":"stream","string":"updated"}},"pk":"stream"}
+{"_meta":{"eventId":"<UUID>","op":"d","approximateCreationDateTime":"<TIMESTAMP>","before":{"pk":"stream","string":"updated"}},"pk":"stream","string":null}
 # ================================
 # Final State Checkpoint
 # ================================

--- a/source-dynamodb/capture.go
+++ b/source-dynamodb/capture.go
@@ -391,6 +391,15 @@ func (c *capture) emitStream(
 			}
 		}
 
+		// Map an explicit NULL for any fields that existed in the prior record but are now absent
+		// in the current record. This is to allow a top-level merge reduction strategy in the
+		// output documents to appropriately represent deleted fields.
+		for field := range beforeRecord {
+			if _, ok := doc[field]; !ok {
+				doc[field] = nil
+			}
+		}
+
 		doc["_meta"] = meta
 
 		raw, err := json.Marshal(doc)

--- a/source-dynamodb/docker-compose.yaml
+++ b/source-dynamodb/docker-compose.yaml
@@ -2,7 +2,7 @@ version: '3.7'
 
 services:
   db:
-    image: "amazon/dynamodb-local:latest"
+    image: "amazon/dynamodb-local:2.1.0"
     command: "-jar DynamoDBLocal.jar -sharedDb"
     ports:
       - "8000:8000"


### PR DESCRIPTION
**Description:**

When reading change stream documents, map an explicit `NULL` for any fields that existed in the prior record but are now absent in the current record. This is to allow a top-level merge reduction strategy in the output documents to appropriately represent deleted fields. We require captured tables to have `NEW_AND_OLD_IMAGES` set on their streams.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1144)
<!-- Reviewable:end -->
