### PR TITLE
source-pendo: validate API key

### DIFF
--- a/source-pendo/source_pendo/__init__.py
+++ b/source-pendo/source_pendo/__init__.py
@@ -14,7 +14,7 @@ from estuary_cdk.capture import (
 )
 from estuary_cdk.http import HTTPMixin
 
-from .resources import all_resources
+from .resources import all_resources, validate_api_key
 from .models import (
     ConnectorState,
     EndpointConfig,
@@ -48,6 +48,7 @@ class Connector(
         log: Logger,
         validate: request.Validate[EndpointConfig, ResourceConfig],
     ) -> response.Validated:
+        await validate_api_key(log, self, validate.config)
         resources = await all_resources(log, self, validate.config)
         resolved = common.resolve_bindings(validate.bindings, resources)
         return common.validated(resolved)


### PR DESCRIPTION
**Description:**

Previously, users could successfully create a task with an invalid Pendo API key. Pendo returns a `403` code when we send a request with an invalid API key, and we now key off that to prevent tasks with invalid API keys from being created.

A screenshot of the error rendered in the UI is below:
![image](https://github.com/user-attachments/assets/b76405ca-5523-4428-9d62-4225f4ae4006)

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

Tested on a local stack. Confirmed:
- an error is thrown before task creation when an invalid API key is provided. 
- tasks can still be created with a valid API key.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2020)
<!-- Reviewable:end -->
