### PR TITLE
source-mysql: Fix handling of empty binary columns

### DIFF
--- a/source-mysql/.snapshots/TestEmptyBlobs-Capture
+++ b/source-mysql/.snapshots/TestEmptyBlobs-Capture
@@ -1,0 +1,11 @@
+# ================================
+# Collection "acmeCo/test/test_emptyblobs_11214558": 3 Documents
+# ================================
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"EmptyBlobs_11214558","cursor":"backfill:0"}},"a_varbinary":"qqqqqg==","a_varchar":"A","id":1}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"EmptyBlobs_11214558","cursor":"backfill:1"}},"a_varbinary":null,"a_varchar":"B","id":2}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"EmptyBlobs_11214558","cursor":"backfill:2"}},"a_varbinary":"zMzMzA==","a_varchar":"","id":3}
+# ================================
+# Final State Checkpoint
+# ================================
+{"bindingStateV1":{"test%2FEmptyBlobs_11214558":{"backfilled":3,"key_columns":["id"],"metadata":{"schema":{"columns":["id","a_varchar","a_varbinary"],"types":{"a_varbinary":"varbinary","a_varchar":"varchar","id":"int"}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
+

--- a/source-mysql/.snapshots/TestEmptyBlobs-Capture
+++ b/source-mysql/.snapshots/TestEmptyBlobs-Capture
@@ -2,7 +2,7 @@
 # Collection "acmeCo/test/test_emptyblobs_11214558": 3 Documents
 # ================================
 {"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"EmptyBlobs_11214558","cursor":"backfill:0"}},"a_varbinary":"qqqqqg==","a_varchar":"A","id":1}
-{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"EmptyBlobs_11214558","cursor":"backfill:1"}},"a_varbinary":null,"a_varchar":"B","id":2}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"EmptyBlobs_11214558","cursor":"backfill:1"}},"a_varbinary":"","a_varchar":"B","id":2}
 {"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"EmptyBlobs_11214558","cursor":"backfill:2"}},"a_varbinary":"zMzMzA==","a_varchar":"","id":3}
 # ================================
 # Final State Checkpoint

--- a/source-mysql/.snapshots/TestEmptyBlobs-Discovery
+++ b/source-mysql/.snapshots/TestEmptyBlobs-Discovery
@@ -1,0 +1,131 @@
+Binding 0:
+{
+    "recommended_name": "test_emptyblobs_11214558",
+    "resource_config_json": {
+      "namespace": "test",
+      "stream": "EmptyBlobs_11214558"
+    },
+    "document_schema_json": {
+      "$defs": {
+        "TestEmptyBlobs_11214558": {
+          "type": "object",
+          "required": [
+            "id"
+          ],
+          "$anchor": "TestEmptyBlobs_11214558",
+          "properties": {
+            "a_varbinary": {
+              "type": "string",
+              "contentEncoding": "base64"
+            },
+            "a_varchar": {
+              "type": "string"
+            },
+            "id": {
+              "type": "integer"
+            }
+          }
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "_meta": {
+                "properties": {
+                  "op": {
+                    "const": "d"
+                  }
+                }
+              }
+            }
+          },
+          "then": {
+            "reduce": {
+              "delete": true,
+              "strategy": "merge"
+            }
+          },
+          "else": {
+            "reduce": {
+              "strategy": "merge"
+            }
+          },
+          "required": [
+            "_meta"
+          ],
+          "properties": {
+            "_meta": {
+              "type": "object",
+              "required": [
+                "op",
+                "source"
+              ],
+              "properties": {
+                "before": {
+                  "$ref": "#TestEmptyBlobs_11214558",
+                  "description": "Record state immediately before this change was applied.",
+                  "reduce": {
+                    "strategy": "firstWriteWins"
+                  }
+                },
+                "op": {
+                  "enum": [
+                    "c",
+                    "d",
+                    "u"
+                  ],
+                  "description": "Change operation type: 'c' Create/Insert, 'u' Update, 'd' Delete."
+                },
+                "source": {
+                  "$id": "https://github.com/estuary/connectors/source-mysql/mysql-source-info",
+                  "properties": {
+                    "ts_ms": {
+                      "type": "integer",
+                      "description": "Unix timestamp (in millis) at which this event was recorded by the database."
+                    },
+                    "schema": {
+                      "type": "string",
+                      "description": "Database schema (namespace) of the event."
+                    },
+                    "snapshot": {
+                      "type": "boolean",
+                      "description": "Snapshot is true if the record was produced from an initial table backfill and unset if produced from the replication log."
+                    },
+                    "table": {
+                      "type": "string",
+                      "description": "Database table of the event."
+                    },
+                    "cursor": {
+                      "type": "string",
+                      "description": "Cursor value representing the current position in the binlog."
+                    },
+                    "txid": {
+                      "type": "string",
+                      "description": "The global transaction identifier associated with a change by MySQL. Only set if GTIDs are enabled."
+                    }
+                  },
+                  "type": "object",
+                  "required": [
+                    "schema",
+                    "table",
+                    "cursor"
+                  ]
+                }
+              },
+              "reduce": {
+                "strategy": "merge"
+              }
+            }
+          }
+        },
+        {
+          "$ref": "#TestEmptyBlobs_11214558"
+        }
+      ]
+    },
+    "key": [
+      "/id"
+    ]
+  }
+

--- a/source-mysql/discovery.go
+++ b/source-mysql/discovery.go
@@ -225,7 +225,7 @@ func (db *mysqlDatabase) translateRecordField(columnType interface{}, val interf
 		// This can be removed after the backfill buffering changes of August 2023
 		// are complete, since once that's done results should be fully processed
 		// as soon as they're received.
-		val = append([]byte(nil), val...)
+		val = append(make([]byte, 0, len(val)), val...)
 		if typeName, ok := columnType.(string); ok {
 			switch typeName {
 			case "bit":


### PR DESCRIPTION
**Description:**

In order to make absolutely sure that no dirty memory-reuse tricks happen to us, we make a copy of any byte data as part of our value translation logic. However, as previously written the copy would translate the empty byte slice `[]byte{}` into the nil byte slice `[]byte(nil)` as a side effect.

This is incorrect, since `[]byte(nil)` serializes to JSON `null` while `[]byte{}` serializes to JSON `""`, and we need to produce the latter form both because it's a more accurate representation of the source data and because the column could be non-nullable and not allow `null` at all.

This is fixed by instead using `make([]byte, ...)` to always allocate a new byte slice of adequate capacity.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1463)
<!-- Reviewable:end -->
