### PR TITLE
materialize-bigquery: use project containing dataset for querying ORMATION_SCHEMA

### DIFF
--- a/materialize-bigquery/bigquery.go
+++ b/materialize-bigquery/bigquery.go
@@ -241,7 +241,8 @@ func (c client) Apply(ctx context.Context, ep *sql.Endpoint, req *pm.Request_App
 	existing := &sql.ExistingColumns{}
 	for _, ds := range datasets {
 		job, err := client.query(ctx, fmt.Sprintf(
-			"select table_name, column_name, is_nullable, data_type from %s.INFORMATION_SCHEMA.COLUMNS;",
+			"select table_name, column_name, is_nullable, data_type from %s.%s.INFORMATION_SCHEMA.COLUMNS;",
+			bqDialect.Identifier(cfg.ProjectID), // Use the project containing the dataset rather than the billing project if a billing project is configured.
 			bqDialect.Identifier(ds),
 		))
 		if err != nil {


### PR DESCRIPTION
**Description:**

The configured project that contains the dataset must be specified when querying the INFORMATION_SCHEMA views if a billing project is configured, otherwise the query defaults to the billing project which will not contain the desired dataset.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1174)
<!-- Reviewable:end -->
