### PR TITLE
fix: Provide primary key `_airtable_id` for `source-airtable`

### DIFF
--- a/source-airtable/source_airtable/source_airtable/schema_helpers.py
+++ b/source-airtable/source_airtable/source_airtable/schema_helpers.py
@@ -142,4 +142,5 @@ class SchemaHelpers:
             json_schema=json_schema,
             supported_sync_modes=[SyncMode.full_refresh],
             supported_destination_sync_modes=[DestinationSyncMode.overwrite, DestinationSyncMode.append_dedup],
+            source_defined_primary_key=[["_airtable_id"]]
         )

--- a/source-airtable/tests/snapshots/source_airtable_tests_test_snapshots__discover__capture.stdout.json
+++ b/source-airtable/tests/snapshots/source_airtable_tests_test_snapshots__discover__capture.stdout.json
@@ -61,7 +61,7 @@
       "x-infer-schema": true
     },
     "key": [
-      "/_meta/row_id"
+      "/_airtable_id"
     ]
   }
 ]


### PR DESCRIPTION
This was being set by the `airbyte-to-flow` override in the old connector, that never got transferred over to the python connector

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1189)
<!-- Reviewable:end -->
