### PR TITLE
sqlcapture: history mode

### DIFF
--- a/source-mysql/.snapshots/TestGeneric-SpecResponse
+++ b/source-mysql/.snapshots/TestGeneric-SpecResponse
@@ -30,6 +30,12 @@
         "description": "Timezone to use when capturing datetime columns. Should normally be left blank to use the database's 'time_zone' system variable. Only required if the 'time_zone' system variable cannot be read and columns with type datetime are being captured. Must be a valid IANA time zone name or +HH:MM offset. Takes precedence over the 'time_zone' system variable if both are set (go.estuary.dev/80J6rX).",
         "order": 3
       },
+      "historyMode": {
+        "type": "boolean",
+        "description": "Capture change events without reducing them to a final state.",
+        "default": true,
+        "order": 4
+      },
       "advanced": {
         "properties": {
           "watermarks_table": {
@@ -109,7 +115,8 @@
     "required": [
       "address",
       "user",
-      "password"
+      "password",
+      "historyMode"
     ],
     "title": "MySQL Connection"
   },

--- a/source-mysql/main.go
+++ b/source-mysql/main.go
@@ -45,16 +45,6 @@ var mysqlDriver = &sqlcapture.Driver{
 	ConfigSchema:     configSchema(),
 	DocumentationURL: "https://go.estuary.dev/source-mysql",
 	Connect:          connectMySQL,
-	HistoryMode:      historyMode,
-}
-
-func historyMode(cfg json.RawMessage) (bool, error) {
-	var config Config
-	if err := pf.UnmarshalStrict(cfg, &config); err != nil {
-		return false, fmt.Errorf("error parsing config json: %w", err)
-	}
-
-	return config.HistoryMode, nil
 }
 
 func main() {
@@ -221,6 +211,10 @@ type mysqlDatabase struct {
 	explained        map[string]struct{} // Tracks tables which have had an `EXPLAIN` run on them during this connector invocation.
 	datetimeLocation *time.Location      // The location in which to interpret DATETIME column values as timestamps.
 	includeTxIDs     map[string]bool     // Tracks which tables should have XID properties in their replication metadata.
+}
+
+func (db *mysqlDatabase) HistoryMode() bool {
+	return db.config.HistoryMode
 }
 
 func (db *mysqlDatabase) connect(ctx context.Context) error {

--- a/source-mysql/main.go
+++ b/source-mysql/main.go
@@ -45,6 +45,16 @@ var mysqlDriver = &sqlcapture.Driver{
 	ConfigSchema:     configSchema(),
 	DocumentationURL: "https://go.estuary.dev/source-mysql",
 	Connect:          connectMySQL,
+	HistoryMode:      historyMode,
+}
+
+func historyMode(cfg json.RawMessage) (bool, error) {
+	var config Config
+	if err := pf.UnmarshalStrict(cfg, &config); err != nil {
+		return false, fmt.Errorf("error parsing config json: %w", err)
+	}
+
+	return config.HistoryMode, nil
 }
 
 func main() {
@@ -112,11 +122,12 @@ func fixMysqlLogging() {
 // Config tells the connector how to connect to the source database and
 // capture changes from it.
 type Config struct {
-	Address  string         `json:"address" jsonschema:"title=Server Address,description=The host or host:port at which the database can be reached." jsonschema_extras:"order=0"`
-	User     string         `json:"user" jsonschema:"title=Login Username,default=flow_capture,description=The database user to authenticate as." jsonschema_extras:"order=1"`
-	Password string         `json:"password" jsonschema:"title=Login Password,description=Password for the specified database user." jsonschema_extras:"secret=true,order=2"`
-	Timezone string         `json:"timezone,omitempty" jsonschema:"title=Timezone,description=Timezone to use when capturing datetime columns. Should normally be left blank to use the database's 'time_zone' system variable. Only required if the 'time_zone' system variable cannot be read and columns with type datetime are being captured. Must be a valid IANA time zone name or +HH:MM offset. Takes precedence over the 'time_zone' system variable if both are set (go.estuary.dev/80J6rX)." jsonschema_extras:"order=3"`
-	Advanced advancedConfig `json:"advanced,omitempty" jsonschema:"title=Advanced Options,description=Options for advanced users. You should not typically need to modify these." jsonschema_extra:"advanced=true"`
+	Address     string         `json:"address" jsonschema:"title=Server Address,description=The host or host:port at which the database can be reached." jsonschema_extras:"order=0"`
+	User        string         `json:"user" jsonschema:"title=Login Username,default=flow_capture,description=The database user to authenticate as." jsonschema_extras:"order=1"`
+	Password    string         `json:"password" jsonschema:"title=Login Password,description=Password for the specified database user." jsonschema_extras:"secret=true,order=2"`
+	Timezone    string         `json:"timezone,omitempty" jsonschema:"title=Timezone,description=Timezone to use when capturing datetime columns. Should normally be left blank to use the database's 'time_zone' system variable. Only required if the 'time_zone' system variable cannot be read and columns with type datetime are being captured. Must be a valid IANA time zone name or +HH:MM offset. Takes precedence over the 'time_zone' system variable if both are set (go.estuary.dev/80J6rX)." jsonschema_extras:"order=3"`
+	HistoryMode bool           `json:"historyMode" jsonschema:"default=true,description=Capture change events without reducing them to a final state." jsonschema_extras:"order=4"`
+	Advanced    advancedConfig `json:"advanced,omitempty" jsonschema:"title=Advanced Options,description=Options for advanced users. You should not typically need to modify these." jsonschema_extra:"advanced=true"`
 
 	NetworkTunnel *tunnelConfig `json:"networkTunnel,omitempty" jsonschema:"title=Network Tunnel,description=Connect to your system through an SSH server that acts as a bastion host for your network."`
 }

--- a/source-postgres/.snapshots/TestCapitalizedTables-Discover
+++ b/source-postgres/.snapshots/TestCapitalizedTables-Discover
@@ -25,6 +25,28 @@ Binding 0:
       },
       "allOf": [
         {
+          "if": {
+            "properties": {
+              "_meta": {
+                "properties": {
+                  "op": {
+                    "const": "d"
+                  }
+                }
+              }
+            }
+          },
+          "then": {
+            "reduce": {
+              "delete": true,
+              "strategy": "merge"
+            }
+          },
+          "else": {
+            "reduce": {
+              "strategy": "merge"
+            }
+          },
           "required": [
             "_meta"
           ],
@@ -96,9 +118,6 @@ Binding 0:
                 "strategy": "merge"
               }
             }
-          },
-          "reduce": {
-            "strategy": "merge"
           }
         },
         {

--- a/source-postgres/.snapshots/TestDiscoveryCapitalization
+++ b/source-postgres/.snapshots/TestDiscoveryCapitalization
@@ -28,6 +28,28 @@ Binding 0:
       },
       "allOf": [
         {
+          "if": {
+            "properties": {
+              "_meta": {
+                "properties": {
+                  "op": {
+                    "const": "d"
+                  }
+                }
+              }
+            }
+          },
+          "then": {
+            "reduce": {
+              "delete": true,
+              "strategy": "merge"
+            }
+          },
+          "else": {
+            "reduce": {
+              "strategy": "merge"
+            }
+          },
           "required": [
             "_meta"
           ],
@@ -99,9 +121,6 @@ Binding 0:
                 "strategy": "merge"
               }
             }
-          },
-          "reduce": {
-            "strategy": "merge"
           }
         },
         {
@@ -143,6 +162,28 @@ Binding 1:
       },
       "allOf": [
         {
+          "if": {
+            "properties": {
+              "_meta": {
+                "properties": {
+                  "op": {
+                    "const": "d"
+                  }
+                }
+              }
+            }
+          },
+          "then": {
+            "reduce": {
+              "delete": true,
+              "strategy": "merge"
+            }
+          },
+          "else": {
+            "reduce": {
+              "strategy": "merge"
+            }
+          },
           "required": [
             "_meta"
           ],
@@ -214,9 +255,6 @@ Binding 1:
                 "strategy": "merge"
               }
             }
-          },
-          "reduce": {
-            "strategy": "merge"
           }
         },
         {
@@ -258,6 +296,28 @@ Binding 2:
       },
       "allOf": [
         {
+          "if": {
+            "properties": {
+              "_meta": {
+                "properties": {
+                  "op": {
+                    "const": "d"
+                  }
+                }
+              }
+            }
+          },
+          "then": {
+            "reduce": {
+              "delete": true,
+              "strategy": "merge"
+            }
+          },
+          "else": {
+            "reduce": {
+              "strategy": "merge"
+            }
+          },
           "required": [
             "_meta"
           ],
@@ -329,9 +389,6 @@ Binding 2:
                 "strategy": "merge"
               }
             }
