### PR TITLE
source-*-batch: Add missing network-tunnel binary

### DIFF
--- a/source-bigquery-batch/Dockerfile
+++ b/source-bigquery-batch/Dockerfile
@@ -31,6 +31,7 @@ ENV PATH="/connector:$PATH"
 
 # Bring in the compiled connector artifact from the builder.
 COPY --from=builder /builder/connector ./source-bigquery-batch
+COPY --from=ghcr.io/estuary/network-tunnel:dev /flow-network-tunnel /usr/bin/flow-network-tunnel
 
 LABEL FLOW_RUNTIME_PROTOCOL=capture
 LABEL CONNECTOR_PROTOCOL=flow-capture

--- a/source-mysql-batch/Dockerfile
+++ b/source-mysql-batch/Dockerfile
@@ -31,6 +31,7 @@ ENV PATH="/connector:$PATH"
 
 # Bring in the compiled connector artifact from the builder.
 COPY --from=builder /builder/connector ./source-mysql-batch
+COPY --from=ghcr.io/estuary/network-tunnel:dev /flow-network-tunnel /usr/bin/flow-network-tunnel
 
 LABEL FLOW_RUNTIME_PROTOCOL=capture
 LABEL CONNECTOR_PROTOCOL=flow-capture

--- a/source-postgres-batch/Dockerfile
+++ b/source-postgres-batch/Dockerfile
@@ -32,6 +32,7 @@ ENV PATH="/connector:$PATH"
 
 # Bring in the compiled connector artifact from the builder.
 COPY --from=builder /builder/connector ./source-postgres-batch
+COPY --from=ghcr.io/estuary/network-tunnel:dev /flow-network-tunnel /usr/bin/flow-network-tunnel
 
 LABEL FLOW_RUNTIME_PROTOCOL=capture
 LABEL CONNECTOR_PROTOCOL=flow-capture

--- a/source-redshift-batch/Dockerfile
+++ b/source-redshift-batch/Dockerfile
@@ -32,6 +32,7 @@ ENV PATH="/connector:$PATH"
 
 # Bring in the compiled connector artifact from the builder.
 COPY --from=builder /builder/connector ./source-redshift-batch
+COPY --from=ghcr.io/estuary/network-tunnel:dev /flow-network-tunnel /usr/bin/flow-network-tunnel
 
 LABEL FLOW_RUNTIME_PROTOCOL=capture
 LABEL CONNECTOR_PROTOCOL=flow-capture


### PR DESCRIPTION
**Description:**

Left this out of https://github.com/estuary/connectors/pull/2190 by mistake.

**Workflow steps:**

Using network tunneling with a batch SQL capture ought to work now.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2219)
<!-- Reviewable:end -->
