### PR TITLE
source-*-batch: Specify resource name when polling fails

### DIFF
--- a/source-bigquery-batch/driver.go
+++ b/source-bigquery-batch/driver.go
@@ -586,7 +586,7 @@ func (c *capture) worker(ctx context.Context, binding *bindingInfo) error {
 
 	for ctx.Err() == nil {
 		if err := c.poll(ctx, binding, queryTemplate); err != nil {
-			return fmt.Errorf("error polling table: %w", err)
+			return fmt.Errorf("error polling binding %q: %w", res.Name, err)
 		}
 	}
 	return ctx.Err()

--- a/source-mysql-batch/driver.go
+++ b/source-mysql-batch/driver.go
@@ -596,7 +596,7 @@ func (c *capture) worker(ctx context.Context, binding *bindingInfo) error {
 
 	for ctx.Err() == nil {
 		if err := c.poll(ctx, binding, queryTemplate); err != nil {
-			return fmt.Errorf("error polling table: %w", err)
+			return fmt.Errorf("error polling binding %q: %w", res.Name, err)
 		}
 	}
 	return ctx.Err()

--- a/source-postgres-batch/driver.go
+++ b/source-postgres-batch/driver.go
@@ -611,7 +611,7 @@ func (c *capture) worker(ctx context.Context, binding *bindingInfo) error {
 
 	for ctx.Err() == nil {
 		if err := c.poll(ctx, binding, queryTemplate); err != nil {
-			return fmt.Errorf("error polling table: %w", err)
+			return fmt.Errorf("error polling binding %q: %w", res.Name, err)
 		}
 	}
 	return ctx.Err()

--- a/source-redshift-batch/driver.go
+++ b/source-redshift-batch/driver.go
@@ -615,7 +615,7 @@ func (c *capture) worker(ctx context.Context, binding *bindingInfo) error {
 
 	for ctx.Err() == nil {
 		if err := c.poll(ctx, binding, queryTemplate); err != nil {
-			return fmt.Errorf("error polling table: %w", err)
+			return fmt.Errorf("error polling binding %q: %w", res.Name, err)
 		}
 	}
 	return ctx.Err()


### PR DESCRIPTION
**Description:**

Previously we would emit very unhelpful error messages like:

    error polling table: error executing query: expected 0 arguments, got 1

After this change that would instead be:

    error polling binding "foo_bar": error executing query: expected 0 arguments, got 1

Which makes it a lot easier to go and fix the problem.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1299)
<!-- Reviewable:end -->
