### PR TITLE
source-snowflake: Support (incremental) dynamic tables

### DIFF
--- a/source-snowflake/.snapshots/TestBasicDatatypes-main
+++ b/source-snowflake/.snapshots/TestBasicDatatypes-main
@@ -2,7 +2,7 @@
 # Collection "acmeCo/test/test_basicdatatypes_77528227": 3 Documents
 # ================================
 {"BDATA":"7loRpQ==","BIT":false,"DATA":"DCBA","FDATA":2.64,"ID":3,"X":0,"Y":0,"_meta":{"op":"c","source":{"schema":"PUBLIC","table":"test_BasicDatatypes_77528227","seq":2,"off":0}}}
-{"BDATA":"/w==","BIT":false,"DATA":"    ","FDATA":0.00001,"ID":4,"X":-9999,"Y":100,"_meta":{"op":"c","source":{"schema":"PUBLIC","table":"test_BasicDatatypes_77528227","seq":2,"off":1}}}
+{"BDATA":"/w==","BIT":false,"DATA":"    ","FDATA":0.00001,"ID":4,"X":-9999,"Y":-0.99,"_meta":{"op":"c","source":{"schema":"PUBLIC","table":"test_BasicDatatypes_77528227","seq":2,"off":1}}}
 {"BDATA":null,"BIT":null,"DATA":null,"FDATA":null,"ID":5,"X":null,"Y":null,"_meta":{"op":"c","source":{"schema":"PUBLIC","table":"test_BasicDatatypes_77528227","seq":2,"off":2}}}
 # ================================
 # Final State Checkpoint

--- a/source-snowflake/.snapshots/TestDynamicTable-discovery
+++ b/source-snowflake/.snapshots/TestDynamicTable-discovery
@@ -1,0 +1,125 @@
+Binding 0:
+{
+    "recommended_name": "test_dynamictable_99720399",
+    "resource_config_json": {
+      "schema": "PUBLIC",
+      "table": "test_DynamicTable_99720399"
+    },
+    "document_schema_json": {
+      "$defs": {
+        "Test_DynamicTable_99720399": {
+          "type": "object",
+          "$anchor": "Test_DynamicTable_99720399",
+          "properties": {
+            "DATA": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "ID": {
+              "type": "integer"
+            }
+          }
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "_meta": {
+                "properties": {
+                  "op": {
+                    "const": "d"
+                  }
+                }
+              }
+            }
+          },
+          "then": {
+            "reduce": {
+              "delete": true,
+              "strategy": "merge"
+            }
+          },
+          "else": {
+            "reduce": {
+              "strategy": "merge"
+            }
+          },
+          "required": [
+            "_meta"
+          ],
+          "properties": {
+            "_meta": {
+              "type": "object",
+              "required": [
+                "op",
+                "source"
+              ],
+              "properties": {
+                "before": {
+                  "$ref": "#Test_DynamicTable_99720399",
+                  "description": "Record state immediately before this change was applied.",
+                  "reduce": {
+                    "strategy": "firstWriteWins"
+                  }
+                },
+                "op": {
+                  "enum": [
+                    "c",
+                    "d",
+                    "u"
+                  ],
+                  "description": "Change operation type: 'c' Create/Insert, 'u' Update, 'd' Delete."
+                },
+                "source": {
+                  "$id": "https://github.com/estuary/connectors/source-snowflake/snowflake-source-metadata",
+                  "properties": {
+                    "ts_ms": {
+                      "type": "integer",
+                      "description": "Unix timestamp (in millis) at which this event was recorded by the database."
+                    },
+                    "schema": {
+                      "type": "string",
+                      "description": "Database schema (namespace) of the event."
+                    },
+                    "snapshot": {
+                      "type": "boolean",
+                      "description": "Snapshot is true if the record was produced from an initial table backfill and unset if produced from the replication log."
+                    },
+                    "table": {
+                      "type": "string",
+                      "description": "Database table of the event."
+                    },
+                    "seq": {
+                      "type": "integer",
+                      "description": "The sequence number of the staging table from which this document was read"
+                    },
+                    "off": {
+                      "type": "integer",
+                      "description": "The offset within that staging table at which this document occurred"
+                    }
+                  },
+                  "type": "object",
+                  "required": [
+                    "schema",
+                    "table",
+                    "seq",
+                    "off"
+                  ]
+                }
+              },
+              "reduce": {
+                "strategy": "merge"
+              }
+            }
+          }
+        },
+        {
+          "$ref": "#Test_DynamicTable_99720399"
+        }
+      ]
+    }
+  }
+

