### PR TITLE
Adding usage rate to build-local script

### DIFF
--- a/build-local.sh
+++ b/build-local.sh
@@ -26,6 +26,7 @@ docker buildx build \
   --platform linux/amd64 \
   --build-arg CONNECTOR_NAME="$1" \
   --build-arg CONNECTOR_TYPE="$CONNECTOR_TYPE" \
+  --build-arg="USAGE_RATE=1.0" \
   --load \
   -t ghcr.io/estuary/"$1":local \
   -f "$DOCKERFILE" \


### PR DESCRIPTION
**Description:**

usage rate is a missing parameter in build-local.sh script, without it local images cannot be processed.
This PR adds this parameter inside the bash script.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1449)
<!-- Reviewable:end -->
