### PR TITLE
source-zendesk-support: fix `ticket_audits` schema and pagination

### DIFF
--- a/source-zendesk-support/acmeCo/ticket_audits.schema.yaml
+++ b/source-zendesk-support/acmeCo/ticket_audits.schema.yaml
@@ -202,6 +202,7 @@ properties:
               additionalProperties: true
             - type: string
             - type: "null"
+            - type: integer
         author_id:
           type:
             - "null"

--- a/source-zendesk-support/source_zendesk_support/schemas/ticket_audits.json
+++ b/source-zendesk-support/source_zendesk_support/schemas/ticket_audits.json
@@ -87,6 +87,9 @@
               },
               {
                 "type": "null"
+              },
+              {
+                "type": "integer"
               }
             ]
           },

--- a/source-zendesk-support/tests/snapshots/snapshots__discover__capture.stdout.json
+++ b/source-zendesk-support/tests/snapshots/snapshots__discover__capture.stdout.json
@@ -1616,6 +1616,9 @@
                   },
                   {
                     "type": "null"
+                  },
+                  {
+                    "type": "integer"
                   }
                 ]
               },

--- a/source-zendesk-support/tests/unit_test.py
+++ b/source-zendesk-support/tests/unit_test.py
@@ -653,7 +653,7 @@ class TestSourceZendeskSupportCursorPaginationStream:
             (GroupMemberships, {"page": 1, "per_page": 100, "sort_by": "asc", "start_time": 1622505600}),
             (TicketForms, {"start_time": 1622505600}),
             (TicketMetricEvents, {"start_time": 1622505600}),
-            (TicketAudits, {"sort_by": "created_at", "sort_order": "desc", "limit": 1000}),
+            (TicketAudits, {"limit": 200}),
             (SatisfactionRatings, {"page": 1, "per_page": 100, "sort_by": "asc", "start_time": 1622505600}),
             (TicketMetrics, {"page[size]": 100, "start_time": 1622505600}),
             (OrganizationMemberships, {"page[size]": 100, "start_time": 1622505600})


### PR DESCRIPTION
**Description:**

Schema violations were occurring because the `value` in a `ticket_audits` document could be an integer. Also, `ticket_audits` were taking a significant amount of time to complete reading documents. This is because the API endpoint does not support filtering results by a start date, so we were reading all documents available. To fix this, logic to filter client-side has been added for the `ticket_audits` stream

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

No documentation updates needed.

**Notes for reviewers:**

Tested on a local stack with a non-trivial amount of documents. Ensured the document that previously caused a schema violation no longer causes an issue. Confirmed pagination works, and stream still gets documents incrementally after the initial backfill.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1799)
<!-- Reviewable:end -->
