### PR TITLE
source-postgres-batch: XID wraparound fix and view discovery option

### DIFF
--- a/source-postgres-batch/.snapshots/TestCaptureFromView-Capture
+++ b/source-postgres-batch/.snapshots/TestCaptureFromView-Capture
@@ -1,0 +1,45 @@
+# ================================
+# Collection "acmeCo/test/test_capturefromview_194890": 23 Documents
+# ================================
+{"_meta":{"polled":"<TIMESTAMP>","index":999},"id":0,"name":"Row 0","txid":999999,"updated_at":"2025-02-13T12:00:00Z","visible":true}
+{"_meta":{"polled":"<TIMESTAMP>","index":999},"id":1,"name":"Row 1","txid":999999,"updated_at":"2025-02-13T12:01:00Z","visible":false}
+{"_meta":{"polled":"<TIMESTAMP>","index":999},"id":2,"name":"Row 2","txid":999999,"updated_at":"2025-02-13T12:02:00Z","visible":true}
+{"_meta":{"polled":"<TIMESTAMP>","index":999},"id":3,"name":"Row 3","txid":999999,"updated_at":"2025-02-13T12:03:00Z","visible":false}
+{"_meta":{"polled":"<TIMESTAMP>","index":999},"id":4,"name":"Row 4","txid":999999,"updated_at":"2025-02-13T12:04:00Z","visible":true}
+{"_meta":{"polled":"<TIMESTAMP>","index":999},"id":5,"name":"Row 5","txid":999999,"updated_at":"2025-02-13T12:05:00Z","visible":false}
+{"_meta":{"polled":"<TIMESTAMP>","index":999},"id":6,"name":"Row 6","txid":999999,"updated_at":"2025-02-13T12:06:00Z","visible":true}
+{"_meta":{"polled":"<TIMESTAMP>","index":999},"id":7,"name":"Row 7","txid":999999,"updated_at":"2025-02-13T12:07:00Z","visible":false}
+{"_meta":{"polled":"<TIMESTAMP>","index":999},"id":8,"name":"Row 8","txid":999999,"updated_at":"2025-02-13T12:08:00Z","visible":true}
+{"_meta":{"polled":"<TIMESTAMP>","index":999},"id":9,"name":"Row 9","txid":999999,"updated_at":"2025-02-13T12:09:00Z","visible":false}
+{"_meta":{"polled":"<TIMESTAMP>","index":999},"id":10,"name":"Row 10","txid":999999,"updated_at":"2025-02-13T12:10:00Z","visible":true}
+{"_meta":{"polled":"<TIMESTAMP>","index":999},"id":11,"name":"Row 11","txid":999999,"updated_at":"2025-02-13T12:11:00Z","visible":false}
+{"_meta":{"polled":"<TIMESTAMP>","index":999},"id":12,"name":"Row 12","txid":999999,"updated_at":"2025-02-13T12:12:00Z","visible":true}
+{"_meta":{"polled":"<TIMESTAMP>","index":999},"id":13,"name":"Row 13","txid":999999,"updated_at":"2025-02-13T12:13:00Z","visible":false}
+{"_meta":{"polled":"<TIMESTAMP>","index":999},"id":14,"name":"Row 14","txid":999999,"updated_at":"2025-02-13T12:14:00Z","visible":true}
+{"_meta":{"polled":"<TIMESTAMP>","index":999},"id":15,"name":"Row 15","txid":999999,"updated_at":"2025-02-13T12:15:00Z","visible":false}
+{"_meta":{"polled":"<TIMESTAMP>","index":999},"id":16,"name":"Row 16","txid":999999,"updated_at":"2025-02-13T12:16:00Z","visible":true}
+{"_meta":{"polled":"<TIMESTAMP>","index":999},"id":17,"name":"Row 17","txid":999999,"updated_at":"2025-02-13T12:17:00Z","visible":false}
+{"_meta":{"polled":"<TIMESTAMP>","index":999},"id":18,"name":"Row 18","txid":999999,"updated_at":"2025-02-13T12:18:00Z","visible":true}
+{"_meta":{"polled":"<TIMESTAMP>","index":999},"id":19,"name":"Row 19","txid":999999,"updated_at":"2025-02-13T12:19:00Z","visible":false}
+{"_meta":{"polled":"<TIMESTAMP>","index":999},"id":2,"name":"Row 2","txid":999999,"updated_at":"2025-02-13T12:20:00Z","visible":false}
+{"_meta":{"polled":"<TIMESTAMP>","index":999},"id":3,"name":"Row 3","txid":999999,"updated_at":"2025-02-13T12:20:00Z","visible":true}
+{"_meta":{"polled":"<TIMESTAMP>","index":999},"id":4,"name":"Row 4","txid":999999,"updated_at":"2025-02-13T12:20:00Z","visible":false}
+# ================================
+# Collection "acmeCo/test/test_capturefromview_227836": 11 Documents
+# ================================
+{"_meta":{"polled":"<TIMESTAMP>","index":999},"id":0,"name":"Row 0","updated_at":"2025-02-13T12:00:00Z"}
+{"_meta":{"polled":"<TIMESTAMP>","index":999},"id":2,"name":"Row 2","updated_at":"2025-02-13T12:02:00Z"}
+{"_meta":{"polled":"<TIMESTAMP>","index":999},"id":4,"name":"Row 4","updated_at":"2025-02-13T12:04:00Z"}
+{"_meta":{"polled":"<TIMESTAMP>","index":999},"id":6,"name":"Row 6","updated_at":"2025-02-13T12:06:00Z"}
+{"_meta":{"polled":"<TIMESTAMP>","index":999},"id":8,"name":"Row 8","updated_at":"2025-02-13T12:08:00Z"}
+{"_meta":{"polled":"<TIMESTAMP>","index":999},"id":10,"name":"Row 10","updated_at":"2025-02-13T12:10:00Z"}
+{"_meta":{"polled":"<TIMESTAMP>","index":999},"id":12,"name":"Row 12","updated_at":"2025-02-13T12:12:00Z"}
+{"_meta":{"polled":"<TIMESTAMP>","index":999},"id":14,"name":"Row 14","updated_at":"2025-02-13T12:14:00Z"}
+{"_meta":{"polled":"<TIMESTAMP>","index":999},"id":16,"name":"Row 16","updated_at":"2025-02-13T12:16:00Z"}
+{"_meta":{"polled":"<TIMESTAMP>","index":999},"id":18,"name":"Row 18","updated_at":"2025-02-13T12:18:00Z"}
+{"_meta":{"polled":"<TIMESTAMP>","index":999},"id":3,"name":"Row 3","updated_at":"2025-02-13T12:20:00Z"}
+# ================================
+# Final State Checkpoint
+# ================================
+{"bindingStateV1":{"test_capturefromview_194890":{"CursorNames":["txid"],"CursorValues":[999999],"LastPolled":"<TIMESTAMP>"},"test_capturefromview_227836":{"CursorNames":["updated_at"],"CursorValues":["2025-02-13T12:20:00Z"],"LastPolled":"<TIMESTAMP>"}}}
+

