### PR TITLE
source-firestore: fix hanging connector on streamChanges error

### DIFF
--- a/source-firestore/pull.go
+++ b/source-firestore/pull.go
@@ -675,6 +675,13 @@ func (c *capture) StreamChanges(ctx context.Context, client *firestore_v1.Client
 			if !catchupStreaming {
 				catchupStreaming = true
 				c.streamsInCatchup.Add(1)
+
+				// Ensure that we call Done if there's an early return
+				defer func() {
+					if catchupStreaming {
+						c.streamsInCatchup.Done()
+					}
+				}()
 			}
 			catchupStarted = time.Now()
 		}


### PR DESCRIPTION
When an error occurs in StreamChanges, we had previously failed to call `Done` on the `streamsInCatchup` `WaitGroup`.  This resulted in the connector hanging indefinitely and refusing to exit. This is a quick and dirty fix to hopefully fix the most acute issues.

This connector almost certainly could benefit from a more thorough review of synchronization. It's possible there's other synchronization bugs hiding here. But I wanted to get this fixed asap, and we can take that on later.