### PR TITLE
source-klaviyo: ignoring 503 HTTP error for Profiles and Global Exclu…

### DIFF
--- a/source-klaviyo/source_klaviyo/streams.py
+++ b/source-klaviyo/source_klaviyo/streams.py
@@ -35,6 +35,25 @@ class KlaviyoStream(HttpStream, ABC):
     def availability_strategy(self) -> Optional[AvailabilityStrategy]:
         return KlaviyoAvailabilityStrategy()
 
+
+    @property
+    def raise_on_http_errors(self) -> bool:
+        # Profiles and Global Exclusions Stream
+        # raise a 503 response when paginating. Ignoring 
+        # raises and retries on both
+        if self.name == "profiles" or self.name == "global_exclusions":
+            return False
+        else:
+            return True
+
+    
+    def should_retry(self, response) -> bool:
+        if self.name == "profiles" or self.name == "global_exclusions":
+            return response.status_code == 429 or response.status_code == 500 or 503 < response.status_code < 600
+        else:
+            return response.status_code == 429 or 500 <= response.status_code < 600
+    
+
     def request_headers(self, **kwargs) -> Mapping[str, Any]:
         return {
             "Accept": "application/json",


### PR DESCRIPTION
…sion streams

**Description:**

Both `Profiles` and `Global Exclusions `streams are raising a 503 HTTP error due to pagination issues. Pagination still believe its returning data, but when accessing the next url for the Profiles search, Klaviyo returns a 503 error and capture breaks. To fix this for now, im ignoring raises on htpp and retries on 503 responses for both streams.


**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1702)
<!-- Reviewable:end -->
