### PR TITLE
source-oracle: no need to find earliest dictionary in online mode

### DIFF
--- a/source-oracle/.snapshots/TestGeneric-SpecResponse
+++ b/source-oracle/.snapshots/TestGeneric-SpecResponse
@@ -83,7 +83,7 @@
               "online"
             ],
             "title": "Dictionary Mode",
-            "description": "How should dictionaries be used in Logminer: one of online or extract. When using online mode schema changes to the table may break the capture but resource usage is limited. When using extract mode schema changes are handled gracefully but more resources of your database (including disk) are used by the process. Defaults to extract."
+            "description": "How should dictionaries be used in Logminer: one of online or extract. When using online mode schema changes to the table may break the capture but resource usage is limited. When using extract mode schema changes are handled gracefully but more resources of your database (including disk) are used by the process. Defaults to online."
           }
         },
         "additionalProperties": false,

--- a/source-oracle/.snapshots/TestSchemaChanges-delete
+++ b/source-oracle/.snapshots/TestSchemaChanges-delete
@@ -5,5 +5,5 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"C%23%23FLOW_TEST_LOGMINER%2FT83287013":{"backfilled":1,"key_columns":["YEAR","STATE"],"mode":"Active"}},"cursor":"11111111"}
+{"bindingStateV1":{"C%23%23FLOW_TEST_LOGMINER%2FT83287013":{"backfilled":1,"key_columns":["STATE","YEAR"],"mode":"Active"}},"cursor":"11111111"}
 

--- a/source-oracle/.snapshots/TestSchemaChanges-init
+++ b/source-oracle/.snapshots/TestSchemaChanges-init
@@ -5,5 +5,5 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"C%23%23FLOW_TEST_LOGMINER%2FT83287013":{"backfilled":1,"key_columns":["YEAR","STATE"],"mode":"Active"}},"cursor":"11111111"}
+{"bindingStateV1":{"C%23%23FLOW_TEST_LOGMINER%2FT83287013":{"backfilled":1,"key_columns":["STATE","YEAR"],"mode":"Active"}},"cursor":"11111111"}
 

--- a/source-oracle/.snapshots/TestSchemaChanges-insert-after
+++ b/source-oracle/.snapshots/TestSchemaChanges-insert-after
@@ -5,5 +5,5 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"C%23%23FLOW_TEST_LOGMINER%2FT83287013":{"backfilled":1,"key_columns":["YEAR","STATE"],"mode":"Active"}},"cursor":"11111111"}
+{"bindingStateV1":{"C%23%23FLOW_TEST_LOGMINER%2FT83287013":{"backfilled":1,"key_columns":["STATE","YEAR"],"mode":"Active"}},"cursor":"11111111"}
 

--- a/source-oracle/.snapshots/TestSchemaChanges-insert-before
+++ b/source-oracle/.snapshots/TestSchemaChanges-insert-before
@@ -5,5 +5,5 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"C%23%23FLOW_TEST_LOGMINER%2FT83287013":{"backfilled":1,"key_columns":["YEAR","STATE"],"mode":"Active"}},"cursor":"11111111"}
+{"bindingStateV1":{"C%23%23FLOW_TEST_LOGMINER%2FT83287013":{"backfilled":1,"key_columns":["STATE","YEAR"],"mode":"Active"}},"cursor":"11111111"}
 

--- a/source-oracle/.snapshots/TestSchemaChanges-update
+++ b/source-oracle/.snapshots/TestSchemaChanges-update
@@ -5,5 +5,5 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"C%23%23FLOW_TEST_LOGMINER%2FT83287013":{"backfilled":1,"key_columns":["YEAR","STATE"],"mode":"Active"}},"cursor":"11111111"}
+{"bindingStateV1":{"C%23%23FLOW_TEST_LOGMINER%2FT83287013":{"backfilled":1,"key_columns":["STATE","YEAR"],"mode":"Active"}},"cursor":"11111111"}
 


### PR DESCRIPTION
**Description:**

- We would search for the latest log file that covers the SCN range we want to capture which begins a dictionary so that in case of schema changes, we have the dictionary information available, however in online mode we are using the current dictionary of the table, and we don't need to look for dictionary in log files. This meant that in online mode we were reading a lot more log files than necessary, slowing us down considerably.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2527)
<!-- Reviewable:end -->
