### PR TITLE
materialize-iceberg: replace "schema" in resource config json with "namespace"

### DIFF
--- a/materialize-iceberg/.snapshots/TestSpec
+++ b/materialize-iceberg/.snapshots/TestSpec
@@ -334,7 +334,7 @@
         "description": "Name of the database table.",
         "x-collection-name": true
       },
-      "schema": {
+      "namespace": {
         "type": "string",
         "title": "Alternative Namespace",
         "description": "Alternative Namespace for this table (optional).",

--- a/materialize-iceberg/config.go
+++ b/materialize-iceberg/config.go
@@ -279,7 +279,7 @@ func (c config) toSsmClient(ctx context.Context) (*ssm.Client, error) {
 
 type resource struct {
 	Table     string `json:"table" jsonschema:"title=Table,description=Name of the database table." jsonschema_extras:"x-collection-name=true"`
-	Namespace string `json:"schema,omitempty" jsonschema:"title=Alternative Namespace,description=Alternative Namespace for this table (optional)." jsonschema_extras:"x-schema-name=true"`
+	Namespace string `json:"namespace,omitempty" jsonschema:"title=Alternative Namespace,description=Alternative Namespace for this table (optional)." jsonschema_extras:"x-schema-name=true"`
 }
 
 func (r resource) Validate() error {


### PR DESCRIPTION
**Description:**

It always should have been "namespace", and this is just fixing that typo.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2515)
<!-- Reviewable:end -->
