### PR TITLE
source-hubspot-native: adjust temporary logging for deals stream

### DIFF
--- a/source-hubspot-native/source_hubspot_native/api.py
+++ b/source-hubspot-native/source_hubspot_native/api.py
@@ -312,11 +312,13 @@ async def fetch_recent_deals(
     url = f"{HUB}/deals/v1/deal/recent/modified"
     params = {"count": 100, "offset": page} if page else {"count": 1}
 
+    log.debug("fetching recent deals", {"params": params})
+
     result = OldRecentDeals.model_validate_json(
         await http.request(log, url, params=params)
     )
 
-    log.debug("fetched recent deals", {"params": params, "result_count": len(result.results), "hasMore": result.hasMore, "offset": result.offset})
+    log.debug("fetched recent deals", {"result_count": len(result.results), "hasMore": result.hasMore, "offset": result.offset})
 
     return (
         (_ms_to_dt(r.properties.hs_lastmodifieddate.timestamp), str(r.dealId))


### PR DESCRIPTION
**Description:**

Follow-up of https://github.com/estuary/connectors/pull/1584; adds a little more (temporary) logging for the `deals` recent changes function.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1585)
<!-- Reviewable:end -->
