### PR TITLE
materialize-snowflake: make account field optional

### DIFF
--- a/materialize-snowflake/.snapshots/TestConfigURI-Optional_Parameters
+++ b/materialize-snowflake/.snapshots/TestConfigURI-Optional_Parameters
@@ -1,0 +1,1 @@
+alex:mysecret@orgname-accountname.snowflakecomputing.com:443?GO_QUERY_RESULT_FORMAT=json&MULTI_STATEMENT_COUNT=0&account=myaccount&application=mytenant_EstuaryFlow&client_session_keep_alive=true&database=mydb&role=myrole&schema=myschema&warehouse=mywarehouse

--- a/materialize-snowflake/.snapshots/TestConfigURI-v1_User_&_Password_Authentication
+++ b/materialize-snowflake/.snapshots/TestConfigURI-v1_User_&_Password_Authentication
@@ -1,0 +1,1 @@
+alex:mysecret@orgname-accountname.snowflakecomputing.com:443?GO_QUERY_RESULT_FORMAT=json&MULTI_STATEMENT_COUNT=0&application=mytenant_EstuaryFlow&client_session_keep_alive=true&database=mydb&schema=myschema

--- a/materialize-snowflake/.snapshots/TestConfigURI-v2_User_&_Password_Authentication
+++ b/materialize-snowflake/.snapshots/TestConfigURI-v2_User_&_Password_Authentication
@@ -1,0 +1,1 @@
+will:password@orgname-accountname.snowflakecomputing.com:443?GO_QUERY_RESULT_FORMAT=json&MULTI_STATEMENT_COUNT=0&application=mytenant_EstuaryFlow&client_session_keep_alive=true&database=mydb&schema=myschema

--- a/materialize-snowflake/.snapshots/TestSpecification
+++ b/materialize-snowflake/.snapshots/TestSpecification
@@ -10,34 +10,34 @@
         "order": 0,
         "pattern": "^[^/:]+.snowflakecomputing.com$"
       },
