### PR TITLE
source-http-ingest: use proper schema uri

### DIFF
--- a/source-http-ingest/tests/test.rs
+++ b/source-http-ingest/tests/test.rs
@@ -291,6 +291,7 @@ fn open_json() -> serde_json::Value {
                         "collection": {
                             "name": "aliceCo/test/webhook-data",
                             "write_schema_json": {
+                                "$id": "file:///some/fake/path.json",
                                 "type": "object",
                                 "properties": {
                                     "_meta": {


### PR DESCRIPTION
Fixes a bug in the source-http-ingest connector where it would use the incorrect uri in cases where the collection schema already contained an `$id`. Now it uses the uri that was actually resolved while building the schema.

Also tweaks the logging of errors to use the more complete degub representation.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2034)
<!-- Reviewable:end -->
