### PR TITLE
source-postgres: Check for slot delete/recreate and error out

### DIFF
--- a/source-postgres/.snapshots/TestCaptureFailsAfterSlotDropped-capture1
+++ b/source-postgres/.snapshots/TestCaptureFailsAfterSlotDropped-capture1
@@ -1,0 +1,10 @@
+# ================================
+# Collection "acmeCo/test/test_capturefailsafterslotdropped_46115540": 2 Documents
+# ================================
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"capturefailsafterslotdropped_46115540","loc":[11111111,11111111,11111111]}},"data":"one","id":1}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"capturefailsafterslotdropped_46115540","loc":[11111111,11111111,11111111]}},"data":"zero","id":0}
+# ================================
+# Final State Checkpoint
+# ================================
+{"bindingStateV1":{"test%2Fcapturefailsafterslotdropped_46115540":{"backfilled":2,"key_columns":["id"],"mode":"Active"}},"cursor":"0/1111111"}
+

--- a/source-postgres/.snapshots/TestCaptureFailsAfterSlotDropped-capture2
+++ b/source-postgres/.snapshots/TestCaptureFailsAfterSlotDropped-capture2
@@ -1,0 +1,9 @@
+# ================================
+# Final State Checkpoint
+# ================================
+{"bindingStateV1":{"test%2Fcapturefailsafterslotdropped_46115540":{"backfilled":2,"key_columns":["id"],"mode":"Active"}},"cursor":"0/1111111"}
+# ================================
+# Captures Terminated With Errors
+# ================================
+error creating replication stream: replication slot "flow_slot" has a confirmed_flush_lsn greater than our start LSN, which means it was probably deleted/recreated and all bindings need to be backfilled
+

--- a/source-postgres/.snapshots/TestCaptureFailsAfterSlotDropped-capture3
+++ b/source-postgres/.snapshots/TestCaptureFailsAfterSlotDropped-capture3
@@ -1,0 +1,9 @@
+# ================================
+# Final State Checkpoint
+# ================================
+{"bindingStateV1":{"test%2Fcapturefailsafterslotdropped_46115540":{"backfilled":2,"key_columns":["id"],"mode":"Active"}},"cursor":"0/1111111"}
+# ================================
+# Captures Terminated With Errors
+# ================================
+error creating replication stream: replication slot "flow_slot" has a confirmed_flush_lsn greater than our start LSN, which means it was probably deleted/recreated and all bindings need to be backfilled
+

--- a/source-postgres/.snapshots/TestCaptureFailsAfterSlotDropped-capture4
+++ b/source-postgres/.snapshots/TestCaptureFailsAfterSlotDropped-capture4
@@ -1,0 +1,16 @@
+# ================================
+# Collection "acmeCo/test/test_capturefailsafterslotdropped_46115540": 8 Documents
+# ================================
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"capturefailsafterslotdropped_46115540","loc":[11111111,11111111,11111111]}},"data":"five","id":5}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"capturefailsafterslotdropped_46115540","loc":[11111111,11111111,11111111]}},"data":"four","id":4}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"capturefailsafterslotdropped_46115540","loc":[11111111,11111111,11111111]}},"data":"one","id":1}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"capturefailsafterslotdropped_46115540","loc":[11111111,11111111,11111111]}},"data":"seven","id":7}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"capturefailsafterslotdropped_46115540","loc":[11111111,11111111,11111111]}},"data":"six","id":6}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"capturefailsafterslotdropped_46115540","loc":[11111111,11111111,11111111]}},"data":"three","id":3}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"capturefailsafterslotdropped_46115540","loc":[11111111,11111111,11111111]}},"data":"two","id":2}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"capturefailsafterslotdropped_46115540","loc":[11111111,11111111,11111111]}},"data":"zero","id":0}
+# ================================
+# Final State Checkpoint
+# ================================
+{"bindingStateV1":{"test%2Fcapturefailsafterslotdropped_46115540":{"backfilled":0,"mode":"Ignore"},"test%2Fcapturefailsafterslotdropped_46115540.v2":{"backfilled":8,"key_columns":["id"],"mode":"Active"}},"cursor":"0/1111111"}
+

--- a/source-postgres/capture_test.go
+++ b/source-postgres/capture_test.go
@@ -485,3 +485,30 @@ func TestCaptureOversizedFields(t *testing.T) {
 		tests.VerifiedCapture(ctx, t, cs)
 	})
 }
