### PR TITLE
materialize-sql: start network tunneling prior to checking pre-reqs

### DIFF
--- a/materialize-bigquery/bigquery.go
+++ b/materialize-bigquery/bigquery.go
@@ -157,6 +157,7 @@ func newBigQueryDriver() *sql.Driver {
 		DocumentationURL: "https://go.estuary.dev/materialize-bigquery",
 		EndpointSpecType: new(config),
 		ResourceSpecType: new(tableConfig),
+		StartTunnel:      func(ctx context.Context, conf any) error { return nil },
 		NewEndpoint: func(ctx context.Context, raw json.RawMessage, tenant string) (*sql.Endpoint, error) {
 			var cfg = new(config)
 			if err := pf.UnmarshalStrict(raw, cfg); err != nil {

--- a/materialize-databricks/driver.go
+++ b/materialize-databricks/driver.go
@@ -74,6 +74,7 @@ func newDatabricksDriver() *sql.Driver {
 		DocumentationURL: "https://go.estuary.dev/materialize-databricks",
 		EndpointSpecType: new(config),
 		ResourceSpecType: new(tableConfig),
+		StartTunnel:      func(ctx context.Context, conf any) error { return nil },
 		NewEndpoint: func(ctx context.Context, raw json.RawMessage, tenant string) (*sql.Endpoint, error) {
 			var cfg = new(config)
 			if err := pf.UnmarshalStrict(raw, cfg); err != nil {

--- a/materialize-motherduck/driver.go
+++ b/materialize-motherduck/driver.go
@@ -151,6 +151,7 @@ func newDuckDriver() *sql.Driver {
 		DocumentationURL: "https://go.estuary.dev/materialize-motherduck",
 		EndpointSpecType: new(config),
 		ResourceSpecType: new(tableConfig),
+		StartTunnel:      func(ctx context.Context, conf any) error { return nil },
 		NewEndpoint: func(ctx context.Context, raw json.RawMessage, tenant string) (*sql.Endpoint, error) {
 			var cfg = new(config)
 			if err := pf.UnmarshalStrict(raw, cfg); err != nil {

--- a/materialize-redshift/driver.go
+++ b/materialize-redshift/driver.go
@@ -195,6 +195,32 @@ func newRedshiftDriver() *sql.Driver {
 		DocumentationURL: "https://go.estuary.dev/materialize-redshift",
 		EndpointSpecType: new(config),
 		ResourceSpecType: new(tableConfig),
+		StartTunnel: func(ctx context.Context, conf any) error {
+			cfg := conf.(*config)
+
+			// If SSH Endpoint is configured, then try to start a tunnel before establishing connections
+			if cfg.networkTunnelEnabled() {
+				host, port, err := net.SplitHostPort(cfg.Address)
+				if err != nil {
+					return fmt.Errorf("splitting address to host and port: %w", err)
+				}
+
+				var sshConfig = &networkTunnel.SshConfig{
+					SshEndpoint: cfg.NetworkTunnel.SshForwarding.SshEndpoint,
+					PrivateKey:  []byte(cfg.NetworkTunnel.SshForwarding.PrivateKey),
+					ForwardHost: host,
+					ForwardPort: port,
+					LocalPort:   "5432",
+				}
+				var tunnel = sshConfig.CreateTunnel()
+
+				if err := tunnel.Start(); err != nil {
+					return fmt.Errorf("error starting network tunnel: %w", err)
+				}
+			}
+
+			return nil
+		},
 		NewEndpoint: func(ctx context.Context, raw json.RawMessage, tenant string) (*sql.Endpoint, error) {
 			var cfg = new(config)
 			if err := pf.UnmarshalStrict(raw, cfg); err != nil {
@@ -212,27 +238,6 @@ func newRedshiftDriver() *sql.Driver {
 				metaBase = append(metaBase, cfg.Schema)
 			}
 			metaSpecs, metaCheckpoints := sql.MetaTables(metaBase)
-
-			// If SSH Endpoint is configured, then try to start a tunnel before establishing connections
-			if cfg.networkTunnelEnabled() {
-				host, port, err := net.SplitHostPort(cfg.Address)
-				if err != nil {
-					return nil, fmt.Errorf("splitting address to host and port: %w", err)
-				}
-
-				var sshConfig = &networkTunnel.SshConfig{
-					SshEndpoint: cfg.NetworkTunnel.SshForwarding.SshEndpoint,
-					PrivateKey:  []byte(cfg.NetworkTunnel.SshForwarding.PrivateKey),
-					ForwardHost: host,
-					ForwardPort: port,
-					LocalPort:   "5432",
-				}
-				var tunnel = sshConfig.CreateTunnel()
-
-				if err := tunnel.Start(); err != nil {
-					return nil, fmt.Errorf("error starting network tunnel: %w", err)
-				}
-			}
 
 			db, err := stdsql.Open("pgx", cfg.toURI())
 			if err != nil {

--- a/materialize-snowflake/snowflake.go
+++ b/materialize-snowflake/snowflake.go
@@ -84,6 +84,7 @@ func newSnowflakeDriver() *sql.Driver {
 		DocumentationURL: "https://go.estuary.dev/materialize-snowflake",
 		EndpointSpecType: new(config),
 		ResourceSpecType: new(tableConfig),
+		StartTunnel:      func(ctx context.Context, conf any) error { return nil },
 		NewEndpoint: func(ctx context.Context, raw json.RawMessage, tenant string) (*sql.Endpoint, error) {
 			var parsed = new(config)
 			if err := pf.UnmarshalStrict(raw, parsed); err != nil {

--- a/materialize-sqlite/sqlite.go
+++ b/materialize-sqlite/sqlite.go
@@ -58,6 +58,7 @@ func NewSQLiteDriver() *sql.Driver {
 		DocumentationURL: "https://go.estuary.dev/materialize-sqlite",
 		EndpointSpecType: new(config),
 		ResourceSpecType: new(tableConfig),
+		StartTunnel:      func(ctx context.Context, conf any) error { return nil },
 		NewEndpoint: func(ctx context.Context, _ json.RawMessage, _ string) (*sql.Endpoint, error) {
 			var path = databasePath
 

--- a/materialize-sqlserver/driver.go
+++ b/materialize-sqlserver/driver.go
@@ -121,26 +121,14 @@ func newSqlServerDriver() *sql.Driver {
 		DocumentationURL: "https://go.estuary.dev/materialize-sqlserver",
 		EndpointSpecType: new(config),
 		ResourceSpecType: new(tableConfig),
-		NewEndpoint: func(ctx context.Context, raw json.RawMessage, tenant string) (*sql.Endpoint, error) {
-			var cfg = new(config)
-			if err := pf.UnmarshalStrict(raw, cfg); err != nil {
-				return nil, fmt.Errorf("parsing endpoint configuration: %w", err)
-			}
-
-			log.WithFields(log.Fields{
-				"database": cfg.Database,
-				"address":  cfg.Address,
-				"user":     cfg.User,
-			}).Info("opening database")
-
-			var metaBase sql.TablePath
-			var metaSpecs, metaCheckpoints = sql.MetaTables(metaBase)
+		StartTunnel: func(ctx context.Context, conf any) error {
+			cfg := conf.(*config)
 
 			// If SSH Endpoint is configured, then try to start a tunnel before establishing connections
 			if cfg.NetworkTunnel != nil && cfg.NetworkTunnel.SshForwarding != nil && cfg.NetworkTunnel.SshForwarding.SshEndpoint != "" {
 				host, port, err := net.SplitHostPort(cfg.Address)
 				if err != nil {
-					return nil, fmt.Errorf("splitting address to host and port: %w", err)
+					return fmt.Errorf("splitting address to host and port: %w", err)
 				}
 
 				var sshConfig = &networkTunnel.SshConfig{
@@ -155,9 +143,26 @@ func newSqlServerDriver() *sql.Driver {
 				// FIXME/question: do we need to shut down the tunnel manually if it is a child process?
 				// at the moment tunnel.Stop is not being called anywhere, but if the connector shuts down, the child process also shuts down.
 				if err := tunnel.Start(); err != nil {
-					return nil, fmt.Errorf("error starting network tunnel: %w", err)
+					return fmt.Errorf("error starting network tunnel: %w", err)
 				}
 			}
+
+			return nil
+		},
+		NewEndpoint: func(ctx context.Context, raw json.RawMessage, tenant string) (*sql.Endpoint, error) {
+			var cfg = new(config)
+			if err := pf.UnmarshalStrict(raw, cfg); err != nil {
+				return nil, fmt.Errorf("parsing endpoint configuration: %w", err)
+			}
+
+			log.WithFields(log.Fields{
+				"database": cfg.Database,
+				"address":  cfg.Address,
+				"user":     cfg.User,
+			}).Info("opening database")
+
+			var metaBase sql.TablePath
+			var metaSpecs, metaCheckpoints = sql.MetaTables(metaBase)
 
 			db, err := stdsql.Open("sqlserver", cfg.ToURI())
 			if err != nil {

--- a/materialize-starburst/starburst.go
+++ b/materialize-starburst/starburst.go
@@ -109,6 +109,7 @@ func newStarburstDriver() *sql.Driver {
 		DocumentationURL: "https://go.estuary.dev/materialize-starburst",
 		EndpointSpecType: new(config),
 		ResourceSpecType: new(tableConfig),
+		StartTunnel:      func(ctx context.Context, conf any) error { return nil },
 		NewEndpoint: func(ctx context.Context, raw json.RawMessage, tenant string) (*sql.Endpoint, error) {
 			var cfg = new(config)
 			if err := pf.UnmarshalStrict(raw, cfg); err != nil {

--- a/tests/materialize/materialize-elasticsearch/snapshot.json
+++ b/tests/materialize/materialize-elasticsearch/snapshot.json
@@ -29,7 +29,7 @@
         "canary": "amputation's",
         "id": 1
       },
-      "flow_published_at": "1970-01-01T00:00:00Z",
+      "flow_published_at": "1970-01-01T00:00:00.000000000Z",
       "id": 1
     },
     {
@@ -42,7 +42,7 @@
         "canary": "armament's",
         "id": 2
       },
-      "flow_published_at": "1970-01-01T00:00:01Z",
+      "flow_published_at": "1970-01-01T00:00:01.000000000Z",
       "id": 2
     },
     {
@@ -55,7 +55,7 @@
         "canary": "splatters",
         "id": 3
       },
-      "flow_published_at": "1970-01-01T00:00:02Z",
+      "flow_published_at": "1970-01-01T00:00:02.000000000Z",
       "id": 3
     },
     {
@@ -68,7 +68,7 @@
         "canary": "strengthen",
         "id": 4
       },
-      "flow_published_at": "1970-01-01T00:00:03Z",
+      "flow_published_at": "1970-01-01T00:00:03.000000000Z",
       "id": 4
     },
     {
@@ -81,7 +81,7 @@
         "canary": "Kringle's",
         "id": 5
       },
-      "flow_published_at": "1970-01-01T00:00:04Z",
+      "flow_published_at": "1970-01-01T00:00:04.000000000Z",
       "id": 5
     },
     {
@@ -94,7 +94,7 @@
         "canary": "grosbeak's",
         "id": 6
       },
-      "flow_published_at": "1970-01-01T00:00:05Z",
+      "flow_published_at": "1970-01-01T00:00:05.000000000Z",
       "id": 6
     },
     {
@@ -107,7 +107,7 @@
         "canary": "pieced",
         "id": 7
       },
-      "flow_published_at": "1970-01-01T01:00:00Z",
+      "flow_published_at": "1970-01-01T01:00:00.000000000Z",
       "id": 7
     },
     {
@@ -120,7 +120,7 @@
         "canary": "roaches",
         "id": 8
       },
-      "flow_published_at": "1970-01-01T01:00:01Z",
+      "flow_published_at": "1970-01-01T01:00:01.000000000Z",
       "id": 8
     },
     {
@@ -133,7 +133,7 @@
         "canary": "devilish",
         "id": 9
       },
-      "flow_published_at": "1970-01-01T01:00:02Z",
+      "flow_published_at": "1970-01-01T01:00:02.000000000Z",
       "id": 9
     },
     {
@@ -146,7 +146,7 @@
         "canary": "glucose's",
         "id": 10
       },
-      "flow_published_at": "1970-01-01T01:00:03Z",
+      "flow_published_at": "1970-01-01T01:00:03.000000000Z",
       "id": 10
     }
   ]
@@ -164,7 +164,7 @@
         "int": 7,
         "str": "str 6"
       },
-      "flow_published_at": "1970-01-01T01:00:04Z",
+      "flow_published_at": "1970-01-01T01:00:04.000000000Z",
       "id": 1,
       "int": 7,
       "str": "str 6"
@@ -179,7 +179,7 @@
         "int": 9,
         "str": "str 7"
       },
-      "flow_published_at": "1970-01-01T01:00:05Z",
+      "flow_published_at": "1970-01-01T01:00:05.000000000Z",
       "id": 2,
       "int": 9,
       "str": "str 7"
@@ -194,7 +194,7 @@
         "int": 11,
         "str": "str 8"
       },
-      "flow_published_at": "1970-01-01T01:00:06Z",
+      "flow_published_at": "1970-01-01T01:00:06.000000000Z",
       "id": 3,
       "int": 11,
       "str": "str 8"
@@ -209,7 +209,7 @@
         "int": 13,
         "str": "str 9"
       },
-      "flow_published_at": "1970-01-01T01:00:07Z",
+      "flow_published_at": "1970-01-01T01:00:07.000000000Z",
       "id": 4,
       "int": 13,
       "str": "str 9"
@@ -224,7 +224,7 @@
         "int": 15,
         "str": "str 10"
       },
-      "flow_published_at": "1970-01-01T01:00:08Z",
+      "flow_published_at": "1970-01-01T01:00:08.000000000Z",
       "id": 5,
       "int": 15,
       "str": "str 10"
@@ -244,7 +244,7 @@
         "int": 1,
         "str": "str 1"
       },
-      "flow_published_at": "1970-01-01T00:00:06Z",
+      "flow_published_at": "1970-01-01T00:00:06.000000000Z",
       "id": 1,
       "int": 1,
       "str": "str 1"
@@ -259,7 +259,7 @@
         "int": 6,
         "str": "str 6"
       },
-      "flow_published_at": "1970-01-01T01:00:04Z",
+      "flow_published_at": "1970-01-01T01:00:04.000000000Z",
       "id": 1,
       "int": 6,
       "str": "str 6"
@@ -274,7 +274,7 @@
         "int": 2,
         "str": "str 2"
       },
-      "flow_published_at": "1970-01-01T00:00:07Z",
+      "flow_published_at": "1970-01-01T00:00:07.000000000Z",
       "id": 2,
       "int": 2,
       "str": "str 2"
@@ -289,7 +289,7 @@
         "int": 7,
         "str": "str 7"
       },
-      "flow_published_at": "1970-01-01T01:00:05Z",
+      "flow_published_at": "1970-01-01T01:00:05.000000000Z",
       "id": 2,
       "int": 7,
       "str": "str 7"
@@ -304,7 +304,7 @@
         "int": 3,
         "str": "str 3"
       },
-      "flow_published_at": "1970-01-01T00:00:08Z",
+      "flow_published_at": "1970-01-01T00:00:08.000000000Z",
       "id": 3,
       "int": 3,
       "str": "str 3"
@@ -319,7 +319,7 @@
         "int": 8,
         "str": "str 8"
       },
-      "flow_published_at": "1970-01-01T01:00:06Z",
+      "flow_published_at": "1970-01-01T01:00:06.000000000Z",
       "id": 3,
       "int": 8,
       "str": "str 8"
@@ -334,7 +334,7 @@
         "int": 4,
         "str": "str 4"
       },
-      "flow_published_at": "1970-01-01T00:00:09Z",
+      "flow_published_at": "1970-01-01T00:00:09.000000000Z",
       "id": 4,
       "int": 4,
       "str": "str 4"
@@ -349,7 +349,7 @@
         "int": 9,
         "str": "str 9"
       },
-      "flow_published_at": "1970-01-01T01:00:07Z",
+      "flow_published_at": "1970-01-01T01:00:07.000000000Z",
       "id": 4,
       "int": 9,
       "str": "str 9"
@@ -364,7 +364,7 @@
         "int": 5,
         "str": "str 5"
       },
-      "flow_published_at": "1970-01-01T00:00:10Z",
+      "flow_published_at": "1970-01-01T00:00:10.000000000Z",
       "id": 5,
       "int": 5,
       "str": "str 5"
@@ -379,7 +379,7 @@
         "int": 10,
         "str": "str 10"
       },
