### PR TITLE
source-shopify: corrected schemas & tests

### DIFF
--- a/source-shopify/acmeCo/custom_collections.schema.yaml
+++ b/source-shopify/acmeCo/custom_collections.schema.yaml
@@ -76,5 +76,6 @@ properties:
       - row_id
 type: object
 required:
+  - id
   - _meta
 x-infer-schema: true

--- a/source-shopify/acmeCo/customers.schema.yaml
+++ b/source-shopify/acmeCo/customers.schema.yaml
@@ -274,5 +274,6 @@ properties:
       - row_id
 type: object
 required:
+  - id
   - _meta
 x-infer-schema: true

--- a/source-shopify/acmeCo/flow.yaml
+++ b/source-shopify/acmeCo/flow.yaml
@@ -35,6 +35,7 @@ collections:
             - row_id
       type: object
       required:
+        - id
         - _meta
       additionalProperties: true
       x-infer-schema: true
@@ -80,6 +81,7 @@ collections:
             - row_id
       type: object
       required:
+        - id
         - _meta
       x-infer-schema: true
     key:
@@ -110,9 +112,7 @@ collections:
             - string
             - "null"
         id:
-          type:
-            - integer
-            - "null"
+          type: integer
         price_rule_id:
           type:
             - integer
@@ -135,6 +135,7 @@ collections:
             - row_id
       type: object
       required:
+        - id
         - _meta
       additionalProperties: true
       x-infer-schema: true
@@ -172,6 +173,7 @@ collections:
             - row_id
       type: object
       required:
+        - inventory_item_id
         - _meta
       x-infer-schema: true
     key:

--- a/source-shopify/acmeCo/inventory_items.schema.yaml
+++ b/source-shopify/acmeCo/inventory_items.schema.yaml
@@ -58,5 +58,6 @@ properties:
       - row_id
 type: object
 required:
+  - id
   - _meta
 x-infer-schema: true

--- a/source-shopify/acmeCo/locations.schema.yaml
+++ b/source-shopify/acmeCo/locations.schema.yaml
@@ -81,5 +81,6 @@ properties:
       - row_id
 type: object
 required:
+  - id
   - _meta
 x-infer-schema: true

--- a/source-shopify/acmeCo/metafields.schema.yaml
+++ b/source-shopify/acmeCo/metafields.schema.yaml
@@ -55,5 +55,6 @@ properties:
       - row_id
 type: object
 required:
+  - id
   - _meta
 x-infer-schema: true

--- a/source-shopify/acmeCo/order_risks.schema.yaml
+++ b/source-shopify/acmeCo/order_risks.schema.yaml
@@ -48,6 +48,7 @@ properties:
       - row_id
 type: object
 required:
+  - id
   - _meta
 additionalProperties: true
 x-infer-schema: true

--- a/source-shopify/acmeCo/orders.schema.yaml
+++ b/source-shopify/acmeCo/orders.schema.yaml
@@ -1244,5 +1244,6 @@ properties:
       - row_id
 type: object
 required:
+  - id
   - _meta
 x-infer-schema: true

--- a/source-shopify/acmeCo/price_rules.schema.yaml
+++ b/source-shopify/acmeCo/price_rules.schema.yaml
@@ -128,6 +128,7 @@ properties:
       - row_id
 type: object
 required:
+  - id
   - _meta
 additionalProperties: true
 x-infer-schema: true

--- a/source-shopify/acmeCo/products.schema.yaml
+++ b/source-shopify/acmeCo/products.schema.yaml
@@ -300,5 +300,6 @@ properties:
       - row_id
 type: object
 required:
+  - id
   - _meta
 x-infer-schema: true

--- a/source-shopify/acmeCo/refunds.schema.yaml
+++ b/source-shopify/acmeCo/refunds.schema.yaml
@@ -50,6 +50,7 @@ properties:
       - row_id
 type: object
 required:
+  - id
   - _meta
 additionalProperties: true
 x-infer-schema: true

--- a/source-shopify/acmeCo/transactions.schema.yaml
+++ b/source-shopify/acmeCo/transactions.schema.yaml
@@ -163,5 +163,6 @@ properties:
       - row_id
 type: object
 required:
+  - id
   - _meta
 x-infer-schema: true

--- a/source-shopify/source_shopify/tap_shopify/schemas/abandoned_checkout.json
+++ b/source-shopify/source_shopify/tap_shopify/schemas/abandoned_checkout.json
@@ -1,6 +1,7 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema",
     "type": "object",
