### PR TITLE
source-zendesk-support: fix oauth

### DIFF
--- a/source-zendesk-support/config.yaml
+++ b/source-zendesk-support/config.yaml
@@ -3,7 +3,7 @@ credentials:
     email: alexb@estuary.dev
     api_token_sops: ENC[AES256_GCM,data:WxXkpbpDG5dfxToEkz41WopKbmj1OrCt43X3Nzhrk9bs3XNkHR1jpg==,iv:2V30uIHCj/fzt6YekkvxqLrIm7cJ4VqeRvp5h+8hqx4=,tag:u8MBtzFdbMER9r4PoLFFFA==,type:str]
 start_date: "2024-07-26T00:00:00Z"
-subdomain: d3v-estuary6996
+subdomain: d3v-estuary
 sops:
     kms: []
     gcp_kms:
@@ -13,8 +13,8 @@ sops:
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2024-07-26T18:43:23Z"
-    mac: ENC[AES256_GCM,data:AR1VwgTlrcPPVw7p1NI2inzrgVipQ/JLQC+qvKpM5BNpIIQcnBJ1HyB9zgMlNaZmGU37N5Xy0xXC9ooqDiFzG2uq2Tw4V4KOXDe5V/gx9LJ0kJPJkjFcY23rMcd8ltpzc/Rl+NjQtd9mGqp/UUwvJV/Vx4zO5x7e1+duFFH88Rg=,iv:JShKcBQ/OS+VOweSZHPvch7SFDvbd/F+BiJ/D51ZHMw=,tag:TmbajKmGhG1hGVI8jmTPSw==,type:str]
+    lastmodified: "2024-08-21T12:55:02Z"
+    mac: ENC[AES256_GCM,data:JtzA0ajJ4FBxVZbWA4ylLt8cQdjfNVrSdfnxGaHYAZ4cTqsajrLYri9y/dEHAe4/uA/ocWGEPt3j7aVbGFWFv6k40yqdnScDoH89Mza5LI2vBl/+1Ki2k1e5DGFVmcgzBnegSWoqMOtCA9o5nwEx0sD+Prez2f0mfpxGJYiD1+4=,iv:5i2hPfceLTbm4CvdRIuD6DLbOLUvPWrYDbfaY/werK0=,tag:xhJtlRI4MHfna5u7qPTVKA==,type:str]
     pgp: []
     encrypted_suffix: _sops
     version: 3.7.3

--- a/source-zendesk-support/source_zendesk_support/spec.json
+++ b/source-zendesk-support/source_zendesk_support/spec.json
@@ -41,16 +41,20 @@
               "access_token": {
                 "type": "string",
                 "title": "Access Token",
-                "description": "The value of the API token generated. See the <a href=\"https://docs.airbyte.com/integrations/sources/zendesk-support\">docs</a> for more information.",
+                "description": "The OAuth access token. See the <a href=\"https://developer.zendesk.com/documentation/ticketing/working-with-oauth/creating-and-using-oauth-tokens-with-the-api/\">Zendesk docs</a> for more information.",
                 "airbyte_secret": true
               },
               "client_id": { 
                 "airbyte_secret": true,
-                "type": "string"
+                "type": "string",
+                "title": "Client ID",
+                "description": "The OAuth client ID. See the <a href=\"https://developer.zendesk.com/documentation/ticketing/working-with-oauth/creating-and-using-oauth-tokens-with-the-api/\">Zendesk docs</a> for more information."
               },
               "client_secret": {
                 "airbyte_secret": true,
-              "type": "string"
+                "type": "string",
+                "title": "Client Secret",
+                "description": "The OAuth client secret. See the <a href=\"https://developer.zendesk.com/documentation/ticketing/working-with-oauth/creating-and-using-oauth-tokens-with-the-api/\">Zendesk docs</a> for more information."
               }
             }
           },

--- a/source-zendesk-support/tests/snapshots/snapshots__capture__capture.stdout.json
+++ b/source-zendesk-support/tests/snapshots/snapshots__capture__capture.stdout.json
@@ -12,7 +12,7 @@
       "group_id": 28835740822676,
       "id": 28835714743188,
       "updated_at": "redacted",
-      "url": "https://d3v-estuary6996.zendesk.com/api/v2/group_memberships/28835714743188.json",
+      "url": "https://d3v-estuary.zendesk.com/api/v2/group_memberships/28835714743188.json",
       "user_id": 28835702984212
     }
   ],
@@ -32,7 +32,7 @@
       "is_public": true,
       "name": "Support",
       "updated_at": "redacted",
