### PR TITLE
materialize: fix round counter error in binding events logger

### DIFF
--- a/materialize-boilerplate/logging.go
+++ b/materialize-boilerplate/logging.go
@@ -433,7 +433,7 @@ func (l *BindingEvents) StartedResourceCommit(path []string) {
 		l.activeStores[strings.Join(path, ".")] = time.Now()
 		l.mu.Unlock()
 
-		l.log(log.Fields{"round": l.round, "resourcePath": path}, "started commiting documents for resource")
+		l.log(log.Fields{"round": l.round - 1, "resourcePath": path}, "started commiting documents for resource")
 	})
 }
 
@@ -446,7 +446,7 @@ func (l *BindingEvents) FinishedResourceCommit(path []string) {
 		l.mu.Unlock()
 
 		l.log(log.Fields{
-			"round":        l.round,
+			"round":        l.round - 1,
 			"resourcePath": path,
 			"took":         took.String(),
 		}, "finished commiting documents for resource")


### PR DESCRIPTION
**Description:**

The round counter is incremented when the materialization starts its commit, and the general idea of starting the entire commit happens before performing the sub-operations for committing to each resource. So the "round" counter for committing to each resource is actually 1 less than currently tabulated.

The "round" counter offset by 1 is overall pretty convoluted and I may need to think about some kind of "load round" counter instead that stores are associated with, although I'm not sure that would be any better. The async operations of the materialization protocol just makes this a bit tricky

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2061)
<!-- Reviewable:end -->
