### PR TITLE
materialize-databricks: support decimal column validation

### DIFF
--- a/materialize-databricks/sqlgen.go
+++ b/materialize-databricks/sqlgen.go
@@ -101,7 +101,7 @@ var databricksDialect = func() sql.Dialect {
 	columnValidator := sql.NewColumnValidator(
 		sql.ColValidation{Types: []string{"string"}, Validate: stringCompatible},
 		sql.ColValidation{Types: []string{"boolean"}, Validate: sql.BooleanCompatible},
-		sql.ColValidation{Types: []string{"long"}, Validate: sql.IntegerCompatible},
+		sql.ColValidation{Types: []string{"long", "decimal"}, Validate: sql.IntegerCompatible},
 		sql.ColValidation{Types: []string{"double"}, Validate: sql.NumberCompatible},
 		sql.ColValidation{Types: []string{"date"}, Validate: sql.DateCompatible},
 		sql.ColValidation{Types: []string{"timestamp"}, Validate: sql.DateTimeCompatible},


### PR DESCRIPTION
**Description:**

- Tested this using my other branch https://github.com/estuary/connectors/pull/1571 which also runs Validate as part of integration tests. Creating the tables, not deleting them, and running integration tests again, verified an error happens without this pull-request complaining about unknown type `DECIMAL`, whereas with this pull-request Validate passes 👍🏽 
- Separated the other pull-request since it requires more time put into it to update all tests for all materialization connectors

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1570)
<!-- Reviewable:end -->
