### PR TITLE
materialize-s3-iceberg: don't use context manager for transaction

### DIFF
--- a/materialize-s3-iceberg/iceberg-ctl/iceberg_ctl/__main__.py
+++ b/materialize-s3-iceberg/iceberg-ctl/iceberg_ctl/__main__.py
@@ -353,9 +353,10 @@ def append_files(
     # operations necessary for true exactly-once semantics, but we'd need to work with the catalog
     # at a lower level than PyIceberg currently makes available.
     checkpoints[materialization] = next_checkpoint
-    with tbl.transaction() as txn:
-        txn.set_properties({"flow_checkpoints_v1": json.dumps(checkpoints)})
-        txn.add_files(file_paths.split(","))
+    txn = tbl.transaction()
+    txn.add_files(file_paths.split(","))
+    txn.set_properties({"flow_checkpoints_v1": json.dumps(checkpoints)})
+    txn.commit_transaction()
 
     # TODO(whb): This additional logging should not really be necessary, but is
     # included for now to assist in troubleshooting potential errors.


### PR DESCRIPTION
**Description:**

The transaction context manager will actually commit the transaction even if an exception is raised by any of its operations. This means that setting the table property and then attempting to add a data file where the data file addition operation fails would still update the table checkpoint, resulting in Flow transaction erroneously being acknowledged even when data wasn't added to the table.

Using the explicit transaction handle and committing it does seem to work as expected though, where if there is an exception before the `commit` none of the operations will be applied.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1936)
<!-- Reviewable:end -->
