### PR TITLE
materialize-elasticsearch: log received document when there are no source fields

### DIFF
--- a/materialize-elasticsearch/transactor.go
+++ b/materialize-elasticsearch/transactor.go
@@ -362,6 +362,7 @@ func (t *transactor) loadDocs(ctx context.Context, getDocs []getDoc, loaded func
 			// This should never be possible, since we ask for a single key from the source
 			// document. It's here to make the intent of looping over values of d.Source below
 			// explicit, since we'll only see a single value.
+			log.WithField("gotDoc", d).Warn("unexpected number of returned source fields")
 			return fmt.Errorf("unexpected number of returned source fields: %d", len(d.Source))
 		}
 


### PR DESCRIPTION
**Description:**

Adding some logging to aid in troubleshooting when this unexpected condition happens.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1700)
<!-- Reviewable:end -->
