### PR TITLE
source-sqlserver: Exclude computed columns from discovery, backfills, and replication

### DIFF
--- a/source-sqlserver/.snapshots/TestComputedColumn-capture
+++ b/source-sqlserver/.snapshots/TestComputedColumn-capture
@@ -1,0 +1,23 @@
+# ================================
+# Collection "acmeCo/test/test_computedcolumn_18851564": 15 Documents
+# ================================
+{"_meta":{"op":"c","source":{"schema":"dbo","snapshot":true,"table":"test_ComputedColumn_18851564","lsn":"","seqval":"AAAAAAAAAAAAAA=="}},"a":"a0","b":"b0","computed":"a0","id":0}
+{"_meta":{"op":"c","source":{"schema":"dbo","snapshot":true,"table":"test_ComputedColumn_18851564","lsn":"","seqval":"AAAAAAAAAAAAAA=="}},"a":null,"b":"b1","computed":"b1","id":1}
+{"_meta":{"op":"c","source":{"schema":"dbo","snapshot":true,"table":"test_ComputedColumn_18851564","lsn":"","seqval":"AAAAAAAAAAAAAA=="}},"a":"a2","b":null,"computed":"a2","id":2}
+{"_meta":{"op":"c","source":{"schema":"dbo","snapshot":true,"table":"test_ComputedColumn_18851564","lsn":"","seqval":"AAAAAAAAAAAAAA=="}},"a":null,"b":null,"computed":"default","id":3}
+{"_meta":{"op":"c","source":{"schema":"dbo","table":"test_ComputedColumn_18851564","lsn":"AAAAAAAAAAAAAA==","seqval":"AAAAAAAAAAAAAA==","updateMask":"Dw=="}},"a":"a4","b":"b4","computed":null,"id":4}
+{"_meta":{"op":"c","source":{"schema":"dbo","table":"test_ComputedColumn_18851564","lsn":"AAAAAAAAAAAAAA==","seqval":"AAAAAAAAAAAAAA==","updateMask":"Dw=="}},"a":null,"b":"b5","computed":null,"id":5}
+{"_meta":{"op":"c","source":{"schema":"dbo","table":"test_ComputedColumn_18851564","lsn":"AAAAAAAAAAAAAA==","seqval":"AAAAAAAAAAAAAA==","updateMask":"Dw=="}},"a":"a6","b":null,"computed":null,"id":6}
+{"_meta":{"op":"c","source":{"schema":"dbo","table":"test_ComputedColumn_18851564","lsn":"AAAAAAAAAAAAAA==","seqval":"AAAAAAAAAAAAAA==","updateMask":"Dw=="}},"a":null,"b":null,"computed":null,"id":7}
+{"_meta":{"op":"u","source":{"schema":"dbo","table":"test_ComputedColumn_18851564","lsn":"AAAAAAAAAAAAAA==","seqval":"AAAAAAAAAAAAAA==","updateMask":"Ag=="}},"a":"a4-modified","b":"b4","computed":null,"id":4}
+{"_meta":{"op":"u","source":{"schema":"dbo","table":"test_ComputedColumn_18851564","lsn":"AAAAAAAAAAAAAA==","seqval":"AAAAAAAAAAAAAA==","updateMask":"BA=="}},"a":null,"b":"b5-modified","computed":null,"id":5}
+{"_meta":{"op":"u","source":{"schema":"dbo","table":"test_ComputedColumn_18851564","lsn":"AAAAAAAAAAAAAA==","seqval":"AAAAAAAAAAAAAA==","updateMask":"Ag=="}},"a":"a6-modified","b":null,"computed":null,"id":6}
+{"_meta":{"op":"d","source":{"schema":"dbo","table":"test_ComputedColumn_18851564","lsn":"AAAAAAAAAAAAAA==","seqval":"AAAAAAAAAAAAAA==","updateMask":"Dw=="}},"a":"a4-modified","b":"b4","computed":null,"id":4}
+{"_meta":{"op":"d","source":{"schema":"dbo","table":"test_ComputedColumn_18851564","lsn":"AAAAAAAAAAAAAA==","seqval":"AAAAAAAAAAAAAA==","updateMask":"Dw=="}},"a":null,"b":"b5-modified","computed":null,"id":5}
+{"_meta":{"op":"d","source":{"schema":"dbo","table":"test_ComputedColumn_18851564","lsn":"AAAAAAAAAAAAAA==","seqval":"AAAAAAAAAAAAAA==","updateMask":"Dw=="}},"a":"a6-modified","b":null,"computed":null,"id":6}
+{"_meta":{"op":"d","source":{"schema":"dbo","table":"test_ComputedColumn_18851564","lsn":"AAAAAAAAAAAAAA==","seqval":"AAAAAAAAAAAAAA==","updateMask":"Dw=="}},"a":null,"b":null,"computed":null,"id":7}
+# ================================
+# Final State Checkpoint
+# ================================
+{"bindingStateV1":{"dbo%2Ftest_ComputedColumn_18851564":{"backfilled":4,"key_columns":["id"],"mode":"Active"}},"cursor":"AAAAAAAAAAAAAA=="}
+

