### PR TITLE
source-mongodb: better error message if connecting to MongoDB Atlas SQL connection string

### DIFF
--- a/source-mongodb/main.go
+++ b/source-mongodb/main.go
@@ -110,7 +110,13 @@ func (d *driver) Connect(ctx context.Context, cfg config) (*mongo.Client, error)
 	// a more helpful error message in the event that someone tries to use the
 	// online-archive url instead of the regular mongodb url.
 	if strings.Contains(cfg.Address, "atlas-online-archive") {
-		return nil, fmt.Errorf("The provided URL appears to be for 'Atlas online archive', which is not supported by this connector. Please use the regular cluster URL instead")
+		return nil, fmt.Errorf("the provided URL appears to be for 'Atlas online archive', which is not supported by this connector. Please use the regular cluster URL instead")
+	}
+
+	// Similarly, MongoDB "Atlas SQL" does not support change streams, so our
+	// connector doesn't work with that either.
+	if strings.HasPrefix(cfg.Address, "mongodb://atlas-sql") {
+		return nil, fmt.Errorf("the provided URL appears to be for 'Atlas SQL Interface', which is not supported by this connector. Please use the regular cluster URL instead")
 	}
 
 	// If SSH Endpoint is configured, then try to start a tunnel before establishing connections.


### PR DESCRIPTION
**Description:**

MongoDB Atlas SQL doesn't support change streams, so we should report a better error message if a user tries to connect with one of those URLs, which has happened a couple of times.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1604)
<!-- Reviewable:end -->
