### PR TITLE
source-postgres: Exclude `pglogical` schema from discovery

### DIFF
--- a/source-postgres/discovery.go
+++ b/source-postgres/discovery.go
@@ -348,7 +348,7 @@ const queryDiscoverTables = `
   SELECT n.nspname, c.relname
   FROM pg_catalog.pg_class c
   JOIN pg_catalog.pg_namespace n ON (n.oid = c.relnamespace)
-  WHERE n.nspname NOT IN ('pg_catalog', 'pg_internal', 'information_schema', 'catalog_history', 'cron')
+  WHERE n.nspname NOT IN ('pg_catalog', 'pg_internal', 'information_schema', 'catalog_history', 'cron', 'pglogical')
     AND NOT c.relispartition
     AND c.relkind IN ('r', 'p');` // 'r' means "Ordinary Table" and 'p' means "Partitioned Table"
 


### PR DESCRIPTION
**Description:**

This is a "system schema" added by the pglogical extension [1] and I don't believe the typical user who happens to have that extension installed wants these tables captured in the first place.

[1] https://www.2ndquadrant.com/en/resources-old/pglogical/pglogical-docs/

**Workflow steps:**

Discovery will no longer produce bindings for tables in the `pglogical` schema in cases where previously it did.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1975)
<!-- Reviewable:end -->
