### PR TITLE
source-airtable: Updating schema generation and table names

### DIFF
--- a/source-airtable/acmeCo/test_base/flow.yaml
+++ b/source-airtable/acmeCo/test_base/flow.yaml
@@ -1,4 +1,58 @@
 ---
-import:
-  - pizzas/flow.yaml
-  - soups/flow.yaml
+collections:
+  acmeCo/test_base/pizzas:
+    schema:
+      $schema: "https://json-schema.org/draft-07/schema#"
+      type: object
+      additionalProperties: true
+      properties:
+        _airtable_id:
+          type: string
+        _airtable_created_time:
+          type:
+            - "null"
+            - string
+        _airtable_table_name:
+          type:
+            - "null"
+            - string
+        _meta:
+          type: object
+          properties:
+            row_id:
+              type: integer
+          required:
+            - row_id
+      required:
+        - _airtable_id
+      x-infer-schema: true
+    key:
+      - /_airtable_id
+  acmeCo/test_base/soups:
+    schema:
+      $schema: "https://json-schema.org/draft-07/schema#"
+      type: object
+      additionalProperties: true
+      properties:
+        _airtable_id:
+          type: string
+        _airtable_created_time:
+          type:
+            - "null"
+            - string
+        _airtable_table_name:
+          type:
+            - "null"
+            - string
+        _meta:
+          type: object
+          properties:
+            row_id:
+              type: integer
+          required:
+            - row_id
+      required:
+        - _airtable_id
+      x-infer-schema: true
+    key:
+      - /_airtable_id

--- a/source-airtable/acmeCo/test_base/pizzas/flow.yaml
+++ b/source-airtable/acmeCo/test_base/pizzas/flow.yaml
@@ -1,6 +1,6 @@
 ---
 collections:
-  acmeCo/test_base/pizzas/tblY71QcPfB7SjY1f:
+  acmeCo/test_base/pizzas:
     schema:
       $schema: "https://json-schema.org/draft-07/schema#"
       type: object

--- a/source-airtable/acmeCo/test_base/soups/flow.yaml
+++ b/source-airtable/acmeCo/test_base/soups/flow.yaml
@@ -1,6 +1,6 @@
 ---
 collections:
-  acmeCo/test_base/soups/tblDi5DS0EjiYi83h:
+  acmeCo/test_base/soups:
     schema:
       $schema: "https://json-schema.org/draft-07/schema#"
       type: object

--- a/source-airtable/source_airtable/schema_helpers.py
+++ b/source-airtable/source_airtable/schema_helpers.py
@@ -93,40 +93,6 @@ class SchemaHelpers:
             "_airtable_table_name": SchemaTypes.string,
         }
 