-          },
-          "reduce": {
-            "strategy": "merge"
           }
         },
         {

--- a/source-postgres/.snapshots/TestDiscoveryComplex
+++ b/source-postgres/.snapshots/TestDiscoveryComplex
@@ -45,6 +45,28 @@ Binding 0:
       },
       "allOf": [
         {
+          "if": {
+            "properties": {
+              "_meta": {
+                "properties": {
+                  "op": {
+                    "const": "d"
+                  }
+                }
+              }
+            }
+          },
+          "then": {
+            "reduce": {
+              "delete": true,
+              "strategy": "merge"
+            }
+          },
+          "else": {
+            "reduce": {
+              "strategy": "merge"
+            }
+          },
           "required": [
             "_meta"
           ],
@@ -116,9 +138,6 @@ Binding 0:
                 "strategy": "merge"
               }
             }
-          },
-          "reduce": {
-            "strategy": "merge"
           }
         },
         {

--- a/source-postgres/.snapshots/TestDiscoveryWithoutPermissions
+++ b/source-postgres/.snapshots/TestDiscoveryWithoutPermissions
@@ -28,6 +28,28 @@ Binding 0:
       },
       "allOf": [
         {
+          "if": {
+            "properties": {
+              "_meta": {
+                "properties": {
+                  "op": {
+                    "const": "d"
+                  }
+                }
+              }
+            }
+          },
+          "then": {
+            "reduce": {
+              "delete": true,
+              "strategy": "merge"
+            }
+          },
+          "else": {
+            "reduce": {
+              "strategy": "merge"
+            }
+          },
           "required": [
             "_meta"
           ],
@@ -99,9 +121,6 @@ Binding 0:
                 "strategy": "merge"
               }
             }
-          },
-          "reduce": {
-            "strategy": "merge"
           }
         },
         {

--- a/source-postgres/.snapshots/TestGeneric-KeylessDiscovery
+++ b/source-postgres/.snapshots/TestGeneric-KeylessDiscovery
@@ -38,6 +38,28 @@ Binding 0:
       },
       "allOf": [
         {
+          "if": {
+            "properties": {
+              "_meta": {
+                "properties": {
+                  "op": {
+                    "const": "d"
+                  }
+                }
+              }
+            }
+          },
+          "then": {
+            "reduce": {
+              "delete": true,
+              "strategy": "merge"
+            }
+          },
+          "else": {
+            "reduce": {
+              "strategy": "merge"
+            }
+          },
           "required": [
             "_meta"
           ],
@@ -109,9 +131,6 @@ Binding 0:
                 "strategy": "merge"
               }
             }
