### PR TITLE
materialize-sql: parse numeric format strings with underscores

### DIFF
--- a/materialize-sql/type_mapping.go
+++ b/materialize-sql/type_mapping.go
@@ -267,6 +267,11 @@ func StdStrToInt() ElementConverter {
 			str = str[:idx]
 		}
 
+		// Flow validates strings like "1__234" and "123_" as integer formats. So we remove all
+		// underscores before trying to parse, as above on the assumption that the string is a
+		// valid formatted integer.
+		str = strings.ReplaceAll(str, "_", "")
+
 		var i big.Int
 		out, ok := i.SetString(str, 10)
 		if !ok {
@@ -292,6 +297,11 @@ func StdStrToFloat(nan, posInfinity, negInfinity interface{}) ElementConverter {
 		case "-Infinity":
 			return negInfinity, nil
 		default:
+			// Flow validates strings like "12__34.1" and "1.23_" as number formats.
+			// strconv.ParseFloat does not allow for trailing underscores or more than one
+			// underscore in a row, so we remove all underscores before trying to parse.
+			str = strings.ReplaceAll(str, "_", "")
+
 			out, err := strconv.ParseFloat(str, 64)
 			if err != nil {
 				return nil, fmt.Errorf("could not convert %q to float64: %w", str, err)

--- a/materialize-sql/type_mapping_test.go
+++ b/materialize-sql/type_mapping_test.go
@@ -32,11 +32,69 @@ func TestStdStrToInt(t *testing.T) {
 			input: "-14.0",
 			want:  -14,
 		},
+		{
+			input: "1_234",
+			want:  1234,
+		},
+		{
+			input: "123_",
+			want:  123,
+		},
+		{
+			input: "_12__34_",
+			want:  1234,
+		},
 	} {
 		t.Run(tt.input, func(t *testing.T) {
 			got, err := StdStrToInt()(tt.input)
 			require.NoError(t, err)
 			require.Equal(t, tt.want, got.(*big.Int).Int64())
+		})
+	}
+}
+
+func TestStdStrToFloat(t *testing.T) {
+	for _, tt := range []struct {
+		input string
+		want  float64
+	}{
+		{
+			input: "11.0",
+			want:  11,
+		},
+		{
+			input: "11.0000000",
+			want:  11,
+		},
+		{
+			input: "1",
+			want:  1,
+		},
+		{
+			input: "-3",
+			want:  -3,
+		},
+		{
+			input: "-14.0",
+			want:  -14,
+		},
+		{
+			input: "1_234.1",
+			want:  1234.1,
+		},
+		{
+			input: "12_34.2",
+			want:  1234.2,
+		},
+		{
+			input: "1.234_",
+			want:  1.234,
+		},
+	} {
+		t.Run(tt.input, func(t *testing.T) {
+			got, err := StdStrToFloat(nil, nil, nil)(tt.input)
+			require.NoError(t, err)
+			require.Equal(t, tt.want, got.(float64))
 		})
 	}
 }


### PR DESCRIPTION
**Description:**

The parsing for strings formatted as numbers and integers used by the Go libraries in materialize-sql have different restrictions on how underscores can be present in the strings than how Flow validates formatted numeric strings. To allow for compatibility, we must remove underscores prior to attempting to parse these strings in preparation to store them in the destination.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1238)
<!-- Reviewable:end -->
