### PR TITLE
source-mysql-batch: Improve connection error reporting

### DIFF
--- a/source-mysql-batch/main.go
+++ b/source-mysql-batch/main.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/tls"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -13,7 +14,6 @@ import (
 	boilerplate "github.com/estuary/connectors/source-boilerplate"
 	"github.com/go-mysql-org/go-mysql/client"
 	"github.com/go-mysql-org/go-mysql/mysql"
-	perrors "github.com/pingcap/errors"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -80,19 +80,23 @@ func connectMySQL(ctx context.Context, cfg *Config) (*client.Conn, error) {
 	}).Info("connecting to database")
 
 	var conn *client.Conn
-	var err error
 	var withTLS = func(c *client.Conn) error {
 		c.SetTLSConfig(&tls.Config{InsecureSkipVerify: true})
 		return nil
 	}
-	if conn, err = client.Connect(cfg.Address, cfg.User, cfg.Password, cfg.Advanced.DBName, withTLS); err == nil {
-		log.WithField("addr", cfg.Address).Debug("connected with TLS")
-	} else if conn, err = client.Connect(cfg.Address, cfg.User, cfg.Password, cfg.Advanced.DBName); err == nil {
-		log.WithField("addr", cfg.Address).Warn("connected without TLS")
-	} else if mysqlErr, ok := perrors.Cause(err).(*mysql.MyError); ok && mysqlErr.Code == mysql.ER_ACCESS_DENIED_ERROR {
-		return nil, cerrors.NewUserError(mysqlErr, "incorrect username or password")
+	if connWithTLS, errWithTLS := client.Connect(cfg.Address, cfg.User, cfg.Password, cfg.Advanced.DBName, withTLS); errWithTLS == nil {
+		log.WithField("addr", cfg.Address).Info("connected with TLS")
+		conn = connWithTLS
+	} else if connWithoutTLS, errWithoutTLS := client.Connect(cfg.Address, cfg.User, cfg.Password, cfg.Advanced.DBName); errWithoutTLS == nil {
+		log.WithField("addr", cfg.Address).Info("connected without TLS")
+		conn = connWithoutTLS
 	} else {
-		return nil, fmt.Errorf("unable to connect to database: %w", err)
+		var mysqlErr *mysql.MyError
+		if errors.As(errWithTLS, &mysqlErr) && mysqlErr.Code == mysql.ER_ACCESS_DENIED_ERROR {
+			return nil, cerrors.NewUserError(mysqlErr, "incorrect username or password")
+		} else {
+			return nil, fmt.Errorf("unable to connect to database: %w", errWithTLS)
+		}
 	}
 
 	if _, err := conn.Execute("SELECT true;"); err != nil {

--- a/source-mysql-batch/main.go
+++ b/source-mysql-batch/main.go
@@ -89,8 +89,8 @@ func connectMySQL(ctx context.Context, cfg *Config) (*client.Conn, error) {
 		log.WithField("addr", cfg.Address).Debug("connected with TLS")
 	} else if conn, err = client.Connect(cfg.Address, cfg.User, cfg.Password, cfg.Advanced.DBName); err == nil {
 		log.WithField("addr", cfg.Address).Warn("connected without TLS")
-	} else if err, ok := perrors.Cause(err).(*mysql.MyError); ok && err.Code == mysql.ER_ACCESS_DENIED_ERROR {
-		return nil, cerrors.NewUserError(err, "incorrect username or password")
+	} else if mysqlErr, ok := perrors.Cause(err).(*mysql.MyError); ok && mysqlErr.Code == mysql.ER_ACCESS_DENIED_ERROR {
+		return nil, cerrors.NewUserError(mysqlErr, "incorrect username or password")
 	} else {
 		return nil, fmt.Errorf("unable to connect to database: %w", err)
 	}


### PR DESCRIPTION
**Description:**

Restructures some of the error reporting around MySQL database connection attempts. Previously there were two issues:

- Error messages sometimes got swallowed and reported as `unable to connect to database: <nil>` because of incorrect variable shadowing.
- We try to connect with both TLS and not-TLS, but in some cases the server will require TLS and the non-TLS connection attempt will fail for that reason, but we didn't report the reason the with-TLS connection attempt failed. Now we report the TLS failure reason when both fail.

Also this commit fixes the "incorrect username/password" special case since that got broken in the upgrade to v1.8.1 of the MySQL client library.

This fixes https://github.com/estuary/connectors/issues/1923

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1924)
<!-- Reviewable:end -->
