### PR TITLE
materialize-s3-*: set "secret" annotation for access key

### DIFF
--- a/filesink/store.go
+++ b/filesink/store.go
@@ -28,7 +28,7 @@ type S3Store struct {
 type S3StoreConfig struct {
 	Bucket             string `json:"bucket" jsonschema:"title=Bucket,description=Bucket to store materialized objects." jsonschema_extras:"order=0"`
 	AWSAccessKeyID     string `json:"awsAccessKeyId" jsonschema:"title=AWS Access Key ID,description=Access Key ID for writing data to the bucket." jsonschema_extras:"order=1"`
-	AWSSecretAccessKey string `json:"awsSecretAccessKey" jsonschema:"title=AWS Secret Access key,description=Secret Access Key for writing data to the bucket." jsonschema_extras:"order=2"`
+	AWSSecretAccessKey string `json:"awsSecretAccessKey" jsonschema:"title=AWS Secret Access key,description=Secret Access Key for writing data to the bucket." jsonschema_extras:"secret=true,order=2"`
 	Region             string `json:"region" jsonschema:"title=Region,description=Region of the bucket to write to." jsonschema_extras:"order=3"`
 
 	UploadInterval string `json:"uploadInterval" jsonschema:"title=Upload Interval,description=Frequency at which files will be uploaded. Must be a valid Go duration string.,enum=5m,enum=15m,enum=30m,enum=1h,default=5m" jsonschema_extras:"order=4"`

--- a/materialize-s3-csv/.snapshots/TestSpec
+++ b/materialize-s3-csv/.snapshots/TestSpec
@@ -19,7 +19,8 @@
         "type": "string",
         "title": "AWS Secret Access key",
         "description": "Secret Access Key for writing data to the bucket.",
-        "order": 2
+        "order": 2,
+        "secret": true
       },
       "region": {
         "type": "string",

--- a/materialize-s3-parquet/.snapshots/TestSpec
+++ b/materialize-s3-parquet/.snapshots/TestSpec
@@ -19,7 +19,8 @@
         "type": "string",
         "title": "AWS Secret Access key",
         "description": "Secret Access Key for writing data to the bucket.",
-        "order": 2
+        "order": 2,
+        "secret": true
       },
       "region": {
         "type": "string",


### PR DESCRIPTION
**Description:**

Adds the "secret" annotation for the `AWSSecretAccessKey` configuration that is used by `materialize-s3-csv` and `materialize-s3-parquet`.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1683)
<!-- Reviewable:end -->
