### PR TITLE
source-google-analytics-data-api-native: validate dimensions and metrics for custom reports

### DIFF
--- a/source-google-analytics-data-api-native/source_google_analytics_data_api_native/__init__.py
+++ b/source-google-analytics-data-api-native/source_google_analytics_data_api_native/__init__.py
@@ -14,7 +14,7 @@ from estuary_cdk.capture import (
 )
 from estuary_cdk.http import HTTPMixin
 
-from .resources import all_resources, validate_credentials, validate_custom_reports_json
+from .resources import all_resources, validate_config, validate_custom_reports_json
 from .models import (
     ConnectorState,
     EndpointConfig,
@@ -42,7 +42,7 @@ class Connector(
     async def discover(
         self, log: Logger, discover: request.Discover[EndpointConfig]
     ) -> response.Discovered[ResourceConfig]:
-        validate_custom_reports_json(discover.config.custom_reports)
+        await validate_custom_reports_json(log, self, discover.config)
         resources = await all_resources(log, self, discover.config)
         return common.discovered(resources)
 
@@ -51,8 +51,7 @@ class Connector(
         log: Logger,
         validate: request.Validate[EndpointConfig, ResourceConfig],
     ) -> response.Validated:
-        await validate_credentials(log, self, validate.config)
-        validate_custom_reports_json(validate.config.custom_reports)
+        await validate_config(log, self, validate.config)
         resources = await all_resources(log, self, validate.config)
         resolved = common.resolve_bindings(validate.bindings, resources)
         return common.validated(resolved)

--- a/source-google-analytics-data-api-native/source_google_analytics_data_api_native/api.py
+++ b/source-google-analytics-data-api-native/source_google_analytics_data_api_native/api.py
@@ -14,6 +14,7 @@ from .models import (
     ReportDocument,
     Row,
     RunReportResponse,
+    MetadataResponse,
 )
 from .utils import (
     dt_to_date_str,
@@ -200,3 +201,20 @@ async def backfill_report(
 
     next_start = min(start + timedelta(days=1), cutoff)
     yield dt_to_str(next_start)
+
+
+async def fetch_metadata(
+    http: HTTPSession,
+    property_id: str,
+    log: Logger,
+) -> tuple[list[str], list[str]]:
+    url = f"{API}/{property_id}/metadata"
+
+    response = MetadataResponse.model_validate_json(
+        await http.request(log, url)
+    )
+
+    dimensions = [dimension.apiName for dimension in response.dimensions]
+    metrics = [metric.apiName for metric in response.metrics]
+
+    return (dimensions, metrics)

--- a/source-google-analytics-data-api-native/source_google_analytics_data_api_native/models.py
+++ b/source-google-analytics-data-api-native/source_google_analytics_data_api_native/models.py
@@ -156,3 +156,21 @@ class RunReportResponse(BaseModel, extra="allow"):
         timeZone: str
 
     metadata: Metadata
+
+
+class MetadataResponse(BaseModel, extra="allow"):
+    class BaseMetadata(BaseModel, extra="allow"):
+        apiName: str
+        uiName: str
+        description: str
+
+    class DimensionMetadata(BaseMetadata):
+        category: str
+
+    class MetricMetadata(DimensionMetadata):
+        type: str
+
+    dimensions: list[DimensionMetadata]
+    metrics: list[MetricMetadata]
+    name: str
+    comparisons: list[BaseMetadata]


### PR DESCRIPTION
**Description:**

Users have quickly run into errors when creating custom reports. We weren't validating the dimensions or metrics specified in custom reports, so the connector was failing after it was published if an invalid dimension/metric was specified. This PR adds validation of all dimensions and metrics specified in any custom reports. The Google API has a handy `/metadata` endpoint that returns all valid dimensions & metrics, so that list is used when validating the user's custom report input.

This validation does _not_ extend to any filters included in custom reports. We need to have a better model for the various types of valid filters before we even think about validating their contents, and developing that model would take a lot more time than I think it's worth investing right now.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

It's probably worthwhile to link Google's [docs](https://developers.google.com/analytics/devguides/reporting/data/v1/api-schema) on the various valid dimensions & metrics in the connector documentation, if only so RunLLM can answer questions about it a little better.

**Notes for reviewers:**

Tested on a local stack. Confirmed invalid dimensions/metrics in custom reports throw a `ValidationError` before publication & provide a clearer message of what caused the failure.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2480)
<!-- Reviewable:end -->