### PR TITLE
source-mysql: Fix primary-key update logic when applied to only-changes bindings

### DIFF
--- a/source-mysql/.snapshots/TestPrimaryKeyUpdateOfOnlyChangesBinding
+++ b/source-mysql/.snapshots/TestPrimaryKeyUpdateOfOnlyChangesBinding
@@ -1,13 +1,15 @@
 # ================================
-# Collection "acmeCo/test/test_primarykeyupdateofonlychangesbinding_51329336": 5 Documents
+# Collection "acmeCo/test/test_primarykeyupdateofonlychangesbinding_51329336": 7 Documents
 # ================================
 {"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"PrimaryKeyUpdateOfOnlyChangesBinding_51329336","cursor":"binlog.000123:56789:123","txid":"11111111-1111-1111-1111-111111111111:111"}},"data":"three","id":3}
 {"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"PrimaryKeyUpdateOfOnlyChangesBinding_51329336","cursor":"binlog.000123:56789:123","txid":"11111111-1111-1111-1111-111111111111:111"}},"data":"four","id":4}
 {"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"PrimaryKeyUpdateOfOnlyChangesBinding_51329336","cursor":"binlog.000123:56789:123","txid":"11111111-1111-1111-1111-111111111111:111"}},"data":"five","id":5}
-{"_meta":{"op":"u","source":{"ts_ms":1111111111111,"schema":"test","table":"PrimaryKeyUpdateOfOnlyChangesBinding_51329336","cursor":"binlog.000123:56789:123","txid":"11111111-1111-1111-1111-111111111111:111"},"before":{"data":"one","id":1}},"data":"one","id":6}
-{"_meta":{"op":"u","source":{"ts_ms":1111111111111,"schema":"test","table":"PrimaryKeyUpdateOfOnlyChangesBinding_51329336","cursor":"binlog.000123:56789:123","txid":"11111111-1111-1111-1111-111111111111:111"},"before":{"data":"four","id":4}},"data":"four","id":7}
+{"_meta":{"op":"d","source":{"ts_ms":1111111111111,"schema":"test","table":"PrimaryKeyUpdateOfOnlyChangesBinding_51329336","cursor":"binlog.000123:56789:123","txid":"11111111-1111-1111-1111-111111111111:111"}},"data":"one","id":1}
+{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"PrimaryKeyUpdateOfOnlyChangesBinding_51329336","cursor":"binlog.000123:56789:123","txid":"11111111-1111-1111-1111-111111111111:111"}},"data":"one","id":6}
+{"_meta":{"op":"d","source":{"ts_ms":1111111111111,"schema":"test","table":"PrimaryKeyUpdateOfOnlyChangesBinding_51329336","cursor":"binlog.000123:56789:123","txid":"11111111-1111-1111-1111-111111111111:111"}},"data":"four","id":4}
+{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"PrimaryKeyUpdateOfOnlyChangesBinding_51329336","cursor":"binlog.000123:56789:123","txid":"11111111-1111-1111-1111-111111111111:111"}},"data":"four","id":7}
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"test%2FPrimaryKeyUpdateOfOnlyChangesBinding_51329336":{"backfilled":0,"metadata":{"charset":"utf8mb4","schema":{"columns":["id","data"],"types":{"data":{"charset":"utf8mb4","type":"text"},"id":{"type":"int"}}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
+{"bindingStateV1":{"test%2FPrimaryKeyUpdateOfOnlyChangesBinding_51329336":{"backfilled":0,"key_columns":["id"],"metadata":{"charset":"utf8mb4","schema":{"columns":["id","data"],"types":{"data":{"charset":"utf8mb4","type":"text"},"id":{"type":"int"}}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
 

--- a/source-mysql/.snapshots/TestPrimaryKeyUpdateOfOnlyChangesBinding
+++ b/source-mysql/.snapshots/TestPrimaryKeyUpdateOfOnlyChangesBinding
@@ -1,0 +1,13 @@
+# ================================
+# Collection "acmeCo/test/test_primarykeyupdateofonlychangesbinding_51329336": 5 Documents
+# ================================
+{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"PrimaryKeyUpdateOfOnlyChangesBinding_51329336","cursor":"binlog.000123:56789:123","txid":"11111111-1111-1111-1111-111111111111:111"}},"data":"three","id":3}
+{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"PrimaryKeyUpdateOfOnlyChangesBinding_51329336","cursor":"binlog.000123:56789:123","txid":"11111111-1111-1111-1111-111111111111:111"}},"data":"four","id":4}
+{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"PrimaryKeyUpdateOfOnlyChangesBinding_51329336","cursor":"binlog.000123:56789:123","txid":"11111111-1111-1111-1111-111111111111:111"}},"data":"five","id":5}
+{"_meta":{"op":"u","source":{"ts_ms":1111111111111,"schema":"test","table":"PrimaryKeyUpdateOfOnlyChangesBinding_51329336","cursor":"binlog.000123:56789:123","txid":"11111111-1111-1111-1111-111111111111:111"},"before":{"data":"one","id":1}},"data":"one","id":6}
+{"_meta":{"op":"u","source":{"ts_ms":1111111111111,"schema":"test","table":"PrimaryKeyUpdateOfOnlyChangesBinding_51329336","cursor":"binlog.000123:56789:123","txid":"11111111-1111-1111-1111-111111111111:111"},"before":{"data":"four","id":4}},"data":"four","id":7}
+# ================================
+# Final State Checkpoint
+# ================================
+{"bindingStateV1":{"test%2FPrimaryKeyUpdateOfOnlyChangesBinding_51329336":{"backfilled":0,"metadata":{"charset":"utf8mb4","schema":{"columns":["id","data"],"types":{"data":{"charset":"utf8mb4","type":"text"},"id":{"type":"int"}}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
+

--- a/source-mysql/capture_test.go
+++ b/source-mysql/capture_test.go
@@ -536,3 +536,38 @@ func TestPrimaryKeyUpdate(t *testing.T) {
 
 	cupaloy.SnapshotT(t, cs.Summary())
 }
+
+func TestPrimaryKeyUpdateOfOnlyChangesBinding(t *testing.T) {
+	var tb, ctx = mysqlTestBackend(t), context.Background()
+	var uniqueID = "51329336"
+	var tableDef = "(id INTEGER PRIMARY KEY, data TEXT)"
+	var tableName = tb.CreateTable(ctx, t, uniqueID, tableDef)
+
+	var cs = tb.CaptureSpec(ctx, t, regexp.MustCompile(uniqueID))
+	cs.Validator = &st.OrderedCaptureValidator{}
+	sqlcapture.TestShutdownAfterCaughtUp = true
+	t.Cleanup(func() { sqlcapture.TestShutdownAfterCaughtUp = false })
+
+	// Set backfill mode to 'Only Changes'
+	var res sqlcapture.Resource
+	require.NoError(t, json.Unmarshal(cs.Bindings[0].ResourceConfigJson, &res))
+	res.Mode = sqlcapture.BackfillModeOnlyChanges
+	resJSON, err := json.Marshal(res)
+	require.NoError(t, err)
+	cs.Bindings[0].ResourceConfigJson = resJSON
+
+	// Initial backfill
+	tb.Insert(ctx, t, tableName, [][]any{{0, "zero"}, {1, "one"}, {2, "two"}})
+	cs.Capture(ctx, t, nil)
+
+	// Some replication
+	tb.Insert(ctx, t, tableName, [][]any{{3, "three"}, {4, "four"}, {5, "five"}})
+	cs.Capture(ctx, t, nil)
+
+	// Primary key updates
+	tb.Update(ctx, t, tableName, "id", 1, "id", 6)
+	tb.Update(ctx, t, tableName, "id", 4, "id", 7)
+	cs.Capture(ctx, t, nil)
+
+	cupaloy.SnapshotT(t, cs.Summary())
+}


### PR DESCRIPTION
**Description:**

We recently (in https://github.com/estuary/connectors/pull/2185) added some logic to `source-mysql` which detects row update events which modify the collection key of the row. Or more pedantically, it detects row updates which modify the value of "whatever columns we consider the row key to be made of", which is almost always the collection key.

_(We play a little fast-and-loose with the concepts at times and it works out because in practice nobody ever sets the collection key to something other than the source DB primary key or tries to tells us to backfill using some other key distinct from the collection key. In fact we should probably deprecate the ability to have a backfill key distinct from the collection key since it's an undocumented backwards-compatibility feature from years ago and I bet nobody is actually using it)._

This distinction matters because in the past bindings with the `"Only Changes"` backfill mode haven't needed to care what the backfill key / scan key / collection key / whatever-you-want-to-call-it is set to, and so we haven't even initialized that state property for such bindings. They go straight from pending to active and don't set `KeyColumns` along the way.

But now, we need to detect update events which modify the row's key, even if they're on an `"Only Changes"` binding. This means that either we need to add entirely new plumbing into the replication logic for "what properties correspond to the collection key", or we need to just accept that this is already what `KeyColumns` holds and therefore it's a bug that we're not setting it on only-changes bindings.

I have opted to go with the latter solution because it's simpler and feels more elegant anyway.

**Workflow steps:**

No user action is required, and the new primary-key update logic in MySQL should now work reliably for only-changes bindings going forward.

**Notes for reviewers:**


This PR is pretty small but if you find it at all confusing it might be clearer when viewed commit-by-commit. It has three parts:

1. A test case demonstrating the issue and eventual fixed behavior.
2. A small refactoring of the `activatePendingStreams` so that any future only-changes bindings will have a correctly initialized `KeyColumns` property.
3. A bit of temporary migration logic in `reconcileStateWithBindings` which identifies preexisting only-changes bindings which are already active with a nil `KeyColumns` and fills in the appropriate value. This can be removed in the near future after it's had a chance to run everywhere that matters.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2201)
<!-- Reviewable:end -->
