### PR TITLE
materialize-snowflake: Host is called Account URL in Snowflake

### DIFF
--- a/materialize-snowflake/.snapshots/TestSpecification
+++ b/materialize-snowflake/.snapshots/TestSpecification
@@ -5,7 +5,7 @@
     "properties": {
       "host": {
         "type": "string",
-        "title": "Host URL",
+        "title": "Host (Account URL)",
         "description": "The Snowflake Host used for the connection. Must include the account identifier and end in .snowflakecomputing.com. Example: orgname-accountname.snowflakecomputing.com (do not include the protocol).",
         "order": 0,
         "pattern": "^[^/:]+.snowflakecomputing.com$"

--- a/materialize-snowflake/config.go
+++ b/materialize-snowflake/config.go
@@ -22,7 +22,7 @@ type config struct {
 	// for specifying the url of an instance. Ideally we should just accept the URL directly and use that, that would save us and
 	// users some headache
 	// See: https://docs.snowflake.com/en/user-guide/admin-account-identifier#non-vps-account-locator-formats-by-cloud-platform-and-region
-	Host       string `json:"host" jsonschema:"title=Host URL,description=The Snowflake Host used for the connection. Must include the account identifier and end in .snowflakecomputing.com. Example: orgname-accountname.snowflakecomputing.com (do not include the protocol)." jsonschema_extras:"order=0,pattern=^[^/:]+.snowflakecomputing.com$"`
+	Host       string `json:"host" jsonschema:"title=Host (Account URL),description=The Snowflake Host used for the connection. Must include the account identifier and end in .snowflakecomputing.com. Example: orgname-accountname.snowflakecomputing.com (do not include the protocol)." jsonschema_extras:"order=0,pattern=^[^/:]+.snowflakecomputing.com$"`
 	Account    string `json:"account" jsonschema:"title=Account,description=The Snowflake account identifier." jsonschema_extras:"order=1"`
 	User       string `json:"user" jsonschema:"-"`
 	Password   string `json:"password" jsonschema:"-"`


### PR DESCRIPTION
**Description:**

- A terminology change following Snowflake's own docs
- Docs PR: https://github.com/estuary/flow/pull/1479

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1617)
<!-- Reviewable:end -->
