### PR TITLE
source-zendesk-support: fix Groups and Organizations streams

### DIFF
--- a/source-zendesk-support/source_zendesk_support/streams.py
+++ b/source-zendesk-support/source_zendesk_support/streams.py
@@ -10,7 +10,7 @@ import time
 from abc import ABC
 from collections import deque
 from concurrent.futures import Future, ProcessPoolExecutor
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, UTC
 from functools import partial
 from math import ceil
 from pickle import PickleError, dumps
@@ -73,6 +73,18 @@ def to_int(s):
             return res[0]
     return s
 
+
+def _s_to_dt_str(s: int) -> str:
+    """
+    Converts a UNIX timestamp in seconds to a date-time formatted string.
+    """
+    return datetime.fromtimestamp(s, tz=UTC).isoformat(' ')
+
+def _dt_str_to_s(dt_str: str) -> int:
+    """
+    Converts a date-time formatted string to a UNIX timestamp in seconds.
+    """
+    return int(datetime.fromisoformat(dt_str).timestamp())
 
 class SourceZendeskException(Exception):
     """default exception of custom SourceZendesk logic"""
@@ -507,6 +519,74 @@ class SourceZendeskIncrementalExportStream(SourceZendeskSupportCursorPaginationS
             yield record
 
 
+class SourceZendeskSupportIncrementalTimeExportStream(SourceZendeskSupportFullRefreshStream, IncrementalMixin):
+    """
+    Incremental time-based export streams.
+    API docs: https://developer.zendesk.com/documentation/ticketing/managing-tickets/using-the-incremental-export-api/#time-based-incremental-exports
+    Airbyte Incremental Stream Docs: https://docs.airbyte.com/connector-development/cdk-python/incremental-stream for some background.
+
+    Uses IncrementalMixin's state setter & getter to persist cursors between requests.
+
+    Note: Incremental time-based export streams theoretically can get stuck in a loop if
+    1000+ resources are updated at the exact same time.
+    """
+    state_checkpoint_interval = 1000
+    _cursor_value = ""
+
+    @property
+    def cursor_field(self) -> str:
+        """Name of the field associated with the state"""
+        return "updated_at"
+
+    @property
+    def state(self) -> Mapping[str, Any]:
+        return {self.cursor_field: self._cursor_value}
+
+    @state.setter
+    def state(self, value: Mapping[str, Any]):
+        self._cursor_value = value[self.cursor_field]
+
+    def path(self, **kwargs) -> str:
+        return f"incremental/{self.response_list_name}"
+
+    def next_page_token(self, response: requests.Response) -> Optional[Mapping[str, Any]]:
+        if self._ignore_pagination:
+            return None
+
+        response_json = response.json()
+
+        pagination_complete = response_json.get(END_OF_STREAM_KEY, False)
+        if pagination_complete:
+            return None
+
+        next_start_time = response_json.get("end_time", None)
+        if next_start_time:
+            return {"start_time": next_start_time}
+
+    def request_params(
+        self, stream_state: Mapping[str, Any], stream_slice: Mapping[str, Any] = None, next_page_token: Mapping[str, Any] = None,
+    ) -> MutableMapping[str, Any]:
+        if next_page_token:
+            return next_page_token
+
+        start_time_state = self.state.get(self.cursor_field, None)
+        if start_time_state:
+            return {"start_time": _dt_str_to_s(start_time_state)}
+        else:
+            return {"start_time": calendar.timegm(pendulum.parse(self._start_date).utctimetuple())}
+
+    def parse_response(self, response: requests.Response, **kwargs) -> Iterable[Mapping]:
+        response_json = response.json()
+
+        records = response_json.get(self.response_list_name, [])
+        for record in records:
+            yield record
+        
+        cursor = response_json.get("end_time", None)
+        if cursor and len(records) != 0:
+            self.state = {self.cursor_field: _s_to_dt_str(cursor)}
+
+
 class SourceZendeskSupportIncrementalCursorExportStream(SourceZendeskIncrementalExportStream, IncrementalMixin):
     """
     Incremental cursor export for Users and Tickets streams
@@ -654,6 +734,17 @@ class SourceZendeskSupportTicketEventsExportStream(SourceZendeskIncrementalExpor
                     yield event
 
 
+class Organizations(SourceZendeskSupportIncrementalTimeExportStream):
+    """
+    API docs: https://developer.zendesk.com/api-reference/ticketing/ticket-management/incremental_exports/#incremental-organization-export
+
+    Note: This stream theoretically can get stuck in a loop if 1000+ organizations are
+    updated at the exact same time. I don't anticipate this will be an issue, but we
+    should keep this in mind if we notice an Organizations stream is stuck.
+    """
+    response_list_name = "organizations"
+
+
 class OrganizationMemberships(SourceZendeskSupportCursorPaginationStream):
     """OrganizationMemberships stream: https://developer.zendesk.com/api-reference/ticketing/organizations/organization_memberships/"""
 
@@ -716,10 +807,6 @@ class Users(SourceZendeskSupportIncrementalCursorExportStream):
     """Users stream: https://developer.zendesk.com/api-reference/ticketing/ticket-management/incremental_exports/#incremental-user-export-cursor-based"""
 
     response_list_name: str = "users"
-
-
-class Organizations(SourceZendeskSupportStream):
-    """Organizations stream: https://developer.zendesk.com/api-reference/ticketing/ticket-management/incremental_exports/"""
 
 
 class Tickets(SourceZendeskSupportIncrementalCursorExportStream):

--- a/source-zendesk-support/source_zendesk_support/streams.py
+++ b/source-zendesk-support/source_zendesk_support/streams.py
@@ -756,6 +756,17 @@ class TicketComments(SourceZendeskSupportTicketEventsExportStream):
 
 class Groups(SourceZendeskSupportStream):
     """Groups stream: https://developer.zendesk.com/api-reference/ticketing/groups/groups/"""
+    def request_params(
+        self,
+        stream_state: Mapping[str, Any] = None,
+        next_page_token: Mapping[str, Any] = None,
+        **kwargs
+    ) -> MutableMapping[str, Any]:
+        params = super().request_params(stream_state=stream_state, next_page_token=next_page_token, **kwargs)
+        # Zendesk by default excludes deleted groups. To include deleted groups in the API response, we have to
+        # use the exclude_deleted query param.
+        params.update({"exclude_deleted": False})
+        return params
 
 
 class GroupMemberships(SourceZendeskSupportCursorPaginationStream):

--- a/source-zendesk-support/tests/snapshots/snapshots__capture__capture.stdout.json
+++ b/source-zendesk-support/tests/snapshots/snapshots__capture__capture.stdout.json
@@ -75,6 +75,7 @@
         "uuid": "DocUUIDPlaceholder-329Bb50aa48EAa9ef"
       },
       "created_at": "2024-07-26T15:41:00Z",
