### PR TITLE
materialize-redshift: compress checkpoints

### DIFF
--- a/materialize-motherduck/client.go
+++ b/materialize-motherduck/client.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	stdsql "database/sql"
-	"encoding/base64"
 	"errors"
 	"fmt"
 	"net/http"
@@ -202,7 +201,7 @@ func (c *client) ExecStatements(ctx context.Context, statements []string) error 
 }
 
 func (c *client) InstallFence(ctx context.Context, checkpoints sql.Table, fence sql.Fence) (sql.Fence, error) {
-	return sql.StdInstallFence(ctx, c.db, checkpoints, fence, base64.StdEncoding.DecodeString)
+	return sql.StdInstallFence(ctx, c.db, checkpoints, fence)
 }
 
 func (c *client) Close() {

--- a/materialize-mysql/client.go
+++ b/materialize-mysql/client.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	stdsql "database/sql"
-	"encoding/base64"
 	"errors"
 	"fmt"
 	"net"
@@ -174,7 +173,7 @@ func (c *client) PutSpec(ctx context.Context, updateSpec sql.MetaSpecsUpdate) er
 }
 
 func (c *client) InstallFence(ctx context.Context, checkpoints sql.Table, fence sql.Fence) (sql.Fence, error) {
-	return sql.StdInstallFence(ctx, c.db, checkpoints, fence, base64.StdEncoding.DecodeString)
+	return sql.StdInstallFence(ctx, c.db, checkpoints, fence)
 }
 
 func (c *client) ExecStatements(ctx context.Context, statements []string) error {

--- a/materialize-postgres/client.go
+++ b/materialize-postgres/client.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	stdsql "database/sql"
-	"encoding/base64"
 	"errors"
 	"fmt"
 	"net"
@@ -179,7 +178,7 @@ func (c *client) ExecStatements(ctx context.Context, statements []string) error 
 }
 
 func (c *client) InstallFence(ctx context.Context, checkpoints sql.Table, fence sql.Fence) (sql.Fence, error) {
-	return sql.StdInstallFence(ctx, c.db, checkpoints, fence, base64.StdEncoding.DecodeString)
+	return sql.StdInstallFence(ctx, c.db, checkpoints, fence)
 }
 
 func (c *client) Close() {

--- a/materialize-redshift/.snapshots/TestSQLGeneration
+++ b/materialize-redshift/.snapshots/TestSQLGeneration
@@ -146,15 +146,6 @@ WHERE "a-schema".key_value.key1 = r.key1 AND "a-schema".key_value.key2 = r.key2 
 
 --- End "a-schema".delta_updates deleteQuery ---
 
---- Begin Fence Update ---
-UPDATE path."to".checkpoints
-	SET   checkpoint = 'AAECAwQFBgcICQ=='
-	WHERE materialization = 'some/Materialization'
-	AND   key_begin = 1122867
-	AND   key_end   = 4293844428
-	AND   fence     = 123;
---- End Fence Update ---
-
 --- Begin "a-schema".key_value createLoadTable (no varchar length) ---
 CREATE TEMPORARY TABLE flow_temp_table_0 (
 	key1 BIGINT,

--- a/materialize-redshift/driver_test.go
+++ b/materialize-redshift/driver_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	stdsql "database/sql"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -15,9 +16,8 @@ import (
 	pf "github.com/estuary/flow/go/protocols/flow"
 	pm "github.com/estuary/flow/go/protocols/materialize"
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
 	"github.com/stretchr/testify/require"
-
-	_ "github.com/jackc/pgx/v5/stdlib"
 )
 
 func mustGetCfg(t *testing.T) config {
@@ -112,16 +112,61 @@ func TestFencingCases(t *testing.T) {
 		testDialect,
 		templates.createTargetTable,
 		func(table sql.Table, fence sql.Fence) error {
-			var fenceUpdate strings.Builder
-			if err := templates.updateFence.Execute(&fenceUpdate, fence); err != nil {
-				return fmt.Errorf("evaluating fence template: %w", err)
+			conn, err := pgx.Connect(ctx, cfg.toURI())
+			if err != nil {
+				return fmt.Errorf("store pgx.Connect: %w", err)
 			}
-			return c.ExecStatements(ctx, []string{fenceUpdate.String()})
+			defer conn.Close(ctx)
+
+			txn, err := conn.BeginTx(ctx, pgx.TxOptions{})
+			if err != nil {
+				return err
+			}
+			defer txn.Rollback(ctx)
+
+			if updateFence(ctx, txn, testDialect, fence) != nil {
+				return err
+			}
+
+			return txn.Commit(ctx)
 		},
 		func(table sql.Table) (out string, err error) {
 			err = c.(*client).withDB(func(db *stdsql.DB) error {
-				out, err = sql.StdDumpTable(ctx, db, table)
-				return err
+				var sql = fmt.Sprintf(
+					"select materialization, key_begin, key_end, fence, FROM_VARBYTE(checkpoint, 'utf8') from %s order by materialization, key_begin, key_end asc;",
+					table.Identifier,
+				)
+
+				rows, err := db.Query(sql)
+				if err != nil {
+					return err
+				}
+				defer rows.Close()
+
+				var b strings.Builder
+				b.WriteString("materialization, key_begin, key_end, fence, checkpoint")
+
+				for rows.Next() {
+					b.WriteString("\n")
+					var materialization string
+					var keyBegin, keyEnd, fence int
+					var checkpoint string
+					if err = rows.Scan(&materialization, &keyBegin, &keyEnd, &fence, &checkpoint); err != nil {
+						return err
+					} else if base64Bytes, err := base64.StdEncoding.DecodeString(checkpoint); err != nil {
+						return err
+					} else if decompressed, err := maybeDecompressBytes(base64Bytes); err != nil {
+						return err
+					} else {
+						b.WriteString(fmt.Sprintf(
+							"%s, %d, %d, %d, %s",
+							materialization, keyBegin, keyEnd, fence, base64.StdEncoding.EncodeToString(decompressed)),
+						)
+					}
+				}
+
+				out = b.String()
+				return nil
 			})
 			return
 		},

--- a/materialize-redshift/sqlgen.go
+++ b/materialize-redshift/sqlgen.go
@@ -160,7 +160,6 @@ type templates struct {
 	mergeInto         *template.Template
 	deleteQuery       *template.Template
 	loadQuery         *template.Template
-	updateFence       *template.Template
 	copyFromS3        *template.Template
 }
 
@@ -286,17 +285,6 @@ SELECT * FROM (SELECT -1, CAST(NULL AS SUPER) LIMIT 0) as nodoc
 {{- end }}
 {{ end }}
 
--- Templated update of a fence checkpoint.
-
-{{ define "updateFence" }}
-UPDATE {{ Identifier $.TablePath }}
-	SET   checkpoint = {{ Literal (Base64Std $.Checkpoint) }}
-	WHERE materialization = {{ Literal $.Materialization.String }}
-	AND   key_begin = {{ $.KeyBegin }}
-	AND   key_end   = {{ $.KeyEnd }}
-	AND   fence     = {{ $.Fence }};
-{{ end }}
-
 -- Templated command to copy data from an S3 file into the destination table. Note the 'ignorecase'
 -- JSON option: This is necessary since by default Redshift lowercases all identifiers.
 
@@ -329,7 +317,6 @@ TRUNCATECOLUMNS;
 		mergeInto:         tplAll.Lookup("mergeInto"),
 		deleteQuery:       tplAll.Lookup("deleteQuery"),
 		loadQuery:         tplAll.Lookup("loadQuery"),
-		updateFence:       tplAll.Lookup("updateFence"),
 		copyFromS3:        tplAll.Lookup("copyFromS3"),
 	}
 }

--- a/materialize-redshift/sqlgen_test.go
+++ b/materialize-redshift/sqlgen_test.go
@@ -35,7 +35,6 @@ func TestSQLGeneration(t *testing.T) {
 				templates.createDeleteTable,
 				templates.deleteQuery,
 			},
-			TplUpdateFence: templates.updateFence,
 		},
 	)
 

--- a/materialize-sql/std_sql.go
+++ b/materialize-sql/std_sql.go
@@ -69,7 +69,7 @@ func StdSQLExecStatements(ctx context.Context, db *sql.DB, statements []string) 
 
 // StdInstallFence is a convenience for Client implementations which
 // use Go's standard `sql.DB` type under the hood.
-func StdInstallFence(ctx context.Context, db *sql.DB, checkpoints Table, fence Fence, decodeFence func(string) ([]byte, error)) (Fence, error) {
+func StdInstallFence(ctx context.Context, db *sql.DB, checkpoints Table, fence Fence) (Fence, error) {
 	var txn, err = db.BeginTx(ctx, nil)
 	if err != nil {
 		return Fence{}, fmt.Errorf("db.BeginTx: %w", err)
@@ -130,8 +130,8 @@ func StdInstallFence(ctx context.Context, db *sql.DB, checkpoints Table, fence F
 		readBegin, readEnd = 1, 0
 	} else if err != nil {
 		return Fence{}, fmt.Errorf("scanning fence and checkpoint: %w", err)
-	} else if fence.Checkpoint, err = decodeFence(checkpoint); err != nil {
-		return Fence{}, fmt.Errorf("decodeFence(checkpoint): %w", err)
+	} else if fence.Checkpoint, err = base64.StdEncoding.DecodeString(checkpoint); err != nil {
+		return Fence{}, fmt.Errorf("base64.Decode(checkpoint): %w", err)
 	}
 
 	// If a checkpoint for this exact range doesn't exist then insert it now.


### PR DESCRIPTION
**Description:**

Adds compression for checkpoints that are stored in the checkpoints table, which should significantly increase the maximum size of checkpoint the 1 MiB VARBYTE column can hold.

VARBYTE columns can also be made larger than 1 MiB (up to 16 MiB, with added query overhead), so if this still ends up not being enough we can add automatic enlargement of the VARBYTE columns, similar to what we have for VARCHAR columns in Redshift already.

The changes in this commit really lean into Redshift handling metadata in its own weird way. Previously the general "install fence" routine was modified to all a decoding callback which was only used by Redshift. Rather than add an additional encoding callback that only Redshift would use, we'll just have Redshift do its own thing entirely and simplify the general case for all other materializations. Having more direct control over the query construction for Redshift has the added benefit of not needing to do a separate Hex decode within the connector, since we can query the known encoding directly.

Closes #1998

For testing, I ran the fence test cases (+ all the tests that can only be run manually), and also verified on a local stack that a prior materialization can be migrated to this one.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

I'm using gzip for compression since we were already using gzip for compressing the spec bytes, also all the data sent to redshift is gzip'd, and gzip is in the stdlib.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/1999)
<!-- Reviewable:end -->
