### PR TITLE
source-postgres: increase connect timeout to 20s

### DIFF
--- a/source-postgres/main.go
+++ b/source-postgres/main.go
@@ -244,7 +244,7 @@ func (db *postgresDatabase) connect(ctx context.Context) error {
 		return fmt.Errorf("error parsing database uri: %w", err)
 	}
 	if config.ConnectTimeout == 0 {
-		config.ConnectTimeout = 10 * time.Second
+		config.ConnectTimeout = 20 * time.Second
 	}
 	conn, err := pgx.ConnectConfig(ctx, config)
 	if err != nil {


### PR DESCRIPTION
We're seeing frequent connection failures for some captures, so kinda just hoping that this might help with those.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2171)
<!-- Reviewable:end -->
