### PR TITLE
materialize-databricks: do not validate string integers as LONG columns

### DIFF
--- a/materialize-databricks/sqlgen.go
+++ b/materialize-databricks/sqlgen.go
@@ -42,9 +42,7 @@ var databricksDialect = func() sql.Dialect {
 			sql.OBJECT:   jsonMapper,
 			sql.MULTIPLE: jsonMapper,
 			sql.STRING_INTEGER: sql.MapStringMaxLen(
-				// We used to materialize these as "LONG", so pre-existing
-				// columns of that type are allowed for backward-compatibility.
-				sql.MapStatic("NUMERIC(38,0)", sql.AlsoCompatibleWith("decimal", "long"), sql.UsingConverter(sql.StrToInt)),
+				sql.MapStatic("NUMERIC(38,0)", sql.AlsoCompatibleWith("decimal"), sql.UsingConverter(sql.StrToInt)),
 				sql.MapStatic("STRING", sql.UsingConverter(sql.ToStr)),
 				38,
 			),

--- a/materialize-sql/type_mapping.go
+++ b/materialize-sql/type_mapping.go
@@ -376,9 +376,11 @@ func (d DDLMapper) MapType(p *Projection) (MappedType, error) {
 	}
 
 	if fc.IgnoreStringFormat || fc.CastToString {
-		// Materialize this field as a string, and convert its values to strings
-		// if configured.
-		ddl, compatibleTypes, _ = d.m[STRING](p)
+		// Materialize this field as a "plain" string, and convert its values to
+		// strings if configured.
+		p := *p
+		p.Inference.String_ = &pf.Inference_String{}
+		ddl, compatibleTypes, _ = d.m[STRING](&p)
 		converter = ToStr
 	}
 


### PR DESCRIPTION
**Description:**

Although this would appear to be a backward compatible transition, the explicit
casting to `NUMERIC(38,0)` that is done in Store queries does not work with
pre-existing `LONG` columns.

Any materializations with pre-existing `LONG` columns for `type: string, format:
integer` fields will need the `LONG` DDL field configuration to be upgraded.
There are a few more of these than I wanted to deal with manually but it
shouldn't be _that_ bad, and it will set us up better for the future.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1851)
<!-- Reviewable:end -->
