### PR TITLE
source-stripe-native: config update, typing, and refactors

### DIFF
--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -43,7 +43,6 @@ on:
       - "source-hubspot/**"
       - "source-notion/**"
       - "source-linkedin-pages/**"
-      - "source-stripe-native/**"
       - "source-linkedin-ads-v2/**"
       - "source-oracle-flashback/**"
       - "source-recharge/**"

--- a/source-stripe-native/config.yaml
+++ b/source-stripe-native/config.yaml
@@ -1,5 +1,6 @@
 credentials:
     access_token_sops: ENC[AES256_GCM,data:dLvs/aZ6E/HvgdgPfLVPRlZAiHnCPs/RpuVrtyL0ytaDWRTZdGTB/5UMiFctVfpLlWQaG3hPq4hsHLdYMlZ8B2P6XMEqrwtOtmx6yAXvtPrY1H3rRathTdbEDb+kFizUc0SayWFJAPeyhgQ=,iv:rtL4yTQMDJjiwnBbLrA1LtrlJAixUdu/vzWwUdk7weU=,tag:PCDBilsBpOBvdEyB95AGGg==,type:str]
+start_date: "2010-01-01T00:00:00+00:00"
 sops:
     kms: []
     gcp_kms:
@@ -9,8 +10,8 @@ sops:
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2024-05-16T13:02:22Z"
-    mac: ENC[AES256_GCM,data:DzVmmV8DF3lqBgrzTNNfPdZAO+SylDOfp7J7lVpnARvGcA3bNUjqn0zSu9hzS5OVvLlWvCoZ9hivR6q9kEzvQnVqkXZf9lJQNPH9jOh3l7xAc3tnIQt6ltcBojYYCMBpL+XkiDlS+xPw+4UKKPrvpPRI7/wP9XItLhVf2FSjRXY=,iv:jhXTxBs/vFiBweU7aNXq3OQbWi18fTRB0swVcM51Vi0=,tag:HX4faTrnxh4h8eu0uFgKtA==,type:str]
+    lastmodified: "2024-09-19T19:05:15Z"
+    mac: ENC[AES256_GCM,data:eQg0lkQQMIELna+yoZUtO0lu+T2y8dWfgFr1J+8T6/N+9NpuNRzltvCRNUIySAm3fBTJ8UdXnuXLtylyp9znpPWRBxEqlcO/Z/uIlhqZTux1uOMGlK+DXb6qF2HECgx4JMzTKIj+/XrGLrFKcNwZr2L8GNTAMJ6P5bMHO12+YZY=,iv:8vw+KoZBfPrAwHemvX9CorGSz/rZyqwQjNaht5xEeQE=,tag:DHbKd8D4yvZEh6MIE8TIzg==,type:str]
     pgp: []
     encrypted_suffix: _sops
     version: 3.8.1

