### PR TITLE
materialize-sql: forbid fields with no types, and don't log applied specs

### DIFF
--- a/materialize-sql/type_mapping.go
+++ b/materialize-sql/type_mapping.go
@@ -504,6 +504,9 @@ func (constrainter) NewConstraints(p *pf.Projection, deltaUpdates bool) *pm.Resp
 	case p.IsRootDocumentProjection():
 		constraint.Type = pm.Response_Validated_Constraint_LOCATION_REQUIRED
 		constraint.Reason = "The root document must be materialized"
+	case len(p.Inference.Types) == 0:
+		constraint.Type = pm.Response_Validated_Constraint_FIELD_FORBIDDEN
+		constraint.Reason = "Cannot materialize a field with no types"
 	case p.Field == "_meta/op":
 		constraint.Type = pm.Response_Validated_Constraint_LOCATION_RECOMMENDED
 		constraint.Reason = "The operation type should usually be materialized"


### PR DESCRIPTION
**Description:**

A couple of small QoL fixes for sql materializations:

- Forbid fields with no types, since these will error on apply and we currently recommend them by default
- Don't log out the base64 applied spec insert/update, since it's not useful and often so huge as to be problematic

Closes https://github.com/estuary/connectors/issues/1404

**Workflow steps:**

When you publish a SQL materialization, the action description for updating or insert the spec will now look something like this:
```
INSERT INTO flow_materializations_v2 (version, spec, materialization) VALUES ('0cff7f5dee810400', '(a-base64-encoded-value)', 'bobCo/mysql2/materialize-mysql')
```

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1435)
<!-- Reviewable:end -->
