### PR TITLE
fix: `source-google-ads` OAuth config

### DIFF
--- a/source-google-ads/__main__.py
+++ b/source-google-ads/__main__.py
@@ -14,7 +14,7 @@ def urlencode_field(field: str):
 
 accessTokenBody = {
     "grant_type": "authorization_code",
-    "client_id": "{{{ 'client_id' }}}",
+    "client_id": "{{{ client_id }}}",
     "client_secret": "{{{ client_secret }}}",
     "redirect_uri": "{{{ redirect_uri }}}",
     "code": "{{{ code }}}",

--- a/source-google-ads/__main__.py
+++ b/source-google-ads/__main__.py
@@ -1,5 +1,6 @@
 from flow_sdk import shim_airbyte_cdk
 from source_google_ads import SourceGoogleAds
+import json
 
 
 def wrap_with_braces(body: str, count: int):
@@ -11,12 +12,19 @@ def wrap_with_braces(body: str, count: int):
 def urlencode_field(field: str):
     return f"{wrap_with_braces('#urlencode',2)}{wrap_with_braces(field,3)}{wrap_with_braces('/urlencode',2)}"
 
+accessTokenBody = {
+    "grant_type": "authorization_code",
+    "client_id": "{{{ 'client_id' }}}",
+    "client_secret": "{{{ client_secret }}}",
+    "redirect_uri": "{{{ redirect_uri }}}",
+    "code": "{{{ code }}}",
+}
 
 shim_airbyte_cdk.CaptureShim(
     delegate=SourceGoogleAds(),
     oauth2={
         "provider": "google",
-        "accessTokenBody": r"{\"grant_type\": \"authorization_code\", \"client_id\": \"{{{ 'client_id' }}}\", \"client_secret\": \"{{{ client_secret }}}\", \"redirect_uri\": \"{{{ redirect_uri }}}\", \"code\": \"{{{ code }}}\"}",
+        "accessTokenBody": json.dumps(accessTokenBody),
         "authUrlTemplate": (
             f"https://accounts.google.com/o/oauth2/auth?"
             f"access_type=offline&"

--- a/source-google-ads/source_google_ads/source_google_ads/spec.json
+++ b/source-google-ads/source_google_ads/source_google_ads/spec.json
@@ -23,28 +23,36 @@
             "type": "string",
             "title": "Client ID",
             "order": 1,
-            "description": "The Client ID of your Google Ads developer application. More instruction on how to find this value in our <a href=\"https://docs.airbyte.com/integrations/sources/google-ads#setup-guide\">docs</a>"
+            "description": "The Client ID of your Google Ads developer application. More instruction on how to find this value in our <a href=\"https://docs.airbyte.com/integrations/sources/google-ads#setup-guide\">docs</a>",
+            "secret": true
           },
           "client_secret": {
             "type": "string",
             "title": "Client Secret",
             "order": 2,
             "description": "The Client Secret of your Google Ads developer application. More instruction on how to find this value in our <a href=\"https://docs.airbyte.com/integrations/sources/google-ads#setup-guide\">docs</a>",
-            "airbyte_secret": true
+            "secret": true
           },
           "refresh_token": {
             "type": "string",
             "title": "Refresh Token",
             "order": 3,
             "description": "The token for obtaining a new access token. More instruction on how to find this value in our <a href=\"https://docs.airbyte.com/integrations/sources/google-ads#setup-guide\">docs</a>",
-            "airbyte_secret": true
+            "secret": true
           },
           "access_token": {
             "type": "string",
             "title": "Access Token",
             "order": 4,
             "description": "Access Token for making authenticated requests. More instruction on how to find this value in our <a href=\"https://docs.airbyte.com/integrations/sources/google-ads#setup-guide\">docs</a>",
-            "airbyte_secret": true
+            "secret": true
+          },
+          "developer_token": {
+            "type": "string",
+            "title": "Developer Token",
+            "order": 2,
+            "description": "Injected by Flow",
+            "secret": true
           }
         }
       },
@@ -53,7 +61,6 @@
         "type": "string",
         "description": "Comma separated list of (client) customer IDs. Each customer ID must be specified as a 10-digit number without dashes. More instruction on how to find this value in our <a href=\"https://docs.airbyte.com/integrations/sources/google-ads#setup-guide\">docs</a>. Metrics streams like AdGroupAdReport cannot be requested for a manager account.",
         "pattern": "^[0-9]{10}(,[0-9]{10})*$",
-        "pattern_descriptor": "The customer ID must be 10 digits. Separate multiple customer IDs using commas.",
         "examples": ["6783948572,5839201945"],
         "order": 1
       },
@@ -62,7 +69,6 @@
         "title": "Start Date",
         "description": "UTC date and time in the format 2017-01-25. Any data before this date will not be replicated.",
         "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$",
