### PR TITLE
source-mysql: Stop ignoring query events with leading comments

### DIFF
--- a/source-mysql/replication.go
+++ b/source-mysql/replication.go
@@ -454,7 +454,7 @@ func decodeRow(streamID string, colNames []string, row []interface{}) (map[strin
 // by extracting and ignoring a SET STATEMENT stanza prior to parsing.
 var silentIgnoreQueriesRe = regexp.MustCompile(`(?i)^(BEGIN|# [^\n]*)$`)
 var createDefinerRegex = `CREATE\s*(OR REPLACE){0,1}\s*(ALGORITHM\s*=\s*[^ ]+)*\s*DEFINER`
-var ignoreQueriesRe = regexp.MustCompile(`(?i)^(BEGIN|COMMIT|GRANT|REVOKE|CREATE USER|` + createDefinerRegex + `|DROP USER|ALTER USER|DROP PROCEDURE|DROP FUNCTION|DROP TRIGGER|SET STATEMENT|# |/\*|-- )`)
+var ignoreQueriesRe = regexp.MustCompile(`(?i)^(BEGIN|COMMIT|GRANT|REVOKE|CREATE USER|` + createDefinerRegex + `|DROP USER|ALTER USER|DROP PROCEDURE|DROP FUNCTION|DROP TRIGGER|SET STATEMENT)`)
 
 func (rs *mysqlReplicationStream) handleQuery(ctx context.Context, schema, query string) error {
 	// There are basically three types of query events we might receive:


### PR DESCRIPTION
**Description:**

This PR stops the MySQL replication DDL parsing logic from ignoring queries which begin with a comment.

There were reasons this was expedient in the past, but it's causing us pain at the moment and the Vitess SQL parser ought to be able to cope with the comments themselves -- IIRC the issue in the past was specific queries which began with a comment and used some unsupported statement type or another.

But right now this is the number one issue with our DDL tracking logic, and unlike the second biggest issue (DDL queries which don't get logged at all) it's unarguably our fault we're not handling it well.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1567)
<!-- Reviewable:end -->
