### PR TITLE
materialize-elasticsearch: allow materializing string values as keywords

### DIFF
--- a/materialize-boilerplate/apply.go
+++ b/materialize-boilerplate/apply.go
@@ -199,12 +199,12 @@ func ApplyChanges(ctx context.Context, req *pm.Request_Apply, applier Applier, i
 		}
 
 		if err := group.Wait(); err != nil {
-			return nil, err
+			return nil, fmt.Errorf("executing concurrent apply actions: %w", err)
 		}
 	} else {
 		for _, a := range actions {
 			if err := a(ctx); err != nil {
-				return nil, err
+				return nil, fmt.Errorf("executing apply actions: %w", err)
 			}
 		}
 	}

--- a/materialize-boilerplate/validate_test.go
+++ b/materialize-boilerplate/validate_test.go
@@ -523,8 +523,8 @@ func (testConstrainter) Compatible(existing EndpointField, proposed *pf.Projecti
 	return existing.Type == strings.Join(proposed.Inference.Types, ","), nil
 }
 
-func (testConstrainter) DescriptionForType(p *pf.Projection) string {
-	return strings.Join(p.Inference.Types, ", ")
+func (testConstrainter) DescriptionForType(p *pf.Projection, _ json.RawMessage) (string, error) {
+	return strings.Join(p.Inference.Types, ", "), nil
 }
 
 func (testConstrainter) NewConstraints(p *pf.Projection, deltaUpdates bool) *pm.Response_Validated_Constraint {

--- a/materialize-dynamodb/type_mapping.go
+++ b/materialize-dynamodb/type_mapping.go
@@ -221,7 +221,7 @@ func (constrainter) Compatible(existing boilerplate.EndpointField, proposed *pf.
 	return strings.EqualFold(existing.Type, string(mapType(proposed).ddbScalarType)), nil
 }
 
-func (constrainter) DescriptionForType(p *pf.Projection) string {
+func (constrainter) DescriptionForType(p *pf.Projection, _ json.RawMessage) (string, error) {
 	out := ""
 	switch t := mapType(p).ddbScalarType; t {
 	case types.ScalarAttributeTypeS:
@@ -232,7 +232,7 @@ func (constrainter) DescriptionForType(p *pf.Projection) string {
 		out = "binary"
 	}
 
-	return out
+	return out, nil
 }
 
 func infoSchema(ctx context.Context, db *dynamodb.Client, tableNames []string) (*boilerplate.InfoSchema, error) {

--- a/materialize-elasticsearch/driver.go
+++ b/materialize-elasticsearch/driver.go
@@ -468,7 +468,9 @@ func (d driver) NewTransactor(ctx context.Context, open pm.Request_Open) (m.Tran
 		fields := append(b.FieldSelection.Keys, b.FieldSelection.Values...)
 		floatFields := make([]bool, len(fields))
 		for idx := range fields {
-			if propForField(fields[idx], b).Type == elasticTypeDouble {
+			if prop, err := propForField(fields[idx], b); err != nil {
+				return nil, nil, fmt.Errorf("propForField in NewTransactor: %w", err)
+			} else if prop.Type == elasticTypeDouble {
 				floatFields[idx] = true
 			}
 		}

--- a/materialize-sql/type_mapping.go
+++ b/materialize-sql/type_mapping.go
@@ -533,7 +533,7 @@ func (c constrainter) Compatible(existing boilerplate.EndpointField, proposed *p
 	return c.dialect.ValidateColumn(existing, *p)
 }
 
-func (constrainter) DescriptionForType(p *pf.Projection) string {
+func (constrainter) DescriptionForType(p *pf.Projection, _ json.RawMessage) (string, error) {
 	desc := "[" + strings.Join(p.Inference.Types, ",") + "]"
 
 	if p.Inference.String_ != nil {
@@ -548,5 +548,5 @@ func (constrainter) DescriptionForType(p *pf.Projection) string {
 		}
 	}
 
-	return desc
+	return desc, nil
 }


### PR DESCRIPTION
**Description:**

Adds the option to materialize string values as keywords via the field configuration in field selection. Previously we would only materialize string fields as keywords if they were part of the collection key.

I had thought about doing more comprehensive validation on this to disallow setting the "keyword" field config value for non-string fields, but that was surprisingly difficult with the way the code is currently structured. This is going to be a pretty advanced feature currently since the only way to edit the field config is through the JSON of the spec, so it seems alright for now to keep it a little unpolished for the sake for expedience.

**Workflow steps:**

Use a spec like this to materialize a string value field `stringField` as a `keyword` mapping instead of a `text` mapping:

```json
{
  "bindings": [
    {
      "resource": {
        "index": "myIndex",
        "delta_updates": false
      },
      "source": "prefix/source/collection",
      "fields": {
        "include": {
          "stringField": {
            "keyword": true
          }
        },
        "recommended": true
      }
    }
  ]
}
```

**Documentation links affected:**

The `materialize-elasticsearch` docs should be updated according to this change, which I will do shortly.

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1268)
<!-- Reviewable:end -->
