### PR TITLE
source-shopify: ordering "Orders" stream and substreams

### DIFF
--- a/source-shopify/acmeCo/orders.schema.yaml
+++ b/source-shopify/acmeCo/orders.schema.yaml
@@ -864,6 +864,18 @@ properties:
           type:
             - string
             - "null"
+        attributed_staffs:
+          type:
+            - array
+            - "null"
+        pre_tax_price:
+          type:
+            - string
+            - "null"
+        pre_tax_price_set:
+          type:
+            - object
+            - "null"
         fulfillable_quantity:
           type:
             - integer

--- a/source-shopify/source_shopify/tap_shopify/client.py
+++ b/source-shopify/source_shopify/tap_shopify/client.py
@@ -66,6 +66,21 @@ class tap_shopifyStream(RESTStream):
 
         if next_page_token:
             return dict(parse_qsl(urlsplit(next_page_token).query))
+        elif not next_page_token and self.name == "orders":
+            params["status"] = "any"
+            params["order"] = "updated_at asc"
+
+            context_state = self.get_context_state(context)
+            last_updated = context_state.get("replication_key_value")
+
+            start_date = self.config.get("start_date")
+
+            if last_updated:
+                params["updated_at_min"] = last_updated
+            elif start_date:
+                params["updated_at_min"] = start_date
+
+            return params
 
         context_state = self.get_context_state(context)
         last_updated = context_state.get("replication_key_value")

--- a/source-shopify/source_shopify/tap_shopify/schemas/order.json
+++ b/source-shopify/source_shopify/tap_shopify/schemas/order.json
@@ -1312,6 +1312,24 @@
                             "null"
                         ]
                     },
