### PR TITLE
materialize-boilerplate: CSV encoder optimizations

### DIFF
--- a/materialize-azure-fabric-warehouse/.snapshots/TestSQLGeneration
+++ b/materialize-azure-fabric-warehouse/.snapshots/TestSQLGeneration
@@ -77,9 +77,10 @@ COPY INTO flow_temp_table_store_0
 (key1, key2, "key!binary", "array", "binary", "boolean", flow_published_at, "integer", "integerGt64Bit", "integerWithUserDDL", multiple, number, "numberCastToString", "object", string, "stringInteger", "stringInteger39Chars", "stringInteger66Chars", "stringNumber", flow_document)
 FROM 'https://some/file1', 'https://some/file2'
 WITH (
-    FILE_TYPE = 'CSV',
-    COMPRESSION = 'Gzip',
-    CREDENTIAL = (IDENTITY='Storage Account Key', SECRET='some-storage-account-key')
+	FILE_TYPE = 'CSV',
+	COMPRESSION = 'Gzip',
+	FIELDQUOTE = '`',
+	CREDENTIAL = (IDENTITY='Storage Account Key', SECRET='some-storage-account-key')
 );
 
 INSERT INTO "a-warehouse"."a-schema".key_value (key1, key2, "key!binary", "array", "binary", "boolean", flow_published_at, "integer", "integerGt64Bit", "integerWithUserDDL", multiple, number, "numberCastToString", "object", string, "stringInteger", "stringInteger39Chars", "stringInteger66Chars", "stringNumber", flow_document)
@@ -96,6 +97,7 @@ FROM 'https://some/file1', 'https://some/file2'
 WITH (
 	FILE_TYPE = 'CSV',
 	COMPRESSION = 'Gzip',
+	FIELDQUOTE = '`',
 	CREDENTIAL = (IDENTITY='Storage Account Key', SECRET='some-storage-account-key')
 );
 --- End "a-warehouse"."a-schema".key_value storeCopyIntoDirectQuery ---
@@ -111,9 +113,10 @@ COPY INTO flow_temp_table_store_1
 ("theKey", "aValue", flow_published_at)
 FROM 'https://some/file1', 'https://some/file2'
 WITH (
-    FILE_TYPE = 'CSV',
-    COMPRESSION = 'Gzip',
-    CREDENTIAL = (IDENTITY='Storage Account Key', SECRET='some-storage-account-key')
+	FILE_TYPE = 'CSV',
+	COMPRESSION = 'Gzip',
+	FIELDQUOTE = '`',
+	CREDENTIAL = (IDENTITY='Storage Account Key', SECRET='some-storage-account-key')
 );
 
 INSERT INTO "a-warehouse"."a-schema".delta_updates ("theKey", "aValue", flow_published_at)
@@ -130,6 +133,7 @@ FROM 'https://some/file1', 'https://some/file2'
 WITH (
 	FILE_TYPE = 'CSV',
 	COMPRESSION = 'Gzip',
+	FIELDQUOTE = '`',
 	CREDENTIAL = (IDENTITY='Storage Account Key', SECRET='some-storage-account-key')
 );
 --- End "a-warehouse"."a-schema".delta_updates storeCopyIntoDirectQuery ---
@@ -145,9 +149,10 @@ COPY INTO flow_temp_table_load_0
 (key1, key2, "key!binary")
 FROM 'https://some/file1', 'https://some/file2'
 WITH (
-    FILE_TYPE = 'CSV',
-    COMPRESSION = 'Gzip',
-    CREDENTIAL = (IDENTITY='Storage Account Key', SECRET='some-storage-account-key')
+	FILE_TYPE = 'CSV',
+	COMPRESSION = 'Gzip',
+	FIELDQUOTE = '`',
+	CREDENTIAL = (IDENTITY='Storage Account Key', SECRET='some-storage-account-key')
 );
 --- End "a-warehouse"."a-schema".key_value createLoadTable ---
 
@@ -191,9 +196,10 @@ COPY INTO flow_temp_table_store_0
 (key1, key2, "key!binary", "array", "binary", "boolean", flow_published_at, "integer", "integerGt64Bit", "integerWithUserDDL", multiple, number, "numberCastToString", "object", string, "stringInteger", "stringInteger39Chars", "stringInteger66Chars", "stringNumber", flow_document)
 FROM 'https://some/file1', 'https://some/file2'
 WITH (
-    FILE_TYPE = 'CSV',
-    COMPRESSION = 'Gzip',
-    CREDENTIAL = (IDENTITY='Storage Account Key', SECRET='some-storage-account-key')
+	FILE_TYPE = 'CSV',
+	COMPRESSION = 'Gzip',
+	FIELDQUOTE = '`',
+	CREDENTIAL = (IDENTITY='Storage Account Key', SECRET='some-storage-account-key')
 );
 
 DELETE r

