### PR TITLE
source-mysql: Send a 'Keepalive Event' for inactive table changes

### DIFF
--- a/sqlcapture/capture.go
+++ b/sqlcapture/capture.go
@@ -480,6 +480,11 @@ func (c *Capture) streamToFence(ctx context.Context, replStream ReplicationStrea
 	return replStream.StreamToFence(ctx, fenceAfter, func(event DatabaseEvent) error {
 		eventCount++
 
+		// Keepalive events do nothing other than increment the event count.
+		if _, ok := event.(*KeepaliveEvent); ok {
+			return nil
+		}
+
 		// Flush events update the checkpoint LSN and may trigger a state update.
 		if event, ok := event.(*FlushEvent); ok {
 			c.State.Cursor = event.Cursor

--- a/sqlcapture/interface.go
+++ b/sqlcapture/interface.go
@@ -88,19 +88,25 @@ type MetadataEvent struct {
 	Metadata json.RawMessage
 }
 
-// A DatabaseEvent can be a ChangeEvent, FlushEvent, or MetadataEvent.
+// KeepaliveEvent informs the generic sqlcapture logic that the replication stream
+// is still active and processing WAL entries which don't require other events.
+type KeepaliveEvent struct{}
+
+// A DatabaseEvent can be a ChangeEvent, FlushEvent, MetadataEvent, or KeepaliveEvent.
 type DatabaseEvent interface {
 	isDatabaseEvent()
 	String() string
 }
 
-func (*ChangeEvent) isDatabaseEvent()   {}
-func (*FlushEvent) isDatabaseEvent()    {}
-func (*MetadataEvent) isDatabaseEvent() {}
+func (*ChangeEvent) isDatabaseEvent()    {}
+func (*FlushEvent) isDatabaseEvent()     {}
+func (*MetadataEvent) isDatabaseEvent()  {}
+func (*KeepaliveEvent) isDatabaseEvent() {}
 
 func (*ChangeEvent) String() string    { return "ChangeEvent" }
 func (evt *FlushEvent) String() string { return "FlushEvent" }
 func (*MetadataEvent) String() string  { return "MetadataEvent" }
+func (*KeepaliveEvent) String() string { return "KeepaliveEvent" }
 
 // KeyFields returns suitable fields for extracting the event primary key.
 func (e *ChangeEvent) KeyFields() map[string]interface{} {


### PR DESCRIPTION
**Description:**

This introduces a new replication event type `KeepaliveEvent` which is effectively a no-op which non-change non-commit WAL events can be translated to, and modifies the MySQL replication logic to use that when filtering out changes from non-captured tables.

In theory I could have kept this entirely within the MySQL code, but I've elected to make it part of the generic machinery since we'll need something very similar if/when we implement read-only replica support for Postgres or SQL Server, and also because in connectors which send a `KeepaliveEvent` this finally resolves the annoying thing where the `processed replication events` logging only counted changes from active bindings.

This is likely to fix https://github.com/estuary/connectors/issues/1909 (if my theory about massive transactions on non-captured tables is correct). Even if it doesn't fix that issue this is definitely still the fix for that theoretical edge case.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1910)
<!-- Reviewable:end -->
