### PR TITLE
sqlcapture: delete reduction for _meta/op: "d"

### DIFF
--- a/source-mysql/.snapshots/TestGeneric-KeylessDiscovery
+++ b/source-mysql/.snapshots/TestGeneric-KeylessDiscovery
@@ -38,6 +38,28 @@ Binding 0:
       },
       "allOf": [
         {
+          "if": {
+            "properties": {
+              "_meta": {
+                "properties": {
+                  "op": {
+                    "const": "d"
+                  }
+                }
+              }
+            }
+          },
+          "then": {
+            "reduce": {
+              "delete": true,
+              "strategy": "merge"
+            }
+          },
+          "else": {
+            "reduce": {
+              "strategy": "merge"
+            }
+          },
           "required": [
             "_meta"
           ],
@@ -104,9 +126,6 @@ Binding 0:
                 "strategy": "merge"
               }
             }
-          },
-          "reduce": {
-            "strategy": "merge"
           }
         },
         {

--- a/source-mysql/.snapshots/TestGeneric-SimpleDiscovery
+++ b/source-mysql/.snapshots/TestGeneric-SimpleDiscovery
@@ -37,6 +37,28 @@ Binding 0:
       },
       "allOf": [
         {
+          "if": {
+            "properties": {
+              "_meta": {
+                "properties": {
+                  "op": {
+                    "const": "d"
+                  }
+                }
+              }
+            }
+          },
+          "then": {
+            "reduce": {
+              "delete": true,
+              "strategy": "merge"
+            }
+          },
+          "else": {
+            "reduce": {
+              "strategy": "merge"
+            }
+          },
           "required": [
             "_meta"
           ],
@@ -103,9 +125,6 @@ Binding 0:
                 "strategy": "merge"
               }
             }
-          },
-          "reduce": {
-            "strategy": "merge"
           }
         },
         {

--- a/source-mysql/.snapshots/TestPartitionedTable-Discovery
+++ b/source-mysql/.snapshots/TestPartitionedTable-Discovery
@@ -32,6 +32,28 @@ Binding 0:
       },
       "allOf": [
         {
+          "if": {
+            "properties": {
+              "_meta": {
+                "properties": {
+                  "op": {
+                    "const": "d"
+                  }
+                }
+              }
+            }
+          },
+          "then": {
+            "reduce": {
+              "delete": true,
+              "strategy": "merge"
+            }
+          },
+          "else": {
+            "reduce": {
+              "strategy": "merge"
+            }
+          },
           "required": [
             "_meta"
           ],
@@ -98,9 +120,6 @@ Binding 0:
                 "strategy": "merge"
               }
             }
-          },
-          "reduce": {
-            "strategy": "merge"
           }
         },
         {

--- a/source-mysql/.snapshots/TestSecondaryIndexDiscovery-index_only
+++ b/source-mysql/.snapshots/TestSecondaryIndexDiscovery-index_only
@@ -38,6 +38,28 @@ Binding 0:
       },
       "allOf": [
         {
+          "if": {
+            "properties": {
+              "_meta": {
+                "properties": {
+                  "op": {
+                    "const": "d"
+                  }
+                }
+              }
+            }
+          },
+          "then": {
+            "reduce": {
+              "delete": true,
+              "strategy": "merge"
+            }
+          },
+          "else": {
+            "reduce": {
+              "strategy": "merge"
+            }
+          },
           "required": [
             "_meta"
           ],
@@ -104,9 +126,6 @@ Binding 0:
                 "strategy": "merge"
               }
             }
-          },
-          "reduce": {
-            "strategy": "merge"
           }
         },
         {

--- a/source-mysql/.snapshots/TestSecondaryIndexDiscovery-nonunique_index
+++ b/source-mysql/.snapshots/TestSecondaryIndexDiscovery-nonunique_index
@@ -35,6 +35,28 @@ Binding 0:
       },
       "allOf": [
         {
+          "if": {
+            "properties": {
+              "_meta": {
+                "properties": {
+                  "op": {
+                    "const": "d"
+                  }
+                }
+              }
+            }
+          },
+          "then": {
+            "reduce": {
+              "delete": true,
+              "strategy": "merge"
+            }
+          },
+          "else": {
+            "reduce": {
+              "strategy": "merge"
+            }
+          },
           "required": [
             "_meta"
           ],
@@ -101,9 +123,6 @@ Binding 0:
                 "strategy": "merge"
               }
             }
