### PR TITLE
source-postgres: Discover OIDs as integers and add tests

### DIFF
--- a/source-postgres/.snapshots/TestScanKeyTypes-OID
+++ b/source-postgres/.snapshots/TestScanKeyTypes-OID
@@ -1,0 +1,88 @@
+####################################
+### Capture from Start
+####################################
+# ================================
+# Collection "acmeCo/test/test_scankeytypes_oid_28040017": 1 Documents
+# ================================
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"scankeytypes_oid_28040017","loc":[11111111,11111111,11111111]}},"data":"Data 1","key":12344}
+# ================================
+# Final State Checkpoint
+# ================================
+{"bindingStateV1":{"test%2Fscankeytypes_oid_28040017":{"backfilled":1,"key_columns":["key"],"mode":"Backfill","scanned":"FjA4"}},"cursor":"0/1111111"}
+
+
+####################################
+### Capture from Key "FjA4"
+####################################
+# ================================
+# Collection "acmeCo/test/test_scankeytypes_oid_28040017": 1 Documents
+# ================================
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"scankeytypes_oid_28040017","loc":[11111111,11111111,11111111]}},"data":"Data 0","key":12345}
+# ================================
+# Final State Checkpoint
+# ================================
+{"bindingStateV1":{"test%2Fscankeytypes_oid_28040017":{"backfilled":2,"key_columns":["key"],"mode":"Backfill","scanned":"FjA5"}},"cursor":"0/1111111"}
+
+
+####################################
+### Capture from Key "FjA5"
+####################################
+# ================================
+# Collection "acmeCo/test/test_scankeytypes_oid_28040017": 1 Documents
+# ================================
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"scankeytypes_oid_28040017","loc":[11111111,11111111,11111111]}},"data":"Data 2","key":12346}
+# ================================
+# Final State Checkpoint
+# ================================
+{"bindingStateV1":{"test%2Fscankeytypes_oid_28040017":{"backfilled":3,"key_columns":["key"],"mode":"Backfill","scanned":"FjA6"}},"cursor":"0/1111111"}
+
+
+####################################
+### Capture from Key "FjA6"
+####################################
+# ================================
+# Collection "acmeCo/test/test_scankeytypes_oid_28040017": 1 Documents
+# ================================
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"scankeytypes_oid_28040017","loc":[11111111,11111111,11111111]}},"data":"Data 3","key":54321}
+# ================================
+# Final State Checkpoint
+# ================================
+{"bindingStateV1":{"test%2Fscankeytypes_oid_28040017":{"backfilled":4,"key_columns":["key"],"mode":"Backfill","scanned":"FtQx"}},"cursor":"0/1111111"}
+
+
+####################################
+### Capture from Key "FtQx"
+####################################
+# ================================
+# Collection "acmeCo/test/test_scankeytypes_oid_28040017": 1 Documents
+# ================================
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"scankeytypes_oid_28040017","loc":[11111111,11111111,11111111]}},"data":"Data 5","key":54322}
+# ================================
+# Final State Checkpoint
+# ================================
+{"bindingStateV1":{"test%2Fscankeytypes_oid_28040017":{"backfilled":5,"key_columns":["key"],"mode":"Backfill","scanned":"FtQy"}},"cursor":"0/1111111"}
+
+
+####################################
+### Capture from Key "FtQy"
+####################################
+# ================================
+# Collection "acmeCo/test/test_scankeytypes_oid_28040017": 1 Documents
+# ================================
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"scankeytypes_oid_28040017","loc":[11111111,11111111,11111111]}},"data":"Data 4","key":54323}
+# ================================
+# Final State Checkpoint
+# ================================
+{"bindingStateV1":{"test%2Fscankeytypes_oid_28040017":{"backfilled":6,"key_columns":["key"],"mode":"Backfill","scanned":"FtQz"}},"cursor":"0/1111111"}
+
+
+####################################
+### Capture from Key "FtQz"
+####################################
+# ================================
+# Final State Checkpoint
+# ================================
+{"bindingStateV1":{"test%2Fscankeytypes_oid_28040017":{"backfilled":6,"key_columns":["key"],"mode":"Active"}},"cursor":"0/1111111"}
+
+
+

