### PR TITLE
materialize-mysql: specify character set for LOAD DATA LOCAL INFILE queries

### DIFF
--- a/materialize-mysql/.snapshots/TestSQLGeneration
+++ b/materialize-mysql/.snapshots/TestSQLGeneration
@@ -57,7 +57,7 @@ TRUNCATE flow_temp_load_table_1;
 
 --- Begin target_table loadLoad ---
 
-LOAD DATA LOCAL INFILE 'Reader::flow_batch_data_load' INTO TABLE flow_temp_load_table_0
+LOAD DATA LOCAL INFILE 'Reader::flow_batch_data_load' INTO TABLE flow_temp_load_table_0 CHARACTER SET utf8mb4
 	FIELDS
 		TERMINATED BY ','
 		OPTIONALLY ENCLOSED BY '"'
@@ -72,7 +72,7 @@ LOAD DATA LOCAL INFILE 'Reader::flow_batch_data_load' INTO TABLE flow_temp_load_
 
 --- Begin `Delta Updates` loadLoad ---
 
-LOAD DATA LOCAL INFILE 'Reader::flow_batch_data_load' INTO TABLE flow_temp_load_table_1
+LOAD DATA LOCAL INFILE 'Reader::flow_batch_data_load' INTO TABLE flow_temp_load_table_1 CHARACTER SET utf8mb4
 	FIELDS
 		TERMINATED BY ','
 		OPTIONALLY ENCLOSED BY '"'
@@ -102,7 +102,7 @@ SELECT * FROM (SELECT -1, CAST(NULL AS JSON) LIMIT 0) as nodoc
 
 --- Begin target_table insertLoad ---
 
-LOAD DATA LOCAL INFILE 'Reader::flow_batch_data_insert' INTO TABLE target_table
+LOAD DATA LOCAL INFILE 'Reader::flow_batch_data_insert' INTO TABLE target_table CHARACTER SET utf8mb4
 	FIELDS
 		TERMINATED BY ','
 		OPTIONALLY ENCLOSED BY '"'
@@ -123,7 +123,7 @@ LOAD DATA LOCAL INFILE 'Reader::flow_batch_data_insert' INTO TABLE target_table
 
 --- Begin `Delta Updates` insertLoad ---
 
-LOAD DATA LOCAL INFILE 'Reader::flow_batch_data_insert' INTO TABLE `Delta Updates`
+LOAD DATA LOCAL INFILE 'Reader::flow_batch_data_insert' INTO TABLE `Delta Updates` CHARACTER SET utf8mb4
 	FIELDS
 		TERMINATED BY ','
 		OPTIONALLY ENCLOSED BY '"'
