### PR TITLE
materialize-pinecone: add attribution source tag to additional API calls

### DIFF
--- a/materialize-pinecone/client/client.go
+++ b/materialize-pinecone/client/client.go
@@ -246,6 +246,7 @@ func (c *PineconeClient) DescribeIndex(ctx context.Context) (PineconeIndexDescri
 	req.Header.Set("accept", "application/json")
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Api-Key", c.apiKey)
+	req.Header.Set("User-Agent", "source_tag=estuary")
 
 	res, err := c.http.Do(req)
 	if err != nil {
@@ -279,6 +280,7 @@ func (c *PineconeClient) Upsert(ctx context.Context, req PineconeUpsertRequest) 
 		req.Header.Set("accept", "application/json")
 		req.Header.Set("Content-Type", "application/json")
 		req.Header.Set("Api-Key", c.apiKey)
+		req.Header.Set("User-Agent", "source_tag=estuary")
 
 		return c.http.Do(req)
 	})
@@ -319,6 +321,7 @@ func (c *PineconeClient) whoami(ctx context.Context) (whoamiResponse, error) {
 	}
 	req.Header.Set("Api-Key", c.apiKey)
 	req.Header.Set("accept", "application/json")
+	req.Header.Set("User-Agent", "source_tag=estuary")
 
 	res, err := c.http.Do(req)
 	if err != nil {


### PR DESCRIPTION
**Description:**

This is a follow-up to https://github.com/estuary/connectors/pull/1578, which only added the attribution to a single API call. We need to add it to all Pinecone API calls, especially `Upsert`.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1588)
<!-- Reviewable:end -->
