### PR TITLE
sqlcapture: Fix backfill termination on slow, high-volume tables

### DIFF
--- a/source-postgres/backfill.go
+++ b/source-postgres/backfill.go
@@ -11,7 +11,7 @@ import (
 )
 
 // ScanTableChunk fetches a chunk of rows from the specified table, resuming from `resumeKey` if non-nil.
-func (db *postgresDatabase) ScanTableChunk(ctx context.Context, info *sqlcapture.DiscoveryInfo, state *sqlcapture.TableState, callback func(event *sqlcapture.ChangeEvent) error) error {
+func (db *postgresDatabase) ScanTableChunk(ctx context.Context, info *sqlcapture.DiscoveryInfo, state *sqlcapture.TableState, callback func(event *sqlcapture.ChangeEvent) error) (bool, error) {
 	var keyColumns = state.KeyColumns
 	var resumeAfter = state.Scanned
 	var schema, table = info.Schema, info.Name
@@ -42,10 +42,10 @@ func (db *postgresDatabase) ScanTableChunk(ctx context.Context, info *sqlcapture
 		if resumeAfter != nil {
 			var resumeKey, err = sqlcapture.UnpackTuple(resumeAfter, decodeKeyFDB)
 			if err != nil {
-				return fmt.Errorf("error unpacking resume key for %q: %w", streamID, err)
+				return false, fmt.Errorf("error unpacking resume key for %q: %w", streamID, err)
 			}
 			if len(resumeKey) != len(keyColumns) {
-				return fmt.Errorf("expected %d resume-key values but got %d", len(keyColumns), len(resumeKey))
+				return false, fmt.Errorf("expected %d resume-key values but got %d", len(keyColumns), len(resumeKey))
 			}
 			logEntry.WithFields(logrus.Fields{
 				"keyColumns": keyColumns,
@@ -58,7 +58,7 @@ func (db *postgresDatabase) ScanTableChunk(ctx context.Context, info *sqlcapture
 			query = db.buildScanQuery(true, isPrecise, keyColumns, columnTypes, schema, table)
 		}
 	default:
-		return fmt.Errorf("invalid backfill mode %q", state.Mode)
+		return false, fmt.Errorf("invalid backfill mode %q", state.Mode)
 	}
 
 	// Keyless backfill queries need to return results in CTID order, but we can't ask
@@ -85,12 +85,13 @@ func (db *postgresDatabase) ScanTableChunk(ctx context.Context, info *sqlcapture
 	logEntry.WithFields(logrus.Fields{"query": query, "args": args}).Debug("executing query")
 	rows, err := db.conn.Query(ctx, query, args...)
 	if err != nil {
-		return fmt.Errorf("unable to execute query %q: %w", query, err)
+		return false, fmt.Errorf("unable to execute query %q: %w", query, err)
 	}
 	defer rows.Close()
 
 	// Process the results into `changeEvent` structs and return them
 	var cols = rows.FieldDescriptions()
+	var resultRows int // Count of rows received within the current backfill chunk
 	var rowOffset = state.BackfilledCount
 	var prevTID pgtype.TID // Used when processing keyless backfill results to sanity-check ordering
 	logEntry.Debug("translating query rows to change events")
@@ -98,7 +99,7 @@ func (db *postgresDatabase) ScanTableChunk(ctx context.Context, info *sqlcapture
 		// Scan the row values and copy into the equivalent map
 		var vals, err = rows.Values()
 		if err != nil {
-			return fmt.Errorf("unable to get row values: %w", err)
+			return false, fmt.Errorf("unable to get row values: %w", err)
 		}
 		var fields = make(map[string]interface{})
 		for idx := range cols {
@@ -111,22 +112,22 @@ func (db *postgresDatabase) ScanTableChunk(ctx context.Context, info *sqlcapture
 
 			rowKey, err = ctid.EncodeText(db.conn.ConnInfo(), nil)
 			if err != nil {
-				return fmt.Errorf("internal error: failed to encode ctid %#v: %w", ctid, err)
+				return false, fmt.Errorf("internal error: failed to encode ctid %#v: %w", ctid, err)
 			}
 
 			// Sanity check that rows are returned in ascending CTID order within a given backfill chunk
 			if (ctid.BlockNumber < prevTID.BlockNumber) || ((ctid.BlockNumber == prevTID.BlockNumber) && (ctid.OffsetNumber <= prevTID.OffsetNumber)) {
-				return fmt.Errorf("internal error: ctid ordering sanity check failed: %v <= %v", ctid, prevTID)
+				return false, fmt.Errorf("internal error: ctid ordering sanity check failed: %v <= %v", ctid, prevTID)
 			}
 			prevTID = ctid
 		} else {
 			rowKey, err = sqlcapture.EncodeRowKey(keyColumns, fields, columnTypes, encodeKeyFDB)
 			if err != nil {
-				return fmt.Errorf("error encoding row key for %q: %w", streamID, err)
+				return false, fmt.Errorf("error encoding row key for %q: %w", streamID, err)
 			}
 		}
 		if err := translateRecordFields(info, fields); err != nil {
-			return fmt.Errorf("error backfilling table %q: %w", table, err)
+			return false, fmt.Errorf("error backfilling table %q: %w", table, err)
 		}
 
 		var event = &sqlcapture.ChangeEvent{
@@ -145,11 +146,14 @@ func (db *postgresDatabase) ScanTableChunk(ctx context.Context, info *sqlcapture
 			After:  fields,
 		}
 		if err := callback(event); err != nil {
-			return fmt.Errorf("error processing change event: %w", err)
+			return false, fmt.Errorf("error processing change event: %w", err)
 		}
+		resultRows++
 		rowOffset++
 	}
-	return nil
+
+	var backfillComplete = resultRows < db.config.Advanced.BackfillChunkSize
+	return backfillComplete, nil
 }
 
 // WriteWatermark writes the provided string into the 'watermarks' table.

--- a/sqlcapture/interface.go
+++ b/sqlcapture/interface.go
@@ -123,7 +123,8 @@ type Database interface {
 	// WatermarksTable returns the name of the table to which WriteWatermarks writes UUIDs.
 	WatermarksTable() string
 	// ScanTableChunk fetches a chunk of rows from the specified table, resuming from the `resumeAfter` row key if non-nil.
-	ScanTableChunk(ctx context.Context, info *DiscoveryInfo, state *TableState, callback func(event *ChangeEvent) error) error
+	// The `backfillComplete` boolean will be true after scanning the final chunk of the table.
+	ScanTableChunk(ctx context.Context, info *DiscoveryInfo, state *TableState, callback func(event *ChangeEvent) error) (backfillComplete bool, err error)
 	// DiscoverTables queries the database for information about tables available for capture.
 	DiscoverTables(ctx context.Context) (map[string]*DiscoveryInfo, error)
 	// TranslateDBToJSONType returns JSON schema information about the provided database column type.


### PR DESCRIPTION
**Description:**

Historically we have detected when a backfill reaches the end of a table when we receive zero new rows from a backfill query. This usually works fine, but can misbehave when a table is both heavily loaded with new rows constantly inserted at the end *and also* the individual backfill queries are relatively slow.

When this happens, the backfill can keep on issuing queries for up to <chunkSize> rows, and receive a few dozen each time, which keeps the backfill from terminating. And normally that's also benign, so we haven't bothered to fix it up until now.

However there are still a few edge cases where backfill queries can get fairly expensive. The one we're seeing in production right now is queries against a very large keyless table in MySQL, but there are a few other scenarios like that where we would very much like to ensure the backfill ends as soon as it can.

Really any number of result rows from a backfill query less than the chunk size means we've just read the final chunk that we need, so it's conceptually simple enough to switch the condition from `count == 0` to `count < chunkSize`. The only complexity is that there's no easy way for the top-level sqlcapture logic to see what chunk size the capture was configured with. So in order to do it that way I had to add a bit of plumbing so that the `ScanTableChunk` function can determine for itself when the backfill is complete.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1565)
<!-- Reviewable:end -->
