### PR TITLE
materialize-s3-iceberg: fix checkpoint accounting for disabled bindings

### DIFF
--- a/materialize-s3-iceberg/iceberg-ctl/iceberg_ctl/__main__.py
+++ b/materialize-s3-iceberg/iceberg-ctl/iceberg_ctl/__main__.py
@@ -355,14 +355,16 @@ def append_files(
     if cp == next_checkpoint:
         print(f"checkpoint is already '{next_checkpoint}'")
         return  # already appended these files
-    elif cp != "" and cp != prev_checkpoint:
-        # An absent checkpoint table property is allowed to accommodate cases
-        # where the user may have manually dropped the table and the
-        # materialization automatically re-created it, outside the normal
-        # backfill counter increment process.
-        raise Exception(
-            f"checkpoint from snapshot ({cp}) did not match either previous ({prev_checkpoint}) or next ({next_checkpoint}) checkpoint"
-        )
+    # TODO(whb): Re-enable this sanity check after any tasks effected by the
+    # disabled bindings state tracking bug have moved past it.
+    # elif cp != "" and cp != prev_checkpoint:
+    #     # An absent checkpoint table property is allowed to accommodate cases
+    #     # where the user may have manually dropped the table and the
+    #     # materialization automatically re-created it, outside the normal
+    #     # backfill counter increment process.
+    #     raise Exception(
+    #         f"checkpoint from snapshot ({cp}) did not match either previous ({prev_checkpoint}) or next ({next_checkpoint}) checkpoint"
+    #     )
     
     # Files are only added if the table checkpoint property has the prior checkpoint. The checkpoint
     # property is updated to the current checkpoint in an atomic operation with appending the files.
@@ -388,7 +390,7 @@ def append_files(
             attempt += 1
 
     tbl = catalog.load_table(table)
-    print(f"{table} updated with flow_checkpoints_v1 property of {tbl.properties.get("flow_checkpoints_v1")} after {attempt} attempts") 
+    print(f"{table} updated with flow_checkpoints_v1 property of {tbl.properties.get("flow_checkpoints_v1")} from {cp} after {attempt} attempts") 
 
 if __name__ == "__main__":
     run(auto_envvar_prefix="ICEBERG")

--- a/materialize-s3-iceberg/transactor.go
+++ b/materialize-s3-iceberg/transactor.go
@@ -229,7 +229,9 @@ func (t *transactor) Store(it *m.StoreIterator) (m.StartCommitFunc, error) {
 			return nil, m.FinishedOperation(err)
 		}
 
-		for _, bindingState := range t.state.BindingStates {
+		for _, b := range t.bindings {
+			bindingState := t.state.BindingStates[b.stateKey]
+
 			if len(bindingState.FileKeys) == 0 {
 				continue // no data for this binding
 			}


### PR DESCRIPTION
**Description:**

This fixes a bug where the previous/current tracked checkpoint hash for disabled bindings would be erroneously advanced for disabled bindings that have a pending staged commit that will be applied if their binding is ever enabled again.

It also includes a temporary disabling of the sanity check that ensures checkpoint hashes advanced as we expect, since some tasks are in a state where this is not true.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

As a point of clarification, these checkpoint hashes are not actual recovered checkpoints as you might see from a "remote store is authoritative" type of materialization, and are only really used for giving us to best chance of not re-applying a prior commit to the same table again, which itself would not even be a catastrophic problem since this is an at-least-once materialization, although with the checkpoint hash tracking it is very unlikely for commits to be re-applied.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2308)
<!-- Reviewable:end -->
