### PR TITLE
materialize-snowflake: error if private key is not valid PEM format

### DIFF
--- a/materialize-snowflake/config.go
+++ b/materialize-snowflake/config.go
@@ -66,7 +66,9 @@ func (c *credentialConfig) privateKey() (*rsa.PrivateKey, error) {
 		// escaped, so here we allow an escape hatch to parse these PEM files
 		var pkString = strings.ReplaceAll(c.PrivateKey, "\\n", "\n")
 		var block, _ = pem.Decode([]byte(pkString))
-		if key, err := x509.ParsePKCS8PrivateKey(block.Bytes); err != nil {
+		if block == nil {
+			return nil, fmt.Errorf("invalid private key: must be PEM format")
+		} else if key, err := x509.ParsePKCS8PrivateKey(block.Bytes); err != nil {
 			return nil, fmt.Errorf("parsing private key: %w", err)
 		} else {
 			return key.(*rsa.PrivateKey), nil


### PR DESCRIPTION
**Description:**

If the provided private key is not in PEM format, `block` will be `nil` and currently we'll panic. Instead, provide an error message that might help the user understand what they can do instead.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1531)
<!-- Reviewable:end -->
