### PR TITLE
materialize-snowflake: add temporary logging when encoding excessively large documents

### DIFF
--- a/materialize-snowflake/snowflake.go
+++ b/materialize-snowflake/snowflake.go
@@ -288,7 +288,7 @@ func (d *transactor) Load(it *m.LoadIterator, loaded func(int, json.RawMessage) 
 			return err
 		} else if converted, err := b.target.ConvertKey(it.Key); err != nil {
 			return fmt.Errorf("converting Load key: %w", err)
-		} else if err = b.load.stage.encodeRow(converted); err != nil {
+		} else if err = b.load.stage.encodeRow(converted, b.target.Source); err != nil {
 			return fmt.Errorf("encoding Load key to scratch file: %w", err)
 		}
 	}
@@ -422,7 +422,7 @@ func (d *transactor) Store(it *m.StoreIterator) (m.StartCommitFunc, error) {
 			return nil, err
 		} else if converted, err := b.target.ConvertAll(it.Key, it.Values, it.RawJSON); err != nil {
 			return nil, fmt.Errorf("converting Store: %w", err)
-		} else if err = b.store.stage.encodeRow(converted); err != nil {
+		} else if err = b.store.stage.encodeRow(converted, b.target.Source); err != nil {
 			return nil, fmt.Errorf("encoding Store to scratch file: %w", err)
 		}
 	}

--- a/materialize-snowflake/staged_file.go
+++ b/materialize-snowflake/staged_file.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	sql "github.com/estuary/connectors/materialize-sql"
+	pf "github.com/estuary/flow/go/protocols/flow"
 	"github.com/google/uuid"
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/sync/errgroup"
@@ -155,7 +156,7 @@ func (f *stagedFile) start(ctx context.Context, db *stdsql.DB) error {
 	return nil
 }
 
-func (f *stagedFile) encodeRow(row []interface{}) error {
+func (f *stagedFile) encodeRow(row []interface{}, collection pf.Collection) error {
 	// May not have an encoder set yet if the previous encodeRow() resulted in flushing the current
 	// file, or for the very first call to encodeRow().
 	if f.encoder == nil {
@@ -164,8 +165,19 @@ func (f *stagedFile) encodeRow(row []interface{}) error {
 		}
 	}
 
+	initialWritten := f.encoder.Written()
+
 	if err := f.encoder.Encode(row); err != nil {
 		return fmt.Errorf("encoding row: %w", err)
+	}
+
+	// Temporary logging for encoding large documents that exceed Snowflake's 16MB limit.
+	delta := f.encoder.Written() - initialWritten
+	if delta > 16*1024*1024 {
+		log.WithFields(log.Fields{
+			"collection": collection.String(),
+			"docSize":    delta,
+		}).Warn("encoded a large document")
 	}
 
 	// Concurrently start the PUT process for this file if the current file has reached

--- a/tests/materialize/materialize-snowflake/setup.sh
+++ b/tests/materialize/materialize-snowflake/setup.sh
@@ -14,8 +14,10 @@ export SNOWFLAKE_AUTH_TYPE="${SNOWFLAKE_AUTH_TYPE}"
 # if auth type is user_password
 export SNOWFLAKE_USER="${SNOWFLAKE_USER:-}"
 export SNOWFLAKE_PASSWORD="${SNOWFLAKE_PASSWORD:-}"
-# if auth type is jwt
-export SNOWFLAKE_PRIVATE_KEY="$(cat ${SNOWFLAKE_PRIVATE_KEY:-} | jq -sR . | sed -e 's/^"//' -e 's/"$//')"
+if [ -z "${${SNOWFLAKE_PRIVATE_KEY+x}}" ]; then 
+  # if auth type is jwt
+  export SNOWFLAKE_PRIVATE_KEY="$(cat ${SNOWFLAKE_PRIVATE_KEY:-} | jq -sR . | sed -e 's/^"//' -e 's/"$//')"
+fi
 
 config_json_template='{
    "host":      "$SNOWFLAKE_HOST",


### PR DESCRIPTION
**Description:**

This is some janky temporary logging for helping troubleshooting "JSON document too large" errors with on-going snowflake materializations. I intent to remove this after the source collection is identified.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1403)
<!-- Reviewable:end -->
