### PR TITLE
Revert "upgrade to Go 1.24"

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/estuary/connectors
 
-go 1.24.0
+go 1.22.4
+
+toolchain go1.22.5
 
 require (
 	cloud.google.com/go v0.115.0
@@ -54,7 +56,6 @@ require (
 	github.com/mitchellh/mapstructure v1.5.0
 	github.com/pinecone-io/go-pinecone v1.1.1
 	github.com/pkg/sftp v1.13.6
-	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2
 	github.com/segmentio/encoding v0.4.0
 	github.com/senseyeio/duration v0.0.0-20180430131211-7c2a214ada46
 	github.com/sijms/go-ora/v2 v2.8.19
@@ -78,7 +79,6 @@ require (
 	google.golang.org/genproto v0.0.0-20240610135401-a8a62080eff3
 	google.golang.org/grpc v1.65.0
 	google.golang.org/protobuf v1.34.2
-	gopkg.in/yaml.v3 v3.0.1
 	vitess.io/vitess v0.15.3
 )
 
@@ -199,6 +199,7 @@ require (
 	github.com/pingcap/errors v0.11.5-0.20240311024730-e056997136bb // indirect
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c // indirect
 	github.com/pkg/errors v0.9.1 // indirect
+	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/prometheus/client_golang v1.19.1 // indirect
 	github.com/prometheus/client_model v0.6.1 // indirect
 	github.com/prometheus/common v0.54.0 // indirect
@@ -248,6 +249,7 @@ require (
 	gopkg.in/jcmturner/dnsutils.v1 v1.0.1 // indirect
 	gopkg.in/jcmturner/gokrb5.v6 v6.1.1 // indirect
 	gopkg.in/jcmturner/rpc.v1 v1.1.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 	gotest.tools/gotestsum v1.8.2 // indirect
 	k8s.io/apimachinery v0.23.17 // indirect
 	nhooyr.io/websocket v1.8.7 // indirect

--- a/materialize-azure-fabric-warehouse/Dockerfile
+++ b/materialize-azure-fabric-warehouse/Dockerfile
@@ -2,7 +2,7 @@ ARG BASE_IMAGE=ghcr.io/estuary/base-image:v1
 
 # Build Stage
 ################################################################################
-FROM --platform=linux/amd64 golang:1.24-bullseye as builder
+FROM --platform=linux/amd64 golang:1.22-bullseye as builder
 
 WORKDIR /builder
 

--- a/materialize-bigquery/Dockerfile
+++ b/materialize-bigquery/Dockerfile
@@ -2,7 +2,7 @@ ARG BASE_IMAGE=ghcr.io/estuary/base-image:v1
 
 # Build Stage
 ################################################################################
-FROM golang:1.24-bullseye as builder
+FROM golang:1.22-bullseye as builder
 
 WORKDIR /builder
 

--- a/materialize-databricks/Dockerfile
+++ b/materialize-databricks/Dockerfile
@@ -2,7 +2,7 @@ ARG BASE_IMAGE=ghcr.io/estuary/base-image:v1
 
 # Build Stage
 ################################################################################
-FROM --platform=linux/amd64 golang:1.24-bullseye as builder
+FROM --platform=linux/amd64 golang:1.22-bullseye as builder
 
 WORKDIR /builder
 

--- a/materialize-dynamodb/Dockerfile
+++ b/materialize-dynamodb/Dockerfile
@@ -2,7 +2,7 @@ ARG BASE_IMAGE=ghcr.io/estuary/base-image:v1
 
 # Build Stage
 ################################################################################
-FROM --platform=linux/amd64 golang:1.24-bullseye as builder
+FROM --platform=linux/amd64 golang:1.22-bullseye as builder
 
 WORKDIR /builder
 

--- a/materialize-elasticsearch/Dockerfile
+++ b/materialize-elasticsearch/Dockerfile
@@ -2,7 +2,7 @@ ARG BASE_IMAGE=ghcr.io/estuary/base-image:v1
 
 # Build Stage
 ################################################################################
-FROM --platform=linux/amd64 golang:1.24-bullseye as builder
+FROM --platform=linux/amd64 golang:1.22-bullseye as builder
 
 WORKDIR /builder
 

--- a/materialize-firebolt/Dockerfile
+++ b/materialize-firebolt/Dockerfile
@@ -2,7 +2,7 @@ ARG BASE_IMAGE=ghcr.io/estuary/base-image:v1
 
 # Build Stage
 ################################################################################
-FROM --platform=linux/amd64 golang:1.24-bullseye as builder
+FROM --platform=linux/amd64 golang:1.22-bullseye as builder
 
 WORKDIR /builder
 

--- a/materialize-gcs-csv/Dockerfile
+++ b/materialize-gcs-csv/Dockerfile
@@ -2,7 +2,7 @@ ARG BASE_IMAGE=ghcr.io/estuary/base-image:v1
 
 # Build Stage
 ################################################################################
-FROM --platform=linux/amd64 golang:1.24-bullseye as builder
+FROM --platform=linux/amd64 golang:1.22-bullseye as builder
 
 WORKDIR /builder
 

--- a/materialize-gcs-parquet/Dockerfile
+++ b/materialize-gcs-parquet/Dockerfile
@@ -2,7 +2,7 @@ ARG BASE_IMAGE=ghcr.io/estuary/base-image:v1
 
 # Build Stage
 ################################################################################
-FROM --platform=linux/amd64 golang:1.24-bullseye as builder
+FROM --platform=linux/amd64 golang:1.22-bullseye as builder
 
 WORKDIR /builder
 

--- a/materialize-google-pubsub/Dockerfile
+++ b/materialize-google-pubsub/Dockerfile
@@ -2,7 +2,7 @@ ARG BASE_IMAGE=ghcr.io/estuary/base-image:v1
 
 # Build Stage
 ################################################################################
-FROM --platform=linux/amd64 golang:1.24-bullseye as builder
+FROM --platform=linux/amd64 golang:1.22-bullseye as builder
 
 WORKDIR /builder
 

--- a/materialize-google-sheets/Dockerfile
+++ b/materialize-google-sheets/Dockerfile
@@ -2,7 +2,7 @@ ARG BASE_IMAGE=ghcr.io/estuary/base-image:v1
 
 # Build Stage
 ################################################################################
-FROM golang:1.24-bullseye as builder
+FROM golang:1.22-bullseye as builder
 
 WORKDIR /builder
 

--- a/materialize-kafka/Dockerfile
+++ b/materialize-kafka/Dockerfile
@@ -2,7 +2,7 @@ ARG BASE_IMAGE=ghcr.io/estuary/base-image:v1
 
 # Build Stage
 ################################################################################
-FROM golang:1.24-bullseye as builder
+FROM golang:1.22-bullseye as builder
 
 RUN apt-get update \
     && apt-get install -y curl ca-certificates pkg-config cmake g++ libssl-dev libsasl2-dev \

--- a/materialize-mongodb/Dockerfile
+++ b/materialize-mongodb/Dockerfile
@@ -2,7 +2,7 @@ ARG BASE_IMAGE=ghcr.io/estuary/base-image:v1
 
 # Build Stage
 ################################################################################
-FROM --platform=linux/amd64 golang:1.24-bullseye as builder
+FROM --platform=linux/amd64 golang:1.22-bullseye as builder
 
 WORKDIR /builder
 

--- a/materialize-motherduck/Dockerfile
+++ b/materialize-motherduck/Dockerfile
@@ -2,7 +2,7 @@ ARG BASE_IMAGE=ghcr.io/estuary/base-image:v1
 
 # Build Stage
 ################################################################################
-FROM --platform=linux/amd64 golang:1.24-bullseye as builder
+FROM --platform=linux/amd64 golang:1.22-bullseye as builder
 
 WORKDIR /builder
 

--- a/materialize-mysql/Dockerfile
+++ b/materialize-mysql/Dockerfile
@@ -2,7 +2,7 @@ ARG BASE_IMAGE=ghcr.io/estuary/base-image:v1
 
 # Build Stage
 ################################################################################
-FROM --platform=linux/amd64 golang:1.24-bullseye as builder
+FROM --platform=linux/amd64 golang:1.22-bullseye as builder
 
 WORKDIR /builder
 

--- a/materialize-pinecone/Dockerfile
+++ b/materialize-pinecone/Dockerfile
@@ -2,7 +2,7 @@ ARG BASE_IMAGE=ghcr.io/estuary/base-image:v1
 
 # Build Stage
 ################################################################################
-FROM --platform=linux/amd64 golang:1.24-bullseye as builder
+FROM --platform=linux/amd64 golang:1.22-bullseye as builder
 
 WORKDIR /builder
 

--- a/materialize-postgres/Dockerfile
+++ b/materialize-postgres/Dockerfile
@@ -2,7 +2,7 @@ ARG BASE_IMAGE=ghcr.io/estuary/base-image:v1
 
 # Build Stage
 ################################################################################
-FROM --platform=linux/amd64 golang:1.24-bullseye as builder
+FROM --platform=linux/amd64 golang:1.22-bullseye as builder
 
 WORKDIR /builder
 

--- a/materialize-redshift/Dockerfile
+++ b/materialize-redshift/Dockerfile
@@ -2,7 +2,7 @@ ARG BASE_IMAGE=ghcr.io/estuary/base-image:v1
 
 # Build Stage
 ################################################################################
-FROM --platform=linux/amd64 golang:1.24-bullseye as builder
+FROM --platform=linux/amd64 golang:1.22-bullseye as builder
 
 WORKDIR /builder
 

--- a/materialize-s3-csv/Dockerfile
+++ b/materialize-s3-csv/Dockerfile
@@ -2,7 +2,7 @@ ARG BASE_IMAGE=ghcr.io/estuary/base-image:v1
 
 # Build Stage
 ################################################################################
-FROM --platform=linux/amd64 golang:1.24-bullseye as builder
+FROM --platform=linux/amd64 golang:1.22-bullseye as builder
 
 WORKDIR /builder
 

--- a/materialize-s3-iceberg/Dockerfile
+++ b/materialize-s3-iceberg/Dockerfile
@@ -19,7 +19,7 @@ RUN poetry install
 
 # Go build stage
 ################################################################################
-FROM --platform=linux/amd64 golang:1.24-bullseye as gobuilder
+FROM --platform=linux/amd64 golang:1.22-bullseye as gobuilder
 
 WORKDIR /builder
 

--- a/materialize-s3-parquet/Dockerfile
+++ b/materialize-s3-parquet/Dockerfile
@@ -2,7 +2,7 @@ ARG BASE_IMAGE=ghcr.io/estuary/base-image:v1
 
 # Build Stage
 ################################################################################
-FROM --platform=linux/amd64 golang:1.24-bullseye as builder
+FROM --platform=linux/amd64 golang:1.22-bullseye as builder
 
 WORKDIR /builder
 

--- a/materialize-slack/Dockerfile
+++ b/materialize-slack/Dockerfile
@@ -2,7 +2,7 @@ ARG BASE_IMAGE=ghcr.io/estuary/base-image:v1
 
 # Build Stage
 ################################################################################
-FROM --platform=linux/amd64 golang:1.24-bullseye as builder
+FROM --platform=linux/amd64 golang:1.22-bullseye as builder
 
 WORKDIR /builder
 

--- a/materialize-snowflake/Dockerfile
+++ b/materialize-snowflake/Dockerfile
@@ -2,7 +2,7 @@ ARG BASE_IMAGE=ghcr.io/estuary/base-image:v1
 
 # Build Stage
 ################################################################################
-FROM golang:1.24-bullseye as builder
+FROM golang:1.22-bullseye as builder
 
 WORKDIR /builder
 

--- a/materialize-sqlite/Dockerfile
+++ b/materialize-sqlite/Dockerfile
@@ -2,7 +2,7 @@ ARG BASE_IMAGE=ghcr.io/estuary/base-image:v1
 
 # Build Stage
 ################################################################################
-FROM --platform=linux/amd64 golang:1.24-bullseye as builder
+FROM --platform=linux/amd64 golang:1.22-bullseye as builder
 
 WORKDIR /builder
 

--- a/materialize-sqlserver/Dockerfile
+++ b/materialize-sqlserver/Dockerfile
@@ -2,7 +2,7 @@ ARG BASE_IMAGE=ghcr.io/estuary/base-image:v1
 
 # Build Stage
 ################################################################################
-FROM --platform=linux/amd64 golang:1.24-bullseye as builder
+FROM --platform=linux/amd64 golang:1.22-bullseye as builder
 
 WORKDIR /builder
 

--- a/materialize-starburst/Dockerfile
+++ b/materialize-starburst/Dockerfile
@@ -2,7 +2,7 @@ ARG BASE_IMAGE=ghcr.io/estuary/base-image:v1
 
 # Build Stage
 ################################################################################
-FROM --platform=linux/amd64 golang:1.24-bullseye as builder
+FROM --platform=linux/amd64 golang:1.22-bullseye as builder
 
 WORKDIR /builder
 

--- a/materialize-webhook/Dockerfile
+++ b/materialize-webhook/Dockerfile
@@ -2,7 +2,7 @@ ARG BASE_IMAGE=ghcr.io/estuary/base-image:v1
 
 # Build Stage
 ################################################################################
-FROM golang:1.24-bullseye as builder
+FROM golang:1.22-bullseye as builder
 
 WORKDIR /builder
 

--- a/source-alpaca/Dockerfile
+++ b/source-alpaca/Dockerfile
@@ -1,6 +1,6 @@
 # Build Stage
 ################################################################################
-FROM golang:1.24-bullseye as builder
+FROM golang:1.22-bullseye as builder
 
 WORKDIR /builder
 

--- a/source-azure-blob-storage/Dockerfile
+++ b/source-azure-blob-storage/Dockerfile
@@ -2,7 +2,7 @@ ARG BASE_IMAGE=ghcr.io/estuary/base-image:v1
 
 # Build Stage
 ################################################################################
-FROM golang:1.24-bullseye as builder
+FROM golang:1.22-bullseye as builder
 
 WORKDIR /builder
 

--- a/source-bigquery-batch/Dockerfile
+++ b/source-bigquery-batch/Dockerfile
@@ -2,7 +2,7 @@ ARG BASE_IMAGE=ghcr.io/estuary/base-image:v1
 
 # Build Stage
 ################################################################################
-FROM golang:1.24-bullseye as builder
+FROM golang:1.22-bullseye as builder
 
 WORKDIR /builder
 

--- a/source-dropbox/Dockerfile
+++ b/source-dropbox/Dockerfile
@@ -2,7 +2,7 @@ ARG BASE_IMAGE=ghcr.io/estuary/base-image:v1
 
 # Build Stage
 ################################################################################
-FROM golang:1.24-bullseye as builder
+FROM golang:1.22-bullseye as builder
 
 WORKDIR /builder
 

--- a/source-dynamodb/Dockerfile
+++ b/source-dynamodb/Dockerfile
@@ -1,6 +1,6 @@
 # Build Stage
 ################################################################################
-FROM golang:1.24-bullseye as builder
+FROM golang:1.22-bullseye as builder
 
 WORKDIR /builder
 

--- a/source-firestore/Dockerfile
+++ b/source-firestore/Dockerfile
@@ -2,7 +2,7 @@ ARG BASE_IMAGE=ghcr.io/estuary/base-image:v1
 
 # Build Stage
 ################################################################################
-FROM golang:1.24-bullseye as builder
+FROM golang:1.22-bullseye as builder
 
 WORKDIR /builder
 

--- a/source-gcs/Dockerfile
+++ b/source-gcs/Dockerfile
@@ -2,7 +2,7 @@ ARG BASE_IMAGE=ghcr.io/estuary/base-image:v1
 
 # Build Stage
 ################################################################################
-FROM golang:1.24-bullseye as builder
+FROM golang:1.22-bullseye as builder
 
 WORKDIR /builder
 

--- a/source-google-drive/Dockerfile
+++ b/source-google-drive/Dockerfile
@@ -2,7 +2,7 @@ ARG BASE_IMAGE=ghcr.io/estuary/base-image:v1
 
 # Build Stage
 ################################################################################
-FROM golang:1.24-bullseye as builder
+FROM golang:1.22-bullseye as builder
 
 WORKDIR /builder
 

--- a/source-google-pubsub/Dockerfile
+++ b/source-google-pubsub/Dockerfile
@@ -2,7 +2,7 @@ ARG BASE_IMAGE=ghcr.io/estuary/base-image:v1
 
 # Build Stage
 ################################################################################
-FROM golang:1.24-bullseye as builder
+FROM golang:1.22-bullseye as builder
 
 WORKDIR /builder
 

--- a/source-hello-world/Dockerfile
+++ b/source-hello-world/Dockerfile
@@ -2,7 +2,7 @@ ARG BASE_IMAGE=ghcr.io/estuary/base-image:v1
 
 # Build Stage
 ################################################################################
-FROM golang:1.24-bullseye as builder
+FROM golang:1.22-bullseye as builder
 
 WORKDIR /builder
 

--- a/source-http-file/Dockerfile
+++ b/source-http-file/Dockerfile
@@ -2,7 +2,7 @@ ARG BASE_IMAGE=ghcr.io/estuary/base-image:v1
 
 # Build Stage
 ################################################################################
-FROM golang:1.24-bullseye as builder
+FROM golang:1.22-bullseye as builder
 
 WORKDIR /builder
 

--- a/source-http-ingest/Dockerfile
+++ b/source-http-ingest/Dockerfile
@@ -2,7 +2,7 @@ ARG BASE_IMAGE=ghcr.io/estuary/base-image:v1
 
 # Build Stage
 ################################################################################
-FROM golang:1.24-bullseye as builder
+FROM golang:1.22-bullseye as builder
 
 RUN apt-get update \
     && apt-get install -y curl ca-certificates pkg-config cmake g++ protobuf-compiler \

--- a/source-kafka/Dockerfile
+++ b/source-kafka/Dockerfile
@@ -2,7 +2,7 @@ ARG BASE_IMAGE=ghcr.io/estuary/base-image:v1
 
 # Build Stage
 ################################################################################
-FROM golang:1.24-bullseye as builder
+FROM golang:1.22-bullseye as builder
 
 RUN apt-get update \
     && apt-get install -y curl ca-certificates pkg-config cmake g++ libssl-dev libsasl2-dev \

--- a/source-kinesis/Dockerfile
+++ b/source-kinesis/Dockerfile
@@ -2,7 +2,7 @@ ARG BASE_IMAGE=ghcr.io/estuary/base-image:v1
 
 # Build Stage
 ################################################################################
-FROM golang:1.24-bullseye as builder
+FROM golang:1.22-bullseye as builder
 
 WORKDIR /builder
 

--- a/source-mongodb/Dockerfile
+++ b/source-mongodb/Dockerfile
@@ -1,6 +1,6 @@
 # Build Stage
 ################################################################################
-FROM golang:1.24-bullseye as builder
+FROM golang:1.22-bullseye as builder
 
 WORKDIR /builder
 

--- a/source-mysql-batch/Dockerfile
+++ b/source-mysql-batch/Dockerfile
@@ -2,7 +2,7 @@ ARG BASE_IMAGE=ghcr.io/estuary/base-image:v1
 
 # Build Stage
 ################################################################################
-FROM golang:1.24-bullseye as builder
+FROM golang:1.22-bullseye as builder
 
 WORKDIR /builder
 

--- a/source-mysql/Dockerfile
+++ b/source-mysql/Dockerfile
@@ -2,7 +2,7 @@ ARG BASE_IMAGE=ghcr.io/estuary/base-image:v1
 
 # Build Stage
 ################################################################################
-FROM golang:1.24-bullseye as builder
+FROM golang:1.22-bullseye as builder
 
 WORKDIR /builder
 

--- a/source-oracle-batch/Dockerfile
+++ b/source-oracle-batch/Dockerfile
@@ -2,7 +2,7 @@ ARG BASE_IMAGE=ghcr.io/estuary/base-image:v1
 
 # Build Stage
 ################################################################################
-FROM golang:1.24-bullseye as builder
+FROM golang:1.22-bullseye as builder
 
 WORKDIR /builder
 

--- a/source-oracle/Dockerfile
+++ b/source-oracle/Dockerfile
@@ -2,7 +2,7 @@ ARG BASE_IMAGE=ghcr.io/estuary/base-image:v1
 
 # Build Stage
 ################################################################################
-FROM golang:1.24-bullseye as builder
+FROM golang:1.22-bullseye as builder
 
 WORKDIR /builder
 

--- a/source-postgres-batch/Dockerfile
+++ b/source-postgres-batch/Dockerfile
@@ -2,7 +2,7 @@ ARG BASE_IMAGE=ghcr.io/estuary/base-image:v1
 
 # Build Stage
 ################################################################################
-FROM golang:1.24-bullseye as builder
+FROM golang:1.22-bullseye as builder
 
 WORKDIR /builder
 

--- a/source-postgres/Dockerfile
+++ b/source-postgres/Dockerfile
@@ -2,7 +2,7 @@ ARG BASE_IMAGE=ghcr.io/estuary/base-image:v1
 
 # Build Stage
 ################################################################################
-FROM golang:1.24-bullseye as builder
+FROM golang:1.22-bullseye as builder
 
 WORKDIR /builder
 

--- a/source-redshift-batch/Dockerfile
+++ b/source-redshift-batch/Dockerfile
@@ -2,7 +2,7 @@ ARG BASE_IMAGE=ghcr.io/estuary/base-image:v1
 
 # Build Stage
 ################################################################################
-FROM golang:1.24-bullseye as builder
+FROM golang:1.22-bullseye as builder
 
 WORKDIR /builder
 

--- a/source-s3/Dockerfile
+++ b/source-s3/Dockerfile
@@ -2,7 +2,7 @@ ARG BASE_IMAGE=ghcr.io/estuary/base-image:v1
 
 # Build Stage
 ################################################################################
-FROM golang:1.24-bullseye as builder
+FROM golang:1.22-bullseye as builder
 
 WORKDIR /builder
 

--- a/source-sftp/Dockerfile
+++ b/source-sftp/Dockerfile
@@ -2,7 +2,7 @@ ARG BASE_IMAGE=ghcr.io/estuary/base-image:v1
 
 # Build Stage
 ################################################################################
-FROM golang:1.24-bullseye as builder
+FROM golang:1.22-bullseye as builder
 
 WORKDIR /builder
 

--- a/source-snowflake/Dockerfile
+++ b/source-snowflake/Dockerfile
@@ -2,7 +2,7 @@ ARG BASE_IMAGE=ghcr.io/estuary/base-image:v1
 
 # Build Stage
 ################################################################################
-FROM golang:1.24-bullseye as builder
+FROM golang:1.22-bullseye as builder
 
 WORKDIR /builder
 

--- a/source-sqlserver/Dockerfile
+++ b/source-sqlserver/Dockerfile
@@ -2,7 +2,7 @@ ARG BASE_IMAGE=ghcr.io/estuary/base-image:v1
 
 # Build Stage
 ################################################################################
-FROM golang:1.24-bullseye as builder
+FROM golang:1.22-bullseye as builder
 
 WORKDIR /builder
 

--- a/source-test/Dockerfile
+++ b/source-test/Dockerfile
@@ -2,7 +2,7 @@ ARG BASE_IMAGE=ghcr.io/estuary/base-image:v1
 
 # Build Stage
 ################################################################################
-FROM golang:1.24-bullseye as builder
+FROM golang:1.22-bullseye as builder
 
 WORKDIR /builder
 


### PR DESCRIPTION
This reverts commit 29b237eaaf6175e07ea4c0dc6a6156b7e65ec150.

**Description:**

The version of the vitess package we use for SQL parsing in `source-mysql` has uses of `linkname` that make it fail to compile on Go versions > 1.23. Later versions of the vitess SQL parser have breaking API modifications that will need to be resolved for us to upgrade to Go 1.24 across the board, so I am reverting this for now.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2426)
<!-- Reviewable:end -->
