### PR TITLE
source-mysql: Support partial row images properly

### DIFF
--- a/source-mysql/.snapshots/TestPartialRowImages-delete
+++ b/source-mysql/.snapshots/TestPartialRowImages-delete
@@ -1,0 +1,9 @@
+# ================================
+# Collection "acmeCo/test/test_partialrowimages_16824726": 1 Documents
+# ================================
+{"_meta":{"op":"d","source":{"schema":"test","table":"PartialRowImages_16824726","cursor":"binlog.000123:56789:123"}},"a":null,"b":null,"c":null,"id":0}
+# ================================
+# Final State Checkpoint
+# ================================
+{"bindingStateV1":{"test%2FPartialRowImages_16824726":{"backfilled":3,"key_columns":["id"],"metadata":{"schema":{"columns":["id","a","b","c"],"types":{"a":{"type":"int"},"b":{"type":"int"},"c":{"type":"int"},"id":{"type":"int"}}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
+

--- a/source-mysql/.snapshots/TestPartialRowImages-delete
+++ b/source-mysql/.snapshots/TestPartialRowImages-delete
@@ -1,7 +1,7 @@
 # ================================
 # Collection "acmeCo/test/test_partialrowimages_16824726": 1 Documents
 # ================================
-{"_meta":{"op":"d","source":{"schema":"test","table":"PartialRowImages_16824726","cursor":"binlog.000123:56789:123"}},"a":null,"b":null,"c":null,"id":0}
+{"_meta":{"op":"d","source":{"ts_ms":1111111111111,"schema":"test","table":"PartialRowImages_16824726","cursor":"binlog.000123:56789:123","txid":"11111111-1111-1111-1111-111111111111:111"}},"id":2}
 # ================================
 # Final State Checkpoint
 # ================================

--- a/source-mysql/.snapshots/TestPartialRowImages-init
+++ b/source-mysql/.snapshots/TestPartialRowImages-init
@@ -1,0 +1,11 @@
+# ================================
+# Collection "acmeCo/test/test_partialrowimages_16824726": 3 Documents
+# ================================
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"PartialRowImages_16824726","cursor":"backfill:0"}},"a":0,"b":0,"c":0,"id":0}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"PartialRowImages_16824726","cursor":"backfill:1"}},"a":1,"b":1,"c":1,"id":1}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"PartialRowImages_16824726","cursor":"backfill:2"}},"a":2,"b":2,"c":2,"id":2}
+# ================================
+# Final State Checkpoint
+# ================================
+{"bindingStateV1":{"test%2FPartialRowImages_16824726":{"backfilled":3,"key_columns":["id"],"metadata":{"schema":{"columns":["id","a","b","c"],"types":{"a":{"type":"int"},"b":{"type":"int"},"c":{"type":"int"},"id":{"type":"int"}}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
+

--- a/source-mysql/.snapshots/TestPartialRowImages-main
+++ b/source-mysql/.snapshots/TestPartialRowImages-main
@@ -1,0 +1,14 @@
+# ================================
+# Collection "acmeCo/test/test_partialrowimages_16824726": 6 Documents
+# ================================
+{"_meta":{"op":"c","source":{"schema":"test","table":"PartialRowImages_16824726","cursor":"binlog.000123:56789:123"}},"a":3,"b":null,"c":null,"id":3}
+{"_meta":{"op":"c","source":{"schema":"test","table":"PartialRowImages_16824726","cursor":"binlog.000123:56789:123"}},"a":null,"b":4,"c":null,"id":4}
+{"_meta":{"op":"c","source":{"schema":"test","table":"PartialRowImages_16824726","cursor":"binlog.000123:56789:123"}},"a":null,"b":null,"c":5,"id":5}
+{"_meta":{"op":"u","source":{"schema":"test","table":"PartialRowImages_16824726","cursor":"binlog.000123:56789:123"},"before":{"a":null,"b":null,"c":null,"id":0}},"a":6,"b":null,"c":null,"id":null}
+{"_meta":{"op":"u","source":{"schema":"test","table":"PartialRowImages_16824726","cursor":"binlog.000123:56789:123"},"before":{"a":null,"b":null,"c":null,"id":1}},"a":null,"b":7,"c":null,"id":null}
+{"_meta":{"op":"u","source":{"schema":"test","table":"PartialRowImages_16824726","cursor":"binlog.000123:56789:123"},"before":{"a":null,"b":null,"c":null,"id":2}},"a":null,"b":null,"c":8,"id":null}
+# ================================
+# Final State Checkpoint
+# ================================
+{"bindingStateV1":{"test%2FPartialRowImages_16824726":{"backfilled":3,"key_columns":["id"],"metadata":{"schema":{"columns":["id","a","b","c"],"types":{"a":{"type":"int"},"b":{"type":"int"},"c":{"type":"int"},"id":{"type":"int"}}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
+

--- a/source-mysql/.snapshots/TestPartialRowImages-main
+++ b/source-mysql/.snapshots/TestPartialRowImages-main
@@ -1,12 +1,12 @@
 # ================================
 # Collection "acmeCo/test/test_partialrowimages_16824726": 6 Documents
 # ================================
-{"_meta":{"op":"c","source":{"schema":"test","table":"PartialRowImages_16824726","cursor":"binlog.000123:56789:123"}},"a":3,"b":null,"c":null,"id":3}
-{"_meta":{"op":"c","source":{"schema":"test","table":"PartialRowImages_16824726","cursor":"binlog.000123:56789:123"}},"a":null,"b":4,"c":null,"id":4}
-{"_meta":{"op":"c","source":{"schema":"test","table":"PartialRowImages_16824726","cursor":"binlog.000123:56789:123"}},"a":null,"b":null,"c":5,"id":5}
-{"_meta":{"op":"u","source":{"schema":"test","table":"PartialRowImages_16824726","cursor":"binlog.000123:56789:123"},"before":{"a":null,"b":null,"c":null,"id":0}},"a":6,"b":null,"c":null,"id":null}
-{"_meta":{"op":"u","source":{"schema":"test","table":"PartialRowImages_16824726","cursor":"binlog.000123:56789:123"},"before":{"a":null,"b":null,"c":null,"id":1}},"a":null,"b":7,"c":null,"id":null}
-{"_meta":{"op":"u","source":{"schema":"test","table":"PartialRowImages_16824726","cursor":"binlog.000123:56789:123"},"before":{"a":null,"b":null,"c":null,"id":2}},"a":null,"b":null,"c":8,"id":null}
+{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"PartialRowImages_16824726","cursor":"binlog.000123:56789:123","txid":"11111111-1111-1111-1111-111111111111:111"}},"a":3,"id":3}
+{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"PartialRowImages_16824726","cursor":"binlog.000123:56789:123","txid":"11111111-1111-1111-1111-111111111111:111"}},"b":4,"id":4}
+{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"PartialRowImages_16824726","cursor":"binlog.000123:56789:123","txid":"11111111-1111-1111-1111-111111111111:111"}},"c":5,"id":5}
+{"_meta":{"op":"u","source":{"ts_ms":1111111111111,"schema":"test","table":"PartialRowImages_16824726","cursor":"binlog.000123:56789:123","txid":"11111111-1111-1111-1111-111111111111:111"},"before":{"id":0}},"a":6,"id":0}
+{"_meta":{"op":"u","source":{"ts_ms":1111111111111,"schema":"test","table":"PartialRowImages_16824726","cursor":"binlog.000123:56789:123","txid":"11111111-1111-1111-1111-111111111111:111"},"before":{"id":1}},"b":7,"id":1}
+{"_meta":{"op":"u","source":{"ts_ms":1111111111111,"schema":"test","table":"PartialRowImages_16824726","cursor":"binlog.000123:56789:123","txid":"11111111-1111-1111-1111-111111111111:111"},"before":{"id":2}},"c":8,"id":2}
 # ================================
 # Final State Checkpoint
 # ================================

--- a/source-mysql/capture_test.go
+++ b/source-mysql/capture_test.go
@@ -309,6 +309,6 @@ func TestPartialRowImages(t *testing.T) {
 	tb.Query(ctx, t, fmt.Sprintf("UPDATE %s SET c = 8 WHERE id = 2", tableName))
 	t.Run("main", func(t *testing.T) { tests.VerifiedCapture(ctx, t, cs) })
 
-	tb.Query(ctx, t, fmt.Sprintf("DELETE FROM %s WHERE id = 0", tableName))
+	tb.Query(ctx, t, fmt.Sprintf("DELETE FROM %s WHERE id = 2", tableName))
 	t.Run("delete", func(t *testing.T) { tests.VerifiedCapture(ctx, t, cs) })
 }


### PR DESCRIPTION
**Description:**

Makes partial row images work correctly by omitting the unspecified columns from the resulting change document rather than filling them out with implicit nulls.

Also adds a test verifying the correct behavior.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1736)
<!-- Reviewable:end -->
