### PR TITLE
source-google-ads: fixing config transformations

### DIFF
--- a/source-google-ads/source_google_ads/custom_query_stream.py
+++ b/source-google-ads/source_google_ads/custom_query_stream.py
@@ -21,8 +21,9 @@ class CustomQueryMixin:
         It will be ignored if provided.
         If you need to enable it, uncomment the next line instead of `return None` and modify your config
         """
-        # return self.config.get("primary_key") or None
-        return None
+        # TODO luis: Thats a quick hack to pass validation step with already created custom queries, will be removed along
+        # with the new custom query creation
+        return ["segments.date"]
 
     @property
     def name(self):

--- a/source-google-ads/source_google_ads/source.py
+++ b/source-google-ads/source_google_ads/source.py
@@ -49,7 +49,8 @@ class SourceGoogleAds(AbstractSource):
             config.pop("end_date")
         for query in config.get("custom_queries", []):
             try:
-                query["query"] = GAQL.parse(query["query"])
+                if type(query["query"]) == str:
+                    query["query"] = GAQL.parse(query["query"])
             except ValueError:
                 message = f"The custom GAQL query {query['table_name']} failed. Validate your GAQL query with the Google Ads query validator. https://developers.google.com/google-ads/api/fields/v17/query_validator"
                 raise AirbyteTracedException(message=message, failure_type=FailureType.config_error)


### PR DESCRIPTION
google ads transformations were breaking due to something re-using the same variables from a earlier step. This made the config transformation step to break.

Also, custom queries were not working due to the lack of primary keys in the validation step. I've added a dud primary key, which will be replaced by the actual primary key input in newer version, in order to allow for already created streams to work


**Notes for reviewers:**

(anything that might help someone review this PR)

