### PR TITLE
materialize-databricks: use PUT api for uploading files

### DIFF
--- a/materialize-databricks/driver.go
+++ b/materialize-databricks/driver.go
@@ -241,8 +241,8 @@ func (t *transactor) addBinding(ctx context.Context, target sql.Table, _range *p
 		return out
 	}
 
-	b.loadFile = newStagedFile(t.store.conn, b.rootStagingPath, translatedFieldNames(target.KeyNames()))
-	b.storeFile = newStagedFile(t.store.conn, b.rootStagingPath, translatedFieldNames(target.ColumnNames()))
+	b.loadFile = newStagedFile(t.cfg, b.rootStagingPath, translatedFieldNames(target.KeyNames()))
+	b.storeFile = newStagedFile(t.cfg, b.rootStagingPath, translatedFieldNames(target.ColumnNames()))
 
 	t.bindings = append(t.bindings, b)
 

--- a/materialize-databricks/driver.go
+++ b/materialize-databricks/driver.go
@@ -246,8 +246,8 @@ func (t *transactor) addBinding(ctx context.Context, target sql.Table, _range *p
 		return out
 	}
 
-	b.loadFile = newStagedFile(t.wsClient.Files, b.rootStagingPath, translatedFieldNames(target.KeyNames()))
-	b.storeFile = newStagedFile(t.wsClient.Files, b.rootStagingPath, translatedFieldNames(target.ColumnNames()))
+	b.loadFile = newStagedFile(t.store.conn, b.rootStagingPath, translatedFieldNames(target.KeyNames()))
+	b.storeFile = newStagedFile(t.store.conn, b.rootStagingPath, translatedFieldNames(target.ColumnNames()))
 
 	t.bindings = append(t.bindings, b)
 

--- a/materialize-databricks/driver.go
+++ b/materialize-databricks/driver.go
@@ -15,7 +15,6 @@ import (
 	"github.com/databricks/databricks-sdk-go"
 	dbConfig "github.com/databricks/databricks-sdk-go/config"
 	"github.com/databricks/databricks-sdk-go/logger"
-	driverctx "github.com/databricks/databricks-sql-go/driverctx"
 	dbsqllog "github.com/databricks/databricks-sql-go/logger"
 	m "github.com/estuary/connectors/go/protocols/materialize"
 	boilerplate "github.com/estuary/connectors/materialize-boilerplate"
@@ -125,10 +124,6 @@ type transactor struct {
 	bindings []*binding
 
 	updateDelay time.Duration
-}
-
-func (t *transactor) Context(ctx context.Context) context.Context {
-	return driverctx.NewContextWithStagingInfo(ctx, []string{t.localStagingPath})
 }
 
 func (d *transactor) UnmarshalState(state json.RawMessage) error {
@@ -259,7 +254,7 @@ func (t *transactor) AckDelay() time.Duration {
 }
 
 func (d *transactor) Load(it *m.LoadIterator, loaded func(int, json.RawMessage) error) error {
-	var ctx = d.Context(it.Context())
+	var ctx = it.Context()
 
 	log.Info("load: starting upload and copying of files")
 	for it.Next() {

--- a/materialize-databricks/staged_file.go
+++ b/materialize-databricks/staged_file.go
@@ -194,7 +194,7 @@ func (f *stagedFile) putWorker(ctx context.Context, filePaths <-chan string) err
 		log.WithField("filepath", f.remoteFilePath(fName)).Debug("staged file: uploading")
 
 		ctx = driverctx.NewContextWithStagingInfo(ctx, []string{f.dir})
-		if _, err := f.conn.ExecContext(ctx, fmt.Sprintf(`PUT '%s' INTO '%s'`, file, f.remoteFilePath(fName))); err != nil {
+		if _, err := f.conn.ExecContext(ctx, fmt.Sprintf(`PUT '%s' INTO '%s' OVERWRITE`, file, f.remoteFilePath(fName))); err != nil {
 			return fmt.Errorf("put file: %w", err)
 		}
 		log.WithField("filepath", f.remoteFilePath(fName)).Debug("staged file: upload done")


### PR DESCRIPTION
**Description:**

- Switch from Files API to PUT API now that it has become publicly available and is the recommended method for uploading files. https://www.databricks.com/blog/announcing-general-availability-unity-catalog-volumes
- Tested by running integration tests and running a large materialization task on this version

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1301)
<!-- Reviewable:end -->
