### PR TITLE
source-zendesk-support: update `ticket_audits` to checkpoint during backfills

### DIFF
--- a/source-zendesk-support/acmeCo/ticket_audits.schema.yaml
+++ b/source-zendesk-support/acmeCo/ticket_audits.schema.yaml
@@ -295,6 +295,101 @@ properties:
           type:
             - "null"
             - string
+            - object
+            - array
+          properties:
+            html_url:
+              type:
+                - "null"
+                - string
+            id:
+              type:
+                - "null"
+                - integer
+            locale:
+              type:
+                - "null"
+                - string
+            title:
+              type:
+                - "null"
+                - string
+            url:
+              type:
+                - "null"
+                - string
+          items:
+            type:
+              - "null"
+              - object
+            properties:
+              article:
+                type:
+                  - "null"
+                  - object
+                properties:
+                  article_id:
+                    type:
+                      - "null"
+                      - integer
+                  brand_id:
+                    type:
+                      - "null"
+                      - integer
+                  html_url:
+                    type:
+                      - "null"
+                      - string
+                  id:
+                    type:
+                      - "null"
+                      - integer
+                  locale:
+                    type:
+                      - "null"
+                      - string
+                  score:
+                    type:
+                      - "null"
+                      - number
+                  title:
+                    type:
+                      - "null"
+                      - string
+                  url:
+                    type:
+                      - "null"
+                      - string
+              reviews:
+                type:
+                  - "null"
+                  - object
+                properties:
+                  agent:
+                    type:
+                      - "null"
+                      - array
+                    items:
+                      type:
+                        - "null"
+                        - string
+                  enduser:
+                    type:
+                      - "null"
+                      - object
+                    properties:
+                      reason:
+                        type:
+                          - "null"
+                          - string
+                      user_id:
+                        type:
+                          - "null"
+                          - integer
+              viewed:
+                type:
+                  - "null"
+                  - boolean
         recipients:
           type:
             - "null"
@@ -319,6 +414,25 @@ properties:
           type:
             - "null"
             - string
+            - array
+            - object
+          items:
+            type:
+              - "null"
+              - string
+          properties:
+            in_business_hours:
+              type:
+                - "null"
+                - boolean
+            minute:
+              type:
+                - "null"
+                - integer
+            seconds:
+              type:
+                - "null"
+                - integer
         macro_title:
           type:
             - "null"

