### PR TITLE
materialize-bigquery: don't start the staged file unless there is data to write to it

### DIFF
--- a/materialize-bigquery/transactor.go
+++ b/materialize-bigquery/transactor.go
@@ -253,7 +253,6 @@ func (t *transactor) Store(it *m.StoreIterator) (m.StartCommitFunc, error) {
 	log.Info("store: starting encoding and uploading of files")
 	for it.Next() {
 		var b = t.bindings[it.Binding]
-		b.storeFile.start()
 
 		var flowDocument = it.RawJSON
 		if t.cfg.HardDelete && it.Delete {
@@ -264,6 +263,9 @@ func (t *transactor) Store(it *m.StoreIterator) (m.StartCommitFunc, error) {
 				continue
 			}
 		}
+
+		b.storeFile.start()
+
 		converted, err := b.target.ConvertAll(it.Key, it.Values, flowDocument)
 		if err != nil {
 			return nil, fmt.Errorf("converting store parameters: %w", err)


### PR DESCRIPTION
**Description:**

If hard deletions are enabled it is possible that a transaction will contain only a single record for a document that is being deleted and doesn't already exist. In this case we won't write any data to the staged file or table.

This scenario uniquely impacts materialize-bigquery, since BigQuery requires there to actually be at least one file present when doing the equivalent of `SELECT * FROM gs://bucket/*.json`, and the rare case of a binding with only deletion of non-existent keys with hard deletions enabled will result in there not being any data to load.

There is likely a more principled way to accomplish this fix, but moving the "starting" of the staged file down a few lines gets it done quickly and easily, and in a way that is assured to not cause any other problems. This particular edge case is not a wide-spread issue, so I'm keeping the change isolated to BigQuery specifically.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1797)
<!-- Reviewable:end -->
