### PR TITLE
source-mysql: Silently ignore `SAVEPOINT` queries

### DIFF
--- a/source-mysql/replication.go
+++ b/source-mysql/replication.go
@@ -464,7 +464,7 @@ func mergePreimage(fields map[string]any, preimage map[string]any) map[string]an
 // with the binlog Query Events for some statements like GRANT and CREATE USER.
 // TODO(johnny): SET STATEMENT is not safe in the general case, and we want to re-visit
 // by extracting and ignoring a SET STATEMENT stanza prior to parsing.
-var silentIgnoreQueriesRe = regexp.MustCompile(`(?i)^(BEGIN|# [^\n]*)$`)
+var silentIgnoreQueriesRe = regexp.MustCompile(`(?i)^(BEGIN|SAVEPOINT .*|# [^\n]*)$`)
 var createDefinerRegex = `CREATE\s*(OR REPLACE){0,1}\s*(ALGORITHM\s*=\s*[^ ]+)*\s*DEFINER`
 var ignoreQueriesRe = regexp.MustCompile(`(?i)^(BEGIN|COMMIT|GRANT|REVOKE|CREATE USER|` + createDefinerRegex + `|DROP USER|ALTER USER|DROP PROCEDURE|DROP FUNCTION|DROP TRIGGER|SET STATEMENT|CREATE EVENT|ALTER EVENT|DROP EVENT)`)
 


### PR DESCRIPTION
**Description:**

When they're used, `SAVEPOINT` query events tend to be absurdly spammy so we definitely don't want to be logging them at `INFO` level.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1774)
<!-- Reviewable:end -->
