### PR TITLE
Revert "source-postgres: Try lowering replication buffer size to one event"

### DIFF
--- a/source-postgres/replication.go
+++ b/source-postgres/replication.go
@@ -214,7 +214,7 @@ const standbyStatusInterval = 10 * time.Second
 // This buffer has been set to a fairly small value, because larger buffers can
 // cause OOM kills when the incoming data rate exceeds the rate at which we're
 // serializing data and getting it into Gazette journals.
-var replicationBufferSize = 1
+var replicationBufferSize = 16
 
 func (s *replicationStream) Events() <-chan sqlcapture.DatabaseEvent {
 	return s.events


### PR DESCRIPTION
Reverts estuary/connectors#1737

That PR was always meant to be a short-lived test if it didn't work. And it didn't work, so back up to 16 we go!

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1738)
<!-- Reviewable:end -->
