### PR TITLE
source-mixpanel-native: incremental `engage` & new config settings

### DIFF
--- a/source-mixpanel-native/source_mixpanel_native/source.py
+++ b/source-mixpanel-native/source_mixpanel_native/source.py
@@ -62,21 +62,23 @@ class SourceMixpanel(AbstractSource):
 
     @adapt_validate_if_testing
     def _validate_and_transform(self, config: MutableMapping[str, Any]):
-        project_timezone, start_date, end_date, attribution_window, select_properties_by_default, region, date_window_size, project_id = (
+        project_timezone, start_date, end_date, attribution_window, region, date_window_size, project_id, page_size, minimal_cohort_members_properties = (
             config.get("project_timezone", "US/Pacific"),
             config.get("start_date"),
             config.get("end_date"),
             config.get("attribution_window", 5),
-            config.get("select_properties_by_default", True),
             config.get("region", "US"),
             config.get("date_window_size", 30),
             config.get("credentials", dict()).get("project_id"),
+            config.get('advanced', {}).get('page_size', 50000),
+            config.get('advanced', {}).get("minimal_cohort_members_properties", True),
         )
+
         if region not in ("US", "EU"):
             raise_config_error("Region must be either EU or US.")
 
-        if select_properties_by_default not in (True, False, "", None):
-            raise_config_error("Please provide a valid True/False value for the `Select properties by default` parameter.")
+        if minimal_cohort_members_properties not in (True, False, "", None):
+            raise_config_error("Please provide a valid True/False value for the `Minimal Cohort Members properties` parameter.")
 
         if not isinstance(attribution_window, int) or attribution_window < 0:
             raise_config_error("Please provide a valid integer for the `Attribution window` parameter.")
@@ -94,10 +96,11 @@ class SourceMixpanel(AbstractSource):
         config["start_date"] = self.validate_date("start date", start_date, today.subtract(days=365))
         config["end_date"] = self.validate_date("end date", end_date, today)
         config["attribution_window"] = attribution_window
-        config["select_properties_by_default"] = select_properties_by_default
         config["region"] = region
         config["date_window_size"] = date_window_size
         config["project_id"] = project_id
+        config["minimal_cohort_members_properties"] = minimal_cohort_members_properties
+        config['page_size'] = page_size
 
         return config
 

--- a/source-mixpanel-native/source_mixpanel_native/spec.json
+++ b/source-mixpanel-native/source_mixpanel_native/spec.json
@@ -79,15 +79,8 @@
         "default": "US/Pacific",
         "examples": ["US/Pacific", "UTC"]
       },
-      "select_properties_by_default": {
-        "order": 4,
-        "title": "Select Properties By Default",
-        "type": "boolean",
-        "description": "Setting this config parameter to TRUE ensures that new properties on events and engage records are captured. Otherwise new properties will be ignored.",
-        "default": true
-      },
       "start_date": {
-        "order": 5,
+        "order": 4,
         "title": "Start Date",
         "type": "string",
         "description": "The date in the format YYYY-MM-DD. Any data before this date will not be replicated. If this option is not set, the connector will replicate data from up to one year ago by default.",
@@ -96,7 +89,7 @@
         "format": "date"
       },
       "end_date": {
-        "order": 6,
+        "order": 5,
         "title": "End Date",
         "type": "string",
         "description": "The date in the format YYYY-MM-DD. Any data after this date will not be replicated. Left empty to always sync to most recent date",
@@ -105,7 +98,7 @@
         "format": "date"
       },
       "region": {
-        "order": 7,
+        "order": 6,
         "title": "Region",
         "description": "The region of mixpanel domain instance either US or EU.",
         "type": "string",
@@ -113,12 +106,34 @@
         "default": "US"
       },
       "date_window_size": {
-        "order": 8,
+        "order": 7,
         "title": "Date slicing window",
         "description": "Defines window size in days, that used to slice through data. You can reduce it, if amount of data in each window is too big for your environment. (This value should be positive integer)",
         "type": "integer",
         "minimum": 1,
         "default": 30
+      },
+      "advanced": {
+        "title": "Advanced",
+        "description": "Advanced configuration options",
+        "type": "object",
+        "order": 8,
+        "properties": {
+            "page_size": {
+                "order": 0,
+                "title": "Page size",
+                "type": "integer",
+                "minimum": 100,
+                "default": 50000
+            },
+            "minimal_cohort_members_properties": {
+                "order": 1,
+                "title": "Minimal Cohort Members properties",
+                "type": "boolean",
+                "description": "Set to TRUE to capture only the minimal properties for the cohort members binding. Typically left as the default.",
+                "default": true
+              }
+        }
       }
     }
   }

