### PR TITLE
materialize-s3-iceberg: default to delta updates if config is absent

### DIFF
--- a/materialize-s3-iceberg/driver_test.go
+++ b/materialize-s3-iceberg/driver_test.go
@@ -61,7 +61,6 @@ func TestValidateAndApply(t *testing.T) {
 	resourceConfig := resource{
 		Namespace: "test_namespace",
 		Table:     "test_table",
-		Delta:     true,
 	}
 
 	catalog := catalog{


### PR DESCRIPTION
**Description:**

Unless the delta updates configuration is explicitly false, we will consider delta updates to be enabled.

Practically speaking the connector only works in delta updates mode, and will error out if this is set to false.

This will allow the materialization to work with a `sourceCapture` set, with new bindings added an absent configuration value for `delta_updates`.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2350)
<!-- Reviewable:end -->
