### PR TITLE
dynamodb: bump allowed idle connections to avoid excessive re-creation

### DIFF
--- a/materialize-dynamodb/main.go
+++ b/materialize-dynamodb/main.go
@@ -1,9 +1,12 @@
 package main
 
 import (
+	awsHTTP "github.com/aws/aws-sdk-go-v2/aws/transport/http"
 	boilerplate "github.com/estuary/connectors/materialize-boilerplate"
 )
 
 func main() {
+	awsHTTP.DefaultHTTPTransportMaxIdleConns = 100        // From 100.
+	awsHTTP.DefaultHTTPTransportMaxIdleConnsPerHost = 100 // From 10.
 	boilerplate.RunMain(driver{})
 }

--- a/source-dynamodb/main.go
+++ b/source-dynamodb/main.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/aws/retry"
+	awsHTTP "github.com/aws/aws-sdk-go-v2/aws/transport/http"
 	awsConfig "github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
@@ -112,5 +113,7 @@ type client struct {
 }
 
 func main() {
+	awsHTTP.DefaultHTTPTransportMaxIdleConns = 100        // From 100.
+	awsHTTP.DefaultHTTPTransportMaxIdleConnsPerHost = 100 // From 10.
 	boilerplate.RunMain(new(driver))
 }


### PR DESCRIPTION
This is speculative, but we're seeing a lot of DNS resolution and re-connection for DynamoDB, and this may cause the connector to do a better job at connection re-use.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2539)
<!-- Reviewable:end -->
