### PR TITLE
source-braintree-native: fix cursor update bug for incremental streams

### DIFF
--- a/source-braintree-native/source_braintree_native/api.py
+++ b/source-braintree-native/source_braintree_native/api.py
@@ -308,7 +308,9 @@ async def fetch_customers(
 
         if doc.created_at > log_cursor:
             yield doc
-            most_recent_created_at = doc.created_at
+
+            if doc.created_at > most_recent_created_at:
+                most_recent_created_at = doc.created_at
 
     if most_recent_created_at > log_cursor:
         yield most_recent_created_at
@@ -338,7 +340,9 @@ async def fetch_credit_card_verifications(
 
         if doc.created_at > log_cursor:
             yield doc
-            most_recent_created_at = doc.created_at
+
+            if doc.created_at > most_recent_created_at:
+                most_recent_created_at = doc.created_at
 
     if most_recent_created_at > log_cursor:
         yield most_recent_created_at
@@ -368,7 +372,9 @@ async def fetch_subscriptions(
 
         if doc.created_at > log_cursor:
             yield doc
-            most_recent_created_at = doc.created_at
+
+            if doc.created_at > most_recent_created_at:
+                most_recent_created_at = doc.created_at
 
     if most_recent_created_at > log_cursor:
         yield most_recent_created_at

--- a/source-braintree-native/tests/snapshots/snapshots__capture__capture.stdout.json
+++ b/source-braintree-native/tests/snapshots/snapshots__capture__capture.stdout.json
@@ -564,10 +564,10 @@
       "add_ons": [],
       "balance": "0.00",
       "billing_day_of_month": 26,
-      "billing_period_end_date": "2024-12-25",
-      "billing_period_start_date": "2024-11-26",
+      "billing_period_end_date": "redacted",
+      "billing_period_start_date": "redacted",
       "created_at": "2024-11-26T16:29:00Z",
-      "current_billing_cycle": 1,
+      "current_billing_cycle": 0,
       "days_past_due": null,
       "description": null,
       "descriptor": {
@@ -582,10 +582,10 @@
       "merchant_account_id": "estuary",
       "never_expires": true,
       "next_bill_amount": "11.00",
-      "next_billing_date": "2024-12-26",
+      "next_billing_date": "redacted",
       "next_billing_period_amount": "11.00",
       "number_of_billing_cycles": null,
-      "paid_through_date": "2024-12-25",
+      "paid_through_date": "redacted",
       "payment_method_token": "haq682e0",
       "plan_id": "38py",
       "price": "11.00",
@@ -941,7 +941,7 @@
       "trial_duration": null,
       "trial_duration_unit": null,
       "trial_period": false,
-      "updated_at": "2024-11-26T16:29:00Z"
+      "updated_at": "redacted"
     }
   ],
   [

--- a/source-braintree-native/tests/test_snapshots.py
+++ b/source-braintree-native/tests/test_snapshots.py
@@ -1,6 +1,14 @@
 import json
 import subprocess
 
+SUBSCRIPTION_FIELDS_TO_REDACT = [
+    'billing_period_end_date',
+    'billing_period_start_date',
+    'next_billing_date',
+    'paid_through_date',
+    'updated_at',
+]
+
 def test_capture(request, snapshot):
     result = subprocess.run(
         [
@@ -36,6 +44,13 @@ def test_capture(request, snapshot):
             for e in evidence:
                 if 'url' in e:
                     e['url'] = 'redacted'
+        if stream == 'acmeCo/subscriptions':
+            for field in SUBSCRIPTION_FIELDS_TO_REDACT:
+                rec[field] = 'redacted'
+            rec['current_billing_cycle'] = 0
+
+            rec['status_history'] = [rec['status_history'][-1]]
+            rec['transactions'] = [rec['transactions'][-1]]
 
     assert snapshot("capture.stdout.json") == unique_stream_lines
 


### PR DESCRIPTION
**Description:**

The `most_recent_created_at` bug detailed in this [PR](https://github.com/estuary/connectors/pull/2217) was also affecting other incremental streams, causing the connector to emit duplicate documents and progress very slowly through results. This PR fixes that bug for the other affected incremental streams - `customers`, `credit_card_verifications`, and `subscriptions`.

Fields within the capture snapshot test have also been redacted. These fields will change every month since they're related to subscriptions & monthly billing, so I'd rather redact them instead of updating them every month.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

Tested on a local stack. Confirmed that `customers`, `credit_card_verifications`, and `subscriptions` now yield the latest `created_at` within a search to use as the next cursor value.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2235)
<!-- Reviewable:end -->