--- a/source-postgres-batch/.snapshots/TestCaptureFromView-DiscoveryWithViews
+++ b/source-postgres-batch/.snapshots/TestCaptureFromView-DiscoveryWithViews
@@ -1,0 +1,109 @@
+Binding 0:
+{
+    "resource_config_json": {
+      "name": "test_capturefromview_194890",
+      "schema": "test",
+      "table": "capturefromview_194890",
+      "cursor": [
+        "txid"
+      ]
+    },
+    "resource_path": [
+      "test_capturefromview_194890"
+    ],
+    "collection": {
+      "name": "acmeCo/test/test_capturefromview_194890",
+      "read_schema_json": {
+        "type": "object",
+        "required": [
+          "_meta",
+          "id"
+        ],
+        "properties": {
+          "_meta": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$id": "https://github.com/estuary/connectors/source-postgres-batch/document-metadata",
+            "properties": {
+              "polled": {
+                "type": "string",
+                "format": "date-time",
+                "title": "Polled Timestamp",
+                "description": "The time at which the update query which produced this document as executed."
+              },
+              "index": {
+                "type": "integer",
+                "title": "Result Index",
+                "description": "The index of this document within the query execution which produced it."
+              }
+            },
+            "type": "object",
+            "required": [
+              "polled",
+              "index"
+            ]
+          },
+          "id": {
+            "type": "integer"
+          }
+        },
+        "x-infer-schema": true
+      },
+      "key": [
+        "/id"
+      ],
+      "projections": null
+    },
+    "state_key": "test_capturefromview_194890"
+  }
+Binding 1:
+{
+    "resource_config_json": {
+      "name": "test_capturefromview_227836",
+      "schema": "test",
+      "table": "capturefromview_227836"
+    },
+    "resource_path": [
+      "test_capturefromview_227836"
+    ],
+    "collection": {
+      "name": "acmeCo/test/test_capturefromview_227836",
+      "read_schema_json": {
+        "type": "object",
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$id": "https://github.com/estuary/connectors/source-postgres-batch/document-metadata",
+            "properties": {
+              "polled": {
+                "type": "string",
+                "format": "date-time",
+                "title": "Polled Timestamp",
+                "description": "The time at which the update query which produced this document as executed."
+              },
+              "index": {
+                "type": "integer",
+                "title": "Result Index",
+                "description": "The index of this document within the query execution which produced it."
+              }
+            },
+            "type": "object",
+            "required": [
+              "polled",
+              "index"
+            ]
+          }
+        },
+        "x-infer-schema": true
+      },
+      "key": [
+        "/_meta/polled",
+        "/_meta/index"
+      ],
+      "projections": null
+    },
+    "state_key": "test_capturefromview_227836"
+  }
+

--- a/source-postgres-batch/.snapshots/TestCaptureFromView-DiscoveryWithoutViews
+++ b/source-postgres-batch/.snapshots/TestCaptureFromView-DiscoveryWithoutViews
@@ -1,0 +1,58 @@
+Binding 0:
+{
+    "resource_config_json": {
+      "name": "test_capturefromview_194890",
+      "schema": "test",
+      "table": "capturefromview_194890",
+      "cursor": [
+        "txid"
+      ]
+    },
+    "resource_path": [
+      "test_capturefromview_194890"
+    ],
+    "collection": {
+      "name": "acmeCo/test/test_capturefromview_194890",
+      "read_schema_json": {
+        "type": "object",
+        "required": [
+          "_meta",
+          "id"
+        ],
+        "properties": {
+          "_meta": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$id": "https://github.com/estuary/connectors/source-postgres-batch/document-metadata",
+            "properties": {
+              "polled": {
+                "type": "string",
+                "format": "date-time",
+                "title": "Polled Timestamp",
+                "description": "The time at which the update query which produced this document as executed."
+              },
+              "index": {
+                "type": "integer",
+                "title": "Result Index",
+                "description": "The index of this document within the query execution which produced it."
+              }
+            },
+            "type": "object",
+            "required": [
+              "polled",
+              "index"
+            ]
+          },
+          "id": {
+            "type": "integer"
+          }
+        },
+        "x-infer-schema": true
+      },
+      "key": [
+        "/id"
+      ],
+      "projections": null
+    },
+    "state_key": "test_capturefromview_194890"
+  }
+

