### PR TITLE
materialize-postgres: include table name in logs for failed table alterations

### DIFF
--- a/materialize-postgres/client.go
+++ b/materialize-postgres/client.go
@@ -159,7 +159,8 @@ func (c *client) AlterTable(ctx context.Context, ta sql.TableAlter) (string, boi
 	return strings.Join(stmts, "\n"), func(ctx context.Context) error {
 		for _, stmt := range stmts {
 			if _, err := c.db.ExecContext(ctx, stmt); err != nil {
-				return err
+				log.WithField("stmt", stmt).Error("alter table statement failed")
+				return fmt.Errorf("executing alter table for table %s: %w", ta.Identifier, err)
 			}
 		}
 		return nil


### PR DESCRIPTION
**Description:**

Adds information to the error and logging for failed table operations to assist in their resolution.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

