### PR TITLE
materialize-iceberg: disable escaping in load responses entirely & log failed merged queries

### DIFF
--- a/materialize-iceberg/python/load.py
+++ b/materialize-iceberg/python/load.py
@@ -35,6 +35,7 @@ def run(input):
         quote="|",
         compression="gzip",
         escapeQuotes=False,
+        escape="\u0000",
     )
 
     for binding in bindings:

--- a/materialize-iceberg/python/merge.py
+++ b/materialize-iceberg/python/merge.py
@@ -27,9 +27,12 @@ def run(input):
             inferSchema=False,
         ).createTempView(f"merge_view_{bindingIdx}")
 
-        spark.sql(query)
-
-        spark.catalog.dropTempView(f"merge_view_{bindingIdx}")
+        try:
+            spark.sql(query)
+        except Exception as e:
+            raise RuntimeError(f"Running merge query failed:\n{query}\nOriginal Error:\n{str(e)}") from e
+        finally:
+            spark.catalog.dropTempView(f"merge_view_{bindingIdx}")
 
 
 run_with_status(args, run)


### PR DESCRIPTION
**Description:**

This configuration is apparently needed to completely disable escaping in the Spark CSV writer, otherwise it will add an extra backslash in front of backslashes that are within double quotes.

Also log out the query for failed merge queries. This is mostly nice so we can tell which source collection it is that is failing to merge.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2520)
<!-- Reviewable:end -->
