### PR TITLE
source-mysql: Correctly handle unsigned integer values

### DIFF
--- a/source-mysql/.snapshots/TestAlterTable_AddColumnBasic-at_end
+++ b/source-mysql/.snapshots/TestAlterTable_AddColumnBasic-at_end
@@ -6,5 +6,5 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"test%2FAlterTable_AddColumnBasic_68678323":{"backfilled":2,"key_columns":["id"],"metadata":{"schema":{"columns":["id","data","extra_end"],"types":{"data":"text","extra_end":"text","id":"int"}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
+{"bindingStateV1":{"test%2FAlterTable_AddColumnBasic_68678323":{"backfilled":2,"key_columns":["id"],"metadata":{"schema":{"columns":["id","data","extra_end"],"types":{"data":"text","extra_end":"text","id":{"type":"int"}}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
 

--- a/source-mysql/.snapshots/TestAlterTable_AddColumnBasic-at_end_restart
+++ b/source-mysql/.snapshots/TestAlterTable_AddColumnBasic-at_end_restart
@@ -6,5 +6,5 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"test%2FAlterTable_AddColumnBasic_68678323":{"backfilled":2,"key_columns":["id"],"metadata":{"schema":{"columns":["id","data","extra_end"],"types":{"data":"text","extra_end":"text","id":"int"}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
+{"bindingStateV1":{"test%2FAlterTable_AddColumnBasic_68678323":{"backfilled":2,"key_columns":["id"],"metadata":{"schema":{"columns":["id","data","extra_end"],"types":{"data":"text","extra_end":"text","id":{"type":"int"}}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
 

--- a/source-mysql/.snapshots/TestAlterTable_AddColumnBasic-at_first
+++ b/source-mysql/.snapshots/TestAlterTable_AddColumnBasic-at_first
@@ -6,5 +6,5 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"test%2FAlterTable_AddColumnBasic_68678323":{"backfilled":2,"key_columns":["id"],"metadata":{"schema":{"columns":["extra_start","id","data","extra_end"],"types":{"data":"text","extra_end":"text","extra_start":"text","id":"int"}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
+{"bindingStateV1":{"test%2FAlterTable_AddColumnBasic_68678323":{"backfilled":2,"key_columns":["id"],"metadata":{"schema":{"columns":["extra_start","id","data","extra_end"],"types":{"data":"text","extra_end":"text","extra_start":"text","id":{"type":"int"}}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
 

--- a/source-mysql/.snapshots/TestAlterTable_AddColumnBasic-at_first_restart
+++ b/source-mysql/.snapshots/TestAlterTable_AddColumnBasic-at_first_restart
@@ -6,5 +6,5 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"test%2FAlterTable_AddColumnBasic_68678323":{"backfilled":2,"key_columns":["id"],"metadata":{"schema":{"columns":["extra_start","id","data","extra_end"],"types":{"data":"text","extra_end":"text","extra_start":"text","id":"int"}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
+{"bindingStateV1":{"test%2FAlterTable_AddColumnBasic_68678323":{"backfilled":2,"key_columns":["id"],"metadata":{"schema":{"columns":["extra_start","id","data","extra_end"],"types":{"data":"text","extra_end":"text","extra_start":"text","id":{"type":"int"}}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
 

--- a/source-mysql/.snapshots/TestAlterTable_AddColumnBasic-at_middle
+++ b/source-mysql/.snapshots/TestAlterTable_AddColumnBasic-at_middle
@@ -6,5 +6,5 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"test%2FAlterTable_AddColumnBasic_68678323":{"backfilled":2,"key_columns":["id"],"metadata":{"schema":{"columns":["extra_start","id","Extra_MIDDLE","data","extra_end"],"types":{"Extra_MIDDLE":"text","data":"text","extra_end":"text","extra_start":"text","id":"int"}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
+{"bindingStateV1":{"test%2FAlterTable_AddColumnBasic_68678323":{"backfilled":2,"key_columns":["id"],"metadata":{"schema":{"columns":["extra_start","id","Extra_MIDDLE","data","extra_end"],"types":{"Extra_MIDDLE":"text","data":"text","extra_end":"text","extra_start":"text","id":{"type":"int"}}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
 

--- a/source-mysql/.snapshots/TestAlterTable_AddColumnBasic-at_middle_restart
+++ b/source-mysql/.snapshots/TestAlterTable_AddColumnBasic-at_middle_restart
@@ -6,5 +6,5 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"test%2FAlterTable_AddColumnBasic_68678323":{"backfilled":2,"key_columns":["id"],"metadata":{"schema":{"columns":["extra_start","id","Extra_MIDDLE","data","extra_end"],"types":{"Extra_MIDDLE":"text","data":"text","extra_end":"text","extra_start":"text","id":"int"}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
+{"bindingStateV1":{"test%2FAlterTable_AddColumnBasic_68678323":{"backfilled":2,"key_columns":["id"],"metadata":{"schema":{"columns":["extra_start","id","Extra_MIDDLE","data","extra_end"],"types":{"Extra_MIDDLE":"text","data":"text","extra_end":"text","extra_start":"text","id":{"type":"int"}}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
 

--- a/source-mysql/.snapshots/TestAlterTable_AddColumnBasic-init
+++ b/source-mysql/.snapshots/TestAlterTable_AddColumnBasic-init
@@ -6,5 +6,5 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"test%2FAlterTable_AddColumnBasic_68678323":{"backfilled":2,"key_columns":["id"],"metadata":{"schema":{"columns":["id","data"],"types":{"data":"text","id":"int"}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
+{"bindingStateV1":{"test%2FAlterTable_AddColumnBasic_68678323":{"backfilled":2,"key_columns":["id"],"metadata":{"schema":{"columns":["id","data"],"types":{"data":"text","id":{"type":"int"}}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
 

--- a/source-mysql/.snapshots/TestAlterTable_AddColumnSetEnum-enum-init
+++ b/source-mysql/.snapshots/TestAlterTable_AddColumnSetEnum-enum-init
@@ -6,5 +6,5 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"test%2FAlterTable_AddColumnSetEnum_enum_76927424":{"backfilled":2,"key_columns":["id"],"metadata":{"schema":{"columns":["id","data"],"types":{"data":"text","id":"int"}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
+{"bindingStateV1":{"test%2FAlterTable_AddColumnSetEnum_enum_76927424":{"backfilled":2,"key_columns":["id"],"metadata":{"schema":{"columns":["id","data"],"types":{"data":"text","id":{"type":"int"}}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
 

--- a/source-mysql/.snapshots/TestAlterTable_AddColumnSetEnum-enum-restart
+++ b/source-mysql/.snapshots/TestAlterTable_AddColumnSetEnum-enum-restart
@@ -6,5 +6,5 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"test%2FAlterTable_AddColumnSetEnum_enum_76927424":{"backfilled":2,"key_columns":["id"],"metadata":{"schema":{"columns":["id","data","enumCol"],"types":{"data":"text","enumCol":{"enum":["","someValue","anotherValue"],"type":"enum"},"id":"int"}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
+{"bindingStateV1":{"test%2FAlterTable_AddColumnSetEnum_enum_76927424":{"backfilled":2,"key_columns":["id"],"metadata":{"schema":{"columns":["id","data","enumCol"],"types":{"data":"text","enumCol":{"enum":["","someValue","anotherValue"],"type":"enum"},"id":{"type":"int"}}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
 

--- a/source-mysql/.snapshots/TestAlterTable_AddColumnSetEnum-enum-stream
+++ b/source-mysql/.snapshots/TestAlterTable_AddColumnSetEnum-enum-stream
@@ -6,5 +6,5 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"test%2FAlterTable_AddColumnSetEnum_enum_76927424":{"backfilled":2,"key_columns":["id"],"metadata":{"schema":{"columns":["id","data","enumCol"],"types":{"data":"text","enumCol":{"enum":["","someValue","anotherValue"],"type":"enum"},"id":"int"}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
+{"bindingStateV1":{"test%2FAlterTable_AddColumnSetEnum_enum_76927424":{"backfilled":2,"key_columns":["id"],"metadata":{"schema":{"columns":["id","data","enumCol"],"types":{"data":"text","enumCol":{"enum":["","someValue","anotherValue"],"type":"enum"},"id":{"type":"int"}}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
 

--- a/source-mysql/.snapshots/TestAlterTable_AddColumnSetEnum-set-init
+++ b/source-mysql/.snapshots/TestAlterTable_AddColumnSetEnum-set-init
@@ -6,5 +6,5 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"test%2FAlterTable_AddColumnSetEnum_set_14622082":{"backfilled":2,"key_columns":["id"],"metadata":{"schema":{"columns":["id","data"],"types":{"data":"text","id":"int"}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
+{"bindingStateV1":{"test%2FAlterTable_AddColumnSetEnum_set_14622082":{"backfilled":2,"key_columns":["id"],"metadata":{"schema":{"columns":["id","data"],"types":{"data":"text","id":{"type":"int"}}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
 

--- a/source-mysql/.snapshots/TestAlterTable_AddColumnSetEnum-set-restart
+++ b/source-mysql/.snapshots/TestAlterTable_AddColumnSetEnum-set-restart
@@ -6,5 +6,5 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"test%2FAlterTable_AddColumnSetEnum_set_14622082":{"backfilled":2,"key_columns":["id"],"metadata":{"schema":{"columns":["id","data","setCol"],"types":{"data":"text","id":"int","setCol":{"enum":["a","b","c"],"type":"set"}}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
+{"bindingStateV1":{"test%2FAlterTable_AddColumnSetEnum_set_14622082":{"backfilled":2,"key_columns":["id"],"metadata":{"schema":{"columns":["id","data","setCol"],"types":{"data":"text","id":{"type":"int"},"setCol":{"enum":["a","b","c"],"type":"set"}}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
 

--- a/source-mysql/.snapshots/TestAlterTable_AddColumnSetEnum-set-stream
+++ b/source-mysql/.snapshots/TestAlterTable_AddColumnSetEnum-set-stream
@@ -6,5 +6,5 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"test%2FAlterTable_AddColumnSetEnum_set_14622082":{"backfilled":2,"key_columns":["id"],"metadata":{"schema":{"columns":["id","data","setCol"],"types":{"data":"text","id":"int","setCol":{"enum":["a","b","c"],"type":"set"}}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
+{"bindingStateV1":{"test%2FAlterTable_AddColumnSetEnum_set_14622082":{"backfilled":2,"key_columns":["id"],"metadata":{"schema":{"columns":["id","data","setCol"],"types":{"data":"text","id":{"type":"int"},"setCol":{"enum":["a","b","c"],"type":"set"}}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
 

--- a/source-mysql/.snapshots/TestAlterTable_AddEnumColumn-init
+++ b/source-mysql/.snapshots/TestAlterTable_AddEnumColumn-init
@@ -6,5 +6,5 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"test%2FAlterTable_AddEnumColumn_30213486":{"backfilled":2,"key_columns":["id"],"metadata":{"schema":{"columns":["id","data"],"types":{"data":"text","id":"int"}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
+{"bindingStateV1":{"test%2FAlterTable_AddEnumColumn_30213486":{"backfilled":2,"key_columns":["id"],"metadata":{"schema":{"columns":["id","data"],"types":{"data":"text","id":{"type":"int"}}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
 

--- a/source-mysql/.snapshots/TestAlterTable_AddEnumColumn-modified
+++ b/source-mysql/.snapshots/TestAlterTable_AddEnumColumn-modified
@@ -7,5 +7,5 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"test%2FAlterTable_AddEnumColumn_30213486":{"backfilled":2,"key_columns":["id"],"metadata":{"schema":{"columns":["id","data","enumcol"],"types":{"data":"text","enumcol":{"enum":["","sm","med","lg"],"type":"enum"},"id":"int"}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
+{"bindingStateV1":{"test%2FAlterTable_AddEnumColumn_30213486":{"backfilled":2,"key_columns":["id"],"metadata":{"schema":{"columns":["id","data","enumcol"],"types":{"data":"text","enumcol":{"enum":["","sm","med","lg"],"type":"enum"},"id":{"type":"int"}}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
 

--- a/source-mysql/.snapshots/TestAlterTable_AddEnumColumn-rebackfilled
+++ b/source-mysql/.snapshots/TestAlterTable_AddEnumColumn-rebackfilled
@@ -9,5 +9,5 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"test%2FAlterTable_AddEnumColumn_30213486":{"backfilled":5,"key_columns":["id"],"metadata":{"schema":{"columns":["id","data","enumcol"],"types":{"data":"text","enumcol":{"enum":["","sm","med","lg"],"type":"enum"},"id":"int"}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
+{"bindingStateV1":{"test%2FAlterTable_AddEnumColumn_30213486":{"backfilled":5,"key_columns":["id"],"metadata":{"schema":{"columns":["id","data","enumcol"],"types":{"data":"text","enumcol":{"enum":["","sm","med","lg"],"type":"enum"},"id":{"type":"int"}}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
 

--- a/source-mysql/.snapshots/TestAlterTable_AddUnsignedColumn-discover1
+++ b/source-mysql/.snapshots/TestAlterTable_AddUnsignedColumn-discover1
@@ -1,0 +1,130 @@
+Binding 0:
+{
+    "recommended_name": "test_altertable_addunsignedcolumn_57413089",
+    "resource_config_json": {
+      "namespace": "test",
+      "stream": "AlterTable_AddUnsignedColumn_57413089"
+    },
+    "document_schema_json": {
+      "$defs": {
+        "TestAlterTable_AddUnsignedColumn_57413089": {
+          "type": "object",
+          "required": [
+            "id"
+          ],
+          "$anchor": "TestAlterTable_AddUnsignedColumn_57413089",
+          "properties": {
+            "data": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "id": {
+              "type": "integer"
+            }
+          }
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "_meta": {
+                "properties": {
+                  "op": {
+                    "const": "d"
+                  }
+                }
+              }
+            }
+          },
+          "then": {
+            "reduce": {
+              "delete": true,
+              "strategy": "merge"
+            }
+          },
+          "else": {
+            "reduce": {
+              "strategy": "merge"
+            }
+          },
+          "required": [
+            "_meta"
+          ],
+          "properties": {
+            "_meta": {
+              "type": "object",
+              "required": [
+                "op",
+                "source"
+              ],
+              "properties": {
+                "before": {
+                  "$ref": "#TestAlterTable_AddUnsignedColumn_57413089",
+                  "description": "Record state immediately before this change was applied.",
+                  "reduce": {
+                    "strategy": "firstWriteWins"
+                  }
+                },
+                "op": {
+                  "enum": [
+                    "c",
+                    "d",
+                    "u"
+                  ],
+                  "description": "Change operation type: 'c' Create/Insert, 'u' Update, 'd' Delete."
+                },
+                "source": {
+                  "$id": "https://github.com/estuary/connectors/source-mysql/mysql-source-info",
+                  "properties": {
+                    "ts_ms": {
+                      "type": "integer",
+                      "description": "Unix timestamp (in millis) at which this event was recorded by the database."
+                    },
+                    "schema": {
+                      "type": "string",
+                      "description": "Database schema (namespace) of the event."
+                    },
+                    "snapshot": {
+                      "type": "boolean",
+                      "description": "Snapshot is true if the record was produced from an initial table backfill and unset if produced from the replication log."
+                    },
+                    "table": {
+                      "type": "string",
+                      "description": "Database table of the event."
+                    },
+                    "cursor": {
+                      "type": "string",
+                      "description": "Cursor value representing the current position in the binlog."
+                    },
+                    "txid": {
+                      "type": "string",
+                      "description": "The global transaction identifier associated with a change by MySQL. Only set if GTIDs are enabled."
+                    }
+                  },
+                  "type": "object",
+                  "required": [
+                    "schema",
+                    "table",
+                    "cursor"
+                  ]
+                }
+              },
+              "reduce": {
+                "strategy": "merge"
+              }
+            }
+          }
+        },
+        {
+          "$ref": "#TestAlterTable_AddUnsignedColumn_57413089"
+        }
+      ]
+    },
+    "key": [
+      "/id"
+    ]
+  }
+

--- a/source-mysql/.snapshots/TestAlterTable_AddUnsignedColumn-discover2
+++ b/source-mysql/.snapshots/TestAlterTable_AddUnsignedColumn-discover2
@@ -24,6 +24,7 @@ Binding 0:
               "type": "integer"
             },
             "uintval": {
+              "minimum": 0,
               "type": [
                 "integer",
                 "null"

--- a/source-mysql/.snapshots/TestAlterTable_AddUnsignedColumn-discover2
+++ b/source-mysql/.snapshots/TestAlterTable_AddUnsignedColumn-discover2
@@ -1,0 +1,136 @@
+Binding 0:
+{
+    "recommended_name": "test_altertable_addunsignedcolumn_57413089",
+    "resource_config_json": {
+      "namespace": "test",
+      "stream": "AlterTable_AddUnsignedColumn_57413089"
+    },
+    "document_schema_json": {
+      "$defs": {
+        "TestAlterTable_AddUnsignedColumn_57413089": {
+          "type": "object",
+          "required": [
+            "id"
+          ],
+          "$anchor": "TestAlterTable_AddUnsignedColumn_57413089",
+          "properties": {
+            "data": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "id": {
+              "type": "integer"
+            },
+            "uintval": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            }
+          }
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "_meta": {
+                "properties": {
+                  "op": {
+                    "const": "d"
+                  }
+                }
+              }
+            }
+          },
+          "then": {
+            "reduce": {
+              "delete": true,
+              "strategy": "merge"
+            }
+          },
+          "else": {
+            "reduce": {
+              "strategy": "merge"
+            }
+          },
+          "required": [
+            "_meta"
+          ],
+          "properties": {
+            "_meta": {
+              "type": "object",
+              "required": [
+                "op",
+                "source"
+              ],
+              "properties": {
+                "before": {
+                  "$ref": "#TestAlterTable_AddUnsignedColumn_57413089",
+                  "description": "Record state immediately before this change was applied.",
+                  "reduce": {
+                    "strategy": "firstWriteWins"
+                  }
+                },
+                "op": {
+                  "enum": [
+                    "c",
+                    "d",
+                    "u"
+                  ],
+                  "description": "Change operation type: 'c' Create/Insert, 'u' Update, 'd' Delete."
+                },
+                "source": {
+                  "$id": "https://github.com/estuary/connectors/source-mysql/mysql-source-info",
+                  "properties": {
+                    "ts_ms": {
+                      "type": "integer",
+                      "description": "Unix timestamp (in millis) at which this event was recorded by the database."
+                    },
+                    "schema": {
+                      "type": "string",
+                      "description": "Database schema (namespace) of the event."
+                    },
+                    "snapshot": {
+                      "type": "boolean",
+                      "description": "Snapshot is true if the record was produced from an initial table backfill and unset if produced from the replication log."
+                    },
+                    "table": {
+                      "type": "string",
+                      "description": "Database table of the event."
+                    },
+                    "cursor": {
+                      "type": "string",
+                      "description": "Cursor value representing the current position in the binlog."
+                    },
+                    "txid": {
+                      "type": "string",
+                      "description": "The global transaction identifier associated with a change by MySQL. Only set if GTIDs are enabled."
+                    }
+                  },
+                  "type": "object",
+                  "required": [
+                    "schema",
+                    "table",
+                    "cursor"
+                  ]
+                }
+              },
+              "reduce": {
+                "strategy": "merge"
+              }
+            }
+          }
+        },
+        {
+          "$ref": "#TestAlterTable_AddUnsignedColumn_57413089"
+        }
+      ]
+    },
+    "key": [
+      "/id"
+    ]
+  }
+

--- a/source-mysql/.snapshots/TestAlterTable_AddUnsignedColumn-init
+++ b/source-mysql/.snapshots/TestAlterTable_AddUnsignedColumn-init
@@ -1,0 +1,10 @@
+# ================================
+# Collection "acmeCo/test/test_altertable_addunsignedcolumn_57413089": 2 Documents
+# ================================
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"AlterTable_AddUnsignedColumn_57413089","cursor":"backfill:0"}},"data":"aaa","id":1}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"AlterTable_AddUnsignedColumn_57413089","cursor":"backfill:1"}},"data":"bbb","id":2}
+# ================================
+# Final State Checkpoint
+# ================================
+{"bindingStateV1":{"test%2FAlterTable_AddUnsignedColumn_57413089":{"backfilled":2,"key_columns":["id"],"metadata":{"schema":{"columns":["id","data"],"types":{"data":"text","id":{"type":"int"}}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
+

--- a/source-mysql/.snapshots/TestAlterTable_AddUnsignedColumn-modified
+++ b/source-mysql/.snapshots/TestAlterTable_AddUnsignedColumn-modified
@@ -1,0 +1,10 @@
+# ================================
+# Collection "acmeCo/test/test_altertable_addunsignedcolumn_57413089": 2 Documents
+# ================================
+{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"AlterTable_AddUnsignedColumn_57413089","cursor":"binlog.000123:56789:123","txid":"11111111-1111-1111-1111-111111111111:111"}},"data":"eee","id":3,"uintval":17777777777777777777}
+{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"AlterTable_AddUnsignedColumn_57413089","cursor":"binlog.000123:56789:123","txid":"11111111-1111-1111-1111-111111111111:111"}},"data":"fff","id":4,"uintval":18000000000000000000}
+# ================================
+# Final State Checkpoint
+# ================================
+{"bindingStateV1":{"test%2FAlterTable_AddUnsignedColumn_57413089":{"backfilled":2,"key_columns":["id"],"metadata":{"schema":{"columns":["id","data","uintval"],"types":{"data":"text","id":{"type":"int"},"uintval":{"type":"bigint","unsigned":true}}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
+

--- a/source-mysql/.snapshots/TestAlterTable_AddUnsignedColumn-rebackfilled
+++ b/source-mysql/.snapshots/TestAlterTable_AddUnsignedColumn-rebackfilled
@@ -1,0 +1,12 @@
+# ================================
+# Collection "acmeCo/test/test_altertable_addunsignedcolumn_57413089": 4 Documents
+# ================================
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"AlterTable_AddUnsignedColumn_57413089","cursor":"backfill:0"}},"data":"aaa","id":1,"uintval":null}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"AlterTable_AddUnsignedColumn_57413089","cursor":"backfill:1"}},"data":"bbb","id":2,"uintval":null}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"AlterTable_AddUnsignedColumn_57413089","cursor":"backfill:2"}},"data":"eee","id":3,"uintval":17777777777777777777}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"AlterTable_AddUnsignedColumn_57413089","cursor":"backfill:3"}},"data":"fff","id":4,"uintval":18000000000000000000}
+# ================================
+# Final State Checkpoint
+# ================================
+{"bindingStateV1":{"test%2FAlterTable_AddUnsignedColumn_57413089":{"backfilled":4,"key_columns":["id"],"metadata":{"schema":{"columns":["id","data","uintval"],"types":{"data":"text","id":{"type":"int"},"uintval":{"type":"bigint","unsigned":true}}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
+

--- a/source-mysql/.snapshots/TestAlterTable_ChangeColumn-capture1
+++ b/source-mysql/.snapshots/TestAlterTable_ChangeColumn-capture1
@@ -6,5 +6,5 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"test%2FAlterTable_ChangeColumn_27484562":{"backfilled":2,"key_columns":["id"],"metadata":{"schema":{"columns":["id","data_two"],"types":{"data_two":"varchar","id":"int"}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
+{"bindingStateV1":{"test%2FAlterTable_ChangeColumn_27484562":{"backfilled":2,"key_columns":["id"],"metadata":{"schema":{"columns":["id","data_two"],"types":{"data_two":"varchar","id":{"type":"int"}}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
 

--- a/source-mysql/.snapshots/TestAlterTable_ChangeColumn-capture2
+++ b/source-mysql/.snapshots/TestAlterTable_ChangeColumn-capture2
@@ -6,5 +6,5 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"test%2FAlterTable_ChangeColumn_27484562":{"backfilled":2,"key_columns":["id"],"metadata":{"schema":{"columns":["data_three","id"],"types":{"data_three":"varchar","id":"int"}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
+{"bindingStateV1":{"test%2FAlterTable_ChangeColumn_27484562":{"backfilled":2,"key_columns":["id"],"metadata":{"schema":{"columns":["data_three","id"],"types":{"data_three":"varchar","id":{"type":"int"}}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
 

--- a/source-mysql/.snapshots/TestAlterTable_ChangeColumn-capture3
+++ b/source-mysql/.snapshots/TestAlterTable_ChangeColumn-capture3
@@ -6,5 +6,5 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"test%2FAlterTable_ChangeColumn_27484562":{"backfilled":2,"key_columns":["id"],"metadata":{"schema":{"columns":["id","data"],"types":{"data":"text","id":"int"}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
+{"bindingStateV1":{"test%2FAlterTable_ChangeColumn_27484562":{"backfilled":2,"key_columns":["id"],"metadata":{"schema":{"columns":["id","data"],"types":{"data":"text","id":{"type":"int"}}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
 

--- a/source-mysql/.snapshots/TestAlterTable_ChangeColumn-init
+++ b/source-mysql/.snapshots/TestAlterTable_ChangeColumn-init
@@ -6,5 +6,5 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"test%2FAlterTable_ChangeColumn_27484562":{"backfilled":2,"key_columns":["id"],"metadata":{"schema":{"columns":["id","data"],"types":{"data":"text","id":"int"}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
+{"bindingStateV1":{"test%2FAlterTable_ChangeColumn_27484562":{"backfilled":2,"key_columns":["id"],"metadata":{"schema":{"columns":["id","data"],"types":{"data":"text","id":{"type":"int"}}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
 

--- a/source-mysql/.snapshots/TestAlterTable_DropColumn-init
+++ b/source-mysql/.snapshots/TestAlterTable_DropColumn-init
@@ -6,5 +6,5 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"test%2FAlterTable_DropColumn_44468116":{"backfilled":2,"key_columns":["id"],"metadata":{"schema":{"columns":["id","data"],"types":{"data":"text","id":"int"}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
+{"bindingStateV1":{"test%2FAlterTable_DropColumn_44468116":{"backfilled":2,"key_columns":["id"],"metadata":{"schema":{"columns":["id","data"],"types":{"data":"text","id":{"type":"int"}}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
 

--- a/source-mysql/.snapshots/TestAlterTable_DropColumn-restart
+++ b/source-mysql/.snapshots/TestAlterTable_DropColumn-restart
@@ -6,5 +6,5 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"test%2FAlterTable_DropColumn_44468116":{"backfilled":2,"key_columns":["id"],"metadata":{"schema":{"columns":["id","other_data"],"types":{"id":"int","other_data":"text"}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
+{"bindingStateV1":{"test%2FAlterTable_DropColumn_44468116":{"backfilled":2,"key_columns":["id"],"metadata":{"schema":{"columns":["id","other_data"],"types":{"id":{"type":"int"},"other_data":"text"}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
 

--- a/source-mysql/.snapshots/TestAlterTable_DropColumn-stream
+++ b/source-mysql/.snapshots/TestAlterTable_DropColumn-stream
@@ -6,5 +6,5 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"test%2FAlterTable_DropColumn_44468116":{"backfilled":2,"key_columns":["id"],"metadata":{"schema":{"columns":["id","other_data"],"types":{"id":"int","other_data":"text"}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
+{"bindingStateV1":{"test%2FAlterTable_DropColumn_44468116":{"backfilled":2,"key_columns":["id"],"metadata":{"schema":{"columns":["id","other_data"],"types":{"id":{"type":"int"},"other_data":"text"}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
 

--- a/source-mysql/.snapshots/TestAlterTable_ModifyColumn-capture1
+++ b/source-mysql/.snapshots/TestAlterTable_ModifyColumn-capture1
@@ -6,5 +6,5 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"test%2FAlterTable_ModifyColumn_13419621":{"backfilled":2,"key_columns":["id"],"metadata":{"schema":{"columns":["id","tag","data"],"types":{"data":"text","id":"int","tag":"varchar"}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
+{"bindingStateV1":{"test%2FAlterTable_ModifyColumn_13419621":{"backfilled":2,"key_columns":["id"],"metadata":{"schema":{"columns":["id","tag","data"],"types":{"data":"text","id":{"type":"int"},"tag":"varchar"}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
 

--- a/source-mysql/.snapshots/TestAlterTable_ModifyColumn-capture2
+++ b/source-mysql/.snapshots/TestAlterTable_ModifyColumn-capture2
@@ -6,5 +6,5 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"test%2FAlterTable_ModifyColumn_13419621":{"backfilled":2,"key_columns":["id"],"metadata":{"schema":{"columns":["tag","id","data"],"types":{"data":"text","id":"int","tag":"varchar"}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
+{"bindingStateV1":{"test%2FAlterTable_ModifyColumn_13419621":{"backfilled":2,"key_columns":["id"],"metadata":{"schema":{"columns":["tag","id","data"],"types":{"data":"text","id":{"type":"int"},"tag":"varchar"}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
 

--- a/source-mysql/.snapshots/TestAlterTable_ModifyColumn-capture3
+++ b/source-mysql/.snapshots/TestAlterTable_ModifyColumn-capture3
@@ -6,5 +6,5 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"test%2FAlterTable_ModifyColumn_13419621":{"backfilled":2,"key_columns":["id"],"metadata":{"schema":{"columns":["id","data","tag"],"types":{"data":"text","id":"int","tag":"text"}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
+{"bindingStateV1":{"test%2FAlterTable_ModifyColumn_13419621":{"backfilled":2,"key_columns":["id"],"metadata":{"schema":{"columns":["id","data","tag"],"types":{"data":"text","id":{"type":"int"},"tag":"text"}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
 

--- a/source-mysql/.snapshots/TestAlterTable_ModifyColumn-capture4
+++ b/source-mysql/.snapshots/TestAlterTable_ModifyColumn-capture4
@@ -6,5 +6,5 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"test%2FAlterTable_ModifyColumn_13419621":{"backfilled":2,"key_columns":["id"],"metadata":{"schema":{"columns":["id","tag","data"],"types":{"data":"text","id":"int","tag":"text"}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
+{"bindingStateV1":{"test%2FAlterTable_ModifyColumn_13419621":{"backfilled":2,"key_columns":["id"],"metadata":{"schema":{"columns":["id","tag","data"],"types":{"data":"text","id":{"type":"int"},"tag":"text"}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
 

--- a/source-mysql/.snapshots/TestAlterTable_ModifyColumn-init
+++ b/source-mysql/.snapshots/TestAlterTable_ModifyColumn-init
@@ -6,5 +6,5 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"test%2FAlterTable_ModifyColumn_13419621":{"backfilled":2,"key_columns":["id"],"metadata":{"schema":{"columns":["id","tag","data"],"types":{"data":"text","id":"int","tag":"text"}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
+{"bindingStateV1":{"test%2FAlterTable_ModifyColumn_13419621":{"backfilled":2,"key_columns":["id"],"metadata":{"schema":{"columns":["id","tag","data"],"types":{"data":"text","id":{"type":"int"},"tag":"text"}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
 

--- a/source-mysql/.snapshots/TestAlterTable_MultipleAlterations-altered
+++ b/source-mysql/.snapshots/TestAlterTable_MultipleAlterations-altered
@@ -6,5 +6,5 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"test%2FAlterTable_MultipleAlterations_95139670":{"backfilled":2,"key_columns":["id"],"metadata":{"schema":{"columns":["extra_first","id","extra_after_id","extra_end"],"types":{"extra_after_id":"text","extra_end":"text","extra_first":"text","id":"int"}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
+{"bindingStateV1":{"test%2FAlterTable_MultipleAlterations_95139670":{"backfilled":2,"key_columns":["id"],"metadata":{"schema":{"columns":["extra_first","id","extra_after_id","extra_end"],"types":{"extra_after_id":"text","extra_end":"text","extra_first":"text","id":{"type":"int"}}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
 

--- a/source-mysql/.snapshots/TestAlterTable_MultipleAlterations-init
+++ b/source-mysql/.snapshots/TestAlterTable_MultipleAlterations-init
@@ -6,5 +6,5 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"test%2FAlterTable_MultipleAlterations_95139670":{"backfilled":2,"key_columns":["id"],"metadata":{"schema":{"columns":["id","data"],"types":{"data":"text","id":"int"}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
+{"bindingStateV1":{"test%2FAlterTable_MultipleAlterations_95139670":{"backfilled":2,"key_columns":["id"],"metadata":{"schema":{"columns":["id","data"],"types":{"data":"text","id":{"type":"int"}}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
 

--- a/source-mysql/.snapshots/TestAlterTable_RenameColumn-capture1
+++ b/source-mysql/.snapshots/TestAlterTable_RenameColumn-capture1
@@ -6,5 +6,5 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"test%2FAlterTable_RenameColumn_73330825":{"backfilled":2,"key_columns":["id"],"metadata":{"schema":{"columns":["id","data_two"],"types":{"data_two":"text","id":"int"}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
+{"bindingStateV1":{"test%2FAlterTable_RenameColumn_73330825":{"backfilled":2,"key_columns":["id"],"metadata":{"schema":{"columns":["id","data_two"],"types":{"data_two":"text","id":{"type":"int"}}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
 

--- a/source-mysql/.snapshots/TestAlterTable_RenameColumn-capture2
+++ b/source-mysql/.snapshots/TestAlterTable_RenameColumn-capture2
@@ -6,5 +6,5 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"test%2FAlterTable_RenameColumn_73330825":{"backfilled":2,"key_columns":["id"],"metadata":{"schema":{"columns":["id","data"],"types":{"data":"text","id":"int"}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
+{"bindingStateV1":{"test%2FAlterTable_RenameColumn_73330825":{"backfilled":2,"key_columns":["id"],"metadata":{"schema":{"columns":["id","data"],"types":{"data":"text","id":{"type":"int"}}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
 

--- a/source-mysql/.snapshots/TestAlterTable_RenameColumn-init
+++ b/source-mysql/.snapshots/TestAlterTable_RenameColumn-init
@@ -6,5 +6,5 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"test%2FAlterTable_RenameColumn_73330825":{"backfilled":2,"key_columns":["id"],"metadata":{"schema":{"columns":["id","data"],"types":{"data":"text","id":"int"}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
+{"bindingStateV1":{"test%2FAlterTable_RenameColumn_73330825":{"backfilled":2,"key_columns":["id"],"metadata":{"schema":{"columns":["id","data"],"types":{"data":"text","id":{"type":"int"}}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
 

--- a/source-mysql/.snapshots/TestComplexDataset-init
+++ b/source-mysql/.snapshots/TestComplexDataset-init
@@ -17,7 +17,7 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"test%2FComplexDataset_56015963":{"backfilled":10,"key_columns":["year","state"],"metadata":{"schema":{"columns":["year","state","fullname","population"],"types":{"fullname":"varchar","population":"int","state":"varchar","year":"int"}}},"mode":"Backfill","scanned":"FgdsAUdBAA=="}},"cursor":"binlog.000123:56789"}
+{"bindingStateV1":{"test%2FComplexDataset_56015963":{"backfilled":10,"key_columns":["year","state"],"metadata":{"schema":{"columns":["year","state","fullname","population"],"types":{"fullname":"varchar","population":{"type":"int"},"state":"varchar","year":{"type":"int"}}}},"mode":"UnfilteredBackfill","scanned":"FgdsAUdBAA=="}},"cursor":"binlog.000123:56789"}
 
 
 ####################################
@@ -39,7 +39,7 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"test%2FComplexDataset_56015963":{"backfilled":20,"key_columns":["year","state"],"metadata":{"schema":{"columns":["year","state","fullname","population"],"types":{"fullname":"varchar","population":"int","state":"varchar","year":"int"}}},"mode":"Backfill","scanned":"FgdsAU1FAA=="}},"cursor":"binlog.000123:56789"}
+{"bindingStateV1":{"test%2FComplexDataset_56015963":{"backfilled":20,"key_columns":["year","state"],"metadata":{"schema":{"columns":["year","state","fullname","population"],"types":{"fullname":"varchar","population":{"type":"int"},"state":"varchar","year":{"type":"int"}}}},"mode":"UnfilteredBackfill","scanned":"FgdsAU1FAA=="}},"cursor":"binlog.000123:56789"}
 
 
 ####################################
@@ -61,7 +61,7 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"test%2FComplexDataset_56015963":{"backfilled":30,"key_columns":["year","state"],"metadata":{"schema":{"columns":["year","state","fullname","population"],"types":{"fullname":"varchar","population":"int","state":"varchar","year":"int"}}},"mode":"Backfill","scanned":"FgdsAU5KAA=="}},"cursor":"binlog.000123:56789"}
+{"bindingStateV1":{"test%2FComplexDataset_56015963":{"backfilled":30,"key_columns":["year","state"],"metadata":{"schema":{"columns":["year","state","fullname","population"],"types":{"fullname":"varchar","population":{"type":"int"},"state":"varchar","year":{"type":"int"}}}},"mode":"UnfilteredBackfill","scanned":"FgdsAU5KAA=="}},"cursor":"binlog.000123:56789"}
 
 
 ####################################
@@ -83,7 +83,7 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"test%2FComplexDataset_56015963":{"backfilled":40,"key_columns":["year","state"],"metadata":{"schema":{"columns":["year","state","fullname","population"],"types":{"fullname":"varchar","population":"int","state":"varchar","year":"int"}}},"mode":"Backfill","scanned":"FgdsAVNEAA=="}},"cursor":"binlog.000123:56789"}
+{"bindingStateV1":{"test%2FComplexDataset_56015963":{"backfilled":40,"key_columns":["year","state"],"metadata":{"schema":{"columns":["year","state","fullname","population"],"types":{"fullname":"varchar","population":{"type":"int"},"state":"varchar","year":{"type":"int"}}}},"mode":"UnfilteredBackfill","scanned":"FgdsAVNEAA=="}},"cursor":"binlog.000123:56789"}
 
 
 ####################################
@@ -105,7 +105,7 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"test%2FComplexDataset_56015963":{"backfilled":50,"key_columns":["year","state"],"metadata":{"schema":{"columns":["year","state","fullname","population"],"types":{"fullname":"varchar","population":"int","state":"varchar","year":"int"}}},"mode":"Backfill","scanned":"FgeAAUFMAA=="}},"cursor":"binlog.000123:56789"}
+{"bindingStateV1":{"test%2FComplexDataset_56015963":{"backfilled":50,"key_columns":["year","state"],"metadata":{"schema":{"columns":["year","state","fullname","population"],"types":{"fullname":"varchar","population":{"type":"int"},"state":"varchar","year":{"type":"int"}}}},"mode":"UnfilteredBackfill","scanned":"FgeAAUFMAA=="}},"cursor":"binlog.000123:56789"}
 
 
 ####################################
@@ -127,7 +127,7 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"test%2FComplexDataset_56015963":{"backfilled":60,"key_columns":["year","state"],"metadata":{"schema":{"columns":["year","state","fullname","population"],"types":{"fullname":"varchar","population":"int","state":"varchar","year":"int"}}},"mode":"Backfill","scanned":"FgeAAUlBAA=="}},"cursor":"binlog.000123:56789"}
+{"bindingStateV1":{"test%2FComplexDataset_56015963":{"backfilled":60,"key_columns":["year","state"],"metadata":{"schema":{"columns":["year","state","fullname","population"],"types":{"fullname":"varchar","population":{"type":"int"},"state":"varchar","year":{"type":"int"}}}},"mode":"UnfilteredBackfill","scanned":"FgeAAUlBAA=="}},"cursor":"binlog.000123:56789"}
 
 
 ####################################
@@ -149,7 +149,7 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"test%2FComplexDataset_56015963":{"backfilled":70,"key_columns":["year","state"],"metadata":{"schema":{"columns":["year","state","fullname","population"],"types":{"fullname":"varchar","population":"int","state":"varchar","year":"int"}}},"mode":"Backfill","scanned":"FgeAAU1JAA=="}},"cursor":"binlog.000123:56789"}
+{"bindingStateV1":{"test%2FComplexDataset_56015963":{"backfilled":70,"key_columns":["year","state"],"metadata":{"schema":{"columns":["year","state","fullname","population"],"types":{"fullname":"varchar","population":{"type":"int"},"state":"varchar","year":{"type":"int"}}}},"mode":"UnfilteredBackfill","scanned":"FgeAAU1JAA=="}},"cursor":"binlog.000123:56789"}
 
 
 ####################################
@@ -171,7 +171,7 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"test%2FComplexDataset_56015963":{"backfilled":80,"key_columns":["year","state"],"metadata":{"schema":{"columns":["year","state","fullname","population"],"types":{"fullname":"varchar","population":"int","state":"varchar","year":"int"}}},"mode":"Backfill","scanned":"FgeAAU5NAA=="}},"cursor":"binlog.000123:56789"}
+{"bindingStateV1":{"test%2FComplexDataset_56015963":{"backfilled":80,"key_columns":["year","state"],"metadata":{"schema":{"columns":["year","state","fullname","population"],"types":{"fullname":"varchar","population":{"type":"int"},"state":"varchar","year":{"type":"int"}}}},"mode":"UnfilteredBackfill","scanned":"FgeAAU5NAA=="}},"cursor":"binlog.000123:56789"}
 
 
 ####################################
@@ -193,7 +193,7 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"test%2FComplexDataset_56015963":{"backfilled":90,"key_columns":["year","state"],"metadata":{"schema":{"columns":["year","state","fullname","population"],"types":{"fullname":"varchar","population":"int","state":"varchar","year":"int"}}},"mode":"Backfill","scanned":"FgeAAVROAA=="}},"cursor":"binlog.000123:56789"}
+{"bindingStateV1":{"test%2FComplexDataset_56015963":{"backfilled":90,"key_columns":["year","state"],"metadata":{"schema":{"columns":["year","state","fullname","population"],"types":{"fullname":"varchar","population":{"type":"int"},"state":"varchar","year":{"type":"int"}}}},"mode":"UnfilteredBackfill","scanned":"FgeAAVROAA=="}},"cursor":"binlog.000123:56789"}
 
 
 ####################################
@@ -215,7 +215,7 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"test%2FComplexDataset_56015963":{"backfilled":100,"key_columns":["year","state"],"metadata":{"schema":{"columns":["year","state","fullname","population"],"types":{"fullname":"varchar","population":"int","state":"varchar","year":"int"}}},"mode":"Backfill","scanned":"FgeUAUFSAA=="}},"cursor":"binlog.000123:56789"}
+{"bindingStateV1":{"test%2FComplexDataset_56015963":{"backfilled":100,"key_columns":["year","state"],"metadata":{"schema":{"columns":["year","state","fullname","population"],"types":{"fullname":"varchar","population":{"type":"int"},"state":"varchar","year":{"type":"int"}}}},"mode":"UnfilteredBackfill","scanned":"FgeUAUFSAA=="}},"cursor":"binlog.000123:56789"}
 
 
 ####################################
@@ -237,7 +237,7 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"test%2FComplexDataset_56015963":{"backfilled":110,"key_columns":["year","state"],"metadata":{"schema":{"columns":["year","state","fullname","population"],"types":{"fullname":"varchar","population":"int","state":"varchar","year":"int"}}},"mode":"Backfill","scanned":"FgeUAUlEAA=="}},"cursor":"binlog.000123:56789"}
+{"bindingStateV1":{"test%2FComplexDataset_56015963":{"backfilled":110,"key_columns":["year","state"],"metadata":{"schema":{"columns":["year","state","fullname","population"],"types":{"fullname":"varchar","population":{"type":"int"},"state":"varchar","year":{"type":"int"}}}},"mode":"UnfilteredBackfill","scanned":"FgeUAUlEAA=="}},"cursor":"binlog.000123:56789"}
 
 
 ####################################
@@ -259,7 +259,7 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"test%2FComplexDataset_56015963":{"backfilled":120,"key_columns":["year","state"],"metadata":{"schema":{"columns":["year","state","fullname","population"],"types":{"fullname":"varchar","population":"int","state":"varchar","year":"int"}}},"mode":"Backfill","scanned":"FgeUAU1OAA=="}},"cursor":"binlog.000123:56789"}
+{"bindingStateV1":{"test%2FComplexDataset_56015963":{"backfilled":120,"key_columns":["year","state"],"metadata":{"schema":{"columns":["year","state","fullname","population"],"types":{"fullname":"varchar","population":{"type":"int"},"state":"varchar","year":{"type":"int"}}}},"mode":"UnfilteredBackfill","scanned":"FgeUAU1OAA=="}},"cursor":"binlog.000123:56789"}
 
 
 ####################################
@@ -281,7 +281,7 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"test%2FComplexDataset_56015963":{"backfilled":130,"key_columns":["year","state"],"metadata":{"schema":{"columns":["year","state","fullname","population"],"types":{"fullname":"varchar","population":"int","state":"varchar","year":"int"}}},"mode":"Backfill","scanned":"FgeUAU5WAA=="}},"cursor":"binlog.000123:56789"}
+{"bindingStateV1":{"test%2FComplexDataset_56015963":{"backfilled":130,"key_columns":["year","state"],"metadata":{"schema":{"columns":["year","state","fullname","population"],"types":{"fullname":"varchar","population":{"type":"int"},"state":"varchar","year":{"type":"int"}}}},"mode":"UnfilteredBackfill","scanned":"FgeUAU5WAA=="}},"cursor":"binlog.000123:56789"}
 
 
 ####################################
@@ -303,7 +303,7 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"test%2FComplexDataset_56015963":{"backfilled":140,"key_columns":["year","state"],"metadata":{"schema":{"columns":["year","state","fullname","population"],"types":{"fullname":"varchar","population":"int","state":"varchar","year":"int"}}},"mode":"Backfill","scanned":"FgeUAVRYAA=="}},"cursor":"binlog.000123:56789"}
+{"bindingStateV1":{"test%2FComplexDataset_56015963":{"backfilled":140,"key_columns":["year","state"],"metadata":{"schema":{"columns":["year","state","fullname","population"],"types":{"fullname":"varchar","population":{"type":"int"},"state":"varchar","year":{"type":"int"}}}},"mode":"UnfilteredBackfill","scanned":"FgeUAVRYAA=="}},"cursor":"binlog.000123:56789"}
 
 
 ####################################
@@ -325,7 +325,7 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"test%2FComplexDataset_56015963":{"backfilled":150,"key_columns":["year","state"],"metadata":{"schema":{"columns":["year","state","fullname","population"],"types":{"fullname":"varchar","population":"int","state":"varchar","year":"int"}}},"mode":"Backfill","scanned":"FgeoAUFSAA=="}},"cursor":"binlog.000123:56789"}
+{"bindingStateV1":{"test%2FComplexDataset_56015963":{"backfilled":150,"key_columns":["year","state"],"metadata":{"schema":{"columns":["year","state","fullname","population"],"types":{"fullname":"varchar","population":{"type":"int"},"state":"varchar","year":{"type":"int"}}}},"mode":"UnfilteredBackfill","scanned":"FgeoAUFSAA=="}},"cursor":"binlog.000123:56789"}
 
 
 ####################################
@@ -347,7 +347,7 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"test%2FComplexDataset_56015963":{"backfilled":160,"key_columns":["year","state"],"metadata":{"schema":{"columns":["year","state","fullname","population"],"types":{"fullname":"varchar","population":"int","state":"varchar","year":"int"}}},"mode":"Backfill","scanned":"FgeoAUlBAA=="}},"cursor":"binlog.000123:56789"}
+{"bindingStateV1":{"test%2FComplexDataset_56015963":{"backfilled":160,"key_columns":["year","state"],"metadata":{"schema":{"columns":["year","state","fullname","population"],"types":{"fullname":"varchar","population":{"type":"int"},"state":"varchar","year":{"type":"int"}}}},"mode":"UnfilteredBackfill","scanned":"FgeoAUlBAA=="}},"cursor":"binlog.000123:56789"}
 
 
 ####################################
@@ -369,7 +369,7 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"test%2FComplexDataset_56015963":{"backfilled":170,"key_columns":["year","state"],"metadata":{"schema":{"columns":["year","state","fullname","population"],"types":{"fullname":"varchar","population":"int","state":"varchar","year":"int"}}},"mode":"Backfill","scanned":"FgeoAU1JAA=="}},"cursor":"binlog.000123:56789"}
+{"bindingStateV1":{"test%2FComplexDataset_56015963":{"backfilled":170,"key_columns":["year","state"],"metadata":{"schema":{"columns":["year","state","fullname","population"],"types":{"fullname":"varchar","population":{"type":"int"},"state":"varchar","year":{"type":"int"}}}},"mode":"UnfilteredBackfill","scanned":"FgeoAU1JAA=="}},"cursor":"binlog.000123:56789"}
 
 
 ####################################
@@ -391,7 +391,7 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"test%2FComplexDataset_56015963":{"backfilled":180,"key_columns":["year","state"],"metadata":{"schema":{"columns":["year","state","fullname","population"],"types":{"fullname":"varchar","population":"int","state":"varchar","year":"int"}}},"mode":"Backfill","scanned":"FgeoAU5NAA=="}},"cursor":"binlog.000123:56789"}
+{"bindingStateV1":{"test%2FComplexDataset_56015963":{"backfilled":180,"key_columns":["year","state"],"metadata":{"schema":{"columns":["year","state","fullname","population"],"types":{"fullname":"varchar","population":{"type":"int"},"state":"varchar","year":{"type":"int"}}}},"mode":"UnfilteredBackfill","scanned":"FgeoAU5NAA=="}},"cursor":"binlog.000123:56789"}
 
 
 ####################################
@@ -413,7 +413,7 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"test%2FComplexDataset_56015963":{"backfilled":190,"key_columns":["year","state"],"metadata":{"schema":{"columns":["year","state","fullname","population"],"types":{"fullname":"varchar","population":"int","state":"varchar","year":"int"}}},"mode":"Backfill","scanned":"FgeoAVROAA=="}},"cursor":"binlog.000123:56789"}
+{"bindingStateV1":{"test%2FComplexDataset_56015963":{"backfilled":190,"key_columns":["year","state"],"metadata":{"schema":{"columns":["year","state","fullname","population"],"types":{"fullname":"varchar","population":{"type":"int"},"state":"varchar","year":{"type":"int"}}}},"mode":"UnfilteredBackfill","scanned":"FgeoAVROAA=="}},"cursor":"binlog.000123:56789"}
 
 
 ####################################
@@ -435,7 +435,7 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"test%2FComplexDataset_56015963":{"backfilled":200,"key_columns":["year","state"],"metadata":{"schema":{"columns":["year","state","fullname","population"],"types":{"fullname":"varchar","population":"int","state":"varchar","year":"int"}}},"mode":"Backfill","scanned":"Fge8AUFMAA=="}},"cursor":"binlog.000123:56789"}
+{"bindingStateV1":{"test%2FComplexDataset_56015963":{"backfilled":200,"key_columns":["year","state"],"metadata":{"schema":{"columns":["year","state","fullname","population"],"types":{"fullname":"varchar","population":{"type":"int"},"state":"varchar","year":{"type":"int"}}}},"mode":"UnfilteredBackfill","scanned":"Fge8AUFMAA=="}},"cursor":"binlog.000123:56789"}
 
 
 ####################################
@@ -457,7 +457,7 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"test%2FComplexDataset_56015963":{"backfilled":210,"key_columns":["year","state"],"metadata":{"schema":{"columns":["year","state","fullname","population"],"types":{"fullname":"varchar","population":"int","state":"varchar","year":"int"}}},"mode":"Backfill","scanned":"Fge8AUhJAA=="}},"cursor":"binlog.000123:56789"}
+{"bindingStateV1":{"test%2FComplexDataset_56015963":{"backfilled":210,"key_columns":["year","state"],"metadata":{"schema":{"columns":["year","state","fullname","population"],"types":{"fullname":"varchar","population":{"type":"int"},"state":"varchar","year":{"type":"int"}}}},"mode":"UnfilteredBackfill","scanned":"Fge8AUhJAA=="}},"cursor":"binlog.000123:56789"}
 
 
 ####################################
@@ -479,7 +479,7 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"test%2FComplexDataset_56015963":{"backfilled":220,"key_columns":["year","state"],"metadata":{"schema":{"columns":["year","state","fullname","population"],"types":{"fullname":"varchar","population":"int","state":"varchar","year":"int"}}},"mode":"Backfill","scanned":"Fge8AU1FAA=="}},"cursor":"binlog.000123:56789"}
+{"bindingStateV1":{"test%2FComplexDataset_56015963":{"backfilled":220,"key_columns":["year","state"],"metadata":{"schema":{"columns":["year","state","fullname","population"],"types":{"fullname":"varchar","population":{"type":"int"},"state":"varchar","year":{"type":"int"}}}},"mode":"UnfilteredBackfill","scanned":"Fge8AU1FAA=="}},"cursor":"binlog.000123:56789"}
 
 
 ####################################
@@ -501,7 +501,7 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"test%2FComplexDataset_56015963":{"backfilled":230,"key_columns":["year","state"],"metadata":{"schema":{"columns":["year","state","fullname","population"],"types":{"fullname":"varchar","population":"int","state":"varchar","year":"int"}}},"mode":"Backfill","scanned":"Fge8AU5KAA=="}},"cursor":"binlog.000123:56789"}
+{"bindingStateV1":{"test%2FComplexDataset_56015963":{"backfilled":230,"key_columns":["year","state"],"metadata":{"schema":{"columns":["year","state","fullname","population"],"types":{"fullname":"varchar","population":{"type":"int"},"state":"varchar","year":{"type":"int"}}}},"mode":"UnfilteredBackfill","scanned":"Fge8AU5KAA=="}},"cursor":"binlog.000123:56789"}
 
 
 ####################################
@@ -523,7 +523,7 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"test%2FComplexDataset_56015963":{"backfilled":240,"key_columns":["year","state"],"metadata":{"schema":{"columns":["year","state","fullname","population"],"types":{"fullname":"varchar","population":"int","state":"varchar","year":"int"}}},"mode":"Backfill","scanned":"Fge8AVNEAA=="}},"cursor":"binlog.000123:56789"}
+{"bindingStateV1":{"test%2FComplexDataset_56015963":{"backfilled":240,"key_columns":["year","state"],"metadata":{"schema":{"columns":["year","state","fullname","population"],"types":{"fullname":"varchar","population":{"type":"int"},"state":"varchar","year":{"type":"int"}}}},"mode":"UnfilteredBackfill","scanned":"Fge8AVNEAA=="}},"cursor":"binlog.000123:56789"}
 
 
 ####################################
@@ -545,7 +545,7 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"test%2FComplexDataset_56015963":{"backfilled":250,"key_columns":["year","state"],"metadata":{"schema":{"columns":["year","state","fullname","population"],"types":{"fullname":"varchar","population":"int","state":"varchar","year":"int"}}},"mode":"Backfill","scanned":"FgfQAUFLAA=="}},"cursor":"binlog.000123:56789"}
+{"bindingStateV1":{"test%2FComplexDataset_56015963":{"backfilled":250,"key_columns":["year","state"],"metadata":{"schema":{"columns":["year","state","fullname","population"],"types":{"fullname":"varchar","population":{"type":"int"},"state":"varchar","year":{"type":"int"}}}},"mode":"UnfilteredBackfill","scanned":"FgfQAUFLAA=="}},"cursor":"binlog.000123:56789"}
 
 
 ####################################
@@ -567,7 +567,7 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"test%2FComplexDataset_56015963":{"backfilled":260,"key_columns":["year","state"],"metadata":{"schema":{"columns":["year","state","fullname","population"],"types":{"fullname":"varchar","population":"int","state":"varchar","year":"int"}}},"mode":"Backfill","scanned":"FgfQAUdBAA=="}},"cursor":"binlog.000123:56789"}
+{"bindingStateV1":{"test%2FComplexDataset_56015963":{"backfilled":260,"key_columns":["year","state"],"metadata":{"schema":{"columns":["year","state","fullname","population"],"types":{"fullname":"varchar","population":{"type":"int"},"state":"varchar","year":{"type":"int"}}}},"mode":"UnfilteredBackfill","scanned":"FgfQAUdBAA=="}},"cursor":"binlog.000123:56789"}
 
 
 ####################################
@@ -589,7 +589,7 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"test%2FComplexDataset_56015963":{"backfilled":270,"key_columns":["year","state"],"metadata":{"schema":{"columns":["year","state","fullname","population"],"types":{"fullname":"varchar","population":"int","state":"varchar","year":"int"}}},"mode":"Backfill","scanned":"FgfQAU1EAA=="}},"cursor":"binlog.000123:56789"}
+{"bindingStateV1":{"test%2FComplexDataset_56015963":{"backfilled":270,"key_columns":["year","state"],"metadata":{"schema":{"columns":["year","state","fullname","population"],"types":{"fullname":"varchar","population":{"type":"int"},"state":"varchar","year":{"type":"int"}}}},"mode":"UnfilteredBackfill","scanned":"FgfQAU1EAA=="}},"cursor":"binlog.000123:56789"}
 
 
 ####################################
@@ -611,7 +611,7 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"test%2FComplexDataset_56015963":{"backfilled":280,"key_columns":["year","state"],"metadata":{"schema":{"columns":["year","state","fullname","population"],"types":{"fullname":"varchar","population":"int","state":"varchar","year":"int"}}},"mode":"Backfill","scanned":"FgfQAU5IAA=="}},"cursor":"binlog.000123:56789"}
+{"bindingStateV1":{"test%2FComplexDataset_56015963":{"backfilled":280,"key_columns":["year","state"],"metadata":{"schema":{"columns":["year","state","fullname","population"],"types":{"fullname":"varchar","population":{"type":"int"},"state":"varchar","year":{"type":"int"}}}},"mode":"UnfilteredBackfill","scanned":"FgfQAU5IAA=="}},"cursor":"binlog.000123:56789"}
 
 
 ####################################
@@ -633,7 +633,7 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"test%2FComplexDataset_56015963":{"backfilled":290,"key_columns":["year","state"],"metadata":{"schema":{"columns":["year","state","fullname","population"],"types":{"fullname":"varchar","population":"int","state":"varchar","year":"int"}}},"mode":"Backfill","scanned":"FgfQAVNDAA=="}},"cursor":"binlog.000123:56789"}
+{"bindingStateV1":{"test%2FComplexDataset_56015963":{"backfilled":290,"key_columns":["year","state"],"metadata":{"schema":{"columns":["year","state","fullname","population"],"types":{"fullname":"varchar","population":{"type":"int"},"state":"varchar","year":{"type":"int"}}}},"mode":"UnfilteredBackfill","scanned":"FgfQAVNDAA=="}},"cursor":"binlog.000123:56789"}
 
 
 ####################################
@@ -655,7 +655,7 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"test%2FComplexDataset_56015963":{"backfilled":300,"key_columns":["year","state"],"metadata":{"schema":{"columns":["year","state","fullname","population"],"types":{"fullname":"varchar","population":"int","state":"varchar","year":"int"}}},"mode":"Backfill","scanned":"FgfQAVdZAA=="}},"cursor":"binlog.000123:56789"}
+{"bindingStateV1":{"test%2FComplexDataset_56015963":{"backfilled":300,"key_columns":["year","state"],"metadata":{"schema":{"columns":["year","state","fullname","population"],"types":{"fullname":"varchar","population":{"type":"int"},"state":"varchar","year":{"type":"int"}}}},"mode":"UnfilteredBackfill","scanned":"FgfQAVdZAA=="}},"cursor":"binlog.000123:56789"}
 
 
 ####################################
@@ -677,7 +677,7 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"test%2FComplexDataset_56015963":{"backfilled":310,"key_columns":["year","state"],"metadata":{"schema":{"columns":["year","state","fullname","population"],"types":{"fullname":"varchar","population":"int","state":"varchar","year":"int"}}},"mode":"Backfill","scanned":"FgfkAUZMAA=="}},"cursor":"binlog.000123:56789"}
+{"bindingStateV1":{"test%2FComplexDataset_56015963":{"backfilled":310,"key_columns":["year","state"],"metadata":{"schema":{"columns":["year","state","fullname","population"],"types":{"fullname":"varchar","population":{"type":"int"},"state":"varchar","year":{"type":"int"}}}},"mode":"UnfilteredBackfill","scanned":"FgfkAUZMAA=="}},"cursor":"binlog.000123:56789"}
 
 
 ####################################
@@ -699,7 +699,7 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"test%2FComplexDataset_56015963":{"backfilled":320,"key_columns":["year","state"],"metadata":{"schema":{"columns":["year","state","fullname","population"],"types":{"fullname":"varchar","population":"int","state":"varchar","year":"int"}}},"mode":"Backfill","scanned":"FgfkAU1BAA=="}},"cursor":"binlog.000123:56789"}
+{"bindingStateV1":{"test%2FComplexDataset_56015963":{"backfilled":320,"key_columns":["year","state"],"metadata":{"schema":{"columns":["year","state","fullname","population"],"types":{"fullname":"varchar","population":{"type":"int"},"state":"varchar","year":{"type":"int"}}}},"mode":"UnfilteredBackfill","scanned":"FgfkAU1BAA=="}},"cursor":"binlog.000123:56789"}
 
 
 ####################################
@@ -721,7 +721,7 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"test%2FComplexDataset_56015963":{"backfilled":330,"key_columns":["year","state"],"metadata":{"schema":{"columns":["year","state","fullname","population"],"types":{"fullname":"varchar","population":"int","state":"varchar","year":"int"}}},"mode":"Backfill","scanned":"FgfkAU5FAA=="}},"cursor":"binlog.000123:56789"}
+{"bindingStateV1":{"test%2FComplexDataset_56015963":{"backfilled":330,"key_columns":["year","state"],"metadata":{"schema":{"columns":["year","state","fullname","population"],"types":{"fullname":"varchar","population":{"type":"int"},"state":"varchar","year":{"type":"int"}}}},"mode":"UnfilteredBackfill","scanned":"FgfkAU5FAA=="}},"cursor":"binlog.000123:56789"}
 
 
 ####################################
@@ -743,7 +743,7 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"test%2FComplexDataset_56015963":{"backfilled":340,"key_columns":["year","state"],"metadata":{"schema":{"columns":["year","state","fullname","population"],"types":{"fullname":"varchar","population":"int","state":"varchar","year":"int"}}},"mode":"Backfill","scanned":"FgfkAVJJAA=="}},"cursor":"binlog.000123:56789"}
+{"bindingStateV1":{"test%2FComplexDataset_56015963":{"backfilled":340,"key_columns":["year","state"],"metadata":{"schema":{"columns":["year","state","fullname","population"],"types":{"fullname":"varchar","population":{"type":"int"},"state":"varchar","year":{"type":"int"}}}},"mode":"UnfilteredBackfill","scanned":"FgfkAVJJAA=="}},"cursor":"binlog.000123:56789"}
 
 
 ####################################
@@ -765,7 +765,7 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"test%2FComplexDataset_56015963":{"backfilled":350,"key_columns":["year","state"],"metadata":{"schema":{"columns":["year","state","fullname","population"],"types":{"fullname":"varchar","population":"int","state":"varchar","year":"int"}}},"mode":"Backfill","scanned":"FgfkAVdWAA=="}},"cursor":"binlog.000123:56789"}
+{"bindingStateV1":{"test%2FComplexDataset_56015963":{"backfilled":350,"key_columns":["year","state"],"metadata":{"schema":{"columns":["year","state","fullname","population"],"types":{"fullname":"varchar","population":{"type":"int"},"state":"varchar","year":{"type":"int"}}}},"mode":"UnfilteredBackfill","scanned":"FgfkAVdWAA=="}},"cursor":"binlog.000123:56789"}
 
 
 ####################################
@@ -778,7 +778,7 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"test%2FComplexDataset_56015963":{"backfilled":351,"key_columns":["year","state"],"metadata":{"schema":{"columns":["year","state","fullname","population"],"types":{"fullname":"varchar","population":"int","state":"varchar","year":"int"}}},"mode":"Backfill","scanned":"FgfkAVdZAA=="}},"cursor":"binlog.000123:56789"}
+{"bindingStateV1":{"test%2FComplexDataset_56015963":{"backfilled":351,"key_columns":["year","state"],"metadata":{"schema":{"columns":["year","state","fullname","population"],"types":{"fullname":"varchar","population":{"type":"int"},"state":"varchar","year":{"type":"int"}}}},"mode":"UnfilteredBackfill","scanned":"FgfkAVdZAA=="}},"cursor":"binlog.000123:56789"}
 
 
 ####################################
@@ -787,7 +787,7 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"test%2FComplexDataset_56015963":{"backfilled":351,"key_columns":["year","state"],"metadata":{"schema":{"columns":["year","state","fullname","population"],"types":{"fullname":"varchar","population":"int","state":"varchar","year":"int"}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
+{"bindingStateV1":{"test%2FComplexDataset_56015963":{"backfilled":351,"key_columns":["year","state"],"metadata":{"schema":{"columns":["year","state","fullname","population"],"types":{"fullname":"varchar","population":{"type":"int"},"state":"varchar","year":{"type":"int"}}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
 
 
 

--- a/source-mysql/.snapshots/TestComplexDataset-restart1
+++ b/source-mysql/.snapshots/TestComplexDataset-restart1
@@ -2,7 +2,7 @@
 ### Capture from Key "FgeUAU5WAA=="
 ####################################
 # ================================
-# Collection "acmeCo/test/test_complexdataset_56015963": 11 Documents
+# Collection "acmeCo/test/test_complexdataset_56015963": 13 Documents
 # ================================
 {"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"ComplexDataset_56015963","cursor":"backfill:130"}},"fullname":"New York","population":13456000,"state":"NY","year":1940}
 {"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"ComplexDataset_56015963","cursor":"backfill:131"}},"fullname":"Ohio","population":6929000,"state":"OH","year":1940}
@@ -15,10 +15,12 @@
 {"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"ComplexDataset_56015963","cursor":"backfill:138"}},"fullname":"Tennessee","population":2935000,"state":"TN","year":1940}
 {"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"ComplexDataset_56015963","cursor":"backfill:139"}},"fullname":"Texas","population":6425000,"state":"TX","year":1940}
 {"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"ComplexDataset_56015963","cursor":"binlog.000123:56789:123","txid":"11111111-1111-1111-1111-111111111111:111"}},"fullname":"No Such State","population":1234,"state":"XX","year":1930}
+{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"ComplexDataset_56015963","cursor":"binlog.000123:56789:123","txid":"11111111-1111-1111-1111-111111111111:111"}},"fullname":"No Such State","population":12345,"state":"XX","year":1970}
+{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"ComplexDataset_56015963","cursor":"binlog.000123:56789:123","txid":"11111111-1111-1111-1111-111111111111:111"}},"fullname":"No Such State","population":123456,"state":"XX","year":1990}
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"test%2FComplexDataset_56015963":{"backfilled":140,"key_columns":["year","state"],"metadata":{"schema":{"columns":["year","state","fullname","population"],"types":{"fullname":"varchar","population":"int","state":"varchar","year":"int"}}},"mode":"Backfill","scanned":"FgeUAVRYAA=="}},"cursor":"binlog.000123:56789"}
+{"bindingStateV1":{"test%2FComplexDataset_56015963":{"backfilled":140,"key_columns":["year","state"],"metadata":{"schema":{"columns":["year","state","fullname","population"],"types":{"fullname":"varchar","population":{"type":"int"},"state":"varchar","year":{"type":"int"}}}},"mode":"UnfilteredBackfill","scanned":"FgeUAVRYAA=="}},"cursor":"binlog.000123:56789"}
 
 
 ####################################
@@ -40,7 +42,7 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"test%2FComplexDataset_56015963":{"backfilled":150,"key_columns":["year","state"],"metadata":{"schema":{"columns":["year","state","fullname","population"],"types":{"fullname":"varchar","population":"int","state":"varchar","year":"int"}}},"mode":"Backfill","scanned":"FgeoAUFSAA=="}},"cursor":"binlog.000123:56789"}
+{"bindingStateV1":{"test%2FComplexDataset_56015963":{"backfilled":150,"key_columns":["year","state"],"metadata":{"schema":{"columns":["year","state","fullname","population"],"types":{"fullname":"varchar","population":{"type":"int"},"state":"varchar","year":{"type":"int"}}}},"mode":"UnfilteredBackfill","scanned":"FgeoAUFSAA=="}},"cursor":"binlog.000123:56789"}
 
 
 ####################################
@@ -62,7 +64,7 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"test%2FComplexDataset_56015963":{"backfilled":160,"key_columns":["year","state"],"metadata":{"schema":{"columns":["year","state","fullname","population"],"types":{"fullname":"varchar","population":"int","state":"varchar","year":"int"}}},"mode":"Backfill","scanned":"FgeoAUlBAA=="}},"cursor":"binlog.000123:56789"}
+{"bindingStateV1":{"test%2FComplexDataset_56015963":{"backfilled":160,"key_columns":["year","state"],"metadata":{"schema":{"columns":["year","state","fullname","population"],"types":{"fullname":"varchar","population":{"type":"int"},"state":"varchar","year":{"type":"int"}}}},"mode":"UnfilteredBackfill","scanned":"FgeoAUlBAA=="}},"cursor":"binlog.000123:56789"}
 
 
 ####################################
@@ -84,7 +86,7 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"test%2FComplexDataset_56015963":{"backfilled":170,"key_columns":["year","state"],"metadata":{"schema":{"columns":["year","state","fullname","population"],"types":{"fullname":"varchar","population":"int","state":"varchar","year":"int"}}},"mode":"Backfill","scanned":"FgeoAU1JAA=="}},"cursor":"binlog.000123:56789"}
+{"bindingStateV1":{"test%2FComplexDataset_56015963":{"backfilled":170,"key_columns":["year","state"],"metadata":{"schema":{"columns":["year","state","fullname","population"],"types":{"fullname":"varchar","population":{"type":"int"},"state":"varchar","year":{"type":"int"}}}},"mode":"UnfilteredBackfill","scanned":"FgeoAU1JAA=="}},"cursor":"binlog.000123:56789"}
 
 
 ####################################
@@ -106,7 +108,7 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"test%2FComplexDataset_56015963":{"backfilled":180,"key_columns":["year","state"],"metadata":{"schema":{"columns":["year","state","fullname","population"],"types":{"fullname":"varchar","population":"int","state":"varchar","year":"int"}}},"mode":"Backfill","scanned":"FgeoAU5NAA=="}},"cursor":"binlog.000123:56789"}
+{"bindingStateV1":{"test%2FComplexDataset_56015963":{"backfilled":180,"key_columns":["year","state"],"metadata":{"schema":{"columns":["year","state","fullname","population"],"types":{"fullname":"varchar","population":{"type":"int"},"state":"varchar","year":{"type":"int"}}}},"mode":"UnfilteredBackfill","scanned":"FgeoAU5NAA=="}},"cursor":"binlog.000123:56789"}
 
 
 ####################################
@@ -128,7 +130,7 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"test%2FComplexDataset_56015963":{"backfilled":190,"key_columns":["year","state"],"metadata":{"schema":{"columns":["year","state","fullname","population"],"types":{"fullname":"varchar","population":"int","state":"varchar","year":"int"}}},"mode":"Backfill","scanned":"FgeoAVROAA=="}},"cursor":"binlog.000123:56789"}
+{"bindingStateV1":{"test%2FComplexDataset_56015963":{"backfilled":190,"key_columns":["year","state"],"metadata":{"schema":{"columns":["year","state","fullname","population"],"types":{"fullname":"varchar","population":{"type":"int"},"state":"varchar","year":{"type":"int"}}}},"mode":"UnfilteredBackfill","scanned":"FgeoAVROAA=="}},"cursor":"binlog.000123:56789"}
 
 
 ####################################
@@ -150,7 +152,7 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"test%2FComplexDataset_56015963":{"backfilled":200,"key_columns":["year","state"],"metadata":{"schema":{"columns":["year","state","fullname","population"],"types":{"fullname":"varchar","population":"int","state":"varchar","year":"int"}}},"mode":"Backfill","scanned":"Fge8AUFLAA=="}},"cursor":"binlog.000123:56789"}
+{"bindingStateV1":{"test%2FComplexDataset_56015963":{"backfilled":200,"key_columns":["year","state"],"metadata":{"schema":{"columns":["year","state","fullname","population"],"types":{"fullname":"varchar","population":{"type":"int"},"state":"varchar","year":{"type":"int"}}}},"mode":"UnfilteredBackfill","scanned":"Fge8AUFLAA=="}},"cursor":"binlog.000123:56789"}
 
 
 ####################################
@@ -172,7 +174,7 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"test%2FComplexDataset_56015963":{"backfilled":210,"key_columns":["year","state"],"metadata":{"schema":{"columns":["year","state","fullname","population"],"types":{"fullname":"varchar","population":"int","state":"varchar","year":"int"}}},"mode":"Backfill","scanned":"Fge8AUdBAA=="}},"cursor":"binlog.000123:56789"}
+{"bindingStateV1":{"test%2FComplexDataset_56015963":{"backfilled":210,"key_columns":["year","state"],"metadata":{"schema":{"columns":["year","state","fullname","population"],"types":{"fullname":"varchar","population":{"type":"int"},"state":"varchar","year":{"type":"int"}}}},"mode":"UnfilteredBackfill","scanned":"Fge8AUdBAA=="}},"cursor":"binlog.000123:56789"}
 
 
 ####################################
@@ -194,7 +196,7 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"test%2FComplexDataset_56015963":{"backfilled":220,"key_columns":["year","state"],"metadata":{"schema":{"columns":["year","state","fullname","population"],"types":{"fullname":"varchar","population":"int","state":"varchar","year":"int"}}},"mode":"Backfill","scanned":"Fge8AU1EAA=="}},"cursor":"binlog.000123:56789"}
+{"bindingStateV1":{"test%2FComplexDataset_56015963":{"backfilled":220,"key_columns":["year","state"],"metadata":{"schema":{"columns":["year","state","fullname","population"],"types":{"fullname":"varchar","population":{"type":"int"},"state":"varchar","year":{"type":"int"}}}},"mode":"UnfilteredBackfill","scanned":"Fge8AU1EAA=="}},"cursor":"binlog.000123:56789"}
 
 
 ####################################
@@ -216,7 +218,7 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"test%2FComplexDataset_56015963":{"backfilled":230,"key_columns":["year","state"],"metadata":{"schema":{"columns":["year","state","fullname","population"],"types":{"fullname":"varchar","population":"int","state":"varchar","year":"int"}}},"mode":"Backfill","scanned":"Fge8AU5IAA=="}},"cursor":"binlog.000123:56789"}
+{"bindingStateV1":{"test%2FComplexDataset_56015963":{"backfilled":230,"key_columns":["year","state"],"metadata":{"schema":{"columns":["year","state","fullname","population"],"types":{"fullname":"varchar","population":{"type":"int"},"state":"varchar","year":{"type":"int"}}}},"mode":"UnfilteredBackfill","scanned":"Fge8AU5IAA=="}},"cursor":"binlog.000123:56789"}
 
 
 ####################################
@@ -238,7 +240,7 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"test%2FComplexDataset_56015963":{"backfilled":240,"key_columns":["year","state"],"metadata":{"schema":{"columns":["year","state","fullname","population"],"types":{"fullname":"varchar","population":"int","state":"varchar","year":"int"}}},"mode":"Backfill","scanned":"Fge8AVNDAA=="}},"cursor":"binlog.000123:56789"}
+{"bindingStateV1":{"test%2FComplexDataset_56015963":{"backfilled":240,"key_columns":["year","state"],"metadata":{"schema":{"columns":["year","state","fullname","population"],"types":{"fullname":"varchar","population":{"type":"int"},"state":"varchar","year":{"type":"int"}}}},"mode":"UnfilteredBackfill","scanned":"Fge8AVNDAA=="}},"cursor":"binlog.000123:56789"}
 
 
 ####################################
@@ -260,7 +262,7 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"test%2FComplexDataset_56015963":{"backfilled":250,"key_columns":["year","state"],"metadata":{"schema":{"columns":["year","state","fullname","population"],"types":{"fullname":"varchar","population":"int","state":"varchar","year":"int"}}},"mode":"Backfill","scanned":"Fge8AVdZAA=="}},"cursor":"binlog.000123:56789"}
+{"bindingStateV1":{"test%2FComplexDataset_56015963":{"backfilled":250,"key_columns":["year","state"],"metadata":{"schema":{"columns":["year","state","fullname","population"],"types":{"fullname":"varchar","population":{"type":"int"},"state":"varchar","year":{"type":"int"}}}},"mode":"UnfilteredBackfill","scanned":"Fge8AVdZAA=="}},"cursor":"binlog.000123:56789"}
 
 
 ####################################
@@ -282,7 +284,7 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"test%2FComplexDataset_56015963":{"backfilled":260,"key_columns":["year","state"],"metadata":{"schema":{"columns":["year","state","fullname","population"],"types":{"fullname":"varchar","population":"int","state":"varchar","year":"int"}}},"mode":"Backfill","scanned":"FgfQAURFAA=="}},"cursor":"binlog.000123:56789"}
+{"bindingStateV1":{"test%2FComplexDataset_56015963":{"backfilled":260,"key_columns":["year","state"],"metadata":{"schema":{"columns":["year","state","fullname","population"],"types":{"fullname":"varchar","population":{"type":"int"},"state":"varchar","year":{"type":"int"}}}},"mode":"UnfilteredBackfill","scanned":"FgfQAURFAA=="}},"cursor":"binlog.000123:56789"}
 
 
 ####################################
@@ -304,7 +306,7 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"test%2FComplexDataset_56015963":{"backfilled":270,"key_columns":["year","state"],"metadata":{"schema":{"columns":["year","state","fullname","population"],"types":{"fullname":"varchar","population":"int","state":"varchar","year":"int"}}},"mode":"Backfill","scanned":"FgfQAUxBAA=="}},"cursor":"binlog.000123:56789"}
+{"bindingStateV1":{"test%2FComplexDataset_56015963":{"backfilled":270,"key_columns":["year","state"],"metadata":{"schema":{"columns":["year","state","fullname","population"],"types":{"fullname":"varchar","population":{"type":"int"},"state":"varchar","year":{"type":"int"}}}},"mode":"UnfilteredBackfill","scanned":"FgfQAUxBAA=="}},"cursor":"binlog.000123:56789"}
 
 
 ####################################
@@ -326,7 +328,7 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"test%2FComplexDataset_56015963":{"backfilled":280,"key_columns":["year","state"],"metadata":{"schema":{"columns":["year","state","fullname","population"],"types":{"fullname":"varchar","population":"int","state":"varchar","year":"int"}}},"mode":"Backfill","scanned":"FgfQAU5EAA=="}},"cursor":"binlog.000123:56789"}
+{"bindingStateV1":{"test%2FComplexDataset_56015963":{"backfilled":280,"key_columns":["year","state"],"metadata":{"schema":{"columns":["year","state","fullname","population"],"types":{"fullname":"varchar","population":{"type":"int"},"state":"varchar","year":{"type":"int"}}}},"mode":"UnfilteredBackfill","scanned":"FgfQAU5EAA=="}},"cursor":"binlog.000123:56789"}
 
 
 ####################################
@@ -348,7 +350,7 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"test%2FComplexDataset_56015963":{"backfilled":290,"key_columns":["year","state"],"metadata":{"schema":{"columns":["year","state","fullname","population"],"types":{"fullname":"varchar","population":"int","state":"varchar","year":"int"}}},"mode":"Backfill","scanned":"FgfQAVBBAA=="}},"cursor":"binlog.000123:56789"}
+{"bindingStateV1":{"test%2FComplexDataset_56015963":{"backfilled":290,"key_columns":["year","state"],"metadata":{"schema":{"columns":["year","state","fullname","population"],"types":{"fullname":"varchar","population":{"type":"int"},"state":"varchar","year":{"type":"int"}}}},"mode":"UnfilteredBackfill","scanned":"FgfQAVBBAA=="}},"cursor":"binlog.000123:56789"}
 
 
 ####################################
@@ -370,7 +372,7 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"test%2FComplexDataset_56015963":{"backfilled":300,"key_columns":["year","state"],"metadata":{"schema":{"columns":["year","state","fullname","population"],"types":{"fullname":"varchar","population":"int","state":"varchar","year":"int"}}},"mode":"Backfill","scanned":"FgfQAVdJAA=="}},"cursor":"binlog.000123:56789"}
+{"bindingStateV1":{"test%2FComplexDataset_56015963":{"backfilled":300,"key_columns":["year","state"],"metadata":{"schema":{"columns":["year","state","fullname","population"],"types":{"fullname":"varchar","population":{"type":"int"},"state":"varchar","year":{"type":"int"}}}},"mode":"UnfilteredBackfill","scanned":"FgfQAVdJAA=="}},"cursor":"binlog.000123:56789"}
 
 
 ####################################
@@ -392,7 +394,7 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"test%2FComplexDataset_56015963":{"backfilled":310,"key_columns":["year","state"],"metadata":{"schema":{"columns":["year","state","fullname","population"],"types":{"fullname":"varchar","population":"int","state":"varchar","year":"int"}}},"mode":"Backfill","scanned":"FgfkAURDAA=="}},"cursor":"binlog.000123:56789"}
+{"bindingStateV1":{"test%2FComplexDataset_56015963":{"backfilled":310,"key_columns":["year","state"],"metadata":{"schema":{"columns":["year","state","fullname","population"],"types":{"fullname":"varchar","population":{"type":"int"},"state":"varchar","year":{"type":"int"}}}},"mode":"UnfilteredBackfill","scanned":"FgfkAURDAA=="}},"cursor":"binlog.000123:56789"}
 
 
 ####################################
@@ -414,7 +416,7 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"test%2FComplexDataset_56015963":{"backfilled":320,"key_columns":["year","state"],"metadata":{"schema":{"columns":["year","state","fullname","population"],"types":{"fullname":"varchar","population":"int","state":"varchar","year":"int"}}},"mode":"Backfill","scanned":"FgfkAUtZAA=="}},"cursor":"binlog.000123:56789"}
+{"bindingStateV1":{"test%2FComplexDataset_56015963":{"backfilled":320,"key_columns":["year","state"],"metadata":{"schema":{"columns":["year","state","fullname","population"],"types":{"fullname":"varchar","population":{"type":"int"},"state":"varchar","year":{"type":"int"}}}},"mode":"UnfilteredBackfill","scanned":"FgfkAUtZAA=="}},"cursor":"binlog.000123:56789"}
 
 
 ####################################
@@ -436,7 +438,7 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"test%2FComplexDataset_56015963":{"backfilled":330,"key_columns":["year","state"],"metadata":{"schema":{"columns":["year","state","fullname","population"],"types":{"fullname":"varchar","population":"int","state":"varchar","year":"int"}}},"mode":"Backfill","scanned":"FgfkAU5DAA=="}},"cursor":"binlog.000123:56789"}
+{"bindingStateV1":{"test%2FComplexDataset_56015963":{"backfilled":330,"key_columns":["year","state"],"metadata":{"schema":{"columns":["year","state","fullname","population"],"types":{"fullname":"varchar","population":{"type":"int"},"state":"varchar","year":{"type":"int"}}}},"mode":"UnfilteredBackfill","scanned":"FgfkAU5DAA=="}},"cursor":"binlog.000123:56789"}
 
 
 ####################################
@@ -458,7 +460,7 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"test%2FComplexDataset_56015963":{"backfilled":340,"key_columns":["year","state"],"metadata":{"schema":{"columns":["year","state","fullname","population"],"types":{"fullname":"varchar","population":"int","state":"varchar","year":"int"}}},"mode":"Backfill","scanned":"FgfkAU9SAA=="}},"cursor":"binlog.000123:56789"}
+{"bindingStateV1":{"test%2FComplexDataset_56015963":{"backfilled":340,"key_columns":["year","state"],"metadata":{"schema":{"columns":["year","state","fullname","population"],"types":{"fullname":"varchar","population":{"type":"int"},"state":"varchar","year":{"type":"int"}}}},"mode":"UnfilteredBackfill","scanned":"FgfkAU9SAA=="}},"cursor":"binlog.000123:56789"}
 
 
 ####################################
@@ -480,7 +482,7 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"test%2FComplexDataset_56015963":{"backfilled":350,"key_columns":["year","state"],"metadata":{"schema":{"columns":["year","state","fullname","population"],"types":{"fullname":"varchar","population":"int","state":"varchar","year":"int"}}},"mode":"Backfill","scanned":"FgfkAVdBAA=="}},"cursor":"binlog.000123:56789"}
+{"bindingStateV1":{"test%2FComplexDataset_56015963":{"backfilled":350,"key_columns":["year","state"],"metadata":{"schema":{"columns":["year","state","fullname","population"],"types":{"fullname":"varchar","population":{"type":"int"},"state":"varchar","year":{"type":"int"}}}},"mode":"UnfilteredBackfill","scanned":"FgfkAVdBAA=="}},"cursor":"binlog.000123:56789"}
 
 
 ####################################
@@ -495,7 +497,7 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"test%2FComplexDataset_56015963":{"backfilled":353,"key_columns":["year","state"],"metadata":{"schema":{"columns":["year","state","fullname","population"],"types":{"fullname":"varchar","population":"int","state":"varchar","year":"int"}}},"mode":"Backfill","scanned":"FgfkAVdZAA=="}},"cursor":"binlog.000123:56789"}
+{"bindingStateV1":{"test%2FComplexDataset_56015963":{"backfilled":353,"key_columns":["year","state"],"metadata":{"schema":{"columns":["year","state","fullname","population"],"types":{"fullname":"varchar","population":{"type":"int"},"state":"varchar","year":{"type":"int"}}}},"mode":"UnfilteredBackfill","scanned":"FgfkAVdZAA=="}},"cursor":"binlog.000123:56789"}
 
 
 ####################################
@@ -504,7 +506,7 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"test%2FComplexDataset_56015963":{"backfilled":353,"key_columns":["year","state"],"metadata":{"schema":{"columns":["year","state","fullname","population"],"types":{"fullname":"varchar","population":"int","state":"varchar","year":"int"}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
+{"bindingStateV1":{"test%2FComplexDataset_56015963":{"backfilled":353,"key_columns":["year","state"],"metadata":{"schema":{"columns":["year","state","fullname","population"],"types":{"fullname":"varchar","population":{"type":"int"},"state":"varchar","year":{"type":"int"}}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
 
 
 

--- a/source-mysql/.snapshots/TestComplexDataset-restart2
+++ b/source-mysql/.snapshots/TestComplexDataset-restart2
@@ -2,7 +2,7 @@
 ### Capture from Key "Fge8AU5IAA=="
 ####################################
 # ================================
-# Collection "acmeCo/test/test_complexdataset_56015963": 14 Documents
+# Collection "acmeCo/test/test_complexdataset_56015963": 16 Documents
 # ================================
 {"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"ComplexDataset_56015963","cursor":"backfill:230"}},"fullname":"New Jersey","population":7376330,"state":"NJ","year":1980}
 {"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"ComplexDataset_56015963","cursor":"backfill:231"}},"fullname":"New Mexico","population":1309400,"state":"NM","year":1980}
@@ -16,12 +16,14 @@
 {"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"ComplexDataset_56015963","cursor":"backfill:239"}},"fullname":"South Carolina","population":3134502,"state":"SC","year":1980}
 {"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"ComplexDataset_56015963","cursor":"binlog.000123:56789:123","txid":"11111111-1111-1111-1111-111111111111:111"}},"fullname":"No Such State","population":1234,"state":"XX","year":1930}
 {"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"ComplexDataset_56015963","cursor":"binlog.000123:56789:123","txid":"11111111-1111-1111-1111-111111111111:111"}},"fullname":"No Such State","population":12345,"state":"XX","year":1970}
+{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"ComplexDataset_56015963","cursor":"binlog.000123:56789:123","txid":"11111111-1111-1111-1111-111111111111:111"}},"fullname":"No Such State","population":123456,"state":"XX","year":1990}
 {"_meta":{"op":"d","source":{"ts_ms":1111111111111,"schema":"test","table":"ComplexDataset_56015963","cursor":"binlog.000123:56789:123","txid":"11111111-1111-1111-1111-111111111111:111"}},"fullname":"No Such State","population":1234,"state":"XX","year":1930}
 {"_meta":{"op":"d","source":{"ts_ms":1111111111111,"schema":"test","table":"ComplexDataset_56015963","cursor":"binlog.000123:56789:123","txid":"11111111-1111-1111-1111-111111111111:111"}},"fullname":"No Such State","population":12345,"state":"XX","year":1970}
+{"_meta":{"op":"d","source":{"ts_ms":1111111111111,"schema":"test","table":"ComplexDataset_56015963","cursor":"binlog.000123:56789:123","txid":"11111111-1111-1111-1111-111111111111:111"}},"fullname":"No Such State","population":123456,"state":"XX","year":1990}
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"test%2FComplexDataset_56015963":{"backfilled":240,"key_columns":["year","state"],"metadata":{"schema":{"columns":["year","state","fullname","population"],"types":{"fullname":"varchar","population":"int","state":"varchar","year":"int"}}},"mode":"Backfill","scanned":"Fge8AVNDAA=="}},"cursor":"binlog.000123:56789"}
+{"bindingStateV1":{"test%2FComplexDataset_56015963":{"backfilled":240,"key_columns":["year","state"],"metadata":{"schema":{"columns":["year","state","fullname","population"],"types":{"fullname":"varchar","population":{"type":"int"},"state":"varchar","year":{"type":"int"}}}},"mode":"UnfilteredBackfill","scanned":"Fge8AVNDAA=="}},"cursor":"binlog.000123:56789"}
 
 
 ####################################
@@ -43,7 +45,7 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"test%2FComplexDataset_56015963":{"backfilled":250,"key_columns":["year","state"],"metadata":{"schema":{"columns":["year","state","fullname","population"],"types":{"fullname":"varchar","population":"int","state":"varchar","year":"int"}}},"mode":"Backfill","scanned":"Fge8AVdZAA=="}},"cursor":"binlog.000123:56789"}
+{"bindingStateV1":{"test%2FComplexDataset_56015963":{"backfilled":250,"key_columns":["year","state"],"metadata":{"schema":{"columns":["year","state","fullname","population"],"types":{"fullname":"varchar","population":{"type":"int"},"state":"varchar","year":{"type":"int"}}}},"mode":"UnfilteredBackfill","scanned":"Fge8AVdZAA=="}},"cursor":"binlog.000123:56789"}
 
 
 ####################################
@@ -65,7 +67,7 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"test%2FComplexDataset_56015963":{"backfilled":260,"key_columns":["year","state"],"metadata":{"schema":{"columns":["year","state","fullname","population"],"types":{"fullname":"varchar","population":"int","state":"varchar","year":"int"}}},"mode":"Backfill","scanned":"FgfQAURFAA=="}},"cursor":"binlog.000123:56789"}
+{"bindingStateV1":{"test%2FComplexDataset_56015963":{"backfilled":260,"key_columns":["year","state"],"metadata":{"schema":{"columns":["year","state","fullname","population"],"types":{"fullname":"varchar","population":{"type":"int"},"state":"varchar","year":{"type":"int"}}}},"mode":"UnfilteredBackfill","scanned":"FgfQAURFAA=="}},"cursor":"binlog.000123:56789"}
 
 
 ####################################
@@ -87,7 +89,7 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"test%2FComplexDataset_56015963":{"backfilled":270,"key_columns":["year","state"],"metadata":{"schema":{"columns":["year","state","fullname","population"],"types":{"fullname":"varchar","population":"int","state":"varchar","year":"int"}}},"mode":"Backfill","scanned":"FgfQAUxBAA=="}},"cursor":"binlog.000123:56789"}
+{"bindingStateV1":{"test%2FComplexDataset_56015963":{"backfilled":270,"key_columns":["year","state"],"metadata":{"schema":{"columns":["year","state","fullname","population"],"types":{"fullname":"varchar","population":{"type":"int"},"state":"varchar","year":{"type":"int"}}}},"mode":"UnfilteredBackfill","scanned":"FgfQAUxBAA=="}},"cursor":"binlog.000123:56789"}
 
 
 ####################################
@@ -109,7 +111,7 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"test%2FComplexDataset_56015963":{"backfilled":280,"key_columns":["year","state"],"metadata":{"schema":{"columns":["year","state","fullname","population"],"types":{"fullname":"varchar","population":"int","state":"varchar","year":"int"}}},"mode":"Backfill","scanned":"FgfQAU5EAA=="}},"cursor":"binlog.000123:56789"}
+{"bindingStateV1":{"test%2FComplexDataset_56015963":{"backfilled":280,"key_columns":["year","state"],"metadata":{"schema":{"columns":["year","state","fullname","population"],"types":{"fullname":"varchar","population":{"type":"int"},"state":"varchar","year":{"type":"int"}}}},"mode":"UnfilteredBackfill","scanned":"FgfQAU5EAA=="}},"cursor":"binlog.000123:56789"}
 
 
 ####################################
@@ -131,7 +133,7 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"test%2FComplexDataset_56015963":{"backfilled":290,"key_columns":["year","state"],"metadata":{"schema":{"columns":["year","state","fullname","population"],"types":{"fullname":"varchar","population":"int","state":"varchar","year":"int"}}},"mode":"Backfill","scanned":"FgfQAVBBAA=="}},"cursor":"binlog.000123:56789"}
+{"bindingStateV1":{"test%2FComplexDataset_56015963":{"backfilled":290,"key_columns":["year","state"],"metadata":{"schema":{"columns":["year","state","fullname","population"],"types":{"fullname":"varchar","population":{"type":"int"},"state":"varchar","year":{"type":"int"}}}},"mode":"UnfilteredBackfill","scanned":"FgfQAVBBAA=="}},"cursor":"binlog.000123:56789"}
 
 
 ####################################
@@ -153,7 +155,7 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"test%2FComplexDataset_56015963":{"backfilled":300,"key_columns":["year","state"],"metadata":{"schema":{"columns":["year","state","fullname","population"],"types":{"fullname":"varchar","population":"int","state":"varchar","year":"int"}}},"mode":"Backfill","scanned":"FgfQAVdJAA=="}},"cursor":"binlog.000123:56789"}
+{"bindingStateV1":{"test%2FComplexDataset_56015963":{"backfilled":300,"key_columns":["year","state"],"metadata":{"schema":{"columns":["year","state","fullname","population"],"types":{"fullname":"varchar","population":{"type":"int"},"state":"varchar","year":{"type":"int"}}}},"mode":"UnfilteredBackfill","scanned":"FgfQAVdJAA=="}},"cursor":"binlog.000123:56789"}
 
 
 ####################################
@@ -175,7 +177,7 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"test%2FComplexDataset_56015963":{"backfilled":310,"key_columns":["year","state"],"metadata":{"schema":{"columns":["year","state","fullname","population"],"types":{"fullname":"varchar","population":"int","state":"varchar","year":"int"}}},"mode":"Backfill","scanned":"FgfkAURDAA=="}},"cursor":"binlog.000123:56789"}
+{"bindingStateV1":{"test%2FComplexDataset_56015963":{"backfilled":310,"key_columns":["year","state"],"metadata":{"schema":{"columns":["year","state","fullname","population"],"types":{"fullname":"varchar","population":{"type":"int"},"state":"varchar","year":{"type":"int"}}}},"mode":"UnfilteredBackfill","scanned":"FgfkAURDAA=="}},"cursor":"binlog.000123:56789"}
 
 
 ####################################
@@ -197,7 +199,7 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"test%2FComplexDataset_56015963":{"backfilled":320,"key_columns":["year","state"],"metadata":{"schema":{"columns":["year","state","fullname","population"],"types":{"fullname":"varchar","population":"int","state":"varchar","year":"int"}}},"mode":"Backfill","scanned":"FgfkAUtZAA=="}},"cursor":"binlog.000123:56789"}
+{"bindingStateV1":{"test%2FComplexDataset_56015963":{"backfilled":320,"key_columns":["year","state"],"metadata":{"schema":{"columns":["year","state","fullname","population"],"types":{"fullname":"varchar","population":{"type":"int"},"state":"varchar","year":{"type":"int"}}}},"mode":"UnfilteredBackfill","scanned":"FgfkAUtZAA=="}},"cursor":"binlog.000123:56789"}
 
 
 ####################################
@@ -219,7 +221,7 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"test%2FComplexDataset_56015963":{"backfilled":330,"key_columns":["year","state"],"metadata":{"schema":{"columns":["year","state","fullname","population"],"types":{"fullname":"varchar","population":"int","state":"varchar","year":"int"}}},"mode":"Backfill","scanned":"FgfkAU5DAA=="}},"cursor":"binlog.000123:56789"}
+{"bindingStateV1":{"test%2FComplexDataset_56015963":{"backfilled":330,"key_columns":["year","state"],"metadata":{"schema":{"columns":["year","state","fullname","population"],"types":{"fullname":"varchar","population":{"type":"int"},"state":"varchar","year":{"type":"int"}}}},"mode":"UnfilteredBackfill","scanned":"FgfkAU5DAA=="}},"cursor":"binlog.000123:56789"}
 
 
 ####################################
@@ -241,7 +243,7 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"test%2FComplexDataset_56015963":{"backfilled":340,"key_columns":["year","state"],"metadata":{"schema":{"columns":["year","state","fullname","population"],"types":{"fullname":"varchar","population":"int","state":"varchar","year":"int"}}},"mode":"Backfill","scanned":"FgfkAU9SAA=="}},"cursor":"binlog.000123:56789"}
+{"bindingStateV1":{"test%2FComplexDataset_56015963":{"backfilled":340,"key_columns":["year","state"],"metadata":{"schema":{"columns":["year","state","fullname","population"],"types":{"fullname":"varchar","population":{"type":"int"},"state":"varchar","year":{"type":"int"}}}},"mode":"UnfilteredBackfill","scanned":"FgfkAU9SAA=="}},"cursor":"binlog.000123:56789"}
 
 
 ####################################
@@ -263,7 +265,7 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"test%2FComplexDataset_56015963":{"backfilled":350,"key_columns":["year","state"],"metadata":{"schema":{"columns":["year","state","fullname","population"],"types":{"fullname":"varchar","population":"int","state":"varchar","year":"int"}}},"mode":"Backfill","scanned":"FgfkAVdBAA=="}},"cursor":"binlog.000123:56789"}
+{"bindingStateV1":{"test%2FComplexDataset_56015963":{"backfilled":350,"key_columns":["year","state"],"metadata":{"schema":{"columns":["year","state","fullname","population"],"types":{"fullname":"varchar","population":{"type":"int"},"state":"varchar","year":{"type":"int"}}}},"mode":"UnfilteredBackfill","scanned":"FgfkAVdBAA=="}},"cursor":"binlog.000123:56789"}
 
 
 ####################################
@@ -278,7 +280,7 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"test%2FComplexDataset_56015963":{"backfilled":353,"key_columns":["year","state"],"metadata":{"schema":{"columns":["year","state","fullname","population"],"types":{"fullname":"varchar","population":"int","state":"varchar","year":"int"}}},"mode":"Backfill","scanned":"FgfkAVdZAA=="}},"cursor":"binlog.000123:56789"}
+{"bindingStateV1":{"test%2FComplexDataset_56015963":{"backfilled":353,"key_columns":["year","state"],"metadata":{"schema":{"columns":["year","state","fullname","population"],"types":{"fullname":"varchar","population":{"type":"int"},"state":"varchar","year":{"type":"int"}}}},"mode":"UnfilteredBackfill","scanned":"FgfkAVdZAA=="}},"cursor":"binlog.000123:56789"}
 
 
 ####################################
@@ -287,7 +289,7 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"test%2FComplexDataset_56015963":{"backfilled":353,"key_columns":["year","state"],"metadata":{"schema":{"columns":["year","state","fullname","population"],"types":{"fullname":"varchar","population":"int","state":"varchar","year":"int"}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
+{"bindingStateV1":{"test%2FComplexDataset_56015963":{"backfilled":353,"key_columns":["year","state"],"metadata":{"schema":{"columns":["year","state","fullname","population"],"types":{"fullname":"varchar","population":{"type":"int"},"state":"varchar","year":{"type":"int"}}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
 
 
 

--- a/source-mysql/.snapshots/TestCursorResume
+++ b/source-mysql/.snapshots/TestCursorResume
@@ -8,7 +8,7 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"test%2FCursorResume_26865190":{"backfilled":1,"key_columns":["epoch","count"],"metadata":{"schema":{"columns":["epoch","count","data"],"types":{"count":"int","data":"text","epoch":"varchar"}}},"mode":"Backfill","scanned":"AQAT/g=="}},"cursor":"binlog.000123:56789"}
+{"bindingStateV1":{"test%2FCursorResume_26865190":{"backfilled":1,"key_columns":["epoch","count"],"metadata":{"schema":{"columns":["epoch","count","data"],"types":{"count":{"type":"int"},"data":"text","epoch":"varchar"}}},"mode":"UnfilteredBackfill","scanned":"AQAT/g=="}},"cursor":"binlog.000123:56789"}
 
 
 ####################################
@@ -21,7 +21,7 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"test%2FCursorResume_26865190":{"backfilled":2,"key_columns":["epoch","count"],"metadata":{"schema":{"columns":["epoch","count","data"],"types":{"count":"int","data":"text","epoch":"varchar"}}},"mode":"Backfill","scanned":"AQAU"}},"cursor":"binlog.000123:56789"}
+{"bindingStateV1":{"test%2FCursorResume_26865190":{"backfilled":2,"key_columns":["epoch","count"],"metadata":{"schema":{"columns":["epoch","count","data"],"types":{"count":{"type":"int"},"data":"text","epoch":"varchar"}}},"mode":"UnfilteredBackfill","scanned":"AQAU"}},"cursor":"binlog.000123:56789"}
 
 
 ####################################
@@ -34,7 +34,7 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"test%2FCursorResume_26865190":{"backfilled":3,"key_columns":["epoch","count"],"metadata":{"schema":{"columns":["epoch","count","data"],"types":{"count":"int","data":"text","epoch":"varchar"}}},"mode":"Backfill","scanned":"ASAgIAAVAw=="}},"cursor":"binlog.000123:56789"}
+{"bindingStateV1":{"test%2FCursorResume_26865190":{"backfilled":3,"key_columns":["epoch","count"],"metadata":{"schema":{"columns":["epoch","count","data"],"types":{"count":{"type":"int"},"data":"text","epoch":"varchar"}}},"mode":"UnfilteredBackfill","scanned":"ASAgIAAVAw=="}},"cursor":"binlog.000123:56789"}
 
 
 ####################################
@@ -47,7 +47,7 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"test%2FCursorResume_26865190":{"backfilled":4,"key_columns":["epoch","count"],"metadata":{"schema":{"columns":["epoch","count","data"],"types":{"count":"int","data":"text","epoch":"varchar"}}},"mode":"Backfill","scanned":"AWFhYQAVAQ=="}},"cursor":"binlog.000123:56789"}
+{"bindingStateV1":{"test%2FCursorResume_26865190":{"backfilled":4,"key_columns":["epoch","count"],"metadata":{"schema":{"columns":["epoch","count","data"],"types":{"count":{"type":"int"},"data":"text","epoch":"varchar"}}},"mode":"UnfilteredBackfill","scanned":"AWFhYQAVAQ=="}},"cursor":"binlog.000123:56789"}
 
 
 ####################################
@@ -60,7 +60,7 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"test%2FCursorResume_26865190":{"backfilled":5,"key_columns":["epoch","count"],"metadata":{"schema":{"columns":["epoch","count","data"],"types":{"count":"int","data":"text","epoch":"varchar"}}},"mode":"Backfill","scanned":"AWFhYQAVAg=="}},"cursor":"binlog.000123:56789"}
+{"bindingStateV1":{"test%2FCursorResume_26865190":{"backfilled":5,"key_columns":["epoch","count"],"metadata":{"schema":{"columns":["epoch","count","data"],"types":{"count":{"type":"int"},"data":"text","epoch":"varchar"}}},"mode":"UnfilteredBackfill","scanned":"AWFhYQAVAg=="}},"cursor":"binlog.000123:56789"}
 
 
 ####################################
@@ -73,7 +73,7 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"test%2FCursorResume_26865190":{"backfilled":6,"key_columns":["epoch","count"],"metadata":{"schema":{"columns":["epoch","count","data"],"types":{"count":"int","data":"text","epoch":"varchar"}}},"mode":"Backfill","scanned":"AWFhYQAVAw=="}},"cursor":"binlog.000123:56789"}
+{"bindingStateV1":{"test%2FCursorResume_26865190":{"backfilled":6,"key_columns":["epoch","count"],"metadata":{"schema":{"columns":["epoch","count","data"],"types":{"count":{"type":"int"},"data":"text","epoch":"varchar"}}},"mode":"UnfilteredBackfill","scanned":"AWFhYQAVAw=="}},"cursor":"binlog.000123:56789"}
 
 
 ####################################
@@ -86,7 +86,7 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"test%2FCursorResume_26865190":{"backfilled":7,"key_columns":["epoch","count"],"metadata":{"schema":{"columns":["epoch","count","data"],"types":{"count":"int","data":"text","epoch":"varchar"}}},"mode":"Backfill","scanned":"AWJiYgATmw=="}},"cursor":"binlog.000123:56789"}
+{"bindingStateV1":{"test%2FCursorResume_26865190":{"backfilled":7,"key_columns":["epoch","count"],"metadata":{"schema":{"columns":["epoch","count","data"],"types":{"count":{"type":"int"},"data":"text","epoch":"varchar"}}},"mode":"UnfilteredBackfill","scanned":"AWJiYgATmw=="}},"cursor":"binlog.000123:56789"}
 
 
 ####################################
@@ -99,7 +99,7 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"test%2FCursorResume_26865190":{"backfilled":8,"key_columns":["epoch","count"],"metadata":{"schema":{"columns":["epoch","count","data"],"types":{"count":"int","data":"text","epoch":"varchar"}}},"mode":"Backfill","scanned":"AWJiYgAVAg=="}},"cursor":"binlog.000123:56789"}
+{"bindingStateV1":{"test%2FCursorResume_26865190":{"backfilled":8,"key_columns":["epoch","count"],"metadata":{"schema":{"columns":["epoch","count","data"],"types":{"count":{"type":"int"},"data":"text","epoch":"varchar"}}},"mode":"UnfilteredBackfill","scanned":"AWJiYgAVAg=="}},"cursor":"binlog.000123:56789"}
 
 
 ####################################
@@ -112,7 +112,7 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"test%2FCursorResume_26865190":{"backfilled":9,"key_columns":["epoch","count"],"metadata":{"schema":{"columns":["epoch","count","data"],"types":{"count":"int","data":"text","epoch":"varchar"}}},"mode":"Backfill","scanned":"AWJiYgAWAU0="}},"cursor":"binlog.000123:56789"}
+{"bindingStateV1":{"test%2FCursorResume_26865190":{"backfilled":9,"key_columns":["epoch","count"],"metadata":{"schema":{"columns":["epoch","count","data"],"types":{"count":{"type":"int"},"data":"text","epoch":"varchar"}}},"mode":"UnfilteredBackfill","scanned":"AWJiYgAWAU0="}},"cursor":"binlog.000123:56789"}
 
 
 ####################################
@@ -125,7 +125,7 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"test%2FCursorResume_26865190":{"backfilled":10,"key_columns":["epoch","count"],"metadata":{"schema":{"columns":["epoch","count","data"],"types":{"count":"int","data":"text","epoch":"varchar"}}},"mode":"Backfill","scanned":"AWJiYgAWEAA="}},"cursor":"binlog.000123:56789"}
+{"bindingStateV1":{"test%2FCursorResume_26865190":{"backfilled":10,"key_columns":["epoch","count"],"metadata":{"schema":{"columns":["epoch","count","data"],"types":{"count":{"type":"int"},"data":"text","epoch":"varchar"}}},"mode":"UnfilteredBackfill","scanned":"AWJiYgAWEAA="}},"cursor":"binlog.000123:56789"}
 
 
 ####################################
@@ -138,7 +138,7 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"test%2FCursorResume_26865190":{"backfilled":11,"key_columns":["epoch","count"],"metadata":{"schema":{"columns":["epoch","count","data"],"types":{"count":"int","data":"text","epoch":"varchar"}}},"mode":"Backfill","scanned":"AWJiYgAXDDUA"}},"cursor":"binlog.000123:56789"}
+{"bindingStateV1":{"test%2FCursorResume_26865190":{"backfilled":11,"key_columns":["epoch","count"],"metadata":{"schema":{"columns":["epoch","count","data"],"types":{"count":{"type":"int"},"data":"text","epoch":"varchar"}}},"mode":"UnfilteredBackfill","scanned":"AWJiYgAXDDUA"}},"cursor":"binlog.000123:56789"}
 
 
 ####################################
@@ -151,7 +151,7 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"test%2FCursorResume_26865190":{"backfilled":12,"key_columns":["epoch","count"],"metadata":{"schema":{"columns":["epoch","count","data"],"types":{"count":"int","data":"text","epoch":"varchar"}}},"mode":"Backfill","scanned":"AWNjYwAWBNI="}},"cursor":"binlog.000123:56789"}
+{"bindingStateV1":{"test%2FCursorResume_26865190":{"backfilled":12,"key_columns":["epoch","count"],"metadata":{"schema":{"columns":["epoch","count","data"],"types":{"count":{"type":"int"},"data":"text","epoch":"varchar"}}},"mode":"UnfilteredBackfill","scanned":"AWNjYwAWBNI="}},"cursor":"binlog.000123:56789"}
 
 
 ####################################
@@ -164,7 +164,7 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"test%2FCursorResume_26865190":{"backfilled":13,"key_columns":["epoch","count"],"metadata":{"schema":{"columns":["epoch","count","data"],"types":{"count":"int","data":"text","epoch":"varchar"}}},"mode":"Backfill","scanned":"AWRkZAAS2O8="}},"cursor":"binlog.000123:56789"}
+{"bindingStateV1":{"test%2FCursorResume_26865190":{"backfilled":13,"key_columns":["epoch","count"],"metadata":{"schema":{"columns":["epoch","count","data"],"types":{"count":{"type":"int"},"data":"text","epoch":"varchar"}}},"mode":"UnfilteredBackfill","scanned":"AWRkZAAS2O8="}},"cursor":"binlog.000123:56789"}
 
 
 ####################################
@@ -177,7 +177,7 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"test%2FCursorResume_26865190":{"backfilled":14,"key_columns":["epoch","count"],"metadata":{"schema":{"columns":["epoch","count","data"],"types":{"count":"int","data":"text","epoch":"varchar"}}},"mode":"Backfill","scanned":"AXgAFQE="}},"cursor":"binlog.000123:56789"}
+{"bindingStateV1":{"test%2FCursorResume_26865190":{"backfilled":14,"key_columns":["epoch","count"],"metadata":{"schema":{"columns":["epoch","count","data"],"types":{"count":{"type":"int"},"data":"text","epoch":"varchar"}}},"mode":"UnfilteredBackfill","scanned":"AXgAFQE="}},"cursor":"binlog.000123:56789"}
 
 
 ####################################
@@ -190,7 +190,7 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"test%2FCursorResume_26865190":{"backfilled":15,"key_columns":["epoch","count"],"metadata":{"schema":{"columns":["epoch","count","data"],"types":{"count":"int","data":"text","epoch":"varchar"}}},"mode":"Backfill","scanned":"AXkAFQE="}},"cursor":"binlog.000123:56789"}
+{"bindingStateV1":{"test%2FCursorResume_26865190":{"backfilled":15,"key_columns":["epoch","count"],"metadata":{"schema":{"columns":["epoch","count","data"],"types":{"count":{"type":"int"},"data":"text","epoch":"varchar"}}},"mode":"UnfilteredBackfill","scanned":"AXkAFQE="}},"cursor":"binlog.000123:56789"}
 
 
 ####################################
@@ -203,7 +203,7 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"test%2FCursorResume_26865190":{"backfilled":16,"key_columns":["epoch","count"],"metadata":{"schema":{"columns":["epoch","count","data"],"types":{"count":"int","data":"text","epoch":"varchar"}}},"mode":"Backfill","scanned":"AXoAFQE="}},"cursor":"binlog.000123:56789"}
+{"bindingStateV1":{"test%2FCursorResume_26865190":{"backfilled":16,"key_columns":["epoch","count"],"metadata":{"schema":{"columns":["epoch","count","data"],"types":{"count":{"type":"int"},"data":"text","epoch":"varchar"}}},"mode":"UnfilteredBackfill","scanned":"AXoAFQE="}},"cursor":"binlog.000123:56789"}
 
 
 ####################################
@@ -212,7 +212,7 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"test%2FCursorResume_26865190":{"backfilled":16,"key_columns":["epoch","count"],"metadata":{"schema":{"columns":["epoch","count","data"],"types":{"count":"int","data":"text","epoch":"varchar"}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
+{"bindingStateV1":{"test%2FCursorResume_26865190":{"backfilled":16,"key_columns":["epoch","count"],"metadata":{"schema":{"columns":["epoch","count","data"],"types":{"count":{"type":"int"},"data":"text","epoch":"varchar"}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
 
 
 

--- a/source-mysql/.snapshots/TestDatetimeNormalization
+++ b/source-mysql/.snapshots/TestDatetimeNormalization
@@ -8,5 +8,5 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"test%2FDatetimeNormalization_24528211":{"backfilled":4,"key_columns":["id"],"metadata":{"schema":{"columns":["id","x"],"types":{"id":"int","x":"datetime"}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
+{"bindingStateV1":{"test%2FDatetimeNormalization_24528211":{"backfilled":4,"key_columns":["id"],"metadata":{"schema":{"columns":["id","x"],"types":{"id":{"type":"int"},"x":"datetime"}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
 

--- a/source-mysql/.snapshots/TestDatetimeNormalization-replication
+++ b/source-mysql/.snapshots/TestDatetimeNormalization-replication
@@ -8,5 +8,5 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"test%2FDatetimeNormalization_24528211":{"backfilled":4,"key_columns":["id"],"metadata":{"schema":{"columns":["id","x"],"types":{"id":"int","x":"datetime"}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
+{"bindingStateV1":{"test%2FDatetimeNormalization_24528211":{"backfilled":4,"key_columns":["id"],"metadata":{"schema":{"columns":["id","x"],"types":{"id":{"type":"int"},"x":"datetime"}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
 

--- a/source-mysql/.snapshots/TestEmptyBlobs-Capture
+++ b/source-mysql/.snapshots/TestEmptyBlobs-Capture
@@ -7,5 +7,5 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"test%2FEmptyBlobs_11214558":{"backfilled":3,"key_columns":["id"],"metadata":{"schema":{"columns":["id","a_varchar","a_varbinary"],"types":{"a_varbinary":"varbinary","a_varchar":"varchar","id":"int"}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
+{"bindingStateV1":{"test%2FEmptyBlobs_11214558":{"backfilled":3,"key_columns":["id"],"metadata":{"schema":{"columns":["id","a_varchar","a_varbinary"],"types":{"a_varbinary":"varbinary","a_varchar":"varchar","id":{"type":"int"}}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
 

--- a/source-mysql/.snapshots/TestEnumDecodingFix-backfill
+++ b/source-mysql/.snapshots/TestEnumDecodingFix-backfill
@@ -9,5 +9,5 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"test%2FEnumDecodingFix_32314857":{"backfilled":5,"key_columns":["id"],"metadata":{"schema":{"columns":["id","category"],"types":{"category":{"enum":["","A","C","B","D"],"type":"enum"},"id":"int"}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
+{"bindingStateV1":{"test%2FEnumDecodingFix_32314857":{"backfilled":5,"key_columns":["id"],"metadata":{"schema":{"columns":["id","category"],"types":{"category":{"enum":["","A","C","B","D"],"type":"enum"},"id":{"type":"int"}}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
 

--- a/source-mysql/.snapshots/TestEnumDecodingFix-replication1
+++ b/source-mysql/.snapshots/TestEnumDecodingFix-replication1
@@ -9,5 +9,5 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"test%2FEnumDecodingFix_32314857":{"backfilled":5,"key_columns":["id"],"metadata":{"schema":{"columns":["id","category"],"types":{"category":{"enum":["","A","C","B","D"],"type":"enum"},"id":"int"}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
+{"bindingStateV1":{"test%2FEnumDecodingFix_32314857":{"backfilled":5,"key_columns":["id"],"metadata":{"schema":{"columns":["id","category"],"types":{"category":{"enum":["","A","C","B","D"],"type":"enum"},"id":{"type":"int"}}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
 

--- a/source-mysql/.snapshots/TestEnumDecodingFix-replication2
+++ b/source-mysql/.snapshots/TestEnumDecodingFix-replication2
@@ -9,5 +9,5 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"test%2FEnumDecodingFix_32314857":{"backfilled":5,"key_columns":["id"],"metadata":{"schema":{"columns":["id","category"],"types":{"category":{"enum":["","A","C","B","D"],"type":"enum"},"id":"int"}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
+{"bindingStateV1":{"test%2FEnumDecodingFix_32314857":{"backfilled":5,"key_columns":["id"],"metadata":{"schema":{"columns":["id","category"],"types":{"category":{"enum":["","A","C","B","D"],"type":"enum"},"id":{"type":"int"}}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
 

--- a/source-mysql/.snapshots/TestEnumEmptyString-backfill
+++ b/source-mysql/.snapshots/TestEnumEmptyString-backfill
@@ -12,5 +12,5 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"test%2FEnumEmptyString_29144777":{"backfilled":8,"key_columns":["id"],"metadata":{"schema":{"columns":["id","category"],"types":{"category":{"enum":["","","A","B","C"],"type":"enum"},"id":"int"}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
+{"bindingStateV1":{"test%2FEnumEmptyString_29144777":{"backfilled":8,"key_columns":["id"],"metadata":{"schema":{"columns":["id","category"],"types":{"category":{"enum":["","","A","B","C"],"type":"enum"},"id":{"type":"int"}}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
 

--- a/source-mysql/.snapshots/TestEnumEmptyString-replication
+++ b/source-mysql/.snapshots/TestEnumEmptyString-replication
@@ -12,5 +12,5 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"test%2FEnumEmptyString_29144777":{"backfilled":8,"key_columns":["id"],"metadata":{"schema":{"columns":["id","category"],"types":{"category":{"enum":["","","A","B","C"],"type":"enum"},"id":"int"}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
+{"bindingStateV1":{"test%2FEnumEmptyString_29144777":{"backfilled":8,"key_columns":["id"],"metadata":{"schema":{"columns":["id","category"],"types":{"category":{"enum":["","","A","B","C"],"type":"enum"},"id":{"type":"int"}}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
 

--- a/source-mysql/.snapshots/TestEnumPrimaryKey
+++ b/source-mysql/.snapshots/TestEnumPrimaryKey
@@ -24,5 +24,5 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"test%2FEnumPrimaryKey_18676708":{"backfilled":20,"key_columns":["category","id"],"metadata":{"schema":{"columns":["category","id","data"],"types":{"category":{"enum":["","A","C","B","D"],"type":"enum"},"data":"text","id":"int"}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
+{"bindingStateV1":{"test%2FEnumPrimaryKey_18676708":{"backfilled":20,"key_columns":["category","id"],"metadata":{"schema":{"columns":["category","id","data"],"types":{"category":{"enum":["","A","C","B","D"],"type":"enum"},"data":"text","id":{"type":"int"}}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
 

--- a/source-mysql/.snapshots/TestGeneric-CatalogPrimaryKey-capture1
+++ b/source-mysql/.snapshots/TestGeneric-CatalogPrimaryKey-capture1
@@ -104,5 +104,5 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"test%2FGeneric_CatalogPrimaryKey_46055452":{"backfilled":100,"key_columns":["fullname","year"],"metadata":{"schema":{"columns":["year","state","fullname","population"],"types":{"fullname":"varchar","population":"int","state":"varchar","year":"int"}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
+{"bindingStateV1":{"test%2FGeneric_CatalogPrimaryKey_46055452":{"backfilled":100,"key_columns":["fullname","year"],"metadata":{"schema":{"columns":["year","state","fullname","population"],"types":{"fullname":"varchar","population":{"type":"int"},"state":"varchar","year":{"type":"int"}}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
 

--- a/source-mysql/.snapshots/TestGeneric-CatalogPrimaryKey-capture2
+++ b/source-mysql/.snapshots/TestGeneric-CatalogPrimaryKey-capture2
@@ -7,5 +7,5 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"test%2FGeneric_CatalogPrimaryKey_46055452":{"backfilled":100,"key_columns":["fullname","year"],"metadata":{"schema":{"columns":["year","state","fullname","population"],"types":{"fullname":"varchar","population":"int","state":"varchar","year":"int"}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
+{"bindingStateV1":{"test%2FGeneric_CatalogPrimaryKey_46055452":{"backfilled":100,"key_columns":["fullname","year"],"metadata":{"schema":{"columns":["year","state","fullname","population"],"types":{"fullname":"varchar","population":{"type":"int"},"state":"varchar","year":{"type":"int"}}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
 

--- a/source-mysql/.snapshots/TestGeneric-CatalogPrimaryKeyOverride-capture1
+++ b/source-mysql/.snapshots/TestGeneric-CatalogPrimaryKeyOverride-capture1
@@ -104,5 +104,5 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"test%2FGeneric_CatalogPrimaryKeyOverride_83617880":{"backfilled":100,"key_columns":["fullname","year"],"metadata":{"schema":{"columns":["year","state","fullname","population"],"types":{"fullname":"varchar","population":"int","state":"varchar","year":"int"}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
+{"bindingStateV1":{"test%2FGeneric_CatalogPrimaryKeyOverride_83617880":{"backfilled":100,"key_columns":["fullname","year"],"metadata":{"schema":{"columns":["year","state","fullname","population"],"types":{"fullname":"varchar","population":{"type":"int"},"state":"varchar","year":{"type":"int"}}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
 

--- a/source-mysql/.snapshots/TestGeneric-CatalogPrimaryKeyOverride-capture2
+++ b/source-mysql/.snapshots/TestGeneric-CatalogPrimaryKeyOverride-capture2
@@ -7,5 +7,5 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"test%2FGeneric_CatalogPrimaryKeyOverride_83617880":{"backfilled":100,"key_columns":["fullname","year"],"metadata":{"schema":{"columns":["year","state","fullname","population"],"types":{"fullname":"varchar","population":"int","state":"varchar","year":"int"}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
+{"bindingStateV1":{"test%2FGeneric_CatalogPrimaryKeyOverride_83617880":{"backfilled":100,"key_columns":["fullname","year"],"metadata":{"schema":{"columns":["year","state","fullname","population"],"types":{"fullname":"varchar","population":{"type":"int"},"state":"varchar","year":{"type":"int"}}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
 

--- a/source-mysql/.snapshots/TestGeneric-EmptyTable-init
+++ b/source-mysql/.snapshots/TestGeneric-EmptyTable-init
@@ -1,5 +1,5 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"test%2FGeneric_EmptyTable_91431165":{"backfilled":0,"key_columns":["id"],"metadata":{"schema":{"columns":["id","data"],"types":{"data":"text","id":"int"}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
+{"bindingStateV1":{"test%2FGeneric_EmptyTable_91431165":{"backfilled":0,"key_columns":["id"],"metadata":{"schema":{"columns":["id","data"],"types":{"data":"text","id":{"type":"int"}}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
 

--- a/source-mysql/.snapshots/TestGeneric-EmptyTable-main
+++ b/source-mysql/.snapshots/TestGeneric-EmptyTable-main
@@ -7,5 +7,5 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"test%2FGeneric_EmptyTable_91431165":{"backfilled":0,"key_columns":["id"],"metadata":{"schema":{"columns":["id","data"],"types":{"data":"text","id":"int"}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
+{"bindingStateV1":{"test%2FGeneric_EmptyTable_91431165":{"backfilled":0,"key_columns":["id"],"metadata":{"schema":{"columns":["id","data"],"types":{"data":"text","id":{"type":"int"}}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
 

--- a/source-mysql/.snapshots/TestGeneric-IgnoredStreams-capture1
+++ b/source-mysql/.snapshots/TestGeneric-IgnoredStreams-capture1
@@ -7,5 +7,5 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"test%2FGeneric_IgnoredStreams_17789375":{"backfilled":3,"key_columns":["id"],"metadata":{"schema":{"columns":["id","data"],"types":{"data":"text","id":"int"}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
+{"bindingStateV1":{"test%2FGeneric_IgnoredStreams_17789375":{"backfilled":3,"key_columns":["id"],"metadata":{"schema":{"columns":["id","data"],"types":{"data":"text","id":{"type":"int"}}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
 

--- a/source-mysql/.snapshots/TestGeneric-IgnoredStreams-capture2
+++ b/source-mysql/.snapshots/TestGeneric-IgnoredStreams-capture2
@@ -6,5 +6,5 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"test%2FGeneric_IgnoredStreams_17789375":{"backfilled":3,"key_columns":["id"],"metadata":{"schema":{"columns":["id","data"],"types":{"data":"text","id":"int"}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
+{"bindingStateV1":{"test%2FGeneric_IgnoredStreams_17789375":{"backfilled":3,"key_columns":["id"],"metadata":{"schema":{"columns":["id","data"],"types":{"data":"text","id":{"type":"int"}}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
 

--- a/source-mysql/.snapshots/TestGeneric-KeylessCapture-Backfill
+++ b/source-mysql/.snapshots/TestGeneric-KeylessCapture-Backfill
@@ -504,5 +504,5 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"test%2FGeneric_KeylessCapture_91511186":{"backfilled":500,"metadata":{"schema":{"columns":["id","data"],"types":{"data":"text","id":"int"}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
+{"bindingStateV1":{"test%2FGeneric_KeylessCapture_91511186":{"backfilled":500,"metadata":{"schema":{"columns":["id","data"],"types":{"data":"text","id":{"type":"int"}}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
 

--- a/source-mysql/.snapshots/TestGeneric-KeylessCapture-Replication
+++ b/source-mysql/.snapshots/TestGeneric-KeylessCapture-Replication
@@ -504,5 +504,5 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"test%2FGeneric_KeylessCapture_91511186":{"backfilled":500,"metadata":{"schema":{"columns":["id","data"],"types":{"data":"text","id":"int"}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
+{"bindingStateV1":{"test%2FGeneric_KeylessCapture_91511186":{"backfilled":500,"metadata":{"schema":{"columns":["id","data"],"types":{"data":"text","id":{"type":"int"}}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
 

--- a/source-mysql/.snapshots/TestGeneric-MultipleStreams-capture1
+++ b/source-mysql/.snapshots/TestGeneric-MultipleStreams-capture1
@@ -7,5 +7,5 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"test%2FGeneric_MultipleStreams_14930049":{"backfilled":3,"key_columns":["id"],"metadata":{"schema":{"columns":["id","data"],"types":{"data":"text","id":"int"}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
+{"bindingStateV1":{"test%2FGeneric_MultipleStreams_14930049":{"backfilled":3,"key_columns":["id"],"metadata":{"schema":{"columns":["id","data"],"types":{"data":"text","id":{"type":"int"}}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
 

--- a/source-mysql/.snapshots/TestGeneric-MultipleStreams-capture2
+++ b/source-mysql/.snapshots/TestGeneric-MultipleStreams-capture2
@@ -13,5 +13,5 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"test%2FGeneric_MultipleStreams_14930049":{"backfilled":3,"key_columns":["id"],"metadata":{"schema":{"columns":["id","data"],"types":{"data":"text","id":"int"}}},"mode":"Active"},"test%2FGeneric_MultipleStreams_26016615":{"backfilled":3,"key_columns":["id"],"metadata":{"schema":{"columns":["id","data"],"types":{"data":"text","id":"int"}}},"mode":"Active"},"test%2FGeneric_MultipleStreams_30084965":{"backfilled":3,"key_columns":["id"],"metadata":{"schema":{"columns":["id","data"],"types":{"data":"text","id":"int"}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
+{"bindingStateV1":{"test%2FGeneric_MultipleStreams_14930049":{"backfilled":3,"key_columns":["id"],"metadata":{"schema":{"columns":["id","data"],"types":{"data":"text","id":{"type":"int"}}}},"mode":"Active"},"test%2FGeneric_MultipleStreams_26016615":{"backfilled":3,"key_columns":["id"],"metadata":{"schema":{"columns":["id","data"],"types":{"data":"text","id":{"type":"int"}}}},"mode":"Active"},"test%2FGeneric_MultipleStreams_30084965":{"backfilled":3,"key_columns":["id"],"metadata":{"schema":{"columns":["id","data"],"types":{"data":"text","id":{"type":"int"}}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
 

--- a/source-mysql/.snapshots/TestGeneric-MultipleStreams-capture3
+++ b/source-mysql/.snapshots/TestGeneric-MultipleStreams-capture3
@@ -1,5 +1,5 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"test%2FGeneric_MultipleStreams_14930049":{"backfilled":3,"key_columns":["id"],"metadata":{"schema":{"columns":["id","data"],"types":{"data":"text","id":"int"}}},"mode":"Active"},"test%2FGeneric_MultipleStreams_26016615":{"backfilled":0,"metadata":{"schema":{"columns":["id","data"],"types":{"data":"text","id":"int"}}},"mode":"Ignore"},"test%2FGeneric_MultipleStreams_30084965":{"backfilled":3,"key_columns":["id"],"metadata":{"schema":{"columns":["id","data"],"types":{"data":"text","id":"int"}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
+{"bindingStateV1":{"test%2FGeneric_MultipleStreams_14930049":{"backfilled":3,"key_columns":["id"],"metadata":{"schema":{"columns":["id","data"],"types":{"data":"text","id":{"type":"int"}}}},"mode":"Active"},"test%2FGeneric_MultipleStreams_26016615":{"backfilled":0,"metadata":{"schema":{"columns":["id","data"],"types":{"data":"text","id":{"type":"int"}}}},"mode":"Ignore"},"test%2FGeneric_MultipleStreams_30084965":{"backfilled":3,"key_columns":["id"],"metadata":{"schema":{"columns":["id","data"],"types":{"data":"text","id":{"type":"int"}}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
 

--- a/source-mysql/.snapshots/TestGeneric-MultipleStreams-capture4
+++ b/source-mysql/.snapshots/TestGeneric-MultipleStreams-capture4
@@ -9,5 +9,5 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"test%2FGeneric_MultipleStreams_14930049":{"backfilled":3,"key_columns":["id"],"metadata":{"schema":{"columns":["id","data"],"types":{"data":"text","id":"int"}}},"mode":"Active"},"test%2FGeneric_MultipleStreams_26016615":{"backfilled":0,"metadata":{"schema":{"columns":["id","data"],"types":{"data":"text","id":"int"}}},"mode":"Ignore"},"test%2FGeneric_MultipleStreams_30084965":{"backfilled":3,"key_columns":["id"],"metadata":{"schema":{"columns":["id","data"],"types":{"data":"text","id":"int"}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
+{"bindingStateV1":{"test%2FGeneric_MultipleStreams_14930049":{"backfilled":3,"key_columns":["id"],"metadata":{"schema":{"columns":["id","data"],"types":{"data":"text","id":{"type":"int"}}}},"mode":"Active"},"test%2FGeneric_MultipleStreams_26016615":{"backfilled":0,"metadata":{"schema":{"columns":["id","data"],"types":{"data":"text","id":{"type":"int"}}}},"mode":"Ignore"},"test%2FGeneric_MultipleStreams_30084965":{"backfilled":3,"key_columns":["id"],"metadata":{"schema":{"columns":["id","data"],"types":{"data":"text","id":{"type":"int"}}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
 

--- a/source-mysql/.snapshots/TestGeneric-MultipleStreams-capture5
+++ b/source-mysql/.snapshots/TestGeneric-MultipleStreams-capture5
@@ -8,5 +8,5 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"test%2FGeneric_MultipleStreams_14930049":{"backfilled":3,"key_columns":["id"],"metadata":{"schema":{"columns":["id","data"],"types":{"data":"text","id":"int"}}},"mode":"Active"},"test%2FGeneric_MultipleStreams_26016615":{"backfilled":4,"key_columns":["id"],"metadata":{"schema":{"columns":["id","data"],"types":{"data":"text","id":"int"}}},"mode":"Active"},"test%2FGeneric_MultipleStreams_30084965":{"backfilled":3,"key_columns":["id"],"metadata":{"schema":{"columns":["id","data"],"types":{"data":"text","id":"int"}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
+{"bindingStateV1":{"test%2FGeneric_MultipleStreams_14930049":{"backfilled":3,"key_columns":["id"],"metadata":{"schema":{"columns":["id","data"],"types":{"data":"text","id":{"type":"int"}}}},"mode":"Active"},"test%2FGeneric_MultipleStreams_26016615":{"backfilled":4,"key_columns":["id"],"metadata":{"schema":{"columns":["id","data"],"types":{"data":"text","id":{"type":"int"}}}},"mode":"Active"},"test%2FGeneric_MultipleStreams_30084965":{"backfilled":3,"key_columns":["id"],"metadata":{"schema":{"columns":["id","data"],"types":{"data":"text","id":{"type":"int"}}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
 

--- a/source-mysql/.snapshots/TestGeneric-ReplicationDeletes-init
+++ b/source-mysql/.snapshots/TestGeneric-ReplicationDeletes-init
@@ -9,5 +9,5 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"test%2FGeneric_ReplicationDeletes_65713151":{"backfilled":5,"key_columns":["id"],"metadata":{"schema":{"columns":["id","data"],"types":{"data":"text","id":"int"}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
+{"bindingStateV1":{"test%2FGeneric_ReplicationDeletes_65713151":{"backfilled":5,"key_columns":["id"],"metadata":{"schema":{"columns":["id","data"],"types":{"data":"text","id":{"type":"int"}}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
 

--- a/source-mysql/.snapshots/TestGeneric-ReplicationDeletes-main
+++ b/source-mysql/.snapshots/TestGeneric-ReplicationDeletes-main
@@ -9,5 +9,5 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"test%2FGeneric_ReplicationDeletes_65713151":{"backfilled":5,"key_columns":["id"],"metadata":{"schema":{"columns":["id","data"],"types":{"data":"text","id":"int"}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
+{"bindingStateV1":{"test%2FGeneric_ReplicationDeletes_65713151":{"backfilled":5,"key_columns":["id"],"metadata":{"schema":{"columns":["id","data"],"types":{"data":"text","id":{"type":"int"}}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
 

--- a/source-mysql/.snapshots/TestGeneric-ReplicationInserts-init
+++ b/source-mysql/.snapshots/TestGeneric-ReplicationInserts-init
@@ -9,5 +9,5 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"test%2FGeneric_ReplicationInserts_58418982":{"backfilled":5,"key_columns":["id"],"metadata":{"schema":{"columns":["id","data"],"types":{"data":"text","id":"int"}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
+{"bindingStateV1":{"test%2FGeneric_ReplicationInserts_58418982":{"backfilled":5,"key_columns":["id"],"metadata":{"schema":{"columns":["id","data"],"types":{"data":"text","id":{"type":"int"}}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
 

--- a/source-mysql/.snapshots/TestGeneric-ReplicationInserts-main
+++ b/source-mysql/.snapshots/TestGeneric-ReplicationInserts-main
@@ -7,5 +7,5 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"test%2FGeneric_ReplicationInserts_58418982":{"backfilled":5,"key_columns":["id"],"metadata":{"schema":{"columns":["id","data"],"types":{"data":"text","id":"int"}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
+{"bindingStateV1":{"test%2FGeneric_ReplicationInserts_58418982":{"backfilled":5,"key_columns":["id"],"metadata":{"schema":{"columns":["id","data"],"types":{"data":"text","id":{"type":"int"}}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
 

--- a/source-mysql/.snapshots/TestGeneric-ReplicationOnly-replication
+++ b/source-mysql/.snapshots/TestGeneric-ReplicationOnly-replication
@@ -2052,5 +2052,5 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"test%2FGeneric_ReplicationOnly_34322067":{"backfilled":0,"metadata":{"schema":{"columns":["id","data"],"types":{"data":"text","id":"int"}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
+{"bindingStateV1":{"test%2FGeneric_ReplicationOnly_34322067":{"backfilled":0,"metadata":{"schema":{"columns":["id","data"],"types":{"data":"text","id":{"type":"int"}}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
 

--- a/source-mysql/.snapshots/TestGeneric-ReplicationUpdates-init
+++ b/source-mysql/.snapshots/TestGeneric-ReplicationUpdates-init
@@ -7,5 +7,5 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"test%2FGeneric_ReplicationUpdates_79710599":{"backfilled":3,"key_columns":["id"],"metadata":{"schema":{"columns":["id","data"],"types":{"data":"text","id":"int"}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
+{"bindingStateV1":{"test%2FGeneric_ReplicationUpdates_79710599":{"backfilled":3,"key_columns":["id"],"metadata":{"schema":{"columns":["id","data"],"types":{"data":"text","id":{"type":"int"}}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
 

--- a/source-mysql/.snapshots/TestGeneric-ReplicationUpdates-main
+++ b/source-mysql/.snapshots/TestGeneric-ReplicationUpdates-main
@@ -9,5 +9,5 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"test%2FGeneric_ReplicationUpdates_79710599":{"backfilled":3,"key_columns":["id"],"metadata":{"schema":{"columns":["id","data"],"types":{"data":"text","id":"int"}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
+{"bindingStateV1":{"test%2FGeneric_ReplicationUpdates_79710599":{"backfilled":3,"key_columns":["id"],"metadata":{"schema":{"columns":["id","data"],"types":{"data":"text","id":{"type":"int"}}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
 

--- a/source-mysql/.snapshots/TestGeneric-SimpleCapture
+++ b/source-mysql/.snapshots/TestGeneric-SimpleCapture
@@ -9,5 +9,5 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"test%2FGeneric_SimpleCapture_24869578":{"backfilled":5,"key_columns":["id"],"metadata":{"schema":{"columns":["id","data"],"types":{"data":"text","id":"int"}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
+{"bindingStateV1":{"test%2FGeneric_SimpleCapture_24869578":{"backfilled":5,"key_columns":["id"],"metadata":{"schema":{"columns":["id","data"],"types":{"data":"text","id":{"type":"int"}}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
 

--- a/source-mysql/.snapshots/TestGeneric-StressCorrectness
+++ b/source-mysql/.snapshots/TestGeneric-StressCorrectness
@@ -6,5 +6,5 @@ no invariant violations observed
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"test%2FGeneric_StressCorrectness_51314288":{"backfilled":999,"key_columns":["id"],"metadata":{"schema":{"columns":["id","counter"],"types":{"counter":"int","id":"int"}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
+{"bindingStateV1":{"test%2FGeneric_StressCorrectness_51314288":{"backfilled":999,"key_columns":["id"],"metadata":{"schema":{"columns":["id","counter"],"types":{"counter":{"type":"int"},"id":{"type":"int"}}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
 

--- a/source-mysql/.snapshots/TestPartitionedTable-Capture
+++ b/source-mysql/.snapshots/TestPartitionedTable-Capture
@@ -104,5 +104,5 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"test%2FPartitionedTable_83812828":{"backfilled":100,"key_columns":["grp","id"],"metadata":{"schema":{"columns":["grp","id","data"],"types":{"data":"text","grp":"int","id":"int"}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
+{"bindingStateV1":{"test%2FPartitionedTable_83812828":{"backfilled":100,"key_columns":["grp","id"],"metadata":{"schema":{"columns":["grp","id","data"],"types":{"data":"text","grp":{"type":"int"},"id":{"type":"int"}}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
 

--- a/source-mysql/.snapshots/TestPartitionedTable-Capture-Replication
+++ b/source-mysql/.snapshots/TestPartitionedTable-Capture-Replication
@@ -104,5 +104,5 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"test%2FPartitionedTable_83812828":{"backfilled":100,"key_columns":["grp","id"],"metadata":{"schema":{"columns":["grp","id","data"],"types":{"data":"text","grp":"int","id":"int"}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
+{"bindingStateV1":{"test%2FPartitionedTable_83812828":{"backfilled":100,"key_columns":["grp","id"],"metadata":{"schema":{"columns":["grp","id","data"],"types":{"data":"text","grp":{"type":"int"},"id":{"type":"int"}}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
 

--- a/source-mysql/.snapshots/TestPrerequisites-captureAB
+++ b/source-mysql/.snapshots/TestPrerequisites-captureAB
@@ -6,5 +6,5 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"test%2FPrerequisites_18262250":{"backfilled":2,"key_columns":["id"],"metadata":{"schema":{"columns":["id","data"],"types":{"data":"text","id":"int"}}},"mode":"Active"},"test%2FPrerequisites_25515955":{"backfilled":0,"key_columns":["id"],"metadata":{"schema":{"columns":["id","data"],"types":{"data":"text","id":"int"}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
+{"bindingStateV1":{"test%2FPrerequisites_18262250":{"backfilled":2,"key_columns":["id"],"metadata":{"schema":{"columns":["id","data"],"types":{"data":"text","id":{"type":"int"}}}},"mode":"Active"},"test%2FPrerequisites_25515955":{"backfilled":0,"key_columns":["id"],"metadata":{"schema":{"columns":["id","data"],"types":{"data":"text","id":{"type":"int"}}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
 

--- a/source-mysql/.snapshots/TestScanKeyTypes-BigInt
+++ b/source-mysql/.snapshots/TestScanKeyTypes-BigInt
@@ -8,7 +8,7 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"test%2FScanKeyTypes_BigInt_754161260003":{"backfilled":1,"key_columns":["k"],"metadata":{"schema":{"columns":["k","data"],"types":{"data":"text","k":"bigint"}}},"mode":"Backfill","scanned":"E/w="}},"cursor":"binlog.000123:56789"}
+{"bindingStateV1":{"test%2FScanKeyTypes_BigInt_754161260003":{"backfilled":1,"key_columns":["k"],"metadata":{"schema":{"columns":["k","data"],"types":{"data":"text","k":{"type":"bigint"}}}},"mode":"Backfill","scanned":"E/w="}},"cursor":"binlog.000123:56789"}
 
 
 ####################################
@@ -21,7 +21,7 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"test%2FScanKeyTypes_BigInt_754161260003":{"backfilled":2,"key_columns":["k"],"metadata":{"schema":{"columns":["k","data"],"types":{"data":"text","k":"bigint"}}},"mode":"Backfill","scanned":"FA=="}},"cursor":"binlog.000123:56789"}
+{"bindingStateV1":{"test%2FScanKeyTypes_BigInt_754161260003":{"backfilled":2,"key_columns":["k"],"metadata":{"schema":{"columns":["k","data"],"types":{"data":"text","k":{"type":"bigint"}}}},"mode":"Backfill","scanned":"FA=="}},"cursor":"binlog.000123:56789"}
 
 
 ####################################
@@ -34,7 +34,7 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"test%2FScanKeyTypes_BigInt_754161260003":{"backfilled":3,"key_columns":["k"],"metadata":{"schema":{"columns":["k","data"],"types":{"data":"text","k":"bigint"}}},"mode":"Backfill","scanned":"FQI="}},"cursor":"binlog.000123:56789"}
+{"bindingStateV1":{"test%2FScanKeyTypes_BigInt_754161260003":{"backfilled":3,"key_columns":["k"],"metadata":{"schema":{"columns":["k","data"],"types":{"data":"text","k":{"type":"bigint"}}}},"mode":"Backfill","scanned":"FQI="}},"cursor":"binlog.000123:56789"}
 
 
 ####################################
@@ -47,7 +47,7 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"test%2FScanKeyTypes_BigInt_754161260003":{"backfilled":4,"key_columns":["k"],"metadata":{"schema":{"columns":["k","data"],"types":{"data":"text","k":"bigint"}}},"mode":"Backfill","scanned":"Fga7"}},"cursor":"binlog.000123:56789"}
+{"bindingStateV1":{"test%2FScanKeyTypes_BigInt_754161260003":{"backfilled":4,"key_columns":["k"],"metadata":{"schema":{"columns":["k","data"],"types":{"data":"text","k":{"type":"bigint"}}}},"mode":"Backfill","scanned":"Fga7"}},"cursor":"binlog.000123:56789"}
 
 
 ####################################
@@ -56,7 +56,7 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"test%2FScanKeyTypes_BigInt_754161260003":{"backfilled":4,"key_columns":["k"],"metadata":{"schema":{"columns":["k","data"],"types":{"data":"text","k":"bigint"}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
+{"bindingStateV1":{"test%2FScanKeyTypes_BigInt_754161260003":{"backfilled":4,"key_columns":["k"],"metadata":{"schema":{"columns":["k","data"],"types":{"data":"text","k":{"type":"bigint"}}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
 
 
 

--- a/source-mysql/.snapshots/TestScanKeyTypes-Bool
+++ b/source-mysql/.snapshots/TestScanKeyTypes-Bool
@@ -8,7 +8,7 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"test%2FScanKeyTypes_Bool_754161260000":{"backfilled":1,"key_columns":["k"],"metadata":{"schema":{"columns":["k","data"],"types":{"data":"text","k":"tinyint"}}},"mode":"Backfill","scanned":"FA=="}},"cursor":"binlog.000123:56789"}
+{"bindingStateV1":{"test%2FScanKeyTypes_Bool_754161260000":{"backfilled":1,"key_columns":["k"],"metadata":{"schema":{"columns":["k","data"],"types":{"data":"text","k":{"type":"tinyint"}}}},"mode":"Backfill","scanned":"FA=="}},"cursor":"binlog.000123:56789"}
 
 
 ####################################
@@ -21,7 +21,7 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"test%2FScanKeyTypes_Bool_754161260000":{"backfilled":2,"key_columns":["k"],"metadata":{"schema":{"columns":["k","data"],"types":{"data":"text","k":"tinyint"}}},"mode":"Backfill","scanned":"FQE="}},"cursor":"binlog.000123:56789"}
+{"bindingStateV1":{"test%2FScanKeyTypes_Bool_754161260000":{"backfilled":2,"key_columns":["k"],"metadata":{"schema":{"columns":["k","data"],"types":{"data":"text","k":{"type":"tinyint"}}}},"mode":"Backfill","scanned":"FQE="}},"cursor":"binlog.000123:56789"}
 
 
 ####################################
@@ -30,7 +30,7 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"test%2FScanKeyTypes_Bool_754161260000":{"backfilled":2,"key_columns":["k"],"metadata":{"schema":{"columns":["k","data"],"types":{"data":"text","k":"tinyint"}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
+{"bindingStateV1":{"test%2FScanKeyTypes_Bool_754161260000":{"backfilled":2,"key_columns":["k"],"metadata":{"schema":{"columns":["k","data"],"types":{"data":"text","k":{"type":"tinyint"}}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
 
 
 

--- a/source-mysql/.snapshots/TestScanKeyTypes-Char
+++ b/source-mysql/.snapshots/TestScanKeyTypes-Char
@@ -8,7 +8,7 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"test%2FScanKeyTypes_Char_754161260009":{"backfilled":1,"key_columns":["k"],"metadata":{"schema":{"columns":["k","data"],"types":{"data":"text","k":"char"}}},"mode":"Backfill","scanned":"AQA="}},"cursor":"binlog.000123:56789"}
+{"bindingStateV1":{"test%2FScanKeyTypes_Char_754161260009":{"backfilled":1,"key_columns":["k"],"metadata":{"schema":{"columns":["k","data"],"types":{"data":"text","k":"char"}}},"mode":"UnfilteredBackfill","scanned":"AQA="}},"cursor":"binlog.000123:56789"}
 
 
 ####################################
@@ -17,50 +17,11 @@
 # ================================
 # Collection "acmeCo/test/test_scankeytypes_char_754161260009": 1 Documents
 # ================================
-{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"ScanKeyTypes_Char_754161260009","cursor":"backfill:1"}},"data":"Data 4","k":"B"}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"ScanKeyTypes_Char_754161260009","cursor":"backfill:1"}},"data":"Data 7","k":"_c"}
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"test%2FScanKeyTypes_Char_754161260009":{"backfilled":2,"key_columns":["k"],"metadata":{"schema":{"columns":["k","data"],"types":{"data":"text","k":"char"}}},"mode":"Backfill","scanned":"AUIA"}},"cursor":"binlog.000123:56789"}
-
-
-####################################
-### Capture from Key "AUIA"
-####################################
-# ================================
-# Collection "acmeCo/test/test_scankeytypes_char_754161260009": 1 Documents
-# ================================
-{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"ScanKeyTypes_Char_754161260009","cursor":"backfill:2"}},"data":"Data 5","k":"E"}
-# ================================
-# Final State Checkpoint
-# ================================
-{"bindingStateV1":{"test%2FScanKeyTypes_Char_754161260009":{"backfilled":3,"key_columns":["k"],"metadata":{"schema":{"columns":["k","data"],"types":{"data":"text","k":"char"}}},"mode":"Backfill","scanned":"AUUA"}},"cursor":"binlog.000123:56789"}
-
-
-####################################
-### Capture from Key "AUUA"
-####################################
-# ================================
-# Collection "acmeCo/test/test_scankeytypes_char_754161260009": 1 Documents
-# ================================
-{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"ScanKeyTypes_Char_754161260009","cursor":"backfill:3"}},"data":"Data 6","k":"H"}
-# ================================
-# Final State Checkpoint
-# ================================
-{"bindingStateV1":{"test%2FScanKeyTypes_Char_754161260009":{"backfilled":4,"key_columns":["k"],"metadata":{"schema":{"columns":["k","data"],"types":{"data":"text","k":"char"}}},"mode":"Backfill","scanned":"AUgA"}},"cursor":"binlog.000123:56789"}
-
-
-####################################
-### Capture from Key "AUgA"
-####################################
-# ================================
-# Collection "acmeCo/test/test_scankeytypes_char_754161260009": 1 Documents
-# ================================
-{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"ScanKeyTypes_Char_754161260009","cursor":"backfill:4"}},"data":"Data 7","k":"_c"}
-# ================================
-# Final State Checkpoint
-# ================================
-{"bindingStateV1":{"test%2FScanKeyTypes_Char_754161260009":{"backfilled":5,"key_columns":["k"],"metadata":{"schema":{"columns":["k","data"],"types":{"data":"text","k":"char"}}},"mode":"Backfill","scanned":"AV9jAA=="}},"cursor":"binlog.000123:56789"}
+{"bindingStateV1":{"test%2FScanKeyTypes_Char_754161260009":{"backfilled":2,"key_columns":["k"],"metadata":{"schema":{"columns":["k","data"],"types":{"data":"text","k":"char"}}},"mode":"UnfilteredBackfill","scanned":"AV9jAA=="}},"cursor":"binlog.000123:56789"}
 
 
 ####################################
@@ -69,11 +30,11 @@
 # ================================
 # Collection "acmeCo/test/test_scankeytypes_char_754161260009": 1 Documents
 # ================================
-{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"ScanKeyTypes_Char_754161260009","cursor":"backfill:5"}},"data":"Data 8","k":"_f"}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"ScanKeyTypes_Char_754161260009","cursor":"backfill:2"}},"data":"Data 8","k":"_f"}
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"test%2FScanKeyTypes_Char_754161260009":{"backfilled":6,"key_columns":["k"],"metadata":{"schema":{"columns":["k","data"],"types":{"data":"text","k":"char"}}},"mode":"Backfill","scanned":"AV9mAA=="}},"cursor":"binlog.000123:56789"}
+{"bindingStateV1":{"test%2FScanKeyTypes_Char_754161260009":{"backfilled":3,"key_columns":["k"],"metadata":{"schema":{"columns":["k","data"],"types":{"data":"text","k":"char"}}},"mode":"UnfilteredBackfill","scanned":"AV9mAA=="}},"cursor":"binlog.000123:56789"}
 
 
 ####################################
@@ -82,11 +43,11 @@
 # ================================
 # Collection "acmeCo/test/test_scankeytypes_char_754161260009": 1 Documents
 # ================================
-{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"ScanKeyTypes_Char_754161260009","cursor":"backfill:6"}},"data":"Data 9","k":"_i"}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"ScanKeyTypes_Char_754161260009","cursor":"backfill:3"}},"data":"Data 9","k":"_i"}
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"test%2FScanKeyTypes_Char_754161260009":{"backfilled":7,"key_columns":["k"],"metadata":{"schema":{"columns":["k","data"],"types":{"data":"text","k":"char"}}},"mode":"Backfill","scanned":"AV9pAA=="}},"cursor":"binlog.000123:56789"}
+{"bindingStateV1":{"test%2FScanKeyTypes_Char_754161260009":{"backfilled":4,"key_columns":["k"],"metadata":{"schema":{"columns":["k","data"],"types":{"data":"text","k":"char"}}},"mode":"UnfilteredBackfill","scanned":"AV9pAA=="}},"cursor":"binlog.000123:56789"}
 
 
 ####################################
@@ -95,11 +56,11 @@
 # ================================
 # Collection "acmeCo/test/test_scankeytypes_char_754161260009": 1 Documents
 # ================================
-{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"ScanKeyTypes_Char_754161260009","cursor":"backfill:7"}},"data":"Data 1","k":"a"}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"ScanKeyTypes_Char_754161260009","cursor":"backfill:4"}},"data":"Data 1","k":"a"}
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"test%2FScanKeyTypes_Char_754161260009":{"backfilled":8,"key_columns":["k"],"metadata":{"schema":{"columns":["k","data"],"types":{"data":"text","k":"char"}}},"mode":"Backfill","scanned":"AWEA"}},"cursor":"binlog.000123:56789"}
+{"bindingStateV1":{"test%2FScanKeyTypes_Char_754161260009":{"backfilled":5,"key_columns":["k"],"metadata":{"schema":{"columns":["k","data"],"types":{"data":"text","k":"char"}}},"mode":"UnfilteredBackfill","scanned":"AWEA"}},"cursor":"binlog.000123:56789"}
 
 
 ####################################
@@ -108,11 +69,24 @@
 # ================================
 # Collection "acmeCo/test/test_scankeytypes_char_754161260009": 1 Documents
 # ================================
-{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"ScanKeyTypes_Char_754161260009","cursor":"backfill:8"}},"data":"Data 2","k":"d"}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"ScanKeyTypes_Char_754161260009","cursor":"backfill:5"}},"data":"Data 4","k":"B"}
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"test%2FScanKeyTypes_Char_754161260009":{"backfilled":9,"key_columns":["k"],"metadata":{"schema":{"columns":["k","data"],"types":{"data":"text","k":"char"}}},"mode":"Backfill","scanned":"AWQA"}},"cursor":"binlog.000123:56789"}
+{"bindingStateV1":{"test%2FScanKeyTypes_Char_754161260009":{"backfilled":6,"key_columns":["k"],"metadata":{"schema":{"columns":["k","data"],"types":{"data":"text","k":"char"}}},"mode":"UnfilteredBackfill","scanned":"AUIA"}},"cursor":"binlog.000123:56789"}
+
+
+####################################
+### Capture from Key "AUIA"
+####################################
+# ================================
+# Collection "acmeCo/test/test_scankeytypes_char_754161260009": 1 Documents
+# ================================
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"ScanKeyTypes_Char_754161260009","cursor":"backfill:6"}},"data":"Data 2","k":"d"}
+# ================================
+# Final State Checkpoint
+# ================================
+{"bindingStateV1":{"test%2FScanKeyTypes_Char_754161260009":{"backfilled":7,"key_columns":["k"],"metadata":{"schema":{"columns":["k","data"],"types":{"data":"text","k":"char"}}},"mode":"UnfilteredBackfill","scanned":"AWQA"}},"cursor":"binlog.000123:56789"}
 
 
 ####################################
@@ -121,15 +95,41 @@
 # ================================
 # Collection "acmeCo/test/test_scankeytypes_char_754161260009": 1 Documents
 # ================================
-{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"ScanKeyTypes_Char_754161260009","cursor":"backfill:9"}},"data":"Data 3","k":"g"}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"ScanKeyTypes_Char_754161260009","cursor":"backfill:7"}},"data":"Data 5","k":"E"}
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"test%2FScanKeyTypes_Char_754161260009":{"backfilled":10,"key_columns":["k"],"metadata":{"schema":{"columns":["k","data"],"types":{"data":"text","k":"char"}}},"mode":"Backfill","scanned":"AWcA"}},"cursor":"binlog.000123:56789"}
+{"bindingStateV1":{"test%2FScanKeyTypes_Char_754161260009":{"backfilled":8,"key_columns":["k"],"metadata":{"schema":{"columns":["k","data"],"types":{"data":"text","k":"char"}}},"mode":"UnfilteredBackfill","scanned":"AUUA"}},"cursor":"binlog.000123:56789"}
+
+
+####################################
+### Capture from Key "AUUA"
+####################################
+# ================================
+# Collection "acmeCo/test/test_scankeytypes_char_754161260009": 1 Documents
+# ================================
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"ScanKeyTypes_Char_754161260009","cursor":"backfill:8"}},"data":"Data 3","k":"g"}
+# ================================
+# Final State Checkpoint
+# ================================
+{"bindingStateV1":{"test%2FScanKeyTypes_Char_754161260009":{"backfilled":9,"key_columns":["k"],"metadata":{"schema":{"columns":["k","data"],"types":{"data":"text","k":"char"}}},"mode":"UnfilteredBackfill","scanned":"AWcA"}},"cursor":"binlog.000123:56789"}
 
 
 ####################################
 ### Capture from Key "AWcA"
+####################################
+# ================================
+# Collection "acmeCo/test/test_scankeytypes_char_754161260009": 1 Documents
+# ================================
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"ScanKeyTypes_Char_754161260009","cursor":"backfill:9"}},"data":"Data 6","k":"H"}
+# ================================
+# Final State Checkpoint
+# ================================
+{"bindingStateV1":{"test%2FScanKeyTypes_Char_754161260009":{"backfilled":10,"key_columns":["k"],"metadata":{"schema":{"columns":["k","data"],"types":{"data":"text","k":"char"}}},"mode":"UnfilteredBackfill","scanned":"AUgA"}},"cursor":"binlog.000123:56789"}
+
+
+####################################
+### Capture from Key "AUgA"
 ####################################
 # ================================
 # Final State Checkpoint

--- a/source-mysql/.snapshots/TestScanKeyTypes-Integer
+++ b/source-mysql/.snapshots/TestScanKeyTypes-Integer
@@ -8,7 +8,7 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"test%2FScanKeyTypes_Integer_754161260001":{"backfilled":1,"key_columns":["k"],"metadata":{"schema":{"columns":["k","data"],"types":{"data":"text","k":"int"}}},"mode":"Backfill","scanned":"E/w="}},"cursor":"binlog.000123:56789"}
+{"bindingStateV1":{"test%2FScanKeyTypes_Integer_754161260001":{"backfilled":1,"key_columns":["k"],"metadata":{"schema":{"columns":["k","data"],"types":{"data":"text","k":{"type":"int"}}}},"mode":"Backfill","scanned":"E/w="}},"cursor":"binlog.000123:56789"}
 
 
 ####################################
@@ -21,7 +21,7 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"test%2FScanKeyTypes_Integer_754161260001":{"backfilled":2,"key_columns":["k"],"metadata":{"schema":{"columns":["k","data"],"types":{"data":"text","k":"int"}}},"mode":"Backfill","scanned":"FA=="}},"cursor":"binlog.000123:56789"}
+{"bindingStateV1":{"test%2FScanKeyTypes_Integer_754161260001":{"backfilled":2,"key_columns":["k"],"metadata":{"schema":{"columns":["k","data"],"types":{"data":"text","k":{"type":"int"}}}},"mode":"Backfill","scanned":"FA=="}},"cursor":"binlog.000123:56789"}
 
 
 ####################################
@@ -34,7 +34,7 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"test%2FScanKeyTypes_Integer_754161260001":{"backfilled":3,"key_columns":["k"],"metadata":{"schema":{"columns":["k","data"],"types":{"data":"text","k":"int"}}},"mode":"Backfill","scanned":"FQI="}},"cursor":"binlog.000123:56789"}
+{"bindingStateV1":{"test%2FScanKeyTypes_Integer_754161260001":{"backfilled":3,"key_columns":["k"],"metadata":{"schema":{"columns":["k","data"],"types":{"data":"text","k":{"type":"int"}}}},"mode":"Backfill","scanned":"FQI="}},"cursor":"binlog.000123:56789"}
 
 
 ####################################
@@ -47,7 +47,7 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"test%2FScanKeyTypes_Integer_754161260001":{"backfilled":4,"key_columns":["k"],"metadata":{"schema":{"columns":["k","data"],"types":{"data":"text","k":"int"}}},"mode":"Backfill","scanned":"Fga7"}},"cursor":"binlog.000123:56789"}
+{"bindingStateV1":{"test%2FScanKeyTypes_Integer_754161260001":{"backfilled":4,"key_columns":["k"],"metadata":{"schema":{"columns":["k","data"],"types":{"data":"text","k":{"type":"int"}}}},"mode":"Backfill","scanned":"Fga7"}},"cursor":"binlog.000123:56789"}
 
 
 ####################################
@@ -56,7 +56,7 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"test%2FScanKeyTypes_Integer_754161260001":{"backfilled":4,"key_columns":["k"],"metadata":{"schema":{"columns":["k","data"],"types":{"data":"text","k":"int"}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
+{"bindingStateV1":{"test%2FScanKeyTypes_Integer_754161260001":{"backfilled":4,"key_columns":["k"],"metadata":{"schema":{"columns":["k","data"],"types":{"data":"text","k":{"type":"int"}}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
 
 
 

--- a/source-mysql/.snapshots/TestScanKeyTypes-SmallInt
+++ b/source-mysql/.snapshots/TestScanKeyTypes-SmallInt
@@ -8,7 +8,7 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"test%2FScanKeyTypes_SmallInt_754161260002":{"backfilled":1,"key_columns":["k"],"metadata":{"schema":{"columns":["k","data"],"types":{"data":"text","k":"smallint"}}},"mode":"Backfill","scanned":"E/w="}},"cursor":"binlog.000123:56789"}
+{"bindingStateV1":{"test%2FScanKeyTypes_SmallInt_754161260002":{"backfilled":1,"key_columns":["k"],"metadata":{"schema":{"columns":["k","data"],"types":{"data":"text","k":{"type":"smallint"}}}},"mode":"Backfill","scanned":"E/w="}},"cursor":"binlog.000123:56789"}
 
 
 ####################################
@@ -21,7 +21,7 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"test%2FScanKeyTypes_SmallInt_754161260002":{"backfilled":2,"key_columns":["k"],"metadata":{"schema":{"columns":["k","data"],"types":{"data":"text","k":"smallint"}}},"mode":"Backfill","scanned":"FA=="}},"cursor":"binlog.000123:56789"}
+{"bindingStateV1":{"test%2FScanKeyTypes_SmallInt_754161260002":{"backfilled":2,"key_columns":["k"],"metadata":{"schema":{"columns":["k","data"],"types":{"data":"text","k":{"type":"smallint"}}}},"mode":"Backfill","scanned":"FA=="}},"cursor":"binlog.000123:56789"}
 
 
 ####################################
@@ -34,7 +34,7 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"test%2FScanKeyTypes_SmallInt_754161260002":{"backfilled":3,"key_columns":["k"],"metadata":{"schema":{"columns":["k","data"],"types":{"data":"text","k":"smallint"}}},"mode":"Backfill","scanned":"FQI="}},"cursor":"binlog.000123:56789"}
+{"bindingStateV1":{"test%2FScanKeyTypes_SmallInt_754161260002":{"backfilled":3,"key_columns":["k"],"metadata":{"schema":{"columns":["k","data"],"types":{"data":"text","k":{"type":"smallint"}}}},"mode":"Backfill","scanned":"FQI="}},"cursor":"binlog.000123:56789"}
 
 
 ####################################
@@ -47,7 +47,7 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"test%2FScanKeyTypes_SmallInt_754161260002":{"backfilled":4,"key_columns":["k"],"metadata":{"schema":{"columns":["k","data"],"types":{"data":"text","k":"smallint"}}},"mode":"Backfill","scanned":"Fga7"}},"cursor":"binlog.000123:56789"}
+{"bindingStateV1":{"test%2FScanKeyTypes_SmallInt_754161260002":{"backfilled":4,"key_columns":["k"],"metadata":{"schema":{"columns":["k","data"],"types":{"data":"text","k":{"type":"smallint"}}}},"mode":"Backfill","scanned":"Fga7"}},"cursor":"binlog.000123:56789"}
 
 
 ####################################
@@ -56,7 +56,7 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"test%2FScanKeyTypes_SmallInt_754161260002":{"backfilled":4,"key_columns":["k"],"metadata":{"schema":{"columns":["k","data"],"types":{"data":"text","k":"smallint"}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
+{"bindingStateV1":{"test%2FScanKeyTypes_SmallInt_754161260002":{"backfilled":4,"key_columns":["k"],"metadata":{"schema":{"columns":["k","data"],"types":{"data":"text","k":{"type":"smallint"}}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
 
 
 

--- a/source-mysql/.snapshots/TestScanKeyTypes-VarChar
+++ b/source-mysql/.snapshots/TestScanKeyTypes-VarChar
@@ -8,7 +8,7 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"test%2FScanKeyTypes_VarChar_754161260008":{"backfilled":1,"key_columns":["k"],"metadata":{"schema":{"columns":["k","data"],"types":{"data":"text","k":"varchar"}}},"mode":"Backfill","scanned":"AQA="}},"cursor":"binlog.000123:56789"}
+{"bindingStateV1":{"test%2FScanKeyTypes_VarChar_754161260008":{"backfilled":1,"key_columns":["k"],"metadata":{"schema":{"columns":["k","data"],"types":{"data":"text","k":"varchar"}}},"mode":"UnfilteredBackfill","scanned":"AQA="}},"cursor":"binlog.000123:56789"}
 
 
 ####################################
@@ -17,50 +17,11 @@
 # ================================
 # Collection "acmeCo/test/test_scankeytypes_varchar_754161260008": 1 Documents
 # ================================
-{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"ScanKeyTypes_VarChar_754161260008","cursor":"backfill:1"}},"data":"Data 4","k":"B"}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"ScanKeyTypes_VarChar_754161260008","cursor":"backfill:1"}},"data":"Data 7","k":"_c"}
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"test%2FScanKeyTypes_VarChar_754161260008":{"backfilled":2,"key_columns":["k"],"metadata":{"schema":{"columns":["k","data"],"types":{"data":"text","k":"varchar"}}},"mode":"Backfill","scanned":"AUIA"}},"cursor":"binlog.000123:56789"}
-
-
-####################################
-### Capture from Key "AUIA"
-####################################
-# ================================
-# Collection "acmeCo/test/test_scankeytypes_varchar_754161260008": 1 Documents
-# ================================
-{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"ScanKeyTypes_VarChar_754161260008","cursor":"backfill:2"}},"data":"Data 5","k":"E"}
-# ================================
-# Final State Checkpoint
-# ================================
-{"bindingStateV1":{"test%2FScanKeyTypes_VarChar_754161260008":{"backfilled":3,"key_columns":["k"],"metadata":{"schema":{"columns":["k","data"],"types":{"data":"text","k":"varchar"}}},"mode":"Backfill","scanned":"AUUA"}},"cursor":"binlog.000123:56789"}
-
-
-####################################
-### Capture from Key "AUUA"
-####################################
-# ================================
-# Collection "acmeCo/test/test_scankeytypes_varchar_754161260008": 1 Documents
-# ================================
-{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"ScanKeyTypes_VarChar_754161260008","cursor":"backfill:3"}},"data":"Data 6","k":"H"}
-# ================================
-# Final State Checkpoint
-# ================================
-{"bindingStateV1":{"test%2FScanKeyTypes_VarChar_754161260008":{"backfilled":4,"key_columns":["k"],"metadata":{"schema":{"columns":["k","data"],"types":{"data":"text","k":"varchar"}}},"mode":"Backfill","scanned":"AUgA"}},"cursor":"binlog.000123:56789"}
-
-
-####################################
-### Capture from Key "AUgA"
-####################################
-# ================================
-# Collection "acmeCo/test/test_scankeytypes_varchar_754161260008": 1 Documents
-# ================================
-{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"ScanKeyTypes_VarChar_754161260008","cursor":"backfill:4"}},"data":"Data 7","k":"_c"}
-# ================================
-# Final State Checkpoint
-# ================================
-{"bindingStateV1":{"test%2FScanKeyTypes_VarChar_754161260008":{"backfilled":5,"key_columns":["k"],"metadata":{"schema":{"columns":["k","data"],"types":{"data":"text","k":"varchar"}}},"mode":"Backfill","scanned":"AV9jAA=="}},"cursor":"binlog.000123:56789"}
+{"bindingStateV1":{"test%2FScanKeyTypes_VarChar_754161260008":{"backfilled":2,"key_columns":["k"],"metadata":{"schema":{"columns":["k","data"],"types":{"data":"text","k":"varchar"}}},"mode":"UnfilteredBackfill","scanned":"AV9jAA=="}},"cursor":"binlog.000123:56789"}
 
 
 ####################################
@@ -69,11 +30,11 @@
 # ================================
 # Collection "acmeCo/test/test_scankeytypes_varchar_754161260008": 1 Documents
 # ================================
-{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"ScanKeyTypes_VarChar_754161260008","cursor":"backfill:5"}},"data":"Data 8","k":"_f"}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"ScanKeyTypes_VarChar_754161260008","cursor":"backfill:2"}},"data":"Data 8","k":"_f"}
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"test%2FScanKeyTypes_VarChar_754161260008":{"backfilled":6,"key_columns":["k"],"metadata":{"schema":{"columns":["k","data"],"types":{"data":"text","k":"varchar"}}},"mode":"Backfill","scanned":"AV9mAA=="}},"cursor":"binlog.000123:56789"}
+{"bindingStateV1":{"test%2FScanKeyTypes_VarChar_754161260008":{"backfilled":3,"key_columns":["k"],"metadata":{"schema":{"columns":["k","data"],"types":{"data":"text","k":"varchar"}}},"mode":"UnfilteredBackfill","scanned":"AV9mAA=="}},"cursor":"binlog.000123:56789"}
 
 
 ####################################
@@ -82,11 +43,11 @@
 # ================================
 # Collection "acmeCo/test/test_scankeytypes_varchar_754161260008": 1 Documents
 # ================================
-{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"ScanKeyTypes_VarChar_754161260008","cursor":"backfill:6"}},"data":"Data 9","k":"_i"}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"ScanKeyTypes_VarChar_754161260008","cursor":"backfill:3"}},"data":"Data 9","k":"_i"}
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"test%2FScanKeyTypes_VarChar_754161260008":{"backfilled":7,"key_columns":["k"],"metadata":{"schema":{"columns":["k","data"],"types":{"data":"text","k":"varchar"}}},"mode":"Backfill","scanned":"AV9pAA=="}},"cursor":"binlog.000123:56789"}
+{"bindingStateV1":{"test%2FScanKeyTypes_VarChar_754161260008":{"backfilled":4,"key_columns":["k"],"metadata":{"schema":{"columns":["k","data"],"types":{"data":"text","k":"varchar"}}},"mode":"UnfilteredBackfill","scanned":"AV9pAA=="}},"cursor":"binlog.000123:56789"}
 
 
 ####################################
@@ -95,11 +56,11 @@
 # ================================
 # Collection "acmeCo/test/test_scankeytypes_varchar_754161260008": 1 Documents
 # ================================
-{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"ScanKeyTypes_VarChar_754161260008","cursor":"backfill:7"}},"data":"Data 1","k":"a"}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"ScanKeyTypes_VarChar_754161260008","cursor":"backfill:4"}},"data":"Data 1","k":"a"}
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"test%2FScanKeyTypes_VarChar_754161260008":{"backfilled":8,"key_columns":["k"],"metadata":{"schema":{"columns":["k","data"],"types":{"data":"text","k":"varchar"}}},"mode":"Backfill","scanned":"AWEA"}},"cursor":"binlog.000123:56789"}
+{"bindingStateV1":{"test%2FScanKeyTypes_VarChar_754161260008":{"backfilled":5,"key_columns":["k"],"metadata":{"schema":{"columns":["k","data"],"types":{"data":"text","k":"varchar"}}},"mode":"UnfilteredBackfill","scanned":"AWEA"}},"cursor":"binlog.000123:56789"}
 
 
 ####################################
@@ -108,11 +69,24 @@
 # ================================
 # Collection "acmeCo/test/test_scankeytypes_varchar_754161260008": 1 Documents
 # ================================
-{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"ScanKeyTypes_VarChar_754161260008","cursor":"backfill:8"}},"data":"Data 2","k":"d"}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"ScanKeyTypes_VarChar_754161260008","cursor":"backfill:5"}},"data":"Data 4","k":"B"}
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"test%2FScanKeyTypes_VarChar_754161260008":{"backfilled":9,"key_columns":["k"],"metadata":{"schema":{"columns":["k","data"],"types":{"data":"text","k":"varchar"}}},"mode":"Backfill","scanned":"AWQA"}},"cursor":"binlog.000123:56789"}
+{"bindingStateV1":{"test%2FScanKeyTypes_VarChar_754161260008":{"backfilled":6,"key_columns":["k"],"metadata":{"schema":{"columns":["k","data"],"types":{"data":"text","k":"varchar"}}},"mode":"UnfilteredBackfill","scanned":"AUIA"}},"cursor":"binlog.000123:56789"}
+
+
+####################################
+### Capture from Key "AUIA"
+####################################
+# ================================
+# Collection "acmeCo/test/test_scankeytypes_varchar_754161260008": 1 Documents
+# ================================
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"ScanKeyTypes_VarChar_754161260008","cursor":"backfill:6"}},"data":"Data 2","k":"d"}
+# ================================
+# Final State Checkpoint
+# ================================
+{"bindingStateV1":{"test%2FScanKeyTypes_VarChar_754161260008":{"backfilled":7,"key_columns":["k"],"metadata":{"schema":{"columns":["k","data"],"types":{"data":"text","k":"varchar"}}},"mode":"UnfilteredBackfill","scanned":"AWQA"}},"cursor":"binlog.000123:56789"}
 
 
 ####################################
@@ -121,15 +95,41 @@
 # ================================
 # Collection "acmeCo/test/test_scankeytypes_varchar_754161260008": 1 Documents
 # ================================
-{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"ScanKeyTypes_VarChar_754161260008","cursor":"backfill:9"}},"data":"Data 3","k":"g"}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"ScanKeyTypes_VarChar_754161260008","cursor":"backfill:7"}},"data":"Data 5","k":"E"}
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"test%2FScanKeyTypes_VarChar_754161260008":{"backfilled":10,"key_columns":["k"],"metadata":{"schema":{"columns":["k","data"],"types":{"data":"text","k":"varchar"}}},"mode":"Backfill","scanned":"AWcA"}},"cursor":"binlog.000123:56789"}
+{"bindingStateV1":{"test%2FScanKeyTypes_VarChar_754161260008":{"backfilled":8,"key_columns":["k"],"metadata":{"schema":{"columns":["k","data"],"types":{"data":"text","k":"varchar"}}},"mode":"UnfilteredBackfill","scanned":"AUUA"}},"cursor":"binlog.000123:56789"}
+
+
+####################################
+### Capture from Key "AUUA"
+####################################
+# ================================
+# Collection "acmeCo/test/test_scankeytypes_varchar_754161260008": 1 Documents
+# ================================
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"ScanKeyTypes_VarChar_754161260008","cursor":"backfill:8"}},"data":"Data 3","k":"g"}
+# ================================
+# Final State Checkpoint
+# ================================
+{"bindingStateV1":{"test%2FScanKeyTypes_VarChar_754161260008":{"backfilled":9,"key_columns":["k"],"metadata":{"schema":{"columns":["k","data"],"types":{"data":"text","k":"varchar"}}},"mode":"UnfilteredBackfill","scanned":"AWcA"}},"cursor":"binlog.000123:56789"}
 
 
 ####################################
 ### Capture from Key "AWcA"
+####################################
+# ================================
+# Collection "acmeCo/test/test_scankeytypes_varchar_754161260008": 1 Documents
+# ================================
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"ScanKeyTypes_VarChar_754161260008","cursor":"backfill:9"}},"data":"Data 6","k":"H"}
+# ================================
+# Final State Checkpoint
+# ================================
+{"bindingStateV1":{"test%2FScanKeyTypes_VarChar_754161260008":{"backfilled":10,"key_columns":["k"],"metadata":{"schema":{"columns":["k","data"],"types":{"data":"text","k":"varchar"}}},"mode":"UnfilteredBackfill","scanned":"AUgA"}},"cursor":"binlog.000123:56789"}
+
+
+####################################
+### Capture from Key "AUgA"
 ####################################
 # ================================
 # Final State Checkpoint

--- a/source-mysql/.snapshots/TestSkipBackfills-init
+++ b/source-mysql/.snapshots/TestSkipBackfills-init
@@ -7,5 +7,5 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"test%2FSkipBackfills_11917332":{"backfilled":0,"key_columns":["id"],"metadata":{"schema":{"columns":["id","data"],"types":{"data":"text","id":"int"}}},"mode":"Active"},"test%2FSkipBackfills_20812231":{"backfilled":3,"key_columns":["id"],"metadata":{"schema":{"columns":["id","data"],"types":{"data":"text","id":"int"}}},"mode":"Active"},"test%2FSkipBackfills_30443514":{"backfilled":0,"key_columns":["id"],"metadata":{"schema":{"columns":["id","data"],"types":{"data":"text","id":"int"}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
+{"bindingStateV1":{"test%2FSkipBackfills_11917332":{"backfilled":0,"key_columns":["id"],"metadata":{"schema":{"columns":["id","data"],"types":{"data":"text","id":{"type":"int"}}}},"mode":"Active"},"test%2FSkipBackfills_20812231":{"backfilled":3,"key_columns":["id"],"metadata":{"schema":{"columns":["id","data"],"types":{"data":"text","id":{"type":"int"}}}},"mode":"Active"},"test%2FSkipBackfills_30443514":{"backfilled":0,"key_columns":["id"],"metadata":{"schema":{"columns":["id","data"],"types":{"data":"text","id":{"type":"int"}}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
 

--- a/source-mysql/.snapshots/TestSkipBackfills-main
+++ b/source-mysql/.snapshots/TestSkipBackfills-main
@@ -19,5 +19,5 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"test%2FSkipBackfills_11917332":{"backfilled":0,"key_columns":["id"],"metadata":{"schema":{"columns":["id","data"],"types":{"data":"text","id":"int"}}},"mode":"Active"},"test%2FSkipBackfills_20812231":{"backfilled":3,"key_columns":["id"],"metadata":{"schema":{"columns":["id","data"],"types":{"data":"text","id":"int"}}},"mode":"Active"},"test%2FSkipBackfills_30443514":{"backfilled":0,"key_columns":["id"],"metadata":{"schema":{"columns":["id","data"],"types":{"data":"text","id":"int"}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
+{"bindingStateV1":{"test%2FSkipBackfills_11917332":{"backfilled":0,"key_columns":["id"],"metadata":{"schema":{"columns":["id","data"],"types":{"data":"text","id":{"type":"int"}}}},"mode":"Active"},"test%2FSkipBackfills_20812231":{"backfilled":3,"key_columns":["id"],"metadata":{"schema":{"columns":["id","data"],"types":{"data":"text","id":{"type":"int"}}}},"mode":"Active"},"test%2FSkipBackfills_30443514":{"backfilled":0,"key_columns":["id"],"metadata":{"schema":{"columns":["id","data"],"types":{"data":"text","id":{"type":"int"}}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
 

--- a/source-mysql/.snapshots/TestTrickyColumnNames-backfill
+++ b/source-mysql/.snapshots/TestTrickyColumnNames-backfill
@@ -11,5 +11,5 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"test%2FTrickyColumnNames_14055203":{"backfilled":2,"key_columns":["Meta/`wtf`~ID"],"metadata":{"schema":{"columns":["Meta/`wtf`~ID","data"],"types":{"Meta/`wtf`~ID":"int","data":"text"}}},"mode":"Active"},"test%2FTrickyColumnNames_28395292":{"backfilled":2,"key_columns":["table"],"metadata":{"schema":{"columns":["table","data"],"types":{"data":"text","table":"int"}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
+{"bindingStateV1":{"test%2FTrickyColumnNames_14055203":{"backfilled":2,"key_columns":["Meta/`wtf`~ID"],"metadata":{"schema":{"columns":["Meta/`wtf`~ID","data"],"types":{"Meta/`wtf`~ID":{"type":"int"},"data":"text"}}},"mode":"Active"},"test%2FTrickyColumnNames_28395292":{"backfilled":2,"key_columns":["table"],"metadata":{"schema":{"columns":["table","data"],"types":{"data":"text","table":{"type":"int"}}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
 

--- a/source-mysql/.snapshots/TestTrickyColumnNames-replication
+++ b/source-mysql/.snapshots/TestTrickyColumnNames-replication
@@ -11,5 +11,5 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"test%2FTrickyColumnNames_14055203":{"backfilled":2,"key_columns":["Meta/`wtf`~ID"],"metadata":{"schema":{"columns":["Meta/`wtf`~ID","data"],"types":{"Meta/`wtf`~ID":"int","data":"text"}}},"mode":"Active"},"test%2FTrickyColumnNames_28395292":{"backfilled":2,"key_columns":["table"],"metadata":{"schema":{"columns":["table","data"],"types":{"data":"text","table":"int"}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
+{"bindingStateV1":{"test%2FTrickyColumnNames_14055203":{"backfilled":2,"key_columns":["Meta/`wtf`~ID"],"metadata":{"schema":{"columns":["Meta/`wtf`~ID","data"],"types":{"Meta/`wtf`~ID":{"type":"int"},"data":"text"}}},"mode":"Active"},"test%2FTrickyColumnNames_28395292":{"backfilled":2,"key_columns":["table"],"metadata":{"schema":{"columns":["table","data"],"types":{"data":"text","table":{"type":"int"}}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
 

--- a/source-mysql/.snapshots/TestTrickyTableNames-Capture
+++ b/source-mysql/.snapshots/TestTrickyTableNames-Capture
@@ -6,5 +6,5 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"":{"backfilled":2,"key_columns":["id"],"metadata":{"schema":{"columns":["id","data"],"types":{"data":"text","id":"int"}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
+{"bindingStateV1":{"":{"backfilled":2,"key_columns":["id"],"metadata":{"schema":{"columns":["id","data"],"types":{"data":"text","id":{"type":"int"}}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
 

--- a/source-mysql/.snapshots/TestTrickyTableNames-Capture-Replication
+++ b/source-mysql/.snapshots/TestTrickyTableNames-Capture-Replication
@@ -6,5 +6,5 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"":{"backfilled":2,"key_columns":["id"],"metadata":{"schema":{"columns":["id","data"],"types":{"data":"text","id":"int"}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
+{"bindingStateV1":{"":{"backfilled":2,"key_columns":["id"],"metadata":{"schema":{"columns":["id","data"],"types":{"data":"text","id":{"type":"int"}}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
 

--- a/source-mysql/.snapshots/TestUnsignedIntegers-backfill
+++ b/source-mysql/.snapshots/TestUnsignedIntegers-backfill
@@ -1,0 +1,9 @@
+# ================================
+# Collection "acmeCo/test/test_unsignedintegers_45511171": 1 Documents
+# ================================
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"UnsignedIntegers_45511171","cursor":"backfill:0"}},"id":1,"v1":222,"v2":55555,"v3":11111111,"v4":3333333333,"v8":17777777777777777777}
+# ================================
+# Final State Checkpoint
+# ================================
+{"bindingStateV1":{"test%2FUnsignedIntegers_45511171":{"backfilled":1,"key_columns":["id"],"metadata":{"schema":{"columns":["id","v1","v2","v3","v4","v8"],"types":{"id":"int","v1":"tinyint","v2":"smallint","v3":"mediumint","v4":"int","v8":"bigint"}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
+

--- a/source-mysql/.snapshots/TestUnsignedIntegers-backfill
+++ b/source-mysql/.snapshots/TestUnsignedIntegers-backfill
@@ -5,5 +5,5 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"test%2FUnsignedIntegers_45511171":{"backfilled":1,"key_columns":["id"],"metadata":{"schema":{"columns":["id","v1","v2","v3","v4","v8"],"types":{"id":"int","v1":"tinyint","v2":"smallint","v3":"mediumint","v4":"int","v8":"bigint"}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
+{"bindingStateV1":{"test%2FUnsignedIntegers_45511171":{"backfilled":1,"key_columns":["id"],"metadata":{"schema":{"columns":["id","v1","v2","v3","v4","v8"],"types":{"id":{"type":"int"},"v1":{"type":"tinyint","unsigned":true},"v2":{"type":"smallint","unsigned":true},"v3":{"type":"mediumint","unsigned":true},"v4":{"type":"int","unsigned":true},"v8":{"type":"bigint","unsigned":true}}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
 

--- a/source-mysql/.snapshots/TestUnsignedIntegers-replication
+++ b/source-mysql/.snapshots/TestUnsignedIntegers-replication
@@ -1,0 +1,9 @@
+# ================================
+# Collection "acmeCo/test/test_unsignedintegers_45511171": 1 Documents
+# ================================
+{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"UnsignedIntegers_45511171","cursor":"binlog.000123:56789:123","txid":"11111111-1111-1111-1111-111111111111:111"}},"id":2,"v1":-34,"v2":-9981,"v3":-5666105,"v4":-961633963,"v8":-668966295931773839}
+# ================================
+# Final State Checkpoint
+# ================================
+{"bindingStateV1":{"test%2FUnsignedIntegers_45511171":{"backfilled":1,"key_columns":["id"],"metadata":{"schema":{"columns":["id","v1","v2","v3","v4","v8"],"types":{"id":"int","v1":"tinyint","v2":"smallint","v3":"mediumint","v4":"int","v8":"bigint"}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
+

--- a/source-mysql/.snapshots/TestUnsignedIntegers-replication
+++ b/source-mysql/.snapshots/TestUnsignedIntegers-replication
@@ -1,9 +1,9 @@
 # ================================
 # Collection "acmeCo/test/test_unsignedintegers_45511171": 1 Documents
 # ================================
-{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"UnsignedIntegers_45511171","cursor":"binlog.000123:56789:123","txid":"11111111-1111-1111-1111-111111111111:111"}},"id":2,"v1":-34,"v2":-9981,"v3":-5666105,"v4":-961633963,"v8":-668966295931773839}
+{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"UnsignedIntegers_45511171","cursor":"binlog.000123:56789:123","txid":"11111111-1111-1111-1111-111111111111:111"}},"id":2,"v1":222,"v2":55555,"v3":11111111,"v4":3333333333,"v8":17777777777777777777}
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"test%2FUnsignedIntegers_45511171":{"backfilled":1,"key_columns":["id"],"metadata":{"schema":{"columns":["id","v1","v2","v3","v4","v8"],"types":{"id":"int","v1":"tinyint","v2":"smallint","v3":"mediumint","v4":"int","v8":"bigint"}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
+{"bindingStateV1":{"test%2FUnsignedIntegers_45511171":{"backfilled":1,"key_columns":["id"],"metadata":{"schema":{"columns":["id","v1","v2","v3","v4","v8"],"types":{"id":{"type":"int"},"v1":{"type":"tinyint","unsigned":true},"v2":{"type":"smallint","unsigned":true},"v3":{"type":"mediumint","unsigned":true},"v4":{"type":"int","unsigned":true},"v8":{"type":"bigint","unsigned":true}}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
 

--- a/source-mysql/capture_test.go
+++ b/source-mysql/capture_test.go
@@ -272,3 +272,17 @@ func TestEnumEmptyString(t *testing.T) {
 	tb.Insert(ctx, t, tableName, [][]any{{5, "A"}, {6, "B"}, {7, "C"}, {8, "error"}, {200, 0}, {201, 1}, {202, ""}, {205, 5}})
 	t.Run("replication", func(t *testing.T) { tests.VerifiedCapture(ctx, t, cs) })
 }
+
+func TestUnsignedIntegers(t *testing.T) {
+	var tb, ctx = mysqlTestBackend(t), context.Background()
+	var uniqueID = "45511171"
+	var tableName = tb.CreateTable(ctx, t, uniqueID, "(id INTEGER PRIMARY KEY, v1 TINYINT UNSIGNED, v2 SMALLINT UNSIGNED, v3 MEDIUMINT UNSIGNED, v4 INT UNSIGNED, v8 BIGINT UNSIGNED)")
+	var cs = tb.CaptureSpec(ctx, t, regexp.MustCompile(uniqueID))
+	cs.Validator = &st.OrderedCaptureValidator{}
+
+	// Insert various test values and then capture them via replication
+	tb.Insert(ctx, t, tableName, [][]any{{1, "222", "55555", "11111111", "3333333333", "17777777777777777777"}})
+	t.Run("backfill", func(t *testing.T) { tests.VerifiedCapture(ctx, t, cs) })
+	tb.Insert(ctx, t, tableName, [][]any{{2, "222", "55555", "11111111", "3333333333", "17777777777777777777"}})
+	t.Run("replication", func(t *testing.T) { tests.VerifiedCapture(ctx, t, cs) })
+}

--- a/source-mysql/discovery.go
+++ b/source-mysql/discovery.go
@@ -164,7 +164,8 @@ func (db *mysqlDatabase) TranslateDBToJSONType(column sqlcapture.ColumnInfo) (*j
 		}
 		schema.nullable = column.IsNullable
 		schema.extras = make(map[string]interface{})
-		if columnType.Type == "enum" {
+		switch columnType.Type {
+		case "enum":
 			var options []interface{}
 			for _, val := range columnType.EnumValues {
 				options = append(options, val)
@@ -173,6 +174,10 @@ func (db *mysqlDatabase) TranslateDBToJSONType(column sqlcapture.ColumnInfo) (*j
 				options = append(options, nil)
 			}
 			schema.extras["enum"] = options
+		case "tinyint", "smallint", "mediumint", "int", "bigint":
+			if columnType.Unsigned {
+				schema.extras["minimum"] = 0
+			}
 		}
 		// TODO(wgd): Is there a good way to describe possible SET values
 		// as a JSON schema? Currently discovery just says 'string'.

--- a/source-mysql/main_test.go
+++ b/source-mysql/main_test.go
@@ -459,6 +459,29 @@ func TestAlterTable_AddEnumColumn(t *testing.T) {
 	t.Run("rebackfilled", func(t *testing.T) { tests.VerifiedCapture(ctx, t, cs) })
 }
 
+func TestAlterTable_AddUnsignedColumn(t *testing.T) {
+	var tb, ctx = mysqlTestBackend(t), context.Background()
+	var uniqueID = "57413089"
+	var table = tb.CreateTable(ctx, t, uniqueID, "(id INTEGER PRIMARY KEY, data TEXT)")
+	tb.Insert(ctx, t, table, [][]interface{}{{1, "aaa"}, {2, "bbb"}})
+
+	t.Run("discover1", func(t *testing.T) { tb.CaptureSpec(ctx, t).VerifyDiscover(ctx, t, regexp.MustCompile(uniqueID)) })
+
+	var cs = tb.CaptureSpec(ctx, t, regexp.MustCompile(uniqueID))
+	t.Run("init", func(t *testing.T) { tests.VerifiedCapture(ctx, t, cs) })
+
+	tb.Query(ctx, t, fmt.Sprintf("ALTER TABLE %s ADD COLUMN uintval BIGINT UNSIGNED;", table))
+	tb.Insert(ctx, t, table, [][]interface{}{
+		{3, "eee", "17777777777777777777"},
+		{4, "fff", "18000000000000000000"},
+	})
+	t.Run("discover2", func(t *testing.T) { tb.CaptureSpec(ctx, t).VerifyDiscover(ctx, t, regexp.MustCompile(uniqueID)) })
+	t.Run("modified", func(t *testing.T) { tests.VerifiedCapture(ctx, t, cs) })
+
+	cs = tb.CaptureSpec(ctx, t, regexp.MustCompile(uniqueID))
+	t.Run("rebackfilled", func(t *testing.T) { tests.VerifiedCapture(ctx, t, cs) })
+}
+
 // TestBinlogExpirySanityCheck verifies that the "dangerously short binlog expiry"
 // sanity check is working as intended.
 func TestBinlogExpirySanityCheck(t *testing.T) {

--- a/source-mysql/replication.go
+++ b/source-mysql/replication.go
@@ -681,13 +681,16 @@ func (rs *mysqlReplicationStream) handleAlterTable(ctx context.Context, stmt *sq
 }
 
 func translateDataType(t sqlparser.ColumnType) any {
-	var typeName = strings.ToLower(t.Type)
-	if typeName == "enum" {
+	switch typeName := strings.ToLower(t.Type); typeName {
+	case "enum":
 		return &mysqlColumnType{Type: typeName, EnumValues: append([]string{""}, unquoteEnumValues(t.EnumValues)...)}
-	} else if typeName == "set" {
+	case "set":
 		return &mysqlColumnType{Type: typeName, EnumValues: unquoteEnumValues(t.EnumValues)}
+	case "tinyint", "smallint", "mediumint", "int", "bigint":
+		return &mysqlColumnType{Type: typeName, Unsigned: t.Unsigned}
+	default:
+		return typeName
 	}
-	return typeName
 }
 
 // unquoteEnumValues applies MySQL single-quote-unescaping to a list of single-quoted


### PR DESCRIPTION
**Description:**

Previously there was a bug where values of an unsigned integer column which were received via replication would incorrectly be cast to the bit-equivalent signed integer value. This applied to all widths of integer -- a `TINYINT UNSIGNED` column could demonstrate this with value `222` being incorrectly captured as `-34`.

This applied only to replication, backfilled values were and are still handled correctly.

The root of the issue is that (unlike the value encoding used for backfill query results) the MySQL binlog value representation doesn't distinguish based on the signedness of integer values, only their bit-width. Consequently the client library parsed all such values as signed integers of the appropriate width and we serialized them unmodified.

The fix was to keep track of an additional signed/unsigned flag as part of the column type metadata for integer columns. When the column is unsigned we cast the value to an unsigned integer and where necessary (primarily for the 24-bit `MEDIUMINT` type but we'll handle any weirdness that might theoretically come up by going `intN -> int64 -> uint64 -> mask`) trim off any sign-extended upper bits.

**Workflow steps:**

No user action is required, except in cases where we believe that unsigned integer values might previously have been captured incorrectly. In those cases we should re-backfill the impacted bindings, ideally discarding old data and materializing into a fresh destination table.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1564)
<!-- Reviewable:end -->
