### PR TITLE
source-zendesk-support-native: misc fixes

### DIFF
--- a/source-zendesk-support-native/source_zendesk_support_native/models.py
+++ b/source-zendesk-support-native/source_zendesk_support_native/models.py
@@ -188,6 +188,12 @@ class TicketCommentsResponse(IncrementalCursorPaginatedResponse):
     resources: list[ZendeskResource] = Field(alias="comments")
 
 
+class AbbreviatedTicket(BaseModel):
+    id: int
+    status: str
+    updated_at: AwareDatetime
+
+
 # Resources that are fetched by following the tickets stream & fetching resources for updated tickets in a separate request.
 # Tuples contain the name, path, and response model for each resource.
 TICKET_CHILD_RESOURCES: list[tuple[str, str, type[IncrementalCursorPaginatedResponse]]] = [

--- a/source-zendesk-support-native/source_zendesk_support_native/models.py
+++ b/source-zendesk-support-native/source_zendesk_support_native/models.py
@@ -20,6 +20,9 @@ from estuary_cdk.http import HTTPSession
 from pydantic import AfterValidator, AwareDatetime, BaseModel, Field
 
 
+EPOCH = datetime(1970, 1, 1, tzinfo=UTC)
+
+
 def urlencode_field(field: str):
     return "{{#urlencode}}{{{ " + field + " }}}{{/urlencode}}"
 
@@ -88,6 +91,7 @@ class EndpointConfig(BaseModel):
         description="UTC date and time in the format YYYY-MM-DDTHH:MM:SSZ. Any data generated before this date will not be replicated. If left blank, the start date will be set to 30 days before the present.",
         title="Start Date",
         default_factory=default_start_date,
+        ge=EPOCH,
     )
     credentials: OAuth2Credentials | ApiToken = Field(
         discriminator="credentials_title",

--- a/source-zendesk-support-native/source_zendesk_support_native/resources.py
+++ b/source-zendesk-support-native/source_zendesk_support_native/resources.py
@@ -18,6 +18,7 @@ from .models import (
     ResourceState,
     TimestampedResource,
     ZendeskResource,
+    EPOCH,
     CLIENT_SIDE_FILTERED_CURSOR_PAGINATED_RESOURCES,
     FULL_REFRESH_CURSOR_PAGINATED_RESOURCES,
     INCREMENTAL_CURSOR_EXPORT_RESOURCES,
@@ -45,8 +46,6 @@ from .api import (
     _dt_to_s,
     TIME_PARAMETER_DELAY,
 )
-
-EPOCH = datetime(1970, 1, 1, tzinfo=UTC)
 
 async def validate_credentials(
         log: Logger, http: HTTPMixin, config: EndpointConfig


### PR DESCRIPTION
**Description:**

This PR includes a few miscellaneous fixes for bugs in `source-zendesk-support-native`. These fixes include:
1. Validating the `start_date` is at least the epoch so converting to a timestamp always results in a non-negative number.
2. Avoiding `aiohttp` `TimeoutError`s for ticket child streams by not trying to maintain a long-lived streaming response when fetching parent tickets.
3. Using a smaller page size for `ticket_metrics` to reduce how much processing Zendesk must do for a response & avoid intermediate gateways from sending us 504 timeout responses.
  i. We might want to make this configurable later or surface 5xx responses through our CDK at some point, but that level of effort isn't necessary right now.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

Tested on a local stack. Confirmed:
- Entering a start date of before the epoch is not accepted as a valid value & prevents task creation.
- Ticket child streams, like `ticket_comments` and `ticket_audits`, no longer experience `TimeoutErrors` from `aiohttp`.
- `ticket_metrics` requests complete successfully & avoid 504 responses when using a smaller page size.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2329)
<!-- Reviewable:end -->
