### PR TITLE
materialize-snowflake: use dialect identifier transformer for schema

### DIFF
--- a/materialize-snowflake/client.go
+++ b/materialize-snowflake/client.go
@@ -67,11 +67,11 @@ func (c *client) CreateTable(ctx context.Context, tc sql.TableCreate) error {
 	}
 	defer conn.Close()
 
-	if _, err := conn.ExecContext(ctx, fmt.Sprintf("CREATE SCHEMA IF NOT EXISTS %q", schemaName)); err != nil {
+	if _, err := conn.ExecContext(ctx, fmt.Sprintf("CREATE SCHEMA IF NOT EXISTS %s", c.ep.Dialect.Identifier(schemaName))); err != nil {
 		return err
 	}
 
-	if _, err := conn.ExecContext(ctx, fmt.Sprintf("USE SCHEMA %q", c.cfg.Schema)); err != nil {
+	if _, err := conn.ExecContext(ctx, fmt.Sprintf("USE SCHEMA %s", c.ep.Dialect.Identifier(c.cfg.Schema))); err != nil {
 		return err
 	}
 
@@ -89,7 +89,7 @@ func (c *client) DeleteTable(ctx context.Context, path []string) (string, boiler
 		}
 		defer conn.Close()
 
-		if _, err := conn.ExecContext(ctx, fmt.Sprintf("USE SCHEMA %q", c.cfg.Schema)); err != nil {
+		if _, err := conn.ExecContext(ctx, fmt.Sprintf("USE SCHEMA %s", c.ep.Dialect.Identifier(c.cfg.Schema))); err != nil {
 			return err
 		}
 		_, err = conn.ExecContext(ctx, stmt)
@@ -111,7 +111,7 @@ func (c *client) AlterTable(ctx context.Context, ta sql.TableAlter) (string, boi
 		}
 		defer conn.Close()
 
-		if _, err := conn.ExecContext(ctx, fmt.Sprintf("USE SCHEMA %q", c.cfg.Schema)); err != nil {
+		if _, err := conn.ExecContext(ctx, fmt.Sprintf("USE SCHEMA %s", c.ep.Dialect.Identifier(c.cfg.Schema))); err != nil {
 			return err
 		}
 		_, err = conn.ExecContext(ctx, alterColumnStmt)


### PR DESCRIPTION
**Description:**

- We were quoting all identifiers and this was leading to "simple" identifiers being quoted which would then distinguish them from then unquoted, upper-case relatives

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1378)
<!-- Reviewable:end -->
