### PR TITLE
source-sqlserver: Another replication diagnostic query

### DIFF
--- a/source-sqlserver/replication.go
+++ b/source-sqlserver/replication.go
@@ -464,6 +464,7 @@ func (db *sqlserverDatabase) ReplicationDiagnostics(ctx context.Context) error {
 
 	query("EXEC msdb.dbo.sp_help_job;")
 	query("EXEC sys.sp_cdc_help_jobs;")
+	query("SELECT * FROM msdb.dbo.cdc_jobs;")
 	query("EXEC sys.sp_cdc_help_change_data_capture;")
 	return nil
 }


### PR DESCRIPTION
**Description:**

Adds another query (`SELECT * FROM msdb.dbo.cdc_jobs;`) to SQL Server replication diagnostics.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1543)
<!-- Reviewable:end -->
