### PR TITLE
source-postgres: Always stringify float keys

### DIFF
--- a/source-mysql/discovery.go
+++ b/source-mysql/discovery.go
@@ -187,7 +187,7 @@ func columnsNonNullable(columnsInfo map[string]sqlcapture.ColumnInfo, columnName
 	return true
 }
 
-func (db *mysqlDatabase) TranslateDBToJSONType(column sqlcapture.ColumnInfo) (*jsonschema.Schema, error) {
+func (db *mysqlDatabase) TranslateDBToJSONType(column sqlcapture.ColumnInfo, isPrimaryKey bool) (*jsonschema.Schema, error) {
 	var schema columnSchema
 	if typeName, ok := column.DataType.(string); ok {
 		schema, ok = mysqlTypeToJSON[typeName]

--- a/source-oracle/discovery.go
+++ b/source-oracle/discovery.go
@@ -85,7 +85,7 @@ func (db *oracleDatabase) DiscoverTables(ctx context.Context) (map[sqlcapture.St
 }
 
 // TranslateDBToJSONType returns JSON schema information about the provided database column type.
-func (db *oracleDatabase) TranslateDBToJSONType(column sqlcapture.ColumnInfo) (*jsonschema.Schema, error) {
+func (db *oracleDatabase) TranslateDBToJSONType(column sqlcapture.ColumnInfo, isPrimaryKey bool) (*jsonschema.Schema, error) {
 	var col = column.DataType.(oracleColumnType)
 
 	var jsonType = col.toJSONSchemaType()

--- a/source-postgres/.snapshots/TestFloatKeyDiscovery
+++ b/source-postgres/.snapshots/TestFloatKeyDiscovery
@@ -1,0 +1,140 @@
+Binding 0:
+{
+    "recommended_name": "test/floatkeydiscovery_46399195",
+    "resource_config_json": {
+      "namespace": "test",
+      "stream": "floatkeydiscovery_46399195"
+    },
+    "document_schema_json": {
+      "$defs": {
+        "TestFloatkeydiscovery_46399195": {
+          "type": "object",
+          "required": [
+            "id"
+          ],
+          "$anchor": "TestFloatkeydiscovery_46399195",
+          "properties": {
+            "id": {
+              "type": "string",
+              "format": "number",
+              "description": "(source type: non-nullable float8)"
+            },
+            "val": {
+              "format": "number",
+              "description": "(source type: float8)",
+              "type": [
+                "number",
+                "string",
+                "null"
+              ]
+            }
+          }
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "_meta": {
+                "properties": {
+                  "op": {
+                    "const": "d"
+                  }
+                }
+              }
+            }
+          },
+          "then": {
+            "reduce": {
+              "delete": true,
+              "strategy": "merge"
+            }
+          },
+          "else": {
+            "reduce": {
+              "strategy": "merge"
+            }
+          },
+          "required": [
+            "_meta"
+          ],
+          "properties": {
+            "_meta": {
+              "type": "object",
+              "required": [
+                "op",
+                "source"
+              ],
+              "properties": {
+                "before": {
+                  "$ref": "#TestFloatkeydiscovery_46399195",
+                  "description": "Record state immediately before this change was applied.",
+                  "reduce": {
+                    "strategy": "firstWriteWins"
+                  }
+                },
+                "op": {
+                  "enum": [
+                    "c",
+                    "d",
+                    "u"
+                  ],
+                  "description": "Change operation type: 'c' Create/Insert, 'u' Update, 'd' Delete."
+                },
+                "source": {
+                  "$id": "https://github.com/estuary/connectors/source-postgres/postgres-source",
+                  "properties": {
+                    "ts_ms": {
+                      "type": "integer",
+                      "description": "Unix timestamp (in millis) at which this event was recorded by the database."
+                    },
+                    "schema": {
+                      "type": "string",
+                      "description": "Database schema (namespace) of the event."
+                    },
+                    "snapshot": {
+                      "type": "boolean",
+                      "description": "Snapshot is true if the record was produced from an initial table backfill and unset if produced from the replication log."
+                    },
+                    "table": {
+                      "type": "string",
+                      "description": "Database table of the event."
+                    },
+                    "loc": {
+                      "items": {
+                        "type": "integer"
+                      },
+                      "type": "array",
+                      "maxItems": 3,
+                      "minItems": 3,
+                      "description": "Location of this WAL event as [last Commit.EndLSN; event LSN; current Begin.FinalLSN]. See https://www.postgresql.org/docs/current/protocol-logicalrep-message-formats.html"
+                    },
+                    "txid": {
+                      "type": "integer",
+                      "description": "The 32-bit transaction ID assigned by Postgres to the commit which produced this change."
+                    }
+                  },
+                  "type": "object",
+                  "required": [
+                    "schema",
+                    "table",
+                    "loc"
+                  ]
+                }
+              },
+              "reduce": {
+                "strategy": "merge"
+              }
+            }
+          }
+        },
+        {
+          "$ref": "#TestFloatkeydiscovery_46399195"
+        }
+      ]
+    },
+    "key": [
+      "/id"
+    ]
+  }
+

--- a/source-postgres/.snapshots/TestFloatKeyDiscovery-capture
+++ b/source-postgres/.snapshots/TestFloatKeyDiscovery-capture
@@ -1,0 +1,12 @@
+# ================================
+# Collection "acmeCo/test/test/floatkeydiscovery_46399195": 4 Documents
+# ================================
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"floatkeydiscovery_46399195","loc":[11111111,11111111,11111111]}},"id":"-12.3456789","val":-12.3456789}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"floatkeydiscovery_46399195","loc":[11111111,11111111,11111111]}},"id":"123.456","val":123.456}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"floatkeydiscovery_46399195","loc":[11111111,11111111,11111111]}},"id":"3.14","val":3.14}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"floatkeydiscovery_46399195","loc":[11111111,11111111,11111111]}},"id":"9999999999.99","val":9999999999.99}
+# ================================
+# Final State Checkpoint
+# ================================
+{"bindingStateV1":{"test%2Ffloatkeydiscovery_46399195":{"backfilled":4,"key_columns":["id"],"mode":"Active"}},"cursor":"0/1111111"}
+

