### PR TITLE
materialize: add missing log message for when evaluating loads starts

### DIFF
--- a/materialize-boilerplate/logging.go
+++ b/materialize-boilerplate/logging.go
@@ -391,6 +391,7 @@ func (l *BindingEvents) do(fn func()) {
 // destination database.
 func (l *BindingEvents) StartedEvaluatingLoads() {
 	l.do(func() {
+		l.log(log.Fields{"round": l.round}, "started evaluating loads")
 		l.evaluatingLoadsStart = time.Now()
 
 		l.stopLogger = make(chan struct{})


### PR DESCRIPTION
**Description:**

Right now there is no immediate log message when evaluating loads starts, but there is supposed to be. This adds that missing log.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2055)
<!-- Reviewable:end -->
