### PR TITLE
source-{redshift,postgres}-batch: Support NaNs

### DIFF
--- a/source-postgres-batch/.snapshots/TestFloatNaNs-Capture
+++ b/source-postgres-batch/.snapshots/TestFloatNaNs-Capture
@@ -1,0 +1,11 @@
+# ================================
+# Collection "acmeCo/test/test_float_nans_10511": 3 Documents
+# ================================
+{"_meta":{"polled":"<TIMESTAMP>","index":999},"a_double":"NaN","a_real":2,"id":0,"txid":999999}
+{"_meta":{"polled":"<TIMESTAMP>","index":999},"a_double":3,"a_real":"NaN","id":1,"txid":999999}
+{"_meta":{"polled":"<TIMESTAMP>","index":999},"a_double":"-Infinity","a_real":"Infinity","id":2,"txid":999999}
+# ================================
+# Final State Checkpoint
+# ================================
+{"bindingStateV1":{"test_float_nans_10511":{"CursorNames":["txid"],"CursorValues":[999999],"LastPolled":"<TIMESTAMP>"}}}
+

--- a/source-postgres-batch/.snapshots/TestFloatNaNs-Discovery
+++ b/source-postgres-batch/.snapshots/TestFloatNaNs-Discovery
@@ -1,0 +1,58 @@
+Binding 0:
+{
+    "resource_config_json": {
+      "name": "test_float_nans_10511",
+      "schema": "test",
+      "table": "float_nans_10511",
+      "cursor": [
+        "txid"
+      ]
+    },
+    "resource_path": [
+      "test_float_nans_10511"
+    ],
+    "collection": {
+      "name": "acmeCo/test/test_float_nans_10511",
+      "read_schema_json": {
+        "type": "object",
+        "required": [
+          "_meta",
+          "id"
+        ],
+        "properties": {
+          "_meta": {
+            "$schema": "http://json-schema.org/draft/2020-12/schema",
+            "$id": "https://github.com/estuary/connectors/source-postgres-batch/document-metadata",
+            "properties": {
+              "polled": {
+                "type": "string",
+                "format": "date-time",
+                "title": "Polled Timestamp",
+                "description": "The time at which the update query which produced this document as executed."
+              },
+              "index": {
+                "type": "integer",
+                "title": "Result Index",
+                "description": "The index of this document within the query execution which produced it."
+              }
+            },
+            "type": "object",
+            "required": [
+              "polled",
+              "index"
+            ]
+          },
+          "id": {
+            "type": "integer"
+          }
+        },
+        "x-infer-schema": true
+      },
+      "key": [
+        "/id"
+      ],
+      "projections": null
+    },
+    "state_key": "test_float_nans_10511"
+  }
+

--- a/source-postgres-batch/main.go
+++ b/source-postgres-batch/main.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"math"
 	"net/url"
 	"strings"
 	"text/template"
@@ -166,6 +167,16 @@ func translatePostgresValue(val any, databaseTypeName string) (any, error) {
 		case strings.EqualFold(databaseTypeName, "JSONB"):
 			return json.RawMessage(val), nil
 		}
+	}
+	if val, ok := val.(float64); ok { // Both FLOAT4 and FLOAT8 columns are float64's here
+		if math.IsNaN(val) {
+			return "NaN", nil
+		} else if math.IsInf(val, +1) {
+			return "Infinity", nil
+		} else if math.IsInf(val, -1) {
+			return "-Infinity", nil
+		}
+		return val, nil
 	}
 	return val, nil
 }

