### PR TITLE
source-facebook-marketing: bump to API & SDK version 21.0

### DIFF
--- a/source-facebook-marketing/poetry.lock
+++ b/source-facebook-marketing/poetry.lock
@@ -264,6 +264,17 @@ files = [
 ]
 
 [[package]]
+name = "capi-param-builder"
+version = "5.1.0"
+description = "Sua descrição aqui"
+optional = false
+python-versions = ">=3.6"
+files = [
+    {file = "capi_param_builder-5.1.0-py3-none-any.whl", hash = "sha256:b4fc2a48d79a5d193c4716083706471213d1255b2778c2fa6251e4a4e9ed12c9"},
+    {file = "capi_param_builder-5.1.0.tar.gz", hash = "sha256:de801092ce24ee4f160095bb60e6c9eb10ae033d43e3791b45b1899f614fe44e"},
+]
+
+[[package]]
 name = "cattrs"
 version = "24.1.2"
 description = "Composable complex class support for attrs and dataclasses."
@@ -579,18 +590,6 @@ files = [
 ]
 
 [[package]]
-name = "enum34"
-version = "1.1.10"
-description = "Python 3.4 Enum backported to 3.3, 3.2, 3.1, 2.7, 2.6, 2.5, and 2.4"
-optional = false
-python-versions = "*"
-files = [
-    {file = "enum34-1.1.10-py2-none-any.whl", hash = "sha256:a98a201d6de3f2ab3db284e70a33b0f896fbf35f8086594e8c9e74b909058d53"},
-    {file = "enum34-1.1.10-py3-none-any.whl", hash = "sha256:c3858660960c984d6ab0ebad691265180da2b43f07e061c0f8dca9ef3cffd328"},
-    {file = "enum34-1.1.10.tar.gz", hash = "sha256:cce6a7477ed816bd2542d03d53db9f0db935dd013b70f336a95c73979289f248"},
-]
-
-[[package]]
 name = "estuary-cdk"
 version = "0.2.0"
 description = "Estuary Connector Development Kit"
@@ -612,19 +611,19 @@ url = "../estuary-cdk"
 
 [[package]]
 name = "facebook-business"
-version = "19.0.0"
+version = "21.0.0"
 description = "Facebook Business SDK"
 optional = false
 python-versions = "*"
 files = [
-    {file = "facebook_business-19.0.0-py3-none-any.whl", hash = "sha256:591deedc010cefeb49151bbfadf72659cf262056072b437ca3dbf0ba37b3fa43"},
-    {file = "facebook_business-19.0.0.tar.gz", hash = "sha256:e12ea2a13d1703922d1b5d3921bc67bd10176596770ce154f287019738775800"},
+    {file = "facebook_business-21.0.0-py3-none-any.whl", hash = "sha256:07ae97e60016df16371be19e58aa68835e186682c951bc0f6843f3219c358fe1"},
+    {file = "facebook_business-21.0.0.tar.gz", hash = "sha256:15e050e596c364ac3491a40a371d0e00188a74cef43e95edf718671fa79cd9fa"},
 ]
 
 [package.dependencies]
 aiohttp = {version = "*", markers = "python_version >= \"3.5.3\""}
+capi-param-builder = ">=0.1.0-dev0"
 curlify = ">=2.1.0"
-enum34 = {version = "*", markers = "python_version >= \"3\""}
 pycountry = ">=19.8.18"
 requests = ">=2.3.0"
 six = ">=1.7.3"
@@ -2190,4 +2189,4 @@ propcache = ">=0.2.0"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "946d5140824f65748ca3686ff70a0b0f8eeae35b97078204c6256b6d597a8836"
+content-hash = "14ef917b697c6d88335f8a691e0863376f55875ffeacd6606a04d4dceebb2082"

--- a/source-facebook-marketing/pyproject.toml
+++ b/source-facebook-marketing/pyproject.toml
@@ -9,7 +9,7 @@ airbyte-cdk = "^0.52"
 estuary-cdk = {path="../estuary-cdk", develop = true}
 python = "^3.11"
 types-requests = "^2.31"
-facebook-business = "19.0.0"
+facebook-business = "21.0.0"
 pydantic = "==1.10.14"
 cached-property = "^1.5.2"
 pendulum = "^3"