--- a/source-mixpanel-native/source_mixpanel_native/streams/base.py
+++ b/source-mixpanel-native/source_mixpanel_native/streams/base.py
@@ -49,7 +49,8 @@ class MixpanelStream(HttpStream, ABC):
         end_date: Date = None,
         date_window_size: int = 30,  # in days
         attribution_window: int = 0,  # in days
-        select_properties_by_default: bool = True,
+        minimal_cohort_members_properties: bool = True,
+        page_size: int = 50000,
         project_id: int = None,
         reqs_per_hour_limit: int = DEFAULT_REQS_PER_HOUR_LIMIT,
         **kwargs,
@@ -58,7 +59,8 @@ class MixpanelStream(HttpStream, ABC):
         self.end_date = end_date
         self.date_window_size = date_window_size
         self.attribution_window = attribution_window
-        self.additional_properties = select_properties_by_default
+        self.minimal_cohort_members_properties = minimal_cohort_members_properties
+        self.page_size = page_size
         self.region = region
         self.project_timezone = project_timezone
         self.project_id = project_id

--- a/source-mixpanel-native/source_mixpanel_native/streams/export.py
+++ b/source-mixpanel-native/source_mixpanel_native/streams/export.py
@@ -100,7 +100,6 @@ class Export(DateSlicesMixin, IncrementalMixpanelStream):
         end_date: Date = None,
         date_window_size: int = 30,  # in days
         attribution_window: int = 0,  # in days
-        select_properties_by_default: bool = True,
         project_id: int = None,
         reqs_per_hour_limit: int = MixpanelStream.DEFAULT_REQS_PER_HOUR_LIMIT,
         **kwargs,
@@ -118,7 +117,6 @@ class Export(DateSlicesMixin, IncrementalMixpanelStream):
             end_date=end_date,
             date_window_size=smaller_date_window,
             attribution_window=attribution_window,
-            select_properties_by_default=select_properties_by_default,
             project_id=project_id,
             reqs_per_hour_limit=reqs_per_hour_limit,
             **kwargs,

