### PR TITLE
source-mysql: Treat CDC updates which change the primary key as implicit deletions

### DIFF
--- a/source-mysql/.snapshots/TestPrimaryKeyUpdate
+++ b/source-mysql/.snapshots/TestPrimaryKeyUpdate
@@ -1,0 +1,16 @@
+# ================================
+# Collection "acmeCo/test/test_primarykeyupdate_63510878": 8 Documents
+# ================================
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"PrimaryKeyUpdate_63510878","cursor":"backfill:0"}},"data":"zero","id":0}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"PrimaryKeyUpdate_63510878","cursor":"backfill:1"}},"data":"one","id":1}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"PrimaryKeyUpdate_63510878","cursor":"backfill:2"}},"data":"two","id":2}
+{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"PrimaryKeyUpdate_63510878","cursor":"binlog.000123:56789:123","txid":"11111111-1111-1111-1111-111111111111:111"}},"data":"three","id":3}
+{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"PrimaryKeyUpdate_63510878","cursor":"binlog.000123:56789:123","txid":"11111111-1111-1111-1111-111111111111:111"}},"data":"four","id":4}
+{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"PrimaryKeyUpdate_63510878","cursor":"binlog.000123:56789:123","txid":"11111111-1111-1111-1111-111111111111:111"}},"data":"five","id":5}
+{"_meta":{"op":"u","source":{"ts_ms":1111111111111,"schema":"test","table":"PrimaryKeyUpdate_63510878","cursor":"binlog.000123:56789:123","txid":"11111111-1111-1111-1111-111111111111:111"},"before":{"data":"one","id":1}},"data":"one","id":6}
+{"_meta":{"op":"u","source":{"ts_ms":1111111111111,"schema":"test","table":"PrimaryKeyUpdate_63510878","cursor":"binlog.000123:56789:123","txid":"11111111-1111-1111-1111-111111111111:111"},"before":{"data":"four","id":4}},"data":"four","id":7}
+# ================================
+# Final State Checkpoint
+# ================================
+{"bindingStateV1":{"test%2FPrimaryKeyUpdate_63510878":{"backfilled":3,"key_columns":["id"],"metadata":{"charset":"utf8mb4","schema":{"columns":["id","data"],"types":{"data":{"charset":"utf8mb4","type":"text"},"id":{"type":"int"}}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
+

--- a/source-mysql/.snapshots/TestPrimaryKeyUpdate
+++ b/source-mysql/.snapshots/TestPrimaryKeyUpdate
@@ -1,5 +1,5 @@
 # ================================
-# Collection "acmeCo/test/test_primarykeyupdate_63510878": 8 Documents
+# Collection "acmeCo/test/test_primarykeyupdate_63510878": 10 Documents
 # ================================
 {"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"PrimaryKeyUpdate_63510878","cursor":"backfill:0"}},"data":"zero","id":0}
 {"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"PrimaryKeyUpdate_63510878","cursor":"backfill:1"}},"data":"one","id":1}
@@ -7,8 +7,10 @@
 {"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"PrimaryKeyUpdate_63510878","cursor":"binlog.000123:56789:123","txid":"11111111-1111-1111-1111-111111111111:111"}},"data":"three","id":3}
 {"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"PrimaryKeyUpdate_63510878","cursor":"binlog.000123:56789:123","txid":"11111111-1111-1111-1111-111111111111:111"}},"data":"four","id":4}
 {"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"PrimaryKeyUpdate_63510878","cursor":"binlog.000123:56789:123","txid":"11111111-1111-1111-1111-111111111111:111"}},"data":"five","id":5}
-{"_meta":{"op":"u","source":{"ts_ms":1111111111111,"schema":"test","table":"PrimaryKeyUpdate_63510878","cursor":"binlog.000123:56789:123","txid":"11111111-1111-1111-1111-111111111111:111"},"before":{"data":"one","id":1}},"data":"one","id":6}
-{"_meta":{"op":"u","source":{"ts_ms":1111111111111,"schema":"test","table":"PrimaryKeyUpdate_63510878","cursor":"binlog.000123:56789:123","txid":"11111111-1111-1111-1111-111111111111:111"},"before":{"data":"four","id":4}},"data":"four","id":7}
+{"_meta":{"op":"d","source":{"ts_ms":1111111111111,"schema":"test","table":"PrimaryKeyUpdate_63510878","cursor":"binlog.000123:56789:123","txid":"11111111-1111-1111-1111-111111111111:111"}},"data":"one","id":1}
+{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"PrimaryKeyUpdate_63510878","cursor":"binlog.000123:56789:123","txid":"11111111-1111-1111-1111-111111111111:111"}},"data":"one","id":6}
+{"_meta":{"op":"d","source":{"ts_ms":1111111111111,"schema":"test","table":"PrimaryKeyUpdate_63510878","cursor":"binlog.000123:56789:123","txid":"11111111-1111-1111-1111-111111111111:111"}},"data":"four","id":4}
+{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"PrimaryKeyUpdate_63510878","cursor":"binlog.000123:56789:123","txid":"11111111-1111-1111-1111-111111111111:111"}},"data":"four","id":7}
 # ================================
 # Final State Checkpoint
 # ================================

--- a/source-mysql/capture_test.go
+++ b/source-mysql/capture_test.go
@@ -509,3 +509,30 @@ func TestDroppedAndRecreatedTable(t *testing.T) {
 
 	cupaloy.SnapshotT(t, cs.Summary())
 }
+
+func TestPrimaryKeyUpdate(t *testing.T) {
+	var tb, ctx = mysqlTestBackend(t), context.Background()
+	var uniqueID = "63510878"
+	var tableDef = "(id INTEGER PRIMARY KEY, data TEXT)"
+	var tableName = tb.CreateTable(ctx, t, uniqueID, tableDef)
+
+	var cs = tb.CaptureSpec(ctx, t, regexp.MustCompile(uniqueID))
+	cs.Validator = &st.OrderedCaptureValidator{}
+	sqlcapture.TestShutdownAfterCaughtUp = true
+	t.Cleanup(func() { sqlcapture.TestShutdownAfterCaughtUp = false })
+
+	// Initial backfill
+	tb.Insert(ctx, t, tableName, [][]any{{0, "zero"}, {1, "one"}, {2, "two"}})
+	cs.Capture(ctx, t, nil)
+
+	// Some replication
+	tb.Insert(ctx, t, tableName, [][]any{{3, "three"}, {4, "four"}, {5, "five"}})
+	cs.Capture(ctx, t, nil)
+
+	// Primary key updates
+	tb.Update(ctx, t, tableName, "id", 1, "id", 6)
+	tb.Update(ctx, t, tableName, "id", 4, "id", 7)
+	cs.Capture(ctx, t, nil)
+
+	cupaloy.SnapshotT(t, cs.Summary())
+}

--- a/source-mysql/main_test.go
+++ b/source-mysql/main_test.go
@@ -115,8 +115,8 @@ func (tb *testBackend) lowerTuningParameters(t testing.TB) {
 func (tb *testBackend) CaptureSpec(ctx context.Context, t testing.TB, streamMatchers ...*regexp.Regexp) *st.CaptureSpec {
 	var sanitizers = make(map[string]*regexp.Regexp)
 	sanitizers[`"<TIMESTAMP>"`] = regexp.MustCompile(`"[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(\.[0-9]+)?(Z|-[0-9]+:[0-9]+)"`)
-	sanitizers[`"cursor":"binlog.000123:56789:123"`] = regexp.MustCompile(`"cursor":".+\.[0-9]+:[0-9]+:[0-9]+"`)
-	sanitizers[`"cursor":"binlog.000123:56789"`] = regexp.MustCompile(`"cursor":".+\.[0-9]+:[0-9]+"`)
+	sanitizers[`"cursor":"binlog.000123:56789:123"`] = regexp.MustCompile(`"cursor":"[^"]+\.[0-9]+:[0-9]+:[0-9]+"`)
+	sanitizers[`"cursor":"binlog.000123:56789"`] = regexp.MustCompile(`"cursor":"[^"]+\.[0-9]+:[0-9]+"`)
 	sanitizers[`"ts_ms":1111111111111`] = regexp.MustCompile(`"ts_ms":[0-9]+`)
 	sanitizers[`"txid":"11111111-1111-1111-1111-111111111111:111"`] = regexp.MustCompile(`"txid":"[0-9a-f-]+:[0-9]+"`)
 

--- a/source-postgres/.snapshots/TestPrimaryKeyUpdate
+++ b/source-postgres/.snapshots/TestPrimaryKeyUpdate
@@ -1,0 +1,16 @@
+# ================================
+# Collection "acmeCo/test/test_primarykeyupdate_63510878": 8 Documents
+# ================================
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"primarykeyupdate_63510878","loc":[11111111,11111111,11111111]}},"data":"zero","id":0}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"primarykeyupdate_63510878","loc":[11111111,11111111,11111111]}},"data":"one","id":1}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"primarykeyupdate_63510878","loc":[11111111,11111111,11111111]}},"data":"two","id":2}
+{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"primarykeyupdate_63510878","loc":[11111111,11111111,11111111],"txid":111111}},"data":"three","id":3}
+{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"primarykeyupdate_63510878","loc":[11111111,11111111,11111111],"txid":111111}},"data":"four","id":4}
+{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"primarykeyupdate_63510878","loc":[11111111,11111111,11111111],"txid":111111}},"data":"five","id":5}
+{"_meta":{"op":"u","source":{"ts_ms":1111111111111,"schema":"test","table":"primarykeyupdate_63510878","loc":[11111111,11111111,11111111],"txid":111111},"before":{"id":1}},"data":"one","id":6}
+{"_meta":{"op":"u","source":{"ts_ms":1111111111111,"schema":"test","table":"primarykeyupdate_63510878","loc":[11111111,11111111,11111111],"txid":111111},"before":{"id":4}},"data":"four","id":7}
+# ================================
+# Final State Checkpoint
+# ================================
+{"bindingStateV1":{"test%2Fprimarykeyupdate_63510878":{"backfilled":3,"key_columns":["id"],"mode":"Active"}},"cursor":"0/1111111"}
+

