### PR TITLE
materialize-s3-iceberg: fetch table paths concurrently

### DIFF
--- a/materialize-s3-iceberg/driver.go
+++ b/materialize-s3-iceberg/driver.go
@@ -362,13 +362,13 @@ func (d driver) NewTransactor(ctx context.Context, open pm.Request_Open, _ *boil
 	}
 
 	catalog := newCatalog(cfg, resourcePaths, open.Materialization)
-	for idx := range bindings {
-		catalogTablePath, err := catalog.tablePath(bindings[idx].path)
-		if err != nil {
-			return nil, nil, nil, fmt.Errorf("getting catalog table path: %w", err)
-		}
+	tablePaths, err := catalog.tablePaths(resourcePaths)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("looking up table paths: %w", err)
+	}
 
-		bindings[idx].catalogTablePath = catalogTablePath
+	for idx := range bindings {
+		bindings[idx].catalogTablePath = tablePaths[idx]
 	}
 
 	s3store, err := filesink.NewS3Store(ctx, filesink.S3StoreConfig{

--- a/materialize-s3-iceberg/driver.go
+++ b/materialize-s3-iceberg/driver.go
@@ -392,6 +392,7 @@ func (d driver) NewTransactor(ctx context.Context, open pm.Request_Open, _ *boil
 				SyncFrequency: interval.String(),
 			},
 		},
+		ExtendedLogging: true,
 	}
 
 	return &transactor{

--- a/materialize-s3-iceberg/iceberg-ctl/poetry.lock
+++ b/materialize-s3-iceberg/iceberg-ctl/poetry.lock
@@ -165,6 +165,19 @@ files = [
 ]
 
 [[package]]
+name = "asyncio"
+version = "3.4.3"
+description = "reference implementation of PEP 3156"
+optional = false
+python-versions = "*"
+files = [
+    {file = "asyncio-3.4.3-cp33-none-win32.whl", hash = "sha256:b62c9157d36187eca799c378e572c969f0da87cd5fc42ca372d92cdb06e7e1de"},
+    {file = "asyncio-3.4.3-cp33-none-win_amd64.whl", hash = "sha256:c46a87b48213d7464f22d9a497b9eef8c1928b68320a2fa94240f969f6fec08c"},
+    {file = "asyncio-3.4.3-py3-none-any.whl", hash = "sha256:c4d18b22701821de07bd6aea8b53d21449ec0ec5680645e5317062ea21817d2d"},
+    {file = "asyncio-3.4.3.tar.gz", hash = "sha256:83360ff8bc97980e4ff25c964c7bd3923d333d177aa4f7fb736b019f26c7cb41"},
+]
+
+[[package]]
 name = "attrs"
 version = "24.2.0"
 description = "Classes Without Boilerplate"
@@ -1598,4 +1611,4 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "bfdeebd1e6fc22361a17a2af53105de9d6afae99e2257a5c27182bbe6c57d39b"
+content-hash = "d801a7453d09a3bbbadd1c495e58d1019c9663056ce967e8d8c3e68e77e67174"

--- a/materialize-s3-iceberg/iceberg-ctl/pyproject.toml
+++ b/materialize-s3-iceberg/iceberg-ctl/pyproject.toml
@@ -10,6 +10,7 @@ python = "^3.11"
 pyiceberg = {extras = ["glue", "pyarrow", "s3fs"], version = "^0.7.0"}
 click = "^8.1.7"
 setuptools = "^70.0.0"
+asyncio = "^3.4.3"
 
 [tool.poetry.group.dev.dependencies]
 debugpy = "^1.8.0"


### PR DESCRIPTION
**Description:**

Adds concurrency to fetching table storage paths, since otherwise this can take a really long time if there are lots of enabled bindings.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2071)
<!-- Reviewable:end -->
