### PR TITLE
Fixing source-hubspot for long duration captures

### DIFF
--- a/source-hubspot/source_hubspot/streams.py
+++ b/source-hubspot/source_hubspot/streams.py
@@ -206,8 +206,8 @@ class API:
 
         return response.json()
 
-    @retry_connection_handler(max_tries=5, factor=5)
-    @retry_after_handler(max_tries=3)
+    @retry_connection_handler(max_tries=10, factor=5)
+    @retry_after_handler(max_tries=5)
     def get(
         self, url: str, params: MutableMapping[str, Any] = None
     ) -> Tuple[Union[MutableMapping[str, Any], List[MutableMapping[str, Any]]], requests.Response]:
@@ -367,11 +367,8 @@ class Stream(HttpStream, ABC):
             json_schema["properties"]["properties"] = {"type": "object", "properties": self.properties}
         return json_schema
 
-    # This 401 retry handler is only there to handle the case that
-    # a token expires in flight. As such, it should only need to
-    # retry a single time at most. Any additional failures are real
-    # and should be bubbled up as such.
-    @retry_401(max_tries=5)
+
+    @retry_401(max_tries=20)
     def handle_request(
         self,
         stream_slice: Mapping[str, Any] = None,
@@ -1328,6 +1325,7 @@ class ContactsListMemberships(Stream):
     ) -> MutableMapping[str, Any]:
         params = super().request_params(stream_state=stream_state, stream_slice=stream_slice, next_page_token=next_page_token)
         params.update({"showListMemberships": True})
+        params.update({"count": 100})
         return params
 
 


### PR DESCRIPTION
**Description:**
When running long duration captures in source-hubspot, a issue might occur where a new `ACCESS_TOKEN` has not yet refreshed, triggering a backoff.

The maximun try value set for this backoff is 5. Given that this can occur multiple times on a long duration stream, this PR aims to fix this by upgrading the backoff max value to 20.

**Tests**
Two tests were made on `contacts_lists_membership` stream:

1. The first one consisted on lowering the backoff max_try value to 1 ( forcing the issue to be raised ). This happened two hours after the stream initialization.

1. The second one consisted on raising the max_try value to 5 ( default ). Two backoffs were triggered: the first after 3 hours and the second after 6 hours after the stream initialization. Prints:

![Screenshot from 2024-02-29 03-56-07](https://github.com/estuary/connectors/assets/14100959/ed62da73-4fda-43e5-a69a-90173ae129f5)

To my knowledge, the standard duration of a `ACCESS_TOKEN` is 30 minutes. Given the time proximity between both backoffs triggers, this might be caused by a pattern. Given the priority of this task and the amount of time necessary to efectivly test, no pattern search was conducted.

**Documentation links affected:**
This PR lead to [the modification](https://github.com/estuary/flow/pull/1399) of Hubspot.md connector docs. 

**Notes for reviewers:**
Tests were made using Estuary dashboard, on a Hubspot > SnowflakeDB pipeline, to guarantee materialization of this stream. No issues were found.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1295)
<!-- Reviewable:end -->
