### PR TITLE
Enable primary_key for custom queries in source-google-ads

### DIFF
--- a/source-google-ads/connector_config.yaml
+++ b/source-google-ads/connector_config.yaml
@@ -1,22 +1,31 @@
 conversion_window_days: 14
 credentials:
-    client_id_sops: ENC[AES256_GCM,data:ZsF2Lbd7Qs5bRUhQmZGZR3ZCs5s/z0+yM9g2+VSv/WM+xQfg3l9UoB3jI2p2f5FLjfbBqf/u9L2hcDWjXF4qb03B6hu6AaVY,iv:YJ/LP4svB3gZNiSrm9mfXwXolSaPLssAWTSXt4KSRy4=,tag:VG7gHrvGR3dPB+bAhPo0WQ==,type:str]
-    client_secret_sops: ENC[AES256_GCM,data:U5aP0B0voAiSZ2JNgoSn3jTKwKE3XFyuFw13+1iDNalYl7A=,iv:Y//VY6aSCPjhcgd8bLjKscReBjlPxN21yAA5yUsRpcg=,tag:Rv4epw5yFRZa9PPhrQW0xw==,type:str]
-    developer_token_sops: ENC[AES256_GCM,data:s5gH/Pjazxh6VwsDF035qhXeNN6qIQ==,iv:ne8jYwF91t8yTgEqpTgwxn4l94Xx4XkiIpGTZyStsvU=,tag:mJ6whBzLoGJidgeoMl+knA==,type:str]
-    refresh_token_sops: ENC[AES256_GCM,data:bNgS+zsZZnTrpn3zbc1V/eRD/WhlUKr7SN42FC3jx5C031SdMR5qtE2MapYRw6Y1f2Kojzj4FZh10b2oRMY8MovrTRx7eNILfNFsWVZwUJe3D0L/ETk1SCMU/BfvOFhfNW3sqcS4AA==,iv:dIT7FRHpn0zcausNIxQzguQO7RC4Rcvu9ycBMOhzOeU=,tag:EuC/r3mrEHqjPTcWDj5Xpw==,type:str]
+    client_id_sops: ENC[AES256_GCM,data:8WgIkKsrK1IqKArD0YRT6RzLuH0SK02q9cjgAObGINR25C1H6rRnpcMnfcr0laY1uNy3UMmIJqsiIGcUHl7t64XyUGYg5qm9,iv:WSWdofGPEp8i776SGf2m7iJvJl/fb9rOwdZoTDY/8Z8=,tag:xpIVkyv+48cSajQMxZ5bLQ==,type:str]
+    client_secret_sops: ENC[AES256_GCM,data:VQ1b9eGY+KxMpr0PQEj4/rFkf3ces4XSLAglID+jGf10iss=,iv:5kZ71TMYWlxqFKeNQ4u+e8X81gfidMB2KPW0lCxgPm4=,tag:4jR+MLrLFBlxyCSE6pk6ZQ==,type:str]
+    developer_token_sops: ENC[AES256_GCM,data:bv+ddS11AW9RGlJ3/QDxItxZlg1TuQ==,iv:GHrwFOXku6dc2YqddecN+ycDlB1Vu/HkHa5u+WOUX/c=,tag:JW6x7MQtdcAVkgAensEO9A==,type:str]
+    refresh_token_sops: ENC[AES256_GCM,data:7pThdov5EltVmHuS6kAbOMSjm1nx4sHbb6vnyTIYUsnCU4NPOfPXxQeMwJNeFohGgn96PqkiSSXT0CBSktumRH9Njoe96e4BmiktAwZ5uttUJkKQTwpQ1QTOXd937JAzQea8Smbguw==,iv:EW+k13SNfJm9tKw1u7+VXtHgPC0eaYoUaA7zUjRtpHc=,tag:ciaiXgbKrGKujZknyu4TeQ==,type:str]
+custom_queries:
+    - query: SELECT segments.ad_destination_type, segments.ad_network_type, segments.day_of_week, customer.auto_tagging_enabled, customer.id, metrics.conversions, campaign.start_date FROM campaign
+      primary_key: customer.id
+      cursor_field: null
+      table_name: unhappytable
+    - query: SELECT ad_group.targeting_setting.target_restrictions FROM ad_group
+      primary_key: customer.id
+      cursor_field: null
+      table_name: ad_group_custom
 customer_id: "6458773721"
 start_date: "2022-01-01"
 sops:
     kms: []
     gcp_kms:
         - resource_id: projects/estuary-theatre/locations/us-central1/keyRings/connector-keyring/cryptoKeys/connector-repository
-          created_at: "2024-02-01T15:11:34Z"
-          enc: CiQAdmEdwpewZLDvu80ySB31XOaRpBuQ5twOS4zpydRmn3imRsQSSQCVvC1zm2KgUypWm0F//eD1yeScHf7y/TMYBC5tqXHiK6Qy4eb7deyHVe5dO5rYenWveJzy7enCAhxAxk9N7RHXUjK89lsgn6E=
+          created_at: "2024-03-21T17:23:42Z"
+          enc: CiQAdmEdwvK590m1n59RHcelPtJUvJec4N+2MGLbrMoX42DpiNISSQCSobQjVRDdX4DDCcvCnqdimvUjMaL3awz9c1kDjw25gROXylJxvQd8g7EddcoQSXGCbgBMxsYnb776jdrIcA/S3sZ8qox+7d4=
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2024-02-01T15:12:59Z"
-    mac: ENC[AES256_GCM,data:kuLSbiCpD9A3PkLg4pEVxYWj8PFXXmoYrH/XGVKZcoJgNUlMehvfcrB2XKIfEnE/lEE9jyQNGMMExwXKFyLrSbT4dwR7rkjD3aW1yyoFaSmAcDReQKKkhhXd+vaOIOgvH0Rjap3btyKSF6M5/WjMo/eM15C4l4Z0809d7dzONvI=,iv:c8YHHO36hDWU7AFgChk+tHcE99krMmbo4UcuTGknSY0=,tag:yLyvkC55JnKSzznTN23Gjw==,type:str]
+    lastmodified: "2024-03-21T17:23:43Z"
+    mac: ENC[AES256_GCM,data:rss+rv+rzLmLHdqVUeRzpWm/byxb+DyXq299rsallEDx0oyWQusBM4tHDjfFaD1F5W37SH6Gu8ojPh5S6wJj367cLWoCEneth6X1AtuaKA0hXCVCvksnwIRp+SEIojFfvxFLwNgsnn6G0swhQuouiRFxDdmW2DowrqUQ0jV/48g=,iv:yjbQMDiAt0FtuA7sYNytkdgMohpQWf7IMkVY8RLfOhQ=,tag:mkSpNZ4EpkYD2ZzA08q9Sg==,type:str]
     pgp: []
     encrypted_suffix: _sops
-    version: 3.7.3
+    version: 3.8.1

--- a/source-google-ads/source_google_ads/custom_query_stream.py
+++ b/source-google-ads/source_google_ads/custom_query_stream.py
@@ -16,13 +16,7 @@ class CustomQueryMixin:
 
     @property
     def primary_key(self) -> str:
-        """
-        The primary_key option is disabled. Config should not provide the primary key.
-        It will be ignored if provided.
-        If you need to enable it, uncomment the next line instead of `return None` and modify your config
-        """
-        # return self.config.get("primary_key") or None
-        return None
+        return self.config.get("primary_key") or None
 
     @property
     def name(self):
@@ -43,7 +37,18 @@ class CustomQueryMixin:
             "properties": {},
             "additionalProperties": True,
         }
