### PR TITLE
materialize-s3-parquet: fix invalid empty state error

### DIFF
--- a/materialize-s3-parquet/driver.go
+++ b/materialize-s3-parquet/driver.go
@@ -330,6 +330,11 @@ func (t *transactor) Store(it *pm.StoreIterator) (pm.StartCommitFunc, error) {
 		if err := t.maybeUpload(); err != nil {
 			return nil, pf.FinishedOperation(err)
 		}
+
+		if len(t.driverCheckpointJSON) == 0 {
+			return nil, pf.FinishedOperation(err)
+		}
+
 		return &pf.ConnectorState{UpdatedJson: t.driverCheckpointJSON},
 			pf.FinishedOperation(err)
 	}, nil

--- a/tests/materialize/materialize-s3-parquet/fetch.sh
+++ b/tests/materialize/materialize-s3-parquet/fetch.sh
@@ -6,7 +6,7 @@ set -o nounset
 
 # The dir relative to ${TEMP_DIR} for storing temp files.
 tmp_dir=tmp
-mkdir -p $(realpath ${TEMP_DIR}/${tmp_dir})
+mkdir -p ${TEMP_DIR}/${tmp_dir}
 
 # Sync data to local.
 >&2 aws s3 sync "s3://${TEST_BUCKET}" ${TEMP_DIR}/${tmp_dir}/ --endpoint-url "${LOCALSTACK_S3_LOCAL_ENDPOINT}" \

--- a/tests/materialize/materialize-s3-parquet/snapshot.json
+++ b/tests/materialize/materialize-s3-parquet/snapshot.json
@@ -11,9 +11,7 @@
   "flushed": {}
 }
 {
-  "startedCommit": {
-    "state": {}
-  }
+  "startedCommit": {}
 }
 {
   "acknowledged": {}
@@ -22,9 +20,7 @@
   "flushed": {}
 }
 {
-  "startedCommit": {
-    "state": {}
-  }
+  "startedCommit": {}
 }
 {
   "acknowledged": {}


### PR DESCRIPTION
**Description:**

- Reproduced the issue by running a materialization locally using `flowctl peview`
- Applied this change, and the connector works

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1181)
<!-- Reviewable:end -->
