### PR TITLE
materialize-s3-iceberg: always allow appends to a table with an empty checkpoint property

### DIFF
--- a/materialize-s3-iceberg/iceberg-ctl/iceberg_ctl/__main__.py
+++ b/materialize-s3-iceberg/iceberg-ctl/iceberg_ctl/__main__.py
@@ -354,7 +354,11 @@ def append_files(
     if cp == next_checkpoint:
         print(f"checkpoint is already '{next_checkpoint}'")
         return  # already appended these files
-    elif cp != prev_checkpoint:
+    elif cp != "" and cp != prev_checkpoint:
+        # An absent checkpoint table property is allowed to accommodate cases
+        # where the user may have manually dropped the table and the
+        # materialization automatically re-created it, outside the normal
+        # backfill counter increment process.
         raise Exception(
             f"checkpoint from snapshot ({cp}) did not match either previous ({prev_checkpoint}) or next ({next_checkpoint}) checkpoint"
         )


### PR DESCRIPTION
**Description:**

An absent checkpoint table property is allowed to accommodate cases where the user may have manually dropped the table and the materialization automatically re-created it, outside the normal backfill counter increment process.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2094)
<!-- Reviewable:end -->
