### PR TITLE
source-postgres: Add 'MinimumBackfillXID' advanced option

### DIFF
--- a/source-postgres/.snapshots/TestGeneric-SpecResponse
+++ b/source-postgres/.snapshots/TestGeneric-SpecResponse
@@ -82,6 +82,12 @@
             "type": "array",
             "title": "Discovery Schema Selection",
             "description": "If this is specified only tables in the selected schema(s) will be automatically discovered. Omit all entries to discover tables from all schemas."
+          },
+          "min_backfill_xid": {
+            "type": "string",
+            "title": "Minimum Backfill XID",
+            "description": "Only backfill rows with XMIN values greater (in a 32-bit modular comparison) than the specified XID. Helpful for reducing re-backfill data volume in certain edge cases.",
+            "pattern": "^[0-9a-fA-F/]+$"
           }
         },
         "additionalProperties": false,

--- a/source-postgres/backfill.go
+++ b/source-postgres/backfill.go
@@ -200,6 +200,9 @@ func (db *postgresDatabase) keylessScanQuery(info *sqlcapture.DiscoveryInfo, sch
 	var query = new(strings.Builder)
 	fmt.Fprintf(query, `SELECT ctid, * FROM "%s"."%s"`, schemaName, tableName)
 	fmt.Fprintf(query, ` WHERE ctid > $1`)
+	if db.config.Advanced.MinimumBackfillXID != "" {
+		fmt.Fprintf(query, ` AND (((xmin::text::bigint - '%s'::text::bigint)<<32)>>32) > 0 AND xmin::text::bigint >= 3`, db.config.Advanced.MinimumBackfillXID)
+	}
 	fmt.Fprintf(query, ` LIMIT %d;`, db.config.Advanced.BackfillChunkSize)
 	return query.String()
 }
@@ -220,11 +223,20 @@ func (db *postgresDatabase) buildScanQuery(start, isPrecise bool, keyColumns []s
 		args = append(args, fmt.Sprintf("$%d", idx+1))
 	}
 
+	// Generate a list of individual WHERE clauses which should be ANDed together
+	var whereClauses []string
+	if !start {
+		whereClauses = append(whereClauses, fmt.Sprintf(`(%s) > (%s)`, strings.Join(pkey, ", "), strings.Join(args, ", ")))
+	}
+	if db.config.Advanced.MinimumBackfillXID != "" {
+		whereClauses = append(whereClauses, fmt.Sprintf(`(((xmin::text::bigint - '%s'::text::bigint)<<32)>>32) > 0 AND xmin::text::bigint >= 3`, db.config.Advanced.MinimumBackfillXID))
+	}
+
 	// Construct the query itself
 	var query = new(strings.Builder)
 	fmt.Fprintf(query, `SELECT * FROM "%s"."%s"`, schemaName, tableName)
-	if !start {
-		fmt.Fprintf(query, ` WHERE (%s) > (%s)`, strings.Join(pkey, ", "), strings.Join(args, ", "))
+	if len(whereClauses) > 0 {
+		fmt.Fprintf(query, " WHERE %s", strings.Join(whereClauses, " AND "))
 	}
 	fmt.Fprintf(query, ` ORDER BY %s`, strings.Join(pkey, ", "))
 	fmt.Fprintf(query, " LIMIT %d;", db.config.Advanced.BackfillChunkSize)

--- a/source-postgres/main.go
+++ b/source-postgres/main.go
@@ -99,13 +99,14 @@ type Config struct {
 }
 
 type advancedConfig struct {
-	PublicationName   string   `json:"publicationName,omitempty" jsonschema:"default=flow_publication,description=The name of the PostgreSQL publication to replicate from."`
-	SlotName          string   `json:"slotName,omitempty" jsonschema:"default=flow_slot,description=The name of the PostgreSQL replication slot to replicate from."`
-	WatermarksTable   string   `json:"watermarksTable,omitempty" jsonschema:"default=public.flow_watermarks,description=The name of the table used for watermark writes during backfills. Must be fully-qualified in '<schema>.<table>' form."`
-	SkipBackfills     string   `json:"skip_backfills,omitempty" jsonschema:"title=Skip Backfills,description=A comma-separated list of fully-qualified table names which should not be backfilled."`
-	BackfillChunkSize int      `json:"backfill_chunk_size,omitempty" jsonschema:"title=Backfill Chunk Size,default=50000,description=The number of rows which should be fetched from the database in a single backfill query."`
-	SSLMode           string   `json:"sslmode,omitempty" jsonschema:"title=SSL Mode,description=Overrides SSL connection behavior by setting the 'sslmode' parameter.,enum=disable,enum=allow,enum=prefer,enum=require,enum=verify-ca,enum=verify-full"`
-	DiscoverSchemas   []string `json:"discover_schemas,omitempty" jsonschema:"title=Discovery Schema Selection,description=If this is specified only tables in the selected schema(s) will be automatically discovered. Omit all entries to discover tables from all schemas."`
+	PublicationName    string   `json:"publicationName,omitempty" jsonschema:"default=flow_publication,description=The name of the PostgreSQL publication to replicate from."`
+	SlotName           string   `json:"slotName,omitempty" jsonschema:"default=flow_slot,description=The name of the PostgreSQL replication slot to replicate from."`
+	WatermarksTable    string   `json:"watermarksTable,omitempty" jsonschema:"default=public.flow_watermarks,description=The name of the table used for watermark writes during backfills. Must be fully-qualified in '<schema>.<table>' form."`
+	SkipBackfills      string   `json:"skip_backfills,omitempty" jsonschema:"title=Skip Backfills,description=A comma-separated list of fully-qualified table names which should not be backfilled."`
+	BackfillChunkSize  int      `json:"backfill_chunk_size,omitempty" jsonschema:"title=Backfill Chunk Size,default=50000,description=The number of rows which should be fetched from the database in a single backfill query."`
+	SSLMode            string   `json:"sslmode,omitempty" jsonschema:"title=SSL Mode,description=Overrides SSL connection behavior by setting the 'sslmode' parameter.,enum=disable,enum=allow,enum=prefer,enum=require,enum=verify-ca,enum=verify-full"`
+	DiscoverSchemas    []string `json:"discover_schemas,omitempty" jsonschema:"title=Discovery Schema Selection,description=If this is specified only tables in the selected schema(s) will be automatically discovered. Omit all entries to discover tables from all schemas."`
+	MinimumBackfillXID string   `json:"min_backfill_xid,omitempty" jsonschema:"title=Minimum Backfill XID,description=Only backfill rows with XMIN values greater (in a 32-bit modular comparison) than the specified XID. Helpful for reducing re-backfill data volume in certain edge cases." jsonschema_extras:"pattern=^[0-9a-fA-F/]+$"`
 }
 
 // Validate checks that the configuration possesses all required properties.


### PR DESCRIPTION
**Description:**

This is completely untested except to make sure it doesn't break anything else in our automated test suite, but the XMIN filtering logic is taken from our batch Postgres connector and this is a pretty straightforward bit of plumbing directly from the advanced connector config into the relevant backfill query generation, so it'll either work or it won't.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1753)
<!-- Reviewable:end -->
