### PR TITLE
materialize-snowflake: use snowpipe for delta update bindings + jwt auth

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -126,6 +126,7 @@ require (
 	github.com/go-jose/go-jose/v3 v3.0.1 // indirect
 	github.com/goccy/go-json v0.10.2 // indirect
 	github.com/godbus/dbus v0.0.0-20190726142602-4481cbc300e2 // indirect
+	github.com/golang-jwt/jwt/v5 v5.2.0 // indirect
 	github.com/golang-sql/civil v0.0.0-20190719163853-cb61b32ac6fe // indirect
 	github.com/golang-sql/sqlexp v0.1.0 // indirect
 	github.com/golang/glog v1.1.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -401,6 +401,8 @@ github.com/golang-jwt/jwt v3.2.2+incompatible/go.mod h1:8pz2t5EyA70fFQQSrl6XZXzq
 github.com/golang-jwt/jwt/v4 v4.2.0/go.mod h1:/xlHOz8bRuivTWchD4jCa+NbatV+wEUSzwAxVc6locg=
 github.com/golang-jwt/jwt/v4 v4.5.0 h1:7cYmW1XlMY7h7ii7UhUyChSgS5wUJEnm9uZVTGqOWzg=
 github.com/golang-jwt/jwt/v4 v4.5.0/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
+github.com/golang-jwt/jwt/v5 v5.2.0 h1:d/ix8ftRUorsN+5eMIlF4T6J8CAt9rch3My2winC1Jw=
+github.com/golang-jwt/jwt/v5 v5.2.0/go.mod h1:pqrtFR0X4osieyHYxtmOUWsAWrfe1Q5UVIyoH402zdk=
 github.com/golang-sql/civil v0.0.0-20190719163853-cb61b32ac6fe h1:lXe2qZdvpiX5WZkZR4hgp4KJVfY3nMkvmwbVkpv1rVY=
 github.com/golang-sql/civil v0.0.0-20190719163853-cb61b32ac6fe/go.mod h1:8vg3r2VgvsThLBIFL93Qb5yWzgyZWhEmBwUJWevAkK0=
 github.com/golang-sql/sqlexp v0.1.0 h1:ZCD6MBpcuOVfGVqsEmY5/4FtYiKz6tSyUv9LPEDei6A=

--- a/materialize-snowflake/.snapshots/TestSpecification
+++ b/materialize-snowflake/.snapshots/TestSpecification
@@ -7,27 +7,14 @@
         "type": "string",
         "title": "Host URL",
         "description": "The Snowflake Host used for the connection. Must include the account identifier and end in .snowflakecomputing.com. Example: orgname-accountname.snowflakecomputing.com (do not include the protocol).",
-        "order": 0,
         "pattern": "^[^/:]+.snowflakecomputing.com$"
+        "order": 0
       },
       "account": {
         "type": "string",
         "title": "Account",
         "description": "The Snowflake account identifier.",
         "order": 1
-      },
-      "user": {
-        "type": "string",
-        "title": "User",
-        "description": "The Snowflake user login name.",
-        "order": 2
-      },
-      "password": {
-        "type": "string",
-        "title": "Password",
-        "description": "The password for the provided user.",
-        "order": 3,
-        "secret": true
       },
       "database": {
         "type": "string",
@@ -52,6 +39,68 @@
         "title": "Role",
         "description": "The user role used to perform actions.",
         "order": 7
+      },
+      "credentials": {
+        "oneOf": [
+          {
+            "properties": {
+              "auth_type": {
+                "type": "string",
+                "const": "user_password",
+                "default": "user_password"
+              },
+              "user": {
+                "type": "string",
+                "title": "User",
+                "description": "The Snowflake user login name",
+                "order": 1
+              },
+              "password": {
+                "type": "string",
+                "title": "Password",
+                "description": "The password for the provided user",
+                "order": 2,
+                "secret": true
+              }
+            },
+            "required": [
+              "auth_type",
+              "user",
+              "password"
+            ],
+            "title": "User Password"
+          },
+          {
+            "properties": {
+              "auth_type": {
+                "type": "string",
+                "const": "jwt",
+                "default": "jwt"
+              },
+              "private_key": {
+                "type": "string",
+                "title": "Private Key",
+                "description": "Private Key to be used to sign the JWT token",
+                "multiline": true,
+                "order": 2,
+                "secret": true
+              }
+            },
+            "required": [
+              "auth_type",
+              "private_key"
+            ],
+            "title": "Private Key (JWT)"
+          }
+        ],
+        "type": "object",
+        "title": "Authentication",
+        "default": {
+          "auth_type": "user_password"
+        },
+        "discriminator": {
+          "propertyName": "auth_type"
+        }
       },
       "advanced": {
         "properties": {
@@ -80,10 +129,9 @@
     "required": [
       "host",
       "account",
-      "user",
-      "password",
       "database",
-      "schema"
+      "schema",
+      "credentials"
     ],
     "title": "SQL Connection"
   },

--- a/materialize-snowflake/.snapshots/TestSpecification
+++ b/materialize-snowflake/.snapshots/TestSpecification
@@ -7,8 +7,8 @@
         "type": "string",
         "title": "Host URL",
         "description": "The Snowflake Host used for the connection. Must include the account identifier and end in .snowflakecomputing.com. Example: orgname-accountname.snowflakecomputing.com (do not include the protocol).",
+        "order": 0,
         "pattern": "^[^/:]+.snowflakecomputing.com$"
-        "order": 0
       },
       "account": {
         "type": "string",
@@ -76,6 +76,12 @@
                 "type": "string",
                 "const": "jwt",
                 "default": "jwt"
+              },
+              "user": {
+                "type": "string",
+                "title": "User",
+                "description": "The Snowflake user login name",
+                "order": 1
               },
               "private_key": {
                 "type": "string",

--- a/materialize-snowflake/client.go
+++ b/materialize-snowflake/client.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	stdsql "database/sql"
-	"encoding/base64"
 	"errors"
 	"fmt"
 	"strings"
@@ -135,7 +134,7 @@ func (c *client) ExecStatements(ctx context.Context, statements []string) error 
 }
 
 func (c *client) InstallFence(ctx context.Context, checkpoints sql.Table, fence sql.Fence) (sql.Fence, error) {
-	return sql.StdInstallFence(ctx, c.db, checkpoints, fence, base64.StdEncoding.DecodeString)
+	return sql.Fence{}, nil
 }
 
 func (c *client) Close() {

--- a/materialize-snowflake/config.go
+++ b/materialize-snowflake/config.go
@@ -62,7 +62,7 @@ func (c *config) ToURI(tenant string) string {
 func (c *credentialConfig) privateKey() (*rsa.PrivateKey, error) {
 	if c.AuthType == JWT {
 		// When providing the PEM file in a JSON file, newlines can't be specified unless
-		// escaped, so here we allow a escape hatch to parse these PEM files
+		// escaped, so here we allow an escape hatch to parse these PEM files
 		var pkString = strings.ReplaceAll(c.PrivateKey, "\\n", "\n")
 		var block, _ = pem.Decode([]byte(pkString))
 		if key, err := x509.ParsePKCS8PrivateKey(block.Bytes); err != nil {
@@ -161,6 +161,7 @@ func (c *config) Validate() error {
 
 		c.Credentials.AuthType = UserPass
 		c.Credentials.Password = c.Password
+		c.Credentials.User = c.User
 	}
 
 	if err := c.Credentials.Validate(); err != nil {
@@ -197,6 +198,9 @@ func (c *credentialConfig) Validate() error {
 }
 
 func (c *credentialConfig) validateUserPassCreds() error {
+	if c.User == "" {
+		return fmt.Errorf("missing user")
+	}
 	if c.Password == "" {
 		return fmt.Errorf("missing password")
 	}
@@ -205,6 +209,9 @@ func (c *credentialConfig) validateUserPassCreds() error {
 }
 
 func (c *credentialConfig) validateJWTCreds() error {
+	if c.User == "" {
+		return fmt.Errorf("missing user")
+	}
 	if c.PrivateKey == "" {
 		return fmt.Errorf("missing private_key")
 	}

--- a/materialize-snowflake/config.go
+++ b/materialize-snowflake/config.go
@@ -1,0 +1,284 @@
+package main
+
+import (
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+	"fmt"
+	"github.com/iancoleman/orderedmap"
+	"github.com/invopop/jsonschema"
+	"regexp"
+	"strings"
+
+	m "github.com/estuary/connectors/go/protocols/materialize"
+	sf "github.com/snowflakedb/gosnowflake"
+)
+
+// config represents the endpoint configuration for snowflake.
+// It must match the one defined for the source specs (flow.yaml) in Rust.
+type config struct {
+	// TODO(mahdi): the Host and Account config is very confusing since Snowflake has multiple ways and very specific requirements
+	// for specifying the url of an instance. Ideally we should just accept the URL directly and use that, that would save us and
+	// users some headache
+	// See: https://docs.snowflake.com/en/user-guide/admin-account-identifier#non-vps-account-locator-formats-by-cloud-platform-and-region
+	Host      string `json:"host" jsonschema:"title=Host URL,description=The Snowflake Host used for the connection. Must include the account identifier and end in .snowflakecomputing.com. Example: orgname-accountname.snowflakecomputing.com (do not include the protocol)." jsonschema_extras:"order=0,pattern=^[^/:]+.snowflakecomputing.com$"`
+	Account   string `json:"account" jsonschema:"title=Account,description=The Snowflake account identifier." jsonschema_extras:"order=1"`
+	User      string `json:"user" jsonschema:"-"`
+	Password  string `json:"password" jsonschema:"-"`
+	Database  string `json:"database" jsonschema:"title=Database,description=The SQL database to connect to." jsonschema_extras:"order=4"`
+	Schema    string `json:"schema" jsonschema:"title=Schema,description=Database schema for bound collection tables (unless overridden within the binding resource configuration) as well as associated materialization metadata tables." jsonschema_extras:"order=5"`
+	Warehouse string `json:"warehouse,omitempty" jsonschema:"title=Warehouse,description=The Snowflake virtual warehouse used to execute queries. Uses the default warehouse for the Snowflake user if left blank." jsonschema_extras:"order=6"`
+	Role      string `json:"role,omitempty" jsonschema:"title=Role,description=The user role used to perform actions." jsonschema_extras:"order=7"`
+
+	Credentials credentialConfig `json:"credentials" jsonschema:"title=Authentication"`
+
+	Advanced advancedConfig `json:"advanced,omitempty" jsonschema:"title=Advanced Options,description=Options for advanced users. You should not typically need to modify these." jsonschema_extras:"advanced=true"`
+}
+
+type advancedConfig struct {
+	UpdateDelay string `json:"updateDelay,omitempty" jsonschema:"title=Update Delay,description=Potentially reduce active warehouse time by increasing the delay between updates. Defaults to 30 minutes if unset.,enum=0s,enum=15m,enum=30m,enum=1h,enum=2h,enum=4h"`
+}
+
+// ToURI converts the Config to a DSN string.
+func (c *config) ToURI(tenant string) string {
+	// Build a DSN connection string.
+	var configCopy = c.asSnowflakeConfig(tenant)
+	// client_session_keep_alive causes the driver to issue a periodic keepalive request.
+	// Without this, the authentication token will expire after 4 hours of inactivity.
+	// The Params map will not have been initialized if the endpoint config didn't specify
+	// it, so we check and initialize here if needed.
+	if configCopy.Params == nil {
+		configCopy.Params = make(map[string]*string)
+	}
+	configCopy.Params["client_session_keep_alive"] = &trueString
+	dsn, err := sf.DSN(&configCopy)
+	if err != nil {
+		panic(fmt.Errorf("building snowflake dsn: %w", err))
+	}
+
+	return dsn
+}
+
+func (c *config) privateKey() (*rsa.PrivateKey, error) {
+	if c.Credentials.AuthType == JWT {
+		// When providing the PEM file in a JSON file, newlines can't be specified unless
+		// escaped, so here we allow a escape hatch to parse these PEM files
+		var pkString = strings.ReplaceAll(c.Credentials.PrivateKey, "\\n", "\n")
+		var block, _ = pem.Decode([]byte(pkString))
+		if key, err := x509.ParsePKCS8PrivateKey(block.Bytes); err != nil {
+			return nil, fmt.Errorf("parsing private key: %w", err)
+		} else {
+			return key.(*rsa.PrivateKey), nil
+		}
+	}
+
+	return nil, fmt.Errorf("only supported with JWT authentication")
+}
+
+func (c *config) asSnowflakeConfig(tenant string) sf.Config {
+	var maxStatementCount string = "0"
+	var json string = "json"
+
+	var conf = sf.Config{
+		Account:     c.Account,
+		Host:        c.Host,
+		Database:    c.Database,
+		Schema:      c.Schema,
+		Warehouse:   c.Warehouse,
+		Role:        c.Role,
+		Application: fmt.Sprintf("%s_EstuaryFlow", tenant),
+		Params: map[string]*string{
+			// By default Snowflake expects the number of statements to be provided
+			// with every request. By setting this parameter to zero we are allowing a
+			// variable number of statements to be executed in a single request
+			"MULTI_STATEMENT_COUNT":  &maxStatementCount,
+			"GO_QUERY_RESULT_FORMAT": &json,
+		},
+	}
+
+	if c.Credentials.AuthType == UserPass {
+		conf.Authenticator = sf.AuthTypeSnowflake
+		conf.User = c.Credentials.User
+		conf.Password = c.Credentials.Password
+	} else if c.Credentials.AuthType == JWT {
+		conf.Authenticator = sf.AuthTypeJwt
+		// We run this as part of validate to ensure that there is no error, so
+		// this is not expected to error here
+		if key, err := c.privateKey(); err != nil {
+			panic(err)
+		} else {
+			conf.PrivateKey = key
+		}
+	} else {
+		conf.Authenticator = sf.AuthTypeSnowflake
+		conf.User = c.User
+		conf.Password = c.Password
+	}
+
+	return conf
+}
+
+var hostRe = regexp.MustCompile(`(?i)^.+.snowflakecomputing\.com$`)
+
+func validHost(h string) error {
+	hasProtocol := strings.Contains(h, "://")
+	missingDomain := !hostRe.MatchString(h)
+
+	if hasProtocol && missingDomain {
+		return fmt.Errorf("invalid host %q (must end in snowflakecomputing.com and not include a protocol)", h)
+	} else if hasProtocol {
+		return fmt.Errorf("invalid host %q (must not include a protocol)", h)
+	} else if missingDomain {
+		return fmt.Errorf("invalid host %q (must end in snowflakecomputing.com)", h)
+	}
+
+	return nil
+}
+
+func (c *config) Validate() error {
+	var requiredProperties = [][]string{
+		{"account", c.Account},
+		{"host", c.Host},
+		{"database", c.Database},
+		{"schema", c.Schema},
+	}
+	for _, req := range requiredProperties {
+		if req[1] == "" {
+			return fmt.Errorf("missing '%s'", req[0])
+		}
+	}
+
+	if _, err := m.ParseDelay(c.Advanced.UpdateDelay); err != nil {
+		return err
+	}
+
+	if c.Password != "" {
+		// If they have both old user and password and new ones, ask them to remove the old ones
+		if c.Credentials.AuthType != "" || c.Credentials.Password != "" {
+			return fmt.Errorf("User and password in the root config are deprecated, please omit them and use the `credentials` config object only.")
+		}
+
+		c.Credentials.AuthType = UserPass
+		c.Credentials.Password = c.Password
+	}
+
+	if err := c.Credentials.Validate(); err != nil {
+		return err
+	}
+
+	if _, err := c.privateKey(); err != nil {
+		return err
+	}
+
+	return validHost(c.Host)
+}
+
+const (
+	UserPass = "user_password" // username and password
+	JWT      = "jwt"           // JWT, needs a private key
+)
+
+type credentialConfig struct {
+	AuthType string `json:"auth_type"`
+
+	User string `json:"user"`
+
+	Password string `json:"password"`
+
+	PrivateKey string `json:"private_key"`
+}
+
+func (c *credentialConfig) Validate() error {
+	switch c.AuthType {
+	case UserPass:
+		return c.validateUserPassCreds()
+	case JWT:
+		return c.validateJWTCreds()
+	default:
+		return fmt.Errorf("invalid credentials auth type %q", c.AuthType)
+	}
+}
+
+func (c *credentialConfig) validateUserPassCreds() error {
+	if c.Password == "" {
+		return fmt.Errorf("missing password")
+	}
+
+	return nil
+}
+
+func (c *credentialConfig) validateJWTCreds() error {
+	if c.PrivateKey == "" {
+		return fmt.Errorf("missing private_key")
+	}
+
+	return nil
+}
+
+// JSONSchema allows for the schema to be (semi-)manually specified when used with the
+// github.com/invopop/jsonschema package in go-schema-gen, to fullfill the required schema shape for
+// our oauth
+func (credentialConfig) JSONSchema() *jsonschema.Schema {
+	uProps := orderedmap.New()
+	uProps.Set("auth_type", &jsonschema.Schema{
+		Type:    "string",
+		Default: UserPass,
+		Const:   UserPass,
+	})
+	uProps.Set("user", &jsonschema.Schema{
+		Title:       "User",
+		Description: "The Snowflake user login name",
+		Type:        "string",
+		Extras: map[string]interface{}{
+			"order": 1,
+		},
+	})
+	uProps.Set("password", &jsonschema.Schema{
+		Title:       "Password",
+		Description: "The password for the provided user",
+		Type:        "string",
+		Extras: map[string]interface{}{
+			"secret": true,
+			"order":  2,
+		},
+	})
+
+	jwtProps := orderedmap.New()
+	jwtProps.Set("auth_type", &jsonschema.Schema{
+		Type:    "string",
+		Default: JWT,
+		Const:   JWT,
+	})
+	jwtProps.Set("private_key", &jsonschema.Schema{
+		Title:       "Private Key",
+		Description: "Private Key to be used to sign the JWT token",
+		Type:        "string",
+		Extras: map[string]interface{}{
+			"secret":    true,
+			"multiline": true,
+			"order":     2,
+		},
+	})
+
+	return &jsonschema.Schema{
+		Title:       "Authentication",
+		Description: "Snowflake Credentials",
+		Default:     map[string]string{"auth_type": UserPass},
+		OneOf: []*jsonschema.Schema{
+			{
+				Title:      "User Password",
+				Required:   []string{"auth_type", "user", "password"},
+				Properties: uProps,
+			},
+			{
+				Title:      "Private Key (JWT)",
+				Required:   []string{"auth_type", "private_key"},
+				Properties: jwtProps,
+			},
+		},
+		Extras: map[string]interface{}{
+			"discriminator": map[string]string{"propertyName": "auth_type"},
+		},
+		Type: "object",
+	}
+}

--- a/materialize-snowflake/config.go
+++ b/materialize-snowflake/config.go
@@ -109,6 +109,7 @@ func (c *config) asSnowflakeConfig(tenant string) sf.Config {
 		} else {
 			conf.PrivateKey = key
 		}
+		conf.User = c.Credentials.User
 	} else {
 		conf.Authenticator = sf.AuthTypeSnowflake
 		conf.User = c.User
@@ -248,6 +249,14 @@ func (credentialConfig) JSONSchema() *jsonschema.Schema {
 		Type:    "string",
 		Default: JWT,
 		Const:   JWT,
+	})
+	jwtProps.Set("user", &jsonschema.Schema{
+		Title:       "User",
+		Description: "The Snowflake user login name",
+		Type:        "string",
+		Extras: map[string]interface{}{
+			"order": 1,
+		},
 	})
 	jwtProps.Set("private_key", &jsonschema.Schema{
 		Title:       "Private Key",

--- a/materialize-snowflake/pipe.go
+++ b/materialize-snowflake/pipe.go
@@ -1,0 +1,265 @@
+package main
+
+import (
+	"bytes"
+	"crypto/rsa"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/google/uuid"
+	log "github.com/sirupsen/logrus"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"text/template"
+	"time"
+)
+
+type PipeClient struct {
+	cfg             *config
+	base            string
+	token           string
+	httpClient      http.Client
+	insertFilesTpl  *template.Template
+	insertReportTpl *template.Template
+	account         string
+}
+
+func publicKeyFingerprint(publicKey *rsa.PublicKey) (string, error) {
+	der, err := x509.MarshalPKIXPublicKey(publicKey)
+	if err != nil {
+		return "", fmt.Errorf("marshalling public key: %w", err)
+	}
+	var hash = sha256.Sum256(der)
+	return fmt.Sprintf("SHA256:%s", base64.StdEncoding.EncodeToString(hash[:])), nil
+}
+
+func NewPipeClient(cfg *config, tenant string) (*PipeClient, error) {
+	httpClient := http.Client{}
+
+	var key, err = cfg.privateKey()
+	if err != nil {
+		return nil, err
+	}
+
+	var account = strings.ToUpper(cfg.Account)
+	var user = strings.ToUpper(cfg.User)
+	var qualifiedUser = fmt.Sprintf("%s.%s", account, user)
+
+	fingerprint, err := publicKeyFingerprint(key.Public().(*rsa.PublicKey))
+	if err != nil {
+		return nil, err
+	}
+
+	log.WithField("fingerprint", fingerprint).Warn("pipe client")
+
+	var claims = &jwt.RegisteredClaims{
+		IssuedAt: jwt.NewNumericDate(time.Now()),
+		// TODO: automatically refresh the JWT token
+		// JWT tokens for Snowflake can live up to an hour
+		ExpiresAt: jwt.NewNumericDate(time.Now().Add(59 * time.Minute)),
+		Issuer:    fmt.Sprintf("%s.%s", qualifiedUser, fingerprint),
+		Subject:   qualifiedUser,
+	}
+
+	var t = jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
+	jwtToken, err := t.SignedString(key)
+	if err != nil {
+		return nil, fmt.Errorf("signing key: %w", err)
+	}
+	log.WithField("token", jwtToken).Warn("pipe client")
+
+	var dsn = cfg.ToURI(tenant)
+	dsnURL, err := url.Parse(fmt.Sprintf("https://%s", dsn))
+	if err != nil {
+		return nil, fmt.Errorf("parsing snowflake dsn: %w", err)
+	}
+	log.WithField("dsn", dsn).WithField("dsnURL", dsnURL).Warn("pipe client")
+
+	var insertFilesTpl = template.Must(template.New("insertFiles").Parse(insertFilesRawTpl))
+	var insertReportTpl = template.Must(template.New("insertFiles").Parse(insertReportRawTpl))
+
+	return &PipeClient{
+		cfg:             cfg,
+		base:            dsnURL.Hostname(),
+		httpClient:      httpClient,
+		token:           jwtToken,
+		insertFilesTpl:  insertFilesTpl,
+		insertReportTpl: insertReportTpl,
+	}, nil
+}
+
+type insertFilesURLTemplate struct {
+	Base     string
+	PipeName string
+	// Used to track the request, we generate a random uuid for this
+	RequestId string
+}
+
+type insertFilesRequest struct {
+	Files []FileRequest `json:"files"`
+}
+
+type FileRequest struct {
+	Path string `json:"path"`
+	Size int    `json:"size"`
+}
+
+type InsertFilesResponse struct {
+	Status    string `json:"responseCode"`
+	RequestId string `json:"requestId"`
+}
+
+const insertFilesRawTpl = "https://{{ $.Base }}/v1/data/pipes/{{ $.PipeName }}/insertFiles?requestId={{ $.RequestId }}"
+const contentType = "application/json;charset=UTF-8"
+const userAgent = "Estuary Technologies Flow"
+
+// pipeName must be a fully-qualified name, e.g.: database.schema.pipe
+func (c *PipeClient) InsertFiles(pipeName string, files []FileRequest) (*InsertFilesResponse, error) {
+	var urlTemplate = insertFilesURLTemplate{
+		Base:      c.base,
+		PipeName:  strings.ToLower(pipeName),
+		RequestId: uuid.New().String(),
+	}
+
+	var reqBody = insertFilesRequest{
+		Files: files,
+	}
+
+	var w strings.Builder
+	c.insertFilesTpl.Execute(&w, urlTemplate)
+	var url = w.String()
+
+	reqBodyJson, err := json.Marshal(reqBody)
+	if err != nil {
+		return nil, fmt.Errorf("marshal insertFiles body: %w", err)
+	}
+
+	req, err := http.NewRequest("POST", url, bytes.NewReader(reqBodyJson))
+	if err != nil {
+		return nil, fmt.Errorf("creating insertFiles request: %w", err)
+	}
+
+	req.Header.Add("Authorization", fmt.Sprintf("BEARER %s", c.token))
+	req.Header.Add("Content-Type", contentType)
+	req.Header.Add("User-Agent", userAgent)
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("insertFiles request: %w", err)
+	}
+
+	var respBuf = new(strings.Builder)
+	_, err = io.Copy(respBuf, resp.Body)
+	resp.Body.Close()
+	if err != nil {
+		return nil, fmt.Errorf("reading response of insertFiles: %w", err)
+	}
+
+	log.WithFields(log.Fields{
+		"url":  url,
+		"body": string(reqBodyJson),
+		"resp": respBuf.String(),
+	}).Warn("pipe client")
+
+	if resp.StatusCode >= 400 {
+		return nil, fmt.Errorf("response error code %d, %s", resp.StatusCode, respBuf)
+	}
+
+	var response InsertFilesResponse
+	err = json.Unmarshal([]byte(respBuf.String()), &response)
+	if err != nil {
+		return nil, fmt.Errorf("parsing response of insertFiles failed: %w", err)
+	}
+
+	if response.Status != "SUCCESS" {
+		return nil, fmt.Errorf("response status %q", response.Status)
+	}
+
+	return &response, nil
+}
+
+const insertReportRawTpl = "https://{{ $.Base }}/v1/data/pipes/{{ $.PipeName }}/insertReport?requestId={{ $.RequestId }}&beginMark={{ $.BeginMark }}"
+
+type insertReportURLTemplate struct {
+	Base     string
+	PipeName string
+	// Used to track the request, we generate a random uuid for this
+	RequestId string
+
+	BeginMark string
+}
+
+type fileReport struct {
+	Path           string `json:"path"`
+	StageLocation  string `json:"stageLocation"`
+	FileSize       int    `json:"fileSize"`
+	TimeReceived   string `json:"timeReceived"`
+	LastInsertTime string `json:"lastInsertTime"`
+	RowsInserted   int    `json:"rowsInserted"`
+	RowsParsed     int    `json:"rowsParsed"`
+	ErrorsSeen     int    `json:"errorsSeen"`
+	ErrorLimit     int    `json:"errorLimit"`
+	Complete       bool   `json:"complete"`
+	Status         string `json:"status"`
+}
+
+type InsertReportResponse struct {
+	NextBeginMark string       `json:"nextBeginMark"`
+	Files         []fileReport `json:"files"`
+}
+
+func (c *PipeClient) InsertReport(pipeName string, beginMark string) (*InsertReportResponse, error) {
+	var urlTemplate = insertReportURLTemplate{
+		Base:      c.base,
+		PipeName:  strings.ToLower(pipeName),
+		RequestId: uuid.New().String(),
+		BeginMark: beginMark,
+	}
+
+	var w strings.Builder
+	c.insertReportTpl.Execute(&w, urlTemplate)
+	var url = w.String()
+
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("creating insertReport request: %w", err)
+	}
+
+	req.Header.Add("Authorization", fmt.Sprintf("BEARER %s", c.token))
+	req.Header.Add("Content-Type", contentType)
+	req.Header.Add("User-Agent", userAgent)
+
+	log.WithFields(log.Fields{
+		"url":     url,
+		"headers": req.Header,
+	}).Warn("pipe client")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("insertReport request: %w", err)
+	}
+
+	var respBuf = new(strings.Builder)
+	_, err = io.Copy(respBuf, resp.Body)
+	resp.Body.Close()
+	if err != nil {
+		return nil, fmt.Errorf("reading response of insertReport: %w", err)
+	}
+
+	if resp.StatusCode >= 400 {
+		return nil, fmt.Errorf("response error code %d, %s", resp.StatusCode, respBuf)
+	}
+
+	var response InsertReportResponse
+	err = json.Unmarshal([]byte(respBuf.String()), &response)
+	if err != nil {
+		return nil, fmt.Errorf("parsing response of insertReport failed: %w", err)
+	}
+
+	return &response, nil
+}

--- a/materialize-snowflake/pipe.go
+++ b/materialize-snowflake/pipe.go
@@ -55,8 +55,6 @@ func NewPipeClient(cfg *config, tenant string) (*PipeClient, error) {
 		return nil, err
 	}
 
-	log.WithField("fingerprint", fingerprint).Warn("pipe client")
-
 	var claims = &jwt.RegisteredClaims{
 		IssuedAt: jwt.NewNumericDate(time.Now()),
 		// TODO: automatically refresh the JWT token
@@ -71,14 +69,12 @@ func NewPipeClient(cfg *config, tenant string) (*PipeClient, error) {
 	if err != nil {
 		return nil, fmt.Errorf("signing key: %w", err)
 	}
-	log.WithField("token", jwtToken).Warn("pipe client")
 
 	var dsn = cfg.ToURI(tenant)
 	dsnURL, err := url.Parse(fmt.Sprintf("https://%s", dsn))
 	if err != nil {
 		return nil, fmt.Errorf("parsing snowflake dsn: %w", err)
 	}
-	log.WithField("dsn", dsn).WithField("dsnURL", dsnURL).Warn("pipe client")
 
 	var insertFilesTpl = template.Must(template.New("insertFiles").Parse(insertFilesRawTpl))
 	var insertReportTpl = template.Must(template.New("insertFiles").Parse(insertReportRawTpl))
@@ -164,7 +160,7 @@ func (c *PipeClient) InsertFiles(pipeName string, files []FileRequest) (*InsertF
 		"url":  url,
 		"body": string(reqBodyJson),
 		"resp": respBuf.String(),
-	}).Warn("pipe client")
+	}).Info("pipe client")
 
 	if resp.StatusCode >= 400 {
 		return nil, fmt.Errorf("response error code %d, %s", resp.StatusCode, respBuf)
@@ -265,7 +261,7 @@ func (c *PipeClient) InsertReport(pipeName string, beginMark string) (*InsertRep
 		"url":      url,
 		"headers":  req.Header,
 		"response": response,
-	}).Warn("insertReport")
+	}).Info("insertReport")
 
 	return &response, nil
 }

--- a/materialize-snowflake/pipe.go
+++ b/materialize-snowflake/pipe.go
@@ -195,17 +195,22 @@ type insertReportURLTemplate struct {
 }
 
 type fileReport struct {
-	Path           string `json:"path"`
-	StageLocation  string `json:"stageLocation"`
-	FileSize       int    `json:"fileSize"`
-	TimeReceived   string `json:"timeReceived"`
-	LastInsertTime string `json:"lastInsertTime"`
-	RowsInserted   int    `json:"rowsInserted"`
-	RowsParsed     int    `json:"rowsParsed"`
-	ErrorsSeen     int    `json:"errorsSeen"`
-	ErrorLimit     int    `json:"errorLimit"`
-	Complete       bool   `json:"complete"`
-	Status         string `json:"status"`
+	Path                   string `json:"path"`
+	StageLocation          string `json:"stageLocation"`
+	FileSize               int    `json:"fileSize"`
+	TimeReceived           string `json:"timeReceived"`
+	LastInsertTime         string `json:"lastInsertTime"`
+	RowsInserted           int    `json:"rowsInserted"`
+	RowsParsed             int    `json:"rowsParsed"`
+	ErrorsSeen             int    `json:"errorsSeen"`
+	ErrorLimit             int    `json:"errorLimit"`
+	FirstError             string `json:"firstError"`
+	FirstErrorLineNum      int    `json:"firstErrorLineNum"`
+	FirstErrorCharacterPos int    `json:"firstErrorCharacterPos"`
+	FirstErrorColumnName   int    `json:"firstErrorColumnName"`
+	SystemError            string `json:"systemError"`
+	Complete               bool   `json:"complete"`
+	Status                 string `json:"status"`
 }
 
 type InsertReportResponse struct {
@@ -234,11 +239,6 @@ func (c *PipeClient) InsertReport(pipeName string, beginMark string) (*InsertRep
 	req.Header.Add("Content-Type", contentType)
 	req.Header.Add("User-Agent", userAgent)
 
-	log.WithFields(log.Fields{
-		"url":     url,
-		"headers": req.Header,
-	}).Warn("pipe client")
-
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("insertReport request: %w", err)
@@ -260,6 +260,12 @@ func (c *PipeClient) InsertReport(pipeName string, beginMark string) (*InsertRep
 	if err != nil {
 		return nil, fmt.Errorf("parsing response of insertReport failed: %w", err)
 	}
+
+	log.WithFields(log.Fields{
+		"url":      url,
+		"headers":  req.Header,
+		"response": response,
+	}).Warn("insertReport")
 
 	return &response, nil
 }

--- a/materialize-snowflake/pipe.go
+++ b/materialize-snowflake/pipe.go
@@ -245,8 +245,12 @@ type fileReport struct {
 }
 
 type InsertReportResponse struct {
-	NextBeginMark string       `json:"nextBeginMark"`
-	Files         []fileReport `json:"files"`
+	// completeResult: false means there were events between the supplied beginMark
+	// and the first even that were missed.
+	// see https://docs.snowflake.com/user-guide/data-load-snowpipe-rest-apis
+	CompleteResult bool         `json:"completeResult"`
+	NextBeginMark  string       `json:"nextBeginMark"`
+	Files          []fileReport `json:"files"`
 }
 
 func (c *PipeClient) InsertReport(pipeName string, beginMark string) (*InsertReportResponse, error) {

--- a/materialize-snowflake/pipe.go
+++ b/materialize-snowflake/pipe.go
@@ -41,7 +41,7 @@ func publicKeyFingerprint(publicKey *rsa.PublicKey) (string, error) {
 func NewPipeClient(cfg *config, tenant string) (*PipeClient, error) {
 	httpClient := http.Client{}
 
-	var key, err = cfg.privateKey()
+	var key, err = cfg.Credentials.privateKey()
 	if err != nil {
 		return nil, err
 	}
@@ -261,7 +261,7 @@ func (c *PipeClient) InsertReport(pipeName string, beginMark string) (*InsertRep
 		"url":      url,
 		"headers":  req.Header,
 		"response": response,
-	}).Info("insertReport")
+	}).Debug("insertReport")
 
 	return &response, nil
 }

--- a/materialize-snowflake/pipe.go
+++ b/materialize-snowflake/pipe.go
@@ -77,7 +77,7 @@ func NewPipeClient(cfg *config, tenant string) (*PipeClient, error) {
 	}
 
 	var insertFilesTpl = template.Must(template.New("insertFiles").Parse(insertFilesRawTpl))
-	var insertReportTpl = template.Must(template.New("insertFiles").Parse(insertReportRawTpl))
+	var insertReportTpl = template.Must(template.New("insertReport").Parse(insertReportRawTpl))
 
 	return &PipeClient{
 		cfg:             cfg,
@@ -160,7 +160,7 @@ func (c *PipeClient) InsertFiles(pipeName string, files []FileRequest) (*InsertF
 		"url":  url,
 		"body": string(reqBodyJson),
 		"resp": respBuf.String(),
-	}).Info("pipe client")
+	}).Debug("pipe client")
 
 	if resp.StatusCode >= 400 {
 		return nil, fmt.Errorf("response error code %d, %s", resp.StatusCode, respBuf)
@@ -173,7 +173,7 @@ func (c *PipeClient) InsertFiles(pipeName string, files []FileRequest) (*InsertF
 	}
 
 	if response.Status != "SUCCESS" {
-		return nil, fmt.Errorf("response status %q", response.Status)
+		return nil, fmt.Errorf("response status %q, %s", response.Status, respBuf)
 	}
 
 	return &response, nil

--- a/materialize-snowflake/pipe.go
+++ b/materialize-snowflake/pipe.go
@@ -47,7 +47,7 @@ func NewPipeClient(cfg *config, tenant string) (*PipeClient, error) {
 	}
 
 	var account = strings.ToUpper(cfg.Account)
-	var user = strings.ToUpper(cfg.User)
+	var user = strings.ToUpper(cfg.Credentials.User)
 	var qualifiedUser = fmt.Sprintf("%s.%s", account, user)
 
 	fingerprint, err := publicKeyFingerprint(key.Public().(*rsa.PublicKey))

--- a/materialize-snowflake/pipe.go
+++ b/materialize-snowflake/pipe.go
@@ -201,7 +201,7 @@ func (c *PipeClient) InsertFiles(pipeName string, files []FileRequest) (*InsertF
 	}).Debug("pipe client")
 
 	if resp.StatusCode >= 400 {
-		return nil, fmt.Errorf("response error code %d, %s", resp.StatusCode, respBuf)
+		return nil, fmt.Errorf("response error code %d, %s", resp.StatusCode, respBuf.String())
 	}
 
 	var response InsertFilesResponse
@@ -210,7 +210,7 @@ func (c *PipeClient) InsertFiles(pipeName string, files []FileRequest) (*InsertF
 	}
 
 	if response.Status != "SUCCESS" {
-		return nil, fmt.Errorf("response status %q, %s", response.Status, respBuf)
+		return nil, fmt.Errorf("response status %q, %s", response.Status, respBuf.String())
 	}
 
 	return &response, nil

--- a/materialize-snowflake/pipe.go
+++ b/materialize-snowflake/pipe.go
@@ -8,15 +8,16 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"github.com/golang-jwt/jwt/v5"
-	"github.com/google/uuid"
-	log "github.com/sirupsen/logrus"
 	"io"
 	"net/http"
 	"net/url"
 	"strings"
 	"text/template"
 	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/google/uuid"
+	log "github.com/sirupsen/logrus"
 )
 
 type PipeClient struct {

--- a/materialize-snowflake/snowflake.go
+++ b/materialize-snowflake/snowflake.go
@@ -452,6 +452,7 @@ func (d *transactor) Store(it *m.StoreIterator) (m.StartCommitFunc, error) {
 			if err := d.store.conn.QueryRowContext(ctx, "SELECT CURRENT_TIMESTAMP()").Scan(&currentTime); err != nil {
 				return nil, fmt.Errorf("querying current timestamp: %w", err)
 			}
+			log.WithField("currentTime", currentTime).Info("got time")
 			d.cp[b.target.StateKey] = &checkpointItem{
 				Table:         b.target.Identifier,
 				StagedDir:     dir,
@@ -478,7 +479,6 @@ func (d *transactor) Store(it *m.StoreIterator) (m.StartCommitFunc, error) {
 		if err != nil {
 			return nil, m.FinishedOperation(fmt.Errorf("creating checkpoint json: %w", err))
 		}
-		log.WithField("checkpoint", string(checkpointJSON)).Info("emitting checkpoint")
 
 		return &pf.ConnectorState{UpdatedJson: checkpointJSON, MergePatch: true}, nil
 	}, nil
@@ -551,7 +551,7 @@ func (d *transactor) Acknowledge(ctx context.Context) (*pf.ConnectorState, error
 		}
 	}
 
-	var hasPipes = len(pipes) > 0
+	//var hasPipes = len(pipes) > 0
 
 	for stateKey, r := range results {
 		var item = d.cp[stateKey]
@@ -618,7 +618,7 @@ func (d *transactor) Acknowledge(ctx context.Context) (*pf.ConnectorState, error
 						"status":            status,
 						"firstErrorMessage": firstErrorMessage,
 						"pipeName":          pipeName,
-					}).Debug("snowpipe: copy history row")
+					}).Info("snowpipe: copy history row")
 
 					for _, recordFile := range record.files {
 						if recordFile.Path == fileName {
@@ -640,8 +640,11 @@ func (d *transactor) Acknowledge(ctx context.Context) (*pf.ConnectorState, error
 					return nil, fmt.Errorf("snowpipe: could not find reports of successful processing for all files of pipe %v", pipes[pipeName])
 				} else {
 					delete(pipes, pipeName)
+					continue
 				}
 			}
+
+			tries = 0
 
 			for _, reportFile := range report.Files {
 				for _, recordFile := range record.files {
@@ -664,7 +667,7 @@ func (d *transactor) Acknowledge(ctx context.Context) (*pf.ConnectorState, error
 			}
 		}
 
-		time.Sleep(20 * time.Second)
+		time.Sleep(6 * time.Second)
 	}
 
 	log.Info("store: finished committing changes")
@@ -687,9 +690,9 @@ func (d *transactor) Acknowledge(ctx context.Context) (*pf.ConnectorState, error
 		return nil, fmt.Errorf("creating checkpoint clearing json: %w", err)
 	}
 
-	if hasPipes {
+	/*if hasPipes {
 		return nil, fmt.Errorf("artificial error")
-	}
+	}*/
 
 	return &pf.ConnectorState{UpdatedJson: json.RawMessage(checkpointJSON), MergePatch: true}, nil
 }

--- a/materialize-snowflake/snowflake.go
+++ b/materialize-snowflake/snowflake.go
@@ -746,16 +746,6 @@ func (d *transactor) hasStateKey(stateKey string) bool {
 	return false
 }
 
-func (d *transactor) bindingByStateKey(stateKey string) *binding {
-	for _, b := range d.bindings {
-		if b.target.StateKey == stateKey {
-			return b
-		}
-	}
-
-	return nil
-}
-
 func (d *transactor) deleteFiles(ctx context.Context, files []string) {
 	for _, f := range files {
 		if _, err := d.store.conn.ExecContext(ctx, fmt.Sprintf("REMOVE %s", f)); err != nil {

--- a/materialize-snowflake/snowflake.go
+++ b/materialize-snowflake/snowflake.go
@@ -482,7 +482,7 @@ func (d *transactor) Acknowledge(ctx context.Context) (*pf.ConnectorState, error
 			var fileRequests = make([]FileRequest, len(item.PipeFiles))
 			for i, f := range item.PipeFiles {
 				fileRequests[i] = FileRequest{
-					Path: "/" + f.Path,
+					Path: f.Path,
 					Size: f.Size,
 				}
 			}

--- a/materialize-snowflake/snowflake.go
+++ b/materialize-snowflake/snowflake.go
@@ -490,11 +490,9 @@ type pipeRecord struct {
 
 // When a file has been successfully loaded, we remove it from the pipe record
 func (pipe *pipeRecord) fileLoaded(file string) {
-	log.WithField("file", file).Debug("file loaded")
 	for i, f := range pipe.files {
 		if f.Path == file {
 			pipe.files = append(pipe.files[:i], pipe.files[i+1:]...)
-			log.WithField("file", file).Debug("file loaded: removed from file list")
 			break
 		}
 	}

--- a/materialize-snowflake/snowflake.go
+++ b/materialize-snowflake/snowflake.go
@@ -601,8 +601,6 @@ func (d *transactor) Acknowledge(ctx context.Context) (*pf.ConnectorState, error
 		}
 	}
 
-	//var hasPipes = len(pipes) > 0
-
 	for stateKey, r := range results {
 		var item = d.cp[stateKey]
 		if _, err := r.RowsAffected(); err != nil {
@@ -734,10 +732,6 @@ func (d *transactor) Acknowledge(ctx context.Context) (*pf.ConnectorState, error
 	if err != nil {
 		return nil, fmt.Errorf("creating checkpoint clearing json: %w", err)
 	}
-
-	/*if hasPipes {
-		return nil, fmt.Errorf("artificial error")
-	}*/
 
 	return &pf.ConnectorState{UpdatedJson: json.RawMessage(checkpointJSON), MergePatch: true}, nil
 }

--- a/materialize-snowflake/snowflake.go
+++ b/materialize-snowflake/snowflake.go
@@ -138,6 +138,9 @@ type transactor struct {
 	bindings    []*binding
 	updateDelay time.Duration
 	cp          checkpoint
+
+	// map of pipe name to beginMarker
+	pipeMarkers map[string]string
 }
 
 func (t *transactor) AckDelay() time.Duration {
@@ -186,10 +189,11 @@ func newTransactor(
 	}
 
 	var d = &transactor{
-		cfg:        cfg,
-		templates:  renderTemplates(dialect),
-		db:         db,
-		pipeClient: pipeClient,
+		cfg:         cfg,
+		templates:   renderTemplates(dialect),
+		db:          db,
+		pipeClient:  pipeClient,
+		pipeMarkers: make(map[string]string),
 	}
 
 	if d.updateDelay, err = m.ParseDelay(cfg.Advanced.UpdateDelay); err != nil {
@@ -255,6 +259,7 @@ func (t *transactor) addBinding(ctx context.Context, target sql.Table) error {
 			return fmt.Errorf("pipeName template: %w", err)
 		} else {
 			d.pipeName = fmt.Sprintf("%s.%s.%s", t.cfg.Database, t.cfg.Schema, strings.ToUpper(strings.Trim(pipeName, "`")))
+			t.pipeMarkers[d.pipeName] = ""
 		}
 
 		if createPipe, err := sql.RenderTableTemplate(target, t.templates.pipeName); err != nil {
@@ -454,16 +459,21 @@ func (d *transactor) Store(it *m.StoreIterator) (m.StartCommitFunc, error) {
 	}, nil
 }
 
+type pipeRecord struct {
+	files []fileRecord
+}
+
 // Acknowledge merges data from temporary table to main table
 func (d *transactor) Acknowledge(ctx context.Context) (*pf.ConnectorState, error) {
-	var asyncCtx = sf.WithAsyncMode(ctx)
-	log.Info("store: starting committing changes")
-
 	// Run the queries using AsyncMode, which means that `ExecContext` will not block
 	// until the query is successful, rather we will store the results of these queries
 	// in a map so that we can then call `RowsAffected` on them, blocking until
 	// the queries are actually executed and done
+	var asyncCtx = sf.WithAsyncMode(ctx)
+	log.Info("store: starting committing changes")
+
 	var results = make(map[string]stdsql.Result)
+	var pipes = make(map[string]pipeRecord)
 	for stateKey, item := range d.cp {
 		// we skip queries that belong to tables which do not have a binding anymore
 		// since these tables might be deleted already
@@ -479,6 +489,7 @@ func (d *transactor) Acknowledge(ctx context.Context) (*pf.ConnectorState, error
 				results[stateKey] = result
 			}
 		} else if len(item.PipeFiles) > 0 {
+			log.WithField("table", item.Table).Info("store: starting pipe requests")
 			var fileRequests = make([]FileRequest, len(item.PipeFiles))
 			for i, f := range item.PipeFiles {
 				fileRequests[i] = FileRequest{
@@ -489,11 +500,13 @@ func (d *transactor) Acknowledge(ctx context.Context) (*pf.ConnectorState, error
 
 			if resp, err := d.pipeClient.InsertFiles(item.PipeName, fileRequests); err != nil {
 				return nil, fmt.Errorf("snowpipe insertFiles: %w", err)
-			} else if report, err := d.pipeClient.InsertReport(item.PipeName, ""); err != nil {
-				return nil, fmt.Errorf("snowpipe insertReports: %w", err)
 			} else {
 				// TODO: make me DEBUG
-				log.WithField("response", resp).Info(fmt.Sprintf("insertFiles sucesssful %+v", report))
+				log.WithField("response", resp).Info(fmt.Sprintf("insertFiles sucesssful"))
+			}
+
+			pipes[item.PipeName] = pipeRecord{
+				files: item.PipeFiles,
 			}
 		}
 	}
@@ -506,6 +519,32 @@ func (d *transactor) Acknowledge(ctx context.Context) (*pf.ConnectorState, error
 		log.WithField("table", item.Table).Info("store: finished query")
 
 		d.deleteFiles(ctx, []string{item.StagedDir})
+	}
+
+	// Keep asking for a report on the files that have been submitted for processing
+	// until they have all been successful, or an error has been thrown
+	for len(pipes) > 0 {
+		for pipeName, record := range pipes {
+			report, err := d.pipeClient.InsertReport(pipeName, d.pipeMarkers[pipeName])
+			if err != nil {
+				return nil, fmt.Errorf("snowpipe insertReports: %w", err)
+			}
+
+			for _, reportFile := range report.Files {
+				for _, recordFile := range record.files {
+					if reportFile.Path == recordFile.Path {
+						if reportFile.Status == "LOADED" {
+							d.pipeMarkers[pipeName] = report.NextBeginMark
+							delete(pipes, pipeName)
+						} else if reportFile.Status == "LOAD_FAILED" || reportFile.Status == "PARTIALLY_LOADED" {
+							return nil, fmt.Errorf("failed to load files in pipe %q: %s, %s", pipeName, reportFile.FirstError, reportFile.SystemError)
+						}
+					}
+				}
+			}
+		}
+
+		time.Sleep(5 * time.Second)
 	}
 
 	log.Info("store: finished committing changes")

--- a/materialize-snowflake/snowflake.go
+++ b/materialize-snowflake/snowflake.go
@@ -394,8 +394,6 @@ func (d *transactor) Store(it *m.StoreIterator) (m.StartCommitFunc, error) {
 					return nil, fmt.Errorf("createPipe template: %w", err)
 				} else if _, err := d.db.ExecContext(ctx, createPipe); err != nil {
 					return nil, fmt.Errorf("creating pipe for table %q: %w", b.target.Path, err)
-				} else {
-					log.WithField("q", createPipe).Info("creating pipe")
 				}
 			}
 		}
@@ -619,15 +617,22 @@ func (d *transactor) Acknowledge(ctx context.Context) (*pf.ConnectorState, error
 						"pipeName":          pipeName,
 					}).Info("snowpipe: copy history row")
 
+					var loadedFiles []string
 					for _, recordFile := range record.files {
 						if recordFile.Path == fileName {
 							if status == "Loaded" {
-								pipes[pipeName].fileLoaded(fileName)
+								loadedFiles = append(loadedFiles, fileName)
 								d.deleteFiles(ctx, []string{record.dir})
+							} else if status == "Load in progress" {
+								tries = 0
 							} else {
 								return nil, fmt.Errorf("unexpected status %q for files in pipe %q: %s", status, pipeName, firstErrorMessage)
 							}
 						}
+					}
+
+					for _, fileName := range loadedFiles {
+						pipes[pipeName].fileLoaded(fileName)
 					}
 				}
 
@@ -645,12 +650,13 @@ func (d *transactor) Acknowledge(ctx context.Context) (*pf.ConnectorState, error
 
 			tries = 0
 
+			var loadedFiles []string
 			for _, reportFile := range report.Files {
 				for _, recordFile := range record.files {
 					if reportFile.Path == recordFile.Path {
 						if reportFile.Status == "LOADED" {
 							d.pipeMarkers[pipeName] = report.NextBeginMark
-							pipes[pipeName].fileLoaded(recordFile.Path)
+							loadedFiles = append(loadedFiles, recordFile.Path)
 							d.deleteFiles(ctx, []string{record.dir})
 						} else if reportFile.Status == "LOAD_FAILED" || reportFile.Status == "PARTIALLY_LOADED" {
 							return nil, fmt.Errorf("failed to load files in pipe %q: %s, %s", pipeName, reportFile.FirstError, reportFile.SystemError)
@@ -659,6 +665,10 @@ func (d *transactor) Acknowledge(ctx context.Context) (*pf.ConnectorState, error
 						}
 					}
 				}
+			}
+
+			for _, fileName := range loadedFiles {
+				pipes[pipeName].fileLoaded(fileName)
 			}
 
 			if len(pipes[pipeName].files) == 0 {

--- a/materialize-snowflake/snowflake.go
+++ b/materialize-snowflake/snowflake.go
@@ -490,9 +490,11 @@ type pipeRecord struct {
 
 // When a file has been successfully loaded, we remove it from the pipe record
 func (pipe *pipeRecord) fileLoaded(file string) {
+	log.WithField("file", file).Debug("file loaded")
 	for i, f := range pipe.files {
 		if f.Path == file {
 			pipe.files = append(pipe.files[:i], pipe.files[i+1:]...)
+			log.WithField("file", file).Debug("file loaded: removed from file list")
 			break
 		}
 	}
@@ -571,6 +573,8 @@ func (d *transactor) Acknowledge(ctx context.Context) (*pf.ConnectorState, error
 				return nil, fmt.Errorf("snowpipe: insertReports: %w", err)
 			}
 
+			var hasItemsInProgress = false
+
 			// If the files have already been loaded, when we submit a request to
 			// load those files again, our request will not show up in reports.
 			// One way to find out whether the files were successfully loaded is to check
@@ -605,6 +609,8 @@ func (d *transactor) Acknowledge(ctx context.Context) (*pf.ConnectorState, error
 					status            string
 					firstErrorMessage *string
 				)
+
+				var loadedFiles []string
 				for rows.Next() {
 					if err := rows.Scan(&fileName, &status, &firstErrorMessage); err != nil {
 						return nil, fmt.Errorf("scanning copy history row: %w", err)
@@ -617,32 +623,27 @@ func (d *transactor) Acknowledge(ctx context.Context) (*pf.ConnectorState, error
 						"pipeName":          pipeName,
 					}).Info("snowpipe: copy history row")
 
-					var loadedFiles []string
-					for _, pipeFile := range pipe.files {
-						if pipeFile.Path == fileName {
-							if status == "Loaded" {
-								loadedFiles = append(loadedFiles, fileName)
-							} else if status == "Load in progress" {
-								tries = 0
-							} else {
-								return nil, fmt.Errorf("unexpected status %q for files in pipe %q: %s", status, pipeName, firstErrorMessage)
-							}
-						}
+					if status == "Loaded" {
+						loadedFiles = append(loadedFiles, fileName)
+					} else if status == "Load in progress" {
+						hasItemsInProgress = true
+					} else {
+						return nil, fmt.Errorf("unexpected status %q for files in pipe %q: %s", status, pipeName, firstErrorMessage)
 					}
+				}
 
-					for _, fileName := range loadedFiles {
-						pipes[pipeName].fileLoaded(fileName)
-						d.deleteFiles(ctx, []string{fileName})
-					}
+				for _, fileName := range loadedFiles {
+					pipe.fileLoaded(fileName)
 				}
 
 				if err := rows.Err(); err != nil {
 					return nil, fmt.Errorf("snowpipe: reading copy history: %w", err)
 				}
 
-				if len(pipes[pipeName].files) > 0 {
-					return nil, fmt.Errorf("snowpipe: could not find reports of successful processing for all files of pipe %v", pipes[pipeName])
+				if len(pipe.files) > 0 && !hasItemsInProgress {
+					return nil, fmt.Errorf("snowpipe: could not find reports of successful processing for all files of pipe %v", pipe)
 				} else {
+					d.deleteFiles(ctx, []string{pipe.dir})
 					delete(pipes, pipeName)
 					continue
 				}
@@ -652,26 +653,22 @@ func (d *transactor) Acknowledge(ctx context.Context) (*pf.ConnectorState, error
 
 			var loadedFiles []string
 			for _, reportFile := range report.Files {
-				for _, pipeFile := range pipe.files {
-					if reportFile.Path == pipeFile.Path {
-						if reportFile.Status == "LOADED" {
-							d.pipeMarkers[pipeName] = report.NextBeginMark
-							loadedFiles = append(loadedFiles, pipeFile.Path)
-						} else if reportFile.Status == "LOAD_FAILED" || reportFile.Status == "PARTIALLY_LOADED" {
-							return nil, fmt.Errorf("failed to load files in pipe %q: %s, %s", pipeName, reportFile.FirstError, reportFile.SystemError)
-						} else if reportFile.Status == "LOAD_IN_PROGRESS" {
-							continue
-						}
-					}
+				if reportFile.Status == "LOADED" {
+					d.pipeMarkers[pipeName] = report.NextBeginMark
+					loadedFiles = append(loadedFiles, reportFile.Path)
+				} else if reportFile.Status == "LOAD_FAILED" || reportFile.Status == "PARTIALLY_LOADED" {
+					return nil, fmt.Errorf("failed to load files in pipe %q: %s, %s", pipeName, reportFile.FirstError, reportFile.SystemError)
+				} else if reportFile.Status == "LOAD_IN_PROGRESS" {
+					continue
 				}
 			}
 
 			for _, fileName := range loadedFiles {
-				pipes[pipeName].fileLoaded(fileName)
-				d.deleteFiles(ctx, []string{fileName})
+				pipe.fileLoaded(fileName)
 			}
 
-			if len(pipes[pipeName].files) == 0 {
+			if len(pipe.files) == 0 {
+				d.deleteFiles(ctx, []string{pipe.dir})
 				delete(pipes, pipeName)
 			}
 		}
@@ -728,7 +725,7 @@ func (d *transactor) bindingByStateKey(stateKey string) *binding {
 
 func (d *transactor) deleteFiles(ctx context.Context, files []string) {
 	for _, f := range files {
-		if _, err := d.store.conn.ExecContext(ctx, fmt.Sprintf("REMOVE '%s'", f)); err != nil {
+		if _, err := d.store.conn.ExecContext(ctx, fmt.Sprintf("REMOVE %s", f)); err != nil {
 			log.WithFields(log.Fields{
 				"file": f,
 				"err":  err,

--- a/materialize-snowflake/snowflake.go
+++ b/materialize-snowflake/snowflake.go
@@ -125,6 +125,14 @@ type transactor struct {
 	cfg        *config
 	db         *stdsql.DB
 	pipeClient *PipeClient
+
+	// We initialise pipes (with a create or replace query) on the first Store
+	// to ensure that queries running as part of the first recovery Acknowledge
+	// do not create duplicates. Queries running on a pipe or idempotent so long
+	// as the pipe is not removed or replaced. The replace clause of the query
+	// will wipe the history of the pipe and so lead to duplicate documents
+	pipesInit bool
+
 	// Variables exclusively used by Load.
 	load struct {
 		conn *stdsql.Conn
@@ -252,25 +260,6 @@ func (t *transactor) addBinding(ctx context.Context, target sql.Table) error {
 	d.load.stage = newStagedFile(os.TempDir())
 	d.store.stage = newStagedFile(os.TempDir())
 
-	// If this is a delta updates binding and we are using JWT auth type, this binding
-	// can use snowpipe
-	if target.DeltaUpdates && t.cfg.Credentials.AuthType == JWT {
-		if pipeName, err := sql.RenderTableTemplate(target, t.templates.pipeName); err != nil {
-			return fmt.Errorf("pipeName template: %w", err)
-		} else {
-			d.pipeName = fmt.Sprintf("%s.%s.%s", t.cfg.Database, t.cfg.Schema, strings.ToUpper(strings.Trim(pipeName, "`")))
-			t.pipeMarkers[d.pipeName] = ""
-		}
-
-		if createPipe, err := sql.RenderTableTemplate(target, t.templates.pipeName); err != nil {
-			return fmt.Errorf("createPipe template: %w", err)
-		} else if _, err := t.db.ExecContext(ctx, createPipe); err != nil {
-			return fmt.Errorf("creating pipe for table %q: %w", target.Path, err)
-		} else {
-			log.WithField("q", createPipe).Info("creating pipe")
-		}
-	}
-
 	t.bindings = append(t.bindings, d)
 	return nil
 }
@@ -385,6 +374,32 @@ type checkpointItem struct {
 type checkpoint = map[string]*checkpointItem
 
 func (d *transactor) Store(it *m.StoreIterator) (m.StartCommitFunc, error) {
+	if !d.pipesInit {
+		log.Info("store: initialising pipes")
+		for _, b := range d.bindings {
+			// If this is a delta updates binding and we are using JWT auth type, this binding
+			// can use snowpipe
+			if b.target.DeltaUpdates && d.cfg.Credentials.AuthType == JWT {
+				if pipeName, err := sql.RenderTableTemplate(b.target, d.templates.pipeName); err != nil {
+					return nil, fmt.Errorf("pipeName template: %w", err)
+				} else {
+					b.pipeName = fmt.Sprintf("%s.%s.%s", d.cfg.Database, d.cfg.Schema, strings.ToUpper(strings.Trim(pipeName, "`")))
+					d.pipeMarkers[b.pipeName] = ""
+				}
+
+				if createPipe, err := sql.RenderTableTemplate(b.target, d.templates.createPipe); err != nil {
+					return nil, fmt.Errorf("createPipe template: %w", err)
+				} else if _, err := d.db.ExecContext(it.Context(), createPipe); err != nil {
+					return nil, fmt.Errorf("creating pipe for table %q: %w", b.target.Path, err)
+				} else {
+					log.WithField("q", createPipe).Info("creating pipe")
+				}
+			}
+		}
+
+		d.pipesInit = true
+	}
+
 	log.Info("store: starting encoding and uploading of files")
 	for it.Next() {
 		var b = d.bindings[it.Binding]
@@ -461,6 +476,7 @@ func (d *transactor) Store(it *m.StoreIterator) (m.StartCommitFunc, error) {
 
 type pipeRecord struct {
 	files []fileRecord
+	dir   string
 }
 
 // Acknowledge merges data from temporary table to main table
@@ -507,9 +523,12 @@ func (d *transactor) Acknowledge(ctx context.Context) (*pf.ConnectorState, error
 
 			pipes[item.PipeName] = pipeRecord{
 				files: item.PipeFiles,
+				dir:   item.StagedDir,
 			}
 		}
 	}
+
+	var hasPipes = len(pipes) > 0
 
 	for stateKey, r := range results {
 		var item = d.cp[stateKey]
@@ -523,11 +542,28 @@ func (d *transactor) Acknowledge(ctx context.Context) (*pf.ConnectorState, error
 
 	// Keep asking for a report on the files that have been submitted for processing
 	// until they have all been successful, or an error has been thrown
+	var tries = 0
+	var maxTries = 5
 	for len(pipes) > 0 {
 		for pipeName, record := range pipes {
 			report, err := d.pipeClient.InsertReport(pipeName, d.pipeMarkers[pipeName])
 			if err != nil {
 				return nil, fmt.Errorf("snowpipe insertReports: %w", err)
+			}
+
+			// If the files have already been loaded, when we submit a request to
+			// load those files again, our request will not show up in reports.
+			// One way to find out whether the files were successfully loaded is to check
+			// the COPY_HISTORY to make sure they are there. If they are not, then something
+			// may be wrong.
+			if len(report.Files) == 0 {
+				if tries >= maxTries {
+          var rows, err := d.store.conn.QueryContext(ctx, "SELECT * FROM TABLE(information_schema.copy_history(TABLE_NAME=>"
+					return nil, fmt.Errorf("could not get a report on the snowpipe request, restarting to try again.")
+				}
+				tries = tries + 1
+
+				continue
 			}
 
 			for _, reportFile := range report.Files {
@@ -536,6 +572,7 @@ func (d *transactor) Acknowledge(ctx context.Context) (*pf.ConnectorState, error
 						if reportFile.Status == "LOADED" {
 							d.pipeMarkers[pipeName] = report.NextBeginMark
 							delete(pipes, pipeName)
+							d.deleteFiles(ctx, []string{record.dir})
 						} else if reportFile.Status == "LOAD_FAILED" || reportFile.Status == "PARTIALLY_LOADED" {
 							return nil, fmt.Errorf("failed to load files in pipe %q: %s, %s", pipeName, reportFile.FirstError, reportFile.SystemError)
 						}
@@ -565,6 +602,10 @@ func (d *transactor) Acknowledge(ctx context.Context) (*pf.ConnectorState, error
 	var checkpointJSON, err = json.Marshal(checkpointClear)
 	if err != nil {
 		return nil, fmt.Errorf("creating checkpoint clearing json: %w", err)
+	}
+
+	if hasPipes {
+		return nil, fmt.Errorf("artificial error")
 	}
 
 	return &pf.ConnectorState{UpdatedJson: json.RawMessage(checkpointJSON), MergePatch: true}, nil

--- a/materialize-snowflake/snowflake.go
+++ b/materialize-snowflake/snowflake.go
@@ -292,7 +292,7 @@ func (d *transactor) Load(it *m.LoadIterator, loaded func(int, json.RawMessage) 
 			// Pass.
 		} else if dir, err := b.load.stage.flush(); err != nil {
 			return fmt.Errorf("load.stage(): %w", err)
-		} else if subqueries[i], err = RenderTableAndFileTemplate(tableAndFile{Table: b.target, File: dir}, d.templates.loadQuery); err != nil {
+		} else if subqueries[i], err = RenderTableAndFileTemplate(b.target, dir, d.templates.loadQuery); err != nil {
 			return fmt.Errorf("loadQuery template: %w", err)
 		} else {
 			toDelete = append(toDelete, dir)
@@ -364,16 +364,19 @@ func (d *transactor) Load(it *m.LoadIterator, loaded func(int, json.RawMessage) 
 }
 
 type checkpointItem struct {
-	Table     string
-	Query     string
-	StagedDir string
-	PipeName  string
-	PipeFiles []fileRecord
+	Table         string
+	Query         string
+	StagedDir     string
+	PipeName      string
+	PipeFiles     []fileRecord
+	PipeStartTime string
 }
 
 type checkpoint = map[string]*checkpointItem
 
 func (d *transactor) Store(it *m.StoreIterator) (m.StartCommitFunc, error) {
+	var ctx = it.Context()
+
 	if !d.pipesInit {
 		log.Info("store: initialising pipes")
 		for _, b := range d.bindings {
@@ -389,7 +392,7 @@ func (d *transactor) Store(it *m.StoreIterator) (m.StartCommitFunc, error) {
 
 				if createPipe, err := sql.RenderTableTemplate(b.target, d.templates.createPipe); err != nil {
 					return nil, fmt.Errorf("createPipe template: %w", err)
-				} else if _, err := d.db.ExecContext(it.Context(), createPipe); err != nil {
+				} else if _, err := d.db.ExecContext(ctx, createPipe); err != nil {
 					return nil, fmt.Errorf("creating pipe for table %q: %w", b.target.Path, err)
 				} else {
 					log.WithField("q", createPipe).Info("creating pipe")
@@ -408,7 +411,7 @@ func (d *transactor) Store(it *m.StoreIterator) (m.StartCommitFunc, error) {
 			b.store.mustMerge = true
 		}
 
-		if err := b.store.stage.start(it.Context(), d.db); err != nil {
+		if err := b.store.stage.start(ctx, d.db); err != nil {
 			return nil, err
 		} else if converted, err := b.target.ConvertAll(it.Key, it.Values, it.RawJSON); err != nil {
 			return nil, fmt.Errorf("converting Store: %w", err)
@@ -435,7 +438,7 @@ func (d *transactor) Store(it *m.StoreIterator) (m.StartCommitFunc, error) {
 		}
 
 		if b.store.mustMerge {
-			if mergeIntoQuery, err := RenderTableAndFileTemplate(tableAndFile{Table: b.target, File: dir}, d.templates.mergeInto); err != nil {
+			if mergeIntoQuery, err := RenderTableAndFileTemplate(b.target, dir, d.templates.mergeInto); err != nil {
 				return nil, fmt.Errorf("mergeInto template: %w", err)
 			} else {
 				d.cp[b.target.StateKey] = &checkpointItem{
@@ -445,14 +448,20 @@ func (d *transactor) Store(it *m.StoreIterator) (m.StartCommitFunc, error) {
 				}
 			}
 		} else if b.pipeName != "" {
-			d.cp[b.target.StateKey] = &checkpointItem{
-				Table:     b.target.Identifier,
-				StagedDir: dir,
-				PipeFiles: b.store.stage.uploaded,
-				PipeName:  b.pipeName,
+			var currentTime string
+			if err := d.store.conn.QueryRowContext(ctx, "SELECT CURRENT_TIMESTAMP()").Scan(&currentTime); err != nil {
+				return nil, fmt.Errorf("querying current timestamp: %w", err)
 			}
+			d.cp[b.target.StateKey] = &checkpointItem{
+				Table:         b.target.Identifier,
+				StagedDir:     dir,
+				PipeFiles:     b.store.stage.uploaded,
+				PipeName:      b.pipeName,
+				PipeStartTime: currentTime,
+			}
+
 		} else {
-			if copyIntoQuery, err := RenderTableAndFileTemplate(tableAndFile{Table: b.target, File: dir}, d.templates.copyInto); err != nil {
+			if copyIntoQuery, err := RenderTableAndFileTemplate(b.target, dir, d.templates.copyInto); err != nil {
 				return nil, fmt.Errorf("copyInto template: %w", err)
 			} else {
 				d.cp[b.target.StateKey] = &checkpointItem{
@@ -469,14 +478,27 @@ func (d *transactor) Store(it *m.StoreIterator) (m.StartCommitFunc, error) {
 		if err != nil {
 			return nil, m.FinishedOperation(fmt.Errorf("creating checkpoint json: %w", err))
 		}
+		log.WithField("checkpoint", string(checkpointJSON)).Info("emitting checkpoint")
 
 		return &pf.ConnectorState{UpdatedJson: checkpointJSON, MergePatch: true}, nil
 	}, nil
 }
 
 type pipeRecord struct {
-	files []fileRecord
-	dir   string
+	files     []fileRecord
+	dir       string
+	binding   *binding
+	startTime string
+}
+
+// When a file has been successfully loaded, we remove it from the pipe record
+func (record *pipeRecord) fileLoaded(file string) {
+	for i, f := range record.files {
+		if f.Path == file {
+			record.files = append(record.files[:i], record.files[i+1:]...)
+			break
+		}
+	}
 }
 
 // Acknowledge merges data from temporary table to main table
@@ -489,7 +511,7 @@ func (d *transactor) Acknowledge(ctx context.Context) (*pf.ConnectorState, error
 	log.Info("store: starting committing changes")
 
 	var results = make(map[string]stdsql.Result)
-	var pipes = make(map[string]pipeRecord)
+	var pipes = make(map[string]*pipeRecord)
 	for stateKey, item := range d.cp {
 		// we skip queries that belong to tables which do not have a binding anymore
 		// since these tables might be deleted already
@@ -517,13 +539,14 @@ func (d *transactor) Acknowledge(ctx context.Context) (*pf.ConnectorState, error
 			if resp, err := d.pipeClient.InsertFiles(item.PipeName, fileRequests); err != nil {
 				return nil, fmt.Errorf("snowpipe insertFiles: %w", err)
 			} else {
-				// TODO: make me DEBUG
-				log.WithField("response", resp).Info(fmt.Sprintf("insertFiles sucesssful"))
+				log.WithField("response", resp).Debug(fmt.Sprintf("insertFiles sucesssful"))
 			}
 
-			pipes[item.PipeName] = pipeRecord{
-				files: item.PipeFiles,
-				dir:   item.StagedDir,
+			pipes[item.PipeName] = &pipeRecord{
+				files:     item.PipeFiles,
+				dir:       item.StagedDir,
+				binding:   d.bindingByStateKey(stateKey),
+				startTime: item.PipeStartTime,
 			}
 		}
 	}
@@ -543,12 +566,12 @@ func (d *transactor) Acknowledge(ctx context.Context) (*pf.ConnectorState, error
 	// Keep asking for a report on the files that have been submitted for processing
 	// until they have all been successful, or an error has been thrown
 	var tries = 0
-	var maxTries = 5
+	var maxTries = 10
 	for len(pipes) > 0 {
 		for pipeName, record := range pipes {
 			report, err := d.pipeClient.InsertReport(pipeName, d.pipeMarkers[pipeName])
 			if err != nil {
-				return nil, fmt.Errorf("snowpipe insertReports: %w", err)
+				return nil, fmt.Errorf("snowpipe: insertReports: %w", err)
 			}
 
 			// If the files have already been loaded, when we submit a request to
@@ -557,13 +580,67 @@ func (d *transactor) Acknowledge(ctx context.Context) (*pf.ConnectorState, error
 			// the COPY_HISTORY to make sure they are there. If they are not, then something
 			// may be wrong.
 			if len(report.Files) == 0 {
-				if tries >= maxTries {
-          var rows, err := d.store.conn.QueryContext(ctx, "SELECT * FROM TABLE(information_schema.copy_history(TABLE_NAME=>"
-					return nil, fmt.Errorf("could not get a report on the snowpipe request, restarting to try again.")
+				if tries < maxTries {
+					tries = tries + 1
+					continue
 				}
-				tries = tries + 1
 
-				continue
+				log.WithField("tries", tries).Info("snowpipe: no files in report, fetching copy history from warehouse")
+
+				var fileNames = make([]string, len(record.files))
+				for i, f := range record.files {
+					fileNames[i] = f.Path
+				}
+
+				query, err := RenderCopyHistoryTemplate(record.binding.target, fileNames, record.startTime, d.templates.copyHistory)
+				if err != nil {
+					return nil, fmt.Errorf("snowpipe: rendering copy history: %w", err)
+				}
+
+				rows, err := d.store.conn.QueryContext(ctx, query)
+				if err != nil {
+					return nil, fmt.Errorf("snowpipe: fetching copy history: %w", err)
+				}
+				defer rows.Close()
+
+				var (
+					fileName          string
+					status            string
+					firstErrorMessage *string
+				)
+				for rows.Next() {
+					if err := rows.Scan(&fileName, &status, &firstErrorMessage); err != nil {
+						return nil, fmt.Errorf("scanning copy history row: %w", err)
+					}
+
+					log.WithFields(log.Fields{
+						"fileName":          fileName,
+						"status":            status,
+						"firstErrorMessage": firstErrorMessage,
+						"pipeName":          pipeName,
+					}).Debug("snowpipe: copy history row")
+
+					for _, recordFile := range record.files {
+						if recordFile.Path == fileName {
+							if status == "Loaded" {
+								pipes[pipeName].fileLoaded(fileName)
+								d.deleteFiles(ctx, []string{record.dir})
+							} else {
+								return nil, fmt.Errorf("unexpected status %q for files in pipe %q: %s", status, pipeName, firstErrorMessage)
+							}
+						}
+					}
+				}
+
+				if err := rows.Err(); err != nil {
+					return nil, fmt.Errorf("snowpipe: reading copy history: %w", err)
+				}
+
+				if len(pipes[pipeName].files) > 0 {
+					return nil, fmt.Errorf("snowpipe: could not find reports of successful processing for all files of pipe %v", pipes[pipeName])
+				} else {
+					delete(pipes, pipeName)
+				}
 			}
 
 			for _, reportFile := range report.Files {
@@ -571,17 +648,23 @@ func (d *transactor) Acknowledge(ctx context.Context) (*pf.ConnectorState, error
 					if reportFile.Path == recordFile.Path {
 						if reportFile.Status == "LOADED" {
 							d.pipeMarkers[pipeName] = report.NextBeginMark
-							delete(pipes, pipeName)
+							pipes[pipeName].fileLoaded(recordFile.Path)
 							d.deleteFiles(ctx, []string{record.dir})
 						} else if reportFile.Status == "LOAD_FAILED" || reportFile.Status == "PARTIALLY_LOADED" {
 							return nil, fmt.Errorf("failed to load files in pipe %q: %s, %s", pipeName, reportFile.FirstError, reportFile.SystemError)
+						} else if reportFile.Status == "LOAD_IN_PROGRESS" {
+							continue
 						}
 					}
 				}
 			}
+
+			if len(pipes[pipeName].files) == 0 {
+				delete(pipes, pipeName)
+			}
 		}
 
-		time.Sleep(5 * time.Second)
+		time.Sleep(20 * time.Second)
 	}
 
 	log.Info("store: finished committing changes")
@@ -619,6 +702,16 @@ func (d *transactor) hasStateKey(stateKey string) bool {
 	}
 
 	return false
+}
+
+func (d *transactor) bindingByStateKey(stateKey string) *binding {
+	for _, b := range d.bindings {
+		if b.target.StateKey == stateKey {
+			return b
+		}
+	}
+
+	return nil
 }
 
 func (d *transactor) deleteFiles(ctx context.Context, files []string) {

--- a/materialize-snowflake/snowflake.go
+++ b/materialize-snowflake/snowflake.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"regexp"
 	"strings"
 	"sync"
 	"time"
@@ -22,107 +21,6 @@ import (
 	"go.gazette.dev/core/consumer/protocol"
 	"golang.org/x/sync/errgroup"
 )
-
-// config represents the endpoint configuration for snowflake.
-// It must match the one defined for the source specs (flow.yaml) in Rust.
-type config struct {
-	Host      string `json:"host" jsonschema:"title=Host URL,description=The Snowflake Host used for the connection. Must include the account identifier and end in .snowflakecomputing.com. Example: orgname-accountname.snowflakecomputing.com (do not include the protocol)." jsonschema_extras:"order=0,pattern=^[^/:]+.snowflakecomputing.com$"`
-	Account   string `json:"account" jsonschema:"title=Account,description=The Snowflake account identifier." jsonschema_extras:"order=1"`
-	User      string `json:"user" jsonschema:"title=User,description=The Snowflake user login name." jsonschema_extras:"order=2"`
-	Password  string `json:"password" jsonschema:"title=Password,description=The password for the provided user." jsonschema_extras:"secret=true,order=3"`
-	Database  string `json:"database" jsonschema:"title=Database,description=The SQL database to connect to." jsonschema_extras:"order=4"`
-	Schema    string `json:"schema" jsonschema:"title=Schema,description=Database schema for bound collection tables (unless overridden within the binding resource configuration) as well as associated materialization metadata tables." jsonschema_extras:"order=5"`
-	Warehouse string `json:"warehouse,omitempty" jsonschema:"title=Warehouse,description=The Snowflake virtual warehouse used to execute queries. Uses the default warehouse for the Snowflake user if left blank." jsonschema_extras:"order=6"`
-	Role      string `json:"role,omitempty" jsonschema:"title=Role,description=The user role used to perform actions." jsonschema_extras:"order=7"`
-
-	Advanced advancedConfig `json:"advanced,omitempty" jsonschema:"title=Advanced Options,description=Options for advanced users. You should not typically need to modify these." jsonschema_extras:"advanced=true"`
-}
-
-type advancedConfig struct {
-	UpdateDelay string `json:"updateDelay,omitempty" jsonschema:"title=Update Delay,description=Potentially reduce active warehouse time by increasing the delay between updates. Defaults to 30 minutes if unset.,enum=0s,enum=15m,enum=30m,enum=1h,enum=2h,enum=4h"`
-}
-
-// ToURI converts the Config to a DSN string.
-func (c *config) ToURI(tenant string) string {
-	// Build a DSN connection string.
-	var configCopy = c.asSnowflakeConfig(tenant)
-	// client_session_keep_alive causes the driver to issue a periodic keepalive request.
-	// Without this, the authentication token will expire after 4 hours of inactivity.
-	// The Params map will not have been initialized if the endpoint config didn't specify
-	// it, so we check and initialize here if needed.
-	if configCopy.Params == nil {
-		configCopy.Params = make(map[string]*string)
-	}
-	configCopy.Params["client_session_keep_alive"] = &trueString
-	dsn, err := sf.DSN(&configCopy)
-	if err != nil {
-		panic(fmt.Errorf("building snowflake dsn: %w", err))
-	}
-
-	return dsn
-}
-
-func (c *config) asSnowflakeConfig(tenant string) sf.Config {
-	var maxStatementCount string = "0"
-	var json string = "json"
-	return sf.Config{
-		Account:     c.Account,
-		Host:        c.Host,
-		User:        c.User,
-		Password:    c.Password,
-		Database:    c.Database,
-		Schema:      c.Schema,
-		Warehouse:   c.Warehouse,
-		Role:        c.Role,
-		Application: fmt.Sprintf("%s_EstuaryFlow", tenant),
-		Params: map[string]*string{
-			// By default Snowflake expects the number of statements to be provided
-			// with every request. By setting this parameter to zero we are allowing a
-			// variable number of statements to be executed in a single request
-			"MULTI_STATEMENT_COUNT":  &maxStatementCount,
-			"GO_QUERY_RESULT_FORMAT": &json,
-		},
-	}
-}
-
-var hostRe = regexp.MustCompile(`(?i)^.+.snowflakecomputing\.com$`)
-
-func validHost(h string) error {
-	hasProtocol := strings.Contains(h, "://")
-	missingDomain := !hostRe.MatchString(h)
-
-	if hasProtocol && missingDomain {
-		return fmt.Errorf("invalid host %q (must end in snowflakecomputing.com and not include a protocol)", h)
-	} else if hasProtocol {
-		return fmt.Errorf("invalid host %q (must not include a protocol)", h)
-	} else if missingDomain {
-		return fmt.Errorf("invalid host %q (must end in snowflakecomputing.com)", h)
-	}
-
-	return nil
-}
-
-func (c *config) Validate() error {
-	var requiredProperties = [][]string{
-		{"account", c.Account},
-		{"host", c.Host},
-		{"user", c.User},
-		{"password", c.Password},
-		{"database", c.Database},
-		{"schema", c.Schema},
-	}
-	for _, req := range requiredProperties {
-		if req[1] == "" {
-			return fmt.Errorf("missing '%s'", req[0])
-		}
-	}
-
-	if _, err := m.ParseDelay(c.Advanced.UpdateDelay); err != nil {
-		return err
-	}
-
-	return validHost(c.Host)
-}
 
 type tableConfig struct {
 	Table  string `json:"table" jsonschema_extras:"x-collection-name=true"`
@@ -224,8 +122,9 @@ func newSnowflakeDriver() *sql.Driver {
 var _ m.DelayedCommitter = (*transactor)(nil)
 
 type transactor struct {
-	cfg *config
-	db  *stdsql.DB
+	cfg        *config
+	db         *stdsql.DB
+	pipeClient *PipeClient
 	// Variables exclusively used by Load.
 	load struct {
 		conn *stdsql.Conn
@@ -277,10 +176,20 @@ func newTransactor(
 		return nil, fmt.Errorf("newTransactor stdsql.Open: %w", err)
 	}
 
+	var pipeClient *PipeClient
+
+	if cfg.Credentials.AuthType == JWT {
+		pipeClient, err = NewPipeClient(cfg, ep.Tenant)
+		if err != nil {
+			return nil, fmt.Errorf("NewPipeCLient: %w", err)
+		}
+	}
+
 	var d = &transactor{
-		cfg:       cfg,
-		templates: renderTemplates(dialect),
-		db:        db,
+		cfg:        cfg,
+		templates:  renderTemplates(dialect),
+		db:         db,
+		pipeClient: pipeClient,
 	}
 
 	if d.updateDelay, err = m.ParseDelay(cfg.Advanced.UpdateDelay); err != nil {
@@ -316,7 +225,8 @@ func newTransactor(
 }
 
 type binding struct {
-	target sql.Table
+	target   sql.Table
+	pipeName string
 	// Variables exclusively used by Load.
 	load struct {
 		loadQuery string
@@ -337,6 +247,24 @@ func (t *transactor) addBinding(ctx context.Context, target sql.Table) error {
 
 	d.load.stage = newStagedFile(os.TempDir())
 	d.store.stage = newStagedFile(os.TempDir())
+
+	// If this is a delta updates binding and we are using JWT auth type, this binding
+	// can use snowpipe
+	if target.DeltaUpdates && t.cfg.Credentials.AuthType == JWT {
+		if pipeName, err := sql.RenderTableTemplate(target, t.templates.pipeName); err != nil {
+			return fmt.Errorf("pipeName template: %w", err)
+		} else {
+			d.pipeName = fmt.Sprintf("%s.%s.%s", t.cfg.Database, t.cfg.Schema, strings.ToUpper(strings.Trim(pipeName, "`")))
+		}
+
+		if createPipe, err := sql.RenderTableTemplate(target, t.templates.pipeName); err != nil {
+			return fmt.Errorf("createPipe template: %w", err)
+		} else if _, err := t.db.ExecContext(ctx, createPipe); err != nil {
+			return fmt.Errorf("creating pipe for table %q: %w", target.Path, err)
+		} else {
+			log.WithField("q", createPipe).Info("creating pipe")
+		}
+	}
 
 	t.bindings = append(t.bindings, d)
 	return nil
@@ -445,6 +373,8 @@ type checkpointItem struct {
 	Table     string
 	Query     string
 	StagedDir string
+	PipeName  string
+	PipeFiles []fileRecord
 }
 
 type checkpoint = map[string]*checkpointItem
@@ -494,6 +424,13 @@ func (d *transactor) Store(it *m.StoreIterator) (m.StartCommitFunc, error) {
 					StagedDir: dir,
 				}
 			}
+		} else if b.pipeName != "" {
+			d.cp[b.target.StateKey] = &checkpointItem{
+				Table:     b.target.Identifier,
+				StagedDir: dir,
+				PipeFiles: b.store.stage.uploaded,
+				PipeName:  b.pipeName,
+			}
 		} else {
 			if copyIntoQuery, err := RenderTableAndFileTemplate(tableAndFile{Table: b.target, File: dir}, d.templates.copyInto); err != nil {
 				return nil, fmt.Errorf("copyInto template: %w", err)
@@ -534,11 +471,30 @@ func (d *transactor) Acknowledge(ctx context.Context) (*pf.ConnectorState, error
 			continue
 		}
 
-		log.WithField("table", item.Table).Info("store: starting query")
-		if result, err := d.store.conn.ExecContext(asyncCtx, item.Query); err != nil {
-			return nil, fmt.Errorf("query %q failed: %w", item.Query, err)
-		} else {
-			results[stateKey] = result
+		if len(item.Query) > 0 {
+			log.WithField("table", item.Table).Info("store: starting query")
+			if result, err := d.store.conn.ExecContext(asyncCtx, item.Query); err != nil {
+				return nil, fmt.Errorf("query %q failed: %w", item.Query, err)
+			} else {
+				results[stateKey] = result
+			}
+		} else if len(item.PipeFiles) > 0 {
+			var fileRequests = make([]FileRequest, len(item.PipeFiles))
+			for i, f := range item.PipeFiles {
+				fileRequests[i] = FileRequest{
+					Path: "/" + f.Path,
+					Size: f.Size,
+				}
+			}
+
+			if resp, err := d.pipeClient.InsertFiles(item.PipeName, fileRequests); err != nil {
+				return nil, fmt.Errorf("snowpipe insertFiles: %w", err)
+			} else if report, err := d.pipeClient.InsertReport(item.PipeName, ""); err != nil {
+				return nil, fmt.Errorf("snowpipe insertReports: %w", err)
+			} else {
+				// TODO: make me DEBUG
+				log.WithField("response", resp).Info(fmt.Sprintf("insertFiles sucesssful %+v", report))
+			}
 		}
 	}
 

--- a/materialize-snowflake/sqlgen.go
+++ b/materialize-snowflake/sqlgen.go
@@ -291,8 +291,17 @@ WHEN NOT MATCHED THEN
 	{{- end -}}
 );
 {{ end }}
+
+{{ define "copyHistory" }}
+SELECT * FROM TABLE(INFORMATION_SCHEMA.COPY_HISTORY(
+  TABLE_NAME=>{{ $.Table.Identifier }},
+  START_TIME=>{{ $.StartTime }}
+) WHERE
+FILE_NAME IN ({{ Join $.Files }})
+{{ end }}
   `)
 
+<<<<<<< HEAD
 	return templates{
 		createTargetTable: tplAll.Lookup("createTargetTable"),
 		alterTableColumns: tplAll.Lookup("alterTableColumns"),
@@ -301,6 +310,18 @@ WHEN NOT MATCHED THEN
 		mergeInto:         tplAll.Lookup("mergeInto"),
 		pipeName:          tplAll.Lookup("pipe_name"),
 		createPipe:        tplAll.Lookup("createPipe"),
+=======
+	return map[string]*template.Template{
+		"pipeName":           tplAll.Lookup("pipe_name"),
+		"createTargetTable":  tplAll.Lookup("createTargetTable"),
+		"replaceTargetTable": tplAll.Lookup("replaceTargetTable"),
+		"alterTableColumns":  tplAll.Lookup("alterTableColumns"),
+		"createPipe":         tplAll.Lookup("createPipe"),
+		"loadQuery":          tplAll.Lookup("loadQuery"),
+		"copyInto":           tplAll.Lookup("copyInto"),
+		"mergeInto":          tplAll.Lookup("mergeInto"),
+		"copyHistory":        tplAll.Lookup("copyHistory"),
+>>>>>>> 552b966a (materialize-snowflake: createPipe after ack, copy_history)
 	}
 }
 

--- a/materialize-snowflake/sqlgen.go
+++ b/materialize-snowflake/sqlgen.go
@@ -296,7 +296,7 @@ WHEN NOT MATCHED THEN
 {{ define "copyHistory" }}
 SELECT FILE_NAME, STATUS, FIRST_ERROR_MESSAGE FROM TABLE(INFORMATION_SCHEMA.COPY_HISTORY(
   TABLE_NAME=>'{{ $.Table.Identifier }}',
-  START_TIME=>TO_TIMESTAMP_LTZ('{{ $.StartTime }}')
+  START_TIME=>DATEADD(MINUTE, -5, TO_TIMESTAMP_LTZ('{{ $.StartTime }}'))
 )) WHERE
 FILE_NAME IN ('{{ Join $.Files "','" }}')
 {{ end }}
@@ -363,6 +363,6 @@ func RenderCopyHistoryTemplate(table sql.Table, files []string, startTime string
 		"table":     table,
 		"files":     files,
 		"startTime": startTime,
-	}).Debug("rendered template")
+	}).Info("rendered template")
 	return s, nil
 }

--- a/materialize-snowflake/sqlgen.go
+++ b/materialize-snowflake/sqlgen.go
@@ -220,6 +220,7 @@ SELECT * FROM (SELECT -1, CAST(NULL AS VARIANT) LIMIT 0) as nodoc
 {{ define "pipe_name" -}}
 flow_pipe_{{ $.Binding }}_{{ Last $.Path }}
 {{- end }}
+
 {{ define "createPipe" }}
 CREATE OR REPLACE PIPE {{ template "pipe_name" . }}
   COMMENT = 'Pipe for table {{ $.Path }}'
@@ -363,6 +364,6 @@ func RenderCopyHistoryTemplate(table sql.Table, files []string, startTime string
 		"table":     table,
 		"files":     files,
 		"startTime": startTime,
-	}).Info("rendered template")
+	}).Debug("rendered template")
 	return s, nil
 }

--- a/materialize-snowflake/sqlgen.go
+++ b/materialize-snowflake/sqlgen.go
@@ -297,7 +297,7 @@ WHEN NOT MATCHED THEN
 {{ define "copyHistory" }}
 SELECT FILE_NAME, STATUS, FIRST_ERROR_MESSAGE FROM TABLE(INFORMATION_SCHEMA.COPY_HISTORY(
   TABLE_NAME=>'{{ $.Table.Identifier }}',
-  START_TIME=>DATEADD(MINUTE, -5, TO_TIMESTAMP_LTZ('{{ $.StartTime }}'))
+  START_TIME=>DATEADD(MINUTE, -30, TO_TIMESTAMP_LTZ('{{ $.StartTime }}'))
 )) WHERE
 FILE_NAME IN ('{{ Join $.Files "','" }}')
 {{ end }}

--- a/materialize-snowflake/sqlgen.go
+++ b/materialize-snowflake/sqlgen.go
@@ -132,6 +132,8 @@ type templates struct {
 	loadQuery         *template.Template
 	copyInto          *template.Template
 	mergeInto         *template.Template
+	pipeName          *template.Template
+	createPipe        *template.Template
 }
 
 func renderTemplates(dialect sql.Dialect) templates {
@@ -214,6 +216,26 @@ SELECT * FROM (SELECT -1, CAST(NULL AS VARIANT) LIMIT 0) as nodoc
 {{ end -}}
 {{ end }}
 
+{{ define "pipe_name" -}}
+flow_pipe_{{ $.Binding }}_{{ Last $.Path }}
+{{- end }}
+{{ define "createPipe" }}
+CREATE OR REPLACE PIPE {{ template "pipe_name" $.Table }}
+  COMMENT = 'Pipe for table {{ $.Table.Path }}'
+  AS COPY INTO {{ $.Table.Identifier }} (
+	{{ range $ind, $key := $.Table.Columns }}
+		{{- if $ind }}, {{ end -}}
+		{{$key.Identifier -}}
+	{{- end }}
+) FROM (
+	SELECT {{ range $ind, $key := $.Table.Columns }}
+	{{- if $ind }}, {{ end -}}
+	$1[{{$ind}}] AS {{$key.Identifier -}}
+	{{- end }}
+	FROM @flow_v1/{{ $.RandomUUID }}
+);
+{{ end }}
+
 {{ define "copyInto" }}
 COPY INTO {{ $.Table.Identifier }} (
 	{{ range $ind, $key := $.Table.Columns }}
@@ -277,6 +299,8 @@ WHEN NOT MATCHED THEN
 		loadQuery:         tplAll.Lookup("loadQuery"),
 		copyInto:          tplAll.Lookup("copyInto"),
 		mergeInto:         tplAll.Lookup("mergeInto"),
+		pipeName:          tplAll.Lookup("pipe_name"),
+		createPipe:        tplAll.Lookup("createPipe"),
 	}
 }
 

--- a/materialize-snowflake/sqlgen.go
+++ b/materialize-snowflake/sqlgen.go
@@ -220,19 +220,19 @@ SELECT * FROM (SELECT -1, CAST(NULL AS VARIANT) LIMIT 0) as nodoc
 flow_pipe_{{ $.Binding }}_{{ Last $.Path }}
 {{- end }}
 {{ define "createPipe" }}
-CREATE OR REPLACE PIPE {{ template "pipe_name" $.Table }}
-  COMMENT = 'Pipe for table {{ $.Table.Path }}'
-  AS COPY INTO {{ $.Table.Identifier }} (
-	{{ range $ind, $key := $.Table.Columns }}
+CREATE OR REPLACE PIPE {{ template "pipe_name" . }}
+  COMMENT = 'Pipe for table {{ $.Path }}'
+  AS COPY INTO {{ $.Identifier }} (
+	{{ range $ind, $key := $.Columns }}
 		{{- if $ind }}, {{ end -}}
 		{{$key.Identifier -}}
 	{{- end }}
 ) FROM (
-	SELECT {{ range $ind, $key := $.Table.Columns }}
+	SELECT {{ range $ind, $key := $.Columns }}
 	{{- if $ind }}, {{ end -}}
 	$1[{{$ind}}] AS {{$key.Identifier -}}
 	{{- end }}
-	FROM @flow_v1/{{ $.RandomUUID }}
+	FROM @flow_v1
 );
 {{ end }}
 

--- a/materialize-snowflake/sqlgen.go
+++ b/materialize-snowflake/sqlgen.go
@@ -134,6 +134,7 @@ type templates struct {
 	mergeInto         *template.Template
 	pipeName          *template.Template
 	createPipe        *template.Template
+	copyHistory       *template.Template
 }
 
 func renderTemplates(dialect sql.Dialect) templates {
@@ -293,15 +294,14 @@ WHEN NOT MATCHED THEN
 {{ end }}
 
 {{ define "copyHistory" }}
-SELECT * FROM TABLE(INFORMATION_SCHEMA.COPY_HISTORY(
-  TABLE_NAME=>{{ $.Table.Identifier }},
-  START_TIME=>{{ $.StartTime }}
-) WHERE
-FILE_NAME IN ({{ Join $.Files }})
+SELECT FILE_NAME, STATUS, FIRST_ERROR_MESSAGE FROM TABLE(INFORMATION_SCHEMA.COPY_HISTORY(
+  TABLE_NAME=>'{{ $.Table.Identifier }}',
+  START_TIME=>TO_TIMESTAMP_LTZ('{{ $.StartTime }}')
+)) WHERE
+FILE_NAME IN ('{{ Join $.Files "','" }}')
 {{ end }}
   `)
 
-<<<<<<< HEAD
 	return templates{
 		createTargetTable: tplAll.Lookup("createTargetTable"),
 		alterTableColumns: tplAll.Lookup("alterTableColumns"),
@@ -310,18 +310,7 @@ FILE_NAME IN ({{ Join $.Files }})
 		mergeInto:         tplAll.Lookup("mergeInto"),
 		pipeName:          tplAll.Lookup("pipe_name"),
 		createPipe:        tplAll.Lookup("createPipe"),
-=======
-	return map[string]*template.Template{
-		"pipeName":           tplAll.Lookup("pipe_name"),
-		"createTargetTable":  tplAll.Lookup("createTargetTable"),
-		"replaceTargetTable": tplAll.Lookup("replaceTargetTable"),
-		"alterTableColumns":  tplAll.Lookup("alterTableColumns"),
-		"createPipe":         tplAll.Lookup("createPipe"),
-		"loadQuery":          tplAll.Lookup("loadQuery"),
-		"copyInto":           tplAll.Lookup("copyInto"),
-		"mergeInto":          tplAll.Lookup("mergeInto"),
-		"copyHistory":        tplAll.Lookup("copyHistory"),
->>>>>>> 552b966a (materialize-snowflake: createPipe after ack, copy_history)
+		copyHistory:       tplAll.Lookup("copyHistory"),
 	}
 }
 
@@ -341,12 +330,39 @@ type tableAndFile struct {
 
 // RenderTableTemplate is a simple implementation of rendering a template with a Table
 // as its context. It's here for demonstration purposes mostly. Feel free to not use it.
-func RenderTableAndFileTemplate(tf tableAndFile, tpl *template.Template) (string, error) {
+func RenderTableAndFileTemplate(table sql.Table, file string, tpl *template.Template) (string, error) {
 	var w strings.Builder
-	if err := tpl.Execute(&w, &tf); err != nil {
+	if err := tpl.Execute(&w, &tableAndFile{Table: table, File: file}); err != nil {
 		return "", err
 	}
 	var s = w.String()
-	log.WithField("rendered", s).WithField("tableAndFile", tf).Debug("rendered template")
+	log.WithFields(log.Fields{
+		"rendered": s,
+		"table":    table,
+		"file":     file,
+	}).Debug("rendered template")
+	return s, nil
+}
+
+type copyHistory struct {
+	Table     sql.Table
+	Files     []string
+	StartTime string
+}
+
+// RenderTableTemplate is a simple implementation of rendering a template with a Table
+// as its context. It's here for demonstration purposes mostly. Feel free to not use it.
+func RenderCopyHistoryTemplate(table sql.Table, files []string, startTime string, tpl *template.Template) (string, error) {
+	var w strings.Builder
+	if err := tpl.Execute(&w, &copyHistory{Table: table, Files: files, StartTime: startTime}); err != nil {
+		return "", err
+	}
+	var s = w.String()
+	log.WithFields(log.Fields{
+		"rendered":  s,
+		"table":     table,
+		"files":     files,
+		"startTime": startTime,
+	}).Debug("rendered template")
 	return s, nil
 }

--- a/materialize-snowflake/staged_file.go
+++ b/materialize-snowflake/staged_file.go
@@ -114,6 +114,7 @@ func (f *stagedFile) start(ctx context.Context, db *stdsql.DB) error {
 	f.started = true
 	f.uuid = uuid.NewString()
 	f.dir = filepath.Join(f.tempdir, f.uuid)
+	f.uploaded = nil
 
 	// Create the local working directory for this binding. As a simplification we will always
 	// remove and re-create the directory since it will already exist for transactions beyond the

--- a/materialize-snowflake/staged_file.go
+++ b/materialize-snowflake/staged_file.go
@@ -222,7 +222,7 @@ func (f *stagedFile) putWorker(ctx context.Context, db *stdsql.DB, filePaths <-c
 			"targetSize": targetSize,
 			"file":       file,
 			"uuid":       f.uuid,
-		}).Info("uploading file")
+		}).Debug("uploading file")
 
 		if size, err := strconv.Atoi(targetSize); err != nil {
 			return fmt.Errorf("parsing targetSize: %w", err)

--- a/materialize-snowflake/staged_file.go
+++ b/materialize-snowflake/staged_file.go
@@ -228,7 +228,7 @@ func (f *stagedFile) putWorker(ctx context.Context, db *stdsql.DB, filePaths <-c
 			return fmt.Errorf("parsing targetSize: %w", err)
 		} else {
 			f.uploaded = append(f.uploaded, fileRecord{
-				Path: target,
+				Path: fmt.Sprintf("%s/%s", f.uuid, target),
 				Size: size,
 			})
 		}

--- a/materialize-snowflake/staged_file.go
+++ b/materialize-snowflake/staged_file.go
@@ -7,10 +7,12 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	sql "github.com/estuary/connectors/materialize-sql"
 	"github.com/google/uuid"
+	log "github.com/sirupsen/logrus"
 	"golang.org/x/sync/errgroup"
 )
 
@@ -32,6 +34,14 @@ func (f *fileBuffer) Close() error {
 		return err
 	}
 	return nil
+}
+
+// we keep track of files we upload so that we can send them to Snowpipe in an
+// insertFiles RPC
+// https://docs.snowflake.com/user-guide/data-load-snowpipe-rest-apis#label-rest-api-insertfiles
+type fileRecord struct {
+	Path string
+	Size int
 }
 
 // stagedFile manages uploading a sequence of local files produced by reading from Load/Store
@@ -79,6 +89,9 @@ type stagedFile struct {
 	// References to the current file being written.
 	buf     *fileBuffer
 	encoder *sql.CountingEncoder
+
+	// list of uploaded files
+	uploaded []fileRecord
 
 	// Per-transaction coordination.
 	putFiles chan string
@@ -201,6 +214,23 @@ func (f *stagedFile) putWorker(ctx context.Context, db *stdsql.DB, filePaths <-c
 			return fmt.Errorf("putWorker PUT to stage: %w", err)
 		} else if !strings.EqualFold("uploaded", status) {
 			return fmt.Errorf("putWorker PUT to stage unexpected upload status: %s", status)
+		}
+
+		log.WithFields(log.Fields{
+			"source":     source,
+			"target":     target,
+			"targetSize": targetSize,
+			"file":       file,
+			"uuid":       f.uuid,
+		}).Info("uploading file")
+
+		if size, err := strconv.Atoi(targetSize); err != nil {
+			return fmt.Errorf("parsing targetSize: %w", err)
+		} else {
+			f.uploaded = append(f.uploaded, fileRecord{
+				Path: target,
+				Size: size,
+			})
 		}
 
 		// Once the file has been staged to Snowflake we don't need it locally anymore and can

--- a/materialize-sql/driver.go
+++ b/materialize-sql/driver.go
@@ -136,6 +136,7 @@ func (d *Driver) Validate(ctx context.Context, req *pm.Request_Validate) (*pm.Re
 				ResourcePath: res.Path(),
 			})
 	}
+
 	return resp, nil
 }
 

--- a/tests/materialize/materialize-snowflake/checks.sh
+++ b/tests/materialize/materialize-snowflake/checks.sh
@@ -1,3 +1,4 @@
 # cleanup the snapshot by replacing uuids with a placeholder so that the test is reproducible
 sed -i '' 's/@flow_v1\/.\{36\}/<uuid>/g' ${SNAPSHOT}
 sed -i '' 's/"Path": ".*"/"Path": "<uuid>"/g' ${SNAPSHOT}
+sed -i '' 's/"PipeStartTime": ".\{1,\}"/"PipeStartTime: "<timestamp>"/g' ${SNAPSHOT}

--- a/tests/materialize/materialize-snowflake/checks.sh
+++ b/tests/materialize/materialize-snowflake/checks.sh
@@ -1,2 +1,3 @@
 # cleanup the snapshot by replacing uuids with a placeholder so that the test is reproducible
 sed -i '' 's/@flow_v1\/.\{36\}/<uuid>/g' ${SNAPSHOT}
+sed -i '' 's/"Path": ".*"/"Path": "<uuid>"/g' ${SNAPSHOT}

--- a/tests/materialize/materialize-snowflake/checks.sh
+++ b/tests/materialize/materialize-snowflake/checks.sh
@@ -1,4 +1,4 @@
 # cleanup the snapshot by replacing uuids with a placeholder so that the test is reproducible
 sed -i '' 's/@flow_v1\/.\{36\}/<uuid>/g' ${SNAPSHOT}
 sed -i '' 's/"Path": ".*"/"Path": "<uuid>"/g' ${SNAPSHOT}
-sed -i '' 's/"PipeStartTime": ".\{1,\}"/"PipeStartTime: "<timestamp>"/g' ${SNAPSHOT}
+sed -i '' 's/"PipeStartTime": ".\{1,\}"/"PipeStartTime": "<timestamp>"/g' ${SNAPSHOT}

--- a/tests/materialize/materialize-snowflake/fetch-data.go
+++ b/tests/materialize/materialize-snowflake/fetch-data.go
@@ -37,7 +37,20 @@ func mustDSN() string {
 		{"SNOWFLAKE_SCHEMA", &conf.Schema},
 		{"SNOWFLAKE_WAREHOUSE", &conf.Warehouse},
 	} {
-		*prop.dest = os.Getenv(prop.key)
+		if v, exists := os.LookupEnv(prop.key); exists {
+			*prop.dest = v
+		}
+	}
+
+	if v, exists := os.LookupEnv("SNOWFLAKE_PRIVATE_KEY"); exists {
+		conf.Authenticator = sf.AuthTypeJwt
+		var pkString = strings.ReplaceAll(v, "\\n", "\n")
+		var block, _ = pem.Decode([]byte(pkString))
+		if key, err := x509.ParsePKCS8PrivateKey(block.Bytes); err != nil {
+			panic(fmt.Errorf("parsing private key: %w", err))
+		} else {
+			conf.PrivateKey = key.(*rsa.PrivateKey)
+		}
 	}
 
 	dsn, err := sf.DSN(&conf)

--- a/tests/materialize/materialize-snowflake/fetch-data.go
+++ b/tests/materialize/materialize-snowflake/fetch-data.go
@@ -2,13 +2,17 @@ package main
 
 import (
 	"context"
+	"crypto/rsa"
+	"crypto/x509"
 	"database/sql"
 	"encoding/json"
+	"encoding/pem"
 	"flag"
 	"fmt"
 	"log"
 	"math"
 	"os"
+	"strings"
 
 	sf "github.com/snowflakedb/gosnowflake"
 )

--- a/tests/materialize/materialize-snowflake/fetch.sh
+++ b/tests/materialize/materialize-snowflake/fetch.sh
@@ -8,6 +8,9 @@ function exportToJsonl() {
   go run ${TEST_DIR}/materialize-snowflake/fetch-data.go "$1" | jq "{ "_table": \"$1\", rows: . }"
 }
 
+
+sleep 10
+
 exportToJsonl "simple"
 exportToJsonl "duplicate_keys_standard"
 exportToJsonl "duplicate_keys_delta"

--- a/tests/materialize/materialize-snowflake/fetch.sh
+++ b/tests/materialize/materialize-snowflake/fetch.sh
@@ -8,9 +8,6 @@ function exportToJsonl() {
   go run ${TEST_DIR}/materialize-snowflake/fetch-data.go "$1" | jq "{ "_table": \"$1\", rows: . }"
 }
 
-
-sleep 10
-
 exportToJsonl "simple"
 exportToJsonl "duplicate_keys_standard"
 exportToJsonl "duplicate_keys_delta"

--- a/tests/materialize/materialize-snowflake/setup.sh
+++ b/tests/materialize/materialize-snowflake/setup.sh
@@ -6,20 +6,29 @@ set -o nounset
 
 export SNOWFLAKE_HOST="${SNOWFLAKE_HOST}"
 export SNOWFLAKE_ACCOUNT="${SNOWFLAKE_ACCOUNT}"
-export SNOWFLAKE_USER="${SNOWFLAKE_USER}"
-export SNOWFLAKE_PASSWORD="${SNOWFLAKE_PASSWORD}"
 export SNOWFLAKE_DATABASE="${SNOWFLAKE_DATABASE}"
 export SNOWFLAKE_SCHEMA="${SNOWFLAKE_SCHEMA}"
 export SNOWFLAKE_WAREHOUSE="${SNOWFLAKE_WAREHOUSE}"
 
+export SNOWFLAKE_AUTH_TYPE="${SNOWFLAKE_AUTH_TYPE}"
+# if auth type is user_password
+export SNOWFLAKE_USER="${SNOWFLAKE_USER:-}"
+export SNOWFLAKE_PASSWORD="${SNOWFLAKE_PASSWORD:-}"
+# if auth type is jwt
+export SNOWFLAKE_PRIVATE_KEY="$(cat ${SNOWFLAKE_PRIVATE_KEY:-} | jq -sR . | sed -e 's/^"//' -e 's/"$//')"
+
 config_json_template='{
    "host":      "$SNOWFLAKE_HOST",
    "account":   "$SNOWFLAKE_ACCOUNT",
-   "user":      "$SNOWFLAKE_USER",
-   "password":  "$SNOWFLAKE_PASSWORD",
    "database":  "$SNOWFLAKE_DATABASE",
    "schema":    "$SNOWFLAKE_SCHEMA",
    "warehouse": "$SNOWFLAKE_WAREHOUSE",
+   "credentials": {
+     "auth_type": "$SNOWFLAKE_AUTH_TYPE",
+     "user": "$SNOWFLAKE_USER",
+     "password": "$SNOWFLAKE_PASSWORD",
+     "private_key": "$SNOWFLAKE_PRIVATE_KEY"
+   },
    "advanced": {
       "updateDelay": "0s"
     }

--- a/tests/materialize/materialize-snowflake/snapshot.json
+++ b/tests/materialize/materialize-snowflake/snapshot.json
@@ -37,7 +37,7 @@
               "Size": 275
             }
           ],
-          "PipeName": "MAHDI_DB.ESTUARY_SCHEMA.FLOW_PIPE_2_DUPLICATE_KEYS_DELTA",
+          "PipeName": "MAHDI_DB.ESTUARY_SCHEMA.FLOW_PIPE_2_DUPLICATE_KEYS_DELTA_00000000",
           "Query": "",
           "StagedDir": "<uuid>",
           "Table": "duplicate_keys_delta"
@@ -49,7 +49,7 @@
               "Size": 140
             }
           ],
-          "PipeName": "MAHDI_DB.ESTUARY_SCHEMA.FLOW_PIPE_3_DUPLICATE_KEYS_DELTA_EXCLUDE_FLOW_DOC",
+          "PipeName": "MAHDI_DB.ESTUARY_SCHEMA.FLOW_PIPE_3_DUPLICATE_KEYS_DELTA_EXCLUDE_FLOW_DOC_00000000",
           "Query": "",
           "StagedDir": "<uuid>",
           "Table": "duplicate_keys_delta_exclude_flow_doc"
@@ -312,7 +312,7 @@
               "Size": 271
             }
           ],
-          "PipeName": "MAHDI_DB.ESTUARY_SCHEMA.FLOW_PIPE_2_DUPLICATE_KEYS_DELTA",
+          "PipeName": "MAHDI_DB.ESTUARY_SCHEMA.FLOW_PIPE_2_DUPLICATE_KEYS_DELTA_00000000",
           "Query": "",
           "StagedDir": "<uuid>",
           "Table": "duplicate_keys_delta"
@@ -328,7 +328,7 @@
               "Size": 137
             }
           ],
-          "PipeName": "MAHDI_DB.ESTUARY_SCHEMA.FLOW_PIPE_3_DUPLICATE_KEYS_DELTA_EXCLUDE_FLOW_DOC",
+          "PipeName": "MAHDI_DB.ESTUARY_SCHEMA.FLOW_PIPE_3_DUPLICATE_KEYS_DELTA_EXCLUDE_FLOW_DOC_00000000",
           "Query": "",
           "StagedDir": "<uuid>",
           "Table": "duplicate_keys_delta_exclude_flow_doc"

--- a/tests/materialize/materialize-snowflake/snapshot.json
+++ b/tests/materialize/materialize-snowflake/snapshot.json
@@ -31,31 +31,53 @@
       "mergePatch": true,
       "updated": {
         "duplicate_keys_delta": {
-          "Query": "\nCOPY INTO duplicate_keys_delta (\n\tid, flow_published_at, int, str, flow_document\n) FROM (\n\tSELECT $1[0] AS id, $1[1] AS flow_published_at, $1[2] AS int, $1[3] AS str, $1[4] AS flow_document\n\tFROM <uuid>\n);\n",
+          "PipeFiles": [
+            {
+              "Path": "<uuid>",
+              "Size": 275
+            }
+          ],
+          "PipeName": "MAHDI_DB.ESTUARY_SCHEMA.FLOW_PIPE_2_DUPLICATE_KEYS_DELTA",
+          "Query": "",
           "StagedDir": "<uuid>",
           "Table": "duplicate_keys_delta"
         },
         "duplicate_keys_delta_exclude_flow_doc": {
-          "Query": "\nCOPY INTO duplicate_keys_delta_exclude_flow_doc (\n\tid, flow_published_at, int, str\n) FROM (\n\tSELECT $1[0] AS id, $1[1] AS flow_published_at, $1[2] AS int, $1[3] AS str\n\tFROM <uuid>\n);\n",
+          "PipeFiles": [
+            {
+              "Path": "<uuid>",
+              "Size": 140
+            }
+          ],
+          "PipeName": "MAHDI_DB.ESTUARY_SCHEMA.FLOW_PIPE_3_DUPLICATE_KEYS_DELTA_EXCLUDE_FLOW_DOC",
+          "Query": "",
           "StagedDir": "<uuid>",
           "Table": "duplicate_keys_delta_exclude_flow_doc"
         },
         "duplicate_keys_standard": {
+          "PipeFiles": null,
+          "PipeName": "",
           "Query": "\nCOPY INTO duplicate_keys_standard (\n\tid, flow_published_at, int, str, flow_document\n) FROM (\n\tSELECT $1[0] AS id, $1[1] AS flow_published_at, $1[2] AS int, $1[3] AS str, $1[4] AS flow_document\n\tFROM <uuid>\n);\n",
           "StagedDir": "<uuid>",
           "Table": "duplicate_keys_standard"
         },
         "formatted_strings": {
+          "PipeFiles": null,
+          "PipeName": "",
           "Query": "\nCOPY INTO formatted_strings (\n\tid, date, datetime, flow_published_at, int_and_str, int_str, num_and_str, num_str, time, flow_document\n) FROM (\n\tSELECT $1[0] AS id, $1[1] AS date, $1[2] AS datetime, $1[3] AS flow_published_at, $1[4] AS int_and_str, $1[5] AS int_str, $1[6] AS num_and_str, $1[7] AS num_str, $1[8] AS time, $1[9] AS flow_document\n\tFROM <uuid>\n);\n",
           "StagedDir": "<uuid>",
           "Table": "formatted_strings"
         },
         "multiple_types": {
+          "PipeFiles": null,
+          "PipeName": "",
           "Query": "\nCOPY INTO multiple_types (\n\tid, array_int, bool_field, float_field, flow_published_at, multiple, nested, nullable_int, str_field, flow_document\n) FROM (\n\tSELECT $1[0] AS id, $1[1] AS array_int, $1[2] AS bool_field, $1[3] AS float_field, $1[4] AS flow_published_at, $1[5] AS multiple, $1[6] AS nested, $1[7] AS nullable_int, $1[8] AS str_field, $1[9] AS flow_document\n\tFROM <uuid>\n);\n",
           "StagedDir": "<uuid>",
           "Table": "multiple_types"
         },
         "simple": {
+          "PipeFiles": null,
+          "PipeName": "",
           "Query": "\nCOPY INTO simple (\n\tid, canary, flow_published_at, flow_document\n) FROM (\n\tSELECT $1[0] AS id, $1[1] AS canary, $1[2] AS flow_published_at, $1[3] AS flow_document\n\tFROM <uuid>\n);\n",
           "StagedDir": "<uuid>",
           "Table": "simple"
@@ -278,31 +300,61 @@
       "mergePatch": true,
       "updated": {
         "duplicate_keys_delta": {
-          "Query": "\nCOPY INTO duplicate_keys_delta (\n\tid, flow_published_at, int, str, flow_document\n) FROM (\n\tSELECT $1[0] AS id, $1[1] AS flow_published_at, $1[2] AS int, $1[3] AS str, $1[4] AS flow_document\n\tFROM <uuid>\n);\n",
+          "PipeFiles": [
+            {
+              "Path": "<uuid>",
+              "Size": 275
+            },
+            {
+              "Path": "<uuid>",
+              "Size": 271
+            }
+          ],
+          "PipeName": "MAHDI_DB.ESTUARY_SCHEMA.FLOW_PIPE_2_DUPLICATE_KEYS_DELTA",
+          "Query": "",
           "StagedDir": "<uuid>",
           "Table": "duplicate_keys_delta"
         },
         "duplicate_keys_delta_exclude_flow_doc": {
-          "Query": "\nCOPY INTO duplicate_keys_delta_exclude_flow_doc (\n\tid, flow_published_at, int, str\n) FROM (\n\tSELECT $1[0] AS id, $1[1] AS flow_published_at, $1[2] AS int, $1[3] AS str\n\tFROM <uuid>\n);\n",
+          "PipeFiles": [
+            {
+              "Path": "<uuid>",
+              "Size": 140
+            },
+            {
+              "Path": "<uuid>",
+              "Size": 137
+            }
+          ],
+          "PipeName": "MAHDI_DB.ESTUARY_SCHEMA.FLOW_PIPE_3_DUPLICATE_KEYS_DELTA_EXCLUDE_FLOW_DOC",
+          "Query": "",
           "StagedDir": "<uuid>",
           "Table": "duplicate_keys_delta_exclude_flow_doc"
         },
         "duplicate_keys_standard": {
+          "PipeFiles": null,
+          "PipeName": "",
           "Query": "\nMERGE INTO duplicate_keys_standard AS l\nUSING (\n\tSELECT $1[0] AS id, $1[1] AS flow_published_at, $1[2] AS int, $1[3] AS str, $1[4] AS flow_document\n\tFROM <uuid>\n) AS r\nON l.id = r.id\nWHEN MATCHED AND IS_NULL_VALUE(r.flow_document) THEN\n\tDELETE\nWHEN MATCHED THEN\n\tUPDATE SET l.flow_published_at = r.flow_published_at, l.int = r.int, l.str = r.str, l.flow_document = r.flow_document\nWHEN NOT MATCHED THEN\n\tINSERT (id, flow_published_at, int, str, flow_document)\n\tVALUES (r.id, r.flow_published_at, r.int, r.str, r.flow_document);\n",
           "StagedDir": "<uuid>",
           "Table": "duplicate_keys_standard"
         },
         "formatted_strings": {
+          "PipeFiles": null,
+          "PipeName": "",
           "Query": "\nCOPY INTO formatted_strings (\n\tid, date, datetime, flow_published_at, int_and_str, int_str, num_and_str, num_str, time, flow_document\n) FROM (\n\tSELECT $1[0] AS id, $1[1] AS date, $1[2] AS datetime, $1[3] AS flow_published_at, $1[4] AS int_and_str, $1[5] AS int_str, $1[6] AS num_and_str, $1[7] AS num_str, $1[8] AS time, $1[9] AS flow_document\n\tFROM <uuid>\n);\n",
           "StagedDir": "<uuid>",
           "Table": "formatted_strings"
         },
         "multiple_types": {
+          "PipeFiles": null,
+          "PipeName": "",
           "Query": "\nMERGE INTO multiple_types AS l\nUSING (\n\tSELECT $1[0] AS id, $1[1] AS array_int, $1[2] AS bool_field, $1[3] AS float_field, $1[4] AS flow_published_at, $1[5] AS multiple, $1[6] AS nested, $1[7] AS nullable_int, $1[8] AS str_field, $1[9] AS flow_document\n\tFROM <uuid>\n) AS r\nON l.id = r.id\nWHEN MATCHED AND IS_NULL_VALUE(r.flow_document) THEN\n\tDELETE\nWHEN MATCHED THEN\n\tUPDATE SET l.array_int = r.array_int, l.bool_field = r.bool_field, l.float_field = r.float_field, l.flow_published_at = r.flow_published_at, l.multiple = r.multiple, l.nested = r.nested, l.nullable_int = r.nullable_int, l.str_field = r.str_field, l.flow_document = r.flow_document\nWHEN NOT MATCHED THEN\n\tINSERT (id, array_int, bool_field, float_field, flow_published_at, multiple, nested, nullable_int, str_field, flow_document)\n\tVALUES (r.id, r.array_int, r.bool_field, r.float_field, r.flow_published_at, r.multiple, r.nested, r.nullable_int, r.str_field, r.flow_document);\n",
           "StagedDir": "<uuid>",
           "Table": "multiple_types"
         },
         "simple": {
+          "PipeFiles": null,
+          "PipeName": "",
           "Query": "\nCOPY INTO simple (\n\tid, canary, flow_published_at, flow_document\n) FROM (\n\tSELECT $1[0] AS id, $1[1] AS canary, $1[2] AS flow_published_at, $1[3] AS flow_document\n\tFROM <uuid>\n);\n",
           "StagedDir": "<uuid>",
           "Table": "simple"

--- a/tests/materialize/materialize-snowflake/snapshot.json
+++ b/tests/materialize/materialize-snowflake/snapshot.json
@@ -305,10 +305,6 @@
           "PipeFiles": [
             {
               "Path": "<uuid>",
-              "Size": 275
-            },
-            {
-              "Path": "<uuid>",
               "Size": 271
             }
           ],
@@ -319,10 +315,6 @@
         },
         "duplicate_keys_delta_exclude_flow_doc": {
           "PipeFiles": [
-            {
-              "Path": "<uuid>",
-              "Size": 140
-            },
             {
               "Path": "<uuid>",
               "Size": 137

--- a/tests/materialize/materialize-snowflake/snapshot.json
+++ b/tests/materialize/materialize-snowflake/snapshot.json
@@ -38,7 +38,7 @@
             }
           ],
           "PipeName": "MAHDI_DB.ESTUARY_SCHEMA.FLOW_PIPE_2_DUPLICATE_KEYS_DELTA",
-          "PipeStartTime: "<timestamp>",
+          "PipeStartTime": "<timestamp>",
           "Query": "",
           "StagedDir": "<uuid>",
           "Table": "duplicate_keys_delta"
@@ -51,7 +51,7 @@
             }
           ],
           "PipeName": "MAHDI_DB.ESTUARY_SCHEMA.FLOW_PIPE_3_DUPLICATE_KEYS_DELTA_EXCLUDE_FLOW_DOC",
-          "PipeStartTime: "<timestamp>",
+          "PipeStartTime": "<timestamp>",
           "Query": "",
           "StagedDir": "<uuid>",
           "Table": "duplicate_keys_delta_exclude_flow_doc"
@@ -320,7 +320,7 @@
             }
           ],
           "PipeName": "MAHDI_DB.ESTUARY_SCHEMA.FLOW_PIPE_2_DUPLICATE_KEYS_DELTA",
-          "PipeStartTime: "<timestamp>",
+          "PipeStartTime": "<timestamp>",
           "Query": "",
           "StagedDir": "<uuid>",
           "Table": "duplicate_keys_delta"
@@ -337,7 +337,7 @@
             }
           ],
           "PipeName": "MAHDI_DB.ESTUARY_SCHEMA.FLOW_PIPE_3_DUPLICATE_KEYS_DELTA_EXCLUDE_FLOW_DOC",
-          "PipeStartTime: "<timestamp>",
+          "PipeStartTime": "<timestamp>",
           "Query": "",
           "StagedDir": "<uuid>",
           "Table": "duplicate_keys_delta_exclude_flow_doc"

--- a/tests/materialize/materialize-snowflake/snapshot.json
+++ b/tests/materialize/materialize-snowflake/snapshot.json
@@ -38,7 +38,6 @@
             }
           ],
           "PipeName": "MAHDI_DB.ESTUARY_SCHEMA.FLOW_PIPE_2_DUPLICATE_KEYS_DELTA",
-          "PipeStartTime": "<timestamp>",
           "Query": "",
           "StagedDir": "<uuid>",
           "Table": "duplicate_keys_delta"
@@ -51,7 +50,6 @@
             }
           ],
           "PipeName": "MAHDI_DB.ESTUARY_SCHEMA.FLOW_PIPE_3_DUPLICATE_KEYS_DELTA_EXCLUDE_FLOW_DOC",
-          "PipeStartTime": "<timestamp>",
           "Query": "",
           "StagedDir": "<uuid>",
           "Table": "duplicate_keys_delta_exclude_flow_doc"
@@ -59,7 +57,6 @@
         "duplicate_keys_standard": {
           "PipeFiles": null,
           "PipeName": "",
-          "PipeStartTime": "",
           "Query": "\nCOPY INTO duplicate_keys_standard (\n\tid, flow_published_at, int, str, flow_document\n) FROM (\n\tSELECT $1[0] AS id, $1[1] AS flow_published_at, $1[2] AS int, $1[3] AS str, $1[4] AS flow_document\n\tFROM <uuid>\n);\n",
           "StagedDir": "<uuid>",
           "Table": "duplicate_keys_standard"
@@ -67,7 +64,6 @@
         "formatted_strings": {
           "PipeFiles": null,
           "PipeName": "",
-          "PipeStartTime": "",
           "Query": "\nCOPY INTO formatted_strings (\n\tid, date, datetime, flow_published_at, int_and_str, int_str, num_and_str, num_str, time, flow_document\n) FROM (\n\tSELECT $1[0] AS id, $1[1] AS date, $1[2] AS datetime, $1[3] AS flow_published_at, $1[4] AS int_and_str, $1[5] AS int_str, $1[6] AS num_and_str, $1[7] AS num_str, $1[8] AS time, $1[9] AS flow_document\n\tFROM <uuid>\n);\n",
           "StagedDir": "<uuid>",
           "Table": "formatted_strings"
@@ -75,7 +71,6 @@
         "multiple_types": {
           "PipeFiles": null,
           "PipeName": "",
-          "PipeStartTime": "",
           "Query": "\nCOPY INTO multiple_types (\n\tid, array_int, bool_field, float_field, flow_published_at, multiple, nested, nullable_int, str_field, flow_document\n) FROM (\n\tSELECT $1[0] AS id, $1[1] AS array_int, $1[2] AS bool_field, $1[3] AS float_field, $1[4] AS flow_published_at, $1[5] AS multiple, $1[6] AS nested, $1[7] AS nullable_int, $1[8] AS str_field, $1[9] AS flow_document\n\tFROM <uuid>\n);\n",
           "StagedDir": "<uuid>",
           "Table": "multiple_types"
@@ -83,7 +78,6 @@
         "simple": {
           "PipeFiles": null,
           "PipeName": "",
-          "PipeStartTime": "",
           "Query": "\nCOPY INTO simple (\n\tid, canary, flow_published_at, flow_document\n) FROM (\n\tSELECT $1[0] AS id, $1[1] AS canary, $1[2] AS flow_published_at, $1[3] AS flow_document\n\tFROM <uuid>\n);\n",
           "StagedDir": "<uuid>",
           "Table": "simple"
@@ -91,7 +85,6 @@
         "symbols": {
           "PipeFiles": null,
           "PipeName": "",
-          "PipeStartTime": "",
           "Query": "\nCOPY INTO symbols (\n\t\"testing (%s)\", flow_published_at, id, flow_document\n) FROM (\n\tSELECT $1[0] AS \"testing (%s)\", $1[1] AS flow_published_at, $1[2] AS id, $1[3] AS flow_document\n\tFROM <uuid>\n);\n",
           "StagedDir": "<uuid>",
           "Table": "symbols"
@@ -320,7 +313,6 @@
             }
           ],
           "PipeName": "MAHDI_DB.ESTUARY_SCHEMA.FLOW_PIPE_2_DUPLICATE_KEYS_DELTA",
-          "PipeStartTime": "<timestamp>",
           "Query": "",
           "StagedDir": "<uuid>",
           "Table": "duplicate_keys_delta"
@@ -337,7 +329,6 @@
             }
           ],
           "PipeName": "MAHDI_DB.ESTUARY_SCHEMA.FLOW_PIPE_3_DUPLICATE_KEYS_DELTA_EXCLUDE_FLOW_DOC",
-          "PipeStartTime": "<timestamp>",
           "Query": "",
           "StagedDir": "<uuid>",
           "Table": "duplicate_keys_delta_exclude_flow_doc"
@@ -345,7 +336,6 @@
         "duplicate_keys_standard": {
           "PipeFiles": null,
           "PipeName": "",
-          "PipeStartTime": "",
           "Query": "\nMERGE INTO duplicate_keys_standard AS l\nUSING (\n\tSELECT $1[0] AS id, $1[1] AS flow_published_at, $1[2] AS int, $1[3] AS str, $1[4] AS flow_document\n\tFROM <uuid>\n) AS r\nON l.id = r.id\nWHEN MATCHED AND IS_NULL_VALUE(r.flow_document) THEN\n\tDELETE\nWHEN MATCHED THEN\n\tUPDATE SET l.flow_published_at = r.flow_published_at, l.int = r.int, l.str = r.str, l.flow_document = r.flow_document\nWHEN NOT MATCHED THEN\n\tINSERT (id, flow_published_at, int, str, flow_document)\n\tVALUES (r.id, r.flow_published_at, r.int, r.str, r.flow_document);\n",
           "StagedDir": "<uuid>",
           "Table": "duplicate_keys_standard"
@@ -353,7 +343,6 @@
         "formatted_strings": {
           "PipeFiles": null,
           "PipeName": "",
-          "PipeStartTime": "",
           "Query": "\nCOPY INTO formatted_strings (\n\tid, date, datetime, flow_published_at, int_and_str, int_str, num_and_str, num_str, time, flow_document\n) FROM (\n\tSELECT $1[0] AS id, $1[1] AS date, $1[2] AS datetime, $1[3] AS flow_published_at, $1[4] AS int_and_str, $1[5] AS int_str, $1[6] AS num_and_str, $1[7] AS num_str, $1[8] AS time, $1[9] AS flow_document\n\tFROM <uuid>\n);\n",
           "StagedDir": "<uuid>",
           "Table": "formatted_strings"
@@ -361,7 +350,6 @@
         "multiple_types": {
           "PipeFiles": null,
           "PipeName": "",
-          "PipeStartTime": "",
           "Query": "\nMERGE INTO multiple_types AS l\nUSING (\n\tSELECT $1[0] AS id, $1[1] AS array_int, $1[2] AS bool_field, $1[3] AS float_field, $1[4] AS flow_published_at, $1[5] AS multiple, $1[6] AS nested, $1[7] AS nullable_int, $1[8] AS str_field, $1[9] AS flow_document\n\tFROM <uuid>\n) AS r\nON l.id = r.id\nWHEN MATCHED AND IS_NULL_VALUE(r.flow_document) THEN\n\tDELETE\nWHEN MATCHED THEN\n\tUPDATE SET l.array_int = r.array_int, l.bool_field = r.bool_field, l.float_field = r.float_field, l.flow_published_at = r.flow_published_at, l.multiple = r.multiple, l.nested = r.nested, l.nullable_int = r.nullable_int, l.str_field = r.str_field, l.flow_document = r.flow_document\nWHEN NOT MATCHED THEN\n\tINSERT (id, array_int, bool_field, float_field, flow_published_at, multiple, nested, nullable_int, str_field, flow_document)\n\tVALUES (r.id, r.array_int, r.bool_field, r.float_field, r.flow_published_at, r.multiple, r.nested, r.nullable_int, r.str_field, r.flow_document);\n",
           "StagedDir": "<uuid>",
           "Table": "multiple_types"
@@ -369,7 +357,6 @@
         "simple": {
           "PipeFiles": null,
           "PipeName": "",
-          "PipeStartTime": "",
           "Query": "\nCOPY INTO simple (\n\tid, canary, flow_published_at, flow_document\n) FROM (\n\tSELECT $1[0] AS id, $1[1] AS canary, $1[2] AS flow_published_at, $1[3] AS flow_document\n\tFROM <uuid>\n);\n",
           "StagedDir": "<uuid>",
           "Table": "simple"

--- a/tests/materialize/materialize-snowflake/snapshot.json
+++ b/tests/materialize/materialize-snowflake/snapshot.json
@@ -38,6 +38,7 @@
             }
           ],
           "PipeName": "MAHDI_DB.ESTUARY_SCHEMA.FLOW_PIPE_2_DUPLICATE_KEYS_DELTA",
+          "PipeStartTime: "<timestamp>",
           "Query": "",
           "StagedDir": "<uuid>",
           "Table": "duplicate_keys_delta"
@@ -50,6 +51,7 @@
             }
           ],
           "PipeName": "MAHDI_DB.ESTUARY_SCHEMA.FLOW_PIPE_3_DUPLICATE_KEYS_DELTA_EXCLUDE_FLOW_DOC",
+          "PipeStartTime: "<timestamp>",
           "Query": "",
           "StagedDir": "<uuid>",
           "Table": "duplicate_keys_delta_exclude_flow_doc"
@@ -57,6 +59,7 @@
         "duplicate_keys_standard": {
           "PipeFiles": null,
           "PipeName": "",
+          "PipeStartTime": "",
           "Query": "\nCOPY INTO duplicate_keys_standard (\n\tid, flow_published_at, int, str, flow_document\n) FROM (\n\tSELECT $1[0] AS id, $1[1] AS flow_published_at, $1[2] AS int, $1[3] AS str, $1[4] AS flow_document\n\tFROM <uuid>\n);\n",
           "StagedDir": "<uuid>",
           "Table": "duplicate_keys_standard"
@@ -64,6 +67,7 @@
         "formatted_strings": {
           "PipeFiles": null,
           "PipeName": "",
+          "PipeStartTime": "",
           "Query": "\nCOPY INTO formatted_strings (\n\tid, date, datetime, flow_published_at, int_and_str, int_str, num_and_str, num_str, time, flow_document\n) FROM (\n\tSELECT $1[0] AS id, $1[1] AS date, $1[2] AS datetime, $1[3] AS flow_published_at, $1[4] AS int_and_str, $1[5] AS int_str, $1[6] AS num_and_str, $1[7] AS num_str, $1[8] AS time, $1[9] AS flow_document\n\tFROM <uuid>\n);\n",
           "StagedDir": "<uuid>",
           "Table": "formatted_strings"
@@ -71,6 +75,7 @@
         "multiple_types": {
           "PipeFiles": null,
           "PipeName": "",
+          "PipeStartTime": "",
           "Query": "\nCOPY INTO multiple_types (\n\tid, array_int, bool_field, float_field, flow_published_at, multiple, nested, nullable_int, str_field, flow_document\n) FROM (\n\tSELECT $1[0] AS id, $1[1] AS array_int, $1[2] AS bool_field, $1[3] AS float_field, $1[4] AS flow_published_at, $1[5] AS multiple, $1[6] AS nested, $1[7] AS nullable_int, $1[8] AS str_field, $1[9] AS flow_document\n\tFROM <uuid>\n);\n",
           "StagedDir": "<uuid>",
           "Table": "multiple_types"
@@ -78,11 +83,15 @@
         "simple": {
           "PipeFiles": null,
           "PipeName": "",
+          "PipeStartTime": "",
           "Query": "\nCOPY INTO simple (\n\tid, canary, flow_published_at, flow_document\n) FROM (\n\tSELECT $1[0] AS id, $1[1] AS canary, $1[2] AS flow_published_at, $1[3] AS flow_document\n\tFROM <uuid>\n);\n",
           "StagedDir": "<uuid>",
           "Table": "simple"
         },
         "symbols": {
+          "PipeFiles": null,
+          "PipeName": "",
+          "PipeStartTime": "",
           "Query": "\nCOPY INTO symbols (\n\t\"testing (%s)\", flow_published_at, id, flow_document\n) FROM (\n\tSELECT $1[0] AS \"testing (%s)\", $1[1] AS flow_published_at, $1[2] AS id, $1[3] AS flow_document\n\tFROM <uuid>\n);\n",
           "StagedDir": "<uuid>",
           "Table": "symbols"
@@ -311,6 +320,7 @@
             }
           ],
           "PipeName": "MAHDI_DB.ESTUARY_SCHEMA.FLOW_PIPE_2_DUPLICATE_KEYS_DELTA",
+          "PipeStartTime: "<timestamp>",
           "Query": "",
           "StagedDir": "<uuid>",
           "Table": "duplicate_keys_delta"
@@ -327,6 +337,7 @@
             }
           ],
           "PipeName": "MAHDI_DB.ESTUARY_SCHEMA.FLOW_PIPE_3_DUPLICATE_KEYS_DELTA_EXCLUDE_FLOW_DOC",
+          "PipeStartTime: "<timestamp>",
           "Query": "",
           "StagedDir": "<uuid>",
           "Table": "duplicate_keys_delta_exclude_flow_doc"
@@ -334,6 +345,7 @@
         "duplicate_keys_standard": {
           "PipeFiles": null,
           "PipeName": "",
+          "PipeStartTime": "",
           "Query": "\nMERGE INTO duplicate_keys_standard AS l\nUSING (\n\tSELECT $1[0] AS id, $1[1] AS flow_published_at, $1[2] AS int, $1[3] AS str, $1[4] AS flow_document\n\tFROM <uuid>\n) AS r\nON l.id = r.id\nWHEN MATCHED AND IS_NULL_VALUE(r.flow_document) THEN\n\tDELETE\nWHEN MATCHED THEN\n\tUPDATE SET l.flow_published_at = r.flow_published_at, l.int = r.int, l.str = r.str, l.flow_document = r.flow_document\nWHEN NOT MATCHED THEN\n\tINSERT (id, flow_published_at, int, str, flow_document)\n\tVALUES (r.id, r.flow_published_at, r.int, r.str, r.flow_document);\n",
           "StagedDir": "<uuid>",
           "Table": "duplicate_keys_standard"
@@ -341,6 +353,7 @@
         "formatted_strings": {
           "PipeFiles": null,
           "PipeName": "",
+          "PipeStartTime": "",
           "Query": "\nCOPY INTO formatted_strings (\n\tid, date, datetime, flow_published_at, int_and_str, int_str, num_and_str, num_str, time, flow_document\n) FROM (\n\tSELECT $1[0] AS id, $1[1] AS date, $1[2] AS datetime, $1[3] AS flow_published_at, $1[4] AS int_and_str, $1[5] AS int_str, $1[6] AS num_and_str, $1[7] AS num_str, $1[8] AS time, $1[9] AS flow_document\n\tFROM <uuid>\n);\n",
           "StagedDir": "<uuid>",
           "Table": "formatted_strings"
@@ -348,6 +361,7 @@
         "multiple_types": {
           "PipeFiles": null,
           "PipeName": "",
+          "PipeStartTime": "",
           "Query": "\nMERGE INTO multiple_types AS l\nUSING (\n\tSELECT $1[0] AS id, $1[1] AS array_int, $1[2] AS bool_field, $1[3] AS float_field, $1[4] AS flow_published_at, $1[5] AS multiple, $1[6] AS nested, $1[7] AS nullable_int, $1[8] AS str_field, $1[9] AS flow_document\n\tFROM <uuid>\n) AS r\nON l.id = r.id\nWHEN MATCHED AND IS_NULL_VALUE(r.flow_document) THEN\n\tDELETE\nWHEN MATCHED THEN\n\tUPDATE SET l.array_int = r.array_int, l.bool_field = r.bool_field, l.float_field = r.float_field, l.flow_published_at = r.flow_published_at, l.multiple = r.multiple, l.nested = r.nested, l.nullable_int = r.nullable_int, l.str_field = r.str_field, l.flow_document = r.flow_document\nWHEN NOT MATCHED THEN\n\tINSERT (id, array_int, bool_field, float_field, flow_published_at, multiple, nested, nullable_int, str_field, flow_document)\n\tVALUES (r.id, r.array_int, r.bool_field, r.float_field, r.flow_published_at, r.multiple, r.nested, r.nullable_int, r.str_field, r.flow_document);\n",
           "StagedDir": "<uuid>",
           "Table": "multiple_types"
@@ -355,6 +369,7 @@
         "simple": {
           "PipeFiles": null,
           "PipeName": "",
+          "PipeStartTime": "",
           "Query": "\nCOPY INTO simple (\n\tid, canary, flow_published_at, flow_document\n) FROM (\n\tSELECT $1[0] AS id, $1[1] AS canary, $1[2] AS flow_published_at, $1[3] AS flow_document\n\tFROM <uuid>\n);\n",
           "StagedDir": "<uuid>",
           "Table": "simple"


### PR DESCRIPTION
**Description:**

- Support a new form of authentication using a username and a private key. We generate a JWT token and sign it using the private key to authenticate with Snowflake and Snowpipe REST API
- When using the JWT authentication mode, delta updates bindings are processed using Snowpipe
- Tested erroring out at the end of Acknowledge phase, and confirmed that we maintain idempotency by not replacing the pipe before sending requests again to the pipe.

One part that I still need to test: I need to test missing files again, I think given that snowpipe requires explicit specification of file names, it might break if we delete some files and then end up retrying those files. Need to verify

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1267)
<!-- Reviewable:end -->
