### PR TITLE
source-hubspot-native: schematize propertiesWithHistory, but make it nullable

### DIFF
--- a/source-hubspot-native/acmeCo/companies.schema.yaml
+++ b/source-hubspot-native/acmeCo/companies.schema.yaml
@@ -3,13 +3,6 @@ $defs:
   History:
     additionalProperties: false
     properties:
-      _meta:
-        allOf:
-          - $ref: "#/$defs/Meta"
-        default:
-          op: u
-          row_id: -1
-        description: Document metadata
       timestamp:
         format: date-time
         title: Timestamp
@@ -93,13 +86,15 @@ properties:
         - type: "null"
     title: Properties
   propertiesWithHistory:
-    additionalProperties:
-      items:
-        $ref: "#/$defs/History"
-      type: array
-    default: {}
+    anyOf:
+      - additionalProperties:
+          items:
+            $ref: "#/$defs/History"
+          type: array
+        type: object
+      - type: "null"
+    default: ~
     title: Propertieswithhistory
-    type: object
   associations:
     additionalProperties: false
     default: {}

--- a/source-hubspot-native/acmeCo/contacts.schema.yaml
+++ b/source-hubspot-native/acmeCo/contacts.schema.yaml
@@ -3,13 +3,6 @@ $defs:
   History:
     additionalProperties: false
     properties:
-      _meta:
-        allOf:
-          - $ref: "#/$defs/Meta"
-        default:
-          op: u
-          row_id: -1
-        description: Document metadata
       timestamp:
         format: date-time
         title: Timestamp
@@ -93,13 +86,15 @@ properties:
         - type: "null"
     title: Properties
   propertiesWithHistory:
-    additionalProperties:
-      items:
-        $ref: "#/$defs/History"
-      type: array
-    default: {}
+    anyOf:
+      - additionalProperties:
+          items:
+            $ref: "#/$defs/History"
+          type: array
+        type: object
+      - type: "null"
+    default: ~
     title: Propertieswithhistory
-    type: object
   associations:
     additionalProperties: false
     default: {}

--- a/source-hubspot-native/acmeCo/deals.schema.yaml
+++ b/source-hubspot-native/acmeCo/deals.schema.yaml
@@ -3,13 +3,6 @@ $defs:
   History:
     additionalProperties: false
     properties:
-      _meta:
-        allOf:
-          - $ref: "#/$defs/Meta"
-        default:
-          op: u
-          row_id: -1
-        description: Document metadata
       timestamp:
         format: date-time
         title: Timestamp
@@ -93,13 +86,15 @@ properties:
         - type: "null"
     title: Properties
   propertiesWithHistory:
-    additionalProperties:
-      items:
-        $ref: "#/$defs/History"
-      type: array
-    default: {}
+    anyOf:
+      - additionalProperties:
+          items:
+            $ref: "#/$defs/History"
+          type: array
+        type: object
+      - type: "null"
+    default: ~
     title: Propertieswithhistory
-    type: object
   associations:
     additionalProperties: false
     default: {}

--- a/source-hubspot-native/acmeCo/engagements.schema.yaml
+++ b/source-hubspot-native/acmeCo/engagements.schema.yaml
@@ -3,13 +3,6 @@ $defs:
   History:
     additionalProperties: false
     properties:
-      _meta:
-        allOf:
-          - $ref: "#/$defs/Meta"
-        default:
-          op: u
-          row_id: -1
-        description: Document metadata
       timestamp:
         format: date-time
         title: Timestamp
@@ -93,13 +86,15 @@ properties:
         - type: "null"
     title: Properties
   propertiesWithHistory:
-    additionalProperties:
-      items:
-        $ref: "#/$defs/History"
-      type: array
-    default: {}
+    anyOf:
+      - additionalProperties:
+          items:
+            $ref: "#/$defs/History"
+          type: array
+        type: object
+      - type: "null"
+    default: ~
     title: Propertieswithhistory
-    type: object
   associations:
     additionalProperties: false
     default: {}

--- a/source-hubspot-native/acmeCo/line_items.schema.yaml
+++ b/source-hubspot-native/acmeCo/line_items.schema.yaml
@@ -3,13 +3,6 @@ $defs:
   History:
     additionalProperties: false
     properties:
-      _meta:
-        allOf:
-          - $ref: "#/$defs/Meta"
-        default:
-          op: u
-          row_id: -1
-        description: Document metadata
       timestamp:
         format: date-time
         title: Timestamp
