### PR TITLE
source-oracle: Undo capitalization tweak

### DIFF
--- a/source-oracle/main.go
+++ b/source-oracle/main.go
@@ -210,7 +210,7 @@ type oracleDatabase struct {
 	tableObjectMapping map[string]tableObject           // A mapping from streamID to objectID, dataObjectID
 }
 
-func (db *oracleDatabase) IsRDS() bool {
+func (db *oracleDatabase) isRDS() bool {
 	return strings.Contains(db.config.Address, "rds.amazonaws.com")
 }
 


### PR DESCRIPTION
**Description:**

In https://github.com/estuary/connectors/pull/1836 I changed the name of the `isRDS()` method to be capitalized `IsRDS()` so that the linter wouldn't complain that it wasn't currently used (since the connector is still new and I suspected it was probably meant to be used soon).

Unfortunately it looks like the change which added a use of that method landed concurrently with my "make the linter happy" PR, so now the build is failing because of the mismatch and there's no longer any actual reason to capitalize it. Whoops.

So this is just a trivial fix to undo that one character diff.