### PR TITLE
source-firestore: Increase re-backfill period from 6h to 24h

### DIFF
--- a/source-firestore/pull.go
+++ b/source-firestore/pull.go
@@ -48,7 +48,7 @@ const progressLogInterval = 10000
 //
 // TODO(wgd): Consider making this user-configurable?
 const (
-	backfillRestartDelayNoRestartCursor   = 6 * time.Hour
+	backfillRestartDelayNoRestartCursor   = 24 * time.Hour
 	backfillRestartDelayWithRestartCursor = 5 * time.Minute
 )
 


### PR DESCRIPTION
**Description:**

Typically the whole "we have to go re-backfill the collection because it's inconsistent" thing only triggers on massive collections which are likely to fail again in the future, _and_ Firestore is really an expensive datastore, so having a default of re-backfilling these collections at most once per day is a nontrivial cost savings.

I'm taking the simplest, dumbest possible route here and just changing the existing hard-coded constant from 6 to 24 hours.

I'd like to go and make this user-configurable at some point, but that's actually more complicated than it seems because of how multiple bindings can share a collection ID and thus fail and need restarting as a group.

This fixes https://github.com/estuary/connectors/issues/2250

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2266)
<!-- Reviewable:end -->
