### PR TITLE
source-mysql: Normalize zero-month/day in MySQL datetimes

### DIFF
--- a/source-mysql/.snapshots/TestDatetimeNormalization
+++ b/source-mysql/.snapshots/TestDatetimeNormalization
@@ -1,0 +1,12 @@
+# ================================
+# Collection "acmeCo/test/test_datetimenormalization_24528211": 4 Documents
+# ================================
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"DatetimeNormalization_24528211","cursor":"backfill:0"}},"id":100,"x":"1991-08-31T17:34:57Z"}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"DatetimeNormalization_24528211","cursor":"backfill:1"}},"id":101,"x":"0001-01-01T00:00:00Z"}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"DatetimeNormalization_24528211","cursor":"backfill:2"}},"id":102,"x":"2023-01-01T06:00:00Z"}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"DatetimeNormalization_24528211","cursor":"backfill:3"}},"id":103,"x":"2023-07-01T05:00:00Z"}
+# ================================
+# Final State Checkpoint
+# ================================
+{"bindingStateV1":{"test%2FDatetimeNormalization_24528211":{"backfilled":4,"key_columns":["id"],"metadata":{"schema":{"columns":["id","x"],"types":{"id":"int","x":"datetime"}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
+

--- a/source-mysql/.snapshots/TestDatetimeNormalization-replication
+++ b/source-mysql/.snapshots/TestDatetimeNormalization-replication
@@ -1,0 +1,12 @@
+# ================================
+# Collection "acmeCo/test/test_datetimenormalization_24528211": 4 Documents
+# ================================
+{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"DatetimeNormalization_24528211","cursor":"binlog.000123:56789:123","txid":"11111111-1111-1111-1111-111111111111:111"}},"id":200,"x":"1991-08-31T17:34:57Z"}
+{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"DatetimeNormalization_24528211","cursor":"binlog.000123:56789:123","txid":"11111111-1111-1111-1111-111111111111:111"}},"id":201,"x":"0001-01-01T00:00:00Z"}
+{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"DatetimeNormalization_24528211","cursor":"binlog.000123:56789:123","txid":"11111111-1111-1111-1111-111111111111:111"}},"id":202,"x":"2022-11-30T06:00:00Z"}
+{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"DatetimeNormalization_24528211","cursor":"binlog.000123:56789:123","txid":"11111111-1111-1111-1111-111111111111:111"}},"id":203,"x":"2023-06-30T05:00:00Z"}
+# ================================
+# Final State Checkpoint
+# ================================
+{"bindingStateV1":{"test%2FDatetimeNormalization_24528211":{"backfilled":4,"key_columns":["id"],"metadata":{"schema":{"columns":["id","x"],"types":{"id":"int","x":"datetime"}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
+


### PR DESCRIPTION
**Description:**

These are invalid and you have to make sure the `NO_ZERO_IN_DATE` mode flag is cleared in order to insert them, but since that's a thing we can receive from the database we need to handle it. We'll handle them by normalizing the zero component to one instead.

This code is rather ugly and produces off-by-one results for backfills versus replication, but it's sufficient to get things unblocked in production and such invalid datetimes are generally a hacky way of saying something like "July 2023" without additional detail anyway, so the inconsistency doesn't feel like the end of the world. We should still chase that down soon, obviously.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1245)
<!-- Reviewable:end -->