+      "deleted_at": null,
       "details": "",
       "domain_names": [],
       "external_id": null,

--- a/source-zendesk-support/tests/test_futures.py
+++ b/source-zendesk-support/tests/test_futures.py
@@ -15,7 +15,7 @@ from airbyte_cdk.models import SyncMode
 from airbyte_cdk.sources.streams.http.exceptions import DefaultBackoffException
 from requests.exceptions import ConnectionError
 from source_zendesk_support.source import BasicApiTokenAuthenticator
-from source_zendesk_support.streams import Macros, Organizations
+from source_zendesk_support.streams import Macros, Organizations, Groups
 
 STREAM_ARGS: dict = {
     "subdomain": "fake-subdomain",
@@ -141,7 +141,7 @@ def test_sleep_time():
     pages = 4
 
     start = datetime.datetime.now()
-    stream = Organizations(**STREAM_ARGS)
+    stream = Groups(**STREAM_ARGS)
     stream.page_size = page_size
 
     def record_gen(start=0, end=100):
@@ -164,7 +164,7 @@ def test_sleep_time():
             {
                 "status_code": 200,
                 "headers": {},
-                "text": json.dumps({"organizations": list(record_gen(page * page_size, min(records_count, (page + 1) * page_size)))})
+                "text": json.dumps({"groups": list(record_gen(page * page_size, min(records_count, (page + 1) * page_size)))})
             }
             for page in range(pages)
         ]

--- a/source-zendesk-support/tests/unit_test.py
+++ b/source-zendesk-support/tests/unit_test.py
@@ -291,7 +291,7 @@ class TestAllStreams:
             (GroupMemberships, "group_memberships"),
             (Groups, "groups"),
             (Macros, "macros"),
-            (Organizations, "organizations"),
+            (Organizations, "incremental/organizations"),
             (OrganizationMemberships, "organization_memberships"),
             (SatisfactionRatings, "satisfaction_ratings"),
             (SlaPolicies, "slas/policies.json"),
