### PR TITLE
source-zendesk-support: handle bools in `ticket_skips` documents

### DIFF
--- a/source-zendesk-support/source_zendesk_support/streams.py
+++ b/source-zendesk-support/source_zendesk_support/streams.py
@@ -976,6 +976,18 @@ class TicketSkips(SourceZendeskSupportCursorPaginationStream):
 
         return params
 
+    def parse_response(self, response: requests.Response, **kwargs) -> Iterable[Mapping]:
+        for record in super().parse_response(response, **kwargs):
+            # Additional handling to coerce custom fields' boolean values to strings.
+            custom_fields = record.get("ticket", {}).get("custom_fields", [])
+
+            for field in custom_fields:
+                value = field.get("value", None)
+                if isinstance(value, bool):
+                    field["value"] = str(value).lower()
+
+            yield record
+
 
 class Posts(SourceZendeskSupportCursorPaginationStream):
     """Posts: https://developer.zendesk.com/api-reference/help_center/help-center-api/posts/#list-posts"""


### PR DESCRIPTION
**Description:**

Very rarely, we get boolean values in a `TicketSkips` stream's custom field values. This change coerces those bools to strings, when present. Using the `parse_response` method for this purpose is similar to its use in other streams, like `TicketComments`.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

No documentation updates needed.

**Notes for reviewers:**

Tested on a local stack. Confirmed that boolean values `True` and `False` are changed to strings & that when the value is not a boolean it's left unchanged.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1802)
<!-- Reviewable:end -->
