### PR TITLE
Modified default query template to find non null cursor

### DIFF
--- a/source-mysql-batch/.snapshots/TestQueryTemplate-FirstOneCursor
+++ b/source-mysql-batch/.snapshots/TestQueryTemplate-FirstOneCursor
@@ -1,1 +1,1 @@
-SELECT * FROM `test`.`foobar`;
+SELECT * FROM `test`.`foobar` ORDER BY `ka`;

--- a/source-mysql-batch/.snapshots/TestQueryTemplate-FirstThreeCursor
+++ b/source-mysql-batch/.snapshots/TestQueryTemplate-FirstThreeCursor
@@ -1,1 +1,1 @@
-SELECT * FROM `test`.`foobar`;
+SELECT * FROM `test`.`foobar` ORDER BY `ka`, `kb`, `kc`;

--- a/source-mysql-batch/.snapshots/TestQueryTemplate-FirstTwoCursor
+++ b/source-mysql-batch/.snapshots/TestQueryTemplate-FirstTwoCursor
@@ -1,1 +1,1 @@
-SELECT * FROM `test`.`foobar`;
+SELECT * FROM `test`.`foobar` ORDER BY `ka`, `kb`;

--- a/source-mysql-batch/main.go
+++ b/source-mysql-batch/main.go
@@ -124,9 +124,9 @@ const tableQueryTemplateTemplate = `{{/*****************************************
    ***********************************************************/ -}}
 {{if .CursorFields -}}
   {{- if .IsFirstQuery -}}
-    SELECT * FROM %[1]s
+    SELECT * FROM %[1]s 
   {{- else -}}
-    SELECT * FROM %[1]s
+    SELECT * FROM %[1]s 
 	{{- range $i, $k := $.CursorFields -}}
 	  {{- if eq $i 0}} WHERE ({{else}}) OR ({{end -}}
       {{- range $j, $n := $.CursorFields -}}

--- a/source-mysql-batch/main.go
+++ b/source-mysql-batch/main.go
@@ -124,7 +124,7 @@ const tableQueryTemplateTemplate = `{{/*****************************************
    ***********************************************************/ -}}
 {{if .CursorFields -}}
   {{- if .IsFirstQuery -}}
-    SELECT * FROM %[1]s;
+    SELECT * FROM %[1]s
   {{- else -}}
     SELECT * FROM %[1]s
 	{{- range $i, $k := $.CursorFields -}}
@@ -137,7 +137,7 @@ const tableQueryTemplateTemplate = `{{/*****************************************
 	{{- end -}}
 	) 
   {{- end -}}
-  ORDER BY {{range $i, $k := $.CursorFields}}{{if gt $i 0}}, {{end}}{{$k}}{{end -}};
+   ORDER BY {{range $i, $k := $.CursorFields}}{{if gt $i 0}}, {{end}}{{$k}}{{end -}};
 {{- else -}}
   SELECT * FROM %[1]s;
 {{- end}}`

--- a/source-mysql-batch/main.go
+++ b/source-mysql-batch/main.go
@@ -124,9 +124,9 @@ const tableQueryTemplateTemplate = `{{/*****************************************
    ***********************************************************/ -}}
 {{if .CursorFields -}}
   {{- if .IsFirstQuery -}}
-    SELECT * FROM %[1]s 
+    SELECT * FROM %[1]s
   {{- else -}}
-    SELECT * FROM %[1]s 
+    SELECT * FROM %[1]s
 	{{- range $i, $k := $.CursorFields -}}
 	  {{- if eq $i 0}} WHERE ({{else}}) OR ({{end -}}
       {{- range $j, $n := $.CursorFields -}}
@@ -137,7 +137,7 @@ const tableQueryTemplateTemplate = `{{/*****************************************
 	{{- end -}}
 	) 
   {{- end -}}
-   ORDER BY {{range $i, $k := $.CursorFields}}{{if gt $i 0}}, {{end}}{{$k}}{{end -}};
+     ORDER BY {{range $i, $k := $.CursorFields}}{{if gt $i 0}}, {{end}}{{$k}}{{end -}};
 {{- else -}}
   SELECT * FROM %[1]s;
 {{- end}}`

--- a/source-mysql-batch/main.go
+++ b/source-mysql-batch/main.go
@@ -136,8 +136,7 @@ const tableQueryTemplateTemplate = `{{/*****************************************
 	  {{$k}} > @flow_cursor_value[{{$i}}]
 	{{- end -}}
 	) 
-  {{- end}}
-  ORDER BY {{range $i, $k := $.CursorFields}}{{if gt $i 0}}, {{end}}{{$k}}{{end -}};
+  {{- end}} ORDER BY {{range $i, $k := $.CursorFields}}{{if gt $i 0}}, {{end}}{{$k}}{{end -}};
 {{- else -}}
   SELECT * FROM %[1]s;
 {{- end}}`

--- a/source-mysql-batch/main.go
+++ b/source-mysql-batch/main.go
@@ -136,8 +136,8 @@ const tableQueryTemplateTemplate = `{{/*****************************************
 	  {{$k}} > @flow_cursor_value[{{$i}}]
 	{{- end -}}
 	) 
-  {{- end -}}
-     ORDER BY {{range $i, $k := $.CursorFields}}{{if gt $i 0}}, {{end}}{{$k}}{{end -}};
+  {{- end}}
+  ORDER BY {{range $i, $k := $.CursorFields}}{{if gt $i 0}}, {{end}}{{$k}}{{end -}};
 {{- else -}}
   SELECT * FROM %[1]s;
 {{- end}}`

--- a/source-mysql-batch/main.go
+++ b/source-mysql-batch/main.go
@@ -135,9 +135,9 @@ const tableQueryTemplateTemplate = `{{/*****************************************
 	  {{- end -}}
 	  {{$k}} > @flow_cursor_value[{{$i}}]
 	{{- end -}}
-	) ORDER BY {{range $i, $k := $.CursorFields}}{{if gt $i 0}}, {{end}}{{$k}}{{end -}}
-	;
+	) 
   {{- end -}}
+  ORDER BY {{range $i, $k := $.CursorFields}}{{if gt $i 0}}, {{end}}{{$k}}{{end -}};
 {{- else -}}
   SELECT * FROM %[1]s;
 {{- end}}`


### PR DESCRIPTION
**Description:**

Fixing bug in the query template where non null values cursor values were not being captured during first query. Query now appends ORDER BY {{cursors}} clause when a cursor is present, whether or not the current query is the first query.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1171)
<!-- Reviewable:end -->
