### PR TITLE
CDK Updates

### DIFF
--- a/estuary-cdk/estuary_cdk/capture/__init__.py
+++ b/estuary-cdk/estuary_cdk/capture/__init__.py
@@ -182,7 +182,7 @@ class Task:
         task = self._tg.create_task(run_task(self))
         task.set_name(child_name)
         return task
-
+    
     def _emit(self, response: Response[EndpointConfig, ResourceConfig, ConnectorState]):
         self._buffer.write(
             response.model_dump_json(by_alias=True, exclude_unset=True).encode()


### PR DESCRIPTION
**Description:**

* Specs with many incremental tasks were struggling to start backfilling on startup as all of the incremental tasks were eagerly starting. This way, if an incremental task has run less than `interval` ago, it'll delay until that interval has fully elapsed before starting.
* Pydantic automatically serializes Decimals as strings, but orjson doesn't know about that. In order to handle this, we must tell `orjson` how to handle Decimals. [Their docs on this](https://github.com/ijl/orjson?tab=readme-ov-file#default)
* Pass the current Task to all of the `FetchXXFns` so that they can directly write to the buffer if need be. **This is a breaking change**

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1621)
<!-- Reviewable:end -->
