### PR TITLE
source-klaviyo: upgrade API version for `campaigns` and `profiles` to 2023-10-15

### DIFF
--- a/source-klaviyo/source_klaviyo/streams.py
+++ b/source-klaviyo/source_klaviyo/streams.py
@@ -279,7 +279,6 @@ class Profiles(IncrementalKlaviyoStream):
 
     cursor_field = "updated"
     comparison_operator = 'greater-than'
-    api_revision = "2023-02-22"
     page_size = 100
     state_checkpoint_interval = 100  # API can return maximum 100 records per page
 
@@ -293,7 +292,7 @@ class Profiles(IncrementalKlaviyoStream):
         next_page_token: Optional[Mapping[str, Any]] = None,
     ) -> MutableMapping[str, Any]:
         params = super().request_params(stream_state=stream_state, stream_slice=stream_slice, next_page_token=next_page_token)
-        params.update({"additional-fields[profile]": "predictive_analytics"})
+        params.update({"additional-fields[profile]": "predictive_analytics,subscriptions"})
         return params
 
 

--- a/source-klaviyo/source_klaviyo/streams.py
+++ b/source-klaviyo/source_klaviyo/streams.py
@@ -147,6 +147,8 @@ class IncrementalKlaviyoStream(KlaviyoStream, ABC):
     # and others only support "greater-than". comparison_operator must be specified for each incremental stream.
     comparison_operator: str = "greater-or-equal"
 
+    additional_filter_condition: str | None = None
+
     def request_params(
         self,
         stream_state: Optional[Mapping[str, Any]],
@@ -177,6 +179,15 @@ class IncrementalKlaviyoStream(KlaviyoStream, ABC):
                 latest_cursor = min(latest_cursor, pendulum.now().subtract(seconds=3))
                 params["filter"] = f"{self.comparison_operator}({self.cursor_field},{latest_cursor.isoformat()})"
             params["sort"] = self.cursor_field
+
+        filter_param = params.get("filter", None)
+
+        if self.additional_filter_condition:
+            if filter_param and self.additional_filter_condition not in filter_param:
+                params["filter"] += f",{self.additional_filter_condition}"
+            elif not filter_param:
+                params["filter"] = f"{self.additional_filter_condition}"
+
         return params
 
 
@@ -209,12 +220,14 @@ class SemiIncrementalKlaviyoStream(KlaviyoStream, ABC):
 
 
 class ArchivedRecordsStream(IncrementalKlaviyoStream):
-    def __init__(self, path: str, cursor_field: str, start_date: Optional[str] = None, api_revision: Optional[str] = None, **kwargs):
+    def __init__(self, path: str, cursor_field: str, start_date: Optional[str] = None, api_revision: Optional[str] = None, additional_filter_condition: Optional[str] = None, **kwargs):
         super().__init__(start_date=start_date, **kwargs)
         self._path = path
         self._cursor_field = cursor_field
         if api_revision:
             self.api_revision = api_revision
+        if additional_filter_condition:
+            self.additional_filter_condition = additional_filter_condition
 
     @property
     def cursor_field(self) -> Union[str, List[str]]:
@@ -244,7 +257,7 @@ class ArchivedRecordsMixin(IncrementalKlaviyoStream, ABC):
 
     @property
     def archived_campaigns(self) -> ArchivedRecordsStream:
-        return ArchivedRecordsStream(self.path(), self.cursor_field, self._start_ts, self.api_revision, api_key=self._api_key)
+        return ArchivedRecordsStream(self.path(), self.cursor_field, self._start_ts, self.api_revision, api_key=self._api_key, additional_filter_condition=self.additional_filter_condition)
 
     def get_updated_state(self, current_stream_state: MutableMapping[str, Any], latest_record: Mapping[str, Any]) -> Mapping[str, Any]:
         """
@@ -300,7 +313,7 @@ class Campaigns(ArchivedRecordsMixin, IncrementalKlaviyoStream):
     """Docs: https://developers.klaviyo.com/en/v2023-06-15/reference/get_campaigns"""
 
     cursor_field = "updated_at"
-    api_revision = "2023-06-15"
+    additional_filter_condition = "equals(messages.channel,'email')"
 
     def path(self, **kwargs) -> str:
         return "campaigns"

--- a/source-klaviyo/tests/test_streams.py
+++ b/source-klaviyo/tests/test_streams.py
@@ -2,6 +2,7 @@
 # Copyright (c) 2023 Airbyte, Inc., all rights reserved.
 #
 from typing import Optional
+from urllib import parse
 from unittest import mock
 
 import pendulum
@@ -429,11 +430,15 @@ class TestCampaignsStream:
 
         stream = Campaigns(api_key=API_KEY)
         requests_mock.register_uri(
-            "GET", "https://a.klaviyo.com/api/campaigns?sort=updated_at", status_code=200, json={"data": input_records}, complete_qs=True
+            "GET",
+            "https://a.klaviyo.com/api/campaigns?" + parse.urlencode({"filter": "equals(messages.channel,'email')", "sort": "updated_at"}),
+            status_code=200,
+            json={"data": input_records},
+            complete_qs=True,
         )
         requests_mock.register_uri(
             "GET",
-            "https://a.klaviyo.com/api/campaigns?sort=updated_at&filter=equals(archived,true)",
+            "https://a.klaviyo.com/api/campaigns?" + parse.urlencode({"filter": "and(equals(messages.channel,'email'),equals(archived,true))", "sort": "updated_at"}),
             status_code=200,
             json={"data": input_records_archived},
             complete_qs=True,

--- a/source-klaviyo/tests/test_streams.py
+++ b/source-klaviyo/tests/test_streams.py
@@ -311,15 +311,15 @@ class TestProfilesStream:
             (
                 {"page[cursor]": "aaA0aAo0aAA0A"},
                 None,
-                {"page[cursor]": "aaA0aAo0aAA0A", "additional-fields[profile]": "predictive_analytics", "sort": "updated"},
+                {"page[cursor]": "aaA0aAo0aAA0A", "additional-fields[profile]": "predictive_analytics,subscriptions", "sort": "updated"},
             ),
             (
                 {"page[cursor]": "aaA0aAo0aAA0A"},
                 100,
-                {"page[cursor]": "aaA0aAo0aAA0A", "additional-fields[profile]": "predictive_analytics", "sort": "updated"},
+                {"page[cursor]": "aaA0aAo0aAA0A", "additional-fields[profile]": "predictive_analytics,subscriptions", "sort": "updated"},
             ),
-            (None, None, {"additional-fields[profile]": "predictive_analytics", "sort": "updated"}),
-            (None, 100, {"page[size]": 100, "additional-fields[profile]": "predictive_analytics", "sort": "updated"}),
+            (None, None, {"additional-fields[profile]": "predictive_analytics,subscriptions", "sort": "updated"}),
+            (None, 100, {"page[size]": 100, "additional-fields[profile]": "predictive_analytics,subscriptions", "sort": "updated"}),
         ),
     )
     def test_request_params(self, next_page_token: Optional[dict], page_size: Optional[int], expected_params: dict):


