### PR TITLE
materialize-iceberg: table identifiers are always lowercase

### DIFF
--- a/materialize-s3-iceberg/driver.go
+++ b/materialize-s3-iceberg/driver.go
@@ -102,7 +102,7 @@ func newResource(cfg config) resource {
 }
 
 func (r resource) path() []string {
-	return []string{r.Namespace, r.Table}
+	return []string{strings.ToLower(r.Namespace), strings.ToLower(r.Table)}
 }
 
 func pathToFQN(p []string) string {


### PR DESCRIPTION
**Description:**

At least with the AWS Glue catalog (which is the only one we use right now), table identifiers are always lowercase. So if you have a resource with a table that has uppercase letters, right now we can't find that table. This fix will have use always treat table identifiers with lowercase, which should fix that problem.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1686)
<!-- Reviewable:end -->
