### PR TITLE
source-stripe-native: adding a pre-process step for 'discounts' fields

### DIFF
--- a/source-stripe-native/acmeCo/InvoiceItems.schema.yaml
+++ b/source-stripe-native/acmeCo/InvoiceItems.schema.yaml
@@ -30,11 +30,19 @@ properties:
   id:
     title: Id
     type: string
+  discounts:
+    anyOf:
+      - items:
+          type: string
+        type: array
+      - type: "null"
+    title: Discounts
   created:
     title: Created
     type: integer
 required:
   - id
+  - discounts
   - created
 title: InvoiceItems
 type: object

--- a/source-stripe-native/acmeCo/SubscriptionItems.schema.yaml
+++ b/source-stripe-native/acmeCo/SubscriptionItems.schema.yaml
@@ -73,7 +73,7 @@ $defs:
       discounts:
         anyOf:
           - items:
-              type: object
+              type: string
             type: array
           - type: "null"
         default: ~

--- a/source-stripe-native/source_stripe_native/models.py
+++ b/source-stripe-native/source_stripe_native/models.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 from enum import StrEnum, auto
 from pydantic import BaseModel, Field, AwareDatetime, model_validator, AliasChoices
-from typing import Literal, Generic, TypeVar, Annotated, ClassVar, TYPE_CHECKING, Dict, List
+from typing import Literal, Generic, TypeVar, Annotated, ClassVar, TYPE_CHECKING, Dict, List, Any
 import urllib.parse
 
 from estuary_cdk.flow import AccessToken
@@ -317,6 +317,7 @@ class InvoiceItems(BaseDocument, extra="allow"):
     SEARCH_NAME: ClassVar[str] = "invoiceitems"
     
     id: str
+    discounts: List[str] | None
     created: int = Field(validation_alias=AliasChoices('date'))
 
 
@@ -440,12 +441,12 @@ class SubscriptionItems(BaseDocument, extra="allow"):
             billing_thresholds: Dict | None = None
             created: int
             metadata: Dict | None = None
-            discounts: list[Dict] | None = None
+            discounts: List[str] | None = None
             plan: Dict | None = None
             price: Dict
             quantity: int | None = None
             subscription: str
-            tax_rates: list[Dict] | None = None
+            tax_rates: List[Dict] | None = None
 
         object: Literal["list"]
         data: list[Values]

--- a/source-stripe-native/tests/snapshots/source_stripe_native_tests_test_snapshots__capture__stdout.json
+++ b/source-stripe-native/tests/snapshots/source_stripe_native_tests_test_snapshots__capture__stdout.json
@@ -54,6 +54,7 @@
             "country": "BR",
             "currency": "brl",
             "default_for_currency": true,
+            "financial_account": null,
             "fingerprint": "FfkcPo9saEcVWPmL",
             "future_requirements": {
               "currently_due": [],
@@ -245,6 +246,7 @@
             "country": "BR",
             "currency": "brl",
             "default_for_currency": true,
+            "financial_account": null,
             "fingerprint": "FfkcPo9saEcVWPmL",
             "future_requirements": {
               "currently_due": [],
@@ -773,7 +775,7 @@
         "some-interesting": "piece-of-information"
       },
       "name": "My Cool Customer",
-      "next_invoice_sequence": 66,
+      "next_invoice_sequence": 92,
       "object": "customer",
       "phone": null,
       "preferred_locales": [],

--- a/source-stripe-native/tests/snapshots/source_stripe_native_tests_test_snapshots__discover__stdout.json
+++ b/source-stripe-native/tests/snapshots/source_stripe_native_tests_test_snapshots__discover__stdout.json
@@ -597,6 +597,20 @@
           "title": "Id",
           "type": "string"
         },
+        "discounts": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "title": "Discounts"
+        },
         "created": {
           "title": "Created",
           "type": "integer"
@@ -604,6 +618,7 @@
       },
       "required": [
         "id",
+        "discounts",
         "created"
       ],
       "title": "InvoiceItems",
@@ -1522,7 +1537,7 @@
               "anyOf": [
                 {
                   "items": {
-                    "type": "object"
+                    "type": "string"
                   },
                   "type": "array"
                 },


### PR DESCRIPTION
**Description:**

The idea behind this PR is to add a pre-process step to both `InvoiceItems` and `SubscriptionItems`  records.
Stripe API seems to deliver them in a variety of types, and for some reason that broke down the schema inference from the connector. Untill the cause is verified, this should allow the connector to run

**Notes for reviewers:**

Tested end-to-end on a local flow setup. Also, the write-schema was modified to allow for the `discounts` field.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1776)
<!-- Reviewable:end -->
