### PR TITLE
source-sqlserver: Make 'read_only' the default

### DIFF
--- a/source-sqlserver/main.go
+++ b/source-sqlserver/main.go
@@ -44,10 +44,8 @@ var featureFlagDefaults = map[string]bool{
 	"uppercase_discovery_queries": false,
 
 	// When true, the capture will use a fence mechanism based on observing CDC worker runs
-	// and LSN positions rather than watermark writes. This mechanism may require additional
-	// permissions, so the plan is to flip this to default-true for new users first and then
-	// see if we can migrate existing captures to read-only operation.
-	"read_only": false,
+	// and LSN positions rather than the old watermark write mechanism.
+	"read_only": true,
 }
 
 // Config tells the connector how to connect to and interact with the source database.


### PR DESCRIPTION
**Description:**

This commit just flips the default setting for the `read_only` feature flag so that any new captures without `no_read_only` set will operate in watermark-less mode. It will be merged immediately after `no_read_only` is set on all captures currently in production.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2385)
<!-- Reviewable:end -->
