### PR TITLE
source-sftp: set recommended_name when directory is /

### DIFF
--- a/source-sftp/main.go
+++ b/source-sftp/main.go
@@ -118,7 +118,12 @@ func (c config) DiscoverRoot() string {
 }
 
 func (c config) RecommendedName() string {
-	return strings.Trim(c.DiscoverRoot(), "/")
+	var name = strings.Trim(c.DiscoverRoot(), "/")
+	if name == "" {
+		return "root"
+	} else {
+		return name
+	}
 }
 
 func (c config) FilesAreMonotonic() bool {


### PR DESCRIPTION
A user entered `/` for the `directory` in the config, and it resulted in the `recommended_name` of the discovered binding being empty. This ensures that the recommended name is always non-empty by defaulting it to `root-directory`. Feel free to suggest a better default name.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1247)
<!-- Reviewable:end -->
