### PR TITLE
materialize-bigquery: use the storage read API if available for load queries

### DIFF
--- a/materialize-bigquery/bigquery.go
+++ b/materialize-bigquery/bigquery.go
@@ -84,6 +84,14 @@ func (c *config) client(ctx context.Context) (*client, error) {
 	if err != nil {
 		return nil, fmt.Errorf("creating bigquery client: %w", err)
 	}
+	// Use the much faster storage read API for reading query results if the
+	// authorization provides sufficient access, typically via the "BigQuery
+	// Read Session User" role. Result iterators will automatically fall back to
+	// the standard but much slower job/table read API if the storage API can't
+	// be accessed.
+	if err := bigqueryClient.EnableStorageReadClient(ctx, clientOpts...); err != nil {
+		return nil, fmt.Errorf("enabling storage read client: %w", err)
+	}
 
 	cloudStorageClient, err := storage.NewClient(ctx, clientOpts...)
 	if err != nil {

--- a/materialize-bigquery/transactor.go
+++ b/materialize-bigquery/transactor.go
@@ -28,6 +28,8 @@ type transactor struct {
 
 	bindings []*binding
 	be       *boilerplate.BindingEvents
+
+	loggedStorageApiMessage bool
 }
 
 func newTransactor(
@@ -228,6 +230,11 @@ func (t *transactor) Load(it *m.LoadIterator, loaded func(int, json.RawMessage) 
 		return fmt.Errorf("load job read: %w", err)
 	}
 	t.be.FinishedEvaluatingLoads()
+
+	if !bqit.IsAccelerated() && !t.loggedStorageApiMessage {
+		log.Warn("not using the storage read API for load queries, performance may not be optimal. see https://go.estuary.dev/materialize-bigquery for more information")
+		t.loggedStorageApiMessage = true
+	}
 
 	for {
 		var bd bindingDocument


### PR DESCRIPTION
**Description:**

The storage read API is dramatically faster at retrieving large query results than the standard job read or table read API. On a test with 10 million rows of synthetic data returned by a load query, I have observed a reduction in processing time from ~21 minutes using the job read API down to ~3 minutes using the storage read API with a `materialize-bigquery` task running on our public data plane.

Historically we have not enabled the storage read API due to its extreme negative effect on memory usage in the connector. Based on testing with the more recent version of the BigQuery client we are now using, this memory situation seems to no longer be an issue at all, with query results read by the storage read API using comparable amounts of memory as the slower standard APIs.

This commit will enable the storage read API if possible. If it isn't possible, probably due to missing permissions, the standard APIs will be used automatically by the BigQuery client and we will log a message indicating that the faster API is not being used with a link to our documentation to help with enabling it.

Closes https://github.com/estuary/connectors/issues/968

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

Update `materialize-bigquery` docs with the recommendation to add the `BigQuery Read Session User` role to the service account used for the connector for optimal load query performance.

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2276)
<!-- Reviewable:end -->
