### PR TITLE
source-oracle: floating points can be keys

### DIFF
--- a/source-oracle/discovery.go
+++ b/source-oracle/discovery.go
@@ -395,9 +395,6 @@ func getColumns(ctx context.Context, conn *sql.DB, tables []*sqlcapture.Discover
 
 		if isPrimaryKey {
 			var streamID = sqlcapture.JoinStreamID(sc.TableSchema, sc.TableName)
-			if format == "number" {
-				return nil, nil, fmt.Errorf("floating point numbers cannot be primary keys: %s.%s", streamID, sc.Name)
-			}
 
 			pks[streamID] = append(pks[streamID], sc.Name)
 		}


### PR DESCRIPTION
**Description:**

- Turns out these some of these `NUMBER` fields used by one of our customers are actually primary keys. We now allow floating point keys, so I'm removing this check in the connector

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2314)
<!-- Reviewable:end -->
