### PR TITLE
m-snowflake: recreate pipes on version change only

### DIFF
--- a/materialize-snowflake/client.go
+++ b/materialize-snowflake/client.go
@@ -74,7 +74,6 @@ func (c *client) CreateTable(ctx context.Context, tc sql.TableCreate) error {
 	if _, err := conn.ExecContext(ctx, fmt.Sprintf("USE SCHEMA %s", c.ep.Dialect.Identifier(c.cfg.Schema))); err != nil {
 		return err
 	}
-
 	_, err = conn.ExecContext(ctx, tc.TableCreateSql)
 	return err
 }

--- a/materialize-snowflake/pipe.go
+++ b/materialize-snowflake/pipe.go
@@ -124,6 +124,16 @@ type InsertFilesResponse struct {
 	RequestId string `json:"requestId"`
 }
 
+type InsertFilesError struct {
+	Code    string `json:"code"`
+	Message string `json:"message"`
+	Success bool   `json:"success"`
+}
+
+func (e InsertFilesError) Error() string {
+	return fmt.Sprintf("(%s) %s", e.Code, e.Message)
+}
+
 const insertFilesRawTpl = "https://{{ $.Base }}/v1/data/pipes/{{ $.PipeName }}/insertFiles?requestId={{ $.RequestId }}"
 const contentType = "application/json;charset=UTF-8"
 const userAgent = "Estuary Technologies Flow"
@@ -201,7 +211,12 @@ func (c *PipeClient) InsertFiles(pipeName string, files []FileRequest) (*InsertF
 	}).Debug("pipe client")
 
 	if resp.StatusCode >= 400 {
-		return nil, fmt.Errorf("response error code %d, %s", resp.StatusCode, respBuf.String())
+		var errResponse InsertFilesError
+		if err := json.Unmarshal([]byte(respBuf.String()), &errResponse); err != nil {
+			return nil, fmt.Errorf("response error code %d, %s", resp.StatusCode, respBuf.String())
+		} else {
+			return nil, errResponse
+		}
 	}
 
 	var response InsertFilesResponse

