### PR TITLE
source-oracle-flashback: skip flashback_on check on RDS instances

### DIFF
--- a/source-oracle-flashback/config.yaml
+++ b/source-oracle-flashback/config.yaml
@@ -21,8 +21,8 @@ sops:
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2024-06-26T18:18:40Z"
-    mac: ENC[AES256_GCM,data:78gOAP0RYqdCt49NtZxPUZhyCT7qWTsrjN6ECbJmbZcBTdeYDbeCTYzlcEaGmDVkoeNFSq00stuT7dL/FLTMpLUQLrsGJ9+Luzl9YhlmAMrKI2N/W4mXWWVJZC7kYAZsQe3Uicc4/28frV1/MbEVJcaBDhmVjgKltAx7M37XqNc=,iv:peNZepRrGgx/eJrmAVDYsds7OB/Ba29WDKQI1VawwWo=,tag:ulpi4EGHQsUrryvLH7yr2Q==,type:str]
+    lastmodified: "2024-07-01T14:24:14Z"
+    mac: ENC[AES256_GCM,data:eTo8EOXgpdPHyeax++/Jzx3n/07vcVfF+vHRMqhbFfvFXK9sqY3QDCB1c8ZSKEtljLLIisiSpzcwyYbJ+AKb3GpID33E/miSoBAMgDIu59jlppbdRHA0f8MGgYj8EH6qK12veRvxz/545WQnFcUbPMQc7YDFXExmE7I/++6NGDo=,iv:SbC/mUWnAivEQ+aJHUUKv1iDJ+kOQHzI7gxln9KWrXQ=,tag:DWjm4h2Dyxdd1WtOMO9VIA==,type:str]
     pgp: []
     encrypted_suffix: _sops
     version: 3.8.1


### PR DESCRIPTION
**Description:**

- RDS instances report flashback as OFF because it cannot be enabled on the whole database, but it is enabled for tables. On RDS instances we skip the flashback_on check.
- Users will still end up needing to skip Flashback checks since RDS instances usually have small undo retentions which are problematic, but at least the error is not misleading

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1688)
<!-- Reviewable:end -->
