### PR TITLE
source-facebook-marketing: use existing session to fetch thumbnail urls

### DIFF
--- a/source-facebook-marketing/source_facebook_marketing/streams/streams.py
+++ b/source-facebook-marketing/source_facebook_marketing/streams/streams.py
@@ -20,10 +20,10 @@ from .base_streams import FBMarketingIncrementalStream, FBMarketingReversedIncre
 logger = logging.getLogger("airbyte")
 
 
-def fetch_thumbnail_data_url(url: str) -> Optional[str]:
+def fetch_thumbnail_data_url(session: requests.Session, url: str) -> Optional[str]:
     """Request thumbnail image and return it embedded into the data-link"""
     try:
-        response = requests.get(url)
+        response = session.request("GET", url)
         if response.status_code == requests.status_codes.codes.OK:
             _type = response.headers["content-type"]
             data = base64.b64encode(response.content)
@@ -67,7 +67,7 @@ class AdCreatives(FBMarketingStream):
             if self._fetch_thumbnail_images:
                 thumbnail_url = record.get("thumbnail_url")
                 if thumbnail_url:
-                    record["thumbnail_data_url"] = fetch_thumbnail_data_url(thumbnail_url)
+                    record["thumbnail_data_url"] = fetch_thumbnail_data_url(self._api.api._session.requests, thumbnail_url)
             yield record
 
     def list_objects(self, params: Mapping[str, Any], account_id: str) -> Iterable:


### PR DESCRIPTION
**Description:**

The `fetch_thumbnail_data_url` function was not re-using the existing `requests.Session` & was instead making one-off `requests.get` calls. This caused a DNS query for each `fetch_thumbnail_data_url` invocation, and overall causes a TON of excessive, identical DNS queries.

By using the existing `requests.Session` instance to make fetch thumbnail URLs, DNS queries are much less frequent since connections can be reused.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

Tested on a local stack. Confirmed that the frequency of DNS queries after this change are significantly lower.