--- a/source-facebook-marketing/source_facebook_marketing/__main__.py
+++ b/source-facebook-marketing/source_facebook_marketing/__main__.py
@@ -9,9 +9,9 @@ asyncio.run(
         delegate=SourceFacebookMarketing(),
         oauth2=flow.OAuth2Spec(
             provider="facebook",
-            authUrlTemplate="https://www.facebook.com/v19.0/dialog/oauth?client_id={{#urlencode}}{{{ client_id }}}{{/urlencode}}&redirect_uri={{#urlencode}}{{{ redirect_uri }}}{{/urlencode}}&state={{#urlencode}}{{{  state }}}{{/urlencode}}&scope=ads_management,ads_read,read_insights,business_management",
+            authUrlTemplate="https://www.facebook.com/v21.0/dialog/oauth?client_id={{#urlencode}}{{{ client_id }}}{{/urlencode}}&redirect_uri={{#urlencode}}{{{ redirect_uri }}}{{/urlencode}}&state={{#urlencode}}{{{  state }}}{{/urlencode}}&scope=ads_management,ads_read,read_insights,business_management",
             accessTokenResponseMap={"access_token": "/access_token"},
-            accessTokenUrlTemplate="https://graph.facebook.com/v19.0/oauth/access_token?client_id={{#urlencode}}{{{ client_id }}}{{/urlencode}}&client_secret={{#urlencode}}{{{ client_secret }}}{{/urlencode}}&code={{#urlencode}}{{{ code }}}{{/urlencode}}&redirect_uri={{#urlencode}}{{{ redirect_uri }}}{{/urlencode}}",
+            accessTokenUrlTemplate="https://graph.facebook.com/v21.0/oauth/access_token?client_id={{#urlencode}}{{{ client_id }}}{{/urlencode}}&client_secret={{#urlencode}}{{{ client_secret }}}{{/urlencode}}&code={{#urlencode}}{{{ code }}}{{/urlencode}}&redirect_uri={{#urlencode}}{{{ redirect_uri }}}{{/urlencode}}",
             accessTokenBody="",  # Uses query arguments.
             accessTokenHeaders={},
         ),

--- a/source-facebook-marketing/source_facebook_marketing/api.py
+++ b/source-facebook-marketing/source_facebook_marketing/api.py
@@ -161,7 +161,7 @@ class API:
     def __init__(self, access_token: str):
         self._account_ids = {}
         # design flaw in MyFacebookAdsApi requires such strange set of new default api instance
-        self.api = MyFacebookAdsApi.init(access_token=access_token, crash_log=False, api_version="v19.0")
+        self.api = MyFacebookAdsApi.init(access_token=access_token, crash_log=False, api_version="v21.0")
         FacebookAdsApi.set_default_api(self.api)
 
     def get_account(self, account_id: str) -> AdAccount:

--- a/source-facebook-marketing/tests/snapshots/snapshots__spec__capture.stdout.json
+++ b/source-facebook-marketing/tests/snapshots/snapshots__spec__capture.stdout.json
@@ -105,6 +105,7 @@
                     "auction_bid",
                     "auction_competitiveness",
                     "auction_max_competitor_bid",
+                    "average_purchases_conversion_value",
                     "buying_type",
                     "campaign_id",
                     "campaign_name",
@@ -116,7 +117,6 @@
                     "catalog_segment_value_omni_purchase_roas",
                     "catalog_segment_value_website_purchase_roas",
                     "clicks",
-                    "conversion_lead_rate",
                     "conversion_rate_ranking",
                     "conversion_values",
                     "conversions",
@@ -127,7 +127,6 @@
                     "cost_per_action_type",
                     "cost_per_ad_click",
                     "cost_per_conversion",
-                    "cost_per_conversion_lead",
                     "cost_per_dda_countby_convs",
                     "cost_per_estimated_ad_recallers",
                     "cost_per_inline_link_click",
@@ -175,8 +174,10 @@
                     "marketing_messages_cost_per_delivered",
                     "marketing_messages_cost_per_link_btn_click",
                     "marketing_messages_spend",
+                    "marketing_messages_website_purchase_values",
                     "mobile_app_purchase_roas",
                     "objective",
+                    "onsite_conversion_messaging_detected_purchase_deduped",
                     "optimization_goal",
                     "outbound_clicks",
                     "outbound_clicks_ctr",
@@ -185,6 +186,7 @@
                     "qualifying_question_qualify_answer_rate",
                     "quality_ranking",
                     "reach",
+                    "shops_assisted_purchases",
                     "social_spend",
                     "spend",
                     "total_postbacks",
@@ -237,8 +239,10 @@
                     "age",
                     "app_id",
                     "body_asset",
+                    "breakdown_reporting_ad_id",
                     "call_to_action_asset",
                     "coarse_conversion_value",
+                    "conversion_destination",
                     "country",
                     "description_asset",
                     "device_platform",
@@ -252,6 +256,7 @@
                     "image_asset",
                     "impression_device",
                     "is_conversion_id_modeled",
+                    "is_rendered_as_delayed_skip_ad",
                     "landing_destination",
                     "link_url_asset",
                     "marketing_messages_btn_name",
@@ -262,6 +267,7 @@
                     "media_format",
                     "media_origin_url",
                     "media_text_content",
+                    "media_type",
                     "mmm",
                     "place_page_id",
                     "platform_position",
@@ -270,11 +276,14 @@
                     "publisher_platform",
                     "redownload",
                     "region",
+                    "signal_source_bucket",
                     "skan_campaign_id",
                     "skan_conversion_id",
                     "skan_version",
                     "standard_event_content_type",
                     "title_asset",
+                    "user_persona_id",
+                    "user_persona_name",
                     "video_asset"
                   ]
                 }
