### PR TITLE
materialize-bigquery: fix query retry logic calculation

### DIFF
--- a/materialize-bigquery/query.go
+++ b/materialize-bigquery/query.go
@@ -40,8 +40,8 @@ func (c client) newQuery(queryString string, parameters ...interface{}) *bigquer
 
 const (
 	maxAttempts            = 30
-	initialBackoff float64 = 200 // Milliseconds
-	maxBackoff             = time.Duration(60 * time.Second)
+	initialBackoff float64 = 200       // Milliseconds
+	maxBackoff             = 60 * 1000 // Milliseconds
 )
 
 // runQuery will run a query and return the completed job.
@@ -94,10 +94,10 @@ func (c client) runQuery(ctx context.Context, query *bigquery.Query) (*bigquery.
 					strings.Contains(err.Error(), "The job encountered an error during execution. Retrying the job may solve the problem.") ||
 					(len(e.Errors) == 1 && e.Errors[0].Reason == "jobRateLimitExceeded") {
 					backoff *= math.Pow(2, 1+rand.Float64())
-					delay := time.Duration(backoff * float64(time.Millisecond))
-					if delay > maxBackoff {
-						delay = maxBackoff
+					if backoff > maxBackoff {
+						backoff = maxBackoff
 					}
+					delay := time.Duration(backoff * float64(time.Millisecond))
 
 					ll := log.WithFields(log.Fields{
 						"attempt":   attempt,


### PR DESCRIPTION
**Description:**

The retry logical calculation was going haywire at larger retry counts. I think it might have been due to an overflow, although I am unable to reproduce this on my local machine and am not 100% convinced it is the cause.

But this change is very simple and I can't see how it wouldn't work at higher retry counts, so I'd like to see if it takes care of the problem.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2260)
<!-- Reviewable:end -->
