### PR TITLE
materialize-boilerplate: fix race condition in extended logger

### DIFF
--- a/materialize-boilerplate/logging_test.go
+++ b/materialize-boilerplate/logging_test.go
@@ -1,0 +1,38 @@
+package boilerplate
+
+import (
+	"sync"
+	"testing"
+
+	log "github.com/sirupsen/logrus"
+)
+
+func TestExtendedLoggerWaitingForDocsRace(t *testing.T) {
+	// TODO(whb): If we ever start running our tests with the -race flag
+	// enabled, this outer loop won't be necessary. As is, running the enclosed
+	// sequence ~100 times or so will reliably produce a panic unless sufficient
+	// synchronization is provided in the extended logger event handler.
+	for idx := 0; idx < 100; idx++ {
+		be := newBindingEvents()
+		logger := newExtendedLogger(loggerAtLevel{lvl: log.InfoLevel}, be)
+		handler := logger.handler()
+
+		handler(sentStartedCommit)
+
+		var wg sync.WaitGroup
+		wg.Add(2)
+		go func() {
+			for idx := 0; idx < 10; idx++ {
+				handler(readLoad)
+			}
+			wg.Done()
+		}()
+
+		go func() {
+			handler(sentAcknowledged)
+			wg.Done()
+		}()
+
+		wg.Wait()
+	}
+}


### PR DESCRIPTION
**Description:**

Materializations can send acknowledgement messages concurrently with reading load or flush messages. This would show up occasionally as a panic due to concurrent access of variables in the "waiting for documents" part of the extendedLogger event handler.

This adds a mutex to guard that concurrent access.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2264)
<!-- Reviewable:end -->