--- a/source-postgres-batch/.snapshots/TestCaptureWithTwoColumnCursor-Capture
+++ b/source-postgres-batch/.snapshots/TestCaptureWithTwoColumnCursor-Capture
@@ -1,0 +1,20 @@
+# ================================
+# Collection "acmeCo/test/test_capturewithtwocolumncursor_321285": 12 Documents
+# ================================
+{"_meta":{"polled":"<TIMESTAMP>","index":999},"data":"v1.1","id":0,"major":1,"minor":1}
+{"_meta":{"polled":"<TIMESTAMP>","index":999},"data":"v1.2","id":1,"major":1,"minor":2}
+{"_meta":{"polled":"<TIMESTAMP>","index":999},"data":"v1.3","id":2,"major":1,"minor":3}
+{"_meta":{"polled":"<TIMESTAMP>","index":999},"data":"v2.1","id":3,"major":2,"minor":1}
+{"_meta":{"polled":"<TIMESTAMP>","index":999},"data":"v2.2","id":4,"major":2,"minor":2}
+{"_meta":{"polled":"<TIMESTAMP>","index":999},"data":"v2.3","id":5,"major":2,"minor":3}
+{"_meta":{"polled":"<TIMESTAMP>","index":999},"data":"v3.1","id":8,"major":3,"minor":1}
+{"_meta":{"polled":"<TIMESTAMP>","index":999},"data":"v3.2","id":9,"major":3,"minor":2}
+{"_meta":{"polled":"<TIMESTAMP>","index":999},"data":"v3.3","id":10,"major":3,"minor":3}
+{"_meta":{"polled":"<TIMESTAMP>","index":999},"data":"v4.1","id":11,"major":4,"minor":1}
+{"_meta":{"polled":"<TIMESTAMP>","index":999},"data":"v4.2","id":12,"major":4,"minor":2}
+{"_meta":{"polled":"<TIMESTAMP>","index":999},"data":"v4.3","id":13,"major":4,"minor":3}
+# ================================
+# Final State Checkpoint
+# ================================
+{"bindingStateV1":{"test_capturewithtwocolumncursor_321285":{"CursorNames":["major","minor"],"CursorValues":[4,3],"LastPolled":"<TIMESTAMP>"}}}
+

--- a/source-postgres-batch/.snapshots/TestCaptureWithTwoColumnCursor-Discovery
+++ b/source-postgres-batch/.snapshots/TestCaptureWithTwoColumnCursor-Discovery
@@ -1,0 +1,59 @@
+Binding 0:
+{
+    "resource_config_json": {
+      "name": "test_capturewithtwocolumncursor_321285",
+      "schema": "test",
+      "table": "capturewithtwocolumncursor_321285",
+      "cursor": [
+        "major",
+        "minor"
+      ]
+    },
+    "resource_path": [
+      "test_capturewithtwocolumncursor_321285"
+    ],
+    "collection": {
+      "name": "acmeCo/test/test_capturewithtwocolumncursor_321285",
+      "read_schema_json": {
+        "type": "object",
+        "required": [
+          "_meta",
+          "id"
+        ],
+        "properties": {
+          "_meta": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$id": "https://github.com/estuary/connectors/source-postgres-batch/document-metadata",
+            "properties": {
+              "polled": {
+                "type": "string",
+                "format": "date-time",
+                "title": "Polled Timestamp",
+                "description": "The time at which the update query which produced this document as executed."
+              },
+              "index": {
+                "type": "integer",
+                "title": "Result Index",
+                "description": "The index of this document within the query execution which produced it."
+              }
+            },
+            "type": "object",
+            "required": [
+              "polled",
+              "index"
+            ]
+          },
+          "id": {
+            "type": "integer"
+          }
+        },
+        "x-infer-schema": true
+      },
+      "key": [
+        "/id"
+      ],
+      "projections": null
+    },
+    "state_key": "test_capturewithtwocolumncursor_321285"
+  }
+

