### PR TITLE
materialize-databricks: increase Validate RPC timeout to 1 minute

### DIFF
--- a/materialize-databricks/client.go
+++ b/materialize-databricks/client.go
@@ -198,7 +198,7 @@ func (c *client) PreReqs(ctx context.Context) *sql.PrereqErr {
 	// after inactivity, and this attempt to connect to the warehouse will initiate their boot-up
 	// process however we don't want to wait 5 minutes as that does not create a good UX for the
 	// user in the UI
-	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	ctx, cancel := context.WithTimeout(ctx, 60*time.Second)
 	defer cancel()
 
 	if err := c.db.PingContext(ctx); err != nil {


### PR DESCRIPTION
**Description:**

- This is to allow serverless instances to start up without the user having to re-try. Dedicated warehouses still will timeout as they take more than 5 minutes usually.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1188)
<!-- Reviewable:end -->
