### PR TITLE
source-hubspot-native: ignore extra associations page results

### DIFF
--- a/source-hubspot-native/source_hubspot_native/models.py
+++ b/source-hubspot-native/source_hubspot_native/models.py
@@ -230,6 +230,16 @@ class Association(BaseModel, extra="forbid"):
     # TODO(johnny): This can potentially have a `pager`, but I'm leaving it out
     # to see if it's ever encountered. If it is, I think we handle by ignoring
     # it and having a position of "we'll get (only) the first page".
+    # TODO(whb): We did encounter this, and for now have decided to ignore any
+    # extra pages.
+    class Cursor(BaseModel, extra="forbid"):
+        after: str
+        link: str
+
+    class Paging(BaseModel, extra="forbid"):
+        next: "Association.Cursor"
+
+    paging: Paging | None = None
 
 
 # An unconstrained Item type.


### PR DESCRIPTION
**Description:**

This has been observed in a production task, and for now we will not capture associations beyond the first page. This could be reconsidered in the future.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1974)
<!-- Reviewable:end -->
