### PR TITLE
source-sqlserver: Remove `format: time` from `TIME` column type

### DIFF
--- a/source-sqlserver/.snapshots/TestDiscoveryIrrelevantConstraints
+++ b/source-sqlserver/.snapshots/TestDiscoveryIrrelevantConstraints
@@ -34,6 +34,28 @@ Binding 0:
       },
       "allOf": [
         {
+          "if": {
+            "properties": {
+              "_meta": {
+                "properties": {
+                  "op": {
+                    "const": "d"
+                  }
+                }
+              }
+            }
+          },
+          "then": {
+            "reduce": {
+              "delete": true,
+              "strategy": "merge"
+            }
+          },
+          "else": {
+            "reduce": {
+              "strategy": "merge"
+            }
+          },
           "required": [
             "_meta"
           ],
@@ -106,9 +128,6 @@ Binding 0:
                 "strategy": "merge"
               }
             }
-          },
-          "reduce": {
-            "strategy": "merge"
           }
         },
         {

--- a/source-sqlserver/.snapshots/TestGeneric-KeylessDiscovery
+++ b/source-sqlserver/.snapshots/TestGeneric-KeylessDiscovery
@@ -38,6 +38,28 @@ Binding 0:
       },
       "allOf": [
         {
+          "if": {
+            "properties": {
+              "_meta": {
+                "properties": {
+                  "op": {
+                    "const": "d"
+                  }
+                }
+              }
+            }
+          },
+          "then": {
+            "reduce": {
+              "delete": true,
+              "strategy": "merge"
+            }
+          },
+          "else": {
+            "reduce": {
+              "strategy": "merge"
+            }
+          },
           "required": [
             "_meta"
           ],
@@ -110,9 +132,6 @@ Binding 0:
                 "strategy": "merge"
               }
             }
-          },
-          "reduce": {
-            "strategy": "merge"
           }
         },
         {

--- a/source-sqlserver/.snapshots/TestGeneric-SimpleDiscovery
+++ b/source-sqlserver/.snapshots/TestGeneric-SimpleDiscovery
@@ -37,6 +37,28 @@ Binding 0:
       },
       "allOf": [
         {
+          "if": {
+            "properties": {
+              "_meta": {
+                "properties": {
+                  "op": {
+                    "const": "d"
+                  }
+                }
+              }
+            }
+          },
+          "then": {
+            "reduce": {
+              "delete": true,
+              "strategy": "merge"
+            }
+          },
+          "else": {
+            "reduce": {
+              "strategy": "merge"
+            }
+          },
           "required": [
             "_meta"
           ],
@@ -109,9 +131,6 @@ Binding 0:
                 "strategy": "merge"
               }
             }
-          },
-          "reduce": {
-            "strategy": "merge"
           }
         },
         {

--- a/source-sqlserver/datatypes_test.go
+++ b/source-sqlserver/datatypes_test.go
@@ -45,7 +45,7 @@ func TestDatatypes(t *testing.T) {
 		{ColumnType: `image`, ExpectType: `{"type":["string","null"],"contentEncoding":"base64"}`, InputValue: []byte{0x12, 0x34, 0x56, 0x78}, ExpectValue: `"EjRWeA=="`},
 
 		{ColumnType: `date`, ExpectType: `{"type":["string","null"],"format":"date"}`, InputValue: `1991-08-31`, ExpectValue: `"1991-08-31"`},
-		{ColumnType: `time`, ExpectType: `{"type":["string","null"],"format":"time"}`, InputValue: `12:34:54.125`, ExpectValue: `"12:34:54.125"`},
+		{ColumnType: `time`, ExpectType: `{"type":["string","null"]}`, InputValue: `12:34:54.125`, ExpectValue: `"12:34:54.125"`},
 		{ColumnType: `datetimeoffset`, ExpectType: `{"type":["string","null"],"format":"date-time"}`, InputValue: `1991-08-31T12:34:54.125-06:00`, ExpectValue: `"1991-08-31T12:34:54.125-06:00"`},
 
 		{ColumnType: `datetime`, ExpectType: `{"type":["string","null"],"format":"date-time"}`, InputValue: `1991-08-31T12:34:56.789`, ExpectValue: `"1991-08-31T12:34:56.79-05:00"`},

--- a/source-sqlserver/discovery.go
+++ b/source-sqlserver/discovery.go
@@ -386,8 +386,17 @@ var sqlserverTypeToJSON = map[string]columnSchema{
 	"image":     {jsonType: "string", contentEncoding: "base64"},
 
 	"date":           {jsonType: "string", format: "date"},
-	"time":           {jsonType: "string", format: "time"},
 	"datetimeoffset": {jsonType: "string", format: "date-time"},
+
+	// The 'time' format in JSON schemas means the RFC3339 'full-time' grammar rule,
+	// which includes a numeric timezone offset. The TIME column in SQL Server has
+	// no associated timezone data, and it's not possible to unambiguously assign a
+	// numeric timezone offset to these HH:MM:SS time values using the configured
+	// datetime location (handwaving at one reason: how do we know if DST applies?).
+	//
+	// So we don't do that, and that's why TIME columns just get turned into strings
+	// without a specific format guarantee here.
+	"time": {jsonType: "string"},
 
 	"uniqueidentifier": {jsonType: "string", format: "uuid"},
 


### PR DESCRIPTION
**Description:**

Previously our discovery schema generation for a `TIME` column in the source database produces `{type: string, format: time}`, but that format means "a string satisfying the `full-time` production rule from RFC3339" and `full-time` has to end in a timezone offset suffix, but the `TIME` column is just a bare `HH:MM:SS[.NNN]` value without any associated time zone offset for us to provide, so right now we don't have any such suffix and that means that the values we capture don't actually satisfy the JSON schema we claimed.

In order to resolve this we could:
1. Slap on a suffix of `"Z"` to every time value
2. Interpret the time values in the capture's configured timezone.
3. Stop claiming these strings match `format: time`

The problem with option 1 is that these times are no generally in the UTC timezone in the first place. The problem with option 2 is that the user might configure a timezone by providing an IANA name like `'America/Chicago'` but that doesn't uniquely identify a fixed UTC offset for a bare `HH:MM:SS` time (basically: should a particular time value be given the DST or non-DST time offset?) and there is no way of resolving that ambiguity which wouldn't lead to unpleasant surprises in at least some cases.

So that leaves us with option 3, just outputting the obvious strings representing these time values and removing the format qualifier that we can't actually satisfy. Unlike `DATETIME` columns (where it's worth the effort to satisfy the RFC3339 timestamp requirements because many materializations can use an appropriate destination-specific type on the other side (and also there we have a `YYYY-MM-DD` part which can be used unambiguously with a named timezone)), I do not believe we have much special handling for `format: time` so this shouldn't be any real loss in practice.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1395)
<!-- Reviewable:end -->