-          },
-          "reduce": {
-            "strategy": "merge"
           }
         },
         {

--- a/source-mysql/.snapshots/TestSecondaryIndexDiscovery-nothing
+++ b/source-mysql/.snapshots/TestSecondaryIndexDiscovery-nothing
@@ -35,6 +35,28 @@ Binding 0:
       },
       "allOf": [
         {
+          "if": {
+            "properties": {
+              "_meta": {
+                "properties": {
+                  "op": {
+                    "const": "d"
+                  }
+                }
+              }
+            }
+          },
+          "then": {
+            "reduce": {
+              "delete": true,
+              "strategy": "merge"
+            }
+          },
+          "else": {
+            "reduce": {
+              "strategy": "merge"
+            }
+          },
           "required": [
             "_meta"
           ],
@@ -101,9 +123,6 @@ Binding 0:
                 "strategy": "merge"
               }
             }
-          },
-          "reduce": {
-            "strategy": "merge"
           }
         },
         {

--- a/source-mysql/.snapshots/TestSecondaryIndexDiscovery-nullable_index
+++ b/source-mysql/.snapshots/TestSecondaryIndexDiscovery-nullable_index
@@ -41,6 +41,28 @@ Binding 0:
       },
       "allOf": [
         {
+          "if": {
+            "properties": {
+              "_meta": {
+                "properties": {
+                  "op": {
+                    "const": "d"
+                  }
+                }
+              }
+            }
+          },
+          "then": {
+            "reduce": {
+              "delete": true,
+              "strategy": "merge"
+            }
+          },
+          "else": {
+            "reduce": {
+              "strategy": "merge"
+            }
+          },
           "required": [
             "_meta"
           ],
@@ -107,9 +129,6 @@ Binding 0:
                 "strategy": "merge"
               }
             }
-          },
-          "reduce": {
-            "strategy": "merge"
           }
         },
         {

--- a/source-mysql/.snapshots/TestSecondaryIndexDiscovery-pk_and_index
+++ b/source-mysql/.snapshots/TestSecondaryIndexDiscovery-pk_and_index
@@ -34,6 +34,28 @@ Binding 0:
       },
       "allOf": [
         {
+          "if": {
+            "properties": {
+              "_meta": {
+                "properties": {
+                  "op": {
+                    "const": "d"
+                  }
+                }
+              }
+            }
+          },
+          "then": {
+            "reduce": {
+              "delete": true,
+              "strategy": "merge"
+            }
+          },
+          "else": {
+            "reduce": {
+              "strategy": "merge"
+            }
+          },
           "required": [
             "_meta"
           ],
@@ -100,9 +122,6 @@ Binding 0:
                 "strategy": "merge"
               }
             }
-          },
-          "reduce": {
-            "strategy": "merge"
           }
         },
         {

--- a/source-mysql/.snapshots/TestTrickyColumnNames-discover
+++ b/source-mysql/.snapshots/TestTrickyColumnNames-discover
@@ -28,6 +28,28 @@ Binding 0:
       },
       "allOf": [
         {
+          "if": {
+            "properties": {
+              "_meta": {
+                "properties": {
+                  "op": {
+                    "const": "d"
+                  }
+                }
+              }
+            }
+          },
+          "then": {
+            "reduce": {
+              "delete": true,
+              "strategy": "merge"
+            }
+          },
+          "else": {
+            "reduce": {
+              "strategy": "merge"
+            }
+          },
           "required": [
             "_meta"
           ],
@@ -94,9 +116,6 @@ Binding 0:
                 "strategy": "merge"
               }
             }
-          },
-          "reduce": {
-            "strategy": "merge"
           }
         },
         {
@@ -138,6 +157,28 @@ Binding 1:
       },
       "allOf": [
         {
+          "if": {
+            "properties": {
+              "_meta": {
+                "properties": {
+                  "op": {
+                    "const": "d"
+                  }
+                }
+              }
+            }
+          },
+          "then": {
+            "reduce": {
+              "delete": true,
+              "strategy": "merge"
+            }
+          },
+          "else": {
+            "reduce": {
+              "strategy": "merge"
+            }
+          },
           "required": [
             "_meta"
           ],
@@ -204,9 +245,6 @@ Binding 1:
                 "strategy": "merge"
               }
             }