--- a/source-sqlserver/.snapshots/TestComputedColumn-capture
+++ b/source-sqlserver/.snapshots/TestComputedColumn-capture
@@ -1,10 +1,10 @@
 # ================================
 # Collection "acmeCo/test/test_computedcolumn_18851564": 15 Documents
 # ================================
-{"_meta":{"op":"c","source":{"schema":"dbo","snapshot":true,"table":"test_ComputedColumn_18851564","lsn":"","seqval":"AAAAAAAAAAAAAA=="}},"a":"a0","b":"b0","computed":"a0","id":0}
-{"_meta":{"op":"c","source":{"schema":"dbo","snapshot":true,"table":"test_ComputedColumn_18851564","lsn":"","seqval":"AAAAAAAAAAAAAA=="}},"a":null,"b":"b1","computed":"b1","id":1}
-{"_meta":{"op":"c","source":{"schema":"dbo","snapshot":true,"table":"test_ComputedColumn_18851564","lsn":"","seqval":"AAAAAAAAAAAAAA=="}},"a":"a2","b":null,"computed":"a2","id":2}
-{"_meta":{"op":"c","source":{"schema":"dbo","snapshot":true,"table":"test_ComputedColumn_18851564","lsn":"","seqval":"AAAAAAAAAAAAAA=="}},"a":null,"b":null,"computed":"default","id":3}
+{"_meta":{"op":"c","source":{"schema":"dbo","snapshot":true,"table":"test_ComputedColumn_18851564","lsn":"","seqval":"AAAAAAAAAAAAAA=="}},"a":"a0","b":"b0","id":0}
+{"_meta":{"op":"c","source":{"schema":"dbo","snapshot":true,"table":"test_ComputedColumn_18851564","lsn":"","seqval":"AAAAAAAAAAAAAA=="}},"a":null,"b":"b1","id":1}
+{"_meta":{"op":"c","source":{"schema":"dbo","snapshot":true,"table":"test_ComputedColumn_18851564","lsn":"","seqval":"AAAAAAAAAAAAAA=="}},"a":"a2","b":null,"id":2}
+{"_meta":{"op":"c","source":{"schema":"dbo","snapshot":true,"table":"test_ComputedColumn_18851564","lsn":"","seqval":"AAAAAAAAAAAAAA=="}},"a":null,"b":null,"id":3}
 {"_meta":{"op":"c","source":{"schema":"dbo","table":"test_ComputedColumn_18851564","lsn":"AAAAAAAAAAAAAA==","seqval":"AAAAAAAAAAAAAA==","updateMask":"Dw=="}},"a":"a4","b":"b4","id":4}
 {"_meta":{"op":"c","source":{"schema":"dbo","table":"test_ComputedColumn_18851564","lsn":"AAAAAAAAAAAAAA==","seqval":"AAAAAAAAAAAAAA==","updateMask":"Dw=="}},"a":null,"b":"b5","id":5}
 {"_meta":{"op":"c","source":{"schema":"dbo","table":"test_ComputedColumn_18851564","lsn":"AAAAAAAAAAAAAA==","seqval":"AAAAAAAAAAAAAA==","updateMask":"Dw=="}},"a":"a6","b":null,"id":6}

