### PR TITLE
estuary-cdk: `common` routines should yield to the event loop

### DIFF
--- a/estuary-cdk/estuary_cdk/capture/common.py
+++ b/estuary-cdk/estuary_cdk/capture/common.py
@@ -453,6 +453,10 @@ async def _binding_snapshot_task(
     )
 
     while True:
+        # Yield to the event loop to prevent starvation.
+        # Note that wait_for does *not* yield if sleep_for has already elapsed.
+        await asyncio.sleep(0)
+
         next_sync = state.updated_at + binding.resourceConfig.interval
         sleep_for = next_sync - datetime.now(tz=UTC)
 
@@ -523,6 +527,9 @@ async def _binding_backfill_task(
         task.log.info(f"beginning backfill", state)
 
     while True:
+        # Yield to the event loop to prevent starvation.
+        await asyncio.sleep(0)
+
         page, next_page = await fetch_page(task.log, state.next_page, state.cutoff)
         for doc in page:
             task.captured(binding_index, doc)
@@ -553,6 +560,8 @@ async def _binding_incremental_task(
     task.log.info(f"resuming incremental replication", state)
 
     while True:
+        # Yield to the event loop to prevent starvation.
+        await asyncio.sleep(0)
 
         checkpoints = 0
         pending = False


### PR DESCRIPTION
Ensure all tasks get a chance to make progress between each tasks's iterations.


**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1314)
<!-- Reviewable:end -->
