### PR TITLE
source-mysql: Fix handling of enums with explicit `''` option

### DIFF
--- a/source-mysql/.snapshots/TestEnumEmptyString-backfill
+++ b/source-mysql/.snapshots/TestEnumEmptyString-backfill
@@ -1,0 +1,16 @@
+# ================================
+# Collection "acmeCo/test/test_enumemptystring_29144777": 8 Documents
+# ================================
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"EnumEmptyString_29144777","cursor":"backfill:0"}},"category":"A","id":1}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"EnumEmptyString_29144777","cursor":"backfill:1"}},"category":"B","id":2}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"EnumEmptyString_29144777","cursor":"backfill:2"}},"category":"C","id":3}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"EnumEmptyString_29144777","cursor":"backfill:3"}},"category":"","id":4}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"EnumEmptyString_29144777","cursor":"backfill:4"}},"category":"","id":100}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"EnumEmptyString_29144777","cursor":"backfill:5"}},"category":"","id":101}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"EnumEmptyString_29144777","cursor":"backfill:6"}},"category":"","id":102}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"EnumEmptyString_29144777","cursor":"backfill:7"}},"category":"","id":105}
+# ================================
+# Final State Checkpoint
+# ================================
+{"bindingStateV1":{"test%2FEnumEmptyString_29144777":{"backfilled":8,"key_columns":["id"],"metadata":{"schema":{"columns":["id","category"],"types":{"category":{"enum":["","","A","B","C"],"type":"enum"},"id":"int"}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
+

--- a/source-mysql/.snapshots/TestEnumEmptyString-replication
+++ b/source-mysql/.snapshots/TestEnumEmptyString-replication
@@ -1,0 +1,16 @@
+# ================================
+# Collection "acmeCo/test/test_enumemptystring_29144777": 8 Documents
+# ================================
+{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"EnumEmptyString_29144777","cursor":"binlog.000123:56789:123","txid":"11111111-1111-1111-1111-111111111111:111"}},"category":"A","id":5}
+{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"EnumEmptyString_29144777","cursor":"binlog.000123:56789:123","txid":"11111111-1111-1111-1111-111111111111:111"}},"category":"B","id":6}
+{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"EnumEmptyString_29144777","cursor":"binlog.000123:56789:123","txid":"11111111-1111-1111-1111-111111111111:111"}},"category":"C","id":7}
+{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"EnumEmptyString_29144777","cursor":"binlog.000123:56789:123","txid":"11111111-1111-1111-1111-111111111111:111"}},"category":"","id":8}
+{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"EnumEmptyString_29144777","cursor":"binlog.000123:56789:123","txid":"11111111-1111-1111-1111-111111111111:111"}},"category":"","id":200}
+{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"EnumEmptyString_29144777","cursor":"binlog.000123:56789:123","txid":"11111111-1111-1111-1111-111111111111:111"}},"category":"","id":201}
+{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"EnumEmptyString_29144777","cursor":"binlog.000123:56789:123","txid":"11111111-1111-1111-1111-111111111111:111"}},"category":"","id":202}
+{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"EnumEmptyString_29144777","cursor":"binlog.000123:56789:123","txid":"11111111-1111-1111-1111-111111111111:111"}},"category":"","id":205}
+# ================================
+# Final State Checkpoint
+# ================================
+{"bindingStateV1":{"test%2FEnumEmptyString_29144777":{"backfilled":8,"key_columns":["id"],"metadata":{"schema":{"columns":["id","category"],"types":{"category":{"enum":["","","A","B","C"],"type":"enum"},"id":"int"}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
+

--- a/source-mysql/discovery.go
+++ b/source-mysql/discovery.go
@@ -470,7 +470,7 @@ func (t *mysqlColumnType) encodeKeyFDB(val any) (tuple.TupleElement, error) {
 // body characters and terminator so that submatch #1 is the full string body.
 // The options for string body characters are, in order, two successive quotes,
 // anything backslash-escaped, and anything that isn't a single-quote.
-var enumValuesRegexp = regexp.MustCompile(`'((?:''|\\.|[^'])+)'(?:,|$)`)
+var enumValuesRegexp = regexp.MustCompile(`'((?:''|\\.|[^'])*)'(?:,|$)`)
 
 // enumValueReplacements contains the complete list of MySQL string escapes from
 // https://dev.mysql.com/doc/refman/8.0/en/string-literals.html#character-escape-sequences


### PR DESCRIPTION
**Description:**

It is possible to define an enum in MySQL with an explicit case for the empty string `''`, for instance `enum('', 'Y', 'N')` is a valid enum definition.

When this is done the empty string is both the text representation of the error value zero *and also* a valid enum option with some particular index (in the above option that index is 1 but it is possible to place that anywhere in the options list), but other than that everything continues to operate as normal.

So to fix that our enum parsing logic needs to accept the empty string, which turns out to only require a single-character fix to the parsing regex because apparently I did a dumb thing and wrote it in such a way that it excluded the empty string before.

This fixes https://github.com/estuary/connectors/issues/1495

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1500)
<!-- Reviewable:end -->
