### PR TITLE
source-redshift-batch: Enable schema inference (while still doing full discovery)

### DIFF
--- a/source-redshift-batch/.snapshots/TestBasicCapture-Discovery
+++ b/source-redshift-batch/.snapshots/TestBasicCapture-Discovery
@@ -47,7 +47,8 @@ Binding 0:
           "id": {
             "type": "integer"
           }
-        }
+        },
+        "x-infer-schema": true
       },
       "key": [
         "/id"

--- a/source-redshift-batch/.snapshots/TestBasicDatatypes-Capture
+++ b/source-redshift-batch/.snapshots/TestBasicDatatypes-Capture
@@ -5,5 +5,5 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"test_basic_datatypes_13111208":{"LastPolled":"<TIMESTAMP>"}}}
+{"bindingStateV1":{"test_basic_datatypes_13111208":{"CursorNames":null,"CursorValues":null,"LastPolled":"<TIMESTAMP>"}}}
 

--- a/source-redshift-batch/.snapshots/TestBasicDatatypes-Discovery
+++ b/source-redshift-batch/.snapshots/TestBasicDatatypes-Discovery
@@ -76,7 +76,8 @@ Binding 0:
           "id": {
             "type": "integer"
           }
-        }
+        },
+        "x-infer-schema": true
       },
       "key": [
         "/id"

--- a/source-redshift-batch/.snapshots/TestFloatNaNs-Capture
+++ b/source-redshift-batch/.snapshots/TestFloatNaNs-Capture
@@ -1,11 +1,11 @@
 # ================================
 # Collection "acmeCo/test/test_float_nans_10511": 3 Documents
 # ================================
-{"_meta":{"polled":"<TIMESTAMP>","index":999},"a_double":"NaN","a_real":2,"id":0,"txid":999999}
-{"_meta":{"polled":"<TIMESTAMP>","index":999},"a_double":3,"a_real":"NaN","id":1,"txid":999999}
-{"_meta":{"polled":"<TIMESTAMP>","index":999},"a_double":"-Infinity","a_real":"Infinity","id":2,"txid":999999}
+{"_meta":{"polled":"<TIMESTAMP>","index":999},"a_double":"NaN","a_real":2,"id":0}
+{"_meta":{"polled":"<TIMESTAMP>","index":999},"a_double":3,"a_real":"NaN","id":1}
+{"_meta":{"polled":"<TIMESTAMP>","index":999},"a_double":"-Infinity","a_real":"Infinity","id":2}
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"test_float_nans_10511":{"CursorNames":["txid"],"CursorValues":[999999],"LastPolled":"<TIMESTAMP>"}}}
+{"bindingStateV1":{"test_float_nans_10511":{"CursorNames":null,"CursorValues":null,"LastPolled":"<TIMESTAMP>"}}}
 

--- a/source-redshift-batch/.snapshots/TestFloatNaNs-Discovery
+++ b/source-redshift-batch/.snapshots/TestFloatNaNs-Discovery
@@ -57,7 +57,8 @@ Binding 0:
           "id": {
             "type": "integer"
           }
-        }
+        },
+        "x-infer-schema": true
       },
       "key": [
         "/id"

--- a/source-redshift-batch/.snapshots/TestFloatNaNs-Discovery
+++ b/source-redshift-batch/.snapshots/TestFloatNaNs-Discovery
@@ -1,14 +1,14 @@
 Binding 0:
 {
     "resource_config_json": {
-      "name": "test_basic_datatypes_13111208",
-      "template": "{{if .CursorFields -}}\n  {{- if .IsFirstQuery -}}\n    SELECT * FROM \"test\".\"basic_datatypes_13111208\"\n  {{- else -}}\n    SELECT * FROM \"test\".\"basic_datatypes_13111208\"\n\t{{- range $i, $k := $.CursorFields -}}\n\t  {{- if eq $i 0}} WHERE ({{else}}) OR ({{end -}}\n      {{- range $j, $n := $.CursorFields -}}\n\t\t{{- if lt $j $i -}}\n\t\t  {{$n}} = ${{add $j 1}} AND {{end -}}\n\t  {{- end -}}\n\t  {{$k}} \u003e ${{add $i 1}}\n\t{{- end -}}\n\t) \n  {{- end}} ORDER BY {{range $i, $k := $.CursorFields}}{{if gt $i 0}}, {{end}}{{$k}}{{end -}};\n{{- else -}}\n  SELECT * FROM \"test\".\"basic_datatypes_13111208\";\n{{- end}}\n"
+      "name": "test_float_nans_10511",
+      "template": "{{if .CursorFields -}}\n  {{- if .IsFirstQuery -}}\n    SELECT * FROM \"test\".\"float_nans_10511\"\n  {{- else -}}\n    SELECT * FROM \"test\".\"float_nans_10511\"\n\t{{- range $i, $k := $.CursorFields -}}\n\t  {{- if eq $i 0}} WHERE ({{else}}) OR ({{end -}}\n      {{- range $j, $n := $.CursorFields -}}\n\t\t{{- if lt $j $i -}}\n\t\t  {{$n}} = ${{add $j 1}} AND {{end -}}\n\t  {{- end -}}\n\t  {{$k}} \u003e ${{add $i 1}}\n\t{{- end -}}\n\t) \n  {{- end}} ORDER BY {{range $i, $k := $.CursorFields}}{{if gt $i 0}}, {{end}}{{$k}}{{end -}};\n{{- else -}}\n  SELECT * FROM \"test\".\"float_nans_10511\";\n{{- end}}\n"
     },
     "resource_path": [
-      "test_basic_datatypes_13111208"
+      "test_float_nans_10511"
     ],
     "collection": {
-      "name": "acmeCo/test/test_basic_datatypes_13111208",
+      "name": "acmeCo/test/test_float_nans_10511",
       "read_schema_json": {
         "type": "object",
         "required": [
@@ -38,15 +38,10 @@ Binding 0:
               "index"
             ]
           },
-          "a_bool": {
+          "a_double": {
+            "format": "number",
             "type": [
-              "boolean",
-              "null"
-            ]
-          },
-          "a_date": {
-            "format": "date-time",
-            "type": [
+              "number",
               "string",
               "null"
             ]
@@ -55,20 +50,6 @@ Binding 0:
             "format": "number",
             "type": [
               "number",
-              "string",
-              "null"
-            ]
-          },
-          "a_ts": {
-            "format": "date-time",
-            "type": [
-              "string",
-              "null"
-            ]
-          },
-          "a_tstz": {
-            "format": "date-time",
-            "type": [
               "string",
               "null"
             ]
@@ -83,6 +64,6 @@ Binding 0:
       ],
       "projections": null
     },
-    "state_key": "test_basic_datatypes_13111208"
+    "state_key": "test_float_nans_10511"
   }
 

--- a/source-redshift-batch/.snapshots/TestKeyDiscovery
+++ b/source-redshift-batch/.snapshots/TestKeyDiscovery
@@ -63,7 +63,8 @@ Binding 0:
           "k_str": {
             "type": "string"
           }
-        }
+        },
+        "x-infer-schema": true
       },
       "key": [
         "/k_smallint",

--- a/source-redshift-batch/.snapshots/TestKeylessDiscovery
+++ b/source-redshift-batch/.snapshots/TestKeylessDiscovery
@@ -93,7 +93,8 @@ Binding 0:
               "null"
             ]
           }
