### PR TITLE
source-{postgres,redshift}-batch: Filter schemas with query

### DIFF
--- a/source-postgres-batch/.snapshots/TestSchemaFilter-FilteredIn
+++ b/source-postgres-batch/.snapshots/TestSchemaFilter-FilteredIn
@@ -1,0 +1,54 @@
+Binding 0:
+{
+    "resource_config_json": {
+      "name": "test_schema_filtering_22492",
+      "template": "{{if .IsFirstQuery -}}\n  SELECT xmin AS txid, * FROM \"test\".\"schema_filtering_22492\" ORDER BY xmin::text::bigint;\n{{- else -}}\n  SELECT xmin AS txid, * FROM \"test\".\"schema_filtering_22492\" WHERE xmin::text::bigint \u003e $1 ORDER BY xmin::text::bigint;\n{{- end}}",
+      "cursor": [
+        "txid"
+      ]
+    },
+    "resource_path": [
+      "test_schema_filtering_22492"
+    ],
+    "collection": {
+      "name": "acmeCo/test/test_schema_filtering_22492",
+      "read_schema_json": {
+        "type": "object",
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "$schema": "http://json-schema.org/draft/2020-12/schema",
+            "$id": "https://github.com/estuary/connectors/source-postgres-batch/document-metadata",
+            "properties": {
+              "polled": {
+                "type": "string",
+                "format": "date-time",
+                "title": "Polled Timestamp",
+                "description": "The time at which the update query which produced this document as executed."
+              },
+              "index": {
+                "type": "integer",
+                "title": "Result Index",
+                "description": "The index of this document within the query execution which produced it."
+              }
+            },
+            "type": "object",
+            "required": [
+              "polled",
+              "index"
+            ]
+          }
+        },
+        "x-infer-schema": true
+      },
+      "key": [
+        "/_meta/polled",
+        "/_meta/index"
+      ],
+      "projections": null
+    },
+    "state_key": "test_schema_filtering_22492"
+  }
+

--- a/source-postgres-batch/.snapshots/TestSchemaFilter-FilteredOut
+++ b/source-postgres-batch/.snapshots/TestSchemaFilter-FilteredOut
@@ -1,0 +1,1 @@
+(no bindings)

--- a/source-postgres-batch/.snapshots/TestSchemaFilter-Unfiltered
+++ b/source-postgres-batch/.snapshots/TestSchemaFilter-Unfiltered
@@ -1,0 +1,54 @@
+Binding 0:
+{
+    "resource_config_json": {
+      "name": "test_schema_filtering_22492",
+      "template": "{{if .IsFirstQuery -}}\n  SELECT xmin AS txid, * FROM \"test\".\"schema_filtering_22492\" ORDER BY xmin::text::bigint;\n{{- else -}}\n  SELECT xmin AS txid, * FROM \"test\".\"schema_filtering_22492\" WHERE xmin::text::bigint \u003e $1 ORDER BY xmin::text::bigint;\n{{- end}}",
+      "cursor": [
+        "txid"
+      ]
+    },
+    "resource_path": [
+      "test_schema_filtering_22492"
+    ],
+    "collection": {
+      "name": "acmeCo/test/test_schema_filtering_22492",
+      "read_schema_json": {
+        "type": "object",
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "$schema": "http://json-schema.org/draft/2020-12/schema",
+            "$id": "https://github.com/estuary/connectors/source-postgres-batch/document-metadata",
+            "properties": {
+              "polled": {
+                "type": "string",
+                "format": "date-time",
+                "title": "Polled Timestamp",
+                "description": "The time at which the update query which produced this document as executed."
+              },
+              "index": {
+                "type": "integer",
+                "title": "Result Index",
+                "description": "The index of this document within the query execution which produced it."
+              }
+            },
+            "type": "object",
+            "required": [
+              "polled",
+              "index"
+            ]
+          }
+        },
+        "x-infer-schema": true
+      },
+      "key": [
+        "/_meta/polled",
+        "/_meta/index"
+      ],
+      "projections": null
+    },
+    "state_key": "test_schema_filtering_22492"
+  }
+

