### PR TITLE
materialize-databricks: read directly from staged files, no temp tables

### DIFF
--- a/materialize-databricks/.snapshots/TestSQLGeneration
+++ b/materialize-databricks/.snapshots/TestSQLGeneration
@@ -1,50 +1,36 @@
---- Begin `a-schema`.target_table createLoadTable ---
-CREATE TABLE IF NOT EXISTS `flow_temp_load_table_shard-range_0_target_table` (
-	key1 BIGINT NOT NULL,
-	key2 BOOLEAN NOT NULL
-);
---- End `a-schema`.target_table createLoadTable ---
-
---- Begin `a-schema`.target_table createStoreTable ---
-CREATE TABLE IF NOT EXISTS `flow_temp_store_table_shard-range_0_target_table` (
-	key1 BIGINT NOT NULL,
-	key2 BOOLEAN NOT NULL,
-	boolean BOOLEAN,
-	integer BIGINT,
-	number DOUBLE,
-	string STRING,
-	flow_document STRING NOT NULL
-);
---- End `a-schema`.target_table createStoreTable ---
-
 --- Begin `a-schema`.target_table loadQuery ---
 SELECT 0, `a-schema`.target_table.flow_document
 	FROM `a-schema`.target_table
-	JOIN `flow_temp_load_table_shard-range_0_target_table` AS r
+	JOIN (
+		(
+			SELECT
+			key1, key2
+			FROM json.`file1`
+		)
+		 UNION (
+			SELECT
+			key1, key2
+			FROM json.`file2`
+		)
+	) AS r
 	ON `a-schema`.target_table.key1 = r.key1 AND `a-schema`.target_table.key2 = r.key2
 --- End `a-schema`.target_table loadQuery ---
 
---- Begin `a-schema`.target_table truncateLoadTable ---
-TRUNCATE TABLE `flow_temp_load_table_shard-range_0_target_table`;
---- End `a-schema`.target_table truncateLoadTable ---
-
---- Begin `a-schema`.target_table truncateStoreTable ---
-TRUNCATE TABLE `flow_temp_store_table_shard-range_0_target_table`;
---- End `a-schema`.target_table truncateStoreTable ---
-
---- Begin `a-schema`.target_table dropLoadTable ---
-DROP TABLE IF EXISTS `flow_temp_load_table_shard-range_0_target_table`
---- End `a-schema`.target_table dropLoadTable ---
-
---- Begin `a-schema`.target_table dropStoreTable ---
-DROP TABLE IF EXISTS `flow_temp_store_table_shard-range_0_target_table`
---- End `a-schema`.target_table dropStoreTable ---
-
 --- Begin `a-schema`.target_table mergeInto ---
 	MERGE INTO `a-schema`.target_table AS l
-	USING `flow_temp_store_table_shard-range_0_target_table` AS r
+	USING (
+		(
+			SELECT
+			key1, key2, boolean, integer, number, string, flow_document
+			FROM json.`file1`
+		)
+		 UNION (
+			SELECT
+			key1, key2, boolean, integer, number, string, flow_document
+			FROM json.`file2`
+		)
+	) AS r
 	ON l.key1 = r.key1::BIGINT AND l.key2 = r.key2::BOOLEAN
-	AND r._metadata_file_name IN (%s)
 	WHEN MATCHED AND r.flow_document <=> NULL THEN
 		DELETE
 	WHEN MATCHED THEN
@@ -61,38 +47,11 @@ DROP TABLE IF EXISTS `flow_temp_store_table_shard-range_0_target_table`
   FROM 'test-staging-path'
 	)
   FILEFORMAT = JSON
-  FILES = (%s)
+  FILES = ('file1','file2')
   FORMAT_OPTIONS ( 'mode' = 'FAILFAST', 'ignoreMissingFiles' = 'false' )
 	COPY_OPTIONS ( 'mergeSchema' = 'true' )
   ;
 --- End `a-schema`.target_table copyIntoDirect ---
