### PR TITLE
source-sqlserver: Query job status during replication diagnostics

### DIFF
--- a/source-sqlserver/replication.go
+++ b/source-sqlserver/replication.go
@@ -422,6 +422,46 @@ func splitStreamID(streamID string) (string, string) {
 }
 
 func (db *sqlserverDatabase) ReplicationDiagnostics(ctx context.Context) error {
-	// TODO: Run some useful diagnostics queries for SQL Server replication and log the results
+	var query = func(q string) {
+		var logEntry = log.WithField("query", q)
+		logEntry.Info("running diagnostics query")
+
+		var rows, err = db.conn.QueryContext(ctx, q)
+		if err != nil {
+			logEntry.WithField("err", err).Error("unable to execute diagnostics query")
+			return
+		}
+		defer rows.Close()
+
+		cnames, err := rows.Columns()
+		if err != nil {
+			logEntry.WithField("err", err).Error("error processing query result")
+			return
+		}
+		var vals = make([]any, len(cnames))
+		var vptrs = make([]any, len(vals))
+		for idx := range vals {
+			vptrs[idx] = &vals[idx]
+		}
+
+		var numResults int
+		for rows.Next() {
+			numResults++
+			if err := rows.Scan(vptrs...); err != nil {
+				logEntry.WithField("err", err).Error("error scanning result row")
+				continue
+			}
+			var logFields = log.Fields{}
+			for idx, name := range cnames {
+				logFields[name] = vals[idx]
+			}
+			log.WithFields(logFields).Info("got row")
+		}
+		if numResults == 0 {
+			logEntry.Info("no results")
+		}
+	}
+
+	query("EXEC msdb.dbo.sp_help_job;")
 	return nil
 }


### PR DESCRIPTION
**Description:**

Since SQL Server replication works by issuing polling queries and most ways that can fail result in errors, a "silent failure" mode seems most likely to come about if the CDC agent job whose job it is to tail the WAL and copy changes into change tables simply isn't running.

The new diagnostic logic is untested, but it will only be run in the event that replication is already not working as intended, so the risk of breakage is minimal here and I intend to try it out in production shortly after it's live.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1431)
<!-- Reviewable:end -->