--- a/source-postgres/.snapshots/TestScanKeyTypes-Double
+++ b/source-postgres/.snapshots/TestScanKeyTypes-Double
@@ -4,7 +4,7 @@
 # ================================
 # Collection "acmeCo/test/test/scankeytypes_double_28040008": 1 Documents
 # ================================
-{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"scankeytypes_double_28040008","loc":[11111111,11111111,11111111]}},"data":"Data 2","key":-1.1}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"scankeytypes_double_28040008","loc":[11111111,11111111,11111111]}},"data":"Data 2","key":"-1.1"}
 # ================================
 # Final State Checkpoint
 # ================================
@@ -17,7 +17,7 @@
 # ================================
 # Collection "acmeCo/test/test/scankeytypes_double_28040008": 1 Documents
 # ================================
-{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"scankeytypes_double_28040008","loc":[11111111,11111111,11111111]}},"data":"Data 1","key":-1}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"scankeytypes_double_28040008","loc":[11111111,11111111,11111111]}},"data":"Data 1","key":"-1"}
 # ================================
 # Final State Checkpoint
 # ================================
@@ -30,7 +30,7 @@
 # ================================
 # Collection "acmeCo/test/test/scankeytypes_double_28040008": 1 Documents
 # ================================
-{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"scankeytypes_double_28040008","loc":[11111111,11111111,11111111]}},"data":"Data 0","key":-0.9}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"scankeytypes_double_28040008","loc":[11111111,11111111,11111111]}},"data":"Data 0","key":"-0.9"}
 # ================================
 # Final State Checkpoint
 # ================================
@@ -43,7 +43,7 @@
 # ================================
 # Collection "acmeCo/test/test/scankeytypes_double_28040008": 1 Documents
 # ================================
-{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"scankeytypes_double_28040008","loc":[11111111,11111111,11111111]}},"data":"Data 3","key":0}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"scankeytypes_double_28040008","loc":[11111111,11111111,11111111]}},"data":"Data 3","key":"0"}
 # ================================
 # Final State Checkpoint
 # ================================
