### PR TITLE
Network Tunneling in Batch SQL Connectors

### DIFF
--- a/go/network-tunnel/interface.go
+++ b/go/network-tunnel/interface.go
@@ -1,0 +1,41 @@
+package networkTunnel
+
+import (
+	"context"
+	"fmt"
+	"net"
+)
+
+type SSHForwardingConfig struct {
+	SSHEndpoint string `json:"sshEndpoint" jsonschema:"title=SSH Endpoint,description=Endpoint of the remote SSH server that supports tunneling (in the form of ssh://user@hostname[:port])" jsonschema_extras:"pattern=^ssh://.+@.+$"`
+	PrivateKey  string `json:"privateKey" jsonschema:"title=SSH Private Key,description=Private key to connect to the remote SSH server." jsonschema_extras:"secret=true,multiline=true"`
+}
+
+type TunnelConfig struct {
+	SSHForwarding *SSHForwardingConfig `json:"sshForwarding,omitempty" jsonschema:"title=SSH Forwarding"`
+}
+
+func (cfg *TunnelConfig) InUse() bool {
+	return cfg != nil && cfg.SSHForwarding != nil && cfg.SSHForwarding.SSHEndpoint != ""
+}
+
+func (cfg *TunnelConfig) Start(ctx context.Context, address string, localPort string) (*SshTunnel, error) {
+	host, port, err := net.SplitHostPort(address)
+	if err != nil {
+		return nil, fmt.Errorf("error splitting address %q into host and port: %w", address, err)
+	}
+
+	var sshConfig = &SshConfig{
+		SshEndpoint: cfg.SSHForwarding.SSHEndpoint,
+		PrivateKey:  []byte(cfg.SSHForwarding.PrivateKey),
+		ForwardHost: host,
+		ForwardPort: port,
+		LocalPort:   localPort,
+	}
+	var tunnel = sshConfig.CreateTunnel()
+
+	if err := tunnel.Start(); err != nil {
+		return nil, err
+	}
+	return tunnel, nil
+}

