### PR TITLE
materialize-redshift: fix panic on empty txn

### DIFF
--- a/materialize-redshift/driver.go
+++ b/materialize-redshift/driver.go
@@ -755,9 +755,11 @@ func (d *transactor) Store(it *m.StoreIterator) (m.StartCommitFunc, error) {
 	}
 
 	// Flush the final binding.
-	var b = d.bindings[lastBinding]
-	if err := flushStagedFile(ctx, b); err != nil {
-		return nil, fmt.Errorf("final binding flushing staged files for collection %q: %w", b.target.Source.String(), err)
+	if lastBinding != -1 {
+		var b = d.bindings[lastBinding]
+		if err := flushStagedFile(ctx, b); err != nil {
+			return nil, fmt.Errorf("final binding flushing staged files for collection %q: %w", b.target.Source.String(), err)
+		}
 	}
 
 	return func(ctx context.Context, runtimeCheckpoint *protocol.Checkpoint) (*pf.ConnectorState, m.OpFuture) {


### PR DESCRIPTION
**Description:**

Following up to #1913, this fixes a panic when a transaction contains 0 stores, which is actually a thing that can happen.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

