### PR TITLE
source-postgres: Flagged DATE and TIME fixes

### DIFF
--- a/source-postgres/backfill.go
+++ b/source-postgres/backfill.go
@@ -130,7 +130,7 @@ func (db *postgresDatabase) ScanTableChunk(ctx context.Context, info *sqlcapture
 				return false, fmt.Errorf("error encoding row key for %q: %w", streamID, err)
 			}
 		}
-		if err := translateRecordFields(info, fields); err != nil {
+		if err := db.translateRecordFields(info, fields); err != nil {
 			return false, fmt.Errorf("error backfilling table %q: %w", table, err)
 		}
 

--- a/source-postgres/datatype_test.go
+++ b/source-postgres/datatype_test.go
@@ -56,6 +56,10 @@ func TestDatatypes(t *testing.T) {
 
 		// Date/Time/Timestamp Types
 		{ColumnType: `date`, ExpectType: `{"type":["string","null"],"format":"date-time"}`, InputValue: `'January 8, 1999'`, ExpectValue: `"1999-01-08T00:00:00Z"`},
+		{ColumnType: `date`, ExpectType: `{"type":["string","null"],"format":"date-time"}`, InputValue: `'January 8, 22021'`, ExpectValue: `"0000-01-01T00:00:00Z"`},
+		// Replacement tests for the previous two once "date_as_date" is the default
+		// {ColumnType: `date`, ExpectType: `{"type":["string","null"],"format":"date"}`, InputValue: `'January 8, 1999'`, ExpectValue: `"1999-01-08"`},
+		// {ColumnType: `date`, ExpectType: `{"type":["string","null"],"format":"date"}`, InputValue: `'January 8, 22021'`, ExpectValue: `"0000-01-01"`},
 		{ColumnType: `timestamp`, ExpectType: `{"type":["string","null"],"format":"date-time"}`, InputValue: `'January 8, 1999'`, ExpectValue: `"1999-01-08T00:00:00Z"`},
 		{ColumnType: `timestamp without time zone`, ExpectType: `{"type":["string","null"],"format":"date-time"}`, InputValue: `'January 8, 1999'`, ExpectValue: `"1999-01-08T00:00:00Z"`},
 		{ColumnType: `timestamp`, ExpectType: `{"type":["string","null"],"format":"date-time"}`, InputValue: `'infinity'`, ExpectValue: `"9999-12-31T23:59:59Z"`},
@@ -64,9 +68,11 @@ func TestDatatypes(t *testing.T) {
 		{ColumnType: `timestamp`, ExpectType: `{"type":["string","null"],"format":"date-time"}`, InputValue: `'20222-08-31T00:00:00Z'`, ExpectValue: `"0000-01-01T00:00:00Z"`},
 		{ColumnType: `timestamp`, ExpectType: `{"type":["string","null"],"format":"date-time"}`, InputValue: `'January 8, 99 BC'`, ExpectValue: `"0000-01-01T00:00:00Z"`},
 		{ColumnType: `timestamp with time zone`, ExpectType: `{"type":["string","null"],"format":"date-time"}`, InputValue: `'January 8, 1999 UTC'`, ExpectValue: `"1999-01-07T16:00:00-08:00"`},
-		// For historical reasons, times without time zone are captured as Unix second timestamps. We can change this if we ever do a version bump or otherwise break compatibility.
 		{ColumnType: `time`, ExpectType: `{"type":["integer","null"]}`, InputValue: `'04:05:06 PST'`, ExpectValue: `14706000000`},
 		{ColumnType: `time without time zone`, ExpectType: `{"type":["integer","null"]}`, InputValue: `'04:05:06 PST'`, ExpectValue: `14706000000`},
+		// Replacement tests for the previous two once "time_as_time" is the default
+		// {ColumnType: `time`, ExpectType: `{"type":["string","null"],"format":"time"}`, InputValue: `'04:05:06 PST'`, ExpectValue: `"04:05:06Z"`},
+		// {ColumnType: `time without time zone`, ExpectType: `{"type":["string","null"],"format":"time"}`, InputValue: `'04:05:06 PST'`, ExpectValue: `"04:05:06Z"`},
 		{ColumnType: `time with time zone`, ExpectType: `{"type":["string","null"],"format":"time"}`, InputValue: `'04:05:06 PST'`, ExpectValue: `"04:05:06-08:00"`},
 		{ColumnType: `time with time zone`, ExpectType: `{"type":["string","null"],"format":"time"}`, InputValue: `'04:05:06 UTC'`, ExpectValue: `"04:05:06Z"`},
 		{ColumnType: `time with time zone`, ExpectType: `{"type":["string","null"],"format":"time"}`, InputValue: `'04:05:06.123 UTC'`, ExpectValue: `"04:05:06.123Z"`},

--- a/source-postgres/datatypes.go
+++ b/source-postgres/datatypes.go
@@ -201,7 +201,7 @@ func decodeRawJSONB(m *pgtype.Map, oid uint32, format int16, src []byte) (any, e
 	return json.RawMessage(src), nil
 }
 
-func translateRecordFields(table *sqlcapture.DiscoveryInfo, f map[string]interface{}) error {
+func (db *postgresDatabase) translateRecordFields(table *sqlcapture.DiscoveryInfo, f map[string]interface{}) error {
 	if f == nil {
 		return nil
 	}
@@ -215,7 +215,7 @@ func translateRecordFields(table *sqlcapture.DiscoveryInfo, f map[string]interfa
 			isPrimaryKey = slices.Contains(table.PrimaryKey, id)
 		}
 
-		var translated, err = translateRecordField(columnInfo, isPrimaryKey, val)
+		var translated, err = db.translateRecordField(columnInfo, isPrimaryKey, val)
 		if err != nil {
 			return fmt.Errorf("error translating field %q value %v: %w", id, val, err)
 		}
@@ -233,7 +233,7 @@ func oversizePlaceholderJSON(orig []byte) json.RawMessage {
 // PostgreSQL `cidr` type becomes a `*net.IPNet`, but the default JSON
 // marshalling of a `net.IPNet` isn't a great fit and we'd prefer to use
 // the `String()` method to get the usual "192.168.100.0/24" notation.
-func translateRecordField(column *sqlcapture.ColumnInfo, isPrimaryKey bool, val any) (any, error) {
+func (db *postgresDatabase) translateRecordField(column *sqlcapture.ColumnInfo, isPrimaryKey bool, val any) (any, error) {
 	var dataType any
 	if column != nil {
 		dataType = column.DataType
@@ -254,6 +254,29 @@ func translateRecordField(column *sqlcapture.ColumnInfo, isPrimaryKey bool, val 
 				}
 			}
 		}
+	case "time":
+		if t, ok := val.(pgtype.Time); ok {
+			if db.featureFlags["time_as_time"] {
+				return time.UnixMicro(t.Microseconds).UTC().Format(rfc3339TimeFormat), nil
+			} else {
+				return t.Microseconds, nil // Historical behavior
+			}
+		}
+		return nil, fmt.Errorf("unexpected value for column of type %q: %#v", dataType, val)
+	case "date":
+		if t, ok := val.(time.Time); ok {
+			if db.featureFlags["date_as_date"] {
+				if t.Year() < 0 || t.Year() > 9999 {
+					// A valid `format: date` satisfies the RFC3339 full-date production rule, which only
+					// permits a positive 4-digit year. Replace out-of-range dates with the zero date.
+					t = time.Date(0, 1, 1, 0, 0, 0, 0, time.UTC)
+				}
+				return t.Format("2006-01-02"), nil
+			} else {
+				return formatRFC3339(t) // Historical behavior
+			}
+		}
+		return nil, fmt.Errorf("unexpected value for column of type %q: %#v", dataType, val)
 	}
 	switch x := val.(type) {
 	case net.HardwareAddr: // column types 'macaddr' and 'macaddr8'
@@ -297,9 +320,9 @@ func translateRecordField(column *sqlcapture.ColumnInfo, isPrimaryKey bool, val 
 		}
 		return x, nil
 	case pgtype.Array[any]:
-		return translateArray(column, isPrimaryKey, x)
+		return db.translateArray(column, isPrimaryKey, x)
 	case pgtype.Range[any]:
-		return stringifyRange(x, isPrimaryKey)
+		return db.stringifyRange(x, isPrimaryKey)
 	case pgtype.Text:
 		if len(x.String) > truncateColumnThreshold {
 			return x.String[:truncateColumnThreshold], nil
@@ -319,8 +342,6 @@ func translateRecordField(column *sqlcapture.ColumnInfo, isPrimaryKey bool, val 
 		}
 	case time.Time:
 		return formatRFC3339(x)
-	case pgtype.Time:
-		return x.Microseconds, nil // For historical reasons, times (note: not timestamps) without time zone are serialized as Unix microseconds
 	case pgtype.Numeric:
 		return x.Value() // Happily the stringified representations of "NaN", "Infinity", and "-Infinity" exactly match what we need
 	case pgtype.Bits:
@@ -357,7 +378,7 @@ func stringifySpecialFloats(x float64) (string, bool) {
 	return "", false
 }
 
-func stringifyRange(r pgtype.Range[any], isPrimaryKey bool) (string, error) {
+func (db *postgresDatabase) stringifyRange(r pgtype.Range[any], isPrimaryKey bool) (string, error) {
 	if r.LowerType == pgtype.Empty || r.UpperType == pgtype.Empty {
 		return "empty", nil
 	}
@@ -370,7 +391,7 @@ func stringifyRange(r pgtype.Range[any], isPrimaryKey bool) (string, error) {
 		buf.WriteString("(")
 	}
 	if r.LowerType == pgtype.Inclusive || r.LowerType == pgtype.Exclusive {
-		if translated, err := translateRecordField(nil, isPrimaryKey, r.Lower); err != nil {
+		if translated, err := db.translateRecordField(nil, isPrimaryKey, r.Lower); err != nil {
 			fmt.Fprintf(buf, "%v", r.Lower)
 		} else {
 			fmt.Fprintf(buf, "%v", translated)
@@ -378,7 +399,7 @@ func stringifyRange(r pgtype.Range[any], isPrimaryKey bool) (string, error) {
 	}
 	buf.WriteString(",")
 	if r.UpperType == pgtype.Inclusive || r.UpperType == pgtype.Exclusive {
-		if translated, err := translateRecordField(nil, isPrimaryKey, r.Upper); err != nil {
+		if translated, err := db.translateRecordField(nil, isPrimaryKey, r.Upper); err != nil {
 			fmt.Fprintf(buf, "%v", r.Upper)
 		} else {
 			fmt.Fprintf(buf, "%v", translated)
@@ -403,13 +424,13 @@ func formatRFC3339(t time.Time) (any, error) {
 	return t.Format(time.RFC3339Nano), nil
 }
 
-func translateArray(_ *sqlcapture.ColumnInfo, isPrimaryKey bool, x pgtype.Array[any]) (any, error) {
+func (db *postgresDatabase) translateArray(_ *sqlcapture.ColumnInfo, isPrimaryKey bool, x pgtype.Array[any]) (any, error) {
 	var dims = make([]int, 0)
 	for _, dim := range x.Dims {
 		dims = append(dims, int(dim.Length))
 	}
 	for idx := range x.Elements {
-		var translated, err = translateRecordField(nil, isPrimaryKey, x.Elements[idx])
+		var translated, err = db.translateRecordField(nil, isPrimaryKey, x.Elements[idx])
 		if err != nil {
 			return nil, err
 		}

--- a/source-postgres/discovery.go
+++ b/source-postgres/discovery.go
@@ -206,6 +206,15 @@ func columnsNonNullable(columnsInfo map[string]sqlcapture.ColumnInfo, columnName
 
 // TranslateDBToJSONType returns JSON schema information about the provided database column type.
 func (db *postgresDatabase) TranslateDBToJSONType(column sqlcapture.ColumnInfo, isPrimaryKey bool) (*jsonschema.Schema, error) {
+	if !db.featureFlags["date_as_date"] {
+		// Historically DATE columns were captured as RFC3339 timestamps.
+		postgresTypeToJSON["date"] = columnSchema{jsonTypes: []string{"string"}, format: "date-time"}
+	}
+	if !db.featureFlags["time_as_time"] {
+		// Historically TIME columns were captured as Unix seconds.
+		postgresTypeToJSON["time"] = columnSchema{jsonTypes: []string{"integer"}}
+	}
+
 	var arrayColumn = false
 	var colSchema columnSchema
 
@@ -341,10 +350,10 @@ var postgresTypeToJSON = map[string]columnSchema{
 	"jsonpath": {jsonTypes: []string{"string"}},
 
 	// Domain-Specific Types
-	"date":        {jsonTypes: []string{"string"}, format: "date-time"},
+	"date":        {jsonTypes: []string{"string"}, format: "date"},
 	"timestamp":   {jsonTypes: []string{"string"}, format: "date-time"},
 	"timestamptz": {jsonTypes: []string{"string"}, format: "date-time"},
-	"time":        {jsonTypes: []string{"integer"}},
+	"time":        {jsonTypes: []string{"string"}, format: "time"},
 	"timetz":      {jsonTypes: []string{"string"}, format: "time"},
 	"interval":    {jsonTypes: []string{"string"}},
 	"money":       {jsonTypes: []string{"string"}},

--- a/source-postgres/main.go
+++ b/source-postgres/main.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/estuary/connectors/go/common"
 	cerrors "github.com/estuary/connectors/go/connector-errors"
 	networkTunnel "github.com/estuary/connectors/go/network-tunnel"
 	schemagen "github.com/estuary/connectors/go/schema-gen"
@@ -76,7 +77,7 @@ func connectPostgres(ctx context.Context, name string, cfg json.RawMessage) (sql
 		}
 	}
 
-	var featureFlags = boilerplate.ParseFeatureFlags(config.Advanced.FeatureFlags, featureFlagDefaults)
+	var featureFlags = common.ParseFeatureFlags(config.Advanced.FeatureFlags, featureFlagDefaults)
 	if config.Advanced.FeatureFlags != "" {
 		logrus.WithField("flags", featureFlags).Info("parsed feature flags")
 	}

--- a/source-postgres/main.go
+++ b/source-postgres/main.go
@@ -123,6 +123,15 @@ var featureFlagDefaults = map[string]bool{
 	// When set, discovered collection schemas will request that schema inference be
 	// used _in addition to_ the full column/types discovery we already do.
 	"use_schema_inference": false,
+
+	// When true, DATE columns are captured as YYYY-MM-DD dates. Historically these
+	// used to be captured as RFC3339 timestamps, which is usually not what users expect.
+	"date_as_date": false,
+
+	// When true, TIME WITHOUT TIME ZONE columns (also known as TIME) are captured as strings
+	// satisfying `format: time`. Historically these used to be captured as Unix microseconds,
+	// which is usually not what users expect.
+	"time_as_time": false,
 }
 
 // Validate checks that the configuration possesses all required properties.

--- a/source-postgres/replication.go
+++ b/source-postgres/replication.go
@@ -661,10 +661,10 @@ func (s *replicationStream) decodeChangeEvent(
 	if !ok {
 		return nil, fmt.Errorf("unknown discovery info for stream %q", streamID)
 	}
-	if err := translateRecordFields(discovery, bf); err != nil {
+	if err := s.db.translateRecordFields(discovery, bf); err != nil {
 		return nil, fmt.Errorf("error translating 'before' tuple: %w", err)
 	}
-	if err := translateRecordFields(discovery, af); err != nil {
+	if err := s.db.translateRecordFields(discovery, af); err != nil {
 		return nil, fmt.Errorf("error translating 'after' tuple: %w", err)
 	}
 


### PR DESCRIPTION
**Description:**

This PR adds two new feature flags:

 - The `date_as_date` flag causes DATE columns to be captured as YYYY-MM-DD dates which satisfy `{type: string, format: date}` where previously they were serialized as full RFC3339 timestamps.
 - The `time_as_time` flag causes TIME (aka TIME WITHOUT TIME ZONE) columns to be captured as HH:MM:SS.PPPZ time values which satisfy `{type: string, format: time}` where previously they were captured as Unix microsecond timestamps.

Both of these changes are long-awaited fixes to user complaints that would have been trivial to address except that it would conflict with an unknown amount of historical collection data.

We will be setting `no_date_as_date,no_time_as_time` on all production captures in the near future and then flipping the default so that new captures will get the new behavior automatically.

**Workflow steps:**

Remove these flags in the near future to opt into the new behavior for a preexisting capture.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2381)
<!-- Reviewable:end -->