--- a/source-postgres/datatype_test.go
+++ b/source-postgres/datatype_test.go
@@ -29,6 +29,8 @@ func TestDatatypes(t *testing.T) {
 		{ColumnType: `serial`, ExpectType: `{"type":"integer"}`, InputValue: `123`, ExpectValue: `123`},      // non-nullable
 		{ColumnType: `smallserial`, ExpectType: `{"type":"integer"}`, InputValue: `123`, ExpectValue: `123`}, // non-nullable
 		{ColumnType: `bigserial`, ExpectType: `{"type":"integer"}`, InputValue: `123`, ExpectValue: `123`},   // non-nullable
+		{ColumnType: `oid not null`, ExpectType: `{"type":"integer"}`, InputValue: `54321`, ExpectValue: `54321`},
+		{ColumnType: `oid`, ExpectType: `{"type":["integer","null"]}`, InputValue: `54321`, ExpectValue: `54321`},
 		{ColumnType: `real`, ExpectType: `{"type":["number","string","null"],"format":"number"}`, InputValue: `123.456`, ExpectValue: `123.456`},
 		{ColumnType: `double precision`, ExpectType: `{"type":["number","string","null"],"format":"number"}`, InputValue: `123.456`, ExpectValue: `123.456`},
 		{ColumnType: `real`, ExpectType: `{"type":["number","string","null"],"format":"number"}`, InputValue: `NaN`, ExpectValue: `"NaN"`},
@@ -194,6 +196,7 @@ func TestScanKeyTypes(t *testing.T) {
 		{"UUID", "UUID", []any{"66b968a7-aeca-4401-8239-5d57958d1572", "4ab4044a-9aab-415c-96c6-17fa338060fa", "c32fb585-fc7f-4347-8fe2-97448f4e93cd"}},
 		{"MAC6", "macaddr", []any{"47:7a:51:62:c3:aa", "6f:cf:f3:49:e0:b1", "65:d0:73:5a:5a:c9", "88:61:08:5b:ae:54"}},
 		{"MAC8", "macaddr8", []any{"5f:99:67:ac:0d:df:88:3a ", "70:26:74:4c:ac:2c:38:59", "e3:70:99:89:b9:d8:e8:21 ", "a5:35:55:da:06:38:39:43"}},
+		{"OID", "oid", []any{12345, 12344, 12346, 54321, 54323, 54322}},
 	} {
 		t.Run(tc.Name, func(t *testing.T) {
 			var uniqueID = fmt.Sprintf("2804%04d", idx)

--- a/source-postgres/discovery.go
+++ b/source-postgres/discovery.go
@@ -302,6 +302,7 @@ var postgresTypeToJSON = map[string]columnSchema{
 	"int2": {jsonTypes: []string{"integer"}},
 	"int4": {jsonTypes: []string{"integer"}},
 	"int8": {jsonTypes: []string{"integer"}},
+	"oid":  {jsonTypes: []string{"integer"}},
 
 	"numeric": {jsonTypes: []string{"string"}, format: "number"},
 	"float4":  {jsonTypes: []string{"number", "string"}, format: "number"},


### PR DESCRIPTION
**Description:**

Previously OID values "worked" (they've always been captured as integer values and it was possible to use them as the backfill key as far as the connector was concerned), but were discovered as the catch-all schema `{}` which meant that OID primary keys would produce a collection with an invalid collection key.

This commit fixes that by changing OID discovery to say they're integers, and adds some test cases to make sure OIDs work as we intend both as values and as primary keys.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1966)
<!-- Reviewable:end -->
