### PR TITLE
source-google-sheets-native: Adding boolValue support

### DIFF
--- a/source-google-sheets-native/source_google_sheets_native/api.py
+++ b/source-google-sheets-native/source_google_sheets_native/api.py
@@ -85,6 +85,9 @@ def convert_row(
         if isinstance((sv := ev.stringValue), str):
             d[headers[ind]] = sv
 
+        if isinstance((bv := ev.boolValue), bool):
+            d[headers[ind]] = bv
+
         if isinstance((nv := ev.numberValue), Decimal):
             nt = (
                 isinstance((ef := column.effectiveFormat), Sheet.EffectiveFormat)

--- a/source-google-sheets-native/source_google_sheets_native/models.py
+++ b/source-google-sheets-native/source_google_sheets_native/models.py
@@ -82,6 +82,7 @@ class Sheet(BaseModel, extra="allow"):
     class EffectiveValue(BaseModel, extra="forbid"):
         stringValue: str | None = None
         numberValue: Decimal | None = None
+        boolValue: bool | None = None
         errorValue: dict | None = None
 
     class EffectiveFormat(BaseModel, extra="forbid"):


### PR DESCRIPTION
**Description:**

source-google-sheets-native is missing [boolValue](https://developers.google.com/sheets/api/reference/rest/v4/spreadsheets/other#ExtendedValue) support, causing any Spreadsheet with boolValues to raise. This PR adds this value to the expected values model. 

**Notes for reviewers:**

Tested end-to-end using a local version of flow and a supabase DB materialization.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1577)
<!-- Reviewable:end -->
