### PR TITLE
source-postgres: Omit generated columns from schemas

### DIFF
--- a/source-postgres/.snapshots/TestGeneratedColumn-capture
+++ b/source-postgres/.snapshots/TestGeneratedColumn-capture
@@ -1,0 +1,23 @@
+# ================================
+# Collection "acmeCo/test/test/generatedcolumn_91418628": 15 Documents
+# ================================
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"generatedcolumn_91418628","loc":[11111111,11111111,11111111]}},"a":"a0","b":"b0","id":0}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"generatedcolumn_91418628","loc":[11111111,11111111,11111111]}},"a":null,"b":"b1","id":1}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"generatedcolumn_91418628","loc":[11111111,11111111,11111111]}},"a":"a2","b":null,"id":2}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"generatedcolumn_91418628","loc":[11111111,11111111,11111111]}},"a":null,"b":null,"id":3}
+{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"generatedcolumn_91418628","loc":[11111111,11111111,11111111],"txid":111111}},"a":"a4","b":"b4","id":4}
+{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"generatedcolumn_91418628","loc":[11111111,11111111,11111111],"txid":111111}},"a":null,"b":"b5","id":5}
+{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"generatedcolumn_91418628","loc":[11111111,11111111,11111111],"txid":111111}},"a":"a6","b":null,"id":6}
+{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"generatedcolumn_91418628","loc":[11111111,11111111,11111111],"txid":111111}},"a":null,"b":null,"id":7}
+{"_meta":{"op":"u","source":{"ts_ms":1111111111111,"schema":"test","table":"generatedcolumn_91418628","loc":[11111111,11111111,11111111],"txid":111111}},"a":"a4-modified","b":"b4","id":4}
+{"_meta":{"op":"u","source":{"ts_ms":1111111111111,"schema":"test","table":"generatedcolumn_91418628","loc":[11111111,11111111,11111111],"txid":111111}},"a":null,"b":"b5-modified","id":5}
+{"_meta":{"op":"u","source":{"ts_ms":1111111111111,"schema":"test","table":"generatedcolumn_91418628","loc":[11111111,11111111,11111111],"txid":111111}},"a":"a6-modified","b":null,"id":6}
+{"_meta":{"op":"d","source":{"ts_ms":1111111111111,"schema":"test","table":"generatedcolumn_91418628","loc":[11111111,11111111,11111111],"txid":111111}},"id":4}
+{"_meta":{"op":"d","source":{"ts_ms":1111111111111,"schema":"test","table":"generatedcolumn_91418628","loc":[11111111,11111111,11111111],"txid":111111}},"id":5}
+{"_meta":{"op":"d","source":{"ts_ms":1111111111111,"schema":"test","table":"generatedcolumn_91418628","loc":[11111111,11111111,11111111],"txid":111111}},"id":6}
+{"_meta":{"op":"d","source":{"ts_ms":1111111111111,"schema":"test","table":"generatedcolumn_91418628","loc":[11111111,11111111,11111111],"txid":111111}},"id":7}
+# ================================
+# Final State Checkpoint
+# ================================
+{"bindingStateV1":{"test%2Fgeneratedcolumn_91418628":{"backfilled":4,"key_columns":["id"],"mode":"Active"}},"cursor":"0/1111111"}
+

--- a/source-postgres/.snapshots/TestGeneratedColumn-discovery
+++ b/source-postgres/.snapshots/TestGeneratedColumn-discovery
@@ -1,0 +1,144 @@
+Binding 0:
+{
+    "recommended_name": "test/generatedcolumn_91418628",
+    "resource_config_json": {
+      "namespace": "test",
+      "stream": "generatedcolumn_91418628"
+    },
+    "document_schema_json": {
+      "$defs": {
+        "TestGeneratedcolumn_91418628": {
+          "type": "object",
+          "required": [
+            "id"
+          ],
+          "$anchor": "TestGeneratedcolumn_91418628",
+          "properties": {
+            "a": {
+              "description": "(source type: varchar)",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "b": {
+              "description": "(source type: varchar)",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "id": {
+              "type": "integer",
+              "description": "(source type: non-nullable int4)"
+            }
+          }
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "_meta": {
+                "properties": {
+                  "op": {
+                    "const": "d"
+                  }
+                }
+              }
+            }
+          },
+          "then": {
+            "reduce": {
+              "delete": true,
+              "strategy": "merge"
+            }
+          },
+          "else": {
+            "reduce": {
+              "strategy": "merge"
+            }
+          },
+          "required": [
+            "_meta"
+          ],
+          "properties": {
+            "_meta": {
+              "type": "object",
+              "required": [
+                "op",
+                "source"
+              ],
+              "properties": {
+                "before": {
+                  "$ref": "#TestGeneratedcolumn_91418628",
+                  "description": "Record state immediately before this change was applied.",
+                  "reduce": {
+                    "strategy": "firstWriteWins"
+                  }
+                },
+                "op": {
+                  "enum": [
+                    "c",
+                    "d",
+                    "u"
+                  ],
+                  "description": "Change operation type: 'c' Create/Insert, 'u' Update, 'd' Delete."
+                },
+                "source": {
+                  "$id": "https://github.com/estuary/connectors/source-postgres/postgres-source",
+                  "properties": {
+                    "ts_ms": {
+                      "type": "integer",
+                      "description": "Unix timestamp (in millis) at which this event was recorded by the database."
+                    },
+                    "schema": {
+                      "type": "string",
+                      "description": "Database schema (namespace) of the event."
+                    },
+                    "snapshot": {
+                      "type": "boolean",
+                      "description": "Snapshot is true if the record was produced from an initial table backfill and unset if produced from the replication log."
+                    },
+                    "table": {
+                      "type": "string",
+                      "description": "Database table of the event."
+                    },
+                    "loc": {
+                      "items": {
+                        "type": "integer"
+                      },
+                      "type": "array",
+                      "maxItems": 3,
+                      "minItems": 3,
+                      "description": "Location of this WAL event as [last Commit.EndLSN; event LSN; current Begin.FinalLSN]. See https://www.postgresql.org/docs/current/protocol-logicalrep-message-formats.html"
+                    },
+                    "txid": {
+                      "type": "integer",
+                      "description": "The 32-bit transaction ID assigned by Postgres to the commit which produced this change."
+                    }
+                  },
+                  "type": "object",
+                  "required": [
+                    "schema",
+                    "table",
+                    "loc"
+                  ]
+                }
+              },
+              "reduce": {
+                "strategy": "merge"
+              }
+            }
+          }
+        },
+        {
+          "$ref": "#TestGeneratedcolumn_91418628"
+        }
+      ]
+    },
+    "key": [
+      "/id"
+    ]
+  }
+


### PR DESCRIPTION
**Description:**

Generated columns cannot be captured via logical replication, so we should't mention them in our discovered schemas or capture their values via backfill either.

This bring PostgreSQL up to parity with how SQL Server handles computed columns.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2397)
<!-- Reviewable:end -->