@@ -138,7 +138,7 @@ LOAD DATA LOCAL INFILE 'Reader::flow_batch_data_insert' INTO TABLE `Delta Update
 
 --- Begin target_table updateLoad ---
 
-LOAD DATA LOCAL INFILE 'Reader::flow_batch_data_update' INTO TABLE flow_temp_update_table_0
+LOAD DATA LOCAL INFILE 'Reader::flow_batch_data_update' INTO TABLE flow_temp_update_table_0 CHARACTER SET utf8mb4
 	FIELDS
 		TERMINATED BY ','
 		OPTIONALLY ENCLOSED BY '"'
@@ -159,7 +159,7 @@ LOAD DATA LOCAL INFILE 'Reader::flow_batch_data_update' INTO TABLE flow_temp_upd
 
 --- Begin `Delta Updates` updateLoad ---
 
-LOAD DATA LOCAL INFILE 'Reader::flow_batch_data_update' INTO TABLE flow_temp_update_table_1
+LOAD DATA LOCAL INFILE 'Reader::flow_batch_data_update' INTO TABLE flow_temp_update_table_1 CHARACTER SET utf8mb4
 	FIELDS
 		TERMINATED BY ','
 		OPTIONALLY ENCLOSED BY '"'
@@ -237,7 +237,7 @@ WHERE
 
 --- Begin target_table deleteLoad ---
 
-LOAD DATA LOCAL INFILE 'Reader::flow_batch_data_delete' INTO TABLE flow_temp_delete_table_0
+LOAD DATA LOCAL INFILE 'Reader::flow_batch_data_delete' INTO TABLE flow_temp_delete_table_0 CHARACTER SET utf8mb4
 	FIELDS
 		TERMINATED BY ','
 		OPTIONALLY ENCLOSED BY '"'
@@ -252,7 +252,7 @@ LOAD DATA LOCAL INFILE 'Reader::flow_batch_data_delete' INTO TABLE flow_temp_del
 
 --- Begin `Delta Updates` deleteLoad ---
 
-LOAD DATA LOCAL INFILE 'Reader::flow_batch_data_delete' INTO TABLE flow_temp_delete_table_1
+LOAD DATA LOCAL INFILE 'Reader::flow_batch_data_delete' INTO TABLE flow_temp_delete_table_1 CHARACTER SET utf8mb4
 	FIELDS
 		TERMINATED BY ','
 		OPTIONALLY ENCLOSED BY '"'

--- a/materialize-mysql/sqlgen.go
+++ b/materialize-mysql/sqlgen.go
@@ -252,7 +252,7 @@ TRUNCATE {{ template "temp_load_name" . }};
 -- Templated load into the temporary load table:
 
 {{ define "loadLoad" }}
-LOAD DATA LOCAL INFILE 'Reader::flow_batch_data_load' INTO TABLE {{ template "temp_load_name" . }}
+LOAD DATA LOCAL INFILE 'Reader::flow_batch_data_load' INTO TABLE {{ template "temp_load_name" . }} CHARACTER SET utf8mb4
 	FIELDS
 		TERMINATED BY ','
 		OPTIONALLY ENCLOSED BY '"'
@@ -287,7 +287,7 @@ SELECT * FROM (SELECT -1, CAST(NULL AS JSON) LIMIT 0) as nodoc
 -- Template to load data into target table
 
 {{ define "insertLoad" }}
-LOAD DATA LOCAL INFILE 'Reader::flow_batch_data_insert' INTO TABLE {{ $.Identifier }}
+LOAD DATA LOCAL INFILE 'Reader::flow_batch_data_insert' INTO TABLE {{ $.Identifier }} CHARACTER SET utf8mb4
 	FIELDS
 		TERMINATED BY ','
 		OPTIONALLY ENCLOSED BY '"'
@@ -319,7 +319,7 @@ CREATE TEMPORARY TABLE {{ template "temp_update_name" . }} (
 {{ end }}
 
 {{ define "updateLoad" }}
-LOAD DATA LOCAL INFILE 'Reader::flow_batch_data_update' INTO TABLE {{ template "temp_update_name" . }}
+LOAD DATA LOCAL INFILE 'Reader::flow_batch_data_update' INTO TABLE {{ template "temp_update_name" . }} CHARACTER SET utf8mb4
 	FIELDS
 		TERMINATED BY ','
 		OPTIONALLY ENCLOSED BY '"'
@@ -373,7 +373,7 @@ CREATE TEMPORARY TABLE {{ template "temp_delete_name" . }} (
 {{ end }}
 
 {{ define "deleteLoad" }}
-LOAD DATA LOCAL INFILE 'Reader::flow_batch_data_delete' INTO TABLE {{ template "temp_delete_name" . }}
+LOAD DATA LOCAL INFILE 'Reader::flow_batch_data_delete' INTO TABLE {{ template "temp_delete_name" . }} CHARACTER SET utf8mb4
 	FIELDS
 		TERMINATED BY ','
 		OPTIONALLY ENCLOSED BY '"'


### PR DESCRIPTION
**Description:**

Flow supports characters from the utf8mb4 character set and we create MySQL tables explicitly with that character set. But we weren't setting that character set for LOAD DATA LOCAL INFILE queries, which results in MySQL defaulting to whatever the server default is. In cases where we may encode 4-byte characters but the server default character set is utf8mb3, that will cause errors since the input is not valid utf8mb3. This fixes that scenario by explicitly declaring the utf8mb4 character set for LOAD DATA LOCAL INFILE queries.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1642)
<!-- Reviewable:end -->
