### PR TITLE
materialize-elasticsearch: don't flatten strings formatted as numeric values

### DIFF
--- a/materialize-elasticsearch/type_mapping.go
+++ b/materialize-elasticsearch/type_mapping.go
@@ -211,6 +211,10 @@ func typesWithoutNull(ts []string) []string {
 }
 
 func mustWrapAndFlatten(p *pf.Projection) bool {
+	if _, isNumeric := boilerplate.AsFormattedNumeric(p); isNumeric {
+		return false
+	}
+
 	nonNullTypes := typesWithoutNull(p.Inference.Types)
 
 	if len(nonNullTypes) != 1 {

--- a/tests/materialize/materialize-elasticsearch/snapshot.json
+++ b/tests/materialize/materialize-elasticsearch/snapshot.json
@@ -834,13 +834,9 @@
       },
       "flow_published_at": "1970-01-01T01:00:13.000000000Z",
       "id": 1,
-      "int_and_str": {
-        "json": 1
-      },
+      "int_and_str": 1,
       "int_str": "10",
-      "num_and_str": {
-        "json": 1.1
-      },
+      "num_and_str": 1.1,
       "num_str": "10.1",
       "time": "00:00:00Z"
     },
@@ -862,13 +858,9 @@
       },
       "flow_published_at": "1970-01-01T01:00:14.000000000Z",
       "id": 2,
-      "int_and_str": {
-        "json": 2
-      },
+      "int_and_str": 2,
       "int_str": "20",
-      "num_and_str": {
-        "json": 2.1
-      },
+      "num_and_str": 2.1,
       "num_str": "20.1",
       "time": "14:20:12.33Z"
     },
@@ -890,13 +882,9 @@
       },
       "flow_published_at": "1970-01-01T00:00:11.000000000Z",
       "id": 3,
-      "int_and_str": {
-        "json": 3
-      },
+      "int_and_str": 3,
       "int_str": "30",
-      "num_and_str": {
-        "json": 3.1
-      },
+      "num_and_str": 3.1,
       "num_str": "30.1",
       "time": "23:59:38.10Z"
     },
@@ -918,13 +906,9 @@
       },
       "flow_published_at": "1970-01-01T00:00:12.000000000Z",
       "id": 4,
-      "int_and_str": {
-        "json": "4"
-      },
+      "int_and_str": "4",
       "int_str": "40",
-      "num_and_str": {
-        "json": "4.1"
-      },
+      "num_and_str": "4.1",
       "num_str": "40.1",
       "time": "23:59:38Z"
     },
@@ -946,13 +930,9 @@
       },
       "flow_published_at": "1970-01-01T01:00:15.000000000Z",
       "id": 5,
-      "int_and_str": {
-        "json": "5"
-      },
+      "int_and_str": "5",
       "int_str": "50",
-      "num_and_str": {
-        "json": "5.1"
-      },
+      "num_and_str": "5.1",
       "num_str": "50.1",
       "time": "23:59:59Z"
     },
@@ -968,13 +948,9 @@
       },
       "flow_published_at": "1970-01-01T01:00:16.000000000Z",
       "id": 8,
-      "int_and_str": {
-        "json": null
-      },
+      "int_and_str": null,
       "int_str": null,
-      "num_and_str": {
-        "json": null
-      },
+      "num_and_str": null,
       "num_str": null,
       "time": null
     },
@@ -990,13 +966,9 @@
       },
       "flow_published_at": "1970-01-01T01:00:17.000000000Z",
       "id": 9,
-      "int_and_str": {
-        "json": null
-      },
+      "int_and_str": null,
       "int_str": null,
-      "num_and_str": {
-        "json": null
-      },
+      "num_and_str": null,
       "num_str": null,
       "time": null
     },
@@ -1012,13 +984,9 @@
       },
       "flow_published_at": "1970-01-01T01:00:18.000000000Z",
       "id": 10,
-      "int_and_str": {
-        "json": null
-      },
+      "int_and_str": null,
       "int_str": null,
-      "num_and_str": {
-        "json": null
-      },
+      "num_and_str": null,
       "num_str": null,
       "time": null
     }


### PR DESCRIPTION
**Description:**

Strings formatted as numeric values have have source fields with multiple types of `string` and `integer` / `number`, but these values should not be wrapped a synthetic flattened object since they aren't really "multiple type" fields, but are materialized as their respective numeric value.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2302)
<!-- Reviewable:end -->
