### PR TITLE
source-redshift-batch: Discover all columns and omit fallback key

### DIFF
--- a/source-redshift-batch/.snapshots/TestBasicCapture-Discovery
+++ b/source-redshift-batch/.snapshots/TestBasicCapture-Discovery
@@ -39,11 +39,13 @@ Binding 0:
               "index"
             ]
           },
+          "data": {
+            "type": "string"
+          },
           "id": {
             "type": "integer"
           }
-        },
-        "x-infer-schema": true
+        }
       },
       "key": [
         "/id"

--- a/source-redshift-batch/.snapshots/TestBasicDatatypes-Discovery
+++ b/source-redshift-batch/.snapshots/TestBasicDatatypes-Discovery
@@ -39,11 +39,28 @@ Binding 0:
               "index"
             ]
           },
+          "a_bool": {
+            "type": "boolean"
+          },
+          "a_date": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "a_real": {
+            "type": "number"
+          },
+          "a_ts": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "a_tstz": {
+            "type": "string",
+            "format": "date-time"
+          },
           "id": {
             "type": "integer"
           }
-        },
-        "x-infer-schema": true
+        }
       },
       "key": [
         "/id"

--- a/source-redshift-batch/.snapshots/TestKeylessDiscovery
+++ b/source-redshift-batch/.snapshots/TestKeylessDiscovery
@@ -1,24 +1,19 @@
 Binding 0:
 {
     "resource_config_json": {
-      "name": "test_key_discovery_329932",
-      "template": "{{if .CursorFields -}}\n  {{- if .IsFirstQuery -}}\n    SELECT * FROM \"test\".\"key_discovery_329932\"\n  {{- else -}}\n    SELECT * FROM \"test\".\"key_discovery_329932\"\n\t{{- range $i, $k := $.CursorFields -}}\n\t  {{- if eq $i 0}} WHERE ({{else}}) OR ({{end -}}\n      {{- range $j, $n := $.CursorFields -}}\n\t\t{{- if lt $j $i -}}\n\t\t  {{$n}} = ${{add $j 1}} AND {{end -}}\n\t  {{- end -}}\n\t  {{$k}} \u003e ${{add $i 1}}\n\t{{- end -}}\n\t) \n  {{- end}} ORDER BY {{range $i, $k := $.CursorFields}}{{if gt $i 0}}, {{end}}{{$k}}{{end -}};\n{{- else -}}\n  SELECT * FROM \"test\".\"key_discovery_329932\";\n{{- end}}\n",
+      "name": "test_keyless_discovery_10352",
+      "template": "{{if .CursorFields -}}\n  {{- if .IsFirstQuery -}}\n    SELECT * FROM \"test\".\"keyless_discovery_10352\"\n  {{- else -}}\n    SELECT * FROM \"test\".\"keyless_discovery_10352\"\n\t{{- range $i, $k := $.CursorFields -}}\n\t  {{- if eq $i 0}} WHERE ({{else}}) OR ({{end -}}\n      {{- range $j, $n := $.CursorFields -}}\n\t\t{{- if lt $j $i -}}\n\t\t  {{$n}} = ${{add $j 1}} AND {{end -}}\n\t  {{- end -}}\n\t  {{$k}} \u003e ${{add $i 1}}\n\t{{- end -}}\n\t) \n  {{- end}} ORDER BY {{range $i, $k := $.CursorFields}}{{if gt $i 0}}, {{end}}{{$k}}{{end -}};\n{{- else -}}\n  SELECT * FROM \"test\".\"keyless_discovery_10352\";\n{{- end}}\n",
       "cursor": null
     },
     "resource_path": [
-      "test_key_discovery_329932"
+      "test_keyless_discovery_10352"
     ],
     "collection": {
-      "name": "acmeCo/test/test_key_discovery_329932",
+      "name": "acmeCo/test/test_keyless_discovery_10352",
       "read_schema_json": {
         "type": "object",
         "required": [
-          "_meta",
-          "k_smallint",
-          "k_int",
-          "k_bigint",
-          "k_bool",
-          "k_str"
+          "_meta"
         ],
         "properties": {
           "_meta": {
@@ -43,35 +38,36 @@ Binding 0:
               "index"
             ]
           },
-          "data": {
-            "type": "string"
-          },
-          "k_bigint": {
+          "v_bigint": {
             "type": "integer"
           },
-          "k_bool": {
+          "v_bool": {
             "type": "boolean"
           },
-          "k_int": {
+          "v_int": {
             "type": "integer"
           },
-          "k_smallint": {
+          "v_smallint": {
             "type": "integer"
           },
-          "k_str": {
+          "v_str": {
             "type": "string"
+          },
+          "v_text": {
+            "type": "string"
+          },
+          "v_ts": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "v_tstz": {
+            "type": "string",
+            "format": "date-time"
           }
         }
       },
-      "key": [
-        "/k_smallint",
-        "/k_int",
-        "/k_bigint",
-        "/k_bool",
-        "/k_str"
-      ],
       "projections": null
     },
-    "state_key": "test_key_discovery_329932"
+    "state_key": "test_keyless_discovery_10352"
   }
 

--- a/source-redshift-batch/.snapshots/TestSchemaFilter-FilteredIn
+++ b/source-redshift-batch/.snapshots/TestSchemaFilter-FilteredIn
@@ -39,11 +39,13 @@ Binding 0:
               "index"
             ]
           },
+          "data": {
+            "type": "string"
+          },
           "id": {
             "type": "integer"
           }
-        },
-        "x-infer-schema": true
+        }
       },
       "key": [
         "/id"

--- a/source-redshift-batch/.snapshots/TestSchemaFilter-Unfiltered
+++ b/source-redshift-batch/.snapshots/TestSchemaFilter-Unfiltered
@@ -39,11 +39,13 @@ Binding 0:
               "index"
             ]
           },
