### PR TITLE
materialize-sql: run preReqs check before endpoint initialization

### DIFF
--- a/materialize-bigquery/bigquery.go
+++ b/materialize-bigquery/bigquery.go
@@ -155,8 +155,8 @@ func Driver() *sql.Driver {
 func newBigQueryDriver() *sql.Driver {
 	return &sql.Driver{
 		DocumentationURL: "https://go.estuary.dev/materialize-bigquery",
-		EndpointSpecType: config{},
-		ResourceSpecType: tableConfig{},
+		EndpointSpecType: new(config),
+		ResourceSpecType: new(tableConfig),
 		NewEndpoint: func(ctx context.Context, raw json.RawMessage, tenant string) (*sql.Endpoint, error) {
 			var cfg = new(config)
 			if err := pf.UnmarshalStrict(raw, cfg); err != nil {
@@ -187,5 +187,6 @@ func newBigQueryDriver() *sql.Driver {
 				ConcurrentApply:     true,
 			}, nil
 		},
+		PreReqs: preReqs,
 	}
 }

--- a/materialize-bigquery/bigquery_test.go
+++ b/materialize-bigquery/bigquery_test.go
@@ -246,13 +246,7 @@ func TestPrereqs(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			cfg := tt.cfg(cfg)
-
-			client, err := cfg.client(context.Background())
-			require.NoError(t, err)
-			defer client.Close()
-
-			require.Equal(t, tt.want, client.PreReqs(context.Background()).Unwrap())
+			require.Equal(t, tt.want, preReqs(context.Background(), tt.cfg(cfg), "testing").Unwrap())
 		})
 	}
 }

--- a/materialize-bigquery/client.go
+++ b/materialize-bigquery/client.go
@@ -179,8 +179,15 @@ func (c *client) CreateSchema(ctx context.Context, schemaName string) error {
 	})
 }
 
-func (c *client) PreReqs(ctx context.Context) *sql.PrereqErr {
+func preReqs(ctx context.Context, conf any, tenant string) *sql.PrereqErr {
 	errs := &sql.PrereqErr{}
+
+	cfg := conf.(*config)
+	c, err := cfg.client(ctx)
+	if err != nil {
+		errs.Err(fmt.Errorf("creating client: %w", err))
+		return errs
+	}
 
 	var googleErr *googleapi.Error
 

--- a/materialize-databricks/driver.go
+++ b/materialize-databricks/driver.go
@@ -102,6 +102,7 @@ func newDatabricksDriver() *sql.Driver {
 				ConcurrentApply:     true,
 			}, nil
 		},
+		PreReqs: preReqs,
 	}
 }
 

--- a/materialize-motherduck/client.go
+++ b/materialize-motherduck/client.go
@@ -127,17 +127,25 @@ func (c *client) CreateSchema(ctx context.Context, schemaName string) error {
 	return sql.StdCreateSchema(ctx, c.db, duckDialect, schemaName)
 }
 
