### PR TITLE
source-braintree-native: change window size from days to hours

### DIFF
--- a/source-braintree-native/source_braintree_native/api.py
+++ b/source-braintree-native/source_braintree_native/api.py
@@ -95,7 +95,7 @@ async def fetch_transactions(
 ) -> AsyncGenerator[IncrementalResource | LogCursor, None]:
     assert isinstance(log_cursor, datetime)
     most_recent_created_at = log_cursor
-    window_end = log_cursor + timedelta(days=window_size)
+    window_end = log_cursor + timedelta(hours=window_size)
     end = min(window_end, datetime.now(tz=UTC))
 
     collection = braintree_gateway.transaction.search(
@@ -129,7 +129,7 @@ async def fetch_customers(
 ) -> AsyncGenerator[IncrementalResource | LogCursor, None]:
     assert isinstance(log_cursor, datetime)
     most_recent_created_at = log_cursor
-    window_end = log_cursor + timedelta(days=window_size)
+    window_end = log_cursor + timedelta(hours=window_size)
     end = min(window_end, datetime.now(tz=UTC))
 
     collection = braintree_gateway.customer.search(
@@ -163,7 +163,7 @@ async def fetch_credit_card_verifications(
 ) -> AsyncGenerator[IncrementalResource | LogCursor, None]:
     assert isinstance(log_cursor, datetime)
     most_recent_created_at = log_cursor
-    window_end = log_cursor + timedelta(days=window_size)
+    window_end = log_cursor + timedelta(hours=window_size)
     end = min(window_end, datetime.now(tz=UTC))
 
     collection = braintree_gateway.verification.search(
@@ -197,7 +197,7 @@ async def fetch_subscriptions(
 ) -> AsyncGenerator[IncrementalResource | LogCursor, None]:
     assert isinstance(log_cursor, datetime)
     most_recent_created_at = log_cursor
-    window_end = log_cursor + timedelta(days=window_size)
+    window_end = log_cursor + timedelta(hours=window_size)
     end = min(window_end, datetime.now(tz=UTC))
 
     collection = braintree_gateway.subscription.search(
@@ -234,7 +234,7 @@ async def fetch_disputes(
     # The start date must be shifted back 1 day since we have to query Braintree using the received_date field,
     # which is less granular than the created_at cursor field (date vs. datetime).
     start = log_cursor - timedelta(days=1)
-    window_end = log_cursor + timedelta(days=window_size)
+    window_end = log_cursor + timedelta(hours=window_size)
     end = min(window_end, datetime.now(tz=UTC))
 
     collection = braintree_gateway.dispute.search(

--- a/source-braintree-native/source_braintree_native/models.py
+++ b/source-braintree-native/source_braintree_native/models.py
@@ -53,9 +53,9 @@ class EndpointConfig(BaseModel):
             default=False,
         )
         window_size: Annotated[int, Field(
-            description="Window size in days for incremental streams. This should be left as the default value unless connector errors indicate a smaller window size is required.",
+            description="Window size in hours for incremental streams. This should be left as the default value unless connector errors indicate a smaller window size is required.",
             title="Window Size",
-            default=15,
+            default=24,
             gt=0,
         )]
 

--- a/source-braintree-native/tests/snapshots/snapshots__spec__capture.stdout.json
+++ b/source-braintree-native/tests/snapshots/snapshots__spec__capture.stdout.json
@@ -12,8 +12,8 @@
               "type": "boolean"
             },
             "window_size": {
-              "default": 15,
-              "description": "Window size in days for incremental streams. This should be left as the default value unless connector errors indicate a smaller window size is required.",
+              "default": 24,
+              "description": "Window size in hours for incremental streams. This should be left as the default value unless connector errors indicate a smaller window size is required.",
               "exclusiveMinimum": 0,
               "title": "Window Size",
               "type": "integer"


### PR DESCRIPTION
**Description:**

Users have enough data in Braintree that a window size of 1 day (the smallest previously possible) wasn't small enough to ensure the connector wasn't missing data. Window size is now specified in hours, with the default updated to 24 hours.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2191)
<!-- Reviewable:end -->
