### PR TITLE
source-mysql: Improve connection error reporting

### DIFF
--- a/source-mysql/main.go
+++ b/source-mysql/main.go
@@ -233,12 +233,12 @@ func (db *mysqlDatabase) connect(_ context.Context) error {
 		logrus.WithField("addr", address).Info("connected without TLS")
 		db.conn = connWithoutTLS
 	} else if errors.As(errWithoutTLS, &mysqlErr) && mysqlErr.Code == mysql.ER_ACCESS_DENIED_ERROR {
-		logrus.WithField("withTLS", errWithTLS).Warn("connecting with TLS failed for an unrelated reason")
+		logrus.WithFields(logrus.Fields{"withTLS": errWithTLS, "nonTLS": errWithoutTLS}).Error("unable to connect to database")
 		return cerrors.NewUserError(mysqlErr, "incorrect username or password")
 	} else if errors.As(errWithoutTLS, &mysqlErr) && mysqlErr.Code == mysqlErrorCodeSecureTransportRequired {
 		return fmt.Errorf("unable to connect to database: %w", errWithTLS)
 	} else {
-		return fmt.Errorf("unable to connect to database: failed with TLS (%w) and without TLS (%w)", errWithTLS, errWithoutTLS)
+		return fmt.Errorf("unable to connect to database: failed both with TLS (%w) and without TLS (%w)", errWithTLS, errWithoutTLS)
 	}
 
 	// Debug logging hook so we can get the server config variables when needed


### PR DESCRIPTION
**Description:**

This PR modifies the MySQL connection / error reporting logic so that it should hopefully be a bit clearer in certain edge cases why the connection failed. Specifically:
* We'll now check both the with-TLS and without-TLS error for an "incorrect username/password" condition, where previously it was just the with-TLS error getting checked.
* When none of the special cases apply, we'll report a more verbose error which includes both the with-TLS and without-TLS failure reasons.
* There is an explicit special case for the "TLS is required" error, and only when that case is hit do we report just the with-TLS failure and omit the "TLS required" error.

I'm optimistic that maybe this will be adequate, finally.

This fixes https://github.com/estuary/connectors/issues/2075

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2097)
<!-- Reviewable:end -->
