### PR TITLE
materialize-mongodb: don't send a batch if there were 0 documents

### DIFF
--- a/materialize-mongodb/transactor.go
+++ b/materialize-mongodb/transactor.go
@@ -180,8 +180,10 @@ func (t *transactor) Store(it *m.StoreIterator) (m.StartCommitFunc, error) {
 	}
 
 	// Drain the last batch.
-	if err := sendBatch(); err != nil {
-		return nil, err
+	if len(batch) > 0 {
+		if err := sendBatch(); err != nil {
+			return nil, err
+		}
 	}
 
 	close(sendBatches)


### PR DESCRIPTION
**Description:**

When setting a `notBefore` configuration there will be transactions with 0 stored documents. This adds a condition to prevent a panic trying to send a batch in Store when there aren't any documents to store.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2160)
<!-- Reviewable:end -->
