### PR TITLE
materialie-databricks: let databricks driver logs through on debug

### DIFF
--- a/materialize-databricks/driver.go
+++ b/materialize-databricks/driver.go
@@ -531,9 +531,12 @@ func (d *transactor) Destroy() {
 }
 
 func main() {
-	logger.DefaultLogger = &NoOpLogger{}
-	if err := dbsqllog.SetLogLevel("disabled"); err != nil {
-		panic(err)
+	// Disable databricks driver logging on INFO level, it can be quite noisy and confusing
+	if log.GetLevel() != log.DebugLevel {
+		logger.DefaultLogger = &NoOpLogger{}
+		if err := dbsqllog.SetLogLevel("disabled"); err != nil {
+			panic(err)
+		}
 	}
 
 	boilerplate.RunMain(newDatabricksDriver())


### PR DESCRIPTION
**Description:**

- I realised we were suppressing logs from databricks sql driver, I'm changing this to only suppress those logs in INFO level. Initially I had seen it log a lot in INFO mode and be confusing for customers, but on debug this could have helped us uncover the databricks bug earlier

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2498)
<!-- Reviewable:end -->
