### PR TITLE
source-zendesk-support: clarify functionality of ignore_pagination

### DIFF
--- a/source-zendesk-support/source_zendesk_support/spec.json
+++ b/source-zendesk-support/source_zendesk_support/spec.json
@@ -88,8 +88,7 @@
       "ignore_pagination": {
         "type": "boolean",
         "default": false,
-        "description": "Makes each stream read a single page of data.",
-        "title": "Should the connector read the second and further pages of data."
+        "title": "Read a single page per sweep. Should be left unchecked in most situations."
       }
     }
   },

--- a/source-zendesk-support/tests/snapshots/snapshots__spec__capture.stdout.json
+++ b/source-zendesk-support/tests/snapshots/snapshots__spec__capture.stdout.json
@@ -100,8 +100,7 @@
         "ignore_pagination": {
           "type": "boolean",
           "default": false,
-          "description": "Makes each stream read a single page of data.",
-          "title": "Should the connector read the second and further pages of data."
+          "title": "Read a single page per sweep. Should be left unchecked in most situations."
         }
       }
     },


### PR DESCRIPTION
**Description:**

The description of the `ignore_pagination` checkbox in the UI was confusing at best. It was not clear whether leaving it unchecked or checked causes streams to read a single page on each sweep and be significantly slower.

The description shown on the UI has been updated to more clearly state that checking the box makes the connector read a single page per sweep.

![image](https://github.com/user-attachments/assets/7055cf8c-0955-4de7-b64b-d6edec189f78)


**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1874)
<!-- Reviewable:end -->
