### PR TITLE
source-facebook-marketing: remove wish_bid from `ads_insights.json`

### DIFF
--- a/source-facebook-marketing/source_facebook_marketing/schemas/ads_insights.json
+++ b/source-facebook-marketing/source_facebook_marketing/schemas/ads_insights.json
@@ -309,9 +309,6 @@
     },
     "website_purchase_roas": {
       "$ref": "ads_action_stats.json"
-    },
-    "wish_bid": {
-      "type": ["null", "number"]
     }
   },
   "type": ["object"],

--- a/source-facebook-marketing/tests/snapshots/snapshots__discover__capture.stdout.json
+++ b/source-facebook-marketing/tests/snapshots/snapshots__discover__capture.stdout.json
@@ -15852,12 +15852,6 @@
             }
           }
         },
-        "wish_bid": {
-          "type": [
-            "null",
-            "number"
-          ]
-        },
         "_meta": {
           "type": "object",
           "properties": {
@@ -19538,12 +19532,6 @@
               }
             }
           }
-        },
-        "wish_bid": {
-          "type": [
-            "null",
-            "number"
-          ]
         },
         "age": {
           "type": [
@@ -23242,12 +23230,6 @@
             }
           }
         },
-        "wish_bid": {
-          "type": [
-            "null",
-            "number"
-          ]
-        },
         "country": {
           "type": [
             "null",
@@ -26936,12 +26918,6 @@
               }
             }
           }
-        },
-        "wish_bid": {
-          "type": [
-            "null",
-            "number"
-          ]
         },
         "region": {
           "type": [
@@ -30632,12 +30608,6 @@
             }
           }
         },
-        "wish_bid": {
-          "type": [
-            "null",
-            "number"
-          ]
-        },
         "dma": {
           "type": [
             "null",
@@ -34326,12 +34296,6 @@
               }
             }
           }
-        },
-        "wish_bid": {
-          "type": [
-            "null",
-            "number"
-          ]
         },
         "publisher_platform": {
           "type": [
@@ -38037,12 +38001,6 @@
               }
             }
           }
-        },
-        "wish_bid": {
-          "type": [
-            "null",
-            "number"
-          ]
         },
         "_meta": {
           "type": "object",


### PR DESCRIPTION
**Description:**

Multiple production tasks have encountered errors where any async job requesting the `wish_bid` field have started consistently failing on Facebook's side. Async jobs that do not request `wish_bid` still succeed.

Removing `wish_bid` from the `ads_insights.json` schema file also removes it from the list of fields requested from async jobs, and tasks that were previously failing should now work fine. It's unclear to me what changed that causes async jobs requesting the `wish_bid` field to fail, and maybe it can be added back later if there's motivation to investigate further & determine root cause.

Discover snapshot changes are expected since `wish_bid` has been removed from the `ads_insights` stream and its children.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

Tested on a local stack. Confirmed tasks that were previously failing due to failed async jobs during the `ads_insights` stream (and children) now completed & work fine.

Existing collections that contain documents with `wish_bid` values do not have `additionalProperties` explicitly set to `false`, so the now extra `wish_bid` field should not cause validation failures when reading from those collections.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2274)
<!-- Reviewable:end -->
