### PR TITLE
materialize-postgres: limit batch size based on document size

### DIFF
--- a/go/protocols/materialize/lifecycle.go
+++ b/go/protocols/materialize/lifecycle.go
@@ -243,13 +243,14 @@ func ReadFlush(request *pm.Request) error {
 
 // StoreIterator is an iterator over Store requests.
 type StoreIterator struct {
-	Binding   int             // Binding index of this stored document.
-	Exists    bool            // Does this document exist in the store already?
-	Key       tuple.Tuple     // Key of the document to store.
-	PackedKey []byte          // PackedKey of the document to store.
-	RawJSON   json.RawMessage // Document to store.
-	Values    tuple.Tuple     // Values of the document to store.
-	Total     int             // Total number of iterated stores.
+	Binding      int             // Binding index of this stored document.
+	Exists       bool            // Does this document exist in the store already?
+	Key          tuple.Tuple     // Key of the document to store.
+	PackedKey    []byte          // PackedKey of the document to store.
+	Values       tuple.Tuple     // Values of the document to store.
+	PackedValues []byte          // PackedValues of the document to store.
+	RawJSON      json.RawMessage // Document to store.
+	Total        int             // Total number of iterated stores.
 
 	stream  RequestRx
 	request *pm.Request // Request read into.
@@ -289,6 +290,7 @@ func (it *StoreIterator) Next() bool {
 		it.err = fmt.Errorf("unpacking Store key: %w", it.err)
 		return false
 	}
+	it.PackedValues = s.ValuesPacked
 	it.Values, it.err = tuple.Unpack(s.ValuesPacked)
 	if it.err != nil {
 		it.err = fmt.Errorf("unpacking Store values: %w", it.err)


### PR DESCRIPTION
**Description:**

This implements batch flushing logic based on the size of documents handled, rather than a simple count of documents.

For loads, it uses the size of the packed key. For stores, it uses the size of packed key, packed values, and raw document JSON. This is just an approximation of the memory used for buffering the queries for these documents in a `pgx.Batch`, but it seemed to work pretty well in a synthetic test case: For documents each around 100kb, this version of the connector will use just a little over 100mb of memory per `docker stats` when doing stores, and have batch sizes of about 50 documents. Each materialized row has all of the fields from the document as well as a field with the entire document, so 50 documents is just about right with a batch size limit of 10mb.

For this same synthetic dataset, the prior version of the connector with its 4096 document count limit would reach 1gb of memory consumption and OOM.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1233)
<!-- Reviewable:end -->
