### PR TITLE
materialize-bigquery: use table read API for load query results

### DIFF
--- a/materialize-bigquery/bigquery.go
+++ b/materialize-bigquery/bigquery.go
@@ -84,7 +84,7 @@ func (c *config) client(ctx context.Context) (*client, error) {
 	if err != nil {
 		return nil, fmt.Errorf("creating bigquery client: %w", err)
 	}
-	if err := bigqueryClient.EnableStorageReadClient(ctx); err != nil {
+	if err := bigqueryClient.EnableStorageReadClient(ctx, clientOpts...); err != nil {
 		panic(err)
 	}
 

--- a/materialize-bigquery/bigquery.go
+++ b/materialize-bigquery/bigquery.go
@@ -84,6 +84,9 @@ func (c *config) client(ctx context.Context) (*client, error) {
 	if err != nil {
 		return nil, fmt.Errorf("creating bigquery client: %w", err)
 	}
+	if err := bigqueryClient.EnableStorageReadClient(ctx); err != nil {
+		panic(err)
+	}
 
 	cloudStorageClient, err := storage.NewClient(ctx, clientOpts...)
 	if err != nil {

--- a/materialize-bigquery/transactor.go
+++ b/materialize-bigquery/transactor.go
@@ -222,11 +222,12 @@ func (t *transactor) Load(it *m.LoadIterator, loaded func(int, json.RawMessage) 
 		return fmt.Errorf("load query: %w", err)
 	}
 
-	bqit, err := job.Read(ctx)
+	conf, err := job.Config()
 	if err != nil {
-		ll.WithError(err).Error("job read failed")
-		return fmt.Errorf("load job read: %w", err)
+		log.Fatal(fmt.Errorf("bigquery job config: %w", err))
 	}
+	queryConfig := conf.(*bigquery.QueryConfig)
+	bqit := t.client.bigqueryClient.DatasetInProject(queryConfig.Dst.ProjectID, queryConfig.Dst.DatasetID).Table(queryConfig.Dst.TableID).Read(ctx)
 	t.be.FinishedEvaluatingLoads()
 
 	for {

--- a/materialize-bigquery/transactor.go
+++ b/materialize-bigquery/transactor.go
@@ -222,12 +222,11 @@ func (t *transactor) Load(it *m.LoadIterator, loaded func(int, json.RawMessage) 
 		return fmt.Errorf("load query: %w", err)
 	}
 
-	conf, err := job.Config()
+	bqit, err := job.Read(ctx)
 	if err != nil {
-		log.Fatal(fmt.Errorf("bigquery job config: %w", err))
+		ll.WithError(err).Error("job read failed")
+		return fmt.Errorf("load job read: %w", err)
 	}
-	queryConfig := conf.(*bigquery.QueryConfig)
-	bqit := t.client.bigqueryClient.DatasetInProject(queryConfig.Dst.ProjectID, queryConfig.Dst.DatasetID).Table(queryConfig.Dst.TableID).Read(ctx)
 	t.be.FinishedEvaluatingLoads()
 
 	for {


### PR DESCRIPTION
Using the table read API to read the temporary table that stores the load query results is faster than using the "job read" API.

**Description:**

(Describe the high level scope of new or changed features)

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2275)
<!-- Reviewable:end -->
