### PR TITLE
materialize-mysql: reduce buffer use for data loading

### DIFF
--- a/materialize-mysql/.snapshots/TestSQLGeneration
+++ b/materialize-mysql/.snapshots/TestSQLGeneration
@@ -57,7 +57,7 @@ TRUNCATE flow_temp_load_table_1;
 
 --- Begin target_table loadLoad ---
 
-LOAD DATA LOCAL INFILE 'Reader::batch_data_load_0' INTO TABLE flow_temp_load_table_0
+LOAD DATA LOCAL INFILE 'Reader::flow_batch_data_load' INTO TABLE flow_temp_load_table_0
 	FIELDS
 		TERMINATED BY ','
 		OPTIONALLY ENCLOSED BY '"'
@@ -72,7 +72,7 @@ LOAD DATA LOCAL INFILE 'Reader::batch_data_load_0' INTO TABLE flow_temp_load_tab
 
 --- Begin `Delta Updates` loadLoad ---
 
-LOAD DATA LOCAL INFILE 'Reader::batch_data_load_1' INTO TABLE flow_temp_load_table_1
+LOAD DATA LOCAL INFILE 'Reader::flow_batch_data_load' INTO TABLE flow_temp_load_table_1
 	FIELDS
 		TERMINATED BY ','
 		OPTIONALLY ENCLOSED BY '"'
@@ -100,9 +100,9 @@ SELECT * FROM (SELECT -1, CAST(NULL AS JSON) LIMIT 0) as nodoc
 
 --- End `Delta Updates` loadQuery ---
 
---- Begin target_table storeLoad ---
+--- Begin target_table insertLoad ---
 
-LOAD DATA LOCAL INFILE 'Reader::batch_data_store_0' INTO TABLE target_table
+LOAD DATA LOCAL INFILE 'Reader::flow_batch_data_insert' INTO TABLE target_table
 	FIELDS
 		TERMINATED BY ','
 		OPTIONALLY ENCLOSED BY '"'
@@ -119,11 +119,11 @@ LOAD DATA LOCAL INFILE 'Reader::batch_data_store_0' INTO TABLE target_table
 		`value`,
 		flow_document
 );
---- End target_table storeLoad ---
+--- End target_table insertLoad ---
 
---- Begin `Delta Updates` storeLoad ---
+--- Begin `Delta Updates` insertLoad ---
 
-LOAD DATA LOCAL INFILE 'Reader::batch_data_store_1' INTO TABLE `Delta Updates`
+LOAD DATA LOCAL INFILE 'Reader::flow_batch_data_insert' INTO TABLE `Delta Updates`
 	FIELDS
 		TERMINATED BY ','
 		OPTIONALLY ENCLOSED BY '"'
@@ -134,11 +134,11 @@ LOAD DATA LOCAL INFILE 'Reader::batch_data_store_1' INTO TABLE `Delta Updates`
 		`theKey`,
 		`aValue`
 );
---- End `Delta Updates` storeLoad ---
+--- End `Delta Updates` insertLoad ---
 
 --- Begin target_table updateLoad ---
 
-LOAD DATA LOCAL INFILE 'Reader::batch_data_update_0' INTO TABLE flow_temp_update_table_0
+LOAD DATA LOCAL INFILE 'Reader::flow_batch_data_update' INTO TABLE flow_temp_update_table_0
 	FIELDS
 		TERMINATED BY ','
 		OPTIONALLY ENCLOSED BY '"'
@@ -159,7 +159,7 @@ LOAD DATA LOCAL INFILE 'Reader::batch_data_update_0' INTO TABLE flow_temp_update
 
 --- Begin `Delta Updates` updateLoad ---
 
-LOAD DATA LOCAL INFILE 'Reader::batch_data_update_1' INTO TABLE flow_temp_update_table_1
+LOAD DATA LOCAL INFILE 'Reader::flow_batch_data_update' INTO TABLE flow_temp_update_table_1
 	FIELDS
 		TERMINATED BY ','
 		OPTIONALLY ENCLOSED BY '"'

