### PR TITLE
materialize-iceberg: use a different mechanism for computing the highest field ID from a schema

### DIFF
--- a/materialize-iceberg/type_mapping_test.go
+++ b/materialize-iceberg/type_mapping_test.go
@@ -1,0 +1,26 @@
+package connector
+
+import (
+	"testing"
+
+	"github.com/apache/iceberg-go"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetHighestFieldID(t *testing.T) {
+	originalFields := []iceberg.NestedField{
+		{ID: 1, Name: "firstKey", Required: true, Type: iceberg.Int64Type{}},
+		{ID: 2, Name: "secondKey", Required: true, Type: iceberg.StringType{}},
+		{ID: 3, Name: "reqVal", Required: true, Type: iceberg.StringType{}},
+		{ID: 4, Name: "optVal", Required: false, Type: iceberg.BooleanType{}},
+		{ID: 5, Name: "thirdVal", Required: true, Type: iceberg.DecimalTypeOf(38, 0)},
+		{ID: 6, Name: "fourthVal", Required: true, Type: &iceberg.ListType{
+			ElementID: 7,
+			Element:   iceberg.StringType{},
+		}},
+	}
+
+	originalSchema := iceberg.NewSchemaWithIdentifiers(1, []int{1, 2}, originalFields...)
+	require.NotEqual(t, originalSchema.HighestFieldID(), getHighestFieldID(originalSchema))
+	require.Equal(t, 7, getHighestFieldID(originalSchema))
+}


### PR DESCRIPTION
**Description:**

We are stuck on an old version of iceberg-go for now that does not account for certain logical types when computing the highest field ID for an existing schema. This creates a simple stand-in for doing that correctly with the column types we use.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

