### PR TITLE
materialize-bigquery: flush bindings when stores are complete

### DIFF
--- a/materialize-bigquery/binding.go
+++ b/materialize-bigquery/binding.go
@@ -17,6 +17,7 @@ type binding struct {
 	loadFile      *stagedFile
 	storeFile     *stagedFile
 	tempTableName string
+	hasData       bool
 }
 
 // bindingDocument is used by the load operation to fetch binding flow_document values


### PR DESCRIPTION
**Description:**

Following #1913 and various updates to other materializations that were before that, this brings in the memory optimization to flush staged files during the Store phase after the binding ticks over to the next one.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2062)
<!-- Reviewable:end -->