+                    "attributed_staffs": {
+                        "type": [
+                            "array",
+                            "null"
+                        ]
+                    },
+                    "pre_tax_price": {
+                        "type": [
+                            "string",
+                            "null"
+                        ]
+                    },
+                    "pre_tax_price_set": {
+                        "type": [
+                            "object",
+                            "null"
+                        ]
+                    },
                     "fulfillable_quantity": {
                         "type": [
                             "integer",

--- a/source-shopify/source_shopify/tap_shopify/streams.py
+++ b/source-shopify/source_shopify/tap_shopify/streams.py
@@ -136,6 +136,8 @@ class OrdersStream(tap_shopifyStream):
     primary_keys = ["id"]
     replication_key = "updated_at"
     schema_filepath = SCHEMAS_DIR / "order.json"
+    STATE_MSG_FREQUENCY = 10
+    is_sorted = True
 
     def post_process(self, row: dict, context: Optional[dict] = None):
         """Perform syntactic transformations only."""
@@ -149,15 +151,6 @@ class OrdersStream(tap_shopifyStream):
     def get_child_context(self, record: dict, context: Optional[dict]) -> dict:
         """Return a context dictionary for child streams."""
         return {"order_id": record["id"]}
-
-    def get_url_params(self, context, next_page_token):
-        """Return a dictionary of values to be used in URL parameterization."""
-        params = super().get_url_params(context, next_page_token)
-
-        if not next_page_token:
-            params["status"] = "any"
-
-        return params
 
 
 class ProductsStream(tap_shopifyStream):
@@ -175,34 +168,40 @@ class TransactionsStream(tap_shopifyStream):
     """Transactions stream."""
 
     parent_stream_type = OrdersStream
+    ignore_parent_replication_keys = True
 
     name = "transactions"
     path = "/orders/{order_id}/transactions.json"
     records_jsonpath = "$.transactions[*]"
     primary_keys = ["id"]
     schema_filepath = SCHEMAS_DIR / "transaction.json"
+    state_partitioning_keys = []
 
 class RefundsStream(tap_shopifyStream):
     """Refunds stream."""
 
     parent_stream_type = OrdersStream
+    ignore_parent_replication_keys = True
 
     name = "refunds"
     path = "/orders/{order_id}/refunds.json"
     records_jsonpath = "$.refunds[*]"
     primary_keys = ["id"]
     schema_filepath = SCHEMAS_DIR / "refund.json"
+    state_partitioning_keys = []
 
 class OrderRiskStream(tap_shopifyStream):
     """OrderRisk stream."""
 
     parent_stream_type = OrdersStream
+    ignore_parent_replication_keys = True
 
     name = "order_risks"
     path = "/orders/{order_id}/risks.json"
     records_jsonpath = "$.risks[*]"
     primary_keys = ["id"]
     schema_filepath = SCHEMAS_DIR / "risk.json"
+    state_partitioning_keys = []
 
 class PriceRuleStream(tap_shopifyStream):
     """PriceRules stream."""

--- a/source-shopify/source_shopify/tap_shopify/tap.py
+++ b/source-shopify/source_shopify/tap_shopify/tap.py
@@ -130,6 +130,8 @@ class Tap_Shopify(Tap):
         th.Property(
             "start_date",
             th.DateTimeType,
+            required=True,
+            default="2020-01-01",
             description="The earliest record date to sync",
         ),
         th.Property(

--- a/source-shopify/tests/snapshots/source_shopify_tests_test_snapshots__capture__capture.stdout.json
+++ b/source-shopify/tests/snapshots/source_shopify_tests_test_snapshots__capture__capture.stdout.json
@@ -3,7 +3,8 @@
     "acmeCo/collects",
     {
       "_meta": {
-        "row_id": 1
+        "row_id": 1,
+        "uuid": "DocUUIDPlaceholder-329Bb50aa48EAa9ef"
       },
       "collection_id": 466392154422,
       "created_at": "2023-11-09T13:19:30-05:00",
@@ -19,7 +20,8 @@
     "acmeCo/collects",
     {
       "_meta": {
-        "row_id": 2
+        "row_id": 2,
+        "uuid": "DocUUIDPlaceholder-329Bb50aa48EAa9ef"
       },
       "collection_id": 466392219958,
       "created_at": "2023-11-09T13:19:35-05:00",
@@ -35,7 +37,8 @@
     "acmeCo/collects",
     {
       "_meta": {
-        "row_id": 3
+        "row_id": 3,
+        "uuid": "DocUUIDPlaceholder-329Bb50aa48EAa9ef"
       },
       "collection_id": 466392219958,
       "created_at": "2023-11-09T13:19:35-05:00",
@@ -51,7 +54,8 @@
     "acmeCo/collects",
     {
       "_meta": {
-        "row_id": 4
+        "row_id": 4,
+        "uuid": "DocUUIDPlaceholder-329Bb50aa48EAa9ef"
       },
       "collection_id": 466392219958,
       "created_at": "2023-11-09T13:19:35-05:00",
@@ -67,7 +71,8 @@
     "acmeCo/custom_collections",
     {
       "_meta": {
-        "row_id": 1
+        "row_id": 1,
+        "uuid": "DocUUIDPlaceholder-329Bb50aa48EAa9ef"
       },
       "admin_graphql_api_id": "gid://shopify/Collection/466392154422",
       "body_html": null,
@@ -86,7 +91,8 @@
     "acmeCo/custom_collections",
     {
       "_meta": {
-        "row_id": 2
+        "row_id": 2,
+        "uuid": "DocUUIDPlaceholder-329Bb50aa48EAa9ef"
       },
       "admin_graphql_api_id": "gid://shopify/Collection/466392219958",
       "body_html": null,
@@ -105,7 +111,8 @@
     "acmeCo/inventory_levels",
     {
       "_meta": {
-        "row_id": 2
+        "row_id": 2,
+        "uuid": "DocUUIDPlaceholder-329Bb50aa48EAa9ef"
       },
       "available": 50,
       "inventory_item_id": 49446550077750,
@@ -118,7 +125,8 @@
     "acmeCo/inventory_levels",
     {
       "_meta": {
-        "row_id": 3
+        "row_id": 3,
+        "uuid": "DocUUIDPlaceholder-329Bb50aa48EAa9ef"
       },
       "available": 50,
       "inventory_item_id": 49446550176054,
@@ -131,7 +139,8 @@
     "acmeCo/inventory_levels",
     {
       "_meta": {
-        "row_id": 4
+        "row_id": 4,
+        "uuid": "DocUUIDPlaceholder-329Bb50aa48EAa9ef"
       },
       "available": 50,
       "inventory_item_id": 49446550372662,
@@ -144,7 +153,8 @@
     "acmeCo/inventory_levels",
     {
       "_meta": {
-        "row_id": 5
+        "row_id": 5,
+        "uuid": "DocUUIDPlaceholder-329Bb50aa48EAa9ef"
       },
       "available": 20,
       "inventory_item_id": 49446550405430,
@@ -157,7 +167,8 @@
     "acmeCo/inventory_levels",
     {
       "_meta": {
-        "row_id": 6
+        "row_id": 6,
+        "uuid": "DocUUIDPlaceholder-329Bb50aa48EAa9ef"
       },
       "available": 50,
       "inventory_item_id": 49446550438198,
@@ -170,7 +181,8 @@
     "acmeCo/inventory_levels",
     {
       "_meta": {
-        "row_id": 7
+        "row_id": 7,
+        "uuid": "DocUUIDPlaceholder-329Bb50aa48EAa9ef"
       },
       "available": 10,
       "inventory_item_id": 49446550470966,
@@ -183,7 +195,8 @@
     "acmeCo/inventory_levels",
     {
       "_meta": {
-        "row_id": 8
+        "row_id": 8,
+        "uuid": "DocUUIDPlaceholder-329Bb50aa48EAa9ef"
       },
       "available": 10,
       "inventory_item_id": 49446550503734,
@@ -196,7 +209,8 @@
     "acmeCo/inventory_levels",
     {
       "_meta": {
-        "row_id": 9
+        "row_id": 9,
+        "uuid": "DocUUIDPlaceholder-329Bb50aa48EAa9ef"
       },
       "available": 10,
       "inventory_item_id": 49446550536502,
@@ -209,7 +223,8 @@
     "acmeCo/inventory_levels",
     {
       "_meta": {
-        "row_id": 10
+        "row_id": 10,
+        "uuid": "DocUUIDPlaceholder-329Bb50aa48EAa9ef"
       },
       "available": 10,
       "inventory_item_id": 49446550569270,
@@ -222,7 +237,8 @@
     "acmeCo/inventory_levels",
     {
       "_meta": {
-        "row_id": 11
+        "row_id": 11,
+        "uuid": "DocUUIDPlaceholder-329Bb50aa48EAa9ef"
       },
       "available": 10,
       "inventory_item_id": 49446550602038,
@@ -235,7 +251,8 @@
     "acmeCo/inventory_levels",
     {
       "_meta": {
-        "row_id": 12
+        "row_id": 12,
+        "uuid": "DocUUIDPlaceholder-329Bb50aa48EAa9ef"
       },
       "available": 50,
       "inventory_item_id": 49446550634806,
@@ -248,7 +265,8 @@
     "acmeCo/inventory_levels",
     {
       "_meta": {
-        "row_id": 13
+        "row_id": 13,
+        "uuid": "DocUUIDPlaceholder-329Bb50aa48EAa9ef"
       },
       "available": null,
       "inventory_item_id": 49446550667574,
@@ -261,7 +279,8 @@
     "acmeCo/inventory_levels",
     {
       "_meta": {
-        "row_id": 14
+        "row_id": 14,
+        "uuid": "DocUUIDPlaceholder-329Bb50aa48EAa9ef"
       },
       "available": 0,
       "inventory_item_id": 49446550700342,
@@ -274,7 +293,8 @@
     "acmeCo/inventory_levels",
     {
       "_meta": {
-        "row_id": 15
+        "row_id": 15,
+        "uuid": "DocUUIDPlaceholder-329Bb50aa48EAa9ef"
       },
       "available": 10,
       "inventory_item_id": 49446550733110,
@@ -287,7 +307,8 @@
     "acmeCo/inventory_levels",
     {
       "_meta": {
-        "row_id": 16
+        "row_id": 16,
+        "uuid": "DocUUIDPlaceholder-329Bb50aa48EAa9ef"
       },
       "available": null,
       "inventory_item_id": 49446550765878,
@@ -300,7 +321,8 @@
     "acmeCo/inventory_levels",
     {
       "_meta": {
-        "row_id": 17
+        "row_id": 17,
+        "uuid": "DocUUIDPlaceholder-329Bb50aa48EAa9ef"
       },
       "available": null,
       "inventory_item_id": 49446550798646,
@@ -313,7 +335,8 @@
     "acmeCo/inventory_levels",
     {
       "_meta": {
-        "row_id": 18
+        "row_id": 18,
+        "uuid": "DocUUIDPlaceholder-329Bb50aa48EAa9ef"
       },
       "available": null,
       "inventory_item_id": 49446550831414,
@@ -326,7 +349,8 @@
     "acmeCo/inventory_levels",
     {
       "_meta": {
-        "row_id": 19
+        "row_id": 19,
+        "uuid": "DocUUIDPlaceholder-329Bb50aa48EAa9ef"
       },
       "available": null,
       "inventory_item_id": 49446550864182,
@@ -339,7 +363,8 @@
     "acmeCo/inventory_levels",
     {
       "_meta": {
-        "row_id": 27
+        "row_id": 27,
+        "uuid": "DocUUIDPlaceholder-329Bb50aa48EAa9ef"
       },
       "available": 20,
       "inventory_item_id": 49446550896950,
@@ -352,7 +377,8 @@
     "acmeCo/inventory_levels",
     {
       "_meta": {
-        "row_id": 1
+        "row_id": 1,
+        "uuid": "DocUUIDPlaceholder-329Bb50aa48EAa9ef"
       },
       "available": 50,
       "inventory_item_id": 49446550929718,
@@ -365,7 +391,8 @@
     "acmeCo/inventory_levels",
     {
       "_meta": {
-        "row_id": 20
+        "row_id": 20,
+        "uuid": "DocUUIDPlaceholder-329Bb50aa48EAa9ef"
       },
       "available": 50,
       "inventory_item_id": 49446550929718,
@@ -378,7 +405,8 @@
     "acmeCo/inventory_levels",
     {
       "_meta": {
-        "row_id": 21
+        "row_id": 21,
+        "uuid": "DocUUIDPlaceholder-329Bb50aa48EAa9ef"
       },
       "available": 50,
       "inventory_item_id": 49446550995254,
@@ -391,7 +419,8 @@
     "acmeCo/inventory_levels",
     {
       "_meta": {
-        "row_id": 28
+        "row_id": 28,
+        "uuid": "DocUUIDPlaceholder-329Bb50aa48EAa9ef"
       },
       "available": 50,
       "inventory_item_id": 49446550995254,
@@ -404,7 +433,8 @@
     "acmeCo/inventory_levels",
     {
       "_meta": {
-        "row_id": 22
+        "row_id": 22,
+        "uuid": "DocUUIDPlaceholder-329Bb50aa48EAa9ef"
       },
       "available": 50,
       "inventory_item_id": 49446551028022,
@@ -417,7 +447,8 @@
     "acmeCo/inventory_levels",
     {
       "_meta": {
-        "row_id": 23
+        "row_id": 23,
+        "uuid": "DocUUIDPlaceholder-329Bb50aa48EAa9ef"
       },
       "available": 50,
       "inventory_item_id": 49446551060790,
@@ -430,7 +461,8 @@
     "acmeCo/inventory_levels",
     {
       "_meta": {
-        "row_id": 24
+        "row_id": 24,
+        "uuid": "DocUUIDPlaceholder-329Bb50aa48EAa9ef"
       },
       "available": 10,
       "inventory_item_id": 49446551093558,
@@ -443,7 +475,8 @@
     "acmeCo/inventory_levels",
     {
       "_meta": {
-        "row_id": 25
+        "row_id": 25,
+        "uuid": "DocUUIDPlaceholder-329Bb50aa48EAa9ef"
       },
       "available": 10,
       "inventory_item_id": 49446551126326,
@@ -456,7 +489,8 @@
     "acmeCo/inventory_levels",
     {
       "_meta": {
-        "row_id": 26
+        "row_id": 26,
+        "uuid": "DocUUIDPlaceholder-329Bb50aa48EAa9ef"
       },
       "available": 10,
       "inventory_item_id": 49446551159094,
@@ -469,7 +503,8 @@
     "acmeCo/locations",
     {
       "_meta": {
-        "row_id": 2
+        "row_id": 2,
+        "uuid": "DocUUIDPlaceholder-329Bb50aa48EAa9ef"
       },
       "active": true,
       "address1": null,
@@ -497,7 +532,8 @@
     "acmeCo/locations",
     {
       "_meta": {
-        "row_id": 1
+        "row_id": 1,
+        "uuid": "DocUUIDPlaceholder-329Bb50aa48EAa9ef"
       },
       "active": true,
       "address1": "123 Main St",
@@ -525,7 +561,8 @@
     "acmeCo/locations",
     {
       "_meta": {
-        "row_id": 3
+        "row_id": 3,
+        "uuid": "DocUUIDPlaceholder-329Bb50aa48EAa9ef"
       },
       "active": true,
       "address1": null,
@@ -553,7 +590,8 @@
     "acmeCo/metafields",
     {
       "_meta": {
-        "row_id": 1
+        "row_id": 1,
+        "uuid": "DocUUIDPlaceholder-329Bb50aa48EAa9ef"
       },
       "created_at": "2023-11-09T13:19:20-05:00",
       "description": null,
@@ -572,7 +610,8 @@
     "acmeCo/metafields",
     {
       "_meta": {
-        "row_id": 2
+        "row_id": 2,
+        "uuid": "DocUUIDPlaceholder-329Bb50aa48EAa9ef"
       },
       "created_at": "2023-11-09T13:19:30-05:00",
       "description": null,
@@ -591,7 +630,8 @@
     "acmeCo/products",
     {
       "_meta": {
-        "row_id": 13
+        "row_id": 13,
+        "uuid": "DocUUIDPlaceholder-329Bb50aa48EAa9ef"
       },
       "admin_graphql_api_id": "gid://shopify/Product/8907741167926",
       "body_html": null,
@@ -657,7 +697,8 @@
     "acmeCo/products",
     {
       "_meta": {
-        "row_id": 17
+        "row_id": 17,
+        "uuid": "DocUUIDPlaceholder-329Bb50aa48EAa9ef"
       },
       "admin_graphql_api_id": "gid://shopify/Product/8907741200694",
       "body_html": null,
@@ -749,7 +790,8 @@
     "acmeCo/products",
     {
       "_meta": {
-        "row_id": 4
+        "row_id": 4,
+        "uuid": "DocUUIDPlaceholder-329Bb50aa48EAa9ef"
       },
       "admin_graphql_api_id": "gid://shopify/Product/8907741298998",
       "body_html": null,
@@ -841,7 +883,8 @@
     "acmeCo/products",
     {
       "_meta": {
-        "row_id": 10
+        "row_id": 10,
+        "uuid": "DocUUIDPlaceholder-329Bb50aa48EAa9ef"
       },
       "admin_graphql_api_id": "gid://shopify/Product/8907741331766",
       "body_html": null,
@@ -933,7 +976,8 @@
     "acmeCo/products",
     {
       "_meta": {
-        "row_id": 9
+        "row_id": 9,
+        "uuid": "DocUUIDPlaceholder-329Bb50aa48EAa9ef"
       },
       "admin_graphql_api_id": "gid://shopify/Product/8907741364534",
       "body_html": "This <b>PREMIUM</b> <i>snowboard</i> is so <b>SUPER</b><i>DUPER</i> awesome!",
@@ -1141,7 +1185,8 @@
     "acmeCo/products",
     {
       "_meta": {
-        "row_id": 11
+        "row_id": 11,
+        "uuid": "DocUUIDPlaceholder-329Bb50aa48EAa9ef"
       },
       "admin_graphql_api_id": "gid://shopify/Product/8907741397302",
       "body_html": null,
@@ -1233,7 +1278,8 @@
     "acmeCo/products",
     {
       "_meta": {
-        "row_id": 5
+        "row_id": 5,
+        "uuid": "DocUUIDPlaceholder-329Bb50aa48EAa9ef"
       },
       "admin_graphql_api_id": "gid://shopify/Product/8907741430070",
       "body_html": null,
@@ -1325,7 +1371,8 @@
     "acmeCo/products",
     {
       "_meta": {
-        "row_id": 12
+        "row_id": 12,
+        "uuid": "DocUUIDPlaceholder-329Bb50aa48EAa9ef"
       },
       "admin_graphql_api_id": "gid://shopify/Product/8907741462838",
       "body_html": null,
@@ -1417,7 +1464,8 @@
     "acmeCo/products",
     {
       "_meta": {
-        "row_id": 16
+        "row_id": 16,
+        "uuid": "DocUUIDPlaceholder-329Bb50aa48EAa9ef"
       },
       "admin_graphql_api_id": "gid://shopify/Product/8907741495606",
       "body_html": null,
@@ -1509,7 +1557,8 @@
     "acmeCo/products",
     {
       "_meta": {
-        "row_id": 8
+        "row_id": 8,
+        "uuid": "DocUUIDPlaceholder-329Bb50aa48EAa9ef"
       },
       "admin_graphql_api_id": "gid://shopify/Product/8907741528374",
       "body_html": null,
@@ -1601,7 +1650,8 @@
     "acmeCo/products",
     {
       "_meta": {
-        "row_id": 1
+        "row_id": 1,
+        "uuid": "DocUUIDPlaceholder-329Bb50aa48EAa9ef"
       },
       "admin_graphql_api_id": "gid://shopify/Product/8907741561142",
       "body_html": "This is a gift card for the store",
@@ -1780,7 +1830,8 @@
     "acmeCo/products",
     {
       "_meta": {
-        "row_id": 14
+        "row_id": 14,
+        "uuid": "DocUUIDPlaceholder-329Bb50aa48EAa9ef"
       },
       "admin_graphql_api_id": "gid://shopify/Product/8907741593910",
       "body_html": null,
@@ -1872,7 +1923,8 @@
     "acmeCo/products",
     {
       "_meta": {
-        "row_id": 3
+        "row_id": 3,
+        "uuid": "DocUUIDPlaceholder-329Bb50aa48EAa9ef"
       },
       "admin_graphql_api_id": "gid://shopify/Product/8907741626678",
       "body_html": null,
@@ -1964,7 +2016,8 @@
     "acmeCo/products",
     {
       "_meta": {
-        "row_id": 15
+        "row_id": 15,
+        "uuid": "DocUUIDPlaceholder-329Bb50aa48EAa9ef"
       },
       "admin_graphql_api_id": "gid://shopify/Product/8907741659446",
       "body_html": null,
@@ -2056,7 +2109,8 @@
     "acmeCo/products",
     {
       "_meta": {
-        "row_id": 7
+        "row_id": 7,
+        "uuid": "DocUUIDPlaceholder-329Bb50aa48EAa9ef"
       },
       "admin_graphql_api_id": "gid://shopify/Product/8907741692214",
       "body_html": null,
@@ -2148,7 +2202,8 @@
     "acmeCo/products",
     {
       "_meta": {
-        "row_id": 6
+        "row_id": 6,
+        "uuid": "DocUUIDPlaceholder-329Bb50aa48EAa9ef"
       },
       "admin_graphql_api_id": "gid://shopify/Product/8907741724982",
       "body_html": null,
@@ -2240,7 +2295,8 @@
     "acmeCo/products",
     {
       "_meta": {
-        "row_id": 2
+        "row_id": 2,
+        "uuid": "DocUUIDPlaceholder-329Bb50aa48EAa9ef"
       },
       "admin_graphql_api_id": "gid://shopify/Product/8907741757750",
       "body_html": null,

--- a/source-shopify/tests/snapshots/source_shopify_tests_test_snapshots__discover__capture.stdout.json
+++ b/source-shopify/tests/snapshots/source_shopify_tests_test_snapshots__discover__capture.stdout.json
@@ -4330,6 +4330,24 @@
                   "null"
                 ]
               },
+              "attributed_staffs": {
+                "type": [
+                  "array",
+                  "null"
+                ]
+              },
+              "pre_tax_price": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "pre_tax_price_set": {
+                "type": [
+                  "object",
+                  "null"
+                ]
+              },
               "fulfillable_quantity": {
                 "type": [
                   "integer",

--- a/source-shopify/tests/snapshots/source_shopify_tests_test_snapshots__spec__capture.stdout.json
+++ b/source-shopify/tests/snapshots/source_shopify_tests_test_snapshots__spec__capture.stdout.json
@@ -73,10 +73,10 @@
         },
         "start_date": {
           "type": [
-            "string",
-            "null"
+            "string"
           ],
           "format": "date-time",
+          "default": "2020-01-01",
           "description": "The earliest record date to sync"
         },
         "admin_url": {
@@ -96,7 +96,8 @@
       },
       "required": [
         "credentials",
-        "store"
+        "store",
+        "start_date"
       ]
     },
     "resourceConfigSchema": {


### PR DESCRIPTION
"Orders" stream takes a long time to sync and ofter breaks. Because of that its state would be written and trigger the incremental step in the capture, instead of finishing backfill. Now that the stream is ordered and the incremental step was limited, the connector will only enter its "incremental" step after synced the whole stream since start_date


**Notes for reviewers:**

Tested using a local flow setup, with materialization to a supabase DB

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1714)
<!-- Reviewable:end -->
