### PR TITLE
source-zendesk-support: update ticket_skips schema

### DIFF
--- a/source-zendesk-support/acmeCo/posts.schema.yaml
+++ b/source-zendesk-support/acmeCo/posts.schema.yaml
@@ -19,6 +19,7 @@ properties:
       type:
         - "null"
         - number
+        - string
   featured:
     type:
       - "null"

--- a/source-zendesk-support/acmeCo/ticket_metrics.schema.yaml
+++ b/source-zendesk-support/acmeCo/ticket_metrics.schema.yaml
@@ -126,6 +126,15 @@ properties:
         type:
           - "null"
           - integer
+  reply_time_in_seconds:
+    type:
+      - "null"
+      - object
+    properties:
+      calendar:
+        type:
+          - "null"
+          - integer
   requester_updated_at:
     type:
       - "null"

--- a/source-zendesk-support/acmeCo/ticket_skips.schema.yaml
+++ b/source-zendesk-support/acmeCo/ticket_skips.schema.yaml
@@ -63,9 +63,14 @@ properties:
                 - "null"
                 - integer
             value:
+              items:
+                type:
+                  - "null"
+                  - string
               type:
                 - "null"
                 - string
+                - array
           type:
             - "null"
             - object

--- a/source-zendesk-support/source_zendesk_support/schemas/ticket_skips.json
+++ b/source-zendesk-support/source_zendesk_support/schemas/ticket_skips.json
@@ -75,9 +75,16 @@
                   ]
                 },
                 "value": {
+                  "items": {
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                  },
                   "type": [
                     "null",
-                    "string"
+                    "string",
+                    "array"
                   ]
                 }
               },

--- a/source-zendesk-support/tests/snapshots/snapshots__capture__capture.stdout.json
+++ b/source-zendesk-support/tests/snapshots/snapshots__capture__capture.stdout.json
@@ -75,17 +75,19 @@
         "uuid": "DocUUIDPlaceholder-329Bb50aa48EAa9ef"
       },
       "created_at": "2024-07-26T15:41:00Z",
-      "details": null,
+      "details": "",
       "domain_names": [],
       "external_id": null,
       "group_id": null,
       "id": 28835714737428,
       "name": "Estuary",
-      "notes": null,
+      "notes": "",
       "organization_fields": {},
       "shared_comments": false,
       "shared_tickets": false,
-      "tags": [],
+      "tags": [
+        "test-tag"
+      ],
       "updated_at": "redacted",
       "url": "https://d3v-estuary.zendesk.com/api/v2/organizations/28835714737428.json"
     }
@@ -301,8 +303,8 @@
         "row_id": 0,
         "uuid": "DocUUIDPlaceholder-329Bb50aa48EAa9ef"
       },
-      "count": 1,
-      "name": "assembly"
+      "name": "redacted",
+      "count": 1
     }
   ],
   [

--- a/source-zendesk-support/tests/snapshots/snapshots__discover__capture.stdout.json
+++ b/source-zendesk-support/tests/snapshots/snapshots__discover__capture.stdout.json
@@ -3369,9 +3369,16 @@
                     ]
                   },
                   "value": {
+                    "items": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
                     "type": [
                       "null",
-                      "string"
+                      "string",
+                      "array"
                     ]
                   }
                 },

--- a/source-zendesk-support/tests/test_snapshots.py
+++ b/source-zendesk-support/tests/test_snapshots.py
@@ -30,13 +30,20 @@ def test_capture(request, snapshot):
             seen.add(stream)
 
     for l in unique_stream_lines:
-        _, rec = l[0], l[1]
+        stream, rec = l[0], l[1]
 
         rec['_meta']['row_id'] = 0
         if "updated_at" in rec:
             rec["updated_at"] = "redacted"
         if "last_login_at" in rec:
             rec["last_login_at"] = "redacted"
+        if stream == "acmeCo/tags":
+            rec["name"] = "redacted"
+            # Updating count with rec["count"] = 1 sets count to be
+            # the tuple [1] instead of the int 1. We can get around
+            # this by deleting the attribute then re-setting it.
+            del rec["count"]
+            rec["count"] = 1
 
 
     assert snapshot("capture.stdout.json") == unique_stream_lines


### PR DESCRIPTION
**Description:**

We have encountered schema violations for `ticket_skips` where a custom field's value is an array of strings. The `ticket_skips.json` schema has been updated to allow this.

I missed updating `posts.schema.yaml` and `ticket_metrics.schema.yaml` in previous PRs, so I've updated them now. Those previous PRs are:
- https://github.com/estuary/connectors/pull/1807 (posts)
- https://github.com/estuary/connectors/pull/1917 (ticket_metrics)

The capture snapshot test has also been flaky because Zendesk Support seems to delete & re-add the default tag I assumed would always be present. I added an organization tag in our Zendesk Support testing account to ensure a tag will always be present, and I redacted the tag fields in the capture snapshot so the test is more reliable.

Discover snapshot changes are expected due to making the `ticket_skips` schema more permissive. Capture snapshot changes are expected due to adding an organization tag in our Zendesk Support testing account & redacting tag fields in the snapshot. 

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

Tested on a local stack. Confirmed the connector no longer crashes when `ticket_skips` encounters a document with a custom field value that's an array of strings.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1988)
<!-- Reviewable:end -->
