### PR TITLE
make connectors free: source/materialize-google-sheets and source-hel…

### DIFF
--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -29,18 +29,25 @@ jobs:
       fail-fast: false
       matrix:
         connector:
+          # Note that every entry here must specify usage_rate. We're unable to
+          # set a default and selectively override it with `0.0`, because GH actions
+          # considers zero values to be "unset" (which is bs and I'm salty about it).
           - name: source-asana
             type: capture
             version: v1
+            usage_rate: 1.0
           - name: source-hubspot-native
             type: capture
             version: v1
+            usage_rate: 1.0
           - name: source-gladly
             type: capture
             version: v1
+            usage_rate: 1.0
           - name: source-google-sheets-native
             type: capture
             version: v1
+            usage_rate: 0.0
 
     steps:
       - uses: actions/checkout@v4
@@ -78,6 +85,7 @@ jobs:
           build-args: |
             CONNECTOR_NAME=${{ matrix.connector.name }}
             CONNECTOR_TYPE=${{ matrix.connector.type }}
+            USAGE_RATE=${{ matrix.usage_rate }}
           tags: ghcr.io/estuary/${{ matrix.connector.name }}:local
 
       - name: Deployment

--- a/estuary-cdk/common.Dockerfile
+++ b/estuary-cdk/common.Dockerfile
@@ -6,7 +6,7 @@ ARG CONNECTOR_NAME
 
 RUN apt-get update && \
     apt install -y --no-install-recommends \
-    python3-poetry 
+    python3-poetry
 
 RUN python -m venv /opt/venv
 ENV VIRTUAL_ENV=/opt/venv
@@ -23,9 +23,14 @@ FROM base as runner
 ARG CONNECTOR_NAME
 ARG CONNECTOR_TYPE
 ARG DOCS_URL
+# The USAGE_RATE arg is required, because GH actions doesn't seem to have a way to conditionally
+# pass it only for the connectors that should have a 0 rate. Comes from `usage_rate` in the
+# `python.yaml` workflow matrix.
+ARG USAGE_RATE
 
 LABEL FLOW_RUNTIME_PROTOCOL=${CONNECTOR_TYPE}
 LABEL FLOW_RUNTIME_CODEC=json
+LABEL dev.estuary.usage-rate=$USAGE_RATE
 
 COPY --from=builder /opt/$CONNECTOR_NAME /opt/$CONNECTOR_NAME
 COPY --from=builder /opt/estuary-cdk /opt/estuary-cdk

--- a/materialize-google-sheets/Dockerfile
+++ b/materialize-google-sheets/Dockerfile
@@ -33,5 +33,6 @@ COPY --from=builder /builder/connector ./materialize-google-sheets
 USER nonroot:nonroot
 
 LABEL FLOW_RUNTIME_PROTOCOL=materialize
+LABEL dev.estuary.usage-rate=0
 
 ENTRYPOINT ["/connector/materialize-google-sheets"]

--- a/source-hello-world/Dockerfile
+++ b/source-hello-world/Dockerfile
@@ -36,6 +36,7 @@ COPY --from=builder /builder/connector ./source-hello-world
 
 LABEL FLOW_RUNTIME_PROTOCOL=capture
 LABEL CONNECTOR_PROTOCOL=flow-capture
+LABEL dev.estuary.usage-rate=0
 
 # Avoid running the connector as root.
 USER nonroot:nonroot


### PR DESCRIPTION
…lo-world

Adds labels to the docker images in order to make some connectors free to run on Estuary's platform.  Goes along with estuary/flow#1403. Free connectors are:

- source-google-sheets-native
- materialize-google-sheets
- source-hello-world

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1321)
<!-- Reviewable:end -->
