### PR TITLE
source-postgres: Support NaN values in float4/float8 columns

### DIFF
--- a/source-postgres/.snapshots/TestDiscoveryComplex
+++ b/source-postgres/.snapshots/TestDiscoveryComplex
@@ -44,8 +44,12 @@ Binding 0:
               "description": "(source type: non-nullable text)"
             },
             "real_": {
-              "type": "number",
-              "description": "(source type: non-nullable float4)"
+              "format": "number",
+              "description": "(source type: non-nullable float4)",
+              "type": [
+                "number",
+                "string"
+              ]
             }
           }
         }

--- a/source-postgres/.snapshots/TestGeneric-KeylessDiscovery
+++ b/source-postgres/.snapshots/TestGeneric-KeylessDiscovery
@@ -27,8 +27,12 @@ Binding 0:
               ]
             },
             "c": {
-              "type": "number",
-              "description": "(source type: non-nullable float4)"
+              "format": "number",
+              "description": "(source type: non-nullable float4)",
+              "type": [
+                "number",
+                "string"
+              ]
             },
             "d": {
               "description": "(source type: varchar)",

--- a/source-postgres/.snapshots/TestGeneric-SimpleDiscovery
+++ b/source-postgres/.snapshots/TestGeneric-SimpleDiscovery
@@ -26,8 +26,12 @@ Binding 0:
               ]
             },
             "c": {
-              "type": "number",
-              "description": "(source type: non-nullable float4)"
+              "format": "number",
+              "description": "(source type: non-nullable float4)",
+              "type": [
+                "number",
+                "string"
+              ]
             },
             "d": {
               "description": "(source type: varchar)",

--- a/source-postgres/datatype_test.go
+++ b/source-postgres/datatype_test.go
@@ -29,8 +29,10 @@ func TestDatatypes(t *testing.T) {
 		{ColumnType: `serial`, ExpectType: `{"type":"integer"}`, InputValue: `123`, ExpectValue: `123`},      // non-nullable
 		{ColumnType: `smallserial`, ExpectType: `{"type":"integer"}`, InputValue: `123`, ExpectValue: `123`}, // non-nullable
 		{ColumnType: `bigserial`, ExpectType: `{"type":"integer"}`, InputValue: `123`, ExpectValue: `123`},   // non-nullable
-		{ColumnType: `real`, ExpectType: `{"type":["number","null"]}`, InputValue: `123.456`, ExpectValue: `123.456`},
-		{ColumnType: `double precision`, ExpectType: `{"type":["number","null"]}`, InputValue: `123.456`, ExpectValue: `123.456`},
+		{ColumnType: `real`, ExpectType: `{"type":["number","string","null"],"format":"number"}`, InputValue: `123.456`, ExpectValue: `123.456`},
+		{ColumnType: `double precision`, ExpectType: `{"type":["number","string","null"],"format":"number"}`, InputValue: `123.456`, ExpectValue: `123.456`},
+		{ColumnType: `real`, ExpectType: `{"type":["number","string","null"],"format":"number"}`, InputValue: `NaN`, ExpectValue: `"NaN"`},
+		{ColumnType: `double precision`, ExpectType: `{"type":["number","string","null"],"format":"number"}`, InputValue: `NaN`, ExpectValue: `"NaN"`},
 
 		{ColumnType: `decimal`, ExpectType: `{"type":["string","null"],"format":"number"}`, InputValue: `123.456`, ExpectValue: `"123.456"`},
 		{ColumnType: `numeric`, ExpectType: `{"type":["string","null"],"format":"number"}`, InputValue: `123.456`, ExpectValue: `"123.456"`},
@@ -122,11 +124,11 @@ func TestDatatypes(t *testing.T) {
 		{ColumnType: `char(5) ARRAY`, ExpectType: fmt.Sprintf(arraySchemaPattern, `{"type":["string","null"]}`), InputValue: `{foo, bar}`, ExpectValue: `{"dimensions":[2],"elements":["foo  ","bar  "]}`},
 		{ColumnType: `cidr ARRAY`, ExpectType: fmt.Sprintf(arraySchemaPattern, `{"type":["string","null"]}`), InputValue: `{192.168.100.0/24, 2001:4f8:3:ba::/64}`, ExpectValue: `{"dimensions":[2],"elements":["192.168.100.0/24","2001:4f8:3:ba::/64"]}`},
 		{ColumnType: `date ARRAY`, ExpectType: fmt.Sprintf(arraySchemaPattern, `{"type":["string","null"],"format":"date-time"}`), InputValue: []interface{}{`2022-01-09`, `2022-01-10`}, ExpectValue: `{"dimensions":[2],"elements":["2022-01-09T00:00:00Z","2022-01-10T00:00:00Z"]}`},
-		{ColumnType: `double precision ARRAY`, ExpectType: fmt.Sprintf(arraySchemaPattern, `{"type":["number","null"]}`), InputValue: []interface{}{1.23, 4.56}, ExpectValue: `{"dimensions":[2],"elements":[1.23,4.56]}`},
+		{ColumnType: `double precision ARRAY`, ExpectType: fmt.Sprintf(arraySchemaPattern, `{"type":["number","string","null"],"format":"number"}`), InputValue: []interface{}{1.23, 4.56}, ExpectValue: `{"dimensions":[2],"elements":[1.23,4.56]}`},
 		{ColumnType: `inet ARRAY`, ExpectType: fmt.Sprintf(arraySchemaPattern, `{"type":["string","null"]}`), InputValue: []interface{}{`192.168.100.0/24`, `2001:4f8:3:ba::/64`}, ExpectValue: `{"dimensions":[2],"elements":["192.168.100.0/24","2001:4f8:3:ba::/64"]}`},
 		{ColumnType: `integer ARRAY`, ExpectType: fmt.Sprintf(arraySchemaPattern, `{"type":["integer","null"]}`), InputValue: []interface{}{1, 2, nil, 4}, ExpectValue: `{"dimensions":[4],"elements":[1,2,null,4]}`},
 		{ColumnType: `numeric ARRAY`, ExpectType: fmt.Sprintf(arraySchemaPattern, `{"type":["string","null"],"format":"number"}`), InputValue: []interface{}{`123.456`, `-789.0123`}, ExpectValue: `{"dimensions":[2],"elements":["123.456","-789.0123"]}`},
-		{ColumnType: `real ARRAY`, ExpectType: fmt.Sprintf(arraySchemaPattern, `{"type":["number","null"]}`), InputValue: []interface{}{123.456, 789.012}, ExpectValue: `{"dimensions":[2],"elements":[123.456,789.012]}`},
+		{ColumnType: `real ARRAY`, ExpectType: fmt.Sprintf(arraySchemaPattern, `{"type":["number","string","null"],"format":"number"}`), InputValue: []interface{}{123.456, 789.012}, ExpectValue: `{"dimensions":[2],"elements":[123.456,789.012]}`},
 		{ColumnType: `smallint ARRAY`, ExpectType: fmt.Sprintf(arraySchemaPattern, `{"type":["integer","null"]}`), InputValue: []interface{}{123, 456, 789}, ExpectValue: `{"dimensions":[3],"elements":[123,456,789]}`},
 		{ColumnType: `text ARRAY`, ExpectType: fmt.Sprintf(arraySchemaPattern, `{"type":["string","null"]}`), InputValue: []interface{}{`Hello, world!`, `asdf`}, ExpectValue: `{"dimensions":[2],"elements":["Hello, world!","asdf"]}`},
 		{ColumnType: `uuid ARRAY`, ExpectType: fmt.Sprintf(arraySchemaPattern, `{"type":["string","null"],"format":"uuid"}`), InputValue: []interface{}{`a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11`}, ExpectValue: `{"dimensions":[1],"elements":["a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11"]}`},

--- a/source-postgres/datatypes.go
+++ b/source-postgres/datatypes.go
@@ -4,6 +4,7 @@ import (
 	"database/sql/driver"
 	"encoding/json"
 	"fmt"
+	"math"
 	"net"
 	"strings"
 	"time"
@@ -228,6 +229,14 @@ func translateRecordField(column *sqlcapture.ColumnInfo, val interface{}) (inter
 			return x[:truncateColumnThreshold], nil
 		}
 		return x, nil
+	case float32:
+		if str, ok := stringifySpecialFloats(float64(x)); ok {
+			return str, nil
+		}
+	case float64:
+		if str, ok := stringifySpecialFloats(x); ok {
+			return str, nil
+		}
 	case json.RawMessage:
 		if len(x) > truncateColumnThreshold {
 			return oversizePlaceholderJSON(x), nil
@@ -279,6 +288,19 @@ func translateRecordField(column *sqlcapture.ColumnInfo, val interface{}) (inter
 	}
 
 	return val, nil
+}
+
+// stringifySpecialFloats replaces the legal IEEE-754 values NaN/Infinity/-Infinity (which
+// don't have a defined JSON representation) with equivalent strings.
+func stringifySpecialFloats(x float64) (string, bool) {
+	if math.IsNaN(x) {
+		return "NaN", true
+	} else if math.IsInf(x, +1) {
+		return "Infinity", true
+	} else if math.IsInf(x, -1) {
+		return "-Infinity", true
+	}
+	return "", false
 }
 
 func stringifyRange(r pgtype.Range[any]) (string, error) {

--- a/source-postgres/discovery.go
+++ b/source-postgres/discovery.go
@@ -252,7 +252,7 @@ type columnSchema struct {
 	contentEncoding string
 	format          string
 	nullable        bool
-	jsonType        string
+	jsonTypes       []string
 }
 
 func (s columnSchema) toType() *jsonschema.Schema {
@@ -265,61 +265,65 @@ func (s columnSchema) toType() *jsonschema.Schema {
 		out.Extras["contentEncoding"] = s.contentEncoding // New in 2019-09.
 	}
 
-	if s.jsonType == "" {
-		// No type constraint.
-	} else if s.nullable {
-		out.Extras["type"] = []string{s.jsonType, "null"} // Use variadic form.
-	} else {
-		out.Type = s.jsonType
+	if s.jsonTypes != nil {
+		var types = append([]string(nil), s.jsonTypes...)
+		if s.nullable {
+			types = append(types, "null")
+		}
+		if len(types) == 1 {
+			out.Type = types[0]
+		} else {
+			out.Extras["type"] = types
+		}
 	}
 	return out
 }
 
 var postgresTypeToJSON = map[string]columnSchema{
-	"bool": {jsonType: "boolean"},
+	"bool": {jsonTypes: []string{"boolean"}},
 
-	"int2": {jsonType: "integer"},
-	"int4": {jsonType: "integer"},
-	"int8": {jsonType: "integer"},
+	"int2": {jsonTypes: []string{"integer"}},
+	"int4": {jsonTypes: []string{"integer"}},
+	"int8": {jsonTypes: []string{"integer"}},
 
-	"numeric": {jsonType: "string", format: "number"},
-	"float4":  {jsonType: "number"},
-	"float8":  {jsonType: "number"},
+	"numeric": {jsonTypes: []string{"string"}, format: "number"},
+	"float4":  {jsonTypes: []string{"number", "string"}, format: "number"},
+	"float8":  {jsonTypes: []string{"number", "string"}, format: "number"},
 
-	"varchar": {jsonType: "string"},
-	"bpchar":  {jsonType: "string"},
-	"text":    {jsonType: "string"},
-	"bytea":   {jsonType: "string", contentEncoding: "base64"},
-	"xml":     {jsonType: "string"},
-	"bit":     {jsonType: "string"},
-	"varbit":  {jsonType: "string"},
+	"varchar": {jsonTypes: []string{"string"}},
+	"bpchar":  {jsonTypes: []string{"string"}},
+	"text":    {jsonTypes: []string{"string"}},
+	"bytea":   {jsonTypes: []string{"string"}, contentEncoding: "base64"},
+	"xml":     {jsonTypes: []string{"string"}},
+	"bit":     {jsonTypes: []string{"string"}},
+	"varbit":  {jsonTypes: []string{"string"}},
 
 	"json":     {},
 	"jsonb":    {},
-	"jsonpath": {jsonType: "string"},
+	"jsonpath": {jsonTypes: []string{"string"}},
 
 	// Domain-Specific Types
-	"date":        {jsonType: "string", format: "date-time"},
-	"timestamp":   {jsonType: "string", format: "date-time"},
-	"timestamptz": {jsonType: "string", format: "date-time"},
-	"time":        {jsonType: "integer"},
-	"timetz":      {jsonType: "string", format: "time"},
-	"interval":    {jsonType: "string"},
-	"money":       {jsonType: "string"},
-	"point":       {jsonType: "string"},
-	"line":        {jsonType: "string"},
-	"lseg":        {jsonType: "string"},
-	"box":         {jsonType: "string"},
-	"path":        {jsonType: "string"},
-	"polygon":     {jsonType: "string"},
-	"circle":      {jsonType: "string"},
-	"inet":        {jsonType: "string"},
-	"cidr":        {jsonType: "string"},
-	"macaddr":     {jsonType: "string"},
-	"macaddr8":    {jsonType: "string"},
-	"tsvector":    {jsonType: "string"},
-	"tsquery":     {jsonType: "string"},
-	"uuid":        {jsonType: "string", format: "uuid"},
+	"date":        {jsonTypes: []string{"string"}, format: "date-time"},
+	"timestamp":   {jsonTypes: []string{"string"}, format: "date-time"},
+	"timestamptz": {jsonTypes: []string{"string"}, format: "date-time"},
+	"time":        {jsonTypes: []string{"integer"}},
+	"timetz":      {jsonTypes: []string{"string"}, format: "time"},
+	"interval":    {jsonTypes: []string{"string"}},
+	"money":       {jsonTypes: []string{"string"}},
+	"point":       {jsonTypes: []string{"string"}},
+	"line":        {jsonTypes: []string{"string"}},
+	"lseg":        {jsonTypes: []string{"string"}},
+	"box":         {jsonTypes: []string{"string"}},
+	"path":        {jsonTypes: []string{"string"}},
+	"polygon":     {jsonTypes: []string{"string"}},
+	"circle":      {jsonTypes: []string{"string"}},
+	"inet":        {jsonTypes: []string{"string"}},
+	"cidr":        {jsonTypes: []string{"string"}},
+	"macaddr":     {jsonTypes: []string{"string"}},
+	"macaddr8":    {jsonTypes: []string{"string"}},
+	"tsvector":    {jsonTypes: []string{"string"}},
+	"tsquery":     {jsonTypes: []string{"string"}},
+	"uuid":        {jsonTypes: []string{"string"}, format: "uuid"},
 }
 
 const queryDiscoverTables = `
@@ -430,7 +434,7 @@ type postgresEnumType struct{}
 
 func (t postgresEnumType) String() string { return "enum" }
 func (t postgresEnumType) toColumnSchema(_ sqlcapture.ColumnInfo) (columnSchema, error) {
-	return columnSchema{jsonType: "string"}, nil
+	return columnSchema{jsonTypes: []string{"string"}}, nil
 }
 
 type postgresRangeType struct {
@@ -445,7 +449,7 @@ func (t postgresRangeType) String() string {
 }
 
 func (t postgresRangeType) toColumnSchema(_ sqlcapture.ColumnInfo) (columnSchema, error) {
-	return columnSchema{jsonType: "string"}, nil
+	return columnSchema{jsonTypes: []string{"string"}}, nil
 }
 
 type postgresCompositeType struct{}


### PR DESCRIPTION
**Description:**

Adds support for NaN (and Infinity and -Infinity) values in float4/float8 columns. Previously these didn't work because we serialize them as JSON numbers and there's no legal JSON representation of a floating-point NaN or infinity. Now we stringify just those three special values, which required also updating the discovery output for those column types to `{type: [string, number], format: number}` but I am assured that our materializations should handle that correctly so it should basically be a no-op for any dataflows that don't encounter NaNs.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1812)
<!-- Reviewable:end -->
