### PR TITLE
dbt: move to materialize-boilerplate, only trigger after delay

### DIFF
--- a/go/dbt/trigger.go
+++ b/go/dbt/trigger.go
@@ -12,14 +12,14 @@ import (
 )
 
 type JobConfig struct {
-	JobID              string `json:"job_id" jsonschema:"title=Job ID,description=dbt job ID"`
-	AccountID          string `json:"account_id" jsonschema:"title=Account ID,description=dbt account ID"`
-	AccessURL          string `json:"access_url,omitempty" jsonschema:"title=Access URL,description=dbt access URL can be found in your Account Settings. See go.estuary.dev/dbt-cloud-trigger" jsonschema_extras:"pattern=^https://.+$"`
-	AccountPrefix      string `json:"account_prefix" jsonschema:"-"`
-	APIKey             string `json:"api_key" jsonschema:"title=API Key,description=dbt API Key" jsonschema_extras:"secret=true"`
-	Cause              string `json:"cause,omitempty" jsonschema:"title=Cause Message,description=You can set a custom 'cause' message for the job trigger. Defaults to 'Estuary Flow'."`
-	Mode               string `json:"mode,omitempty" jsonschema:"title=Job Trigger Mode,description=Specifies how should already-running jobs be treated. Defaults to 'skip' which skips the trigger if a job is already running; 'replace' cancels the running job and runs a new one; while 'ignore' triggers a new job regardless of existing jobs.,enum=skip,enum=replace,enum=ignore,default=skip"`
-	SafetyTriggerDelay string `json:"safety_trigger_delay,omitempty" jsonschema:"-"`
+	JobID         string `json:"job_id" jsonschema:"title=Job ID,description=dbt job ID"`
+	AccountID     string `json:"account_id" jsonschema:"title=Account ID,description=dbt account ID"`
+	AccessURL     string `json:"access_url,omitempty" jsonschema:"title=Access URL,description=dbt access URL can be found in your Account Settings. See go.estuary.dev/dbt-cloud-trigger" jsonschema_extras:"pattern=^https://.+$"`
+	AccountPrefix string `json:"account_prefix" jsonschema:"-"`
+	APIKey        string `json:"api_key" jsonschema:"title=API Key,description=dbt API Key" jsonschema_extras:"secret=true"`
+	Cause         string `json:"cause,omitempty" jsonschema:"title=Cause Message,description=You can set a custom 'cause' message for the job trigger. Defaults to 'Estuary Flow'."`
+	Mode          string `json:"mode,omitempty" jsonschema:"title=Job Trigger Mode,description=Specifies how should already-running jobs be treated. Defaults to 'skip' which skips the trigger if a job is already running; 'replace' cancels the running job and runs a new one; while 'ignore' triggers a new job regardless of existing jobs.,enum=skip,enum=replace,enum=ignore,default=skip"`
+	Interval      string `json:"interval,omitempty" jsonschema:"title=Run Interval,description=How frequently should the DBT job run? This interval is only triggered if data has been materialized by your task,default=30m"`
 }
 
 func (c *JobConfig) Validate() error {

--- a/go/dbt/trigger.go
+++ b/go/dbt/trigger.go
@@ -12,13 +12,14 @@ import (
 )
 
 type JobConfig struct {
-	JobID         string `json:"job_id" jsonschema:"title=Job ID,description=dbt job ID"`
-	AccountID     string `json:"account_id" jsonschema:"title=Account ID,description=dbt account ID"`
-	AccessURL     string `json:"access_url,omitempty" jsonschema:"title=Access URL,description=dbt access URL can be found in your Account Settings. See go.estuary.dev/dbt-cloud-trigger" jsonschema_extras:"pattern=^https://.+$"`
-	AccountPrefix string `json:"account_prefix" jsonschema:"-"`
-	APIKey        string `json:"api_key" jsonschema:"title=API Key,description=dbt API Key" jsonschema_extras:"secret=true"`
-	Cause         string `json:"cause,omitempty" jsonschema:"title=Cause Message,description=You can set a custom 'cause' message for the job trigger. Defaults to 'Estuary Flow'."`
-	Mode          string `json:"mode,omitempty" jsonschema:"title=Job Trigger Mode,description=Specifies how should already-running jobs be treated. Defaults to 'skip' which skips the trigger if a job is already running; 'replace' cancels the running job and runs a new one; while 'ignore' triggers a new job regardless of existing jobs.,enum=skip,enum=replace,enum=ignore,default=skip"`
+	JobID              string `json:"job_id" jsonschema:"title=Job ID,description=dbt job ID"`
+	AccountID          string `json:"account_id" jsonschema:"title=Account ID,description=dbt account ID"`
+	AccessURL          string `json:"access_url,omitempty" jsonschema:"title=Access URL,description=dbt access URL can be found in your Account Settings. See go.estuary.dev/dbt-cloud-trigger" jsonschema_extras:"pattern=^https://.+$"`
+	AccountPrefix      string `json:"account_prefix" jsonschema:"-"`
+	APIKey             string `json:"api_key" jsonschema:"title=API Key,description=dbt API Key" jsonschema_extras:"secret=true"`
+	Cause              string `json:"cause,omitempty" jsonschema:"title=Cause Message,description=You can set a custom 'cause' message for the job trigger. Defaults to 'Estuary Flow'."`
+	Mode               string `json:"mode,omitempty" jsonschema:"title=Job Trigger Mode,description=Specifies how should already-running jobs be treated. Defaults to 'skip' which skips the trigger if a job is already running; 'replace' cancels the running job and runs a new one; while 'ignore' triggers a new job regardless of existing jobs.,enum=skip,enum=replace,enum=ignore,default=skip"`
+	SafetyTriggerDelay string `json:"safety_trigger_delay,omitempty" jsonschema:"-"`
 }
 
 func (c *JobConfig) Validate() error {

--- a/go/dbt/trigger.go
+++ b/go/dbt/trigger.go
@@ -123,7 +123,7 @@ func JobTrigger(config JobConfig) error {
 	}
 
 	if !response.Status.IsSuccess {
-		return fmt.Errorf(response.Status.UserMessage)
+		return fmt.Errorf("%s", response.Status.UserMessage)
 	}
 
 	return nil
@@ -149,7 +149,7 @@ func CurrentRuns(config JobConfig) ([]RunResponseData, error) {
 	}
 
 	if !response.Status.IsSuccess {
-		return nil, fmt.Errorf(response.Status.UserMessage)
+		return nil, fmt.Errorf("%s", response.Status.UserMessage)
 	}
 
 	var runs []RunResponseData
@@ -168,7 +168,7 @@ func CancelRun(config JobConfig, runId int) error {
 	}
 
 	if !response.Status.IsSuccess {
-		return fmt.Errorf(response.Status.UserMessage)
+		return fmt.Errorf("%s", response.Status.UserMessage)
 	}
 
 	return nil

--- a/materialize-bigquery/.snapshots/TestSpecification
+++ b/materialize-bigquery/.snapshots/TestSpecification
@@ -143,6 +143,12 @@
             "title": "Job Trigger Mode",
             "description": "Specifies how should already-running jobs be treated. Defaults to 'skip' which skips the trigger if a job is already running; 'replace' cancels the running job and runs a new one; while 'ignore' triggers a new job regardless of existing jobs.",
             "default": "skip"
+          },
+          "interval": {
+            "type": "string",
+            "title": "Run Interval",
+            "description": "How frequently should the DBT job run? This interval is only triggered if data has been materialized by your task",
+            "default": "30m"
           }
         },
         "additionalProperties": false,

