### PR TITLE
materialize-mysql: fix docker healthcheck for mariadb

### DIFF
--- a/materialize-mysql/docker-compose.yaml
+++ b/materialize-mysql/docker-compose.yaml
@@ -25,7 +25,7 @@ services:
     networks:
       - flow-test
     healthcheck:
-      test: [ "CMD", "mysql", "-h", "127.0.0.1", "-u", "$MYSQL_USER", "--password=$MYSQL_PASSWORD", "--port", "3306", "--execute", "SHOW DATABASES;"]
+      test: ["CMD", "healthcheck.sh", "--connect", "--innodb_initialized"]
       interval: 1s
       retries: 30
     ports:


### PR DESCRIPTION
**Description:**

- the existing healthcheck fails and that means running integration tests fails

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2098)
<!-- Reviewable:end -->
