### PR TITLE
source-hubspot-native: don't serialize empty object for empty propertiesWithHistory

### DIFF
--- a/source-hubspot-native/source_hubspot_native/models.py
+++ b/source-hubspot-native/source_hubspot_native/models.py
@@ -183,6 +183,8 @@ class BaseCRMObject(BaseDocument, extra="forbid"):
         self.propertiesWithHistory = {
             k: v for k, v in self.propertiesWithHistory.items() if len(v)
         }
+        if len(self.propertiesWithHistory) == 0:
+            delattr(self, "propertiesWithHistory")
 
         # If the model has attached inline associations,
         # hoist them to corresponding arrays. Then clear associations.


### PR DESCRIPTION
**Description:**

Omit the frivolous empty object for an empty propertiesWithHistory, so that it is not picked up by schema inference. The default setting will not capture propertiesWithHistory so having this empty object in every document would likely be confusing.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2261)
<!-- Reviewable:end -->