-      "url": "https://d3v-estuary6996.zendesk.com/api/v2/groups/28835740822676.json"
+      "url": "https://d3v-estuary.zendesk.com/api/v2/groups/28835740822676.json"
     }
   ],
   [
@@ -63,7 +63,7 @@
       "restriction": null,
       "title": "Take it!",
       "updated_at": "redacted",
-      "url": "https://d3v-estuary6996.zendesk.com/api/v2/macros/28835714801684.json"
+      "url": "https://d3v-estuary.zendesk.com/api/v2/macros/28835714801684.json"
     }
   ],
   [
@@ -87,7 +87,7 @@
       "shared_tickets": false,
       "tags": [],
       "updated_at": "redacted",
-      "url": "https://d3v-estuary6996.zendesk.com/api/v2/organizations/28835714737428.json"
+      "url": "https://d3v-estuary.zendesk.com/api/v2/organizations/28835714737428.json"
     }
   ],
   [
@@ -104,7 +104,7 @@
       "organization_id": 28835714737428,
       "organization_name": "Estuary",
       "updated_at": "redacted",
-      "url": "https://d3v-estuary6996.zendesk.com/api/v2/organization_memberships/28835714744724.json",
+      "url": "https://d3v-estuary.zendesk.com/api/v2/organization_memberships/28835714744724.json",
       "user_id": 28835702984212,
       "view_tickets": true
     }
@@ -126,7 +126,7 @@
       "featured": false,
       "follower_count": 1,
       "frozen": false,
-      "html_url": "https://d3v-estuary6996.zendesk.com/hc/en-us/community/posts/28847424303764-I-d-like-a-way-for-users-to-submit-feature-requests",
+      "html_url": "https://d3v-estuary.zendesk.com/hc/en-us/community/posts/28847424303764-I-d-like-a-way-for-users-to-submit-feature-requests",
       "id": 28847424303764,
       "non_author_editor_id": null,
       "non_author_updated_at": null,
@@ -135,7 +135,7 @@
       "title": "I'd like a way for users to submit feature requests",
       "topic_id": 28847452157844,
       "updated_at": "redacted",
-      "url": "https://d3v-estuary6996.zendesk.com/api/v2/help_center/community/posts/28847424303764-I-d-like-a-way-for-users-to-submit-feature-requests.json",
+      "url": "https://d3v-estuary.zendesk.com/api/v2/help_center/community/posts/28847424303764-I-d-like-a-way-for-users-to-submit-feature-requests.json",
       "vote_count": 1,
       "vote_sum": 1
     }
@@ -151,14 +151,14 @@
       "author_id": 28835702984212,
       "body": "A test post comment.",
       "created_at": "2024-08-01T13:10:11Z",
-      "html_url": "https://d3v-estuary6996.zendesk.com/hc/en-us/community/posts/28847424303764-I-d-like-a-way-for-users-to-submit-feature-requests/comments/29005581511700",
+      "html_url": "https://d3v-estuary.zendesk.com/hc/en-us/community/posts/28847424303764-I-d-like-a-way-for-users-to-submit-feature-requests/comments/29005581511700",
       "id": 29005581511700,
       "non_author_editor_id": null,
       "non_author_updated_at": null,
       "official": false,
       "post_id": 28847424303764,
       "updated_at": "redacted",
-      "url": "https://d3v-estuary6996.zendesk.com/api/v2/help_center/community/posts/28847424303764/comments/29005581511700.json",
+      "url": "https://d3v-estuary.zendesk.com/api/v2/help_center/community/posts/28847424303764/comments/29005581511700.json",
       "vote_count": 1,
       "vote_sum": 1
     }
@@ -176,7 +176,7 @@
       "item_id": 29005581511700,
       "item_type": "PostComment",
       "updated_at": "redacted",
-      "url": "https://d3v-estuary6996.zendesk.com/api/v2/help_center/votes/29005807715092.json",
+      "url": "https://d3v-estuary.zendesk.com/api/v2/help_center/votes/29005807715092.json",
       "user_id": 28835702984212,
       "value": 1
     }
@@ -194,7 +194,7 @@
       "item_id": 28847424303764,
       "item_type": "Post",
       "updated_at": "redacted",
-      "url": "https://d3v-estuary6996.zendesk.com/api/v2/help_center/votes/29005734783508.json",
+      "url": "https://d3v-estuary.zendesk.com/api/v2/help_center/votes/29005734783508.json",
       "user_id": 28835702984212,
       "value": 1
     }
@@ -218,7 +218,7 @@
       "score": "offered",
       "ticket_id": 29,
       "updated_at": "redacted",
