### PR TITLE
source-postgres: Support CDC without watermarks

### DIFF
--- a/source-postgres/.snapshots/TestGeneric-SpecResponse
+++ b/source-postgres/.snapshots/TestGeneric-SpecResponse
@@ -93,6 +93,11 @@
             "title": "Minimum Backfill XID",
             "description": "Only backfill rows with XMIN values greater (in a 32-bit modular comparison) than the specified XID. Helpful for reducing re-backfill data volume in certain edge cases.",
             "pattern": "^[0-9]+$"
+          },
+          "read_only_capture": {
+            "type": "boolean",
+            "title": "Read-Only Capture",
+            "description": "When set the capture will operate in read-only mode and avoid operations such as watermark writes. This comes with some tradeoffs; consult the connector documentation for more information."
           }
         },
         "additionalProperties": false,

--- a/source-postgres/Dockerfile
+++ b/source-postgres/Dockerfile
@@ -23,7 +23,7 @@ ENV PATH="/builder/bin:$PATH"
 ARG TEST_DATABASE=yes
 ENV TEST_DATABASE=$TEST_DATABASE
 ENV CI_BUILD=yes
-RUN go test -short -failfast -v ./source-postgres/... --db_address=localhost:5432
+RUN go test -short -failfast -v ./source-postgres/... --db_control_address=localhost:5432  --db_capture_address=localhost:5432
 
 # Build the connector.
 RUN --mount=type=cache,id=gomod,target=/go/pkg/mod \

--- a/source-postgres/capture_test.go
+++ b/source-postgres/capture_test.go
@@ -87,6 +87,19 @@ func TestSlotLSNAdvances(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping test in short mode.")
 	}
+	if *dbCaptureAddress != *dbControlAddress {
+		// If the database used for test control operations is not the same database
+		// we're capturing from (that is, we're testing some sort of replicated setup)
+		// then issuing a query against pg_replication_slots using the test control
+		// connection won't tell us whether the replica slot is advancing, so this
+		// test will fail even if it's working correctly.
+		//
+		// In theory the test could be rewritten to establish a temporary control
+		// connection to the capture database and check there, but it's not worth
+		// the effort in general since we know this logic works in non-replicated
+		// setups and I've verified it manually in the standby replica scenario.
+		t.Skip("skipping test in replicated test scenario")
+	}
 
 	var tb, ctx = postgresTestBackend(t), context.Background()
 	var uniqueID = "99718274"

--- a/source-postgres/database.go
+++ b/source-postgres/database.go
@@ -86,10 +86,10 @@ func recreateReplicationSlot(ctx context.Context, conn *pgx.Conn, slotName strin
 
 // queryLatestServerLSN returns the latest server WAL LSN.
 func queryLatestServerLSN(ctx context.Context, conn *pgx.Conn) (pglogrepl.LSN, error) {
-	var query = "SELECT pg_current_wal_lsn()"
+	var query = "SELECT pg_current_wal_flush_lsn()"
 	var currentLSN pglogrepl.LSN
 	if err := conn.QueryRow(ctx, query).Scan(&currentLSN); err != nil {
-		return 0, fmt.Errorf("error querying current WAL LSN: %w", err)
+		return 0, fmt.Errorf("error querying current WAL flush LSN: %w", err)
 	}
 	return currentLSN, nil
 }

--- a/source-postgres/database.go
+++ b/source-postgres/database.go
@@ -83,3 +83,13 @@ func recreateReplicationSlot(ctx context.Context, conn *pgx.Conn, slotName strin
 	}
 	return createReplicationSlot(ctx, conn, slotName)
 }
+
+// queryLatestServerLSN returns the latest server WAL LSN.
+func queryLatestServerLSN(ctx context.Context, conn *pgx.Conn) (pglogrepl.LSN, error) {
+	var query = "SELECT pg_current_wal_lsn()"
+	var currentLSN pglogrepl.LSN
+	if err := conn.QueryRow(ctx, query).Scan(&currentLSN); err != nil {
+		return 0, fmt.Errorf("error querying current WAL LSN: %w", err)
+	}
+	return currentLSN, nil
+}

--- a/source-postgres/main.go
+++ b/source-postgres/main.go
@@ -105,6 +105,7 @@ type advancedConfig struct {
 	DiscoverSchemas       []string `json:"discover_schemas,omitempty" jsonschema:"title=Discovery Schema Selection,description=If this is specified only tables in the selected schema(s) will be automatically discovered. Omit all entries to discover tables from all schemas."`
 	DiscoverOnlyPublished bool     `json:"discover_only_published,omitempty" jsonschema:"title=Discover Only Published Tables,description=When set the capture will only discover tables which have already been added to the publication. This can be useful if you intend to manage which tables are captured by adding or removing them from the publication."`
 	MinimumBackfillXID    string   `json:"min_backfill_xid,omitempty" jsonschema:"title=Minimum Backfill XID,description=Only backfill rows with XMIN values greater (in a 32-bit modular comparison) than the specified XID. Helpful for reducing re-backfill data volume in certain edge cases." jsonschema_extras:"pattern=^[0-9]+$"`
+	ReadOnlyCapture       bool     `json:"read_only_capture,omitempty" jsonschema:"title=Read-Only Capture,description=When set the capture will operate in read-only mode and avoid operations such as watermark writes. This comes with some tradeoffs; consult the connector documentation for more information."`
 }
 
 // Validate checks that the configuration possesses all required properties.

