### PR TITLE
source-redshift-batch: Add the 'use_schema_inference' feature flag

### DIFF
--- a/source-boilerplate/feature_flags.go
+++ b/source-boilerplate/feature_flags.go
@@ -1,0 +1,25 @@
+package boilerplate
+
+import "strings"
+
+// ParseFeatureFlags parses a comma-separated list of flag names and combines that with a
+// map describing default flag settings in the absence of any flags. A flag name can be
+// prefixed with 'no_' to explicitly set it to a false value, in case the default is (or
+// might soon become) true.
+func ParseFeatureFlags(flags string, defaults map[string]bool) map[string]bool {
+	var settings = make(map[string]bool)
+	for k, v := range defaults {
+		settings[k] = v
+	}
+	for _, flagName := range strings.Split(flags, ",") {
+		var flagValue = true
+		if strings.HasPrefix(flagName, "no_") {
+			flagName = strings.TrimPrefix(flagName, "no_")
+			flagValue = false
+		}
+		if flagName != "" {
+			settings[flagName] = flagValue
+		}
+	}
+	return settings
+}

--- a/source-redshift-batch/.snapshots/TestBasicDatatypes-Capture
+++ b/source-redshift-batch/.snapshots/TestBasicDatatypes-Capture
@@ -5,5 +5,5 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"test_basic_datatypes_13111208":{"LastPolled":"<TIMESTAMP>"}}}
+{"bindingStateV1":{"test_basic_datatypes_13111208":{"CursorNames":null,"CursorValues":null,"LastPolled":"<TIMESTAMP>"}}}
 

--- a/source-redshift-batch/.snapshots/TestFeatureFlagUseSchemaInference-Discovery
+++ b/source-redshift-batch/.snapshots/TestFeatureFlagUseSchemaInference-Discovery
@@ -1,0 +1,60 @@
+Binding 0:
+{
+    "resource_config_json": {
+      "name": "test_feature_flag_use_schema_inference_77244729",
+      "template": "{{if .CursorFields -}}\n  {{- if .IsFirstQuery -}}\n    SELECT * FROM \"test\".\"feature_flag_use_schema_inference_77244729\"\n  {{- else -}}\n    SELECT * FROM \"test\".\"feature_flag_use_schema_inference_77244729\"\n\t{{- range $i, $k := $.CursorFields -}}\n\t  {{- if eq $i 0}} WHERE ({{else}}) OR ({{end -}}\n      {{- range $j, $n := $.CursorFields -}}\n\t\t{{- if lt $j $i -}}\n\t\t  {{$n}} = ${{add $j 1}} AND {{end -}}\n\t  {{- end -}}\n\t  {{$k}} \u003e ${{add $i 1}}\n\t{{- end -}}\n\t) \n  {{- end}} ORDER BY {{range $i, $k := $.CursorFields}}{{if gt $i 0}}, {{end}}{{$k}}{{end -}};\n{{- else -}}\n  SELECT * FROM \"test\".\"feature_flag_use_schema_inference_77244729\";\n{{- end}}\n"
+    },
+    "resource_path": [
+      "test_feature_flag_use_schema_inference_77244729"
+    ],
+    "collection": {
+      "name": "acmeCo/test/test_feature_flag_use_schema_inference_77244729",
+      "read_schema_json": {
+        "type": "object",
+        "required": [
+          "_meta",
+          "id"
+        ],
+        "properties": {
+          "_meta": {
+            "$schema": "http://json-schema.org/draft/2020-12/schema",
+            "$id": "https://github.com/estuary/connectors/source-redshift-batch/document-metadata",
+            "properties": {
+              "polled": {
+                "type": "string",
+                "format": "date-time",
+                "title": "Polled Timestamp",
+                "description": "The time at which the update query which produced this document as executed."
+              },
+              "index": {
+                "type": "integer",
+                "title": "Result Index",
+                "description": "The index of this document within the query execution which produced it."
+              }
+            },
+            "type": "object",
+            "required": [
+              "polled",
+              "index"
+            ]
+          },
+          "data": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "id": {
+            "type": "integer"
+          }
+        },
+        "x-infer-schema": true
+      },
+      "key": [
+        "/id"
+      ],
+      "projections": null
+    },
+    "state_key": "test_feature_flag_use_schema_inference_77244729"
+  }
+

