### PR TITLE
source-mongodb: split large change stream event documents v2

### DIFF
--- a/source-mongodb/.snapshots/TestCaptureSplitLargeDocuments
+++ b/source-mongodb/.snapshots/TestCaptureSplitLargeDocuments
@@ -1,0 +1,14 @@
+# ================================
+# Collection "acmeCo/test/testCollection": 6 Documents
+# ================================
+{"_id":"smallDocument","_meta":{"op":"c"},"baz":"qux","foo":"bar"}
+{"_id":"smallDocument","_meta":{"before":{"_id":"smallDocument","baz":"qux","foo":"bar"},"op":"u"},"baz":"qux","foo":"bar_updated"}
+{"_id":"hugeDocument","_meta":{"op":"c"},"key1":"<TOKEN>","key2":"<TOKEN>","key3":"<TOKEN>","key4":"<TOKEN>","key5":"<TOKEN>","key6":"<TOKEN>","key7":"<TOKEN>","key8":"<TOKEN>","key9":"<TOKEN>"}
+{"_id":"hugeDocument","_meta":{"before":{"_id":"hugeDocument","key1":"<TOKEN>","key2":"<TOKEN>","key3":"<TOKEN>","key4":"<TOKEN>","key5":"<TOKEN>","key6":"<TOKEN>","key7":"<TOKEN>","key8":"<TOKEN>","key9":"<TOKEN>"},"op":"u"},"key1":"updated","key2":"<TOKEN>","key3":"<TOKEN>","key4":"<TOKEN>","key5":"<TOKEN>","key6":"<TOKEN>","key7":"<TOKEN>","key8":"<TOKEN>","key9":"also updated"}
+{"_id":"otherSmallDocument","_meta":{"op":"c"},"some":"other","values":"here"}
+{"_id":"otherSmallDocument","_meta":{"before":{"_id":"otherSmallDocument","some":"other","values":"here"},"op":"u"},"some":"other_updated","values":"here"}
+# ================================
+# Final State Checkpoint
+# ================================
+{"bindingStateV1":{"testDb%2FtestCollection":{"backfill":{"done":true}}},"databaseResumeTokens":{"testDb":"<TOKEN>"}}
+

--- a/source-mongodb/change_stream.go
+++ b/source-mongodb/change_stream.go
@@ -126,6 +126,7 @@ func (c *capture) initializeStreams(
 				"ns":                       1,
 				"clusterTime":              1,
 				"fullDocumentBeforeChange": 1,
+				"splitEvent":               1,
 			}}},
 		}
 
