### PR TITLE
fix: Disable Airtable OAuth since it never worked

### DIFF
--- a/source-airtable/source_airtable/source_airtable/spec.json
+++ b/source-airtable/source_airtable/source_airtable/spec.json
@@ -7,74 +7,17 @@
     "additionalProperties": true,
     "properties": {
       "credentials": {
-        "title": "Authentication",
+        "title": "Personal Access Token",
         "type": "object",
-        "discriminator": {
-          "propertyName": "auth_method"
-        },
-        "oneOf": [
-          {
-            "type": "object",
-            "title": "OAuth2",
-            "x-oauth2-provider": "airtable",
-            "required": ["client_id", "client_secret", "refresh_token"],
-            "properties": {
-              "auth_method": {
-                "type": "string",
-                "const": "oauth2.0",
-                "default": "oauth2.0",
-                "order": 0
-              },
-              "client_id": {
-                "type": "string",
-                "title": "Client ID",
-                "description": "The client ID of the Airtable developer application.",
-                "airbyte_secret": true
-              },
-              "client_secret": {
-                "type": "string",
-                "title": "Client secret",
-                "description": "The client secret the Airtable developer application.",
-                "airbyte_secret": true
-              },
-              "access_token": {
-                "type": "string",
-                "description": "Access Token for making authenticated requests.",
-                "airbyte_secret": true
-              },
-              "token_expiry_date": {
-                "type": "string",
-                "description": "The date-time when the access token should be refreshed.",
-                "format": "date-time"
-              },
-              "refresh_token": {
-                "type": "string",
-                "title": "Refresh token",
-                "description": "The key to refresh the expired access token.",
-                "airbyte_secret": true
-              }
-            }
-          },
-          {
+        "required": ["api_key"],
+        "properties": {
+          "api_key": {
+            "type": "string",
+            "description": "The Personal Access Token for the Airtable account. See https://airtable.com/developers/web/guides/personal-access-tokens for more information on how to obtain this token.",
             "title": "Personal Access Token",
-            "type": "object",
-            "required": ["api_key"],
-            "properties": {
-              "auth_method": {
-                "type": "string",
-                "const": "api_key",
-                "default": "api_key",
-                "order": 0
-              },
-              "api_key": {
-                "type": "string",
-                "description": "The Personal Access Token for the Airtable account. See the <a href=\"https://airtable.com/developers/web/guides/personal-access-tokens\">Support Guide</a> for more information on how to obtain this token.",
-                "title": "Personal Access Token",
-                "airbyte_secret": true
-              }
-            }
+            "airbyte_secret": true
           }
-        ]
+        }
       }
     },
     "required": ["credentials"]

--- a/source-airtable/tests/snapshots/source_airtable_tests_test_snapshots__spec__capture.stdout.json
+++ b/source-airtable/tests/snapshots/source_airtable_tests_test_snapshots__spec__capture.stdout.json
@@ -8,80 +8,19 @@
       "additionalProperties": true,
       "properties": {
         "credentials": {
-          "title": "Authentication",
+          "title": "Personal Access Token",
           "type": "object",
-          "discriminator": {
-            "propertyName": "auth_method"
-          },
-          "oneOf": [
-            {
-              "type": "object",
-              "title": "OAuth2",
-              "x-oauth2-provider": "airtable",
-              "required": [
-                "client_id",
-                "client_secret",
-                "refresh_token"
-              ],
-              "properties": {
-                "auth_method": {
-                  "type": "string",
-                  "const": "oauth2.0",
-                  "default": "oauth2.0",
-                  "order": 0
-                },
-                "client_id": {
-                  "type": "string",
-                  "title": "Client ID",
-                  "description": "The client ID of the Airtable developer application.",
-                  "airbyte_secret": true
-                },
-                "client_secret": {
-                  "type": "string",
-                  "title": "Client secret",
-                  "description": "The client secret the Airtable developer application.",
-                  "airbyte_secret": true
-                },
-                "access_token": {
-                  "type": "string",
-                  "description": "Access Token for making authenticated requests.",
-                  "airbyte_secret": true
-                },
-                "token_expiry_date": {
-                  "type": "string",
-                  "description": "The date-time when the access token should be refreshed.",
-                  "format": "date-time"
-                },
-                "refresh_token": {
-                  "type": "string",
-                  "title": "Refresh token",
-                  "description": "The key to refresh the expired access token.",
-                  "airbyte_secret": true
-                }
-              }
-            },
-            {
+          "required": [
+            "api_key"
+          ],
+          "properties": {
+            "api_key": {
+              "type": "string",
+              "description": "The Personal Access Token for the Airtable account. See https://airtable.com/developers/web/guides/personal-access-tokens for more information on how to obtain this token.",
               "title": "Personal Access Token",
-              "type": "object",
-              "required": [
-                "api_key"
-              ],
-              "properties": {
-                "auth_method": {
-                  "type": "string",
-                  "const": "api_key",
-                  "default": "api_key",
-                  "order": 0
-                },
-                "api_key": {
-                  "type": "string",
-                  "description": "The Personal Access Token for the Airtable account. See the <a href=\"https://airtable.com/developers/web/guides/personal-access-tokens\">Support Guide</a> for more information on how to obtain this token.",
-                  "title": "Personal Access Token",
-                  "airbyte_secret": true
-                }
-              }
+              "airbyte_secret": true
             }
-          ]
+          }
         }
       },
       "required": [


### PR DESCRIPTION
Airtable's access tokens expire after 60m, and their refresh tokens [expire](https://airtable.com/developers/web/api/oauth-reference#token-expiry-refresh-tokens) theoretically after 60 days. Since we don't have a way to store new refresh tokens, theoretically airtable OAuth integrations should work for 60d and then fail. In actuality, this connector is failing after 60 minutes. It _appears_ that the refresh tokens Airtable is giving us expire after 60m. Normally this would be fine as they're supposed to be single-use tokens anyway, but we don't support storing updated credentials like this.

As far as I know, our solution was to just disable OAuth for Airtable captures entirely, and only expose the ability to use PATs. This knowledge got lost when importing this connector and we tried to configure OAuth like we do with all connectors. This PR re-disables it until we have a way to properly store updated credentials like new refresh tokens.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1262)
<!-- Reviewable:end -->
