### PR TITLE
sqlcapture: Remove cursor replacements

### DIFF
--- a/sqlcapture/main.go
+++ b/sqlcapture/main.go
@@ -273,8 +273,6 @@ func (d *Driver) Pull(open *pc.Request_Open, stream *boilerplate.PullOutput) err
 	// scoped.
 	var hackyCursorReplacements = map[string]map[string]string{
 		"TASKHASH415b69936fe1324600d67943e50235fc57fb7e0196b8f5f0TASKHASH": {"binlog.000123:456789": "binlog.000123:456789"}, // Example
-		"2697514fcbeb6fd162d4ae80d01325caf4f46f3ee1ed48f724a6897f09422634": {"mysql_grpads-bin.001693:768074601": "mysql_grpads-bin.001693:4"},
-		"4f70f302602149564d19a9858834299c5bf42a4fb5d8926e93997fb6bbdf25a7": {"mariadb-bin.013693:91254673": "mariadb-bin.013693:4"},
 	}
 	var hasher = sha256.New()
 	hasher.Write([]byte(open.Capture.Name))


### PR DESCRIPTION
**Description:**

Added in https://github.com/estuary/connectors/pull/1904, these have had their intended effect in production and it's good practice to clean them up immediately now that they're no longer needed.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1905)
<!-- Reviewable:end -->
