### PR TITLE
source-mysql: Normalize invalid dates the same as timestamp date parts

### DIFF
--- a/source-mysql/.snapshots/TestDateNormalization
+++ b/source-mysql/.snapshots/TestDateNormalization
@@ -1,0 +1,16 @@
+# ================================
+# Collection "acmeCo/test/test_datenormalization_44310403": 8 Documents
+# ================================
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"DateNormalization_44310403","cursor":"backfill:0"}},"id":100,"x":"1991-08-31"}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"DateNormalization_44310403","cursor":"backfill:1"}},"id":101,"x":"0001-01-01"}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"DateNormalization_44310403","cursor":"backfill:2"}},"id":102,"x":"2023-00-00"}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"DateNormalization_44310403","cursor":"backfill:3"}},"id":103,"x":"2023-07-00"}
+{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"DateNormalization_44310403","cursor":"binlog.000123:56789:123","txid":"11111111-1111-1111-1111-111111111111:111"}},"id":200,"x":"1991-08-31"}
+{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"DateNormalization_44310403","cursor":"binlog.000123:56789:123","txid":"11111111-1111-1111-1111-111111111111:111"}},"id":201,"x":"0001-01-01"}
+{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"DateNormalization_44310403","cursor":"binlog.000123:56789:123","txid":"11111111-1111-1111-1111-111111111111:111"}},"id":202,"x":"2023-00-00"}
+{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"DateNormalization_44310403","cursor":"binlog.000123:56789:123","txid":"11111111-1111-1111-1111-111111111111:111"}},"id":203,"x":"2023-07-00"}
+# ================================
+# Final State Checkpoint
+# ================================
+{"bindingStateV1":{"test%2FDateNormalization_44310403":{"backfilled":4,"key_columns":["id"],"metadata":{"charset":"utf8mb4","schema":{"columns":["id","x"],"types":{"id":{"type":"int"},"x":"date"}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
+

--- a/source-mysql/.snapshots/TestDateNormalization
+++ b/source-mysql/.snapshots/TestDateNormalization
@@ -3,12 +3,12 @@
 # ================================
 {"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"DateNormalization_44310403","cursor":"backfill:0"}},"id":100,"x":"1991-08-31"}
 {"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"DateNormalization_44310403","cursor":"backfill:1"}},"id":101,"x":"0001-01-01"}
-{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"DateNormalization_44310403","cursor":"backfill:2"}},"id":102,"x":"2023-00-00"}
-{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"DateNormalization_44310403","cursor":"backfill:3"}},"id":103,"x":"2023-07-00"}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"DateNormalization_44310403","cursor":"backfill:2"}},"id":102,"x":"2023-01-01"}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"DateNormalization_44310403","cursor":"backfill:3"}},"id":103,"x":"2023-07-01"}
 {"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"DateNormalization_44310403","cursor":"binlog.000123:56789:123","txid":"11111111-1111-1111-1111-111111111111:111"}},"id":200,"x":"1991-08-31"}
 {"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"DateNormalization_44310403","cursor":"binlog.000123:56789:123","txid":"11111111-1111-1111-1111-111111111111:111"}},"id":201,"x":"0001-01-01"}
-{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"DateNormalization_44310403","cursor":"binlog.000123:56789:123","txid":"11111111-1111-1111-1111-111111111111:111"}},"id":202,"x":"2023-00-00"}
-{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"DateNormalization_44310403","cursor":"binlog.000123:56789:123","txid":"11111111-1111-1111-1111-111111111111:111"}},"id":203,"x":"2023-07-00"}
+{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"DateNormalization_44310403","cursor":"binlog.000123:56789:123","txid":"11111111-1111-1111-1111-111111111111:111"}},"id":202,"x":"2023-01-01"}
+{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"DateNormalization_44310403","cursor":"binlog.000123:56789:123","txid":"11111111-1111-1111-1111-111111111111:111"}},"id":203,"x":"2023-07-01"}
 # ================================
 # Final State Checkpoint
 # ================================


### PR DESCRIPTION
**Description:**

This commit factors out the date-normalization we apply to the date portions of timestamps and datetimes, and applies that same logic to the values of date columns.

For valid values this makes no difference. For the zero value this also makes no difference. But MySQL, while it normally rejects dates like `2024-00-00` or `2024-10-00` as invalid, has some mode settings which allows those, and currently we capture them verbatim. Which is a problem because the month or date components of a `format: date` string cannot be zero, and while we don't _currently_ discover `date` columns as a `format: date` string that's only because of compatibility issues and is something we'd like to change in the near future (and also we currently recommend that people add it to the read schema themselves if they need it ASAP), so we should try to satisfy that format anyway.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2096)
<!-- Reviewable:end -->