--- a/materialize-snowflake/snowflake.go
+++ b/materialize-snowflake/snowflake.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	stdsql "database/sql"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -149,9 +150,6 @@ type transactor struct {
 	// this shard's range spec and version, used to key pipes so they don't collide
 	_range  *pf.RangeSpec
 	version string
-
-	// list of pipe names that need to be cleaned up
-	pipeCleanups []string
 }
 
 func (t *transactor) AckDelay() time.Duration {
@@ -238,7 +236,8 @@ func newTransactor(
 }
 
 type binding struct {
-	target   sql.Table
+	target sql.Table
+
 	pipeName string
 	// Variables exclusively used by Load.
 	load struct {
@@ -269,25 +268,6 @@ func (d *transactor) addBinding(ctx context.Context, target sql.Table) error {
 		} else {
 			pipeName = strings.ToUpper(strings.Trim(pipeName, "`"))
 			b.pipeName = fmt.Sprintf("%s.%s.%s", d.cfg.Database, d.cfg.Schema, pipeName)
-		}
-
-		// Check to see if a pipe for this version already exists
-		var queries = fmt.Sprintf("SHOW PIPES LIKE '%s';", pipeName)
-		rows, err := d.db.QueryContext(ctx, queries)
-		if err != nil {
-			return fmt.Errorf("finding pipe %q: %w", b.pipeName, err)
-		}
-		var pipeExists = rows.Next()
-
-		// Only create the pipe if it doesn't exist. Since the pipe name is versioned by the spec
-		// it means if the spec has been updated, we will end up creating a new pipe
-		if !pipeExists {
-			log.WithField("name", b.pipeName).Info("store: creating pipe")
-			if createPipe, err := RenderTableShardVersionTemplate(b.target, d._range.KeyBegin, d.version, d.templates.createPipe); err != nil {
-				return fmt.Errorf("createPipe template: %w", err)
-			} else if _, err := d.db.ExecContext(ctx, createPipe); err != nil {
-				return fmt.Errorf("creating pipe for table %q: %w", b.target.Path, err)
-			}
 		}
 	}
 
@@ -394,6 +374,16 @@ func (d *transactor) Load(it *m.LoadIterator, loaded func(int, json.RawMessage) 
 	return nil
 }
 
+func (d *transactor) pipeExists(ctx context.Context, pipeName string) (bool, error) {
+	// Check to see if a pipe for this version already exists
+	var query = fmt.Sprintf("SHOW PIPES LIKE '%s';", pipeName)
+	rows, err := d.db.QueryContext(ctx, query)
+	if err != nil {
+		return false, fmt.Errorf("finding pipe %q: %w", pipeName, err)
+	}
+	return rows.Next(), nil
+}
+
 type checkpointItem struct {
 	Table     string
 	Query     string
@@ -407,22 +397,6 @@ type checkpoint = map[string]*checkpointItem
 
 func (d *transactor) Store(it *m.StoreIterator) (m.StartCommitFunc, error) {
 	var ctx = it.Context()
-
-	// FIXME: I initially wrote this piece in Acknowledge, but in that case
-	// if we are unable to commit the checkpoint update after deleting the pipes, on a restart
-	// the acknowledge will be tried again but the pipe won't exist. I don't feel easy about ignoring cases where the pipe does not exist
-	// since that means committing a transaction that we are not 100% sure has been actually processed
-	// an alternative is cleaning up the pipes as part of the Store phase by keeping the list of pipes to cleanup in memory
-	// of the connector. This means there is a possible edge case where we will not cleanup the pipe: if Acknowledge runs successfully
-	// but the connector restarts before the next Store is able to process the pipe cleanups. I think I prefer the latter.
-	for _, pipeName := range d.pipeCleanups {
-		log.WithField("pipeName", pipeName).Info("dropping pipe")
-		if _, err := d.store.conn.ExecContext(ctx, fmt.Sprintf("DROP PIPE IF EXISTS %s;", pipeName)); err != nil {
-			return nil, fmt.Errorf("dropping pipe %s failed: %w", pipeName, err)
-		}
-	}
-
-	d.pipeCleanups = nil
 
 	log.Info("store: starting encoding and uploading of files")
 	for it.Next() {
@@ -470,6 +444,38 @@ func (d *transactor) Store(it *m.StoreIterator) (m.StartCommitFunc, error) {
 				}
 			}
 		} else if b.pipeName != "" {
+			var pipeNameParts = strings.Split(b.pipeName, ".")
+			var pipeNameLastPart = pipeNameParts[len(pipeNameParts)-1]
+
+			// Check to see if a pipe for this version already exists
+			exists, err := d.pipeExists(ctx, pipeNameLastPart)
+			if err != nil {
+				return nil, err
+			}
+
+			// Only create the pipe if it doesn't exist. Since the pipe name is versioned by the spec
+			// it means if the spec has been updated, we will end up creating a new pipe
+			if !exists {
+				log.WithField("name", b.pipeName).Info("store: creating pipe")
+				if createPipe, err := RenderTableShardVersionTemplate(b.target, d._range.KeyBegin, d.version, d.templates.createPipe); err != nil {
+					return nil, fmt.Errorf("createPipe template: %w", err)
+				} else if _, err := d.db.ExecContext(ctx, createPipe); err != nil {
+					return nil, fmt.Errorf("creating pipe for table %q: %w", b.target.Path, err)
+				}
+			}
+
+			// Our understanding is that CREATE PIPE is _eventually consistent_, and so we
+			// wait until we can make sure the pipe exists before continuing
+			for !exists {
+				exists, err = d.pipeExists(ctx, pipeNameLastPart)
+				if err != nil {
+					return nil, err
+				}
+				if !exists {
+					time.Sleep(5 * time.Second)
+				}
+			}
+
 			d.cp[b.target.StateKey] = &checkpointItem{
 				Table:     b.target.Identifier,
 				StagedDir: dir,
@@ -608,6 +614,13 @@ func (d *transactor) Acknowledge(ctx context.Context) (*pf.ConnectorState, error
 			}
 
 			if resp, err := d.pipeClient.InsertFiles(item.PipeName, fileRequests); err != nil {
+				var insertErr InsertFilesError
+				if errors.As(err, &insertErr) && insertErr.Code == "390404" && strings.Contains(insertErr.Message, "Pipe not found") {
+					log.WithField("pipeName", item.PipeName).Info("pipe does not exist, skipping this checkpoint item")
+					// Pipe was not found for this checkpoint item. We take this to mean that this item has already
+					// been processed and the pipe has been cleaned up by us in a prior Acknowledge
+					continue
+				}
 				return nil, fmt.Errorf("snowpipe insertFiles: %w", err)
 			} else {
 				log.WithField("response", resp).Debug("insertFiles successful")
@@ -636,7 +649,7 @@ func (d *transactor) Acknowledge(ctx context.Context) (*pf.ConnectorState, error
 
 	// If we see no results from the REST API for `maxTries` iterations, then we
 	// fallback to asking the `COPY_HISTORY` table. We allow up to 5 minutes for results to show up in the REST API.
-	var maxTries = 20
+	var maxTries = 40
 	var retryDelaySeconds = 3 * time.Second
 	for tries := 0; tries < maxTries; tries++ {
 		for pipeName, pipe := range pipes {
@@ -748,6 +761,16 @@ func (d *transactor) Acknowledge(ctx context.Context) (*pf.ConnectorState, error
 
 	log.Info("store: finished committing changes")
 
+	for _, item := range d.cp {
+		// If the spec version has bumped, we need to clean up the old pipes
+		if len(item.PipeName) > 0 && item.Version != d.version {
+			log.WithField("pipeName", item.PipeName).Info("dropping pipe")
+			if _, err := d.store.conn.ExecContext(ctx, fmt.Sprintf("DROP PIPE IF EXISTS %s;", item.PipeName)); err != nil {
+				return nil, fmt.Errorf("dropping pipe %s failed: %w", item.PipeName, err)
+			}
+		}
+	}
+
 	// After having applied the checkpoint, we try to clean up the checkpoint in the ack response
 	// so that a restart of the connector does not need to run the same queries again
 	// Note that this is an best-effort "attempt" and there is no guarantee that this checkpoint update
@@ -764,13 +787,6 @@ func (d *transactor) Acknowledge(ctx context.Context) (*pf.ConnectorState, error
 	var checkpointJSON, err = json.Marshal(checkpointClear)
 	if err != nil {
 		return nil, fmt.Errorf("creating checkpoint clearing json: %w", err)
-	}
-
-	for _, item := range d.cp {
-		// If the spec version has bumped, we need to clean up the old pipes
-		if len(item.PipeName) > 0 && item.Version != d.version {
-			d.pipeCleanups = append(d.pipeCleanups, item.PipeName)
-		}
 	}
 
 	return &pf.ConnectorState{UpdatedJson: json.RawMessage(checkpointJSON), MergePatch: true}, nil

--- a/materialize-snowflake/snowflake.go
+++ b/materialize-snowflake/snowflake.go
@@ -761,7 +761,11 @@ func (d *transactor) Acknowledge(ctx context.Context) (*pf.ConnectorState, error
 
 	log.Info("store: finished committing changes")
 
-	for _, item := range d.cp {
+	for _, b := range d.bindings {
+		var item, ok = d.cp[b.target.StateKey]
+		if !ok {
+			continue
+		}
 		// If the spec version has bumped, we need to clean up the old pipes
 		if len(item.PipeName) > 0 && item.Version != d.version {
 			log.WithField("pipeName", item.PipeName).Info("dropping pipe")

--- a/tests/materialize/materialize-snowflake/snapshot.json
+++ b/tests/materialize/materialize-snowflake/snapshot.json
@@ -37,10 +37,11 @@
               "Size": 275
             }
           ],
-          "PipeName": "MAHDI_DB.ESTUARY_SCHEMA.FLOW_PIPE_2_DUPLICATE_KEYS_DELTA_00000000",
+          "PipeName": "MAHDI_DB.ESTUARY_SCHEMA.FLOW_PIPE_2_DUPLICATE_KEYS_DELTA_00000000_TEST",
           "Query": "",
           "StagedDir": "<uuid>",
-          "Table": "duplicate_keys_delta"
+          "Table": "duplicate_keys_delta",
+          "Version": "test"
         },
         "duplicate_keys_delta_exclude_flow_doc": {
           "PipeFiles": [
@@ -49,45 +50,51 @@
               "Size": 140
             }
           ],
-          "PipeName": "MAHDI_DB.ESTUARY_SCHEMA.FLOW_PIPE_3_DUPLICATE_KEYS_DELTA_EXCLUDE_FLOW_DOC_00000000",
+          "PipeName": "MAHDI_DB.ESTUARY_SCHEMA.FLOW_PIPE_3_DUPLICATE_KEYS_DELTA_EXCLUDE_FLOW_DOC_00000000_TEST",
           "Query": "",
           "StagedDir": "<uuid>",
-          "Table": "duplicate_keys_delta_exclude_flow_doc"
+          "Table": "duplicate_keys_delta_exclude_flow_doc",
+          "Version": "test"
         },
         "duplicate_keys_standard": {
           "PipeFiles": null,
           "PipeName": "",
           "Query": "\nCOPY INTO duplicate_keys_standard (\n\tid, flow_published_at, int, str, flow_document\n) FROM (\n\tSELECT $1[0] AS id, $1[1] AS flow_published_at, $1[2] AS int, $1[3] AS str, $1[4] AS flow_document\n\tFROM <uuid>\n);\n",
           "StagedDir": "<uuid>",
-          "Table": "duplicate_keys_standard"
+          "Table": "duplicate_keys_standard",
+          "Version": ""
         },
         "formatted_strings": {
           "PipeFiles": null,
           "PipeName": "",
           "Query": "\nCOPY INTO formatted_strings (\n\tid, date, datetime, flow_published_at, int_and_str, int_str, num_and_str, num_str, time, flow_document\n) FROM (\n\tSELECT $1[0] AS id, $1[1] AS date, $1[2] AS datetime, $1[3] AS flow_published_at, $1[4] AS int_and_str, $1[5] AS int_str, $1[6] AS num_and_str, $1[7] AS num_str, $1[8] AS time, $1[9] AS flow_document\n\tFROM <uuid>\n);\n",
           "StagedDir": "<uuid>",
-          "Table": "formatted_strings"
+          "Table": "formatted_strings",
+          "Version": ""
         },
         "multiple_types": {
           "PipeFiles": null,
           "PipeName": "",
           "Query": "\nCOPY INTO multiple_types (\n\tid, array_int, bool_field, float_field, flow_published_at, multiple, nested, nullable_int, str_field, flow_document\n) FROM (\n\tSELECT $1[0] AS id, $1[1] AS array_int, $1[2] AS bool_field, $1[3] AS float_field, $1[4] AS flow_published_at, $1[5] AS multiple, $1[6] AS nested, $1[7] AS nullable_int, $1[8] AS str_field, $1[9] AS flow_document\n\tFROM <uuid>\n);\n",
           "StagedDir": "<uuid>",
-          "Table": "multiple_types"
+          "Table": "multiple_types",
+          "Version": ""
         },
         "simple": {
           "PipeFiles": null,
           "PipeName": "",
           "Query": "\nCOPY INTO simple (\n\tid, canary, flow_published_at, flow_document\n) FROM (\n\tSELECT $1[0] AS id, $1[1] AS canary, $1[2] AS flow_published_at, $1[3] AS flow_document\n\tFROM <uuid>\n);\n",
           "StagedDir": "<uuid>",
-          "Table": "simple"
+          "Table": "simple",
+          "Version": ""
         },
         "symbols": {
           "PipeFiles": null,
           "PipeName": "",
           "Query": "\nCOPY INTO symbols (\n\t\"testing (%s)\", flow_published_at, id, flow_document\n) FROM (\n\tSELECT $1[0] AS \"testing (%s)\", $1[1] AS flow_published_at, $1[2] AS id, $1[3] AS flow_document\n\tFROM <uuid>\n);\n",
           "StagedDir": "<uuid>",
-          "Table": "symbols"
+          "Table": "symbols",
+          "Version": ""
         }
       }
     }
@@ -308,10 +315,11 @@
               "Size": 271
             }
           ],
-          "PipeName": "MAHDI_DB.ESTUARY_SCHEMA.FLOW_PIPE_2_DUPLICATE_KEYS_DELTA_00000000",
+          "PipeName": "MAHDI_DB.ESTUARY_SCHEMA.FLOW_PIPE_2_DUPLICATE_KEYS_DELTA_00000000_TEST",
           "Query": "",
           "StagedDir": "<uuid>",
-          "Table": "duplicate_keys_delta"
+          "Table": "duplicate_keys_delta",
+          "Version": "test"
         },
         "duplicate_keys_delta_exclude_flow_doc": {
           "PipeFiles": [
@@ -320,38 +328,43 @@
               "Size": 137
             }
           ],
-          "PipeName": "MAHDI_DB.ESTUARY_SCHEMA.FLOW_PIPE_3_DUPLICATE_KEYS_DELTA_EXCLUDE_FLOW_DOC_00000000",
+          "PipeName": "MAHDI_DB.ESTUARY_SCHEMA.FLOW_PIPE_3_DUPLICATE_KEYS_DELTA_EXCLUDE_FLOW_DOC_00000000_TEST",
           "Query": "",
           "StagedDir": "<uuid>",
-          "Table": "duplicate_keys_delta_exclude_flow_doc"
+          "Table": "duplicate_keys_delta_exclude_flow_doc",
+          "Version": "test"
         },
         "duplicate_keys_standard": {
           "PipeFiles": null,
           "PipeName": "",
           "Query": "\nMERGE INTO duplicate_keys_standard AS l\nUSING (\n\tSELECT $1[0] AS id, $1[1] AS flow_published_at, $1[2] AS int, $1[3] AS str, $1[4] AS flow_document\n\tFROM <uuid>\n) AS r\nON l.id = r.id\nWHEN MATCHED AND IS_NULL_VALUE(r.flow_document) THEN\n\tDELETE\nWHEN MATCHED THEN\n\tUPDATE SET l.flow_published_at = r.flow_published_at, l.int = r.int, l.str = r.str, l.flow_document = r.flow_document\nWHEN NOT MATCHED THEN\n\tINSERT (id, flow_published_at, int, str, flow_document)\n\tVALUES (r.id, r.flow_published_at, r.int, r.str, r.flow_document);\n",
           "StagedDir": "<uuid>",
-          "Table": "duplicate_keys_standard"
+          "Table": "duplicate_keys_standard",
+          "Version": "test"
         },
         "formatted_strings": {
           "PipeFiles": null,
           "PipeName": "",
           "Query": "\nCOPY INTO formatted_strings (\n\tid, date, datetime, flow_published_at, int_and_str, int_str, num_and_str, num_str, time, flow_document\n) FROM (\n\tSELECT $1[0] AS id, $1[1] AS date, $1[2] AS datetime, $1[3] AS flow_published_at, $1[4] AS int_and_str, $1[5] AS int_str, $1[6] AS num_and_str, $1[7] AS num_str, $1[8] AS time, $1[9] AS flow_document\n\tFROM <uuid>\n);\n",
           "StagedDir": "<uuid>",
-          "Table": "formatted_strings"
+          "Table": "formatted_strings",
+          "Version": ""
         },
         "multiple_types": {
           "PipeFiles": null,
           "PipeName": "",
           "Query": "\nMERGE INTO multiple_types AS l\nUSING (\n\tSELECT $1[0] AS id, $1[1] AS array_int, $1[2] AS bool_field, $1[3] AS float_field, $1[4] AS flow_published_at, $1[5] AS multiple, $1[6] AS nested, $1[7] AS nullable_int, $1[8] AS str_field, $1[9] AS flow_document\n\tFROM <uuid>\n) AS r\nON l.id = r.id\nWHEN MATCHED AND IS_NULL_VALUE(r.flow_document) THEN\n\tDELETE\nWHEN MATCHED THEN\n\tUPDATE SET l.array_int = r.array_int, l.bool_field = r.bool_field, l.float_field = r.float_field, l.flow_published_at = r.flow_published_at, l.multiple = r.multiple, l.nested = r.nested, l.nullable_int = r.nullable_int, l.str_field = r.str_field, l.flow_document = r.flow_document\nWHEN NOT MATCHED THEN\n\tINSERT (id, array_int, bool_field, float_field, flow_published_at, multiple, nested, nullable_int, str_field, flow_document)\n\tVALUES (r.id, r.array_int, r.bool_field, r.float_field, r.flow_published_at, r.multiple, r.nested, r.nullable_int, r.str_field, r.flow_document);\n",
           "StagedDir": "<uuid>",
-          "Table": "multiple_types"
+          "Table": "multiple_types",
+          "Version": "test"
         },
         "simple": {
           "PipeFiles": null,
           "PipeName": "",
           "Query": "\nCOPY INTO simple (\n\tid, canary, flow_published_at, flow_document\n) FROM (\n\tSELECT $1[0] AS id, $1[1] AS canary, $1[2] AS flow_published_at, $1[3] AS flow_document\n\tFROM <uuid>\n);\n",
           "StagedDir": "<uuid>",
-          "Table": "simple"
+          "Table": "simple",
+          "Version": ""
         }
       }
     }


### PR DESCRIPTION
**Description:**

- We have realised that `CREATE OR REPLACE PIPE` is eventually consistent, and so re-creating a pipe on each connector restart was leading to a race where we would send our file ingestion requests to the old pipe (even though we made the request after having run the `CREATE OR REPLACE` query) while that old pipe was going to be deleted and we would then request status updates from the new pipe which did not know about the old pipe. This lead to maximum retries when trying to fetch status of pipe and then a restart for us to attempt to ingest the file again...
- With this change, we only re-create a pipe if the spec version has changed. We also version the pipe name so that when this change is happening, the new pipe and the old pipe do not collide in names, leading to races

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1467)
<!-- Reviewable:end -->
