### PR TITLE
source-mysql: Set ReadTimeout/WriteTimeout on connection

### DIFF
--- a/source-mysql/main.go
+++ b/source-mysql/main.go
@@ -215,10 +215,15 @@ func (db *mysqlDatabase) connect(_ context.Context) error {
 		c.SetTLSConfig(&tls.Config{InsecureSkipVerify: true})
 		return nil
 	}
-	if connWithTLS, errWithTLS := client.Connect(address, db.config.User, db.config.Password, db.config.Advanced.DBName, withTLS); errWithTLS == nil {
+	var withTimeouts = func(c *client.Conn) error {
+		c.ReadTimeout = 60 * time.Second
+		c.WriteTimeout = 60 * time.Second
+		return nil
+	}
+	if connWithTLS, errWithTLS := client.Connect(address, db.config.User, db.config.Password, db.config.Advanced.DBName, withTimeouts, withTLS); errWithTLS == nil {
 		logrus.WithField("addr", address).Info("connected with TLS")
 		db.conn = connWithTLS
-	} else if connWithoutTLS, errWithoutTLS := client.Connect(address, db.config.User, db.config.Password, db.config.Advanced.DBName); errWithoutTLS == nil {
+	} else if connWithoutTLS, errWithoutTLS := client.Connect(address, db.config.User, db.config.Password, db.config.Advanced.DBName, withTimeouts); errWithoutTLS == nil {
 		logrus.WithField("addr", address).Info("connected without TLS")
 		db.conn = connWithoutTLS
 	} else {


### PR DESCRIPTION
**Description:**

Without these set, it's possible for the initial server connect to hang indefinitely. We've seen this in production when going through an SSH tunnel (which I assume silently broke during the connection attempt), with a hang of over 8 hours.