### PR TITLE
source-firestore: Only retry TargetChange.REMOVE after 60s

### DIFF
--- a/source-firestore/pull.go
+++ b/source-firestore/pull.go
@@ -783,8 +783,10 @@ func (c *capture) StreamChanges(ctx context.Context, client *firestore_v1.Client
 					target.ResumeType = &firestore_pb.Target_ReadTime{ReadTime: timestamppb.New(time.Now())}
 				} else if tc.Cause != nil {
 					logEntry.WithField("cause", tc.Cause.Message).Warn("unexpected TargetChange.REMOVE")
+					time.Sleep(retryInterval)
 				} else {
 					logEntry.Warn("unexpected TargetChange.REMOVE")
+					time.Sleep(retryInterval)
 				}
 			case firestore_pb.TargetChange_CURRENT:
 				if log.IsLevelEnabled(log.TraceLevel) {


### PR DESCRIPTION
**Description:**

This *probably* isn't necessary, but one of the challenges with Firestore change streaming is that it's actually not super hard to end up in a permanent failure loop where you keep reading the same documents over and over and accidentally rack up large bills.

In other places where we retry after a failure status we generally wait 60 seconds before trying again, and it's probably prudent to do that for the newly added `TargetChange.REMOVE` retry logic as well.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1445)
<!-- Reviewable:end -->
