### PR TITLE
materialize-databricks: set http timeout to 5 minutes

### DIFF
--- a/materialize-databricks/driver.go
+++ b/materialize-databricks/driver.go
@@ -394,9 +394,10 @@ func newTransactor(
 	var cfg = ep.Config.(*config)
 
 	wsClient, err := databricks.NewWorkspaceClient(&databricks.Config{
-		Host:        fmt.Sprintf("%s/%s", cfg.Address, cfg.HTTPPath),
-		Token:       cfg.Credentials.PersonalAccessToken,
-		Credentials: dbConfig.PatCredentials{}, // enforce PAT auth
+		Host:               fmt.Sprintf("%s/%s", cfg.Address, cfg.HTTPPath),
+		Token:              cfg.Credentials.PersonalAccessToken,
+		Credentials:        dbConfig.PatCredentials{}, // enforce PAT auth
+		HTTPTimeoutSeconds: 5 * 60,                    // This is necessary for file uploads as they can sometimes take longer than the default 60s
 	})
 	if err != nil {
 		return nil, fmt.Errorf("initialising workspace client: %w", err)


### PR DESCRIPTION
**Description:**

- The default timeout for the HTTP client used by the Databricks SDK is one minute. This can trip up when uploading the 128MB files depending on the destination storage's bandwidth. This change updates the timeout to be 5 minutes to allow more time for file uploads.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1163)
<!-- Reviewable:end -->
