### PR TITLE
source-postgres: Set application_name param

### DIFF
--- a/source-postgres/.snapshots/TestConfigURI-Basic
+++ b/source-postgres/.snapshots/TestConfigURI-Basic
@@ -1,2 +1,2 @@
-postgres://will:secret1234@example.com:5432/somedb
+postgres://will:secret1234@example.com:5432/somedb?application_name=estuary_flow
 config valid

--- a/source-postgres/.snapshots/TestConfigURI-IncorrectSSL
+++ b/source-postgres/.snapshots/TestConfigURI-IncorrectSSL
@@ -1,2 +1,2 @@
-postgres://will:secret1234@example.com:5432/somedb?sslmode=whoops-this-isnt-right
+postgres://will:secret1234@example.com:5432/somedb?application_name=estuary_flow&sslmode=whoops-this-isnt-right
 invalid 'sslmode' configuration: unknown setting "whoops-this-isnt-right"

--- a/source-postgres/.snapshots/TestConfigURI-RequireSSL
+++ b/source-postgres/.snapshots/TestConfigURI-RequireSSL
@@ -1,2 +1,2 @@
-postgres://will:secret1234@example.com:5432/somedb?sslmode=verify-full
+postgres://will:secret1234@example.com:5432/somedb?application_name=estuary_flow&sslmode=verify-full
 config valid

--- a/source-postgres/main.go
+++ b/source-postgres/main.go
@@ -227,6 +227,7 @@ func (c *Config) ToURI() string {
 		uri.Path = "/" + c.Database
 	}
 	var params = make(url.Values)
+	params.Set("application_name", "estuary_flow")
 	if c.Advanced.SSLMode != "" {
 		params.Set("sslmode", c.Advanced.SSLMode)
 	}


### PR DESCRIPTION
**Description:**

This means we show up like this in pg_stat_replication:

    postgres=> SELECT * FROM pg_stat_replication;
    -[ RECORD 1 ]----+------------------------------
    pid              | 36917
    usesysid         | 16540
    usename          | flow_capture
    application_name | estuary_flow
    client_addr      | 99.27.226.225
    client_hostname  |
    client_port      | 40560
    backend_start    | 2025-02-25 16:40:03.981342+00
    [...]

Currently the `application_name` field is entirely blank, so it seems like having anything at all there is a clear win. We might consider making it customizable or filing in the capture task name in the future, but for now this is better than nothing.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2449)
<!-- Reviewable:end -->
