### PR TITLE
materialize-snowflake: debug log the Load query before sending loaded documents

### DIFF
--- a/materialize-snowflake/snowflake.go
+++ b/materialize-snowflake/snowflake.go
@@ -392,6 +392,9 @@ func (d *transactor) Load(it *m.LoadIterator, loaded func(int, json.RawMessage) 
 
 			mutex.Lock()
 			defer mutex.Unlock()
+			log.WithFields(log.Fields{
+				"query": query,
+			}).Debug("sending Loaded documents from query")
 			for rows.Next() {
 				if err = rows.Scan(&binding, &document); err != nil {
 					return fmt.Errorf("scanning Load document: %w", err)


### PR DESCRIPTION
**Description:**

We have observed runtime errors for specific cases of sending loaded documents to the runtime, and this debug logging can be enabled to see which query produced those documents, and specifically for which collection.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2102)
<!-- Reviewable:end -->
