### PR TITLE
Revert "source-postgres-batch: Fix XID wraparound behavior"

### DIFF
--- a/source-postgres-batch/.snapshots/TestQueryTemplates-XMinFirstQuery
+++ b/source-postgres-batch/.snapshots/TestQueryTemplates-XMinFirstQuery
@@ -1,4 +1,1 @@
-SELECT xmin AS txid, * FROM "test"."foobar"
-    WHERE xmin::text::bigint >= 3
-      AND (((txid_current() - xmin::text::bigint)<<32)>>32) >= 0
-    ORDER BY xmin::text::bigint;
+SELECT xmin AS txid, * FROM "test"."foobar" ORDER BY xmin::text::bigint;

--- a/source-postgres-batch/.snapshots/TestQueryTemplates-XMinSubsequentQuery
+++ b/source-postgres-batch/.snapshots/TestQueryTemplates-XMinSubsequentQuery
@@ -1,5 +1,3 @@
 SELECT xmin AS txid, * FROM "test"."foobar"
-    WHERE xmin::text::bigint >= 3
-      AND (((txid_current() - xmin::text::bigint)<<32)>>32) >= 0
-      AND (((xmin::text::bigint - $1::bigint)<<32)>>32) > 0
+    WHERE (((xmin::text::bigint - $1::bigint)<<32)>>32) > 0 AND xmin::text::bigint >= 3
     ORDER BY (((xmin::text::bigint - $1::bigint)<<32)>>32);

--- a/source-postgres-batch/main.go
+++ b/source-postgres-batch/main.go
@@ -168,15 +168,10 @@ func selectQueryTemplate(res *Resource) (string, error) {
 // the XID epoch wraps around. If this assumption is violated it would in principle be doable
 // to `SELECT txid_current() as polled_txid, ...` and use "polled_txid" as the cursor value.
 const tableQueryTemplateXMIN = `{{if .IsFirstQuery -}}
-  SELECT xmin AS txid, * FROM {{quoteTableName .SchemaName .TableName}}
-    WHERE xmin::text::bigint >= 3
-      AND (((txid_current() - xmin::text::bigint)<<32)>>32) >= 0
-    ORDER BY xmin::text::bigint;
+  SELECT xmin AS txid, * FROM {{quoteTableName .SchemaName .TableName}} ORDER BY xmin::text::bigint;
 {{- else -}}
   SELECT xmin AS txid, * FROM {{quoteTableName .SchemaName .TableName}}
-    WHERE xmin::text::bigint >= 3
-      AND (((txid_current() - xmin::text::bigint)<<32)>>32) >= 0
-      AND (((xmin::text::bigint - $1::bigint)<<32)>>32) > 0
+    WHERE (((xmin::text::bigint - $1::bigint)<<32)>>32) > 0 AND xmin::text::bigint >= 3
     ORDER BY (((xmin::text::bigint - $1::bigint)<<32)>>32);
 {{- end}}`
 


### PR DESCRIPTION
**Description:**

This reverts commit e57acbcb75aed8f74b15ff6cfeeb9ed3e200f981 and un-fixes https://github.com/estuary/connectors/issues/2383

Turns out the particular function we're using here doesn't work on a standby replica, which is...bad. Since the XID wraparound failure mode this guards against is still mostly theoretical (has never been seen in production yet) and the failures on read-only standby replicas are very much real, we should revert this and then revisit how to make it work on a standby as well.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2466)
<!-- Reviewable:end -->
