### PR TITLE
source-google-analytics-data-api-native: only require apiName in metadata

### DIFF
--- a/source-google-analytics-data-api-native/source_google_analytics_data_api_native/models.py
+++ b/source-google-analytics-data-api-native/source_google_analytics_data_api_native/models.py
@@ -161,16 +161,6 @@ class RunReportResponse(BaseModel, extra="allow"):
 class MetadataResponse(BaseModel, extra="allow"):
     class BaseMetadata(BaseModel, extra="allow"):
         apiName: str
-        uiName: str
-        description: str
 
-    class DimensionMetadata(BaseMetadata):
-        category: str
-
-    class MetricMetadata(DimensionMetadata):
-        type: str
-
-    dimensions: list[DimensionMetadata]
-    metrics: list[MetricMetadata]
-    name: str
-    comparisons: list[BaseMetadata]
+    dimensions: list[BaseMetadata]
+    metrics: list[BaseMetadata]


### PR DESCRIPTION
**Description:**

Turns out that sometimes those other fields in the `MetadataResponse` aren't present, and the connector is failing validation when they aren't present. This commit strips `MetadataResponse` to only include the fields we need.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2484)
<!-- Reviewable:end -->