--- a/source-postgres-batch/.snapshots/TestCaptureWithUpdatedAtCursor-Capture
+++ b/source-postgres-batch/.snapshots/TestCaptureWithUpdatedAtCursor-Capture
@@ -1,0 +1,28 @@
+# ================================
+# Collection "acmeCo/test/test_capturewithupdatedatcursor_792371": 20 Documents
+# ================================
+{"_meta":{"polled":"<TIMESTAMP>","index":999},"data":"Value for row 0","id":0,"updated_at":"2025-02-13T12:00:00Z"}
+{"_meta":{"polled":"<TIMESTAMP>","index":999},"data":"Value for row 1","id":1,"updated_at":"2025-02-13T12:01:00Z"}
+{"_meta":{"polled":"<TIMESTAMP>","index":999},"data":"Value for row 2","id":2,"updated_at":"2025-02-13T12:02:00Z"}
+{"_meta":{"polled":"<TIMESTAMP>","index":999},"data":"Value for row 3","id":3,"updated_at":"2025-02-13T12:03:00Z"}
+{"_meta":{"polled":"<TIMESTAMP>","index":999},"data":"Value for row 4","id":4,"updated_at":"2025-02-13T12:04:00Z"}
+{"_meta":{"polled":"<TIMESTAMP>","index":999},"data":"Value for row 5","id":5,"updated_at":"2025-02-13T12:05:00Z"}
+{"_meta":{"polled":"<TIMESTAMP>","index":999},"data":"Value for row 6","id":6,"updated_at":"2025-02-13T12:06:00Z"}
+{"_meta":{"polled":"<TIMESTAMP>","index":999},"data":"Value for row 7","id":7,"updated_at":"2025-02-13T12:07:00Z"}
+{"_meta":{"polled":"<TIMESTAMP>","index":999},"data":"Value for row 8","id":8,"updated_at":"2025-02-13T12:08:00Z"}
+{"_meta":{"polled":"<TIMESTAMP>","index":999},"data":"Value for row 9","id":9,"updated_at":"2025-02-13T12:09:00Z"}
+{"_meta":{"polled":"<TIMESTAMP>","index":999},"data":"Value for row 10","id":10,"updated_at":"2025-02-13T12:10:00Z"}
+{"_meta":{"polled":"<TIMESTAMP>","index":999},"data":"Value for row 11","id":11,"updated_at":"2025-02-13T12:11:00Z"}
+{"_meta":{"polled":"<TIMESTAMP>","index":999},"data":"Value for row 12","id":12,"updated_at":"2025-02-13T12:12:00Z"}
+{"_meta":{"polled":"<TIMESTAMP>","index":999},"data":"Value for row 13","id":13,"updated_at":"2025-02-13T12:13:00Z"}
+{"_meta":{"polled":"<TIMESTAMP>","index":999},"data":"Value for row 14","id":14,"updated_at":"2025-02-13T12:14:00Z"}
+{"_meta":{"polled":"<TIMESTAMP>","index":999},"data":"Value for row 15","id":15,"updated_at":"2025-02-13T12:15:00Z"}
+{"_meta":{"polled":"<TIMESTAMP>","index":999},"data":"Value for row 16","id":16,"updated_at":"2025-02-13T12:16:00Z"}
+{"_meta":{"polled":"<TIMESTAMP>","index":999},"data":"Value for row 17","id":17,"updated_at":"2025-02-13T12:17:00Z"}
+{"_meta":{"polled":"<TIMESTAMP>","index":999},"data":"Value for row 18","id":18,"updated_at":"2025-02-13T12:18:00Z"}
+{"_meta":{"polled":"<TIMESTAMP>","index":999},"data":"Value for row 19","id":19,"updated_at":"2025-02-13T12:19:00Z"}
+# ================================
+# Final State Checkpoint
+# ================================
+{"bindingStateV1":{"test_capturewithupdatedatcursor_792371":{"CursorNames":["updated_at"],"CursorValues":["2025-02-13T12:19:00Z"],"LastPolled":"<TIMESTAMP>"}}}
+

--- a/source-postgres-batch/.snapshots/TestCaptureWithUpdatedAtCursor-Discovery
+++ b/source-postgres-batch/.snapshots/TestCaptureWithUpdatedAtCursor-Discovery
@@ -1,0 +1,58 @@
+Binding 0:
+{
+    "resource_config_json": {
+      "name": "test_capturewithupdatedatcursor_792371",
+      "schema": "test",
+      "table": "capturewithupdatedatcursor_792371",
+      "cursor": [
+        "updated_at"
+      ]
+    },
+    "resource_path": [
+      "test_capturewithupdatedatcursor_792371"
+    ],
+    "collection": {
+      "name": "acmeCo/test/test_capturewithupdatedatcursor_792371",
+      "read_schema_json": {
+        "type": "object",
+        "required": [
+          "_meta",
+          "id"
+        ],
+        "properties": {
+          "_meta": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$id": "https://github.com/estuary/connectors/source-postgres-batch/document-metadata",
+            "properties": {
+              "polled": {
+                "type": "string",
+                "format": "date-time",
+                "title": "Polled Timestamp",
+                "description": "The time at which the update query which produced this document as executed."
+              },
+              "index": {
+                "type": "integer",
+                "title": "Result Index",
+                "description": "The index of this document within the query execution which produced it."
+              }
+            },
+            "type": "object",
+            "required": [
+              "polled",
+              "index"
+            ]
+          },
+          "id": {
+            "type": "integer"
+          }
+        },
+        "x-infer-schema": true
+      },
+      "key": [
+        "/id"
+      ],
+      "projections": null
+    },
+    "state_key": "test_capturewithupdatedatcursor_792371"
+  }
+

