### PR TITLE
sqlcapture: Add source column type information to JSON schemas

### DIFF
--- a/source-mysql/.snapshots/TestAlterTable_AddEnumColumn-discover1
+++ b/source-mysql/.snapshots/TestAlterTable_AddEnumColumn-discover1
@@ -15,13 +15,15 @@ Binding 0:
           "$anchor": "TestAlterTable_AddEnumColumn_30213486",
           "properties": {
             "data": {
+              "description": "(source type: text)",
               "type": [
                 "string",
                 "null"
               ]
             },
             "id": {
-              "type": "integer"
+              "type": "integer",
+              "description": "(source type: non-nullable int)"
             }
           }
         }

--- a/source-mysql/.snapshots/TestAlterTable_AddEnumColumn-discover2
+++ b/source-mysql/.snapshots/TestAlterTable_AddEnumColumn-discover2
@@ -15,12 +15,14 @@ Binding 0:
           "$anchor": "TestAlterTable_AddEnumColumn_30213486",
           "properties": {
             "data": {
+              "description": "(source type: text)",
               "type": [
                 "string",
                 "null"
               ]
             },
             "enumcol": {
+              "description": "(source type: enum)",
               "enum": [
                 "",
                 "sm",
@@ -34,7 +36,8 @@ Binding 0:
               ]
             },
             "id": {
-              "type": "integer"
+              "type": "integer",
+              "description": "(source type: non-nullable int)"
             }
           }
         }

--- a/source-mysql/.snapshots/TestAlterTable_AddUnsignedColumn-discover1
+++ b/source-mysql/.snapshots/TestAlterTable_AddUnsignedColumn-discover1
@@ -15,13 +15,15 @@ Binding 0:
           "$anchor": "TestAlterTable_AddUnsignedColumn_57413089",
           "properties": {
             "data": {
+              "description": "(source type: text)",
               "type": [
                 "string",
                 "null"
               ]
             },
             "id": {
-              "type": "integer"
+              "type": "integer",
+              "description": "(source type: non-nullable int)"
             }
           }
         }

--- a/source-mysql/.snapshots/TestAlterTable_AddUnsignedColumn-discover2
+++ b/source-mysql/.snapshots/TestAlterTable_AddUnsignedColumn-discover2
@@ -15,15 +15,18 @@ Binding 0:
           "$anchor": "TestAlterTable_AddUnsignedColumn_57413089",
           "properties": {
             "data": {
+              "description": "(source type: text)",
               "type": [
                 "string",
                 "null"
               ]
             },
             "id": {
-              "type": "integer"
+              "type": "integer",
+              "description": "(source type: non-nullable int)"
             },
             "uintval": {
+              "description": "(source type: bigint unsigned)",
               "type": [
                 "integer",
                 "null"

--- a/source-mysql/.snapshots/TestEmptyBlobs-Discovery
+++ b/source-mysql/.snapshots/TestEmptyBlobs-Discovery
@@ -16,13 +16,16 @@ Binding 0:
           "properties": {
             "a_varbinary": {
               "type": "string",
+              "description": "(source type: non-nullable varbinary)",
               "contentEncoding": "base64"
             },
             "a_varchar": {
-              "type": "string"
+              "type": "string",
+              "description": "(source type: non-nullable varchar)"
             },
             "id": {
-              "type": "integer"
+              "type": "integer",
+              "description": "(source type: non-nullable int)"
             }
           }
         }

--- a/source-mysql/.snapshots/TestEnumDecodingFix-discovery
+++ b/source-mysql/.snapshots/TestEnumDecodingFix-discovery
@@ -1,0 +1,138 @@
+Binding 0:
+{
+    "recommended_name": "test_enumdecodingfix_32314857",
+    "resource_config_json": {
+      "namespace": "test",
+      "stream": "EnumDecodingFix_32314857"
+    },
+    "document_schema_json": {
+      "$defs": {
+        "TestEnumDecodingFix_32314857": {
+          "type": "object",
+          "required": [
+            "id"
+          ],
+          "$anchor": "TestEnumDecodingFix_32314857",
+          "properties": {
+            "category": {
+              "enum": [
+                "",
+                "A",
+                "C",
+                "B",
+                "D",
+                null
+              ],
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "id": {
+              "type": "integer"
+            }
+          }
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "_meta": {
+                "properties": {
+                  "op": {
+                    "const": "d"
+                  }
+                }
+              }
+            }
+          },
+          "then": {
+            "reduce": {
+              "delete": true,
+              "strategy": "merge"
+            }
+          },
+          "else": {
+            "reduce": {
+              "strategy": "merge"
+            }
+          },
+          "required": [
+            "_meta"
+          ],
+          "properties": {
+            "_meta": {
+              "type": "object",
+              "required": [
+                "op",
+                "source"
+              ],
+              "properties": {
+                "before": {
+                  "$ref": "#TestEnumDecodingFix_32314857",
+                  "description": "Record state immediately before this change was applied.",
+                  "reduce": {
+                    "strategy": "firstWriteWins"
+                  }
+                },
+                "op": {
+                  "enum": [
+                    "c",
+                    "d",
+                    "u"
+                  ],
+                  "description": "Change operation type: 'c' Create/Insert, 'u' Update, 'd' Delete."
+                },
+                "source": {
+                  "$id": "https://github.com/estuary/connectors/source-mysql/mysql-source-info",
+                  "properties": {
+                    "ts_ms": {
+                      "type": "integer",
+                      "description": "Unix timestamp (in millis) at which this event was recorded by the database."
+                    },
+                    "schema": {
+                      "type": "string",
+                      "description": "Database schema (namespace) of the event."
+                    },
+                    "snapshot": {
+                      "type": "boolean",
+                      "description": "Snapshot is true if the record was produced from an initial table backfill and unset if produced from the replication log."
+                    },
+                    "table": {
+                      "type": "string",
+                      "description": "Database table of the event."
+                    },
+                    "cursor": {
+                      "type": "string",
+                      "description": "Cursor value representing the current position in the binlog."
+                    },
+                    "txid": {
+                      "type": "string",
+                      "description": "The global transaction identifier associated with a change by MySQL. Only set if GTIDs are enabled."
+                    }
+                  },
+                  "type": "object",
+                  "required": [
+                    "schema",
+                    "table",
+                    "cursor"
+                  ]
+                }
+              },
+              "reduce": {
+                "strategy": "merge"
+              }
+            }
+          }
+        },
+        {
+          "$ref": "#TestEnumDecodingFix_32314857"
+        }
+      ]
+    },
+    "key": [
+      "/id"
+    ]
+  }
+

--- a/source-mysql/.snapshots/TestEnumDecodingFix-discovery
+++ b/source-mysql/.snapshots/TestEnumDecodingFix-discovery
@@ -15,6 +15,7 @@ Binding 0:
           "$anchor": "TestEnumDecodingFix_32314857",
           "properties": {
             "category": {
+              "description": "(source type: enum)",
               "enum": [
                 "",
                 "A",
@@ -29,7 +30,8 @@ Binding 0:
               ]
             },
             "id": {
-              "type": "integer"
+              "type": "integer",
+              "description": "(source type: non-nullable int)"
             }
           }
         }

