### PR TITLE
source-mysql: Support for MySQL v8.4

### DIFF
--- a/source-mysql/database.go
+++ b/source-mysql/database.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/estuary/connectors/sqlcapture"
+	"github.com/sirupsen/logrus"
+)
+
+// queryDatabaseVersion examines the server version string to figure out what product
+// and release version we're talking to, and saves the results for later use.
+func (db *mysqlDatabase) queryDatabaseVersion() error {
+	var version string
+	var results, err = db.conn.Execute(`SELECT @@GLOBAL.version;`)
+	if err != nil {
+		return fmt.Errorf("unable to query database version: %w", err)
+	} else if len(results.Values) != 1 || len(results.Values[0]) != 1 {
+		return fmt.Errorf("unable to query database version: malformed response")
+	}
+
+	db.versionString = string(results.Values[0][0].AsString())
+	db.versionProduct = "MySQL"
+	if strings.Contains(strings.ToLower(db.versionString), "mariadb") {
+		db.versionProduct = "MariaDB"
+	}
+	major, minor, err := sqlcapture.ParseVersion(version)
+	if err != nil {
+		return fmt.Errorf("unable to parse database version from %q: %w", version, err)
+	}
+	db.versionMajor = major
+	db.versionMinor = minor
+
+	logrus.WithFields(logrus.Fields{
+		"version": db.versionString,
+		"product": db.versionProduct,
+		"major":   db.versionMajor,
+		"minor":   db.versionMinor,
+	}).Info("queried database version")
+	return nil
+}

--- a/source-mysql/database.go
+++ b/source-mysql/database.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/estuary/connectors/sqlcapture"
+	"github.com/go-mysql-org/go-mysql/mysql"
 	"github.com/sirupsen/logrus"
 )
 
@@ -18,6 +19,7 @@ func (db *mysqlDatabase) queryDatabaseVersion() error {
 	} else if len(results.Values) != 1 || len(results.Values[0]) != 1 {
 		return fmt.Errorf("unable to query database version: malformed response")
 	}
+	defer results.Close()
 
 	db.versionString = string(results.Values[0][0].AsString())
 	db.versionProduct = "MySQL"
@@ -38,4 +40,54 @@ func (db *mysqlDatabase) queryDatabaseVersion() error {
 		"minor":   db.versionMinor,
 	}).Info("queried database version")
 	return nil
+}
+
+type binlogStatus struct {
+	Position mysql.Position // The current binlog filename and offset
+	Extra    map[string]any // Any other result columns from `SHOW MASTER STATUS`
+}
+
+// queryBinlogStatus fetches the current binary logging position and configuration using
+// the SHOW MASTER STATUS / SHOW BINARY LOG STATUS query (depending on the server version).
+func (db *mysqlDatabase) queryBinlogStatus() (*binlogStatus, error) {
+	// The 'SHOW MASTER STATUS' query is the only form that works on MySQL <8.0.22, but
+	// support was dropped in MySQL 8.4.0 so we have to select the appropriate query for
+	// the server version we're connected to.
+	var statusQuery = "SHOW MASTER STATUS;"
+	if db.versionProduct == "MySQL" && ((db.versionMajor == 8 && db.versionMinor >= 4) || db.versionMajor > 8) {
+		statusQuery = "SHOW BINARY LOG STATUS;"
+	}
+
+	var results, err = db.conn.Execute(statusQuery)
+	if err != nil {
+		return nil, fmt.Errorf("error querying binlog status: %w", err)
+	}
+	if len(results.Values) == 0 {
+		return nil, fmt.Errorf("error querying binlog status: empty result set (is binary logging enabled?)")
+	}
+	defer results.Close()
+
+	// Extract the binlog filename and offset
+	var row = results.Values[0]
+	var filename = string(row[0].AsString())
+	var offset = uint32(row[1].AsInt64())
+
+	// Copy any/all additional result columns into the 'extra' map
+	var extra = make(map[string]any)
+	for idx := 2; idx < len(row); idx++ {
+		var key = string(results.Fields[idx].Name)
+		var val = row[idx].Value()
+		if bs, ok := val.([]byte); ok {
+			val = string(bs)
+		}
+		extra[key] = val
+	}
+
+	return &binlogStatus{
+		Position: mysql.Position{
+			Name: filename,
+			Pos:  offset,
+		},
+		Extra: extra,
+	}, nil
 }

