### PR TITLE
sqlcapture: Cursor replacement for production task

### DIFF
--- a/sqlcapture/main.go
+++ b/sqlcapture/main.go
@@ -309,6 +309,9 @@ func (d *Driver) Pull(open *pc.Request_Open, stream *boilerplate.PullOutput) err
 	// scoped.
 	var hackyCursorReplacements = map[string]map[string]string{
 		"TASKHASH415b69936fe1324600d67943e50235fc57fb7e0196b8f5f0TASKHASH": {"binlog.000123:456789": "binlog.000123:456789"}, // Example
+
+		// Added 2024-11-13
+		"f976b2fd842a663be34d55f54bf0cabd9d85c4abf62d37345dc082b37ddd1d78": {"bin.063725:3828548756": "bin.063725:4"},
 	}
 	var hasher = sha256.New()
 	hasher.Write([]byte(open.Capture.Name))


### PR DESCRIPTION
**Description:**

A production task ran into trouble and needs its binlog cursor manually adjusted using the mechanism we built for doing that.

Ask Will for further context

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2141)
<!-- Reviewable:end -->
