### PR TITLE
materialize-parquet: handle number types encoded as integers

### DIFF
--- a/materialize-boilerplate/stream-encode/parquet.go
+++ b/materialize-boilerplate/stream-encode/parquet.go
@@ -564,6 +564,8 @@ func getNumberVal(val any) (got float64, err error) {
 		got = v
 	case float32:
 		got = float64(v)
+	case int64:
+		got = float64(v)
 	case string:
 		if p, parseErr := strconv.ParseFloat(v, 64); parseErr != nil {
 			err = fmt.Errorf("unable to parse string %q as float64: %w", v, parseErr)


### PR DESCRIPTION
**Description:**

Fields of `type: number` that contain values without any fractional part may be encoded as FDB integers, and those need to be cast to float64 for writing them to parquet DOUBLE columns.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1769)
<!-- Reviewable:end -->
