### PR TITLE
Docs and scripts for bulk editing feature flags

### DIFF
--- a/docs/feature_flags.md
+++ b/docs/feature_flags.md
@@ -25,6 +25,16 @@ The process for changing a default connector behavior is as follows:
  - Add a feature flag `new_thing` with default value false, which controls the relevant
    connector behavior via an `if featureFlags["new_thing"] {...}` at the appropriate
    point(s) in the code.
+   - If this is the first feature flag added to a particular connector, you may need
+     to add the feature flag boilerplate, which consists of a default-values map
+     `featureFlagDefaults` and some startup logic to parse the config property and
+     store the results in the connector state. See the "Worked Example" section for
+     links to example PRs.
+   - Even though the default value is generally false, you should add all feature flags
+     to the `featureFlagDefaults` map with a couple of lines of comment explaining what
+     exactly changes when it's true or false. This way we have a single location to
+     check to answer questions like "what feature flags does this connector have" and
+     "what happens if I toggle this flag?"
  - Edit the endpoint configs of all tasks that currently exist in production to add the
    `no_new_thing` flag setting.
  - Merge another PR which changes the connector default for `new_thing` to true.

--- a/docs/feature_flags.md
+++ b/docs/feature_flags.md
@@ -36,14 +36,16 @@ simultaneously with the endpoint config edit, and doing things in the opposite o
 would behave even worse (if a task got unlucky and restarted at the wrong moment,
 it would pick up the default-change PR before the `no_new_thing` flag setting and
 exhibit the new behavior temporarily before going back to the old behavior). The window
-here is minutes at most and it only impacts new task creation, so just try keep an eye
-on that and perform the two operations fairly close together.
+here is minutes at most and it only impacts new task creation, so just try to perform the
+two operations close together and keep an eye on whether any new tasks were created during
+the process.
 
 ## Experimental Features
 
 An experimental feature is even simpler, just add a feature flag controlling the new
 behavior. Normally this should be default-off, but if it makes things clearer there
-shouldn't be anything wrong with adding a default-on flag instead.
+shouldn't be anything wrong with adding a default-on flag instead and having `no_foobar`
+be the setting which opts into the new behavior.
 
 ## Bulk Editing Process
 

--- a/docs/feature_flags.md
+++ b/docs/feature_flags.md
@@ -1,0 +1,78 @@
+# Feature Flags
+
+Sometimes we need a mechanism for customizing connector behavior per-task in a somewhat
+behind-the-scenes kind of way. Uses for this mechanism include:
+
+ - Changing the default behavior of a connector while preserving the existing behavior for
+   all preexisting tasks.
+ - Implementing a risky, experimental, or power-user feature which we can explicitly enable
+   (or direct a user to enable) on specific tasks without making it a global change.
+
+The mechanism we've settled on for this purpose is an advanced property in the endpoint
+config which holds "feature flags". This property should be a string, located at the
+path `/advanced/feature_flags` in the config, which holds a comma-separated list of
+flag settings.
+
+For a given flag `do_something` there are two valid flag settings: `do_something` and
+`no_do_something`. These flag settings are combined at connector startup with a list
+of connector default values for the flags, so that in effect we have a ternary option
+of explicit-yes / explicit-no / default for each feature flag.
+
+## Changing Default Behaviors
+
+The process for changing a default connector behavior is as follows:
+
+ - Add a feature flag `new_thing` with default value false, which controls the relevant
+   connector behavior via an `if featureFlags["new_thing"] {...}` at the appropriate
+   point(s) in the code.
+ - Edit the endpoint configs of all tasks that currently exist in production to add the
+   `no_new_thing` flag setting.
+ - Merge another PR which changes the connector default for `new_thing` to true.
+
+Note that there's a sort of race condition here where any tasks created in between the
+bulk config edit and the connector default change will exhibit a change in behavior. This
+is probably unavoidable, since there is no way to atomically merge the default-change
+simultaneously with the endpoint config edit, and doing things in the opposite order
+would behave even worse (if a task got unlucky and restarted at the wrong moment,
+it would pick up the default-change PR before the `no_new_thing` flag setting and
+exhibit the new behavior temporarily before going back to the old behavior). The window
+here is minutes at most and it only impacts new task creation, so just try keep an eye
+on that and perform the two operations fairly close together.
+
+## Experimental Features
+
+An experimental feature is even simpler, just add a feature flag controlling the new
+behavior. Normally this should be default-off, but if it makes things clearer there
+shouldn't be anything wrong with adding a default-on flag instead.
+
+## Bulk Editing Process
+
+There are a couple of scripts I've written which make it easier to add a feature flag
+to all production tasks using a particular connector.
+
+The `scripts/list-tasks.sh` script queries the Supabase `live_specs` table for all
+tasks running a particular connector, and optionally can add them all to the active
+`flowctl` draft automatically.
+
+The `scripts/bulk-config-editor.sh` script can modify every `*.config.yaml` file
+under the current directory to add a feature flag setting to the appropriate property.
+
+The complete workflow goes something like this:
+
+```bash
+$ mkdir -p draft && cd draft && echo '*' > .gitignore          # Create a directory somewhere to hold the Flow specs being edited
+$ flowctl draft create                                         # Create a new draft
+$ ../scripts/list-tasks.sh --connector=source-mysql --draft    # Add all source-mysql (and variants) captures to the current draft
+$ flowctl draft develop                                        # Pull down draft specs into a local directory
+$ ../scripts/bulk-config-editor.sh --set_flag=do_some_thing    # Add the 'do_some_thing' feature flag to the local endpoint configs, with interactive diffs and prompting
+$ flowctl draft author --source flow.yaml                      # Upload modified specs to the draft
+$ flowctl draft publish                                        # Publish the uploaded specs
+```
+
+## Worked Example
+
+TODO(wgd): Describe and add PR links when doing the MySQL `format: date` change.
+
+1. Adding the feature flags plumbing and a feature flag.
+2. Running through the commands to set no_flag.
+3. Flipping the default.

