### PR TITLE
source-firestore: Capture document references as strings in backfills too

### DIFF
--- a/source-firestore/.snapshots/TestDocumentReferences-backfill
+++ b/source-firestore/.snapshots/TestDocumentReferences-backfill
@@ -2,7 +2,7 @@
 # Collection "flow_source_tests/*/docs": 2 Documents
 # ================================
 {"_meta":{"path":"projects/project-id-123456/databases/(default)/documents/flow_source_tests/TestDocumentReferences/docs/1","ctime":"<TIMESTAMP>","mtime":"<TIMESTAMP>","snapshot":true},"data":1}
-{"_meta":{"path":"projects/project-id-123456/databases/(default)/documents/flow_source_tests/TestDocumentReferences/docs/2","ctime":"<TIMESTAMP>","mtime":"<TIMESTAMP>","snapshot":true},"ref":{"Parent":{"Parent":{"Parent":{"Parent":null,"Path":"projects/project-id-123456/databases/(default)/documents/flow_source_tests","ID":"flow_source_tests"},"Path":"projects/project-id-123456/databases/(default)/documents/flow_source_tests/TestDocumentReferences","ID":"TestDocumentReferences"},"Path":"projects/project-id-123456/databases/(default)/documents/flow_source_tests/TestDocumentReferences/docs","ID":"docs"},"Path":"projects/project-id-123456/databases/(default)/documents/flow_source_tests/TestDocumentReferences/docs/1","ID":"1"}}
+{"_meta":{"path":"projects/project-id-123456/databases/(default)/documents/flow_source_tests/TestDocumentReferences/docs/2","ctime":"<TIMESTAMP>","mtime":"<TIMESTAMP>","snapshot":true},"ref":"projects/project-id-123456/databases/(default)/documents/flow_source_tests/TestDocumentReferences/docs/1"}
 # ================================
 # Final State Checkpoint
 # ================================

--- a/source-firestore/.snapshots/TestDocumentReferences-backfill
+++ b/source-firestore/.snapshots/TestDocumentReferences-backfill
@@ -1,0 +1,10 @@
+# ================================
+# Collection "flow_source_tests/*/docs": 2 Documents
+# ================================
+{"_meta":{"path":"projects/project-id-123456/databases/(default)/documents/flow_source_tests/TestDocumentReferences/docs/1","ctime":"<TIMESTAMP>","mtime":"<TIMESTAMP>","snapshot":true},"data":1}
+{"_meta":{"path":"projects/project-id-123456/databases/(default)/documents/flow_source_tests/TestDocumentReferences/docs/2","ctime":"<TIMESTAMP>","mtime":"<TIMESTAMP>","snapshot":true},"ref":{"Parent":{"Parent":{"Parent":{"Parent":null,"Path":"projects/project-id-123456/databases/(default)/documents/flow_source_tests","ID":"flow_source_tests"},"Path":"projects/project-id-123456/databases/(default)/documents/flow_source_tests/TestDocumentReferences","ID":"TestDocumentReferences"},"Path":"projects/project-id-123456/databases/(default)/documents/flow_source_tests/TestDocumentReferences/docs","ID":"docs"},"Path":"projects/project-id-123456/databases/(default)/documents/flow_source_tests/TestDocumentReferences/docs/1","ID":"1"}}
+# ================================
+# Final State Checkpoint
+# ================================
+{"bindingStateV1":{"flow_source_tests%2F%2A%2Fdocs":{"Backfill":{"Completed":true,"Cursor":"","MTime":"<TIMESTAMP>","StartAfter":"<TIMESTAMP>"},"ReadTime":"<TIMESTAMP>"}}}
+

--- a/source-firestore/.snapshots/TestDocumentReferences-replication
+++ b/source-firestore/.snapshots/TestDocumentReferences-replication
@@ -1,0 +1,10 @@
+# ================================
+# Collection "flow_source_tests/*/docs": 2 Documents
+# ================================
+{"_meta":{"path":"projects/project-id-123456/databases/(default)/documents/flow_source_tests/TestDocumentReferences/docs/3","ctime":"<TIMESTAMP>","mtime":"<TIMESTAMP>"},"data":3}
+{"_meta":{"path":"projects/project-id-123456/databases/(default)/documents/flow_source_tests/TestDocumentReferences/docs/4","ctime":"<TIMESTAMP>","mtime":"<TIMESTAMP>"},"ref":"projects/project-id-123456/databases/(default)/documents/flow_source_tests/TestDocumentReferences/docs/3"}
+# ================================
+# Final State Checkpoint
+# ================================
+{"bindingStateV1":{"flow_source_tests%2F%2A%2Fdocs":{"Backfill":{"Completed":true,"Cursor":"","MTime":"<TIMESTAMP>","StartAfter":"<TIMESTAMP>"},"ReadTime":"<TIMESTAMP>"}}}
+

--- a/source-firestore/pull.go
+++ b/source-firestore/pull.go
@@ -1139,6 +1139,8 @@ func sanitizeValue(x interface{}) interface{} {
 			x[key] = sanitizeValue(value)
 		}
 		return x
+	case *firestore.DocumentRef:
+		return x.Path
 	}
 	return x
 }


### PR DESCRIPTION
**Description:**

This PR adds a test demonstrating that backfills and replication used to emit Firestore document references in two different representations. In replication we would emit the path as a string like:

```
"projects/project-id-123456/databases/(default)/documents/flow_source_tests/TestDocumentReferences/docs/1"
```

whereas in backfills we would emit a hairy recursive struct like:

```
{
  "Parent": {
    "Parent": {
      "Parent": {
        "Parent": null,
        "Path": "projects/project-id-123456/databases/(default)/documents/flow_source_tests",
        "ID": "flow_source_tests"
      },
      "Path": "projects/project-id-123456/databases/(default)/documents/flow_source_tests/TestDocumentReferences",
      "ID": "TestDocumentReferences"
    },
    "Path": "projects/project-id-123456/databases/(default)/documents/flow_source_tests/TestDocumentReferences/docs",
    "ID": "docs"
  },
  "Path": "projects/project-id-123456/databases/(default)/documents/flow_source_tests/TestDocumentReferences/docs/1",
  "ID": "1"
}
```

If you're paying close attention you might notice that every bit of that nested struct is redundant with the outermost path, and in fact the code that generates this whole struct representation does so by parsing that path value anyway.

The other part of this PR makes them consistent. Since I'm pretty sure the recursive struct representation will play much less nicely with schema inference than a simple string representation, I've opted to change backfill output to be consistent with replication and just emit the raw path string all the time.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2325)
<!-- Reviewable:end -->
