### PR TITLE
source-postgres: Replication slot validation, take three

### DIFF
--- a/source-postgres/.snapshots/TestCaptureAfterSlotDropped-capture1
+++ b/source-postgres/.snapshots/TestCaptureAfterSlotDropped-capture1
@@ -1,0 +1,10 @@
+# ================================
+# Collection "acmeCo/test/test_captureafterslotdropped_46115540": 2 Documents
+# ================================
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"captureafterslotdropped_46115540","loc":[11111111,11111111,11111111]}},"data":"one","id":1}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"captureafterslotdropped_46115540","loc":[11111111,11111111,11111111]}},"data":"zero","id":0}
+# ================================
+# Final State Checkpoint
+# ================================
+{"bindingStateV1":{"test%2Fcaptureafterslotdropped_46115540":{"backfilled":2,"key_columns":["id"],"mode":"Active"}},"cursor":"0/1111111"}
+

--- a/source-postgres/.snapshots/TestCaptureAfterSlotDropped-capture2
+++ b/source-postgres/.snapshots/TestCaptureAfterSlotDropped-capture2
@@ -1,0 +1,5 @@
+# ================================
+# Final State Checkpoint
+# ================================
+{"bindingStateV1":{"test%2Fcaptureafterslotdropped_46115540":{"backfilled":2,"key_columns":["id"],"mode":"Active"}},"cursor":"0/1111111"}
+

--- a/source-postgres/.snapshots/TestCaptureAfterSlotDropped-capture3
+++ b/source-postgres/.snapshots/TestCaptureAfterSlotDropped-capture3
@@ -1,0 +1,10 @@
+# ================================
+# Collection "acmeCo/test/test_captureafterslotdropped_46115540": 2 Documents
+# ================================
+{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"captureafterslotdropped_46115540","loc":[11111111,11111111,11111111],"txid":111111}},"data":"seven","id":7}
+{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"captureafterslotdropped_46115540","loc":[11111111,11111111,11111111],"txid":111111}},"data":"six","id":6}
+# ================================
+# Final State Checkpoint
+# ================================
+{"bindingStateV1":{"test%2Fcaptureafterslotdropped_46115540":{"backfilled":2,"key_columns":["id"],"mode":"Active"}},"cursor":"0/1111111"}
+

--- a/source-postgres/.snapshots/TestCaptureAfterSlotDropped-capture4
+++ b/source-postgres/.snapshots/TestCaptureAfterSlotDropped-capture4
@@ -1,0 +1,16 @@
+# ================================
+# Collection "acmeCo/test/test_captureafterslotdropped_46115540": 8 Documents
+# ================================
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"captureafterslotdropped_46115540","loc":[11111111,11111111,11111111]}},"data":"five","id":5}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"captureafterslotdropped_46115540","loc":[11111111,11111111,11111111]}},"data":"four","id":4}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"captureafterslotdropped_46115540","loc":[11111111,11111111,11111111]}},"data":"one","id":1}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"captureafterslotdropped_46115540","loc":[11111111,11111111,11111111]}},"data":"seven","id":7}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"captureafterslotdropped_46115540","loc":[11111111,11111111,11111111]}},"data":"six","id":6}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"captureafterslotdropped_46115540","loc":[11111111,11111111,11111111]}},"data":"three","id":3}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"captureafterslotdropped_46115540","loc":[11111111,11111111,11111111]}},"data":"two","id":2}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"captureafterslotdropped_46115540","loc":[11111111,11111111,11111111]}},"data":"zero","id":0}
+# ================================
+# Final State Checkpoint
+# ================================
+{"bindingStateV1":{"test%2Fcaptureafterslotdropped_46115540":{"backfilled":0,"mode":"Ignore"},"test%2Fcaptureafterslotdropped_46115540.v2":{"backfilled":8,"key_columns":["id"],"mode":"Active"}},"cursor":"0/1111111"}
+

--- a/source-postgres/capture_test.go
+++ b/source-postgres/capture_test.go
@@ -505,3 +505,30 @@ func TestCaptureOversizedFields(t *testing.T) {
 		tests.VerifiedCapture(ctx, t, cs)
 	})
 }
