### PR TITLE
source-postgres: Add check for active replication slot

### DIFF
--- a/source-postgres/database.go
+++ b/source-postgres/database.go
@@ -14,6 +14,7 @@ type replicationSlotInfo struct {
 	Database          string
 	Plugin            string
 	SlotType          string
+	Active            bool
 	RestartLSN        pglogrepl.LSN
 	ConfirmedFlushLSN pglogrepl.LSN
 	WALStatus         string
@@ -29,8 +30,8 @@ func queryReplicationSlotInfo(ctx context.Context, conn *pgx.Conn, slotName stri
 	// This is necessary because the 'wal_status' column was only added in Postgres 13, and
 	// while we definitely want it if it's available we also need to support older versions
 	// where the column doesn't exist.
-	var query = `SELECT slot_name, database, plugin, slot_type, restart_lsn, confirmed_flush_lsn, coalesce(row_to_json(s)->>'wal_status'::text, 'unknown') as wal_status FROM pg_catalog.pg_replication_slots s WHERE slot_name = $1`
-	if err := conn.QueryRow(ctx, query, slotName).Scan(&info.SlotName, &info.Database, &info.Plugin, &info.SlotType, &info.RestartLSN, &info.ConfirmedFlushLSN, &info.WALStatus); err != nil {
+	var query = `SELECT slot_name, database, plugin, slot_type, active, restart_lsn, confirmed_flush_lsn, coalesce(row_to_json(s)->>'wal_status'::text, 'unknown') as wal_status FROM pg_catalog.pg_replication_slots s WHERE slot_name = $1`
+	if err := conn.QueryRow(ctx, query, slotName).Scan(&info.SlotName, &info.Database, &info.Plugin, &info.SlotType, &info.Active, &info.RestartLSN, &info.ConfirmedFlushLSN, &info.WALStatus); err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, nil
 		} else {

--- a/source-postgres/replication.go
+++ b/source-postgres/replication.go
@@ -69,6 +69,8 @@ func (db *postgresDatabase) ReplicationStream(ctx context.Context, startCursor s
 		// completely unable to produce a fatal error, and double-checking to make extra sure we don't
 		// accidentally dereference a null pointer doesn't really hurt anything.
 		logrus.WithField("slot", slot).Warn("replication slot has no metadata (and probably doesn't exist?)")
+	} else if slotInfo.Active {
+		logrus.WithField("slot", slot).Warn("replication slot is already active (is another capture already running against this database?)")
 	} else if slotInfo.WALStatus == "lost" {
 		logrus.WithField("slot", slot).Warn("replication slot was invalidated by the server, it must be deleted and all bindings backfilled")
 	} else if startLSN < slotInfo.ConfirmedFlushLSN {


### PR DESCRIPTION
**Description:**

One easily-overlooked way that one might end up with a task's restart LSN being less than the slot's confirmed flush LSN is if there are multiple captures from the same database trying to use the same replication slot.

We should at least try to avoid giving a misleading "the slot was probably dropped and recreated" message in this case, which can be done by checking whether the slot is already active before we've started replication.

Note that this isn't bulletproof, since it's possible for the other of the two misconfigured captures to be momentarily offline when we're doing this check, but it's still better than nothing.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1705)
<!-- Reviewable:end -->