@@ -93,13 +86,15 @@ properties:
         - type: "null"
     title: Properties
   propertiesWithHistory:
-    additionalProperties:
-      items:
-        $ref: "#/$defs/History"
-      type: array
-    default: {}
+    anyOf:
+      - additionalProperties:
+          items:
+            $ref: "#/$defs/History"
+          type: array
+        type: object
+      - type: "null"
+    default: ~
     title: Propertieswithhistory
-    type: object
   associations:
     additionalProperties: false
     default: {}

--- a/source-hubspot-native/acmeCo/products.schema.yaml
+++ b/source-hubspot-native/acmeCo/products.schema.yaml
@@ -3,13 +3,6 @@ $defs:
   History:
     additionalProperties: false
     properties:
-      _meta:
-        allOf:
-          - $ref: "#/$defs/Meta"
-        default:
-          op: u
-          row_id: -1
-        description: Document metadata
       timestamp:
         format: date-time
         title: Timestamp
@@ -93,13 +86,15 @@ properties:
         - type: "null"
     title: Properties
   propertiesWithHistory:
-    additionalProperties:
-      items:
-        $ref: "#/$defs/History"
-      type: array
-    default: {}
+    anyOf:
+      - additionalProperties:
+          items:
+            $ref: "#/$defs/History"
+          type: array
+        type: object
+      - type: "null"
+    default: ~
     title: Propertieswithhistory
-    type: object
   associations:
     additionalProperties: false
     default: {}

--- a/source-hubspot-native/acmeCo/tickets.schema.yaml
+++ b/source-hubspot-native/acmeCo/tickets.schema.yaml
@@ -3,13 +3,6 @@ $defs:
   History:
     additionalProperties: false
     properties:
-      _meta:
-        allOf:
-          - $ref: "#/$defs/Meta"
-        default:
-          op: u
-          row_id: -1
-        description: Document metadata
       timestamp:
         format: date-time
         title: Timestamp
@@ -93,13 +86,15 @@ properties:
         - type: "null"
     title: Properties
   propertiesWithHistory:
-    additionalProperties:
-      items:
-        $ref: "#/$defs/History"
-      type: array
-    default: {}
+    anyOf:
+      - additionalProperties:
+          items:
+            $ref: "#/$defs/History"
+          type: array
+        type: object
+      - type: "null"
+    default: ~
     title: Propertieswithhistory
-    type: object
   associations:
     additionalProperties: false
     default: {}

--- a/source-hubspot-native/source_hubspot_native/models.py
+++ b/source-hubspot-native/source_hubspot_native/models.py
@@ -159,7 +159,7 @@ class BaseCRMObject(BaseDocument, extra="forbid"):
     archived: bool
 
     properties: dict[str, str | None]
-    propertiesWithHistory: SkipJsonSchema[dict[str, list[History]]] = {}
+    propertiesWithHistory: dict[str, list[History]] | None = None
 
     class InlineAssociations(BaseModel):
         class Entry(BaseModel):
@@ -180,11 +180,11 @@ class BaseCRMObject(BaseDocument, extra="forbid"):
     def _post_init(self) -> Self:
         # Clear properties and history which don't have current values.
         self.properties = {k: v for k, v in self.properties.items() if v}
-        self.propertiesWithHistory = {
-            k: v for k, v in self.propertiesWithHistory.items() if len(v)
-        }
-        if len(self.propertiesWithHistory) == 0:
-            delattr(self, "propertiesWithHistory")
+        if self.propertiesWithHistory:
+            self.propertiesWithHistory = {
+                k: v for k, v in self.propertiesWithHistory.items() if len(v)
+            }
+
 
         # If the model has attached inline associations,
         # hoist them to corresponding arrays. Then clear associations.

