### PR TITLE
source-mysql: Fix broken test of the query-ignore regexp

### DIFF
--- a/source-mysql/replication_test.go
+++ b/source-mysql/replication_test.go
@@ -4,16 +4,17 @@ import "testing"
 
 func TestIgnoreQueries(t *testing.T) {
 	var cases = map[string]bool{
-		`# This is a comment`:          true,
-		`/* This is also a comment */`: true,
-		`BEGIN`:                        true,
-		`COMMIT`:                       true,
-		`CREATE DEFINER`:               true,
-		`CREATE OR REPLACE DEFINER`:    true,
+		`BEGIN`:                     true,
+		`COMMIT`:                    true,
+		`CREATE DEFINER`:            true,
+		`CREATE OR REPLACE DEFINER`: true,
 		`CREATE OR REPLACE ALGORITHM=UNDEFINED DEFINER`: true,
 		`CREATE ALGORITHM = TEMPTABLE DEFINER`:          true,
 
 		`CREATE USER IF NOT EXISTS flow_capture IDENTIFIED BY 'secret1234'`: true,
+
+		"# This is a comment\n ALTER TABLE foobar ADD COLUMN x INTEGER;":        false,
+		`/* This is also a comment */ ALTER TABLE foobar ADD COLUMN x INTEGER;`: false,
 
 		`CREATE DATABASE IF NOT EXISTS test`:     false,
 		`INSERT INTO foobar VALUES (1, 'hello')`: false,


### PR DESCRIPTION
**Description:**

Apparently I broke a test when making the comment-ignoring change in https://github.com/estuary/connectors/pull/1567 and since then the `source-mysql` CI build has been failing. Whoops.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1582)
<!-- Reviewable:end -->
