### PR TITLE
source-zendesk-support: checkpoint `TicketMetricEvents` state after every 1000 documents

### DIFF
--- a/source-zendesk-support/source_zendesk_support/streams.py
+++ b/source-zendesk-support/source_zendesk_support/streams.py
@@ -932,6 +932,7 @@ class TicketMetricEvents(SourceZendeskSupportCursorPaginationStream):
     TicketMetricEvents stream: https://developer.zendesk.com/api-reference/ticketing/tickets/ticket_metric_events/
     """
 
+    state_checkpoint_interval = 1000
     cursor_field = "time"
     page_size = 1000
 


### PR DESCRIPTION
**Description:**

Previously, `TicketMetricEvents` was only emitting documents and checkpointing state after reading all available documents from Zendesk Support & getting caught up to the present. `TicketMetricEvents` can take multiple hours to backfill, and any task restarts during the backfill cause `TicketMetricEvents` to start over completely instead of picking back up where it left off before the restart.

Setting [`state_checkpoint_interval`](https://docs.airbyte.com/connector-development/cdk-python/incremental-stream#interval-based-checkpointing) tells `TickeMetricEvents` to checkpoint state & emit documents after every 1000 documents, and this allows the stream to pick up where it left off if it's interrupted during a backfill.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

Tested on a local stack. Confirmed that `TicketMetricEvents` checkpoints state after every 1000 documents and uses the most recently checkpointed state if it's interrupted during a sweep/backfill.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2014)
<!-- Reviewable:end -->
