### PR TITLE
materialize-s3-iceberg: add integration test

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -260,7 +260,7 @@ jobs:
         run: python -m pip install databricks-sql-cli
 
       - name: Install duckdb
-        if: matrix.connector == 'materialize-motherduck'
+        if: matrix.connector == 'materialize-motherduck' || matrix.connector == 'materialize-s3-iceberg'
         uses: opt-nc/setup-duckdb-action@v1.0.7
         with:
           version: v0.10.3
@@ -280,7 +280,8 @@ jobs:
               "materialize-snowflake",
               "materialize-databricks",
               "materialize-bigquery",
-              "materialize-redshift"
+              "materialize-redshift",
+              "materialize-s3-iceberg"
             ]'), matrix.connector)
         env:
           GCP_SERVICE_ACCOUNT_KEY: ${{ secrets.GCP_SERVICE_ACCOUNT_KEY }}

--- a/tests/materialize/materialize-s3-iceberg/checks.sh
+++ b/tests/materialize/materialize-s3-iceberg/checks.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+SED_CMD="sed"
+if [ "$(uname -s)" = "Darwin" ]; then
+  SED_CMD="gsed"
+fi
+
+# File keys are represented in the connector state as random UUIDs and will be
+# replaced with a placeholder to make the test reproducable.
+$SED_CMD -i'' 's/[0-9a-f]\{8\}-[0-9a-f]\{4\}-[0-9a-f]\{4\}-[0-9a-f]\{4\}-[0-9a-f]\{12\}.parquet/<UUID>.parquet/g' ${SNAPSHOT}

--- a/tests/materialize/materialize-s3-iceberg/cleanup.sh
+++ b/tests/materialize/materialize-s3-iceberg/cleanup.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+set -o errexit
+set -o pipefail
+set -o nounset
+
+aws glue delete-database --name "${NAMESPACE}"
+aws s3 rm $S3_DATA_URI --recursive

