### PR TITLE
source-braintree-native: concatenate search limit error message

### DIFF
--- a/source-braintree-native/source_braintree_native/api.py
+++ b/source-braintree-native/source_braintree_native/api.py
@@ -31,9 +31,11 @@ CONVENIENCE_OBJECTS = [
 
 
 def _search_limit_error_message(count: int, name: str) -> str:
-    msg = f"{count} {name} returned in a single search which is "
-    f"greater than or equal to Braintree's documented maximum for a single {name} search. "
-    "Reduce the window size and backfill this stream."
+    msg = (
+        f"{count} {name} returned in a single search which is "
+        f"greater than or equal to Braintree's documented maximum for a single {name} search. "
+        "Reduce the window size and backfill this stream."
+    )
 
     return msg
 
@@ -73,7 +75,7 @@ def _braintree_object_to_dict(braintree_object):
         data.pop('_setattrs', None)
         return data
 
-
+# TODO(bair): Refactor snapshot_ and fetch_ functions to make asynchronous API requests instead of synchronous requests.
 async def snapshot_resources(
         braintree_gateway: BraintreeGateway,
         gateway_property: str,


### PR DESCRIPTION
**Description:**

~~The Braintree SDK's API calls are all synchronous, so they block the event loop, meaning only a subset of streams can make progress at a time. Adding `await asyncio.sleep(0)` to the top of the various fetch functions allows other streams to make progress since these functions now yield to the event loop.~~

~~Using `await asyncio.sleep(0)` within the connector-specific code for this purpose is a temporary measure until I refactor the connector to make asynchronous API requests.~~

I also fixed an issue with the search limit error message where the f-strings were not concatenated together & the full error message wasn't getting displayed.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2193)
<!-- Reviewable:end -->
