### PR TITLE
source-postgres: Fix `NaN` value of `NUMERIC` column

### DIFF
--- a/source-postgres/datatype_test.go
+++ b/source-postgres/datatype_test.go
@@ -34,6 +34,8 @@ func TestDatatypes(t *testing.T) {
 
 		{ColumnType: `decimal`, ExpectType: `{"type":["string","null"],"format":"number"}`, InputValue: `123.456`, ExpectValue: `"123.456"`},
 		{ColumnType: `numeric`, ExpectType: `{"type":["string","null"],"format":"number"}`, InputValue: `123.456`, ExpectValue: `"123.456"`},
+		{ColumnType: `numeric`, ExpectType: `{"type":["string","null"],"format":"number"}`, InputValue: `NaN`, ExpectValue: `"NaN"`},
+		{ColumnType: `numeric`, ExpectType: `{"type":["string","null"],"format":"number"}`, InputValue: `-infinity`, ExpectValue: `"-Infinity"`},
 		{ColumnType: `numeric(4,2)`, ExpectType: `{"type":["string","null"],"format":"number"}`, InputValue: `12.34`, ExpectValue: `"12.34"`},
 		{ColumnType: `character varying(10)`, ExpectType: `{"type":["string","null"]}`, InputValue: `foo`, ExpectValue: `"foo"`},
 		{ColumnType: `varchar(10)`, ExpectType: `{"type":["string","null"]}`, InputValue: `foo`, ExpectValue: `"foo"`},

--- a/source-postgres/datatypes.go
+++ b/source-postgres/datatypes.go
@@ -259,14 +259,7 @@ func translateRecordField(column *sqlcapture.ColumnInfo, val interface{}) (inter
 	case pgtype.Time:
 		return x.Microseconds, nil // For historical reasons, times (note: not timestamps) without time zone are serialized as Unix microseconds
 	case pgtype.Numeric:
-		// By default a Numeric value is marshalled to a JSON number, but most JSON parsers and
-		// encoders suffer from precision issues so we really want them to be turned into a JSON
-		// string containing the formatted number instead.
-		var bs, err = json.Marshal(x)
-		if err != nil {
-			return nil, err
-		}
-		return string(bs), nil
+		return x.Value() // Happily the stringified representations of "NaN", "Infinity", and "-Infinity" exactly match what we need
 	case pgtype.Bits:
 		return x.Value() // The Value() method encodes to the desired "0101" text string
 	case pgtype.Interval:


### PR DESCRIPTION
**Description:**

This was broken in the PGX v5 upgrade and not caught because we didn't have a test case for `NaN` values in `NUMERIC` columns.

This commit adds such a test and fixes the translation logic so that it works correctly. I'm not entirely sure why I went with such a convoluted mechanism for producing a numeric string before when it turns out that `x.Value()` works exactly as we'd want, but whatever.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1763)
<!-- Reviewable:end -->
