### PR TITLE
source-{mysql,postgres,sqlserver}: Secondary index debug logs

### DIFF
--- a/source-mysql/discovery.go
+++ b/source-mysql/discovery.go
@@ -86,20 +86,20 @@ func (db *mysqlDatabase) DiscoverTables(ctx context.Context) (map[string]*sqlcap
 		if !ok || info.PrimaryKey != nil {
 			continue
 		}
-		for _, columns := range indexColumns {
-			// Test that for each column the value is non-nullable
+		logrus.WithFields(logrus.Fields{
+			"table":   streamID,
+			"indices": len(indexColumns),
+		}).Debug("checking for suitable secondary index")
+		for indexName, columns := range indexColumns {
+			// Test that all columns of the index are non-nullable.
 			if columnsNonNullable(info.Columns, columns) {
 				logrus.WithFields(logrus.Fields{
-					"table": streamID,
-					"index": columns,
-				}).Trace("using unique secondary index as primary key")
+					"table":   streamID,
+					"index":   indexName,
+					"columns": columns,
+				}).Debug("selected unique secondary index as table key")
 				info.PrimaryKey = columns
 				break
-			} else {
-				logrus.WithFields(logrus.Fields{
-					"table": streamID,
-					"index": columns,
-				}).Trace("cannot use secondary index because some of its columns are nullable")
 			}
 		}
 	}

--- a/source-postgres/discovery.go
+++ b/source-postgres/discovery.go
@@ -112,20 +112,20 @@ func (db *postgresDatabase) DiscoverTables(ctx context.Context) (map[string]*sql
 		if !ok || info.PrimaryKey != nil {
 			continue
 		}
-		for _, columns := range indexColumns {
-			// Test that for each column the value is non-nullable
+		logrus.WithFields(logrus.Fields{
+			"table":   streamID,
+			"indices": len(indexColumns),
+		}).Debug("checking for suitable secondary index")
+		for indexName, columns := range indexColumns {
+			// Test that all columns of the index are non-nullable.
 			if columnsNonNullable(info.Columns, columns) {
 				logrus.WithFields(logrus.Fields{
-					"table": streamID,
-					"index": columns,
-				}).Trace("using unique secondary index as primary key")
+					"table":   streamID,
+					"index":   indexName,
+					"columns": columns,
+				}).Debug("selected unique secondary index as table key")
 				info.PrimaryKey = columns
 				break
-			} else {
-				logrus.WithFields(logrus.Fields{
-					"table": streamID,
-					"index": columns,
-				}).Trace("cannot use secondary index because some of its columns are nullable")
 			}
 		}
 	}

--- a/source-sqlserver/discovery.go
+++ b/source-sqlserver/discovery.go
@@ -80,20 +80,20 @@ func (db *sqlserverDatabase) DiscoverTables(ctx context.Context) (map[string]*sq
 		if !ok || info.PrimaryKey != nil {
 			continue
 		}
-		for _, columns := range indexColumns {
-			// Test that for each column the value is non-nullable
+		log.WithFields(log.Fields{
+			"table":   streamID,
+			"indices": len(indexColumns),
+		}).Debug("checking for suitable secondary index")
+		for indexName, columns := range indexColumns {
+			// Test that all columns of the index are non-nullable.
 			if columnsNonNullable(info.Columns, columns) {
 				log.WithFields(log.Fields{
-					"table": streamID,
-					"index": columns,
-				}).Trace("using unique secondary index as primary key")
+					"table":   streamID,
+					"index":   indexName,
+					"columns": columns,
+				}).Debug("selected unique secondary index as table key")
 				info.PrimaryKey = columns
 				break
-			} else {
-				log.WithFields(log.Fields{
-					"table": streamID,
-					"index": columns,
-				}).Trace("cannot use secondary index because some of its columns are nullable")
 			}
 		}
 	}


### PR DESCRIPTION
**Description:**

Tweaks the logging around secondary index selection during discovery so that the messages will be more useful, and so that they will be logged at `DEBUG` level so we can see them more easily.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1606)
<!-- Reviewable:end -->
