### PR TITLE
source-mysql: Simplify secondary index discovery

### DIFF
--- a/source-mysql/.snapshots/TestSecondaryIndexDiscovery-index_and_fk
+++ b/source-mysql/.snapshots/TestSecondaryIndexDiscovery-index_and_fk
@@ -1,0 +1,130 @@
+Binding 0:
+{
+    "recommended_name": "test_secondaryindexdiscovery_index_and_fk_g16025",
+    "resource_config_json": {
+      "namespace": "test",
+      "stream": "SecondaryIndexDiscovery_index_and_fk_g16025"
+    },
+    "document_schema_json": {
+      "$defs": {
+        "TestSecondaryIndexDiscovery_index_and_fk_g16025": {
+          "type": "object",
+          "required": [
+            "id"
+          ],
+          "$anchor": "TestSecondaryIndexDiscovery_index_and_fk_g16025",
+          "properties": {
+            "id": {
+              "type": "integer"
+            },
+            "parent_id": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            }
+          }
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "_meta": {
+                "properties": {
+                  "op": {
+                    "const": "d"
+                  }
+                }
+              }
+            }
+          },
+          "then": {
+            "reduce": {
+              "delete": true,
+              "strategy": "merge"
+            }
+          },
+          "else": {
+            "reduce": {
+              "strategy": "merge"
+            }
+          },
+          "required": [
+            "_meta"
+          ],
+          "properties": {
+            "_meta": {
+              "type": "object",
+              "required": [
+                "op",
+                "source"
+              ],
+              "properties": {
+                "before": {
+                  "$ref": "#TestSecondaryIndexDiscovery_index_and_fk_g16025",
+                  "description": "Record state immediately before this change was applied.",
+                  "reduce": {
+                    "strategy": "firstWriteWins"
+                  }
+                },
+                "op": {
+                  "enum": [
+                    "c",
+                    "d",
+                    "u"
+                  ],
+                  "description": "Change operation type: 'c' Create/Insert, 'u' Update, 'd' Delete."
+                },
+                "source": {
+                  "$id": "https://github.com/estuary/connectors/source-mysql/mysql-source-info",
+                  "properties": {
+                    "ts_ms": {
+                      "type": "integer",
+                      "description": "Unix timestamp (in millis) at which this event was recorded by the database."
+                    },
+                    "schema": {
+                      "type": "string",
+                      "description": "Database schema (namespace) of the event."
+                    },
+                    "snapshot": {
+                      "type": "boolean",
+                      "description": "Snapshot is true if the record was produced from an initial table backfill and unset if produced from the replication log."
+                    },
+                    "table": {
+                      "type": "string",
+                      "description": "Database table of the event."
+                    },
+                    "cursor": {
+                      "type": "string",
+                      "description": "Cursor value representing the current position in the binlog."
+                    },
+                    "txid": {
+                      "type": "string",
+                      "description": "The global transaction identifier associated with a change by MySQL. Only set if GTIDs are enabled."
+                    }
+                  },
+                  "type": "object",
+                  "required": [
+                    "schema",
+                    "table",
+                    "cursor"
+                  ]
+                }
+              },
+              "reduce": {
+                "strategy": "merge"
+              }
+            }
+          }
+        },
+        {
+          "$ref": "#TestSecondaryIndexDiscovery_index_and_fk_g16025"
+        }
+      ]
+    },
+    "key": [
+      "/id"
+    ]
+  }
+

