### PR TITLE
source-postgres: Feature flag `use_schema_inference`

### DIFF
--- a/source-postgres/.snapshots/TestGeneric-SpecResponse
+++ b/source-postgres/.snapshots/TestGeneric-SpecResponse
@@ -104,6 +104,11 @@
             "type": "boolean",
             "title": "Read-Only Capture",
             "description": "When set the capture will operate in read-only mode and avoid operations such as watermark writes. This comes with some tradeoffs; consult the connector documentation for more information."
+          },
+          "feature_flags": {
+            "type": "string",
+            "title": "Feature Flags",
+            "description": "This property is intended for Estuary internal use. You should only modify this field as directed by Estuary support."
           }
         },
         "additionalProperties": false,

--- a/source-postgres/discovery.go
+++ b/source-postgres/discovery.go
@@ -50,6 +50,9 @@ func (db *postgresDatabase) DiscoverTables(ctx context.Context) (map[sqlcapture.
 			// We want to exclude the watermarks table from the output bindings, but we still discover it
 			table.OmitBinding = true
 		}
+		if db.featureFlags["use_schema_inference"] {
+			table.UseSchemaInference = true
+		}
 		tableMap[streamID] = table
 	}
 	for _, column := range columns {

--- a/source-postgres/main.go
+++ b/source-postgres/main.go
@@ -118,7 +118,11 @@ type advancedConfig struct {
 	FeatureFlags          string   `json:"feature_flags,omitempty" jsonschema:"title=Feature Flags,description=This property is intended for Estuary internal use. You should only modify this field as directed by Estuary support."`
 }
 
-var featureFlagDefaults = map[string]bool{}
+var featureFlagDefaults = map[string]bool{
+	// When set, discovered collection schemas will request that schema inference be
+	// used _in addition to_ the full column/types discovery we already do.
+	"use_schema_inference": false,
+}
 
 // Validate checks that the configuration possesses all required properties.
 func (c *Config) Validate() error {

--- a/source-postgres/main_test.go
+++ b/source-postgres/main_test.go
@@ -30,6 +30,8 @@ var (
 	dbCapturePass    = flag.String("db_capture_pass", "secret1234", "The password for the capture user")
 
 	readOnlyCapture = flag.Bool("read_only_capture", false, "When true, run test captures in read-only mode")
+
+	testFeatureFlags = flag.String("feature_flags", "", "Feature flags to apply to all test captures.")
 )
 
 const testSchemaName = "test"
@@ -75,6 +77,7 @@ func postgresTestBackend(t testing.TB) *testBackend {
 		Password: *dbCapturePass,
 		Database: *dbName,
 	}
+	captureConfig.Advanced.FeatureFlags = *testFeatureFlags
 	captureConfig.Advanced.BackfillChunkSize = 16
 	if *readOnlyCapture {
 		captureConfig.Advanced.ReadOnlyCapture = true

--- a/sqlcapture/discovery.go
+++ b/sqlcapture/discovery.go
@@ -192,6 +192,9 @@ func DiscoverCatalog(ctx context.Context, db Database) ([]*pc.Response_Discovere
 				{Ref: "#" + anchor},
 			},
 		}
+		if table.UseSchemaInference {
+			schema.Extras = map[string]any{"x-infer-schema": true}
+		}
 
 		var rawSchema, err = schema.MarshalJSON()
 		if err != nil {

--- a/sqlcapture/interface.go
+++ b/sqlcapture/interface.go
@@ -214,6 +214,8 @@ type DiscoveryInfo struct {
 	BaseTable   bool                  // True if the table type is 'BASE TABLE' and false for views or other not-physical-table entities.
 	OmitBinding bool                  // True if the table should be omitted from discovery catalog generation.
 
+	UseSchemaInference bool // True if generated JSON schemas for this table should request schema inference.
+
 	// UnpredictableKeyOrdering will be true when the connector is unable to guarantee
 	// (for a particular table) that serialized RowKey values will accurately reproduce
 	// (when compared bytewise lexicographically) the database sort ordering of the same


### PR DESCRIPTION
**Description:**

This PR adds a feature flag `use_schema_inference` to `source-postgres` which when set causes `x-infer-schema: true` to be added to discovered schemas.

Actually figuring out the right spot to add the `x-infer-schema` annotation was surprisingly tricky, what I ended up doing was adding a third "partial schema" to the top-level `allOf`, where the new schema is literally just `{"x-infer-schema": true}`. I think that works?

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2337)
<!-- Reviewable:end -->