--- a/source-snowflake/.snapshots/TestDynamicTable-initial
+++ b/source-snowflake/.snapshots/TestDynamicTable-initial
@@ -1,0 +1,13 @@
+# ================================
+# Collection "acmeCo/test/test_dynamictable_99720399": 5 Documents
+# ================================
+{"DATA":"A","ID":0,"_meta":{"op":"c","source":{"schema":"PUBLIC","snapshot":true,"table":"test_DynamicTable_99720399","seq":0,"off":0}}}
+{"DATA":"5","ID":4,"_meta":{"op":"c","source":{"schema":"PUBLIC","snapshot":true,"table":"test_DynamicTable_99720399","seq":0,"off":1}}}
+{"DATA":"Four","ID":3,"_meta":{"op":"c","source":{"schema":"PUBLIC","snapshot":true,"table":"test_DynamicTable_99720399","seq":0,"off":2}}}
+{"DATA":"CDEFGHIJKLMNOP","ID":2,"_meta":{"op":"c","source":{"schema":"PUBLIC","snapshot":true,"table":"test_DynamicTable_99720399","seq":0,"off":3}}}
+{"DATA":"bbb","ID":1,"_meta":{"op":"c","source":{"schema":"PUBLIC","snapshot":true,"table":"test_DynamicTable_99720399","seq":0,"off":4}}}
+# ================================
+# Final State Checkpoint
+# ================================
+{"streams":{"PUBLIC%2Ftest_DynamicTable_99720399":{"off":0,"seq":2,"uid":"FFFFFFFFFFFFFFFF_PUBLIC_TEST_DYNAMICTABLE_99720399"}}}
+

--- a/source-snowflake/.snapshots/TestDynamicTable-subsequent
+++ b/source-snowflake/.snapshots/TestDynamicTable-subsequent
@@ -1,0 +1,13 @@
+# ================================
+# Collection "acmeCo/test/test_dynamictable_99720399": 5 Documents
+# ================================
+{"DATA":"F","ID":6,"_meta":{"op":"c","source":{"schema":"PUBLIC","table":"test_DynamicTable_99720399","seq":2,"off":0}}}
+{"DATA":"11","ID":10,"_meta":{"op":"c","source":{"schema":"PUBLIC","table":"test_DynamicTable_99720399","seq":2,"off":1}}}
+{"DATA":"Ten","ID":9,"_meta":{"op":"c","source":{"schema":"PUBLIC","table":"test_DynamicTable_99720399","seq":2,"off":2}}}
+{"DATA":"QRSTUVWXYZ","ID":8,"_meta":{"op":"c","source":{"schema":"PUBLIC","table":"test_DynamicTable_99720399","seq":2,"off":3}}}
+{"DATA":"ggg","ID":7,"_meta":{"op":"c","source":{"schema":"PUBLIC","table":"test_DynamicTable_99720399","seq":2,"off":4}}}
+# ================================
+# Final State Checkpoint
+# ================================
+{"streams":{"PUBLIC%2Ftest_DynamicTable_99720399":{"off":0,"seq":3,"uid":"FFFFFFFFFFFFFFFF_PUBLIC_TEST_DYNAMICTABLE_99720399"}}}
+

--- a/source-snowflake/README.md
+++ b/source-snowflake/README.md
@@ -12,4 +12,20 @@ Useful commands:
 
     $ docker build -t ghcr.io/estuary/source-snowflake:local -f source-snowflake/Dockerfile .
     $ flowctl raw discover --source acmeCo/flow.yaml
-    $ flowctl raw capture acmeCo/flow.yaml
+    $ flowctl raw capture --source acmeCo/flow.yaml
+
+Example `flow.yaml` for discovery:
+
+    captures:
+      acmeCo/source-snowflake:
+        endpoint:
+          connector:
+            image: "ghcr.io/estuary/source-snowflake:v1"
+            config:
+              host: bn92689.us-central1.gcp.snowflakecomputing.com
+              account: bn92689
+              user: USERNAME
+              password: secret1234
+              database: CONNECTOR_TESTING
+              warehouse: COMPUTE_WH
+        bindings: []

