### PR TITLE
source-http-ingest: Stop using serde_json::Value

### DIFF
--- a/source-http-ingest/Cargo.lock
+++ b/source-http-ingest/Cargo.lock
@@ -340,6 +340,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8318a53db07bb3f8dca91a600466bdb3f2eaadeedfdbcf02e1accbad9271ba50"
 
 [[package]]
+name = "caseless"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "808dab3318747be122cb31d36de18d4d1c81277a76f8332a02b81a3d73463d7f"
+dependencies = [
+ "regex",
+ "unicode-normalization",
+]
+
+[[package]]
 name = "cc"
 version = "1.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -846,6 +856,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
+name = "humantime"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
+
+[[package]]
+name = "humantime-serde"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57a3db5ea5923d99402c94e9feb261dc5ee9b4efa158b0315f788cf549cc200c"
+dependencies = [
+ "humantime",
+ "serde",
+]
+
+[[package]]
 name = "hyper"
 version = "0.14.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -929,6 +955,17 @@ dependencies = [
 
 [[package]]
 name = "idna"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "418a0a6fab821475f634efe3ccc45c013f742efe03d853e8d3355d5cb850ecf8"
+dependencies = [
+ "matches",
+ "unicode-bidi",
+ "unicode-normalization",
+]
+
+[[package]]
+name = "idna"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "634d9b1461af396cad843f47fdba5597a4f9e6ddd4bfb6ff5d85028c25cb12f6"
@@ -936,6 +973,12 @@ dependencies = [
  "unicode-bidi",
  "unicode-normalization",
 ]
+
+[[package]]
+name = "if_chain"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb56e1aa765b4b4f3aadfab769793b7087bb03a4ea4920644a6d238e2df5b9ed"
 
 [[package]]
 name = "indexmap"
