### PR TITLE
source-sqlserver: Support CDC without watermarks

### DIFF
--- a/source-sqlserver/backfill.go
+++ b/source-sqlserver/backfill.go
@@ -141,7 +141,7 @@ func (db *sqlserverDatabase) ScanTableChunk(ctx context.Context, info *sqlcaptur
 					Snapshot: true,
 					Table:    table,
 				},
-				LSN:    []byte{},
+				LSN:    LSN{},
 				SeqVal: seqval,
 			},
 			Before: nil,

--- a/source-sqlserver/docker-initdb.sh
+++ b/source-sqlserver/docker-initdb.sh
@@ -18,6 +18,8 @@ CREATE LOGIN flow_capture WITH PASSWORD = 'we2rie1E';
 GO
 CREATE USER flow_capture FOR LOGIN flow_capture;
 GO
+GRANT VIEW DATABASE STATE TO flow_capture;
+GO
 GRANT SELECT ON SCHEMA :: dbo TO flow_capture;
 GO
 GRANT SELECT ON SCHEMA :: cdc TO flow_capture;

--- a/source-sqlserver/main.go
+++ b/source-sqlserver/main.go
@@ -41,6 +41,12 @@ var featureFlagDefaults = map[string]bool{
 	// to work in the Turkish_CI_AS locale), but didn't want to release it unconditionally
 	// on a Friday without much testing so it's gated behind a flag for now.
 	"uppercase_discovery_queries": false,
+
+	// When true, the capture will use a fence mechanism based on observing CDC worker runs
+	// and LSN positions rather than watermark writes. This mechanism may require additional
+	// permissions, so the plan is to flip this to default-true for new users first and then
+	// see if we can migrate existing captures to read-only operation.
+	"read_only": false,
 }
 
 // Config tells the connector how to connect to and interact with the source database.

--- a/source-sqlserver/main_test.go
+++ b/source-sqlserver/main_test.go
@@ -21,13 +21,15 @@ import (
 )
 
 var (
-	dbAddress = flag.String("db_addr", "127.0.0.1:1433", "Connect to the specified address/port for tests")
-	dbName    = flag.String("db_name", "test", "Connect to the named database for tests")
+	dbName = flag.String("db_name", "test", "Connect to the named database for tests")
 
-	dbControlUser = flag.String("db_control_user", "sa", "The user for test setup/control operations")
-	dbControlPass = flag.String("db_control_pass", "gf6w6dkD", "The password the the test setup/control user")
-	dbCaptureUser = flag.String("db_capture_user", "flow_capture", "The user to perform captures as")
-	dbCapturePass = flag.String("db_capture_pass", "we2rie1E", "The password for the capture user")
+	dbControlAddress = flag.String("db_control_addr", "127.0.0.1:1433", "The database server address to use for test setup/control operations")
+	dbControlUser    = flag.String("db_control_user", "sa", "The user for test setup/control operations")
+	dbControlPass    = flag.String("db_control_pass", "gf6w6dkD", "The password the the test setup/control user")
+
+	dbCaptureAddress = flag.String("db_capture_addr", "127.0.0.1:1433", "The database server address to use for test captures")
+	dbCaptureUser    = flag.String("db_capture_user", "flow_capture", "The user to perform captures as")
+	dbCapturePass    = flag.String("db_capture_pass", "we2rie1E", "The password for the capture user")
 
 	enableCDCWhenCreatingTables = flag.Bool("enable_cdc_when_creating_tables", true, "Set to true if CDC should be enabled before the test capture runs")
 	testSchemaName              = flag.String("test_schema_name", "dbo", "The schema in which to create test tables.")
@@ -57,14 +59,14 @@ func sqlserverTestBackend(t *testing.T) *testBackend {
 
 	// Open control connection
 	var controlURI = (&Config{
-		Address:  *dbAddress,
+		Address:  *dbControlAddress,
 		User:     *dbControlUser,
 		Password: *dbControlPass,
 		Database: *dbName,
 	}).ToURI()
 	log.WithFields(log.Fields{
 		"user": *dbControlUser,
-		"addr": *dbAddress,
+		"addr": *dbControlAddress,
 	}).Info("opening control connection")
 	var conn, err = sql.Open("sqlserver", controlURI)
 	require.NoError(t, err)
@@ -72,7 +74,7 @@ func sqlserverTestBackend(t *testing.T) *testBackend {
 
 	// Construct the capture config
 	var captureConfig = Config{
-		Address:  *dbAddress,
+		Address:  *dbCaptureAddress,
 		User:     *dbCaptureUser,
 		Password: *dbCapturePass,
 		Database: *dbName,

--- a/source-sqlserver/prerequisites.go
+++ b/source-sqlserver/prerequisites.go
@@ -183,7 +183,7 @@ func currentUserHasDBOwner(ctx context.Context, conn *sql.DB) (bool, error) {
 }
 
 func (db *sqlserverDatabase) prerequisiteViewCDCScanHistory(ctx context.Context) error {
-	var _, err = listCDCLogScanSessions(ctx, db.conn)
+	var _, err = latestCDCLogScanSession(ctx, db.conn)
 	if err != nil {
 		log.WithField("err", err).Error("failed to list CDC log scan sessions")
 		var msErr mssqldb.Error


### PR DESCRIPTION
**Description:**

This PR adds support to the SQL Server CDC connector for running without watermark writes. This new support exists side-by-side with the existing watermark-based mechanism, and can be enabled on a specific capture by adding the `read_only` feature flag to the advanced endpoint config.

Watermark-free CDC requires an additional database permission (`VIEW DATABASE STATE`, or in SQL Server 2022+ `VIEW DATABASE PERFORMANCE STATE` also suffices) which isn't granted by default, so we can't currently turn it on for preexisting captures. However other than the setup obstacle, there should be no downside to the new implementation [1].

[1] This is contrasted with the PostgreSQL situation, where read-only CDC has legitimate operational downsides and so we expect to retain both modes of operation forever. In SQL Server it's theoretically possible that we will get to a point where every SQL Server capture is using the new implementation and we can remove watermark writes entirely.

The plan is that after https://github.com/estuary/connectors/issues/1994 is complete we will add the `no_read_only` feature flag to all currently-existing SQL Server captures and then toggle the default behavior so any new captures will be created in watermark-free mode (we might also do some additional testing in between those points). We can then work with users to get preexisting captures moved over to watermark-less operation, or we can simply not do that if we don't think it's worth the effort.

This fixes https://github.com/estuary/connectors/issues/2215

**Workflow steps:**

Most users aren't expected to do anything. If someone creates a new capture tomorrow, it will still use watermark writes, and at some point in the not too distant future the default behavior and documentation will both change to instead ask for the `VIEW DATABASE STATE` permission and not say anything about watermarks at all.

If a user needs to opt into watermark-less mode today, they can do so by putting `read_only` in the feature flags, and after the default-flip a user could in theory opt back into watermark-writing mode by putting `no_read_only` in the feature flags.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2330)
<!-- Reviewable:end -->