-func (c *client) PreReqs(ctx context.Context) *sql.PrereqErr {
+func preReqs(ctx context.Context, conf any, tenant string) *sql.PrereqErr {
 	errs := &sql.PrereqErr{}
+
+	cfg := conf.(*config)
+
+	db, err := cfg.db(ctx)
+	if err != nil {
+		errs.Err(err)
+		return errs
+	}
 
 	pingCtx, cancel := context.WithTimeout(ctx, 20*time.Second)
 	defer cancel()
 
-	if err := c.db.PingContext(pingCtx); err != nil {
+	if err := db.PingContext(pingCtx); err != nil {
 		errs.Err(err)
 	}
 
-	s3client, err := c.cfg.toS3Client(ctx)
+	s3client, err := cfg.toS3Client(ctx)
 	if err != nil {
 		// This is not caused by invalid S3 credentials, and would most likely be a logic error in
 		// the connector code.
@@ -146,11 +154,11 @@ func (c *client) PreReqs(ctx context.Context) *sql.PrereqErr {
 	}
 
 	// Test creating, reading, and deleting an object from the configured bucket and bucket path.
-	testKey := path.Join(c.cfg.BucketPath, uuid.NewString())
+	testKey := path.Join(cfg.BucketPath, uuid.NewString())
 
 	var awsErr *awsHttp.ResponseError
 	if _, err := s3client.PutObject(ctx, &s3.PutObjectInput{
-		Bucket: aws.String(c.cfg.Bucket),
+		Bucket: aws.String(cfg.Bucket),
 		Key:    aws.String(testKey),
 		Body:   strings.NewReader("testing"),
 	}); err != nil {
@@ -158,26 +166,26 @@ func (c *client) PreReqs(ctx context.Context) *sql.PrereqErr {
 			// Handling for the two most common cases: The bucket doesn't exist, or the bucket does
 			// exist but the configured credentials aren't authorized to write to it.
 			if awsErr.Response.Response.StatusCode == http.StatusNotFound {
-				err = fmt.Errorf("bucket %q does not exist", c.cfg.Bucket)
+				err = fmt.Errorf("bucket %q does not exist", cfg.Bucket)
 			} else if awsErr.Response.Response.StatusCode == http.StatusForbidden {
-				err = fmt.Errorf("not authorized to write to %q", path.Join(c.cfg.Bucket, c.cfg.BucketPath))
+				err = fmt.Errorf("not authorized to write to %q", path.Join(cfg.Bucket, cfg.BucketPath))
 			}
 		}
 		errs.Err(err)
 	} else if _, err := s3client.GetObject(ctx, &s3.GetObjectInput{
-		Bucket: aws.String(c.cfg.Bucket),
+		Bucket: aws.String(cfg.Bucket),
 		Key:    aws.String(testKey),
 	}); err != nil {
 		if errors.As(err, &awsErr) && awsErr.Response.Response.StatusCode == http.StatusForbidden {
-			err = fmt.Errorf("not authorized to read from %q", path.Join(c.cfg.Bucket, c.cfg.BucketPath))
+			err = fmt.Errorf("not authorized to read from %q", path.Join(cfg.Bucket, cfg.BucketPath))
 		}
 		errs.Err(err)
 	} else if _, err := s3client.DeleteObject(ctx, &s3.DeleteObjectInput{
-		Bucket: aws.String(c.cfg.Bucket),
+		Bucket: aws.String(cfg.Bucket),
 		Key:    aws.String(testKey),
 	}); err != nil {
 		if errors.As(err, &awsErr) && awsErr.Response.Response.StatusCode == http.StatusForbidden {
-			err = fmt.Errorf("not authorized to delete from %q", path.Join(c.cfg.Bucket, c.cfg.BucketPath))
+			err = fmt.Errorf("not authorized to delete from %q", path.Join(cfg.Bucket, cfg.BucketPath))
 		}
 		errs.Err(err)
 	}

--- a/materialize-motherduck/driver.go
+++ b/materialize-motherduck/driver.go
@@ -176,6 +176,7 @@ func newDuckDriver() *sql.Driver {
 				ConcurrentApply:     false,
 			}, nil
 		},
+		PreReqs: preReqs,
 	}
 }
 

--- a/materialize-motherduck/driver_test.go
+++ b/materialize-motherduck/driver_test.go
@@ -200,13 +200,7 @@ func TestPrereqs(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			cfg := tt.cfg(cfg)
-
-			client, err := newClient(ctx, &sql.Endpoint{Config: cfg})
-			require.NoError(t, err)
-			defer client.Close()
-
-			require.Equal(t, tt.want, client.PreReqs(ctx).Unwrap())
+			require.Equal(t, tt.want, preReqs(ctx, tt.cfg(cfg), "testing").Unwrap())
 		})
 	}
 }

--- a/materialize-mysql/driver.go
+++ b/materialize-mysql/driver.go
@@ -318,6 +318,7 @@ func newMysqlDriver() *sql.Driver {
 				ConcurrentApply:     false,
 			}, nil
 		},
+		PreReqs: preReqs,
 	}
 }
 