--- a/source-mysql/discovery.go
+++ b/source-mysql/discovery.go
@@ -640,20 +640,12 @@ func getPrimaryKeys(ctx context.Context, conn *client.Conn) (map[string][]string
 }
 
 const queryDiscoverSecondaryIndices = `
-SELECT stat.table_schema,
-       stat.table_name,
-       stat.index_name,
-	   stat.column_name,
-	   stat.seq_in_index
-FROM information_schema.statistics stat
-     JOIN information_schema.table_constraints tco
-          ON stat.table_schema = tco.table_schema
-          AND stat.table_name = tco.table_name
-          AND stat.index_name = tco.constraint_name
-WHERE stat.non_unique = 0
-      AND stat.table_schema NOT IN ('information_schema', 'sys', 'performance_schema', 'mysql')
-      AND tco.constraint_type != 'PRIMARY KEY'
-ORDER BY stat.table_schema, stat.table_name, stat.index_name, stat.seq_in_index
+SELECT stat.table_schema, stat.table_name, stat.index_name, stat.column_name, stat.seq_in_index
+  FROM information_schema.statistics stat
+  WHERE stat.non_unique = 0
+    AND stat.index_name != 'PRIMARY'
+    AND stat.table_schema NOT IN ('information_schema', 'sys', 'performance_schema', 'mysql')
+  ORDER BY stat.table_schema, stat.table_name, stat.index_name, stat.seq_in_index
 `
 
 func getSecondaryIndexes(ctx context.Context, conn *client.Conn) (map[string]map[string][]string, error) {

--- a/source-mysql/discovery_test.go
+++ b/source-mysql/discovery_test.go
@@ -25,6 +25,19 @@ func TestSecondaryIndexDiscovery(t *testing.T) {
 		tb.Query(ctx, t, fmt.Sprintf(`CREATE UNIQUE INDEX %s_k23 ON %s (k2, k3)`, shortName, tableName))
 		tb.CaptureSpec(ctx, t).VerifyDiscover(ctx, t, regexp.MustCompile(regexp.QuoteMeta(uniqueString)))
 	})
+	t.Run("index_and_fk", func(t *testing.T) {
+		// It's possible to have multiple constraints on the same table with the same constraint
+		// name but different types. This shouldn't matter now that our secondary index discovery
+		// query no longer joins against `information_schema.table_constraints` at all, but this
+		// test case just makes sure that scenario doesn't break anything.
+		var uniqueA, uniqueB = "g26313", "g16025"
+		var tableA = tb.CreateTable(ctx, t, uniqueA, "(id INTEGER PRIMARY KEY, data TEXT)")
+		var shortNameA = tableA[strings.Index(tableA, ".")+1:]
+		var tableB = tb.CreateTable(ctx, t, uniqueB, fmt.Sprintf("(id INTEGER NOT NULL, parent_id INTEGER, CONSTRAINT FK_%[1]s_ParentID FOREIGN KEY (parent_id) REFERENCES %[1]s(id), CONSTRAINT FK_%[1]s_ParentID UNIQUE (parent_id))", shortNameA))
+		var shortNameB = tableB[strings.Index(tableB, ".")+1:]
+		tb.Query(ctx, t, fmt.Sprintf(`CREATE UNIQUE INDEX IX_%[1]s_ParentID ON %s(id)`, shortNameB, tableB))
+		tb.CaptureSpec(ctx, t).VerifyDiscover(ctx, t, regexp.MustCompile(regexp.QuoteMeta(uniqueB)))
+	})
 	t.Run("nullable_index", func(t *testing.T) {
 		var uniqueString = "g31990"
 		var tableName = tb.CreateTable(ctx, t, uniqueString, "(k1 INTEGER, k2 INTEGER, k3 INTEGER, data TEXT)")


### PR DESCRIPTION
**Description:**

Previously the secondary-index discovery query had a bug in its join against `information_schema.table_constraints` which would crop up if there were multiple constraints on the same table, with the same constraint name, but different constraint types. For instance, a `UNIQUE` constraint and a `FOREIGN KEY` one.

But after rereading the relevant discovery query I'm not sure why we're even looking at that table in the first place. All we used that join for was a `tco.constraint_type != 'PRIMARY KEY'` filter clause, but as we can see in the primary-key discovery query we can also just check whether `stat.index_name = 'PRIMARY'` so the join should be entirely unnecessary.

This commit also adds a subtest to `TestSecondaryIndexDiscovery` which reproduces the scenario that previously failed. After the query fix in this commit the new subtest also passes.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1741)
<!-- Reviewable:end -->
