### PR TITLE
materialize-redshift: add back column truncation

### DIFF
--- a/materialize-redshift/.snapshots/TestSQLGeneration
+++ b/materialize-redshift/.snapshots/TestSQLGeneration
@@ -117,7 +117,7 @@ UPDATE path."To".checkpoints
 	AND   fence     = 123;
 --- End Fence Update ---
 
---- Begin Copy From S3 Without Case Sensitive Identifiers---
+--- Begin Copy From S3 Without Case Sensitive Identifiers or Truncation ---
 COPY my_temp_table
 FROM 's3://some_bucket/files.manifest'
 MANIFEST
@@ -127,9 +127,9 @@ JSON 'auto ignorecase'
 GZIP
 DATEFORMAT 'auto'
 TIMEFORMAT 'auto';
---- End Copy From S3 Without Case Sensitive Identifier ---
+--- End Copy From S3 Without Case Sensitive Identifier or Truncation ---
 
---- Begin Copy From S3 With Case Sensitive Identifiers---
+--- Begin Copy From S3 With Case Sensitive Identifiers and Truncation ---
 COPY my_temp_table
 FROM 's3://some_bucket/files.manifest'
 MANIFEST
@@ -138,5 +138,6 @@ REGION 'us-somewhere-1'
 JSON 'auto'
 GZIP
 DATEFORMAT 'auto'
-TIMEFORMAT 'auto';
---- End Copy From S3 With Case Sensitive Identifiers ---
+TIMEFORMAT 'auto'
+TRUNCATECOLUMNS;
+--- End Copy From S3 With Case Sensitive Identifiers and Truncation ---

--- a/materialize-redshift/sqlgen.go
+++ b/materialize-redshift/sqlgen.go
@@ -154,6 +154,7 @@ type copyFromS3Params struct {
 	ManifestURL                    string
 	Config                         *config
 	CaseSensitiveIdentifierEnabled bool
+	TruncateColumns                bool
 }
 
 type loadTableParams struct {
@@ -296,7 +297,12 @@ JSON 'auto ignorecase'
 {{- end }}
 GZIP
 DATEFORMAT 'auto'
-TIMEFORMAT 'auto';
+TIMEFORMAT 'auto'
+{{- if $.TruncateColumns }}
+TRUNCATECOLUMNS;
+{{- else -}}
+;
+{{- end }}
 {{ end }}
 	`)
 	return templates{

--- a/materialize-redshift/sqlgen_test.go
+++ b/materialize-redshift/sqlgen_test.go
@@ -116,15 +116,16 @@ func TestSQLGeneration(t *testing.T) {
 		CaseSensitiveIdentifierEnabled: false,
 	}
 
-	snap.WriteString("--- Begin Copy From S3 Without Case Sensitive Identifiers---")
+	snap.WriteString("--- Begin Copy From S3 Without Case Sensitive Identifiers or Truncation ---")
 	require.NoError(t, templates.copyFromS3.Execute(&snap, copyParams))
-	snap.WriteString("--- End Copy From S3 Without Case Sensitive Identifier ---\n\n")
+	snap.WriteString("--- End Copy From S3 Without Case Sensitive Identifier or Truncation ---\n\n")
 
 	copyParams.CaseSensitiveIdentifierEnabled = true
+	copyParams.TruncateColumns = true
 
-	snap.WriteString("--- Begin Copy From S3 With Case Sensitive Identifiers---")
+	snap.WriteString("--- Begin Copy From S3 With Case Sensitive Identifiers and Truncation ---")
 	require.NoError(t, templates.copyFromS3.Execute(&snap, copyParams))
-	snap.WriteString("--- End Copy From S3 With Case Sensitive Identifiers ---")
+	snap.WriteString("--- End Copy From S3 With Case Sensitive Identifiers and Truncation ---")
 
 	cupaloy.SnapshotT(t, snap.String())
 }


### PR DESCRIPTION
**Description:**

This column truncation was removed in a recent commit under the assumption that the runtime would prevent the connector from seeing strings over the allowed limit, but we are seeing errors resulting from strings being too long to materialize with the newly deployed image.

This adds back the truncation configurations that were removed to get things unbroken in the short-term while I figure out why the original assumption didn't hold.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1566)
<!-- Reviewable:end -->
