### PR TITLE
source-postgres: Register domain type OIDs as aliases

### DIFF
--- a/source-postgres/.snapshots/TestCaptureDomainJSONB-capture1
+++ b/source-postgres/.snapshots/TestCaptureDomainJSONB-capture1
@@ -1,0 +1,10 @@
+# ================================
+# Collection "acmeCo/test/test_capturedomainjsonb_40925847": 2 Documents
+# ================================
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"capturedomainjsonb_40925847","loc":[11111111,11111111,11111111]}},"data":{"foo":"bar"},"id":1}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"capturedomainjsonb_40925847","loc":[11111111,11111111,11111111]}},"data":{},"id":0}
+# ================================
+# Final State Checkpoint
+# ================================
+{"bindingStateV1":{"test%2Fcapturedomainjsonb_40925847":{"backfilled":2,"key_columns":["id"],"mode":"Active"}},"cursor":"0/1111111"}
+

--- a/source-postgres/.snapshots/TestCaptureDomainJSONB-capture2
+++ b/source-postgres/.snapshots/TestCaptureDomainJSONB-capture2
@@ -1,0 +1,10 @@
+# ================================
+# Collection "acmeCo/test/test_capturedomainjsonb_40925847": 2 Documents
+# ================================
+{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"capturedomainjsonb_40925847","loc":[11111111,11111111,11111111],"txid":111111}},"data":{"asdf":{"a":1,"b":2}},"id":3}
+{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"capturedomainjsonb_40925847","loc":[11111111,11111111,11111111],"txid":111111}},"data":{"baz":[1,2,3]},"id":2}
+# ================================
+# Final State Checkpoint
+# ================================
+{"bindingStateV1":{"test%2Fcapturedomainjsonb_40925847":{"backfilled":2,"key_columns":["id"],"mode":"Active"}},"cursor":"0/1111111"}
+


### PR DESCRIPTION
**Description:**

As explained in the added code, a user-defined domain type (which can be created via `CREATE DOMAIN name AS base_type` and which is basically just a type alias with optional constraints) ought to be decoded the same as a value of the base type.

We accomplish this by processing the `TypeMessage` event and when the namespace is omitted (which implicitly means "pg_catalog", if the Postgres docs can be trusted here) we look up the type name in the type map and register the user type OID as having the name and codec of the base type (if found).

Also adds a test case which exercises this behavior. If not for the fix in this commit, snapshot `TestCaptureDomainJSONB-capture2` would have its JSONB values emitted as strings rather than as raw JSON.

This fixes https://github.com/estuary/connectors/issues/1912

**Notes for reviewers:**

I considered making the fix a bit more narrowly-targeted to just `json` and `jsonb` aliases, but I believe that the logic as written does the right thing for domain types which alias any builtin Postgres data type, and there are plenty of other cases where we haven't registered our own custom decode function but we'd still like to use the same decode logic for these aliases as the PGX client library would use for the base type.

Since the "register as an alias" logic only kicks in when the named type is in `pg_catalog` (which, per the docs, is what an empty schema means for this message) and it does nothing other than emitting a warning if the type name isn't found when we look it up, I believe it's safe to just do this generically for all `TypeMessage` events with an empty schema.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1926)
<!-- Reviewable:end -->
