### PR TITLE
source-stripe-native: handle responses for children of deleted resources

### DIFF
--- a/source-stripe-native/source_stripe_native/models.py
+++ b/source-stripe-native/source_stripe_native/models.py
@@ -428,7 +428,6 @@ class InvoiceLineItems(BaseStripeChildObject):
     EVENT_TYPES: ClassVar[dict[str, Literal["c", "u", "d"]]] = {
         "invoice.created": "c",
         "invoice.updated": "u",
-        "invoice.deleted": "d",
     }
 
 


### PR DESCRIPTION
**Description:**

Child streams, like `InvoiceLineItems` perform incremental replication by watching for events on their associated parent resource, then requesting all child resources for that parent when an event happens. However, since there can be some time between when we process an event & what actually happens in Stripe, it's possible for us to request child resources of a deleted parent. Stripe returns a `404` code and somewhat unique text to indicate this. We can safely skip requesting these resources when this happens.

This situation can happen if a creation/update is quickly followed by a deletion. If the connector is stuck for a while and a backlog of events we haven't processed builds up, there's even more opportunity for us to request deleted resources.

I noticed this issue happening with `InvoiceLineItems`, so I also removed the "invoice.deleted" event from that stream's `EVENT_TYPES` since we'll just get an error back if we request a deleted invoice's line items.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

Tested on a local stack. Confirmed that requesting children of a deleted parent resource no longer crashes the connector & that the connector continues processing after handling the error.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1982)
<!-- Reviewable:end -->