+    "required": ["id"],
     "properties": {
         "abandoned_checkout_url": {
             "type": [

--- a/source-shopify/source_shopify/tap_shopify/schemas/carrier_service.json
+++ b/source-shopify/source_shopify/tap_shopify/schemas/carrier_service.json
@@ -1,6 +1,7 @@
 {
     "type": "object",
     "additionalProperties": true,
+    "required": ["id"],
     "properties": {
         "active": {
             "type": ["boolean","null"]

--- a/source-shopify/source_shopify/tap_shopify/schemas/collect.json
+++ b/source-shopify/source_shopify/tap_shopify/schemas/collect.json
@@ -1,6 +1,7 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema",
     "type": "object",
+    "required": ["id"],
     "properties": {
         "collection_id": {
             "type": [

--- a/source-shopify/source_shopify/tap_shopify/schemas/custom_collection.json
+++ b/source-shopify/source_shopify/tap_shopify/schemas/custom_collection.json
@@ -1,6 +1,7 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema",
     "type": "object",
+    "required": ["id"],
     "properties": {
         "body_html": {
             "type": [

--- a/source-shopify/source_shopify/tap_shopify/schemas/customer.json
+++ b/source-shopify/source_shopify/tap_shopify/schemas/customer.json
@@ -1,6 +1,7 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema",
     "type": "object",
+    "required": ["id"],
     "properties": {
         "id": {
             "type": [

--- a/source-shopify/source_shopify/tap_shopify/schemas/discount_code.json
+++ b/source-shopify/source_shopify/tap_shopify/schemas/discount_code.json
@@ -1,6 +1,7 @@
 {
     "type": "object",
     "additionalProperties": true,
+    "required": ["id"],
     "properties": {
         "code": {
             "type": ["string", "null"]
@@ -14,7 +15,7 @@
             "format": "date-time"
         },
         "id": {
-            "type": ["integer","null"]
+            "type": "integer"
         },
         "price_rule_id": {
             "type": ["integer","null"]

--- a/source-shopify/source_shopify/tap_shopify/schemas/inventory_item.json
+++ b/source-shopify/source_shopify/tap_shopify/schemas/inventory_item.json
@@ -1,6 +1,7 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema",
     "type": "object",
+    "required": ["id"],
     "properties": {
         "cost": {
             "type": [

--- a/source-shopify/source_shopify/tap_shopify/schemas/inventory_level.json
+++ b/source-shopify/source_shopify/tap_shopify/schemas/inventory_level.json
@@ -1,6 +1,7 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema",
     "type": "object",
+    "required": ["inventory_item_id"],
     "properties": {
         "available": {
             "type": [

--- a/source-shopify/source_shopify/tap_shopify/schemas/location.json
+++ b/source-shopify/source_shopify/tap_shopify/schemas/location.json
@@ -1,6 +1,7 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema",
     "type": "object",
+    "required": ["id"],
     "properties": {
         "active": {
             "type": "boolean"

--- a/source-shopify/source_shopify/tap_shopify/schemas/metafield.json
+++ b/source-shopify/source_shopify/tap_shopify/schemas/metafield.json
@@ -1,6 +1,7 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema",
     "type": "object",
+    "required": ["id"],
     "properties": {
         "created_at": {
             "type": [

--- a/source-shopify/source_shopify/tap_shopify/schemas/order.json
+++ b/source-shopify/source_shopify/tap_shopify/schemas/order.json
@@ -1,6 +1,7 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema",
     "type": "object",
+    "required": ["id"],
     "properties": {
         "id": {
             "type": [

--- a/source-shopify/source_shopify/tap_shopify/schemas/price_rule.json
+++ b/source-shopify/source_shopify/tap_shopify/schemas/price_rule.json
@@ -1,6 +1,7 @@
 {
     "type": "object",
     "additionalProperties": true,
+    "required": ["id"],
     "properties": {
         "allocation_method": {
             "type": ["string","null"]

--- a/source-shopify/source_shopify/tap_shopify/schemas/product.json
+++ b/source-shopify/source_shopify/tap_shopify/schemas/product.json
@@ -1,6 +1,7 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema",
     "type": "object",
+    "required": ["id"],
     "properties": {
         "id": {
             "type": [

--- a/source-shopify/source_shopify/tap_shopify/schemas/refund.json
+++ b/source-shopify/source_shopify/tap_shopify/schemas/refund.json
@@ -1,6 +1,7 @@
 {
     "type": "object",
     "additionalProperties": true,
+    "required": ["id"],
     "properties": {
         "created_at": {
             "type": ["string", "null"],

--- a/source-shopify/source_shopify/tap_shopify/schemas/risk.json
+++ b/source-shopify/source_shopify/tap_shopify/schemas/risk.json
@@ -1,6 +1,7 @@
 {
     "type": "object",
     "additionalProperties": true,
+    "required": ["id"],
     "properties": {
         "cause_cancel": {
             "type": ["boolean","null"]

--- a/source-shopify/source_shopify/tap_shopify/schemas/transaction.json
+++ b/source-shopify/source_shopify/tap_shopify/schemas/transaction.json
@@ -1,6 +1,7 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema",
     "type": "object",
+    "required": ["id"],
     "properties": {
         "amount": {
             "type": [

--- a/source-shopify/source_shopify/tap_shopify/schemas/user.json
+++ b/source-shopify/source_shopify/tap_shopify/schemas/user.json
@@ -1,6 +1,7 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema",
     "type": "object",
+    "required": ["id"],
     "properties": {
         "id": {
             "type": [

--- a/source-shopify/tests/snapshots/source_shopify_tests_test_snapshots__discover__capture.stdout.json
+++ b/source-shopify/tests/snapshots/source_shopify_tests_test_snapshots__discover__capture.stdout.json
@@ -154,6 +154,7 @@
       },
       "type": "object",
       "required": [
+        "id",
         "_meta"
       ],
       "x-infer-schema": true
@@ -425,6 +426,7 @@
       },
       "type": "object",
       "required": [
+        "id",
         "_meta"
       ],
       "x-infer-schema": true
@@ -1144,6 +1146,7 @@
       },
       "type": "object",
       "required": [
+        "id",
         "_meta"
       ],
       "x-infer-schema": true
@@ -1375,6 +1378,7 @@
       },
       "type": "object",
       "required": [
+        "id",
         "_meta"
       ],
       "x-infer-schema": true
@@ -1486,6 +1490,7 @@
       },
       "type": "object",
       "required": [
+        "inventory_item_id",
         "_meta"
       ],
       "x-infer-schema": true
@@ -1831,6 +1836,7 @@
       },
       "type": "object",
       "required": [
+        "id",
         "_meta"
       ],
       "x-infer-schema": true
@@ -2059,6 +2065,7 @@
       },
       "type": "object",
       "required": [
+        "id",
         "_meta"
       ],
       "x-infer-schema": true
@@ -4898,6 +4905,7 @@
       },
       "type": "object",
       "required": [
+        "id",
         "_meta"
       ],
       "x-infer-schema": true
@@ -5562,6 +5570,7 @@
       },
       "type": "object",
       "required": [
+        "id",
         "_meta"
       ],
       "x-infer-schema": true
@@ -6082,6 +6091,7 @@
       },
       "type": "object",
       "required": [
+        "id",
         "_meta"
       ],
       "x-infer-schema": true
@@ -6289,6 +6299,7 @@
       },
       "type": "object",
       "required": [
+        "id",
         "_meta"
       ],
       "additionalProperties": true,
@@ -6413,10 +6424,7 @@
           ]
         },
         "id": {
-          "type": [
-            "integer",
-            "null"
-          ]
+          "type": "integer"
         },
         "price_rule_id": {
           "type": [
@@ -6452,6 +6460,7 @@
       },
       "type": "object",
       "required": [
+        "id",
         "_meta"
       ],
       "additionalProperties": true,
@@ -6969,6 +6978,7 @@
       },
       "type": "object",
       "required": [
+        "id",
         "_meta"
       ],
       "additionalProperties": true,
@@ -7111,6 +7121,7 @@
       },
       "type": "object",
       "required": [
+        "id",
         "_meta"
       ],
       "additionalProperties": true,
@@ -7317,6 +7328,7 @@
       },
       "type": "object",
       "required": [
+        "id",
         "_meta"
       ],
       "additionalProperties": true,


### PR DESCRIPTION
**Description:**

Correcting `source-shopify`  schemas. 
Both `source-shopify` and `source-google-ads` schemas are breaking, this PR solves all
schema related issues after the new streams were added in `source-shopify`

**Notes for reviewers:**

To evalute all changes, tests were made using a local flow instance and materializing to a Supabase DB 
**All 15 streams were captured and materialized**

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1655)
<!-- Reviewable:end -->
