### PR TITLE
CDK updates

### DIFF
--- a/estuary-cdk/estuary_cdk/capture/common.py
+++ b/estuary-cdk/estuary_cdk/capture/common.py
@@ -276,6 +276,12 @@ class Resource(Generic[_BaseDocument, _BaseResourceConfig, _BaseResourceState]):
             int,
             ResourceState,
             Task,
+            list[
+                tuple[
+                    CaptureBinding[_ResourceConfig],
+                    "Resource[_BaseDocument, _ResourceConfig, _ResourceState]",
+                ]
+            ]
         ],
         None,
     ]
@@ -394,6 +400,7 @@ def open(
                 index,
                 state,
                 task,
+                resolved_bindings
             )
 
     return (response.Opened(explicitAcknowledgements=False), _run)

--- a/estuary-cdk/estuary_cdk/capture/common.py
+++ b/estuary-cdk/estuary_cdk/capture/common.py
@@ -171,6 +171,15 @@ class ConnectorState(GenericModel, Generic[_BaseResourceState], extra="forbid"):
 
 _ConnectorState = TypeVar("_ConnectorState", bound=ConnectorState)
 
+@dataclass
+class AssociatedDocument(Generic[_BaseDocument]):
+    """
+    Emitting AssociatedDocument allows you to represent capturing document for other bindings.
+    You might use this if your data model requires you to load "child" documents when capturing a "parent" document,
+    instead of independently loading the child data stream.
+    """
+    doc: _BaseDocument
+    binding: int
 
 FetchSnapshotFn = Callable[[Logger], AsyncGenerator[_BaseDocument, None]]
 """
@@ -184,7 +193,7 @@ not emitted by the connector.
 
 FetchPageFn = Callable[
     [Logger, PageCursor, LogCursor],
-    AsyncGenerator[_BaseDocument | PageCursor, None],
+    AsyncGenerator[_BaseDocument | AssociatedDocument | PageCursor, None],
 ]
 """
 FetchPageFn fetches available checkpoints since the provided last PageCursor.
@@ -209,7 +218,7 @@ returning without yielding a final PageCursor.
 
 FetchChangesFn = Callable[
     [Logger, LogCursor],
-    AsyncGenerator[_BaseDocument | LogCursor, None],
+    AsyncGenerator[_BaseDocument | AssociatedDocument | LogCursor, None],
 ]
 """
 FetchChangesFn fetches available checkpoints since the provided last LogCursor.
@@ -552,6 +561,9 @@ async def _binding_backfill_task(
             if isinstance(item, BaseDocument):
                 task.captured(binding_index, item)
                 done = True
+            elif isinstance(item, AssociatedDocument):
+                task.captured(item.binding, item.doc)
+                done = True
             elif item is None:
                 raise RuntimeError(
                     f"Implementation error: FetchPageFn yielded PageCursor None. To represent end-of-sequence, yield documents and return without a final PageCursor."
@@ -594,8 +606,11 @@ async def _binding_incremental_task(
             if isinstance(item, BaseDocument):
                 task.captured(binding_index, item)
                 pending = True
+            elif isinstance(item, AssociatedDocument):
+                # TODO(jshearer): Assert that the binding index exists (and is enabled?)
+                task.captured(item.binding, item.doc)
+                pending = True
             else:
-
                 # Ensure LogCursor types match and that they're strictly increasing.
                 is_larger = False
                 if isinstance(item, int) and isinstance(state.cursor, int):

--- a/estuary-cdk/estuary_cdk/capture/common.py
+++ b/estuary-cdk/estuary_cdk/capture/common.py
@@ -36,7 +36,7 @@ The two predominant strategies for accessing logs are:
 Note that `str` cannot be added to this type union, as it makes parsing states ambiguous.
 """
 
-PageCursor = str | NonNegativeInt | None
+PageCursor = str | int | None
 """PageCursor is a cursor into a paged result set.
 These cursors are predominantly an opaque string or an internal offset integer.
 

--- a/source-gladly/source_gladly/resources.py
+++ b/source-gladly/source_gladly/resources.py
@@ -35,6 +35,7 @@ async def all_resources(
         binding_index: int,
         state: ResourceState,
         task: Task,
+        all_bindings
     ):
         common.open_binding(
             binding,

--- a/source-google-sheets-native/source_google_sheets_native/resources.py
+++ b/source-google-sheets-native/source_google_sheets_native/resources.py
@@ -50,6 +50,7 @@ def sheet(http: HTTPSession, spreadsheet_id: str, sheet: Sheet):
         binding_index: int,
         state: ResourceState,
         task: Task,
+        all_bindings
     ):
         common.open_binding(
             binding,

--- a/source-hubspot-native/source_hubspot_native/resources.py
+++ b/source-hubspot-native/source_hubspot_native/resources.py
@@ -185,6 +185,7 @@ def crm_object_custom(
         binding_index: int,
         state: ResourceState,
         task: Task,
+        all_bindings
     ):
         common.open_binding(
             binding,
@@ -393,6 +394,7 @@ def properties(http: HTTPSession) -> common.Resource:
         binding_index: int,
         state: ResourceState,
         task: Task,
+        all_bindings
     ):
         common.open_binding(
             binding,


### PR DESCRIPTION
**Description:**

Updates to the CDK that arose out of Netsuite work:

* Relax `PageCursor` to accept negative ints. This is just a typing change, but it was required because some page cursor values in Netsuite are genuinely negative ints
* Teach `FetchChangesFn` and `FetchPageFn` to accept documents for different bindings by way of yielding `AssociatedDocuments`. This is needed in order to enable loading associated documents, which we need to do for e.g `TransactionAccountingLine`
* Pass `open()` information about all bindings in order for it to find the bindings of its associations (specifically so that it knows which binding index to emit documents for when loading associated docs)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1458)
<!-- Reviewable:end -->
