### PR TITLE
m-snowflake: increase retry count and delay

### DIFF
--- a/tests/materialize/materialize-snowflake/setup.sh
+++ b/tests/materialize/materialize-snowflake/setup.sh
@@ -14,7 +14,7 @@ export SNOWFLAKE_AUTH_TYPE="${SNOWFLAKE_AUTH_TYPE}"
 # if auth type is user_password
 export SNOWFLAKE_USER="${SNOWFLAKE_USER:-}"
 export SNOWFLAKE_PASSWORD="${SNOWFLAKE_PASSWORD:-}"
-if [ -z "${${SNOWFLAKE_PRIVATE_KEY+x}}" ]; then 
+if [ -n "${SNOWFLAKE_PRIVATE_KEY:-}" ]; then 
   # if auth type is jwt
   export SNOWFLAKE_PRIVATE_KEY="$(cat ${SNOWFLAKE_PRIVATE_KEY:-} | jq -sR . | sed -e 's/^"//' -e 's/"$//')"
 fi


### PR DESCRIPTION
**Description:**

- Allow more time for Snowpipe results to show up
- We have a task which we have seen that requests sent at 11:06 show up in results only at 11:10, that's 4 minutes later. Here I am allowing up to 5 minutes.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1444)
<!-- Reviewable:end -->
