### PR TITLE
source-mongodb: fix cluster time in server hello and log last event optime

### DIFF
--- a/source-mongodb/pull.go
+++ b/source-mongodb/pull.go
@@ -160,6 +160,7 @@ type capture struct {
 	state                 captureState
 	processedStreamEvents int
 	emittedStreamDocs     int
+	lastEventClusterTime  primitive.Timestamp
 
 	// Controls for starting and stopping the stream progress logger.
 	streamLoggerStop   chan (struct{})


### PR DESCRIPTION
**Description:**

Sharded clusters do not have a "lastWrite" response in their server hello command response, but they do have "operationTime", as do non-sharded replica sets, and that is exactly the same piece of information: the cluster time of the last majority-committed operation for the cluster. So we'll use "operationTime" instead of "lastWrite" so that we have the cluster time for both sharded and non-sharded clusters when catching up streams between backfilling.

Also adds a bit of addition logging to the "stream progress" logs to indicate the cluster time of the most recently processed event. This may help diagnose issues where the change stream position is lost potentially due to the connector not being able to keep up with the change stream for a database, by comparing the cluster time (which is in epoch seconds) to the wall clock timestamp of the log to see if it is lagging increasingly behind.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

