### PR TITLE
materialize-sql: don't use merge bounds for datetimes

### DIFF
--- a/materialize-sql/templating.go
+++ b/materialize-sql/templating.go
@@ -152,6 +152,13 @@ func (b *MergeBoundsBuilder) Build() []MergeBound {
 			// the complexity and overhead of comparing their binary values is
 			// probably not worth it.
 			continue
+		} else if ft == STRING && col.Inference.String_ != nil && col.Inference.String_.Format == "date-time" {
+			// At least one destination (BigQuery) has known issues with keys
+			// that are date-times with sub-microsecond precision when used as a
+			// merge bound. For simplicity such formatted strings will never
+			// appear in merge bounds, although we should figure out how to do
+			// this more selectively in the future.
+			continue
 		}
 
 		conditions[idx].LiteralLower = b.literaler(b.lower[idx])


### PR DESCRIPTION
**Description:**

At least one destination (BigQuery) has known issues with keys that are date-times with sub-microsecond precision when used as a merge bound. For simplicity such formatted strings will never appear in merge bounds, although we should figure out how to do this more selectively in the future.

I suspect that at least Redshift would also fail with a nanosecond timestamp if included in a merge bound query, but haven't tested that directly. These types of keys are pretty rare.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2514)
<!-- Reviewable:end -->
