### PR TITLE
source-postgres: Lower replication buffer from 16k to 16

### DIFF
--- a/source-postgres/replication.go
+++ b/source-postgres/replication.go
@@ -211,10 +211,10 @@ const standbyStatusInterval = 10 * time.Second
 // In normal use it's a constant, it's just a variable so that tests are more
 // likely to exercise blocking sends and backpressure.
 //
-// The buffer is much larger for PostgreSQL than for most other databases, because
-// empirically this helps us to cope with spikes of intense load which can otherwise
-// cause the database to cut us off.
-var replicationBufferSize = 16 * 1024 // Assuming change events average ~2kB then 16k * 2kB = 32MB
+// This buffer has been set to a fairly small value, because larger buffers can
+// cause OOM kills when the incoming data rate exceeds the rate at which we're
+// serializing data and getting it into Gazette journals.
+var replicationBufferSize = 16
 
 func (s *replicationStream) Events() <-chan sqlcapture.DatabaseEvent {
 	return s.events


### PR DESCRIPTION
**Description:**

I'm making an educated guess that this is responsible for a user's capture OOMing, and I suspect that 16k is much too large anyway.

As we know from queuing theory, in the steady state a buffer is always either empty or full. And I have a strong suspicion that this buffer is basically always emptyish in most production capture tasks and the only purpose it actually serves is helping smooth out the work passing so that both the replication thread and the main capture serialization thread can keep busy.

Based on that intuition, I figure that 16 should actually be plenty to keep the threads from blocking on each other most of the time, while being much less likely to cause OOMing if it does fill up temporarily.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1735)
<!-- Reviewable:end -->
