### PR TITLE
source-hubspot-native: Expand HubSpot Engagement associations

### DIFF
--- a/source-hubspot-native/acmeCo/engagements.schema.yaml
+++ b/source-hubspot-native/acmeCo/engagements.schema.yaml
@@ -100,11 +100,89 @@ properties:
     default: {}
     title: Associations
     type: object
+  contacts:
+    default: []
+    items:
+      type: integer
+    title: Contacts
+    type: array
+  companies:
+    default: []
+    items:
+      type: integer
+    title: Companies
+    type: array
   deals:
     default: []
     items:
       type: integer
     title: Deals
+    type: array
+  tickets:
+    default: []
+    items:
+      type: integer
+    title: Tickets
+    type: array
+  content:
+    default: []
+    items:
+      type: integer
+    title: Content
+    type: array
+  quotes:
+    default: []
+    items:
+      type: integer
+    title: Quotes
+    type: array
+  orders:
+    default: []
+    items:
+      type: integer
+    title: Orders
+    type: array
+  emails:
+    default: []
+    items:
+      type: integer
+    title: Emails
+    type: array
+  meetings:
+    default: []
+    items:
+      type: integer
+    title: Meetings
+    type: array
+  notes:
+    default: []
+    items:
+      type: integer
+    title: Notes
+    type: array
+  tasks:
+    default: []
+    items:
+      type: integer
+    title: Tasks
+    type: array
+  carts:
+    default: []
+    items:
+      type: integer
+    title: Carts
+    type: array
+  partner_clients:
+    default: []
+    items:
+      type: integer
+    title: Partner Clients
+    type: array
+  marketing_event:
+    default: []
+    items:
+      type: integer
+    title: Marketing Event
     type: array
 required:
   - id

--- a/source-hubspot-native/tests/snapshots/snapshots__capture__stdout.json
+++ b/source-hubspot-native/tests/snapshots/snapshots__capture__stdout.json
@@ -4993,6 +4993,9 @@
         "uuid": "DocUUIDPlaceholder-329Bb50aa48EAa9ef"
       },
       "archived": false,
+      "companies": [
+        19015593502
+      ],
       "createdAt": "2024-02-15T17:25:55.752000Z",
       "id": 47494434080,
       "properties": {

--- a/source-hubspot-native/tests/snapshots/snapshots__discover__stdout.json
+++ b/source-hubspot-native/tests/snapshots/snapshots__discover__stdout.json
@@ -743,12 +743,116 @@
           "title": "Associations",
           "type": "object"
         },
+        "contacts": {
+          "default": [],
+          "items": {
+            "type": "integer"
+          },
+          "title": "Contacts",
+          "type": "array"
+        },
+        "companies": {
+          "default": [],
+          "items": {
+            "type": "integer"
+          },
+          "title": "Companies",
+          "type": "array"
+        },
         "deals": {
           "default": [],
           "items": {
             "type": "integer"
           },
           "title": "Deals",
+          "type": "array"
+        },
+        "tickets": {
+          "default": [],
+          "items": {
+            "type": "integer"
+          },
+          "title": "Tickets",
+          "type": "array"
+        },
+        "content": {
+          "default": [],
+          "items": {
+            "type": "integer"
+          },
+          "title": "Content",
+          "type": "array"
+        },
+        "quotes": {
+          "default": [],
+          "items": {
+            "type": "integer"
+          },
+          "title": "Quotes",
+          "type": "array"
+        },
+        "orders": {
+          "default": [],
+          "items": {
+            "type": "integer"
+          },
+          "title": "Orders",
+          "type": "array"
+        },
+        "emails": {
+          "default": [],
+          "items": {
+            "type": "integer"
+          },
+          "title": "Emails",
+          "type": "array"
+        },
+        "meetings": {
+          "default": [],
+          "items": {
+            "type": "integer"
+          },
+          "title": "Meetings",
+          "type": "array"
+        },
+        "notes": {
+          "default": [],
+          "items": {
+            "type": "integer"
+          },
+          "title": "Notes",
+          "type": "array"
+        },
+        "tasks": {
+          "default": [],
+          "items": {
+            "type": "integer"
+          },
+          "title": "Tasks",
+          "type": "array"
+        },
+        "carts": {
+          "default": [],
+          "items": {
+            "type": "integer"
+          },
+          "title": "Carts",
+          "type": "array"
+        },
+        "partner_clients": {
+          "default": [],
+          "items": {
+            "type": "integer"
+          },
+          "title": "Partner Clients",
+          "type": "array"
+        },
+        "marketing_event": {
+          "default": [],
+          "items": {
+            "type": "integer"
+          },
+          "title": "Marketing Event",
           "type": "array"
         }
       },


### PR DESCRIPTION
**Description:**

Expand HubSpot Engagement associations to support multiple object types. Update the Engagement model and schema to include associations for contacts, companies, tickets, content, quotes, orders, emails, meetings, notes, tasks, and carts.

[HubSpot's V1 API for Engagements](https://developers.hubspot.com/docs/reference/api/crm/engagements/engagement-details#get-an-engagement) returns the following associations:

```
"engagement": {
    ...
    "associations": {
        "contactIds": [],
        "companyIds": [],
        "dealIds": [],
        "ownerIds": [],
        "workflowIds": [],
        "ticketIds": [],
        "contentIds": [],
        "quoteIds": [],
        "marketingEventIds": [],
        "partnerClientIds": [],
        "orderIds": [],
        "cartIds": []
    },
    ...
}
```

However, when testing each using [HubSpot's batch read associations endpoint](https://developers.hubspot.com/docs/reference/api/crm/associations/association-details#post-%2Fcrm%2Fv4%2Fassociations%2F%7Bfromobjecttype%7D%2F%7Btoobjecttype%7D%2Fbatch%2Fread), I was only able to get valid API responses for those in **bold**.

- **contacts**
- **companies**
- **deals**
- **tickets**
- **quotes**
- **orders**
- **emails**
- **meetings**
- **notes**
- **tasks**
- **content**
- **orders**
- **carts**
- **marketing events** - only `marketing_event` worked - not `marketing_events`
- **partner clients**
- owners - is a top-level property, `ownerId`
- workflows

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2505)
<!-- Reviewable:end -->