-          },
-          "reduce": {
-            "strategy": "merge"
           }
         },
         {

--- a/source-mysql/.snapshots/TestTrickyTableNames-Discover
+++ b/source-mysql/.snapshots/TestTrickyTableNames-Discover
@@ -25,6 +25,28 @@ Binding 0:
       },
       "allOf": [
         {
+          "if": {
+            "properties": {
+              "_meta": {
+                "properties": {
+                  "op": {
+                    "const": "d"
+                  }
+                }
+              }
+            }
+          },
+          "then": {
+            "reduce": {
+              "delete": true,
+              "strategy": "merge"
+            }
+          },
+          "else": {
+            "reduce": {
+              "strategy": "merge"
+            }
+          },
           "required": [
             "_meta"
           ],
@@ -91,9 +113,6 @@ Binding 0:
                 "strategy": "merge"
               }
             }
-          },
-          "reduce": {
-            "strategy": "merge"
           }
         },
         {

--- a/source-sqlserver/.snapshots/TestIndexIncludedDiscovery
+++ b/source-sqlserver/.snapshots/TestIndexIncludedDiscovery
@@ -38,6 +38,28 @@ Binding 0:
       },
       "allOf": [
         {
+          "if": {
+            "properties": {
+              "_meta": {
+                "properties": {
+                  "op": {
+                    "const": "d"
+                  }
+                }
+              }
+            }
+          },
+          "then": {
+            "reduce": {
+              "delete": true,
+              "strategy": "merge"
+            }
+          },
+          "else": {
+            "reduce": {
+              "strategy": "merge"
+            }
+          },
           "required": [
             "_meta"
           ],
@@ -110,9 +132,6 @@ Binding 0:
                 "strategy": "merge"
               }
             }
-          },
-          "reduce": {
-            "strategy": "merge"
           }
         },
         {

--- a/source-sqlserver/.snapshots/TestSecondaryIndexDiscovery-index_only
+++ b/source-sqlserver/.snapshots/TestSecondaryIndexDiscovery-index_only
@@ -38,6 +38,28 @@ Binding 0:
       },
       "allOf": [
         {
+          "if": {
+            "properties": {
+              "_meta": {
+                "properties": {
+                  "op": {
+                    "const": "d"
+                  }
+                }
+              }
+            }
+          },
+          "then": {
+            "reduce": {
+              "delete": true,
+              "strategy": "merge"
+            }
+          },
+          "else": {
+            "reduce": {
+              "strategy": "merge"
+            }
+          },
           "required": [
             "_meta"
           ],
@@ -110,9 +132,6 @@ Binding 0:
                 "strategy": "merge"
               }
             }
-          },
-          "reduce": {
-            "strategy": "merge"
           }
         },
         {

--- a/source-sqlserver/.snapshots/TestSecondaryIndexDiscovery-nonunique_index
+++ b/source-sqlserver/.snapshots/TestSecondaryIndexDiscovery-nonunique_index
@@ -35,6 +35,28 @@ Binding 0:
       },
       "allOf": [
         {
+          "if": {
+            "properties": {
+              "_meta": {
+                "properties": {
+                  "op": {
+                    "const": "d"
+                  }
+                }
+              }
+            }
+          },
+          "then": {
+            "reduce": {
+              "delete": true,
+              "strategy": "merge"
+            }
+          },
+          "else": {
+            "reduce": {
+              "strategy": "merge"
+            }
+          },
           "required": [
             "_meta"
           ],
@@ -107,9 +129,6 @@ Binding 0:
                 "strategy": "merge"
               }
             }
-          },
-          "reduce": {
-            "strategy": "merge"
           }
         },
         {

--- a/source-sqlserver/.snapshots/TestSecondaryIndexDiscovery-nothing
+++ b/source-sqlserver/.snapshots/TestSecondaryIndexDiscovery-nothing
@@ -35,6 +35,28 @@ Binding 0:
       },
       "allOf": [
         {
+          "if": {
+            "properties": {
+              "_meta": {
+                "properties": {
+                  "op": {
+                    "const": "d"
+                  }
+                }
+              }
+            }
+          },
+          "then": {
+            "reduce": {
+              "delete": true,
+              "strategy": "merge"
+            }
+          },
+          "else": {
+            "reduce": {
+              "strategy": "merge"
+            }
+          },
           "required": [
             "_meta"
           ],
@@ -107,9 +129,6 @@ Binding 0:
                 "strategy": "merge"
               }
             }