--- a/source-redshift-batch/.snapshots/TestFloatNaNs-Capture
+++ b/source-redshift-batch/.snapshots/TestFloatNaNs-Capture
@@ -1,11 +1,11 @@
 # ================================
 # Collection "acmeCo/test/test_float_nans_10511": 3 Documents
 # ================================
-{"_meta":{"polled":"<TIMESTAMP>","index":999},"a_double":"NaN","a_real":2,"id":0,"txid":999999}
-{"_meta":{"polled":"<TIMESTAMP>","index":999},"a_double":3,"a_real":"NaN","id":1,"txid":999999}
-{"_meta":{"polled":"<TIMESTAMP>","index":999},"a_double":"-Infinity","a_real":"Infinity","id":2,"txid":999999}
+{"_meta":{"polled":"<TIMESTAMP>","index":999},"a_double":"NaN","a_real":2,"id":0}
+{"_meta":{"polled":"<TIMESTAMP>","index":999},"a_double":3,"a_real":"NaN","id":1}
+{"_meta":{"polled":"<TIMESTAMP>","index":999},"a_double":"-Infinity","a_real":"Infinity","id":2}
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"test_float_nans_10511":{"CursorNames":["txid"],"CursorValues":[999999],"LastPolled":"<TIMESTAMP>"}}}
+{"bindingStateV1":{"test_float_nans_10511":{"CursorNames":null,"CursorValues":null,"LastPolled":"<TIMESTAMP>"}}}
 

--- a/source-redshift-batch/.snapshots/TestFloatNaNs-Discovery
+++ b/source-redshift-batch/.snapshots/TestFloatNaNs-Discovery
@@ -1,14 +1,14 @@
 Binding 0:
 {
     "resource_config_json": {
-      "name": "test_basic_datatypes_13111208",
-      "template": "{{if .CursorFields -}}\n  {{- if .IsFirstQuery -}}\n    SELECT * FROM \"test\".\"basic_datatypes_13111208\"\n  {{- else -}}\n    SELECT * FROM \"test\".\"basic_datatypes_13111208\"\n\t{{- range $i, $k := $.CursorFields -}}\n\t  {{- if eq $i 0}} WHERE ({{else}}) OR ({{end -}}\n      {{- range $j, $n := $.CursorFields -}}\n\t\t{{- if lt $j $i -}}\n\t\t  {{$n}} = ${{add $j 1}} AND {{end -}}\n\t  {{- end -}}\n\t  {{$k}} \u003e ${{add $i 1}}\n\t{{- end -}}\n\t) \n  {{- end}} ORDER BY {{range $i, $k := $.CursorFields}}{{if gt $i 0}}, {{end}}{{$k}}{{end -}};\n{{- else -}}\n  SELECT * FROM \"test\".\"basic_datatypes_13111208\";\n{{- end}}\n"
+      "name": "test_float_nans_10511",
+      "template": "{{if .CursorFields -}}\n  {{- if .IsFirstQuery -}}\n    SELECT * FROM \"test\".\"float_nans_10511\"\n  {{- else -}}\n    SELECT * FROM \"test\".\"float_nans_10511\"\n\t{{- range $i, $k := $.CursorFields -}}\n\t  {{- if eq $i 0}} WHERE ({{else}}) OR ({{end -}}\n      {{- range $j, $n := $.CursorFields -}}\n\t\t{{- if lt $j $i -}}\n\t\t  {{$n}} = ${{add $j 1}} AND {{end -}}\n\t  {{- end -}}\n\t  {{$k}} \u003e ${{add $i 1}}\n\t{{- end -}}\n\t) \n  {{- end}} ORDER BY {{range $i, $k := $.CursorFields}}{{if gt $i 0}}, {{end}}{{$k}}{{end -}};\n{{- else -}}\n  SELECT * FROM \"test\".\"float_nans_10511\";\n{{- end}}\n"
     },
     "resource_path": [
-      "test_basic_datatypes_13111208"
+      "test_float_nans_10511"
     ],
     "collection": {
-      "name": "acmeCo/test/test_basic_datatypes_13111208",
+      "name": "acmeCo/test/test_float_nans_10511",
       "read_schema_json": {
         "type": "object",
         "required": [
@@ -38,15 +38,10 @@ Binding 0:
               "index"
             ]
           },
-          "a_bool": {
+          "a_double": {
+            "format": "number",
             "type": [
-              "boolean",
-              "null"
-            ]
-          },
-          "a_date": {
-            "format": "date-time",
-            "type": [
+              "number",
               "string",
               "null"
             ]
@@ -55,20 +50,6 @@ Binding 0:
             "format": "number",
             "type": [
               "number",
-              "string",
-              "null"
-            ]
-          },
-          "a_ts": {
-            "format": "date-time",
-            "type": [
-              "string",
-              "null"
-            ]
-          },
-          "a_tstz": {
-            "format": "date-time",
-            "type": [
               "string",
               "null"
             ]
@@ -83,6 +64,6 @@ Binding 0:
       ],
       "projections": null
     },
-    "state_key": "test_basic_datatypes_13111208"
+    "state_key": "test_float_nans_10511"
   }
 

--- a/source-redshift-batch/.snapshots/TestSpec
+++ b/source-redshift-batch/.snapshots/TestSpec
@@ -55,6 +55,11 @@
             ],
             "title": "SSL Mode",
             "description": "Overrides SSL connection behavior by setting the 'sslmode' parameter."