-          },
-          "reduce": {
-            "strategy": "merge"
           }
         },
         {

--- a/source-postgres/.snapshots/TestGeneric-SimpleDiscovery
+++ b/source-postgres/.snapshots/TestGeneric-SimpleDiscovery
@@ -37,6 +37,28 @@ Binding 0:
       },
       "allOf": [
         {
+          "if": {
+            "properties": {
+              "_meta": {
+                "properties": {
+                  "op": {
+                    "const": "d"
+                  }
+                }
+              }
+            }
+          },
+          "then": {
+            "reduce": {
+              "delete": true,
+              "strategy": "merge"
+            }
+          },
+          "else": {
+            "reduce": {
+              "strategy": "merge"
+            }
+          },
           "required": [
             "_meta"
           ],
@@ -108,9 +130,6 @@ Binding 0:
                 "strategy": "merge"
               }
             }
-          },
-          "reduce": {
-            "strategy": "merge"
           }
         },
         {

--- a/source-postgres/.snapshots/TestGeneric-SpecResponse
+++ b/source-postgres/.snapshots/TestGeneric-SpecResponse
@@ -28,6 +28,12 @@
         "default": "postgres",
         "order": 3
       },
+      "historyMode": {
+        "type": "boolean",
+        "description": "Capture change events without reducing them to a final state.",
+        "default": true,
+        "order": 4
+      },
       "advanced": {
         "properties": {
           "publicationName": {
@@ -121,7 +127,8 @@
       "address",
       "user",
       "password",
-      "database"
+      "database",
+      "historyMode"
     ],
     "title": "PostgreSQL Connection"
   },
@@ -145,12 +152,14 @@
       "namespace": {
         "type": "string",
         "title": "Schema",
-        "description": "The schema (namespace) in which the table resides."
+        "description": "The schema (namespace) in which the table resides.",
+        "readOnly": true
       },
       "stream": {
         "type": "string",
         "title": "Table Name",
-        "description": "The name of the table to be captured."
+        "description": "The name of the table to be captured.",
+        "readOnly": true
       }
     },
     "type": "object",

--- a/source-postgres/.snapshots/TestPartitionedTableDiscovery
+++ b/source-postgres/.snapshots/TestPartitionedTableDiscovery
@@ -29,6 +29,28 @@ Binding 0:
       },
       "allOf": [
         {
+          "if": {
+            "properties": {
+              "_meta": {
+                "properties": {
+                  "op": {
+                    "const": "d"
+                  }
+                }
+              }
+            }
+          },
+          "then": {
+            "reduce": {
+              "delete": true,
+              "strategy": "merge"
+            }
+          },
+          "else": {
+            "reduce": {
+              "strategy": "merge"
+            }
+          },
           "required": [
             "_meta"
           ],
@@ -100,9 +122,6 @@ Binding 0:
                 "strategy": "merge"
               }
             }
-          },
-          "reduce": {
-            "strategy": "merge"
           }
         },
         {

--- a/source-postgres/.snapshots/TestSecondaryIndexDiscovery-index_only
+++ b/source-postgres/.snapshots/TestSecondaryIndexDiscovery-index_only
@@ -38,6 +38,28 @@ Binding 0:
       },
       "allOf": [
         {
+          "if": {
+            "properties": {
+              "_meta": {
+                "properties": {
+                  "op": {
+                    "const": "d"
+                  }
+                }
+              }
+            }
+          },
+          "then": {
+            "reduce": {
+              "delete": true,
+              "strategy": "merge"
+            }
+          },
+          "else": {
+            "reduce": {
+              "strategy": "merge"
+            }
+          },
           "required": [
             "_meta"
           ],
@@ -109,9 +131,6 @@ Binding 0:
                 "strategy": "merge"
               }
             }
-          },
-          "reduce": {
-            "strategy": "merge"
           }
         },
         {

--- a/source-postgres/.snapshots/TestSecondaryIndexDiscovery-nonunique_index
+++ b/source-postgres/.snapshots/TestSecondaryIndexDiscovery-nonunique_index
@@ -35,6 +35,28 @@ Binding 0:
       },
       "allOf": [
         {
+          "if": {
+            "properties": {
+              "_meta": {
+                "properties": {
+                  "op": {
+                    "const": "d"
+                  }
+                }
+              }
+            }
+          },
+          "then": {
+            "reduce": {
+              "delete": true,
+              "strategy": "merge"
+            }
+          },
+          "else": {
+            "reduce": {
+              "strategy": "merge"
+            }
+          },
           "required": [
             "_meta"
           ],
@@ -106,9 +128,6 @@ Binding 0:
                 "strategy": "merge"
               }
             }
-          },
-          "reduce": {
-            "strategy": "merge"
           }
         },
         {

--- a/source-postgres/.snapshots/TestSecondaryIndexDiscovery-nothing
+++ b/source-postgres/.snapshots/TestSecondaryIndexDiscovery-nothing
@@ -35,6 +35,28 @@ Binding 0:
       },
       "allOf": [
         {
+          "if": {
+            "properties": {
+              "_meta": {
+                "properties": {
+                  "op": {
+                    "const": "d"
+                  }
+                }
+              }
+            }
+          },
+          "then": {
+            "reduce": {
+              "delete": true,
+              "strategy": "merge"
+            }
+          },
+          "else": {
+            "reduce": {
+              "strategy": "merge"
+            }
+          },
           "required": [
             "_meta"
           ],
@@ -106,9 +128,6 @@ Binding 0:
                 "strategy": "merge"
               }
             }
