### PR TITLE
source-hubspot-native: conditionally discover `email_events` binding

### DIFF
--- a/source-hubspot-native/tests/snapshots/snapshots__discover__stdout.json
+++ b/source-hubspot-native/tests/snapshots/snapshots__discover__stdout.json
@@ -1479,94 +1479,6 @@
     ]
   },
   {
-    "recommendedName": "email_events",
-    "resourceConfig": {
-      "name": "email_events"
-    },
-    "documentSchema": {
-      "$defs": {
-        "Meta": {
-          "properties": {
-            "op": {
-              "default": "u",
-              "description": "Operation type (c: Create, u: Update, d: Delete)",
-              "enum": [
-                "c",
-                "u",
-                "d"
-              ],
-              "title": "Op",
-              "type": "string"
-            },
-            "row_id": {
-              "default": -1,
-              "description": "Row ID of the Document, counting up from zero, or -1 if not known",
-              "title": "Row Id",
-              "type": "integer"
-            }
-          },
-          "title": "Meta",
-          "type": "object"
-        }
-      },
-      "additionalProperties": true,
-      "properties": {
-        "_meta": {
-          "allOf": [
-            {
-              "$ref": "#/$defs/Meta"
-            }
-          ],
-          "default": {
-            "op": "u",
-            "row_id": -1
-          },
-          "description": "Document metadata"
-        },
-        "id": {
-          "title": "Id",
-          "type": "string"
-        },
-        "created": {
-          "format": "date-time",
-          "title": "Created",
-          "type": "string"
-        },
-        "type": {
-          "enum": [
-            "SENT",
-            "DROPPED",
-            "PROCESSED",
-            "DELIVERED",
-            "DEFERRED",
-            "BOUNCE",
-            "OPEN",
-            "CLICK",
-            "PRINT",
-            "FORWARD",
-            "STATUSCHANGE",
-            "SPAMREPORT",
-            "SUPPRESSED",
-            "SUPPRESSION",
-            "UNBOUNCE"
-          ],
-          "title": "Type",
-          "type": "string"
-        }
-      },
-      "required": [
-        "id",
-        "created"
-      ],
-      "title": "EmailEvent",
-      "type": "object",
-      "x-infer-schema": true
-    },
-    "key": [
-      "/id"
-    ]
-  },
-  {
     "recommendedName": "deal_pipelines",
     "resourceConfig": {
       "name": "deal_pipelines",
@@ -1730,6 +1642,94 @@
     },
     "key": [
       "/_meta/row_id"
+    ]
+  },
+  {
+    "recommendedName": "email_events",
+    "resourceConfig": {
+      "name": "email_events"
+    },
+    "documentSchema": {
+      "$defs": {
+        "Meta": {
+          "properties": {
+            "op": {
+              "default": "u",
+              "description": "Operation type (c: Create, u: Update, d: Delete)",
+              "enum": [
+                "c",
+                "u",
+                "d"
+              ],
+              "title": "Op",
+              "type": "string"
+            },
+            "row_id": {
+              "default": -1,
+              "description": "Row ID of the Document, counting up from zero, or -1 if not known",
+              "title": "Row Id",
+              "type": "integer"
+            }
+          },
+          "title": "Meta",
+          "type": "object"
+        }
+      },
+      "additionalProperties": true,
+      "properties": {
+        "_meta": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/Meta"
+            }
+          ],
+          "default": {
+            "op": "u",
+            "row_id": -1
+          },
+          "description": "Document metadata"
+        },
+        "id": {
+          "title": "Id",
+          "type": "string"
+        },
+        "created": {
+          "format": "date-time",
+          "title": "Created",
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "SENT",
+            "DROPPED",
+            "PROCESSED",
+            "DELIVERED",
+            "DEFERRED",
+            "BOUNCE",
+            "OPEN",
+            "CLICK",
+            "PRINT",
+            "FORWARD",
+            "STATUSCHANGE",
+            "SPAMREPORT",
+            "SUPPRESSED",
+            "SUPPRESSION",
+            "UNBOUNCE"
+          ],
+          "title": "Type",
+          "type": "string"
+        }
+      },
+      "required": [
+        "id",
+        "created"
+      ],
+      "title": "EmailEvent",
+      "type": "object",
+      "x-infer-schema": true
+    },
+    "key": [
+      "/id"
     ]
   }
 ]


### PR DESCRIPTION
**Description:**

Not all HubSpot accounts have enough permissions to access the endpoint for the `email_events` binding. This binding is now discovered only if we can successfully hit the associated endpoint without a permissions error.

The permissions checking code isn't very reusable, but it can be refactored later if/when the connector needs to conditionally discover other bindings.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

Tested on a local stack. Confirmed that `email_events` is discovered if a user's HubSpot account has the appropriate permissions, and `email_events` is not discovered if the user's HubSpot account does not have the appropriate permissions.

Existing captures that have `email_events` enabled but whose tokens do not have the appropriate permissions should either disable the `email_events` binding or perform discoveries to remove `email_events` as a possible binding. The latter will likely be handled by auto-discovers.

The discover snapshot change is expected since the order of the bindings returned by `all_resources` has changed (`email_events` is now at the end of the list).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2222)
<!-- Reviewable:end -->
