### PR TITLE
source-sqlserver: Improved replication diagnostics

### DIFF
--- a/source-mysql/replication.go
+++ b/source-mysql/replication.go
@@ -905,7 +905,7 @@ func (db *mysqlDatabase) ReplicationDiagnostics(ctx context.Context) error {
 				}
 				logFields[key] = val
 			}
-			logrus.WithFields(logFields).Info("got row")
+			logrus.WithFields(logFields).Info("got diagnostic row")
 		}
 	}
 

--- a/source-postgres/replication.go
+++ b/source-postgres/replication.go
@@ -700,7 +700,7 @@ func (db *postgresDatabase) ReplicationDiagnostics(ctx context.Context) error {
 			for idx, val := range row {
 				logFields[string(keys[idx].Name)] = val
 			}
-			logrus.WithFields(logFields).Info("got row")
+			logrus.WithFields(logFields).Info("got diagnostic row")
 		}
 		if numResults == 0 {
 			logrus.WithField("query", q).Info("no results")

--- a/source-sqlserver/replication.go
+++ b/source-sqlserver/replication.go
@@ -455,7 +455,7 @@ func (db *sqlserverDatabase) ReplicationDiagnostics(ctx context.Context) error {
 			for idx, name := range cnames {
 				logFields[name] = vals[idx]
 			}
-			log.WithFields(logFields).Info("got row")
+			log.WithFields(logFields).Info("got diagnostic row")
 		}
 		if numResults == 0 {
 			logEntry.Info("no results")

--- a/source-sqlserver/replication.go
+++ b/source-sqlserver/replication.go
@@ -463,5 +463,7 @@ func (db *sqlserverDatabase) ReplicationDiagnostics(ctx context.Context) error {
 	}
 
 	query("EXEC msdb.dbo.sp_help_job;")
+	query("EXEC sys.sp_cdc_help_jobs;")
+	query("EXEC sys.sp_cdc_help_change_data_capture;")
 	return nil
 }


### PR DESCRIPTION
**Description:**

This PR adds a couple more queries to the automated replication diagnostics for SQL Server.

It also rewords the `"got row"` log message for all three of Postgres/MySQL/MSSQL -- it was usually clear from context that these were diagnostic query results, but when there are lots of complex result rows that's less obvious so hopefully `"got diagnostic row"` will be clearer in such cases.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1542)
<!-- Reviewable:end -->
