### PR TITLE
materialize-elasticsearch: enable compression for request bodies

### DIFF
--- a/materialize-elasticsearch/driver.go
+++ b/materialize-elasticsearch/driver.go
@@ -250,11 +250,12 @@ func (c config) toClient(disableRetry bool) (*client, error) {
 
 	es, err := elasticsearch.NewClient(
 		elasticsearch.Config{
-			Addresses:     []string{endpoint},
-			Username:      c.Credentials.Username,
-			Password:      c.Credentials.Password,
-			APIKey:        c.Credentials.ApiKey,
-			RetryOnStatus: []int{429, 502, 503, 504},
+			Addresses:           []string{endpoint},
+			CompressRequestBody: true,
+			Username:            c.Credentials.Username,
+			Password:            c.Credentials.Password,
+			APIKey:              c.Credentials.ApiKey,
+			RetryOnStatus:       []int{429, 502, 503, 504},
 			RetryBackoff: func(i int) time.Duration {
 				d := time.Duration(1<<i) * time.Second
 				log.WithFields(log.Fields{


### PR DESCRIPTION
**Description:**

This is a config option that is available for the ElasticSearch client that we weren't using. The hope is that this reduces our egress costs, and may help with system that have a limited acceptable payload size for certain requests.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1645)
<!-- Reviewable:end -->
