### PR TITLE
source-jira-native: skip fetching child resources of deleted projects (additional streams)

### DIFF
--- a/source-jira-native/source_jira_native/streams.py
+++ b/source-jira-native/source_jira_native/streams.py
@@ -1015,6 +1015,10 @@ class ProjectAvatars(JiraStream):
 
     def read_records(self, stream_slice: Optional[Mapping[str, Any]] = None, **kwargs) -> Iterable[Mapping[str, Any]]:
         for project in read_full_refresh(self.projects_stream):
+            # Skip fetching child resources for deleted projects since attempting to do so will return a 404 error.
+            if project.get('deleted', None):
+                continue
+
             yield from super().read_records(stream_slice={"key": project["key"]}, **kwargs)
 
 
@@ -1049,6 +1053,10 @@ class ProjectComponents(JiraStream):
 
     def read_records(self, stream_slice: Optional[Mapping[str, Any]] = None, **kwargs) -> Iterable[Mapping[str, Any]]:
         for project in read_full_refresh(self.projects_stream):
+            # Skip fetching child resources for deleted projects since attempting to do so will return a 404 error.
+            if project.get('deleted', None):
+                continue
+
             yield from super().read_records(stream_slice={"key": project["key"]}, **kwargs)
 
 
@@ -1100,6 +1108,10 @@ class ProjectPermissionSchemes(JiraStream):
 
     def read_records(self, stream_slice: Optional[Mapping[str, Any]] = None, **kwargs) -> Iterable[Mapping[str, Any]]:
         for project in read_full_refresh(self.projects_stream):
+            # Skip fetching child resources for deleted projects since attempting to do so will return a 404 error.
+            if project.get('deleted', None):
+                continue
+
             yield from super().read_records(stream_slice={"key": project["key"]}, **kwargs)
 
     def transform(self, record: MutableMapping[str, Any], stream_slice: Mapping[str, Any], **kwargs) -> MutableMapping[str, Any]:
@@ -1152,7 +1164,7 @@ class ProjectVersions(JiraStream):
 
     def read_records(self, stream_slice: Optional[Mapping[str, Any]] = None, **kwargs) -> Iterable[Mapping[str, Any]]:
         for project in read_full_refresh(self.projects_stream):
-            # Skip fetching emails for deleted projects since attempting to do so will return a 404 error.
+            # Skip fetching child resources for deleted projects since attempting to do so will return a 404 error.
             if project.get('deleted', None):
                 continue
 


### PR DESCRIPTION
**Description:**

I missed applying the fix in e329435 to the `project_avatars`, `project_components`, and `project_permission_schemes` streams.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

I did not test on a local stack to confirm this works, but I'm fairly confident it will considering it's the same issue that should be resolved by https://github.com/estuary/connectors/pull/2394.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2398)
<!-- Reviewable:end -->
