### PR TITLE
scripts/feature-flag-automation: Even more automated

### DIFF
--- a/scripts/feature-flag-automation.sh
+++ b/scripts/feature-flag-automation.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+set -e
+
+# Get the directory where this script is located
+SCRIPT_DIR="$(dirname "$0")"
+
+# Check for required args
+if [ "$#" -lt 2 ]; then
+  echo "Usage: $0 FLAG_NAME CONNECTOR [CONNECTOR...]"
+  echo "Example: $0 no_frob_xyzzy source-mysql source-postgres"
+  exit 1
+fi
+
+FLAG=$1
+shift
+CONNECTORS=("$@")
+WORKDIR="specs_${FLAG}_$(date +%Y%m%d_%H%M%S)"
+
+# Show plan and get user confirmation
+echo "Setting flag '$FLAG' on connectors: ${CONNECTORS[*]}"
+echo "Working directory: $WORKDIR"
+echo "Plan:"
+echo ""
+for CONNECTOR in "${CONNECTORS[@]}"; do
+  echo "    $SCRIPT_DIR/list-tasks.sh --connector=$CONNECTOR --pull --missing=$FLAG --dir=$WORKDIR"
+done
+echo "    $SCRIPT_DIR/bulk-config-editor.sh --set_flag=$FLAG --dir=$WORKDIR"
+echo "    $SCRIPT_DIR/bulk-publish.sh --mark --dir=$WORKDIR"
+echo
+
+read -p "Proceed? (y/N) " REPLY
+if [[ ! $REPLY == "y" && ! $REPLY == "Y" ]]; then
+  echo "Operation cancelled"
+  exit 1
+fi
+
+# Create working directory
+mkdir -p "$WORKDIR"
+
+# List and pull tasks for each connector name provided
+for CONNECTOR in "${CONNECTORS[@]}"; do
+  echo "Listing and pulling tasks missing $FLAG for $CONNECTOR..."
+  "$SCRIPT_DIR/list-tasks.sh" --connector="$CONNECTOR" --pull --missing="$FLAG" --dir="$WORKDIR"
+done
+
+echo "Adding feature flag setting $FLAG to all configs..."
+"$SCRIPT_DIR/bulk-config-editor.sh" --set_flag="$FLAG" --dir="$WORKDIR"
+
+echo "Publishing all modified tasks..."
+"$SCRIPT_DIR/bulk-publish.sh" --mark --dir="$WORKDIR"
+
+echo "All operations completed. Check for any tasks that failed to publish."
+echo "To retry failed tasks, run this command again with the same arguments."


### PR DESCRIPTION
**Description:**

This adds a new script which is a lightweight wrapper around the `list-tasks`, `bulk-config-editor`, and `bulk-publish` scripts to make it even easier to set a `no_foobar` flag on all tasks using a particular set of connectors. Example:

    $ ./feature-flag-automation.sh no_keyless_row_id source-postgres-batch source-mysql-batch source-redshift-batch source-bigquery-batch
    Setting flag 'no_keyless_row_id' on connectors: source-postgres-batch source-mysql-batch source-redshift-batch source-bigquery-batch
    Working directory: specs_no_keyless_row_id_20250304_114701
    Plan:

        ./list-tasks.sh --connector=source-postgres-batch --pull --missing=no_keyless_row_id --dir=specs_no_keyless_row_id_20250304_114701
        ./list-tasks.sh --connector=source-mysql-batch --pull --missing=no_keyless_row_id --dir=specs_no_keyless_row_id_20250304_114701
        ./list-tasks.sh --connector=source-redshift-batch --pull --missing=no_keyless_row_id --dir=specs_no_keyless_row_id_20250304_114701
        ./list-tasks.sh --connector=source-bigquery-batch --pull --missing=no_keyless_row_id --dir=specs_no_keyless_row_id_20250304_114701
        ./bulk-config-editor.sh --set_flag=no_keyless_row_id --dir=specs_no_keyless_row_id_20250304_114701
        ./bulk-publish.sh --mark --dir=specs_no_keyless_row_id_20250304_114701

    Proceed? (y/N)

This script is even more specialized for the specific case of the thing I've had to do like half a dozen times now, but it makes that operation very easy indeed and reduces the chance of messing things up due to a typo or copy-paste error in one command.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2479)
<!-- Reviewable:end -->
