### PR TITLE
materialize-motherduck: set user agent in connection string

### DIFF
--- a/materialize-motherduck/driver.go
+++ b/materialize-motherduck/driver.go
@@ -73,7 +73,9 @@ func (c *config) Validate() error {
 }
 
 func (c *config) db(ctx context.Context) (*stdsql.DB, error) {
-	db, err := stdsql.Open("duckdb", fmt.Sprintf("md:%s?motherduck_token=%s", c.Database, c.Token))
+	var userAgent = "Estuary"
+
+	db, err := stdsql.Open("duckdb", fmt.Sprintf("md:%s?motherduck_token=%s&custom_user_agent=%s", c.Database, c.Token, userAgent))
 	if err != nil {
 		if strings.Contains(err.Error(), "Jwt header is an invalid JSON (UNAUTHENTICATED") {
 			return nil, fmt.Errorf("invalid token: unauthenticated")


### PR DESCRIPTION
**Description:**

Sets the `custom_user_agent` in the duckdb DSN, to enable tracking partner usage with MotherDuck.

Closes #1166

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1175)
<!-- Reviewable:end -->
