### PR TITLE
source-mixpanel-native: change export stream primary key

### DIFF
--- a/source-mixpanel-native/source_mixpanel_native/schemas/export.json
+++ b/source-mixpanel-native/source_mixpanel_native/schemas/export.json
@@ -10,6 +10,10 @@
       "description": "Timestamp of the event",
       "type": "string",
       "format": "date-time"
-    }
+    },
+    "insert_id": {
+        "description": "Unique insertion identifier",
+        "type": "string"
+      }
   }
 }

--- a/source-mixpanel-native/source_mixpanel_native/streams/export.py
+++ b/source-mixpanel-native/source_mixpanel_native/streams/export.py
@@ -85,7 +85,7 @@ class Export(DateSlicesMixin, IncrementalMixpanelStream):
      3 queries per second and 60 queries per hour.
     """
 
-    primary_key: list[str] = ["distinct_id", "time"]
+    primary_key: str = "insert_id"
     cursor_field: str = "time"
 
     transformer = TypeTransformer(TransformConfig.DefaultSchemaNormalization)

--- a/source-mixpanel-native/tests/snapshots/source_mixpanel_native_tests_test_snapshots__discover__capture.stdout.json
+++ b/source-mixpanel-native/tests/snapshots/source_mixpanel_native_tests_test_snapshots__discover__capture.stdout.json
@@ -211,14 +211,17 @@
           "description": "Timestamp of the event",
           "format": "date-time",
           "type": "string"
+        },
+        "insert_id": {
+            "description": "Unique insertion identifier",
+            "type": "string"
         }
       },
       "type": "object",
       "x-infer-schema": true
     },
     "key": [
-      "/distinct_id",
-      "/time"
+      "/insert_id"
     ],
     "recommendedName": "export",
     "resourceConfig": {


### PR DESCRIPTION
**Description:**

Correcting the primary key for the `export` stream to be `insert_id`.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1877)
<!-- Reviewable:end -->
