### PR TITLE
source-postgres: Try lowering replication buffer size to one event

### DIFF
--- a/source-postgres/replication.go
+++ b/source-postgres/replication.go
@@ -214,7 +214,7 @@ const standbyStatusInterval = 10 * time.Second
 // This buffer has been set to a fairly small value, because larger buffers can
 // cause OOM kills when the incoming data rate exceeds the rate at which we're
 // serializing data and getting it into Gazette journals.
-var replicationBufferSize = 16
+var replicationBufferSize = 1
 
 func (s *replicationStream) Events() <-chan sqlcapture.DatabaseEvent {
 	return s.events


### PR DESCRIPTION
**Description:**

Followup to https://github.com/estuary/connectors/pull/1735

Just to make absolutely sure that this buffer isn't the issue here. If this doesn't fix the OOMs we're seeing in production, we should revert it and figure out what else is going wrong.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1737)
<!-- Reviewable:end -->