@@ -56,7 +56,7 @@
 # ================================
 # Collection "acmeCo/test/test/scankeytypes_double_28040008": 1 Documents
 # ================================
-{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"scankeytypes_double_28040008","loc":[11111111,11111111,11111111]}},"data":"Data 4","key":0.9}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"scankeytypes_double_28040008","loc":[11111111,11111111,11111111]}},"data":"Data 4","key":"0.9"}
 # ================================
 # Final State Checkpoint
 # ================================
@@ -69,7 +69,7 @@
 # ================================
 # Collection "acmeCo/test/test/scankeytypes_double_28040008": 1 Documents
 # ================================
-{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"scankeytypes_double_28040008","loc":[11111111,11111111,11111111]}},"data":"Data 5","key":1}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"scankeytypes_double_28040008","loc":[11111111,11111111,11111111]}},"data":"Data 5","key":"1"}
 # ================================
 # Final State Checkpoint
 # ================================
@@ -82,7 +82,7 @@
 # ================================
 # Collection "acmeCo/test/test/scankeytypes_double_28040008": 1 Documents
 # ================================
-{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"scankeytypes_double_28040008","loc":[11111111,11111111,11111111]}},"data":"Data 6","key":1.111}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"scankeytypes_double_28040008","loc":[11111111,11111111,11111111]}},"data":"Data 6","key":"1.111"}
 # ================================
 # Final State Checkpoint
 # ================================
@@ -95,7 +95,7 @@
 # ================================
 # Collection "acmeCo/test/test/scankeytypes_double_28040008": 1 Documents
 # ================================
-{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"scankeytypes_double_28040008","loc":[11111111,11111111,11111111]}},"data":"Data 7","key":1.222}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"scankeytypes_double_28040008","loc":[11111111,11111111,11111111]}},"data":"Data 7","key":"1.222"}
 # ================================
 # Final State Checkpoint
 # ================================
@@ -108,7 +108,7 @@
 # ================================
 # Collection "acmeCo/test/test/scankeytypes_double_28040008": 1 Documents
 # ================================
-{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"scankeytypes_double_28040008","loc":[11111111,11111111,11111111]}},"data":"Data 8","key":1.333}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"scankeytypes_double_28040008","loc":[11111111,11111111,11111111]}},"data":"Data 8","key":"1.333"}
 # ================================
 # Final State Checkpoint
 # ================================
@@ -121,7 +121,7 @@
 # ================================
 # Collection "acmeCo/test/test/scankeytypes_double_28040008": 1 Documents
 # ================================
-{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"scankeytypes_double_28040008","loc":[11111111,11111111,11111111]}},"data":"Data 9","key":1.444}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"scankeytypes_double_28040008","loc":[11111111,11111111,11111111]}},"data":"Data 9","key":"1.444"}
 # ================================
 # Final State Checkpoint
 # ================================
@@ -134,7 +134,7 @@
 # ================================
 # Collection "acmeCo/test/test/scankeytypes_double_28040008": 1 Documents
 # ================================
-{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"scankeytypes_double_28040008","loc":[11111111,11111111,11111111]}},"data":"Data 10","key":1.555}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"scankeytypes_double_28040008","loc":[11111111,11111111,11111111]}},"data":"Data 10","key":"1.555"}
 # ================================
 # Final State Checkpoint
 # ================================
@@ -147,7 +147,7 @@
 # ================================
 # Collection "acmeCo/test/test/scankeytypes_double_28040008": 1 Documents
 # ================================
-{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"scankeytypes_double_28040008","loc":[11111111,11111111,11111111]}},"data":"Data 11","key":1.666}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"scankeytypes_double_28040008","loc":[11111111,11111111,11111111]}},"data":"Data 11","key":"1.666"}
 # ================================
 # Final State Checkpoint
 # ================================
@@ -160,7 +160,7 @@
 # ================================
 # Collection "acmeCo/test/test/scankeytypes_double_28040008": 1 Documents
 # ================================
