### PR TITLE
materialize-dynamodb: log failed batch writes in stores

### DIFF
--- a/materialize-dynamodb/transactor.go
+++ b/materialize-dynamodb/transactor.go
@@ -301,6 +301,7 @@ func (t *transactor) storeWorker(ctx context.Context, batches <-chan map[string]
 					RequestItems: batch,
 				})
 				if err != nil {
+					log.WithField("batch", batch).Error("failed batch write")
 					return err
 				}
 


### PR DESCRIPTION
**Description:**

Log out information about the batch attempting to be stored if the store operation fails.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1937)
<!-- Reviewable:end -->
