### PR TITLE
fix: Forgot `x-oauth2-provider` on `source-airtable` and `source-asana`

### DIFF
--- a/source-airtable/source_airtable/source_airtable/spec.json
+++ b/source-airtable/source_airtable/source_airtable/spec.json
@@ -13,6 +13,7 @@
           {
             "type": "object",
             "title": "OAuth2.0",
+            "x-oauth2-provider": "airtable",
             "required": ["client_id", "client_secret", "refresh_token"],
             "properties": {
               "auth_method": {

--- a/source-airtable/tests/snapshots/source_airtable_tests_test_snapshots__spec__capture.stdout.json
+++ b/source-airtable/tests/snapshots/source_airtable_tests_test_snapshots__spec__capture.stdout.json
@@ -14,6 +14,7 @@
             {
               "type": "object",
               "title": "OAuth2.0",
+              "x-oauth2-provider": "airtable",
               "required": [
                 "client_id",
                 "client_secret",

--- a/source-asana/source_asana/source_asana/spec.json
+++ b/source-asana/source_asana/source_asana/spec.json
@@ -15,6 +15,7 @@
           {
             "type": "object",
             "title": "Authenticate via Asana (Oauth)",
+            "x-oauth2-provider": "asana",
             "required": ["client_id", "client_secret", "refresh_token"],
             "properties": {
               "option_title": {

--- a/source-asana/tests/snapshots/source_asana_tests_test_snapshots__spec__capture.stdout.json
+++ b/source-asana/tests/snapshots/source_asana_tests_test_snapshots__spec__capture.stdout.json
@@ -18,6 +18,7 @@
             {
               "type": "object",
               "title": "Authenticate via Asana (Oauth)",
+              "x-oauth2-provider": "asana",
               "required": [
                 "client_id",
                 "client_secret",


### PR DESCRIPTION
This enables the OAuth button

![Screen Shot 2024-01-18 at 17 57 52](https://github.com/estuary/connectors/assets/4368270/295e50ac-f15d-4d99-99d3-0e0d6a4ddea9)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1192)
<!-- Reviewable:end -->