+
+func TestCaptureFailsAfterSlotDropped(t *testing.T) {
+	var tb, ctx = postgresTestBackend(t), context.Background()
+	var uniqueID = "46115540"
+	var tableName = tb.CreateTable(ctx, t, uniqueID, "(id INTEGER PRIMARY KEY, data TEXT)")
+	var cs = tb.CaptureSpec(ctx, t, regexp.MustCompile(uniqueID))
+
+	// Run a normal capture
+	tb.Insert(ctx, t, tableName, [][]any{{0, "zero"}, {1, "one"}})
+	t.Run("capture1", func(t *testing.T) { tests.VerifiedCapture(ctx, t, cs) })
+
+	// Drop the replication slot while the task is offline, and it should recreate
+	// the replication slot and then start failing because its saved position isn't
+	// valid any longer.
+	tb.Insert(ctx, t, tableName, [][]any{{2, "two"}, {3, "three"}})
+	tb.Query(ctx, t, fmt.Sprintf("SELECT pg_drop_replication_slot('flow_slot');"))
+	tb.Insert(ctx, t, tableName, [][]any{{4, "four"}, {5, "five"}})
+	t.Run("capture2", func(t *testing.T) { tests.VerifiedCapture(ctx, t, cs) })
+
+	// A subsequent capture run should still be failing since we haven't fixed it.
+	tb.Insert(ctx, t, tableName, [][]any{{6, "six"}, {7, "seven"}})
+	t.Run("capture3", func(t *testing.T) { tests.VerifiedCapture(ctx, t, cs) })
+
+	// Append a version to the state key to simulate bumping the backfill counter for this binding.
+	cs.Bindings[0].StateKey += ".v2"
+	t.Run("capture4", func(t *testing.T) { tests.VerifiedCapture(ctx, t, cs) })
+}

--- a/source-postgres/prerequisites.go
+++ b/source-postgres/prerequisites.go
@@ -2,12 +2,10 @@ package main
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"strings"
 
 	"github.com/estuary/connectors/sqlcapture"
-	"github.com/jackc/pgx/v4"
 	"github.com/sirupsen/logrus"
 )
 
