### PR TITLE
materialize-snowflake: set the file format to allow duplicate keys

### DIFF
--- a/materialize-snowflake/sqlgen.go
+++ b/materialize-snowflake/sqlgen.go
@@ -338,6 +338,7 @@ CREATE STAGE IF NOT EXISTS flow_v1
 FILE_FORMAT = (
   TYPE = JSON
   BINARY_FORMAT = BASE64
+  ALLOW_DUPLICATE = TRUE
 )
 COMMENT = 'Internal stage used by Estuary Flow to stage loaded & stored documents'
 ;`


### PR DESCRIPTION
**Description:**

All of our upstream processing allows JSON objects with duplicate keys to exist, so it is possible for an object like this to end up in Snowflake's JSON parsing.

Unfortunately the default Snowflake parsing behavior is to error out if there is a duplicate key, but this configuration will instead cause it to follow the convention of just taking the last value for the duplicated key.

It's set on the created stage for simplicity. This means it won't retroactively apply to all existing stages, but this is a very rare thing so I think it's fine to handle on a go-forward basis. If it happens (again) with any existing materialization, the resolution is to run the query `ALTER STAGE flow_v1 SET FILE_FORMAT = (TYPE = JSON BINARY_FORMAT = BASE64 ALLOW_DUPLICATE = TRUE);`. If this turns out to be common thing to do (unlikely, I think), we can add some logic to the connector to respond to certain errors by running that command.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2357)
<!-- Reviewable:end -->
