### PR TITLE
materialize-bigquery: create numeric formatted string column key fields as strings columns

### DIFF
--- a/materialize-bigquery/sqlgen.go
+++ b/materialize-bigquery/sqlgen.go
@@ -67,9 +67,15 @@ var bqDialect = func() sql.Dialect {
 		sql.STRING: sql.StringTypeMapper{
 			Fallback: sql.NewStaticMapper("STRING"),
 			WithFormat: map[string]sql.TypeMapper{
-				"integer": sql.NewStaticMapper("BIGNUMERIC(38,0)", sql.WithElementConverter(sql.StdStrToInt())),
-				// https://cloud.google.com/bigquery/docs/reference/standard-sql/conversion_functions#cast_as_floating_point
-				"number":    sql.NewStaticMapper("FLOAT64", sql.WithElementConverter(sql.StdStrToFloat("NaN", "Infinity", "-Infinity"))),
+				"integer": sql.PrimaryKeyMapper{
+					PrimaryKey: sql.NewStaticMapper("STRING"),
+					Delegate:   sql.NewStaticMapper("BIGNUMERIC(38,0)", sql.WithElementConverter(sql.StdStrToInt())),
+				},
+				"number": sql.PrimaryKeyMapper{
+					PrimaryKey: sql.NewStaticMapper("STRING"),
+					// https://cloud.google.com/bigquery/docs/reference/standard-sql/conversion_functions#cast_as_floating_point
+					Delegate: sql.NewStaticMapper("FLOAT64", sql.WithElementConverter(sql.StdStrToFloat("NaN", "Infinity", "-Infinity"))),
+				},
 				"date":      sql.NewStaticMapper("DATE", sql.WithElementConverter(sql.ClampDate())),
 				"date-time": sql.NewStaticMapper("TIMESTAMP", sql.WithElementConverter(sql.ClampDatetime())),
 			},


### PR DESCRIPTION
**Description:**

For string fields with `format: integer` or `format: number`, we have the convention of creating these columns as their underlying "string" column type if they are collection keys. This wasn't happening in `materialize-bigquery`, which causes immediate validation errors when a table like this is created. This fixes that issue, by making `materialize-bigquery` consistently with all other SQL materializations.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

I'm not totally sure we really need to create `type: string, format: integer` fields as `string` columns, but its what we have been doing everywhere else and I think it makes the most sense to be consistent. It is necessary for `type: string, format: number` columns to avoid issues with rounding in the destination when it doesn't support a sufficiently large decimal column type, which is generally the case. And we have not addressed primary key fields with various other `format` types, and I'm leaving that as tomorrow's problem as well.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1358)
<!-- Reviewable:end -->
