### PR TITLE
source-oracle-flashback: handle TRUNCATEs by backfilling automatically

### DIFF
--- a/source-oracle-flashback/tests/snapshots/snapshots__capture_schema_change__stdout.json
+++ b/source-oracle-flashback/tests/snapshots/snapshots__capture_schema_change__stdout.json
@@ -1,0 +1,17 @@
+[
+  [
+    "acmeCo/FLOW_TEST_TEST_CHANGES",
+    {
+      "ID": "1",
+      "STR": "record 1",
+      "_meta": {
+        "op": "c",
+        "source": {
+          "row_id": "<row_id>",
+          "table": "TEST_CHANGES"
+        },
+        "uuid": "DocUUIDPlaceholder-329Bb50aa48EAa9ef"
+      }
+    }
+  ]
+]

--- a/source-oracle-flashback/tests/snapshots/snapshots__capture_truncate__stdout.json
+++ b/source-oracle-flashback/tests/snapshots/snapshots__capture_truncate__stdout.json
@@ -1,0 +1,32 @@
+[
+  [
+    "acmeCo/FLOW_TEST_TEST_CHANGES",
+    {
+      "ID": "1",
+      "STR": "record 1",
+      "_meta": {
+        "op": "c",
+        "source": {
+          "row_id": "<row_id>",
+          "table": "TEST_CHANGES"
+        },
+        "uuid": "DocUUIDPlaceholder-329Bb50aa48EAa9ef"
+      }
+    }
+  ],
+  [
+    "acmeCo/FLOW_TEST_TEST_CHANGES",
+    {
+      "ID": "2",
+      "STR": "record 2",
+      "_meta": {
+        "op": "c",
+        "source": {
+          "row_id": "<row_id>",
+          "table": "TEST_CHANGES"
+        },
+        "uuid": "DocUUIDPlaceholder-329Bb50aa48EAa9ef"
+      }
+    }
+  ]
+]


### PR DESCRIPTION
**Description:**

- Automatically trigger a backfill when a table is TRUNCATEd
- Still throw an error if the schema has changed (a re-discover is necessary in that case)

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1698)
<!-- Reviewable:end -->
