### PR TITLE
source-postgres: Set 'flatten_arrays' by default

### DIFF
--- a/source-postgres/.snapshots/TestCIText-Capture
+++ b/source-postgres/.snapshots/TestCIText-Capture
@@ -1,12 +1,12 @@
 # ================================
 # Collection "acmeCo/test/test/citext_58810479": 6 Documents
 # ================================
-{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"citext_58810479","loc":[11111111,11111111,11111111]}},"arr":{"dimensions":[2],"elements":["a","b"]},"data":"zero","id":0}
-{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"citext_58810479","loc":[11111111,11111111,11111111]}},"arr":{"dimensions":[2],"elements":["c","d"]},"data":"one","id":1}
-{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"citext_58810479","loc":[11111111,11111111,11111111]}},"arr":{"dimensions":[2],"elements":["e","f"]},"data":"two","id":2}
-{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"citext_58810479","loc":[11111111,11111111,11111111],"txid":111111}},"arr":{"dimensions":[2],"elements":["g","h"]},"data":"three","id":3}
-{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"citext_58810479","loc":[11111111,11111111,11111111],"txid":111111}},"arr":{"dimensions":[2],"elements":["i","j"]},"data":"four","id":4}
-{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"citext_58810479","loc":[11111111,11111111,11111111],"txid":111111}},"arr":{"dimensions":[2],"elements":["k","l"]},"data":"five","id":5}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"citext_58810479","loc":[11111111,11111111,11111111]}},"arr":["a","b"],"data":"zero","id":0}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"citext_58810479","loc":[11111111,11111111,11111111]}},"arr":["c","d"],"data":"one","id":1}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"citext_58810479","loc":[11111111,11111111,11111111]}},"arr":["e","f"],"data":"two","id":2}
+{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"citext_58810479","loc":[11111111,11111111,11111111],"txid":111111}},"arr":["g","h"],"data":"three","id":3}
+{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"citext_58810479","loc":[11111111,11111111,11111111],"txid":111111}},"arr":["i","j"],"data":"four","id":4}
+{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"citext_58810479","loc":[11111111,11111111,11111111],"txid":111111}},"arr":["k","l"],"data":"five","id":5}
 # ================================
 # Final State Checkpoint
 # ================================

--- a/source-postgres/.snapshots/TestCIText-Discovery
+++ b/source-postgres/.snapshots/TestCIText-Discovery
@@ -15,30 +15,15 @@ Binding 0:
           "$anchor": "TestCitext_58810479",
           "properties": {
             "arr": {
-              "required": [
-                "dimensions",
-                "elements"
-              ],
-              "description": "(source type: _citext)",
-              "properties": {
-                "dimensions": {
-                  "items": {
-                    "type": "integer"
-                  },
-                  "type": "array"
-                },
-                "elements": {
-                  "items": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "type": "array"
-                }
+              "items": {
+                "type": [
+                  "string",
+                  "null"
+                ]
               },
+              "description": "(source type: _citext)",
               "type": [
-                "object",
+                "array",
                 "null"
               ]
             },

--- a/source-postgres/discovery.go
+++ b/source-postgres/discovery.go
@@ -283,7 +283,7 @@ func (db *postgresDatabase) TranslateDBToJSONType(column sqlcapture.ColumnInfo, 
 		// New behavior: If the column is an array, turn the element type into a JSON array.
 		jsonType = &jsonschema.Schema{
 			Items:  colSchema.toType(),
-			Extras: map[string]any{"type": []string{"array"}},
+			Extras: map[string]any{"type": "array"},
 		}
 		if column.IsNullable {
 			// The column value itself may be null if the column is nullable.

--- a/source-postgres/main.go
+++ b/source-postgres/main.go
@@ -136,7 +136,7 @@ var featureFlagDefaults = map[string]bool{
 	// When true, array columns are captured as a flat array of values in the JSON output.
 	// When false, array columns are captured as a `{dimensions, elements}` object which
 	// preserves dimensionality (at the cost of being awful to use in most cases).
-	"flatten_arrays": false,
+	"flatten_arrays": true,
 }
 
 // Validate checks that the configuration possesses all required properties.


### PR DESCRIPTION
**Description:**

Another feature-flagged default change. This one will make new captures going forward discover array columns as just the JSON array of flattened element values.

As with other changes of this kind, this will only be merged after I have set the corresponding `no_<flag>` on all tasks in production to preserve current behavior.

This is part of https://github.com/estuary/connectors/issues/2460

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2475)
<!-- Reviewable:end -->
