### PR TITLE
source-oracle: better message for supplemental logging

### DIFF
--- a/source-oracle/Dockerfile
+++ b/source-oracle/Dockerfile
@@ -23,7 +23,7 @@ ENV PATH="/builder/bin:$PATH"
 ARG TEST_DATABASE=no
 ENV TEST_DATABASE=$TEST_DATABASE
 ENV CI_BUILD=yes
-#RUN go test -short -failfast -v ./source-oracle/...
+RUN go test -short -failfast -v ./source-oracle/...
 
 # Build the connector.
 RUN --mount=type=cache,id=gomod,target=/go/pkg/mod \

--- a/source-oracle/capture_test.go
+++ b/source-oracle/capture_test.go
@@ -64,6 +64,7 @@ func TestAllTypes(t *testing.T) {
 		{"interval_year", "INTERVAL YEAR(4) TO MONTH", NewRawTupleValue("INTERVAL '1234-5' YEAR(4) TO MONTH")},
 		{"interval_day", "INTERVAL DAY TO SECOND", NewRawTupleValue("INTERVAL '1 2:3:4.567' DAY TO SECOND(3)")},
 		{"r", "RAW(1000)", NewRawTupleValue("UTL_RAW.CAST_To_RAW('testing raw value')")},
+		{"anycol", "ANYDATA", NewRawTupleValue("NULL")},
 	}
 
 	var columnDefs = "("

--- a/source-oracle/discovery.go
+++ b/source-oracle/discovery.go
@@ -356,7 +356,13 @@ func getColumns(ctx context.Context, conn *sql.DB, tables []*sqlcapture.Discover
 			t = reflect.TypeFor[[]byte]()
 			jsonType = "string"
 		} else {
-			return nil, nil, fmt.Errorf("unsupported data type: %s", dataType)
+			logrus.WithFields(logrus.Fields{
+				"owner":    sc.TableSchema,
+				"table":    sc.TableName,
+				"dataType": dataType,
+				"column":   sc.Name,
+			}).Warn("skipping column, data type is not supported")
+			continue
 		}
 
 		sc.DataType = oracleColumnType{

--- a/source-oracle/prerequisites.go
+++ b/source-oracle/prerequisites.go
@@ -29,7 +29,11 @@ func (db *oracleDatabase) prerequisiteSupplementalLogging(ctx context.Context, o
 
 	if all != "YES" {
 		if min != "YES" {
-			return fmt.Errorf("supplemental logging not enabled. Please enable supplemental logging using `ALTER DATABASE ADD SUPPLEMENTAL LOG DATA`")
+			var enableCommand = "ALTER DATABASE ADD SUPPLEMENTAL LOG DATA (ALL) COLUMNS;"
+			if db.isRDS() {
+				enableCommand = "BEGIN rdsadmin.rdsadmin_util.alter_supplemental_logging(p_action => 'ADD', p_type   => 'ALL'); END;"
+			}
+			return fmt.Errorf("supplemental logging not enabled. Please enable supplemental logging using `%s`", enableCommand)
 		}
 
 		if owner != "" && tableName != "" {


### PR DESCRIPTION
**Description:**

- RDS instances require a different command to enable supplemental logging
- Log warning for unsupported data types but allow discovery (same logic as flashback)

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1839)
<!-- Reviewable:end -->
