### PR TITLE
materialize-sql: change column migration misleading log message

### DIFF
--- a/materialize-sql/std_sql.go
+++ b/materialize-sql/std_sql.go
@@ -515,7 +515,7 @@ func StdColumnTypeMigration(ctx context.Context, dialect Dialect, table Table, m
 		"originalColumnExists": migration.OriginalColumnExists,
 		"progressColumnExists": migration.ProgressColumnExists,
 		"step":                 step,
-	}).Info("migrating columns using column renaming")
+	}).Info("rendered queries for column migration using renaming")
 
 	if len(steps) == 0 {
 		steps = StdMigrationSteps


### PR DESCRIPTION
**Description:**

- The previous log line made it seem like it was actually doing the migration, but in reality it is only rendering queries for migration. In cases of multiple column migration the previous message made it seem like all but the last column had already been migrated in milliseconds while the last one was taking its time. This threw me off just now while debugging a task.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2306)
<!-- Reviewable:end -->
