### PR TITLE
source-mongodb: split large change stream event documents

### DIFF
--- a/source-mongodb/.snapshots/TestCaptureSplitLargeDocuments
+++ b/source-mongodb/.snapshots/TestCaptureSplitLargeDocuments
@@ -1,0 +1,14 @@
+# ================================
+# Collection "acmeCo/test/testCollection": 6 Documents
+# ================================
+{"_id":"smallDocument","_meta":{"op":"c"},"baz":"qux","foo":"bar"}
+{"_id":"smallDocument","_meta":{"before":{"_id":"smallDocument","baz":"qux","foo":"bar"},"op":"u"},"baz":"qux","foo":"bar_updated"}
+{"_id":"hugeDocument","_meta":{"op":"c"},"key1":"<TOKEN>","key2":"<TOKEN>","key3":"<TOKEN>","key4":"<TOKEN>","key5":"<TOKEN>","key6":"<TOKEN>","key7":"<TOKEN>","key8":"<TOKEN>","key9":"<TOKEN>"}
+{"_id":"hugeDocument","_meta":{"before":{"_id":"hugeDocument","key1":"<TOKEN>","key2":"<TOKEN>","key3":"<TOKEN>","key4":"<TOKEN>","key5":"<TOKEN>","key6":"<TOKEN>","key7":"<TOKEN>","key8":"<TOKEN>","key9":"<TOKEN>"},"op":"u"},"key1":"updated","key2":"<TOKEN>","key3":"<TOKEN>","key4":"<TOKEN>","key5":"<TOKEN>","key6":"<TOKEN>","key7":"<TOKEN>","key8":"<TOKEN>","key9":"also updated"}
+{"_id":"otherSmallDocument","_meta":{"op":"c"},"some":"other","values":"here"}
+{"_id":"otherSmallDocument","_meta":{"before":{"_id":"otherSmallDocument","some":"other","values":"here"},"op":"u"},"some":"other_updated","values":"here"}
+# ================================
+# Final State Checkpoint
+# ================================
+{"bindingStateV1":{"testDb%2FtestCollection":{"backfill":{"done":true}}},"databaseResumeTokens":{"testDb":"<TOKEN>"}}
+

--- a/source-mongodb/change_stream.go
+++ b/source-mongodb/change_stream.go
@@ -126,6 +126,7 @@ func (c *capture) initializeStreams(
 				"ns":                       1,
 				"clusterTime":              1,
 				"fullDocumentBeforeChange": 1,
+				"splitEvent":               1,
 			}}},
 		}
 
