### PR TITLE
source-mysql: Correctly handle enum values when processing DDL query events

### DIFF
--- a/source-mysql/.snapshots/TestAlterTable_AddColumnSetEnum-enum-restart
+++ b/source-mysql/.snapshots/TestAlterTable_AddColumnSetEnum-enum-restart
@@ -1,10 +1,10 @@
 # ================================
 # Collection "acmeCo/test/test_altertable_addcolumnsetenum_enum_76927424": 2 Documents
 # ================================
-{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"AlterTable_AddColumnSetEnum_enum_76927424","cursor":"binlog.000123:56789:123","txid":"11111111-1111-1111-1111-111111111111:111"}},"data":"eee","enumCol":"'someValue'","id":5}
-{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"AlterTable_AddColumnSetEnum_enum_76927424","cursor":"binlog.000123:56789:123","txid":"11111111-1111-1111-1111-111111111111:111"}},"data":"fff","enumCol":"'someValue'","id":6}
+{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"AlterTable_AddColumnSetEnum_enum_76927424","cursor":"binlog.000123:56789:123","txid":"11111111-1111-1111-1111-111111111111:111"}},"data":"eee","enumCol":"someValue","id":5}
+{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"AlterTable_AddColumnSetEnum_enum_76927424","cursor":"binlog.000123:56789:123","txid":"11111111-1111-1111-1111-111111111111:111"}},"data":"fff","enumCol":"someValue","id":6}
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"test%2FAlterTable_AddColumnSetEnum_enum_76927424":{"backfilled":2,"key_columns":["id"],"metadata":{"schema":{"columns":["id","data","enumCol"],"types":{"data":"text","enumCol":{"enum":["","'someValue'","'anotherValue'"],"type":"enum"},"id":"int"}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
+{"bindingStateV1":{"test%2FAlterTable_AddColumnSetEnum_enum_76927424":{"backfilled":2,"key_columns":["id"],"metadata":{"schema":{"columns":["id","data","enumCol"],"types":{"data":"text","enumCol":{"enum":["","someValue","anotherValue"],"type":"enum"},"id":"int"}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
 

--- a/source-mysql/.snapshots/TestAlterTable_AddColumnSetEnum-enum-stream
+++ b/source-mysql/.snapshots/TestAlterTable_AddColumnSetEnum-enum-stream
@@ -1,10 +1,10 @@
 # ================================
 # Collection "acmeCo/test/test_altertable_addcolumnsetenum_enum_76927424": 2 Documents
 # ================================
-{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"AlterTable_AddColumnSetEnum_enum_76927424","cursor":"binlog.000123:56789:123","txid":"11111111-1111-1111-1111-111111111111:111"}},"data":"ccc","enumCol":"'anotherValue'","id":3}
-{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"AlterTable_AddColumnSetEnum_enum_76927424","cursor":"binlog.000123:56789:123","txid":"11111111-1111-1111-1111-111111111111:111"}},"data":"ddd","enumCol":"'someValue'","id":4}
+{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"AlterTable_AddColumnSetEnum_enum_76927424","cursor":"binlog.000123:56789:123","txid":"11111111-1111-1111-1111-111111111111:111"}},"data":"ccc","enumCol":"anotherValue","id":3}
+{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"AlterTable_AddColumnSetEnum_enum_76927424","cursor":"binlog.000123:56789:123","txid":"11111111-1111-1111-1111-111111111111:111"}},"data":"ddd","enumCol":"someValue","id":4}
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"test%2FAlterTable_AddColumnSetEnum_enum_76927424":{"backfilled":2,"key_columns":["id"],"metadata":{"schema":{"columns":["id","data","enumCol"],"types":{"data":"text","enumCol":{"enum":["","'someValue'","'anotherValue'"],"type":"enum"},"id":"int"}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
+{"bindingStateV1":{"test%2FAlterTable_AddColumnSetEnum_enum_76927424":{"backfilled":2,"key_columns":["id"],"metadata":{"schema":{"columns":["id","data","enumCol"],"types":{"data":"text","enumCol":{"enum":["","someValue","anotherValue"],"type":"enum"},"id":"int"}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
 

--- a/source-mysql/.snapshots/TestAlterTable_AddColumnSetEnum-set-restart
+++ b/source-mysql/.snapshots/TestAlterTable_AddColumnSetEnum-set-restart
@@ -1,10 +1,10 @@
 # ================================
 # Collection "acmeCo/test/test_altertable_addcolumnsetenum_set_14622082": 2 Documents
 # ================================
-{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"AlterTable_AddColumnSetEnum_set_14622082","cursor":"binlog.000123:56789:123","txid":"11111111-1111-1111-1111-111111111111:111"}},"data":"eee","id":5,"setCol":"'a','c'"}
-{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"AlterTable_AddColumnSetEnum_set_14622082","cursor":"binlog.000123:56789:123","txid":"11111111-1111-1111-1111-111111111111:111"}},"data":"fff","id":6,"setCol":"'b','c'"}
+{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"AlterTable_AddColumnSetEnum_set_14622082","cursor":"binlog.000123:56789:123","txid":"11111111-1111-1111-1111-111111111111:111"}},"data":"eee","id":5,"setCol":"a,c"}
+{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"AlterTable_AddColumnSetEnum_set_14622082","cursor":"binlog.000123:56789:123","txid":"11111111-1111-1111-1111-111111111111:111"}},"data":"fff","id":6,"setCol":"b,c"}
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"test%2FAlterTable_AddColumnSetEnum_set_14622082":{"backfilled":2,"key_columns":["id"],"metadata":{"schema":{"columns":["id","data","setCol"],"types":{"data":"text","id":"int","setCol":{"enum":["'a'","'b'","'c'"],"type":"set"}}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
+{"bindingStateV1":{"test%2FAlterTable_AddColumnSetEnum_set_14622082":{"backfilled":2,"key_columns":["id"],"metadata":{"schema":{"columns":["id","data","setCol"],"types":{"data":"text","id":"int","setCol":{"enum":["a","b","c"],"type":"set"}}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
 

--- a/source-mysql/.snapshots/TestAlterTable_AddColumnSetEnum-set-stream
+++ b/source-mysql/.snapshots/TestAlterTable_AddColumnSetEnum-set-stream
@@ -1,10 +1,10 @@
 # ================================
 # Collection "acmeCo/test/test_altertable_addcolumnsetenum_set_14622082": 2 Documents
 # ================================
-{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"AlterTable_AddColumnSetEnum_set_14622082","cursor":"binlog.000123:56789:123","txid":"11111111-1111-1111-1111-111111111111:111"}},"data":"ccc","id":3,"setCol":"'a','b'"}
-{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"AlterTable_AddColumnSetEnum_set_14622082","cursor":"binlog.000123:56789:123","txid":"11111111-1111-1111-1111-111111111111:111"}},"data":"ddd","id":4,"setCol":"'b','c'"}
+{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"AlterTable_AddColumnSetEnum_set_14622082","cursor":"binlog.000123:56789:123","txid":"11111111-1111-1111-1111-111111111111:111"}},"data":"ccc","id":3,"setCol":"a,b"}
+{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"AlterTable_AddColumnSetEnum_set_14622082","cursor":"binlog.000123:56789:123","txid":"11111111-1111-1111-1111-111111111111:111"}},"data":"ddd","id":4,"setCol":"b,c"}
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"test%2FAlterTable_AddColumnSetEnum_set_14622082":{"backfilled":2,"key_columns":["id"],"metadata":{"schema":{"columns":["id","data","setCol"],"types":{"data":"text","id":"int","setCol":{"enum":["'a'","'b'","'c'"],"type":"set"}}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
+{"bindingStateV1":{"test%2FAlterTable_AddColumnSetEnum_set_14622082":{"backfilled":2,"key_columns":["id"],"metadata":{"schema":{"columns":["id","data","setCol"],"types":{"data":"text","id":"int","setCol":{"enum":["a","b","c"],"type":"set"}}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
 

--- a/source-mysql/.snapshots/TestAlterTable_AddEnumColumn-discover1
+++ b/source-mysql/.snapshots/TestAlterTable_AddEnumColumn-discover1
@@ -1,0 +1,130 @@
+Binding 0:
+{
+    "recommended_name": "test_altertable_addenumcolumn_30213486",
+    "resource_config_json": {
+      "namespace": "test",
+      "stream": "AlterTable_AddEnumColumn_30213486"
+    },
+    "document_schema_json": {
+      "$defs": {
+        "TestAlterTable_AddEnumColumn_30213486": {
+          "type": "object",
+          "required": [
+            "id"
+          ],
+          "$anchor": "TestAlterTable_AddEnumColumn_30213486",
+          "properties": {
+            "data": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "id": {
+              "type": "integer"
+            }
+          }
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "_meta": {
+                "properties": {
+                  "op": {
+                    "const": "d"
+                  }
+                }
+              }
+            }
+          },
+          "then": {
+            "reduce": {
+              "delete": true,
+              "strategy": "merge"
+            }
+          },
+          "else": {
+            "reduce": {
+              "strategy": "merge"
+            }
+          },
+          "required": [
+            "_meta"
+          ],
+          "properties": {
+            "_meta": {
+              "type": "object",
+              "required": [
+                "op",
+                "source"
+              ],
+              "properties": {
+                "before": {
+                  "$ref": "#TestAlterTable_AddEnumColumn_30213486",
+                  "description": "Record state immediately before this change was applied.",
+                  "reduce": {
+                    "strategy": "firstWriteWins"
+                  }
+                },
+                "op": {
+                  "enum": [
+                    "c",
+                    "d",
+                    "u"
+                  ],
+                  "description": "Change operation type: 'c' Create/Insert, 'u' Update, 'd' Delete."
+                },
+                "source": {
+                  "$id": "https://github.com/estuary/connectors/source-mysql/mysql-source-info",
+                  "properties": {
+                    "ts_ms": {
+                      "type": "integer",
+                      "description": "Unix timestamp (in millis) at which this event was recorded by the database."
+                    },
+                    "schema": {
+                      "type": "string",
+                      "description": "Database schema (namespace) of the event."
+                    },
+                    "snapshot": {
+                      "type": "boolean",
+                      "description": "Snapshot is true if the record was produced from an initial table backfill and unset if produced from the replication log."
+                    },
+                    "table": {
+                      "type": "string",
+                      "description": "Database table of the event."
+                    },
+                    "cursor": {
+                      "type": "string",
+                      "description": "Cursor value representing the current position in the binlog."
+                    },
+                    "txid": {
+                      "type": "string",
+                      "description": "The global transaction identifier associated with a change by MySQL. Only set if GTIDs are enabled."
+                    }
+                  },
+                  "type": "object",
+                  "required": [
+                    "schema",
+                    "table",
+                    "cursor"
+                  ]
+                }
+              },
+              "reduce": {
+                "strategy": "merge"
+              }
+            }
+          }
+        },
+        {
+          "$ref": "#TestAlterTable_AddEnumColumn_30213486"
+        }
+      ]
+    },
+    "key": [
+      "/id"
+    ]
+  }
+

--- a/source-mysql/.snapshots/TestAlterTable_AddEnumColumn-discover2
+++ b/source-mysql/.snapshots/TestAlterTable_AddEnumColumn-discover2
@@ -1,0 +1,143 @@
+Binding 0:
+{
+    "recommended_name": "test_altertable_addenumcolumn_30213486",
+    "resource_config_json": {
+      "namespace": "test",
+      "stream": "AlterTable_AddEnumColumn_30213486"
+    },
+    "document_schema_json": {
+      "$defs": {
+        "TestAlterTable_AddEnumColumn_30213486": {
+          "type": "object",
+          "required": [
+            "id"
+          ],
+          "$anchor": "TestAlterTable_AddEnumColumn_30213486",
+          "properties": {
+            "data": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "enumcol": {
+              "enum": [
+                "",
+                "sm",
+                "med",
+                "lg",
+                null
+              ],
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "id": {
+              "type": "integer"
+            }
+          }
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "_meta": {
+                "properties": {
+                  "op": {
+                    "const": "d"
+                  }
+                }
+              }
+            }
+          },
+          "then": {
+            "reduce": {
+              "delete": true,
+              "strategy": "merge"
+            }
+          },
+          "else": {
+            "reduce": {
+              "strategy": "merge"
+            }
+          },
+          "required": [
+            "_meta"
+          ],
+          "properties": {
+            "_meta": {
+              "type": "object",
+              "required": [
+                "op",
+                "source"
+              ],
+              "properties": {
+                "before": {
+                  "$ref": "#TestAlterTable_AddEnumColumn_30213486",
+                  "description": "Record state immediately before this change was applied.",
+                  "reduce": {
+                    "strategy": "firstWriteWins"
+                  }
+                },
+                "op": {
+                  "enum": [
+                    "c",
+                    "d",
+                    "u"
+                  ],
+                  "description": "Change operation type: 'c' Create/Insert, 'u' Update, 'd' Delete."
+                },
+                "source": {
+                  "$id": "https://github.com/estuary/connectors/source-mysql/mysql-source-info",
+                  "properties": {
+                    "ts_ms": {
+                      "type": "integer",
+                      "description": "Unix timestamp (in millis) at which this event was recorded by the database."
+                    },
+                    "schema": {
+                      "type": "string",
+                      "description": "Database schema (namespace) of the event."
+                    },
+                    "snapshot": {
+                      "type": "boolean",
+                      "description": "Snapshot is true if the record was produced from an initial table backfill and unset if produced from the replication log."
+                    },
+                    "table": {
+                      "type": "string",
+                      "description": "Database table of the event."
+                    },
+                    "cursor": {
+                      "type": "string",
+                      "description": "Cursor value representing the current position in the binlog."
+                    },
+                    "txid": {
+                      "type": "string",
+                      "description": "The global transaction identifier associated with a change by MySQL. Only set if GTIDs are enabled."
+                    }
+                  },
+                  "type": "object",
+                  "required": [
+                    "schema",
+                    "table",
+                    "cursor"
+                  ]
+                }
+              },
+              "reduce": {
+                "strategy": "merge"
+              }
+            }
+          }
+        },
+        {
+          "$ref": "#TestAlterTable_AddEnumColumn_30213486"
+        }
+      ]
+    },
+    "key": [
+      "/id"
+    ]
+  }
+

--- a/source-mysql/.snapshots/TestAlterTable_AddEnumColumn-init
+++ b/source-mysql/.snapshots/TestAlterTable_AddEnumColumn-init
@@ -1,0 +1,10 @@
+# ================================
+# Collection "acmeCo/test/test_altertable_addenumcolumn_30213486": 2 Documents
+# ================================
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"AlterTable_AddEnumColumn_30213486","cursor":"backfill:0"}},"data":"aaa","id":1}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"AlterTable_AddEnumColumn_30213486","cursor":"backfill:1"}},"data":"bbb","id":2}
+# ================================
+# Final State Checkpoint
+# ================================
+{"bindingStateV1":{"test%2FAlterTable_AddEnumColumn_30213486":{"backfilled":2,"key_columns":["id"],"metadata":{"schema":{"columns":["id","data"],"types":{"data":"text","id":"int"}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
+

--- a/source-mysql/.snapshots/TestAlterTable_AddEnumColumn-modified
+++ b/source-mysql/.snapshots/TestAlterTable_AddEnumColumn-modified
@@ -1,11 +1,11 @@
 # ================================
 # Collection "acmeCo/test/test_altertable_addenumcolumn_30213486": 3 Documents
 # ================================
-{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"AlterTable_AddEnumColumn_30213486","cursor":"binlog.000123:56789:123","txid":"11111111-1111-1111-1111-111111111111:111"}},"data":"eee","enumcol":"'med'","id":3}
-{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"AlterTable_AddEnumColumn_30213486","cursor":"binlog.000123:56789:123","txid":"11111111-1111-1111-1111-111111111111:111"}},"data":"fff","enumcol":"'lg'","id":4}
-{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"AlterTable_AddEnumColumn_30213486","cursor":"binlog.000123:56789:123","txid":"11111111-1111-1111-1111-111111111111:111"}},"data":"ggg","enumcol":"'sm'","id":5}
+{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"AlterTable_AddEnumColumn_30213486","cursor":"binlog.000123:56789:123","txid":"11111111-1111-1111-1111-111111111111:111"}},"data":"eee","enumcol":"med","id":3}
+{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"AlterTable_AddEnumColumn_30213486","cursor":"binlog.000123:56789:123","txid":"11111111-1111-1111-1111-111111111111:111"}},"data":"fff","enumcol":"lg","id":4}
+{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"AlterTable_AddEnumColumn_30213486","cursor":"binlog.000123:56789:123","txid":"11111111-1111-1111-1111-111111111111:111"}},"data":"ggg","enumcol":"sm","id":5}
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"test%2FAlterTable_AddEnumColumn_30213486":{"backfilled":2,"key_columns":["id"],"metadata":{"schema":{"columns":["id","data","enumcol"],"types":{"data":"text","enumcol":{"enum":["","'sm'","'med'","'lg'"],"type":"enum"},"id":"int"}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
+{"bindingStateV1":{"test%2FAlterTable_AddEnumColumn_30213486":{"backfilled":2,"key_columns":["id"],"metadata":{"schema":{"columns":["id","data","enumcol"],"types":{"data":"text","enumcol":{"enum":["","sm","med","lg"],"type":"enum"},"id":"int"}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
 

--- a/source-mysql/.snapshots/TestAlterTable_AddEnumColumn-modified
+++ b/source-mysql/.snapshots/TestAlterTable_AddEnumColumn-modified
@@ -1,0 +1,11 @@
+# ================================
+# Collection "acmeCo/test/test_altertable_addenumcolumn_30213486": 3 Documents
+# ================================
+{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"AlterTable_AddEnumColumn_30213486","cursor":"binlog.000123:56789:123","txid":"11111111-1111-1111-1111-111111111111:111"}},"data":"eee","enumcol":"'med'","id":3}
+{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"AlterTable_AddEnumColumn_30213486","cursor":"binlog.000123:56789:123","txid":"11111111-1111-1111-1111-111111111111:111"}},"data":"fff","enumcol":"'lg'","id":4}
+{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"AlterTable_AddEnumColumn_30213486","cursor":"binlog.000123:56789:123","txid":"11111111-1111-1111-1111-111111111111:111"}},"data":"ggg","enumcol":"'sm'","id":5}
+# ================================
+# Final State Checkpoint
+# ================================
+{"bindingStateV1":{"test%2FAlterTable_AddEnumColumn_30213486":{"backfilled":2,"key_columns":["id"],"metadata":{"schema":{"columns":["id","data","enumcol"],"types":{"data":"text","enumcol":{"enum":["","'sm'","'med'","'lg'"],"type":"enum"},"id":"int"}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
+

--- a/source-mysql/.snapshots/TestAlterTable_AddEnumColumn-rebackfilled
+++ b/source-mysql/.snapshots/TestAlterTable_AddEnumColumn-rebackfilled
@@ -1,0 +1,13 @@
+# ================================
+# Collection "acmeCo/test/test_altertable_addenumcolumn_30213486": 5 Documents
+# ================================
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"AlterTable_AddEnumColumn_30213486","cursor":"backfill:0"}},"data":"aaa","enumcol":null,"id":1}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"AlterTable_AddEnumColumn_30213486","cursor":"backfill:1"}},"data":"bbb","enumcol":null,"id":2}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"AlterTable_AddEnumColumn_30213486","cursor":"backfill:2"}},"data":"eee","enumcol":"med","id":3}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"AlterTable_AddEnumColumn_30213486","cursor":"backfill:3"}},"data":"fff","enumcol":"lg","id":4}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"AlterTable_AddEnumColumn_30213486","cursor":"backfill:4"}},"data":"ggg","enumcol":"sm","id":5}
+# ================================
+# Final State Checkpoint
+# ================================
+{"bindingStateV1":{"test%2FAlterTable_AddEnumColumn_30213486":{"backfilled":5,"key_columns":["id"],"metadata":{"schema":{"columns":["id","data","enumcol"],"types":{"data":"text","enumcol":{"enum":["","sm","med","lg"],"type":"enum"},"id":"int"}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
+


### PR DESCRIPTION
**Description:**

When processing DDL query events involving enum (and set) columns we're relying on the Vitess SQL parser giving us the correct list of options for the column types and using that to update our metadata. However, apparently we've been getting single-quoted (and potentially backslash-escaped) strings back from the parser and so our metadata ends up in an incorrect state which disagrees with our own discovery logic and the results of a subsequent backfill.

The behavior on Vitess's part appears to be deliberate. The single-quoted strings are actually tokenized into plain-old strings and then explicitly turned back into single-quoted strings via the `encodeSQLString()` helper function when the parse tree is built. I have no idea why this would ever be desirable, but whatever.

The fix is simple, we just need to apply the same single-quoted-string-unquoting function to these enum values here as we already do when parsing discovery results involving enums.

**Workflow steps:**

Future DDL queries involving enum columns will result in correct metadata updates (no more incorrect `'foo'` single-quotes around the actual options).

Any captures which previously processed a DDL query involving an enum column may have incorrect metadata for that column, however they should generally not capture incorrect data as a result because the first time they actually process a change event for that column the resulting document will fail validation.

(Actually, I guess that implicitly assumes they're using automatic discovery so that the collection schema knows the correct options so the incorrect document fails validation. Captures which don't automatically update their schema to have the new enum column could hypothetically allow an incorrect value to slip past)

I intend to go spend some time tomorrow investigating whether any production captures (other than the two which have already encountered errors and been re-backfilled manually) have incorrect metadata as a result of this. I suspect not, because DDL queries involving enum columns seem like they ought to be a reasonably rare edge case, but it's worth taking the time to be sure.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1452)
<!-- Reviewable:end -->
