### PR TITLE
source-postgres: Support `_citext` columns

### DIFF
--- a/source-postgres/.snapshots/TestCIText-Capture
+++ b/source-postgres/.snapshots/TestCIText-Capture
@@ -1,0 +1,14 @@
+# ================================
+# Collection "acmeCo/test/test_citext_58810479": 6 Documents
+# ================================
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"citext_58810479","loc":[11111111,11111111,11111111]}},"arr":{"dimensions":[2],"elements":["a","b"]},"data":"zero","id":0}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"citext_58810479","loc":[11111111,11111111,11111111]}},"arr":{"dimensions":[2],"elements":["c","d"]},"data":"one","id":1}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"citext_58810479","loc":[11111111,11111111,11111111]}},"arr":{"dimensions":[2],"elements":["e","f"]},"data":"two","id":2}
+{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"citext_58810479","loc":[11111111,11111111,11111111],"txid":111111}},"arr":{"dimensions":[2],"elements":["g","h"]},"data":"three","id":3}
+{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"citext_58810479","loc":[11111111,11111111,11111111],"txid":111111}},"arr":{"dimensions":[2],"elements":["i","j"]},"data":"four","id":4}
+{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"citext_58810479","loc":[11111111,11111111,11111111],"txid":111111}},"arr":{"dimensions":[2],"elements":["k","l"]},"data":"five","id":5}
+# ================================
+# Final State Checkpoint
+# ================================
+{"bindingStateV1":{"test%2Fcitext_58810479":{"backfilled":3,"key_columns":["id"],"mode":"Active"}},"cursor":"0/1111111"}
+

--- a/source-postgres/.snapshots/TestCIText-Discovery
+++ b/source-postgres/.snapshots/TestCIText-Discovery
@@ -1,0 +1,166 @@
+Binding 0:
+{
+    "recommended_name": "test_citext_58810479",
+    "resource_config_json": {
+      "namespace": "test",
+      "stream": "citext_58810479"
+    },
+    "document_schema_json": {
+      "$defs": {
+        "TestCitext_58810479": {
+          "type": "object",
+          "required": [
+            "id"
+          ],
+          "$anchor": "TestCitext_58810479",
+          "properties": {
+            "arr": {
+              "type": "object",
+              "required": [
+                "dimensions",
+                "elements"
+              ],
+              "description": "(source type: _citext)",
+              "properties": {
+                "dimensions": {
+                  "items": {
+                    "type": "integer"
+                  },
+                  "type": "array"
+                },
+                "elements": {
+                  "items": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "type": "array"
+                }
+              },
+              "type": [
+                "object",
+                "null"
+              ]
+            },
+            "data": {
+              "description": "(source type: citext)",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "id": {
+              "type": "integer",
+              "description": "(source type: non-nullable int4)"
+            }
+          }
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "_meta": {
+                "properties": {
+                  "op": {
+                    "const": "d"
+                  }
+                }
+              }
+            }
+          },
+          "then": {
+            "reduce": {
+              "delete": true,
+              "strategy": "merge"
+            }
+          },
+          "else": {
+            "reduce": {
+              "strategy": "merge"
+            }
+          },
+          "required": [
+            "_meta"
+          ],
+          "properties": {
+            "_meta": {
+              "type": "object",
+              "required": [
+                "op",
+                "source"
+              ],
+              "properties": {
+                "before": {
+                  "$ref": "#TestCitext_58810479",
+                  "description": "Record state immediately before this change was applied.",
+                  "reduce": {
+                    "strategy": "firstWriteWins"
+                  }
+                },
+                "op": {
+                  "enum": [
+                    "c",
+                    "d",
+                    "u"
+                  ],
+                  "description": "Change operation type: 'c' Create/Insert, 'u' Update, 'd' Delete."
+                },
+                "source": {
+                  "$id": "https://github.com/estuary/connectors/source-postgres/postgres-source",
+                  "properties": {
+                    "ts_ms": {
+                      "type": "integer",
+                      "description": "Unix timestamp (in millis) at which this event was recorded by the database."
+                    },
+                    "schema": {
+                      "type": "string",
+                      "description": "Database schema (namespace) of the event."
+                    },
+                    "snapshot": {
+                      "type": "boolean",
+                      "description": "Snapshot is true if the record was produced from an initial table backfill and unset if produced from the replication log."
+                    },
+                    "table": {
+                      "type": "string",
+                      "description": "Database table of the event."
+                    },
+                    "loc": {
+                      "items": {
+                        "type": "integer"
+                      },
+                      "type": "array",
+                      "maxItems": 3,
+                      "minItems": 3,
+                      "description": "Location of this WAL event as [last Commit.EndLSN; event LSN; current Begin.FinalLSN]. See https://www.postgresql.org/docs/current/protocol-logicalrep-message-formats.html"
+                    },
+                    "txid": {
+                      "type": "integer",
+                      "description": "The 32-bit transaction ID assigned by Postgres to the commit which produced this change."
+                    }
+                  },
+                  "type": "object",
+                  "required": [
+                    "schema",
+                    "table",
+                    "loc"
+                  ]
+                }
+              },
+              "reduce": {
+                "strategy": "merge"
+              }
+            }
+          }
+        },
+        {
+          "$ref": "#TestCitext_58810479"
+        }
+      ]
+    },
+    "key": [
+      "/id"
+    ]
+  }
+

