### PR TITLE
source-postgres: Add 'flatten_arrays' flag

### DIFF
--- a/source-postgres/.snapshots/TestFeatureFlagFlattenArrays-Disabled-Capture
+++ b/source-postgres/.snapshots/TestFeatureFlagFlattenArrays-Disabled-Capture
@@ -1,0 +1,12 @@
+# ================================
+# Collection "acmeCo/test/test/featureflagflattenarrays_70143951": 4 Documents
+# ================================
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"featureflagflattenarrays_70143951","loc":[11111111,11111111,11111111]}},"id":1,"int_array":{"dimensions":[3],"elements":[1,2,3]},"nested_array":{"dimensions":[2,2],"elements":[1,2,3,4]},"text_array":{"dimensions":[3],"elements":["a","b","c"]}}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"featureflagflattenarrays_70143951","loc":[11111111,11111111,11111111]}},"id":2,"int_array":{"dimensions":[2],"elements":[10,20]},"nested_array":{"dimensions":[2,2],"elements":[5,6,7,8]},"text_array":{"dimensions":[2],"elements":["foo","bar"]}}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"featureflagflattenarrays_70143951","loc":[11111111,11111111,11111111]}},"id":3,"int_array":{"dimensions":[],"elements":[]},"nested_array":{"dimensions":[],"elements":[]},"text_array":{"dimensions":[],"elements":[]}}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"featureflagflattenarrays_70143951","loc":[11111111,11111111,11111111]}},"id":4,"int_array":null,"nested_array":null,"text_array":null}
+# ================================
+# Final State Checkpoint
+# ================================
+{"bindingStateV1":{"test%2Ffeatureflagflattenarrays_70143951":{"backfilled":4,"key_columns":["id"],"mode":"Active"}},"cursor":"0/1111111"}
+

--- a/source-postgres/.snapshots/TestFeatureFlagFlattenArrays-Disabled-Discovery
+++ b/source-postgres/.snapshots/TestFeatureFlagFlattenArrays-Disabled-Discovery
@@ -1,0 +1,214 @@
+Binding 0:
+{
+    "recommended_name": "test/featureflagflattenarrays_70143951",
+    "resource_config_json": {
+      "namespace": "test",
+      "stream": "featureflagflattenarrays_70143951"
+    },
+    "document_schema_json": {
+      "$defs": {
+        "TestFeatureflagflattenarrays_70143951": {
+          "type": "object",
+          "required": [
+            "id"
+          ],
+          "$anchor": "TestFeatureflagflattenarrays_70143951",
+          "properties": {
+            "id": {
+              "type": "integer",
+              "description": "(source type: non-nullable int4)"
+            },
+            "int_array": {
+              "required": [
+                "dimensions",
+                "elements"
+              ],
+              "description": "(source type: _int4)",
+              "properties": {
+                "dimensions": {
+                  "items": {
+                    "type": "integer"
+                  },
+                  "type": "array"
+                },
+                "elements": {
+                  "items": {
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "type": "array"
+                }
+              },
+              "type": [
+                "object",
+                "null"
+              ]
+            },
+            "nested_array": {
+              "required": [
+                "dimensions",
+                "elements"
+              ],
+              "description": "(source type: _int4)",
+              "properties": {
+                "dimensions": {
+                  "items": {
+                    "type": "integer"
+                  },
+                  "type": "array"
+                },
+                "elements": {
+                  "items": {
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "type": "array"
+                }
+              },
+              "type": [
+                "object",
+                "null"
+              ]
+            },
+            "text_array": {
+              "required": [
+                "dimensions",
+                "elements"
+              ],
+              "description": "(source type: _text)",
+              "properties": {
+                "dimensions": {
+                  "items": {
+                    "type": "integer"
+                  },
+                  "type": "array"
+                },
+                "elements": {
+                  "items": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "type": "array"
+                }
+              },
+              "type": [
+                "object",
+                "null"
+              ]
+            }
+          }
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "_meta": {
+                "properties": {
+                  "op": {
+                    "const": "d"
+                  }
+                }
+              }
+            }
+          },
+          "then": {
+            "reduce": {
+              "delete": true,
+              "strategy": "merge"
+            }
+          },
+          "else": {
+            "reduce": {
+              "strategy": "merge"
+            }
+          },
+          "required": [
+            "_meta"
+          ],
+          "properties": {
+            "_meta": {
+              "type": "object",
+              "required": [
+                "op",
+                "source"
+              ],
+              "properties": {
+                "before": {
+                  "$ref": "#TestFeatureflagflattenarrays_70143951",
+                  "description": "Record state immediately before this change was applied.",
+                  "reduce": {
+                    "strategy": "firstWriteWins"
+                  }
+                },
+                "op": {
+                  "enum": [
+                    "c",
+                    "d",
+                    "u"
+                  ],
+                  "description": "Change operation type: 'c' Create/Insert, 'u' Update, 'd' Delete."
+                },
+                "source": {
+                  "$id": "https://github.com/estuary/connectors/source-postgres/postgres-source",
+                  "properties": {
+                    "ts_ms": {
+                      "type": "integer",
+                      "description": "Unix timestamp (in millis) at which this event was recorded by the database."
+                    },
+                    "schema": {
+                      "type": "string",
+                      "description": "Database schema (namespace) of the event."
+                    },
+                    "snapshot": {
+                      "type": "boolean",
+                      "description": "Snapshot is true if the record was produced from an initial table backfill and unset if produced from the replication log."
+                    },
+                    "table": {
+                      "type": "string",
+                      "description": "Database table of the event."
+                    },
+                    "loc": {
+                      "items": {
+                        "type": "integer"
+                      },
+                      "type": "array",
+                      "maxItems": 3,
+                      "minItems": 3,
+                      "description": "Location of this WAL event as [last Commit.EndLSN; event LSN; current Begin.FinalLSN]. See https://www.postgresql.org/docs/current/protocol-logicalrep-message-formats.html"
+                    },
+                    "txid": {
+                      "type": "integer",
+                      "description": "The 32-bit transaction ID assigned by Postgres to the commit which produced this change."
+                    }
+                  },
+                  "type": "object",
+                  "required": [
+                    "schema",
+                    "table",
+                    "loc"
+                  ]
+                }
+              },
+              "reduce": {
+                "strategy": "merge"
+              }
+            }
+          }
+        },
+        {
+          "$ref": "#TestFeatureflagflattenarrays_70143951"
+        }
+      ]
+    },
+    "key": [
+      "/id"
+    ]
+  }
+

