### PR TITLE
source-genesys: fix `conversations` default param bug

### DIFF
--- a/source-genesys/source_genesys/api.py
+++ b/source-genesys/source_genesys/api.py
@@ -87,13 +87,17 @@ async def _perform_conversation_job(
         domain: str,
         log: Logger,
         start_date: datetime,
-        end_date: datetime = datetime.now(tz=UTC),
+        end_date: datetime | None = None,
 ) -> AsyncGenerator[Conversation, None]:
     """
     Requests the Genesys API to perform an async job & paginates through the results.
 
     API docs - https://developer.genesys.cloud/routing/conversations/conversations-apis#post-api-v2-analytics-conversations-details-jobs
     """
+
+    if end_date is None:
+        end_date = datetime.now(tz=UTC)
+
     # Submit job.
     url = f"{COMMON_API}.{domain}/api/v2/analytics/conversations/details/jobs"
     body = {


### PR DESCRIPTION
**Description:**

In Python, default parameters are evaluated once when the function definition is executed ([source](https://docs.python.org/3/reference/compound_stmts.html#function-definitions)). This means that a default param of `datetime.now(tz=UTC)` is only evaluated when the program starts up, and that same value is used for each subsequent function call. Meaning that within the connector, `_perform_conversation_job` was using a fixed end date and not incrementing it over time.

Now, a default value of `None` is used in `_perform_conversation_job` to indicate that the current time should be used as the end date.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

Tested on a local stack. Confirmed that not providing an `end_date` argument for `_perform_conversation_job` will cause `end_date` to be the current datetime instead of when the connector last restarted.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2218)
<!-- Reviewable:end -->
