### PR TITLE
estuary-cdk: additional SIGQUIT logging & patching `requests.Session.send` for Airbyte imports

### DIFF
--- a/estuary-cdk/estuary_cdk/__init__.py
+++ b/estuary-cdk/estuary_cdk/__init__.py
@@ -95,6 +95,11 @@ class BaseConnector(Generic[Request], abc.ABC):
                 if task is this_task:
                     continue
 
+                log.info("Attempting to inject SIGQUIT exception into task.", {
+                    "task.get_name()": task.get_name(),
+                    "task.get_coro().__name__": task.get_coro().__name__,
+                })
+
                 # Reach inside the task coroutine to inject an exception, which
                 # will unwind the task stack and lets us print a precise stack trace.
                 try:

--- a/estuary-cdk/estuary_cdk/requests_session_send_patch.py
+++ b/estuary-cdk/estuary_cdk/requests_session_send_patch.py
@@ -1,0 +1,15 @@
+import requests
+
+# Airbyte's CDK does not set a timeout for HTTP requests, so we patch it to always have a timeout.
+
+DEFAULT_TIMEOUT = 60 * 60 * 6 # 6 hours
+
+lib_send = requests.Session.send
+
+def send(*args, **kwargs):
+    if kwargs.get("timeout", None) is None:
+        kwargs["timeout"] = DEFAULT_TIMEOUT
+
+    return lib_send(*args, **kwargs)
+
+setattr(requests.Session, "send", send)

--- a/estuary-cdk/estuary_cdk/shim_airbyte_cdk.py
+++ b/estuary-cdk/estuary_cdk/shim_airbyte_cdk.py
@@ -352,7 +352,7 @@ class CaptureShim(BaseCaptureConnector):
             await asyncio.sleep(0)
 
             if task.stopping.event.is_set():
-                task.log.debug(f"Airbyte shim is yielding to stop.")
+                task.log.info(f"Airbyte shim is yielding to stop.")
                 return
 
             if record := message.record:
@@ -449,5 +449,6 @@ class CaptureShim(BaseCaptureConnector):
                 raise RuntimeError("unexpected AirbyteMessage", message)
 
         # Emit a final checkpoint before exiting.
+        task.log.info("Emitting final checkpoint for sweep.")
         task.checkpoint(connector_state, merge_patch=False)
         return None

--- a/source-airtable/source_airtable/__main__.py
+++ b/source-airtable/source_airtable/__main__.py
@@ -1,4 +1,5 @@
 import estuary_cdk.pydantic_polyfill  # Must be first.
+import estuary_cdk.requests_session_send_patch # Must be second.
 
 import asyncio
 from estuary_cdk import shim_airbyte_cdk, flow

--- a/source-asana/source_asana/__main__.py
+++ b/source-asana/source_asana/__main__.py
@@ -1,4 +1,5 @@
 import estuary_cdk.pydantic_polyfill  # Must be first.
+import estuary_cdk.requests_session_send_patch # Must be second.
 
 import asyncio
 from estuary_cdk import shim_airbyte_cdk, flow

--- a/source-brevo/source_brevo/__main__.py
+++ b/source-brevo/source_brevo/__main__.py
@@ -1,4 +1,5 @@
 import estuary_cdk.pydantic_polyfill # Must be first.
+import estuary_cdk.requests_session_send_patch # Must be second.
 
 import asyncio
 

--- a/source-facebook-marketing/source_facebook_marketing/__main__.py
+++ b/source-facebook-marketing/source_facebook_marketing/__main__.py
@@ -1,4 +1,5 @@
 import estuary_cdk.pydantic_polyfill  # Must be first.
+import estuary_cdk.requests_session_send_patch # Must be second.
 
 import asyncio
 from estuary_cdk import shim_airbyte_cdk, flow

--- a/source-google-ads/source_google_ads/__main__.py
+++ b/source-google-ads/source_google_ads/__main__.py
@@ -1,4 +1,5 @@
 import estuary_cdk.pydantic_polyfill  # Must be first.
+import estuary_cdk.requests_session_send_patch # Must be second.
 
 import asyncio
 from estuary_cdk import shim_airbyte_cdk, flow

--- a/source-hubspot/source_hubspot/__main__.py
+++ b/source-hubspot/source_hubspot/__main__.py
@@ -1,4 +1,5 @@
 import estuary_cdk.pydantic_polyfill  # Must be first.
+import estuary_cdk.requests_session_send_patch # Must be second.
 
 import asyncio
 import urllib

