### PR TITLE
estuary-cdk: Add `restart_interval` override

### DIFF
--- a/estuary-cdk/estuary_cdk/capture/__init__.py
+++ b/estuary-cdk/estuary_cdk/capture/__init__.py
@@ -262,7 +262,13 @@ class BaseCaptureConnector(
             # Gracefully exit after the capture interval has elapsed.
             # We don't do this within the TaskGroup because we don't
             # want to block on it.
-            asyncio.create_task(stop_on_elapsed_interval(open.capture.intervalSeconds))
+            asyncio.create_task(
+                stop_on_elapsed_interval(
+                    int(open.capture.config.restart_interval.total_seconds())
+                    if open.capture.config.restart_interval
+                    else open.capture.intervalSeconds
+                )
+            )
 
             async with asyncio.TaskGroup() as tg:
 

--- a/estuary-cdk/estuary_cdk/flow.py
+++ b/estuary-cdk/estuary_cdk/flow.py
@@ -1,9 +1,22 @@
 import abc
 from dataclasses import dataclass
-from pydantic import BaseModel, NonNegativeInt, PositiveInt
-from typing import Any, Literal, TypeVar, Generic, Literal
+from datetime import timedelta
+from pydantic import BaseModel, Field, NonNegativeInt, PositiveInt
+from typing import Any, Literal, Optional, TypeVar, Generic, Literal
 
 from .pydantic_polyfill import GenericModel
+
+
+class BaseEndpointConfig(abc.ABC, BaseModel, extra="forbid"):
+    """
+    BaseEndpointConfig defines the endpoint config attribute(s) shared by all connectors.
+    """
+
+    # If unset, use the default `intervalSeconds` provided as part of the Open request
+    restart_interval: Optional[timedelta] = Field(
+        default=None, description="How long before the connector restarts automatically"
+    )
+
 
 # The type of this invoked connector.
 ConnectorType = Literal[
@@ -12,7 +25,7 @@ ConnectorType = Literal[
 ]
 
 # Generic type of a connector's endpoint configuration.
-EndpointConfig = TypeVar("EndpointConfig")
+EndpointConfig = TypeVar("EndpointConfig", bound=BaseEndpointConfig)
 
 # Generic type of a connector's resource configuration.
 ResourceConfig = TypeVar("ResourceConfig", bound=BaseModel)


### PR DESCRIPTION
**Description:**

This allows connectors to override their target lifetime. The problem is that some connectors may have tasks that run for longer than the restart interval. Since the restart signal is soft, i.e all tasks are allowed to run to completion before the connector exits (but no new tasks will be started once the restart signal has been triggered), tasks running longer than the restart interval could effectively starve the shorter-running tasks.

**Note:** This _does_ feel like kind of a band-aid fix, but I'm not thinking of a better option right now. Needing to restart at all feels like a bit of a smell... so maybe this should be paired with some logic to just never (voluntarily, we should still handle external exit requests properly) restart if not needed? 

Also, ideally this would be hidden under an Advanced section, but I wasn't confident enough in my knowledge of Python OOP best practices to define a generic/abstract base `BaseAdvanced` class, and then have the abstract `BaseEndpointConfig` include it, while also allowing both to remain extendable by connector authors. If you feel strongly that it should be in Advanced then I'll go and figure this part out, if not I'm happy to leave it as is for now.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1354)
<!-- Reviewable:end -->