-      "flow_published_at": "1970-01-01T01:00:08Z",
+      "flow_published_at": "1970-01-01T01:00:08.000000000Z",
       "id": 5,
       "int": 10,
       "str": "str 10"
@@ -391,70 +391,70 @@
   "rows": [
     {
       "_meta/flow_truncated": false,
-      "flow_published_at": "1970-01-01T00:00:06Z",
+      "flow_published_at": "1970-01-01T00:00:06.000000000Z",
       "id": 1,
       "int": 1,
       "str": "str 1"
     },
     {
       "_meta/flow_truncated": false,
-      "flow_published_at": "1970-01-01T01:00:04Z",
+      "flow_published_at": "1970-01-01T01:00:04.000000000Z",
       "id": 1,
       "int": 6,
       "str": "str 6"
     },
     {
       "_meta/flow_truncated": false,
-      "flow_published_at": "1970-01-01T00:00:07Z",
+      "flow_published_at": "1970-01-01T00:00:07.000000000Z",
       "id": 2,
       "int": 2,
       "str": "str 2"
     },
     {
       "_meta/flow_truncated": false,
-      "flow_published_at": "1970-01-01T01:00:05Z",
+      "flow_published_at": "1970-01-01T01:00:05.000000000Z",
       "id": 2,
       "int": 7,
       "str": "str 7"
     },
     {
       "_meta/flow_truncated": false,
-      "flow_published_at": "1970-01-01T00:00:08Z",
+      "flow_published_at": "1970-01-01T00:00:08.000000000Z",
       "id": 3,
       "int": 3,
       "str": "str 3"
     },
     {
       "_meta/flow_truncated": false,
-      "flow_published_at": "1970-01-01T01:00:06Z",
+      "flow_published_at": "1970-01-01T01:00:06.000000000Z",
       "id": 3,
       "int": 8,
       "str": "str 8"
     },
     {
       "_meta/flow_truncated": false,
-      "flow_published_at": "1970-01-01T00:00:09Z",
+      "flow_published_at": "1970-01-01T00:00:09.000000000Z",
       "id": 4,
       "int": 4,
       "str": "str 4"
     },
     {
       "_meta/flow_truncated": false,
-      "flow_published_at": "1970-01-01T01:00:07Z",
+      "flow_published_at": "1970-01-01T01:00:07.000000000Z",
       "id": 4,
       "int": 9,
       "str": "str 9"
     },
     {
       "_meta/flow_truncated": false,
-      "flow_published_at": "1970-01-01T00:00:10Z",
+      "flow_published_at": "1970-01-01T00:00:10.000000000Z",
       "id": 5,
       "int": 5,
       "str": "str 5"
     },
     {
       "_meta/flow_truncated": false,
-      "flow_published_at": "1970-01-01T01:00:08Z",
+      "flow_published_at": "1970-01-01T01:00:08.000000000Z",
       "id": 5,
       "int": 10,
       "str": "str 10"
@@ -487,7 +487,7 @@
         "nullable_int": null,
         "str_field": "str1"
       },
-      "flow_published_at": "1970-01-01T00:00:13Z",
+      "flow_published_at": "1970-01-01T00:00:13.000000000Z",
       "id": 1,
       "nested": {
         "id": "i1"
@@ -518,7 +518,7 @@
         "nullable_int": 2,
         "str_field": "str2"
       },
-      "flow_published_at": "1970-01-01T00:00:14Z",
+      "flow_published_at": "1970-01-01T00:00:14.000000000Z",
       "id": 2,
       "nested": {
         "id": "i2"
@@ -549,7 +549,7 @@
         "nullable_int": null,
         "str_field": "str3"
       },
-      "flow_published_at": "1970-01-01T00:00:15Z",
+      "flow_published_at": "1970-01-01T00:00:15.000000000Z",
       "id": 3,
       "nested": {
         "id": "i3"
@@ -580,7 +580,7 @@
         "nullable_int": 4,
         "str_field": "str4"
       },
-      "flow_published_at": "1970-01-01T00:00:16Z",
+      "flow_published_at": "1970-01-01T00:00:16.000000000Z",
       "id": 4,
       "nested": {
         "id": "i4"
@@ -611,7 +611,7 @@
         "nullable_int": null,
         "str_field": "str5"
       },
-      "flow_published_at": "1970-01-01T00:00:17Z",
+      "flow_published_at": "1970-01-01T00:00:17.000000000Z",
       "id": 5,
       "nested": {
         "id": "i5"
@@ -646,7 +646,7 @@
         "nullable_int": 6,
         "str_field": "str6 v2"
       },
-      "flow_published_at": "1970-01-01T01:00:19Z",
+      "flow_published_at": "1970-01-01T01:00:19.000000000Z",
       "id": 6,
       "nested": {
         "id": "i6"
@@ -679,7 +679,7 @@
         "nullable_int": null,
         "str_field": "str7 v2"
       },
-      "flow_published_at": "1970-01-01T01:00:20Z",
+      "flow_published_at": "1970-01-01T01:00:20.000000000Z",
       "id": 7,
       "nested": {
         "id": "i7"
@@ -710,7 +710,7 @@
         "nullable_int": 8,
         "str_field": "str8 v2"
       },
-      "flow_published_at": "1970-01-01T01:00:21Z",
+      "flow_published_at": "1970-01-01T01:00:21.000000000Z",
       "id": 8,
       "nested": {
         "id": "i8"
@@ -741,7 +741,7 @@
         "nullable_int": null,
         "str_field": "str9 v2"
       },
-      "flow_published_at": "1970-01-01T01:00:22Z",
+      "flow_published_at": "1970-01-01T01:00:22.000000000Z",
       "id": 9,
       "nested": {
         "id": "i9"
@@ -772,7 +772,7 @@
         "nullable_int": 10,
         "str_field": "str10 v2"
       },
-      "flow_published_at": "1970-01-01T01:00:23Z",
+      "flow_published_at": "1970-01-01T01:00:23.000000000Z",
       "id": 10,
       "nested": {
         "id": "i10"
@@ -802,7 +802,7 @@
         "num_str": "10.1",
         "time": "00:00:00Z"
       },
-      "flow_published_at": "1970-01-01T01:00:13Z",
+      "flow_published_at": "1970-01-01T01:00:13.000000000Z",
       "id": 1,
       "int_and_str": 1,
       "int_str": "10",
@@ -827,7 +827,7 @@
         "num_str": "20.1",
         "time": "14:20:12.33Z"
       },