--- a/source-mysql/.snapshots/TestEnumEmptyString-discovery
+++ b/source-mysql/.snapshots/TestEnumEmptyString-discovery
@@ -15,6 +15,7 @@ Binding 0:
           "$anchor": "TestEnumEmptyString_29144777",
           "properties": {
             "category": {
+              "description": "(source type: enum)",
               "enum": [
                 "",
                 "",
@@ -29,7 +30,8 @@ Binding 0:
               ]
             },
             "id": {
-              "type": "integer"
+              "type": "integer",
+              "description": "(source type: non-nullable int)"
             }
           }
         }

--- a/source-mysql/.snapshots/TestEnumEmptyString-discovery
+++ b/source-mysql/.snapshots/TestEnumEmptyString-discovery
@@ -1,0 +1,138 @@
+Binding 0:
+{
+    "recommended_name": "test_enumemptystring_29144777",
+    "resource_config_json": {
+      "namespace": "test",
+      "stream": "EnumEmptyString_29144777"
+    },
+    "document_schema_json": {
+      "$defs": {
+        "TestEnumEmptyString_29144777": {
+          "type": "object",
+          "required": [
+            "id"
+          ],
+          "$anchor": "TestEnumEmptyString_29144777",
+          "properties": {
+            "category": {
+              "enum": [
+                "",
+                "",
+                "A",
+                "B",
+                "C",
+                null
+              ],
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "id": {
+              "type": "integer"
+            }
+          }
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "_meta": {
+                "properties": {
+                  "op": {
+                    "const": "d"
+                  }
+                }
+              }
+            }
+          },
+          "then": {
+            "reduce": {
+              "delete": true,
+              "strategy": "merge"
+            }
+          },
+          "else": {
+            "reduce": {
+              "strategy": "merge"
+            }
+          },
+          "required": [
+            "_meta"
+          ],
+          "properties": {
+            "_meta": {
+              "type": "object",
+              "required": [
+                "op",
+                "source"
+              ],
+              "properties": {
+                "before": {
+                  "$ref": "#TestEnumEmptyString_29144777",
+                  "description": "Record state immediately before this change was applied.",
+                  "reduce": {
+                    "strategy": "firstWriteWins"
+                  }
+                },
+                "op": {
+                  "enum": [
+                    "c",
+                    "d",
+                    "u"
+                  ],
+                  "description": "Change operation type: 'c' Create/Insert, 'u' Update, 'd' Delete."
+                },
+                "source": {
+                  "$id": "https://github.com/estuary/connectors/source-mysql/mysql-source-info",
+                  "properties": {
+                    "ts_ms": {
+                      "type": "integer",
+                      "description": "Unix timestamp (in millis) at which this event was recorded by the database."
+                    },
+                    "schema": {
+                      "type": "string",
+                      "description": "Database schema (namespace) of the event."
+                    },
+                    "snapshot": {
+                      "type": "boolean",
+                      "description": "Snapshot is true if the record was produced from an initial table backfill and unset if produced from the replication log."
+                    },
+                    "table": {
+                      "type": "string",
+                      "description": "Database table of the event."
+                    },
+                    "cursor": {
+                      "type": "string",
+                      "description": "Cursor value representing the current position in the binlog."
+                    },
+                    "txid": {
+                      "type": "string",
+                      "description": "The global transaction identifier associated with a change by MySQL. Only set if GTIDs are enabled."
+                    }
+                  },
+                  "type": "object",
+                  "required": [
+                    "schema",
+                    "table",
+                    "cursor"
+                  ]
+                }
+              },
+              "reduce": {
+                "strategy": "merge"
+              }
+            }
+          }
+        },
+        {
+          "$ref": "#TestEnumEmptyString_29144777"
+        }
+      ]
+    },
+    "key": [
+      "/id"
+    ]
+  }
+

--- a/source-mysql/.snapshots/TestEnumPrimaryKey-discovery
+++ b/source-mysql/.snapshots/TestEnumPrimaryKey-discovery
@@ -17,6 +17,7 @@ Binding 0:
           "properties": {
             "category": {
               "type": "string",
+              "description": "(source type: non-nullable enum)",
               "enum": [
                 "",
                 "A",
@@ -26,13 +27,15 @@ Binding 0:
               ]
             },
             "data": {
+              "description": "(source type: text)",
               "type": [
                 "string",
                 "null"
               ]
             },
             "id": {
-              "type": "integer"
+              "type": "integer",
+              "description": "(source type: non-nullable int)"
             }
           }
         }

--- a/source-mysql/.snapshots/TestEnumPrimaryKey-discovery
+++ b/source-mysql/.snapshots/TestEnumPrimaryKey-discovery
@@ -1,0 +1,142 @@
+Binding 0:
+{
+    "recommended_name": "test_enumprimarykey_18676708",
+    "resource_config_json": {
+      "namespace": "test",
+      "stream": "EnumPrimaryKey_18676708"
+    },
+    "document_schema_json": {
+      "$defs": {
+        "TestEnumPrimaryKey_18676708": {
+          "type": "object",
+          "required": [
+            "category",
+            "id"
+          ],
+          "$anchor": "TestEnumPrimaryKey_18676708",
+          "properties": {
+            "category": {
+              "type": "string",
+              "enum": [
+                "",
+                "A",
+                "C",
+                "B",
+                "D"
+              ]
+            },
+            "data": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "id": {
+              "type": "integer"
+            }
+          }
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "_meta": {
+                "properties": {
+                  "op": {
+                    "const": "d"
+                  }
+                }
+              }
+            }
+          },
+          "then": {
+            "reduce": {
+              "delete": true,
+              "strategy": "merge"
+            }
+          },
+          "else": {
+            "reduce": {
+              "strategy": "merge"
+            }
+          },
+          "required": [
+            "_meta"
+          ],
+          "properties": {
+            "_meta": {
+              "type": "object",
+              "required": [
+                "op",
+                "source"
+              ],
+              "properties": {
+                "before": {
+                  "$ref": "#TestEnumPrimaryKey_18676708",
+                  "description": "Record state immediately before this change was applied.",
+                  "reduce": {
+                    "strategy": "firstWriteWins"
+                  }
+                },
+                "op": {
+                  "enum": [
+                    "c",
+                    "d",
+                    "u"
+                  ],
+                  "description": "Change operation type: 'c' Create/Insert, 'u' Update, 'd' Delete."
+                },
+                "source": {
+                  "$id": "https://github.com/estuary/connectors/source-mysql/mysql-source-info",
+                  "properties": {
+                    "ts_ms": {
+                      "type": "integer",
+                      "description": "Unix timestamp (in millis) at which this event was recorded by the database."
+                    },
+                    "schema": {
+                      "type": "string",
+                      "description": "Database schema (namespace) of the event."
+                    },
+                    "snapshot": {
+                      "type": "boolean",
+                      "description": "Snapshot is true if the record was produced from an initial table backfill and unset if produced from the replication log."
+                    },
+                    "table": {
+                      "type": "string",
+                      "description": "Database table of the event."
+                    },
+                    "cursor": {
+                      "type": "string",
+                      "description": "Cursor value representing the current position in the binlog."
+                    },
+                    "txid": {
+                      "type": "string",
+                      "description": "The global transaction identifier associated with a change by MySQL. Only set if GTIDs are enabled."
+                    }
+                  },
+                  "type": "object",
+                  "required": [
+                    "schema",
+                    "table",
+                    "cursor"
+                  ]
+                }
+              },
+              "reduce": {
+                "strategy": "merge"
+              }
+            }
+          }
+        },
+        {
+          "$ref": "#TestEnumPrimaryKey_18676708"
+        }
+      ]
+    },
+    "key": [
+      "/category",
+      "/id"
+    ]
+  }
+

