### PR TITLE
materialize-pinecone: add attribution source tag

### DIFF
--- a/materialize-pinecone/client/client.go
+++ b/materialize-pinecone/client/client.go
@@ -218,6 +218,7 @@ func (c *PineconeClient) DescribeIndexStats(ctx context.Context) (PineconeIndexS
 	req.Header.Set("accept", "application/json")
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Api-Key", c.apiKey)
+	req.Header.Set("User-Agent", "source_tag=estuary")
 
 	res, err := c.http.Do(req)
 	if err != nil {


### PR DESCRIPTION
**Description:**

See https://pinecone-2-partner-integration-guide.mintlify.app/integrations/build-integration/attribute-api-activity

There's actually a Go pinecone client now so we could consider changing the connector to use that at some point. A reason to do that would be that I'd imagine it uses the more performant gRPC API, so it would make sense to do if we ever see Pinecone being the bottleneck for the materialization.

For now we can simply add the attribution to own HTTP client though.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1578)
<!-- Reviewable:end -->
