### PR TITLE
source-sqlserver: Add another query to replication diagnostics

### DIFF
--- a/source-sqlserver/replication.go
+++ b/source-sqlserver/replication.go
@@ -1015,6 +1015,7 @@ func (db *sqlserverDatabase) ReplicationDiagnostics(ctx context.Context) error {
 
 	query("SELECT * FROM sys.dm_server_services;")
 	query("SELECT * FROM sys.dm_cdc_log_scan_sessions;")
+	query("SELECT * FROM sys.dm_cdc_errors;")
 	query("EXEC msdb.dbo.sp_help_job;")
 	query("EXEC sys.sp_cdc_help_jobs;")
 	query("SELECT * FROM msdb.dbo.cdc_jobs;")


### PR DESCRIPTION
**Description:**

While debugging a SQL Server replication issue, I noticed that we're not currently capturing this as part of our diagnostics. (I don't think this would give us anything useful for the issue I was just debugging, but in other cases it would be good to have this information).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2067)
<!-- Reviewable:end -->
