### PR TITLE
estuary-cdk: Fix adding `op` and `row_id` to the `meta_` property.

### DIFF
--- a/estuary-cdk/estuary_cdk/shim_airbyte_cdk.py
+++ b/estuary-cdk/estuary_cdk/shim_airbyte_cdk.py
@@ -340,9 +340,8 @@ class CaptureShim(BaseCaptureConnector):
                     )
                     continue
 
-                doc = Document(
-                    meta_=Document.Meta(op="u", row_id=entry[1].rowId), **record.data
-                )
+                doc = Document(**record.data)
+                doc.meta_ = Document.Meta(op="u", row_id=entry[1].rowId)
                 entry[1].rowId += 1
 
                 task.captured(entry[0], doc)


### PR DESCRIPTION
**Description:**

The new `source-pendo` connector was failing with schema violations - the documents didn't have a `row_id` in the `_meta` property. However, they did have a `meta_` property with a `row_id`. This fix puts `row_id` in the documents' `_meta` property.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1831)
<!-- Reviewable:end -->
