### PR TITLE
source-hubspot-native: fix variable access bug

### DIFF
--- a/source-hubspot-native/source_hubspot_native/api.py
+++ b/source-hubspot-native/source_hubspot_native/api.py
@@ -645,18 +645,6 @@ async def fetch_search_objects_modified_at(
             "limit": limit,
         }
 
-        # Log every 10,000 returned records, since there are 200 per page.
-        if round % 50 == 0:
-            log.info(
-                "fetching ids for records modified at instant",
-                {
-                    "object_name": object_name,
-                    "instant": modified,
-                    "count": len(output_items),
-                    "remaining": result.total,
-                }
-            )
-
         result: SearchPageResult[CustomObjectSearchResult] = SearchPageResult[CustomObjectSearchResult].model_validate_json(
             await http.request(log, url, method="POST", json=input)
         )
@@ -669,6 +657,18 @@ async def fetch_search_objects_modified_at(
                 raise Exception(f"unexpected id order: {r.id} <= {id_cursor}")
             id_cursor = r.id
             output_items.add((r.properties.hs_lastmodifieddate, str(r.id)))
+
+        # Log every 10,000 returned records, since there are 200 per page.
+        if round % 50 == 0:
+            log.info(
+                "fetching ids for records modified at instant",
+                {
+                    "object_name": object_name,
+                    "instant": modified,
+                    "count": len(output_items),
+                    "remaining": result.total,
+                }
+            )
 
         if not result.paging:
             break


### PR DESCRIPTION
**Description:**

Quick fix of a bug introduced by the ordering of the the logging statement in `fetch_search_objects_modified_at`, where `result.total` is not available initializing the variable in the first loop.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2122)
<!-- Reviewable:end -->
