### PR TITLE
source-{postgres,redshift}-batch: Use 'pg_catalog' for discovery

### DIFF
--- a/source-postgres-batch/.snapshots/TestBasicCapture-Discovery
+++ b/source-postgres-batch/.snapshots/TestBasicCapture-Discovery
@@ -15,7 +15,8 @@ Binding 0:
       "read_schema_json": {
         "type": "object",
         "required": [
-          "_meta"
+          "_meta",
+          "id"
         ],
         "properties": {
           "_meta": {
@@ -39,13 +40,15 @@ Binding 0:
               "polled",
               "index"
             ]
+          },
+          "id": {
+            "type": "integer"
           }
         },
         "x-infer-schema": true
       },
       "key": [
-        "/_meta/polled",
-        "/_meta/index"
+        "/id"
       ],
       "projections": null
     },

--- a/source-postgres-batch/.snapshots/TestKeyDiscovery
+++ b/source-postgres-batch/.snapshots/TestKeyDiscovery
@@ -1,22 +1,26 @@
 Binding 0:
 {
     "resource_config_json": {
-      "name": "test_basic_datatypes_13111208",
-      "template": "{{if .IsFirstQuery -}}\n  SELECT xmin AS txid, * FROM \"test\".\"basic_datatypes_13111208\" ORDER BY xmin::text::bigint;\n{{- else -}}\n  SELECT xmin AS txid, * FROM \"test\".\"basic_datatypes_13111208\" WHERE xmin::text::bigint \u003e $1 ORDER BY xmin::text::bigint;\n{{- end}}",
+      "name": "test_key_discovery_329932",
+      "template": "{{if .IsFirstQuery -}}\n  SELECT xmin AS txid, * FROM \"test\".\"key_discovery_329932\" ORDER BY xmin::text::bigint;\n{{- else -}}\n  SELECT xmin AS txid, * FROM \"test\".\"key_discovery_329932\" WHERE xmin::text::bigint \u003e $1 ORDER BY xmin::text::bigint;\n{{- end}}",
       "cursor": [
         "txid"
       ]
     },
     "resource_path": [
-      "test_basic_datatypes_13111208"
+      "test_key_discovery_329932"
     ],
     "collection": {
-      "name": "acmeCo/test/test_basic_datatypes_13111208",
+      "name": "acmeCo/test/test_key_discovery_329932",
       "read_schema_json": {
         "type": "object",
         "required": [
           "_meta",
-          "id"
+          "k_smallint",
+          "k_int",
+          "k_bigint",
+          "k_bool",
+          "k_str"
         ],
         "properties": {
           "_meta": {
@@ -41,17 +45,33 @@ Binding 0:
               "index"
             ]
           },
-          "id": {
+          "k_bigint": {
             "type": "integer"
+          },
+          "k_bool": {
+            "type": "boolean"
+          },
+          "k_int": {
+            "type": "integer"
+          },
+          "k_smallint": {
+            "type": "integer"
+          },
+          "k_str": {
+            "type": "string"
           }
         },
         "x-infer-schema": true
       },
       "key": [
-        "/id"
+        "/k_smallint",
+        "/k_int",
+        "/k_bigint",
+        "/k_bool",
+        "/k_str"
       ],
       "projections": null
     },
-    "state_key": "test_basic_datatypes_13111208"
+    "state_key": "test_key_discovery_329932"
   }
 

--- a/source-postgres-batch/.snapshots/TestSchemaFilter-FilteredIn
+++ b/source-postgres-batch/.snapshots/TestSchemaFilter-FilteredIn
@@ -15,7 +15,8 @@ Binding 0:
       "read_schema_json": {
         "type": "object",
         "required": [
-          "_meta"
+          "_meta",
+          "id"
         ],
         "properties": {
           "_meta": {
@@ -39,13 +40,15 @@ Binding 0:
               "polled",
               "index"
             ]
+          },
+          "id": {
+            "type": "integer"
           }
         },
         "x-infer-schema": true
       },
       "key": [
-        "/_meta/polled",
-        "/_meta/index"
+        "/id"
       ],
       "projections": null
     },

