### PR TITLE
source-sqlserver: Uppercase discovery flag

### DIFF
--- a/source-sqlserver/.snapshots/TestAlterationAddColumn-Automatic
+++ b/source-sqlserver/.snapshots/TestAlterationAddColumn-Automatic
@@ -5,12 +5,12 @@
 {"_meta":{"op":"c","source":{"schema":"dbo","snapshot":true,"table":"test_AlterationAddColumn_Automatic_81310450","lsn":"","seqval":"AAAAAAAAAAAAAA=="}},"data":"one","id":1}
 {"_meta":{"op":"c","source":{"schema":"dbo","table":"test_AlterationAddColumn_Automatic_81310450","lsn":"AAAAAAAAAAAAAA==","seqval":"AAAAAAAAAAAAAA==","updateMask":"Aw=="}},"data":"two","id":2}
 {"_meta":{"op":"c","source":{"schema":"dbo","table":"test_AlterationAddColumn_Automatic_81310450","lsn":"AAAAAAAAAAAAAA==","seqval":"AAAAAAAAAAAAAA==","updateMask":"Aw=="}},"data":"three","id":3}
-{"_meta":{"op":"c","source":{"schema":"dbo","table":"test_AlterationAddColumn_Automatic_81310450","lsn":"AAAAAAAAAAAAAA==","seqval":"AAAAAAAAAAAAAA==","updateMask":"Aw=="}},"data":"four","id":4}
-{"_meta":{"op":"c","source":{"schema":"dbo","table":"test_AlterationAddColumn_Automatic_81310450","lsn":"AAAAAAAAAAAAAA==","seqval":"AAAAAAAAAAAAAA==","updateMask":"Aw=="}},"data":"five","id":5}
+{"_meta":{"op":"c","source":{"schema":"dbo","table":"test_AlterationAddColumn_Automatic_81310450","lsn":"AAAAAAAAAAAAAA==","seqval":"AAAAAAAAAAAAAA==","updateMask":"Bw=="}},"data":"four","extra":"ccc","id":4}
+{"_meta":{"op":"c","source":{"schema":"dbo","table":"test_AlterationAddColumn_Automatic_81310450","lsn":"AAAAAAAAAAAAAA==","seqval":"AAAAAAAAAAAAAA==","updateMask":"Bw=="}},"data":"five","extra":"ddd","id":5}
 {"_meta":{"op":"c","source":{"schema":"dbo","table":"test_AlterationAddColumn_Automatic_81310450","lsn":"AAAAAAAAAAAAAA==","seqval":"AAAAAAAAAAAAAA==","updateMask":"Bw=="}},"data":"six","extra":"eee","id":6}
 {"_meta":{"op":"c","source":{"schema":"dbo","table":"test_AlterationAddColumn_Automatic_81310450","lsn":"AAAAAAAAAAAAAA==","seqval":"AAAAAAAAAAAAAA==","updateMask":"Bw=="}},"data":"seven","extra":"fff","id":7}
-{"_meta":{"op":"c","source":{"schema":"dbo","table":"test_AlterationAddColumn_Automatic_81310450","lsn":"AAAAAAAAAAAAAA==","seqval":"AAAAAAAAAAAAAA==","updateMask":"Bw=="}},"data":"eight","extra":"ggg","id":8}
-{"_meta":{"op":"c","source":{"schema":"dbo","table":"test_AlterationAddColumn_Automatic_81310450","lsn":"AAAAAAAAAAAAAA==","seqval":"AAAAAAAAAAAAAA==","updateMask":"Bw=="}},"data":"nine","extra":"hhh","id":9}
+{"_meta":{"op":"c","source":{"schema":"dbo","table":"test_AlterationAddColumn_Automatic_81310450","lsn":"AAAAAAAAAAAAAA==","seqval":"AAAAAAAAAAAAAA==","updateMask":"Dw=="}},"data":"eight","evenmore":"baz","extra":"ggg","id":8}
+{"_meta":{"op":"c","source":{"schema":"dbo","table":"test_AlterationAddColumn_Automatic_81310450","lsn":"AAAAAAAAAAAAAA==","seqval":"AAAAAAAAAAAAAA==","updateMask":"Dw=="}},"data":"nine","evenmore":"asdf","extra":"hhh","id":9}
 # ================================
 # Final State Checkpoint
 # ================================