--- a/tests/materialize/materialize-s3-iceberg/config.yaml
+++ b/tests/materialize/materialize-s3-iceberg/config.yaml
@@ -1,0 +1,21 @@
+aws_access_key_id_sops: ENC[AES256_GCM,data:/oA/7d65KFw1riN4GWnKvOrVkQE=,iv:3Atq33S2DFf8I0MFXaDLtBjy86J0RFUikwRyNa8Y76I=,tag:BlJ3aIT+LYcKEbBv0P7yDw==,type:str]
+aws_secret_access_key_sops: ENC[AES256_GCM,data:KZXuhZM//ohrHRgR8CwcP7icYRHhFpkd2jBoAZl7CYyDU+5v67Ph2g==,iv:ZyOXVJD17oE2bAJhk+D/Y8OXpBQTqBUlu+TASvn2PvE=,tag:Su5/HkbCS84TtUPvHc5Iug==,type:str]
+bucket: estuary-iceberg-test
+region: us-east-2
+prefix: test-data
+namespace: iceberg-test
+upload_interval: PT5M
+sops:
+    kms: []
+    gcp_kms:
+        - resource_id: projects/estuary-theatre/locations/us-central1/keyRings/connector-keyring/cryptoKeys/connector-repository
+          created_at: "2024-02-01T17:08:49Z"
+          enc: CiQAdmEdwu+udGkiZbfnnE8djh5o4P8p4Rm3WeXcN0XpcDF4sewSSQCVvC1zSqNDZIN7J2EPjuvJM4ILtloOm9w/OGsE4YwB2qH+sKsDDBYuIDDXtHml6w4wG0iksPY1Yxty0casvU6v02mfM3QOvyk=
+    azure_kv: []
+    hc_vault: []
+    age: []
+    lastmodified: "2024-07-10T20:22:33Z"
+    mac: ENC[AES256_GCM,data:crPG9r9KWvYlJl9vlnLv1PH1oUwq5SIXXEy6jkwgQlwCSrMRfj9tQh9ja2ZQ68UERORNWlYQA0O1sfcJ0ETip1t6kQtcyMrZDfTdOQcLis57RkP9Y5KK8RTgHnRyIle4P+cabPIeEJ4FGusrymvkv6aNGgk0f++Qk6i4Ajag2ew=,iv:lI1xXqmQbZBqkzEc5LdZWhFtH17s3UlWIuMjVcfS9SU=,tag:IUBHTMC6qk1cBLfif6tcfA==,type:str]
+    pgp: []
+    encrypted_suffix: _sops
+    version: 3.8.1

--- a/tests/materialize/materialize-s3-iceberg/fetch.sh
+++ b/tests/materialize/materialize-s3-iceberg/fetch.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -o errexit
+set -o pipefail
+set -o nounset
+
+duckdb -json :memory: "SET timezone to UTC; \
+    INSTALL httpfs; \
+    LOAD httpfs; \
+    SET s3_access_key_id='${AWS_ACCESS_KEY_ID}'; \
+    SET s3_secret_access_key='${AWS_SECRET_ACCESS_KEY}'; \
+    SET s3_region='${AWS_REGION}'; \
+    SELECT * from '${S3_DATA_URI}/*.parquet' order by id;"

--- a/tests/materialize/materialize-s3-iceberg/setup.sh
+++ b/tests/materialize/materialize-s3-iceberg/setup.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+set -o errexit
+set -o pipefail
+set -o nounset
+
+resources_json_template='[
+  {
+    "resource": {
+      "table": "simple_delta",
+      "delta_updates": true
+    },
+    "source": "${TEST_COLLECTION_SIMPLE}"
+  }
+]'
+
+function decrypt_config {
+  sops --output-type json --decrypt $1 | jq 'walk( if type == "object" then with_entries(.key |= rtrimstr("_sops")) else . end)' 
+}
+
+export CONNECTOR_CONFIG="$(decrypt_config ${TEST_DIR}/${CONNECTOR}/config.yaml)"
+export AWS_ACCESS_KEY_ID="$(echo $CONNECTOR_CONFIG | jq -r .aws_access_key_id)"
+export AWS_SECRET_ACCESS_KEY="$(echo $CONNECTOR_CONFIG | jq -r .aws_secret_access_key)"
+export AWS_REGION="$(echo $CONNECTOR_CONFIG | jq -r .region)"
+export AWS_BUCKET="$(echo $CONNECTOR_CONFIG | jq -r .bucket)"
+export PREFIX="$(echo $CONNECTOR_CONFIG | jq -r .prefix)"
+export NAMESPACE=$(echo $CONNECTOR_CONFIG | jq -r .namespace)
+
+export RESOURCES_CONFIG="$(echo "$resources_json_template" | envsubst | jq -c)"
+
+export S3_DATA_URI="s3://${AWS_BUCKET}/${PREFIX}"
+
+echo "Creating database: ${NAMESPACE}"
+aws glue create-database --database-input "{\"Name\": \"${NAMESPACE}\"}"

