### PR TITLE
source-klaviyo: raise errors for `Profiles` and `GlobalExclusions`

### DIFF
--- a/source-klaviyo/source_klaviyo/streams.py
+++ b/source-klaviyo/source_klaviyo/streams.py
@@ -37,17 +37,6 @@ class KlaviyoStream(HttpStream, ABC):
         return KlaviyoAvailabilityStrategy()
 
 
-    @property
-    def raise_on_http_errors(self) -> bool:
-        # Profiles and Global Exclusions Stream
-        # raise a 503 response when paginating. Ignoring 
-        # raises and retries on both
-        if self.name == "profiles" or self.name == "global_exclusions":
-            return False
-        else:
-            return True
-
-    
     def should_retry(self, response) -> bool:
         if self.name == "profiles" or self.name == "global_exclusions":
             return response.status_code == 429 or response.status_code == 500 or 503 < response.status_code < 600


### PR DESCRIPTION
**Description:**

The `raise_on_http_errors` property has been suppressing all errors for the `Profiles` and `GlobalExclusions` streams. It looks like this was originally done because Klaviyo sometimes returns a `503` when paginating per the Airbyte comments. I have not been able to replicate this. If that does happen, we should now get an error message, the shard should fail & restart, and the stream should pick up where it last left off paginating.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

Tested on a local stack. Confirmed that HTTP errors (specifically a `400` response) for `Profiles` and `GlobalExclusions` fails the shard and logs out an error message.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2118)
<!-- Reviewable:end -->
