### PR TITLE
sources: use state keys for `filesource` and batch SQL captures

### DIFF
--- a/filesource/state.go
+++ b/filesource/state.go
@@ -5,16 +5,105 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/sirupsen/logrus"
+	boilerplate "github.com/estuary/connectors/source-boilerplate"
+	pf "github.com/estuary/flow/go/protocols/flow"
+	log "github.com/sirupsen/logrus"
 )
 
-// States is the State of each captured file prefix.
-type States map[string]State
+// unmarshalState for CaptureState provides compatibility with legacy state checkpoints which were a
+// map[string]State keying the stream name to the State. It should be removed when all Filesource
+// captures have migrated to the new state, after which point older captures that haven't migrated
+// will be non-functional.
+func unmarshalState(stateJson json.RawMessage, bindings []*pf.CaptureSpec_Binding) (CaptureState, bool, error) {
+	s := CaptureState{
+		States: make(map[boilerplate.StateKey]State),
+	}
 
-func (p States) Validate() error {
-	for prefix, state := range p {
+	// Legacy states are an object with "streams" from the resource pointing to a State. The new
+	// state is an object with a single key of "bindingStateV1", with that pointing to an object
+	// containing State's keyed by binding stateKeys. Unmarshal into this general structure first to
+	// figure out which one we are dealing with.
+	v := make(map[string]json.RawMessage)
+	if err := json.Unmarshal(stateJson, &v); err != nil {
+		return CaptureState{}, false, err
+	}
+	migrated := false
+
+	if len(v) == 0 {
+		// State was an empty object.
+		return s, migrated, nil
+	}
+
+	// Check to see if we're dealing with an already migrated state which will have the top level
+	// property "bindingStateV1" and only that property, or an old state that has 1 or theoretically
+	// more (but currently all filesource captures only have 1) other top level keys.
+	var newStateProperty = "bindingStateV1"
+	if _, ok := v[newStateProperty]; ok && len(v) != 1 {
+		return CaptureState{}, false, fmt.Errorf("existing state has key 'bindingStateV1' but %d top level keys", len(v))
+	} else if _, ok := v[newStateProperty]; ok {
+		log.Info("skipping state migration since it's already done")
+		if err := json.Unmarshal(v[newStateProperty], &s.States); err != nil {
+			return CaptureState{}, false, err
+		}
+	} else {
+		// There is no key for "bindingStateV1" yet, so we must not have migrated the state and
+		// should do that now.
+		migrated = true
+
+		for _, b := range bindings {
+			if b.StateKey == "" {
+				return CaptureState{}, false, fmt.Errorf("state key was empty for binding %s", b.ResourcePath)
+			}
+
+			var res resource
+			if err := pf.UnmarshalStrict(b.ResourceConfigJson, &res); err != nil {
+				return CaptureState{}, false, fmt.Errorf("error parsing resource config: %w", err)
+			}
+
+			stateRaw, ok := v[res.Stream]
+			if !ok {
+				// We've already established that v has keys, so bail out if the state can't be
+				// found. All current filesource captures have only a single binding and will either
+				// have that one binding in the state or have an empty state that didn't even need
+				// to be migrated, so getting here should be impossible.
+				return CaptureState{}, false, fmt.Errorf("existing state not found for stream %q", res.Stream)
+			}
+
+			var streamState State
+			if err := json.Unmarshal(stateRaw, &streamState); err != nil {
+				return CaptureState{}, false, err
+			}
+			s.States[boilerplate.StateKey(b.StateKey)] = streamState
+
+			log.WithFields(log.Fields{
+				"stateKey":    b.StateKey,
+				"stream":      res.Stream,
+				"streamState": streamState,
+			}).Info("migrated binding state")
+		}
+
+		log.WithFields(log.Fields{
+			"oldState": string(stateJson),
+			"newState": s,
+		}).Info("migrated capture state")
+	}
+
+	if err := s.Validate(); err != nil {
+		return CaptureState{}, false, err
+	}
+
+	return s, migrated, nil
+}
+
+// CaptureState is the State of each captured binding.
+type CaptureState struct {
+	States map[boilerplate.StateKey]State `json:"bindingStateV1,omitempty"`
+}
+
+func (s CaptureState) Validate() error {
+	for stateKey, state := range s.States {
 		if err := state.Validate(); err != nil {
-			return fmt.Errorf("prefix %s: %w", prefix, err)
+			return fmt.Errorf("stateKey %s: %w", stateKey, err)
 		}
 	}
 	return nil
@@ -198,7 +287,7 @@ func (p *State) finishPath() {
 		// store is very delayed and is PUTing objects at wall-clock future
 		// timepoints, with effective modification times _behind_ the selected
 		// horizon timestamp.
-		logrus.WithFields(logrus.Fields{
+		log.WithFields(log.Fields{
 			"horizon": p.MaxBound,
 			"path":    p.Path,
 			"records": p.Records,

--- a/source-bigquery-batch/.snapshots/TestBasicCapture-Capture
+++ b/source-bigquery-batch/.snapshots/TestBasicCapture-Capture
@@ -14,5 +14,5 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"Streams":{"basic_capture_826935":{"CursorNames":["id"],"CursorValues":[9],"LastPolled":"<TIMESTAMP>"}}}
+{"bindingStateV1":{"basic_capture_826935":{"CursorNames":["id"],"CursorValues":[9],"LastPolled":"<TIMESTAMP>"}}}
 

--- a/source-bigquery-batch/.snapshots/TestBasicCapture-Discovery
+++ b/source-bigquery-batch/.snapshots/TestBasicCapture-Discovery
@@ -48,6 +48,7 @@ Binding 0:
         "/id"
       ],
       "projections": null
-    }
+    },
+    "state_key": "basic_capture_826935"
   }
 

--- a/source-bigquery-batch/driver.go
+++ b/source-bigquery-batch/driver.go
@@ -410,13 +410,17 @@ func (drv *BatchSQLDriver) Pull(open *pc.Request_Open, stream *boilerplate.PullO
 	}
 	defer db.Close()
 
-	var resources []Resource
-	for _, binding := range open.Capture.Bindings {
+	var bindings []bindingInfo
+	for idx, binding := range open.Capture.Bindings {
 		var res Resource
 		if err := pf.UnmarshalStrict(binding.ResourceConfigJson, &res); err != nil {
 			return fmt.Errorf("parsing resource config: %w", err)
 		}
-		resources = append(resources, res)
+		bindings = append(bindings, bindingInfo{
+			resource: res,
+			index:    idx,
+			stateKey: boilerplate.StateKey(binding.StateKey),
+		})
 	}
 
 	var state captureState
@@ -425,27 +429,47 @@ func (drv *BatchSQLDriver) Pull(open *pc.Request_Open, stream *boilerplate.PullO
 			return fmt.Errorf("parsing state checkpoint: %w", err)
 		}
 	}
-	state, err = updateResourceStates(state, resources)
+
+	migrated, err := migrateState(&state, open.Capture.Bindings)
+	if err != nil {
+		return fmt.Errorf("migrating binding states: %w", err)
+	}
+
+	state, err = updateResourceStates(state, bindings)
 	if err != nil {
 		return fmt.Errorf("error initializing resource states: %w", err)
 	}
 
+	if err := stream.Ready(false); err != nil {
+		return err
+	}
+
+	if migrated {
+		if cp, err := json.Marshal(state); err != nil {
+			return fmt.Errorf("error serializing checkpoint: %w", err)
+		} else if err := stream.Checkpoint(cp, false); err != nil {
+			return fmt.Errorf("updating migrated checkpoint: %w", err)
+		}
+	}
+
 	var capture = &capture{
-		Config:    &cfg,
-		State:     &state,
-		DB:        db,
-		Resources: resources,
-		Output:    stream,
+		Config:   &cfg,
+		State:    &state,
+		DB:       db,
+		Bindings: bindings,
+		Output:   stream,
 	}
 	return capture.Run(stream.Context())
 }
 
-func updateResourceStates(prevState captureState, resources []Resource) (captureState, error) {
+func updateResourceStates(prevState captureState, bindings []bindingInfo) (captureState, error) {
 	var newState = captureState{
-		Streams: make(map[string]*streamState),
+		Streams: make(map[boilerplate.StateKey]*streamState),
 	}
-	for _, res := range resources {
-		var stream = prevState.Streams[res.Name]
+	for _, binding := range bindings {
+		var sk = binding.stateKey
+		var res = binding.resource
+		var stream = prevState.Streams[sk]
 		if stream != nil && !slices.Equal(stream.CursorNames, res.Cursor) {
 			log.WithFields(log.Fields{
 				"name": res.Name,
@@ -457,22 +481,70 @@ func updateResourceStates(prevState captureState, resources []Resource) (capture
 		if stream == nil {
 			stream = &streamState{CursorNames: res.Cursor}
 		}
-		newState.Streams[res.Name] = stream
+		newState.Streams[sk] = stream
 	}
 	return newState, nil
 }
 
 type capture struct {
-	Config    *Config
-	State     *captureState
-	DB        *bigquery.Client
-	Resources []Resource
-	Output    *boilerplate.PullOutput
-	Mutex     sync.Mutex
+	Config   *Config
+	State    *captureState
+	DB       *bigquery.Client
+	Bindings []bindingInfo
+	Output   *boilerplate.PullOutput
+	Mutex    sync.Mutex
+}
+
+type bindingInfo struct {
+	resource Resource
+	index    int
+	stateKey boilerplate.StateKey
 }
 
 type captureState struct {
-	Streams map[string]*streamState
+	Streams    map[boilerplate.StateKey]*streamState `json:"bindingStateV1,omitempty"`
+	OldStreams map[string]*streamState               `json:"Streams,omitempty"` // TODO(whb): Remove once all captures have migrated.
+}
+
+func migrateState(state *captureState, bindings []*pf.CaptureSpec_Binding) (bool, error) {
+	if state.Streams != nil && state.OldStreams != nil {
+		return false, fmt.Errorf("application error: both Streams and OldStreams were non-nil")
+	} else if state.Streams != nil {
+		log.Info("skipping state migration since it's already done")
+		return false, nil
+	}
+
+	state.Streams = make(map[boilerplate.StateKey]*streamState)
+
+	for _, b := range bindings {
+		if b.StateKey == "" {
+			return false, fmt.Errorf("state key was empty for binding %s", b.ResourcePath)
+		}
+
+		var res Resource
+		if err := pf.UnmarshalStrict(b.ResourceConfigJson, &res); err != nil {
+			return false, fmt.Errorf("parsing resource config: %w", err)
+		}
+
+		ll := log.WithFields(log.Fields{
+			"stateKey": b.StateKey,
+			"name":     res.Name,
+		})
+
+		stateFromOldStreams, ok := state.OldStreams[res.Name]
+		if !ok {
+			// This may happen if the connector has never emitted any checkpoints.
+			ll.Warn("no state found for binding while migrating state")
+			continue
+		}
+
+		state.Streams[boilerplate.StateKey(b.StateKey)] = stateFromOldStreams
+		ll.Info("migrated binding state")
+	}
+
+	state.OldStreams = nil
+
+	return true, nil
 }
 
 type streamState struct {
@@ -486,15 +558,10 @@ func (s *captureState) Validate() error {
 }
 
 func (c *capture) Run(ctx context.Context) error {
-	// Notify Flow that we're starting.
-	if err := c.Output.Ready(false); err != nil {
-		return err
-	}
-
 	var eg, workerCtx = errgroup.WithContext(ctx)
-	for idx, res := range c.Resources {
-		var idx, res = idx, res // Copy for goroutine closure
-		eg.Go(func() error { return c.worker(workerCtx, idx, &res) })
+	for _, binding := range c.Bindings {
+		var binding = binding // Copy for goroutine closure
+		eg.Go(func() error { return c.worker(workerCtx, &binding) })
 	}
 	if err := eg.Wait(); err != nil {
 		return fmt.Errorf("capture terminated with error: %w", err)
@@ -502,7 +569,8 @@ func (c *capture) Run(ctx context.Context) error {
 	return nil
 }
 
-func (c *capture) worker(ctx context.Context, bindingIndex int, res *Resource) error {
+func (c *capture) worker(ctx context.Context, binding *bindingInfo) error {
+	var res = binding.resource
 	log.WithFields(log.Fields{
 		"name":   res.Name,
 		"tmpl":   res.Template,
@@ -516,7 +584,7 @@ func (c *capture) worker(ctx context.Context, bindingIndex int, res *Resource) e
 	}
 
 	for ctx.Err() == nil {
-		if err := c.poll(ctx, bindingIndex, queryTemplate, res); err != nil {
+		if err := c.poll(ctx, binding, queryTemplate); err != nil {
 			return fmt.Errorf("error polling table: %w", err)
 		}
 	}
@@ -529,8 +597,10 @@ func quoteIdentifier(name string) string {
 
 func quoteColumnName(name string) string { return quoteIdentifier(name) }
 
-func (c *capture) poll(ctx context.Context, bindingIndex int, tmpl *template.Template, res *Resource) error {
-	var state, ok = c.State.Streams[res.Name]
+func (c *capture) poll(ctx context.Context, binding *bindingInfo, tmpl *template.Template) error {
+	var res = binding.resource
+	var stateKey = binding.stateKey
+	var state, ok = c.State.Streams[stateKey]
 	if !ok {
 		return fmt.Errorf("internal error: no state for stream %q", res.Name)
 	}
@@ -660,7 +730,7 @@ func (c *capture) poll(ctx context.Context, bindingIndex int, tmpl *template.Tem
 		serializedDocument, err = shape.Encode(serializedDocument, rowValues)
 		if err != nil {
 			return fmt.Errorf("error serializing document: %w", err)
-		} else if err := c.Output.Documents(bindingIndex, serializedDocument); err != nil {
+		} else if err := c.Output.Documents(binding.index, serializedDocument); err != nil {
 			return fmt.Errorf("error emitting document: %w", err)
 		}
 
@@ -676,14 +746,14 @@ func (c *capture) poll(ctx context.Context, bindingIndex int, tmpl *template.Tem
 
 		count++
 		if count%documentsPerCheckpoint == 0 {
-			if err := c.streamStateCheckpoint(res.Name, state); err != nil {
+			if err := c.streamStateCheckpoint(stateKey, state); err != nil {
 				return err
 			}
 		}
 	}
 
 	if count%documentsPerCheckpoint != 0 {
-		if err := c.streamStateCheckpoint(res.Name, state); err != nil {
+		if err := c.streamStateCheckpoint(stateKey, state); err != nil {
 			return err
 		}
 	}
@@ -695,9 +765,9 @@ func (c *capture) poll(ctx context.Context, bindingIndex int, tmpl *template.Tem
 	return nil
 }
 
-func (c *capture) streamStateCheckpoint(name string, state *streamState) error {
-	var checkpointPatch = captureState{Streams: make(map[string]*streamState)}
-	checkpointPatch.Streams[name] = state
+func (c *capture) streamStateCheckpoint(sk boilerplate.StateKey, state *streamState) error {
+	var checkpointPatch = captureState{Streams: make(map[boilerplate.StateKey]*streamState)}
+	checkpointPatch.Streams[sk] = state
 
 	if checkpointJSON, err := json.Marshal(checkpointPatch); err != nil {
 		return fmt.Errorf("error serializing state checkpoint: %w", err)

--- a/source-bigquery-batch/main_test.go
+++ b/source-bigquery-batch/main_test.go
@@ -224,6 +224,7 @@ func discoverStreams(ctx context.Context, t testing.TB, cs *st.CaptureSpec, matc
 				Key:            discovered.Key,
 			},
 			ResourcePath: []string{res.Name},
+			StateKey:     res.Name,
 		})
 	}
 	return bindings

--- a/source-mysql-batch/.snapshots/TestBasicCapture
+++ b/source-mysql-batch/.snapshots/TestBasicCapture
@@ -254,5 +254,5 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"Streams":{"test_basic_capture_826935":{"CursorNames":["id"],"CursorValues":[249],"LastPolled":"<TIMESTAMP>"}}}
+{"bindingStateV1":{"test_basic_capture_826935":{"CursorNames":["id"],"CursorValues":[249],"LastPolled":"<TIMESTAMP>"}}}
 

--- a/source-mysql-batch/driver.go
+++ b/source-mysql-batch/driver.go
@@ -412,13 +412,17 @@ func (drv *BatchSQLDriver) Pull(open *pc.Request_Open, stream *boilerplate.PullO
 	}
 	defer db.Close()
 
-	var resources []Resource
-	for _, binding := range open.Capture.Bindings {
+	var bindings []bindingInfo
+	for idx, binding := range open.Capture.Bindings {
 		var res Resource
 		if err := pf.UnmarshalStrict(binding.ResourceConfigJson, &res); err != nil {
 			return fmt.Errorf("parsing resource config: %w", err)
 		}
-		resources = append(resources, res)
+		bindings = append(bindings, bindingInfo{
+			resource: res,
+			index:    idx,
+			stateKey: boilerplate.StateKey(binding.StateKey),
+		})
 	}
 
 	var state captureState
@@ -427,27 +431,47 @@ func (drv *BatchSQLDriver) Pull(open *pc.Request_Open, stream *boilerplate.PullO
 			return fmt.Errorf("parsing state checkpoint: %w", err)
 		}
 	}
-	state, err = updateResourceStates(state, resources)
+
+	migrated, err := migrateState(&state, open.Capture.Bindings)
+	if err != nil {
+		return fmt.Errorf("migrating binding states: %w", err)
+	}
+
+	state, err = updateResourceStates(state, bindings)
 	if err != nil {
 		return fmt.Errorf("error initializing resource states: %w", err)
 	}
 
+	if err := stream.Ready(false); err != nil {
+		return err
+	}
+
+	if migrated {
+		if cp, err := json.Marshal(state); err != nil {
+			return fmt.Errorf("error serializing checkpoint: %w", err)
+		} else if err := stream.Checkpoint(cp, false); err != nil {
+			return fmt.Errorf("updating migrated checkpoint: %w", err)
+		}
+	}
+
 	var capture = &capture{
-		Config:    &cfg,
-		State:     &state,
-		DB:        db,
-		Resources: resources,
-		Output:    stream,
+		Config:   &cfg,
+		State:    &state,
+		DB:       db,
+		Bindings: bindings,
+		Output:   stream,
 	}
 	return capture.Run(stream.Context())
 }
 
-func updateResourceStates(prevState captureState, resources []Resource) (captureState, error) {
+func updateResourceStates(prevState captureState, bindings []bindingInfo) (captureState, error) {
 	var newState = captureState{
-		Streams: make(map[string]*streamState),
+		Streams: make(map[boilerplate.StateKey]*streamState),
 	}
-	for _, res := range resources {
-		var stream = prevState.Streams[res.Name]
+	for _, binding := range bindings {
+		var sk = binding.stateKey
+		var res = binding.resource
+		var stream = prevState.Streams[sk]
 		if stream != nil && !slices.Equal(stream.CursorNames, res.Cursor) {
 			log.WithFields(log.Fields{
 				"name": res.Name,
@@ -459,22 +483,70 @@ func updateResourceStates(prevState captureState, resources []Resource) (capture
 		if stream == nil {
 			stream = &streamState{CursorNames: res.Cursor}
 		}
-		newState.Streams[res.Name] = stream
+		newState.Streams[sk] = stream
 	}
 	return newState, nil
 }
 
 type capture struct {
-	Config    *Config
-	State     *captureState
-	DB        *client.Conn
-	Resources []Resource
-	Output    *boilerplate.PullOutput
-	Mutex     sync.Mutex
+	Config   *Config
+	State    *captureState
+	DB       *client.Conn
+	Bindings []bindingInfo
+	Output   *boilerplate.PullOutput
+	Mutex    sync.Mutex
+}
+
+type bindingInfo struct {
+	resource Resource
+	index    int
+	stateKey boilerplate.StateKey
 }
 
 type captureState struct {
-	Streams map[string]*streamState
+	Streams    map[boilerplate.StateKey]*streamState `json:"bindingStateV1,omitempty"`
+	OldStreams map[string]*streamState               `json:"Streams,omitempty"` // TODO(whb): Remove once all captures have migrated.
+}
+
+func migrateState(state *captureState, bindings []*pf.CaptureSpec_Binding) (bool, error) {
+	if state.Streams != nil && state.OldStreams != nil {
+		return false, fmt.Errorf("application error: both Streams and OldStreams were non-nil")
+	} else if state.Streams != nil {
+		log.Info("skipping state migration since it's already done")
+		return false, nil
+	}
+
+	state.Streams = make(map[boilerplate.StateKey]*streamState)
+
+	for _, b := range bindings {
+		if b.StateKey == "" {
+			return false, fmt.Errorf("state key was empty for binding %s", b.ResourcePath)
+		}
+
+		var res Resource
+		if err := pf.UnmarshalStrict(b.ResourceConfigJson, &res); err != nil {
+			return false, fmt.Errorf("parsing resource config: %w", err)
+		}
+
+		ll := log.WithFields(log.Fields{
+			"stateKey": b.StateKey,
+			"name":     res.Name,
+		})
+
+		stateFromOldStreams, ok := state.OldStreams[res.Name]
+		if !ok {
+			// This may happen if the connector has never emitted any checkpoints.
+			ll.Warn("no state found for binding while migrating state")
+			continue
+		}
+
+		state.Streams[boilerplate.StateKey(b.StateKey)] = stateFromOldStreams
+		ll.Info("migrated binding state")
+	}
+
+	state.OldStreams = nil
+
+	return true, nil
 }
 
 type streamState struct {
@@ -488,15 +560,10 @@ func (s *captureState) Validate() error {
 }
 
 func (c *capture) Run(ctx context.Context) error {
-	// Notify Flow that we're starting.
-	if err := c.Output.Ready(false); err != nil {
-		return err
-	}
-
 	var eg, workerCtx = errgroup.WithContext(ctx)
-	for idx, res := range c.Resources {
-		var idx, res = idx, res // Copy for goroutine closure
-		eg.Go(func() error { return c.worker(workerCtx, idx, &res) })
+	for _, binding := range c.Bindings {
+		var binding = binding // Copy for goroutine closure
+		eg.Go(func() error { return c.worker(workerCtx, &binding) })
 	}
 	if err := eg.Wait(); err != nil {
 		return fmt.Errorf("capture terminated with error: %w", err)
@@ -504,7 +571,8 @@ func (c *capture) Run(ctx context.Context) error {
 	return nil
 }
 
-func (c *capture) worker(ctx context.Context, bindingIndex int, res *Resource) error {
+func (c *capture) worker(ctx context.Context, binding *bindingInfo) error {
+	var res = binding.resource
 	log.WithFields(log.Fields{
 		"name":   res.Name,
 		"tmpl":   res.Template,
@@ -518,7 +586,7 @@ func (c *capture) worker(ctx context.Context, bindingIndex int, res *Resource) e
 	}
 
 	for ctx.Err() == nil {
-		if err := c.poll(ctx, bindingIndex, queryTemplate, res); err != nil {
+		if err := c.poll(ctx, binding, queryTemplate); err != nil {
 			return fmt.Errorf("error polling table: %w", err)
 		}
 	}
@@ -581,8 +649,10 @@ func quoteColumnName(name string) string {
 	return "`" + strings.ReplaceAll(name, "`", "``") + "`"
 }
 
-func (c *capture) poll(ctx context.Context, bindingIndex int, tmpl *template.Template, res *Resource) error {
-	var state, ok = c.State.Streams[res.Name]
+func (c *capture) poll(ctx context.Context, binding *bindingInfo, tmpl *template.Template) error {
+	var res = binding.resource
+	var stateKey = binding.stateKey
+	var state, ok = c.State.Streams[stateKey]
 	if !ok {
 		return fmt.Errorf("internal error: no state for stream %q", res.Name)
 	}
@@ -709,7 +779,7 @@ func (c *capture) poll(ctx context.Context, bindingIndex int, tmpl *template.Tem
 		serializedDocument, err = shape.Encode(serializedDocument, rowValues)
 		if err != nil {
 			return fmt.Errorf("error serializing document: %w", err)
-		} else if err := c.Output.Documents(bindingIndex, serializedDocument); err != nil {
+		} else if err := c.Output.Documents(binding.index, serializedDocument); err != nil {
 			return fmt.Errorf("error emitting document: %w", err)
 		}
 
@@ -725,7 +795,7 @@ func (c *capture) poll(ctx context.Context, bindingIndex int, tmpl *template.Tem
 
 		count++
 		if count%documentsPerCheckpoint == 0 {
-			if err := c.streamStateCheckpoint(res.Name, state); err != nil {
+			if err := c.streamStateCheckpoint(stateKey, state); err != nil {
 				return err
 			}
 		}
@@ -735,7 +805,7 @@ func (c *capture) poll(ctx context.Context, bindingIndex int, tmpl *template.Tem
 	}
 
 	if count%documentsPerCheckpoint != 0 {
-		if err := c.streamStateCheckpoint(res.Name, state); err != nil {
+		if err := c.streamStateCheckpoint(stateKey, state); err != nil {
 			return err
 		}
 	}
@@ -747,9 +817,9 @@ func (c *capture) poll(ctx context.Context, bindingIndex int, tmpl *template.Tem
 	return nil
 }
 
-func (c *capture) streamStateCheckpoint(name string, state *streamState) error {
-	var checkpointPatch = captureState{Streams: make(map[string]*streamState)}
-	checkpointPatch.Streams[name] = state
+func (c *capture) streamStateCheckpoint(sk boilerplate.StateKey, state *streamState) error {
+	var checkpointPatch = captureState{Streams: make(map[boilerplate.StateKey]*streamState)}
+	checkpointPatch.Streams[sk] = state
 
 	if checkpointJSON, err := json.Marshal(checkpointPatch); err != nil {
 		return fmt.Errorf("error serializing state checkpoint: %w", err)

--- a/source-mysql-batch/main_test.go
+++ b/source-mysql-batch/main_test.go
@@ -183,6 +183,7 @@ func discoverStreams(ctx context.Context, t testing.TB, cs *st.CaptureSpec, matc
 				Key:            discovered.Key,
 			},
 			ResourcePath: []string{res.Name},
+			StateKey:     res.Name,
 		})
 	}
 	return bindings

--- a/source-postgres-batch/.snapshots/TestBasicCapture
+++ b/source-postgres-batch/.snapshots/TestBasicCapture
@@ -254,5 +254,5 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"Streams":{"test_basic_capture_826935":{"CursorNames":["txid"],"CursorValues":[999999],"LastPolled":"<TIMESTAMP>"}}}
+{"bindingStateV1":{"test_basic_capture_826935":{"CursorNames":["txid"],"CursorValues":[999999],"LastPolled":"<TIMESTAMP>"}}}
 

--- a/source-postgres-batch/main_test.go
+++ b/source-postgres-batch/main_test.go
@@ -135,6 +135,7 @@ func discoverStreams(ctx context.Context, t testing.TB, cs *st.CaptureSpec, matc
 				Key:            discovered.Key,
 			},
 			ResourcePath: []string{res.Name},
+			StateKey:     res.Name,
 		})
 	}
 	return bindings


### PR DESCRIPTION
**Description:**

Updates the 3 SQL batch captures to use state keys: `source-bigquery-batch`, `source-mysql-batch`, and `source-postgres-batch`. These were all pretty straightforward and nearly identical changes.

Also updates the `filesource` framework to use state keys. This was slightly more involved because of that way the previous checkpoint was structured. There are 5 captures that use this framework.

We'll be able to remove the "migration" shims for these captures once all existing captures have migrated, and perhaps after some amount of time has passed where we are confident that no previously disabled captures will start back up that we don't want to be broken.

See issue https://github.com/estuary/connectors/issues/1146

**Workflow steps:**

Use `backfill` to re-start any of these captures from the beginning.

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1150)
<!-- Reviewable:end -->
