### PR TITLE
materialize-databricks: fix commit logging for split queries

### DIFF
--- a/materialize-databricks/driver.go
+++ b/materialize-databricks/driver.go
@@ -465,8 +465,8 @@ func (d *transactor) Acknowledge(ctx context.Context) (*pf.ConnectorState, error
 			}
 			queries = []string{item.Query}
 		}
+		d.be.StartedResourceCommit(path)
 		for _, query := range queries {
-			d.be.StartedResourceCommit(path)
 			if _, err := db.ExecContext(ctx, query); err != nil {
 				// When doing a recovery apply, it may be the case that some tables & files have already been deleted after being applied
 				// it is okay to skip them in this case
@@ -477,8 +477,8 @@ func (d *transactor) Acknowledge(ctx context.Context) (*pf.ConnectorState, error
 				}
 				return nil, fmt.Errorf("query %q failed: %w", query, err)
 			}
-			d.be.FinishedResourceCommit(path)
 		}
+		d.be.FinishedResourceCommit(path)
 
 		// Cleanup files.
 		d.deleteFiles(ctx, item.ToDelete)


### PR DESCRIPTION
**Description:**

Databricks Store queries may be split into multiple separate items for large file sizes. This fixing the logging so that the started / ending commit messaging is not emitted for each of the split queries, but rather for the entire binding.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2199)
<!-- Reviewable:end -->
