### PR TITLE
source-zendesk-support-native: add streams to achieve parity with imported connector

### DIFF
--- a/source-zendesk-support-native/acmeCo/account_attributes.schema.yaml
+++ b/source-zendesk-support-native/acmeCo/account_attributes.schema.yaml
@@ -1,0 +1,31 @@
+---
+$defs:
+  Meta:
+    properties:
+      op:
+        default: u
+        description: "Operation type (c: Create, u: Update, d: Delete)"
+        enum:
+          - c
+          - u
+          - d
+        title: Op
+        type: string
+      row_id:
+        default: -1
+        description: "Row ID of the Document, counting up from zero, or -1 if not known"
+        title: Row Id
+        type: integer
+    title: Meta
+    type: object
+additionalProperties: true
+properties:
+  _meta:
+    $ref: "#/$defs/Meta"
+    default:
+      op: u
+      row_id: -1
+    description: Document metadata
+title: FullRefreshResource
+type: object
+x-infer-schema: true

--- a/source-zendesk-support-native/acmeCo/automations.schema.yaml
+++ b/source-zendesk-support-native/acmeCo/automations.schema.yaml
@@ -1,0 +1,41 @@
+---
+$defs:
+  Meta:
+    properties:
+      op:
+        default: u
+        description: "Operation type (c: Create, u: Update, d: Delete)"
+        enum:
+          - c
+          - u
+          - d
+        title: Op
+        type: string
+      row_id:
+        default: -1
+        description: "Row ID of the Document, counting up from zero, or -1 if not known"
+        title: Row Id
+        type: integer
+    title: Meta
+    type: object
+additionalProperties: true
+properties:
+  _meta:
+    $ref: "#/$defs/Meta"
+    default:
+      op: u
+      row_id: -1
+    description: Document metadata
+  id:
+    title: Id
+    type: integer
+  updated_at:
+    format: date-time
+    title: Updated At
+    type: string
+required:
+  - id
+  - updated_at
+title: TimestampedResource
+type: object
+x-infer-schema: true

--- a/source-zendesk-support-native/acmeCo/custom_roles.schema.yaml
+++ b/source-zendesk-support-native/acmeCo/custom_roles.schema.yaml
@@ -1,0 +1,41 @@
+---
+$defs:
+  Meta:
+    properties:
+      op:
+        default: u
+        description: "Operation type (c: Create, u: Update, d: Delete)"
+        enum:
+          - c
+          - u
+          - d
+        title: Op
+        type: string
+      row_id:
+        default: -1
+        description: "Row ID of the Document, counting up from zero, or -1 if not known"
+        title: Row Id
+        type: integer
+    title: Meta
+    type: object
+additionalProperties: true
+properties:
+  _meta:
+    $ref: "#/$defs/Meta"
+    default:
+      op: u
+      row_id: -1
+    description: Document metadata
+  id:
+    title: Id
+    type: integer
+  updated_at:
+    format: date-time
+    title: Updated At
+    type: string
+required:
+  - id
+  - updated_at
+title: TimestampedResource
+type: object
+x-infer-schema: true

--- a/source-zendesk-support-native/acmeCo/flow.yaml
+++ b/source-zendesk-support-native/acmeCo/flow.yaml
@@ -40,6 +40,10 @@ collections:
     schema: organizations.schema.yaml
     key:
       - /id
+  acmeCo/post_comment_votes:
+    schema: post_comment_votes.schema.yaml
+    key:
+      - /id
   acmeCo/post_comments:
     schema: post_comments.schema.yaml
     key:

--- a/source-zendesk-support-native/acmeCo/flow.yaml
+++ b/source-zendesk-support-native/acmeCo/flow.yaml
@@ -40,6 +40,14 @@ collections:
     schema: organizations.schema.yaml
     key:
       - /id
+  acmeCo/post_comments:
+    schema: post_comments.schema.yaml
+    key:
+      - /id
+  acmeCo/post_votes:
+    schema: post_votes.schema.yaml
+    key:
+      - /id
   acmeCo/posts:
     schema: posts.schema.yaml
     key:

--- a/source-zendesk-support-native/acmeCo/flow.yaml
+++ b/source-zendesk-support-native/acmeCo/flow.yaml
@@ -32,6 +32,10 @@ collections:
     schema: satisfaction_ratings.schema.yaml
     key:
       - /id
+  acmeCo/schedules:
+    schema: schedules.schema.yaml
+    key:
+      - /_meta/row_id
   acmeCo/sla_policies:
     schema: sla_policies.schema.yaml
     key:

--- a/source-zendesk-support-native/acmeCo/flow.yaml
+++ b/source-zendesk-support-native/acmeCo/flow.yaml
@@ -28,6 +28,10 @@ collections:
     schema: organization_memberships.schema.yaml
     key:
       - /id
+  acmeCo/organizations:
+    schema: organizations.schema.yaml
+    key:
+      - /id
   acmeCo/satisfaction_ratings:
     schema: satisfaction_ratings.schema.yaml
     key:

--- a/source-zendesk-support-native/acmeCo/flow.yaml
+++ b/source-zendesk-support-native/acmeCo/flow.yaml
@@ -4,6 +4,10 @@ collections:
     schema: audit_logs.schema.yaml
     key:
       - /id
+  acmeCo/automations:
+    schema: automations.schema.yaml
+    key:
+      - /id
   acmeCo/brands:
     schema: brands.schema.yaml
     key:
@@ -30,6 +34,10 @@ collections:
       - /id
   acmeCo/organizations:
     schema: organizations.schema.yaml
+    key:
+      - /id
+  acmeCo/posts:
+    schema: posts.schema.yaml
     key:
       - /id
   acmeCo/satisfaction_ratings:
@@ -82,6 +90,10 @@ collections:
       - /id
   acmeCo/tickets:
     schema: tickets.schema.yaml
+    key:
+      - /id
+  acmeCo/topics:
+    schema: topics.schema.yaml
     key:
       - /id
   acmeCo/users:

--- a/source-zendesk-support-native/acmeCo/flow.yaml
+++ b/source-zendesk-support-native/acmeCo/flow.yaml
@@ -24,6 +24,10 @@ collections:
     schema: satisfaction_ratings.schema.yaml
     key:
       - /id
+  acmeCo/sla_policies:
+    schema: sla_policies.schema.yaml
+    key:
+      - /_meta/row_id
   acmeCo/tags:
     schema: tags.schema.yaml
     key:

--- a/source-zendesk-support-native/acmeCo/flow.yaml
+++ b/source-zendesk-support-native/acmeCo/flow.yaml
@@ -1,5 +1,9 @@
 ---
 collections:
+  acmeCo/account_attributes:
+    schema: account_attributes.schema.yaml
+    key:
+      - /_meta/row_id
   acmeCo/audit_logs:
     schema: audit_logs.schema.yaml
     key:

--- a/source-zendesk-support-native/acmeCo/flow.yaml
+++ b/source-zendesk-support-native/acmeCo/flow.yaml
@@ -8,6 +8,10 @@ collections:
     schema: brands.schema.yaml
     key:
       - /id
+  acmeCo/custom_roles:
+    schema: custom_roles.schema.yaml
+    key:
+      - /id
   acmeCo/group_memberships:
     schema: group_memberships.schema.yaml
     key:
@@ -46,6 +50,10 @@ collections:
       - /id
   acmeCo/ticket_fields:
     schema: ticket_fields.schema.yaml
+    key:
+      - /id
+  acmeCo/ticket_forms:
+    schema: ticket_forms.schema.yaml
     key:
       - /id
   acmeCo/ticket_metric_events:

--- a/source-zendesk-support-native/acmeCo/flow.yaml
+++ b/source-zendesk-support-native/acmeCo/flow.yaml
@@ -8,6 +8,10 @@ collections:
     schema: brands.schema.yaml
     key:
       - /id
+  acmeCo/group_memberships:
+    schema: group_memberships.schema.yaml
+    key:
+      - /id
   acmeCo/groups:
     schema: groups.schema.yaml
     key:

--- a/source-zendesk-support-native/acmeCo/group_memberships.schema.yaml
+++ b/source-zendesk-support-native/acmeCo/group_memberships.schema.yaml
@@ -1,0 +1,41 @@
+---
+$defs:
+  Meta:
+    properties:
+      op:
+        default: u
+        description: "Operation type (c: Create, u: Update, d: Delete)"
+        enum:
+          - c
+          - u
+          - d
+        title: Op
+        type: string
+      row_id:
+        default: -1
+        description: "Row ID of the Document, counting up from zero, or -1 if not known"
+        title: Row Id
+        type: integer
+    title: Meta
+    type: object
+additionalProperties: true
+properties:
+  _meta:
+    $ref: "#/$defs/Meta"
+    default:
+      op: u
+      row_id: -1
+    description: Document metadata
+  id:
+    title: Id
+    type: integer
+  updated_at:
+    format: date-time
+    title: Updated At
+    type: string
+required:
+  - id
+  - updated_at
+title: TimestampedResource
+type: object
+x-infer-schema: true

--- a/source-zendesk-support-native/acmeCo/organizations.schema.yaml
+++ b/source-zendesk-support-native/acmeCo/organizations.schema.yaml
@@ -1,0 +1,41 @@
+---
+$defs:
+  Meta:
+    properties:
+      op:
+        default: u
+        description: "Operation type (c: Create, u: Update, d: Delete)"
+        enum:
+          - c
+          - u
+          - d
+        title: Op
+        type: string
+      row_id:
+        default: -1
+        description: "Row ID of the Document, counting up from zero, or -1 if not known"
+        title: Row Id
+        type: integer
+    title: Meta
+    type: object
+additionalProperties: true
+properties:
+  _meta:
+    $ref: "#/$defs/Meta"
+    default:
+      op: u
+      row_id: -1
+    description: Document metadata
+  id:
+    title: Id
+    type: integer
+  updated_at:
+    format: date-time
+    title: Updated At
+    type: string
+required:
+  - id
+  - updated_at
+title: TimestampedResource
+type: object
+x-infer-schema: true

--- a/source-zendesk-support-native/acmeCo/post_comment_votes.schema.yaml
+++ b/source-zendesk-support-native/acmeCo/post_comment_votes.schema.yaml
@@ -1,0 +1,36 @@
+---
+$defs:
+  Meta:
+    properties:
+      op:
+        default: u
+        description: "Operation type (c: Create, u: Update, d: Delete)"
+        enum:
+          - c
+          - u
+          - d
+        title: Op
+        type: string
+      row_id:
+        default: -1
+        description: "Row ID of the Document, counting up from zero, or -1 if not known"
+        title: Row Id
+        type: integer
+    title: Meta
+    type: object
+additionalProperties: true
+properties:
+  _meta:
+    $ref: "#/$defs/Meta"
+    default:
+      op: u
+      row_id: -1
+    description: Document metadata
+  id:
+    title: Id
+    type: integer
+required:
+  - id
+title: ZendeskResource
+type: object
+x-infer-schema: true

