### PR TITLE
sql captures: Fix `staticcheck` lint complaints

### DIFF
--- a/source-mysql/backfill.go
+++ b/source-mysql/backfill.go
@@ -165,7 +165,7 @@ var columnBinaryKeyComparison = map[string]bool{
 	"longtext":   true,
 }
 
-func (db *mysqlDatabase) keylessScanQuery(info *sqlcapture.DiscoveryInfo, schemaName, tableName string) string {
+func (db *mysqlDatabase) keylessScanQuery(_ *sqlcapture.DiscoveryInfo, schemaName, tableName string) string {
 	var query = new(strings.Builder)
 	fmt.Fprintf(query, "SELECT * FROM `%s`.`%s`", schemaName, tableName)
 	fmt.Fprintf(query, " LIMIT %d", db.config.Advanced.BackfillChunkSize)

--- a/source-mysql/discovery.go
+++ b/source-mysql/discovery.go
@@ -413,7 +413,7 @@ const queryDiscoverTables = `
   WHERE table_schema != 'information_schema' AND table_schema != 'performance_schema'
     AND table_schema != 'mysql' AND table_schema != 'sys';`
 
-func getTables(ctx context.Context, conn *client.Conn) ([]*sqlcapture.DiscoveryInfo, error) {
+func getTables(_ context.Context, conn *client.Conn) ([]*sqlcapture.DiscoveryInfo, error) {
 	var results, err = conn.Execute(queryDiscoverTables)
 	if err != nil {
 		return nil, fmt.Errorf("error listing tables: %w", err)
@@ -436,7 +436,7 @@ const queryDiscoverColumns = `
   FROM information_schema.columns
   ORDER BY table_schema, table_name, ordinal_position;`
 
-func getColumns(ctx context.Context, conn *client.Conn) ([]sqlcapture.ColumnInfo, error) {
+func getColumns(_ context.Context, conn *client.Conn) ([]sqlcapture.ColumnInfo, error) {
 	var results, err = conn.Execute(queryDiscoverColumns)
 	if err != nil {
 		return nil, fmt.Errorf("error querying columns: %w", err)
@@ -642,7 +642,7 @@ SELECT table_schema, table_name, column_name, seq_in_index
 // primary keys. Table names are fully qualified as "<schema>.<name>", and
 // primary keys are represented as a list of column names, in the order that
 // they form the table's primary key.
-func getPrimaryKeys(ctx context.Context, conn *client.Conn) (map[string][]string, error) {
+func getPrimaryKeys(_ context.Context, conn *client.Conn) (map[string][]string, error) {
 	var results, err = conn.Execute(queryDiscoverPrimaryKeys)
 	if err != nil {
 		return nil, fmt.Errorf("error querying primary keys: %w", err)
@@ -675,7 +675,7 @@ SELECT stat.table_schema, stat.table_name, stat.index_name, stat.column_name, st
   ORDER BY stat.table_schema, stat.table_name, stat.index_name, stat.seq_in_index
 `
 
-func getSecondaryIndexes(ctx context.Context, conn *client.Conn) (map[string]map[string][]string, error) {
+func getSecondaryIndexes(_ context.Context, conn *client.Conn) (map[string]map[string][]string, error) {
 	var results, err = conn.Execute(queryDiscoverSecondaryIndices)
 	if err != nil {
 		return nil, fmt.Errorf("error querying secondary indexes: %w", err)

--- a/source-mysql/main.go
+++ b/source-mysql/main.go
@@ -204,7 +204,7 @@ func (db *mysqlDatabase) HistoryMode() bool {
 	return db.config.HistoryMode
 }
 
-func (db *mysqlDatabase) connect(ctx context.Context) error {
+func (db *mysqlDatabase) connect(_ context.Context) error {
 	logrus.WithFields(logrus.Fields{
 		"addr":     db.config.Address,
 		"dbName":   db.config.Advanced.DBName,

--- a/source-mysql/prerequisites.go
+++ b/source-mysql/prerequisites.go
@@ -46,7 +46,7 @@ const (
 	mariadbReqMinorVersion = 3
 )
 
-func (db *mysqlDatabase) prerequisiteVersion(ctx context.Context) error {
+func (db *mysqlDatabase) prerequisiteVersion(_ context.Context) error {
 	var minMajor, minMinor = mysqlReqMajorVersion, mysqlReqMinorVersion
 	if db.versionProduct == "MariaDB" {
 		minMajor, minMinor = mariadbReqMajorVersion, mariadbReqMinorVersion

--- a/source-mysql/replication.go
+++ b/source-mysql/replication.go
@@ -731,15 +731,6 @@ func unquoteEnumValues(values []string) []string {
 	return unquoted
 }
 
-func findStr(needle string, cols []string) int {
-	for idx, val := range cols {
-		if val == needle {
-			return idx
-		}
-	}
-	return -1
-}
-
 func resolveTableName(defaultSchema string, name sqlparser.TableName) string {
 	var schema, table = name.Qualifier.String(), name.Name.String()
 	if schema == "" {

--- a/source-oracle/main.go
+++ b/source-oracle/main.go
@@ -124,7 +124,7 @@ func (c *Config) Validate() error {
 	}
 
 	if !slices.Contains([]string{"", DictionaryModeExtract, DictionaryModeOnline}, c.Advanced.DictionaryMode) {
-		return fmt.Errorf("dictionary mode must be one of %s or %s.", DictionaryModeExtract, DictionaryModeOnline)
+		return fmt.Errorf("dictionary mode must be one of %s or %s", DictionaryModeExtract, DictionaryModeOnline)
 	}
 
 	return nil
@@ -210,7 +210,7 @@ type oracleDatabase struct {
 	tableObjectMapping map[string]tableObject           // A mapping from streamID to objectID, dataObjectID
 }
 
-func (db *oracleDatabase) isRDS() bool {
+func (db *oracleDatabase) IsRDS() bool {
 	return strings.Contains(db.config.Address, "rds.amazonaws.com")
 }
 
@@ -218,7 +218,7 @@ func (db *oracleDatabase) HistoryMode() bool {
 	return db.config.HistoryMode
 }
 
-func (db *oracleDatabase) connect(ctx context.Context) error {
+func (db *oracleDatabase) connect(_ context.Context) error {
 	logrus.WithFields(logrus.Fields{
 		"address":        db.config.Address,
 		"user":           db.config.User,

--- a/source-postgres/backfill.go
+++ b/source-postgres/backfill.go
@@ -196,7 +196,7 @@ var columnBinaryKeyComparison = map[string]bool{
 	"text":    true,
 }
 
-func (db *postgresDatabase) keylessScanQuery(info *sqlcapture.DiscoveryInfo, schemaName, tableName string) string {
+func (db *postgresDatabase) keylessScanQuery(_ *sqlcapture.DiscoveryInfo, schemaName, tableName string) string {
 	var query = new(strings.Builder)
 	fmt.Fprintf(query, `SELECT ctid, * FROM "%s"."%s"`, schemaName, tableName)
 	fmt.Fprintf(query, ` WHERE ctid > $1`)

--- a/source-postgres/capture_test.go
+++ b/source-postgres/capture_test.go
@@ -520,7 +520,7 @@ func TestCaptureAfterSlotDropped(t *testing.T) {
 	// the replication slot and then start failing because its saved position isn't
 	// valid any longer.
 	tb.Insert(ctx, t, tableName, [][]any{{2, "two"}, {3, "three"}})
-	tb.Query(ctx, t, fmt.Sprintf("SELECT pg_drop_replication_slot('flow_slot');"))
+	tb.Query(ctx, t, "SELECT pg_drop_replication_slot('flow_slot');")
 	tb.Insert(ctx, t, tableName, [][]any{{4, "four"}, {5, "five"}})
 	t.Run("capture2", func(t *testing.T) { tests.VerifiedCapture(ctx, t, cs) })
 

--- a/source-postgres/prerequisites.go
+++ b/source-postgres/prerequisites.go
@@ -174,7 +174,7 @@ func (db *postgresDatabase) prerequisitePublication(ctx context.Context) error {
 	// If the user already created the publication we won't try and set the flag, that's their job.
 	// The main reason this might fail is if we're running against a pre-v13 database, which doesn't
 	// have this flag, so we log but ignore any errors here.
-	if _, err := db.conn.Exec(ctx, fmt.Sprintf(`ALTER PUBLICATION flow_publication SET (publish_via_partition_root = true)`)); err != nil {
+	if _, err := db.conn.Exec(ctx, fmt.Sprintf(`ALTER PUBLICATION "%s" SET (publish_via_partition_root = true)`, pubName)); err != nil {
 		logEntry.WithField("err", err).Warn("unable to set publish_via_partition_root flag (this is normal for versions < 13)")
 	}
 

--- a/source-postgres/replication.go
+++ b/source-postgres/replication.go
@@ -156,9 +156,9 @@ type postgresSource struct {
 
 // Named constants for the LSN locations within a postgresSource.Location.
 const (
-	pgLocLastCommitEndLSN = 0 // Index of last Commit.EndLSN in postgresSource.Location.
-	pgLocEventLSN         = 1 // Index of this event LSN in postgresSource.Location.
-	pgLocBeginFinalLSN    = 2 // Index of current Begin.FinalLSN in postgresSource.Location.
+	PGLocLastCommitEndLSN = 0 // Index of last Commit.EndLSN in postgresSource.Location.
+	PGLocEventLSN         = 1 // Index of this event LSN in postgresSource.Location.
+	PGLocBeginFinalLSN    = 2 // Index of current Begin.FinalLSN in postgresSource.Location.
 )
 
 func (s *postgresSource) Common() sqlcapture.SourceCommon {

--- a/source-sqlserver/backfill.go
+++ b/source-sqlserver/backfill.go
@@ -147,7 +147,7 @@ func (db *sqlserverDatabase) ScanTableChunk(ctx context.Context, info *sqlcaptur
 	return backfillComplete, rows.Err()
 }
 
-func (db *sqlserverDatabase) keylessScanQuery(info *sqlcapture.DiscoveryInfo, schemaName, tableName string) string {
+func (db *sqlserverDatabase) keylessScanQuery(_ *sqlcapture.DiscoveryInfo, schemaName, tableName string) string {
 	var query = new(strings.Builder)
 	fmt.Fprintf(query, "SELECT * FROM [%s].[%s]", schemaName, tableName)
 	fmt.Fprintf(query, " ORDER BY %%%%physloc%%%%")

--- a/source-sqlserver/collation_test.go
+++ b/source-sqlserver/collation_test.go
@@ -20,7 +20,7 @@ import (
 func TestVarcharKeyDiscovery(t *testing.T) {
 	var tb, ctx = sqlserverTestBackend(t), context.Background()
 	var uniqueID = "42325208"
-	tb.CreateTable(ctx, t, uniqueID, fmt.Sprintf("(id VARCHAR(32) PRIMARY KEY, data TEXT)"))
+	tb.CreateTable(ctx, t, uniqueID, "(id VARCHAR(32) PRIMARY KEY, data TEXT)")
 	tb.CaptureSpec(ctx, t).VerifyDiscover(ctx, t, regexp.MustCompile(uniqueID))
 }
 
@@ -40,7 +40,7 @@ func TestCollatedCapture(t *testing.T) {
 			var tableName = tb.CreateTable(ctx, t, uniqueID, fmt.Sprintf("(id %s(32) COLLATE SQL_Latin1_General_CP1_CI_AS PRIMARY KEY, data TEXT)", columnType))
 
 			var testRows [][]any
-			var testRunes = []rune("?abcdef€‚ƒ„…†‡ˆ‰Š‹ŒŽ‘’“”•–—˜™š›œžŸ ¡¢£¤¥¦§¨©ª«¬­®¯°±²³´µ¶·¸¹º»¼½¾¿ÀÁÂÃÄÅÆÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖ×ØÙÚÛÜÝÞß÷ÿ") // 100 distinct runes
+			var testRunes = []rune("?abcdef€‚ƒ„…†‡ˆ‰Š‹ŒŽ‘’“”•–—˜™š›œžŸ ¡¢£¤¥¦§¨©ª«¬\u00AD®¯°±²³´µ¶·¸¹º»¼½¾¿ÀÁÂÃÄÅÆÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖ×ØÙÚÛÜÝÞß÷ÿ") // 100 distinct runes
 			for idx, r := range testRunes {
 				testRows = append(testRows, []any{fmt.Sprintf("a%sa %03d", string(r), idx), fmt.Sprintf("Row A%03d", idx)})
 				testRows = append(testRows, []any{fmt.Sprintf("a%sb %03d", string(r), idx), fmt.Sprintf("Row B%03d", idx)})

--- a/source-sqlserver/prerequisites.go
+++ b/source-sqlserver/prerequisites.go
@@ -14,12 +14,9 @@ import (
 func (db *sqlserverDatabase) SetupPrerequisites(ctx context.Context) []error {
 	var errs []error
 
-	//if err := db.prerequisiteVersion(ctx); err != nil {
-	//	// Return early if the database version is incompatible with the connector since additional
-	//	// errors will be of minimal use.
-	//	errs = append(errs, err)
-	//	return errs
-	//}
+	if err := db.prerequisiteVersion(ctx); err != nil {
+		log.WithField("err", err).Debug("server version prerequisite failed")
+	}
 
 	for _, prereq := range []func(ctx context.Context) error{
 		db.prerequisiteCDCEnabled,

--- a/sqlcapture/capture.go
+++ b/sqlcapture/capture.go
@@ -319,7 +319,7 @@ func (c *Capture) Run(ctx context.Context) (err error) {
 	return nil
 }
 
-func (c *Capture) updateState(ctx context.Context) error {
+func (c *Capture) updateState(_ context.Context) error {
 	// Create the Streams map if nil
 	if c.State.Streams == nil {
 		c.State.Streams = make(map[boilerplate.StateKey]*TableState)

--- a/sqlcapture/discovery.go
+++ b/sqlcapture/discovery.go
@@ -82,6 +82,7 @@ func DiscoverCatalog(ctx context.Context, db Database) ([]*pc.Response_Discovere
 		}
 
 		// The anchor by which we'll reference the table schema.
+		//lint:ignore SA1019 We don't need the title-casing to handle punctuation properly so strings.Title() is sufficient
 		var anchor = strings.Title(table.Schema) + strings.Title(table.Name)
 
 		// Build `properties` schemas for each table column.

--- a/sqlcapture/tests/tests.go
+++ b/sqlcapture/tests/tests.go
@@ -448,7 +448,7 @@ func (v *correctnessInvariantsCaptureValidator) Output(collection string, data j
 	case "u":
 		change = fmt.Sprintf("Update(%d)", event.Counter)
 	case "d":
-		change = fmt.Sprintf("Delete()")
+		change = "Delete()"
 	default:
 		change = fmt.Sprintf("UnknownOperation(%q)", event.Meta.Operation)
 	}


### PR DESCRIPTION
**Description:**

I'm about to take a stab at a fairly large refactor around how watermarking works, so it seemed prudent to make sure that the connectors in question were lint-clean beforehand.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1836)
<!-- Reviewable:end -->
