### PR TITLE
source-mysql: Two replication metadata tweaks

### DIFF
--- a/source-mysql/replication.go
+++ b/source-mysql/replication.go
@@ -468,10 +468,10 @@ func (rs *mysqlReplicationStream) handleQuery(ctx context.Context, schema, query
 	//     don't impact our capture or because we get the relevant information
 	//     by some other means.
 	if ignoreQueriesRe.MatchString(query) {
-		logrus.WithField("query", query).Trace("ignoring query event")
+		logrus.WithField("query", query).Info("ignoring query event")
 		return nil
 	}
-	logrus.WithField("query", query).Debug("handling query event")
+	logrus.WithField("query", query).Info("handling query event")
 
 	var stmt, err = sqlparser.Parse(query)
 	if err != nil {

--- a/source-mysql/replication.go
+++ b/source-mysql/replication.go
@@ -480,7 +480,7 @@ func (rs *mysqlReplicationStream) handleQuery(ctx context.Context, schema, query
 	logrus.WithField("stmt", fmt.Sprintf("%#v", stmt)).Debug("parsed query")
 
 	switch stmt := stmt.(type) {
-	case *sqlparser.CreateDatabase, *sqlparser.CreateTable, *sqlparser.Savepoint, *sqlparser.Flush:
+	case *sqlparser.CreateDatabase, *sqlparser.AlterDatabase, *sqlparser.CreateTable, *sqlparser.Savepoint, *sqlparser.Flush:
 		logrus.WithField("query", query).Debug("ignoring benign query")
 	case *sqlparser.CreateView, *sqlparser.AlterView, *sqlparser.DropView:
 		// All view creation/deletion/alterations should be fine to ignore since we don't capture from views.


### PR DESCRIPTION
**Description:**

This PR combines two relatively trivial tweaks to the MySQL replication metadata tracking:

- Upgrading the log levels for DDL query event processing so that we'll always get something in the logs at `INFO` level. This should help us actually figure out what's happened the next time our metadata tracking gets out of sync with the source table.
- Whitelisting `ALTER DATABASE` queries as safe. There is no `ALTER DATABASE` query that we actually need to care about, so this was fairly simple.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1412)
<!-- Reviewable:end -->
