### PR TITLE
fix: Airbyte shim typo

### DIFF
--- a/python/flow_sdk/shim_airbyte_cdk.py
+++ b/python/flow_sdk/shim_airbyte_cdk.py
@@ -259,7 +259,8 @@ class CaptureShim(Connector):
             if record := message.record:
                 entry = index.get((record.namespace, record.stream), None)
                 if entry is None:
-                    raise Exception(f"Document read in unrecognized stream {record.stream} (namespace: {record.namespace})")
+                    logger.warn(f"Document read in unrecognized stream {record.stream} (namespace: {record.namespace})")
+                    continue
 
                 record.data.setdefault("_meta", {})["row_id"] = entry[1]
                 entry[1] += 1
@@ -282,7 +283,8 @@ class CaptureShim(Connector):
 
                 binding_lookup = index.get((state_msg.stream.stream_descriptor.namespace, state_msg.stream.stream_descriptor.name), None)
                 if binding_lookup is None:
-                    raise Exception(f"Received state message for unrecognized stream {state_msg.stream.stream_descriptor.name} (namespace: {state_msg.stream.stream_descriptor.namespace})")                
+                    logger.warn(f"Received state message for unrecognized stream {state_msg.stream.stream_descriptor.name} (namespace: {state_msg.stream.stream_descriptor.namespace})")                
+                    continue
                 
                 # index values: [binding_index, row_id]
                 binding = bindings[binding_lookup[0]]

--- a/python/flow_sdk/shim_airbyte_cdk.py
+++ b/python/flow_sdk/shim_airbyte_cdk.py
@@ -57,7 +57,7 @@ class State:
         if not self.bindingStateV1:
             self.bindingStateV1 = {}
         if not state_key in self.bindingStateV1:
-            self.bindingStateV1[state_key] = StreamState()
+            self.bindingStateV1[state_key] = StreamState(msg, 0)
         self.bindingStateV1[state_key].state = msg
 
     def to_airbyte_input(self):
@@ -287,7 +287,7 @@ class CaptureShim(Connector):
                     continue
                 
                 # index values: [binding_index, row_id]
-                binding = bindings[binding_lookup[0]]
+                binding: response.ValidatedBinding = bindings[binding_lookup[0]]
 
                 state.handle_message(state_msg, binding["stateKey"])
                 emit(

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "flow-sdk"
-version = "0.1.6"
+version = "0.1.8"
 description = ""
 authors = ["Joseph Shearer <joseph@estuary.dev>", "Johnny Graettinger <johnny@estuary.dev>"]
 readme = "README.md"

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "flow-sdk"
-version = "0.1.5"
+version = "0.1.6"
 description = ""
 authors = ["Joseph Shearer <joseph@estuary.dev>", "Johnny Graettinger <johnny@estuary.dev>"]
 readme = "README.md"

--- a/source-airtable/acmeCo/test_base/flow.yaml
+++ b/source-airtable/acmeCo/test_base/flow.yaml
@@ -1,3 +1,4 @@
 ---
 import:
   - pizzas/flow.yaml
+  - soups/flow.yaml

--- a/source-airtable/acmeCo/test_base/soups/flow.yaml
+++ b/source-airtable/acmeCo/test_base/soups/flow.yaml
@@ -1,6 +1,6 @@
 ---
 collections:
-  acmeCo/test_base/pizzas/tblY71QcPfB7SjY1f:
+  acmeCo/test_base/soups/tblDi5DS0EjiYi83h:
     schema:
       $schema: "https://json-schema.org/draft-07/schema#"
       type: object
@@ -20,14 +20,14 @@ collections:
           type:
             - "null"
             - string
+        notes:
+          type:
+            - "null"
+            - string
         status:
           type:
             - "null"
             - string
-        cost:
-          type:
-            - "null"
-            - number
         _meta:
           type: object
           properties:

--- a/source-airtable/test.flow.yaml
+++ b/source-airtable/test.flow.yaml
@@ -10,8 +10,16 @@ captures:
           - "-m"
           - source-airtable
         config: config.yaml
+    shards:
+      logLevel: debug
     bindings:
       - resource:
           stream: test_base/pizzas/tblY71QcPfB7SjY1f
           syncMode: full_refresh
         target: acmeCo/test_base/pizzas/tblY71QcPfB7SjY1f
+        disable: false
+      - resource:
+          stream: test_base/soups/tblDi5DS0EjiYi83h
+          syncMode: full_refresh
+        target: acmeCo/test_base/soups/tblDi5DS0EjiYi83h
+        disable: true

--- a/source-airtable/tests/snapshots/source_airtable_tests_test_snapshots__discover__capture.stdout.json
+++ b/source-airtable/tests/snapshots/source_airtable_tests_test_snapshots__discover__capture.stdout.json
@@ -63,5 +63,70 @@
     "key": [
       "/_airtable_id"
     ]
+  },
+  {
+    "recommendedName": "test_base/soups/tblDi5DS0EjiYi83h",
+    "resourceConfig": {
+      "stream": "test_base/soups/tblDi5DS0EjiYi83h",
+      "syncMode": "full_refresh"
+    },
+    "documentSchema": {
+      "$schema": "https://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "_airtable_id": {
+          "type": "string"
+        },
+        "_airtable_created_time": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "_airtable_table_name": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "name": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "notes": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "status": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "_meta": {
+          "type": "object",
+          "properties": {
+            "row_id": {
+              "type": "integer"
+            }
+          },
+          "required": [
+            "row_id"
+          ]
+        }
+      },
+      "required": [
+        "_airtable_id"
+      ],
+      "x-infer-schema": true
+    },
+    "key": [
+      "/_airtable_id"
+    ]
   }
 ]


### PR DESCRIPTION
The consequence of this was that we were not persisting state messages (and crashing instead), so incremental captures would fail to be incremental.

Note, this also adds a more clear exception for a scenario I encountered in a customer's task where it was outputting documents for a binding/stream ID that we didn't know about, and crashing. I _think_ we should still crash in this case, but at least now the message will be more clear and make it easier to track down the problem. 

As a fast-follow I would like to add integration test coverage for incremental captures

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1217)
<!-- Reviewable:end -->
