### PR TITLE
materialize-bigquery: use range hints for load queries

### DIFF
--- a/materialize-bigquery/.snapshots/TestSQLGeneration
+++ b/materialize-bigquery/.snapshots/TestSQLGeneration
@@ -33,22 +33,6 @@ CREATE TABLE IF NOT EXISTS projectID.dataset.delta_updates (
 CLUSTER BY theKey;
 --- End projectID.dataset.delta_updates createTargetTable ---
 
---- Begin projectID.dataset.key_value loadQuery ---
-SELECT 0, l.flow_document
-	FROM projectID.dataset.key_value AS l
-	JOIN flow_temp_table_0 AS r
-		 ON l.key1 = r.c0
-		 AND l.key2 = r.c1
-		 AND l.key_binary = r.c2
-
---- End projectID.dataset.key_value loadQuery ---
-
---- Begin projectID.dataset.delta_updates loadQuery ---
-
-SELECT -1, NULL LIMIT 0
-
---- End projectID.dataset.delta_updates loadQuery ---
-
 --- Begin projectID.dataset.key_value storeInsert ---
 INSERT INTO projectID.dataset.key_value (key1, key2, key_binary, `array`, binary, boolean, flow_published_at, integer, integerGt64Bit, integerWithUserDDL, multiple, number, numberCastToString, object, string, stringInteger, stringInteger39Chars, stringInteger66Chars, stringNumber, flow_document)
 SELECT c0, c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11, c12, c13, c14, c15, c16, c17, c18, c19 FROM flow_temp_table_0;
@@ -167,5 +151,15 @@ WHEN NOT MATCHED THEN
 	INSERT (key1, key2, key_binary, `array`, binary, boolean, flow_published_at, integer, integerGt64Bit, integerWithUserDDL, multiple, number, numberCastToString, object, string, stringInteger, stringInteger39Chars, stringInteger66Chars, stringNumber, flow_document)
 	VALUES (r.c0, r.c1, r.c2, r.c3, r.c4, r.c5, r.c6, r.c7, r.c8, r.c9, r.c10, r.c11, r.c12, r.c13, r.c14, r.c15, r.c16, r.c17, r.c18, r.c19);
 --- End projectID.dataset.key_value storeUpdate ---
+
+--- Begin projectID.dataset.key_value loadQuery ---
+SELECT 0, l.flow_document
+	FROM projectID.dataset.key_value AS l
+	JOIN flow_temp_table_0 AS r
+		 ON l.key1 = r.c0 AND l.key1 >= 10 AND l.key1 <= 100
+		 AND l.key2 = r.c1
+		 AND l.key_binary = r.c2 AND l.key_binary >= 'aGVsbG8K' AND l.key_binary <= 'Z29vZGJ5ZQo='
+
+--- End projectID.dataset.key_value loadQuery ---
 
 

--- a/materialize-bigquery/binding.go
+++ b/materialize-bigquery/binding.go
@@ -10,15 +10,15 @@ import (
 
 type binding struct {
 	target         sql.Table
-	loadQuerySQL   string
 	storeInsertSQL string
 
-	loadFile      *stagedFile
-	storeFile     *stagedFile
-	tempTableName string
-	hasData       bool
-	mustMerge     bool
-	mergeBounds   *sql.MergeBoundsBuilder
+	loadFile         *stagedFile
+	storeFile        *stagedFile
+	tempTableName    string
+	hasData          bool
+	mustMerge        bool
+	loadMergeBounds  *sql.MergeBoundsBuilder
+	storeMergeBounds *sql.MergeBoundsBuilder
 }
 
 // bindingDocument is used by the load operation to fetch binding flow_document values

--- a/materialize-bigquery/sqlgen_test.go
+++ b/materialize-bigquery/sqlgen_test.go
@@ -24,7 +24,6 @@ func TestSQLGeneration(t *testing.T) {
 		sql.TestTemplates{
 			TableTemplates: []*template.Template{
 				tplCreateTargetTable,
-				tplLoadQuery,
 				tplStoreInsert,
 			},
 			TplAddColumns:    tplAlterTableColumns,
@@ -35,8 +34,10 @@ func TestSQLGeneration(t *testing.T) {
 		},
 	)
 
-	{
-		tpl := tplStoreUpdate
+	for _, tpl := range []*template.Template{
+		tplStoreUpdate,
+		tplLoadQuery,
+	} {
 		tbl := tables[0]
 		require.False(t, tbl.DeltaUpdates)
 		var testcase = tbl.Identifier + " " + tpl.Name()
@@ -59,7 +60,7 @@ func TestSQLGeneration(t *testing.T) {
 			},
 		}
 
-		tf := mergeQueryInput{
+		tf := queryParams{
 			Table:  tbl,
 			Bounds: bounds,
 		}

--- a/tests/materialize/materialize-bigquery/fetch-data.go
+++ b/tests/materialize/materialize-bigquery/fetch-data.go
@@ -16,7 +16,7 @@ import (
 )
 
 var deleteTable = flag.Bool("delete", false, "delete the table instead of dumping its contents")
-var deleteSpecs = flag.Bool("delete-specs", false, "stored materialize checkpoint and specs")
+var deleteSpecs = flag.Bool("delete-specs", false, "delete stored checkpoint")
 
 func main() {
 	flag.Parse()
@@ -64,11 +64,7 @@ func main() {
 		}
 		os.Exit(0)
 	} else if *deleteSpecs {
-		query := fmt.Sprintf(
-			"delete from %s.flow_checkpoints_v1 where materialization='tests/materialize-bigquery/materialize';delete from %s.flow_materializations_v2 where materialization='tests/materialize-bigquery/materialize';",
-			dataset,
-			dataset,
-		)
+		query := fmt.Sprintf("delete from %s.flow_checkpoints_v1 where materialization='tests/materialize-bigquery/materialize'", dataset)
 
 		job, err := client.Query(query).Run(ctx)
 		if err != nil {


### PR DESCRIPTION
**Description:**

Bound load queries by the minimum & maximum values for observed keys to load. This may help reduce costs associated with scanning data which we know does not contain values we are interested in.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2348)
<!-- Reviewable:end -->