@@ -114,41 +112,43 @@ func (db *postgresDatabase) prerequisiteReplicationUser(ctx context.Context) err
 }
 
 func (db *postgresDatabase) prerequisiteReplicationSlot(ctx context.Context) error {
-	// If the replication slot already exists in our configured database then we're satisfied.
+	// Get information about the replication slot
 	var slotName = db.config.Advanced.SlotName
-	var configuredDatabase = db.config.Database
 	var logEntry = logrus.WithFields(logrus.Fields{
 		"slot":     slotName,
-		"database": configuredDatabase,
+		"database": db.config.Database,
 	})
-	var slotDatabase string
-	if err := db.conn.QueryRow(ctx, fmt.Sprintf(`SELECT database FROM pg_catalog.pg_replication_slots WHERE slot_name = '%s' AND slot_type = 'logical';`, slotName)).Scan(&slotDatabase); err != nil {
-		if !errors.Is(err, pgx.ErrNoRows) {
-			return fmt.Errorf("error querying replication slots: %w", err)
-		}
+	var slotInfo, err = queryReplicationSlotInfo(ctx, db.conn, slotName)
+	if err != nil {
+		return err
 	}
-	if slotDatabase == configuredDatabase {
-		logEntry.Debug("replication slot exists")
+
+	// If the replication slot doesn't exist at all, try to create it. If successful then we're done here.
+	if slotInfo == nil {
+		logEntry.Info("attempting to create replication slot")
+		if _, err := db.conn.Exec(ctx, fmt.Sprintf(`SELECT pg_create_logical_replication_slot($1, 'pgoutput');`), slotName); err != nil {
+			return fmt.Errorf("replication slot %q doesn't exist and couldn't be created", slotName)
+		}
+		logEntry.Info("created replication slot")
 		return nil
 	}
+	logEntry.Debug("replication slot exists")
 
-	// Slot exists, but not in our database.
-	if slotDatabase != "" {
+	// If the replication slot already exists, perform some sanity checking to make sure it's usable.
+	if slotInfo.Database != "" && slotInfo.Database != db.config.Database {
 		return fmt.Errorf(
-			"replication slot %q exists in database %q, but the configured database is %q: consider using a different slot name or removing the existing slot",
+			"replication slot %q exists in database %q, but the configured database is %q, consider using a different slot name or removing the existing slot",
 			slotName,
-			slotDatabase,
-			configuredDatabase,
+			slotInfo.Database,
+			db.config.Database,
 		)
 	}
-
-	// Slot does not exist in any database. Try to create it.
-	logEntry.Info("attempting to create replication slot")
-	if _, err := db.conn.Exec(ctx, fmt.Sprintf(`SELECT pg_create_logical_replication_slot('%s', 'pgoutput');`, slotName)); err != nil {
-		return fmt.Errorf("replication slot %q doesn't exist and couldn't be created", slotName)
+	if slotInfo.Plugin != "pgoutput" || slotInfo.SlotType != "logical" {
+		return fmt.Errorf("replication slot %q was incorrectly created, consider using a different slot name or removing the existing slot", slotName)
 	}
-
-	logEntry.Info("created replication slot")
+	if slotInfo.WALStatus == "lost" {
+		return fmt.Errorf("replication slot %q was invalidated by the server, it must be deleted and all bindings backfilled", slotName)
+	}
 	return nil
 }
 

--- a/source-postgres/replication.go
+++ b/source-postgres/replication.go
@@ -16,6 +16,7 @@ import (
 	"github.com/jackc/pglogrepl"
 	"github.com/jackc/pgproto3/v2"
 	"github.com/jackc/pgtype"
+	"github.com/jackc/pgx/v4"
 	"github.com/sirupsen/logrus"
 )
 
@@ -53,6 +54,19 @@ func (db *postgresDatabase) ReplicationStream(ctx context.Context, startCursor s
 	}
 
 	var slot, publication = db.config.Advanced.SlotName, db.config.Advanced.PublicationName
+
+	// Check that the slot's `confirmed_flush_lsn` is less than or equal to our resume cursor value.
+	// This is necessary because Postgres deliberately allows clients to specify an older start LSN,
+	// and then ignores that and uses the confirmed LSN instead. Supposedly this simplifies writing
+	// clients in some cases, but in our case it never helps, and instead it causes trouble if/when
+	// the replication slot is dropped and recreated.
+	slotInfo, err := queryReplicationSlotInfo(ctx, db.conn, slot)
+	if err != nil {
+		return nil, err
+	}
+	if startLSN < slotInfo.ConfirmedFlushLSN {
+		return nil, fmt.Errorf("replication slot %q has a confirmed_flush_lsn greater than our start LSN, which means it was probably deleted/recreated and all bindings need to be backfilled", slot)
+	}
 
 	logrus.WithFields(logrus.Fields{
 		"startLSN":    startLSN,
@@ -711,4 +725,30 @@ func (db *postgresDatabase) ReplicationDiagnostics(ctx context.Context) error {
 	query("SELECT * FROM pg_replication_slots;")
 	query("SELECT pg_current_wal_flush_lsn(), pg_current_wal_insert_lsn(), pg_current_wal_lsn();")
 	return nil
+}
+
+type replicationSlotInfo struct {
+	SlotName          string
+	Database          string
+	Plugin            string
+	SlotType          string
+	RestartLSN        pglogrepl.LSN
+	ConfirmedFlushLSN pglogrepl.LSN
+	WALStatus         string
+}
+
+// queryReplicationSlotInfo returns information about the named replication slot, if it exists.
+// If the slot doesn't exist then a nil pointer is returned, but without an error. An error is
+// only returned if the query itself fails.
+func queryReplicationSlotInfo(ctx context.Context, conn *pgx.Conn, slotName string) (*replicationSlotInfo, error) {
+	var info replicationSlotInfo
+	var query = `SELECT slot_name, database, plugin, slot_type, restart_lsn, confirmed_flush_lsn, wal_status FROM pg_catalog.pg_replication_slots WHERE slot_name = $1`
+	if err := conn.QueryRow(ctx, query, slotName).Scan(&info.SlotName, &info.Database, &info.Plugin, &info.SlotType, &info.RestartLSN, &info.ConfirmedFlushLSN, &info.WALStatus); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, nil
+		} else {
+			return nil, fmt.Errorf("error querying replication slots: %w", err)
+		}
+	}
+	return &info, nil
 }


### PR DESCRIPTION
**Description:**

This PR fixes the behavior of `source-postgres` when the replication slot is deleted and then recreated, so that it will error out until the user re-backfills all bindings (the intended behavior) instead of just silently skipping an unknown amount of change data and then continuing where it left off (the behavior prior to today).

While I was at it I also threw in a change I've been meaning to get around to, which makes the automated diagnostics queries run once at capture startup. This is a good idea in general because it gives us more debugging information in certain cases where tasks are consistently failing before they reach the replication diagnostics timeout, and I went ahead and did it as part of this work because the extra logging made it easier to verify exactly what was going on with the Postgres replication slot management.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1653)
<!-- Reviewable:end -->
