### PR TITLE
Modified OAuth2 and Access Token specs in estuary_cdk & source-hubspot-native fixes

### DIFF
--- a/estuary-cdk/estuary_cdk/flow.py
+++ b/estuary-cdk/estuary_cdk/flow.py
@@ -90,7 +90,10 @@ class ConnectorStateUpdate(GenericModel, Generic[ConnectorState]):
 
 
 class AccessToken(BaseModel):
-    credentials_title: Literal["Private App Credentials"] = "Private App Credentials"
+    credentials_title: Literal["Private App Credentials"] = Field(
+        default="Private App Credentials",
+        json_schema_extra={"type": "string"}
+    )
     access_token: str = Field(
         title="Access Token",
         json_schema_extra={"secret": True},
@@ -113,7 +116,10 @@ class ValidationError(Exception):
 
 
 class BaseOAuth2Credentials(abc.ABC, BaseModel):
-    credentials_title: Literal["OAuth Credentials"] = "OAuth Credentials"
+    credentials_title: Literal["OAuth Credentials"] = Field(
+        default="OAuth Credentials",
+        json_schema_extra={"type": "string"}
+    )
     client_id: str = Field(
         title="Client Id",
         json_schema_extra={"secret": True},

--- a/estuary-cdk/estuary_cdk/flow.py
+++ b/estuary-cdk/estuary_cdk/flow.py
@@ -1,6 +1,6 @@
 import abc
 from dataclasses import dataclass
-from pydantic import BaseModel, NonNegativeInt, PositiveInt
+from pydantic import BaseModel, NonNegativeInt, PositiveInt, Field
 from typing import Any, Literal, TypeVar, Generic, Literal
 
 from .pydantic_polyfill import GenericModel
@@ -91,7 +91,10 @@ class ConnectorStateUpdate(GenericModel, Generic[ConnectorState]):
 
 class AccessToken(BaseModel):
     credentials_title: Literal["Private App Credentials"] = "Private App Credentials"
-    access_token: str
+    access_token: str = Field(
+        title="Access Token",
+        json_schema_extra={"secret": True},
+    )
 
 
 class BasicAuth(BaseModel):
@@ -111,9 +114,18 @@ class ValidationError(Exception):
 
 class BaseOAuth2Credentials(abc.ABC, BaseModel):
     credentials_title: Literal["OAuth Credentials"] = "OAuth Credentials"
-    client_id: str
-    client_secret: str
-    refresh_token: str
+    client_id: str = Field(
+        title="Client Id",
+        json_schema_extra={"secret": True},
+    )
+    client_secret: str = Field(
+        title="Client Secret",
+        json_schema_extra={"secret": True},
+    )
+    refresh_token: str = Field(
+        title="Refresh Token",
+        json_schema_extra={"secret": True},
+    )
 
     @abc.abstractmethod
     def _you_must_build_oauth2_credentials_for_a_provider(self): ...

--- a/source-google-sheets-native/tests/snapshots/source_google_sheets_native_tests_test_snapshots__spec__stdout.json
+++ b/source-google-sheets-native/tests/snapshots/source_google_sheets_native_tests_test_snapshots__spec__stdout.json
@@ -8,7 +8,8 @@
             "credentials_title": {
               "const": "Private App Credentials",
               "default": "Private App Credentials",
-              "title": "Credentials Title"
+              "title": "Credentials Title",
+              "type": "string"
             },
             "access_token": {
               "secret": true,
@@ -27,7 +28,8 @@
             "credentials_title": {
               "const": "OAuth Credentials",
               "default": "OAuth Credentials",
-              "title": "Credentials Title"
+              "title": "Credentials Title",
+              "type": "string"
             },
             "client_id": {
               "secret": true,

--- a/source-google-sheets-native/tests/snapshots/source_google_sheets_native_tests_test_snapshots__spec__stdout.json
+++ b/source-google-sheets-native/tests/snapshots/source_google_sheets_native_tests_test_snapshots__spec__stdout.json
@@ -11,6 +11,7 @@
               "title": "Credentials Title"
             },
             "access_token": {
+              "secret": true,
               "title": "Access Token",
               "type": "string"
             }
@@ -29,14 +30,17 @@
               "title": "Credentials Title"
             },
             "client_id": {
+              "secret": true,
               "title": "Client Id",
               "type": "string"
             },
             "client_secret": {
+              "secret": true,
               "title": "Client Secret",
               "type": "string"
             },
             "refresh_token": {
+              "secret": true,
               "title": "Refresh Token",
               "type": "string"
             }

--- a/source-hubspot-native/acmeCo/companies.schema.yaml
+++ b/source-hubspot-native/acmeCo/companies.schema.yaml
@@ -1,7 +1,7 @@
 ---
 $defs:
   History:
-    additionalProperties: false
+    additionalProperties: true
     properties:
       _meta:
         allOf:

--- a/source-hubspot-native/acmeCo/contacts.schema.yaml
+++ b/source-hubspot-native/acmeCo/contacts.schema.yaml
@@ -1,7 +1,7 @@
 ---
 $defs:
   History:
-    additionalProperties: false
+    additionalProperties: true
     properties:
       _meta:
         allOf:

--- a/source-hubspot-native/acmeCo/deals.schema.yaml
+++ b/source-hubspot-native/acmeCo/deals.schema.yaml
@@ -1,7 +1,7 @@
 ---
 $defs:
   History:
-    additionalProperties: false
+    additionalProperties: true
     properties:
       _meta:
         allOf:

--- a/source-hubspot-native/acmeCo/engagements.schema.yaml
+++ b/source-hubspot-native/acmeCo/engagements.schema.yaml
@@ -1,7 +1,7 @@
 ---
 $defs:
   History:
-    additionalProperties: false
+    additionalProperties: true
     properties:
       _meta:
         allOf:

--- a/source-hubspot-native/acmeCo/engagements_calls.schema.yaml
+++ b/source-hubspot-native/acmeCo/engagements_calls.schema.yaml
@@ -1,7 +1,7 @@
 ---
 $defs:
   History:
-    additionalProperties: false
+    additionalProperties: true
     properties:
       _meta:
         allOf:

--- a/source-hubspot-native/acmeCo/engagements_emails.schema.yaml
+++ b/source-hubspot-native/acmeCo/engagements_emails.schema.yaml
@@ -1,7 +1,7 @@
 ---
 $defs:
   History:
-    additionalProperties: false
+    additionalProperties: true
     properties:
       _meta:
         allOf:

--- a/source-hubspot-native/acmeCo/engagements_meetings.schema.yaml
+++ b/source-hubspot-native/acmeCo/engagements_meetings.schema.yaml
@@ -1,7 +1,7 @@
 ---
 $defs:
   History:
-    additionalProperties: false
+    additionalProperties: true
     properties:
       _meta:
         allOf:

--- a/source-hubspot-native/acmeCo/engagements_notes.schema.yaml
+++ b/source-hubspot-native/acmeCo/engagements_notes.schema.yaml
@@ -1,7 +1,7 @@
 ---
 $defs:
   History:
-    additionalProperties: false
+    additionalProperties: true
     properties:
       _meta:
         allOf:

--- a/source-hubspot-native/acmeCo/engagements_tasks.schema.yaml
+++ b/source-hubspot-native/acmeCo/engagements_tasks.schema.yaml
@@ -1,7 +1,7 @@
 ---
 $defs:
   History:
-    additionalProperties: false
+    additionalProperties: true
     properties:
       _meta:
         allOf:

--- a/source-hubspot-native/acmeCo/feedback_submissions.schema.yaml
+++ b/source-hubspot-native/acmeCo/feedback_submissions.schema.yaml
@@ -1,7 +1,7 @@
 ---
 $defs:
   History:
-    additionalProperties: false
+    additionalProperties: true
     properties:
       _meta:
         allOf:

--- a/source-hubspot-native/acmeCo/goal_targets.schema.yaml
+++ b/source-hubspot-native/acmeCo/goal_targets.schema.yaml
@@ -1,7 +1,7 @@
 ---
 $defs:
   History:
-    additionalProperties: false
+    additionalProperties: true
     properties:
       _meta:
         allOf:

--- a/source-hubspot-native/acmeCo/line_items.schema.yaml
+++ b/source-hubspot-native/acmeCo/line_items.schema.yaml
@@ -1,7 +1,7 @@
 ---
 $defs:
   History:
-    additionalProperties: false
+    additionalProperties: true
     properties:
       _meta:
         allOf:

--- a/source-hubspot-native/acmeCo/products.schema.yaml
+++ b/source-hubspot-native/acmeCo/products.schema.yaml
@@ -1,7 +1,7 @@
 ---
 $defs:
   History:
-    additionalProperties: false
+    additionalProperties: true
     properties:
       _meta:
         allOf:

--- a/source-hubspot-native/acmeCo/ticket_pipelines.schema.yaml
+++ b/source-hubspot-native/acmeCo/ticket_pipelines.schema.yaml
@@ -1,7 +1,7 @@
 ---
 $defs:
   History:
-    additionalProperties: false
+    additionalProperties: true
     properties:
       _meta:
         allOf:

--- a/source-hubspot-native/acmeCo/tickets.schema.yaml
+++ b/source-hubspot-native/acmeCo/tickets.schema.yaml
@@ -1,7 +1,7 @@
 ---
 $defs:
   History:
-    additionalProperties: false
+    additionalProperties: true
     properties:
       _meta:
         allOf:

--- a/source-hubspot-native/source_hubspot_native/__init__.py
+++ b/source-hubspot-native/source_hubspot_native/__init__.py
@@ -30,7 +30,7 @@ class Connector(
 
     async def spec(self, log: Logger, _: request.Spec) -> ConnectorSpec:
         return ConnectorSpec(
-            documentationUrl="https://go.estuary.dev/source-hubspot-native",
+            documentationUrl="https://go.estuary.dev/hubspot-real-time",
             configSchema=EndpointConfig.model_json_schema(),
             oauth2=OAUTH2_SPEC,
             resourceConfigSchema=ResourceConfig.model_json_schema(),

--- a/source-hubspot-native/source_hubspot_native/api.py
+++ b/source-hubspot-native/source_hubspot_native/api.py
@@ -397,7 +397,9 @@ async def fetch_changes_no_batch(
         
         for ts, id, result in iter:
             recent.append((ts, id)) # Used later to update log_cursor value
-            yield V1CRMObject.model_validate_json(json.dumps(result)) 
+            doc = V1CRMObject.model_validate_json(json.dumps(result))
+            doc.meta_= V1CRMObject.Meta(op="u") 
+            yield  doc
 
 
         if not next_page:

--- a/source-hubspot-native/source_hubspot_native/models.py
+++ b/source-hubspot-native/source_hubspot_native/models.py
@@ -80,9 +80,10 @@ class EndpointConfig(BaseModel):
     credentials: OAuth2Credentials | AccessToken = Field(
         discriminator="credentials_title",
         title="Authentication",
+        json_schema_extra={"type": "object"}
     )
     start_date: AwareDatetime = Field(
-        title="start_date",
+        title="Start Date",
     )
 
 
@@ -172,7 +173,7 @@ class BaseCRMObject(BaseDocument, extra="forbid"):
     IGNORE_PROPERTY_SEARCH: ClassVar[bool] = False
     ENFORCE_URL: ClassVar[str]
 
-    class History(BaseDocument, extra="forbid"):
+    class History(BaseDocument, extra="allow"):
         timestamp: datetime
         value: str
         sourceType: str

--- a/source-hubspot-native/tests/snapshots/source_hubspot_native_tests_test_snapshots__capture__stdout.json
+++ b/source-hubspot-native/tests/snapshots/source_hubspot_native_tests_test_snapshots__capture__stdout.json
@@ -1,5 +1,1077 @@
 [
   [
+    "acmeCo/contacts",
+    {
+      "_meta": {
+        "op": "u"
+      },
+      "archived": false,
+      "createdAt": "2024-04-16T03:42:41.810000Z",
+      "id": 12791224888,
+      "properties": {
+        "createdate": "2024-04-16T03:42:41.810Z",
+        "email": "test2@test.com",
+        "firstname": "Joe2",
+        "hs_all_assigned_business_unit_ids": "0",
+        "hs_all_owner_ids": "750122779",
+        "hs_analytics_average_page_views": "0",
+        "hs_analytics_first_timestamp": "2024-04-16T03:42:41.810Z",
+        "hs_analytics_num_event_completions": "0",
+        "hs_analytics_num_page_views": "0",
+        "hs_analytics_num_visits": "0",
+        "hs_analytics_revenue": "0.0",
+        "hs_analytics_source": "OFFLINE",
+        "hs_analytics_source_data_1": "CRM_UI",
+        "hs_analytics_source_data_2": "userId:51770238",
+        "hs_count_is_unworked": "1",
+        "hs_count_is_worked": "0",
+        "hs_created_by_user_id": "51770238",
+        "hs_date_entered_lead": "2024-04-16T03:42:41.810Z",
+        "hs_is_unworked": "true",
+        "hs_latest_source": "OFFLINE",
+        "hs_latest_source_data_1": "CRM_UI",
+        "hs_latest_source_data_2": "userId:51770238",
+        "hs_latest_source_timestamp": "2024-04-16T03:42:41.934Z",
+        "hs_lifecyclestage_lead_date": "2024-04-16T03:42:41.810Z",
+        "hs_marketable_status": "false",
+        "hs_marketable_until_renewal": "false",
+        "hs_object_id": "12791224888",
+        "hs_object_source": "CRM_UI",
+        "hs_object_source_id": "userId:51770238",
+        "hs_object_source_label": "CRM_UI",
+        "hs_object_source_user_id": "51770238",
+        "hs_pipeline": "contacts-lifecycle-pipeline",
+        "hs_predictivecontactscore_v2": "3.6",
+        "hs_sequences_actively_enrolled_count": "0",
+        "hs_social_facebook_clicks": "0",
+        "hs_social_google_plus_clicks": "0",
+        "hs_social_linkedin_clicks": "0",
+        "hs_social_num_broadcast_clicks": "0",
+        "hs_social_twitter_clicks": "0",
+        "hs_time_in_lead": "redacted",
+        "hs_updated_by_user_id": "51770238",
+        "hs_user_ids_of_all_owners": "51770238",
+        "hs_v2_date_entered_lead": "2024-04-16T03:42:41.810Z",
+        "hubspot_owner_assigneddate": "2024-04-16T03:42:41.810Z",
+        "hubspot_owner_id": "750122779",
+        "lastmodifieddate": "2024-04-16T03:43:09.380Z",
+        "lastname": "Doe2",
+        "lifecyclestage": "lead",
+        "hs_time_in_opportunity": "redacted"
+      },
+      "propertiesWithHistory": {
+        "createdate": [
+          {
+            "sourceId": "userId:51770238",
+            "sourceType": "CRM_UI",
+            "timestamp": "2024-04-16T03:42:41.810000Z",
+            "updatedByUserId": 51770238,
+            "value": "2024-04-16T03:42:41.810Z"
+          }
+        ],
+        "email": [
+          {
+            "sourceId": "userId:51770238",
+            "sourceType": "CRM_UI",
+            "timestamp": "2024-04-16T03:42:41.810000Z",
+            "updatedByUserId": 51770238,
+            "value": "test2@test.com"
+          }
+        ],
+        "firstname": [
+          {
+            "sourceId": "userId:51770238",
+            "sourceType": "CRM_UI",
+            "timestamp": "2024-04-16T03:42:41.810000Z",
+            "updatedByUserId": 51770238,
+            "value": "Joe2"
+          }
+        ],
+        "hs_all_assigned_business_unit_ids": [
+          {
+            "sourceId": "userId:51770238",
+            "sourceType": "CRM_UI",
+            "timestamp": "2024-04-16T03:42:41.810000Z",
+            "updatedByUserId": 51770238,
+            "value": "0"
+          }
+        ],
+        "hs_all_owner_ids": [
+          {
+            "sourceId": "userId:51770238",
+            "sourceType": "CRM_UI",
+            "timestamp": "2024-04-16T03:42:41.810000Z",
+            "updatedByUserId": 51770238,
+            "value": "750122779"
+          }
+        ],
+        "hs_analytics_average_page_views": [
+          {
+            "sourceId": "WebAnalyticsPropertyCalculation",
+            "sourceType": "ANALYTICS",
+            "timestamp": "2024-04-16T03:42:47.940000Z",
+            "value": "0"
+          }
+        ],
+        "hs_analytics_first_timestamp": [
+          {
+            "sourceId": "WebAnalyticsPropertyCalculation",
+            "sourceType": "ANALYTICS",
+            "timestamp": "2024-04-16T03:42:47.940000Z",
+            "value": "2024-04-16T03:42:41.810Z"
+          }
+        ],
+        "hs_analytics_num_event_completions": [
+          {
+            "sourceId": "WebAnalyticsPropertyCalculation",
+            "sourceType": "ANALYTICS",
+            "timestamp": "2024-04-16T03:42:47.940000Z",
+            "value": "0"
+          }
+        ],
+        "hs_analytics_num_page_views": [
+          {
+            "sourceId": "WebAnalyticsPropertyCalculation",
+            "sourceType": "ANALYTICS",
+            "timestamp": "2024-04-16T03:42:47.940000Z",
+            "value": "0"
+          }
+        ],
+        "hs_analytics_num_visits": [
+          {
+            "sourceId": "WebAnalyticsPropertyCalculation",
+            "sourceType": "ANALYTICS",
+            "timestamp": "2024-04-16T03:42:47.940000Z",
+            "value": "0"
+          }
+        ],
+        "hs_analytics_revenue": [
+          {
+            "sourceId": "WebAnalyticsPropertyCalculation",
+            "sourceType": "ANALYTICS",
+            "timestamp": "2024-04-16T03:42:47.940000Z",
+            "value": "0.0"
+          }
+        ],
+        "hs_analytics_source": [
+          {
+            "sourceId": "WebAnalyticsPropertyCalculation",
+            "sourceType": "ANALYTICS",
+            "timestamp": "2024-04-16T03:42:47.940000Z",
+            "value": "OFFLINE"
+          }
+        ],
+        "hs_analytics_source_data_1": [
+          {
+            "sourceId": "WebAnalyticsPropertyCalculation",
+            "sourceType": "ANALYTICS",
+            "timestamp": "2024-04-16T03:42:47.940000Z",
+            "value": "CRM_UI"
+          }
+        ],
+        "hs_analytics_source_data_2": [
+          {
+            "sourceId": "WebAnalyticsPropertyCalculation",
+            "sourceType": "ANALYTICS",
+            "timestamp": "2024-04-16T03:42:47.940000Z",
+            "value": "userId:51770238"
+          }
+        ],
+        "hs_count_is_unworked": [
+          {
+            "sourceId": "CalculatedPropertyComputer",
+            "sourceType": "CALCULATED",
+            "timestamp": "2024-04-16T03:42:41.810000Z",
+            "updatedByUserId": 51770238,
+            "value": "1"
+          }
+        ],
+        "hs_count_is_worked": [
+          {
+            "sourceId": "CalculatedPropertyComputer",
+            "sourceType": "CALCULATED",
+            "timestamp": "2024-04-16T03:42:41.810000Z",
+            "updatedByUserId": 51770238,
+            "value": "0"
+          }
+        ],
+        "hs_created_by_user_id": [
+          {
+            "sourceId": "userId:51770238",
+            "sourceType": "CRM_UI",
+            "timestamp": "2024-04-16T03:42:41.810000Z",
+            "updatedByUserId": 51770238,
+            "value": "51770238"
+          }
+        ],
+        "hs_date_entered_lead": [
+          {
+            "sourceType": "CALCULATED",
+            "timestamp": "2024-04-16T03:42:41.810000Z",
+            "value": "2024-04-16T03:42:41.810Z"
+          }
+        ],
+        "hs_is_unworked": [
+          {
+            "sourceId": "CalculatedPropertyComputer",
+            "sourceType": "CALCULATED",
+            "timestamp": "2024-04-16T03:42:41.810000Z",
+            "updatedByUserId": 51770238,
+            "value": "true"
+          }
+        ],
+        "hs_latest_source": [
+          {
+            "sourceId": "WebAnalyticsPropertyCalculation",
+            "sourceType": "ANALYTICS",
+            "timestamp": "2024-04-16T03:42:47.940000Z",
+            "value": "OFFLINE"
+          }
+        ],
+        "hs_latest_source_data_1": [
+          {
+            "sourceId": "WebAnalyticsPropertyCalculation",
+            "sourceType": "ANALYTICS",
+            "timestamp": "2024-04-16T03:42:47.940000Z",
+            "value": "CRM_UI"
+          }
+        ],
+        "hs_latest_source_data_2": [
+          {
+            "sourceId": "WebAnalyticsPropertyCalculation",
+            "sourceType": "ANALYTICS",
+            "timestamp": "2024-04-16T03:42:47.940000Z",
+            "value": "userId:51770238"
+          }
+        ],
+        "hs_latest_source_timestamp": [
+          {
+            "sourceId": "WebAnalyticsPropertyCalculation",
+            "sourceType": "ANALYTICS",
+            "timestamp": "2024-04-16T03:42:47.940000Z",
+            "value": "2024-04-16T03:42:41.934Z"
+          }
+        ],
+        "hs_lifecyclestage_lead_date": [
+          {
+            "sourceId": "userId:51770238",
+            "sourceType": "CRM_UI",
+            "timestamp": "2024-04-16T03:42:41.810000Z",
+            "updatedByUserId": 51770238,
+            "value": "2024-04-16T03:42:41.810Z"
+          }
+        ],
+        "hs_marketable_status": [
+          {
+            "sourceId": "userId:51770238",
+            "sourceType": "CRM_UI",
+            "timestamp": "2024-04-16T03:42:41.810000Z",
+            "updatedByUserId": 51770238,
+            "value": "false"
+          }
+        ],
+        "hs_marketable_until_renewal": [
+          {
+            "sourceId": "userId:51770238",
+            "sourceType": "CRM_UI",
+            "timestamp": "2024-04-16T03:42:41.810000Z",
+            "updatedByUserId": 51770238,
+            "value": "false"
+          }
+        ],
+        "hs_object_id": [
+          {
+            "sourceId": "userId:51770238",
+            "sourceType": "CRM_UI",
+            "timestamp": "2024-04-16T03:42:41.810000Z",
+            "updatedByUserId": 51770238,
+            "value": "12791224888"
+          }
+        ],
+        "hs_object_source": [
+          {
+            "sourceId": "userId:51770238",
+            "sourceType": "CRM_UI",
+            "timestamp": "2024-04-16T03:42:41.810000Z",
+            "updatedByUserId": 51770238,
+            "value": "CRM_UI"
+          }
+        ],
+        "hs_object_source_id": [
+          {
+            "sourceId": "userId:51770238",
+            "sourceType": "CRM_UI",
+            "timestamp": "2024-04-16T03:42:41.810000Z",
+            "updatedByUserId": 51770238,
+            "value": "userId:51770238"
+          }
+        ],
+        "hs_object_source_label": [
+          {
+            "sourceId": "userId:51770238",
+            "sourceType": "CRM_UI",
+            "timestamp": "2024-04-16T03:42:41.810000Z",
+            "updatedByUserId": 51770238,
+            "value": "CRM_UI"
+          }
+        ],
+        "hs_object_source_user_id": [
+          {
+            "sourceId": "userId:51770238",
+            "sourceType": "CRM_UI",
+            "timestamp": "2024-04-16T03:42:41.810000Z",
+            "updatedByUserId": 51770238,
+            "value": "51770238"
+          }
+        ],
+        "hs_pipeline": [
+          {
+            "sourceId": "userId:51770238",
+            "sourceType": "CRM_UI",
+            "timestamp": "2024-04-16T03:42:41.810000Z",
+            "updatedByUserId": 51770238,
+            "value": "contacts-lifecycle-pipeline"
+          }
+        ],
+        "hs_predictivecontactscore_v2": [
+          {
+            "sourceId": "DataPrediction",
+            "sourceLabel": "HubSpot Predictive Contact Scoring Model",
+            "sourceType": "AI_GROUP",
+            "timestamp": "2024-04-16T03:42:45.867000Z",
+            "value": "3.6"
+          }
+        ],
+        "hs_sequences_actively_enrolled_count": [
+          {
+            "sourceId": "RollupProperties",
+            "sourceType": "CALCULATED",
+            "timestamp": "2024-04-16T03:42:43.509000Z",
+            "value": "0"
+          }
+        ],
+        "hs_social_facebook_clicks": [
+          {
+            "sourceId": "WebAnalyticsPropertyCalculation",
+            "sourceType": "ANALYTICS",
+            "timestamp": "2024-04-16T03:42:47.940000Z",
+            "value": "0"
+          }
+        ],
+        "hs_social_google_plus_clicks": [
+          {
+            "sourceId": "WebAnalyticsPropertyCalculation",
+            "sourceType": "ANALYTICS",
+            "timestamp": "2024-04-16T03:42:47.940000Z",
+            "value": "0"
+          }
+        ],
+        "hs_social_linkedin_clicks": [
+          {
+            "sourceId": "WebAnalyticsPropertyCalculation",
+            "sourceType": "ANALYTICS",
+            "timestamp": "2024-04-16T03:42:47.940000Z",
+            "value": "0"
+          }
+        ],
+        "hs_social_num_broadcast_clicks": [
+          {
+            "sourceId": "WebAnalyticsPropertyCalculation",
+            "sourceType": "ANALYTICS",
+            "timestamp": "2024-04-16T03:42:47.940000Z",
+            "value": "0"
+          }
+        ],
+        "hs_social_twitter_clicks": [
+          {
+            "sourceId": "WebAnalyticsPropertyCalculation",
+            "sourceType": "ANALYTICS",
+            "timestamp": "2024-04-16T03:42:47.940000Z",
+            "value": "0"
+          }
+        ],
+        "hs_time_in_lead": "redacted",
+        "hs_updated_by_user_id": [
+          {
+            "sourceId": "userId:51770238",
+            "sourceType": "CRM_UI",
+            "timestamp": "2024-04-16T03:42:41.810000Z",
+            "updatedByUserId": 51770238,
+            "value": "51770238"
+          }
+        ],
+        "hs_user_ids_of_all_owners": [
+          {
+            "sourceId": "userId:51770238",
+            "sourceType": "CRM_UI",
+            "timestamp": "2024-04-16T03:42:41.810000Z",
+            "updatedByUserId": 51770238,
+            "value": "51770238"
+          }
+        ],
+        "hs_v2_date_entered_lead": [
+          {
+            "sourceType": "CALCULATED",
+            "timestamp": "2024-04-16T03:43:09.356000Z",
+            "value": "2024-04-16T03:42:41.810Z"
+          }
+        ],
+        "hubspot_owner_assigneddate": [
+          {
+            "sourceId": "userId:51770238",
+            "sourceType": "CRM_UI",
+            "timestamp": "2024-04-16T03:42:41.810000Z",
+            "updatedByUserId": 51770238,
+            "value": "2024-04-16T03:42:41.810Z"
+          }
+        ],
+        "hubspot_owner_id": [
+          {
+            "sourceId": "userId:51770238",
+            "sourceType": "CRM_UI",
+            "timestamp": "2024-04-16T03:42:41.810000Z",
+            "updatedByUserId": 51770238,
+            "value": "750122779"
+          }
+        ],
+        "lastmodifieddate": [
+          {
+            "sourceType": "API",
+            "timestamp": "2024-04-16T03:43:09.380000Z",
+            "value": "2024-04-16T03:43:09.380Z"
+          },
+          {
+            "sourceType": "API",
+            "timestamp": "2024-04-16T03:42:47.940000Z",
+            "value": "2024-04-16T03:42:47.940Z"
+          },
+          {
+            "sourceId": "DataPrediction",
+            "sourceType": "AI_GROUP",
+            "timestamp": "2024-04-16T03:42:46.249000Z",
+            "value": "2024-04-16T03:42:46.249Z"
+          },
+          {
+            "sourceType": "CALCULATED",
+            "timestamp": "2024-04-16T03:42:43.593000Z",
+            "value": "2024-04-16T03:42:43.593Z"
+          },
+          {
+            "sourceId": "userId:51770238",
+            "sourceType": "CRM_UI",
+            "timestamp": "2024-04-16T03:42:41.810000Z",
+            "updatedByUserId": 51770238,
+            "value": "2024-04-16T03:42:41.810Z"
+          }
+        ],
+        "lastname": [
+          {
+            "sourceId": "userId:51770238",
+            "sourceType": "CRM_UI",
+            "timestamp": "2024-04-16T03:42:41.810000Z",
+            "updatedByUserId": 51770238,
+            "value": "Doe2"
+          }
+        ],
+        "lifecyclestage": [
+          {
+            "sourceId": "userId:51770238",
+            "sourceType": "CRM_UI",
+            "timestamp": "2024-04-16T03:42:41.810000Z",
+            "updatedByUserId": 51770238,
+            "value": "lead"
+          }
+        ],
+        "hs_time_in_opportunity": "redacted"
+      },
+      "updatedAt": "2024-04-16T03:43:09.380000Z"
+    }
+  ],
+  [
+    "acmeCo/contacts",
+    {
+      "_meta": {
+        "op": "u"
+      },
+      "archived": false,
+      "createdAt": "2024-04-16T02:30:56.919000Z",
+      "id": 12794981224,
+      "properties": {
+        "createdate": "2024-04-16T02:30:56.919Z",
+        "email": "test@test.com",
+        "firstname": "Joe",
+        "hs_all_assigned_business_unit_ids": "0",
+        "hs_all_owner_ids": "750122779",
+        "hs_analytics_average_page_views": "0",
+        "hs_analytics_first_timestamp": "2024-04-16T02:30:56.919Z",
+        "hs_analytics_num_event_completions": "0",
+        "hs_analytics_num_page_views": "0",
+        "hs_analytics_num_visits": "0",
+        "hs_analytics_revenue": "0.0",
+        "hs_analytics_source": "OFFLINE",
+        "hs_analytics_source_data_1": "CRM_UI",
+        "hs_analytics_source_data_2": "userId:51770238",
+        "hs_count_is_unworked": "1",
+        "hs_count_is_worked": "0",
+        "hs_created_by_user_id": "51770238",
+        "hs_date_entered_lead": "2024-04-16T02:30:56.919Z",
+        "hs_is_unworked": "true",
+        "hs_latest_source": "OFFLINE",
+        "hs_latest_source_data_1": "CRM_UI",
+        "hs_latest_source_data_2": "userId:51770238",
+        "hs_latest_source_timestamp": "2024-04-16T02:30:57.049Z",
+        "hs_lifecyclestage_lead_date": "2024-04-16T02:30:56.919Z",
+        "hs_marketable_status": "false",
+        "hs_marketable_until_renewal": "false",
+        "hs_object_id": "12794981224",
+        "hs_object_source": "CRM_UI",
+        "hs_object_source_id": "userId:51770238",
+        "hs_object_source_label": "CRM_UI",
+        "hs_object_source_user_id": "51770238",
+        "hs_pipeline": "contacts-lifecycle-pipeline",
+        "hs_predictivecontactscore_v2": "3.6",
+        "hs_sequences_actively_enrolled_count": "0",
+        "hs_social_facebook_clicks": "0",
+        "hs_social_google_plus_clicks": "0",
+        "hs_social_linkedin_clicks": "0",
+        "hs_social_num_broadcast_clicks": "0",
+        "hs_social_twitter_clicks": "0",
+        "hs_time_in_lead": "redacted",
+        "hs_updated_by_user_id": "51770238",
+        "hs_user_ids_of_all_owners": "51770238",
+        "hs_v2_date_entered_lead": "2024-04-16T02:30:56.919Z",
+        "hubspot_owner_assigneddate": "2024-04-16T02:30:56.919Z",
+        "hubspot_owner_id": "750122779",
+        "lastmodifieddate": "2024-04-16T02:31:23.976Z",
+        "lastname": "Doe",
+        "lifecyclestage": "lead",
+        "hs_time_in_opportunity": "redacted"
+      },
+      "propertiesWithHistory": {
+        "createdate": [
+          {
+            "sourceId": "userId:51770238",
+            "sourceType": "CRM_UI",
+            "timestamp": "2024-04-16T02:30:56.919000Z",
+            "updatedByUserId": 51770238,
+            "value": "2024-04-16T02:30:56.919Z"
+          }
+        ],
+        "email": [
+          {
+            "sourceId": "userId:51770238",
+            "sourceType": "CRM_UI",
+            "timestamp": "2024-04-16T02:30:56.919000Z",
+            "updatedByUserId": 51770238,
+            "value": "test@test.com"
+          }
+        ],
+        "firstname": [
+          {
+            "sourceId": "userId:51770238",
+            "sourceType": "CRM_UI",
+            "timestamp": "2024-04-16T02:30:56.919000Z",
+            "updatedByUserId": 51770238,
+            "value": "Joe"
+          }
+        ],
+        "hs_all_assigned_business_unit_ids": [
+          {
+            "sourceId": "userId:51770238",
+            "sourceType": "CRM_UI",
+            "timestamp": "2024-04-16T02:30:56.919000Z",
+            "updatedByUserId": 51770238,
+            "value": "0"
+          }
+        ],
+        "hs_all_owner_ids": [
+          {
+            "sourceId": "userId:51770238",
+            "sourceType": "CRM_UI",
+            "timestamp": "2024-04-16T02:30:56.919000Z",
+            "updatedByUserId": 51770238,
+            "value": "750122779"
+          }
+        ],
+        "hs_analytics_average_page_views": [
+          {
+            "sourceId": "WebAnalyticsPropertyCalculation",
+            "sourceType": "ANALYTICS",
+            "timestamp": "2024-04-16T02:31:16.770000Z",
+            "value": "0"
+          }
+        ],
+        "hs_analytics_first_timestamp": [
+          {
+            "sourceId": "WebAnalyticsPropertyCalculation",
+            "sourceType": "ANALYTICS",
+            "timestamp": "2024-04-16T02:31:16.770000Z",
+            "value": "2024-04-16T02:30:56.919Z"
+          }
+        ],
+        "hs_analytics_num_event_completions": [
+          {
+            "sourceId": "WebAnalyticsPropertyCalculation",
+            "sourceType": "ANALYTICS",
+            "timestamp": "2024-04-16T02:31:16.770000Z",
+            "value": "0"
+          }
+        ],
+        "hs_analytics_num_page_views": [
+          {
+            "sourceId": "WebAnalyticsPropertyCalculation",
+            "sourceType": "ANALYTICS",
+            "timestamp": "2024-04-16T02:31:16.770000Z",
+            "value": "0"
+          }
+        ],
+        "hs_analytics_num_visits": [
+          {
+            "sourceId": "WebAnalyticsPropertyCalculation",
+            "sourceType": "ANALYTICS",
+            "timestamp": "2024-04-16T02:31:16.770000Z",
+            "value": "0"
+          }
+        ],
+        "hs_analytics_revenue": [
+          {
+            "sourceId": "WebAnalyticsPropertyCalculation",
+            "sourceType": "ANALYTICS",
+            "timestamp": "2024-04-16T02:31:16.770000Z",
+            "value": "0.0"
+          }
+        ],
+        "hs_analytics_source": [
+          {
+            "sourceId": "WebAnalyticsPropertyCalculation",
+            "sourceType": "ANALYTICS",
+            "timestamp": "2024-04-16T02:31:16.770000Z",
+            "value": "OFFLINE"
+          }
+        ],
+        "hs_analytics_source_data_1": [
+          {
+            "sourceId": "WebAnalyticsPropertyCalculation",
+            "sourceType": "ANALYTICS",
+            "timestamp": "2024-04-16T02:31:16.770000Z",
+            "value": "CRM_UI"
+          }
+        ],
+        "hs_analytics_source_data_2": [
+          {
+            "sourceId": "WebAnalyticsPropertyCalculation",
+            "sourceType": "ANALYTICS",
+            "timestamp": "2024-04-16T02:31:16.770000Z",
+            "value": "userId:51770238"
+          }
+        ],
+        "hs_count_is_unworked": [
+          {
+            "sourceId": "CalculatedPropertyComputer",
+            "sourceType": "CALCULATED",
+            "timestamp": "2024-04-16T02:30:56.919000Z",
+            "updatedByUserId": 51770238,
+            "value": "1"
+          }
+        ],
+        "hs_count_is_worked": [
+          {
+            "sourceId": "CalculatedPropertyComputer",
+            "sourceType": "CALCULATED",
+            "timestamp": "2024-04-16T02:30:56.919000Z",
+            "updatedByUserId": 51770238,
+            "value": "0"
+          }
+        ],
+        "hs_created_by_user_id": [
+          {
+            "sourceId": "userId:51770238",
+            "sourceType": "CRM_UI",
+            "timestamp": "2024-04-16T02:30:56.919000Z",
+            "updatedByUserId": 51770238,
+            "value": "51770238"
+          }
+        ],
+        "hs_date_entered_lead": [
+          {
+            "sourceType": "CALCULATED",
+            "timestamp": "2024-04-16T02:30:56.919000Z",
+            "value": "2024-04-16T02:30:56.919Z"
+          }
+        ],
+        "hs_is_unworked": [
+          {
+            "sourceId": "CalculatedPropertyComputer",
+            "sourceType": "CALCULATED",
+            "timestamp": "2024-04-16T02:30:56.919000Z",
+            "updatedByUserId": 51770238,
+            "value": "true"
+          }
+        ],
+        "hs_latest_source": [
+          {
+            "sourceId": "WebAnalyticsPropertyCalculation",
+            "sourceType": "ANALYTICS",
+            "timestamp": "2024-04-16T02:31:16.770000Z",
+            "value": "OFFLINE"
+          }
+        ],
+        "hs_latest_source_data_1": [
+          {
+            "sourceId": "WebAnalyticsPropertyCalculation",
+            "sourceType": "ANALYTICS",
+            "timestamp": "2024-04-16T02:31:16.770000Z",
+            "value": "CRM_UI"
+          }
+        ],
+        "hs_latest_source_data_2": [
+          {
+            "sourceId": "WebAnalyticsPropertyCalculation",
+            "sourceType": "ANALYTICS",
+            "timestamp": "2024-04-16T02:31:16.770000Z",
+            "value": "userId:51770238"
+          }
+        ],
+        "hs_latest_source_timestamp": [
+          {
+            "sourceId": "WebAnalyticsPropertyCalculation",
+            "sourceType": "ANALYTICS",
+            "timestamp": "2024-04-16T02:31:16.770000Z",
+            "value": "2024-04-16T02:30:57.049Z"
+          }
+        ],
+        "hs_lifecyclestage_lead_date": [
+          {
+            "sourceId": "userId:51770238",
+            "sourceType": "CRM_UI",
+            "timestamp": "2024-04-16T02:30:56.919000Z",
+            "updatedByUserId": 51770238,
+            "value": "2024-04-16T02:30:56.919Z"
+          }
+        ],
+        "hs_marketable_status": [
+          {
+            "sourceId": "userId:51770238",
+            "sourceType": "CRM_UI",
+            "timestamp": "2024-04-16T02:30:56.919000Z",
+            "updatedByUserId": 51770238,
+            "value": "false"
+          }
+        ],
+        "hs_marketable_until_renewal": [
+          {
+            "sourceId": "userId:51770238",
+            "sourceType": "CRM_UI",
+            "timestamp": "2024-04-16T02:30:56.919000Z",
+            "updatedByUserId": 51770238,
+            "value": "false"
+          }
+        ],
+        "hs_object_id": [
+          {
+            "sourceId": "userId:51770238",
+            "sourceType": "CRM_UI",
+            "timestamp": "2024-04-16T02:30:56.919000Z",
+            "updatedByUserId": 51770238,
+            "value": "12794981224"
+          }
+        ],
+        "hs_object_source": [
+          {
+            "sourceId": "userId:51770238",
+            "sourceType": "CRM_UI",
+            "timestamp": "2024-04-16T02:30:56.919000Z",
+            "updatedByUserId": 51770238,
+            "value": "CRM_UI"
+          }
+        ],
+        "hs_object_source_id": [
+          {
+            "sourceId": "userId:51770238",
+            "sourceType": "CRM_UI",
+            "timestamp": "2024-04-16T02:30:56.919000Z",
+            "updatedByUserId": 51770238,
+            "value": "userId:51770238"
+          }
+        ],
+        "hs_object_source_label": [
+          {
+            "sourceId": "userId:51770238",
+            "sourceType": "CRM_UI",
+            "timestamp": "2024-04-16T02:30:56.919000Z",
+            "updatedByUserId": 51770238,
+            "value": "CRM_UI"
+          }
+        ],
+        "hs_object_source_user_id": [
+          {
+            "sourceId": "userId:51770238",
+            "sourceType": "CRM_UI",
+            "timestamp": "2024-04-16T02:30:56.919000Z",
+            "updatedByUserId": 51770238,
+            "value": "51770238"
+          }
+        ],
+        "hs_pipeline": [
+          {
+            "sourceId": "userId:51770238",
+            "sourceType": "CRM_UI",
+            "timestamp": "2024-04-16T02:30:56.919000Z",
+            "updatedByUserId": 51770238,
+            "value": "contacts-lifecycle-pipeline"
+          }
+        ],
+        "hs_predictivecontactscore_v2": [
+          {
+            "sourceId": "DataPrediction",
+            "sourceLabel": "HubSpot Predictive Contact Scoring Model",
+            "sourceType": "AI_GROUP",
+            "timestamp": "2024-04-16T02:31:22.568000Z",
+            "value": "3.6"
+          }
+        ],
+        "hs_sequences_actively_enrolled_count": [
+          {
+            "sourceId": "RollupProperties",
+            "sourceType": "CALCULATED",
+            "timestamp": "2024-04-16T02:30:58.315000Z",
+            "value": "0"
+          }
+        ],
+        "hs_social_facebook_clicks": [
+          {
+            "sourceId": "WebAnalyticsPropertyCalculation",
+            "sourceType": "ANALYTICS",
+            "timestamp": "2024-04-16T02:31:16.770000Z",
+            "value": "0"
+          }
+        ],
+        "hs_social_google_plus_clicks": [
+          {
+            "sourceId": "WebAnalyticsPropertyCalculation",
+            "sourceType": "ANALYTICS",
+            "timestamp": "2024-04-16T02:31:16.770000Z",
+            "value": "0"
+          }
+        ],
+        "hs_social_linkedin_clicks": [
+          {
+            "sourceId": "WebAnalyticsPropertyCalculation",
+            "sourceType": "ANALYTICS",
+            "timestamp": "2024-04-16T02:31:16.770000Z",
+            "value": "0"
+          }
+        ],
+        "hs_social_num_broadcast_clicks": [
+          {
+            "sourceId": "WebAnalyticsPropertyCalculation",
+            "sourceType": "ANALYTICS",
+            "timestamp": "2024-04-16T02:31:16.770000Z",
+            "value": "0"
+          }
+        ],
+        "hs_social_twitter_clicks": [
+          {
+            "sourceId": "WebAnalyticsPropertyCalculation",
+            "sourceType": "ANALYTICS",
+            "timestamp": "2024-04-16T02:31:16.770000Z",
+            "value": "0"
+          }
+        ],
+        "hs_time_in_lead": "redacted",
+        "hs_updated_by_user_id": [
+          {
+            "sourceId": "userId:51770238",
+            "sourceType": "CRM_UI",
+            "timestamp": "2024-04-16T02:30:56.919000Z",
+            "updatedByUserId": 51770238,
+            "value": "51770238"
+          }
+        ],
+        "hs_user_ids_of_all_owners": [
+          {
+            "sourceId": "userId:51770238",
+            "sourceType": "CRM_UI",
+            "timestamp": "2024-04-16T02:30:56.919000Z",
+            "updatedByUserId": 51770238,
+            "value": "51770238"
+          }
+        ],
+        "hs_v2_date_entered_lead": [
+          {
+            "sourceType": "CALCULATED",
+            "timestamp": "2024-04-16T02:31:00.798000Z",
+            "value": "2024-04-16T02:30:56.919Z"
+          }
+        ],
+        "hubspot_owner_assigneddate": [
+          {
+            "sourceId": "userId:51770238",
+            "sourceType": "CRM_UI",
+            "timestamp": "2024-04-16T02:30:56.919000Z",
+            "updatedByUserId": 51770238,
+            "value": "2024-04-16T02:30:56.919Z"
+          }
+        ],
+        "hubspot_owner_id": [
+          {
+            "sourceId": "userId:51770238",
+            "sourceType": "CRM_UI",
+            "timestamp": "2024-04-16T02:30:56.919000Z",
+            "updatedByUserId": 51770238,
+            "value": "750122779"
+          }
+        ],
+        "lastmodifieddate": [
+          {
+            "sourceId": "DataPrediction",
+            "sourceType": "AI_GROUP",
+            "timestamp": "2024-04-16T02:31:23.976000Z",
+            "value": "2024-04-16T02:31:23.976Z"
+          },
+          {
+            "sourceType": "API",
+            "timestamp": "2024-04-16T02:31:16.770000Z",
+            "value": "2024-04-16T02:31:16.770Z"
+          },
+          {
+            "sourceType": "API",
+            "timestamp": "2024-04-16T02:31:00.809000Z",
+            "value": "2024-04-16T02:31:00.809Z"
+          },
+          {
+            "sourceType": "CALCULATED",
+            "timestamp": "2024-04-16T02:30:58.328000Z",
+            "value": "2024-04-16T02:30:58.328Z"
+          },
+          {
+            "sourceId": "userId:51770238",
+            "sourceType": "CRM_UI",
+            "timestamp": "2024-04-16T02:30:56.919000Z",
+            "updatedByUserId": 51770238,
+            "value": "2024-04-16T02:30:56.919Z"
+          }
+        ],
+        "lastname": [
+          {
+            "sourceId": "userId:51770238",
+            "sourceType": "CRM_UI",
+            "timestamp": "2024-04-16T02:30:56.919000Z",
+            "updatedByUserId": 51770238,
+            "value": "Doe"
+          }
+        ],
+        "lifecyclestage": [
+          {
+            "sourceId": "userId:51770238",
+            "sourceType": "CRM_UI",
+            "timestamp": "2024-04-16T02:30:56.919000Z",
+            "updatedByUserId": 51770238,
+            "value": "lead"
+          }
+        ],
+        "hs_time_in_opportunity": "redacted"
+      },
+      "updatedAt": "2024-04-16T02:31:23.976000Z"
+    }
+  ],
+  [
+    "acmeCo/contacts_lists_subscription",
+    {
+      "_meta": {
+        "op": "u"
+      },
+      "addedAt": 1713238961934,
+      "canonical-vid": 12791224888,
+      "form-submissions": [],
+      "identity-profiles": [
+        {
+          "deleted-changed-timestamp": 0,
+          "identities": [
+            {
+              "is-primary": true,
+              "timestamp": 1713238961810,
+              "type": "EMAIL",
+              "value": "test2@test.com"
+            },
+            {
+              "timestamp": 1713238961930,
+              "type": "LEAD_GUID",
+              "value": "194ce471-8209-4600-826c-05ea3c685bbb"
+            }
+          ],
+          "saved-at-timestamp": 1713238961934,
+          "vid": 12791224888
+        }
+      ],
+      "is-contact": true,
+      "list-memberships": [],
+      "merge-audits": [],
+      "merged-vids": [],
+      "portal-id": 45386308,
+      "properties": {
+        "firstname": {
+          "value": "Joe2"
+        },
+        "lastmodifieddate": {
+          "value": "1713238989380"
+        },
+        "lastname": {
+          "value": "Doe2"
+        }
+      },
+      "vid": "12791224888"
+    }
+  ],
+  [
+    "acmeCo/contacts_lists_subscription",
+    {
+      "_meta": {
+        "op": "u"
+      },
+      "addedAt": 1713234657049,
+      "canonical-vid": 12794981224,
+      "form-submissions": [],
+      "identity-profiles": [
+        {
+          "deleted-changed-timestamp": 0,
+          "identities": [
+            {
+              "is-primary": true,
+              "timestamp": 1713234656919,
+              "type": "EMAIL",
+              "value": "test@test.com"
+            },
+            {
+              "timestamp": 1713234657046,
+              "type": "LEAD_GUID",
+              "value": "e1f71942-f251-48b5-80d4-ebc126f97fe8"
+            }
+          ],
+          "saved-at-timestamp": 1713234657049,
+          "vid": 12794981224
+        }
+      ],
+      "is-contact": true,
+      "list-memberships": [],
+      "merge-audits": [],
+      "merged-vids": [],
+      "portal-id": 45386308,
+      "properties": {
+        "firstname": {
+          "value": "Joe"
+        },
+        "lastmodifieddate": {
+          "value": "1713234683976"
+        },
+        "lastname": {
+          "value": "Doe"
+        }
+      },
+      "vid": "12794981224"
+    }
+  ],
+  [
     "acmeCo/marketing_emails",
     {
       "_meta": {
@@ -1993,149 +3065,6 @@
       "options": [],
       "type": "string",
       "updatedAt": "2023-03-02T13:20:44.637Z"
-    }
-  ],
-  [
-    "acmeCo/properties",
-    {
-      "_meta": {
-        "op": "c",
-        "row_id": 39
-      },
-      "calculated": false,
-      "createdAt": "2019-08-06T02:41:46.170Z",
-      "description": "The path in the FileManager CDN for this company's avatar override image. Automatically set by HubSpot.",
-      "displayOrder": -1,
-      "externalOptions": false,
-      "fieldType": "text",
-      "formField": false,
-      "groupName": "companyinformation",
-      "hasUniqueValue": false,
-      "hidden": true,
-      "hubspotDefined": true,
-      "hubspotObject": "companies",
-      "label": "Avatar FileManager key",
-      "modificationMetadata": {
-        "archivable": true,
-        "readOnlyDefinition": true,
-        "readOnlyValue": true
-      },
-      "name": "hs_avatar_filemanager_key",
-      "options": [],
-      "type": "string",
-      "updatedAt": "2022-05-27T23:06:08.771Z"
-    }
-  ],
-  [
-    "acmeCo/properties",
-    {
-      "_meta": {
-        "op": "c",
-        "row_id": 40
-      },
-      "calculated": false,
-      "createdAt": "2020-01-28T22:45:20.560Z",
-      "description": "The user that created this object. This value is automatically set by HubSpot and may not be modified.",
-      "displayOrder": -1,
-      "externalOptions": false,
-      "fieldType": "number",
-      "formField": false,
-      "groupName": "companyinformation",
-      "hasUniqueValue": false,
-      "hidden": false,
-      "hubspotDefined": true,
-      "hubspotObject": "companies",
-      "label": "Created by user ID",
-      "modificationMetadata": {
-        "archivable": true,
-        "readOnlyDefinition": true,
-        "readOnlyValue": true
-      },
-      "name": "hs_created_by_user_id",
-      "options": [],
-      "type": "number",
-      "updatedAt": "2023-06-09T19:56:38.314Z"
-    }
-  ],
-  [
-    "acmeCo/properties",
-    {
-      "_meta": {
-        "op": "c",
-        "row_id": 41
-      },
-      "calculated": false,
-      "createdAt": "1970-01-01T00:00:00Z",
-      "description": "The date and time at which this object was created. This value is automatically set by HubSpot and may not be modified.",
-      "displayOrder": -1,
-      "externalOptions": false,
-      "fieldType": "date",
-      "formField": false,
-      "groupName": "companyinformation",
-      "hasUniqueValue": false,
-      "hidden": true,
-      "hubspotDefined": true,
-      "hubspotObject": "companies",
-      "label": "Object create date/time",
-      "modificationMetadata": {
-        "archivable": true,
-        "readOnlyDefinition": true,
-        "readOnlyValue": true
-      },
-      "name": "hs_createdate",
-      "options": [],
-      "type": "datetime",
-      "updatedAt": "2023-12-05T17:03:58.823Z"
-    }
-  ],
-  [
-    "acmeCo/properties",
-    {
-      "_meta": {
-        "op": "c",
-        "row_id": 42
-      },
-      "calculated": false,
-      "createdAt": "2024-04-09T21:45:07.560Z",
-      "description": "This property stores a CSM's sentiment towards a company.",
-      "displayOrder": -1,
-      "externalOptions": false,
-      "fieldType": "select",
-      "formField": false,
-      "groupName": "companyinformation",
-      "hasUniqueValue": false,
-      "hidden": false,
-      "hubspotDefined": true,
-      "hubspotObject": "companies",
-      "label": "CSM Sentiment",
-      "modificationMetadata": {
-        "archivable": true,
-        "readOnlyDefinition": false,
-        "readOnlyValue": false
-      },
-      "name": "hs_csm_sentiment",
-      "options": [
-        {
-          "displayOrder": 0,
-          "hidden": false,
-          "label": "At-Risk",
-          "value": "at_risk"
-        },
-        {
-          "displayOrder": 1,
-          "hidden": false,
-          "label": "Neutral",
-          "value": "neutral"
-        },
-        {
-          "displayOrder": 2,
-          "hidden": false,
-          "label": "Healthy",
-          "value": "healthy"
-        }
-      ],
-      "type": "enumeration",
-      "updatedAt": "2024-04-09T21:45:07.560Z"
     }
   ]
 ]

--- a/source-hubspot-native/tests/snapshots/source_hubspot_native_tests_test_snapshots__capture__stdout.json
+++ b/source-hubspot-native/tests/snapshots/source_hubspot_native_tests_test_snapshots__capture__stdout.json
@@ -2096,27 +2096,46 @@
         "row_id": 42
       },
       "calculated": false,
-      "createdAt": "2024-02-23T19:17:13.324Z",
-      "description": "This property stores the average sentiment of open support tickets at a given time",
+      "createdAt": "2024-04-09T21:45:07.560Z",
+      "description": "This property stores a CSM's sentiment towards a company.",
       "displayOrder": -1,
       "externalOptions": false,
-      "fieldType": "number",
+      "fieldType": "select",
       "formField": false,
-      "groupName": "company_activity",
+      "groupName": "companyinformation",
       "hasUniqueValue": false,
       "hidden": false,
       "hubspotDefined": true,
       "hubspotObject": "companies",
-      "label": "Customer Success Ticket Sentiment",
+      "label": "CSM Sentiment",
       "modificationMetadata": {
         "archivable": true,
         "readOnlyDefinition": false,
-        "readOnlyValue": true
+        "readOnlyValue": false
       },
-      "name": "hs_customer_success_ticket_sentiment",
-      "options": [],
-      "type": "number",
-      "updatedAt": "2024-02-23T19:17:13.324Z"
+      "name": "hs_csm_sentiment",
+      "options": [
+        {
+          "displayOrder": 0,
+          "hidden": false,
+          "label": "At-Risk",
+          "value": "at_risk"
+        },
+        {
+          "displayOrder": 1,
+          "hidden": false,
+          "label": "Neutral",
+          "value": "neutral"
+        },
+        {
+          "displayOrder": 2,
+          "hidden": false,
+          "label": "Healthy",
+          "value": "healthy"
+        }
+      ],
+      "type": "enumeration",
+      "updatedAt": "2024-04-09T21:45:07.560Z"
     }
   ]
 ]

--- a/source-hubspot-native/tests/snapshots/source_hubspot_native_tests_test_snapshots__discover__stdout.json
+++ b/source-hubspot-native/tests/snapshots/source_hubspot_native_tests_test_snapshots__discover__stdout.json
@@ -8,7 +8,7 @@
     "documentSchema": {
       "$defs": {
         "History": {
-          "additionalProperties": false,
+          "additionalProperties": true,
           "properties": {
             "_meta": {
               "allOf": [
@@ -198,7 +198,7 @@
     "documentSchema": {
       "$defs": {
         "History": {
-          "additionalProperties": false,
+          "additionalProperties": true,
           "properties": {
             "_meta": {
               "allOf": [
@@ -380,7 +380,7 @@
     "documentSchema": {
       "$defs": {
         "History": {
-          "additionalProperties": false,
+          "additionalProperties": true,
           "properties": {
             "_meta": {
               "allOf": [
@@ -578,7 +578,7 @@
     "documentSchema": {
       "$defs": {
         "History": {
-          "additionalProperties": false,
+          "additionalProperties": true,
           "properties": {
             "_meta": {
               "allOf": [
@@ -1120,7 +1120,7 @@
     "documentSchema": {
       "$defs": {
         "History": {
-          "additionalProperties": false,
+          "additionalProperties": true,
           "properties": {
             "_meta": {
               "allOf": [
@@ -1379,7 +1379,7 @@
     "documentSchema": {
       "$defs": {
         "History": {
-          "additionalProperties": false,
+          "additionalProperties": true,
           "properties": {
             "_meta": {
               "allOf": [
@@ -1593,7 +1593,7 @@
     "documentSchema": {
       "$defs": {
         "History": {
-          "additionalProperties": false,
+          "additionalProperties": true,
           "properties": {
             "_meta": {
               "allOf": [
@@ -1807,7 +1807,7 @@
     "documentSchema": {
       "$defs": {
         "History": {
-          "additionalProperties": false,
+          "additionalProperties": true,
           "properties": {
             "_meta": {
               "allOf": [
@@ -2021,7 +2021,7 @@
     "documentSchema": {
       "$defs": {
         "History": {
-          "additionalProperties": false,
+          "additionalProperties": true,
           "properties": {
             "_meta": {
               "allOf": [
@@ -2235,7 +2235,7 @@
     "documentSchema": {
       "$defs": {
         "History": {
-          "additionalProperties": false,
+          "additionalProperties": true,
           "properties": {
             "_meta": {
               "allOf": [
@@ -2449,7 +2449,7 @@
     "documentSchema": {
       "$defs": {
         "History": {
-          "additionalProperties": false,
+          "additionalProperties": true,
           "properties": {
             "_meta": {
               "allOf": [
@@ -2631,7 +2631,7 @@
     "documentSchema": {
       "$defs": {
         "History": {
-          "additionalProperties": false,
+          "additionalProperties": true,
           "properties": {
             "_meta": {
               "allOf": [
@@ -2813,7 +2813,7 @@
     "documentSchema": {
       "$defs": {
         "History": {
-          "additionalProperties": false,
+          "additionalProperties": true,
           "properties": {
             "_meta": {
               "allOf": [
@@ -2995,7 +2995,7 @@
     "documentSchema": {
       "$defs": {
         "History": {
-          "additionalProperties": false,
+          "additionalProperties": true,
           "properties": {
             "_meta": {
               "allOf": [
@@ -3177,7 +3177,7 @@
     "documentSchema": {
       "$defs": {
         "History": {
-          "additionalProperties": false,
+          "additionalProperties": true,
           "properties": {
             "_meta": {
               "allOf": [
@@ -3837,7 +3837,7 @@
     "documentSchema": {
       "$defs": {
         "History": {
-          "additionalProperties": false,
+          "additionalProperties": true,
           "properties": {
             "_meta": {
               "allOf": [

--- a/source-hubspot-native/tests/snapshots/source_hubspot_native_tests_test_snapshots__spec__stdout.json
+++ b/source-hubspot-native/tests/snapshots/source_hubspot_native_tests_test_snapshots__spec__stdout.json
@@ -8,7 +8,8 @@
             "credentials_title": {
               "const": "Private App Credentials",
               "default": "Private App Credentials",
-              "title": "Credentials Title"
+              "title": "Credentials Title",
+              "type": "string"
             },
             "access_token": {
               "secret": true,
@@ -27,7 +28,8 @@
             "credentials_title": {
               "const": "OAuth Credentials",
               "default": "OAuth Credentials",
-              "title": "Credentials Title"
+              "title": "Credentials Title",
+              "type": "string"
             },
             "client_id": {
               "secret": true,
@@ -72,11 +74,12 @@
               "$ref": "#/$defs/AccessToken"
             }
           ],
-          "title": "Authentication"
+          "title": "Authentication",
+          "type": "object"
         },
         "start_date": {
           "format": "date-time",
-          "title": "start_date",
+          "title": "Start Date",
           "type": "string"
         }
       },
@@ -110,7 +113,7 @@
       "title": "ResourceConfig",
       "type": "object"
     },
-    "documentationUrl": "https://go.estuary.dev/source-hubspot-native",
+    "documentationUrl": "https://go.estuary.dev/hubspot-real-time",
     "oauth2": {
       "provider": "hubspot",
       "authUrlTemplate": "https://app.hubspot.com/oauth/authorize?client_id={{#urlencode}}{{{ client_id }}}{{/urlencode}}&scope=crm.lists.read%20crm.objects.companies.read%20crm.objects.contacts.read%20crm.objects.deals.read%20crm.objects.owners.read%20crm.schemas.companies.read%20crm.schemas.contacts.read%20crm.schemas.deals.read%20e-commerce%20files%20files.ui_hidden.read%20forms%20forms-uploaded-files%20sales-email-read%20communication_preferences.read%20communication_preferences.read_write%20tickets&optional_scope=automation%20content%20crm.objects.custom.read%20crm.objects.feedback_submissions.read%20crm.objects.goals.read%20crm.schemas.custom.read&redirect_uri={{#urlencode}}{{{ redirect_uri }}}{{/urlencode}}&response_type=code&state={{#urlencode}}{{{ state }}}{{/urlencode}}",

--- a/source-hubspot-native/tests/snapshots/source_hubspot_native_tests_test_snapshots__spec__stdout.json
+++ b/source-hubspot-native/tests/snapshots/source_hubspot_native_tests_test_snapshots__spec__stdout.json
@@ -11,6 +11,7 @@
               "title": "Credentials Title"
             },
             "access_token": {
+              "secret": true,
               "title": "Access Token",
               "type": "string"
             }
@@ -29,14 +30,17 @@
               "title": "Credentials Title"
             },
             "client_id": {
+              "secret": true,
               "title": "Client Id",
               "type": "string"
             },
             "client_secret": {
+              "secret": true,
               "title": "Client Secret",
               "type": "string"
             },
             "refresh_token": {
+              "secret": true,
               "title": "Refresh Token",
               "type": "string"
             }

--- a/source-hubspot-native/tests/test_snapshots.py
+++ b/source-hubspot-native/tests/test_snapshots.py
@@ -20,6 +20,18 @@ def test_capture(request, snapshot):
     assert result.returncode == 0
     lines = [json.loads(l) for l in result.stdout.splitlines()[:50]]
 
+    for l in lines:
+        typ, rec = l[0], l[1]
+
+        if typ == "acmeCo/contacts":
+            rec["properties"]["hs_time_in_lead"] = "redacted"
+            rec["properties"]["hs_time_in_opportunity"] = "redacted"
+            rec["propertiesWithHistory"]["hs_time_in_lead"] = "redacted"
+            rec["propertiesWithHistory"]["hs_time_in_opportunity"] = "redacted"
+        elif typ == "acmeCo/deals":
+            rec["properties"]["hs_time_in_appointmentscheduled"] = "redacted"
+            rec["propertiesWithHistory"]["hs_time_in_appointmentscheduled"] = "redacted"
+
     assert snapshot("stdout.json") == lines
 
 


### PR DESCRIPTION
# Tests

## Local Stack

Tests were made using a flow local stack along with a free-tier version of supabase for materialization.

In order to fix OAuth2 & Access Token issues, both were granted a `secret=True` setting within their sensible data fields.
Also, both `credentials_title` and `credentials` fields were assigned basic types, so that Flow UI would not display warnings. This modified both spec snapshots from `source-hubspot-native` and `source-google-sheets-native`, and they were also updated in this PR. 

The following Streams were validated using the newly built ":local" source-hubspot-native inside Flow UI:
- Companies
- Contact Lists
- Contacts
- Contacts Lists Subscription
- Email Events
- Email Subscriptions
- Marketing Emails
- Properties
- Subscription Changes
- Custom Objects ( Venues is our generated example )

The following Streams were not able to be validated using the newly built connector inside Flow UI, but were validated using flowctl preview:
- Campaigns
- Deal Pipelines
- Deals
- Engagements
- Engagements Calls
- Engagements Emails
- Engagements Meetings
- Engagements Notes
- Engagements Tasks
- Feedback Submissions
- Marketing Forms
- Owners
- Products
- Tickets


The following Streams were not able to be validated (No data was ever returned by them, probably due to the lack of data inside testing accounts):
- Workflows
- Goal Targets
- Line Items
- Ticket Pipelines

## Production Stack

As this connector is already deployed, tests were executed on the production version, also using a free-tier version of supabase for materialization.
Initial tests displayed schema validation errors, showing missing properties on "Contacts" Stream, along with schema errors on Deals and Engagements streams. Missing properties on the "Contacts" Stream seem to be caused by newly added properties. To allow for better maintenance of this connector, PropertiesWithHistory fields were set to be dinamic and allow for extra inputs.

With the new changes, capture snapshots are now more complete and hold similar data to the imported `source-hubspot` version

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1493)
<!-- Reviewable:end -->
