### PR TITLE
source-zendesk-support: switch Groups stream to use cursor pagination

### DIFF
--- a/source-zendesk-support/source_zendesk_support/streams.py
+++ b/source-zendesk-support/source_zendesk_support/streams.py
@@ -841,15 +841,16 @@ class TicketComments(SourceZendeskSupportTicketEventsExportStream):
             yield record
 
 
-class Groups(SourceZendeskSupportStream):
+class Groups(SourceZendeskSupportCursorPaginationStream):
     """Groups stream: https://developer.zendesk.com/api-reference/ticketing/groups/groups/"""
+
     def request_params(
         self,
-        stream_state: Mapping[str, Any] = None,
+        stream_state: Mapping[str, Any],
+        stream_slice: Mapping[str, Any] = None,
         next_page_token: Mapping[str, Any] = None,
-        **kwargs
     ) -> MutableMapping[str, Any]:
-        params = super().request_params(stream_state=stream_state, next_page_token=next_page_token, **kwargs)
+        params = super().request_params(stream_state=stream_state, stream_slice=stream_slice, next_page_token=next_page_token)
         # Zendesk by default excludes deleted groups. To include deleted groups in the API response, we have to
         # use the exclude_deleted query param.
         params.update({"exclude_deleted": False})

--- a/source-zendesk-support/tests/test_futures.py
+++ b/source-zendesk-support/tests/test_futures.py
@@ -141,7 +141,7 @@ def test_sleep_time():
     pages = 4
 
     start = datetime.datetime.now()
-    stream = Groups(**STREAM_ARGS)
+    stream = Macros(**STREAM_ARGS)
     stream.page_size = page_size
 
     def record_gen(start=0, end=100):
@@ -164,7 +164,7 @@ def test_sleep_time():
             {
                 "status_code": 200,
                 "headers": {},
-                "text": json.dumps({"groups": list(record_gen(page * page_size, min(records_count, (page + 1) * page_size)))})
+                "text": json.dumps({"macros": list(record_gen(page * page_size, min(records_count, (page + 1) * page_size)))})
             }
             for page in range(pages)
         ]

--- a/source-zendesk-support/tests/unit_test.py
+++ b/source-zendesk-support/tests/unit_test.py
@@ -340,13 +340,11 @@ class TestSourceZendeskSupportStream:
         "stream_cls",
         [
             (Macros),
-            (Groups),
             (SatisfactionRatings),
             (TicketFields),
         ],
         ids=[
             "Macros",
-            "Groups",
             "SatisfactionRatings",
             "TicketFields",
         ],
@@ -365,7 +363,6 @@ class TestSourceZendeskSupportStream:
         [
             (Macros),
             (Organizations),
-            (Groups),
             (SatisfactionRatings),
             (TicketFields),
             (TicketMetrics),
@@ -373,7 +370,6 @@ class TestSourceZendeskSupportStream:
         ids=[
             "Macros",
             "Organizations",
-            "Groups",
             "SatisfactionRatings",
             "TicketFields",
             "TicketMetrics",
@@ -408,12 +404,10 @@ class TestSourceZendeskSupportStream:
         "stream_cls, expected",
         [
             (Macros, None),
-            (Groups, None),
             (TicketFields, None),
         ],
         ids=[
             "Macros",
-            "Groups",
             "TicketFields",
         ],
     )
@@ -426,12 +420,10 @@ class TestSourceZendeskSupportStream:
         "stream_cls, expected",
         [
             (Macros, {"start_time": 1622505600}),
-            (Groups, {"start_time": 1622505600, "exclude_deleted": False}),
             (TicketFields, {"start_time": 1622505600}),
         ],
         ids=[
             "Macros",
-            "Groups",
             "TicketFields",
         ],
     )