--- a/materialize-bigquery/transactor.go
+++ b/materialize-bigquery/transactor.go
@@ -8,7 +8,6 @@ import (
 	"text/template"
 
 	"cloud.google.com/go/bigquery"
-	"github.com/estuary/connectors/go/dbt"
 	m "github.com/estuary/connectors/go/protocols/materialize"
 	boilerplate "github.com/estuary/connectors/materialize-boilerplate"
 	sql "github.com/estuary/connectors/materialize-sql"
@@ -98,6 +97,7 @@ func newTransactor(
 			Config: cfg.Schedule,
 			Jitter: []byte(cfg.ProjectID + cfg.Dataset),
 		},
+		DBTJobTrigger: &cfg.DBTJobTrigger,
 	}
 
 	return t, opts, nil
@@ -376,13 +376,6 @@ func (t *transactor) commit(ctx context.Context, cleanupFiles []func(context.Con
 	if _, err := t.client.runQuery(ctx, query); err != nil {
 		log.WithField("query", queryString).Error("query failed")
 		return fmt.Errorf("commit query: %w", err)
-	}
-
-	if t.cfg.DBTJobTrigger.Enabled() {
-		log.Info("store: dbt job trigger")
-		if err := dbt.JobTrigger(t.cfg.DBTJobTrigger); err != nil {
-			return fmt.Errorf("triggering dbt job: %w", err)
-		}
 	}
 
 	return nil

--- a/materialize-boilerplate/boilerplate.go
+++ b/materialize-boilerplate/boilerplate.go
@@ -18,6 +18,7 @@ import (
 	_ "net/http/pprof"
 
 	cerrors "github.com/estuary/connectors/go/connector-errors"
+	"github.com/estuary/connectors/go/dbt"
 	m "github.com/estuary/connectors/go/protocols/materialize"
 	pm "github.com/estuary/flow/go/protocols/materialize"
 	protoio "github.com/gogo/protobuf/io"
@@ -35,6 +36,9 @@ type MaterializeOptions struct {
 	// AckSchedule is configuration for scheduling of runtime acknowledgements
 	// sent from the connector at the completion of its commits.
 	AckSchedule *AckScheduleOption
+
+	// DBTJobTrigger is configuration for enabling DBT job triggers after commits
+	DBTJobTrigger *dbt.JobConfig
 }
 
 // AckScheduleOption enables a schedule for acknowledgements of the

--- a/materialize-boilerplate/transactions_stream.go
+++ b/materialize-boilerplate/transactions_stream.go
@@ -6,6 +6,7 @@ import (
 	"slices"
 	"time"
 
+	"github.com/estuary/connectors/go/dbt"
 	m "github.com/estuary/connectors/go/protocols/materialize"
 	"github.com/estuary/connectors/go/schedule"
 	pm "github.com/estuary/flow/go/protocols/materialize"
@@ -56,6 +57,8 @@ type transactionsStream struct {
 	ackSchedule   schedule.Schedule
 	lastAckTime   time.Time
 	storedHistory []int
+
+	dbtJobTrigger *dbt.JobConfig
 }
 
 // newTransactionsStream wraps a base stream MaterializeStream with extra
@@ -87,6 +90,10 @@ func newTransactionsStream(
 			return nil, fmt.Errorf("creating ack schedule: %w", err)
 		}
 		s.ackSchedule = sched
+	}
+
+	if options.DBTJobTrigger != nil && options.DBTJobTrigger.Enabled() {
+		s.dbtJobTrigger = options.DBTJobTrigger
 	}
 
 	// ackSchedule may be `nil` even if options.AckSchedule was not if the
@@ -194,11 +201,24 @@ func (l *transactionsStream) maybeDelayAcknowledgement() error {
 			l.handler(startedAckDelay)
 			ll.WithField("delay", d.String()).Info("delaying before acknowledging commit")
 
+			// We trigger dbt job only if the delay is taking effect, to avoid bursting
+			// dbt job triggers during backfills
+			if l.dbtJobTrigger != nil {
+				if err := dbt.JobTrigger(*l.dbtJobTrigger); err != nil {
+					return fmt.Errorf("triggering dbt job: %w", err)
+				}
+			}
+
 			select {
 			case <-l.ctx.Done():
 				return l.ctx.Err()
 			case <-time.After(d):
 			}
+		}
+	} else if l.dbtJobTrigger != nil {
+		// We also trigger dbt jobs if there is no sync frequency at all
+		if err := dbt.JobTrigger(*l.dbtJobTrigger); err != nil {
+			return fmt.Errorf("triggering dbt job: %w", err)
 		}
 	}
 

--- a/materialize-databricks/.snapshots/TestSpecification
+++ b/materialize-databricks/.snapshots/TestSpecification
@@ -157,6 +157,12 @@
             "title": "Job Trigger Mode",
             "description": "Specifies how should already-running jobs be treated. Defaults to 'skip' which skips the trigger if a job is already running; 'replace' cancels the running job and runs a new one; while 'ignore' triggers a new job regardless of existing jobs.",
             "default": "skip"
+          },
+          "interval": {
+            "type": "string",
+            "title": "Run Interval",
+            "description": "How frequently should the DBT job run? This interval is only triggered if data has been materialized by your task",
+            "default": "30m"
           }
         },
         "additionalProperties": false,

