### PR TITLE
source-mysql: Feature-flagged date fix

### DIFF
--- a/source-mysql/.snapshots/TestGeneric-SpecResponse
+++ b/source-mysql/.snapshots/TestGeneric-SpecResponse
@@ -74,6 +74,11 @@
             "title": "Discovery Schema Selection",
             "description": "If this is specified only tables in the selected schema(s) will be automatically discovered. Omit all entries to discover tables from all schemas."
           },
+          "feature_flags": {
+            "type": "string",
+            "title": "Feature Flags",
+            "description": "This property is intended for Estuary internal use. You should only modify this field as directed by Estuary support."
+          },
           "watermarks_table": {
             "type": "string",
             "title": "Watermarks Table Name",

--- a/source-mysql/main.go
+++ b/source-mysql/main.go
@@ -29,7 +29,11 @@ import (
 	_ "time/tzdata"
 )
 
-var featureFlagDefaults = map[string]bool{}
+var featureFlagDefaults = map[string]bool{
+	// When true, date columns will be discovered as `type: string, format: date`
+	// instead of simply `type: string`
+	"date_schema_format": false,
+}
 
 type sshForwarding struct {
 	SSHEndpoint string `json:"sshEndpoint" jsonschema:"title=SSH Endpoint,description=Endpoint of the remote SSH server that supports tunneling (in the form of ssh://user@hostname[:port])" jsonschema_extras:"pattern=^ssh://.+@.+$"`

--- a/source-mysql/main_test.go
+++ b/source-mysql/main_test.go
@@ -35,6 +35,8 @@ var (
 
 	useMyISAM                = flag.Bool("use_myisam_engine", false, "When set, all test tables will be created using the MyISAM storage engine")
 	skipBinlogRetentionCheck = flag.Bool("skip_binlog_retention_check", false, "When set, skips the binlog retention sanity check")
+
+	testFeatureFlags = flag.String("feature_flags", "", "Feature flags to apply to all test captures.")
 )
 
 const testSchemaName = "test"
@@ -90,6 +92,7 @@ func mysqlTestBackend(t testing.TB) *testBackend {
 			SkipBinlogRetentionCheck: *skipBinlogRetentionCheck,
 		},
 	}
+	captureConfig.Advanced.FeatureFlags = *testFeatureFlags
 	captureConfig.Advanced.BackfillChunkSize = 16
 	if err := captureConfig.Validate(); err != nil {
 		t.Fatalf("error validating capture config: %v", err)


### PR DESCRIPTION
**Description:**

Adds feature flag `date_schema_format` which when set will cause date columns to have `format: date` in their discovery output.

**Workflow steps:**

If absolutely necessary you could add that manually to a task's advanced config, but if you can wait a bit I'm going to change the default in the near future and then no action will be required for new tasks and preexisting tasks will be able to opt in by removing the `no_date_schema_format` flag setting.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2374)
<!-- Reviewable:end -->