### PR DESCRIPTION
**Description:**

While most streams are using version 2023-10-15 of Klaviyo's API, `campaigns` and `profiles` are on earlier versions. This PR updates both streams to use API version 2023-10-15.

Changes from the updates are mainly to the location of certain properties in each stream's documents.

### `campaigns`
The `attributes.message` property is now under the `relationships.campaign-messages.data[0].id` location.

### `profiles`
The `attributes.subscriptions.email.marketing.suppressions` field is renamed to `attributes.subscriptions.email.marketing.suppression` (i.e. from plural to singular).


A note about `campaigns`. In API versions including 2023-10-15 and later, Klaviyo now has different types of campaigns. Previously, only email campaigns were returned from the `/campaigns` endpoint, but in version 2023-10-15 SMS campaigns can also be fetched at that endpoint. However, only a single type of campaign can be fetched in a single request-response cycle because Klaviyo only accepts a single campaign type in the request's query params. While it's possible to rewrite the `campaigns` stream to fetch these additional campaign types by using stream slices & updated state management techniques, doing so is a relatively large effort. Since our currently enabled captures have email campaigns & no SMS campaigns,
I'm punting on adding the functionality to fetch multiple types of campaigns in the `campaigns` stream to a later date.


Closes #2367.


**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

Tested on a local stack. Confirmed `campaigns` and `profiles` streams fetch records and complete. Confirmed the other incremental stream `events` is not affected by the updates to the `IncrementalKlaviyoStream` class.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2378)
<!-- Reviewable:end -->