-        "pattern_descriptor": "YYYY-MM-DD",
         "examples": ["2017-01-25"],
         "order": 2,
         "format": "date"
@@ -72,7 +78,6 @@
         "title": "End Date",
         "description": "UTC date and time in the format 2017-01-25. Any data after this date will not be replicated.",
         "pattern": "^$|^[0-9]{4}-[0-9]{2}-[0-9]{2}$",
-        "pattern_descriptor": "YYYY-MM-DD",
         "examples": ["2017-01-30"],
         "order": 6,
         "format": "date"

--- a/source-google-ads/source_google_ads/source_google_ads/spec.json
+++ b/source-google-ads/source_google_ads/source_google_ads/spec.json
@@ -14,19 +14,11 @@
         "order": 0,
         "x-oauth2-provider": "google",
         "required": [
-          "developer_token",
           "client_id",
           "client_secret",
           "refresh_token"
         ],
         "properties": {
-          "developer_token": {
-            "type": "string",
-            "title": "Developer Token",
-            "order": 0,
-            "description": "Developer token granted by Google to use their APIs. More instruction on how to find this value in our <a href=\"https://docs.airbyte.com/integrations/sources/google-ads#setup-guide\">docs</a>",
-            "airbyte_secret": true
-          },
           "client_id": {
             "type": "string",
             "title": "Client ID",

--- a/source-google-ads/source_google_ads/source_google_ads/spec.json
+++ b/source-google-ads/source_google_ads/source_google_ads/spec.json
@@ -12,6 +12,7 @@
         "description": "",
         "title": "Google Credentials",
         "order": 0,
+        "x-oauth2-provider": "google",
         "required": [
           "developer_token",
           "client_id",

--- a/source-google-ads/tests/snapshots/source_google_ads_tests_test_snapshots__spec__capture.stdout.json
+++ b/source-google-ads/tests/snapshots/source_google_ads_tests_test_snapshots__spec__capture.stdout.json
@@ -181,7 +181,7 @@
       "provider": "google",
       "authUrlTemplate": "https://accounts.google.com/o/oauth2/auth?access_type=offline&prompt=consent&client_id={{#urlencode}}{{{client_id}}}{{/urlencode}}&redirect_uri={{#urlencode}}{{{redirect_uri}}}{{/urlencode}}&response_type=code&scope=https://www.googleapis.com/auth/adwords&state={{#urlencode}}{{{state}}}{{/urlencode}}",
       "accessTokenUrlTemplate": "https://oauth2.googleapis.com/token",
-      "accessTokenBody": "{\\\"grant_type\\\": \\\"authorization_code\\\", \\\"client_id\\\": \\\"{{{ 'client_id' }}}\\\", \\\"client_secret\\\": \\\"{{{ client_secret }}}\\\", \\\"redirect_uri\\\": \\\"{{{ redirect_uri }}}\\\", \\\"code\\\": \\\"{{{ code }}}\\\"}",
+      "accessTokenBody": "{\"grant_type\": \"authorization_code\", \"client_id\": \"{{{ 'client_id' }}}\", \"client_secret\": \"{{{ client_secret }}}\", \"redirect_uri\": \"{{{ redirect_uri }}}\", \"code\": \"{{{ code }}}\"}",
       "accessTokenResponseMap": {
         "refresh_token": "/refresh_token"
       }

--- a/source-google-ads/tests/snapshots/source_google_ads_tests_test_snapshots__spec__capture.stdout.json
+++ b/source-google-ads/tests/snapshots/source_google_ads_tests_test_snapshots__spec__capture.stdout.json
@@ -17,6 +17,7 @@
           "description": "",
           "title": "Google Credentials",
           "order": 0,
+          "x-oauth2-provider": "google",
           "required": [
             "developer_token",
             "client_id",

--- a/source-google-ads/tests/snapshots/source_google_ads_tests_test_snapshots__spec__capture.stdout.json
+++ b/source-google-ads/tests/snapshots/source_google_ads_tests_test_snapshots__spec__capture.stdout.json
@@ -19,19 +19,11 @@
           "order": 0,
           "x-oauth2-provider": "google",
           "required": [
-            "developer_token",
             "client_id",
             "client_secret",
             "refresh_token"
           ],
           "properties": {
-            "developer_token": {
-              "type": "string",
-              "title": "Developer Token",
-              "order": 0,
-              "description": "Developer token granted by Google to use their APIs. More instruction on how to find this value in our <a href=\"https://docs.airbyte.com/integrations/sources/google-ads#setup-guide\">docs</a>",
-              "airbyte_secret": true
-            },
             "client_id": {
               "type": "string",
               "title": "Client ID",
@@ -181,7 +173,7 @@
       "provider": "google",
       "authUrlTemplate": "https://accounts.google.com/o/oauth2/auth?access_type=offline&prompt=consent&client_id={{#urlencode}}{{{client_id}}}{{/urlencode}}&redirect_uri={{#urlencode}}{{{redirect_uri}}}{{/urlencode}}&response_type=code&scope=https://www.googleapis.com/auth/adwords&state={{#urlencode}}{{{state}}}{{/urlencode}}",
       "accessTokenUrlTemplate": "https://oauth2.googleapis.com/token",
-      "accessTokenBody": "{\"grant_type\": \"authorization_code\", \"client_id\": \"{{{ 'client_id' }}}\", \"client_secret\": \"{{{ client_secret }}}\", \"redirect_uri\": \"{{{ redirect_uri }}}\", \"code\": \"{{{ code }}}\"}",
+      "accessTokenBody": "{\"grant_type\": \"authorization_code\", \"client_id\": \"{{{ client_id }}}\", \"client_secret\": \"{{{ client_secret }}}\", \"redirect_uri\": \"{{{ redirect_uri }}}\", \"code\": \"{{{ code }}}\"}",
       "accessTokenResponseMap": {
         "refresh_token": "/refresh_token"
       }

--- a/source-google-ads/tests/snapshots/source_google_ads_tests_test_snapshots__spec__capture.stdout.json
+++ b/source-google-ads/tests/snapshots/source_google_ads_tests_test_snapshots__spec__capture.stdout.json
@@ -28,28 +28,36 @@
               "type": "string",
               "title": "Client ID",
               "order": 1,
-              "description": "The Client ID of your Google Ads developer application. More instruction on how to find this value in our <a href=\"https://docs.airbyte.com/integrations/sources/google-ads#setup-guide\">docs</a>"
+              "description": "The Client ID of your Google Ads developer application. More instruction on how to find this value in our <a href=\"https://docs.airbyte.com/integrations/sources/google-ads#setup-guide\">docs</a>",
+              "secret": true
             },
             "client_secret": {
               "type": "string",
               "title": "Client Secret",
               "order": 2,
               "description": "The Client Secret of your Google Ads developer application. More instruction on how to find this value in our <a href=\"https://docs.airbyte.com/integrations/sources/google-ads#setup-guide\">docs</a>",
-              "airbyte_secret": true
+              "secret": true
             },
             "refresh_token": {
               "type": "string",
               "title": "Refresh Token",
               "order": 3,
               "description": "The token for obtaining a new access token. More instruction on how to find this value in our <a href=\"https://docs.airbyte.com/integrations/sources/google-ads#setup-guide\">docs</a>",
-              "airbyte_secret": true
+              "secret": true
             },
             "access_token": {
               "type": "string",
               "title": "Access Token",
               "order": 4,
               "description": "Access Token for making authenticated requests. More instruction on how to find this value in our <a href=\"https://docs.airbyte.com/integrations/sources/google-ads#setup-guide\">docs</a>",
-              "airbyte_secret": true
+              "secret": true
+            },
+            "developer_token": {
+              "type": "string",
+              "title": "Developer Token",
+              "order": 2,
+              "description": "Injected by Flow",
+              "secret": true
             }
           }
         },
@@ -58,7 +66,6 @@
           "type": "string",
           "description": "Comma separated list of (client) customer IDs. Each customer ID must be specified as a 10-digit number without dashes. More instruction on how to find this value in our <a href=\"https://docs.airbyte.com/integrations/sources/google-ads#setup-guide\">docs</a>. Metrics streams like AdGroupAdReport cannot be requested for a manager account.",
           "pattern": "^[0-9]{10}(,[0-9]{10})*$",
-          "pattern_descriptor": "The customer ID must be 10 digits. Separate multiple customer IDs using commas.",
           "examples": [
             "6783948572,5839201945"
           ],
@@ -69,7 +76,6 @@
           "title": "Start Date",
           "description": "UTC date and time in the format 2017-01-25. Any data before this date will not be replicated.",
           "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$",
-          "pattern_descriptor": "YYYY-MM-DD",
           "examples": [
             "2017-01-25"
           ],
@@ -81,7 +87,6 @@
           "title": "End Date",
           "description": "UTC date and time in the format 2017-01-25. Any data after this date will not be replicated.",
           "pattern": "^$|^[0-9]{4}-[0-9]{2}-[0-9]{2}$",
-          "pattern_descriptor": "YYYY-MM-DD",
           "examples": [
             "2017-01-30"
           ],


### PR DESCRIPTION
**Description:**

* Add `"x-oauth2-provider": "google"` to `source-google-ads`
* Fix `accessTokenBody` being improperly formatted/escaped
* Remove `pattern_descriptor` fields, which is apparently an Airbyte-specific thing and was causing jsonschema validation to fail

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1260)
<!-- Reviewable:end -->