--- a/materialize-mysql/driver_test.go
+++ b/materialize-mysql/driver_test.go
@@ -230,13 +230,7 @@ func TestPrereqs(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			cfg := tt.cfg(*cfg)
-
-			client, err := newClient(ctx, &sql.Endpoint{Config: cfg})
-			require.NoError(t, err)
-			defer client.Close()
-
-			var actual = client.PreReqs(ctx).Unwrap()
+			var actual = preReqs(ctx, tt.cfg(*cfg), "").Unwrap()
 
 			require.Equal(t, len(tt.want), len(actual))
 			for i := 0; i < len(tt.want); i++ {

--- a/materialize-postgres/client.go
+++ b/materialize-postgres/client.go
@@ -40,8 +40,16 @@ func newClient(ctx context.Context, ep *sql.Endpoint) (sql.Client, error) {
 	}, nil
 }
 
-func (c *client) PreReqs(ctx context.Context) *sql.PrereqErr {
+func preReqs(ctx context.Context, conf any, tenant string) *sql.PrereqErr {
 	errs := &sql.PrereqErr{}
+
+	cfg := conf.(*config)
+
+	db, err := stdsql.Open("pgx", cfg.ToURI())
+	if err != nil {
+		errs.Err(err)
+		return errs
+	}
 
 	// Use a reasonable timeout for this connection test. It is not uncommon for a misconfigured
 	// connection (wrong host, wrong port, etc.) to hang for several minutes on Ping and we want to
@@ -49,7 +57,7 @@ func (c *client) PreReqs(ctx context.Context) *sql.PrereqErr {
 	ctx, cancel := context.WithTimeout(ctx, 20*time.Second)
 	defer cancel()
 
-	if err := c.db.PingContext(ctx); err != nil {
+	if err := db.PingContext(ctx); err != nil {
 		// Provide a more user-friendly representation of some common error causes.
 		var pgErr *pgconn.PgError
 		var netConnErr *net.DNSError
@@ -60,15 +68,15 @@ func (c *client) PreReqs(ctx context.Context) *sql.PrereqErr {
 			case "28P01":
 				err = fmt.Errorf("incorrect username or password")
 			case "3D000":
-				err = fmt.Errorf("database %q does not exist", c.cfg.Database)
+				err = fmt.Errorf("database %q does not exist", cfg.Database)
 			}
 		} else if errors.As(err, &netConnErr) {
 			if netConnErr.IsNotFound {
-				err = fmt.Errorf("host at address %q cannot be found", c.cfg.Address)
+				err = fmt.Errorf("host at address %q cannot be found", cfg.Address)
 			}
 		} else if errors.As(err, &netOpErr) {
 			if netOpErr.Timeout() {
-				err = fmt.Errorf("connection to host at address %q timed out (incorrect host or port?)", c.cfg.Address)
+				err = fmt.Errorf("connection to host at address %q timed out (incorrect host or port?)", cfg.Address)
 			}
 		}
 

--- a/materialize-postgres/driver.go
+++ b/materialize-postgres/driver.go
@@ -214,6 +214,7 @@ func newPostgresDriver() *sql.Driver {
 				ConcurrentApply:     false,
 			}, nil
 		},
+		PreReqs: preReqs,
 	}
 }
 

--- a/materialize-postgres/driver_test.go
+++ b/materialize-postgres/driver_test.go
@@ -140,17 +140,9 @@ func TestPrereqs(t *testing.T) {
 		},
 	}
 
-	ctx := context.Background()
-
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			cfg := tt.cfg(*cfg)
-
-			client, err := newClient(ctx, &sql.Endpoint{Config: cfg})
-			require.NoError(t, err)
-			defer client.Close()
-
-			require.Equal(t, tt.want, client.PreReqs(context.Background()).Unwrap())
+			require.Equal(t, tt.want, preReqs(context.Background(), tt.cfg(*cfg), "testing").Unwrap())
 		})
 	}
 }

--- a/materialize-redshift/driver.go
+++ b/materialize-redshift/driver.go
@@ -266,6 +266,7 @@ func newRedshiftDriver() *sql.Driver {
 				ConcurrentApply:     true,
 			}, nil
 		},
+		PreReqs: preReqs,
 	}
 }
 

