### PR TITLE
Phil/http ingest logs

### DIFF
--- a/source-http-ingest/Cargo.lock
+++ b/source-http-ingest/Cargo.lock
@@ -2410,6 +2410,7 @@ dependencies = [
  "tokio-util",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]

--- a/source-http-ingest/Cargo.toml
+++ b/source-http-ingest/Cargo.toml
@@ -33,7 +33,7 @@ utoipa-swagger-ui = { version = "7.1", features = ["axum"] }
 time = { version = "0.3", features = ["formatting"] }
 uuid = { version = "1.7", features = ["v4"] }
 lazy_static = "1.4"
-tower-http = { version = "0.5", features = ["decompression-full"] }
+tower-http = { version = "0.5", features = ["decompression-full", "trace"] }
 tower = "0.4"
 
 [dev-dependencies]

--- a/source-http-ingest/src/server.rs
+++ b/source-http-ingest/src/server.rs
@@ -43,6 +43,7 @@ pub async fn run_server(
         // This layer applies to all routes defined _before_ it, so the max body size is
         // the size after decompression.
         .layer(RequestDecompressionLayer::new())
+        .route_layer(tower_http::trace::TraceLayer::new_for_http())
         .with_state(Arc::new(handler));
 
     let address = std::net::SocketAddr::from((std::net::Ipv4Addr::UNSPECIFIED, listen_on_port()));

--- a/source-http-ingest/src/server.rs
+++ b/source-http-ingest/src/server.rs
@@ -43,7 +43,26 @@ pub async fn run_server(
         // This layer applies to all routes defined _before_ it, so the max body size is
         // the size after decompression.
         .layer(RequestDecompressionLayer::new())
-        .route_layer(tower_http::trace::TraceLayer::new_for_http())
+        .route_layer(
+            tower_http::trace::TraceLayer::new_for_http()
+                .make_span_with(|req: &http::Request<_>| {
+                    tracing::debug_span!(
+                        "http-request",
+                        path = req.uri().path(),
+                        status_code = tracing::field::Empty,
+                        published = tracing::field::Empty,
+                        handler_time_ms = tracing::field::Empty,
+                    )
+                })
+                .on_response(
+                    |response: &http::Response<_>,
+                     latency: std::time::Duration,
+                     span: &tracing::Span| {
+                        span.record("status_code", &tracing::field::display(response.status()));
+                        span.record("handler_time_ms", latency.as_millis());
+                    },
+                ),
+        )
         .with_state(Arc::new(handler));
 
     let address = std::net::SocketAddr::from((std::net::Ipv4Addr::UNSPECIFIED, listen_on_port()));
@@ -57,12 +76,6 @@ pub async fn run_server(
     Ok(())
 }
 
-// If you turn on debug logging, you get a pretty decent request handling log from just this attribute :)
-#[tracing::instrument(
-    level = "debug",
-    skip(handler, request_headers, body, query_params),
-    fields(response_status)
-)]
 async fn handle_webhook(
     State(handler): State<Arc<Handler>>,
     request_headers: axum::http::header::HeaderMap,
@@ -70,7 +83,7 @@ async fn handle_webhook(
     Query(query_params): Query<serde_json::Map<String, serde_json::Value>>,
     body: Bytes,
 ) -> (StatusCode, Json<Value>) {
-    let resp = match handler
+    match handler
         .handle_webhook(path, request_headers, query_params, body)
         .await
     {
@@ -80,9 +93,7 @@ async fn handle_webhook(
             let body = serde_json::json!({ "error": err.to_string() });
             (StatusCode::INTERNAL_SERVER_ERROR, Json(body))
         }
-    };
-    tracing::Span::current().record("response_status", resp.0.as_str());
-    resp
+    }
 }
 
 struct CollectionHandler {
@@ -380,7 +391,7 @@ impl Handler {
         let n_docs = enhanced_docs.len();
         tracing::debug!(%n_docs, elapsed_ms = %start.elapsed().as_millis(), "documents are valid and ready to publish");
         self.io.publish(enhanced_docs).await?;
-        tracing::debug!(%n_docs, elapsed_ms = %start.elapsed().as_millis(), "documents published successfully");
+        tracing::Span::current().record("published", n_docs);
         Ok((
             StatusCode::OK,
             Json(serde_json::json!({ "published": n_docs })),


### PR DESCRIPTION
**Description:**

Minor updates to the logging in the `source-http-ingest` connector to add some useful information and reduce redundant spans.

Now with debug logging enabled, you'll get logs like this:

```json
{"timestamp":"2024-09-16T17:58:46.055975789Z","level":"DEBUG","message":"close","time.busy":"229µs","time.idle":"236µs","span":{"handler_time_ms":"0","path":"/another.json","published":1,"status_code":"200 OK","name":"http-request"}}
```

where the span covers the entire time it took to process the request, including sending the response. The `handler_time_ms` is the time it took to validate and publish the documents, and `published` is the number of documents that were captured.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1947)
<!-- Reviewable:end -->
