### PR TITLE
materialize-postgres: override statement_timeout to never timeout

### DIFF
--- a/materialize-postgres/driver.go
+++ b/materialize-postgres/driver.go
@@ -253,6 +253,14 @@ func newTransactor(
 		return nil, fmt.Errorf("store pgx.Connect: %w", err)
 	}
 
+	// Override statement_timeout with a session-level setting to never timeout
+	// statements.
+	if _, err := d.load.conn.Exec(ctx, "set statement_timeout = 0;"); err != nil {
+		return nil, fmt.Errorf("load set statement_timeout: %w", err)
+	} else if _, err := d.store.conn.Exec(ctx, "set statement_timeout = 0;"); err != nil {
+		return nil, fmt.Errorf("store set statement_timeout: %w", err)
+	}
+
 	for _, binding := range bindings {
 		if err = d.addBinding(ctx, binding); err != nil {
 			return nil, fmt.Errorf("addBinding of %s: %w", binding.Path, err)


### PR DESCRIPTION
**Description:**

For both the load and store connections, run a `set statement_timeout = 0;` statement to prevent our statements from timing out if a different default timeout is set.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1764)
<!-- Reviewable:end -->
