### PR TITLE
source-postgres: Suport MAC addresses as primary keys

### DIFF
--- a/source-postgres/.snapshots/TestScanKeyTypes-MAC6
+++ b/source-postgres/.snapshots/TestScanKeyTypes-MAC6
@@ -1,0 +1,62 @@
+####################################
+### Capture from Start
+####################################
+# ================================
+# Collection "acmeCo/test/test_scankeytypes_mac6_28040015": 1 Documents
+# ================================
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"scankeytypes_mac6_28040015","loc":[11111111,11111111,11111111]}},"data":"Data 0","key":"47:7a:51:62:c3:aa"}
+# ================================
+# Final State Checkpoint
+# ================================
+{"bindingStateV1":{"test%2Fscankeytypes_mac6_28040015":{"backfilled":1,"key_columns":["key"],"mode":"Backfill","scanned":"AjQ3OjdhOjUxOjYyOmMzOmFhAA=="}},"cursor":"0/1111111"}
+
+
+####################################
+### Capture from Key "AjQ3OjdhOjUxOjYyOmMzOmFhAA=="
+####################################
+# ================================
+# Collection "acmeCo/test/test_scankeytypes_mac6_28040015": 1 Documents
+# ================================
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"scankeytypes_mac6_28040015","loc":[11111111,11111111,11111111]}},"data":"Data 2","key":"65:d0:73:5a:5a:c9"}
+# ================================
+# Final State Checkpoint
+# ================================
+{"bindingStateV1":{"test%2Fscankeytypes_mac6_28040015":{"backfilled":2,"key_columns":["key"],"mode":"Backfill","scanned":"AjY1OmQwOjczOjVhOjVhOmM5AA=="}},"cursor":"0/1111111"}
+
+
+####################################
+### Capture from Key "AjY1OmQwOjczOjVhOjVhOmM5AA=="
+####################################
+# ================================
+# Collection "acmeCo/test/test_scankeytypes_mac6_28040015": 1 Documents
+# ================================
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"scankeytypes_mac6_28040015","loc":[11111111,11111111,11111111]}},"data":"Data 1","key":"6f:cf:f3:49:e0:b1"}
+# ================================
+# Final State Checkpoint
+# ================================
+{"bindingStateV1":{"test%2Fscankeytypes_mac6_28040015":{"backfilled":3,"key_columns":["key"],"mode":"Backfill","scanned":"AjZmOmNmOmYzOjQ5OmUwOmIxAA=="}},"cursor":"0/1111111"}
+
+
+####################################
+### Capture from Key "AjZmOmNmOmYzOjQ5OmUwOmIxAA=="
+####################################
+# ================================
+# Collection "acmeCo/test/test_scankeytypes_mac6_28040015": 1 Documents
+# ================================
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"scankeytypes_mac6_28040015","loc":[11111111,11111111,11111111]}},"data":"Data 3","key":"88:61:08:5b:ae:54"}
+# ================================
+# Final State Checkpoint
+# ================================
+{"bindingStateV1":{"test%2Fscankeytypes_mac6_28040015":{"backfilled":4,"key_columns":["key"],"mode":"Backfill","scanned":"Ajg4OjYxOjA4OjViOmFlOjU0AA=="}},"cursor":"0/1111111"}
+
+
+####################################
+### Capture from Key "Ajg4OjYxOjA4OjViOmFlOjU0AA=="
+####################################
+# ================================
+# Final State Checkpoint
+# ================================
+{"bindingStateV1":{"test%2Fscankeytypes_mac6_28040015":{"backfilled":4,"key_columns":["key"],"mode":"Active"}},"cursor":"0/1111111"}
+
+
+