--- a/materialize-mysql/infile.go
+++ b/materialize-mysql/infile.go
@@ -1,0 +1,109 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	stdsql "database/sql"
+	"encoding/csv"
+	"encoding/json"
+	"fmt"
+	"io"
+
+	"github.com/go-sql-driver/mysql"
+)
+
+const (
+	// Limit the maximum size of buffered data before flushing a batch.
+	batchSizeThreshold = 10 * 1024 * 1024
+
+	// File name representations used both here and in the SQL templates.
+	loadInfileName   = "flow_batch_data_load"
+	insertInfileName = "flow_batch_data_insert"
+	updateInfileName = "flow_batch_data_update"
+)
+
+type infile struct {
+	w    *csv.Writer
+	buff *bytes.Buffer
+}
+
+func newInfile(readerName string) *infile {
+	var buff bytes.Buffer
+
+	mysql.RegisterReaderHandler(readerName,
+		func() io.Reader {
+			return &buff
+		},
+	)
+
+	return &infile{
+		w:    csv.NewWriter(&buff),
+		buff: &buff,
+	}
+}
+
+// write writes a single row to the infile buffer. If the buffer is sufficiently larger after the
+// write, it will flush the batch to MySQL per `drainQuery`.
+func (i *infile) write(ctx context.Context, converted []any, txn *stdsql.Tx, drainQuery string) error {
+	if record, err := rowToCSVRecord(converted); err != nil {
+		return fmt.Errorf("error encoding row to CSV: %w", err)
+	} else if err := i.w.Write(record); err != nil {
+		return fmt.Errorf("writing csv record: %w", err)
+	}
+
+	i.w.Flush()
+	if err := i.w.Error(); err != nil {
+		return fmt.Errorf("flushing csv to buffer: %w", err)
+	}
+
+	if i.buff.Len() > batchSizeThreshold {
+		if err := i.drain(ctx, txn, drainQuery); err != nil {
+			return fmt.Errorf("draining infile after write: %w", err)
+		}
+	}
+
+	return nil
+}
+
+func (i *infile) drain(ctx context.Context, txn *stdsql.Tx, drainQuery string) error {
+	if i.buff.Len() == 0 {
+		// Simplification for callers when there is nothing to drain, which would happen if the
+		// infile was drained based on size just prior to cycling through to a different binding.
+		return nil
+	}
+
+	if _, err := txn.ExecContext(ctx, drainQuery); err != nil {
+		return fmt.Errorf("executing infile drain query: %w", err)
+	}
+
+	return nil
+}
+
+func rowToCSVRecord(row []any) ([]string, error) {
+	var record = make([]string, len(row))
+	for i, v := range row {
+		switch value := v.(type) {
+		case []byte:
+			record[i] = string(value)
+		case string:
+			record[i] = value
+		case nil:
+			// See https://dev.mysql.com/doc/refman/8.0/en/problems-with-null.html
+			record[i] = "NULL"
+		case bool:
+			if !value {
+				record[i] = "0"
+			} else {
+				record[i] = "1"
+			}
+		default:
+			b, err := json.Marshal(value)
+			if err != nil {
+				return nil, fmt.Errorf("encoding value as json: %w", err)
+			}
+			record[i] = string(b)
+		}
+	}
+
+	return record, nil
+}

--- a/materialize-mysql/sqlgen.go
+++ b/materialize-mysql/sqlgen.go
@@ -163,7 +163,7 @@ type templates struct {
 	updateLoad        *template.Template
 	updateReplace     *template.Template
 	updateTruncate    *template.Template
-	storeLoad         *template.Template
+	insertLoad        *template.Template
 	loadQuery         *template.Template
 	loadLoad          *template.Template
 	installFence      *template.Template
@@ -244,7 +244,7 @@ TRUNCATE {{ template "temp_load_name" . }};
 -- Templated load into the temporary load table:
 
 {{ define "loadLoad" }}
-LOAD DATA LOCAL INFILE 'Reader::batch_data_load_{{ $.Binding }}' INTO TABLE {{ template "temp_load_name" . }}
+LOAD DATA LOCAL INFILE 'Reader::flow_batch_data_load' INTO TABLE {{ template "temp_load_name" . }}
 	FIELDS
 		TERMINATED BY ','
 		OPTIONALLY ENCLOSED BY '"'
@@ -278,8 +278,8 @@ SELECT * FROM (SELECT -1, CAST(NULL AS JSON) LIMIT 0) as nodoc
 
 -- Template to load data into target table
 
-{{ define "storeLoad" }}
-LOAD DATA LOCAL INFILE 'Reader::batch_data_store_{{ $.Binding }}' INTO TABLE {{ $.Identifier }}
+{{ define "insertLoad" }}
+LOAD DATA LOCAL INFILE 'Reader::flow_batch_data_insert' INTO TABLE {{ $.Identifier }}
 	FIELDS
 		TERMINATED BY ','
 		OPTIONALLY ENCLOSED BY '"'
@@ -311,7 +311,7 @@ CREATE TEMPORARY TABLE {{ template "temp_update_name" . }} (
 {{ end }}
 
 {{ define "updateLoad" }}
-LOAD DATA LOCAL INFILE 'Reader::batch_data_update_{{ $.Binding }}' INTO TABLE {{ template "temp_update_name" . }}
+LOAD DATA LOCAL INFILE 'Reader::flow_batch_data_update' INTO TABLE {{ template "temp_update_name" . }}
 	FIELDS
 		TERMINATED BY ','
 		OPTIONALLY ENCLOSED BY '"'
@@ -406,7 +406,7 @@ UPDATE {{ Identifier $.TablePath }}
 		updateLoad:        tplAll.Lookup("updateLoad"),
 		updateReplace:     tplAll.Lookup("updateReplace"),
 		updateTruncate:    tplAll.Lookup("truncateUpdateTable"),
-		storeLoad:         tplAll.Lookup("storeLoad"),
+		insertLoad:        tplAll.Lookup("insertLoad"),
 		loadQuery:         tplAll.Lookup("loadQuery"),
 		loadLoad:          tplAll.Lookup("loadLoad"),
 		installFence:      tplAll.Lookup("installFence"),

--- a/materialize-mysql/sqlgen_test.go
+++ b/materialize-mysql/sqlgen_test.go
@@ -48,7 +48,7 @@ func TestSQLGeneration(t *testing.T) {
 		templates.tempTruncate,
 		templates.loadLoad,
 		templates.loadQuery,
-		templates.storeLoad,
+		templates.insertLoad,
 		templates.updateLoad,
 		templates.updateReplace,
 		templates.updateTruncate,


### PR DESCRIPTION
**Description:**

Create transactor-scoped buffers and local file readers for uploading data across all bindings, rather than a buffer per binding. Also flush buffers after each time the binding changes during loads to take advantage of the natural grouping of load keys per binding, even though they aren't strictly increasing like for stores.

This greatly reduces memory use of the connector, and allows it to use a constant amount of memory rather than being proportional to the number of bindings.

Closes [#1332](https://github.com/estuary/connectors/issues/1332)

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1331)
<!-- Reviewable:end -->
