### PR TITLE
source-genesys: add discriminator to endpoint config's credentials

### DIFF
--- a/source-genesys/source_genesys/models.py
+++ b/source-genesys/source_genesys/models.py
@@ -22,7 +22,10 @@ OAUTH2_SPEC = ClientCredentialsOAuth2Spec(
     }
 )
 
-OAuth2Credentials = ClientCredentialsOAuth2Credentials
+# The class name appears in the UI's Authentication section, so we wrap the non-user friendly name in a slighly better name.
+# TODO(alex): figure out why the class name is appearing in the UI & determine if there's some property to set that overrides it.
+class OAuth(ClientCredentialsOAuth2Credentials):
+    pass
 
 
 def default_start_date():
@@ -55,8 +58,9 @@ class EndpointConfig(BaseModel):
     ] = Field(
         title="Genesys Cloud Domain"
     )
-    credentials: OAuth2Credentials = Field(
+    credentials: OAuth = Field(
         title="Authentication",
+        discriminator="credentials_title"
     )
 
 

--- a/source-genesys/tests/snapshots/snapshots__spec__capture.stdout.json
+++ b/source-genesys/tests/snapshots/snapshots__spec__capture.stdout.json
@@ -3,7 +3,7 @@
     "protocol": 3032023,
     "configSchema": {
       "$defs": {
-        "ClientCredentialsOAuth2Credentials": {
+        "OAuth": {
           "properties": {
             "credentials_title": {
               "const": "OAuth Credentials",
@@ -29,7 +29,7 @@
             "client_id",
             "client_secret"
           ],
-          "title": "ClientCredentialsOAuth2Credentials",
+          "title": "OAuth",
           "type": "object"
         }
       },
@@ -62,7 +62,17 @@
           "type": "string"
         },
         "credentials": {
-          "$ref": "#/$defs/ClientCredentialsOAuth2Credentials",
+          "discriminator": {
+            "mapping": {
+              "OAuth Credentials": "#/$defs/OAuth"
+            },
+            "propertyName": "credentials_title"
+          },
+          "oneOf": [
+            {
+              "$ref": "#/$defs/OAuth"
+            }
+          ],
           "title": "Authentication"
         }
       },


### PR DESCRIPTION
**Description:**

Changes include:
- Add a `discriminator` to the endpoint config's `credentials` so it's easier to add more authentication methods later if needed.
- Wrap the `ClientCredentialsOAuth2Credentials` class in a more user-friendly name since it shows up in the UI somehow. There's likely a more elegant & correct solution to fix this, but I haven't found it yet.

After these changes, the UI looks like the below:
![image](https://github.com/user-attachments/assets/81342118-39a0-48cc-a82e-b8c5ed658aba)


**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

Spec snapshot updates are expected since the endpoint config has changed. There is no real use of the connector yet, so there are no existing tasks affected by these changes.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2144)
<!-- Reviewable:end -->