--- a/docs/feature_flags.md
+++ b/docs/feature_flags.md
@@ -18,44 +18,54 @@ For a given flag `do_something` there are two valid flag settings: `do_something
 of connector default values for the flags, so that in effect we have a ternary option
 of explicit-yes / explicit-no / default for each feature flag.
 
+## Adding a New Flag
+
+Add the flag's default value to the default-values map, along with a short explanatory
+comment. Flags names should be in `snake_case`, and all flags should have a default value
+in this map as well as a comment so that there's a single location to check and see what
+flags a particular connector supports:
+
+```go
+var featureFlagDefaults = map[string]bool{
+  // A short (one or two line) description of what this flag does when set/unset.
+  "do_something": false,
+}
+```
+
+Then at the appropriate point(s) in the code, introduce the new logic conditional on the
+flag setting:
+
+```go
+if db.featureFlags["do_something"] {
+  panic("do_something feature flag not yet implemented")
+}
+```
+
+If this is the first feature flag added to the connector, you may need to add the
+typical boilerplate as well.
+
+## Experimental Features
+
+For an experimental feature, just add a feature flag controlling the new behavior.
+Typically this should be default-off, but if it makes things clearer there shouldn't
+be anything wrong with adding a default-on flag instead and having `no_foobar` be the
+setting which opts into the new behavior.
+
 ## Changing Default Behaviors
 
 The process for changing a default connector behavior is as follows:
 
- - Add a feature flag `new_thing` with default value false, which controls the relevant
-   connector behavior via an `if featureFlags["new_thing"] {...}` at the appropriate
-   point(s) in the code.
-   - If this is the first feature flag added to a particular connector, you may need
-     to add the feature flag boilerplate, which consists of a default-values map
-     `featureFlagDefaults` and some startup logic to parse the config property and
-     store the results in the connector state. See the "Worked Example" section for
-     links to example PRs.
-   - Even though the default value is generally false, you should add all feature flags
-     to the `featureFlagDefaults` map with a couple of lines of comment explaining what
-     exactly changes when it's true or false. This way we have a single location to
-     check to answer questions like "what feature flags does this connector have" and
-     "what happens if I toggle this flag?"
- - Edit the endpoint configs of all tasks that currently exist in production to add the
-   `no_new_thing` flag setting.
- - Merge another PR which changes the connector default for `new_thing` to true.
+ - Add the feature flag `new_thing` with a default value corresponding to the old behavior (typically false).
+ - Edit the endpoint configs of all tasks in production to add the `no_new_thing` flag setting.
+ - Merge a followup PR which changes the connector default for `new_thing` to true.
 
 Note that there's a sort of race condition here where any tasks created in between the
 bulk config edit and the connector default change will exhibit a change in behavior. This
-is probably unavoidable, since there is no way to atomically merge the default-change
-simultaneously with the endpoint config edit, and doing things in the opposite order
-would behave even worse (if a task got unlucky and restarted at the wrong moment,
-it would pick up the default-change PR before the `no_new_thing` flag setting and
-exhibit the new behavior temporarily before going back to the old behavior). The window
-here is minutes at most and it only impacts new task creation, so just try to perform the
-two operations close together and keep an eye on whether any new tasks were created during
-the process.
-
-## Experimental Features
-
-An experimental feature is even simpler, just add a feature flag controlling the new
-behavior. Normally this should be default-off, but if it makes things clearer there
-shouldn't be anything wrong with adding a default-on flag instead and having `no_foobar`
-be the setting which opts into the new behavior.
+is unavoidable, since there is no way to atomically merge the default-change simultaneously
+with the endpoint config edit, and doing things in the opposite order would behave worse if
+we got unlucky with task restart timing. The window of concern here is minutes and it only
+impacts new tasks, so just try to perform the two operations close together and keep an eye
+on whether any new tasks were created during the process.
 
 ## Bulk Editing Process
 
@@ -72,11 +82,8 @@ under the current directory to add a feature flag setting to the appropriate pro
 The complete workflow goes something like this:
 
 ```bash
