### PR TITLE
materialize-s3-iceberg: set a timeout on append files

### DIFF
--- a/materialize-s3-iceberg/driver_test.go
+++ b/materialize-s3-iceberg/driver_test.go
@@ -76,7 +76,7 @@ func TestValidateAndApply(t *testing.T) {
 		cfg,
 		resourceConfig,
 		func(t *testing.T) string {
-			is, err := catalog.infoSchema()
+			is, err := catalog.infoSchema(ctx)
 			require.NoError(t, err)
 
 			fields, err := is.FieldsForResource(resourceConfig.path())

--- a/materialize-s3-iceberg/icebergctl.go
+++ b/materialize-s3-iceberg/icebergctl.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -40,8 +41,8 @@ type tableAlter struct {
 
 // Run a command with iceberg-ctl. The config is required for every command other than
 // `print-config-schema`, currently.
-func runIcebergctl(cfg *config, args ...string) ([]byte, error) {
-	cmd := exec.Command(pythonPath, append([]string{"iceberg-ctl/iceberg_ctl"}, args...)...)
+func runIcebergctl(ctx context.Context, cfg *config, args ...string) ([]byte, error) {
+	cmd := exec.CommandContext(ctx, pythonPath, append([]string{"iceberg-ctl/iceberg_ctl"}, args...)...)
 
 	if cfg != nil {
 		configJson, err := json.Marshal(cfg)

--- a/materialize-s3-iceberg/transactor.go
+++ b/materialize-s3-iceberg/transactor.go
@@ -8,6 +8,7 @@ import (
 	"path"
 	"regexp"
 	"strings"
+	"time"
 
 	"github.com/cespare/xxhash/v2"
 	"github.com/estuary/connectors/filesink"
@@ -260,7 +261,9 @@ func (t *transactor) Acknowledge(ctx context.Context) (*pf.ConnectorState, error
 		})
 
 		ll.Info("starting appendFiles for table")
-		if err := t.catalog.appendFiles(t.materialization, b.path, bindingState.FileKeys, bindingState.PreviousCheckpoint, bindingState.CurrentCheckpoint); err != nil {
+		appendCtx, cancel := context.WithTimeout(ctx, 5*time.Minute)
+		defer cancel()
+		if err := t.catalog.appendFiles(appendCtx, t.materialization, b.path, bindingState.FileKeys, bindingState.PreviousCheckpoint, bindingState.CurrentCheckpoint); err != nil {
 			return nil, fmt.Errorf("appendFiles for %s: %w", b.path, err)
 		}
 		ll.Info("finished appendFiles for table")


### PR DESCRIPTION
**Description:**

We have observed that append requests can hang indefinitely when using a REST catalog. This implements a conservative timeout of 5 minutes for these append requests, so that the connector can log an error and re-start if an append request takes an extremely long time.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2113)
<!-- Reviewable:end -->