--- a/source-postgres/datatype_test.go
+++ b/source-postgres/datatype_test.go
@@ -142,6 +142,10 @@ func TestDatatypes(t *testing.T) {
 		{ColumnType: `tsrange`, ExpectType: `{"type":["string","null"]}`, InputValue: `[2010-01-01 11:30 UTC,2010-01-01 15:00 UTC)`, ExpectValue: `"[2010-01-01T11:30:00Z,2010-01-01T15:00:00Z)"`},
 		{ColumnType: `tstzrange`, ExpectType: `{"type":["string","null"]}`, InputValue: `[2010-01-01 11:30 UTC,2010-01-01 15:00 UTC)`, ExpectValue: `"[2010-01-01T03:30:00-08:00,2010-01-01T07:00:00-08:00)"`},
 		{ColumnType: `daterange`, ExpectType: `{"type":["string","null"]}`, InputValue: `(2010-01-01,2010-01-02]`, ExpectValue: `"[2010-01-02T00:00:00Z,2010-01-03T00:00:00Z)"`},
+
+		// Extension types
+		{ColumnType: `citext`, ExpectType: `{"type":["string","null"]}`, InputValue: `Hello, world!`, ExpectValue: `"Hello, world!"`},
+		{ColumnType: `citext[]`, ExpectType: fmt.Sprintf(arraySchemaPattern, `{"type":["string","null"]}`), InputValue: `{"Hello, world!",asdf}`, ExpectValue: `{"dimensions":[2],"elements":["Hello, world!","asdf"]}`},
 	})
 }
 

--- a/source-postgres/discovery.go
+++ b/source-postgres/discovery.go
@@ -315,7 +315,7 @@ var postgresTypeToJSON = map[string]columnSchema{
 	"varchar": {jsonTypes: []string{"string"}},
 	"bpchar":  {jsonTypes: []string{"string"}},
 	"text":    {jsonTypes: []string{"string"}},
-	"citext":  {jsonTypes: []string{"string"}}, // From the 'citext' extension so we don't test it by default, but it hurts nothing to support it here
+	"citext":  {jsonTypes: []string{"string"}}, // From the 'citext' extension, but common enough we ought to support it properly
 	"bytea":   {jsonTypes: []string{"string"}, contentEncoding: "base64"},
 	"xml":     {jsonTypes: []string{"string"}},
 	"bit":     {jsonTypes: []string{"string"}},

--- a/source-postgres/docker-entrypoint-initdb.d/init-user-db.sh
+++ b/source-postgres/docker-entrypoint-initdb.d/init-user-db.sh
@@ -13,4 +13,6 @@ psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" <<-E
 
     CREATE PUBLICATION flow_publication FOR ALL TABLES;
     ALTER PUBLICATION flow_publication SET (publish_via_partition_root = true);
+
+    CREATE EXTENSION IF NOT EXISTS citext;
 EOSQL

--- a/source-postgres/main.go
+++ b/source-postgres/main.go
@@ -263,7 +263,7 @@ func (db *postgresDatabase) connect(ctx context.Context) error {
 
 		return fmt.Errorf("unable to connect to database: %w", err)
 	}
-	if err := registerDatatypeTweaks(conn.TypeMap()); err != nil {
+	if err := registerDatatypeTweaks(ctx, conn, conn.TypeMap()); err != nil {
 		return err
 	}
 	db.conn = conn

--- a/source-postgres/replication.go
+++ b/source-postgres/replication.go
@@ -107,7 +107,7 @@ func (db *postgresDatabase) ReplicationStream(ctx context.Context, startCursor s
 	}
 
 	var typeMap = pgtype.NewMap()
-	if err := registerDatatypeTweaks(typeMap); err != nil {
+	if err := registerDatatypeTweaks(ctx, db.conn, typeMap); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
**Description:**

Arrays of `citext` are tricky because `citext` is an extension type which means that it has no stable OID, and as a result the PGX client library doesn't have any default type mappings for it. In the absence of any registered codec, values are always captured in their stringified text-protocol format.

However our discovery logic still notices that it's an array and emits the appropriate schema for an array of text values, which means there's a mismatch and we're not satisfying our own schema. Which is bad. While `citext` is an extension type, it's a common one and the citext extension ships as part of the Postgres release, so I believe we should still support it as best we can.

This commit fixes that by extending the "datatype tweaks" logic with a query against `pg_catalog.pg_type` looking for specific extension types we support (which currently is just `citext`) and for each result row we register custom handlers for the base type and arrays of that type.

Since this is all getting fairly complex, I've also gone ahead and added test cases for `citext` and `_citext` datatype support. But of course those don't work against a database without that extension installed, so the CI database setup script has been modified to install it. (The `citext` extension is shipped as part of Postgres itself, it just isn't enabled by default, so we just have to run `CREATE EXTENSION citext`).

**Workflow steps:**

Columns of type `citext[]` should just work going forward.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2166)
<!-- Reviewable:end -->
