### PR TITLE
estuary-cdk: use fixed restart interval of 24 hours and make backfills respect it too

### DIFF
--- a/estuary-cdk/estuary_cdk/capture/__init__.py
+++ b/estuary-cdk/estuary_cdk/capture/__init__.py
@@ -255,14 +255,14 @@ class BaseCaptureConnector(
 
             stopping = Task.Stopping(asyncio.Event())
 
-            async def stop_on_elapsed_interval(interval: int) -> None:
-                await asyncio.sleep(interval)
+            async def periodic_stop() -> None:
+                await asyncio.sleep(24 * 60 * 60) # 24 hours
                 stopping.event.set()
 
-            # Gracefully exit after the capture interval has elapsed.
+            # Gracefully exit after a moderate period of time.
             # We don't do this within the TaskGroup because we don't
             # want to block on it.
-            asyncio.create_task(stop_on_elapsed_interval(open.capture.intervalSeconds))
+            asyncio.create_task(periodic_stop())
 
             async with asyncio.TaskGroup() as tg:
 

--- a/estuary-cdk/estuary_cdk/capture/common.py
+++ b/estuary-cdk/estuary_cdk/capture/common.py
@@ -562,6 +562,10 @@ async def _binding_backfill_task(
         # Yield to the event loop to prevent starvation.
         await asyncio.sleep(0)
 
+        if task.stopping.event.is_set():
+            task.log.debug(f"backfill is yielding to stop")
+            return
+
         # Track if fetch_page returns without having yielded a PageCursor.
         done = True 
 

--- a/source-hubspot-native/source_hubspot_native/api.py
+++ b/source-hubspot-native/source_hubspot_native/api.py
@@ -312,13 +312,9 @@ async def fetch_recent_deals(
     url = f"{HUB}/deals/v1/deal/recent/modified"
     params = {"count": 100, "offset": page} if page else {"count": 1}
 
-    log.debug("fetching recent deals", {"params": params})
-
     result = OldRecentDeals.model_validate_json(
         await http.request(log, url, params=params)
     )
-
-    log.debug("fetched recent deals", {"result_count": len(result.results), "hasMore": result.hasMore, "offset": result.offset})
 
     return (
         (_ms_to_dt(r.properties.hs_lastmodifieddate.timestamp), str(r.dealId))


### PR DESCRIPTION
**Description:**

Currently when any incremental task stops yielding documents after the resource-specific interval
has elapsed, the task will exit and remain idle until all other tasks have completed and the
connector exits. This is a problem when there are long-running backfills which make take longer to
complete than the incremental streams can allow because of log cursor expiration, etc.

To address this, backfill tasks are being made aware of the "stopping" signal, and they will return
when this signal is set, even if the backfill isn't 100% complete. This will cause the capture to do
its periodic restart after all incremental tasks have caught up, and not require all backfills to be
complete as well.

To prevent excessive restarting that may negatively impact throughput during backfills a fixed
interval for these restarts of 24 hours is being set.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1586)
<!-- Reviewable:end -->
