### PR TITLE
source-stripe-native: make created optional for Accounts

### DIFF
--- a/source-stripe-native/source_stripe_native/models.py
+++ b/source-stripe-native/source_stripe_native/models.py
@@ -151,6 +151,12 @@ class Accounts(BaseStripeObjectWithEvents):
         "account.updated": "u",
     }
 
+    # Accounts docs returned in account.updated events may not have a created field.
+    created: int = Field(
+        default=None,
+        # Don't schematize the default value.
+        json_schema_extra=lambda x: x.pop('default') # type: ignore
+    )
 
 # Could not verify Persons events are generated in test mode, but suspect
 # they are generated in Stripe's live mode.

--- a/source-stripe-native/tests/snapshots/snapshots__discover__stdout.json
+++ b/source-stripe-native/tests/snapshots/snapshots__discover__stdout.json
@@ -59,8 +59,7 @@
       },
       "required": [
         "id",
-        "object",
-        "created"
+        "object"
       ],
       "title": "Accounts",
       "type": "object",


### PR DESCRIPTION
**Description:**

Sometimes, `account.updated` events do not have a `created` field in the document, causing failures when we validate the document against its model. Making `created` optional will avoid these failures and reflect the API's actual response. The default value of `None` is removed from the schema to keep it aligned with how we understand the `created` field: it's either present as an `int` or it's not present at all. In other words, it's an optional, non-nullable field.

Note: I've only noted that this occurs for `account.updated` events for when the user's own Stripe account is created. I couldn't confirm if all `account.updated` events have `created` missing in the document, or if `Accounts` documents really don't have `created` fields at all. If this becomes an issue later, we will need to re-evaluate how we backfill `Accounts` since we rely on a `created` field being present.

Discover snapshot change is expected due to switching `created` from a required field to an optional field for `Accounts`.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

Tested on a local stack. Confirmed `Accounts` does not cause shard failures when `account.updated` events do not have a `created` field in the document.

Existing tasks will need to be re-discovered since we're changing `created` from required to optional for `Accounts`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1978)
<!-- Reviewable:end -->
