### PR TITLE
source-klaviyo: Adding event_name field to Events stream

### DIFF
--- a/source-klaviyo/acmeCo/events.schema.yaml
+++ b/source-klaviyo/acmeCo/events.schema.yaml
@@ -12,6 +12,10 @@ properties:
   datetime:
     type: string
     format: date-time
+  event_name:
+    type:
+      - string
+      - "null"
   attributes:
     type:
       - "null"

--- a/source-klaviyo/source_klaviyo/schemas/events.json
+++ b/source-klaviyo/source_klaviyo/schemas/events.json
@@ -7,6 +7,7 @@
     "type": { "type": "string" },
     "id": { "type": "string" },
     "datetime": { "type": "string", "format": "date-time" },
+    "event_name": {"type":["string","null"]},
     "attributes": {
       "type": ["null", "object"],
       "properties": {

--- a/source-klaviyo/source_klaviyo/streams.py
+++ b/source-klaviyo/source_klaviyo/streams.py
@@ -334,6 +334,13 @@ class Events(IncrementalKlaviyoStream):
                 continue
             record['datetime'] = record['datetime'].replace(" ","T")
             record['attributes']['datetime'] = record['attributes']['datetime'].replace(" ","T")
+
+            try:
+                link = record['relationships']['metric']['links']['related']
+                response2 = requests.get(link, headers=self.request_headers())
+                record["event_name"] = response2.json()['data']["attributes"]['name']
+            except:
+                record["event_name"] = None
             yield record
 
 

--- a/source-klaviyo/tests/snapshots/source_klaviyo_tests_test_snapshots__discover__capture.stdout.json
+++ b/source-klaviyo/tests/snapshots/source_klaviyo_tests_test_snapshots__discover__capture.stdout.json
@@ -366,6 +366,12 @@
           "format": "date-time",
           "type": "string"
         },
+        "event_name": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "id": {
           "type": "string"
         },


### PR DESCRIPTION
**Description:**

A user requested the "event_name" field to be included on the "Events" stream schema.
This PR adds a call to the metrics endpoint in order to get the event_name value, since the Events stream originally does not return it.   



**Notes for reviewers:**

(anything that might help someone review this PR)

