### PR TITLE
airbyte shim: fixes for state handling

### DIFF
--- a/estuary-cdk/estuary_cdk/shim_airbyte_cdk.py
+++ b/estuary-cdk/estuary_cdk/shim_airbyte_cdk.py
@@ -78,8 +78,15 @@ class ResourceState(common.BaseResourceState, extra="forbid"):
     """state is a dict encoding of AirbyteStateMessage"""
 
 
-ConnectorState = common.ConnectorState[ResourceState]
-"""Use the common.ConnectorState shape with ResourceState"""
+class ConnectorState(common.ConnectorState[ResourceState], extra="ignore"):
+    """ConnectorState represents a number of ResourceStates, keyed by binding state key.
+    
+    Top-level fields other than bindingStateV1 are ignored, to allow for a lossy migration from
+    states that existed prior to adopting this convection. Connectors transitioning in this way will
+    effectively start over from the beginning.
+    """
+
+    bindingStateV1: dict[str, ResourceState] = {}
 
 
 class Document(common.BaseDocument, extra="allow"):

--- a/estuary-cdk/estuary_cdk/shim_airbyte_cdk.py
+++ b/estuary-cdk/estuary_cdk/shim_airbyte_cdk.py
@@ -268,6 +268,12 @@ class CaptureShim(BaseCaptureConnector):
         ]
         airbyte_catalog = ConfiguredAirbyteCatalog(streams=airbyte_streams)
 
+        if "bindingStateV1" not in connector_state.__fields_set__:
+            # Initialize the top-level state object so that it is properly serialized if this is an
+            # "empty" state, which occurs for a brand new task that has never emitted any
+            # checkpoints.
+            connector_state.__setattr__("bindingStateV1", {})
+
         # Index of Airbyte (namespace, stream) => ResourceState.
         # Use `setdefault()` to initialize ResourceState if it's not already part of `connector_state`.
         index: dict[tuple[str | None, str], tuple[int, ResourceState]] = {


### PR DESCRIPTION
**Description:**

A couple of fixes for state handling in the airbyte shim. See individual commit messages.

**Workflow steps:**

Run an airbyte-shim-based connector and it will persist state, and also be able to migrate from ATF versions of the connector by re-backfilling all of its bindings.

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1432)
<!-- Reviewable:end -->
