### PR TITLE
source-postgres: Handle null restart_lsn values

### DIFF
--- a/source-postgres/database.go
+++ b/source-postgres/database.go
@@ -16,7 +16,7 @@ type replicationSlotInfo struct {
 	Plugin            string
 	SlotType          string
 	Active            bool
-	RestartLSN        pglogrepl.LSN
+	RestartLSN        *pglogrepl.LSN
 	ConfirmedFlushLSN pglogrepl.LSN
 	WALStatus         string
 }


### PR DESCRIPTION
When querying replication slot info for an invalidated slot, the `restart_lsn` column is typically null which resulted in a:

```
error querying replication slots: can't scan into dest[5]: can not scan <nil> to LSN
```

warning rather than the intended behavior where the query itself succeeds and because `wal_status == 'lost'` we instead warn that:

```
replication slot was invalidated by the server, it must be deleted and all bindings backfilled
```

Note that in either case this is currently just a warning and the actual error today is still:

```
runTransactions: readMessage: error creating replication stream: unable to start replication: ERROR: cannot read from logical replication slot "flow_slot" (SQLSTATE 55000)
```

I would like to get the logic working reliably in warn-mode before we make it a hard error, for obvious reasons.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2188)
<!-- Reviewable:end -->
