### PR TITLE
source-facebook-marketing: validate account ids

### DIFF
--- a/source-facebook-marketing/source_facebook_marketing/source.py
+++ b/source-facebook-marketing/source_facebook_marketing/source.py
@@ -34,7 +34,7 @@ from source_facebook_marketing.streams import (
     Videos,
 )
 
-from .utils import validate_end_date, validate_start_date
+from .utils import validate_end_date, validate_start_date, validate_account_ids
 
 logger = logging.getLogger("airbyte")
 UNSUPPORTED_FIELDS = {"unique_conversions", "unique_ctr", "unique_clicks",
@@ -95,6 +95,8 @@ class SourceFacebookMarketing(AbstractSource):
         config.end_date = validate_end_date(config.start_date, config.end_date)
 
         api = API(access_token=config.credentials.access_token)
+
+        validate_account_ids(api, config.account_ids)
 
         insights_args = dict(
             api=api, start_date=config.start_date, end_date=config.end_date, insights_lookback_window=config.insights_lookback_window, account_ids=config.account_ids,

--- a/source-facebook-marketing/source_facebook_marketing/utils.py
+++ b/source-facebook-marketing/source_facebook_marketing/utils.py
@@ -3,9 +3,13 @@
 #
 
 import logging
+from typing import List
 
 import pendulum
 from pendulum import DateTime
+from estuary_cdk.flow import ValidationError
+
+from source_facebook_marketing.api import API, FacebookAPIException
 
 logger = logging.getLogger("airbyte")
 
@@ -45,3 +49,15 @@ def validate_end_date(start_date: DateTime, end_date: DateTime) -> DateTime:
         logger.warning(message)
         return start_date
     return end_date
+
+def validate_account_ids(api: API, account_ids: List[str]):
+    errs = []
+    for account_id in account_ids:
+        try:
+            api._find_account(account_id)
+        except FacebookAPIException as err:
+            msg = f"Error when validating account ID {account_id}: {err}"
+            errs.append(msg)
+
+    if len(errs) > 0:
+        raise ValidationError(errs)


### PR DESCRIPTION
**Description:**

Currently, the connector does not validate user provided account IDs can be successfully used to hit the Facebook Marketing API. This PR adds a check for this before task creation.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

Tested on a local stack. Confirmed invalid account IDs are detected before task creation, and an error message is displayed indicating which account IDs are invalid.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2163)
<!-- Reviewable:end -->
