### PR TITLE
source-{mysql,postgres,sqlserver}: Sort secondary indices by name

### DIFF
--- a/source-postgres/discovery.go
+++ b/source-postgres/discovery.go
@@ -7,6 +7,7 @@ import (
 	"net"
 	"reflect"
 	"slices"
+	"sort"
 	"strings"
 	"time"
 
@@ -112,21 +113,38 @@ func (db *postgresDatabase) DiscoverTables(ctx context.Context) (map[string]*sql
 		if !ok || info.PrimaryKey != nil {
 			continue
 		}
+
+		// Make a list of all usable indexes.
 		logrus.WithFields(logrus.Fields{
 			"table":   streamID,
 			"indices": len(indexColumns),
-		}).Debug("checking for suitable secondary index")
+		}).Debug("checking for suitable secondary indexes")
+		var suitableIndexes []string
 		for indexName, columns := range indexColumns {
-			// Test that all columns of the index are non-nullable.
 			if columnsNonNullable(info.Columns, columns) {
 				logrus.WithFields(logrus.Fields{
 					"table":   streamID,
 					"index":   indexName,
 					"columns": columns,
-				}).Debug("selected unique secondary index as table key")
-				info.PrimaryKey = columns
-				break
+				}).Debug("secondary index could be used as primary key")
+				suitableIndexes = append(suitableIndexes, indexName)
 			}
+		}
+
+		// Sort the list by index name and pick the first one, if there are multiple.
+		// This helps ensure stable selection, although it could still change due to
+		// the creation of a new secondary index.
+		sort.Strings(suitableIndexes)
+		if len(suitableIndexes) > 0 {
+			var selectedIndex = suitableIndexes[0]
+			logrus.WithFields(logrus.Fields{
+				"table":   streamID,
+				"index":   selectedIndex,
+				"columns": columns,
+			}).Debug("selected secondary index as table key")
+			info.PrimaryKey = indexColumns[selectedIndex]
+		} else {
+			logrus.WithField("table", streamID).Debug("no secondary index is suitable")
 		}
 	}
 

--- a/source-sqlserver/discovery.go
+++ b/source-sqlserver/discovery.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"fmt"
 	"slices"
+	"sort"
 	"strings"
 
 	"github.com/estuary/connectors/sqlcapture"
@@ -80,21 +81,38 @@ func (db *sqlserverDatabase) DiscoverTables(ctx context.Context) (map[string]*sq
 		if !ok || info.PrimaryKey != nil {
 			continue
 		}
+
+		// Make a list of all usable indexes.
 		log.WithFields(log.Fields{
 			"table":   streamID,
 			"indices": len(indexColumns),
-		}).Debug("checking for suitable secondary index")
+		}).Debug("checking for suitable secondary indexes")
+		var suitableIndexes []string
 		for indexName, columns := range indexColumns {
-			// Test that all columns of the index are non-nullable.
 			if columnsNonNullable(info.Columns, columns) {
 				log.WithFields(log.Fields{
 					"table":   streamID,
 					"index":   indexName,
 					"columns": columns,
-				}).Debug("selected unique secondary index as table key")
-				info.PrimaryKey = columns
-				break
+				}).Debug("secondary index could be used as primary key")
+				suitableIndexes = append(suitableIndexes, indexName)
 			}
+		}
+
+		// Sort the list by index name and pick the first one, if there are multiple.
+		// This helps ensure stable selection, although it could still change due to
+		// the creation of a new secondary index.
+		sort.Strings(suitableIndexes)
+		if len(suitableIndexes) > 0 {
+			var selectedIndex = suitableIndexes[0]
+			log.WithFields(log.Fields{
+				"table":   streamID,
+				"index":   selectedIndex,
+				"columns": columns,
+			}).Debug("selected secondary index as table key")
+			info.PrimaryKey = indexColumns[selectedIndex]
+		} else {
+			log.WithField("table", streamID).Debug("no secondary index is suitable")
 		}
 	}
 


### PR DESCRIPTION
**Description:**

This commit alters the secondary index selection heuristic (which is used during discovery, if a table has no primary key, to try and provide a useful alternative to use as the collection/backfill key).

Previously we picked the first suitable index, where "first" was defined in terms of iterating over a map from index name to the list of columns making up the index. When stated like that the flaw ought to be obvious -- Go map iteration order is random, so if there were multiple suitable indices we could pick a different one every time discovery gets run.

The fix is to make a list of suitable indexes, sort the list by name, and then pick the first one from that list. This is still not perfect (as it could still change if a new index is created on the source database) but the selection will at least no longer keep changing every time we run discovery.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1607)
<!-- Reviewable:end -->
