### PR TITLE
materialize-snowflake: percent encode username + password input

### DIFF
--- a/materialize-snowflake/.snapshots/TestConfigURI-User_&_Password_Authentication
+++ b/materialize-snowflake/.snapshots/TestConfigURI-User_&_Password_Authentication
@@ -1,0 +1,1 @@
+will:some%2Bcomplex%2Fpassword@orgname-accountname.snowflakecomputing.com:443?GO_QUERY_RESULT_FORMAT=json&MULTI_STATEMENT_COUNT=0&application=mytenant_EstuaryFlow&client_session_keep_alive=true&database=mydb&schema=myschema

--- a/materialize-snowflake/.snapshots/TestConfigURI-v1_User_&_Password_Authentication
+++ b/materialize-snowflake/.snapshots/TestConfigURI-v1_User_&_Password_Authentication
@@ -1,1 +1,0 @@
-alex:mysecret@orgname-accountname.snowflakecomputing.com:443?GO_QUERY_RESULT_FORMAT=json&MULTI_STATEMENT_COUNT=0&application=mytenant_EstuaryFlow&client_session_keep_alive=true&database=mydb&schema=myschema

--- a/materialize-snowflake/.snapshots/TestConfigURI-v2_User_&_Password_Authentication
+++ b/materialize-snowflake/.snapshots/TestConfigURI-v2_User_&_Password_Authentication
@@ -1,1 +1,0 @@
-will:password@orgname-accountname.snowflakecomputing.com:443?GO_QUERY_RESULT_FORMAT=json&MULTI_STATEMENT_COUNT=0&application=mytenant_EstuaryFlow&client_session_keep_alive=true&database=mydb&schema=myschema

--- a/materialize-snowflake/config.go
+++ b/materialize-snowflake/config.go
@@ -69,8 +69,9 @@ func (c *config) toURI(tenant string) (string, error) {
 	}
 
 	// Authentication
+	var user string
 	if c.Credentials.AuthType == UserPass {
-		uri.User = url.UserPassword(c.Credentials.User, c.Credentials.Password)
+		user = url.QueryEscape(c.Credentials.User) + ":" + url.QueryEscape(c.Credentials.Password)
 	} else if c.Credentials.AuthType == JWT {
 		// We run this as part of validate to ensure that there is no error, so
 		// this is not expected to error here.
@@ -83,12 +84,12 @@ func (c *config) toURI(tenant string) (string, error) {
 			queryParams.Add("privateKey", privateKeyString)
 			queryParams.Add("authenticator", strings.ToLower(sf.AuthTypeJwt.String()))
 		}
-		uri.User = url.User(c.Credentials.User)
+		user = url.QueryEscape(c.Credentials.User)
 	} else {
 		return "", fmt.Errorf("unknown auth type: %s", c.Credentials.AuthType)
 	}
 
-	dsn := uri.User.String() + "@" + uri.Hostname() + ":" + uri.Port() + "?" + queryParams.Encode()
+	dsn := user + "@" + uri.Hostname() + ":" + uri.Port() + "?" + queryParams.Encode()
 	return dsn, nil
 }
 

--- a/materialize-snowflake/config_test.go
+++ b/materialize-snowflake/config_test.go
@@ -9,14 +9,14 @@ import (
 
 func TestConfigURI(t *testing.T) {
 	for name, cfg := range map[string]config{
-		"v2 User & Password Authentication": {
+		"User & Password Authentication": {
 			Host:     "orgname-accountname.snowflakecomputing.com",
 			Database: "mydb",
 			Schema:   "myschema",
 			Credentials: credentialConfig{
 				UserPass,
 				"will",
-				"password",
+				"some+complex/password",
 				"non-existant-jwt",
 			},
 		},


### PR DESCRIPTION
**Description:**

The user/password encoding that `uri.User.String()` uses is actually slightly different than `url.QueryEscape()`, and the latter is what is needed to handle inputs with special characters to build a compatible Snowflake DSN.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1972)
<!-- Reviewable:end -->
