### PR TITLE
materialize-sql: close client in Validate

### DIFF
--- a/materialize-databricks/staged_file.go
+++ b/materialize-databricks/staged_file.go
@@ -16,7 +16,7 @@ import (
 )
 
 const fileSizeLimit = 128 * 1024 * 1024
-const uploadConcurrency = 5 // that means we may use up to 1.28GB disk space
+const uploadConcurrency = 3
 
 // fileBuffer provides Close() for a *bufio.Writer writing to an *os.File. Close() will flush the
 // buffer and close the underlying file.

--- a/materialize-sql/driver.go
+++ b/materialize-sql/driver.go
@@ -76,7 +76,10 @@ func (d *Driver) Validate(ctx context.Context, req *pm.Request_Validate) (*pm.Re
 		return nil, fmt.Errorf("building endpoint: %w", err)
 	} else if client, err = endpoint.NewClient(ctx, endpoint); err != nil {
 		return nil, fmt.Errorf("creating client: %w", err)
-	} else if prereqErrs := client.PreReqs(ctx); prereqErrs.Len() != 0 {
+	}
+	defer client.Close()
+
+	if prereqErrs := client.PreReqs(ctx); prereqErrs.Len() != 0 {
 		return nil, cerrors.NewUserError(nil, prereqErrs.Error())
 	} else if loadedSpec, _, err = loadSpec(ctx, client, endpoint, req.Name); err != nil {
 		return nil, fmt.Errorf("loading current applied materialization spec: %w", err)


### PR DESCRIPTION
**Description:**

- We previously applied this change of short-lived database connections elsewhere in the connector, but we got reports that they still see leftover connections _sometimes_. I found that we had this case where we would open a connection in Validate as part of initialising the `client`, but we were not closing it.
- Decreased file upload concurrency until https://github.com/databricks/databricks-sql-go/pull/197 is merged
**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1402)
<!-- Reviewable:end -->
