### PR TITLE
materialize-snowflake: limit number of retries based on pipe numbers

### DIFF
--- a/materialize-snowflake/snowflake.go
+++ b/materialize-snowflake/snowflake.go
@@ -724,103 +724,106 @@ func (d *transactor) Acknowledge(ctx context.Context) (*pf.ConnectorState, error
 
 	// If we see no results from the REST API for `maxTries` iterations, then we
 	// fallback to asking the `COPY_HISTORY` table. We allow up to 5 minutes for results to show up in the REST API.
-	var maxTries = 40
-	var retryDelay = 3 * time.Second
-	for tries := 0; tries < maxTries; tries++ {
-		for pipeName, pipe := range pipes {
-			// if the pipe has no files to begin with, just skip it
-			// we might have processed all files of this pipe previously
-			if len(pipe.files) == 0 {
-				continue
-			}
-
-			// We first try to check the status of pipes using the REST API's insertReport
-			// The REST API does not wake up the warehouse, hence our preference
-			// however this API is not the most ergonomic and sometimes does not yield
-			// results as expected
-			report, err := d.pipeClient.InsertReport(pipeName)
-			if err != nil {
-				return nil, fmt.Errorf("snowpipe: insertReports: %w", err)
-			}
-
-			// If the files have already been loaded, when we submit a request to
-			// load those files again, our request will not show up in reports.
-			// Moreover, insertReport only retains events for 10 minutes.
-			// One way to find out whether the files were successfully loaded is to check
-			// the COPY_HISTORY to make sure they are there. The COPY_HISTORY is much more
-			// reliable. If they are not there, then something is wrong.
-			if len(report.Files) == 0 {
-				// We try `maxTries` times since it may take some time for the REST API
-				// to reflect the new pipe requests
-				if tries < maxTries-1 {
-					time.Sleep(retryDelay)
+	if len(pipes) > 0 {
+		// 5 minutes divided by three seconds for each pipe
+		var maxTries = (5 * 60) / (3 * len(pipes))
+		var retryDelay = 3 * time.Second
+		for tries := 0; tries < maxTries; tries++ {
+			for pipeName, pipe := range pipes {
+				// if the pipe has no files to begin with, just skip it
+				// we might have processed all files of this pipe previously
+				if len(pipe.files) == 0 {
 					continue
 				}
 
-				log.WithFields(log.Fields{
-					"tries": tries,
-					"pipe":  pipeName,
-				}).Info("snowpipe: no files in report, fetching copy history from warehouse")
-
-				var fileNames = make([]string, len(pipe.files))
-				for i, f := range pipe.files {
-					fileNames[i] = f.Path
-				}
-
-				rows, err := d.copyHistory(ctx, pipe.tableName, fileNames)
+				// We first try to check the status of pipes using the REST API's insertReport
+				// The REST API does not wake up the warehouse, hence our preference
+				// however this API is not the most ergonomic and sometimes does not yield
+				// results as expected
+				report, err := d.pipeClient.InsertReport(pipeName)
 				if err != nil {
-					return nil, err
+					return nil, fmt.Errorf("snowpipe: insertReports: %w", err)
 				}
 
-				// If there are items still in progress, we continue retrying until those items
-				// resolve to another status
-				var hasItemsInProgress = false
+				// If the files have already been loaded, when we submit a request to
+				// load those files again, our request will not show up in reports.
+				// Moreover, insertReport only retains events for 10 minutes.
+				// One way to find out whether the files were successfully loaded is to check
+				// the COPY_HISTORY to make sure they are there. The COPY_HISTORY is much more
+				// reliable. If they are not there, then something is wrong.
+				if len(report.Files) == 0 {
+					// We try `maxTries` times since it may take some time for the REST API
+					// to reflect the new pipe requests
+					if tries < maxTries-1 {
+						time.Sleep(retryDelay)
+						continue
+					}
 
-				for _, row := range rows {
-					if row.status == "Loaded" {
-						pipe.fileLoaded(row.fileName)
-					} else if row.status == "Load in progress" {
-						hasItemsInProgress = true
-					} else {
-						return nil, fmt.Errorf("unexpected status %q for files in pipe %q: %s", row.status, pipeName, row.firstErrorMessage)
+					log.WithFields(log.Fields{
+						"tries": tries,
+						"pipe":  pipeName,
+					}).Info("snowpipe: no files in report, fetching copy history from warehouse")
+
+					var fileNames = make([]string, len(pipe.files))
+					for i, f := range pipe.files {
+						fileNames[i] = f.Path
+					}
+
+					rows, err := d.copyHistory(ctx, pipe.tableName, fileNames)
+					if err != nil {
+						return nil, err
+					}
+
+					// If there are items still in progress, we continue retrying until those items
+					// resolve to another status
+					var hasItemsInProgress = false
+
+					for _, row := range rows {
+						if row.status == "Loaded" {
+							pipe.fileLoaded(row.fileName)
+						} else if row.status == "Load in progress" {
+							hasItemsInProgress = true
+						} else {
+							return nil, fmt.Errorf("unexpected status %q for files in pipe %q: %s", row.status, pipeName, row.firstErrorMessage)
+						}
+					}
+
+					// If items are still in progress, we continue trying to fetch their results
+					if hasItemsInProgress {
+						tries--
+						time.Sleep(retryDelay)
+						continue
+					}
+
+					if len(pipe.files) > 0 {
+						return nil, fmt.Errorf("snowpipe: could not find reports of successful processing for all files of pipe %v", pipe)
+					}
+
+					// All files have been processed for this pipe, we can skip to the next pipe
+					d.deleteFiles(ctx, []string{pipe.dir})
+					continue
+				}
+
+				// So long as we are able to get some results from the REST API, we do not
+				// want to ask COPY_HISTORY. So we reset the counter if we see some results from the REST API
+				tries = 0
+
+				for _, reportFile := range report.Files {
+					if reportFile.Status == "LOADED" {
+						pipe.fileLoaded(reportFile.Path)
+					} else if reportFile.Status == "LOAD_FAILED" || reportFile.Status == "PARTIALLY_LOADED" {
+						return nil, fmt.Errorf("failed to load files in pipe %q: %s, %s", pipeName, reportFile.FirstError, reportFile.SystemError)
+					} else if reportFile.Status == "LOAD_IN_PROGRESS" {
+						continue
 					}
 				}
 
-				// If items are still in progress, we continue trying to fetch their results
-				if hasItemsInProgress {
-					tries--
+				if len(pipe.files) == 0 {
+					d.deleteFiles(ctx, []string{pipe.dir})
+					continue
+				} else {
 					time.Sleep(retryDelay)
-					continue
 				}
-
-				if len(pipe.files) > 0 {
-					return nil, fmt.Errorf("snowpipe: could not find reports of successful processing for all files of pipe %v", pipe)
-				}
-
-				// All files have been processed for this pipe, we can skip to the next pipe
-				d.deleteFiles(ctx, []string{pipe.dir})
-				continue
-			}
-
-			// So long as we are able to get some results from the REST API, we do not
-			// want to ask COPY_HISTORY. So we reset the counter if we see some results from the REST API
-			tries = 0
-
-			for _, reportFile := range report.Files {
-				if reportFile.Status == "LOADED" {
-					pipe.fileLoaded(reportFile.Path)
-				} else if reportFile.Status == "LOAD_FAILED" || reportFile.Status == "PARTIALLY_LOADED" {
-					return nil, fmt.Errorf("failed to load files in pipe %q: %s, %s", pipeName, reportFile.FirstError, reportFile.SystemError)
-				} else if reportFile.Status == "LOAD_IN_PROGRESS" {
-					continue
-				}
-			}
-
-			if len(pipe.files) == 0 {
-				d.deleteFiles(ctx, []string{pipe.dir})
-				continue
-			} else {
-				time.Sleep(retryDelay)
 			}
 		}
 	}


### PR DESCRIPTION
**Description:**

- when tasks have a large number of bindings, we keep retrying for too long. In cases where the ingestion reports are expired, this creates a forever loop. This pull-request limits the length of time we retry to 5 minutes maximum.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2002)
<!-- Reviewable:end -->
