### PR TITLE
Making table name readOnly

### DIFF
--- a/sqlcapture/main.go
+++ b/sqlcapture/main.go
@@ -22,7 +22,7 @@ type Resource struct {
 	Mode BackfillMode `json:"mode,omitempty" jsonschema:"title=Backfill Mode,description=How the preexisting contents of the table should be backfilled. This should generally not be changed.,default=,enum=,enum=Normal,enum=Precise,enum=Only Changes,enum=Without Primary Key"`
 
 	Namespace string `json:"namespace" jsonschema:"title=Schema,description=The schema (namespace) in which the table resides."`
-	Stream    string `json:"stream" jsonschema:"title=Table Name,description=The name of the table to be captured."`
+	Stream    string `json:"stream" jsonschema:"title=Table Name,description=The name of the table to be captured.,readOnly:true"`
 
 	// PrimaryKey allows the user to override the "scan key" columns which will be used
 	// to perform backfill queries and merge replicated changes. If left unset we default


### PR DESCRIPTION
**Description:**

Table name in the resource config for sql captures should be a read only field

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1328)
<!-- Reviewable:end -->