--- a/source-postgres/.snapshots/TestScanKeyTypes-MAC8
+++ b/source-postgres/.snapshots/TestScanKeyTypes-MAC8
@@ -1,0 +1,62 @@
+####################################
+### Capture from Start
+####################################
+# ================================
+# Collection "acmeCo/test/test_scankeytypes_mac8_28040016": 1 Documents
+# ================================
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"scankeytypes_mac8_28040016","loc":[11111111,11111111,11111111]}},"data":"Data 0","key":"5f:99:67:ac:0d:df:88:3a"}
+# ================================
+# Final State Checkpoint
+# ================================
+{"bindingStateV1":{"test%2Fscankeytypes_mac8_28040016":{"backfilled":1,"key_columns":["key"],"mode":"Backfill","scanned":"AjVmOjk5OjY3OmFjOjBkOmRmOjg4OjNhAA=="}},"cursor":"0/1111111"}
+
+
+####################################
+### Capture from Key "AjVmOjk5OjY3OmFjOjBkOmRmOjg4OjNhAA=="
+####################################
+# ================================
+# Collection "acmeCo/test/test_scankeytypes_mac8_28040016": 1 Documents
+# ================================
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"scankeytypes_mac8_28040016","loc":[11111111,11111111,11111111]}},"data":"Data 1","key":"70:26:74:4c:ac:2c:38:59"}
+# ================================
+# Final State Checkpoint
+# ================================
+{"bindingStateV1":{"test%2Fscankeytypes_mac8_28040016":{"backfilled":2,"key_columns":["key"],"mode":"Backfill","scanned":"AjcwOjI2Ojc0OjRjOmFjOjJjOjM4OjU5AA=="}},"cursor":"0/1111111"}
+
+
+####################################
+### Capture from Key "AjcwOjI2Ojc0OjRjOmFjOjJjOjM4OjU5AA=="
+####################################
+# ================================
+# Collection "acmeCo/test/test_scankeytypes_mac8_28040016": 1 Documents
+# ================================
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"scankeytypes_mac8_28040016","loc":[11111111,11111111,11111111]}},"data":"Data 3","key":"a5:35:55:da:06:38:39:43"}
+# ================================
+# Final State Checkpoint
+# ================================
+{"bindingStateV1":{"test%2Fscankeytypes_mac8_28040016":{"backfilled":3,"key_columns":["key"],"mode":"Backfill","scanned":"AmE1OjM1OjU1OmRhOjA2OjM4OjM5OjQzAA=="}},"cursor":"0/1111111"}
+
+
+####################################
+### Capture from Key "AmE1OjM1OjU1OmRhOjA2OjM4OjM5OjQzAA=="
+####################################
+# ================================
+# Collection "acmeCo/test/test_scankeytypes_mac8_28040016": 1 Documents
+# ================================
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"scankeytypes_mac8_28040016","loc":[11111111,11111111,11111111]}},"data":"Data 2","key":"e3:70:99:89:b9:d8:e8:21"}
+# ================================
+# Final State Checkpoint
+# ================================
+{"bindingStateV1":{"test%2Fscankeytypes_mac8_28040016":{"backfilled":4,"key_columns":["key"],"mode":"Backfill","scanned":"AmUzOjcwOjk5Ojg5OmI5OmQ4OmU4OjIxAA=="}},"cursor":"0/1111111"}
+
+
+####################################
+### Capture from Key "AmUzOjcwOjk5Ojg5OmI5OmQ4OmU4OjIxAA=="
+####################################
+# ================================
+# Final State Checkpoint
+# ================================
+{"bindingStateV1":{"test%2Fscankeytypes_mac8_28040016":{"backfilled":4,"key_columns":["key"],"mode":"Active"}},"cursor":"0/1111111"}
+
+
+

