### PR TITLE
materialize-s3-iceberg: don't run table alter command if there are no alterations

### DIFF
--- a/materialize-s3-iceberg/glue.go
+++ b/materialize-s3-iceberg/glue.go
@@ -136,6 +136,12 @@ func (c *glueCatalog) DeleteResource(_ context.Context, path []string) (string, 
 }
 
 func (c *glueCatalog) UpdateResource(_ context.Context, spec *pf.MaterializationSpec, bindingIndex int, bindingUpdate boilerplate.BindingUpdate) (string, boilerplate.ActionApplyFn, error) {
+	if len(bindingUpdate.NewProjections) == 0 && len(bindingUpdate.NewlyNullableFields) == 0 {
+		// Nothing to do, since only adding new columns or dropping nullability
+		// constraints is supported currently.
+		return "", nil, nil
+	}
+
 	b := spec.Bindings[bindingIndex]
 
 	ta := tableAlter{}


### PR DESCRIPTION
**Description:**

Don't run the alter table `iceberg-ctl` command if there are no new columns or nullability constraints to drop, since those are the only table alternations currently supported.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1772)
<!-- Reviewable:end -->
