### PR TITLE
Revert "source-postgres: Flagged DATE and TIME fixes"

### DIFF
--- a/source-postgres/backfill.go
+++ b/source-postgres/backfill.go
@@ -130,7 +130,7 @@ func (db *postgresDatabase) ScanTableChunk(ctx context.Context, info *sqlcapture
 				return false, fmt.Errorf("error encoding row key for %q: %w", streamID, err)
 			}
 		}
-		if err := db.translateRecordFields(info, fields); err != nil {
+		if err := translateRecordFields(info, fields); err != nil {
 			return false, fmt.Errorf("error backfilling table %q: %w", table, err)
 		}
 

--- a/source-postgres/datatype_test.go
+++ b/source-postgres/datatype_test.go
@@ -56,10 +56,6 @@ func TestDatatypes(t *testing.T) {
 
 		// Date/Time/Timestamp Types
 		{ColumnType: `date`, ExpectType: `{"type":["string","null"],"format":"date-time"}`, InputValue: `'January 8, 1999'`, ExpectValue: `"1999-01-08T00:00:00Z"`},
-		{ColumnType: `date`, ExpectType: `{"type":["string","null"],"format":"date-time"}`, InputValue: `'January 8, 22021'`, ExpectValue: `"0000-01-01T00:00:00Z"`},
-		// Replacement tests for the previous two once "date_as_date" is the default
-		// {ColumnType: `date`, ExpectType: `{"type":["string","null"],"format":"date"}`, InputValue: `'January 8, 1999'`, ExpectValue: `"1999-01-08"`},
-		// {ColumnType: `date`, ExpectType: `{"type":["string","null"],"format":"date"}`, InputValue: `'January 8, 22021'`, ExpectValue: `"0000-01-01"`},
 		{ColumnType: `timestamp`, ExpectType: `{"type":["string","null"],"format":"date-time"}`, InputValue: `'January 8, 1999'`, ExpectValue: `"1999-01-08T00:00:00Z"`},
 		{ColumnType: `timestamp without time zone`, ExpectType: `{"type":["string","null"],"format":"date-time"}`, InputValue: `'January 8, 1999'`, ExpectValue: `"1999-01-08T00:00:00Z"`},
 		{ColumnType: `timestamp`, ExpectType: `{"type":["string","null"],"format":"date-time"}`, InputValue: `'infinity'`, ExpectValue: `"9999-12-31T23:59:59Z"`},
@@ -68,11 +64,9 @@ func TestDatatypes(t *testing.T) {
 		{ColumnType: `timestamp`, ExpectType: `{"type":["string","null"],"format":"date-time"}`, InputValue: `'20222-08-31T00:00:00Z'`, ExpectValue: `"0000-01-01T00:00:00Z"`},
 		{ColumnType: `timestamp`, ExpectType: `{"type":["string","null"],"format":"date-time"}`, InputValue: `'January 8, 99 BC'`, ExpectValue: `"0000-01-01T00:00:00Z"`},
 		{ColumnType: `timestamp with time zone`, ExpectType: `{"type":["string","null"],"format":"date-time"}`, InputValue: `'January 8, 1999 UTC'`, ExpectValue: `"1999-01-07T16:00:00-08:00"`},
+		// For historical reasons, times without time zone are captured as Unix second timestamps. We can change this if we ever do a version bump or otherwise break compatibility.
 		{ColumnType: `time`, ExpectType: `{"type":["integer","null"]}`, InputValue: `'04:05:06 PST'`, ExpectValue: `14706000000`},
 		{ColumnType: `time without time zone`, ExpectType: `{"type":["integer","null"]}`, InputValue: `'04:05:06 PST'`, ExpectValue: `14706000000`},
-		// Replacement tests for the previous two once "time_as_time" is the default
-		// {ColumnType: `time`, ExpectType: `{"type":["string","null"],"format":"time"}`, InputValue: `'04:05:06 PST'`, ExpectValue: `"04:05:06Z"`},
-		// {ColumnType: `time without time zone`, ExpectType: `{"type":["string","null"],"format":"time"}`, InputValue: `'04:05:06 PST'`, ExpectValue: `"04:05:06Z"`},
 		{ColumnType: `time with time zone`, ExpectType: `{"type":["string","null"],"format":"time"}`, InputValue: `'04:05:06 PST'`, ExpectValue: `"04:05:06-08:00"`},
 		{ColumnType: `time with time zone`, ExpectType: `{"type":["string","null"],"format":"time"}`, InputValue: `'04:05:06 UTC'`, ExpectValue: `"04:05:06Z"`},
 		{ColumnType: `time with time zone`, ExpectType: `{"type":["string","null"],"format":"time"}`, InputValue: `'04:05:06.123 UTC'`, ExpectValue: `"04:05:06.123Z"`},

--- a/source-postgres/discovery.go
+++ b/source-postgres/discovery.go
@@ -206,15 +206,6 @@ func columnsNonNullable(columnsInfo map[string]sqlcapture.ColumnInfo, columnName
 
 // TranslateDBToJSONType returns JSON schema information about the provided database column type.
 func (db *postgresDatabase) TranslateDBToJSONType(column sqlcapture.ColumnInfo, isPrimaryKey bool) (*jsonschema.Schema, error) {
-	if !db.featureFlags["date_as_date"] {
-		// Historically DATE columns were captured as RFC3339 timestamps.
-		postgresTypeToJSON["date"] = columnSchema{jsonTypes: []string{"string"}, format: "date-time"}
-	}
-	if !db.featureFlags["time_as_time"] {
-		// Historically TIME columns were captured as Unix seconds.
-		postgresTypeToJSON["time"] = columnSchema{jsonTypes: []string{"integer"}}
-	}
-
 	var arrayColumn = false
 	var colSchema columnSchema
 
@@ -350,10 +341,10 @@ var postgresTypeToJSON = map[string]columnSchema{
 	"jsonpath": {jsonTypes: []string{"string"}},
 
 	// Domain-Specific Types
-	"date":        {jsonTypes: []string{"string"}, format: "date"},
+	"date":        {jsonTypes: []string{"string"}, format: "date-time"},
 	"timestamp":   {jsonTypes: []string{"string"}, format: "date-time"},
 	"timestamptz": {jsonTypes: []string{"string"}, format: "date-time"},
-	"time":        {jsonTypes: []string{"string"}, format: "time"},
+	"time":        {jsonTypes: []string{"integer"}},
 	"timetz":      {jsonTypes: []string{"string"}, format: "time"},
 	"interval":    {jsonTypes: []string{"string"}},
 	"money":       {jsonTypes: []string{"string"}},

--- a/source-postgres/main.go
+++ b/source-postgres/main.go
@@ -123,15 +123,6 @@ var featureFlagDefaults = map[string]bool{
 	// When set, discovered collection schemas will request that schema inference be
 	// used _in addition to_ the full column/types discovery we already do.
 	"use_schema_inference": false,
-
-	// When true, DATE columns are captured as YYYY-MM-DD dates. Historically these
-	// used to be captured as RFC3339 timestamps, which is usually not what users expect.
-	"date_as_date": false,
-
-	// When true, TIME WITHOUT TIME ZONE columns (also known as TIME) are captured as strings
-	// satisfying `format: time`. Historically these used to be captured as Unix microseconds,
-	// which is usually not what users expect.
-	"time_as_time": false,
 }
 
 // Validate checks that the configuration possesses all required properties.

--- a/source-postgres/replication.go
+++ b/source-postgres/replication.go
@@ -661,10 +661,10 @@ func (s *replicationStream) decodeChangeEvent(
 	if !ok {
 		return nil, fmt.Errorf("unknown discovery info for stream %q", streamID)
 	}
-	if err := s.db.translateRecordFields(discovery, bf); err != nil {
+	if err := translateRecordFields(discovery, bf); err != nil {
 		return nil, fmt.Errorf("error translating 'before' tuple: %w", err)
 	}
-	if err := s.db.translateRecordFields(discovery, af); err != nil {
+	if err := translateRecordFields(discovery, af); err != nil {
 		return nil, fmt.Errorf("error translating 'after' tuple: %w", err)
 	}
 


### PR DESCRIPTION
Reverts estuary/connectors#2381

Bug in null value handling

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2393)
<!-- Reviewable:end -->