@@ -298,6 +307,10 @@
                     "action_type",
                     "action_video_sound",
                     "action_video_type",
+                    "conversion_destination",
+                    "matched_persona_id",
+                    "matched_persona_name",
+                    "signal_source_bucket",
                     "standard_event_content_type"
                   ]
                 }
@@ -454,8 +467,8 @@
     "documentationUrl": "https://go.estuary.dev/facebook-marketing",
     "oauth2": {
       "provider": "facebook",
-      "authUrlTemplate": "https://www.facebook.com/v19.0/dialog/oauth?client_id={{#urlencode}}{{{ client_id }}}{{/urlencode}}&redirect_uri={{#urlencode}}{{{ redirect_uri }}}{{/urlencode}}&state={{#urlencode}}{{{  state }}}{{/urlencode}}&scope=ads_management,ads_read,read_insights,business_management",
-      "accessTokenUrlTemplate": "https://graph.facebook.com/v19.0/oauth/access_token?client_id={{#urlencode}}{{{ client_id }}}{{/urlencode}}&client_secret={{#urlencode}}{{{ client_secret }}}{{/urlencode}}&code={{#urlencode}}{{{ code }}}{{/urlencode}}&redirect_uri={{#urlencode}}{{{ redirect_uri }}}{{/urlencode}}",
+      "authUrlTemplate": "https://www.facebook.com/v21.0/dialog/oauth?client_id={{#urlencode}}{{{ client_id }}}{{/urlencode}}&redirect_uri={{#urlencode}}{{{ redirect_uri }}}{{/urlencode}}&state={{#urlencode}}{{{  state }}}{{/urlencode}}&scope=ads_management,ads_read,read_insights,business_management",
+      "accessTokenUrlTemplate": "https://graph.facebook.com/v21.0/oauth/access_token?client_id={{#urlencode}}{{{ client_id }}}{{/urlencode}}&client_secret={{#urlencode}}{{{ client_secret }}}{{/urlencode}}&code={{#urlencode}}{{{ code }}}{{/urlencode}}&redirect_uri={{#urlencode}}{{{ redirect_uri }}}{{/urlencode}}",
       "accessTokenResponseMap": {
         "access_token": "/access_token"
       }


### PR DESCRIPTION
**Description:**

The Facebook Marketing API v19.0 is available until 04FEB2025, so this commit bumps the connector up to use the most recent version 21.0. No significant differences affecting the connector were noted while testing the connector & reviewing Facebook's changelogs for [v20.0](https://developers.facebook.com/docs/marketing-api/marketing-api-changelog/version20.0) and [v21.0](https://developers.facebook.com/docs/marketing-api/marketing-api-changelog/version21.0) & the `facebook-business` SDK's [changelog](https://github.com/facebook/facebook-python-business-sdk/compare/19.0.0...21.0.0).

Spec snapshot changes are expected - various insights fields were removed / added. Although those new fields could be added to the `ads_insights.json` schema file, I figure we can wait & see if anyone actually wants those fields before making that update.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

Tested on a local stack with a few separate Facebook Marketing accounts. Confirmed:
- the connector works after upgrading the API and SDK versions to 21.0.
- no schema violation occur for streams after the upgrade.
- no existing tasks are using custom insights with the deprecated `conversion_lead_rate` or `cost_per_conversion_lead` fields.