+          "data": {
+            "type": "string"
+          },
           "id": {
             "type": "integer"
           }
-        },
-        "x-infer-schema": true
+        }
       },
       "key": [
         "/id"

--- a/source-redshift-batch/README.md
+++ b/source-redshift-batch/README.md
@@ -1,4 +1,20 @@
 Redshift Batch Source Connector
 ===============================
 
-TODO
+Redshift external connectivity setup:
+
+1. Set 'Publicly Accessible' to 'On' for the workgroup
+2. The associated VPC Security Group needs an Inbound Rule permitting Redshift
+   traffic from `0.0.0.0/0` or from the Estuary public IP.
+3. The associated VPC Route Table needs a route for traffic to `0.0.0.0/0` or
+   the Estuary public IP to egress via an Internet Gateway.
+4. If the VPC uses network ACLs, they also need to permit inbound and outbound
+   Redshift traffic.
+
+Example user setup:
+
+    $ psql 'postgres://admin:Secret1234@default-workgroup.123456789123.us-east-1.redshift-serverless.amazonaws.com:5439/dev'
+    dev=# CREATE USER flow_capture WITH PASSWORD 'Secret1234';
+    dev=# CREATE SCHEMA test;
+    dev=# ALTER DEFAULT PRIVILEGES FOR USER admin IN SCHEMA test GRANT ALL ON TABLES TO flow_capture;
+    dev=# GRANT ALL ON SCHEMA test TO flow_capture;

--- a/source-redshift-batch/driver.go
+++ b/source-redshift-batch/driver.go
@@ -365,10 +365,11 @@ func discoverColumns(ctx context.Context, db *sql.DB, discoverSchemas []string) 
 	fmt.Fprintf(query, "  WHERE a.attnum > 0")
 	fmt.Fprintf(query, "    AND NOT a.attisdropped")
 	fmt.Fprintf(query, "    AND c.relkind IN ('r', 'p', 'v', 'f')")
-	fmt.Fprintf(query, "    AND nc.nspname NOT IN ('pg_catalog', 'pg_internal', 'information_schema', 'catalog_history', 'cron')")
 	if len(discoverSchemas) > 0 {
 		fmt.Fprintf(query, "    AND nc.nspname = ANY ($1)")
 		args = append(args, discoverSchemas)
+	} else {
+		fmt.Fprintf(query, "    AND nc.nspname NOT IN ('pg_catalog', 'pg_internal', 'information_schema', 'catalog_history', 'cron')")
 	}
 	fmt.Fprintf(query, "  ORDER BY nc.nspname, c.relname, a.attnum;")
 
@@ -445,6 +446,8 @@ func discoverPrimaryKeys(ctx context.Context, db *sql.DB, discoverSchemas []stri
 	if len(discoverSchemas) > 0 {
 		fmt.Fprintf(query, "    AND nr.nspname = ANY ($1)")
 		args = append(args, discoverSchemas)
+	} else {
+		fmt.Fprintf(query, "    AND nr.nspname NOT IN ('pg_catalog', 'pg_internal', 'information_schema', 'catalog_history', 'cron')")
 	}
 	fmt.Fprintf(query, "  ORDER BY r.relname, pos.n;")
 

--- a/source-redshift-batch/driver.go
+++ b/source-redshift-batch/driver.go
@@ -86,10 +86,7 @@ type documentMetadata struct {
 	Index  int       `json:"index" jsonschema:"title=Result Index,description=The index of this document within the query execution which produced it."`
 }
 
-// The fallback collection key just refers to the polling iteration and result index of each document.
-var fallbackKey = []string{"/_meta/polled", "/_meta/index"}
-
-func generateCollectionSchema(keyColumns []string, columnTypes map[string]*jsonschema.Schema) (json.RawMessage, error) {
+func generateCollectionSchema(keyColumns []string, columnTypes map[string]columnType) (json.RawMessage, error) {
 	// Generate schema for the metadata via reflection
 	var reflector = jsonschema.Reflector{
 		ExpandedStruct: true,
@@ -99,18 +96,12 @@ func generateCollectionSchema(keyColumns []string, columnTypes map[string]*jsons
 	metadataSchema.Definitions = nil
 	metadataSchema.AdditionalProperties = nil
 
-	var required = []string{"_meta"}
+	var required = append([]string{"_meta"}, keyColumns...)
 	var properties = map[string]*jsonschema.Schema{
 		"_meta": metadataSchema,
 	}
-
-	for _, colName := range keyColumns {
-		var columnType = columnTypes[colName]
-		if columnType == nil {
-			return nil, fmt.Errorf("unable to add key column %q to schema: type unknown", colName)
-		}
-		properties[colName] = columnType
-		required = append(required, colName)
+	for colName, colType := range columnTypes {
+		properties[colName] = colType.JSONSchema()
 	}
 
 	var schema = &jsonschema.Schema{
@@ -118,8 +109,7 @@ func generateCollectionSchema(keyColumns []string, columnTypes map[string]*jsons
 		Required:             required,
 		AdditionalProperties: nil,
 		Extras: map[string]interface{}{
-			"properties":     properties,
-			"x-infer-schema": true,
+			"properties": properties,
 		},
 	}
 
@@ -130,14 +120,6 @@ func generateCollectionSchema(keyColumns []string, columnTypes map[string]*jsons
 	}
 	return json.RawMessage(bs), nil
 }
-
-var minimalSchema = func() json.RawMessage {
-	var schema, err = generateCollectionSchema(nil, nil)
-	if err != nil {
-		panic(err)
-	}
-	return schema
-}()
 
 // Spec returns metadata about the capture connector.
 func (drv *BatchSQLDriver) Spec(ctx context.Context, req *pc.Request_Spec) (*pc.Response_Spec, error) {
@@ -174,24 +156,41 @@ func (drv *BatchSQLDriver) Discover(ctx context.Context, req *pc.Request_Discove
 	}
 	defer db.Close()
 
+	// Run discovery queries
 	tables, err := discoverTables(ctx, db, cfg.Advanced.DiscoverSchemas)
 	if err != nil {
 		return nil, fmt.Errorf("error listing tables: %w", err)
+	}
+	columns, err := discoverColumns(ctx, db, cfg.Advanced.DiscoverSchemas)
+	if err != nil {
+		return nil, fmt.Errorf("error listing columns: %w", err)
 	}
 	keys, err := discoverPrimaryKeys(ctx, db, cfg.Advanced.DiscoverSchemas)
 	if err != nil {
 		return nil, fmt.Errorf("error listing primary keys: %w", err)
 	}
 
-	// We rebuild this map even though `discoverPrimaryKeys` already built and
-	// discarded it, in order to keep the `discoverTables` / `discoverPrimaryKeys`
-	// interface as stupidly simple as possible, which ought to make it just that
-	// little bit easier to do this generically for multiple databases.
-	var keysByTable = make(map[string]*discoveredPrimaryKey)
-	for _, key := range keys {
-		keysByTable[key.Schema+"."+key.Table] = key
+	// Aggregate column information by table
+	var columnsByTable = make(map[string][]*discoveredColumn)
+	for _, column := range columns {
+		var tableID = column.Schema + "." + column.Table
+		columnsByTable[tableID] = append(columnsByTable[tableID], column)
+		if column.Index != len(columnsByTable[tableID]) {
+			return nil, fmt.Errorf("internal error: column %q of table %q appears out of order", column.Name, tableID)
+		}
 	}
 
+	// Aggregate primary-key information by table
+	var keysByTable = make(map[string][]*discoveredPrimaryKey)
+	for _, key := range keys {
+		var tableID = key.Schema + "." + key.Table
+		keysByTable[tableID] = append(keysByTable[tableID], key)
+		if key.Index != len(keysByTable[tableID]) {
+			return nil, fmt.Errorf("internal error: primary key column %q of table %q appears out of order", key.Column, tableID)
+		}
+	}
+
+	// Generate discovery resource and collection schema for this table
 	var bindings []*pc.Response_Discovered_Binding
 	for _, table := range tables {
 		var tableID = table.Schema + "." + table.Name
@@ -211,26 +210,32 @@ func (drv *BatchSQLDriver) Discover(ctx context.Context, req *pc.Request_Discove
 			return nil, fmt.Errorf("error serializing resource spec: %w", err)
 		}
 
-		// Try to generate a useful collection schema, but on error fall back to the
-		// minimal schema with the default key [/_meta/polled, /_meta/index].
-		var collectionSchema = minimalSchema
-		var collectionKey = fallbackKey
-		if tableKey, ok := keysByTable[tableID]; ok {
-			if generatedSchema, err := generateCollectionSchema(tableKey.Columns, tableKey.ColumnTypes); err == nil {
-				collectionSchema = generatedSchema
-				collectionKey = nil
-				for _, colName := range tableKey.Columns {
-					collectionKey = append(collectionKey, primaryKeyToCollectionKey(colName))
-				}
-			} else {
-				log.WithFields(log.Fields{"table": tableID, "err": err}).Warn("unable to generate collection schema")
-			}
+		// Generate a collection schema from the column types and key column names of this table.
+		var keyColumns []string
+		for _, key := range keysByTable[tableID] {
+			keyColumns = append(keyColumns, key.Column)
+		}
+
+		var columnTypes = make(map[string]columnType)
+		for _, column := range columnsByTable[tableID] {
+			columnTypes[column.Name] = column.DataType
+		}
+
+		generatedSchema, err := generateCollectionSchema(keyColumns, columnTypes)
+		if err != nil {
+			log.WithFields(log.Fields{"table": tableID, "err": err}).Warn("unable to generate collection schema")
+			continue
+		}
+
+		var collectionKey []string
+		for _, colName := range keyColumns {
+			collectionKey = append(collectionKey, primaryKeyToCollectionKey(colName))
 		}
 
 		bindings = append(bindings, &pc.Response_Discovered_Binding{
 			RecommendedName:    recommendedName,
 			ResourceConfigJson: resourceConfigJSON,
-			DocumentSchemaJson: collectionSchema,
+			DocumentSchemaJson: generatedSchema,
 			Key:                collectionKey,
 			ResourcePath:       []string{res.Name},
 		})
@@ -259,7 +264,7 @@ func discoverTables(ctx context.Context, db *sql.DB, discoverSchemas []string) (
 	var query = new(strings.Builder)
 	var args []any
 
-	fmt.Fprintf(query, "SELECT n.nspname AS table_schema,")
+	fmt.Fprintf(query, "SELECT nc.nspname AS table_schema,")
 	fmt.Fprintf(query, "       c.relname AS table_name,")
 	fmt.Fprintf(query, "       CASE")
 	fmt.Fprintf(query, "         WHEN c.relkind = ANY (ARRAY['r'::\"char\", 'p'::\"char\"]) THEN 'BASE TABLE'::text")
@@ -268,12 +273,13 @@ func discoverTables(ctx context.Context, db *sql.DB, discoverSchemas []string) (
 	fmt.Fprintf(query, "         ELSE ''::text")
 	fmt.Fprintf(query, "       END::information_schema.character_data AS table_type")
 	fmt.Fprintf(query, " FROM pg_catalog.pg_class c")
-	fmt.Fprintf(query, " JOIN pg_catalog.pg_namespace n ON (n.oid = c.relnamespace)")
-	fmt.Fprintf(query, " WHERE n.nspname NOT IN ('pg_catalog', 'pg_internal', 'information_schema', 'catalog_history', 'cron')")
-	fmt.Fprintf(query, "  AND c.relkind IN ('r', 'p', 'v', 'f')")
+	fmt.Fprintf(query, " JOIN pg_catalog.pg_namespace nc ON (nc.oid = c.relnamespace)")
+	fmt.Fprintf(query, " WHERE c.relkind IN ('r', 'p', 'v', 'f')")
 	if len(discoverSchemas) > 0 {
-		fmt.Fprintf(query, "  AND n.nspname = ANY ($1)")
+		fmt.Fprintf(query, "  AND nc.nspname = ANY ($1)")
 		args = append(args, discoverSchemas)
+	} else {
+		fmt.Fprintf(query, "  AND nc.nspname NOT IN ('pg_catalog', 'pg_internal', 'information_schema', 'catalog_history', 'cron')")
 	}
 	fmt.Fprintf(query, ";")
 
@@ -298,11 +304,122 @@ func discoverTables(ctx context.Context, db *sql.DB, discoverSchemas []string) (
 	return tables, nil
 }
 
+type discoveredColumn struct {
+	Schema      string     // The schema in which the table resides
+	Table       string     // The name of the table with this column
+	Name        string     // The name of the column
+	Index       int        // The ordinal position of the column within a row
+	IsNullable  bool       // Whether the column can be null
+	DataType    columnType // The datatype of the column
+	Description *string    // The description of the column, if present and known
+}
+
+type columnType interface {
+	JSONSchema() *jsonschema.Schema
+}
+
+type basicColumnType struct {
+	jsonType        string
+	contentEncoding string
+	format          string
+	nullable        bool
+	description     string
+}
+
+func (ct *basicColumnType) JSONSchema() *jsonschema.Schema {
+	var sch = &jsonschema.Schema{
+		Format: ct.format,
+		Extras: make(map[string]interface{}),
+	}
+
+	if ct.contentEncoding != "" {
+		sch.Extras["contentEncoding"] = ct.contentEncoding // New in 2019-09.
+	}
+
+	if ct.jsonType == "" {
+		// No type constraint.
+	} else if !ct.nullable {
+		sch.Type = ct.jsonType
+	} else {
+		sch.Extras["type"] = []string{ct.jsonType, "null"}
+	}
+	return sch
+}
+
+func discoverColumns(ctx context.Context, db *sql.DB, discoverSchemas []string) ([]*discoveredColumn, error) {
+	var query = new(strings.Builder)
+	var args []any
+	fmt.Fprintf(query, "SELECT nc.nspname as table_schema,")
+	fmt.Fprintf(query, "       c.relname as table_name,")
+	fmt.Fprintf(query, "       a.attname as column_name,")
+	fmt.Fprintf(query, "       a.attnum as column_index,")
+	fmt.Fprintf(query, "       NOT (a.attnotnull OR (t.typtype = 'd' AND t.typnotnull)) AS is_nullable,")
+	fmt.Fprintf(query, "       COALESCE(bt.typname, t.typname) AS udt_name,")
+	fmt.Fprintf(query, "       t.typtype::text AS typtype")
+	fmt.Fprintf(query, "  FROM pg_catalog.pg_attribute a")
+	fmt.Fprintf(query, "  JOIN pg_catalog.pg_type t ON a.atttypid = t.oid")
+	fmt.Fprintf(query, "  JOIN pg_catalog.pg_class c ON a.attrelid = c.oid")
+	fmt.Fprintf(query, "  JOIN pg_catalog.pg_namespace nc ON c.relnamespace = nc.oid")
+	fmt.Fprintf(query, "  LEFT JOIN (pg_catalog.pg_type bt JOIN pg_namespace nbt ON bt.typnamespace = nbt.oid)")
+	fmt.Fprintf(query, "    ON t.typtype = 'd'::\"char\" AND t.typbasetype = bt.oid")
+	fmt.Fprintf(query, "  WHERE a.attnum > 0")
+	fmt.Fprintf(query, "    AND NOT a.attisdropped")
+	fmt.Fprintf(query, "    AND c.relkind IN ('r', 'p', 'v', 'f')")
+	fmt.Fprintf(query, "    AND nc.nspname NOT IN ('pg_catalog', 'pg_internal', 'information_schema', 'catalog_history', 'cron')")
+	if len(discoverSchemas) > 0 {
+		fmt.Fprintf(query, "    AND nc.nspname = ANY ($1)")
+		args = append(args, discoverSchemas)
+	}
+	fmt.Fprintf(query, "  ORDER BY nc.nspname, c.relname, a.attnum;")
+
+	rows, err := db.QueryContext(ctx, query.String(), args...)
+	if err != nil {
+		return nil, fmt.Errorf("error executing discovery query %q: %w", query.String(), err)
+	}
+	defer rows.Close()
+
+	var columns []*discoveredColumn
+	for rows.Next() {
+		var tableSchema, tableName, columnName string
+		var columnIndex int
+		var isNullable bool
+		var typeName, typeType string
+		if err := rows.Scan(&tableSchema, &tableName, &columnName, &columnIndex, &isNullable, &typeName, &typeType); err != nil {
+			return nil, fmt.Errorf("error scanning result row: %w", err)
+		}
+
+		// Decode column type information into a usable form
+		var dataType columnType
+		switch typeType {
+		case "e": // enum values are captured as strings
+			dataType = &basicColumnType{jsonType: "string"}
+		case "r", "m": // ranges and multiranges are captured as strings
+			dataType = &basicColumnType{jsonType: "string"}
+		default:
+			var ok bool
+			dataType, ok = databaseTypeToJSON[typeName]
+			if !ok {
+				dataType = &basicColumnType{description: fmt.Sprintf("using catch-all schema for unknown type %q", typeName)}
+			}
+		}
+
+		columns = append(columns, &discoveredColumn{
+			Schema:     tableSchema,
+			Table:      tableName,
+			Name:       columnName,
+			Index:      columnIndex,
+			IsNullable: isNullable,
+			DataType:   dataType,
+		})
+	}
+	return columns, nil
+}
+
 type discoveredPrimaryKey struct {
-	Schema      string
-	Table       string
-	Columns     []string
-	ColumnTypes map[string]*jsonschema.Schema
+	Schema string
+	Table  string
+	Column string
+	Index  int
 }
 
 func discoverPrimaryKeys(ctx context.Context, db *sql.DB, discoverSchemas []string) ([]*discoveredPrimaryKey, error) {
@@ -312,22 +429,15 @@ func discoverPrimaryKeys(ctx context.Context, db *sql.DB, discoverSchemas []stri
 	fmt.Fprintf(query, "SELECT nr.nspname::information_schema.sql_identifier AS table_schema,")
 	fmt.Fprintf(query, "       r.relname::information_schema.sql_identifier AS table_name,")
 	fmt.Fprintf(query, "       a.attname::information_schema.sql_identifier AS column_name,")
-	fmt.Fprintf(query, "       pos.n::information_schema.cardinal_number AS ordinal_position,")
-	// The handling of type names here is a bit weak, refer to how the `information_schema.columns`
-	// view computes its `data_type` column for a more comprehensive approach. But in practice we
-	// don't need all of that complexity just to identify basic integer columns, so this ought to
-	// be sufficient for now.
-	fmt.Fprintf(query, "       t.typname AS type_name")
+	fmt.Fprintf(query, "       pos.n::information_schema.cardinal_number AS ordinal_position")
 	fmt.Fprintf(query, "  FROM pg_namespace nr,")
 	fmt.Fprintf(query, "       pg_class r,")
 	fmt.Fprintf(query, "       pg_attribute a,")
-	fmt.Fprintf(query, "       pg_type t,")
 	fmt.Fprintf(query, "       pg_constraint c,")
 	fmt.Fprintf(query, "       generate_series(1,100,1) pos(n)")
 	fmt.Fprintf(query, "  WHERE nr.oid = r.relnamespace")
 	fmt.Fprintf(query, "    AND r.oid = a.attrelid")
 	fmt.Fprintf(query, "    AND r.oid = c.conrelid")
-	fmt.Fprintf(query, "    AND t.oid = a.atttypid")
 	fmt.Fprintf(query, "    AND c.conkey[pos.n] = a.attnum")
 	fmt.Fprintf(query, "    AND NOT a.attisdropped")
 	fmt.Fprintf(query, "    AND c.contype = 'p'::\"char\"")
@@ -344,50 +454,69 @@ func discoverPrimaryKeys(ctx context.Context, db *sql.DB, discoverSchemas []stri
 	}
 	defer rows.Close()
 
-	var keysByTable = make(map[string]*discoveredPrimaryKey)
+	var keys []*discoveredPrimaryKey
 	for rows.Next() {
-		var tableSchema, tableName, columnName, dataType string
+		var tableSchema, tableName, columnName string
 		var ordinalPosition int
-		if err := rows.Scan(&tableSchema, &tableName, &columnName, &ordinalPosition, &dataType); err != nil {
+		if err := rows.Scan(&tableSchema, &tableName, &columnName, &ordinalPosition); err != nil {
 			return nil, fmt.Errorf("error scanning result row: %w", err)
 		}
 
-		var tableID = tableSchema + "." + tableName
-		var keyInfo = keysByTable[tableID]
-		if keyInfo == nil {
-			keyInfo = &discoveredPrimaryKey{
-				Schema:      tableSchema,
-				Table:       tableName,
-				ColumnTypes: make(map[string]*jsonschema.Schema),
-			}
-			keysByTable[tableID] = keyInfo
-		}
-		keyInfo.Columns = append(keyInfo.Columns, columnName)
-		if jsonSchema, ok := databaseTypeToJSON[dataType]; ok {
-			keyInfo.ColumnTypes[columnName] = jsonSchema
-		} else {
-			// Assume unknown types are strings, because it's almost always a string.
-			// (Or it's an object, but those can't be Flow collection keys anyway)
-			keyInfo.ColumnTypes[columnName] = &jsonschema.Schema{Type: "string"}
-		}
-		if ordinalPosition != len(keyInfo.Columns) {
-			return nil, fmt.Errorf("primary key column %q (of table %q) appears out of order", columnName, tableID)
-		}
-	}
-
-	var keys []*discoveredPrimaryKey
-	for _, key := range keysByTable {
-		keys = append(keys, key)
+		keys = append(keys, &discoveredPrimaryKey{
+			Schema: tableSchema,
+			Table:  tableName,
+			Column: columnName,
+			Index:  ordinalPosition,
+		})
 	}
 	return keys, nil
 }
 
-var databaseTypeToJSON = map[string]*jsonschema.Schema{
-	"int2":    {Type: "integer"},
-	"int4":    {Type: "integer"},
-	"int8":    {Type: "integer"},
-	"bool":    {Type: "boolean"},
-	"varchar": {Type: "string"},
+var databaseTypeToJSON = map[string]columnType{
+	"bool": &basicColumnType{jsonType: "boolean"},
+
+	"int2": &basicColumnType{jsonType: "integer"},
+	"int4": &basicColumnType{jsonType: "integer"},
+	"int8": &basicColumnType{jsonType: "integer"},
+
+	"numeric": &basicColumnType{jsonType: "string", format: "number"},
+	"float4":  &basicColumnType{jsonType: "number"},
+	"float8":  &basicColumnType{jsonType: "number"},
+
+	"varchar": &basicColumnType{jsonType: "string"},
+	"bpchar":  &basicColumnType{jsonType: "string"},
+	"text":    &basicColumnType{jsonType: "string"},
+	"bytea":   &basicColumnType{jsonType: "string", contentEncoding: "base64"},
+	"xml":     &basicColumnType{jsonType: "string"},
+	"bit":     &basicColumnType{jsonType: "string"},
+	"varbit":  &basicColumnType{jsonType: "string"},
+
+	"json":     &basicColumnType{},
+	"jsonb":    &basicColumnType{},
+	"jsonpath": &basicColumnType{jsonType: "string"},
+
+	// Domain-Specific Types
+	"date":        &basicColumnType{jsonType: "string", format: "date-time"},
+	"timestamp":   &basicColumnType{jsonType: "string", format: "date-time"},
+	"timestamptz": &basicColumnType{jsonType: "string", format: "date-time"},
+	"time":        &basicColumnType{jsonType: "integer"},
+	"timetz":      &basicColumnType{jsonType: "string", format: "time"},
+	"interval":    &basicColumnType{jsonType: "string"},
+	"money":       &basicColumnType{jsonType: "string"},
+	"point":       &basicColumnType{jsonType: "string"},
+	"line":        &basicColumnType{jsonType: "string"},
+	"lseg":        &basicColumnType{jsonType: "string"},
+	"box":         &basicColumnType{jsonType: "string"},
+	"path":        &basicColumnType{jsonType: "string"},
+	"polygon":     &basicColumnType{jsonType: "string"},
+	"circle":      &basicColumnType{jsonType: "string"},
+	"inet":        &basicColumnType{jsonType: "string"},
+	"cidr":        &basicColumnType{jsonType: "string"},
+	"macaddr":     &basicColumnType{jsonType: "string"},
+	"macaddr8":    &basicColumnType{jsonType: "string"},
+	"tsvector":    &basicColumnType{jsonType: "string"},
+	"tsquery":     &basicColumnType{jsonType: "string"},
+	"uuid":        &basicColumnType{jsonType: "string", format: "uuid"},
 }
 
 var catalogNameSanitizerRe = regexp.MustCompile(`(?i)[^a-z0-9\-_.]`)

--- a/source-redshift-batch/main_test.go
+++ b/source-redshift-batch/main_test.go
@@ -194,6 +194,20 @@ func TestKeyDiscovery(t *testing.T) {
 	snapshotBindings(t, discoverStreams(ctx, t, cs, regexp.MustCompile(uniqueID)))
 }
 
+func TestKeylessDiscovery(t *testing.T) {
+	var ctx, cs = context.Background(), testCaptureSpec(t)
+	var control = testControlClient(ctx, t)
+	var uniqueID = "10352"
+	var tableName = fmt.Sprintf("test.keyless_discovery_%s", uniqueID)
+
+	executeControlQuery(ctx, t, control, fmt.Sprintf("DROP TABLE IF EXISTS %s", tableName))
+	t.Cleanup(func() { executeControlQuery(ctx, t, control, fmt.Sprintf("DROP TABLE IF EXISTS %s", tableName)) })
+	executeControlQuery(ctx, t, control, fmt.Sprintf("CREATE TABLE %s(v_smallint SMALLINT, v_int INTEGER, v_bigint BIGINT, v_bool BOOLEAN, v_str VARCHAR(8), v_ts TIMESTAMP, v_tstz TIMESTAMP WITH TIME ZONE, v_text TEXT)", tableName))
+
+	cs.EndpointSpec.(*Config).Advanced.DiscoverSchemas = []string{"test"}
+	snapshotBindings(t, discoverStreams(ctx, t, cs, regexp.MustCompile(uniqueID)))
+}
+
 func testControlClient(ctx context.Context, t testing.TB) *sql.DB {
 	t.Helper()
 	if os.Getenv("TEST_DATABASE") != "yes" {
@@ -208,7 +222,7 @@ func testControlClient(ctx context.Context, t testing.TB) *sql.DB {
 	if controlPass == "" {
 		controlPass = *dbCapturePass
 	}
-	var controlURI = fmt.Sprintf(`postgres://%s:%s@%s/%s?sslmode=require`, controlUser, controlPass, *dbAddress, *dbName)
+	var controlURI = fmt.Sprintf(`postgres://%s:%s@%s/%s`, controlUser, controlPass, *dbAddress, *dbName)
 	log.WithField("uri", controlURI).Debug("opening database control connection")
 	var conn, err = sql.Open("pgx", controlURI)
 	require.NoError(t, err)


### PR DESCRIPTION
**Description:**

This PR modifies the `source-redshift-batch` connector so that the generated schemas for discovered collections will include all columns with appropriate JSON schema types, rather than just the primary-key columns as it did previously.

In addition `source-redshift-batch` will no longer suggest a fallback collection key of `[/_meta/polled, /_meta/offset]` for tables without a primary key. This means that users will be forced to pick their desired collection key, which is why it was important that we adjust the discovered schema so that they have appropriate options to choose from.

**Workflow steps:**

I haven't given a lot of thought to how the change in discovery output will impact existing uses of the Redshift connector. The omission of a collection key for keyless tables should be benign, but I'm not sure what the removal of the `x-infer-schema` property and the sudden appearance of more properties in the connector's discovered schemas will do. Probably it will all work out correctly, I think?

New users will find that when doing the capture creation flow in the UI any tables lacking primary keys (which, in a data warehouse like Redshift, is most of them) they are prompted to select a collection key using one or more columns of  the source table, and must do so before they can finish creating the capture.

Existing users will find that if they go and manually reversion their collection with a more appropriate key, it no longer gets blown away by the automatic discovery merging behavior.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1397)
<!-- Reviewable:end -->
