### PR TITLE
source-mysql: Make `date_schema_format` the default

### DIFF
--- a/source-mysql/datatype_test.go
+++ b/source-mysql/datatype_test.go
@@ -92,8 +92,8 @@ func TestDatatypes(t *testing.T) {
 		{ColumnType: "set('a', 'b', 'c')", ExpectType: `{"type":["string","null"]}`, InputValue: "b", ExpectValue: `"b"`},
 		{ColumnType: "set('a', 'b', 'c')", ExpectType: `{"type":["string","null"]}`, InputValue: "a,c", ExpectValue: `"a,c"`},
 
-		{ColumnType: "date", ExpectType: `{"type":["string","null"]}`, InputValue: "1991-08-31", ExpectValue: `"1991-08-31"`},
-		{ColumnType: "date", ExpectType: `{"type":["string","null"]}`, InputValue: "0000-00-00", ExpectValue: `"0001-01-01"`},
+		{ColumnType: "date", ExpectType: `{"type":["string","null"],"format":"date"}`, InputValue: "1991-08-31", ExpectValue: `"1991-08-31"`},
+		{ColumnType: "date", ExpectType: `{"type":["string","null"],"format":"date"}`, InputValue: "0000-00-00", ExpectValue: `"0001-01-01"`},
 		{ColumnType: "time", ExpectType: `{"type":["string","null"]}`, InputValue: "765:43:21", ExpectValue: `"765:43:21"`},
 		{ColumnType: "time", ExpectType: `{"type":["string","null"]}`, InputValue: "00:00:00", ExpectValue: `"00:00:00"`},
 		{ColumnType: "year", ExpectType: `{"type":["integer","null"]}`, InputValue: "2003", ExpectValue: `2003`},

--- a/source-mysql/main.go
+++ b/source-mysql/main.go
@@ -32,7 +32,7 @@ import (
 var featureFlagDefaults = map[string]bool{
 	// When true, date columns will be discovered as `type: string, format: date`
 	// instead of simply `type: string`
-	"date_schema_format": false,
+	"date_schema_format": true,
 }
 
 type sshForwarding struct {


### PR DESCRIPTION
**Description:**

This commit flips the default behavior for the `date_schema_format` feature flag. It will be merged immediately after all production MySQL captures have been modified with the `no_date_schema_format` setting.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2384)
<!-- Reviewable:end -->
