### PR TITLE
materialize-sql: fixes for column validations and nullability

### DIFF
--- a/materialize-boilerplate/apply.go
+++ b/materialize-boilerplate/apply.go
@@ -148,10 +148,10 @@ func ApplyChanges(ctx context.Context, req *pm.Request_Apply, applier Applier, i
 					}
 
 					newRequired := projection.Inference.Exists == pf.Inference_MUST && !slices.Contains(projection.Inference.Types, pf.JsonTypeNull)
-					if !existingField.Nullable && !newRequired {
-						// The existing field is not nullable, but the proposed projection for the
-						// field is. The existing field will need to be modified to be made
-						// nullable.
+					if !existingField.Nullable && !newRequired && !existingField.HasDefault {
+						// The existing field is not nullable and does not have a default value, but
+						// the proposed projection for the field is nullable. The existing field
+						// will need to be modified to be made nullable.
 						params.NewlyNullableFields = append(params.NewlyNullableFields, existingField)
 					}
 				} else {

--- a/materialize-boilerplate/info_schema.go
+++ b/materialize-boilerplate/info_schema.go
@@ -16,6 +16,7 @@ type EndpointField struct {
 	Nullable           bool
 	Type               string
 	CharacterMaxLength int
+	HasDefault         bool
 }
 
 // LocatePathFn takes a Flow resource path and outputs an equal-length string slice containing

--- a/materialize-postgres/sqlgen.go
+++ b/materialize-postgres/sqlgen.go
@@ -53,7 +53,7 @@ var pgDialect = func() sql.Dialect {
 	}
 
 	columnValidator := sql.NewColumnValidator(
-		sql.ColValidation{Types: []string{"bigint"}, Validate: sql.IntegerCompatible},
+		sql.ColValidation{Types: []string{"bigint", "integer"}, Validate: sql.IntegerCompatible},
 		sql.ColValidation{Types: []string{"double precision"}, Validate: sql.NumberCompatible},
 		sql.ColValidation{Types: []string{"numeric"}, Validate: sql.NumericCompatible},
 		sql.ColValidation{Types: []string{"boolean"}, Validate: sql.BooleanCompatible},


### PR DESCRIPTION
**Description:**

- For `materialize-postgres`, we create columns as "bigint", but pre-created tables may have columns that are just "integers", and we want to support those.
- In general, columns with default values can be NOT NULL even if the Flow collection field is not required, since
the default value will take the place of a null value for the field.

This works for our stats postgres materialization, which uses pre-created tables with `integer` column types (not `bigint`) and also has `NOT NULL` columns with default values where we are materializing nullable fields. I also ran the tests for all other materializations that consider columns with default values.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1187)
<!-- Reviewable:end -->