--- a/source-sqlserver/.snapshots/TestComputedColumn-capture
+++ b/source-sqlserver/.snapshots/TestComputedColumn-capture
@@ -5,17 +5,17 @@
 {"_meta":{"op":"c","source":{"schema":"dbo","snapshot":true,"table":"test_ComputedColumn_18851564","lsn":"","seqval":"AAAAAAAAAAAAAA=="}},"a":null,"b":"b1","computed":"b1","id":1}
 {"_meta":{"op":"c","source":{"schema":"dbo","snapshot":true,"table":"test_ComputedColumn_18851564","lsn":"","seqval":"AAAAAAAAAAAAAA=="}},"a":"a2","b":null,"computed":"a2","id":2}
 {"_meta":{"op":"c","source":{"schema":"dbo","snapshot":true,"table":"test_ComputedColumn_18851564","lsn":"","seqval":"AAAAAAAAAAAAAA=="}},"a":null,"b":null,"computed":"default","id":3}
-{"_meta":{"op":"c","source":{"schema":"dbo","table":"test_ComputedColumn_18851564","lsn":"AAAAAAAAAAAAAA==","seqval":"AAAAAAAAAAAAAA==","updateMask":"Dw=="}},"a":"a4","b":"b4","computed":null,"id":4}
-{"_meta":{"op":"c","source":{"schema":"dbo","table":"test_ComputedColumn_18851564","lsn":"AAAAAAAAAAAAAA==","seqval":"AAAAAAAAAAAAAA==","updateMask":"Dw=="}},"a":null,"b":"b5","computed":null,"id":5}
-{"_meta":{"op":"c","source":{"schema":"dbo","table":"test_ComputedColumn_18851564","lsn":"AAAAAAAAAAAAAA==","seqval":"AAAAAAAAAAAAAA==","updateMask":"Dw=="}},"a":"a6","b":null,"computed":null,"id":6}
-{"_meta":{"op":"c","source":{"schema":"dbo","table":"test_ComputedColumn_18851564","lsn":"AAAAAAAAAAAAAA==","seqval":"AAAAAAAAAAAAAA==","updateMask":"Dw=="}},"a":null,"b":null,"computed":null,"id":7}
-{"_meta":{"op":"u","source":{"schema":"dbo","table":"test_ComputedColumn_18851564","lsn":"AAAAAAAAAAAAAA==","seqval":"AAAAAAAAAAAAAA==","updateMask":"Ag=="}},"a":"a4-modified","b":"b4","computed":null,"id":4}
-{"_meta":{"op":"u","source":{"schema":"dbo","table":"test_ComputedColumn_18851564","lsn":"AAAAAAAAAAAAAA==","seqval":"AAAAAAAAAAAAAA==","updateMask":"BA=="}},"a":null,"b":"b5-modified","computed":null,"id":5}
-{"_meta":{"op":"u","source":{"schema":"dbo","table":"test_ComputedColumn_18851564","lsn":"AAAAAAAAAAAAAA==","seqval":"AAAAAAAAAAAAAA==","updateMask":"Ag=="}},"a":"a6-modified","b":null,"computed":null,"id":6}
-{"_meta":{"op":"d","source":{"schema":"dbo","table":"test_ComputedColumn_18851564","lsn":"AAAAAAAAAAAAAA==","seqval":"AAAAAAAAAAAAAA==","updateMask":"Dw=="}},"a":"a4-modified","b":"b4","computed":null,"id":4}
-{"_meta":{"op":"d","source":{"schema":"dbo","table":"test_ComputedColumn_18851564","lsn":"AAAAAAAAAAAAAA==","seqval":"AAAAAAAAAAAAAA==","updateMask":"Dw=="}},"a":null,"b":"b5-modified","computed":null,"id":5}
-{"_meta":{"op":"d","source":{"schema":"dbo","table":"test_ComputedColumn_18851564","lsn":"AAAAAAAAAAAAAA==","seqval":"AAAAAAAAAAAAAA==","updateMask":"Dw=="}},"a":"a6-modified","b":null,"computed":null,"id":6}
-{"_meta":{"op":"d","source":{"schema":"dbo","table":"test_ComputedColumn_18851564","lsn":"AAAAAAAAAAAAAA==","seqval":"AAAAAAAAAAAAAA==","updateMask":"Dw=="}},"a":null,"b":null,"computed":null,"id":7}
+{"_meta":{"op":"c","source":{"schema":"dbo","table":"test_ComputedColumn_18851564","lsn":"AAAAAAAAAAAAAA==","seqval":"AAAAAAAAAAAAAA==","updateMask":"Dw=="}},"a":"a4","b":"b4","id":4}
+{"_meta":{"op":"c","source":{"schema":"dbo","table":"test_ComputedColumn_18851564","lsn":"AAAAAAAAAAAAAA==","seqval":"AAAAAAAAAAAAAA==","updateMask":"Dw=="}},"a":null,"b":"b5","id":5}
+{"_meta":{"op":"c","source":{"schema":"dbo","table":"test_ComputedColumn_18851564","lsn":"AAAAAAAAAAAAAA==","seqval":"AAAAAAAAAAAAAA==","updateMask":"Dw=="}},"a":"a6","b":null,"id":6}
+{"_meta":{"op":"c","source":{"schema":"dbo","table":"test_ComputedColumn_18851564","lsn":"AAAAAAAAAAAAAA==","seqval":"AAAAAAAAAAAAAA==","updateMask":"Dw=="}},"a":null,"b":null,"id":7}
+{"_meta":{"op":"u","source":{"schema":"dbo","table":"test_ComputedColumn_18851564","lsn":"AAAAAAAAAAAAAA==","seqval":"AAAAAAAAAAAAAA==","updateMask":"Ag=="}},"a":"a4-modified","b":"b4","id":4}
+{"_meta":{"op":"u","source":{"schema":"dbo","table":"test_ComputedColumn_18851564","lsn":"AAAAAAAAAAAAAA==","seqval":"AAAAAAAAAAAAAA==","updateMask":"BA=="}},"a":null,"b":"b5-modified","id":5}
+{"_meta":{"op":"u","source":{"schema":"dbo","table":"test_ComputedColumn_18851564","lsn":"AAAAAAAAAAAAAA==","seqval":"AAAAAAAAAAAAAA==","updateMask":"Ag=="}},"a":"a6-modified","b":null,"id":6}
+{"_meta":{"op":"d","source":{"schema":"dbo","table":"test_ComputedColumn_18851564","lsn":"AAAAAAAAAAAAAA==","seqval":"AAAAAAAAAAAAAA==","updateMask":"Dw=="}},"a":"a4-modified","b":"b4","id":4}
+{"_meta":{"op":"d","source":{"schema":"dbo","table":"test_ComputedColumn_18851564","lsn":"AAAAAAAAAAAAAA==","seqval":"AAAAAAAAAAAAAA==","updateMask":"Dw=="}},"a":null,"b":"b5-modified","id":5}
+{"_meta":{"op":"d","source":{"schema":"dbo","table":"test_ComputedColumn_18851564","lsn":"AAAAAAAAAAAAAA==","seqval":"AAAAAAAAAAAAAA==","updateMask":"Dw=="}},"a":"a6-modified","b":null,"id":6}
+{"_meta":{"op":"d","source":{"schema":"dbo","table":"test_ComputedColumn_18851564","lsn":"AAAAAAAAAAAAAA==","seqval":"AAAAAAAAAAAAAA==","updateMask":"Dw=="}},"a":null,"b":null,"id":7}
 # ================================
 # Final State Checkpoint
 # ================================

