### PR TITLE
source-*-batch: Timeouts and partial-progress logging

### DIFF
--- a/source-bigquery-batch/driver.go
+++ b/source-bigquery-batch/driver.go
@@ -701,12 +701,19 @@ func (c *capture) poll(ctx context.Context, binding *bindingInfo, tmpl *template
 				return err
 			}
 		}
+		if count%100000 == 1 {
+			log.WithFields(log.Fields{
+				"name":  res.Name,
+				"count": count,
+			}).Info("processing query results")
+		}
 	}
 
 	log.WithFields(log.Fields{
+		"name":  res.Name,
 		"query": query,
 		"count": count,
-	}).Info("query complete")
+	}).Info("polling complete")
 	state.LastPolled = pollTime
 	if err := c.streamStateCheckpoint(stateKey, state); err != nil {
 		return err

--- a/source-bigquery-batch/driver.go
+++ b/source-bigquery-batch/driver.go
@@ -32,6 +32,21 @@ const (
 	// on overall throughput, and isn't really needed anyway. So instead we emit one for
 	// every N rows, plus one when the query results are fully processed.
 	documentsPerCheckpoint = 1000
+
+	// We have a watchdog timeout which fires if we're sitting there waiting for query
+	// results but haven't received anything for a while. This constant specifies the
+	// duration of that timeout while waiting for for the first result row.
+	//
+	// It is useful to have two different timeouts for the first result row versus any
+	// subsequent rows, because sometimes when using a cursor the queries can have some
+	// nontrivial startup cost and we don't want to make things any more failure-prone
+	// than we have to.
+	pollingWatchdogFirstRowTimeout = 30 * time.Minute
+
+	// The duration of the no-data watchdog for subsequent rows after the first one.
+	// This timeout can be less generous, because after the first row is received we
+	// ought to be getting a consistent stream of results until the query completes.
+	pollingWatchdogTimeout = 5 * time.Minute
 )
 
 var (
@@ -615,6 +630,14 @@ func (c *capture) poll(ctx context.Context, binding *bindingInfo, tmpl *template
 	}).Info("executing query")
 	var pollTime = time.Now().UTC()
 
+	// Set up a watchdog timeout which will terminate the capture task if no data is
+	// received after a long period of time. The deferred stop ensures that the timeout
+	// will always be cancelled for good when the polling operation finishes.
+	var watchdog = time.AfterFunc(pollingWatchdogFirstRowTimeout, func() {
+		log.WithField("name", res.Name).Fatal("polling timed out")
+	})
+	defer watchdog.Stop()
+
 	var q = c.DB.Query(query)
 	var params []bigquery.QueryParameter
 	for idx, val := range cursorValues {
@@ -643,6 +666,7 @@ func (c *capture) poll(ctx context.Context, binding *bindingInfo, tmpl *template
 		} else if err != nil {
 			return fmt.Errorf("error reading result row: %w", err)
 		}
+		watchdog.Reset(pollingWatchdogTimeout) // Reset the no-data watchdog timeout after each row received
 
 		if shape == nil {
 			// Construct a Shape corresponding to the columns of these result rows

--- a/source-postgres-batch/driver.go
+++ b/source-postgres-batch/driver.go
@@ -725,12 +725,19 @@ func (c *capture) poll(ctx context.Context, binding *bindingInfo, tmpl *template
 				return err
 			}
 		}
+		if count%100000 == 1 {
+			log.WithFields(log.Fields{
+				"name":  res.Name,
+				"count": count,
+			}).Info("processing query results")
+		}
 	}
 
 	log.WithFields(log.Fields{
+		"name":  res.Name,
 		"query": query,
 		"count": count,
-	}).Info("query complete")
+	}).Info("polling complete")
 	if err := rows.Err(); err != nil {
 		return fmt.Errorf("error processing results iterator: %w", err)
 	}

--- a/source-postgres-batch/driver.go
+++ b/source-postgres-batch/driver.go
@@ -29,6 +29,21 @@ const (
 	// throughput, and isn't really needed anyway. So instead we emit one for every
 	// N rows, plus another when the query results are fully processed.
 	documentsPerCheckpoint = 1000
+
+	// We have a watchdog timeout which fires if we're sitting there waiting for query
+	// results but haven't received anything for a while. This constant specifies the
+	// duration of that timeout while waiting for for the first result row.
+	//
+	// It is useful to have two different timeouts for the first result row versus any
+	// subsequent rows, because sometimes when using a cursor the queries can have some
+	// nontrivial startup cost and we don't want to make things any more failure-prone
+	// than we have to.
+	pollingWatchdogFirstRowTimeout = 30 * time.Minute
+
+	// The duration of the no-data watchdog for subsequent rows after the first one.
+	// This timeout can be less generous, because after the first row is received we
+	// ought to be getting a consistent stream of results until the query completes.
+	pollingWatchdogTimeout = 5 * time.Minute
 )
 
 // BatchSQLDriver represents a generic "batch SQL" capture behavior, parameterized
