### PR TITLE
source-oracle-flashback: make sure _meta/source/row_id is required

### DIFF
--- a/source-oracle-flashback/config.yaml
+++ b/source-oracle-flashback/config.yaml
@@ -22,8 +22,8 @@ sops:
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2024-08-25T06:31:24Z"
-    mac: ENC[AES256_GCM,data:b1xGx2t6eZ+xRb7hljIhZKQ8aKQgzdY1DUZjwioBMHO0CF6+7GobXeNgDgJQ/i/nPthU7oDpyUJFYJOGhWzNODP5CgEoMJdlGn8/+qFzprzODxXflkH4k4AiVvrrEFphvMIRxt98Z+vHmhhMY40dLch6kfXClxeiBdpF3Jsq1D0=,iv:pTDoakL/hGXDI/k+KcLrVZK070nu51KoDtiB6XBj924=,tag:+IOi6V5b4jqNzcyikzNQUw==,type:str]
+    lastmodified: "2024-10-16T11:20:22Z"
+    mac: ENC[AES256_GCM,data:SGN6RYWnIxGbG+SGVYctEbV1er6Rg271Rnd3nLdOSpIffR5AN2CY7IdCGrb6qAkTwIaG0ks2w3pDjgxtnjYLG3KvCEu2ee0yLJc0nZ2ShVfLyunrLpYXaGzORUYj4BMriDrs1fUIuovSDvFqTI1ApSnf7YJuqvXfjj7L0JdJ9Vw=,iv:PVNe9PfQkQOSJ8kAGLtinb/LPafb2ihYxbivZW+x9R4=,tag:DKgrACz46b5DJTLx4L9H/w==,type:str]
     pgp: []
     encrypted_suffix: _sops
     version: 3.8.1

--- a/source-oracle-flashback/source_oracle_flashback/models.py
+++ b/source-oracle-flashback/source_oracle_flashback/models.py
@@ -154,10 +154,10 @@ class Document(BaseDocument, extra="allow"):
                 description="Database System Change Number, available for incremental events"
             )
 
-        source: Source | None = Field(alias="source")
+        source: Source = Field(alias="source")
 
     meta_: Meta = Field(
-        default=Meta(op="u", source=None), alias="_meta", description="Document metadata"
+        alias="_meta", description="Document metadata"
     )
 
     pass

--- a/source-oracle-flashback/tests/snapshots/snapshots__discover__stdout.json
+++ b/source-oracle-flashback/tests/snapshots/snapshots__discover__stdout.json
@@ -21,14 +21,7 @@
               "type": "string"
             },
             "source": {
-              "anyOf": [
-                {
-                  "$ref": "#/$defs/Source"
-                },
-                {
-                  "type": "null"
-                }
-              ]
+              "$ref": "#/$defs/Source"
             }
           },
           "required": [
@@ -80,10 +73,6 @@
               "$ref": "#/$defs/Meta"
             }
           ],
-          "default": {
-            "op": "u",
-            "source": null
-          },
           "description": "Document metadata"
         },
         "ID": {
@@ -369,6 +358,7 @@
         }
       },
       "required": [
+        "_meta",
         "ID"
       ],
       "title": "TEST_ALL_TYPES",
@@ -400,14 +390,7 @@
               "type": "string"
             },
             "source": {
-              "anyOf": [
-                {
-                  "$ref": "#/$defs/Source"
-                },
-                {
-                  "type": "null"
-                }
-              ]
+              "$ref": "#/$defs/Source"
             }
           },
           "required": [
@@ -459,10 +442,6 @@
               "$ref": "#/$defs/Meta"
             }
           ],
-          "default": {
-            "op": "u",
-            "source": null
-          },
           "description": "Document metadata"
         },
         "ID": {
@@ -485,6 +464,7 @@
         }
       },
       "required": [
+        "_meta",
         "ID"
       ],
       "title": "TEST_CHANGES",
@@ -516,14 +496,7 @@
               "type": "string"
             },
             "source": {
-              "anyOf": [
-                {
-                  "$ref": "#/$defs/Source"
-                },
-                {
-                  "type": "null"
-                }
-              ]
+              "$ref": "#/$defs/Source"
             }
           },
           "required": [
@@ -575,10 +548,6 @@
               "$ref": "#/$defs/Meta"
             }
           ],
-          "default": {
-            "op": "u",
-            "source": null
-          },
           "description": "Document metadata"
         },
         "ID": {
@@ -595,6 +564,9 @@
           "title": "Id"
         }
       },
+      "required": [
+        "_meta"
+      ],
       "title": "TEST",
       "type": "object"
     },
@@ -624,14 +596,7 @@
               "type": "string"
             },
             "source": {
-              "anyOf": [
-                {
-                  "$ref": "#/$defs/Source"
-                },
-                {
-                  "type": "null"
-                }
-              ]
+              "$ref": "#/$defs/Source"
             }
           },
           "required": [
@@ -683,10 +648,6 @@
               "$ref": "#/$defs/Meta"
             }
           ],
-          "default": {
-            "op": "u",
-            "source": null
-          },
           "description": "Document metadata"
         },
         "ID": {
@@ -703,6 +664,9 @@
           "title": "Id"
         }
       },
+      "required": [
+        "_meta"
+      ],
       "title": "TEST_EMPTY",
       "type": "object"
     },


### PR DESCRIPTION
**Description:**

- `_meta/soruce/row_id` is the primary key of documents in some cases when a natural key cannot be found. This property is always present so it should be marked as required so that materializations can materialize it as non-nullable

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2060)
<!-- Reviewable:end -->
