### PR TITLE
source-sqlserver: Disable DB version prerequisite check

### DIFF
--- a/source-sqlserver/prerequisites.go
+++ b/source-sqlserver/prerequisites.go
@@ -13,12 +13,12 @@ import (
 func (db *sqlserverDatabase) SetupPrerequisites(ctx context.Context) []error {
 	var errs []error
 
-	if err := db.prerequisiteVersion(ctx); err != nil {
-		// Return early if the database version is incompatible with the connector since additional
-		// errors will be of minimal use.
-		errs = append(errs, err)
-		return errs
-	}
+	//if err := db.prerequisiteVersion(ctx); err != nil {
+	//	// Return early if the database version is incompatible with the connector since additional
+	//	// errors will be of minimal use.
+	//	errs = append(errs, err)
+	//	return errs
+	//}
 
 	for _, prereq := range []func(ctx context.Context) error{
 		db.prerequisiteCDCEnabled,


### PR DESCRIPTION
**Description:**

Currently this check is *way* too conservative, because we know that the SQL Server CDC functionality has existed in its current form since at least SQL Server 2008 (though not all versions of the database).

In the absence of this check, a database which doesn't support CDC will instead produce several errors, something like:

    - CDC is not enabled on database "db" and user "flow_capture" cannot enable it
    - unable to query capture instances for table "dbo.flow_watermarks": <something about unknown table cdc.change_tables>
    - error querying the current LSN: <something about unknown procedure sys.fn_cdc_get_max_lsn>

(In case it wasn't clear I haven't actually run this against such a database just now, so I'm handwaving exactly what the database- provided portion of those errors will look like).

This seems like a reasonable tradeoff since right now our stubborn insistence on a minimum database version blocks real users with old databases from setting up a capture, and after all the work we went to around text collations I am not aware of any other issues with capturing from such DBs.

It is possible that this check was still valuable for specific Azure managed SQL Server installs, so I haven't deleted it outright but simply disabled it until we can re-evaluate whether there's any purpose to this check at all.

**Workflow steps:**

Users with pre-2014 SQL Server databases will no longer be blocked from creating a capture solely for that reason.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1429)
<!-- Reviewable:end -->
