### PR TITLE
materializations: automatically create schemas and handle pre-existing tables with no columns

### DIFF
--- a/materialize-bigquery/.snapshots/TestValidateAndApply
+++ b/materialize-bigquery/.snapshots/TestValidateAndApply
@@ -79,14 +79,14 @@ Big Schema Re-validated Constraints:
 Big Schema Changed Types Constraints:
 {"Field":"_meta/flow_truncated","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
 {"Field":"arrayField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"boolField","Type":6,"TypeString":"UNSATISFIABLE","Reason":"Field 'boolField' is already being materialized as endpoint type 'BOOL' but endpoint type 'INT64' is required by its schema '{ type: [integer] }'"}
+{"Field":"boolField","Type":6,"TypeString":"UNSATISFIABLE","Reason":"Field 'boolField' is already being materialized as endpoint type 'BOOLEAN' but endpoint type 'INT64' is required by its schema '{ type: [integer] }'"}
 {"Field":"flow_document","Type":1,"TypeString":"FIELD_REQUIRED","Reason":"This field is the document in the current materialization"}
 {"Field":"flow_published_at","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"intField","Type":6,"TypeString":"UNSATISFIABLE","Reason":"Field 'intField' is already being materialized as endpoint type 'INT64' but endpoint type 'STRING' is required by its schema '{ type: [string] }'"}
+{"Field":"intField","Type":6,"TypeString":"UNSATISFIABLE","Reason":"Field 'intField' is already being materialized as endpoint type 'INTEGER' but endpoint type 'STRING' is required by its schema '{ type: [string] }'"}
 {"Field":"key","Type":1,"TypeString":"FIELD_REQUIRED","Reason":"This field is a key in the current materialization"}
 {"Field":"multipleField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
 {"Field":"nullField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"Object fields may be materialized"}
-{"Field":"numField","Type":6,"TypeString":"UNSATISFIABLE","Reason":"Field 'numField' is already being materialized as endpoint type 'FLOAT64' but endpoint type 'BOOL' is required by its schema '{ type: [boolean] }'"}
+{"Field":"numField","Type":6,"TypeString":"UNSATISFIABLE","Reason":"Field 'numField' is already being materialized as endpoint type 'FLOAT' but endpoint type 'BOOL' is required by its schema '{ type: [boolean] }'"}
 {"Field":"objField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
 {"Field":"stringDateField","Type":6,"TypeString":"UNSATISFIABLE","Reason":"Field 'stringDateField' is already being materialized as endpoint type 'DATE' but endpoint type 'STRING' is required by its schema '{ type: [string] }'"}
 {"Field":"stringDateTimeField","Type":6,"TypeString":"UNSATISFIABLE","Reason":"Field 'stringDateTimeField' is already being materialized as endpoint type 'TIMESTAMP' but endpoint type 'STRING' is required by its schema '{ type: [string] }'"}
@@ -104,7 +104,7 @@ Big Schema Changed Types Constraints:
 {"Field":"stringJsonPointerField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
 {"Field":"stringMacAddr8Field","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
 {"Field":"stringMacAddrField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringNumberField","Type":6,"TypeString":"UNSATISFIABLE","Reason":"Field 'stringNumberField' is already being materialized as endpoint type 'FLOAT64' but endpoint type 'STRING' is required by its schema '{ type: [string] }'"}
+{"Field":"stringNumberField","Type":6,"TypeString":"UNSATISFIABLE","Reason":"Field 'stringNumberField' is already being materialized as endpoint type 'FLOAT' but endpoint type 'STRING' is required by its schema '{ type: [string] }'"}
 {"Field":"stringRegexField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
 {"Field":"stringRelativeJsonPointerField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
 {"Field":"stringTimeField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}

--- a/materialize-bigquery/client.go
+++ b/materialize-bigquery/client.go
@@ -132,6 +132,13 @@ func (c *client) DeleteTable(ctx context.Context, path []string) (string, boiler
 	}, nil
 }
 
+// TODO(whb): In display of needless cruelty, BigQuery will throw an error if you try to use an
+// ALTER TABLE sql statement to add columns to a table with no pre-existing columns, claiming that
+// it does not have a schema. I believe the client API would allow us to set the schema, but this
+// would have to be done in a totally different way than we are currently doing things and I'm not
+// up for tackling that right now. With recent changes to at least recognizing that tables with no
+// columns exist, we'll at least get a coherent error message when this happens and can know that
+// the workaround is to re-backfill the table so it gets created fresh with the needed columns.
 func (c *client) AlterTable(ctx context.Context, ta sql.TableAlter) (string, boilerplate.ActionApplyFn, error) {
 	var alterColumnStmtBuilder strings.Builder
 	if err := tplAlterTableColumns.Execute(&alterColumnStmtBuilder, ta); err != nil {

--- a/materialize-bigquery/client.go
+++ b/materialize-bigquery/client.go
@@ -10,6 +10,7 @@ import (
 	"path"
 	"slices"
 	"strings"
+	"sync"
 
 	"cloud.google.com/go/bigquery"
 	storage "cloud.google.com/go/storage"
@@ -18,6 +19,7 @@ import (
 	pf "github.com/estuary/flow/go/protocols/flow"
 	"github.com/google/uuid"
 	log "github.com/sirupsen/logrus"
+	"golang.org/x/sync/errgroup"
 	"google.golang.org/api/googleapi"
 	"google.golang.org/api/iterator"
 )
@@ -47,53 +49,54 @@ func (c *client) InfoSchema(ctx context.Context, resourcePaths [][]string) (*boi
 	slices.Sort(datasets)
 	datasets = slices.Compact(datasets)
 
+	// Fetch table and column metadata using the metadata API. This API is free to use, and has very
+	// high rate limits. Running a job to query the INFORMATION_SCHEMA view costs a minimum of 10MB
+	// per query, so this is a little more cost effective and efficient.
+	var mu sync.Mutex
+	group, groupCtx := errgroup.WithContext(ctx)
+
 	for _, ds := range datasets {
-		job, err := c.query(ctx, fmt.Sprintf(
-			"select table_schema, table_name, column_name, is_nullable, data_type, column_default from %s.%s.INFORMATION_SCHEMA.COLUMNS;",
-			bqDialect.Identifier(c.cfg.ProjectID), // Use the project containing the dataset rather than the billing project if a billing project is configured.
-			bqDialect.Identifier(ds),
-		))
-		if err != nil {
-			return nil, fmt.Errorf("querying INFORMATION_SCHEMA.COLUMNS for dataset %q: %w", ds, err)
-		}
-
-		it, err := job.Read(ctx)
-		if err != nil {
-			return nil, fmt.Errorf("reading job: %w", err)
-		}
-
-		type columnRow struct {
-			TableSchema   string `bigquery:"table_schema"`
-			TableName     string `bigquery:"table_name"`
-			ColumnName    string `bigquery:"column_name"`
-			IsNullable    string `bigquery:"is_nullable"` // string YES or NO
-			DataType      string `bigquery:"data_type"`
-			ColumnDefault string `bigquery:"column_default"` // "NULL" if no default
-		}
+		tableIter := c.bigqueryClient.DatasetInProject(c.cfg.ProjectID, ds).Tables(ctx)
 
 		for {
-			var c columnRow
-			if err = it.Next(&c); err == iterator.Done {
-				break
-			} else if err != nil {
-				return nil, fmt.Errorf("columnRow read: %w", err)
+			table, err := tableIter.Next()
+			if err != nil {
+				if err == iterator.Done {
+					break
+				}
+				return nil, fmt.Errorf("table iterator next: %w", err)
 			}
 
-			if strings.HasPrefix(c.DataType, "BIGNUMERIC") {
-				// BigQuery includes the precision of BIGNUMERIC columns in the DataType string. We
-				// want to treat all pre-existing BIGNUMERIC columns the same, so that is stripped
-				// out here.
-				c.DataType = "BIGNUMERIC"
-			}
+			mu.Lock()
+			is.PushResource(table.DatasetID, table.TableID)
+			mu.Unlock()
 
-			is.PushField(boilerplate.EndpointField{
-				Name:               c.ColumnName,
-				Nullable:           strings.EqualFold(c.IsNullable, "yes"),
-				Type:               c.DataType,
-				CharacterMaxLength: 0, // BigQuery does not have a character_maximum_length in its INFORMATION_SCHEMA.COLUMNS view.
-				HasDefault:         !strings.EqualFold(c.ColumnDefault, "null"),
-			}, c.TableSchema, c.TableName)
+			group.Go(func() error {
+				md, err := table.Metadata(groupCtx, bigquery.WithMetadataView(bigquery.BasicMetadataView))
+				if err != nil {
+					return fmt.Errorf("getting metadata for %s.%s: %w", table.DatasetID, table.TableID, err)
+				}
+
+				mu.Lock()
+				defer mu.Unlock()
+
+				for _, f := range md.Schema {
+					is.PushField(boilerplate.EndpointField{
+						Name:               f.Name,
+						Nullable:           !f.Required,
+						Type:               string(f.Type),
+						CharacterMaxLength: int(f.MaxLength),
+						HasDefault:         len(f.DefaultValueExpression) > 0,
+					}, table.DatasetID, table.TableID)
+				}
+
+				return nil
+			})
 		}
+	}
+
+	if err := group.Wait(); err != nil {
+		return nil, err
 	}
 
 	return is, nil

--- a/materialize-bigquery/client.go
+++ b/materialize-bigquery/client.go
@@ -48,9 +48,6 @@ func (c *client) InfoSchema(ctx context.Context, resourcePaths [][]string) (*boi
 		rpDatasets[bqDialect.TableLocator(p).TableSchema] = struct{}{}
 	}
 
-	slices.Sort(datasets)
-	datasets = slices.Compact(datasets)
-
 	// Fetch table and column metadata using the metadata API. This API is free to use, and has very
 	// high rate limits. Running a job to query the INFORMATION_SCHEMA view costs a minimum of 10MB
 	// per query, so this is a little more cost effective and efficient.

--- a/materialize-bigquery/sqlgen.go
+++ b/materialize-bigquery/sqlgen.go
@@ -89,9 +89,9 @@ var bqDialect = func() sql.Dialect {
 
 	columnValidator := sql.NewColumnValidator(
 		sql.ColValidation{Types: []string{"string"}, Validate: stringCompatible},
-		sql.ColValidation{Types: []string{"bool"}, Validate: sql.BooleanCompatible},
-		sql.ColValidation{Types: []string{"int64"}, Validate: sql.IntegerCompatible},
-		sql.ColValidation{Types: []string{"float64"}, Validate: sql.NumberCompatible},
+		sql.ColValidation{Types: []string{"boolean"}, Validate: sql.BooleanCompatible},
+		sql.ColValidation{Types: []string{"integer"}, Validate: sql.IntegerCompatible},
+		sql.ColValidation{Types: []string{"float"}, Validate: sql.NumberCompatible},
 		sql.ColValidation{Types: []string{"json"}, Validate: sql.MultipleCompatible},
 		sql.ColValidation{Types: []string{"bignumeric"}, Validate: bignumericCompatible},
 		sql.ColValidation{Types: []string{"date"}, Validate: sql.DateCompatible},

--- a/materialize-bigquery/staged_file.go
+++ b/materialize-bigquery/staged_file.go
@@ -106,7 +106,7 @@ func (f *stagedFile) fileKey(file string) string {
 	return path.Join(f.prefix, file)
 }
 
-func (f *stagedFile) flush(ctx context.Context) (func(context.Context), error) {
+func (f *stagedFile) flush() (func(context.Context), error) {
 	if err := f.flushFile(); err != nil {
 		return nil, err
 	}

--- a/materialize-bigquery/transactor.go
+++ b/materialize-bigquery/transactor.go
@@ -87,7 +87,7 @@ func newTransactor(
 			fieldSchemas[f.Name] = f
 		}
 
-		if err = t.addBinding(ctx, binding, fieldSchemas); err != nil {
+		if err = t.addBinding(binding, fieldSchemas); err != nil {
 			return nil, fmt.Errorf("addBinding of %s: %w", binding.Path, err)
 		}
 	}
@@ -95,7 +95,7 @@ func newTransactor(
 	return t, nil
 }
 
-func (t *transactor) addBinding(ctx context.Context, target sql.Table, fieldSchemas map[string]*bigquery.FieldSchema) error {
+func (t *transactor) addBinding(target sql.Table, fieldSchemas map[string]*bigquery.FieldSchema) error {
 	loadSchema, err := schemaForCols(target.KeyPtrs(), fieldSchemas)
 	if err != nil {
 		return err
@@ -193,7 +193,7 @@ func (t *transactor) Load(it *m.LoadIterator, loaded func(int, json.RawMessage) 
 
 		subqueries = append(subqueries, b.loadQuerySQL)
 
-		delete, err := b.loadFile.flush(ctx)
+		delete, err := b.loadFile.flush()
 		if err != nil {
 			return fmt.Errorf("flushing load file for binding[%d]: %w", idx, err)
 		}
@@ -293,7 +293,7 @@ func (t *transactor) commit(ctx context.Context) error {
 			continue
 		}
 
-		delete, err := b.storeFile.flush(ctx)
+		delete, err := b.storeFile.flush()
 		if err != nil {
 			return fmt.Errorf("flushing store file for binding[%d]: %w", idx, err)
 		}

--- a/materialize-boilerplate/info_schema.go
+++ b/materialize-boilerplate/info_schema.go
@@ -73,6 +73,19 @@ func (i *InfoSchema) PushField(field EndpointField, location ...string) {
 	i.resources[rk] = append(i.resources[rk], field)
 }
 
+// PushResource adds a resource with no fields to the InfoSchema. An example of using this is for a
+// database table which may be able to exist with no columns that would otherwise not be represented
+// by only registering all discovered columns.
+func (i *InfoSchema) PushResource(location ...string) {
+	rk := joinPath(location)
+
+	if _, ok := i.resources[rk]; ok {
+		panic(fmt.Sprintf("logic error: PushResource when resourceKey %q has already been set", rk))
+	}
+
+	i.resources[rk] = nil
+}
+
 // GetField returns the EndpointField for a Flow resource path and field name.
 func (i *InfoSchema) GetField(resourcePath []string, fieldName string) (EndpointField, error) {
 	rk := joinPath(i.locatePath(resourcePath))

--- a/materialize-boilerplate/info_schema_test.go
+++ b/materialize-boilerplate/info_schema_test.go
@@ -47,6 +47,10 @@ func TestInfoSchema(t *testing.T) {
 	is.PushField(nullableField, transformPath(loc1)...)
 	is.PushField(nonNullableField, transformPath(loc2)...)
 
+	loc3 := []string{"third", "location"}
+
+	is.PushResource(transformPath(loc3)...)
+
 	t.Run("can't push a duplicate", func(t *testing.T) {
 		require.Panics(t, func() { is.PushField(nullableField, transformPath(loc1)...) })
 	})
@@ -82,6 +86,12 @@ func TestInfoSchema(t *testing.T) {
 		require.True(t, is.HasField(loc1, untransform(nullableField.Name)))
 		require.False(t, is.HasField([]string{"d'", "oh"}, untransform(nullableField.Name)))
 		require.False(t, is.HasField(loc1, untransform(nullableField.Name)+"d'oh"))
+	})
+
+	t.Run("HasResource", func(t *testing.T) {
+		require.True(t, is.HasResource(loc1))
+		require.False(t, is.HasResource([]string{"d'", "oh"}))
+		require.True(t, is.HasResource(loc3))
 	})
 
 	t.Run("FieldsForResource", func(t *testing.T) {

--- a/materialize-elasticsearch/client.go
+++ b/materialize-elasticsearch/client.go
@@ -223,6 +223,8 @@ func (c *client) infoSchema(ctx context.Context) (*boilerplate.InfoSchema, error
 	}
 
 	for index, meta := range indexMeta {
+		is.PushResource(index)
+
 		for field, prop := range meta.Mappings.Properties {
 			is.PushField(boilerplate.EndpointField{
 				Name:               field,

--- a/materialize-motherduck/driver.go
+++ b/materialize-motherduck/driver.go
@@ -286,7 +286,7 @@ func (d *transactor) Store(it *m.StoreIterator) (m.StartCommitFunc, error) {
 					continue
 				}
 
-				delete, err := b.storeFile.flush(ctx)
+				delete, err := b.storeFile.flush()
 				if err != nil {
 					return fmt.Errorf("flushing store file for binding[%d]: %w", idx, err)
 				}

--- a/materialize-motherduck/staged_file.go
+++ b/materialize-motherduck/staged_file.go
@@ -155,7 +155,7 @@ func (f *stagedFile) allFiles() []string {
 	return out
 }
 
-func (f *stagedFile) flush(ctx context.Context) (func(context.Context), error) {
+func (f *stagedFile) flush() (func(context.Context), error) {
 	if err := f.flushFile(); err != nil {
 		return nil, err
 	}

--- a/materialize-mysql/client.go
+++ b/materialize-mysql/client.go
@@ -88,7 +88,7 @@ func (c *client) PreReqs(ctx context.Context) *sql.PrereqErr {
 }
 
 func (c *client) InfoSchema(ctx context.Context, resourcePaths [][]string) (is *boilerplate.InfoSchema, err error) {
-	return sql.StdFetchInfoSchema(ctx, c.db, c.ep.Dialect, "def", c.cfg.Database, resourcePaths)
+	return sql.StdFetchInfoSchema(ctx, c.db, c.ep.Dialect, "def", resourcePaths)
 }
 
 func (c *client) AlterTable(ctx context.Context, ta sql.TableAlter) (string, boilerplate.ActionApplyFn, error) {

--- a/materialize-mysql/driver.go
+++ b/materialize-mysql/driver.go
@@ -394,7 +394,7 @@ func prepareNewTransactor(
 		for _, b := range open.Materialization.Bindings {
 			resourcePaths = append(resourcePaths, b.ResourcePath)
 		}
-		is, err := sql.StdFetchInfoSchema(ctx, db, ep.Dialect, "def", cfg.Database, resourcePaths)
+		is, err := sql.StdFetchInfoSchema(ctx, db, ep.Dialect, "def", resourcePaths)
 		if err != nil {
 			return nil, err
 		}

--- a/materialize-postgres/client.go
+++ b/materialize-postgres/client.go
@@ -19,6 +19,8 @@ import (
 	_ "github.com/jackc/pgx/v4/stdlib"
 )
 
+var _ sql.SchemaManager = (*client)(nil)
+
 type client struct {
 	db  *stdsql.DB
 	cfg *config
@@ -86,7 +88,7 @@ func (c *client) InfoSchema(ctx context.Context, resourcePaths [][]string) (*boi
 		}
 	}
 
-	return sql.StdFetchInfoSchema(ctx, c.db, pgDialect, catalog, c.cfg.metaSchema(), resourcePaths)
+	return sql.StdFetchInfoSchema(ctx, c.db, pgDialect, catalog, resourcePaths)
 }
 
 func (c *client) PutSpec(ctx context.Context, updateSpec sql.MetaSpecsUpdate) error {
@@ -133,6 +135,14 @@ func (c *client) AlterTable(ctx context.Context, ta sql.TableAlter) (string, boi
 		_, err := c.db.ExecContext(ctx, alterColumnStmt)
 		return err
 	}, nil
+}
+
+func (c *client) ListSchemas(ctx context.Context) ([]string, error) {
+	return sql.StdListSchemas(ctx, c.db)
+}
+
+func (c *client) CreateSchema(ctx context.Context, schemaName string) error {
+	return sql.StdCreateSchema(ctx, c.db, pgDialect, schemaName)
 }
 
 func (c *client) FetchSpecAndVersion(ctx context.Context, specs sql.Table, materialization pf.Materialization) (string, string, error) {

--- a/materialize-postgres/docker-compose.yaml
+++ b/materialize-postgres/docker-compose.yaml
@@ -3,12 +3,19 @@ version: "3.7"
 services:
   postgres:
     image: 'postgres:latest'
-    command: ["postgres"]
-    environment: {"POSTGRES_DB": "flow", "POSTGRES_USER": "flow", "POSTGRES_PASSWORD": "flow"}
+    command: [ "postgres" ]
+    environment:
+      {
+        "POSTGRES_DB": "flow",
+        "POSTGRES_USER": "flow",
+        "POSTGRES_PASSWORD": "flow"
+      }
     networks:
       - flow-test
     volumes:
       - postgres_data:/var/lib/postgresql/data
+    ports:
+      - "5432:5432"
 
 networks:
   flow-test:

--- a/materialize-postgres/driver.go
+++ b/materialize-postgres/driver.go
@@ -113,13 +113,6 @@ func (c *config) ToURI() string {
 	return uri.String()
 }
 
-func (c *config) metaSchema() string {
-	if c.Schema == "" {
-		return "public"
-	}
-	return c.Schema
-}
-
 type tableConfig struct {
 	Table         string `json:"table" jsonschema:"title=Table,description=Name of the database table" jsonschema_extras:"x-collection-name=true"`
 	Schema        string `json:"schema,omitempty" jsonschema:"title=Alternative Schema,description=Alternative schema for this table (optional)"`

--- a/materialize-postgres/driver_test.go
+++ b/materialize-postgres/driver_test.go
@@ -20,8 +20,9 @@ import (
 func testConfig() *config {
 	return &config{
 		Address:  "localhost:5432",
-		User:     "postgres",
-		Password: "postgres",
+		User:     "flow",
+		Password: "flow",
+		Database: "flow",
 		Schema:   "public",
 	}
 }
@@ -48,7 +49,7 @@ func TestValidateAndApply(t *testing.T) {
 		func(t *testing.T) string {
 			t.Helper()
 
-			sch, err := sql.StdGetSchema(ctx, db, "postgres", resourceConfig.Schema, resourceConfig.Table)
+			sch, err := sql.StdGetSchema(ctx, db, cfg.Database, resourceConfig.Schema, resourceConfig.Table)
 			require.NoError(t, err)
 
 			return sch

--- a/materialize-redshift/.snapshots/TestValidateAndApply
+++ b/materialize-redshift/.snapshots/TestValidateAndApply
@@ -79,24 +79,24 @@ Big Schema Re-validated Constraints:
 Big Schema Changed Types Constraints:
 {"Field":"_meta/flow_truncated","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
 {"Field":"arrayField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"boolField","Type":6,"TypeString":"UNSATISFIABLE","Reason":"Field 'boolField' is already being materialized as endpoint type 'boolean' and cannot be changed to type '[integer]'"}
+{"Field":"boolField","Type":6,"TypeString":"UNSATISFIABLE","Reason":"Field 'boolField' is already being materialized as endpoint type 'BOOLEAN' but endpoint type 'BIGINT' is required by its schema '{ type: [integer] }'"}
 {"Field":"flow_document","Type":1,"TypeString":"FIELD_REQUIRED","Reason":"This field is the document in the current materialization"}
 {"Field":"flow_published_at","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"intField","Type":6,"TypeString":"UNSATISFIABLE","Reason":"Field 'intField' is already being materialized as endpoint type 'bigint' and cannot be changed to type '[string]'"}
+{"Field":"intField","Type":6,"TypeString":"UNSATISFIABLE","Reason":"Field 'intField' is already being materialized as endpoint type 'BIGINT' but endpoint type 'TEXT' is required by its schema '{ type: [string] }'"}
 {"Field":"key","Type":1,"TypeString":"FIELD_REQUIRED","Reason":"This field is a key in the current materialization"}
 {"Field":"multipleField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
 {"Field":"nullField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"Object fields may be materialized"}
-{"Field":"numField","Type":6,"TypeString":"UNSATISFIABLE","Reason":"Field 'numField' is already being materialized as endpoint type 'double precision' and cannot be changed to type '[boolean]'"}
-{"Field":"objField","Type":6,"TypeString":"UNSATISFIABLE","Reason":"Field 'objField' is already being materialized as endpoint type 'super' and cannot be changed to type '[string]'"}
-{"Field":"stringDateField","Type":6,"TypeString":"UNSATISFIABLE","Reason":"Field 'stringDateField' is already being materialized as endpoint type 'date' and cannot be changed to type '[string]'"}
-{"Field":"stringDateTimeField","Type":6,"TypeString":"UNSATISFIABLE","Reason":"Field 'stringDateTimeField' is already being materialized as endpoint type 'timestamp with time zone' and cannot be changed to type '[string]'"}
+{"Field":"numField","Type":6,"TypeString":"UNSATISFIABLE","Reason":"Field 'numField' is already being materialized as endpoint type 'DOUBLE PRECISION' but endpoint type 'BOOLEAN' is required by its schema '{ type: [boolean] }'"}
+{"Field":"objField","Type":6,"TypeString":"UNSATISFIABLE","Reason":"Field 'objField' is already being materialized as endpoint type 'SUPER' but endpoint type 'TEXT' is required by its schema '{ type: [string] }'"}
+{"Field":"stringDateField","Type":6,"TypeString":"UNSATISFIABLE","Reason":"Field 'stringDateField' is already being materialized as endpoint type 'DATE' but endpoint type 'TEXT' is required by its schema '{ type: [string] }'"}
+{"Field":"stringDateTimeField","Type":6,"TypeString":"UNSATISFIABLE","Reason":"Field 'stringDateTimeField' is already being materialized as endpoint type 'TIMESTAMP WITH TIME ZONE' but endpoint type 'TEXT' is required by its schema '{ type: [string] }'"}
 {"Field":"stringDurationField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
 {"Field":"stringEmailField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringField","Type":6,"TypeString":"UNSATISFIABLE","Reason":"Field 'stringField' is already being materialized as endpoint type 'character varying' and cannot be changed to type '[integer]'"}
+{"Field":"stringField","Type":6,"TypeString":"UNSATISFIABLE","Reason":"Field 'stringField' is already being materialized as endpoint type 'CHARACTER VARYING' but endpoint type 'BIGINT' is required by its schema '{ type: [integer] }'"}
 {"Field":"stringHostnameField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
 {"Field":"stringIdnEmailField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
 {"Field":"stringIdnHostnameField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringIntegerField","Type":6,"TypeString":"UNSATISFIABLE","Reason":"Field 'stringIntegerField' is already being materialized as endpoint type 'numeric' and cannot be changed to type '[string]'"}
+{"Field":"stringIntegerField","Type":6,"TypeString":"UNSATISFIABLE","Reason":"Field 'stringIntegerField' is already being materialized as endpoint type 'NUMERIC' but endpoint type 'TEXT' is required by its schema '{ type: [string] }'"}
 {"Field":"stringIpv4Field","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
 {"Field":"stringIpv6Field","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
 {"Field":"stringIriField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
@@ -104,12 +104,12 @@ Big Schema Changed Types Constraints:
 {"Field":"stringJsonPointerField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
 {"Field":"stringMacAddr8Field","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
 {"Field":"stringMacAddrField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringNumberField","Type":6,"TypeString":"UNSATISFIABLE","Reason":"Field 'stringNumberField' is already being materialized as endpoint type 'double precision' and cannot be changed to type '[string]'"}
+{"Field":"stringNumberField","Type":6,"TypeString":"UNSATISFIABLE","Reason":"Field 'stringNumberField' is already being materialized as endpoint type 'DOUBLE PRECISION' but endpoint type 'TEXT' is required by its schema '{ type: [string] }'"}
 {"Field":"stringRegexField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
 {"Field":"stringRelativeJsonPointerField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
 {"Field":"stringTimeField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringUint32Field","Type":6,"TypeString":"UNSATISFIABLE","Reason":"Field 'stringUint32Field' is already being materialized as endpoint type 'numeric' and cannot be changed to type '[string]'"}
-{"Field":"stringUint64Field","Type":6,"TypeString":"UNSATISFIABLE","Reason":"Field 'stringUint64Field' is already being materialized as endpoint type 'numeric' and cannot be changed to type '[string]'"}
+{"Field":"stringUint32Field","Type":6,"TypeString":"UNSATISFIABLE","Reason":"Field 'stringUint32Field' is already being materialized as endpoint type 'NUMERIC' but endpoint type 'TEXT' is required by its schema '{ type: [string] }'"}
+{"Field":"stringUint64Field","Type":6,"TypeString":"UNSATISFIABLE","Reason":"Field 'stringUint64Field' is already being materialized as endpoint type 'NUMERIC' but endpoint type 'TEXT' is required by its schema '{ type: [string] }'"}
 {"Field":"stringUriField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
 {"Field":"stringUriReferenceField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
 {"Field":"stringUriTemplateField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}

--- a/materialize-snowflake/config.go
+++ b/materialize-snowflake/config.go
@@ -5,10 +5,11 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
-	"github.com/iancoleman/orderedmap"
-	"github.com/invopop/jsonschema"
 	"regexp"
 	"strings"
+
+	"github.com/iancoleman/orderedmap"
+	"github.com/invopop/jsonschema"
 
 	m "github.com/estuary/connectors/go/protocols/materialize"
 	sf "github.com/snowflakedb/gosnowflake"
@@ -40,9 +41,9 @@ type advancedConfig struct {
 }
 
 // ToURI converts the Config to a DSN string.
-func (c *config) ToURI(tenant string, withSchema bool) string {
+func (c *config) ToURI(tenant string) string {
 	// Build a DSN connection string.
-	var configCopy = c.asSnowflakeConfig(tenant, withSchema)
+	var configCopy = c.asSnowflakeConfig(tenant)
 	// client_session_keep_alive causes the driver to issue a periodic keepalive request.
 	// Without this, the authentication token will expire after 4 hours of inactivity.
 	// The Params map will not have been initialized if the endpoint config didn't specify
@@ -75,20 +76,15 @@ func (c *credentialConfig) privateKey() (*rsa.PrivateKey, error) {
 	return nil, fmt.Errorf("only supported with JWT authentication")
 }
 
-func (c *config) asSnowflakeConfig(tenant string, withSchema bool) sf.Config {
+func (c *config) asSnowflakeConfig(tenant string) sf.Config {
 	var maxStatementCount string = "0"
 	var json string = "json"
-
-	var schema = ""
-	if withSchema {
-		schema = c.Schema
-	}
 
 	var conf = sf.Config{
 		Account:     c.Account,
 		Host:        c.Host,
 		Database:    c.Database,
-		Schema:      schema,
+		Schema:      c.Schema,
 		Warehouse:   c.Warehouse,
 		Role:        c.Role,
 		Application: fmt.Sprintf("%s_EstuaryFlow", tenant),
@@ -182,12 +178,9 @@ const (
 )
 
 type credentialConfig struct {
-	AuthType string `json:"auth_type"`
-
-	User string `json:"user"`
-
-	Password string `json:"password"`
-
+	AuthType   string `json:"auth_type"`
+	User       string `json:"user"`
+	Password   string `json:"password"`
 	PrivateKey string `json:"private_key"`
 }
 

--- a/materialize-snowflake/pipe.go
+++ b/materialize-snowflake/pipe.go
@@ -72,7 +72,7 @@ func generateJWTToken(key *rsa.PrivateKey, user string, accountName string) (str
 func NewPipeClient(cfg *config, accountName string, tenant string) (*PipeClient, error) {
 	httpClient := http.Client{}
 
-	var dsn = cfg.ToURI(tenant, true)
+	var dsn = cfg.ToURI(tenant)
 	dsnURL, err := url.Parse(fmt.Sprintf("https://%s", dsn))
 	if err != nil {
 		return nil, fmt.Errorf("parsing snowflake dsn: %w", err)

--- a/materialize-snowflake/snowflake_test.go
+++ b/materialize-snowflake/snowflake_test.go
@@ -24,7 +24,11 @@ func mustGetCfg(t *testing.T) config {
 		return config{}
 	}
 
-	out := config{}
+	out := config{
+		Credentials: credentialConfig{
+			AuthType: UserPass,
+		},
+	}
 
 	for _, prop := range []struct {
 		key  string
@@ -32,8 +36,8 @@ func mustGetCfg(t *testing.T) config {
 	}{
 		{"SNOWFLAKE_HOST", &out.Host},
 		{"SNOWFLAKE_ACCOUNT", &out.Account},
-		{"SNOWFLAKE_USER", &out.User},
-		{"SNOWFLAKE_PASSWORD", &out.Password},
+		{"SNOWFLAKE_USER", &out.Credentials.User},
+		{"SNOWFLAKE_PASSWORD", &out.Credentials.Password},
 		{"SNOWFLAKE_DATABASE", &out.Database},
 		{"SNOWFLAKE_SCHEMA", &out.Schema},
 	} {
@@ -57,7 +61,7 @@ func TestValidateAndApply(t *testing.T) {
 		Schema: "PUBLIC",
 	}
 
-	db, err := stdsql.Open("snowflake", cfg.ToURI("testing", true))
+	db, err := stdsql.Open("snowflake", cfg.ToURI("testing"))
 	require.NoError(t, err)
 	defer db.Close()
 
@@ -127,7 +131,7 @@ func TestPrereqs(t *testing.T) {
 		{
 			name: "wrong username",
 			cfg: func(cfg config) *config {
-				cfg.User = "wrong" + cfg.User
+				cfg.Credentials.User = "wrong" + cfg.User
 				return &cfg
 			},
 			want: []error{fmt.Errorf("incorrect username or password")},
@@ -135,7 +139,7 @@ func TestPrereqs(t *testing.T) {
 		{
 			name: "wrong password",
 			cfg: func(cfg config) *config {
-				cfg.Password = "wrong" + cfg.Password
+				cfg.Credentials.Password = "wrong" + cfg.Password
 				return &cfg
 			},
 			want: []error{fmt.Errorf("incorrect username or password")},

--- a/materialize-sql/apply.go
+++ b/materialize-sql/apply.go
@@ -96,7 +96,7 @@ func (a *sqlApplier) CreateMetaTables(ctx context.Context, spec *pf.Materializat
 	return strings.Join(actionDesc, "\n"), func(ctx context.Context) error {
 		for _, c := range creates {
 			if err := a.client.CreateTable(ctx, c); err != nil {
-				return err
+				return fmt.Errorf("creating meta table %s: %w", c.Identifier, err)
 			}
 		}
 		return nil

--- a/materialize-sql/endpoint.go
+++ b/materialize-sql/endpoint.go
@@ -50,6 +50,20 @@ type Client interface {
 	Close()
 }
 
+// SchemaManager is an optional interface that destinations can implement if they support schemas
+// and their automatic creation.
+type SchemaManager interface {
+	// ListSchemas returns a list of all existing schemas, with their names as-reported by the
+	// destination.
+	ListSchemas(ctx context.Context) ([]string, error)
+
+	// Create schema creates a schema. The schemaName will have already had any dialect-specific
+	// transformations applied to it (ex: replacing special characters with underscores) via
+	// TableLocator, but it will not have identifier quoting applied, and identifier quoting must be
+	// handled by the caller if needed.
+	CreateSchema(ctx context.Context, schemaName string) error
+}
+
 // Resource is a driver-provided type which represents the SQL resource
 // (for example, a table) bound to by a binding.
 type Resource interface {

--- a/materialize-sql/std_sql.go
+++ b/materialize-sql/std_sql.go
@@ -340,7 +340,6 @@ func StdFetchInfoSchema(
 	db *sql.DB,
 	dialect Dialect,
 	catalog string, // typically the "database"
-	metaSchema string, // usually from the endpoint configuration; this is the schema where the metadata tables are
 	resourcePaths [][]string,
 ) (*boilerplate.InfoSchema, error) {
 	is := boilerplate.NewInfoSchema(
@@ -348,8 +347,15 @@ func StdFetchInfoSchema(
 		dialect.ColumnLocator,
 	)
 
+	if len(resourcePaths) == 0 {
+		// Trivial case: No resources, so there are no applicable tables or columns. This is only
+		// possible if the materialization has no bindings and the endpoint doesn't have any
+		// metadata tables or their table paths are not included in the list of resource paths.
+		return is, nil
+	}
+
 	// Map the resource paths to an appropriate identifier for inclusion in the coming query.
-	schemas := []string{dialect.Literal(metaSchema)}
+	schemas := make([]string, 0, len(resourcePaths))
 	for _, p := range resourcePaths {
 		loc := dialect.TableLocator(p)
 		schemas = append(schemas, dialect.Literal(loc.TableSchema))
@@ -431,6 +437,35 @@ func StdFetchInfoSchema(
 	}
 
 	return is, nil
+}
+
+type ListSchemasFn func(context.Context) ([]string, error)
+
+type CreateSchemaFn func(context.Context, string) error
+
+func StdListSchemas(ctx context.Context, db *sql.DB) ([]string, error) {
+	rows, err := db.QueryContext(ctx, "select schema_name from information_schema.schemata")
+	if err != nil {
+		return nil, fmt.Errorf("querying information_schema.schemata: %w", err)
+	}
+	defer rows.Close()
+
+	out := []string{}
+
+	for rows.Next() {
+		var schema string
+		if err := rows.Scan(&schema); err != nil {
+			return nil, fmt.Errorf("scanning row: %w", err)
+		}
+		out = append(out, schema)
+	}
+
+	return out, nil
+}
+
+func StdCreateSchema(ctx context.Context, db *sql.DB, dialect Dialect, schemaName string) error {
+	_, err := db.ExecContext(ctx, fmt.Sprintf("create schema %s", dialect.Identifier(schemaName)))
+	return err
 }
 
 func ToLocatePathFn(fn TableLocatorFn) boilerplate.LocatePathFn {

--- a/materialize-sqlserver/client.go
+++ b/materialize-sqlserver/client.go
@@ -75,14 +75,7 @@ func (c *client) PreReqs(ctx context.Context) *sql.PrereqErr {
 }
 
 func (c *client) InfoSchema(ctx context.Context, resourcePaths [][]string) (is *boilerplate.InfoSchema, err error) {
-	// We don't (yet) allow setting a schema for the endpoint or resources, so we need to get the
-	// default schema for the configured user.
-	var schema string
-	if err := c.db.QueryRowContext(ctx, "select schema_name()").Scan(&schema); err != nil {
-		return nil, fmt.Errorf("querying schema for current user: %w", err)
-	}
-
-	return sql.StdFetchInfoSchema(ctx, c.db, c.ep.Dialect, c.cfg.Database, schema, resourcePaths)
+	return sql.StdFetchInfoSchema(ctx, c.db, c.ep.Dialect, c.cfg.Database, resourcePaths)
 }
 
 func (c *client) AlterTable(ctx context.Context, ta sql.TableAlter) (string, boilerplate.ActionApplyFn, error) {

--- a/materialize-starburst/client.go
+++ b/materialize-starburst/client.go
@@ -12,6 +12,8 @@ import (
 	pf "github.com/estuary/flow/go/protocols/flow"
 )
 
+var _ sql.SchemaManager = (*client)(nil)
+
 type client struct {
 	db        *stdsql.DB
 	cfg       *config
@@ -161,6 +163,14 @@ func (c *client) AlterTable(_ context.Context, ta sql.TableAlter) (string, boile
 		}
 		return nil
 	}, nil
+}
+
+func (c *client) ListSchemas(ctx context.Context) ([]string, error) {
+	return sql.StdListSchemas(ctx, c.db)
+}
+
+func (c *client) CreateSchema(ctx context.Context, schemaName string) error {
+	return sql.StdCreateSchema(ctx, c.db, c.ep.Dialect, schemaName)
 }
 
 func (c *client) PreReqs(ctx context.Context) *sql.PrereqErr {


### PR DESCRIPTION
**Description:**

Two main changes in this pull request:
1. Make `InfoSchema` aware of pre-existing resources that have no columns, via a new `PushResource` method. Materialization connectors are responsible for populating resources (tables, in the common case) even if they don't have any columns. This closes https://github.com/estuary/connectors/issues/1451
2. Implement automatic schema creation as a general feature for SQL materializations. They can all do this now, except for `materialize-sqlserver` and `materialize-mysql` which do not support setting schemas. The driver for this was to eliminate runtime errors when a user sets an alternate schema that doesn't exist and we don't check for that in validation, which closes https://github.com/estuary/connectors/issues/1256

There are some other small fixes and adjustments that were made along the way; see individual commit messages.

I tested these changes by doing the following for all the updated materializations:
 - Ran all the unit tests, even the ones that you have to run manually
 - Manually set up a materialization with a pre-existing table that has no columns. It still breaks for BigQuery, see commit/comment for that, but at least we'll have a better error message. Other than that we'll be able to add columns to the existing tables successfully on systems that actually support creating a table with no columns.
 - Manually set up a materialization where both the endpoint config schema and a resource config schema don't exist. Admittedly most cases won't work if the endpoint config schema doesn't already exist, and I stopped short of re-working things enough to make that work in general. But resource config alternate schema creation does work for everything.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1503)
<!-- Reviewable:end -->
