### PR TITLE
materialize-webhook: support custom headers & chunk transactions across multiple webhooks

### DIFF
--- a/materialize-webhook/driver.go
+++ b/materialize-webhook/driver.go
@@ -126,6 +126,9 @@ func (driver) Validate(ctx context.Context, req *pm.Request_Validate) (*pm.Respo
 			case projection.IsRootDocumentProjection():
 				constraint.Type = pm.Response_Validated_Constraint_LOCATION_REQUIRED
 				constraint.Reason = "The root document must be materialized"
+			case projection.IsPrimaryKey:
+				constraint.Type = pm.Response_Validated_Constraint_LOCATION_REQUIRED
+				constraint.Reason = "Document keys must be included"
 			default:
 				constraint.Type = pm.Response_Validated_Constraint_FIELD_FORBIDDEN
 				constraint.Reason = "Webhooks only materialize the full document"


### PR DESCRIPTION
**Description:**

Changes include:
- Supporting custom headers.
- Requiring collection keys in field selection.
- Chunking transactions across multiple webhooks.
- Webhook bodies are ~100 MiB or less.
- Removing retry mechanism in favor of allowing the connector to fail & retry the webhook when it is automatically restarted.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

The HTTP Webhook [docs](https://docs.estuary.dev/reference/Connectors/materialization-connectors/http-webhook/) should be updated to reflect the configuration options.

**Notes for reviewers:**

Tested on a local stack. Confirmed:
- A single webhook only contains documents from a single binding.
- Webhooks are finished & closed once they reach/exceed the 100 MiB cutoff limit.
- Custom headers are specified in webhooks.
- Documents with different primary key values are not reduced by the runtime before being sent as Store requests.

The 1 MiB cutoff was arbitrarily chosen, and it's possible for the webhook to be larger than the cutoff if the last document piped into the webhook body pushes the byte count over the cutoff. This is because the rolling byte count is incremented after piping the document into the request. Taking this approach simplified the connector, but if we absolutely must not send webhooks larger than the cutoff, we can refactor the connector to do so. Hopefully this approach works for now.
<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2128)
<!-- Reviewable:end -->
