### PR TITLE
source-postgres: Fix empty array serialization after PGX v5

### DIFF
--- a/source-postgres/datatype_test.go
+++ b/source-postgres/datatype_test.go
@@ -105,6 +105,7 @@ func TestDatatypes(t *testing.T) {
 		//    [...] declaring the array size or number of dimensions in CREATE TABLE is
 		//    simply documentation; it does not affect run-time behavior.
 		// This set of test cases exercises that expectation.
+		{ColumnType: `integer[3][3]`, ExpectType: fmt.Sprintf(arraySchemaPattern, `{"type":["integer","null"]}`), InputValue: `{}`, ExpectValue: `{"dimensions":[],"elements":[]}`},
 		{ColumnType: `integer[3][3]`, ExpectType: fmt.Sprintf(arraySchemaPattern, `{"type":["integer","null"]}`), InputValue: `{{{{{{1}}}}}}`, ExpectValue: `{"dimensions":[1,1,1,1,1,1],"elements":[1]}`},
 		{ColumnType: `integer[3][3]`, ExpectType: fmt.Sprintf(arraySchemaPattern, `{"type":["integer","null"]}`), InputValue: `{1,2,3,4,5,6}`, ExpectValue: `{"dimensions":[6],"elements":[1,2,3,4,5,6]}`},
 		{ColumnType: `integer[3][3]`, ExpectType: fmt.Sprintf(arraySchemaPattern, `{"type":["integer","null"]}`), InputValue: `{{1,2,3},{4,5,6},{7,8,9}}`, ExpectValue: `{"dimensions":[3,3],"elements":[1,2,3,4,5,6,7,8,9]}`},

--- a/source-postgres/datatypes.go
+++ b/source-postgres/datatypes.go
@@ -335,7 +335,7 @@ func formatRFC3339(t time.Time) (any, error) {
 }
 
 func translateArray(_ *sqlcapture.ColumnInfo, x pgtype.Array[any]) (any, error) {
-	var dims []int
+	var dims = make([]int, 0)
 	for _, dim := range x.Dims {
 		dims = append(dims, int(dim.Length))
 	}


### PR DESCRIPTION
**Description:**

The package upgrade to PGX v5 caused a lot of churn around how we translate various datatypes, and the array handling had to be rewritten entirely. Looks like I missed an edge case because the dimensions list is serialized as `null` when it should be `[]` for an empty array coming from the DB.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1759)
<!-- Reviewable:end -->
