### PR TITLE
source-oracle: fix integer key encoding

### DIFF
--- a/source-oracle/.snapshots/TestIntegerKey-backfill
+++ b/source-oracle/.snapshots/TestIntegerKey-backfill
@@ -1,0 +1,9 @@
+# ================================
+# Collection "acmeCo/test/c__flow_test_logminer/t12319541": 1 Documents
+# ================================
+{"NUM18":999999999999999999,"_meta":{"op":"c","source":{"schema":"C##FLOW_TEST_LOGMINER","snapshot":true,"table":"T12319541","row_id":"AAAAAAAAAAAAAAAAAA","rs_id":"111111111111111111","ssn":111}}}
+# ================================
+# Final State Checkpoint
+# ================================
+{"bindingStateV1":{"C%23%23FLOW_TEST_LOGMINER%2FT12319541":{"backfilled":1,"key_columns":["NUM18"],"mode":"Active"}},"cursor":"11111111"}
+

--- a/source-oracle/.snapshots/TestIntegerKey-discover
+++ b/source-oracle/.snapshots/TestIntegerKey-discover
@@ -1,0 +1,135 @@
+Binding 0:
+{
+    "recommended_name": "c__flow_test_logminer/t12319541",
+    "resource_config_json": {
+      "namespace": "C##FLOW_TEST_LOGMINER",
+      "stream": "T12319541"
+    },
+    "document_schema_json": {
+      "$defs": {
+        "C##FLOW_TEST_LOGMINERT12319541": {
+          "type": "object",
+          "required": [
+            "NUM18"
+          ],
+          "$anchor": "C##FLOW_TEST_LOGMINERT12319541",
+          "properties": {
+            "NUM18": {
+              "type": "integer",
+              "description": "(source type: non-nullable NUMBER)"
+            }
+          }
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "_meta": {
+                "properties": {
+                  "op": {
+                    "const": "d"
+                  }
+                }
+              }
+            }
+          },
+          "then": {
+            "reduce": {
+              "delete": true,
+              "strategy": "merge"
+            }
+          },
+          "else": {
+            "reduce": {
+              "strategy": "merge"
+            }
+          },
+          "required": [
+            "_meta"
+          ],
+          "properties": {
+            "_meta": {
+              "type": "object",
+              "required": [
+                "op",
+                "source"
+              ],
+              "properties": {
+                "before": {
+                  "$ref": "#C##FLOW_TEST_LOGMINERT12319541",
+                  "description": "Record state immediately before this change was applied.",
+                  "reduce": {
+                    "strategy": "firstWriteWins"
+                  }
+                },
+                "op": {
+                  "enum": [
+                    "c",
+                    "d",
+                    "u"
+                  ],
+                  "description": "Change operation type: 'c' Create/Insert, 'u' Update, 'd' Delete."
+                },
+                "source": {
+                  "$id": "https://github.com/estuary/connectors/source-oracle/oracle-source",
+                  "properties": {
+                    "ts_ms": {
+                      "type": "integer",
+                      "description": "Unix timestamp (in millis) at which this event was recorded by the database."
+                    },
+                    "schema": {
+                      "type": "string",
+                      "description": "Database schema (namespace) of the event."
+                    },
+                    "snapshot": {
+                      "type": "boolean",
+                      "description": "Snapshot is true if the record was produced from an initial table backfill and unset if produced from the replication log."
+                    },
+                    "table": {
+                      "type": "string",
+                      "description": "Database table of the event."
+                    },
+                    "scn": {
+                      "type": "integer",
+                      "description": "SCN of this event"
+                    },
+                    "row_id": {
+                      "type": "string",
+                      "description": "ROWID of the document"
+                    },
+                    "rs_id": {
+                      "type": "string",
+                      "description": "Record Set ID of the logical change"
+                    },
+                    "ssn": {
+                      "type": "integer",
+                      "description": "SQL sequence number of the logical change"
+                    }
+                  },
+                  "type": "object",
+                  "required": [
+                    "schema",
+                    "table",
+                    "row_id",
+                    "rs_id",
+                    "ssn"
+                  ]
+                }
+              },
+              "reduce": {
+                "strategy": "merge"
+              }
+            }
+          }
+        },
+        {
+          "$ref": "#C##FLOW_TEST_LOGMINERT12319541"
+        }
+      ]
+    },
+    "key": [
+      "/NUM18"
+    ]
+  }
+

--- a/source-oracle/.snapshots/TestIntegerKey-replication
+++ b/source-oracle/.snapshots/TestIntegerKey-replication
@@ -1,0 +1,9 @@
+# ================================
+# Collection "acmeCo/test/c__flow_test_logminer/t12319541": 1 Documents
+# ================================
+{"NUM18":999999999999999998,"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"C##FLOW_TEST_LOGMINER","table":"T12319541","scn":11111111,"row_id":"AAAAAAAAAAAAAAAAAA","rs_id":"111111111111111111","ssn":111}}}
+# ================================
+# Final State Checkpoint
+# ================================
+{"bindingStateV1":{"C%23%23FLOW_TEST_LOGMINER%2FT12319541":{"backfilled":1,"key_columns":["NUM18"],"mode":"Active"}},"cursor":"11111111"}
+


### PR DESCRIPTION
**Description:**

- A customer hit an issue when using integer columns with precision < 18 as primary keys, this is a case that we had not covered with our tests, so I added tests, reproduced the issue and here is the implemented fix. Left comments to explain the various changes.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2494)
<!-- Reviewable:end -->
