### PR TITLE
source-mysql: Don't specify `minimum: 0` for now

### DIFF
--- a/source-mysql/.snapshots/TestAlterTable_AddUnsignedColumn-discover2
+++ b/source-mysql/.snapshots/TestAlterTable_AddUnsignedColumn-discover2
@@ -24,7 +24,6 @@ Binding 0:
               "type": "integer"
             },
             "uintval": {
-              "minimum": 0,
               "type": [
                 "integer",
                 "null"

--- a/source-mysql/discovery.go
+++ b/source-mysql/discovery.go
@@ -176,7 +176,10 @@ func (db *mysqlDatabase) TranslateDBToJSONType(column sqlcapture.ColumnInfo) (*j
 			schema.extras["enum"] = options
 		case "tinyint", "smallint", "mediumint", "int", "bigint":
 			if columnType.Unsigned {
-				schema.extras["minimum"] = 0
+				// FIXME(wgd)(2024-05-08): We should be specifying `minimum: 0` for unsigned integer
+				// columns but currently there are collections and captures in production
+				// which this breaks. Re-enable this after we've fixed those.
+				// schema.extras["minimum"] = 0
 			}
 		}
 		// TODO(wgd): Is there a good way to describe possible SET values


### PR DESCRIPTION
**Description:**

This broke several things in production and we should get those fixed with correct values of unsigned integer columns before we start enforcing that in the schema.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1569)
<!-- Reviewable:end -->
