### PR TITLE
Removing access token headers

### DIFF
--- a/source-google-sheets-native/source_google_sheets_native/models.py
+++ b/source-google-sheets-native/source_google_sheets_native/models.py
@@ -19,7 +19,6 @@ OAUTH2_SPEC = OAuth2Spec(
     provider="google",
     authUrlTemplate="https://accounts.google.com/o/oauth2/auth?access_type=offline&prompt=consent&client_id={{#urlencode}}{{{ client_id }}}{{/urlencode}}&redirect_uri={{#urlencode}}{{{ redirect_uri }}}{{/urlencode}}&response_type=code&scope=https://www.googleapis.com/auth/spreadsheets.readonly https://www.googleapis.com/auth/drive.readonly&state={{#urlencode}}{{{ state }}}{{/urlencode}}",
     accessTokenUrlTemplate="https://oauth2.googleapis.com/token",
-    accessTokenHeaders={"content-type": "application/x-www-form-urlencoded"},
     accessTokenBody=(
         '{"grant_type": "authorization_code", "client_id": "{{{ client_id }}}", "client_secret": "{{{ client_secret }}}", "redirect_uri": "{{{ redirect_uri }}}", "code": "{{{ code }}}"}'
     ),

--- a/source-google-sheets-native/source_google_sheets_native/models.py
+++ b/source-google-sheets-native/source_google_sheets_native/models.py
@@ -22,6 +22,7 @@ OAUTH2_SPEC = OAuth2Spec(
     accessTokenBody=(
         '{"grant_type": "authorization_code", "client_id": "{{{ client_id }}}", "client_secret": "{{{ client_secret }}}", "redirect_uri": "{{{ redirect_uri }}}", "code": "{{{ code }}}"}'
     ),
+    accessTokenHeaders={"content-type":"application/json"},
     accessTokenResponseMap={"refresh_token": "/refresh_token"},
 )
 

--- a/source-google-sheets-native/tests/snapshots/source_google_sheets_native_tests_test_snapshots__spec__stdout.json
+++ b/source-google-sheets-native/tests/snapshots/source_google_sheets_native_tests_test_snapshots__spec__stdout.json
@@ -114,7 +114,7 @@
       "accessTokenUrlTemplate": "https://oauth2.googleapis.com/token",
       "accessTokenBody": "{\"grant_type\": \"authorization_code\", \"client_id\": \"{{{ client_id }}}\", \"client_secret\": \"{{{ client_secret }}}\", \"redirect_uri\": \"{{{ redirect_uri }}}\", \"code\": \"{{{ code }}}\"}",
       "accessTokenHeaders": {
-        "content-type": "application/x-www-form-urlencoded"
+        "content-type": "application/json"
       },
       "accessTokenResponseMap": {
         "refresh_token": "/refresh_token"


### PR DESCRIPTION
**Description:**

accessTokenHeaders was set to x-www-form-urlencoded, breaking OAuth.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1468)
<!-- Reviewable:end -->
