### PR TITLE
ci: pin poetry version to 1.8.5

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -242,6 +242,8 @@ jobs:
       - name: Install Poetry
         if: ${{matrix.python}}
         uses: snok/install-poetry@v1
+        with:
+            version: 1.8.5
 
       - name: Python connector ${{ matrix.connector }} snapshot tests
         if: ${{matrix.python}}


### PR DESCRIPTION
**Description:**

CI for `source-criteo` and `source-shopify` started failing sometime between 04JAN2025 and 06JAN2025. The logs for one of the most recent successful runs on [04JAN](https://github.com/estuary/connectors/actions/runs/12614028118/job/35152522481) contain:
```
Warning: The current project could not be installed: No file/folder found for package source-shopify-estuary
If you do not want to install the current project use --no-root.
If you want to use Poetry only for dependency management but not for packaging, you can disable package mode by setting package-mode = false in your pyproject.toml file.
In a future version of Poetry this warning will become an error!
```
That successful run was using Poetry v1.8.5.

On 05JAN2025, Poetry released v2.0.0, and the `snok/install-poetry@v1` action began installing v2.0.0 instead of v1.8.5. True to it's earlier warning, Poetry started raising an error during CI for `source-criteo` and `source-shopify` & CI for those connectors started failing.

It looks like pinning the Poetry version used during install to v1.8.5 lets CI for those two connectors succeed again.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2445)
<!-- Reviewable:end -->
