### PR TITLE
materialize-postgres: materialize UUID formatted strings as UUID columns

### DIFF
--- a/materialize-bigquery/transactor.go
+++ b/materialize-bigquery/transactor.go
@@ -40,6 +40,7 @@ func newTransactor(
 	fence sql.Fence,
 	bindings []sql.Table,
 	open pm.Request_Open,
+	is *boilerplate.InfoSchema,
 ) (_ m.Transactor, err error) {
 	cfg := ep.Config.(*config)
 

--- a/materialize-databricks/driver.go
+++ b/materialize-databricks/driver.go
@@ -135,6 +135,7 @@ func newTransactor(
 	fence sql.Fence,
 	bindings []sql.Table,
 	open pm.Request_Open,
+	is *boilerplate.InfoSchema,
 ) (_ m.Transactor, err error) {
 	var cfg = ep.Config.(*config)
 

--- a/materialize-motherduck/driver.go
+++ b/materialize-motherduck/driver.go
@@ -14,6 +14,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	m "github.com/estuary/connectors/go/protocols/materialize"
+	boilerplate "github.com/estuary/connectors/materialize-boilerplate"
 	sql "github.com/estuary/connectors/materialize-sql"
 	pf "github.com/estuary/flow/go/protocols/flow"
 	pm "github.com/estuary/flow/go/protocols/materialize"
@@ -197,6 +198,7 @@ func newTransactor(
 	fence sql.Fence,
 	bindings []sql.Table,
 	open pm.Request_Open,
+	is *boilerplate.InfoSchema,
 ) (_ m.Transactor, err error) {
 	cfg := ep.Config.(*config)
 

--- a/materialize-postgres/.snapshots/TestValidateAndApply
+++ b/materialize-postgres/.snapshots/TestValidateAndApply
@@ -113,7 +113,7 @@ Big Schema Changed Types Constraints:
 {"Field":"stringUriField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
 {"Field":"stringUriReferenceField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
 {"Field":"stringUriTemplateField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringUuidField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"stringUuidField","Type":6,"TypeString":"UNSATISFIABLE","Reason":"Field 'stringUuidField' is already being materialized as endpoint type 'UUID' but endpoint type 'TEXT' is required by its schema '{ type: [string] }'"}
 
 Big Schema Materialized Resource Schema With All Fields Required:
 {"Name":"_meta/flow_truncated","Nullable":"NO","Type":"boolean"}
@@ -151,7 +151,7 @@ Big Schema Materialized Resource Schema With All Fields Required:
 {"Name":"stringUriField","Nullable":"NO","Type":"text"}
 {"Name":"stringUriReferenceField","Nullable":"NO","Type":"text"}
 {"Name":"stringUriTemplateField","Nullable":"NO","Type":"text"}
-{"Name":"stringUuidField","Nullable":"NO","Type":"text"}
+{"Name":"stringUuidField","Nullable":"NO","Type":"uuid"}
 
 Big Schema Materialized Resource Schema With No Fields Required:
 {"Name":"_meta/flow_truncated","Nullable":"NO","Type":"boolean"}
@@ -189,7 +189,7 @@ Big Schema Materialized Resource Schema With No Fields Required:
 {"Name":"stringUriField","Nullable":"YES","Type":"text"}
 {"Name":"stringUriReferenceField","Nullable":"YES","Type":"text"}
 {"Name":"stringUriTemplateField","Nullable":"YES","Type":"text"}
-{"Name":"stringUuidField","Nullable":"YES","Type":"text"}
+{"Name":"stringUuidField","Nullable":"YES","Type":"uuid"}
 
 Big Schema Changed Types With Table Replacement Constraints:
 {"Field":"_meta/flow_truncated","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"Metadata fields fields are able to be materialized"}

--- a/materialize-postgres/sqlgen.go
+++ b/materialize-postgres/sqlgen.go
@@ -82,6 +82,16 @@ var pgDialect = func() sql.Dialect {
 	}
 }()
 
+type loadTableKey struct {
+	Identifier string
+	DDL        string
+}
+
+type loadTableColumns struct {
+	Binding int
+	Keys    []loadTableKey
+}
+
 var (
 	tplAll = sql.MustParseTemplate(pgDialect, "root", `
 {{ define "temp_name" -}}

--- a/materialize-postgres/sqlgen.go
+++ b/materialize-postgres/sqlgen.go
@@ -43,6 +43,10 @@ var pgDialect = func() sql.Dialect {
 					"macaddr":   sql.MapStatic("MACADDR"),
 					"macaddr8":  sql.MapStatic("MACADDR8"),
 					"time":      sql.MapStatic("TIME", sql.AlsoCompatibleWith("time without time zone")),
+					// UUID format was added on 30-Sept-2024, and pre-existing
+					// text type of columns are allowed to validate for
+					// compatibility with pre-existing columns.
+					"uuid": sql.MapStatic("UUID", sql.AlsoCompatibleWith("text", "character varying")),
 				},
 			}),
 		},

--- a/materialize-snowflake/snowflake.go
+++ b/materialize-snowflake/snowflake.go
@@ -216,6 +216,7 @@ func newTransactor(
 	fence sql.Fence,
 	bindings []sql.Table,
 	open pm.Request_Open,
+	is *boilerplate.InfoSchema,
 ) (_ m.Transactor, err error) {
 	var cfg = ep.Config.(*config)
 

--- a/materialize-sql/endpoint.go
+++ b/materialize-sql/endpoint.go
@@ -111,7 +111,7 @@ type Endpoint struct {
 	// which will be parsed into and validated from a resource configuration.
 	NewResource func(*Endpoint) Resource
 	// NewTransactor returns a Transactor ready for pm.RunTransactions.
-	NewTransactor func(ctx context.Context, _ *Endpoint, _ Fence, bindings []Table, open pm.Request_Open) (m.Transactor, error)
+	NewTransactor func(ctx context.Context, _ *Endpoint, _ Fence, bindings []Table, open pm.Request_Open, is *boilerplate.InfoSchema) (m.Transactor, error)
 	// Tenant owning this task, as determined from the task name.
 	Tenant string
 	// ConcurrentApply of Apply actions, for system that may benefit from a scatter/gather strategy

--- a/materialize-sqlite/sqlite.go
+++ b/materialize-sqlite/sqlite.go
@@ -155,6 +155,7 @@ func newTransactor(
 	fence sql.Fence,
 	bindings []sql.Table,
 	open pm.Request_Open,
+	is *boilerplate.InfoSchema,
 ) (_ m.Transactor, err error) {
 	var d = &transactor{
 		dialect: &sqliteDialect,

--- a/materialize-sqlserver/driver.go
+++ b/materialize-sqlserver/driver.go
@@ -241,13 +241,14 @@ type transactor struct {
 
 func prepareNewTransactor(
 	templates templates,
-) func(context.Context, *sql.Endpoint, sql.Fence, []sql.Table, pm.Request_Open) (m.Transactor, error) {
+) func(context.Context, *sql.Endpoint, sql.Fence, []sql.Table, pm.Request_Open, *boilerplate.InfoSchema) (m.Transactor, error) {
 	return func(
 		ctx context.Context,
 		ep *sql.Endpoint,
 		fence sql.Fence,
 		bindings []sql.Table,
 		open pm.Request_Open,
+		is *boilerplate.InfoSchema,
 	) (_ m.Transactor, err error) {
 		var cfg = ep.Config.(*config)
 		var d = &transactor{templates: templates, cfg: cfg}

--- a/materialize-starburst/starburst.go
+++ b/materialize-starburst/starburst.go
@@ -157,6 +157,7 @@ func newTransactor(
 	_ sql.Fence,
 	tables []sql.Table,
 	open pm.Request_Open,
+	is *boilerplate.InfoSchema,
 ) (_ m.Transactor, err error) {
 	var cfg = ep.Config.(*config)
 	var templates = renderTemplates(starburstTrinoDialect)


### PR DESCRIPTION
**Description:**

Materialize UUID formatted strings as UUID columns, but continue to allow TEXT columns to validate for these fields since there are pre-existing columns and we don't want to force a backfill of them. Transferring the values of the fields is the same if they are UUID columns vs. TEXT columns.

Going forward new or re-backfilled tables will have UUID formatted strings materialized as UUID columns.

Also: Create load tables for `materialize-postgres` with column DDL based on the key columns of the target tables. This is required for join query comparisons to work correctly for pre-existing tables that have UUID fields materialized as TEXT columns. Most of the diff is a result of this change.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1993)
<!-- Reviewable:end -->
