### PR TITLE
facebook: use default empty string for primary keys instead of required

### DIFF
--- a/source-facebook-marketing/source_facebook_marketing/streams/base_insight_streams.py
+++ b/source-facebook-marketing/source_facebook_marketing/streams/base_insight_streams.py
@@ -301,16 +301,9 @@ class AdsInsights(FBMarketingIncrementalStream):
             if k not in schema["properties"]:
                 continue
 
-            tys = schema["properties"][k]["type"]
-
-            if "null" in tys:
-                schema["properties"][k]["type"].remove("null")
-
-            if "required" not in schema:
-                schema["required"] = []
-
-            if k not in schema["required"]:
-                schema["required"].append(k)
+            typ = schema["properties"][k]["type"]
+            if "string" in typ or typ == "string":
+                schema["properties"][k]["default"] = ""
 
         return schema
 

--- a/source-facebook-marketing/source_facebook_marketing/streams/base_insight_streams.py
+++ b/source-facebook-marketing/source_facebook_marketing/streams/base_insight_streams.py
@@ -300,10 +300,11 @@ class AdsInsights(FBMarketingIncrementalStream):
         for k in self.primary_key:
             if k not in schema["properties"]:
                 continue
-
+            
             typ = schema["properties"][k]["type"]
             if "string" in typ or typ == "string":
-                schema["properties"][k]["default"] = ""
+                if "format" not in schema["properties"][k]:
+                    schema["properties"][k]["default"] = ""
 
         return schema
 

--- a/source-facebook-marketing/test.flow.yaml
+++ b/source-facebook-marketing/test.flow.yaml
@@ -4,8 +4,6 @@ import:
 captures:
   acmeCo/source-facebook-marketing:
     endpoint:
-      # connector:
-      #   image: ghcr.io/estuary/source-facebook-marketing:testing
       local:
         command:
           - python
@@ -20,10 +18,14 @@ captures:
       - resource:
           stream: ad_sets
           syncMode: incremental
+          cursorField:
+            - updated_time
         target: acmeCo/ad_sets
       - resource:
           stream: ads
           syncMode: incremental
+          cursorField:
+            - updated_time
         target: acmeCo/ads
       - resource:
           stream: ad_creatives
@@ -32,34 +34,50 @@ captures:
       - resource:
           stream: ads_insights
           syncMode: incremental
+          cursorField:
+            - date_start
         target: acmeCo/ads_insights
       - resource:
           stream: ads_insights_age_and_gender
           syncMode: incremental
+          cursorField:
+            - date_start
         target: acmeCo/ads_insights_age_and_gender
       - resource:
           stream: ads_insights_country
           syncMode: incremental
+          cursorField:
+            - date_start
         target: acmeCo/ads_insights_country
       - resource:
           stream: ads_insights_region
           syncMode: incremental
+          cursorField:
+            - date_start
         target: acmeCo/ads_insights_region
       - resource:
           stream: ads_insights_dma
           syncMode: incremental
+          cursorField:
+            - date_start
         target: acmeCo/ads_insights_dma
       - resource:
           stream: ads_insights_platform_and_device
           syncMode: incremental
+          cursorField:
+            - date_start
         target: acmeCo/ads_insights_platform_and_device
       - resource:
           stream: ads_insights_action_type
           syncMode: incremental
+          cursorField:
+            - date_start
         target: acmeCo/ads_insights_action_type
       - resource:
           stream: campaigns
           syncMode: incremental
+          cursorField:
+            - updated_time
         target: acmeCo/campaigns
       - resource:
           stream: custom_conversions
@@ -68,12 +86,24 @@ captures:
       - resource:
           stream: images
           syncMode: incremental
+          cursorField:
+            - updated_time
         target: acmeCo/images
       - resource:
           stream: videos
           syncMode: incremental
+          cursorField:
+            - updated_time
         target: acmeCo/videos
+      - resource:
+          stream: activities
+          syncMode: incremental
+          cursorField:
+            - event_time
+        target: acmeCo/activities
       - resource:
           stream: customads_insights_publisher_platform
           syncMode: incremental
+          cursorField:
+            - date_start
         target: acmeCo/customads_insights_publisher_platform

