### PR TITLE
Mahdi/bigquery idempotent apply

### DIFF
--- a/materialize-bigquery/client.go
+++ b/materialize-bigquery/client.go
@@ -3,7 +3,6 @@ package connector
 import (
 	"context"
 	dbSql "database/sql"
-	"encoding/base64"
 	"errors"
 	"fmt"
 	"net/http"
@@ -237,42 +236,7 @@ func (c *client) ExecStatements(ctx context.Context, statements []string) error 
 }
 
 func (c *client) InstallFence(ctx context.Context, _ sql.Table, fence sql.Fence) (sql.Fence, error) {
-	var query strings.Builder
-	if err := tplInstallFence.Execute(&query, fence); err != nil {
-		return fence, fmt.Errorf("evaluating fence template: %w", err)
-	}
-
-	log.Info("installing fence")
-	job, err := c.query(ctx, query.String())
-	if err != nil {
-		return fence, err
-	}
-	var bqFence struct {
-		Fence      int64  `bigquery:"fence"`
-		Checkpoint string `bigquery:"checkpoint"`
-	}
-	log.Info("reading installed fence")
-	if err = c.fetchOne(ctx, job, &bqFence); err != nil {
-		return fence, fmt.Errorf("read fence: %w", err)
-	}
-
-	checkpoint, err := base64.StdEncoding.DecodeString(bqFence.Checkpoint)
-	if err != nil {
-		return fence, fmt.Errorf("base64.Decode(checkpoint): %w", err)
-	}
-
-	fence.Fence = bqFence.Fence
-	fence.Checkpoint = checkpoint
-
-	log.WithFields(log.Fields{
-		"fence":            fence.Fence,
-		"keyBegin":         fence.KeyBegin,
-		"keyEnd":           fence.KeyEnd,
-		"materialization":  fence.Materialization.String(),
-		"checkpointsTable": fence.TablePath,
-	}).Info("fence installed successfully")
-
-	return fence, nil
+	return sql.Fence{}, nil
 }
 
 func (c *client) Close() {

--- a/materialize-bigquery/descriptor_proto.go
+++ b/materialize-bigquery/descriptor_proto.go
@@ -1,0 +1,49 @@
+package connector
+
+import (
+	"fmt"
+
+	sql "github.com/estuary/connectors/materialize-sql"
+	"google.golang.org/protobuf/types/descriptorpb"
+)
+
+func getTableDescriptorProto(table sql.Table) descriptorpb.DescriptorProto {
+	var cols = table.Columns()
+
+	var dp = descriptorpb.DescriptorProto{
+		Name:  &table.Identifier,
+		Field: make([]*descriptorpb.FieldDescriptorProto, len(cols)),
+	}
+
+	for i, col := range cols {
+		var t descriptorpb.FieldDescriptorProto_Type
+		var flatType, _ = col.AsFlatType()
+		switch flatType {
+		case sql.ARRAY:
+			t = descriptorpb.FieldDescriptorProto_TYPE_STRING
+		case sql.BINARY:
+			t = descriptorpb.FieldDescriptorProto_TYPE_BYTES
+		case sql.BOOLEAN:
+			t = descriptorpb.FieldDescriptorProto_TYPE_BOOL
+		case sql.INTEGER:
+			t = descriptorpb.FieldDescriptorProto_TYPE_INT64
+		case sql.MULTIPLE:
+			t = descriptorpb.FieldDescriptorProto_TYPE_STRING
+		case sql.OBJECT:
+			t = descriptorpb.FieldDescriptorProto_TYPE_STRING
+		case sql.STRING:
+			t = descriptorpb.FieldDescriptorProto_TYPE_STRING
+		case sql.NUMBER:
+			t = descriptorpb.FieldDescriptorProto_TYPE_DOUBLE
+		default:
+			panic(fmt.Sprintf("unknown type in getTableDescriptorProto: %v", col))
+		}
+
+		dp.Field[i] = &descriptorpb.FieldDescriptorProto{
+			Name: &col.Field,
+			Type: &t,
+		}
+	}
+
+	return dp
+}

--- a/materialize-bigquery/query.go
+++ b/materialize-bigquery/query.go
@@ -52,7 +52,7 @@ func (c client) runQuery(ctx context.Context, query *bigquery.Query) (*bigquery.
 	for attempt := 0; attempt < maxAttempts; attempt++ {
 		job, err = query.Run(ctx)
 		if err != nil {
-			return nil, fmt.Errorf("run: %w", err)
+			return nil, err
 		}
 
 		// Weirdness ahead: if `err != nil`, then `status` might be nil. But if `err == nil`, then

--- a/materialize-bigquery/transactor.go
+++ b/materialize-bigquery/transactor.go
@@ -13,7 +13,7 @@ import (
 	sql "github.com/estuary/connectors/materialize-sql"
 	pf "github.com/estuary/flow/go/protocols/flow"
 	pm "github.com/estuary/flow/go/protocols/materialize"
-	"github.com/google/UUID"
+	"github.com/google/uuid"
 	log "github.com/sirupsen/logrus"
 	"go.gazette.dev/core/consumer/protocol"
 	"google.golang.org/api/iterator"
@@ -346,6 +346,7 @@ func (t *transactor) Acknowledge(ctx context.Context) (*pf.ConnectorState, error
 		var edcs = make(map[string]bigquery.ExternalData)
 		edcs[item.TempTableName] = item.EDC
 		query.TableDefinitions = edcs
+		query.JobID = item.JobID
 
 		log.WithField("table", item.Table).Info("store: starting query")
 		if _, err := t.client.runQuery(ctx, query); err != nil {

--- a/materialize-bigquery/transactor.go
+++ b/materialize-bigquery/transactor.go
@@ -389,10 +389,6 @@ func (t *transactor) Acknowledge(ctx context.Context) (*pf.ConnectorState, error
 		}).Info("store: finished query")
 	}
 
-	/*if len(t.cp) > 0 {
-		return nil, fmt.Errorf("artificial error")
-	}*/
-
 	// After having applied the checkpoint, we try to clean up the checkpoint in the ack response
 	// so that a restart of the connector does not need to run the same queries again
 	// Note that this is an best-effort "attempt" and there is no guarantee that this checkpoint update
@@ -411,6 +407,8 @@ func (t *transactor) Acknowledge(ctx context.Context) (*pf.ConnectorState, error
 	if err != nil {
 		return nil, fmt.Errorf("creating checkpoint clearing json: %w", err)
 	}
+
+	log.Info("store: finished committing changes")
 
 	return &pf.ConnectorState{UpdatedJson: json.RawMessage(checkpointJSON), MergePatch: true}, nil
 }

--- a/materialize-bigquery/transactor.go
+++ b/materialize-bigquery/transactor.go
@@ -331,7 +331,8 @@ func (t *transactor) Acknowledge(ctx context.Context) (*pf.ConnectorState, error
 		}
 
 		var query = t.client.newQuery(item.Query)
-		var edcs = map[string]bigquery.ExternalDataConfig{item.TempTableName: *item.EDC}
+		var edcs = make(map[string]bigquery.ExternalData)
+		edcs[item.TempTableName] = item.EDC
 		query.TableDefinitions = edcs
 
 		log.WithField("table", item.Table).Info("store: starting query")

--- a/materialize-bigquery/transactor.go
+++ b/materialize-bigquery/transactor.go
@@ -16,6 +16,7 @@ import (
 	"github.com/google/uuid"
 	log "github.com/sirupsen/logrus"
 	"go.gazette.dev/core/consumer/protocol"
+	"google.golang.org/api/googleapi"
 	"google.golang.org/api/iterator"
 )
 
@@ -30,10 +31,13 @@ type transactor struct {
 
 	bindings    []*binding
 	updateDelay time.Duration
+
+	needsRestart bool
 }
 
 type checkpointItem struct {
 	Table         string
+	StateKey      string
 	TempTableName string
 	Query         string
 	JobID         string
@@ -169,6 +173,10 @@ func (t *transactor) AckDelay() time.Duration {
 }
 
 func (t *transactor) Load(it *m.LoadIterator, loaded func(int, json.RawMessage) error) error {
+	if t.needsRestart {
+		return fmt.Errorf("one or more queries failed during commit phase, restarting the connector to retry them")
+	}
+
 	var ctx = it.Context()
 
 	log.Info("load: starting encoding and uploading of files")
@@ -296,6 +304,7 @@ func (t *transactor) Store(it *m.StoreIterator) (m.StartCommitFunc, error) {
 		t.cp[b.target.StateKey] = &checkpointItem{
 			Table:         b.target.Identifier,
 			TempTableName: b.tempTableName,
+			StateKey:      b.target.StateKey,
 			JobID:         jobId,
 			Query:         query,
 			EDC:           b.storeFile.edc(),
@@ -335,6 +344,20 @@ func (d *transactor) hasStateKey(stateKey string) bool {
 func (t *transactor) Acknowledge(ctx context.Context) (*pf.ConnectorState, error) {
 	log.Info("store: starting committing changes")
 
+	// After having applied the checkpoint, we try to clean up the checkpoint in the ack response
+	// so that a restart of the connector does not need to run the same queries again
+	// Note that this is an best-effort "attempt" and there is no guarantee that this checkpoint update
+	// can actually be committed
+	// Important to note that in this case we do not reset the checkpoint for all bindings, but only the ones
+	// that have been committed in this transaction. The reason is that it may be the case that a binding
+	// which has been disabled right after a failed attempt to run its queries, must be able to recover by enabling
+	// the binding and running the queries that are pending for its last transaction.
+	var checkpointUpdate = make(checkpoint)
+	for _, b := range t.bindings {
+		checkpointUpdate[b.target.StateKey] = nil
+		delete(t.cp, b.target.StateKey)
+	}
+
 	for stateKey, item := range t.cp {
 		// we skip queries that belong to tables which do not have a binding anymore
 		// since these tables might be deleted already
@@ -348,33 +371,54 @@ func (t *transactor) Acknowledge(ctx context.Context) (*pf.ConnectorState, error
 		query.TableDefinitions = edcs
 		query.JobID = item.JobID
 
-		log.WithField("table", item.Table).Info("store: starting query")
+		log.WithField("table", item.Table).WithField("JobID", item.JobID).Info("store: starting query")
 		if _, err := t.client.runQuery(ctx, query); err != nil {
+			if e, ok := err.(*googleapi.Error); ok {
+				log.WithField("e.Message", e.Message).WithField("Errors", e.Errors).WithField("Message", e.Message).Info("google api error")
+				// 409 means "Already Exists", meaning the job already exists
+				// in this case we retry the same job
+				if e.Code == 409 {
+					job, err := t.client.bigqueryClient.JobFromID(ctx, item.JobID)
+					if err != nil {
+						return nil, fmt.Errorf("finding job %q failed: %w", item.JobID, err)
+					}
+
+					status, err := job.Wait(ctx)
+					if err != nil {
+						return nil, fmt.Errorf("fetching job %q status: %w", item.JobID, err)
+					}
+					log.WithField("status", status).WithField("JobID", item.JobID).Info("job status")
+
+					// If the job failed, we need to retry by re-running the same query with a different
+					// JobID. However, we can't do that here as we can't then record the JobID to track it
+					// in further runs of Acknowledge. So instead we update the checkpoint here and restart the connector
+					// to pick up the new checkpoint and retry.
+					// See https://issuetracker.google.com/issues/35905399 for a discussion on retrying bq jobs
+					err = status.Err()
+					if err != nil {
+						item.JobID = uuid.NewString()
+						checkpointUpdate[item.StateKey] = item
+						t.needsRestart = true
+					}
+				}
+			}
 			return nil, fmt.Errorf("query %q failed: %w", item.Query, err)
+		} else {
+			for _, f := range item.Files {
+				deleteFile(ctx, t.client.cloudStorageClient, item.Bucket, f)
+			}
 		}
+
 		log.WithField("table", item.Table).Info("store: finished query")
-
-		for _, f := range item.Files {
-			deleteFile(ctx, t.client.cloudStorageClient, item.Bucket, f)
-		}
 	}
 
-	log.Info("store: finished commit")
+	log.WithField("needsRestart", t.needsRestart).Info("store: finished commit")
 
-	// After having applied the checkpoint, we try to clean up the checkpoint in the ack response
-	// so that a restart of the connector does not need to run the same queries again
-	// Note that this is an best-effort "attempt" and there is no guarantee that this checkpoint update
-	// can actually be committed
-	// Important to note that in this case we do not reset the checkpoint for all bindings, but only the ones
-	// that have been committed in this transaction. The reason is that it may be the case that a binding
-	// which has been disabled right after a failed attempt to run its queries, must be able to recover by enabling
-	// the binding and running the queries that are pending for its last transaction.
-	var checkpointClear = make(checkpoint)
-	for _, b := range t.bindings {
-		checkpointClear[b.target.StateKey] = nil
-		delete(t.cp, b.target.StateKey)
+	if len(t.cp) > 0 && !t.needsRestart {
+		return nil, fmt.Errorf("artificial error")
 	}
-	var checkpointJSON, err = json.Marshal(checkpointClear)
+
+	var checkpointJSON, err = json.Marshal(checkpointUpdate)
 	if err != nil {
 		return nil, fmt.Errorf("creating checkpoint clearing json: %w", err)
 	}

--- a/materialize-snowflake/snowflake.go
+++ b/materialize-snowflake/snowflake.go
@@ -145,8 +145,7 @@ type transactor struct {
 	}
 	// Variables exclusively used by Store.
 	store struct {
-		conn  *stdsql.Conn
-		fence *sql.Fence
+		conn *stdsql.Conn
 	}
 	templates   templates
 	bindings    []*binding
@@ -180,7 +179,7 @@ func (d *transactor) UnmarshalState(state json.RawMessage) error {
 func newTransactor(
 	ctx context.Context,
 	ep *sql.Endpoint,
-	fence sql.Fence,
+	_ sql.Fence,
 	bindings []sql.Table,
 	open pm.Request_Open,
 ) (_ m.Transactor, err error) {
@@ -217,8 +216,6 @@ func newTransactor(
 	if d.updateDelay, err = m.ParseDelay(cfg.Advanced.UpdateDelay); err != nil {
 		return nil, err
 	}
-
-	d.store.fence = &fence
 
 	// Establish connections.
 	if db, err := stdsql.Open("snowflake", cfg.ToURI(ep.Tenant, true)); err != nil {

--- a/tests/materialize/materialize-bigquery/checks.sh
+++ b/tests/materialize/materialize-bigquery/checks.sh
@@ -1,0 +1,4 @@
+# cleanup the snapshot by replacing uuids with a placeholder so that the test is reproducible
+sed -i '' 's/"JobID": ".*"/"Path": "<uuid>"/g' ${SNAPSHOT}
+sed -i '' 's/"gs:\/\/.*"/"<path>"/g' ${SNAPSHOT}
+sed -i '' 's/".\{36\}\/.\{36\}"/"<path>"/g' ${SNAPSHOT}

--- a/tests/materialize/materialize-bigquery/cleanup.sh
+++ b/tests/materialize/materialize-bigquery/cleanup.sh
@@ -8,7 +8,9 @@ function dropTable() {
 
 # Remove materialized tables.
 dropTable "simple"
-dropTable "duplicate_keys"
+dropTable "duplicate_keys_standard"
+dropTable "duplicate_keys_delta"
+dropTable "duplicate_keys_delta_exclude_flow_doc"
 dropTable "multiple_types"
 dropTable "formatted_strings"
 

--- a/tests/materialize/materialize-bigquery/fetch.sh
+++ b/tests/materialize/materialize-bigquery/fetch.sh
@@ -9,6 +9,8 @@ function exportToJsonl() {
 }
 
 exportToJsonl "simple"
-exportToJsonl "duplicate_keys"
+exportToJsonl "duplicate_keys_standard"
+exportToJsonl "duplicate_keys_delta"
+exportToJsonl "duplicate_keys_delta_exclude_flow_doc"
 exportToJsonl "multiple_types"
 exportToJsonl "formatted_strings"

--- a/tests/materialize/materialize-bigquery/setup.sh
+++ b/tests/materialize/materialize-bigquery/setup.sh
@@ -30,9 +30,29 @@ resources_json_template='[
   },
   {
     "resource": {
-      "table": "duplicate_keys"
+      "table": "duplicate_keys_standard"
     },
     "source": "${TEST_COLLECTION_DUPLICATED_KEYS}"
+  },
+  {
+    "resource": {
+      "table": "duplicate_keys_delta",
+      "delta_updates": true
+    },
+    "source": "${TEST_COLLECTION_DUPLICATED_KEYS}"
+  },
+  {
+    "resource": {
+      "table": "duplicate_keys_delta_exclude_flow_doc",
+      "delta_updates": true
+    },
+    "source": "${TEST_COLLECTION_DUPLICATED_KEYS}",
+    "fields": {
+      "recommended": true,
+      "exclude": [
+        "flow_document" 
+      ]
+    }
   },
   {
     "resource": {

--- a/tests/materialize/materialize-bigquery/snapshot.json
+++ b/tests/materialize/materialize-bigquery/snapshot.json
@@ -1,6 +1,6 @@
 {
   "applied": {
-    "actionDescription": "UPDATE `estuary-theatre`.testing.flow_materializations_v2 SET version = 'test', spec = '(a-base64-encoded-value)' WHERE materialization = 'tests/materialize-bigquery/materialize';"
+    "actionDescription": "CREATE TABLE IF NOT EXISTS `estuary-theatre`.testing.simple (\n\t\tid INT64 NOT NULL,\n\t\tcanary STRING NOT NULL,\n\t\tflow_published_at TIMESTAMP NOT NULL,\n\t\tflow_document STRING NOT NULL\n)\nCLUSTER BY id;\n\nCREATE TABLE IF NOT EXISTS `estuary-theatre`.testing.duplicate_keys_standard (\n\t\tid INT64 NOT NULL,\n\t\tflow_published_at TIMESTAMP NOT NULL,\n\t\tint INT64,\n\t\tstr STRING NOT NULL,\n\t\tflow_document STRING NOT NULL\n)\nCLUSTER BY id;\n\nCREATE TABLE IF NOT EXISTS `estuary-theatre`.testing.duplicate_keys_delta (\n\t\tid INT64 NOT NULL,\n\t\tflow_published_at TIMESTAMP NOT NULL,\n\t\tint INT64,\n\t\tstr STRING NOT NULL,\n\t\tflow_document STRING NOT NULL\n)\nCLUSTER BY id;\n\nCREATE TABLE IF NOT EXISTS `estuary-theatre`.testing.duplicate_keys_delta_exclude_flow_doc (\n\t\tid INT64 NOT NULL,\n\t\tflow_published_at TIMESTAMP NOT NULL,\n\t\tint INT64,\n\t\tstr STRING NOT NULL\n)\nCLUSTER BY id;\n\nCREATE TABLE IF NOT EXISTS `estuary-theatre`.testing.multiple_types (\n\t\tid INT64 NOT NULL,\n\t\tarray_int STRING,\n\t\tbool_field BOOL,\n\t\tfloat_field FLOAT64,\n\t\tflow_published_at TIMESTAMP NOT NULL,\n\t\tmultiple JSON,\n\t\tnested STRING,\n\t\tnullable_int INT64,\n\t\tstr_field STRING NOT NULL,\n\t\tflow_document STRING NOT NULL\n)\nCLUSTER BY id;\n\nCREATE TABLE IF NOT EXISTS `estuary-theatre`.testing.formatted_strings (\n\t\tid INT64 NOT NULL,\n\t\tdate DATE,\n\t\tdatetime TIMESTAMP,\n\t\tflow_published_at TIMESTAMP NOT NULL,\n\t\tint_and_str BIGNUMERIC(38,0),\n\t\tint_str BIGNUMERIC(38,0),\n\t\tnum_and_str FLOAT64,\n\t\tnum_str FLOAT64,\n\t\ttime STRING,\n\t\tflow_document STRING NOT NULL\n)\nCLUSTER BY id;\n\nINSERT INTO `estuary-theatre`.testing.flow_materializations_v2 (version, spec, materialization) VALUES ('test', '(a-base64-encoded-value)', 'tests/materialize-bigquery/materialize');"
   }
 }
 {
@@ -18,407 +18,6 @@
         "estuary-theatre%2Ftesting%2Fmultiple_types": null,
         "estuary-theatre%2Ftesting%2Fsimple": null
       }
-    }
-  }
-}
-{
-  "loaded": {
-    "binding": 1,
-    "doc": {
-      "_meta": {
-        "uuid": "8de85150-20e1-11ee-990b-ffd12dfcd47f"
-      },
-      "id": 1,
-      "int": 6,
-      "str": "str 6"
-    }
-  }
-}
-{
-  "loaded": {
-    "binding": 1,
-    "doc": {
-      "_meta": {
-        "uuid": "957348bc-20e1-11ee-990b-ffd12dfcd47f"
-      },
-      "id": 2,
-      "int": 7,
-      "str": "str 7"
-    }
-  }
-}
-{
-  "loaded": {
-    "binding": 1,
-    "doc": {
-      "_meta": {
-        "uuid": "9afb3ff6-20e1-11ee-990b-ffd12dfcd47f"
-      },
-      "id": 3,
-      "int": 8,
-      "str": "str 8"
-    }
-  }
-}
-{
-  "loaded": {
-    "binding": 1,
-    "doc": {
-      "_meta": {
-        "uuid": "a1100a70-20e1-11ee-990b-ffd12dfcd47f"
-      },
-      "id": 4,
-      "int": 9,
-      "str": "str 9"
-    }
-  }
-}
-{
-  "loaded": {
-    "binding": 1,
-    "doc": {
-      "_meta": {
-        "uuid": "a65203a8-20e1-11ee-990b-ffd12dfcd47f"
-      },
-      "id": 5,
-      "int": 10,
-      "str": "str 10"
-    }
-  }
-}
-{
-  "loaded": {
-    "binding": 4,
-    "doc": {
-      "_meta": {
-        "uuid": "3fd2ec78-20e1-11ee-990b-ffd12dfcd47f"
-      },
-      "array_int": [
-        11,
-        12
-      ],
-      "bool_field": false,
-      "float_field": 1.1,
-      "id": 1,
-      "multiple": 1,
-      "nested": {
-        "id": "i1"
-      },
-      "nullable_int": null,
-      "str_field": "str1"
-    }
-  }
-}
-{
-  "loaded": {
-    "binding": 4,
-    "doc": {
-      "_meta": {
-        "uuid": "4b37f0b8-20e1-11ee-990b-ffd12dfcd47f"
-      },
-      "array_int": [
-        21,
-        22
-      ],
-      "bool_field": true,
-      "float_field": 2.2,
-      "id": 2,
-      "multiple": 2.2,
-      "nested": {
-        "id": "i2"
-      },
-      "nullable_int": 2,
-      "str_field": "str2"
-    }
-  }
-}
-{
-  "loaded": {
-    "binding": 4,
-    "doc": {
-      "_meta": {
-        "uuid": "51016380-20e1-11ee-990b-ffd12dfcd47f"
-      },
-      "array_int": [
-        31,
-        32
-      ],
-      "bool_field": false,
-      "float_field": 3.3,
-      "id": 3,
-      "multiple": true,
-      "nested": {
-        "id": "i3"
-      },
-      "nullable_int": null,
-      "str_field": "str3"
-    }
-  }
-}
-{
-  "loaded": {
-    "binding": 4,
-    "doc": {
-      "_meta": {
-        "uuid": "5660aaca-20e1-11ee-990b-ffd12dfcd47f"
-      },
-      "array_int": [
-        41,
-        42
-      ],
-      "bool_field": true,
-      "float_field": 4.4,
-      "id": 4,
-      "multiple": false,
-      "nested": {
-        "id": "i4"
-      },
-      "nullable_int": 4,
-      "str_field": "str4"
-    }
-  }
-}
-{
-  "loaded": {
-    "binding": 4,
-    "doc": {
-      "_meta": {
-        "uuid": "5af9e236-20e1-11ee-990b-ffd12dfcd47f"
-      },
-      "array_int": [
-        51,
-        52
-      ],
-      "bool_field": false,
-      "float_field": 5.5,
-      "id": 5,
-      "multiple": "string five",
-      "nested": {
-        "id": "i5"
-      },
-      "nullable_int": null,
-      "str_field": "str5"
-    }
-  }
-}
-{
-  "loaded": {
-    "binding": 4,
-    "doc": {
-      "_meta": {
-        "uuid": "e4b646c2-20e1-11ee-990b-ffd12dfcd47f"
-      },
-      "array_int": [
-        61,
-        62
-      ],
-      "bool_field": true,
-      "float_field": 66.66,
-      "id": 6,
-      "multiple": [
-        "one",
-        2,
-        true
-      ],
-      "nested": {
-        "id": "i6"
-      },
-      "nullable_int": 6,
-      "str_field": "str6 v2"
-    }
-  }
-}
-{
-  "loaded": {
-    "binding": 4,
-    "doc": {
-      "_meta": {
-        "uuid": "eb40dafc-20e1-11ee-990b-ffd12dfcd47f"
-      },
-      "array_int": [
-        71,
-        72
-      ],
-      "bool_field": false,
-      "float_field": 77.77,
-      "id": 7,
-      "multiple": {
-        "object": "seven"
-      },
-      "nested": {
-        "id": "i7"
-      },
-      "nullable_int": null,
-      "str_field": "str7 v2"
-    }
-  }
-}
-{
-  "loaded": {
-    "binding": 4,
-    "doc": {
-      "_meta": {
-        "uuid": "f163eef6-20e1-11ee-990b-ffd12dfcd47f"
-      },
-      "array_int": [
-        81,
-        82
-      ],
-      "bool_field": true,
-      "float_field": 88.88,
-      "id": 8,
-      "multiple": null,
-      "nested": {
-        "id": "i8"
-      },
-      "nullable_int": 8,
-      "str_field": "str8 v2"
-    }
-  }
-}
-{
-  "loaded": {
-    "binding": 4,
-    "doc": {
-      "_meta": {
-        "uuid": "f5b064a8-20e1-11ee-990b-ffd12dfcd47f"
-      },
-      "array_int": [
-        91,
-        92
-      ],
-      "bool_field": false,
-      "float_field": 99.99,
-      "id": 9,
-      "nested": {
-        "id": "i9"
-      },
-      "nullable_int": null,
-      "str_field": "str9 v2"
-    }
-  }
-}
-{
-  "loaded": {
-    "binding": 4,
-    "doc": {
-      "_meta": {
-        "uuid": "fb0cc8b0-20e1-11ee-990b-ffd12dfcd47f"
-      },
-      "array_int": [
-        1,
-        2
-      ],
-      "bool_field": true,
-      "float_field": 1010.101,
-      "id": 10,
-      "nested": {
-        "id": "i10"
-      },
-      "nullable_int": 10,
-      "str_field": "str10 v2"
-    }
-  }
-}
-{
-  "loaded": {
-    "binding": 5,
-    "doc": {
-      "_meta": {
-        "uuid": "75c06bd6-20e0-11ee-990b-ffd12dfcd47f"
-      },
-      "date": "1000-03-03",
-      "datetime": "1000-03-03T23:59:38.10Z",
-      "id": 3,
-      "int_and_str": 3,
-      "int_str": "30",
-      "num_and_str": 3.1,
-      "num_str": "30.1",
-      "time": "23:59:38.10Z"
-    }
-  }
-}
-{
-  "loaded": {
-    "binding": 5,
-    "doc": {
-      "_meta": {
-        "uuid": "8bbf898a-20e0-11ee-990b-ffd12dfcd47f"
-      },
-      "date": "2023-08-29",
-      "datetime": "2023-08-29T23:59:38Z",
-      "id": 4,
-      "int_and_str": "4",
-      "int_str": "40",
-      "num_and_str": "4.1",
-      "num_str": "40.1",
-      "time": "23:59:38Z"
-    }
-  }
-}
-{
-  "loaded": {
-    "doc": {
-      "_meta": {
-        "uuid": "75c06bd6-20e0-11ee-990b-ffd12dfcd47f"
-      },
-      "canary": "amputation's",
-      "id": 1
-    }
-  }
-}
-{
-  "loaded": {
-    "doc": {
-      "_meta": {
-        "uuid": "7dbe8ebc-20e0-11ee-990b-ffd12dfcd47f"
-      },
-      "canary": "armament's",
-      "id": 2
-    }
-  }
-}
-{
-  "loaded": {
-    "doc": {
-      "_meta": {
-        "uuid": "8bbf898a-20e0-11ee-990b-ffd12dfcd47f"
-      },
-      "canary": "splatters",
-      "id": 3
-    }
-  }
-}
-{
-  "loaded": {
-    "doc": {
-      "_meta": {
-        "uuid": "9b994ae4-20e0-11ee-990b-ffd12dfcd47f"
-      },
-      "canary": "strengthen",
-      "id": 4
-    }
-  }
-}
-{
-  "loaded": {
-    "doc": {
-      "_meta": {
-        "uuid": "b4b60968-20e0-11ee-990b-ffd12dfcd47f"
-      },
-      "canary": "Kringle's",
-      "id": 5
-    }
-  }
-}
-{
-  "loaded": {
-    "doc": {
-      "_meta": {
-        "uuid": "bcef4bc6-20e0-11ee-990b-ffd12dfcd47f"
-      },
-      "canary": "grosbeak's",
-      "id": 6
     }
   }
 }
@@ -516,13 +115,13 @@
             ],
             "SourceFormat": "NEWLINE_DELIMITED_JSON",
             "SourceURIs": [
-              "gs://estuary-bigquery-test/5d4e4b04-3e9f-46f3-b22a-a494d4e99462/4903b7e9-2a8d-4963-a362-2bd56897a425"
+              "<path>"
             ]
           },
           "Files": [
-            "5d4e4b04-3e9f-46f3-b22a-a494d4e99462/4903b7e9-2a8d-4963-a362-2bd56897a425"
+            "<path>"
           ],
-          "JobID": "2d64c378-6e48-439a-9ba6-630501fba47f",
+          "Path": "<uuid>",
           "Query": "INSERT INTO `estuary-theatre`.testing.duplicate_keys_delta (id, flow_published_at, int, str, flow_document)\nSELECT c0, c1, c2, c3, c4 FROM flow_temp_table_2;\n",
           "Table": "`estuary-theatre`.testing.duplicate_keys_delta",
           "TempTableName": "flow_temp_table_2"
@@ -599,13 +198,13 @@
             ],
             "SourceFormat": "NEWLINE_DELIMITED_JSON",
             "SourceURIs": [
-              "gs://estuary-bigquery-test/1987f468-d4d8-4592-a77e-ad6dec8909a7/f22ea73b-c6f5-4932-a225-6588cb681207"
+              "<path>"
             ]
           },
           "Files": [
-            "1987f468-d4d8-4592-a77e-ad6dec8909a7/f22ea73b-c6f5-4932-a225-6588cb681207"
+            "<path>"
           ],
-          "JobID": "e34bc439-b085-4ede-86ae-9e116bb906fa",
+          "Path": "<uuid>",
           "Query": "INSERT INTO `estuary-theatre`.testing.duplicate_keys_delta_exclude_flow_doc (id, flow_published_at, int, str)\nSELECT c0, c1, c2, c3 FROM flow_temp_table_3;\n",
           "Table": "`estuary-theatre`.testing.duplicate_keys_delta_exclude_flow_doc",
           "TempTableName": "flow_temp_table_3"
@@ -696,13 +295,13 @@
             ],
             "SourceFormat": "NEWLINE_DELIMITED_JSON",
             "SourceURIs": [
-              "gs://estuary-bigquery-test/377b7c04-9262-4b04-821b-057b9993b0af/fda71677-7c6a-4a5c-8acf-de734637f02b"
+              "<path>"
             ]
           },
           "Files": [
-            "377b7c04-9262-4b04-821b-057b9993b0af/fda71677-7c6a-4a5c-8acf-de734637f02b"
+            "<path>"
           ],
-          "JobID": "57eecc7a-bb91-47f8-a43f-a338c24e0aaa",
+          "Path": "<uuid>",
           "Query": "MERGE INTO `estuary-theatre`.testing.duplicate_keys_standard AS l\nUSING flow_temp_table_1 AS r\nON l.id = r.c0\nWHEN MATCHED AND r.c4 IS NULL THEN\n\tDELETE\nWHEN MATCHED THEN\n\tUPDATE SET l.flow_published_at = r.c1, l.int = r.c2, l.str = r.c3, l.flow_document = r.c4\nWHEN NOT MATCHED THEN\n\tINSERT (id, flow_published_at, int, str, flow_document)\n\tVALUES (r.c0, r.c1, r.c2, r.c3, r.c4);\n",
           "Table": "`estuary-theatre`.testing.duplicate_keys_standard",
           "TempTableName": "flow_temp_table_1"
@@ -863,13 +462,13 @@
             ],
             "SourceFormat": "NEWLINE_DELIMITED_JSON",
             "SourceURIs": [
-              "gs://estuary-bigquery-test/bab7a39e-b2a9-4653-a24f-88b3e29916f6/2b6e3904-e0cd-4cea-9e78-e4682fbebbee"
+              "<path>"
             ]
           },
           "Files": [
-            "bab7a39e-b2a9-4653-a24f-88b3e29916f6/2b6e3904-e0cd-4cea-9e78-e4682fbebbee"
+            "<path>"
           ],
-          "JobID": "2b56b2e3-6bbc-4a02-829e-65479c661349",
+          "Path": "<uuid>",
           "Query": "MERGE INTO `estuary-theatre`.testing.formatted_strings AS l\nUSING flow_temp_table_5 AS r\nON l.id = r.c0\nWHEN MATCHED AND r.c9 IS NULL THEN\n\tDELETE\nWHEN MATCHED THEN\n\tUPDATE SET l.date = r.c1, l.datetime = r.c2, l.flow_published_at = r.c3, l.int_and_str = r.c4, l.int_str = r.c5, l.num_and_str = r.c6, l.num_str = r.c7, l.time = r.c8, l.flow_document = r.c9\nWHEN NOT MATCHED THEN\n\tINSERT (id, date, datetime, flow_published_at, int_and_str, int_str, num_and_str, num_str, time, flow_document)\n\tVALUES (r.c0, r.c1, r.c2, r.c3, r.c4, r.c5, r.c6, r.c7, r.c8, r.c9);\n",
           "Table": "`estuary-theatre`.testing.formatted_strings",
           "TempTableName": "flow_temp_table_5"
@@ -1030,13 +629,13 @@
             ],
             "SourceFormat": "NEWLINE_DELIMITED_JSON",
             "SourceURIs": [
-              "gs://estuary-bigquery-test/e7f5808c-fee5-44b7-9e95-b430b5927660/2a0a48c1-6f13-464a-b119-6509b6bf6860"
+              "<path>"
             ]
           },
           "Files": [
-            "e7f5808c-fee5-44b7-9e95-b430b5927660/2a0a48c1-6f13-464a-b119-6509b6bf6860"
+            "<path>"
           ],
-          "JobID": "9c86fd98-87c7-4111-bd49-e8fc3ccb8a23",
+          "Path": "<uuid>",
           "Query": "MERGE INTO `estuary-theatre`.testing.multiple_types AS l\nUSING flow_temp_table_4 AS r\nON l.id = r.c0\nWHEN MATCHED AND r.c9 IS NULL THEN\n\tDELETE\nWHEN MATCHED THEN\n\tUPDATE SET l.array_int = r.c1, l.bool_field = r.c2, l.float_field = r.c3, l.flow_published_at = r.c4, l.multiple = r.c5, l.nested = r.c6, l.nullable_int = r.c7, l.str_field = r.c8, l.flow_document = r.c9\nWHEN NOT MATCHED THEN\n\tINSERT (id, array_int, bool_field, float_field, flow_published_at, multiple, nested, nullable_int, str_field, flow_document)\n\tVALUES (r.c0, r.c1, r.c2, r.c3, r.c4, r.c5, r.c6, r.c7, r.c8, r.c9);\n",
           "Table": "`estuary-theatre`.testing.multiple_types",
           "TempTableName": "flow_temp_table_4"
@@ -1113,13 +712,13 @@
             ],
             "SourceFormat": "NEWLINE_DELIMITED_JSON",
             "SourceURIs": [
-              "gs://estuary-bigquery-test/39b90a17-f254-4a11-b4b4-4794b83a1914/eb538bfb-2292-4165-94f7-b87969824e77"
+              "<path>"
             ]
           },
           "Files": [
-            "39b90a17-f254-4a11-b4b4-4794b83a1914/eb538bfb-2292-4165-94f7-b87969824e77"
+            "<path>"
           ],
-          "JobID": "692b114e-9b94-4bf9-aede-c9f5e1866ec0",
+          "Path": "<uuid>",
           "Query": "MERGE INTO `estuary-theatre`.testing.simple AS l\nUSING flow_temp_table_0 AS r\nON l.id = r.c0\nWHEN MATCHED AND r.c3 IS NULL THEN\n\tDELETE\nWHEN MATCHED THEN\n\tUPDATE SET l.canary = r.c1, l.flow_published_at = r.c2, l.flow_document = r.c3\nWHEN NOT MATCHED THEN\n\tINSERT (id, canary, flow_published_at, flow_document)\n\tVALUES (r.c0, r.c1, r.c2, r.c3);\n",
           "Table": "`estuary-theatre`.testing.simple",
           "TempTableName": "flow_temp_table_0"
@@ -1328,140 +927,6 @@
   }
 }
 {
-  "loaded": {
-    "binding": 5,
-    "doc": {
-      "_meta": {
-        "uuid": "b1e13a0e-20e1-11ee-990b-ffd12dfcd47f"
-      },
-      "date": "0000-01-01",
-      "datetime": "0000-01-01T00:00:00Z",
-      "id": 1,
-      "int_and_str": 1,
-      "int_str": "10",
-      "num_and_str": 1.1,
-      "num_str": "10.1",
-      "time": "00:00:00Z"
-    }
-  }
-}
-{
-  "loaded": {
-    "binding": 5,
-    "doc": {
-      "_meta": {
-        "uuid": "b81a9bf4-20e1-11ee-990b-ffd12dfcd47f"
-      },
-      "date": "1999-02-02",
-      "datetime": "1999-02-02T14:20:12.33Z",
-      "id": 2,
-      "int_and_str": 2,
-      "int_str": "20",
-      "num_and_str": 2.1,
-      "num_str": "20.1",
-      "time": "14:20:12.33Z"
-    }
-  }
-}
-{
-  "loaded": {
-    "binding": 5,
-    "doc": {
-      "_meta": {
-        "uuid": "c02bd79a-20e1-11ee-990b-ffd12dfcd47f"
-      },
-      "date": "9999-12-31",
-      "datetime": "9999-12-31T23:59:59Z",
-      "id": 5,
-      "int_and_str": "5",
-      "int_str": "50",
-      "num_and_str": "5.1",
-      "num_str": "50.1",
-      "time": "23:59:59Z"
-    }
-  }
-}
-{
-  "loaded": {
-    "binding": 5,
-    "doc": {
-      "_meta": {
-        "uuid": "c02bd79a-20e1-11ee-990b-ffd12dfcd47f"
-      },
-      "id": 10,
-      "num_str": "-Infinity"
-    }
-  }
-}
-{
-  "loaded": {
-    "binding": 5,
-    "doc": {
-      "_meta": {
-        "uuid": "c02bd79a-20e1-11ee-990b-ffd12dfcd47f"
-      },
-      "id": 8,
-      "num_str": "NaN"
-    }
-  }
-}
-{
-  "loaded": {
-    "binding": 5,
-    "doc": {
-      "_meta": {
-        "uuid": "c02bd79a-20e1-11ee-990b-ffd12dfcd47f"
-      },
-      "id": 9,
-      "num_str": "Infinity"
-    }
-  }
-}
-{
-  "loaded": {
-    "doc": {
-      "_meta": {
-        "uuid": "134a1456-20e1-11ee-990b-ffd12dfcd47f"
-      },
-      "canary": "pieced",
-      "id": 7
-    }
-  }
-}
-{
-  "loaded": {
-    "doc": {
-      "_meta": {
-        "uuid": "1b953992-20e1-11ee-990b-ffd12dfcd47f"
-      },
-      "canary": "roaches",
-      "id": 8
-    }
-  }
-}
-{
-  "loaded": {
-    "doc": {
-      "_meta": {
-        "uuid": "7e2df422-20e1-11ee-990b-ffd12dfcd47f"
-      },
-      "canary": "devilish",
-      "id": 9
-    }
-  }
-}
-{
-  "loaded": {
-    "doc": {
-      "_meta": {
-        "uuid": "8458b580-20e1-11ee-990b-ffd12dfcd47f"
-      },
-      "canary": "glucose's",
-      "id": 10
-    }
-  }
-}
-{
   "flushed": {}
 }
 {
@@ -1555,13 +1020,13 @@
             ],
             "SourceFormat": "NEWLINE_DELIMITED_JSON",
             "SourceURIs": [
-              "gs://estuary-bigquery-test/5d4e4b04-3e9f-46f3-b22a-a494d4e99462/3358e6fa-f1f1-471f-95c4-9ea24a2f7d5d"
+              "<path>"
             ]
           },
           "Files": [
-            "5d4e4b04-3e9f-46f3-b22a-a494d4e99462/3358e6fa-f1f1-471f-95c4-9ea24a2f7d5d"
+            "<path>"
           ],