--- a/source-iterable/source_iterable/__main__.py
+++ b/source-iterable/source_iterable/__main__.py
@@ -1,4 +1,5 @@
 import estuary_cdk.pydantic_polyfill  # Must be first.
+import estuary_cdk.requests_session_send_patch # Must be second.
 
 import asyncio
 import urllib

--- a/source-jira-native/source_jira_native/__main__.py
+++ b/source-jira-native/source_jira_native/__main__.py
@@ -1,4 +1,5 @@
 import estuary_cdk.pydantic_polyfill  # Must be first.
+import estuary_cdk.requests_session_send_patch # Must be second.
 
 import asyncio
 import urllib

--- a/source-klaviyo/source_klaviyo/__main__.py
+++ b/source-klaviyo/source_klaviyo/__main__.py
@@ -1,4 +1,5 @@
 import estuary_cdk.pydantic_polyfill  # Must be first.
+import estuary_cdk.requests_session_send_patch # Must be second.
 
 import asyncio
 import urllib

--- a/source-linkedin-ads-v2/source_linkedin_ads_v2/__main__.py
+++ b/source-linkedin-ads-v2/source_linkedin_ads_v2/__main__.py
@@ -1,4 +1,5 @@
 import estuary_cdk.pydantic_polyfill  # Must be first.
+import estuary_cdk.requests_session_send_patch # Must be second.
 
 import asyncio
 import urllib

--- a/source-linkedin-pages/source_linkedin_pages/__main__.py
+++ b/source-linkedin-pages/source_linkedin_pages/__main__.py
@@ -1,4 +1,5 @@
 import estuary_cdk.pydantic_polyfill  # Must be first. # noqa
+import estuary_cdk.requests_session_send_patch # Must be second.
 
 import asyncio
 from estuary_cdk import shim_airbyte_cdk, flow

--- a/source-mixpanel-native/source_mixpanel_native/__main__.py
+++ b/source-mixpanel-native/source_mixpanel_native/__main__.py
@@ -1,4 +1,5 @@
 import estuary_cdk.pydantic_polyfill  # Must be first.
+import estuary_cdk.requests_session_send_patch # Must be second.
 
 import asyncio
 import urllib

--- a/source-recharge/source_recharge/__main__.py
+++ b/source-recharge/source_recharge/__main__.py
@@ -1,4 +1,5 @@
 import estuary_cdk.pydantic_polyfill  # Must be first.
+import estuary_cdk.requests_session_send_patch # Must be second.
 
 import asyncio
 import urllib

--- a/source-twilio/source_twilio/__main__.py
+++ b/source-twilio/source_twilio/__main__.py
@@ -1,4 +1,5 @@
 import estuary_cdk.pydantic_polyfill  # Must be first.
+import estuary_cdk.requests_session_send_patch # Must be second.
 
 import asyncio
 import urllib

--- a/source-zendesk-support/source_zendesk_support/__main__.py
+++ b/source-zendesk-support/source_zendesk_support/__main__.py
@@ -1,4 +1,5 @@
 import estuary_cdk.pydantic_polyfill # Must be first.
+import estuary_cdk.requests_session_send_patch # Must be second.
 
 import asyncio
 import json


### PR DESCRIPTION
**Description:**

There have been tricky, intermittent cases of imported Airbyte connectors hanging with essentially no network traffic. I've added some additional logging when a `SIGQUIT` is injected & in the `CaptureShim`'s methods to help debug when these imports hang.

I also have a theory that since Airbyte imports use the `requests` package to make synchronous HTTP requests, the `requests` package doesn't have any default timeouts, and I can't find anywhere in the `airbyte_cdk` where a timeout is specified for `requests`, that setting a timeout for `requests` _might_ prevent Airbyte imports from hanging until the connector is restarted after 24 hours. I've made `requests_session_send_patch.py` to patch in a default timeout, and imported it in all Airbyte imports. I'm not certain the missing timeouts are the problem, but it's currently the best, actionable theory I have.

We've only observed `source-zendesk-support` and `source-jira-native` hanging like this so far, but I chose to patch `requests.Session.send` for all currently imported connectors to avoid playing whack-a-mole with imports that we haven't seen have this issue yet. If any imports still hang for `DEFAULT_TIMEOUT` seconds, then we'll know that the issue isn't due to a mising `requests` timeout.

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

Confirmed Airbyte imports can still make HTTP requests & receive responses. Confirmed that using `requests` to send an HTTP request to a server that accepts the request but doesn't send data back will timeout after `DEFAULT_TIMEOUT` seconds.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2380)
<!-- Reviewable:end -->
