### PR TITLE
sqlcapture: Treat tables with omitted primary-key columns as keyless

### DIFF
--- a/source-sqlserver/.snapshots/TestComputedPrimaryKey-capture
+++ b/source-sqlserver/.snapshots/TestComputedPrimaryKey-capture
@@ -10,5 +10,5 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"dbo%2Ftest_ComputedPrimaryKey_10118243":{"backfilled":3,"key_columns":["id"],"mode":"Active"}},"cursor":"AAAAAAAAAAAAAA=="}
+{"bindingStateV1":{"dbo%2Ftest_ComputedPrimaryKey_10118243":{"backfilled":3,"mode":"Active"}},"cursor":"AAAAAAAAAAAAAA=="}
 

--- a/source-sqlserver/.snapshots/TestComputedPrimaryKey-capture
+++ b/source-sqlserver/.snapshots/TestComputedPrimaryKey-capture
@@ -1,0 +1,14 @@
+# ================================
+# Collection "acmeCo/test/dbo/test_computedprimarykey_10118243": 6 Documents
+# ================================
+{"_meta":{"op":"c","source":{"schema":"dbo","snapshot":true,"table":"test_ComputedPrimaryKey_10118243","lsn":"","seqval":"AAAAAAAAAAAAAA=="}},"actual_id":0,"data":"zero"}
+{"_meta":{"op":"c","source":{"schema":"dbo","snapshot":true,"table":"test_ComputedPrimaryKey_10118243","lsn":"","seqval":"AAAAAAAAAAAAAA=="}},"actual_id":1,"data":"one"}
+{"_meta":{"op":"c","source":{"schema":"dbo","snapshot":true,"table":"test_ComputedPrimaryKey_10118243","lsn":"","seqval":"AAAAAAAAAAAAAA=="}},"actual_id":2,"data":"two"}
+{"_meta":{"op":"c","source":{"schema":"dbo","table":"test_ComputedPrimaryKey_10118243","lsn":"AAAAAAAAAAAAAA==","seqval":"AAAAAAAAAAAAAA==","updateMask":"Bw=="}},"actual_id":3,"data":"three"}
+{"_meta":{"op":"c","source":{"schema":"dbo","table":"test_ComputedPrimaryKey_10118243","lsn":"AAAAAAAAAAAAAA==","seqval":"AAAAAAAAAAAAAA==","updateMask":"Bw=="}},"actual_id":4,"data":"four"}
+{"_meta":{"op":"c","source":{"schema":"dbo","table":"test_ComputedPrimaryKey_10118243","lsn":"AAAAAAAAAAAAAA==","seqval":"AAAAAAAAAAAAAA==","updateMask":"Bw=="}},"actual_id":5,"data":"five"}
+# ================================
+# Final State Checkpoint
+# ================================
+{"bindingStateV1":{"dbo%2Ftest_ComputedPrimaryKey_10118243":{"backfilled":3,"key_columns":["id"],"mode":"Active"}},"cursor":"AAAAAAAAAAAAAA=="}
+

