### PR TITLE
source-http-ingest: remove printlns

### DIFF
--- a/source-http-ingest/src/lib.rs
+++ b/source-http-ingest/src/lib.rs
@@ -318,8 +318,6 @@ pub async fn read_capture_request(stdin: &mut io::BufReader<io::Stdin>) -> anyho
     if buf.trim().is_empty() {
         anyhow::bail!("unexpected EOF reading request from stdin");
     }
-    eprintln!("got request (len={}):", buf.len());
-    eprintln!("{}", &buf[..buf.len().min(12000)]);
     let deser = serde_json::from_str(&buf).context("deserializing request")?;
     Ok(deser)
 }


### PR DESCRIPTION
The previous commit added some println statements to help debug an issue, and I forgot to remove them.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1941)
<!-- Reviewable:end -->
