### PR TITLE
source-zendesk-support-native: add configurable page size for incremental export streams

### DIFF
--- a/source-zendesk-support-native/source_zendesk_support_native/models.py
+++ b/source-zendesk-support-native/source_zendesk_support_native/models.py
@@ -21,6 +21,7 @@ from pydantic import AfterValidator, AwareDatetime, BaseModel, Field
 
 
 EPOCH = datetime(1970, 1, 1, tzinfo=UTC)
+MAX_INCREMENTAL_EXPORT_PAGE_SIZE = 1000
 
 
 def urlencode_field(field: str):
@@ -96,6 +97,21 @@ class EndpointConfig(BaseModel):
     credentials: OAuth2Credentials | ApiToken = Field(
         discriminator="credentials_title",
         title="Authentication",
+    )
+    class Advanced(BaseModel):
+        incremental_export_page_size: Annotated[int, Field(
+            description="Page size for incremental export streams. Typically left as the default unless Estuary Support or the connector logs indicate otherwise.",
+            title="Incremental Export Streams' Page Size",
+            default=MAX_INCREMENTAL_EXPORT_PAGE_SIZE,
+            le=MAX_INCREMENTAL_EXPORT_PAGE_SIZE,
+            gt=0,
+        )]
+
+    advanced: Advanced = Field(
+        default_factory=Advanced, #type: ignore
+        title="Advanced Config",
+        description="Advanced settings for the connector.",
+        json_schema_extra={"advanced": True},
     )
 
 

--- a/source-zendesk-support-native/source_zendesk_support_native/resources.py
+++ b/source-zendesk-support-native/source_zendesk_support_native/resources.py
@@ -132,12 +132,14 @@ def ticket_metrics(
                 fetch_ticket_metrics,
                 http,
                 config.subdomain,
+                config.advanced.incremental_export_page_size,
             ),
             fetch_page=functools.partial(
                 backfill_ticket_metrics,
                 http,
                 config.subdomain,
                 config.start_date,
+                config.advanced.incremental_export_page_size,
             )
         )
 
@@ -388,6 +390,7 @@ def incremental_cursor_export_resources(
                 http,
                 config.subdomain,
                 name,
+                config.advanced.incremental_export_page_size,
             ),
             fetch_page=functools.partial(
                 backfill_incremental_cursor_export_resources,
@@ -395,6 +398,7 @@ def incremental_cursor_export_resources(
                 config.subdomain,
                 name,
                 config.start_date,
+                config.advanced.incremental_export_page_size,
             )
         )
 
@@ -448,6 +452,7 @@ def ticket_child_resources(
                 config.subdomain,
                 path,
                 response_model,
+                config.advanced.incremental_export_page_size,
             ),
             fetch_page=functools.partial(
                 backfill_ticket_child_resources,
@@ -456,6 +461,7 @@ def ticket_child_resources(
                 path,
                 response_model,
                 config.start_date,
+                config.advanced.incremental_export_page_size,
             )
         )
 

--- a/source-zendesk-support-native/tests/snapshots/snapshots__spec__capture.stdout.json
+++ b/source-zendesk-support-native/tests/snapshots/snapshots__spec__capture.stdout.json
@@ -3,6 +3,20 @@
     "protocol": 3032023,
     "configSchema": {
       "$defs": {
+        "Advanced": {
+          "properties": {
+            "incremental_export_page_size": {
+              "default": 1000,
+              "description": "Page size for incremental export streams. Typically left as the default unless Estuary Support or the connector logs indicate otherwise.",
+              "exclusiveMinimum": 0,
+              "maximum": 1000,
+              "title": "Incremental Export Streams' Page Size",
+              "type": "integer"
+            }
+          },
+          "title": "Advanced",
+          "type": "object"
+        },
         "ApiToken": {
           "properties": {
             "credentials_title": {
@@ -91,6 +105,12 @@
             }
           ],
           "title": "Authentication"
+        },
+        "advanced": {
+          "$ref": "#/$defs/Advanced",
+          "advanced": true,
+          "description": "Advanced settings for the connector.",
+          "title": "Advanced Config"
         }
       },
       "required": [


### PR DESCRIPTION
**Description:**

If a user's Zendesk account has extremely large tickets/users and we request a sufficiently large number of results per page, it's possible to receive 504 responses from the intermediate gateways if Zendesk takes too long to send back results. Instead of tinkering with this in the connector code whenever this comes up, I'm opting to make this a configurable setting that's easily adjusted on a per capture basis.

A future improvement would be to automatically detect these types of 504 responses & dynamically reduce the page size. That's a bit more involved though since our CDK automatically retries any requests that receive 5xx responses, meaning the connector code never sees these 5xx errors. Determining if/how the CDK should expose 5xx responses is left as a later exercise.

Spec snapshot changes are expected due to the added config setting.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

Docs should be updated to reflect the new config setting.

**Notes for reviewers:**

Tested on a local stack. Confirmed:
- All streams complete.
- The page size used for incremental export streams does change based on the configured page size.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2331)
<!-- Reviewable:end -->
