### PR TITLE
sqlcapture: Quality-of-life tweaks to log messages

### DIFF
--- a/sqlcapture/capture.go
+++ b/sqlcapture/capture.go
@@ -677,7 +677,7 @@ func (c *Capture) backfillStreams(ctx context.Context) error {
 	if len(streams) != 0 {
 		var streamID = streams[rand.Intn(len(streams))]
 		logrus.WithFields(logrus.Fields{
-			"streams":  streams,
+			"count":    len(streams),
 			"selected": streamID,
 		}).Info("backfilling streams")
 		if err := c.backfillStream(ctx, streamID); err != nil {

--- a/sqlcapture/capture.go
+++ b/sqlcapture/capture.go
@@ -476,7 +476,7 @@ func (c *Capture) updateState(ctx context.Context) error {
 	// bindings and then re-enable them (which will cause them all to get backfilled anew, as they
 	// should after such an event).
 	if allStreamsAreNew {
-		logrus.Info("no active bindings, resetting cursor")
+		logrus.Info("all bindings are new, resetting replication cursor")
 		c.State.Cursor = ""
 	}
 

--- a/sqlcapture/capture.go
+++ b/sqlcapture/capture.go
@@ -730,8 +730,13 @@ func (c *Capture) backfillStream(ctx context.Context, streamID string) error {
 	}
 
 	// Update stream state to reflect backfill results
+	logrus.WithFields(logrus.Fields{
+		"stream": streamID,
+		"rows":   eventCount,
+	}).Info("processed backfill rows")
 	var state = c.State.Streams[stateKey]
 	if eventCount == 0 {
+		logrus.WithField("stream", streamID).Info("backfill completed")
 		state.Mode = TableModeActive
 		state.Scanned = nil
 	} else {


### PR DESCRIPTION
**Description:**

This PR bundles together several small logging tweaks each meant to address specific things that keep on annoying me when looking at SQL CDC task logs. The commit messages contain more details on each change, but the TL;DR summaries are:

- Fixed the wording of the `no active bindings, resetting cursor` message because it's inaccurate now that the state key changes allow the cursor to be reset _if all bindings are newly added (including backfill increments) in this restart_ without the need for an intermediate startup without any active bindings.
- Logging the number of backfill rows processed (for symmetry with replication and because this would have been useful info once or twice in the past) and when a particular table is determined to be done backfilling.
- No longer logging the full list of tables in backfill before each backfill iteration, instead just the selected table and the count will be logged. The full list was unnecessarily verbose and also made Ctrl-F searching for logs relevant to a specific table much harder than it needs to be.

**Workflow steps:**

There shouldn't be any functional changes, this just makes the logs a bit more useful (according to my personal opinion as the guy who probably looks at these task's logs the most).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1488)
<!-- Reviewable:end -->
