### PR TITLE
materialize-snowflake: USE SCHEMA for alter table executions

### DIFF
--- a/materialize-snowflake/client.go
+++ b/materialize-snowflake/client.go
@@ -65,6 +65,7 @@ func (c *client) CreateTable(ctx context.Context, tc sql.TableCreate) error {
 	if err != nil {
 		return err
 	}
+	defer conn.Close()
 
 	if _, err := conn.ExecContext(ctx, fmt.Sprintf("CREATE SCHEMA IF NOT EXISTS %q", schemaName)); err != nil {
 		return err
@@ -86,6 +87,8 @@ func (c *client) DeleteTable(ctx context.Context, path []string) (string, boiler
 		if err != nil {
 			return err
 		}
+		defer conn.Close()
+
 		if _, err := conn.ExecContext(ctx, fmt.Sprintf("USE SCHEMA %q", c.cfg.Schema)); err != nil {
 			return err
 		}
@@ -106,10 +109,12 @@ func (c *client) AlterTable(ctx context.Context, ta sql.TableAlter) (string, boi
 		if err != nil {
 			return err
 		}
+		defer conn.Close()
+
 		if _, err := conn.ExecContext(ctx, fmt.Sprintf("USE SCHEMA %q", c.cfg.Schema)); err != nil {
 			return err
 		}
-		_, err = c.db.ExecContext(ctx, alterColumnStmt)
+		_, err = conn.ExecContext(ctx, alterColumnStmt)
 		return err
 	}, nil
 }


### PR DESCRIPTION
**Description:**

Make sure we use the same connection that ran the USE SCHEMA command when running table alterations. Also make sure to return connections to the connection pool when done.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1373)
<!-- Reviewable:end -->
