### PR TITLE
materialize-redshift: locate long identifiers by truncation in information_schema output

### DIFF
--- a/materialize-redshift/sqlgen_test.go
+++ b/materialize-redshift/sqlgen_test.go
@@ -125,3 +125,38 @@ func TestSQLGeneration(t *testing.T) {
 
 	cupaloy.SnapshotT(t, snap.String())
 }
+
+func TestTruncatedIdentifier(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "no truncation",
+			input: "hello",
+			want:  "hello",
+		},
+		{
+			name:  "truncate ASCII",
+			input: strings.Repeat("a", 128),
+			want:  strings.Repeat("a", 127),
+		},
+		{
+			name:  "truncate UTF-8",
+			input: strings.Repeat("a", 125) + "码",
+			want:  strings.Repeat("a", 125),
+		},
+		{
+			name:  "empty input",
+			input: "",
+			want:  "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, truncatedIdentifier(tt.input))
+		})
+	}
+}


### PR DESCRIPTION
**Description:**

Redshift automatically truncates identifiers longer than 127 bytes. We can still make tables and columns with identifiers longer than this, but they are always truncated when interacting with them. Notably, this means we need to be aware of the possibility for truncation when reading the output from the information_schema view, which will show the truncated form.

See also 49a4802aaef6ce63ad11b82c308d288db15e9f28, which is a very similar adaptation for materialize-postgres.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1237)
<!-- Reviewable:end -->
