### PR TITLE
materialize-iceberg: use multiLine option for CSV reading

### DIFF
--- a/materialize-iceberg/python/load.py
+++ b/materialize-iceberg/python/load.py
@@ -26,6 +26,7 @@ def run(input):
             quote="`",
             header=False,
             inferSchema=False,
+            multiLine=True,
         ).createTempView(f"load_view_{bindingIdx}")
 
     spark.sql(query).write.csv(

--- a/materialize-iceberg/python/merge.py
+++ b/materialize-iceberg/python/merge.py
@@ -25,6 +25,7 @@ def run(input):
             quote="`",
             header=False,
             inferSchema=False,
+            multiLine=True,
         ).createTempView(f"merge_view_{bindingIdx}")
 
         try:


### PR DESCRIPTION
**Description:**

PySpark requires this option when reading CSV data that may contain newline characters, even if they are within quotes.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2521)
<!-- Reviewable:end -->
