### PR TITLE
materialize-redshift: Switch to writing checkpoints using LZ4 compression

### DIFF
--- a/materialize-redshift/.snapshots/TestSQLGeneration
+++ b/materialize-redshift/.snapshots/TestSQLGeneration
@@ -148,7 +148,7 @@ WHERE "a-schema".key_value.key1 = r.key1 AND "a-schema".key_value.key2 = r.key2 
 
 --- Begin Fence Update ---
 UPDATE path."to".checkpoints
-	SET   checkpoint = 'AAECAwQFBgcICQ=='
+	SET   checkpoint = 'BCJNGGRwuQoAAIAAAQIDBAUGBwgJAAAAAKaizGw='
 	WHERE materialization = 'some/Materialization'
 	AND   key_begin = 1122867
 	AND   key_end   = 4293844428

--- a/materialize-redshift/sqlgen.go
+++ b/materialize-redshift/sqlgen.go
@@ -290,7 +290,7 @@ SELECT * FROM (SELECT -1, CAST(NULL AS SUPER) LIMIT 0) as nodoc
 
 {{ define "updateFence" }}
 UPDATE {{ Identifier $.TablePath }}
-	SET   checkpoint = {{ Literal (Base64Std $.Checkpoint) }}
+	SET   checkpoint = {{ Literal (LZ4Compress $.Checkpoint | Base64Std) }}
 	WHERE materialization = {{ Literal $.Materialization.String }}
 	AND   key_begin = {{ $.KeyBegin }}
 	AND   key_end   = {{ $.KeyEnd }}


### PR DESCRIPTION
The motivation for this change is to enable more bindings in a redshift materialization. It should be backwards-compatible in that it supports loading checkpoints in either base64 or LZ4 formats, but will always write new checkpoint data in LZ4.

### 🚨 Do not merge yet 🚨

I have not tested this yet. I need to figure out how to set up a redshift account, run the connector, test that it upgrades from base64 to lz4 correctly, etc.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1985)
<!-- Reviewable:end -->
