### PR TITLE
source-postgres: Special-case check for Supabase connection pooler

### DIFF
--- a/source-postgres/main.go
+++ b/source-postgres/main.go
@@ -132,7 +132,7 @@ func (c *Config) Validate() error {
 	// since it lets us name the specific thing they're using and give instructions for precisely how
 	// to get the correct address instead.
 	if strings.HasSuffix(c.Address, ".pooler.supabase.com:6543") || strings.HasSuffix(c.Address, ".pooler.supabase.com") {
-		return cerrors.NewUserError(nil, fmt.Sprintf("address must be a direct connection: address %q is using the Supabase connection pooler, uncheck the 'Display connection pooler' option", c.Address))
+		return cerrors.NewUserError(nil, fmt.Sprintf("address must be a direct connection: address %q is using the Supabase connection pooler, consult go.estuary.dev/supabase-direct-address for details", c.Address))
 	}
 
 	if c.Advanced.WatermarksTable != "" && !strings.Contains(c.Advanced.WatermarksTable, ".") {


### PR DESCRIPTION
**Description:**

Adds a special case check for Postgres database addresses ending in `.pooler.supabase.com:6543` and `.pooler.supabase.com` (that latter address is _also_ invalid since the pooler isn't running  on the default Postgres port, but the user intent is clear so we might as well present the appropriate error message then too).

We should still try to add generic connection pooler detection logic in the future (https://github.com/estuary/connectors/issues/1576) but even after such logic exists it's probably still useful to have special cases for common ones like this so that we can provide an even more tailored error message. This one, for instance, will tell the user as clearly as I could manage that `address must be a direct connection: address %q is using the Supabase connection pooler, uncheck the 'Display connection pooler' option` and will use the "UserError" plumbing to strip out as much error prefixing as possible.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1622)
<!-- Reviewable:end -->