--- a/source-postgres/datatype_test.go
+++ b/source-postgres/datatype_test.go
@@ -177,21 +177,23 @@ func TestScanKeyTypes(t *testing.T) {
 		ColumnType string
 		Values     []interface{}
 	}{
-		{"Bool", "BOOLEAN", []interface{}{"true", "false"}},
-		{"Integer", "INTEGER", []interface{}{0, -3, 2, 1723}},
-		{"SmallInt", "SMALLINT", []interface{}{0, -3, 2, 1723}},
-		{"BigInt", "BIGINT", []interface{}{0, -3, 2, 1723}},
-		{"Serial", "SERIAL", []interface{}{0, -3, 2, 1723}},
-		{"SmallSerial", "SMALLSERIAL", []interface{}{0, -3, 2, 1723}},
-		{"BigSerial", "BIGSERIAL", []interface{}{0, -3, 2, 1723}},
-		{"Real", "REAL", []interface{}{-0.9, -1.0, -1.1, 0.0, 0.9, 1.0, 1.111, 1.222, 1.333, 1.444, 1.555, 1.666, 1.777, 1.888, 1.999, 2.000}},
-		{"Double", "DOUBLE PRECISION", []interface{}{-0.9, -1.0, -1.1, 0.0, 0.9, 1.0, 1.111, 1.222, 1.333, 1.444, 1.555, 1.666, 1.777, 1.888, 1.999, 2.000}},
-		{"Decimal", "DECIMAL", []interface{}{-0.9, -1.0, -1.1, 0.0, 0.9, 1.0, 1.111, 1.222, 1.333, 1.444, 1.555, 1.666, 1.777, 1.888, 1.999, 2.000}},
-		{"Numeric", "NUMERIC(4,3)", []interface{}{-0.9, -1.0, -1.1, 0.0, 0.9, 1.0, 1.111, 1.222, 1.333, 1.444, 1.555, 1.666, 1.777, 1.888, 1.999, 2.000}},
-		{"VarChar", "VARCHAR(10)", []interface{}{"", "   ", "a", "b", "c", "A", "B", "C", "_a", "_b", "_c"}},
-		{"Char", "CHAR(3)", []interface{}{"   ", "a", "b", "c", "A", "B", "C", "_a", "_b", "_c"}},
-		{"Text", "TEXT", []interface{}{"", "   ", "a", "b", "c", "A", "B", "C", "_a", "_b", "_c"}},
-		{"UUID", "UUID", []interface{}{"66b968a7-aeca-4401-8239-5d57958d1572", "4ab4044a-9aab-415c-96c6-17fa338060fa", "c32fb585-fc7f-4347-8fe2-97448f4e93cd"}},
+		{"Bool", "BOOLEAN", []any{"true", "false"}},
+		{"Integer", "INTEGER", []any{0, -3, 2, 1723}},
+		{"SmallInt", "SMALLINT", []any{0, -3, 2, 1723}},
+		{"BigInt", "BIGINT", []any{0, -3, 2, 1723}},
+		{"Serial", "SERIAL", []any{0, -3, 2, 1723}},
+		{"SmallSerial", "SMALLSERIAL", []any{0, -3, 2, 1723}},
+		{"BigSerial", "BIGSERIAL", []any{0, -3, 2, 1723}},
+		{"Real", "REAL", []any{-0.9, -1.0, -1.1, 0.0, 0.9, 1.0, 1.111, 1.222, 1.333, 1.444, 1.555, 1.666, 1.777, 1.888, 1.999, 2.000}},
+		{"Double", "DOUBLE PRECISION", []any{-0.9, -1.0, -1.1, 0.0, 0.9, 1.0, 1.111, 1.222, 1.333, 1.444, 1.555, 1.666, 1.777, 1.888, 1.999, 2.000}},
+		{"Decimal", "DECIMAL", []any{-0.9, -1.0, -1.1, 0.0, 0.9, 1.0, 1.111, 1.222, 1.333, 1.444, 1.555, 1.666, 1.777, 1.888, 1.999, 2.000}},
+		{"Numeric", "NUMERIC(4,3)", []any{-0.9, -1.0, -1.1, 0.0, 0.9, 1.0, 1.111, 1.222, 1.333, 1.444, 1.555, 1.666, 1.777, 1.888, 1.999, 2.000}},
+		{"VarChar", "VARCHAR(10)", []any{"", "   ", "a", "b", "c", "A", "B", "C", "_a", "_b", "_c"}},
+		{"Char", "CHAR(3)", []any{"   ", "a", "b", "c", "A", "B", "C", "_a", "_b", "_c"}},
+		{"Text", "TEXT", []any{"", "   ", "a", "b", "c", "A", "B", "C", "_a", "_b", "_c"}},
+		{"UUID", "UUID", []any{"66b968a7-aeca-4401-8239-5d57958d1572", "4ab4044a-9aab-415c-96c6-17fa338060fa", "c32fb585-fc7f-4347-8fe2-97448f4e93cd"}},
+		{"MAC6", "macaddr", []any{"47:7a:51:62:c3:aa", "6f:cf:f3:49:e0:b1", "65:d0:73:5a:5a:c9", "88:61:08:5b:ae:54"}},
+		{"MAC8", "macaddr8", []any{"5f:99:67:ac:0d:df:88:3a ", "70:26:74:4c:ac:2c:38:59", "e3:70:99:89:b9:d8:e8:21 ", "a5:35:55:da:06:38:39:43"}},
 	} {
 		t.Run(tc.Name, func(t *testing.T) {
 			var uniqueID = fmt.Sprintf("2804%04d", idx)

--- a/source-postgres/datatypes.go
+++ b/source-postgres/datatypes.go
@@ -378,6 +378,8 @@ func encodeKeyFDB(key, ktype interface{}) (tuple.TupleElement, error) {
 			return nil, fmt.Errorf("error parsing uuid: %w", err)
 		}
 		return id.String(), nil
+	case net.HardwareAddr: // column types 'macaddr' and 'macaddr8'
+		return key.String(), nil
 	case time.Time:
 		return key.Format(sortableRFC3339Nano), nil
 	case pgtype.Numeric:


### PR DESCRIPTION
**Description:**

Previously MAC addresses as primary keys didn't work. Or possibly this was broken as part of the PGX v5 upgrade and we didn't notice because we didn't have a test case for MAC address PKs.

Either way, this PR adds a couple of test cases and the necessary FDB key serialization special case to make them work.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1899)
<!-- Reviewable:end -->
