### PR TITLE
source-zendesk-support: Fix pagination issues with `tickets` and `users` streams

### DIFF
--- a/source-zendesk-support/tests/snapshots/snapshots__discover__capture.stdout.json
+++ b/source-zendesk-support/tests/snapshots/snapshots__discover__capture.stdout.json
@@ -3885,7 +3885,7 @@
       "stream": "tickets",
       "syncMode": "incremental",
       "cursorField": [
-        "updated_at"
+        "after_cursor"
       ]
     },
     "documentSchema": {
@@ -4468,7 +4468,7 @@
       "stream": "users",
       "syncMode": "incremental",
       "cursorField": [
-        "updated_at"
+        "after_cursor"
       ]
     },
     "documentSchema": {


### PR DESCRIPTION
**Description:**

`tickets` and `users` streams were previously using incremental timestamp-based pagination, resulting in duplicated data. It was also possible for the connector to get stuck making the same request if 1,000+ documents were modified at the same time. By moving to [incremental cursor pagination](https://developer.zendesk.com/documentation/ticketing/managing-tickets/using-the-incremental-export-api/#cursor-based-incremental-exports), these issues are resolved.

The `test_check_stream_state` unit test is no longer applicable, since the `cursorField` is not longer within each document. The `cursorField` is instead only in the response body, and the `IncrementalMixin`'s `state` setters and getters are used to checkpoint cursors between requests. The [`ClientSideIncrementalStream`](https://github.com/estuary/connectors/blob/14f92e7f20590cfac389bfee712d8656f8d131c6/source-hubspot/source_hubspot/streams.py#L794C7-L794C34) and [`IncrementalStream`](https://github.com/estuary/connectors/blob/14f92e7f20590cfac389bfee712d8656f8d131c6/source-hubspot/source_hubspot/streams.py#L906C7-L906C24) from the `source-hubspot` connector were referenced for determining how to checkpoint state use the Airbyte CDK.

Discover snapshot changes: Only the expected `cursorField` changes.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

Docs will need updated to reflect the changed `cursorField` for the `tickets` and `users` streams.

**Notes for reviewers:**

Tested on a local stack and using a Zendesk account with a non-trivial amount of `tickets` and `users` data. Confirmed that cursors are checkpointed & the connector resumes with the last checkpointed cursor after recovering from a failure.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1789)
<!-- Reviewable:end -->
