### PR TITLE
materialize-bigquery: return and error rather than panic if table metadata can't be found

### DIFF
--- a/materialize-bigquery/transactor.go
+++ b/materialize-bigquery/transactor.go
@@ -76,6 +76,10 @@ func prepareNewTransactor(
 			// as the JSON encoding of the values is the same they may be used for columns that would
 			// have been created differently due to evolution of the dialect's column types.
 			res := is.GetResource(binding.Path)
+			if res == nil {
+				return nil, nil, fmt.Errorf("could not get metadata for table %s: verify that the table exists and that the connector service account user is authorized for it", binding.Identifier)
+			}
+
 			schema := res.Meta.(bigquery.Schema)
 
 			log.WithFields(log.Fields{


### PR DESCRIPTION
**Description:**

Although this really shouldn't ever happen, like so many things that shouldn't happen it has happened and the panic is not as useful of an error message as it could be. So we will return a bit more of an instructive error message when it does happen.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2532)
<!-- Reviewable:end -->
