### PR TITLE
source-intercom-native: dynamically reduce `conversation_parts` window size

### DIFF
--- a/source-intercom-native/source_intercom_native/api.py
+++ b/source-intercom-native/source_intercom_native/api.py
@@ -263,8 +263,6 @@ async def fetch_tickets(
     url = f"{API}/tickets/search"
     body = _generate_conversations_or_tickets_search_body(start, end)
 
-    count = 0
-
     while True:
         response = TicketsSearchResponse.model_validate_json(
                 await http.request(log, url, "POST", json=body)
@@ -294,7 +292,6 @@ async def fetch_tickets(
 
             if ticket.updated_at > start:
                 yield ticket
-                count += 1
 
         if response.pages.next is None:
             yield _s_to_dt(last_seen_ts)
@@ -317,8 +314,6 @@ async def fetch_conversations(
 
     url = f"{API}/conversations/search"
     body = _generate_conversations_or_tickets_search_body(start, end)
-
-    count = 0
 
     while True:
         response = ConversationsSearchResponse.model_validate_json(
@@ -349,7 +344,6 @@ async def fetch_conversations(
 
             if conversation.updated_at > start:
                 yield conversation
-                count += 1
 
         if response.pages.next is None:
             yield _s_to_dt(last_seen_ts)


### PR DESCRIPTION
**Description:**

In `conversation_parts`, we attempt to only yield parts that have been updated since the previous sweep. Because of this, we can only checkpoint after checking a full date window. If a date window contains a large number of updated conversations, it can take `conversation_parts` more than one day to check all those conversations for updated parts. This has been observed for at least one task; about 4,000 pages of conversations were updated within 1 day (the smallest configurable date window).

This commit adds some dynamic reduction logic to size of the date window `conversation_parts` checks in a single `fetch_conversation_parts` invocation. If there are more than 25 pages of conversations, then the date window is split in half until there are <= 25 pages or the date window is the smallest possible size (1 second).

An alternative approach would be to yield all parts of an updated conversation, then `conversation_parts` can checkpoint after each page of conversations. I chose to do dynamic window reduction since that's keeps the connector's current behavior of only yielding updated parts, but this alternative approach could be worth while later if the date window approach is too slow & we aren't extremely concerned about yielding duplicate, non-updated parts.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

Tested on a local stack. Confirmed the date window for a single invocation of `fetch_conversation_parts` is reduced until there are <= 25 pages of conversations or the date window is the smallest possible size of 1 second.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2439)
<!-- Reviewable:end -->