-          },
-          "reduce": {
-            "strategy": "merge"
           }
         },
         {

--- a/source-postgres/.snapshots/TestSecondaryIndexDiscovery-nullable_index
+++ b/source-postgres/.snapshots/TestSecondaryIndexDiscovery-nullable_index
@@ -41,6 +41,28 @@ Binding 0:
       },
       "allOf": [
         {
+          "if": {
+            "properties": {
+              "_meta": {
+                "properties": {
+                  "op": {
+                    "const": "d"
+                  }
+                }
+              }
+            }
+          },
+          "then": {
+            "reduce": {
+              "delete": true,
+              "strategy": "merge"
+            }
+          },
+          "else": {
+            "reduce": {
+              "strategy": "merge"
+            }
+          },
           "required": [
             "_meta"
           ],
@@ -112,9 +134,6 @@ Binding 0:
                 "strategy": "merge"
               }
             }
-          },
-          "reduce": {
-            "strategy": "merge"
           }
         },
         {

--- a/source-postgres/.snapshots/TestSecondaryIndexDiscovery-pk_and_index
+++ b/source-postgres/.snapshots/TestSecondaryIndexDiscovery-pk_and_index
@@ -34,6 +34,28 @@ Binding 0:
       },
       "allOf": [
         {
+          "if": {
+            "properties": {
+              "_meta": {
+                "properties": {
+                  "op": {
+                    "const": "d"
+                  }
+                }
+              }
+            }
+          },
+          "then": {
+            "reduce": {
+              "delete": true,
+              "strategy": "merge"
+            }
+          },
+          "else": {
+            "reduce": {
+              "strategy": "merge"
+            }
+          },
           "required": [
             "_meta"
           ],
@@ -105,9 +127,6 @@ Binding 0:
                 "strategy": "merge"
               }
             }
-          },
-          "reduce": {
-            "strategy": "merge"
           }
         },
         {

--- a/source-postgres/.snapshots/TestTrickyColumnNames-discover
+++ b/source-postgres/.snapshots/TestTrickyColumnNames-discover
@@ -28,6 +28,28 @@ Binding 0:
       },
       "allOf": [
         {
+          "if": {
+            "properties": {
+              "_meta": {
+                "properties": {
+                  "op": {
+                    "const": "d"
+                  }
+                }
+              }
+            }
+          },
+          "then": {
+            "reduce": {
+              "delete": true,
+              "strategy": "merge"
+            }
+          },
+          "else": {
+            "reduce": {
+              "strategy": "merge"
+            }
+          },
           "required": [
             "_meta"
           ],
@@ -99,9 +121,6 @@ Binding 0:
                 "strategy": "merge"
               }
             }
-          },
-          "reduce": {
-            "strategy": "merge"
           }
         },
         {
@@ -143,6 +162,28 @@ Binding 1:
       },
       "allOf": [
         {
+          "if": {
+            "properties": {
+              "_meta": {
+                "properties": {
+                  "op": {
+                    "const": "d"
+                  }
+                }
+              }
+            }
+          },
+          "then": {
+            "reduce": {
+              "delete": true,
+              "strategy": "merge"
+            }
+          },
+          "else": {
+            "reduce": {
+              "strategy": "merge"
+            }
+          },
           "required": [
             "_meta"
           ],
@@ -214,9 +255,6 @@ Binding 1:
                 "strategy": "merge"
               }
             }
-          },
-          "reduce": {
-            "strategy": "merge"
           }
         },
         {

--- a/source-postgres/.snapshots/TestUserTypes-Domain-Discovery
+++ b/source-postgres/.snapshots/TestUserTypes-Domain-Discovery
@@ -28,6 +28,28 @@ Binding 0:
       },
       "allOf": [
         {
+          "if": {
+            "properties": {
+              "_meta": {
+                "properties": {
+                  "op": {
+                    "const": "d"
+                  }
+                }
+              }
+            }
+          },
+          "then": {
+            "reduce": {
+              "delete": true,
+              "strategy": "merge"
+            }
+          },
+          "else": {
+            "reduce": {
+              "strategy": "merge"
+            }
+          },
           "required": [
             "_meta"
           ],
@@ -99,9 +121,6 @@ Binding 0:
                 "strategy": "merge"
               }
             }
-          },
-          "reduce": {
-            "strategy": "merge"
           }
         },
         {

--- a/source-postgres/.snapshots/TestUserTypes-Enum-Discovery
+++ b/source-postgres/.snapshots/TestUserTypes-Enum-Discovery
@@ -28,6 +28,28 @@ Binding 0:
       },
       "allOf": [
         {
+          "if": {
+            "properties": {
+              "_meta": {
+                "properties": {
+                  "op": {
+                    "const": "d"
+                  }
+                }
+              }
+            }
+          },
+          "then": {
+            "reduce": {
+              "delete": true,
+              "strategy": "merge"
+            }
+          },
+          "else": {
+            "reduce": {
+              "strategy": "merge"
+            }
+          },
           "required": [
             "_meta"
           ],
@@ -99,9 +121,6 @@ Binding 0:
                 "strategy": "merge"
               }
             }
