### PR TITLE
Revert "materialize-bigquery: validate "number" columns as either bignumeric or float64"

### DIFF
--- a/materialize-bigquery/sqlgen.go
+++ b/materialize-bigquery/sqlgen.go
@@ -85,9 +85,7 @@ var bqDialect = func() sql.Dialect {
 		sql.ColValidation{Types: []string{"string"}, Validate: stringCompatible},
 		sql.ColValidation{Types: []string{"bool"}, Validate: sql.BooleanCompatible},
 		sql.ColValidation{Types: []string{"int64"}, Validate: sql.IntegerCompatible},
-		// We used to create number columns as "bignumeric", so allowing "bignumeric" for these
-		// columns allows for backward compatibility.
-		sql.ColValidation{Types: []string{"float64, bignumeric"}, Validate: sql.NumberCompatible},
+		sql.ColValidation{Types: []string{"float64"}, Validate: sql.NumberCompatible},
 		sql.ColValidation{Types: []string{"json"}, Validate: sql.MultipleCompatible},
 		sql.ColValidation{Types: []string{"bignumeric"}, Validate: sql.IntegerCompatible},
 		sql.ColValidation{Types: []string{"date"}, Validate: sql.DateCompatible},


### PR DESCRIPTION
**Description:**

Clean revert of 24b4fc12934c76258252ac6118dd95db6af8e561. We actually need to do something a little more complicated here, along the lines of allowing the same column type to have multiple validators, rather than one validator using multiple column types.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1206)
<!-- Reviewable:end -->