--- a/go/network-tunnel/network_tunnel.go
+++ b/go/network-tunnel/network_tunnel.go
@@ -1,4 +1,4 @@
-package network_tunnel
+package networkTunnel
 
 import (
 	"bytes"

--- a/source-bigquery-batch/main.go
+++ b/source-bigquery-batch/main.go
@@ -24,7 +24,6 @@ type Config struct {
 	Dataset         string `json:"dataset" jsonschema:"title=Dataset,description=BigQuery dataset to discover tables within." jsonschema_extras:"order=2"`
 
 	Advanced advancedConfig `json:"advanced,omitempty" jsonschema:"title=Advanced Options,description=Options for advanced users. You should not typically need to modify these." jsonschema_extra:"advanced=true"`
-	// TODO(wgd): Add network tunnel support
 }
 
 type advancedConfig struct {

--- a/source-mysql-batch/.snapshots/TestSpec
+++ b/source-mysql-batch/.snapshots/TestSpec
@@ -47,6 +47,38 @@
         "type": "object",
         "title": "Advanced Options",
         "description": "Options for advanced users. You should not typically need to modify these."
+      },
+      "networkTunnel": {
+        "properties": {
+          "sshForwarding": {
+            "properties": {
+              "sshEndpoint": {
+                "type": "string",
+                "title": "SSH Endpoint",
+                "description": "Endpoint of the remote SSH server that supports tunneling (in the form of ssh://user@hostname[:port])",
+                "pattern": "^ssh://.+@.+$"
+              },
+              "privateKey": {
+                "type": "string",
+                "title": "SSH Private Key",
+                "description": "Private key to connect to the remote SSH server.",
+                "multiline": true,
+                "secret": true
+              }
+            },
+            "additionalProperties": false,
+            "type": "object",
+            "required": [
+              "sshEndpoint",
+              "privateKey"
+            ],
+            "title": "SSH Forwarding"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "title": "Network Tunnel",
+        "description": "Connect to your system through an SSH server that acts as a bastion host for your network."
       }
     },
     "type": "object",

--- a/source-postgres-batch/.snapshots/TestSpec
+++ b/source-postgres-batch/.snapshots/TestSpec
@@ -61,6 +61,38 @@
         "type": "object",
         "title": "Advanced Options",
         "description": "Options for advanced users. You should not typically need to modify these."
+      },
+      "networkTunnel": {
+        "properties": {
+          "sshForwarding": {
+            "properties": {
+              "sshEndpoint": {
+                "type": "string",
+                "title": "SSH Endpoint",
+                "description": "Endpoint of the remote SSH server that supports tunneling (in the form of ssh://user@hostname[:port])",
+                "pattern": "^ssh://.+@.+$"
+              },
+              "privateKey": {
+                "type": "string",
+                "title": "SSH Private Key",
+                "description": "Private key to connect to the remote SSH server.",
+                "multiline": true,
+                "secret": true
+              }
+            },
+            "additionalProperties": false,
+            "type": "object",
+            "required": [
+              "sshEndpoint",
+              "privateKey"
+            ],
+            "title": "SSH Forwarding"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "title": "Network Tunnel",
+        "description": "Connect to your system through an SSH server that acts as a bastion host for your network."
       }
     },
     "type": "object",

--- a/source-postgres-batch/main.go
+++ b/source-postgres-batch/main.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"text/template"
 
+	networkTunnel "github.com/estuary/connectors/go/network-tunnel"
 	"github.com/estuary/connectors/go/schedule"
 	schemagen "github.com/estuary/connectors/go/schema-gen"
 	boilerplate "github.com/estuary/connectors/source-boilerplate"
@@ -25,7 +26,8 @@ type Config struct {
 	Password string         `json:"password" jsonschema:"description=Password for the specified database user." jsonschema_extras:"secret=true,order=2"`
 	Database string         `json:"database" jsonschema:"default=postgres,description=Logical database name to capture from." jsonschema_extras:"order=3"`
 	Advanced advancedConfig `json:"advanced,omitempty" jsonschema:"title=Advanced Options,description=Options for advanced users. You should not typically need to modify these." jsonschema_extra:"advanced=true"`
-	// TODO(wgd): Add network tunnel support
+
+	NetworkTunnel *networkTunnel.TunnelConfig `json:"networkTunnel,omitempty" jsonschema:"title=Network Tunnel,description=Connect to your system through an SSH server that acts as a bastion host for your network."`
 }
 
 type advancedConfig struct {
@@ -71,6 +73,9 @@ func (c *Config) SetDefaults() {
 // ToURI converts the Config to a DSN string.
 func (c *Config) ToURI() string {
 	var address = c.Address
+	if c.NetworkTunnel.InUse() {
+		address = "localhost:5432"
+	}
 	var uri = url.URL{
 		Scheme: "postgres",
 		Host:   address,
@@ -95,6 +100,13 @@ func connectPostgres(ctx context.Context, cfg *Config) (*sql.DB, error) {
 		"user":     cfg.User,
 		"database": cfg.Database,
 	}).Info("connecting to database")
+
+	// If a network tunnel is configured, then try to start it before establishing connections.
+	if cfg.NetworkTunnel.InUse() {
+		if _, err := cfg.NetworkTunnel.Start(ctx, cfg.Address, "5432"); err != nil {
+			return nil, err
+		}
+	}
 
 	var db, err = sql.Open("pgx", cfg.ToURI())
 	if err != nil {

--- a/source-redshift-batch/.snapshots/TestSpec
+++ b/source-redshift-batch/.snapshots/TestSpec
@@ -61,6 +61,38 @@
         "type": "object",
         "title": "Advanced Options",
         "description": "Options for advanced users. You should not typically need to modify these."
+      },
+      "networkTunnel": {
+        "properties": {
+          "sshForwarding": {
+            "properties": {
+              "sshEndpoint": {
+                "type": "string",
+                "title": "SSH Endpoint",
+                "description": "Endpoint of the remote SSH server that supports tunneling (in the form of ssh://user@hostname[:port])",
+                "pattern": "^ssh://.+@.+$"
+              },
+              "privateKey": {
+                "type": "string",
+                "title": "SSH Private Key",
+                "description": "Private key to connect to the remote SSH server.",
+                "multiline": true,
+                "secret": true
+              }
+            },
+            "additionalProperties": false,
+            "type": "object",
+            "required": [
+              "sshEndpoint",
+              "privateKey"
+            ],
+            "title": "SSH Forwarding"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "title": "Network Tunnel",
+        "description": "Connect to your system through an SSH server that acts as a bastion host for your network."
       }
     },
     "type": "object",


### PR DESCRIPTION
**Description:**

Integrates network/SSH tunneling into the batch SQL connectors, with the exception of `source-bigquery-batch` since it's not self-evident how to apply it there and I'm just picking some extremely low-hanging fruit here.

**Notes for reviewers:**

In order to avoid copy-pasting a bunch of unnecessary bits of boilerplate, I have factored out some of the config structs and startup logic that other connectors used into the network tunnel Go package and am using that here. I have not gone back and modified the other dozen connectors with SSH tunneling support to use the more concise integration in this PR, but it's something we might want to do at some point just for code health reasons.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2190)
<!-- Reviewable:end -->
