### PR TITLE
source-zendesk-support: update capture snapshot

### DIFF
--- a/source-zendesk-support/tests/snapshots/snapshots__capture__capture.stdout.json
+++ b/source-zendesk-support/tests/snapshots/snapshots__capture__capture.stdout.json
@@ -803,6 +803,10 @@
         "end_user_list_access": "full",
         "end_user_profile_access": "readonly",
         "explore_access": "readonly",
+        "explore_reports": {
+          "ticket_access": "all",
+          "ticket_access_selected_groups": []
+        },
         "forum_access": "readonly",
         "forum_access_restricted_content": false,
         "group_access": false,


### PR DESCRIPTION
**Description:**

Over the weekend, it looks like Zendesk Support added a `configuration.explore_reports` field to all custom roles returned via their API. This is causing our `source-zendesk-support` capture snapshot test to fail, so updating the snapshot will let our tests pass. This is preventing the build for #1988 from succeeding (tests passed Friday for the PR, but they didn't pass this morning when I merged :sweat:).

Since `configuration.explore_reports` isn't included in the official Zendesk Support docs yet, I'm holding off on adding that field to the stream's schema in case Zendesk removes it.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

Ensured tests passed locally after updating the snapshot.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1991)
<!-- Reviewable:end -->
