### PR TITLE
Revert "materialize-mongodb: remove _id property from loaded docs"

### DIFF
--- a/materialize-mongodb/transactor.go
+++ b/materialize-mongodb/transactor.go
@@ -280,14 +280,6 @@ func (t *transactor) storeWorker(
 }
 
 func sanitizeDocument(doc map[string]interface{}) map[string]interface{} {
-	// We need to remove the _id property from loaded documents because the
-	// Flow collection schemas may forbid that property. If we left it in, it
-	// could cause validation errors on loaded documents.
-	delete(doc, idField)
-	return sanitizeDocumentInner(doc)
-}
-
-func sanitizeDocumentInner(doc map[string]interface{}) map[string]interface{} {
 	for key, value := range doc {
 		switch v := value.(type) {
 		case float64:
@@ -295,7 +287,7 @@ func sanitizeDocumentInner(doc map[string]interface{}) map[string]interface{} {
 				doc[key] = "NaN"
 			}
 		case map[string]interface{}:
-			doc[key] = sanitizeDocumentInner(v)
+			doc[key] = sanitizeDocument(v)
 		}
 	}
 

--- a/tests/materialize/materialize-mongodb/snapshot.json
+++ b/tests/materialize/materialize-mongodb/snapshot.json
@@ -19,6 +19,7 @@
 {
   "loaded": {
     "doc": {
+      "_id": "1501",
       "_meta": {
         "uuid": "75c06bd6-20e0-11ee-990b-ffd12dfcd47f"
       },
@@ -31,6 +32,7 @@
 {
   "loaded": {
     "doc": {
+      "_id": "1502",
       "_meta": {
         "uuid": "7dbe8ebc-20e0-11ee-990b-ffd12dfcd47f"
       },
@@ -43,6 +45,7 @@
 {
   "loaded": {
     "doc": {
+      "_id": "1503",
       "_meta": {
         "uuid": "8bbf898a-20e0-11ee-990b-ffd12dfcd47f"
       },
@@ -55,6 +58,7 @@
 {
   "loaded": {
     "doc": {
+      "_id": "1504",
       "_meta": {
         "uuid": "9b994ae4-20e0-11ee-990b-ffd12dfcd47f"
       },
@@ -67,6 +71,7 @@
 {
   "loaded": {
     "doc": {
+      "_id": "1505",
       "_meta": {
         "uuid": "bcef4bc6-20e0-11ee-990b-ffd12dfcd47f"
       },


### PR DESCRIPTION
Reverts estuary/connectors#1156

We need to re-think this. As implemented here, we'd break use cases where the users data legitimately includes an `_id` field (such as if they're capturing from mongodb 🤦 ).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1157)
<!-- Reviewable:end -->