-      "account": {
-        "type": "string",
-        "title": "Account",
-        "description": "The Snowflake account identifier.",
-        "order": 1
-      },
       "database": {
         "type": "string",
         "title": "Database",
         "description": "The SQL database to connect to.",
-        "order": 4
+        "order": 3
       },
       "schema": {
         "type": "string",
         "title": "Schema",
         "description": "Database schema for bound collection tables (unless overridden within the binding resource configuration) as well as associated materialization metadata tables.",
-        "order": 5
+        "order": 4
       },
       "warehouse": {
         "type": "string",
         "title": "Warehouse",
         "description": "The Snowflake virtual warehouse used to execute queries. Uses the default warehouse for the Snowflake user if left blank.",
-        "order": 6
+        "order": 5
       },
       "role": {
         "type": "string",
         "title": "Role",
         "description": "The user role used to perform actions.",
+        "order": 6
+      },
+      "account": {
+        "type": "string",
+        "title": "Account",
+        "description": "Optional Snowflake account identifier.",
         "order": 7
       },
       "hardDelete": {
@@ -191,7 +191,6 @@
     "type": "object",
     "required": [
       "host",
-      "account",
       "database",
       "schema",
       "credentials"

--- a/materialize-snowflake/client.go
+++ b/materialize-snowflake/client.go
@@ -24,7 +24,12 @@ type client struct {
 func newClient(ctx context.Context, ep *sql.Endpoint) (sql.Client, error) {
 	cfg := ep.Config.(*config)
 
-	db, err := stdsql.Open("snowflake", cfg.ToURI(ep.Tenant))
+	dsn, err := cfg.toURI(ep.Tenant)
+	if err != nil {
+		return nil, err
+	}
+
+	db, err := stdsql.Open("snowflake", dsn)
 	if err != nil {
 		return nil, err
 	}

--- a/materialize-snowflake/config_test.go
+++ b/materialize-snowflake/config_test.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/bradleyjkemp/cupaloy"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConfigURI(t *testing.T) {
+	for name, cfg := range map[string]config{
+		"v1 User & Password Authentication": {
+			Host:     "orgname-accountname.snowflakecomputing.com",
+			User:     "alex",
+			Password: "mysecret",
+			Database: "mydb",
+			Schema:   "myschema",
+		},
+		"Optional Parameters": {
+			Host:      "orgname-accountname.snowflakecomputing.com",
+			User:      "alex",
+			Password:  "mysecret",
+			Database:  "mydb",
+			Schema:    "myschema",
+			Warehouse: "mywarehouse",
+			Role:      "myrole",
+			Account:   "myaccount",
+		},
+		"v2 User & Password Authentication": {
+			Host:     "orgname-accountname.snowflakecomputing.com",
+			Database: "mydb",
+			Schema:   "myschema",
+			Credentials: credentialConfig{
+				UserPass,
+				"will",
+				"password",
+				"non-existant-jwt",
+			},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			require.NoError(t, cfg.Validate())
+			uri, err := cfg.toURI("mytenant")
+			require.NoError(t, err)
+			cupaloy.SnapshotT(t, uri)
+		})
+	}
+}

--- a/materialize-snowflake/pipe.go
+++ b/materialize-snowflake/pipe.go
@@ -72,7 +72,11 @@ func generateJWTToken(key *rsa.PrivateKey, user string, accountName string) (str
 func NewPipeClient(cfg *config, accountName string, tenant string) (*PipeClient, error) {
 	httpClient := http.Client{}
 
-	var dsn = cfg.ToURI(tenant)
+	var dsn, err = cfg.toURI(tenant)
+	if err != nil {
+		return nil, fmt.Errorf("building snowflake dsn: %w", err)
+	}
+
 	dsnURL, err := url.Parse(fmt.Sprintf("https://%s", dsn))
 	if err != nil {
 		return nil, fmt.Errorf("parsing snowflake dsn: %w", err)

--- a/materialize-snowflake/snowflake.go
+++ b/materialize-snowflake/snowflake.go
@@ -176,7 +176,12 @@ func newTransactor(
 
 	dialect := snowflakeDialect(cfg.Schema)
 
-	db, err := stdsql.Open("snowflake", cfg.ToURI(ep.Tenant))
+	dsn, err := cfg.toURI(ep.Tenant)
+	if err != nil {
+		return nil, fmt.Errorf("building snowflake dsn: %w", err)
+	}
+
+	db, err := stdsql.Open("snowflake", dsn)
 	if err != nil {
 		return nil, fmt.Errorf("newTransactor stdsql.Open: %w", err)
 	}
@@ -212,13 +217,13 @@ func newTransactor(
 	d.store.fence = &fence
 
 	// Establish connections.
-	if db, err := stdsql.Open("snowflake", cfg.ToURI(ep.Tenant)); err != nil {
+	if db, err := stdsql.Open("snowflake", dsn); err != nil {
 		return nil, fmt.Errorf("load stdsql.Open: %w", err)
 	} else if d.load.conn, err = db.Conn(ctx); err != nil {
 		return nil, fmt.Errorf("load db.Conn: %w", err)
 	}
 
-	if db, err := stdsql.Open("snowflake", cfg.ToURI(ep.Tenant)); err != nil {
+	if db, err := stdsql.Open("snowflake", dsn); err != nil {
 		return nil, fmt.Errorf("store stdsql.Open: %w", err)
 	} else if d.store.conn, err = db.Conn(ctx); err != nil {
 		return nil, fmt.Errorf("store db.Conn: %w", err)

--- a/materialize-snowflake/snowflake_test.go
+++ b/materialize-snowflake/snowflake_test.go
@@ -61,7 +61,10 @@ func TestValidateAndApply(t *testing.T) {
 		Schema: "PUBLIC",
 	}
 
-	db, err := stdsql.Open("snowflake", cfg.ToURI("testing"))
+	dsn, err := cfg.toURI("testing")
+	require.NoError(t, err)
+
+	db, err := stdsql.Open("snowflake", dsn)
 	require.NoError(t, err)
 	defer db.Close()
 


### PR DESCRIPTION
**Description:**

Snowflake does not require an `account` query parameter in the connection string, so this change makes the `account` input optional. The `go-snowflake` driver's `sf.DSN` method for building the connection string can error out when `account` isn't provided, so instead we build the connection string ourselves.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

The [Snowflake materialization docs](https://github.com/estuary/flow/blob/master/site/docs/reference/Connectors/materialization-connectors/Snowflake.md) will need updated to reflect that `account` is not required.

**Notes for reviewers:**

Tested locally with:
- both password & JWT authentication.
- both flavors of Snowflake `host` URL formats 
  - `<orgname>-<account_name>.snowflakecomputing.com`
  - `<accountlocator>.<region>.<cloud>.snowflakecomputing.com`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1725)
<!-- Reviewable:end -->