--- a/source-mixpanel-native/tests/snapshots/snapshots__discover__capture.stdout.json
+++ b/source-mixpanel-native/tests/snapshots/snapshots__discover__capture.stdout.json
@@ -1,13 +1,27 @@
 [
   {
+    "recommendedName": "cohorts",
+    "resourceConfig": {
+      "stream": "cohorts",
+      "syncMode": "incremental",
+      "cursorField": [
+        "created"
+      ]
+    },
     "documentSchema": {
       "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
       "additionalProperties": true,
       "required": [
         "id"
       ],
       "properties": {
+        "id": {
+          "description": "The unique identifier of the cohort data.",
+          "type": "integer"
+        },
         "_meta": {
+          "type": "object",
           "properties": {
             "row_id": {
               "type": "integer"
@@ -15,47 +29,28 @@
           },
           "required": [
             "row_id"
-          ],
-          "type": "object"
-        },
-        "id": {
-          "description": "The unique identifier of the cohort data.",
-          "type": "integer"
+          ]
         }
       },
-      "type": "object",
       "x-infer-schema": true
     },
     "key": [
       "/id"
-    ],
-    "recommendedName": "cohorts",
-    "resourceConfig": {
-      "cursorField": [
-        "created"
-      ],
-      "stream": "cohorts",
-      "syncMode": "incremental"
-    }
+    ]
   },
   {
+    "recommendedName": "cohort_members",
+    "resourceConfig": {
+      "stream": "cohort_members",
+      "syncMode": "full_refresh"
+    },
     "documentSchema": {
       "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
       "required": [
         "distinct_id"
       ],
       "properties": {
-        "_meta": {
-          "properties": {
-            "row_id": {
-              "type": "integer"
-            }
-          },
-          "required": [
-            "row_id"
-          ],
-          "type": "object"
-        },
         "cohort_id": {
           "description": "The unique identifier of the cohort to which the member belongs",
           "type": [
@@ -70,75 +65,52 @@
         "id": {
           "description": "The unique identifier of the cohort member",
           "type": "string"
+        },
+        "_meta": {
+          "type": "object",
+          "properties": {
+            "row_id": {
+              "type": "integer"
+            }
+          },
+          "required": [
+            "row_id"
+          ]
         }
       },
-      "type": "object",
       "x-infer-schema": true
     },
     "key": [
       "/distinct_id"
-    ],
-    "recommendedName": "cohort_members",
-    "resourceConfig": {
-      "cursorField": [
-        "last_seen"
-      ],
-      "stream": "cohort_members",
-      "syncMode": "incremental"
-    }
+    ]
   },
   {
+    "recommendedName": "funnels",
+    "resourceConfig": {
+      "stream": "funnels",
+      "syncMode": "incremental",
+      "cursorField": [
+        "date"
+      ]
+    },
     "documentSchema": {
       "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
       "required": [
         "date",
         "funnel_id"
       ],
       "properties": {
-        "_meta": {
-          "properties": {
-            "row_id": {
-              "type": "integer"
-            }
-          },
-          "required": [
-            "row_id"
-          ],
-          "type": "object"
+        "funnel_id": {
+          "description": "Unique identifier for the funnel.",
+          "type": "integer"
         },
         "date": {
           "description": "Date field for the funnel data.",
           "type": "string"
         },
-        "funnel_id": {
-          "description": "Unique identifier for the funnel.",
-          "type": "integer"
-        }
-      },
-      "type": "object",
-      "x-infer-schema": true
-    },
-    "key": [
-      "/funnel_id",
-      "/date"
-    ],
-    "recommendedName": "funnels",
-    "resourceConfig": {
-      "cursorField": [
-        "date"
-      ],
-      "stream": "funnels",
-      "syncMode": "incremental"
-    }
-  },
-  {
-    "documentSchema": {
-      "$schema": "http://json-schema.org/draft-07/schema#",
-      "required": [
-        "date"
-      ],
-      "properties": {
         "_meta": {
+          "type": "object",
           "properties": {
             "row_id": {
               "type": "integer"
@@ -146,15 +118,35 @@
           },
           "required": [
             "row_id"
-          ],
-          "type": "object"
-        },
-        "amount": {
-          "description": "Total revenue amount for the specified date",
-          "type": [
-            "null",
-            "number"
           ]
+        }
+      },
+      "x-infer-schema": true
+    },
+    "key": [
+      "/funnel_id",
+      "/date"
+    ]
+  },
+  {
+    "recommendedName": "revenue",
+    "resourceConfig": {
+      "stream": "revenue",
+      "syncMode": "incremental",
+      "cursorField": [
+        "date"
+      ]
+    },
+    "documentSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "required": [
+        "date"
+      ],
+      "properties": {
+        "date": {
+          "description": "Date for which the revenue data is recorded",
+          "type": "string"
         },
         "count": {
           "description": "Number of revenue transactions for the specified date",
@@ -163,41 +155,22 @@
             "integer"
           ]
         },
-        "date": {
-          "description": "Date for which the revenue data is recorded",
-          "type": "string"
-        },
         "paid_count": {
           "description": "Number of successful paid transactions for the specified date",
           "type": [
             "null",
             "integer"
           ]
-        }
-      },
-      "type": "object",
-      "x-infer-schema": true
-    },
-    "key": [
-      "/date"
-    ],
-    "recommendedName": "revenue",
-    "resourceConfig": {
-      "cursorField": [
-        "date"
-      ],
-      "stream": "revenue",
-      "syncMode": "incremental"
-    }
-  },
-  {
-    "documentSchema": {
-      "$schema": "http://json-schema.org/draft-07/schema#",
-      "required": [
-        "insert_id"
-      ],
-      "properties": {
+        },
+        "amount": {
+          "description": "Total revenue amount for the specified date",
+          "type": [
+            "null",
+            "number"
+          ]
+        },
         "_meta": {
+          "type": "object",
           "properties": {
             "row_id": {
               "type": "integer"
@@ -205,46 +178,46 @@
           },
           "required": [
             "row_id"
-          ],
-          "type": "object"
-        },
+          ]
+        }
+      },
+      "x-infer-schema": true
+    },
+    "key": [
+      "/date"
+    ]
+  },
+  {
+    "recommendedName": "export",
+    "resourceConfig": {
+      "stream": "export",
+      "syncMode": "incremental",
+      "cursorField": [
+        "time"
+      ]
+    },
+    "documentSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "required": [
+        "insert_id"
+      ],
+      "properties": {
         "distinct_id": {
           "description": "Unique identifier for the event",
           "type": "string"
         },
         "time": {
           "description": "Timestamp of the event",
-          "format": "date-time",
-          "type": "string"
+          "type": "string",
+          "format": "date-time"
         },
         "insert_id": {
-            "description": "Unique insertion identifier",
-            "type": "string"
-        }
-      },
-      "type": "object",
-      "x-infer-schema": true
-    },
-    "key": [
-      "/insert_id"
-    ],
-    "recommendedName": "export",
-    "resourceConfig": {
-      "cursorField": [
-        "time"
-      ],
-      "stream": "export",
-      "syncMode": "incremental"
-    }
-  },
-  {
-    "documentSchema": {
-      "$schema": "http://json-schema.org/draft-07/schema#",
-      "required": [
-        "id"
-      ],
-      "properties": {
+          "description": "Unique insertion identifier",
+          "type": "string"
+        },
         "_meta": {
+          "type": "object",
           "properties": {
             "row_id": {
               "type": "integer"
@@ -252,18 +225,30 @@
           },
           "required": [
             "row_id"
-          ],
-          "type": "object"
-        },
+          ]
+        }
+      },
+      "x-infer-schema": true
+    },
+    "key": [
+      "/insert_id"
+    ]
+  },
+  {
+    "recommendedName": "annotations",
+    "resourceConfig": {
+      "stream": "annotations",
+      "syncMode": "full_refresh"
+    },
+    "documentSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "required": [
+        "id"
+      ],
+      "properties": {
         "date": {
           "description": "The date of the annotation in ISO 8601 date-time format.",
-          "type": [
-            "null",
-            "string"
-          ]
-        },
-        "description": {
-          "description": "The description or notes associated with the annotation.",
           "type": [
             "null",
             "string"
@@ -272,28 +257,16 @@
         "id": {
           "description": "The unique identifier of the annotation.",
           "type": "integer"
-        }
-      },
-      "type": "object",
-      "x-infer-schema": true
-    },
-    "key": [
-      "/id"
-    ],
-    "recommendedName": "annotations",
-    "resourceConfig": {
-      "stream": "annotations",
-      "syncMode": "full_refresh"
-    }
-  },
-  {
-    "documentSchema": {
-      "$schema": "http://json-schema.org/draft-07/schema#",
-      "required": [
-        "distinct_id"
-      ],
-      "properties": {
+        },
+        "description": {
+          "description": "The description or notes associated with the annotation.",
+          "type": [
+            "null",
+            "string"
+          ]
+        },
         "_meta": {
+          "type": "object",
           "properties": {
             "row_id": {
               "type": "integer"
@@ -301,9 +274,31 @@
           },
           "required": [
             "row_id"
-          ],
-          "type": "object"
-        },
+          ]
+        }
+      },
+      "x-infer-schema": true
+    },
+    "key": [
+      "/id"
+    ]
+  },
+  {
+    "recommendedName": "engage",
+    "resourceConfig": {
+      "stream": "engage",
+      "syncMode": "incremental",
+      "cursorField": [
+        "last_seen"
+      ]
+    },
+    "documentSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "required": [
+        "distinct_id"
+      ],
+      "properties": {
         "distinct_id": {
           "description": "The unique identifier for the user.",
           "type": "string"
@@ -311,21 +306,23 @@
         "id": {
           "description": "The unique ID associated with the user.",
           "type": "string"
+        },
+        "_meta": {
+          "type": "object",
+          "properties": {
+            "row_id": {
+              "type": "integer"
+            }
+          },
+          "required": [
+            "row_id"
+          ]
         }
       },
-      "type": "object",
       "x-infer-schema": true
     },
     "key": [
       "/distinct_id"
-    ],
-    "recommendedName": "engage",
-    "resourceConfig": {
-      "cursorField": [
-        "last_seen"
-      ],
-      "stream": "engage",
-      "syncMode": "incremental"
-    }
+    ]
   }
 ]

