### PR TITLE
source-oracle-flashback: raise query errors that aren't ORA-30052

### DIFF
--- a/source-oracle-flashback/source_oracle_flashback/api.py
+++ b/source-oracle-flashback/source_oracle_flashback/api.py
@@ -288,6 +288,8 @@ async def fetch_changes(
                     if "ORA-30052" in str(e) and is_rds:
                         log.info("Automatically triggering a backfill due to ORA-30052 (low retention period of redo logs has caused a gap in data)")
                         yield Triggers.BACKFILL
+                    else:
+                        raise
 
                 cols = [col[0] for col in c.description]
                 c.rowfactory = functools.partial(changes_rowfactory, table.table_name, cols)


### PR DESCRIPTION
**Description:**

We were swallowing errors from queries that weren't caused by ORA-30052. This fixed that by raising exceptions that can't be automatically fixed by a backfill.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

