### PR TITLE
source-oracle: fix wrong default value for watermarks table

### DIFF
--- a/source-oracle/main.go
+++ b/source-oracle/main.go
@@ -116,7 +116,7 @@ type Config struct {
 
 type advancedConfig struct {
 	SkipBackfills        string   `json:"skip_backfills,omitempty" jsonschema:"title=Skip Backfills,description=A comma-separated list of fully-qualified table names which should not be backfilled."`
-	WatermarksTable      string   `json:"watermarksTable,omitempty" jsonschema:"default=USER.FLOW_WATERMARKS,description=The name of the table used for watermark writes during backfills. Must be fully-qualified in '<schema>.<table>' form."`
+	WatermarksTable      string   `json:"watermarksTable,omitempty" jsonschema:"description=The name of the table used for watermark writes during backfills. Must be fully-qualified in '<schema>.<table>' form."`
 	BackfillChunkSize    int      `json:"backfill_chunk_size,omitempty" jsonschema:"title=Backfill Chunk Size,default=50000,description=The number of rows which should be fetched from the database in a single backfill query."`
 	IncrementalChunkSize int      `json:"incremental_chunk_size,omitempty" jsonschema:"title=Incremental Chunk Size,default=10000,description=The number of rows which should be fetched from the database in a single incremental query."`
 	IncrementalSCNRange  int      `json:"incremental_scn_range,omitempty" jsonschema:"title=Incremental SCN Range,default=50000,description=The SCN range captured at every iteration."`


### PR DESCRIPTION
**Description:**

- The default value meant that if somebody clicked on Advanced and set something else, their watermarks table would be set to the literal `USER.FLOW_WATERMARKS` which would be wrong in most cases

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2371)
<!-- Reviewable:end -->
