### PR TITLE
materialize-s3-iceberg: add ignoreStringFormat field configuration

### DIFF
--- a/materialize-s3-iceberg/driver.go
+++ b/materialize-s3-iceberg/driver.go
@@ -313,10 +313,15 @@ func (d driver) NewTransactor(ctx context.Context, open pm.Request_Open) (m.Tran
 			return nil, nil, fmt.Errorf("unmarshalling resource config: %w", err)
 		}
 
+		pqSchema, err := parquetSchema(b.FieldSelection.AllFields(), b.Collection, b.FieldSelection.FieldConfigJsonMap)
+		if err != nil {
+			return nil, nil, err
+		}
+
 		resourcePaths = append(resourcePaths, res.path())
 		bindings = append(bindings, binding{
 			path:       b.ResourcePath,
-			pqSchema:   schemaWithOptions(b.FieldSelection.AllFields(), b.Collection),
+			pqSchema:   pqSchema,
 			includeDoc: b.FieldSelection.Document != "",
 			stateKey:   b.StateKey,
 		})

--- a/materialize-s3-iceberg/glue.go
+++ b/materialize-s3-iceberg/glue.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 
 	boilerplate "github.com/estuary/connectors/materialize-boilerplate"
-	enc "github.com/estuary/connectors/materialize-boilerplate/stream-encode"
 	pf "github.com/estuary/flow/go/protocols/flow"
 	log "github.com/sirupsen/logrus"
 )
@@ -98,7 +97,11 @@ func (c *glueCatalog) CreateResource(_ context.Context, spec *pf.Materialization
 
 	tc := tableCreate{Location: c.tableLocation}
 
-	parquetSchema := schemaWithOptions(b.FieldSelection.AllFields(), b.Collection)
+	parquetSchema, err := parquetSchema(b.FieldSelection.AllFields(), b.Collection, b.FieldSelection.FieldConfigJsonMap)
+	if err != nil {
+		return "", nil, err
+	}
+
 	for _, f := range parquetSchema {
 		tc.Fields = append(tc.Fields, existingIcebergColumn{
 			Name:     f.Name,
@@ -151,7 +154,11 @@ func (c *glueCatalog) UpdateResource(_ context.Context, spec *pf.Materialization
 	}
 
 	for _, p := range bindingUpdate.NewProjections {
-		s := enc.ProjectionToParquetSchemaElement(p, schemaOptions...)
+		s, err := projectionToParquetSchemaElement(p, b.FieldSelection.FieldConfigJsonMap[p.Field])
+		if err != nil {
+			return "", nil, err
+		}
+
 		ta.NewColumns = append(ta.NewColumns, existingIcebergColumn{
 			Name:     s.Name,
 			Nullable: true, // always true for added columns


### PR DESCRIPTION
**Description:**

Adds the ignoreStringFormat field configuration which when set will materialize string fields as regular strings, disregarding any format annotation they might have.

Manually tested by first materializing a collection without the field config set and seeing the column as a timestamptz, then adding the field configuration which causes an unsatisfiable constraint. Increasing the backfill counter allows the materialization to proceed by re-creating the table with a string type for the column, and string values are added to the column

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1786)
<!-- Reviewable:end -->
