### PR TITLE
source-oracle: Minor cleanups

### DIFF
--- a/source-oracle/.snapshots/TestAllTypes-discover
+++ b/source-oracle/.snapshots/TestAllTypes-discover
@@ -13,12 +13,14 @@ Binding 0:
           "$anchor": "FLOW_TEST_LOGMINERT18110541",
           "properties": {
             "DATEONLY": {
+              "description": "(source type: DATE)",
               "type": [
                 "string",
                 "null"
               ]
             },
             "DATETIME": {
+              "description": "(source type: DATE)",
               "type": [
                 "string",
                 "null"
@@ -26,6 +28,7 @@ Binding 0:
             },
             "DOUBLE_PRECISION": {
               "format": "number",
+              "description": "(source type: FLOAT)",
               "type": [
                 "string",
                 "null"
@@ -33,6 +36,7 @@ Binding 0:
             },
             "FLOAT_126": {
               "format": "number",
+              "description": "(source type: FLOAT)",
               "type": [
                 "string",
                 "null"
@@ -40,18 +44,21 @@ Binding 0:
             },
             "INTEG": {
               "format": "integer",
+              "description": "(source type: NUMBER)",
               "type": [
                 "string",
                 "null"
               ]
             },
             "INTERVAL_DAY": {
+              "description": "(source type: INTERVAL DAY(2) TO SECOND(6))",
               "type": [
                 "string",
                 "null"
               ]
             },
             "INTERVAL_YEAR": {
+              "description": "(source type: INTERVAL YEAR(4) TO MONTH)",
               "type": [
                 "string",
                 "null"
@@ -59,12 +66,14 @@ Binding 0:
             },
             "NUM": {
               "format": "number",
+              "description": "(source type: NUMBER)",
               "type": [
                 "string",
                 "null"
               ]
             },
             "NUM15": {
+              "description": "(source type: NUMBER)",
               "type": [
                 "integer",
                 "null"
@@ -72,18 +81,21 @@ Binding 0:
             },
             "NUM19": {
               "format": "integer",
+              "description": "(source type: NUMBER)",
               "type": [
                 "string",
                 "null"
               ]
             },
             "NVCHAR2": {
+              "description": "(source type: NVARCHAR2)",
               "type": [
                 "string",
                 "null"
               ]
             },
             "R": {
+              "description": "(source type: RAW)",
               "type": [
                 "string",
                 "null"
@@ -91,12 +103,14 @@ Binding 0:
             },
             "REAL_NUM": {
               "format": "number",
+              "description": "(source type: FLOAT)",
               "type": [
                 "string",
                 "null"
               ]
             },
             "SINGLE_NCHAR": {
+              "description": "(source type: NCHAR)",
               "type": [
                 "string",
                 "null"
@@ -104,30 +118,35 @@ Binding 0:
             },
             "SMALL_INT": {
               "format": "integer",
+              "description": "(source type: NUMBER)",
               "type": [
                 "string",
                 "null"
               ]
             },
             "TS": {
+              "description": "(source type: TIMESTAMP(6))",
               "type": [
                 "string",
                 "null"
               ]
             },
             "TS_LOCAL_TZ": {
+              "description": "(source type: TIMESTAMP(6) WITH LOCAL TIME ZONE)",
               "type": [
                 "string",
                 "null"
               ]
             },
             "TS_LOCAL_TZ_NINE": {
+              "description": "(source type: TIMESTAMP(9) WITH LOCAL TIME ZONE)",
               "type": [
                 "string",
                 "null"
               ]
             },
             "TS_NINE": {
+              "description": "(source type: TIMESTAMP(9))",
               "type": [
                 "string",
                 "null"
@@ -135,6 +154,7 @@ Binding 0:
             },
             "TS_TZ": {
               "format": "date-time",
+              "description": "(source type: TIMESTAMP(6) WITH TIME ZONE)",
               "type": [
                 "string",
                 "null"
@@ -142,18 +162,21 @@ Binding 0:
             },
             "TS_TZ_NINE": {
               "format": "date-time",
+              "description": "(source type: TIMESTAMP(9) WITH TIME ZONE)",
               "type": [
                 "string",
                 "null"
               ]
             },
             "VCAHR2": {
+              "description": "(source type: VARCHAR2)",
               "type": [
                 "string",
                 "null"
               ]
             },
             "VCHAR": {
+              "description": "(source type: VARCHAR2)",
               "type": [
                 "string",
                 "null"

--- a/source-oracle/.snapshots/TestCapitalizedTables-Discover
+++ b/source-oracle/.snapshots/TestCapitalizedTables-Discover
@@ -15,6 +15,7 @@ Binding 0:
           "$anchor": "FLOW_TEST_LOGMINERUSERS",
           "properties": {
             "DATA": {
+              "description": "(source type: VARCHAR2)",
               "type": [
                 "string",
                 "null"
@@ -22,7 +23,8 @@ Binding 0:
             },
             "ID": {
               "type": "string",
-              "format": "number"
+              "format": "integer",
+              "description": "(source type: non-nullable NUMBER)"
             }
           }
         }

--- a/source-oracle/.snapshots/TestGeneric-KeylessDiscovery
+++ b/source-oracle/.snapshots/TestGeneric-KeylessDiscovery
@@ -14,12 +14,14 @@ Binding 0:
           "properties": {
             "A": {
               "format": "integer",
+              "description": "(source type: NUMBER)",
               "type": [
                 "string",
                 "null"
               ]
             },
             "B": {
+              "description": "(source type: VARCHAR2)",
               "type": [
                 "string",
                 "null"
@@ -27,12 +29,14 @@ Binding 0:
             },
             "C": {
               "format": "number",
+              "description": "(source type: FLOAT)",
               "type": [
                 "string",
                 "null"
               ]
             },
             "D": {
+              "description": "(source type: VARCHAR2)",
               "type": [
                 "string",
                 "null"

--- a/source-oracle/.snapshots/TestGeneric-MissingTable
+++ b/source-oracle/.snapshots/TestGeneric-MissingTable
@@ -5,5 +5,5 @@
 # ================================
 # Captures Terminated With Errors
 # ================================
-error updating capture state: table "FLOW_TEST_LOGMINER.T27607177" is a configured binding of this capture, but doesn't exist or isn't visible with current permissions
+error updating capture state: table "flow_test_logminer.t27607177" is a configured binding of this capture, but doesn't exist or isn't visible with current permissions
 

--- a/source-oracle/.snapshots/TestGeneric-SimpleDiscovery
+++ b/source-oracle/.snapshots/TestGeneric-SimpleDiscovery
@@ -16,9 +16,11 @@ Binding 0:
           "properties": {
             "A": {
               "type": "string",
-              "format": "integer"
+              "format": "integer",
+              "description": "(source type: non-nullable NUMBER)"
             },
             "B": {
+              "description": "(source type: VARCHAR2)",
               "type": [
                 "string",
                 "null"
@@ -26,12 +28,14 @@ Binding 0:
             },
             "C": {
               "format": "number",
+              "description": "(source type: FLOAT)",
               "type": [
                 "string",
                 "null"
               ]
             },
             "D": {
+              "description": "(source type: VARCHAR2)",
               "type": [
                 "string",
                 "null"

--- a/source-oracle/.snapshots/TestNullValues-discover
+++ b/source-oracle/.snapshots/TestNullValues-discover
@@ -13,12 +13,14 @@ Binding 0:
           "$anchor": "FLOW_TEST_LOGMINERT18110541",
           "properties": {
             "DATEONLY": {
+              "description": "(source type: DATE)",
               "type": [
                 "string",
                 "null"
               ]
             },
             "DATETIME": {
+              "description": "(source type: DATE)",
               "type": [
                 "string",
                 "null"
@@ -26,6 +28,7 @@ Binding 0:
             },
             "DOUBLE_PRECISION": {
               "format": "number",
+              "description": "(source type: FLOAT)",
               "type": [
                 "string",
                 "null"
@@ -33,6 +36,7 @@ Binding 0:
             },
             "FLOAT_126": {
               "format": "number",
+              "description": "(source type: FLOAT)",
               "type": [
                 "string",
                 "null"
@@ -40,18 +44,21 @@ Binding 0:
             },
             "INTEG": {
               "format": "integer",
+              "description": "(source type: NUMBER)",
               "type": [
                 "string",
                 "null"
               ]
             },
             "INTERVAL_DAY": {
+              "description": "(source type: INTERVAL DAY(2) TO SECOND(6))",
               "type": [
                 "string",
                 "null"
               ]
             },
             "INTERVAL_YEAR": {
+              "description": "(source type: INTERVAL YEAR(4) TO MONTH)",
               "type": [
                 "string",
                 "null"
@@ -59,12 +66,14 @@ Binding 0:
             },
             "NUM": {
               "format": "number",
+              "description": "(source type: NUMBER)",
               "type": [
                 "string",
                 "null"
               ]
             },
             "NUM15": {
+              "description": "(source type: NUMBER)",
               "type": [
                 "integer",
                 "null"
@@ -72,18 +81,21 @@ Binding 0:
             },
             "NUM19": {
               "format": "integer",
+              "description": "(source type: NUMBER)",
               "type": [
                 "string",
                 "null"
               ]
             },
             "NVCHAR2": {
+              "description": "(source type: NVARCHAR2)",
               "type": [
                 "string",
                 "null"
               ]
             },
             "R": {
+              "description": "(source type: RAW)",
               "type": [
                 "string",
                 "null"
@@ -91,12 +103,14 @@ Binding 0:
             },
             "REAL_NUM": {
               "format": "number",
+              "description": "(source type: FLOAT)",
               "type": [
                 "string",
                 "null"
               ]
             },
             "SINGLE_NCHAR": {
+              "description": "(source type: NCHAR)",
               "type": [
                 "string",
                 "null"
@@ -104,30 +118,35 @@ Binding 0:
             },
             "SMALL_INT": {
               "format": "integer",
+              "description": "(source type: NUMBER)",
               "type": [
                 "string",
                 "null"
               ]
             },
             "TS": {
+              "description": "(source type: TIMESTAMP(6))",
               "type": [
                 "string",
                 "null"
               ]
             },
             "TS_LOCAL_TZ": {
+              "description": "(source type: TIMESTAMP(6) WITH LOCAL TIME ZONE)",
               "type": [
                 "string",
                 "null"
               ]
             },
             "TS_LOCAL_TZ_NINE": {
+              "description": "(source type: TIMESTAMP(9) WITH LOCAL TIME ZONE)",
               "type": [
                 "string",
                 "null"
               ]
             },
             "TS_NINE": {
+              "description": "(source type: TIMESTAMP(9))",
               "type": [
                 "string",
                 "null"
@@ -135,6 +154,7 @@ Binding 0:
             },
             "TS_TZ": {
               "format": "date-time",
+              "description": "(source type: TIMESTAMP(6) WITH TIME ZONE)",
               "type": [
                 "string",
                 "null"
@@ -142,18 +162,21 @@ Binding 0:
             },
             "TS_TZ_NINE": {
               "format": "date-time",
+              "description": "(source type: TIMESTAMP(9) WITH TIME ZONE)",
               "type": [
                 "string",
                 "null"
               ]
             },
             "VCAHR2": {
+              "description": "(source type: VARCHAR2)",
               "type": [
                 "string",
                 "null"
               ]
             },
             "VCHAR": {
+              "description": "(source type: VARCHAR2)",
               "type": [
                 "string",
                 "null"

--- a/source-oracle/.snapshots/TestStringKey-discover
+++ b/source-oracle/.snapshots/TestStringKey-discover
@@ -14,6 +14,7 @@ Binding 0:
           "properties": {
             "ID": {
               "format": "integer",
+              "description": "(source type: NUMBER)",
               "type": [
                 "string",
                 "null"

--- a/source-oracle/.snapshots/TestTrickyColumnNames-discover
+++ b/source-oracle/.snapshots/TestTrickyColumnNames-discover
@@ -15,6 +15,7 @@ Binding 0:
           "$anchor": "FLOW_TEST_LOGMINERT39256824",
           "properties": {
             "DATA": {
+              "description": "(source type: VARCHAR2)",
               "type": [
                 "string",
                 "null"
@@ -22,7 +23,8 @@ Binding 0:
             },
             "`Meta/'wtf'~ID`": {
               "type": "string",
-              "format": "integer"
+              "format": "integer",
+              "description": "(source type: non-nullable NUMBER)"
             }
           }
         }
@@ -145,6 +147,7 @@ Binding 1:
           "$anchor": "FLOW_TEST_LOGMINERT42531495",
           "properties": {
             "DATA": {
+              "description": "(source type: VARCHAR2)",
               "type": [
                 "string",
                 "null"
@@ -152,7 +155,8 @@ Binding 1:
             },
             "table": {
               "type": "string",
-              "format": "integer"
+              "format": "integer",
+              "description": "(source type: non-nullable NUMBER)"
             }
           }
         }

--- a/source-oracle/discovery.go
+++ b/source-oracle/discovery.go
@@ -272,6 +272,10 @@ type oracleColumnType struct {
 	nullable  bool
 }
 
+func (ct oracleColumnType) String() string {
+	return ct.original
+}
+
 // SMALLINT, INT and INTEGER have a default precision 38 which is not included in the column information
 const defaultNumericPrecision = 38
 

--- a/source-oracle/main.go
+++ b/source-oracle/main.go
@@ -293,8 +293,8 @@ func (db *oracleDatabase) ShouldBackfill(streamID string) bool {
 	if db.config.Advanced.SkipBackfills != "" {
 		// This repeated splitting is a little inefficient, but this check is done at
 		// most once per table during connector startup and isn't really worth caching.
-		for _, skipStreamID := range strings.Split(db.config.Advanced.SkipBackfills, ",") {
-			if streamID == skipStreamID {
+		for _, skipTableName := range strings.Split(db.config.Advanced.SkipBackfills, ",") {
+			if strings.EqualFold(streamID, skipTableName) {
 				return false
 			}
 		}


### PR DESCRIPTION
**Description:**

Fixes a couple of minor issues discovered when I tried running the test suite for myself. Other than some snapshot updates the actual changes are fixing the 'Skip Backfills' logic to use case-insensitive table name comparison and fixing the stringification of the discovered Oracle column type struct so the "include source type info in discovered schemas" feature produces nice readable descriptions.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1837)
<!-- Reviewable:end -->
