### PR TITLE
source-hubspot-native: add more email event types

### DIFF
--- a/source-hubspot-native/source_hubspot_native/models.py
+++ b/source-hubspot-native/source_hubspot_native/models.py
@@ -390,10 +390,12 @@ class EmailEvent(BaseDocument, extra="allow"):
         "BOUNCE",
         "OPEN",
         "CLICK",
+        "PRINT",
         "FORWARD",
         "STATUSCHANGE",
         "SPAMREPORT",
         "SUPPRESSED",
+        "SUPPRESSION", # "SUPPRESSION" is documented in HubSpot's docs, but "SUPPRESSED" isn't. We've seen "SUPPRESSED" events, so "SUPPRESSION" events might not actually occur.
         "UNBOUNCE", # This is not actually a type reported by HubSpot, but the absence of the "type" field means its an UNBOUNCE type.
     ] = Field(
         default="UNBOUNCE",

--- a/source-hubspot-native/tests/snapshots/snapshots__discover__stdout.json
+++ b/source-hubspot-native/tests/snapshots/snapshots__discover__stdout.json
@@ -1128,10 +1128,12 @@
             "BOUNCE",
             "OPEN",
             "CLICK",
+            "PRINT",
             "FORWARD",
             "STATUSCHANGE",
             "SPAMREPORT",
             "SUPPRESSED",
+            "SUPPRESSION",
             "UNBOUNCE"
           ],
           "title": "Type",


### PR DESCRIPTION
**Description:**

We've encountered even more email event types and need to expand the model to include them. Relevant HubSpot docs are [here](https://legacydocs.hubspot.com/docs/methods/email/email_events_overview).

Interestingly, the `SUPPRESSED` type isn't documented in HubSpot's docs but we have seen it used in existing records. The similarly named `SUPPRESSION` type is listed in the docs; I'm not sure if this is a typo on HubSpot's end, or if they have an undocumented `SUPPRESSED` type. If it turns out `SUPPRESSION` is a HubSpot typo, we can remove it later.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2066)
<!-- Reviewable:end -->