-          "JobID": "c190e225-c572-4008-8c5f-bb00beb9ed58",
+          "Path": "<uuid>",
           "Query": "INSERT INTO `estuary-theatre`.testing.duplicate_keys_delta (id, flow_published_at, int, str, flow_document)\nSELECT c0, c1, c2, c3, c4 FROM flow_temp_table_2;\n",
           "Table": "`estuary-theatre`.testing.duplicate_keys_delta",
           "TempTableName": "flow_temp_table_2"
@@ -1638,13 +1103,13 @@
             ],
             "SourceFormat": "NEWLINE_DELIMITED_JSON",
             "SourceURIs": [
-              "gs://estuary-bigquery-test/1987f468-d4d8-4592-a77e-ad6dec8909a7/faec2c9d-caef-41b2-b194-887313c23a8d"
+              "<path>"
             ]
           },
           "Files": [
-            "1987f468-d4d8-4592-a77e-ad6dec8909a7/faec2c9d-caef-41b2-b194-887313c23a8d"
+            "<path>"
           ],
-          "JobID": "e9ec9da7-ca56-4801-97e9-ecf1104b253f",
+          "Path": "<uuid>",
           "Query": "INSERT INTO `estuary-theatre`.testing.duplicate_keys_delta_exclude_flow_doc (id, flow_published_at, int, str)\nSELECT c0, c1, c2, c3 FROM flow_temp_table_3;\n",
           "Table": "`estuary-theatre`.testing.duplicate_keys_delta_exclude_flow_doc",
           "TempTableName": "flow_temp_table_3"
@@ -1735,13 +1200,13 @@
             ],
             "SourceFormat": "NEWLINE_DELIMITED_JSON",
             "SourceURIs": [
-              "gs://estuary-bigquery-test/377b7c04-9262-4b04-821b-057b9993b0af/4b056874-ef16-49d3-8344-58a9a0e4d789"
+              "<path>"
             ]
           },
           "Files": [
-            "377b7c04-9262-4b04-821b-057b9993b0af/4b056874-ef16-49d3-8344-58a9a0e4d789"
+            "<path>"
           ],
-          "JobID": "15a4ecdb-a079-4cc2-bd58-e9b18a083b01",
+          "Path": "<uuid>",
           "Query": "MERGE INTO `estuary-theatre`.testing.duplicate_keys_standard AS l\nUSING flow_temp_table_1 AS r\nON l.id = r.c0\nWHEN MATCHED AND r.c4 IS NULL THEN\n\tDELETE\nWHEN MATCHED THEN\n\tUPDATE SET l.flow_published_at = r.c1, l.int = r.c2, l.str = r.c3, l.flow_document = r.c4\nWHEN NOT MATCHED THEN\n\tINSERT (id, flow_published_at, int, str, flow_document)\n\tVALUES (r.c0, r.c1, r.c2, r.c3, r.c4);\n",
           "Table": "`estuary-theatre`.testing.duplicate_keys_standard",
           "TempTableName": "flow_temp_table_1"
@@ -1902,13 +1367,13 @@
             ],
             "SourceFormat": "NEWLINE_DELIMITED_JSON",
             "SourceURIs": [
-              "gs://estuary-bigquery-test/bab7a39e-b2a9-4653-a24f-88b3e29916f6/e048c71e-5557-4da2-b23b-c5c1e4506dc0"
+              "<path>"
             ]
           },
           "Files": [
-            "bab7a39e-b2a9-4653-a24f-88b3e29916f6/e048c71e-5557-4da2-b23b-c5c1e4506dc0"
+            "<path>"
           ],
-          "JobID": "6ad475b3-9994-4216-b892-dadf34ea0aa4",
+          "Path": "<uuid>",
           "Query": "MERGE INTO `estuary-theatre`.testing.formatted_strings AS l\nUSING flow_temp_table_5 AS r\nON l.id = r.c0\nWHEN MATCHED AND r.c9 IS NULL THEN\n\tDELETE\nWHEN MATCHED THEN\n\tUPDATE SET l.date = r.c1, l.datetime = r.c2, l.flow_published_at = r.c3, l.int_and_str = r.c4, l.int_str = r.c5, l.num_and_str = r.c6, l.num_str = r.c7, l.time = r.c8, l.flow_document = r.c9\nWHEN NOT MATCHED THEN\n\tINSERT (id, date, datetime, flow_published_at, int_and_str, int_str, num_and_str, num_str, time, flow_document)\n\tVALUES (r.c0, r.c1, r.c2, r.c3, r.c4, r.c5, r.c6, r.c7, r.c8, r.c9);\n",
           "Table": "`estuary-theatre`.testing.formatted_strings",
           "TempTableName": "flow_temp_table_5"
@@ -2069,13 +1534,13 @@
             ],
             "SourceFormat": "NEWLINE_DELIMITED_JSON",
             "SourceURIs": [
-              "gs://estuary-bigquery-test/e7f5808c-fee5-44b7-9e95-b430b5927660/5af3a503-cfbf-49cc-b986-132dcff9989f"
+              "<path>"
             ]
           },
           "Files": [
-            "e7f5808c-fee5-44b7-9e95-b430b5927660/5af3a503-cfbf-49cc-b986-132dcff9989f"
+            "<path>"
           ],
-          "JobID": "fce92299-2321-4781-9482-5626f6309c56",
+          "Path": "<uuid>",
           "Query": "MERGE INTO `estuary-theatre`.testing.multiple_types AS l\nUSING flow_temp_table_4 AS r\nON l.id = r.c0\nWHEN MATCHED AND r.c9 IS NULL THEN\n\tDELETE\nWHEN MATCHED THEN\n\tUPDATE SET l.array_int = r.c1, l.bool_field = r.c2, l.float_field = r.c3, l.flow_published_at = r.c4, l.multiple = r.c5, l.nested = r.c6, l.nullable_int = r.c7, l.str_field = r.c8, l.flow_document = r.c9\nWHEN NOT MATCHED THEN\n\tINSERT (id, array_int, bool_field, float_field, flow_published_at, multiple, nested, nullable_int, str_field, flow_document)\n\tVALUES (r.c0, r.c1, r.c2, r.c3, r.c4, r.c5, r.c6, r.c7, r.c8, r.c9);\n",
           "Table": "`estuary-theatre`.testing.multiple_types",
           "TempTableName": "flow_temp_table_4"
@@ -2152,13 +1617,13 @@
             ],
             "SourceFormat": "NEWLINE_DELIMITED_JSON",
             "SourceURIs": [
-              "gs://estuary-bigquery-test/39b90a17-f254-4a11-b4b4-4794b83a1914/7a609f18-e815-49c1-9ece-4374cc6c15e2"
+              "<path>"
             ]
           },
           "Files": [
-            "39b90a17-f254-4a11-b4b4-4794b83a1914/7a609f18-e815-49c1-9ece-4374cc6c15e2"
+            "<path>"
           ],
-          "JobID": "e3a694b0-d0b1-4dcf-a1c4-c48394e9be88",
+          "Path": "<uuid>",
           "Query": "MERGE INTO `estuary-theatre`.testing.simple AS l\nUSING flow_temp_table_0 AS r\nON l.id = r.c0\nWHEN MATCHED AND r.c3 IS NULL THEN\n\tDELETE\nWHEN MATCHED THEN\n\tUPDATE SET l.canary = r.c1, l.flow_published_at = r.c2, l.flow_document = r.c3\nWHEN NOT MATCHED THEN\n\tINSERT (id, canary, flow_published_at, flow_document)\n\tVALUES (r.c0, r.c1, r.c2, r.c3);\n",
           "Table": "`estuary-theatre`.testing.simple",
           "TempTableName": "flow_temp_table_0"
