### PR TITLE
source-mysql: No flushing TableMapEvents

### DIFF
--- a/source-mysql/replication.go
+++ b/source-mysql/replication.go
@@ -402,7 +402,6 @@ func (rs *mysqlReplicationStream) run(ctx context.Context, startCursor mysql.Pos
 			rs.uncommittedChanges = 0      // Reset count of all uncommitted changes
 			rs.nonTransactionalChanges = 0 // Reset count of uncommitted non-transactional changes
 		case *replication.TableMapEvent:
-			implicitFlush = true // Implicit FlushEvent conversion permitted
 			logrus.WithField("data", data).Trace("Table Map Event")
 		case *replication.GTIDEvent:
 			implicitFlush = true // Implicit FlushEvent conversion permitted


### PR DESCRIPTION
**Description:**

These events are paired with one or more immediately-following row changes. Checkpointing after the TableMapEvent means that a capture could potentially restart in between those events and be unable to decode the row changes due to missing context.

This may have happened in production, but I haven't proven this was the issue -- it's just definitely wrong regardless.