### PR TITLE
source-mysql: Replace date `0000-00-00` with `0001-01-01`

### DIFF
--- a/source-mysql/datatype_test.go
+++ b/source-mysql/datatype_test.go
@@ -89,7 +89,7 @@ func TestDatatypes(t *testing.T) {
 		{ColumnType: "set('a', 'b', 'c')", ExpectType: `{"type":["string","null"]}`, InputValue: "a,c", ExpectValue: `"a,c"`},
 
 		{ColumnType: "date", ExpectType: `{"type":["string","null"]}`, InputValue: "1991-08-31", ExpectValue: `"1991-08-31"`},
-		{ColumnType: "date", ExpectType: `{"type":["string","null"]}`, InputValue: "0000-00-00", ExpectValue: `"0000-00-00"`},
+		{ColumnType: "date", ExpectType: `{"type":["string","null"]}`, InputValue: "0000-00-00", ExpectValue: `"0001-01-01"`},
 		{ColumnType: "time", ExpectType: `{"type":["string","null"]}`, InputValue: "765:43:21", ExpectValue: `"765:43:21"`},
 		{ColumnType: "time", ExpectType: `{"type":["string","null"]}`, InputValue: "00:00:00", ExpectValue: `"00:00:00"`},
 		{ColumnType: "year", ExpectType: `{"type":["integer","null"]}`, InputValue: "2003", ExpectValue: `2003`},


### PR DESCRIPTION
**Description:**

As discussed on Slack earlier today, this PR causes the zero value `0000-00-00` of the MySQL `date` column type to be serialized as `0001-01-01` going forward so that it can satisfy `format: date` validation. Both values are outside of the range of legal nonzero date values and all existing user collections treat these as generic strings anyway, so this is a backwards-compatible change as far as we're concerned and should not break any existing dataflows.

While the new value is compatible with JSON schema `format: date` validation we are not changing the discovery output at this time, because that could break preexisting datasets with the old zero value. Users who need these columns to be materialized as dates can adjust their read schema appropriately.

This fixes https://github.com/estuary/connectors/issues/1943

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1944)
<!-- Reviewable:end -->