@@ -2295,74 +1760,11 @@
       "str": "str 6"
     },
     {
-      "flow_document": "{\"_meta\":{\"uuid\":\"8de85150-20e1-11ee-990b-ffd12dfcd47f\"},\"id\":1,\"int\":6,\"str\":\"str 6\"}",
-      "flow_published_at": "2023-07-12T18:26:01.560712Z",
-      "id": 1,
-      "int": 6,
-      "str": "str 6"
-    },
-    {
       "flow_document": "{\"_meta\":{\"uuid\":\"75c06bd6-20e0-11ee-990b-ffd12dfcd47f\"},\"id\":1,\"int\":1,\"str\":\"str 1\"}",
       "flow_published_at": "2023-07-12T18:18:11.537199Z",
       "id": 1,
       "int": 1,
       "str": "str 1"
-    },
-    {
-      "flow_document": "{\"_meta\":{\"uuid\":\"8de85150-20e1-11ee-990b-ffd12dfcd47f\"},\"id\":1,\"int\":6,\"str\":\"str 6\"}",
-      "flow_published_at": "2023-07-12T18:26:01.560712Z",
-      "id": 1,
-      "int": 6,
-      "str": "str 6"
-    },
-    {
-      "flow_document": "{\"_meta\":{\"uuid\":\"75c06bd6-20e0-11ee-990b-ffd12dfcd47f\"},\"id\":1,\"int\":1,\"str\":\"str 1\"}",
-      "flow_published_at": "2023-07-12T18:18:11.537199Z",
-      "id": 1,
-      "int": 1,
-      "str": "str 1"
-    },
-    {
-      "flow_document": "{\"_meta\":{\"uuid\":\"8de85150-20e1-11ee-990b-ffd12dfcd47f\"},\"id\":1,\"int\":6,\"str\":\"str 6\"}",
-      "flow_published_at": "2023-07-12T18:26:01.560712Z",
-      "id": 1,
-      "int": 6,
-      "str": "str 6"
-    },
-    {
-      "flow_document": "{\"_meta\":{\"uuid\":\"8de85150-20e1-11ee-990b-ffd12dfcd47f\"},\"id\":1,\"int\":6,\"str\":\"str 6\"}",
-      "flow_published_at": "2023-07-12T18:26:01.560712Z",
-      "id": 1,
-      "int": 6,
-      "str": "str 6"
-    },
-    {
-      "flow_document": "{\"_meta\":{\"uuid\":\"75c06bd6-20e0-11ee-990b-ffd12dfcd47f\"},\"id\":1,\"int\":1,\"str\":\"str 1\"}",
-      "flow_published_at": "2023-07-12T18:18:11.537199Z",
-      "id": 1,
-      "int": 1,
-      "str": "str 1"
-    },
-    {
-      "flow_document": "{\"_meta\":{\"uuid\":\"75c06bd6-20e0-11ee-990b-ffd12dfcd47f\"},\"id\":1,\"int\":1,\"str\":\"str 1\"}",
-      "flow_published_at": "2023-07-12T18:18:11.537199Z",
-      "id": 1,
-      "int": 1,
-      "str": "str 1"
-    },
-    {
-      "flow_document": "{\"_meta\":{\"uuid\":\"75c06bd6-20e0-11ee-990b-ffd12dfcd47f\"},\"id\":1,\"int\":1,\"str\":\"str 1\"}",
-      "flow_published_at": "2023-07-12T18:18:11.537199Z",
-      "id": 1,
-      "int": 1,
-      "str": "str 1"
-    },
-    {
-      "flow_document": "{\"_meta\":{\"uuid\":\"957348bc-20e1-11ee-990b-ffd12dfcd47f\"},\"id\":2,\"int\":7,\"str\":\"str 7\"}",
-      "flow_published_at": "2023-07-12T18:26:14.215494Z",
-      "id": 2,
-      "int": 7,
-      "str": "str 7"
     },
     {
       "flow_document": "{\"_meta\":{\"uuid\":\"957348bc-20e1-11ee-990b-ffd12dfcd47f\"},\"id\":2,\"int\":7,\"str\":\"str 7\"}",
@@ -2379,116 +1781,11 @@
       "str": "str 2"
     },
     {
-      "flow_document": "{\"_meta\":{\"uuid\":\"7dbe8ebc-20e0-11ee-990b-ffd12dfcd47f\"},\"id\":2,\"int\":2,\"str\":\"str 2\"}",
-      "flow_published_at": "2023-07-12T18:18:24.946758Z",
-      "id": 2,
-      "int": 2,
-      "str": "str 2"
-    },
-    {
-      "flow_document": "{\"_meta\":{\"uuid\":\"7dbe8ebc-20e0-11ee-990b-ffd12dfcd47f\"},\"id\":2,\"int\":2,\"str\":\"str 2\"}",
-      "flow_published_at": "2023-07-12T18:18:24.946758Z",
-      "id": 2,
-      "int": 2,
-      "str": "str 2"
-    },
-    {
-      "flow_document": "{\"_meta\":{\"uuid\":\"957348bc-20e1-11ee-990b-ffd12dfcd47f\"},\"id\":2,\"int\":7,\"str\":\"str 7\"}",
-      "flow_published_at": "2023-07-12T18:26:14.215494Z",
-      "id": 2,
-      "int": 7,
-      "str": "str 7"
-    },
-    {
-      "flow_document": "{\"_meta\":{\"uuid\":\"7dbe8ebc-20e0-11ee-990b-ffd12dfcd47f\"},\"id\":2,\"int\":2,\"str\":\"str 2\"}",
-      "flow_published_at": "2023-07-12T18:18:24.946758Z",
-      "id": 2,
-      "int": 2,
-      "str": "str 2"
-    },
-    {
-      "flow_document": "{\"_meta\":{\"uuid\":\"7dbe8ebc-20e0-11ee-990b-ffd12dfcd47f\"},\"id\":2,\"int\":2,\"str\":\"str 2\"}",
-      "flow_published_at": "2023-07-12T18:18:24.946758Z",
-      "id": 2,
-      "int": 2,
-      "str": "str 2"
-    },
-    {
-      "flow_document": "{\"_meta\":{\"uuid\":\"957348bc-20e1-11ee-990b-ffd12dfcd47f\"},\"id\":2,\"int\":7,\"str\":\"str 7\"}",
-      "flow_published_at": "2023-07-12T18:26:14.215494Z",
-      "id": 2,
-      "int": 7,
-      "str": "str 7"
-    },
-    {
-      "flow_document": "{\"_meta\":{\"uuid\":\"957348bc-20e1-11ee-990b-ffd12dfcd47f\"},\"id\":2,\"int\":7,\"str\":\"str 7\"}",
-      "flow_published_at": "2023-07-12T18:26:14.215494Z",
-      "id": 2,
-      "int": 7,
-      "str": "str 7"
-    },
-    {
       "flow_document": "{\"_meta\":{\"uuid\":\"9afb3ff6-20e1-11ee-990b-ffd12dfcd47f\"},\"id\":3,\"int\":8,\"str\":\"str 8\"}",
       "flow_published_at": "2023-07-12T18:26:23.495167Z",
       "id": 3,
       "int": 8,
       "str": "str 8"
-    },
-    {
-      "flow_document": "{\"_meta\":{\"uuid\":\"9afb3ff6-20e1-11ee-990b-ffd12dfcd47f\"},\"id\":3,\"int\":8,\"str\":\"str 8\"}",
-      "flow_published_at": "2023-07-12T18:26:23.495167Z",
-      "id": 3,
-      "int": 8,
-      "str": "str 8"
-    },
-    {
-      "flow_document": "{\"_meta\":{\"uuid\":\"9afb3ff6-20e1-11ee-990b-ffd12dfcd47f\"},\"id\":3,\"int\":8,\"str\":\"str 8\"}",
-      "flow_published_at": "2023-07-12T18:26:23.495167Z",
-      "id": 3,
-      "int": 8,
-      "str": "str 8"
-    },
-    {
-      "flow_document": "{\"_meta\":{\"uuid\":\"9afb3ff6-20e1-11ee-990b-ffd12dfcd47f\"},\"id\":3,\"int\":8,\"str\":\"str 8\"}",
-      "flow_published_at": "2023-07-12T18:26:23.495167Z",
-      "id": 3,
-      "int": 8,
-      "str": "str 8"
-    },
-    {
-      "flow_document": "{\"_meta\":{\"uuid\":\"8bbf898a-20e0-11ee-990b-ffd12dfcd47f\"},\"id\":3,\"int\":3,\"str\":\"str 3\"}",
-      "flow_published_at": "2023-07-12T18:18:48.441281Z",
-      "id": 3,
-      "int": 3,
-      "str": "str 3"
-    },
-    {
-      "flow_document": "{\"_meta\":{\"uuid\":\"9afb3ff6-20e1-11ee-990b-ffd12dfcd47f\"},\"id\":3,\"int\":8,\"str\":\"str 8\"}",
-      "flow_published_at": "2023-07-12T18:26:23.495167Z",
-      "id": 3,
-      "int": 8,
-      "str": "str 8"
-    },
-    {
-      "flow_document": "{\"_meta\":{\"uuid\":\"8bbf898a-20e0-11ee-990b-ffd12dfcd47f\"},\"id\":3,\"int\":3,\"str\":\"str 3\"}",
-      "flow_published_at": "2023-07-12T18:18:48.441281Z",
-      "id": 3,
-      "int": 3,
-      "str": "str 3"
-    },
-    {
-      "flow_document": "{\"_meta\":{\"uuid\":\"8bbf898a-20e0-11ee-990b-ffd12dfcd47f\"},\"id\":3,\"int\":3,\"str\":\"str 3\"}",
-      "flow_published_at": "2023-07-12T18:18:48.441281Z",
-      "id": 3,
-      "int": 3,
-      "str": "str 3"
-    },
-    {
-      "flow_document": "{\"_meta\":{\"uuid\":\"8bbf898a-20e0-11ee-990b-ffd12dfcd47f\"},\"id\":3,\"int\":3,\"str\":\"str 3\"}",
-      "flow_published_at": "2023-07-12T18:18:48.441281Z",
-      "id": 3,
-      "int": 3,
-      "str": "str 3"
     },
     {
       "flow_document": "{\"_meta\":{\"uuid\":\"8bbf898a-20e0-11ee-990b-ffd12dfcd47f\"},\"id\":3,\"int\":3,\"str\":\"str 3\"}",
@@ -2512,123 +1809,11 @@
       "str": "str 4"
     },
     {
-      "flow_document": "{\"_meta\":{\"uuid\":\"a1100a70-20e1-11ee-990b-ffd12dfcd47f\"},\"id\":4,\"int\":9,\"str\":\"str 9\"}",
-      "flow_published_at": "2023-07-12T18:26:33.697752Z",
-      "id": 4,
-      "int": 9,
-      "str": "str 9"
-    },
-    {
-      "flow_document": "{\"_meta\":{\"uuid\":\"9b994ae4-20e0-11ee-990b-ffd12dfcd47f\"},\"id\":4,\"int\":4,\"str\":\"str 4\"}",
-      "flow_published_at": "2023-07-12T18:19:15.034186Z",
-      "id": 4,
-      "int": 4,
-      "str": "str 4"
-    },
-    {
-      "flow_document": "{\"_meta\":{\"uuid\":\"a1100a70-20e1-11ee-990b-ffd12dfcd47f\"},\"id\":4,\"int\":9,\"str\":\"str 9\"}",
-      "flow_published_at": "2023-07-12T18:26:33.697752Z",
-      "id": 4,
-      "int": 9,
-      "str": "str 9"
-    },
-    {
-      "flow_document": "{\"_meta\":{\"uuid\":\"9b994ae4-20e0-11ee-990b-ffd12dfcd47f\"},\"id\":4,\"int\":4,\"str\":\"str 4\"}",
-      "flow_published_at": "2023-07-12T18:19:15.034186Z",
-      "id": 4,
-      "int": 4,
-      "str": "str 4"
-    },
-    {
-      "flow_document": "{\"_meta\":{\"uuid\":\"a1100a70-20e1-11ee-990b-ffd12dfcd47f\"},\"id\":4,\"int\":9,\"str\":\"str 9\"}",
-      "flow_published_at": "2023-07-12T18:26:33.697752Z",
-      "id": 4,
-      "int": 9,
-      "str": "str 9"
-    },
-    {
-      "flow_document": "{\"_meta\":{\"uuid\":\"9b994ae4-20e0-11ee-990b-ffd12dfcd47f\"},\"id\":4,\"int\":4,\"str\":\"str 4\"}",
-      "flow_published_at": "2023-07-12T18:19:15.034186Z",
-      "id": 4,
-      "int": 4,
-      "str": "str 4"
-    },
-    {
-      "flow_document": "{\"_meta\":{\"uuid\":\"9b994ae4-20e0-11ee-990b-ffd12dfcd47f\"},\"id\":4,\"int\":4,\"str\":\"str 4\"}",
-      "flow_published_at": "2023-07-12T18:19:15.034186Z",
-      "id": 4,
-      "int": 4,
-      "str": "str 4"
-    },
-    {
-      "flow_document": "{\"_meta\":{\"uuid\":\"a1100a70-20e1-11ee-990b-ffd12dfcd47f\"},\"id\":4,\"int\":9,\"str\":\"str 9\"}",
-      "flow_published_at": "2023-07-12T18:26:33.697752Z",
-      "id": 4,
-      "int": 9,
-      "str": "str 9"
-    },
-    {
       "flow_document": "{\"_meta\":{\"uuid\":\"a65203a8-20e1-11ee-990b-ffd12dfcd47f\"},\"id\":5,\"int\":10,\"str\":\"str 10\"}",
       "flow_published_at": "2023-07-12T18:26:42.518724Z",
       "id": 5,
       "int": 10,
       "str": "str 10"
-    },
-    {
-      "flow_document": "{\"_meta\":{\"uuid\":\"a65203a8-20e1-11ee-990b-ffd12dfcd47f\"},\"id\":5,\"int\":10,\"str\":\"str 10\"}",
-      "flow_published_at": "2023-07-12T18:26:42.518724Z",
-      "id": 5,
-      "int": 10,
-      "str": "str 10"
-    },
-    {
-      "flow_document": "{\"_meta\":{\"uuid\":\"bcef4bc6-20e0-11ee-990b-ffd12dfcd47f\"},\"id\":5,\"int\":5,\"str\":\"str 5\"}",
-      "flow_published_at": "2023-07-12T18:20:10.962631Z",
-      "id": 5,
-      "int": 5,
-      "str": "str 5"
-    },
-    {
-      "flow_document": "{\"_meta\":{\"uuid\":\"bcef4bc6-20e0-11ee-990b-ffd12dfcd47f\"},\"id\":5,\"int\":5,\"str\":\"str 5\"}",
-      "flow_published_at": "2023-07-12T18:20:10.962631Z",
-      "id": 5,
-      "int": 5,
-      "str": "str 5"
-    },
-    {
-      "flow_document": "{\"_meta\":{\"uuid\":\"a65203a8-20e1-11ee-990b-ffd12dfcd47f\"},\"id\":5,\"int\":10,\"str\":\"str 10\"}",
-      "flow_published_at": "2023-07-12T18:26:42.518724Z",
-      "id": 5,
-      "int": 10,
-      "str": "str 10"
-    },
-    {
-      "flow_document": "{\"_meta\":{\"uuid\":\"a65203a8-20e1-11ee-990b-ffd12dfcd47f\"},\"id\":5,\"int\":10,\"str\":\"str 10\"}",
-      "flow_published_at": "2023-07-12T18:26:42.518724Z",
-      "id": 5,
-      "int": 10,
-      "str": "str 10"
-    },
-    {
-      "flow_document": "{\"_meta\":{\"uuid\":\"a65203a8-20e1-11ee-990b-ffd12dfcd47f\"},\"id\":5,\"int\":10,\"str\":\"str 10\"}",
-      "flow_published_at": "2023-07-12T18:26:42.518724Z",
-      "id": 5,
-      "int": 10,
-      "str": "str 10"
-    },
-    {
-      "flow_document": "{\"_meta\":{\"uuid\":\"bcef4bc6-20e0-11ee-990b-ffd12dfcd47f\"},\"id\":5,\"int\":5,\"str\":\"str 5\"}",
-      "flow_published_at": "2023-07-12T18:20:10.962631Z",
-      "id": 5,
-      "int": 5,
-      "str": "str 5"
-    },
-    {
-      "flow_document": "{\"_meta\":{\"uuid\":\"bcef4bc6-20e0-11ee-990b-ffd12dfcd47f\"},\"id\":5,\"int\":5,\"str\":\"str 5\"}",
-      "flow_published_at": "2023-07-12T18:20:10.962631Z",
-      "id": 5,
-      "int": 5,
-      "str": "str 5"
     },
     {
       "flow_document": "{\"_meta\":{\"uuid\":\"bcef4bc6-20e0-11ee-990b-ffd12dfcd47f\"},\"id\":5,\"int\":5,\"str\":\"str 5\"}",
@@ -2648,88 +1833,10 @@
       "str": "str 6"
     },
     {
-      "flow_published_at": "2023-07-12T18:26:01.560712Z",
-      "id": 1,
-      "int": 6,
-      "str": "str 6"
-    },
-    {
       "flow_published_at": "2023-07-12T18:18:11.537199Z",
       "id": 1,
       "int": 1,
       "str": "str 1"
-    },
-    {
-      "flow_published_at": "2023-07-12T18:26:01.560712Z",
-      "id": 1,
-      "int": 6,
-      "str": "str 6"
-    },
-    {
-      "flow_published_at": "2023-07-12T18:26:01.560712Z",
-      "id": 1,
-      "int": 6,
-      "str": "str 6"
-    },
-    {
-      "flow_published_at": "2023-07-12T18:26:01.560712Z",
-      "id": 1,
-      "int": 6,
-      "str": "str 6"
-    },
-    {
-      "flow_published_at": "2023-07-12T18:18:11.537199Z",
-      "id": 1,
-      "int": 1,
-      "str": "str 1"
-    },
-    {
-      "flow_published_at": "2023-07-12T18:18:11.537199Z",
-      "id": 1,
-      "int": 1,
-      "str": "str 1"
-    },
-    {
-      "flow_published_at": "2023-07-12T18:18:11.537199Z",
-      "id": 1,
-      "int": 1,
-      "str": "str 1"
-    },
-    {
-      "flow_published_at": "2023-07-12T18:18:11.537199Z",
-      "id": 1,
-      "int": 1,
-      "str": "str 1"
-    },
-    {
-      "flow_published_at": "2023-07-12T18:18:24.946758Z",
-      "id": 2,
-      "int": 2,
-      "str": "str 2"
-    },
-    {
-      "flow_published_at": "2023-07-12T18:26:14.215494Z",
-      "id": 2,
-      "int": 7,
-      "str": "str 7"
-    },
-    {
-      "flow_published_at": "2023-07-12T18:26:14.215494Z",
-      "id": 2,
-      "int": 7,
-      "str": "str 7"
-    },
-    {
-      "flow_published_at": "2023-07-12T18:26:14.215494Z",
-      "id": 2,
-      "int": 7,
-      "str": "str 7"
-    },
-    {
-      "flow_published_at": "2023-07-12T18:26:14.215494Z",
-      "id": 2,
-      "int": 7,
-      "str": "str 7"
     },
     {
       "flow_published_at": "2023-07-12T18:26:14.215494Z",
@@ -2744,30 +1851,6 @@
       "str": "str 2"
     },
     {
-      "flow_published_at": "2023-07-12T18:18:24.946758Z",
-      "id": 2,
-      "int": 2,
-      "str": "str 2"
-    },
-    {
-      "flow_published_at": "2023-07-12T18:18:24.946758Z",
-      "id": 2,
-      "int": 2,
-      "str": "str 2"
-    },
-    {
-      "flow_published_at": "2023-07-12T18:18:24.946758Z",
-      "id": 2,
-      "int": 2,
-      "str": "str 2"
-    },
-    {
-      "flow_published_at": "2023-07-12T18:26:23.495167Z",
-      "id": 3,
-      "int": 8,
-      "str": "str 8"
-    },
-    {
       "flow_published_at": "2023-07-12T18:26:23.495167Z",
       "id": 3,
       "int": 8,
@@ -2780,54 +1863,6 @@
       "str": "str 3"
     },
     {
-      "flow_published_at": "2023-07-12T18:26:23.495167Z",
-      "id": 3,
-      "int": 8,
-      "str": "str 8"
-    },
-    {
-      "flow_published_at": "2023-07-12T18:18:48.441281Z",
-      "id": 3,
-      "int": 3,
-      "str": "str 3"
-    },
-    {
-      "flow_published_at": "2023-07-12T18:26:23.495167Z",
-      "id": 3,
-      "int": 8,
-      "str": "str 8"
-    },
-    {
-      "flow_published_at": "2023-07-12T18:26:23.495167Z",
-      "id": 3,
-      "int": 8,
-      "str": "str 8"
-    },
-    {
-      "flow_published_at": "2023-07-12T18:18:48.441281Z",
-      "id": 3,
-      "int": 3,
-      "str": "str 3"
-    },
-    {
-      "flow_published_at": "2023-07-12T18:18:48.441281Z",
-      "id": 3,
-      "int": 3,
-      "str": "str 3"
-    },
-    {
-      "flow_published_at": "2023-07-12T18:18:48.441281Z",
-      "id": 3,
-      "int": 3,
-      "str": "str 3"
-    },
-    {
-      "flow_published_at": "2023-07-12T18:19:15.034186Z",
-      "id": 4,
-      "int": 4,
-      "str": "str 4"
-    },
-    {
       "flow_published_at": "2023-07-12T18:26:33.697752Z",
       "id": 4,
       "int": 9,
@@ -2838,96 +1873,6 @@
       "id": 4,
       "int": 4,
       "str": "str 4"
-    },
-    {
-      "flow_published_at": "2023-07-12T18:19:15.034186Z",
-      "id": 4,
-      "int": 4,
-      "str": "str 4"
-    },
-    {
-      "flow_published_at": "2023-07-12T18:19:15.034186Z",
-      "id": 4,
-      "int": 4,
-      "str": "str 4"
-    },
-    {
-      "flow_published_at": "2023-07-12T18:19:15.034186Z",
-      "id": 4,
-      "int": 4,
-      "str": "str 4"
-    },
-    {
-      "flow_published_at": "2023-07-12T18:26:33.697752Z",
-      "id": 4,
-      "int": 9,
-      "str": "str 9"
-    },
-    {
-      "flow_published_at": "2023-07-12T18:26:33.697752Z",
-      "id": 4,
-      "int": 9,
-      "str": "str 9"
-    },
-    {
-      "flow_published_at": "2023-07-12T18:26:33.697752Z",
-      "id": 4,
-      "int": 9,
-      "str": "str 9"
-    },
-    {
-      "flow_published_at": "2023-07-12T18:26:33.697752Z",
-      "id": 4,
-      "int": 9,
-      "str": "str 9"
-    },
-    {
-      "flow_published_at": "2023-07-12T18:26:42.518724Z",
-      "id": 5,
-      "int": 10,
-      "str": "str 10"
-    },
-    {
-      "flow_published_at": "2023-07-12T18:26:42.518724Z",
-      "id": 5,
-      "int": 10,
-      "str": "str 10"
-    },
-    {
-      "flow_published_at": "2023-07-12T18:20:10.962631Z",
-      "id": 5,
-      "int": 5,
-      "str": "str 5"
-    },
-    {
-      "flow_published_at": "2023-07-12T18:20:10.962631Z",
-      "id": 5,
-      "int": 5,
-      "str": "str 5"
-    },
-    {
-      "flow_published_at": "2023-07-12T18:20:10.962631Z",
-      "id": 5,
-      "int": 5,
-      "str": "str 5"
-    },
-    {
-      "flow_published_at": "2023-07-12T18:26:42.518724Z",
-      "id": 5,
-      "int": 10,
-      "str": "str 10"
-    },
-    {
-      "flow_published_at": "2023-07-12T18:20:10.962631Z",
-      "id": 5,
-      "int": 5,
-      "str": "str 5"
-    },
-    {
-      "flow_published_at": "2023-07-12T18:26:42.518724Z",
-      "id": 5,
-      "int": 10,
-      "str": "str 10"
     },
     {
       "flow_published_at": "2023-07-12T18:26:42.518724Z",

--- a/tests/materialize/materialize-bigquery/snapshot.json
+++ b/tests/materialize/materialize-bigquery/snapshot.json
@@ -1,24 +1,558 @@
 {
   "applied": {
-    "actionDescription": "CREATE TABLE IF NOT EXISTS `estuary-theatre`.testing.flow_materializations_v2 (\n\t\tmaterialization STRING NOT NULL,\n\t\tversion STRING NOT NULL,\n\t\tspec STRING NOT NULL\n)\nCLUSTER BY materialization;\n\nCREATE TABLE IF NOT EXISTS `estuary-theatre`.testing.flow_checkpoints_v1 (\n\t\tmaterialization STRING NOT NULL,\n\t\tkey_begin INT64 NOT NULL,\n\t\tkey_end INT64 NOT NULL,\n\t\tfence INT64 NOT NULL,\n\t\tcheckpoint STRING NOT NULL\n)\nCLUSTER BY materialization, key_begin, key_end;\n\nCREATE TABLE IF NOT EXISTS `estuary-theatre`.testing.simple (\n\t\tid INT64 NOT NULL,\n\t\tcanary STRING NOT NULL,\n\t\tflow_published_at TIMESTAMP NOT NULL,\n\t\tflow_document STRING NOT NULL\n)\nCLUSTER BY id;\n\nCREATE TABLE IF NOT EXISTS `estuary-theatre`.testing.duplicate_keys (\n\t\tid INT64 NOT NULL,\n\t\tflow_published_at TIMESTAMP NOT NULL,\n\t\tint INT64,\n\t\tstr STRING NOT NULL,\n\t\tflow_document STRING NOT NULL\n)\nCLUSTER BY id;\n\nCREATE TABLE IF NOT EXISTS `estuary-theatre`.testing.multiple_types (\n\t\tid INT64 NOT NULL,\n\t\tarray_int STRING,\n\t\tbool_field BOOL,\n\t\tfloat_field FLOAT64,\n\t\tflow_published_at TIMESTAMP NOT NULL,\n\t\tmultiple JSON,\n\t\tnested STRING,\n\t\tnullable_int INT64,\n\t\tstr_field STRING NOT NULL,\n\t\tflow_document STRING NOT NULL\n)\nCLUSTER BY id;\n\nCREATE TABLE IF NOT EXISTS `estuary-theatre`.testing.formatted_strings (\n\t\tid INT64 NOT NULL,\n\t\tdate DATE,\n\t\tdatetime TIMESTAMP,\n\t\tflow_published_at TIMESTAMP NOT NULL,\n\t\tint_and_str BIGNUMERIC(38,0),\n\t\tint_str BIGNUMERIC(38,0),\n\t\tnum_and_str FLOAT64,\n\t\tnum_str FLOAT64,\n\t\ttime STRING,\n\t\tflow_document STRING NOT NULL\n)\nCLUSTER BY id;\n\nINSERT INTO `estuary-theatre`.testing.flow_materializations_v2 (version, spec, materialization) VALUES ('test', '(a-base64-encoded-value)', 'tests/materialize-bigquery/materialize');"
+    "actionDescription": "CREATE TABLE IF NOT EXISTS `estuary-theatre`.testing.simple (\n\t\tid INT64 NOT NULL,\n\t\tcanary STRING NOT NULL,\n\t\tflow_published_at TIMESTAMP NOT NULL,\n\t\tflow_document STRING NOT NULL\n)\nCLUSTER BY id;\n\nCREATE TABLE IF NOT EXISTS `estuary-theatre`.testing.duplicate_keys (\n\t\tid INT64 NOT NULL,\n\t\tflow_published_at TIMESTAMP NOT NULL,\n\t\tint INT64,\n\t\tstr STRING NOT NULL,\n\t\tflow_document STRING NOT NULL\n)\nCLUSTER BY id;\n\nCREATE TABLE IF NOT EXISTS `estuary-theatre`.testing.multiple_types (\n\t\tid INT64 NOT NULL,\n\t\tarray_int STRING,\n\t\tbool_field BOOL,\n\t\tfloat_field FLOAT64,\n\t\tflow_published_at TIMESTAMP NOT NULL,\n\t\tmultiple JSON,\n\t\tnested STRING,\n\t\tnullable_int INT64,\n\t\tstr_field STRING NOT NULL,\n\t\tflow_document STRING NOT NULL\n)\nCLUSTER BY id;\n\nCREATE TABLE IF NOT EXISTS `estuary-theatre`.testing.formatted_strings (\n\t\tid INT64 NOT NULL,\n\t\tdate DATE,\n\t\tdatetime TIMESTAMP,\n\t\tflow_published_at TIMESTAMP NOT NULL,\n\t\tint_and_str BIGNUMERIC(38,0),\n\t\tint_str BIGNUMERIC(38,0),\n\t\tnum_and_str FLOAT64,\n\t\tnum_str FLOAT64,\n\t\ttime STRING,\n\t\tflow_document STRING NOT NULL\n)\nCLUSTER BY id;\n\nINSERT INTO `estuary-theatre`.testing.flow_materializations_v2 (version, spec, materialization) VALUES ('test', '(a-base64-encoded-value)', 'tests/materialize-bigquery/materialize');"
   }
 }
 {
-  "opened": {
-    "runtimeCheckpoint": {}
-  }
+  "opened": {}
 }
 {
-  "acknowledged": {}
+  "acknowledged": {
+    "state": {
+      "mergePatch": true,
+      "updated": {
+        "estuary-theatre%2Ftesting%2Fduplicate_keys": null,
+        "estuary-theatre%2Ftesting%2Fformatted_strings": null,
+        "estuary-theatre%2Ftesting%2Fmultiple_types": null,
+        "estuary-theatre%2Ftesting%2Fsimple": null
+      }
+    }
+  }
 }
 {
   "flushed": {}
 }
 {
-  "startedCommit": {}
+  "startedCommit": {
+    "state": {
+      "mergePatch": true,
+      "updated": {
+        "estuary-theatre%2Ftesting%2Fduplicate_keys": {
+          "Bucket": "estuary-bigquery-test",
+          "EDC": {
+            "AutoDetect": false,
+            "Compression": "GZIP",
+            "ConnectionID": "",
+            "DecimalTargetTypes": null,
+            "HivePartitioningOptions": null,
+            "IgnoreUnknownValues": false,
+            "MaxBadRecords": 0,
+            "Options": null,
+            "ReferenceFileSchemaURI": "",
+            "Schema": [
+              {
+                "Collation": "",
+                "DefaultValueExpression": "",
+                "Description": "",
+                "MaxLength": 0,
+                "Name": "c0",
+                "PolicyTags": null,
+                "Precision": 0,
+                "Repeated": false,
+                "Required": true,
+                "Scale": 0,
+                "Schema": null,
+                "Type": "INTEGER"
+              },
+              {
+                "Collation": "",
+                "DefaultValueExpression": "",
+                "Description": "",
+                "MaxLength": 0,
+                "Name": "c1",
+                "PolicyTags": null,
+                "Precision": 0,
+                "Repeated": false,
+                "Required": true,
+                "Scale": 0,
+                "Schema": null,
+                "Type": "TIMESTAMP"
+              },
+              {
+                "Collation": "",
+                "DefaultValueExpression": "",
+                "Description": "",
+                "MaxLength": 0,
+                "Name": "c2",
+                "PolicyTags": null,
+                "Precision": 0,
+                "Repeated": false,
+                "Required": false,
+                "Scale": 0,
+                "Schema": null,
+                "Type": "INTEGER"
+              },
+              {
+                "Collation": "",
+                "DefaultValueExpression": "",
+                "Description": "",
+                "MaxLength": 0,
+                "Name": "c3",
+                "PolicyTags": null,
+                "Precision": 0,
+                "Repeated": false,
+                "Required": true,
+                "Scale": 0,
+                "Schema": null,
+                "Type": "STRING"
+              },
+              {
+                "Collation": "",
+                "DefaultValueExpression": "",
+                "Description": "",
+                "MaxLength": 0,
+                "Name": "c4",
+                "PolicyTags": null,
+                "Precision": 0,
+                "Repeated": false,
+                "Required": true,
+                "Scale": 0,
+                "Schema": null,
+                "Type": "STRING"
+              }
+            ],
+            "SourceFormat": "NEWLINE_DELIMITED_JSON",
+            "SourceURIs": [
+              "gs://estuary-bigquery-test/30c6ff92-234d-44d9-99d5-e9d3ac8db4ad/92c0b0d9-c0e3-43f4-b34b-9828ea2a025b"
+            ]
+          },
+          "Files": [
+            "30c6ff92-234d-44d9-99d5-e9d3ac8db4ad/92c0b0d9-c0e3-43f4-b34b-9828ea2a025b"
+          ],
+          "Query": "MERGE INTO `estuary-theatre`.testing.duplicate_keys AS l\nUSING flow_temp_table_1 AS r\nON l.id = r.c0\nWHEN MATCHED AND r.c4 IS NULL THEN\n\tDELETE\nWHEN MATCHED THEN\n\tUPDATE SET l.flow_published_at = r.c1, l.int = r.c2, l.str = r.c3, l.flow_document = r.c4\nWHEN NOT MATCHED THEN\n\tINSERT (id, flow_published_at, int, str, flow_document)\n\tVALUES (r.c0, r.c1, r.c2, r.c3, r.c4);\n",
+          "Table": "`estuary-theatre`.testing.duplicate_keys",
+          "TempTableName": "flow_temp_table_1"
+        },
+        "estuary-theatre%2Ftesting%2Fformatted_strings": {
+          "Bucket": "estuary-bigquery-test",
+          "EDC": {
+            "AutoDetect": false,
+            "Compression": "GZIP",
+            "ConnectionID": "",
+            "DecimalTargetTypes": null,
+            "HivePartitioningOptions": null,
+            "IgnoreUnknownValues": false,
+            "MaxBadRecords": 0,
+            "Options": null,
+            "ReferenceFileSchemaURI": "",
+            "Schema": [
+              {
+                "Collation": "",
+                "DefaultValueExpression": "",
+                "Description": "",
+                "MaxLength": 0,
+                "Name": "c0",
+                "PolicyTags": null,
+                "Precision": 0,
+                "Repeated": false,
+                "Required": true,
+                "Scale": 0,
+                "Schema": null,
+                "Type": "INTEGER"
+              },
+              {
+                "Collation": "",
+                "DefaultValueExpression": "",
+                "Description": "",
+                "MaxLength": 0,
+                "Name": "c1",
+                "PolicyTags": null,
+                "Precision": 0,
+                "Repeated": false,
+                "Required": false,
+                "Scale": 0,
+                "Schema": null,
+                "Type": "DATE"
+              },
+              {
+                "Collation": "",
+                "DefaultValueExpression": "",
+                "Description": "",
+                "MaxLength": 0,
+                "Name": "c2",
+                "PolicyTags": null,
+                "Precision": 0,
+                "Repeated": false,
+                "Required": false,
+                "Scale": 0,
+                "Schema": null,
+                "Type": "TIMESTAMP"
+              },
+              {
+                "Collation": "",
+                "DefaultValueExpression": "",
+                "Description": "",
+                "MaxLength": 0,
+                "Name": "c3",
+                "PolicyTags": null,
+                "Precision": 0,
+                "Repeated": false,
+                "Required": true,
+                "Scale": 0,
+                "Schema": null,
+                "Type": "TIMESTAMP"
+              },
+              {
+                "Collation": "",
+                "DefaultValueExpression": "",
+                "Description": "",
+                "MaxLength": 0,
+                "Name": "c4",
+                "PolicyTags": null,
+                "Precision": 38,
+                "Repeated": false,
+                "Required": false,
+                "Scale": 0,
+                "Schema": null,
+                "Type": "BIGNUMERIC"
+              },
+              {
+                "Collation": "",
+                "DefaultValueExpression": "",
+                "Description": "",
+                "MaxLength": 0,
+                "Name": "c5",
+                "PolicyTags": null,
+                "Precision": 38,
+                "Repeated": false,
+                "Required": false,
+                "Scale": 0,
+                "Schema": null,
+                "Type": "BIGNUMERIC"
+              },
+              {
+                "Collation": "",
+                "DefaultValueExpression": "",
+                "Description": "",
+                "MaxLength": 0,
+                "Name": "c6",
+                "PolicyTags": null,
+                "Precision": 0,
+                "Repeated": false,
+                "Required": false,
+                "Scale": 0,
+                "Schema": null,
+                "Type": "FLOAT"
+              },
+              {
+                "Collation": "",
+                "DefaultValueExpression": "",
+                "Description": "",
+                "MaxLength": 0,
+                "Name": "c7",
+                "PolicyTags": null,
+                "Precision": 0,
+                "Repeated": false,
+                "Required": false,
+                "Scale": 0,
+                "Schema": null,
+                "Type": "FLOAT"
+              },
+              {
+                "Collation": "",
+                "DefaultValueExpression": "",
+                "Description": "",
+                "MaxLength": 0,
+                "Name": "c8",
+                "PolicyTags": null,
+                "Precision": 0,
+                "Repeated": false,
+                "Required": false,
+                "Scale": 0,
+                "Schema": null,
+                "Type": "STRING"
+              },
+              {
+                "Collation": "",
+                "DefaultValueExpression": "",
+                "Description": "",
+                "MaxLength": 0,
+                "Name": "c9",
+                "PolicyTags": null,
+                "Precision": 0,
+                "Repeated": false,
+                "Required": true,
+                "Scale": 0,
+                "Schema": null,
+                "Type": "STRING"
+              }
+            ],
+            "SourceFormat": "NEWLINE_DELIMITED_JSON",
+            "SourceURIs": [
+              "gs://estuary-bigquery-test/318d841f-cb22-45c7-a12b-5bf600d404d7/0847333a-13b8-4085-a62e-28c42d97a795"
+            ]
+          },
+          "Files": [
+            "318d841f-cb22-45c7-a12b-5bf600d404d7/0847333a-13b8-4085-a62e-28c42d97a795"
+          ],
+          "Query": "MERGE INTO `estuary-theatre`.testing.formatted_strings AS l\nUSING flow_temp_table_3 AS r\nON l.id = r.c0\nWHEN MATCHED AND r.c9 IS NULL THEN\n\tDELETE\nWHEN MATCHED THEN\n\tUPDATE SET l.date = r.c1, l.datetime = r.c2, l.flow_published_at = r.c3, l.int_and_str = r.c4, l.int_str = r.c5, l.num_and_str = r.c6, l.num_str = r.c7, l.time = r.c8, l.flow_document = r.c9\nWHEN NOT MATCHED THEN\n\tINSERT (id, date, datetime, flow_published_at, int_and_str, int_str, num_and_str, num_str, time, flow_document)\n\tVALUES (r.c0, r.c1, r.c2, r.c3, r.c4, r.c5, r.c6, r.c7, r.c8, r.c9);\n",
+          "Table": "`estuary-theatre`.testing.formatted_strings",
+          "TempTableName": "flow_temp_table_3"
+        },
+        "estuary-theatre%2Ftesting%2Fmultiple_types": {
+          "Bucket": "estuary-bigquery-test",
+          "EDC": {
+            "AutoDetect": false,
+            "Compression": "GZIP",
+            "ConnectionID": "",
+            "DecimalTargetTypes": null,
+            "HivePartitioningOptions": null,
+            "IgnoreUnknownValues": false,
+            "MaxBadRecords": 0,
+            "Options": null,
+            "ReferenceFileSchemaURI": "",
+            "Schema": [
+              {
+                "Collation": "",
+                "DefaultValueExpression": "",
+                "Description": "",
+                "MaxLength": 0,
+                "Name": "c0",
+                "PolicyTags": null,
+                "Precision": 0,
+                "Repeated": false,
+                "Required": true,
+                "Scale": 0,
+                "Schema": null,
+                "Type": "INTEGER"
+              },
+              {
+                "Collation": "",
+                "DefaultValueExpression": "",
+                "Description": "",
+                "MaxLength": 0,
+                "Name": "c1",
+                "PolicyTags": null,
+                "Precision": 0,
+                "Repeated": false,
+                "Required": false,
+                "Scale": 0,
+                "Schema": null,
+                "Type": "STRING"
+              },
+              {
+                "Collation": "",
+                "DefaultValueExpression": "",
+                "Description": "",
+                "MaxLength": 0,
+                "Name": "c2",
+                "PolicyTags": null,
+                "Precision": 0,
+                "Repeated": false,
+                "Required": false,
+                "Scale": 0,
+                "Schema": null,
+                "Type": "BOOLEAN"
+              },
+              {
+                "Collation": "",
+                "DefaultValueExpression": "",
+                "Description": "",
+                "MaxLength": 0,
+                "Name": "c3",
+                "PolicyTags": null,
+                "Precision": 0,
+                "Repeated": false,
+                "Required": false,
+                "Scale": 0,
+                "Schema": null,
+                "Type": "FLOAT"
+              },
+              {
+                "Collation": "",
+                "DefaultValueExpression": "",
+                "Description": "",
+                "MaxLength": 0,
+                "Name": "c4",
+                "PolicyTags": null,
+                "Precision": 0,
+                "Repeated": false,
+                "Required": true,
+                "Scale": 0,
+                "Schema": null,
+                "Type": "TIMESTAMP"
+              },
+              {
+                "Collation": "",
+                "DefaultValueExpression": "",
+                "Description": "",
+                "MaxLength": 0,
+                "Name": "c5",
+                "PolicyTags": null,
+                "Precision": 0,
+                "Repeated": false,
+                "Required": false,
+                "Scale": 0,
+                "Schema": null,
+                "Type": "JSON"
+              },
+              {
+                "Collation": "",
+                "DefaultValueExpression": "",
+                "Description": "",
+                "MaxLength": 0,
+                "Name": "c6",
+                "PolicyTags": null,
+                "Precision": 0,
+                "Repeated": false,
+                "Required": false,
+                "Scale": 0,
+                "Schema": null,
+                "Type": "STRING"
+              },
+              {
+                "Collation": "",
+                "DefaultValueExpression": "",
+                "Description": "",
+                "MaxLength": 0,
+                "Name": "c7",
+                "PolicyTags": null,
+                "Precision": 0,
+                "Repeated": false,
+                "Required": false,
+                "Scale": 0,
+                "Schema": null,
+                "Type": "INTEGER"
+              },
+              {
+                "Collation": "",
+                "DefaultValueExpression": "",
+                "Description": "",
+                "MaxLength": 0,
+                "Name": "c8",
+                "PolicyTags": null,
+                "Precision": 0,
+                "Repeated": false,
+                "Required": true,
+                "Scale": 0,
+                "Schema": null,
+                "Type": "STRING"
+              },
+              {
+                "Collation": "",
+                "DefaultValueExpression": "",
+                "Description": "",
+                "MaxLength": 0,
+                "Name": "c9",
+                "PolicyTags": null,
+                "Precision": 0,
+                "Repeated": false,
+                "Required": true,
+                "Scale": 0,
+                "Schema": null,
+                "Type": "STRING"
+              }
+            ],
+            "SourceFormat": "NEWLINE_DELIMITED_JSON",
+            "SourceURIs": [
+              "gs://estuary-bigquery-test/8a3dfc1f-4d00-4900-81b7-50b38d1caa58/6e6aa2b6-0edb-4bb4-895b-97e2fdb1fc68"
+            ]
+          },
+          "Files": [
+            "8a3dfc1f-4d00-4900-81b7-50b38d1caa58/6e6aa2b6-0edb-4bb4-895b-97e2fdb1fc68"
+          ],
+          "Query": "MERGE INTO `estuary-theatre`.testing.multiple_types AS l\nUSING flow_temp_table_2 AS r\nON l.id = r.c0\nWHEN MATCHED AND r.c9 IS NULL THEN\n\tDELETE\nWHEN MATCHED THEN\n\tUPDATE SET l.array_int = r.c1, l.bool_field = r.c2, l.float_field = r.c3, l.flow_published_at = r.c4, l.multiple = r.c5, l.nested = r.c6, l.nullable_int = r.c7, l.str_field = r.c8, l.flow_document = r.c9\nWHEN NOT MATCHED THEN\n\tINSERT (id, array_int, bool_field, float_field, flow_published_at, multiple, nested, nullable_int, str_field, flow_document)\n\tVALUES (r.c0, r.c1, r.c2, r.c3, r.c4, r.c5, r.c6, r.c7, r.c8, r.c9);\n",
+          "Table": "`estuary-theatre`.testing.multiple_types",
+          "TempTableName": "flow_temp_table_2"
+        },
+        "estuary-theatre%2Ftesting%2Fsimple": {
+          "Bucket": "estuary-bigquery-test",
+          "EDC": {
+            "AutoDetect": false,
+            "Compression": "GZIP",
+            "ConnectionID": "",
+            "DecimalTargetTypes": null,
+            "HivePartitioningOptions": null,
+            "IgnoreUnknownValues": false,
+            "MaxBadRecords": 0,
+            "Options": null,
+            "ReferenceFileSchemaURI": "",
+            "Schema": [
+              {
+                "Collation": "",
+                "DefaultValueExpression": "",
+                "Description": "",
+                "MaxLength": 0,
+                "Name": "c0",
+                "PolicyTags": null,
+                "Precision": 0,
+                "Repeated": false,
+                "Required": true,
+                "Scale": 0,
+                "Schema": null,
+                "Type": "INTEGER"
+              },
+              {
+                "Collation": "",
+                "DefaultValueExpression": "",
+                "Description": "",
+                "MaxLength": 0,
+                "Name": "c1",
+                "PolicyTags": null,
+                "Precision": 0,
+                "Repeated": false,
+                "Required": true,
+                "Scale": 0,
+                "Schema": null,
+                "Type": "STRING"
+              },
+              {
+                "Collation": "",
+                "DefaultValueExpression": "",
+                "Description": "",
+                "MaxLength": 0,
+                "Name": "c2",
+                "PolicyTags": null,
+                "Precision": 0,
+                "Repeated": false,
+                "Required": true,
+                "Scale": 0,
+                "Schema": null,
+                "Type": "TIMESTAMP"
+              },
+              {
+                "Collation": "",
+                "DefaultValueExpression": "",
+                "Description": "",
+                "MaxLength": 0,
+                "Name": "c3",
+                "PolicyTags": null,
+                "Precision": 0,
+                "Repeated": false,
+                "Required": true,
+                "Scale": 0,
+                "Schema": null,
+                "Type": "STRING"
+              }
+            ],
+            "SourceFormat": "NEWLINE_DELIMITED_JSON",
+            "SourceURIs": [
+              "gs://estuary-bigquery-test/5d1c1e98-105a-49ff-bc4e-f2bca5f6188f/92f28d24-ba84-4234-aeda-6062254b75c4"
+            ]
+          },
+          "Files": [
+            "5d1c1e98-105a-49ff-bc4e-f2bca5f6188f/92f28d24-ba84-4234-aeda-6062254b75c4"
+          ],
+          "Query": "MERGE INTO `estuary-theatre`.testing.simple AS l\nUSING flow_temp_table_0 AS r\nON l.id = r.c0\nWHEN MATCHED AND r.c3 IS NULL THEN\n\tDELETE\nWHEN MATCHED THEN\n\tUPDATE SET l.canary = r.c1, l.flow_published_at = r.c2, l.flow_document = r.c3\nWHEN NOT MATCHED THEN\n\tINSERT (id, canary, flow_published_at, flow_document)\n\tVALUES (r.c0, r.c1, r.c2, r.c3);\n",
+          "Table": "`estuary-theatre`.testing.simple",
+          "TempTableName": "flow_temp_table_0"
+        }
+      }
+    }
+  }
 }
 {
-  "acknowledged": {}
+  "acknowledged": {
+    "state": {
+      "mergePatch": true,
+      "updated": {
+        "estuary-theatre%2Ftesting%2Fduplicate_keys": null,
+        "estuary-theatre%2Ftesting%2Fformatted_strings": null,
+        "estuary-theatre%2Ftesting%2Fmultiple_types": null,
+        "estuary-theatre%2Ftesting%2Fsimple": null
+      }
+    }
+  }
 }
 {
   "loaded": {
@@ -208,10 +742,536 @@
   "flushed": {}
 }
 {
-  "startedCommit": {}
+  "startedCommit": {
+    "state": {
+      "mergePatch": true,
+      "updated": {
+        "estuary-theatre%2Ftesting%2Fduplicate_keys": {
+          "Bucket": "estuary-bigquery-test",
+          "EDC": {
+            "AutoDetect": false,
+            "Compression": "GZIP",
+            "ConnectionID": "",
+            "DecimalTargetTypes": null,
+            "HivePartitioningOptions": null,
+            "IgnoreUnknownValues": false,
+            "MaxBadRecords": 0,
+            "Options": null,
+            "ReferenceFileSchemaURI": "",
+            "Schema": [
+              {
+                "Collation": "",
+                "DefaultValueExpression": "",
+                "Description": "",
+                "MaxLength": 0,
+                "Name": "c0",
+                "PolicyTags": null,
+                "Precision": 0,
+                "Repeated": false,
+                "Required": true,
+                "Scale": 0,
+                "Schema": null,
+                "Type": "INTEGER"
+              },
+              {
+                "Collation": "",
+                "DefaultValueExpression": "",
+                "Description": "",
+                "MaxLength": 0,
+                "Name": "c1",
+                "PolicyTags": null,
+                "Precision": 0,
+                "Repeated": false,
+                "Required": true,
+                "Scale": 0,
+                "Schema": null,
+                "Type": "TIMESTAMP"
+              },
+              {
+                "Collation": "",
+                "DefaultValueExpression": "",
+                "Description": "",
+                "MaxLength": 0,
+                "Name": "c2",
+                "PolicyTags": null,
+                "Precision": 0,
+                "Repeated": false,
+                "Required": false,
+                "Scale": 0,
+                "Schema": null,
+                "Type": "INTEGER"
+              },
+              {
+                "Collation": "",
+                "DefaultValueExpression": "",
+                "Description": "",
+                "MaxLength": 0,
+                "Name": "c3",
+                "PolicyTags": null,
+                "Precision": 0,
+                "Repeated": false,
+                "Required": true,
+                "Scale": 0,
+                "Schema": null,
+                "Type": "STRING"
+              },
+              {
+                "Collation": "",
+                "DefaultValueExpression": "",
+                "Description": "",
+                "MaxLength": 0,
+                "Name": "c4",
+                "PolicyTags": null,
+                "Precision": 0,
+                "Repeated": false,
+                "Required": true,
+                "Scale": 0,
+                "Schema": null,
+                "Type": "STRING"
+              }
+            ],
+            "SourceFormat": "NEWLINE_DELIMITED_JSON",
+            "SourceURIs": [
+              "gs://estuary-bigquery-test/30c6ff92-234d-44d9-99d5-e9d3ac8db4ad/09a1fd53-841e-4caf-af89-a840825e928c"
+            ]
+          },
+          "Files": [
+            "30c6ff92-234d-44d9-99d5-e9d3ac8db4ad/09a1fd53-841e-4caf-af89-a840825e928c"
+          ],
+          "Query": "MERGE INTO `estuary-theatre`.testing.duplicate_keys AS l\nUSING flow_temp_table_1 AS r\nON l.id = r.c0\nWHEN MATCHED AND r.c4 IS NULL THEN\n\tDELETE\nWHEN MATCHED THEN\n\tUPDATE SET l.flow_published_at = r.c1, l.int = r.c2, l.str = r.c3, l.flow_document = r.c4\nWHEN NOT MATCHED THEN\n\tINSERT (id, flow_published_at, int, str, flow_document)\n\tVALUES (r.c0, r.c1, r.c2, r.c3, r.c4);\n",
+          "Table": "`estuary-theatre`.testing.duplicate_keys",
+          "TempTableName": "flow_temp_table_1"
+        },
+        "estuary-theatre%2Ftesting%2Fformatted_strings": {
+          "Bucket": "estuary-bigquery-test",
+          "EDC": {
+            "AutoDetect": false,
+            "Compression": "GZIP",
+            "ConnectionID": "",
+            "DecimalTargetTypes": null,
+            "HivePartitioningOptions": null,
+            "IgnoreUnknownValues": false,
+            "MaxBadRecords": 0,
+            "Options": null,
+            "ReferenceFileSchemaURI": "",
+            "Schema": [
+              {
+                "Collation": "",
+                "DefaultValueExpression": "",
+                "Description": "",
+                "MaxLength": 0,
+                "Name": "c0",
+                "PolicyTags": null,
+                "Precision": 0,
+                "Repeated": false,
+                "Required": true,
+                "Scale": 0,
+                "Schema": null,
+                "Type": "INTEGER"
+              },
+              {
+                "Collation": "",
+                "DefaultValueExpression": "",
+                "Description": "",
+                "MaxLength": 0,
+                "Name": "c1",
+                "PolicyTags": null,
+                "Precision": 0,
+                "Repeated": false,
+                "Required": false,
+                "Scale": 0,
+                "Schema": null,
+                "Type": "DATE"
+              },
+              {
+                "Collation": "",
+                "DefaultValueExpression": "",
+                "Description": "",
+                "MaxLength": 0,
+                "Name": "c2",
+                "PolicyTags": null,
+                "Precision": 0,
+                "Repeated": false,
+                "Required": false,
+                "Scale": 0,
+                "Schema": null,
+                "Type": "TIMESTAMP"
+              },
+              {
+                "Collation": "",
+                "DefaultValueExpression": "",
+                "Description": "",
+                "MaxLength": 0,
+                "Name": "c3",
+                "PolicyTags": null,
+                "Precision": 0,
+                "Repeated": false,
+                "Required": true,
+                "Scale": 0,
+                "Schema": null,
+                "Type": "TIMESTAMP"
+              },
+              {
+                "Collation": "",
+                "DefaultValueExpression": "",
+                "Description": "",
+                "MaxLength": 0,
+                "Name": "c4",
+                "PolicyTags": null,
+                "Precision": 38,
+                "Repeated": false,
+                "Required": false,
+                "Scale": 0,
+                "Schema": null,
+                "Type": "BIGNUMERIC"
+              },
+              {
+                "Collation": "",
+                "DefaultValueExpression": "",
+                "Description": "",
+                "MaxLength": 0,
+                "Name": "c5",
+                "PolicyTags": null,
+                "Precision": 38,
+                "Repeated": false,
+                "Required": false,
+                "Scale": 0,
+                "Schema": null,
+                "Type": "BIGNUMERIC"
+              },
+              {
+                "Collation": "",
+                "DefaultValueExpression": "",
+                "Description": "",
+                "MaxLength": 0,
+                "Name": "c6",
+                "PolicyTags": null,
+                "Precision": 0,
+                "Repeated": false,
+                "Required": false,
+                "Scale": 0,
+                "Schema": null,
+                "Type": "FLOAT"
+              },
+              {
+                "Collation": "",
+                "DefaultValueExpression": "",
+                "Description": "",
+                "MaxLength": 0,
+                "Name": "c7",
+                "PolicyTags": null,
+                "Precision": 0,
+                "Repeated": false,
+                "Required": false,
+                "Scale": 0,
+                "Schema": null,
+                "Type": "FLOAT"
+              },
+              {
+                "Collation": "",
+                "DefaultValueExpression": "",
+                "Description": "",
+                "MaxLength": 0,
+                "Name": "c8",
+                "PolicyTags": null,
+                "Precision": 0,
+                "Repeated": false,
+                "Required": false,
+                "Scale": 0,
+                "Schema": null,
+                "Type": "STRING"
+              },
+              {
+                "Collation": "",
+                "DefaultValueExpression": "",
+                "Description": "",
+                "MaxLength": 0,
+                "Name": "c9",
+                "PolicyTags": null,
+                "Precision": 0,
+                "Repeated": false,
+                "Required": true,
+                "Scale": 0,
+                "Schema": null,
+                "Type": "STRING"
+              }
+            ],
+            "SourceFormat": "NEWLINE_DELIMITED_JSON",
+            "SourceURIs": [
+              "gs://estuary-bigquery-test/318d841f-cb22-45c7-a12b-5bf600d404d7/36954c97-1267-4080-8df4-d295e96dfac8"
+            ]
+          },
+          "Files": [
+            "318d841f-cb22-45c7-a12b-5bf600d404d7/36954c97-1267-4080-8df4-d295e96dfac8"
+          ],
+          "Query": "MERGE INTO `estuary-theatre`.testing.formatted_strings AS l\nUSING flow_temp_table_3 AS r\nON l.id = r.c0\nWHEN MATCHED AND r.c9 IS NULL THEN\n\tDELETE\nWHEN MATCHED THEN\n\tUPDATE SET l.date = r.c1, l.datetime = r.c2, l.flow_published_at = r.c3, l.int_and_str = r.c4, l.int_str = r.c5, l.num_and_str = r.c6, l.num_str = r.c7, l.time = r.c8, l.flow_document = r.c9\nWHEN NOT MATCHED THEN\n\tINSERT (id, date, datetime, flow_published_at, int_and_str, int_str, num_and_str, num_str, time, flow_document)\n\tVALUES (r.c0, r.c1, r.c2, r.c3, r.c4, r.c5, r.c6, r.c7, r.c8, r.c9);\n",
+          "Table": "`estuary-theatre`.testing.formatted_strings",
+          "TempTableName": "flow_temp_table_3"
+        },
+        "estuary-theatre%2Ftesting%2Fmultiple_types": {
+          "Bucket": "estuary-bigquery-test",
+          "EDC": {
+            "AutoDetect": false,
+            "Compression": "GZIP",
+            "ConnectionID": "",
+            "DecimalTargetTypes": null,
+            "HivePartitioningOptions": null,
+            "IgnoreUnknownValues": false,
+            "MaxBadRecords": 0,
+            "Options": null,
+            "ReferenceFileSchemaURI": "",
+            "Schema": [
+              {
+                "Collation": "",
+                "DefaultValueExpression": "",
+                "Description": "",
+                "MaxLength": 0,
+                "Name": "c0",
+                "PolicyTags": null,
+                "Precision": 0,
+                "Repeated": false,
+                "Required": true,
+                "Scale": 0,
+                "Schema": null,
+                "Type": "INTEGER"
+              },
+              {
+                "Collation": "",
+                "DefaultValueExpression": "",
+                "Description": "",
+                "MaxLength": 0,
+                "Name": "c1",
+                "PolicyTags": null,
+                "Precision": 0,
+                "Repeated": false,
+                "Required": false,
+                "Scale": 0,
+                "Schema": null,
+                "Type": "STRING"
+              },
+              {
+                "Collation": "",
+                "DefaultValueExpression": "",
+                "Description": "",
+                "MaxLength": 0,
+                "Name": "c2",
+                "PolicyTags": null,
+                "Precision": 0,
+                "Repeated": false,
+                "Required": false,
+                "Scale": 0,
+                "Schema": null,
+                "Type": "BOOLEAN"
+              },
+              {
+                "Collation": "",
+                "DefaultValueExpression": "",
+                "Description": "",
+                "MaxLength": 0,
+                "Name": "c3",
+                "PolicyTags": null,
+                "Precision": 0,
+                "Repeated": false,
+                "Required": false,
+                "Scale": 0,
+                "Schema": null,
+                "Type": "FLOAT"
+              },
+              {
+                "Collation": "",
+                "DefaultValueExpression": "",
+                "Description": "",
+                "MaxLength": 0,
+                "Name": "c4",
+                "PolicyTags": null,
+                "Precision": 0,
+                "Repeated": false,
+                "Required": true,
+                "Scale": 0,
+                "Schema": null,
+                "Type": "TIMESTAMP"
+              },
+              {
+                "Collation": "",
+                "DefaultValueExpression": "",
+                "Description": "",
+                "MaxLength": 0,
+                "Name": "c5",
+                "PolicyTags": null,
+                "Precision": 0,
+                "Repeated": false,
+                "Required": false,
+                "Scale": 0,
+                "Schema": null,
+                "Type": "JSON"
+              },
+              {
+                "Collation": "",
+                "DefaultValueExpression": "",
+                "Description": "",
+                "MaxLength": 0,
+                "Name": "c6",
+                "PolicyTags": null,
+                "Precision": 0,
+                "Repeated": false,
+                "Required": false,
+                "Scale": 0,
+                "Schema": null,
+                "Type": "STRING"
+              },
+              {
+                "Collation": "",
+                "DefaultValueExpression": "",
+                "Description": "",
+                "MaxLength": 0,
+                "Name": "c7",
+                "PolicyTags": null,
+                "Precision": 0,
+                "Repeated": false,
+                "Required": false,
+                "Scale": 0,
+                "Schema": null,
+                "Type": "INTEGER"
+              },
+              {
+                "Collation": "",
+                "DefaultValueExpression": "",
+                "Description": "",
+                "MaxLength": 0,
+                "Name": "c8",
+                "PolicyTags": null,
+                "Precision": 0,
+                "Repeated": false,
+                "Required": true,
+                "Scale": 0,
+                "Schema": null,
+                "Type": "STRING"
+              },
+              {
+                "Collation": "",
+                "DefaultValueExpression": "",
+                "Description": "",
+                "MaxLength": 0,
+                "Name": "c9",
+                "PolicyTags": null,
+                "Precision": 0,
+                "Repeated": false,
+                "Required": true,
+                "Scale": 0,
+                "Schema": null,
+                "Type": "STRING"
+              }
+            ],
+            "SourceFormat": "NEWLINE_DELIMITED_JSON",
+            "SourceURIs": [
+              "gs://estuary-bigquery-test/8a3dfc1f-4d00-4900-81b7-50b38d1caa58/4c735b7a-aaf1-4af3-a03d-627485265367"
+            ]
+          },
+          "Files": [
+            "8a3dfc1f-4d00-4900-81b7-50b38d1caa58/4c735b7a-aaf1-4af3-a03d-627485265367"
+          ],
+          "Query": "MERGE INTO `estuary-theatre`.testing.multiple_types AS l\nUSING flow_temp_table_2 AS r\nON l.id = r.c0\nWHEN MATCHED AND r.c9 IS NULL THEN\n\tDELETE\nWHEN MATCHED THEN\n\tUPDATE SET l.array_int = r.c1, l.bool_field = r.c2, l.float_field = r.c3, l.flow_published_at = r.c4, l.multiple = r.c5, l.nested = r.c6, l.nullable_int = r.c7, l.str_field = r.c8, l.flow_document = r.c9\nWHEN NOT MATCHED THEN\n\tINSERT (id, array_int, bool_field, float_field, flow_published_at, multiple, nested, nullable_int, str_field, flow_document)\n\tVALUES (r.c0, r.c1, r.c2, r.c3, r.c4, r.c5, r.c6, r.c7, r.c8, r.c9);\n",
+          "Table": "`estuary-theatre`.testing.multiple_types",
+          "TempTableName": "flow_temp_table_2"
+        },
+        "estuary-theatre%2Ftesting%2Fsimple": {
+          "Bucket": "estuary-bigquery-test",
+          "EDC": {
+            "AutoDetect": false,
+            "Compression": "GZIP",
+            "ConnectionID": "",
+            "DecimalTargetTypes": null,
+            "HivePartitioningOptions": null,
+            "IgnoreUnknownValues": false,
+            "MaxBadRecords": 0,
+            "Options": null,
+            "ReferenceFileSchemaURI": "",
+            "Schema": [
+              {
+                "Collation": "",
+                "DefaultValueExpression": "",
+                "Description": "",
+                "MaxLength": 0,
+                "Name": "c0",
+                "PolicyTags": null,
+                "Precision": 0,
+                "Repeated": false,
+                "Required": true,
+                "Scale": 0,
+                "Schema": null,
+                "Type": "INTEGER"
+              },
+              {
+                "Collation": "",
+                "DefaultValueExpression": "",
+                "Description": "",
+                "MaxLength": 0,
+                "Name": "c1",
+                "PolicyTags": null,
+                "Precision": 0,
+                "Repeated": false,
+                "Required": true,
+                "Scale": 0,
+                "Schema": null,
+                "Type": "STRING"
+              },
+              {
+                "Collation": "",
+                "DefaultValueExpression": "",
+                "Description": "",
+                "MaxLength": 0,
+                "Name": "c2",
+                "PolicyTags": null,
+                "Precision": 0,
+                "Repeated": false,
+                "Required": true,
+                "Scale": 0,
+                "Schema": null,
+                "Type": "TIMESTAMP"
+              },
+              {
+                "Collation": "",
+                "DefaultValueExpression": "",
+                "Description": "",
+                "MaxLength": 0,
+                "Name": "c3",
+                "PolicyTags": null,
+                "Precision": 0,
+                "Repeated": false,
+                "Required": true,
+                "Scale": 0,
+                "Schema": null,
+                "Type": "STRING"
+              }
+            ],
+            "SourceFormat": "NEWLINE_DELIMITED_JSON",
+            "SourceURIs": [
+              "gs://estuary-bigquery-test/5d1c1e98-105a-49ff-bc4e-f2bca5f6188f/27adda32-3703-4989-b31c-b1c2efba9ef8"
+            ]
+          },
+          "Files": [
+            "5d1c1e98-105a-49ff-bc4e-f2bca5f6188f/27adda32-3703-4989-b31c-b1c2efba9ef8"
+          ],
+          "Query": "MERGE INTO `estuary-theatre`.testing.simple AS l\nUSING flow_temp_table_0 AS r\nON l.id = r.c0\nWHEN MATCHED AND r.c3 IS NULL THEN\n\tDELETE\nWHEN MATCHED THEN\n\tUPDATE SET l.canary = r.c1, l.flow_published_at = r.c2, l.flow_document = r.c3\nWHEN NOT MATCHED THEN\n\tINSERT (id, canary, flow_published_at, flow_document)\n\tVALUES (r.c0, r.c1, r.c2, r.c3);\n",
+          "Table": "`estuary-theatre`.testing.simple",
+          "TempTableName": "flow_temp_table_0"
+        }
+      }
+    }
+  }
 }
 {
-  "acknowledged": {}
+  "acknowledged": {
+    "state": {
+      "mergePatch": true,
+      "updated": {
+        "estuary-theatre%2Ftesting%2Fduplicate_keys": null,
+        "estuary-theatre%2Ftesting%2Fformatted_strings": null,
+        "estuary-theatre%2Ftesting%2Fmultiple_types": null,
+        "estuary-theatre%2Ftesting%2Fsimple": null
+      }
+    }
+  }
 }
 [
   1,
@@ -494,16 +1554,13 @@
   }
 }
 {
-  "opened": {
-    "runtimeCheckpoint": {
-      "sources": {
-        "a/read/journal;suffix": {
-          "readThrough": "1"
-        }
-      }
-    }
-  }
+  "opened": {}
 }
 {
-  "acknowledged": {}
+  "acknowledged": {
+    "state": {
+      "mergePatch": true,
+      "updated": {}
+    }
+  }
 }

--- a/tests/materialize/materialize-bigquery/snapshot.json
+++ b/tests/materialize/materialize-bigquery/snapshot.json
@@ -1827,22 +1827,16 @@
 {
   "estuary-theatre.testing.duplicate_keys_delta_exclude_flow_doc": [
     {
-      "flow_published_at": "2023-07-12T18:18:11.537199Z",
-      "id": 1,
-      "int": 1,
-      "str": "str 1"
-    },
-    {
       "flow_published_at": "2023-07-12T18:26:01.560712Z",
       "id": 1,
       "int": 6,
       "str": "str 6"
     },
     {
-      "flow_published_at": "2023-07-12T18:18:24.946758Z",
-      "id": 2,
-      "int": 2,
-      "str": "str 2"
+      "flow_published_at": "2023-07-12T18:18:11.537199Z",
+      "id": 1,
+      "int": 1,
+      "str": "str 1"
     },
     {
       "flow_published_at": "2023-07-12T18:26:14.215494Z",
@@ -1851,10 +1845,10 @@
       "str": "str 7"
     },
     {
-      "flow_published_at": "2023-07-12T18:18:48.441281Z",
-      "id": 3,
-      "int": 3,
-      "str": "str 3"
+      "flow_published_at": "2023-07-12T18:18:24.946758Z",
+      "id": 2,
+      "int": 2,
+      "str": "str 2"
     },
     {
       "flow_published_at": "2023-07-12T18:26:23.495167Z",
@@ -1863,10 +1857,10 @@
       "str": "str 8"
     },
     {
-      "flow_published_at": "2023-07-12T18:19:15.034186Z",
-      "id": 4,
-      "int": 4,
-      "str": "str 4"
+      "flow_published_at": "2023-07-12T18:18:48.441281Z",
+      "id": 3,
+      "int": 3,
+      "str": "str 3"
     },
     {
       "flow_published_at": "2023-07-12T18:26:33.697752Z",
@@ -1875,16 +1869,22 @@
       "str": "str 9"
     },
     {
-      "flow_published_at": "2023-07-12T18:20:10.962631Z",
-      "id": 5,
-      "int": 5,
-      "str": "str 5"
+      "flow_published_at": "2023-07-12T18:19:15.034186Z",
+      "id": 4,
+      "int": 4,
+      "str": "str 4"
     },
     {
       "flow_published_at": "2023-07-12T18:26:42.518724Z",
       "id": 5,
       "int": 10,
       "str": "str 10"
+    },
+    {
+      "flow_published_at": "2023-07-12T18:20:10.962631Z",
+      "id": 5,
+      "int": 5,
+      "str": "str 5"
     }
   ]
 }

--- a/tests/materialize/materialize-bigquery/snapshot.json
+++ b/tests/materialize/materialize-bigquery/snapshot.json
@@ -1827,22 +1827,16 @@
 {
   "estuary-theatre.testing.duplicate_keys_delta_exclude_flow_doc": [
     {
-      "flow_published_at": "2023-07-12T18:26:01.560712Z",
-      "id": 1,
-      "int": 6,
-      "str": "str 6"
-    },
-    {
       "flow_published_at": "2023-07-12T18:18:11.537199Z",
       "id": 1,
       "int": 1,
       "str": "str 1"
     },
     {
-      "flow_published_at": "2023-07-12T18:26:14.215494Z",
-      "id": 2,
-      "int": 7,
-      "str": "str 7"
+      "flow_published_at": "2023-07-12T18:26:01.560712Z",
+      "id": 1,
+      "int": 6,
+      "str": "str 6"
     },
     {
       "flow_published_at": "2023-07-12T18:18:24.946758Z",
@@ -1851,10 +1845,10 @@
       "str": "str 2"
     },
     {
-      "flow_published_at": "2023-07-12T18:26:23.495167Z",
-      "id": 3,
-      "int": 8,
-      "str": "str 8"
+      "flow_published_at": "2023-07-12T18:26:14.215494Z",
+      "id": 2,
+      "int": 7,
+      "str": "str 7"
     },
     {
       "flow_published_at": "2023-07-12T18:18:48.441281Z",
@@ -1863,10 +1857,10 @@
       "str": "str 3"
     },
     {
-      "flow_published_at": "2023-07-12T18:26:33.697752Z",
-      "id": 4,
-      "int": 9,
-      "str": "str 9"
+      "flow_published_at": "2023-07-12T18:26:23.495167Z",
+      "id": 3,
+      "int": 8,
+      "str": "str 8"
     },
     {
       "flow_published_at": "2023-07-12T18:19:15.034186Z",
@@ -1875,16 +1869,22 @@
       "str": "str 4"
     },
     {
-      "flow_published_at": "2023-07-12T18:26:42.518724Z",
-      "id": 5,
-      "int": 10,
-      "str": "str 10"
+      "flow_published_at": "2023-07-12T18:26:33.697752Z",
+      "id": 4,
+      "int": 9,
+      "str": "str 9"
     },
     {
       "flow_published_at": "2023-07-12T18:20:10.962631Z",
       "id": 5,
       "int": 5,
       "str": "str 5"
+    },
+    {
+      "flow_published_at": "2023-07-12T18:26:42.518724Z",
+      "id": 5,
+      "int": 10,
+      "str": "str 10"
     }
   ]
 }

--- a/tests/materialize/materialize-bigquery/snapshot.json
+++ b/tests/materialize/materialize-bigquery/snapshot.json
@@ -1,6 +1,6 @@
 {
   "applied": {
-    "actionDescription": "CREATE TABLE IF NOT EXISTS `estuary-theatre`.testing.simple (\n\t\tid INT64 NOT NULL,\n\t\tcanary STRING NOT NULL,\n\t\tflow_published_at TIMESTAMP NOT NULL,\n\t\tflow_document STRING NOT NULL\n)\nCLUSTER BY id;\n\nCREATE TABLE IF NOT EXISTS `estuary-theatre`.testing.duplicate_keys (\n\t\tid INT64 NOT NULL,\n\t\tflow_published_at TIMESTAMP NOT NULL,\n\t\tint INT64,\n\t\tstr STRING NOT NULL,\n\t\tflow_document STRING NOT NULL\n)\nCLUSTER BY id;\n\nCREATE TABLE IF NOT EXISTS `estuary-theatre`.testing.multiple_types (\n\t\tid INT64 NOT NULL,\n\t\tarray_int STRING,\n\t\tbool_field BOOL,\n\t\tfloat_field FLOAT64,\n\t\tflow_published_at TIMESTAMP NOT NULL,\n\t\tmultiple JSON,\n\t\tnested STRING,\n\t\tnullable_int INT64,\n\t\tstr_field STRING NOT NULL,\n\t\tflow_document STRING NOT NULL\n)\nCLUSTER BY id;\n\nCREATE TABLE IF NOT EXISTS `estuary-theatre`.testing.formatted_strings (\n\t\tid INT64 NOT NULL,\n\t\tdate DATE,\n\t\tdatetime TIMESTAMP,\n\t\tflow_published_at TIMESTAMP NOT NULL,\n\t\tint_and_str BIGNUMERIC(38,0),\n\t\tint_str BIGNUMERIC(38,0),\n\t\tnum_and_str FLOAT64,\n\t\tnum_str FLOAT64,\n\t\ttime STRING,\n\t\tflow_document STRING NOT NULL\n)\nCLUSTER BY id;\n\nINSERT INTO `estuary-theatre`.testing.flow_materializations_v2 (version, spec, materialization) VALUES ('test', '(a-base64-encoded-value)', 'tests/materialize-bigquery/materialize');"
+    "actionDescription": "UPDATE `estuary-theatre`.testing.flow_materializations_v2 SET version = 'test', spec = '(a-base64-encoded-value)' WHERE materialization = 'tests/materialize-bigquery/materialize';"
   }
 }
 {
@@ -11,11 +11,414 @@
     "state": {
       "mergePatch": true,
       "updated": {
-        "estuary-theatre%2Ftesting%2Fduplicate_keys": null,
+        "estuary-theatre%2Ftesting%2Fduplicate_keys_delta": null,
+        "estuary-theatre%2Ftesting%2Fduplicate_keys_delta_exclude_flow_doc": null,
+        "estuary-theatre%2Ftesting%2Fduplicate_keys_standard": null,
         "estuary-theatre%2Ftesting%2Fformatted_strings": null,
         "estuary-theatre%2Ftesting%2Fmultiple_types": null,
         "estuary-theatre%2Ftesting%2Fsimple": null
       }
+    }
+  }
+}
+{
+  "loaded": {
+    "binding": 1,
+    "doc": {
+      "_meta": {
+        "uuid": "8de85150-20e1-11ee-990b-ffd12dfcd47f"
+      },
+      "id": 1,
+      "int": 6,
+      "str": "str 6"
+    }
+  }
+}
+{
+  "loaded": {
+    "binding": 1,
+    "doc": {
+      "_meta": {
+        "uuid": "957348bc-20e1-11ee-990b-ffd12dfcd47f"
+      },
+      "id": 2,
+      "int": 7,
+      "str": "str 7"
+    }
+  }
+}
+{
+  "loaded": {
+    "binding": 1,
+    "doc": {
+      "_meta": {
+        "uuid": "9afb3ff6-20e1-11ee-990b-ffd12dfcd47f"
+      },
+      "id": 3,
+      "int": 8,
+      "str": "str 8"
+    }
+  }
+}
+{
+  "loaded": {
+    "binding": 1,
+    "doc": {
+      "_meta": {
+        "uuid": "a1100a70-20e1-11ee-990b-ffd12dfcd47f"
+      },
+      "id": 4,
+      "int": 9,
+      "str": "str 9"
+    }
+  }
+}
+{
+  "loaded": {
+    "binding": 1,
+    "doc": {
+      "_meta": {
+        "uuid": "a65203a8-20e1-11ee-990b-ffd12dfcd47f"
+      },
+      "id": 5,
+      "int": 10,
+      "str": "str 10"
+    }
+  }
+}
+{
+  "loaded": {
+    "binding": 4,
+    "doc": {
+      "_meta": {
+        "uuid": "3fd2ec78-20e1-11ee-990b-ffd12dfcd47f"
+      },
+      "array_int": [
+        11,
+        12
+      ],
+      "bool_field": false,
+      "float_field": 1.1,
+      "id": 1,
+      "multiple": 1,
+      "nested": {
+        "id": "i1"
+      },
+      "nullable_int": null,
+      "str_field": "str1"
+    }
+  }
+}
+{
+  "loaded": {
+    "binding": 4,
+    "doc": {
+      "_meta": {
+        "uuid": "4b37f0b8-20e1-11ee-990b-ffd12dfcd47f"
+      },
+      "array_int": [
+        21,
+        22
+      ],
+      "bool_field": true,
+      "float_field": 2.2,
+      "id": 2,
+      "multiple": 2.2,
+      "nested": {
+        "id": "i2"
+      },
+      "nullable_int": 2,
+      "str_field": "str2"
+    }
+  }
+}
+{
+  "loaded": {
+    "binding": 4,
+    "doc": {
+      "_meta": {
+        "uuid": "51016380-20e1-11ee-990b-ffd12dfcd47f"
+      },
+      "array_int": [
+        31,
+        32
+      ],
+      "bool_field": false,
+      "float_field": 3.3,
+      "id": 3,
+      "multiple": true,
+      "nested": {
+        "id": "i3"
+      },
+      "nullable_int": null,
+      "str_field": "str3"
+    }
+  }
+}
+{
+  "loaded": {
+    "binding": 4,
+    "doc": {
+      "_meta": {
+        "uuid": "5660aaca-20e1-11ee-990b-ffd12dfcd47f"
+      },
+      "array_int": [
+        41,
+        42
+      ],
+      "bool_field": true,
+      "float_field": 4.4,
+      "id": 4,
+      "multiple": false,
+      "nested": {
+        "id": "i4"
+      },
+      "nullable_int": 4,
+      "str_field": "str4"
+    }
+  }
+}
+{
+  "loaded": {
+    "binding": 4,
+    "doc": {
+      "_meta": {
+        "uuid": "5af9e236-20e1-11ee-990b-ffd12dfcd47f"
+      },
+      "array_int": [
+        51,
+        52
+      ],
+      "bool_field": false,
+      "float_field": 5.5,
+      "id": 5,
+      "multiple": "string five",
+      "nested": {
+        "id": "i5"
+      },
+      "nullable_int": null,
+      "str_field": "str5"
+    }
+  }
+}
+{
+  "loaded": {
+    "binding": 4,
+    "doc": {
+      "_meta": {
+        "uuid": "e4b646c2-20e1-11ee-990b-ffd12dfcd47f"
+      },
+      "array_int": [
+        61,
+        62
+      ],
+      "bool_field": true,
+      "float_field": 66.66,
+      "id": 6,
+      "multiple": [
+        "one",
+        2,
+        true
+      ],
+      "nested": {
+        "id": "i6"
+      },
+      "nullable_int": 6,
+      "str_field": "str6 v2"
+    }
+  }
+}
+{
+  "loaded": {
+    "binding": 4,
+    "doc": {
+      "_meta": {
+        "uuid": "eb40dafc-20e1-11ee-990b-ffd12dfcd47f"
+      },
+      "array_int": [
+        71,
+        72
+      ],
+      "bool_field": false,
+      "float_field": 77.77,
+      "id": 7,
+      "multiple": {
+        "object": "seven"
+      },
+      "nested": {
+        "id": "i7"
+      },
+      "nullable_int": null,
+      "str_field": "str7 v2"
+    }
+  }
+}
+{
+  "loaded": {
+    "binding": 4,
+    "doc": {
+      "_meta": {
+        "uuid": "f163eef6-20e1-11ee-990b-ffd12dfcd47f"
+      },
+      "array_int": [
+        81,
+        82
+      ],
+      "bool_field": true,
+      "float_field": 88.88,
+      "id": 8,
+      "multiple": null,
+      "nested": {
+        "id": "i8"
+      },
+      "nullable_int": 8,
+      "str_field": "str8 v2"
+    }
+  }
+}
+{
+  "loaded": {
+    "binding": 4,
+    "doc": {
+      "_meta": {
+        "uuid": "f5b064a8-20e1-11ee-990b-ffd12dfcd47f"
+      },
+      "array_int": [
+        91,
+        92
+      ],
+      "bool_field": false,
+      "float_field": 99.99,
+      "id": 9,
+      "nested": {
+        "id": "i9"
+      },
+      "nullable_int": null,
+      "str_field": "str9 v2"
+    }
+  }
+}
+{
+  "loaded": {
+    "binding": 4,
+    "doc": {
+      "_meta": {
+        "uuid": "fb0cc8b0-20e1-11ee-990b-ffd12dfcd47f"
+      },
+      "array_int": [
+        1,
+        2
+      ],
+      "bool_field": true,
+      "float_field": 1010.101,
+      "id": 10,
+      "nested": {
+        "id": "i10"
+      },
+      "nullable_int": 10,
+      "str_field": "str10 v2"
+    }
+  }
+}
+{
+  "loaded": {
+    "binding": 5,
+    "doc": {
+      "_meta": {
+        "uuid": "75c06bd6-20e0-11ee-990b-ffd12dfcd47f"
+      },
+      "date": "1000-03-03",
+      "datetime": "1000-03-03T23:59:38.10Z",
+      "id": 3,
+      "int_and_str": 3,
+      "int_str": "30",
+      "num_and_str": 3.1,
+      "num_str": "30.1",
+      "time": "23:59:38.10Z"
+    }
+  }
+}
+{
+  "loaded": {
+    "binding": 5,
+    "doc": {
+      "_meta": {
+        "uuid": "8bbf898a-20e0-11ee-990b-ffd12dfcd47f"
+      },
+      "date": "2023-08-29",
+      "datetime": "2023-08-29T23:59:38Z",
+      "id": 4,
+      "int_and_str": "4",
+      "int_str": "40",
+      "num_and_str": "4.1",
+      "num_str": "40.1",
+      "time": "23:59:38Z"
+    }
+  }
+}
+{
+  "loaded": {
+    "doc": {
+      "_meta": {
+        "uuid": "75c06bd6-20e0-11ee-990b-ffd12dfcd47f"
+      },
+      "canary": "amputation's",
+      "id": 1
+    }
+  }
+}
+{
+  "loaded": {
+    "doc": {
+      "_meta": {
+        "uuid": "7dbe8ebc-20e0-11ee-990b-ffd12dfcd47f"
+      },
+      "canary": "armament's",
+      "id": 2
+    }
+  }
+}
+{
+  "loaded": {
+    "doc": {
+      "_meta": {
+        "uuid": "8bbf898a-20e0-11ee-990b-ffd12dfcd47f"
+      },
+      "canary": "splatters",
+      "id": 3
+    }
+  }
+}
+{
+  "loaded": {
+    "doc": {
+      "_meta": {
+        "uuid": "9b994ae4-20e0-11ee-990b-ffd12dfcd47f"
+      },
+      "canary": "strengthen",
+      "id": 4
+    }
+  }
+}
+{
+  "loaded": {
+    "doc": {
+      "_meta": {
+        "uuid": "b4b60968-20e0-11ee-990b-ffd12dfcd47f"
+      },
+      "canary": "Kringle's",
+      "id": 5
+    }
+  }
+}
+{
+  "loaded": {
+    "doc": {
+      "_meta": {
+        "uuid": "bcef4bc6-20e0-11ee-990b-ffd12dfcd47f"
+      },
+      "canary": "grosbeak's",
+      "id": 6
     }
   }
 }
