### PR TITLE
source-postgres: Unexpected EOF is not an error

### DIFF
--- a/sqlcapture/capture.go
+++ b/sqlcapture/capture.go
@@ -170,6 +170,10 @@ const (
 	streamProgressInterval     = 60 * time.Second // After `streamProgressInterval` the replication streaming code may log a progress report.
 )
 
+var (
+	errWatermarkNotReached = fmt.Errorf("replication stream closed before reaching watermark")
+)
+
 // Run is the top level entry point of the capture process.
 func (c *Capture) Run(ctx context.Context) (err error) {
 	// Perform discovery and cache the result. This is used at startup when
@@ -593,7 +597,7 @@ func (c *Capture) streamToWatermarkWithOptions(ctx context.Context, replStream R
 	if err := ctx.Err(); err != nil {
 		return err
 	}
-	return fmt.Errorf("replication stream closed before reaching watermark")
+	return errWatermarkNotReached
 }
 
 func (c *Capture) handleReplicationEvent(event DatabaseEvent) error {

--- a/sqlcapture/main.go
+++ b/sqlcapture/main.go
@@ -3,6 +3,7 @@ package sqlcapture
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"slices"
@@ -345,5 +346,10 @@ func (d *Driver) Pull(open *pc.Request_Open, stream *boilerplate.PullOutput) err
 		}
 	}
 
-	return c.Run(ctx)
+	err = c.Run(ctx)
+	if errors.Is(err, errWatermarkNotReached) {
+		log.Warn("replication stream closed unexpectedly")
+		return nil
+	}
+	return err
 }


### PR DESCRIPTION
**Description:**

Instead we'll just shut down cleanly (while logging a warning) and assume that a subsequent retry will succeed.

This fixes https://github.com/estuary/connectors/issues/1183

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1252)
<!-- Reviewable:end -->
