### PR TITLE
source-snowflake: Use `ESTUARY_STAGING` as default staging schema

### DIFF
--- a/source-snowflake/.snapshots/TestSpec
+++ b/source-snowflake/.snapshots/TestSpec
@@ -46,7 +46,7 @@
           "flowSchema": {
             "type": "string",
             "description": "The schema in which Flow will create and manage its streams and staging tables.",
-            "default": "FLOW"
+            "default": "ESTUARY_STAGING"
           }
         },
         "additionalProperties": false,

--- a/source-snowflake/main.go
+++ b/source-snowflake/main.go
@@ -31,7 +31,7 @@ type config struct {
 }
 
 type advancedConfig struct {
-	FlowSchema string `json:"flowSchema,omitempty" jsonschema:"default=FLOW,description=The schema in which Flow will create and manage its streams and staging tables."`
+	FlowSchema string `json:"flowSchema,omitempty" jsonschema:"default=ESTUARY_STAGING,description=The schema in which Flow will create and manage its streams and staging tables."`
 }
 
 var hostRe = regexp.MustCompile(`(?i)^.+.snowflakecomputing\.com$`)
@@ -71,7 +71,7 @@ func (c *config) SetDefaults() {
 	// Note these are 1:1 with 'omitempty' in Config field tags,
 	// which cause these fields to be emitted as non-required.
 	if c.Advanced.FlowSchema == "" {
-		c.Advanced.FlowSchema = "FLOW"
+		c.Advanced.FlowSchema = "ESTUARY_STAGING"
 	}
 }
 


### PR DESCRIPTION
**Description:**

This makes the naming more consistent with the pattern used for other entities (user account / role / warehouse) our documentation will guide users to set up.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1242)
<!-- Reviewable:end -->