@@ -27,7 +430,7 @@
     "state": {
       "mergePatch": true,
       "updated": {
-        "estuary-theatre%2Ftesting%2Fduplicate_keys": {
+        "estuary-theatre%2Ftesting%2Fduplicate_keys_delta": {
           "Bucket": "estuary-bigquery-test",
           "EDC": {
             "AutoDetect": false,
@@ -113,14 +516,195 @@
             ],
             "SourceFormat": "NEWLINE_DELIMITED_JSON",
             "SourceURIs": [
-              "gs://estuary-bigquery-test/30c6ff92-234d-44d9-99d5-e9d3ac8db4ad/92c0b0d9-c0e3-43f4-b34b-9828ea2a025b"
+              "gs://estuary-bigquery-test/5d4e4b04-3e9f-46f3-b22a-a494d4e99462/4903b7e9-2a8d-4963-a362-2bd56897a425"
             ]
           },
           "Files": [
-            "30c6ff92-234d-44d9-99d5-e9d3ac8db4ad/92c0b0d9-c0e3-43f4-b34b-9828ea2a025b"
+            "5d4e4b04-3e9f-46f3-b22a-a494d4e99462/4903b7e9-2a8d-4963-a362-2bd56897a425"
           ],
-          "Query": "MERGE INTO `estuary-theatre`.testing.duplicate_keys AS l\nUSING flow_temp_table_1 AS r\nON l.id = r.c0\nWHEN MATCHED AND r.c4 IS NULL THEN\n\tDELETE\nWHEN MATCHED THEN\n\tUPDATE SET l.flow_published_at = r.c1, l.int = r.c2, l.str = r.c3, l.flow_document = r.c4\nWHEN NOT MATCHED THEN\n\tINSERT (id, flow_published_at, int, str, flow_document)\n\tVALUES (r.c0, r.c1, r.c2, r.c3, r.c4);\n",
-          "Table": "`estuary-theatre`.testing.duplicate_keys",
+          "JobID": "2d64c378-6e48-439a-9ba6-630501fba47f",
+          "Query": "INSERT INTO `estuary-theatre`.testing.duplicate_keys_delta (id, flow_published_at, int, str, flow_document)\nSELECT c0, c1, c2, c3, c4 FROM flow_temp_table_2;\n",
+          "Table": "`estuary-theatre`.testing.duplicate_keys_delta",
+          "TempTableName": "flow_temp_table_2"
+        },
+        "estuary-theatre%2Ftesting%2Fduplicate_keys_delta_exclude_flow_doc": {
+          "Bucket": "estuary-bigquery-test",
+          "EDC": {
+            "AutoDetect": false,
+            "Compression": "GZIP",
+            "ConnectionID": "",
+            "DecimalTargetTypes": null,
+            "HivePartitioningOptions": null,
+            "IgnoreUnknownValues": false,
+            "MaxBadRecords": 0,
+            "Options": null,
+            "ReferenceFileSchemaURI": "",
+            "Schema": [
+              {
+                "Collation": "",
+                "DefaultValueExpression": "",
+                "Description": "",
+                "MaxLength": 0,
+                "Name": "c0",
+                "PolicyTags": null,
+                "Precision": 0,
+                "Repeated": false,
+                "Required": true,
+                "Scale": 0,
+                "Schema": null,
+                "Type": "INTEGER"
+              },
+              {
+                "Collation": "",
+                "DefaultValueExpression": "",
+                "Description": "",
+                "MaxLength": 0,
+                "Name": "c1",
+                "PolicyTags": null,
+                "Precision": 0,
+                "Repeated": false,
+                "Required": true,
+                "Scale": 0,
+                "Schema": null,
+                "Type": "TIMESTAMP"
+              },
+              {
+                "Collation": "",
+                "DefaultValueExpression": "",
+                "Description": "",
+                "MaxLength": 0,
+                "Name": "c2",
+                "PolicyTags": null,
+                "Precision": 0,
+                "Repeated": false,
+                "Required": false,
+                "Scale": 0,
+                "Schema": null,
+                "Type": "INTEGER"
+              },
+              {
+                "Collation": "",
+                "DefaultValueExpression": "",
+                "Description": "",
+                "MaxLength": 0,
+                "Name": "c3",
+                "PolicyTags": null,
+                "Precision": 0,
+                "Repeated": false,
+                "Required": true,
+                "Scale": 0,
+                "Schema": null,
+                "Type": "STRING"
+              }
+            ],
+            "SourceFormat": "NEWLINE_DELIMITED_JSON",
+            "SourceURIs": [
+              "gs://estuary-bigquery-test/1987f468-d4d8-4592-a77e-ad6dec8909a7/f22ea73b-c6f5-4932-a225-6588cb681207"
+            ]
+          },
+          "Files": [
+            "1987f468-d4d8-4592-a77e-ad6dec8909a7/f22ea73b-c6f5-4932-a225-6588cb681207"
+          ],
+          "JobID": "e34bc439-b085-4ede-86ae-9e116bb906fa",
+          "Query": "INSERT INTO `estuary-theatre`.testing.duplicate_keys_delta_exclude_flow_doc (id, flow_published_at, int, str)\nSELECT c0, c1, c2, c3 FROM flow_temp_table_3;\n",
+          "Table": "`estuary-theatre`.testing.duplicate_keys_delta_exclude_flow_doc",
+          "TempTableName": "flow_temp_table_3"
+        },
+        "estuary-theatre%2Ftesting%2Fduplicate_keys_standard": {
+          "Bucket": "estuary-bigquery-test",
+          "EDC": {
+            "AutoDetect": false,
+            "Compression": "GZIP",
+            "ConnectionID": "",
+            "DecimalTargetTypes": null,
+            "HivePartitioningOptions": null,
+            "IgnoreUnknownValues": false,
+            "MaxBadRecords": 0,
+            "Options": null,
+            "ReferenceFileSchemaURI": "",
+            "Schema": [
+              {
+                "Collation": "",
+                "DefaultValueExpression": "",
+                "Description": "",
+                "MaxLength": 0,
+                "Name": "c0",
+                "PolicyTags": null,
+                "Precision": 0,
+                "Repeated": false,
+                "Required": true,
+                "Scale": 0,
+                "Schema": null,
+                "Type": "INTEGER"
+              },
+              {
+                "Collation": "",
+                "DefaultValueExpression": "",
+                "Description": "",
+                "MaxLength": 0,
+                "Name": "c1",
+                "PolicyTags": null,
+                "Precision": 0,
+                "Repeated": false,
+                "Required": true,
+                "Scale": 0,
+                "Schema": null,
+                "Type": "TIMESTAMP"
+              },
+              {
+                "Collation": "",
+                "DefaultValueExpression": "",
+                "Description": "",
+                "MaxLength": 0,
+                "Name": "c2",
+                "PolicyTags": null,
+                "Precision": 0,
+                "Repeated": false,
+                "Required": false,
+                "Scale": 0,
+                "Schema": null,
+                "Type": "INTEGER"
+              },
+              {
+                "Collation": "",
+                "DefaultValueExpression": "",
+                "Description": "",
+                "MaxLength": 0,
+                "Name": "c3",
+                "PolicyTags": null,
+                "Precision": 0,
+                "Repeated": false,
+                "Required": true,
+                "Scale": 0,
+                "Schema": null,
+                "Type": "STRING"
+              },
+              {
+                "Collation": "",
+                "DefaultValueExpression": "",
+                "Description": "",
+                "MaxLength": 0,
+                "Name": "c4",
+                "PolicyTags": null,
+                "Precision": 0,
+                "Repeated": false,
+                "Required": true,
+                "Scale": 0,
+                "Schema": null,
+                "Type": "STRING"
+              }
+            ],
+            "SourceFormat": "NEWLINE_DELIMITED_JSON",
+            "SourceURIs": [
+              "gs://estuary-bigquery-test/377b7c04-9262-4b04-821b-057b9993b0af/fda71677-7c6a-4a5c-8acf-de734637f02b"
+            ]
+          },
+          "Files": [
+            "377b7c04-9262-4b04-821b-057b9993b0af/fda71677-7c6a-4a5c-8acf-de734637f02b"
+          ],
+          "JobID": "57eecc7a-bb91-47f8-a43f-a338c24e0aaa",
+          "Query": "MERGE INTO `estuary-theatre`.testing.duplicate_keys_standard AS l\nUSING flow_temp_table_1 AS r\nON l.id = r.c0\nWHEN MATCHED AND r.c4 IS NULL THEN\n\tDELETE\nWHEN MATCHED THEN\n\tUPDATE SET l.flow_published_at = r.c1, l.int = r.c2, l.str = r.c3, l.flow_document = r.c4\nWHEN NOT MATCHED THEN\n\tINSERT (id, flow_published_at, int, str, flow_document)\n\tVALUES (r.c0, r.c1, r.c2, r.c3, r.c4);\n",
+          "Table": "`estuary-theatre`.testing.duplicate_keys_standard",
           "TempTableName": "flow_temp_table_1"
         },
         "estuary-theatre%2Ftesting%2Fformatted_strings": {
@@ -279,15 +863,16 @@
             ],
             "SourceFormat": "NEWLINE_DELIMITED_JSON",
             "SourceURIs": [
-              "gs://estuary-bigquery-test/318d841f-cb22-45c7-a12b-5bf600d404d7/0847333a-13b8-4085-a62e-28c42d97a795"
+              "gs://estuary-bigquery-test/bab7a39e-b2a9-4653-a24f-88b3e29916f6/2b6e3904-e0cd-4cea-9e78-e4682fbebbee"
             ]
           },
           "Files": [
-            "318d841f-cb22-45c7-a12b-5bf600d404d7/0847333a-13b8-4085-a62e-28c42d97a795"
+            "bab7a39e-b2a9-4653-a24f-88b3e29916f6/2b6e3904-e0cd-4cea-9e78-e4682fbebbee"
           ],
-          "Query": "MERGE INTO `estuary-theatre`.testing.formatted_strings AS l\nUSING flow_temp_table_3 AS r\nON l.id = r.c0\nWHEN MATCHED AND r.c9 IS NULL THEN\n\tDELETE\nWHEN MATCHED THEN\n\tUPDATE SET l.date = r.c1, l.datetime = r.c2, l.flow_published_at = r.c3, l.int_and_str = r.c4, l.int_str = r.c5, l.num_and_str = r.c6, l.num_str = r.c7, l.time = r.c8, l.flow_document = r.c9\nWHEN NOT MATCHED THEN\n\tINSERT (id, date, datetime, flow_published_at, int_and_str, int_str, num_and_str, num_str, time, flow_document)\n\tVALUES (r.c0, r.c1, r.c2, r.c3, r.c4, r.c5, r.c6, r.c7, r.c8, r.c9);\n",
+          "JobID": "2b56b2e3-6bbc-4a02-829e-65479c661349",
+          "Query": "MERGE INTO `estuary-theatre`.testing.formatted_strings AS l\nUSING flow_temp_table_5 AS r\nON l.id = r.c0\nWHEN MATCHED AND r.c9 IS NULL THEN\n\tDELETE\nWHEN MATCHED THEN\n\tUPDATE SET l.date = r.c1, l.datetime = r.c2, l.flow_published_at = r.c3, l.int_and_str = r.c4, l.int_str = r.c5, l.num_and_str = r.c6, l.num_str = r.c7, l.time = r.c8, l.flow_document = r.c9\nWHEN NOT MATCHED THEN\n\tINSERT (id, date, datetime, flow_published_at, int_and_str, int_str, num_and_str, num_str, time, flow_document)\n\tVALUES (r.c0, r.c1, r.c2, r.c3, r.c4, r.c5, r.c6, r.c7, r.c8, r.c9);\n",
           "Table": "`estuary-theatre`.testing.formatted_strings",
-          "TempTableName": "flow_temp_table_3"
+          "TempTableName": "flow_temp_table_5"
         },
         "estuary-theatre%2Ftesting%2Fmultiple_types": {
           "Bucket": "estuary-bigquery-test",
@@ -445,15 +1030,16 @@
             ],
             "SourceFormat": "NEWLINE_DELIMITED_JSON",
             "SourceURIs": [
-              "gs://estuary-bigquery-test/8a3dfc1f-4d00-4900-81b7-50b38d1caa58/6e6aa2b6-0edb-4bb4-895b-97e2fdb1fc68"
+              "gs://estuary-bigquery-test/e7f5808c-fee5-44b7-9e95-b430b5927660/2a0a48c1-6f13-464a-b119-6509b6bf6860"
             ]
           },
           "Files": [
-            "8a3dfc1f-4d00-4900-81b7-50b38d1caa58/6e6aa2b6-0edb-4bb4-895b-97e2fdb1fc68"
+            "e7f5808c-fee5-44b7-9e95-b430b5927660/2a0a48c1-6f13-464a-b119-6509b6bf6860"
           ],
