### PR TITLE
source-sqlserver: Omit null text/image/ntext values on deletes

### DIFF
--- a/source-sqlserver/.snapshots/TestDeletedTextColumn-init
+++ b/source-sqlserver/.snapshots/TestDeletedTextColumn-init
@@ -1,0 +1,10 @@
+# ================================
+# Collection "acmeCo/test/test_deletedtextcolumn_41823101": 2 Documents
+# ================================
+{"_meta":{"op":"c","source":{"schema":"dbo","snapshot":true,"table":"test_DeletedTextColumn_41823101","lsn":"","seqval":"AAAAAAAAAAAAAA=="}},"id":0,"v_int":100,"v_text":"zero","v_varchar":"zero"}
+{"_meta":{"op":"c","source":{"schema":"dbo","snapshot":true,"table":"test_DeletedTextColumn_41823101","lsn":"","seqval":"AAAAAAAAAAAAAA=="}},"id":1,"v_int":101,"v_text":"one","v_varchar":"one"}
+# ================================
+# Final State Checkpoint
+# ================================
+{"bindingStateV1":{"dbo%2Ftest_DeletedTextColumn_41823101":{"backfilled":2,"key_columns":["id"],"mode":"Active"}},"cursor":"AAAAAAAAAAAAAA=="}
+

--- a/source-sqlserver/.snapshots/TestDeletedTextColumn-main
+++ b/source-sqlserver/.snapshots/TestDeletedTextColumn-main
@@ -1,0 +1,12 @@
+# ================================
+# Collection "acmeCo/test/test_deletedtextcolumn_41823101": 4 Documents
+# ================================
+{"_meta":{"op":"c","source":{"schema":"dbo","table":"test_DeletedTextColumn_41823101","lsn":"AAAAAAAAAAAAAA==","seqval":"AAAAAAAAAAAAAA==","updateMask":"Dw=="}},"id":2,"v_int":102,"v_text":"two","v_varchar":"two"}
+{"_meta":{"op":"c","source":{"schema":"dbo","table":"test_DeletedTextColumn_41823101","lsn":"AAAAAAAAAAAAAA==","seqval":"AAAAAAAAAAAAAA==","updateMask":"Dw=="}},"id":3,"v_int":103,"v_text":"three","v_varchar":"three"}
+{"_meta":{"op":"d","source":{"schema":"dbo","table":"test_DeletedTextColumn_41823101","lsn":"AAAAAAAAAAAAAA==","seqval":"AAAAAAAAAAAAAA==","updateMask":"Dw=="}},"id":1,"v_int":101,"v_text":null,"v_varchar":"one"}
+{"_meta":{"op":"d","source":{"schema":"dbo","table":"test_DeletedTextColumn_41823101","lsn":"AAAAAAAAAAAAAA==","seqval":"AAAAAAAAAAAAAA==","updateMask":"Dw=="}},"id":2,"v_int":102,"v_text":null,"v_varchar":"two"}
+# ================================
+# Final State Checkpoint
+# ================================
+{"bindingStateV1":{"dbo%2Ftest_DeletedTextColumn_41823101":{"backfilled":2,"key_columns":["id"],"mode":"Active"}},"cursor":"AAAAAAAAAAAAAA=="}
+

--- a/source-sqlserver/.snapshots/TestDeletedTextColumn-main
+++ b/source-sqlserver/.snapshots/TestDeletedTextColumn-main
@@ -3,8 +3,8 @@
 # ================================
 {"_meta":{"op":"c","source":{"schema":"dbo","table":"test_DeletedTextColumn_41823101","lsn":"AAAAAAAAAAAAAA==","seqval":"AAAAAAAAAAAAAA==","updateMask":"Dw=="}},"id":2,"v_int":102,"v_text":"two","v_varchar":"two"}
 {"_meta":{"op":"c","source":{"schema":"dbo","table":"test_DeletedTextColumn_41823101","lsn":"AAAAAAAAAAAAAA==","seqval":"AAAAAAAAAAAAAA==","updateMask":"Dw=="}},"id":3,"v_int":103,"v_text":"three","v_varchar":"three"}
-{"_meta":{"op":"d","source":{"schema":"dbo","table":"test_DeletedTextColumn_41823101","lsn":"AAAAAAAAAAAAAA==","seqval":"AAAAAAAAAAAAAA==","updateMask":"Dw=="}},"id":1,"v_int":101,"v_text":null,"v_varchar":"one"}
-{"_meta":{"op":"d","source":{"schema":"dbo","table":"test_DeletedTextColumn_41823101","lsn":"AAAAAAAAAAAAAA==","seqval":"AAAAAAAAAAAAAA==","updateMask":"Dw=="}},"id":2,"v_int":102,"v_text":null,"v_varchar":"two"}
+{"_meta":{"op":"d","source":{"schema":"dbo","table":"test_DeletedTextColumn_41823101","lsn":"AAAAAAAAAAAAAA==","seqval":"AAAAAAAAAAAAAA==","updateMask":"Dw=="}},"id":1,"v_int":101,"v_varchar":"one"}
+{"_meta":{"op":"d","source":{"schema":"dbo","table":"test_DeletedTextColumn_41823101","lsn":"AAAAAAAAAAAAAA==","seqval":"AAAAAAAAAAAAAA==","updateMask":"Dw=="}},"id":2,"v_int":102,"v_varchar":"two"}
 # ================================
 # Final State Checkpoint
 # ================================

--- a/source-sqlserver/main_test.go
+++ b/source-sqlserver/main_test.go
@@ -458,3 +458,18 @@ func TestAlterationAddColumn(t *testing.T) {
 		})
 	}
 }
+
+func TestDeletedTextColumn(t *testing.T) {
+	var tb, ctx = sqlserverTestBackend(t), context.Background()
+	var uniqueID = "41823101"
+	var tableName = tb.CreateTable(ctx, t, uniqueID, "(id INTEGER PRIMARY KEY, v_text TEXT NOT NULL, v_varchar VARCHAR(32), v_int INTEGER)")
+	var cs = tb.CaptureSpec(ctx, t, regexp.MustCompile(uniqueID))
+	cs.Validator = &st.OrderedCaptureValidator{}
+
+	tb.Insert(ctx, t, tableName, [][]any{{0, "zero", "zero", 100}, {1, "one", "one", 101}})
+	t.Run("init", func(t *testing.T) { tests.VerifiedCapture(ctx, t, cs) })
+	tb.Insert(ctx, t, tableName, [][]any{{2, "two", "two", 102}, {3, "three", "three", 103}})
+	tb.Delete(ctx, t, tableName, "id", 1)
+	tb.Delete(ctx, t, tableName, "id", 2)
+	t.Run("main", func(t *testing.T) { tests.VerifiedCapture(ctx, t, cs) })
+}


### PR DESCRIPTION
**Description:**

According to MS docs, these columns always hold null values in the CDC table for a delete op, and blindly emitting those is incorrect and can cause schema validation failures if the text column is non-nullable.

The fix is to omit the property when the value is nil, the type is text/image/ntext, and the operation is a delete. In theory
this is always fine, because if the preimage value is a real null then we already have that in the LHS document that the delete will be merged into.

We could probably be even more aggressive in omitting properties here, honestly, but there's no real motivation to do that so I have gone with the minimal fix that only impacts the datatypes for which the default behavior is definitely wrong.

This fixes https://github.com/estuary/connectors/issues/1927

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1929)
<!-- Reviewable:end -->
