### PR TITLE
source-{http-ingest,kafka}: update flow protocol pin

### DIFF
--- a/source-http-ingest/Cargo.lock
+++ b/source-http-ingest/Cargo.lock
@@ -64,7 +64,7 @@ dependencies = [
 [[package]]
 name = "allocator"
 version = "0.0.0"
-source = "git+https://github.com/estuary/flow#af95f7b986e6abb37328161ed91ee8202a2fa841"
+source = "git+https://github.com/estuary/flow#eb0047a15c45ca170c0aa947ee52bc2ef21f6e8d"
 dependencies = [
  "jemalloc-ctl",
  "jemallocator",
@@ -482,7 +482,7 @@ dependencies = [
 [[package]]
 name = "doc"
 version = "0.0.0"
-source = "git+https://github.com/estuary/flow#af95f7b986e6abb37328161ed91ee8202a2fa841"
+source = "git+https://github.com/estuary/flow#eb0047a15c45ca170c0aa947ee52bc2ef21f6e8d"
 dependencies = [
  "base64 0.13.1",
  "bigdecimal",
@@ -1097,7 +1097,7 @@ dependencies = [
 [[package]]
 name = "json"
 version = "0.0.0"
-source = "git+https://github.com/estuary/flow#af95f7b986e6abb37328161ed91ee8202a2fa841"
+source = "git+https://github.com/estuary/flow#eb0047a15c45ca170c0aa947ee52bc2ef21f6e8d"
 dependencies = [
  "addr",
  "bigdecimal",
@@ -1243,7 +1243,7 @@ dependencies = [
 [[package]]
 name = "models"
 version = "0.0.0"
-source = "git+https://github.com/estuary/flow#af95f7b986e6abb37328161ed91ee8202a2fa841"
+source = "git+https://github.com/estuary/flow#eb0047a15c45ca170c0aa947ee52bc2ef21f6e8d"
 dependencies = [
  "caseless",
  "humantime-serde",
@@ -1614,12 +1614,12 @@ dependencies = [
 [[package]]
 name = "proto-build"
 version = "0.0.0"
-source = "git+https://github.com/estuary/flow#af95f7b986e6abb37328161ed91ee8202a2fa841"
+source = "git+https://github.com/estuary/flow#eb0047a15c45ca170c0aa947ee52bc2ef21f6e8d"
 
 [[package]]
 name = "proto-flow"
 version = "0.0.0"
-source = "git+https://github.com/estuary/flow#af95f7b986e6abb37328161ed91ee8202a2fa841"
+source = "git+https://github.com/estuary/flow#eb0047a15c45ca170c0aa947ee52bc2ef21f6e8d"
 dependencies = [
  "bytes",
  "pbjson",
@@ -1638,7 +1638,7 @@ dependencies = [
 [[package]]
 name = "proto-gazette"
 version = "0.0.0"
-source = "git+https://github.com/estuary/flow#af95f7b986e6abb37328161ed91ee8202a2fa841"
+source = "git+https://github.com/estuary/flow#eb0047a15c45ca170c0aa947ee52bc2ef21f6e8d"
 dependencies = [
  "bytes",
  "pbjson",
@@ -2661,7 +2661,7 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 [[package]]
 name = "tuple"
 version = "0.0.0"
-source = "git+https://github.com/estuary/flow#af95f7b986e6abb37328161ed91ee8202a2fa841"
+source = "git+https://github.com/estuary/flow#eb0047a15c45ca170c0aa947ee52bc2ef21f6e8d"
 dependencies = [
  "memchr",
  "serde_json",

--- a/source-kafka/Cargo.lock
+++ b/source-kafka/Cargo.lock
@@ -690,7 +690,7 @@ dependencies = [
 [[package]]
 name = "doc"
 version = "0.0.0"
-source = "git+https://github.com/estuary/flow#60e47f697826a8128b533cc5f4600acb5d80cdbc"
+source = "git+https://github.com/estuary/flow#eb0047a15c45ca170c0aa947ee52bc2ef21f6e8d"
 dependencies = [
  "base64 0.13.1",
  "bigdecimal 0.3.1",
@@ -1378,7 +1378,7 @@ dependencies = [
 [[package]]
 name = "json"
 version = "0.0.0"
-source = "git+https://github.com/estuary/flow#60e47f697826a8128b533cc5f4600acb5d80cdbc"
+source = "git+https://github.com/estuary/flow#eb0047a15c45ca170c0aa947ee52bc2ef21f6e8d"
 dependencies = [
  "addr",
  "bigdecimal 0.3.1",
@@ -1962,7 +1962,7 @@ dependencies = [
 [[package]]
 name = "proto-flow"
 version = "0.0.0"
-source = "git+https://github.com/estuary/flow#60e47f697826a8128b533cc5f4600acb5d80cdbc"
+source = "git+https://github.com/estuary/flow#eb0047a15c45ca170c0aa947ee52bc2ef21f6e8d"
 dependencies = [
  "bytes",
  "pbjson",
@@ -1977,7 +1977,7 @@ dependencies = [
 [[package]]
 name = "proto-gazette"
 version = "0.0.0"
-source = "git+https://github.com/estuary/flow#60e47f697826a8128b533cc5f4600acb5d80cdbc"
+source = "git+https://github.com/estuary/flow#eb0047a15c45ca170c0aa947ee52bc2ef21f6e8d"
 dependencies = [
  "bytes",
  "pbjson",
@@ -3053,7 +3053,7 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 [[package]]
 name = "tuple"
 version = "0.0.0"
-source = "git+https://github.com/estuary/flow#60e47f697826a8128b533cc5f4600acb5d80cdbc"
+source = "git+https://github.com/estuary/flow#eb0047a15c45ca170c0aa947ee52bc2ef21f6e8d"
 dependencies = [
  "memchr",
  "serde_json",


### PR DESCRIPTION
**Description:**

Updates the Flow protocol pin for rust connectors to include array information in projection inference, per the changes in
https://github.com/estuary/flow/pull/1787.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2197)
<!-- Reviewable:end -->