-          "Query": "MERGE INTO `estuary-theatre`.testing.multiple_types AS l\nUSING flow_temp_table_2 AS r\nON l.id = r.c0\nWHEN MATCHED AND r.c9 IS NULL THEN\n\tDELETE\nWHEN MATCHED THEN\n\tUPDATE SET l.array_int = r.c1, l.bool_field = r.c2, l.float_field = r.c3, l.flow_published_at = r.c4, l.multiple = r.c5, l.nested = r.c6, l.nullable_int = r.c7, l.str_field = r.c8, l.flow_document = r.c9\nWHEN NOT MATCHED THEN\n\tINSERT (id, array_int, bool_field, float_field, flow_published_at, multiple, nested, nullable_int, str_field, flow_document)\n\tVALUES (r.c0, r.c1, r.c2, r.c3, r.c4, r.c5, r.c6, r.c7, r.c8, r.c9);\n",
+          "JobID": "9c86fd98-87c7-4111-bd49-e8fc3ccb8a23",
+          "Query": "MERGE INTO `estuary-theatre`.testing.multiple_types AS l\nUSING flow_temp_table_4 AS r\nON l.id = r.c0\nWHEN MATCHED AND r.c9 IS NULL THEN\n\tDELETE\nWHEN MATCHED THEN\n\tUPDATE SET l.array_int = r.c1, l.bool_field = r.c2, l.float_field = r.c3, l.flow_published_at = r.c4, l.multiple = r.c5, l.nested = r.c6, l.nullable_int = r.c7, l.str_field = r.c8, l.flow_document = r.c9\nWHEN NOT MATCHED THEN\n\tINSERT (id, array_int, bool_field, float_field, flow_published_at, multiple, nested, nullable_int, str_field, flow_document)\n\tVALUES (r.c0, r.c1, r.c2, r.c3, r.c4, r.c5, r.c6, r.c7, r.c8, r.c9);\n",
           "Table": "`estuary-theatre`.testing.multiple_types",
