### PR TITLE
source-postgres: Handle NULL confirmed_flush_lsn

### DIFF
--- a/source-postgres/database.go
+++ b/source-postgres/database.go
@@ -18,7 +18,7 @@ type replicationSlotInfo struct {
 	SlotType          string
 	Active            bool
 	RestartLSN        *pglogrepl.LSN
-	ConfirmedFlushLSN pglogrepl.LSN
+	ConfirmedFlushLSN *pglogrepl.LSN
 	WALStatus         string
 }
 


### PR DESCRIPTION
**Description:**

In normal operation a replication slot will always have a non-null `confirmed_flush_lsn`, but we saw the other day that it _is_ actually possible to observe a null value for that field if the replication slot is stuck in the middle of being created because it has to wait for a long-running transaction to complete.

Since one major cause of replication slot recreation is when the old slot gets invalidated, and one major cause of invalidation is when a long-running transaction forces excessive WAL retention, this is actually less rare than it seems. It will happen any time a long-running transaction causes slot invalidation and the user just hits "Backfill All" without killing the transaction (assuming it didn't end on its own, of course).

Since I would really like to make these `queryReplicationSlotInfo` checks fatal errors in the near future this logic needs to be bulletproof, so we need to handle that situation.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2436)
<!-- Reviewable:end -->
