### PR TITLE
source-redshift-batch: Discover float as number-or-string

### DIFF
--- a/source-redshift-batch/driver.go
+++ b/source-redshift-batch/driver.go
@@ -343,7 +343,7 @@ type columnType interface {
 }
 
 type basicColumnType struct {
-	jsonType        string
+	jsonTypes       []string
 	contentEncoding string
 	format          string
 	nullable        bool
@@ -360,12 +360,16 @@ func (ct *basicColumnType) JSONSchema() *jsonschema.Schema {
 		sch.Extras["contentEncoding"] = ct.contentEncoding // New in 2019-09.
 	}
 
-	if ct.jsonType == "" {
-		// No type constraint.
-	} else if !ct.nullable {
-		sch.Type = ct.jsonType
-	} else {
-		sch.Extras["type"] = []string{ct.jsonType, "null"}
+	if ct.jsonTypes != nil {
+		var types = append([]string(nil), ct.jsonTypes...)
+		if ct.nullable {
+			types = append(types, "null")
+		}
+		if len(types) == 1 {
+			sch.Type = types[0]
+		} else {
+			sch.Extras["type"] = types
+		}
 	}
 	return sch
 }
@@ -417,9 +421,9 @@ func discoverColumns(ctx context.Context, db *sql.DB, discoverSchemas []string) 
 		var dataType basicColumnType
 		switch typeType {
 		case "e": // enum values are captured as strings
-			dataType = basicColumnType{jsonType: "string"}
+			dataType = basicColumnType{jsonTypes: []string{"string"}}
 		case "r", "m": // ranges and multiranges are captured as strings
-			dataType = basicColumnType{jsonType: "string"}
+			dataType = basicColumnType{jsonTypes: []string{"string"}}
 		default:
 			var ok bool
 			dataType, ok = databaseTypeToJSON[typeName]
@@ -501,50 +505,50 @@ func discoverPrimaryKeys(ctx context.Context, db *sql.DB, discoverSchemas []stri
 }
 
 var databaseTypeToJSON = map[string]basicColumnType{
-	"bool": {jsonType: "boolean"},
+	"bool": {jsonTypes: []string{"boolean"}},
 
-	"int2": {jsonType: "integer"},
-	"int4": {jsonType: "integer"},
-	"int8": {jsonType: "integer"},
+	"int2": {jsonTypes: []string{"integer"}},
+	"int4": {jsonTypes: []string{"integer"}},
+	"int8": {jsonTypes: []string{"integer"}},
 
-	"numeric": {jsonType: "string", format: "number"},
-	"float4":  {jsonType: "number"},
-	"float8":  {jsonType: "number"},
+	"numeric": {jsonTypes: []string{"string"}, format: "number"},
+	"float4":  {jsonTypes: []string{"number", "string"}, format: "number"},
+	"float8":  {jsonTypes: []string{"number", "string"}, format: "number"},
 
-	"varchar": {jsonType: "string"},
-	"bpchar":  {jsonType: "string"},
-	"text":    {jsonType: "string"},
-	"bytea":   {jsonType: "string", contentEncoding: "base64"},
-	"xml":     {jsonType: "string"},
-	"bit":     {jsonType: "string"},
-	"varbit":  {jsonType: "string"},
+	"varchar": {jsonTypes: []string{"string"}},
+	"bpchar":  {jsonTypes: []string{"string"}},
+	"text":    {jsonTypes: []string{"string"}},
+	"bytea":   {jsonTypes: []string{"string"}, contentEncoding: "base64"},
+	"xml":     {jsonTypes: []string{"string"}},
+	"bit":     {jsonTypes: []string{"string"}},
+	"varbit":  {jsonTypes: []string{"string"}},
 
 	"json":     {},
 	"jsonb":    {},
-	"jsonpath": {jsonType: "string"},
+	"jsonpath": {jsonTypes: []string{"string"}},
 
 	// Domain-Specific Types
-	"date":        {jsonType: "string", format: "date-time"},
-	"timestamp":   {jsonType: "string", format: "date-time"},
-	"timestamptz": {jsonType: "string", format: "date-time"},
-	"time":        {jsonType: "integer"},
-	"timetz":      {jsonType: "string", format: "time"},
-	"interval":    {jsonType: "string"},
-	"money":       {jsonType: "string"},
-	"point":       {jsonType: "string"},
-	"line":        {jsonType: "string"},
-	"lseg":        {jsonType: "string"},
-	"box":         {jsonType: "string"},
-	"path":        {jsonType: "string"},
-	"polygon":     {jsonType: "string"},
-	"circle":      {jsonType: "string"},
-	"inet":        {jsonType: "string"},
-	"cidr":        {jsonType: "string"},
-	"macaddr":     {jsonType: "string"},
-	"macaddr8":    {jsonType: "string"},
-	"tsvector":    {jsonType: "string"},
-	"tsquery":     {jsonType: "string"},
-	"uuid":        {jsonType: "string", format: "uuid"},
+	"date":        {jsonTypes: []string{"string"}, format: "date-time"},
+	"timestamp":   {jsonTypes: []string{"string"}, format: "date-time"},
+	"timestamptz": {jsonTypes: []string{"string"}, format: "date-time"},
+	"time":        {jsonTypes: []string{"integer"}},
+	"timetz":      {jsonTypes: []string{"string"}, format: "time"},
+	"interval":    {jsonTypes: []string{"string"}},
+	"money":       {jsonTypes: []string{"string"}},
+	"point":       {jsonTypes: []string{"string"}},
+	"line":        {jsonTypes: []string{"string"}},
+	"lseg":        {jsonTypes: []string{"string"}},
+	"box":         {jsonTypes: []string{"string"}},
+	"path":        {jsonTypes: []string{"string"}},
+	"polygon":     {jsonTypes: []string{"string"}},
+	"circle":      {jsonTypes: []string{"string"}},
+	"inet":        {jsonTypes: []string{"string"}},
+	"cidr":        {jsonTypes: []string{"string"}},
+	"macaddr":     {jsonTypes: []string{"string"}},
+	"macaddr8":    {jsonTypes: []string{"string"}},
+	"tsvector":    {jsonTypes: []string{"string"}},
+	"tsquery":     {jsonTypes: []string{"string"}},
+	"uuid":        {jsonTypes: []string{"string"}, format: "uuid"},
 }
 
 var catalogNameSanitizerRe = regexp.MustCompile(`(?i)[^a-z0-9\-_.]`)


### PR DESCRIPTION
**Description:**

This commit copies over some discovery changes from the `source-postgres` CDC connector (from which the Redshift discovery logic is mostly derived) to allow a source DB type to be mapped to multiple JSON types instead of just one.

Then that feature is used so that float4/float8 columns can be discovered as "either string-format-number or number". This is consistent with what `source-postgres` does and might help us with NaN-handling at some point in the future, but the real reason it's useful *right now* is that it unblocks a production capture which is currently having trouble with a column type changing from `NUMERIC` to `FLOAT`, because schema inference says that values are string-format-number and discovery says that values are numbers and Flow says that there are no values which can satisfy both of those constraints.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2120)
<!-- Reviewable:end -->
