### PR TITLE
build: use latest duckdb version in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -257,9 +257,9 @@ jobs:
 
       - name: Install duckdb
         if: matrix.connector == 'materialize-motherduck' || matrix.connector == 'materialize-s3-iceberg'
-        uses: opt-nc/setup-duckdb-action@v1.0.7
+        uses: opt-nc/setup-duckdb-action@v1.0.8
         with:
-          version: v0.10.3
+          version: v1.1.3
 
       - name: Materialization connector ${{ matrix.connector }} integration tests
         if: |


### PR DESCRIPTION
**Description:**

Versions less than 1.1.0 will soon be unsupported will connecting to Motherduck. Use the latest version in CI processes.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2247)
<!-- Reviewable:end -->
