### PR TITLE
source-oracle: fix prerequisites table-level logging check run on pdb

### DIFF
--- a/source-oracle/prerequisites.go
+++ b/source-oracle/prerequisites.go
@@ -41,6 +41,9 @@ func (db *oracleDatabase) prerequisiteSupplementalLogging(ctx context.Context, o
 		}
 
 		if owner != "" && tableName != "" {
+			if err := db.switchToPDB(ctx); err != nil {
+				return err
+			}
 			row = db.conn.QueryRowContext(ctx, "SELECT LOG_GROUP_TYPE FROM ALL_LOG_GROUPS WHERE OWNER=:1 AND TABLE_NAME=:2", owner, tableName)
 			var logType string
 


### PR DESCRIPTION
**Description:**

- When we check supplemental logging, we do it on the CDB level because it is a database-level configuration, but if database-level supplemental logging is not enabled, when checking table-level we need to check on the PDB level because that's where the tables are

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2311)
<!-- Reviewable:end -->
