### PR TITLE
source-hubspot-native: use v3 of the owners API

### DIFF
--- a/source-hubspot-native/source_hubspot_native/resources.py
+++ b/source-hubspot-native/source_hubspot_native/resources.py
@@ -250,10 +250,6 @@ def deal_pipelines(http: HTTPSession) -> Resource:
 
 def owners(http: HTTPSession) -> Resource:
 
-    async def snapshot(log: Logger) -> AsyncGenerator[Owner, None]:
-        for item in await fetch_owners(log, http):
-            yield item
-
     def open(
         binding: CaptureBinding[ResourceConfig],
         binding_index: int,
@@ -266,7 +262,7 @@ def owners(http: HTTPSession) -> Resource:
             binding_index,
             state,
             task,
-            fetch_snapshot=snapshot,
+            fetch_snapshot=functools.partial(fetch_owners, http),
             tombstone=Owner(_meta=Owner.Meta(op="d"), createdAt=None, updatedAt=None),
         )
 

--- a/source-hubspot-native/tests/snapshots/snapshots__capture__stdout.json
+++ b/source-hubspot-native/tests/snapshots/snapshots__capture__stdout.json
@@ -5736,28 +5736,15 @@
         "row_id": 0,
         "uuid": "DocUUIDPlaceholder-329Bb50aa48EAa9ef"
       },
-      "activeSalesforceId": null,
-      "activeUserId": 63843671,
+      "archived": false,
       "createdAt": "2024-02-08T02:34:06.654000Z",
       "email": "johnny@estuary.dev",
       "firstName": "Johnny",
-      "hasContactsAccess": false,
-      "isActive": true,
+      "id": "722900407",
       "lastName": "Graettinger",
-      "ownerId": 722900407,
-      "portalId": 45192106,
-      "remoteList": [
-        {
-          "active": true,
-          "id": 579527292,
-          "ownerId": 722900407,
-          "portalId": 45192106,
-          "remoteId": "63843671",
-          "remoteType": "HUBSPOT"
-        }
-      ],
       "type": "PERSON",
       "updatedAt": "2024-02-08T04:35:51.909000Z",
+      "userId": 63843671,
       "userIdIncludingInactive": 63843671
     }
   ]


### PR DESCRIPTION
**Description:**

The v2 owners API has been deprecated and actually doesn't even work on newer accounts. We need to use the v3 owners API instead of the v2 owners API to prevent issues with newer HubSpot accounts.

The API output is slightly different between the v3 and the v2 API, but since this is a snapshot stream anyway and very low volume for our current use cases, I'm not anticipating that being a huge issue.

We could build in some kind of backward compatibility to make the v2 and v3 output more the same, or have captures that are able to use the v2 API or something like that, but I don't think that is worth the long-term maintenance cost we would take on.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