-      "url": "https://d3v-estuary6996.zendesk.com/api/v2/satisfaction_ratings/29013431981588.json"
+      "url": "https://d3v-estuary.zendesk.com/api/v2/satisfaction_ratings/29013431981588.json"
     }
   ],
   [
@@ -290,7 +290,7 @@
       "position": 1,
       "title": "Test SLA Policy",
       "updated_at": "redacted",
-      "url": "https://d3v-estuary6996.zendesk.com/api/v2/slas/policies/29006807867284.json"
+      "url": "https://d3v-estuary.zendesk.com/api/v2/slas/policies/29006807867284.json"
     }
   ],
   [
@@ -486,7 +486,7 @@
       "title_in_portal": "Subject",
       "type": "subject",
       "updated_at": "redacted",
-      "url": "https://d3v-estuary6996.zendesk.com/api/v2/ticket_fields/28835714573076.json",
+      "url": "https://d3v-estuary.zendesk.com/api/v2/ticket_fields/28835714573076.json",
       "visible_in_portal": true
     }
   ],
@@ -538,7 +538,7 @@
       "status_updated_at": "2024-07-26T15:41:04Z",
       "ticket_id": 1,
       "updated_at": "redacted",
-      "url": "https://d3v-estuary6996.zendesk.com/api/v2/ticket_metrics/28835715028244.json"
+      "url": "https://d3v-estuary.zendesk.com/api/v2/ticket_metrics/28835715028244.json"
     }
   ],
   [
@@ -623,7 +623,7 @@
         "ticket_form_id": 28835740693908,
         "type": "incident",
         "updated_at": "2024-08-01T14:45:47Z",
-        "url": "https://d3v-estuary6996.zendesk.com/api/v2/tickets/1.json",
+        "url": "https://d3v-estuary.zendesk.com/api/v2/tickets/1.json",
         "via": {
           "channel": "sample_ticket",
           "source": {
@@ -699,7 +699,7 @@
       "ticket_form_id": 28835740693908,
       "type": "incident",
       "updated_at": "redacted",
-      "url": "https://d3v-estuary6996.zendesk.com/api/v2/tickets/1.json",
+      "url": "https://d3v-estuary.zendesk.com/api/v2/tickets/1.json",
       "via": {
         "channel": "sample_ticket",
         "source": {
@@ -752,7 +752,7 @@
       "time_zone": "America/New_York",
       "two_factor_auth_enabled": null,
       "updated_at": "redacted",
-      "url": "https://d3v-estuary6996.zendesk.com/api/v2/users/28835702984212.json",
+      "url": "https://d3v-estuary.zendesk.com/api/v2/users/28835702984212.json",
       "user_fields": {},
       "verified": true
     }
@@ -766,7 +766,7 @@
         "uuid": "DocUUIDPlaceholder-329Bb50aa48EAa9ef"
       },
       "active": true,
-      "brand_url": "https://d3v-estuary6996.zendesk.com",
+      "brand_url": "https://d3v-estuary.zendesk.com",
       "created_at": "2024-07-26T15:40:59Z",
       "default": true,
       "has_help_center": true,
@@ -777,12 +777,12 @@
       "logo": null,
       "name": "Estuary",
       "signature_template": "{{agent.signature}}",
-      "subdomain": "d3v-estuary6996",
+      "subdomain": "d3v-estuary",
       "ticket_form_ids": [
         28835740693908
       ],
       "updated_at": "redacted",
-      "url": "https://d3v-estuary6996.zendesk.com/api/v2/brands/28835714705684.json"
+      "url": "https://d3v-estuary.zendesk.com/api/v2/brands/28835714705684.json"
     }
   ],
   [
@@ -928,7 +928,7 @@
         28835767646868
       ],
       "updated_at": "redacted",
-      "url": "https://d3v-estuary6996.zendesk.com/api/v2/ticket_forms/28835740693908.json"
+      "url": "https://d3v-estuary.zendesk.com/api/v2/ticket_forms/28835740693908.json"
     }
   ],
   [
@@ -943,7 +943,7 @@
       "id": "6149ea30-5004-11ef-ba4d-1fb32c16a1d3",
       "name": "Test attribute",
       "updated_at": "redacted",
-      "url": "https://d3v-estuary6996.zendesk.com/api/v2/routing/attributes/6149ea30-5004-11ef-ba4d-1fb32c16a1d3.json"
+      "url": "https://d3v-estuary.zendesk.com/api/v2/routing/attributes/6149ea30-5004-11ef-ba4d-1fb32c16a1d3.json"
     }
   ],
   [

--- a/source-zendesk-support/tests/snapshots/snapshots__spec__capture.stdout.json
+++ b/source-zendesk-support/tests/snapshots/snapshots__spec__capture.stdout.json
@@ -50,16 +50,20 @@
                 "access_token": {
                   "type": "string",
                   "title": "Access Token",
-                  "description": "The value of the API token generated. See the <a href=\"https://docs.airbyte.com/integrations/sources/zendesk-support\">docs</a> for more information.",
+                  "description": "The OAuth access token. See the <a href=\"https://developer.zendesk.com/documentation/ticketing/working-with-oauth/creating-and-using-oauth-tokens-with-the-api/\">Zendesk docs</a> for more information.",
                   "airbyte_secret": true
                 },
                 "client_id": {
                   "airbyte_secret": true,
-                  "type": "string"
+                  "type": "string",
+                  "title": "Client ID",
+                  "description": "The OAuth client ID. See the <a href=\"https://developer.zendesk.com/documentation/ticketing/working-with-oauth/creating-and-using-oauth-tokens-with-the-api/\">Zendesk docs</a> for more information."
                 },
                 "client_secret": {
                   "airbyte_secret": true,
-                  "type": "string"
+                  "type": "string",
+                  "title": "Client Secret",
+                  "description": "The OAuth client secret. See the <a href=\"https://developer.zendesk.com/documentation/ticketing/working-with-oauth/creating-and-using-oauth-tokens-with-the-api/\">Zendesk docs</a> for more information."
                 }
               }
             },
