### PR TITLE
source-snowflake: discover vector columns

### DIFF
--- a/source-snowflake/.snapshots/TestVectorDatatypes-discover
+++ b/source-snowflake/.snapshots/TestVectorDatatypes-discover
@@ -1,0 +1,147 @@
+Binding 0:
+{
+    "recommended_name": "test_vectordatatypes_56892992",
+    "resource_config_json": {
+      "schema": "PUBLIC",
+      "table": "test_VectorDatatypes_56892992"
+    },
+    "document_schema_json": {
+      "$defs": {
+        "Test_VectorDatatypes_56892992": {
+          "type": "object",
+          "required": [
+            "ID"
+          ],
+          "$anchor": "Test_VectorDatatypes_56892992",
+          "properties": {
+            "A": {
+              "items": {
+                "type": "number"
+              },
+              "maxItems": 5,
+              "minItems": 5,
+              "type": [
+                "array",
+                "null"
+              ]
+            },
+            "B": {
+              "items": {
+                "type": "integer"
+              },
+              "maxItems": 3,
+              "minItems": 3,
+              "type": [
+                "array",
+                "null"
+              ]
+            },
+            "ID": {
+              "type": "integer"
+            }
+          }
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "_meta": {
+                "properties": {
+                  "op": {
+                    "const": "d"
+                  }
+                }
+              }
+            }
+          },
+          "then": {
+            "reduce": {
+              "delete": true,
+              "strategy": "merge"
+            }
+          },
+          "else": {
+            "reduce": {
+              "strategy": "merge"
+            }
+          },
+          "required": [
+            "_meta"
+          ],
+          "properties": {
+            "_meta": {
+              "type": "object",
+              "required": [
+                "op",
+                "source"
+              ],
+              "properties": {
+                "before": {
+                  "$ref": "#Test_VectorDatatypes_56892992",
+                  "description": "Record state immediately before this change was applied.",
+                  "reduce": {
+                    "strategy": "firstWriteWins"
+                  }
+                },
+                "op": {
+                  "enum": [
+                    "c",
+                    "d",
+                    "u"
+                  ],
+                  "description": "Change operation type: 'c' Create/Insert, 'u' Update, 'd' Delete."
+                },
+                "source": {
+                  "$id": "https://github.com/estuary/connectors/source-snowflake/snowflake-source-metadata",
+                  "properties": {
+                    "ts_ms": {
+                      "type": "integer",
+                      "description": "Unix timestamp (in millis) at which this event was recorded by the database."
+                    },
+                    "schema": {
+                      "type": "string",
+                      "description": "Database schema (namespace) of the event."
+                    },
+                    "snapshot": {
+                      "type": "boolean",
+                      "description": "Snapshot is true if the record was produced from an initial table backfill and unset if produced from the replication log."
+                    },
+                    "table": {
+                      "type": "string",
+                      "description": "Database table of the event."
+                    },
+                    "seq": {
+                      "type": "integer",
+                      "description": "The sequence number of the staging table from which this document was read"
+                    },
+                    "off": {
+                      "type": "integer",
+                      "description": "The offset within that staging table at which this document occurred"
+                    }
+                  },
+                  "type": "object",
+                  "required": [
+                    "schema",
+                    "table",
+                    "seq",
+                    "off"
+                  ]
+                }
+              },
+              "reduce": {
+                "strategy": "merge"
+              }
+            }
+          }
+        },
+        {
+          "$ref": "#Test_VectorDatatypes_56892992"
+        }
+      ]
+    },
+    "key": [
+      "/ID"
+    ]
+  }
+

--- a/source-snowflake/.snapshots/TestVectorDatatypes-init
+++ b/source-snowflake/.snapshots/TestVectorDatatypes-init
@@ -1,0 +1,10 @@
+# ================================
+# Collection "acmeCo/test/test_vectordatatypes_56892992": 2 Documents
+# ================================
+{"A":"[1.100000,2.200000,3.000000,4.400000,5.500000]","B":null,"ID":1,"_meta":{"op":"c","source":{"schema":"PUBLIC","snapshot":true,"table":"test_VectorDatatypes_56892992","seq":0,"off":0}}}
+{"A":null,"B":"[1,2,3]","ID":2,"_meta":{"op":"c","source":{"schema":"PUBLIC","snapshot":true,"table":"test_VectorDatatypes_56892992","seq":0,"off":1}}}
+# ================================
+# Final State Checkpoint
+# ================================
+{"streams":{"PUBLIC%2Ftest_VectorDatatypes_56892992":{"off":0,"seq":2,"uid":"FFFFFFFFFFFFFFFF_PUBLIC_TEST_VECTORDATATYPES_56892992"}}}
+

--- a/source-snowflake/.snapshots/TestVectorDatatypes-main
+++ b/source-snowflake/.snapshots/TestVectorDatatypes-main
@@ -1,0 +1,10 @@
+# ================================
+# Collection "acmeCo/test/test_vectordatatypes_56892992": 2 Documents
+# ================================
+{"A":"[1.100000,2.200000,3.000000,4.400000,5.500000]","B":null,"ID":3,"_meta":{"op":"c","source":{"schema":"PUBLIC","table":"test_VectorDatatypes_56892992","seq":2,"off":0}}}
+{"A":null,"B":"[1,2,3]","ID":4,"_meta":{"op":"c","source":{"schema":"PUBLIC","table":"test_VectorDatatypes_56892992","seq":2,"off":1}}}
+# ================================
+# Final State Checkpoint
+# ================================
+{"streams":{"PUBLIC%2Ftest_VectorDatatypes_56892992":{"off":0,"seq":3,"uid":"FFFFFFFFFFFFFFFF_PUBLIC_TEST_VECTORDATATYPES_56892992"}}}
+


### PR DESCRIPTION
**Description:**

Snowflake has a special type of column for storing vector embeddings. These columns contain either integer or float values in a fixed-length array.

We can discover schemas for these fields accordingly, giving their discovered arrays annotations for the type of items and min/max length of the array, which will always be the size of the vector.

These types of schematized fields may eventually be used by materializations for materializing into corresponding vector columns or indexes.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2157)
<!-- Reviewable:end -->