-          },
-          "reduce": {
-            "strategy": "merge"
           }
         },
         {

--- a/source-sqlserver/.snapshots/TestSecondaryIndexDiscovery-nullable_index
+++ b/source-sqlserver/.snapshots/TestSecondaryIndexDiscovery-nullable_index
@@ -41,6 +41,28 @@ Binding 0:
       },
       "allOf": [
         {
+          "if": {
+            "properties": {
+              "_meta": {
+                "properties": {
+                  "op": {
+                    "const": "d"
+                  }
+                }
+              }
+            }
+          },
+          "then": {
+            "reduce": {
+              "delete": true,
+              "strategy": "merge"
+            }
+          },
+          "else": {
+            "reduce": {
+              "strategy": "merge"
+            }
+          },
           "required": [
             "_meta"
           ],
@@ -113,9 +135,6 @@ Binding 0:
                 "strategy": "merge"
               }
             }
-          },
-          "reduce": {
-            "strategy": "merge"
           }
         },
         {

--- a/source-sqlserver/.snapshots/TestSecondaryIndexDiscovery-pk_and_index
+++ b/source-sqlserver/.snapshots/TestSecondaryIndexDiscovery-pk_and_index
@@ -34,6 +34,28 @@ Binding 0:
       },
       "allOf": [
         {
+          "if": {
+            "properties": {
+              "_meta": {
+                "properties": {
+                  "op": {
+                    "const": "d"
+                  }
+                }
+              }
+            }
+          },
+          "then": {
+            "reduce": {
+              "delete": true,
+              "strategy": "merge"
+            }
+          },
+          "else": {
+            "reduce": {
+              "strategy": "merge"
+            }
+          },
           "required": [
             "_meta"
           ],
@@ -106,9 +128,6 @@ Binding 0:
                 "strategy": "merge"
               }
             }
-          },
-          "reduce": {
-            "strategy": "merge"
           }
         },
         {

--- a/source-sqlserver/.snapshots/TestVarcharKeyDiscovery
+++ b/source-sqlserver/.snapshots/TestVarcharKeyDiscovery
@@ -28,6 +28,28 @@ Binding 0:
       },
       "allOf": [
         {
+          "if": {
+            "properties": {
+              "_meta": {
+                "properties": {
+                  "op": {
+                    "const": "d"
+                  }
+                }
+              }
+            }
+          },
+          "then": {
+            "reduce": {
+              "delete": true,
+              "strategy": "merge"
+            }
+          },
+          "else": {
+            "reduce": {
+              "strategy": "merge"
+            }
+          },
           "required": [
             "_meta"
           ],
@@ -100,9 +122,6 @@ Binding 0:
                 "strategy": "merge"
               }
             }
-          },
-          "reduce": {
-            "strategy": "merge"
           }
         },
         {

--- a/sqlcapture/discovery.go
+++ b/sqlcapture/discovery.go
@@ -127,11 +127,40 @@ func DiscoverCatalog(ctx context.Context, db Database) ([]*pc.Response_Discovere
 								Required: []string{"op", "source"},
 							},
 						},
-						"reduce": map[string]interface{}{
-							"strategy": "merge",
-						},
 					},
 					Required: []string{"_meta"},
+					If: &jsonschema.Schema{
+						Extras: map[string]interface{}{
+							"properties": map[string]*jsonschema.Schema{
+								"_meta": {
+									Extras: map[string]interface{}{
+										"properties": map[string]*jsonschema.Schema{
+											"op": {
+												Extras: map[string]interface{}{
+													"const": "d",
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+					Then: &jsonschema.Schema{
+						Extras: map[string]interface{}{
+							"reduce": map[string]interface{}{
+								"strategy": "merge",
+								"delete":   true,
+							},
+						},
+					},
+					Else: &jsonschema.Schema{
+						Extras: map[string]interface{}{
+							"reduce": map[string]interface{}{
+								"strategy": "merge",
+							},
+						},
+					},
 				},
 				{Ref: "#" + anchor},
 			},


### PR DESCRIPTION
**Description:**

- Update the schema of `sqlcapture` connector so that when `_meta/op: "d"`, our JSONSchema specifies `reduce: { delete: true }`
- Tested this using `flowctl preview --delay 5s` and adding a log at https://github.com/estuary/flow/blob/74b61c820ffe19472eb435ad67f32b51968e26f5/crates/doc/src/reduce/strategy.rs#L357 to check whether the runtime would detect `delete: true` and it works as expected.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1371)
<!-- Reviewable:end -->
