### PR TITLE
source-zendesk-support: update ticket_metrics schema

### DIFF
--- a/source-zendesk-support/source_zendesk_support/schemas/ticket_metrics.json
+++ b/source-zendesk-support/source_zendesk_support/schemas/ticket_metrics.json
@@ -104,6 +104,14 @@
         }
       }
     },
+    "reply_time_in_seconds": {
+        "type": ["null", "object"],
+        "properties": {
+          "calendar": {
+            "type": ["null", "integer"]
+          }
+        }
+    },
     "requester_updated_at": {
       "type": ["null", "string"],
       "format": "date-time"

--- a/source-zendesk-support/tests/snapshots/snapshots__discover__capture.stdout.json
+++ b/source-zendesk-support/tests/snapshots/snapshots__discover__capture.stdout.json
@@ -3082,6 +3082,20 @@
             }
           }
         },
+        "reply_time_in_seconds": {
+          "type": [
+            "null",
+            "object"
+          ],
+          "properties": {
+            "calendar": {
+              "type": [
+                "null",
+                "integer"
+              ]
+            }
+          }
+        },
         "requester_updated_at": {
           "type": [
             "null",


### PR DESCRIPTION
**Description:**

The `reply_time_in_seconds` field was not listed in the `ticket_metrics` schema, so materializations were not able to recognize that the field existed. Adding `reply_time_in_seconds` to the schema should allow the field to be materialized.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1917)
<!-- Reviewable:end -->
