### PR TITLE
source-{postgres,sqlserver}: Check for error after backfill query

### DIFF
--- a/source-postgres/backfill.go
+++ b/source-postgres/backfill.go
@@ -153,7 +153,7 @@ func (db *postgresDatabase) ScanTableChunk(ctx context.Context, info *sqlcapture
 	}
 
 	var backfillComplete = resultRows < db.config.Advanced.BackfillChunkSize
-	return backfillComplete, nil
+	return backfillComplete, rows.Err()
 }
 
 // WriteWatermark writes the provided string into the 'watermarks' table.

--- a/source-sqlserver/backfill.go
+++ b/source-sqlserver/backfill.go
@@ -144,7 +144,7 @@ func (db *sqlserverDatabase) ScanTableChunk(ctx context.Context, info *sqlcaptur
 	}
 
 	var backfillComplete = resultRows < db.config.Advanced.BackfillChunkSize
-	return backfillComplete, nil
+	return backfillComplete, rows.Err()
 }
 
 func (db *sqlserverDatabase) keylessScanQuery(info *sqlcapture.DiscoveryInfo, schemaName, tableName string) string {


### PR DESCRIPTION
**Description:**

These connectors previously only checked for errors which occur when first executing the query, but it's possible for something to go wrong partway through streaming query results, and right now if that happens after we've read some rows but before we've received all <chunkSize> then we incorrectly indicate success and the end of a backfill.

Which is really not what we ought to be doing there.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1592)
<!-- Reviewable:end -->
