### PR TITLE
source-stripe-native: Handle empty connected account list in resource methods

### DIFF
--- a/source-stripe-native/config.yaml
+++ b/source-stripe-native/config.yaml
@@ -1,18 +1,18 @@
 credentials:
-    access_token_sops: ENC[AES256_GCM,data:7iG2cZ/7379LcC/C+hKbpmfPtIZpINAvI+Kl2EmrJQS4GHygNTQmvh9k3xqgZcnPihVJmfXUcAAN9xpzKLhhtx6WX335pzgI2lIveKLxa+qaAcBauFoqnZhhiAV7MsnrxDqp69SqtdA5QbU=,iv:2ESJfwINDwLkqnAsQ1n/3ZZI9YUSO3zVO9xAE3X+Wuw=,tag:p1NZ4ejRfxAb1+3RXQmYkg==,type:str]
+    access_token_sops: ENC[AES256_GCM,data:JLPRanyakzcBb8AMFIs0I+g5D1w7obPxQXoCi6wSV5Ot66sX2phfn1pCE34LcmTxlokAS7CSDUdAyAsw36Eltb6iZGfkHBDtJ2S3BGGz2HEen8SgnkapNkfjOJfjkvOSEFzcH/af7w1OIJQ=,iv:Qt59fJGiz9JoHltxkA7EPqWHChjB+ppXMa3izz7UqBk=,tag:mYZWNrsOQJWH7Rc+rR+u2Q==,type:str]
 start_date: "2010-01-01T00:00:00+00:00"
-capture_connected_accounts: false
+capture_connected_accounts: true
 sops:
     kms: []
     gcp_kms:
         - resource_id: projects/estuary-theatre/locations/us-central1/keyRings/connector-keyring/cryptoKeys/connector-repository