--- a/source-mixpanel-native/tests/snapshots/snapshots__spec__capture.stdout.json
+++ b/source-mixpanel-native/tests/snapshots/snapshots__spec__capture.stdout.json
@@ -1,185 +1,200 @@
 [
   {
+    "protocol": 3032023,
     "configSchema": {
       "$schema": "http://json-schema.org/draft-07/schema#",
+      "title": "Source Mixpanel Spec",
+      "required": [
+        "credentials"
+      ],
+      "type": "object",
       "properties": {
-        "attribution_window": {
-          "default": 5,
-          "description": "A period of time for attributing results to ads and the lookback period after those actions occur during which ad results are counted. Default attribution window is 5 days. (This value should be non-negative integer)",
-          "order": 2,
-          "title": "Attribution Window",
-          "type": "integer"
-        },
         "credentials": {
+          "title": "Authentication *",
           "description": "Choose how to authenticate to Mixpanel",
+          "type": "object",
+          "order": 0,
           "oneOf": [
             {
-              "properties": {
-                "option_title": {
-                  "const": "Service Account",
-                  "order": 0,
-                  "type": "string"
-                },
-                "project_id": {
-                  "description": "Your project ID number. See the <a href=\"https://help.mixpanel.com/hc/en-us/articles/115004490503-Project-Settings#project-id\">docs</a> for more information on how to obtain this.",
-                  "order": 3,
-                  "title": "Project ID",
-                  "type": "integer"
-                },
-                "secret": {
-                  "airbyte_secret": true,
-                  "description": "Mixpanel Service Account Secret. See the <a href=\"https://developer.mixpanel.com/reference/service-accounts\">docs</a> for more information on how to obtain this.",
-                  "order": 2,
-                  "title": "Secret",
-                  "type": "string"
-                },
-                "username": {
-                  "description": "Mixpanel Service Account Username. See the <a href=\"https://developer.mixpanel.com/reference/service-accounts\">docs</a> for more information on how to obtain this.",
-                  "order": 1,
-                  "title": "Username",
-                  "type": "string"
-                }
-              },
+              "type": "object",
+              "title": "Service Account",
               "required": [
                 "username",
                 "secret",
                 "project_id"
               ],
-              "title": "Service Account",
-              "type": "object"
+              "properties": {
+                "option_title": {
+                  "type": "string",
+                  "const": "Service Account",
+                  "order": 0
+                },
+                "username": {
+                  "order": 1,
+                  "title": "Username",
+                  "type": "string",
+                  "description": "Mixpanel Service Account Username. See the <a href=\"https://developer.mixpanel.com/reference/service-accounts\">docs</a> for more information on how to obtain this."
+                },
+                "secret": {
+                  "order": 2,
+                  "title": "Secret",
+                  "type": "string",
+                  "description": "Mixpanel Service Account Secret. See the <a href=\"https://developer.mixpanel.com/reference/service-accounts\">docs</a> for more information on how to obtain this.",
+                  "airbyte_secret": true
+                },
+                "project_id": {
+                  "order": 3,
+                  "title": "Project ID",
+                  "description": "Your project ID number. See the <a href=\"https://help.mixpanel.com/hc/en-us/articles/115004490503-Project-Settings#project-id\">docs</a> for more information on how to obtain this.",
+                  "type": "integer"
+                }
+              }
             },
             {
-              "properties": {
-                "api_secret": {
-                  "airbyte_secret": true,
-                  "description": "Mixpanel project secret. See the <a href=\"https://developer.mixpanel.com/reference/project-secret#managing-a-projects-secret\">docs</a> for more information on how to obtain this.",
-                  "order": 1,
-                  "title": "Project Secret",
-                  "type": "string"
-                },
-                "option_title": {
-                  "const": "Project Secret",
-                  "order": 0,
-                  "type": "string"
-                }
-              },
+              "type": "object",
+              "title": "Project Secret",
               "required": [
                 "api_secret"
               ],
-              "title": "Project Secret",
-              "type": "object"
+              "properties": {
+                "option_title": {
+                  "type": "string",
+                  "const": "Project Secret",
+                  "order": 0
+                },
+                "api_secret": {
+                  "order": 1,
+                  "title": "Project Secret",
+                  "type": "string",
+                  "description": "Mixpanel project secret. See the <a href=\"https://developer.mixpanel.com/reference/project-secret#managing-a-projects-secret\">docs</a> for more information on how to obtain this.",
+                  "airbyte_secret": true
+                }
+              }
             }
-          ],
-          "order": 0,
-          "title": "Authentication *",
-          "type": "object"
+          ]
         },
-        "date_window_size": {
-          "default": 30,
-          "description": "Defines window size in days, that used to slice through data. You can reduce it, if amount of data in each window is too big for your environment. (This value should be positive integer)",
-          "minimum": 1,
-          "order": 8,
-          "title": "Date slicing window",
-          "type": "integer"
-        },
-        "end_date": {
-          "description": "The date in the format YYYY-MM-DD. Any data after this date will not be replicated. Left empty to always sync to most recent date",
-          "examples": [
-            "2021-11-16"
-          ],
-          "format": "date",
-          "order": 6,
-          "pattern": "^$|^[0-9]{4}-[0-9]{2}-[0-9]{2}(T[0-9]{2}:[0-9]{2}:[0-9]{2}Z)?$",
-          "title": "End Date",
-          "type": "string"
+        "attribution_window": {
+          "order": 2,
+          "title": "Attribution Window",
+          "type": "integer",
+          "description": "A period of time for attributing results to ads and the lookback period after those actions occur during which ad results are counted. Default attribution window is 5 days. (This value should be non-negative integer)",
+          "default": 5
         },
         "project_timezone": {
-          "default": "US/Pacific",
+          "order": 3,
+          "title": "Project Timezone",
+          "type": "string",
           "description": "Time zone in which integer date times are stored. The project timezone may be found in the project settings in the <a href=\"https://help.mixpanel.com/hc/en-us/articles/115004547203-Manage-Timezones-for-Projects-in-Mixpanel\">Mixpanel console</a>.",
+          "default": "US/Pacific",
           "examples": [
             "US/Pacific",
             "UTC"
-          ],
-          "order": 3,
-          "title": "Project Timezone",
-          "type": "string"
-        },
-        "region": {
-          "default": "US",
-          "description": "The region of mixpanel domain instance either US or EU.",
-          "enum": [
-            "US",
-            "EU"
-          ],
-          "order": 7,
-          "title": "Region",
-          "type": "string"
-        },
-        "select_properties_by_default": {
-          "default": true,
-          "description": "Setting this config parameter to TRUE ensures that new properties on events and engage records are captured. Otherwise new properties will be ignored.",
-          "order": 4,
-          "title": "Select Properties By Default",
-          "type": "boolean"
+          ]
         },
         "start_date": {
+          "order": 4,
+          "title": "Start Date",
+          "type": "string",
           "description": "The date in the format YYYY-MM-DD. Any data before this date will not be replicated. If this option is not set, the connector will replicate data from up to one year ago by default.",
           "examples": [
             "2021-11-16"
           ],
-          "format": "date",
-          "order": 5,
           "pattern": "^$|^[0-9]{4}-[0-9]{2}-[0-9]{2}(T[0-9]{2}:[0-9]{2}:[0-9]{2}Z)?$",
-          "title": "Start Date",
-          "type": "string"
+          "format": "date"
+        },
+        "end_date": {
+          "order": 5,
+          "title": "End Date",
+          "type": "string",
+          "description": "The date in the format YYYY-MM-DD. Any data after this date will not be replicated. Left empty to always sync to most recent date",
+          "examples": [
+            "2021-11-16"
+          ],
+          "pattern": "^$|^[0-9]{4}-[0-9]{2}-[0-9]{2}(T[0-9]{2}:[0-9]{2}:[0-9]{2}Z)?$",
+          "format": "date"
+        },
+        "region": {
+          "order": 6,
+          "title": "Region",
+          "description": "The region of mixpanel domain instance either US or EU.",
+          "type": "string",
+          "enum": [
+            "US",
+            "EU"
+          ],
+          "default": "US"
+        },
+        "date_window_size": {
+          "order": 7,
+          "title": "Date slicing window",
+          "description": "Defines window size in days, that used to slice through data. You can reduce it, if amount of data in each window is too big for your environment. (This value should be positive integer)",
+          "type": "integer",
+          "minimum": 1,
+          "default": 30
+        },
+        "advanced": {
+          "title": "Advanced",
+          "description": "Advanced configuration options",
+          "type": "object",
+          "order": 8,
+          "properties": {
+            "page_size": {
+              "order": 0,
+              "title": "Page size",
+              "type": "integer",
+              "minimum": 100,
+              "default": 50000
+            },
+            "minimal_cohort_members_properties": {
+              "order": 1,
+              "title": "Minimal Cohort Members properties",
+              "type": "boolean",
+              "description": "Set to TRUE to capture only the minimal properties for the cohort members binding. Typically left as the default.",
+              "default": true
+            }
+          }
         }
-      },
-      "required": [
-        "credentials"
-      ],
-      "title": "Source Mixpanel Spec",
-      "type": "object"
+      }
     },
