### PR TITLE
source-pendo: address logged warning

### DIFF
--- a/source-pendo/source_pendo/manifest.yaml
+++ b/source-pendo/source_pendo/manifest.yaml
@@ -177,6 +177,9 @@ schemas:
       id:
         type: string
         description: The unique ID of the page.
+      _meta:
+        type: object
+        description: Metadata object added by Estuary.
     additionalProperties: true
   Feature:
     type: object
@@ -185,6 +188,9 @@ schemas:
       id:
         type: string
         description: The unique identifier of the feature.
+      _meta:
+        type: object
+        description: Metadata object added by Estuary.
     additionalProperties: true
   Report:
     type: object
@@ -193,6 +199,9 @@ schemas:
       id:
         type: string
         description: Unique ID of the report
+      _meta:
+        type: object
+        description: Metadata object added by Estuary.
     additionalProperties: true
   Guide:
     type: object
@@ -201,12 +210,23 @@ schemas:
       id:
         type: string
         description: Unique identifier of the guide.
+      _meta:
+        type: object
+        description: Metadata object added by Estuary.
     additionalProperties: true
   Account Metadata:
     type: object
     $schema: http://json-schema.org/schema#
+    properties:
+      _meta:
+        type: object
+        description: Metadata object added by Estuary.
     additionalProperties: true
   Visitor Metadata:
     type: object
     $schema: http://json-schema.org/schema#
+    properties:
+      _meta:
+        type: object
+        description: Metadata object added by Estuary.
     additionalProperties: true

--- a/source-pendo/tests/snapshots/snapshots__discover__capture.stdout.json
+++ b/source-pendo/tests/snapshots/snapshots__discover__capture.stdout.json
@@ -15,6 +15,7 @@
         },
         "_meta": {
           "type": "object",
+          "description": "Metadata object added by Estuary.",
           "properties": {
             "row_id": {
               "type": "integer"
@@ -48,6 +49,7 @@
         },
         "_meta": {
           "type": "object",
+          "description": "Metadata object added by Estuary.",
           "properties": {
             "row_id": {
               "type": "integer"
@@ -81,6 +83,7 @@
         },
         "_meta": {
           "type": "object",
+          "description": "Metadata object added by Estuary.",
           "properties": {
             "row_id": {
               "type": "integer"
@@ -114,6 +117,7 @@
         },
         "_meta": {
           "type": "object",
+          "description": "Metadata object added by Estuary.",
           "properties": {
             "row_id": {
               "type": "integer"
@@ -140,10 +144,10 @@
     "documentSchema": {
       "type": "object",
       "$schema": "http://json-schema.org/schema#",
-      "additionalProperties": true,
       "properties": {
         "_meta": {
           "type": "object",
+          "description": "Metadata object added by Estuary.",
           "properties": {
             "row_id": {
               "type": "integer"
@@ -154,6 +158,7 @@
           ]
         }
       },
+      "additionalProperties": true,
       "x-infer-schema": true
     },
     "key": [
@@ -169,10 +174,10 @@
     "documentSchema": {
       "type": "object",
       "$schema": "http://json-schema.org/schema#",
-      "additionalProperties": true,
       "properties": {
         "_meta": {
           "type": "object",
+          "description": "Metadata object added by Estuary.",
           "properties": {
             "row_id": {
               "type": "integer"
@@ -183,6 +188,7 @@
           ]
         }
       },
+      "additionalProperties": true,
       "x-infer-schema": true
     },
     "key": [


### PR DESCRIPTION
**Description:**

`source-pendo` uses version 4.4.2 of the AirbyteCDK, and a warning is logged in this version by the [`_filter_schema_invalid_properties` method](https://github.com/airbytehq/airbyte/blob/59d0cb6c5375abd7fd6dc17876764cca5cf199c7/airbyte-cdk/python/airbyte_cdk/sources/streams/core.py#L634-L636) when a property exists on a document that isn't specified in the schema. The `_meta` property we add was causing this warning to be logged, and adding `_meta` to each stream's schema within `manifest.yaml` prevents the warning from being logged.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

Tested on a local stack & confirmed the warning is no longer logged.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1852)
<!-- Reviewable:end -->
