### PR TITLE
materializations: update error message for unsupported column types

### DIFF
--- a/materialize-sql/column_validation.go
+++ b/materialize-sql/column_validation.go
@@ -41,7 +41,7 @@ func NewColumnValidator(validations ...ColValidation) ColumnValidator {
 func (cv ColumnValidator) ValidateColumn(existing boilerplate.EndpointField, p pf.Projection) (bool, error) {
 	v, ok := cv.validationStrategies[strings.ToLower(existing.Type)]
 	if !ok {
-		return false, fmt.Errorf("no column validator found for endpoint column %q [type %q]", existing.Name, existing.Type)
+		return false, fmt.Errorf("connector does not support materializing to columns of type %q (column %q)", existing.Type, existing.Name)
 	}
 
 	return v(p), nil


### PR DESCRIPTION
**Description:**

It is fairly rare that this condition is ever hit since it means that a user manually changed the type of a target table column, but the "no column validator found" messaging is kind of obscure in that case. A better way to state it is that the connector doesn't support materializing to that type of column, so that is what it will say now.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1680)
<!-- Reviewable:end -->
