### PR TITLE
source-sqlserver: Fix CI builds consistently failing

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -181,6 +181,7 @@ jobs:
             "source-mongodb"
             ]'), matrix.connector)
         run: |
+          set +e # Show logs even if startup fails
           docker compose --file ${{ matrix.connector }}/docker-compose.yaml up --wait
           docker logs ${{ matrix.connector }}-db-1
 

--- a/source-sqlserver/README.md
+++ b/source-sqlserver/README.md
@@ -29,7 +29,7 @@ automated test suite runs take 10-20x longer than they do on other databases.
 
 Some useful commands for working with a test instance of SQL Server:
 
-    $ docker-compose -f ./source-sqlserver/docker-compose.yaml exec db /opt/mssql-tools/bin/sqlcmd -U sa -P gf6w6dkD
+    $ docker-compose -f ./source-sqlserver/docker-compose.yaml exec db /opt/mssql-tools18/bin/sqlcmd -C -U sa -P gf6w6dkD
 
     ## Enabling CDC on a database
     > CREATE DATABASE test;

--- a/source-sqlserver/docker-initdb.sh
+++ b/source-sqlserver/docker-initdb.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+set -ex
 /opt/mssql/bin/sqlservr &
 DBPID="$!"
 
@@ -37,7 +38,7 @@ WAITFOR DELAY '00:00:02';
 GO
 EXEC sys.sp_cdc_start_job @job_type = 'capture';
 GO
-  " | /opt/mssql-tools/bin/sqlcmd -U sa -P gf6w6dkD
+  " | /opt/mssql-tools18/bin/sqlcmd -C -U sa -P gf6w6dkD
   echo "[initdb] Database initialization complete!"
   touch /var/opt/mssql/initdb-performed
 else

--- a/tests/source-sqlserver/cleanup.sh
+++ b/tests/source-sqlserver/cleanup.sh
@@ -6,7 +6,7 @@ function sql {
     echo "sql> " $@
     echo -e "$@\nGO\n" | docker exec -i \
       ${CONTAINER_NAME} \
-      /opt/mssql-tools/bin/sqlcmd \
+      /opt/mssql-tools18/bin/sqlcmd -C \
       -U ${SQLSERVER_USER} \
       -P ${SQLSERVER_PASSWORD}
 }

--- a/tests/source-sqlserver/setup.sh
+++ b/tests/source-sqlserver/setup.sh
@@ -30,7 +30,7 @@ function sql {
     echo "sql> " $@
     echo -e "$@\nGO\n" | docker exec -i \
       ${CONTAINER_NAME} \
-      /opt/mssql-tools/bin/sqlcmd \
+      /opt/mssql-tools18/bin/sqlcmd -C \
       -U ${SQLSERVER_USER} \
       -P ${SQLSERVER_PASSWORD}
 }


### PR DESCRIPTION
**Description:**

Apparently in late July, Microsoft pushed an update to the `2022-latest` Docker image we use for SQL Server in CI builds. (I didn't notice this locally because how often does one run a `docker pull` for a relatively stable test dependency, but for the past couple of weeks all SQL Server CI builds were failing.)

The update contained two notable changes:
- The directory `/opt/mssql-tools` which contains the `sqlcmd` binary was renamed to `/opt/mssql-tools18`
- The `sqlcmd` binary was upgraded and the new version defaults to stricter certificate validation that a self-hosted server in a CI build fails.

The fix was very simple, just changing the path to the binary and adding a `-C` flag which means "trust the server certificate". I'm also leaving in place a couple of the tweaks I had to make as part of figuring out what the issue was, because I think they're useful changes for CI build debuggability in the future.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1777)
<!-- Reviewable:end -->
