### PR TITLE
ci: only refresh tags if connector is updated

### DIFF
--- a/.github/actions/deploy/action.yaml
+++ b/.github/actions/deploy/action.yaml
@@ -60,8 +60,15 @@ runs:
       shell: bash
       run: sudo apt install postgresql
 
+    - uses: dorny/paths-filter@v2
+      id: filter
+      with:
+        filters: |
+          connector:
+            - "${{ inputs.connector }}/**"
+
     - name: Refresh connector tags for ${{ inputs.connector }}
-      if: ${{ github.event_name == 'push' }}
+      if: github.event_name == 'push' && steps.filter.outputs.connector == 'true'
       shell: bash
       env:
         PGDATABASE: ${{ inputs.pg_database }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -301,8 +301,15 @@ jobs:
           sudo apt update
           sudo apt install postgresql
 
+      - uses: dorny/paths-filter@v2
+        id: filter
+        with:
+          filters: |
+            connector:
+              - "${{ matrix.connector }}/**"
+
       - name: Refresh connector tags for ${{ matrix.connector }}
-        if: ${{ github.event_name == 'push' }}
+        if: github.event_name == 'push' && steps.filter.outputs.connector == 'true'
         env:
           PGHOST: ${{ secrets.POSTGRES_CONNECTOR_REFRESH_HOST }}
           PGUSER: ${{ secrets.POSTGRES_CONNECTOR_REFRESH_USER }}


### PR DESCRIPTION
**Description:**

- Previously we would refresh the connector tags of all connectors even if they were not updated in the commit
- With this change, we only refresh connectors which have had their code updated
- One caveat is updating of a SDK / dependencies (go.mod) / shared files will not trigger a refresh unless a connector has also been directly updated. We can also include those shared resources in our condition

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1370)
<!-- Reviewable:end -->
