### PR TITLE
materializations: use correct resource path when building InfoSchema in Open

### DIFF
--- a/materialize-sql/driver.go
+++ b/materialize-sql/driver.go
@@ -263,8 +263,8 @@ func (d *Driver) NewTransactor(ctx context.Context, open pm.Request_Open) (m.Tra
 
 	var tables []Table
 	for index, spec := range open.Materialization.Bindings {
+		resourcePaths = append(resourcePaths, spec.ResourcePath)
 		var resource = endpoint.NewResource(endpoint)
-		resourcePaths = append(resourcePaths, resource.Path())
 
 		if err := pf.UnmarshalStrict(spec.ResourceConfigJson, resource); err != nil {
 			return nil, nil, fmt.Errorf("resource binding for collection %q: %w", spec.Collection.Name, err)


### PR DESCRIPTION
**Description:**

Fixes a bug where an uninitialized resource was being used to populate the resourcePaths list. The standard InfoSchema builder only really cares about the "schema" part of the resource path, so this handling was actually working most of the time when a materialization's tables were all in the same schema as its metadata tables. But if there are tables in other schemas, they weren't being property enumerated.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1996)
<!-- Reviewable:end -->