@@ -1143,6 +1186,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "matches"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2532096657941c2fea9c289d370a250971c689d4f143798ff67113ec042024a5"
+
+[[package]]
 name = "matchit"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1189,6 +1238,26 @@ dependencies = [
  "libc",
  "wasi",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "models"
+version = "0.0.0"
+source = "git+https://github.com/estuary/flow#af95f7b986e6abb37328161ed91ee8202a2fa841"
+dependencies = [
+ "caseless",
+ "humantime-serde",
+ "lazy_static",
+ "regex",
+ "schemars",
+ "serde",
+ "serde_json",
+ "superslice",
+ "time",
+ "unicode-normalization",
+ "url",
+ "uuid",
+ "validator",
 ]
 
 [[package]]
@@ -2198,6 +2267,7 @@ dependencies = [
  "insta",
  "json",
  "lazy_static",
+ "models",
  "proto-flow",
  "reqwest 0.11.27",
  "schemars",
@@ -2226,6 +2296,12 @@ name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
+name = "superslice"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab16ced94dbd8a46c82fd81e3ed9a8727dac2977ea869d217bcc4ea1f122e81f"
 
 [[package]]
 name = "syn"
@@ -2639,7 +2715,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22784dbdf76fdde8af1aeda5622b546b422b6fc585325248a2bf9f5e41e94d6c"
 dependencies = [
  "form_urlencoded",
- "idna",
+ "idna 0.5.0",
  "percent-encoding",
  "serde",
 ]
@@ -2695,6 +2771,48 @@ checksum = "81dfa00651efa65069b0b6b651f4aaa31ba9e3c3ce0137aaad053604ee7e0314"
 dependencies = [
  "getrandom",
  "serde",
+]
+
+[[package]]
+name = "validator"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f07b0a1390e01c0fc35ebb26b28ced33c9a3808f7f9fbe94d3cc01e233bfeed5"
+dependencies = [
+ "idna 0.2.3",
+ "lazy_static",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "url",
+ "validator_derive",
+]
+
+[[package]]
+name = "validator_derive"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea7ed5e8cf2b6bdd64a6c4ce851da25388a89327b17b88424ceced6bd5017923"
+dependencies = [
+ "if_chain",
+ "lazy_static",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "syn 1.0.109",
+ "validator_types",
+]
+
+[[package]]
+name = "validator_types"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2ddf34293296847abfc1493b15c6e2f5d3cd19f57ad7d22673bf4c6278da329"
+dependencies = [
+ "proc-macro2",
+ "syn 1.0.109",
 ]
 
 [[package]]

--- a/source-http-ingest/Cargo.lock
+++ b/source-http-ingest/Cargo.lock
@@ -62,6 +62,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator"
+version = "0.0.0"
+source = "git+https://github.com/estuary/flow#af95f7b986e6abb37328161ed91ee8202a2fa841"
+dependencies = [
+ "jemalloc-ctl",
+ "jemallocator",
+ "lazy_static",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -462,7 +472,7 @@ dependencies = [
 [[package]]
 name = "doc"
 version = "0.0.0"
-source = "git+https://github.com/estuary/flow#5452270e8b02d409763da616f53c6479d7d31405"
+source = "git+https://github.com/estuary/flow#af95f7b986e6abb37328161ed91ee8202a2fa841"
 dependencies = [
  "base64 0.13.1",
  "bigdecimal",
@@ -577,6 +587,12 @@ checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "funty"
@@ -986,6 +1002,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
+name = "jemalloc-ctl"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c502a5ff9dd2924f1ed32ba96e3b65735d837b4bfd978d3161b1702e66aca4b7"
+dependencies = [
+ "jemalloc-sys",
+ "libc",
+ "paste",
+]
+
+[[package]]
+name = "jemalloc-sys"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d3b9f3f5c9b31aa0f5ed3260385ac205db665baa41d49bb8338008ae94ede45"
+dependencies = [
+ "cc",
+ "fs_extra",
+ "libc",
+]
+
+[[package]]
+name = "jemallocator"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43ae63fcfc45e99ab3d1b29a46782ad679e98436c3169d15a167a1108a724b69"
+dependencies = [
+ "jemalloc-sys",
+ "libc",
+]
+
+[[package]]
 name = "jobserver"
 version = "0.1.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1006,7 +1054,7 @@ dependencies = [
 [[package]]
 name = "json"
 version = "0.0.0"
-source = "git+https://github.com/estuary/flow#5452270e8b02d409763da616f53c6479d7d31405"
+source = "git+https://github.com/estuary/flow#af95f7b986e6abb37328161ed91ee8202a2fa841"
 dependencies = [
  "addr",
  "bigdecimal",
@@ -1259,6 +1307,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "paste"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45ca20c77d80be666aef2b45486da86238fabe33e38306bd3118fe4af33fa880"
+dependencies = [
+ "paste-impl",
+ "proc-macro-hack",
+]
+
+[[package]]
+name = "paste-impl"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d95a7db200b97ef370c8e6de0088252f7e0dfff7d047a28528e47456c0fc98b6"
+dependencies = [
+ "proc-macro-hack",
+]
+
+[[package]]
 name = "pbjson"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1408,6 +1475,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-hack"
+version = "0.5.20+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068"
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1472,12 +1545,12 @@ dependencies = [
 [[package]]
 name = "proto-build"
 version = "0.0.0"
-source = "git+https://github.com/estuary/flow#5452270e8b02d409763da616f53c6479d7d31405"
+source = "git+https://github.com/estuary/flow#af95f7b986e6abb37328161ed91ee8202a2fa841"
 
 [[package]]
 name = "proto-flow"
 version = "0.0.0"
-source = "git+https://github.com/estuary/flow#5452270e8b02d409763da616f53c6479d7d31405"
+source = "git+https://github.com/estuary/flow#af95f7b986e6abb37328161ed91ee8202a2fa841"
 dependencies = [
  "bytes",
  "pbjson",
@@ -1496,7 +1569,7 @@ dependencies = [
 [[package]]
 name = "proto-gazette"
 version = "0.0.0"
-source = "git+https://github.com/estuary/flow#5452270e8b02d409763da616f53c6479d7d31405"
+source = "git+https://github.com/estuary/flow#af95f7b986e6abb37328161ed91ee8202a2fa841"
 dependencies = [
  "bytes",
  "pbjson",
@@ -2115,6 +2188,7 @@ dependencies = [
 name = "source-http-ingest"
 version = "0.1.0"
 dependencies = [
+ "allocator",
  "anyhow",
  "async-trait",
  "axum",
@@ -2510,7 +2584,7 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 [[package]]
 name = "tuple"
 version = "0.0.0"
-source = "git+https://github.com/estuary/flow#5452270e8b02d409763da616f53c6479d7d31405"
+source = "git+https://github.com/estuary/flow#af95f7b986e6abb37328161ed91ee8202a2fa841"
 dependencies = [
  "memchr",
  "serde_json",
@@ -2768,7 +2842,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/source-http-ingest/Cargo.toml
+++ b/source-http-ingest/Cargo.toml
@@ -5,9 +5,12 @@ edition = "2021"
 
 
 [dependencies]
+allocator = { git = "https://github.com/estuary/flow" }
 doc = { git = "https://github.com/estuary/flow" }
 json = { git = "https://github.com/estuary/flow" }
-proto-flow = { git = "https://github.com/estuary/flow", features = ["generate"] }
+proto-flow = { git = "https://github.com/estuary/flow", features = [
+    "generate",
+] }
 
 anyhow = "1.0"
 async-trait = "0.1"
@@ -16,10 +19,7 @@ futures = "0.3"
 http = "1.0"
 schemars = "0.8"
 serde = "1.0"
-serde_json = { version = "1.0", features = [
-    "raw_value",
-    "float_roundtrip"
-] }
+serde_json = { version = "1.0", features = ["raw_value", "float_roundtrip"] }
 tokio = { version = "1", features = ["full"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = [

--- a/source-http-ingest/Cargo.toml
+++ b/source-http-ingest/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2021"
 allocator = { git = "https://github.com/estuary/flow" }
 doc = { git = "https://github.com/estuary/flow" }
 json = { git = "https://github.com/estuary/flow" }
+models = { git = "https://github.com/estuary/flow" }
 proto-flow = { git = "https://github.com/estuary/flow", features = [
     "generate",
 ] }

--- a/source-http-ingest/src/main.rs
+++ b/source-http-ingest/src/main.rs
@@ -1,3 +1,6 @@
+// Links in the allocator crate, which sets the global allocator to jemalloc
+extern crate allocator;
+
 use anyhow::Context;
 use source_http_ingest::run_connector;
 use tokio::io;

--- a/source-http-ingest/src/server.rs
+++ b/source-http-ingest/src/server.rs
@@ -9,7 +9,8 @@ use axum::{
 use doc::Annotation;
 use http::status::StatusCode;
 use json::validator::Validator;
-use serde_json::{value::RawValue, Value};
+use models::RawValue;
+use serde_json::Value;
 use tower_http::decompression::RequestDecompressionLayer;
 use utoipa::openapi::{self, schema, security, OpenApi, OpenApiBuilder};
 use utoipa_swagger_ui::SwaggerUi;
@@ -173,8 +174,7 @@ impl CollectionHandler {
             meta.insert(properties::QUERY.to_string(), Value::Object(query_params));
         }
 
-        let meta_value =
-            serde_json::value::to_raw_value(&meta).context("serializing _meta object")?;
+        let meta_value = models::RawValue::from_value(&Value::Object(meta));
         object.insert(properties::META.to_string(), meta_value);
 
         let serialized = serde_json::to_string(&object).context("serializing prepared document")?;
@@ -685,7 +685,7 @@ fn new_uuid() -> String {
     uuid::Uuid::new_v4().to_string()
 }
 
-type JsonObj = BTreeMap<String, Box<RawValue>>;
+type JsonObj = BTreeMap<String, RawValue>;
 
 #[derive(serde::Deserialize)]
 #[serde(untagged)]

--- a/source-http-ingest/tests/test.rs
+++ b/source-http-ingest/tests/test.rs
@@ -57,6 +57,7 @@ async fn test_http_request_processing() -> Result<(), anyhow::Error> {
         // needing to figure out what it is by parsing log output.
         .env("SOURCE_HTTP_INGEST_PORT", "27172")
         .env("LOG_LEVEL", "debug")
+        .env("RUST_BACKTRACE", "1")
         .spawn()?;
 
     let stdin = child.stdin.take().unwrap();


### PR DESCRIPTION
Removes the use of `serde_json::Value` for parsed documents, and instead use `RawValue` as much as possible. This is done in order to reduce memory usage, as the overhead of `Value` is quite high.

Also changes to using a `String` to represent the fully prepared documents to be captured. This allows us to skip an extra serialization step since the capture protocol requires these documents to be `String`s anyway.

This unfortunately required changing how we validate documents, since the `doc::Validator` can only be used with parsed documents. So we instead use a `json::Validator`, which can validate the `String` directly.

Also changes to using jemalloc instead of the system allocator.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1987)
<!-- Reviewable:end -->