--- a/source-mysql/.snapshots/TestGeneric-KeylessDiscovery
+++ b/source-mysql/.snapshots/TestGeneric-KeylessDiscovery
@@ -13,21 +13,25 @@ Binding 0:
           "$anchor": "TestGeneric_KeylessDiscovery_t32386",
           "properties": {
             "a": {
+              "description": "(source type: int)",
               "type": [
                 "integer",
                 "null"
               ]
             },
             "b": {
+              "description": "(source type: text)",
               "type": [
                 "string",
                 "null"
               ]
             },
             "c": {
-              "type": "number"
+              "type": "number",
+              "description": "(source type: non-nullable double)"
             },
             "d": {
+              "description": "(source type: varchar)",
               "type": [
                 "string",
                 "null"

--- a/source-mysql/.snapshots/TestGeneric-SimpleDiscovery
+++ b/source-mysql/.snapshots/TestGeneric-SimpleDiscovery
@@ -15,18 +15,22 @@ Binding 0:
           "$anchor": "TestGeneric_SimpleDiscovery_49210954",
           "properties": {
             "a": {
-              "type": "integer"
+              "type": "integer",
+              "description": "(source type: non-nullable int)"
             },
             "b": {
+              "description": "(source type: text)",
               "type": [
                 "string",
                 "null"
               ]
             },
             "c": {
-              "type": "number"
+              "type": "number",
+              "description": "(source type: non-nullable double)"
             },
             "d": {
+              "description": "(source type: varchar)",
               "type": [
                 "string",
                 "null"

--- a/source-mysql/.snapshots/TestPartitionedTable-Discovery
+++ b/source-mysql/.snapshots/TestPartitionedTable-Discovery
@@ -16,16 +16,19 @@ Binding 0:
           "$anchor": "TestPartitionedTable_83812828",
           "properties": {
             "data": {
+              "description": "(source type: text)",
               "type": [
                 "string",
                 "null"
               ]
             },
             "grp": {
-              "type": "integer"
+              "type": "integer",
+              "description": "(source type: non-nullable int)"
             },
             "id": {
-              "type": "integer"
+              "type": "integer",
+              "description": "(source type: non-nullable int)"
             }
           }
         }

--- a/source-mysql/.snapshots/TestSecondaryIndexDiscovery-index_and_fk
+++ b/source-mysql/.snapshots/TestSecondaryIndexDiscovery-index_and_fk
@@ -15,9 +15,11 @@ Binding 0:
           "$anchor": "TestSecondaryIndexDiscovery_index_and_fk_g16025",
           "properties": {
             "id": {
-              "type": "integer"
+              "type": "integer",
+              "description": "(source type: non-nullable int)"
             },
             "parent_id": {
+              "description": "(source type: int)",
               "type": [
                 "integer",
                 "null"

--- a/source-mysql/.snapshots/TestSecondaryIndexDiscovery-index_only
+++ b/source-mysql/.snapshots/TestSecondaryIndexDiscovery-index_only
@@ -16,22 +16,26 @@ Binding 0:
           "$anchor": "TestSecondaryIndexDiscovery_index_only_g26313",
           "properties": {
             "data": {
+              "description": "(source type: text)",
               "type": [
                 "string",
                 "null"
               ]
             },
             "k1": {
+              "description": "(source type: int)",
               "type": [
                 "integer",
                 "null"
               ]
             },
             "k2": {
-              "type": "integer"
+              "type": "integer",
+              "description": "(source type: non-nullable int)"
             },
             "k3": {
-              "type": "integer"
+              "type": "integer",
+              "description": "(source type: non-nullable int)"
             }
           }
         }

--- a/source-mysql/.snapshots/TestSecondaryIndexDiscovery-nonunique_index
+++ b/source-mysql/.snapshots/TestSecondaryIndexDiscovery-nonunique_index
@@ -13,22 +13,26 @@ Binding 0:
           "$anchor": "TestSecondaryIndexDiscovery_nonunique_index_g22906",
           "properties": {
             "data": {
+              "description": "(source type: text)",
               "type": [
                 "string",
                 "null"
               ]
             },
             "k1": {
+              "description": "(source type: int)",
               "type": [
                 "integer",
                 "null"
               ]
             },
             "k2": {
-              "type": "integer"
+              "type": "integer",
+              "description": "(source type: non-nullable int)"
             },
             "k3": {
-              "type": "integer"
+              "type": "integer",
+              "description": "(source type: non-nullable int)"
             }
           }
         }

--- a/source-mysql/.snapshots/TestSecondaryIndexDiscovery-nothing
+++ b/source-mysql/.snapshots/TestSecondaryIndexDiscovery-nothing
@@ -13,22 +13,26 @@ Binding 0:
           "$anchor": "TestSecondaryIndexDiscovery_nothing_g14307",
           "properties": {
             "data": {
+              "description": "(source type: text)",
               "type": [
                 "string",
                 "null"
               ]
             },
             "k1": {
+              "description": "(source type: int)",
               "type": [
                 "integer",
                 "null"
               ]
             },
             "k2": {
-              "type": "integer"
+              "type": "integer",
+              "description": "(source type: non-nullable int)"
             },
             "k3": {
-              "type": "integer"
+              "type": "integer",
+              "description": "(source type: non-nullable int)"
             }
           }
         }

--- a/source-mysql/.snapshots/TestSecondaryIndexDiscovery-nullable_index
+++ b/source-mysql/.snapshots/TestSecondaryIndexDiscovery-nullable_index
@@ -13,24 +13,28 @@ Binding 0:
           "$anchor": "TestSecondaryIndexDiscovery_nullable_index_g31990",
           "properties": {
             "data": {
+              "description": "(source type: text)",
               "type": [
                 "string",
                 "null"
               ]
             },
             "k1": {
+              "description": "(source type: int)",
               "type": [
                 "integer",
                 "null"
               ]
             },
             "k2": {
+              "description": "(source type: int)",
               "type": [
                 "integer",
                 "null"
               ]
             },
             "k3": {
+              "description": "(source type: int)",
               "type": [
                 "integer",
                 "null"

--- a/source-mysql/.snapshots/TestSecondaryIndexDiscovery-pk_and_index
+++ b/source-mysql/.snapshots/TestSecondaryIndexDiscovery-pk_and_index
@@ -15,19 +15,23 @@ Binding 0:
           "$anchor": "TestSecondaryIndexDiscovery_pk_and_index_g14228",
           "properties": {
             "data": {
+              "description": "(source type: text)",
               "type": [
                 "string",
                 "null"
               ]
             },
             "k1": {
-              "type": "integer"
+              "type": "integer",
+              "description": "(source type: non-nullable int)"
             },
             "k2": {
-              "type": "integer"
+              "type": "integer",
+              "description": "(source type: non-nullable int)"
             },
             "k3": {
-              "type": "integer"
+              "type": "integer",
+              "description": "(source type: non-nullable int)"
             }
           }
         }

--- a/source-mysql/.snapshots/TestTrickyColumnNames-discover
+++ b/source-mysql/.snapshots/TestTrickyColumnNames-discover
@@ -15,9 +15,11 @@ Binding 0:
           "$anchor": "TestTrickyColumnNames_14055203",
           "properties": {
             "Meta/`wtf`~ID": {
-              "type": "integer"
+              "type": "integer",
+              "description": "(source type: non-nullable int)"
             },
             "data": {
+              "description": "(source type: text)",
               "type": [
                 "string",
                 "null"
@@ -144,13 +146,15 @@ Binding 1:
           "$anchor": "TestTrickyColumnNames_28395292",
           "properties": {
             "data": {
+              "description": "(source type: text)",
               "type": [
                 "string",
                 "null"
               ]
             },
             "table": {
-              "type": "integer"
+              "type": "integer",
+              "description": "(source type: non-nullable int)"
             }
           }
         }

--- a/source-mysql/.snapshots/TestTrickyTableNames-Discover
+++ b/source-mysql/.snapshots/TestTrickyTableNames-Discover
@@ -15,10 +15,12 @@ Binding 0:
           "$anchor": "TestUsErS!@#$",
           "properties": {
             "data": {
-              "type": "string"
+              "type": "string",
+              "description": "(source type: non-nullable text)"
             },
             "id": {
-              "type": "integer"
+              "type": "integer",
+              "description": "(source type: non-nullable int)"
             }
           }
         }

--- a/source-mysql/.snapshots/TestUnsignedIntegers-discovery
+++ b/source-mysql/.snapshots/TestUnsignedIntegers-discovery
@@ -15,33 +15,39 @@ Binding 0:
           "$anchor": "TestUnsignedIntegers_45511171",
           "properties": {
             "id": {
-              "type": "integer"
+              "type": "integer",
+              "description": "(source type: non-nullable int)"
             },
             "v1": {
+              "description": "(source type: tinyint unsigned)",
               "type": [
                 "integer",
                 "null"
               ]
             },
             "v2": {
+              "description": "(source type: smallint unsigned)",
               "type": [
                 "integer",
                 "null"
               ]
             },
             "v3": {
+              "description": "(source type: mediumint unsigned)",
               "type": [
                 "integer",
                 "null"
               ]
             },
             "v4": {
+              "description": "(source type: int unsigned)",
               "type": [
                 "integer",
                 "null"
               ]
             },
             "v8": {
+              "description": "(source type: bigint unsigned)",
               "type": [
                 "integer",
                 "null"

--- a/source-mysql/.snapshots/TestUnsignedIntegers-discovery
+++ b/source-mysql/.snapshots/TestUnsignedIntegers-discovery
@@ -1,0 +1,154 @@
+Binding 0:
+{
+    "recommended_name": "test_unsignedintegers_45511171",
+    "resource_config_json": {
+      "namespace": "test",
+      "stream": "UnsignedIntegers_45511171"
+    },
+    "document_schema_json": {
+      "$defs": {
+        "TestUnsignedIntegers_45511171": {
+          "type": "object",
+          "required": [
+            "id"
+          ],
+          "$anchor": "TestUnsignedIntegers_45511171",
+          "properties": {
+            "id": {
+              "type": "integer"
+            },
+            "v1": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "v2": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "v3": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "v4": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "v8": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            }
+          }
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "_meta": {
+                "properties": {
+                  "op": {
+                    "const": "d"
+                  }
+                }
+              }
+            }
+          },
+          "then": {
+            "reduce": {
+              "delete": true,
+              "strategy": "merge"
+            }
+          },
+          "else": {
+            "reduce": {
+              "strategy": "merge"
+            }
+          },
+          "required": [
+            "_meta"
+          ],
+          "properties": {
+            "_meta": {
+              "type": "object",
+              "required": [
+                "op",
+                "source"
+              ],
+              "properties": {
+                "before": {
+                  "$ref": "#TestUnsignedIntegers_45511171",
+                  "description": "Record state immediately before this change was applied.",
+                  "reduce": {
+                    "strategy": "firstWriteWins"
+                  }
+                },
+                "op": {
+                  "enum": [
+                    "c",
+                    "d",
+                    "u"
+                  ],
+                  "description": "Change operation type: 'c' Create/Insert, 'u' Update, 'd' Delete."
+                },
+                "source": {
+                  "$id": "https://github.com/estuary/connectors/source-mysql/mysql-source-info",
+                  "properties": {
+                    "ts_ms": {
+                      "type": "integer",
+                      "description": "Unix timestamp (in millis) at which this event was recorded by the database."
+                    },
+                    "schema": {
+                      "type": "string",
+                      "description": "Database schema (namespace) of the event."
+                    },
+                    "snapshot": {
+                      "type": "boolean",
+                      "description": "Snapshot is true if the record was produced from an initial table backfill and unset if produced from the replication log."
+                    },
+                    "table": {
+                      "type": "string",
+                      "description": "Database table of the event."
+                    },
+                    "cursor": {
+                      "type": "string",
+                      "description": "Cursor value representing the current position in the binlog."
+                    },
+                    "txid": {
+                      "type": "string",
+                      "description": "The global transaction identifier associated with a change by MySQL. Only set if GTIDs are enabled."
+                    }
+                  },
+                  "type": "object",
+                  "required": [
+                    "schema",
+                    "table",
+                    "cursor"
+                  ]
+                }
+              },
+              "reduce": {
+                "strategy": "merge"
+              }
+            }
+          }
+        },
+        {
+          "$ref": "#TestUnsignedIntegers_45511171"
+        }
+      ]
+    },
+    "key": [
+      "/id"
+    ]
+  }
+

--- a/source-mysql/capture_test.go
+++ b/source-mysql/capture_test.go
@@ -171,6 +171,7 @@ func TestEnumPrimaryKey(t *testing.T) {
 	cs.Validator = &st.OrderedCaptureValidator{}
 	cs.EndpointSpec.(*Config).Advanced.BackfillChunkSize = 3
 
+	t.Run("discovery", func(t *testing.T) { cs.VerifyDiscover(ctx, t, regexp.MustCompile(uniqueID)) })
 	// Insert various test values and then capture them
 	tb.Insert(ctx, t, tableName, [][]interface{}{
 		{"A", 1, "A1"}, {"A", 2, "A2"}, {"A", 3, "A3"}, {"A", 4, "A4"},
@@ -192,6 +193,7 @@ func TestEnumDecodingFix(t *testing.T) {
 	var cs = tb.CaptureSpec(ctx, t, regexp.MustCompile(uniqueID))
 	cs.Validator = &st.OrderedCaptureValidator{}
 
+	t.Run("discovery", func(t *testing.T) { cs.VerifyDiscover(ctx, t, regexp.MustCompile(uniqueID)) })
 	// Insert various test values and then capture them via replication
 	tb.Insert(ctx, t, tableName, [][]interface{}{{1, "A"}, {2, "B"}, {3, "C"}, {4, "D"}, {5, "error"}})
 	t.Run("backfill", func(t *testing.T) { tests.VerifiedCapture(ctx, t, cs) })
@@ -266,6 +268,7 @@ func TestEnumEmptyString(t *testing.T) {
 	var cs = tb.CaptureSpec(ctx, t, regexp.MustCompile(uniqueID))
 	cs.Validator = &st.OrderedCaptureValidator{}
 
+	t.Run("discovery", func(t *testing.T) { cs.VerifyDiscover(ctx, t, regexp.MustCompile(uniqueID)) })
 	// Insert various test values and then capture them via replication
 	tb.Insert(ctx, t, tableName, [][]any{{1, "A"}, {2, "B"}, {3, "C"}, {4, "error"}, {100, 0}, {101, 1}, {102, ""}, {105, 5}})
 	t.Run("backfill", func(t *testing.T) { tests.VerifiedCapture(ctx, t, cs) })
@@ -280,6 +283,7 @@ func TestUnsignedIntegers(t *testing.T) {
 	var cs = tb.CaptureSpec(ctx, t, regexp.MustCompile(uniqueID))
 	cs.Validator = &st.OrderedCaptureValidator{}
 
+	t.Run("discovery", func(t *testing.T) { cs.VerifyDiscover(ctx, t, regexp.MustCompile(uniqueID)) })
 	// Insert various test values and then capture them via replication
 	tb.Insert(ctx, t, tableName, [][]any{{1, "222", "55555", "11111111", "3333333333", "17777777777777777777"}})
 	t.Run("backfill", func(t *testing.T) { tests.VerifiedCapture(ctx, t, cs) })

--- a/source-mysql/discovery.go
+++ b/source-mysql/discovery.go
@@ -488,6 +488,13 @@ type mysqlColumnType struct {
 	Unsigned   bool     `json:"unsigned,omitempty" mapstructure:"unsigned"` // True IFF an integer type is unsigned
 }
 
+func (t *mysqlColumnType) String() string {
+	if t.Unsigned {
+		return t.Type + " unsigned"
+	}
+	return t.Type
+}
+
 func (t *mysqlColumnType) translateRecordField(val interface{}) (interface{}, error) {
 	logrus.WithFields(logrus.Fields{
 		"type":  fmt.Sprintf("%#v", t),

--- a/source-postgres/.snapshots/TestCapitalizedTables-Discover
+++ b/source-postgres/.snapshots/TestCapitalizedTables-Discover
@@ -15,10 +15,12 @@ Binding 0:
           "$anchor": "TestUSERS",
           "properties": {
             "data": {
-              "type": "string"
+              "type": "string",
+              "description": "(source type: non-nullable text)"
             },
             "id": {
-              "type": "integer"
+              "type": "integer",
+              "description": "(source type: non-nullable int4)"
             }
           }
         }

--- a/source-postgres/.snapshots/TestDiscoveryCapitalization
+++ b/source-postgres/.snapshots/TestDiscoveryCapitalization
@@ -15,13 +15,15 @@ Binding 0:
           "$anchor": "TestDiscoveryCapitalization_AaAaA",
           "properties": {
             "data": {
+              "description": "(source type: text)",
               "type": [
                 "string",
                 "null"
               ]
             },
             "id": {
-              "type": "integer"
+              "type": "integer",
+              "description": "(source type: non-nullable int4)"
             }
           }
         }
@@ -149,13 +151,15 @@ Binding 1:
           "$anchor": "TestDiscoverycapitalization_bbbbb",
           "properties": {
             "data": {
+              "description": "(source type: text)",
               "type": [
                 "string",
                 "null"
               ]
             },
             "id": {
-              "type": "integer"
+              "type": "integer",
+              "description": "(source type: non-nullable int4)"
             }
           }
         }
@@ -283,13 +287,15 @@ Binding 2:
           "$anchor": "TestDiscoverycapitalization_ccccc",
           "properties": {
             "data": {
+              "description": "(source type: text)",
               "type": [
                 "string",
                 "null"
               ]
             },
             "id": {
-              "type": "integer"
+              "type": "integer",
+              "description": "(source type: non-nullable int4)"
             }
           }
         }

--- a/source-postgres/.snapshots/TestDiscoveryComplex
+++ b/source-postgres/.snapshots/TestDiscoveryComplex
@@ -16,15 +16,20 @@ Binding 0:
           "$anchor": "TestDiscoverycomplex_cheap_oxygenation",
           "properties": {
             "Bounded Text": {
+              "description": "(source type: varchar)",
               "type": [
                 "string",
                 "null"
               ]
             },
-            "doc": {},
-            "doc/bin": {},
+            "doc": {
+              "description": "(source type: json)"
+            },
+            "doc/bin": {
+              "description": "(source type: non-nullable jsonb)"
+            },
             "foo": {
-              "description": "This is a text field!",
+              "description": "This is a text field! (source type: text)",
               "type": [
                 "string",
                 "null"
@@ -32,13 +37,15 @@ Binding 0:
             },
             "k1": {
               "type": "integer",
-              "description": "I think this is a key ?"
+              "description": "I think this is a key ? (source type: non-nullable int4)"
             },
             "k2": {
-              "type": "string"
+              "type": "string",
+              "description": "(source type: non-nullable text)"
             },
             "real_": {
-              "type": "number"
+              "type": "number",
+              "description": "(source type: non-nullable float4)"
             }
           }
         }

--- a/source-postgres/.snapshots/TestDiscoveryWithoutPermissions
+++ b/source-postgres/.snapshots/TestDiscoveryWithoutPermissions
@@ -15,13 +15,15 @@ Binding 0:
           "$anchor": "PublicDiscoverywithoutpermissions_117535",
           "properties": {
             "data": {
+              "description": "(source type: text)",
               "type": [
                 "string",
                 "null"
               ]
             },
             "id": {
-              "type": "integer"
+              "type": "integer",
+              "description": "(source type: non-nullable int4)"
             }
           }
         }

--- a/source-postgres/.snapshots/TestGeneric-KeylessDiscovery
+++ b/source-postgres/.snapshots/TestGeneric-KeylessDiscovery
@@ -13,21 +13,25 @@ Binding 0:
           "$anchor": "TestGeneric_keylessdiscovery_t32386",
           "properties": {
             "a": {
+              "description": "(source type: int4)",
               "type": [
                 "integer",
                 "null"
               ]
             },
             "b": {
+              "description": "(source type: text)",
               "type": [
                 "string",
                 "null"
               ]
             },
             "c": {
-              "type": "number"
+              "type": "number",
+              "description": "(source type: non-nullable float4)"
             },
             "d": {
+              "description": "(source type: varchar)",
               "type": [
                 "string",
                 "null"

--- a/source-postgres/.snapshots/TestGeneric-SimpleDiscovery
+++ b/source-postgres/.snapshots/TestGeneric-SimpleDiscovery
@@ -15,18 +15,22 @@ Binding 0:
           "$anchor": "TestGeneric_simplediscovery_49210954",
           "properties": {
             "a": {
-              "type": "integer"
+              "type": "integer",
+              "description": "(source type: non-nullable int4)"
             },
             "b": {
+              "description": "(source type: text)",
               "type": [
                 "string",
                 "null"
               ]
             },
             "c": {
-              "type": "number"
+              "type": "number",
+              "description": "(source type: non-nullable float4)"
             },
             "d": {
+              "description": "(source type: varchar)",
               "type": [
                 "string",
                 "null"

--- a/source-postgres/.snapshots/TestPartitionedTableDiscovery
+++ b/source-postgres/.snapshots/TestPartitionedTableDiscovery
@@ -16,9 +16,11 @@ Binding 0:
           "properties": {
             "logdate": {
               "type": "string",
-              "format": "date-time"
+              "format": "date-time",
+              "description": "(source type: non-nullable date)"
             },
             "value": {
+              "description": "(source type: text)",
               "type": [
                 "string",
                 "null"

--- a/source-postgres/.snapshots/TestSecondaryIndexDiscovery-index_only
+++ b/source-postgres/.snapshots/TestSecondaryIndexDiscovery-index_only
@@ -16,22 +16,26 @@ Binding 0:
           "$anchor": "TestSecondaryindexdiscovery_index_only_g26313",
           "properties": {
             "data": {
+              "description": "(source type: text)",
               "type": [
                 "string",
                 "null"
               ]
             },
             "k1": {
+              "description": "(source type: int4)",
               "type": [
                 "integer",
                 "null"
               ]
             },
             "k2": {
-              "type": "integer"
+              "type": "integer",
+              "description": "(source type: non-nullable int4)"
             },
             "k3": {
-              "type": "integer"
+              "type": "integer",
+              "description": "(source type: non-nullable int4)"
             }
           }
         }

--- a/source-postgres/.snapshots/TestSecondaryIndexDiscovery-nonunique_index
+++ b/source-postgres/.snapshots/TestSecondaryIndexDiscovery-nonunique_index
@@ -13,22 +13,26 @@ Binding 0:
           "$anchor": "TestSecondaryindexdiscovery_nonunique_index_g22906",
           "properties": {
             "data": {
+              "description": "(source type: text)",
               "type": [
                 "string",
                 "null"
               ]
             },
             "k1": {
+              "description": "(source type: int4)",
               "type": [
                 "integer",
                 "null"
               ]
             },
             "k2": {
-              "type": "integer"
+              "type": "integer",
+              "description": "(source type: non-nullable int4)"
             },
             "k3": {
-              "type": "integer"
+              "type": "integer",
+              "description": "(source type: non-nullable int4)"
             }
           }
         }

--- a/source-postgres/.snapshots/TestSecondaryIndexDiscovery-nothing
+++ b/source-postgres/.snapshots/TestSecondaryIndexDiscovery-nothing
@@ -13,22 +13,26 @@ Binding 0:
           "$anchor": "TestSecondaryindexdiscovery_nothing_g14307",
           "properties": {
             "data": {
+              "description": "(source type: text)",
               "type": [
                 "string",
                 "null"
               ]
             },
             "k1": {
+              "description": "(source type: int4)",
               "type": [
                 "integer",
                 "null"
               ]
             },
             "k2": {
-              "type": "integer"
+              "type": "integer",
+              "description": "(source type: non-nullable int4)"
             },
             "k3": {
-              "type": "integer"
+              "type": "integer",
+              "description": "(source type: non-nullable int4)"
             }
           }
         }

--- a/source-postgres/.snapshots/TestSecondaryIndexDiscovery-nullable_index
+++ b/source-postgres/.snapshots/TestSecondaryIndexDiscovery-nullable_index
@@ -13,24 +13,28 @@ Binding 0:
           "$anchor": "TestSecondaryindexdiscovery_nullable_index_g31990",
           "properties": {
             "data": {
+              "description": "(source type: text)",
               "type": [
                 "string",
                 "null"
               ]
             },
             "k1": {
+              "description": "(source type: int4)",
               "type": [
                 "integer",
                 "null"
               ]
             },
             "k2": {
+              "description": "(source type: int4)",
               "type": [
                 "integer",
                 "null"
               ]
             },
             "k3": {
+              "description": "(source type: int4)",
               "type": [
                 "integer",
                 "null"

--- a/source-postgres/.snapshots/TestSecondaryIndexDiscovery-pk_and_index
+++ b/source-postgres/.snapshots/TestSecondaryIndexDiscovery-pk_and_index
@@ -15,19 +15,23 @@ Binding 0:
           "$anchor": "TestSecondaryindexdiscovery_pk_and_index_g14228",
           "properties": {
             "data": {
+              "description": "(source type: text)",
               "type": [
                 "string",
                 "null"
               ]
             },
             "k1": {
-              "type": "integer"
+              "type": "integer",
+              "description": "(source type: non-nullable int4)"
             },
             "k2": {
-              "type": "integer"
+              "type": "integer",
+              "description": "(source type: non-nullable int4)"
             },
             "k3": {
-              "type": "integer"
+              "type": "integer",
+              "description": "(source type: non-nullable int4)"
             }
           }
         }

--- a/source-postgres/.snapshots/TestTrickyColumnNames-discover
+++ b/source-postgres/.snapshots/TestTrickyColumnNames-discover
@@ -15,9 +15,11 @@ Binding 0:
           "$anchor": "TestTrickycolumnnames_39256824",
           "properties": {
             "Meta/\"wtf\"~ID": {
-              "type": "integer"
+              "type": "integer",
+              "description": "(source type: non-nullable int4)"
             },
             "data": {
+              "description": "(source type: text)",
               "type": [
                 "string",
                 "null"
@@ -149,13 +151,15 @@ Binding 1:
           "$anchor": "TestTrickycolumnnames_42531495",
           "properties": {
             "data": {
+              "description": "(source type: text)",
               "type": [
                 "string",
                 "null"
               ]
             },
             "table": {
-              "type": "integer"
+              "type": "integer",
+              "description": "(source type: non-nullable int4)"
             }
           }
         }

--- a/source-postgres/.snapshots/TestUserTypes-Domain-Discovery
+++ b/source-postgres/.snapshots/TestUserTypes-Domain-Discovery
@@ -15,9 +15,11 @@ Binding 0:
           "$anchor": "TestUsertypes_domain_68961947",
           "properties": {
             "id": {
-              "type": "integer"
+              "type": "integer",
+              "description": "(source type: non-nullable int4)"
             },
             "value": {
+              "description": "(source type: text)",
               "type": [
                 "string",
                 "null"

--- a/source-postgres/.snapshots/TestUserTypes-Enum-Discovery
+++ b/source-postgres/.snapshots/TestUserTypes-Enum-Discovery
@@ -15,9 +15,11 @@ Binding 0:
           "$anchor": "TestUsertypes_enum_64812435",
           "properties": {
             "id": {
-              "type": "integer"
+              "type": "integer",
+              "description": "(source type: non-nullable int4)"
             },
             "value": {
+              "description": "(source type: enum)",
               "type": [
                 "string",
                 "null"

--- a/source-postgres/.snapshots/TestUserTypes-Range-Discovery
+++ b/source-postgres/.snapshots/TestUserTypes-Range-Discovery
@@ -15,9 +15,11 @@ Binding 0:
           "$anchor": "TestUsertypes_range_91324557",
           "properties": {
             "id": {
-              "type": "integer"
+              "type": "integer",
+              "description": "(source type: non-nullable int4)"
             },
             "value": {
+              "description": "(source type: range)",
               "type": [
                 "string",
                 "null"

--- a/source-postgres/.snapshots/TestUserTypes-Tuple-Discovery
+++ b/source-postgres/.snapshots/TestUserTypes-Tuple-Discovery
@@ -19,11 +19,7 @@ Binding 0:
               "description": "(source type: non-nullable int4)"
             },
             "value": {
-              "description": "(source type: composite)",
-              "type": [
-                "string",
-                "null"
-              ]
+              "description": "(source type: composite)"
             }
           }
         }

--- a/source-postgres/.snapshots/TestUserTypes-Tuple-Discovery
+++ b/source-postgres/.snapshots/TestUserTypes-Tuple-Discovery
@@ -15,10 +15,15 @@ Binding 0:
           "$anchor": "TestUsertypes_tuple_51424093",
           "properties": {
             "id": {
-              "type": "integer"
+              "type": "integer",
+              "description": "(source type: non-nullable int4)"
             },
             "value": {
-              "description": "using catch-all schema: unable to translate PostgreSQL type \"usertuple\" into JSON schema"
+              "description": "(source type: composite)",
+              "type": [
+                "string",
+                "null"
+              ]
             }
           }
         }

--- a/source-postgres/discovery.go
+++ b/source-postgres/discovery.go
@@ -452,7 +452,7 @@ type postgresCompositeType struct{}
 
 func (t postgresCompositeType) String() string { return "composite" }
 func (t postgresCompositeType) toColumnSchema(_ sqlcapture.ColumnInfo) (columnSchema, error) {
-	return columnSchema{jsonType: "string"}, nil
+	return columnSchema{}, nil
 }
 
 // Query copied from pgjdbc's method PgDatabaseMetaData.getPrimaryKeys() with

--- a/source-sqlserver/.snapshots/TestDiscoveryIrrelevantConstraints
+++ b/source-sqlserver/.snapshots/TestDiscoveryIrrelevantConstraints
@@ -15,19 +15,22 @@ Binding 0:
           "$anchor": "DboTest_DiscoveryIrrelevantConstraints_44516719",
           "properties": {
             "data": {
+              "description": "(source type: text)",
               "type": [
                 "string",
                 "null"
               ]
             },
             "foo": {
+              "description": "(source type: int)",
               "type": [
                 "integer",
                 "null"
               ]
             },
             "id": {
-              "type": "string"
+              "type": "string",
+              "description": "(source type: non-nullable varchar(64))"
             }
           }
         }

--- a/source-sqlserver/.snapshots/TestGeneric-KeylessDiscovery
+++ b/source-sqlserver/.snapshots/TestGeneric-KeylessDiscovery
@@ -13,21 +13,25 @@ Binding 0:
           "$anchor": "DboTest_Generic_KeylessDiscovery_t32386",
           "properties": {
             "a": {
+              "description": "(source type: int)",
               "type": [
                 "integer",
                 "null"
               ]
             },
             "b": {
+              "description": "(source type: text)",
               "type": [
                 "string",
                 "null"
               ]
             },
             "c": {
-              "type": "number"
+              "type": "number",
+              "description": "(source type: non-nullable real)"
             },
             "d": {
+              "description": "(source type: varchar(255))",
               "type": [
                 "string",
                 "null"

--- a/source-sqlserver/.snapshots/TestGeneric-SimpleDiscovery
+++ b/source-sqlserver/.snapshots/TestGeneric-SimpleDiscovery
@@ -15,18 +15,22 @@ Binding 0:
           "$anchor": "DboTest_Generic_SimpleDiscovery_49210954",
           "properties": {
             "a": {
-              "type": "integer"
+              "type": "integer",
+              "description": "(source type: non-nullable int)"
             },
             "b": {
+              "description": "(source type: text)",
               "type": [
                 "string",
                 "null"
               ]
             },
             "c": {
-              "type": "number"
+              "type": "number",
+              "description": "(source type: non-nullable real)"
             },
             "d": {
+              "description": "(source type: varchar(255))",
               "type": [
                 "string",
                 "null"

--- a/source-sqlserver/.snapshots/TestIndexIncludedDiscovery
+++ b/source-sqlserver/.snapshots/TestIndexIncludedDiscovery
@@ -16,22 +16,26 @@ Binding 0:
           "$anchor": "DboTest_IndexIncludedDiscovery_98476798",
           "properties": {
             "data": {
+              "description": "(source type: text)",
               "type": [
                 "string",
                 "null"
               ]
             },
             "k1": {
+              "description": "(source type: int)",
               "type": [
                 "integer",
                 "null"
               ]
             },
             "k2": {
-              "type": "integer"
+              "type": "integer",
+              "description": "(source type: non-nullable int)"
             },
             "k3": {
-              "type": "integer"
+              "type": "integer",
+              "description": "(source type: non-nullable int)"
             }
           }
         }

--- a/source-sqlserver/.snapshots/TestSecondaryIndexDiscovery-index_only
+++ b/source-sqlserver/.snapshots/TestSecondaryIndexDiscovery-index_only
@@ -16,22 +16,26 @@ Binding 0:
           "$anchor": "DboTest_SecondaryIndexDiscovery_index_only_g26313",
           "properties": {
             "data": {
+              "description": "(source type: text)",
               "type": [
                 "string",
                 "null"
               ]
             },
             "k1": {
+              "description": "(source type: int)",
               "type": [
                 "integer",
                 "null"
               ]
             },
             "k2": {
-              "type": "integer"
+              "type": "integer",
+              "description": "(source type: non-nullable int)"
             },
             "k3": {
-              "type": "integer"
+              "type": "integer",
+              "description": "(source type: non-nullable int)"
             }
           }
         }

--- a/source-sqlserver/.snapshots/TestSecondaryIndexDiscovery-nonunique_index
+++ b/source-sqlserver/.snapshots/TestSecondaryIndexDiscovery-nonunique_index
@@ -13,22 +13,26 @@ Binding 0:
           "$anchor": "DboTest_SecondaryIndexDiscovery_nonunique_index_g22906",
           "properties": {
             "data": {
+              "description": "(source type: text)",
               "type": [
                 "string",
                 "null"
               ]
             },
             "k1": {
+              "description": "(source type: int)",
               "type": [
                 "integer",
                 "null"
               ]
             },
             "k2": {
-              "type": "integer"
+              "type": "integer",
+              "description": "(source type: non-nullable int)"
             },
             "k3": {
-              "type": "integer"
+              "type": "integer",
+              "description": "(source type: non-nullable int)"
             }
           }
         }

--- a/source-sqlserver/.snapshots/TestSecondaryIndexDiscovery-nothing
+++ b/source-sqlserver/.snapshots/TestSecondaryIndexDiscovery-nothing
@@ -13,22 +13,26 @@ Binding 0:
           "$anchor": "DboTest_SecondaryIndexDiscovery_nothing_g14307",
           "properties": {
             "data": {
+              "description": "(source type: text)",
               "type": [
                 "string",
                 "null"
               ]
             },
             "k1": {
+              "description": "(source type: int)",
               "type": [
                 "integer",
                 "null"
               ]
             },
             "k2": {
-              "type": "integer"
+              "type": "integer",
+              "description": "(source type: non-nullable int)"
             },
             "k3": {
-              "type": "integer"
+              "type": "integer",
+              "description": "(source type: non-nullable int)"
             }
           }
         }

--- a/source-sqlserver/.snapshots/TestSecondaryIndexDiscovery-nullable_index
+++ b/source-sqlserver/.snapshots/TestSecondaryIndexDiscovery-nullable_index
@@ -13,24 +13,28 @@ Binding 0:
           "$anchor": "DboTest_SecondaryIndexDiscovery_nullable_index_g31990",
           "properties": {
             "data": {
+              "description": "(source type: text)",
               "type": [
                 "string",
                 "null"
               ]
             },
             "k1": {
+              "description": "(source type: int)",
               "type": [
                 "integer",
                 "null"
               ]
             },
             "k2": {
+              "description": "(source type: int)",
               "type": [
                 "integer",
                 "null"
               ]
             },
             "k3": {
+              "description": "(source type: int)",
               "type": [
                 "integer",
                 "null"

--- a/source-sqlserver/.snapshots/TestSecondaryIndexDiscovery-pk_and_index
+++ b/source-sqlserver/.snapshots/TestSecondaryIndexDiscovery-pk_and_index
@@ -15,19 +15,23 @@ Binding 0:
           "$anchor": "DboTest_SecondaryIndexDiscovery_pk_and_index_g14228",
           "properties": {
             "data": {
+              "description": "(source type: text)",
               "type": [
                 "string",
                 "null"
               ]
             },
             "k1": {
-              "type": "integer"
+              "type": "integer",
+              "description": "(source type: non-nullable int)"
             },
             "k2": {
-              "type": "integer"
+              "type": "integer",
+              "description": "(source type: non-nullable int)"
             },
             "k3": {
-              "type": "integer"
+              "type": "integer",
+              "description": "(source type: non-nullable int)"
             }
           }
         }

--- a/source-sqlserver/.snapshots/TestVarcharKeyDiscovery
+++ b/source-sqlserver/.snapshots/TestVarcharKeyDiscovery
@@ -15,13 +15,15 @@ Binding 0:
           "$anchor": "DboTest_VarcharKeyDiscovery_42325208",
           "properties": {
             "data": {
+              "description": "(source type: text)",
               "type": [
                 "string",
                 "null"
               ]
             },
             "id": {
-              "type": "string"
+              "type": "string",
+              "description": "(source type: non-nullable varchar(64))"
             }
           }
         }

--- a/source-sqlserver/discovery.go
+++ b/source-sqlserver/discovery.go
@@ -239,6 +239,10 @@ type sqlserverTextColumnType struct {
 	FullType  string // The full type of the column, such as `varchar(32)` for example
 }
 
+func (t sqlserverTextColumnType) String() string {
+	return t.FullType
+}
+
 // Joining on the 6-tuple {CONSTRAINT,TABLE}_{CATALOG,SCHEMA,NAME} is probably
 // overkill but shouldn't hurt, and helps to make absolutely sure that we're
 // matching up the constraint type with the column names/positions correctly.

--- a/sqlcapture/discovery.go
+++ b/sqlcapture/discovery.go
@@ -95,12 +95,19 @@ func DiscoverCatalog(ctx context.Context, db Database) ([]*pc.Response_Discovere
 					"error": err,
 					"type":  column.DataType,
 				}).Debug("error translating column type to JSON schema")
-				properties[column.Name] = &jsonschema.Schema{
-					Description: fmt.Sprintf("using catch-all schema: %v", err),
+				jsonType = &jsonschema.Schema{
+					Description: fmt.Sprintf("using catch-all schema (%v)", err),
 				}
-			} else {
-				properties[column.Name] = jsonType
 			}
+			if jsonType.Description != "" {
+				jsonType.Description += " "
+			}
+			var nullabilityDescription = ""
+			if !column.IsNullable {
+				nullabilityDescription = "non-nullable "
+			}
+			jsonType.Description += fmt.Sprintf("(source type: %s%s)", nullabilityDescription, column.DataType)
+			properties[column.Name] = jsonType
 		}
 
 		// Schema.Properties is a weird OrderedMap thing, which doesn't allow for inline

--- a/sqlcapture/tests/datatypes.go
+++ b/sqlcapture/tests/datatypes.go
@@ -54,9 +54,12 @@ func TestDatatypes(ctx context.Context, t *testing.T, tb TestBackend, cases []Da
 				require.Len(t, skimmed.Definitions, 1)
 
 				for _, tbl := range skimmed.Definitions {
-					var expectParsed, actualParsed interface{}
+					var expectParsed, actualParsed any
 					require.NoError(t, json.Unmarshal([]byte(tc.ExpectType), &expectParsed))
 					require.NoError(t, json.Unmarshal(tbl.Properties["b"], &actualParsed))
+					if m, ok := actualParsed.(map[string]any); ok {
+						delete(m, "description")
+					}
 					require.Equal(t, expectParsed, actualParsed)
 				}
 			})


### PR DESCRIPTION
**Description:**

This commit modifies the generic SQL CDC discovery logic so that it will include type information like `(source type: int)` or `(source type: non-nullable enum)` in the description of every column property in the discovered JSON schemas.

In the event that there's already a description, for example in the case of Postgres discovery with comments, the source type info will be appended after that comment.

The goal of this change is to make it much easier to see exactly what sort of source column types we're actually dealing with, as the JSON schema types are a more restricted set and often there may be multiple database types mapped to identical JSON schema types. Currently to see this information we have to go use a low-level `flowctl-go shards edit` command to toggle debug logging on for a capture, search through the massive volume of debug output for the relevant column of the correct table to see what it was, and then go toggle the log level back to `INFO`. This is a pain and I'm also not a big fan of having to restart a task just to see what column types it's handling.

**Workflow steps:**

When looking at a collection in the UI, the "code view" of the collection spec should now tell us what source database type corresponds to each property.

**Notes for reviewers:**

This is in some sense a fairly trivial change, but it produces a pretty large diff since it impacts every property of every discovery snapshot. I also had to refactor a bit of the Postgres discovery logic so that this would work nicely with enums and other user-defined data types, and in practice the biggest risk of this change is if I could have made a mistake there which wasn't caught by our tests.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1768)
<!-- Reviewable:end -->
