### PR TITLE
network-tunnel: pass log level argument

### DIFF
--- a/go/network-tunnel/network_tunnel.go
+++ b/go/network-tunnel/network_tunnel.go
@@ -62,6 +62,13 @@ func (t SshTunnel) Start() error {
 		"local-port":   t.Config.LocalPort,
 	}).Info("starting network-tunnel")
 
+	logLevel := log.GetLevel().String()
+	if logLevel == "warning" {
+		// Adapt the logrus level to a compatible `env_filter` level of the
+		// network-tunnel `tracing_subscriber`.
+		logLevel = "warn"
+	}
+
 	t.Cmd = exec.CommandContext(
 		t.ctx,
 		"flow-network-tunnel",
@@ -71,6 +78,7 @@ func (t SshTunnel) Start() error {
 		"--forward-host", t.Config.ForwardHost,
 		"--forward-port", t.Config.ForwardPort,
 		"--local-port", t.Config.LocalPort,
+		"--log.level", logLevel,
 	)
 
 	stdout, err := t.Cmd.StdoutPipe()


### PR DESCRIPTION
**Description:**

We weren't getting any of the logs from the network-tunnel application because we weren't giving it a log level. This fixes that so we will get network-tunnel logs.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

