### PR TITLE
source-mongodb: merge deletion events

### DIFF
--- a/source-mongodb/.snapshots/TestDiscover
+++ b/source-mongodb/.snapshots/TestDiscover
@@ -20,7 +20,7 @@ Binding 0:
       "then": {
         "reduce": {
           "delete": true,
-          "strategy": "lastWriteWins"
+          "strategy": "merge"
         }
       },
       "type": "object",
@@ -106,7 +106,7 @@ Binding 1:
       "then": {
         "reduce": {
           "delete": true,
-          "strategy": "lastWriteWins"
+          "strategy": "merge"
         }
       },
       "type": "object",

--- a/source-mongodb/.snapshots/TestDiscoverAllDatabases
+++ b/source-mongodb/.snapshots/TestDiscoverAllDatabases
@@ -20,7 +20,7 @@ Binding 0:
       "then": {
         "reduce": {
           "delete": true,
-          "strategy": "lastWriteWins"
+          "strategy": "merge"
         }
       },
       "type": "object",
@@ -106,7 +106,7 @@ Binding 1:
       "then": {
         "reduce": {
           "delete": true,
-          "strategy": "lastWriteWins"
+          "strategy": "merge"
         }
       },
       "type": "object",
@@ -192,7 +192,7 @@ Binding 2:
       "then": {
         "reduce": {
           "delete": true,
-          "strategy": "lastWriteWins"
+          "strategy": "merge"
         }
       },
       "type": "object",
@@ -278,7 +278,7 @@ Binding 3:
       "then": {
         "reduce": {
           "delete": true,
-          "strategy": "lastWriteWins"
+          "strategy": "merge"
         }
       },
       "type": "object",
@@ -364,7 +364,7 @@ Binding 4:
       "then": {
         "reduce": {
           "delete": true,
-          "strategy": "lastWriteWins"
+          "strategy": "merge"
         }
       },
       "type": "object",
@@ -450,7 +450,7 @@ Binding 5:
       "then": {
         "reduce": {
           "delete": true,
-          "strategy": "lastWriteWins"
+          "strategy": "merge"
         }
       },
       "type": "object",

--- a/source-mongodb/.snapshots/TestDiscoverMultipleDatabases
+++ b/source-mongodb/.snapshots/TestDiscoverMultipleDatabases
@@ -20,7 +20,7 @@ Binding 0:
       "then": {
         "reduce": {
           "delete": true,
-          "strategy": "lastWriteWins"
+          "strategy": "merge"
         }
       },
       "type": "object",
@@ -106,7 +106,7 @@ Binding 1:
       "then": {
         "reduce": {
           "delete": true,
-          "strategy": "lastWriteWins"
+          "strategy": "merge"
         }
       },
       "type": "object",
@@ -192,7 +192,7 @@ Binding 2:
       "then": {
         "reduce": {
           "delete": true,
-          "strategy": "lastWriteWins"
+          "strategy": "merge"
         }
       },
       "type": "object",
@@ -278,7 +278,7 @@ Binding 3:
       "then": {
         "reduce": {
           "delete": true,
-          "strategy": "lastWriteWins"
+          "strategy": "merge"
         }
       },
       "type": "object",

--- a/source-mongodb/discovery.go
+++ b/source-mongodb/discovery.go
@@ -85,7 +85,7 @@ func generateMinimalSchema() json.RawMessage {
 		Then: &jsonschema.Schema{
 			Extras: map[string]interface{}{
 				"reduce": map[string]interface{}{
-					"strategy": "lastWriteWins",
+					"strategy": "merge",
 					"delete":   true,
 				},
 			},


### PR DESCRIPTION
**Description:**

This adds the (conditional) reduction strategy to deletion events to merge them into existing documents. For materializations using soft deletions, this will have the effect of only updating the `_meta/op` column to `"d"` for the materialized row, instead of removing all of the values from other non-key columns.

This will make soft deletions for MongoDB-captured collections work the same way as other CDC connectors, while still using the top-level "last write wins" reductions strategy for other events, most notably updates, where we don't emit explicit `null` values for removed fields (yet).

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1933)
<!-- Reviewable:end -->