--- a/source-sqlserver/.snapshots/TestComputedPrimaryKey-discovery
+++ b/source-sqlserver/.snapshots/TestComputedPrimaryKey-discovery
@@ -2,6 +2,7 @@ Binding 0:
 {
     "recommended_name": "dbo/test_computedprimarykey_10118243",
     "resource_config_json": {
+      "mode": "Without Primary Key",
       "namespace": "dbo",
       "stream": "test_ComputedPrimaryKey_10118243"
     },
@@ -9,9 +10,6 @@ Binding 0:
       "$defs": {
         "DboTest_ComputedPrimaryKey_10118243": {
           "type": "object",
-          "required": [
-            "id"
-          ],
           "$anchor": "DboTest_ComputedPrimaryKey_10118243",
           "properties": {
             "actual_id": {
@@ -132,7 +130,8 @@ Binding 0:
       ]
     },
     "key": [
-      "/id"
+      "/_meta/source/lsn",
+      "/_meta/source/seqval"
     ]
   }
 

--- a/source-sqlserver/.snapshots/TestComputedPrimaryKey-discovery
+++ b/source-sqlserver/.snapshots/TestComputedPrimaryKey-discovery
@@ -1,0 +1,138 @@
+Binding 0:
+{
+    "recommended_name": "dbo/test_computedprimarykey_10118243",
+    "resource_config_json": {
+      "namespace": "dbo",
+      "stream": "test_ComputedPrimaryKey_10118243"
+    },
+    "document_schema_json": {
+      "$defs": {
+        "DboTest_ComputedPrimaryKey_10118243": {
+          "type": "object",
+          "required": [
+            "id"
+          ],
+          "$anchor": "DboTest_ComputedPrimaryKey_10118243",
+          "properties": {
+            "actual_id": {
+              "type": "integer",
+              "description": "(source type: non-nullable int)"
+            },
+            "data": {
+              "description": "(source type: varchar(64))",
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          }
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "_meta": {
+                "properties": {
+                  "op": {
+                    "const": "d"
+                  }
+                }
+              }
+            }
+          },
+          "then": {
+            "reduce": {
+              "delete": true,
+              "strategy": "merge"
+            }
+          },
+          "else": {
+            "reduce": {
+              "strategy": "merge"
+            }
+          },
+          "required": [
+            "_meta"
+          ],
+          "properties": {
+            "_meta": {
+              "type": "object",
+              "required": [
+                "op",
+                "source"
+              ],
+              "properties": {
+                "before": {
+                  "$ref": "#DboTest_ComputedPrimaryKey_10118243",
+                  "description": "Record state immediately before this change was applied.",
+                  "reduce": {
+                    "strategy": "firstWriteWins"
+                  }
+                },
+                "op": {
+                  "enum": [
+                    "c",
+                    "d",
+                    "u"
+                  ],
+                  "description": "Change operation type: 'c' Create/Insert, 'u' Update, 'd' Delete."
+                },
+                "source": {
+                  "$id": "https://github.com/estuary/connectors/source-sqlserver/sqlserver-source-info",
+                  "properties": {
+                    "ts_ms": {
+                      "type": "integer",
+                      "description": "Unix timestamp (in millis) at which this event was recorded by the database."
+                    },
+                    "schema": {
+                      "type": "string",
+                      "description": "Database schema (namespace) of the event."
+                    },
+                    "snapshot": {
+                      "type": "boolean",
+                      "description": "Snapshot is true if the record was produced from an initial table backfill and unset if produced from the replication log."
+                    },
+                    "table": {
+                      "type": "string",
+                      "description": "Database table of the event."
+                    },
+                    "lsn": {
+                      "type": "string",
+                      "contentEncoding": "base64",
+                      "description": "The LSN at which a CDC event occurred. Only set for CDC events"
+                    },
+                    "seqval": {
+                      "type": "string",
+                      "contentEncoding": "base64",
+                      "description": "Sequence value used to order changes to a row within a transaction. Only set for CDC events"
+                    },
+                    "updateMask": {
+                      "description": "A bit mask with a bit corresponding to each captured column identified for the capture instance. Only set for CDC events"
+                    }
+                  },
+                  "type": "object",
+                  "required": [
+                    "schema",
+                    "table",
+                    "lsn",
+                    "seqval"
+                  ]
+                }
+              },
+              "reduce": {
+                "strategy": "merge"
+              }
+            }
+          }
+        },
+        {
+          "$ref": "#DboTest_ComputedPrimaryKey_10118243"
+        }
+      ]
+    },
+    "key": [
+      "/id"
+    ]
+  }
+


### PR DESCRIPTION
**Description:**

We omit columns from discovered schemas when they're things we can't reliably capture, as is the case with SQL Server or Postgres computed columns.

At least in SQL Server, but I think probably also in Postgres, it is possible to use such a column as the primary key of a table. When this happens we currently emit a nonsensical schema in which the column isn't defined as a property of the output documents, but _is_ listed as required and is suggested as the collection key.

This is incorrect both because the schema is incoherent, and because that column isn't going to be reliably present (it won't be present in replicated changes, specifically) so it can't be a collection key anyway. The best outcome here is just to treat the table as keyless, so I've put some sanity-checking logic in the `sqlcapture` catalog generation code to do that.

It might be smarter to eventually integrate a "is any key column generated" check into the secondary index selection logic for impacted databases, so that if the primary key of a table is generated but there's a unique secondary index that isn't we use that. But that seemed like a lot of additional complexity for a very niche edge case, so I'm just going with the simple fix for a situation that blatantly cannot ever be correct here.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2396)
<!-- Reviewable:end -->
