### PR TITLE
sqlcapture: Use segmentio JSON encoder instead of stdlib

### DIFF
--- a/sqlcapture/capture.go
+++ b/sqlcapture/capture.go
@@ -2,7 +2,6 @@ package sqlcapture
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"io"
 	"math/rand"
@@ -10,6 +9,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/segmentio/encoding/json"
 
 	boilerplate "github.com/estuary/connectors/source-boilerplate"
 	pf "github.com/estuary/flow/go/protocols/flow"


### PR DESCRIPTION
**Description:**

JSON encoding is one of the single largest bottlenecks in the SQL CDC captures at present. A recent example in production where replication throughput was constrained by connector CPU had JSON serialization at around 70% of main thread CPU usage.

The standard library `encoding/json` package is fairly slow with the way it uses reflection everywhere, and the package `github.com/segmentio/encoding/json` is a drop-in replacement which performs 2-3x better in most benchmarks.

So swapping out the JSON encoder used here is a very easy way to improve the situation, although in the long run there are fancier approaches we could potentially use to make it even faster.

See also:
- source-mysql-batch in https://github.com/estuary/connectors/pull/1005
- materialize-sql in https://github.com/estuary/connectors/pull/1010

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1394)
<!-- Reviewable:end -->
