### PR TITLE
materialize-sql: remove CheckedInt64 converter

### DIFF
--- a/materialize-bigquery/sqlgen.go
+++ b/materialize-bigquery/sqlgen.go
@@ -66,7 +66,7 @@ var bqDialect = func() sql.Dialect {
 			sql.BINARY:  sql.MapStatic("STRING"),
 			sql.BOOLEAN: sql.MapStatic("BOOLEAN"),
 			sql.INTEGER: sql.MapSignedInt64(
-				sql.MapStatic("INTEGER", sql.UsingConverter(sql.CheckedInt64)),
+				sql.MapStatic("INTEGER"),
 				sql.MapStatic("BIGNUMERIC(38,0)", sql.AlsoCompatibleWith("bignumeric")),
 			),
 			// We used to materialize these as "BIGNUMERIC(38,0)", so

--- a/materialize-databricks/sqlgen.go
+++ b/materialize-databricks/sqlgen.go
@@ -35,7 +35,7 @@ var databricksDialect = func() sql.Dialect {
 			sql.BINARY:  sql.MapStatic("BINARY"),
 			sql.BOOLEAN: sql.MapStatic("BOOLEAN"),
 			sql.INTEGER: sql.MapSignedInt64(
-				sql.MapStatic("LONG", sql.UsingConverter(sql.CheckedInt64)),
+				sql.MapStatic("LONG"),
 				sql.MapStatic("NUMERIC(38,0)", sql.AlsoCompatibleWith("decimal")),
 			),
 			sql.NUMBER:   sql.MapStatic("DOUBLE"),

--- a/materialize-motherduck/sqlgen.go
+++ b/materialize-motherduck/sqlgen.go
@@ -11,7 +11,7 @@ var duckDialect = func() sql.Dialect {
 	mapper := sql.NewDDLMapper(
 		sql.FlatTypeMappings{
 			sql.INTEGER: sql.MapSignedInt64(
-				sql.MapStatic("BIGINT", sql.UsingConverter(sql.CheckedInt64)),
+				sql.MapStatic("BIGINT"),
 				sql.MapStatic("HUGEINT"),
 			),
 			sql.NUMBER:   sql.MapStatic("DOUBLE"),

--- a/materialize-mysql/sqlgen.go
+++ b/materialize-mysql/sqlgen.go
@@ -46,7 +46,7 @@ var mysqlDialect = func(tzLocation *time.Location, database string) sql.Dialect 
 	mapper := sql.NewDDLMapper(
 		sql.FlatTypeMappings{
 			sql.INTEGER: sql.MapSignedInt64(
-				sql.MapStatic("BIGINT", sql.UsingConverter(sql.CheckedInt64)),
+				sql.MapStatic("BIGINT"),
 				sql.MapStatic("NUMERIC(65,0)", sql.AlsoCompatibleWith("decimal")),
 			),
 			sql.NUMBER:   sql.MapStatic("DOUBLE PRECISION", sql.AlsoCompatibleWith("double")),

--- a/materialize-postgres/sqlgen.go
+++ b/materialize-postgres/sqlgen.go
@@ -13,7 +13,7 @@ var pgDialect = func() sql.Dialect {
 	mapper := sql.NewDDLMapper(
 		sql.FlatTypeMappings{
 			sql.INTEGER: sql.MapSignedInt64(
-				sql.MapStatic("BIGINT", sql.AlsoCompatibleWith("integer"), sql.UsingConverter(sql.CheckedInt64)),
+				sql.MapStatic("BIGINT", sql.AlsoCompatibleWith("integer")),
 				sql.MapStatic("NUMERIC"),
 			),
 			sql.NUMBER:         sql.MapStatic("DOUBLE PRECISION"),

--- a/materialize-redshift/sqlgen.go
+++ b/materialize-redshift/sqlgen.go
@@ -32,7 +32,7 @@ var rsDialect = func(caseSensitiveIdentifierEnabled bool) sql.Dialect {
 	mapper := sql.NewDDLMapper(
 		sql.FlatTypeMappings{
 			sql.INTEGER: sql.MapSignedInt64(
-				sql.MapStatic("BIGINT", sql.UsingConverter(sql.CheckedInt64)),
+				sql.MapStatic("BIGINT"),
 				sql.MapStatic("NUMERIC(38,0)", sql.AlsoCompatibleWith("numeric")),
 			),
 			sql.NUMBER:   sql.MapStatic("DOUBLE PRECISION"),

--- a/materialize-sql/element_converter.go
+++ b/materialize-sql/element_converter.go
@@ -183,28 +183,3 @@ var ClampDate ElementConverter = StringCastConverter(func(str string) (interface
 	}
 	return str, nil
 })
-
-// CheckedIn64 passes through values that can be represented as a signed 64-bit
-// integer, and produces an error for other values.
-func CheckedInt64(te tuple.TupleElement) (any, error) {
-	switch ii := te.(type) {
-	case int64:
-		return ii, nil
-	case uint64, float64:
-		return nil, fmt.Errorf("value of %v (%T) will not fit in a signed 64-bit integer", te, te)
-	case string:
-		if b, err := StrToInt(ii); err != nil {
-			return nil, err
-		} else if b, ok := b.(*big.Int); !ok {
-			return nil, fmt.Errorf("application error: expected *big.Int from StrToInt")
-		} else if !b.IsInt64() {
-			return nil, fmt.Errorf("value of %v (%T) will not fit in a signed 64-bit integer", te, te)
-		} else {
-			return b.Int64(), nil
-		}
-	case nil:
-		return nil, nil
-	default:
-		return nil, fmt.Errorf("CheckedInt64 unsupported type %T (%#v)", te, te)
-	}
-}

--- a/materialize-sql/element_converter_test.go
+++ b/materialize-sql/element_converter_test.go
@@ -2,8 +2,6 @@ package sql
 
 import (
 	"encoding/json"
-	"fmt"
-	"math"
 	"math/big"
 	"testing"
 
@@ -137,65 +135,5 @@ func TestToJsonString(t *testing.T) {
 		got, err := ToJsonString(tt.input)
 		require.NoError(t, err)
 		require.Equal(t, tt.want, got)
-	}
-}
-
-func TestCheckedInt64(t *testing.T) {
-	for _, tt := range []struct {
-		input   any
-		want    any
-		wantErr bool
-	}{
-		{
-			input:   nil,
-			want:    nil,
-			wantErr: false,
-		},
-		{
-			input:   int64(12),
-			want:    int64(12),
-			wantErr: false,
-		},
-		{
-			input:   "1234",
-			want:    int64(1234),
-			wantErr: false,
-		},
-		{
-			input:   uint64(math.MaxUint64),
-			want:    nil,
-			wantErr: true,
-		},
-		{
-			input:   float64(math.MaxFloat64),
-			want:    nil,
-			wantErr: true,
-		},
-		{
-			input:   fmt.Sprintf("%.0f", math.MaxFloat64),
-			want:    nil,
-			wantErr: true,
-		},
-		{
-			input:   true,
-			want:    nil,
-			wantErr: true,
-		},
-		{
-			input:   "notanintegerstring",
-			want:    nil,
-			wantErr: true,
-		},
-	} {
-		got, err := CheckedInt64(tt.input)
-		if tt.wantErr {
-			require.Error(t, err)
-		} else {
-			require.NoError(t, err)
-		}
-		require.Equal(t, tt.want, got)
-		if tt.want != nil {
-			require.IsType(t, int64(0), tt.want)
-		}
 	}
 }

--- a/materialize-sqlserver/sqlgen.go
+++ b/materialize-sqlserver/sqlgen.go
@@ -46,7 +46,7 @@ var sqlServerDialect = func(collation string, schemaName string) sql.Dialect {
 	mapper := sql.NewDDLMapper(
 		sql.FlatTypeMappings{
 			sql.INTEGER: sql.MapSignedInt64(
-				sql.MapStatic("BIGINT", sql.UsingConverter(sql.CheckedInt64)),
+				sql.MapStatic("BIGINT"),
 				sql.MapStatic(textType, sql.AlsoCompatibleWith(stringType), sql.UsingConverter(sql.ToStr)),
 			),
 			sql.NUMBER:   sql.MapStatic("DOUBLE PRECISION", sql.AlsoCompatibleWith("float")),
@@ -56,7 +56,7 @@ var sqlServerDialect = func(collation string, schemaName string) sql.Dialect {
 			sql.BINARY:   sql.MapStatic(textType, sql.AlsoCompatibleWith(stringType)),
 			sql.MULTIPLE: sql.MapStatic(textType, sql.AlsoCompatibleWith(stringType), sql.UsingConverter(sql.ToJsonString)),
 			sql.STRING_INTEGER: sql.MapStringMaxLen(
-				sql.MapStatic("BIGINT", sql.UsingConverter(sql.CheckedInt64)),
+				sql.MapStatic("BIGINT", sql.UsingConverter(strToInt)),
 				sql.MapStatic(textType, sql.AlsoCompatibleWith(stringType), sql.UsingConverter(sql.ToStr)),
 				// The maximum length of a signed 64-bit integer is 19
 				// characters.


### PR DESCRIPTION
**Description:**

This removes the CheckedInt64 converter, the only purpose of which was to evaluate if a value would fit into a signed 64-bit integer column, and produce a nice error message if it didn't.

It was flawed because it did not account for values transmitted as floats when they are small and have no fractional component.

I may revisit this in the future. For now this just takes out the check.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1850)
<!-- Reviewable:end -->
