### PR TITLE
source-mysql: Two bits of production wrangling

### DIFF
--- a/sqlcapture/main.go
+++ b/sqlcapture/main.go
@@ -309,6 +309,9 @@ func (d *Driver) Pull(open *pc.Request_Open, stream *boilerplate.PullOutput) err
 	// scoped.
 	var hackyCursorReplacements = map[string]map[string]string{
 		"TASKHASH415b69936fe1324600d67943e50235fc57fb7e0196b8f5f0TASKHASH": {"binlog.000123:456789": "binlog.000123:456789"}, // Example
+
+		// Added 2024-11-20
+		"f976b2fd842a663be34d55f54bf0cabd9d85c4abf62d37345dc082b37ddd1d78": {"bin.064637:9322989": "bin.064610:4"},
 	}
 	var hasher = sha256.New()
 	hasher.Write([]byte(open.Capture.Name))


### PR DESCRIPTION
**Description:**

This PR does two things, which I've combined into one PR because they're both tiny and this was more convenient:

1. Adds another temporary cursor replacement rule to get a production task rewound to an earlier portion of the binlog.
2. Adds a special-case to the "Skip Backfills" advanced config option so that the value `*.*` means "all tables". This doesn't generalize to like `schema.*` or anything right now, it's literally just matching that one string, but we needed a way to stop all tables in a capture from backfilling simultaneously with the cursor reset, and this seemed like the least bad option that could be done quickly.

**Workflow steps:**

The one capture that this is all targeted at is currently disabled. After these changes are live in production, that capture should be modified to have `*.*` in the advanced "Skip Backfills" option and then re-enabled.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2158)
<!-- Reviewable:end -->
