### PR TITLE
source-mysql: Configurable heartbeat/watermark interval

### DIFF
--- a/source-mysql/.snapshots/TestGeneric-SpecResponse
+++ b/source-mysql/.snapshots/TestGeneric-SpecResponse
@@ -71,6 +71,13 @@
             "title": "Backfill Chunk Size",
             "description": "The number of rows which should be fetched from the database in a single backfill query.",
             "default": 50000
+          },
+          "heartbeat_interval": {
+            "type": "string",
+            "title": "Heartbeat Interval",
+            "description": "How frequently to issue watermark writes as a heartbeat during replication streaming. Must be a valid Go duration string.",
+            "default": "60s",
+            "pattern": "^[-+]?([0-9]+([.][0-9]+)?(h|m|s|ms))+$"
           }
         },
         "additionalProperties": false,

--- a/source-mysql/main.go
+++ b/source-mysql/main.go
@@ -386,6 +386,10 @@ func (db *mysqlDatabase) RequestTxIDs(schema, table string) {
 	db.includeTxIDs[sqlcapture.JoinStreamID(schema, table)] = true
 }
 
+func (db *mysqlDatabase) HeartbeatWatermarkInterval() time.Duration {
+	return 60 * time.Second
+}
+
 // mysqlSourceInfo is source metadata for data capture events.
 type mysqlSourceInfo struct {
 	sqlcapture.SourceCommon

--- a/source-postgres/main.go
+++ b/source-postgres/main.go
@@ -332,3 +332,7 @@ func (db *postgresDatabase) RequestTxIDs(schema, table string) {
 	}
 	db.includeTxIDs[sqlcapture.JoinStreamID(schema, table)] = true
 }
+
+func (db *postgresDatabase) HeartbeatWatermarkInterval() time.Duration {
+	return 60 * time.Second
+}

--- a/source-sqlserver/main.go
+++ b/source-sqlserver/main.go
@@ -253,3 +253,7 @@ func (db *sqlserverDatabase) FallbackCollectionKey() []string {
 }
 
 func (db *sqlserverDatabase) RequestTxIDs(schema, table string) {}
+
+func (db *sqlserverDatabase) HeartbeatWatermarkInterval() time.Duration {
+	return 60 * time.Second
+}

--- a/sqlcapture/interface.go
+++ b/sqlcapture/interface.go
@@ -3,6 +3,7 @@ package sqlcapture
 import (
 	"context"
 	"encoding/json"
+	"time"
 
 	"github.com/invopop/jsonschema"
 )
@@ -122,6 +123,9 @@ type Database interface {
 	WriteWatermark(ctx context.Context, watermark string) error
 	// WatermarksTable returns the name of the table to which WriteWatermarks writes UUIDs.
 	WatermarksTable() string
+	// Once the capture is indefinitely streaming changes, it will write a heartbeat watermark this often.
+	HeartbeatWatermarkInterval() time.Duration
+
 	// ScanTableChunk fetches a chunk of rows from the specified table, resuming from the `resumeAfter` row key if non-nil.
 	// The `backfillComplete` boolean will be true after scanning the final chunk of the table.
 	ScanTableChunk(ctx context.Context, info *DiscoveryInfo, state *TableState, callback func(event *ChangeEvent) error) (backfillComplete bool, err error)


### PR DESCRIPTION
**Description:**

Adds an advanced config option allowing `source-mysql` captures to override the heartbeat write interval from its default of 60s. This is primarily useful because MySQL has a bunch of old archaic storage engines, some of which (*cough* MyISAM *cough*) don't even support transactions. And when changes are made to a table using one of these storage engines, there may not be any transaction-committing `XIDEvent` in the binlog.

But as long as the watermarks table is created with the InnoDB storage engine we are guaranteed to see a regular and reliable source of transaction commits, so things still mostly work when capturing data from tables using a non-transactional storage engine. Except...we only write watermarks every 60s by default, and it would be nice to at least bring the latency _a little bit_ lower than that, like 1-5 seconds perhaps.

Someday we might add more "first-class" support for MyISAM and other specialty storage engines. If we did, this would look like a bit of metadata tracking which tables are "non-transactional" and a bit of logic in the replication stream client code to generate synthetic commit events after each `RowsEvent` on such tables. But that's complicated and honestly MyISAM is old and deprecated and it might not be worth the engineering investment.

On the other hand, making the existing heartbeat-watermark-write behavior take a configurable interval in the advanced capture settings is a half-hour job and works pretty well as a stopgap. So for now we'll just do that and table the whole problem unless/until it becomes a real priority.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1654)
<!-- Reviewable:end -->
