### PR TITLE
source-postgres: Fix duplicate `type` on arrays

### DIFF
--- a/source-postgres/.snapshots/TestCIText-Discovery
+++ b/source-postgres/.snapshots/TestCIText-Discovery
@@ -15,7 +15,6 @@ Binding 0:
           "$anchor": "TestCitext_58810479",
           "properties": {
             "arr": {
-              "type": "object",
               "required": [
                 "dimensions",
                 "elements"

--- a/source-postgres/discovery.go
+++ b/source-postgres/discovery.go
@@ -256,7 +256,6 @@ func (db *postgresDatabase) TranslateDBToJSONType(column sqlcapture.ColumnInfo, 
 		colSchema.nullable = true
 
 		jsonType = &jsonschema.Schema{
-			Type: "object",
 			Extras: map[string]interface{}{
 				"properties": map[string]*jsonschema.Schema{
 					"dimensions": {
@@ -275,6 +274,8 @@ func (db *postgresDatabase) TranslateDBToJSONType(column sqlcapture.ColumnInfo, 
 		// The column value itself may be null if the column is nullable.
 		if column.IsNullable {
 			jsonType.Extras["type"] = []string{"object", "null"}
+		} else {
+			jsonType.Type = "object"
 		}
 	} else {
 		colSchema.nullable = column.IsNullable


### PR DESCRIPTION
**Description:**

Previously the generated JSON schema for a nullable array-valued column in Postgres would have duplicate `type` properties: one nullable and one not. This fixes that duplication.

I did a quick check and it appears that this is only an issue for Postgres and only shows up in this one test snapshot.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2392)
<!-- Reviewable:end -->
