### PR TITLE
filesink: log the resource path when failing to encode a row

### DIFF
--- a/filesink/filesink.go
+++ b/filesink/filesink.go
@@ -301,7 +301,7 @@ func (t *transactor) Store(it *m.StoreIterator) (m.StartCommitFunc, error) {
 		}
 
 		if err := encoder.Encode(row); err != nil {
-			return nil, fmt.Errorf("encoding row: %w", err)
+			return nil, fmt.Errorf("encoding row for resource %q: %w", b.path, err)
 		}
 
 		if t.common.FileSizeLimit != 0 && encoder.Written() >= t.common.FileSizeLimit {


### PR DESCRIPTION
**Description:**

Adds some additional logging to assist with troubleshooting.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2495)
<!-- Reviewable:end -->
