### PR TITLE
materialize-bigquery: validate bignumeric columns as integer or number

### DIFF
--- a/materialize-bigquery/sqlgen.go
+++ b/materialize-bigquery/sqlgen.go
@@ -87,7 +87,7 @@ var bqDialect = func() sql.Dialect {
 		sql.ColValidation{Types: []string{"int64"}, Validate: sql.IntegerCompatible},
 		sql.ColValidation{Types: []string{"float64"}, Validate: sql.NumberCompatible},
 		sql.ColValidation{Types: []string{"json"}, Validate: sql.MultipleCompatible},
-		sql.ColValidation{Types: []string{"bignumeric"}, Validate: sql.IntegerCompatible},
+		sql.ColValidation{Types: []string{"bignumeric"}, Validate: bignumericCompatible},
 		sql.ColValidation{Types: []string{"date"}, Validate: sql.DateCompatible},
 		sql.ColValidation{Types: []string{"timestamp"}, Validate: sql.DateTimeCompatible},
 	)
@@ -117,6 +117,13 @@ var bqDialect = func() sql.Dialect {
 		ColumnValidator: columnValidator,
 	}
 }()
+
+// bignumericCompatible allows either integers or numbers, since we used to create number columns as
+// "bignumeric" (now they are float64), and currently create strings formatted as integers as
+// "bignumeric". This is needed for compatibility for older materializations.
+func bignumericCompatible(p pf.Projection) bool {
+	return sql.IntegerCompatible(p) || sql.NumberCompatible(p)
+}
 
 // stringCompatible allow strings of any format, arrays, or objects to be materialized.
 func stringCompatible(p pf.Projection) bool {


### PR DESCRIPTION
**Description:**

We used to create number columns as "bignumeric" (see https://github.com/estuary/connectors/pull/859.), and now create strings formatted as integer columns as "bignumeric". Allowing "bignumeric" columns to be either integer or number compatible allows both new and old materializations to work.

Manually tested by using a pre-created column with a number field as a "bignumeric" column and verified that it was able to validate on this new image, whereas it fails on the current dev image.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1207)
<!-- Reviewable:end -->
