### PR TITLE
source-postgres: LSN commit logging tweaks

### DIFF
--- a/sqlcapture/capture.go
+++ b/sqlcapture/capture.go
@@ -823,7 +823,10 @@ func (c *Capture) handleAcknowledgement(ctx context.Context, count int, replStre
 
 	var cursor = c.pending.cursors[count-1]
 	c.pending.cursors = c.pending.cursors[count:]
-	logrus.WithField("cursor", cursor).Trace("acknowledged up to cursor")
+	logrus.WithFields(logrus.Fields{
+		"count":  count,
+		"cursor": cursor,
+	}).Debug("acknowledged up to cursor")
 	replStream.Acknowledge(ctx, cursor)
 	return nil
 }


### PR DESCRIPTION
**Description:**

Hopefully this will be enough to show us what, if anything, is going wrong in rare cases to cause the 'confirmed_flush_lsn is greater than resume LSN' warning to fire.

The most important thing here is the introduction of a new INFO level debug message which will output the confirmed LSN immediately before we send it to the server in a "Standby Status Update", if it's different from the previous update. Since we send these updates every 10 seconds this could be moderately spammy, producing up to 6 log messages each minute where previously our steady-state streaming behavior was to emit 2 log messages each minute, a 4x increase. But I think it's worth doing that temporarily across the board so we can actually be 100% certain, the next time we see that warning trigger, whether we had actually sent a confirmation with that value. Once this debugging is all done this message will probably be lowered back to DEBUG level.

There are also a couple of other tweaks to the DEBUG level logging which should make it a bit easier to see what the actual Flow acknowledgement pattern looks like if I dig into a specific task more deeply, but I think that would be much too spammy to have on by default.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1767)
<!-- Reviewable:end -->
