### PR TITLE
materialize-boilerplate: staged files doesn't try to clean up bindings that haven't started

### DIFF
--- a/materialize-boilerplate/staged_files.go
+++ b/materialize-boilerplate/staged_files.go
@@ -115,6 +115,10 @@ func (sf *StagedFiles[T]) CleanupCurrentTransaction(ctx context.Context) error {
 
 		var uris []string
 		for _, f := range sf.stagedFiles {
+			if !f.started {
+				continue
+			}
+
 			for _, u := range f.uploaded {
 				uris = append(uris, sf.client.URI(u))
 			}


### PR DESCRIPTION
**Description:**

There was a bug where if a binding had data in one transaction but not the next, calls to `CleanupCurrentTransaction` would try to delete files from the prior transaction where it had data even during the current transaction, since it is the call to `EncodeRow` that clears out the list of files for the binding.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

