### PR TITLE
materialize-snowflake: use range hints for load queries

### DIFF
--- a/materialize-snowflake/.snapshots/TestSQLGeneration
+++ b/materialize-snowflake/.snapshots/TestSQLGeneration
@@ -92,6 +92,18 @@ ALTER TABLE "a-schema".key_value ALTER COLUMN
 	second_required_column DROP NOT NULL;
 --- End alter table drop not nulls ---
 
+--- Begin "a-schema".key_value loadQuery ---
+SELECT 0, "a-schema".key_value.flow_document
+	FROM "a-schema".key_value
+	JOIN (
+		SELECT $1[0] AS key1, $1[1] AS key2, $1[2] AS "key!binary"
+		FROM test-file
+	) AS r
+	ON "a-schema".key_value.key1 = r.key1 AND "a-schema".key_value.key1 >= 10 AND "a-schema".key_value.key1 <= 100
+	AND "a-schema".key_value.key2 = r.key2
+	AND "a-schema".key_value."key!binary" = r."key!binary" AND "a-schema".key_value."key!binary" >= 'aGVsbG8K' AND "a-schema".key_value."key!binary" <= 'Z29vZGJ5ZQo='
+--- End "a-schema".key_value loadQuery ---
+
 --- Begin "a-schema".key_value mergeInto ---
 MERGE INTO "a-schema".key_value AS l
 USING (
@@ -110,16 +122,6 @@ WHEN NOT MATCHED and r.flow_document!='delete' THEN
 	INSERT (key1, key2, "key!binary", array, binary, boolean, flow_published_at, integer, integerGt64Bit, integerWithUserDDL, multiple, number, numberCastToString, object, string, stringInteger, stringInteger39Chars, stringInteger66Chars, stringNumber, flow_document)
 	VALUES (r.key1, r.key2, r."key!binary", r.array, r.binary, r.boolean, r.flow_published_at, r.integer, r.integerGt64Bit, r.integerWithUserDDL, r.multiple, r.number, r.numberCastToString, r.object, r.string, r.stringInteger, r.stringInteger39Chars, r.stringInteger66Chars, r.stringNumber, r.flow_document);
 --- End "a-schema".key_value mergeInto ---
-
---- Begin "a-schema".key_value loadQuery ---
-SELECT 0, "a-schema".key_value.flow_document
-	FROM "a-schema".key_value
-	JOIN (
-		SELECT $1[0] AS key1, $1[1] AS key2, $1[2] AS "key!binary"
-		FROM test-file
-	) AS r
-	ON "a-schema".key_value.key1 = r.key1 AND "a-schema".key_value.key2 = r.key2 AND "a-schema".key_value."key!binary" = r."key!binary"
---- End "a-schema".key_value loadQuery ---
 
 --- Begin "a-schema".key_value copyInto ---
 COPY INTO "a-schema".key_value (

--- a/materialize-snowflake/sqlgen_test.go
+++ b/materialize-snowflake/sqlgen_test.go
@@ -34,8 +34,10 @@ func TestSQLGeneration(t *testing.T) {
 		},
 	)
 
-	{
-		tpl := templates.mergeInto
+	for _, tpl := range []*template.Template{
+		templates.loadQuery,
+		templates.mergeInto,
+	} {
 		tbl := tables[0]
 		require.False(t, tbl.DeltaUpdates)
 		var testcase = tbl.Identifier + " " + tpl.Name()
@@ -58,7 +60,7 @@ func TestSQLGeneration(t *testing.T) {
 			},
 		}
 
-		tf := mergeQueryInput{
+		tf := boundedQueryInput{
 			Table:  tbl,
 			File:   "test-file",
 			Bounds: bounds,
@@ -70,7 +72,6 @@ func TestSQLGeneration(t *testing.T) {
 	}
 
 	for _, tpl := range []*template.Template{
-		templates.loadQuery,
 		templates.copyInto,
 	} {
 		tbl := tables[0]


### PR DESCRIPTION
**Description:**

Bound load queries by the minimum & maximum values for observed keys to load. This may help reduce costs associated with scanning data which we know does not contain values we are interested in.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

See also https://github.com/estuary/connectors/pull/2348, which implemented this in a very similar way for `materialize-bigquery`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2370)
<!-- Reviewable:end -->
