### PR TITLE
source-mysql: Error on out-of-range enum index

### DIFF
--- a/source-mysql/discovery.go
+++ b/source-mysql/discovery.go
@@ -480,6 +480,7 @@ func (t *mysqlColumnType) translateRecordField(val interface{}) (interface{}, er
 			if 0 <= index && int(index) < len(t.EnumValues) {
 				return t.EnumValues[index], nil
 			}
+			return "", fmt.Errorf("enum value out of range: index %d does not match known options %q, backfill the table to reinitialize the inconsistent table metadata", index, t.EnumValues)
 		} else if bs, ok := val.([]byte); ok {
 			return string(bs), nil
 		}


### PR DESCRIPTION
**Description:**

Previously out-of-range enum indices would fall through the value translation logic and be emitted as integers (which would then immediately fail schema validation). This makes the source of the failure more immediately evident.

This fixes https://github.com/estuary/connectors/issues/1625

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1633)
<!-- Reviewable:end -->