@@ -643,6 +658,14 @@ func (c *capture) poll(ctx context.Context, binding *bindingInfo, tmpl *template
 	}).Info("executing query")
 	var pollTime = time.Now().UTC()
 
+	// Set up a watchdog timeout which will terminate the capture task if no data is
+	// received after a long period of time. The deferred stop ensures that the timeout
+	// will always be cancelled for good when the polling operation finishes.
+	var watchdog = time.AfterFunc(pollingWatchdogFirstRowTimeout, func() {
+		log.WithField("name", res.Name).Fatal("polling timed out")
+	})
+	defer watchdog.Stop()
+
 	rows, err := c.DB.QueryContext(ctx, query, cursorValues...)
 	if err != nil {
 		return fmt.Errorf("error executing query: %w", err)
@@ -689,6 +712,7 @@ func (c *capture) poll(ctx context.Context, binding *bindingInfo, tmpl *template
 		if err := rows.Scan(columnPointers...); err != nil {
 			return fmt.Errorf("error scanning result row: %w", err)
 		}
+		watchdog.Reset(pollingWatchdogTimeout) // Reset the no-data watchdog timeout after each row received
 
 		for idx, val := range columnValues {
 			var translatedVal, err = c.TranslateValue(val, columnTypes[idx].DatabaseTypeName())

--- a/source-redshift-batch/driver.go
+++ b/source-redshift-batch/driver.go
@@ -898,12 +898,19 @@ func (c *capture) poll(ctx context.Context, binding *bindingInfo, tmpl *template
 				return err
 			}
 		}
+		if count%100000 == 1 {
+			log.WithFields(log.Fields{
+				"name":  res.Name,
+				"count": count,
+			}).Info("processing query results")
+		}
 	}
 
 	log.WithFields(log.Fields{
+		"name":  res.Name,
 		"query": query,
 		"count": count,
-	}).Info("query complete")
+	}).Info("polling complete")
 	if err := rows.Err(); err != nil {
 		return fmt.Errorf("error processing results iterator: %w", err)
 	}


### PR DESCRIPTION
**Description:**

This PR adds no-data watchdog timeouts to all of the batch SQL connectors, such that if a long period of time passes without any rows being received (when we're awaiting polling query results) it will kill the capture. The time period is pretty generous: 30 minutes when we're waiting for the first result row and 5 minutes for subsequent rows. Pretty much the only times this watchdog should fire are:

 - When the database connection has silently dropped on us (which is a thing that happens sometimes, especially when using SSH tunneling)
 - When the polling query is performing a full-table sort on some massive dataset. And generally speaking if that hasn't finished after 30 minutes it's not likely that we'll actually end up with a successful capture and a pleasant user experience anyway.

I'm still a _little bit_ concerned that even a 30 minute timeout on the initial result rows might cause us to error out in situations where we otherwise could have just kept waiting and eventually gotten results. For example if it takes an hour to sort a particular table but we're only polling it once a day and the user is okay with the DB load of that full-table sort, then in that one particular scenario the user would be better-served by a connector without any such watchdog timeout.

But I think that in practice that scenario basically never happens. Note that when we're doing a cursorless full-refresh of a table we just issue a `SELECT * FROM foobar` query without any ordering, so the ordering clause only comes into play when the user has set up a cursor and clearly _wants_ more efficient incremental sync behavior. So 30 minutes is probably fine. Even ten minutes would probably be fine.

This PR also adds a couple much smaller improvements:

- Partial-progress logging so we can tell when looking at the task logs whether a capture was sitting there idly waiting for results, or whether it was furiously processing results but there were just a lot of them.
- MySQL connection timeouts, the same as we use on the MySQL CDC connector. This is just for consistency with the CDC connector, and because I was already working on "batch MySQL timeouts" and so it seemed related-enough to throw in at the same time.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2267)
<!-- Reviewable:end -->