--- a/source-postgres-batch/.snapshots/TestFullRefresh-Capture
+++ b/source-postgres-batch/.snapshots/TestFullRefresh-Capture
@@ -1,0 +1,38 @@
+# ================================
+# Collection "acmeCo/test/test_fullrefresh_902536": 30 Documents
+# ================================
+{"_meta":{"polled":"<TIMESTAMP>","index":999},"data":"Value for row 0","id":0}
+{"_meta":{"polled":"<TIMESTAMP>","index":999},"data":"Value for row 1","id":1}
+{"_meta":{"polled":"<TIMESTAMP>","index":999},"data":"Value for row 2","id":2}
+{"_meta":{"polled":"<TIMESTAMP>","index":999},"data":"Value for row 3","id":3}
+{"_meta":{"polled":"<TIMESTAMP>","index":999},"data":"Value for row 4","id":4}
+{"_meta":{"polled":"<TIMESTAMP>","index":999},"data":"Value for row 5","id":5}
+{"_meta":{"polled":"<TIMESTAMP>","index":999},"data":"Value for row 6","id":6}
+{"_meta":{"polled":"<TIMESTAMP>","index":999},"data":"Value for row 7","id":7}
+{"_meta":{"polled":"<TIMESTAMP>","index":999},"data":"Value for row 8","id":8}
+{"_meta":{"polled":"<TIMESTAMP>","index":999},"data":"Value for row 9","id":9}
+{"_meta":{"polled":"<TIMESTAMP>","index":999},"data":"Value for row 0","id":0}
+{"_meta":{"polled":"<TIMESTAMP>","index":999},"data":"Value for row 1","id":1}
+{"_meta":{"polled":"<TIMESTAMP>","index":999},"data":"Value for row 2","id":2}
+{"_meta":{"polled":"<TIMESTAMP>","index":999},"data":"Value for row 3","id":3}
+{"_meta":{"polled":"<TIMESTAMP>","index":999},"data":"Value for row 4","id":4}
+{"_meta":{"polled":"<TIMESTAMP>","index":999},"data":"Value for row 5","id":5}
+{"_meta":{"polled":"<TIMESTAMP>","index":999},"data":"Value for row 6","id":6}
+{"_meta":{"polled":"<TIMESTAMP>","index":999},"data":"Value for row 7","id":7}
+{"_meta":{"polled":"<TIMESTAMP>","index":999},"data":"Value for row 8","id":8}
+{"_meta":{"polled":"<TIMESTAMP>","index":999},"data":"Value for row 9","id":9}
+{"_meta":{"polled":"<TIMESTAMP>","index":999},"data":"Value for row 10","id":10}
+{"_meta":{"polled":"<TIMESTAMP>","index":999},"data":"Value for row 11","id":11}
+{"_meta":{"polled":"<TIMESTAMP>","index":999},"data":"Value for row 12","id":12}
+{"_meta":{"polled":"<TIMESTAMP>","index":999},"data":"Value for row 13","id":13}
+{"_meta":{"polled":"<TIMESTAMP>","index":999},"data":"Value for row 14","id":14}
+{"_meta":{"polled":"<TIMESTAMP>","index":999},"data":"Value for row 15","id":15}
+{"_meta":{"polled":"<TIMESTAMP>","index":999},"data":"Value for row 16","id":16}
+{"_meta":{"polled":"<TIMESTAMP>","index":999},"data":"Value for row 17","id":17}
+{"_meta":{"polled":"<TIMESTAMP>","index":999},"data":"Value for row 18","id":18}
+{"_meta":{"polled":"<TIMESTAMP>","index":999},"data":"Value for row 19","id":19}
+# ================================
+# Final State Checkpoint
+# ================================
+{"bindingStateV1":{"test_fullrefresh_902536":{"LastPolled":"<TIMESTAMP>"}}}
+

--- a/source-postgres-batch/.snapshots/TestFullRefresh-Discovery
+++ b/source-postgres-batch/.snapshots/TestFullRefresh-Discovery
@@ -1,0 +1,55 @@
+Binding 0:
+{
+    "resource_config_json": {
+      "name": "test_fullrefresh_902536",
+      "schema": "test",
+      "table": "fullrefresh_902536"
+    },
+    "resource_path": [
+      "test_fullrefresh_902536"
+    ],
+    "collection": {
+      "name": "acmeCo/test/test_fullrefresh_902536",
+      "read_schema_json": {
+        "type": "object",
+        "required": [
+          "_meta",
+          "id"
+        ],
+        "properties": {
+          "_meta": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$id": "https://github.com/estuary/connectors/source-postgres-batch/document-metadata",
+            "properties": {
+              "polled": {
+                "type": "string",
+                "format": "date-time",
+                "title": "Polled Timestamp",
+                "description": "The time at which the update query which produced this document as executed."
+              },
+              "index": {
+                "type": "integer",
+                "title": "Result Index",
+                "description": "The index of this document within the query execution which produced it."
+              }
+            },
+            "type": "object",
+            "required": [
+              "polled",
+              "index"
+            ]
+          },
+          "id": {
+            "type": "integer"
+          }
+        },
+        "x-infer-schema": true
+      },
+      "key": [
+        "/id"
+      ],
+      "projections": null
+    },
+    "state_key": "test_fullrefresh_902536"
+  }
+

--- a/source-postgres-batch/.snapshots/TestQueryTemplates-MultiCursorFirstQuery
+++ b/source-postgres-batch/.snapshots/TestQueryTemplates-MultiCursorFirstQuery
@@ -1,0 +1,2 @@
+SELECT * FROM "test"."foobar" ORDER BY "major", "minor";
+

--- a/source-postgres-batch/.snapshots/TestQueryTemplates-MultiCursorSubsequentQuery
+++ b/source-postgres-batch/.snapshots/TestQueryTemplates-MultiCursorSubsequentQuery
@@ -1,0 +1,2 @@
+SELECT * FROM "test"."foobar" WHERE ("major" > $1) OR ("major" = $1 AND "minor" > $2) ORDER BY "major", "minor";
+

--- a/source-postgres-batch/.snapshots/TestQueryTemplates-SingleCursorFirstQuery
+++ b/source-postgres-batch/.snapshots/TestQueryTemplates-SingleCursorFirstQuery
@@ -1,0 +1,2 @@
+SELECT * FROM "test"."foobar" ORDER BY "updated_at";
+

--- a/source-postgres-batch/.snapshots/TestQueryTemplates-SingleCursorSubsequentQuery
+++ b/source-postgres-batch/.snapshots/TestQueryTemplates-SingleCursorSubsequentQuery
@@ -1,0 +1,2 @@
+SELECT * FROM "test"."foobar" WHERE ("updated_at" > $1) ORDER BY "updated_at";
+

--- a/source-postgres-batch/.snapshots/TestQueryTemplates-XMinFirstQuery
+++ b/source-postgres-batch/.snapshots/TestQueryTemplates-XMinFirstQuery
@@ -1,0 +1,1 @@
+SELECT xmin AS txid, * FROM "test"."foobar" ORDER BY xmin::text::bigint;

