### PR TITLE
source-postgres: Cache table-publication info used when checking prerequisites

### DIFF
--- a/source-postgres/backfill.go
+++ b/source-postgres/backfill.go
@@ -227,7 +227,7 @@ func quoteColumnName(name string) string {
 func (db *postgresDatabase) explainQuery(ctx context.Context, streamID, query string, args []interface{}) {
 	// Only EXPLAIN the backfill query once per connector invocation
 	if db.explained == nil {
-		db.explained = make(map[string]struct{})
+		db.explained = make(map[sqlcapture.StreamID]struct{})
 	}
 	if _, ok := db.explained[streamID]; ok {
 		return

--- a/sqlcapture/capture.go
+++ b/sqlcapture/capture.go
@@ -811,7 +811,9 @@ func (c *Capture) handleAcknowledgement(ctx context.Context, count int, replStre
 	return nil
 }
 
+type StreamID = string
+
 // JoinStreamID combines a namespace and a stream name into a dotted name like "public.foo_table".
-func JoinStreamID(namespace, stream string) string {
+func JoinStreamID(namespace, stream string) StreamID {
 	return strings.ToLower(namespace + "." + stream)
 }


### PR DESCRIPTION
**Description:**

This PR adds a small `map[StreamID]bool` keeping track of which tables are published according to `pg_catalog.pg_publication_tables`, so that when verifying that all active bindings are published we can issue a single query and then just consult the cache instead of having to issue one query for every binding.

This doesn't fix the overall O(n) nature of the per-table prerequisite validation because we still at minimum issue a `SELECT * FROM table LIMIT 0` query to check table readability, but it improves the constant factor by 2x and means there's only the one O(n) operation left, both of which are worthwhile improvements.

(This PR also contains a little bit of fiddling about to introduce a `sqlcapture.StreamID` type alias, because when I went to add a `map[string]bool` it bothered me just enough to do something about it, and then use that alias in a couple of other spots because otherwise the asymmetry of calling one Postgres per-table info cache a `map[sqlcapture.StreamID]stuff` and another a `map[string]stuff` would bother me too. You can pretty much ignore all that though.)

**Workflow steps:**

Nothing should change except validation should run faster on captures with lots (hundreds) of bindings.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1579)
<!-- Reviewable:end -->
