### PR TITLE
source-postgres: Fix dumb issue with 'MinimumBackfillXID'

### DIFF
--- a/source-postgres/.snapshots/TestGeneric-SpecResponse
+++ b/source-postgres/.snapshots/TestGeneric-SpecResponse
@@ -87,7 +87,7 @@
             "type": "string",
             "title": "Minimum Backfill XID",
             "description": "Only backfill rows with XMIN values greater (in a 32-bit modular comparison) than the specified XID. Helpful for reducing re-backfill data volume in certain edge cases.",
-            "pattern": "^[0-9a-fA-F/]+$"
+            "pattern": "^[0-9]+$"
           }
         },
         "additionalProperties": false,

--- a/source-postgres/backfill.go
+++ b/source-postgres/backfill.go
@@ -201,7 +201,7 @@ func (db *postgresDatabase) keylessScanQuery(info *sqlcapture.DiscoveryInfo, sch
 	fmt.Fprintf(query, `SELECT ctid, * FROM "%s"."%s"`, schemaName, tableName)
 	fmt.Fprintf(query, ` WHERE ctid > $1`)
 	if db.config.Advanced.MinimumBackfillXID != "" {
-		fmt.Fprintf(query, ` AND (((xmin::text::bigint - '%s'::text::bigint)<<32)>>32) > 0 AND xmin::text::bigint >= 3`, db.config.Advanced.MinimumBackfillXID)
+		fmt.Fprintf(query, ` AND (((xmin::text::bigint - %s::bigint)<<32)>>32) > 0 AND xmin::text::bigint >= 3`, db.config.Advanced.MinimumBackfillXID)
 	}
 	fmt.Fprintf(query, ` LIMIT %d;`, db.config.Advanced.BackfillChunkSize)
 	return query.String()
@@ -229,7 +229,7 @@ func (db *postgresDatabase) buildScanQuery(start, isPrecise bool, keyColumns []s
 		whereClauses = append(whereClauses, fmt.Sprintf(`(%s) > (%s)`, strings.Join(pkey, ", "), strings.Join(args, ", ")))
 	}
 	if db.config.Advanced.MinimumBackfillXID != "" {
-		whereClauses = append(whereClauses, fmt.Sprintf(`(((xmin::text::bigint - '%s'::text::bigint)<<32)>>32) > 0 AND xmin::text::bigint >= 3`, db.config.Advanced.MinimumBackfillXID))
+		whereClauses = append(whereClauses, fmt.Sprintf(`(((xmin::text::bigint - %s::bigint)<<32)>>32) > 0 AND xmin::text::bigint >= 3`, db.config.Advanced.MinimumBackfillXID))
 	}
 
 	// Construct the query itself

--- a/source-postgres/main.go
+++ b/source-postgres/main.go
@@ -106,7 +106,7 @@ type advancedConfig struct {
 	BackfillChunkSize  int      `json:"backfill_chunk_size,omitempty" jsonschema:"title=Backfill Chunk Size,default=50000,description=The number of rows which should be fetched from the database in a single backfill query."`
 	SSLMode            string   `json:"sslmode,omitempty" jsonschema:"title=SSL Mode,description=Overrides SSL connection behavior by setting the 'sslmode' parameter.,enum=disable,enum=allow,enum=prefer,enum=require,enum=verify-ca,enum=verify-full"`
 	DiscoverSchemas    []string `json:"discover_schemas,omitempty" jsonschema:"title=Discovery Schema Selection,description=If this is specified only tables in the selected schema(s) will be automatically discovered. Omit all entries to discover tables from all schemas."`
-	MinimumBackfillXID string   `json:"min_backfill_xid,omitempty" jsonschema:"title=Minimum Backfill XID,description=Only backfill rows with XMIN values greater (in a 32-bit modular comparison) than the specified XID. Helpful for reducing re-backfill data volume in certain edge cases." jsonschema_extras:"pattern=^[0-9a-fA-F/]+$"`
+	MinimumBackfillXID string   `json:"min_backfill_xid,omitempty" jsonschema:"title=Minimum Backfill XID,description=Only backfill rows with XMIN values greater (in a 32-bit modular comparison) than the specified XID. Helpful for reducing re-backfill data volume in certain edge cases." jsonschema_extras:"pattern=^[0-9]+$"`
 }
 
 // Validate checks that the configuration possesses all required properties.


### PR DESCRIPTION
**Description:**

I got confused between XIDs and LSNs when writing https://github.com/estuary/connectors/pull/1753. This should fix it to work correctly with decimal integer XIDs.