### PR TITLE
materialize-mongodb: remove _id property from loaded docs

### DIFF
--- a/materialize-mongodb/transactor.go
+++ b/materialize-mongodb/transactor.go
@@ -280,6 +280,14 @@ func (t *transactor) storeWorker(
 }
 
 func sanitizeDocument(doc map[string]interface{}) map[string]interface{} {
+	// We need to remove the _id property from loaded documents because the
+	// Flow collection schemas may forbid that property. If we left it in, it
+	// could cause validation errors on loaded documents.
+	delete(doc, idField)
+	return sanitizeDocumentInner(doc)
+}
+
+func sanitizeDocumentInner(doc map[string]interface{}) map[string]interface{} {
 	for key, value := range doc {
 		switch v := value.(type) {
 		case float64:
@@ -287,7 +295,7 @@ func sanitizeDocument(doc map[string]interface{}) map[string]interface{} {
 				doc[key] = "NaN"
 			}
 		case map[string]interface{}:
-			doc[key] = sanitizeDocument(v)
+			doc[key] = sanitizeDocumentInner(v)
 		}
 	}
 

--- a/tests/materialize/materialize-mongodb/snapshot.json
+++ b/tests/materialize/materialize-mongodb/snapshot.json
@@ -19,7 +19,6 @@
 {
   "loaded": {
     "doc": {
-      "_id": "1501",
       "_meta": {
         "uuid": "75c06bd6-20e0-11ee-990b-ffd12dfcd47f"
       },
@@ -32,7 +31,6 @@
 {
   "loaded": {
     "doc": {
-      "_id": "1502",
       "_meta": {
         "uuid": "7dbe8ebc-20e0-11ee-990b-ffd12dfcd47f"
       },
@@ -45,7 +43,6 @@
 {
   "loaded": {
     "doc": {
-      "_id": "1503",
       "_meta": {
         "uuid": "8bbf898a-20e0-11ee-990b-ffd12dfcd47f"
       },
@@ -58,7 +55,6 @@
 {
   "loaded": {
     "doc": {
-      "_id": "1504",
       "_meta": {
         "uuid": "9b994ae4-20e0-11ee-990b-ffd12dfcd47f"
       },
@@ -71,7 +67,6 @@
 {
   "loaded": {
     "doc": {
-      "_id": "1505",
       "_meta": {
         "uuid": "bcef4bc6-20e0-11ee-990b-ffd12dfcd47f"
       },


### PR DESCRIPTION
Removes the `_id` property before returning loaded documents. This is to prevent that property from causing schema validation errors for collections that use a top level `reduce: { strategy: merge }`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1156)
<!-- Reviewable:end -->
