### PR TITLE
source-*-batch: No longer run discovery during Validate

### DIFF
--- a/source-bigquery-batch/main.go
+++ b/source-bigquery-batch/main.go
@@ -83,7 +83,22 @@ func connectBigQuery(ctx context.Context, cfg *Config) (*bigquery.Client, error)
 	if err != nil {
 		return nil, fmt.Errorf("creating bigquery client: %w", err)
 	}
+
+	if err := executeQuery(ctx, client, "SELECT true;"); err != nil {
+		return nil, fmt.Errorf("error executing no-op query: %w", err)
+	}
 	return client, nil
+}
+
+func executeQuery(ctx context.Context, client *bigquery.Client, query string) error {
+	if job, err := client.Query(query).Run(ctx); err != nil {
+		return err
+	} else if js, err := job.Wait(ctx); err != nil {
+		return err
+	} else if js.Err() != nil {
+		return js.Err()
+	}
+	return nil
 }
 
 const tableQueryTemplateTemplate = `{{/* Default query template which adapts to cursor field selection */}}

--- a/source-mysql-batch/driver.go
+++ b/source-mysql-batch/driver.go
@@ -383,14 +383,18 @@ func recommendedCatalogName(schema, table string) string {
 // Validate checks that the configuration appears correct and that we can connect
 // to the database and execute queries.
 func (drv *BatchSQLDriver) Validate(ctx context.Context, req *pc.Request_Validate) (*pc.Response_Validated, error) {
-	// Perform discovery, which inherently validates that the config is well-formed
-	// and that we can connect to the database and execute (some) queries.
-	if _, err := drv.Discover(ctx, &pc.Request_Discover{
-		ConnectorType: req.ConnectorType,
-		ConfigJson:    req.ConfigJson,
-	}); err != nil {
+	// Unmarshal the configuration and verify that we can connect to the database
+	var cfg Config
+	if err := pf.UnmarshalStrict(req.ConfigJson, &cfg); err != nil {
+		return nil, fmt.Errorf("parsing endpoint config: %w", err)
+	}
+	cfg.SetDefaults()
+
+	var db, err = drv.Connect(ctx, &cfg)
+	if err != nil {
 		return nil, err
 	}
+	defer db.Close()
 
 	// Unmarshal and validate resource bindings to make sure they're well-formed too.
 	var out []*pc.Response_Validated_Binding

--- a/source-mysql-batch/main.go
+++ b/source-mysql-batch/main.go
@@ -91,6 +91,10 @@ func connectMySQL(ctx context.Context, cfg *Config) (*client.Conn, error) {
 	} else {
 		return nil, fmt.Errorf("unable to connect to database: %w", err)
 	}
+
+	if _, err := conn.Execute("SELECT true;"); err != nil {
+		return nil, fmt.Errorf("error executing no-op query: %w", err)
+	}
 	return conn, nil
 }
 

--- a/source-postgres-batch/driver.go
+++ b/source-postgres-batch/driver.go
@@ -391,14 +391,18 @@ func recommendedCatalogName(schema, table string) string {
 // Validate checks that the configuration appears correct and that we can connect
 // to the database and execute queries.
 func (drv *BatchSQLDriver) Validate(ctx context.Context, req *pc.Request_Validate) (*pc.Response_Validated, error) {
-	// Perform discovery, which inherently validates that the config is well-formed
-	// and that we can connect to the database and execute (some) queries.
-	if _, err := drv.Discover(ctx, &pc.Request_Discover{
-		ConnectorType: req.ConnectorType,
-		ConfigJson:    req.ConfigJson,
-	}); err != nil {
+	// Unmarshal the configuration and verify that we can connect to the database
+	var cfg Config
+	if err := pf.UnmarshalStrict(req.ConfigJson, &cfg); err != nil {
+		return nil, fmt.Errorf("parsing endpoint config: %w", err)
+	}
+	cfg.SetDefaults()
+
+	var db, err = drv.Connect(ctx, &cfg)
+	if err != nil {
 		return nil, err
 	}
+	defer db.Close()
 
 	// Unmarshal and validate resource bindings to make sure they're well-formed too.
 	var out []*pc.Response_Validated_Binding

--- a/source-postgres-batch/main.go
+++ b/source-postgres-batch/main.go
@@ -99,6 +99,8 @@ func connectPostgres(ctx context.Context, cfg *Config) (*sql.DB, error) {
 		return nil, fmt.Errorf("error opening database connection: %w", err)
 	} else if err := db.PingContext(ctx); err != nil {
 		return nil, fmt.Errorf("error pinging database: %w", err)
+	} else if _, err := db.ExecContext(ctx, "SELECT true;"); err != nil {
+		return nil, fmt.Errorf("error executing no-op query: %w", err)
 	}
 	return db, nil
 }

--- a/source-redshift-batch/driver.go
+++ b/source-redshift-batch/driver.go
@@ -395,14 +395,18 @@ func recommendedCatalogName(schema, table string) string {
 // Validate checks that the configuration appears correct and that we can connect
 // to the database and execute queries.
 func (drv *BatchSQLDriver) Validate(ctx context.Context, req *pc.Request_Validate) (*pc.Response_Validated, error) {
-	// Perform discovery, which inherently validates that the config is well-formed
-	// and that we can connect to the database and execute (some) queries.
-	if _, err := drv.Discover(ctx, &pc.Request_Discover{
-		ConnectorType: req.ConnectorType,
-		ConfigJson:    req.ConfigJson,
-	}); err != nil {
+	// Unmarshal the configuration and verify that we can connect to the database
+	var cfg Config
+	if err := pf.UnmarshalStrict(req.ConfigJson, &cfg); err != nil {
+		return nil, fmt.Errorf("parsing endpoint config: %w", err)
+	}
+	cfg.SetDefaults()
+
+	var db, err = drv.Connect(ctx, &cfg)
+	if err != nil {
 		return nil, err
 	}
+	defer db.Close()
 
 	// Unmarshal and validate resource bindings to make sure they're well-formed too.
 	var out []*pc.Response_Validated_Binding

--- a/source-redshift-batch/main.go
+++ b/source-redshift-batch/main.go
@@ -99,6 +99,8 @@ func connectRedshift(ctx context.Context, cfg *Config) (*sql.DB, error) {
 		return nil, fmt.Errorf("error opening database connection: %w", err)
 	} else if err := db.PingContext(ctx); err != nil {
 		return nil, fmt.Errorf("error pinging database: %w", err)
+	} else if _, err := db.ExecContext(ctx, "SELECT true;"); err != nil {
+		return nil, fmt.Errorf("error executing no-op query: %w", err)
 	}
 	return db, nil
 }


### PR DESCRIPTION
**Description:**

I have reason to believe that running discovery is causing publication failures for at least one user whose database has a lot of stuff in it, and there's no strong need to run the full discovery process as part of validation -- it was just an easy-to-implement way of getting a bunch of sanity checking done all at once.

So the call to `Discover()` is removed, in favor of merely parsing the config and connecting to the database. The database connect function has been modified in each connector so that it now runs a no-op `SELECT true;` query, to make sure that we don't introduce some sort of subtle failure mode where validation passes but the user doesn't actually have the ability to execute queries at all.
