### PR TITLE
source-postgres: Discover 'citext' columns as strings

### DIFF
--- a/source-postgres/discovery.go
+++ b/source-postgres/discovery.go
@@ -182,7 +182,7 @@ func predictableColumnOrder(colType any) bool {
 	// Currently all textual primary key columns are considered to be 'unpredictable' so that backfills
 	// will default to using the 'imprecise' ordering semantics which avoids full-table sorts. Refer to
 	// https://github.com/estuary/connectors/issues/1343 for more details.
-	if colType == "varchar" || colType == "bpchar" || colType == "text" {
+	if colType == "varchar" || colType == "bpchar" || colType == "text" || colType == "citext" {
 		return false
 	} else if _, ok := colType.(postgresEnumType); ok {
 		return false
@@ -314,6 +314,7 @@ var postgresTypeToJSON = map[string]columnSchema{
 	"varchar": {jsonTypes: []string{"string"}},
 	"bpchar":  {jsonTypes: []string{"string"}},
 	"text":    {jsonTypes: []string{"string"}},
+	"citext":  {jsonTypes: []string{"string"}}, // From the 'citext' extension so we don't test it by default, but it hurts nothing to support it here
 	"bytea":   {jsonTypes: []string{"string"}, contentEncoding: "base64"},
 	"xml":     {jsonTypes: []string{"string"}},
 	"bit":     {jsonTypes: []string{"string"}},


### PR DESCRIPTION
**Description:**

The `citext` column type is added by the `citext` extension and stores text with a case-insensitive comparison operator. In my testing it looks like we're capturing these values correctly as strings, but discovery is emitting the catch-all schema which can cause some materializations to do...suboptimal things with those values.

This commit adds `"citext"` to the discovery type mapping table so it should work correctly, but doesn't add any test cases as it's an extension type (even though the extension is a standard part of the Postgres release and has been for ages so we could probably add the requisite `CREATE EXTENSION "citext"` statement to the test DB setup script and then treat it like any other built-in type...)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2035)
<!-- Reviewable:end -->
