### PR TITLE
materialize-databricks: keep base64 encoded string keys as strings

### DIFF
--- a/materialize-databricks/sqlgen.go
+++ b/materialize-databricks/sqlgen.go
@@ -69,8 +69,11 @@ var databricksDialect = func() sql.Dialect {
 
 	// https://docs.databricks.com/en/sql/language-manual/sql-ref-datatypes.html
 	var mapper sql.TypeMapper = sql.ProjectionTypeMapper{
-		sql.ARRAY:    jsonMapper,
-		sql.BINARY:   sql.NewStaticMapper("BINARY"),
+		sql.ARRAY: jsonMapper,
+		sql.BINARY: sql.PrimaryKeyMapper{
+			PrimaryKey: sql.NewStaticMapper("STRING"),
+			Delegate:   sql.NewStaticMapper("BINARY"),
+		},
 		sql.BOOLEAN:  sql.NewStaticMapper("BOOLEAN"),
 		sql.INTEGER:  customDDLMapper(sql.NewStaticMapper("BIGINT")),
 		sql.NUMBER:   sql.NewStaticMapper("DOUBLE"),
@@ -158,12 +161,12 @@ var databricksDialect = func() sql.Dialect {
 // stringCompatible allow strings of any format, arrays, objects, or fields with multiple types to
 // be materialized since they are all converted to strings.
 func stringCompatible(p pf.Projection) bool {
-	// TODO(whb): This is a hack for making sure that pre-existing base64 encoded columns that were
-	// materialized as string columns in v1 fail validation in v2, which will materialize these
-	// columns as binary. This is needed because we currently validate a pre-existing "string"
-	// column positively with a string field having any format, content-type, or content-encoding,
-	// see https://github.com/estuary/connectors/issues/1501.
-	if sql.TypesOrNull(p.Inference.Types, []string{"string"}) {
+	// TODO(whb): This is a hack for making sure that pre-existing non-collection key base64 encoded
+	// columns that were materialized as string columns in v1 fail validation in v2, which will
+	// materialize these columns as binary. This is needed because we currently validate a
+	// pre-existing "string" column positively with a string field having any format, content-type,
+	// or content-encoding, see https://github.com/estuary/connectors/issues/1501.
+	if !p.IsPrimaryKey && sql.TypesOrNull(p.Inference.Types, []string{"string"}) {
 		if p.Inference.String_.ContentEncoding == "base64" {
 			return false
 		}


### PR DESCRIPTION
**Description:**

As a simplification to avoid having to deal with equality comparisons between binary columns and staged JSON values, we'll keep materializing collection keys with base64 encoding as strings.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1572)
<!-- Reviewable:end -->