--- a/materialize-redshift/driver_test.go
+++ b/materialize-redshift/driver_test.go
@@ -221,13 +221,7 @@ func TestPrereqs(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			cfg := tt.cfg(cfg)
-
-			client, err := newClient(ctx, &sql.Endpoint{Config: cfg})
-			require.NoError(t, err)
-			defer client.Close()
-
-			require.Equal(t, tt.want, client.PreReqs(ctx).Unwrap())
+			require.Equal(t, tt.want, preReqs(ctx, tt.cfg(cfg), "testing").Unwrap())
 		})
 	}
 }

--- a/materialize-snowflake/snowflake.go
+++ b/materialize-snowflake/snowflake.go
@@ -134,6 +134,7 @@ func newSnowflakeDriver() *sql.Driver {
 				ConcurrentApply:     true,
 			}, nil
 		},
+		PreReqs: preReqs,
 	}
 }
 

--- a/materialize-snowflake/snowflake_test.go
+++ b/materialize-snowflake/snowflake_test.go
@@ -157,17 +157,9 @@ func TestPrereqs(t *testing.T) {
 		},
 	}
 
-	ctx := context.Background()
-
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			cfg := tt.cfg(cfg)
-
-			client, err := newClient(ctx, &sql.Endpoint{Config: cfg})
-			require.NoError(t, err)
-			defer client.Close()
-
-			require.Equal(t, tt.want, client.PreReqs(context.Background()).Unwrap())
+			require.Equal(t, tt.want, preReqs(context.Background(), tt.cfg(cfg), "testing").Unwrap())
 		})
 	}
 }

--- a/materialize-sql/endpoint.go
+++ b/materialize-sql/endpoint.go
@@ -19,12 +19,6 @@ type Client interface {
 	ExecStatements(ctx context.Context, statements []string) error
 	InstallFence(ctx context.Context, checkpoints Table, fence Fence) (Fence, error)
 
-	// PreReqs performs verification checks that the provided configuration can be used to interact
-	// with the endpoint to the degree required by the connector, to as much of an extent as
-	// possible. The returned PrereqErr can include multiple separate errors if it possible to
-	// determine that there is more than one issue that needs corrected.
-	PreReqs(ctx context.Context) *PrereqErr
-
 	// InfoSchema returns a populated *boilerplate.InfoSchema containing the state of the actual
 	// materialized tables in the schemas referenced by the resourcePaths. It doesn't necessarily
 	// need to include all tables in the entire destination system, but must include all tables in

--- a/materialize-sqlite/sqlite.go
+++ b/materialize-sqlite/sqlite.go
@@ -110,7 +110,7 @@ func (c *client) InfoSchema(ctx context.Context, resourcePaths [][]string) (is *
 	), nil
 }
 
-func (c *client) PreReqs(ctx context.Context) *sql.PrereqErr {
+func preReqs(ctx context.Context, conf any, tenant string) *sql.PrereqErr {
 	return &sql.PrereqErr{}
 }
 

--- a/materialize-sqlserver/driver.go
+++ b/materialize-sqlserver/driver.go
@@ -193,6 +193,7 @@ func newSqlServerDriver() *sql.Driver {
 				ConcurrentApply:     false,
 			}, nil
 		},
+		PreReqs: preReqs,
 	}
 }
 

