### PR TITLE
source-mixpanel-native: increase `funnels` date window size

### DIFF
--- a/source-mixpanel-native/source_mixpanel_native/streams/funnels.py
+++ b/source-mixpanel-native/source_mixpanel_native/streams/funnels.py
@@ -43,6 +43,23 @@ class Funnels(DateSlicesMixin, IncrementalMixpanelStream):
         # we'll have to emit state every 15 records
         return 1000
 
+    def __init__(
+        self,
+        date_window_size: int = 30,
+        **kwargs,
+    ):
+        # This stream checks from the start_date to the end_date for each funnel. Typically,
+        # there's KB of data between the start_date & end_date for each funnel, and using
+        # small date windows causes the connector to make multiple requests for each funnel.
+        # Since we should be able to fetch all data for a funnel in a single request,
+        # we use an extremely large data window to force the connector to make a single request
+        # for all of a funnel's records between the start & end dates.
+
+        super().__init__(
+            date_window_size = 100_000,
+            **kwargs,
+        )
+
     def path(self, **kwargs) -> str:
         return "funnels"
 


### PR DESCRIPTION
**Description:**

This implements the fix made to `annotations` in https://github.com/estuary/connectors/pull/2389 to the `funnels` stream. The connector has to send at least one API request for each funnel, and for users with hundreds of funnels, this will at minimum take multiple hours. If the connector uses a small date window size & makes more than a single request per funnel, then it's possible for `funnels` to never complete in 24 hours. 

Since each funnel typically only has KB of data, we can force `funnels` to make a single request per funnel by using a very large date window size.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

Tested on a local stack. Confirmed that a single request is made per funnel even when the configured date window size is small (1 day).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2440)
<!-- Reviewable:end -->
