### PR TITLE
cdk: Fix unneccesary escaping on key components in Airbyte shim

### DIFF
--- a/estuary-cdk/estuary_cdk/shim_airbyte_cdk.py
+++ b/estuary-cdk/estuary_cdk/shim_airbyte_cdk.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass
 from logging import Logger
 from pydantic import Field
-from typing import Any, ClassVar, Annotated, Callable, Awaitable, Literal
+from typing import Any, ClassVar, Annotated, Callable, Awaitable, List, Literal
 import logging
 import os
 
@@ -86,6 +86,36 @@ class Document(common.BaseDocument, extra="allow"):
     pass
 
 
+def escape_field(field: str) -> str:
+    return field.replace("~", "~0").replace("/", "~1")
+
+
+def transform_airbyte_key(key: str | List[str] | List[List[str]]) -> List[str]:
+    key_fields: List[str] = []
+
+    if isinstance(key, str):
+        # key = "piz/za"
+        # key_fields: ["piz~1za"]
+        key_fields = [escape_field(key)]
+    elif isinstance(key, list):
+        for component in key:
+            if isinstance(component, str):
+                # key = ["piz/za", "par~ty"]
+                # key_fields: ["piz~1za", "pa~0rty"]
+                key_fields.append(escape_field(component))
+            elif isinstance(component, list):
+                # key = [["pizza", "che/ese"], "potato"]
+                # Implies a document like {"potato": 12, "pizza": {"che/ese": 5}}
+                # key_fields: ["pizza/che~1ese", "potato"]
+                key_fields.append(
+                    "/".join((escape_field(field) for field in component))
+                )
+            else:
+                raise ValueError(f"Invalid key component: {component}")
+
+    return key_fields
+
+
 @dataclass
 class CaptureShim(BaseCaptureConnector):
     delegate: AirbyteSource
@@ -124,11 +154,8 @@ class CaptureShim(BaseCaptureConnector):
             if stream.source_defined_primary_key:
                 # Map array of array of property names into an array of JSON pointers.
                 key = [
-                    "/"
-                    + "/".join(
-                        p.replace("~", "~0").replace("/", "~1") for p in component
-                    )
-                    for component in stream.source_defined_primary_key
+                    "/" + key
+                    for key in transform_airbyte_key(stream.source_defined_primary_key)
                 ]
             elif resource_config.sync_mode == "full_refresh":
                 # Synthesize a key based on the record's order within each stream refresh.
@@ -176,13 +203,17 @@ class CaptureShim(BaseCaptureConnector):
         )
 
     async def discover(
-        self, log: Logger, discover: request.Discover[EndpointConfig],
+        self,
+        log: Logger,
+        discover: request.Discover[EndpointConfig],
     ) -> response.Discovered:
         resources = await self._all_resources(log, discover.config)
         return common.discovered(resources)
 
     async def validate(
-        self, log: Logger, validate: request.Validate[EndpointConfig, ResourceConfig],
+        self,
+        log: Logger,
+        validate: request.Validate[EndpointConfig, ResourceConfig],
     ) -> response.Validated:
 
         result = self.delegate.check(log, validate.config)

--- a/estuary-cdk/tests/test_airbyte_cdk.py
+++ b/estuary-cdk/tests/test_airbyte_cdk.py
@@ -1,0 +1,10 @@
+from estuary_cdk.shim_airbyte_cdk import transform_airbyte_key
+
+def test_transform_airbyte_key():
+    assert transform_airbyte_key("pizza") == ["pizza"]
+    assert transform_airbyte_key("piz/za") == ["piz~1za"]
+    assert transform_airbyte_key(["piz/za"]) == ["piz~1za"]
+    assert transform_airbyte_key(["piz/za", "par~ty"]) == ["piz~1za", "par~0ty"]
+    assert transform_airbyte_key([["pizza", "che/ese"], "potato"]) == [
+       "pizza/che~1ese", "potato"
+    ]


### PR DESCRIPTION
**Description:**

Flow key components are strings that represent JSON pointers. So a key component `/meta/row_id` would mean that the key for document `{"meta": {"row_id": 1234}}` would be `1234`. But we could also have a document like `{"pizza/party": 1234}`, and if we wanted to use that field `"pizza/party"` as the key, that’s where we’d want to escape it as `"pizza~1party"`. I did some digging, and it looks like airbyte handles nested keys a little differently:
```python
    @property
    @abstractmethod
    def primary_key(self) -> Optional[Union[str, List[str], List[List[str]]]]:
        """
        :return: string if single primary key, list of strings if composite primary key, list of list of strings if composite primary key consisting of nested fields.
          If the stream has no primary keys, return None.
        """
```

So this PR updates our key escaping to be more nuanced and handle translating Airbyte's nested-list representation to our escaped-string representation.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1393)
<!-- Reviewable:end -->
