### PR TITLE
materialize-snowflake: respect TIMESTAMP_TYPE_MAPPING if it is explicitly set to TIMESTAMP_NTZ

### DIFF
--- a/materialize-snowflake/snowflake.go
+++ b/materialize-snowflake/snowflake.go
@@ -144,6 +144,7 @@ func getTimestampTypeMapping(ctx context.Context, db *stdsql.DB) (timestampTypeM
 
 	type paramRow struct {
 		Value string `db:"value"`
+		Level string `db:"level"`
 	}
 
 	got := paramRow{}
@@ -156,11 +157,11 @@ func getTimestampTypeMapping(ctx context.Context, db *stdsql.DB) (timestampTypeM
 		return "", fmt.Errorf("invalid timestamp type mapping: %s", got.Value)
 	}
 
-	log.WithField("value", got.Value).Debug("queried TIMESTAMP_TYPE_MAPPING")
+	log.WithFields(log.Fields{"value": got.Value, "level": got.Level}).Debug("queried TIMESTAMP_TYPE_MAPPING")
 
-	if m == timestampNTZ {
-		// Default to LTZ if the TIMESTAMP_TYPE_MAPPING is set to NTZ, either
-		// explicitly or via the default.
+	if m == timestampNTZ && got.Level == "" {
+		// Default to LTZ if the TIMESTAMP_TYPE_MAPPING parameter is using the
+		// default and has not been explicitly set to use TIMESTAMP_NTZ.
 		m = timestampLTZ
 	}
 

--- a/materialize-snowflake/sqlgen.go
+++ b/materialize-snowflake/sqlgen.go
@@ -30,7 +30,7 @@ var (
 	// NTZ is the default type if it hasn't been otherwise set for the database,
 	// but it's generally not a very good choice since it ignores timezone
 	// information and stores the time directly as a wallclock time without
-	// adjusting it to UTC. We never create columns with this type.
+	// adjusting it to UTC.
 	timestampNTZ timestampTypeMapping = "TIMESTAMP_NTZ"
 
 	// LTZ stores the time in Snowflake as UTC and performs operations on it


### PR DESCRIPTION
**Description:**

Some users actually want to materialize columns as TIMESTAMP_NTZ, so we need to detect when that parameter has been explicitly set and use it if it has.

The general case of the parameter being unset and defaulting to TIMESTAMP_NTZ will continue to behave like before and use TIMESTAMP_LTZ, but if it is set to TIMESTAMP_NTZ at the account/role/user level, we will use TIMESTAMP_NTZ for columns.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2077)
<!-- Reviewable:end -->
