### PR TITLE
source-mongodb: request pre-images for change events if available

### DIFF
--- a/source-mongodb/.snapshots/TestDiscover
+++ b/source-mongodb/.snapshots/TestDiscover
@@ -44,6 +44,11 @@ Binding 0:
               ],
               "title": "Change Operation",
               "description": "Change operation type: 'c' Create/Insert 'u' Update 'd' Delete."
+            },
+            "before": {
+              "type": "object",
+              "title": "Before Document",
+              "description": "Record state immediately before this change was applied. Available if pre-images are enabled for the MongoDB collection."
             }
           },
           "type": "object"
@@ -101,6 +106,11 @@ Binding 1:
               ],
               "title": "Change Operation",
               "description": "Change operation type: 'c' Create/Insert 'u' Update 'd' Delete."
+            },
+            "before": {
+              "type": "object",
+              "title": "Before Document",
+              "description": "Record state immediately before this change was applied. Available if pre-images are enabled for the MongoDB collection."
             }
           },
           "type": "object"

--- a/source-mongodb/.snapshots/TestDiscoverAllDatabases
+++ b/source-mongodb/.snapshots/TestDiscoverAllDatabases
@@ -44,6 +44,11 @@ Binding 0:
               ],
               "title": "Change Operation",
               "description": "Change operation type: 'c' Create/Insert 'u' Update 'd' Delete."
+            },
+            "before": {
+              "type": "object",
+              "title": "Before Document",
+              "description": "Record state immediately before this change was applied. Available if pre-images are enabled for the MongoDB collection."
             }
           },
           "type": "object"
@@ -101,6 +106,11 @@ Binding 1:
               ],
               "title": "Change Operation",
               "description": "Change operation type: 'c' Create/Insert 'u' Update 'd' Delete."
+            },
+            "before": {
+              "type": "object",
+              "title": "Before Document",
+              "description": "Record state immediately before this change was applied. Available if pre-images are enabled for the MongoDB collection."
             }
           },
           "type": "object"
@@ -158,6 +168,11 @@ Binding 2:
               ],
               "title": "Change Operation",
               "description": "Change operation type: 'c' Create/Insert 'u' Update 'd' Delete."
+            },
+            "before": {
+              "type": "object",
+              "title": "Before Document",
+              "description": "Record state immediately before this change was applied. Available if pre-images are enabled for the MongoDB collection."
             }
           },
           "type": "object"
@@ -215,6 +230,11 @@ Binding 3:
               ],
               "title": "Change Operation",
               "description": "Change operation type: 'c' Create/Insert 'u' Update 'd' Delete."
+            },
+            "before": {
+              "type": "object",
+              "title": "Before Document",
+              "description": "Record state immediately before this change was applied. Available if pre-images are enabled for the MongoDB collection."
             }
           },
           "type": "object"
@@ -272,6 +292,11 @@ Binding 4:
               ],
               "title": "Change Operation",
               "description": "Change operation type: 'c' Create/Insert 'u' Update 'd' Delete."
+            },
+            "before": {
+              "type": "object",
+              "title": "Before Document",
+              "description": "Record state immediately before this change was applied. Available if pre-images are enabled for the MongoDB collection."
             }
           },
           "type": "object"
@@ -329,6 +354,11 @@ Binding 5:
               ],
               "title": "Change Operation",
               "description": "Change operation type: 'c' Create/Insert 'u' Update 'd' Delete."
+            },
+            "before": {
+              "type": "object",
+              "title": "Before Document",
+              "description": "Record state immediately before this change was applied. Available if pre-images are enabled for the MongoDB collection."
             }
           },
           "type": "object"

--- a/source-mongodb/.snapshots/TestDiscoverMultipleDatabases
+++ b/source-mongodb/.snapshots/TestDiscoverMultipleDatabases
@@ -44,6 +44,11 @@ Binding 0:
               ],
               "title": "Change Operation",
               "description": "Change operation type: 'c' Create/Insert 'u' Update 'd' Delete."
+            },
+            "before": {
+              "type": "object",
+              "title": "Before Document",
+              "description": "Record state immediately before this change was applied. Available if pre-images are enabled for the MongoDB collection."
             }
           },
           "type": "object"
@@ -101,6 +106,11 @@ Binding 1:
               ],
               "title": "Change Operation",
               "description": "Change operation type: 'c' Create/Insert 'u' Update 'd' Delete."
+            },
+            "before": {
+              "type": "object",
+              "title": "Before Document",
+              "description": "Record state immediately before this change was applied. Available if pre-images are enabled for the MongoDB collection."
             }
           },
           "type": "object"
@@ -158,6 +168,11 @@ Binding 2:
               ],
               "title": "Change Operation",
               "description": "Change operation type: 'c' Create/Insert 'u' Update 'd' Delete."
+            },
+            "before": {
+              "type": "object",
+              "title": "Before Document",
+              "description": "Record state immediately before this change was applied. Available if pre-images are enabled for the MongoDB collection."
             }
           },
           "type": "object"
@@ -215,6 +230,11 @@ Binding 3:
               ],
               "title": "Change Operation",
               "description": "Change operation type: 'c' Create/Insert 'u' Update 'd' Delete."
+            },
+            "before": {
+              "type": "object",
+              "title": "Before Document",
+              "description": "Record state immediately before this change was applied. Available if pre-images are enabled for the MongoDB collection."
             }
           },
           "type": "object"

--- a/source-mongodb/discovery.go
+++ b/source-mongodb/discovery.go
@@ -24,12 +24,14 @@ var minimalSchema = generateMinimalSchema()
 const idProperty = "_id"
 
 const (
-	metaProperty = "_meta"
-	opProperty   = "op"
+	metaProperty   = "_meta"
+	opProperty     = "op"
+	beforeProperty = "before"
 )
 
 type documentMetadata struct {
-	Op string `json:"op,omitempty" jsonschema:"title=Change Operation,description=Change operation type: 'c' Create/Insert 'u' Update 'd' Delete.,enum=c,enum=u,enum=d"`
+	Op     string         `json:"op,omitempty" jsonschema:"title=Change Operation,description=Change operation type: 'c' Create/Insert 'u' Update 'd' Delete.,enum=c,enum=u,enum=d"`
+	Before map[string]any `json:"before,omitempty" jsonschema:"title=Before Document,description=Record state immediately before this change was applied. Available if pre-images are enabled for the MongoDB collection."`
 }
 
 func generateMinimalSchema() json.RawMessage {


### PR DESCRIPTION
**Description:**

Recent versions of MongoDB make pre-images for update, replace, and delete events available if the MongoDB collections are configured for it. This is useful to capture if it is there, so we will capture these pre-images if they are available.

We'll probably need to implement support for splitting large events at some point, so we will only request these pre-images on versions of MongoDB that support `$changeStreamSplitLargeEvent`. I think we are safe to not do that right now, since it will be fairly complicated and it is not common for documents to be that large - and if there are hopefully they don't have pre-images enabled on their collections.

The existing unit and integration tests confirm the connector output is identical after this change for collections that don't have pre-images enabled, since the tests only create them without pre-images enabled. I manually tested scenarios of collections that do have pre-images enabled and verified that the `before` documents are captured for update, replace, and delete events.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

`source-mongodb` documentation will need updated for this change.

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1711)
<!-- Reviewable:end -->