--- a/source-redshift-batch/.snapshots/TestSchemaFilter-FilteredIn
+++ b/source-redshift-batch/.snapshots/TestSchemaFilter-FilteredIn
@@ -1,0 +1,55 @@
+Binding 0:
+{
+    "resource_config_json": {
+      "name": "test_schema_filtering_22492",
+      "template": "{{if .CursorFields -}}\n  {{- if .IsFirstQuery -}}\n    SELECT * FROM \"test\".\"schema_filtering_22492\"\n  {{- else -}}\n    SELECT * FROM \"test\".\"schema_filtering_22492\"\n\t{{- range $i, $k := $.CursorFields -}}\n\t  {{- if eq $i 0}} WHERE ({{else}}) OR ({{end -}}\n      {{- range $j, $n := $.CursorFields -}}\n\t\t{{- if lt $j $i -}}\n\t\t  {{$n}} = ${{add $j 1}} AND {{end -}}\n\t  {{- end -}}\n\t  {{$k}} \u003e ${{add $i 1}}\n\t{{- end -}}\n\t) \n  {{- end}} ORDER BY {{range $i, $k := $.CursorFields}}{{if gt $i 0}}, {{end}}{{$k}}{{end -}};\n{{- else -}}\n  SELECT * FROM \"test\".\"schema_filtering_22492\";\n{{- end}}\n",
+      "cursor": null
+    },
+    "resource_path": [
+      "test_schema_filtering_22492"
+    ],
+    "collection": {
+      "name": "acmeCo/test/test_schema_filtering_22492",
+      "read_schema_json": {
+        "type": "object",
+        "required": [
+          "_meta",
+          "id"
+        ],
+        "properties": {
+          "_meta": {
+            "$schema": "http://json-schema.org/draft/2020-12/schema",
+            "$id": "https://github.com/estuary/connectors/source-redshift-batch/document-metadata",
+            "properties": {
+              "polled": {
+                "type": "string",
+                "format": "date-time",
+                "title": "Polled Timestamp",
+                "description": "The time at which the update query which produced this document as executed."
+              },
+              "index": {
+                "type": "integer",
+                "title": "Result Index",
+                "description": "The index of this document within the query execution which produced it."
+              }
+            },
+            "type": "object",
+            "required": [
+              "polled",
+              "index"
+            ]
+          },
+          "id": {
+            "type": "integer"
+          }
+        },
+        "x-infer-schema": true
+      },
+      "key": [
+        "/id"
+      ],
+      "projections": null
+    },
+    "state_key": "test_schema_filtering_22492"
+  }
+

--- a/source-redshift-batch/.snapshots/TestSchemaFilter-FilteredOut
+++ b/source-redshift-batch/.snapshots/TestSchemaFilter-FilteredOut
@@ -1,0 +1,1 @@
+(no bindings)

--- a/source-redshift-batch/.snapshots/TestSchemaFilter-Unfiltered
+++ b/source-redshift-batch/.snapshots/TestSchemaFilter-Unfiltered
@@ -1,0 +1,55 @@
+Binding 0:
+{
+    "resource_config_json": {
+      "name": "test_schema_filtering_22492",
+      "template": "{{if .CursorFields -}}\n  {{- if .IsFirstQuery -}}\n    SELECT * FROM \"test\".\"schema_filtering_22492\"\n  {{- else -}}\n    SELECT * FROM \"test\".\"schema_filtering_22492\"\n\t{{- range $i, $k := $.CursorFields -}}\n\t  {{- if eq $i 0}} WHERE ({{else}}) OR ({{end -}}\n      {{- range $j, $n := $.CursorFields -}}\n\t\t{{- if lt $j $i -}}\n\t\t  {{$n}} = ${{add $j 1}} AND {{end -}}\n\t  {{- end -}}\n\t  {{$k}} \u003e ${{add $i 1}}\n\t{{- end -}}\n\t) \n  {{- end}} ORDER BY {{range $i, $k := $.CursorFields}}{{if gt $i 0}}, {{end}}{{$k}}{{end -}};\n{{- else -}}\n  SELECT * FROM \"test\".\"schema_filtering_22492\";\n{{- end}}\n",
+      "cursor": null
+    },
+    "resource_path": [
+      "test_schema_filtering_22492"
+    ],
+    "collection": {
+      "name": "acmeCo/test/test_schema_filtering_22492",
+      "read_schema_json": {
+        "type": "object",
+        "required": [
+          "_meta",
+          "id"
+        ],
+        "properties": {
+          "_meta": {
+            "$schema": "http://json-schema.org/draft/2020-12/schema",
+            "$id": "https://github.com/estuary/connectors/source-redshift-batch/document-metadata",
+            "properties": {
+              "polled": {
+                "type": "string",
+                "format": "date-time",
+                "title": "Polled Timestamp",
+                "description": "The time at which the update query which produced this document as executed."
+              },
+              "index": {
+                "type": "integer",
+                "title": "Result Index",
+                "description": "The index of this document within the query execution which produced it."
+              }
+            },
+            "type": "object",
+            "required": [
+              "polled",
+              "index"
+            ]
+          },
+          "id": {
+            "type": "integer"
+          }
+        },
+        "x-infer-schema": true
+      },
+      "key": [
+        "/id"
+      ],
+      "projections": null
+    },
+    "state_key": "test_schema_filtering_22492"
+  }
+