-
---- Begin `a-schema`.target_table copyIntoStore ---
-	COPY INTO `flow_temp_store_table_shard-range_0_target_table` FROM (
-    SELECT
-		_metadata.file_name as _metadata_file_name,
-		key1::BIGINT, key2::BOOLEAN, boolean::BOOLEAN, integer::BIGINT, number::DOUBLE, string::STRING, flow_document::STRING
-    FROM 'test-staging-path'
-	)
-  FILEFORMAT = JSON
-  FILES = (%s)
-  FORMAT_OPTIONS ( 'mode' = 'FAILFAST', 'primitivesAsString' = 'true', 'ignoreMissingFiles' = 'false' )
-	COPY_OPTIONS ( 'mergeSchema' = 'true' )
-  ;
---- End `a-schema`.target_table copyIntoStore ---
-
---- Begin `a-schema`.target_table copyIntoLoad ---
-	COPY INTO `flow_temp_load_table_shard-range_0_target_table` FROM (
-    SELECT
-      key1::BIGINT, key2::BOOLEAN
-    FROM 'test-staging-path'
-  )
-  FILEFORMAT = JSON
-  FILES = (%s)
-  FORMAT_OPTIONS ( 'mode' = 'FAILFAST', 'ignoreMissingFiles' = 'false' )
-	COPY_OPTIONS ( 'mergeSchema' = 'true' )
-  ;
---- End `a-schema`.target_table copyIntoLoad ---
 
 --- Begin `a-schema`.target_table createTargetTable ---
 CREATE TABLE IF NOT EXISTS `a-schema`.target_table (
@@ -106,44 +65,25 @@ CREATE TABLE IF NOT EXISTS `a-schema`.target_table (
 ) COMMENT 'Generated for materialization test/sqlite of collection key/value';
 --- End `a-schema`.target_table createTargetTable ---
 
---- Begin `default`.`Delta_Updates` createLoadTable ---
-CREATE TABLE IF NOT EXISTS `flow_temp_load_table_shard-range_1_Delta_Updates` (
-	`theKey` STRING NOT NULL
-);
---- End `default`.`Delta_Updates` createLoadTable ---
-
---- Begin `default`.`Delta_Updates` createStoreTable ---
-CREATE TABLE IF NOT EXISTS `flow_temp_store_table_shard-range_1_Delta_Updates` (
-	`theKey` STRING NOT NULL,
-	`aValue` BIGINT
-);
---- End `default`.`Delta_Updates` createStoreTable ---
-
 --- Begin `default`.`Delta_Updates` loadQuery ---
 SELECT -1, ""
 --- End `default`.`Delta_Updates` loadQuery ---
 
---- Begin `default`.`Delta_Updates` truncateLoadTable ---
-TRUNCATE TABLE `flow_temp_load_table_shard-range_1_Delta_Updates`;
---- End `default`.`Delta_Updates` truncateLoadTable ---
-
---- Begin `default`.`Delta_Updates` truncateStoreTable ---
-TRUNCATE TABLE `flow_temp_store_table_shard-range_1_Delta_Updates`;
---- End `default`.`Delta_Updates` truncateStoreTable ---
-
---- Begin `default`.`Delta_Updates` dropLoadTable ---
-DROP TABLE IF EXISTS `flow_temp_load_table_shard-range_1_Delta_Updates`
---- End `default`.`Delta_Updates` dropLoadTable ---
-
---- Begin `default`.`Delta_Updates` dropStoreTable ---
-DROP TABLE IF EXISTS `flow_temp_store_table_shard-range_1_Delta_Updates`
---- End `default`.`Delta_Updates` dropStoreTable ---
-
 --- Begin `default`.`Delta_Updates` mergeInto ---
 	MERGE INTO `default`.`Delta_Updates` AS l
-	USING `flow_temp_store_table_shard-range_1_Delta_Updates` AS r
+	USING (
+		(
+			SELECT
+			`theKey`, `aValue`
+			FROM json.`file1`
+		)
+		 UNION (
+			SELECT
+			`theKey`, `aValue`
+			FROM json.`file2`
+		)
+	) AS r
 	ON l.`theKey` = r.`theKey`::STRING
-	AND r._metadata_file_name IN (%s)
 	WHEN MATCHED THEN
 		UPDATE SET l.`aValue` = r.`aValue`::BIGINT
 	WHEN NOT MATCHED THEN
@@ -158,38 +98,11 @@ DROP TABLE IF EXISTS `flow_temp_store_table_shard-range_1_Delta_Updates`
   FROM 'test-staging-path'
 	)
   FILEFORMAT = JSON
-  FILES = (%s)
+  FILES = ('file1','file2')
   FORMAT_OPTIONS ( 'mode' = 'FAILFAST', 'ignoreMissingFiles' = 'false' )
 	COPY_OPTIONS ( 'mergeSchema' = 'true' )
   ;
 --- End `default`.`Delta_Updates` copyIntoDirect ---
