### PR TITLE
source-sqlserver: Read Replica CDC

### DIFF
--- a/source-sqlserver/main.go
+++ b/source-sqlserver/main.go
@@ -52,6 +52,10 @@ var featureFlagDefaults = map[string]bool{
 	// event data starts to expire before it can be captured, but should generally only be
 	// needed in exceptional circumstances when recovering from some sort of major breakage.
 	"tolerate_missed_changes": false,
+
+	// Force use of the 'replica fence' mechanism, which is normally used automatically
+	// when the target database is detected as a replica.
+	"replica_fencing": false,
 }
 
 // Config tells the connector how to connect to and interact with the source database.

--- a/source-sqlserver/main_test.go
+++ b/source-sqlserver/main_test.go
@@ -113,6 +113,9 @@ func (tb *testBackend) CaptureSpec(ctx context.Context, t testing.TB, streamMatc
 		Validator:    &st.SortedCaptureValidator{},
 		Sanitizers:   sanitizers,
 	}
+	if strings.Contains(*testFeatureFlags, "replica_fencing") {
+		cs.CaptureDelay = 1 * time.Second
+	}
 	if len(streamMatchers) > 0 {
 		cs.Bindings = tests.DiscoverBindings(ctx, t, tb, streamMatchers...)
 	}


### PR DESCRIPTION
**Description:**

This PR adds support for SQL Server CDC capturing from a read-only standby replica. It does this by:

- Implementing a new fence mechanism in `streamToReplicaFence` which only consults information which is available on a read-only replica.
- Detecting at startup whether the target database is a read replica.
- Automatically using `streamToReplicaFence` when the target database is a read replica (or when the `replica_fencing` feature flag is explicitly enabled, just in case we need to be able to manually turn it on in other situations).

This new fence mechanism has a minor downside, which is that it doesn't (and can't, at least in every possible scenario) guarantee that when a row is modified concurrently with a backfill, the backfilled row state and the concurrent changes from replication will be captured in the same Flow transaction.

Other than this caveat the capture output is still entirely correct, so any users with standard reduction behavior into a materialization wouldn't even be able to notice a difference, but it's just a _tiny_ bit weaker of a correctness guarantee compared to what our SQL CDC connectors usually offer.

But I have proven to my own satisfaction that it is literally impossible to make the more precise guarantee in all situations when looking solely at the available data on a read replica, so if we want to support read replica CDC for SQL Server at all this is the best we're going to be able to do. And we do want to support that.

This fixes https://github.com/estuary/connectors/issues/2548

**Workflow steps:**

Setting up a capture from a SQL Server read replica should just work.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2547)
<!-- Reviewable:end -->
