### PR TITLE
materialize-databricks: support AdditionalSql in binding configuration

### DIFF
--- a/materialize-databricks/.snapshots/TestSpecification
+++ b/materialize-databricks/.snapshots/TestSpecification
@@ -208,6 +208,12 @@
         "description": "Should updates to this table be done via delta updates. Default is false.",
         "default": false,
         "x-delta-updates": true
+      },
+      "additional_table_create_sql": {
+        "type": "string",
+        "title": "Additional Table Create SQL",
+        "description": "Additional SQL statement(s) to be run after table is created.",
+        "multiline": true
       }
     },
     "type": "object",

--- a/materialize-databricks/driver.go
+++ b/materialize-databricks/driver.go
@@ -29,9 +29,10 @@ const defaultPort = "443"
 const volumeName = "flow_staging"
 
 type tableConfig struct {
-	Table  string `json:"table" jsonschema:"title=Table,description=Name of the table" jsonschema_extras:"x-collection-name=true"`
-	Schema string `json:"schema,omitempty" jsonschema:"title=Schema,description=Schema where the table resides" jsonschema_extras:"x-schema-name=true"`
-	Delta  bool   `json:"delta_updates,omitempty" jsonschema:"default=false,title=Delta Update,description=Should updates to this table be done via delta updates. Default is false." jsonschema_extras:"x-delta-updates=true"`
+	Table         string `json:"table" jsonschema:"title=Table,description=Name of the table" jsonschema_extras:"x-collection-name=true"`
+	Schema        string `json:"schema,omitempty" jsonschema:"title=Schema,description=Schema where the table resides" jsonschema_extras:"x-schema-name=true"`
+	Delta         bool   `json:"delta_updates,omitempty" jsonschema:"default=false,title=Delta Update,description=Should updates to this table be done via delta updates. Default is false." jsonschema_extras:"x-delta-updates=true"`
+	AdditionalSql string `json:"additional_table_create_sql,omitempty" jsonschema:"title=Additional Table Create SQL,description=Additional SQL statement(s) to be run after table is created." jsonschema_extras:"multiline=true"`
 }
 
 func newTableConfig(ep *sql.Endpoint) sql.Resource {


### PR DESCRIPTION
**Description:**

Tested manually by running a task with additional SQL set to add a TBLPROPERTY to one of the tables, it worked as expected 👍🏽 

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2530)
<!-- Reviewable:end -->