--- a/materialize-sqlserver/driver_test.go
+++ b/materialize-sqlserver/driver_test.go
@@ -238,13 +238,7 @@ func TestPrereqs(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			cfg := tt.cfg(*cfg)
-
-			c, err := newClient(ctx, &sql.Endpoint{Config: cfg})
-			require.NoError(t, err)
-			defer c.Close()
-
-			var actual = c.PreReqs(ctx).Unwrap()
+			var actual = preReqs(ctx, tt.cfg(*cfg), "testing").Unwrap()
 
 			require.Equal(t, len(tt.want), len(actual))
 			for i := 0; i < len(tt.want); i++ {

--- a/materialize-starburst/client.go
+++ b/materialize-starburst/client.go
@@ -173,12 +173,16 @@ func (c *client) CreateSchema(ctx context.Context, schemaName string) error {
 	return sql.StdCreateSchema(ctx, c.db, c.ep.Dialect, schemaName)
 }
 
-func (c *client) PreReqs(ctx context.Context) *sql.PrereqErr {
+func preReqs(ctx context.Context, conf any, tenant string) *sql.PrereqErr {
 	errs := &sql.PrereqErr{}
-	err := c.db.PingContext(ctx)
-	if err != nil {
+
+	cfg := conf.(*config)
+	if db, err := openDB(cfg.ToURI()); err != nil {
+		errs.Err(err)
+	} else if err := db.PingContext(ctx); err != nil {
 		errs.Err(err)
 	}
+
 	return errs
 }
 

--- a/materialize-starburst/starburst.go
+++ b/materialize-starburst/starburst.go
@@ -137,6 +137,7 @@ func newStarburstDriver() *sql.Driver {
 				Tenant:              tenant,
 			}, nil
 		},
+		PreReqs: preReqs,
 	}
 }
 

--- a/tests/materialize/materialize-databricks/config.yaml
+++ b/tests/materialize/materialize-databricks/config.yaml
@@ -7,7 +7,7 @@ syncSchedule:
     syncFrequency: 0s
 credentials:
     auth_type: PAT
-    personal_access_token_sops: ENC[AES256_GCM,data:LBaw6Ry6tXhZ4sWfENJ2It8PzERVVysVyqghFleppL1Fjcb/,iv:fx2I8YpHNZL/mqHvdP08cnGdfNtmm2oCA2QCmtxpgMU=,tag:5CIlCwbb2gv8BP/l+SuMWw==,type:str]
+    personal_access_token_sops: ENC[AES256_GCM,data:XIk56zlHUY/JOcXcJHEjn1lwBPkHrnEeelbwlluZpJLsxO5F,iv:5wFjIu/MRFf9NSGZJ7NVYql8n6v46DZ1+NjpKlBBaek=,tag:+zjtRfAA4ak/krR78PQyMA==,type:str]
 sops:
     kms: []
     gcp_kms:
@@ -17,8 +17,8 @@ sops:
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2024-07-03T16:41:43Z"
-    mac: ENC[AES256_GCM,data:iQWcd4Afi5lWsW1ZLu0CP1RRqTm/pGtkHhBGkBlHnF3zUT1JW1Y7WvolGuoMqx6JrOX6Cyj4aTEFbr6dD/kI//NY7OziMxLnstuWFUn6Yu7uYrkql+fVvHX6mJO4LnsVI8ULKODvGRxNCw7AMLc9nbu6CJtzwscn06i7nGcejAk=,iv:FvKuCfZrHHikJVltDB/fBdiKfo90leO+c+wUAbwTznM=,tag:UVH23+rEyRZv69Bq7OSF6A==,type:str]
+    lastmodified: "2024-08-12T16:51:23Z"
+    mac: ENC[AES256_GCM,data:KwymtIUa8+JtaFOf3EE6RI93WP03Ho41xFjzW1lNAHQQBjEkvPcqor3+zbZWsbIdBRmxjr9Yw71QbX0mZTRdyDhQl9HhZKVZrHxsav69BhKmpruKNP1X7eX9sR/axO+TbfYjAkyZw7Fmo76lnUXn6J0wAN1cIkuUQyPecv/iqHs=,iv:ZSXsvS7gYGlI3HU4BXwPwk3f1XvLVkwU/91Pmz3lOo0=,tag:0KGzElp/6wNvq/CIu+wXrg==,type:str]
     pgp: []
     encrypted_suffix: _sops
     version: 3.8.1


### PR DESCRIPTION
**Description:**

Many SQL materializations have come to need to run queries or otherwise interact with the destination system as part of their endpoint initialization. This effectively bypasses the pre-requisite checking that is currently implemented in the `Client.Prereqs` method, and can result in confusing and misleading raw error messages if the connector is misconfigured.

The fix here is to make the prereqs checking a separate function that is called prior to creating the endpoint. This implementation tends toward a quick-and-dirty fix, and a more satisfying code structuring would probably involve a much larger refactoring that would incorporate generics. But I'm holding off on doing that for now to get the better error messages working again ASAP.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1792)
<!-- Reviewable:end -->