-      "flow_published_at": "1970-01-01T01:00:14Z",
+      "flow_published_at": "1970-01-01T01:00:14.000000000Z",
       "id": 2,
       "int_and_str": 2,
       "int_str": "20",
@@ -852,7 +852,7 @@
         "num_str": "30.1",
         "time": "23:59:38.10Z"
       },
-      "flow_published_at": "1970-01-01T00:00:11Z",
+      "flow_published_at": "1970-01-01T00:00:11.000000000Z",
       "id": 3,
       "int_and_str": 3,
       "int_str": "30",
@@ -877,7 +877,7 @@
         "num_str": "40.1",
         "time": "23:59:38Z"
       },
-      "flow_published_at": "1970-01-01T00:00:12Z",
+      "flow_published_at": "1970-01-01T00:00:12.000000000Z",
       "id": 4,
       "int_and_str": "4",
       "int_str": "40",
@@ -902,7 +902,7 @@
         "num_str": "50.1",
         "time": "23:59:59Z"
       },
-      "flow_published_at": "1970-01-01T01:00:15Z",
+      "flow_published_at": "1970-01-01T01:00:15.000000000Z",
       "id": 5,
       "int_and_str": "5",
       "int_str": "50",
@@ -921,7 +921,7 @@
         "id": 8,
         "num_str": "NaN"
       },
