### PR TITLE
source-zendesk-support-native: handle cursor paginated responses with no results

### DIFF
--- a/source-zendesk-support-native/source_zendesk_support_native/models.py
+++ b/source-zendesk-support-native/source_zendesk_support_native/models.py
@@ -208,8 +208,9 @@ FULL_REFRESH_OFFSET_PAGINATED_RESOURCES: list[tuple[str, str, type[FullRefreshOf
 class FullRefreshCursorPaginatedResponse(FullRefreshResponse):
     class Meta(BaseModel, extra="forbid"):
         has_more: bool
-        after_cursor: str | None
-        before_cursor: str | None
+        # after_cursor and before_cursor are not present in the response if there are no results.
+        after_cursor: str | None = None
+        before_cursor: str | None = None
 
     meta: Meta
     resources: list[FullRefreshResource]


### PR DESCRIPTION
**Description:**

When there are no results at all in a cursor paginated response, the after and before cursor fields are not present. Although that shouldn't affect the code flow (the `has_more` field would stop any attempted pagination), a default value is needed to avoid validation errors when validating the response.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

Tested on a local stack. Confirmed `posts` (the stream I observed this issue on) does not fail when the response contains no `after_cursor` or `before_cursor` field.

