### PR TITLE
materializations: find existing bindings based only on resource path

### DIFF
--- a/materialize-boilerplate/apply.go
+++ b/materialize-boilerplate/apply.go
@@ -112,7 +112,7 @@ func ApplyChanges(ctx context.Context, req *pm.Request_Apply, applier Applier, i
 		// The existing binding spec is used to extract various properties that can't be learned
 		// from introspecting the destination system, such as the backfill counter and if the
 		// materialization was previously delta updates.
-		existingBinding, err := findExistingBinding(binding.ResourcePath, binding.Collection.Name, storedSpec)
+		existingBinding, err := findExistingBinding(binding.ResourcePath, storedSpec)
 		if err != nil {
 			return nil, fmt.Errorf("finding existing binding: %w", err)
 		}

--- a/materialize-boilerplate/validate.go
+++ b/materialize-boilerplate/validate.go
@@ -48,7 +48,7 @@ func (v Validator) ValidateBinding(
 	fieldConfigJsonMap map[string]json.RawMessage,
 	storedSpec *pf.MaterializationSpec,
 ) (map[string]*pm.Response_Validated_Constraint, error) {
-	existingBinding, err := findExistingBinding(path, boundCollection.Name, storedSpec)
+	existingBinding, err := findExistingBinding(path, storedSpec)
 	if err != nil {
 		return nil, err
 	}
@@ -324,16 +324,12 @@ func (v Validator) ambiguousFieldIsSelected(p pf.Projection, fieldSelection []st
 }
 
 // findExistingBinding locates a binding within an existing stored specification.
-func findExistingBinding(
-	resourcePath []string,
-	proposedCollection pf.Collection,
-	storedSpec *pf.MaterializationSpec,
-) (*pf.MaterializationSpec_Binding, error) {
+func findExistingBinding(resourcePath []string, storedSpec *pf.MaterializationSpec) (*pf.MaterializationSpec_Binding, error) {
 	if storedSpec == nil {
 		return nil, nil // Binding is trivially not found
 	}
 	for _, existingBinding := range storedSpec.Bindings {
-		if existingBinding.Collection.Name == proposedCollection && slices.Equal(resourcePath, existingBinding.ResourcePath) {
+		if slices.Equal(resourcePath, existingBinding.ResourcePath) {
 			return existingBinding, nil
 		}
 	}


### PR DESCRIPTION
**Description:**

Matching on both the collection name + resource path doesn't work well if the backfill counter for a binding is incremented simultaneously with changing the source collection. This isn't terribly common, but will automatically happen via the schema evolutions handler when a collection key changes. In this case, the current behavior will consider the binding brand new, and will not re-create the table.

Matching on just the resource path is consistent with how the runtime computes state keys for bindings, which are only based on the resource path. This will allow the materialization to consider a binding with a different source collection for the same resource path to be a continuation of that binding, and will react to backfill counter changes accordingly.

This also resolves edge cases noted in 3b616f2, where changing the source collection for a table simultaneously with switching from delta updates to standard updates would cause problems. We can now prevent that switch from happening as well.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1258)
<!-- Reviewable:end -->