--- a/source-hubspot-native/tests/snapshots/snapshots__discover__stdout.json
+++ b/source-hubspot-native/tests/snapshots/snapshots__discover__stdout.json
@@ -6,6 +6,67 @@
     },
     "documentSchema": {
       "$defs": {
+        "History": {
+          "additionalProperties": false,
+          "properties": {
+            "timestamp": {
+              "format": "date-time",
+              "title": "Timestamp",
+              "type": "string"
+            },
+            "value": {
+              "title": "Value",
+              "type": "string"
+            },
+            "sourceType": {
+              "title": "Sourcetype",
+              "type": "string"
+            },
+            "sourceId": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "title": "Sourceid"
+            },
+            "sourceLabel": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "title": "Sourcelabel"
+            },
+            "updatedByUserId": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "title": "Updatedbyuserid"
+            }
+          },
+          "required": [
+            "timestamp",
+            "value",
+            "sourceType"
+          ],
+          "title": "History",
+          "type": "object"
+        },
         "Meta": {
           "properties": {
             "op": {
@@ -75,6 +136,24 @@
             ]
           },
           "title": "Properties"
+        },
+        "propertiesWithHistory": {
+          "anyOf": [
+            {
+              "additionalProperties": {
+                "items": {
+                  "$ref": "#/$defs/History"
+                },
+                "type": "array"
+              },
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Propertieswithhistory"
         },
         "associations": {
           "additionalProperties": false,
@@ -121,6 +200,67 @@
     },
     "documentSchema": {
       "$defs": {
+        "History": {
+          "additionalProperties": false,
+          "properties": {
+            "timestamp": {
+              "format": "date-time",
+              "title": "Timestamp",
+              "type": "string"
+            },
+            "value": {
+              "title": "Value",
+              "type": "string"
+            },
+            "sourceType": {
+              "title": "Sourcetype",
+              "type": "string"
+            },
+            "sourceId": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "title": "Sourceid"
+            },
+            "sourceLabel": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "title": "Sourcelabel"
+            },
+            "updatedByUserId": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "title": "Updatedbyuserid"
+            }
+          },
+          "required": [
+            "timestamp",
+            "value",
+            "sourceType"
+          ],
+          "title": "History",
+          "type": "object"
+        },
         "Meta": {
           "properties": {
             "op": {
@@ -190,6 +330,24 @@
             ]
           },
           "title": "Properties"
+        },
+        "propertiesWithHistory": {
+          "anyOf": [
+            {
+              "additionalProperties": {
+                "items": {
+                  "$ref": "#/$defs/History"
+                },
+                "type": "array"
+              },
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Propertieswithhistory"
         },
         "associations": {
           "additionalProperties": false,
@@ -228,6 +386,67 @@
     },
     "documentSchema": {
       "$defs": {
+        "History": {
+          "additionalProperties": false,
+          "properties": {
+            "timestamp": {
+              "format": "date-time",
+              "title": "Timestamp",
+              "type": "string"
+            },
+            "value": {
+              "title": "Value",
+              "type": "string"
+            },
+            "sourceType": {
+              "title": "Sourcetype",
+              "type": "string"
+            },
+            "sourceId": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "title": "Sourceid"
+            },
+            "sourceLabel": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "title": "Sourcelabel"
+            },
+            "updatedByUserId": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "title": "Updatedbyuserid"
+            }
+          },
+          "required": [
+            "timestamp",
+            "value",
+            "sourceType"
+          ],
+          "title": "History",
+          "type": "object"
+        },
         "Meta": {
           "properties": {
             "op": {
@@ -297,6 +516,24 @@
             ]
           },
           "title": "Properties"
+        },
+        "propertiesWithHistory": {
+          "anyOf": [
+            {
+              "additionalProperties": {
+                "items": {
+                  "$ref": "#/$defs/History"
+                },
+                "type": "array"
+              },
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Propertieswithhistory"
         },
         "associations": {
           "additionalProperties": false,
@@ -351,6 +588,67 @@
     },
     "documentSchema": {
       "$defs": {
+        "History": {
+          "additionalProperties": false,
+          "properties": {
+            "timestamp": {
+              "format": "date-time",
+              "title": "Timestamp",
+              "type": "string"
+            },
+            "value": {
+              "title": "Value",
+              "type": "string"
+            },
+            "sourceType": {
+              "title": "Sourcetype",
+              "type": "string"
+            },
+            "sourceId": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "title": "Sourceid"
+            },
+            "sourceLabel": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "title": "Sourcelabel"
+            },
+            "updatedByUserId": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "title": "Updatedbyuserid"
+            }
+          },
+          "required": [
+            "timestamp",
+            "value",
+            "sourceType"
+          ],
+          "title": "History",
+          "type": "object"
+        },
         "Meta": {
           "properties": {
             "op": {
@@ -420,6 +718,24 @@
             ]
           },
           "title": "Properties"
+        },
+        "propertiesWithHistory": {
+          "anyOf": [
+            {
+              "additionalProperties": {
+                "items": {
+                  "$ref": "#/$defs/History"
+                },
+                "type": "array"
+              },
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Propertieswithhistory"
         },
         "associations": {
           "additionalProperties": false,
@@ -458,6 +774,67 @@
     },
     "documentSchema": {
       "$defs": {
+        "History": {
+          "additionalProperties": false,
+          "properties": {
+            "timestamp": {
+              "format": "date-time",
+              "title": "Timestamp",
+              "type": "string"
+            },
+            "value": {
+              "title": "Value",
+              "type": "string"
+            },
+            "sourceType": {
+              "title": "Sourcetype",
+              "type": "string"
+            },
+            "sourceId": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "title": "Sourceid"
+            },
+            "sourceLabel": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "title": "Sourcelabel"
+            },
+            "updatedByUserId": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "title": "Updatedbyuserid"
+            }
+          },
+          "required": [
+            "timestamp",
+            "value",
+            "sourceType"
+          ],
+          "title": "History",
+          "type": "object"
+        },
         "Meta": {
           "properties": {
             "op": {
@@ -527,6 +904,24 @@
             ]
           },
           "title": "Properties"
+        },
+        "propertiesWithHistory": {
+          "anyOf": [
+            {
+              "additionalProperties": {
+                "items": {
+                  "$ref": "#/$defs/History"
+                },
+                "type": "array"
+              },
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Propertieswithhistory"
         },
         "associations": {
           "additionalProperties": false,
@@ -581,6 +976,67 @@
     },
     "documentSchema": {
       "$defs": {
+        "History": {
+          "additionalProperties": false,
+          "properties": {
+            "timestamp": {
+              "format": "date-time",
+              "title": "Timestamp",
+              "type": "string"
+            },
+            "value": {
+              "title": "Value",
+              "type": "string"
+            },
+            "sourceType": {
+              "title": "Sourcetype",
+              "type": "string"
+            },
+            "sourceId": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "title": "Sourceid"
+            },
+            "sourceLabel": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "title": "Sourcelabel"
+            },
+            "updatedByUserId": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "title": "Updatedbyuserid"
+            }
+          },
+          "required": [
+            "timestamp",
+            "value",
+            "sourceType"
+          ],
+          "title": "History",
+          "type": "object"
+        },
         "Meta": {
           "properties": {
             "op": {
@@ -650,6 +1106,24 @@
             ]
           },
           "title": "Properties"
+        },
+        "propertiesWithHistory": {
+          "anyOf": [
+            {
+              "additionalProperties": {
+                "items": {
+                  "$ref": "#/$defs/History"
+                },
+                "type": "array"
+              },
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Propertieswithhistory"
         },
         "associations": {
           "additionalProperties": false,
@@ -680,6 +1154,67 @@
     },
     "documentSchema": {
       "$defs": {
+        "History": {
+          "additionalProperties": false,
+          "properties": {
+            "timestamp": {
+              "format": "date-time",
+              "title": "Timestamp",
+              "type": "string"
+            },
+            "value": {
+              "title": "Value",
+              "type": "string"
+            },
+            "sourceType": {
+              "title": "Sourcetype",
+              "type": "string"
+            },
+            "sourceId": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "title": "Sourceid"
+            },
+            "sourceLabel": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "title": "Sourcelabel"
+            },
+            "updatedByUserId": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "title": "Updatedbyuserid"
+            }
+          },
+          "required": [
+            "timestamp",
+            "value",
+            "sourceType"
+          ],
+          "title": "History",
+          "type": "object"
+        },
         "Meta": {
           "properties": {
             "op": {
@@ -749,6 +1284,24 @@
             ]
           },
           "title": "Properties"
+        },
+        "propertiesWithHistory": {
+          "anyOf": [
+            {
+              "additionalProperties": {
+                "items": {
+                  "$ref": "#/$defs/History"
+                },
+                "type": "array"
+              },
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Propertieswithhistory"
         },
         "associations": {
           "additionalProperties": false,


### PR DESCRIPTION
**Description:**

Since the top-level document has `additionalProperties: false`, the optional `propertiesWithHistory` property needs to be in the schema, otherwise when the option is turned on the capture this property there will be a schema violation.

This adds the property back to the schema, but makes it nullable, since it won't always be there.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2263)
<!-- Reviewable:end -->