--- a/source-sqlserver/.snapshots/TestComputedColumn-discovery
+++ b/source-sqlserver/.snapshots/TestComputedColumn-discovery
@@ -28,10 +28,6 @@ Binding 0:
                 "null"
               ]
             },
-            "computed": {
-              "type": "string",
-              "description": "(source type: non-nullable varchar(64))"
-            },
             "id": {
               "type": "integer",
               "description": "(source type: non-nullable int)"

--- a/source-sqlserver/.snapshots/TestComputedColumn-discovery
+++ b/source-sqlserver/.snapshots/TestComputedColumn-discovery
@@ -1,0 +1,149 @@
+Binding 0:
+{
+    "recommended_name": "test_computedcolumn_18851564",
+    "resource_config_json": {
+      "namespace": "dbo",
+      "stream": "test_ComputedColumn_18851564"
+    },
+    "document_schema_json": {
+      "$defs": {
+        "DboTest_ComputedColumn_18851564": {
+          "type": "object",
+          "required": [
+            "id"
+          ],
+          "$anchor": "DboTest_ComputedColumn_18851564",
+          "properties": {
+            "a": {
+              "description": "(source type: varchar(64))",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "b": {
+              "description": "(source type: varchar(64))",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "computed": {
+              "type": "string",
+              "description": "(source type: non-nullable varchar(64))"
+            },
+            "id": {
+              "type": "integer",
+              "description": "(source type: non-nullable int)"
+            }
+          }
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "_meta": {
+                "properties": {
+                  "op": {
+                    "const": "d"
+                  }
+                }
+              }
+            }
+          },
+          "then": {
+            "reduce": {
+              "delete": true,
+              "strategy": "merge"
+            }
+          },
+          "else": {
+            "reduce": {
+              "strategy": "merge"
+            }
+          },
+          "required": [
+            "_meta"
+          ],
+          "properties": {
+            "_meta": {
+              "type": "object",
+              "required": [
+                "op",
+                "source"
+              ],
+              "properties": {
+                "before": {
+                  "$ref": "#DboTest_ComputedColumn_18851564",
+                  "description": "Record state immediately before this change was applied.",
+                  "reduce": {
+                    "strategy": "firstWriteWins"
+                  }
+                },
+                "op": {
+                  "enum": [
+                    "c",
+                    "d",
+                    "u"
+                  ],
+                  "description": "Change operation type: 'c' Create/Insert, 'u' Update, 'd' Delete."
+                },
+                "source": {
+                  "$id": "https://github.com/estuary/connectors/source-sqlserver/sqlserver-source-info",
+                  "properties": {
+                    "ts_ms": {
+                      "type": "integer",
+                      "description": "Unix timestamp (in millis) at which this event was recorded by the database."
+                    },
+                    "schema": {
+                      "type": "string",
+                      "description": "Database schema (namespace) of the event."
+                    },
+                    "snapshot": {
+                      "type": "boolean",
+                      "description": "Snapshot is true if the record was produced from an initial table backfill and unset if produced from the replication log."
+                    },
+                    "table": {
+                      "type": "string",
+                      "description": "Database table of the event."
+                    },
+                    "lsn": {
+                      "type": "string",
+                      "contentEncoding": "base64",
+                      "description": "The LSN at which a CDC event occurred. Only set for CDC events"
+                    },
+                    "seqval": {
+                      "type": "string",
+                      "contentEncoding": "base64",
+                      "description": "Sequence value used to order changes to a row within a transaction. Only set for CDC events"
+                    },
+                    "updateMask": {
+                      "description": "A bit mask with a bit corresponding to each captured column identified for the capture instance. Only set for CDC events"
+                    }
+                  },
+                  "type": "object",
+                  "required": [
+                    "schema",
+                    "table",
+                    "lsn",
+                    "seqval"
+                  ]
+                }
+              },
+              "reduce": {
+                "strategy": "merge"
+              }
+            }
+          }
+        },
+        {
+          "$ref": "#DboTest_ComputedColumn_18851564"
+        }
+      ]
+    },
+    "key": [
+      "/id"
+    ]
+  }
+

--- a/source-sqlserver/main_test.go
+++ b/source-sqlserver/main_test.go
@@ -473,3 +473,35 @@ func TestDeletedTextColumn(t *testing.T) {
 	tb.Delete(ctx, t, tableName, "id", 2)
 	t.Run("main", func(t *testing.T) { tests.VerifiedCapture(ctx, t, cs) })
 }
+
+func TestComputedColumn(t *testing.T) {
+	var tb, ctx = sqlserverTestBackend(t), context.Background()
+	var uniqueID = "18851564"
+	var tableName = tb.CreateTable(ctx, t, uniqueID, "(id INTEGER PRIMARY KEY, a VARCHAR(32), b VARCHAR(32), computed AS ISNULL(a, ISNULL(b, 'default')))")
+
+	var cs = tb.CaptureSpec(ctx, t, regexp.MustCompile(uniqueID))
+	cs.Validator = &st.OrderedCaptureValidator{}
+	t.Cleanup(func() { sqlcapture.TestShutdownAfterCaughtUp = false })
+	sqlcapture.TestShutdownAfterCaughtUp = true
+
+	t.Run("discovery", func(t *testing.T) {
+		cs.VerifyDiscover(ctx, t, regexp.MustCompile(uniqueID))
+	})
+
+	t.Run("capture", func(t *testing.T) {
+		tb.Insert(ctx, t, tableName, [][]any{{0, "a0", "b0"}, {1, nil, "b1"}, {2, "a2", nil}, {3, nil, nil}})
+		cs.Capture(ctx, t, nil)
+		tb.Insert(ctx, t, tableName, [][]any{{4, "a4", "b4"}, {5, nil, "b5"}, {6, "a6", nil}, {7, nil, nil}})
+		cs.Capture(ctx, t, nil)
+		tb.Update(ctx, t, tableName, "id", 4, "a", "a4-modified")
+		tb.Update(ctx, t, tableName, "id", 5, "b", "b5-modified")
+		tb.Update(ctx, t, tableName, "id", 6, "a", "a6-modified")
+		cs.Capture(ctx, t, nil)
+		tb.Delete(ctx, t, tableName, "id", 4)
+		tb.Delete(ctx, t, tableName, "id", 5)
+		tb.Delete(ctx, t, tableName, "id", 6)
+		tb.Delete(ctx, t, tableName, "id", 7)
+		cs.Capture(ctx, t, nil)
+		cupaloy.SnapshotT(t, cs.Summary())
+	})
+}

--- a/sqlcapture/discovery.go
+++ b/sqlcapture/discovery.go
@@ -82,6 +82,10 @@ func DiscoverCatalog(ctx context.Context, db Database) ([]*pc.Response_Discovere
 		// Build `properties` schemas for each table column.
 		var properties = make(map[string]*jsonschema.Schema)
 		for _, column := range table.Columns {
+			if column.OmitColumn {
+				continue // Skip adding properties corresponding to omitted columns
+			}
+
 			var jsonType, err = db.TranslateDBToJSONType(column)
 			if err != nil {
 				// Unhandled types are translated to the catch-all schema {} but with

--- a/sqlcapture/interface.go
+++ b/sqlcapture/interface.go
@@ -230,4 +230,5 @@ type ColumnInfo struct {
 	IsNullable  bool        // True if the column can contain nulls.
 	DataType    interface{} // The datatype of this column. May be a string name or a more complex struct.
 	Description *string     // Stored description of the column, if any.
+	OmitColumn  bool        // True if the column should be omitted from discovery JSON schema generation.
 }


### PR DESCRIPTION
**Description:**

According to [Microsoft documentation](https://learn.microsoft.com/en-us/sql/relational-databases/system-functions/cdc-fn-cdc-get-all-changes-capture-instance-transact-sql?view=sql-server-ver16):

> Computed columns that are included in a capture instance always have a value of NULL.

This means that we cannot capture computed column values via CDC. And if we can't capture them via CDC, then we shouldn't capture them in backfills either since the values could quickly become stale and incorrect. And if we're not capturing them via CDC or backfills then we shouldn't mention them in our discovered schemas either.

This fixes https://github.com/estuary/connectors/issues/1995

**Workflow steps:**

Captures will no longer include values for computed columns in their output documents. Since the computed columns aren't required this should always be fine.

Discovery will no longer mention computed columns in the generated schemas. Since we don't set `additionalProperties: false` this should not make any preexisting documents invalid.

However I'm not certain if this could qualify as a breaking change to the collection schema for other reasons, or how exactly materializations will handle the change.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2006)
<!-- Reviewable:end -->
