### PR TITLE
sqlcapture: handle u/int8 values in fdb tuple packing

### DIFF
--- a/source-mysql/datatype_test.go
+++ b/source-mysql/datatype_test.go
@@ -31,10 +31,10 @@ func TestDatatypes(t *testing.T) {
 		{ColumnType: "text", ExpectType: `{"type":["string","null"]}`, InputValue: "hello", ExpectValue: `"hello"`},
 
 		// Integer Types
-		{ColumnType: "tinyint", ExpectType: `{"type":"integer"}`, InputValue: 123, ExpectValue: `123`, PrimaryKeyValue: 124, PrimaryExpectValue: `124`},
-		{ColumnType: "smallint", ExpectType: `{"type":"integer"}`, InputValue: 123, ExpectValue: `123`, PrimaryKeyValue: 124, PrimaryExpectValue: `124`},
-		{ColumnType: "mediumint", ExpectType: `{"type":"integer"}`, InputValue: 123, ExpectValue: `123`, PrimaryKeyValue: 124, PrimaryExpectValue: `124`},
-		{ColumnType: "int", ExpectType: `{"type":"integer"}`, InputValue: 123, ExpectValue: `123`, PrimaryKeyValue: 124, PrimaryExpectValue: `124`},
+		{ColumnType: "tinyint", ExpectType: `{"type":"integer"}`, InputValue: 123, ExpectValue: `123`, AsPrimaryKey: true},
+		{ColumnType: "smallint", ExpectType: `{"type":"integer"}`, InputValue: 123, ExpectValue: `123`, AsPrimaryKey: true},
+		{ColumnType: "mediumint", ExpectType: `{"type":"integer"}`, InputValue: 123, ExpectValue: `123`, AsPrimaryKey: true},
+		{ColumnType: "int", ExpectType: `{"type":"integer"}`, InputValue: 123, ExpectValue: `123`, AsPrimaryKey: true},
 		{ColumnType: "bigint", ExpectType: `{"type":["integer","null"]}`, InputValue: -1234567890123456789, ExpectValue: `-1234567890123456789`},
 
 		// MySQL "boolean" type is a synonym for tinyint(1)

--- a/source-mysql/datatype_test.go
+++ b/source-mysql/datatype_test.go
@@ -31,10 +31,10 @@ func TestDatatypes(t *testing.T) {
 		{ColumnType: "text", ExpectType: `{"type":["string","null"]}`, InputValue: "hello", ExpectValue: `"hello"`},
 
 		// Integer Types
-		{ColumnType: "tinyint", ExpectType: `{"type":["integer","null"]}`, InputValue: 123, ExpectValue: `123`},
-		{ColumnType: "smallint", ExpectType: `{"type":["integer","null"]}`, InputValue: 123, ExpectValue: `123`},
-		{ColumnType: "mediumint", ExpectType: `{"type":["integer","null"]}`, InputValue: 123, ExpectValue: `123`},
-		{ColumnType: "int", ExpectType: `{"type":["integer","null"]}`, InputValue: 123, ExpectValue: `123`},
+		{ColumnType: "tinyint", ExpectType: `{"type":"integer"}`, InputValue: 123, ExpectValue: `123`, PrimaryKeyValue: 124, PrimaryExpectValue: `124`},
+		{ColumnType: "smallint", ExpectType: `{"type":"integer"}`, InputValue: 123, ExpectValue: `123`, PrimaryKeyValue: 124, PrimaryExpectValue: `124`},
+		{ColumnType: "mediumint", ExpectType: `{"type":"integer"}`, InputValue: 123, ExpectValue: `123`, PrimaryKeyValue: 124, PrimaryExpectValue: `124`},
+		{ColumnType: "int", ExpectType: `{"type":"integer"}`, InputValue: 123, ExpectValue: `123`, PrimaryKeyValue: 124, PrimaryExpectValue: `124`},
 		{ColumnType: "bigint", ExpectType: `{"type":["integer","null"]}`, InputValue: -1234567890123456789, ExpectValue: `-1234567890123456789`},
 
 		// MySQL "boolean" type is a synonym for tinyint(1)
@@ -204,6 +204,7 @@ func TestScanKeyTypes(t *testing.T) {
 		{"Bool", "BOOLEAN", []interface{}{"1", "0"}},
 		{"Integer", "INTEGER", []interface{}{0, -3, 2, 1723}},
 		{"SmallInt", "SMALLINT", []interface{}{0, -3, 2, 1723}},
+		{"TinyInt", "TINYINT", []interface{}{0, -3, 2, 255}},
 		{"BigInt", "BIGINT", []interface{}{0, -3, 2, 1723}},
 		{"Real", "REAL", []interface{}{-0.9, -1.0, -1.1, 0.0, 0.9, 1.0, 1.111, 1.222, 1.333, 1.444, 1.555, 1.666, 1.777, 1.888, 1.999, 2.000}},
 		{"Double", "DOUBLE PRECISION", []interface{}{-0.9, -1.0, -1.1, 0.0, 0.9, 1.0, 1.111, 1.222, 1.333, 1.444, 1.555, 1.666, 1.777, 1.888, 1.999, 2.000}},

--- a/sqlcapture/tests/datatypes.go
+++ b/sqlcapture/tests/datatypes.go
@@ -20,8 +20,7 @@ type DatatypeTestCase struct {
 	InputValue  interface{}
 	ExpectValue string
 
-	PrimaryKeyValue    interface{}
-	PrimaryExpectValue string
+	AsPrimaryKey bool
 }
 
 // TestDatatypes runs a series of tests creating tables with specific column types
@@ -39,8 +38,8 @@ func TestDatatypes(ctx context.Context, t *testing.T, tb TestBackend, cases []Da
 		t.Run(fmt.Sprintf("%d_%s", idx, testName), func(t *testing.T) {
 			var uniqueID = fmt.Sprintf("1%07d", idx)
 			var tableName string
-			if tc.PrimaryKeyValue != nil {
-				tableName = tb.CreateTable(ctx, t, uniqueID, fmt.Sprintf("(b %s PRIMARY KEY)", tc.ColumnType))
+			if tc.AsPrimaryKey {
+				tableName = tb.CreateTable(ctx, t, uniqueID, fmt.Sprintf("(a INTEGER, b %s, PRIMARY KEY (a,b))", tc.ColumnType))
 			} else {
 				tableName = tb.CreateTable(ctx, t, uniqueID, fmt.Sprintf("(a INTEGER PRIMARY KEY, b %s)", tc.ColumnType))
 			}
@@ -75,30 +74,15 @@ func TestDatatypes(ctx context.Context, t *testing.T, tb TestBackend, cases []Da
 				cs.Sanitizers = make(map[string]*regexp.Regexp)
 
 				t.Run("scan", func(t *testing.T) {
-					var v [][]any
-					if tc.PrimaryKeyValue != nil {
-						v = [][]any{{tc.InputValue}}
-					} else {
-						v = [][]any{{1, tc.InputValue}}
-					}
-					tb.Insert(ctx, t, tableName, v)
+					tb.Insert(ctx, t, tableName, [][]interface{}{{1, tc.InputValue}})
 					var output = RunCapture(ctx, t, cs)
-					verifyRoundTrip(t, tc, tc.ExpectValue, output)
+					verifyRoundTrip(t, tc, output)
 				})
 
 				t.Run("replication", func(t *testing.T) {
-					var v [][]any
-					var expected string = tc.ExpectValue
-					if tc.PrimaryKeyValue != nil {
-						v = [][]any{{tc.PrimaryKeyValue}}
-						expected = tc.PrimaryExpectValue
-					} else {
-						v = [][]any{{2, tc.InputValue}}
-					}
-					tb.Insert(ctx, t, tableName, v)
+					tb.Insert(ctx, t, tableName, [][]interface{}{{2, tc.InputValue}})
 					var output = RunCapture(ctx, t, cs)
-
-					verifyRoundTrip(t, tc, expected, output)
+					verifyRoundTrip(t, tc, output)
 				})
 			})
 		})
@@ -109,7 +93,7 @@ type datatypeTestRecord struct {
 	Value json.RawMessage `json:"b"`
 }
 
-func verifyRoundTrip(t *testing.T, tc DatatypeTestCase, expected, actual string) {
+func verifyRoundTrip(t *testing.T, tc DatatypeTestCase, actual string) {
 	t.Helper()
 
 	// Extract the document of interest from the full capture summary
@@ -130,7 +114,7 @@ func verifyRoundTrip(t *testing.T, tc DatatypeTestCase, expected, actual string)
 		return
 	}
 
-	if string(record.Value) != expected {
+	if string(record.Value) != tc.ExpectValue {
 		t.Errorf("result mismatch for type %q: input %q, got %q, expected %q",
 			tc.ColumnType, tc.InputValue, string(record.Value), tc.ExpectValue)
 	}

--- a/sqlcapture/tuples.go
+++ b/sqlcapture/tuples.go
@@ -41,10 +41,14 @@ func packTuple(xs []interface{}) (bs []byte, err error) {
 		// Values not natively supported by the FoundationDB tuple encoding code
 		// must be converted into ones that are.
 		switch x := x.(type) {
+		case uint8:
+			t = append(t, uint(x))
 		case uint16:
 			t = append(t, uint(x))
 		case uint32:
 			t = append(t, uint(x))
+		case int8:
+			t = append(t, int(x))
 		case int16:
 			t = append(t, int(x))
 		case int32:


### PR DESCRIPTION
**Description:**

- Added the ability to test datatypes as primary keys to our test harness and used it to test the int8 case
- Prior to this pull-request we would get this error if a `tinyint` was used as [part of] a primary key
```
error encoding row key for \"test.datatypes_5_tinyint_10000005\": error serializing FDB tuple: unencodable element at index 0 (124, type int8)
```

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1581)
<!-- Reviewable:end -->