--- a/source-redshift-batch/.snapshots/TestFloatNaNs-Capture
+++ b/source-redshift-batch/.snapshots/TestFloatNaNs-Capture
@@ -1,0 +1,11 @@
+# ================================
+# Collection "acmeCo/test/test_float_nans_10511": 3 Documents
+# ================================
+{"_meta":{"polled":"<TIMESTAMP>","index":999},"a_double":"NaN","a_real":2,"id":0,"txid":999999}
+{"_meta":{"polled":"<TIMESTAMP>","index":999},"a_double":3,"a_real":"NaN","id":1,"txid":999999}
+{"_meta":{"polled":"<TIMESTAMP>","index":999},"a_double":"-Infinity","a_real":"Infinity","id":2,"txid":999999}
+# ================================
+# Final State Checkpoint
+# ================================
+{"bindingStateV1":{"test_float_nans_10511":{"CursorNames":["txid"],"CursorValues":[999999],"LastPolled":"<TIMESTAMP>"}}}
+

--- a/source-redshift-batch/main.go
+++ b/source-redshift-batch/main.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"math"
 	"net/url"
 	"strings"
 
@@ -151,6 +152,16 @@ func translateRedshiftValue(val any, databaseTypeName string) (any, error) {
 		case strings.EqualFold(databaseTypeName, "JSONB"):
 			return json.RawMessage(val), nil
 		}
+	}
+	if val, ok := val.(float64); ok { // Both FLOAT4 and FLOAT8 columns are float64's here
+		if math.IsNaN(val) {
+			return "NaN", nil
+		} else if math.IsInf(val, +1) {
+			return "Infinity", nil
+		} else if math.IsInf(val, -1) {
+			return "-Infinity", nil
+		}
+		return val, nil
 	}
 	return val, nil
 }

--- a/source-redshift-batch/main_test.go
+++ b/source-redshift-batch/main_test.go
@@ -155,6 +155,31 @@ func TestBasicDatatypes(t *testing.T) {
 	})
 }
 
+func TestFloatNaNs(t *testing.T) {
+	var ctx, cs = context.Background(), testCaptureSpec(t)
+	var control = testControlClient(ctx, t)
+	var uniqueID = "10511"
+	var tableName = fmt.Sprintf("test.float_nans_%s", uniqueID)
+
+	executeControlQuery(ctx, t, control, fmt.Sprintf("DROP TABLE IF EXISTS %s", tableName))
+	t.Cleanup(func() { executeControlQuery(ctx, t, control, fmt.Sprintf("DROP TABLE IF EXISTS %s", tableName)) })
+	executeControlQuery(ctx, t, control, fmt.Sprintf("CREATE TABLE %s(id INTEGER PRIMARY KEY, a_real REAL, a_double DOUBLE PRECISION)", tableName))
+
+	cs.Bindings = discoverStreams(ctx, t, cs, regexp.MustCompile(uniqueID))
+
+	t.Run("Discovery", func(t *testing.T) { snapshotBindings(t, cs.Bindings) })
+
+	t.Run("Capture", func(t *testing.T) {
+		executeControlQuery(ctx, t, control, fmt.Sprintf(`INSERT INTO %s VALUES (0, 2.0, 'NaN'), (1, 'NaN', 3.0), (2, 'Infinity', '-Infinity')`, tableName))
+
+		// Run the capture for 1 second, which should be plenty to pull down a few rows.
+		var captureCtx, cancelCapture = context.WithCancel(ctx)
+		time.AfterFunc(1*time.Second, cancelCapture)
+		cs.Capture(captureCtx, t, nil)
+		cupaloy.SnapshotT(t, cs.Summary())
+	})
+}
+
 func TestSchemaFilter(t *testing.T) {
 	var ctx, cs = context.Background(), testCaptureSpec(t)
 	var control = testControlClient(ctx, t)


### PR DESCRIPTION
**Description:**

Adds support in the batch Postgres and Redshift captures for the special floating-point values `'NaN'`, `'Infinity'`, and `'-Infinity'`, which are translated into the corresponding strings as we do for other captures.

Since Postgres batch relies on schema inference for non-key property types and Redshift batch already has logic to discover floating-point columns as `type: [number, string], format: number` for other reasons, this doesn't require any discovery changes.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2131)
<!-- Reviewable:end -->
