### PR TITLE
source-google-sheets-native: ignoring null rows after empty spreadshe…

### DIFF
--- a/source-google-sheets-native/source_google_sheets_native/api.py
+++ b/source-google-sheets-native/source_google_sheets_native/api.py
@@ -69,7 +69,7 @@ async def fetch_rows(
     lotus_epoch = datetime(1899, 12, 30, tzinfo=user_tz)
 
     return (
-        convert_row(id, headers, row.values, lotus_epoch) for id, row in enumerate(rows)
+        convert_row(id, headers, row.values, lotus_epoch) for id, row in enumerate(rows) if row.values is not None 
     )
 
 


### PR DESCRIPTION
…et validation


**Description:**

One bug report showed that there can be cases where a row simply has a Null value inside its 'values' parameters. This doesnt seem to be covered in the docs and i dont fully understand what happened to that row, but since we are now validating if a spreadsheet is empty or not, adding a simple check to the row generator in `fetch_rows` solves the issue
and allow for the streams to run

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1609)
<!-- Reviewable:end -->
