### PR TITLE
source-intercom-native: handle 404 when fetching company segments

### DIFF
--- a/source-intercom-native/source_intercom_native/api.py
+++ b/source-intercom-native/source_intercom_native/api.py
@@ -654,9 +654,15 @@ async def fetch_company_segments(
     for id in company_ids:
         segments_url = f"{API}/companies/{id}/segments"
 
-        company_segments = CompanySegmentsResponse.model_validate_json(
-            await http.request(log, segments_url)
-        )
+        try:
+            company_segments = CompanySegmentsResponse.model_validate_json(
+                await http.request(log, segments_url)
+            )
+        except HTTPError as err:
+            if err.code == 404 and 'Company Not Found' in err.message:
+                continue
+            else:
+                raise
 
         for segment in company_segments.data:
             if segment.updated_at > last_seen_ts:


### PR DESCRIPTION
**Description:**

Sometimes, a company retrieved via the Intercom API is an archived/deleted company. There is no property that indicates if a company is archived/deleted, so the connector doesn't know if that's the case until we try to fetch sub-resources (i.e. segments) of the company. When we try to fetch segments of a deleted/archived company, we receive a somewhat specific 404 response.

This PR handles those 404s more gracefully & moves on to fetches the next company's segments.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

Confirmed receiving a 404 with the message "Company Not Found" when attempting to fetch a company's segments does not raise an error & causes the connector to continue fetching the other companies' segments.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2554)
<!-- Reviewable:end -->
