### PR TITLE
materialize-iceberg: log the values for "previous" and "next" checkpoints when appending files

### DIFF
--- a/materialize-s3-iceberg/iceberg-ctl/iceberg_ctl/__main__.py
+++ b/materialize-s3-iceberg/iceberg-ctl/iceberg_ctl/__main__.py
@@ -331,11 +331,18 @@ def append_files(
     # append the same files concurrently. In principal Iceberg catalogs support the atomic
     # operations necessary for true exactly-once semantics, but we'd need to work with the catalog
     # at a lower level than PyIceberg currently makes available.
-
     tbl.add_files(
         file_paths.split(","), snapshot_properties={"checkpoint": next_checkpoint}
     )
 
+    # TODO(whb): This additional checking should not really be necessary, but is
+    # included for now to assist in troubleshooting potential errors.
+    tbl = catalog.load_table(table)
+    snap = tbl.current_snapshot()
+    assert snap is not None
+    assert snap.summary is not None
+    cp = snap.summary["checkpoint"]
+    print(f"set checkpoint to {cp}")
 
 if __name__ == "__main__":
     run(auto_envvar_prefix="ICEBERG")

--- a/materialize-s3-iceberg/transactor.go
+++ b/materialize-s3-iceberg/transactor.go
@@ -218,7 +218,11 @@ func (t *transactor) Acknowledge(ctx context.Context) (*pf.ConnectorState, error
 			continue // no data for this binding
 		}
 
-		ll := log.WithField("table", pathToFQN(b.path))
+		ll := log.WithFields(log.Fields{
+			"table":             pathToFQN(b.path),
+			"previousCheckoint": state.PreviousCheckpoint,
+			"currentCheckpoint": state.CurrentCheckpoint,
+		})
 
 		ll.Info("starting appendFiles for table")
 		if err := t.catalog.appendFiles(b.path, state.FilePaths, state.PreviousCheckpoint, state.CurrentCheckpoint); err != nil {


### PR DESCRIPTION
**Description:**

Trivial logging addition to assist in troubleshooting failures.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1752)
<!-- Reviewable:end -->
