### PR TITLE
source-postgres-batch: Extend watchdog timeouts

### DIFF
--- a/source-postgres-batch/driver.go
+++ b/source-postgres-batch/driver.go
@@ -38,12 +38,12 @@ const (
 	// subsequent rows, because sometimes when using a cursor the queries can have some
 	// nontrivial startup cost and we don't want to make things any more failure-prone
 	// than we have to.
-	pollingWatchdogFirstRowTimeout = 30 * time.Minute
+	pollingWatchdogFirstRowTimeout = 6 * time.Hour
 
 	// The duration of the no-data watchdog for subsequent rows after the first one.
 	// This timeout can be less generous, because after the first row is received we
 	// ought to be getting a consistent stream of results until the query completes.
-	pollingWatchdogTimeout = 5 * time.Minute
+	pollingWatchdogTimeout = 15 * time.Minute
 )
 
 var (


### PR DESCRIPTION
**Description:**

Increases the no-data watchdog from 30 minutes to 6 hours when waiting for initial results, and from 5 to 15 minutes while results should be streaming in.