### PR TITLE
materialize-s3-iceberg: use table paths of loaded tables

### DIFF
--- a/materialize-s3-iceberg/catalog.go
+++ b/materialize-s3-iceberg/catalog.go
@@ -73,6 +73,15 @@ func (c *catalog) infoSchema() (*boilerplate.InfoSchema, error) {
 	return is, nil
 }
 
+func (c *catalog) tablePath(resourcePath []string) (string, error) {
+	b, err := runIcebergctl(c.cfg, "table-path", pathToFQN(resourcePath))
+	if err != nil {
+		return "", err
+	}
+
+	return string(b), nil
+}
+
 func (c *catalog) listNamespaces() ([]string, error) {
 	var got []string
 

--- a/materialize-s3-iceberg/iceberg-ctl/iceberg_ctl/__main__.py
+++ b/materialize-s3-iceberg/iceberg-ctl/iceberg_ctl/__main__.py
@@ -171,6 +171,19 @@ def info_schema(
 
 @run.command()
 @click.pass_context
+@click.argument("table", type=str)
+def table_path(
+    ctx: Context,
+    table: str,
+):
+    catalog = ctx.obj["catalog"]
+    assert isinstance(catalog, Catalog)
+
+    print(catalog.load_table(table).location())
+
+
+@run.command()
+@click.pass_context
 def list_namespaces(ctx: Context):
     catalog = ctx.obj["catalog"]
     assert isinstance(catalog, Catalog)

--- a/materialize-s3-iceberg/icebergctl.go
+++ b/materialize-s3-iceberg/icebergctl.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -63,5 +64,5 @@ func runIcebergctl(cfg *config, args ...string) ([]byte, error) {
 		return nil, err
 	}
 
-	return out, nil
+	return bytes.TrimSuffix(out, []byte("\n")), nil
 }


### PR DESCRIPTION
**Description:**

Some catalogs disregard the configured table path when a table is created, and just do their own thing. To make sure data files get put into the right place, we need to retrieve the actual path of created tables.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1921)
<!-- Reviewable:end -->