-          created_at: "2025-03-04T15:38:33Z"
-          enc: CiQAdmEdwpifyiYXJmh1JpbtmbNtZcif3KHKcxPPsWtvwCNEp5sSSQCtUdBGHOd6Ai+9YMjMeIq9TzWF7v8RqkljcGFqHvOluAIUU4MqSa57wuUbTYTREgKxUynYRlpbOdBYpIFF+BZf4peGKj/NlsQ=
+          created_at: "2025-03-07T21:20:45Z"
+          enc: CiQAdmEdwqj7wNLmtF7bRmbZp/HTg7GH0fyXZ/0sd+HAJylZ5Q8SSQCtUdBGNtHMe91hNh4GvgqEh8NOsOj3n8uAPVtnLmgyuetL9N7hBnXzXae6bkOaZj/OehhQjTPRJrfAjJBe/FBoTPLHxMO9gbw=
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2025-03-04T15:38:34Z"
-    mac: ENC[AES256_GCM,data:hFGI3Y4t8bvBqoTWx2Qa8/UQ4AH46JZ/dwUXsRRS1D3Bh7uS7javuXLf3bSRIynXV6Y+u79ZJsbH26L8Ifr5fwUBWXhn7eI94s0N0rn1F1TUklQKpHQAN3p7x9b8hn8XvFjEDBBQPXQQQFT0Hltn+g2kKhE1e+nFUvI98DV/9Bk=,iv:KA6kD6QP71Giz/uxZ1ceHuPOwImBWY3KHyGDqGrmV1U=,tag:licITgXgJHodNH+MVLuY/Q==,type:str]
+    lastmodified: "2025-03-07T21:20:45Z"
+    mac: ENC[AES256_GCM,data:I3mhDLPF07sAGViAGYXSZMx//Pp3pJOoFARqrEagfoR+96evSb845q818SxqEJeUVkPF0Weue6f9FwSyuAUHpu9+LPYAZrVixHr/HeFEFLfvCe/yFf0fTXO7GhsKdGiucqzrd6nRc6/byVyka75H86MzCsdrOW5zVyfwXPr0jUM=,iv:HguMQ+BM+H2AIpdUMlWW9oDWRL4zzB+JZYTLC7xQblU=,tag:B1AV7zVrP5hQ7kMrUe6m7w==,type:str]
     pgp: []
     encrypted_suffix: _sops
     version: 3.9.4

--- a/source-stripe-native/source_stripe_native/resources.py
+++ b/source-stripe-native/source_stripe_native/resources.py
@@ -235,19 +235,47 @@ def base_object(
         task: Task,
         all_bindings,
     ):
-        fetch_changes_fns = {
-            account_id: functools.partial(
-                fetch_incremental, cls, platform_account_id, account_id, http
+        if not connected_account_ids or len(connected_account_ids) == 0:
+            fetch_changes_fns = functools.partial(
+                fetch_incremental,
+                cls,
+                platform_account_id,
+                None,
+                http,
             )
-            for account_id in all_account_ids
-        }
+        else:
+            fetch_changes_fns = {
+                account_id: functools.partial(
+                    fetch_incremental,
+                    cls,
+                    platform_account_id,
+                    account_id,
+                    http,
+                )
+                for account_id in all_account_ids
+            }
 
-        fetch_page_fns = {
-            account_id: functools.partial(
-                fetch_backfill, cls, start_date, platform_account_id, account_id, http
+        if not connected_account_ids or len(connected_account_ids) == 0:
+            fetch_page_fns = functools.partial(
+                fetch_backfill,
+                cls,
+                start_date,
+                platform_account_id,
+                None,
+                http,
             )
-            for account_id in all_account_ids
-        }
+        else:
+            fetch_page_fns = {
+                account_id: functools.partial(
+                    fetch_backfill,
+                    cls,
+                    start_date,
+                    platform_account_id,
+                    account_id,
+                    http,
+                )
+                for account_id in all_account_ids
+            }
 
         open_binding(
             binding,
@@ -293,30 +321,51 @@ def child_object(
         task: Task,
         all_bindings,
     ):
-        fetch_changes_fns = {
-            account_id: functools.partial(
+        if not connected_account_ids or len(connected_account_ids) == 0:
+            fetch_changes_fns = functools.partial(
                 fetch_incremental_substreams,
                 cls,
                 child_cls,
                 platform_account_id,
-                account_id,
+                None,
                 http,
             )
-            for account_id in all_account_ids
-        }
+        else:
+            fetch_changes_fns = {
+                account_id: functools.partial(
+                    fetch_incremental_substreams,
+                    cls,
+                    child_cls,
+                    platform_account_id,
+                    account_id,
+                    http,
+                )
+                for account_id in all_account_ids
+            }
 
-        fetch_page_fns = {
-            account_id: functools.partial(
+        if not connected_account_ids or len(connected_account_ids) == 0:
+            fetch_page_fns = functools.partial(
                 fetch_backfill_substreams,
                 cls,
                 child_cls,
                 start_date,
                 platform_account_id,
-                account_id,
+                None,
                 http,
             )
-            for account_id in all_account_ids
-        }
+        else:
+            fetch_page_fns = {
+                account_id: functools.partial(
+                    fetch_backfill_substreams,
+                    cls,
+                    child_cls,
+                    start_date,
+                    platform_account_id,
+                    account_id,
+                    http,
+                )
+                for account_id in all_account_ids
+            }
 
         open_binding(
             binding,
@@ -365,25 +414,49 @@ def split_child_object(
         task: Task,
         all_bindings,
     ):
-        fetch_changes_fns = {
-            account_id: functools.partial(
-                fetch_incremental, child_cls, platform_account_id, account_id, http
+        if not connected_account_ids or len(connected_account_ids) == 0:
+            fetch_changes_fns = functools.partial(
+                fetch_incremental,
+                child_cls,
+                platform_account_id,
+                None,
+                http,
             )
-            for account_id in all_account_ids
-        }
+        else:
+            fetch_changes_fns = {
+                account_id: functools.partial(
+                    fetch_incremental,
+                    child_cls,
+                    platform_account_id,
+                    account_id,
+                    http,
+                )
+                for account_id in all_account_ids
+            }
 
-        fetch_page_fns = {
-            account_id: functools.partial(
+        if not connected_account_ids or len(connected_account_ids) == 0:
+            fetch_page_fns = functools.partial(
                 fetch_backfill_substreams,
                 cls,
                 child_cls,
                 start_date,
                 platform_account_id,
-                account_id,
+                None,
                 http,
             )
-            for account_id in all_account_ids
-        }
+        else:
+            fetch_page_fns = {
+                account_id: functools.partial(
+                    fetch_backfill_substreams,
+                    cls,
+                    child_cls,
+                    start_date,
+                    platform_account_id,
+                    account_id,
+                    http,
+                )
+                for account_id in all_account_ids
+            }
 
         open_binding(
             binding,
@@ -431,30 +504,51 @@ def usage_records(
         task: Task,
         all_bindings,
     ):
-        fetch_changes_fns = {
-            account_id: functools.partial(
+        if not connected_account_ids or len(connected_account_ids) == 0:
+            fetch_changes_fns = functools.partial(
                 fetch_incremental_usage_records,
                 cls,
                 child_cls,
                 platform_account_id,
-                account_id,
+                None,
                 http,
             )
-            for account_id in all_account_ids
-        }
+        else:
+            fetch_changes_fns = {
+                account_id: functools.partial(
+                    fetch_incremental_usage_records,
+                    cls,
+                    child_cls,
+                    platform_account_id,
+                    account_id,
+                    http,
+                )
+                for account_id in all_account_ids
+            }
 
-        fetch_page_fns = {
-            account_id: functools.partial(
+        if not connected_account_ids or len(connected_account_ids) == 0:
+            fetch_page_fns = functools.partial(
                 fetch_backfill_usage_records,
                 cls,
                 child_cls,
                 start_date,
                 platform_account_id,
-                account_id,
+                None,
                 http,
             )
-            for account_id in all_account_ids
-        }
+        else:
+            fetch_page_fns = {
+                account_id: functools.partial(
+                    fetch_backfill_usage_records,
+                    cls,
+                    child_cls,
+                    start_date,
+                    platform_account_id,
+                    account_id,
+                    http,
+                )
+                for account_id in all_account_ids
+            }
 
         open_binding(
             binding,
@@ -502,19 +596,47 @@ def no_events_object(
         task: Task,
         all_bindings,
     ):
-        fetch_changes_fns = {
-            account_id: functools.partial(
-                fetch_incremental_no_events, cls, platform_account_id, account_id, http
+        if not connected_account_ids or len(connected_account_ids) == 0:
+            fetch_changes_fns = functools.partial(
+                fetch_incremental_no_events,
+                cls,
+                platform_account_id,
+                None,
+                http,
             )
-            for account_id in all_account_ids
-        }
+        else:
+            fetch_changes_fns = {
+                account_id: functools.partial(
+                    fetch_incremental_no_events,
+                    cls,
+                    platform_account_id,
+                    account_id,
+                    http,
+                )
+                for account_id in all_account_ids
+            }
 
-        fetch_page_fns = {
-            account_id: functools.partial(
-                fetch_backfill, cls, start_date, platform_account_id, account_id, http
+        if not connected_account_ids or len(connected_account_ids) == 0:
+            fetch_page_fns = functools.partial(
+                fetch_backfill,
+                cls,
+                start_date,
+                platform_account_id,
+                None,
+                http,
             )
-            for account_id in all_account_ids
-        }
+        else:
+            fetch_page_fns = {
+                account_id: functools.partial(
+                    fetch_backfill,
+                    cls,
+                    start_date,
+                    platform_account_id,
+                    account_id,
+                    http,
+                )
+                for account_id in all_account_ids
+            }
 
         open_binding(
             binding,

--- a/source-stripe-native/tests/snapshots/snapshots__capture__stdout.json
+++ b/source-stripe-native/tests/snapshots/snapshots__capture__stdout.json
@@ -176,6 +176,573 @@
       "business_profile": {
         "annual_revenue": null,
         "estimated_worker_count": null,
+        "mcc": "5734",
+        "name": "Teste",
+        "support_address": null,
+        "support_email": null,
+        "support_phone": null,
+        "support_url": null,
+        "url": "www.pudim.com.br"
+      },
+      "capabilities": {
+        "card_payments": "active",
+        "transfers": "active"
+      },
+      "charges_enabled": true,
+      "controller": {
+        "fees": {
+          "payer": "application_express"
+        },
+        "is_controller": true,
+        "losses": {
+          "payments": "application"
+        },
+        "requirement_collection": "stripe",
+        "stripe_dashboard": {
+          "type": "express"
+        },
+        "type": "application"
+      },
+      "country": "BR",
+      "created": 1715111618,
+      "default_currency": "brl",
+      "details_submitted": true,
+      "email": null,
+      "external_accounts": {
+        "data": [
+          {
+            "account": "acct_1PDu50Q1qnzwasyf",
+            "account_holder_name": null,
+            "account_holder_type": null,
+            "account_type": null,
+            "available_payout_methods": [
+              "standard"
+            ],
+            "bank_name": "STRIPE TEST BANK",
+            "country": "BR",
+            "currency": "brl",
+            "default_for_currency": true,
+            "fingerprint": "FfkcPo9saEcVWPmL",
+            "future_requirements": {
+              "currently_due": [],
+              "errors": [],
+              "past_due": [],
+              "pending_verification": []
+            },
+            "id": "ba_1PEBQcQ1qnzwasyfS0uS5zM0",
+            "last4": "1234",
+            "metadata": {},
+            "object": "bank_account",
+            "requirements": {
+              "currently_due": [],
+              "errors": [],
+              "past_due": [],
+              "pending_verification": []
+            },
+            "routing_number": "110-0000",
+            "status": "new"
+          }
+        ],
+        "has_more": false,
+        "object": "list",
+        "total_count": 1,
+        "url": "/v1/accounts/acct_1PDu50Q1qnzwasyf/external_accounts"
+      },
+      "future_requirements": {
+        "alternatives": [],
+        "current_deadline": null,
+        "currently_due": [],
+        "disabled_reason": null,
+        "errors": [],
+        "eventually_due": [],
+        "past_due": [],
+        "pending_verification": []
+      },
+      "id": "acct_1PDu50Q1qnzwasyf",
+      "login_links": {
+        "data": [],
+        "has_more": false,
+        "object": "list",
+        "total_count": 0,
+        "url": "/v1/accounts/acct_1PDu50Q1qnzwasyf/login_links"
+      },
+      "metadata": {},
+      "object": "account",
+      "payouts_enabled": true,
+      "requirements": {
+        "alternatives": [],
+        "current_deadline": null,
+        "currently_due": [],
+        "disabled_reason": null,
+        "errors": [],
+        "eventually_due": [],
+        "past_due": [],
+        "pending_verification": []
+      },
+      "settings": {
+        "bacs_debit_payments": {
+          "display_name": null,
+          "service_user_number": null
+        },
+        "branding": {
+          "icon": null,
+          "logo": null,
+          "primary_color": null,
+          "secondary_color": null
+        },
+        "card_issuing": {
+          "tos_acceptance": {
+            "date": null,
+            "ip": null
+          }
+        },
+        "card_payments": {
+          "decline_on": {
+            "avs_failure": false,
+            "cvc_failure": false
+          },
+          "statement_descriptor_prefix": null,
+          "statement_descriptor_prefix_kana": null,
+          "statement_descriptor_prefix_kanji": null
+        },
+        "dashboard": {
+          "display_name": "pudim.com.br",
+          "timezone": "Etc/UTC"
+        },
+        "invoices": {
+          "default_account_tax_ids": null
+        },
+        "payments": {
+          "statement_descriptor": "WWW.PUDIM.COM.BR",
+          "statement_descriptor_kana": null,
+          "statement_descriptor_kanji": null
+        },
+        "payouts": {
+          "debit_negative_balances": true,
+          "schedule": {
+            "delay_days": 30,
+            "interval": "daily"
+          },
+          "statement_descriptor": null
+        },
+        "sepa_debit_payments": {}
+      },
+      "tos_acceptance": {
+        "date": 1715112768
+      },
+      "type": "express"
+    }
+  ],
+  [
+    "acmeCo/Accounts",
+    {
+      "_meta": {
+        "uuid": "DocUUIDPlaceholder-329Bb50aa48EAa9ef"
+      },
+      "account_id": "acct_1O4Om6LzZ0uyKPmd",
+      "business_profile": {
+        "annual_revenue": null,
+        "estimated_worker_count": null,
+        "mcc": null,
+        "name": null,
+        "product_description": null,
+        "support_address": null,
+        "support_email": null,
+        "support_phone": null,
+        "support_url": null,
+        "url": null
+      },
+      "business_type": "company",
+      "capabilities": {
+        "card_payments": "inactive",
+        "transfers": "inactive"
+      },
+      "charges_enabled": false,
+      "company": {
+        "address": {
+          "city": null,
+          "country": "BR",
+          "line1": null,
+          "line2": null,
+          "postal_code": null,
+          "state": null
+        },
+        "directors_provided": false,
+        "executives_provided": false,
+        "name": null,
+        "owners_provided": false,
+        "tax_id_provided": false,
+        "verification": {
+          "document": {
+            "back": null,
+            "details": null,
+            "details_code": null,
+            "front": null
+          }
+        }
+      },
+      "controller": {
+        "fees": {
+          "payer": "application_custom"
+        },
+        "is_controller": true,
+        "losses": {
+          "payments": "application"
+        },
+        "requirement_collection": "application",
+        "stripe_dashboard": {
+          "type": "none"
+        },
+        "type": "application"
+      },
+      "country": "BR",
+      "created": 1715113936,
+      "default_currency": "brl",
+      "details_submitted": false,
+      "email": null,
+      "external_accounts": {
+        "data": [
+          {
+            "account": "acct_1PDugNPwuHD69DFD",
+            "account_holder_name": "Jenny Rosen",
+            "account_holder_type": "individual",
+            "account_type": null,
+            "available_payout_methods": [
+              "standard"
+            ],
+            "bank_name": "STRIPE TEST BANK",
+            "country": "BR",
+            "currency": "brl",
+            "default_for_currency": true,
+            "fingerprint": "FfkcPo9saEcVWPmL",
+            "future_requirements": {
+              "currently_due": [],
+              "errors": [],
+              "past_due": [],
+              "pending_verification": []
+            },
+            "id": "ba_1PEBMiPwuHD69DFDrbKh6UkV",
+            "last4": "1234",
+            "metadata": {},
+            "object": "bank_account",
+            "requirements": {
+              "currently_due": [],
+              "errors": [],
+              "past_due": [],
+              "pending_verification": []
+            },
+            "routing_number": "110-0000",
+            "status": "new"
+          }
+        ],
+        "has_more": false,
+        "object": "list",
+        "total_count": 1,
+        "url": "/v1/accounts/acct_1PDugNPwuHD69DFD/external_accounts"
+      },
+      "future_requirements": {
+        "alternatives": [],
+        "current_deadline": null,
+        "currently_due": [],
+        "disabled_reason": null,
+        "errors": [],
+        "eventually_due": [],
+        "past_due": [],
+        "pending_verification": []
+      },
+      "id": "acct_1PDugNPwuHD69DFD",
+      "metadata": {},
+      "object": "account",
+      "payouts_enabled": false,
+      "requirements": {
+        "alternatives": [],
+        "current_deadline": null,
+        "currently_due": [
+          "business_profile.mcc",
+          "business_profile.product_description",
+          "company.address.city",
+          "company.address.line1",
+          "company.address.postal_code",
+          "company.address.state",
+          "company.directors_provided",
+          "company.executives_provided",
+          "company.name",
+          "company.owners_provided",
+          "company.phone",
+          "company.tax_id",
+          "company.verification.document",
+          "directors.address.city",
+          "directors.address.line1",
+          "directors.address.postal_code",
+          "directors.address.state",
+          "directors.dob.day",
+          "directors.dob.month",
+          "directors.dob.year",
+          "directors.email",
+          "directors.first_name",
+          "directors.id_number",
+          "directors.last_name",
+          "directors.political_exposure",
+          "directors.relationship.title",
+          "directors.verification.document",
+          "executives.address.city",
+          "executives.address.line1",
+          "executives.address.postal_code",
+          "executives.address.state",
+          "executives.dob.day",
+          "executives.dob.month",
+          "executives.dob.year",
+          "executives.email",
+          "executives.first_name",
+          "executives.id_number",
+          "executives.last_name",
+          "executives.political_exposure",
+          "executives.relationship.title",
+          "executives.verification.document",
+          "owners.address.city",
+          "owners.address.line1",
+          "owners.address.postal_code",
+          "owners.address.state",
+          "owners.dob.day",
+          "owners.dob.month",
+          "owners.dob.year",
+          "owners.first_name",
+          "owners.id_number",
+          "owners.last_name",
+          "owners.political_exposure",
+          "owners.relationship.percent_ownership",
+          "owners.verification.document",
+          "representative.address.city",
+          "representative.address.line1",
+          "representative.address.postal_code",
+          "representative.address.state",
+          "representative.dob.day",
+          "representative.dob.month",
+          "representative.dob.year",
+          "representative.email",
+          "representative.first_name",
+          "representative.id_number",
+          "representative.last_name",
+          "representative.phone",
+          "representative.political_exposure",
+          "representative.relationship.executive",
+          "representative.relationship.title",
+          "representative.verification.document"
+        ],
+        "disabled_reason": "requirements.past_due",
+        "errors": [],
+        "eventually_due": [
+          "business_profile.mcc",
+          "business_profile.product_description",
+          "company.address.city",
+          "company.address.line1",
+          "company.address.postal_code",
+          "company.address.state",
+          "company.directors_provided",
+          "company.executives_provided",
+          "company.name",
+          "company.owners_provided",
+          "company.phone",
+          "company.tax_id",
+          "company.verification.document",
+          "directors.address.city",
+          "directors.address.line1",
+          "directors.address.postal_code",
+          "directors.address.state",
+          "directors.dob.day",
+          "directors.dob.month",
+          "directors.dob.year",
+          "directors.email",
+          "directors.first_name",
+          "directors.id_number",
+          "directors.last_name",
+          "directors.political_exposure",
+          "directors.relationship.title",
+          "directors.verification.document",
+          "executives.address.city",
+          "executives.address.line1",
+          "executives.address.postal_code",
+          "executives.address.state",
+          "executives.dob.day",
+          "executives.dob.month",
+          "executives.dob.year",
+          "executives.email",
+          "executives.first_name",
+          "executives.id_number",
+          "executives.last_name",
+          "executives.political_exposure",
+          "executives.relationship.title",
+          "executives.verification.document",
+          "owners.address.city",
+          "owners.address.line1",
+          "owners.address.postal_code",
+          "owners.address.state",
+          "owners.dob.day",
+          "owners.dob.month",
+          "owners.dob.year",
+          "owners.first_name",
+          "owners.id_number",
+          "owners.last_name",
+          "owners.political_exposure",
+          "owners.relationship.percent_ownership",
+          "owners.verification.document",
+          "representative.address.city",
+          "representative.address.line1",
+          "representative.address.postal_code",
+          "representative.address.state",
+          "representative.dob.day",
+          "representative.dob.month",
+          "representative.dob.year",
+          "representative.email",
+          "representative.first_name",
+          "representative.id_number",
+          "representative.last_name",
+          "representative.phone",
+          "representative.political_exposure",
+          "representative.relationship.executive",
+          "representative.relationship.title",
+          "representative.verification.document"
+        ],
+        "past_due": [
+          "business_profile.mcc",
+          "business_profile.product_description",
+          "company.address.city",
+          "company.address.line1",
+          "company.address.postal_code",
+          "company.address.state",
+          "company.directors_provided",
+          "company.executives_provided",
+          "company.name",
+          "company.owners_provided",
+          "company.phone",
+          "company.tax_id",
+          "company.verification.document",
+          "directors.address.city",
+          "directors.address.line1",
+          "directors.address.postal_code",
+          "directors.address.state",
+          "directors.dob.day",
+          "directors.dob.month",
+          "directors.dob.year",
+          "directors.email",
+          "directors.first_name",
+          "directors.id_number",
+          "directors.last_name",
+          "directors.political_exposure",
+          "directors.relationship.title",
+          "directors.verification.document",
+          "executives.address.city",
+          "executives.address.line1",
+          "executives.address.postal_code",
+          "executives.address.state",
+          "executives.dob.day",
+          "executives.dob.month",
+          "executives.dob.year",
+          "executives.email",
+          "executives.first_name",
+          "executives.id_number",
+          "executives.last_name",
+          "executives.political_exposure",
+          "executives.relationship.title",
+          "executives.verification.document",
+          "owners.address.city",
+          "owners.address.line1",
+          "owners.address.postal_code",
+          "owners.address.state",
+          "owners.dob.day",
+          "owners.dob.month",
+          "owners.dob.year",
+          "owners.first_name",
+          "owners.id_number",
+          "owners.last_name",
+          "owners.political_exposure",
+          "owners.relationship.percent_ownership",
+          "owners.verification.document",
+          "representative.address.city",
+          "representative.address.line1",
+          "representative.address.postal_code",
+          "representative.address.state",
+          "representative.dob.day",
+          "representative.dob.month",
+          "representative.dob.year",
+          "representative.email",
+          "representative.first_name",
+          "representative.id_number",
+          "representative.last_name",
+          "representative.phone",
+          "representative.political_exposure",
+          "representative.relationship.executive",
+          "representative.relationship.title",
+          "representative.verification.document"
+        ],
+        "pending_verification": []
+      },
+      "settings": {
+        "bacs_debit_payments": {
+          "display_name": null,
+          "service_user_number": null
+        },
+        "branding": {
+          "icon": null,
+          "logo": null,
+          "primary_color": null,
+          "secondary_color": null
+        },
+        "card_issuing": {
+          "tos_acceptance": {
+            "date": null,
+            "ip": null
+          }
+        },
+        "card_payments": {
+          "decline_on": {
+            "avs_failure": false,
+            "cvc_failure": false
+          },
+          "statement_descriptor_prefix": null,
+          "statement_descriptor_prefix_kana": null,
+          "statement_descriptor_prefix_kanji": null
+        },
+        "dashboard": {
+          "display_name": null,
+          "timezone": "Etc/UTC"
+        },
+        "invoices": {
+          "default_account_tax_ids": null
+        },
+        "payments": {
+          "statement_descriptor": null,
+          "statement_descriptor_kana": null,
+          "statement_descriptor_kanji": null
+        },
+        "payouts": {
+          "debit_negative_balances": false,
+          "schedule": {
+            "delay_days": 30,
+            "interval": "daily"
+          },
+          "statement_descriptor": null
+        },
+        "sepa_debit_payments": {}
+      },
+      "tos_acceptance": {
+        "date": 1715113935,
+        "ip": "127.0.0.1",
+        "user_agent": null
+      },
+      "type": "custom"
+    }
+  ],
+  [
+    "acmeCo/Accounts",
+    {
+      "_meta": {
+        "uuid": "DocUUIDPlaceholder-329Bb50aa48EAa9ef"
+      },
+      "account_id": "acct_1O4Om6LzZ0uyKPmd",
+      "business_profile": {
+        "annual_revenue": null,
+        "estimated_worker_count": null,
         "mcc": null,
         "name": null,
         "product_description": null,
@@ -705,6 +1272,144 @@
     }
   ],
   [
+    "acmeCo/Accounts",
+    {
+      "_meta": {
+        "uuid": "DocUUIDPlaceholder-329Bb50aa48EAa9ef"
+      },
+      "account_id": "acct_1O4Om6LzZ0uyKPmd",
+      "business_profile": {
+        "annual_revenue": null,
+        "estimated_worker_count": null,
+        "mcc": null,
+        "name": null,
+        "support_address": null,
+        "support_email": null,
+        "support_phone": null,
+        "support_url": null,
+        "url": null
+      },
+      "capabilities": {},
+      "charges_enabled": false,
+      "controller": {
+        "fees": {
+          "payer": "account"
+        },
+        "is_controller": true,
+        "losses": {
+          "payments": "stripe"
+        },
+        "requirement_collection": "stripe",
+        "stripe_dashboard": {
+          "type": "full"
+        },
+        "type": "application"
+      },
+      "country": "US",
+      "created": 1715177798,
+      "default_currency": "usd",
+      "details_submitted": false,
+      "email": null,
+      "external_accounts": {
+        "data": [],
+        "has_more": false,
+        "object": "list",
+        "total_count": 0,
+        "url": "/v1/accounts/acct_1PEBIPKJ8Atczg1v/external_accounts"
+      },
+      "future_requirements": {
+        "alternatives": [],
+        "current_deadline": null,
+        "currently_due": [],
+        "disabled_reason": null,
+        "errors": [],
+        "eventually_due": [],
+        "past_due": [],
+        "pending_verification": []
+      },
+      "id": "acct_1PEBIPKJ8Atczg1v",
+      "metadata": {},
+      "object": "account",
+      "payouts_enabled": false,
+      "requirements": {
+        "alternatives": [],
+        "current_deadline": null,
+        "currently_due": [
+          "business_profile.product_description",
+          "business_profile.support_phone",
+          "business_profile.url",
+          "external_account",
+          "tos_acceptance.date",
+          "tos_acceptance.ip"
+        ],
+        "disabled_reason": "requirements.past_due",
+        "errors": [],
+        "eventually_due": [
+          "business_profile.product_description",
+          "business_profile.support_phone",
+          "business_profile.url",
+          "external_account",
+          "tos_acceptance.date",
+          "tos_acceptance.ip"
+        ],
+        "past_due": [],
+        "pending_verification": []
+      },
+      "settings": {
+        "bacs_debit_payments": {
+          "display_name": null,
+          "service_user_number": null
+        },
+        "branding": {
+          "icon": null,
+          "logo": null,
+          "primary_color": null,
+          "secondary_color": null
+        },
+        "card_issuing": {
+          "tos_acceptance": {
+            "date": null,
+            "ip": null
+          }
+        },
+        "card_payments": {
+          "decline_on": {
+            "avs_failure": true,
+            "cvc_failure": true
+          },
+          "statement_descriptor_prefix": null,
+          "statement_descriptor_prefix_kana": null,
+          "statement_descriptor_prefix_kanji": null
+        },
+        "dashboard": {
+          "display_name": null,
+          "timezone": "Etc/UTC"
+        },
+        "invoices": {
+          "default_account_tax_ids": null
+        },
+        "payments": {
+          "statement_descriptor": null,
+          "statement_descriptor_kana": null,
+          "statement_descriptor_kanji": null
+        },
+        "payouts": {
+          "debit_negative_balances": true,
+          "schedule": {
+            "delay_days": 2,
+            "interval": "daily"
+          },
+          "statement_descriptor": null
+        },
+        "sepa_debit_payments": {}
+      },
+      "tos_acceptance": {
+        "date": null
+      },
+      "type": "standard"
+    }
+  ],
+  [
     "acmeCo/Customers",
     {
       "_meta": {
@@ -779,6 +1484,42 @@
       },
       "name": "My Cool Customer",
       "next_invoice_sequence": 70,
+      "object": "customer",
+      "phone": null,
+      "preferred_locales": [],
+      "shipping": null,
+      "tax_exempt": "none",
+      "test_clock": null
+    }
+  ],
+  [
+    "acmeCo/Customers",
+    {
+      "_meta": {
+        "uuid": "DocUUIDPlaceholder-329Bb50aa48EAa9ef"
+      },
+      "account_id": "acct_1PDu50Q1qnzwasyf",
+      "address": null,
+      "balance": 0,
+      "created": 1715113031,
+      "currency": "brl",
+      "default_source": null,
+      "delinquent": true,
+      "description": null,
+      "discount": null,
+      "email": "test@test.com",
+      "id": "cus_Q42WkH3Qc0OZUQ",
+      "invoice_prefix": "B65FF57E",
+      "invoice_settings": {
+        "custom_fields": null,
+        "default_payment_method": null,
+        "footer": null,
+        "rendering_options": null
+      },
+      "livemode": false,
+      "metadata": {},
+      "name": "TestCustomer",
+      "next_invoice_sequence": 2,
       "object": "customer",
       "phone": null,
       "preferred_locales": [],
@@ -5547,482 +6288,6 @@
       },
       "paid": true,
       "payment_intent": "pi_3PO4euLzZ0uyKPmd0UHiq0KI",
-      "payment_method": "pm_1PDXrnLzZ0uyKPmdelC1923W",
-      "payment_method_details": {
-        "card": {
-          "amount_authorized": 1000,
-          "authorization_code": null,
-          "brand": "visa",
-          "checks": {
-            "address_line1_check": null,
-            "address_postal_code_check": null,
-            "cvc_check": null
-          },
-          "country": "US",
-          "exp_month": 5,
-          "exp_year": 2025,
-          "extended_authorization": {
-            "status": "disabled"
-          },
-          "fingerprint": "RIa1hFrmo5OK93gL",
-          "funding": "credit",
-          "incremental_authorization": {
-            "status": "unavailable"
-          },
-          "installments": null,
-          "last4": "4242",
-          "mandate": null,
-          "multicapture": {
-            "status": "unavailable"
-          },
-          "network": "visa",
-          "network_token": {
-            "used": false
-          },
-          "network_transaction_id": "827397491047011",
-          "overcapture": {
-            "maximum_amount_capturable": 1000,
-            "status": "unavailable"
-          },
-          "regulated_status": "unregulated",
-          "three_d_secure": null,
-          "wallet": null
-        },
-        "type": "card"
-      },
-      "radar_options": {},
-      "receipt_email": null,
-      "receipt_number": null,
-      "receipt_url": "redacted",
-      "refunded": false,
-      "review": null,
-      "shipping": null,
-      "source": null,
-      "source_transfer": null,
-      "statement_descriptor": null,
-      "statement_descriptor_suffix": null,
-      "status": "succeeded",
-      "transfer_data": null,
-      "transfer_group": null
-    }
-  ],
-  [
-    "acmeCo/Charges",
-    {
-      "_meta": {
-        "uuid": "DocUUIDPlaceholder-329Bb50aa48EAa9ef"
-      },
-      "account_id": "acct_1O4Om6LzZ0uyKPmd",
-      "amount": 1000,
-      "amount_captured": 1000,
-      "amount_refunded": 0,
-      "application": null,
-      "application_fee": null,
-      "application_fee_amount": null,
-      "balance_transaction": "txn_3POR8HLzZ0uyKPmd01fc6GKm",
-      "billing_details": {
-        "address": {
-          "city": null,
-          "country": null,
-          "line1": null,
-          "line2": null,
-          "postal_code": null,
-          "state": null
-        },
-        "email": null,
-        "name": null,
-        "phone": null
-      },
-      "calculated_statement_descriptor": "Stripe",
-      "captured": true,
-      "created": 1717621953,
-      "currency": "usd",
-      "customer": "cus_Q3fCJO6pdqbdAr",
-      "description": "Subscription update",
-      "destination": null,
-      "dispute": null,
-      "disputed": false,
-      "failure_balance_transaction": null,
-      "failure_code": null,
-      "failure_message": null,
-      "fraud_details": {},
-      "id": "ch_3POR8HLzZ0uyKPmd0wryZWQR",
-      "invoice": null,
-      "livemode": false,
-      "metadata": {},
-      "object": "charge",
-      "on_behalf_of": null,
-      "order": null,
-      "outcome": {
-        "advice_code": null,
-        "network_advice_code": null,
-        "network_decline_code": null,
-        "network_status": "approved_by_network",
-        "reason": null,
-        "risk_level": "normal",
-        "risk_score": 59,
-        "seller_message": "Payment complete.",
-        "type": "authorized"
-      },
-      "paid": true,
-      "payment_intent": "pi_3POR8HLzZ0uyKPmd0qT4fZiG",
-      "payment_method": "pm_1PDXrnLzZ0uyKPmdelC1923W",
-      "payment_method_details": {
-        "card": {
-          "amount_authorized": 1000,
-          "authorization_code": null,
-          "brand": "visa",
-          "checks": {
-            "address_line1_check": null,
-            "address_postal_code_check": null,
-            "cvc_check": null
-          },
-          "country": "US",
-          "exp_month": 5,
-          "exp_year": 2025,
-          "extended_authorization": {
-            "status": "disabled"
-          },
-          "fingerprint": "RIa1hFrmo5OK93gL",
-          "funding": "credit",
-          "incremental_authorization": {
-            "status": "unavailable"
-          },
-          "installments": null,
-          "last4": "4242",
-          "mandate": null,
-          "multicapture": {
-            "status": "unavailable"
-          },
-          "network": "visa",
-          "network_token": {
-            "used": false
-          },
-          "network_transaction_id": "827397491047011",
-          "overcapture": {
-            "maximum_amount_capturable": 1000,
-            "status": "unavailable"
-          },
-          "regulated_status": "unregulated",
-          "three_d_secure": null,
-          "wallet": null
-        },
-        "type": "card"
-      },
-      "radar_options": {},
-      "receipt_email": null,
-      "receipt_number": null,
-      "receipt_url": "redacted",
-      "refunded": false,
-      "review": null,
-      "shipping": null,
-      "source": null,
-      "source_transfer": null,
-      "statement_descriptor": null,
-      "statement_descriptor_suffix": null,
-      "status": "succeeded",
-      "transfer_data": null,
-      "transfer_group": null
-    }
-  ],
-  [
-    "acmeCo/Charges",
-    {
-      "_meta": {
-        "uuid": "DocUUIDPlaceholder-329Bb50aa48EAa9ef"
-      },
-      "account_id": "acct_1O4Om6LzZ0uyKPmd",
-      "amount": 1000,
-      "amount_captured": 1000,
-      "amount_refunded": 0,
-      "application": null,
-      "application_fee": null,
-      "application_fee_amount": null,
-      "balance_transaction": "txn_3POnbgLzZ0uyKPmd0Kfqj4JQ",
-      "billing_details": {
-        "address": {
-          "city": null,
-          "country": null,
-          "line1": null,
-          "line2": null,
-          "postal_code": null,
-          "state": null
-        },
-        "email": null,
-        "name": null,
-        "phone": null
-      },
-      "calculated_statement_descriptor": "Stripe",
-      "captured": true,
-      "created": 1717708345,
-      "currency": "usd",
-      "customer": "cus_Q3fCJO6pdqbdAr",
-      "description": "Subscription update",
-      "destination": null,
-      "dispute": null,
-      "disputed": false,
-      "failure_balance_transaction": null,
-      "failure_code": null,
-      "failure_message": null,
-      "fraud_details": {},
-      "id": "ch_3POnbgLzZ0uyKPmd04LXMxRa",
-      "invoice": null,
-      "livemode": false,
-      "metadata": {},
-      "object": "charge",
-      "on_behalf_of": null,
-      "order": null,
-      "outcome": {
-        "advice_code": null,
-        "network_advice_code": null,
-        "network_decline_code": null,
-        "network_status": "approved_by_network",
-        "reason": null,
-        "risk_level": "normal",
-        "risk_score": 34,
-        "seller_message": "Payment complete.",
-        "type": "authorized"
-      },
-      "paid": true,
-      "payment_intent": "pi_3POnbgLzZ0uyKPmd0rLJ28n1",
-      "payment_method": "pm_1PDXrnLzZ0uyKPmdelC1923W",
-      "payment_method_details": {
-        "card": {
-          "amount_authorized": 1000,
-          "authorization_code": null,
-          "brand": "visa",
-          "checks": {
-            "address_line1_check": null,
-            "address_postal_code_check": null,
-            "cvc_check": null
-          },
-          "country": "US",
-          "exp_month": 5,
-          "exp_year": 2025,
-          "extended_authorization": {
-            "status": "disabled"
-          },
-          "fingerprint": "RIa1hFrmo5OK93gL",
-          "funding": "credit",
-          "incremental_authorization": {
-            "status": "unavailable"
-          },
-          "installments": null,
-          "last4": "4242",
-          "mandate": null,
-          "multicapture": {
-            "status": "unavailable"
-          },
-          "network": "visa",
-          "network_token": {
-            "used": false
-          },
-          "network_transaction_id": "827397491047011",
-          "overcapture": {
-            "maximum_amount_capturable": 1000,
-            "status": "unavailable"
-          },
-          "regulated_status": "unregulated",
-          "three_d_secure": null,
-          "wallet": null
-        },
-        "type": "card"
-      },
-      "radar_options": {},
-      "receipt_email": null,
-      "receipt_number": null,
-      "receipt_url": "redacted",
-      "refunded": false,
-      "review": null,
-      "shipping": null,
-      "source": null,
-      "source_transfer": null,
-      "statement_descriptor": null,
-      "statement_descriptor_suffix": null,
-      "status": "succeeded",
-      "transfer_data": null,
-      "transfer_group": null
-    }
-  ],
-  [
-    "acmeCo/Charges",
-    {
-      "_meta": {
-        "uuid": "DocUUIDPlaceholder-329Bb50aa48EAa9ef"
-      },
-      "account_id": "acct_1O4Om6LzZ0uyKPmd",
-      "amount": 1000,
-      "amount_captured": 1000,
-      "amount_refunded": 0,
-      "application": null,
-      "application_fee": null,
-      "application_fee_amount": null,
-      "balance_transaction": "txn_3PPA56LzZ0uyKPmd0IkRh26H",
-      "billing_details": {
-        "address": {
-          "city": null,
-          "country": null,
-          "line1": null,
-          "line2": null,
-          "postal_code": null,
-          "state": null
-        },
-        "email": null,
-        "name": null,
-        "phone": null
-      },
-      "calculated_statement_descriptor": "Stripe",
-      "captured": true,
-      "created": 1717794737,
-      "currency": "usd",
-      "customer": "cus_Q3fCJO6pdqbdAr",
-      "description": "Subscription update",
-      "destination": null,
-      "dispute": null,
-      "disputed": false,
-      "failure_balance_transaction": null,
-      "failure_code": null,
-      "failure_message": null,
-      "fraud_details": {},
-      "id": "ch_3PPA56LzZ0uyKPmd043XdIE4",
-      "invoice": null,
-      "livemode": false,
-      "metadata": {},
-      "object": "charge",
-      "on_behalf_of": null,
-      "order": null,
-      "outcome": {
-        "advice_code": null,
-        "network_advice_code": null,
-        "network_decline_code": null,
-        "network_status": "approved_by_network",
-        "reason": null,
-        "risk_level": "normal",
-        "risk_score": 16,
-        "seller_message": "Payment complete.",
-        "type": "authorized"
-      },
-      "paid": true,
-      "payment_intent": "pi_3PPA56LzZ0uyKPmd05hGVj3V",
-      "payment_method": "pm_1PDXrnLzZ0uyKPmdelC1923W",
-      "payment_method_details": {
-        "card": {
-          "amount_authorized": 1000,
-          "authorization_code": null,
-          "brand": "visa",
-          "checks": {
-            "address_line1_check": null,
-            "address_postal_code_check": null,
-            "cvc_check": null
-          },
-          "country": "US",
-          "exp_month": 5,
-          "exp_year": 2025,
-          "extended_authorization": {
-            "status": "disabled"
-          },
-          "fingerprint": "RIa1hFrmo5OK93gL",
-          "funding": "credit",
-          "incremental_authorization": {
-            "status": "unavailable"
-          },
-          "installments": null,
-          "last4": "4242",
-          "mandate": null,
-          "multicapture": {
-            "status": "unavailable"
-          },
-          "network": "visa",
-          "network_token": {
-            "used": false
-          },
-          "network_transaction_id": "827397491047011",
-          "overcapture": {
-            "maximum_amount_capturable": 1000,
-            "status": "unavailable"
-          },
-          "regulated_status": "unregulated",
-          "three_d_secure": null,
-          "wallet": null
-        },
-        "type": "card"
-      },
-      "radar_options": {},
-      "receipt_email": null,
-      "receipt_number": null,
-      "receipt_url": "redacted",
-      "refunded": false,
-      "review": null,
-      "shipping": null,
-      "source": null,
-      "source_transfer": null,
-      "statement_descriptor": null,
-      "statement_descriptor_suffix": null,
-      "status": "succeeded",
-      "transfer_data": null,
-      "transfer_group": null
-    }
-  ],
-  [
-    "acmeCo/Charges",
-    {
-      "_meta": {
-        "uuid": "DocUUIDPlaceholder-329Bb50aa48EAa9ef"
-      },
-      "account_id": "acct_1O4Om6LzZ0uyKPmd",
-      "amount": 1000,
-      "amount_captured": 1000,
-      "amount_refunded": 0,
-      "application": null,
-      "application_fee": null,
-      "application_fee_amount": null,
-      "balance_transaction": "txn_3PPWXjLzZ0uyKPmd17fONGfR",
-      "billing_details": {
-        "address": {
-          "city": null,
-          "country": null,
-          "line1": null,
-          "line2": null,
-          "postal_code": null,
-          "state": null
-        },
-        "email": null,
-        "name": null,
-        "phone": null
-      },
-      "calculated_statement_descriptor": "Stripe",
-      "captured": true,
-      "created": 1717881079,
-      "currency": "usd",
-      "customer": "cus_Q3fCJO6pdqbdAr",
-      "description": "Subscription update",
-      "destination": null,
-      "dispute": null,
-      "disputed": false,
-      "failure_balance_transaction": null,
-      "failure_code": null,
-      "failure_message": null,
-      "fraud_details": {},
-      "id": "ch_3PPWXjLzZ0uyKPmd1fgeFMIn",
-      "invoice": null,
-      "livemode": false,
-      "metadata": {},
-      "object": "charge",
-      "on_behalf_of": null,
-      "order": null,
-      "outcome": {
-        "advice_code": null,
-        "network_advice_code": null,
-        "network_decline_code": null,
-        "network_status": "approved_by_network",
-        "reason": null,
-        "risk_level": "normal",
-        "risk_score": 29,
-        "seller_message": "Payment complete.",
-        "type": "authorized"
-      },
-      "paid": true,
-      "payment_intent": "pi_3PPWXjLzZ0uyKPmd1a1fMBFR",
       "payment_method": "pm_1PDXrnLzZ0uyKPmdelC1923W",
       "payment_method_details": {
         "card": {


### PR DESCRIPTION
**Description:**

Modify base_object, child_object, split_child_object, usage_records, and no_events_object methods to handle cases where no connected accounts are provided. When no connected accounts are present, the methods now use a single fetch function with a None account_id instead of creating per-account fetch functions.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2504)
<!-- Reviewable:end -->
