### PR TITLE
source-mysql: Fix enum decoding off-by-one bug by migrating old metadata

### DIFF
--- a/source-mysql/.snapshots/TestEnumDecodingFix-backfill
+++ b/source-mysql/.snapshots/TestEnumDecodingFix-backfill
@@ -1,0 +1,13 @@
+# ================================
+# Collection "acmeCo/test/test_enumdecodingfix_32314857": 5 Documents
+# ================================
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"EnumDecodingFix_32314857","cursor":"backfill:0"}},"category":"A","id":1}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"EnumDecodingFix_32314857","cursor":"backfill:1"}},"category":"B","id":2}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"EnumDecodingFix_32314857","cursor":"backfill:2"}},"category":"C","id":3}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"EnumDecodingFix_32314857","cursor":"backfill:3"}},"category":"D","id":4}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"EnumDecodingFix_32314857","cursor":"backfill:4"}},"category":"","id":5}
+# ================================
+# Final State Checkpoint
+# ================================
+{"bindingStateV1":{"test%2FEnumDecodingFix_32314857":{"backfilled":5,"key_columns":["id"],"metadata":{"schema":{"columns":["id","category"],"types":{"category":{"enum":["","A","C","B","D"],"type":"enum"},"id":"int"}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
+

--- a/source-mysql/.snapshots/TestEnumDecodingFix-replication1
+++ b/source-mysql/.snapshots/TestEnumDecodingFix-replication1
@@ -1,0 +1,13 @@
+# ================================
+# Collection "acmeCo/test/test_enumdecodingfix_32314857": 5 Documents
+# ================================
+{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"EnumDecodingFix_32314857","cursor":"binlog.000123:56789:123","txid":"11111111-1111-1111-1111-111111111111:111"}},"category":"A","id":6}
+{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"EnumDecodingFix_32314857","cursor":"binlog.000123:56789:123","txid":"11111111-1111-1111-1111-111111111111:111"}},"category":"B","id":7}
+{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"EnumDecodingFix_32314857","cursor":"binlog.000123:56789:123","txid":"11111111-1111-1111-1111-111111111111:111"}},"category":"C","id":8}
+{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"EnumDecodingFix_32314857","cursor":"binlog.000123:56789:123","txid":"11111111-1111-1111-1111-111111111111:111"}},"category":"D","id":9}
+{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"EnumDecodingFix_32314857","cursor":"binlog.000123:56789:123","txid":"11111111-1111-1111-1111-111111111111:111"}},"category":"","id":10}
+# ================================
+# Final State Checkpoint
+# ================================
+{"bindingStateV1":{"test%2FEnumDecodingFix_32314857":{"backfilled":5,"key_columns":["id"],"metadata":{"schema":{"columns":["id","category"],"types":{"category":{"enum":["","A","C","B","D"],"type":"enum"},"id":"int"}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
+

--- a/source-mysql/.snapshots/TestEnumDecodingFix-replication2
+++ b/source-mysql/.snapshots/TestEnumDecodingFix-replication2
@@ -1,0 +1,13 @@
+# ================================
+# Collection "acmeCo/test/test_enumdecodingfix_32314857": 5 Documents
+# ================================
+{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"EnumDecodingFix_32314857","cursor":"binlog.000123:56789:123","txid":"11111111-1111-1111-1111-111111111111:111"}},"category":"C","id":11}
+{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"EnumDecodingFix_32314857","cursor":"binlog.000123:56789:123","txid":"11111111-1111-1111-1111-111111111111:111"}},"category":"D","id":12}
+{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"EnumDecodingFix_32314857","cursor":"binlog.000123:56789:123","txid":"11111111-1111-1111-1111-111111111111:111"}},"category":"B","id":13}
+{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"EnumDecodingFix_32314857","cursor":"binlog.000123:56789:123","txid":"11111111-1111-1111-1111-111111111111:111"}},"category":"","id":14}
+{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"EnumDecodingFix_32314857","cursor":"binlog.000123:56789:123","txid":"11111111-1111-1111-1111-111111111111:111"}},"category":"A","id":15}
+# ================================
+# Final State Checkpoint
+# ================================
+{"bindingStateV1":{"test%2FEnumDecodingFix_32314857":{"backfilled":5,"key_columns":["id"],"metadata":{"schema":{"columns":["id","category"],"types":{"category":{"enum":["A","C","B","D",""],"type":"enum"},"id":"int"}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
+

--- a/source-mysql/.snapshots/TestEnumDecodingFix-replication2
+++ b/source-mysql/.snapshots/TestEnumDecodingFix-replication2
@@ -1,13 +1,13 @@
 # ================================
 # Collection "acmeCo/test/test_enumdecodingfix_32314857": 5 Documents
 # ================================
-{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"EnumDecodingFix_32314857","cursor":"binlog.000123:56789:123","txid":"11111111-1111-1111-1111-111111111111:111"}},"category":"C","id":11}
-{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"EnumDecodingFix_32314857","cursor":"binlog.000123:56789:123","txid":"11111111-1111-1111-1111-111111111111:111"}},"category":"D","id":12}
-{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"EnumDecodingFix_32314857","cursor":"binlog.000123:56789:123","txid":"11111111-1111-1111-1111-111111111111:111"}},"category":"B","id":13}
-{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"EnumDecodingFix_32314857","cursor":"binlog.000123:56789:123","txid":"11111111-1111-1111-1111-111111111111:111"}},"category":"","id":14}
-{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"EnumDecodingFix_32314857","cursor":"binlog.000123:56789:123","txid":"11111111-1111-1111-1111-111111111111:111"}},"category":"A","id":15}
+{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"EnumDecodingFix_32314857","cursor":"binlog.000123:56789:123","txid":"11111111-1111-1111-1111-111111111111:111"}},"category":"A","id":11}
+{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"EnumDecodingFix_32314857","cursor":"binlog.000123:56789:123","txid":"11111111-1111-1111-1111-111111111111:111"}},"category":"B","id":12}
+{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"EnumDecodingFix_32314857","cursor":"binlog.000123:56789:123","txid":"11111111-1111-1111-1111-111111111111:111"}},"category":"C","id":13}
+{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"EnumDecodingFix_32314857","cursor":"binlog.000123:56789:123","txid":"11111111-1111-1111-1111-111111111111:111"}},"category":"D","id":14}
+{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"EnumDecodingFix_32314857","cursor":"binlog.000123:56789:123","txid":"11111111-1111-1111-1111-111111111111:111"}},"category":"","id":15}
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"test%2FEnumDecodingFix_32314857":{"backfilled":5,"key_columns":["id"],"metadata":{"schema":{"columns":["id","category"],"types":{"category":{"enum":["A","C","B","D",""],"type":"enum"},"id":"int"}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
+{"bindingStateV1":{"test%2FEnumDecodingFix_32314857":{"backfilled":5,"key_columns":["id"],"metadata":{"schema":{"columns":["id","category"],"types":{"category":{"enum":["","A","C","B","D"],"type":"enum"},"id":"int"}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
 

--- a/source-mysql/capture_test.go
+++ b/source-mysql/capture_test.go
@@ -183,6 +183,9 @@ func TestEnumPrimaryKey(t *testing.T) {
 }
 
 func TestEnumDecodingFix(t *testing.T) {
+	// This test is part of the fix for the enum decoding bug introduced by https://github.com/estuary/connectors/pull/1336
+	// and can be deleted after the metadata migration logic is also removed. The metadata migration logic can safely be
+	// removed after all live captures we care about have run the fix code and updated their checkpoint metadata.
 	var tb, ctx = mysqlTestBackend(t), context.Background()
 	var uniqueID = "32314857"
 	var tableName = tb.CreateTable(ctx, t, uniqueID, "(id INTEGER PRIMARY KEY, category ENUM('A', 'C', 'B', 'D'))")


### PR DESCRIPTION
**Description:**

In https://github.com/estuary/connectors/pull/1336 I (unnecessarily) refactored `source-mysql` to have the enum cases ordered like ["", "A", "B"] where previously they were ["A", "B", ""] and updated the indexing to match. But preexisting captures from before that change have the old style ordering in their metadata, and that's not updated anywhere, so they decode replication events incorrectly.

We can't even revert the changed indexing behavior at this point, because by now there are important captures which have been re-backfilled using the new ordering in their metadata, which would be incorrect if we simply reverted the change.

In order to fix this, we need to roll things forward and implement some metadata update logic which will prepend `""` to the list of options for any enum which doesn't already have it.

Once all production captures have run this code and updated their metadata it will be safe to remove the migration code and the associated test case.

After this change is live we should:

1. Ensure that all `source-mysql` capture tasks are restarted ASAP to make sure they pick up this fix.
2. Identify the scope of potentially-incorrect data which might have been captured over the past 4 days. Capture tasks which were restarted in the last 4 days and which captured replication events into their output collection from a table with an enum column type could potentially have incorrect values and will need to either be re-backfilled or otherwise fixed [1].

[1] It is theoretically possible to identify any incorrectly captured documents in the output collections which have not since been updated again, locate the enum case ordering which was in use at the time, construct an edited document, and append that into the collection. This would be a ton of work and it's almost certainly better to re-backfill, but if it's really important and we find a collection which cannot be recaptured this could be done.

**Notes for reviewers:**

Please look at this closely and let me know if you think of any edge cases I might have overlooked, I already screwed this up once with the original refactoring and I'd really prefer not to make things worse with a failed bugfix.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1361)
<!-- Reviewable:end -->