--- a/source-postgres-batch/.snapshots/TestSchemaFilter-Unfiltered
+++ b/source-postgres-batch/.snapshots/TestSchemaFilter-Unfiltered
@@ -15,7 +15,8 @@ Binding 0:
       "read_schema_json": {
         "type": "object",
         "required": [
-          "_meta"
+          "_meta",
+          "id"
         ],
         "properties": {
           "_meta": {
@@ -39,13 +40,15 @@ Binding 0:
               "polled",
               "index"
             ]
+          },
+          "id": {
+            "type": "integer"
           }
         },
         "x-infer-schema": true
       },
       "key": [
-        "/_meta/polled",
-        "/_meta/index"
+        "/id"
       ],
       "projections": null
     },

--- a/source-postgres-batch/driver.go
+++ b/source-postgres-batch/driver.go
@@ -155,14 +155,6 @@ func (BatchSQLDriver) Apply(ctx context.Context, req *pc.Request_Apply) (*pc.Res
 	return &pc.Response_Applied{ActionDescription: ""}, nil
 }
 
-var excludedSystemSchemas = []string{
-	"pg_catalog",
-	"information_schema",
-	"pg_internal",
-	"catalog_history",
-	"cron",
-}
-
 // Discover enumerates tables and views from `information_schema.tables` and generates
 // placeholder capture queries for thos tables.
 func (drv *BatchSQLDriver) Discover(ctx context.Context, req *pc.Request_Discover) (*pc.Response_Discovered, error) {
@@ -198,11 +190,6 @@ func (drv *BatchSQLDriver) Discover(ctx context.Context, req *pc.Request_Discove
 
 	var bindings []*pc.Response_Discovered_Binding
 	for _, table := range tables {
-		// Exclude tables in "system schemas" such as information_schema or pg_catalog.
-		if slices.Contains(excludedSystemSchemas, table.Schema) {
-			continue
-		}
-
 		var tableID = table.Schema + "." + table.Name
 
 		var recommendedName = recommendedCatalogName(table.Schema, table.Name)
@@ -267,12 +254,25 @@ type discoveredTable struct {
 func discoverTables(ctx context.Context, db *sql.DB, discoverSchemas []string) ([]*discoveredTable, error) {
 	var query = new(strings.Builder)
 	var args []any
-	fmt.Fprintf(query, "SELECT table_schema, table_name, table_type FROM information_schema.tables")
+
+	fmt.Fprintf(query, "SELECT n.nspname AS table_schema,")
+	fmt.Fprintf(query, "       c.relname AS table_name,")
+	fmt.Fprintf(query, "       CASE")
+	fmt.Fprintf(query, "         WHEN n.oid = pg_my_temp_schema() THEN 'LOCAL TEMPORARY'::text")
+	fmt.Fprintf(query, "         WHEN c.relkind = ANY (ARRAY['r'::\"char\", 'p'::\"char\"]) THEN 'BASE TABLE'::text")
+	fmt.Fprintf(query, "         WHEN c.relkind = 'v'::\"char\" THEN 'VIEW'::text")
+	fmt.Fprintf(query, "         WHEN c.relkind = 'f'::\"char\" THEN 'FOREIGN'::text")
+	fmt.Fprintf(query, "         ELSE ''::text")
+	fmt.Fprintf(query, "       END::information_schema.character_data AS table_type")
+	fmt.Fprintf(query, " FROM pg_catalog.pg_class c")
+	fmt.Fprintf(query, " JOIN pg_catalog.pg_namespace n ON (n.oid = c.relnamespace)")
+	fmt.Fprintf(query, " WHERE n.nspname NOT IN ('pg_catalog', 'pg_internal', 'information_schema', 'catalog_history', 'cron')")
+	fmt.Fprintf(query, "  AND c.relkind IN ('r', 'p', 'v', 'f')")
 	if len(discoverSchemas) > 0 {
-		fmt.Fprintf(query, " WHERE table_schema = ANY ($1)")
+		fmt.Fprintf(query, "  AND n.nspname = ANY ($1)")
 		args = append(args, discoverSchemas)
 	}
-	fmt.Fprintf(query, ";")
+	fmt.Fprintf(query, "  AND NOT c.relispartition;") // Exclude subpartitions of a partitioned table from discovery
 
 	rows, err := db.QueryContext(ctx, query.String(), args...)
 	if err != nil {
@@ -305,29 +305,28 @@ type discoveredPrimaryKey struct {
 func discoverPrimaryKeys(ctx context.Context, db *sql.DB, discoverSchemas []string) ([]*discoveredPrimaryKey, error) {
 	var query = new(strings.Builder)
 	var args []any
-	// Joining on the 6-tuple {CONSTRAINT,TABLE}_{CATALOG,SCHEMA,NAME} is probably
-	// overkill but shouldn't hurt, and helps to make absolutely sure that we're
-	// matching up the constraint type with the column names/positions correctly.
-	fmt.Fprintf(query, "SELECT kcu.table_schema, kcu.table_name, kcu.column_name, kcu.ordinal_position, col.data_type")
-	fmt.Fprintf(query, " FROM information_schema.key_column_usage kcu")
-	fmt.Fprintf(query, " JOIN information_schema.table_constraints tcs")
-	fmt.Fprintf(query, "  ON  tcs.constraint_catalog = kcu.constraint_catalog")
-	fmt.Fprintf(query, "  AND tcs.constraint_schema = kcu.constraint_schema")
-	fmt.Fprintf(query, "  AND tcs.constraint_name = kcu.constraint_name")
-	fmt.Fprintf(query, "  AND tcs.table_catalog = kcu.table_catalog")
-	fmt.Fprintf(query, "  AND tcs.table_schema = kcu.table_schema")
-	fmt.Fprintf(query, "  AND tcs.table_name = kcu.table_name")
-	fmt.Fprintf(query, " JOIN information_schema.columns col")
-	fmt.Fprintf(query, "  ON  col.table_catalog = kcu.table_catalog")
-	fmt.Fprintf(query, "  AND col.table_schema = kcu.table_schema")
-	fmt.Fprintf(query, "  AND col.table_name = kcu.table_name")
-	fmt.Fprintf(query, "  AND col.column_name = kcu.column_name")
-	fmt.Fprintf(query, " WHERE tcs.constraint_type = 'PRIMARY KEY'")
+
+	fmt.Fprintf(query, "SELECT result.TABLE_SCHEM, result.TABLE_NAME, result.COLUMN_NAME, result.KEY_SEQ, result.TYPE_NAME")
+	fmt.Fprintf(query, " FROM (")
+	fmt.Fprintf(query, "  SELECT n.nspname AS TABLE_SCHEM,")
+	fmt.Fprintf(query, "   ct.relname AS TABLE_NAME, a.attname AS COLUMN_NAME,")
+	fmt.Fprintf(query, "   (information_schema._pg_expandarray(i.indkey)).n AS KEY_SEQ, ci.relname AS PK_NAME,")
+	fmt.Fprintf(query, "   information_schema._pg_expandarray(i.indkey) AS KEYS, a.attnum AS A_ATTNUM,")
+	fmt.Fprintf(query, "   t.typname AS TYPE_NAME")
+	fmt.Fprintf(query, "  FROM pg_catalog.pg_class ct")
+	fmt.Fprintf(query, "   JOIN pg_catalog.pg_attribute a ON (ct.oid = a.attrelid)")
+	fmt.Fprintf(query, "   JOIN pg_catalog.pg_namespace n ON (ct.relnamespace = n.oid)")
+	fmt.Fprintf(query, "   JOIN pg_catalog.pg_index i ON (a.attrelid = i.indrelid)")
+	fmt.Fprintf(query, "   JOIN pg_catalog.pg_class ci ON (ci.oid = i.indexrelid)")
+	fmt.Fprintf(query, "   JOIN pg_catalog.pg_type t ON (a.atttypid = t.oid)")
+	fmt.Fprintf(query, "  WHERE i.indisprimary")
 	if len(discoverSchemas) > 0 {
-		fmt.Fprintf(query, "  AND kcu.table_schema = ANY ($1)")
+		fmt.Fprintf(query, "   AND n.nspname = ANY ($1)")
 		args = append(args, discoverSchemas)
 	}
-	fmt.Fprintf(query, " ORDER BY kcu.table_schema, kcu.table_name, kcu.ordinal_position;")
+	fmt.Fprintf(query, " ) result")
+	fmt.Fprintf(query, " WHERE result.A_ATTNUM = (result.KEYS).x")
+	fmt.Fprintf(query, " ORDER BY result.table_name, result.pk_name, result.key_seq;")
 
 	rows, err := db.QueryContext(ctx, query.String(), args...)
 	if err != nil {
@@ -374,10 +373,11 @@ func discoverPrimaryKeys(ctx context.Context, db *sql.DB, discoverSchemas []stri
 }
 
 var databaseTypeToJSON = map[string]*jsonschema.Schema{
-	"integer":  {Type: "integer"},
-	"bigint":   {Type: "integer"},
-	"smallint": {Type: "integer"},
-	"boolean":  {Type: "boolean"},
+	"int2":    {Type: "integer"},
+	"int4":    {Type: "integer"},
+	"int8":    {Type: "integer"},
+	"bool":    {Type: "boolean"},
+	"varchar": {Type: "string"},
 }
 
 var catalogNameSanitizerRe = regexp.MustCompile(`(?i)[^a-z0-9\-_.]`)

--- a/source-postgres-batch/main_test.go
+++ b/source-postgres-batch/main_test.go
@@ -139,6 +139,20 @@ func TestSchemaFilter(t *testing.T) {
 	})
 }
 
+func TestKeyDiscovery(t *testing.T) {
+	var ctx, cs = context.Background(), testCaptureSpec(t)
+	var control = testControlClient(ctx, t)
+	var uniqueID = "329932"
+	var tableName = fmt.Sprintf("test.key_discovery_%s", uniqueID)
+
+	executeControlQuery(ctx, t, control, fmt.Sprintf("DROP TABLE IF EXISTS %s", tableName))
+	t.Cleanup(func() { executeControlQuery(ctx, t, control, fmt.Sprintf("DROP TABLE IF EXISTS %s", tableName)) })
+	executeControlQuery(ctx, t, control, fmt.Sprintf("CREATE TABLE %s(k_smallint SMALLINT, k_int INTEGER, k_bigint BIGINT, k_bool BOOLEAN, k_str VARCHAR(8), data TEXT, PRIMARY KEY (k_smallint, k_int, k_bigint, k_bool, k_str))", tableName))
+
+	cs.EndpointSpec.(*Config).Advanced.DiscoverSchemas = []string{"test"}
+	snapshotBindings(t, discoverStreams(ctx, t, cs, regexp.MustCompile(uniqueID)))
+}
+
 func testControlClient(ctx context.Context, t testing.TB) *sql.DB {
 	t.Helper()
 	if os.Getenv("TEST_DATABASE") != "yes" {

--- a/source-redshift-batch/.snapshots/TestKeyDiscovery
+++ b/source-redshift-batch/.snapshots/TestKeyDiscovery
@@ -1,0 +1,75 @@
+Binding 0:
+{
+    "resource_config_json": {
+      "name": "test_key_discovery_329932",
+      "template": "{{if .CursorFields -}}\n  {{- if .IsFirstQuery -}}\n    SELECT * FROM \"test\".\"key_discovery_329932\"\n  {{- else -}}\n    SELECT * FROM \"test\".\"key_discovery_329932\"\n\t{{- range $i, $k := $.CursorFields -}}\n\t  {{- if eq $i 0}} WHERE ({{else}}) OR ({{end -}}\n      {{- range $j, $n := $.CursorFields -}}\n\t\t{{- if lt $j $i -}}\n\t\t  {{$n}} = ${{add $j 1}} AND {{end -}}\n\t  {{- end -}}\n\t  {{$k}} \u003e ${{add $i 1}}\n\t{{- end -}}\n\t) \n  {{- end}} ORDER BY {{range $i, $k := $.CursorFields}}{{if gt $i 0}}, {{end}}{{$k}}{{end -}};\n{{- else -}}\n  SELECT * FROM \"test\".\"key_discovery_329932\";\n{{- end}}\n",
+      "cursor": null
+    },
+    "resource_path": [
+      "test_key_discovery_329932"
+    ],
+    "collection": {
+      "name": "acmeCo/test/test_key_discovery_329932",
+      "read_schema_json": {
+        "type": "object",
+        "required": [
+          "_meta",
+          "k_smallint",
+          "k_int",
+          "k_bigint",
+          "k_bool",
+          "k_str"
+        ],
+        "properties": {
+          "_meta": {
+            "$schema": "http://json-schema.org/draft/2020-12/schema",
+            "$id": "https://github.com/estuary/connectors/source-redshift-batch/document-metadata",
+            "properties": {
+              "polled": {
+                "type": "string",
+                "format": "date-time",
+                "title": "Polled Timestamp",
+                "description": "The time at which the update query which produced this document as executed."
+              },
+              "index": {
+                "type": "integer",
+                "title": "Result Index",
+                "description": "The index of this document within the query execution which produced it."
+              }
+            },
+            "type": "object",
+            "required": [
+              "polled",
+              "index"
+            ]
+          },
+          "k_bigint": {
+            "type": "integer"
+          },
+          "k_bool": {
+            "type": "boolean"
+          },
+          "k_int": {
+            "type": "integer"
+          },
+          "k_smallint": {
+            "type": "integer"
+          },
+          "k_str": {
+            "type": "string"
+          }
+        },
+        "x-infer-schema": true
+      },
+      "key": [
+        "/k_smallint",
+        "/k_int",
+        "/k_bigint",
+        "/k_bool",
+        "/k_str"
+      ],
+      "projections": null
+    },
+    "state_key": "test_key_discovery_329932"
+  }
+

--- a/source-redshift-batch/main_test.go
+++ b/source-redshift-batch/main_test.go
@@ -180,6 +180,20 @@ func TestSchemaFilter(t *testing.T) {
 	})
 }
 
+func TestKeyDiscovery(t *testing.T) {
+	var ctx, cs = context.Background(), testCaptureSpec(t)
+	var control = testControlClient(ctx, t)
+	var uniqueID = "329932"
+	var tableName = fmt.Sprintf("test.key_discovery_%s", uniqueID)
+
+	executeControlQuery(ctx, t, control, fmt.Sprintf("DROP TABLE IF EXISTS %s", tableName))
+	t.Cleanup(func() { executeControlQuery(ctx, t, control, fmt.Sprintf("DROP TABLE IF EXISTS %s", tableName)) })
+	executeControlQuery(ctx, t, control, fmt.Sprintf("CREATE TABLE %s(k_smallint SMALLINT, k_int INTEGER, k_bigint BIGINT, k_bool BOOLEAN, k_str VARCHAR(8), data TEXT, PRIMARY KEY (k_smallint, k_int, k_bigint, k_bool, k_str))", tableName))
+
+	cs.EndpointSpec.(*Config).Advanced.DiscoverSchemas = []string{"test"}
+	snapshotBindings(t, discoverStreams(ctx, t, cs, regexp.MustCompile(uniqueID)))
+}
+
 func testControlClient(ctx context.Context, t testing.TB) *sql.DB {
 	t.Helper()
 	if os.Getenv("TEST_DATABASE") != "yes" {


### PR DESCRIPTION
**Description:**

This PR replaces the table and primary key discovery queries used by the batch Postgres and Redshift captures. Previously these queries read from various `information_schema` views, but in practice getting permission grants set up so those views return the needed information could be quite difficult.

The fix is to drop down a level and consult the 'pg_catalog' tables directly. This ended up being a bit more complicated than expected, because Redshift is based on a really old version of Postgres and also changed some things around, but I think the new queries that I ended up with should work well enough for now.

This fixes https://github.com/estuary/connectors/issues/1342

**Workflow steps:**

There should be no changes that the user needs to care about, save that discovery will actually produce useful results in more situations.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1379)
<!-- Reviewable:end -->
