### PR TITLE
source-impact-native: switching snapshots pk to _meta/row_id

### DIFF
--- a/source-impact-native/source_impact_native/models.py
+++ b/source-impact-native/source_impact_native/models.py
@@ -64,9 +64,7 @@ class Ads(BaseDocument, extra="allow"):
     START_DATE_INCREMENTAL: ClassVar[str]  = None
     END_DATE: ClassVar[str] = ""
     REP_KEY: ClassVar[str] = ""
-    PRIMARY_KEY: ClassVar[str] = "/Id"
-
-    Id: str
+    PRIMARY_KEY: ClassVar[str] = "/_meta/row_id"
 
 class Catalogs(BaseDocument, extra="allow"):
     NAME: ClassVar[str] = "Catalogs"
@@ -74,9 +72,7 @@ class Catalogs(BaseDocument, extra="allow"):
     START_DATE_INCREMENTAL: ClassVar[str]  = None
     END_DATE: ClassVar[str] = ""
     REP_KEY: ClassVar[str] = ""
-    PRIMARY_KEY: ClassVar[str] = "/Id"
-
-    Id: str
+    PRIMARY_KEY: ClassVar[str] = "/_meta/row_id"
 
 class Invoices(BaseDocument, extra="allow"):
     NAME: ClassVar[str] = "Invoices"
@@ -137,9 +133,8 @@ class Campaigns(BaseDocument, extra="allow"):
     START_DATE: ClassVar[str] = ""
     END_DATE: ClassVar[str] = ""
     REP_KEY: ClassVar[str] = ""
-    PRIMARY_KEY: ClassVar[str] = "/Id"
+    PRIMARY_KEY: ClassVar[str] = "/_meta/row_id"
 
-    Id: str
 
 class Reports(BaseDocument, extra="allow"):
     # No query parameters available, and no date replication key
@@ -167,9 +162,7 @@ class PhoneNumbers(BaseDocument, extra="allow"):
     START_DATE: ClassVar[str] = ""
     END_DATE: ClassVar[str] = ""
     REP_KEY: ClassVar[str] = "DateCreated"
-    PRIMARY_KEY: ClassVar[str] = "/Id"
-
-    Id: str
+    PRIMARY_KEY: ClassVar[str] = "/_meta/row_id"
 
 class PromoCodes(BaseDocument, extra="allow"):
     NAME: ClassVar[str] = "PromoCodes"
@@ -218,9 +211,7 @@ class MediaPartnerGroups(BaseDocument, extra="allow"):
     START_DATE: ClassVar[str] = ""
     END_DATE: ClassVar[str] = ""
     REP_KEY: ClassVar[str] = ""
-    PRIMARY_KEY: ClassVar[str] = "/Id"
-
-    Id: str
+    PRIMARY_KEY: ClassVar[str] = "/_meta/row_id"
 
 class Notes(BaseDocument, extra="allow"):
     NAME: ClassVar[str] = "Notes"

--- a/source-impact-native/tests/snapshots/source_impact_native_tests_test_snapshots__discover__stdout.json
+++ b/source-impact-native/tests/snapshots/source_impact_native_tests_test_snapshots__discover__stdout.json
@@ -592,21 +592,14 @@
             "row_id": -1
           },
           "description": "Document metadata"
-        },
-        "Id": {
-          "title": "Id",
-          "type": "string"
         }
       },
-      "required": [
-        "Id"
-      ],
       "title": "Campaigns",
       "type": "object",
       "x-infer-schema": true
     },
     "key": [
-      "/Id"
+      "/_meta/row_id"
     ]
   },
   {
@@ -653,21 +646,14 @@
             "row_id": -1
           },
           "description": "Document metadata"
-        },
-        "Id": {
-          "title": "Id",
-          "type": "string"
         }
       },
-      "required": [
-        "Id"
-      ],
       "title": "Ads",
       "type": "object",
       "x-infer-schema": true
     },
     "key": [
-      "/Id"
+      "/_meta/row_id"
     ]
   },
   {
@@ -714,21 +700,14 @@
             "row_id": -1
           },
           "description": "Document metadata"
-        },
-        "Id": {
-          "title": "Id",
-          "type": "string"
         }
       },
-      "required": [
-        "Id"
-      ],
       "title": "Catalogs",
       "type": "object",
       "x-infer-schema": true
     },
     "key": [
-      "/Id"
+      "/_meta/row_id"
     ]
   },
   {
@@ -829,21 +808,14 @@
             "row_id": -1
           },
           "description": "Document metadata"
-        },
-        "Id": {
-          "title": "Id",
-          "type": "string"
         }
       },
-      "required": [
-        "Id"
-      ],
       "title": "PhoneNumbers",
       "type": "object",
       "x-infer-schema": true
     },
     "key": [
-      "/Id"
+      "/_meta/row_id"
     ]
   },
   {
@@ -1134,21 +1106,14 @@
             "row_id": -1
           },
           "description": "Document metadata"
-        },
-        "Id": {
-          "title": "Id",
-          "type": "string"
         }
       },
-      "required": [
-        "Id"
-      ],
       "title": "MediaPartnerGroups",
       "type": "object",
       "x-infer-schema": true
     },
     "key": [
-      "/Id"
+      "/_meta/row_id"
     ]
   }
 ]


### PR DESCRIPTION
after fixing the tombstone value with the correct class, the connector still broke due to tombstone failures. The newer bugs happened because there were still a pk required that was not being fed to the newer tombstone model. In order to fix that, i've removed all previous pk from snapshot models and fixated all pks to _meta/row_id ( the default strategy )


**Notes for reviewers:**

All changes were tested using a local flow instance, and materialized to a free-tier neon POSTGRES db
All snapshot streams were tested and materialized

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1980)
<!-- Reviewable:end -->
