### PR TITLE
network-tunnel: Don't fail on Stop() of nil tunnel

### DIFF
--- a/go/network-tunnel/network_tunnel.go
+++ b/go/network-tunnel/network_tunnel.go
@@ -126,6 +126,9 @@ func (t *SshTunnel) Start() error {
 }
 
 func (t *SshTunnel) Stop() {
+	if t == nil {
+		return
+	}
 	if t.Cmd != nil {
 		// Using the negative pid signals kill to a process group.
 		// This ensures the children of the process are also killed


### PR DESCRIPTION
**Description:**

Currently `source-oracle` does an unconditional `db.tunnel.Stop()` during shutdown regardless of whether a network tunnel exists, but the implementation of `Stop()` assumes that the tunnel must not be nil. This disagreement could be resolved in either direction, but it seemed cleaner to just make `Stop()` a no-op for nil receivers.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2175)
<!-- Reviewable:end -->
