### PR TITLE
source-postgres: Fix minor bug in acknowledgement handling

### DIFF
--- a/source-postgres/replication.go
+++ b/source-postgres/replication.go
@@ -676,6 +676,12 @@ func (s *replicationStream) ActivateTable(ctx context.Context, streamID string, 
 // advance the "Restart LSN" to the same point, but so long as you ignore the details
 // things will work out in the end.
 func (s *replicationStream) Acknowledge(ctx context.Context, cursor string) error {
+	if cursor == "" {
+		// The empty cursor will be acknowledged once at startup when all bindings
+		// are new, because the initial state checkpoint will have an unspecified
+		// cursor value on purpose. We don't need to do anything with those.
+		return nil
+	}
 	var lsn, err = pglogrepl.ParseLSN(cursor)
 	if err != nil {
 		return fmt.Errorf("error parsing acknowledge cursor: %w", err)


### PR DESCRIPTION
**Description:**

The big SQL Server CDC overhaul which was merged recently fixed a missing error return path when the Acknowledge method fails, but apparently it had always been returning an error the very first time for a Postgres capture because the first checkpoint a Postgres capture emits after being started up with all-new bindings has an empty cursor string on purpose.

This fixes that.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1838)
<!-- Reviewable:end -->
