### PR TITLE
source-zendesk-support: change streams to cursor pagination

### DIFF
--- a/source-zendesk-support/tests/snapshots/snapshots__capture__capture.stdout.json
+++ b/source-zendesk-support/tests/snapshots/snapshots__capture__capture.stdout.json
@@ -4,21 +4,21 @@
     {
       "_meta": {
         "op": "u",
-        "row_id": 99,
+        "row_id": 101,
         "uuid": "DocUUIDPlaceholder-329Bb50aa48EAa9ef"
       },
-      "action": "create",
-      "action_label": "Created",
+      "action": "update",
+      "action_label": "Updated",
       "actor_id": -1,
       "actor_name": "Zendesk",
-      "change_description": "Organization Estuary created",
-      "created_at": "2024-07-26T15:41:02Z",
-      "id": 28835703787924,
+      "change_description": "Changed from not set to Alex Bair",
+      "created_at": "2024-07-26T15:40:53Z",
+      "id": 28835703011988,
       "ip_address": null,
-      "source_id": 28835714737428,
-      "source_label": "Organization: Estuary",
-      "source_type": "organization",
-      "url": "https://d3v-estuary6996.zendesk.com/api/v2/audit_logs/28835703787924.json"
+      "source_id": 21678981,
+      "source_label": "Contacts: Account owner",
+      "source_type": "account",
+      "url": "https://d3v-estuary6996.zendesk.com/api/v2/audit_logs/28835703011988.json"
     }
   ],
   [
@@ -226,7 +226,7 @@
     {
       "_meta": {
         "op": "u",
-        "row_id": 0,
+        "row_id": 1,
         "uuid": "DocUUIDPlaceholder-329Bb50aa48EAa9ef"
       },
       "assignee_id": 28835702984212,
@@ -320,7 +320,7 @@
     {
       "_meta": {
         "op": "u",
-        "row_id": 15,
+        "row_id": 11,
         "uuid": "DocUUIDPlaceholder-329Bb50aa48EAa9ef"
       },
       "count": 1,


### PR DESCRIPTION
**Description:**

Zendesk's API allows the use of both offset pagination and cursor pagination to get documents. Previously, we were using offset pagination, which is limited to only getting the first 100 pages of documents. Cursor pagination does not have this limit, so all streams using offset pagination have been changed to use cursor pagination.

Since many streams inherit from common classes, some logic was pushed down the inheritance chain to streams that don't use cursor pagination.

Additionally, the `TicketAudits` stream was previously retrieving all pages of documents. This has been changed to only get pages containing documents after the start date/last seen date.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

No documentation updates needed.

**Notes for reviewers:**

Tested all streams on a local stack.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1804)
<!-- Reviewable:end -->
