### PR TITLE
source-postgres: Don't fetch column descriptions in system schemas

### DIFF
--- a/source-postgres/discovery.go
+++ b/source-postgres/discovery.go
@@ -592,6 +592,7 @@ const queryColumnDescriptions = `
 			isc.column_name,
 			pg_catalog.col_description(format('"%s"."%s"',isc.table_schema,isc.table_name)::regclass::oid,isc.ordinal_position) description
 		FROM information_schema.columns isc
+		WHERE isc.table_schema NOT IN ('pg_catalog', 'pg_internal', 'information_schema', 'catalog_history', 'cron', 'pglogical')
 	) as descriptions WHERE description != '';
 `
 


### PR DESCRIPTION
**Description:**

We already don't fetch the tables themselves from system schemas, so fetching column descriptions is pointless. And empirically, the part of the query expression that actually gets the description often fails with errors like `permission denied for schema cron` in production.

Hopefully if we explicitly filter out those schemas we'll see it succeed more often.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2054)
<!-- Reviewable:end -->
