### PR TITLE
materialize-sql: clamp integer values to math.MaxInt64 where needed

### DIFF
--- a/materialize-bigquery/sqlgen.go
+++ b/materialize-bigquery/sqlgen.go
@@ -60,7 +60,7 @@ var bqDialect = func() sql.Dialect {
 		sql.ARRAY:    sql.NewStaticMapper("STRING", sql.WithElementConverter(jsonConverter)),
 		sql.BINARY:   sql.NewStaticMapper("BYTES"),
 		sql.BOOLEAN:  sql.NewStaticMapper("BOOL"),
-		sql.INTEGER:  sql.NewStaticMapper("INT64"),
+		sql.INTEGER:  sql.NewStaticMapper("INT64", sql.WithElementConverter(sql.ClampInt64())),
 		sql.NUMBER:   sql.NewStaticMapper("FLOAT64"),
 		sql.OBJECT:   sql.NewStaticMapper("STRING", sql.WithElementConverter(jsonConverter)),
 		sql.MULTIPLE: sql.NewStaticMapper("JSON", sql.WithElementConverter(sql.JsonBytesConverter)),

--- a/materialize-databricks/sqlgen.go
+++ b/materialize-databricks/sqlgen.go
@@ -55,7 +55,7 @@ var databricksDialect = func() sql.Dialect {
 		sql.ARRAY:    jsonMapper,
 		sql.BINARY:   sql.NewStaticMapper("BINARY"),
 		sql.BOOLEAN:  sql.NewStaticMapper("BOOLEAN"),
-		sql.INTEGER:  sql.NewStaticMapper("BIGINT"),
+		sql.INTEGER:  sql.NewStaticMapper("BIGINT", sql.WithElementConverter(sql.ClampInt64())),
 		sql.NUMBER:   sql.NewStaticMapper("DOUBLE"),
 		sql.OBJECT:   jsonMapper,
 		sql.MULTIPLE: jsonMapper,

--- a/materialize-motherduck/sqlgen.go
+++ b/materialize-motherduck/sqlgen.go
@@ -9,7 +9,7 @@ import (
 
 var duckDialect = func() sql.Dialect {
 	var mapper sql.TypeMapper = sql.ProjectionTypeMapper{
-		sql.INTEGER:  sql.NewStaticMapper("BIGINT"),
+		sql.INTEGER:  sql.NewStaticMapper("BIGINT", sql.WithElementConverter(sql.ClampInt64())),
 		sql.NUMBER:   sql.NewStaticMapper("DOUBLE"),
 		sql.BOOLEAN:  sql.NewStaticMapper("BOOLEAN"),
 		sql.OBJECT:   sql.NewStaticMapper("JSON", sql.WithElementConverter(sql.JsonBytesConverter)),

--- a/materialize-postgres/sqlgen.go
+++ b/materialize-postgres/sqlgen.go
@@ -11,7 +11,7 @@ import (
 
 var pgDialect = func() sql.Dialect {
 	var mapper sql.TypeMapper = sql.ProjectionTypeMapper{
-		sql.INTEGER:  sql.NewStaticMapper("BIGINT"),
+		sql.INTEGER:  sql.NewStaticMapper("BIGINT", sql.WithElementConverter(sql.ClampInt64())),
 		sql.NUMBER:   sql.NewStaticMapper("DOUBLE PRECISION"),
 		sql.BOOLEAN:  sql.NewStaticMapper("BOOLEAN"),
 		sql.OBJECT:   sql.NewStaticMapper("JSON"),

--- a/materialize-redshift/sqlgen.go
+++ b/materialize-redshift/sqlgen.go
@@ -36,7 +36,7 @@ var rsDialect = func() sql.Dialect {
 	}
 
 	var mapper sql.TypeMapper = sql.ProjectionTypeMapper{
-		sql.INTEGER:  sql.NewStaticMapper("BIGINT"),
+		sql.INTEGER:  sql.NewStaticMapper("BIGINT", sql.WithElementConverter(sql.ClampInt64())),
 		sql.NUMBER:   sql.NewStaticMapper("DOUBLE PRECISION"),
 		sql.BOOLEAN:  sql.NewStaticMapper("BOOLEAN"),
 		sql.OBJECT:   sql.NewStaticMapper("SUPER", sql.WithElementConverter(sql.JsonBytesConverter)),

--- a/materialize-sql/type_mapping.go
+++ b/materialize-sql/type_mapping.go
@@ -3,6 +3,7 @@ package sql
 import (
 	"encoding/json"
 	"fmt"
+	"math"
 	"math/big"
 	"slices"
 	"strconv"
@@ -329,6 +330,19 @@ func ClampDate() ElementConverter {
 		}
 		return str, nil
 	})
+}
+
+// ClampInteger restricts values from JSON "integer" fields to the range of an int64 for systems
+// that do not allow values larger than that.
+func ClampInt64() ElementConverter {
+	return func(te tuple.TupleElement) (interface{}, error) {
+		switch te.(type) {
+		case uint64, *big.Int, float64:
+			return math.MaxInt64, nil
+		default:
+			return te, nil
+		}
+	}
 }
 
 // NullableMapper wraps a ColumnMapper to add "NULL" and/or "NOT NULL" to the generated SQL type

--- a/materialize-sqlserver/sqlgen.go
+++ b/materialize-sqlserver/sqlgen.go
@@ -52,7 +52,7 @@ var sqlServerDialect = func(collation string, schemaName string) sql.Dialect {
 	var jsonConverter = sql.WithElementConverter(sql.Compose(sql.StdByteArrayToStr, sql.JsonBytesConverter))
 
 	var mapper sql.TypeMapper = sql.ProjectionTypeMapper{
-		sql.INTEGER: sql.NewStaticMapper("BIGINT"),
+		sql.INTEGER: sql.NewStaticMapper("BIGINT", sql.WithElementConverter(sql.ClampInt64())),
 		sql.NUMBER:  sql.NewStaticMapper("DOUBLE PRECISION"),
 		sql.BOOLEAN: sql.NewStaticMapper("BIT"),
 		sql.OBJECT:  sql.NewStaticMapper(textType, jsonConverter),

--- a/materialize-starburst/sqlgen.go
+++ b/materialize-starburst/sqlgen.go
@@ -46,7 +46,7 @@ var starburstDialect = func() sql.Dialect {
 		sql.ARRAY:    sql.NewStaticMapper("VARCHAR", sql.WithElementConverter(jsonConverter)),
 		sql.BINARY:   sql.NewStaticMapper("VARBINARY"),
 		sql.BOOLEAN:  sql.NewStaticMapper("BOOLEAN"),
-		sql.INTEGER:  sql.NewStaticMapper("BIGINT"),
+		sql.INTEGER:  sql.NewStaticMapper("BIGINT", sql.WithElementConverter(sql.ClampInt64())),
 		sql.NUMBER:   sql.NewStaticMapper("DOUBLE", sql.WithElementConverter(doubleConverter)),
 		sql.OBJECT:   sql.NewStaticMapper("VARCHAR", sql.WithElementConverter(jsonConverter)),
 		sql.MULTIPLE: sql.NewStaticMapper("VARCHAR", sql.WithElementConverter(jsonConverter)),


### PR DESCRIPTION
**Description:**

JSON schemas do not enforce a maximum value for integer types, but many destination systems can only store a maximum of math.MaxInt64 in their "integer" types of columns.

It's not generally desirable to create other types of columns (e.g. FLOAT) just to support these rare very large integers, so instead provide a way for selected materializations to clamp very large integers to math.MaxInt64.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1279)
<!-- Reviewable:end -->
