### PR TITLE
source-stripe-native: fix `Accounts` related bugs

### DIFF
--- a/source-stripe-native/source_stripe_native/api.py
+++ b/source-stripe-native/source_stripe_native/api.py
@@ -340,7 +340,19 @@ async def _capture_substreams(
 
     # Fetch child records
     while True:
-        if cls_child.NAME == "Persons" and parent_data.controller["requirement_collection"] == "stripe" :
+        # Per the Stripe docs, Persons can't be accessed for accounts where `account.controller.requirement_collection` is "stripe". It also
+        # appears that when `account.controller.type` is "account", then Persons can't be accessed. This handling may need refined further
+        # if we encounter further access issues and our understanding of the Stripe API deepens.
+        # Docs reference: https://docs.stripe.com/api/persons
+        if (
+                cls_child.NAME == "Persons" and
+                parent_data.controller["type"] == "account"
+            ) or (
+                cls_child.NAME == "Persons" and 
+                "requirement_collection" in parent_data.controller and
+                parent_data.controller["requirement_collection"] is not None and 
+                parent_data.controller["requirement_collection"] == "stripe"
+            ):
             break
 
         try:

--- a/source-stripe-native/tests/snapshots/snapshots__capture__stdout.json
+++ b/source-stripe-native/tests/snapshots/snapshots__capture__stdout.json
@@ -884,6 +884,7 @@
       "on_behalf_of": null,
       "order": null,
       "outcome": {
+        "advice_code": null,
         "network_advice_code": null,
         "network_decline_code": null,
         "network_status": "approved_by_network",
@@ -927,10 +928,12 @@
           "network_token": {
             "used": false
           },
+          "network_transaction_id": "827397491047011",
           "overcapture": {
             "maximum_amount_capturable": 1000,
             "status": "unavailable"
           },
+          "regulated_status": "unregulated",
           "three_d_secure": null,
           "wallet": null
         },
@@ -999,6 +1002,7 @@
       "on_behalf_of": null,
       "order": null,
       "outcome": {
+        "advice_code": null,
         "network_advice_code": null,
         "network_decline_code": null,
         "network_status": "approved_by_network",
@@ -1042,10 +1046,12 @@
           "network_token": {
             "used": false
           },
+          "network_transaction_id": "827397491047011",
           "overcapture": {
             "maximum_amount_capturable": 1000,
             "status": "unavailable"
           },
+          "regulated_status": "unregulated",
           "three_d_secure": null,
           "wallet": null
         },
@@ -1114,6 +1120,7 @@
       "on_behalf_of": null,
       "order": null,
       "outcome": {
+        "advice_code": null,
         "network_advice_code": null,
         "network_decline_code": null,
         "network_status": "approved_by_network",
@@ -1157,10 +1164,12 @@
           "network_token": {
             "used": false
           },
+          "network_transaction_id": "827397491047011",
           "overcapture": {
             "maximum_amount_capturable": 23000,
             "status": "unavailable"
           },
+          "regulated_status": "unregulated",
           "three_d_secure": null,
           "wallet": null
         },
@@ -1229,6 +1238,7 @@
       "on_behalf_of": null,
       "order": null,
       "outcome": {
+        "advice_code": null,
         "network_advice_code": null,
         "network_decline_code": null,
         "network_status": "approved_by_network",
@@ -1272,10 +1282,12 @@
           "network_token": {
             "used": false
           },
+          "network_transaction_id": "681224810881551",
           "overcapture": {
             "maximum_amount_capturable": 4500,
             "status": "unavailable"
           },
+          "regulated_status": "unregulated",
           "three_d_secure": null,
           "wallet": null
         },
@@ -1344,6 +1356,7 @@
       "on_behalf_of": null,
       "order": null,
       "outcome": {
+        "advice_code": "try_again_later",
         "network_advice_code": null,
         "network_decline_code": null,
         "network_status": "declined_by_network",
@@ -1387,10 +1400,12 @@
           "network_token": {
             "used": false
           },
+          "network_transaction_id": "679079100110708",
           "overcapture": {
             "maximum_amount_capturable": 104000,
             "status": "unavailable"
           },
+          "regulated_status": "unregulated",
           "three_d_secure": null,
           "wallet": null
         },
@@ -1459,6 +1474,7 @@
       "on_behalf_of": null,
       "order": null,
       "outcome": {
+        "advice_code": "try_again_later",
         "network_advice_code": null,
         "network_decline_code": null,
         "network_status": "declined_by_network",
@@ -1502,10 +1518,12 @@
           "network_token": {
             "used": false
           },
+          "network_transaction_id": "679079100110708",
           "overcapture": {
             "maximum_amount_capturable": 104000,
             "status": "unavailable"
           },
+          "regulated_status": "unregulated",
           "three_d_secure": null,
           "wallet": null
         },
@@ -1574,6 +1592,7 @@
       "on_behalf_of": null,
       "order": null,
       "outcome": {
+        "advice_code": "try_again_later",
         "network_advice_code": null,
         "network_decline_code": null,
         "network_status": "declined_by_network",
@@ -1617,10 +1636,12 @@
           "network_token": {
             "used": false
           },
+          "network_transaction_id": "122781025487112",
           "overcapture": {
             "maximum_amount_capturable": 104000,
             "status": "unavailable"
           },
+          "regulated_status": "unregulated",
           "three_d_secure": null,
           "wallet": null
         },
@@ -1689,6 +1710,7 @@
       "on_behalf_of": null,
       "order": null,
       "outcome": {
+        "advice_code": null,
         "network_advice_code": null,
         "network_decline_code": null,
         "network_status": "not_sent_to_network",
@@ -1733,10 +1755,12 @@
           "network_token": {
             "used": false
           },
+          "network_transaction_id": "901181049710011",
           "overcapture": {
             "maximum_amount_capturable": 300,
             "status": "unavailable"
           },
+          "regulated_status": "unregulated",
           "three_d_secure": null,
           "wallet": null
         },
@@ -1805,6 +1829,7 @@
       "on_behalf_of": null,
       "order": null,
       "outcome": {
+        "advice_code": null,
         "network_advice_code": null,
         "network_decline_code": null,
         "network_status": "not_sent_to_network",
@@ -1849,10 +1874,12 @@
           "network_token": {
             "used": false
           },
+          "network_transaction_id": "901181049710011",
           "overcapture": {
             "maximum_amount_capturable": 300,
             "status": "unavailable"
           },
+          "regulated_status": "unregulated",
           "three_d_secure": null,
           "wallet": null
         },
@@ -1921,6 +1948,7 @@
       "on_behalf_of": null,
       "order": null,
       "outcome": {
+        "advice_code": null,
         "network_advice_code": null,
         "network_decline_code": null,
         "network_status": "approved_by_network",
@@ -1965,10 +1993,12 @@
           "network_token": {
             "used": false
           },
+          "network_transaction_id": "486510374104685",
           "overcapture": {
             "maximum_amount_capturable": 300,
             "status": "unavailable"
           },
+          "regulated_status": "unregulated",
           "three_d_secure": null,
           "wallet": null
         },
@@ -2037,6 +2067,7 @@
       "on_behalf_of": null,
       "order": null,
       "outcome": {
+        "advice_code": null,
         "network_advice_code": null,
         "network_decline_code": null,
         "network_status": "approved_by_network",
@@ -2080,10 +2111,12 @@
           "network_token": {
             "used": false
           },
+          "network_transaction_id": "777611781103110",
           "overcapture": {
             "maximum_amount_capturable": 1200,
             "status": "unavailable"
           },
+          "regulated_status": "unregulated",
           "three_d_secure": null,
           "wallet": null
         },
@@ -2152,6 +2185,7 @@
       "on_behalf_of": null,
       "order": null,
       "outcome": {
+        "advice_code": null,
         "network_advice_code": null,
         "network_decline_code": null,
         "network_status": "approved_by_network",
@@ -2195,10 +2229,12 @@
           "network_token": {
             "used": false
           },
+          "network_transaction_id": "531099911175113",
           "overcapture": {
             "maximum_amount_capturable": 1200,
             "status": "unavailable"
           },
+          "regulated_status": "unregulated",
           "three_d_secure": null,
           "wallet": null
         },
@@ -2267,6 +2303,7 @@
       "on_behalf_of": null,
       "order": null,
       "outcome": {
+        "advice_code": null,
         "network_advice_code": null,
         "network_decline_code": null,
         "network_status": "approved_by_network",
@@ -2310,10 +2347,12 @@
           "network_token": {
             "used": false
           },
+          "network_transaction_id": "486510374104685",
           "overcapture": {
             "maximum_amount_capturable": 3400,
             "status": "unavailable"
           },
+          "regulated_status": "unregulated",
           "three_d_secure": null,
           "wallet": null
         },
@@ -2382,6 +2421,7 @@
       "on_behalf_of": null,
       "order": null,
       "outcome": {
+        "advice_code": null,
         "network_advice_code": null,
         "network_decline_code": null,
         "network_status": "approved_by_network",
@@ -2425,10 +2465,12 @@
           "network_token": {
             "used": false
           },
+          "network_transaction_id": "827397491047011",
           "overcapture": {
             "maximum_amount_capturable": 1000,
             "status": "unavailable"
           },
+          "regulated_status": "unregulated",
           "three_d_secure": null,
           "wallet": null
         },
@@ -2497,6 +2539,7 @@
       "on_behalf_of": null,
       "order": null,
       "outcome": {
+        "advice_code": null,
         "network_advice_code": null,
         "network_decline_code": null,
         "network_status": "approved_by_network",
@@ -2540,10 +2583,12 @@
           "network_token": {
             "used": false
           },
+          "network_transaction_id": "827397491047011",
           "overcapture": {
             "maximum_amount_capturable": 1000,
             "status": "unavailable"
           },
+          "regulated_status": "unregulated",
           "three_d_secure": null,
           "wallet": null
         },
@@ -2612,6 +2657,7 @@
       "on_behalf_of": null,
       "order": null,
       "outcome": {
+        "advice_code": null,
         "network_advice_code": null,
         "network_decline_code": null,
         "network_status": "approved_by_network",
@@ -2655,10 +2701,12 @@
           "network_token": {
             "used": false
           },
+          "network_transaction_id": "827397491047011",
           "overcapture": {
             "maximum_amount_capturable": 1000,
             "status": "unavailable"
           },
+          "regulated_status": "unregulated",
           "three_d_secure": null,
           "wallet": null
         },
@@ -2727,6 +2775,7 @@
       "on_behalf_of": null,
       "order": null,
       "outcome": {
+        "advice_code": null,
         "network_advice_code": null,
         "network_decline_code": null,
         "network_status": "approved_by_network",
@@ -2770,10 +2819,12 @@
           "network_token": {
             "used": false
           },
+          "network_transaction_id": "827397491047011",
           "overcapture": {
             "maximum_amount_capturable": 1000,
             "status": "unavailable"
           },
+          "regulated_status": "unregulated",
           "three_d_secure": null,
           "wallet": null
         },
@@ -2842,6 +2893,7 @@
       "on_behalf_of": null,
       "order": null,
       "outcome": {
+        "advice_code": null,
         "network_advice_code": null,
         "network_decline_code": null,
         "network_status": "approved_by_network",
@@ -2885,10 +2937,12 @@
           "network_token": {
             "used": false
           },
+          "network_transaction_id": "827397491047011",
           "overcapture": {
             "maximum_amount_capturable": 1000,
             "status": "unavailable"
           },
+          "regulated_status": "unregulated",
           "three_d_secure": null,
           "wallet": null
         },
@@ -2957,6 +3011,7 @@
       "on_behalf_of": null,
       "order": null,
       "outcome": {
+        "advice_code": null,
         "network_advice_code": null,
         "network_decline_code": null,
         "network_status": "approved_by_network",
@@ -3000,10 +3055,12 @@
           "network_token": {
             "used": false
           },
+          "network_transaction_id": "827397491047011",
           "overcapture": {
             "maximum_amount_capturable": 1000,
             "status": "unavailable"
           },
+          "regulated_status": "unregulated",
           "three_d_secure": null,
           "wallet": null
         },
@@ -3072,6 +3129,7 @@
       "on_behalf_of": null,
       "order": null,
       "outcome": {
+        "advice_code": null,
         "network_advice_code": null,
         "network_decline_code": null,
         "network_status": "approved_by_network",
@@ -3115,10 +3173,12 @@
           "network_token": {
             "used": false
           },
+          "network_transaction_id": "827397491047011",
           "overcapture": {
             "maximum_amount_capturable": 1000,
             "status": "unavailable"
           },
+          "regulated_status": "unregulated",
           "three_d_secure": null,
           "wallet": null
         },
@@ -3187,6 +3247,7 @@
       "on_behalf_of": null,
       "order": null,
       "outcome": {
+        "advice_code": null,
         "network_advice_code": null,
         "network_decline_code": null,
         "network_status": "approved_by_network",
@@ -3230,10 +3291,12 @@
           "network_token": {
             "used": false
           },
+          "network_transaction_id": "827397491047011",
           "overcapture": {
             "maximum_amount_capturable": 1000,
             "status": "unavailable"
           },
+          "regulated_status": "unregulated",
           "three_d_secure": null,
           "wallet": null
         },
@@ -3302,6 +3365,7 @@
       "on_behalf_of": null,
       "order": null,
       "outcome": {
+        "advice_code": null,
         "network_advice_code": null,
         "network_decline_code": null,
         "network_status": "approved_by_network",
@@ -3345,10 +3409,12 @@
           "network_token": {
             "used": false
           },
+          "network_transaction_id": "827397491047011",
           "overcapture": {
             "maximum_amount_capturable": 1000,
             "status": "unavailable"
           },
+          "regulated_status": "unregulated",
           "three_d_secure": null,
           "wallet": null
         },
@@ -3417,6 +3483,7 @@
       "on_behalf_of": null,
       "order": null,
       "outcome": {
+        "advice_code": null,
         "network_advice_code": null,
         "network_decline_code": null,
         "network_status": "approved_by_network",
@@ -3460,10 +3527,12 @@
           "network_token": {
             "used": false
           },
+          "network_transaction_id": "827397491047011",
           "overcapture": {
             "maximum_amount_capturable": 1000,
             "status": "unavailable"
           },
+          "regulated_status": "unregulated",
           "three_d_secure": null,
           "wallet": null
         },
@@ -3532,6 +3601,7 @@
       "on_behalf_of": null,
       "order": null,
       "outcome": {
+        "advice_code": null,
         "network_advice_code": null,
         "network_decline_code": null,
         "network_status": "approved_by_network",
@@ -3575,10 +3645,12 @@
           "network_token": {
             "used": false
           },
+          "network_transaction_id": "827397491047011",
           "overcapture": {
             "maximum_amount_capturable": 1000,
             "status": "unavailable"
           },
+          "regulated_status": "unregulated",
           "three_d_secure": null,
           "wallet": null
         },
@@ -3647,6 +3719,7 @@
       "on_behalf_of": null,
       "order": null,
       "outcome": {
+        "advice_code": null,
         "network_advice_code": null,
         "network_decline_code": null,
         "network_status": "approved_by_network",
@@ -3690,10 +3763,12 @@
           "network_token": {
             "used": false
           },
+          "network_transaction_id": "827397491047011",
           "overcapture": {
             "maximum_amount_capturable": 1000,
             "status": "unavailable"
           },
+          "regulated_status": "unregulated",
           "three_d_secure": null,
           "wallet": null
         },
@@ -3762,6 +3837,7 @@
       "on_behalf_of": null,
       "order": null,
       "outcome": {
+        "advice_code": null,
         "network_advice_code": null,
         "network_decline_code": null,
         "network_status": "approved_by_network",
@@ -3805,10 +3881,12 @@
           "network_token": {
             "used": false
           },
+          "network_transaction_id": "827397491047011",
           "overcapture": {
             "maximum_amount_capturable": 1000,
             "status": "unavailable"
           },
+          "regulated_status": "unregulated",
           "three_d_secure": null,
           "wallet": null
         },
@@ -3877,6 +3955,7 @@
       "on_behalf_of": null,
       "order": null,
       "outcome": {
+        "advice_code": null,
         "network_advice_code": null,
         "network_decline_code": null,
         "network_status": "approved_by_network",
@@ -3920,10 +3999,12 @@
           "network_token": {
             "used": false
           },
+          "network_transaction_id": "827397491047011",
           "overcapture": {
             "maximum_amount_capturable": 1000,
             "status": "unavailable"
           },
+          "regulated_status": "unregulated",
           "three_d_secure": null,
           "wallet": null
         },
@@ -3992,6 +4073,7 @@
       "on_behalf_of": null,
       "order": null,
       "outcome": {
+        "advice_code": null,
         "network_advice_code": null,
         "network_decline_code": null,
         "network_status": "approved_by_network",
@@ -4035,10 +4117,12 @@
           "network_token": {
             "used": false
           },
+          "network_transaction_id": "827397491047011",
           "overcapture": {
             "maximum_amount_capturable": 1000,
             "status": "unavailable"
           },
+          "regulated_status": "unregulated",
           "three_d_secure": null,
           "wallet": null
         },
@@ -4107,6 +4191,7 @@
       "on_behalf_of": null,
       "order": null,
       "outcome": {
+        "advice_code": null,
         "network_advice_code": null,
         "network_decline_code": null,
         "network_status": "approved_by_network",
@@ -4150,10 +4235,12 @@
           "network_token": {
             "used": false
           },
+          "network_transaction_id": "827397491047011",
           "overcapture": {
             "maximum_amount_capturable": 1000,
             "status": "unavailable"
           },
+          "regulated_status": "unregulated",
           "three_d_secure": null,
           "wallet": null
         },
@@ -4222,6 +4309,7 @@
       "on_behalf_of": null,
       "order": null,
       "outcome": {
+        "advice_code": null,
         "network_advice_code": null,
         "network_decline_code": null,
         "network_status": "approved_by_network",
@@ -4265,10 +4353,12 @@
           "network_token": {
             "used": false
           },
+          "network_transaction_id": "827397491047011",
           "overcapture": {
             "maximum_amount_capturable": 1000,
             "status": "unavailable"
           },
+          "regulated_status": "unregulated",
           "three_d_secure": null,
           "wallet": null
         },
@@ -4337,6 +4427,7 @@
       "on_behalf_of": null,
       "order": null,
       "outcome": {
+        "advice_code": null,
         "network_advice_code": null,
         "network_decline_code": null,
         "network_status": "approved_by_network",
@@ -4380,10 +4471,12 @@
           "network_token": {
             "used": false
           },
+          "network_transaction_id": "827397491047011",
           "overcapture": {
             "maximum_amount_capturable": 1000,
             "status": "unavailable"
           },
+          "regulated_status": "unregulated",
           "three_d_secure": null,
           "wallet": null
         },
@@ -4452,6 +4545,7 @@
       "on_behalf_of": null,
       "order": null,
       "outcome": {
+        "advice_code": null,
         "network_advice_code": null,
         "network_decline_code": null,
         "network_status": "approved_by_network",
@@ -4495,10 +4589,12 @@
           "network_token": {
             "used": false
           },
+          "network_transaction_id": "827397491047011",
           "overcapture": {
             "maximum_amount_capturable": 1000,
             "status": "unavailable"
           },
+          "regulated_status": "unregulated",
           "three_d_secure": null,
           "wallet": null
         },
@@ -4567,6 +4663,7 @@
       "on_behalf_of": null,
       "order": null,
       "outcome": {
+        "advice_code": null,
         "network_advice_code": null,
         "network_decline_code": null,
         "network_status": "approved_by_network",
@@ -4610,10 +4707,12 @@
           "network_token": {
             "used": false
           },
+          "network_transaction_id": "827397491047011",
           "overcapture": {
             "maximum_amount_capturable": 1000,
             "status": "unavailable"
           },
+          "regulated_status": "unregulated",
           "three_d_secure": null,
           "wallet": null
         },
@@ -4682,6 +4781,7 @@
       "on_behalf_of": null,
       "order": null,
       "outcome": {
+        "advice_code": null,
         "network_advice_code": null,
         "network_decline_code": null,
         "network_status": "approved_by_network",
@@ -4725,10 +4825,12 @@
           "network_token": {
             "used": false
           },
+          "network_transaction_id": "827397491047011",
           "overcapture": {
             "maximum_amount_capturable": 1000,
             "status": "unavailable"
           },
+          "regulated_status": "unregulated",
           "three_d_secure": null,
           "wallet": null
         },
@@ -4797,6 +4899,7 @@
       "on_behalf_of": null,
       "order": null,
       "outcome": {
+        "advice_code": null,
         "network_advice_code": null,
         "network_decline_code": null,
         "network_status": "approved_by_network",
@@ -4840,10 +4943,12 @@
           "network_token": {
             "used": false
           },
+          "network_transaction_id": "827397491047011",
           "overcapture": {
             "maximum_amount_capturable": 1000,
             "status": "unavailable"
           },
+          "regulated_status": "unregulated",
           "three_d_secure": null,
           "wallet": null
         },
@@ -4912,6 +5017,7 @@
       "on_behalf_of": null,
       "order": null,
       "outcome": {
+        "advice_code": null,
         "network_advice_code": null,
         "network_decline_code": null,
         "network_status": "approved_by_network",
@@ -4955,10 +5061,12 @@
           "network_token": {
             "used": false
           },
+          "network_transaction_id": "827397491047011",
           "overcapture": {
             "maximum_amount_capturable": 1000,
             "status": "unavailable"
           },
+          "regulated_status": "unregulated",
           "three_d_secure": null,
           "wallet": null
         },
@@ -5027,6 +5135,7 @@
       "on_behalf_of": null,
       "order": null,
       "outcome": {
+        "advice_code": null,
         "network_advice_code": null,
         "network_decline_code": null,
         "network_status": "approved_by_network",
@@ -5070,10 +5179,12 @@
           "network_token": {
             "used": false
           },
+          "network_transaction_id": "827397491047011",
           "overcapture": {
             "maximum_amount_capturable": 1000,
             "status": "unavailable"
           },
+          "regulated_status": "unregulated",
           "three_d_secure": null,
           "wallet": null
         },
@@ -5142,6 +5253,7 @@
       "on_behalf_of": null,
       "order": null,
       "outcome": {
+        "advice_code": null,
         "network_advice_code": null,
         "network_decline_code": null,
         "network_status": "approved_by_network",
@@ -5185,10 +5297,12 @@
           "network_token": {
             "used": false
           },
+          "network_transaction_id": "827397491047011",
           "overcapture": {
             "maximum_amount_capturable": 1000,
             "status": "unavailable"
           },
+          "regulated_status": "unregulated",
           "three_d_secure": null,
           "wallet": null
         },
@@ -5257,6 +5371,7 @@
       "on_behalf_of": null,
       "order": null,
       "outcome": {
+        "advice_code": null,
         "network_advice_code": null,
         "network_decline_code": null,
         "network_status": "approved_by_network",
@@ -5300,10 +5415,12 @@
           "network_token": {
             "used": false
           },
+          "network_transaction_id": "827397491047011",
           "overcapture": {
             "maximum_amount_capturable": 1000,
             "status": "unavailable"
           },
+          "regulated_status": "unregulated",
           "three_d_secure": null,
           "wallet": null
         },
@@ -5372,6 +5489,7 @@
       "on_behalf_of": null,
       "order": null,
       "outcome": {
+        "advice_code": null,
         "network_advice_code": null,
         "network_decline_code": null,
         "network_status": "approved_by_network",
@@ -5415,10 +5533,12 @@
           "network_token": {
             "used": false
           },
+          "network_transaction_id": "827397491047011",
           "overcapture": {
             "maximum_amount_capturable": 1000,
             "status": "unavailable"
           },
+          "regulated_status": "unregulated",
           "three_d_secure": null,
           "wallet": null
         },
@@ -5487,6 +5607,7 @@
       "on_behalf_of": null,
       "order": null,
       "outcome": {
+        "advice_code": null,
         "network_advice_code": null,
         "network_decline_code": null,
         "network_status": "approved_by_network",
@@ -5530,10 +5651,12 @@
           "network_token": {
             "used": false
           },
+          "network_transaction_id": "827397491047011",
           "overcapture": {
             "maximum_amount_capturable": 1000,
             "status": "unavailable"
           },
+          "regulated_status": "unregulated",
           "three_d_secure": null,
           "wallet": null
         },
@@ -5602,6 +5725,7 @@
       "on_behalf_of": null,
       "order": null,
       "outcome": {
+        "advice_code": null,
         "network_advice_code": null,
         "network_decline_code": null,
         "network_status": "approved_by_network",
@@ -5645,10 +5769,12 @@
           "network_token": {
             "used": false
           },
+          "network_transaction_id": "827397491047011",
           "overcapture": {
             "maximum_amount_capturable": 1000,
             "status": "unavailable"
           },
+          "regulated_status": "unregulated",
           "three_d_secure": null,
           "wallet": null
         },
@@ -5717,6 +5843,7 @@
       "on_behalf_of": null,
       "order": null,
       "outcome": {
+        "advice_code": null,
         "network_advice_code": null,
         "network_decline_code": null,
         "network_status": "approved_by_network",
@@ -5760,10 +5887,12 @@
           "network_token": {
             "used": false
           },
+          "network_transaction_id": "827397491047011",
           "overcapture": {
             "maximum_amount_capturable": 1000,
             "status": "unavailable"
           },
+          "regulated_status": "unregulated",
           "three_d_secure": null,
           "wallet": null
         },
@@ -5832,6 +5961,7 @@
       "on_behalf_of": null,
       "order": null,
       "outcome": {
+        "advice_code": null,
         "network_advice_code": null,
         "network_decline_code": null,
         "network_status": "approved_by_network",
@@ -5875,10 +6005,12 @@
           "network_token": {
             "used": false
           },
+          "network_transaction_id": "827397491047011",
           "overcapture": {
             "maximum_amount_capturable": 1000,
             "status": "unavailable"
           },
+          "regulated_status": "unregulated",
           "three_d_secure": null,
           "wallet": null
         },


### PR DESCRIPTION
**Description:**

The scope of this PR includes:
- Handling results that don't have a `created` field. 
  - When backfilling, the connector was relying on all results having a `created` field to determine whether the result was within the backfill timespan. However, `Accounts` results do not always have a `created` field (I assume a legacy Stripe system or Stripe support created these accounts & circumvented whatever system adds the `created` field). Since the connector can't tell otherwise without `created`, it assumes the result is within the backfill timespan and yields it.
- Improving handling for when `Persons` cannot be read for an external account.
- Handling insufficient permission errors for `ExternalBankAccount` and `ExternalAccountCards` streams if the error is due to insufficient Stripe Connect permissions.
  - From my brief research, it seems like connecting an external account to a Stripe account requires using the "Stripe Connect" feature, and it's possible to limit what data Stripe can read from this external account. If the user restricts Stripe's permissions in this way, then we receive a `403` response when trying to read the `ExternalBankAccount` and `ExternalAccountCards` streams for the account. I assume these types of restricted permissions are preferred for some users, so the connector logs a warning and continues instead of failing.
- Updating the capture snapshot to include fields that Stripe added.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

Tested on a local stack with a Stripe account that has a non-trivial number of external accounts. Confirmed:
- `Account`s without `created` fields are yielded during backfills.
- The connector does not crash when trying to read `ExternalBankAccount` and `ExternalAccountCards` and receiving a `403` response with the specific "You cannot perform this request as you do not have Platform Controls for the Stripe Dashboard on this account." message.
- The connector does not request `Persons` if we know the account is an external account & the request would fail with a `403` error.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2234)
<!-- Reviewable:end -->
