### PR TITLE
common/feature_flags: Trim whitespace

### DIFF
--- a/go/common/feature_flags.go
+++ b/go/common/feature_flags.go
@@ -12,6 +12,7 @@ func ParseFeatureFlags(flags string, defaults map[string]bool) map[string]bool {
 		settings[k] = v
 	}
 	for _, flagName := range strings.Split(flags, ",") {
+		flagName = strings.TrimSpace(flagName)
 		var flagValue = true
 		if strings.HasPrefix(flagName, "no_") {
 			flagName = strings.TrimPrefix(flagName, "no_")


### PR DESCRIPTION
**Description:**

Makes it so a setting like `do_foo, do_bar` parses the same as `do_foo,do_bar`.

Without this fix it instead parses the second one as a flag setting `" do_bar"` which is clearly very distinct from the intended `"do_bar"` flag.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2470)
<!-- Reviewable:end -->