-$ mkdir -p draft && cd draft && echo '*' > .gitignore          # Create a directory somewhere to hold the Flow specs being edited
-$ flowctl draft create                                         # Create a new draft
-$ ../scripts/list-tasks.sh --connector=source-mysql --draft    # Add all source-mysql (and variants) captures to the current draft
-$ flowctl draft develop                                        # Pull down draft specs into a local directory
-$ ../scripts/bulk-config-editor.sh --set_flag=do_some_thing    # Add the 'do_some_thing' feature flag to the local endpoint configs, with interactive diffs and prompting
+$ ../scripts/list-tasks.sh --connector=source-mysql --pull --dir=./specs     # Fetch task specs for every source-mysql (and variants) capture in production
+$ ../scripts/bulk-config-editor.sh --set_flag=do_some_thing --dir=./specs    # Add the 'do_some_thing' feature flag to the local endpoint configs, with interactive diffs
 $ flowctl draft author --source flow.yaml                      # Upload modified specs to the draft
 $ flowctl draft publish                                        # Publish the uploaded specs
 ```
@@ -88,3 +95,46 @@ TODO(wgd): Describe and add PR links when doing the MySQL `format: date` change.
 1. Adding the feature flags plumbing and a feature flag.
 2. Running through the commands to set no_flag.
 3. Flipping the default.
+
+## Appendix: Feature Flag Boilerplate
+
+Edit `main.go` to introduce a default-settings map:
+
+```go
+var featureFlagDefaults = map[string]bool{}
+```
+
+add the feature flags property to the advanced config struct:
+
+```go
+type advancedConfig struct {
+// [...other properties...]
+    FeatureFlags string `json:"feature_flags,omitempty" jsonschema:"title=Feature Flags,description=This property is intended for Estuary internal use. You should only modify this field as directed by Estuary support."`
+}
+```
+
+and introduce some startup logic to parse the flags property, merge with default values,
+and save the parsed flag settings into the appropriate state struct.
+
+```go
+    var featureFlags = boilerplate.ParseFeatureFlags(config.Advanced.FeatureFlags, featureFlagDefaults)
+    if config.Advanced.FeatureFlags != "" {
+        log.WithField("flags", featureFlags).Info("parsed feature flags")
+    }
+    // [...a bit later...]
+    db.featureFlags = featureFlags
+```
+
+Finally add a command-line flag in `main_test.go` so that flag settings can be overridden
+on the command-line when running the test suite:
+
+```go
+testFeatureFlags = flag.String("feature_flags", "", "Feature flags to apply to all test captures.")
+```
+
+and plumb that command-line flag value into the capture configuration at the appropriate
+point(s):
+
+```go
+captureConfig.Advanced.FeatureFlags = *testFeatureFlags
+```

--- a/scripts/bulk-config-editor.sh
+++ b/scripts/bulk-config-editor.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+set -e
+TMP="$(mktemp -d)"
+DIR="$(dirname $0)"
+NAME="$(basename $0 .sh)"
+trap "rm -rf '$TMP'" EXIT
+go build -C "$DIR/$NAME" -o "$TMP/$NAME" .
+"$TMP/$NAME" $@

--- a/scripts/bulk-config-editor/editing.go
+++ b/scripts/bulk-config-editor/editing.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os/exec"
+	"strings"
+
+	log "github.com/sirupsen/logrus"
+)
+
+// configEdit represents a single "set property foo to bar" edit to an endpoint config.
+//
+// We have to represent edits in this form so that we can either apply them ourselves
+// (to plaintext configs) or by invoking `sops set` on an encrypted config.
+type configEdit struct {
+	Path  []string
+	Value any
+}
+
+func (e *configEdit) String() string {
+	return fmt.Sprintf("%s = %v", strings.Join(e.Path, "."), e.Value)
+}
+
+func editPlaintextTaskConfig(cfg any, edits []configEdit) (any, error) {
+	for _, edit := range edits {
+		modified, err := setAtPath(cfg, edit.Path, edit.Value)
+		if err != nil {
+			return nil, fmt.Errorf("error applying edit [%s]: %w", edit.String(), err)
+		}
+		cfg = modified
+	}
+	return cfg, nil
+}
+
+func editEncryptedTaskConfig(ctx context.Context, configFile string, edits []configEdit) error {
+	// Execute sops commands to perform the specified edits
+	for _, edit := range edits {
+		log.WithField("edit", edit.String()).Debug("applying edit")
+
+		// TODO(wgd): Allow unsetting if edit.Value is nil?
+		var bs, err = json.Marshal(edit.Value)
+		if err != nil {
+			return fmt.Errorf("error serializing edited value: %w", err)
+		}
+		var cmd = exec.CommandContext(ctx, "sops", "set", configFile, asPyDictIndex(edit.Path), string(bs))
+		if _, err = cmd.Output(); err != nil {
+			if err, ok := err.(*exec.ExitError); ok {
+				return fmt.Errorf("error editing with SOPS: %s", strings.TrimSpace(string(err.Stderr)))
+			}
+			return fmt.Errorf("error editing with SOPS: %w", err)
+		}
+	}
+	return nil
+}
+
+func asPyDictIndex(path []string) string {
+	var xs []string
+	for _, elem := range path {
+		// TODO(wgd): Consider supporting array indices?
+		xs = append(xs, fmt.Sprintf(`[%q]`, elem))
+	}
+	return strings.Join(xs, "")
+}
+
+func setAtPath(x any, p []string, v any) (any, error) {
+	if len(p) == 0 {
+		return v, nil
+	}
+
+	if x == nil {
+		x = make(map[string]any)
+	}
+	if obj, ok := x.(map[string]any); ok {
+		modified, err := setAtPath(obj[p[0]], p[1:], v)
+		if err != nil {
+			return nil, err
+		}
+		obj[p[0]] = modified
+		return obj, nil
+	}
+
+	return nil, fmt.Errorf("unable to modify %v at pointer %s", x, strings.Join(p, "."))
+}
+
+func indexPath(x any, path ...string) (any, bool) {
+	for _, p := range path {
+		if m, ok := x.(map[string]any); !ok {
+			return nil, false
+		} else if v, ok := m[p]; !ok {
+			return nil, false
+		} else {
+			x = v
+		}
+	}
+	return x, true
+}

--- a/scripts/bulk-config-editor/main.go
+++ b/scripts/bulk-config-editor/main.go
@@ -1,0 +1,262 @@
+// The bulk-config-editor script applies an edit operation to all endpoint configs in a
+// local directory, using SOPS as necessary to manipulate encrypted configs.
+//
+// While the script is written to be fairly modular, it is designed to be used alongside
+// the list-tasks script to bulk-edit all production tasks using a particular connector
+// to have some new feature flag.
+//
+// The process for doing that is described in 'docs/feature_flags.md'
+package main
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/pmezard/go-difflib/difflib"
+	"gopkg.in/yaml.v3"
+
+	log "github.com/sirupsen/logrus"
+)
+
+var scriptDescription = `
+The bulk-config-editor script applies an edit operation to all endpoint
+configs in a local directory, using SOPS as necessary to manipulate
+encrypted configs.
+
+Refer to 'docs/feature_flags.md' for more information on the intended
+use-case and workflow.
+`
+
+var (
+	logLevel   = flag.String("log_level", "info", "The log level to print at.")
+	configsDir = flag.String("dir", ".", "The directory within which to edit configs.")
+	setFlag    = flag.String("set_flag", "", "A feature-flag setting to add to every task.")
+)
+
+func main() {
+	flag.Usage = func() {
+		fmt.Fprintf(flag.CommandLine.Output(), "%s\n", scriptDescription)
+		fmt.Fprintf(flag.CommandLine.Output(), "usage of %s:\n", os.Args[0])
+		flag.PrintDefaults()
+	}
+	flag.Parse()
+	if lvl, err := log.ParseLevel(*logLevel); err != nil {
+		log.WithFields(log.Fields{"level": *logLevel, "err": err}).Fatal("invalid log level")
+	} else {
+		log.SetLevel(lvl)
+	}
+
+	if err := performEdits(context.Background()); err != nil {
+		log.WithField("err", err).Fatal("error")
+	}
+}
+
+func performEdits(ctx context.Context) error {
+	// As a sanity check, verify that there's a flow.yaml file in the current directory
+	if _, err := os.Stat("./flow.yaml"); errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("no flow.yaml in the current directory")
+	}
+
+	// List all *.config.yaml files under the current directory
+	var configFiles, err = listConfigFiles(*configsDir)
+	if err != nil {
+		return fmt.Errorf("error listing config files: %w", err)
+	}
+	if len(configFiles) == 0 {
+		return fmt.Errorf("no files named '*.config.yaml' under the current directory")
+	}
+
+	// Compute edits for each config file
+	log.WithField("count", len(configFiles)).Info("editing config files")
+	var errs []error
+	for _, configFile := range configFiles {
+		if err := editConfigFile(ctx, configFile); err != nil {
+			errs = append(errs, fmt.Errorf("error editing config %q: %w", configFile, err))
+		}
+	}
+	if len(errs) > 0 {
+		fmt.Printf("failed to edit %d configs\n", len(errs))
+		for _, err := range errs {
+			fmt.Printf("%s\n", err.Error())
+		}
+	}
+	return nil
+}
+
+func editConfigFile(ctx context.Context, configFile string) error {
+	// Read in and parse the config file
+	var originalConfigBytes, err = os.ReadFile(configFile)
+	if err != nil {
+		return fmt.Errorf("error reading file: %w", err)
+	}
+	var originalConfig any
+	if err := yaml.Unmarshal(originalConfigBytes, &originalConfig); err != nil {
+		return fmt.Errorf("error parsing file: %w", err)
+	}
+
+	// Compute edits based on the parsed original config
+	edits, err := computeEdits(originalConfig)
+	if err != nil {
+		return fmt.Errorf("error computing edits: %w", err)
+	}
+
+	// Apply edits, either using SOPS if the file is encrypted or by modifying
+	// the parsed representation in-process if it's plaintext.
+	var modifiedConfig any
+	if _, ok := indexPath(originalConfig, "sops"); ok {
+		log.WithField("name", configFile).Debug("editing SOPS encrypted config")
+		if err := editEncryptedTaskConfig(ctx, configFile, edits); err != nil {
+			return fmt.Errorf("error applying edits via SOPS: %w", err)
+		}
+
+		// Read in the modified config for diffing against the original
+		modifiedConfigBytes, err := os.ReadFile(configFile)
+		if err != nil {
+			return fmt.Errorf("error reading modified config: %w", err)
+		}
+		if err := yaml.Unmarshal(modifiedConfigBytes, &modifiedConfig); err != nil {
+			return fmt.Errorf("error parsing modified config: %w", err)
+		}
+	} else {
+		// In order to not mess up the diffs we need the edits to the modified config to
+		// not share any pointers with the original version of the config. We could do some
+		// fiddly deep-copy logic, but the simplest way to achieve this is by re-parsing the
+		// original config a second time and then modifying that.
+		if err := yaml.Unmarshal(originalConfigBytes, &modifiedConfig); err != nil {
+			return fmt.Errorf("error re-parsing config: %w", err)
+		}
+
+		log.WithField("name", configFile).Debug("editing plaintext config")
+		modifiedConfig, err = editPlaintextTaskConfig(modifiedConfig, edits)
+		if err != nil {
+			return fmt.Errorf("error applying edits in memory: %w", err)
+		}
+
+		// Serialize and write out the modified config
+		bs, err := yaml.Marshal(modifiedConfig)
+		if err != nil {
+			return fmt.Errorf("error marshalling modified config: %w", err)
+		}
+		if err := os.WriteFile(configFile, bs, 0664); err != nil {
+			return fmt.Errorf("error writing modified config: %w", err)
+		}
+
+		// It takes about a second per config file edited with SOPS, and that's actually
+		// pretty convenient for watching the edits go by and making sure they all seem
+		// basically reasonable. So it messes with that if plaintext configs just zip on
+		// past instantly.
+		time.Sleep(500 * time.Millisecond)
+	}
+
+	log.WithField("name", configFile).Debug("edited config")
+	if err := printYAMLDiff(originalConfig, modifiedConfig, configFile, true); err != nil {
+		return fmt.Errorf("error diffing config: %w", err)
+	}
+	return nil
+}
+
+func listConfigFiles(dir string) ([]string, error) {
+	var filePaths []string
+	err := filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if !info.IsDir() && strings.HasSuffix(info.Name(), ".config.yaml") {
+			filePaths = append(filePaths, path)
+		}
+		return nil
+	})
+	return filePaths, err
+}
+
+func printYAMLDiff(old, new any, description string, colorize bool) error {
+	oldBytes, err := yaml.Marshal(old)
+	if err != nil {
+		return fmt.Errorf("error serializing old value: %w", err)
+	}
+	newBytes, err := yaml.Marshal(new)
+	if err != nil {
+		return fmt.Errorf("error serializing new value: %w", err)
+	}
+
+	configDiff, err := difflib.GetUnifiedDiffString(difflib.UnifiedDiff{
+		A:        difflib.SplitLines(string(oldBytes)),
+		B:        difflib.SplitLines(string(newBytes)),
+		FromFile: fmt.Sprintf("Original (%s)", description),
+		ToFile:   fmt.Sprintf("Modified (%s)", description),
+		Context:  1,
+	})
+	if err != nil {
+		return fmt.Errorf("error diffing JSON objects: %w", err)
+	}
+
+	var diffLines = strings.Split(configDiff, "\n")
+	if len(diffLines) == 1 && diffLines[0] == "" {
+		diffLines = nil
+	}
+	for _, diffLine := range diffLines {
+		var colorCode = ""
+		if colorize {
+			colorCode = "\033[0m"
+			if strings.HasPrefix(diffLine, "-") {
+				colorCode = "\033[1;31m"
+			}
+			if strings.HasPrefix(diffLine, "+") {
+				colorCode = "\033[1;32m"
+			}
+		}
+		fmt.Printf("%s%s\n", colorCode, diffLine)
+	}
+	if len(diffLines) == 0 {
+		fmt.Printf("%s (no diff)\n", description)
+	}
+	return nil
+}
+
+// computeEdits applies the desired edit(s) to the provided task config. Currently there
+// is only one edit type, but it should be reasonably clear how to add others.
+func computeEdits(cfg any) ([]configEdit, error) {
+	if *setFlag != "" {
+		return addFeatureFlag(cfg, *setFlag)
+	}
+	return nil, fmt.Errorf("no edits specified on the command-line")
+}
+
+// addFeatureFlag constructs an edit which sets the /advanced/feature_flags property to have
+// the specified flag. If there is already a value for /advanced/feature_flags the new flag is
+// appended to the comma-separated list, unless the prior flags include a setting for this
+// particular flag, in which case an error is returned instead so the task won't be changed.
+func addFeatureFlag(cfg any, flagName string) ([]configEdit, error) {
+	// Determine whether the task config already has a feature flags property, and if so
+	// parse it as a list of flag settings which we can easily append to.
+	var featureFlags []string
+	if flagsProp, ok := indexPath(cfg, "advanced", "feature_flags"); ok {
+		if flagsString, ok := flagsProp.(string); ok {
+			log.WithField("flags", flagsProp).Debug("task already has feature flags")
+			featureFlags = strings.Split(flagsString, ",")
+		}
+	}
+
+	// If the preexisting feature flags already include a setting for this base flag name,
+	// we don't want to add a redundant or contradictory one. In theory we might want to
+	// be able to flip flags here, but it seems safer to just refuse to do anything when
+	// this happens.
+	var flagBase = strings.TrimPrefix(flagName, "no_")
+	if slices.Contains(featureFlags, flagBase) || slices.Contains(featureFlags, "no_"+flagBase) {
+		return nil, fmt.Errorf("task config already has a setting for feature flag %q, doing nothing", flagBase)
+	}
+
+	// Finally, add the specified flag to the list and emit the resulting config edit.
+	featureFlags = append(featureFlags, flagName)
+	return []configEdit{{
+		Path:  []string{"advanced", "feature_flags"},
+		Value: strings.Join(featureFlags, ","),
+	}}, nil
+}

--- a/scripts/bulk-config-editor/main.go
+++ b/scripts/bulk-config-editor/main.go
@@ -36,7 +36,7 @@ use-case and workflow.
 
 var (
 	logLevel   = flag.String("log_level", "info", "The log level to print at.")
-	configsDir = flag.String("dir", ".", "The directory within which to edit configs.")
+	configsDir = flag.String("dir", "./specs", "The directory beneath which to edit configs.")
 	setFlag    = flag.String("set_flag", "", "A feature-flag setting to add to every task.")
 )
 

--- a/scripts/bulk-publish.sh
+++ b/scripts/bulk-publish.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+set -e
+TMP="$(mktemp -d)"
+DIR="$(dirname $0)"
+NAME="$(basename $0 .sh)"
+trap "rm -rf '$TMP'" EXIT
+go build -C "$DIR/$NAME" -o "$TMP/$NAME" .
+"$TMP/$NAME" $@

--- a/scripts/bulk-publish/main.go
+++ b/scripts/bulk-publish/main.go
@@ -46,6 +46,10 @@ func main() {
 	} else {
 		log.SetLevel(lvl)
 	}
+	log.SetFormatter(&log.TextFormatter{
+		FullTimestamp: true,
+		PadLevelText:  true,
+	})
 
 	if err := performPublishing(context.Background()); err != nil {
 		log.WithError(err).Fatal("error")
@@ -70,7 +74,7 @@ func performPublishing(ctx context.Context) error {
 		} else if hasImports && !hasOnlyImports {
 			return fmt.Errorf("file %q imports other files and also contains other non-import data, which is not supported", file)
 		} else if hasImports && hasOnlyImports {
-			log.WithField("file", file).Warn("skipping file with imports")
+			log.WithField("file", file).Warn("skipping import-only flow.yaml")
 		} else {
 			leafFiles = append(leafFiles, file)
 		}
@@ -150,10 +154,9 @@ func publishFile(ctx context.Context, file string) error {
 		return fmt.Errorf("error creating draft: %w", err)
 	} else if err := flowctl(ctx, "draft", "author", "--source", file); err != nil {
 		return fmt.Errorf("error authoring draft: %w", err)
+	} else if err := flowctl(ctx, "draft", "publish"); err != nil {
+		return fmt.Errorf("error publishing draft: %w", err)
 	}
-
-	// TODO(wgd): Run 'flowctl draft publish'
-	panic("unfinished")
 	return nil
 }
 

--- a/scripts/bulk-publish/main.go
+++ b/scripts/bulk-publish/main.go
@@ -1,0 +1,164 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+
+	log "github.com/sirupsen/logrus"
+)
+
+var scriptDescription = `
+The bulk-publish script is used to publish all leaf 'flow.yaml' files underneath
+a local directory to production, independently of each other so that a failure to
+publish one spec doesn't block others.
+
+This behavior works best when applied to the directory structure created by the
+list-tasks script when using the '--pull' flag, but the script has logic to avoid
+publishing any 'flow.yaml' files which import others so _in theory_ it should work
+correctly on the specs produced by 'flowctl draft develop' as well.
+
+Refer to 'docs/feature_flags.md' for more information on the intended use-case and workflow.
+`
+
+var (
+	logLevel      = flag.String("log_level", "info", "The log level to print at.")
+	configsDir    = flag.String("dir", "./specs", "The directory beneath which to publish configs.")
+	markPublished = flag.Bool("mark", false, "When true, renames files after publishing so that another run of this script will ignore them.")
+	yesFlag       = flag.Bool("yes", false, "When true, automatically answer 'yes' to the continue prompt.")
+)
+
+func main() {
+	flag.Usage = func() {
+		fmt.Fprintf(flag.CommandLine.Output(), "%s\n", scriptDescription)
+		fmt.Fprintf(flag.CommandLine.Output(), "usage of %s:\n", os.Args[0])
+		flag.PrintDefaults()
+	}
+	flag.Parse()
+	if lvl, err := log.ParseLevel(*logLevel); err != nil {
+		log.WithFields(log.Fields{"level": *logLevel, "err": err}).Fatal("invalid log level")
+	} else {
+		log.SetLevel(lvl)
+	}
+
+	if err := performPublishing(context.Background()); err != nil {
+		log.WithError(err).Fatal("error")
+	}
+}
+
+func performPublishing(ctx context.Context) error {
+	// List all flow.yaml files underneath the configs directory, recursively.
+	var files, err = listFilesNamed(*configsDir, "flow.yaml")
+	if err != nil {
+		return fmt.Errorf("error listing flow.yaml files: %w", err)
+	}
+
+	// Parse each YAML file and check if it imports any other files. Strictly
+	// speaking this check isn't required if we assume that the local specs came
+	// from running 'list-tasks.sh --pull', but it's a good safety check in case
+	// the specs came from 'flowctl draft develop'.
+	var leafFiles []string
+	for _, file := range files {
+		if hasImports, hasOnlyImports, err := checkForImports(file); err != nil {
+			return fmt.Errorf("error checking flow.yaml file for imports: %w", err)
+		} else if hasImports && !hasOnlyImports {
+			return fmt.Errorf("file %q imports other files and also contains other non-import data, which is not supported", file)
+		} else if hasImports && hasOnlyImports {
+			log.WithField("file", file).Warn("skipping file with imports")
+		} else {
+			leafFiles = append(leafFiles, file)
+		}
+	}
+
+	if len(leafFiles) == 0 {
+		return fmt.Errorf("no leaf flow.yaml files found")
+	}
+	if !*yesFlag {
+		fmt.Printf("Publish %d changes? (y/N) ", len(leafFiles))
+		var response string
+		fmt.Scanln(&response)
+		if !strings.EqualFold(response, "y") {
+			fmt.Println("Aborting.")
+			return nil
+		}
+	}
+
+	// For each flow.yaml file, try and publish it to production.
+	var failedFiles []string
+	for _, file := range leafFiles {
+		if err := publishFile(ctx, file); err != nil {
+			log.WithField("file", file).WithError(err).Warn("error publishing file")
+			failedFiles = append(failedFiles, file)
+		} else if *markPublished {
+			var newFilename = strings.ReplaceAll(file, "flow.yaml", "flow.published.yaml")
+			if err := os.Rename(file, newFilename); err != nil {
+				return fmt.Errorf("error renaming file %q to %q: %w", file, newFilename, err)
+			}
+		}
+	}
+	for _, file := range failedFiles {
+		log.WithField("file", file).Error("failed to publish")
+	}
+	return nil
+}
+
+// listFilesNamed returns a list of all files under the given directory (recursively) with the given name.
+func listFilesNamed(dir, filename string) ([]string, error) {
+	var files []string
+	var err = filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if !info.IsDir() && info.Name() == filename {
+			files = append(files, path)
+		}
+		return nil
+	})
+	return files, err
+}
+
+// checkForImports reads the file at the given path and checks whether it has a top-level property named 'import'.
+func checkForImports(file string) (hasImports bool, hasOnlyImports bool, err error) {
+	bs, err := os.ReadFile(file)
+	if err != nil {
+		return false, false, fmt.Errorf("error reading file: %w", err)
+	}
+	var doc any
+	if err := yaml.Unmarshal(bs, &doc); err != nil {
+		return false, false, fmt.Errorf("error unmarshalling YAML: %w", err)
+	}
+	if m, ok := doc.(map[string]any); ok {
+		if _, hasImports := m["import"]; hasImports {
+			return true, len(m) == 1, nil
+		}
+	}
+
+	return false, false, nil
+}
+
+// publishFile publishes the file at the given path to production.
+func publishFile(ctx context.Context, file string) error {
+	log.WithField("file", file).Info("publishing file")
+
+	if err := flowctl(ctx, "draft", "create"); err != nil {
+		return fmt.Errorf("error creating draft: %w", err)
+	} else if err := flowctl(ctx, "draft", "author", "--source", file); err != nil {
+		return fmt.Errorf("error authoring draft: %w", err)
+	}
+
+	// TODO(wgd): Run 'flowctl draft publish'
+	panic("unfinished")
+	return nil
+}
+
+func flowctl(ctx context.Context, args ...string) error {
+	log.WithField("command", args).Debug("executing flowctl command")
+	var _, err = exec.CommandContext(ctx, "flowctl", args...).Output()
+	return err
+}

--- a/scripts/list-tasks.sh
+++ b/scripts/list-tasks.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+set -e
+TMP="$(mktemp -d)"
+DIR="$(dirname $0)"
+NAME="$(basename $0 .sh)"
+trap "rm -rf '$TMP'" EXIT
+go build -C "$DIR/$NAME" -o "$TMP/$NAME" .
+"$TMP/$NAME" $@

--- a/scripts/list-tasks/main.go
+++ b/scripts/list-tasks/main.go
@@ -1,0 +1,157 @@
+// The list-tasks script enumerates all tasks using any variant of a particular
+// connector, and add them to the active flowctl draft.
+//
+// It consults 'https://raw.githubusercontent.com/estuary/connectors/refs/heads/main/<connector>/VARIANTS'
+// to get an updated list of all variant names of a particular connector, and then lists all matching
+// tasks using a 'flowctl raw get' query like:
+//
+//	flowctl raw get --table live_specs --query select=catalog_name,connector_image_name \
+//	  --query 'spec_type=eq.capture' \
+//	  --query 'connector_image_name=in.("ghcr.io/estuary/source-mysql")' \
+//	  --query 'catalog_name=like.acmeCo/*'
+//
+// This is primarily meant for bulk editing workflows, which are described in more detail in
+// 'docs/feature_flags.md'.
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+
+	log "github.com/sirupsen/logrus"
+)
+
+var scriptDescription = `
+The list-tasks script enumerates all tasks using any variant of a
+particular connector, and optionally add them to the active flowctl
+draft.
+
+Refer to 'docs/feature_flags.md' for more information on the intended
+use-case and workflow.
+`
+
+var (
+	logLevel = flag.String("log_level", "info", "The log level to print at.")
+
+	taskType   = flag.String("type", "capture", "The type of catalog spec to list (typically 'capture' or 'materialization').")
+	imageName  = flag.String("connector", "", "The connector image name to filter on. Can be a full URL like 'ghcr.io/estuary/source-mysql' or a short name like 'source-mysql', and in the latter case the name will be expanded into a full URL including all variants. If unspecified the task list will not be filtered by connector.")
+	namePrefix = flag.String("prefix", "", "The task name prefix to filter on. If unspecified the task listing will not be filtered by name.")
+
+	addToDraft = flag.Bool("draft", false, "When true, all listed tasks will be added to the active flowctl draft")
+)
+
+func main() {
+	flag.Usage = func() {
+		fmt.Fprintf(flag.CommandLine.Output(), "%s\n", scriptDescription)
+		fmt.Fprintf(flag.CommandLine.Output(), "usage of %s:\n", os.Args[0])
+		flag.PrintDefaults()
+	}
+	flag.Parse()
+	if lvl, err := log.ParseLevel(*logLevel); err != nil {
+		log.WithFields(log.Fields{"level": *logLevel, "err": err}).Fatal("invalid log level")
+	} else {
+		log.SetLevel(lvl)
+	}
+
+	var ctx = context.Background()
+
+	var imageNames []string
+	if strings.Contains(*imageName, "/") {
+		imageNames = append(imageNames, *imageName)
+	} else if variants, err := listVariants(*imageName); err != nil {
+		log.Fatalf("error listing variants of connector %q: %v", *imageName, err)
+	} else {
+		imageNames = variants
+	}
+
+	var tasks, err = listTasks(ctx, *taskType, imageNames, *namePrefix)
+	if err != nil {
+		log.Fatalf("error listing tasks: %v", err)
+	}
+	sort.Slice(tasks, func(i, j int) bool { return strings.Compare(tasks[i].CatalogName, tasks[j].CatalogName) < 0 })
+	for _, task := range tasks {
+		if *addToDraft {
+			if err := addTaskToDraft(ctx, task.CatalogName); err != nil {
+				log.Fatalf("error adding task %q to flowctl draft: %v", task.CatalogName, err)
+			}
+			fmt.Printf("added %q to draft\n", task.CatalogName)
+		} else {
+			fmt.Println(task.CatalogName)
+		}
+	}
+}
+
+type taskSpec struct {
+	CatalogName    string          `json:"catalog_name"`
+	ConnectorImage string          `json:"connector_image_name"`
+	Spec           json.RawMessage `json:"spec"`
+}
+
+func listTasks(ctx context.Context, taskType string, imageNames []string, namePrefix string) ([]*taskSpec, error) {
+	var command = []string{"flowctl", "raw", "get", "--table=live_specs", "--query", "select=catalog_name,connector_image_name"}
+
+	if taskType != "" {
+		command = append(command, "--query", fmt.Sprintf("spec_type=eq.%s", taskType))
+	}
+	if *imageName != "" {
+		command = append(command, "--query", fmt.Sprintf("connector_image_name=in.(%s)", strings.Join(imageNames, ",")))
+	}
+	if namePrefix != "" {
+		command = append(command, "--query", fmt.Sprintf("catalog_name=like.%s*", namePrefix))
+	}
+
+	log.WithField("command", command).Info("executing task listing command")
+	var bs, err = exec.CommandContext(ctx, command[0], command[1:]...).Output()
+	if err != nil {
+		return nil, fmt.Errorf("error querying live specs: %w", err)
+	}
+	var tasks []*taskSpec
+	var failureInfo struct {
+		Code    string `json:"code"`
+		Message string `json:"message"`
+	}
+	if err := json.Unmarshal(bs, &tasks); err == nil {
+		return tasks, nil
+	} else if json.Unmarshal(bs, &failureInfo) == nil && failureInfo.Message != "" {
+		return nil, fmt.Errorf("error querying live specs: %s", failureInfo.Message)
+	} else {
+		return nil, fmt.Errorf("error parsing live specs query results: %w", err)
+	}
+}
+
+func listVariants(connectorName string) ([]string, error) {
+	var variantsURL = fmt.Sprintf("https://raw.githubusercontent.com/estuary/connectors/refs/heads/main/%s/VARIANTS", connectorName)
+
+	resp, err := http.Get(variantsURL)
+	if err != nil {
+		return nil, fmt.Errorf("error fetching variants list: %w", err)
+	}
+	defer resp.Body.Close()
+
+	bs, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("error fetching variants list: %w", err)
+	}
+
+	var variants []string
+	variants = append(variants, fmt.Sprintf("ghcr.io/estuary/%s", connectorName))
+	for _, v := range strings.Split(string(bs), "\n") {
+		variants = append(variants, fmt.Sprintf("ghcr.io/estuary/%s", v))
+	}
+	return variants, nil
+}
+
+func addTaskToDraft(ctx context.Context, taskName string) error {
+	var command = []string{"flowctl", "catalog", "draft", "--name", taskName}
+	log.WithField("command", command).Debug("executing flowctl command")
+	var _, err = exec.CommandContext(ctx, command[0], command[1:]...).Output()
+	return err
+}

--- a/scripts/list-tasks/main.go
+++ b/scripts/list-tasks/main.go
@@ -66,6 +66,10 @@ func main() {
 	} else {
 		log.SetLevel(lvl)
 	}
+	log.SetFormatter(&log.TextFormatter{
+		FullTimestamp: true,
+		PadLevelText:  true,
+	})
 
 	if err := performListing(context.Background()); err != nil {
 		log.WithField("err", err).Fatal("error listing tasks")

--- a/scripts/list-tasks/main.go
+++ b/scripts/list-tasks/main.go
@@ -41,7 +41,7 @@ use-case and workflow.
 var (
 	logLevel = flag.String("log_level", "info", "The log level to print at.")
 
-	taskType   = flag.String("type", "capture", "The type of catalog spec to list (typically 'capture' or 'materialization').")
+	taskType   = flag.String("type", "", "The type of catalog spec to list (typically 'capture' or 'materialization'). If unspecified the task listing will not be filtered by type.")
 	imageName  = flag.String("connector", "", "The connector image name to filter on. Can be a full URL like 'ghcr.io/estuary/source-mysql' or a short name like 'source-mysql', and in the latter case the name will be expanded into a full URL including all variants. If unspecified the task list will not be filtered by connector.")
 	namePrefix = flag.String("prefix", "", "The task name prefix to filter on. If unspecified the task listing will not be filtered by name.")
 


### PR DESCRIPTION
**Description:**

This PR adds the following:
* Documentation in `docs/feature_flags.md` which describes the intended purpose of connector feature flags, how to introduce a new feature flag when changing the default behavior of a connector, and how to set a flag on all production tasks.
* A tool `scripts/list-tasks.sh` which can query the Supabase `live_specs` table to list all tasks running (any variant of) a particular connector and, optionally, add them all to the active `flowctl` draft.
* Another tool `scripts/bulk-config-editor.sh` which can edit all endpoint config YAML files under a particular directory to add a feature flag setting. It handles encrypted-vs-plaintext configs, extends or introduces the `/advanced/feature_flags` property as needed, and skips configs which already have a setting for the same "base name" of the flag (the `foobar` vs `no_foobar` distinction).

After thinking about the problem for a while, those two scripts are what I settled on as the cleanest way to break down the process. I was originally going to have a more monolithic tool, but it started feeling like I was writing a bunch of wrappers around `flowctl` commands and just exposing the underlying "create and modify a flowctl draft" process would be both cleaner and more trustworthy (since the new tools are just manipulating the draft and specs, the results can be cross-checked or refined in any way one desires before publishing).

This partially addresses https://github.com/estuary/connectors/issues/1994, now I just need to make some connector default behavior changes using the tool to close it out.

**Workflow steps:**

As described in the new docs, the overall process of bulk setting a feature flag looks like:

```bash
$ mkdir -p draft && cd draft && echo '*' > .gitignore          # Create a directory somewhere to hold the Flow specs being edited
$ flowctl draft create                                         # Create a new draft
$ ../scripts/list-tasks.sh --connector=source-mysql --draft    # Add all source-mysql (and variants) captures to the current draft
$ flowctl draft develop                                        # Pull down draft specs into a local directory
$ ../scripts/bulk-config-editor.sh --set_flag=do_some_thing    # Add the 'do_some_thing' feature flag to the local endpoint configs, with interactive diffs and prompting
$ flowctl draft author --source flow.yaml                      # Upload modified specs to the draft
$ flowctl draft publish                                        # Publish the uploaded specs
```

**Notes for reviewers:**

The scripts are written in Go, but I've added little shell helper scripts for running them because those can be symlinked into a local binaries directory (or the whole `scripts/` directory added into one's `$PATH`).

It's tempting to try and refine the scripts further, but I think that in their current form they'll work just fine for the initial rounds of feature-flag assisted behavior changes, so spending more time on them right now risks going into speculative over-engineering territory and I'd rather get them out for review in case there are real issues I've overlooked.

I was originally thinking of adding these in the `scripts` directory of the `flow` repository, but then I got to thinking about adding some connector documentation about feature flags as well and the fact that these tools are straddling the line between "flowctl helper" and "operational thing for connectors" and decided to put them here instead.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2353)
<!-- Reviewable:end -->
