### PR TITLE
materialize-motherduck: use string columns for UUIDs

### DIFF
--- a/materialize-motherduck/.snapshots/TestValidateAndApply
+++ b/materialize-motherduck/.snapshots/TestValidateAndApply
@@ -113,7 +113,7 @@ Big Schema Changed Types Constraints:
 {"Field":"stringUriField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
 {"Field":"stringUriReferenceField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
 {"Field":"stringUriTemplateField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringUuidField","Type":6,"TypeString":"UNSATISFIABLE","Reason":"Field 'stringUuidField' is already being materialized as endpoint type 'UUID' but endpoint type 'VARCHAR' is required by its schema '{ type: [string] }'"}
+{"Field":"stringUuidField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
 
 Big Schema Materialized Resource Schema With All Fields Required:
 {"Name":"_meta/flow_truncated","Nullable":"NO","Type":"BOOLEAN"}
@@ -151,7 +151,7 @@ Big Schema Materialized Resource Schema With All Fields Required:
 {"Name":"stringUriField","Nullable":"NO","Type":"VARCHAR"}
 {"Name":"stringUriReferenceField","Nullable":"NO","Type":"VARCHAR"}
 {"Name":"stringUriTemplateField","Nullable":"NO","Type":"VARCHAR"}
-{"Name":"stringUuidField","Nullable":"NO","Type":"UUID"}
+{"Name":"stringUuidField","Nullable":"NO","Type":"VARCHAR"}
 
 Big Schema Materialized Resource Schema With No Fields Required:
 {"Name":"_meta/flow_truncated","Nullable":"NO","Type":"BOOLEAN"}
@@ -189,7 +189,7 @@ Big Schema Materialized Resource Schema With No Fields Required:
 {"Name":"stringUriField","Nullable":"YES","Type":"VARCHAR"}
 {"Name":"stringUriReferenceField","Nullable":"YES","Type":"VARCHAR"}
 {"Name":"stringUriTemplateField","Nullable":"YES","Type":"VARCHAR"}
-{"Name":"stringUuidField","Nullable":"YES","Type":"UUID"}
+{"Name":"stringUuidField","Nullable":"YES","Type":"VARCHAR"}
 
 Big Schema Changed Types With Table Replacement Constraints:
 {"Field":"_meta/flow_truncated","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"Metadata fields fields are able to be materialized"}

--- a/materialize-motherduck/sqlgen.go
+++ b/materialize-motherduck/sqlgen.go
@@ -32,7 +32,11 @@ var duckDialect = func() sql.Dialect {
 				"date-time": sql.NewStaticMapper("TIMESTAMP WITH TIME ZONE"),
 				"duration":  sql.NewStaticMapper("INTERVAL"),
 				"time":      sql.NewStaticMapper("TIME"),
-				"uuid":      sql.NewStaticMapper("UUID"),
+				// UUIDs are currently broken in the DuckDB version used by MotherDuck, see
+				// https://github.com/duckdb/duckdb/issues/9193. To support UUIDs in the future,
+				// we'll need to re-backfill tables that have UUIDs as strings, or allow string
+				// columns to validate as uuid columns.
+				// "uuid":      sql.NewStaticMapper("UUID"),
 			},
 		},
 	}


### PR DESCRIPTION
**Description:**

Materialize UUID fields as string columns since UUID columns are currently broken in the DuckDB version used by MotherDuck.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1337)
<!-- Reviewable:end -->
