### PR TITLE
materialize-mysql: handle transactions with 0 Store requests

### DIFF
--- a/materialize-mysql/driver.go
+++ b/materialize-mysql/driver.go
@@ -801,8 +801,10 @@ func (d *transactor) Store(it *m.StoreIterator) (_ m.StartCommitFunc, err error)
 	}
 
 	// Drain the final binding.
-	if err := drainBinding(d.bindings[lastBinding]); err != nil {
-		return nil, err
+	if lastBinding != -1 {
+		if err := drainBinding(d.bindings[lastBinding]); err != nil {
+			return nil, err
+		}
 	}
 
 	return func(ctx context.Context, runtimeCheckpoint *protocol.Checkpoint) (*pf.ConnectorState, m.OpFuture) {


### PR DESCRIPTION
**Description:**

For transactions with 0 Store requests, which may happen when a `notBefore` is set on the materialization, prevent a panic by not trying to flush the "final" binding when there aren't any bindings with data.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2245)
<!-- Reviewable:end -->
