### PR TITLE
source-hubspot-native: search API fallback for certain bindings

### DIFF
--- a/source-hubspot-native/source_hubspot_native/api.py
+++ b/source-hubspot-native/source_hubspot_native/api.py
@@ -1,4 +1,5 @@
 import asyncio
+import functools
 import itertools
 import json
 from datetime import UTC, datetime, timedelta
@@ -235,6 +236,7 @@ async def fetch_changes(
     fetch_recent: FetchRecentFn,
     http: HTTPSession,
     object_name: str,
+    fallback_to_search_api: bool,
     # Remainder is common.FetchChangesFn:
     log: Logger,
     log_cursor: LogCursor,
@@ -245,6 +247,7 @@ async def fetch_changes(
     # as `log_cursor`, or no pages remain.
     recent: list[tuple[datetime, str]] = []
     next_page: PageCursor = None
+    using_fallback = False
 
     while True:
         iter, next_page = await fetch_recent(log, http, log_cursor, next_page)
@@ -257,6 +260,25 @@ async def fetch_changes(
 
         if not next_page:
             break
+
+        if fallback_to_search_api and not using_fallback and len(recent) >= 9_900:
+            log.info(f"falling back to Search API to return more than 10,000 recent records")
+
+            # Some fetch_recent functions are limited to a maximum number of
+            # recent records. After that point we can use the Search API to fill
+            # in the rest. The Search API is slower and has consistency problems
+            # with very recent data so it is generally not used as the first
+            # option for capturing data, but falling back to it is preferable
+            # over doing an entire re-backfill.
+            using_fallback = True
+            next_page = None
+
+            # The datetime of the oldest of the retrieved records is used here
+            # as the inclusive upper limit for the Search API. There may be many
+            # records with the same "created at" timestamp and runs of these
+            # records may span the `use_search_api_limit` boundary. In this case
+            # we will capture some of the same records twice.
+            fetch_recent = functools.partial(fetch_recent_search_objects, object_name, min(r[0] for r in recent))
 
     recent.sort()  # Oldest updates first.
 
@@ -351,10 +373,9 @@ async def fetch_recent_tickets(
     return ((_ms_to_dt(r.timestamp), str(r.objectId)) for r in result), None
 
 
-# TODO(whb): As we add more object types that might need to use the search API for getting recent
-# changes, this function will probably make sense to generalize.
-async def fetch_recent_custom_objects(
+async def fetch_recent_search_objects(
     object_name: str,
+    until: datetime | None,
     log: Logger,
     http: HTTPSession,
     since: datetime,
@@ -362,17 +383,19 @@ async def fetch_recent_custom_objects(
 ) -> tuple[Iterable[tuple[datetime, str]], PageCursor]:
     
     url = f"{HUB}/crm/v3/objects/{object_name}/search"
-    # The search API has known inconsistencies with very recent data.
-    horizon = datetime.now(tz=UTC) - CONSISTENCY_HORIZON_DELTA
-    if horizon <= since:
-        return [], None
+    if not until:
+        # Fetch up until the present time. The search API has known
+        # inconsistencies with very recent data, so a small offset is applied.
+        until = datetime.now(tz=UTC) - CONSISTENCY_HORIZON_DELTA
+        if until <= since:
+            return [], None
 
     input = {
         "filters": [
             {
                 "propertyName": "hs_lastmodifieddate",
                 "operator": "BETWEEN",
-                "highValue": horizon.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
+                "highValue": until.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
                 "value": since.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
             },
         ],

--- a/source-hubspot-native/source_hubspot_native/api.py
+++ b/source-hubspot-native/source_hubspot_native/api.py
@@ -470,8 +470,10 @@ async def fetch_recent_email_events(
     assert isinstance(log_cursor, datetime)
 
     url = f"{HUB}/email/public/v1/events"
-    # The email events API has known inconsistencies with very recent data.
-    horizon = datetime.now(tz=UTC) - CONSISTENCY_HORIZON_DELTA
+    # The email events API has known inconsistencies with recent data. Empirical
+    # evidence suggests that values as short as 5 minutes are too recent, but 1
+    # hour of delay will work.
+    horizon = datetime.now(tz=UTC) - timedelta(hours=1)
     if horizon <= log_cursor:
         return
 

--- a/source-hubspot-native/source_hubspot_native/resources.py
+++ b/source-hubspot-native/source_hubspot_native/resources.py
@@ -180,6 +180,6 @@ def email_events(http: HTTPSession) -> Resource:
             inc=ResourceState.Incremental(cursor=started_at),
             backfill=ResourceState.Backfill(next_page=None, cutoff=started_at),
         ),
-        initial_config=ResourceConfig(name=Names.email_events),
+        initial_config=ResourceConfig(name=Names.email_events, interval=timedelta(minutes=5)),
         schema_inference=True,
     )

--- a/source-hubspot-native/source_hubspot_native/resources.py
+++ b/source-hubspot-native/source_hubspot_native/resources.py
@@ -17,7 +17,7 @@ from .api import (
     fetch_properties,
     fetch_recent_companies,
     fetch_recent_contacts,
-    fetch_recent_custom_objects,
+    fetch_recent_search_objects,
     fetch_recent_deals,
     fetch_recent_email_events,
     fetch_recent_engagements,
@@ -59,15 +59,15 @@ async def all_resources(
 
     custom_object_resources = [
         crm_object(
-            CustomObject, n, http, functools.partial(fetch_recent_custom_objects, n)
+            CustomObject, n, http, functools.partial(fetch_recent_search_objects, n, None)
         )
         for n in custom_object_names
     ]
 
     return [
-        crm_object(Company, Names.companies, http, fetch_recent_companies),
+        crm_object(Company, Names.companies, http, fetch_recent_companies, True),
         crm_object(Contact, Names.contacts, http, fetch_recent_contacts),
-        crm_object(Deal, Names.deals, http, fetch_recent_deals),
+        crm_object(Deal, Names.deals, http, fetch_recent_deals, True),
         crm_object(Engagement, Names.engagements, http, fetch_recent_engagements),
         crm_object(Ticket, Names.tickets, http, fetch_recent_tickets),
         properties(http, itertools.chain(standard_object_names, custom_object_names)),
@@ -77,7 +77,11 @@ async def all_resources(
 
 
 def crm_object(
-    cls: type[CRMObject], object_name, http: HTTPSession, fetch_recent: FetchRecentFn
+    cls: type[CRMObject],
+    object_name: str,
+    http: HTTPSession,
+    fetch_recent: FetchRecentFn,
+    fallback_to_search_api: bool = False,
 ) -> Resource:
 
     def open(
@@ -92,7 +96,7 @@ def crm_object(
             binding_index,
             state,
             task,
-            fetch_changes=functools.partial(fetch_changes, cls, fetch_recent, http, object_name),
+            fetch_changes=functools.partial(fetch_changes, cls, fetch_recent, http, object_name, fallback_to_search_api),
             fetch_page=functools.partial(fetch_page, cls, http, object_name),
         )
 

--- a/source-hubspot-native/tests/snapshots/snapshots__discover__stdout.json
+++ b/source-hubspot-native/tests/snapshots/snapshots__discover__stdout.json
@@ -1067,7 +1067,8 @@
   {
     "recommendedName": "email_events",
     "resourceConfig": {
-      "name": "email_events"
+      "name": "email_events",
+      "interval": "PT300S"
     },
     "documentSchema": {
       "$defs": {


### PR DESCRIPTION
**Description:**

Closes https://github.com/estuary/connectors/issues/1724

The main change here is adding the ability for the `deals` and `companies` bindings to fall back to using the [HubSpot search API](https://developers.hubspot.com/docs/api/crm/search) when there are more than 10,000 changed records to fetch. The "legacy" APIs we use for listing changes of these objects do not let you page back further than 10,000 items, so this is necessary to avoid needing to completely re-backfill the binding.

One assumption here is that by using the legacy API to get the ~10,000 records that we can, we won't run into issues with the Search API returning bogus results for very "recent" data, as it is known to do. For example, if a source HubSpot account has 20,000 updates to `deals` all right about at the same time, we'll see that happen right away with the legacy API and then after having paged through ~10,000 records with the legacy API, start using the search API. Theoretically this could be too recent for the search API to produce consistent results and we might miss data. I am assuming that the time it takes to get 10,000 records from the legacy API and the inner workings of HubSpot _will_ produce consistent results when using the Search API in this way, but it is an area of uncertainty and would be the first thing I'd suspect if missing data is reported for these cases. Hopefully it all just works though.

Another adjustment is to make the `email_events` resource have a time horizon considerably longer than 5 minutes, due to observations that a 5 minute horizon will still end up missing data to API inconsistencies. I was able to reproduce these inconsistencies locally with 5 minutes, and tested that a 1 hour horizon did not produce them. So we'll go with 1 hour to not miss any data.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1743)
<!-- Reviewable:end -->
