### PR TITLE
materialize-elasticsearch: create the meta index with the server default number of shards

### DIFF
--- a/materialize-elasticsearch/client.go
+++ b/materialize-elasticsearch/client.go
@@ -32,8 +32,9 @@ func (c *client) createMetaIndex(ctx context.Context, replicas *int) error {
 		"specBytes": {Type: elasticTypeBinary},
 	}
 
-	numShards := 1
-	return c.createIndex(ctx, defaultFlowMaterializations, &numShards, replicas, props)
+	// The meta index will always be created with the default number of shards.
+	// Long term we plan to not require a meta index at all.
+	return c.createIndex(ctx, defaultFlowMaterializations, nil, replicas, props)
 }
 
 func (c *client) putSpec(ctx context.Context, spec *pf.MaterializationSpec, version string) error {


### PR DESCRIPTION
**Description:**

Rather than always create the meta index with 1 shard, create it with the server default number of shards by leaving the "shards" parameter unspecified.

We might not really need more than 1 shard for this index, but there are near-term plans to not create the meta index at all and instead use the "last spec" available in Validate and Apply requests. This change should also allow our connector to work with serverless Elasticsearch, which does not allow setting the number of shards or replicas for indices.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1733)
<!-- Reviewable:end -->