--- a/source-snowflake/capture.go
+++ b/source-snowflake/capture.go
@@ -243,7 +243,7 @@ func (c *capture) updateState(ctx context.Context) error {
 				"uid":   uniqueID,
 			}).Info("binding added")
 
-			var isDynamic = dynamicTables[binding.Table]
+			var _, isDynamic = dynamicTables[binding.Table] // Any table with an entry in the dynamicTables map must be a dynamic table
 
 			streamName, err := createChangeStream(ctx, c.Config, c.DB, binding.Table, isDynamic, uniqueID)
 			if err != nil {

--- a/source-snowflake/capture_test.go
+++ b/source-snowflake/capture_test.go
@@ -70,7 +70,7 @@ func TestBasicDatatypes(t *testing.T) {
 
 	tb.Insert(ctx, t, tableName, [][]any{
 		{3, "DCBA", []byte{0xEE, 0x5A, 0x11, 0xA5}, 2.64, false, 0, 0},
-		{4, "    ", []byte{0xFF}, 0.00001, false, -9999, 99.999},
+		{4, "    ", []byte{0xFF}, 0.00001, false, -9999, -0.99},
 		{5, nil, nil, nil, nil, nil, nil},
 	})
 	t.Run("main", func(t *testing.T) { verifiedCapture(ctx, t, cs) })

--- a/source-snowflake/discovery.go
+++ b/source-snowflake/discovery.go
@@ -52,11 +52,12 @@ type snowflakeDiscoveryResults struct {
 }
 
 type snowflakeDiscoveryTable struct {
-	Database string `db:"database_name"`
-	Schema   string `db:"schema_name"`
-	Name     string `db:"name"`
-	Kind     string `db:"kind"`
-	Comment  string `db:"comment"`
+	Database  string `db:"database_name"`
+	Schema    string `db:"schema_name"`
+	Name      string `db:"name"`
+	Kind      string `db:"kind"`
+	Comment   string `db:"comment"`
+	IsDynamic string `db:"is_dynamic"`
 }
 
 type snowflakeDiscoveryColumn struct {


### PR DESCRIPTION
**Description:**

As a general rule, if a connector returns something from discovery then we should be able to capture that thing without errors, and if we can't capture a particular type of entity then it shouldn't be suggested by discovery in the first place. A user should be able to just blindly click 'Next' in the capture creation flow and end up with something that works.

This was not previously the case for dynamic tables in Snowflake. They're tantalizingly close to working without any extra action, but for reasons known only to them Snowflake is very nitpicky about making you acknowledge that a table is dynamic. For instance you can't just say `CREATE STREAM ... ON TABLE`, you have to tell them `CREATE STREAM ... ON DYNAMIC TABLE`.

So dynamic tables didn't work, but our discovery logic returned them, which meant that we're violating that "just clicking Next ought to work" principle I described above. This had to be fixed in one of the two obvious ways, and I figure that once we've got logic to query whether a table is dynamic we might as well just plug that into the appropriate bits of the capture so it can use the necessary dynamic-table variants of the operations.

There turns out to be an additional wrinkle however. Snowflake's documentation won't say this explicitly anywhere, but basically you can create change streams from _incremental_ dynamic tables but you can't create a stream on a _full refresh_ dynamic table. So it turns out we still have to have some discovery filtering logic in order to exclude dynamic tables with `REFRESH_MODE = FULL`.

With these changes, the Snowflake CDC connector should support dynamic tables with `REFRESH_MODE = INCREMENTAL` and also satisfy that "stuff discovery suggests is stuff we can capture" principle described earlier, at least for all of the types of Snowflake table I know about.

**Workflow steps:**

Discovery will no longer return dynamic tables with `REFRESH_MODE = FULL` in the first place. Dynamic tables with `REFRESH_MODE = INCREMENTAL` will still be discovered, and now they will actually work.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2145)
<!-- Reviewable:end -->