-    "documentationUrl": "https://go.estuary.dev/kC5MzU",
-    "protocol": 3032023,
     "resourceConfigSchema": {
-      "additionalProperties": false,
+      "title": "ResourceConfig",
       "description": "ResourceConfig encodes a configured resource stream",
+      "type": "object",
       "properties": {
-        "cursorField": {
-          "items": {
-            "type": "string"
-          },
-          "title": "Cursor Field",
-          "type": "array"
-        },
-        "namespace": {
-          "description": "Enclosing schema namespace of this resource",
-          "title": "Namespace",
-          "type": "string"
-        },
         "stream": {
-          "description": "Name of this stream",
           "title": "Stream",
+          "description": "Name of this stream",
           "type": "string"
         },
         "syncMode": {
+          "title": "Sync Mode",
           "description": "Sync this resource incrementally, or fully refresh it every run",
           "enum": [
             "full_refresh",
             "incremental"
           ],
-          "title": "Sync Mode",
           "type": "string"
+        },
+        "namespace": {
+          "title": "Namespace",
+          "description": "Enclosing schema namespace of this resource",
+          "type": "string"
+        },
+        "cursorField": {
+          "title": "Cursor Field",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         }
       },
       "required": [
         "stream",
         "syncMode"
       ],
-      "title": "ResourceConfig",
-      "type": "object"
+      "additionalProperties": false
     },
