### PR TITLE
source-intercom-native: add config option to use `/companies/scroll` endpoint

### DIFF
--- a/source-intercom-native/source_intercom_native/models.py
+++ b/source-intercom-native/source_intercom_native/models.py
@@ -67,6 +67,11 @@ class EndpointConfig(BaseModel):
             default=5,
             gt=0,
         )]
+        use_companies_list_endpoint: bool = Field(
+            description="If selected, the /companies/list endpoint is used instead of the /companies/scroll endpoint. Typically, leave as the default unless the connector's logs indicate otherwise.",
+            title="Use /companies/list endpoint",
+            default=False,
+        )
 
     advanced: Advanced = Field(
         default_factory=Advanced, #type: ignore
@@ -156,8 +161,18 @@ class CompanyListResponse(BaseModel, extra="allow"):
     pages: Pagination
 
 
+class CompanyScrollResponse(BaseModel, extra="allow"):
+    data: list[TimestampedResource]
+    scroll_param: str
+
+
 ClientSideFilteringResourceFetchChangesFn = Callable[
     [HTTPSession, Logger, LogCursor],
+    AsyncGenerator[TimestampedResource | LogCursor, None],
+]
+
+CompanyResourceFetchChangesFn = Callable[
+    [HTTPSession, bool, Logger, LogCursor],
     AsyncGenerator[TimestampedResource | LogCursor, None],
 ]
 

--- a/source-intercom-native/tests/snapshots/snapshots__spec__capture.stdout.json
+++ b/source-intercom-native/tests/snapshots/snapshots__spec__capture.stdout.json
@@ -31,6 +31,12 @@
               "exclusiveMinimum": 0,
               "title": "Window Size",
               "type": "integer"
+            },
+            "use_companies_list_endpoint": {
+              "default": false,
+              "description": "If selected, the /companies/list endpoint is used instead of the /companies/scroll endpoint. Typically, leave as the default unless the connector's logs indicate otherwise.",
+              "title": "Use /companies/list endpoint",
+              "type": "boolean"
             }
           },
           "title": "Advanced",


### PR DESCRIPTION
**Description:**

Intercom has two separate endpoints for retrieving companies: `/companies/list` (limited to 10k companies) and `/companies/scroll` (limited to only one "scroll" happening at a time). For users that have more than 10k companies in their Intercom account, they will need to use the `/companies/scroll` endpoint to ensure no data is missed.

The connector previously always used the `/companies/list` endpoint, and this PR adds the ability to use the `/companies/scroll` endpoint instead. The new `use_companies_list_endpoint` config option controls which of the two company-related endpoints are used. Within the connector, an `asyncio.Lock` is used to avoid attempting concurrent "scrolls" between the two streams that want to use `/companies/scroll` - `companies` and `company_segments`.

The connector defaults to using `/companies/scroll`, preferring to capture all data instead of potentially missing data if the user has >10k companies. 

It may be worthwhile to remove the option to use `/companies/list` at a later date. The main reasons I anticipate users would check the `use_companies_list_endpoint` option are:
- they have another application using `/companies/scroll` that they can't disable (not sure how common that is)
- they want the slight speed boost in `companies` and `company_segments` (which seems relatively negligible with the limited testing I've done)

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

`source-intercom-native` connector docs should be updated to reflect the new `use_companies_list_endpoint` config option.

**Notes for reviewers:**

Tested on a local stack. Confirmed:
- Companies can be successfully fetched via the `_scroll_companies` function.
- The `companies` and `company_segments` streams do not concurrently try to hit `/companies/scroll`.
- The `use_companies_list_endpoint` config option controls whether `/companies/list` or `/companies/scroll` is used.
- The connector crashes & logs an error message if it tries to access `/companies/scroll` but receives a `400` response indicating some other application is using the endpoint.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2256)
<!-- Reviewable:end -->