--- a/source-zendesk-support/source_zendesk_support/schemas/ticket_audits.json
+++ b/source-zendesk-support/source_zendesk_support/schemas/ticket_audits.json
@@ -165,7 +165,83 @@
             "type": ["null", "string"]
           },
           "body": {
-            "type": ["null", "string"]
+            "type": ["null", "string", "object", "array"],
+            "properties": {
+                "html_url": {
+                    "type": ["null", "string"]
+                },
+                "id": {
+                    "type": ["null", "integer"]
+                },
+                "locale": {
+                    "type": ["null", "string"]
+                },
+                "title": {
+                    "type": ["null", "string"]
+                },
+                "url": {
+                    "type": ["null", "string"]
+                }
+            },
+            "items": {
+                "type": ["null", "object"],
+                "properties": {
+                    "article": {
+                        "type": ["null", "object"],
+                        "properties": {
+                            "article_id": {
+                                "type": ["null", "integer"]
+                            },
+                            "brand_id": {
+                                "type": ["null", "integer"]
+                            },
+                            "html_url": {
+                                "type": ["null", "string"]
+                            },
+                            "id": {
+                                "type": ["null", "integer"]
+                            },
+                            "locale": {
+                                "type": ["null", "string"]
+                            },
+                            "score": {
+                                "type": ["null", "number"]
+                            },
+                            "title": {
+                                "type": ["null", "string"]
+                            },
+                            "url": {
+                                "type": ["null", "string"]
+                            }
+                        }
+                    },
+                    "reviews": {
+                        "type": ["null", "object"],
+                        "properties": {
+                            "agent": {
+                                "type": ["null", "array"],
+                                "items": {
+                                    "type": ["null", "string"]
+                                }
+                            },
+                            "enduser": {
+                                "type": ["null", "object"],
+                                "properties": {
+                                    "reason": {
+                                        "type": ["null", "string"]
+                                    },
+                                    "user_id": {
+                                        "type": ["null", "integer"]
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "viewed": {
+                        "type": ["null", "boolean"]
+                    }
+                }
+            }
           },
           "recipients": {
             "type": ["null", "array"],
@@ -183,7 +259,21 @@
             "type": ["null", "integer"]
           },
           "previous_value": {
-            "type": ["null", "string"]
+            "type": ["null", "string", "array", "object"],
+            "items": {
+                "type": ["null", "string"]
+            },
+            "properties": {
+                "in_business_hours": {
+                    "type": ["null", "boolean"]
+                },
+                "minute": {
+                    "type": ["null", "integer"]
+                },
+                "seconds": {
+                    "type": ["null", "integer"]
+                }
+            }
           },
           "macro_title": {
             "type": ["null", "string"]

--- a/source-zendesk-support/source_zendesk_support/streams.py
+++ b/source-zendesk-support/source_zendesk_support/streams.py
@@ -835,6 +835,18 @@ class Tickets(SourceZendeskSupportIncrementalCursorExportStream):
         """
         return SourceZendeskIncrementalExportStream.check_start_time_param(requested_start_time, value=3)
 
+    def parse_response(self, response: requests.Response, **kwargs) -> Iterable[Mapping]:
+        for record in super().parse_response(response, **kwargs):
+            # Additional handling to coerce custom fields' boolean values to strings.
+            custom_fields = record.get("custom_fields", [])
+
+            for field in custom_fields:
+                value = field.get("value", None)
+                if isinstance(value, bool):
+                    field["value"] = str(value).lower()
+
+            yield record
+
 
 class TicketComments(SourceZendeskSupportTicketEventsExportStream):
     """

--- a/source-zendesk-support/test.flow.yaml
+++ b/source-zendesk-support/test.flow.yaml
@@ -84,7 +84,7 @@ captures:
           stream: ticket_audits
           syncMode: incremental
           cursorField:
-            - created_at
+            - after_cursor
         target: acmeCo/ticket_audits
       - resource:
           stream: ticket_comments

--- a/source-zendesk-support/tests/snapshots/snapshots__capture__capture.stdout.json
+++ b/source-zendesk-support/tests/snapshots/snapshots__capture__capture.stdout.json
@@ -577,6 +577,7 @@
         "description": "Hi there,\n\nI\u2019m sending an email because I\u2019m having a problem setting up your new product. Can you help me troubleshoot?\n\nThanks,\n The Customer\n\n",
         "due_at": null,
         "email_cc_ids": [],
+        "encoded_id": "Y4NVZV-M3XM2",
         "external_id": null,
         "fields": [
           {
@@ -653,6 +654,7 @@
       "description": "Hi there,\n\nI\u2019m sending an email because I\u2019m having a problem setting up your new product. Can you help me troubleshoot?\n\nThanks,\n The Customer\n\n",
       "due_at": null,
       "email_cc_ids": [],
+      "encoded_id": "Y4NVZV-M3XM2",
       "external_id": null,
       "fields": [
         {
@@ -792,6 +794,10 @@
         "end_user_list_access": "full",
         "end_user_profile_access": "readonly",
         "explore_access": "readonly",
+        "explore_reports": {
+          "ticket_access": "all",
+          "ticket_access_selected_groups": []
+        },
         "forum_access": "readonly",
         "forum_access_restricted_content": false,
         "group_access": false,

--- a/source-zendesk-support/tests/snapshots/snapshots__discover__capture.stdout.json
+++ b/source-zendesk-support/tests/snapshots/snapshots__discover__capture.stdout.json
@@ -1308,7 +1308,7 @@
       "stream": "ticket_audits",
       "syncMode": "incremental",
       "cursorField": [
-        "created_at"
+        "after_cursor"
       ]
     },
     "documentSchema": {
@@ -1760,8 +1760,152 @@
               "body": {
                 "type": [
                   "null",
-                  "string"
-                ]
+                  "string",
+                  "object",
+                  "array"
+                ],
+                "properties": {
+                  "html_url": {
+                    "type": [
+                      "null",
+                      "string"
+                    ]
+                  },
+                  "id": {
+                    "type": [
+                      "null",
+                      "integer"
+                    ]
+                  },
+                  "locale": {
+                    "type": [
+                      "null",
+                      "string"
+                    ]
+                  },
+                  "title": {
+                    "type": [
+                      "null",
+                      "string"
+                    ]
+                  },
+                  "url": {
+                    "type": [
+                      "null",
+                      "string"
+                    ]
+                  }
+                },
+                "items": {
+                  "type": [
+                    "null",
+                    "object"
+                  ],
+                  "properties": {
+                    "article": {
+                      "type": [
+                        "null",
+                        "object"
+                      ],
+                      "properties": {
+                        "article_id": {
+                          "type": [
+                            "null",
+                            "integer"
+                          ]
+                        },
+                        "brand_id": {
+                          "type": [
+                            "null",
+                            "integer"
+                          ]
+                        },
+                        "html_url": {
+                          "type": [
+                            "null",
+                            "string"
+                          ]
+                        },
+                        "id": {
+                          "type": [
+                            "null",
+                            "integer"
+                          ]
+                        },
+                        "locale": {
+                          "type": [
+                            "null",
+                            "string"
+                          ]
+                        },
+                        "score": {
+                          "type": [
+                            "null",
+                            "number"
+                          ]
+                        },
+                        "title": {
+                          "type": [
+                            "null",
+                            "string"
+                          ]
+                        },
+                        "url": {
+                          "type": [
+                            "null",
+                            "string"
+                          ]
+                        }
+                      }
+                    },
+                    "reviews": {
+                      "type": [
+                        "null",
+                        "object"
+                      ],
+                      "properties": {
+                        "agent": {
+                          "type": [
+                            "null",
+                            "array"
+                          ],
+                          "items": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          }
+                        },
+                        "enduser": {
+                          "type": [
+                            "null",
+                            "object"
+                          ],
+                          "properties": {
+                            "reason": {
+                              "type": [
+                                "null",
+                                "string"
+                              ]
+                            },
+                            "user_id": {
+                              "type": [
+                                "null",
+                                "integer"
+                              ]
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "viewed": {
+                      "type": [
+                        "null",
+                        "boolean"
+                      ]
+                    }
+                  }
+                }
               },
               "recipients": {
                 "type": [
@@ -1796,8 +1940,36 @@
               "previous_value": {
                 "type": [
                   "null",
-                  "string"
-                ]
+                  "string",
+                  "array",
+                  "object"
+                ],
+                "items": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "properties": {
+                  "in_business_hours": {
+                    "type": [
+                      "null",
+                      "boolean"
+                    ]
+                  },
+                  "minute": {
+                    "type": [
+                      "null",
+                      "integer"
+                    ]
+                  },
+                  "seconds": {
+                    "type": [
+                      "null",
+                      "integer"
+                    ]
+                  }
+                }
               },
               "macro_title": {
                 "type": [

--- a/source-zendesk-support/tests/unit_test.py
+++ b/source-zendesk-support/tests/unit_test.py
@@ -296,7 +296,6 @@ class TestAllStreams:
             (SatisfactionRatings, "satisfaction_ratings"),
             (SlaPolicies, "slas/policies.json"),
             (Tags, "tags"),
-            (TicketAudits, "ticket_audits"),
             (TicketComments, "incremental/ticket_events.json"),
             (TicketFields, "ticket_fields"),
             (TicketForms, "ticket_forms"),
@@ -317,7 +316,6 @@ class TestAllStreams:
             "SatisfactionRatings",
             "SlaPolicies",
             "Tags",
-            "TicketAudits",
             "TicketComments",
             "TicketFields",
             "TicketForms",
@@ -518,7 +516,6 @@ class TestSourceZendeskSupportCursorPaginationStream:
             (GroupMemberships, {}, {"updated_at": "2022-03-17T16:03:07Z"}, {"updated_at": "2022-03-17T16:03:07Z"}),
             (TicketForms, {}, {"updated_at": "2023-03-17T16:03:07Z"}, {"updated_at": "2023-03-17T16:03:07Z"}),
             (TicketMetricEvents, {}, {"time": "2024-03-17T16:03:07Z"}, {"time": "2024-03-17T16:03:07Z"}),
-            (TicketAudits, {}, {"created_at": "2025-03-17T16:03:07Z"}, {"created_at": "2025-03-17T16:03:07Z"}),
             (OrganizationMemberships, {}, {"updated_at": "2025-03-17T16:03:07Z"}, {"updated_at": "2025-03-17T16:03:07Z"}),
         ],
         ids=[
@@ -526,7 +523,6 @@ class TestSourceZendeskSupportCursorPaginationStream:
             "GroupMemberships",
             "TicketForms",
             "TicketMetricEvents",
-            "TicketAudits",
             "OrganizationMemberships",
         ],
     )
@@ -581,7 +577,6 @@ class TestSourceZendeskSupportCursorPaginationStream:
             (GroupMemberships, 1622505600),
             (TicketForms, 1622505600),
             (TicketMetricEvents, 1622505600),
-            (TicketAudits, 1622505600),
             (OrganizationMemberships, 1622505600),
         ],
         ids=[
@@ -589,7 +584,6 @@ class TestSourceZendeskSupportCursorPaginationStream:
             "GroupMemberships",
             "TicketForms",
             "TicketMetricEvents",
-            "TicketAudits",
             "OrganizationMemberships",
         ],
     )
@@ -605,7 +599,7 @@ class TestSourceZendeskSupportCursorPaginationStream:
             (GroupMemberships, {"page[size]": 100, "start_time": 1622505600, "sort_by": "asc"}),
             (TicketForms, {}),
             (TicketMetricEvents, {"page[size]": 1000, "start_time": 1622505600}),
-            (TicketAudits, {"limit": 200}),
+            (TicketAudits, {"page[size]": 100}),
             (SatisfactionRatings, {"page[size]": 100, "start_time": 1622505600}),
             (OrganizationMemberships, {"page[size]": 100, "start_time": 1622505600})
         ],
@@ -881,7 +875,7 @@ def test_read_tickets_stream(requests_mock):
                 {"id": 360023382300, "value": None},
                 {"id": 360004841380, "value": "customer_tickets"},
                 {"id": 360022469240, "value": "5"},
-                {"id": 360023712840, "value": "False"},
+                {"id": 360023712840, "value": "false"},
             ]
         },
     ]


### PR DESCRIPTION
**Description:**

The previously used `/ticket_audits` endpoint used to list all ticket audits always returns results in descending order and did not let us specify a date window/start date to filter what results are returned. This prevented the connector from checkpointing during backfills, and if backfills spanned 24+ hours, they wouldn't complete since the CDK restarts the connector after it's been running for 24 hours.

The `ticket_audits` stream now uses `tickets` as a parent stream, fetching an updated ticket then fetching the audits for that ticket. Although this makes the stream slower since it now makes more HTTP requests to get results, this is the only way I found to get `ticket_audits` in ascending order & let us checkpoint progress for backfills spanning 24+ hours.

Additional scope in this PR includes:
- Widening `schemas/ticket_audits.json` to account for schema violations encountered during testing
- Coercing any boolean values for custom fields in `tickets` to strings. This is the same processing implemented in https://github.com/estuary/connectors/pull/1802. This was also motivated by schema violations encountered during testing.
- Updating tests for the changes made in the PR.

Snapshot changes are expected. Discover snapshot changes are due to the changes to `ticket_audits` and schema widening. Capture snapshot changes are due to fields Zendesk added to some streams a while ago. These fields have been present and stable for a couple months now, so it should be alright to add them to the capture snapshot.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

Tested on a local stack. Confirmed:
- `ticket_audits` checkpoints during backfills.
- `tickets` and `users` streams' behaviors have not changed.
- no schema violations occurred for the relatively small date ranges I tested over.

All existing captures should backfill their `ticket_audits` stream after this PR is merged due to the state change.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2288)
<!-- Reviewable:end -->
