### PR TITLE
materialize-redshift: include name of table in nullability constrainterror message

### DIFF
--- a/materialize-redshift/client.go
+++ b/materialize-redshift/client.go
@@ -115,7 +115,7 @@ func (c *client) AlterTable(ctx context.Context, ta sql.TableAlter) (string, boi
 	// never need to drop nullability constraints, since Redshift does not allow dropping
 	// nullability and we don't ever create columns as NOT NULL as a result.
 	if len(ta.DropNotNulls) != 0 { // sanity check
-		return "", nil, fmt.Errorf("redshift cannot drop nullability constraints but got %d DropNotNulls", len(ta.DropNotNulls))
+		return "", nil, fmt.Errorf("redshift cannot drop nullability constraints but got %d DropNotNulls for table %s", len(ta.DropNotNulls), ta.Identifier)
 	}
 
 	statements := []string{}


### PR DESCRIPTION
**Description:**

Include the name of the (pre-existing) table if we ever find that we would need to drop a nullability constraint on the table.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1616)
<!-- Reviewable:end -->
