### PR TITLE
source-firestore: Sanitize float infinities into strings

### DIFF
--- a/source-firestore/pull.go
+++ b/source-firestore/pull.go
@@ -952,6 +952,10 @@ func translateValue(val *firestore_pb.Value) (interface{}, error) {
 	case *firestore_pb.Value_DoubleValue:
 		if math.IsNaN(val.DoubleValue) {
 			return "NaN", nil
+		} else if math.IsInf(val.DoubleValue, +1) {
+			return "Infinity", nil
+		} else if math.IsInf(val.DoubleValue, -1) {
+			return "-Infinity", nil
 		}
 		return val.DoubleValue, nil
 	case *firestore_pb.Value_TimestampValue:
@@ -997,6 +1001,10 @@ func sanitizeValue(x interface{}) interface{} {
 	case float64:
 		if math.IsNaN(x) {
 			return "NaN"
+		} else if math.IsInf(x, +1) {
+			return "Infinity"
+		} else if math.IsInf(x, -1) {
+			return "-Infinity"
 		}
 	case []interface{}:
 		for idx, value := range x {


### PR DESCRIPTION
**Description:**

We already sanitize `NaN` in this way, I'm just copy-pasting the same logic we apply in other connectors for positive and negative infinity as well.

Since previously this would fail JSON serialization we know that the connector has never successfully processed float infinities before.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1525)
<!-- Reviewable:end -->