--- a/source-zendesk-support-native/acmeCo/post_comments.schema.yaml
+++ b/source-zendesk-support-native/acmeCo/post_comments.schema.yaml
@@ -1,0 +1,36 @@
+---
+$defs:
+  Meta:
+    properties:
+      op:
+        default: u
+        description: "Operation type (c: Create, u: Update, d: Delete)"
+        enum:
+          - c
+          - u
+          - d
+        title: Op
+        type: string
+      row_id:
+        default: -1
+        description: "Row ID of the Document, counting up from zero, or -1 if not known"
+        title: Row Id
+        type: integer
+    title: Meta
+    type: object
+additionalProperties: true
+properties:
+  _meta:
+    $ref: "#/$defs/Meta"
+    default:
+      op: u
+      row_id: -1
+    description: Document metadata
+  id:
+    title: Id
+    type: integer
+required:
+  - id
+title: ZendeskResource
+type: object
+x-infer-schema: true

--- a/source-zendesk-support-native/acmeCo/post_votes.schema.yaml
+++ b/source-zendesk-support-native/acmeCo/post_votes.schema.yaml
@@ -1,0 +1,36 @@
+---
+$defs:
+  Meta:
+    properties:
+      op:
+        default: u
+        description: "Operation type (c: Create, u: Update, d: Delete)"
+        enum:
+          - c
+          - u
+          - d
+        title: Op
+        type: string
+      row_id:
+        default: -1
+        description: "Row ID of the Document, counting up from zero, or -1 if not known"
+        title: Row Id
+        type: integer
+    title: Meta
+    type: object
+additionalProperties: true
+properties:
+  _meta:
+    $ref: "#/$defs/Meta"
+    default:
+      op: u
+      row_id: -1
+    description: Document metadata
+  id:
+    title: Id
+    type: integer
+required:
+  - id
+title: ZendeskResource
+type: object
+x-infer-schema: true

--- a/source-zendesk-support-native/acmeCo/posts.schema.yaml
+++ b/source-zendesk-support-native/acmeCo/posts.schema.yaml
@@ -1,0 +1,41 @@
+---
+$defs:
+  Meta:
+    properties:
+      op:
+        default: u
+        description: "Operation type (c: Create, u: Update, d: Delete)"
+        enum:
+          - c
+          - u
+          - d
+        title: Op
+        type: string
+      row_id:
+        default: -1
+        description: "Row ID of the Document, counting up from zero, or -1 if not known"
+        title: Row Id
+        type: integer
+    title: Meta
+    type: object
+additionalProperties: true
+properties:
+  _meta:
+    $ref: "#/$defs/Meta"
+    default:
+      op: u
+      row_id: -1
+    description: Document metadata
+  id:
+    title: Id
+    type: integer
+  updated_at:
+    format: date-time
+    title: Updated At
+    type: string
+required:
+  - id
+  - updated_at
+title: TimestampedResource
+type: object
+x-infer-schema: true

--- a/source-zendesk-support-native/acmeCo/schedules.schema.yaml
+++ b/source-zendesk-support-native/acmeCo/schedules.schema.yaml
@@ -1,0 +1,31 @@
+---
+$defs:
+  Meta:
+    properties:
+      op:
+        default: u
+        description: "Operation type (c: Create, u: Update, d: Delete)"
+        enum:
+          - c
+          - u
+          - d
+        title: Op
+        type: string
+      row_id:
+        default: -1
+        description: "Row ID of the Document, counting up from zero, or -1 if not known"
+        title: Row Id
+        type: integer
+    title: Meta
+    type: object
+additionalProperties: true
+properties:
+  _meta:
+    $ref: "#/$defs/Meta"
+    default:
+      op: u
+      row_id: -1
+    description: Document metadata
+title: FullRefreshResource
+type: object
+x-infer-schema: true

--- a/source-zendesk-support-native/acmeCo/sla_policies.schema.yaml
+++ b/source-zendesk-support-native/acmeCo/sla_policies.schema.yaml
@@ -1,0 +1,31 @@
+---
+$defs:
+  Meta:
+    properties:
+      op:
+        default: u
+        description: "Operation type (c: Create, u: Update, d: Delete)"
+        enum:
+          - c
+          - u
+          - d
+        title: Op
+        type: string
+      row_id:
+        default: -1
+        description: "Row ID of the Document, counting up from zero, or -1 if not known"
+        title: Row Id
+        type: integer
+    title: Meta
+    type: object
+additionalProperties: true
+properties:
+  _meta:
+    $ref: "#/$defs/Meta"
+    default:
+      op: u
+      row_id: -1
+    description: Document metadata
+title: FullRefreshResource
+type: object
+x-infer-schema: true

--- a/source-zendesk-support-native/acmeCo/ticket_forms.schema.yaml
+++ b/source-zendesk-support-native/acmeCo/ticket_forms.schema.yaml
@@ -1,0 +1,41 @@
+---
+$defs:
+  Meta:
+    properties:
+      op:
+        default: u
+        description: "Operation type (c: Create, u: Update, d: Delete)"
+        enum:
+          - c
+          - u
+          - d
+        title: Op
+        type: string
+      row_id:
+        default: -1
+        description: "Row ID of the Document, counting up from zero, or -1 if not known"
+        title: Row Id
+        type: integer
+    title: Meta
+    type: object
+additionalProperties: true
+properties:
+  _meta:
+    $ref: "#/$defs/Meta"
+    default:
+      op: u
+      row_id: -1
+    description: Document metadata
+  id:
+    title: Id
+    type: integer
+  updated_at:
+    format: date-time
+    title: Updated At
+    type: string
+required:
+  - id
+  - updated_at
+title: TimestampedResource
+type: object
+x-infer-schema: true

--- a/source-zendesk-support-native/acmeCo/topics.schema.yaml
+++ b/source-zendesk-support-native/acmeCo/topics.schema.yaml
@@ -1,0 +1,41 @@
+---
+$defs:
+  Meta:
+    properties:
+      op:
+        default: u
+        description: "Operation type (c: Create, u: Update, d: Delete)"
+        enum:
+          - c
+          - u
+          - d
+        title: Op
+        type: string
+      row_id:
+        default: -1
+        description: "Row ID of the Document, counting up from zero, or -1 if not known"
+        title: Row Id
+        type: integer
+    title: Meta
+    type: object
+additionalProperties: true
+properties:
+  _meta:
+    $ref: "#/$defs/Meta"
+    default:
+      op: u
+      row_id: -1
+    description: Document metadata
+  id:
+    title: Id
+    type: integer
+  updated_at:
+    format: date-time
+    title: Updated At
+    type: string
+required:
+  - id
+  - updated_at
+title: TimestampedResource
+type: object
+x-infer-schema: true

