### PR TITLE
source-http-ingest: improve error message on invlalid json schemas

### DIFF
--- a/source-http-ingest/src/server.rs
+++ b/source-http-ingest/src/server.rs
@@ -623,7 +623,9 @@ pub fn openapi_spec<'a>(
 
         let openapi_schema =
             serde_json::from_str::<openapi::Schema>(&binding.collection.write_schema_json)
-                .context("deserializing collection schema")?;
+                .context("The collection JSON schema (or writeSchema) could not be parsed as an \
+                    OpenAPI schema. Please ensure that no fields have multiple types or conditional \
+                    schemas, as those are unsupported by the connector at this time")?;
 
         let mut content_builder = openapi::content::ContentBuilder::new().schema(openapi_schema);
 


### PR DESCRIPTION
Improves the error message when one of the collection JSON schemas cannot be parsed as an `openapi::Schema`. The openapi library we use only supports a subset of JSON schema, so things like multiple types or conditionals don't work. We might in the future want to try a different library, but for now this just improves the error message in the (hopefully rare) case that someone tries using any fancy json schema features.