-          "TempTableName": "flow_temp_table_2"
+          "TempTableName": "flow_temp_table_4"
         },
         "estuary-theatre%2Ftesting%2Fsimple": {
           "Bucket": "estuary-bigquery-test",
@@ -527,12 +1113,13 @@
             ],
             "SourceFormat": "NEWLINE_DELIMITED_JSON",
             "SourceURIs": [
-              "gs://estuary-bigquery-test/5d1c1e98-105a-49ff-bc4e-f2bca5f6188f/92f28d24-ba84-4234-aeda-6062254b75c4"
+              "gs://estuary-bigquery-test/39b90a17-f254-4a11-b4b4-4794b83a1914/eb538bfb-2292-4165-94f7-b87969824e77"
             ]
           },
           "Files": [
-            "5d1c1e98-105a-49ff-bc4e-f2bca5f6188f/92f28d24-ba84-4234-aeda-6062254b75c4"
+            "39b90a17-f254-4a11-b4b4-4794b83a1914/eb538bfb-2292-4165-94f7-b87969824e77"
           ],
+          "JobID": "692b114e-9b94-4bf9-aede-c9f5e1866ec0",
           "Query": "MERGE INTO `estuary-theatre`.testing.simple AS l\nUSING flow_temp_table_0 AS r\nON l.id = r.c0\nWHEN MATCHED AND r.c3 IS NULL THEN\n\tDELETE\nWHEN MATCHED THEN\n\tUPDATE SET l.canary = r.c1, l.flow_published_at = r.c2, l.flow_document = r.c3\nWHEN NOT MATCHED THEN\n\tINSERT (id, canary, flow_published_at, flow_document)\n\tVALUES (r.c0, r.c1, r.c2, r.c3);\n",
           "Table": "`estuary-theatre`.testing.simple",
           "TempTableName": "flow_temp_table_0"
