### PR TITLE
materialize-databricks: use stateKey for tracking binding state

### DIFF
--- a/materialize-databricks/driver.go
+++ b/materialize-databricks/driver.go
@@ -114,6 +114,8 @@ type transactor struct {
 	cp checkpoint
 	// is this checkpoint a recovered checkpoint?
 	cpRecovery bool
+	// Guard for concurrent access for cp.
+	mu sync.Mutex
 
 	wsClient *databricks.WorkspaceClient
 
@@ -133,11 +135,20 @@ type transactor struct {
 	updateDelay time.Duration
 }
 
-func (t transactor) Context(ctx context.Context) context.Context {
+func (t *transactor) Context(ctx context.Context) context.Context {
 	return driverctx.NewContextWithStagingInfo(ctx, []string{t.localStagingPath})
 }
 
 func (d *transactor) UnmarshalState(state json.RawMessage) error {
+	// A connector running on the "old" state may not have emitted an ack yet. We don't support
+	// migrating states so hopefully this is nothing but an empty checkpoint.
+	var oldCp oldCheckpoint
+	if err := json.Unmarshal(state, &oldCp); err != nil {
+		log.WithField("oldCheckpoint", oldCp).WithError(err).Warn("failed to unmarshal state into oldCheckpoint")
+	} else if len(oldCp.Queries) > 0 || len(oldCp.ToDelete) > 0 {
+		return fmt.Errorf("UnmarshalState application logic error: oldCp was not empty: %#v", oldCp)
+	}
+
 	if err := json.Unmarshal(state, &d.cp); err != nil {
 		return err
 	}
@@ -402,7 +413,15 @@ func (d *transactor) Load(it *m.LoadIterator, loaded func(int, json.RawMessage) 
 	return nil
 }
 
-type checkpoint struct {
+type checkpointItem struct {
+	Query    string
+	ToDelete []string
+}
+
+type checkpoint map[string]*checkpointItem
+
+// TODO: Remove once all tasks have migrated to using the new checkpoint.
+type oldCheckpoint struct {
 	Queries []string
 
 	// List of files to cleanup after committing the queries
@@ -426,14 +445,12 @@ func (d *transactor) Store(it *m.StoreIterator) (_ m.StartCommitFunc, err error)
 	log.Info("store: starting file upload and copies")
 	for it.Next() {
 		var b = d.bindings[it.Binding]
-		b.storeFile.start(ctx)
 
-		converted, err := b.target.ConvertAll(it.Key, it.Values, it.RawJSON)
-		if err != nil {
+		if err := b.storeFile.start(ctx); err != nil {
+			return nil, err
+		} else if converted, err := b.target.ConvertAll(it.Key, it.Values, it.RawJSON); err != nil {
 			return nil, fmt.Errorf("converting store parameters: %w", err)
-		}
-
-		if err := b.storeFile.encodeRow(converted); err != nil {
+		} else if b.storeFile.encodeRow(converted); err != nil {
 			return nil, fmt.Errorf("encoding row for store: %w", err)
 		}
 
@@ -442,16 +459,13 @@ func (d *transactor) Store(it *m.StoreIterator) (_ m.StartCommitFunc, err error)
 		}
 	}
 
-	// Upload the staged files and build a list of merge and truncate queries that need to be run
-	// to effectively commit the files into destination tables. These queries are stored
-	// in the checkpoint so that if the connector is restarted in middle of a commit
-	// it can run the same queries on the next startup. This is the pattern for
-	// recovery log being authoritative and the connector idempotently applies a commit
-	var queries []string
-	// all files uploaded across bindings
-	var toDelete []string
-	// mutex to ensure safety of updating these variables
-	mtx := sync.Mutex{}
+	// Upload the staged files and build a list of merge and truncate queries that need to be run to
+	// effectively commit the files into destination tables. These queries are stored in the
+	// checkpoint so that if the connector is restarted in middle of a commit it can run the same
+	// queries on the next startup. This is the pattern for recovery log being authoritative and the
+	// connector idempotently applies a commit. These are keyed on the binding stateKey so that in
+	// case of a recovery being necessary we don't run queries belonging to bindings that have been
+	// removed.
 
 	// we run these processes in parallel
 	group, groupCtx := errgroup.WithContext(ctx)
@@ -463,13 +477,12 @@ func (d *transactor) Store(it *m.StoreIterator) (_ m.StartCommitFunc, err error)
 		var bindingCopy = b
 		var idxCopy = idx
 		group.Go(func() error {
+			var query string
+
 			toCopy, toDeleteBinding, err := bindingCopy.storeFile.flush()
 			if err != nil {
 				return fmt.Errorf("flushing store file for binding[%d]: %w", idxCopy, err)
 			}
-			mtx.Lock()
-			toDelete = append(toDelete, toDeleteBinding...)
-			mtx.Unlock()
 
 			// In case of delta updates or if there are no existing keys being stored
 			// we directly copy from staged files into the target table. Note that this is retriable
@@ -477,9 +490,7 @@ func (d *transactor) Store(it *m.StoreIterator) (_ m.StartCommitFunc, err error)
 			// not be loaded again
 			// see https://docs.databricks.com/en/sql/language-manual/delta-copy-into.html
 			if bindingCopy.target.DeltaUpdates || !bindingCopy.needsMerge {
-				mtx.Lock()
-				queries = append(queries, renderWithFiles(bindingCopy.copyIntoDirect, toCopy...))
-				mtx.Unlock()
+				query = renderWithFiles(bindingCopy.copyIntoDirect, toCopy...)
 			} else {
 				// Create a binding-scoped temporary table for store documents to be merged
 				// into target table
@@ -491,10 +502,15 @@ func (d *transactor) Store(it *m.StoreIterator) (_ m.StartCommitFunc, err error)
 				if _, err := d.store.conn.ExecContext(groupCtx, renderWithFiles(bindingCopy.copyIntoStore, toCopy...)); err != nil {
 					return fmt.Errorf("store: copying into to temporary table: %w", err)
 				}
+				query = renderWithFiles(bindingCopy.mergeInto, toCopy...)
+			}
 
-				mtx.Lock()
-				queries = append(queries, renderWithFiles(bindingCopy.mergeInto, toCopy...), bindingCopy.dropStoreSQL)
-				mtx.Unlock()
+			d.mu.Lock()
+			defer d.mu.Unlock()
+
+			d.cp[bindingCopy.target.StateKey] = &checkpointItem{
+				Query:    query,
+				ToDelete: toDeleteBinding,
 			}
 
 			return nil
@@ -508,10 +524,7 @@ func (d *transactor) Store(it *m.StoreIterator) (_ m.StartCommitFunc, err error)
 	log.Info("store: finished file upload and copies")
 
 	return func(ctx context.Context, runtimeCheckpoint *protocol.Checkpoint) (*pf.ConnectorState, m.OpFuture) {
-		var cp = checkpoint{Queries: queries, ToDelete: toDelete}
-		d.cp = cp
-
-		var checkpointJSON, err = json.Marshal(cp)
+		var checkpointJSON, err = json.Marshal(d.cp)
 		if err != nil {
 			return nil, m.FinishedOperation(fmt.Errorf("creating checkpoint json: %w", err))
 		}
@@ -531,8 +544,15 @@ func renderWithFiles(tpl string, files ...string) string {
 // TODO: run these queries concurrently for improved performance
 func (d *transactor) Acknowledge(ctx context.Context) (*pf.ConnectorState, error) {
 	log.Info("store: starting committing changes")
-	for _, q := range d.cp.Queries {
-		if _, err := d.store.conn.ExecContext(ctx, q); err != nil {
+
+	for stateKey, item := range d.cp {
+		// we skip queries that belong to tables which do not have a binding anymore
+		// since these tables might be deleted already
+		if !d.hasStateKey(stateKey) {
+			continue
+		}
+
+		if _, err := d.store.conn.ExecContext(ctx, item.Query); err != nil {
 			// When doing a recovery apply, it may be the case that some tables & files have already been deleted after being applied
 			// it is okay to skip them in this case
 			if d.cpRecovery {
@@ -540,29 +560,42 @@ func (d *transactor) Acknowledge(ctx context.Context) (*pf.ConnectorState, error
 					continue
 				}
 			}
-			return nil, fmt.Errorf("query %q failed: %w", q, err)
+			return nil, fmt.Errorf("query %q failed: %w", item.Query, err)
 		}
-	}
-	log.Info("store: finished committing changes")
 
-	// Cleanup files and tables
-	d.deleteFiles(ctx, d.cp.ToDelete)
+		// Cleanup files.
+		d.deleteFiles(ctx, item.ToDelete)
+	}
 
 	d.cpRecovery = false
 
-	// Best-effort zero'ing of the checkpoint after a successful application of the checkpoint.
-	// Right now we always run all the queries in the checkpoint, but very soon will use state
-	// keys and need to change the structure of the checkpoint.
-	checkpointClear := checkpoint{
-		Queries:  nil,
-		ToDelete: nil,
+	// After having applied the checkpoint, we try to clean up the checkpoint in the ack response
+	// so that a restart of the connector does not need to run the same queries again
+	// Note that this is an best-effort "attempt" and there is no guarantee that this checkpoint update
+	// can actually be committed
+	// Important to note that in this case we do not reset the checkpoint for all bindings, but only the ones
+	// that have been committed in this transaction. The reason is that it may be the case that a binding
+	// which has been disabled right after a failed attempt to run its queries, must be able to recover by enabling
+	// the binding and running the queries that are pending for its last transaction.
+	var checkpointClear = make(checkpoint)
+	for _, b := range d.bindings {
+		checkpointClear[b.target.StateKey] = nil
+		delete(d.cp, b.target.StateKey)
 	}
 	var checkpointJSON, err = json.Marshal(checkpointClear)
 	if err != nil {
 		return nil, fmt.Errorf("creating checkpoint clearing json: %w", err)
 	}
-
 	return &pf.ConnectorState{UpdatedJson: json.RawMessage(checkpointJSON), MergePatch: true}, nil
+}
+
+func (d *transactor) hasStateKey(stateKey string) bool {
+	for _, b := range d.bindings {
+		if b.target.StateKey == stateKey {
+			return true
+		}
+	}
+	return false
 }
 
 func (d *transactor) Destroy() {

--- a/materialize-snowflake/snowflake.go
+++ b/materialize-snowflake/snowflake.go
@@ -528,9 +528,6 @@ func (d *transactor) Acknowledge(ctx context.Context) (*pf.ConnectorState, error
 	// the queries are actually executed and done
 	var results = make(map[string]stdsql.Result)
 	for stateKey, item := range d.cp {
-		if len(item.Query) == 0 {
-			continue
-		}
 		// we skip queries that belong to tables which do not have a binding anymore
 		// since these tables might be deleted already
 		if !d.hasStateKey(stateKey) {

--- a/tests/materialize/materialize-databricks/snapshot.json
+++ b/tests/materialize/materialize-databricks/snapshot.json
@@ -7,7 +7,19 @@
   "opened": {}
 }
 {
-  "acknowledged": {}
+  "acknowledged": {
+    "state": {
+      "mergePatch": true,
+      "updated": {
+        "default%2Fduplicate_keys_delta": null,
+        "default%2Fduplicate_keys_delta_exclude_flow_doc": null,
+        "default%2Fduplicate_keys_standard": null,
+        "default%2Fformatted_strings": null,
+        "default%2Fmultiple_types": null,
+        "default%2Fsimple": null
+      }
+    }
+  }
 }
 {
   "flushed": {}
@@ -16,28 +28,60 @@
   "startedCommit": {
     "state": {
       "updated": {
-        "Queries": [
-          "\n\tCOPY INTO `default`.formatted_strings FROM (\n    SELECT\n\t\tid::BIGINT, date::DATE, datetime::TIMESTAMP, flow_published_at::TIMESTAMP, int_and_str::BIGINT, int_str::BIGINT, num_and_str::DOUBLE, num_str::DOUBLE, time::STRING, flow_document::STRING\n  FROM '/Volumes/main/default/flow_staging/flow_temp_tables'\n\t)\n  FILEFORMAT = JSON\n  FILES = ('<uuid>')\n  FORMAT_OPTIONS ( 'mode' = 'FAILFAST', 'ignoreMissingFiles' = 'false' )\n\tCOPY_OPTIONS ( 'mergeSchema' = 'true' )\n  ;\n",
-          "\n\tCOPY INTO `default`.multiple_types FROM (\n    SELECT\n\t\tid::BIGINT, array_int::STRING, bool_field::BOOLEAN, float_field::DOUBLE, flow_published_at::TIMESTAMP, multiple::STRING, nested::STRING, nullable_int::BIGINT, str_field::STRING, flow_document::STRING\n  FROM '/Volumes/main/default/flow_staging/flow_temp_tables'\n\t)\n  FILEFORMAT = JSON\n  FILES = ('<uuid>')\n  FORMAT_OPTIONS ( 'mode' = 'FAILFAST', 'ignoreMissingFiles' = 'false' )\n\tCOPY_OPTIONS ( 'mergeSchema' = 'true' )\n  ;\n",
-          "\n\tCOPY INTO `default`.duplicate_keys_delta FROM (\n    SELECT\n\t\tid::BIGINT, flow_published_at::TIMESTAMP, int::BIGINT, str::STRING, flow_document::STRING\n  FROM '/Volumes/main/default/flow_staging/flow_temp_tables'\n\t)\n  FILEFORMAT = JSON\n  FILES = ('<uuid>')\n  FORMAT_OPTIONS ( 'mode' = 'FAILFAST', 'ignoreMissingFiles' = 'false' )\n\tCOPY_OPTIONS ( 'mergeSchema' = 'true' )\n  ;\n",
-          "\n\tCOPY INTO `default`.duplicate_keys_delta_exclude_flow_doc FROM (\n    SELECT\n\t\tid::BIGINT, flow_published_at::TIMESTAMP, int::BIGINT, str::STRING\n  FROM '/Volumes/main/default/flow_staging/flow_temp_tables'\n\t)\n  FILEFORMAT = JSON\n  FILES = ('<uuid>')\n  FORMAT_OPTIONS ( 'mode' = 'FAILFAST', 'ignoreMissingFiles' = 'false' )\n\tCOPY_OPTIONS ( 'mergeSchema' = 'true' )\n  ;\n",
-          "\n\tCOPY INTO `default`.simple FROM (\n    SELECT\n\t\tid::BIGINT, canary::STRING, flow_published_at::TIMESTAMP, flow_document::STRING\n  FROM '/Volumes/main/default/flow_staging/flow_temp_tables'\n\t)\n  FILEFORMAT = JSON\n  FILES = ('<uuid>')\n  FORMAT_OPTIONS ( 'mode' = 'FAILFAST', 'ignoreMissingFiles' = 'false' )\n\tCOPY_OPTIONS ( 'mergeSchema' = 'true' )\n  ;\n",
-          "\n\tCOPY INTO `default`.duplicate_keys_standard FROM (\n    SELECT\n\t\tid::BIGINT, flow_published_at::TIMESTAMP, int::BIGINT, str::STRING, flow_document::STRING\n  FROM '/Volumes/main/default/flow_staging/flow_temp_tables'\n\t)\n  FILEFORMAT = JSON\n  FILES = ('<uuid>')\n  FORMAT_OPTIONS ( 'mode' = 'FAILFAST', 'ignoreMissingFiles' = 'false' )\n\tCOPY_OPTIONS ( 'mergeSchema' = 'true' )\n  ;\n"
-        ],
-        "ToDelete": [
-          "/Volumes/main/default/flow_staging/flow_temp_tables/<uuid>",
-          "/Volumes/main/default/flow_staging/flow_temp_tables/<uuid>",
-          "/Volumes/main/default/flow_staging/flow_temp_tables/<uuid>",
-          "/Volumes/main/default/flow_staging/flow_temp_tables/<uuid>",
-          "/Volumes/main/default/flow_staging/flow_temp_tables/<uuid>",
-          "/Volumes/main/default/flow_staging/flow_temp_tables/<uuid>"
-        ]
+        "default%2Fduplicate_keys_delta": {
+          "Query": "\n\tCOPY INTO `default`.duplicate_keys_delta FROM (\n    SELECT\n\t\tid::BIGINT, flow_published_at::TIMESTAMP, int::BIGINT, str::STRING, flow_document::STRING\n  FROM '/Volumes/main/default/flow_staging/flow_temp_tables'\n\t)\n  FILEFORMAT = JSON\n  FILES = ('<uuid>')\n  FORMAT_OPTIONS ( 'mode' = 'FAILFAST', 'ignoreMissingFiles' = 'false' )\n\tCOPY_OPTIONS ( 'mergeSchema' = 'true' )\n  ;\n",
+          "ToDelete": [
+            "/Volumes/main/default/flow_staging/flow_temp_tables/<uuid>"
+          ]
+        },
+        "default%2Fduplicate_keys_delta_exclude_flow_doc": {
+          "Query": "\n\tCOPY INTO `default`.duplicate_keys_delta_exclude_flow_doc FROM (\n    SELECT\n\t\tid::BIGINT, flow_published_at::TIMESTAMP, int::BIGINT, str::STRING\n  FROM '/Volumes/main/default/flow_staging/flow_temp_tables'\n\t)\n  FILEFORMAT = JSON\n  FILES = ('<uuid>')\n  FORMAT_OPTIONS ( 'mode' = 'FAILFAST', 'ignoreMissingFiles' = 'false' )\n\tCOPY_OPTIONS ( 'mergeSchema' = 'true' )\n  ;\n",
+          "ToDelete": [
+            "/Volumes/main/default/flow_staging/flow_temp_tables/<uuid>"
+          ]
+        },
+        "default%2Fduplicate_keys_standard": {
+          "Query": "\n\tCOPY INTO `default`.duplicate_keys_standard FROM (\n    SELECT\n\t\tid::BIGINT, flow_published_at::TIMESTAMP, int::BIGINT, str::STRING, flow_document::STRING\n  FROM '/Volumes/main/default/flow_staging/flow_temp_tables'\n\t)\n  FILEFORMAT = JSON\n  FILES = ('<uuid>')\n  FORMAT_OPTIONS ( 'mode' = 'FAILFAST', 'ignoreMissingFiles' = 'false' )\n\tCOPY_OPTIONS ( 'mergeSchema' = 'true' )\n  ;\n",
+          "ToDelete": [
+            "/Volumes/main/default/flow_staging/flow_temp_tables/<uuid>"
+          ]
+        },
+        "default%2Fformatted_strings": {
+          "Query": "\n\tCOPY INTO `default`.formatted_strings FROM (\n    SELECT\n\t\tid::BIGINT, date::DATE, datetime::TIMESTAMP, flow_published_at::TIMESTAMP, int_and_str::BIGINT, int_str::BIGINT, num_and_str::DOUBLE, num_str::DOUBLE, time::STRING, flow_document::STRING\n  FROM '/Volumes/main/default/flow_staging/flow_temp_tables'\n\t)\n  FILEFORMAT = JSON\n  FILES = ('<uuid>')\n  FORMAT_OPTIONS ( 'mode' = 'FAILFAST', 'ignoreMissingFiles' = 'false' )\n\tCOPY_OPTIONS ( 'mergeSchema' = 'true' )\n  ;\n",
+          "ToDelete": [
+            "/Volumes/main/default/flow_staging/flow_temp_tables/<uuid>"
+          ]
+        },
+        "default%2Fmultiple_types": {
+          "Query": "\n\tCOPY INTO `default`.multiple_types FROM (\n    SELECT\n\t\tid::BIGINT, array_int::STRING, bool_field::BOOLEAN, float_field::DOUBLE, flow_published_at::TIMESTAMP, multiple::STRING, nested::STRING, nullable_int::BIGINT, str_field::STRING, flow_document::STRING\n  FROM '/Volumes/main/default/flow_staging/flow_temp_tables'\n\t)\n  FILEFORMAT = JSON\n  FILES = ('<uuid>')\n  FORMAT_OPTIONS ( 'mode' = 'FAILFAST', 'ignoreMissingFiles' = 'false' )\n\tCOPY_OPTIONS ( 'mergeSchema' = 'true' )\n  ;\n",
+          "ToDelete": [
+            "/Volumes/main/default/flow_staging/flow_temp_tables/<uuid>"
+          ]
+        },
+        "default%2Fsimple": {
+          "Query": "\n\tCOPY INTO `default`.simple FROM (\n    SELECT\n\t\tid::BIGINT, canary::STRING, flow_published_at::TIMESTAMP, flow_document::STRING\n  FROM '/Volumes/main/default/flow_staging/flow_temp_tables'\n\t)\n  FILEFORMAT = JSON\n  FILES = ('<uuid>')\n  FORMAT_OPTIONS ( 'mode' = 'FAILFAST', 'ignoreMissingFiles' = 'false' )\n\tCOPY_OPTIONS ( 'mergeSchema' = 'true' )\n  ;\n",
+          "ToDelete": [
+            "/Volumes/main/default/flow_staging/flow_temp_tables/<uuid>"
+          ]
+        }
       }
     }
   }
 }
 {
-  "acknowledged": {}
+  "acknowledged": {
+    "state": {
+      "mergePatch": true,
+      "updated": {
+        "default%2Fduplicate_keys_delta": null,
+        "default%2Fduplicate_keys_delta_exclude_flow_doc": null,
+        "default%2Fduplicate_keys_standard": null,
+        "default%2Fformatted_strings": null,
+        "default%2Fmultiple_types": null,
+        "default%2Fsimple": null
+      }
+    }
+  }
 }
 {
   "loaded": {
@@ -230,30 +274,60 @@
   "startedCommit": {
     "state": {
       "updated": {
-        "Queries": [
-          "\n\tCOPY INTO `default`.formatted_strings FROM (\n    SELECT\n\t\tid::BIGINT, date::DATE, datetime::TIMESTAMP, flow_published_at::TIMESTAMP, int_and_str::BIGINT, int_str::BIGINT, num_and_str::DOUBLE, num_str::DOUBLE, time::STRING, flow_document::STRING\n  FROM '/Volumes/main/default/flow_staging/flow_temp_tables'\n\t)\n  FILEFORMAT = JSON\n  FILES = ('<uuid>')\n  FORMAT_OPTIONS ( 'mode' = 'FAILFAST', 'ignoreMissingFiles' = 'false' )\n\tCOPY_OPTIONS ( 'mergeSchema' = 'true' )\n  ;\n",
-          "\n\tCOPY INTO `default`.duplicate_keys_delta FROM (\n    SELECT\n\t\tid::BIGINT, flow_published_at::TIMESTAMP, int::BIGINT, str::STRING, flow_document::STRING\n  FROM '/Volumes/main/default/flow_staging/flow_temp_tables'\n\t)\n  FILEFORMAT = JSON\n  FILES = ('<uuid>')\n  FORMAT_OPTIONS ( 'mode' = 'FAILFAST', 'ignoreMissingFiles' = 'false' )\n\tCOPY_OPTIONS ( 'mergeSchema' = 'true' )\n  ;\n",
-          "\n\tCOPY INTO `default`.simple FROM (\n    SELECT\n\t\tid::BIGINT, canary::STRING, flow_published_at::TIMESTAMP, flow_document::STRING\n  FROM '/Volumes/main/default/flow_staging/flow_temp_tables'\n\t)\n  FILEFORMAT = JSON\n  FILES = ('<uuid>')\n  FORMAT_OPTIONS ( 'mode' = 'FAILFAST', 'ignoreMissingFiles' = 'false' )\n\tCOPY_OPTIONS ( 'mergeSchema' = 'true' )\n  ;\n",
-          "\n\tCOPY INTO `default`.duplicate_keys_delta_exclude_flow_doc FROM (\n    SELECT\n\t\tid::BIGINT, flow_published_at::TIMESTAMP, int::BIGINT, str::STRING\n  FROM '/Volumes/main/default/flow_staging/flow_temp_tables'\n\t)\n  FILEFORMAT = JSON\n  FILES = ('<uuid>')\n  FORMAT_OPTIONS ( 'mode' = 'FAILFAST', 'ignoreMissingFiles' = 'false' )\n\tCOPY_OPTIONS ( 'mergeSchema' = 'true' )\n  ;\n",
-          "\n\tMERGE INTO `default`.duplicate_keys_standard AS l\n\tUSING `flow_temp_store_table_00000000_00000000_1_duplicate_keys_standard` AS r\n\tON l.id = r.id::BIGINT\n\tAND r._metadata_file_name IN ('<uuid>')\n\tWHEN MATCHED AND r.flow_document <=> NULL THEN\n\t\tDELETE\n\tWHEN MATCHED THEN\n\t\tUPDATE SET l.flow_published_at = r.flow_published_at::TIMESTAMP, l.int = r.int::BIGINT, l.str = r.str::STRING, l.flow_document = r.flow_document\n\tWHEN NOT MATCHED THEN\n\t\tINSERT (id, flow_published_at, int, str, flow_document)\n\t\tVALUES (r.id::BIGINT, r.flow_published_at::TIMESTAMP, r.int::BIGINT, r.str::STRING, r.flow_document::STRING);\n",
-          "\nDROP TABLE IF EXISTS `flow_temp_store_table_00000000_00000000_1_duplicate_keys_standard`\n",
-          "\n\tMERGE INTO `default`.multiple_types AS l\n\tUSING `flow_temp_store_table_00000000_00000000_4_multiple_types` AS r\n\tON l.id = r.id::BIGINT\n\tAND r._metadata_file_name IN ('<uuid>')\n\tWHEN MATCHED AND r.flow_document <=> NULL THEN\n\t\tDELETE\n\tWHEN MATCHED THEN\n\t\tUPDATE SET l.array_int = r.array_int::STRING, l.bool_field = r.bool_field::BOOLEAN, l.float_field = r.float_field::DOUBLE, l.flow_published_at = r.flow_published_at::TIMESTAMP, l.multiple = r.multiple::STRING, l.nested = r.nested::STRING, l.nullable_int = r.nullable_int::BIGINT, l.str_field = r.str_field::STRING, l.flow_document = r.flow_document\n\tWHEN NOT MATCHED THEN\n\t\tINSERT (id, array_int, bool_field, float_field, flow_published_at, multiple, nested, nullable_int, str_field, flow_document)\n\t\tVALUES (r.id::BIGINT, r.array_int::STRING, r.bool_field::BOOLEAN, r.float_field::DOUBLE, r.flow_published_at::TIMESTAMP, r.multiple::STRING, r.nested::STRING, r.nullable_int::BIGINT, r.str_field::STRING, r.flow_document::STRING);\n",
-          "\nDROP TABLE IF EXISTS `flow_temp_store_table_00000000_00000000_4_multiple_types`\n"
-        ],
-        "ToDelete": [
-          "/Volumes/main/default/flow_staging/flow_temp_tables/<uuid>",
-          "/Volumes/main/default/flow_staging/flow_temp_tables/<uuid>",
-          "/Volumes/main/default/flow_staging/flow_temp_tables/<uuid>",
-          "/Volumes/main/default/flow_staging/flow_temp_tables/<uuid>",
-          "/Volumes/main/default/flow_staging/flow_temp_tables/<uuid>",
-          "/Volumes/main/default/flow_staging/flow_temp_tables/<uuid>"
-        ]
+        "default%2Fduplicate_keys_delta": {
+          "Query": "\n\tCOPY INTO `default`.duplicate_keys_delta FROM (\n    SELECT\n\t\tid::BIGINT, flow_published_at::TIMESTAMP, int::BIGINT, str::STRING, flow_document::STRING\n  FROM '/Volumes/main/default/flow_staging/flow_temp_tables'\n\t)\n  FILEFORMAT = JSON\n  FILES = ('<uuid>')\n  FORMAT_OPTIONS ( 'mode' = 'FAILFAST', 'ignoreMissingFiles' = 'false' )\n\tCOPY_OPTIONS ( 'mergeSchema' = 'true' )\n  ;\n",
+          "ToDelete": [
+            "/Volumes/main/default/flow_staging/flow_temp_tables/<uuid>"
+          ]
+        },
+        "default%2Fduplicate_keys_delta_exclude_flow_doc": {
+          "Query": "\n\tCOPY INTO `default`.duplicate_keys_delta_exclude_flow_doc FROM (\n    SELECT\n\t\tid::BIGINT, flow_published_at::TIMESTAMP, int::BIGINT, str::STRING\n  FROM '/Volumes/main/default/flow_staging/flow_temp_tables'\n\t)\n  FILEFORMAT = JSON\n  FILES = ('<uuid>')\n  FORMAT_OPTIONS ( 'mode' = 'FAILFAST', 'ignoreMissingFiles' = 'false' )\n\tCOPY_OPTIONS ( 'mergeSchema' = 'true' )\n  ;\n",
+          "ToDelete": [
+            "/Volumes/main/default/flow_staging/flow_temp_tables/<uuid>"
+          ]
+        },
+        "default%2Fduplicate_keys_standard": {
+          "Query": "\n\tMERGE INTO `default`.duplicate_keys_standard AS l\n\tUSING `flow_temp_store_table_00000000_00000000_1_duplicate_keys_standard` AS r\n\tON l.id = r.id::BIGINT\n\tAND r._metadata_file_name IN ('<uuid>')\n\tWHEN MATCHED AND r.flow_document <=> NULL THEN\n\t\tDELETE\n\tWHEN MATCHED THEN\n\t\tUPDATE SET l.flow_published_at = r.flow_published_at::TIMESTAMP, l.int = r.int::BIGINT, l.str = r.str::STRING, l.flow_document = r.flow_document\n\tWHEN NOT MATCHED THEN\n\t\tINSERT (id, flow_published_at, int, str, flow_document)\n\t\tVALUES (r.id::BIGINT, r.flow_published_at::TIMESTAMP, r.int::BIGINT, r.str::STRING, r.flow_document::STRING);\n",
+          "ToDelete": [
+            "/Volumes/main/default/flow_staging/flow_temp_tables/<uuid>"
+          ]
+        },
+        "default%2Fformatted_strings": {
+          "Query": "\n\tCOPY INTO `default`.formatted_strings FROM (\n    SELECT\n\t\tid::BIGINT, date::DATE, datetime::TIMESTAMP, flow_published_at::TIMESTAMP, int_and_str::BIGINT, int_str::BIGINT, num_and_str::DOUBLE, num_str::DOUBLE, time::STRING, flow_document::STRING\n  FROM '/Volumes/main/default/flow_staging/flow_temp_tables'\n\t)\n  FILEFORMAT = JSON\n  FILES = ('<uuid>')\n  FORMAT_OPTIONS ( 'mode' = 'FAILFAST', 'ignoreMissingFiles' = 'false' )\n\tCOPY_OPTIONS ( 'mergeSchema' = 'true' )\n  ;\n",
+          "ToDelete": [
+            "/Volumes/main/default/flow_staging/flow_temp_tables/<uuid>"
+          ]
+        },
+        "default%2Fmultiple_types": {
+          "Query": "\n\tMERGE INTO `default`.multiple_types AS l\n\tUSING `flow_temp_store_table_00000000_00000000_4_multiple_types` AS r\n\tON l.id = r.id::BIGINT\n\tAND r._metadata_file_name IN ('<uuid>')\n\tWHEN MATCHED AND r.flow_document <=> NULL THEN\n\t\tDELETE\n\tWHEN MATCHED THEN\n\t\tUPDATE SET l.array_int = r.array_int::STRING, l.bool_field = r.bool_field::BOOLEAN, l.float_field = r.float_field::DOUBLE, l.flow_published_at = r.flow_published_at::TIMESTAMP, l.multiple = r.multiple::STRING, l.nested = r.nested::STRING, l.nullable_int = r.nullable_int::BIGINT, l.str_field = r.str_field::STRING, l.flow_document = r.flow_document\n\tWHEN NOT MATCHED THEN\n\t\tINSERT (id, array_int, bool_field, float_field, flow_published_at, multiple, nested, nullable_int, str_field, flow_document)\n\t\tVALUES (r.id::BIGINT, r.array_int::STRING, r.bool_field::BOOLEAN, r.float_field::DOUBLE, r.flow_published_at::TIMESTAMP, r.multiple::STRING, r.nested::STRING, r.nullable_int::BIGINT, r.str_field::STRING, r.flow_document::STRING);\n",
+          "ToDelete": [
+            "/Volumes/main/default/flow_staging/flow_temp_tables/<uuid>"
+          ]
+        },
+        "default%2Fsimple": {
+          "Query": "\n\tCOPY INTO `default`.simple FROM (\n    SELECT\n\t\tid::BIGINT, canary::STRING, flow_published_at::TIMESTAMP, flow_document::STRING\n  FROM '/Volumes/main/default/flow_staging/flow_temp_tables'\n\t)\n  FILEFORMAT = JSON\n  FILES = ('<uuid>')\n  FORMAT_OPTIONS ( 'mode' = 'FAILFAST', 'ignoreMissingFiles' = 'false' )\n\tCOPY_OPTIONS ( 'mergeSchema' = 'true' )\n  ;\n",
+          "ToDelete": [
+            "/Volumes/main/default/flow_staging/flow_temp_tables/<uuid>"
+          ]
+        }
       }
     }
   }
 }
 {
-  "acknowledged": {}
+  "acknowledged": {
+    "state": {
+      "mergePatch": true,
+      "updated": {
+        "default%2Fduplicate_keys_delta": null,
+        "default%2Fduplicate_keys_delta_exclude_flow_doc": null,
+        "default%2Fduplicate_keys_standard": null,
+        "default%2Fformatted_strings": null,
+        "default%2Fmultiple_types": null,
+        "default%2Fsimple": null
+      }
+    }
+  }
 }
 {
   "row": {
@@ -856,5 +930,10 @@
   "opened": {}
 }
 {
-  "acknowledged": {}
+  "acknowledged": {
+    "state": {
+      "mergePatch": true,
+      "updated": {}
+    }
+  }
 }


### PR DESCRIPTION
**Description:**

_Related PR: https://github.com/estuary/connectors/pull/1213. This was merged and all active databricks materializations are now running on it and emitting post-ack zero'd checkpoints._

Adds support for state keys to materialize-databricks. The backfill capability more-or-less worked even without this, but the full `stateKey` implementation mitigates certain unlikely edge cases that may occur if the ack state is not persisted, and a table is re-backfilled and then persisted queries for the prior table are run against the re-created table.

I manually tested migrating an existing materialization from the prior image over to this, as well as starting a new materialization from scratch with this image. Also various combinations of multiple bindings with or without data and disabling & re-enabling them to make sure everything looked right.

See issue [#1146](https://github.com/estuary/connectors/issues/1146)

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1215)
<!-- Reviewable:end -->
