### PR TITLE
source-hubspot-native: add email events and custom objects

### DIFF
--- a/estuary-cdk/estuary_cdk/capture/common.py
+++ b/estuary-cdk/estuary_cdk/capture/common.py
@@ -14,6 +14,7 @@ from typing import (
     Literal,
     TypeVar,
 )
+
 from pydantic import AwareDatetime, BaseModel, Field, NonNegativeInt
 
 from ..flow import (
@@ -25,7 +26,6 @@ from ..flow import (
 )
 from ..pydantic_polyfill import GenericModel
 from . import Task, request, response
-
 
 LogCursor = AwareDatetime | NonNegativeInt
 """LogCursor is a cursor into a logical log of changes.
@@ -49,7 +49,8 @@ class BaseDocument(BaseModel):
 
     class Meta(BaseModel):
         op: Literal["c", "u", "d"] = Field(
-            description="Operation type (c: Create, u: Update, d: Delete)"
+            default="u",
+            description="Operation type (c: Create, u: Update, d: Delete)",
         )
         row_id: int = Field(
             default=-1,

--- a/source-gladly/tests/snapshots/snapshots__discover__stdout.json
+++ b/source-gladly/tests/snapshots/snapshots__discover__stdout.json
@@ -35,6 +35,7 @@
         "Meta": {
           "properties": {
             "op": {
+              "default": "u",
               "description": "Operation type (c: Create, u: Update, d: Delete)",
               "enum": [
                 "c",
@@ -51,9 +52,6 @@
               "type": "integer"
             }
           },
-          "required": [
-            "op"
-          ],
           "title": "Meta",
           "type": "object"
         }
@@ -143,6 +141,7 @@
         "Meta": {
           "properties": {
             "op": {
+              "default": "u",
               "description": "Operation type (c: Create, u: Update, d: Delete)",
               "enum": [
                 "c",
@@ -159,9 +158,6 @@
               "type": "integer"
             }
           },
-          "required": [
-            "op"
-          ],
           "title": "Meta",
           "type": "object"
         }
@@ -251,6 +247,7 @@
         "Meta": {
           "properties": {
             "op": {
+              "default": "u",
               "description": "Operation type (c: Create, u: Update, d: Delete)",
               "enum": [
                 "c",
@@ -267,9 +264,6 @@
               "type": "integer"
             }
           },
-          "required": [
-            "op"
-          ],
           "title": "Meta",
           "type": "object"
         }
@@ -359,6 +353,7 @@
         "Meta": {
           "properties": {
             "op": {
+              "default": "u",
               "description": "Operation type (c: Create, u: Update, d: Delete)",
               "enum": [
                 "c",
@@ -375,9 +370,6 @@
               "type": "integer"
             }
           },
-          "required": [
-            "op"
-          ],
           "title": "Meta",
           "type": "object"
         }
@@ -467,6 +459,7 @@
         "Meta": {
           "properties": {
             "op": {
+              "default": "u",
               "description": "Operation type (c: Create, u: Update, d: Delete)",
               "enum": [
                 "c",
@@ -483,9 +476,6 @@
               "type": "integer"
             }
           },
-          "required": [
-            "op"
-          ],
           "title": "Meta",
           "type": "object"
         }
@@ -575,6 +565,7 @@
         "Meta": {
           "properties": {
             "op": {
+              "default": "u",
               "description": "Operation type (c: Create, u: Update, d: Delete)",
               "enum": [
                 "c",
@@ -591,9 +582,6 @@
               "type": "integer"
             }
           },
-          "required": [
-            "op"
-          ],
           "title": "Meta",
           "type": "object"
         }
@@ -683,6 +671,7 @@
         "Meta": {
           "properties": {
             "op": {
+              "default": "u",
               "description": "Operation type (c: Create, u: Update, d: Delete)",
               "enum": [
                 "c",
@@ -699,9 +688,6 @@
               "type": "integer"
             }
           },
-          "required": [
-            "op"
-          ],
           "title": "Meta",
           "type": "object"
         }

--- a/source-google-sheets-native/tests/snapshots/source_google_sheets_native_tests_test_snapshots__discover__stdout.json
+++ b/source-google-sheets-native/tests/snapshots/source_google_sheets_native_tests_test_snapshots__discover__stdout.json
@@ -10,6 +10,7 @@
         "Meta": {
           "properties": {
             "op": {
+              "default": "u",
               "description": "Operation type (c: Create, u: Update, d: Delete)",
               "enum": [
                 "c",
@@ -26,9 +27,6 @@
               "type": "integer"
             }
           },
-          "required": [
-            "op"
-          ],
           "title": "Meta",
           "type": "object"
         }
@@ -67,6 +65,7 @@
         "Meta": {
           "properties": {
             "op": {
+              "default": "u",
               "description": "Operation type (c: Create, u: Update, d: Delete)",
               "enum": [
                 "c",
@@ -83,9 +82,6 @@
               "type": "integer"
             }
           },
-          "required": [
-            "op"
-          ],
           "title": "Meta",
           "type": "object"
         }

--- a/source-hubspot-native/source_hubspot_native/__init__.py
+++ b/source-hubspot-native/source_hubspot_native/__init__.py
@@ -30,7 +30,7 @@ class Connector(
 
     async def spec(self, log: Logger, _: request.Spec) -> ConnectorSpec:
         return ConnectorSpec(
-            documentationUrl="https://docs.estuary.dev",
+            documentationUrl="https://go.estuary.dev/hubspot-real-time",
             configSchema=EndpointConfig.model_json_schema(),
             oauth2=OAUTH2_SPEC,
             resourceConfigSchema=ResourceConfig.model_json_schema(),

--- a/source-hubspot-native/source_hubspot_native/api.py
+++ b/source-hubspot-native/source_hubspot_native/api.py
@@ -1,15 +1,15 @@
-from datetime import datetime, UTC
-from estuary_cdk.http import HTTPSession
-from logging import Logger
-from pydantic import TypeAdapter
-from typing import Iterable, Any, Callable, Awaitable, AsyncGenerator
 import asyncio
 import itertools
+from datetime import UTC, datetime
+from logging import Logger
+from typing import Any, AsyncGenerator, Awaitable, Callable, Iterable
 
 from estuary_cdk.capture.common import (
-    PageCursor,
     LogCursor,
+    PageCursor,
 )
+from estuary_cdk.http import HTTPSession
+from pydantic import TypeAdapter
 
 from .models import (
     Association,
@@ -57,7 +57,7 @@ async def fetch_page(
 
     input = {
         "associations": ",".join(cls.ASSOCIATED_ENTITIES),
-        "limit": 2,  # 50, # Maximum when requesting history. TODO(johnny).
+        "limit": 50, # Maximum when requesting history.
         "properties": property_names,
         "propertiesWithHistory": property_names,
     }

--- a/source-hubspot-native/source_hubspot_native/api.py
+++ b/source-hubspot-native/source_hubspot_native/api.py
@@ -219,7 +219,7 @@ async def fetch_changes(
 
     recent.sort()  # Oldest updates first.
 
-    for batch_it in itertools.batched(recent, 100):
+    for batch_it in itertools.batched(recent, 50):
         batch = list(batch_it)
 
         documents: BatchResult[CRMObject] = await fetch_batch_with_associations(

--- a/source-hubspot-native/source_hubspot_native/api.py
+++ b/source-hubspot-native/source_hubspot_native/api.py
@@ -77,24 +77,65 @@ async def fetch_page(
     assert isinstance(cutoff, datetime)
 
     url = f"{HUB}/crm/v3/objects/{object_name}"
+    output: list[CRMObject] = []
     properties = await fetch_properties(log, http, object_name)
-    property_names = ",".join(p.name for p in properties.results if not p.calculated)
 
-    input = {
-        "associations": ",".join(cls.ASSOCIATED_ENTITIES),
-        "limit": 50, # Maximum when requesting history.
-        "properties": property_names,
-        "propertiesWithHistory": property_names,
-    }
-    if page:
-        input["after"] = page
-
-    _cls: Any = cls  # Silence mypy false-positive.
-    result: PageResult[CRMObject] = PageResult[_cls].model_validate_json(
-        await http.request(log, url, method="GET", params=input)
+    # There is a limit on how large a URL can be when making a GET request to HubSpot. Exactly what
+    # this limit is is a bit mysterious to me. Empirical testing indicates that a single property
+    # with an alphanumeric name ~32k characters long will push it over the limit. However, this ~32k
+    # length limit assumption does not seem to hold when considering huge amounts of shorter
+    # property names, which is more common. The chunk size here is a best guess then based on
+    # something that works for actual rea;-world use cases. Note that the length is effectively
+    # doubled by the fact that we request both properties and properties with history.
+    #
+    # If this calculation results in more than one chunk of properties to retrieve based on the
+    # cumulative byte lengths, we will issue multiple requests for different sets of properties and
+    # combine the results together in the output documents.
+    chunked_properties = _chunk_props(
+        [p.name for p in properties.results if not p.calculated],
+        5 * 1024,
     )
 
-    for doc in result.results:
+    for props in chunked_properties:
+        property_names = ",".join(props)
+
+        input = {
+            "associations": ",".join(cls.ASSOCIATED_ENTITIES),
+            "limit": 50, # Maximum when requesting history.
+            "properties": property_names,
+            "propertiesWithHistory": property_names,
+        }
+        if page:
+            input["after"] = page
+
+        _cls: Any = cls  # Silence mypy false-positive.
+        result: PageResult[CRMObject] = PageResult[_cls].model_validate_json(
+            await http.request(log, url, method="GET", params=input)
+        )
+
+        for idx, doc in enumerate(result.results):
+            if idx == len(output):
+                # Populate the document at idx the first time around.
+                output.append(doc)
+            else:
+                # When fetching values for additional chunks of properties, we require that
+                # documents are received in the same order.
+                assert output[idx].id == doc.id
+
+                # An additional requirement is that if a document gets updated while we are fetching
+                # a separate chunk of properties, that its `updatedAt` value will be increased to
+                # the point that it will be beyond the cutoff for the backfill and the updated
+                # document will be captured via the incremental stream. This will prevent any
+                # inconsistencies arising from a document being updated in the midst of us fetching
+                # its properties.
+                if output[idx].updatedAt != doc.updatedAt:
+                    assert doc.updatedAt >= cutoff
+                    output[idx].updatedAt = doc.updatedAt # We'll discard this document per the check a little further down.
+
+                output[idx].properties.update(doc.properties)
+                output[idx].propertiesWithHistory.update(doc.propertiesWithHistory)
+
+    for doc in output:
         if doc.updatedAt < cutoff:
             yield doc
 
@@ -320,10 +361,8 @@ async def fetch_recent_custom_objects(
 ) -> tuple[Iterable[tuple[datetime, str]], PageCursor]:
     
     url = f"{HUB}/crm/v3/objects/{object_name}/search"
-
     # The search API has known inconsistencies with very recent data.
     horizon = datetime.now(tz=UTC) - CONSISTENCY_HORIZON_DELTA
-
     if horizon <= since:
         return [], None
 
@@ -346,7 +385,6 @@ async def fetch_recent_custom_objects(
         ],
         "limit": 100,
     }
-
     if cursor:
         input["after"] = cursor
 
@@ -355,7 +393,6 @@ async def fetch_recent_custom_objects(
     )
 
     newCursor = result.paging.next.after if result.paging else None
-
     return ((r.properties.hs_lastmodifieddate, str(r.id)) for r in result.results), newCursor
 
 
@@ -365,7 +402,6 @@ async def list_custom_objects(
 ) -> list[str]:
     
     url = f"{HUB}/crm/v3/schemas"
-    
     # Note: The schemas endpoint always returns all items in a single call, so there's never
     # pagination.
     result = PageResult[CustomObjectSchema].model_validate_json(
@@ -385,12 +421,10 @@ async def fetch_email_events_page(
     assert isinstance(cutoff, datetime)
     
     url = f"{HUB}/email/public/v1/events"
-
     input: Dict[str, Any] = {
         "endTimestamp": _dt_to_ms(cutoff) - 1, # endTimestamp is inclusive.
         "limit": 1000,
     }
-
     if page:
         input["offset"] = page
 
@@ -412,10 +446,8 @@ async def fetch_recent_email_events(
     assert isinstance(log_cursor, datetime)
 
     url = f"{HUB}/email/public/v1/events"
-
     # The email events API has known inconsistencies with very recent data.
     horizon = datetime.now(tz=UTC) - CONSISTENCY_HORIZON_DELTA
-
     if horizon <= log_cursor:
         return
 
@@ -455,3 +487,25 @@ def _ms_to_dt(ms: int) -> datetime:
 
 def _dt_to_ms(dt: datetime) -> int:
     return int(dt.timestamp() * 1000)
+
+def _chunk_props(props: list[str], max_bytes: int) -> list[list[str]]:
+    result: list[list[str]] = []
+
+    current_chunk: list[str] = []
+    current_size = 0
+
+    for p in props:
+        sz = len(p.encode('utf-8'))
+
+        if current_size + sz > max_bytes:
+            result.append(current_chunk)
+            current_chunk = []
+            current_size = 0
+
+        current_chunk.append(p)
+        current_size += sz
+
+    if current_chunk:
+        result.append(current_chunk)
+
+    return result

--- a/source-hubspot-native/source_hubspot_native/models.py
+++ b/source-hubspot-native/source_hubspot_native/models.py
@@ -1,7 +1,7 @@
 import urllib.parse
 from datetime import datetime, timedelta
 from enum import StrEnum, auto
-from typing import TYPE_CHECKING, Annotated, ClassVar, Generic, Literal, TypeVar
+from typing import TYPE_CHECKING, Annotated, ClassVar, Generic, Literal, Self, TypeVar
 
 from estuary_cdk.capture.common import (
     AccessToken,
@@ -114,10 +114,7 @@ class Properties(BaseDocument, extra="forbid"):
 
 # Base Struct for all CRM Objects within HubSpot.
 class BaseCRMObject(BaseDocument, extra="forbid"):
-    # Class-scoped metadata attached to concrete subclasses.
-    NAME: ClassVar[str]
     ASSOCIATED_ENTITIES: ClassVar[list[str]]
-    CACHED_PROPERTIES: ClassVar[Properties]
 
     class History(BaseDocument, extra="forbid"):
         timestamp: datetime
@@ -151,7 +148,7 @@ class BaseCRMObject(BaseDocument, extra="forbid"):
     ] = {}
 
     @model_validator(mode="after")
-    def _post_init(self) -> "BaseCRMObject":
+    def _post_init(self) -> Self:
         # Clear properties and history which don't have current values.
         self.properties = {k: v for k, v in self.properties.items() if v is not None}
         self.propertiesWithHistory = {
@@ -173,7 +170,6 @@ CRMObject = TypeVar("CRMObject", bound=BaseCRMObject)
 
 
 class Company(BaseCRMObject):
-    NAME = Names.companies
     ASSOCIATED_ENTITIES = [Names.contacts, Names.deals]
 
     contacts: list[int] = []
@@ -181,14 +177,12 @@ class Company(BaseCRMObject):
 
 
 class Contact(BaseCRMObject):
-    NAME = Names.contacts
     ASSOCIATED_ENTITIES = [Names.companies]
 
     companies: list[int] = []
 
 
 class Deal(BaseCRMObject):
-    NAME = Names.deals
     ASSOCIATED_ENTITIES = [Names.contacts, Names.engagements, Names.line_items]
 
     contacts: list[int] = []
@@ -197,14 +191,12 @@ class Deal(BaseCRMObject):
 
 
 class Engagement(BaseCRMObject):
-    NAME = Names.engagements
     ASSOCIATED_ENTITIES = [Names.deals]
 
     deals: list[int] = []
 
 
 class Ticket(BaseCRMObject):
-    NAME = Names.tickets
     ASSOCIATED_ENTITIES = [Names.contacts, Names.engagements, Names.line_items]
 
     contacts: list[int] = []

--- a/source-hubspot-native/source_hubspot_native/models.py
+++ b/source-hubspot-native/source_hubspot_native/models.py
@@ -1,11 +1,9 @@
+import urllib.parse
 from datetime import datetime
 from enum import StrEnum, auto
-from pydantic import BaseModel, Field, AwareDatetime, model_validator
-from typing import Literal, Generic, TypeVar, Annotated, ClassVar, TYPE_CHECKING
-import urllib.parse
+from typing import TYPE_CHECKING, Annotated, ClassVar, Generic, Literal, TypeVar
 
 from estuary_cdk.capture.common import (
-    ConnectorState as GenericConnectorState,
     AccessToken,
     BaseDocument,
     BaseOAuth2Credentials,
@@ -13,6 +11,10 @@ from estuary_cdk.capture.common import (
     ResourceConfig,
     ResourceState,
 )
+from estuary_cdk.capture.common import (
+    ConnectorState as GenericConnectorState,
+)
+from pydantic import AwareDatetime, BaseModel, Field, model_validator
 
 scopes = [
     "crm.lists.read",
@@ -121,6 +123,7 @@ class BaseCRMObject(BaseDocument, extra="forbid"):
         value: str
         sourceType: str
         sourceId: str | None = None
+        sourceLabel: str | None = None
         updatedByUserId: int | None = None
 
     id: int

--- a/source-hubspot-native/source_hubspot_native/resources.py
+++ b/source-hubspot-native/source_hubspot_native/resources.py
@@ -1,38 +1,38 @@
-from datetime import datetime, UTC, timedelta
-from typing import AsyncGenerator, Awaitable, Iterable
-from logging import Logger
 import functools
+from datetime import UTC, datetime, timedelta
+from logging import Logger
+from typing import AsyncGenerator, Awaitable, Iterable
 
-from estuary_cdk.flow import CaptureBinding
 from estuary_cdk.capture import Task
-from estuary_cdk.capture.common import Resource, LogCursor, PageCursor, open_binding
-from estuary_cdk.http import HTTPSession, HTTPMixin, TokenSource
+from estuary_cdk.capture.common import LogCursor, PageCursor, Resource, open_binding
+from estuary_cdk.flow import CaptureBinding
+from estuary_cdk.http import HTTPMixin, HTTPSession, TokenSource
 
-from .models import (
-    BaseCRMObject,
-    CRMObject,
-    Company,
-    Contact,
-    Deal,
-    EndpointConfig,
-    Engagement,
-    Names,
-    OAUTH2_SPEC,
-    Property,
-    ResourceConfig,
-    ResourceState,
-    Ticket,
-)
 from .api import (
     FetchRecentFn,
+    fetch_changes,
     fetch_page,
     fetch_properties,
-    fetch_changes,
     fetch_recent_companies,
     fetch_recent_contacts,
     fetch_recent_deals,
     fetch_recent_engagements,
     fetch_recent_tickets,
+)
+from .models import (
+    OAUTH2_SPEC,
+    BaseCRMObject,
+    Company,
+    Contact,
+    CRMObject,
+    Deal,
+    EndpointConfig,
+    Engagement,
+    Names,
+    Property,
+    ResourceConfig,
+    ResourceState,
+    Ticket,
 )
 
 

--- a/source-hubspot-native/tests/snapshots/source_hubspot_native_tests_test_snapshots__discover__stdout.json
+++ b/source-hubspot-native/tests/snapshots/source_hubspot_native_tests_test_snapshots__discover__stdout.json
@@ -46,6 +46,18 @@
               "default": null,
               "title": "Sourceid"
             },
+            "sourceLabel": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "title": "Sourcelabel"
+            },
             "updatedByUserId": {
               "anyOf": [
                 {
@@ -70,6 +82,7 @@
         "Meta": {
           "properties": {
             "op": {
+              "default": "u",
               "description": "Operation type (c: Create, u: Update, d: Delete)",
               "enum": [
                 "c",
@@ -86,9 +99,6 @@
               "type": "integer"
             }
           },
-          "required": [
-            "op"
-          ],
           "title": "Meta",
           "type": "object"
         }
@@ -235,6 +245,18 @@
               "default": null,
               "title": "Sourceid"
             },
+            "sourceLabel": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "title": "Sourcelabel"
+            },
             "updatedByUserId": {
               "anyOf": [
                 {
@@ -259,6 +281,7 @@
         "Meta": {
           "properties": {
             "op": {
+              "default": "u",
               "description": "Operation type (c: Create, u: Update, d: Delete)",
               "enum": [
                 "c",
@@ -275,9 +298,6 @@
               "type": "integer"
             }
           },
-          "required": [
-            "op"
-          ],
           "title": "Meta",
           "type": "object"
         }
@@ -416,6 +436,18 @@
               "default": null,
               "title": "Sourceid"
             },
+            "sourceLabel": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "title": "Sourcelabel"
+            },
             "updatedByUserId": {
               "anyOf": [
                 {
@@ -440,6 +472,7 @@
         "Meta": {
           "properties": {
             "op": {
+              "default": "u",
               "description": "Operation type (c: Create, u: Update, d: Delete)",
               "enum": [
                 "c",
@@ -456,9 +489,6 @@
               "type": "integer"
             }
           },
-          "required": [
-            "op"
-          ],
           "title": "Meta",
           "type": "object"
         }
@@ -613,6 +643,18 @@
               "default": null,
               "title": "Sourceid"
             },
+            "sourceLabel": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "title": "Sourcelabel"
+            },
             "updatedByUserId": {
               "anyOf": [
                 {
@@ -637,6 +679,7 @@
         "Meta": {
           "properties": {
             "op": {
+              "default": "u",
               "description": "Operation type (c: Create, u: Update, d: Delete)",
               "enum": [
                 "c",
@@ -653,9 +696,6 @@
               "type": "integer"
             }
           },
-          "required": [
-            "op"
-          ],
           "title": "Meta",
           "type": "object"
         }
@@ -794,6 +834,18 @@
               "default": null,
               "title": "Sourceid"
             },
+            "sourceLabel": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "title": "Sourcelabel"
+            },
             "updatedByUserId": {
               "anyOf": [
                 {
@@ -818,6 +870,7 @@
         "Meta": {
           "properties": {
             "op": {
+              "default": "u",
               "description": "Operation type (c: Create, u: Update, d: Delete)",
               "enum": [
                 "c",
@@ -834,9 +887,6 @@
               "type": "integer"
             }
           },
-          "required": [
-            "op"
-          ],
           "title": "Meta",
           "type": "object"
         }
@@ -955,6 +1005,7 @@
         "Meta": {
           "properties": {
             "op": {
+              "default": "u",
               "description": "Operation type (c: Create, u: Update, d: Delete)",
               "enum": [
                 "c",
@@ -971,9 +1022,6 @@
               "type": "integer"
             }
           },
-          "required": [
-            "op"
-          ],
           "title": "Meta",
           "type": "object"
         }
@@ -1014,6 +1062,91 @@
     },
     "key": [
       "/_meta/row_id"
+    ]
+  },
+  {
+    "recommendedName": "email_events",
+    "resourceConfig": {
+      "name": "email_events"
+    },
+    "documentSchema": {
+      "$defs": {
+        "Meta": {
+          "properties": {
+            "op": {
+              "default": "u",
+              "description": "Operation type (c: Create, u: Update, d: Delete)",
+              "enum": [
+                "c",
+                "u",
+                "d"
+              ],
+              "title": "Op",
+              "type": "string"
+            },
+            "row_id": {
+              "default": -1,
+              "description": "Row ID of the Document, counting up from zero, or -1 if not known",
+              "title": "Row Id",
+              "type": "integer"
+            }
+          },
+          "title": "Meta",
+          "type": "object"
+        }
+      },
+      "additionalProperties": true,
+      "properties": {
+        "_meta": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/Meta"
+            }
+          ],
+          "default": {
+            "op": "u",
+            "row_id": -1
+          },
+          "description": "Document metadata"
+        },
+        "id": {
+          "title": "Id",
+          "type": "string"
+        },
+        "created": {
+          "format": "date-time",
+          "title": "Created",
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "SENT",
+            "DROPPED",
+            "PROCESSED",
+            "DELIVERED",
+            "DEFERRED",
+            "BOUNCE",
+            "OPEN",
+            "CLICK",
+            "STATUSCHANGE",
+            "SPAMREPORT",
+            "SUPPRESSED",
+            "UNBOUNCE"
+          ],
+          "title": "Type",
+          "type": "string"
+        }
+      },
+      "required": [
+        "id",
+        "created"
+      ],
+      "title": "EmailEvent",
+      "type": "object",
+      "x-infer-schema": true
+    },
+    "key": [
+      "/id"
     ]
   }
 ]

--- a/source-hubspot-native/tests/snapshots/source_hubspot_native_tests_test_snapshots__spec__stdout.json
+++ b/source-hubspot-native/tests/snapshots/source_hubspot_native_tests_test_snapshots__spec__stdout.json
@@ -106,7 +106,7 @@
       "title": "ResourceConfig",
       "type": "object"
     },
-    "documentationUrl": "https://docs.estuary.dev",
+    "documentationUrl": "https://go.estuary.dev/hubspot-real-time",
     "oauth2": {
       "provider": "hubspot",
       "authUrlTemplate": "https://app.hubspot.com/oauth/authorize?client_id={{#urlencode}}{{{ client_id }}}{{/urlencode}}&scope=crm.lists.read%20crm.objects.companies.read%20crm.objects.contacts.read%20crm.objects.deals.read%20crm.objects.owners.read%20crm.schemas.companies.read%20crm.schemas.contacts.read%20crm.schemas.deals.read%20e-commerce%20files%20files.ui_hidden.read%20forms%20forms-uploaded-files%20sales-email-read%20tickets&optional_scope=automation%20content%20crm.objects.custom.read%20crm.objects.feedback_submissions.read%20crm.objects.goals.read%20crm.schemas.custom.read&redirect_uri={{#urlencode}}{{{ redirect_uri }}}{{/urlencode}}&response_type=code&state={{#urlencode}}{{{ state }}}{{/urlencode}}",


### PR DESCRIPTION
**Description:**

Adds bindings for email events and custom objects to `source-hubspot-native`, as well as some other fixes along the way to get the connector working.

The APIs used for both of these bindings have been noted elsewhere to have consistency issues, so the data from them will be delayed by 5 minutes with the hopes that such a delay is long enough to give us consistent results. Of course this is a total guess, based on almost nothing, and we may need to adjust it based on real-world observations.

I've manually tested the connector built from these changes and compared it with the existing ATF based connector to verify that the outputs are equivalent. I've also run it against a large hubspot account and verified that it captures data that looks reasonably correct.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

We should update the hubspot native docs per these changes, and note that the data from the new bindings is delayed by 5 minutes.

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1549)
<!-- Reviewable:end -->