-
---- Begin `default`.`Delta_Updates` copyIntoStore ---
-	COPY INTO `flow_temp_store_table_shard-range_1_Delta_Updates` FROM (
-    SELECT
-		_metadata.file_name as _metadata_file_name,
-		`theKey`::STRING, `aValue`::BIGINT
-    FROM 'test-staging-path'
-	)
-  FILEFORMAT = JSON
-  FILES = (%s)
-  FORMAT_OPTIONS ( 'mode' = 'FAILFAST', 'primitivesAsString' = 'true', 'ignoreMissingFiles' = 'false' )
-	COPY_OPTIONS ( 'mergeSchema' = 'true' )
-  ;
---- End `default`.`Delta_Updates` copyIntoStore ---
-
---- Begin `default`.`Delta_Updates` copyIntoLoad ---
-	COPY INTO `flow_temp_load_table_shard-range_1_Delta_Updates` FROM (
-    SELECT
-      `theKey`::STRING
-    FROM 'test-staging-path'
-  )
-  FILEFORMAT = JSON
-  FILES = (%s)
-  FORMAT_OPTIONS ( 'mode' = 'FAILFAST', 'ignoreMissingFiles' = 'false' )
-	COPY_OPTIONS ( 'mergeSchema' = 'true' )
-  ;
---- End `default`.`Delta_Updates` copyIntoLoad ---
 
 --- Begin `default`.`Delta_Updates` createTargetTable ---
 CREATE TABLE IF NOT EXISTS `default`.`Delta_Updates` (
@@ -207,9 +120,19 @@ ALTER TABLE `a-schema`.target_table ADD COLUMN
 
 --- Begin target_table_no_values_materialized mergeInto ---
 	MERGE INTO ``.target_table_no_values_materialized AS l
-	USING `flow_temp_store_table_shard-range_2_target_table_no_values_materialized` AS r
+	USING (
+		(
+			SELECT
+			key1, key2, flow_document
+			FROM json.`file2`
+		)
+		 UNION (
+			SELECT
+			key1, key2, flow_document
+			FROM json.`file3`
+		)
+	) AS r
 	ON l.key1 = r.key1::BIGINT AND l.key2 = r.key2::BOOLEAN
-	AND r._metadata_file_name IN (%s)
 	WHEN MATCHED AND r.flow_document <=> NULL THEN
 		DELETE
 	WHEN MATCHED THEN

--- a/materialize-databricks/.snapshots/TestSQLGeneration
+++ b/materialize-databricks/.snapshots/TestSQLGeneration
@@ -7,7 +7,7 @@ SELECT 0, `a-schema`.target_table.flow_document
 			key1, key2
 			FROM json.`file1`
 		)
