### PR TITLE
source-impact-native: removing logcursor check for Actions streams

### DIFF
--- a/source-impact-native/source_impact_native/api.py
+++ b/source-impact-native/source_impact_native/api.py
@@ -143,10 +143,7 @@ async def fetch_incremental_actions(
                     max_ts = _s_to_dt(results[f"CreationDate"])
                     doc = _cls.model_validate_json(json.dumps(results))
                     yield doc
-            
-                elif _s_to_dt(results[f"CreationDate"]) < log_cursor:
-                    iterating = False
-                    break
+
             if result.get("@nextpageuri"):
                 url = API + result["@nextpageuri"]
             else:

--- a/source-impact-native/source_impact_native/resources.py
+++ b/source-impact-native/source_impact_native/resources.py
@@ -178,7 +178,7 @@ def snapshot_object(
             state,
             task,
             fetch_snapshot=functools.partial(fetch_snapshot, cls, account_sid, http),
-            tombstone=cls.PRIMARY_KEY,
+            tombstone=cls(_meta=cls.Meta(op="d")),
         )
 
     return Resource(
@@ -250,7 +250,7 @@ def media_groups_object(
             state,
             task,
             fetch_snapshot=functools.partial(fetch_snapshot_child, cls_parent, cls, account_sid, http),
-            tombstone=cls.PRIMARY_KEY,
+            tombstone=cls(_meta=cls.Meta(op="d")),
         )
 
     return Resource(


### PR DESCRIPTION
The Actions stream response seems to be ignoring the creation date order, and it also seems to not be returning data as in order of last updated record, only of impact creation. in order to support that, im removing the smaller logcursor check which would cause the connector to not return every record in incremental sync

The Actions stream response seems to be ignoring the creation date order, and it also seems to not be returning
data as in order of last updated record, only of impact creation. in order to support that, im removing the smaller logcursor check
which would cause the connector to not return every record in incremental

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1948)
<!-- Reviewable:end -->
