### PR TITLE
Revert "source-mysql: Set ReadTimeout/WriteTimeout on connection"

### DIFF
--- a/source-mysql/main.go
+++ b/source-mysql/main.go
@@ -215,15 +215,10 @@ func (db *mysqlDatabase) connect(_ context.Context) error {
 		c.SetTLSConfig(&tls.Config{InsecureSkipVerify: true})
 		return nil
 	}
-	var withTimeouts = func(c *client.Conn) error {
-		c.ReadTimeout = 60 * time.Second
-		c.WriteTimeout = 60 * time.Second
-		return nil
-	}
-	if connWithTLS, errWithTLS := client.Connect(address, db.config.User, db.config.Password, db.config.Advanced.DBName, withTimeouts, withTLS); errWithTLS == nil {
+	if connWithTLS, errWithTLS := client.Connect(address, db.config.User, db.config.Password, db.config.Advanced.DBName, withTLS); errWithTLS == nil {
 		logrus.WithField("addr", address).Info("connected with TLS")
 		db.conn = connWithTLS
-	} else if connWithoutTLS, errWithoutTLS := client.Connect(address, db.config.User, db.config.Password, db.config.Advanced.DBName, withTimeouts); errWithoutTLS == nil {
+	} else if connWithoutTLS, errWithoutTLS := client.Connect(address, db.config.User, db.config.Password, db.config.Advanced.DBName); errWithoutTLS == nil {
 		logrus.WithField("addr", address).Info("connected without TLS")
 		db.conn = connWithoutTLS
 	} else {


### PR DESCRIPTION
Reverts estuary/connectors#2073

Somehow the read/write timeouts appear to be set once and then somehow getting stuck -- captures consistently start up and then fail **exactly** one minute after the initial database connection.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2074)
<!-- Reviewable:end -->
