### PR TITLE
materialize-iceberg: serialize pyspark command inputs to a file

### DIFF
--- a/materialize-iceberg/python/load.py
+++ b/materialize-iceberg/python/load.py
@@ -1,5 +1,3 @@
-import json
-
 from common import (
     NestedField,
     common_args,
@@ -11,14 +9,12 @@ from common import (
 args = common_args()
 spark = get_spark_session(args)
 
-input = json.loads(args.input)
-query = input["query"]
-bindings = input["bindings"]
-output_location = input["output_location"]
-status_output = args.status_output
 
+def run(input):
+    query = input["query"]
+    bindings = input["bindings"]
+    output_location = input["output_location"]
 
-def run():
     for binding in bindings:
         bindingIdx: int = binding["binding"]
         keys: list[NestedField] = [NestedField(**key) for key in binding["keys"]]

--- a/materialize-iceberg/python/merge.py
+++ b/materialize-iceberg/python/merge.py
@@ -11,12 +11,9 @@ from common import (
 args = common_args()
 spark = get_spark_session(args)
 
-input = json.loads(args.input)
-bindings = input["bindings"]
 
-
-def run():
-    for binding in bindings:
+def run(input):
+    for binding in input["bindings"]:
         bindingIdx: int = binding["binding"]
         query: str = binding["query"]
         columns: list[NestedField] = [NestedField(**col) for col in binding["columns"]]

--- a/materialize-iceberg/python/python.go
+++ b/materialize-iceberg/python/python.go
@@ -26,8 +26,7 @@ type MergeBinding struct {
 }
 
 type MergeInput struct {
-	Bindings       []MergeBinding `json:"bindings"`
-	OutputLocation string         `json:"output_location"`
+	Bindings []MergeBinding `json:"bindings"`
 }
 
 type StatusOutput struct {


### PR DESCRIPTION
**Description:**

The maximum argument length for an EMR job is actually quite limited, around 10k characters, so if the command input for a job gets very long it will fail. This will happen if any number of significant bindings is associated with a transaction or even a single binding with a large number of fields, since all of the fields and their types need to be provided to the script in a serialized form, in addition to the query to execute.

The fix here is to write out the input to a temporary cloud storage file and read that in the PySpark script. Rather than providing the input as an argument, the input is now a URI to the input file.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2499)
<!-- Reviewable:end -->
