### PR TITLE
source-bigquery-batch: Translate NaN to `"NaN"`

### DIFF
--- a/source-bigquery-batch/main.go
+++ b/source-bigquery-batch/main.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"math"
 	"strings"
 
 	"cloud.google.com/go/bigquery"
@@ -66,6 +67,10 @@ func translateBigQueryValue(val any, fieldType bigquery.FieldType) (any, error) 
 	case string:
 		if fieldType == "JSON" && json.Valid([]byte(val)) {
 			return json.RawMessage([]byte(val)), nil
+		}
+	case float64:
+		if math.IsNaN(val) {
+			return "NaN", nil
 		}
 	}
 	return val, nil


### PR DESCRIPTION
**Description:**

Unlike most SQL databases BigQuery allows NaNs to be stored into a floating-point column. The Go JSON serializer rejects NaNs, as they're not actually representable as JSON numbers.

There's no strictly right answer here, but in the past (see for instance `source-firestore`) we've mapped NaN floats to the string `"NaN"` in captures, so let's do that here too.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1300)
<!-- Reviewable:end -->
