### PR TITLE
sqlcapture: Handle context cancellation during change streaming

### DIFF
--- a/sqlcapture/capture.go
+++ b/sqlcapture/capture.go
@@ -528,47 +528,51 @@ func (c *Capture) streamToWatermarkWithOptions(ctx context.Context, replStream R
 	var eventCount int
 	defer func() { logrus.WithField("events", eventCount).Info("processed replication events") }()
 
-	for event := range replStream.Events() {
-		eventCount++
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case event, ok := <-replStream.Events():
+			if !ok {
+				return errWatermarkNotReached
+			}
+			eventCount++
 
-		// Flush events update the checkpointed LSN and trigger a state update.
-		// If this is the commit after the target watermark, it also ends the loop.
-		if event, ok := event.(*FlushEvent); ok {
-			c.State.Cursor = event.Cursor
-			if reportFlush {
-				if err := c.emitState(); err != nil {
-					return fmt.Errorf("error emitting state update: %w", err)
+			// Flush events update the checkpointed LSN and trigger a state update.
+			// If this is the commit after the target watermark, it also ends the loop.
+			if event, ok := event.(*FlushEvent); ok {
+				c.State.Cursor = event.Cursor
+				if reportFlush {
+					if err := c.emitState(); err != nil {
+						return fmt.Errorf("error emitting state update: %w", err)
+					}
+				}
+				if watermarkReached {
+					return nil
+				}
+				continue
+			}
+
+			// Check for watermark change events and set a flag when the target watermark is reached.
+			// The subsequent FlushEvent will exit the loop.
+			if event, ok := event.(*ChangeEvent); ok {
+				if event.Operation != DeleteOp && event.Source.Common().StreamID() == watermarksTable {
+					var actual = event.After["watermark"]
+					if actual == nil {
+						actual = event.After["WATERMARK"]
+					}
+					logrus.WithFields(logrus.Fields{"expected": watermark, "actual": actual}).Debug("watermark change")
+					if actual == watermark {
+						watermarkReached = true
+					}
 				}
 			}
-			if watermarkReached {
-				return nil
-			}
-			continue
-		}
 
-		// Check for watermark change events and set a flag when the target watermark is reached.
-		// The subsequent FlushEvent will exit the loop.
-		if event, ok := event.(*ChangeEvent); ok {
-			if event.Operation != DeleteOp && event.Source.Common().StreamID() == watermarksTable {
-				var actual = event.After["watermark"]
-				if actual == nil {
-					actual = event.After["WATERMARK"]
-				}
-				logrus.WithFields(logrus.Fields{"expected": watermark, "actual": actual}).Debug("watermark change")
-				if actual == watermark {
-					watermarkReached = true
-				}
+			if err := c.handleReplicationEvent(event); err != nil {
+				return err
 			}
-		}
-
-		if err := c.handleReplicationEvent(event); err != nil {
-			return err
 		}
 	}
-	if err := ctx.Err(); err != nil {
-		return err
-	}
-	return errWatermarkNotReached
 }
 
 func (c *Capture) handleReplicationEvent(event DatabaseEvent) error {


### PR DESCRIPTION
**Description:**

Currently if the context passed to 'streamToWatermarkWithOptions' is cancelled but the events channel doesn't close, the connector will continue to wait for a watermark which may never arrive.

Most of the time when the context is cancelled it's at the top level of the capture so this doesn't come up, but the indefinite streaming state is currently modelled as a process of running the change streaming process in a worker thread with a second thread which will wait for a reasonable period of time and then write the watermark.

The problem is, if this watermark write fails we want the work context cancellation to cause the stream-until-watermark thread to also shut down, and as currently written it doesn't.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1828)
<!-- Reviewable:end -->