--- a/materialize-mysql/.snapshots/TestSpecification
+++ b/materialize-mysql/.snapshots/TestSpecification
@@ -80,6 +80,12 @@
             "title": "Job Trigger Mode",
             "description": "Specifies how should already-running jobs be treated. Defaults to 'skip' which skips the trigger if a job is already running; 'replace' cancels the running job and runs a new one; while 'ignore' triggers a new job regardless of existing jobs.",
             "default": "skip"
+          },
+          "interval": {
+            "type": "string",
+            "title": "Run Interval",
+            "description": "How frequently should the DBT job run? This interval is only triggered if data has been materialized by your task",
+            "default": "30m"
           }
         },
         "additionalProperties": false,

--- a/materialize-mysql/driver.go
+++ b/materialize-mysql/driver.go
@@ -453,7 +453,10 @@ func prepareNewTransactor(
 		}
 		d.load.unionSQL = strings.Join(subqueries, "\nUNION ALL\n") + ";"
 
-		return d, nil, nil
+		opts := &boilerplate.MaterializeOptions{
+			DBTJobTrigger: &cfg.DBTJobTrigger,
+		}
+		return d, opts, nil
 	}
 }
 
@@ -854,13 +857,6 @@ func (d *transactor) Store(it *m.StoreIterator) (_ m.StartCommitFunc, err error)
 
 			if err := txn.Commit(); err != nil {
 				return fmt.Errorf("committing Store transaction: %w", err)
-			}
-
-			if d.cfg.DBTJobTrigger.Enabled() {
-				log.Info("store: dbt job trigger")
-				if err := dbt.JobTrigger(d.cfg.DBTJobTrigger); err != nil {
-					return fmt.Errorf("triggering dbt job: %w", err)
-				}
 			}
 
 			return nil

