### PR TITLE
source-oracle: fix first run on redo log files with no dictionary

### DIFF
--- a/source-oracle/.snapshots/TestUnsupportedTypes-backfill
+++ b/source-oracle/.snapshots/TestUnsupportedTypes-backfill
@@ -1,0 +1,9 @@
+# ================================
+# Collection "acmeCo/test/flow_test_logminer_t18110541": 1 Documents
+# ================================
+{"NVCHAR2":"nvarchar2 value with unicode characters ❤️ \\ 🔥️')","_meta":{"op":"c","source":{"schema":"FLOW_TEST_LOGMINER","snapshot":true,"table":"T18110541","row_id":"AAAAAAAAAAAAAAAAAA"}}}
+# ================================
+# Final State Checkpoint
+# ================================
+{"bindingStateV1":{"FLOW_TEST_LOGMINER%2FT18110541":{"backfilled":1,"mode":"Active"}},"cursor":"11111111"}
+

--- a/source-oracle/.snapshots/TestUnsupportedTypes-discover
+++ b/source-oracle/.snapshots/TestUnsupportedTypes-discover
@@ -1,0 +1,126 @@
+Binding 0:
+{
+    "recommended_name": "flow_test_logminer_t18110541",
+    "resource_config_json": {
+      "mode": "Without Primary Key",
+      "namespace": "FLOW_TEST_LOGMINER",
+      "stream": "T18110541"
+    },
+    "document_schema_json": {
+      "$defs": {
+        "FLOW_TEST_LOGMINERT18110541": {
+          "type": "object",
+          "$anchor": "FLOW_TEST_LOGMINERT18110541",
+          "properties": {
+            "NVCHAR2": {
+              "description": "(source type: NVARCHAR2)",
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          }
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "_meta": {
+                "properties": {
+                  "op": {
+                    "const": "d"
+                  }
+                }
+              }
+            }
+          },
+          "then": {
+            "reduce": {
+              "delete": true,
+              "strategy": "merge"
+            }
+          },
+          "else": {
+            "reduce": {
+              "strategy": "merge"
+            }
+          },
+          "required": [
+            "_meta"
+          ],
+          "properties": {
+            "_meta": {
+              "type": "object",
+              "required": [
+                "op",
+                "source"
+              ],
+              "properties": {
+                "before": {
+                  "$ref": "#FLOW_TEST_LOGMINERT18110541",
+                  "description": "Record state immediately before this change was applied.",
+                  "reduce": {
+                    "strategy": "firstWriteWins"
+                  }
+                },
+                "op": {
+                  "enum": [
+                    "c",
+                    "d",
+                    "u"
+                  ],
+                  "description": "Change operation type: 'c' Create/Insert, 'u' Update, 'd' Delete."
+                },
+                "source": {
+                  "$id": "https://github.com/estuary/connectors/source-oracle/oracle-source",
+                  "properties": {
+                    "ts_ms": {
+                      "type": "integer",
+                      "description": "Unix timestamp (in millis) at which this event was recorded by the database."
+                    },
+                    "schema": {
+                      "type": "string",
+                      "description": "Database schema (namespace) of the event."
+                    },
+                    "snapshot": {
+                      "type": "boolean",
+                      "description": "Snapshot is true if the record was produced from an initial table backfill and unset if produced from the replication log."
+                    },
+                    "table": {
+                      "type": "string",
+                      "description": "Database table of the event."
+                    },
+                    "scn": {
+                      "type": "integer",
+                      "description": "SCN of this event"
+                    },
+                    "row_id": {
+                      "type": "string",
+                      "description": "ROWID of the document"
+                    }
+                  },
+                  "type": "object",
+                  "required": [
+                    "schema",
+                    "table",
+                    "row_id"
+                  ]
+                }
+              },
+              "reduce": {
+                "strategy": "merge"
+              }
+            }
+          }
+        },
+        {
+          "$ref": "#FLOW_TEST_LOGMINERT18110541"
+        }
+      ]
+    },
+    "key": [
+      "/_meta/source/row_id"
+    ]
+  }
+

--- a/source-oracle/.snapshots/TestUnsupportedTypes-replication
+++ b/source-oracle/.snapshots/TestUnsupportedTypes-replication
@@ -1,0 +1,9 @@
+# ================================
+# Collection "acmeCo/test/flow_test_logminer_t18110541": 1 Documents
+# ================================
+{"NVCHAR2":"nvarchar2 value with unicode characters ❤️ \\ 🔥️')","_meta":{"op":"u","source":{"ts_ms":1111111111111,"schema":"FLOW_TEST_LOGMINER","table":"T18110541","scn":11111111,"row_id":"AAAAAAAAAAAAAAAAAA"},"before":{"NVCHAR2":"nvarchar2 value with unicode characters ❤️ \\ 🔥️')"}}}
+# ================================
+# Final State Checkpoint
+# ================================
+{"bindingStateV1":{"FLOW_TEST_LOGMINER%2FT18110541":{"backfilled":1,"mode":"Active"}},"cursor":"11111111"}
+

