### PR TITLE
materializations: a couple of validation fixes

### DIFF
--- a/materialize-bigquery/sqlgen.go
+++ b/materialize-bigquery/sqlgen.go
@@ -85,7 +85,9 @@ var bqDialect = func() sql.Dialect {
 		sql.ColValidation{Types: []string{"string"}, Validate: stringCompatible},
 		sql.ColValidation{Types: []string{"bool"}, Validate: sql.BooleanCompatible},
 		sql.ColValidation{Types: []string{"int64"}, Validate: sql.IntegerCompatible},
-		sql.ColValidation{Types: []string{"float64"}, Validate: sql.NumberCompatible},
+		// We used to create number columns as "bignumeric", so allowing "bignumeric" for these
+		// columns allows for backward compatibility.
+		sql.ColValidation{Types: []string{"float64, bignumeric"}, Validate: sql.NumberCompatible},
 		sql.ColValidation{Types: []string{"json"}, Validate: sql.MultipleCompatible},
 		sql.ColValidation{Types: []string{"bignumeric"}, Validate: sql.IntegerCompatible},
 		sql.ColValidation{Types: []string{"date"}, Validate: sql.DateCompatible},

--- a/materialize-elasticsearch/type_mapping.go
+++ b/materialize-elasticsearch/type_mapping.go
@@ -160,7 +160,12 @@ func (constrainter) Compatible(existing boilerplate.EndpointField, proposed *pf.
 		}, prop), nil
 	}
 
-	// Otherwise, require that the types match.
+	if prop == elasticTypeText {
+		// Allow text fields to be materialized to either text mappings or keyword mappings.
+		return strings.EqualFold(existing.Type, string(elasticTypeText)) || strings.EqualFold(existing.Type, string(elasticTypeKeyword)), nil
+	}
+
+	// Otherwise, require that the types match exactly.
 	return strings.EqualFold(existing.Type, string(prop)), nil
 }
 


### PR DESCRIPTION
**Description:**

A couple of simple fixes I found from a survey of existing materializations:

* For `materialize-bigquery`, we used to create number columns as "bignumeric", so allowing "bignumeric" for these columns allows for backward compatibility.

* For `materialize-elasticsearch`, there are cases where users have pre-created or modified mappings for fields we would create as `text` to instead be `keyword`. This seems like a reasonable thing to support, so that is being allowed by validation.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