--- a/source-postgres/.snapshots/TestFeatureFlagFlattenArrays-Enabled-Capture
+++ b/source-postgres/.snapshots/TestFeatureFlagFlattenArrays-Enabled-Capture
@@ -1,0 +1,12 @@
+# ================================
+# Collection "acmeCo/test/test/featureflagflattenarrays_70143951": 4 Documents
+# ================================
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"featureflagflattenarrays_70143951","loc":[11111111,11111111,11111111]}},"id":1,"int_array":[1,2,3],"nested_array":[1,2,3,4],"text_array":["a","b","c"]}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"featureflagflattenarrays_70143951","loc":[11111111,11111111,11111111]}},"id":2,"int_array":[10,20],"nested_array":[5,6,7,8],"text_array":["foo","bar"]}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"featureflagflattenarrays_70143951","loc":[11111111,11111111,11111111]}},"id":3,"int_array":[],"nested_array":[],"text_array":[]}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"featureflagflattenarrays_70143951","loc":[11111111,11111111,11111111]}},"id":4,"int_array":null,"nested_array":null,"text_array":null}
+# ================================
+# Final State Checkpoint
+# ================================
+{"bindingStateV1":{"test%2Ffeatureflagflattenarrays_70143951":{"backfilled":4,"key_columns":["id"],"mode":"Active"}},"cursor":"0/1111111"}
+