--- a/materialize-postgres/.snapshots/TestSpecification
+++ b/materialize-postgres/.snapshots/TestSpecification
@@ -81,6 +81,12 @@
             "title": "Job Trigger Mode",
             "description": "Specifies how should already-running jobs be treated. Defaults to 'skip' which skips the trigger if a job is already running; 'replace' cancels the running job and runs a new one; while 'ignore' triggers a new job regardless of existing jobs.",
             "default": "skip"
+          },
+          "interval": {
+            "type": "string",
+            "title": "Run Interval",
+            "description": "How frequently should the DBT job run? This interval is only triggered if data has been materialized by your task",
+            "default": "30m"
           }
         },
         "additionalProperties": false,

--- a/materialize-postgres/driver.go
+++ b/materialize-postgres/driver.go
@@ -304,7 +304,11 @@ func newTransactor(
 	}
 	d.load.unionSQL = strings.Join(subqueries, "\nUNION ALL\n") + ";"
 
-	return d, nil, nil
+	opts := &boilerplate.MaterializeOptions{
+		DBTJobTrigger: &cfg.DBTJobTrigger,
+	}
+
+	return d, opts, nil
 }
 
 type binding struct {
@@ -523,13 +527,6 @@ func (d *transactor) Store(it *m.StoreIterator) (_ m.StartCommitFunc, err error)
 
 			if err := txn.Commit(ctx); err != nil {
 				return fmt.Errorf("committing Store transaction: %w", err)
-			}
-
-			if d.cfg.DBTJobTrigger.Enabled() {
-				log.Info("store: dbt job trigger")
-				if err := dbt.JobTrigger(d.cfg.DBTJobTrigger); err != nil {
-					return fmt.Errorf("triggering dbt job: %w", err)
-				}
 			}
 
 			return nil

--- a/materialize-redshift/.snapshots/TestSpecification
+++ b/materialize-redshift/.snapshots/TestSpecification
@@ -162,6 +162,12 @@
             "title": "Job Trigger Mode",
             "description": "Specifies how should already-running jobs be treated. Defaults to 'skip' which skips the trigger if a job is already running; 'replace' cancels the running job and runs a new one; while 'ignore' triggers a new job regardless of existing jobs.",
             "default": "skip"
+          },
+          "interval": {
+            "type": "string",
+            "title": "Run Interval",
+            "description": "How frequently should the DBT job run? This interval is only triggered if data has been materialized by your task",
+            "default": "30m"
           }
         },
         "additionalProperties": false,

--- a/materialize-redshift/driver.go
+++ b/materialize-redshift/driver.go
@@ -325,6 +325,7 @@ func prepareNewTransactor(
 				Config: cfg.Schedule,
 				Jitter: []byte(cfg.Address),
 			},
+			DBTJobTrigger: &cfg.DBTJobTrigger,
 		}
 
 		return d, opts, nil
