### PR TITLE
source-mysql: Support enum primary keys whose cases are in non-alphabetical order

### DIFF
--- a/source-mysql/.snapshots/TestAlterTable_AddColumnSetEnum-enum-restart
+++ b/source-mysql/.snapshots/TestAlterTable_AddColumnSetEnum-enum-restart
@@ -6,5 +6,5 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"test%2FAlterTable_AddColumnSetEnum_enum_76927424":{"backfilled":2,"key_columns":["id"],"metadata":{"schema":{"columns":["id","data","enumCol"],"types":{"data":"text","enumCol":{"enum":["'someValue'","'anotherValue'"],"type":"enum"},"id":"int"}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
+{"bindingStateV1":{"test%2FAlterTable_AddColumnSetEnum_enum_76927424":{"backfilled":2,"key_columns":["id"],"metadata":{"schema":{"columns":["id","data","enumCol"],"types":{"data":"text","enumCol":{"enum":["","'someValue'","'anotherValue'"],"type":"enum"},"id":"int"}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
 

--- a/source-mysql/.snapshots/TestAlterTable_AddColumnSetEnum-enum-stream
+++ b/source-mysql/.snapshots/TestAlterTable_AddColumnSetEnum-enum-stream
@@ -6,5 +6,5 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"test%2FAlterTable_AddColumnSetEnum_enum_76927424":{"backfilled":2,"key_columns":["id"],"metadata":{"schema":{"columns":["id","data","enumCol"],"types":{"data":"text","enumCol":{"enum":["'someValue'","'anotherValue'"],"type":"enum"},"id":"int"}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
+{"bindingStateV1":{"test%2FAlterTable_AddColumnSetEnum_enum_76927424":{"backfilled":2,"key_columns":["id"],"metadata":{"schema":{"columns":["id","data","enumCol"],"types":{"data":"text","enumCol":{"enum":["","'someValue'","'anotherValue'"],"type":"enum"},"id":"int"}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
 

--- a/source-mysql/.snapshots/TestEnumPrimaryKey
+++ b/source-mysql/.snapshots/TestEnumPrimaryKey
@@ -24,5 +24,5 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"test%2FEnumPrimaryKey_18676708":{"backfilled":20,"key_columns":["category","id"],"metadata":{"schema":{"columns":["category","id","data"],"types":{"category":{"enum":["A","C","B","D",""],"type":"enum"},"data":"text","id":"int"}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
+{"bindingStateV1":{"test%2FEnumPrimaryKey_18676708":{"backfilled":20,"key_columns":["category","id"],"metadata":{"schema":{"columns":["category","id","data"],"types":{"category":{"enum":["","A","C","B","D"],"type":"enum"},"data":"text","id":"int"}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
 

--- a/source-mysql/.snapshots/TestEnumPrimaryKey
+++ b/source-mysql/.snapshots/TestEnumPrimaryKey
@@ -1,0 +1,28 @@
+# ================================
+# Collection "acmeCo/test/test_enumprimarykey_18676708": 20 Documents
+# ================================
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"EnumPrimaryKey_18676708","cursor":"backfill:0"}},"category":"","data":"E1","id":1}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"EnumPrimaryKey_18676708","cursor":"backfill:1"}},"category":"","data":"E2","id":2}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"EnumPrimaryKey_18676708","cursor":"backfill:2"}},"category":"","data":"E3","id":3}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"EnumPrimaryKey_18676708","cursor":"backfill:3"}},"category":"","data":"E4","id":4}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"EnumPrimaryKey_18676708","cursor":"backfill:4"}},"category":"A","data":"A1","id":1}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"EnumPrimaryKey_18676708","cursor":"backfill:5"}},"category":"A","data":"A2","id":2}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"EnumPrimaryKey_18676708","cursor":"backfill:6"}},"category":"A","data":"A3","id":3}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"EnumPrimaryKey_18676708","cursor":"backfill:7"}},"category":"A","data":"A4","id":4}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"EnumPrimaryKey_18676708","cursor":"backfill:8"}},"category":"C","data":"C1","id":1}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"EnumPrimaryKey_18676708","cursor":"backfill:9"}},"category":"C","data":"C2","id":2}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"EnumPrimaryKey_18676708","cursor":"backfill:10"}},"category":"C","data":"C3","id":3}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"EnumPrimaryKey_18676708","cursor":"backfill:11"}},"category":"C","data":"C4","id":4}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"EnumPrimaryKey_18676708","cursor":"backfill:12"}},"category":"B","data":"B1","id":1}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"EnumPrimaryKey_18676708","cursor":"backfill:13"}},"category":"B","data":"B2","id":2}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"EnumPrimaryKey_18676708","cursor":"backfill:14"}},"category":"B","data":"B3","id":3}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"EnumPrimaryKey_18676708","cursor":"backfill:15"}},"category":"B","data":"B4","id":4}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"EnumPrimaryKey_18676708","cursor":"backfill:16"}},"category":"D","data":"D1","id":1}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"EnumPrimaryKey_18676708","cursor":"backfill:17"}},"category":"D","data":"D2","id":2}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"EnumPrimaryKey_18676708","cursor":"backfill:18"}},"category":"D","data":"D3","id":3}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"EnumPrimaryKey_18676708","cursor":"backfill:19"}},"category":"D","data":"D4","id":4}
+# ================================
+# Final State Checkpoint
+# ================================
+{"bindingStateV1":{"test%2FEnumPrimaryKey_18676708":{"backfilled":20,"key_columns":["category","id"],"metadata":{"schema":{"columns":["category","id","data"],"types":{"category":{"enum":["A","C","B","D",""],"type":"enum"},"data":"text","id":"int"}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
+

--- a/source-mysql/datatype_test.go
+++ b/source-mysql/datatype_test.go
@@ -80,10 +80,10 @@ func TestDatatypes(t *testing.T) {
 		{ColumnType: "mediumblob", ExpectType: `{"type":["string","null"],"contentEncoding":"base64"}`, InputValue: []byte{0x12, 0x34, 0x56, 0x78}, ExpectValue: `"EjRWeA=="`},
 		{ColumnType: "longblob", ExpectType: `{"type":["string","null"],"contentEncoding":"base64"}`, InputValue: []byte{0x12, 0x34, 0x56, 0x78}, ExpectValue: `"EjRWeA=="`},
 
-		{ColumnType: `enum('sm', 'med', 'lg')`, ExpectType: `{"type":["string","null"],"enum":["sm","med","lg","",null]}`, InputValue: nil, ExpectValue: `null`},
-		{ColumnType: `enum('sm', 'med', 'lg') not null`, ExpectType: `{"type":"string","enum":["sm","med","lg",""]}`, InputValue: "sm", ExpectValue: `"sm"`},
-		{ColumnType: `enum('s,m', 'med', '\'lg\'')`, ExpectType: `{"type":["string","null"],"enum":["s,m","med","'lg'","",null]}`, InputValue: `'lg'`, ExpectValue: `"'lg'"`},
-		{ColumnType: `enum('s,m', 'med', '\'lg\'')`, ExpectType: `{"type":["string","null"],"enum":["s,m","med","'lg'","",null]}`, InputValue: `invalid`, ExpectValue: `""`},
+		{ColumnType: `enum('sm', 'med', 'lg')`, ExpectType: `{"type":["string","null"],"enum":["","sm","med","lg",null]}`, InputValue: nil, ExpectValue: `null`},
+		{ColumnType: `enum('sm', 'med', 'lg') not null`, ExpectType: `{"type":"string","enum":["","sm","med","lg"]}`, InputValue: "sm", ExpectValue: `"sm"`},
+		{ColumnType: `enum('s,m', 'med', '\'lg\'')`, ExpectType: `{"type":["string","null"],"enum":["","s,m","med","'lg'",null]}`, InputValue: `'lg'`, ExpectValue: `"'lg'"`},
+		{ColumnType: `enum('s,m', 'med', '\'lg\'')`, ExpectType: `{"type":["string","null"],"enum":["","s,m","med","'lg'",null]}`, InputValue: `invalid`, ExpectValue: `""`},
 
 		{ColumnType: "set('a', 'b', 'c')", ExpectType: `{"type":["string","null"]}`, InputValue: "b", ExpectValue: `"b"`},
 		{ColumnType: "set('a', 'b', 'c')", ExpectType: `{"type":["string","null"]}`, InputValue: "a,c", ExpectValue: `"a,c"`},

--- a/source-mysql/main.go
+++ b/source-mysql/main.go
@@ -338,11 +338,12 @@ func (db *mysqlDatabase) FallbackCollectionKey() []string {
 }
 
 func encodeKeyFDB(key, ktype interface{}) (tuple.TupleElement, error) {
-	switch val := key.(type) {
-	case []byte:
-		if typeName, ok := ktype.(string); ok {
-			switch typeName {
-			case "decimal":
+	if columnType, ok := ktype.(*mysqlColumnType); ok {
+		return columnType.encodeKeyFDB(key)
+	} else if typeName, ok := ktype.(string); ok {
+		switch typeName {
+		case "decimal":
+			if val, ok := key.([]byte); ok {
 				// TODO(wgd): This should probably be done in a more principled way, but
 				// this is a viable placeholder solution.
 				return strconv.ParseFloat(string(val), 64)

--- a/source-mysql/replication.go
+++ b/source-mysql/replication.go
@@ -676,7 +676,9 @@ func (rs *mysqlReplicationStream) handleAlterTable(ctx context.Context, stmt *sq
 
 func translateDataType(t sqlparser.ColumnType) any {
 	var typeName = strings.ToLower(t.Type)
-	if typeName == "enum" || typeName == "set" {
+	if typeName == "enum" {
+		return &mysqlColumnType{Type: typeName, EnumValues: append([]string{""}, t.EnumValues...)}
+	} else if typeName == "set" {
 		return &mysqlColumnType{Type: typeName, EnumValues: t.EnumValues}
 	}
 	return typeName


### PR DESCRIPTION
**Description:**

This PR fixes the connector backfill behavior when capturing from tables whose primary key includes a column of enum type whose cases are listed in non-alphabetical order.

The issue in this scenario was previously that if asked to `ORDER BY category` (where `category` is an enum column), MySQL will sort the rows based on the integer representation of those values. However when we ask it to return rows `WHERE category > 'foo'` for some string value `'foo'` the database will return those rows where that column's string representation is lexicographically greater than the string `'foo'`. Which is arguably correct, we need to cast that string to an enum to get the comparison behavior we actually want. But it makes things tricky for us here, because that cast is nontrivial to write generically.

So instead what we've done is the moral equivalent of going `WHERE category > 2` and comparing to the integer representation of the enum. To make this work we have to store the integer index of the enum value in our backfill row key serialization, instead of the string value as we previously did. Since the only things we use the row keys for are ordering comparisons and feeding back into the database, this is better than the current behavior in all cases.

**Workflow steps:**

Backfills in the rather niche corner case described above can now work in precise mode like they're supposed to.

I believe this change can safely be rolled out without any special effort at coordinating things. The change to row key serialization is technically incompatible, but this will only be an issue in practice if there's an ongoing backfill of a table with an enumeration primary key which gets restarted before the backfill completes, and if that were to happen it would show up in the task failures log and we can fix it by re-backfilling the impacted table(s) from the top.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1336)
<!-- Reviewable:end -->