@@ -522,6 +514,7 @@ class TestSourceZendeskSupportCursorPaginationStream:
     @pytest.mark.parametrize(
         "stream_cls, current_state, last_record, expected",
         [
+            (Groups, {}, {"updated_at": "2022-03-17T16:03:07Z"}, {"updated_at": "2022-03-17T16:03:07Z"}),
             (GroupMemberships, {}, {"updated_at": "2022-03-17T16:03:07Z"}, {"updated_at": "2022-03-17T16:03:07Z"}),
             (TicketForms, {}, {"updated_at": "2023-03-17T16:03:07Z"}, {"updated_at": "2023-03-17T16:03:07Z"}),
             (TicketMetricEvents, {}, {"time": "2024-03-17T16:03:07Z"}, {"time": "2024-03-17T16:03:07Z"}),
@@ -529,6 +522,7 @@ class TestSourceZendeskSupportCursorPaginationStream:
             (OrganizationMemberships, {}, {"updated_at": "2025-03-17T16:03:07Z"}, {"updated_at": "2025-03-17T16:03:07Z"}),
         ],
         ids=[
+            "Groups",
             "GroupMemberships",
             "TicketForms",
             "TicketMetricEvents",
@@ -544,6 +538,7 @@ class TestSourceZendeskSupportCursorPaginationStream:
     @pytest.mark.parametrize(
         "stream_cls, response, expected",
         [
+            (Groups, {}, None),
             (GroupMemberships, {}, None),
             (TicketForms, {}, None),
             (TicketMetricEvents, {}, None),
@@ -562,6 +557,7 @@ class TestSourceZendeskSupportCursorPaginationStream:
             ),
         ],
         ids=[
+            "Groups",
             "GroupMemberships",
             "TicketForms",
             "TicketMetricEvents",
@@ -581,6 +577,7 @@ class TestSourceZendeskSupportCursorPaginationStream:
     @pytest.mark.parametrize(
         "stream_cls, expected",
         [
+            (Groups, 1622505600),
             (GroupMemberships, 1622505600),
             (TicketForms, 1622505600),
             (TicketMetricEvents, 1622505600),
@@ -588,6 +585,7 @@ class TestSourceZendeskSupportCursorPaginationStream:
             (OrganizationMemberships, 1622505600),
         ],
         ids=[
+            "Groups",
             "GroupMemberships",
             "TicketForms",
             "TicketMetricEvents",
@@ -603,6 +601,7 @@ class TestSourceZendeskSupportCursorPaginationStream:
     @pytest.mark.parametrize(
         "stream_cls, expected",
         [
+            (Groups, {"page[size]": 100, "start_time": 1622505600, "exclude_deleted": False}),
             (GroupMemberships, {"page[size]": 100, "start_time": 1622505600, "sort_by": "asc"}),
             (TicketForms, {}),
             (TicketMetricEvents, {"page[size]": 1000, "start_time": 1622505600}),
@@ -611,6 +610,7 @@ class TestSourceZendeskSupportCursorPaginationStream:
             (OrganizationMemberships, {"page[size]": 100, "start_time": 1622505600})
         ],
         ids=[
+            "Groups",
             "GroupMemberships",
             "TicketForms",
             "TicketMetricEvents",


### PR DESCRIPTION
**Description:**

Previously, the `Groups` stream was inheriting from the `BaseSourceZendeskSupportStream` class, meaning it paginated by retrieving the total number of results from a `/count` endpoint, calculated how many pages there should be based off that count, then concurrently sent requests for those pages of results. When I added the `exclude_deleted` param earlier to all `Groups` requests, I didn't ensure that the `/count` endpoint would include deleted groups. It does not, and it doesn't accept the `exclude_deleted` query param. So when the connector was calculating how many pages there should be, it wasn't including deleted groups in the total count, and we were missing results.

Instead of keeping `Groups` as a `BaseSourceZendeskSupportStream` that uses this older method of pagination, I switched `Groups` to use cursor pagination. The stream's behaviour and document schema remained the same, only how it queries the Zendesk API changed. 

We should move `Macros` and `TicketFields` off of `BaseSourceZendeskSupportStream` too since their current pagination method has limitations that don't exist for the newer cursor pagination-based classes, but that can be done at a later time.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

Tested on a local stack. Confirmed:
- All results for `Groups` were retrieved.
- All tests pass.

