### PR TITLE
source-mysql: Fix some benign error/warnings that get logged

### DIFF
--- a/source-mysql/discovery.go
+++ b/source-mysql/discovery.go
@@ -478,7 +478,7 @@ func charsetFromCollation(name string) string {
 	//
 	// We rely on this assumption to identify known charsets based on the decoders table here.
 	for charset := range mysqlStringDecoders {
-		if strings.HasPrefix(name, charset) {
+		if strings.HasPrefix(name, charset+"_") {
 			return charset
 		}
 	}
@@ -702,6 +702,8 @@ func decodeBytesToString(charset string, bs []byte) (string, error) {
 }
 
 var mysqlStringDecoders = map[string]func([]byte) (string, error){
+	"utf8":    decodeUTF8, // MariaDB alias for utf8mb3 or utf8mb4 depending on config. We don't care, it's all UTF-8 text to us.
+	"ascii":   decodeUTF8, // Guaranteed only ASCII characters (8-bit clean), meaning we can still treat it as UTF-8.
 	"utf8mb3": decodeUTF8,
 	"utf8mb4": decodeUTF8,
 	"latin1":  decodeLatin1,

--- a/source-mysql/replication.go
+++ b/source-mysql/replication.go
@@ -108,7 +108,7 @@ func (db *mysqlDatabase) ReplicationStream(ctx context.Context, startCursor stri
 		syncConfig.TLSConfig = nil
 		syncer = replication.NewBinlogSyncer(syncConfig)
 		if streamer, err = syncer.StartSync(pos); err == nil {
-			logrus.Warn("replication connected without TLS")
+			logrus.Info("replication connected without TLS")
 		} else {
 			return nil, fmt.Errorf("error starting binlog sync: %w", err)
 		}


### PR DESCRIPTION
**Description:**

The collation families `utf8_whatever` and `ascii_whatever` are explicitly added to the charsets table so we stop logging errors reading `unknown charset for collation, assuming UTF-8` and just do that without complaining because UTF-8 is in fact correct.

The `replication connected without TLS` log message is downgraded from WARN to INFO to match the main (non-replication) connection logging.

Between these fixes, that's all the main sources of errors and warnings in our production MySQL tasks, so hopefully that will be much less noisy to keep an eye on in the future.

This fixes https://github.com/estuary/connectors/issues/2056

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2058)
<!-- Reviewable:end -->