--- a/materialize-azure-fabric-warehouse/sqlgen.go
+++ b/materialize-azure-fabric-warehouse/sqlgen.go
@@ -159,9 +159,10 @@ COPY INTO {{ template "temp_name_load" $ }}
 ({{- range $ind, $key := $.Keys }}{{- if $ind }}, {{ end }}{{$key.Identifier}}{{- end }})
 FROM {{ range $ind, $uri := $.URIs }}{{- if $ind }}, {{ end }}'{{$uri}}'{{- end }}
 WITH (
-    FILE_TYPE = 'CSV',
-    COMPRESSION = 'Gzip',
-    CREDENTIAL = (IDENTITY='Storage Account Key', SECRET='{{ $.StorageAccountKey }}')
+	FILE_TYPE = 'CSV',
+	COMPRESSION = 'Gzip',
+	FIELDQUOTE = '{{ Backtick }}',
+	CREDENTIAL = (IDENTITY='Storage Account Key', SECRET='{{ $.StorageAccountKey }}')
 );
 {{ end }}
 
@@ -192,9 +193,10 @@ COPY INTO {{ template "temp_name_store" $ }}
 ({{- range $ind, $col := $.Columns }}{{- if $ind }}, {{ end }}{{$col.Identifier}}{{- end }})
 FROM {{ range $ind, $uri := $.URIs }}{{- if $ind }}, {{ end }}'{{$uri}}'{{- end }}
 WITH (
-    FILE_TYPE = 'CSV',
-    COMPRESSION = 'Gzip',
-    CREDENTIAL = (IDENTITY='Storage Account Key', SECRET='{{ $.StorageAccountKey }}')
+	FILE_TYPE = 'CSV',
+	COMPRESSION = 'Gzip',
+	FIELDQUOTE = '{{ Backtick }}',
+	CREDENTIAL = (IDENTITY='Storage Account Key', SECRET='{{ $.StorageAccountKey }}')
 );
 {{- end }}
 
@@ -248,6 +250,7 @@ FROM {{ range $ind, $uri := $.URIs }}{{- if $ind }}, {{ end }}'{{$uri}}'{{- end 
 WITH (
 	FILE_TYPE = 'CSV',
 	COMPRESSION = 'Gzip',
+	FIELDQUOTE = '{{ Backtick }}',
 	CREDENTIAL = (IDENTITY='Storage Account Key', SECRET='{{ $.StorageAccountKey }}')
 );
 {{ end }}

--- a/materialize-azure-fabric-warehouse/staged_file.go
+++ b/materialize-azure-fabric-warehouse/staged_file.go
@@ -42,7 +42,7 @@ type stagedFileClient struct {
 }
 
 func (s *stagedFileClient) NewEncoder(w io.WriteCloser, fields []string) boilerplate.Encoder {
-	return enc.NewCsvEncoder(w, fields, enc.WithCsvSkipHeaders())
+	return enc.NewCsvEncoder(w, fields, enc.WithCsvSkipHeaders(), enc.WithCsvQuoteChar('`'))
 }
 
 func (s *stagedFileClient) NewObject(uuid string) azureBlobObject {

--- a/materialize-boilerplate/stream-encode/csv_test.go
+++ b/materialize-boilerplate/stream-encode/csv_test.go
@@ -77,7 +77,7 @@ func TestCsvWriter(t *testing.T) {
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			var buf bytes.Buffer
-			csvw := newCsvWriter(&buf)
+			csvw := newCsvWriter(&buf, '"')
 			require.NoError(t, csvw.writeRow(tt.row))
 			require.Equal(t, tt.want, buf.String())
 		})

--- a/materialize-sql/templating.go
+++ b/materialize-sql/templating.go
@@ -26,6 +26,7 @@ func MustParseTemplate(dialect Dialect, name, body string) *template.Template {
 		"Contains":   func(s string, substr string) bool { return strings.Contains(s, substr) },
 		"Last":       func(s []string) string { return s[len(s)-1] },
 		"First":      func(s []string) string { return s[0] },
+		"Backtick":   func() string { return "`" }, // Go string literals don't allow a ` character
 	})
 	return template.Must(tpl.Parse(body))
 }


### PR DESCRIPTION
**Description:**

Eliminate allocations and allow for specifying an alternate quote character to improve the performance of CSV encoding.

The benefits from these changes are pretty significant, about an order of magnitude faster encoding for streams of representative JSON documents. For optimum performance it is important to not have to escape many quote characters, so picking something than a double quote is best since our JSON documents will typically have a lot of those ex. the `flow_document` field.

The CSV encoder is about equivalent with our optimized JSON encoder now, and the CPU time for both is dominated by the compression activity rather than the serialization.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2399)
<!-- Reviewable:end -->
