### PR TITLE
materializations: don't try to drop nullability if the projection has a default value

### DIFF
--- a/materialize-boilerplate/apply.go
+++ b/materialize-boilerplate/apply.go
@@ -178,10 +178,12 @@ func ApplyChanges(ctx context.Context, req *pm.Request_Apply, applier Applier, i
 					}
 
 					newRequired := projection.Inference.Exists == pf.Inference_MUST && !slices.Contains(projection.Inference.Types, pf.JsonTypeNull)
-					if !existingField.Nullable && !newRequired && !existingField.HasDefault {
-						// The existing field is not nullable and does not have a default value, but
-						// the proposed projection for the field is nullable. The existing field
-						// will need to be modified to be made nullable.
+					newlyNullable := !existingField.Nullable && !newRequired
+					projectionHasDefault := projection.Inference.DefaultJson != nil
+					if newlyNullable && !existingField.HasDefault && !projectionHasDefault {
+						// The field has newly been made nullable and neither the existing field nor
+						// the projection has a default value. The existing field will need to be
+						// modified to be made nullable since it may need to hold null values now.
 						params.NewlyNullableFields = append(params.NewlyNullableFields, existingField)
 					}
 				} else {


### PR DESCRIPTION
**Description:**

In e852e80, materializations were made aware of the possibility for default values in the materialized columns, and that we should not try to drop "not null" constraints on columns like this, under the assumption that the destination system is fine with us sending a "null" since it will automatically be populated (in a sense) with that default value.

This didn't take into consideration the fact that Flow projections can also have default values, and in this case we will never see a "null" for these fields from the Flow runtime, and instead will always see that default value. So here too we do not need to drop nullability constraints - the materialized columns can stay "not null" and as long as there is that default value annotation things will work fine.

This is particularly important for materializing nullable collection keys with default values. This is allowed (see 5d53313 as well), and some systems like postgres consider primary key fields non-nullable. Prior to this commit, the connector would try to drop a "not null" constraint on a primary key column that was created from a projection with a default value if the materialized column didn't have a default value. We don't currently create columns with default values based on projections (though maybe we will, later) so this would cause the materialization to fail the next time it tries to do an `Apply`. But now, the materialization will not try to drop a "not null" on a materialized key field as long as the projection has a default value.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1448)
<!-- Reviewable:end -->