--- a/source-postgres/capture_test.go
+++ b/source-postgres/capture_test.go
@@ -614,3 +614,30 @@ func TestCIText(t *testing.T) {
 		cupaloy.SnapshotT(t, cs.Summary())
 	})
 }
+
+func TestPrimaryKeyUpdate(t *testing.T) {
+	var tb, ctx = postgresTestBackend(t), context.Background()
+	var uniqueID = "63510878"
+	var tableDef = "(id INTEGER PRIMARY KEY, data TEXT)"
+	var tableName = tb.CreateTable(ctx, t, uniqueID, tableDef)
+
+	var cs = tb.CaptureSpec(ctx, t, regexp.MustCompile(uniqueID))
+	cs.Validator = &st.OrderedCaptureValidator{}
+	sqlcapture.TestShutdownAfterCaughtUp = true
+	t.Cleanup(func() { sqlcapture.TestShutdownAfterCaughtUp = false })
+
+	// Initial backfill
+	tb.Insert(ctx, t, tableName, [][]any{{0, "zero"}, {1, "one"}, {2, "two"}})
+	cs.Capture(ctx, t, nil)
+
+	// Some replication
+	tb.Insert(ctx, t, tableName, [][]any{{3, "three"}, {4, "four"}, {5, "five"}})
+	cs.Capture(ctx, t, nil)
+
+	// Primary key updates
+	tb.Update(ctx, t, tableName, "id", 1, "id", 6)
+	tb.Update(ctx, t, tableName, "id", 4, "id", 7)
+	cs.Capture(ctx, t, nil)
+
+	cupaloy.SnapshotT(t, cs.Summary())
+}