--- a/source-stripe-native/source_stripe_native/api.py
+++ b/source-stripe-native/source_stripe_native/api.py
@@ -69,7 +69,7 @@ async def fetch_incremental(
 
 async def fetch_backfill(
     cls,
-    stop_date,
+    start_date,
     http: HTTPSession,
     log: Logger,
     page: str | None,
@@ -83,7 +83,7 @@ async def fetch_backfill(
     It works by calling each individual stream endpoint and parsing each result,
     created before the cutoff, with its model.
 
-    If a document is equal-to or older-than the stop_date, this means we've reached the limit
+    If a document is equal-to or older-than the start_date, this means we've reached the limit
     set by the user, and the stream halts. 
 
     """
@@ -103,11 +103,11 @@ async def fetch_backfill(
     )
 
     for doc in result.data:
-        if _s_to_dt(doc.created) == stop_date:
+        if _s_to_dt(doc.created) == start_date:
             # Yield final document for reference
             yield doc
             return
-        elif _s_to_dt(doc.created) < stop_date:
+        elif _s_to_dt(doc.created) < start_date:
             return
         elif _s_to_dt(doc.created) < cutoff:
             yield doc
@@ -187,7 +187,7 @@ async def fetch_incremental_substreams(
 async def fetch_backfill_substreams(
     cls,
     cls_child,
-    stop_date,
+    start_date,
     http: HTTPSession,
     log: Logger,
     page: str | None,
@@ -220,7 +220,7 @@ async def fetch_backfill_substreams(
     )
 
     for doc in result.data:
-        if _s_to_dt(doc.created) == stop_date:
+        if _s_to_dt(doc.created) == start_date:
             parent_data = doc
             id = parent_data.id
 
@@ -240,7 +240,7 @@ async def fetch_backfill_substreams(
                 yield doc 
             return
 
-        elif _s_to_dt(doc.created) < stop_date:
+        elif _s_to_dt(doc.created) < start_date:
             return
 
         elif _s_to_dt(doc.created) < cutoff:
@@ -431,7 +431,7 @@ async def fetch_incremental_usage_records(
 async def fetch_backfill_usage_records(
     cls,
     cls_child,
-    stop_date,
+    start_date,
     http: HTTPSession,
     log: Logger,
     page: str | None,
@@ -462,7 +462,7 @@ async def fetch_backfill_usage_records(
     )
 
     for doc in result.data:
-        if _s_to_dt(doc.created) == stop_date:
+        if _s_to_dt(doc.created) == start_date:
             parent_data = doc
             for item in parent_data.items.data:
                 id = item.id
@@ -482,7 +482,7 @@ async def fetch_backfill_usage_records(
                     yield doc 
             return
 
-        elif _s_to_dt(doc.created) < stop_date:
+        elif _s_to_dt(doc.created) < start_date:
             return
 
         elif _s_to_dt(doc.created) < cutoff:

--- a/source-stripe-native/source_stripe_native/models.py
+++ b/source-stripe-native/source_stripe_native/models.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone, timedelta
 from enum import StrEnum, auto
 from pydantic import BaseModel, Field, AwareDatetime, model_validator, AliasChoices
 from typing import Literal, Generic, TypeVar, Annotated, ClassVar, TYPE_CHECKING, Dict, List
@@ -15,13 +15,17 @@ from estuary_cdk.capture.common import (
 )
 
 
+def default_start_date():
+    dt = datetime.now(timezone.utc) - timedelta(days=30)
+    return dt
+
 class EndpointConfig(BaseModel):
     credentials: AccessToken = Field(
-        title="API Key"        )
-    stop_date: AwareDatetime = Field(
-        description="Replication Stop Date. Records will only be considered for backfilling "\
-                    "before the stop_date, similar to a start date",
-        default=datetime.fromisoformat("2010-01-01T00:00:00Z".replace('Z', '+00:00'))
+        title="API Key"
+    )
+    start_date: AwareDatetime = Field(
+        description="UTC data and time in the format YYYY-MM-DDTHH:MM:SSZ. Any data generated before this date will not be replicated. If left blank, the start date will be set to 30 days before the present date. ",
+        default_factory=default_start_date,
     )
 
 

--- a/source-stripe-native/source_stripe_native/models.py
+++ b/source-stripe-native/source_stripe_native/models.py
@@ -69,344 +69,305 @@ class BackfillResult(BaseModel, Generic[Item], extra="allow"):
     data: List[Item]
 
 
-class Files(BaseDocument, extra="allow"):
+class BaseStripeObject(BaseDocument, extra="allow"):
+    """
+    Shared properties between all Stripe objects.
+    """
+    NAME: ClassVar[str]
+    SEARCH_NAME: ClassVar[str]
+
+    id: str
+
+
+class BaseStripeObjectNoEvents(BaseStripeObject):
+    """
+    Stream that does not have any corresponding events 
+    generated at the /events endpoint.
+    """
+    created: int
+
+
+class BaseStripeObjectWithEvents(BaseStripeObject):
+    """
+    Stream that has corresponding events
+    generated at the /events endpoint.
+    """
+    TYPES: ClassVar[str]
+
+    created: int
+
+
+# Note: BaseStripeChildObject is prepositioning for later when we have separate 
+# TYPES class attributes for parent and child classes.
+class BaseStripeChildObject(BaseStripeObject):
+    """
+    Child stream that can only be accessed by using an
+    ID from a parent stream.
+    """
+    pass
+
+
+StripeObject = TypeVar("StripeObject", bound=BaseStripeObject)
+StripeObjectNoEvents = TypeVar("StripeObjectNoEvents", bound=BaseStripeObjectNoEvents)
+StripeObjectWithEvents = TypeVar("StripeObjectWithEvents", bound=BaseStripeObjectWithEvents)
+StripeChildObject = TypeVar("StripeChildObject", bound=BaseStripeChildObject)
+
+
+class Files(BaseStripeObjectNoEvents):
     """
     Incremental stream with no Events
     """
     NAME: ClassVar[str] = "Files"
     SEARCH_NAME: ClassVar[str] = "files"
 
-    id: str
 
-
-class FilesLink(BaseDocument, extra="allow"):
+class FilesLink(BaseStripeObjectNoEvents):
     """
     Incremental stream with no Events
     """
     NAME: ClassVar[str] = "FilesLink"
     SEARCH_NAME: ClassVar[str] = "file_links"
 
-    id: str
 
-
-class BalanceTransactions(BaseDocument, extra="allow"):
+class BalanceTransactions(BaseStripeObjectNoEvents):
     """
     Incremental stream with no Events
     """
     NAME: ClassVar[str] = "BalanceTransactions"
     SEARCH_NAME: ClassVar[str] = "balance_transactions"
 
-    id: str
 
-
-class Accounts(BaseDocument, extra="allow"):
+class Accounts(BaseStripeObjectWithEvents):
     NAME: ClassVar[str] = "Accounts"
     TYPES: ClassVar[str] =  "accounts.updated"
     SEARCH_NAME: ClassVar[str] = "accounts"
 
-    id: str
 
-class Persons(BaseDocument, extra="allow"):
+class Persons(BaseStripeChildObject):
     """
-    Child Stream
     Parent Stream: Accounts
     """
     NAME: ClassVar[str] = "Persons"
     SEARCH_NAME: ClassVar[str] = "persons"
 
-    id: str
 
-
-class ExternalAccountCards(BaseDocument, extra="allow"):
+class ExternalAccountCards(BaseStripeChildObject):
     """
-    Child Stream
     Parent Stream: Accounts
     """
     NAME: ClassVar[str] = "ExternalAccountCards"
     SEARCH_NAME: ClassVar[str] = "external_accounts"
 
-    id: str
 
-
-class ExternalBankAccount(BaseDocument, extra="allow"):
+class ExternalBankAccount(BaseStripeChildObject):
     """
-    Child Stream
     Parent Stream: Accounts
     """
     NAME: ClassVar[str] = "ExternalBankAccount"
     SEARCH_NAME: ClassVar[str] = "external_accounts"
 
-    id: str
 
-
-class ApplicationFees(BaseDocument, extra="allow"):
+class ApplicationFees(BaseStripeObjectWithEvents):
     NAME: ClassVar[str] = "ApplicationFees"
     TYPES: ClassVar[str] =  "application_fee.refunded"
     SEARCH_NAME: ClassVar[str] = "application_fees"
 
-    id: str
 
-
-class ApplicationFeesRefunds(BaseDocument, extra="allow"):
+class ApplicationFeesRefunds(BaseStripeChildObject):
     """
-    Child Stream
     Parent Stream: ApplicationFees
     """
     NAME: ClassVar[str] = "ApplicationFeesRefunds"
     SEARCH_NAME: ClassVar[str] = "refunds"
 
-    id: str
 
-
-class Authorizations(BaseDocument, extra="allow"):
+class Authorizations(BaseStripeObjectWithEvents):
     NAME: ClassVar[str] = "Authorizations"
     TYPES: ClassVar[str] =  "issuing_authorization.updated"
     SEARCH_NAME: ClassVar[str] = "issuing/authorizations"
 
-    id: str
 
-
-class Customers(BaseDocument, extra="allow"):
+class Customers(BaseStripeObjectWithEvents):
     NAME: ClassVar[str] = "Customers"
     TYPES: ClassVar[str] =  "customer.updated"
     SEARCH_NAME: ClassVar[str] = "customers"
 
-    id: str
 
-
-class Cards(BaseDocument, extra="allow"):
+class Cards(BaseStripeChildObject):
     """
-    Child Stream
     Parent Stream: Customers
     """
     NAME: ClassVar[str] = "Cards"
     SEARCH_NAME: ClassVar[str] = "cards"
 
-    id: str
 
-
-class Bank_Accounts(BaseDocument, extra="allow"):
+class Bank_Accounts(BaseStripeChildObject):
     """
-    Child Stream
     Parent Stream: Customers
     """
     NAME: ClassVar[str] = "BankAccounts"
     SEARCH_NAME: ClassVar[str] = "bank_accounts"
 
-    id: str
 
-
-class CustomerBalanceTransaction(BaseDocument, extra="allow"):
+class CustomerBalanceTransaction(BaseStripeChildObject):
     """
-    Child Stream
     Parent Stream: Customers
     """
     NAME: ClassVar[str] = "CustomerBalanceTransaction"
     SEARCH_NAME: ClassVar[str] = "balance_transactions"
 
-    id: str
 
-
-class PaymentMethods(BaseDocument, extra="allow"):
+class PaymentMethods(BaseStripeChildObject):
     """
-    Child Stream
     Parent Stream: Customers
     """
     NAME: ClassVar[str] = "PaymentMethods"
     SEARCH_NAME: ClassVar[str] = "payment_methods"
 
-    id: str
 
-
-class CardHolders(BaseDocument, extra="allow"):
+class CardHolders(BaseStripeObjectWithEvents):
     NAME: ClassVar[str] = "CardHolders"
     TYPES: ClassVar[str] =  "issuing_cardholder.updated"
     SEARCH_NAME: ClassVar[str] = "issuing/cardholders"
 
-    id: str
 
-
-class Charges(BaseDocument, extra="allow"):
+class Charges(BaseStripeObjectWithEvents):
     NAME: ClassVar[str] = "Charges"
     TYPES: ClassVar[str] =  "charge.updated"
     SEARCH_NAME: ClassVar[str] = "charges"
 
-    id: str
 
-
-class CheckoutSessions(BaseDocument, extra="allow"):
+class CheckoutSessions(BaseStripeObjectWithEvents):
     NAME: ClassVar[str] = "CheckoutSessions"
     TYPES: ClassVar[str] =  "checkout.session.*"
     SEARCH_NAME: ClassVar[str] = "checkout/sessions"
 
-    id: str
 
-
-class CheckoutSessionsLine(BaseDocument, extra="allow"):
+class CheckoutSessionsLine(BaseStripeChildObject):
     """
-    Child Stream
     Parent Stream: CheckoutSessions
     """
     NAME: ClassVar[str] = "CheckoutSessionsLine"
     SEARCH_NAME: ClassVar[str] = "line_items"
 
-    id: str
 
-
-class Coupons(BaseDocument, extra="allow"):
+class Coupons(BaseStripeObjectWithEvents):
     NAME: ClassVar[str] = "Coupons"
     TYPES: ClassVar[str] =  "coupon.updated"
     SEARCH_NAME: ClassVar[str] = "coupons"
 
-    id: str
 
-
-class CreditNotes(BaseDocument, extra="allow"):
+class CreditNotes(BaseStripeObjectWithEvents):
     NAME: ClassVar[str] = "CreditNotes"
     TYPES: ClassVar[str] =  "credit_note.updated"
     SEARCH_NAME: ClassVar[str] = "credit_notes"
 
-    id: str
 
-
-class CreditNotesLines(BaseDocument, extra="allow"):
+class CreditNotesLines(BaseStripeChildObject):
     """
-    Child Stream
     Parent Stream: CreditNotes
     """
     NAME: ClassVar[str] = "CreditNotesLines"
     SEARCH_NAME: ClassVar[str] = "lines"
 
-    id: str
 
-
-class Disputes(BaseDocument, extra="allow"):
+class Disputes(BaseStripeObjectWithEvents):
     NAME: ClassVar[str] = "Disputes"
     TYPES: ClassVar[str] =  "charge.dispute.updated"
     SEARCH_NAME: ClassVar[str] = "disputes"
 
-    id: str
 
-
-class EarlyFraudWarning(BaseDocument, extra="allow"):
+class EarlyFraudWarning(BaseStripeObjectWithEvents):
     NAME: ClassVar[str] = "EarlyFraudWarning"
     TYPES: ClassVar[str] =  "radar.early_fraud_warning.*"
     SEARCH_NAME: ClassVar[str] = "radar/early_fraud_warnings"
 
-    id: str
 
-
-class InvoiceItems(BaseDocument, extra="allow"):
+class InvoiceItems(BaseStripeObjectWithEvents):
     NAME: ClassVar[str] = "InvoiceItems"
     TYPES: ClassVar[str] =  "invoiceitem.*"
     SEARCH_NAME: ClassVar[str] = "invoiceitems"
-    
-    id: str
+
     created: int = Field(validation_alias=AliasChoices('date'))
 
 
-class Invoices(BaseDocument, extra="allow"):
+class Invoices(BaseStripeObjectWithEvents):
     NAME: ClassVar[str] = "Invoices"
     TYPES: ClassVar[str] =  "invoice.updated"
     SEARCH_NAME: ClassVar[str] = "invoices"
 
-    id: str
 
-
-class InvoiceLineItems(BaseDocument, extra="allow"):
+class InvoiceLineItems(BaseStripeChildObject):
     """
-    Child Stream
     Parent Stream: Invoices
     """
     NAME: ClassVar[str] = "InvoiceLineItems"
     SEARCH_NAME: ClassVar[str] = "lines"
 
-    id: str
 
-
-class PaymentIntent(BaseDocument, extra="allow"):
+class PaymentIntent(BaseStripeObjectWithEvents):
     NAME: ClassVar[str] = "PaymentIntents"
     TYPES: ClassVar[str] =  "payment_intent.*"
     SEARCH_NAME: ClassVar[str] = "payment_intents"
 
-    id: str
 
-
-class Payouts(BaseDocument, extra="allow"):
+class Payouts(BaseStripeObjectWithEvents):
     NAME: ClassVar[str] = "Payouts"
     TYPES: ClassVar[str] =  "payout.updated"
     SEARCH_NAME: ClassVar[str] = "payouts"
 
-    id: str
 
-
-class Plans(BaseDocument, extra="allow"):
+class Plans(BaseStripeObjectWithEvents):
     NAME: ClassVar[str] = "Plans"
     TYPES: ClassVar[str] =  "plan.updated"
     SEARCH_NAME: ClassVar[str] = "plans"
 
-    id: str
 
-class Products(BaseDocument, extra="allow"):
+class Products(BaseStripeObjectWithEvents):
     NAME: ClassVar[str] = "Products"
     TYPES: ClassVar[str] =  "product.updated"
     SEARCH_NAME: ClassVar[str] = "products"
 
-    id: str
 
-
-class PromotionCode(BaseDocument, extra="allow"):
+class PromotionCode(BaseStripeObjectWithEvents):
     NAME: ClassVar[str] = "PromotionCode"
     TYPES: ClassVar[str] =  "promotion_code.updated"
     SEARCH_NAME: ClassVar[str] = "promotion_codes"
 
-    id: str
 
-
-class Refunds(BaseDocument, extra="allow"):
+class Refunds(BaseStripeObjectWithEvents):
     NAME: ClassVar[str] = "Refunds"
     TYPES: ClassVar[str] =  "refund.updated"
     SEARCH_NAME: ClassVar[str] = "refunds"
 
-    id: str
 
-
-class Reviews(BaseDocument, extra="allow"):
+class Reviews(BaseStripeObjectWithEvents):
     NAME: ClassVar[str] = "Reviews"
     TYPES: ClassVar[str] =  "review.*"
     SEARCH_NAME: ClassVar[str] = "reviews"
 
-    id: str
 
-
-class SetupIntents(BaseDocument, extra="allow"):
+class SetupIntents(BaseStripeObjectWithEvents):
     NAME: ClassVar[str] = "SetupIntents"
     TYPES: ClassVar[str] =  "setup_intent.*"
     SEARCH_NAME: ClassVar[str] = "setup_intents"
 
-    id: str
 
-
-class SetupAttempts(BaseDocument, extra="allow"):
+class SetupAttempts(BaseStripeChildObject):
     """
-    Child Stream
     Parent Stream: SetupIntents
     """
     NAME: ClassVar[str] = "SetupAttempts"
     SEARCH_NAME: ClassVar[str] = "setup_attempts"
 
-    id: str
 
-
-class Subscriptions(BaseDocument, extra="allow"):
+class Subscriptions(BaseStripeObjectWithEvents):
     NAME: ClassVar[str] = "Subscriptions"
     TYPES: ClassVar[str] =  "customer.subscription.*"
     SEARCH_NAME: ClassVar[str] = "subscriptions"
 
-    id: str
 
-
-class SubscriptionItems(BaseDocument, extra="allow"):
+class SubscriptionItems(BaseStripeObjectWithEvents):
     NAME: ClassVar[str] = "SubscriptionItems"
     TYPES: ClassVar[str] =  "customer.subscription.*"
     SEARCH_NAME: ClassVar[str] = "subscriptions"
@@ -417,63 +378,50 @@ class SubscriptionItems(BaseDocument, extra="allow"):
 
         data: list[Values]
 
-    id: str
     items: Items
 
 
-class UsageRecords(BaseDocument, extra="allow"):
+class UsageRecords(BaseStripeChildObject):
     """
-    Child Stream
     Parent Stream: SubscriptionItems
     """
     NAME: ClassVar[str] = "UsageRecords"
     SEARCH_NAME: ClassVar[str] = "usage_record_summaries"
 
-    id: str
     subscription_item: str
 
 
-class SubscriptionsSchedule(BaseDocument, extra="allow"):
+class SubscriptionsSchedule(BaseStripeObjectWithEvents):
     NAME: ClassVar[str] = "SubscriptionSchedule"
     TYPES: ClassVar[str] =  "subscription_schedule.updated"
     SEARCH_NAME: ClassVar[str] = "subscription_schedules"
 
-    id: str
 
-
-class TopUps(BaseDocument, extra="allow"):
+class TopUps(BaseStripeObjectWithEvents):
     NAME: ClassVar[str] = "TopUps"
     TYPES: ClassVar[str] =  "topup.*"
     SEARCH_NAME: ClassVar[str] = "topups"
 
-    id: str
 
-
-class Transactions(BaseDocument, extra="allow"):
+class Transactions(BaseStripeObjectWithEvents):
     NAME: ClassVar[str] = "Transactions"
     TYPES: ClassVar[str] =  "issuing_transaction.updated"
     SEARCH_NAME: ClassVar[str] = "issuing/transactions"
 
-    id: str
 
-
-class Transfers(BaseDocument, extra="allow"):
+class Transfers(BaseStripeObjectWithEvents):
     NAME: ClassVar[str] = "Transfers"
     TYPES: ClassVar[str] =  "transfer.updated"
     SEARCH_NAME: ClassVar[str] = "transfers"
 
-    id: str
 
-
-class TransferReversals(BaseDocument, extra="allow"):
+class TransferReversals(BaseStripeChildObject):
     """
-    Child Stream
     Parent Stream: Transfers
     """
     NAME: ClassVar[str] = "TransferReversals"
     SEARCH_NAME: ClassVar[str] = "reversals"
 
-    id: str
 
 # Streams can have 0 or more children. In most cases, child streams are accessible if their parent stream is accessible,
 # and they are inaccessible if their parent is inaccessible. 

--- a/source-stripe-native/tests/snapshots/snapshots__discover__stdout.json
+++ b/source-stripe-native/tests/snapshots/snapshots__discover__stdout.json
@@ -47,10 +47,15 @@
         "id": {
           "title": "Id",
           "type": "string"
+        },
+        "created": {
+          "title": "Created",
+          "type": "integer"
         }
       },
       "required": [
-        "id"
+        "id",
+        "created"
       ],
       "title": "Accounts",
       "type": "object",
@@ -92,7 +97,7 @@
         }
       },
       "additionalProperties": true,
-      "description": "Child Stream\nParent Stream: Accounts",
+      "description": "Parent Stream: Accounts",
       "properties": {
         "_meta": {
           "allOf": [
@@ -154,7 +159,7 @@
         }
       },
       "additionalProperties": true,
-      "description": "Child Stream\nParent Stream: Accounts",
+      "description": "Parent Stream: Accounts",
       "properties": {
         "_meta": {
           "allOf": [
@@ -216,7 +221,7 @@
         }
       },
       "additionalProperties": true,
-      "description": "Child Stream\nParent Stream: Accounts",
+      "description": "Parent Stream: Accounts",
       "properties": {
         "_meta": {
           "allOf": [
@@ -294,10 +299,15 @@
         "id": {
           "title": "Id",
           "type": "string"
+        },
+        "created": {
+          "title": "Created",
+          "type": "integer"
         }
       },
       "required": [
-        "id"
+        "id",
+        "created"
       ],
       "title": "ApplicationFees",
       "type": "object",
@@ -339,7 +349,7 @@
         }
       },
       "additionalProperties": true,
-      "description": "Child Stream\nParent Stream: ApplicationFees",
+      "description": "Parent Stream: ApplicationFees",
       "properties": {
         "_meta": {
           "allOf": [
@@ -417,10 +427,15 @@
         "id": {
           "title": "Id",
           "type": "string"
+        },
+        "created": {
+          "title": "Created",
+          "type": "integer"
         }
       },
       "required": [
-        "id"
+        "id",
+        "created"
       ],
       "title": "Customers",
       "type": "object",
@@ -462,7 +477,7 @@
         }
       },
       "additionalProperties": true,
-      "description": "Child Stream\nParent Stream: Customers",
+      "description": "Parent Stream: Customers",
       "properties": {
         "_meta": {
           "allOf": [
@@ -524,7 +539,7 @@
         }
       },
       "additionalProperties": true,
-      "description": "Child Stream\nParent Stream: Customers",
+      "description": "Parent Stream: Customers",
       "properties": {
         "_meta": {
           "allOf": [
@@ -586,7 +601,7 @@
         }
       },
       "additionalProperties": true,
-      "description": "Child Stream\nParent Stream: Customers",
+      "description": "Parent Stream: Customers",
       "properties": {
         "_meta": {
           "allOf": [
@@ -648,7 +663,7 @@
         }
       },
       "additionalProperties": true,
-      "description": "Child Stream\nParent Stream: Customers",
+      "description": "Parent Stream: Customers",
       "properties": {
         "_meta": {
           "allOf": [
@@ -726,10 +741,15 @@
         "id": {
           "title": "Id",
           "type": "string"
+        },
+        "created": {
+          "title": "Created",
+          "type": "integer"
         }
       },
       "required": [
-        "id"
+        "id",
+        "created"
       ],
       "title": "Charges",
       "type": "object",
@@ -787,10 +807,15 @@
         "id": {
           "title": "Id",
           "type": "string"
+        },
+        "created": {
+          "title": "Created",
+          "type": "integer"
         }
       },
       "required": [
-        "id"
+        "id",
+        "created"
       ],
       "title": "CheckoutSessions",
       "type": "object",
@@ -832,7 +857,7 @@
         }
       },
       "additionalProperties": true,
-      "description": "Child Stream\nParent Stream: CheckoutSessions",
+      "description": "Parent Stream: CheckoutSessions",
       "properties": {
         "_meta": {
           "allOf": [
@@ -910,10 +935,15 @@
         "id": {
           "title": "Id",
           "type": "string"
+        },
+        "created": {
+          "title": "Created",
+          "type": "integer"
         }
       },
       "required": [
-        "id"
+        "id",
+        "created"
       ],
       "title": "Coupons",
       "type": "object",
@@ -971,10 +1001,15 @@
         "id": {
           "title": "Id",
           "type": "string"
+        },
+        "created": {
+          "title": "Created",
+          "type": "integer"
         }
       },
       "required": [
-        "id"
+        "id",
+        "created"
       ],
       "title": "CreditNotes",
       "type": "object",
@@ -1016,7 +1051,7 @@
         }
       },
       "additionalProperties": true,
-      "description": "Child Stream\nParent Stream: CreditNotes",
+      "description": "Parent Stream: CreditNotes",
       "properties": {
         "_meta": {
           "allOf": [
@@ -1094,10 +1129,15 @@
         "id": {
           "title": "Id",
           "type": "string"
+        },
+        "created": {
+          "title": "Created",
+          "type": "integer"
         }
       },
       "required": [
-        "id"
+        "id",
+        "created"
       ],
       "title": "Disputes",
       "type": "object",
@@ -1155,10 +1195,15 @@
         "id": {
           "title": "Id",
           "type": "string"
+        },
+        "created": {
+          "title": "Created",
+          "type": "integer"
         }
       },
       "required": [
-        "id"
+        "id",
+        "created"
       ],
       "title": "EarlyFraudWarning",
       "type": "object",
@@ -1282,10 +1327,15 @@
         "id": {
           "title": "Id",
           "type": "string"
+        },
+        "created": {
+          "title": "Created",
+          "type": "integer"
         }
       },
       "required": [
-        "id"
+        "id",
+        "created"
       ],
       "title": "Invoices",
       "type": "object",
@@ -1327,7 +1377,7 @@
         }
       },
       "additionalProperties": true,
-      "description": "Child Stream\nParent Stream: Invoices",
+      "description": "Parent Stream: Invoices",
       "properties": {
         "_meta": {
           "allOf": [
@@ -1405,10 +1455,15 @@
         "id": {
           "title": "Id",
           "type": "string"
+        },
+        "created": {
+          "title": "Created",
+          "type": "integer"
         }
       },
       "required": [
-        "id"
+        "id",
+        "created"
       ],
       "title": "PaymentIntent",
       "type": "object",
@@ -1466,10 +1521,15 @@
         "id": {
           "title": "Id",
           "type": "string"
+        },
+        "created": {
+          "title": "Created",
+          "type": "integer"
         }
       },
       "required": [
-        "id"
+        "id",
+        "created"
       ],
       "title": "Payouts",
       "type": "object",
@@ -1527,10 +1587,15 @@
         "id": {
           "title": "Id",
           "type": "string"
+        },
+        "created": {
+          "title": "Created",
+          "type": "integer"
         }
       },
       "required": [
-        "id"
+        "id",
+        "created"
       ],
       "title": "Plans",
       "type": "object",
@@ -1588,10 +1653,15 @@
         "id": {
           "title": "Id",
           "type": "string"
+        },
+        "created": {
+          "title": "Created",
+          "type": "integer"
         }
       },
       "required": [
-        "id"
+        "id",
+        "created"
       ],
       "title": "Products",
       "type": "object",
@@ -1649,10 +1719,15 @@
         "id": {
           "title": "Id",
           "type": "string"
+        },
+        "created": {
+          "title": "Created",
+          "type": "integer"
         }
       },
       "required": [
-        "id"
+        "id",
+        "created"
       ],
       "title": "PromotionCode",
       "type": "object",
@@ -1710,10 +1785,15 @@
         "id": {
           "title": "Id",
           "type": "string"
+        },
+        "created": {
+          "title": "Created",
+          "type": "integer"
         }
       },
       "required": [
-        "id"
+        "id",
+        "created"
       ],
       "title": "Refunds",
       "type": "object",
@@ -1771,10 +1851,15 @@
         "id": {
           "title": "Id",
           "type": "string"
+        },
+        "created": {
+          "title": "Created",
+          "type": "integer"
         }
       },
       "required": [
-        "id"
+        "id",
+        "created"
       ],
       "title": "Reviews",
       "type": "object",
@@ -1832,10 +1917,15 @@
         "id": {
           "title": "Id",
           "type": "string"
+        },
+        "created": {
+          "title": "Created",
+          "type": "integer"
         }
       },
       "required": [
-        "id"
+        "id",
+        "created"
       ],
       "title": "SetupIntents",
       "type": "object",
@@ -1877,7 +1967,7 @@
         }
       },
       "additionalProperties": true,
-      "description": "Child Stream\nParent Stream: SetupIntents",
+      "description": "Parent Stream: SetupIntents",
       "properties": {
         "_meta": {
           "allOf": [
@@ -1955,10 +2045,15 @@
         "id": {
           "title": "Id",
           "type": "string"
+        },
+        "created": {
+          "title": "Created",
+          "type": "integer"
         }
       },
       "required": [
-        "id"
+        "id",
+        "created"
       ],
       "title": "Subscriptions",
       "type": "object",
@@ -2016,10 +2111,15 @@
         "id": {
           "title": "Id",
           "type": "string"
+        },
+        "created": {
+          "title": "Created",
+          "type": "integer"
         }
       },
       "required": [
-        "id"
+        "id",
+        "created"
       ],
       "title": "SubscriptionsSchedule",
       "type": "object",
@@ -2109,12 +2209,17 @@
           "title": "Id",
           "type": "string"
         },
+        "created": {
+          "title": "Created",
+          "type": "integer"
+        },
         "items": {
           "$ref": "#/$defs/Items"
         }
       },
       "required": [
         "id",
+        "created",
         "items"
       ],
       "title": "SubscriptionItems",
@@ -2157,7 +2262,7 @@
         }
       },
       "additionalProperties": true,
-      "description": "Child Stream\nParent Stream: SubscriptionItems",
+      "description": "Parent Stream: SubscriptionItems",
       "properties": {
         "_meta": {
           "allOf": [
@@ -2240,10 +2345,15 @@
         "id": {
           "title": "Id",
           "type": "string"
+        },
+        "created": {
+          "title": "Created",
+          "type": "integer"
         }
       },
       "required": [
-        "id"
+        "id",
+        "created"
       ],
       "title": "TopUps",
       "type": "object",
@@ -2301,10 +2411,15 @@
         "id": {
           "title": "Id",
           "type": "string"
+        },
+        "created": {
+          "title": "Created",
+          "type": "integer"
         }
       },
       "required": [
-        "id"
+        "id",
+        "created"
       ],
       "title": "Transfers",
       "type": "object",
@@ -2346,7 +2461,7 @@
         }
       },
       "additionalProperties": true,
-      "description": "Child Stream\nParent Stream: Transfers",
+      "description": "Parent Stream: Transfers",
       "properties": {
         "_meta": {
           "allOf": [
@@ -2425,10 +2540,15 @@
         "id": {
           "title": "Id",
           "type": "string"
+        },
+        "created": {
+          "title": "Created",
+          "type": "integer"
         }
       },
       "required": [
-        "id"
+        "id",
+        "created"
       ],
       "title": "Files",
       "type": "object",
@@ -2487,10 +2607,15 @@
         "id": {
           "title": "Id",
           "type": "string"
+        },
+        "created": {
+          "title": "Created",
+          "type": "integer"
         }
       },
       "required": [
-        "id"
+        "id",
+        "created"
       ],
       "title": "FilesLink",
       "type": "object",
@@ -2549,10 +2674,15 @@
         "id": {
           "title": "Id",
           "type": "string"
+        },
+        "created": {
+          "title": "Created",
+          "type": "integer"
         }
       },
       "required": [
-        "id"
+        "id",
+        "created"
       ],
       "title": "BalanceTransactions",
       "type": "object",

--- a/source-stripe-native/tests/snapshots/snapshots__spec__stdout.json
+++ b/source-stripe-native/tests/snapshots/snapshots__spec__stdout.json
@@ -36,11 +36,10 @@
           ],
           "title": "API Key"
         },
-        "stop_date": {
-          "default": "2010-01-01T00:00:00Z",
-          "description": "Replication Stop Date. Records will only be considered for backfilling before the stop_date, similar to a start date",
+        "start_date": {
+          "description": "UTC data and time in the format YYYY-MM-DDTHH:MM:SSZ. Any data generated before this date will not be replicated. If left blank, the start date will be set to 30 days before the present date. ",
           "format": "date-time",
-          "title": "Stop Date",
+          "title": "Start Date",
           "type": "string"
         }
       },


### PR DESCRIPTION
**Description:**

This PR covers a handful of quick updates:
- Remove a redundant line in the GH python workflow.
- Rename the config's `stop_date` to `start_date`.
  - Update the default `start_date` to be 30 days in the past rather than a fixed date in 2010.
- Improve typing.
  - Create classes that contain shared attributes among models.
  - Add typing to `fetch_*` functions in `api.py`.
- Minor refactors related to variable naming & reuse that improve readability.


Spec snapshot changes are expected due to the `start_date` updates. 

Discover snapshot changes are expected due to the new classes containing shared attributes. The `created` field exists on all non-child streams' documents, and we were already relying on `created` to know when to stop backfilling. Making `created` explicit in the model improves Python's type checking.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

Tested locally & confirmed start date field renders correctly in the UI. Also confirmed tasks are created without issue, and streams still backfill & incrementally replicate for a short time span.

After merging, existing tasks will need updated to rename their `stop_date` to `start_date`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1969)
<!-- Reviewable:end -->
