### PR TITLE
source-braintree-native: split incremental streams into distinct incremental & backfill processes

### DIFF
--- a/source-braintree-native/source_braintree_native/models.py
+++ b/source-braintree-native/source_braintree_native/models.py
@@ -8,6 +8,7 @@ from estuary_cdk.capture.common import (
     BaseDocument,
     ConnectorState as GenericConnectorState,
     LogCursor,
+    PageCursor,
     ResourceConfig,
     ResourceState,
 )
@@ -85,4 +86,9 @@ class Transaction(IncrementalResource):
 IncrementalResourceFetchChangesFn = Callable[
     [BraintreeGateway, int, Logger, LogCursor],
     AsyncGenerator[IncrementalResource | LogCursor, None],
+]
+
+IncrementalResourceFetchPageFn = Callable[
+    [BraintreeGateway, int, Logger, PageCursor, LogCursor],
+    AsyncGenerator[IncrementalResource | PageCursor, None],
 ]


### PR DESCRIPTION
**Description:**

Incremental streams (except `transactions`) must be periodically backfilled to capture updates. This PR splits incremental streams into distinct backfill & incremental processes so the connector can continue making incremental progress while periodic backfills run.

The window size for `disputes` is also restricted to always be 24 hours or more due to the `date` granularity of the `received_date` search field used; searching with date windows smaller than 24 hours will return duplicate results & slow the stream down, especially during backfills.

After merging, existing captures should be backfilled. We may want to consider timing this release with a planned periodic backfill.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

Tested on a local stack. Confirmed incremental streams now all have distinct incremental & backfill processes, and the backfill processes complete.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2295)
<!-- Reviewable:end -->
