### PR TITLE
source-oracle: use `online` as default dictionary mode

### DIFF
--- a/source-oracle/main.go
+++ b/source-oracle/main.go
@@ -123,7 +123,7 @@ type advancedConfig struct {
 	IncrementalSCNRange  int      `json:"incremental_scn_range,omitempty" jsonschema:"title=Incremental SCN Range,default=50000,description=The SCN range captured at every iteration."`
 	DiscoverSchemas      []string `json:"discover_schemas,omitempty" jsonschema:"title=Discovery Schema Selection,description=If this is specified only tables in the selected schema(s) will be automatically discovered. Omit all entries to discover tables from all schemas."`
 	NodeID               uint32   `json:"node_id,omitempty" jsonschema:"title=Node ID,description=Node ID for the capture. Each node in a replication cluster must have a unique 32-bit ID. The specific value doesn't matter so long as it is unique. If unset or zero the connector will pick a value."`
-	DictionaryMode       string   `json:"dictionary_mode,omitempty" jsonschema:"title=Dictionary Mode,description=How should dictionaries be used in Logminer: one of online or extract. When using online mode schema changes to the table may break the capture but resource usage is limited. When using extract mode schema changes are handled gracefully but more resources of your database (including disk) are used by the process. Defaults to extract.,enum=extract,enum=online"`
+	DictionaryMode       string   `json:"dictionary_mode,omitempty" jsonschema:"title=Dictionary Mode,description=How should dictionaries be used in Logminer: one of online or extract. When using online mode schema changes to the table may break the capture but resource usage is limited. When using extract mode schema changes are handled gracefully but more resources of your database (including disk) are used by the process. Defaults to online.,enum=extract,enum=online"`
 }
 
 // Validate checks that the configuration possesses all required properties.
@@ -188,7 +188,7 @@ func (c *Config) SetDefaults(name string) {
 	}
 
 	if c.Advanced.DictionaryMode == "" {
-		c.Advanced.DictionaryMode = DictionaryModeExtract
+		c.Advanced.DictionaryMode = DictionaryModeOnline
 	}
 }
 


### PR DESCRIPTION

**Description:**

extract mode is better for long-term consistency since it supports schema changes, but it is really slow. online mode is much faster and it gives users a better first experience. If they hit an issue with schema changes, they can switch to extract mode, and theoretically they can switch back to online mode after the schema changes are captured.


**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