@@ -546,7 +1133,9 @@
     "state": {
       "mergePatch": true,
       "updated": {
-        "estuary-theatre%2Ftesting%2Fduplicate_keys": null,
+        "estuary-theatre%2Ftesting%2Fduplicate_keys_delta": null,
+        "estuary-theatre%2Ftesting%2Fduplicate_keys_delta_exclude_flow_doc": null,
+        "estuary-theatre%2Ftesting%2Fduplicate_keys_standard": null,
         "estuary-theatre%2Ftesting%2Fformatted_strings": null,
         "estuary-theatre%2Ftesting%2Fmultiple_types": null,
         "estuary-theatre%2Ftesting%2Fsimple": null
@@ -621,7 +1210,7 @@
 }
 {
   "loaded": {
-    "binding": 2,
+    "binding": 4,
     "doc": {
       "_meta": {
         "uuid": "5fc54530-20e1-11ee-990b-ffd12dfcd47f"
@@ -648,7 +1237,7 @@
 }
 {
   "loaded": {
-    "binding": 2,
+    "binding": 4,
     "doc": {
       "_meta": {
         "uuid": "64b39506-20e1-11ee-990b-ffd12dfcd47f"
@@ -673,7 +1262,7 @@
 }
 {
   "loaded": {
-    "binding": 2,
+    "binding": 4,
     "doc": {
       "_meta": {
         "uuid": "6acb8444-20e1-11ee-990b-ffd12dfcd47f"
@@ -696,7 +1285,7 @@
 }
 {
   "loaded": {
-    "binding": 2,
+    "binding": 4,
     "doc": {
       "_meta": {
         "uuid": "6ff68e0a-20e1-11ee-990b-ffd12dfcd47f"
@@ -718,7 +1307,7 @@
 }
 {
   "loaded": {
-    "binding": 2,
+    "binding": 4,
     "doc": {
       "_meta": {
         "uuid": "75679e4c-20e1-11ee-990b-ffd12dfcd47f"
@@ -739,6 +1328,140 @@
   }
 }
 {
+  "loaded": {
+    "binding": 5,
+    "doc": {
+      "_meta": {
+        "uuid": "b1e13a0e-20e1-11ee-990b-ffd12dfcd47f"
+      },
+      "date": "0000-01-01",
+      "datetime": "0000-01-01T00:00:00Z",
+      "id": 1,
+      "int_and_str": 1,
+      "int_str": "10",
+      "num_and_str": 1.1,
+      "num_str": "10.1",
+      "time": "00:00:00Z"
+    }
+  }
+}
+{
+  "loaded": {
+    "binding": 5,
+    "doc": {
+      "_meta": {
+        "uuid": "b81a9bf4-20e1-11ee-990b-ffd12dfcd47f"
+      },
+      "date": "1999-02-02",
+      "datetime": "1999-02-02T14:20:12.33Z",
+      "id": 2,
+      "int_and_str": 2,
+      "int_str": "20",
+      "num_and_str": 2.1,
+      "num_str": "20.1",
+      "time": "14:20:12.33Z"
+    }
+  }
+}
+{
+  "loaded": {
+    "binding": 5,
+    "doc": {
+      "_meta": {
+        "uuid": "c02bd79a-20e1-11ee-990b-ffd12dfcd47f"
+      },
+      "date": "9999-12-31",
+      "datetime": "9999-12-31T23:59:59Z",
+      "id": 5,
+      "int_and_str": "5",
+      "int_str": "50",
+      "num_and_str": "5.1",
+      "num_str": "50.1",
+      "time": "23:59:59Z"
+    }
+  }
+}
+{
+  "loaded": {
+    "binding": 5,
+    "doc": {
+      "_meta": {
+        "uuid": "c02bd79a-20e1-11ee-990b-ffd12dfcd47f"
+      },
+      "id": 10,
+      "num_str": "-Infinity"
+    }
+  }
+}
+{
+  "loaded": {
+    "binding": 5,
+    "doc": {
+      "_meta": {
+        "uuid": "c02bd79a-20e1-11ee-990b-ffd12dfcd47f"
+      },
+      "id": 8,
+      "num_str": "NaN"
+    }
+  }
+}
+{
+  "loaded": {
+    "binding": 5,
+    "doc": {
+      "_meta": {
+        "uuid": "c02bd79a-20e1-11ee-990b-ffd12dfcd47f"
+      },
+      "id": 9,
+      "num_str": "Infinity"
+    }
+  }
+}
+{
+  "loaded": {
+    "doc": {
+      "_meta": {
+        "uuid": "134a1456-20e1-11ee-990b-ffd12dfcd47f"
+      },
+      "canary": "pieced",
+      "id": 7
+    }
+  }
+}
+{
+  "loaded": {
+    "doc": {
+      "_meta": {
+        "uuid": "1b953992-20e1-11ee-990b-ffd12dfcd47f"
+      },
+      "canary": "roaches",
+      "id": 8
+    }
+  }
+}
+{
+  "loaded": {
+    "doc": {
+      "_meta": {
+        "uuid": "7e2df422-20e1-11ee-990b-ffd12dfcd47f"
+      },
+      "canary": "devilish",
+      "id": 9
+    }
+  }
+}
+{
+  "loaded": {
+    "doc": {
+      "_meta": {
+        "uuid": "8458b580-20e1-11ee-990b-ffd12dfcd47f"
+      },
+      "canary": "glucose's",
+      "id": 10
+    }
+  }
+}
+{
   "flushed": {}
 }
 {
@@ -746,7 +1469,7 @@
     "state": {
       "mergePatch": true,
       "updated": {
-        "estuary-theatre%2Ftesting%2Fduplicate_keys": {
+        "estuary-theatre%2Ftesting%2Fduplicate_keys_delta": {
           "Bucket": "estuary-bigquery-test",
           "EDC": {
             "AutoDetect": false,
@@ -832,14 +1555,195 @@
             ],
             "SourceFormat": "NEWLINE_DELIMITED_JSON",
             "SourceURIs": [
-              "gs://estuary-bigquery-test/30c6ff92-234d-44d9-99d5-e9d3ac8db4ad/09a1fd53-841e-4caf-af89-a840825e928c"
+              "gs://estuary-bigquery-test/5d4e4b04-3e9f-46f3-b22a-a494d4e99462/3358e6fa-f1f1-471f-95c4-9ea24a2f7d5d"
             ]
           },
           "Files": [
-            "30c6ff92-234d-44d9-99d5-e9d3ac8db4ad/09a1fd53-841e-4caf-af89-a840825e928c"
+            "5d4e4b04-3e9f-46f3-b22a-a494d4e99462/3358e6fa-f1f1-471f-95c4-9ea24a2f7d5d"
           ],
-          "Query": "MERGE INTO `estuary-theatre`.testing.duplicate_keys AS l\nUSING flow_temp_table_1 AS r\nON l.id = r.c0\nWHEN MATCHED AND r.c4 IS NULL THEN\n\tDELETE\nWHEN MATCHED THEN\n\tUPDATE SET l.flow_published_at = r.c1, l.int = r.c2, l.str = r.c3, l.flow_document = r.c4\nWHEN NOT MATCHED THEN\n\tINSERT (id, flow_published_at, int, str, flow_document)\n\tVALUES (r.c0, r.c1, r.c2, r.c3, r.c4);\n",
-          "Table": "`estuary-theatre`.testing.duplicate_keys",
+          "JobID": "c190e225-c572-4008-8c5f-bb00beb9ed58",
+          "Query": "INSERT INTO `estuary-theatre`.testing.duplicate_keys_delta (id, flow_published_at, int, str, flow_document)\nSELECT c0, c1, c2, c3, c4 FROM flow_temp_table_2;\n",
+          "Table": "`estuary-theatre`.testing.duplicate_keys_delta",
+          "TempTableName": "flow_temp_table_2"
+        },
+        "estuary-theatre%2Ftesting%2Fduplicate_keys_delta_exclude_flow_doc": {
+          "Bucket": "estuary-bigquery-test",
+          "EDC": {
+            "AutoDetect": false,
+            "Compression": "GZIP",
+            "ConnectionID": "",
+            "DecimalTargetTypes": null,
+            "HivePartitioningOptions": null,
+            "IgnoreUnknownValues": false,
+            "MaxBadRecords": 0,
+            "Options": null,
+            "ReferenceFileSchemaURI": "",
+            "Schema": [
+              {
+                "Collation": "",
+                "DefaultValueExpression": "",
+                "Description": "",
+                "MaxLength": 0,
+                "Name": "c0",
+                "PolicyTags": null,
+                "Precision": 0,
+                "Repeated": false,
+                "Required": true,
+                "Scale": 0,
+                "Schema": null,
+                "Type": "INTEGER"
+              },
+              {
+                "Collation": "",
+                "DefaultValueExpression": "",
+                "Description": "",
+                "MaxLength": 0,
+                "Name": "c1",
+                "PolicyTags": null,
+                "Precision": 0,
+                "Repeated": false,
+                "Required": true,
+                "Scale": 0,
+                "Schema": null,
+                "Type": "TIMESTAMP"
+              },
+              {
+                "Collation": "",
+                "DefaultValueExpression": "",
+                "Description": "",
+                "MaxLength": 0,
+                "Name": "c2",
+                "PolicyTags": null,
+                "Precision": 0,
+                "Repeated": false,
+                "Required": false,
+                "Scale": 0,
+                "Schema": null,
+                "Type": "INTEGER"
+              },
+              {
+                "Collation": "",
+                "DefaultValueExpression": "",
+                "Description": "",
+                "MaxLength": 0,
+                "Name": "c3",
+                "PolicyTags": null,
+                "Precision": 0,
+                "Repeated": false,
+                "Required": true,
+                "Scale": 0,
+                "Schema": null,
+                "Type": "STRING"
+              }
+            ],
+            "SourceFormat": "NEWLINE_DELIMITED_JSON",
+            "SourceURIs": [
+              "gs://estuary-bigquery-test/1987f468-d4d8-4592-a77e-ad6dec8909a7/faec2c9d-caef-41b2-b194-887313c23a8d"
+            ]
+          },
+          "Files": [
+            "1987f468-d4d8-4592-a77e-ad6dec8909a7/faec2c9d-caef-41b2-b194-887313c23a8d"
+          ],
+          "JobID": "e9ec9da7-ca56-4801-97e9-ecf1104b253f",
+          "Query": "INSERT INTO `estuary-theatre`.testing.duplicate_keys_delta_exclude_flow_doc (id, flow_published_at, int, str)\nSELECT c0, c1, c2, c3 FROM flow_temp_table_3;\n",
+          "Table": "`estuary-theatre`.testing.duplicate_keys_delta_exclude_flow_doc",
+          "TempTableName": "flow_temp_table_3"
+        },
+        "estuary-theatre%2Ftesting%2Fduplicate_keys_standard": {
+          "Bucket": "estuary-bigquery-test",
+          "EDC": {
+            "AutoDetect": false,
+            "Compression": "GZIP",
+            "ConnectionID": "",
+            "DecimalTargetTypes": null,
+            "HivePartitioningOptions": null,
+            "IgnoreUnknownValues": false,
+            "MaxBadRecords": 0,
+            "Options": null,
+            "ReferenceFileSchemaURI": "",
+            "Schema": [
+              {
+                "Collation": "",
+                "DefaultValueExpression": "",
+                "Description": "",
+                "MaxLength": 0,
+                "Name": "c0",
+                "PolicyTags": null,
+                "Precision": 0,
+                "Repeated": false,
+                "Required": true,
+                "Scale": 0,
+                "Schema": null,
+                "Type": "INTEGER"
+              },
+              {
+                "Collation": "",
+                "DefaultValueExpression": "",
+                "Description": "",
+                "MaxLength": 0,
+                "Name": "c1",
+                "PolicyTags": null,
+                "Precision": 0,
+                "Repeated": false,
+                "Required": true,
+                "Scale": 0,
+                "Schema": null,
+                "Type": "TIMESTAMP"
+              },
+              {
+                "Collation": "",
+                "DefaultValueExpression": "",
+                "Description": "",
+                "MaxLength": 0,
+                "Name": "c2",
+                "PolicyTags": null,
+                "Precision": 0,
+                "Repeated": false,
+                "Required": false,
+                "Scale": 0,
+                "Schema": null,
+                "Type": "INTEGER"
+              },
+              {
+                "Collation": "",
+                "DefaultValueExpression": "",
+                "Description": "",
+                "MaxLength": 0,
+                "Name": "c3",
+                "PolicyTags": null,
+                "Precision": 0,
+                "Repeated": false,
+                "Required": true,
+                "Scale": 0,
+                "Schema": null,
+                "Type": "STRING"
+              },
+              {
+                "Collation": "",
+                "DefaultValueExpression": "",
+                "Description": "",
+                "MaxLength": 0,
+                "Name": "c4",
+                "PolicyTags": null,
+                "Precision": 0,
+                "Repeated": false,
+                "Required": true,
+                "Scale": 0,
+                "Schema": null,
+                "Type": "STRING"
+              }
+            ],
+            "SourceFormat": "NEWLINE_DELIMITED_JSON",
+            "SourceURIs": [
+              "gs://estuary-bigquery-test/377b7c04-9262-4b04-821b-057b9993b0af/4b056874-ef16-49d3-8344-58a9a0e4d789"
+            ]
+          },
+          "Files": [
+            "377b7c04-9262-4b04-821b-057b9993b0af/4b056874-ef16-49d3-8344-58a9a0e4d789"
+          ],
+          "JobID": "15a4ecdb-a079-4cc2-bd58-e9b18a083b01",
+          "Query": "MERGE INTO `estuary-theatre`.testing.duplicate_keys_standard AS l\nUSING flow_temp_table_1 AS r\nON l.id = r.c0\nWHEN MATCHED AND r.c4 IS NULL THEN\n\tDELETE\nWHEN MATCHED THEN\n\tUPDATE SET l.flow_published_at = r.c1, l.int = r.c2, l.str = r.c3, l.flow_document = r.c4\nWHEN NOT MATCHED THEN\n\tINSERT (id, flow_published_at, int, str, flow_document)\n\tVALUES (r.c0, r.c1, r.c2, r.c3, r.c4);\n",
+          "Table": "`estuary-theatre`.testing.duplicate_keys_standard",
           "TempTableName": "flow_temp_table_1"
         },
         "estuary-theatre%2Ftesting%2Fformatted_strings": {
@@ -998,15 +1902,16 @@
             ],
             "SourceFormat": "NEWLINE_DELIMITED_JSON",
             "SourceURIs": [
-              "gs://estuary-bigquery-test/318d841f-cb22-45c7-a12b-5bf600d404d7/36954c97-1267-4080-8df4-d295e96dfac8"
+              "gs://estuary-bigquery-test/bab7a39e-b2a9-4653-a24f-88b3e29916f6/e048c71e-5557-4da2-b23b-c5c1e4506dc0"
             ]
           },
           "Files": [
-            "318d841f-cb22-45c7-a12b-5bf600d404d7/36954c97-1267-4080-8df4-d295e96dfac8"
+            "bab7a39e-b2a9-4653-a24f-88b3e29916f6/e048c71e-5557-4da2-b23b-c5c1e4506dc0"
           ],
-          "Query": "MERGE INTO `estuary-theatre`.testing.formatted_strings AS l\nUSING flow_temp_table_3 AS r\nON l.id = r.c0\nWHEN MATCHED AND r.c9 IS NULL THEN\n\tDELETE\nWHEN MATCHED THEN\n\tUPDATE SET l.date = r.c1, l.datetime = r.c2, l.flow_published_at = r.c3, l.int_and_str = r.c4, l.int_str = r.c5, l.num_and_str = r.c6, l.num_str = r.c7, l.time = r.c8, l.flow_document = r.c9\nWHEN NOT MATCHED THEN\n\tINSERT (id, date, datetime, flow_published_at, int_and_str, int_str, num_and_str, num_str, time, flow_document)\n\tVALUES (r.c0, r.c1, r.c2, r.c3, r.c4, r.c5, r.c6, r.c7, r.c8, r.c9);\n",
+          "JobID": "6ad475b3-9994-4216-b892-dadf34ea0aa4",
+          "Query": "MERGE INTO `estuary-theatre`.testing.formatted_strings AS l\nUSING flow_temp_table_5 AS r\nON l.id = r.c0\nWHEN MATCHED AND r.c9 IS NULL THEN\n\tDELETE\nWHEN MATCHED THEN\n\tUPDATE SET l.date = r.c1, l.datetime = r.c2, l.flow_published_at = r.c3, l.int_and_str = r.c4, l.int_str = r.c5, l.num_and_str = r.c6, l.num_str = r.c7, l.time = r.c8, l.flow_document = r.c9\nWHEN NOT MATCHED THEN\n\tINSERT (id, date, datetime, flow_published_at, int_and_str, int_str, num_and_str, num_str, time, flow_document)\n\tVALUES (r.c0, r.c1, r.c2, r.c3, r.c4, r.c5, r.c6, r.c7, r.c8, r.c9);\n",
           "Table": "`estuary-theatre`.testing.formatted_strings",
-          "TempTableName": "flow_temp_table_3"
+          "TempTableName": "flow_temp_table_5"
         },
         "estuary-theatre%2Ftesting%2Fmultiple_types": {
           "Bucket": "estuary-bigquery-test",
@@ -1164,15 +2069,16 @@
             ],
             "SourceFormat": "NEWLINE_DELIMITED_JSON",
             "SourceURIs": [
-              "gs://estuary-bigquery-test/8a3dfc1f-4d00-4900-81b7-50b38d1caa58/4c735b7a-aaf1-4af3-a03d-627485265367"
+              "gs://estuary-bigquery-test/e7f5808c-fee5-44b7-9e95-b430b5927660/5af3a503-cfbf-49cc-b986-132dcff9989f"
             ]
           },
           "Files": [
-            "8a3dfc1f-4d00-4900-81b7-50b38d1caa58/4c735b7a-aaf1-4af3-a03d-627485265367"
+            "e7f5808c-fee5-44b7-9e95-b430b5927660/5af3a503-cfbf-49cc-b986-132dcff9989f"
           ],
-          "Query": "MERGE INTO `estuary-theatre`.testing.multiple_types AS l\nUSING flow_temp_table_2 AS r\nON l.id = r.c0\nWHEN MATCHED AND r.c9 IS NULL THEN\n\tDELETE\nWHEN MATCHED THEN\n\tUPDATE SET l.array_int = r.c1, l.bool_field = r.c2, l.float_field = r.c3, l.flow_published_at = r.c4, l.multiple = r.c5, l.nested = r.c6, l.nullable_int = r.c7, l.str_field = r.c8, l.flow_document = r.c9\nWHEN NOT MATCHED THEN\n\tINSERT (id, array_int, bool_field, float_field, flow_published_at, multiple, nested, nullable_int, str_field, flow_document)\n\tVALUES (r.c0, r.c1, r.c2, r.c3, r.c4, r.c5, r.c6, r.c7, r.c8, r.c9);\n",
+          "JobID": "fce92299-2321-4781-9482-5626f6309c56",
+          "Query": "MERGE INTO `estuary-theatre`.testing.multiple_types AS l\nUSING flow_temp_table_4 AS r\nON l.id = r.c0\nWHEN MATCHED AND r.c9 IS NULL THEN\n\tDELETE\nWHEN MATCHED THEN\n\tUPDATE SET l.array_int = r.c1, l.bool_field = r.c2, l.float_field = r.c3, l.flow_published_at = r.c4, l.multiple = r.c5, l.nested = r.c6, l.nullable_int = r.c7, l.str_field = r.c8, l.flow_document = r.c9\nWHEN NOT MATCHED THEN\n\tINSERT (id, array_int, bool_field, float_field, flow_published_at, multiple, nested, nullable_int, str_field, flow_document)\n\tVALUES (r.c0, r.c1, r.c2, r.c3, r.c4, r.c5, r.c6, r.c7, r.c8, r.c9);\n",
           "Table": "`estuary-theatre`.testing.multiple_types",
-          "TempTableName": "flow_temp_table_2"
+          "TempTableName": "flow_temp_table_4"
         },
         "estuary-theatre%2Ftesting%2Fsimple": {
           "Bucket": "estuary-bigquery-test",
@@ -1246,12 +2152,13 @@
             ],
             "SourceFormat": "NEWLINE_DELIMITED_JSON",
             "SourceURIs": [
-              "gs://estuary-bigquery-test/5d1c1e98-105a-49ff-bc4e-f2bca5f6188f/27adda32-3703-4989-b31c-b1c2efba9ef8"
+              "gs://estuary-bigquery-test/39b90a17-f254-4a11-b4b4-4794b83a1914/7a609f18-e815-49c1-9ece-4374cc6c15e2"
             ]
           },
           "Files": [
-            "5d1c1e98-105a-49ff-bc4e-f2bca5f6188f/27adda32-3703-4989-b31c-b1c2efba9ef8"
+            "39b90a17-f254-4a11-b4b4-4794b83a1914/7a609f18-e815-49c1-9ece-4374cc6c15e2"
           ],
+          "JobID": "e3a694b0-d0b1-4dcf-a1c4-c48394e9be88",
           "Query": "MERGE INTO `estuary-theatre`.testing.simple AS l\nUSING flow_temp_table_0 AS r\nON l.id = r.c0\nWHEN MATCHED AND r.c3 IS NULL THEN\n\tDELETE\nWHEN MATCHED THEN\n\tUPDATE SET l.canary = r.c1, l.flow_published_at = r.c2, l.flow_document = r.c3\nWHEN NOT MATCHED THEN\n\tINSERT (id, canary, flow_published_at, flow_document)\n\tVALUES (r.c0, r.c1, r.c2, r.c3);\n",
           "Table": "`estuary-theatre`.testing.simple",
           "TempTableName": "flow_temp_table_0"
@@ -1265,7 +2172,9 @@
     "state": {
       "mergePatch": true,
       "updated": {
-        "estuary-theatre%2Ftesting%2Fduplicate_keys": null,
+        "estuary-theatre%2Ftesting%2Fduplicate_keys_delta": null,
+        "estuary-theatre%2Ftesting%2Fduplicate_keys_delta_exclude_flow_doc": null,
+        "estuary-theatre%2Ftesting%2Fduplicate_keys_standard": null,
         "estuary-theatre%2Ftesting%2Fformatted_strings": null,
         "estuary-theatre%2Ftesting%2Fmultiple_types": null,
         "estuary-theatre%2Ftesting%2Fsimple": null
@@ -1273,281 +2182,891 @@
     }
   }
 }
-[
-  1,
-  "amputation's",
-  "2023-07-12T18:18:11.537199Z",
-  "{\"_meta\":{\"uuid\":\"75c06bd6-20e0-11ee-990b-ffd12dfcd47f\"},\"canary\":\"amputation's\",\"id\":1}"
-]
-[
-  2,
-  "armament's",
-  "2023-07-12T18:18:24.946758Z",
-  "{\"_meta\":{\"uuid\":\"7dbe8ebc-20e0-11ee-990b-ffd12dfcd47f\"},\"canary\":\"armament's\",\"id\":2}"
-]
-[
-  3,
-  "splatters",
-  "2023-07-12T18:18:48.441281Z",
-  "{\"_meta\":{\"uuid\":\"8bbf898a-20e0-11ee-990b-ffd12dfcd47f\"},\"canary\":\"splatters\",\"id\":3}"
-]
-[
-  4,
-  "strengthen",
-  "2023-07-12T18:19:15.034186Z",
-  "{\"_meta\":{\"uuid\":\"9b994ae4-20e0-11ee-990b-ffd12dfcd47f\"},\"canary\":\"strengthen\",\"id\":4}"
-]
-[
-  5,
-  "Kringle's",
-  "2023-07-12T18:19:57.165604Z",
-  "{\"_meta\":{\"uuid\":\"b4b60968-20e0-11ee-990b-ffd12dfcd47f\"},\"canary\":\"Kringle's\",\"id\":5}"
-]
-[
-  6,
-  "grosbeak's",
-  "2023-07-12T18:20:10.962631Z",
-  "{\"_meta\":{\"uuid\":\"bcef4bc6-20e0-11ee-990b-ffd12dfcd47f\"},\"canary\":\"grosbeak's\",\"id\":6}"
-]
-[
-  7,
-  "pieced",
-  "2023-07-12T18:22:35.841647Z",
-  "{\"_meta\":{\"uuid\":\"134a1456-20e1-11ee-990b-ffd12dfcd47f\"},\"canary\":\"pieced\",\"id\":7}"
-]
-[
-  8,
-  "roaches",
-  "2023-07-12T18:22:49.755893Z",
-  "{\"_meta\":{\"uuid\":\"1b953992-20e1-11ee-990b-ffd12dfcd47f\"},\"canary\":\"roaches\",\"id\":8}"
-]
-[
-  9,
-  "devilish",
-  "2023-07-12T18:25:35.173533Z",
-  "{\"_meta\":{\"uuid\":\"7e2df422-20e1-11ee-990b-ffd12dfcd47f\"},\"canary\":\"devilish\",\"id\":9}"
-]
-[
-  10,
-  "glucose's",
-  "2023-07-12T18:25:45.520064Z",
-  "{\"_meta\":{\"uuid\":\"8458b580-20e1-11ee-990b-ffd12dfcd47f\"},\"canary\":\"glucose's\",\"id\":10}"
-]
-[
-  1,
-  "2023-07-12T18:26:01.560712Z",
-  6,
-  "str 6",
-  "{\"_meta\":{\"uuid\":\"8de85150-20e1-11ee-990b-ffd12dfcd47f\"},\"id\":1,\"int\":6,\"str\":\"str 6\"}"
-]
-[
-  2,
-  "2023-07-12T18:26:14.215494Z",
-  7,
-  "str 7",
-  "{\"_meta\":{\"uuid\":\"957348bc-20e1-11ee-990b-ffd12dfcd47f\"},\"id\":2,\"int\":7,\"str\":\"str 7\"}"
-]
-[
-  3,
-  "2023-07-12T18:26:23.495167Z",
-  8,
-  "str 8",
-  "{\"_meta\":{\"uuid\":\"9afb3ff6-20e1-11ee-990b-ffd12dfcd47f\"},\"id\":3,\"int\":8,\"str\":\"str 8\"}"
-]
-[
-  4,
-  "2023-07-12T18:26:33.697752Z",
-  9,
-  "str 9",
-  "{\"_meta\":{\"uuid\":\"a1100a70-20e1-11ee-990b-ffd12dfcd47f\"},\"id\":4,\"int\":9,\"str\":\"str 9\"}"
-]
-[
-  5,
-  "2023-07-12T18:26:42.518724Z",
-  10,
-  "str 10",
-  "{\"_meta\":{\"uuid\":\"a65203a8-20e1-11ee-990b-ffd12dfcd47f\"},\"id\":5,\"int\":10,\"str\":\"str 10\"}"
-]
-[
-  1,
-  "[11,12]",
-  false,
-  1.1,
-  "2023-07-12T18:23:50.55822Z",
-  "1",
-  "{\"id\":\"i1\"}",
-  null,
-  "str1",
-  "{\"_meta\":{\"uuid\":\"3fd2ec78-20e1-11ee-990b-ffd12dfcd47f\"},\"array_int\":[11,12],\"bool_field\":false,\"float_field\":1.1,\"id\":1,\"multiple\":1,\"nested\":{\"id\":\"i1\"},\"nullable_int\":null,\"str_field\":\"str1\"}"
-]
-[
-  2,
-  "[21,22]",
-  true,
-  2.2,
-  "2023-07-12T18:24:09.67518Z",
-  "2.2",
-  "{\"id\":\"i2\"}",
-  2,
-  "str2",
-  "{\"_meta\":{\"uuid\":\"4b37f0b8-20e1-11ee-990b-ffd12dfcd47f\"},\"array_int\":[21,22],\"bool_field\":true,\"float_field\":2.2,\"id\":2,\"multiple\":2.2,\"nested\":{\"id\":\"i2\"},\"nullable_int\":2,\"str_field\":\"str2\"}"
-]
-[
-  3,
-  "[31,32]",
-  false,
-  3.3,
-  "2023-07-12T18:24:19.384Z",
-  "true",
-  "{\"id\":\"i3\"}",
-  null,
-  "str3",
-  "{\"_meta\":{\"uuid\":\"51016380-20e1-11ee-990b-ffd12dfcd47f\"},\"array_int\":[31,32],\"bool_field\":false,\"float_field\":3.3,\"id\":3,\"multiple\":true,\"nested\":{\"id\":\"i3\"},\"nullable_int\":null,\"str_field\":\"str3\"}"
-]
-[
-  4,
-  "[41,42]",
-  true,
-  4.4,
-  "2023-07-12T18:24:28.397025Z",
-  "false",
-  "{\"id\":\"i4\"}",
-  4,
-  "str4",
-  "{\"_meta\":{\"uuid\":\"5660aaca-20e1-11ee-990b-ffd12dfcd47f\"},\"array_int\":[41,42],\"bool_field\":true,\"float_field\":4.4,\"id\":4,\"multiple\":false,\"nested\":{\"id\":\"i4\"},\"nullable_int\":4,\"str_field\":\"str4\"}"
-]
-[
-  5,
-  "[51,52]",
-  false,
-  5.5,
-  "2023-07-12T18:24:36.112031Z",
-  "\"string five\"",
-  "{\"id\":\"i5\"}",
-  null,
-  "str5",
-  "{\"_meta\":{\"uuid\":\"5af9e236-20e1-11ee-990b-ffd12dfcd47f\"},\"array_int\":[51,52],\"bool_field\":false,\"float_field\":5.5,\"id\":5,\"multiple\":\"string five\",\"nested\":{\"id\":\"i5\"},\"nullable_int\":null,\"str_field\":\"str5\"}"
-]
-[
-  6,
-  "[61,62]",
-  true,
-  66.66,
-  "2023-07-12T18:28:27.194541Z",
-  "[\"one\",2,true]",
-  "{\"id\":\"i6\"}",
-  6,
-  "str6 v2",
-  "{\"_meta\":{\"uuid\":\"e4b646c2-20e1-11ee-990b-ffd12dfcd47f\"},\"array_int\":[61,62],\"bool_field\":true,\"float_field\":66.66,\"id\":6,\"multiple\":[\"one\",2,true],\"nested\":{\"id\":\"i6\"},\"nullable_int\":6,\"str_field\":\"str6 v2\"}"
-]
-[
-  7,
-  "[71,72]",
-  false,
-  77.77,
-  "2023-07-12T18:28:38.169062Z",
-  "{\"object\":\"seven\"}",
-  "{\"id\":\"i7\"}",
-  null,
-  "str7 v2",
-  "{\"_meta\":{\"uuid\":\"eb40dafc-20e1-11ee-990b-ffd12dfcd47f\"},\"array_int\":[71,72],\"bool_field\":false,\"float_field\":77.77,\"id\":7,\"multiple\":{\"object\":\"seven\"},\"nested\":{\"id\":\"i7\"},\"nullable_int\":null,\"str_field\":\"str7 v2\"}"
-]
-[
-  8,
-  "[81,82]",
-  true,
-  88.88,
-  "2023-07-12T18:28:48.465279Z",
-  "null",
-  "{\"id\":\"i8\"}",
-  8,
-  "str8 v2",
-  "{\"_meta\":{\"uuid\":\"f163eef6-20e1-11ee-990b-ffd12dfcd47f\"},\"array_int\":[81,82],\"bool_field\":true,\"float_field\":88.88,\"id\":8,\"multiple\":null,\"nested\":{\"id\":\"i8\"},\"nullable_int\":8,\"str_field\":\"str8 v2\"}"
-]
-[
-  9,
-  "[91,92]",
-  false,
-  99.99,
-  "2023-07-12T18:28:55.677252Z",
-  "null",
-  "{\"id\":\"i9\"}",
-  null,
-  "str9 v2",
-  "{\"_meta\":{\"uuid\":\"f5b064a8-20e1-11ee-990b-ffd12dfcd47f\"},\"array_int\":[91,92],\"bool_field\":false,\"float_field\":99.99,\"id\":9,\"nested\":{\"id\":\"i9\"},\"nullable_int\":null,\"str_field\":\"str9 v2\"}"
-]
-[
-  10,
-  "[1,2]",
-  true,
-  1010.101,
-  "2023-07-12T18:29:04.671352Z",
-  "null",
-  "{\"id\":\"i10\"}",
-  10,
-  "str10 v2",
-  "{\"_meta\":{\"uuid\":\"fb0cc8b0-20e1-11ee-990b-ffd12dfcd47f\"},\"array_int\":[1,2],\"bool_field\":true,\"float_field\":1010.101,\"id\":10,\"nested\":{\"id\":\"i10\"},\"nullable_int\":10,\"str_field\":\"str10 v2\"}"
-]
-[
-  1,
-  "0001-01-01",
-  "0001-01-01T00:00:00Z",
-  "2023-07-12T18:27:01.912219Z",
-  "1",
-  "10",
-  1.1,
-  10.1,
-  "00:00:00Z",
-  "{\"_meta\":{\"uuid\":\"b1e13a0e-20e1-11ee-990b-ffd12dfcd47f\"},\"date\":\"0000-01-01\",\"datetime\":\"0000-01-01T00:00:00Z\",\"id\":1,\"int_and_str\":1,\"int_str\":\"10\",\"num_and_str\":1.1,\"num_str\":\"10.1\",\"time\":\"00:00:00Z\"}"
-]
-[
-  2,
-  "1999-02-02",
-  "1999-02-02T14:20:12.33Z",
-  "2023-07-12T18:27:12.35461Z",
-  "2",
-  "20",
-  2.1,
-  20.1,
-  "14:20:12.33Z",
-  "{\"_meta\":{\"uuid\":\"b81a9bf4-20e1-11ee-990b-ffd12dfcd47f\"},\"date\":\"1999-02-02\",\"datetime\":\"1999-02-02T14:20:12.33Z\",\"id\":2,\"int_and_str\":2,\"int_str\":\"20\",\"num_and_str\":2.1,\"num_str\":\"20.1\",\"time\":\"14:20:12.33Z\"}"
-]
-[
-  3,
-  "1000-03-03",
-  "1000-03-03T23:59:38.099999Z",
-  "2023-07-12T18:18:11.537199Z",
-  "3",
-  "30",
-  3.1,
-  30.1,
-  "23:59:38.10Z",
-  "{\"_meta\":{\"uuid\":\"75c06bd6-20e0-11ee-990b-ffd12dfcd47f\"},\"date\":\"1000-03-03\",\"datetime\":\"1000-03-03T23:59:38.10Z\",\"id\":3,\"int_and_str\":3,\"int_str\":\"30\",\"num_and_str\":3.1,\"num_str\":\"30.1\",\"time\":\"23:59:38.10Z\"}"
-]
-[
-  4,
-  "2023-08-29",
-  "2023-08-29T23:59:38Z",
-  "2023-07-12T18:18:48.441281Z",
-  "4",
-  "40",
-  4.1,
-  40.1,
-  "23:59:38Z",
-  "{\"_meta\":{\"uuid\":\"8bbf898a-20e0-11ee-990b-ffd12dfcd47f\"},\"date\":\"2023-08-29\",\"datetime\":\"2023-08-29T23:59:38Z\",\"id\":4,\"int_and_str\":\"4\",\"int_str\":\"40\",\"num_and_str\":\"4.1\",\"num_str\":\"40.1\",\"time\":\"23:59:38Z\"}"
-]
-[
-  5,
-  "9999-12-31",
-  "9999-12-31T23:59:59Z",
-  "2023-07-12T18:27:25.889321Z",
-  "5",
-  "50",
-  5.1,
-  50.1,
-  "23:59:59Z",
-  "{\"_meta\":{\"uuid\":\"c02bd79a-20e1-11ee-990b-ffd12dfcd47f\"},\"date\":\"9999-12-31\",\"datetime\":\"9999-12-31T23:59:59Z\",\"id\":5,\"int_and_str\":\"5\",\"int_str\":\"50\",\"num_and_str\":\"5.1\",\"num_str\":\"50.1\",\"time\":\"23:59:59Z\"}"
-]
+{
+  "estuary-theatre.testing.simple": [
+    {
+      "canary": "amputation's",
+      "flow_document": "{\"_meta\":{\"uuid\":\"75c06bd6-20e0-11ee-990b-ffd12dfcd47f\"},\"canary\":\"amputation's\",\"id\":1}",
+      "flow_published_at": "2023-07-12T18:18:11.537199Z",
+      "id": 1
+    },
+    {
+      "canary": "armament's",
+      "flow_document": "{\"_meta\":{\"uuid\":\"7dbe8ebc-20e0-11ee-990b-ffd12dfcd47f\"},\"canary\":\"armament's\",\"id\":2}",
+      "flow_published_at": "2023-07-12T18:18:24.946758Z",
+      "id": 2
+    },
+    {
+      "canary": "splatters",
+      "flow_document": "{\"_meta\":{\"uuid\":\"8bbf898a-20e0-11ee-990b-ffd12dfcd47f\"},\"canary\":\"splatters\",\"id\":3}",
+      "flow_published_at": "2023-07-12T18:18:48.441281Z",
+      "id": 3
+    },
+    {
+      "canary": "strengthen",
+      "flow_document": "{\"_meta\":{\"uuid\":\"9b994ae4-20e0-11ee-990b-ffd12dfcd47f\"},\"canary\":\"strengthen\",\"id\":4}",
+      "flow_published_at": "2023-07-12T18:19:15.034186Z",
+      "id": 4
+    },
+    {
+      "canary": "Kringle's",
+      "flow_document": "{\"_meta\":{\"uuid\":\"b4b60968-20e0-11ee-990b-ffd12dfcd47f\"},\"canary\":\"Kringle's\",\"id\":5}",
+      "flow_published_at": "2023-07-12T18:19:57.165604Z",
+      "id": 5
+    },
+    {
+      "canary": "grosbeak's",
+      "flow_document": "{\"_meta\":{\"uuid\":\"bcef4bc6-20e0-11ee-990b-ffd12dfcd47f\"},\"canary\":\"grosbeak's\",\"id\":6}",
+      "flow_published_at": "2023-07-12T18:20:10.962631Z",
+      "id": 6
+    },
+    {
+      "canary": "pieced",
+      "flow_document": "{\"_meta\":{\"uuid\":\"134a1456-20e1-11ee-990b-ffd12dfcd47f\"},\"canary\":\"pieced\",\"id\":7}",
+      "flow_published_at": "2023-07-12T18:22:35.841647Z",
+      "id": 7
+    },
+    {
+      "canary": "roaches",
+      "flow_document": "{\"_meta\":{\"uuid\":\"1b953992-20e1-11ee-990b-ffd12dfcd47f\"},\"canary\":\"roaches\",\"id\":8}",
+      "flow_published_at": "2023-07-12T18:22:49.755893Z",
+      "id": 8
+    },
+    {
+      "canary": "devilish",
+      "flow_document": "{\"_meta\":{\"uuid\":\"7e2df422-20e1-11ee-990b-ffd12dfcd47f\"},\"canary\":\"devilish\",\"id\":9}",
+      "flow_published_at": "2023-07-12T18:25:35.173533Z",
+      "id": 9
+    },
+    {
+      "canary": "glucose's",
+      "flow_document": "{\"_meta\":{\"uuid\":\"8458b580-20e1-11ee-990b-ffd12dfcd47f\"},\"canary\":\"glucose's\",\"id\":10}",
+      "flow_published_at": "2023-07-12T18:25:45.520064Z",
+      "id": 10
+    }
+  ]
+}
+{
+  "estuary-theatre.testing.duplicate_keys_standard": [
+    {
+      "flow_document": "{\"_meta\":{\"uuid\":\"8de85150-20e1-11ee-990b-ffd12dfcd47f\"},\"id\":1,\"int\":6,\"str\":\"str 6\"}",
+      "flow_published_at": "2023-07-12T18:26:01.560712Z",
+      "id": 1,
+      "int": 6,
+      "str": "str 6"
+    },
+    {
+      "flow_document": "{\"_meta\":{\"uuid\":\"957348bc-20e1-11ee-990b-ffd12dfcd47f\"},\"id\":2,\"int\":7,\"str\":\"str 7\"}",
+      "flow_published_at": "2023-07-12T18:26:14.215494Z",
+      "id": 2,
+      "int": 7,
+      "str": "str 7"
+    },
+    {
+      "flow_document": "{\"_meta\":{\"uuid\":\"9afb3ff6-20e1-11ee-990b-ffd12dfcd47f\"},\"id\":3,\"int\":8,\"str\":\"str 8\"}",
+      "flow_published_at": "2023-07-12T18:26:23.495167Z",
+      "id": 3,
+      "int": 8,
+      "str": "str 8"
+    },
+    {
+      "flow_document": "{\"_meta\":{\"uuid\":\"a1100a70-20e1-11ee-990b-ffd12dfcd47f\"},\"id\":4,\"int\":9,\"str\":\"str 9\"}",
+      "flow_published_at": "2023-07-12T18:26:33.697752Z",
+      "id": 4,
+      "int": 9,
+      "str": "str 9"
+    },
+    {
+      "flow_document": "{\"_meta\":{\"uuid\":\"a65203a8-20e1-11ee-990b-ffd12dfcd47f\"},\"id\":5,\"int\":10,\"str\":\"str 10\"}",
+      "flow_published_at": "2023-07-12T18:26:42.518724Z",
+      "id": 5,
+      "int": 10,
+      "str": "str 10"
+    }
+  ]
+}
+{
+  "estuary-theatre.testing.duplicate_keys_delta": [
+    {
+      "flow_document": "{\"_meta\":{\"uuid\":\"8de85150-20e1-11ee-990b-ffd12dfcd47f\"},\"id\":1,\"int\":6,\"str\":\"str 6\"}",
+      "flow_published_at": "2023-07-12T18:26:01.560712Z",
+      "id": 1,
+      "int": 6,
+      "str": "str 6"
+    },
+    {
+      "flow_document": "{\"_meta\":{\"uuid\":\"8de85150-20e1-11ee-990b-ffd12dfcd47f\"},\"id\":1,\"int\":6,\"str\":\"str 6\"}",
+      "flow_published_at": "2023-07-12T18:26:01.560712Z",
+      "id": 1,
+      "int": 6,
+      "str": "str 6"
+    },
+    {
+      "flow_document": "{\"_meta\":{\"uuid\":\"75c06bd6-20e0-11ee-990b-ffd12dfcd47f\"},\"id\":1,\"int\":1,\"str\":\"str 1\"}",
+      "flow_published_at": "2023-07-12T18:18:11.537199Z",
+      "id": 1,
+      "int": 1,
+      "str": "str 1"
+    },
+    {
+      "flow_document": "{\"_meta\":{\"uuid\":\"8de85150-20e1-11ee-990b-ffd12dfcd47f\"},\"id\":1,\"int\":6,\"str\":\"str 6\"}",
+      "flow_published_at": "2023-07-12T18:26:01.560712Z",
+      "id": 1,
+      "int": 6,
+      "str": "str 6"
+    },
+    {
+      "flow_document": "{\"_meta\":{\"uuid\":\"75c06bd6-20e0-11ee-990b-ffd12dfcd47f\"},\"id\":1,\"int\":1,\"str\":\"str 1\"}",
+      "flow_published_at": "2023-07-12T18:18:11.537199Z",
+      "id": 1,
+      "int": 1,
+      "str": "str 1"
+    },
+    {
+      "flow_document": "{\"_meta\":{\"uuid\":\"8de85150-20e1-11ee-990b-ffd12dfcd47f\"},\"id\":1,\"int\":6,\"str\":\"str 6\"}",
+      "flow_published_at": "2023-07-12T18:26:01.560712Z",
+      "id": 1,
+      "int": 6,
+      "str": "str 6"
+    },
+    {
+      "flow_document": "{\"_meta\":{\"uuid\":\"8de85150-20e1-11ee-990b-ffd12dfcd47f\"},\"id\":1,\"int\":6,\"str\":\"str 6\"}",
+      "flow_published_at": "2023-07-12T18:26:01.560712Z",
+      "id": 1,
+      "int": 6,
+      "str": "str 6"
+    },
+    {
+      "flow_document": "{\"_meta\":{\"uuid\":\"75c06bd6-20e0-11ee-990b-ffd12dfcd47f\"},\"id\":1,\"int\":1,\"str\":\"str 1\"}",
+      "flow_published_at": "2023-07-12T18:18:11.537199Z",
+      "id": 1,
+      "int": 1,
+      "str": "str 1"
+    },
+    {
+      "flow_document": "{\"_meta\":{\"uuid\":\"75c06bd6-20e0-11ee-990b-ffd12dfcd47f\"},\"id\":1,\"int\":1,\"str\":\"str 1\"}",
+      "flow_published_at": "2023-07-12T18:18:11.537199Z",
+      "id": 1,
+      "int": 1,
+      "str": "str 1"
+    },
+    {
+      "flow_document": "{\"_meta\":{\"uuid\":\"75c06bd6-20e0-11ee-990b-ffd12dfcd47f\"},\"id\":1,\"int\":1,\"str\":\"str 1\"}",
+      "flow_published_at": "2023-07-12T18:18:11.537199Z",
+      "id": 1,
+      "int": 1,
+      "str": "str 1"
+    },
+    {
+      "flow_document": "{\"_meta\":{\"uuid\":\"957348bc-20e1-11ee-990b-ffd12dfcd47f\"},\"id\":2,\"int\":7,\"str\":\"str 7\"}",
+      "flow_published_at": "2023-07-12T18:26:14.215494Z",
+      "id": 2,
+      "int": 7,
+      "str": "str 7"
+    },
+    {
+      "flow_document": "{\"_meta\":{\"uuid\":\"957348bc-20e1-11ee-990b-ffd12dfcd47f\"},\"id\":2,\"int\":7,\"str\":\"str 7\"}",
+      "flow_published_at": "2023-07-12T18:26:14.215494Z",
+      "id": 2,
+      "int": 7,
+      "str": "str 7"
+    },
+    {
+      "flow_document": "{\"_meta\":{\"uuid\":\"7dbe8ebc-20e0-11ee-990b-ffd12dfcd47f\"},\"id\":2,\"int\":2,\"str\":\"str 2\"}",
+      "flow_published_at": "2023-07-12T18:18:24.946758Z",
+      "id": 2,
+      "int": 2,
+      "str": "str 2"
+    },
+    {
+      "flow_document": "{\"_meta\":{\"uuid\":\"7dbe8ebc-20e0-11ee-990b-ffd12dfcd47f\"},\"id\":2,\"int\":2,\"str\":\"str 2\"}",
+      "flow_published_at": "2023-07-12T18:18:24.946758Z",
+      "id": 2,
+      "int": 2,
+      "str": "str 2"
+    },
+    {
+      "flow_document": "{\"_meta\":{\"uuid\":\"7dbe8ebc-20e0-11ee-990b-ffd12dfcd47f\"},\"id\":2,\"int\":2,\"str\":\"str 2\"}",
+      "flow_published_at": "2023-07-12T18:18:24.946758Z",
+      "id": 2,
+      "int": 2,
+      "str": "str 2"
+    },
+    {
+      "flow_document": "{\"_meta\":{\"uuid\":\"957348bc-20e1-11ee-990b-ffd12dfcd47f\"},\"id\":2,\"int\":7,\"str\":\"str 7\"}",
+      "flow_published_at": "2023-07-12T18:26:14.215494Z",
+      "id": 2,
+      "int": 7,
+      "str": "str 7"
+    },
+    {
+      "flow_document": "{\"_meta\":{\"uuid\":\"7dbe8ebc-20e0-11ee-990b-ffd12dfcd47f\"},\"id\":2,\"int\":2,\"str\":\"str 2\"}",
+      "flow_published_at": "2023-07-12T18:18:24.946758Z",
+      "id": 2,
+      "int": 2,
+      "str": "str 2"
+    },
+    {
+      "flow_document": "{\"_meta\":{\"uuid\":\"7dbe8ebc-20e0-11ee-990b-ffd12dfcd47f\"},\"id\":2,\"int\":2,\"str\":\"str 2\"}",
+      "flow_published_at": "2023-07-12T18:18:24.946758Z",
+      "id": 2,
+      "int": 2,
+      "str": "str 2"
+    },
+    {
+      "flow_document": "{\"_meta\":{\"uuid\":\"957348bc-20e1-11ee-990b-ffd12dfcd47f\"},\"id\":2,\"int\":7,\"str\":\"str 7\"}",
+      "flow_published_at": "2023-07-12T18:26:14.215494Z",
+      "id": 2,
+      "int": 7,
+      "str": "str 7"
+    },
+    {
+      "flow_document": "{\"_meta\":{\"uuid\":\"957348bc-20e1-11ee-990b-ffd12dfcd47f\"},\"id\":2,\"int\":7,\"str\":\"str 7\"}",
+      "flow_published_at": "2023-07-12T18:26:14.215494Z",
+      "id": 2,
+      "int": 7,
+      "str": "str 7"
+    },
+    {
+      "flow_document": "{\"_meta\":{\"uuid\":\"9afb3ff6-20e1-11ee-990b-ffd12dfcd47f\"},\"id\":3,\"int\":8,\"str\":\"str 8\"}",
+      "flow_published_at": "2023-07-12T18:26:23.495167Z",
+      "id": 3,
+      "int": 8,
+      "str": "str 8"
+    },
+    {
+      "flow_document": "{\"_meta\":{\"uuid\":\"9afb3ff6-20e1-11ee-990b-ffd12dfcd47f\"},\"id\":3,\"int\":8,\"str\":\"str 8\"}",
+      "flow_published_at": "2023-07-12T18:26:23.495167Z",
+      "id": 3,
+      "int": 8,
+      "str": "str 8"
+    },
+    {
+      "flow_document": "{\"_meta\":{\"uuid\":\"9afb3ff6-20e1-11ee-990b-ffd12dfcd47f\"},\"id\":3,\"int\":8,\"str\":\"str 8\"}",
+      "flow_published_at": "2023-07-12T18:26:23.495167Z",
+      "id": 3,
+      "int": 8,
+      "str": "str 8"
+    },
+    {
+      "flow_document": "{\"_meta\":{\"uuid\":\"9afb3ff6-20e1-11ee-990b-ffd12dfcd47f\"},\"id\":3,\"int\":8,\"str\":\"str 8\"}",
+      "flow_published_at": "2023-07-12T18:26:23.495167Z",
+      "id": 3,
+      "int": 8,
+      "str": "str 8"
+    },
+    {
+      "flow_document": "{\"_meta\":{\"uuid\":\"8bbf898a-20e0-11ee-990b-ffd12dfcd47f\"},\"id\":3,\"int\":3,\"str\":\"str 3\"}",
+      "flow_published_at": "2023-07-12T18:18:48.441281Z",
+      "id": 3,
+      "int": 3,
+      "str": "str 3"
+    },
+    {
+      "flow_document": "{\"_meta\":{\"uuid\":\"9afb3ff6-20e1-11ee-990b-ffd12dfcd47f\"},\"id\":3,\"int\":8,\"str\":\"str 8\"}",
+      "flow_published_at": "2023-07-12T18:26:23.495167Z",
+      "id": 3,
+      "int": 8,
+      "str": "str 8"
+    },
+    {
+      "flow_document": "{\"_meta\":{\"uuid\":\"8bbf898a-20e0-11ee-990b-ffd12dfcd47f\"},\"id\":3,\"int\":3,\"str\":\"str 3\"}",
+      "flow_published_at": "2023-07-12T18:18:48.441281Z",
+      "id": 3,
+      "int": 3,
+      "str": "str 3"
+    },
+    {
+      "flow_document": "{\"_meta\":{\"uuid\":\"8bbf898a-20e0-11ee-990b-ffd12dfcd47f\"},\"id\":3,\"int\":3,\"str\":\"str 3\"}",
+      "flow_published_at": "2023-07-12T18:18:48.441281Z",
+      "id": 3,
+      "int": 3,
+      "str": "str 3"
+    },
+    {
+      "flow_document": "{\"_meta\":{\"uuid\":\"8bbf898a-20e0-11ee-990b-ffd12dfcd47f\"},\"id\":3,\"int\":3,\"str\":\"str 3\"}",
+      "flow_published_at": "2023-07-12T18:18:48.441281Z",
+      "id": 3,
+      "int": 3,
+      "str": "str 3"
+    },
+    {
+      "flow_document": "{\"_meta\":{\"uuid\":\"8bbf898a-20e0-11ee-990b-ffd12dfcd47f\"},\"id\":3,\"int\":3,\"str\":\"str 3\"}",
+      "flow_published_at": "2023-07-12T18:18:48.441281Z",
+      "id": 3,
+      "int": 3,
+      "str": "str 3"
+    },
+    {
+      "flow_document": "{\"_meta\":{\"uuid\":\"a1100a70-20e1-11ee-990b-ffd12dfcd47f\"},\"id\":4,\"int\":9,\"str\":\"str 9\"}",
+      "flow_published_at": "2023-07-12T18:26:33.697752Z",
+      "id": 4,
+      "int": 9,
+      "str": "str 9"
+    },
+    {
+      "flow_document": "{\"_meta\":{\"uuid\":\"9b994ae4-20e0-11ee-990b-ffd12dfcd47f\"},\"id\":4,\"int\":4,\"str\":\"str 4\"}",
+      "flow_published_at": "2023-07-12T18:19:15.034186Z",
+      "id": 4,
+      "int": 4,
+      "str": "str 4"
+    },
+    {
+      "flow_document": "{\"_meta\":{\"uuid\":\"a1100a70-20e1-11ee-990b-ffd12dfcd47f\"},\"id\":4,\"int\":9,\"str\":\"str 9\"}",
+      "flow_published_at": "2023-07-12T18:26:33.697752Z",
+      "id": 4,
+      "int": 9,
+      "str": "str 9"
+    },
+    {
+      "flow_document": "{\"_meta\":{\"uuid\":\"9b994ae4-20e0-11ee-990b-ffd12dfcd47f\"},\"id\":4,\"int\":4,\"str\":\"str 4\"}",
+      "flow_published_at": "2023-07-12T18:19:15.034186Z",
+      "id": 4,
+      "int": 4,
+      "str": "str 4"
+    },
+    {
+      "flow_document": "{\"_meta\":{\"uuid\":\"a1100a70-20e1-11ee-990b-ffd12dfcd47f\"},\"id\":4,\"int\":9,\"str\":\"str 9\"}",
+      "flow_published_at": "2023-07-12T18:26:33.697752Z",
+      "id": 4,
+      "int": 9,
+      "str": "str 9"
+    },
+    {
+      "flow_document": "{\"_meta\":{\"uuid\":\"9b994ae4-20e0-11ee-990b-ffd12dfcd47f\"},\"id\":4,\"int\":4,\"str\":\"str 4\"}",
+      "flow_published_at": "2023-07-12T18:19:15.034186Z",
+      "id": 4,
+      "int": 4,
+      "str": "str 4"
+    },
+    {
+      "flow_document": "{\"_meta\":{\"uuid\":\"a1100a70-20e1-11ee-990b-ffd12dfcd47f\"},\"id\":4,\"int\":9,\"str\":\"str 9\"}",
+      "flow_published_at": "2023-07-12T18:26:33.697752Z",
+      "id": 4,
+      "int": 9,
+      "str": "str 9"
+    },
+    {
+      "flow_document": "{\"_meta\":{\"uuid\":\"9b994ae4-20e0-11ee-990b-ffd12dfcd47f\"},\"id\":4,\"int\":4,\"str\":\"str 4\"}",
+      "flow_published_at": "2023-07-12T18:19:15.034186Z",
+      "id": 4,
+      "int": 4,
+      "str": "str 4"
+    },
+    {
+      "flow_document": "{\"_meta\":{\"uuid\":\"9b994ae4-20e0-11ee-990b-ffd12dfcd47f\"},\"id\":4,\"int\":4,\"str\":\"str 4\"}",
+      "flow_published_at": "2023-07-12T18:19:15.034186Z",
+      "id": 4,
+      "int": 4,
+      "str": "str 4"
+    },
+    {
+      "flow_document": "{\"_meta\":{\"uuid\":\"a1100a70-20e1-11ee-990b-ffd12dfcd47f\"},\"id\":4,\"int\":9,\"str\":\"str 9\"}",
+      "flow_published_at": "2023-07-12T18:26:33.697752Z",
+      "id": 4,
+      "int": 9,
+      "str": "str 9"
+    },
+    {
+      "flow_document": "{\"_meta\":{\"uuid\":\"a65203a8-20e1-11ee-990b-ffd12dfcd47f\"},\"id\":5,\"int\":10,\"str\":\"str 10\"}",
+      "flow_published_at": "2023-07-12T18:26:42.518724Z",
+      "id": 5,
+      "int": 10,
+      "str": "str 10"
+    },
+    {
+      "flow_document": "{\"_meta\":{\"uuid\":\"a65203a8-20e1-11ee-990b-ffd12dfcd47f\"},\"id\":5,\"int\":10,\"str\":\"str 10\"}",
+      "flow_published_at": "2023-07-12T18:26:42.518724Z",
+      "id": 5,
+      "int": 10,
+      "str": "str 10"
+    },
+    {
+      "flow_document": "{\"_meta\":{\"uuid\":\"bcef4bc6-20e0-11ee-990b-ffd12dfcd47f\"},\"id\":5,\"int\":5,\"str\":\"str 5\"}",
+      "flow_published_at": "2023-07-12T18:20:10.962631Z",
+      "id": 5,
+      "int": 5,
+      "str": "str 5"
+    },
+    {
+      "flow_document": "{\"_meta\":{\"uuid\":\"bcef4bc6-20e0-11ee-990b-ffd12dfcd47f\"},\"id\":5,\"int\":5,\"str\":\"str 5\"}",
+      "flow_published_at": "2023-07-12T18:20:10.962631Z",
+      "id": 5,
+      "int": 5,
+      "str": "str 5"
+    },
+    {
+      "flow_document": "{\"_meta\":{\"uuid\":\"a65203a8-20e1-11ee-990b-ffd12dfcd47f\"},\"id\":5,\"int\":10,\"str\":\"str 10\"}",
+      "flow_published_at": "2023-07-12T18:26:42.518724Z",
+      "id": 5,
+      "int": 10,
+      "str": "str 10"
+    },
+    {
+      "flow_document": "{\"_meta\":{\"uuid\":\"a65203a8-20e1-11ee-990b-ffd12dfcd47f\"},\"id\":5,\"int\":10,\"str\":\"str 10\"}",
+      "flow_published_at": "2023-07-12T18:26:42.518724Z",
+      "id": 5,
+      "int": 10,
+      "str": "str 10"
+    },
+    {
+      "flow_document": "{\"_meta\":{\"uuid\":\"a65203a8-20e1-11ee-990b-ffd12dfcd47f\"},\"id\":5,\"int\":10,\"str\":\"str 10\"}",
+      "flow_published_at": "2023-07-12T18:26:42.518724Z",
+      "id": 5,
+      "int": 10,
+      "str": "str 10"
+    },
+    {
+      "flow_document": "{\"_meta\":{\"uuid\":\"bcef4bc6-20e0-11ee-990b-ffd12dfcd47f\"},\"id\":5,\"int\":5,\"str\":\"str 5\"}",
+      "flow_published_at": "2023-07-12T18:20:10.962631Z",
+      "id": 5,
+      "int": 5,
+      "str": "str 5"
+    },
+    {
+      "flow_document": "{\"_meta\":{\"uuid\":\"bcef4bc6-20e0-11ee-990b-ffd12dfcd47f\"},\"id\":5,\"int\":5,\"str\":\"str 5\"}",
+      "flow_published_at": "2023-07-12T18:20:10.962631Z",
+      "id": 5,
+      "int": 5,
+      "str": "str 5"
+    },
+    {
+      "flow_document": "{\"_meta\":{\"uuid\":\"bcef4bc6-20e0-11ee-990b-ffd12dfcd47f\"},\"id\":5,\"int\":5,\"str\":\"str 5\"}",
+      "flow_published_at": "2023-07-12T18:20:10.962631Z",
+      "id": 5,
+      "int": 5,
+      "str": "str 5"
+    }
+  ]
+}
+{
+  "estuary-theatre.testing.duplicate_keys_delta_exclude_flow_doc": [
+    {
+      "flow_published_at": "2023-07-12T18:26:01.560712Z",
+      "id": 1,
+      "int": 6,
+      "str": "str 6"
+    },
+    {
+      "flow_published_at": "2023-07-12T18:26:01.560712Z",
+      "id": 1,
+      "int": 6,
+      "str": "str 6"
+    },
+    {
+      "flow_published_at": "2023-07-12T18:18:11.537199Z",
+      "id": 1,
+      "int": 1,
+      "str": "str 1"
+    },
+    {
+      "flow_published_at": "2023-07-12T18:26:01.560712Z",
+      "id": 1,
+      "int": 6,
+      "str": "str 6"
+    },
+    {
+      "flow_published_at": "2023-07-12T18:26:01.560712Z",
+      "id": 1,
+      "int": 6,
+      "str": "str 6"
+    },
+    {
+      "flow_published_at": "2023-07-12T18:26:01.560712Z",
+      "id": 1,
+      "int": 6,
+      "str": "str 6"
+    },
+    {
+      "flow_published_at": "2023-07-12T18:18:11.537199Z",
+      "id": 1,
+      "int": 1,
+      "str": "str 1"
+    },
+    {
+      "flow_published_at": "2023-07-12T18:18:11.537199Z",
+      "id": 1,
+      "int": 1,
+      "str": "str 1"
+    },
+    {
+      "flow_published_at": "2023-07-12T18:18:11.537199Z",
+      "id": 1,
+      "int": 1,
+      "str": "str 1"
+    },
+    {
+      "flow_published_at": "2023-07-12T18:18:11.537199Z",
+      "id": 1,
+      "int": 1,
+      "str": "str 1"
+    },
+    {
+      "flow_published_at": "2023-07-12T18:18:24.946758Z",
+      "id": 2,
+      "int": 2,
+      "str": "str 2"
+    },
+    {
+      "flow_published_at": "2023-07-12T18:26:14.215494Z",
+      "id": 2,
+      "int": 7,
+      "str": "str 7"
+    },
+    {
+      "flow_published_at": "2023-07-12T18:26:14.215494Z",
+      "id": 2,
+      "int": 7,
+      "str": "str 7"
+    },
+    {
+      "flow_published_at": "2023-07-12T18:26:14.215494Z",
+      "id": 2,
+      "int": 7,
+      "str": "str 7"
+    },
+    {
+      "flow_published_at": "2023-07-12T18:26:14.215494Z",
+      "id": 2,
+      "int": 7,
+      "str": "str 7"
+    },
+    {
+      "flow_published_at": "2023-07-12T18:26:14.215494Z",
+      "id": 2,
+      "int": 7,
+      "str": "str 7"
+    },
+    {
+      "flow_published_at": "2023-07-12T18:18:24.946758Z",
+      "id": 2,
+      "int": 2,
+      "str": "str 2"
+    },
+    {
+      "flow_published_at": "2023-07-12T18:18:24.946758Z",
+      "id": 2,
+      "int": 2,
+      "str": "str 2"
+    },
+    {
+      "flow_published_at": "2023-07-12T18:18:24.946758Z",
+      "id": 2,
+      "int": 2,
+      "str": "str 2"
+    },
+    {
+      "flow_published_at": "2023-07-12T18:18:24.946758Z",
+      "id": 2,
+      "int": 2,
+      "str": "str 2"
+    },
+    {
+      "flow_published_at": "2023-07-12T18:26:23.495167Z",
+      "id": 3,
+      "int": 8,
+      "str": "str 8"
+    },
+    {
+      "flow_published_at": "2023-07-12T18:26:23.495167Z",
+      "id": 3,
+      "int": 8,
+      "str": "str 8"
+    },
+    {
+      "flow_published_at": "2023-07-12T18:18:48.441281Z",
+      "id": 3,
+      "int": 3,
+      "str": "str 3"
+    },
+    {
+      "flow_published_at": "2023-07-12T18:26:23.495167Z",
+      "id": 3,
+      "int": 8,
+      "str": "str 8"
+    },
+    {
+      "flow_published_at": "2023-07-12T18:18:48.441281Z",
+      "id": 3,
+      "int": 3,
+      "str": "str 3"
+    },
+    {
+      "flow_published_at": "2023-07-12T18:26:23.495167Z",
+      "id": 3,
+      "int": 8,
+      "str": "str 8"
+    },
+    {
+      "flow_published_at": "2023-07-12T18:26:23.495167Z",
+      "id": 3,
+      "int": 8,
+      "str": "str 8"
+    },
+    {
+      "flow_published_at": "2023-07-12T18:18:48.441281Z",
+      "id": 3,
+      "int": 3,
+      "str": "str 3"
+    },
+    {
+      "flow_published_at": "2023-07-12T18:18:48.441281Z",
+      "id": 3,
+      "int": 3,
+      "str": "str 3"
+    },
+    {
+      "flow_published_at": "2023-07-12T18:18:48.441281Z",
+      "id": 3,
+      "int": 3,
+      "str": "str 3"
+    },
+    {
+      "flow_published_at": "2023-07-12T18:19:15.034186Z",
+      "id": 4,
+      "int": 4,
+      "str": "str 4"
+    },
+    {
+      "flow_published_at": "2023-07-12T18:26:33.697752Z",
+      "id": 4,
+      "int": 9,
+      "str": "str 9"
+    },
+    {
+      "flow_published_at": "2023-07-12T18:19:15.034186Z",
+      "id": 4,
+      "int": 4,
+      "str": "str 4"
+    },
+    {
+      "flow_published_at": "2023-07-12T18:19:15.034186Z",
+      "id": 4,
+      "int": 4,
+      "str": "str 4"
+    },
+    {
+      "flow_published_at": "2023-07-12T18:19:15.034186Z",
+      "id": 4,
+      "int": 4,
+      "str": "str 4"
+    },
+    {
+      "flow_published_at": "2023-07-12T18:19:15.034186Z",
+      "id": 4,
+      "int": 4,
+      "str": "str 4"
+    },
+    {
+      "flow_published_at": "2023-07-12T18:26:33.697752Z",
+      "id": 4,
+      "int": 9,
+      "str": "str 9"
+    },
+    {
+      "flow_published_at": "2023-07-12T18:26:33.697752Z",
+      "id": 4,
+      "int": 9,
+      "str": "str 9"
+    },
+    {
+      "flow_published_at": "2023-07-12T18:26:33.697752Z",
+      "id": 4,
+      "int": 9,
+      "str": "str 9"
+    },
+    {
+      "flow_published_at": "2023-07-12T18:26:33.697752Z",
+      "id": 4,
+      "int": 9,
+      "str": "str 9"
+    },
+    {
+      "flow_published_at": "2023-07-12T18:26:42.518724Z",
+      "id": 5,
+      "int": 10,
+      "str": "str 10"
+    },
+    {
+      "flow_published_at": "2023-07-12T18:26:42.518724Z",
+      "id": 5,
+      "int": 10,
+      "str": "str 10"
+    },
+    {
+      "flow_published_at": "2023-07-12T18:20:10.962631Z",
+      "id": 5,
+      "int": 5,
+      "str": "str 5"
+    },
+    {
+      "flow_published_at": "2023-07-12T18:20:10.962631Z",
+      "id": 5,
+      "int": 5,
+      "str": "str 5"
+    },
+    {
+      "flow_published_at": "2023-07-12T18:20:10.962631Z",
+      "id": 5,
+      "int": 5,
+      "str": "str 5"
+    },
+    {
+      "flow_published_at": "2023-07-12T18:26:42.518724Z",
+      "id": 5,
+      "int": 10,
+      "str": "str 10"
+    },
+    {
+      "flow_published_at": "2023-07-12T18:20:10.962631Z",
+      "id": 5,
+      "int": 5,
+      "str": "str 5"
+    },
+    {
+      "flow_published_at": "2023-07-12T18:26:42.518724Z",
+      "id": 5,
+      "int": 10,
+      "str": "str 10"
+    },
+    {
+      "flow_published_at": "2023-07-12T18:26:42.518724Z",
+      "id": 5,
+      "int": 10,
+      "str": "str 10"
+    },
+    {
+      "flow_published_at": "2023-07-12T18:20:10.962631Z",
+      "id": 5,
+      "int": 5,
+      "str": "str 5"
+    }
+  ]
+}
+{
+  "estuary-theatre.testing.multiple_types": [
+    {
+      "array_int": "[11,12]",
+      "bool_field": false,
+      "float_field": 1.1,
+      "flow_document": "{\"_meta\":{\"uuid\":\"3fd2ec78-20e1-11ee-990b-ffd12dfcd47f\"},\"array_int\":[11,12],\"bool_field\":false,\"float_field\":1.1,\"id\":1,\"multiple\":1,\"nested\":{\"id\":\"i1\"},\"nullable_int\":null,\"str_field\":\"str1\"}",
+      "flow_published_at": "2023-07-12T18:23:50.55822Z",
+      "id": 1,
+      "multiple": "1",
+      "nested": "{\"id\":\"i1\"}",
+      "nullable_int": null,
+      "str_field": "str1"
+    },
+    {
+      "array_int": "[21,22]",
+      "bool_field": true,
+      "float_field": 2.2,
+      "flow_document": "{\"_meta\":{\"uuid\":\"4b37f0b8-20e1-11ee-990b-ffd12dfcd47f\"},\"array_int\":[21,22],\"bool_field\":true,\"float_field\":2.2,\"id\":2,\"multiple\":2.2,\"nested\":{\"id\":\"i2\"},\"nullable_int\":2,\"str_field\":\"str2\"}",
+      "flow_published_at": "2023-07-12T18:24:09.67518Z",
+      "id": 2,
+      "multiple": "2.2",
+      "nested": "{\"id\":\"i2\"}",
+      "nullable_int": 2,
+      "str_field": "str2"
+    },
+    {
+      "array_int": "[31,32]",
+      "bool_field": false,
+      "float_field": 3.3,
+      "flow_document": "{\"_meta\":{\"uuid\":\"51016380-20e1-11ee-990b-ffd12dfcd47f\"},\"array_int\":[31,32],\"bool_field\":false,\"float_field\":3.3,\"id\":3,\"multiple\":true,\"nested\":{\"id\":\"i3\"},\"nullable_int\":null,\"str_field\":\"str3\"}",
+      "flow_published_at": "2023-07-12T18:24:19.384Z",
+      "id": 3,
+      "multiple": "true",
+      "nested": "{\"id\":\"i3\"}",
+      "nullable_int": null,
+      "str_field": "str3"
+    },
+    {
+      "array_int": "[41,42]",
+      "bool_field": true,
+      "float_field": 4.4,
+      "flow_document": "{\"_meta\":{\"uuid\":\"5660aaca-20e1-11ee-990b-ffd12dfcd47f\"},\"array_int\":[41,42],\"bool_field\":true,\"float_field\":4.4,\"id\":4,\"multiple\":false,\"nested\":{\"id\":\"i4\"},\"nullable_int\":4,\"str_field\":\"str4\"}",
+      "flow_published_at": "2023-07-12T18:24:28.397025Z",
+      "id": 4,
+      "multiple": "false",
+      "nested": "{\"id\":\"i4\"}",
+      "nullable_int": 4,
+      "str_field": "str4"
+    },
+    {
+      "array_int": "[51,52]",
+      "bool_field": false,
+      "float_field": 5.5,
+      "flow_document": "{\"_meta\":{\"uuid\":\"5af9e236-20e1-11ee-990b-ffd12dfcd47f\"},\"array_int\":[51,52],\"bool_field\":false,\"float_field\":5.5,\"id\":5,\"multiple\":\"string five\",\"nested\":{\"id\":\"i5\"},\"nullable_int\":null,\"str_field\":\"str5\"}",
+      "flow_published_at": "2023-07-12T18:24:36.112031Z",
+      "id": 5,
+      "multiple": "\"string five\"",
+      "nested": "{\"id\":\"i5\"}",
+      "nullable_int": null,
+      "str_field": "str5"
+    },
+    {
+      "array_int": "[61,62]",
+      "bool_field": true,
+      "float_field": 66.66,
+      "flow_document": "{\"_meta\":{\"uuid\":\"e4b646c2-20e1-11ee-990b-ffd12dfcd47f\"},\"array_int\":[61,62],\"bool_field\":true,\"float_field\":66.66,\"id\":6,\"multiple\":[\"one\",2,true],\"nested\":{\"id\":\"i6\"},\"nullable_int\":6,\"str_field\":\"str6 v2\"}",
+      "flow_published_at": "2023-07-12T18:28:27.194541Z",
+      "id": 6,
+      "multiple": "[\"one\",2,true]",
+      "nested": "{\"id\":\"i6\"}",
+      "nullable_int": 6,
+      "str_field": "str6 v2"
+    },
+    {
+      "array_int": "[71,72]",
+      "bool_field": false,
+      "float_field": 77.77,
+      "flow_document": "{\"_meta\":{\"uuid\":\"eb40dafc-20e1-11ee-990b-ffd12dfcd47f\"},\"array_int\":[71,72],\"bool_field\":false,\"float_field\":77.77,\"id\":7,\"multiple\":{\"object\":\"seven\"},\"nested\":{\"id\":\"i7\"},\"nullable_int\":null,\"str_field\":\"str7 v2\"}",
+      "flow_published_at": "2023-07-12T18:28:38.169062Z",
+      "id": 7,
+      "multiple": "{\"object\":\"seven\"}",
+      "nested": "{\"id\":\"i7\"}",
+      "nullable_int": null,
+      "str_field": "str7 v2"
+    },
+    {
+      "array_int": "[81,82]",
+      "bool_field": true,
+      "float_field": 88.88,
+      "flow_document": "{\"_meta\":{\"uuid\":\"f163eef6-20e1-11ee-990b-ffd12dfcd47f\"},\"array_int\":[81,82],\"bool_field\":true,\"float_field\":88.88,\"id\":8,\"multiple\":null,\"nested\":{\"id\":\"i8\"},\"nullable_int\":8,\"str_field\":\"str8 v2\"}",
+      "flow_published_at": "2023-07-12T18:28:48.465279Z",
+      "id": 8,
+      "multiple": "null",
+      "nested": "{\"id\":\"i8\"}",
+      "nullable_int": 8,
+      "str_field": "str8 v2"
+    },
+    {
+      "array_int": "[91,92]",
+      "bool_field": false,
+      "float_field": 99.99,
+      "flow_document": "{\"_meta\":{\"uuid\":\"f5b064a8-20e1-11ee-990b-ffd12dfcd47f\"},\"array_int\":[91,92],\"bool_field\":false,\"float_field\":99.99,\"id\":9,\"nested\":{\"id\":\"i9\"},\"nullable_int\":null,\"str_field\":\"str9 v2\"}",
+      "flow_published_at": "2023-07-12T18:28:55.677252Z",
+      "id": 9,
+      "multiple": "null",
+      "nested": "{\"id\":\"i9\"}",
+      "nullable_int": null,
+      "str_field": "str9 v2"
+    },
+    {
+      "array_int": "[1,2]",
+      "bool_field": true,
+      "float_field": 1010.101,
+      "flow_document": "{\"_meta\":{\"uuid\":\"fb0cc8b0-20e1-11ee-990b-ffd12dfcd47f\"},\"array_int\":[1,2],\"bool_field\":true,\"float_field\":1010.101,\"id\":10,\"nested\":{\"id\":\"i10\"},\"nullable_int\":10,\"str_field\":\"str10 v2\"}",
+      "flow_published_at": "2023-07-12T18:29:04.671352Z",
+      "id": 10,
+      "multiple": "null",
+      "nested": "{\"id\":\"i10\"}",
+      "nullable_int": 10,
+      "str_field": "str10 v2"
+    }
+  ]
+}
 {
   "applied": {
     "actionDescription": "UPDATE `estuary-theatre`.testing.flow_materializations_v2 SET version = 'test', spec = '(a-base64-encoded-value)' WHERE materialization = 'tests/materialize-bigquery/materialize';"


### PR DESCRIPTION
**Description:**

- Switches BigQuery to idempotent apply pattern, this means no more fencing and that would help alleviate the write contentions we experience with this connector
- Also updated the way the integration test snapshot is taken so it is more informative now and includes duplicate keys and delta updates
- During Store phase, we upload the data to gcs and prepare the queries to be run as part of the checkpoint. This includes a JobID for the query job to be run. During Acknowledge we try to create a job and run the query with the given ID. If we find that the job already exists, it means we have been able to successfully kickstart the query before, and at this point we only need to check the status of the job and if it has errored, we raise that error for the query.
- A JobID can only be created once. If the "creation" of a job itself is successful, no matter whether the actual query succeeds or not, the JobID has been allocated and cannot be re-allocated. On the other hand, if the creation of a Job fails, we can always create that job with the JobID since that JobID is free to take.
- This means once we have executed a SQL query once, we cannot retry it if it fails. This is a limitation in face of queries that may not be deterministic. I have not hit this error myself, but I can imagine a case of a SQL query failing due to a hiccup in reading the content of files from gcs (I think of this as unlikely)
- However we are guaranteed to be able to run the SQL query with the generated JobID once, since if creating the job fails we can retry creating the job with the same ID

**Workflow steps:**

- Tested erroring out after Store phase but before Ack phase can run, and on a subsequent restart the queries are run as expected
- Tested erroring out after Ack phase has run queries but before it has cleaned up the checkpoint, and on restart the recovery step checks the job status and does not lead to duplicate rows

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1411)
<!-- Reviewable:end -->