--- a/source-sqlserver/.snapshots/TestPrimaryKeyUpdate
+++ b/source-sqlserver/.snapshots/TestPrimaryKeyUpdate
@@ -1,0 +1,18 @@
+# ================================
+# Collection "acmeCo/test/test_primarykeyupdate_63510878": 10 Documents
+# ================================
+{"_meta":{"op":"c","source":{"schema":"dbo","snapshot":true,"table":"test_PrimaryKeyUpdate_63510878","lsn":"","seqval":"AAAAAAAAAAAAAA=="}},"data":"zero","id":0}
+{"_meta":{"op":"c","source":{"schema":"dbo","snapshot":true,"table":"test_PrimaryKeyUpdate_63510878","lsn":"","seqval":"AAAAAAAAAAAAAA=="}},"data":"one","id":1}
+{"_meta":{"op":"c","source":{"schema":"dbo","snapshot":true,"table":"test_PrimaryKeyUpdate_63510878","lsn":"","seqval":"AAAAAAAAAAAAAA=="}},"data":"two","id":2}
+{"_meta":{"op":"c","source":{"schema":"dbo","table":"test_PrimaryKeyUpdate_63510878","lsn":"AAAAAAAAAAAAAA==","seqval":"AAAAAAAAAAAAAA==","updateMask":"Aw=="}},"data":"three","id":3}
+{"_meta":{"op":"c","source":{"schema":"dbo","table":"test_PrimaryKeyUpdate_63510878","lsn":"AAAAAAAAAAAAAA==","seqval":"AAAAAAAAAAAAAA==","updateMask":"Aw=="}},"data":"four","id":4}
+{"_meta":{"op":"c","source":{"schema":"dbo","table":"test_PrimaryKeyUpdate_63510878","lsn":"AAAAAAAAAAAAAA==","seqval":"AAAAAAAAAAAAAA==","updateMask":"Aw=="}},"data":"five","id":5}
+{"_meta":{"op":"d","source":{"schema":"dbo","table":"test_PrimaryKeyUpdate_63510878","lsn":"AAAAAAAAAAAAAA==","seqval":"AAAAAAAAAAAAAA==","updateMask":"Aw=="}},"id":1}
+{"_meta":{"op":"c","source":{"schema":"dbo","table":"test_PrimaryKeyUpdate_63510878","lsn":"AAAAAAAAAAAAAA==","seqval":"AAAAAAAAAAAAAA==","updateMask":"Aw=="}},"data":"one","id":6}
+{"_meta":{"op":"d","source":{"schema":"dbo","table":"test_PrimaryKeyUpdate_63510878","lsn":"AAAAAAAAAAAAAA==","seqval":"AAAAAAAAAAAAAA==","updateMask":"Aw=="}},"id":4}
+{"_meta":{"op":"c","source":{"schema":"dbo","table":"test_PrimaryKeyUpdate_63510878","lsn":"AAAAAAAAAAAAAA==","seqval":"AAAAAAAAAAAAAA==","updateMask":"Aw=="}},"data":"four","id":7}
+# ================================
+# Final State Checkpoint
+# ================================
+{"bindingStateV1":{"dbo%2Ftest_PrimaryKeyUpdate_63510878":{"backfilled":3,"key_columns":["id"],"mode":"Active"}},"cursor":"AAAAAAAAAAAAAA=="}
+