@@ -340,14 +340,12 @@ class TestSourceZendeskSupportStream:
         "stream_cls",
         [
             (Macros),
-            (Organizations),
             (Groups),
             (SatisfactionRatings),
             (TicketFields),
         ],
         ids=[
             "Macros",
-            "Organizations",
             "Groups",
             "SatisfactionRatings",
             "TicketFields",
@@ -390,19 +388,12 @@ class TestSourceZendeskSupportStream:
         "stream_cls, current_state, last_record, expected",
         [
             (Macros, {}, {"updated_at": "2022-03-17T16:03:07Z"}, {"updated_at": "2022-03-17T16:03:07Z"}),
-            (
-                Organizations,
-                {"updated_at": "2022-03-17T16:03:07Z"},
-                {"updated_at": "2023-03-17T16:03:07Z"},
-                {"updated_at": "2023-03-17T16:03:07Z"},
-            ),
             (Groups, {}, {"updated_at": "2022-03-17T16:03:07Z"}, {"updated_at": "2022-03-17T16:03:07Z"}),
             (SatisfactionRatings, {}, {"updated_at": "2022-03-17T16:03:07Z"}, {"updated_at": "2022-03-17T16:03:07Z"}),
             (TicketFields, {}, {"updated_at": "2022-03-17T16:03:07Z"}, {"updated_at": "2022-03-17T16:03:07Z"}),
         ],
         ids=[
             "Macros",
-            "Organizations",
             "Groups",
             "SatisfactionRatings",
             "TicketFields",
@@ -417,13 +408,11 @@ class TestSourceZendeskSupportStream:
         "stream_cls, expected",
         [
             (Macros, None),
-            (Organizations, None),
             (Groups, None),
             (TicketFields, None),
         ],
         ids=[
             "Macros",
-            "Organizations",
             "Groups",
             "TicketFields",
         ],
@@ -437,13 +426,11 @@ class TestSourceZendeskSupportStream:
         "stream_cls, expected",
         [
             (Macros, {"start_time": 1622505600}),
-            (Organizations, {"start_time": 1622505600}),
             (Groups, {"start_time": 1622505600, "exclude_deleted": False}),
             (TicketFields, {"start_time": 1622505600}),
         ],
         ids=[
             "Macros",
-            "Organizations",
             "Groups",
             "TicketFields",
         ],
@@ -682,11 +669,13 @@ class TestSourceZendeskIncrementalExportStream:
             (Users),
             (Tickets),
             (TicketMetrics),
+            (Organizations),
         ],
         ids=[
             "Users",
             "Tickets",
-            "TicketMetrics"
+            "TicketMetrics",
+            "Organizations",
         ],
     )
     def test_next_page_token(self, requests_mock, stream_cls):
@@ -703,11 +692,13 @@ class TestSourceZendeskIncrementalExportStream:
             (Users, {"start_time": 1622505600}),
             (Tickets, {"start_time": 1622505600}),
             (TicketMetrics, {"start_time": 1622505600, "include": "metric_sets"}),
+            (Organizations, {"start_time": 1622505600}),
         ],
         ids=[
             "Users",
             "Tickets",
-            "TicketMetrics"
+            "TicketMetrics",
+            "Organizations",
         ],
     )
     def test_request_params(self, stream_cls, expected):
@@ -720,10 +711,12 @@ class TestSourceZendeskIncrementalExportStream:
         [
             (Users),
             (Tickets),
+            (Organizations),
         ],
         ids=[
             "Users",
             "Tickets",
+            "Organizations",
         ],
     )
     def test_parse_response(self, requests_mock, stream_cls):

--- a/source-zendesk-support/tests/unit_test.py
+++ b/source-zendesk-support/tests/unit_test.py
@@ -438,7 +438,7 @@ class TestSourceZendeskSupportStream:
         [
             (Macros, {"start_time": 1622505600}),
             (Organizations, {"start_time": 1622505600}),
-            (Groups, {"start_time": 1622505600}),
+            (Groups, {"start_time": 1622505600, "exclude_deleted": False}),
             (TicketFields, {"start_time": 1622505600}),
         ],
         ids=[


### PR DESCRIPTION
**Description:**

The `Groups` and `Organizations` streams were missing data. This PR addresses the issues causing these streams to miss data.

### `Groups`
Deleted groups were not being retrieved previously. By including the `exclude_deleted` query param and setting it to `false`, the Zendesk Support API is now returning deleted groups.

### `Organizations`
Only 10k organizations were being retrieved previously. The `Organizations` stream was using page numbers to paginate through results. This is an older, but still supported, pagination method for Zendesk Support, and they only allow you to paginate through 10k results even if there are more. Using the page number based pagination method was causing us to only retrieve 10k documents and miss any remaining ones.

I've updated the `Organizations` stream to use Zendesk's [time-based incremental export](https://developer.zendesk.com/documentation/ticketing/managing-tickets/using-the-incremental-export-api/#time-based-incremental-exports) endpoint. This endpoint paginates by providing a start time, and all resources created/updated at or after that start time are returned. This lets us retrieve all resources instead of just a subset. This pagination strategy does have the potential downside of getting stuck in a loop if 1000+ (the max number of results per page) resources are updated at the exact same time, but there aren't currently better ways to retrieve incremental updates for `Organizations`.

Capture snapshot changes are expected. The new time-based incremental export endpoint adds a `deleted_at` property to each organization resource.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

Tested on a local stack with a Zendesk account that had deleted groups and more than 10k organizations. Confirmed: 
- deleted groups are now retrieved 
- more than 10k organizations are retrieved
- updated tests pass

All `Organizations` bindings for existing tasks need to be backfilled after merging to clear out previous state.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2007)
<!-- Reviewable:end -->
