### PR TITLE
models: quoted_* methods return str, not bool

### DIFF
--- a/source-oracle-flashback/source_oracle_flashback/models.py
+++ b/source-oracle-flashback/source_oracle_flashback/models.py
@@ -215,7 +215,7 @@ class OracleColumn(BaseModel, extra="forbid"):
     nullable: bool = Field(default=True, alias="NULLABLE")
 
     @computed_field
-    def quoted_column_name(self) -> bool:
+    def quoted_column_name(self) -> str:
         return quote_identifier(self.column_name)
 
     @computed_field
@@ -253,11 +253,11 @@ class Table:
     model_fields: dict[str, Any]
 
     @computed_field
-    def quoted_owner(self) -> bool:
+    def quoted_owner(self) -> str:
         return quote_identifier(self.owner)
 
     @computed_field
-    def quoted_table_name(self) -> bool:
+    def quoted_table_name(self) -> str:
         return quote_identifier(self.table_name)
 
     def create_model(self) -> type[Document]:


### PR DESCRIPTION
**Description:**

- We were getting tons of these errors:
```
Expected `bool` but got `str` - serialized value may not be as expected
```

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2009)
<!-- Reviewable:end -->