--- a/source-zendesk-support-native/source_zendesk_support_native/api.py
+++ b/source-zendesk-support-native/source_zendesk_support_native/api.py
@@ -26,8 +26,8 @@ from .models import (
 
 CURSOR_PAGINATION_PAGE_SIZE = 100
 MAX_SATISFACTION_RATINGS_WINDOW_SIZE = timedelta(days=30)
-# Zendesk errors out if a start or end time parameter is more recent than 60 seconds in the past.
-TIME_PARAMETER_DELAY = timedelta(seconds=60)
+# Zendesk errors out if a start or end time parameter is 60 seconds or less in the past. 
+TIME_PARAMETER_DELAY = timedelta(seconds=61)
 
 DATETIME_STRING_FORMAT = "%Y-%m-%dT%H:%M:%SZ"
 

--- a/source-zendesk-support-native/source_zendesk_support_native/api.py
+++ b/source-zendesk-support-native/source_zendesk_support_native/api.py
@@ -9,6 +9,7 @@ from estuary_cdk.incremental_json_processor import IncrementalJsonProcessor
 
 from .models import (
     FullRefreshResource,
+    FullRefreshResponse,
     FullRefreshOffsetPaginatedResponse,
     FullRefreshCursorPaginatedResponse,
     ZendeskResource,
@@ -67,6 +68,23 @@ def _is_timestamp(string: str) -> bool:
         return True
     except ValueError:
         return False
+
+
+async def snapshot_resources(
+    http: HTTPSession,
+    subdomain: str,
+    path: str,
+    response_model: type[FullRefreshResponse],
+    log: Logger,
+) -> AsyncGenerator[FullRefreshResource, None]:
+    url = f"{url_base(subdomain)}/{path}"
+
+    response = response_model.model_validate_json(
+        await http.request(log, url)
+    )
+
+    for resource in response.resources:
+        yield resource
 
 
 async def snapshot_offset_paginated_resources(

--- a/source-zendesk-support-native/source_zendesk_support_native/models.py
+++ b/source-zendesk-support-native/source_zendesk_support_native/models.py
@@ -253,6 +253,10 @@ class GroupsResponse(ClientSideIncrementalCursorPaginatedResponse):
     resources: list[TimestampedResource] = Field(alias="groups")
 
 
+class GroupMembershipsResponse(ClientSideIncrementalCursorPaginatedResponse):
+    resources: list[TimestampedResource] = Field(alias="group_memberships")
+
+
 class MacrosResponse(ClientSideIncrementalCursorPaginatedResponse):
     resources: list[TimestampedResource] = Field(alias="macros")
 
@@ -266,6 +270,7 @@ class OrganizationMembershipsResponse(ClientSideIncrementalCursorPaginatedRespon
 CLIENT_SIDE_FILTERED_CURSOR_PAGINATED_RESOURCES: list[tuple[str, str, dict[str, str | int] | None, type[ClientSideIncrementalCursorPaginatedResponse]]] = [
     ("brands", "brands", None, BrandsResponse),
     ("groups", "groups", {"exclude_deleted": "false"}, GroupsResponse),
+    ("group_memberships", "group_memberships", None, GroupMembershipsResponse),
     ("macros", "macros", None, MacrosResponse),
     ("organization_memberships", "organization_memberships", None, OrganizationMembershipsResponse),
     ("ticket_fields", "ticket_fields", None, TicketFieldsResponse),

--- a/source-zendesk-support-native/source_zendesk_support_native/models.py
+++ b/source-zendesk-support-native/source_zendesk_support_native/models.py
@@ -152,7 +152,26 @@ INCREMENTAL_CURSOR_EXPORT_RESOURCES: list[INCREMENTAL_CURSOR_EXPORT_TYPES] = [
 ]
 
 
-class FullRefreshCursorPaginatedResponse(BaseModel, extra="allow"):
+class FullRefreshResponse(BaseModel, extra="allow"):
+    resources: list[FullRefreshResource]
+
+
+class FullRefreshOffsetPaginatedResponse(FullRefreshResponse):
+    next_page: str | None
+
+
+class SlaPoliciesResponse(FullRefreshOffsetPaginatedResponse):
+    resources: list[FullRefreshResource] = Field(alias="sla_policies")
+
+
+# Full refresh resources that paginted with page offsets.
+# Tuples contain the name, path, and response model for each resource.
+FULL_REFRESH_OFFSET_PAGINATED_RESOURCES: list[tuple[str, str, type[FullRefreshOffsetPaginatedResponse]]] = [
+    ("sla_policies", "slas/policies", SlaPoliciesResponse),
+]
+
+
+class FullRefreshCursorPaginatedResponse(FullRefreshResponse):
     class Meta(BaseModel, extra="forbid"):
         has_more: bool
         after_cursor: str | None

--- a/source-zendesk-support-native/source_zendesk_support_native/models.py
+++ b/source-zendesk-support-native/source_zendesk_support_native/models.py
@@ -355,8 +355,13 @@ class PostVotesResponse(IncrementalCursorPaginatedResponse):
     resources: list[ZendeskResource] = Field(alias="votes")
 
 
+class PostComment(ZendeskResource):
+    post_id: int
+    vote_count: int
+
+
 class PostCommentsResponse(IncrementalCursorPaginatedResponse):
-    resources: list[ZendeskResource] = Field(alias="comments")
+    resources: list[PostComment] = Field(alias="comments")
 
 
 # Resources that are fetched by following the posts stream & fetching resources for updated posts in a separate request.
@@ -373,3 +378,7 @@ class AuditLog(ZendeskResource):
 
 class AuditLogsResponse(FullRefreshCursorPaginatedResponse):
     resources: list[AuditLog] = Field(alias="audit_logs")
+
+
+class PostCommentVotesResponse(PostVotesResponse):
+    pass

--- a/source-zendesk-support-native/source_zendesk_support_native/models.py
+++ b/source-zendesk-support-native/source_zendesk_support_native/models.py
@@ -189,6 +189,10 @@ class FullRefreshOffsetPaginatedResponse(FullRefreshResponse):
     next_page: str | None
 
 
+class AccountAttributesResponse(FullRefreshOffsetPaginatedResponse):
+    resources: list[FullRefreshResource] = Field(alias="attributes")
+
+
 class SlaPoliciesResponse(FullRefreshOffsetPaginatedResponse):
     resources: list[FullRefreshResource] = Field(alias="sla_policies")
 
@@ -196,7 +200,8 @@ class SlaPoliciesResponse(FullRefreshOffsetPaginatedResponse):
 # Full refresh resources that paginted with page offsets.
 # Tuples contain the name, path, and response model for each resource.
 FULL_REFRESH_OFFSET_PAGINATED_RESOURCES: list[tuple[str, str, type[FullRefreshOffsetPaginatedResponse]]] = [
-    ("sla_policies", "slas/policies", SlaPoliciesResponse),
+        ("account_attributes", "routing/attributes", AccountAttributesResponse),
+        ("sla_policies", "slas/policies", SlaPoliciesResponse),
 ]
 
 

--- a/source-zendesk-support-native/source_zendesk_support_native/models.py
+++ b/source-zendesk-support-native/source_zendesk_support_native/models.py
@@ -237,6 +237,26 @@ TICKET_CHILD_RESOURCES: list[tuple[str, str, type[IncrementalCursorPaginatedResp
 ]
 
 
+class ClientSideIncrementalOffsetPaginatedResponse(FullRefreshOffsetPaginatedResponse):
+    resources: list[TimestampedResource]
+
+
+class CustomRolesResponse(ClientSideIncrementalOffsetPaginatedResponse):
+    resources: list[TimestampedResource] = Field(alias="custom_roles")
+
+
+class TicketFormsResponse(ClientSideIncrementalOffsetPaginatedResponse):
+    resources: list[TimestampedResource] = Field(alias="ticket_forms")
+
+
+# Incremental client side resources that are paginated with page offsets.
+# Tuples contain the name, path, and response model for each resource.
+CLIENT_SIDE_FILTERED_OFFSET_PAGINATED_RESOURCES: list[tuple[str, str, type[ClientSideIncrementalOffsetPaginatedResponse]]] = [
+    ("custom_roles", "custom_roles", CustomRolesResponse),
+    ("ticket_forms", "ticket_forms", TicketFormsResponse),
+]
+
+
 class ClientSideIncrementalCursorPaginatedResponse(FullRefreshCursorPaginatedResponse):
     resources: list[TimestampedResource]
 

--- a/source-zendesk-support-native/source_zendesk_support_native/models.py
+++ b/source-zendesk-support-native/source_zendesk_support_native/models.py
@@ -156,6 +156,17 @@ class FullRefreshResponse(BaseModel, extra="allow"):
     resources: list[FullRefreshResource]
 
 
+class SchedulesResponse(FullRefreshResponse):
+    resources: list[FullRefreshResource] = Field(alias="schedules")
+
+
+# Full refresh resources with no pagination.
+# Tuples contain the name, path, and response model for each resource.
+FULL_REFRESH_RESOURCES: list[tuple[str, str, type[FullRefreshResponse]]] = [
+    ("schedules", "business_hours/schedules", SchedulesResponse),
+]
+
+
 class FullRefreshOffsetPaginatedResponse(FullRefreshResponse):
     next_page: str | None
 

--- a/source-zendesk-support-native/source_zendesk_support_native/models.py
+++ b/source-zendesk-support-native/source_zendesk_support_native/models.py
@@ -130,6 +130,24 @@ class TimestampedResource(ZendeskResource):
     updated_at: AwareDatetime
 
 
+class IncrementalTimeExportResponse(BaseModel, extra="allow"):
+    next_page: str | None
+    count: int
+    end_of_stream: bool
+    end_time: int | None
+    resources: list[TimestampedResource]
+
+
+class OrganizationsResponse(IncrementalTimeExportResponse):
+    resources: list[TimestampedResource] = Field(alias="organizations")
+
+# Incremental time based export resources.
+# Tuples contain the name, path, and response model for each resource.
+INCREMENTAL_TIME_EXPORT_RESOURCES: list[tuple[str, str, type[IncrementalTimeExportResponse]]] = [
+    ("organizations", "organizations", OrganizationsResponse),
+]
+
+
 class IncrementalCursorExportResponse(BaseModel, extra="allow"):
     after_cursor: str | None
     end_of_stream: bool

--- a/source-zendesk-support-native/source_zendesk_support_native/models.py
+++ b/source-zendesk-support-native/source_zendesk_support_native/models.py
@@ -290,6 +290,10 @@ class ClientSideIncrementalCursorPaginatedResponse(FullRefreshCursorPaginatedRes
     resources: list[TimestampedResource]
 
 
+class AutomationsResponse(ClientSideIncrementalCursorPaginatedResponse):
+    resources: list[TimestampedResource] = Field(alias="automations")
+
+
 class BrandsResponse(ClientSideIncrementalCursorPaginatedResponse):
     resources: list[TimestampedResource] = Field(alias="brands")
 
@@ -314,15 +318,26 @@ class OrganizationMembershipsResponse(ClientSideIncrementalCursorPaginatedRespon
     resources: list[TimestampedResource] = Field(alias="organization_memberships")
 
 
+class PostsResponse(ClientSideIncrementalCursorPaginatedResponse):
+    resources: list[TimestampedResource] = Field(alias="posts")
+
+
+class TopicsResponse(ClientSideIncrementalCursorPaginatedResponse):
+    resources: list[TimestampedResource] = Field(alias="topics")
+
+
 # Incremental client side resources that are paginated with a cursor.
 # Tuples contain the name, path, any additional request query params, and response model for each resource.
 CLIENT_SIDE_FILTERED_CURSOR_PAGINATED_RESOURCES: list[tuple[str, str, dict[str, str | int] | None, type[ClientSideIncrementalCursorPaginatedResponse]]] = [
+    ("automations", "automations", None, AutomationsResponse),
     ("brands", "brands", None, BrandsResponse),
     ("groups", "groups", {"exclude_deleted": "false"}, GroupsResponse),
     ("group_memberships", "group_memberships", None, GroupMembershipsResponse),
     ("macros", "macros", None, MacrosResponse),
     ("organization_memberships", "organization_memberships", None, OrganizationMembershipsResponse),
+    ("posts", "community/posts", None, PostsResponse),
     ("ticket_fields", "ticket_fields", None, TicketFieldsResponse),
+    ("topics", "community/topics", None, TopicsResponse),
 ]
 
 

--- a/source-zendesk-support-native/source_zendesk_support_native/models.py
+++ b/source-zendesk-support-native/source_zendesk_support_native/models.py
@@ -323,8 +323,13 @@ class OrganizationMembershipsResponse(ClientSideIncrementalCursorPaginatedRespon
     resources: list[TimestampedResource] = Field(alias="organization_memberships")
 
 
+class Post(TimestampedResource):
+    comment_count: int
+    vote_count: int
+
+
 class PostsResponse(ClientSideIncrementalCursorPaginatedResponse):
-    resources: list[TimestampedResource] = Field(alias="posts")
+    resources: list[Post] = Field(alias="posts")
 
 
 class TopicsResponse(ClientSideIncrementalCursorPaginatedResponse):
@@ -343,6 +348,22 @@ CLIENT_SIDE_FILTERED_CURSOR_PAGINATED_RESOURCES: list[tuple[str, str, dict[str, 
     ("posts", "community/posts", None, PostsResponse),
     ("ticket_fields", "ticket_fields", None, TicketFieldsResponse),
     ("topics", "community/topics", None, TopicsResponse),
+]
+
+
+class PostVotesResponse(IncrementalCursorPaginatedResponse):
+    resources: list[ZendeskResource] = Field(alias="votes")
+
+
+class PostCommentsResponse(IncrementalCursorPaginatedResponse):
+    resources: list[ZendeskResource] = Field(alias="comments")
+
+
+# Resources that are fetched by following the posts stream & fetching resources for updated posts in a separate request.
+# Tuples contain the name, path segment, and response model for each resource.
+POST_CHILD_RESOURCES: list[tuple[str, str, type[IncrementalCursorPaginatedResponse]]] = [
+    ("post_votes", "votes", PostVotesResponse),
+    ("post_comments", "comments", PostCommentsResponse),
 ]
 
 

--- a/source-zendesk-support-native/source_zendesk_support_native/resources.py
+++ b/source-zendesk-support-native/source_zendesk_support_native/resources.py
@@ -216,7 +216,7 @@ def full_refresh_resources(
             open=functools.partial(open, path, response_model),
             initial_state=ResourceState(),
             initial_config=ResourceConfig(
-                name=name, interval=timedelta(minutes=5)
+                name=name, interval=timedelta(minutes=60)
             ),
             schema_inference=True,
         )
@@ -262,7 +262,7 @@ def full_refresh_offset_paginated_resources(
             open=functools.partial(open, path, response_model),
             initial_state=ResourceState(),
             initial_config=ResourceConfig(
-                name=name, interval=timedelta(minutes=5)
+                name=name, interval=timedelta(minutes=60)
             ),
             schema_inference=True,
         )
@@ -291,11 +291,11 @@ def full_refresh_cursor_paginated_resources(
             state,
             task,
             fetch_snapshot=functools.partial(
-            snapshot_cursor_paginated_resources,
-            http,
-            config.subdomain,
-            path,
-            response_model,
+                snapshot_cursor_paginated_resources,
+                http,
+                config.subdomain,
+                path,
+                response_model,
         ),
             tombstone=FullRefreshResource(_meta=FullRefreshResource.Meta(op="d"))
         )
@@ -308,7 +308,7 @@ def full_refresh_cursor_paginated_resources(
             open=functools.partial(open, path, response_model),
             initial_state=ResourceState(),
             initial_config=ResourceConfig(
-                name=name, interval=timedelta(minutes=5)
+                name=name, interval=timedelta(minutes=60)
             ),
             schema_inference=True,
         )
@@ -357,7 +357,7 @@ def client_side_filtered_offset_paginated_resources(
                 inc=ResourceState.Incremental(cursor=EPOCH)
             ),
             initial_config=ResourceConfig(
-                name=name, interval=timedelta(minutes=5)
+                name=name, interval=timedelta(minutes=30)
             ),
             schema_inference=True,
         )
@@ -408,7 +408,7 @@ def client_side_filtered_cursor_paginated_resources(
                 inc=ResourceState.Incremental(cursor=EPOCH)
             ),
             initial_config=ResourceConfig(
-                name=name, interval=timedelta(minutes=5)
+                name=name, interval=timedelta(minutes=15)
             ),
             schema_inference=True,
         )
@@ -745,7 +745,7 @@ def post_child_resources(
                 inc=ResourceState.Incremental(cursor=config.start_date),
             ),
             initial_config=ResourceConfig(
-                name=name, interval=timedelta(minutes=5)
+                name=name, interval=timedelta(minutes=30)
             ),
             schema_inference=True,
         )
@@ -787,7 +787,7 @@ def post_comment_votes(
             inc=ResourceState.Incremental(cursor=config.start_date),
         ),
         initial_config=ResourceConfig(
-            name="post_comment_votes", interval=timedelta(minutes=5)
+            name="post_comment_votes", interval=timedelta(minutes=30)
         ),
         schema_inference=True,
     )

--- a/source-zendesk-support-native/source_zendesk_support_native/resources.py
+++ b/source-zendesk-support-native/source_zendesk_support_native/resources.py
@@ -11,6 +11,7 @@ from .models import (
     AuditLog,
     ClientSideIncrementalCursorPaginatedResponse,
     EndpointConfig,
+    FullRefreshOffsetPaginatedResponse,
     FullRefreshCursorPaginatedResponse,
     FullRefreshResource,
     IncrementalCursorPaginatedResponse,
@@ -20,6 +21,7 @@ from .models import (
     ZendeskResource,
     EPOCH,
     CLIENT_SIDE_FILTERED_CURSOR_PAGINATED_RESOURCES,
+    FULL_REFRESH_OFFSET_PAGINATED_RESOURCES,
     FULL_REFRESH_CURSOR_PAGINATED_RESOURCES,
     INCREMENTAL_CURSOR_EXPORT_RESOURCES,
     INCREMENTAL_CURSOR_EXPORT_TYPES,
@@ -41,6 +43,7 @@ from .api import (
     fetch_satisfaction_ratings,
     fetch_ticket_child_resources,
     fetch_ticket_metrics,
+    snapshot_offset_paginated_resources,
     snapshot_cursor_paginated_resources,
     url_base,
     _dt_to_s,
@@ -162,6 +165,52 @@ def ticket_metrics(
         ),
         schema_inference=True,
     )
+
+
+def full_refresh_offset_paginated_resources(
+        log: Logger, http: HTTPMixin, config: EndpointConfig
+) -> list[common.Resource]:
+
+    def open(
+            path: str,
+            response_model: type[FullRefreshOffsetPaginatedResponse],
+            binding: CaptureBinding[ResourceConfig],
+            binding_index: int,
+            state: ResourceState,
+            task: Task,
+            all_bindings
+    ):
+        common.open_binding(
+            binding,
+            binding_index,
+            state,
+            task,
+            fetch_snapshot=functools.partial(
+                snapshot_offset_paginated_resources,
+                http,
+                config.subdomain,
+                path,
+                response_model,
+            ),
+            tombstone=FullRefreshResource(_meta=FullRefreshResource.Meta(op="d"))
+        )
+
+    resources = [
+        common.Resource(
+            name=name,
+            key=["/_meta/row_id"],
+            model=FullRefreshResource,
+            open=functools.partial(open, path, response_model),
+            initial_state=ResourceState(),
+            initial_config=ResourceConfig(
+                name=name, interval=timedelta(minutes=5)
+            ),
+            schema_inference=True,
+        )
+        for (name, path, response_model) in FULL_REFRESH_OFFSET_PAGINATED_RESOURCES
+    ]
+
+    return resources
 
 
 def full_refresh_cursor_paginated_resources(
@@ -499,6 +548,7 @@ async def all_resources(
     return [
         audit_logs(log, http, config),
         ticket_metrics(log, http, config),
+        *full_refresh_offset_paginated_resources(log, http, config),
         *full_refresh_cursor_paginated_resources(log, http, config),
         *client_side_filtered_cursor_paginated_resources(log, http, config),
         satisfaction_ratings(log, http, config),

--- a/source-zendesk-support-native/test.flow.yaml
+++ b/source-zendesk-support-native/test.flow.yaml
@@ -28,6 +28,14 @@ captures:
           interval: PT5M
         target: acmeCo/tags
       - resource:
+          name: custom_roles
+          interval: PT5M
+        target: acmeCo/custom_roles
+      - resource:
+          name: ticket_forms
+          interval: PT5M
+        target: acmeCo/ticket_forms
+      - resource:
           name: brands
           interval: PT5M
         target: acmeCo/brands

--- a/source-zendesk-support-native/test.flow.yaml
+++ b/source-zendesk-support-native/test.flow.yaml
@@ -36,6 +36,10 @@ captures:
           interval: PT5M
         target: acmeCo/groups
       - resource:
+          name: group_memberships
+          interval: PT5M
+        target: acmeCo/group_memberships
+      - resource:
           name: macros
           interval: PT5M
         target: acmeCo/macros

--- a/source-zendesk-support-native/test.flow.yaml
+++ b/source-zendesk-support-native/test.flow.yaml
@@ -21,63 +21,63 @@ captures:
         target: acmeCo/ticket_metrics
       - resource:
           name: schedules
-          interval: PT5M
+          interval: PT1H
         target: acmeCo/schedules
       - resource:
           name: account_attributes
-          interval: PT5M
+          interval: PT1H
         target: acmeCo/account_attributes
       - resource:
           name: sla_policies
-          interval: PT5M
+          interval: PT1H
         target: acmeCo/sla_policies
       - resource:
           name: tags
-          interval: PT5M
+          interval: PT1H
         target: acmeCo/tags
       - resource:
           name: custom_roles
-          interval: PT5M
+          interval: PT30M
         target: acmeCo/custom_roles
       - resource:
           name: ticket_forms
-          interval: PT5M
+          interval: PT30M
         target: acmeCo/ticket_forms
       - resource:
           name: automations
-          interval: PT5M
+          interval: PT15M
         target: acmeCo/automations
       - resource:
           name: brands
-          interval: PT5M
+          interval: PT15M
         target: acmeCo/brands
       - resource:
           name: groups
-          interval: PT5M
+          interval: PT15M
         target: acmeCo/groups
       - resource:
           name: group_memberships
-          interval: PT5M
+          interval: PT15M
         target: acmeCo/group_memberships
       - resource:
           name: macros
-          interval: PT5M
+          interval: PT15M
         target: acmeCo/macros
       - resource:
           name: organization_memberships
-          interval: PT5M
+          interval: PT15M
         target: acmeCo/organization_memberships
       - resource:
           name: posts
-          interval: PT5M
+          interval: PT15M
         target: acmeCo/posts
       - resource:
           name: ticket_fields
-          interval: PT5M
+          interval: PT15M
         target: acmeCo/ticket_fields
       - resource:
           name: topics
-          interval: PT5M
+          interval: PT15M
         target: acmeCo/topics
       - resource:
           name: satisfaction_ratings
@@ -113,13 +113,13 @@ captures:
         target: acmeCo/ticket_comments
       - resource:
           name: post_votes
-          interval: PT5M
+          interval: PT30M
         target: acmeCo/post_votes
       - resource:
           name: post_comments
-          interval: PT5M
+          interval: PT30M
         target: acmeCo/post_comments
       - resource:
           name: post_comment_votes
-          interval: PT5M
+          interval: PT30M
         target: acmeCo/post_comment_votes

--- a/source-zendesk-support-native/test.flow.yaml
+++ b/source-zendesk-support-native/test.flow.yaml
@@ -20,6 +20,10 @@ captures:
           interval: PT5M
         target: acmeCo/ticket_metrics
       - resource:
+          name: sla_policies
+          interval: PT5M
+        target: acmeCo/sla_policies
+      - resource:
           name: tags
           interval: PT5M
         target: acmeCo/tags

--- a/source-zendesk-support-native/test.flow.yaml
+++ b/source-zendesk-support-native/test.flow.yaml
@@ -24,6 +24,10 @@ captures:
           interval: PT5M
         target: acmeCo/schedules
       - resource:
+          name: account_attributes
+          interval: PT5M
+        target: acmeCo/account_attributes
+      - resource:
           name: sla_policies
           interval: PT5M
         target: acmeCo/sla_policies

--- a/source-zendesk-support-native/test.flow.yaml
+++ b/source-zendesk-support-native/test.flow.yaml
@@ -20,6 +20,10 @@ captures:
           interval: PT5M
         target: acmeCo/ticket_metrics
       - resource:
+          name: schedules
+          interval: PT5M
+        target: acmeCo/schedules
+      - resource:
           name: sla_policies
           interval: PT5M
         target: acmeCo/sla_policies

--- a/source-zendesk-support-native/test.flow.yaml
+++ b/source-zendesk-support-native/test.flow.yaml
@@ -111,3 +111,11 @@ captures:
           name: ticket_comments
           interval: PT5M
         target: acmeCo/ticket_comments
+      - resource:
+          name: post_votes
+          interval: PT5M
+        target: acmeCo/post_votes
+      - resource:
+          name: post_comments
+          interval: PT5M
+        target: acmeCo/post_comments

--- a/source-zendesk-support-native/test.flow.yaml
+++ b/source-zendesk-support-native/test.flow.yaml
@@ -40,6 +40,10 @@ captures:
           interval: PT5M
         target: acmeCo/ticket_forms
       - resource:
+          name: automations
+          interval: PT5M
+        target: acmeCo/automations
+      - resource:
           name: brands
           interval: PT5M
         target: acmeCo/brands
@@ -60,9 +64,17 @@ captures:
           interval: PT5M
         target: acmeCo/organization_memberships
       - resource:
+          name: posts
+          interval: PT5M
+        target: acmeCo/posts
+      - resource:
           name: ticket_fields
           interval: PT5M
         target: acmeCo/ticket_fields
+      - resource:
+          name: topics
+          interval: PT5M
+        target: acmeCo/topics
       - resource:
           name: satisfaction_ratings
           interval: PT5M

--- a/source-zendesk-support-native/test.flow.yaml
+++ b/source-zendesk-support-native/test.flow.yaml
@@ -76,6 +76,10 @@ captures:
           interval: PT5M
         target: acmeCo/ticket_metric_events
       - resource:
+          name: organizations
+          interval: PT5M
+        target: acmeCo/organizations
+      - resource:
           name: tickets
           interval: PT5M
         target: acmeCo/tickets

--- a/source-zendesk-support-native/test.flow.yaml
+++ b/source-zendesk-support-native/test.flow.yaml
@@ -119,3 +119,7 @@ captures:
           name: post_comments
           interval: PT5M
         target: acmeCo/post_comments
+      - resource:
+          name: post_comment_votes
+          interval: PT5M
+        target: acmeCo/post_comment_votes

--- a/source-zendesk-support-native/tests/snapshots/snapshots__capture__capture.stdout.json
+++ b/source-zendesk-support-native/tests/snapshots/snapshots__capture__capture.stdout.json
@@ -265,6 +265,24 @@
     }
   ],
   [
+    "acmeCo/post_comment_votes",
+    {
+      "_meta": {
+        "uuid": "DocUUIDPlaceholder-329Bb50aa48EAa9ef",
+        "row_id": 0
+      },
+      "created_at": "2024-08-01T13:19:33Z",
+      "id": 29005807715092,
+      "item_id": 29005581511700,
+      "item_type": "PostComment",
+      "post_id": 28847424303764,
+      "updated_at": "redacted",
+      "url": "https://d3v-estuary.zendesk.com/api/v2/help_center/votes/29005807715092.json",
+      "user_id": 28835702984212,
+      "value": 1
+    }
+  ],
+  [
     "acmeCo/post_comments",
     {
       "_meta": {

--- a/source-zendesk-support-native/tests/snapshots/snapshots__capture__capture.stdout.json
+++ b/source-zendesk-support-native/tests/snapshots/snapshots__capture__capture.stdout.json
@@ -206,6 +206,43 @@
     }
   ],
   [
+    "acmeCo/schedules",
+    {
+      "_meta": {
+        "op": "c",
+        "row_id": 0,
+        "uuid": "DocUUIDPlaceholder-329Bb50aa48EAa9ef"
+      },
+      "created_at": "2024-08-01T13:29:59Z",
+      "id": 29006094707860,
+      "intervals": [
+        {
+          "end_time": 2460,
+          "start_time": 1980
+        },
+        {
+          "end_time": 3900,
+          "start_time": 3420
+        },
+        {
+          "end_time": 5340,
+          "start_time": 4860
+        },
+        {
+          "end_time": 6780,
+          "start_time": 6300
+        },
+        {
+          "end_time": 8220,
+          "start_time": 7740
+        }
+      ],
+      "name": "Test schedule",
+      "time_zone": "Eastern Time (US & Canada)",
+      "updated_at": "redacted"
+    }
+  ],
+  [
     "acmeCo/sla_policies",
     {
       "_meta": {

--- a/source-zendesk-support-native/tests/snapshots/snapshots__capture__capture.stdout.json
+++ b/source-zendesk-support-native/tests/snapshots/snapshots__capture__capture.stdout.json
@@ -27,6 +27,82 @@
     }
   ],
   [
+    "acmeCo/custom_roles",
+    {
+      "_meta": {
+        "uuid": "DocUUIDPlaceholder-329Bb50aa48EAa9ef",
+        "row_id": 0
+      },
+      "configuration": {
+        "assign_agent_statuses": false,
+        "assign_tickets_to_any_group": false,
+        "chat_access": false,
+        "custom_objects": {},
+        "end_user_list_access": "full",
+        "end_user_profile_access": "readonly",
+        "explore_access": "readonly",
+        "explore_reports": {
+          "ticket_access": "all",
+          "ticket_access_selected_groups": []
+        },
+        "forum_access": "readonly",
+        "forum_access_restricted_content": false,
+        "group_access": false,
+        "light_agent": true,
+        "macro_access": "readonly",
+        "manage_automations": false,
+        "manage_business_rules": false,
+        "manage_contextual_workspaces": false,
+        "manage_deletion_schedules": "none",
+        "manage_dynamic_content": false,
+        "manage_extensions_and_channels": false,
+        "manage_facebook": false,
+        "manage_group_memberships": false,
+        "manage_groups": false,
+        "manage_macro_content_suggestions": false,
+        "manage_malicious_attachments": false,
+        "manage_organization_fields": false,
+        "manage_organizations": false,
+        "manage_roles": "none",
+        "manage_skills": false,
+        "manage_slas": false,
+        "manage_suspended_tickets": false,
+        "manage_ticket_fields": false,
+        "manage_ticket_forms": false,
+        "manage_triggers": false,
+        "manage_user_fields": false,
+        "moderate_forums": false,
+        "organization_editing": false,
+        "organization_notes_editing": false,
+        "read_macro_content_suggestions": false,
+        "report_access": "readonly",
+        "side_conversation_create": true,
+        "ticket_access": "within-groups",
+        "ticket_comment_access": "none",
+        "ticket_deletion": false,
+        "ticket_editing": false,
+        "ticket_merge": false,
+        "ticket_redaction": false,
+        "ticket_tag_editing": false,
+        "twitter_search_access": false,
+        "user_view_access": "none",
+        "view_access": "readonly",
+        "view_deleted_tickets": false,
+        "view_filter_tickets": true,
+        "view_reduced_count": false,
+        "voice_access": false,
+        "voice_dashboard_access": false
+      },
+      "created_at": "2024-07-26T15:40:56Z",
+      "description": "Can view and add private comments to tickets",
+      "id": 28835714382484,
+      "name": "Light agent",
+      "role_type": 1,
+      "team_member_count": 0,
+      "updated_at": "redacted"
+    }
+  ],
+  [
     "acmeCo/group_memberships",
     {
       "_meta": {
@@ -387,6 +463,42 @@
       "updated_at": "redacted",
       "url": "https://d3v-estuary.zendesk.com/api/v2/ticket_fields/28835714573076.json",
       "visible_in_portal": true
+    }
+  ],
+  [
+    "acmeCo/ticket_forms",
+    {
+      "_meta": {
+        "uuid": "DocUUIDPlaceholder-329Bb50aa48EAa9ef",
+        "row_id": 0
+      },
+      "active": true,
+      "agent_conditions": [],
+      "created_at": "2024-07-26T15:40:58Z",
+      "default": true,
+      "display_name": "Default Ticket Form",
+      "end_user_conditions": [],
+      "end_user_visible": true,
+      "id": 28835740693908,
+      "in_all_brands": true,
+      "name": "Default Ticket Form",
+      "position": 0,
+      "raw_display_name": "Default Ticket Form",
+      "raw_name": "Default Ticket Form",
+      "restricted_brand_ids": [],
+      "ticket_field_ids": [
+        28835714573076,
+        28835740681620,
+        28835740683540,
+        28835740685844,
+        28835714576020,
+        28835740687508,
+        28835740688660,
+        28835714575124,
+        28835767646868
+      ],
+      "updated_at": "redacted",
+      "url": "https://d3v-estuary.zendesk.com/api/v2/ticket_forms/28835740693908.json"
     }
   ],
   [

--- a/source-zendesk-support-native/tests/snapshots/snapshots__capture__capture.stdout.json
+++ b/source-zendesk-support-native/tests/snapshots/snapshots__capture__capture.stdout.json
@@ -1,5 +1,44 @@
 [
   [
+    "acmeCo/automations",
+    {
+      "_meta": {
+        "uuid": "DocUUIDPlaceholder-329Bb50aa48EAa9ef",
+        "row_id": 0
+      },
+      "actions": [
+        {
+          "field": "status",
+          "value": "closed"
+        }
+      ],
+      "active": true,
+      "conditions": {
+        "all": [
+          {
+            "field": "status",
+            "operator": "is",
+            "value": "solved"
+          },
+          {
+            "field": "SOLVED",
+            "operator": "greater_than",
+            "value": "72"
+          }
+        ],
+        "any": []
+      },
+      "created_at": "2024-07-26T15:41:01Z",
+      "default": true,
+      "id": 28835714782868,
+      "position": 0,
+      "raw_title": "Close ticket 3 days after status is set to solved",
+      "title": "Close ticket 3 days after status is set to solved",
+      "updated_at": "redacted",
+      "url": "https://d3v-estuary.zendesk.com/api/v2/automations/28835714782868.json"
+    }
+  ],
+  [
     "acmeCo/brands",
     {
       "_meta": {
@@ -208,6 +247,36 @@
       ],
       "updated_at": "redacted",
       "url": "https://d3v-estuary.zendesk.com/api/v2/organizations/28835714737428.json"
+    }
+  ],
+  [
+    "acmeCo/posts",
+    {
+      "_meta": {
+        "uuid": "DocUUIDPlaceholder-329Bb50aa48EAa9ef",
+        "row_id": 0
+      },
+      "author_id": 28835702984212,
+      "closed": false,
+      "comment_count": 2,
+      "content_tag_ids": [],
+      "created_at": "2024-07-26T20:41:46Z",
+      "details": "<p>You can add a topic like this one in your community. End users can add feature requests and describe their use cases. Other users can comment on the requests and vote for them. Product managers can review feature requests and provide feedback.</p>",
+      "featured": false,
+      "follower_count": 1,
+      "frozen": false,
+      "html_url": "https://d3v-estuary.zendesk.com/hc/en-us/community/posts/28847424303764-I-d-like-a-way-for-users-to-submit-feature-requests",
+      "id": 28847424303764,
+      "non_author_editor_id": null,
+      "non_author_updated_at": null,
+      "pinned": false,
+      "status": "none",
+      "title": "I'd like a way for users to submit feature requests",
+      "topic_id": 28847452157844,
+      "updated_at": "redacted",
+      "url": "https://d3v-estuary.zendesk.com/api/v2/help_center/community/posts/28847424303764-I-d-like-a-way-for-users-to-submit-feature-requests.json",
+      "vote_count": 1,
+      "vote_sum": 1
     }
   ],
   [
@@ -780,6 +849,27 @@
           "to": {}
         }
       }
+    }
+  ],
+  [
+    "acmeCo/topics",
+    {
+      "_meta": {
+        "uuid": "DocUUIDPlaceholder-329Bb50aa48EAa9ef",
+        "row_id": 0
+      },
+      "community_id": 28847452144020,
+      "created_at": "2024-07-26T20:41:45Z",
+      "description": null,
+      "follower_count": 1,
+      "html_url": "https://d3v-estuary.zendesk.com/hc/en-us/community/topics/28847452144788-General-Discussion",
+      "id": 28847452144788,
+      "manageable_by": "managers",
+      "name": "General Discussion",
+      "position": 0,
+      "updated_at": "redacted",
+      "url": "https://d3v-estuary.zendesk.com/api/v2/help_center/community/topics/28847452144788.json",
+      "user_segment_id": null
     }
   ],
   [

--- a/source-zendesk-support-native/tests/snapshots/snapshots__capture__capture.stdout.json
+++ b/source-zendesk-support-native/tests/snapshots/snapshots__capture__capture.stdout.json
@@ -1,5 +1,20 @@
 [
   [
+    "acmeCo/account_attributes",
+    {
+      "_meta": {
+        "op": "c",
+        "row_id": 0,
+        "uuid": "DocUUIDPlaceholder-329Bb50aa48EAa9ef"
+      },
+      "created_at": "2024-08-01T12:48:41Z",
+      "id": "6149ea30-5004-11ef-ba4d-1fb32c16a1d3",
+      "name": "Test attribute",
+      "updated_at": "redacted",
+      "url": "https://d3v-estuary.zendesk.com/api/v2/routing/attributes/6149ea30-5004-11ef-ba4d-1fb32c16a1d3.json"
+    }
+  ],
+  [
     "acmeCo/automations",
     {
       "_meta": {

--- a/source-zendesk-support-native/tests/snapshots/snapshots__capture__capture.stdout.json
+++ b/source-zendesk-support-native/tests/snapshots/snapshots__capture__capture.stdout.json
@@ -265,6 +265,46 @@
     }
   ],
   [
+    "acmeCo/post_comments",
+    {
+      "_meta": {
+        "uuid": "DocUUIDPlaceholder-329Bb50aa48EAa9ef",
+        "row_id": 0
+      },
+      "author_id": 28835702984212,
+      "body": "A test post comment.",
+      "created_at": "2024-08-01T13:10:11Z",
+      "html_url": "https://d3v-estuary.zendesk.com/hc/en-us/community/posts/28847424303764-I-d-like-a-way-for-users-to-submit-feature-requests/comments/29005581511700",
+      "id": 29005581511700,
+      "non_author_editor_id": null,
+      "non_author_updated_at": null,
+      "official": false,
+      "post_id": 28847424303764,
+      "updated_at": "redacted",
+      "url": "https://d3v-estuary.zendesk.com/api/v2/help_center/community/posts/28847424303764/comments/29005581511700.json",
+      "vote_count": 1,
+      "vote_sum": 1
+    }
+  ],
+  [
+    "acmeCo/post_votes",
+    {
+      "_meta": {
+        "uuid": "DocUUIDPlaceholder-329Bb50aa48EAa9ef",
+        "row_id": 0
+      },
+      "created_at": "2024-08-01T13:15:00Z",
+      "id": 29005734783508,
+      "item_id": 28847424303764,
+      "item_type": "Post",
+      "post_id": 28847424303764,
+      "updated_at": "redacted",
+      "url": "https://d3v-estuary.zendesk.com/api/v2/help_center/votes/29005734783508.json",
+      "user_id": 28835702984212,
+      "value": 1
+    }
+  ],
+  [
     "acmeCo/posts",
     {
       "_meta": {

--- a/source-zendesk-support-native/tests/snapshots/snapshots__capture__capture.stdout.json
+++ b/source-zendesk-support-native/tests/snapshots/snapshots__capture__capture.stdout.json
@@ -114,6 +114,78 @@
     }
   ],
   [
+    "acmeCo/sla_policies",
+    {
+      "_meta": {
+        "op": "c",
+        "row_id": 0,
+        "uuid": "DocUUIDPlaceholder-329Bb50aa48EAa9ef"
+      },
+      "created_at": "2024-08-01T13:54:40Z",
+      "description": "Details copied form Zendesk API code sample. For urgent incidents, we will respond to tickets in 10 minutes",
+      "filter": {
+        "all": [
+          {
+            "field": "ticket_type_id",
+            "operator": "is",
+            "value": "2"
+          }
+        ],
+        "any": []
+      },
+      "id": 29006807867284,
+      "metric_settings": null,
+      "policy_metrics": [
+        {
+          "business_hours": false,
+          "metric": "requester_wait_time",
+          "priority": "low",
+          "target": 180,
+          "target_in_seconds": 10800
+        },
+        {
+          "business_hours": false,
+          "metric": "first_reply_time",
+          "priority": "normal",
+          "target": 30,
+          "target_in_seconds": 1800
+        },
+        {
+          "business_hours": false,
+          "metric": "requester_wait_time",
+          "priority": "normal",
+          "target": 160,
+          "target_in_seconds": 9600
+        },
+        {
+          "business_hours": false,
+          "metric": "requester_wait_time",
+          "priority": "high",
+          "target": 140,
+          "target_in_seconds": 8400
+        },
+        {
+          "business_hours": false,
+          "metric": "first_reply_time",
+          "priority": "urgent",
+          "target": 10,
+          "target_in_seconds": 600
+        },
+        {
+          "business_hours": false,
+          "metric": "requester_wait_time",
+          "priority": "urgent",
+          "target": 120,
+          "target_in_seconds": 7200
+        }
+      ],
+      "position": 1,
+      "title": "Test SLA Policy",
+      "updated_at": "redacted",
+      "url": "https://d3v-estuary.zendesk.com/api/v2/slas/policies/29006807867284.json"
+    }
+  ],
+  [
     "acmeCo/ticket_audits",
     {
       "_meta": {

--- a/source-zendesk-support-native/tests/snapshots/snapshots__capture__capture.stdout.json
+++ b/source-zendesk-support-native/tests/snapshots/snapshots__capture__capture.stdout.json
@@ -185,6 +185,32 @@
     }
   ],
   [
+    "acmeCo/organizations",
+    {
+      "_meta": {
+        "uuid": "DocUUIDPlaceholder-329Bb50aa48EAa9ef",
+        "row_id": 0
+      },
+      "created_at": "2024-07-26T15:41:00Z",
+      "deleted_at": null,
+      "details": "",
+      "domain_names": [],
+      "external_id": null,
+      "group_id": null,
+      "id": 28835714737428,
+      "name": "Estuary",
+      "notes": "",
+      "organization_fields": {},
+      "shared_comments": false,
+      "shared_tickets": false,
+      "tags": [
+        "test-tag"
+      ],
+      "updated_at": "redacted",
+      "url": "https://d3v-estuary.zendesk.com/api/v2/organizations/28835714737428.json"
+    }
+  ],
+  [
     "acmeCo/satisfaction_ratings",
     {
       "_meta": {

--- a/source-zendesk-support-native/tests/snapshots/snapshots__capture__capture.stdout.json
+++ b/source-zendesk-support-native/tests/snapshots/snapshots__capture__capture.stdout.json
@@ -27,6 +27,22 @@
     }
   ],
   [
+    "acmeCo/group_memberships",
+    {
+      "_meta": {
+        "uuid": "DocUUIDPlaceholder-329Bb50aa48EAa9ef",
+        "row_id": 0
+      },
+      "created_at": "2024-07-26T15:41:00Z",
+      "default": true,
+      "group_id": 28835740822676,
+      "id": 28835714743188,
+      "updated_at": "redacted",
+      "url": "https://d3v-estuary.zendesk.com/api/v2/group_memberships/28835714743188.json",
+      "user_id": 28835702984212
+    }
+  ],
+  [
     "acmeCo/groups",
     {
       "_meta": {

--- a/source-zendesk-support-native/tests/snapshots/snapshots__discover__capture.stdout.json
+++ b/source-zendesk-support-native/tests/snapshots/snapshots__discover__capture.stdout.json
@@ -448,6 +448,70 @@
     ]
   },
   {
+    "recommendedName": "organizations",
+    "resourceConfig": {
+      "name": "organizations",
+      "interval": "PT5M"
+    },
+    "documentSchema": {
+      "$defs": {
+        "Meta": {
+          "properties": {
+            "op": {
+              "default": "u",
+              "description": "Operation type (c: Create, u: Update, d: Delete)",
+              "enum": [
+                "c",
+                "u",
+                "d"
+              ],
+              "title": "Op",
+              "type": "string"
+            },
+            "row_id": {
+              "default": -1,
+              "description": "Row ID of the Document, counting up from zero, or -1 if not known",
+              "title": "Row Id",
+              "type": "integer"
+            }
+          },
+          "title": "Meta",
+          "type": "object"
+        }
+      },
+      "additionalProperties": true,
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/Meta",
+          "default": {
+            "op": "u",
+            "row_id": -1
+          },
+          "description": "Document metadata"
+        },
+        "id": {
+          "title": "Id",
+          "type": "integer"
+        },
+        "updated_at": {
+          "format": "date-time",
+          "title": "Updated At",
+          "type": "string"
+        }
+      },
+      "required": [
+        "id",
+        "updated_at"
+      ],
+      "title": "TimestampedResource",
+      "type": "object",
+      "x-infer-schema": true
+    },
+    "key": [
+      "/id"
+    ]
+  },
+  {
     "recommendedName": "satisfaction_ratings",
     "resourceConfig": {
       "name": "satisfaction_ratings",

--- a/source-zendesk-support-native/tests/snapshots/snapshots__discover__capture.stdout.json
+++ b/source-zendesk-support-native/tests/snapshots/snapshots__discover__capture.stdout.json
@@ -128,6 +128,70 @@
     ]
   },
   {
+    "recommendedName": "group_memberships",
+    "resourceConfig": {
+      "name": "group_memberships",
+      "interval": "PT5M"
+    },
+    "documentSchema": {
+      "$defs": {
+        "Meta": {
+          "properties": {
+            "op": {
+              "default": "u",
+              "description": "Operation type (c: Create, u: Update, d: Delete)",
+              "enum": [
+                "c",
+                "u",
+                "d"
+              ],
+              "title": "Op",
+              "type": "string"
+            },
+            "row_id": {
+              "default": -1,
+              "description": "Row ID of the Document, counting up from zero, or -1 if not known",
+              "title": "Row Id",
+              "type": "integer"
+            }
+          },
+          "title": "Meta",
+          "type": "object"
+        }
+      },
+      "additionalProperties": true,
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/Meta",
+          "default": {
+            "op": "u",
+            "row_id": -1
+          },
+          "description": "Document metadata"
+        },
+        "id": {
+          "title": "Id",
+          "type": "integer"
+        },
+        "updated_at": {
+          "format": "date-time",
+          "title": "Updated At",
+          "type": "string"
+        }
+      },
+      "required": [
+        "id",
+        "updated_at"
+      ],
+      "title": "TimestampedResource",
+      "type": "object",
+      "x-infer-schema": true
+    },
+    "key": [
+      "/id"
+    ]
+  },
+  {
     "recommendedName": "groups",
     "resourceConfig": {
       "name": "groups",

--- a/source-zendesk-support-native/tests/snapshots/snapshots__discover__capture.stdout.json
+++ b/source-zendesk-support-native/tests/snapshots/snapshots__discover__capture.stdout.json
@@ -1,5 +1,56 @@
 [
   {
+    "recommendedName": "account_attributes",
+    "resourceConfig": {
+      "name": "account_attributes",
+      "interval": "PT5M"
+    },
+    "documentSchema": {
+      "$defs": {
+        "Meta": {
+          "properties": {
+            "op": {
+              "default": "u",
+              "description": "Operation type (c: Create, u: Update, d: Delete)",
+              "enum": [
+                "c",
+                "u",
+                "d"
+              ],
+              "title": "Op",
+              "type": "string"
+            },
+            "row_id": {
+              "default": -1,
+              "description": "Row ID of the Document, counting up from zero, or -1 if not known",
+              "title": "Row Id",
+              "type": "integer"
+            }
+          },
+          "title": "Meta",
+          "type": "object"
+        }
+      },
+      "additionalProperties": true,
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/Meta",
+          "default": {
+            "op": "u",
+            "row_id": -1
+          },
+          "description": "Document metadata"
+        }
+      },
+      "title": "FullRefreshResource",
+      "type": "object",
+      "x-infer-schema": true
+    },
+    "key": [
+      "/_meta/row_id"
+    ]
+  },
+  {
     "recommendedName": "audit_logs",
     "resourceConfig": {
       "name": "audit_logs",

--- a/source-zendesk-support-native/tests/snapshots/snapshots__discover__capture.stdout.json
+++ b/source-zendesk-support-native/tests/snapshots/snapshots__discover__capture.stdout.json
@@ -64,6 +64,70 @@
     ]
   },
   {
+    "recommendedName": "automations",
+    "resourceConfig": {
+      "name": "automations",
+      "interval": "PT5M"
+    },
+    "documentSchema": {
+      "$defs": {
+        "Meta": {
+          "properties": {
+            "op": {
+              "default": "u",
+              "description": "Operation type (c: Create, u: Update, d: Delete)",
+              "enum": [
+                "c",
+                "u",
+                "d"
+              ],
+              "title": "Op",
+              "type": "string"
+            },
+            "row_id": {
+              "default": -1,
+              "description": "Row ID of the Document, counting up from zero, or -1 if not known",
+              "title": "Row Id",
+              "type": "integer"
+            }
+          },
+          "title": "Meta",
+          "type": "object"
+        }
+      },
+      "additionalProperties": true,
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/Meta",
+          "default": {
+            "op": "u",
+            "row_id": -1
+          },
+          "description": "Document metadata"
+        },
+        "id": {
+          "title": "Id",
+          "type": "integer"
+        },
+        "updated_at": {
+          "format": "date-time",
+          "title": "Updated At",
+          "type": "string"
+        }
+      },
+      "required": [
+        "id",
+        "updated_at"
+      ],
+      "title": "TimestampedResource",
+      "type": "object",
+      "x-infer-schema": true
+    },
+    "key": [
+      "/id"
+    ]
+  },
+  {
     "recommendedName": "brands",
     "resourceConfig": {
       "name": "brands",
@@ -451,6 +515,70 @@
     "recommendedName": "organizations",
     "resourceConfig": {
       "name": "organizations",
+      "interval": "PT5M"
+    },
+    "documentSchema": {
+      "$defs": {
+        "Meta": {
+          "properties": {
+            "op": {
+              "default": "u",
+              "description": "Operation type (c: Create, u: Update, d: Delete)",
+              "enum": [
+                "c",
+                "u",
+                "d"
+              ],
+              "title": "Op",
+              "type": "string"
+            },
+            "row_id": {
+              "default": -1,
+              "description": "Row ID of the Document, counting up from zero, or -1 if not known",
+              "title": "Row Id",
+              "type": "integer"
+            }
+          },
+          "title": "Meta",
+          "type": "object"
+        }
+      },
+      "additionalProperties": true,
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/Meta",
+          "default": {
+            "op": "u",
+            "row_id": -1
+          },
+          "description": "Document metadata"
+        },
+        "id": {
+          "title": "Id",
+          "type": "integer"
+        },
+        "updated_at": {
+          "format": "date-time",
+          "title": "Updated At",
+          "type": "string"
+        }
+      },
+      "required": [
+        "id",
+        "updated_at"
+      ],
+      "title": "TimestampedResource",
+      "type": "object",
+      "x-infer-schema": true
+    },
+    "key": [
+      "/id"
+    ]
+  },
+  {
+    "recommendedName": "posts",
+    "resourceConfig": {
+      "name": "posts",
       "interval": "PT5M"
     },
     "documentSchema": {
@@ -1144,6 +1272,70 @@
     "recommendedName": "tickets",
     "resourceConfig": {
       "name": "tickets",
+      "interval": "PT5M"
+    },
+    "documentSchema": {
+      "$defs": {
+        "Meta": {
+          "properties": {
+            "op": {
+              "default": "u",
+              "description": "Operation type (c: Create, u: Update, d: Delete)",
+              "enum": [
+                "c",
+                "u",
+                "d"
+              ],
+              "title": "Op",
+              "type": "string"
+            },
+            "row_id": {
+              "default": -1,
+              "description": "Row ID of the Document, counting up from zero, or -1 if not known",
+              "title": "Row Id",
+              "type": "integer"
+            }
+          },
+          "title": "Meta",
+          "type": "object"
+        }
+      },
+      "additionalProperties": true,
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/Meta",
+          "default": {
+            "op": "u",
+            "row_id": -1
+          },
+          "description": "Document metadata"
+        },
+        "id": {
+          "title": "Id",
+          "type": "integer"
+        },
+        "updated_at": {
+          "format": "date-time",
+          "title": "Updated At",
+          "type": "string"
+        }
+      },
+      "required": [
+        "id",
+        "updated_at"
+      ],
+      "title": "TimestampedResource",
+      "type": "object",
+      "x-infer-schema": true
+    },
+    "key": [
+      "/id"
+    ]
+  },
+  {
+    "recommendedName": "topics",
+    "resourceConfig": {
+      "name": "topics",
       "interval": "PT5M"
     },
     "documentSchema": {

--- a/source-zendesk-support-native/tests/snapshots/snapshots__discover__capture.stdout.json
+++ b/source-zendesk-support-native/tests/snapshots/snapshots__discover__capture.stdout.json
@@ -3,7 +3,7 @@
     "recommendedName": "account_attributes",
     "resourceConfig": {
       "name": "account_attributes",
-      "interval": "PT5M"
+      "interval": "PT1H"
     },
     "documentSchema": {
       "$defs": {
@@ -118,7 +118,7 @@
     "recommendedName": "automations",
     "resourceConfig": {
       "name": "automations",
-      "interval": "PT5M"
+      "interval": "PT15M"
     },
     "documentSchema": {
       "$defs": {
@@ -182,7 +182,7 @@
     "recommendedName": "brands",
     "resourceConfig": {
       "name": "brands",
-      "interval": "PT5M"
+      "interval": "PT15M"
     },
     "documentSchema": {
       "$defs": {
@@ -246,7 +246,7 @@
     "recommendedName": "custom_roles",
     "resourceConfig": {
       "name": "custom_roles",
-      "interval": "PT5M"
+      "interval": "PT30M"
     },
     "documentSchema": {
       "$defs": {
@@ -310,7 +310,7 @@
     "recommendedName": "group_memberships",
     "resourceConfig": {
       "name": "group_memberships",
-      "interval": "PT5M"
+      "interval": "PT15M"
     },
     "documentSchema": {
       "$defs": {
@@ -374,7 +374,7 @@
     "recommendedName": "groups",
     "resourceConfig": {
       "name": "groups",
-      "interval": "PT5M"
+      "interval": "PT15M"
     },
     "documentSchema": {
       "$defs": {
@@ -438,7 +438,7 @@
     "recommendedName": "macros",
     "resourceConfig": {
       "name": "macros",
-      "interval": "PT5M"
+      "interval": "PT15M"
     },
     "documentSchema": {
       "$defs": {
@@ -502,7 +502,7 @@
     "recommendedName": "organization_memberships",
     "resourceConfig": {
       "name": "organization_memberships",
-      "interval": "PT5M"
+      "interval": "PT15M"
     },
     "documentSchema": {
       "$defs": {
@@ -630,7 +630,7 @@
     "recommendedName": "post_comment_votes",
     "resourceConfig": {
       "name": "post_comment_votes",
-      "interval": "PT5M"
+      "interval": "PT30M"
     },
     "documentSchema": {
       "$defs": {
@@ -688,7 +688,7 @@
     "recommendedName": "post_comments",
     "resourceConfig": {
       "name": "post_comments",
-      "interval": "PT5M"
+      "interval": "PT30M"
     },
     "documentSchema": {
       "$defs": {
@@ -746,7 +746,7 @@
     "recommendedName": "post_votes",
     "resourceConfig": {
       "name": "post_votes",
-      "interval": "PT5M"
+      "interval": "PT30M"
     },
     "documentSchema": {
       "$defs": {
@@ -804,7 +804,7 @@
     "recommendedName": "posts",
     "resourceConfig": {
       "name": "posts",
-      "interval": "PT5M"
+      "interval": "PT15M"
     },
     "documentSchema": {
       "$defs": {
@@ -926,7 +926,7 @@
     "recommendedName": "schedules",
     "resourceConfig": {
       "name": "schedules",
-      "interval": "PT5M"
+      "interval": "PT1H"
     },
     "documentSchema": {
       "$defs": {
@@ -977,7 +977,7 @@
     "recommendedName": "sla_policies",
     "resourceConfig": {
       "name": "sla_policies",
-      "interval": "PT5M"
+      "interval": "PT1H"
     },
     "documentSchema": {
       "$defs": {
@@ -1028,7 +1028,7 @@
     "recommendedName": "tags",
     "resourceConfig": {
       "name": "tags",
-      "interval": "PT5M"
+      "interval": "PT1H"
     },
     "documentSchema": {
       "$defs": {
@@ -1195,7 +1195,7 @@
     "recommendedName": "ticket_fields",
     "resourceConfig": {
       "name": "ticket_fields",
-      "interval": "PT5M"
+      "interval": "PT15M"
     },
     "documentSchema": {
       "$defs": {
@@ -1259,7 +1259,7 @@
     "recommendedName": "ticket_forms",
     "resourceConfig": {
       "name": "ticket_forms",
-      "interval": "PT5M"
+      "interval": "PT30M"
     },
     "documentSchema": {
       "$defs": {
@@ -1561,7 +1561,7 @@
     "recommendedName": "topics",
     "resourceConfig": {
       "name": "topics",
-      "interval": "PT5M"
+      "interval": "PT15M"
     },
     "documentSchema": {
       "$defs": {

--- a/source-zendesk-support-native/tests/snapshots/snapshots__discover__capture.stdout.json
+++ b/source-zendesk-support-native/tests/snapshots/snapshots__discover__capture.stdout.json
@@ -627,6 +627,122 @@
     ]
   },
   {
+    "recommendedName": "post_comments",
+    "resourceConfig": {
+      "name": "post_comments",
+      "interval": "PT5M"
+    },
+    "documentSchema": {
+      "$defs": {
+        "Meta": {
+          "properties": {
+            "op": {
+              "default": "u",
+              "description": "Operation type (c: Create, u: Update, d: Delete)",
+              "enum": [
+                "c",
+                "u",
+                "d"
+              ],
+              "title": "Op",
+              "type": "string"
+            },
+            "row_id": {
+              "default": -1,
+              "description": "Row ID of the Document, counting up from zero, or -1 if not known",
+              "title": "Row Id",
+              "type": "integer"
+            }
+          },
+          "title": "Meta",
+          "type": "object"
+        }
+      },
+      "additionalProperties": true,
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/Meta",
+          "default": {
+            "op": "u",
+            "row_id": -1
+          },
+          "description": "Document metadata"
+        },
+        "id": {
+          "title": "Id",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "id"
+      ],
+      "title": "ZendeskResource",
+      "type": "object",
+      "x-infer-schema": true
+    },
+    "key": [
+      "/id"
+    ]
+  },
+  {
+    "recommendedName": "post_votes",
+    "resourceConfig": {
+      "name": "post_votes",
+      "interval": "PT5M"
+    },
+    "documentSchema": {
+      "$defs": {
+        "Meta": {
+          "properties": {
+            "op": {
+              "default": "u",
+              "description": "Operation type (c: Create, u: Update, d: Delete)",
+              "enum": [
+                "c",
+                "u",
+                "d"
+              ],
+              "title": "Op",
+              "type": "string"
+            },
+            "row_id": {
+              "default": -1,
+              "description": "Row ID of the Document, counting up from zero, or -1 if not known",
+              "title": "Row Id",
+              "type": "integer"
+            }
+          },
+          "title": "Meta",
+          "type": "object"
+        }
+      },
+      "additionalProperties": true,
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/Meta",
+          "default": {
+            "op": "u",
+            "row_id": -1
+          },
+          "description": "Document metadata"
+        },
+        "id": {
+          "title": "Id",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "id"
+      ],
+      "title": "ZendeskResource",
+      "type": "object",
+      "x-infer-schema": true
+    },
+    "key": [
+      "/id"
+    ]
+  },
+  {
     "recommendedName": "posts",
     "resourceConfig": {
       "name": "posts",

--- a/source-zendesk-support-native/tests/snapshots/snapshots__discover__capture.stdout.json
+++ b/source-zendesk-support-native/tests/snapshots/snapshots__discover__capture.stdout.json
@@ -506,6 +506,57 @@
     ]
   },
   {
+    "recommendedName": "schedules",
+    "resourceConfig": {
+      "name": "schedules",
+      "interval": "PT5M"
+    },
+    "documentSchema": {
+      "$defs": {
+        "Meta": {
+          "properties": {
+            "op": {
+              "default": "u",
+              "description": "Operation type (c: Create, u: Update, d: Delete)",
+              "enum": [
+                "c",
+                "u",
+                "d"
+              ],
+              "title": "Op",
+              "type": "string"
+            },
+            "row_id": {
+              "default": -1,
+              "description": "Row ID of the Document, counting up from zero, or -1 if not known",
+              "title": "Row Id",
+              "type": "integer"
+            }
+          },
+          "title": "Meta",
+          "type": "object"
+        }
+      },
+      "additionalProperties": true,
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/Meta",
+          "default": {
+            "op": "u",
+            "row_id": -1
+          },
+          "description": "Document metadata"
+        }
+      },
+      "title": "FullRefreshResource",
+      "type": "object",
+      "x-infer-schema": true
+    },
+    "key": [
+      "/_meta/row_id"
+    ]
+  },
+  {
     "recommendedName": "sla_policies",
     "resourceConfig": {
       "name": "sla_policies",

--- a/source-zendesk-support-native/tests/snapshots/snapshots__discover__capture.stdout.json
+++ b/source-zendesk-support-native/tests/snapshots/snapshots__discover__capture.stdout.json
@@ -627,6 +627,64 @@
     ]
   },
   {
+    "recommendedName": "post_comment_votes",
+    "resourceConfig": {
+      "name": "post_comment_votes",
+      "interval": "PT5M"
+    },
+    "documentSchema": {
+      "$defs": {
+        "Meta": {
+          "properties": {
+            "op": {
+              "default": "u",
+              "description": "Operation type (c: Create, u: Update, d: Delete)",
+              "enum": [
+                "c",
+                "u",
+                "d"
+              ],
+              "title": "Op",
+              "type": "string"
+            },
+            "row_id": {
+              "default": -1,
+              "description": "Row ID of the Document, counting up from zero, or -1 if not known",
+              "title": "Row Id",
+              "type": "integer"
+            }
+          },
+          "title": "Meta",
+          "type": "object"
+        }
+      },
+      "additionalProperties": true,
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/Meta",
+          "default": {
+            "op": "u",
+            "row_id": -1
+          },
+          "description": "Document metadata"
+        },
+        "id": {
+          "title": "Id",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "id"
+      ],
+      "title": "ZendeskResource",
+      "type": "object",
+      "x-infer-schema": true
+    },
+    "key": [
+      "/id"
+    ]
+  },
+  {
     "recommendedName": "post_comments",
     "resourceConfig": {
       "name": "post_comments",

--- a/source-zendesk-support-native/tests/snapshots/snapshots__discover__capture.stdout.json
+++ b/source-zendesk-support-native/tests/snapshots/snapshots__discover__capture.stdout.json
@@ -128,6 +128,70 @@
     ]
   },
   {
+    "recommendedName": "custom_roles",
+    "resourceConfig": {
+      "name": "custom_roles",
+      "interval": "PT5M"
+    },
+    "documentSchema": {
+      "$defs": {
+        "Meta": {
+          "properties": {
+            "op": {
+              "default": "u",
+              "description": "Operation type (c: Create, u: Update, d: Delete)",
+              "enum": [
+                "c",
+                "u",
+                "d"
+              ],
+              "title": "Op",
+              "type": "string"
+            },
+            "row_id": {
+              "default": -1,
+              "description": "Row ID of the Document, counting up from zero, or -1 if not known",
+              "title": "Row Id",
+              "type": "integer"
+            }
+          },
+          "title": "Meta",
+          "type": "object"
+        }
+      },
+      "additionalProperties": true,
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/Meta",
+          "default": {
+            "op": "u",
+            "row_id": -1
+          },
+          "description": "Document metadata"
+        },
+        "id": {
+          "title": "Id",
+          "type": "integer"
+        },
+        "updated_at": {
+          "format": "date-time",
+          "title": "Updated At",
+          "type": "string"
+        }
+      },
+      "required": [
+        "id",
+        "updated_at"
+      ],
+      "title": "TimestampedResource",
+      "type": "object",
+      "x-infer-schema": true
+    },
+    "key": [
+      "/id"
+    ]
+  },
+  {
     "recommendedName": "group_memberships",
     "resourceConfig": {
       "name": "group_memberships",
@@ -663,6 +727,70 @@
     "recommendedName": "ticket_fields",
     "resourceConfig": {
       "name": "ticket_fields",
+      "interval": "PT5M"
+    },
+    "documentSchema": {
+      "$defs": {
+        "Meta": {
+          "properties": {
+            "op": {
+              "default": "u",
+              "description": "Operation type (c: Create, u: Update, d: Delete)",
+              "enum": [
+                "c",
+                "u",
+                "d"
+              ],
+              "title": "Op",
+              "type": "string"
+            },
+            "row_id": {
+              "default": -1,
+              "description": "Row ID of the Document, counting up from zero, or -1 if not known",
+              "title": "Row Id",
+              "type": "integer"
+            }
+          },
+          "title": "Meta",
+          "type": "object"
+        }
+      },
+      "additionalProperties": true,
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/Meta",
+          "default": {
+            "op": "u",
+            "row_id": -1
+          },
+          "description": "Document metadata"
+        },
+        "id": {
+          "title": "Id",
+          "type": "integer"
+        },
+        "updated_at": {
+          "format": "date-time",
+          "title": "Updated At",
+          "type": "string"
+        }
+      },
+      "required": [
+        "id",
+        "updated_at"
+      ],
+      "title": "TimestampedResource",
+      "type": "object",
+      "x-infer-schema": true
+    },
+    "key": [
+      "/id"
+    ]
+  },
+  {
+    "recommendedName": "ticket_forms",
+    "resourceConfig": {
+      "name": "ticket_forms",
       "interval": "PT5M"
     },
     "documentSchema": {

--- a/source-zendesk-support-native/tests/snapshots/snapshots__discover__capture.stdout.json
+++ b/source-zendesk-support-native/tests/snapshots/snapshots__discover__capture.stdout.json
@@ -378,6 +378,57 @@
     ]
   },
   {
+    "recommendedName": "sla_policies",
+    "resourceConfig": {
+      "name": "sla_policies",
+      "interval": "PT5M"
+    },
+    "documentSchema": {
+      "$defs": {
+        "Meta": {
+          "properties": {
+            "op": {
+              "default": "u",
+              "description": "Operation type (c: Create, u: Update, d: Delete)",
+              "enum": [
+                "c",
+                "u",
+                "d"
+              ],
+              "title": "Op",
+              "type": "string"
+            },
+            "row_id": {
+              "default": -1,
+              "description": "Row ID of the Document, counting up from zero, or -1 if not known",
+              "title": "Row Id",
+              "type": "integer"
+            }
+          },
+          "title": "Meta",
+          "type": "object"
+        }
+      },
+      "additionalProperties": true,
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/Meta",
+          "default": {
+            "op": "u",
+            "row_id": -1
+          },
+          "description": "Document metadata"
+        }
+      },
+      "title": "FullRefreshResource",
+      "type": "object",
+      "x-infer-schema": true
+    },
+    "key": [
+      "/_meta/row_id"
+    ]
+  },
+  {
     "recommendedName": "tags",
     "resourceConfig": {
       "name": "tags",


### PR DESCRIPTION
**Description:**

This PR's scope includes:
- Adding streams to bring `source-zendesk-support-native` on (and above) stream parity with the imported `source-zendesk-support`.
  -  Added streams include:
      - `account_attributes`
      - `automations`
      - `custom_roles`
      - `group_memberships`
      - `organizations`
      - `post_comment_votes`
      - `post_comments`
      - `post_votes`
      - `posts`
      - `schedules`
      - `sla_policies`
      - `ticket_forms`
      - `topics`
- Increasing the default interval for resources that have infrequent updates.
- Conditionally discover `account_attributes` and `audit_logs` if the provided credentials have access to the appropriate endpoints.

See individual commits for more details.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

Documentation should be updated to reflect the new streams & mark the imported `source-zendesk-support` as deprecated.

**Notes for reviewers:**

Tested on a local stack. Confirmed all streams capture data & complete.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2407)
<!-- Reviewable:end -->
