### PR TITLE
source-{mysql,postgres,redshift}-batch: Schema filtering

### DIFF
--- a/source-mysql-batch/.snapshots/TestSpec
+++ b/source-mysql-batch/.snapshots/TestSpec
@@ -29,6 +29,14 @@
             "description": "When and how often to execute fetch queries. Accepts a Go duration string like '5m' or '6h' for frequency-based polling or a string like 'daily at 12:34Z' to poll at a specific time (specified in UTC) every day. Defaults to '24h' if unset.",
             "pattern": "^([-+]?([0-9]+([.][0-9]+)?(h|m|s|ms))+|daily at [0-9][0-9]?:[0-9]{2}Z)$"
           },
+          "discover_schemas": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Discovery Schema Selection",
+            "description": "If this is specified only tables in the selected schema(s) will be automatically discovered. Omit all entries to discover tables from all schemas."
+          },
           "dbname": {
             "type": "string",
             "title": "Database Name",

--- a/source-mysql-batch/driver.go
+++ b/source-mysql-batch/driver.go
@@ -173,7 +173,7 @@ func (drv *BatchSQLDriver) Discover(ctx context.Context, req *pc.Request_Discove
 	}
 	defer db.Close()
 
-	tables, err := discoverTables(ctx, db)
+	tables, err := discoverTables(ctx, db, cfg.Advanced.DiscoverSchemas)
 	if err != nil {
 		return nil, fmt.Errorf("error listing tables: %w", err)
 	}
@@ -261,7 +261,7 @@ type discoveredTable struct {
 	Type   string // Usually 'BASE TABLE' or 'VIEW'
 }
 
-func discoverTables(ctx context.Context, db *client.Conn) ([]*discoveredTable, error) {
+func discoverTables(ctx context.Context, db *client.Conn, discoverSchemas []string) ([]*discoveredTable, error) {
 	var results, err = db.Execute(queryDiscoverTables)
 	if err != nil {
 		return nil, fmt.Errorf("error discovering tables: %w", err)
@@ -270,10 +270,18 @@ func discoverTables(ctx context.Context, db *client.Conn) ([]*discoveredTable, e
 
 	var tables []*discoveredTable
 	for _, row := range results.Values {
+		var tableSchema = string(row[0].AsString())
+		var tableName = string(row[1].AsString())
+		var tableType = string(row[2].AsString())
+
+		if len(discoverSchemas) > 0 && !slices.Contains(discoverSchemas, tableSchema) {
+			log.WithFields(log.Fields{"schema": tableSchema, "table": tableName}).Debug("ignoring table")
+			continue
+		}
 		tables = append(tables, &discoveredTable{
-			Schema: string(row[0].AsString()),
-			Name:   string(row[1].AsString()),
-			Type:   string(row[2].AsString()),
+			Schema: tableSchema,
+			Name:   tableName,
+			Type:   tableType,
 		})
 	}
 	return tables, nil

--- a/source-mysql-batch/main.go
+++ b/source-mysql-batch/main.go
@@ -27,8 +27,9 @@ type Config struct {
 }
 
 type advancedConfig struct {
-	PollSchedule string `json:"poll,omitempty" jsonschema:"title=Default Polling Schedule,description=When and how often to execute fetch queries. Accepts a Go duration string like '5m' or '6h' for frequency-based polling or a string like 'daily at 12:34Z' to poll at a specific time (specified in UTC) every day. Defaults to '24h' if unset." jsonschema_extras:"pattern=^([-+]?([0-9]+([.][0-9]+)?(h|m|s|ms))+|daily at [0-9][0-9]?:[0-9]{2}Z)$"`
-	DBName       string `json:"dbname,omitempty" jsonschema:"title=Database Name,description=The name of database to connect to. In general this shouldn't matter. The connector can discover and capture from all databases it's authorized to access."`
+	PollSchedule    string   `json:"poll,omitempty" jsonschema:"title=Default Polling Schedule,description=When and how often to execute fetch queries. Accepts a Go duration string like '5m' or '6h' for frequency-based polling or a string like 'daily at 12:34Z' to poll at a specific time (specified in UTC) every day. Defaults to '24h' if unset." jsonschema_extras:"pattern=^([-+]?([0-9]+([.][0-9]+)?(h|m|s|ms))+|daily at [0-9][0-9]?:[0-9]{2}Z)$"`
+	DiscoverSchemas []string `json:"discover_schemas,omitempty" jsonschema:"title=Discovery Schema Selection,description=If this is specified only tables in the selected schema(s) will be automatically discovered. Omit all entries to discover tables from all schemas."`
+	DBName          string   `json:"dbname,omitempty" jsonschema:"title=Database Name,description=The name of database to connect to. In general this shouldn't matter. The connector can discover and capture from all databases it's authorized to access."`
 }
 
 // Validate checks that the configuration possesses all required properties.

--- a/source-postgres-batch/.snapshots/TestSpec
+++ b/source-postgres-batch/.snapshots/TestSpec
@@ -35,6 +35,14 @@
             "description": "When and how often to execute fetch queries. Accepts a Go duration string like '5m' or '6h' for frequency-based polling or a string like 'daily at 12:34Z' to poll at a specific time (specified in UTC) every day. Defaults to '5m' if unset.",
             "pattern": "^([-+]?([0-9]+([.][0-9]+)?(h|m|s|ms))+|daily at [0-9][0-9]?:[0-9]{2}Z)$"
           },
+          "discover_schemas": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Discovery Schema Selection",
+            "description": "If this is specified only tables in the selected schema(s) will be automatically discovered. Omit all entries to discover tables from all schemas."
+          },
           "sslmode": {
             "type": "string",
             "enum": [

--- a/source-postgres-batch/main.go
+++ b/source-postgres-batch/main.go
@@ -27,8 +27,9 @@ type Config struct {
 }
 
 type advancedConfig struct {
-	PollSchedule string `json:"poll,omitempty" jsonschema:"title=Default Polling Schedule,description=When and how often to execute fetch queries. Accepts a Go duration string like '5m' or '6h' for frequency-based polling or a string like 'daily at 12:34Z' to poll at a specific time (specified in UTC) every day. Defaults to '5m' if unset." jsonschema_extras:"pattern=^([-+]?([0-9]+([.][0-9]+)?(h|m|s|ms))+|daily at [0-9][0-9]?:[0-9]{2}Z)$"`
-	SSLMode      string `json:"sslmode,omitempty" jsonschema:"title=SSL Mode,description=Overrides SSL connection behavior by setting the 'sslmode' parameter.,enum=disable,enum=allow,enum=prefer,enum=require,enum=verify-ca,enum=verify-full"`
+	PollSchedule    string   `json:"poll,omitempty" jsonschema:"title=Default Polling Schedule,description=When and how often to execute fetch queries. Accepts a Go duration string like '5m' or '6h' for frequency-based polling or a string like 'daily at 12:34Z' to poll at a specific time (specified in UTC) every day. Defaults to '5m' if unset." jsonschema_extras:"pattern=^([-+]?([0-9]+([.][0-9]+)?(h|m|s|ms))+|daily at [0-9][0-9]?:[0-9]{2}Z)$"`
+	DiscoverSchemas []string `json:"discover_schemas,omitempty" jsonschema:"title=Discovery Schema Selection,description=If this is specified only tables in the selected schema(s) will be automatically discovered. Omit all entries to discover tables from all schemas."`
+	SSLMode         string   `json:"sslmode,omitempty" jsonschema:"title=SSL Mode,description=Overrides SSL connection behavior by setting the 'sslmode' parameter.,enum=disable,enum=allow,enum=prefer,enum=require,enum=verify-ca,enum=verify-full"`
 }
 
 // Validate checks that the configuration possesses all required properties.

--- a/source-redshift-batch/.snapshots/TestSpec
+++ b/source-redshift-batch/.snapshots/TestSpec
@@ -35,6 +35,14 @@
             "description": "When and how often to execute fetch queries. Accepts a Go duration string like '5m' or '6h' for frequency-based polling or a string like 'daily at 12:34Z' to poll at a specific time (specified in UTC) every day. Defaults to '24h' if unset.",
             "pattern": "^([-+]?([0-9]+([.][0-9]+)?(h|m|s|ms))+|daily at [0-9][0-9]?:[0-9]{2}Z)$"
           },
+          "discover_schemas": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Discovery Schema Selection",
+            "description": "If this is specified only tables in the selected schema(s) will be automatically discovered. Omit all entries to discover tables from all schemas."
+          },
           "sslmode": {
             "type": "string",
             "enum": [

--- a/source-redshift-batch/driver.go
+++ b/source-redshift-batch/driver.go
@@ -182,7 +182,7 @@ func (drv *BatchSQLDriver) Discover(ctx context.Context, req *pc.Request_Discove
 	}
 	defer db.Close()
 
-	tables, err := discoverTables(ctx, db)
+	tables, err := discoverTables(ctx, db, cfg.Advanced.DiscoverSchemas)
 	if err != nil {
 		return nil, fmt.Errorf("error listing tables: %w", err)
 	}
@@ -270,7 +270,7 @@ type discoveredTable struct {
 	Type   string // Usually 'BASE TABLE' or 'VIEW'
 }
 
-func discoverTables(ctx context.Context, db *sql.DB) ([]*discoveredTable, error) {
+func discoverTables(ctx context.Context, db *sql.DB, discoverSchemas []string) ([]*discoveredTable, error) {
 	rows, err := db.QueryContext(ctx, queryDiscoverTables)
 	if err != nil {
 		return nil, fmt.Errorf("error executing discovery query: %w", err)
@@ -284,6 +284,10 @@ func discoverTables(ctx context.Context, db *sql.DB) ([]*discoveredTable, error)
 			return nil, fmt.Errorf("error scanning result row: %w", err)
 		}
 
+		if len(discoverSchemas) > 0 && !slices.Contains(discoverSchemas, tableSchema) {
+			log.WithFields(log.Fields{"schema": tableSchema, "table": tableName}).Debug("ignoring table")
+			continue
+		}
 		tables = append(tables, &discoveredTable{
 			Schema: tableSchema,
 			Name:   tableName,

--- a/source-redshift-batch/main.go
+++ b/source-redshift-batch/main.go
@@ -27,8 +27,9 @@ type Config struct {
 }
 
 type advancedConfig struct {
-	PollSchedule string `json:"poll,omitempty" jsonschema:"title=Default Polling Schedule,description=When and how often to execute fetch queries. Accepts a Go duration string like '5m' or '6h' for frequency-based polling or a string like 'daily at 12:34Z' to poll at a specific time (specified in UTC) every day. Defaults to '24h' if unset." jsonschema_extras:"pattern=^([-+]?([0-9]+([.][0-9]+)?(h|m|s|ms))+|daily at [0-9][0-9]?:[0-9]{2}Z)$"`
-	SSLMode      string `json:"sslmode,omitempty" jsonschema:"title=SSL Mode,description=Overrides SSL connection behavior by setting the 'sslmode' parameter.,enum=disable,enum=allow,enum=prefer,enum=require,enum=verify-ca,enum=verify-full"`
+	PollSchedule    string   `json:"poll,omitempty" jsonschema:"title=Default Polling Schedule,description=When and how often to execute fetch queries. Accepts a Go duration string like '5m' or '6h' for frequency-based polling or a string like 'daily at 12:34Z' to poll at a specific time (specified in UTC) every day. Defaults to '24h' if unset." jsonschema_extras:"pattern=^([-+]?([0-9]+([.][0-9]+)?(h|m|s|ms))+|daily at [0-9][0-9]?:[0-9]{2}Z)$"`
+	DiscoverSchemas []string `json:"discover_schemas,omitempty" jsonschema:"title=Discovery Schema Selection,description=If this is specified only tables in the selected schema(s) will be automatically discovered. Omit all entries to discover tables from all schemas."`
+	SSLMode         string   `json:"sslmode,omitempty" jsonschema:"title=SSL Mode,description=Overrides SSL connection behavior by setting the 'sslmode' parameter.,enum=disable,enum=allow,enum=prefer,enum=require,enum=verify-ca,enum=verify-full"`
 }
 
 // Validate checks that the configuration possesses all required properties.


### PR DESCRIPTION
**Description:**

Adds a new advanced config property for specifying a list of schemas to discover tables within.

If the property is unset then tables all schemas will still be discovered. If one or more values are specified for this property then only tables from those schemas will be returned and everything else will be ignored.

Note that the discovery queries still fetch information about all tables in the entire database and the filtering is applied within the connector to the query results. In general this should be fine, but if it becomes an issue in the future it should be possible to push down the logic into `WHERE` clauses in the discovery queries themselves.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1290)
<!-- Reviewable:end -->
