### PR TITLE
network-tunnel: exit without logging an error on EOF before READY

### DIFF
--- a/go/network-tunnel/network_tunnel.go
+++ b/go/network-tunnel/network_tunnel.go
@@ -10,6 +10,7 @@ import (
 	"os/exec"
 	"syscall"
 
+	cerrors "github.com/estuary/connectors/go/connector-errors"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -112,7 +113,7 @@ func (t *SshTunnel) Start() error {
 		// an error that we would like to surface to the user without logging anything further
 		// ourselves
 		if err == io.EOF {
-			os.Exit(1)
+			return cerrors.NewTransparentError(err)
 		}
 		return fmt.Errorf("reading READY signal from network-tunnel: %w", err)
 	} else if !bytes.Equal(readyBuf, ready) {

--- a/materialize-elasticsearch/driver.go
+++ b/materialize-elasticsearch/driver.go
@@ -240,7 +240,7 @@ func (c config) toClient(disableRetry bool) (*client, error) {
 		var tunnel = sshConfig.CreateTunnel()
 
 		if err := tunnel.Start(); err != nil {
-			return nil, fmt.Errorf("error starting network tunnel: %w", err)
+			return nil, err
 		}
 
 		// If SSH Tunnel is configured, we are going to create a tunnel from localhost:9200 to

--- a/materialize-mongodb/driver.go
+++ b/materialize-mongodb/driver.go
@@ -44,7 +44,7 @@ func (d *driver) connect(ctx context.Context, cfg config) (*mongo.Client, error)
 		var tunnel = sshConfig.CreateTunnel()
 
 		if err := tunnel.Start(); err != nil {
-			return nil, fmt.Errorf("error starting network tunnel: %w", err)
+			return nil, err
 		}
 	}
 

--- a/materialize-mysql/driver.go
+++ b/materialize-mysql/driver.go
@@ -245,7 +245,7 @@ func newMysqlDriver() *sql.Driver {
 				// FIXME/question: do we need to shut down the tunnel manually if it is a child process?
 				// at the moment tunnel.Stop is not being called anywhere, but if the connector shuts down, the child process also shuts down.
 				if err := tunnel.Start(); err != nil {
-					return fmt.Errorf("error starting network tunnel: %w", err)
+					return err
 				}
 			}
 

--- a/materialize-postgres/driver.go
+++ b/materialize-postgres/driver.go
@@ -203,7 +203,7 @@ func newPostgresDriver() *sql.Driver {
 				// FIXME/question: do we need to shut down the tunnel manually if it is a child process?
 				// at the moment tunnel.Stop is not being called anywhere, but if the connector shuts down, the child process also shuts down.
 				if err := tunnel.Start(); err != nil {
-					return fmt.Errorf("error starting network tunnel: %w", err)
+					return err
 				}
 			}
 

--- a/materialize-redshift/driver.go
+++ b/materialize-redshift/driver.go
@@ -210,7 +210,7 @@ func newRedshiftDriver() *sql.Driver {
 				var tunnel = sshConfig.CreateTunnel()
 
 				if err := tunnel.Start(); err != nil {
-					return fmt.Errorf("error starting network tunnel: %w", err)
+					return err
 				}
 			}
 

--- a/source-mongodb/main.go
+++ b/source-mongodb/main.go
@@ -228,7 +228,7 @@ func (d *driver) Connect(ctx context.Context, cfg config) (*mongo.Client, error)
 		var tunnel = sshConfig.CreateTunnel()
 
 		if err := tunnel.Start(); err != nil {
-			return nil, fmt.Errorf("error starting network tunnel: %w", err)
+			return nil, err
 		}
 	} else if isDocDB {
 		return nil, fmt.Errorf("the provided address %q appears to be for Amazon DocumentDB, which requires an SSH tunnel configuration", cfg.Address)

--- a/source-mysql/main.go
+++ b/source-mysql/main.go
@@ -75,7 +75,7 @@ func connectMySQL(ctx context.Context, name string, cfg json.RawMessage) (sqlcap
 		// FIXME/question: do we need to shut down the tunnel manually if it is a child process?
 		// at the moment tunnel.Stop is not being called anywhere, but if the connector shuts down, the child process also shuts down.
 		if err := tunnel.Start(); err != nil {
-			return nil, fmt.Errorf("error starting network tunnel: %w", err)
+			return nil, err
 		}
 	}
 

--- a/source-oracle/main.go
+++ b/source-oracle/main.go
@@ -73,7 +73,7 @@ func connectOracle(ctx context.Context, name string, cfg json.RawMessage) (sqlca
 		db.tunnel = sshConfig.CreateTunnel()
 
 		if err := db.tunnel.Start(); err != nil {
-			return nil, fmt.Errorf("error starting network tunnel: %w", err)
+			return nil, err
 		}
 	}
 

--- a/source-postgres/main.go
+++ b/source-postgres/main.go
@@ -72,7 +72,7 @@ func connectPostgres(ctx context.Context, name string, cfg json.RawMessage) (sql
 		// FIXME/question: do we need to shut down the tunnel manually if it is a child process?
 		// at the moment tunnel.Stop is not being called anywhere, but if the connector shuts down, the child process also shuts down.
 		if err := tunnel.Start(); err != nil {
-			return nil, fmt.Errorf("error starting network tunnel: %w", err)
+			return nil, err
 		}
 	}
 

--- a/source-sqlserver/main.go
+++ b/source-sqlserver/main.go
@@ -179,7 +179,7 @@ func connectSQLServer(ctx context.Context, name string, cfg json.RawMessage) (sq
 		// FIXME/question: do we need to shut down the tunnel manually if it is a child process?
 		// at the moment tunnel.Stop is not being called anywhere, but if the connector shuts down, the child process also shuts down.
 		if err := tunnel.Start(); err != nil {
-			return nil, fmt.Errorf("error starting network tunnel: %w", err)
+			return nil, err
 		}
 	}
 


### PR DESCRIPTION
**Description:**

Sister pull-request of https://github.com/estuary/network-tunnel/pull/9 to surface the underlying SSH client error when network-tunnel fails to establish a SSH tunnel

Example output:


<img width="1305" alt="image" src="https://github.com/user-attachments/assets/b063217e-9437-4fce-abc0-4c1a58bbc93c">


**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2085)
<!-- Reviewable:end -->
