### PR TITLE
filesource: log modTimes and time boundaries for skipped files

### DIFF
--- a/filesource/state.go
+++ b/filesource/state.go
@@ -144,11 +144,11 @@ func (p *State) shouldSkip(path string, modTime time.Time) (_ bool, reason strin
 	}
 	// Is the path modified before our window (exclusive) ?
 	if !modTime.After(p.MinBound) {
-		return true, "!modTime.After(MinBound)"
+		return true, fmt.Sprintf("!modTime.After(MinBound): modTime %s vs. MinBound %s", modTime.UTC().String(), p.MinBound.UTC().String())
 	}
 	// Is the path modified after our window (exclusive) ?
 	if !p.MaxBound.After(modTime) {
-		return true, "!MaxBound.After(modTime)"
+		return true, fmt.Sprintf("!MaxBound.After(modTime): MaxBound %s vs. modTime %s", p.MaxBound.UTC().String(), modTime.UTC().String())
 	}
 	return false, ""
 }

--- a/filesource/state_test.go
+++ b/filesource/state_test.go
@@ -18,7 +18,7 @@ func TestNoFiles(t *testing.T) {
 	// File is too new.
 	var skip, reason = s.shouldSkip("aaa", *ts(11))
 	require.True(t, skip)
-	require.Equal(t, "!MaxBound.After(modTime)", reason)
+	require.Equal(t, "!MaxBound.After(modTime): MaxBound 1970-01-01 00:00:10 +0000 UTC vs. modTime 1970-01-01 00:00:11 +0000 UTC", reason)
 
 	s.finishSweep(true)
 	verify(t, State{}, s)
@@ -98,7 +98,7 @@ func TestSuccessfulSweeps(t *testing.T) {
 	// Non-monotonic: This time, aaa @8 is too old to be processed.
 	skip, reason := s1.shouldSkip("aaa", *ts(8))
 	require.True(t, skip)
-	require.Equal(t, reason, "!modTime.After(MinBound)")
+	require.Equal(t, reason, "!modTime.After(MinBound): modTime 1970-01-01 00:00:08 +0000 UTC vs. MinBound 1970-01-01 00:00:08 +0000 UTC")
 
 	// bbb @9 has been modified, and should be.
 	// We detect this even though it's before our previous sweep start,
@@ -207,7 +207,7 @@ func TestSuccessfulSweeps(t *testing.T) {
 	// It skips a modTime that's < 50, but > the recovered MaxBound.
 	skip, reason = s1.shouldSkip("zzz", *ts(45))
 	require.True(t, skip)
-	require.Equal(t, reason, "!MaxBound.After(modTime)")
+	require.Equal(t, reason, "!MaxBound.After(modTime): MaxBound 1970-01-01 00:00:40 +0000 UTC vs. modTime 1970-01-01 00:00:45 +0000 UTC")
 
 	// s1 recovers by re-reading ddd @ 35.
 	require.True(t, s1.startPath("ddd", *ts(35)))
@@ -322,13 +322,13 @@ func TestMonotonicChanges(t *testing.T) {
 	// Still does not re-process files, but now its based on the MinBound.
 	skip, reason = s.shouldSkip("aaa", *ts(5))
 	require.True(t, skip)
-	require.Equal(t, "!modTime.After(MinBound)", reason)
+	require.Equal(t, "!modTime.After(MinBound): modTime 1970-01-01 00:00:05 +0000 UTC vs. MinBound 1970-01-01 00:00:23 +0000 UTC", reason)
 	skip, reason = s.shouldSkip("ccc", *ts(12))
 	require.True(t, skip)
-	require.Equal(t, "!modTime.After(MinBound)", reason)
+	require.Equal(t, "!modTime.After(MinBound): modTime 1970-01-01 00:00:12 +0000 UTC vs. MinBound 1970-01-01 00:00:23 +0000 UTC", reason)
 	skip, reason = s.shouldSkip("eee", *ts(23))
 	require.True(t, skip)
-	require.Equal(t, "!modTime.After(MinBound)", reason)
+	require.Equal(t, "!modTime.After(MinBound): modTime 1970-01-01 00:00:23 +0000 UTC vs. MinBound 1970-01-01 00:00:23 +0000 UTC", reason)
 
 	// Will process newer files.
 	skip, _ = s.shouldSkip("fff", *ts(33))
@@ -362,7 +362,7 @@ func TestMonotonicChanges(t *testing.T) {
 	// since MinBound is retained, even though it is not incremented.
 	skip, reason = s.shouldSkip("ggg", *ts(1))
 	require.True(t, skip)
-	require.Equal(t, "!modTime.After(MinBound)", reason)
+	require.Equal(t, "!modTime.After(MinBound): modTime 1970-01-01 00:00:01 +0000 UTC vs. MinBound 1970-01-01 00:00:23 +0000 UTC", reason)
 }
 
 func ts(i int64) *time.Time {


### PR DESCRIPTION
**Description:**

Adds some additional debug log information for filesource captures when they skip files due to modification times being either too recent or too old.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1646)
<!-- Reviewable:end -->
