### PR TITLE
source-firestore: Logging tweak and retry `TargetChange.REMOVE` failures

### DIFF
--- a/source-firestore/pull.go
+++ b/source-firestore/pull.go
@@ -368,7 +368,15 @@ func (c *capture) Run(ctx context.Context) error {
 		}
 		if resourceState.Backfill == nil || resourceState.Backfill.Completed {
 			// Do nothing when no backfill is required
-		} else if resumeState, ok := backfillCollections[collectionID]; !ok {
+			continue
+		}
+		log.WithFields(log.Fields{
+			"resource":   resourceState.path,
+			"collection": collectionID,
+			"startAfter": resourceState.Backfill.StartAfter,
+			"cursor":     resourceState.Backfill.Cursor,
+		}).Debug("backfill required for binding")
+		if resumeState, ok := backfillCollections[collectionID]; !ok {
 			backfillCollections[collectionID] = resourceState.Backfill
 		} else if !resumeState.Equal(resourceState.Backfill) {
 			return fmt.Errorf("internal error: backfill state mismatch for resource %q with collection ID %q", resourceState.path, collectionID)


### PR DESCRIPTION
**Description:**

Adds a bit of debug logging to provide greater visibility into backfill state mismatches, and modifies the handling of non-catchup-failure `TargetChange.REMOVE` events to also just retry internally rather than failing the connector.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1441)
<!-- Reviewable:end -->
