### PR TITLE
source-zendesk-support: fix `ticket_metrics` and `ticket_metric_events`

### DIFF
--- a/source-zendesk-support/test.flow.yaml
+++ b/source-zendesk-support/test.flow.yaml
@@ -102,7 +102,7 @@ captures:
           stream: ticket_metrics
           syncMode: incremental
           cursorField:
-            - updated_at
+            - after_cursor
         target: acmeCo/ticket_metrics
       - resource:
           stream: ticket_metric_events
@@ -120,13 +120,13 @@ captures:
           stream: tickets
           syncMode: incremental
           cursorField:
-            - updated_at
+            - after_cursor
         target: acmeCo/tickets
       - resource:
           stream: users
           syncMode: incremental
           cursorField:
-            - updated_at
+            - after_cursor
         target: acmeCo/users
       - resource:
           stream: brands

--- a/source-zendesk-support/tests/snapshots/snapshots__discover__capture.stdout.json
+++ b/source-zendesk-support/tests/snapshots/snapshots__discover__capture.stdout.json
@@ -2886,7 +2886,7 @@
       "stream": "ticket_metrics",
       "syncMode": "incremental",
       "cursorField": [
-        "updated_at"
+        "after_cursor"
       ]
     },
     "documentSchema": {


### PR DESCRIPTION
**Description:**

Tasks have had issues with `ticket_metrics` and `ticket_metric_events` taking a very long time to backfill. Fixes are detailed below.


## `ticket_metrics`
The endpoint we were using before wasn't appropriate for capturing changes to ticket metrics; it was returning metrics in descending order of when the associated ticket was created, _not_ when the ticket was updated. 

To fix this, the stream was changed to use the same incremental logic & endpoint as the `tickets` stream, and sideload in the metrics for each ticket. This gives us all the benefits of the recent `tickets` improvements (emitting state every 1k documents, good cursor-based incremental sync).

## `ticket_metric_events`
This stream functions correctly & behaves incrementally, but it's extremely dense and takes a long time to complete the initial backfill. 

The number of documents per page was increased from 100 to 1,000, so that should help speed up backfills some. Logging was also added after each successfully parsed response to show how far along the stream has caught up.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

Zendesk Support docs need updated to reflect the new cursor field for `ticket_metrics`.

**Notes for reviewers:**

Tested on a local stack with a number of Zendesk accounts. Confirmed streams completed & were incremental after the initial backfill.

Existing tasks `ticket_metrics` binding will need backfilled very soon after the PR is merged due to the `ticket_metrics` cursor field change.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1895)
<!-- Reviewable:end -->