--- a/source-postgres/.snapshots/TestFeatureFlagFlattenArrays-Enabled-Discovery
+++ b/source-postgres/.snapshots/TestFeatureFlagFlattenArrays-Enabled-Discovery
@@ -1,0 +1,169 @@
+Binding 0:
+{
+    "recommended_name": "test/featureflagflattenarrays_70143951",
+    "resource_config_json": {
+      "namespace": "test",
+      "stream": "featureflagflattenarrays_70143951"
+    },
+    "document_schema_json": {
+      "$defs": {
+        "TestFeatureflagflattenarrays_70143951": {
+          "type": "object",
+          "required": [
+            "id"
+          ],
+          "$anchor": "TestFeatureflagflattenarrays_70143951",
+          "properties": {
+            "id": {
+              "type": "integer",
+              "description": "(source type: non-nullable int4)"
+            },
+            "int_array": {
+              "items": {
+                "type": [
+                  "integer",
+                  "null"
+                ]
+              },
+              "description": "(source type: _int4)",
+              "type": [
+                "array",
+                "null"
+              ]
+            },
+            "nested_array": {
+              "items": {
+                "type": [
+                  "integer",
+                  "null"
+                ]
+              },
+              "description": "(source type: _int4)",
+              "type": [
+                "array",
+                "null"
+              ]
+            },
+            "text_array": {
+              "items": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "description": "(source type: _text)",
+              "type": [
+                "array",
+                "null"
+              ]
+            }
+          }
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "_meta": {
+                "properties": {
+                  "op": {
+                    "const": "d"
+                  }
+                }
+              }
+            }
+          },
+          "then": {
+            "reduce": {
+              "delete": true,
+              "strategy": "merge"
+            }
+          },
+          "else": {
+            "reduce": {
+              "strategy": "merge"
+            }
+          },
+          "required": [
+            "_meta"
+          ],
+          "properties": {
+            "_meta": {
+              "type": "object",
+              "required": [
+                "op",
+                "source"
+              ],
+              "properties": {
+                "before": {
+                  "$ref": "#TestFeatureflagflattenarrays_70143951",
+                  "description": "Record state immediately before this change was applied.",
+                  "reduce": {
+                    "strategy": "firstWriteWins"
+                  }
+                },
+                "op": {
+                  "enum": [
+                    "c",
+                    "d",
+                    "u"
+                  ],
+                  "description": "Change operation type: 'c' Create/Insert, 'u' Update, 'd' Delete."
+                },
+                "source": {
+                  "$id": "https://github.com/estuary/connectors/source-postgres/postgres-source",
+                  "properties": {
+                    "ts_ms": {
+                      "type": "integer",
+                      "description": "Unix timestamp (in millis) at which this event was recorded by the database."
+                    },
+                    "schema": {
+                      "type": "string",
+                      "description": "Database schema (namespace) of the event."
+                    },
+                    "snapshot": {
+                      "type": "boolean",
+                      "description": "Snapshot is true if the record was produced from an initial table backfill and unset if produced from the replication log."
+                    },
+                    "table": {
+                      "type": "string",
+                      "description": "Database table of the event."
+                    },
+                    "loc": {
+                      "items": {
+                        "type": "integer"
+                      },
+                      "type": "array",
+                      "maxItems": 3,
+                      "minItems": 3,
+                      "description": "Location of this WAL event as [last Commit.EndLSN; event LSN; current Begin.FinalLSN]. See https://www.postgresql.org/docs/current/protocol-logicalrep-message-formats.html"
+                    },
+                    "txid": {
+                      "type": "integer",
+                      "description": "The 32-bit transaction ID assigned by Postgres to the commit which produced this change."
+                    }
+                  },
+                  "type": "object",
+                  "required": [
+                    "schema",
+                    "table",
+                    "loc"
+                  ]
+                }
+              },
+              "reduce": {
+                "strategy": "merge"
+              }
+            }
+          }
+        },
+        {
+          "$ref": "#TestFeatureflagflattenarrays_70143951"
+        }
+      ]
+    },
+    "key": [
+      "/id"
+    ]
+  }
+

--- a/source-postgres/main.go
+++ b/source-postgres/main.go
@@ -132,6 +132,11 @@ var featureFlagDefaults = map[string]bool{
 	// satisfying `format: time`. Historically these used to be captured as Unix microseconds,
 	// which is usually not what users expect.
 	"time_as_time": true,
+
+	// When true, array columns are captured as a flat array of values in the JSON output.
+	// When false, array columns are captured as a `{dimensions, elements}` object which
+	// preserves dimensionality (at the cost of being awful to use in most cases).
+	"flatten_arrays": false,
 }
 
 // Validate checks that the configuration possesses all required properties.


### PR DESCRIPTION
**Description:**

Currently source-postgres captures array columns as a JSON object with dimensions and elements properties, each of which is an array. This is because PostgreSQL arrays are inherently multidimensional, and we're trying to preserve them as faithfully as possible.

But it turns out that nobody ever wants that, they just want simple, boring one-dimensional arrays of values to translate into a JSON array of equivalent values. So we should do that by default going forward.

This partially addresses https://github.com/estuary/connectors/issues/2460

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2471)
<!-- Reviewable:end -->
