### PR TITLE
source-hubspot-native: emit `null` instead of empty string for date and datetime

### DIFF
--- a/source-hubspot-native/source_hubspot_native/models.py
+++ b/source-hubspot-native/source_hubspot_native/models.py
@@ -105,6 +105,7 @@ class Property(BaseDocument, extra="allow"):
 
     name: str = ""
     calculated: bool = False
+    type: str | None = None
     hubspotObject: str = "unknown"  # Added by us.
 
 

--- a/source-hubspot-native/tests/snapshots/snapshots__discover__stdout.json
+++ b/source-hubspot-native/tests/snapshots/snapshots__discover__stdout.json
@@ -1050,6 +1050,18 @@
           "title": "Calculated",
           "type": "boolean"
         },
+        "type": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Type"
+        },
         "hubspotObject": {
           "default": "unknown",
           "title": "Hubspotobject",


### PR DESCRIPTION
**Description:**

This will allow schema inference on the collection to infer the appropriate format, rather than the `""` string forcing it to be a string with no format.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

