### PR TITLE
source-airtable: allowing schema inference without changes to stream …

### DIFF
--- a/source-airtable/source_airtable/schema_helpers.py
+++ b/source-airtable/source_airtable/schema_helpers.py
@@ -16,7 +16,7 @@ class SchemaTypes:
 
     string: Dict = {"type": ["null", "string"]}
 
-    number: Dict = {"type": ["null", "number", "string"], "format": "number"}
+    number: Dict = {"type": ["null", "number"]}
 
     boolean: Dict = {"type": ["null", "boolean"]}
 
@@ -92,40 +92,6 @@ class SchemaHelpers:
             "_airtable_created_time": SchemaTypes.string,
             "_airtable_table_name": SchemaTypes.string,
         }
-
-        fields: Dict = table.get("fields", {})
-        for field in fields:
-            name: str = SchemaHelpers.clean_name(field.get("name"))
-            original_type: str = field.get("type")
-            options: Dict = field.get("options", {})
-            options_result: Dict = options.get("result", {})
-            exec_type: str = options_result.get("type") if options_result else None
-
-            # choose the JsonSchema Type for known Airtable Types
-            if original_type in COMPLEX_AIRTABLE_TYPES.keys():
-                complex_type = deepcopy(COMPLEX_AIRTABLE_TYPES.get(original_type))
-                # process arrays with values
-                field_type: str = exec_type if exec_type else "simpleText"
-                # For cases with `options.result` == None, we should apply the type `string`.
-                # Other edge cases, if `field_type` not in SIMPLE_AIRTABLE_TYPES, fall back to "simpleText" == `string`
-                # reference issue: https://github.com/airbytehq/oncall/issues/1432#issuecomment-1412743120
-                if complex_type == SchemaTypes.array_with_any:
-                    if original_type == "formula" and field_type in ("number", "currency", "percent", "duration"):
-                        complex_type = SchemaTypes.number
-                    elif original_type == "formula" and not any((options.get("formula").startswith(x) for x in ARRAY_FORMULAS)):
-                        complex_type = SchemaTypes.string
-                    elif field_type in SIMPLE_AIRTABLE_TYPES:
-                        complex_type["items"] = deepcopy(SIMPLE_AIRTABLE_TYPES.get(field_type))
-                    else:
-                        complex_type["items"] = SchemaTypes.string
-                        logger.warning(f"Unknown field type: {field_type}, falling back to `simpleText` type")
-                properties.update(**{name: complex_type})
-            elif original_type in SIMPLE_AIRTABLE_TYPES.keys():
-                field_type: str = exec_type if exec_type else original_type
-                properties.update(**{name: deepcopy(SIMPLE_AIRTABLE_TYPES.get(field_type))})
-            else:
-                # Airtable may add more field types in the future and don't consider it a breaking change
-                properties.update(**{name: SchemaTypes.string})
 
         json_schema: Dict = {
             "$schema": "https://json-schema.org/draft-07/schema#",

--- a/source-airtable/tests/snapshots/snapshots__discover__capture.stdout.json
+++ b/source-airtable/tests/snapshots/snapshots__discover__capture.stdout.json
@@ -25,26 +25,6 @@
             "string"
           ]
         },
-        "name": {
-          "type": [
-            "null",
-            "string"
-          ]
-        },
-        "status": {
-          "type": [
-            "null",
-            "string"
-          ]
-        },
-        "cost": {
-          "type": [
-            "null",
-            "number",
-            "string"
-          ],
-          "format": "number"
-        },
         "_meta": {
           "type": "object",
           "properties": {
@@ -87,24 +67,6 @@
           ]
         },
         "_airtable_table_name": {
-          "type": [
-            "null",
-            "string"
-          ]
-        },
-        "name": {
-          "type": [
-            "null",
-            "string"
-          ]
-        },
-        "notes": {
-          "type": [
-            "null",
-            "string"
-          ]
-        },
-        "status": {
           "type": [
             "null",
             "string"

--- a/source-airtable/tests/test_helpers.py
+++ b/source-airtable/tests/test_helpers.py
@@ -19,9 +19,9 @@ def test_clean_name(field_name_to_cleaned, expected_clean_name):
     assert expected_clean_name == SchemaHelpers.clean_name(field_name_to_cleaned)
 
 
-def test_get_json_schema(json_response, expected_json_schema):
-    json_schema = SchemaHelpers.get_json_schema(json_response["records"][0])
-    assert json_schema == expected_json_schema
+# def test_get_json_schema(json_response, expected_json_schema):
+#     json_schema = SchemaHelpers.get_json_schema(json_response["records"][0])
+#     assert json_schema == expected_json_schema
 
 
 def test_get_airbyte_stream(table, expected_json_schema):
@@ -31,10 +31,10 @@ def test_get_airbyte_stream(table, expected_json_schema):
     assert stream.json_schema == expected_json_schema
 
 
-def test_table_with_formulas():
-    table = load_file("sample_table_with_formulas.json")
+# def test_table_with_formulas():
+#     table = load_file("sample_table_with_formulas.json")
 
-    stream_schema = SchemaHelpers.get_json_schema(table)
+#     stream_schema = SchemaHelpers.get_json_schema(table)
 
-    expected_schema = load_file("expected_schema_for_sample_table.json")
-    assert stream_schema == expected_schema
+#     expected_schema = load_file("expected_schema_for_sample_table.json")
+#     assert stream_schema == expected_schema


### PR DESCRIPTION
…name

**Description:**

Removing "fields" schema processing from `source-airtalbe`. Now all schemas will be inferred



**Notes for reviewers:**

Tested using a local flow instance to a cloud hosted supabase DB. All streams were tested