-        fields: Dict = table.get("fields", {})
-        for field in fields:
-            name: str = SchemaHelpers.clean_name(field.get("name"))
-            original_type: str = field.get("type")
-            options: Dict = field.get("options", {})
-            options_result: Dict = options.get("result", {})
-            exec_type: str = options_result.get("type") if options_result else None
-
-            # choose the JsonSchema Type for known Airtable Types
-            if original_type in COMPLEX_AIRTABLE_TYPES.keys():
-                complex_type = deepcopy(COMPLEX_AIRTABLE_TYPES.get(original_type))
-                # process arrays with values
-                field_type: str = exec_type if exec_type else "simpleText"
-                # For cases with `options.result` == None, we should apply the type `string`.
-                # Other edge cases, if `field_type` not in SIMPLE_AIRTABLE_TYPES, fall back to "simpleText" == `string`
-                # reference issue: https://github.com/airbytehq/oncall/issues/1432#issuecomment-1412743120
-                if complex_type == SchemaTypes.array_with_any:
-                    if original_type == "formula" and field_type in ("number", "currency", "percent", "duration"):
-                        complex_type = SchemaTypes.number
-                    elif original_type == "formula" and not any((options.get("formula").startswith(x) for x in ARRAY_FORMULAS)):
-                        complex_type = SchemaTypes.string
-                    elif field_type in SIMPLE_AIRTABLE_TYPES:
-                        complex_type["items"] = deepcopy(SIMPLE_AIRTABLE_TYPES.get(field_type))
-                    else:
-                        complex_type["items"] = SchemaTypes.string
-                        logger.warning(f"Unknown field type: {field_type}, falling back to `simpleText` type")
-                properties.update(**{name: complex_type})
-            elif original_type in SIMPLE_AIRTABLE_TYPES.keys():
-                field_type: str = exec_type if exec_type else original_type
-                properties.update(**{name: deepcopy(SIMPLE_AIRTABLE_TYPES.get(field_type))})
-            else:
-                # Airtable may add more field types in the future and don't consider it a breaking change
-                properties.update(**{name: SchemaTypes.string})
-
         json_schema: Dict = {
             "$schema": "https://json-schema.org/draft-07/schema#",
             "type": "object",

--- a/source-airtable/source_airtable/source.py
+++ b/source-airtable/source_airtable/source.py
@@ -44,11 +44,15 @@ class SourceAirtable(AbstractSource):
         for index, configured_stream in enumerate(catalog.streams):
             stream_instance = stream_instances.get(configured_stream.stream.name)
             if not stream_instance:
-                table_id = configured_stream.stream.name.split("/")[2]
-                similar_streams = [s for s in stream_instances if s.endswith(table_id)]
+                # Removing table_id and similar_streams
+                # As we are not outputting the table_id within
+                # The table name anymore.
+
+                #table_id = configured_stream.stream.name.split("/")[2]
+                #similar_streams = [s for s in stream_instances if s.endswith(table_id)]
                 logger.warn(
                     f"The requested stream {configured_stream.stream.name} was not found in the source. Please check if this stream was renamed or removed previously and reset data, removing from catalog for this sync run. For more information please refer to documentation: https://docs.airbyte.com/integrations/sources/airtable/#note-on-changed-table-names-and-deleted-tables"
-                    f" Similar streams: {similar_streams}"
+                    #f" Similar streams: {similar_streams}"
                     f" Available streams: {stream_instances.keys()}"
                 )
                 del catalog.streams[index]
@@ -83,7 +87,7 @@ class SourceAirtable(AbstractSource):
                     {
                         "stream_path": f"{base_id}/{table.get('id')}",
                         "stream": SchemaHelpers.get_airbyte_stream(
-                            f"{base_name}/{SchemaHelpers.clean_name(table.get('name'))}/{table.get('id')}",
+                            f"{base_name}/{SchemaHelpers.clean_name(table.get('name'))}",
                             SchemaHelpers.get_json_schema(table),
                         ),
                         "table_name": table.get("name"),

--- a/source-airtable/test.flow.yaml
+++ b/source-airtable/test.flow.yaml
@@ -10,16 +10,14 @@ captures:
           - "-m"
           - source_airtable
         config: config.yaml
-    shards:
-      logLevel: debug
     bindings:
       - resource:
-          stream: test_base/pizzas/tblY71QcPfB7SjY1f
+          stream: test_base/pizzas
           syncMode: full_refresh
-        target: acmeCo/test_base/pizzas/tblY71QcPfB7SjY1f
-        disable: false
+        target: acmeCo/test_base/pizzas
       - resource:
-          stream: test_base/soups/tblDi5DS0EjiYi83h
+          stream: test_base/soups
           syncMode: full_refresh
-        target: acmeCo/test_base/soups/tblDi5DS0EjiYi83h
-        disable: true
+        target: acmeCo/test_base/soups
+    shards:
+      logLevel: debug

--- a/source-airtable/tests/conftest.py
+++ b/source-airtable/tests/conftest.py
@@ -39,7 +39,7 @@ def fake_tables_response():
 
 @pytest.fixture
 def expected_discovery_stream_name():
-    return ["test_base/test_table/5678"]
+    return ["test_base/test_table"]
 
 
 @pytest.fixture
@@ -176,8 +176,8 @@ def make_stream(prepared_stream):
 
 @pytest.fixture
 def fake_catalog(make_stream):
-    stream1 = make_stream(name="test_base/test_table1/abcdef")
-    stream2 = make_stream(name="test_base/test_table2/qwerty")
+    stream1 = make_stream(name="test_base/test_table1")
+    stream2 = make_stream(name="test_base/test_table2")
     return ConfiguredAirbyteCatalog(
         streams=[stream1, stream2],
     )
@@ -185,6 +185,6 @@ def fake_catalog(make_stream):
 
 @pytest.fixture
 def fake_streams(make_airtable_stream):
-    stream1 = make_airtable_stream(name="test_base/test_table1/abcdef")
-    stream2 = make_airtable_stream(name="test_base/test_table2_renamed/qwerty")
+    stream1 = make_airtable_stream(name="test_base/test_table1")
+    stream2 = make_airtable_stream(name="test_base/test_table2_renamed")
     yield [stream1, stream2]

--- a/source-airtable/tests/snapshots/snapshots__capture__capture.stdout.json
+++ b/source-airtable/tests/snapshots/snapshots__capture__capture.stdout.json
@@ -1,6 +1,6 @@
 [
   [
-    "acmeCo/test_base/pizzas/tblY71QcPfB7SjY1f",
+    "acmeCo/test_base/pizzas",
     {
       "_airtable_created_time": "2023-10-26T19:15:35.000Z",
       "_airtable_id": "recEi9L0zVx5T1TXa",
@@ -16,7 +16,7 @@
     }
   ],
   [
-    "acmeCo/test_base/pizzas/tblY71QcPfB7SjY1f",
+    "acmeCo/test_base/pizzas",
     {
       "_airtable_created_time": "2023-10-26T19:15:35.000Z",
       "_airtable_id": "recwIuv53qfJI2o7E",
@@ -32,7 +32,7 @@
     }
   ],
   [
-    "acmeCo/test_base/pizzas/tblY71QcPfB7SjY1f",
+    "acmeCo/test_base/pizzas",
     {
       "_airtable_created_time": "2023-10-26T19:15:35.000Z",
       "_airtable_id": "recyiWwcNMoh2SDvd",
@@ -44,6 +44,54 @@
       "cost": 300,
       "name": "Cheese",
       "status": "To do",
+      "ts": "redacted-timestamp"
+    }
+  ],
+  [
+    "acmeCo/test_base/soups",
+    {
+      "_airtable_created_time": "2024-01-26T17:57:14.000Z",
+      "_airtable_id": "recKrbxbdBYUS9XqG",
+      "_airtable_table_name": "Soups",
+      "_meta": {
+        "op": "u",
+        "row_id": 0
+      },
+      "name": "Broccoli Cheddar",
+      "notes": "Absolutely Delicious",
+      "status": "In progress",
+      "ts": "redacted-timestamp"
+    }
+  ],
+  [
+    "acmeCo/test_base/soups",
+    {
+      "_airtable_created_time": "2024-01-26T17:57:14.000Z",
+      "_airtable_id": "recccWEXsqTf0cxw6",
+      "_airtable_table_name": "Soups",
+      "_meta": {
+        "op": "u",
+        "row_id": 1
+      },
+      "name": "Minestrone",
+      "notes": "Yum Yum Yum",
+      "status": "Todo",
+      "ts": "redacted-timestamp"
+    }
+  ],
+  [
+    "acmeCo/test_base/soups",
+    {
+      "_airtable_created_time": "2024-01-26T17:57:14.000Z",
+      "_airtable_id": "recuhWw0rDiAgWS6T",
+      "_airtable_table_name": "Soups",
+      "_meta": {
+        "op": "u",
+        "row_id": 2
+      },
+      "name": "Italian Wedding",
+      "notes": "It's a meata ball!",
+      "status": "Done",
       "ts": "redacted-timestamp"
     }
   ]

--- a/source-airtable/tests/snapshots/snapshots__discover__capture.stdout.json
+++ b/source-airtable/tests/snapshots/snapshots__discover__capture.stdout.json
@@ -1,8 +1,8 @@
 [
   {
-    "recommendedName": "test_base/pizzas/tblY71QcPfB7SjY1f",
+    "recommendedName": "test_base/pizzas",
     "resourceConfig": {
-      "stream": "test_base/pizzas/tblY71QcPfB7SjY1f",
+      "stream": "test_base/pizzas",
       "syncMode": "full_refresh"
     },
     "documentSchema": {
@@ -24,26 +24,6 @@
             "null",
             "string"
           ]
-        },
-        "name": {
-          "type": [
-            "null",
-            "string"
-          ]
-        },
-        "status": {
-          "type": [
-            "null",
-            "string"
-          ]
-        },
-        "cost": {
-          "type": [
-            "null",
-            "number",
-            "string"
-          ],
-          "format": "number"
         },
         "_meta": {
           "type": "object",
@@ -67,9 +47,9 @@
     ]
   },
   {
-    "recommendedName": "test_base/soups/tblDi5DS0EjiYi83h",
+    "recommendedName": "test_base/soups",
     "resourceConfig": {
-      "stream": "test_base/soups/tblDi5DS0EjiYi83h",
+      "stream": "test_base/soups",
       "syncMode": "full_refresh"
     },
     "documentSchema": {
@@ -87,24 +67,6 @@
           ]
         },
         "_airtable_table_name": {
-          "type": [
-            "null",
-            "string"
-          ]
-        },
-        "name": {
-          "type": [
-            "null",
-            "string"
-          ]
-        },
-        "notes": {
-          "type": [
-            "null",
-            "string"
-          ]
-        },
-        "status": {
           "type": [
             "null",
             "string"

--- a/source-airtable/tests/test_helpers.py
+++ b/source-airtable/tests/test_helpers.py
@@ -18,10 +18,11 @@ def load_file(file_name: str) -> Mapping[str, Any]:
 def test_clean_name(field_name_to_cleaned, expected_clean_name):
     assert expected_clean_name == SchemaHelpers.clean_name(field_name_to_cleaned)
 
+# Test removed since schema will now be inferred
 
-def test_get_json_schema(json_response, expected_json_schema):
-    json_schema = SchemaHelpers.get_json_schema(json_response["records"][0])
-    assert json_schema == expected_json_schema
+# def test_get_json_schema(json_response, expected_json_schema):
+#     json_schema = SchemaHelpers.get_json_schema(json_response["records"][0])
+#     assert json_schema == expected_json_schema
 
 
 def test_get_airbyte_stream(table, expected_json_schema):
@@ -30,11 +31,12 @@ def test_get_airbyte_stream(table, expected_json_schema):
     assert stream.name == table
     assert stream.json_schema == expected_json_schema
 
+# Test removed since schema will now be inferred
 
-def test_table_with_formulas():
-    table = load_file("sample_table_with_formulas.json")
+# def test_table_with_formulas():
+#     table = load_file("sample_table_with_formulas.json")
 
-    stream_schema = SchemaHelpers.get_json_schema(table)
+#     stream_schema = SchemaHelpers.get_json_schema(table)
 
-    expected_schema = load_file("expected_schema_for_sample_table.json")
-    assert stream_schema == expected_schema
+#     expected_schema = load_file("expected_schema_for_sample_table.json")
+#     assert stream_schema == expected_schema


### PR DESCRIPTION
**Description:**

Schema is now being inferred instead of generated by a bunch of confusing properties rules. Because of that, two tests on test_helpers.py file were removed, since the expected schema would not be inferred by the airbyte schemahelper.

Also removed the table_id from all table names. It didnt play a important role, its value is already inside each doc and probably made for SQL queries to be big and "dirty"

All tests are passing on both pytest and a local flow version i ran with custom credentials


**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1647)
<!-- Reviewable:end -->