--- a/source-oracle/decode.go
+++ b/source-oracle/decode.go
@@ -203,7 +203,8 @@ func (s *replicationStream) decodeMessage(msg logminerMessage) (sqlcapture.Datab
 		err := sqlparser.VisitExpr(del.Where.Expr, func(node sqlparser.SQLNode) (kontinue bool, err error) {
 			switch n := node.(type) {
 			case *sqlparser.ComparisonExpr:
-				var key = unquote(sqlparser.String(n.Left))
+				var col = n.Left.(*sqlparser.ColName)
+				var key = unquote(sqlparser.String(col.Name))
 				if key == "ROWID" {
 					var value = n.Right.(*sqlparser.Literal).Val
 					after[key] = value
@@ -226,10 +227,12 @@ func (s *replicationStream) decodeMessage(msg logminerMessage) (sqlcapture.Datab
 		if !ok {
 			return nil, fmt.Errorf("expected UPDATE sql statement, instead got: %v", ast)
 		}
+
 		err := sqlparser.VisitExpr(update.Where.Expr, func(node sqlparser.SQLNode) (kontinue bool, err error) {
 			switch n := node.(type) {
 			case *sqlparser.ComparisonExpr:
-				var key = unquote(sqlparser.String(n.Left))
+				var col = n.Left.(*sqlparser.ColName)
+				var key = unquote(sqlparser.String(col.Name))
 				value, err := decodeValue(n.Right)
 				if err != nil {
 					return false, fmt.Errorf("update sql statement where clause %q, key %q: %w", msg.SQL, key, err)
@@ -260,7 +263,8 @@ func (s *replicationStream) decodeMessage(msg logminerMessage) (sqlcapture.Datab
 		err = sqlparser.VisitExpr(undo.Where.Expr, func(node sqlparser.SQLNode) (kontinue bool, err error) {
 			switch n := node.(type) {
 			case *sqlparser.ComparisonExpr:
-				var key = unquote(sqlparser.String(n.Left))
+				var col = n.Left.(*sqlparser.ColName)
+				var key = unquote(sqlparser.String(col.Name))
 				value, err := decodeValue(n.Right)
 				if err != nil {
 					return false, fmt.Errorf("update sql undo statement where clause %q, key %q: %w", msg.UndoSQL, key, err)
@@ -292,7 +296,8 @@ func (s *replicationStream) decodeMessage(msg logminerMessage) (sqlcapture.Datab
 		err := sqlparser.VisitExpr(del.Where.Expr, func(node sqlparser.SQLNode) (kontinue bool, err error) {
 			switch n := node.(type) {
 			case *sqlparser.ComparisonExpr:
-				var key = unquote(sqlparser.String(n.Left))
+				var col = n.Left.(*sqlparser.ColName)
+				var key = unquote(sqlparser.String(col.Name))
 				value, err := decodeValue(n.Right)
 				if err != nil {
 					return false, fmt.Errorf("delete sql statement %q, key %q: %w", msg.SQL, key, err)

--- a/source-oracle/decode.go
+++ b/source-oracle/decode.go
@@ -152,6 +152,7 @@ func decodeUnistr(input string) (string, error) {
 
 func (s *replicationStream) decodeMessage(msg logminerMessage) (sqlcapture.DatabaseEvent, error) {
 	var streamID = sqlcapture.JoinStreamID(msg.Owner, msg.TableName)
+
 	var parser, err = sqlparser.New(sqlparser.Options{})
 	if err != nil {
 		return nil, err
@@ -325,7 +326,9 @@ func (s *replicationStream) decodeMessage(msg logminerMessage) (sqlcapture.Datab
 		if err := translateRecordFields(discovery, after); err != nil {
 			return nil, fmt.Errorf("error translating 'after' tuple: %w", err)
 		}
-	} else if before != nil {
+	}
+
+	if before != nil {
 		rowid = before["ROWID"].(string)
 		if err := translateRecordFields(discovery, before); err != nil {
 			return nil, fmt.Errorf("error translating 'before' tuple: %w", err)

--- a/source-oracle/discovery.go
+++ b/source-oracle/discovery.go
@@ -152,6 +152,11 @@ func translateRecordFields(table *sqlcapture.DiscoveryInfo, f map[string]interfa
 			}
 		}
 
+		if columnInfo == nil {
+			delete(f, id)
+			continue
+		}
+
 		var translated, err = translateRecordField(columnInfo, val)
 		if err != nil {
 			return fmt.Errorf("error translating field %q value %v: %w", id, val, err)


### PR DESCRIPTION
**Description:**

- the first run will not be able to find any archive logs with dictionaries, so it will yield NULL for `MAX(NEXT_CHANGE#) from V$ARCHIVELOG`. In these instances we just find the first log file that contains the SCN range we are looking for.
- SCNs are actually 48 bit in size, so we should store them in int64s, updated that
- Turns out if there is an `ANYDATA` column in a table, the logminer query will use a table alias (presumable to use another alias for the anydata in case its properties need to be updated). As I wrote a test for unsupported data types, also found this issue, which is now resolved by parsing the left hand side of comparison expressions in `WHERE` statements as `sqlparser.ColName` and using the column name without its alias qualification.
- Also remove columns which are not part of the discovered columns from the resulting document to avoid ambiguous behavior for those columns

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1841)
<!-- Reviewable:end -->
