### PR TITLE
source-dynamodb: increase concurrent table backfill scan workers

### DIFF
--- a/source-dynamodb/pull.go
+++ b/source-dynamodb/pull.go
@@ -32,7 +32,7 @@ const (
 	backfillDuration = 1 * time.Hour
 
 	// Number of concurrent workers to use when backfilling a table.
-	backfillConcurrency = 3
+	backfillConcurrency = 5
 
 	// Number of stream workers which may concurrently send requests for stream data.
 	streamConcurrency = 5


### PR DESCRIPTION
**Description:**

This may improve throughput when scanning a single large table with large documents.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

The originally selected value of 3 was completely arbitrary, and so is this new value. There may be some really fancy way to figure out the optimal value dynamically, but this manual adjustment should be good enough for now to provide useful information.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1347)
<!-- Reviewable:end -->