+    "documentationUrl": "https://go.estuary.dev/kC5MzU",
     "resourcePathPointers": [
       "/namespace",
       "/stream"


### PR DESCRIPTION
**Description:**

A production `source-mixpanel-native` capture is OOM-ing on the `cohort_members` stream (and likely would OOM on the `engage` stream if it was enabled). This is happening because a single API response is large enough that it OOMs the connector. Typically this could be managed by using a smaller page size for API responses, but the Mixpanel API has a harsh rate limit (1 request / minute) and using a page size small enough to *not* OOM would make the connector take over 24 hours to complete (our self-enforced limit before restarting connectors). To address this, the `engage` stream now works as an incremental stream & the `cohort_members` stream only gets the minimum properties necessary to identify which document in the `engage` stream is associated with a given `cohort_members` document if `minimal_cohort_members_properties` is `true`.

A future PR will uncomment lines 34-35 & 61-62 of `cohort_members.py` when we're ready to have the `minimal_cohort_members_properties` functionality be live. Existing tasks should have the `minimal_cohort_members_properties` set to `false` to avoid different behavior when that future PR is merged.

### Snapshot changes:

Spec and discover snapshot changes are expected due to the changes to `engage` and `cohort_members`.

Spec [jsondiff](https://jsondiff.com/?left=https://raw.githubusercontent.com/estuary/connectors/af7d3189f956d2b5b467265e5af5105ccb18c8ff/source-mixpanel-native/tests/snapshots/snapshots__spec__capture.stdout.json&right=https://raw.githubusercontent.com/estuary/connectors/61381124595ad05cccc5b2cbc87e21ddb4a0c77e/source-mixpanel-native/tests/snapshots/snapshots__spec__capture.stdout.json) - the `select_properties_by_default` option was removed (it wasn't being used for anything in the connector) and the `advanced/page_size` and `advanced/minimal_cohort_members_properties` options were added.

Discover [jsondiff](https://jsondiff.com/?left=https://raw.githubusercontent.com/estuary/connectors/af7d3189f956d2b5b467265e5af5105ccb18c8ff/source-mixpanel-native/tests/snapshots/snapshots__discover__capture.stdout.json&right=https://raw.githubusercontent.com/estuary/connectors/61381124595ad05cccc5b2cbc87e21ddb4a0c77e/source-mixpanel-native/tests/snapshots/snapshots__discover__capture.stdout.json) - `cohort_members` was listed as an `incremental` stream in the snapshot, but it didn't function as an incremental stream yet. It now is listed correctly as a `full_refresh` stream.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

Tested on a local stack. Confirmed that:
- `engage` behaves incrementally
- `cohort_members` is able to successfully complete when `minimal_cohort_members_properties` is set for the capture that was previously OOM-ing.

All existing captures need their `minimal_cohort_members_properties` set before merging the follow-up PR to make the associated functionality live. All existing captures should also have their `engage` stream backfilled since it's moving from `full_refresh` to `incremental`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2244)
<!-- Reviewable:end -->