-          },
-          "reduce": {
-            "strategy": "merge"
           }
         },
         {

--- a/source-postgres/.snapshots/TestUserTypes-Range-Discovery
+++ b/source-postgres/.snapshots/TestUserTypes-Range-Discovery
@@ -28,6 +28,28 @@ Binding 0:
       },
       "allOf": [
         {
+          "if": {
+            "properties": {
+              "_meta": {
+                "properties": {
+                  "op": {
+                    "const": "d"
+                  }
+                }
+              }
+            }
+          },
+          "then": {
+            "reduce": {
+              "delete": true,
+              "strategy": "merge"
+            }
+          },
+          "else": {
+            "reduce": {
+              "strategy": "merge"
+            }
+          },
           "required": [
             "_meta"
           ],
@@ -99,9 +121,6 @@ Binding 0:
                 "strategy": "merge"
               }
             }
-          },
-          "reduce": {
-            "strategy": "merge"
           }
         },
         {

--- a/source-postgres/.snapshots/TestUserTypes-Tuple-Discovery
+++ b/source-postgres/.snapshots/TestUserTypes-Tuple-Discovery
@@ -25,6 +25,28 @@ Binding 0:
       },
       "allOf": [
         {
+          "if": {
+            "properties": {
+              "_meta": {
+                "properties": {
+                  "op": {
+                    "const": "d"
+                  }
+                }
+              }
+            }
+          },
+          "then": {
+            "reduce": {
+              "delete": true,
+              "strategy": "merge"
+            }
+          },
+          "else": {
+            "reduce": {
+              "strategy": "merge"
+            }
+          },
           "required": [
             "_meta"
           ],
@@ -96,9 +118,6 @@ Binding 0:
                 "strategy": "merge"
               }
             }