--- a/source-facebook-marketing/tests/snapshots/snapshots__discover__capture.stdout.json
+++ b/source-facebook-marketing/tests/snapshots/snapshots__discover__capture.stdout.json
@@ -12218,7 +12218,8 @@
         "account_id": {
           "type": [
             "string"
-          ]
+          ],
+          "default": ""
         },
         "account_name": {
           "type": [
@@ -12451,7 +12452,8 @@
         "ad_id": {
           "type": [
             "string"
-          ]
+          ],
+          "default": ""
         },
         "ad_impression_actions": {
           "type": [
@@ -14014,7 +14016,8 @@
           "format": "date",
           "type": [
             "string"
-          ]
+          ],
+          "default": ""
         },
         "date_stop": {
           "format": "date",
@@ -15951,7 +15954,8 @@
         "account_id": {
           "type": [
             "string"
-          ]
+          ],
+          "default": ""
         },
         "account_name": {
           "type": [
@@ -16184,7 +16188,8 @@
         "ad_id": {
           "type": [
             "string"
-          ]
+          ],
+          "default": ""
         },
         "ad_impression_actions": {
           "type": [
@@ -17747,7 +17752,8 @@
           "format": "date",
           "type": [
             "string"
-          ]
+          ],
+          "default": ""
         },
         "date_stop": {
           "format": "date",
@@ -19639,13 +19645,17 @@
         },
         "age": {
           "type": [
+            "null",
             "string"
-          ]
+          ],
+          "default": ""
         },
         "gender": {
           "type": [
+            "null",
             "string"
-          ]
+          ],
+          "default": ""
         },
         "_meta": {
           "type": "object",
@@ -19665,9 +19675,7 @@
       "required": [
         "account_id",
         "ad_id",
-        "date_start",
-        "age",
-        "gender"
+        "date_start"
       ]
     },
     "key": [
@@ -19698,7 +19706,8 @@
         "account_id": {
           "type": [
             "string"
-          ]
+          ],
+          "default": ""
         },
         "account_name": {
           "type": [
@@ -19931,7 +19940,8 @@
         "ad_id": {
           "type": [
             "string"
-          ]
+          ],
+          "default": ""
         },
         "ad_impression_actions": {
           "type": [
@@ -21494,7 +21504,8 @@
           "format": "date",
           "type": [
             "string"
-          ]
+          ],
+          "default": ""
         },
         "date_stop": {
           "format": "date",
@@ -23386,8 +23397,10 @@
         },
         "country": {
           "type": [
+            "null",
             "string"
-          ]
+          ],
+          "default": ""
         },
         "_meta": {
           "type": "object",
@@ -23407,8 +23420,7 @@
       "required": [
         "account_id",
         "ad_id",
-        "date_start",
-        "country"
+        "date_start"
       ]
     },
     "key": [
@@ -23438,7 +23450,8 @@
         "account_id": {
           "type": [
             "string"
-          ]
+          ],
+          "default": ""
         },
         "account_name": {
           "type": [
@@ -23671,7 +23684,8 @@
         "ad_id": {
           "type": [
             "string"
-          ]
+          ],
+          "default": ""
         },
         "ad_impression_actions": {
           "type": [
@@ -25234,7 +25248,8 @@
           "format": "date",
           "type": [
             "string"
-          ]
+          ],
+          "default": ""
         },
         "date_stop": {
           "format": "date",
@@ -27126,8 +27141,10 @@
         },
         "region": {
           "type": [
+            "null",
             "string"
-          ]
+          ],
+          "default": ""
         },
         "_meta": {
           "type": "object",
@@ -27147,8 +27164,7 @@
       "required": [
         "account_id",
         "ad_id",
-        "date_start",
-        "region"
+        "date_start"
       ]
     },
     "key": [
@@ -27178,7 +27194,8 @@
         "account_id": {
           "type": [
             "string"
-          ]
+          ],
+          "default": ""
         },
         "account_name": {
           "type": [
@@ -27411,7 +27428,8 @@
         "ad_id": {
           "type": [
             "string"
-          ]
+          ],
+          "default": ""
         },
         "ad_impression_actions": {
           "type": [
@@ -28974,7 +28992,8 @@
           "format": "date",
           "type": [
             "string"
-          ]
+          ],
+          "default": ""
         },
         "date_stop": {
           "format": "date",
@@ -30866,8 +30885,10 @@
         },
         "dma": {
           "type": [
+            "null",
             "string"
-          ]
+          ],
+          "default": ""
         },
         "_meta": {
           "type": "object",
@@ -30887,8 +30908,7 @@
       "required": [
         "account_id",
         "ad_id",
-        "date_start",
-        "dma"
+        "date_start"
       ]
     },
     "key": [
@@ -30918,7 +30938,8 @@
         "account_id": {
           "type": [
             "string"
-          ]
+          ],
+          "default": ""
         },
         "account_name": {
           "type": [
@@ -31151,7 +31172,8 @@
         "ad_id": {
           "type": [
             "string"
-          ]
+          ],
+          "default": ""
         },
         "ad_impression_actions": {
           "type": [
@@ -32714,7 +32736,8 @@
           "format": "date",
           "type": [
             "string"
-          ]
+          ],
+          "default": ""
         },
         "date_stop": {
           "format": "date",
@@ -34606,18 +34629,24 @@
         },
         "publisher_platform": {
           "type": [
+            "null",
             "string"
-          ]
+          ],
+          "default": ""
         },
         "platform_position": {
           "type": [
+            "null",
             "string"
-          ]
+          ],
+          "default": ""
         },
         "impression_device": {
           "type": [
+            "null",
             "string"
-          ]
+          ],
+          "default": ""
         },
         "_meta": {
           "type": "object",
@@ -34637,10 +34666,7 @@
       "required": [
         "account_id",
         "ad_id",
-        "date_start",
-        "publisher_platform",
-        "platform_position",
-        "impression_device"
+        "date_start"
       ]
     },
     "key": [
@@ -34672,7 +34698,8 @@
         "account_id": {
           "type": [
             "string"
-          ]
+          ],
+          "default": ""
         },
         "account_name": {
           "type": [
@@ -34905,7 +34932,8 @@
         "ad_id": {
           "type": [
             "string"
-          ]
+          ],
+          "default": ""
         },
         "ad_impression_actions": {
           "type": [
@@ -36468,7 +36496,8 @@
           "format": "date",
           "type": [
             "string"
-          ]
+          ],
+          "default": ""
         },
         "date_stop": {
           "format": "date",
@@ -39183,7 +39212,8 @@
         "account_id": {
           "type": [
             "string"
-          ]
+          ],
+          "default": ""
         },
         "account_name": {
           "type": [
@@ -39194,7 +39224,8 @@
         "ad_id": {
           "type": [
             "string"
-          ]
+          ],
+          "default": ""
         },
         "ad_name": {
           "type": [
@@ -39236,7 +39267,8 @@
           "format": "date",
           "type": [
             "string"
-          ]
+          ],
+          "default": ""
         },
         "date_stop": {
           "format": "date",
@@ -39339,8 +39371,10 @@
         },
         "publisher_platform": {
           "type": [
+            "null",
             "string"
-          ]
+          ],
+          "default": ""
         },
         "_meta": {
           "type": "object",
@@ -39360,8 +39394,7 @@
       "required": [
         "account_id",
         "ad_id",
-        "date_start",
-        "publisher_platform"
+        "date_start"
       ]
     },
     "key": [

--- a/source-facebook-marketing/tests/snapshots/snapshots__discover__capture.stdout.json
+++ b/source-facebook-marketing/tests/snapshots/snapshots__discover__capture.stdout.json
@@ -14016,8 +14016,7 @@
           "format": "date",
           "type": [
             "string"
-          ],
-          "default": ""
+          ]
         },
         "date_stop": {
           "format": "date",
@@ -17752,8 +17751,7 @@
           "format": "date",
           "type": [
             "string"
-          ],
-          "default": ""
+          ]
         },
         "date_stop": {
           "format": "date",
@@ -21504,8 +21502,7 @@
           "format": "date",
           "type": [
             "string"
-          ],
-          "default": ""
+          ]
         },
         "date_stop": {
           "format": "date",
@@ -25248,8 +25245,7 @@
           "format": "date",
           "type": [
             "string"
-          ],
-          "default": ""
+          ]
         },
         "date_stop": {
           "format": "date",
@@ -28992,8 +28988,7 @@
           "format": "date",
           "type": [
             "string"
-          ],
-          "default": ""
+          ]
         },
         "date_stop": {
           "format": "date",
@@ -32736,8 +32731,7 @@
           "format": "date",
           "type": [
             "string"
-          ],
-          "default": ""
+          ]
         },
         "date_stop": {
           "format": "date",
@@ -36496,8 +36490,7 @@
           "format": "date",
           "type": [
             "string"
-          ],
-          "default": ""
+          ]
         },
         "date_stop": {
           "format": "date",
@@ -39267,8 +39260,7 @@
           "format": "date",
           "type": [
             "string"
-          ],
-          "default": ""
+          ]
         },
         "date_stop": {
           "format": "date",


### PR DESCRIPTION
**Description:**

- Use a default string so we can capture these collections even though sometimes the keys do not exist in certain documents. In these cases those documents will get reduced together (this is what has happened previously as well, since these fields were not even marked as a key)

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1386)
<!-- Reviewable:end -->
