### PR TITLE
source-google-analytics-data-api-native: add lookback window functionality

### DIFF
--- a/source-google-analytics-data-api-native/source_google_analytics_data_api_native/models.py
+++ b/source-google-analytics-data-api-native/source_google_analytics_data_api_native/models.py
@@ -85,7 +85,20 @@ class EndpointConfig(BaseModel):
         discriminator="credentials_title",
         title="Authentication",
     )
+    class Advanced(BaseModel):
+        lookback_window_size: Annotated[int, Field(
+            description="Number of days to lookback from the present for updates.",
+            title="Lookback Window Size",
+            default=30,
+            ge=0,
+        )]
 
+    advanced: Advanced = Field(
+        default_factory=Advanced, #type: ignore
+        title="Advanced Config",
+        description="Advanced settings for the connector.",
+        json_schema_extra={"advanced": True},
+    )
 
 ConnectorState = GenericConnectorState[ResourceState]
 

--- a/source-google-analytics-data-api-native/source_google_analytics_data_api_native/resources.py
+++ b/source-google-analytics-data-api-native/source_google_analytics_data_api_native/resources.py
@@ -152,6 +152,8 @@ def reports(
                 timezone,
                 model,
                 report,
+                config.start_date,
+                config.advanced.lookback_window_size,
             ),
             fetch_page=functools.partial(
                 backfill_report,

--- a/source-google-analytics-data-api-native/source_google_analytics_data_api_native/resources.py
+++ b/source-google-analytics-data-api-native/source_google_analytics_data_api_native/resources.py
@@ -182,7 +182,7 @@ def reports(
                 backfill=ResourceState.Backfill(cutoff=cutoff, next_page=dt_to_str(start))
             ),
             initial_config=ResourceConfig(
-                name=report.name, interval=timedelta(minutes=5)
+                name=report.name, interval=timedelta(minutes=30)
             ),
             schema_inference=True,
         )

--- a/source-google-analytics-data-api-native/tests/snapshots/snapshots__discover__capture.stdout.json
+++ b/source-google-analytics-data-api-native/tests/snapshots/snapshots__discover__capture.stdout.json
@@ -3,7 +3,7 @@
     "recommendedName": "daily_active_users",
     "resourceConfig": {
       "name": "daily_active_users",
-      "interval": "PT5M"
+      "interval": "PT30M"
     },
     "documentSchema": {
       "$defs": {
@@ -73,7 +73,7 @@
     "recommendedName": "devices",
     "resourceConfig": {
       "name": "devices",
-      "interval": "PT5M"
+      "interval": "PT30M"
     },
     "documentSchema": {
       "$defs": {
@@ -161,7 +161,7 @@
     "recommendedName": "four_weekly_active_users",
     "resourceConfig": {
       "name": "four_weekly_active_users",
-      "interval": "PT5M"
+      "interval": "PT30M"
     },
     "documentSchema": {
       "$defs": {
@@ -231,7 +231,7 @@
     "recommendedName": "locations",
     "resourceConfig": {
       "name": "locations",
-      "interval": "PT5M"
+      "interval": "PT30M"
     },
     "documentSchema": {
       "$defs": {
@@ -319,7 +319,7 @@
     "recommendedName": "my_custom_report_with_a_filter",
     "resourceConfig": {
       "name": "my_custom_report_with_a_filter",
-      "interval": "PT5M"
+      "interval": "PT30M"
     },
     "documentSchema": {
       "$defs": {
@@ -395,7 +395,7 @@
     "recommendedName": "pages",
     "resourceConfig": {
       "name": "pages",
-      "interval": "PT5M"
+      "interval": "PT30M"
     },
     "documentSchema": {
       "$defs": {
@@ -477,7 +477,7 @@
     "recommendedName": "traffic_sources",
     "resourceConfig": {
       "name": "traffic_sources",
-      "interval": "PT5M"
+      "interval": "PT30M"
     },
     "documentSchema": {
       "$defs": {
@@ -559,7 +559,7 @@
     "recommendedName": "website_overview",
     "resourceConfig": {
       "name": "website_overview",
-      "interval": "PT5M"
+      "interval": "PT30M"
     },
     "documentSchema": {
       "$defs": {
@@ -629,7 +629,7 @@
     "recommendedName": "weekly_active_users",
     "resourceConfig": {
       "name": "weekly_active_users",
-      "interval": "PT5M"
+      "interval": "PT30M"
     },
     "documentSchema": {
       "$defs": {

--- a/source-google-analytics-data-api-native/tests/snapshots/snapshots__spec__capture.stdout.json
+++ b/source-google-analytics-data-api-native/tests/snapshots/snapshots__spec__capture.stdout.json
@@ -3,6 +3,19 @@
     "protocol": 3032023,
     "configSchema": {
       "$defs": {
+        "Advanced": {
+          "properties": {
+            "lookback_window_size": {
+              "default": 30,
+              "description": "Number of days to lookback from the present for updates.",
+              "minimum": 0,
+              "title": "Lookback Window Size",
+              "type": "integer"
+            }
+          },
+          "title": "Advanced",
+          "type": "object"
+        },
         "_OAuth2Credentials": {
           "properties": {
             "credentials_title": {
@@ -68,6 +81,12 @@
             }
           ],
           "title": "Authentication"
+        },
+        "advanced": {
+          "$ref": "#/$defs/Advanced",
+          "advanced": true,
+          "description": "Advanced settings for the connector.",
+          "title": "Advanced Config"
         }
       },
       "required": [


### PR DESCRIPTION
**Description:**

Per a user, GA4 data underlying some reports can still change N days after the report was captured. As the connector is right now, the incremental task fetches the most recent day's report & never looks back to recapture previous days reports. Meaning, the older reports can be outdated if the underlying data changed. The value of N seems to vary depending on the type of data, report, ingestion method, etc. based on these [Google docs](https://support.google.com/analytics/answer/11198161).

To fix this, this PR adds a configurable lookback window that forces the incremental task to always fetch reports for the past `lookback_window_size` days whenever it runs.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

The `source-google-analytics-data-api-native` docs should be updated to reflect the new lookback window setting.

**Notes for reviewers:**

Tested on a local stack. Confirmed that the incremental task fetches the report for the past `lookback_window_size` days before the current `log_cursor` datetime on each sweep.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2516)
<!-- Reviewable:end -->