--- a/source-postgres-batch/.snapshots/TestQueryTemplates-XMinFirstQuery
+++ b/source-postgres-batch/.snapshots/TestQueryTemplates-XMinFirstQuery
@@ -1,1 +1,4 @@
-SELECT xmin AS txid, * FROM "test"."foobar" ORDER BY xmin::text::bigint;
+SELECT xmin AS txid, * FROM "test"."foobar"
+    WHERE xmin::text::bigint >= 3
+      AND (((txid_current() - xmin::text::bigint)<<32)>>32) >= 0
+    ORDER BY xmin::text::bigint;

--- a/source-postgres-batch/.snapshots/TestQueryTemplates-XMinSubsequentQuery
+++ b/source-postgres-batch/.snapshots/TestQueryTemplates-XMinSubsequentQuery
@@ -1,0 +1,3 @@
+SELECT xmin AS txid, * FROM "test"."foobar"
+    WHERE (((xmin::text::bigint - $1::bigint)<<32)>>32) > 0 AND xmin::text::bigint >= 3
+    ORDER BY (((xmin::text::bigint - $1::bigint)<<32)>>32);

--- a/source-postgres-batch/.snapshots/TestQueryTemplates-XMinSubsequentQuery
+++ b/source-postgres-batch/.snapshots/TestQueryTemplates-XMinSubsequentQuery
@@ -1,3 +1,5 @@
 SELECT xmin AS txid, * FROM "test"."foobar"
-    WHERE (((xmin::text::bigint - $1::bigint)<<32)>>32) > 0 AND xmin::text::bigint >= 3
+    WHERE xmin::text::bigint >= 3
+      AND (((txid_current() - xmin::text::bigint)<<32)>>32) >= 0
+      AND (((xmin::text::bigint - $1::bigint)<<32)>>32) > 0
     ORDER BY (((xmin::text::bigint - $1::bigint)<<32)>>32);

