### PR TITLE
source-mysql: More connection error logging

### DIFF
--- a/source-mysql-batch/main.go
+++ b/source-mysql-batch/main.go
@@ -91,6 +91,7 @@ func connectMySQL(ctx context.Context, cfg *Config) (*client.Conn, error) {
 		log.WithField("addr", cfg.Address).Info("connected without TLS")
 		conn = connWithoutTLS
 	} else {
+		log.WithFields(log.Fields{"withTLS": errWithTLS, "nonTLS": errWithoutTLS}).Error("unable to connect to database")
 		var mysqlErr *mysql.MyError
 		if errors.As(errWithTLS, &mysqlErr) && mysqlErr.Code == mysql.ER_ACCESS_DENIED_ERROR {
 			return nil, cerrors.NewUserError(mysqlErr, "incorrect username or password")

--- a/source-mysql/main.go
+++ b/source-mysql/main.go
@@ -222,6 +222,7 @@ func (db *mysqlDatabase) connect(_ context.Context) error {
 		logrus.WithField("addr", address).Info("connected without TLS")
 		db.conn = connWithoutTLS
 	} else {
+		logrus.WithFields(logrus.Fields{"withTLS": errWithTLS, "nonTLS": errWithoutTLS}).Error("unable to connect to database")
 		var mysqlErr *mysql.MyError
 		if errors.As(errWithTLS, &mysqlErr) && mysqlErr.Code == mysql.ER_ACCESS_DENIED_ERROR {
 			return cerrors.NewUserError(mysqlErr, "incorrect username or password")


### PR DESCRIPTION
**Description:**

I hate this TLS vs non-TLS connection retrying thing and how it results in two distinct errors, let's just make sure to log both so I can at least figure out what went wrong in all cases.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2031)
<!-- Reviewable:end -->
