### PR TITLE
source-mysql: Ignore ROLLBACK query events

### DIFF
--- a/source-mysql/replication.go
+++ b/source-mysql/replication.go
@@ -635,7 +635,7 @@ func mergePreimage(fields map[string]any, preimage map[string]any) map[string]an
 // with the binlog Query Events for some statements like GRANT and CREATE USER.
 // TODO(johnny): SET STATEMENT is not safe in the general case, and we want to re-visit
 // by extracting and ignoring a SET STATEMENT stanza prior to parsing.
-var silentIgnoreQueriesRe = regexp.MustCompile(`(?i)^(BEGIN|COMMIT|SAVEPOINT .*|# [^\n]*)$`)
+var silentIgnoreQueriesRe = regexp.MustCompile(`(?i)^(BEGIN|COMMIT|ROLLBACK|SAVEPOINT .*|# [^\n]*)$`)
 var createDefinerRegex = `CREATE\s*(OR REPLACE){0,1}\s*(ALGORITHM\s*=\s*[^ ]+)*\s*DEFINER`
 var ignoreQueriesRe = regexp.MustCompile(`(?i)^(BEGIN|COMMIT|GRANT|REVOKE|CREATE USER|` + createDefinerRegex + `|DROP USER|ALTER USER|DROP PROCEDURE|DROP FUNCTION|DROP TRIGGER|SET STATEMENT|CREATE EVENT|ALTER EVENT|DROP EVENT)`)
 


### PR DESCRIPTION
**Description:**

Generally speaking we shouldn't see BEGIN/COMMIT/ROLLBACK events in the binlog, and we can't actually support a rollback on a table that we're actively processing since we've already emitted the changes. But since we do see them in certain edge cases we ought to ignore them properly.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2321)
<!-- Reviewable:end -->
