### PR TITLE
source-kinesis: logging if getting a shard iterator fails

### DIFF
--- a/source-kinesis/capture.go
+++ b/source-kinesis/capture.go
@@ -342,7 +342,10 @@ func (r *shardReader) readShard() {
 			return
 		} else {
 			// oh well, we tried. Time to call it a day
-
+			log.WithError(err).WithFields(log.Fields{
+				"stream":  r.source.stream,
+				"shardId": r.source.shardID,
+			}).Error("getting kinesis shard iterator failed")
 			return
 		}
 	}
@@ -491,6 +494,7 @@ func (r *shardReader) getShardIterator() (string, error) {
 		shardIterReq.ShardIteratorType = &START_AT_BEGINNING
 	}
 
+	log.WithField("shardIterReq", shardIterReq).Info("requesting shard iterator")
 	shardIterResp, err := r.parent.client.GetShardIteratorWithContext(r.parent.ctx, &shardIterReq)
 	if err != nil {
 		return "", err


### PR DESCRIPTION
**Description:**

Currently an error for getting a shard iterator is just swallowed entirely. We should probably fail the capture when this happens, but as a really low-effort debugging benefit we can at least log these errors if they happen.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2149)
<!-- Reviewable:end -->
