### PR TITLE
source-postgres: Fix 'infinity' value in DATE column

### DIFF
--- a/source-postgres/.snapshots/TestSpecialTemporalValues
+++ b/source-postgres/.snapshots/TestSpecialTemporalValues
@@ -1,0 +1,16 @@
+# ================================
+# Collection "acmeCo/test/test/specialtemporalvalues_33220241": 8 Documents
+# ================================
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"specialtemporalvalues_33220241","loc":[11111111,11111111,11111111]}},"a_date":"1970-01-01","a_time":null,"a_timestamp":"<TIMESTAMP>","id":0}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"specialtemporalvalues_33220241","loc":[11111111,11111111,11111111]}},"a_date":"9999-12-31","a_time":null,"a_timestamp":"<TIMESTAMP>","id":1}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"specialtemporalvalues_33220241","loc":[11111111,11111111,11111111]}},"a_date":"0000-01-01","a_time":null,"a_timestamp":"<TIMESTAMP>","id":2}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"specialtemporalvalues_33220241","loc":[11111111,11111111,11111111]}},"a_date":null,"a_time":"00:00:00Z","a_timestamp":null,"id":3}
+{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"specialtemporalvalues_33220241","loc":[11111111,11111111,11111111],"txid":111111}},"a_date":"1970-01-01","a_time":null,"a_timestamp":"<TIMESTAMP>","id":10}
+{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"specialtemporalvalues_33220241","loc":[11111111,11111111,11111111],"txid":111111}},"a_date":"9999-12-31","a_time":null,"a_timestamp":"<TIMESTAMP>","id":11}
+{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"specialtemporalvalues_33220241","loc":[11111111,11111111,11111111],"txid":111111}},"a_date":"0000-01-01","a_time":null,"a_timestamp":"<TIMESTAMP>","id":12}
+{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"specialtemporalvalues_33220241","loc":[11111111,11111111,11111111],"txid":111111}},"a_date":null,"a_time":"00:00:00Z","a_timestamp":null,"id":13}
+# ================================
+# Final State Checkpoint
+# ================================
+{"bindingStateV1":{"test%2Fspecialtemporalvalues_33220241":{"backfilled":4,"key_columns":["id"],"mode":"Active"}},"cursor":"0/1111111"}
+

--- a/source-postgres/datatypes.go
+++ b/source-postgres/datatypes.go
@@ -23,6 +23,8 @@ import (
 const (
 	infinityTimestamp         = "9999-12-31T23:59:59Z"
 	negativeInfinityTimestamp = "0000-01-01T00:00:00Z"
+	infinityDate              = "9999-12-31"
+	negativeInfinityDate      = "0000-01-01"
 	rfc3339TimeFormat         = "15:04:05.999999999Z07:00"
 	truncateColumnThreshold   = 8 * 1024 * 1024 // Arbitrarily selected value
 )
@@ -277,6 +279,17 @@ func (db *postgresDatabase) translateRecordField(column *sqlcapture.ColumnInfo, 
 			} else {
 				return formatRFC3339(t) // Historical behavior
 			}
+		} else if x, ok := val.(pgtype.InfinityModifier); ok {
+			if !db.featureFlags["date_as_date"] {
+				if x == pgtype.Infinity {
+					return infinityTimestamp, nil
+				}
+				return negativeInfinityTimestamp, nil
+			}
+			if x == pgtype.Infinity {
+				return infinityDate, nil
+			}
+			return negativeInfinityDate, nil
 		} else if val == nil {
 			return nil, nil
 		}


### PR DESCRIPTION
**Description:**

Also adds a test of the various weird inputs that date/time columns accept, even though I think most of them translate to some specific date/time value and infinity is the only weird one here.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2552)
<!-- Reviewable:end -->
