### PR TITLE
source-postgres-batch: Correctly handle XID wraparound

### DIFF
--- a/source-postgres-batch/.snapshots/TestBasicCapture-Discovery
+++ b/source-postgres-batch/.snapshots/TestBasicCapture-Discovery
@@ -2,7 +2,8 @@ Binding 0:
 {
     "resource_config_json": {
       "name": "test_basic_capture_826935",
-      "template": "{{if .IsFirstQuery -}}\n  SELECT xmin AS txid, * FROM \"test\".\"basic_capture_826935\" ORDER BY xmin::text::bigint;\n{{- else -}}\n  SELECT xmin AS txid, * FROM \"test\".\"basic_capture_826935\" WHERE xmin::text::bigint \u003e $1 ORDER BY xmin::text::bigint;\n{{- end}}",
+      "schema": "test",
+      "table": "basic_capture_826935",
       "cursor": [
         "txid"
       ]

--- a/source-postgres-batch/.snapshots/TestBasicDatatypes-Discovery
+++ b/source-postgres-batch/.snapshots/TestBasicDatatypes-Discovery
@@ -2,7 +2,8 @@ Binding 0:
 {
     "resource_config_json": {
       "name": "test_basic_datatypes_13111208",
-      "template": "{{if .IsFirstQuery -}}\n  SELECT xmin AS txid, * FROM \"test\".\"basic_datatypes_13111208\" ORDER BY xmin::text::bigint;\n{{- else -}}\n  SELECT xmin AS txid, * FROM \"test\".\"basic_datatypes_13111208\" WHERE xmin::text::bigint \u003e $1 ORDER BY xmin::text::bigint;\n{{- end}}",
+      "schema": "test",
+      "table": "basic_datatypes_13111208",
       "cursor": [
         "txid"
       ]

--- a/source-postgres-batch/.snapshots/TestKeyDiscovery
+++ b/source-postgres-batch/.snapshots/TestKeyDiscovery
@@ -2,7 +2,8 @@ Binding 0:
 {
     "resource_config_json": {
       "name": "test_key_discovery_329932",
-      "template": "{{if .IsFirstQuery -}}\n  SELECT xmin AS txid, * FROM \"test\".\"key_discovery_329932\" ORDER BY xmin::text::bigint;\n{{- else -}}\n  SELECT xmin AS txid, * FROM \"test\".\"key_discovery_329932\" WHERE xmin::text::bigint \u003e $1 ORDER BY xmin::text::bigint;\n{{- end}}",
+      "schema": "test",
+      "table": "key_discovery_329932",
       "cursor": [
         "txid"
       ]

--- a/source-postgres-batch/.snapshots/TestSchemaFilter-FilteredIn
+++ b/source-postgres-batch/.snapshots/TestSchemaFilter-FilteredIn
@@ -2,7 +2,8 @@ Binding 0:
 {
     "resource_config_json": {
       "name": "test_schema_filtering_22492",
-      "template": "{{if .IsFirstQuery -}}\n  SELECT xmin AS txid, * FROM \"test\".\"schema_filtering_22492\" ORDER BY xmin::text::bigint;\n{{- else -}}\n  SELECT xmin AS txid, * FROM \"test\".\"schema_filtering_22492\" WHERE xmin::text::bigint \u003e $1 ORDER BY xmin::text::bigint;\n{{- end}}",
+      "schema": "test",
+      "table": "schema_filtering_22492",
       "cursor": [
         "txid"
       ]

--- a/source-postgres-batch/.snapshots/TestSchemaFilter-Unfiltered
+++ b/source-postgres-batch/.snapshots/TestSchemaFilter-Unfiltered
@@ -2,7 +2,8 @@ Binding 0:
 {
     "resource_config_json": {
       "name": "test_schema_filtering_22492",
-      "template": "{{if .IsFirstQuery -}}\n  SELECT xmin AS txid, * FROM \"test\".\"schema_filtering_22492\" ORDER BY xmin::text::bigint;\n{{- else -}}\n  SELECT xmin AS txid, * FROM \"test\".\"schema_filtering_22492\" WHERE xmin::text::bigint \u003e $1 ORDER BY xmin::text::bigint;\n{{- end}}",
+      "schema": "test",
+      "table": "schema_filtering_22492",
       "cursor": [
         "txid"
       ]

--- a/source-postgres-batch/.snapshots/TestSpec
+++ b/source-postgres-batch/.snapshots/TestSpec
@@ -78,16 +78,21 @@
     "properties": {
       "name": {
         "type": "string",
-        "title": "Name",
+        "title": "Resource Name",
         "description": "The unique name of this resource.",
         "order": 0
       },
-      "template": {
+      "schema": {
         "type": "string",
-        "title": "Query Template",
-        "description": "The query template (pkg.go.dev/text/template) which will be rendered and then executed.",
-        "multiline": true,
-        "order": 3
+        "title": "Schema Name",
+        "description": "The name of the schema in which the captured table lives. The query template must be overridden if this is unset.",
+        "order": 1
+      },
+      "table": {
+        "type": "string",
+        "title": "Table Name",
+        "description": "The name of the table to be captured. The query template must be overridden if this is unset.",
+        "order": 2
       },
       "cursor": {
         "items": {
@@ -96,20 +101,26 @@
         "type": "array",
         "title": "Cursor Columns",
         "description": "The names of columns which should be persisted between query executions as a cursor.",
-        "order": 2
+        "order": 3
       },
       "poll": {
         "type": "string",
         "title": "Polling Schedule",
         "description": "When and how often to execute the fetch query (overrides the connector default setting). Accepts a Go duration string like '5m' or '6h' for frequency-based polling or a string like 'daily at 12:34Z' to poll at a specific time (specified in UTC) every day.",
-        "order": 1,
+        "order": 4,
         "pattern": "^([-+]?([0-9]+([.][0-9]+)?(h|m|s|ms))+|daily at [0-9][0-9]?:[0-9]{2}Z)$"
+      },
+      "template": {
+        "type": "string",
+        "title": "Query Template Override",
+        "description": "Optionally overrides the query template which will be rendered and then executed. Consult documentation for examples.",
+        "multiline": true,
+        "order": 5
       }
     },
     "type": "object",
     "required": [
-      "name",
-      "template"
+      "name"
     ],
     "title": "Batch SQL Resource Spec"
   },


### PR DESCRIPTION
**Description:**

This PR modifies the `source-postgres-batch` connector in two related ways:

- The polling query is tweaked so that it should work correctly even when the XID epoch wraps around (provided that the source table is updated more frequently than that wraparound happens -- if that's an issue I have ideas and believe it's fixable, but it felt out of scope for the current goal).
- The resource config now leaves the template empty and expects the connector to supply the default behavior. Since the template used to hard-code in a table name, there are now two new resource config fields for the schema/table name, which simply get plumbed into the template. This means that if there's some minor issue with the polling query behavior we can fix it in the future by rolling out a new connector build, without having to go and update old captures which have "baked in" the query template initially provided by discovery.

I would have liked to have tested this PR more than I did, but exercising XID wraparound behavior in small-scale local testing is damnably hard. I have substituted a small amount of semi-manual testing involving `pg_resetwal` plus a whole bunch of thinking about the problem, so hopefully I didn't overlook anything important.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1623)
<!-- Reviewable:end -->
