### PR TITLE
source-oracle: Normalize watermarks table names

### DIFF
--- a/source-oracle/replication.go
+++ b/source-oracle/replication.go
@@ -347,7 +347,7 @@ var replicationBufferSize = 16
 
 func (s *replicationStream) StartReplication(ctx context.Context, discovery map[sqlcapture.StreamID]*sqlcapture.DiscoveryInfo) error {
 	// Activate replication for the watermarks table.
-	var watermarks = s.db.config.Advanced.WatermarksTable
+	var watermarks = s.db.WatermarksTable()
 	var watermarksInfo = discovery[watermarks]
 	if watermarksInfo == nil {
 		return fmt.Errorf("error activating replication for watermarks table %q: table missing from latest autodiscovery", watermarks)


### PR DESCRIPTION
**Description:**

Our internal representation of stream IDs is normalized to lower- case but Oracle makes this tricky, so we need to use the actual `db.WatermarksTable()` method which also normalizes the name when trying to look up the discovered metadata for the table.

