### PR TITLE
source-gladly: use BaseModel for Event Model nested objects

### DIFF
--- a/source-gladly/source_gladly/models.py
+++ b/source-gladly/source_gladly/models.py
@@ -43,13 +43,12 @@ ConnectorState = GenericConnectorState[ResourceState]
 # through schema inference.
 class Event(BaseDocument, extra="forbid"):
 
-    class Initiator(BaseDocument, extra="forbid"):
+    class Initiator(BaseModel, extra="forbid"):
         id: str
         type: str
 
-    class Content(BaseDocument, extra="allow"):
-        class Context(BaseDocument, extra="allow"):
-            pass
+    class Content(BaseModel, extra="allow"):
+        pass
 
     id: str
     type: str

--- a/source-gladly/tests/snapshots/source_gladly_tests_test_snapshots__discover__stdout.json
+++ b/source-gladly/tests/snapshots/source_gladly_tests_test_snapshots__discover__stdout.json
@@ -9,38 +9,13 @@
       "$defs": {
         "Content": {
           "additionalProperties": true,
-          "properties": {
-            "_meta": {
-              "allOf": [
-                {
-                  "$ref": "#/$defs/Meta"
-                }
-              ],
-              "default": {
-                "op": "u",
-                "row_id": -1
-              },
-              "description": "Document metadata"
-            }
-          },
+          "properties": {},
           "title": "Content",
           "type": "object"
         },
         "Initiator": {
           "additionalProperties": false,
           "properties": {
-            "_meta": {
-              "allOf": [
-                {
-                  "$ref": "#/$defs/Meta"
-                }
-              ],
-              "default": {
-                "op": "u",
-                "row_id": -1
-              },
-              "description": "Document metadata"
-            },
             "id": {
               "title": "Id",
               "type": "string"
@@ -142,38 +117,13 @@
       "$defs": {
         "Content": {
           "additionalProperties": true,
-          "properties": {
-            "_meta": {
-              "allOf": [
-                {
-                  "$ref": "#/$defs/Meta"
-                }
-              ],
-              "default": {
-                "op": "u",
-                "row_id": -1
-              },
-              "description": "Document metadata"
-            }
-          },
+          "properties": {},
           "title": "Content",
           "type": "object"
         },
         "Initiator": {
           "additionalProperties": false,
           "properties": {
-            "_meta": {
-              "allOf": [
-                {
-                  "$ref": "#/$defs/Meta"
-                }
-              ],
-              "default": {
-                "op": "u",
-                "row_id": -1
-              },
-              "description": "Document metadata"
-            },
             "id": {
               "title": "Id",
               "type": "string"
@@ -275,38 +225,13 @@
       "$defs": {
         "Content": {
           "additionalProperties": true,
-          "properties": {
-            "_meta": {
-              "allOf": [
-                {
-                  "$ref": "#/$defs/Meta"
-                }
-              ],
-              "default": {
-                "op": "u",
-                "row_id": -1
-              },
-              "description": "Document metadata"
-            }
-          },
+          "properties": {},
           "title": "Content",
           "type": "object"
         },
         "Initiator": {
           "additionalProperties": false,
           "properties": {
-            "_meta": {
-              "allOf": [
-                {
-                  "$ref": "#/$defs/Meta"
-                }
-              ],
-              "default": {
-                "op": "u",
-                "row_id": -1
-              },
-              "description": "Document metadata"
-            },
             "id": {
               "title": "Id",
               "type": "string"
@@ -408,38 +333,13 @@
       "$defs": {
         "Content": {
           "additionalProperties": true,
-          "properties": {
-            "_meta": {
-              "allOf": [
-                {
-                  "$ref": "#/$defs/Meta"
-                }
-              ],
-              "default": {
-                "op": "u",
-                "row_id": -1
-              },
-              "description": "Document metadata"
-            }
-          },
+          "properties": {},
           "title": "Content",
           "type": "object"
         },
         "Initiator": {
           "additionalProperties": false,
           "properties": {
-            "_meta": {
-              "allOf": [
-                {
-                  "$ref": "#/$defs/Meta"
-                }
-              ],
-              "default": {
-                "op": "u",
-                "row_id": -1
-              },
-              "description": "Document metadata"
-            },
             "id": {
               "title": "Id",
               "type": "string"
@@ -541,38 +441,13 @@
       "$defs": {
         "Content": {
           "additionalProperties": true,
-          "properties": {
-            "_meta": {
-              "allOf": [
-                {
-                  "$ref": "#/$defs/Meta"
-                }
-              ],
-              "default": {
-                "op": "u",
-                "row_id": -1
-              },
-              "description": "Document metadata"
-            }
-          },
+          "properties": {},
           "title": "Content",
           "type": "object"
         },
         "Initiator": {
           "additionalProperties": false,
           "properties": {
-            "_meta": {
-              "allOf": [
-                {
-                  "$ref": "#/$defs/Meta"
-                }
-              ],
-              "default": {
-                "op": "u",
-                "row_id": -1
-              },
-              "description": "Document metadata"
-            },
             "id": {
               "title": "Id",
               "type": "string"
@@ -674,38 +549,13 @@
       "$defs": {
         "Content": {
           "additionalProperties": true,
-          "properties": {
-            "_meta": {
-              "allOf": [
-                {
-                  "$ref": "#/$defs/Meta"
-                }
-              ],
-              "default": {
-                "op": "u",
-                "row_id": -1
-              },
-              "description": "Document metadata"
-            }
-          },
+          "properties": {},
           "title": "Content",
           "type": "object"
         },
         "Initiator": {
           "additionalProperties": false,
           "properties": {
-            "_meta": {
-              "allOf": [
-                {
-                  "$ref": "#/$defs/Meta"
-                }
-              ],
-              "default": {
-                "op": "u",
-                "row_id": -1
-              },
-              "description": "Document metadata"
-            },
             "id": {
               "title": "Id",
               "type": "string"
@@ -807,38 +657,13 @@
       "$defs": {
         "Content": {
           "additionalProperties": true,
-          "properties": {
-            "_meta": {
-              "allOf": [
-                {
-                  "$ref": "#/$defs/Meta"
-                }
-              ],
-              "default": {
-                "op": "u",
-                "row_id": -1
-              },
-              "description": "Document metadata"
-            }
-          },
+          "properties": {},
           "title": "Content",
           "type": "object"
         },
         "Initiator": {
           "additionalProperties": false,
           "properties": {
-            "_meta": {
-              "allOf": [
-                {
-                  "$ref": "#/$defs/Meta"
-                }
-              ],
-              "default": {
-                "op": "u",
-                "row_id": -1
-              },
-              "description": "Document metadata"
-            },
             "id": {
               "title": "Id",
               "type": "string"


### PR DESCRIPTION
**Description:**

BaseDocument includes _meta fields which we don't want for the nested objects of Event, so use BaseModel instead.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1324)
<!-- Reviewable:end -->