-      "flow_published_at": "1970-01-01T01:00:16Z",
+      "flow_published_at": "1970-01-01T01:00:16.000000000Z",
       "id": 8,
       "int_and_str": null,
       "int_str": null,
@@ -940,7 +940,7 @@
         "id": 9,
         "num_str": "Infinity"
       },
-      "flow_published_at": "1970-01-01T01:00:17Z",
+      "flow_published_at": "1970-01-01T01:00:17.000000000Z",
       "id": 9,
       "int_and_str": null,
       "int_str": null,
@@ -959,7 +959,7 @@
         "id": 10,
         "num_str": "-Infinity"
       },
-      "flow_published_at": "1970-01-01T01:00:18Z",
+      "flow_published_at": "1970-01-01T01:00:18.000000000Z",
       "id": 10,
       "int_and_str": null,
       "int_str": null,
@@ -982,7 +982,7 @@
         },
         "id": 2
       },
-      "flow_published_at": "1970-01-01T01:00:26Z",
+      "flow_published_at": "1970-01-01T01:00:26.000000000Z",
       "id": 2
     },
     {
@@ -995,7 +995,7 @@
         },
         "id": 3
       },
-      "flow_published_at": "1970-01-01T01:00:27Z",
+      "flow_published_at": "1970-01-01T01:00:27.000000000Z",
       "id": 3
     }
   ]