--- a/source-redshift-batch/driver.go
+++ b/source-redshift-batch/driver.go
@@ -186,7 +186,7 @@ func (drv *BatchSQLDriver) Discover(ctx context.Context, req *pc.Request_Discove
 	if err != nil {
 		return nil, fmt.Errorf("error listing tables: %w", err)
 	}
-	keys, err := discoverPrimaryKeys(ctx, db)
+	keys, err := discoverPrimaryKeys(ctx, db, cfg.Advanced.DiscoverSchemas)
 	if err != nil {
 		return nil, fmt.Errorf("error listing primary keys: %w", err)
 	}
@@ -262,8 +262,6 @@ func primaryKeyToCollectionKey(key string) string {
 	return "/" + key
 }
 
-const queryDiscoverTables = `SELECT table_schema, table_name, table_type FROM information_schema.tables;`
-
 type discoveredTable struct {
 	Schema string
 	Name   string
@@ -271,9 +269,18 @@ type discoveredTable struct {
 }
 
 func discoverTables(ctx context.Context, db *sql.DB, discoverSchemas []string) ([]*discoveredTable, error) {
-	rows, err := db.QueryContext(ctx, queryDiscoverTables)
+	var query = new(strings.Builder)
+	var args []any
+	fmt.Fprintf(query, "SELECT table_schema, table_name, table_type FROM information_schema.tables")
+	if len(discoverSchemas) > 0 {
+		fmt.Fprintf(query, " WHERE table_schema = ANY ($1)")
+		args = append(args, discoverSchemas)
+	}
+	fmt.Fprintf(query, ";")
+
+	rows, err := db.QueryContext(ctx, query.String(), args...)
 	if err != nil {
-		return nil, fmt.Errorf("error executing discovery query: %w", err)
+		return nil, fmt.Errorf("error executing discovery query %q: %w", query.String(), err)
 	}
 	defer rows.Close()
 
@@ -282,11 +289,6 @@ func discoverTables(ctx context.Context, db *sql.DB, discoverSchemas []string) (
 		var tableSchema, tableName, tableType string
 		if err := rows.Scan(&tableSchema, &tableName, &tableType); err != nil {
 			return nil, fmt.Errorf("error scanning result row: %w", err)
-		}
-
-		if len(discoverSchemas) > 0 && !slices.Contains(discoverSchemas, tableSchema) {
-			log.WithFields(log.Fields{"schema": tableSchema, "table": tableName}).Debug("ignoring table")
-			continue
 		}
 		tables = append(tables, &discoveredTable{
 			Schema: tableSchema,
@@ -297,28 +299,6 @@ func discoverTables(ctx context.Context, db *sql.DB, discoverSchemas []string) (
 	return tables, nil
 }
 
-// Joining on the 6-tuple {CONSTRAINT,TABLE}_{CATALOG,SCHEMA,NAME} is probably
-// overkill but shouldn't hurt, and helps to make absolutely sure that we're
-// matching up the constraint type with the column names/positions correctly.
-const queryDiscoverPrimaryKeys = `
-SELECT kcu.table_schema, kcu.table_name, kcu.column_name, kcu.ordinal_position, col.data_type
-  FROM information_schema.key_column_usage kcu
-  JOIN information_schema.table_constraints tcs
-    ON  tcs.constraint_catalog = kcu.constraint_catalog
-    AND tcs.constraint_schema = kcu.constraint_schema
-    AND tcs.constraint_name = kcu.constraint_name
-    AND tcs.table_catalog = kcu.table_catalog
-    AND tcs.table_schema = kcu.table_schema
-    AND tcs.table_name = kcu.table_name
-  JOIN information_schema.columns col
-    ON  col.table_catalog = kcu.table_catalog
-	AND col.table_schema = kcu.table_schema
-	AND col.table_name = kcu.table_name
-	AND col.column_name = kcu.column_name
-  WHERE tcs.constraint_type = 'PRIMARY KEY'
-  ORDER BY kcu.table_schema, kcu.table_name, kcu.ordinal_position;
-`
-
 type discoveredPrimaryKey struct {
 	Schema      string
 	Table       string
@@ -326,10 +306,36 @@ type discoveredPrimaryKey struct {
 	ColumnTypes map[string]*jsonschema.Schema
 }
 
-func discoverPrimaryKeys(ctx context.Context, db *sql.DB) ([]*discoveredPrimaryKey, error) {
-	rows, err := db.QueryContext(ctx, queryDiscoverPrimaryKeys)
+func discoverPrimaryKeys(ctx context.Context, db *sql.DB, discoverSchemas []string) ([]*discoveredPrimaryKey, error) {
+	var query = new(strings.Builder)
+	var args []any
+	// Joining on the 6-tuple {CONSTRAINT,TABLE}_{CATALOG,SCHEMA,NAME} is probably
+	// overkill but shouldn't hurt, and helps to make absolutely sure that we're
+	// matching up the constraint type with the column names/positions correctly.
+	fmt.Fprintf(query, "SELECT kcu.table_schema, kcu.table_name, kcu.column_name, kcu.ordinal_position, col.data_type")
+	fmt.Fprintf(query, " FROM information_schema.key_column_usage kcu")
+	fmt.Fprintf(query, " JOIN information_schema.table_constraints tcs")
+	fmt.Fprintf(query, "  ON  tcs.constraint_catalog = kcu.constraint_catalog")
+	fmt.Fprintf(query, "  AND tcs.constraint_schema = kcu.constraint_schema")
+	fmt.Fprintf(query, "  AND tcs.constraint_name = kcu.constraint_name")
+	fmt.Fprintf(query, "  AND tcs.table_catalog = kcu.table_catalog")
+	fmt.Fprintf(query, "  AND tcs.table_schema = kcu.table_schema")
+	fmt.Fprintf(query, "  AND tcs.table_name = kcu.table_name")
+	fmt.Fprintf(query, " JOIN information_schema.columns col")
+	fmt.Fprintf(query, "  ON  col.table_catalog = kcu.table_catalog")
+	fmt.Fprintf(query, "  AND col.table_schema = kcu.table_schema")
+	fmt.Fprintf(query, "  AND col.table_name = kcu.table_name")
+	fmt.Fprintf(query, "  AND col.column_name = kcu.column_name")
+	fmt.Fprintf(query, " WHERE tcs.constraint_type = 'PRIMARY KEY'")
+	if len(discoverSchemas) > 0 {
+		fmt.Fprintf(query, "  AND kcu.table_schema = ANY ($1)")
+		args = append(args, discoverSchemas)
+	}
+	fmt.Fprintf(query, " ORDER BY kcu.table_schema, kcu.table_name, kcu.ordinal_position;")
+
+	rows, err := db.QueryContext(ctx, query.String(), args...)
 	if err != nil {
-		return nil, fmt.Errorf("error executing discovery query: %w", err)
+		return nil, fmt.Errorf("error executing discovery query %q: %w", query.String(), err)
 	}
 	defer rows.Close()
 

--- a/source-redshift-batch/main_test.go
+++ b/source-redshift-batch/main_test.go
@@ -96,20 +96,7 @@ func TestBasicCapture(t *testing.T) {
 
 	// Discover the table and verify discovery snapshot
 	cs.Bindings = discoverStreams(ctx, t, cs, regexp.MustCompile(uniqueID))
-	t.Run("Discovery", func(t *testing.T) {
-		var summary = new(strings.Builder)
-		for idx, binding := range cs.Bindings {
-			fmt.Fprintf(summary, "Binding %d:\n", idx)
-			bs, err := json.MarshalIndent(binding, "  ", "  ")
-			require.NoError(t, err)
-			io.Copy(summary, bytes.NewReader(bs))
-			fmt.Fprintf(summary, "\n")
-		}
-		if len(cs.Bindings) == 0 {
-			fmt.Fprintf(summary, "(no output)")
-		}
-		cupaloy.SnapshotT(t, summary.String())
-	})
+	t.Run("Discovery", func(t *testing.T) { snapshotBindings(t, cs.Bindings) })
 
 	// Edit the discovered binding to use the ID column as a cursor
 	var res Resource
@@ -154,20 +141,7 @@ func TestBasicDatatypes(t *testing.T) {
 
 	// Discover the table and verify discovery snapshot
 	cs.Bindings = discoverStreams(ctx, t, cs, regexp.MustCompile(uniqueID))
-	t.Run("Discovery", func(t *testing.T) {
-		var summary = new(strings.Builder)
-		for idx, binding := range cs.Bindings {
-			fmt.Fprintf(summary, "Binding %d:\n", idx)
-			bs, err := json.MarshalIndent(binding, "  ", "  ")
-			require.NoError(t, err)
-			io.Copy(summary, bytes.NewReader(bs))
-			fmt.Fprintf(summary, "\n")
-		}
-		if len(cs.Bindings) == 0 {
-			fmt.Fprintf(summary, "(no output)")
-		}
-		cupaloy.SnapshotT(t, summary.String())
-	})
+	t.Run("Discovery", func(t *testing.T) { snapshotBindings(t, cs.Bindings) })
 
 	t.Run("Capture", func(t *testing.T) {
 		executeControlQuery(ctx, t, control, fmt.Sprintf("INSERT INTO %s(id, a_real, a_bool, a_date, a_ts, a_tstz) VALUES ($1,$2,$3,$4,$5,$6)", tableName),
@@ -178,6 +152,31 @@ func TestBasicDatatypes(t *testing.T) {
 		time.AfterFunc(5*time.Second, cancelCapture)
 		cs.Capture(captureCtx, t, nil)
 		cupaloy.SnapshotT(t, cs.Summary())
+	})
+}
+
+func TestSchemaFilter(t *testing.T) {
+	var ctx, cs = context.Background(), testCaptureSpec(t)
+	var control = testControlClient(ctx, t)
+	var uniqueID = "22492"
+	var tableName = fmt.Sprintf("test.schema_filtering_%s", uniqueID)
+
+	executeControlQuery(ctx, t, control, fmt.Sprintf("DROP TABLE IF EXISTS %s", tableName))
+	t.Cleanup(func() { executeControlQuery(ctx, t, control, fmt.Sprintf("DROP TABLE IF EXISTS %s", tableName)) })
+	executeControlQuery(ctx, t, control, fmt.Sprintf("CREATE TABLE %s(id INTEGER PRIMARY KEY, data TEXT)", tableName))
+
+	// Run discovery with several schema filters and snapshot the results
+	t.Run("Unfiltered", func(t *testing.T) {
+		cs.EndpointSpec.(*Config).Advanced.DiscoverSchemas = []string{}
+		snapshotBindings(t, discoverStreams(ctx, t, cs, regexp.MustCompile(uniqueID)))
+	})
+	t.Run("FilteredOut", func(t *testing.T) {
+		cs.EndpointSpec.(*Config).Advanced.DiscoverSchemas = []string{"foo", "bar"}
+		snapshotBindings(t, discoverStreams(ctx, t, cs, regexp.MustCompile(uniqueID)))
+	})
+	t.Run("FilteredIn", func(t *testing.T) {
+		cs.EndpointSpec.(*Config).Advanced.DiscoverSchemas = []string{"foo", "test"}
+		snapshotBindings(t, discoverStreams(ctx, t, cs, regexp.MustCompile(uniqueID)))
 	})
 }
 
@@ -260,4 +259,19 @@ func discoverStreams(ctx context.Context, t testing.TB, cs *st.CaptureSpec, matc
 		})
 	}
 	return bindings
+}
+
+func snapshotBindings(t testing.TB, bindings []*pf.CaptureSpec_Binding) {
+	var summary = new(strings.Builder)
+	for idx, binding := range bindings {
+		fmt.Fprintf(summary, "Binding %d:\n", idx)
+		bs, err := json.MarshalIndent(binding, "  ", "  ")
+		require.NoError(t, err)
+		io.Copy(summary, bytes.NewReader(bs))
+		fmt.Fprintf(summary, "\n")
+	}
+	if len(bindings) == 0 {
+		fmt.Fprintf(summary, "(no bindings)")
+	}
+	cupaloy.SnapshotT(t, summary.String())
 }


### PR DESCRIPTION
**Description:**

Previously schema-filtering of discovery results was done by running a set of "give me everything" queries and then filtering out any results not matching the list of desired schemas.

However we have encountered at least one user whose production database is so large that the complete unfiltered query takes multiple minutes to execute, which can slow down binding refreshes so much that they consistently time out. We have confirmed that this slowdown is fixed by putting the desired schema(s) in a `WHERE` clause of the discovery query itself, so that's how we'll fix it.

So this PR removes the logic that previously filtered discovery based on schema and instead adds a `WHERE table_schema = ANY ($1)` clause to the queries (along with the appropriate argument value) if the schema-filtering list is non-empty.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1312)
<!-- Reviewable:end -->
