### PR TITLE
materialize-databricks: batch merge queries into smaller sections

### DIFF
--- a/materialize-databricks/driver.go
+++ b/materialize-databricks/driver.go
@@ -405,6 +405,7 @@ func (d *transactor) Store(it *m.StoreIterator) (_ m.StartCommitFunc, err error)
 		// not be loaded again
 		// see https://docs.databricks.com/en/sql/language-manual/delta-copy-into.html
 		if b.target.DeltaUpdates || !b.needsMerge {
+			// TODO: switch to slices.Chunk once we switch to go1.23
 			for i := 0; i < len(toCopy); i += queryBatchSize {
 				end := i + queryBatchSize
 				if end > len(toCopy) {

--- a/tests/materialize/materialize-databricks/snapshot.json
+++ b/tests/materialize/materialize-databricks/snapshot.json
@@ -7,49 +7,65 @@
   {
     "updated": {
       "some-schema%2Fdeletions": {
-        "Query": "\n\tCOPY INTO `some-schema`.deletions FROM (\n    SELECT\n\t\tid::LONG, `_meta/op`::STRING, flow_published_at::TIMESTAMP, flow_document::STRING\n  FROM '/Volumes/main/some-schema/flow_staging/flow_temp_tables'\n\t)\n  FILEFORMAT = JSON\n  FILES = ('<uuid>')\n  FORMAT_OPTIONS ( 'mode' = 'FAILFAST', 'ignoreMissingFiles' = 'false' )\n\tCOPY_OPTIONS ( 'mergeSchema' = 'true' )\n  ;\n",
+        "Queries": [
+          "\n\tCOPY INTO `some-schema`.deletions FROM (\n    SELECT\n\t\tid::LONG, `_meta/op`::STRING, flow_published_at::TIMESTAMP, flow_document::STRING\n  FROM '/Volumes/main/some-schema/flow_staging/flow_temp_tables'\n\t)\n  FILEFORMAT = JSON\n  FILES = ('<uuid>')\n  FORMAT_OPTIONS ( 'mode' = 'FAILFAST', 'ignoreMissingFiles' = 'false' )\n\tCOPY_OPTIONS ( 'mergeSchema' = 'true' )\n  ;\n"
+        ],
         "ToDelete": [
           "/Volumes/main/some-schema/flow_staging/flow_temp_tables/<uuid>"
         ]
       },
       "some-schema%2Fduplicate_keys_delta": {
-        "Query": "\n\tCOPY INTO `some-schema`.duplicate_keys_delta FROM (\n    SELECT\n\t\tid::LONG, flow_published_at::TIMESTAMP, int::LONG, str::STRING, flow_document::STRING\n  FROM '/Volumes/main/some-schema/flow_staging/flow_temp_tables'\n\t)\n  FILEFORMAT = JSON\n  FILES = ('<uuid>')\n  FORMAT_OPTIONS ( 'mode' = 'FAILFAST', 'ignoreMissingFiles' = 'false' )\n\tCOPY_OPTIONS ( 'mergeSchema' = 'true' )\n  ;\n",
+        "Queries": [
+          "\n\tCOPY INTO `some-schema`.duplicate_keys_delta FROM (\n    SELECT\n\t\tid::LONG, flow_published_at::TIMESTAMP, int::LONG, str::STRING, flow_document::STRING\n  FROM '/Volumes/main/some-schema/flow_staging/flow_temp_tables'\n\t)\n  FILEFORMAT = JSON\n  FILES = ('<uuid>')\n  FORMAT_OPTIONS ( 'mode' = 'FAILFAST', 'ignoreMissingFiles' = 'false' )\n\tCOPY_OPTIONS ( 'mergeSchema' = 'true' )\n  ;\n"
+        ],
         "ToDelete": [
           "/Volumes/main/some-schema/flow_staging/flow_temp_tables/<uuid>"
         ]
       },
       "some-schema%2Fduplicate_keys_delta_exclude_flow_doc": {
-        "Query": "\n\tCOPY INTO `some-schema`.duplicate_keys_delta_exclude_flow_doc FROM (\n    SELECT\n\t\tid::LONG, flow_published_at::TIMESTAMP, int::LONG, str::STRING\n  FROM '/Volumes/main/some-schema/flow_staging/flow_temp_tables'\n\t)\n  FILEFORMAT = JSON\n  FILES = ('<uuid>')\n  FORMAT_OPTIONS ( 'mode' = 'FAILFAST', 'ignoreMissingFiles' = 'false' )\n\tCOPY_OPTIONS ( 'mergeSchema' = 'true' )\n  ;\n",
+        "Queries": [
+          "\n\tCOPY INTO `some-schema`.duplicate_keys_delta_exclude_flow_doc FROM (\n    SELECT\n\t\tid::LONG, flow_published_at::TIMESTAMP, int::LONG, str::STRING\n  FROM '/Volumes/main/some-schema/flow_staging/flow_temp_tables'\n\t)\n  FILEFORMAT = JSON\n  FILES = ('<uuid>')\n  FORMAT_OPTIONS ( 'mode' = 'FAILFAST', 'ignoreMissingFiles' = 'false' )\n\tCOPY_OPTIONS ( 'mergeSchema' = 'true' )\n  ;\n"
+        ],
         "ToDelete": [
           "/Volumes/main/some-schema/flow_staging/flow_temp_tables/<uuid>"
         ]
       },
       "some-schema%2Fduplicate_keys_standard": {
-        "Query": "\n\tCOPY INTO `some-schema`.duplicate_keys_standard FROM (\n    SELECT\n\t\tid::LONG, flow_published_at::TIMESTAMP, int::LONG, str::STRING, flow_document::STRING\n  FROM '/Volumes/main/some-schema/flow_staging/flow_temp_tables'\n\t)\n  FILEFORMAT = JSON\n  FILES = ('<uuid>')\n  FORMAT_OPTIONS ( 'mode' = 'FAILFAST', 'ignoreMissingFiles' = 'false' )\n\tCOPY_OPTIONS ( 'mergeSchema' = 'true' )\n  ;\n",
+        "Queries": [
+          "\n\tCOPY INTO `some-schema`.duplicate_keys_standard FROM (\n    SELECT\n\t\tid::LONG, flow_published_at::TIMESTAMP, int::LONG, str::STRING, flow_document::STRING\n  FROM '/Volumes/main/some-schema/flow_staging/flow_temp_tables'\n\t)\n  FILEFORMAT = JSON\n  FILES = ('<uuid>')\n  FORMAT_OPTIONS ( 'mode' = 'FAILFAST', 'ignoreMissingFiles' = 'false' )\n\tCOPY_OPTIONS ( 'mergeSchema' = 'true' )\n  ;\n"
+        ],
         "ToDelete": [
           "/Volumes/main/some-schema/flow_staging/flow_temp_tables/<uuid>"
         ]
       },
       "some-schema%2Fformatted_strings": {
-        "Query": "\n\tCOPY INTO `some-schema`.formatted_strings FROM (\n    SELECT\n\t\tid::LONG, date::DATE, datetime::TIMESTAMP, flow_published_at::TIMESTAMP, int_and_str::NUMERIC(38,0), int_str::NUMERIC(38,0), num_and_str::DOUBLE, num_str::DOUBLE, time::STRING, flow_document::STRING\n  FROM '/Volumes/main/some-schema/flow_staging/flow_temp_tables'\n\t)\n  FILEFORMAT = JSON\n  FILES = ('<uuid>')\n  FORMAT_OPTIONS ( 'mode' = 'FAILFAST', 'ignoreMissingFiles' = 'false' )\n\tCOPY_OPTIONS ( 'mergeSchema' = 'true' )\n  ;\n",
+        "Queries": [
+          "\n\tCOPY INTO `some-schema`.formatted_strings FROM (\n    SELECT\n\t\tid::LONG, date::DATE, datetime::TIMESTAMP, flow_published_at::TIMESTAMP, int_and_str::NUMERIC(38,0), int_str::NUMERIC(38,0), num_and_str::DOUBLE, num_str::DOUBLE, time::STRING, flow_document::STRING\n  FROM '/Volumes/main/some-schema/flow_staging/flow_temp_tables'\n\t)\n  FILEFORMAT = JSON\n  FILES = ('<uuid>')\n  FORMAT_OPTIONS ( 'mode' = 'FAILFAST', 'ignoreMissingFiles' = 'false' )\n\tCOPY_OPTIONS ( 'mergeSchema' = 'true' )\n  ;\n"
+        ],
         "ToDelete": [
           "/Volumes/main/some-schema/flow_staging/flow_temp_tables/<uuid>"
         ]
       },
       "some-schema%2Fmultiple_types": {
-        "Query": "\n\tCOPY INTO `some-schema`.multiple_types FROM (\n    SELECT\n\t\tid::LONG, array_int::STRING, unbase64(binary_field)::BINARY as binary_field, bool_field::BOOLEAN, float_field::DOUBLE, flow_published_at::TIMESTAMP, multiple::STRING, nested::STRING, nullable_int::LONG, str_field::STRING, flow_document::STRING\n  FROM '/Volumes/main/some-schema/flow_staging/flow_temp_tables'\n\t)\n  FILEFORMAT = JSON\n  FILES = ('<uuid>')\n  FORMAT_OPTIONS ( 'mode' = 'FAILFAST', 'ignoreMissingFiles' = 'false' )\n\tCOPY_OPTIONS ( 'mergeSchema' = 'true' )\n  ;\n",
+        "Queries": [
+          "\n\tCOPY INTO `some-schema`.multiple_types FROM (\n    SELECT\n\t\tid::LONG, array_int::STRING, unbase64(binary_field)::BINARY as binary_field, bool_field::BOOLEAN, float_field::DOUBLE, flow_published_at::TIMESTAMP, multiple::STRING, nested::STRING, nullable_int::LONG, str_field::STRING, flow_document::STRING\n  FROM '/Volumes/main/some-schema/flow_staging/flow_temp_tables'\n\t)\n  FILEFORMAT = JSON\n  FILES = ('<uuid>')\n  FORMAT_OPTIONS ( 'mode' = 'FAILFAST', 'ignoreMissingFiles' = 'false' )\n\tCOPY_OPTIONS ( 'mergeSchema' = 'true' )\n  ;\n"
+        ],
         "ToDelete": [
           "/Volumes/main/some-schema/flow_staging/flow_temp_tables/<uuid>"
         ]
       },
       "some-schema%2Fsimple": {
-        "Query": "\n\tCOPY INTO `some-schema`.simple FROM (\n    SELECT\n\t\tid::LONG, canary::STRING, flow_published_at::TIMESTAMP, flow_document::STRING\n  FROM '/Volumes/main/some-schema/flow_staging/flow_temp_tables'\n\t)\n  FILEFORMAT = JSON\n  FILES = ('<uuid>')\n  FORMAT_OPTIONS ( 'mode' = 'FAILFAST', 'ignoreMissingFiles' = 'false' )\n\tCOPY_OPTIONS ( 'mergeSchema' = 'true' )\n  ;\n",
+        "Queries": [
+          "\n\tCOPY INTO `some-schema`.simple FROM (\n    SELECT\n\t\tid::LONG, canary::STRING, flow_published_at::TIMESTAMP, flow_document::STRING\n  FROM '/Volumes/main/some-schema/flow_staging/flow_temp_tables'\n\t)\n  FILEFORMAT = JSON\n  FILES = ('<uuid>')\n  FORMAT_OPTIONS ( 'mode' = 'FAILFAST', 'ignoreMissingFiles' = 'false' )\n\tCOPY_OPTIONS ( 'mergeSchema' = 'true' )\n  ;\n"
+        ],
         "ToDelete": [
           "/Volumes/main/some-schema/flow_staging/flow_temp_tables/<uuid>"
         ]
       },
       "some-schema%2Funsigned_bigint": {
-        "Query": "\n\tCOPY INTO `some-schema`.unsigned_bigint FROM (\n    SELECT\n\t\tid::LONG, flow_published_at::TIMESTAMP, unsigned_bigint::NUMERIC(38,0), flow_document::STRING\n  FROM '/Volumes/main/some-schema/flow_staging/flow_temp_tables'\n\t)\n  FILEFORMAT = JSON\n  FILES = ('<uuid>')\n  FORMAT_OPTIONS ( 'mode' = 'FAILFAST', 'ignoreMissingFiles' = 'false' )\n\tCOPY_OPTIONS ( 'mergeSchema' = 'true' )\n  ;\n",
+        "Queries": [
+          "\n\tCOPY INTO `some-schema`.unsigned_bigint FROM (\n    SELECT\n\t\tid::LONG, flow_published_at::TIMESTAMP, unsigned_bigint::NUMERIC(38,0), flow_document::STRING\n  FROM '/Volumes/main/some-schema/flow_staging/flow_temp_tables'\n\t)\n  FILEFORMAT = JSON\n  FILES = ('<uuid>')\n  FORMAT_OPTIONS ( 'mode' = 'FAILFAST', 'ignoreMissingFiles' = 'false' )\n\tCOPY_OPTIONS ( 'mergeSchema' = 'true' )\n  ;\n"
+        ],
         "ToDelete": [
           "/Volumes/main/some-schema/flow_staging/flow_temp_tables/<uuid>"
         ]
@@ -62,43 +78,57 @@
   {
     "updated": {
       "some-schema%2Fdeletions": {
-        "Query": "\n\tMERGE INTO `some-schema`.deletions AS l\n\tUSING (\n\t\t(\n\t\t\tSELECT\n\t\t\tid::LONG, `_meta/op`::STRING, flow_published_at::TIMESTAMP, flow_document::STRING\n\t\t\tFROM json.`/Volumes/main/some-schema/flow_staging/flow_temp_tables/<uuid>`\n\t\t)\n\t) AS r\n\tON l.id = r.id\n\tWHEN MATCHED AND r.flow_document='\"delete\"' THEN\n\t\tDELETE\n\tWHEN MATCHED THEN\n\t\tUPDATE SET l.`_meta/op` = r.`_meta/op`, l.flow_published_at = r.flow_published_at, l.flow_document = r.flow_document\n\tWHEN NOT MATCHED THEN\n\t\tINSERT (id, `_meta/op`, flow_published_at, flow_document)\n\t\tVALUES (r.id, r.`_meta/op`, r.flow_published_at, r.flow_document);\n",
+        "Queries": [
+          "\n\tMERGE INTO `some-schema`.deletions AS l\n\tUSING (\n\t\t(\n\t\t\tSELECT\n\t\t\tid::LONG, `_meta/op`::STRING, flow_published_at::TIMESTAMP, flow_document::STRING\n\t\t\tFROM json.`/Volumes/main/some-schema/flow_staging/flow_temp_tables/<uuid>`\n\t\t)\n\t) AS r\n\tON l.id = r.id\n\tWHEN MATCHED AND r.flow_document='\"delete\"' THEN\n\t\tDELETE\n\tWHEN MATCHED THEN\n\t\tUPDATE SET l.`_meta/op` = r.`_meta/op`, l.flow_published_at = r.flow_published_at, l.flow_document = r.flow_document\n\tWHEN NOT MATCHED THEN\n\t\tINSERT (id, `_meta/op`, flow_published_at, flow_document)\n\t\tVALUES (r.id, r.`_meta/op`, r.flow_published_at, r.flow_document);\n"
+        ],
         "ToDelete": [
           "/Volumes/main/some-schema/flow_staging/flow_temp_tables/<uuid>"
         ]
       },
       "some-schema%2Fduplicate_keys_delta": {
-        "Query": "\n\tCOPY INTO `some-schema`.duplicate_keys_delta FROM (\n    SELECT\n\t\tid::LONG, flow_published_at::TIMESTAMP, int::LONG, str::STRING, flow_document::STRING\n  FROM '/Volumes/main/some-schema/flow_staging/flow_temp_tables'\n\t)\n  FILEFORMAT = JSON\n  FILES = ('<uuid>')\n  FORMAT_OPTIONS ( 'mode' = 'FAILFAST', 'ignoreMissingFiles' = 'false' )\n\tCOPY_OPTIONS ( 'mergeSchema' = 'true' )\n  ;\n",
+        "Queries": [
+          "\n\tCOPY INTO `some-schema`.duplicate_keys_delta FROM (\n    SELECT\n\t\tid::LONG, flow_published_at::TIMESTAMP, int::LONG, str::STRING, flow_document::STRING\n  FROM '/Volumes/main/some-schema/flow_staging/flow_temp_tables'\n\t)\n  FILEFORMAT = JSON\n  FILES = ('<uuid>')\n  FORMAT_OPTIONS ( 'mode' = 'FAILFAST', 'ignoreMissingFiles' = 'false' )\n\tCOPY_OPTIONS ( 'mergeSchema' = 'true' )\n  ;\n"
+        ],
         "ToDelete": [
           "/Volumes/main/some-schema/flow_staging/flow_temp_tables/<uuid>"
         ]
       },
       "some-schema%2Fduplicate_keys_delta_exclude_flow_doc": {
-        "Query": "\n\tCOPY INTO `some-schema`.duplicate_keys_delta_exclude_flow_doc FROM (\n    SELECT\n\t\tid::LONG, flow_published_at::TIMESTAMP, int::LONG, str::STRING\n  FROM '/Volumes/main/some-schema/flow_staging/flow_temp_tables'\n\t)\n  FILEFORMAT = JSON\n  FILES = ('<uuid>')\n  FORMAT_OPTIONS ( 'mode' = 'FAILFAST', 'ignoreMissingFiles' = 'false' )\n\tCOPY_OPTIONS ( 'mergeSchema' = 'true' )\n  ;\n",
+        "Queries": [
+          "\n\tCOPY INTO `some-schema`.duplicate_keys_delta_exclude_flow_doc FROM (\n    SELECT\n\t\tid::LONG, flow_published_at::TIMESTAMP, int::LONG, str::STRING\n  FROM '/Volumes/main/some-schema/flow_staging/flow_temp_tables'\n\t)\n  FILEFORMAT = JSON\n  FILES = ('<uuid>')\n  FORMAT_OPTIONS ( 'mode' = 'FAILFAST', 'ignoreMissingFiles' = 'false' )\n\tCOPY_OPTIONS ( 'mergeSchema' = 'true' )\n  ;\n"
+        ],
         "ToDelete": [
           "/Volumes/main/some-schema/flow_staging/flow_temp_tables/<uuid>"
         ]
       },
       "some-schema%2Fduplicate_keys_standard": {
-        "Query": "\n\tMERGE INTO `some-schema`.duplicate_keys_standard AS l\n\tUSING (\n\t\t(\n\t\t\tSELECT\n\t\t\tid::LONG, flow_published_at::TIMESTAMP, int::LONG, str::STRING, flow_document::STRING\n\t\t\tFROM json.`/Volumes/main/some-schema/flow_staging/flow_temp_tables/<uuid>`\n\t\t)\n\t) AS r\n\tON l.id = r.id\n\tWHEN MATCHED AND r.flow_document='\"delete\"' THEN\n\t\tDELETE\n\tWHEN MATCHED THEN\n\t\tUPDATE SET l.flow_published_at = r.flow_published_at, l.int = r.int, l.str = r.str, l.flow_document = r.flow_document\n\tWHEN NOT MATCHED THEN\n\t\tINSERT (id, flow_published_at, int, str, flow_document)\n\t\tVALUES (r.id, r.flow_published_at, r.int, r.str, r.flow_document);\n",
+        "Queries": [
+          "\n\tMERGE INTO `some-schema`.duplicate_keys_standard AS l\n\tUSING (\n\t\t(\n\t\t\tSELECT\n\t\t\tid::LONG, flow_published_at::TIMESTAMP, int::LONG, str::STRING, flow_document::STRING\n\t\t\tFROM json.`/Volumes/main/some-schema/flow_staging/flow_temp_tables/<uuid>`\n\t\t)\n\t) AS r\n\tON l.id = r.id\n\tWHEN MATCHED AND r.flow_document='\"delete\"' THEN\n\t\tDELETE\n\tWHEN MATCHED THEN\n\t\tUPDATE SET l.flow_published_at = r.flow_published_at, l.int = r.int, l.str = r.str, l.flow_document = r.flow_document\n\tWHEN NOT MATCHED THEN\n\t\tINSERT (id, flow_published_at, int, str, flow_document)\n\t\tVALUES (r.id, r.flow_published_at, r.int, r.str, r.flow_document);\n"
+        ],
         "ToDelete": [
           "/Volumes/main/some-schema/flow_staging/flow_temp_tables/<uuid>"
         ]
       },
       "some-schema%2Fformatted_strings": {
-        "Query": "\n\tCOPY INTO `some-schema`.formatted_strings FROM (\n    SELECT\n\t\tid::LONG, date::DATE, datetime::TIMESTAMP, flow_published_at::TIMESTAMP, int_and_str::NUMERIC(38,0), int_str::NUMERIC(38,0), num_and_str::DOUBLE, num_str::DOUBLE, time::STRING, flow_document::STRING\n  FROM '/Volumes/main/some-schema/flow_staging/flow_temp_tables'\n\t)\n  FILEFORMAT = JSON\n  FILES = ('<uuid>')\n  FORMAT_OPTIONS ( 'mode' = 'FAILFAST', 'ignoreMissingFiles' = 'false' )\n\tCOPY_OPTIONS ( 'mergeSchema' = 'true' )\n  ;\n",
+        "Queries": [
+          "\n\tCOPY INTO `some-schema`.formatted_strings FROM (\n    SELECT\n\t\tid::LONG, date::DATE, datetime::TIMESTAMP, flow_published_at::TIMESTAMP, int_and_str::NUMERIC(38,0), int_str::NUMERIC(38,0), num_and_str::DOUBLE, num_str::DOUBLE, time::STRING, flow_document::STRING\n  FROM '/Volumes/main/some-schema/flow_staging/flow_temp_tables'\n\t)\n  FILEFORMAT = JSON\n  FILES = ('<uuid>')\n  FORMAT_OPTIONS ( 'mode' = 'FAILFAST', 'ignoreMissingFiles' = 'false' )\n\tCOPY_OPTIONS ( 'mergeSchema' = 'true' )\n  ;\n"
+        ],
         "ToDelete": [
           "/Volumes/main/some-schema/flow_staging/flow_temp_tables/<uuid>"
         ]
       },
       "some-schema%2Fmultiple_types": {
-        "Query": "\n\tMERGE INTO `some-schema`.multiple_types AS l\n\tUSING (\n\t\t(\n\t\t\tSELECT\n\t\t\tid::LONG, array_int::STRING, unbase64(binary_field)::BINARY as binary_field, bool_field::BOOLEAN, float_field::DOUBLE, flow_published_at::TIMESTAMP, multiple::STRING, nested::STRING, nullable_int::LONG, str_field::STRING, flow_document::STRING\n\t\t\tFROM json.`/Volumes/main/some-schema/flow_staging/flow_temp_tables/<uuid>`\n\t\t)\n\t) AS r\n\tON l.id = r.id\n\tWHEN MATCHED AND r.flow_document='\"delete\"' THEN\n\t\tDELETE\n\tWHEN MATCHED THEN\n\t\tUPDATE SET l.array_int = r.array_int, l.binary_field = r.binary_field, l.bool_field = r.bool_field, l.float_field = r.float_field, l.flow_published_at = r.flow_published_at, l.multiple = r.multiple, l.nested = r.nested, l.nullable_int = r.nullable_int, l.str_field = r.str_field, l.flow_document = r.flow_document\n\tWHEN NOT MATCHED THEN\n\t\tINSERT (id, array_int, binary_field, bool_field, float_field, flow_published_at, multiple, nested, nullable_int, str_field, flow_document)\n\t\tVALUES (r.id, r.array_int, r.binary_field, r.bool_field, r.float_field, r.flow_published_at, r.multiple, r.nested, r.nullable_int, r.str_field, r.flow_document);\n",
+        "Queries": [
+          "\n\tMERGE INTO `some-schema`.multiple_types AS l\n\tUSING (\n\t\t(\n\t\t\tSELECT\n\t\t\tid::LONG, array_int::STRING, unbase64(binary_field)::BINARY as binary_field, bool_field::BOOLEAN, float_field::DOUBLE, flow_published_at::TIMESTAMP, multiple::STRING, nested::STRING, nullable_int::LONG, str_field::STRING, flow_document::STRING\n\t\t\tFROM json.`/Volumes/main/some-schema/flow_staging/flow_temp_tables/<uuid>`\n\t\t)\n\t) AS r\n\tON l.id = r.id\n\tWHEN MATCHED AND r.flow_document='\"delete\"' THEN\n\t\tDELETE\n\tWHEN MATCHED THEN\n\t\tUPDATE SET l.array_int = r.array_int, l.binary_field = r.binary_field, l.bool_field = r.bool_field, l.float_field = r.float_field, l.flow_published_at = r.flow_published_at, l.multiple = r.multiple, l.nested = r.nested, l.nullable_int = r.nullable_int, l.str_field = r.str_field, l.flow_document = r.flow_document\n\tWHEN NOT MATCHED THEN\n\t\tINSERT (id, array_int, binary_field, bool_field, float_field, flow_published_at, multiple, nested, nullable_int, str_field, flow_document)\n\t\tVALUES (r.id, r.array_int, r.binary_field, r.bool_field, r.float_field, r.flow_published_at, r.multiple, r.nested, r.nullable_int, r.str_field, r.flow_document);\n"
+        ],
         "ToDelete": [
           "/Volumes/main/some-schema/flow_staging/flow_temp_tables/<uuid>"
         ]
       },
       "some-schema%2Fsimple": {
-        "Query": "\n\tCOPY INTO `some-schema`.simple FROM (\n    SELECT\n\t\tid::LONG, canary::STRING, flow_published_at::TIMESTAMP, flow_document::STRING\n  FROM '/Volumes/main/some-schema/flow_staging/flow_temp_tables'\n\t)\n  FILEFORMAT = JSON\n  FILES = ('<uuid>')\n  FORMAT_OPTIONS ( 'mode' = 'FAILFAST', 'ignoreMissingFiles' = 'false' )\n\tCOPY_OPTIONS ( 'mergeSchema' = 'true' )\n  ;\n",
+        "Queries": [
+          "\n\tCOPY INTO `some-schema`.simple FROM (\n    SELECT\n\t\tid::LONG, canary::STRING, flow_published_at::TIMESTAMP, flow_document::STRING\n  FROM '/Volumes/main/some-schema/flow_staging/flow_temp_tables'\n\t)\n  FILEFORMAT = JSON\n  FILES = ('<uuid>')\n  FORMAT_OPTIONS ( 'mode' = 'FAILFAST', 'ignoreMissingFiles' = 'false' )\n\tCOPY_OPTIONS ( 'mergeSchema' = 'true' )\n  ;\n"
+        ],
         "ToDelete": [
           "/Volumes/main/some-schema/flow_staging/flow_temp_tables/<uuid>"
         ]
@@ -111,43 +141,57 @@
   {
     "updated": {
       "some-schema%2Fdeletions": {
-        "Query": "\n\tMERGE INTO `some-schema`.deletions AS l\n\tUSING (\n\t\t(\n\t\t\tSELECT\n\t\t\tid::LONG, `_meta/op`::STRING, flow_published_at::TIMESTAMP, flow_document::STRING\n\t\t\tFROM json.`/Volumes/main/some-schema/flow_staging/flow_temp_tables/<uuid>`\n\t\t)\n\t) AS r\n\tON l.id = r.id\n\tWHEN MATCHED AND r.flow_document='\"delete\"' THEN\n\t\tDELETE\n\tWHEN MATCHED THEN\n\t\tUPDATE SET l.`_meta/op` = r.`_meta/op`, l.flow_published_at = r.flow_published_at, l.flow_document = r.flow_document\n\tWHEN NOT MATCHED THEN\n\t\tINSERT (id, `_meta/op`, flow_published_at, flow_document)\n\t\tVALUES (r.id, r.`_meta/op`, r.flow_published_at, r.flow_document);\n",
+        "Queries": [
+          "\n\tMERGE INTO `some-schema`.deletions AS l\n\tUSING (\n\t\t(\n\t\t\tSELECT\n\t\t\tid::LONG, `_meta/op`::STRING, flow_published_at::TIMESTAMP, flow_document::STRING\n\t\t\tFROM json.`/Volumes/main/some-schema/flow_staging/flow_temp_tables/<uuid>`\n\t\t)\n\t) AS r\n\tON l.id = r.id\n\tWHEN MATCHED AND r.flow_document='\"delete\"' THEN\n\t\tDELETE\n\tWHEN MATCHED THEN\n\t\tUPDATE SET l.`_meta/op` = r.`_meta/op`, l.flow_published_at = r.flow_published_at, l.flow_document = r.flow_document\n\tWHEN NOT MATCHED THEN\n\t\tINSERT (id, `_meta/op`, flow_published_at, flow_document)\n\t\tVALUES (r.id, r.`_meta/op`, r.flow_published_at, r.flow_document);\n"
+        ],
         "ToDelete": [
           "/Volumes/main/some-schema/flow_staging/flow_temp_tables/<uuid>"
         ]
       },
       "some-schema%2Fduplicate_keys_delta": {
-        "Query": "\n\tCOPY INTO `some-schema`.duplicate_keys_delta FROM (\n    SELECT\n\t\tid::LONG, flow_published_at::TIMESTAMP, int::LONG, str::STRING, flow_document::STRING\n  FROM '/Volumes/main/some-schema/flow_staging/flow_temp_tables'\n\t)\n  FILEFORMAT = JSON\n  FILES = ('<uuid>')\n  FORMAT_OPTIONS ( 'mode' = 'FAILFAST', 'ignoreMissingFiles' = 'false' )\n\tCOPY_OPTIONS ( 'mergeSchema' = 'true' )\n  ;\n",
+        "Queries": [
+          "\n\tCOPY INTO `some-schema`.duplicate_keys_delta FROM (\n    SELECT\n\t\tid::LONG, flow_published_at::TIMESTAMP, int::LONG, str::STRING, flow_document::STRING\n  FROM '/Volumes/main/some-schema/flow_staging/flow_temp_tables'\n\t)\n  FILEFORMAT = JSON\n  FILES = ('<uuid>')\n  FORMAT_OPTIONS ( 'mode' = 'FAILFAST', 'ignoreMissingFiles' = 'false' )\n\tCOPY_OPTIONS ( 'mergeSchema' = 'true' )\n  ;\n"
+        ],
         "ToDelete": [
           "/Volumes/main/some-schema/flow_staging/flow_temp_tables/<uuid>"
         ]
       },
       "some-schema%2Fduplicate_keys_delta_exclude_flow_doc": {
-        "Query": "\n\tCOPY INTO `some-schema`.duplicate_keys_delta_exclude_flow_doc FROM (\n    SELECT\n\t\tid::LONG, flow_published_at::TIMESTAMP, int::LONG, str::STRING\n  FROM '/Volumes/main/some-schema/flow_staging/flow_temp_tables'\n\t)\n  FILEFORMAT = JSON\n  FILES = ('<uuid>')\n  FORMAT_OPTIONS ( 'mode' = 'FAILFAST', 'ignoreMissingFiles' = 'false' )\n\tCOPY_OPTIONS ( 'mergeSchema' = 'true' )\n  ;\n",
+        "Queries": [
+          "\n\tCOPY INTO `some-schema`.duplicate_keys_delta_exclude_flow_doc FROM (\n    SELECT\n\t\tid::LONG, flow_published_at::TIMESTAMP, int::LONG, str::STRING\n  FROM '/Volumes/main/some-schema/flow_staging/flow_temp_tables'\n\t)\n  FILEFORMAT = JSON\n  FILES = ('<uuid>')\n  FORMAT_OPTIONS ( 'mode' = 'FAILFAST', 'ignoreMissingFiles' = 'false' )\n\tCOPY_OPTIONS ( 'mergeSchema' = 'true' )\n  ;\n"
+        ],
         "ToDelete": [
           "/Volumes/main/some-schema/flow_staging/flow_temp_tables/<uuid>"
         ]
       },
       "some-schema%2Fduplicate_keys_standard": {
-        "Query": "\n\tMERGE INTO `some-schema`.duplicate_keys_standard AS l\n\tUSING (\n\t\t(\n\t\t\tSELECT\n\t\t\tid::LONG, flow_published_at::TIMESTAMP, int::LONG, str::STRING, flow_document::STRING\n\t\t\tFROM json.`/Volumes/main/some-schema/flow_staging/flow_temp_tables/<uuid>`\n\t\t)\n\t) AS r\n\tON l.id = r.id\n\tWHEN MATCHED AND r.flow_document='\"delete\"' THEN\n\t\tDELETE\n\tWHEN MATCHED THEN\n\t\tUPDATE SET l.flow_published_at = r.flow_published_at, l.int = r.int, l.str = r.str, l.flow_document = r.flow_document\n\tWHEN NOT MATCHED THEN\n\t\tINSERT (id, flow_published_at, int, str, flow_document)\n\t\tVALUES (r.id, r.flow_published_at, r.int, r.str, r.flow_document);\n",
+        "Queries": [
+          "\n\tMERGE INTO `some-schema`.duplicate_keys_standard AS l\n\tUSING (\n\t\t(\n\t\t\tSELECT\n\t\t\tid::LONG, flow_published_at::TIMESTAMP, int::LONG, str::STRING, flow_document::STRING\n\t\t\tFROM json.`/Volumes/main/some-schema/flow_staging/flow_temp_tables/<uuid>`\n\t\t)\n\t) AS r\n\tON l.id = r.id\n\tWHEN MATCHED AND r.flow_document='\"delete\"' THEN\n\t\tDELETE\n\tWHEN MATCHED THEN\n\t\tUPDATE SET l.flow_published_at = r.flow_published_at, l.int = r.int, l.str = r.str, l.flow_document = r.flow_document\n\tWHEN NOT MATCHED THEN\n\t\tINSERT (id, flow_published_at, int, str, flow_document)\n\t\tVALUES (r.id, r.flow_published_at, r.int, r.str, r.flow_document);\n"
+        ],
         "ToDelete": [
           "/Volumes/main/some-schema/flow_staging/flow_temp_tables/<uuid>"
         ]
       },
       "some-schema%2Fformatted_strings": {
-        "Query": "\n\tCOPY INTO `some-schema`.formatted_strings FROM (\n    SELECT\n\t\tid::LONG, date::DATE, datetime::TIMESTAMP, flow_published_at::TIMESTAMP, int_and_str::NUMERIC(38,0), int_str::NUMERIC(38,0), num_and_str::DOUBLE, num_str::DOUBLE, time::STRING, flow_document::STRING\n  FROM '/Volumes/main/some-schema/flow_staging/flow_temp_tables'\n\t)\n  FILEFORMAT = JSON\n  FILES = ('<uuid>')\n  FORMAT_OPTIONS ( 'mode' = 'FAILFAST', 'ignoreMissingFiles' = 'false' )\n\tCOPY_OPTIONS ( 'mergeSchema' = 'true' )\n  ;\n",
+        "Queries": [
+          "\n\tCOPY INTO `some-schema`.formatted_strings FROM (\n    SELECT\n\t\tid::LONG, date::DATE, datetime::TIMESTAMP, flow_published_at::TIMESTAMP, int_and_str::NUMERIC(38,0), int_str::NUMERIC(38,0), num_and_str::DOUBLE, num_str::DOUBLE, time::STRING, flow_document::STRING\n  FROM '/Volumes/main/some-schema/flow_staging/flow_temp_tables'\n\t)\n  FILEFORMAT = JSON\n  FILES = ('<uuid>')\n  FORMAT_OPTIONS ( 'mode' = 'FAILFAST', 'ignoreMissingFiles' = 'false' )\n\tCOPY_OPTIONS ( 'mergeSchema' = 'true' )\n  ;\n"
+        ],
         "ToDelete": [
           "/Volumes/main/some-schema/flow_staging/flow_temp_tables/<uuid>"
         ]
       },
       "some-schema%2Fmultiple_types": {
-        "Query": "\n\tMERGE INTO `some-schema`.multiple_types AS l\n\tUSING (\n\t\t(\n\t\t\tSELECT\n\t\t\tid::LONG, array_int::STRING, unbase64(binary_field)::BINARY as binary_field, bool_field::BOOLEAN, float_field::DOUBLE, flow_published_at::TIMESTAMP, multiple::STRING, nested::STRING, nullable_int::LONG, str_field::STRING, flow_document::STRING\n\t\t\tFROM json.`/Volumes/main/some-schema/flow_staging/flow_temp_tables/<uuid>`\n\t\t)\n\t) AS r\n\tON l.id = r.id\n\tWHEN MATCHED AND r.flow_document='\"delete\"' THEN\n\t\tDELETE\n\tWHEN MATCHED THEN\n\t\tUPDATE SET l.array_int = r.array_int, l.binary_field = r.binary_field, l.bool_field = r.bool_field, l.float_field = r.float_field, l.flow_published_at = r.flow_published_at, l.multiple = r.multiple, l.nested = r.nested, l.nullable_int = r.nullable_int, l.str_field = r.str_field, l.flow_document = r.flow_document\n\tWHEN NOT MATCHED THEN\n\t\tINSERT (id, array_int, binary_field, bool_field, float_field, flow_published_at, multiple, nested, nullable_int, str_field, flow_document)\n\t\tVALUES (r.id, r.array_int, r.binary_field, r.bool_field, r.float_field, r.flow_published_at, r.multiple, r.nested, r.nullable_int, r.str_field, r.flow_document);\n",
+        "Queries": [
+          "\n\tMERGE INTO `some-schema`.multiple_types AS l\n\tUSING (\n\t\t(\n\t\t\tSELECT\n\t\t\tid::LONG, array_int::STRING, unbase64(binary_field)::BINARY as binary_field, bool_field::BOOLEAN, float_field::DOUBLE, flow_published_at::TIMESTAMP, multiple::STRING, nested::STRING, nullable_int::LONG, str_field::STRING, flow_document::STRING\n\t\t\tFROM json.`/Volumes/main/some-schema/flow_staging/flow_temp_tables/<uuid>`\n\t\t)\n\t) AS r\n\tON l.id = r.id\n\tWHEN MATCHED AND r.flow_document='\"delete\"' THEN\n\t\tDELETE\n\tWHEN MATCHED THEN\n\t\tUPDATE SET l.array_int = r.array_int, l.binary_field = r.binary_field, l.bool_field = r.bool_field, l.float_field = r.float_field, l.flow_published_at = r.flow_published_at, l.multiple = r.multiple, l.nested = r.nested, l.nullable_int = r.nullable_int, l.str_field = r.str_field, l.flow_document = r.flow_document\n\tWHEN NOT MATCHED THEN\n\t\tINSERT (id, array_int, binary_field, bool_field, float_field, flow_published_at, multiple, nested, nullable_int, str_field, flow_document)\n\t\tVALUES (r.id, r.array_int, r.binary_field, r.bool_field, r.float_field, r.flow_published_at, r.multiple, r.nested, r.nullable_int, r.str_field, r.flow_document);\n"
+        ],
         "ToDelete": [
           "/Volumes/main/some-schema/flow_staging/flow_temp_tables/<uuid>"
         ]
       },
       "some-schema%2Fsimple": {
-        "Query": "\n\tCOPY INTO `some-schema`.simple FROM (\n    SELECT\n\t\tid::LONG, canary::STRING, flow_published_at::TIMESTAMP, flow_document::STRING\n  FROM '/Volumes/main/some-schema/flow_staging/flow_temp_tables'\n\t)\n  FILEFORMAT = JSON\n  FILES = ('<uuid>')\n  FORMAT_OPTIONS ( 'mode' = 'FAILFAST', 'ignoreMissingFiles' = 'false' )\n\tCOPY_OPTIONS ( 'mergeSchema' = 'true' )\n  ;\n",
+        "Queries": [
+          "\n\tCOPY INTO `some-schema`.simple FROM (\n    SELECT\n\t\tid::LONG, canary::STRING, flow_published_at::TIMESTAMP, flow_document::STRING\n  FROM '/Volumes/main/some-schema/flow_staging/flow_temp_tables'\n\t)\n  FILEFORMAT = JSON\n  FILES = ('<uuid>')\n  FORMAT_OPTIONS ( 'mode' = 'FAILFAST', 'ignoreMissingFiles' = 'false' )\n\tCOPY_OPTIONS ( 'mergeSchema' = 'true' )\n  ;\n"
+        ],
         "ToDelete": [
           "/Volumes/main/some-schema/flow_staging/flow_temp_tables/<uuid>"
         ]


### PR DESCRIPTION
**Description:**

- Tested by running integration tests, and by reducing the staged file size threshold and running a task with that configuration. With 128 files per merge query, the length of the query string itself is small enough to fit databricks limits, but it means we may process up to ~16GB of data in a single query, which I also think should be okay.
- I didn't apply the same batching on load queries, since for load queries, if we consider each ID to be 36 bytes (that's a uuid, I think this is one of the larger common key types, whereas most keys will be ~8 bytes as int64 or similar), we  can fit ~3M ids in a single staged file for load phase, and before we hit 128 files to batch up the query, we will have ~477M ids in those 128 files.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1891)
<!-- Reviewable:end -->