-		 UNION (
+		 UNION ALL (
 			SELECT
 			key1, key2
 			FROM json.`file2`
@@ -24,7 +24,7 @@ SELECT 0, `a-schema`.target_table.flow_document
 			key1, key2, boolean, integer, number, string, flow_document
 			FROM json.`file1`
 		)
-		 UNION (
+		 UNION ALL (
 			SELECT
 			key1, key2, boolean, integer, number, string, flow_document
 			FROM json.`file2`
@@ -77,7 +77,7 @@ SELECT -1, ""
 			`theKey`, `aValue`
 			FROM json.`file1`
 		)
-		 UNION (
+		 UNION ALL (
 			SELECT
 			`theKey`, `aValue`
 			FROM json.`file2`
@@ -126,7 +126,7 @@ ALTER TABLE `a-schema`.target_table ADD COLUMN
 			key1, key2, flow_document
 			FROM json.`file2`
 		)
-		 UNION (
+		 UNION ALL (
 			SELECT
 			key1, key2, flow_document
 			FROM json.`file3`

--- a/materialize-databricks/sqlgen.go
+++ b/materialize-databricks/sqlgen.go
@@ -178,7 +178,7 @@ SELECT {{ $.Table.Binding }}, {{ $.Table.Identifier }}.{{ $.Table.Document.Ident
 	FROM {{ $.Table.Identifier }}
 	JOIN (
 		{{- range $fi, $file := $.Files }}
-		{{ if $fi }} UNION {{ end -}}
+		{{ if $fi }} UNION ALL {{ end -}}
 		(
 			SELECT
 			{{ range $ind, $key := $.Table.Keys }}
@@ -237,7 +237,7 @@ SELECT -1, ""
 	MERGE INTO {{ $.Table.Identifier }} AS l
 	USING (
 		{{- range $fi, $file := $.Files }}
-		{{ if $fi }} UNION {{ end -}}
+		{{ if $fi }} UNION ALL {{ end -}}
 		(
 			SELECT
 			{{ range $ind, $key := $.Table.Columns }}

--- a/materialize-databricks/sqlgen_test.go
+++ b/materialize-databricks/sqlgen_test.go
@@ -40,21 +40,13 @@ func TestSQLGeneration(t *testing.T) {
 
 	for _, tbl := range []sqlDriver.Table{table1, table2} {
 		for _, tpl := range []*template.Template{
-			tplCreateLoadTable,
-			tplCreateStoreTable,
 			tplLoadQuery,
-			tplTruncateLoad,
-			tplTruncateStore,
-			tplDropLoad,
-			tplDropStore,
 			tplMergeInto,
 			tplCopyIntoDirect,
-			tplCopyIntoStore,
-			tplCopyIntoLoad,
 		} {
 			var testcase = tbl.Identifier + " " + tpl.Name()
 
-			var tplData = Template{Table: &tbl, StagingPath: "test-staging-path", ShardRange: "shard-range"}
+			var tplData = tableWithFiles{Table: &tbl, StagingPath: "test-staging-path", Files: []string{"file1", "file2"}}
 			snap.WriteString("--- Begin " + testcase + " ---")
 			require.NoError(t, tpl.Execute(&snap, &tplData))
 			snap.WriteString("--- End " + testcase + " ---\n\n")
@@ -89,7 +81,7 @@ func TestSQLGeneration(t *testing.T) {
 	require.NoError(t, err)
 
 	snap.WriteString("--- Begin " + "target_table_no_values_materialized mergeInto" + " ---")
-	var tplData = Template{Table: &tableNoValues, StagingPath: "test-staging-path", ShardRange: "shard-range"}
+	var tplData = tableWithFiles{Table: &tableNoValues, StagingPath: "test-staging-path", Files: []string{"file2", "file3"}}
 	require.NoError(t, tplMergeInto.Execute(&snap, &tplData))
 	snap.WriteString("--- End " + "target_table_no_values_materialized mergeInto" + " ---\n\n")
 

--- a/materialize-databricks/staged_file.go
+++ b/materialize-databricks/staged_file.go
@@ -15,7 +15,7 @@ import (
 )
 
 const fileSizeLimit = 128 * 1024 * 1024
-const uploadConcurrency = 10 // that means we may use up to 1.28GB disk space
+const uploadConcurrency = 5 // that means we may use up to 1.28GB disk space
 
 // fileBuffer provides Close() for a *bufio.Writer writing to an *os.File. Close() will flush the
 // buffer and close the underlying file.

--- a/tests/materialize/materialize-databricks/cleanup.sh
+++ b/tests/materialize/materialize-databricks/cleanup.sh
@@ -5,6 +5,7 @@ set -o pipefail
 set -o nounset
 
 function dropTable() {
+	echo "dropping $1"
 	echo "y" | dbsqlcli -e "DROP TABLE IF EXISTS $1";
 }
 

--- a/tests/materialize/materialize-databricks/snapshot.json
+++ b/tests/materialize/materialize-databricks/snapshot.json
@@ -30,42 +30,36 @@
       "updated": {
         "some-schema%2Fduplicate_keys_delta": {
           "Query": "\n\tCOPY INTO `some-schema`.duplicate_keys_delta FROM (\n    SELECT\n\t\tid::BIGINT, flow_published_at::TIMESTAMP, int::BIGINT, str::STRING, flow_document::STRING\n  FROM '/Volumes/main/some-schema/flow_staging/flow_temp_tables'\n\t)\n  FILEFORMAT = JSON\n  FILES = ('<uuid>')\n  FORMAT_OPTIONS ( 'mode' = 'FAILFAST', 'ignoreMissingFiles' = 'false' )\n\tCOPY_OPTIONS ( 'mergeSchema' = 'true' )\n  ;\n",
-          "TableCleanup": "\nDROP TABLE IF EXISTS `flow_temp_store_table_00000000_00000000_2_duplicate_keys_delta`\n",
           "ToDelete": [
             "/Volumes/main/some-schema/flow_staging/flow_temp_tables/<uuid>"
           ]
         },
         "some-schema%2Fduplicate_keys_delta_exclude_flow_doc": {
           "Query": "\n\tCOPY INTO `some-schema`.duplicate_keys_delta_exclude_flow_doc FROM (\n    SELECT\n\t\tid::BIGINT, flow_published_at::TIMESTAMP, int::BIGINT, str::STRING\n  FROM '/Volumes/main/some-schema/flow_staging/flow_temp_tables'\n\t)\n  FILEFORMAT = JSON\n  FILES = ('<uuid>')\n  FORMAT_OPTIONS ( 'mode' = 'FAILFAST', 'ignoreMissingFiles' = 'false' )\n\tCOPY_OPTIONS ( 'mergeSchema' = 'true' )\n  ;\n",
-          "TableCleanup": "\nDROP TABLE IF EXISTS `flow_temp_store_table_00000000_00000000_3_duplicate_keys_delta_exclude_flow_doc`\n",
           "ToDelete": [
             "/Volumes/main/some-schema/flow_staging/flow_temp_tables/<uuid>"
           ]
         },
         "some-schema%2Fduplicate_keys_standard": {
           "Query": "\n\tCOPY INTO `some-schema`.duplicate_keys_standard FROM (\n    SELECT\n\t\tid::BIGINT, flow_published_at::TIMESTAMP, int::BIGINT, str::STRING, flow_document::STRING\n  FROM '/Volumes/main/some-schema/flow_staging/flow_temp_tables'\n\t)\n  FILEFORMAT = JSON\n  FILES = ('<uuid>')\n  FORMAT_OPTIONS ( 'mode' = 'FAILFAST', 'ignoreMissingFiles' = 'false' )\n\tCOPY_OPTIONS ( 'mergeSchema' = 'true' )\n  ;\n",
-          "TableCleanup": "\nDROP TABLE IF EXISTS `flow_temp_store_table_00000000_00000000_1_duplicate_keys_standard`\n",
           "ToDelete": [
             "/Volumes/main/some-schema/flow_staging/flow_temp_tables/<uuid>"
           ]
         },
         "some-schema%2Fformatted_strings": {
           "Query": "\n\tCOPY INTO `some-schema`.formatted_strings FROM (\n    SELECT\n\t\tid::BIGINT, date::DATE, datetime::TIMESTAMP, flow_published_at::TIMESTAMP, int_and_str::BIGINT, int_str::BIGINT, num_and_str::DOUBLE, num_str::DOUBLE, time::STRING, flow_document::STRING\n  FROM '/Volumes/main/some-schema/flow_staging/flow_temp_tables'\n\t)\n  FILEFORMAT = JSON\n  FILES = ('<uuid>')\n  FORMAT_OPTIONS ( 'mode' = 'FAILFAST', 'ignoreMissingFiles' = 'false' )\n\tCOPY_OPTIONS ( 'mergeSchema' = 'true' )\n  ;\n",
-          "TableCleanup": "\nDROP TABLE IF EXISTS `flow_temp_store_table_00000000_00000000_5_formatted_strings`\n",
           "ToDelete": [
             "/Volumes/main/some-schema/flow_staging/flow_temp_tables/<uuid>"
           ]
         },
         "some-schema%2Fmultiple_types": {
           "Query": "\n\tCOPY INTO `some-schema`.multiple_types FROM (\n    SELECT\n\t\tid::BIGINT, array_int::STRING, bool_field::BOOLEAN, float_field::DOUBLE, flow_published_at::TIMESTAMP, multiple::STRING, nested::STRING, nullable_int::BIGINT, str_field::STRING, flow_document::STRING\n  FROM '/Volumes/main/some-schema/flow_staging/flow_temp_tables'\n\t)\n  FILEFORMAT = JSON\n  FILES = ('<uuid>')\n  FORMAT_OPTIONS ( 'mode' = 'FAILFAST', 'ignoreMissingFiles' = 'false' )\n\tCOPY_OPTIONS ( 'mergeSchema' = 'true' )\n  ;\n",
-          "TableCleanup": "\nDROP TABLE IF EXISTS `flow_temp_store_table_00000000_00000000_4_multiple_types`\n",
           "ToDelete": [
             "/Volumes/main/some-schema/flow_staging/flow_temp_tables/<uuid>"
           ]
         },
         "some-schema%2Fsimple": {
           "Query": "\n\tCOPY INTO `some-schema`.simple FROM (\n    SELECT\n\t\tid::BIGINT, canary::STRING, flow_published_at::TIMESTAMP, flow_document::STRING\n  FROM '/Volumes/main/some-schema/flow_staging/flow_temp_tables'\n\t)\n  FILEFORMAT = JSON\n  FILES = ('<uuid>')\n  FORMAT_OPTIONS ( 'mode' = 'FAILFAST', 'ignoreMissingFiles' = 'false' )\n\tCOPY_OPTIONS ( 'mergeSchema' = 'true' )\n  ;\n",
-          "TableCleanup": "\nDROP TABLE IF EXISTS `flow_temp_store_table_00000000_00000000_0_simple`\n",
           "ToDelete": [
             "/Volumes/main/some-schema/flow_staging/flow_temp_tables/<uuid>"
           ]
@@ -282,42 +276,36 @@
       "updated": {
         "some-schema%2Fduplicate_keys_delta": {
           "Query": "\n\tCOPY INTO `some-schema`.duplicate_keys_delta FROM (\n    SELECT\n\t\tid::BIGINT, flow_published_at::TIMESTAMP, int::BIGINT, str::STRING, flow_document::STRING\n  FROM '/Volumes/main/some-schema/flow_staging/flow_temp_tables'\n\t)\n  FILEFORMAT = JSON\n  FILES = ('<uuid>')\n  FORMAT_OPTIONS ( 'mode' = 'FAILFAST', 'ignoreMissingFiles' = 'false' )\n\tCOPY_OPTIONS ( 'mergeSchema' = 'true' )\n  ;\n",
-          "TableCleanup": "\nDROP TABLE IF EXISTS `flow_temp_store_table_00000000_00000000_2_duplicate_keys_delta`\n",
           "ToDelete": [
             "/Volumes/main/some-schema/flow_staging/flow_temp_tables/<uuid>"
           ]
         },
         "some-schema%2Fduplicate_keys_delta_exclude_flow_doc": {
           "Query": "\n\tCOPY INTO `some-schema`.duplicate_keys_delta_exclude_flow_doc FROM (\n    SELECT\n\t\tid::BIGINT, flow_published_at::TIMESTAMP, int::BIGINT, str::STRING\n  FROM '/Volumes/main/some-schema/flow_staging/flow_temp_tables'\n\t)\n  FILEFORMAT = JSON\n  FILES = ('<uuid>')\n  FORMAT_OPTIONS ( 'mode' = 'FAILFAST', 'ignoreMissingFiles' = 'false' )\n\tCOPY_OPTIONS ( 'mergeSchema' = 'true' )\n  ;\n",
-          "TableCleanup": "\nDROP TABLE IF EXISTS `flow_temp_store_table_00000000_00000000_3_duplicate_keys_delta_exclude_flow_doc`\n",
           "ToDelete": [
             "/Volumes/main/some-schema/flow_staging/flow_temp_tables/<uuid>"
           ]
         },
         "some-schema%2Fduplicate_keys_standard": {
-          "Query": "\n\tMERGE INTO `some-schema`.duplicate_keys_standard AS l\n\tUSING `flow_temp_store_table_00000000_00000000_1_duplicate_keys_standard` AS r\n\tON l.id = r.id::BIGINT\n\tAND r._metadata_file_name IN ('<uuid>')\n\tWHEN MATCHED AND r.flow_document <=> NULL THEN\n\t\tDELETE\n\tWHEN MATCHED THEN\n\t\tUPDATE SET l.flow_published_at = r.flow_published_at::TIMESTAMP, l.int = r.int::BIGINT, l.str = r.str::STRING, l.flow_document = r.flow_document\n\tWHEN NOT MATCHED THEN\n\t\tINSERT (id, flow_published_at, int, str, flow_document)\n\t\tVALUES (r.id::BIGINT, r.flow_published_at::TIMESTAMP, r.int::BIGINT, r.str::STRING, r.flow_document::STRING);\n",
-          "TableCleanup": "\nDROP TABLE IF EXISTS `flow_temp_store_table_00000000_00000000_1_duplicate_keys_standard`\n",
+          "Query": "\n\tMERGE INTO `some-schema`.duplicate_keys_standard AS l\n\tUSING (\n\t\t(\n\t\t\tSELECT\n\t\t\tid, flow_published_at, int, str, flow_document\n\t\t\tFROM json.`/Volumes/main/some-schema/flow_staging/flow_temp_tables/<uuid>`\n\t\t)\n\t) AS r\n\tON l.id = r.id::BIGINT\n\tWHEN MATCHED AND r.flow_document <=> NULL THEN\n\t\tDELETE\n\tWHEN MATCHED THEN\n\t\tUPDATE SET l.flow_published_at = r.flow_published_at::TIMESTAMP, l.int = r.int::BIGINT, l.str = r.str::STRING, l.flow_document = r.flow_document\n\tWHEN NOT MATCHED THEN\n\t\tINSERT (id, flow_published_at, int, str, flow_document)\n\t\tVALUES (r.id::BIGINT, r.flow_published_at::TIMESTAMP, r.int::BIGINT, r.str::STRING, r.flow_document::STRING);\n",
           "ToDelete": [
             "/Volumes/main/some-schema/flow_staging/flow_temp_tables/<uuid>"
           ]
         },
         "some-schema%2Fformatted_strings": {
           "Query": "\n\tCOPY INTO `some-schema`.formatted_strings FROM (\n    SELECT\n\t\tid::BIGINT, date::DATE, datetime::TIMESTAMP, flow_published_at::TIMESTAMP, int_and_str::BIGINT, int_str::BIGINT, num_and_str::DOUBLE, num_str::DOUBLE, time::STRING, flow_document::STRING\n  FROM '/Volumes/main/some-schema/flow_staging/flow_temp_tables'\n\t)\n  FILEFORMAT = JSON\n  FILES = ('<uuid>')\n  FORMAT_OPTIONS ( 'mode' = 'FAILFAST', 'ignoreMissingFiles' = 'false' )\n\tCOPY_OPTIONS ( 'mergeSchema' = 'true' )\n  ;\n",
-          "TableCleanup": "\nDROP TABLE IF EXISTS `flow_temp_store_table_00000000_00000000_5_formatted_strings`\n",
           "ToDelete": [
             "/Volumes/main/some-schema/flow_staging/flow_temp_tables/<uuid>"
           ]
         },
         "some-schema%2Fmultiple_types": {
-          "Query": "\n\tMERGE INTO `some-schema`.multiple_types AS l\n\tUSING `flow_temp_store_table_00000000_00000000_4_multiple_types` AS r\n\tON l.id = r.id::BIGINT\n\tAND r._metadata_file_name IN ('<uuid>')\n\tWHEN MATCHED AND r.flow_document <=> NULL THEN\n\t\tDELETE\n\tWHEN MATCHED THEN\n\t\tUPDATE SET l.array_int = r.array_int::STRING, l.bool_field = r.bool_field::BOOLEAN, l.float_field = r.float_field::DOUBLE, l.flow_published_at = r.flow_published_at::TIMESTAMP, l.multiple = r.multiple::STRING, l.nested = r.nested::STRING, l.nullable_int = r.nullable_int::BIGINT, l.str_field = r.str_field::STRING, l.flow_document = r.flow_document\n\tWHEN NOT MATCHED THEN\n\t\tINSERT (id, array_int, bool_field, float_field, flow_published_at, multiple, nested, nullable_int, str_field, flow_document)\n\t\tVALUES (r.id::BIGINT, r.array_int::STRING, r.bool_field::BOOLEAN, r.float_field::DOUBLE, r.flow_published_at::TIMESTAMP, r.multiple::STRING, r.nested::STRING, r.nullable_int::BIGINT, r.str_field::STRING, r.flow_document::STRING);\n",
-          "TableCleanup": "\nDROP TABLE IF EXISTS `flow_temp_store_table_00000000_00000000_4_multiple_types`\n",
+          "Query": "\n\tMERGE INTO `some-schema`.multiple_types AS l\n\tUSING (\n\t\t(\n\t\t\tSELECT\n\t\t\tid, array_int, bool_field, float_field, flow_published_at, multiple, nested, nullable_int, str_field, flow_document\n\t\t\tFROM json.`/Volumes/main/some-schema/flow_staging/flow_temp_tables/<uuid>`\n\t\t)\n\t) AS r\n\tON l.id = r.id::BIGINT\n\tWHEN MATCHED AND r.flow_document <=> NULL THEN\n\t\tDELETE\n\tWHEN MATCHED THEN\n\t\tUPDATE SET l.array_int = r.array_int::STRING, l.bool_field = r.bool_field::BOOLEAN, l.float_field = r.float_field::DOUBLE, l.flow_published_at = r.flow_published_at::TIMESTAMP, l.multiple = r.multiple::STRING, l.nested = r.nested::STRING, l.nullable_int = r.nullable_int::BIGINT, l.str_field = r.str_field::STRING, l.flow_document = r.flow_document\n\tWHEN NOT MATCHED THEN\n\t\tINSERT (id, array_int, bool_field, float_field, flow_published_at, multiple, nested, nullable_int, str_field, flow_document)\n\t\tVALUES (r.id::BIGINT, r.array_int::STRING, r.bool_field::BOOLEAN, r.float_field::DOUBLE, r.flow_published_at::TIMESTAMP, r.multiple::STRING, r.nested::STRING, r.nullable_int::BIGINT, r.str_field::STRING, r.flow_document::STRING);\n",
           "ToDelete": [
             "/Volumes/main/some-schema/flow_staging/flow_temp_tables/<uuid>"
           ]
         },
         "some-schema%2Fsimple": {
           "Query": "\n\tCOPY INTO `some-schema`.simple FROM (\n    SELECT\n\t\tid::BIGINT, canary::STRING, flow_published_at::TIMESTAMP, flow_document::STRING\n  FROM '/Volumes/main/some-schema/flow_staging/flow_temp_tables'\n\t)\n  FILEFORMAT = JSON\n  FILES = ('<uuid>')\n  FORMAT_OPTIONS ( 'mode' = 'FAILFAST', 'ignoreMissingFiles' = 'false' )\n\tCOPY_OPTIONS ( 'mergeSchema' = 'true' )\n  ;\n",
-          "TableCleanup": "\nDROP TABLE IF EXISTS `flow_temp_store_table_00000000_00000000_0_simple`\n",
           "ToDelete": [
             "/Volumes/main/some-schema/flow_staging/flow_temp_tables/<uuid>"
           ]
@@ -433,26 +421,6 @@
 }
 {
   "row": {
-    "flow_document": "{\"_meta\":{\"uuid\":\"8de85150-20e1-11ee-990b-ffd12dfcd47f\"},\"id\":1,\"int\":6,\"str\":\"str 6\"}",
-    "flow_published_at": "2023-07-12 18:26:01.560712+00:00",
-    "id": 1,
-    "int": 6,
-    "str": "str 6"
-  },
-  "table": "`main`.`some-schema`.duplicate_keys_standard"
-}
-{
-  "row": {
-    "flow_document": "{\"_meta\":{\"uuid\":\"957348bc-20e1-11ee-990b-ffd12dfcd47f\"},\"id\":2,\"int\":7,\"str\":\"str 7\"}",
-    "flow_published_at": "2023-07-12 18:26:14.215494+00:00",
-    "id": 2,
-    "int": 7,
-    "str": "str 7"
-  },
-  "table": "`main`.`some-schema`.duplicate_keys_standard"
-}
-{
-  "row": {
     "flow_document": "{\"_meta\":{\"uuid\":\"9afb3ff6-20e1-11ee-990b-ffd12dfcd47f\"},\"id\":3,\"int\":8,\"str\":\"str 8\"}",
     "flow_published_at": "2023-07-12 18:26:23.495167+00:00",
     "id": 3,
@@ -473,11 +441,31 @@
 }
 {
   "row": {
+    "flow_document": "{\"_meta\":{\"uuid\":\"957348bc-20e1-11ee-990b-ffd12dfcd47f\"},\"id\":2,\"int\":7,\"str\":\"str 7\"}",
+    "flow_published_at": "2023-07-12 18:26:14.215494+00:00",
+    "id": 2,
+    "int": 7,
+    "str": "str 7"
+  },
+  "table": "`main`.`some-schema`.duplicate_keys_standard"
+}
+{
+  "row": {
     "flow_document": "{\"_meta\":{\"uuid\":\"a65203a8-20e1-11ee-990b-ffd12dfcd47f\"},\"id\":5,\"int\":10,\"str\":\"str 10\"}",
     "flow_published_at": "2023-07-12 18:26:42.518724+00:00",
     "id": 5,
     "int": 10,
     "str": "str 10"
+  },
+  "table": "`main`.`some-schema`.duplicate_keys_standard"
+}
+{
+  "row": {
+    "flow_document": "{\"_meta\":{\"uuid\":\"8de85150-20e1-11ee-990b-ffd12dfcd47f\"},\"id\":1,\"int\":6,\"str\":\"str 6\"}",
+    "flow_published_at": "2023-07-12 18:26:01.560712+00:00",
+    "id": 1,
+    "int": 6,
+    "str": "str 6"
   },
   "table": "`main`.`some-schema`.duplicate_keys_standard"
 }
@@ -748,6 +736,21 @@
 }
 {
   "row": {
+    "array_int": "[91,92]",
+    "bool_field": "False",
+    "float_field": 99.99,
+    "flow_document": "{\"_meta\":{\"uuid\":\"f5b064a8-20e1-11ee-990b-ffd12dfcd47f\"},\"array_int\":[91,92],\"bool_field\":false,\"float_field\":99.99,\"id\":9,\"nested\":{\"id\":\"i9\"},\"nullable_int\":null,\"str_field\":\"str9 v2\"}",
+    "flow_published_at": "2023-07-12 18:28:55.677252+00:00",
+    "id": 9,
+    "multiple": "",
+    "nested": "{\"id\":\"i9\"}",
+    "nullable_int": "",
+    "str_field": "str9 v2"
+  },
+  "table": "`main`.`some-schema`.multiple_types"
+}
+{
+  "row": {
     "array_int": "[61,62]",
     "bool_field": "True",
     "float_field": 66.66,
@@ -788,21 +791,6 @@
     "nested": "{\"id\":\"i8\"}",
     "nullable_int": 8,
     "str_field": "str8 v2"
-  },
-  "table": "`main`.`some-schema`.multiple_types"
-}
-{
-  "row": {
-    "array_int": "[91,92]",
-    "bool_field": "False",
-    "float_field": 99.99,
-    "flow_document": "{\"_meta\":{\"uuid\":\"f5b064a8-20e1-11ee-990b-ffd12dfcd47f\"},\"array_int\":[91,92],\"bool_field\":false,\"float_field\":99.99,\"id\":9,\"nested\":{\"id\":\"i9\"},\"nullable_int\":null,\"str_field\":\"str9 v2\"}",
-    "flow_published_at": "2023-07-12 18:28:55.677252+00:00",
-    "id": 9,
-    "multiple": "",
-    "nested": "{\"id\":\"i9\"}",
-    "nullable_int": "",
-    "str_field": "str9 v2"
   },
   "table": "`main`.`some-schema`.multiple_types"
 }


### PR DESCRIPTION
**Description:**

- Remove the use of temporary tables and use the Databricks SQL syntax for reading from files described here: https://docs.databricks.com/en/files/index.html

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1329)
<!-- Reviewable:end -->
