### PR TITLE
source-mixpanel-native: increase `annotations` date window size

### DIFF
--- a/source-mixpanel-native/source_mixpanel_native/streams/annotations.py
+++ b/source-mixpanel-native/source_mixpanel_native/streams/annotations.py
@@ -27,6 +27,21 @@ class Annotations(DateSlicesMixin, MixpanelStream):
 
     primary_key: str = "id"
 
+    def __init__(
+        self,
+        date_window_size: int = 30,
+        **kwargs,
+    ):
+        # This stream rarely has much data, and its not incremental, so there's no benefit
+        # to doing date window slices for annotations when we *should* be able to fetch all records
+        # in a single request. Using an extremely large date window will cause the connector to
+        # use a single request to fetch all records.
+
+        super().__init__(
+            date_window_size = 100_000,
+            **kwargs,
+        )
+
     @property
     def data_field(self):
         return "results" if self.project_id else "annotations"


### PR DESCRIPTION
**Description:**

The `annotations` stream has signficantly fewer records than other streams that use the `DateSlicesMixin`, and `annotations` isn't incremental like many of those other streams. By using small date window sizes, `annotations` makes multiple HTTP requests checking each date window for records. Since there are typically only KB of annotations in users' Mixpanel accounts, the connector _could_ make a single request for a really large date window & get all records faster.

This PR makes `annotations` always use a large date window to try & get all records in a single request. An equivalent, cleaner, more time-intensive change would be rewriting `annotations` to not use the `DateSlicesMixin` and just specifying `from_date` and `to_date` query params in the `Annotations` class. But that refactor can be done later after confirming this approach works.


**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

Tested on a local stack. Confirmed that all annotations currently captured by existing tasks with `annotations` enabled are now captured in a single request.