@@ -142,11 +146,11 @@
     "documentationUrl": "https://go.estuary.dev/an43nb",
     "oauth2": {
       "provider": "zendesk",
-      "authUrlTemplate": "https://estuarysupport.zendesk.com/oauth/authorizations/new?response_type=code&client_id={{#urlencode}}{{{ client_id }}}{{/urlencode}}&redirect_uri={{#urlencode}}{{{ redirect_uri }}}{{/urlencode}}&scope=read&state={{#urlencode}}{{{ state }}}{{/urlencode}}",
-      "accessTokenUrlTemplate": "https://estuarysupport.zendesk.com/oauth/tokens",
-      "accessTokenBody": "grant_type=authorization_code&client_id={{#urlencode}}{{{ client_id }}}{{/urlencode}}&client_secret={{#urlencode}}{{{ client_secret }}}{{/urlencode}}&redirect_uri={{#urlencode}}{{{ redirect_uri }}}{{/urlencode}}&code={{#urlencode}}{{{ code }}}{{/urlencode}}",
+      "authUrlTemplate": "https://{{{ config.subdomain }}}.zendesk.com/oauth/authorizations/new?response_type=code&client_id={{#urlencode}}{{{ client_id }}}{{/urlencode}}&redirect_uri={{#urlencode}}{{{ redirect_uri }}}{{/urlencode}}&scope=read&state={{#urlencode}}{{{ state }}}{{/urlencode}}",
+      "accessTokenUrlTemplate": "https://{{{ config.subdomain }}}.zendesk.com/oauth/tokens",
+      "accessTokenBody": "{\"grant_type\": \"authorization_code\", \"code\": \"{{{ code }}}\", \"client_id\": \"{{{ client_id }}}\", \"client_secret\": \"{{{ client_secret }}}\", \"redirect_uri\": \"{{{ redirect_uri }}}\", \"scope\": \"read\"}",
       "accessTokenHeaders": {
-        "content-type": "application/x-www-form-urlencoded"
+        "Content-Type": "application/json"
       },
       "accessTokenResponseMap": {
         "access_token": "/access_token"


### PR DESCRIPTION
**Description:**

The imported `source-zendesk-support` connector's OAuth did not work. The OAuth code in `__main__.py` was updated to work with the OAuth app created in our Zendesk testing account.

I also changed the subdomain of our testing account to "d3v-estuary" since it might be viewable if someone inspects HTTP requests during the OAuth process., Although the subdomain change is reflected in the capture snapshot, I don't anticipate we will need to change this again, so the affected snapshotted properties don't need redacted.

**Workflow steps:**

When creating a Zendesk Support capture, enter the subdomain, then click the OAuth button. Follow the prompts to login to your Zendesk account, then allow Estuary access.

**Documentation links affected:**

Docs will need updated - authentication can be done with OAuth now.

**Notes for reviewers:**

Tested on a local stack. Confirmed streams still work as before with our Zendesk testing account when authenticated with OAuth.

The `{{{ config.subdomain }}}` syntax in `__main__.py` comes from our [docs](https://github.com/estuary/connectors/tree/main/python#the-url) and gets the user-entered subdomain in the UI. This means OAuth will fail if the user hasn't entered a subdomain prior to initiating the OAuth process. We currently don't require the subdomain before pressing the OAuth button, so that failure could be unexpected if a user tries to complete OAuth before filling out earlier fields. I think this is unlikely to happen though, and we don't handle this situation with other connectors (like `source-shopify`), so I don't think this needs addressed right now.

In order for the OAuth app in our Zendesk testing account to work with other Zendesk accounts, I had to request a [global OAuth client](https://developer.zendesk.com/documentation/marketplace/building-a-marketplace-app/set-up-a-global-oauth-client/#set-up-a-global-oauth-client). The request was made 21AUG2024, and the expected turnaround is about a week. I'll hold off merging into main until Zendesk finishes their part of the process.

The client id and client secret in the production database will need updated when this PR is merged.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1832)
<!-- Reviewable:end -->
