### PR TITLE
sqlcapture: Cursor replacement for production task

### DIFF
--- a/sqlcapture/main.go
+++ b/sqlcapture/main.go
@@ -310,8 +310,8 @@ func (d *Driver) Pull(open *pc.Request_Open, stream *boilerplate.PullOutput) err
 	var hackyCursorReplacements = map[string]map[string]string{
 		"TASKHASH415b69936fe1324600d67943e50235fc57fb7e0196b8f5f0TASKHASH": {"binlog.000123:456789": "binlog.000123:456789"}, // Example
 
-		// Added 2024-11-20
-		"f976b2fd842a663be34d55f54bf0cabd9d85c4abf62d37345dc082b37ddd1d78": {"bin.064637:9322989": "bin.064610:4"},
+		// Added 2024-11-21
+		"f976b2fd842a663be34d55f54bf0cabd9d85c4abf62d37345dc082b37ddd1d78": {"bin.064767:104548992": "bin.064563:4"},
 	}
 	var hasher = sha256.New()
 	hasher.Write([]byte(open.Capture.Name))


### PR DESCRIPTION
**Description:**

A production task ran into trouble and needs its binlog cursor manually adjusted. Ask Will or Dave for further context.

This is the same task we had to poke yesterday and I hadn't gotten around to deleting the previous replacement, so just the specific cursor values need to change this time.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2161)
<!-- Reviewable:end -->
