### PR TITLE
source-hubspot: Fixing tests

### DIFF
--- a/source-hubspot/source_hubspot/streams.py
+++ b/source-hubspot/source_hubspot/streams.py
@@ -447,8 +447,9 @@ class Stream(HttpStream, ABC):
         # Here we define both the new expiry date and its copy
         # This will be used to compare wether the token expiry date has rotated
         # if the token has a new expiry date, it means we have a new token
-        self.authenticator._token_expiry_date = self.authenticator._token_expiry_date.subtract(minutes=2)
-        old_expiry_date = deepcopy(self.authenticator._token_expiry_date)
+        if type(self.authenticator) is Oauth2Authenticator: 
+            self.authenticator._token_expiry_date = self.authenticator._token_expiry_date.subtract(minutes=2)
+            old_expiry_date = deepcopy(self.authenticator._token_expiry_date)
         try:
             while not pagination_complete:
                 properties = self._property_wrapper
@@ -472,7 +473,7 @@ class Stream(HttpStream, ABC):
                 # our token has expired and calculate the new _token_expiry_date
                 # then, we compare with the deep copy of the last token expiry date
                 # if its different, that means we have a new token. 
-                if old_expiry_date != self.authenticator._token_expiry_date:
+                if type(self.authenticator) is Oauth2Authenticator and old_expiry_date != self.authenticator._token_expiry_date:
                     # this means that we got a new token
                     self.logger.info(" GOT NEW TOKEN ")
                     self.authenticator._token_expiry_date = self.authenticator._token_expiry_date.subtract(minutes=2)

--- a/source-hubspot/tests/snapshots/snapshots__discover__capture.stdout.json
+++ b/source-hubspot/tests/snapshots/snapshots__discover__capture.stdout.json
@@ -640,6 +640,12 @@
                 "string"
               ]
             },
+            "hs_country_code": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
             "hs_created_by_user_id": {
               "type": [
                 "null",
@@ -15021,6 +15027,12 @@
             },
             "hs_sales_email_last_replied": {
               "format": "date-time",
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "hs_seen_by_agent_ids": {
               "type": [
                 "null",
                 "string"


### PR DESCRIPTION
# Why this fix was created?
Errors in [source-hubspot](https://github.com/estuary/connectors/actions/runs/8883481172/job/24390442518) build
# Fixes
Updated discovery snapshots, as a new field was added in companies Just a note on this: 
i **think** its not a new field added by hubspot, but a property field that came in a different order when calling the properties API. The code will limit the amount of properties, and given that then can come in different orders, may cause this issue. I saw this behaviour when working with source-hubspot-native , but i still neeed some time to evaluate.

Also added a check on the authenticator type in streams.py. Tests were using TokenAuthenticator and calling the read_records method, causing the code to fail.


**Notes for reviewers:**

All changes were tested with end-to-end tests on a hosted supabase

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1538)
<!-- Reviewable:end -->
