### PR TITLE
Adding some detail about `secret` requirements to guidelines markdown

### DIFF
--- a/config_schema_guidelines.md
+++ b/config_schema_guidelines.md
@@ -291,3 +291,17 @@ Keep in mind - it will display at the top of the group that contains the propert
   ...
 }
 ```
+
+### Using a `type` of `[null, _scalar_]` has some limitations
+
+The UI can handle rendering several inputs as "nullable". The UI handles this if there is exactly *two* types and one of them is `null` and the other is one of the following: `string`, `number`, `integer`. The order in the `type` array does not matter. 
+
+```json
+{
+  "title": "A string that can be null",
+  "description": "",
+  "type": ["string", "null"]
+}
+```
+
+If you set `type` to an array outside of this then JSONForms will try to handle the rendering as best it can.


### PR DESCRIPTION
**Description:**

Adding some important details about the `secret` handler in json schemas.

Going to document as if this is already done -> https://github.com/estuary/connectors/issues/2326

**Workflow steps:**

N/A

**Documentation links affected:**

N/A

**Notes for reviewers:**

N/A

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2327)
<!-- Reviewable:end -->
