### PR TITLE
materialize-mysql: use longtext instead of JSON for mariadb

### DIFF
--- a/materialize-mysql/.snapshots/TestValidateAndApplyMigrationsMariaDB
+++ b/materialize-mysql/.snapshots/TestValidateAndApplyMigrationsMariaDB
@@ -1,0 +1,88 @@
+Base Initial Constraints:
+{"Field":"_meta/flow_truncated","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"Metadata fields fields are able to be materialized"}
+{"Field":"dateValue","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The projection has a single scalar type"}
+{"Field":"datetimeValue","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The projection has a single scalar type"}
+{"Field":"flow_document","Type":2,"TypeString":"LOCATION_REQUIRED","Reason":"The root document must be materialized"}
+{"Field":"flow_published_at","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The projection has a single scalar type"}
+{"Field":"int64","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The projection has a single scalar type"}
+{"Field":"intWidenedToJson","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The projection has a single scalar type"}
+{"Field":"key","Type":2,"TypeString":"LOCATION_REQUIRED","Reason":"All Locations that are part of the collections key are required"}
+{"Field":"multiple","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This field is able to be materialized"}
+{"Field":"nonScalarValue","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"Object fields may be materialized"}
+{"Field":"nullValue","Type":5,"TypeString":"FIELD_FORBIDDEN","Reason":"Cannot materialize a field where the only possible type is 'null'"}
+{"Field":"numericString","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The projection has a single scalar type"}
+{"Field":"optional","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"Object fields may be materialized"}
+{"Field":"requiredNumeric","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The projection has a single scalar type"}
+{"Field":"scalarValue","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The projection has a single scalar type"}
+{"Field":"second_root","Type":5,"TypeString":"FIELD_FORBIDDEN","Reason":"Only a single root document projection can be materialized for standard updates"}
+{"Field":"stringWidenedToJson","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The projection has a single scalar type"}
+{"Field":"timeValue","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The projection has a single scalar type"}
+
+Migratable Changes Before Apply Schema:
+{"Name":"_meta/flow_truncated","Nullable":"NO","Type":"tinyint"}
+{"Name":"dateValue","Nullable":"YES","Type":"date"}
+{"Name":"datetimeValue","Nullable":"YES","Type":"datetime"}
+{"Name":"flow_document","Nullable":"NO","Type":"longtext"}
+{"Name":"flow_published_at","Nullable":"NO","Type":"datetime"}
+{"Name":"int64","Nullable":"YES","Type":"bigint"}
+{"Name":"intWidenedToJson","Nullable":"YES","Type":"bigint"}
+{"Name":"key","Nullable":"NO","Type":"varchar"}
+{"Name":"multiple","Nullable":"YES","Type":"longtext"}
+{"Name":"nonScalarValue","Nullable":"YES","Type":"longtext"}
+{"Name":"numericString","Nullable":"YES","Type":"decimal"}
+{"Name":"optional","Nullable":"YES","Type":"longtext"}
+{"Name":"requiredNumeric","Nullable":"NO","Type":"decimal"}
+{"Name":"scalarValue","Nullable":"NO","Type":"longtext"}
+{"Name":"stringWidenedToJson","Nullable":"YES","Type":"longtext"}
+{"Name":"timeValue","Nullable":"YES","Type":"time"}
+
+
+Migratable Changes Before Apply Data:
+key (VARCHAR), _meta/flow_truncated (TINYINT), dateValue (DATE), datetimeValue (DATETIME), flow_published_at (DATETIME), int64 (BIGINT), intWidenedToJson (BIGINT), multiple (TEXT), nonScalarValue (TEXT), numericString (DECIMAL), optional (TEXT), requiredNumeric (DECIMAL), scalarValue (TEXT), stringWidenedToJson (TEXT), timeValue (TIME), flow_document (TEXT)
+
+1, 0, 2024-01-01, 2024-01-01 01:01:01.111111, 2024-09-13 01:01:01.000000, 1, 999, <nil>, <nil>, 123, <nil>, 456, test, hello, 01:01:01.000000, {}
+
+Migratable Changes Constraints:
+{"Field":"_meta/flow_truncated","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"dateValue","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"datetimeValue","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"flow_document","Type":1,"TypeString":"FIELD_REQUIRED","Reason":"This field is the document in the current materialization"}
+{"Field":"flow_published_at","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"int64","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"intWidenedToJson","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"key","Type":1,"TypeString":"FIELD_REQUIRED","Reason":"This field is a key in the current materialization"}
+{"Field":"multiple","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"nonScalarValue","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"nullValue","Type":5,"TypeString":"FIELD_FORBIDDEN","Reason":"Cannot materialize a field where the only possible type is 'null'"}
+{"Field":"numericString","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"optional","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"requiredNumeric","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"scalarValue","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"second_root","Type":5,"TypeString":"FIELD_FORBIDDEN","Reason":"Cannot materialize root document projection 'second_root' because field 'flow_document' is already being materialized as the document"}
+{"Field":"stringWidenedToJson","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"timeValue","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+
+Migratable Changes Applied Schema:
+{"Name":"_meta/flow_truncated","Nullable":"NO","Type":"tinyint"}
+{"Name":"dateValue","Nullable":"YES","Type":"longtext"}
+{"Name":"datetimeValue","Nullable":"YES","Type":"longtext"}
+{"Name":"flow_document","Nullable":"NO","Type":"longtext"}
+{"Name":"flow_published_at","Nullable":"NO","Type":"datetime"}
+{"Name":"int64","Nullable":"YES","Type":"bigint"}
+{"Name":"intWidenedToJson","Nullable":"YES","Type":"longtext"}
+{"Name":"key","Nullable":"NO","Type":"varchar"}
+{"Name":"multiple","Nullable":"YES","Type":"longtext"}
+{"Name":"nonScalarValue","Nullable":"YES","Type":"longtext"}
+{"Name":"numericString","Nullable":"YES","Type":"longtext"}
+{"Name":"optional","Nullable":"YES","Type":"longtext"}
+{"Name":"requiredNumeric","Nullable":"NO","Type":"longtext"}
+{"Name":"scalarValue","Nullable":"NO","Type":"longtext"}
+{"Name":"stringWidenedToJson","Nullable":"YES","Type":"longtext"}
+{"Name":"timeValue","Nullable":"YES","Type":"longtext"}
+
+
+Migratable Changes Applied Data:
+key (VARCHAR), _meta/flow_truncated (TINYINT), flow_published_at (DATETIME), int64 (BIGINT), multiple (TEXT), nonScalarValue (TEXT), optional (TEXT), scalarValue (TEXT), stringWidenedToJson (TEXT), flow_document (TEXT), dateValue (TEXT), datetimeValue (TEXT), intWidenedToJson (TEXT), numericString (TEXT), requiredNumeric (TEXT), timeValue (TEXT)
+
+1, 0, 2024-09-13 01:01:01.000000, 1, <nil>, <nil>, <nil>, test, hello, {}, 2024-01-01, 2024-01-01T01:01:01.111111Z, 999, 123, 456, 01:01:01.000000
+

--- a/materialize-mysql/docker-compose.yaml
+++ b/materialize-mysql/docker-compose.yaml
@@ -16,6 +16,21 @@ services:
     ports:
       - "3306:3306"
 
+  mariadb:
+    image: 'mariadb:11.5'
+    platform: linux/amd64
+    environment: {"MYSQL_DATABASE": "flow", "MYSQL_USER": "flow", "MYSQL_PASSWORD": "flow", "MYSQL_ROOT_PASSWORD": "flow"}
+    volumes:
+      - mariadb_data:/var/lib/mysql
+    networks:
+      - flow-test
+    healthcheck:
+      test: [ "CMD", "mysql", "-h", "127.0.0.1", "-u", "$MYSQL_USER", "--password=$MYSQL_PASSWORD", "--port", "3306", "--execute", "SHOW DATABASES;"]
+      interval: 1s
+      retries: 30
+    ports:
+      - "3305:3306"
+
 networks:
   flow-test:
     name: flow-test
@@ -23,3 +38,4 @@ networks:
 
 volumes:
   mysql_data: {}
+  mariadb_data: {}

--- a/materialize-mysql/sqlgen_test.go
+++ b/materialize-mysql/sqlgen_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-var testDialect = mysqlDialect(time.FixedZone("UTC", 0), "db")
+var testDialect = mysqlDialect(time.FixedZone("UTC", 0), "db", "mysql")
 
 func TestSQLGeneration(t *testing.T) {
 	var templates = renderTemplates(testDialect)


### PR DESCRIPTION
**Description:**

- [MariaDB does not have a distinct `JSON` type, it is instead a `LONGTEXT` alias](https://mariadb.com/kb/en/json-data-type/), so for MariaDB instances from now on we actually create a `LONGTEXT` to avoid confusing the connector over compatibility of MULTIPLE fields.
- Added MariaDB to our tests so we can check that flow_documents is not modified when running an Apply RPC against a MariaDB instance. I ran the tests and can confirm we do not attempt to migrate `flow_document` with this update. MySQL instances will retain their previous behavior (also verified using our tests).

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2053)
<!-- Reviewable:end -->
