### PR TITLE
stdsql: close connection used to ping database in exec

### DIFF
--- a/materialize-sql/std_sql.go
+++ b/materialize-sql/std_sql.go
@@ -46,11 +46,13 @@ func StdSQLExecStatements(ctx context.Context, db *sql.DB, statements []string) 
 	// through a single connection. This allows a driver to explicitly run
 	// `BEGIN;` and `COMMIT;` statements around a transactional operation.
 	var conn, err = db.Conn(ctx)
-	if err == nil {
-		err = conn.PingContext(ctx)
-	}
 	if err != nil {
 		return fmt.Errorf("connecting to DB: %w", err)
+	}
+	defer conn.Close()
+
+	if err = conn.PingContext(ctx); err != nil {
+		return fmt.Errorf("ping DB: %w", err)
 	}
 
 	for _, statement := range statements {
@@ -59,7 +61,8 @@ func StdSQLExecStatements(ctx context.Context, db *sql.DB, statements []string) 
 		}
 		logrus.WithField("sql", statement).Debug("executed statement")
 	}
-	return conn.Close() // Release to pool.
+
+	return nil
 }
 
 // StdInstallFence is a convenience for Client implementations which

--- a/materialize-sql/std_sql.go
+++ b/materialize-sql/std_sql.go
@@ -49,7 +49,9 @@ func StdSQLExecStatements(ctx context.Context, db *sql.DB, statements []string) 
 	if err != nil {
 		return fmt.Errorf("connecting to DB: %w", err)
 	}
-	defer conn.Close()
+	defer func() {
+		err = conn.Close()
+	}()
 
 	if err = conn.PingContext(ctx); err != nil {
 		return fmt.Errorf("ping DB: %w", err)
@@ -62,7 +64,7 @@ func StdSQLExecStatements(ctx context.Context, db *sql.DB, statements []string) 
 		logrus.WithField("sql", statement).Debug("executed statement")
 	}
 
-	return nil
+	return err
 }
 
 // StdInstallFence is a convenience for Client implementations which


### PR DESCRIPTION
**Description:**

- I found the root cause of the leftover connection in Databricks, we were creating this additional connection here but not closing it.
- I was able to reproduce the original issue and can confirm with this patch it doesn't happen anymore

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1430)
<!-- Reviewable:end -->