-        }
+        },
+        "x-infer-schema": true
       },
       "projections": null
     },

--- a/source-redshift-batch/.snapshots/TestSchemaFilter-FilteredIn
+++ b/source-redshift-batch/.snapshots/TestSchemaFilter-FilteredIn
@@ -47,7 +47,8 @@ Binding 0:
           "id": {
             "type": "integer"
           }
-        }
+        },
+        "x-infer-schema": true
       },
       "key": [
         "/id"

--- a/source-redshift-batch/.snapshots/TestSchemaFilter-Unfiltered
+++ b/source-redshift-batch/.snapshots/TestSchemaFilter-Unfiltered
@@ -47,7 +47,8 @@ Binding 0:
           "id": {
             "type": "integer"
           }
-        }
+        },
+        "x-infer-schema": true
       },
       "key": [
         "/id"

--- a/source-redshift-batch/driver.go
+++ b/source-redshift-batch/driver.go
@@ -109,7 +109,8 @@ func generateCollectionSchema(keyColumns []string, columnTypes map[string]column
 		Required:             required,
 		AdditionalProperties: nil,
 		Extras: map[string]interface{}{
-			"properties": properties,
+			"properties":     properties,
+			"x-infer-schema": true,
 		},
 	}
 


### PR DESCRIPTION
**Description:**

In some sense this is a fairly large change, because it's pulling in all of the schema inference machinery. But in another sense it isn't that big a deal because we're still discovering a full schema for ourselves which documents must satisfy, so all schema inference can do is narrow down the _read-time_ types further.

Which is exactly what we need to solve the problem of collection keys coming from nullable source columns and being materialized as the actual destination primary key. Currently we discover all columns with their actual source-DB nullability, which is fine.

But a lot of Redshift users don't have declared primary keys on their table and instead have to explicitly specify which properties should be the collection key. Which is fine.

Except that a lot of the time, those columns in the Redshift source are technically nullable, simply because the user never bothered to put a `NOT NULL` constraint on them. This is _also_ fine, Flow can handle it.

Except, SQL materializations often can't. They need the collection key to be non-nullable so that it can be the primary key of the materialized tables.

In the past, this has been worked around by specifying a default value annotation in the collection schema. Which _should_ not do anything at all, but the materialization incorrectly assumes that if a default value annotation is present then the property can't ever be null. This is not actually true, as the default value only applies to _omitted_ values and not explicitly-null values.

We should fix that, but until this PR goes live setting a default value is the only knob we have available to tell a materialization "it's okay, just assume it won't actually be null".

After this PR is merged, the inferred schema will be used again and (in cases where these collection-key properties aren't ever actually null) will provide a tighter schema describing the actual data observed in the collection, which means it won't include null, which means the materialization won't get upset that the collection key is potentially nullable.

If a null value were to be inserted into the source table, we would capture it into the collection, the materialization would read it and fail with a schema violation error, and at some point schema inference would note that now null is a possible value, but be unable to publish that a schema update because it would fail validation.

That isn't ideal, but in general null values don't suddenly appear in this context and there are two solutions:
 1. Just alter the source DB column to be non-nullable.
 2. Disable schema inference and manually tell us what schema the user wants us to use.

The combination of these two escape hatches seems like plenty to me.

Phew. That was a lot of description for a one-line PR.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

This PR hasn't been tested against an actual Redshift instance because the one in our 1Password appears to either no longer exist or have had its password changed, and I don't think I have a working AWS account with which to fix that at the moment. However I ran the test suite against Postgres locally just to make sure I got all the snapshot updates from this change (plus some other updates from other changes which are months-old), and this doesn't change anything about how the connector interacts with the server, so it should be fine.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2178)
<!-- Reviewable:end -->