--- a/source-sqlserver/.snapshots/TestDroppedAndRecreatedTable
+++ b/source-sqlserver/.snapshots/TestDroppedAndRecreatedTable
@@ -1,5 +1,5 @@
 # ================================
-# Collection "acmeCo/test/test_droppedandrecreatedtable_37815596": 15 Documents
+# Collection "acmeCo/test/dbo/test_droppedandrecreatedtable_37815596": 15 Documents
 # ================================
 {"_meta":{"op":"c","source":{"schema":"dbo","snapshot":true,"table":"test_DroppedAndRecreatedTable_37815596","lsn":"","seqval":"AAAAAAAAAAAAAA=="}},"data":"zero","id":0}
 {"_meta":{"op":"c","source":{"schema":"dbo","snapshot":true,"table":"test_DroppedAndRecreatedTable_37815596","lsn":"","seqval":"AAAAAAAAAAAAAA=="}},"data":"one","id":1}

--- a/source-sqlserver/.snapshots/TestGeneric-SpecResponse
+++ b/source-sqlserver/.snapshots/TestGeneric-SpecResponse
@@ -79,6 +79,11 @@
             "type": "string",
             "title": "CDC Instance Access Role",
             "description": "When set the connector will create new CDC instances with the specified 'role_name' argument as the gating role. When unset the capture user name is used as the 'role_name' instead. Has no effect if CDC instances are managed manually."
+          },
+          "feature_flags": {
+            "type": "string",
+            "title": "Feature Flags",
+            "description": "This property is intended for Estuary internal use. You should only modify this field as directed by Estuary support."
           }
         },
         "additionalProperties": false,

--- a/source-sqlserver/main_test.go
+++ b/source-sqlserver/main_test.go
@@ -31,6 +31,7 @@ var (
 
 	enableCDCWhenCreatingTables = flag.Bool("enable_cdc_when_creating_tables", true, "Set to true if CDC should be enabled before the test capture runs")
 	testSchemaName              = flag.String("test_schema_name", "dbo", "The schema in which to create test tables.")
+	testFeatureFlags            = flag.String("feature_flags", "", "Feature flags to apply to all test captures.")
 )
 
 func TestMain(m *testing.M) {
@@ -76,6 +77,7 @@ func sqlserverTestBackend(t *testing.T) *testBackend {
 		Password: *dbCapturePass,
 		Database: *dbName,
 	}
+	captureConfig.Advanced.FeatureFlags = *testFeatureFlags
 	// Other connectors use 16 in tests, but going below 128 here
 	// appears to change database backfill row ordering in the
 	// 'DuplicatedScanKey' test.


### PR DESCRIPTION
**Description:**

This commit adds a new feature flag (and since this is the first one added to the SQL Server capture, all of the feature flag boilerplate as well) which when set causes the connector to use capitalized variants of all discovery queries.

Previously table names, column names, and the like were lowercase in our discovery queries because it looks nicer and the distinction doesn't matter in most databases since they use a case-insensitive collation for table names anyway. But there exists at least one locale where the distinction matters, so we should probably have that capitalized normally anyway.

I'm reasonably sure the case change itself is a safe change to make across the board, but it's Friday and I'm fighting off a cold so I would really prefer not to make any potentially breaking changes like that. Consequently it's been gated behind a feature flag for now, but next week we should test this some more, flip the default, and ultimately remove all the query duplication and selection logic once we're sure the new queries work everywhere.

**Workflow steps:**

Add `uppercase_discovery_queries` to the "Feature Flags" advanced config property to use the new uppercase query variants.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2294)
<!-- Reviewable:end -->