+
+func TestCaptureAfterSlotDropped(t *testing.T) {
+	var tb, ctx = postgresTestBackend(t), context.Background()
+	var uniqueID = "46115540"
+	var tableName = tb.CreateTable(ctx, t, uniqueID, "(id INTEGER PRIMARY KEY, data TEXT)")
+	var cs = tb.CaptureSpec(ctx, t, regexp.MustCompile(uniqueID))
+
+	// Run a normal capture
+	tb.Insert(ctx, t, tableName, [][]any{{0, "zero"}, {1, "one"}})
+	t.Run("capture1", func(t *testing.T) { tests.VerifiedCapture(ctx, t, cs) })
+
+	// Drop the replication slot while the task is offline, and it should recreate
+	// the replication slot and then start failing because its saved position isn't
+	// valid any longer.
+	tb.Insert(ctx, t, tableName, [][]any{{2, "two"}, {3, "three"}})
+	tb.Query(ctx, t, fmt.Sprintf("SELECT pg_drop_replication_slot('flow_slot');"))
+	tb.Insert(ctx, t, tableName, [][]any{{4, "four"}, {5, "five"}})
+	t.Run("capture2", func(t *testing.T) { tests.VerifiedCapture(ctx, t, cs) })
+
+	// A subsequent capture run should still be failing since we haven't fixed it.
+	tb.Insert(ctx, t, tableName, [][]any{{6, "six"}, {7, "seven"}})
+	t.Run("capture3", func(t *testing.T) { tests.VerifiedCapture(ctx, t, cs) })
+
+	// Append a version to the state key to simulate bumping the backfill counter for this binding.
+	cs.Bindings[0].StateKey += ".v2"
+	t.Run("capture4", func(t *testing.T) { tests.VerifiedCapture(ctx, t, cs) })
+}

--- a/source-postgres/database.go
+++ b/source-postgres/database.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/jackc/pglogrepl"
+	"github.com/jackc/pgx/v4"
+)
+
+type replicationSlotInfo struct {
+	SlotName          string
+	Database          string
+	Plugin            string
+	SlotType          string
+	RestartLSN        pglogrepl.LSN
+	ConfirmedFlushLSN pglogrepl.LSN
+	WALStatus         string
+}
+
+// queryReplicationSlotInfo returns information about the named replication slot, if it exists.
+// If the slot doesn't exist then a nil pointer is returned, but without an error. An error is
+// only returned if the query itself fails.
+func queryReplicationSlotInfo(ctx context.Context, conn *pgx.Conn, slotName string) (*replicationSlotInfo, error) {
+	var info replicationSlotInfo
+	// This query employs a somewhat ugly hack in which row_to_json(), JSON indexing, and the
+	// COALESCE() function are combined to implement a "select column if it exists" behavior.
+	// This is necessary because the 'wal_status' column was only added in Postgres 13, and
+	// while we definitely want it if it's available we also need to support older versions
+	// where the column doesn't exist.
+	var query = `SELECT slot_name, database, plugin, slot_type, restart_lsn, confirmed_flush_lsn, coalesce(row_to_json(s)->>'wal_status'::text, 'unknown') as wal_status FROM pg_catalog.pg_replication_slots s WHERE slot_name = $1`
+	if err := conn.QueryRow(ctx, query, slotName).Scan(&info.SlotName, &info.Database, &info.Plugin, &info.SlotType, &info.RestartLSN, &info.ConfirmedFlushLSN, &info.WALStatus); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, nil
+		} else {
+			return nil, fmt.Errorf("error querying replication slots: %w", err)
+		}
+	}
+	return &info, nil
+}

--- a/source-postgres/replication.go
+++ b/source-postgres/replication.go
@@ -707,7 +707,7 @@ func (db *postgresDatabase) ReplicationDiagnostics(ctx context.Context) error {
 		}
 	}
 
-	query("SELECT * FROM public.flow_watermarks;")
+	query("SELECT * FROM " + db.WatermarksTable() + ";")
 	query("SELECT * FROM pg_replication_slots;")
 	query("SELECT pg_current_wal_flush_lsn(), pg_current_wal_insert_lsn(), pg_current_wal_lsn();")
 	return nil


### PR DESCRIPTION
**Description:**

This is a more cautious attempt to get out the replication slot LSN checking.

The check was previously merged in https://github.com/estuary/connectors/pull/1653, then reverted because of a query failure on older database versions in which replication slots don't have a `wal_status` column. This was fixed and the check was merged again in https://github.com/estuary/connectors/pull/1679, which was then reverted because we saw failures in production which suggested that there might be something wrong with our assumption that the connector's restart checkpoint LSN would always be greater than or equal to the latest LSN confirmed with the database.

So this time we're taking it even slower. This PR adds the same `queryReplicationSlotInfo` helper function, a test case covering the behavior when a slot is dropped and then recreated, and the basic logic for the LSN comparison check, but the check itself has been nerfed so it will only ever log warnings. In addition the more comprehensive changes to the "does the slot exist" validation check have been omitted entirely, since they're not the most important part of this anyway.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1697)
<!-- Reviewable:end -->
