### PR TITLE
sqlcapture: Tweak table activation error messages

### DIFF
--- a/sqlcapture/capture.go
+++ b/sqlcapture/capture.go
@@ -173,10 +173,10 @@ func (c *Capture) Run(ctx context.Context) (err error) {
 	}
 	var watermarks = c.Database.WatermarksTable()
 	if c.discovery[watermarks] == nil {
-		return fmt.Errorf("watermarks table %q does not exist", watermarks)
+		return fmt.Errorf("error activating replication for watermarks table %q: table was not observed by autodiscovery", watermarks)
 	}
 	if err := replStream.ActivateTable(ctx, watermarks, c.discovery[watermarks].PrimaryKey, c.discovery[watermarks], nil); err != nil {
-		return fmt.Errorf("error activating table %q: %w", watermarks, err)
+		return fmt.Errorf("error activating replication for watermarks table %q: %w", watermarks, err)
 	}
 	if err := replStream.StartReplication(ctx); err != nil {
 		return fmt.Errorf("error starting replication: %w", err)
@@ -245,7 +245,7 @@ func (c *Capture) Run(ctx context.Context) (err error) {
 		c.State.Streams[stateKey] = state
 
 		if err := replStream.ActivateTable(ctx, streamID, state.KeyColumns, c.discovery[streamID], state.Metadata); err != nil {
-			return fmt.Errorf("error activating %q for replication: %w", streamID, err)
+			return fmt.Errorf("error activating replication for table %q: %w", streamID, err)
 		}
 	}
 


### PR DESCRIPTION
**Description:**

These messages were originally written before we had prerequisite validation for a lot of the basic errors, which is why the error for the watermarks table not showing up via discovery is "table doesn't exist" -- because that used to be by far the most likely reason we'd see that.

But now we already check for the basics so we should really give the wordier and more complicated but actually precise description of what's gone wrong there.

Then while I was at it I tweaked a couple of adjacent messages for consistency.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1678)
<!-- Reviewable:end -->