-{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"scankeytypes_double_28040008","loc":[11111111,11111111,11111111]}},"data":"Data 12","key":1.777}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"scankeytypes_double_28040008","loc":[11111111,11111111,11111111]}},"data":"Data 12","key":"1.777"}
 # ================================
 # Final State Checkpoint
 # ================================
@@ -173,7 +173,7 @@
 # ================================
 # Collection "acmeCo/test/test/scankeytypes_double_28040008": 1 Documents
 # ================================
-{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"scankeytypes_double_28040008","loc":[11111111,11111111,11111111]}},"data":"Data 13","key":1.888}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"scankeytypes_double_28040008","loc":[11111111,11111111,11111111]}},"data":"Data 13","key":"1.888"}
 # ================================
 # Final State Checkpoint
 # ================================
@@ -186,7 +186,7 @@
 # ================================
 # Collection "acmeCo/test/test/scankeytypes_double_28040008": 1 Documents
 # ================================
-{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"scankeytypes_double_28040008","loc":[11111111,11111111,11111111]}},"data":"Data 14","key":1.999}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"scankeytypes_double_28040008","loc":[11111111,11111111,11111111]}},"data":"Data 14","key":"1.999"}
 # ================================
 # Final State Checkpoint
 # ================================
@@ -199,7 +199,7 @@
 # ================================
 # Collection "acmeCo/test/test/scankeytypes_double_28040008": 1 Documents
 # ================================
-{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"scankeytypes_double_28040008","loc":[11111111,11111111,11111111]}},"data":"Data 15","key":2}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"scankeytypes_double_28040008","loc":[11111111,11111111,11111111]}},"data":"Data 15","key":"2"}
 # ================================
 # Final State Checkpoint
 # ================================

--- a/source-postgres/.snapshots/TestScanKeyTypes-Real
+++ b/source-postgres/.snapshots/TestScanKeyTypes-Real
@@ -4,7 +4,7 @@
 # ================================
 # Collection "acmeCo/test/test/scankeytypes_real_28040007": 1 Documents
 # ================================
-{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"scankeytypes_real_28040007","loc":[11111111,11111111,11111111]}},"data":"Data 2","key":-1.1}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"scankeytypes_real_28040007","loc":[11111111,11111111,11111111]}},"data":"Data 2","key":"-1.1"}
 # ================================
 # Final State Checkpoint
 # ================================
@@ -17,7 +17,7 @@
 # ================================
 # Collection "acmeCo/test/test/scankeytypes_real_28040007": 1 Documents
 # ================================
-{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"scankeytypes_real_28040007","loc":[11111111,11111111,11111111]}},"data":"Data 1","key":-1}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"scankeytypes_real_28040007","loc":[11111111,11111111,11111111]}},"data":"Data 1","key":"-1"}
 # ================================
 # Final State Checkpoint
 # ================================
@@ -30,7 +30,7 @@
 # ================================
 # Collection "acmeCo/test/test/scankeytypes_real_28040007": 1 Documents
 # ================================
-{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"scankeytypes_real_28040007","loc":[11111111,11111111,11111111]}},"data":"Data 0","key":-0.9}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"scankeytypes_real_28040007","loc":[11111111,11111111,11111111]}},"data":"Data 0","key":"-0.9"}
 # ================================
 # Final State Checkpoint
 # ================================
@@ -43,7 +43,7 @@
 # ================================
 # Collection "acmeCo/test/test/scankeytypes_real_28040007": 1 Documents
 # ================================
-{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"scankeytypes_real_28040007","loc":[11111111,11111111,11111111]}},"data":"Data 3","key":0}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"scankeytypes_real_28040007","loc":[11111111,11111111,11111111]}},"data":"Data 3","key":"0"}
 # ================================
 # Final State Checkpoint
 # ================================
@@ -56,7 +56,7 @@
 # ================================
 # Collection "acmeCo/test/test/scankeytypes_real_28040007": 1 Documents
 # ================================
-{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"scankeytypes_real_28040007","loc":[11111111,11111111,11111111]}},"data":"Data 4","key":0.9}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"scankeytypes_real_28040007","loc":[11111111,11111111,11111111]}},"data":"Data 4","key":"0.9"}
 # ================================
 # Final State Checkpoint
 # ================================
