### PR TITLE
source-zendesk-support: omit tags from capture snapshot

### DIFF
--- a/source-zendesk-support/tests/snapshots/snapshots__capture__capture.stdout.json
+++ b/source-zendesk-support/tests/snapshots/snapshots__capture__capture.stdout.json
@@ -297,18 +297,6 @@
     }
   ],
   [
-    "acmeCo/tags",
-    {
-      "_meta": {
-        "op": "u",
-        "row_id": 0,
-        "uuid": "DocUUIDPlaceholder-329Bb50aa48EAa9ef"
-      },
-      "name": "redacted",
-      "count": 1
-    }
-  ],
-  [
     "acmeCo/ticket_audits",
     {
       "_meta": {

--- a/source-zendesk-support/tests/test_snapshots.py
+++ b/source-zendesk-support/tests/test_snapshots.py
@@ -3,6 +3,10 @@ import subprocess
 
 
 def test_capture(request, snapshot):
+    OMITTED_STREAMS = [
+        "acmeCo/tags",
+    ]
+
     result = subprocess.run(
         [
             "flowctl",
@@ -25,7 +29,7 @@ def test_capture(request, snapshot):
 
     for line in lines:
         stream = line[0]
-        if stream not in seen:
+        if stream not in seen and stream not in OMITTED_STREAMS:
             unique_stream_lines.append(line)
             seen.add(stream)
 
@@ -37,13 +41,6 @@ def test_capture(request, snapshot):
             rec["updated_at"] = "redacted"
         if "last_login_at" in rec:
             rec["last_login_at"] = "redacted"
-        if stream == "acmeCo/tags":
-            rec["name"] = "redacted"
-            # Updating count with rec["count"] = 1 sets count to be
-            # the tuple [1] instead of the int 1. We can get around
-            # this by deleting the attribute then re-setting it.
-            del rec["count"]
-            rec["count"] = 1
 
 
     assert snapshot("capture.stdout.json") == unique_stream_lines


### PR DESCRIPTION
**Description:**

The [`/tags`](https://developer.zendesk.com/api-reference/ticketing/ticket-management/tags/#list-tags) endpoint returns the most popular tags used in the last 60 days. After 60 days, it's possible for existing tags to not be returned if they weren't used recently. Because we aren't going into Zendesk & using tags every once in a while, the capture snapshot has been failing in CI. Instead of making a reminder to go into Zendesk every 2 months and use a tag, I think it's easier to just remove tags from the capture snapshot.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

Confirmed snapshot tests passed locally.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2044)
<!-- Reviewable:end -->