+          },
+          "feature_flags": {
+            "type": "string",
+            "title": "Feature Flags",
+            "description": "This property is intended for Estuary internal use. You should only modify this field as directed by Estuary support."
           }
         },
         "additionalProperties": false,

--- a/source-redshift-batch/main.go
+++ b/source-redshift-batch/main.go
@@ -31,6 +31,7 @@ type advancedConfig struct {
 	PollSchedule    string   `json:"poll,omitempty" jsonschema:"title=Default Polling Schedule,description=When and how often to execute fetch queries. Accepts a Go duration string like '5m' or '6h' for frequency-based polling or a string like 'daily at 12:34Z' to poll at a specific time (specified in UTC) every day. Defaults to '24h' if unset." jsonschema_extras:"pattern=^([-+]?([0-9]+([.][0-9]+)?(h|m|s|ms))+|daily at [0-9][0-9]?:[0-9]{2}Z)$"`
 	DiscoverSchemas []string `json:"discover_schemas,omitempty" jsonschema:"title=Discovery Schema Selection,description=If this is specified only tables in the selected schema(s) will be automatically discovered. Omit all entries to discover tables from all schemas."`
 	SSLMode         string   `json:"sslmode,omitempty" jsonschema:"title=SSL Mode,description=Overrides SSL connection behavior by setting the 'sslmode' parameter.,enum=disable,enum=allow,enum=prefer,enum=require,enum=verify-ca,enum=verify-full"`
+	FeatureFlags    string   `json:"feature_flags,omitempty" jsonschema:"title=Feature Flags,description=This property is intended for Estuary internal use. You should only modify this field as directed by Estuary support."`
 }
 
 // Validate checks that the configuration possesses all required properties.


### PR DESCRIPTION
**Description:**

This PR introduces the `/advanced/feature_flags` config setting to the Redshift batch capture, adds a helper function in `source-boilerplate` for parsing those flags with default values and support for `no_` prefixes, and then uses that feature flags infrastructure to add a new one named `use_schema_inference` which when set causes discovered collection schemas to have `x-infer-schema: true` set so that they use the inferred schema in conjunction with the discovered schema.

This is useful because Redshift is a data warehouse where users often use very loose declared types on the tables, and then want to be able to rely on more precise as-used-in-practice type guarantees when materializing their dataset. For example, it's tolerably common to have no declared primary keys and declare all columns with a potentially-nullable type, then manually specify a collection key made of one or more of those properties, and then want to materialize that collection to a SQL database. And currently that doesn't work because the columns designated as the key are potentially nullable in the source DB, even if there are no actual nulls in practice. Turning on schema inference is the escape hatch which allows this to work right up until the moment they actually stick a null into their source data.

**Workflow steps:**

Put `use_schema_inference` in the "Feature Flags" section of the advanced endpoint config. In the future if more feature flags than just this one exist, they should be comma-separated.

Note that once enabled on a particular capture, simply removing the feature flag will not turn schema inference back on -- as I understand things the use of schema inference is "sticky" and disabling it would require manually fiddling with the collection schemas.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2187)
<!-- Reviewable:end -->
