### PR TITLE
source-postgres: exclude temp tables from discovery

### DIFF
--- a/source-postgres/discovery.go
+++ b/source-postgres/discovery.go
@@ -355,6 +355,8 @@ const queryDiscoverTables = `
   JOIN pg_catalog.pg_namespace n ON (n.oid = c.relnamespace)
   WHERE n.nspname NOT IN ('pg_catalog', 'pg_internal', 'information_schema', 'catalog_history', 'cron', 'pglogical')
     AND NOT c.relispartition
+    -- exclude temporary tables ('t') and unlogged tables ('u')
+    AND c.relpersistence = 'p'
     AND c.relkind IN ('r', 'p');` // 'r' means "Ordinary Table" and 'p' means "Partitioned Table"
 
 func getTables(ctx context.Context, conn *pgx.Conn, selectedSchemas []string) ([]*sqlcapture.DiscoveryInfo, error) {


### PR DESCRIPTION
Filters out temporary and unlogged tables during discovery. These tables cause validation to fail because they cannot be added to publications. The filtering is done based on the `pg_class.relpersistence` values, described in the docs: https://www.postgresql.org/docs/current/catalog-pg-class.html#CATALOG-PG-CLASS

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2133)
<!-- Reviewable:end -->
