### PR TITLE
materialize-*: handle hard deletion of nonexistent docs

### DIFF
--- a/materialize-bigquery/transactor.go
+++ b/materialize-bigquery/transactor.go
@@ -251,7 +251,12 @@ func (t *transactor) Store(it *m.StoreIterator) (m.StartCommitFunc, error) {
 
 		var flowDocument = it.RawJSON
 		if t.cfg.HardDelete && it.Delete {
-			flowDocument = json.RawMessage(`"delete"`)
+			if it.Exists {
+				flowDocument = json.RawMessage(`"delete"`)
+			} else {
+				// Ignore items which do not exist and are already deleted
+				continue
+			}
 		}
 		converted, err := b.target.ConvertAll(it.Key, it.Values, flowDocument)
 		if err != nil {

--- a/materialize-databricks/driver.go
+++ b/materialize-databricks/driver.go
@@ -356,7 +356,12 @@ func (d *transactor) Store(it *m.StoreIterator) (_ m.StartCommitFunc, err error)
 
 		var flowDocument = it.RawJSON
 		if d.cfg.HardDelete && it.Delete {
-			flowDocument = json.RawMessage(`"delete"`)
+			if it.Exists {
+				flowDocument = json.RawMessage(`"delete"`)
+			} else {
+				// Ignore items which do not exist and are already deleted
+				continue
+			}
 		}
 
 		if err := b.storeFile.start(ctx); err != nil {

--- a/materialize-mysql/driver.go
+++ b/materialize-mysql/driver.go
@@ -705,9 +705,14 @@ func (d *transactor) Store(it *m.StoreIterator) (_ m.StartCommitFunc, err error)
 
 		var converted []any
 		if it.Delete && d.cfg.HardDelete {
-			converted, err = b.target.ConvertKey(it.Key)
-			if err != nil {
-				return nil, fmt.Errorf("converting delete parameters: %w", err)
+			if it.Exists {
+				converted, err = b.target.ConvertKey(it.Key)
+				if err != nil {
+					return nil, fmt.Errorf("converting delete parameters: %w", err)
+				}
+			} else {
+				// Ignore items which do not exist and are already deleted
+				continue
 			}
 		} else {
 			converted, err = b.target.ConvertAll(it.Key, it.Values, it.RawJSON)

--- a/materialize-redshift/driver.go
+++ b/materialize-redshift/driver.go
@@ -644,11 +644,16 @@ func (d *transactor) Store(it *m.StoreIterator) (m.StartCommitFunc, error) {
 		// so we can't use it to both update and delete rows. So instead we use a separate
 		// temporary table and run a `DELETE USING` query to delete rows
 		if d.cfg.HardDelete && it.Delete {
-			file = b.deleteFile
+			if it.Exists {
+				file = b.deleteFile
 
-			converted, err = b.target.ConvertKey(it.Key)
-			if err != nil {
-				return nil, fmt.Errorf("converting delete parameters: %w", err)
+				converted, err = b.target.ConvertKey(it.Key)
+				if err != nil {
+					return nil, fmt.Errorf("converting delete parameters: %w", err)
+				}
+			} else {
+				// Ignore items which do not exist and are already deleted
+				continue
 			}
 		} else {
 			file = b.storeFile

--- a/materialize-snowflake/snowflake.go
+++ b/materialize-snowflake/snowflake.go
@@ -405,7 +405,12 @@ func (d *transactor) Store(it *m.StoreIterator) (m.StartCommitFunc, error) {
 
 		var flowDocument = it.RawJSON
 		if d.cfg.HardDelete && it.Delete {
-			flowDocument = json.RawMessage(`"delete"`)
+			if it.Exists {
+				flowDocument = json.RawMessage(`"delete"`)
+			} else {
+				// Ignore items which do not exist and are already deleted
+				continue
+			}
 		}
 
 		if err := b.store.stage.start(ctx, d.db); err != nil {

--- a/materialize-sqlserver/driver.go
+++ b/materialize-sqlserver/driver.go
@@ -462,7 +462,12 @@ func (d *transactor) Store(it *m.StoreIterator) (_ m.StartCommitFunc, err error)
 
 		var flowDocument = it.RawJSON
 		if d.cfg.HardDelete && it.Delete {
-			flowDocument = json.RawMessage(`"delete"`)
+			if it.Exists {
+				flowDocument = json.RawMessage(`"delete"`)
+			} else {
+				// Ignore items which do not exist and are already deleted
+				continue
+			}
 		}
 		converted, err := b.target.ConvertAll(it.Key, it.Values, flowDocument)
 		if err != nil {

--- a/tests/materialize/fixture.json
+++ b/tests/materialize/fixture.json
@@ -73,6 +73,9 @@
 
     ["tests/deletions", { "id": 1, "_meta": {"op": "d"} }],
     ["tests/deletions", { "id": 2, "_meta": {"op": "u"} }],
-    ["tests/deletions", { "id": 3, "_meta": {"op": "c"} }]
+    ["tests/deletions", { "id": 3, "_meta": {"op": "c"} }],
+
+    ["tests/deletions", { "id": 4, "_meta": {"op": "c"} }],
+    ["tests/deletions", { "id": 4, "_meta": {"op": "d"} }]
   ]
 ]


### PR DESCRIPTION
**Description:**

- It is possible to have documents with `it.Delete` that have not previously existed in the destination. For hard deletions, we want to ignore these documents and avoid inserting them

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1640)
<!-- Reviewable:end -->
