### PR TITLE
source-sqlserver-batch: Default to 24h polling interval

### DIFF
--- a/source-sqlserver-batch/.snapshots/TestSpec
+++ b/source-sqlserver-batch/.snapshots/TestSpec
@@ -42,7 +42,7 @@
           "poll": {
             "type": "string",
             "title": "Default Polling Schedule",
-            "description": "When and how often to execute fetch queries. Accepts a Go duration string like '5m' or '6h' for frequency-based polling or a string like 'daily at 12:34Z' to poll at a specific time (specified in UTC) every day. Defaults to '5m' if unset.",
+            "description": "When and how often to execute fetch queries. Accepts a Go duration string like '5m' or '6h' for frequency-based polling or a string like 'daily at 12:34Z' to poll at a specific time (specified in UTC) every day. Defaults to '24h' if unset.",
             "pattern": "^([-+]?([0-9]+([.][0-9]+)?(h|m|s|ms))+|daily at [0-9][0-9]?:[0-9]{2}Z)$"
           },
           "discover_schemas": {

--- a/source-sqlserver-batch/main.go
+++ b/source-sqlserver-batch/main.go
@@ -41,7 +41,7 @@ type Config struct {
 type advancedConfig struct {
 	DiscoverViews   bool     `json:"discover_views,omitempty" jsonschema:"title=Discover Views,description=When set views will be automatically discovered as resources. If unset only tables will be discovered."`
 	Timezone        string   `json:"timezone,omitempty" jsonschema:"title=Time Zone,default=UTC,description=The IANA timezone name in which datetime columns will be converted to RFC3339 timestamps. Defaults to UTC if left blank."`
-	PollSchedule    string   `json:"poll,omitempty" jsonschema:"title=Default Polling Schedule,description=When and how often to execute fetch queries. Accepts a Go duration string like '5m' or '6h' for frequency-based polling or a string like 'daily at 12:34Z' to poll at a specific time (specified in UTC) every day. Defaults to '5m' if unset." jsonschema_extras:"pattern=^([-+]?([0-9]+([.][0-9]+)?(h|m|s|ms))+|daily at [0-9][0-9]?:[0-9]{2}Z)$"`
+	PollSchedule    string   `json:"poll,omitempty" jsonschema:"title=Default Polling Schedule,description=When and how often to execute fetch queries. Accepts a Go duration string like '5m' or '6h' for frequency-based polling or a string like 'daily at 12:34Z' to poll at a specific time (specified in UTC) every day. Defaults to '24h' if unset." jsonschema_extras:"pattern=^([-+]?([0-9]+([.][0-9]+)?(h|m|s|ms))+|daily at [0-9][0-9]?:[0-9]{2}Z)$"`
 	DiscoverSchemas []string `json:"discover_schemas,omitempty" jsonschema:"title=Discovery Schema Selection,description=If this is specified only tables in the selected schema(s) will be automatically discovered. Omit all entries to discover tables from all schemas."`
 	FeatureFlags    string   `json:"feature_flags,omitempty" jsonschema:"title=Feature Flags,description=This property is intended for Estuary internal use. You should only modify this field as directed by Estuary support."`
 
@@ -95,7 +95,7 @@ func (c *Config) SetDefaults() {
 	}
 
 	if c.Advanced.PollSchedule == "" {
-		c.Advanced.PollSchedule = "1h"
+		c.Advanced.PollSchedule = "24h"
 	}
 
 	if c.Advanced.Timezone == "" {


### PR DESCRIPTION
**Description:**

I can't remember why I made it 1h for this new capture when the others like MySQL (barring Postgres which is a special case as it uses xmin) default to 24h.

This changes the default behavior to 24h, when it's not overridden by either the endpoint spec or a particular resource config.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2553)
<!-- Reviewable:end -->
