### PR TITLE
source-intercom-native: hydrate `contacts` with all attached tags

### DIFF
--- a/source-intercom-native/source_intercom_native/models.py
+++ b/source-intercom-native/source_intercom_native/models.py
@@ -1,5 +1,13 @@
 from datetime import datetime, UTC, timedelta
-from typing import Annotated, AsyncGenerator, Callable, Literal, TYPE_CHECKING, Optional
+from typing import (
+    Annotated,
+    AsyncGenerator,
+    Callable,
+    Generic,
+    Optional,
+    TYPE_CHECKING,
+    TypeVar,
+)
 
 from estuary_cdk.capture.common import (
     AccessToken,
@@ -112,8 +120,37 @@ class SearchResponse(BaseModel, extra="allow"):
     pages: Pagination
 
 
+_Subresource = TypeVar("_Subresource", bound=BaseModel)
+
+
+class NestedTag(BaseModel):
+    id: str
+    type: str
+    url: str
+
+
+class Contact(TimestampedResource):
+    class Subresources(BaseModel, Generic[_Subresource]):
+        data: list[_Subresource]
+        has_more: bool
+        total_count: int
+        type: str
+        url: str
+
+    tags: Subresources[NestedTag]
+
+
+class ContactTagsResponse(BaseModel, extra="allow"):
+    class Tag(BaseModel, extra="forbid"):
+        id: str
+        type: str
+        name: str
+
+    data: list[Tag]
+
+
 class ContactsSearchResponse(SearchResponse):
-    data: list[TimestampedResource]
+    data: list[Contact]
 
 
 class TicketsSearchResponse(SearchResponse):

--- a/source-intercom-native/tests/snapshots/snapshots__capture__capture.stdout.json
+++ b/source-intercom-native/tests/snapshots/snapshots__capture__capture.stdout.json
@@ -187,16 +187,87 @@
         "type": "list"
       },
       "tags": {
-        "data": [],
+        "data": [
+          {
+            "id": "10718342",
+            "type": "tag",
+            "url": "/tags/10718342"
+          },
+          {
+            "id": "10718351",
+            "type": "tag",
+            "url": "/tags/10718351"
+          },
+          {
+            "id": "10718352",
+            "type": "tag",
+            "url": "/tags/10718352"
+          },
+          {
+            "id": "10718349",
+            "type": "tag",
+            "url": "/tags/10718349"
+          },
+          {
+            "id": "10718354",
+            "type": "tag",
+            "url": "/tags/10718354"
+          },
+          {
+            "id": "10718353",
+            "type": "tag",
+            "url": "/tags/10718353"
+          },
+          {
+            "id": "10718347",
+            "type": "tag",
+            "url": "/tags/10718347"
+          },
+          {
+            "id": "10718350",
+            "type": "tag",
+            "url": "/tags/10718350"
+          },
+          {
+            "id": "10718345",
+            "type": "tag",
+            "url": "/tags/10718345"
+          },
+          {
+            "id": "10718343",
+            "type": "tag",
+            "url": "/tags/10718343"
+          },
+          {
+            "id": "10718348",
+            "type": "tag",
+            "url": "/tags/10718348"
+          },
+          {
+            "id": "10718344",
+            "type": "tag",
+            "url": "/tags/10718344"
+          },
+          {
+            "id": "10718355",
+            "type": "tag",
+            "url": "/tags/10718355"
+          },
+          {
+            "id": "10718346",
+            "type": "tag",
+            "url": "/tags/10718346"
+          }
+        ],
         "has_more": false,
-        "total_count": 0,
+        "total_count": 14,
         "type": "list",
         "url": "/contacts/67570a878b6e26fe4ce6a894/tags"
       },
       "type": "contact",
       "unsubscribed_from_emails": false,
       "unsubscribed_from_sms": false,
-      "updated_at": 1734097734,
+      "updated_at": 1740758913,
       "utm_campaign": null,
       "utm_content": null,
       "utm_medium": null,

--- a/source-intercom-native/tests/test_snapshots.py
+++ b/source-intercom-native/tests/test_snapshots.py
@@ -12,7 +12,7 @@ def test_capture(request, snapshot):
             "--sessions",
             "1",
             "--delay",
-            "10s",
+            "30s",
         ],
         stdout=subprocess.PIPE,
         text=True,


### PR DESCRIPTION
**Description:**

A contact contain multiple sub-resources, like tags. There can be a large number of sub-resources attached to one contact, but only a subset are included when fetching a contact from Intercom's API. For example, only the [first 10 tags](https://developers.intercom.com/docs/references/2.8/rest-api/api.intercom.io/models/contact_tags) are included in a contact. To get all sub-resources, the connector would need to make an additional request to fetch them then hydrate the contact with the full set of sub-resources.

This commit adds this hydration functionality for tags within a contact. There are other possible sub-resources that we could hydrate (notes, companies, opted_out_subscription_types, etc.), but users are only asking about tags right now. So I'm only adding functionality for tags for now. Hydrating other sub-resources should be fairly straightforward if we need to do so later.

Capture snapshot changes are expected. I added >10 tags to both contacts in our developer Intercom account to test for this new tag hydration functionality.

Addresses https://github.com/estuary/connectors/issues/2463.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

Tested on a local stack. Confirmed contacts that previously had only 10 tags included & have more than 10 attached tags now contain the full set of >10 tags.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2465)
<!-- Reviewable:end -->
