### PR TITLE
source-mysql: Stop logging scary collation error messages

### DIFF
--- a/source-mysql/discovery.go
+++ b/source-mysql/discovery.go
@@ -475,6 +475,15 @@ func getTables(_ context.Context, conn *client.Conn) ([]*sqlcapture.DiscoveryInf
 }
 
 func charsetFromCollation(name string) string {
+	// TODO(wgd): The only way we can end up with an empty collation name here is if the
+	// TABLE_COLLATION column of INFORMATION_SCHEMA.TABLES is empty. For now we can just
+	// assume it's UTF-8 compatible, but for perfect correctness we need to keep track of
+	// the server's default collation setting and use that here.
+	if name == "" {
+		logrus.Debug("assuming UTF-8 for unspecified collation(s)")
+		return mysqlDefaultCharset
+	}
+
 	// According to https://dev.mysql.com/doc/refman/8.4/en/information-schema-tables-table.html:
 	//
 	//     The output does not explicitly list the table default character set, but the collation


### PR DESCRIPTION
**Description:**

This isn't an error, it's not even a warning. We should improve this and track the server default collation as described in the new comment _eventually_, but for now it should suffice to just assume the default MySQL charset here.

Since that's what we already did, the only real impact of this change is to change the log message and severity in the specific case where the collation name is `""`.

**Notes for reviewers:**

This is a bit of a stopgap until I have time to add the aforementioned "keep track of the server default collation and use it here" logic. But it's a stopgap that prevents us logging dozens or hundreds of scary looking error messages which users might see and be justifiably concerned by, when really this is totally fine and benign in basically all circumstances.
