### PR TITLE
source-mysql: Ignore unparseable query events

### DIFF
--- a/source-mysql/replication.go
+++ b/source-mysql/replication.go
@@ -496,7 +496,11 @@ func (rs *mysqlReplicationStream) handleQuery(ctx context.Context, schema, query
 
 	var stmt, err = sqlparser.Parse(query)
 	if err != nil {
-		return fmt.Errorf("unable to parse query %q: %w", query, err)
+		logrus.WithFields(logrus.Fields{
+			"query": query,
+			"err":   err,
+		}).Warn("failed to parse query event, ignoring it")
+		return nil
 	}
 	logrus.WithField("stmt", fmt.Sprintf("%#v", stmt)).Debug("parsed query")
 


### PR DESCRIPTION
**Description:**

We use the Vitess SQL parser to parse MySQL query events so that we can apply DDL changes to our table metadata tracking. But the Vitess SQL parser is a reimplementation of the MySQL grammar and it can be a bit spotty in its support for various edge cases.

But in practice, we don't care about those edge cases. The things we care about are basic `ALTER / DROP / TRUNCATE / RENAME` table operations which are pretty well supported, and the failures are all in the long tail of niche statements we'd like to ignore anyway.

We've been treating parse failures as a fatal error for some time now (I want to say it's been over a year?) and as far as I can recall this has never caught a legitimate issue, instead it just makes the capture more flaky than it needs to be.

So given the following justifications:
1. We have never observed in production an unparseable query which was actually part of the finite set of DDL statements we care about.
2. If we somehow did miss a DDL statement we care about, this would either change the number of columns in the table or the types of a column, either of which is likely to result in the task failing for that reason instead.
3. If the task did start failing like this, we're still logging all query events so we can pretty easily see what's wrong.
4. Backfilling an impacted table will still get it working again.

I think it's high time we make these parse failures a non-fatal warn-and-ignore instead of a fatal error.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1830)
<!-- Reviewable:end -->
