### PR TITLE
connectors: update schemagen

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -42,8 +42,7 @@ require (
 	github.com/gogo/protobuf v1.3.2
 	github.com/golang-jwt/jwt/v5 v5.2.1
 	github.com/google/uuid v1.6.0
-	github.com/iancoleman/orderedmap v0.3.0
-	github.com/invopop/jsonschema v0.5.0
+	github.com/invopop/jsonschema v0.13.0
 	github.com/jackc/pgconn v1.14.3
 	github.com/jackc/pglogrepl v0.0.0-20240307033717-828fbfe908e9
 	github.com/jackc/pgx/v5 v5.6.0
@@ -56,6 +55,7 @@ require (
 	github.com/mitchellh/mapstructure v1.5.0
 	github.com/pinecone-io/go-pinecone v1.1.1
 	github.com/pkg/sftp v1.13.6
+	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2
 	github.com/segmentio/encoding v0.4.0
 	github.com/senseyeio/duration v0.0.0-20180430131211-7c2a214ada46
 	github.com/sijms/go-ora/v2 v2.8.19
@@ -65,6 +65,7 @@ require (
 	github.com/stretchr/testify v1.9.0
 	github.com/tidwall/gjson v1.17.1
 	github.com/trinodb/trino-go-client v0.313.0
+	github.com/wk8/go-ordered-map/v2 v2.1.8
 	github.com/xitongsys/parquet-go v1.6.2
 	github.com/xitongsys/parquet-go-source v0.0.0-20220527110425-ba4adb87a31b
 	go.gazette.dev/core v0.100.0
@@ -79,6 +80,7 @@ require (
 	google.golang.org/genproto v0.0.0-20240610135401-a8a62080eff3
 	google.golang.org/grpc v1.65.0
 	google.golang.org/protobuf v1.34.2
+	gopkg.in/yaml.v3 v3.0.1
 	vitess.io/vitess v0.15.3
 )
 
@@ -136,7 +138,9 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/sso v1.12.8 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.14.8 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sts v1.18.9 // indirect
+	github.com/bahlo/generic-list-go v0.2.0 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
+	github.com/buger/jsonparser v1.1.1 // indirect
 	github.com/coreos/go-oidc/v3 v3.10.0 // indirect
 	github.com/danieljoos/wincred v1.2.1 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
@@ -185,6 +189,7 @@ require (
 	github.com/klauspost/cpuid/v2 v2.2.8 // indirect
 	github.com/kr/fs v0.1.0 // indirect
 	github.com/kylelemons/godebug v1.1.0 // indirect
+	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/matishsiao/goInfo v0.0.0-20210923090445-da2e3fa8d45f // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
@@ -199,7 +204,6 @@ require (
 	github.com/pingcap/errors v0.11.5-0.20240311024730-e056997136bb // indirect
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c // indirect
 	github.com/pkg/errors v0.9.1 // indirect
-	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/prometheus/client_golang v1.19.1 // indirect
 	github.com/prometheus/client_model v0.6.1 // indirect
 	github.com/prometheus/common v0.54.0 // indirect
@@ -249,7 +253,6 @@ require (
 	gopkg.in/jcmturner/dnsutils.v1 v1.0.1 // indirect
 	gopkg.in/jcmturner/gokrb5.v6 v6.1.1 // indirect
 	gopkg.in/jcmturner/rpc.v1 v1.1.0 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 	gotest.tools/gotestsum v1.8.2 // indirect
 	k8s.io/apimachinery v0.23.17 // indirect
 	nhooyr.io/websocket v1.8.7 // indirect

--- a/go.sum
+++ b/go.sum
@@ -267,6 +267,8 @@ github.com/aws/smithy-go v1.13.5/go.mod h1:Tg+OJXh4MB2R/uN61Ko2f6hTZwB/ZYGOtib8J
 github.com/aws/smithy-go v1.14.2/go.mod h1:Tg+OJXh4MB2R/uN61Ko2f6hTZwB/ZYGOtib8J3gBHzA=
 github.com/aws/smithy-go v1.20.2 h1:tbp628ireGtzcHDDmLT/6ADHidqnwgF57XOXZe6tp4Q=
 github.com/aws/smithy-go v1.20.2/go.mod h1:krry+ya/rV9RDcV/Q16kpu6ypI4K2czasz0NC3qS14E=
+github.com/bahlo/generic-list-go v0.2.0 h1:5sz/EEAK+ls5wF+NeqDpk5+iNdMDXrh3z3nPnH1Wvgk=
+github.com/bahlo/generic-list-go v0.2.0/go.mod h1:2KvAjgMlE5NNynlg/5iLrrCCZ2+5xWbdbCW3pNTGyYg=
 github.com/beego/goyaml2 v0.0.0-20130207012346-5545475820dd/go.mod h1:1b+Y/CofkYwXMUU0OhQqGvsY2Bvgr4j6jfT699wyZKQ=
 github.com/beego/x2j v0.0.0-20131220205130-a0352aadc542/go.mod h1:kSeGC/p1AbBiEp5kat81+DSQrZenVBZXklMLaELspWU=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
@@ -279,6 +281,8 @@ github.com/boombuler/barcode v1.0.0/go.mod h1:paBWMcWSl3LHKBqUq+rly7CNSldXjb2rDl
 github.com/bradfitz/gomemcache v0.0.0-20180710155616-bc664df96737/go.mod h1:PmM6Mmwb0LSuEubjR8N7PtNe1KxZLtOUHtbeikc5h60=
 github.com/bradleyjkemp/cupaloy v2.3.0+incompatible h1:UafIjBvWQmS9i/xRg+CamMrnLTKNzo+bdmT/oH34c2Y=
 github.com/bradleyjkemp/cupaloy v2.3.0+incompatible/go.mod h1:Au1Xw1sgaJ5iSFktEhYsS0dbQiS1B0/XMXl+42y9Ilk=
+github.com/buger/jsonparser v1.1.1 h1:2PnMjfWD7wBILjqQbt530v576A/cAbQvEW9gGIpYMUs=
+github.com/buger/jsonparser v1.1.1/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx27UK13J/0=
 github.com/bytedance/sonic v1.10.0 h1:qtNZduETEIWJVIyDl01BeNxur2rW9OwTQ/yBqFRkKEk=
 github.com/bytedance/sonic v1.10.0/go.mod h1:iZcSUejdk5aukTND/Eu/ivjQuEL0Cu9/rf50Hi0u/g4=
 github.com/casbin/casbin v1.7.0/go.mod h1:c67qKN6Oum3UF5Q1+BByfFxkwKvhwW57ITjqwtzR1KE=
@@ -603,15 +607,12 @@ github.com/hashicorp/golang-lru v0.5.4/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uG
 github.com/hashicorp/golang-lru v1.0.2 h1:dV3g9Z/unq5DpblPpw+Oqcv4dU/1omnb4Ok8iPY6p1c=
 github.com/hashicorp/golang-lru v1.0.2/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
-github.com/iancoleman/orderedmap v0.0.0-20190318233801-ac98e3ecb4b0/go.mod h1:N0Wam8K1arqPXNWjMo21EXnBPOPp36vB07FNRdD2geA=
-github.com/iancoleman/orderedmap v0.3.0 h1:5cbR2grmZR/DiVt+VJopEhtVs9YGInGIxAoMJn+Ichc=
-github.com/iancoleman/orderedmap v0.3.0/go.mod h1:XuLcCUkdL5owUCQeF2Ue9uuw1EptkJDkXXS7VoV7XGE=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/imdario/mergo v0.3.13 h1:lFzP57bqS/wsqKssCGmtLAb8A0wKjLGrve2q3PPVcBk=
 github.com/imdario/mergo v0.3.13/go.mod h1:4lJ1jqUDcsbIECGy0RUJAXNIhg+6ocWgb1ALK2O4oXg=
-github.com/invopop/jsonschema v0.5.0 h1:6tvpBcwTGxzvx3M9f3IfzqQVyZvoH+0NRUtBcsgyfrU=
-github.com/invopop/jsonschema v0.5.0/go.mod h1:O9uiLokuu0+MGFlyiaqtWxwqJm41/+8Nj0lD7A36YH0=
+github.com/invopop/jsonschema v0.13.0 h1:KvpoAJWEjR3uD9Kbm2HWJmqsEaHt8lBUpd0qHcIi21E=
+github.com/invopop/jsonschema v0.13.0/go.mod h1:ffZ5Km5SWWRAIN6wbDXItl95euhFz2uON45H2qjYt+0=
 github.com/jackc/chunkreader/v2 v2.0.0/go.mod h1:odVSm741yZoC3dpHEUXIqA9tQRhFrgOHwnPIn9lDKlk=
 github.com/jackc/chunkreader/v2 v2.0.1 h1:i+RDz65UE+mmpjTfyz0MoVTnzeYxroil2G82ki7MGG8=
 github.com/jackc/chunkreader/v2 v2.0.1/go.mod h1:odVSm741yZoC3dpHEUXIqA9tQRhFrgOHwnPIn9lDKlk=
@@ -643,6 +644,7 @@ github.com/jmespath/go-jmespath/internal/testify v1.5.1 h1:shLQSRRSCCPj3f2gpwzGw
 github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfCI6z80xFu9LTZmf1ZRjMHUOPmWr69U=
 github.com/jmoiron/sqlx v1.4.0 h1:1PLqN7S1UYp5t4SrVVnt4nUVNemrDAtxlulVe+Qgm3o=
 github.com/jmoiron/sqlx v1.4.0/go.mod h1:ZrZ7UsYB/weZdl2Bxg6jCRO9c3YHl8r3ahlKmRT4JLY=
+github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/json-iterator/go v1.1.9/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
 github.com/json-iterator/go v1.1.10/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
@@ -687,6 +689,8 @@ github.com/leodido/go-urn v1.2.4/go.mod h1:7ZrI8mTSeBSHl/UaRyKQW1qZeMgak41ANeCNa
 github.com/lib/pq v1.0.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
 github.com/lib/pq v1.10.9 h1:YXG7RB+JIjhP29X+OtkiDnYaXQwpS4JEWq7dtCCRUEw=
 github.com/lib/pq v1.10.9/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
+github.com/mailru/easyjson v0.7.7 h1:UGYAvKxe3sBsEDzO8ZeWOSlIQfWFlxbzLZe7hwFURr0=
+github.com/mailru/easyjson v0.7.7/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
 github.com/marcboeker/go-duckdb v1.8.0 h1:iOWv1wTL0JIMqpyns6hCf5XJJI4fY6lmJNk+itx5RRo=
 github.com/marcboeker/go-duckdb v1.8.0/go.mod h1:2oV8BZv88S16TKGKM+Lwd0g7DX84x0jMxjTInThC8Is=
 github.com/matishsiao/goInfo v0.0.0-20210923090445-da2e3fa8d45f h1:B0OD7nYl2FPQEVrw8g2uyc1lGEzNbvrKh7fspGZcbvY=
@@ -871,7 +875,6 @@ github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/
 github.com/stretchr/testify v1.2.0/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
-github.com/stretchr/testify v1.3.1-0.20190311161405-34c6fa2dc709/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
@@ -912,6 +915,8 @@ github.com/vmihailenco/msgpack/v5 v5.3.5/go.mod h1:7xyJ9e+0+9SaZT0Wt1RGleJXzli6Q
 github.com/vmihailenco/tagparser/v2 v2.0.0 h1:y09buUbR+b5aycVFQs/g70pqKVZNBmxwAhO7/IwNM9g=
 github.com/vmihailenco/tagparser/v2 v2.0.0/go.mod h1:Wri+At7QHww0WTrCBeu4J6bNtoV6mEfg5OIWRZA9qds=
 github.com/wendal/errors v0.0.0-20130201093226-f66c77a7882b/go.mod h1:Q12BUT7DqIlHRmgv3RskH+UCM/4eqVMgI0EMmlSpAXc=
+github.com/wk8/go-ordered-map/v2 v2.1.8 h1:5h/BUHu93oj4gIdvHHHGsScSTMijfx5PeYkE/fJgbpc=
+github.com/wk8/go-ordered-map/v2 v2.1.8/go.mod h1:5nJHM5DyteebpVlHnWMV0rPz6Zp7+xBAnxjb1X5vnTw=
 github.com/xdg-go/pbkdf2 v1.0.0 h1:Su7DPu48wXMwC3bs7MCNG+z4FhcyEuz5dlvchbq0B0c=
 github.com/xdg-go/pbkdf2 v1.0.0/go.mod h1:jrpuAogTd400dnrH08LKmI/xc1MbPOebTwRqcT5RDeI=
 github.com/xdg-go/scram v1.1.2 h1:FHX5I5B4i4hKRVRBCFRxq1iQRej7WO3hhBuJf+UUySY=

--- a/go/auth/google/.snapshots/TestConfigSchema
+++ b/go/auth/google/.snapshots/TestConfigSchema
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft/2020-12/schema",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://github.com/estuary/connectors/go/auth/google/credential-config",
   "oneOf": [
     {

--- a/go/auth/google/config.go
+++ b/go/auth/google/config.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/iancoleman/orderedmap"
 	"github.com/invopop/jsonschema"
+	orderedmap "github.com/wk8/go-ordered-map/v2"
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/google"
 )
@@ -86,7 +86,7 @@ func (c *CredentialConfig) GoogleCredentials(ctx context.Context, scopes ...stri
 // github.com/invopop/jsonschema package in go-schema-gen, to fullfill the required schema shape for
 // our oauth connectors.
 func (CredentialConfig) JSONSchema() *jsonschema.Schema {
-	serviceAccountProps := orderedmap.New()
+	serviceAccountProps := orderedmap.New[string, *jsonschema.Schema]()
 	serviceAccountProps.Set("auth_type", &jsonschema.Schema{
 		Type:    "string",
 		Default: SERVICE_AUTH_TYPE,
@@ -105,7 +105,7 @@ func (CredentialConfig) JSONSchema() *jsonschema.Schema {
 		},
 	})
 
-	oauthProps := orderedmap.New()
+	oauthProps := orderedmap.New[string, *jsonschema.Schema]()
 	oauthProps.Set("auth_type", &jsonschema.Schema{
 		Type:    "string",
 		Default: CLIENT_AUTH_TYPE,

--- a/go/schema-gen/.snapshots/TestGenerateSchema
+++ b/go/schema-gen/.snapshots/TestGenerateSchema
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft/2020-12/schema",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://github.com/estuary/connectors/go/schema-gen/test-config",
   "properties": {
     "password": {

--- a/materialize-azure-fabric-warehouse/.snapshots/TestSpecification
+++ b/materialize-azure-fabric-warehouse/.snapshots/TestSpecification
@@ -1,6 +1,6 @@
 {
   "config_schema_json": {
-    "$schema": "http://json-schema.org/draft/2020-12/schema",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$id": "https://github.com/estuary/connectors/materialize-azure-fabric-warehouse/config",
     "properties": {
       "clientID": {
@@ -188,7 +188,7 @@
     "title": "SQL Connection"
   },
   "resource_config_schema_json": {
-    "$schema": "http://json-schema.org/draft/2020-12/schema",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$id": "https://github.com/estuary/connectors/materialize-azure-fabric-warehouse/table-config",
     "properties": {
       "table": {

--- a/materialize-bigquery/.snapshots/TestSpecification
+++ b/materialize-bigquery/.snapshots/TestSpecification
@@ -1,6 +1,6 @@
 {
   "config_schema_json": {
-    "$schema": "http://json-schema.org/draft/2020-12/schema",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$id": "https://github.com/estuary/connectors/materialize-bigquery/config",
     "properties": {
       "project_id": {
@@ -186,7 +186,7 @@
     "title": "SQL Connection"
   },
   "resource_config_schema_json": {
-    "$schema": "http://json-schema.org/draft/2020-12/schema",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$id": "https://github.com/estuary/connectors/materialize-bigquery/table-config",
     "properties": {
       "table": {

--- a/materialize-boilerplate/.snapshots/TestScheduleConfigSchema
+++ b/materialize-boilerplate/.snapshots/TestScheduleConfigSchema
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft/2020-12/schema",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://github.com/estuary/connectors/materialize-boilerplate/schedule-config",
   "properties": {
     "syncFrequency": {

--- a/materialize-databricks/.snapshots/TestSpecification
+++ b/materialize-databricks/.snapshots/TestSpecification
@@ -1,6 +1,6 @@
 {
   "config_schema_json": {
-    "$schema": "http://json-schema.org/draft/2020-12/schema",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$id": "https://github.com/estuary/connectors/materialize-databricks/config",
     "properties": {
       "address": {
@@ -187,7 +187,7 @@
     "title": "SQL Connection"
   },
   "resource_config_schema_json": {
-    "$schema": "http://json-schema.org/draft/2020-12/schema",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$id": "https://github.com/estuary/connectors/materialize-databricks/table-config",
     "properties": {
       "table": {

--- a/materialize-databricks/config.go
+++ b/materialize-databricks/config.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/estuary/connectors/go/dbt"
 	boilerplate "github.com/estuary/connectors/materialize-boilerplate"
-	"github.com/iancoleman/orderedmap"
 	"github.com/invopop/jsonschema"
+	orderedmap "github.com/wk8/go-ordered-map/v2"
 )
 
 // config represents the endpoint configuration for sql server.
@@ -55,7 +55,7 @@ func (c *credentialConfig) validatePATCreds() error {
 // github.com/invopop/jsonschema package in go-schema-gen, to fullfill the required schema shape for
 // our oauth
 func (credentialConfig) JSONSchema() *jsonschema.Schema {
-	patProps := orderedmap.New()
+	patProps := orderedmap.New[string, *jsonschema.Schema]()
 	patProps.Set("auth_type", &jsonschema.Schema{
 		Type:    "string",
 		Default: PAT_AUTH_TYPE,

--- a/materialize-dynamodb/.snapshots/TestSpec
+++ b/materialize-dynamodb/.snapshots/TestSpec
@@ -1,6 +1,6 @@
 {
   "config_schema_json": {
-    "$schema": "http://json-schema.org/draft/2020-12/schema",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$id": "https://github.com/estuary/connectors/materialize-dynamodb/config",
     "properties": {
       "awsAccessKeyId": {
@@ -45,7 +45,7 @@
     "title": "Materialize DynamoDB Spec"
   },
   "resource_config_schema_json": {
-    "$schema": "http://json-schema.org/draft/2020-12/schema",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$id": "https://github.com/estuary/connectors/materialize-dynamodb/resource",
     "properties": {
       "table": {

--- a/materialize-elasticsearch/.snapshots/TestDriverSpec
+++ b/materialize-elasticsearch/.snapshots/TestDriverSpec
@@ -1,6 +1,6 @@
 {
   "config_schema_json": {
-    "$schema": "http://json-schema.org/draft/2020-12/schema",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$id": "https://github.com/estuary/connectors/materialize-elasticsearch/config",
     "properties": {
       "endpoint": {
@@ -113,7 +113,7 @@
     "title": "Elasticsearch Connection"
   },
   "resource_config_schema_json": {
-    "$schema": "http://json-schema.org/draft/2020-12/schema",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$id": "https://github.com/estuary/connectors/materialize-elasticsearch/resource",
     "properties": {
       "index": {

--- a/materialize-elasticsearch/driver.go
+++ b/materialize-elasticsearch/driver.go
@@ -60,7 +60,7 @@ type advancedConfig struct {
 // instead of being generated from the structs.
 func configSchema() json.RawMessage {
 	var schemaStr = `{
-		"$schema": "http://json-schema.org/draft/2020-12/schema",
+		"$schema": "https://json-schema.org/draft/2020-12/schema",
 		"$id": "https://github.com/estuary/connectors/materialize-elasticsearch/config",
 		"properties": {
 		  "endpoint": {

--- a/materialize-firebolt/.snapshots/TestDriverSpec
+++ b/materialize-firebolt/.snapshots/TestDriverSpec
@@ -1,6 +1,6 @@
 {
   "config_schema_json": {
-    "$schema": "http://json-schema.org/draft/2020-12/schema",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$id": "https://github.com/estuary/connectors/materialize-firebolt/config",
     "properties": {
       "client_id": {
@@ -79,7 +79,7 @@
     "title": "Firebolt Connection"
   },
   "resource_config_schema_json": {
-    "$schema": "http://json-schema.org/draft/2020-12/schema",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$id": "https://github.com/estuary/connectors/materialize-firebolt/resource",
     "properties": {
       "table": {

--- a/materialize-gcs-csv/.snapshots/TestSpec
+++ b/materialize-gcs-csv/.snapshots/TestSpec
@@ -1,6 +1,6 @@
 {
   "config_schema_json": {
-    "$schema": "http://json-schema.org/draft/2020-12/schema",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$id": "https://github.com/estuary/connectors/materialize-gcs-csv/config",
     "properties": {
       "bucket": {
@@ -66,7 +66,7 @@
     "title": "EndpointConfig"
   },
   "resource_config_schema_json": {
-    "$schema": "http://json-schema.org/draft/2020-12/schema",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$id": "https://github.com/estuary/connectors/filesink/resource",
     "properties": {
       "path": {

--- a/materialize-gcs-parquet/.snapshots/TestSpec
+++ b/materialize-gcs-parquet/.snapshots/TestSpec
@@ -1,6 +1,6 @@
 {
   "config_schema_json": {
-    "$schema": "http://json-schema.org/draft/2020-12/schema",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$id": "https://github.com/estuary/connectors/materialize-gcs-parquet/config",
     "properties": {
       "bucket": {
@@ -72,7 +72,7 @@
     "title": "EndpointConfig"
   },
   "resource_config_schema_json": {
-    "$schema": "http://json-schema.org/draft/2020-12/schema",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$id": "https://github.com/estuary/connectors/filesink/resource",
     "properties": {
       "path": {

--- a/materialize-google-pubsub/.snapshots/TestSpec
+++ b/materialize-google-pubsub/.snapshots/TestSpec
@@ -1,6 +1,6 @@
 {
   "config_schema_json": {
-    "$schema": "http://json-schema.org/draft/2020-12/schema",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$id": "https://github.com/estuary/connectors/materialize-google-pubsub/config",
     "properties": {
       "project_id": {
@@ -82,7 +82,7 @@
     "title": "Materialize Google PubSub Spec"
   },
   "resource_config_schema_json": {
-    "$schema": "http://json-schema.org/draft/2020-12/schema",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$id": "https://github.com/estuary/connectors/materialize-google-pubsub/resource",
     "properties": {
       "topic": {

--- a/materialize-google-sheets/.snapshots/TestSpec
+++ b/materialize-google-sheets/.snapshots/TestSpec
@@ -1,6 +1,6 @@
 {
   "config_schema_json": {
-    "$schema": "http://json-schema.org/draft/2020-12/schema",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$id": "https://github.com/estuary/connectors/materialize-google-sheets/config",
     "properties": {
       "spreadsheetUrl": {
@@ -82,7 +82,7 @@
     "title": "Google Sheets Materialization"
   },
   "resource_config_schema_json": {
-    "$schema": "http://json-schema.org/draft/2020-12/schema",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$id": "https://github.com/estuary/connectors/materialize-google-sheets/resource",
     "properties": {
       "sheet": {

--- a/materialize-mongodb/.snapshots/TestSpecification
+++ b/materialize-mongodb/.snapshots/TestSpecification
@@ -1,6 +1,6 @@
 {
   "config_schema_json": {
-    "$schema": "http://json-schema.org/draft/2020-12/schema",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$id": "https://github.com/estuary/connectors/materialize-mongodb/config",
     "properties": {
       "address": {
@@ -78,7 +78,7 @@
     "title": "Materialize MongoDB Spec"
   },
   "resource_config_schema_json": {
-    "$schema": "http://json-schema.org/draft/2020-12/schema",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$id": "https://github.com/estuary/connectors/materialize-mongodb/resource",
     "properties": {
       "collection": {

--- a/materialize-motherduck/.snapshots/TestSpecification
+++ b/materialize-motherduck/.snapshots/TestSpecification
@@ -1,6 +1,6 @@
 {
   "config_schema_json": {
-    "$schema": "http://json-schema.org/draft/2020-12/schema",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$id": "https://github.com/estuary/connectors/materialize-motherduck/config",
     "properties": {
       "token": {
@@ -75,7 +75,7 @@
     "title": "SQL Connection"
   },
   "resource_config_schema_json": {
-    "$schema": "http://json-schema.org/draft/2020-12/schema",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$id": "https://github.com/estuary/connectors/materialize-motherduck/table-config",
     "properties": {
       "table": {

--- a/materialize-mysql/.snapshots/TestSpecification
+++ b/materialize-mysql/.snapshots/TestSpecification
@@ -1,6 +1,6 @@
 {
   "config_schema_json": {
-    "$schema": "http://json-schema.org/draft/2020-12/schema",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$id": "https://github.com/estuary/connectors/materialize-mysql/config",
     "properties": {
       "address": {
@@ -183,7 +183,7 @@
     "title": "SQL Connection"
   },
   "resource_config_schema_json": {
-    "$schema": "http://json-schema.org/draft/2020-12/schema",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$id": "https://github.com/estuary/connectors/materialize-mysql/table-config",
     "properties": {
       "table": {

--- a/materialize-pinecone/.snapshots/TestSpecification
+++ b/materialize-pinecone/.snapshots/TestSpecification
@@ -1,6 +1,6 @@
 {
   "config_schema_json": {
-    "$schema": "http://json-schema.org/draft/2020-12/schema",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$id": "https://github.com/estuary/connectors/materialize-pinecone/config",
     "properties": {
       "index": {
@@ -53,7 +53,7 @@
     "title": "Materialize Pinecone Spec"
   },
   "resource_config_schema_json": {
-    "$schema": "http://json-schema.org/draft/2020-12/schema",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$id": "https://github.com/estuary/connectors/materialize-pinecone/resource",
     "properties": {
       "namespace": {

--- a/materialize-postgres/.snapshots/TestSpecification
+++ b/materialize-postgres/.snapshots/TestSpecification
@@ -1,6 +1,6 @@
 {
   "config_schema_json": {
-    "$schema": "http://json-schema.org/draft/2020-12/schema",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$id": "https://github.com/estuary/connectors/materialize-postgres/config",
     "properties": {
       "address": {
@@ -163,7 +163,7 @@
     "title": "SQL Connection"
   },
   "resource_config_schema_json": {
-    "$schema": "http://json-schema.org/draft/2020-12/schema",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$id": "https://github.com/estuary/connectors/materialize-postgres/table-config",
     "properties": {
       "table": {

--- a/materialize-redshift/.snapshots/TestSpecification
+++ b/materialize-redshift/.snapshots/TestSpecification
@@ -1,6 +1,6 @@
 {
   "config_schema_json": {
-    "$schema": "http://json-schema.org/draft/2020-12/schema",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$id": "https://github.com/estuary/connectors/materialize-redshift/config",
     "properties": {
       "address": {
@@ -226,7 +226,7 @@
     "title": "SQL Connection"
   },
   "resource_config_schema_json": {
-    "$schema": "http://json-schema.org/draft/2020-12/schema",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$id": "https://github.com/estuary/connectors/materialize-redshift/table-config",
     "properties": {
       "table": {

--- a/materialize-s3-csv/.snapshots/TestSpec
+++ b/materialize-s3-csv/.snapshots/TestSpec
@@ -1,6 +1,6 @@
 {
   "config_schema_json": {
-    "$schema": "http://json-schema.org/draft/2020-12/schema",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$id": "https://github.com/estuary/connectors/materialize-s3-csv/config",
     "properties": {
       "bucket": {
@@ -85,7 +85,7 @@
     "title": "EndpointConfig"
   },
   "resource_config_schema_json": {
-    "$schema": "http://json-schema.org/draft/2020-12/schema",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$id": "https://github.com/estuary/connectors/filesink/resource",
     "properties": {
       "path": {

--- a/materialize-s3-iceberg/.snapshots/TestSpec
+++ b/materialize-s3-iceberg/.snapshots/TestSpec
@@ -153,7 +153,7 @@
     "type": "object"
   },
   "resource_config_schema_json": {
-    "$schema": "http://json-schema.org/draft/2020-12/schema",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$id": "https://github.com/estuary/connectors/materialize-s3-iceberg/resource",
     "properties": {
       "table": {

--- a/materialize-s3-parquet/.snapshots/TestSpec
+++ b/materialize-s3-parquet/.snapshots/TestSpec
@@ -1,6 +1,6 @@
 {
   "config_schema_json": {
-    "$schema": "http://json-schema.org/draft/2020-12/schema",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$id": "https://github.com/estuary/connectors/materialize-s3-parquet/config",
     "properties": {
       "bucket": {
@@ -91,7 +91,7 @@
     "title": "EndpointConfig"
   },
   "resource_config_schema_json": {
-    "$schema": "http://json-schema.org/draft/2020-12/schema",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$id": "https://github.com/estuary/connectors/filesink/resource",
     "properties": {
       "path": {

--- a/materialize-snowflake/.snapshots/TestSpecification
+++ b/materialize-snowflake/.snapshots/TestSpecification
@@ -1,6 +1,6 @@
 {
   "config_schema_json": {
-    "$schema": "http://json-schema.org/draft/2020-12/schema",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$id": "https://github.com/estuary/connectors/materialize-snowflake/config",
     "properties": {
       "host": {
@@ -233,7 +233,7 @@
     "title": "SQL Connection"
   },
   "resource_config_schema_json": {
-    "$schema": "http://json-schema.org/draft/2020-12/schema",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$id": "https://github.com/estuary/connectors/materialize-snowflake/table-config",
     "properties": {
       "table": {

--- a/materialize-snowflake/config.go
+++ b/materialize-snowflake/config.go
@@ -10,12 +10,11 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/iancoleman/orderedmap"
-	"github.com/invopop/jsonschema"
-
 	"github.com/estuary/connectors/go/dbt"
 	boilerplate "github.com/estuary/connectors/materialize-boilerplate"
+	"github.com/invopop/jsonschema"
 	sf "github.com/snowflakedb/gosnowflake"
+	orderedmap "github.com/wk8/go-ordered-map/v2"
 )
 
 // config represents the endpoint configuration for snowflake.
@@ -208,7 +207,7 @@ func (c *credentialConfig) validateJWTCreds() error {
 // github.com/invopop/jsonschema package in go-schema-gen, to fullfill the required schema shape for
 // our oauth
 func (credentialConfig) JSONSchema() *jsonschema.Schema {
-	uProps := orderedmap.New()
+	uProps := orderedmap.New[string, *jsonschema.Schema]()
 	uProps.Set("auth_type", &jsonschema.Schema{
 		Type:    "string",
 		Default: UserPass,
@@ -232,7 +231,7 @@ func (credentialConfig) JSONSchema() *jsonschema.Schema {
 		},
 	})
 
-	jwtProps := orderedmap.New()
+	jwtProps := orderedmap.New[string, *jsonschema.Schema]()
 	jwtProps.Set("auth_type", &jsonschema.Schema{
 		Type:    "string",
 		Default: JWT,

--- a/materialize-sqlserver/.snapshots/TestSpecification
+++ b/materialize-sqlserver/.snapshots/TestSpecification
@@ -1,6 +1,6 @@
 {
   "config_schema_json": {
-    "$schema": "http://json-schema.org/draft/2020-12/schema",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$id": "https://github.com/estuary/connectors/materialize-sqlserver/config",
     "properties": {
       "address": {
@@ -141,7 +141,7 @@
     "title": "SQL Connection"
   },
   "resource_config_schema_json": {
-    "$schema": "http://json-schema.org/draft/2020-12/schema",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$id": "https://github.com/estuary/connectors/materialize-sqlserver/table-config",
     "properties": {
       "table": {

--- a/materialize-starburst/.snapshots/TestSpecification
+++ b/materialize-starburst/.snapshots/TestSpecification
@@ -1,6 +1,6 @@
 {
   "config_schema_json": {
-    "$schema": "http://json-schema.org/draft/2020-12/schema",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$id": "https://github.com/estuary/connectors/materialize-starburst/config",
     "properties": {
       "host": {
@@ -123,7 +123,7 @@
     "title": "SQL Connection"
   },
   "resource_config_schema_json": {
-    "$schema": "http://json-schema.org/draft/2020-12/schema",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$id": "https://github.com/estuary/connectors/materialize-starburst/table-config",
     "properties": {
       "table": {

--- a/source-alpaca/.snapshots/TestDiscover
+++ b/source-alpaca/.snapshots/TestDiscover
@@ -5,7 +5,7 @@ Binding 0:
       "name": "iex"
     },
     "document_schema_json": {
-      "$schema": "http://json-schema.org/draft/2020-12/schema",
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://github.com/estuary/connectors/source-alpaca/trade-document",
       "properties": {
         "ID": {

--- a/source-alpaca/.snapshots/TestSpec
+++ b/source-alpaca/.snapshots/TestSpec
@@ -1,6 +1,6 @@
 {
   "config_schema_json": {
-    "$schema": "http://json-schema.org/draft/2020-12/schema",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$id": "https://github.com/estuary/connectors/source-alpaca/config",
     "properties": {
       "api_key_id": {
@@ -87,7 +87,7 @@
     "title": "Source Alpaca Spec"
   },
   "resource_config_schema_json": {
-    "$schema": "http://json-schema.org/draft/2020-12/schema",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$id": "https://github.com/estuary/connectors/source-alpaca/resource",
     "properties": {
       "name": {

--- a/source-bigquery-batch/.snapshots/TestBasicCapture-Discovery
+++ b/source-bigquery-batch/.snapshots/TestBasicCapture-Discovery
@@ -17,7 +17,7 @@ Binding 0:
         ],
         "properties": {
           "_meta": {
-            "$schema": "http://json-schema.org/draft/2020-12/schema",
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "$id": "https://github.com/estuary/connectors/source-bigquery-batch/document-metadata",
             "properties": {
               "polled": {

--- a/source-bigquery-batch/.snapshots/TestDatetimeCursor-Discovery
+++ b/source-bigquery-batch/.snapshots/TestDatetimeCursor-Discovery
@@ -16,7 +16,7 @@ Binding 0:
         ],
         "properties": {
           "_meta": {
-            "$schema": "http://json-schema.org/draft/2020-12/schema",
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "$id": "https://github.com/estuary/connectors/source-bigquery-batch/document-metadata",
             "properties": {
               "polled": {

--- a/source-bigquery-batch/.snapshots/TestSpec
+++ b/source-bigquery-batch/.snapshots/TestSpec
@@ -1,6 +1,6 @@
 {
   "config_schema_json": {
-    "$schema": "http://json-schema.org/draft/2020-12/schema",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$id": "https://github.com/estuary/connectors/source-bigquery-batch/config",
     "properties": {
       "project_id": {
@@ -47,7 +47,7 @@
     "title": "Batch BigQuery"
   },
   "resource_config_schema_json": {
-    "$schema": "http://json-schema.org/draft/2020-12/schema",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$id": "https://github.com/estuary/connectors/source-bigquery-batch/resource",
     "properties": {
       "name": {

--- a/source-dynamodb/.snapshots/TestSpec
+++ b/source-dynamodb/.snapshots/TestSpec
@@ -1,6 +1,6 @@
 {
   "config_schema_json": {
-    "$schema": "http://json-schema.org/draft/2020-12/schema",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$id": "https://github.com/estuary/connectors/source-dynamodb/config",
     "properties": {
       "awsAccessKeyId": {
@@ -55,7 +55,7 @@
     "title": "Source DynamoDB Spec"
   },
   "resource_config_schema_json": {
-    "$schema": "http://json-schema.org/draft/2020-12/schema",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$id": "https://github.com/estuary/connectors/source-dynamodb/resource",
     "properties": {
       "table": {

--- a/source-firestore/.snapshots/TestDiscovery
+++ b/source-firestore/.snapshots/TestDiscovery
@@ -12,7 +12,7 @@ Binding 0:
       ],
       "properties": {
         "_meta": {
-          "$schema": "http://json-schema.org/draft/2020-12/schema",
+          "$schema": "https://json-schema.org/draft/2020-12/schema",
           "$id": "https://github.com/estuary/connectors/source-firestore/document-metadata",
           "properties": {
             "path": {
@@ -76,7 +76,7 @@ Binding 1:
       ],
       "properties": {
         "_meta": {
-          "$schema": "http://json-schema.org/draft/2020-12/schema",
+          "$schema": "https://json-schema.org/draft/2020-12/schema",
           "$id": "https://github.com/estuary/connectors/source-firestore/document-metadata",
           "properties": {
             "path": {
@@ -140,7 +140,7 @@ Binding 2:
       ],
       "properties": {
         "_meta": {
-          "$schema": "http://json-schema.org/draft/2020-12/schema",
+          "$schema": "https://json-schema.org/draft/2020-12/schema",
           "$id": "https://github.com/estuary/connectors/source-firestore/document-metadata",
           "properties": {
             "path": {
@@ -204,7 +204,7 @@ Binding 3:
       ],
       "properties": {
         "_meta": {
-          "$schema": "http://json-schema.org/draft/2020-12/schema",
+          "$schema": "https://json-schema.org/draft/2020-12/schema",
           "$id": "https://github.com/estuary/connectors/source-firestore/document-metadata",
           "properties": {
             "path": {

--- a/source-firestore/.snapshots/TestSpec
+++ b/source-firestore/.snapshots/TestSpec
@@ -1,6 +1,6 @@
 {
   "config_schema_json": {
-    "$schema": "http://json-schema.org/draft/2020-12/schema",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$id": "https://github.com/estuary/connectors/source-firestore/config",
     "properties": {
       "googleCredentials": {
@@ -44,7 +44,7 @@
     "title": "Google Firestore"
   },
   "resource_config_schema_json": {
-    "$schema": "http://json-schema.org/draft/2020-12/schema",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$id": "https://github.com/estuary/connectors/source-firestore/resource",
     "properties": {
       "path": {

--- a/source-google-pubsub/.snapshots/TestSpecification
+++ b/source-google-pubsub/.snapshots/TestSpecification
@@ -1,6 +1,6 @@
 {
   "config_schema_json": {
-    "$schema": "http://json-schema.org/draft/2020-12/schema",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$id": "https://github.com/estuary/connectors/source-google-pubsub/config",
     "properties": {
       "projectId": {
@@ -32,7 +32,7 @@
     "title": "Source Google PubSub Spec"
   },
   "resource_config_schema_json": {
-    "$schema": "http://json-schema.org/draft/2020-12/schema",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$id": "https://github.com/estuary/connectors/source-google-pubsub/resource",
     "properties": {
       "topic": {

--- a/source-kinesis/.snapshots/TestSpec
+++ b/source-kinesis/.snapshots/TestSpec
@@ -1,6 +1,6 @@
 {
   "config_schema_json": {
-    "$schema": "http://json-schema.org/draft/2020-12/schema",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$id": "https://github.com/estuary/connectors/source-kinesis/config",
     "properties": {
       "region": {
@@ -40,7 +40,7 @@
     "title": "Kinesis"
   },
   "resource_config_schema_json": {
-    "$schema": "http://json-schema.org/draft/2020-12/schema",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$id": "https://github.com/estuary/connectors/source-kinesis/resource",
     "properties": {
       "stream": {

--- a/source-mongodb/.snapshots/TestDiscover
+++ b/source-mongodb/.snapshots/TestDiscover
@@ -33,7 +33,7 @@ Binding 0:
           "type": "string"
         },
         "_meta": {
-          "$schema": "http://json-schema.org/draft/2020-12/schema",
+          "$schema": "https://json-schema.org/draft/2020-12/schema",
           "$id": "https://github.com/estuary/connectors/source-mongodb/document-metadata",
           "properties": {
             "op": {
@@ -120,7 +120,7 @@ Binding 1:
           "type": "string"
         },
         "_meta": {
-          "$schema": "http://json-schema.org/draft/2020-12/schema",
+          "$schema": "https://json-schema.org/draft/2020-12/schema",
           "$id": "https://github.com/estuary/connectors/source-mongodb/document-metadata",
           "properties": {
             "op": {

--- a/source-mongodb/.snapshots/TestDiscoverAllDatabases
+++ b/source-mongodb/.snapshots/TestDiscoverAllDatabases
@@ -33,7 +33,7 @@ Binding 0:
           "type": "string"
         },
         "_meta": {
-          "$schema": "http://json-schema.org/draft/2020-12/schema",
+          "$schema": "https://json-schema.org/draft/2020-12/schema",
           "$id": "https://github.com/estuary/connectors/source-mongodb/document-metadata",
           "properties": {
             "op": {
@@ -120,7 +120,7 @@ Binding 1:
           "type": "string"
         },
         "_meta": {
-          "$schema": "http://json-schema.org/draft/2020-12/schema",
+          "$schema": "https://json-schema.org/draft/2020-12/schema",
           "$id": "https://github.com/estuary/connectors/source-mongodb/document-metadata",
           "properties": {
             "op": {
@@ -207,7 +207,7 @@ Binding 2:
           "type": "string"
         },
         "_meta": {
-          "$schema": "http://json-schema.org/draft/2020-12/schema",
+          "$schema": "https://json-schema.org/draft/2020-12/schema",
           "$id": "https://github.com/estuary/connectors/source-mongodb/document-metadata",
           "properties": {
             "op": {
@@ -294,7 +294,7 @@ Binding 3:
           "type": "string"
         },
         "_meta": {
-          "$schema": "http://json-schema.org/draft/2020-12/schema",
+          "$schema": "https://json-schema.org/draft/2020-12/schema",
           "$id": "https://github.com/estuary/connectors/source-mongodb/document-metadata",
           "properties": {
             "op": {
@@ -381,7 +381,7 @@ Binding 4:
           "type": "string"
         },
         "_meta": {
-          "$schema": "http://json-schema.org/draft/2020-12/schema",
+          "$schema": "https://json-schema.org/draft/2020-12/schema",
           "$id": "https://github.com/estuary/connectors/source-mongodb/document-metadata",
           "properties": {
             "op": {
@@ -468,7 +468,7 @@ Binding 5:
           "type": "string"
         },
         "_meta": {
-          "$schema": "http://json-schema.org/draft/2020-12/schema",
+          "$schema": "https://json-schema.org/draft/2020-12/schema",
           "$id": "https://github.com/estuary/connectors/source-mongodb/document-metadata",
           "properties": {
             "op": {

--- a/source-mongodb/.snapshots/TestDiscoverBatchCollections
+++ b/source-mongodb/.snapshots/TestDiscoverBatchCollections
@@ -33,7 +33,7 @@ Binding 0:
           "type": "string"
         },
         "_meta": {
-          "$schema": "http://json-schema.org/draft/2020-12/schema",
+          "$schema": "https://json-schema.org/draft/2020-12/schema",
           "$id": "https://github.com/estuary/connectors/source-mongodb/document-metadata",
           "properties": {
             "op": {
@@ -122,7 +122,7 @@ Binding 1:
           "type": "string"
         },
         "_meta": {
-          "$schema": "http://json-schema.org/draft/2020-12/schema",
+          "$schema": "https://json-schema.org/draft/2020-12/schema",
           "$id": "https://github.com/estuary/connectors/source-mongodb/document-metadata",
           "properties": {
             "op": {
@@ -210,7 +210,7 @@ Binding 2:
           "type": "string"
         },
         "_meta": {
-          "$schema": "http://json-schema.org/draft/2020-12/schema",
+          "$schema": "https://json-schema.org/draft/2020-12/schema",
           "$id": "https://github.com/estuary/connectors/source-mongodb/document-metadata",
           "properties": {
             "op": {

--- a/source-mongodb/.snapshots/TestDiscoverMultipleDatabases
+++ b/source-mongodb/.snapshots/TestDiscoverMultipleDatabases
@@ -33,7 +33,7 @@ Binding 0:
           "type": "string"
         },
         "_meta": {
-          "$schema": "http://json-schema.org/draft/2020-12/schema",
+          "$schema": "https://json-schema.org/draft/2020-12/schema",
           "$id": "https://github.com/estuary/connectors/source-mongodb/document-metadata",
           "properties": {
             "op": {
@@ -120,7 +120,7 @@ Binding 1:
           "type": "string"
         },
         "_meta": {
-          "$schema": "http://json-schema.org/draft/2020-12/schema",
+          "$schema": "https://json-schema.org/draft/2020-12/schema",
           "$id": "https://github.com/estuary/connectors/source-mongodb/document-metadata",
           "properties": {
             "op": {
@@ -207,7 +207,7 @@ Binding 2:
           "type": "string"
         },
         "_meta": {
-          "$schema": "http://json-schema.org/draft/2020-12/schema",
+          "$schema": "https://json-schema.org/draft/2020-12/schema",
           "$id": "https://github.com/estuary/connectors/source-mongodb/document-metadata",
           "properties": {
             "op": {
@@ -294,7 +294,7 @@ Binding 3:
           "type": "string"
         },
         "_meta": {
-          "$schema": "http://json-schema.org/draft/2020-12/schema",
+          "$schema": "https://json-schema.org/draft/2020-12/schema",
           "$id": "https://github.com/estuary/connectors/source-mongodb/document-metadata",
           "properties": {
             "op": {

--- a/source-mongodb/.snapshots/TestSpec
+++ b/source-mongodb/.snapshots/TestSpec
@@ -1,6 +1,6 @@
 {
   "config_schema_json": {
-    "$schema": "http://json-schema.org/draft/2020-12/schema",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$id": "https://github.com/estuary/connectors/source-mongodb/config",
     "properties": {
       "address": {
@@ -99,7 +99,7 @@
     "title": "MongoDB"
   },
   "resource_config_schema_json": {
-    "$schema": "http://json-schema.org/draft/2020-12/schema",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$id": "https://github.com/estuary/connectors/source-mongodb/resource",
     "properties": {
       "database": {

--- a/source-mysql-batch/.snapshots/TestAsyncCapture-Discovery
+++ b/source-mysql-batch/.snapshots/TestAsyncCapture-Discovery
@@ -21,7 +21,7 @@ Binding 0:
         ],
         "properties": {
           "_meta": {
-            "$schema": "http://json-schema.org/draft/2020-12/schema",
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "$id": "https://github.com/estuary/connectors/source-mysql-batch/document-metadata",
             "properties": {
               "polled": {

--- a/source-mysql-batch/.snapshots/TestBinaryTypes-Discovery
+++ b/source-mysql-batch/.snapshots/TestBinaryTypes-Discovery
@@ -21,7 +21,7 @@ Binding 0:
         ],
         "properties": {
           "_meta": {
-            "$schema": "http://json-schema.org/draft/2020-12/schema",
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "$id": "https://github.com/estuary/connectors/source-mysql-batch/document-metadata",
             "properties": {
               "polled": {

--- a/source-mysql-batch/.snapshots/TestCaptureWithEmptyPoll-Discovery
+++ b/source-mysql-batch/.snapshots/TestCaptureWithEmptyPoll-Discovery
@@ -21,7 +21,7 @@ Binding 0:
         ],
         "properties": {
           "_meta": {
-            "$schema": "http://json-schema.org/draft/2020-12/schema",
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "$id": "https://github.com/estuary/connectors/source-mysql-batch/document-metadata",
             "properties": {
               "polled": {

--- a/source-mysql-batch/.snapshots/TestCaptureWithModifications-Discovery
+++ b/source-mysql-batch/.snapshots/TestCaptureWithModifications-Discovery
@@ -21,7 +21,7 @@ Binding 0:
         ],
         "properties": {
           "_meta": {
-            "$schema": "http://json-schema.org/draft/2020-12/schema",
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "$id": "https://github.com/estuary/connectors/source-mysql-batch/document-metadata",
             "properties": {
               "polled": {

--- a/source-mysql-batch/.snapshots/TestCaptureWithNullCursor-Discovery
+++ b/source-mysql-batch/.snapshots/TestCaptureWithNullCursor-Discovery
@@ -21,7 +21,7 @@ Binding 0:
         ],
         "properties": {
           "_meta": {
-            "$schema": "http://json-schema.org/draft/2020-12/schema",
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "$id": "https://github.com/estuary/connectors/source-mysql-batch/document-metadata",
             "properties": {
               "polled": {

--- a/source-mysql-batch/.snapshots/TestCaptureWithTwoColumnCursor-Discovery
+++ b/source-mysql-batch/.snapshots/TestCaptureWithTwoColumnCursor-Discovery
@@ -22,7 +22,7 @@ Binding 0:
         ],
         "properties": {
           "_meta": {
-            "$schema": "http://json-schema.org/draft/2020-12/schema",
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "$id": "https://github.com/estuary/connectors/source-mysql-batch/document-metadata",
             "properties": {
               "polled": {

--- a/source-mysql-batch/.snapshots/TestCaptureWithUpdatedAtCursor-Discovery
+++ b/source-mysql-batch/.snapshots/TestCaptureWithUpdatedAtCursor-Discovery
@@ -21,7 +21,7 @@ Binding 0:
         ],
         "properties": {
           "_meta": {
-            "$schema": "http://json-schema.org/draft/2020-12/schema",
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "$id": "https://github.com/estuary/connectors/source-mysql-batch/document-metadata",
             "properties": {
               "polled": {

--- a/source-mysql-batch/.snapshots/TestDateAndTimeTypes-Discovery
+++ b/source-mysql-batch/.snapshots/TestDateAndTimeTypes-Discovery
@@ -21,7 +21,7 @@ Binding 0:
         ],
         "properties": {
           "_meta": {
-            "$schema": "http://json-schema.org/draft/2020-12/schema",
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "$id": "https://github.com/estuary/connectors/source-mysql-batch/document-metadata",
             "properties": {
               "polled": {

--- a/source-mysql-batch/.snapshots/TestEnumAndSetTypes-Discovery
+++ b/source-mysql-batch/.snapshots/TestEnumAndSetTypes-Discovery
@@ -21,7 +21,7 @@ Binding 0:
         ],
         "properties": {
           "_meta": {
-            "$schema": "http://json-schema.org/draft/2020-12/schema",
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "$id": "https://github.com/estuary/connectors/source-mysql-batch/document-metadata",
             "properties": {
               "polled": {

--- a/source-mysql-batch/.snapshots/TestFullRefresh-Discovery
+++ b/source-mysql-batch/.snapshots/TestFullRefresh-Discovery
@@ -18,7 +18,7 @@ Binding 0:
         ],
         "properties": {
           "_meta": {
-            "$schema": "http://json-schema.org/draft/2020-12/schema",
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "$id": "https://github.com/estuary/connectors/source-mysql-batch/document-metadata",
             "properties": {
               "polled": {

--- a/source-mysql-batch/.snapshots/TestIntegerTypes-Discovery
+++ b/source-mysql-batch/.snapshots/TestIntegerTypes-Discovery
@@ -21,7 +21,7 @@ Binding 0:
         ],
         "properties": {
           "_meta": {
-            "$schema": "http://json-schema.org/draft/2020-12/schema",
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "$id": "https://github.com/estuary/connectors/source-mysql-batch/document-metadata",
             "properties": {
               "polled": {

--- a/source-mysql-batch/.snapshots/TestJSONType-Discovery
+++ b/source-mysql-batch/.snapshots/TestJSONType-Discovery
@@ -21,7 +21,7 @@ Binding 0:
         ],
         "properties": {
           "_meta": {
-            "$schema": "http://json-schema.org/draft/2020-12/schema",
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "$id": "https://github.com/estuary/connectors/source-mysql-batch/document-metadata",
             "properties": {
               "polled": {

--- a/source-mysql-batch/.snapshots/TestNumericTypes-Discovery
+++ b/source-mysql-batch/.snapshots/TestNumericTypes-Discovery
@@ -21,7 +21,7 @@ Binding 0:
         ],
         "properties": {
           "_meta": {
-            "$schema": "http://json-schema.org/draft/2020-12/schema",
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "$id": "https://github.com/estuary/connectors/source-mysql-batch/document-metadata",
             "properties": {
               "polled": {

--- a/source-mysql-batch/.snapshots/TestQueryTemplateOverride-Discovery
+++ b/source-mysql-batch/.snapshots/TestQueryTemplateOverride-Discovery
@@ -20,7 +20,7 @@ Binding 0:
         ],
         "properties": {
           "_meta": {
-            "$schema": "http://json-schema.org/draft/2020-12/schema",
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "$id": "https://github.com/estuary/connectors/source-mysql-batch/document-metadata",
             "properties": {
               "polled": {

--- a/source-mysql-batch/.snapshots/TestSimpleCapture-Discovery
+++ b/source-mysql-batch/.snapshots/TestSimpleCapture-Discovery
@@ -21,7 +21,7 @@ Binding 0:
         ],
         "properties": {
           "_meta": {
-            "$schema": "http://json-schema.org/draft/2020-12/schema",
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "$id": "https://github.com/estuary/connectors/source-mysql-batch/document-metadata",
             "properties": {
               "polled": {

--- a/source-mysql-batch/.snapshots/TestSpatialTypes-Discovery
+++ b/source-mysql-batch/.snapshots/TestSpatialTypes-Discovery
@@ -21,7 +21,7 @@ Binding 0:
         ],
         "properties": {
           "_meta": {
-            "$schema": "http://json-schema.org/draft/2020-12/schema",
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "$id": "https://github.com/estuary/connectors/source-mysql-batch/document-metadata",
             "properties": {
               "polled": {

--- a/source-mysql-batch/.snapshots/TestSpec
+++ b/source-mysql-batch/.snapshots/TestSpec
@@ -1,6 +1,6 @@
 {
   "config_schema_json": {
-    "$schema": "http://json-schema.org/draft/2020-12/schema",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$id": "https://github.com/estuary/connectors/source-mysql-batch/config",
     "properties": {
       "address": {
@@ -90,7 +90,7 @@
     "title": "Batch SQL"
   },
   "resource_config_schema_json": {
-    "$schema": "http://json-schema.org/draft/2020-12/schema",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$id": "https://github.com/estuary/connectors/source-mysql-batch/resource",
     "properties": {
       "name": {

--- a/source-mysql-batch/.snapshots/TestStringTypes-Discovery
+++ b/source-mysql-batch/.snapshots/TestStringTypes-Discovery
@@ -21,7 +21,7 @@ Binding 0:
         ],
         "properties": {
           "_meta": {
-            "$schema": "http://json-schema.org/draft/2020-12/schema",
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "$id": "https://github.com/estuary/connectors/source-mysql-batch/document-metadata",
             "properties": {
               "polled": {

--- a/source-mysql/.snapshots/TestGeneric-SpecResponse
+++ b/source-mysql/.snapshots/TestGeneric-SpecResponse
@@ -1,7 +1,7 @@
 {
   "protocol": 3032023,
   "config_schema_json": {
-    "$schema": "http://json-schema.org/draft/2020-12/schema",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$id": "https://github.com/estuary/connectors/source-mysql/config",
     "properties": {
       "address": {
@@ -141,7 +141,7 @@
     "title": "MySQL Connection"
   },
   "resource_config_schema_json": {
-    "$schema": "http://json-schema.org/draft/2020-12/schema",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$id": "https://github.com/estuary/connectors/sqlcapture/resource",
     "properties": {
       "mode": {

--- a/source-oracle-batch/.snapshots/TestBasicCapture-Discovery
+++ b/source-oracle-batch/.snapshots/TestBasicCapture-Discovery
@@ -25,7 +25,7 @@ Binding 0:
             "format": "integer"
           },
           "_meta": {
-            "$schema": "http://json-schema.org/draft/2020-12/schema",
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "$id": "https://github.com/estuary/connectors/source-oracle-batch/document-metadata",
             "properties": {
               "polled": {

--- a/source-oracle-batch/.snapshots/TestBasicDatatypes-Discovery
+++ b/source-oracle-batch/.snapshots/TestBasicDatatypes-Discovery
@@ -25,7 +25,7 @@ Binding 0:
             "format": "integer"
           },
           "_meta": {
-            "$schema": "http://json-schema.org/draft/2020-12/schema",
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "$id": "https://github.com/estuary/connectors/source-oracle-batch/document-metadata",
             "properties": {
               "polled": {

--- a/source-oracle-batch/.snapshots/TestFloatNaNs-Discovery
+++ b/source-oracle-batch/.snapshots/TestFloatNaNs-Discovery
@@ -25,7 +25,7 @@ Binding 0:
             "format": "integer"
           },
           "_meta": {
-            "$schema": "http://json-schema.org/draft/2020-12/schema",
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "$id": "https://github.com/estuary/connectors/source-oracle-batch/document-metadata",
             "properties": {
               "polled": {

--- a/source-oracle-batch/.snapshots/TestKeyDiscovery
+++ b/source-oracle-batch/.snapshots/TestKeyDiscovery
@@ -38,7 +38,7 @@ Binding 0:
             "type": "string"
           },
           "_meta": {
-            "$schema": "http://json-schema.org/draft/2020-12/schema",
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "$id": "https://github.com/estuary/connectors/source-oracle-batch/document-metadata",
             "properties": {
               "polled": {

--- a/source-oracle-batch/.snapshots/TestSchemaFilter-FilteredIn
+++ b/source-oracle-batch/.snapshots/TestSchemaFilter-FilteredIn
@@ -25,7 +25,7 @@ Binding 0:
             "format": "integer"
           },
           "_meta": {
-            "$schema": "http://json-schema.org/draft/2020-12/schema",
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "$id": "https://github.com/estuary/connectors/source-oracle-batch/document-metadata",
             "properties": {
               "polled": {

--- a/source-oracle-batch/.snapshots/TestSchemaFilter-Unfiltered
+++ b/source-oracle-batch/.snapshots/TestSchemaFilter-Unfiltered
@@ -25,7 +25,7 @@ Binding 0:
             "format": "integer"
           },
           "_meta": {
-            "$schema": "http://json-schema.org/draft/2020-12/schema",
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "$id": "https://github.com/estuary/connectors/source-oracle-batch/document-metadata",
             "properties": {
               "polled": {

--- a/source-oracle-batch/.snapshots/TestSpec
+++ b/source-oracle-batch/.snapshots/TestSpec
@@ -1,6 +1,6 @@
 {
   "config_schema_json": {
-    "$schema": "http://json-schema.org/draft/2020-12/schema",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$id": "https://github.com/estuary/connectors/source-oracle-batch/config",
     "properties": {
       "address": {
@@ -105,7 +105,7 @@
     "title": "Batch SQL"
   },
   "resource_config_schema_json": {
-    "$schema": "http://json-schema.org/draft/2020-12/schema",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$id": "https://github.com/estuary/connectors/source-oracle-batch/resource",
     "properties": {
       "name": {

--- a/source-oracle/.snapshots/TestGeneric-SpecResponse
+++ b/source-oracle/.snapshots/TestGeneric-SpecResponse
@@ -1,7 +1,7 @@
 {
   "protocol": 3032023,
   "config_schema_json": {
-    "$schema": "http://json-schema.org/draft/2020-12/schema",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$id": "https://github.com/estuary/connectors/source-oracle/config",
     "properties": {
       "address": {
@@ -136,7 +136,7 @@
     "title": "Oracle Connection"
   },
   "resource_config_schema_json": {
-    "$schema": "http://json-schema.org/draft/2020-12/schema",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$id": "https://github.com/estuary/connectors/sqlcapture/resource",
     "properties": {
       "mode": {

--- a/source-postgres-batch/.snapshots/TestArrayTypes-Discovery
+++ b/source-postgres-batch/.snapshots/TestArrayTypes-Discovery
@@ -21,7 +21,7 @@ Binding 0:
         ],
         "properties": {
           "_meta": {
-            "$schema": "http://json-schema.org/draft/2020-12/schema",
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "$id": "https://github.com/estuary/connectors/source-postgres-batch/document-metadata",
             "properties": {
               "polled": {

--- a/source-postgres-batch/.snapshots/TestAsyncCapture-Discovery
+++ b/source-postgres-batch/.snapshots/TestAsyncCapture-Discovery
@@ -21,7 +21,7 @@ Binding 0:
         ],
         "properties": {
           "_meta": {
-            "$schema": "http://json-schema.org/draft/2020-12/schema",
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "$id": "https://github.com/estuary/connectors/source-postgres-batch/document-metadata",
             "properties": {
               "polled": {

--- a/source-postgres-batch/.snapshots/TestBinaryTypes-Discovery
+++ b/source-postgres-batch/.snapshots/TestBinaryTypes-Discovery
@@ -21,7 +21,7 @@ Binding 0:
         ],
         "properties": {
           "_meta": {
-            "$schema": "http://json-schema.org/draft/2020-12/schema",
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "$id": "https://github.com/estuary/connectors/source-postgres-batch/document-metadata",
             "properties": {
               "polled": {

--- a/source-postgres-batch/.snapshots/TestCaptureWithEmptyPoll-Discovery
+++ b/source-postgres-batch/.snapshots/TestCaptureWithEmptyPoll-Discovery
@@ -21,7 +21,7 @@ Binding 0:
         ],
         "properties": {
           "_meta": {
-            "$schema": "http://json-schema.org/draft/2020-12/schema",
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "$id": "https://github.com/estuary/connectors/source-postgres-batch/document-metadata",
             "properties": {
               "polled": {

--- a/source-postgres-batch/.snapshots/TestDateAndTimeTypes-Discovery
+++ b/source-postgres-batch/.snapshots/TestDateAndTimeTypes-Discovery
@@ -21,7 +21,7 @@ Binding 0:
         ],
         "properties": {
           "_meta": {
-            "$schema": "http://json-schema.org/draft/2020-12/schema",
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "$id": "https://github.com/estuary/connectors/source-postgres-batch/document-metadata",
             "properties": {
               "polled": {

--- a/source-postgres-batch/.snapshots/TestGeometricTypes-Discovery
+++ b/source-postgres-batch/.snapshots/TestGeometricTypes-Discovery
@@ -21,7 +21,7 @@ Binding 0:
         ],
         "properties": {
           "_meta": {
-            "$schema": "http://json-schema.org/draft/2020-12/schema",
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "$id": "https://github.com/estuary/connectors/source-postgres-batch/document-metadata",
             "properties": {
               "polled": {

--- a/source-postgres-batch/.snapshots/TestIntegerTypes-Discovery
+++ b/source-postgres-batch/.snapshots/TestIntegerTypes-Discovery
@@ -21,7 +21,7 @@ Binding 0:
         ],
         "properties": {
           "_meta": {
-            "$schema": "http://json-schema.org/draft/2020-12/schema",
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "$id": "https://github.com/estuary/connectors/source-postgres-batch/document-metadata",
             "properties": {
               "polled": {

--- a/source-postgres-batch/.snapshots/TestJSONTypes-Discovery
+++ b/source-postgres-batch/.snapshots/TestJSONTypes-Discovery
@@ -21,7 +21,7 @@ Binding 0:
         ],
         "properties": {
           "_meta": {
-            "$schema": "http://json-schema.org/draft/2020-12/schema",
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "$id": "https://github.com/estuary/connectors/source-postgres-batch/document-metadata",
             "properties": {
               "polled": {

--- a/source-postgres-batch/.snapshots/TestKeyDiscovery
+++ b/source-postgres-batch/.snapshots/TestKeyDiscovery
@@ -25,7 +25,7 @@ Binding 0:
         ],
         "properties": {
           "_meta": {
-            "$schema": "http://json-schema.org/draft/2020-12/schema",
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "$id": "https://github.com/estuary/connectors/source-postgres-batch/document-metadata",
             "properties": {
               "polled": {

--- a/source-postgres-batch/.snapshots/TestModificationsAndDeletions-Discovery
+++ b/source-postgres-batch/.snapshots/TestModificationsAndDeletions-Discovery
@@ -21,7 +21,7 @@ Binding 0:
         ],
         "properties": {
           "_meta": {
-            "$schema": "http://json-schema.org/draft/2020-12/schema",
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "$id": "https://github.com/estuary/connectors/source-postgres-batch/document-metadata",
             "properties": {
               "polled": {

--- a/source-postgres-batch/.snapshots/TestNetworkTypes-Discovery
+++ b/source-postgres-batch/.snapshots/TestNetworkTypes-Discovery
@@ -21,7 +21,7 @@ Binding 0:
         ],
         "properties": {
           "_meta": {
-            "$schema": "http://json-schema.org/draft/2020-12/schema",
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "$id": "https://github.com/estuary/connectors/source-postgres-batch/document-metadata",
             "properties": {
               "polled": {

--- a/source-postgres-batch/.snapshots/TestNumericTypes-Discovery
+++ b/source-postgres-batch/.snapshots/TestNumericTypes-Discovery
@@ -21,7 +21,7 @@ Binding 0:
         ],
         "properties": {
           "_meta": {
-            "$schema": "http://json-schema.org/draft/2020-12/schema",
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "$id": "https://github.com/estuary/connectors/source-postgres-batch/document-metadata",
             "properties": {
               "polled": {

--- a/source-postgres-batch/.snapshots/TestSchemaFilter-FilteredIn
+++ b/source-postgres-batch/.snapshots/TestSchemaFilter-FilteredIn
@@ -21,7 +21,7 @@ Binding 0:
         ],
         "properties": {
           "_meta": {
-            "$schema": "http://json-schema.org/draft/2020-12/schema",
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "$id": "https://github.com/estuary/connectors/source-postgres-batch/document-metadata",
             "properties": {
               "polled": {

--- a/source-postgres-batch/.snapshots/TestSchemaFilter-Unfiltered
+++ b/source-postgres-batch/.snapshots/TestSchemaFilter-Unfiltered
@@ -21,7 +21,7 @@ Binding 0:
         ],
         "properties": {
           "_meta": {
-            "$schema": "http://json-schema.org/draft/2020-12/schema",
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "$id": "https://github.com/estuary/connectors/source-postgres-batch/document-metadata",
             "properties": {
               "polled": {

--- a/source-postgres-batch/.snapshots/TestSimpleCapture-Discovery
+++ b/source-postgres-batch/.snapshots/TestSimpleCapture-Discovery
@@ -21,7 +21,7 @@ Binding 0:
         ],
         "properties": {
           "_meta": {
-            "$schema": "http://json-schema.org/draft/2020-12/schema",
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "$id": "https://github.com/estuary/connectors/source-postgres-batch/document-metadata",
             "properties": {
               "polled": {

--- a/source-postgres-batch/.snapshots/TestSpec
+++ b/source-postgres-batch/.snapshots/TestSpec
@@ -1,6 +1,6 @@
 {
   "config_schema_json": {
-    "$schema": "http://json-schema.org/draft/2020-12/schema",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$id": "https://github.com/estuary/connectors/source-postgres-batch/config",
     "properties": {
       "address": {
@@ -105,7 +105,7 @@
     "title": "Batch SQL"
   },
   "resource_config_schema_json": {
-    "$schema": "http://json-schema.org/draft/2020-12/schema",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$id": "https://github.com/estuary/connectors/source-postgres-batch/resource",
     "properties": {
       "name": {

--- a/source-postgres-batch/.snapshots/TestStringTypes-Discovery
+++ b/source-postgres-batch/.snapshots/TestStringTypes-Discovery
@@ -21,7 +21,7 @@ Binding 0:
         ],
         "properties": {
           "_meta": {
-            "$schema": "http://json-schema.org/draft/2020-12/schema",
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "$id": "https://github.com/estuary/connectors/source-postgres-batch/document-metadata",
             "properties": {
               "polled": {

--- a/source-postgres-batch/.snapshots/TestUUIDType-Discovery
+++ b/source-postgres-batch/.snapshots/TestUUIDType-Discovery
@@ -21,7 +21,7 @@ Binding 0:
         ],
         "properties": {
           "_meta": {
-            "$schema": "http://json-schema.org/draft/2020-12/schema",
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "$id": "https://github.com/estuary/connectors/source-postgres-batch/document-metadata",
             "properties": {
               "polled": {

--- a/source-postgres-batch/.snapshots/TestXMLType-Discovery
+++ b/source-postgres-batch/.snapshots/TestXMLType-Discovery
@@ -21,7 +21,7 @@ Binding 0:
         ],
         "properties": {
           "_meta": {
-            "$schema": "http://json-schema.org/draft/2020-12/schema",
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "$id": "https://github.com/estuary/connectors/source-postgres-batch/document-metadata",
             "properties": {
               "polled": {

--- a/source-postgres/.snapshots/TestGeneric-SpecResponse
+++ b/source-postgres/.snapshots/TestGeneric-SpecResponse
@@ -1,7 +1,7 @@
 {
   "protocol": 3032023,
   "config_schema_json": {
-    "$schema": "http://json-schema.org/draft/2020-12/schema",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$id": "https://github.com/estuary/connectors/source-postgres/config",
     "properties": {
       "address": {
@@ -160,7 +160,7 @@
     "title": "PostgreSQL Connection"
   },
   "resource_config_schema_json": {
-    "$schema": "http://json-schema.org/draft/2020-12/schema",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$id": "https://github.com/estuary/connectors/sqlcapture/resource",
     "properties": {
       "mode": {

--- a/source-redshift-batch/.snapshots/TestBasicCapture-Discovery
+++ b/source-redshift-batch/.snapshots/TestBasicCapture-Discovery
@@ -17,7 +17,7 @@ Binding 0:
         ],
         "properties": {
           "_meta": {
-            "$schema": "http://json-schema.org/draft/2020-12/schema",
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "$id": "https://github.com/estuary/connectors/source-redshift-batch/document-metadata",
             "properties": {
               "polled": {

--- a/source-redshift-batch/.snapshots/TestBasicDatatypes-Discovery
+++ b/source-redshift-batch/.snapshots/TestBasicDatatypes-Discovery
@@ -17,7 +17,7 @@ Binding 0:
         ],
         "properties": {
           "_meta": {
-            "$schema": "http://json-schema.org/draft/2020-12/schema",
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "$id": "https://github.com/estuary/connectors/source-redshift-batch/document-metadata",
             "properties": {
               "polled": {

--- a/source-redshift-batch/.snapshots/TestFeatureFlagUseSchemaInference-Discovery
+++ b/source-redshift-batch/.snapshots/TestFeatureFlagUseSchemaInference-Discovery
@@ -17,7 +17,7 @@ Binding 0:
         ],
         "properties": {
           "_meta": {
-            "$schema": "http://json-schema.org/draft/2020-12/schema",
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "$id": "https://github.com/estuary/connectors/source-redshift-batch/document-metadata",
             "properties": {
               "polled": {

--- a/source-redshift-batch/.snapshots/TestFloatNaNs-Discovery
+++ b/source-redshift-batch/.snapshots/TestFloatNaNs-Discovery
@@ -17,7 +17,7 @@ Binding 0:
         ],
         "properties": {
           "_meta": {
-            "$schema": "http://json-schema.org/draft/2020-12/schema",
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "$id": "https://github.com/estuary/connectors/source-redshift-batch/document-metadata",
             "properties": {
               "polled": {

--- a/source-redshift-batch/.snapshots/TestKeyDiscovery
+++ b/source-redshift-batch/.snapshots/TestKeyDiscovery
@@ -21,7 +21,7 @@ Binding 0:
         ],
         "properties": {
           "_meta": {
-            "$schema": "http://json-schema.org/draft/2020-12/schema",
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "$id": "https://github.com/estuary/connectors/source-redshift-batch/document-metadata",
             "properties": {
               "polled": {

--- a/source-redshift-batch/.snapshots/TestKeylessDiscovery
+++ b/source-redshift-batch/.snapshots/TestKeylessDiscovery
@@ -16,7 +16,7 @@ Binding 0:
         ],
         "properties": {
           "_meta": {
-            "$schema": "http://json-schema.org/draft/2020-12/schema",
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "$id": "https://github.com/estuary/connectors/source-redshift-batch/document-metadata",
             "properties": {
               "polled": {

--- a/source-redshift-batch/.snapshots/TestSchemaFilter-FilteredIn
+++ b/source-redshift-batch/.snapshots/TestSchemaFilter-FilteredIn
@@ -17,7 +17,7 @@ Binding 0:
         ],
         "properties": {
           "_meta": {
-            "$schema": "http://json-schema.org/draft/2020-12/schema",
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "$id": "https://github.com/estuary/connectors/source-redshift-batch/document-metadata",
             "properties": {
               "polled": {

--- a/source-redshift-batch/.snapshots/TestSchemaFilter-Unfiltered
+++ b/source-redshift-batch/.snapshots/TestSchemaFilter-Unfiltered
@@ -17,7 +17,7 @@ Binding 0:
         ],
         "properties": {
           "_meta": {
-            "$schema": "http://json-schema.org/draft/2020-12/schema",
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "$id": "https://github.com/estuary/connectors/source-redshift-batch/document-metadata",
             "properties": {
               "polled": {

--- a/source-redshift-batch/.snapshots/TestSpec
+++ b/source-redshift-batch/.snapshots/TestSpec
@@ -1,6 +1,6 @@
 {
   "config_schema_json": {
-    "$schema": "http://json-schema.org/draft/2020-12/schema",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$id": "https://github.com/estuary/connectors/source-redshift-batch/config",
     "properties": {
       "address": {
@@ -110,7 +110,7 @@
     "title": "Batch SQL"
   },
   "resource_config_schema_json": {
-    "$schema": "http://json-schema.org/draft/2020-12/schema",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$id": "https://github.com/estuary/connectors/source-redshift-batch/resource",
     "properties": {
       "name": {

--- a/source-snowflake/.snapshots/TestSpec
+++ b/source-snowflake/.snapshots/TestSpec
@@ -1,6 +1,6 @@
 {
   "config_schema_json": {
-    "$schema": "http://json-schema.org/draft/2020-12/schema",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$id": "https://github.com/estuary/connectors/source-snowflake/config",
     "properties": {
       "host": {
@@ -66,7 +66,7 @@
     "title": "Snowflake Connection"
   },
   "resource_config_schema_json": {
-    "$schema": "http://json-schema.org/draft/2020-12/schema",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$id": "https://github.com/estuary/connectors/source-snowflake/resource",
     "properties": {
       "schema": {

--- a/source-sqlserver/.snapshots/TestGeneric-SpecResponse
+++ b/source-sqlserver/.snapshots/TestGeneric-SpecResponse
@@ -1,7 +1,7 @@
 {
   "protocol": 3032023,
   "config_schema_json": {
-    "$schema": "http://json-schema.org/draft/2020-12/schema",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$id": "https://github.com/estuary/connectors/source-sqlserver/config",
     "properties": {
       "address": {
@@ -135,7 +135,7 @@
     "title": "SQL Server Connection"
   },
   "resource_config_schema_json": {
-    "$schema": "http://json-schema.org/draft/2020-12/schema",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$id": "https://github.com/estuary/connectors/sqlcapture/resource",
     "properties": {
       "mode": {


### PR DESCRIPTION
**Description:**

Updates the `invopop/jsonschema` package to the latest.

Although not used directly here, this will make doing things like `oneOfs` in generated schemas easier (although still not really "easy"), and I plan on doing that in later work.

Since this update is an almost-entirely mechanical update that touches just about every connector's test snapshots, I wanted to split it out as a separate PR.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2427)
<!-- Reviewable:end -->