--- a/source-postgres/main_test.go
+++ b/source-postgres/main_test.go
@@ -106,7 +106,7 @@ func (tb *testBackend) CaptureSpec(ctx context.Context, t testing.TB, streamMatc
 	var sanitizers = make(map[string]*regexp.Regexp)
 	sanitizers[`"<TIMESTAMP>"`] = regexp.MustCompile(`"[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(\.[0-9]+)?(Z|-[0-9]+:[0-9]+)"`)
 	sanitizers[`"loc":[11111111,11111111,11111111]`] = regexp.MustCompile(`"loc":\[(-1|[0-9]+),[0-9]+,[0-9]+\]`)
-	sanitizers[`"cursor":"0/1111111"`] = regexp.MustCompile(`"cursor":"0/[0-9A-F]+"`)
+	sanitizers[`"cursor":"0/1111111"`] = regexp.MustCompile(`"cursor":"[0-9A-F]+/[0-9A-F]+"`)
 	sanitizers[`"ts_ms":1111111111111`] = regexp.MustCompile(`"ts_ms":[0-9]+`)
 	sanitizers[`"txid":111111`] = regexp.MustCompile(`"txid":[0-9]+`)
 

--- a/source-postgres/main_test.go
+++ b/source-postgres/main_test.go
@@ -158,7 +158,7 @@ func (tb *testBackend) Insert(ctx context.Context, t testing.TB, table string, r
 	if err != nil {
 		t.Fatalf("unable to begin transaction: %v", err)
 	}
-	log.WithFields(log.Fields{"table": table, "count": len(rows), "first": rows[0]}).Debug("inserting data")
+	log.WithFields(log.Fields{"table": table, "count": len(rows)}).Debug("inserting data")
 	var query = fmt.Sprintf(`INSERT INTO %s VALUES %s`, table, argsTuple(len(rows[0])))
 	for _, row := range rows {
 		log.WithFields(log.Fields{"table": table, "row": row}).Trace("inserting row")

--- a/source-postgres/replication.go
+++ b/source-postgres/replication.go
@@ -370,16 +370,6 @@ func (s *replicationStream) StreamToFence(ctx context.Context, fenceAfter time.D
 }
 
 func (s *replicationStream) StartReplication(ctx context.Context, discovery map[sqlcapture.StreamID]*sqlcapture.DiscoveryInfo) error {
-	// Activate replication for the watermarks table.
-	var watermarks = s.db.config.Advanced.WatermarksTable
-	var watermarksInfo = discovery[watermarks]
-	if watermarksInfo == nil {
-		return fmt.Errorf("error activating replication for watermarks table %q: table missing from latest autodiscovery", watermarks)
-	}
-	if err := s.ActivateTable(ctx, watermarks, watermarksInfo.PrimaryKey, watermarksInfo, nil); err != nil {
-		return fmt.Errorf("error activating replication for watermarks table %q: %w", watermarks, err)
-	}
-
 	var streamCtx, streamCancel = context.WithCancel(ctx)
 	s.events = make(chan sqlcapture.DatabaseEvent, replicationBufferSize)
 	s.errCh = make(chan error)


### PR DESCRIPTION
**Description:**

This PR replaces the PostgreSQL CDC fence logic which was previously based on detection of our own watermark writes with some new (actually heavily copied from MySQL) fence logic based entirely on WAL LSN positions.

However by default we still write a watermark as part of establishing a fence position, in order to guarantee that there will be at least one WAL event whose LSN is greater than the minimum fence LSN. So the other half of this PR was adding a new advanced setting (`"Read-Only Capture"`) which disables that behavior.

Disabling watermark writes is not without its tradeoffs. Put simply, due to the way Postgres reorders and cleans up the underlying WAL events when doing logical replication, we can't always guarantee that the latest LSN value obtained from `pg_current_wal_flush_lsn()` (or any of its sibling functions) actually corresponds to an event which we'll be told about. This can most trivially be proven when you consider the situation of an idle database on a server which hosts other active databases, but it's actually possible to run into similar trouble even when there's just the one database on the server. So when enabling read-only mode one must be sure that the server will always have a modest rate of changes on the database which is being captured from.

But the upshot is that we can now run captures without any "writes" to the database (so long as you don't consider replication slot management a write, because that's unavoidable) and it's even possible to capture from read-only standby replicas (with a big big big asterisk that says "except sometimes those setups can be very prone to invalidating replication slots if there's even a tiny bit of downtime"). Yay.

**Workflow steps:**

To continue using the connector as before, no action is required. The change from watermark value detection to LSN position fencing should be invisible to users, and we still by default write watermarks at the same cadence as before.

To set up a new capture which doesn't write watermarks, enable the "Read-Only Capture" toggle in the advanced endpoint config.

**Documentation links affected:**

We will need to update PostgreSQL documentation to discuss the new option and the user's responsibility to ensure that the database won't be fully idle when using it.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2202)
<!-- Reviewable:end -->
