### PR TITLE
source-braintree-native: fix nullable key on full refresh resources

### DIFF
--- a/source-braintree-native/source_braintree_native/models.py
+++ b/source-braintree-native/source_braintree_native/models.py
@@ -70,7 +70,7 @@ ConnectorState = GenericConnectorState[ResourceState]
 
 
 class FullRefreshResource(BaseDocument, extra="allow"):
-    id: str | None
+    pass
 
 
 class IncrementalResource(BaseDocument, extra="allow"):

--- a/source-braintree-native/source_braintree_native/resources.py
+++ b/source-braintree-native/source_braintree_native/resources.py
@@ -96,13 +96,13 @@ def full_refresh_resources(
                 gateway_property,
                 gateway_response_field,
             ),
-            tombstone=FullRefreshResource(_meta=FullRefreshResource.Meta(op="d"), id=None)
+            tombstone=FullRefreshResource(_meta=FullRefreshResource.Meta(op="d"))
         )
 
     return [
         common.Resource(
             name=name,
-            key=["/id"],
+            key=["/_meta/row_id"],
             model=FullRefreshResource,
             open=functools.partial(open, _create_gateway(config), gateway_property, gateway_response_field),
             initial_state=ResourceState(),

--- a/source-braintree-native/tests/snapshots/snapshots__discover__capture.stdout.json
+++ b/source-braintree-native/tests/snapshots/snapshots__discover__capture.stdout.json
@@ -40,28 +40,14 @@
             "row_id": -1
           },
           "description": "Document metadata"
-        },
-        "id": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "title": "Id"
         }
       },
-      "required": [
-        "id"
-      ],
       "title": "FullRefreshResource",
       "type": "object",
       "x-infer-schema": true
     },
     "key": [
-      "/id"
+      "/_meta/row_id"
     ]
   },
   {
@@ -105,28 +91,14 @@
             "row_id": -1
           },
           "description": "Document metadata"
-        },
-        "id": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "title": "Id"
         }
       },
-      "required": [
-        "id"
-      ],
       "title": "FullRefreshResource",
       "type": "object",
       "x-infer-schema": true
     },
     "key": [
-      "/id"
+      "/_meta/row_id"
     ]
   },
   {
@@ -170,28 +142,14 @@
             "row_id": -1
           },
           "description": "Document metadata"
-        },
-        "id": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "title": "Id"
         }
       },
-      "required": [
-        "id"
-      ],
       "title": "FullRefreshResource",
       "type": "object",
       "x-infer-schema": true
     },
     "key": [
-      "/id"
+      "/_meta/row_id"
     ]
   },
   {
@@ -235,28 +193,14 @@
             "row_id": -1
           },
           "description": "Document metadata"
-        },
-        "id": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "title": "Id"
         }
       },
-      "required": [
-        "id"
-      ],
       "title": "FullRefreshResource",
       "type": "object",
       "x-infer-schema": true
     },
     "key": [
-      "/id"
+      "/_meta/row_id"
     ]
   },
   {


### PR DESCRIPTION
**Description:**

Keys on full refresh resources need to be non-nullable. The key for these resources is now `_meta/row_id` instead of `id`.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2192)
<!-- Reviewable:end -->
