### PR TITLE
kafka: SASL mechanism must have a dash between before numbers

### DIFF
--- a/materialize-kafka/src/configuration.rs
+++ b/materialize-kafka/src/configuration.rs
@@ -34,7 +34,9 @@ pub enum Credentials {
 #[serde(rename_all = "SCREAMING-KEBAB-CASE")]
 pub enum SaslMechanism {
     Plain,
+    #[serde(rename = "SCRAM-SHA-256")]
     ScramSha256,
+    #[serde(rename = "SCRAM-SHA-512")]
     ScramSha512,
 }
 

--- a/source-kafka/src/configuration.rs
+++ b/source-kafka/src/configuration.rs
@@ -34,7 +34,9 @@ pub enum Credentials {
 #[serde(rename_all = "SCREAMING-KEBAB-CASE")]
 pub enum SaslMechanism {
     Plain,
+    #[serde(rename = "SCRAM-SHA-256")]
     ScramSha256,
+    #[serde(rename = "SCRAM-SHA-512")]
     ScramSha512,
 }
 


### PR DESCRIPTION
**Description:**

It seems SCREAMING-KEBAB-CASE does not put a dash before numbers. Tested by running `cargo test` with a `test.flow.yaml` file that had `credentials.mechanism: SCRAM-SHA-256` and verified with this PR the error no longer appears

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2231)
<!-- Reviewable:end -->