--- a/source-mysql/database.go
+++ b/source-mysql/database.go
@@ -12,7 +12,6 @@ import (
 // queryDatabaseVersion examines the server version string to figure out what product
 // and release version we're talking to, and saves the results for later use.
 func (db *mysqlDatabase) queryDatabaseVersion() error {
-	var version string
 	var results, err = db.conn.Execute(`SELECT @@GLOBAL.version;`)
 	if err != nil {
 		return fmt.Errorf("unable to query database version: %w", err)
@@ -26,9 +25,9 @@ func (db *mysqlDatabase) queryDatabaseVersion() error {
 	if strings.Contains(strings.ToLower(db.versionString), "mariadb") {
 		db.versionProduct = "MariaDB"
 	}
-	major, minor, err := sqlcapture.ParseVersion(version)
+	major, minor, err := sqlcapture.ParseVersion(db.versionString)
 	if err != nil {
-		return fmt.Errorf("unable to parse database version from %q: %w", version, err)
+		return fmt.Errorf("unable to parse database version from %q: %w", db.versionString, err)
 	}
 	db.versionMajor = major
 	db.versionMinor = minor

--- a/source-mysql/docker-compose.yaml
+++ b/source-mysql/docker-compose.yaml
@@ -2,7 +2,7 @@ version: "3.7"
 
 services:
   db:
-    image: 'mysql:8.0.35'
+    image: 'mysql:8.4'
     command: [ "--gtid-mode=ON", "--enforce-gtid-consistency=ON" ]
     ## Alternative setup for testing MariaDB:
     # image: 'mariadb:latest'

--- a/source-mysql/main.go
+++ b/source-mysql/main.go
@@ -306,7 +306,9 @@ func (db *mysqlDatabase) connect(ctx context.Context) error {
 		return fmt.Errorf("error setting session time_zone: %w", err)
 	}
 
-	db.queryDatabaseVersion()
+	if err := db.queryDatabaseVersion(); err != nil {
+		logrus.WithField("err", err).Warn("failed to query database version")
+	}
 
 	return nil
 }

--- a/source-mysql/main.go
+++ b/source-mysql/main.go
@@ -212,6 +212,10 @@ func configSchema() json.RawMessage {
 }
 
 type mysqlDatabase struct {
+	versionString              string // The raw contents of the 'version' system variable
+	versionProduct             string // Usually either "MySQL" or "MariaDB"
+	versionMajor, versionMinor int    // The major/minor version the server is running
+
 	config           *Config
 	conn             *client.Conn
 	explained        map[string]struct{} // Tracks tables which have had an `EXPLAIN` run on them during this connector invocation.
@@ -301,6 +305,8 @@ func (db *mysqlDatabase) connect(ctx context.Context) error {
 	if _, err := db.conn.Execute("SET SESSION time_zone = '+00:00';"); err != nil {
 		return fmt.Errorf("error setting session time_zone: %w", err)
 	}
+
+	db.queryDatabaseVersion()
 
 	return nil
 }

--- a/source-mysql/main_test.go
+++ b/source-mysql/main_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"flag"
 	"fmt"
 	"os"
@@ -13,6 +14,7 @@ import (
 	_ "github.com/go-mysql-org/go-mysql/driver"
 
 	st "github.com/estuary/connectors/source-boilerplate/testing"
+	"github.com/estuary/connectors/sqlcapture"
 	"github.com/estuary/connectors/sqlcapture/tests"
 	"github.com/go-mysql-org/go-mysql/client"
 	"github.com/sirupsen/logrus"
@@ -591,10 +593,18 @@ func TestComplexDataset(t *testing.T) {
 	cs.EndpointSpec.(*Config).Advanced.BackfillChunkSize = 10
 
 	t.Run("init", func(t *testing.T) {
-		var summary, states = tests.RestartingBackfillCapture(ctx, t, cs)
+		var summary, _ = tests.RestartingBackfillCapture(ctx, t, cs)
 		cupaloy.SnapshotT(t, summary)
-		cs.Checkpoint = states[13] // Next restart between (1940, 'NV') and (1940, 'NY')
-		logrus.WithField("checkpoint", string(cs.Checkpoint)).Warn("restart at")
+
+		// Rewind the backfill state to a specific reproducible point
+		var state sqlcapture.PersistentState
+		require.NoError(t, json.Unmarshal(cs.Checkpoint, &state))
+		state.Streams["test%2FComplexDataset_56015963"].BackfilledCount = 130
+		state.Streams["test%2FComplexDataset_56015963"].Mode = sqlcapture.TableModeUnfilteredBackfill
+		state.Streams["test%2FComplexDataset_56015963"].Scanned = []byte{0x16, 0x07, 0x94, 0x01, 0x4e, 0x56, 0x00}
+		var bs, err = json.Marshal(&state)
+		require.NoError(t, err)
+		cs.Checkpoint = bs
 	})
 
 	tb.Insert(ctx, t, tableName, [][]interface{}{
@@ -603,9 +613,18 @@ func TestComplexDataset(t *testing.T) {
 		{1990, "XX", "No Such State", 123456}, // An insert after the second restart, which will be visible in the table scan and should be filtered during replication
 	})
 	t.Run("restart1", func(t *testing.T) {
-		var summary, states = tests.RestartingBackfillCapture(ctx, t, cs)
+		var summary, _ = tests.RestartingBackfillCapture(ctx, t, cs)
 		cupaloy.SnapshotT(t, summary)
-		cs.Checkpoint = states[10] // Next restart in the middle of 1980 data
+
+		// Rewind the backfill state to a specific reproducible point
+		var state sqlcapture.PersistentState
+		require.NoError(t, json.Unmarshal(cs.Checkpoint, &state))
+		state.Streams["test%2FComplexDataset_56015963"].BackfilledCount = 230
+		state.Streams["test%2FComplexDataset_56015963"].Mode = sqlcapture.TableModeUnfilteredBackfill
+		state.Streams["test%2FComplexDataset_56015963"].Scanned = []byte{0x16, 0x07, 0xbc, 0x01, 0x4e, 0x48, 0x00}
+		var bs, err = json.Marshal(&state)
+		require.NoError(t, err)
+		cs.Checkpoint = bs
 	})
 
 	tb.Query(ctx, t, fmt.Sprintf("DELETE FROM %s WHERE state = 'XX';", tableName))

--- a/source-mysql/prerequisites.go
+++ b/source-mysql/prerequisites.go
@@ -149,6 +149,7 @@ func (db *mysqlDatabase) prerequisiteUserPermissions(ctx context.Context) error 
 	// authorized for CDC.
 	var status, err = db.queryBinlogStatus()
 	if err != nil {
+		logrus.WithField("err", err).Info("failed to query binlog status")
 		return fmt.Errorf("user %q needs the REPLICATION CLIENT permission", db.config.User)
 	}
 

--- a/source-mysql/prerequisites.go
+++ b/source-mysql/prerequisites.go
@@ -302,10 +302,7 @@ func getBinlogExpiry(conn *client.Conn) (time.Duration, error) {
 	// And as the final resort we'll check 'expire_logs_days' if 'seconds' was zero or nonexistent.
 	expireLogsDays, err := queryNumericVariable(conn, `SHOW VARIABLES LIKE 'expire_logs_days';`)
 	logrus.WithFields(logrus.Fields{"days": expireLogsDays, "err": err}).Debug("queried MySQL variable 'expire_logs_days'")
-	if err != nil {
-		return 0, err
-	}
-	if expireLogsDays > 0 {
+	if err == nil && expireLogsDays > 0 {
 		return time.Duration(expireLogsDays) * 24 * time.Hour, nil
 	}
 


### PR DESCRIPTION
**Description:**

This PR fixes the `source-mysql` connector to support MySQL 8.4, which was released a couple of months ago. This involved a couple of trivial incompatibilities and a version bump to the CI database dockerfile, and then the main thing was that MySQL 8.4 went and fully removed the deprecated `SHOW MASTER STATUS` command.

This command was deprecated in MySQL 8.0.22 in favor of a new `SHOW BINARY LOG STATUS` which does the exact same thing. Since we want to support MySQL <8.0.22 we used the old query exclusively, but now that's no longer sufficient and there is no single query that works on all versions of MySQL. So to handle this we have to actually keep track of the database version and issue the appropriate query depending on what server we're connected to.

This was done by factoring out most of the version string querying/parsing logic from the `prerequisiteVersion` check into a helper function which gets run immediately upon connecting and which saves the resulting version info into some fields of the database struct, and then factoring out the `SHOW MASTER STATUS` query into another helper function which selects the appropriate query to run based on those properties.

This seems to work, although the refactor of the version-checking logic has me feeling a bit cautious so I'll probably do a careful rollout tomorrow where I'll force a restart of all production MySQL capture tasks and make sure none of them suddenly start failing, while I'm still sitting at my desk and thinking about it so it can be reverted quick if anything goes wrong.

(Honestly this keeps coming up, it might be time to write a helper script that can query the set of live tasks running a particular connector, figure out which ones are currently green, issue a forced restart to all of them, and then complain if any of them start failing during some short window after the restart. I know I'll want it for the Postgres "slot validation redux" PR whenever I get around to merging that...)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1684)
<!-- Reviewable:end -->
