### PR TITLE
source-postgres: Add 'Discover Only Published Tables' setting

### DIFF
--- a/source-postgres/.snapshots/TestGeneric-SpecResponse
+++ b/source-postgres/.snapshots/TestGeneric-SpecResponse
@@ -83,6 +83,11 @@
             "title": "Discovery Schema Selection",
             "description": "If this is specified only tables in the selected schema(s) will be automatically discovered. Omit all entries to discover tables from all schemas."
           },
+          "discover_only_published": {
+            "type": "boolean",
+            "title": "Discover Only Published Tables",
+            "description": "When set the capture will only discover tables which have already been added to the publication. This can be useful if you intend to manage which tables are captured by adding or removing them from the publication."
+          },
           "min_backfill_xid": {
             "type": "string",
             "title": "Minimum Backfill XID",

--- a/source-postgres/discovery.go
+++ b/source-postgres/discovery.go
@@ -164,6 +164,20 @@ func (db *postgresDatabase) discoverTables(ctx context.Context) (map[sqlcapture.
 		}
 	}
 
+	// If we've been asked to only discover tables which are already in the
+	// publication, go through and mark any non-published tables as omitted.
+	if db.config.Advanced.DiscoverOnlyPublished {
+		var publicationStatus, err = listPublishedTables(ctx, db.conn, db.config.Advanced.PublicationName)
+		if err != nil {
+			return nil, err
+		}
+		for streamID, info := range tableMap {
+			if !publicationStatus[streamID] {
+				info.OmitBinding = true
+			}
+		}
+	}
+
 	if logrus.IsLevelEnabled(logrus.DebugLevel) {
 		for id, info := range tableMap {
 			logrus.WithFields(logrus.Fields{

--- a/source-postgres/main.go
+++ b/source-postgres/main.go
@@ -96,14 +96,15 @@ type Config struct {
 }
 
 type advancedConfig struct {
-	PublicationName    string   `json:"publicationName,omitempty" jsonschema:"default=flow_publication,description=The name of the PostgreSQL publication to replicate from."`
-	SlotName           string   `json:"slotName,omitempty" jsonschema:"default=flow_slot,description=The name of the PostgreSQL replication slot to replicate from."`
-	WatermarksTable    string   `json:"watermarksTable,omitempty" jsonschema:"default=public.flow_watermarks,description=The name of the table used for watermark writes during backfills. Must be fully-qualified in '<schema>.<table>' form."`
-	SkipBackfills      string   `json:"skip_backfills,omitempty" jsonschema:"title=Skip Backfills,description=A comma-separated list of fully-qualified table names which should not be backfilled."`
-	BackfillChunkSize  int      `json:"backfill_chunk_size,omitempty" jsonschema:"title=Backfill Chunk Size,default=50000,description=The number of rows which should be fetched from the database in a single backfill query."`
-	SSLMode            string   `json:"sslmode,omitempty" jsonschema:"title=SSL Mode,description=Overrides SSL connection behavior by setting the 'sslmode' parameter.,enum=disable,enum=allow,enum=prefer,enum=require,enum=verify-ca,enum=verify-full"`
-	DiscoverSchemas    []string `json:"discover_schemas,omitempty" jsonschema:"title=Discovery Schema Selection,description=If this is specified only tables in the selected schema(s) will be automatically discovered. Omit all entries to discover tables from all schemas."`
-	MinimumBackfillXID string   `json:"min_backfill_xid,omitempty" jsonschema:"title=Minimum Backfill XID,description=Only backfill rows with XMIN values greater (in a 32-bit modular comparison) than the specified XID. Helpful for reducing re-backfill data volume in certain edge cases." jsonschema_extras:"pattern=^[0-9]+$"`
+	PublicationName       string   `json:"publicationName,omitempty" jsonschema:"default=flow_publication,description=The name of the PostgreSQL publication to replicate from."`
+	SlotName              string   `json:"slotName,omitempty" jsonschema:"default=flow_slot,description=The name of the PostgreSQL replication slot to replicate from."`
+	WatermarksTable       string   `json:"watermarksTable,omitempty" jsonschema:"default=public.flow_watermarks,description=The name of the table used for watermark writes during backfills. Must be fully-qualified in '<schema>.<table>' form."`
+	SkipBackfills         string   `json:"skip_backfills,omitempty" jsonschema:"title=Skip Backfills,description=A comma-separated list of fully-qualified table names which should not be backfilled."`
+	BackfillChunkSize     int      `json:"backfill_chunk_size,omitempty" jsonschema:"title=Backfill Chunk Size,default=50000,description=The number of rows which should be fetched from the database in a single backfill query."`
+	SSLMode               string   `json:"sslmode,omitempty" jsonschema:"title=SSL Mode,description=Overrides SSL connection behavior by setting the 'sslmode' parameter.,enum=disable,enum=allow,enum=prefer,enum=require,enum=verify-ca,enum=verify-full"`
+	DiscoverSchemas       []string `json:"discover_schemas,omitempty" jsonschema:"title=Discovery Schema Selection,description=If this is specified only tables in the selected schema(s) will be automatically discovered. Omit all entries to discover tables from all schemas."`
+	DiscoverOnlyPublished bool     `json:"discover_only_published,omitempty" jsonschema:"title=Discover Only Published Tables,description=When set the capture will only discover tables which have already been added to the publication. This can be useful if you intend to manage which tables are captured by adding or removing them from the publication."`
+	MinimumBackfillXID    string   `json:"min_backfill_xid,omitempty" jsonschema:"title=Minimum Backfill XID,description=Only backfill rows with XMIN values greater (in a 32-bit modular comparison) than the specified XID. Helpful for reducing re-backfill data volume in certain edge cases." jsonschema_extras:"pattern=^[0-9]+$"`
 }
 
 // Validate checks that the configuration possesses all required properties.


### PR DESCRIPTION
**Description:**

This is an advanced option which, when set, instructs the capture to only return discovery results for tables which are already in the publication.

This is useful in cases where users might wish to administer the set of tables which are being captured by adding or removing the table from the publication in the source DB.

I implemented a test case for this, but since our CI test database is currently created with a `FOR ALL TABLES` publication it can't currently be added to the CI test suite.

**Workflow steps:**

By default nothing should change. When the advanced option "Discover Only Published Tables" is enabled, the capture will omit discovery bindings for any tables which aren't already present in the publication. This allows users to control which tables are to be captured by adding or removing them from the publication, and everything should propagate downstream smoothly from there.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2042)
<!-- Reviewable:end -->
