### PR TITLE
materialize-elasticsearch: don't waitForActiveShards when connecting to serverless clusters

### DIFF
--- a/materialize-elasticsearch/client.go
+++ b/materialize-elasticsearch/client.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"strings"
 
 	elasticsearch "github.com/elastic/go-elasticsearch/v8"
 	"github.com/elastic/go-elasticsearch/v8/esutil"
@@ -237,4 +238,28 @@ func (c *client) infoSchema(ctx context.Context) (*boilerplate.InfoSchema, error
 	}
 
 	return is, nil
+}
+
+func (c *client) isServerless(ctx context.Context) (bool, error) {
+	res, err := c.es.Info(c.es.Info.WithContext(ctx))
+	if err != nil {
+		return false, fmt.Errorf("getting serverless status: %w", err)
+	}
+	defer res.Body.Close()
+	if res.IsError() {
+		return false, fmt.Errorf("getting serverless status error response [%s] %s", res.Status(), res.String())
+	}
+
+	type infoResponse struct {
+		Version struct {
+			BuildFlavor string `json:"build_flavor"`
+		} `json:"version"`
+	}
+
+	var info infoResponse
+	if err := json.NewDecoder(res.Body).Decode(&info); err != nil {
+		return false, fmt.Errorf("decoding serverless status response: %w", err)
+	}
+
+	return strings.EqualFold(info.Version.BuildFlavor, "serverless"), nil
 }

--- a/materialize-elasticsearch/driver.go
+++ b/materialize-elasticsearch/driver.go
@@ -471,6 +471,14 @@ func (d driver) NewTransactor(ctx context.Context, open pm.Request_Open) (m.Tran
 		return nil, nil, fmt.Errorf("creating client: %w", err)
 	}
 
+	isServerless, err := client.isServerless(ctx)
+	if err != nil {
+		return nil, nil, fmt.Errorf("getting serverless status: %w", err)
+	}
+	if isServerless {
+		log.Info("connected to a serverless elasticsearch cluster")
+	}
+
 	indexToBinding := make(map[string]int)
 	var bindings []binding
 	for idx, b := range open.Materialization.Bindings {
@@ -506,6 +514,7 @@ func (d driver) NewTransactor(ctx context.Context, open pm.Request_Open) (m.Tran
 		cfg:            &cfg,
 		client:         client,
 		bindings:       bindings,
+		isServerless:   isServerless,
 		indexToBinding: indexToBinding,
 	}
 	return transactor, &pm.Response_Opened{}, nil


### PR DESCRIPTION
**Description:**

This option isn't supported when connecting to serverless clusters (they don't have shards), so we need to detect when we are connecting to a serverless cluster and not set it if we are.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1734)
<!-- Reviewable:end -->