@@ -150,6 +151,7 @@ func (c *capture) initializeStreams(
 		opts := options.ChangeStream().SetFullDocument(options.UpdateLookup)
 		if requestPreImages {
 			opts = opts.SetFullDocumentBeforeChange(options.WhenAvailable)
+			pl = append(pl, bson.D{{Key: "$changeStreamSplitLargeEvent", Value: bson.D{}}}) // must be the last stage in the pipeline
 		}
 
 		if t, ok := c.state.DatabaseResumeTokens[db]; ok {
@@ -280,9 +282,23 @@ func (c *capture) tryStream(
 ) error {
 	for s.ms.TryNext(ctx) {
 		var ev changeEvent
-		if err := s.ms.Decode(&ev); err != nil {
-			return fmt.Errorf("change stream decoding document: %w", err)
-		} else if err := c.handleEvent(ev, s.db, s.ms.ResumeToken()); err != nil {
+
+		splitRaw := s.ms.Current.Lookup("splitEvent")
+		if !splitRaw.IsZero() {
+			// This change event is split across multiple change stream event
+			// "fragments". Each of the fragments in the sequence must be read
+			// and combined.
+			if err := readFragments(ctx, s, &ev); err != nil {
+				return fmt.Errorf("assembling event from change stream event segments: %w", err)
+			}
+		} else {
+			// This change event is not split.
+			if err := s.ms.Decode(&ev); err != nil {
+				return fmt.Errorf("change stream decoding document: %w", err)
+			}
+		}
+
+		if err := c.handleEvent(ev, s.db, s.ms.ResumeToken()); err != nil {
 			return err
 		}
 
@@ -325,6 +341,44 @@ func (c *capture) tryStream(
 	c.mu.Lock()
 	c.state.DatabaseResumeTokens[s.db] = tok
 	c.mu.Unlock()
+
+	return nil
+}
+
+type splitEvent struct {
+	Fragment int `bson:"fragment"`
+	Of       int `bson:"of"`
+}
+
+func readFragments(
+	ctx context.Context,
+	s changeStream,
+	ev *changeEvent,
+) error {
+	// Fragments are repeatedly unmarshalled into a single change event since no
+	// two fragments have overlapping top-level properties - MongoDB only splits
+	// on top-level document fields.
+	lastFragment := 0
+	for {
+		// Upon entering this loop, the change stream must already have been
+		// advanced to a split change event. For the duration of the loop it is
+		// an error if an event is not split, since we only want to read to
+		// "end" of the current set of fragments.
+		var se splitEvent
+		if splitRaw, err := s.ms.Current.LookupErr("splitEvent"); err != nil {
+			return fmt.Errorf("finding splitEvent in document fragment: %w", err)
+		} else if err := splitRaw.Unmarshal(&se); err != nil {
+			return err
+		} else if lastFragment += 1; lastFragment != se.Fragment { // cheap sanity check
+			return fmt.Errorf("expected fragment %d but got %d", lastFragment, se.Fragment)
+		} else if err := s.ms.Decode(ev); err != nil {
+			return fmt.Errorf("decoding fragment: %w", err)
+		} else if se.Fragment == se.Of { // done reading fragments
+			break
+		} else if !s.ms.Next(ctx) { // advance to the next fragment, blocking until it is available (note: TryNext cannot be used)
+			return fmt.Errorf("advancing change stream: %w", s.ms.Err())
+		}
+	}
 
 	return nil
 }

--- a/source-mongodb/main_test.go
+++ b/source-mongodb/main_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/url"
 	"regexp"
+	"strings"
 	"testing"
 	"time"
 
@@ -14,6 +15,8 @@ import (
 	"github.com/estuary/flow/go/protocols/flow"
 	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo/options"
 )
 
 func TestCapture(t *testing.T) {
@@ -101,6 +104,95 @@ func TestCapture(t *testing.T) {
 	updateData(ctx, t, client, database2, col3, binaryPkVals(1), "forthColumn_new")
 
 	advanceCapture(ctx, t, cs)
+
+	cupaloy.SnapshotT(t, cs.Summary())
+}
+
+func TestCaptureSplitLargeDocuments(t *testing.T) {
+	database := "testDb"
+	col := "testCollection"
+
+	ctx := context.Background()
+	client, cfg := testClient(t)
+
+	cleanup := func() {
+		dropCollection(ctx, t, client, database, col)
+	}
+	cleanup()
+	t.Cleanup(cleanup)
+
+	require.NoError(t, client.Database(database).CreateCollection(ctx, col, &options.CreateCollectionOptions{ChangeStreamPreAndPostImages: bson.D{{Key: "enabled", Value: true}}}))
+
+	cs := &st.CaptureSpec{
+		Driver:       &driver{},
+		EndpointSpec: &cfg,
+		Checkpoint:   []byte("{}"),
+		Validator:    &st.OrderedCaptureValidator{},
+		Sanitizers:   commonSanitizers(),
+		Bindings:     []*flow.CaptureSpec_Binding{makeBinding(t, database, col)},
+	}
+
+	collection := client.Database(database).Collection(col)
+
+	// Do the initial backfill to get into "streaming mode" to start capturing changes.
+	advanceCapture(ctx, t, cs)
+
+	// Insert a small document and update it.
+	val := map[string]string{"_id": "smallDocument", "foo": "bar", "baz": "qux"}
+	_, err := collection.InsertOne(ctx, val)
+	require.NoError(t, err)
+	val["foo"] = "bar_updated"
+	res, err := collection.UpdateOne(ctx, bson.D{{Key: "_id", Value: val["_id"]}}, bson.D{{Key: "$set", Value: val}})
+	require.NoError(t, err)
+	require.Equal(t, 1, int(res.ModifiedCount))
+
+	// Insert a huge document and update it. The output sanitizers will replace
+	// the very long values with `<TOKEN>` based on the simple token
+	// sanitization logic.
+	val = map[string]string{
+		"_id":  "hugeDocument",
+		"key1": strings.Repeat("value1", 200000),
+		"key2": strings.Repeat("value2", 200000),
+		"key3": strings.Repeat("value3", 200000),
+		"key4": strings.Repeat("value4", 200000),
+		"key5": strings.Repeat("value5", 200000),
+		"key6": strings.Repeat("value6", 200000),
+		"key7": strings.Repeat("value7", 200000),
+		"key8": strings.Repeat("value8", 200000),
+		"key9": strings.Repeat("value9", 200000),
+	}
+	_, err = collection.InsertOne(ctx, val)
+	require.NoError(t, err)
+	val["key1"] = "updated"
+	val["key9"] = "also updated"
+	res, err = collection.UpdateOne(ctx, bson.D{{Key: "_id", Value: val["_id"]}}, bson.D{{Key: "$set", Value: val}})
+	require.NoError(t, err)
+	require.Equal(t, 1, int(res.ModifiedCount))
+
+	// Another small document.
+	val = map[string]string{"_id": "otherSmallDocument", "some": "other", "values": "here"}
+	_, err = collection.InsertOne(ctx, val)
+	require.NoError(t, err)
+	val["some"] = "other_updated"
+	res, err = collection.UpdateOne(ctx, bson.D{{Key: "_id", Value: val["_id"]}}, bson.D{{Key: "$set", Value: val}})
+	require.NoError(t, err)
+	require.Equal(t, 1, int(res.ModifiedCount))
+
+	// Read change stream documents, waiting until we have received all 6
+	// expected change stream documents, not counting checkpoints. Reading the
+	// huge document and its updates from the change stream takes a non-trivial
+	// amount of time.
+	count := 0
+	captureCtx, cancel := context.WithCancel(context.Background())
+	time.AfterFunc(5*time.Second, cancel) // don't wait forever though
+	cs.Capture(captureCtx, t, func(msg json.RawMessage) {
+		if !strings.Contains(string(msg), "bindingStateV1") {
+			count++
+		}
+		if count == 6 {
+			cancel()
+		}
+	})
 
 	cupaloy.SnapshotT(t, cs.Summary())
 }


### PR DESCRIPTION
**Description:**

For deployments that support splitting large change stream event documents, include that pipeline stage and handle the resulting fragments.

It is possible for a change stream event document to exceed the standard 16MiB limit when it includes a pre-image and is an update to a very large document, which can sometimes happen.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1756)
<!-- Reviewable:end -->
