### PR TITLE
source-bigquery-batch: Fix behavior of `DATETIME` cursors with fractional-second precision

### DIFF
--- a/source-bigquery-batch/.snapshots/TestDatetimeCursor-Capture
+++ b/source-bigquery-batch/.snapshots/TestDatetimeCursor-Capture
@@ -1,0 +1,11 @@
+# ================================
+# Collection "acmeCo/test/datetime_cursor_132448": 3 Documents
+# ================================
+{"_meta":{"polled":"<TIMESTAMP>","index":999},"data":"Value for row \"2023-08-10T07:54:54.123\"","id":"2023-08-10T07:54:54.123000"}
+{"_meta":{"polled":"<TIMESTAMP>","index":999},"data":"Value for row \"2024-10-23T03:22:31.456\"","id":"2024-10-23T03:22:31.456000"}
+{"_meta":{"polled":"<TIMESTAMP>","index":999},"data":"Value for row \"2024-10-23T03:23:00.789\"","id":"2024-10-23T03:23:00.789000"}
+# ================================
+# Final State Checkpoint
+# ================================
+{"bindingStateV1":{"datetime_cursor_132448":{"CursorNames":["id"],"CursorValues":["2024-10-23T03:23:00.789000"],"LastPolled":"<TIMESTAMP>"}}}
+

--- a/source-bigquery-batch/.snapshots/TestDatetimeCursor-Discovery
+++ b/source-bigquery-batch/.snapshots/TestDatetimeCursor-Discovery
@@ -1,0 +1,51 @@
+Binding 0:
+{
+    "resource_config_json": {
+      "name": "datetime_cursor_132448",
+      "template": "{{/* Default query template which adapts to cursor field selection */}}\n{{- if not .CursorFields -}}\n  SELECT * FROM `testdata`.`datetime_cursor_132448`;\n{{- else -}}\n  SELECT * FROM `testdata`.`datetime_cursor_132448`\n  {{- if not .IsFirstQuery -}}\n\t{{- range $i, $k := $.CursorFields -}}\n\t  {{- if eq $i 0}} WHERE ({{else}}) OR ({{end -}}\n      {{- range $j, $n := $.CursorFields -}}\n\t\t{{- if lt $j $i -}}\n\t\t  {{$n}} = @p{{$j}} AND {{end -}}\n\t  {{- end -}}\n\t  {{$k}} \u003e @p{{$i}}\n\t{{- end -}})\n  {{- end}}\n  ORDER BY {{range $i, $k := $.CursorFields}}{{if gt $i 0}}, {{end}}{{$k}}{{end -}};\n{{- end}}"
+    },
+    "resource_path": [
+      "datetime_cursor_132448"
+    ],
+    "collection": {
+      "name": "acmeCo/test/datetime_cursor_132448",
+      "read_schema_json": {
+        "type": "object",
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "$schema": "http://json-schema.org/draft/2020-12/schema",
+            "$id": "https://github.com/estuary/connectors/source-bigquery-batch/document-metadata",
+            "properties": {
+              "polled": {
+                "type": "string",
+                "format": "date-time",
+                "title": "Polled Timestamp",
+                "description": "The time at which the update query which produced this document as executed."
+              },
+              "index": {
+                "type": "integer",
+                "title": "Result Index",
+                "description": "The index of this document within the query execution which produced it."
+              }
+            },
+            "type": "object",
+            "required": [
+              "polled",
+              "index"
+            ]
+          }
+        },
+        "x-infer-schema": true
+      },
+      "key": [
+        "/_meta/polled",
+        "/_meta/index"
+      ],
+      "projections": null
+    },
+    "state_key": "datetime_cursor_132448"
+  }
+

--- a/source-bigquery-batch/main.go
+++ b/source-bigquery-batch/main.go
@@ -6,8 +6,10 @@ import (
 	"fmt"
 	"math"
 	"strings"
+	"time"
 
 	"cloud.google.com/go/bigquery"
+	"cloud.google.com/go/civil"
 	"github.com/estuary/connectors/go/schedule"
 	schemagen "github.com/estuary/connectors/go/schema-gen"
 	boilerplate "github.com/estuary/connectors/source-boilerplate"
@@ -62,8 +64,15 @@ func (c *Config) SetDefaults() {
 	}
 }
 
+const (
+	// Google Cloud DATETIME columns support microsecond precision at most
+	datetimeFormatMicros = "2006-01-02T15:04:05.000000"
+)
+
 func translateBigQueryValue(val any, fieldType bigquery.FieldType) (any, error) {
 	switch val := val.(type) {
+	case civil.DateTime:
+		return val.In(time.UTC).Format(datetimeFormatMicros), nil
 	case string:
 		if fieldType == "JSON" && json.Valid([]byte(val)) {
 			return json.RawMessage([]byte(val)), nil


### PR DESCRIPTION
**Description:**

BigQuery DATETIME columns only support microsecond precision, but the default serialization of the Go `civil.DateTime` struct uses nanosecond precision. Which is fine for output only, and *also* is fine for cursors until the capture restarts, and *also* is fine when the datetime values are whole seconds.

But a fractional-second datetime used as a cursor will be stored as a string in the state checkpoint, and trying to feed that back to BigQuery after a restart will produce an error because there are too many digits of precision.

The fix is to handle the formatting of `civil.DateTime` values into strings ourselves and make sure it only has six digits.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2086)
<!-- Reviewable:end -->
