### PR TITLE
source-mysql: ignore more complicated CREATE ... DEFINER ... VIEW qs

### DIFF
--- a/source-mysql/replication.go
+++ b/source-mysql/replication.go
@@ -453,7 +453,8 @@ func decodeRow(streamID string, colNames []string, row []interface{}) (map[strin
 // TODO(johnny): SET STATEMENT is not safe in the general case, and we want to re-visit
 // by extracting and ignoring a SET STATEMENT stanza prior to parsing.
 var silentIgnoreQueriesRe = regexp.MustCompile(`(?i)^(BEGIN|# [^\n]*)$`)
-var ignoreQueriesRe = regexp.MustCompile(`(?i)^(BEGIN|COMMIT|GRANT|REVOKE|CREATE USER|CREATE DEFINER|DROP USER|ALTER USER|DROP PROCEDURE|DROP FUNCTION|DROP TRIGGER|SET STATEMENT|# |/\*|-- )`)
+var createDefinerRegex = `CREATE\s*(OR REPLACE){0,1}\s*(ALGORITHM\s*=\s*[^ ]+)*\s*DEFINER`
+var ignoreQueriesRe = regexp.MustCompile(`(?i)^(BEGIN|COMMIT|GRANT|REVOKE|CREATE USER|` + createDefinerRegex + `|DROP USER|ALTER USER|DROP PROCEDURE|DROP FUNCTION|DROP TRIGGER|SET STATEMENT|# |/\*|-- )`)
 
 func (rs *mysqlReplicationStream) handleQuery(ctx context.Context, schema, query string) error {
 	// There are basically three types of query events we might receive:

--- a/source-mysql/replication_test.go
+++ b/source-mysql/replication_test.go
@@ -8,6 +8,10 @@ func TestIgnoreQueries(t *testing.T) {
 		`/* This is also a comment */`: true,
 		`BEGIN`:                        true,
 		`COMMIT`:                       true,
+		`CREATE DEFINER`:               true,
+		`CREATE OR REPLACE DEFINER`:    true,
+		`CREATE OR REPLACE ALGORITHM=UNDEFINED DEFINER`: true,
+		`CREATE ALGORITHM = TEMPTABLE DEFINER`:          true,
 
 		`CREATE USER IF NOT EXISTS flow_capture IDENTIFIED BY 'secret1234'`: true,
 


### PR DESCRIPTION
**Description:**

- Ignore more complex cases of `CREATE VIEW`, such as this one:
```
CREATE ALGORITHM=UNDEFINED DEFINER=`viewer`@`%` SQL SECURITY DEFINER VIEW `capture_facebook_expression` AS SELECT ...
```

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1460)
<!-- Reviewable:end -->
