### PR TITLE
source-mysql: Fix BINARY(N) inconsistency

### DIFF
--- a/source-mysql/.snapshots/TestAddBinaryColumn
+++ b/source-mysql/.snapshots/TestAddBinaryColumn
@@ -1,0 +1,14 @@
+# ================================
+# Collection "acmeCo/test/test_addbinarycolumn_58901622": 6 Documents
+# ================================
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"AddBinaryColumn_58901622","cursor":"backfill:0"}},"id":1}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"AddBinaryColumn_58901622","cursor":"backfill:1"}},"id":2}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"AddBinaryColumn_58901622","cursor":"backfill:2"}},"id":3}
+{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"AddBinaryColumn_58901622","cursor":"binlog.000123:56789:123","txid":"11111111-1111-1111-1111-111111111111:111"}},"data":"AQIDBAUGBwg=","id":4}
+{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"AddBinaryColumn_58901622","cursor":"binlog.000123:56789:123","txid":"11111111-1111-1111-1111-111111111111:111"}},"data":"AQIDBAAAAAA=","id":5}
+{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"AddBinaryColumn_58901622","cursor":"binlog.000123:56789:123","txid":"11111111-1111-1111-1111-111111111111:111"}},"data":"AQIDAAAAAAA=","id":6}
+# ================================
+# Final State Checkpoint
+# ================================
+{"bindingStateV1":{"test%2FAddBinaryColumn_58901622":{"backfilled":3,"key_columns":["id"],"metadata":{"charset":"utf8mb4","schema":{"columns":["id","data"],"types":{"data":{"maxlen":8,"type":"binary"},"id":{"type":"int"}}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
+

--- a/source-mysql/datatype_test.go
+++ b/source-mysql/datatype_test.go
@@ -72,10 +72,10 @@ func TestDatatypes(t *testing.T) {
 		{ColumnType: "mediumtext", ExpectType: `{"type":["string","null"]}`, InputValue: "foo", ExpectValue: `"foo"`},
 		{ColumnType: "longtext", ExpectType: `{"type":["string","null"]}`, InputValue: "foo", ExpectValue: `"foo"`},
 
-		// TODO(wgd): The BINARY(n) type has a mild inconsistency in its treatment of trailing null bytes
-		// between backfill and replication.
 		{ColumnType: "binary(5)", ExpectType: `{"type":["string","null"],"contentEncoding":"base64"}`, InputValue: []byte{0x12, 0x34, 0x56, 0x78, 0x9A}, ExpectValue: `"EjRWeJo="`},
+		{ColumnType: "binary(8)", ExpectType: `{"type":["string","null"],"contentEncoding":"base64"}`, InputValue: []byte{0xE2, 0x28, 0xA1, 0x00, 0x00}, ExpectValue: `"4iihAAAAAAA="`},
 		{ColumnType: "varbinary(5)", ExpectType: `{"type":["string","null"],"contentEncoding":"base64"}`, InputValue: []byte{0x12, 0x34, 0x56, 0x78}, ExpectValue: `"EjRWeA=="`},
+		{ColumnType: "varbinary(8)", ExpectType: `{"type":["string","null"],"contentEncoding":"base64"}`, InputValue: []byte{0xE2, 0x28, 0xA1, 0x00, 0x00}, ExpectValue: `"4iihAAA="`},
 		{ColumnType: "tinyblob", ExpectType: `{"type":["string","null"],"contentEncoding":"base64"}`, InputValue: []byte{0x12, 0x34, 0x56, 0x78}, ExpectValue: `"EjRWeA=="`},
 		{ColumnType: "blob", ExpectType: `{"type":["string","null"],"contentEncoding":"base64"}`, InputValue: []byte{0x12, 0x34, 0x56, 0x78}, ExpectValue: `"EjRWeA=="`},
 		{ColumnType: "mediumblob", ExpectType: `{"type":["string","null"],"contentEncoding":"base64"}`, InputValue: []byte{0x12, 0x34, 0x56, 0x78}, ExpectValue: `"EjRWeA=="`},

--- a/source-mysql/replication.go
+++ b/source-mysql/replication.go
@@ -795,6 +795,14 @@ func translateDataType(meta *mysqlTableMetadata, t sqlparser.ColumnType) any {
 			charset = mysqlDefaultCharset // Finally fall back to UTF-8 if nothing else supersedes that
 		}
 		return &mysqlColumnType{Type: typeName, Charset: charset}
+	case "binary":
+		var columnLength int
+		if t.Length == nil {
+			columnLength = 1 // A type of just 'BINARY' is allowed and is a synonym for 'BINARY(1)'
+		} else if n, err := strconv.Atoi(t.Length.Val); err == nil {
+			columnLength = n // Otherwise if a length is specified we should be able to parse that as an integer and use that
+		}
+		return &mysqlColumnType{Type: typeName, MaxLength: columnLength}
 	default:
 		return typeName
 	}


### PR DESCRIPTION
**Description:**

A `BINARY(N)` column holds fixed-length byte data, with zero- padding to the specified length. This all works as expected for backfills, but the actual binlog data stores the value with any trailing zeroes stripped so that's what we get via replication.

This commit adds a new datatype test case verifying the behavior around trailing zero bytes and implicit padding (and just for good measure it also makes the nonzero bytes an invalid UTF-8 byte sequence), modifies discovery to keep track of the length of a `BINARY(N)` column, and modifies the value translation code to zero-pad as necessary.

**Workflow steps:**

Bindings which are initialized after this change will discover and initialize the column metadata with a length property for binary columns, which is used to zero-pad when needed.

Preexisting bindings will not have this length metadata, so the old value translation logic has been left in place as well and will still apply the inconsistent trailing-zeroes behavior unless/until the offending bindings are backfilled again.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2104)
<!-- Reviewable:end -->
