### PR TITLE
facebook: use string formatting for errors

### DIFF
--- a/source-facebook-marketing/source_facebook_marketing/streams/async_job_manager.py
+++ b/source-facebook-marketing/source_facebook_marketing/streams/async_job_manager.py
@@ -103,13 +103,13 @@ class InsightAsyncJobManager:
                 if job.attempt_number >= self.MAX_NUMBER_OF_ATTEMPTS:
                     raise JobException(f"{job}: failed more than {self.MAX_NUMBER_OF_ATTEMPTS} times. Terminating...")
                 elif job.attempt_number == 2:
-                    logger.info("%s: failed second time, trying to split job into smaller jobs.", job)
+                    logger.info(f"{job}: failed second time, trying to split job into smaller jobs.")
                     smaller_jobs = job.split_job()
                     grouped_jobs = ParentAsyncJob(api=self._api.api, jobs=smaller_jobs, interval=job.interval)
                     running_jobs.append(grouped_jobs)
                     grouped_jobs.start()
                 else:
-                    logger.info("%s: failed, restarting", job)
+                    logger.info(f"{job}: failed, restarting")
                     job.restart()
                     running_jobs.append(job)
                 failed_num += 1


### PR DESCRIPTION

**Description:**

- pydantic cannot serialize job as JSON, and ends up throwing the error: TypeError: Object of type 'InsightAsyncJob' is not JSON serializable


**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

