### PR TITLE
source-postgres: Make stream-to-fence watchdog 12 hours

### DIFF
--- a/source-postgres/replication.go
+++ b/source-postgres/replication.go
@@ -249,7 +249,7 @@ var (
 	// operation will error out if no further events are received when there ought to be
 	// some. This should never be hit in normal operation, and exists only so that certain
 	// rare failure modes produce an error rather than blocking forever.
-	streamToFenceWatchdogTimeout = 5 * time.Minute
+	streamToFenceWatchdogTimeout = 12 * 60 * time.Minute
 )
 
 func (s *replicationStream) StreamToFence(ctx context.Context, fenceAfter time.Duration, callback func(event sqlcapture.DatabaseEvent) error) error {


### PR DESCRIPTION
**Description:**

It's causing problem for at least one production task and the failure mode this guards against is much less important in the immediate term than allowing production to catch back up.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2285)
<!-- Reviewable:end -->
