### PR TITLE
materializations: don't check for identical resource paths in validate

### DIFF
--- a/materialize-boilerplate/validate.go
+++ b/materialize-boilerplate/validate.go
@@ -323,8 +323,7 @@ func (v Validator) ambiguousFieldIsSelected(p pf.Projection, fieldSelection []st
 	return false
 }
 
-// findExistingBinding locates a binding within an existing stored specification, and verifies that
-// there are no target path conflicts with a proposed binding that does not already exist.
+// findExistingBinding locates a binding within an existing stored specification.
 func findExistingBinding(
 	resourcePath []string,
 	proposedCollection pf.Collection,
@@ -335,19 +334,7 @@ func findExistingBinding(
 	}
 	for _, existingBinding := range storedSpec.Bindings {
 		if existingBinding.Collection.Name == proposedCollection && slices.Equal(resourcePath, existingBinding.ResourcePath) {
-			// The binding already exists for this collection and is being materialized to the
-			// target.
 			return existingBinding, nil
-		} else if slices.Equal(resourcePath, existingBinding.ResourcePath) {
-			// There is a binding already materializing to the target, but for a different
-			// collection.
-			return nil, fmt.Errorf(
-				"cannot add a new binding to materialize collection '%s' to '%s' because an existing binding for collection '%s' is already materializing to '%s'",
-				proposedCollection.String(),
-				resourcePath,
-				existingBinding.Collection.Name,
-				resourcePath,
-			)
 		}
 	}
 	return nil, nil

--- a/materialize-boilerplate/validate_test.go
+++ b/materialize-boilerplate/validate_test.go
@@ -243,27 +243,6 @@ func TestValidate(t *testing.T) {
 		require.NoError(t, err)
 	})
 
-	t.Run("can't materialize two collections to the same target", func(t *testing.T) {
-		existing := loadValidateSpec(t, "base.flow.proto")
-		proposed := loadValidateSpec(t, "base.flow.proto")
-
-		proposed.Bindings[0].Collection.Name = pf.Collection("other")
-
-		is := testInfoSchemaFromSpec(t, existing, simpleTestTransform)
-		validator := NewValidator(testConstrainter{}, is)
-
-		_, err := validator.ValidateBinding(
-			[]string{"key_value"},
-			false,
-			proposed.Bindings[0].Backfill,
-			proposed.Bindings[0].Collection,
-			proposed.Bindings[0].FieldSelection.FieldConfigJsonMap,
-			existing,
-		)
-
-		require.ErrorContains(t, err, "cannot add a new binding to materialize collection 'other' to '[key_value]' because an existing binding for collection 'key/value' is already materializing to '[key_value]'")
-	})
-
 	t.Run("can't materialize a nullable collection key with no default value", func(t *testing.T) {
 		proposed := loadValidateSpec(t, "nullable-key.flow.proto")
 


### PR DESCRIPTION
**Description:**

This check was problematic because it didn't allow for "removing" a binding and "adding" a different binding to the same table in the same publication. There is no reason to forbid this, since the actual columns & types of the materialized resource are used for validating that a binding is compatible. So, the source collection of a binding could be changed and still go to the same table, as long as the already materialized table is compatible with the source collection.

There are edge cases where this might be a problem, such as if the previous binding was delta updates and the new one is not and the target table has existing rows in duplicate for certain keys from the delta updates materialization. This same thing could currently happen if the binding were removed, published, and then added back with a different source collection in the same publication, so this change doesn't seem like it makes that situation any worse. And there is a fix for this, via the backfill counter of the binding.

As for the possibility of there being two identical resource paths within the same materialization, we don't need to check that in the connector anymore since the control plane validates that it can't happen.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1255)
<!-- Reviewable:end -->
