### PR TITLE
source-klaviyo: fixing event_name field

### DIFF
--- a/source-klaviyo/acmeCo/events.schema.yaml
+++ b/source-klaviyo/acmeCo/events.schema.yaml
@@ -14,8 +14,8 @@ properties:
     format: date-time
   event_name:
     type:
-      - string
       - "null"
+      - string
   attributes:
     type:
       - "null"

--- a/source-klaviyo/source_klaviyo/schemas/events.json
+++ b/source-klaviyo/source_klaviyo/schemas/events.json
@@ -7,7 +7,7 @@
     "type": { "type": "string" },
     "id": { "type": "string" },
     "datetime": { "type": "string", "format": "date-time" },
-    "event_name": {"type":["string","null"]},
+    "event_name": {"type":["null", "string"]},
     "attributes": {
       "type": ["null", "object"],
       "properties": {

--- a/source-klaviyo/source_klaviyo/streams.py
+++ b/source-klaviyo/source_klaviyo/streams.py
@@ -340,7 +340,7 @@ class Events(IncrementalKlaviyoStream):
                 response2 = requests.get(link, headers=self.request_headers())
                 record["event_name"] = response2.json()['data']["attributes"]['name']
             except:
-                self.logger.warning(f"Name not found for Event {record["id"]}")
+                self.logger.warning(f"Name not found for Event {record['id']}")
             yield record
 
 

--- a/source-klaviyo/source_klaviyo/streams.py
+++ b/source-klaviyo/source_klaviyo/streams.py
@@ -340,7 +340,7 @@ class Events(IncrementalKlaviyoStream):
                 response2 = requests.get(link, headers=self.request_headers())
                 record["event_name"] = response2.json()['data']["attributes"]['name']
             except:
-                record["event_name"] = None
+                self.logger.warning(f"Name not found for Event {record["id"]}")
             yield record
 
 

--- a/source-klaviyo/tests/snapshots/source_klaviyo_tests_test_snapshots__discover__capture.stdout.json
+++ b/source-klaviyo/tests/snapshots/source_klaviyo_tests_test_snapshots__discover__capture.stdout.json
@@ -368,8 +368,8 @@
         },
         "event_name": {
           "type": [
-            "string",
-            "null"
+            "null",
+            "string"
           ]
         },
         "id": {


### PR DESCRIPTION
**Description:**

event_name field was set to be created with a None/NULL value. Instead, it should've been created only with a string value, and if requirements to create it are not met, it should not be created at all. This commit fixes that, along with updating tests and schema.


**Notes for reviewers:**

Tested using flowctl and a local flow setup with a supabase DB as destination.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1695)
<!-- Reviewable:end -->