--- a/tests/materialize/materialize-s3-iceberg/snapshot.json
+++ b/tests/materialize/materialize-s3-iceberg/snapshot.json
@@ -1,0 +1,123 @@
+[
+  "applied.actionDescription",
+  "create table \"iceberg-test.simple_delta\""
+]
+[
+  "connectorState",
+  {
+    "updated": {
+      "bindingStates": {
+        "iceberg-test%2Fsimple_delta": {
+          "currentCheckpoint": "ce03a88604a70da2",
+          "fileKeys": [
+            "s3://estuary-iceberg-test/test-data/<UUID>.parquet"
+          ]
+        }
+      }
+    }
+  }
+]
+[
+  "connectorState",
+  {
+    "updated": {
+      "bindingStates": {
+        "iceberg-test%2Fsimple_delta": {
+          "previousCheckpoint": "ce03a88604a70da2",
+          "currentCheckpoint": "7a60ee931eb4057c",
+          "fileKeys": [
+            "s3://estuary-iceberg-test/test-data/<UUID>.parquet"
+          ]
+        }
+      }
+    }
+  }
+]
+[
+  "connectorState",
+  {
+    "updated": {
+      "bindingStates": {
+        "iceberg-test%2Fsimple_delta": {
+          "previousCheckpoint": "ce03a88604a70da2",
+          "currentCheckpoint": "7a60ee931eb4057c",
+          "fileKeys": [
+            "s3://estuary-iceberg-test/test-data/<UUID>.parquet"
+          ]
+        }
+      }
+    }
+  }
+]
+[
+  {
+    "canary": "amputation's",
+    "flow_document": "{\"_meta\":{\"uuid\":\"13814000-1dd2-11b2-8000-071353030311\"},\"canary\":\"amputation's\",\"id\":1}",
+    "flow_published_at": "1970-01-01 00:00:00+00",
+    "id": 1
+  },
+  {
+    "canary": "armament's",
+    "flow_document": "{\"_meta\":{\"uuid\":\"1419d680-1dd2-11b2-8000-071353030311\"},\"canary\":\"armament's\",\"id\":2}",
+    "flow_published_at": "1970-01-01 00:00:01+00",
+    "id": 2
+  },
+  {
+    "canary": "splatters",
+    "flow_document": "{\"_meta\":{\"uuid\":\"14b26d00-1dd2-11b2-8000-071353030311\"},\"canary\":\"splatters\",\"id\":3}",
+    "flow_published_at": "1970-01-01 00:00:02+00",
+    "id": 3
+  },
+  {
+    "canary": "strengthen",
+    "flow_document": "{\"_meta\":{\"uuid\":\"154b0380-1dd2-11b2-8000-071353030311\"},\"canary\":\"strengthen\",\"id\":4}",
+    "flow_published_at": "1970-01-01 00:00:03+00",
+    "id": 4
+  },
+  {
+    "canary": "Kringle's",
+    "flow_document": "{\"_meta\":{\"uuid\":\"15e39a00-1dd2-11b2-8000-071353030311\"},\"canary\":\"Kringle's\",\"id\":5}",
+    "flow_published_at": "1970-01-01 00:00:04+00",
+    "id": 5
+  },
+  {
+    "canary": "grosbeak's",
+    "flow_document": "{\"_meta\":{\"uuid\":\"167c3080-1dd2-11b2-8000-071353030311\"},\"canary\":\"grosbeak's\",\"id\":6}",
+    "flow_published_at": "1970-01-01 00:00:05+00",
+    "id": 6
+  },
+  {
+    "canary": "pieced",
+    "flow_document": "{\"_meta\":{\"uuid\":\"7545a800-1dda-11b2-8000-071353030311\"},\"canary\":\"pieced\",\"id\":7}",
+    "flow_published_at": "1970-01-01 01:00:00+00",
+    "id": 7
+  },
+  {
+    "canary": "roaches",
+    "flow_document": "{\"_meta\":{\"uuid\":\"75de3e80-1dda-11b2-8000-071353030311\"},\"canary\":\"roaches\",\"id\":8}",
+    "flow_published_at": "1970-01-01 01:00:01+00",
+    "id": 8
+  },
+  {
+    "canary": "devilish",
+    "flow_document": "{\"_meta\":{\"uuid\":\"7676d500-1dda-11b2-8000-071353030311\"},\"canary\":\"devilish\",\"id\":9}",
+    "flow_published_at": "1970-01-01 01:00:02+00",
+    "id": 9
+  },
+  {
+    "canary": "glucose's",
+    "flow_document": "{\"_meta\":{\"uuid\":\"770f6b80-1dda-11b2-8000-071353030311\"},\"canary\":\"glucose's\",\"id\":10}",
+    "flow_published_at": "1970-01-01 01:00:03+00",
+    "id": 10
+  }
+]
+[
+  "applied.actionDescription",
+  ""
+]
+[
+  "connectorState",
+  {
+    "updated": {}
+  }
+]


### PR DESCRIPTION
**Description:**

Adds a very simple test to make sure that the connector works end-to-end.

Querying data out of iceberg table is a whole thing, and there's not a slick way to do it for the purposes of snapshotting the materialized data. For now we'll just do the simple delta updates test and read the parquet files that get written as a result of that. Down the road when we implement a standard updates materialization or the tooling for querying iceberg tables via CLI tools improves we could expand these tests. For now they will just make sure the connector works.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1713)
<!-- Reviewable:end -->