-        # full list {'ENUM', 'STRING', 'DATE', 'DOUBLE', 'RESOURCE_NAME', 'INT32', 'INT64', 'BOOLEAN', 'MESSAGE'}
+        # full list
+        # {
+        #     "ENUM",
+        #     "STRING",
+        #     "DATE",
+        #     "DOUBLE",
+        #     "RESOURCE_NAME",
+        #     "INT32",
+        #     "INT64",
+        #     "BOOLEAN",
+        #     "MESSAGE",
+        # }
 
         google_datatype_mapping = {
             "INT64": "integer",
@@ -60,12 +65,19 @@ class CustomQueryMixin:
 
         for field in fields:
             node = google_schema.get(field)
-            # Data type return in enum format: "GoogleAdsFieldDataType.<data_type>"
+            # Data type return in enum format:
+            # "GoogleAdsFieldDataType.<data_type>"
             google_data_type = node.data_type.name
             if google_data_type == "ENUM":
-                field_value = {"type": "string", "enum": list(node.enum_values)}
+                field_value = {
+                    "type": "string",
+                    "enum": list(node.enum_values),
+                }
                 if node.is_repeated:
-                    field_value = {"type": ["null", "array"], "items": field_value}
+                    field_value = {
+                        "type": ["null", "array"],
+                        "items": field_value,
+                    }
             elif google_data_type == "MESSAGE":
                 # Represents protobuf message and could be anything, set custom
                 # attribute "protobuf_message" to convert it to a string (or
@@ -77,7 +89,10 @@ class CustomQueryMixin:
                     output_type = ["string", "null"]
                 field_value = {"type": output_type, "protobuf_message": True}
             else:
-                output_type = [google_datatype_mapping.get(google_data_type, "string"), "null"]
+                output_type = [
+                    google_datatype_mapping.get(google_data_type, "string"),
+                    "null",
+                ]
                 field_value = {"type": output_type}
                 if google_data_type == "DATE":
                     field_value["format"] = "date"
@@ -89,14 +104,22 @@ class CustomQueryMixin:
 
 class IncrementalCustomQuery(CustomQueryMixin, IncrementalGoogleAdsStream):
     def get_query(self, stream_slice: Mapping[str, Any] = None) -> str:
-        start_date, end_date = stream_slice["start_date"], stream_slice["end_date"]
-        query = self.insert_segments_date_expr(self.config["query"], start_date, end_date)
+        start_date = stream_slice["start_date"]
+        end_date = stream_slice["end_date"]
+        query = self.insert_segments_date_expr(
+            self.config["query"], start_date, end_date
+        )
         return str(query)
 
     @staticmethod
-    def insert_segments_date_expr(query: GAQL, start_date: str, end_date: str) -> GAQL:
+    def insert_segments_date_expr(
+        query: GAQL,
+        start_date: str,
+        end_date: str,
+    ) -> GAQL:
         """
-        Insert segments.date condition to break query into slices for incremental stream.
+        Insert segments.date condition to break query into
+        slices for incremental stream.
         :param query Origin user defined query
         :param start_date start date for metric (inclusive)
         :param end_date end date for metric (inclusive)

--- a/source-google-ads/source_google_ads/source.py
+++ b/source-google-ads/source_google_ads/source.py
@@ -12,7 +12,9 @@ from airbyte_cdk.sources import AbstractSource
 from airbyte_cdk.sources.streams import Stream
 from airbyte_cdk.utils import AirbyteTracedException
 from google.ads.googleads.errors import GoogleAdsException
-from google.ads.googleads.v15.errors.types.authorization_error import AuthorizationErrorEnum
+from google.ads.googleads.v15.errors.types.authorization_error import (
+    AuthorizationErrorEnum,
+)
 from pendulum import parse, today
 
 from .custom_query_stream import CustomQuery, IncrementalCustomQuery
@@ -39,7 +41,12 @@ from .streams import (
 )
 from .utils import GAQL
 
-FULL_REFRESH_CUSTOM_TABLE = ["asset", "asset_group_listing_group_filter", "custom_audience", "geo_target_constant"]
+FULL_REFRESH_CUSTOM_TABLE = [
+    "asset",
+    "asset_group_listing_group_filter",
+    "custom_audience",
+    "geo_target_constant",
+]
 
 
 class SourceGoogleAds(AbstractSource):
@@ -49,10 +56,12 @@ class SourceGoogleAds(AbstractSource):
             config.pop("end_date")
         for query in config.get("custom_queries", []):
             try:
-                query["query"] = GAQL.parse(query["query"])
+                query["query"] = GAQL.parse(str(query["query"]))
             except ValueError:
                 message = f"The custom GAQL query {query['table_name']} failed. Validate your GAQL query with the Google Ads query validator. https://developers.google.com/google-ads/api/fields/v15/query_validator"
-                raise AirbyteTracedException(message=message, failure_type=FailureType.config_error)
+                raise AirbyteTracedException(
+                    message=message, failure_type=FailureType.config_error
+                )
         return config
 
     @staticmethod
@@ -68,7 +77,9 @@ class SourceGoogleAds(AbstractSource):
         return credentials
 
     @staticmethod
-    def get_incremental_stream_config(google_api: GoogleAds, config: Mapping[str, Any], customers: List[Customer]):
+    def get_incremental_stream_config(
+        google_api: GoogleAds, config: Mapping[str, Any], customers: List[Customer]
+    ):
         end_date = config.get("end_date")
         if end_date:
             end_date = min(today(), parse(end_date)).to_date_string()
@@ -81,11 +92,15 @@ class SourceGoogleAds(AbstractSource):
         )
         return incremental_stream_config
 
-    def get_account_info(self, google_api: GoogleAds, config: Mapping[str, Any]) -> Iterable[Iterable[Mapping[str, Any]]]:
+    def get_account_info(
+        self, google_api: GoogleAds, config: Mapping[str, Any]
+    ) -> Iterable[Iterable[Mapping[str, Any]]]:
         dummy_customers = [Customer(id=_id) for _id in config["customer_id"].split(",")]
         accounts_stream = ServiceAccounts(google_api, customers=dummy_customers)
         for slice_ in accounts_stream.stream_slices():
-            yield accounts_stream.read_records(sync_mode=SyncMode.full_refresh, stream_slice=slice_)
+            yield accounts_stream.read_records(
+                sync_mode=SyncMode.full_refresh, stream_slice=slice_
+            )
 
     @staticmethod
     def is_metrics_in_custom_query(query: GAQL) -> bool:
@@ -94,7 +109,9 @@ class SourceGoogleAds(AbstractSource):
                 return True
         return False
 
-    def check_connection(self, logger: logging.Logger, config: Mapping[str, Any]) -> Tuple[bool, any]:
+    def check_connection(
+        self, logger: logging.Logger, config: Mapping[str, Any]
+    ) -> Tuple[bool, any]:
         config = self._validate_and_transform(config)
         try:
             logger.info("Checking the config")
@@ -106,17 +123,26 @@ class SourceGoogleAds(AbstractSource):
             for customer in customers:
                 for query in config.get("custom_queries", []):
                     query = query["query"]
-                    if customer.is_manager_account and self.is_metrics_in_custom_query(query):
+                    if customer.is_manager_account and self.is_metrics_in_custom_query(
+                        query
+                    ):
                         logger.warning(
                             f"Metrics are not available for manager account {customer.id}. "
                             f"Please remove metrics fields in your custom query: {query}."
                         )
                     if query.resource_name not in FULL_REFRESH_CUSTOM_TABLE:
                         if IncrementalCustomQuery.cursor_field in query.fields:
-                            return False, f"Custom query should not contain {IncrementalCustomQuery.cursor_field}"
-                        query = IncrementalCustomQuery.insert_segments_date_expr(query, "1980-01-01", "1980-01-01")
+                            return (
+                                False,
+                                f"Custom query should not contain {IncrementalCustomQuery.cursor_field}",
+                            )
+                        query = IncrementalCustomQuery.insert_segments_date_expr(
+                            query, "1980-01-01", "1980-01-01"
+                        )
                     query = query.set_limit(1)
-                    response = google_api.send_request(str(query), customer_id=customer.id)
+                    response = google_api.send_request(
+                        str(query), customer_id=customer.id
+                    )
                     # iterate over the response otherwise exceptions will not be raised!
                     for _ in response:
                         pass
@@ -126,19 +152,32 @@ class SourceGoogleAds(AbstractSource):
                 x.error_code.authorization_error for x in exception.failure.errors
             ):
                 message = f"Failed to access the customer '{exception.customer_id}'. Ensure the customer is linked to your manager account or check your permissions to access this customer account."
-                raise AirbyteTracedException(message=message, failure_type=FailureType.config_error)
-            error_messages = ", ".join([error.message for error in exception.failure.errors])
+                raise AirbyteTracedException(
+                    message=message, failure_type=FailureType.config_error
+                )
+            error_messages = ", ".join(
+                [error.message for error in exception.failure.errors]
+            )
             logger.error(traceback.format_exc())
-            return False, f"Unable to connect to Google Ads API with the provided configuration - {error_messages}"
+            return (
+                False,
+                f"Unable to connect to Google Ads API with the provided configuration - {error_messages}",
+            )
 
     def streams(self, config: Mapping[str, Any]) -> List[Stream]:
         config = self._validate_and_transform(config)
         google_api = GoogleAds(credentials=self.get_credentials(config))
         accounts = self.get_account_info(google_api, config)
         customers = Customer.from_accounts(accounts)
-        non_manager_accounts = [customer for customer in customers if not customer.is_manager_account]
-        incremental_config = self.get_incremental_stream_config(google_api, config, customers)
-        non_manager_incremental_config = self.get_incremental_stream_config(google_api, config, non_manager_accounts)
+        non_manager_accounts = [
+            customer for customer in customers if not customer.is_manager_account
+        ]
+        incremental_config = self.get_incremental_stream_config(
+            google_api, config, customers
+        )
+        non_manager_incremental_config = self.get_incremental_stream_config(
+            google_api, config, non_manager_accounts
+        )
         streams = [
             AdGroupAds(**incremental_config),
             AdGroupAdLabels(google_api, customers=customers),
@@ -168,12 +207,33 @@ class SourceGoogleAds(AbstractSource):
             if self.is_metrics_in_custom_query(query):
                 if non_manager_accounts:
                     if query.resource_name in FULL_REFRESH_CUSTOM_TABLE:
-                        streams.append(CustomQuery(config=single_query_config, api=google_api, customers=non_manager_accounts))
+                        streams.append(
+                            CustomQuery(
+                                config=single_query_config,
+                                api=google_api,
+                                customers=non_manager_accounts,
+                            )
+                        )
                     else:
-                        streams.append(IncrementalCustomQuery(config=single_query_config, **non_manager_incremental_config))
+                        streams.append(
+                            IncrementalCustomQuery(
+                                config=single_query_config,
+                                **non_manager_incremental_config,
+                            )
+                        )
                 continue
             if query.resource_name in FULL_REFRESH_CUSTOM_TABLE:
-                streams.append(CustomQuery(config=single_query_config, api=google_api, customers=customers))
+                streams.append(
+                    CustomQuery(
+                        config=single_query_config,
+                        api=google_api,
+                        customers=customers,
+                    )
+                )
             else:
-                streams.append(IncrementalCustomQuery(config=single_query_config, **incremental_config))
+                streams.append(
+                    IncrementalCustomQuery(
+                        config=single_query_config, **incremental_config
+                    )
+                )
         return streams

--- a/source-google-ads/source_google_ads/spec.json
+++ b/source-google-ads/source_google_ads/spec.json
@@ -4,7 +4,11 @@
     "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "Google Ads Spec",
     "type": "object",
-    "required": ["credentials", "start_date", "customer_id"],
+    "required": [
+      "credentials",
+      "start_date",
+      "customer_id"
+    ],
     "additionalProperties": true,
     "properties": {
       "credentials": {
@@ -61,7 +65,9 @@
         "type": "string",
         "description": "Comma separated list of (client) customer IDs. Each customer ID must be specified as a 10-digit number without dashes. More instruction on how to find this value in our <a href=\"https://docs.airbyte.com/integrations/sources/google-ads#setup-guide\">docs</a>. Metrics streams like AdGroupAdReport cannot be requested for a manager account.",
         "pattern": "^[0-9]{10}(,[0-9]{10})*$",
-        "examples": ["6783948572,5839201945"],
+        "examples": [
+          "6783948572,5839201945"
+        ],
         "order": 1
       },
       "start_date": {
@@ -69,7 +75,9 @@
         "title": "Start Date",
         "description": "UTC date and time in the format 2017-01-25. Any data before this date will not be replicated.",
         "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$",
-        "examples": ["2017-01-25"],
+        "examples": [
+          "2017-01-25"
+        ],
         "order": 2,
         "format": "date"
       },
@@ -78,7 +86,9 @@
         "title": "End Date",
         "description": "UTC date and time in the format 2017-01-25. Any data after this date will not be replicated.",
         "pattern": "^$|^[0-9]{4}-[0-9]{2}-[0-9]{2}$",
-        "examples": ["2017-01-30"],
+        "examples": [
+          "2017-01-30"
+        ],
         "order": 6,
         "format": "date"
       },
@@ -89,7 +99,10 @@
         "order": 3,
         "items": {
           "type": "object",
-          "required": ["query", "table_name"],
+          "required": [
+            "query",
+            "table_name"
+          ],
           "properties": {
             "query": {
               "type": "string",
@@ -103,6 +116,11 @@
               "type": "string",
               "title": "Destination Table Name",
               "description": "The table name in your destination database for choosen query."
+            },
+            "primary_key": {
+              "type": "string",
+              "title": "Destination Table Primary Key",
+              "description": "The primary key in your destination database."
             }
           }
         }
@@ -112,7 +130,9 @@
         "title": "Login Customer ID for Managed Accounts",
         "description": "If your access to the customer account is through a manager account, this field is required and must be set to the customer ID of the manager account (10-digit number without dashes). More information about this field you can see <a href=\"https://developers.google.com/google-ads/api/docs/concepts/call-structure#cid\">here</a>",
         "pattern": "^([0-9]{10})?$",
-        "examples": ["7349206847"],
+        "examples": [
+          "7349206847"
+        ],
         "order": 4
       },
       "conversion_window_days": {
@@ -122,7 +142,9 @@
         "minimum": 0,
         "maximum": 1095,
         "default": 14,
-        "examples": [14],
+        "examples": [
+          14
+        ],
         "order": 5
       }
     }
@@ -135,11 +157,17 @@
         "properties": {
           "access_token": {
             "type": "string",
-            "path_in_connector_config": ["credentials", "access_token"]
+            "path_in_connector_config": [
+              "credentials",
+              "access_token"
+            ]
           },
           "refresh_token": {
             "type": "string",
-            "path_in_connector_config": ["credentials", "refresh_token"]
+            "path_in_connector_config": [
+              "credentials",
+              "refresh_token"
+            ]
           }
         }
       },
@@ -159,15 +187,24 @@
         "properties": {
           "client_id": {
             "type": "string",
-            "path_in_connector_config": ["credentials", "client_id"]
+            "path_in_connector_config": [
+              "credentials",
+              "client_id"
+            ]
           },
           "client_secret": {
             "type": "string",
-            "path_in_connector_config": ["credentials", "client_secret"]
+            "path_in_connector_config": [
+              "credentials",
+              "client_secret"
+            ]
           },
           "developer_token": {
             "type": "string",
-            "path_in_connector_config": ["credentials", "developer_token"]
+            "path_in_connector_config": [
+              "credentials",
+              "developer_token"
+            ]
           }
         }
       }

--- a/source-google-ads/source_google_ads/utils.py
+++ b/source-google-ads/source_google_ads/utils.py
@@ -84,12 +84,33 @@ class GAQL:
         return re.sub(r"\s+", " ", s)
 
     def set_where(self, value: str):
-        return self.__class__(self.fields, self.resource_name, value, self.order_by, self.limit, self.parameters)
+        return self.__class__(
+            self.fields,
+            self.resource_name,
+            value,
+            self.order_by,
+            self.limit,
+            self.parameters,
+        )
 
     def set_limit(self, value: int):
-        return self.__class__(self.fields, self.resource_name, self.where, self.order_by, value, self.parameters)
+        return self.__class__(
+            self.fields,
+            self.resource_name,
+            self.where,
+            self.order_by,
+            value,
+            self.parameters,
+        )
 
     def append_field(self, value):
         fields = list(self.fields)
         fields.append(value)
-        return self.__class__(tuple(fields), self.resource_name, self.where, self.order_by, self.limit, self.parameters)
+        return self.__class__(
+            tuple(fields),
+            self.resource_name,
+            self.where,
+            self.order_by,
+            self.limit,
+            self.parameters,
+        )

--- a/source-google-ads/tests/snapshots/snapshots__discover__capture.stdout.json
+++ b/source-google-ads/tests/snapshots/snapshots__discover__capture.stdout.json
@@ -5411,5 +5411,160 @@
       "/ad_group.id",
       "/ad_group_criterion.criterion_id"
     ]
+  },
+  {
+    "recommendedName": "unhappytable",
+    "resourceConfig": {
+      "stream": "unhappytable",
+      "syncMode": "incremental",
+      "cursorField": [
+        "segments.date"
+      ]
+    },
+    "documentSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "segments.ad_destination_type": {
+          "type": "string",
+          "enum": [
+            "APP_DEEP_LINK",
+            "APP_STORE",
+            "LEAD_FORM",
+            "LOCATION_LISTING",
+            "MAP_DIRECTIONS",
+            "MESSAGE",
+            "NOT_APPLICABLE",
+            "PHONE_CALL",
+            "UNKNOWN",
+            "UNMODELED_FOR_CONVERSIONS",
+            "UNSPECIFIED",
+            "WEBSITE",
+            "YOUTUBE"
+          ]
+        },
+        "segments.ad_network_type": {
+          "type": "string",
+          "enum": [
+            "CONTENT",
+            "GOOGLE_TV",
+            "MIXED",
+            "SEARCH",
+            "SEARCH_PARTNERS",
+            "UNKNOWN",
+            "UNSPECIFIED",
+            "YOUTUBE"
+          ]
+        },
+        "segments.day_of_week": {
+          "type": "string",
+          "enum": [
+            "FRIDAY",
+            "MONDAY",
+            "SATURDAY",
+            "SUNDAY",
+            "THURSDAY",
+            "TUESDAY",
+            "UNKNOWN",
+            "UNSPECIFIED",
+            "WEDNESDAY"
+          ]
+        },
+        "customer.auto_tagging_enabled": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "customer.id": {
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "metrics.conversions": {
+          "type": [
+            "number",
+            "null"
+          ]
+        },
+        "campaign.start_date": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "format": "date"
+        },
+        "segments.date": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "format": "date"
+        },
+        "_meta": {
+          "type": "object",
+          "properties": {
+            "row_id": {
+              "type": "integer"
+            }
+          },
+          "required": [
+            "row_id"
+          ]
+        }
+      },
+      "additionalProperties": true,
+      "x-infer-schema": true
+    },
+    "key": [
+      "/customer.id"
+    ]
+  },
+  {
+    "recommendedName": "ad_group_custom",
+    "resourceConfig": {
+      "stream": "ad_group_custom",
+      "syncMode": "incremental",
+      "cursorField": [
+        "segments.date"
+      ]
+    },
+    "documentSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "ad_group.targeting_setting.target_restrictions": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "protobuf_message": true
+        },
+        "segments.date": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "format": "date"
+        },
+        "_meta": {
+          "type": "object",
+          "properties": {
+            "row_id": {
+              "type": "integer"
+            }
+          },
+          "required": [
+            "row_id"
+          ]
+        }
+      },
+      "additionalProperties": true,
+      "x-infer-schema": true
+    },
+    "key": [
+      "/customer.id"
+    ]
   }
 ]

--- a/source-google-ads/tests/snapshots/snapshots__spec__capture.stdout.json
+++ b/source-google-ads/tests/snapshots/snapshots__spec__capture.stdout.json
@@ -117,6 +117,11 @@
                 "type": "string",
                 "title": "Destination Table Name",
                 "description": "The table name in your destination database for choosen query."
+              },
+              "primary_key": {
+                "type": "string",
+                "title": "Destination Table Primary Key",
+                "description": "The primary key in your destination database."
               }
             }
           }

--- a/source-google-ads/tests/test_custom_query.py
+++ b/source-google-ads/tests/test_custom_query.py
@@ -4,21 +4,42 @@
 
 from unittest.mock import MagicMock
 
-from source_google_ads.custom_query_stream import CustomQueryMixin, IncrementalCustomQuery
+from source_google_ads.custom_query_stream import (
+    CustomQueryMixin,
+    IncrementalCustomQuery,
+)
 from source_google_ads.utils import GAQL
+
+TERMS = [
+    "ad_group.resource_name",
+    "ad_group.status",
+    "ad_group.target_cpa_micros",
+    "ad_group.target_cpm_micros",
+    "ad_group.target_roas",
+    "ad_group.targeting_setting.target_restrictions",
+    "ad_group.tracking_url_template",
+    "ad_group.type",
+    "ad_group.url_custom_parameters",
+    "campaign.accessible_bidding_strategy",
+    "campaign.ad_serving_optimization_status",
+    "campaign.advertising_channel_type",
+    "campaign.advertising_channel_sub_type",
+    "campaign.app_campaign_setting.app_id",
+    "campaign.app_campaign_setting.app_store",
+]
 
 
 def test_custom_query():
-    input_q = """SELECT ad_group.resource_name, ad_group.status, ad_group.target_cpa_micros, ad_group.target_cpm_micros,
-     ad_group.target_roas, ad_group.targeting_setting.target_restrictions, ad_group.tracking_url_template, ad_group.type,
-     ad_group.url_custom_parameters, campaign.accessible_bidding_strategy, campaign.ad_serving_optimization_status,
-     campaign.advertising_channel_type, campaign.advertising_channel_sub_type, campaign.app_campaign_setting.app_id,
-     campaign.app_campaign_setting.app_store FROM search_term_view"""
-    output_q = IncrementalCustomQuery.insert_segments_date_expr(GAQL.parse(input_q), "1980-01-01", "1980-01-01")
-    assert (
-        str(output_q)
-        == """SELECT ad_group.resource_name, ad_group.status, ad_group.target_cpa_micros, ad_group.target_cpm_micros, ad_group.target_roas, ad_group.targeting_setting.target_restrictions, ad_group.tracking_url_template, ad_group.type, ad_group.url_custom_parameters, campaign.accessible_bidding_strategy, campaign.ad_serving_optimization_status, campaign.advertising_channel_type, campaign.advertising_channel_sub_type, campaign.app_campaign_setting.app_id, campaign.app_campaign_setting.app_store, segments.date FROM search_term_view WHERE segments.date BETWEEN '1980-01-01' AND '1980-01-01'"""
+    input_q = f"SELECT {', '.join(TERMS)} FROM search_term_view"
+    output_q = IncrementalCustomQuery.insert_segments_date_expr(
+        GAQL.parse(input_q), "1980-01-01", "1980-01-01"
     )
+    expected = (
+        f"SELECT {', '.join(TERMS + ['segments.date'])} "
+        "FROM search_term_view "
+        "WHERE segments.date BETWEEN '1980-01-01' AND '1980-01-01'"
+    )
+    assert str(output_q) == expected
 
 
 class Obj:
@@ -27,29 +48,54 @@ class Obj:
 
 
 def test_get_json_schema():
-    query_object = MagicMock(return_value={
-        'a': Obj(data_type=Obj(name='ENUM'), is_repeated=False, enum_values=['a', 'aa']),
-        'b': Obj(data_type=Obj(name='ENUM'), is_repeated=True,  enum_values=['b', 'bb']),
-        'c': Obj(data_type=Obj(name='MESSAGE'), is_repeated=False),
-        'd': Obj(data_type=Obj(name='MESSAGE'), is_repeated=True),
-        'e': Obj(data_type=Obj(name='STRING')),
-        'f': Obj(data_type=Obj(name='DATE')),
-    })
-    instance = CustomQueryMixin(config={'query': Obj(fields=['a', 'b', 'c', 'd', 'e', 'f'])})
+    query_object = MagicMock(
+        return_value={
+            "a": Obj(
+                data_type=Obj(name="ENUM"),
+                is_repeated=False,
+                enum_values=["a", "aa"],
+            ),
+            "b": Obj(
+                data_type=Obj(name="ENUM"),
+                is_repeated=True,
+                enum_values=["b", "bb"],
+            ),
+            "c": Obj(
+                data_type=Obj(name="MESSAGE"),
+                is_repeated=False,
+            ),
+            "d": Obj(
+                data_type=Obj(name="MESSAGE"),
+                is_repeated=True,
+            ),
+            "e": Obj(data_type=Obj(name="STRING")),
+            "f": Obj(data_type=Obj(name="DATE")),
+        }
+    )
+    instance = CustomQueryMixin(
+        config={
+            "query": Obj(
+                fields=["a", "b", "c", "d", "e", "f"],
+            )
+        }
+    )
     instance.cursor_field = None
     instance.google_ads_client = Obj(get_fields_metadata=query_object)
     schema = instance.get_json_schema()
 
     assert schema == {
-        '$schema': 'http://json-schema.org/draft-07/schema#',
-        'additionalProperties': True,
-        'type': 'object',
-        'properties': {
-            'a': {'type': 'string', 'enum': ['a', 'aa']},
-            'b': {'type': ['null', 'array'], 'items': {'type': 'string', 'enum': ['b', 'bb']}},
-            'c': {'type': ['string', 'null'], 'protobuf_message': True},
-            'd': {'type': ['array', 'null'], 'protobuf_message': True},
-            'e': {'type': ['string', 'null']},
-            'f': {'type': ['string', 'null'], 'format': 'date'},
-        }
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "additionalProperties": True,
+        "type": "object",
+        "properties": {
+            "a": {"type": "string", "enum": ["a", "aa"]},
+            "b": {
+                "type": ["null", "array"],
+                "items": {"type": "string", "enum": ["b", "bb"]},
+            },
+            "c": {"type": ["string", "null"], "protobuf_message": True},
+            "d": {"type": ["array", "null"], "protobuf_message": True},
+            "e": {"type": ["string", "null"]},
+            "f": {"type": ["string", "null"], "format": "date"},
+        },
     }


### PR DESCRIPTION
**Description:**

We have a customer who is trying to add custom queries to the source-google-ads connector. The errors were caused by the lack of primary keys for the `CustomQueryMixin` stream, this PR enables it.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1387)
<!-- Reviewable:end -->