--- a/source-postgres-batch/.snapshots/TestSpec
+++ b/source-postgres-batch/.snapshots/TestSpec
@@ -29,6 +29,11 @@
       },
       "advanced": {
         "properties": {
+          "discover_views": {
+            "type": "boolean",
+            "title": "Discover Views",
+            "description": "When set views will be automatically discovered as resources. If unset only tables will be discovered."
+          },
           "poll": {
             "type": "string",
             "title": "Default Polling Schedule",

--- a/source-postgres-batch/driver.go
+++ b/source-postgres-batch/driver.go
@@ -61,7 +61,7 @@ type BatchSQLDriver struct {
 
 	Connect             func(ctx context.Context, cfg *Config) (*sql.DB, error)
 	TranslateValue      func(val any, databaseTypeName string) (any, error)
-	GenerateResource    func(resourceName, schemaName, tableName, tableType string) (*Resource, error)
+	GenerateResource    func(cfg *Config, resourceName, schemaName, tableName, tableType string) (*Resource, error)
 	SelectQueryTemplate func(res *Resource) (string, error)
 }
 
@@ -223,7 +223,7 @@ func (drv *BatchSQLDriver) Discover(ctx context.Context, req *pc.Request_Discove
 		var tableID = table.Schema + "." + table.Name
 
 		var recommendedName = recommendedCatalogName(table.Schema, table.Name)
-		var res, err = drv.GenerateResource(recommendedName, table.Schema, table.Name, table.Type)
+		var res, err = drv.GenerateResource(&cfg, recommendedName, table.Schema, table.Name, table.Type)
 		if err != nil {
 			log.WithFields(log.Fields{
 				"reason": err,

--- a/source-postgres-batch/main.go
+++ b/source-postgres-batch/main.go
@@ -31,6 +31,7 @@ type Config struct {
 }
 
 type advancedConfig struct {
+	DiscoverViews   bool     `json:"discover_views,omitempty" jsonschema:"title=Discover Views,description=When set views will be automatically discovered as resources. If unset only tables will be discovered."`
 	PollSchedule    string   `json:"poll,omitempty" jsonschema:"title=Default Polling Schedule,description=When and how often to execute fetch queries. Accepts a Go duration string like '5m' or '6h' for frequency-based polling or a string like 'daily at 12:34Z' to poll at a specific time (specified in UTC) every day. Defaults to '5m' if unset." jsonschema_extras:"pattern=^([-+]?([0-9]+([.][0-9]+)?(h|m|s|ms))+|daily at [0-9][0-9]?:[0-9]{2}Z)$"`
 	DiscoverSchemas []string `json:"discover_schemas,omitempty" jsonschema:"title=Discovery Schema Selection,description=If this is specified only tables in the selected schema(s) will be automatically discovered. Omit all entries to discover tables from all schemas."`
 	SSLMode         string   `json:"sslmode,omitempty" jsonschema:"title=SSL Mode,description=Overrides SSL connection behavior by setting the 'sslmode' parameter.,enum=disable,enum=allow,enum=prefer,enum=require,enum=verify-ca,enum=verify-full"`
@@ -193,17 +194,23 @@ var templateFuncs = template.FuncMap{
 	"quoteIdentifier": quoteIdentifier,
 }
 
-func generatePostgresResource(resourceName, schemaName, tableName, tableType string) (*Resource, error) {
-	if !strings.EqualFold(tableType, "BASE TABLE") {
-		return nil, fmt.Errorf("discovery will not autogenerate resource configs for entities of type %q, but you may add them manually", tableType)
+func generatePostgresResource(cfg *Config, resourceName, schemaName, tableName, tableType string) (*Resource, error) {
+	if strings.EqualFold(tableType, "BASE TABLE") {
+		return &Resource{
+			Name:       resourceName,
+			SchemaName: schemaName,
+			TableName:  tableName,
+			Cursor:     []string{"txid"},
+		}, nil
 	}
-
-	return &Resource{
-		Name:       resourceName,
-		SchemaName: schemaName,
-		TableName:  tableName,
-		Cursor:     []string{"txid"},
-	}, nil
+	if strings.EqualFold(tableType, "VIEW") && cfg.Advanced.DiscoverViews {
+		return &Resource{
+			Name:       resourceName,
+			SchemaName: schemaName,
+			TableName:  tableName,
+		}, nil
+	}
+	return nil, fmt.Errorf("unsupported entity type %q", tableType)
 }
 
 func translatePostgresValue(val any, databaseTypeName string) (any, error) {

--- a/source-postgres-batch/main_test.go
+++ b/source-postgres-batch/main_test.go
@@ -183,6 +183,15 @@ func setShutdownAfterQuery(t testing.TB, setting bool) {
 	t.Cleanup(func() { TestShutdownAfterQuery = oldSetting })
 }
 
+func setResourceCursor(t testing.TB, binding *pf.CaptureSpec_Binding, cursor ...string) {
+	var res Resource
+	require.NoError(t, json.Unmarshal(binding.ResourceConfigJson, &res))
+	res.Cursor = cursor
+	var bs, err = json.Marshal(res)
+	require.NoError(t, err)
+	binding.ResourceConfigJson = bs
+}
+
 // TestSpec verifies the connector's response to the Spec RPC against a snapshot.
 func TestSpec(t *testing.T) {
 	response, err := postgresDriver.Spec(context.Background(), &pc.Request_Spec{})
@@ -1096,6 +1105,113 @@ func TestCaptureWithEmptyPoll(t *testing.T) {
 		}
 		cs.Capture(ctx, t, nil)
 
+		cupaloy.SnapshotT(t, cs.Summary())
+	})
+}
+
+// TestFullRefresh exercises the scenario of a table without a configured cursor,
+// which causes the capture to perform a full refresh every time it runs.
+func TestFullRefresh(t *testing.T) {
+	var ctx, cs, control = context.Background(), testCaptureSpec(t), testControlClient(t)
+	var tableName, uniqueID = testTableName(t, uniqueTableID(t))
+	createTestTable(t, control, tableName, "(id INTEGER PRIMARY KEY, data TEXT)")
+
+	cs.Bindings = discoverBindings(ctx, t, cs, regexp.MustCompile(uniqueID))
+	setResourceCursor(t, cs.Bindings[0]) // Empty cursor means full refresh behavior
+
+	t.Run("Discovery", func(t *testing.T) { cupaloy.SnapshotT(t, summarizeBindings(t, cs.Bindings)) })
+
+	t.Run("Capture", func(t *testing.T) {
+		setShutdownAfterQuery(t, true)
+		for i := 0; i < 10; i++ {
+			executeControlQuery(t, control, fmt.Sprintf("INSERT INTO %s VALUES ($1, $2)", tableName),
+				i, fmt.Sprintf("Value for row %d", i))
+		}
+		cs.Capture(ctx, t, nil)
+
+		for i := 10; i < 20; i++ {
+			executeControlQuery(t, control, fmt.Sprintf("INSERT INTO %s VALUES ($1, $2)", tableName),
+				i, fmt.Sprintf("Value for row %d", i))
+		}
+		cs.Capture(ctx, t, nil)
+		cupaloy.SnapshotT(t, cs.Summary())
+	})
+}
+
+// TestCaptureWithUpdatedAtCursor exercises the use-case of a capture using
+// an updated_at timestamp column as the cursor.
+func TestCaptureWithUpdatedAtCursor(t *testing.T) {
+	var ctx, cs, control = context.Background(), testCaptureSpec(t), testControlClient(t)
+	var tableName, uniqueID = testTableName(t, uniqueTableID(t))
+	createTestTable(t, control, tableName, `(
+        id INTEGER PRIMARY KEY,
+        data TEXT,
+        updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+    )`)
+
+	cs.Bindings = discoverBindings(ctx, t, cs, regexp.MustCompile(uniqueID))
+	setResourceCursor(t, cs.Bindings[0], "updated_at")
+
+	t.Run("Discovery", func(t *testing.T) { cupaloy.SnapshotT(t, summarizeBindings(t, cs.Bindings)) })
+
+	t.Run("Capture", func(t *testing.T) {
+		setShutdownAfterQuery(t, true)
+		baseTime := time.Date(2025, 2, 13, 12, 0, 0, 0, time.UTC)
+
+		for i := 0; i < 10; i++ {
+			executeControlQuery(t, control, fmt.Sprintf("INSERT INTO %s VALUES ($1, $2, $3)", tableName),
+				i, fmt.Sprintf("Value for row %d", i), baseTime.Add(time.Duration(i)*time.Minute))
+		}
+		cs.Capture(ctx, t, nil)
+
+		for i := 10; i < 20; i++ {
+			executeControlQuery(t, control, fmt.Sprintf("INSERT INTO %s VALUES ($1, $2, $3)", tableName),
+				i, fmt.Sprintf("Value for row %d", i), baseTime.Add(time.Duration(i)*time.Minute))
+		}
+		cs.Capture(ctx, t, nil)
+		cupaloy.SnapshotT(t, cs.Summary())
+	})
+}
+
+// TestCaptureWithTwoColumnCursor exercises the use-case of a capture using
+// a multiple-column compound cursor.
+func TestCaptureWithTwoColumnCursor(t *testing.T) {
+	var ctx, cs, control = context.Background(), testCaptureSpec(t), testControlClient(t)
+	var tableName, uniqueID = testTableName(t, uniqueTableID(t))
+	createTestTable(t, control, tableName, `(
+        id INTEGER PRIMARY KEY,
+        major INTEGER,
+        minor INTEGER,
+        data TEXT
+    )`)
+
+	cs.Bindings = discoverBindings(ctx, t, cs, regexp.MustCompile(uniqueID))
+	setResourceCursor(t, cs.Bindings[0], "major", "minor")
+
+	t.Run("Discovery", func(t *testing.T) { cupaloy.SnapshotT(t, summarizeBindings(t, cs.Bindings)) })
+
+	t.Run("Capture", func(t *testing.T) {
+		setShutdownAfterQuery(t, true)
+
+		// First batch with lower version numbers
+		for _, row := range [][]any{
+			{0, 1, 1, "v1.1"}, {1, 1, 2, "v1.2"}, {2, 1, 3, "v1.3"},
+			{3, 2, 1, "v2.1"}, {4, 2, 2, "v2.2"}, {5, 2, 3, "v2.3"},
+		} {
+			executeControlQuery(t, control, fmt.Sprintf("INSERT INTO %s VALUES ($1, $2, $3, $4)", tableName), row...)
+		}
+		cs.Capture(ctx, t, nil)
+
+		// Second batch with higher version numbers
+		for _, row := range [][]any{
+			{6, 0, 9, "Value ignored because major is too small"},
+			{7, 2, 0, "Value ignored because minor is too small"},
+			{8, 3, 1, "v3.1"}, {9, 3, 2, "v3.2"}, {10, 3, 3, "v3.3"},
+			{11, 4, 1, "v4.1"}, {12, 4, 2, "v4.2"}, {13, 4, 3, "v4.3"},
+		} {
+			executeControlQuery(t, control, fmt.Sprintf("INSERT INTO %s VALUES ($1, $2, $3, $4)", tableName), row...)
+		}
+		cs.Capture(ctx, t, nil)
 		cupaloy.SnapshotT(t, cs.Summary())
 	})
 }

--- a/source-postgres-batch/main_test.go
+++ b/source-postgres-batch/main_test.go
@@ -1215,3 +1215,38 @@ func TestCaptureWithTwoColumnCursor(t *testing.T) {
 		cupaloy.SnapshotT(t, cs.Summary())
 	})
 }
+
+// TestQueryTemplates exercises the selection and execution of query templates
+// for various combinations of resource spec and stream state.
+func TestQueryTemplates(t *testing.T) {
+	var testCases = []struct {
+		name         string
+		cursor       []string
+		cursorValues []any
+	}{
+		{name: "XMinFirstQuery", cursor: []string{"txid"}},
+		{name: "XMinSubsequentQuery", cursor: []string{"txid"}, cursorValues: []any{12345}},
+		{name: "SingleCursorFirstQuery", cursor: []string{"updated_at"}},
+		{name: "SingleCursorSubsequentQuery", cursor: []string{"updated_at"}, cursorValues: []any{"2024-02-20 12:00:00"}},
+		{name: "MultiCursorFirstQuery", cursor: []string{"major", "minor"}},
+		{name: "MultiCursorSubsequentQuery", cursor: []string{"major", "minor"}, cursorValues: []any{1, 2}},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			var resource = &Resource{
+				Name:       "test_foobar",
+				SchemaName: "test",
+				TableName:  "foobar",
+				Cursor:     tc.cursor,
+			}
+			var state = &streamState{
+				CursorNames:  tc.cursor,
+				CursorValues: tc.cursorValues,
+			}
+			var query, err = postgresDriver.buildQuery(resource, state)
+			require.NoError(t, err)
+			cupaloy.SnapshotT(t, query)
+		})
+	}
+}


### PR DESCRIPTION
**Description:**

This PR bundles together three closely-related fixes to the `source-postgres-batch` connector:

- Support for non-XMIN cursor settings. Previously there was a user-modifiable cursor property in the resource spec, but in practice if it ever got set to something other than `["xmin"]` without the user also supplying their own query template this would just break. We omit query templates by default, so for that reason it makes sense that we'd want this to just work automatically (applying the same full-refresh or cursor-incremental polling behavior that other connectors use).
- Support for view discovery. Implements a new advanced option `Discover Views` which when set causes views to be returned by discovery. In a truly stunning coincidence, we need the non-XMIN cursor support to make this work correctly since views don't have an XMIN column.
- A fix for the XID wraparound failure mode. Previously there was a theoretical (never actually observed in production AFAIK) failure state for this connector where after XID wraparound occurs on a database it could go into an infinite loop reading out the full contents of the table over and over. This is remedied by adding an explicit upper bound to the XMIN-incremental polling queries so that a given polling iteration will never return rows with a higher XID than the bottom 32-bit portion of `txid_current()`.
  - Expanding slightly, we know that any row whose XID is greater (in the same mod-2^32 circular comparison sense that we use for other XID comparisons) than the bottom 32 bits of `txid_current()` must be from an earlier "epoch" (that is, the upper not-actually-stored 32 bits of the full 64-bit XID).
  - This fixes https://github.com/estuary/connectors/issues/2383

**Workflow steps:**

Nothing should change by default, the connector should just be a bit more flexible and failure-proof in general, plus there's now an advanced option for if a user wants to capture their views automatically.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2438)
<!-- Reviewable:end -->
