### PR TITLE
source-mysql: Ignore RowsQueryEvents

### DIFF
--- a/source-mysql/replication.go
+++ b/source-mysql/replication.go
@@ -419,6 +419,8 @@ func (rs *mysqlReplicationStream) run(ctx context.Context) error {
 			} else {
 				logrus.WithField("event", event.Header.EventType.String()).Debug("Generic Event")
 			}
+		case *replication.RowsQueryEvent:
+			logrus.WithField("query", string(data.Query)).Debug("ignoring Rows Query Event")
 		default:
 			return fmt.Errorf("unhandled event type: %q", event.Header.EventType)
 		}


### PR DESCRIPTION
**Description:**

These appear to be ignorable metadata which we don't need to do anything with.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1294)
<!-- Reviewable:end -->
