### PR TITLE
source-hubspot-native: add "FORWARD" to email event types

### DIFF
--- a/source-hubspot-native/source_hubspot_native/models.py
+++ b/source-hubspot-native/source_hubspot_native/models.py
@@ -390,6 +390,7 @@ class EmailEvent(BaseDocument, extra="allow"):
         "BOUNCE",
         "OPEN",
         "CLICK",
+        "FORWARD",
         "STATUSCHANGE",
         "SPAMREPORT",
         "SUPPRESSED",

--- a/source-hubspot-native/tests/snapshots/snapshots__discover__stdout.json
+++ b/source-hubspot-native/tests/snapshots/snapshots__discover__stdout.json
@@ -1128,6 +1128,7 @@
             "BOUNCE",
             "OPEN",
             "CLICK",
+            "FORWARD",
             "STATUSCHANGE",
             "SPAMREPORT",
             "SUPPRESSED",


### PR DESCRIPTION
**Description:**

An existing task is failing because email events it's receiving have a `FORWARD` type, which isn't allow in the model. This PR adds `FORWARD` as an allowed email event type.

Relevant HubSpot docs are [here](https://legacydocs.hubspot.com/docs/methods/email/email_events_overview). Skimming through them, we may need to add more email event types in the future (`PRINT` ? ), but that can be done later if needed.

Discover snapshot changes are expected since a new email event type was added to the `EmailEvent` model.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

I haven't been able to test this locally yet due to issues with `flowctl` I'm hitting this morning, but this feels like a pretty clear cut issue & solution that could probably be safely merged without testing on a local stack. If you think otherwise, LMK and I'll hold off until I can test locally.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2065)
<!-- Reviewable:end -->
