### PR TITLE
source-mixpanel-native: Remove state checkpoint property for `export`

### DIFF
--- a/source-mixpanel-native/source_mixpanel_native/streams/base.py
+++ b/source-mixpanel-native/source_mixpanel_native/streams/base.py
@@ -27,13 +27,6 @@ class MixpanelStream(HttpStream, ABC):
     DEFAULT_REQS_PER_HOUR_LIMIT = 60
 
     @property
-    def state_checkpoint_interval(self) -> int:
-        # to meet the requirement of emitting state at least once per 15 minutes,
-        # we assume there's at least 1 record per request returned. Given that each request is followed by a 60 seconds sleep
-        # we'll have to emit state every 15 records
-        return 10000
-
-    @property
     def url_base(self):
         prefix = "eu." if self.region == "EU" else ""
         return f"https://{prefix}mixpanel.com/api/2.0/"


### PR DESCRIPTION
During the connector import, the [`state_checkpoint_interval` property](https://docs.airbyte.com/connector-development/cdk-python/incremental-stream#interval-based-checkpointing) was added to the [`export` stream](https://developer.mixpanel.com/reference/raw-event-export), which checkpoints state after every N documents. This assumes that documents are in ascending order of the cursor field. However, `export` does not return documents in ascending order, so this strategy does not work. I also suspect it interfers with `get_updated_state` - the other older way to checkpoint state. This could explain why the `export` stream for an existing task is missing documents.

Also, sometimes the API returns an `export` document with a `insert_id�` property instead of `insert_id`. Logic to strip off the extra bytes was added.

**Description:**

(Describe the high level scope of new or changed features)

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

Tested locally with a smaller date range (~MAR2020 - AUG2020). A significant number of `insert_id`s (the primary key for `export`) were present in the `export` collection that were not there before.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1887)
<!-- Reviewable:end -->