--- a/tests/materialize/materialize-google-sheets/snapshot.json
+++ b/tests/materialize/materialize-google-sheets/snapshot.json
@@ -59,7 +59,7 @@
     },
     {
       "userEnteredValue": {
-        "stringValue": "1970-01-01T00:00:00Z"
+        "stringValue": "1970-01-01T00:00:00.000000000Z"
       }
     }
   ]
@@ -78,7 +78,7 @@
     },
     {
       "userEnteredValue": {
-        "stringValue": "1970-01-01T00:00:01Z"
+        "stringValue": "1970-01-01T00:00:01.000000000Z"
       }
     }
   ]
@@ -97,7 +97,7 @@
     },
     {
       "userEnteredValue": {
-        "stringValue": "1970-01-01T00:00:02Z"
+        "stringValue": "1970-01-01T00:00:02.000000000Z"
       }
     }
   ]
@@ -116,7 +116,7 @@
     },
     {
       "userEnteredValue": {
-        "stringValue": "1970-01-01T00:00:03Z"
+        "stringValue": "1970-01-01T00:00:03.000000000Z"
       }
     }
   ]
@@ -135,7 +135,7 @@
     },
     {
       "userEnteredValue": {
-        "stringValue": "1970-01-01T00:00:04Z"
+        "stringValue": "1970-01-01T00:00:04.000000000Z"
       }
     }
   ]
