### PR TITLE
Fixing Hubspot Custom streams schema

### DIFF
--- a/source-hubspot/source_hubspot/streams.py
+++ b/source-hubspot/source_hubspot/streams.py
@@ -239,7 +239,7 @@ class API:
 
         schema = {
             "$schema": "http://json-schema.org/draft-07/schema#",
-            "type": ["null", "object"],
+            "type": "object",
             "additionalProperties": True,
             "properties": {
                 "id": {"type": ["null", "string"]},


### PR DESCRIPTION
**Description:**

Huspot Custom Streams schema was being generated with a `null` type, rendering the schema invalid to estuary dashboards. This PR removes that



**Notes for reviewers:**
Tests were made using a developer Hubspot account and a custom stream named venues
Results:
![Screenshot from 2024-03-05 17-58-51](https://github.com/estuary/connectors/assets/14100959/13838e76-bc50-4205-81b6-2618ff68fbca)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1322)
<!-- Reviewable:end -->
