### PR TITLE
Remove delete tables

### DIFF
--- a/materialize-cratedb/sqlgen.go
+++ b/materialize-cratedb/sqlgen.go
@@ -170,6 +170,11 @@ CREATE TABLE {{ template "temp_name" . }} (
 );
 {{ end }}
 
+-- Templated deletion of a temporary load table:
+{{ define "dropLoadTable" }}
+DROP TABLE IF EXISTS {{ template "temp_name" . }};
+{{ end }}
+
 -- Templated insertion into the temporary load table:
 
 {{ define "loadInsert" }}
@@ -296,6 +301,7 @@ UPDATE {{ Identifier $.TablePath }}
 	AND   fence     = {{ $.Fence }};
 {{ end }}
 `)
+	tplDropLoadTable     = tplAll.Lookup("dropLoadTable")
 	tplCreateLoadTable   = tplAll.Lookup("createLoadTable")
 	tplCreateTargetTable = tplAll.Lookup("createTargetTable")
 	tplAlterTableColumns = tplAll.Lookup("alterTableColumns")


### PR DESCRIPTION
**Description:**
* Make integration ~tests pass by tweaking a fixture value~ and modifying two cratedb types.
* Add remove temp tables

**Notes for reviewers:**
I'm not sure if this is the right place to delete tables, I tried to do at the end of `Load` but on the last load iteration it tries to insert a new value, and of course the temp table does not exist.

Next best thing I thought was to delete when the session was over, similarly to how postgres temp table works, I worked out that `Destroy` was the right place to do that, on top of that I'm also trying to delete the binding `before` adding a new Binding, just in case.

In the `Destroy` thingy, I'm just creating a blank `context.Background()` for `removeBinding`, does that affect in any way?, in https://github.com/estuary/connectors/commit/c50cb09a3ec6d3458ae2fe5a41eeda7f076847ee I tried to pass the context to the `transactor` to be able to re-utilize it later and the effect was the same in my tests

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2477)
<!-- Reviewable:end -->