@@ -861,13 +862,6 @@ func (d *transactor) commit(ctx context.Context, varcharColumnUpdates map[string
 		return err
 	} else if err := txn.Commit(ctx); err != nil {
 		return fmt.Errorf("committing store transaction: %w", err)
-	}
-
-	if d.cfg.DBTJobTrigger.Enabled() {
-		log.Info("store: dbt job trigger")
-		if err := dbt.JobTrigger(d.cfg.DBTJobTrigger); err != nil {
-			return fmt.Errorf("triggering dbt job: %w", err)
-		}
 	}
 
 	return nil

--- a/materialize-snowflake/.snapshots/TestSpecification
+++ b/materialize-snowflake/.snapshots/TestSpecification
@@ -204,6 +204,12 @@
             "title": "Job Trigger Mode",
             "description": "Specifies how should already-running jobs be treated. Defaults to 'skip' which skips the trigger if a job is already running; 'replace' cancels the running job and runs a new one; while 'ignore' triggers a new job regardless of existing jobs.",
             "default": "skip"
+          },
+          "interval": {
+            "type": "string",
+            "title": "Run Interval",
+            "description": "How frequently should the DBT job run? This interval is only triggered if data has been materialized by your task",
+            "default": "30m"
           }
         },
         "additionalProperties": false,

--- a/materialize-snowflake/snowflake.go
+++ b/materialize-snowflake/snowflake.go
@@ -12,7 +12,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/estuary/connectors/go/dbt"
 	m "github.com/estuary/connectors/go/protocols/materialize"
 	boilerplate "github.com/estuary/connectors/materialize-boilerplate"
 	sql "github.com/estuary/connectors/materialize-sql"
@@ -276,6 +275,7 @@ func newTransactor(
 			Config: cfg.Schedule,
 			Jitter: []byte(cfg.Host + cfg.Warehouse),
 		},
+		DBTJobTrigger: &cfg.DBTJobTrigger,
 	}
 
 	return d, opts, nil
@@ -816,13 +816,6 @@ func (d *transactor) Acknowledge(ctx context.Context) (*pf.ConnectorState, error
 					time.Sleep(retryDelay)
 				}
 			}
-		}
-	}
-
-	if d.cfg.DBTJobTrigger.Enabled() && len(d.cp) > 0 {
-		log.Info("store: dbt job trigger")
-		if err := dbt.JobTrigger(d.cfg.DBTJobTrigger); err != nil {
-			return nil, fmt.Errorf("triggering dbt job: %w", err)
 		}
 	}
 

--- a/materialize-sqlserver/.snapshots/TestSpecification
+++ b/materialize-sqlserver/.snapshots/TestSpecification
@@ -80,6 +80,12 @@
             "title": "Job Trigger Mode",
             "description": "Specifies how should already-running jobs be treated. Defaults to 'skip' which skips the trigger if a job is already running; 'replace' cancels the running job and runs a new one; while 'ignore' triggers a new job regardless of existing jobs.",
             "default": "skip"
+          },
+          "interval": {
+            "type": "string",
+            "title": "Run Interval",
+            "description": "How frequently should the DBT job run? This interval is only triggered if data has been materialized by your task",
+            "default": "30m"
           }
         },
         "additionalProperties": false,

--- a/materialize-sqlserver/driver.go
+++ b/materialize-sqlserver/driver.go
@@ -281,7 +281,11 @@ func prepareNewTransactor(
 		}
 		d.load.unionSQL = strings.Join(subqueries, "\nUNION ALL\n") + ";"
 
-		return d, nil, nil
+		opts := &boilerplate.MaterializeOptions{
+			DBTJobTrigger: &cfg.DBTJobTrigger,
+		}
+
+		return d, opts, nil
 	}
 }
 
@@ -586,13 +590,6 @@ func (d *transactor) Store(it *m.StoreIterator) (_ m.StartCommitFunc, err error)
 
 			if err := txn.Commit(); err != nil {
 				return fmt.Errorf("committing Store transaction: %w", err)
-			}
-
-			if d.cfg.DBTJobTrigger.Enabled() {
-				log.Info("store: dbt job trigger")
-				if err := dbt.JobTrigger(d.cfg.DBTJobTrigger); err != nil {
-					return fmt.Errorf("triggering dbt job: %w", err)
-				}
 			}
 
 			return nil


### PR DESCRIPTION
**Description:**

- Move dbt job trigger logic to materialize-boilerplate where it can be better integrated with sync frequency logic, and makes it easier for materialization connectors to integrate the functionality in general

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2082)
<!-- Reviewable:end -->
