### PR TITLE
source-postgres: Don't use IDENTIFY_SYSTEM

### DIFF
--- a/source-postgres/replication.go
+++ b/source-postgres/replication.go
@@ -62,15 +62,12 @@ func (db *postgresDatabase) ReplicationStream(ctx context.Context, startCursor s
 			logrus.WithField("err", err).Debug("error recreating replication slot")
 		}
 
-		// Obtain the current WAL flush location via an IDENTIFY_SYSTEM command.
-		// Note: We use IDENTIFY_SYSTEM here for legacy reasons, it might be cleaner
-		// to get this information from the newly-recreated slot's confirmed_flush_lsn
-		// now that we do it that way.
-		var sysident, err = pglogrepl.IdentifySystem(ctx, conn)
+		// Obtain the current WAL flush location on the server and initialize the cursor to that point.
+		var flushLSN, err = queryLatestServerLSN(ctx, db.conn)
 		if err != nil {
-			return nil, fmt.Errorf("unable to read WAL flush LSN from database: %w", err)
+			return nil, fmt.Errorf("unable to initialize cursor to current server LSN: %w", err)
 		}
-		startLSN = sysident.XLogPos
+		startLSN = flushLSN
 	}
 
 	// Check that the slot's `confirmed_flush_lsn` is less than or equal to our resume cursor value.


### PR DESCRIPTION
**Description:**

Apparently Google's AlloyDB added a gratuitous fifth field to the IDENTIFY_SYSTEM command results, which currently breaks the helper function pglogrepl.IdentifySystem which expects there to be exactly the four fields one gets back from PostgreSQL.

The only thing we use IdentifySystem for is to establish the WAL flush location on the server, and we already have our own function (`queryLatestServerLSN`) which does precisely that and doesn't rely on parsing the IDENTIFY_SYSTEM result, so let's just use that one instead.

**Workflow steps:**

There shouldn't be any user-visible impact except that AlloyDB captures work.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2430)
<!-- Reviewable:end -->