@@ -69,7 +69,7 @@
 # ================================
 # Collection "acmeCo/test/test/scankeytypes_real_28040007": 1 Documents
 # ================================
-{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"scankeytypes_real_28040007","loc":[11111111,11111111,11111111]}},"data":"Data 5","key":1}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"scankeytypes_real_28040007","loc":[11111111,11111111,11111111]}},"data":"Data 5","key":"1"}
 # ================================
 # Final State Checkpoint
 # ================================
@@ -82,7 +82,7 @@
 # ================================
 # Collection "acmeCo/test/test/scankeytypes_real_28040007": 1 Documents
 # ================================
-{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"scankeytypes_real_28040007","loc":[11111111,11111111,11111111]}},"data":"Data 6","key":1.111}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"scankeytypes_real_28040007","loc":[11111111,11111111,11111111]}},"data":"Data 6","key":"1.111"}
 # ================================
 # Final State Checkpoint
 # ================================
@@ -95,7 +95,7 @@
 # ================================
 # Collection "acmeCo/test/test/scankeytypes_real_28040007": 1 Documents
 # ================================
-{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"scankeytypes_real_28040007","loc":[11111111,11111111,11111111]}},"data":"Data 7","key":1.222}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"scankeytypes_real_28040007","loc":[11111111,11111111,11111111]}},"data":"Data 7","key":"1.222"}
 # ================================
 # Final State Checkpoint
 # ================================
@@ -108,7 +108,7 @@
 # ================================
 # Collection "acmeCo/test/test/scankeytypes_real_28040007": 1 Documents
 # ================================
-{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"scankeytypes_real_28040007","loc":[11111111,11111111,11111111]}},"data":"Data 8","key":1.333}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"scankeytypes_real_28040007","loc":[11111111,11111111,11111111]}},"data":"Data 8","key":"1.333"}
 # ================================
 # Final State Checkpoint
 # ================================
@@ -121,7 +121,7 @@
 # ================================
 # Collection "acmeCo/test/test/scankeytypes_real_28040007": 1 Documents
 # ================================
-{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"scankeytypes_real_28040007","loc":[11111111,11111111,11111111]}},"data":"Data 9","key":1.444}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"scankeytypes_real_28040007","loc":[11111111,11111111,11111111]}},"data":"Data 9","key":"1.444"}
 # ================================
 # Final State Checkpoint
 # ================================
@@ -134,7 +134,7 @@
 # ================================
 # Collection "acmeCo/test/test/scankeytypes_real_28040007": 1 Documents
 # ================================
-{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"scankeytypes_real_28040007","loc":[11111111,11111111,11111111]}},"data":"Data 10","key":1.555}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"scankeytypes_real_28040007","loc":[11111111,11111111,11111111]}},"data":"Data 10","key":"1.555"}
 # ================================
 # Final State Checkpoint
 # ================================
@@ -147,7 +147,7 @@
 # ================================
 # Collection "acmeCo/test/test/scankeytypes_real_28040007": 1 Documents
 # ================================
-{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"scankeytypes_real_28040007","loc":[11111111,11111111,11111111]}},"data":"Data 11","key":1.666}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"scankeytypes_real_28040007","loc":[11111111,11111111,11111111]}},"data":"Data 11","key":"1.666"}
 # ================================
 # Final State Checkpoint
 # ================================
@@ -160,7 +160,7 @@
 # ================================
 # Collection "acmeCo/test/test/scankeytypes_real_28040007": 1 Documents
 # ================================
-{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"scankeytypes_real_28040007","loc":[11111111,11111111,11111111]}},"data":"Data 12","key":1.777}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"scankeytypes_real_28040007","loc":[11111111,11111111,11111111]}},"data":"Data 12","key":"1.777"}
 # ================================
 # Final State Checkpoint
 # ================================
@@ -173,7 +173,7 @@
 # ================================
 # Collection "acmeCo/test/test/scankeytypes_real_28040007": 1 Documents
 # ================================
