### PR TITLE
tests: use flowctl raw discover instead of flowctl-go in capture tests

### DIFF
--- a/tests/run.sh
+++ b/tests/run.sh
@@ -77,19 +77,6 @@ DATA_PLANE_PID=$!
 # Arrange to stop the data plane on exit.
 trap "kill -s SIGTERM ${DATA_PLANE_PID} && wait ${DATA_PLANE_PID}" EXIT
 
-# Get the spec from the connector and ensure it's valid json.
-cat >"$TESTDIR/spec.yaml" <<EOF
-captures:
-  tests/${CONNECTOR}/from-source:
-    endpoint:
-      connector:
-        image: "${CONNECTOR_IMAGE}"
-        config: {}
-    bindings: []
-EOF
-
-flowctl raw spec --source "$TESTDIR/spec.yaml" | jq -cM || bail "failed to validate spec"
-
 # Execute test-specific setup steps.
 echo -e "\nexecuting setup"
 source "tests/${CONNECTOR}/setup.sh" || bail "${CONNECTOR}/setup.sh failed"
@@ -100,6 +87,20 @@ fi
 if [[ -z "$CONNECTOR_CONFIG" ]]; then
   bail "setup did not set CONNECTOR_CONFIG"
 fi
+
+# Get the spec from the connector and ensure it's valid json.
+cat >"$TESTDIR/spec.yaml" <<EOF
+captures:
+  tests/${CONNECTOR}/from-source:
+    endpoint:
+      connector:
+        image: "${CONNECTOR_IMAGE}"
+        config: ${CONNECTOR_CONFIG}
+    bindings: []
+EOF
+
+flowctl raw spec --source "$TESTDIR/spec.yaml" | jq -cM || bail "failed to validate spec"
+
 TEST_STATUS="Test Failed"
 function test_shutdown() {
   kill -s SIGTERM ${DATA_PLANE_PID} && wait ${DATA_PLANE_PID} && ./tests/${CONNECTOR}/cleanup.sh
@@ -114,8 +115,8 @@ trap "test_shutdown" EXIT
 export ID_TYPE="${ID_TYPE:-integer}"
 
 # Verify discover works
-flowctl-go api discover --image="${CONNECTOR_IMAGE}" --network "flow-test" --log.level=debug --config=<(echo ${CONNECTOR_CONFIG}) >${TESTDIR}/discover_output.json || bail "Discover failed."
-cat ${TESTDIR}/discover_output.json | jq ".bindings[] | select(.recommendedName == \"${TEST_STREAM}\") | .documentSchema" >${TESTDIR}/bindings.json
+flowctl raw discover --network flow-test --source $TESTDIR/spec.yaml -o json --emit-raw >${TESTDIR}/discover_output.json || bail "Discover failed."
+cat ${TESTDIR}/discover_output.json | jq "select(.recommendedName == \"${TEST_STREAM}\") | .documentSchema" >${TESTDIR}/bindings.json
 
 if [[ -f "tests/${CONNECTOR}/bindings.json" ]]; then
   cat ${TESTDIR}/bindings.json


### PR DESCRIPTION
**Description:**

~~Most captures already test discovery as part of their unit testing, and
`flowctl-go` doesn't work for this anymore. `flowctl raw discover` doesn't work
quite the same way and I couldn't come up with a very satisfying way to replace
it with that.~~

~~Eventually we should rework these tests to use `flowctl preview` along with
`flowctl raw discover`. I've made a couple of attempts at that and have found it
to be more of an effort that I want to take on right now, so this does the
simple thing and just disables the non-working `flowctl-go api discover`.~~

Edit: Actually ended up getting this working with `flowctl raw discover`; see updated commit description.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1896)
<!-- Reviewable:end -->