### PR DESCRIPTION
**Description:**

This PR adds tests to `source-{postgres,mysql,sqlserver}` exercising the capture behavior when a row is updated in a way which modifies its primary key. There are two ways this could be handled:

1. Just transcribe the update literally, with the new row as the collection key and the old primary-key value in the before-state metadata.
2. Generate a synthetic pair of a delete event for the old primary-key value, and an insert event for the new value.

Option (2) is more correct because it results in a deletion of the old row being propagated to any standard / merge update materializations, and also maintains the "the first mention of any previously-nonexisting key should be an insert event" invariant that is sometimes useful. Especially when combined with hard deletions, this means that the destination table will continue to precisely match the source, whereas option (1) would leave behind a bunch of vestigial rows corresponding to old primary-key values which were superseded by later updates.

Previously, SQL Server implemented option (2) while MySQL and Postgres implemented option (1). This was the path of least resistance for each of these captures. The actual meat of this PR is that now `source-mysql` implements option (2) as well by explicitly checking whether the row key is changed between the before and after states of an update event, and emitting the aforementioned synthetic pair of delete/inserts if so.

Postgres is not updated in this PR, because while the actual detection logic would be basically identical there's some additional change event plumbing which assumes that each CDC event from the database will yield at most one change event internally, and fixing that is slightly more involved so I'm punting on it for the moment in order to get MySQL fixed sooner. We should come back and address that soon so all the SQL CDC connectors are consistent.

**Workflow steps:**

Going forward, updates to MySQL tables which modify the primary key of a row will be captured as implicitly deleting the old row-state and inserting the new row-state.

Any preexisting stale rows from primary-key updates which occurred before this change went live will not be cleaned up, remedying that will require manual work or a complete backfill of the impacted dataflows.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2185)
<!-- Reviewable:end -->