-{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"scankeytypes_real_28040007","loc":[11111111,11111111,11111111]}},"data":"Data 13","key":1.888}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"scankeytypes_real_28040007","loc":[11111111,11111111,11111111]}},"data":"Data 13","key":"1.888"}
 # ================================
 # Final State Checkpoint
 # ================================
@@ -186,7 +186,7 @@
 # ================================
 # Collection "acmeCo/test/test/scankeytypes_real_28040007": 1 Documents
 # ================================
-{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"scankeytypes_real_28040007","loc":[11111111,11111111,11111111]}},"data":"Data 14","key":1.999}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"scankeytypes_real_28040007","loc":[11111111,11111111,11111111]}},"data":"Data 14","key":"1.999"}
 # ================================
 # Final State Checkpoint
 # ================================
@@ -199,7 +199,7 @@
 # ================================
 # Collection "acmeCo/test/test/scankeytypes_real_28040007": 1 Documents
 # ================================
-{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"scankeytypes_real_28040007","loc":[11111111,11111111,11111111]}},"data":"Data 15","key":2}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"scankeytypes_real_28040007","loc":[11111111,11111111,11111111]}},"data":"Data 15","key":"2"}
 # ================================
 # Final State Checkpoint
 # ================================

--- a/source-sqlserver/discovery.go
+++ b/source-sqlserver/discovery.go
@@ -420,7 +420,7 @@ func getComputedColumns(ctx context.Context, conn *sql.DB) (map[sqlcapture.Strea
 }
 
 // TranslateDBToJSONType returns JSON schema information about the provided database column type.
-func (db *sqlserverDatabase) TranslateDBToJSONType(column sqlcapture.ColumnInfo) (*jsonschema.Schema, error) {
+func (db *sqlserverDatabase) TranslateDBToJSONType(column sqlcapture.ColumnInfo, isPrimaryKey bool) (*jsonschema.Schema, error) {
 	var schema columnSchema
 	if typeInfo, ok := column.DataType.(*sqlserverTextColumnType); ok {
 		if schema, ok = sqlserverTypeToJSON[typeInfo.Type]; !ok {

--- a/sqlcapture/discovery.go
+++ b/sqlcapture/discovery.go
@@ -86,7 +86,8 @@ func DiscoverCatalog(ctx context.Context, db Database) ([]*pc.Response_Discovere
 				continue // Skip adding properties corresponding to omitted columns
 			}
 
-			var jsonType, err = db.TranslateDBToJSONType(column)
+			var isPrimaryKey = slices.Contains(table.PrimaryKey, column.Name)
+			var jsonType, err = db.TranslateDBToJSONType(column, isPrimaryKey)
 			if err != nil {
 				// Unhandled types are translated to the catch-all schema {} but with
 				// a description clarifying that we don't have a better translation.

--- a/sqlcapture/interface.go
+++ b/sqlcapture/interface.go
@@ -144,7 +144,7 @@ type Database interface {
 	// DiscoverTables queries the database for the latest information about tables available for capture.
 	DiscoverTables(ctx context.Context) (map[StreamID]*DiscoveryInfo, error)
 	// TranslateDBToJSONType returns JSON schema information about the provided database column type.
-	TranslateDBToJSONType(column ColumnInfo) (*jsonschema.Schema, error)
+	TranslateDBToJSONType(column ColumnInfo, isPrimaryKey bool) (*jsonschema.Schema, error)
 	// Returns an empty instance of the source-specific metadata (used for JSON schema generation).
 	EmptySourceMetadata() SourceMetadata
 	// ShouldBackfill returns true if a given table's contents should be backfilled.


### PR DESCRIPTION
**Description:**

Flow won't / can't accept a `type: [string, number], format: number` as a collection key. We have to support strings as serialized float values because they need to be able to hold special values such as `"NaN"` and `"Infinity"`, so in order to make float keys work right we have to always stringify them.

**Workflow steps:**

Capturing from tables with `REAL` and `DOUBLE PRECISION` primary keys should now Just Work, where previously it would inevitably fail. Any captures which were previously working should be unaffected, because this only changes the behavior when the floating-point value occurs in the primary key of the table.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2304)
<!-- Reviewable:end -->
