### PR TITLE
Source-hubspot: Removing max amount of auth retries

### DIFF
--- a/source-hubspot/source_hubspot/streams.py
+++ b/source-hubspot/source_hubspot/streams.py
@@ -371,7 +371,7 @@ class Stream(HttpStream, ABC):
         return json_schema
 
 
-    @retry_401(max_tries=20)
+    @retry_401()
     def handle_request(
         self,
         stream_slice: Mapping[str, Any] = None,

--- a/source-hubspot/source_hubspot/streams.py
+++ b/source-hubspot/source_hubspot/streams.py
@@ -14,6 +14,7 @@ from typing import Any, Dict, Iterable, List, Mapping, MutableMapping, Optional,
 import backoff
 import pendulum as pendulum
 import requests
+from copy import deepcopy
 from airbyte_cdk.entrypoint import logger
 from airbyte_cdk.models import SyncMode
 from airbyte_cdk.sources import Source
@@ -371,7 +372,7 @@ class Stream(HttpStream, ABC):
         return json_schema
 
 
-    @retry_401()
+    @retry_401(max_tries=5)
     def handle_request(
         self,
         stream_slice: Mapping[str, Any] = None,
@@ -443,6 +444,8 @@ class Stream(HttpStream, ABC):
         pagination_complete = False
 
         next_page_token = None
+        self.authenticator._token_expiry_date = self.authenticator._token_expiry_date.subtract(minutes=2)
+        old_expiry_date = deepcopy(self.authenticator._token_expiry_date)
         try:
             while not pagination_complete:
                 properties = self._property_wrapper
@@ -461,6 +464,11 @@ class Stream(HttpStream, ABC):
                     )
                     records = self._transform(self.parse_response(response, stream_state=stream_state, stream_slice=stream_slice))
 
+                if old_expiry_date != self.authenticator._token_expiry_date:
+                    # this means that we got a new token
+                    self.logger.info(" GOT NEW TOKEN ")
+                    self.authenticator._token_expiry_date = self.authenticator._token_expiry_date.subtract(minutes=2)
+                    old_expiry_date = deepcopy(self.authenticator._token_expiry_date)
                 if self.filter_old_records:
                     records = self._filter_old_records(records)
                 yield from records


### PR DESCRIPTION
**Description:**
As of now, Hubspot Source still fails due to  re-authentication limits.
This happens due to Hubspot `access_token` short lifespan ( about 30 minutes ), and the connector failing to re-authenticate properly.
Previous attemps set the number of retries to 20, but it seems the amount of user data can be higher than estimated and no issues would arise from removing the limit.

More information on the commit.
**Notes for reviewers:**
### New tests ( second commit, reviewing )
Tests were made locally running for about 2 hours and 15 hours

Token rotation is marked with a **GOT NEW TOKEN** info logger message.
![Screenshot from 2024-03-22 14-51-57](https://github.com/estuary/connectors/assets/14100959/4759bd84-e3e7-4023-a3a5-9a150e61c66b)

as one can validate, each new token now rotates on about 28 minutes run, not 30 ( lifetime of the hubspot access_token)

Fully stats after runing for about 15 hours:
![Screenshot from 2024-03-24 11-25-16](https://github.com/estuary/connectors/assets/14100959/7b1eaf40-fe99-4565-bf34-7ca9d3d28835)


<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1352)
<!-- Reviewable:end -->