-          },
-          "reduce": {
-            "strategy": "merge"
           }
         },
         {

--- a/source-postgres/Dockerfile
+++ b/source-postgres/Dockerfile
@@ -9,7 +9,7 @@ WORKDIR /builder
 # Download & compile dependencies early. Doing this separately allows for layer
 # caching opportunities when no dependencies are updated.
 COPY go.* ./
-# RUN go mod download
+RUN go mod download
 
 COPY go                  ./go
 COPY source-boilerplate  ./source-boilerplate
@@ -23,7 +23,7 @@ ENV PATH="/builder/bin:$PATH"
 ARG TEST_DATABASE=yes
 ENV TEST_DATABASE=$TEST_DATABASE
 ENV CI_BUILD=yes
-# RUN go test -short -v ./source-postgres/... --db_address=localhost:5432
+RUN go test -short -v ./source-postgres/... --db_address=localhost:5432
 
 # Build the connector.
 RUN --mount=type=cache,id=gomod,target=/go/pkg/mod \

--- a/source-postgres/main.go
+++ b/source-postgres/main.go
@@ -38,6 +38,16 @@ var postgresDriver = &sqlcapture.Driver{
 	ConfigSchema:     configSchema(),
 	DocumentationURL: "https://go.estuary.dev/source-postgresql",
 	Connect:          connectPostgres,
+	HistoryMode:      historyMode,
+}
+
+func historyMode(cfg json.RawMessage) (bool, error) {
+	var config Config
+	if err := pf.UnmarshalStrict(cfg, &config); err != nil {
+		return false, fmt.Errorf("error parsing config json: %w", err)
+	}
+
+	return config.HistoryMode, nil
 }
 
 // The standard library `time.RFC3339Nano` is wrong for historical reasons, this
@@ -88,11 +98,12 @@ func connectPostgres(ctx context.Context, name string, cfg json.RawMessage) (sql
 
 // Config tells the connector how to connect to and interact with the source database.
 type Config struct {
-	Address  string         `json:"address" jsonschema:"title=Server Address,description=The host or host:port at which the database can be reached." jsonschema_extras:"order=0"`
-	User     string         `json:"user" jsonschema:"default=flow_capture,description=The database user to authenticate as." jsonschema_extras:"order=1"`
-	Password string         `json:"password" jsonschema:"description=Password for the specified database user." jsonschema_extras:"secret=true,order=2"`
-	Database string         `json:"database" jsonschema:"default=postgres,description=Logical database name to capture from." jsonschema_extras:"order=3"`
-	Advanced advancedConfig `json:"advanced,omitempty" jsonschema:"title=Advanced Options,description=Options for advanced users. You should not typically need to modify these." jsonschema_extra:"advanced=true"`
+	Address     string         `json:"address" jsonschema:"title=Server Address,description=The host or host:port at which the database can be reached." jsonschema_extras:"order=0"`
+	User        string         `json:"user" jsonschema:"default=flow_capture,description=The database user to authenticate as." jsonschema_extras:"order=1"`
+	Password    string         `json:"password" jsonschema:"description=Password for the specified database user." jsonschema_extras:"secret=true,order=2"`
+	Database    string         `json:"database" jsonschema:"default=postgres,description=Logical database name to capture from." jsonschema_extras:"order=3"`
+	HistoryMode bool           `json:"historyMode" jsonschema:"default=true,description=Capture change events without reducing them to a final state." jsonschema_extras:"order=4"`
+	Advanced    advancedConfig `json:"advanced,omitempty" jsonschema:"title=Advanced Options,description=Options for advanced users. You should not typically need to modify these." jsonschema_extra:"advanced=true"`
 
 	NetworkTunnel *tunnelConfig `json:"networkTunnel,omitempty" jsonschema:"title=Network Tunnel,description=Connect to your system through an SSH server that acts as a bastion host for your network."`
 }

--- a/source-postgres/main.go
+++ b/source-postgres/main.go
@@ -38,16 +38,6 @@ var postgresDriver = &sqlcapture.Driver{
 	ConfigSchema:     configSchema(),
 	DocumentationURL: "https://go.estuary.dev/source-postgresql",
 	Connect:          connectPostgres,
-	HistoryMode:      historyMode,
-}
-
-func historyMode(cfg json.RawMessage) (bool, error) {
-	var config Config
-	if err := pf.UnmarshalStrict(cfg, &config); err != nil {
-		return false, fmt.Errorf("error parsing config json: %w", err)
-	}
-
-	return config.HistoryMode, nil
 }
 
 // The standard library `time.RFC3339Nano` is wrong for historical reasons, this
@@ -220,6 +210,10 @@ type postgresDatabase struct {
 	conn         *pgx.Conn
 	explained    map[string]struct{} // Tracks tables which have had an `EXPLAIN` run on them during this connector invocation
 	includeTxIDs map[string]bool     // Tracks which tables should have XID properties in their replication metadata
+}
+
+func (db *postgresDatabase) HistoryMode() bool {
+	return db.config.HistoryMode
 }
 
 func (db *postgresDatabase) connect(ctx context.Context) error {

--- a/source-sqlserver/.snapshots/TestGeneric-SpecResponse
+++ b/source-sqlserver/.snapshots/TestGeneric-SpecResponse
@@ -34,6 +34,12 @@
         "default": "UTC",
         "order": 4
       },
+      "historyMode": {
+        "type": "boolean",
+        "description": "Capture change events without reducing them to a final state.",
+        "default": true,
+        "order": 5
+      },
       "advanced": {
         "properties": {
           "watermarksTable": {
@@ -96,7 +102,8 @@
       "address",
       "user",
       "password",
-      "database"
+      "database",
+      "historyMode"
     ],
     "title": "SQL Server Connection"
   },

--- a/source-sqlserver/main.go
+++ b/source-sqlserver/main.go
@@ -30,19 +30,32 @@ var sqlserverDriver = &sqlcapture.Driver{
 	ConfigSchema:     configSchema(),
 	DocumentationURL: "https://go.estuary.dev/source-sqlserver",
 	Connect:          connectSQLServer,
+	HistoryMode:      historyMode,
+}
+
+func historyMode(cfg json.RawMessage) (bool, error) {
+	var config Config
+	if err := pf.UnmarshalStrict(cfg, &config); err != nil {
+		return false, fmt.Errorf("error parsing config json: %w", err)
+	}
+
+	return config.HistoryMode, nil
 }
 
 const defaultPort = "1433"
 
 // Config tells the connector how to connect to and interact with the source database.
 type Config struct {
-	Address       string         `json:"address" jsonschema:"title=Server Address,description=The host or host:port at which the database can be reached." jsonschema_extras:"order=0"`
-	User          string         `json:"user" jsonschema:"default=flow_capture,description=The database user to authenticate as." jsonschema_extras:"order=1"`
-	Password      string         `json:"password" jsonschema:"description=Password for the specified database user." jsonschema_extras:"secret=true,order=2"`
-	Database      string         `json:"database" jsonschema:"description=Logical database name to capture from." jsonschema_extras:"order=3"`
-	Timezone      string         `json:"timezone,omitempty" jsonschema:"title=Time Zone,default=UTC,description=The IANA timezone name in which datetime columns will be converted to RFC3339 timestamps. Defaults to UTC if left blank." jsonschema_extras:"order=4"`
-	Advanced      advancedConfig `json:"advanced,omitempty" jsonschema:"title=Advanced Options,description=Options for advanced users. You should not typically need to modify these." jsonschema_extra:"advanced=true"`
-	NetworkTunnel *tunnelConfig  `json:"networkTunnel,omitempty" jsonschema:"title=Network Tunnel,description=Connect to your system through an SSH server that acts as a bastion host for your network."`
+	Address     string `json:"address" jsonschema:"title=Server Address,description=The host or host:port at which the database can be reached." jsonschema_extras:"order=0"`
+	User        string `json:"user" jsonschema:"default=flow_capture,description=The database user to authenticate as." jsonschema_extras:"order=1"`
+	Password    string `json:"password" jsonschema:"description=Password for the specified database user." jsonschema_extras:"secret=true,order=2"`
+	Database    string `json:"database" jsonschema:"description=Logical database name to capture from." jsonschema_extras:"order=3"`
+	Timezone    string `json:"timezone,omitempty" jsonschema:"title=Time Zone,default=UTC,description=The IANA timezone name in which datetime columns will be converted to RFC3339 timestamps. Defaults to UTC if left blank." jsonschema_extras:"order=4"`
+	HistoryMode bool   `json:"historyMode" jsonschema:"default=true,description=Capture change events without reducing them to a final state." jsonschema_extras:"order=5"`
+
+	Advanced advancedConfig `json:"advanced,omitempty" jsonschema:"title=Advanced Options,description=Options for advanced users. You should not typically need to modify these." jsonschema_extra:"advanced=true"`
+
+	NetworkTunnel *tunnelConfig `json:"networkTunnel,omitempty" jsonschema:"title=Network Tunnel,description=Connect to your system through an SSH server that acts as a bastion host for your network."`
 }
 
 type advancedConfig struct {

--- a/source-sqlserver/main.go
+++ b/source-sqlserver/main.go
@@ -30,16 +30,6 @@ var sqlserverDriver = &sqlcapture.Driver{
 	ConfigSchema:     configSchema(),
 	DocumentationURL: "https://go.estuary.dev/source-sqlserver",
 	Connect:          connectSQLServer,
-	HistoryMode:      historyMode,
-}
-
-func historyMode(cfg json.RawMessage) (bool, error) {
-	var config Config
-	if err := pf.UnmarshalStrict(cfg, &config); err != nil {
-		return false, fmt.Errorf("error parsing config json: %w", err)
-	}
-
-	return config.HistoryMode, nil
 }
 
 const defaultPort = "1433"
@@ -202,6 +192,10 @@ type sqlserverDatabase struct {
 	conn   *sql.DB
 
 	datetimeLocation *time.Location // The location in which to interpret DATETIME column values as timestamps.
+}
+
+func (db *sqlserverDatabase) HistoryMode() bool {
+	return db.config.HistoryMode
 }
 
 func (db *sqlserverDatabase) connect(ctx context.Context) error {

--- a/sqlcapture/discovery.go
+++ b/sqlcapture/discovery.go
@@ -15,7 +15,7 @@ import (
 
 // DiscoverCatalog queries the database and generates discovered bindings
 // describing the available tables and their columns.
-func DiscoverCatalog(ctx context.Context, db Database) ([]*pc.Response_Discovered_Binding, error) {
+func DiscoverCatalog(ctx context.Context, db Database, historyMode bool) ([]*pc.Response_Discovered_Binding, error) {
 	tables, err := db.DiscoverTables(ctx)
 	if err != nil {
 		return nil, err
@@ -34,6 +34,15 @@ func DiscoverCatalog(ctx context.Context, db Database) ([]*pc.Response_Discovere
 		AllowAdditionalProperties: true,
 	}).Reflect(db.EmptySourceMetadata())
 	sourceSchema.Version = ""
+
+	if historyMode {
+		sourceSchema.Extras = map[string]interface{}{
+			"reduce": map[string]interface{}{
+				"strategy":    "lastWriteWins",
+				"associative": false,
+			},
+		}
+	}
 
 	var catalog []*pc.Response_Discovered_Binding
 	for _, table := range tables {

--- a/sqlcapture/discovery.go
+++ b/sqlcapture/discovery.go
@@ -15,7 +15,7 @@ import (
 
 // DiscoverCatalog queries the database and generates discovered bindings
 // describing the available tables and their columns.
-func DiscoverCatalog(ctx context.Context, db Database, historyMode bool) ([]*pc.Response_Discovered_Binding, error) {
+func DiscoverCatalog(ctx context.Context, db Database) ([]*pc.Response_Discovered_Binding, error) {
 	tables, err := db.DiscoverTables(ctx)
 	if err != nil {
 		return nil, err
@@ -35,7 +35,7 @@ func DiscoverCatalog(ctx context.Context, db Database, historyMode bool) ([]*pc.
 	}).Reflect(db.EmptySourceMetadata())
 	sourceSchema.Version = ""
 
-	if historyMode {
+	if db.HistoryMode() {
 		sourceSchema.Extras = map[string]interface{}{
 			"reduce": map[string]interface{}{
 				"strategy":    "lastWriteWins",

--- a/sqlcapture/interface.go
+++ b/sqlcapture/interface.go
@@ -132,6 +132,8 @@ type Database interface {
 	EmptySourceMetadata() SourceMetadata
 	// ShouldBackfill returns true if a given table's contents should be backfilled.
 	ShouldBackfill(streamID string) bool
+	// HistoryMode returns whether history mode (non-associative reduction of events) is enabled
+	HistoryMode() bool
 
 	// The collection key which should be suggested if discovery fails to find suitable
 	// primary key. This should be some property or combination of properties in the

--- a/sqlcapture/main.go
+++ b/sqlcapture/main.go
@@ -92,8 +92,7 @@ type Driver struct {
 	ConfigSchema     json.RawMessage
 	DocumentationURL string
 
-	Connect     func(ctx context.Context, name string, cfg json.RawMessage) (Database, error)
-	HistoryMode func(cfg json.RawMessage) (bool, error)
+	Connect func(ctx context.Context, name string, cfg json.RawMessage) (Database, error)
 }
 
 type prerequisitesError struct {
@@ -183,12 +182,7 @@ func (d *Driver) Validate(ctx context.Context, req *pc.Request_Validate) (*pc.Re
 	}
 	defer db.Close(ctx)
 
-	historyMode, err := d.HistoryMode(req.ConfigJson)
-	if err != nil {
-		return nil, fmt.Errorf("error checking history mode: %w", err)
-	}
-
-	if _, err := DiscoverCatalog(ctx, db, historyMode); err != nil {
+	if _, err := DiscoverCatalog(ctx, db); err != nil {
 		return nil, err
 	}
 
@@ -225,12 +219,7 @@ func (d *Driver) Discover(ctx context.Context, req *pc.Request_Discover) (*pc.Re
 	}
 	defer db.Close(ctx)
 
-	historyMode, err := d.HistoryMode(req.ConfigJson)
-	if err != nil {
-		return nil, fmt.Errorf("error checking history mode: %w", err)
-	}
-
-	discoveredBindings, err := DiscoverCatalog(ctx, db, historyMode)
+	discoveredBindings, err := DiscoverCatalog(ctx, db)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
**Description:**

- One important realisation about transaction reductions is that the first document of a transaction is never reduced, and it is only the second and third and subsequent documents that may be reduced together.
- Tested this change on postgres, mysql and sqlserver connectors and here are results:

Queries:
```
insert into test(id, x) values(1, 'created'); update test set x='updated'; update test set x='updated 2'; delete from test;
```

Postgres, History mode OFF:
```
["acmeCo/test",{"_meta":{"op":"c","source":{"loc":[24427448,24427448,24427584],"schema":"public","table":"test","ts_ms":1712561583740,"txid":2499}},"id":1,"x":"created"}]                                              
["acmeCo/test",{"_meta":{"op":"d","source":{"loc":[24427888,24427888,24427952],"schema":"public","table":"test","ts_ms":1712561583756,"txid":2502}},"id":1,"x":"updated 2"}]                                            
```


Postgres, History mode ON
```
["acmeCo/test",{"_meta":{"op":"c","source":{"loc":[24424896,24424896,24425464],"schema":"public","table":"test","ts_ms":1712561524977,"txid":2487}},"id":1,"x":"created"}]                                              
["acmeCo/test",{"_meta":{"op":"u","source":{"loc":[24425512,24425512,24425592],"schema":"public","table":"test","ts_ms":1712561524982,"txid":2488}},"id":1,"x":"updated"}]                                              
["acmeCo/test",{"_meta":{"op":"u","source":{"loc":[24425640,24425640,24425720],"schema":"public","table":"test","ts_ms":1712561524988,"txid":2489}},"id":1,"x":"updated 2"}]                                            
["acmeCo/test",{"_meta":{"op":"d","source":{"loc":[24425768,24425768,24425832],"schema":"public","table":"test","ts_ms":1712561524992,"txid":2490}},"id":1}]                                                         
```

MySQL, history mode off:

```
["acmeCo/test_test",{"_meta":{"op":"c","source":{"cursor":"binlog.000002:3502:0","schema":"test","table":"test","ts_ms":1712570573182,"txid":"d44110b4-f58e-11ee-88d1-0242ac130003:24"}},"id":1,"x":"created"}]         
["acmeCo/test_test",{"_meta":{"before":{"id":1,"x":"created"},"op":"d","source":{"cursor":"binlog.000002:4425:0","schema":"test","table":"test","ts_ms":1712570573201,"txid":"d44110b4-f58e-11ee-88d1-0242ac130003:27"}}
,"id":1,"x":"updated 2"}]
```

MySQL, History mode ON:
```
["acmeCo/test_test",{"_meta":{"op":"c","source":{"cursor":"binlog.000002:6158:0","schema":"test","table":"test","ts_ms":1712570640934,"txid":"d44110b4-f58e-11ee-88d1-0242ac130003:32"}},"id":1,"x":"created"}]
["acmeCo/test_test",{"_meta":{"before":{"id":1,"x":"created"},"op":"u","source":{"cursor":"binlog.000002:6472:0","schema":"test","table":"test","ts_ms":1712570640939,"txid":"d44110b4-f58e-11ee-88d1-0242ac130003:33"}},"id":1,"x":"updated"}]
["acmeCo/test_test",{"_meta":{"before":{"id":1,"x":"updated"},"op":"u","source":{"cursor":"binlog.000002:6788:0","schema":"test","table":"test","ts_ms":1712570640942,"txid":"d44110b4-f58e-11ee-88d1-0242ac130003:34"}},"id":1,"x":"updated 2"}]
["acmeCo/test_test",{"_meta":{"op":"d","source":{"cursor":"binlog.000002:7081:0","schema":"test","table":"test","ts_ms":1712570640945,"txid":"d44110b4-f58e-11ee-88d1-0242ac130003:35"}},"id":1,"x":"updated 2"}]
```

SQLServer, History mode OFF:

```
["acmeCo/test",{"_meta":{"op":"c","source":{"lsn":"AAAAKQAACmgAAw==","schema":"dbo","seqval":"AAAAKQAACmgAAg==","table":"test","updateMask":"Aw=="}},"id":1,"x":"created"}]                                             
["acmeCo/test",{"_meta":{"op":"d","source":{"lsn":"AAAAKQAACoAABQ==","schema":"dbo","seqval":"AAAAKQAACoAAAg==","table":"test","updateMask":"Aw=="}},"id":1,"x":"updated 2"}]
```

SQLServer, History mode ON:
```
["acmeCo/test",{"_meta":{"op":"c","source":{"lsn":"AAAAKQAADCAAAw==","schema":"dbo","seqval":"AAAAKQAADCAAAg==","table":"test","updateMask":"Aw=="}},"id":1,"x":"created"}]                                             
["acmeCo/test",{"_meta":{"op":"u","source":{"lsn":"AAAAKQAADCgAAw==","schema":"dbo","seqval":"AAAAKQAADCgAAg==","table":"test","updateMask":"Ag=="}},"id":1,"x":"updated"}]                                             
["acmeCo/test",{"_meta":{"op":"u","source":{"lsn":"AAAAKQAADDAAAw==","schema":"dbo","seqval":"AAAAKQAADDAAAg==","table":"test","updateMask":"Ag=="}},"id":1,"x":"updated 2"}]                                           
["acmeCo/test",{"_meta":{"op":"d","source":{"lsn":"AAAAKQAADDgABQ==","schema":"dbo","seqval":"AAAAKQAADDgAAg==","table":"test","updateMask":"Aw=="}},"id":1,"x":"updated 2"}]
```


**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1459)
<!-- Reviewable:end -->