@@ -154,7 +154,7 @@
     },
     {
       "userEnteredValue": {
-        "stringValue": "1970-01-01T00:00:05Z"
+        "stringValue": "1970-01-01T00:00:05.000000000Z"
       }
     }
   ]
@@ -173,7 +173,7 @@
     },
     {
       "userEnteredValue": {
-        "stringValue": "1970-01-01T01:00:00Z"
+        "stringValue": "1970-01-01T01:00:00.000000000Z"
       }
     }
   ]
@@ -192,7 +192,7 @@
     },
     {
       "userEnteredValue": {
-        "stringValue": "1970-01-01T01:00:01Z"
+        "stringValue": "1970-01-01T01:00:01.000000000Z"
       }
     }
   ]
@@ -211,7 +211,7 @@
     },
     {
       "userEnteredValue": {
-        "stringValue": "1970-01-01T01:00:02Z"
+        "stringValue": "1970-01-01T01:00:02.000000000Z"
       }
     }
   ]
@@ -230,7 +230,7 @@
     },
     {
       "userEnteredValue": {
-        "stringValue": "1970-01-01T01:00:03Z"
+        "stringValue": "1970-01-01T01:00:03.000000000Z"
       }
     }
   ]
@@ -268,7 +268,7 @@
     },
     {
       "userEnteredValue": {
-        "stringValue": "1970-01-01T01:00:04Z"
+        "stringValue": "1970-01-01T01:00:04.000000000Z"
       }
     },
     {
@@ -292,7 +292,7 @@
     },
     {
       "userEnteredValue": {
-        "stringValue": "1970-01-01T01:00:05Z"
+        "stringValue": "1970-01-01T01:00:05.000000000Z"
       }
     },
     {
@@ -316,7 +316,7 @@
     },
     {
       "userEnteredValue": {
-        "stringValue": "1970-01-01T01:00:06Z"
+        "stringValue": "1970-01-01T01:00:06.000000000Z"
       }
     },
     {
@@ -340,7 +340,7 @@
     },
     {
       "userEnteredValue": {
-        "stringValue": "1970-01-01T01:00:07Z"
+        "stringValue": "1970-01-01T01:00:07.000000000Z"
       }
     },
     {
@@ -364,7 +364,7 @@
     },
     {
       "userEnteredValue": {
-        "stringValue": "1970-01-01T01:00:08Z"
+        "stringValue": "1970-01-01T01:00:08.000000000Z"
       }
     },
     {
@@ -443,7 +443,7 @@
     },
     {
       "userEnteredValue": {
-        "stringValue": "1970-01-01T00:00:13Z"
+        "stringValue": "1970-01-01T00:00:13.000000000Z"
       }
     },
     {
@@ -479,7 +479,7 @@
     },
     {
       "userEnteredValue": {
-        "stringValue": "1970-01-01T00:00:14Z"
+        "stringValue": "1970-01-01T00:00:14.000000000Z"
       }
     },
     {
@@ -519,7 +519,7 @@
     },
     {
       "userEnteredValue": {
-        "stringValue": "1970-01-01T00:00:15Z"
+        "stringValue": "1970-01-01T00:00:15.000000000Z"
       }
     },
     {
@@ -555,7 +555,7 @@
     },
     {
       "userEnteredValue": {
-        "stringValue": "1970-01-01T00:00:16Z"
+        "stringValue": "1970-01-01T00:00:16.000000000Z"
       }
     },
     {
@@ -595,7 +595,7 @@
     },
     {
       "userEnteredValue": {
-        "stringValue": "1970-01-01T00:00:17Z"
+        "stringValue": "1970-01-01T00:00:17.000000000Z"
       }
     },
     {
@@ -631,7 +631,7 @@
     },
     {
       "userEnteredValue": {
-        "stringValue": "1970-01-01T01:00:19Z"
+        "stringValue": "1970-01-01T01:00:19.000000000Z"
       }
     },
     {
@@ -671,7 +671,7 @@
     },
     {
       "userEnteredValue": {
-        "stringValue": "1970-01-01T01:00:20Z"
+        "stringValue": "1970-01-01T01:00:20.000000000Z"
       }
     },
     {
@@ -707,7 +707,7 @@
     },
     {
       "userEnteredValue": {
-        "stringValue": "1970-01-01T01:00:21Z"
+        "stringValue": "1970-01-01T01:00:21.000000000Z"
       }
     },
     {
@@ -751,7 +751,7 @@
     },
     {
       "userEnteredValue": {
-        "stringValue": "1970-01-01T01:00:22Z"
+        "stringValue": "1970-01-01T01:00:22.000000000Z"
       }
     },
     {
@@ -791,7 +791,7 @@
     },
     {
       "userEnteredValue": {
-        "stringValue": "1970-01-01T01:00:23Z"
+        "stringValue": "1970-01-01T01:00:23.000000000Z"
       }
     },
     {

--- a/tests/materialize/materialize-snowflake/snapshot.json
+++ b/tests/materialize/materialize-snowflake/snapshot.json
@@ -22,7 +22,7 @@
         "PipeFiles": [
           {
             "Path": "<uuid>",
-            "Size": 228
+            "Size": 240
           }
         ],
         "Version": "0101010101010101"
@@ -35,7 +35,7 @@
         "PipeFiles": [
           {
             "Path": "<uuid>",
-            "Size": 116
+            "Size": 119
           }
         ],
         "Version": "0101010101010101"
@@ -112,7 +112,7 @@
         "PipeFiles": [
           {
             "Path": "<uuid>",
-            "Size": 230
+            "Size": 240
           }
         ],
         "Version": "0101010101010101"
@@ -125,7 +125,7 @@
         "PipeFiles": [
           {
             "Path": "<uuid>",
-            "Size": 115
+            "Size": 116
           }
         ],
         "Version": "0101010101010101"
@@ -181,7 +181,7 @@
         "PipeFiles": [
           {
             "Path": "<uuid>",
-            "Size": 230
+            "Size": 240
           }
         ],
         "PipeName": "ESTUARY_DB.ESTUARY_SCHEMA.FLOW_PIPE_2_DUPLICATE_KEYS_DELTA_00000000_0101010101010101",
@@ -194,7 +194,7 @@
         "PipeFiles": [
           {
             "Path": "<uuid>",
-            "Size": 115
+            "Size": 116
           }
         ],
         "PipeName": "ESTUARY_DB.ESTUARY_SCHEMA.FLOW_PIPE_3_DUPLICATE_KEYS_DELTA_EXCLUDE_FLOW_DOC_00000000_0101010101010101",


### PR DESCRIPTION
**Description:**

5183d03 changed the pre-requisite checks to run prior to initializing the `sql.Endpoint` struct, but that causes problems if there is a network tunnel configured since the network tunnel was only started as part of creating that struct.

This creates a separate `StartTunnel` function that is a property of `sql.Driver` which must be called before the database can be interacted with, which is taken care of by the materialize-sql framework before it runs Validate, Apply, or Open.

We've accumulated quite a lot of tech debt around this whole setup process and I'd like to refactor it more comprehensively soon. Right now this should work though, although I'm not very happy with how things currently have to be structured.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1803)
<!-- Reviewable:end -->
