### PR TITLE
source-braintree-native: run synchronous API calls in separate threads

### DIFF
--- a/source-braintree-native/source_braintree_native/api.py
+++ b/source-braintree-native/source_braintree_native/api.py
@@ -124,18 +124,15 @@ async def fetch_transactions(
         TransactionSearch.created_at.between(log_cursor, end),
     )
 
-    count = 0
+    if collection.maximum_size >= TRANSACTION_SEARCH_LIMIT:
+        raise RuntimeError(_search_limit_error_message(collection.maximum_size, "transactions"))
 
     async for object in _async_iterator_wrapper(collection):
-        count += 1
         doc = IncrementalResource.model_validate(_braintree_object_to_dict(object))
 
         if doc.created_at > log_cursor:
             yield doc
             most_recent_created_at = doc.created_at
-
-    if count >= TRANSACTION_SEARCH_LIMIT:
-        raise RuntimeError(_search_limit_error_message(count, "transactions"))
 
     if end == window_end:
         yield window_end
@@ -159,18 +156,15 @@ async def fetch_customers(
         CustomerSearch.created_at.between(log_cursor, end),
     )
 
-    count = 0
+    if collection.maximum_size >= SEARCH_LIMIT:
+        raise RuntimeError(_search_limit_error_message(collection.maximum_size, "customers"))
 
     async for object in _async_iterator_wrapper(collection):
-        count += 1
         doc = IncrementalResource.model_validate(_braintree_object_to_dict(object))
 
         if doc.created_at > log_cursor:
             yield doc
             most_recent_created_at = doc.created_at
-
-    if count >= SEARCH_LIMIT:
-        raise RuntimeError(_search_limit_error_message(count, "customers"))
 
     if end == window_end:
         yield window_end
@@ -194,24 +188,20 @@ async def fetch_credit_card_verifications(
         CreditCardVerificationSearch.created_at.between(log_cursor, end),
     )
 
-    count = 0
+    if collection.maximum_size >= SEARCH_LIMIT:
+        raise RuntimeError(_search_limit_error_message(collection.maximum_size, "credit card verifications"))
 
     async for object in _async_iterator_wrapper(collection):
-        count += 1
         doc = IncrementalResource.model_validate(_braintree_object_to_dict(object))
 
         if doc.created_at > log_cursor:
             yield doc
             most_recent_created_at = doc.created_at
 
-    if count >= SEARCH_LIMIT:
-        raise RuntimeError(_search_limit_error_message(count, "credit card verifications"))
-
     if end == window_end:
         yield window_end
     elif most_recent_created_at > log_cursor:
         yield most_recent_created_at
-
 
 async def fetch_subscriptions(
         braintree_gateway: BraintreeGateway,
@@ -229,18 +219,15 @@ async def fetch_subscriptions(
         SubscriptionSearch.created_at.between(log_cursor, end),
     )
 
-    count = 0
+    if collection.maximum_size >= SEARCH_LIMIT:
+        raise RuntimeError(_search_limit_error_message(collection.maximum_size, "subscriptions"))
 
     async for object in _async_iterator_wrapper(collection):
-        count += 1
         doc = IncrementalResource.model_validate(_braintree_object_to_dict(object))
 
         if doc.created_at > log_cursor:
             yield doc
             most_recent_created_at = doc.created_at
-
-    if count >= SEARCH_LIMIT:
-        raise RuntimeError(_search_limit_error_message(count, "subscriptions"))
 
     if end == window_end:
         yield window_end


### PR DESCRIPTION
**Description:**

The Braintree SDK makes synchronous HTTP requests, which was blocking the main thread and preventing separate streams from sending concurrent API calls. Any HTTP requests made by the Braintree SDK are now wrapped in [`asyncio.to_thread`](https://docs.python.org/3/library/asyncio-task.html#asyncio.to_thread), which runs the function in a separate thread. This unblocks the main thread and lets separate streams make concurrent API calls.

The `maximum_size` property that indicates how many results are found in a specific date window is now used to throw search limit errors sooner instead of after we iterate through & count up all results.

Note: The `disputes` stream cannot use the `maximum_size` property because the Braintree SDK returns a `PaginatedCollection` instead of a `ResourceCollection` for `disputes`, and `PaginatedCollection`s don't have a `maximum_size` property.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

Tested on a local stack. Confirmed:
- HTTP requests made by the Braintree SDK are done in separate threads, and separate streams are able to make concurrent API calls.
- Search limit errors are still raised when a search limit is exceeded.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2195)
<!-- Reviewable:end -->
