### PR TITLE
materialize-redshift: support clusters with `enable_case_sensitive_identifier` set to ON

### DIFF
--- a/materialize-redshift/.snapshots/TestSQLGeneration
+++ b/materialize-redshift/.snapshots/TestSQLGeneration
@@ -2,7 +2,7 @@
 CREATE TABLE IF NOT EXISTS "a-schema".target_table (
 	key1 BIGINT,
 	"key!2" BOOLEAN,
-	Camel_Case BIGINT,
+	"Camel_Case" BIGINT,
 	"a Time" TIMESTAMPTZ,
 	"array" SUPER,
 	lower_case BIGINT,
@@ -15,7 +15,7 @@ COMMENT ON COLUMN "a-schema".target_table.key1 IS 'Key One Title
 Key One Description
 auto-generated projection of JSON at: /key1 with inferred types: [integer]';
 COMMENT ON COLUMN "a-schema".target_table."key!2" IS 'auto-generated projection of JSON at: /key!2 with inferred types: [boolean]';
-COMMENT ON COLUMN "a-schema".target_table.Camel_Case IS 'auto-generated projection of JSON at: /Camel_Case with inferred types: [integer]';
+COMMENT ON COLUMN "a-schema".target_table."Camel_Case" IS 'auto-generated projection of JSON at: /Camel_Case with inferred types: [integer]';
 COMMENT ON COLUMN "a-schema".target_table."a Time" IS 'auto-generated projection of JSON at: /a Time with inferred types: [string]';
 COMMENT ON COLUMN "a-schema".target_table."array" IS 'This is an array!
 auto-generated projection of JSON at: /array with inferred types: [array]';
@@ -26,13 +26,13 @@ COMMENT ON COLUMN "a-schema".target_table.flow_document IS 'auto-generated proje
 
 --- Begin "Delta Updates" createTargetTable ---
 CREATE TABLE IF NOT EXISTS "Delta Updates" (
-	theKey TEXT,
-	aValue BIGINT
+	"theKey" TEXT,
+	"aValue" BIGINT
 );
 
 COMMENT ON TABLE "Delta Updates" IS 'Generated for materialization test/sqlite of collection delta/updates';
-COMMENT ON COLUMN "Delta Updates".theKey IS 'auto-generated projection of JSON at: /theKey with inferred types: [string]';
-COMMENT ON COLUMN "Delta Updates".aValue IS 'A super-awesome value.
+COMMENT ON COLUMN "Delta Updates"."theKey" IS 'auto-generated projection of JSON at: /theKey with inferred types: [string]';
+COMMENT ON COLUMN "Delta Updates"."aValue" IS 'A super-awesome value.
 auto-generated projection of JSON at: /aValue with inferred types: [integer]';
 --- End "Delta Updates" createTargetTable ---
 
@@ -53,21 +53,21 @@ MERGE INTO "a-schema".target_table
 USING flow_temp_table_0 AS r
 ON "a-schema".target_table.key1 = r.key1 AND "a-schema".target_table."key!2" = r."key!2"
 WHEN MATCHED THEN
-	UPDATE SET Camel_Case = r.Camel_Case, "a Time" = r."a Time", "array" = r."array", lower_case = r.lower_case, value = r.value, flow_document = r.flow_document
+	UPDATE SET "Camel_Case" = r."Camel_Case", "a Time" = r."a Time", "array" = r."array", lower_case = r.lower_case, value = r.value, flow_document = r.flow_document
 WHEN NOT MATCHED THEN
-	INSERT (key1, "key!2", Camel_Case, "a Time", "array", lower_case, value, flow_document)
-	VALUES (r.key1, r."key!2", r.Camel_Case, r."a Time", r."array", r.lower_case, r.value, r.flow_document);
+	INSERT (key1, "key!2", "Camel_Case", "a Time", "array", lower_case, value, flow_document)
+	VALUES (r.key1, r."key!2", r."Camel_Case", r."a Time", r."array", r.lower_case, r.value, r.flow_document);
 --- End "a-schema".target_table mergeInto ---
 
 --- Begin "Delta Updates" mergeInto ---
 MERGE INTO "Delta Updates"
 USING flow_temp_table_1 AS r
-ON "Delta Updates".theKey = r.theKey
+ON "Delta Updates"."theKey" = r."theKey"
 WHEN MATCHED THEN
-	UPDATE SET aValue = r.aValue
+	UPDATE SET "aValue" = r."aValue"
 WHEN NOT MATCHED THEN
-	INSERT (theKey, aValue)
-	VALUES (r.theKey, r.aValue);
+	INSERT ("theKey", "aValue")
+	VALUES (r."theKey", r."aValue");
 --- End "Delta Updates" mergeInto ---
 
 --- Begin "a-schema".target_table loadQuery ---
@@ -91,7 +91,7 @@ CREATE TEMPORARY TABLE flow_temp_table_0 (
 
 --- Begin "Delta Updates" createLoadTable (no varchar length) ---
 CREATE TEMPORARY TABLE flow_temp_table_1 (
-	theKey TEXT
+	"theKey" TEXT
 );
 --- End "Delta Updates" createLoadTable (no varchar length) ---
 
@@ -104,7 +104,7 @@ CREATE TEMPORARY TABLE flow_temp_table_0 (
 
 --- Begin "Delta Updates" createLoadTable (with varchar length) ---
 CREATE TEMPORARY TABLE flow_temp_table_1 (
-	theKey VARCHAR(400)
+	"theKey" VARCHAR(400)
 );
 --- End "Delta Updates" createLoadTable (with varchar length) ---
 
@@ -117,20 +117,7 @@ UPDATE path."To".checkpoints
 	AND   fence     = 123;
 --- End Fence Update ---
 
---- Begin Copy From S3 With Truncation---
-COPY my_temp_table
-FROM 's3://some_bucket/files.manifest'
-MANIFEST
-CREDENTIALS 'aws_access_key_id=accessKeyID;aws_secret_access_key=secretKey'
-REGION 'us-somewhere-1'
-JSON 'auto ignorecase'
-GZIP
-DATEFORMAT 'auto'
-TIMEFORMAT 'auto'
-TRUNCATECOLUMNS;
---- End Copy From S3 With Truncation ---
-
---- Begin Copy From S3 Without Truncation---
+--- Begin Copy From S3 Without Case Sensitive Identifiers---
 COPY my_temp_table
 FROM 's3://some_bucket/files.manifest'
 MANIFEST
@@ -140,4 +127,16 @@ JSON 'auto ignorecase'
 GZIP
 DATEFORMAT 'auto'
 TIMEFORMAT 'auto';
---- End Copy From S3 Without Truncation ---
+--- End Copy From S3 Without Case Sensitive Identifier ---
+
+--- Begin Copy From S3 With Case Sensitive Identifiers---
+COPY my_temp_table
+FROM 's3://some_bucket/files.manifest'
+MANIFEST
+CREDENTIALS 'aws_access_key_id=accessKeyID;aws_secret_access_key=secretKey'
+REGION 'us-somewhere-1'
+JSON 'auto'
+GZIP
+DATEFORMAT 'auto'
+TIMEFORMAT 'auto';
+--- End Copy From S3 With Case Sensitive Identifiers ---

--- a/materialize-redshift/client.go
+++ b/materialize-redshift/client.go
@@ -102,7 +102,7 @@ func (c *client) CreateTable(ctx context.Context, tc sql.TableCreate) error {
 }
 
 func (c *client) DeleteTable(ctx context.Context, path []string) (string, boilerplate.ActionApplyFn, error) {
-	stmt := fmt.Sprintf("DROP TABLE %s;", rsDialect.Identifier(path...))
+	stmt := fmt.Sprintf("DROP TABLE %s;", c.ep.Dialect.Identifier(path...))
 
 	return stmt, func(ctx context.Context) error {
 		_, err := c.db.ExecContext(ctx, stmt)
@@ -159,7 +159,7 @@ func (c *client) ListSchemas(ctx context.Context) ([]string, error) {
 }
 
 func (c *client) CreateSchema(ctx context.Context, schemaName string) error {
-	return sql.StdCreateSchema(ctx, c.db, rsDialect, schemaName)
+	return sql.StdCreateSchema(ctx, c.db, c.ep.Dialect, schemaName)
 }
 
 func (c *client) PreReqs(ctx context.Context) *sql.PrereqErr {

--- a/materialize-redshift/driver.go
+++ b/materialize-redshift/driver.go
@@ -243,18 +243,22 @@ func newRedshiftDriver() *sql.Driver {
 			}
 
 			var caseSensitiveIdentifierEnabled = strings.EqualFold(caseSensitiveIdentifier, "on")
+			var dialect = rsDialect(caseSensitiveIdentifierEnabled)
+			var templates = renderTemplates(dialect)
 
-			log.WithField("caseSensitiveIdentifierEnabled", caseSensitiveIdentifierEnabled).Info("detected value for enable_case_sensitive_identifier")
+			if caseSensitiveIdentifierEnabled {
+				log.WithField("caseSensitiveIdentifierEnabled", caseSensitiveIdentifierEnabled).Info("detected value for enable_case_sensitive_identifier")
+			}
 
 			return &sql.Endpoint{
 				Config:              cfg,
-				Dialect:             rsDialect,
+				Dialect:             dialect,
 				MetaSpecs:           &metaSpecs,
 				MetaCheckpoints:     &metaCheckpoints,
 				NewClient:           newClient,
-				CreateTableTemplate: tplCreateTargetTable,
+				CreateTableTemplate: templates.createTargetTable,
 				NewResource:         newTableConfig,
-				NewTransactor:       newTransactor,
+				NewTransactor:       prepareNewTransactor(templates, caseSensitiveIdentifierEnabled),
 				Tenant:              tenant,
 				ConcurrentApply:     true,
 			}, nil
@@ -265,77 +269,87 @@ func newRedshiftDriver() *sql.Driver {
 var _ m.DelayedCommitter = (*transactor)(nil)
 
 type transactor struct {
+	templates   templates
+	dialect     sql.Dialect
 	fence       sql.Fence
 	bindings    []*binding
 	cfg         *config
 	updateDelay time.Duration
 }
 
-func newTransactor(
-	ctx context.Context,
-	ep *sql.Endpoint,
-	fence sql.Fence,
-	bindings []sql.Table,
-	open pm.Request_Open,
-) (_ m.Transactor, err error) {
-	var cfg = ep.Config.(*config)
+func prepareNewTransactor(
+	templates templates,
+	caseSensitiveIdentifierEnabled bool,
+) func(context.Context, *sql.Endpoint, sql.Fence, []sql.Table, pm.Request_Open) (m.Transactor, error) {
+	return func(
+		ctx context.Context,
+		ep *sql.Endpoint,
+		fence sql.Fence,
+		bindings []sql.Table,
+		open pm.Request_Open,
+	) (_ m.Transactor, err error) {
+		var cfg = ep.Config.(*config)
 
-	var d = &transactor{
-		fence: fence,
-		cfg:   cfg,
-	}
-
-	if d.updateDelay, err = m.ParseDelay(cfg.Advanced.UpdateDelay); err != nil {
-		return nil, err
-	}
-
-	s3client, err := d.cfg.toS3Client(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	db, err := stdsql.Open("pgx", d.cfg.toURI())
-	if err != nil {
-		return nil, err
-	}
-	defer db.Close()
-
-	schemas := []string{}
-	for _, b := range bindings {
-		if !slices.Contains(schemas, b.InfoLocation.TableSchema) {
-			schemas = append(schemas, b.InfoLocation.TableSchema)
+		var d = &transactor{
+			templates: templates,
+			dialect:   ep.Dialect,
+			fence:     fence,
+			cfg:       cfg,
 		}
-	}
 
-	catalog := cfg.Database
-	if catalog == "" {
-		// An endpoint-level database configuration is not required, so query for the active
-		// database if that's the case.
-		if err := db.QueryRowContext(ctx, "select current_database();").Scan(&catalog); err != nil {
-			return nil, fmt.Errorf("querying for connected database: %w", err)
+		if d.updateDelay, err = m.ParseDelay(cfg.Advanced.UpdateDelay); err != nil {
+			return nil, err
 		}
-	}
-	resourcePaths := make([][]string, 0, len(open.Materialization.Bindings))
-	for _, b := range open.Materialization.Bindings {
-		resourcePaths = append(resourcePaths, b.ResourcePath)
-	}
-	is, err := sql.StdFetchInfoSchema(ctx, db, rsDialect, catalog, resourcePaths)
-	if err != nil {
-		return nil, err
-	}
 
-	for idx, target := range bindings {
-		if err = d.addBinding(
-			idx,
-			target,
-			s3client,
-			is,
-		); err != nil {
-			return nil, fmt.Errorf("addBinding of %s: %w", target.Path, err)
+		s3client, err := d.cfg.toS3Client(ctx)
+		if err != nil {
+			return nil, err
 		}
-	}
 
-	return d, nil
+		db, err := stdsql.Open("pgx", d.cfg.toURI())
+		if err != nil {
+			return nil, err
+		}
+		defer db.Close()
+
+		schemas := []string{}
+		for _, b := range bindings {
+			if !slices.Contains(schemas, b.InfoLocation.TableSchema) {
+				schemas = append(schemas, b.InfoLocation.TableSchema)
+			}
+		}
+
+		catalog := cfg.Database
+		if catalog == "" {
+			// An endpoint-level database configuration is not required, so query for the active
+			// database if that's the case.
+			if err := db.QueryRowContext(ctx, "select current_database();").Scan(&catalog); err != nil {
+				return nil, fmt.Errorf("querying for connected database: %w", err)
+			}
+		}
+		resourcePaths := make([][]string, 0, len(open.Materialization.Bindings))
+		for _, b := range open.Materialization.Bindings {
+			resourcePaths = append(resourcePaths, b.ResourcePath)
+		}
+		is, err := sql.StdFetchInfoSchema(ctx, db, ep.Dialect, catalog, resourcePaths)
+		if err != nil {
+			return nil, err
+		}
+
+		for idx, target := range bindings {
+			if err = d.addBinding(
+				idx,
+				target,
+				s3client,
+				is,
+				caseSensitiveIdentifierEnabled,
+			); err != nil {
+				return nil, fmt.Errorf("addBinding of %s: %w", target.Path, err)
+			}
+		}
+
+		return d, nil
+	}
 }
 
 type binding struct {
@@ -365,6 +379,7 @@ func (t *transactor) addBinding(
 	target sql.Table,
 	client *s3.Client,
 	is *boilerplate.InfoSchema,
+	caseSensitiveIdentifierEnabled bool,
 ) error {
 	var b = &binding{
 		target:    target,
@@ -374,23 +389,22 @@ func (t *transactor) addBinding(
 
 	// Render templates that require specific S3 "COPY INTO" parameters.
 	for _, m := range []struct {
-		sql             *string
-		target          string
-		columns         []*sql.Column
-		truncateColumns bool
-		stagedFile      *stagedFile
+		sql        *string
+		target     string
+		columns    []*sql.Column
+		stagedFile *stagedFile
 	}{
-		{&b.copyIntoLoadTableSQL, fmt.Sprintf("flow_temp_table_%d", bindingIdx), target.KeyPtrs(), false, b.loadFile},
-		{&b.copyIntoMergeTableSQL, fmt.Sprintf("flow_temp_table_%d", bindingIdx), target.Columns(), true, b.storeFile},
-		{&b.copyIntoTargetTableSQL, target.Identifier, target.Columns(), true, b.storeFile},
+		{&b.copyIntoLoadTableSQL, fmt.Sprintf("flow_temp_table_%d", bindingIdx), target.KeyPtrs(), b.loadFile},
+		{&b.copyIntoMergeTableSQL, fmt.Sprintf("flow_temp_table_%d", bindingIdx), target.Columns(), b.storeFile},
+		{&b.copyIntoTargetTableSQL, target.Identifier, target.Columns(), b.storeFile},
 	} {
 		var sql strings.Builder
-		if err := tplCopyFromS3.Execute(&sql, copyFromS3Params{
-			Target:          m.target,
-			Columns:         m.columns,
-			ManifestURL:     m.stagedFile.fileURI(manifestFile),
-			Config:          t.cfg,
-			TruncateColumns: m.truncateColumns,
+		if err := t.templates.copyFromS3.Execute(&sql, copyFromS3Params{
+			Target:                         m.target,
+			Columns:                        m.columns,
+			ManifestURL:                    m.stagedFile.fileURI(manifestFile),
+			Config:                         t.cfg,
+			CaseSensitiveIdentifierEnabled: caseSensitiveIdentifierEnabled,
 		}); err != nil {
 			return err
 		}
@@ -402,9 +416,9 @@ func (t *transactor) addBinding(
 		sql *string
 		tpl *template.Template
 	}{
-		{&b.createStoreTableSQL, tplCreateStoreTable},
-		{&b.mergeIntoSQL, tplMergeInto},
-		{&b.loadQuerySQL, tplLoadQuery},
+		{&b.createStoreTableSQL, t.templates.createStoreTable},
+		{&b.mergeIntoSQL, t.templates.mergeInto},
+		{&b.loadQuerySQL, t.templates.loadQuery},
 	} {
 		var err error
 		if *m.sql, err = sql.RenderTableTemplate(target, m.tpl); err != nil {
@@ -414,7 +428,7 @@ func (t *transactor) addBinding(
 
 	// The load table template is re-evaluated every transaction to account for the specific string
 	// lengths observed for string keys in the load key set.
-	b.createLoadTableTemplate = tplCreateLoadTable
+	b.createLoadTableTemplate = t.templates.createLoadTable
 
 	// Retain column metadata information for this binding as a snapshot of the target table
 	// configuration when the connector started, indexed in the same order as values will be
@@ -662,7 +676,7 @@ func (d *transactor) Store(it *m.StoreIterator) (m.StartCommitFunc, error) {
 		}
 
 		var fenceUpdate strings.Builder
-		if err := tplUpdateFence.Execute(&fenceUpdate, d.fence); err != nil {
+		if err := d.templates.updateFence.Execute(&fenceUpdate, d.fence); err != nil {
 			return nil, m.FinishedOperation(fmt.Errorf("evaluating fence update template: %w", err))
 		}
 
@@ -676,14 +690,6 @@ func (d *transactor) commit(ctx context.Context, fenceUpdate string, hasUpdates 
 		return fmt.Errorf("store pgx.Connect: %w", err)
 	}
 	defer conn.Close(ctx)
-
-	// Truncate strings within SUPER types by setting this option, since these have the same limits
-	// on maximum VARCHAR lengths as table columns do. Notably, this will truncate any strings in
-	// `flow_document` (stored as a SUPER column) that otherwise would prevent the row from being
-	// added to the table.
-	if _, err := conn.Exec(ctx, "SET json_parse_truncate_strings=ON;"); err != nil {
-		return fmt.Errorf("configuring json_parse_truncate_strings=ON: %w", err)
-	}
 
 	// Update any columns that require setting to VARCHAR(MAX) for storing large strings. ALTER
 	// TABLE ALTER COLUMN statements cannot be run inside transaction blocks.
@@ -729,7 +735,7 @@ func (d *transactor) commit(ctx context.Context, fenceUpdate string, hasUpdates 
 	// checkpoints table. For best performance, a single materialization per database should be
 	// used, or separate materializations within the same database should use a different schema for
 	// their metadata.
-	if _, err := txn.Exec(ctx, fmt.Sprintf("lock %s;", rsDialect.Identifier(d.fence.TablePath...))); err != nil {
+	if _, err := txn.Exec(ctx, fmt.Sprintf("lock %s;", d.dialect.Identifier(d.fence.TablePath...))); err != nil {
 		return fmt.Errorf("obtaining checkpoints table lock: %w", err)
 	}
 


### PR DESCRIPTION
**Description:**

The `enable_case_sensitive_identifier` configuration makes it so Redshift does not always lowercase all identifiers, and causes it to preserve the casing of quoted identifiers.

Previously we would always assume that this parameter was OFF and that we should treat identifiers as lowercase, but this breaks materializations where the cluster is configured with the parameter to ON.

The changes here allow us to support clusters where `enable_case_sensitive_identifier` is set to ON.

Tested by running all the unit and e2e tests, and manually ran a materialization with mixed capitalization fields with `enable_case_sensitive_identifier` both on and off to make sure it produced the expected output.

Closes https://github.com/estuary/connectors/issues/1273

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

The [Naming conventions](https://docs.estuary.dev/reference/Connectors/materialization-connectors/amazon-redshift/#naming-conventions) section in our documentation should be updated to reflect this change.

**Notes for reviewers:**

I've verified that all existing Redshift materializations either have `enable_case_sensitive_identifier` set to OFF, or are broken because we can't handle clusters where it's ON. For existing systems with `enable_case_sensitive_identifier` set to OFF, there should be no change in behavior of the connector. 

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1551)
<!-- Reviewable:end -->
