### PR TITLE
source-http-ingest: add CORS support

### DIFF
--- a/source-http-ingest/Cargo.toml
+++ b/source-http-ingest/Cargo.toml
@@ -34,7 +34,11 @@ utoipa-swagger-ui = { version = "7.1", features = ["axum"] }
 time = { version = "0.3", features = ["formatting"] }
 uuid = { version = "1.7", features = ["v4"] }
 lazy_static = "1.4"
-tower-http = { version = "0.5", features = ["decompression-full", "trace"] }
+tower-http = { version = "0.5", features = [
+    "decompression-full",
+    "trace",
+    "cors",
+] }
 tower = "0.4"
 
 [dev-dependencies]

--- a/source-http-ingest/src/snapshots/source_http_ingest__test__endpoint_config_schema.snap
+++ b/source-http-ingest/src/snapshots/source_http_ingest__test__endpoint_config_schema.snap
@@ -7,6 +7,16 @@ expression: schema
   "title": "EndpointConfig",
   "type": "object",
   "properties": {
+    "allowedCorsOrigins": {
+      "title": "CORS Allowed Origins",
+      "description": "List of allowed CORS origins. If empty, then CORS will be disabled. Otherwise, each item in the list will be interpreted as a specific request origin that will be permitted by the `Access-Control-Allow-Origin` header for preflight requests coming from that origin. As a special case, the value `*` is permitted in order to allow all origins. The `*` should be used with extreme caution, however. See: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Origin",
+      "default": [],
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "order": 3
+    },
     "paths": {
       "title": "URL paths",
       "description": "List of URL paths to accept requests at.\n\nDiscovery will return a separate collection for each given path. Paths must be provided without any percent encoding, and should not include any query parameters or fragment.",
@@ -17,7 +27,8 @@ expression: schema
       "items": {
         "type": "string",
         "pattern": "/.+"
-      }
+      },
+      "order": 1
     },
     "requireAuthToken": {
       "title": "Authentication token",
@@ -27,6 +38,7 @@ expression: schema
         "string",
         "null"
       ],
+      "order": 2,
       "secret": true
     }
   }


### PR DESCRIPTION
Supports CORS preflight requests on an opt-in basis. The goal is to allow the users to capture data directly from browsers. A list of allowed origins was added to the endpoint config. If left empty (the default), then cors will be disabled entirely. A non-empty list will enable cors for the specific origins listed. As a special case, `*` may be used to permit any origin.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2173)
<!-- Reviewable:end -->
