### PR TITLE
source-notion: remove pattern_descriptor from config

### DIFF
--- a/source-notion/source_notion/spec.json
+++ b/source-notion/source_notion/spec.json
@@ -10,7 +10,6 @@
         "title": "Start Date",
         "description": "UTC date and time in the format YYYY-MM-DDTHH:MM:SS.000Z. During incremental sync, any data generated before this date will not be replicated. If left blank, the start date will be set to 2 years before the present date.",
         "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}.[0-9]{3}Z$",
-        "pattern_descriptor": "YYYY-MM-DDTHH:MM:SS.000Z",
         "examples": ["2020-11-16T00:00:00.000Z"],
         "type": "string",
         "format": "date-time"

--- a/source-notion/tests/snapshots/snapshots__spec__capture.stdout.json
+++ b/source-notion/tests/snapshots/snapshots__spec__capture.stdout.json
@@ -13,7 +13,6 @@
           "title": "Start Date",
           "description": "UTC date and time in the format YYYY-MM-DDTHH:MM:SS.000Z. During incremental sync, any data generated before this date will not be replicated. If left blank, the start date will be set to 2 years before the present date.",
           "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}.[0-9]{3}Z$",
-          "pattern_descriptor": "YYYY-MM-DDTHH:MM:SS.000Z",
           "examples": [
             "2020-11-16T00:00:00.000Z"
           ],


### PR DESCRIPTION
Removes the "pattern_descriptor" property from the configuration, since I don't believe it was actually doing something and seems to have recently cause the endpoint config to fail to work with config encryption for unknown reasons.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1784)
<!-- Reviewable:end -->