@@ -150,6 +151,7 @@ func (c *capture) initializeStreams(
 		opts := options.ChangeStream().SetFullDocument(options.UpdateLookup)
 		if requestPreImages {
 			opts = opts.SetFullDocumentBeforeChange(options.WhenAvailable)
+			pl = append(pl, bson.D{{Key: "$changeStreamSplitLargeEvent", Value: bson.D{}}}) // must be the last stage in the pipeline
 		}
 
 		if t, ok := c.state.DatabaseResumeTokens[db]; ok {
@@ -280,9 +282,23 @@ func (c *capture) tryStream(
 ) error {
 	for s.ms.TryNext(ctx) {
 		var ev changeEvent
-		if err := s.ms.Decode(&ev); err != nil {
-			return fmt.Errorf("change stream decoding document: %w", err)
-		} else if err := c.handleEvent(ev, s.db, s.ms.ResumeToken()); err != nil {
+
+		splitRaw := s.ms.Current.Lookup("splitEvent")
+		if !splitRaw.IsZero() {
+			// This change event is split across multiple change stream event
+			// "fragments". Each of the fragments in the sequence must be read
+			// and combined.
+			if err := readFragments(ctx, s, &ev); err != nil {
+				return fmt.Errorf("assembling event from change stream event segments: %w", err)
+			}
+		} else {
+			// This change event is not split.
+			if err := s.ms.Decode(&ev); err != nil {
+				return fmt.Errorf("change stream decoding document: %w", err)
+			}
+		}
+
+		if err := c.handleEvent(ev, s.db, s.ms.ResumeToken()); err != nil {
 			return err
 		}
 
@@ -325,6 +341,44 @@ func (c *capture) tryStream(
 	c.mu.Lock()
 	c.state.DatabaseResumeTokens[s.db] = tok
 	c.mu.Unlock()
+
+	return nil
+}
+
+type splitEvent struct {
+	Fragment int `bson:"fragment"`
+	Of       int `bson:"of"`
+}
+
+func readFragments(
+	ctx context.Context,
+	s changeStream,
+	ev *changeEvent,
+) error {
+	// Fragments are repeatedly unmarshalled into a single change event since no
+	// two fragments have overlapping top-level properties - MongoDB only splits
+	// on top-level document fields.
+	lastFragment := 0
+	for {
+		// Upon entering this loop, the change stream must already have been
+		// advanced to a split change event. For the duration of the loop it is
+		// an error if an event is not split, since we only want to read to
+		// "end" of the current set of fragments.
+		var se splitEvent
+		if splitRaw, err := s.ms.Current.LookupErr("splitEvent"); err != nil {
+			return fmt.Errorf("finding splitEvent in document fragment: %w", err)
+		} else if err := splitRaw.Unmarshal(&se); err != nil {
+			return err
+		} else if lastFragment += 1; lastFragment != se.Fragment { // cheap sanity check
+			return fmt.Errorf("expected fragment %d but got %d", lastFragment, se.Fragment)
+		} else if err := s.ms.Decode(ev); err != nil {
+			return fmt.Errorf("decoding fragment: %w", err)
+		} else if se.Fragment == se.Of { // done reading fragments
+			break
+		} else if !s.ms.Next(ctx) { // advance to the next fragment, blocking until it is available (note: TryNext cannot be used)
+			return fmt.Errorf("advancing change stream: %w", s.ms.Err())
+		}
+	}
 
 	return nil
 }

--- a/source-mongodb/main_test.go
+++ b/source-mongodb/main_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/url"
 	"regexp"
+	"strings"
 	"testing"
 	"time"
 
@@ -14,6 +15,8 @@ import (
 	"github.com/estuary/flow/go/protocols/flow"
 	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo/options"
 )
 
 func TestCapture(t *testing.T) {
@@ -101,6 +104,95 @@ func TestCapture(t *testing.T) {
 	updateData(ctx, t, client, database2, col3, binaryPkVals(1), "forthColumn_new")
 
 	advanceCapture(ctx, t, cs)
+
+	cupaloy.SnapshotT(t, cs.Summary())
+}
+
+func TestCaptureSplitLargeDocuments(t *testing.T) {
+	database := "testDb"
+	col := "testCollection"
+
+	ctx := context.Background()
+	client, cfg := testClient(t)
+
+	cleanup := func() {
+		dropCollection(ctx, t, client, database, col)
+	}
+	cleanup()
+	t.Cleanup(cleanup)
+
+	require.NoError(t, client.Database(database).CreateCollection(ctx, col, &options.CreateCollectionOptions{ChangeStreamPreAndPostImages: bson.D{{Key: "enabled", Value: true}}}))
+
+	cs := &st.CaptureSpec{
+		Driver:       &driver{},
+		EndpointSpec: &cfg,
+		Checkpoint:   []byte("{}"),
+		Validator:    &st.OrderedCaptureValidator{},
+		Sanitizers:   commonSanitizers(),
+		Bindings:     []*flow.CaptureSpec_Binding{makeBinding(t, database, col)},
+	}
+
+	collection := client.Database(database).Collection(col)
+
+	// Do the initial backfill to get into "streaming mode" to start capturing changes.
+	advanceCapture(ctx, t, cs)
+
+	// Insert a small document and update it.
+	val := map[string]string{"_id": "smallDocument", "foo": "bar", "baz": "qux"}
+	_, err := collection.InsertOne(ctx, val)
+	require.NoError(t, err)
+	val["foo"] = "bar_updated"
+	res, err := collection.UpdateOne(ctx, bson.D{{Key: "_id", Value: val["_id"]}}, bson.D{{Key: "$set", Value: val}})
+	require.NoError(t, err)
+	require.Equal(t, 1, int(res.ModifiedCount))
+
+	// Insert a huge document and update it. The output sanitizers will replace
+	// the very long values with `<TOKEN>` based on the simple token
+	// sanitization logic.
+	val = map[string]string{
+		"_id":  "hugeDocument",
+		"key1": strings.Repeat("value1", 200000),
+		"key2": strings.Repeat("value2", 200000),
+		"key3": strings.Repeat("value3", 200000),
+		"key4": strings.Repeat("value4", 200000),
+		"key5": strings.Repeat("value5", 200000),
+		"key6": strings.Repeat("value6", 200000),
+		"key7": strings.Repeat("value7", 200000),
+		"key8": strings.Repeat("value8", 200000),
+		"key9": strings.Repeat("value9", 200000),
+	}
+	_, err = collection.InsertOne(ctx, val)
+	require.NoError(t, err)
+	val["key1"] = "updated"
+	val["key9"] = "also updated"
+	res, err = collection.UpdateOne(ctx, bson.D{{Key: "_id", Value: val["_id"]}}, bson.D{{Key: "$set", Value: val}})
+	require.NoError(t, err)
+	require.Equal(t, 1, int(res.ModifiedCount))
+
+	// Another small document.
+	val = map[string]string{"_id": "otherSmallDocument", "some": "other", "values": "here"}
+	_, err = collection.InsertOne(ctx, val)
+	require.NoError(t, err)
+	val["some"] = "other_updated"
+	res, err = collection.UpdateOne(ctx, bson.D{{Key: "_id", Value: val["_id"]}}, bson.D{{Key: "$set", Value: val}})
+	require.NoError(t, err)
+	require.Equal(t, 1, int(res.ModifiedCount))
+
+	// Read change stream documents, waiting until we have received all 6
+	// expected change stream documents, not counting checkpoints. Reading the
+	// huge document and its updates from the change stream takes a non-trivial
+	// amount of time.
+	count := 0
+	captureCtx, cancel := context.WithCancel(context.Background())
+	time.AfterFunc(5*time.Second, cancel) // don't wait forever though
+	cs.Capture(captureCtx, t, func(msg json.RawMessage) {
+		if !strings.Contains(string(msg), "bindingStateV1") {
+			count++
+		}
+		if count == 6 {
+			cancel()
+		}
+	})
 
 	cupaloy.SnapshotT(t, cs.Summary())
 }

--- a/source-mongodb/pull.go
+++ b/source-mongodb/pull.go
@@ -2,8 +2,10 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math"
+	"strings"
 	"sync"
 	"time"
 
@@ -79,20 +81,14 @@ func (d *driver) Pull(open *pc.Request_Open, stream *boilerplate.PullOutput) err
 
 	log.Info("connected to database")
 
-	// Log some basic information about the database we are connected to if possible. buildInfo is
-	// an administrator command so it may not be available on all databases / configurations.
-	requestPreImages := false
-	if info, err := getBuildInfo(ctx, client); err != nil {
-		log.WithError(err).Info("could not query buildInfo")
-	} else {
-		log.WithFields(log.Fields{
-			"version": info.Version,
-		}).Info("buildInfo")
-		requestPreImages = info.supportsPreImages()
+	// Log some basic information about the database we are connected to. Even
+	// though this is an "admin" command, it always works with valid
+	// credentials, regardless of the user's actual permissions.
+	info, err := getBuildInfo(ctx, client)
+	if err != nil {
+		return fmt.Errorf("could not query buildInfo: %w", err)
 	}
-	if !requestPreImages {
-		log.Info("pre-images will not be requested for change streams")
-	}
+	log.WithFields(log.Fields{"version": info.Version}).Info("buildInfo")
 
 	var prevState captureState
 	if err := pf.UnmarshalStrict(open.StateJson, &prevState); err != nil {
@@ -122,6 +118,16 @@ func (d *driver) Pull(open *pc.Request_Open, stream *boilerplate.PullOutput) err
 		return fmt.Errorf("marshalling prevState checkpoint: %w", err)
 	} else if err := c.output.Checkpoint(checkpointJson, false); err != nil {
 		return fmt.Errorf("outputting prevState checkpoint: %w", err)
+	}
+
+	if len(bindings) == 0 {
+		// No bindings to capture.
+		return nil
+	}
+
+	requestPreImages, err := supportsPreImages(ctx, info, bindings[0].resource.Database, client)
+	if err != nil {
+		return fmt.Errorf("checking if server supports pre-images: %w", err)
 	}
 
 	didBackfill := false
@@ -322,23 +328,6 @@ type buildInfo struct {
 	VersionArray []int  `bson:"versionArray"`
 }
 
-// supportsPreImages returns true if the server supports pre-images, which is
-// really a proxy for it supporting the $changeStreamSplitLargeEvent pipeline
-// staged which was introduced in 6.0.9 and 7.0.0+. Pre-images were technically
-// supported starting in 6.0, but since we may need to use
-// $changeStreamSplitLargeEvent to handle resulting event documents larger than
-// 16MB we only support them if we're on 6.0.9 or later.
-func (b buildInfo) supportsPreImages() bool {
-	if len(b.VersionArray) < 3 {
-		return false
-	}
-
-	major := b.VersionArray[0]
-	minor := b.VersionArray[1]
-	patch := b.VersionArray[2]
-	return major >= 7 || (major == 6 && patch >= 9) || (major == 6 && minor >= 1)
-}
-
 func getBuildInfo(ctx context.Context, client *mongo.Client) (buildInfo, error) {
 	var info buildInfo
 	if res := client.Database("admin").RunCommand(ctx, bson.D{{"buildInfo", 1}}); res.Err() != nil {
@@ -348,4 +337,56 @@ func getBuildInfo(ctx context.Context, client *mongo.Client) (buildInfo, error) 
 	} else {
 		return info, nil
 	}
+}
+
+// supportsPreImages returns true if the server supports pre-images. To support
+// pre-images, the server must be a sufficiently recent version, and it must
+// support the $changeStreamSplitLargeEvent pipeline stage that is required to
+// split large change event documents that may arise from including the
+// pre-image for updates to large documents.
+//
+// Support for the $changeStreamSplitLargeEvent pipeline stage was added in
+// version 6.0.9 and 7.0.0+, so that's the first thing we check. Some versions
+// of MongoDB Atlas also do not support the $changeStreamSplitLargeEvent
+// pipeline stage, and the only way to know if we are connecting to one of those
+// short of using the MongoDB Atlas admin API (which requires a separate API
+// key) is to just try opening a change stream with the option enabled and
+// seeing if it works or not.
+func supportsPreImages(ctx context.Context, b buildInfo, database string, client *mongo.Client) (bool, error) {
+	ll := log.WithField("version", b.Version)
+
+	if len(b.VersionArray) < 3 {
+		ll.WithField("VersionArray", b.VersionArray).Info("not requesting pre-images due to insufficient version information")
+		return false, nil
+	}
+
+	major := b.VersionArray[0]
+	minor := b.VersionArray[1]
+	patch := b.VersionArray[2]
+	sufficientVersion := major >= 7 || (major == 6 && patch >= 9) || (major == 6 && minor >= 1)
+
+	if !sufficientVersion {
+		ll.Info("not requesting pre-images because this MongoDB server version is too old")
+		return false, nil
+	}
+
+	// Try opening a change stream with the $changeStreamSplitLargeEvent
+	// pipeline stage.
+	cs, err := client.Database(database).Watch(ctx, mongo.Pipeline{bson.D{{Key: "$changeStreamSplitLargeEvent", Value: bson.D{}}}})
+	if err != nil {
+		var commandError mongo.CommandError
+		if errors.As(err, &commandError) {
+			if commandError.Name == "AtlasError" && strings.HasPrefix(commandError.Message, "$changeStreamSplitLargeEvent is not allowed") {
+				ll.WithField("atlasError", err).Info("not requesting pre-images because this MongoDB Atlas instance does not support the $changeStreamSplitLargeEvent stage")
+				return false, nil
+			}
+		}
+		return false, fmt.Errorf("opening change stream to test for $changeStreamSplitLargeEvent support: %w", err)
+	}
+
+	if err := cs.Close(ctx); err != nil {
+		return false, fmt.Errorf("closing change stream: %w", err)
+	}
+
+	return true, nil
 }


### PR DESCRIPTION
**Description:**

This is a modification to the way we check for pre-image support, and a re-application of the commit https://github.com/estuary/connectors/commit/5f66809a67e39f53a73030069fd081e4382f3e5a where the `$changeStreamSplitLargeEvent` pipeline stage was added.

The problem from that initial attempt was that the split event pipeline stage is not supported on somewhat-commonly used versions of MongoDB Atlas. Unfortunately there's no way to know if we are connected to one of those or not without just trying to create a change stream with that pipeline stage enabled.

The first commit here updates the check for pre-image support (which by extension is checking for support of `$changeStreamSplitLargeEvent`) to verify that the split event stage works by trying to create a change stream with it enabled and examining the error if there is one. The second commit is the re-application of https://github.com/estuary/connectors/commit/5f66809a67e39f53a73030069fd081e4382f3e5a, which should now work without causing existing tasks that don't support the split event stage to fail.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1760)
<!-- Reviewable:end -->
