### PR TITLE
materialize-databricks: support binary primary keys

### DIFF
--- a/materialize-databricks/.snapshots/TestSQLGeneration
+++ b/materialize-databricks/.snapshots/TestSQLGeneration
@@ -13,7 +13,7 @@ SELECT 0, `a-schema`.target_table.flow_document
 			FROM json.`file2`
 		)
 	) AS r
-	ON `a-schema`.target_table.key1 = r.key1 AND `a-schema`.target_table.key2 = r.key2
+	ON `a-schema`.target_table.key1 = r.key1 AND `a-schema`.target_table.key2 = unbase64(r.key2)
 --- End `a-schema`.target_table loadQuery ---
 
 --- Begin `a-schema`.target_table mergeInto ---
@@ -21,12 +21,12 @@ SELECT 0, `a-schema`.target_table.flow_document
 	USING (
 		(
 			SELECT
-			key1::BIGINT, key2::BOOLEAN, unbase64(binary)::BINARY as binary, boolean::BOOLEAN, integer::BIGINT, `unsigned-integer`::DECIMAL(20), number::DOUBLE, string::STRING, flow_document::STRING
+			key1::BIGINT, unbase64(key2)::BINARY as key2, unbase64(binary)::BINARY as binary, boolean::BOOLEAN, integer::BIGINT, `unsigned-integer`::DECIMAL(20), number::DOUBLE, string::STRING, flow_document::STRING
 			FROM json.`file1`
 		)
 		 UNION ALL (
 			SELECT
-			key1::BIGINT, key2::BOOLEAN, unbase64(binary)::BINARY as binary, boolean::BOOLEAN, integer::BIGINT, `unsigned-integer`::DECIMAL(20), number::DOUBLE, string::STRING, flow_document::STRING
+			key1::BIGINT, unbase64(key2)::BINARY as key2, unbase64(binary)::BINARY as binary, boolean::BOOLEAN, integer::BIGINT, `unsigned-integer`::DECIMAL(20), number::DOUBLE, string::STRING, flow_document::STRING
 			FROM json.`file2`
 		)
 	) AS r
@@ -43,7 +43,7 @@ SELECT 0, `a-schema`.target_table.flow_document
 --- Begin `a-schema`.target_table copyIntoDirect ---
 	COPY INTO `a-schema`.target_table FROM (
     SELECT
-		key1::BIGINT, key2::BOOLEAN, unbase64(binary)::BINARY as binary, boolean::BOOLEAN, integer::BIGINT, `unsigned-integer`::DECIMAL(20), number::DOUBLE, string::STRING, flow_document::STRING
+		key1::BIGINT, unbase64(key2)::BINARY as key2, unbase64(binary)::BINARY as binary, boolean::BOOLEAN, integer::BIGINT, `unsigned-integer`::DECIMAL(20), number::DOUBLE, string::STRING, flow_document::STRING
   FROM 'test-staging-path'
 	)
   FILEFORMAT = JSON
@@ -56,7 +56,7 @@ SELECT 0, `a-schema`.target_table.flow_document
 --- Begin `a-schema`.target_table createTargetTable ---
 CREATE TABLE IF NOT EXISTS `a-schema`.target_table (
   key1 BIGINT NOT NULL COMMENT 'auto-generated projection of JSON at: /key1 with inferred types: [integer]',
-  key2 BOOLEAN NOT NULL COMMENT 'auto-generated projection of JSON at: /key2 with inferred types: [boolean]',
+  key2 BINARY NOT NULL COMMENT 'auto-generated projection of JSON at: /key2 with inferred types: [string]',
   binary BINARY COMMENT 'auto-generated projection of JSON at: /binary with inferred types: [string]',
   boolean BOOLEAN COMMENT 'auto-generated projection of JSON at: /boolean with inferred types: [boolean]',
   integer BIGINT COMMENT 'auto-generated projection of JSON at: /integer with inferred types: [integer]',

--- a/materialize-databricks/testdata/flow.yaml
+++ b/materialize-databricks/testdata/flow.yaml
@@ -4,7 +4,8 @@ collections:
       type: object
       properties:
         key1: { type: integer }
-        key2: { type: boolean }
+        key2: { type: binary }
+        binary: { type: string, contentEncoding: base64 }
         boolean: { type: boolean }
         integer: { type: integer }
         number: { type: number }

--- a/materialize-databricks/testdata/spec.json
+++ b/materialize-databricks/testdata/spec.json
@@ -34,7 +34,8 @@
               "type": "integer"
             },
             "key2": {
-              "type": "boolean"
+              "type": "string",
+              "contentEncoding": "base64"
             },
             "number": {
               "type": "number"
@@ -114,8 +115,11 @@
             "is_primary_key": true,
             "inference": {
               "types": [
-                "boolean"
+                "string"
               ],
+              "string": {
+                "content_encoding": "base64"
+              },
               "exists": 1
             }
           },


### PR DESCRIPTION
**Description:**

Adds support for collection key fields that are base64-encoded strings to be materialized as binary columns, in addition to the previously added support for value fields.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1575)
<!-- Reviewable:end -->
