### PR TITLE
sqlcapture + source-boilerplate: The most trivial connector status implementation

### DIFF
--- a/source-boilerplate/boilerplate.go
+++ b/source-boilerplate/boilerplate.go
@@ -134,7 +134,7 @@ func (s *ConnectorServer) Capture(stream pc.Connector_CaptureServer) error {
 				return err
 			}
 		case request.Discover != nil:
-			log.WithField("eventType", "connectorStatus").Info("Discovering tables")
+			// No connectorStatus logging here, Discover RPC logging doesn't go into the ops log collection.
 			if response, err := s.Connector.Discover(ctx, request.Discover); err != nil {
 				return err
 			} else if err := stream.Send(&pc.Response{Discovered: response}); err != nil {

--- a/source-boilerplate/boilerplate.go
+++ b/source-boilerplate/boilerplate.go
@@ -68,6 +68,9 @@ func RunMain(connector Connector) {
 		log.SetLevel(lvl)
 	}
 
+	// Log an 'Initializing' message as soon as logging is configured.
+	log.WithField("eventType", "connectorStatus").Info("Initializing connector")
+
 	var ctx, _ = signal.NotifyContext(context.Background(), syscall.SIGTERM, syscall.SIGINT)
 	var stream pc.Connector_CaptureServer
 
@@ -131,24 +134,28 @@ func (s *ConnectorServer) Capture(stream pc.Connector_CaptureServer) error {
 				return err
 			}
 		case request.Discover != nil:
+			log.WithField("eventType", "connectorStatus").Info("Discovering tables")
 			if response, err := s.Connector.Discover(ctx, request.Discover); err != nil {
 				return err
 			} else if err := stream.Send(&pc.Response{Discovered: response}); err != nil {
 				return err
 			}
 		case request.Validate != nil:
+			log.WithField("eventType", "connectorStatus").Info("Validating capture configuration")
 			if response, err := s.Connector.Validate(ctx, request.Validate); err != nil {
 				return err
 			} else if err := stream.Send(&pc.Response{Validated: response}); err != nil {
 				return err
 			}
 		case request.Apply != nil:
+			log.WithField("eventType", "connectorStatus").Info("Applying capture configuration")
 			if response, err := s.Connector.Apply(ctx, request.Apply); err != nil {
 				return err
 			} else if err := stream.Send(&pc.Response{Applied: response}); err != nil {
 				return err
 			}
 		case request.Open != nil:
+			log.WithField("eventType", "connectorStatus").Info("Starting capture")
 			return s.Connector.Pull(request.Open, &PullOutput{Connector_CaptureServer: stream})
 		default:
 			return fmt.Errorf("unexpected request %#v", request)
@@ -166,7 +173,7 @@ type PullOutput struct {
 
 // Ready sends a PullResponse_Opened message to indicate that the capture has started.
 func (out *PullOutput) Ready(explicitAcknowledgements bool) error {
-	log.Debug("sending PullResponse.Opened")
+	log.WithField("eventType", "connectorStatus").Info("Capture started")
 	out.Lock()
 	defer out.Unlock()
 	if err := out.Send(&pc.Response{

--- a/sqlcapture/capture.go
+++ b/sqlcapture/capture.go
@@ -14,7 +14,7 @@ import (
 	"github.com/segmentio/encoding/json"
 
 	boilerplate "github.com/estuary/connectors/source-boilerplate"
-	"github.com/sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 )
 
 var (
@@ -158,13 +158,13 @@ var (
 func (c *Capture) Run(ctx context.Context) (err error) {
 	// Perform discovery and log the full results for convenience. This info
 	// will be needed when activating all currently-active bindings below.
-	logrus.Info("discovering tables")
+	log.Info("discovering tables")
 	discovery, err := c.Database.DiscoverTables(ctx)
 	if err != nil {
 		return fmt.Errorf("error discovering database tables: %w", err)
 	}
 	for streamID, discoveryInfo := range discovery {
-		logrus.WithFields(logrus.Fields{
+		log.WithFields(log.Fields{
 			"table":     streamID,
 			"discovery": discoveryInfo,
 		}).Debug("discovered table")
@@ -198,7 +198,7 @@ func (c *Capture) Run(ctx context.Context) (err error) {
 	// and relay them to the replication stream acknowledgement.
 	go func() {
 		if err := c.acknowledgeWorker(ctx, c.Output, replStream); err != nil {
-			logrus.WithField("err", err).Fatal("error relaying acknowledgements from stdin")
+			log.WithField("err", err).Fatal("error relaying acknowledgements from stdin")
 		}
 	}()
 
@@ -271,7 +271,7 @@ func (c *Capture) reconcileStateWithBindings(_ context.Context) error {
 			continue
 		}
 
-		logrus.WithField("stateKey", stateKey).Info("binding added to capture")
+		log.WithField("stateKey", stateKey).Info("binding added to capture")
 		c.State.Streams[stateKey] = &TableState{Mode: TableStatePending, dirty: true}
 	}
 
@@ -289,7 +289,7 @@ func (c *Capture) reconcileStateWithBindings(_ context.Context) error {
 	}
 	for stateKey, state := range c.State.Streams {
 		if state.Mode != TableStateIgnore && !streamExistsInCatalog(stateKey) {
-			logrus.WithField("stateKey", stateKey).Info("binding removed from capture")
+			log.WithField("stateKey", stateKey).Info("binding removed from capture")
 			c.State.Streams[stateKey] = &TableState{
 				Mode:     TableStateIgnore,
 				Metadata: json.RawMessage("null"), // Explicit null to clear out old metadata
@@ -310,10 +310,10 @@ func (c *Capture) reconcileStateWithBindings(_ context.Context) error {
 				}
 			}
 			if len(binding.Resource.PrimaryKey) > 0 {
-				logrus.WithFields(logrus.Fields{"stateKey": binding.StateKey, "key": binding.Resource.PrimaryKey}).Debug("key overriden by resource config")
+				log.WithFields(log.Fields{"stateKey": binding.StateKey, "key": binding.Resource.PrimaryKey}).Debug("key overriden by resource config")
 				state.KeyColumns = binding.Resource.PrimaryKey
 			}
-			logrus.WithField("stateKey", binding.StateKey).WithField("key", state.KeyColumns).Info("initialized missing KeyColumns state for only-changes binding")
+			log.WithField("stateKey", binding.StateKey).WithField("key", state.KeyColumns).Info("initialized missing KeyColumns state for only-changes binding")
 			state.dirty = true
 		}
 	}
@@ -324,9 +324,9 @@ func (c *Capture) reconcileStateWithBindings(_ context.Context) error {
 	// recovery path after WAL deletion, just hit the "Backfill Everything" button in the UI.
 	if allStreamsAreNew {
 		if len(c.Bindings) > 0 {
-			logrus.Info("all bindings are new, resetting replication cursor")
+			log.Info("all bindings are new, resetting replication cursor")
 		} else {
-			logrus.Info("capture has no bindings, resetting replication cursor")
+			log.Info("capture has no bindings, resetting replication cursor")
 		}
 		c.State.Cursor = ""
 	}
@@ -369,7 +369,7 @@ func (c *Capture) activatePendingStreams(ctx context.Context, discovery map[Stre
 		// remove it in the future once it will not break any otherwise-successful
 		// captures.
 		if !discoveryInfo.BaseTable {
-			logrus.WithField("stream", streamID).Warn("automatically ignoring a binding whose type is not `BASE TABLE`")
+			log.WithField("stream", streamID).Warn("automatically ignoring a binding whose type is not `BASE TABLE`")
 			state.Mode = TableStateIgnore
 			continue
 		}
@@ -386,33 +386,33 @@ func (c *Capture) activatePendingStreams(ctx context.Context, discovery map[Stre
 			}
 		}
 		if len(binding.Resource.PrimaryKey) > 0 {
-			logrus.WithFields(logrus.Fields{"stream": streamID, "key": binding.Resource.PrimaryKey}).Debug("key overriden by resource config")
+			log.WithFields(log.Fields{"stream": streamID, "key": binding.Resource.PrimaryKey}).Debug("key overriden by resource config")
 			state.KeyColumns = binding.Resource.PrimaryKey
 		}
 
 		// Select the appropriate state transition depending on the backfill mode in the resource config.
-		logrus.WithFields(logrus.Fields{"stream": streamID, "mode": binding.Resource.Mode}).Info("activating replication for stream")
+		log.WithFields(log.Fields{"stream": streamID, "mode": binding.Resource.Mode}).Info("activating replication for stream")
 		switch binding.Resource.Mode {
 		case BackfillModeAutomatic:
 			if discoveryInfo.UnpredictableKeyOrdering {
-				logrus.WithField("stream", streamID).Info("autoselected unfiltered (normal) backfill mode (database key ordering is unpredictable)")
+				log.WithField("stream", streamID).Info("autoselected unfiltered (normal) backfill mode (database key ordering is unpredictable)")
 				state.Mode = TableStateUnfilteredBackfill
 			} else {
-				logrus.WithField("stream", streamID).Info("autoselected precise backfill mode")
+				log.WithField("stream", streamID).Info("autoselected precise backfill mode")
 				state.Mode = TableStatePreciseBackfill
 			}
 		case BackfillModePrecise:
-			logrus.WithField("stream", streamID).Info("user selected precise backfill mode")
+			log.WithField("stream", streamID).Info("user selected precise backfill mode")
 			state.Mode = TableStatePreciseBackfill
 		case BackfillModeNormal:
-			logrus.WithField("stream", streamID).Info("user selected unfiltered (normal) backfill mode")
+			log.WithField("stream", streamID).Info("user selected unfiltered (normal) backfill mode")
 			state.Mode = TableStateUnfilteredBackfill
 		case BackfillModeWithoutKey:
-			logrus.WithField("stream", streamID).Info("user selected keyless backfill mode")
+			log.WithField("stream", streamID).Info("user selected keyless backfill mode")
 			state.Mode = TableStateKeylessBackfill
 			state.KeyColumns = nil
 		case BackfillModeOnlyChanges:
-			logrus.WithField("stream", streamID).Info("user selected only changes, skipping backfill")
+			log.WithField("stream", streamID).Info("user selected only changes, skipping backfill")
 			state.Mode = TableStateActive
 		default:
 			return fmt.Errorf("invalid backfill mode %q for stream %q", binding.Resource.Mode, streamID)
@@ -421,9 +421,9 @@ func (c *Capture) activatePendingStreams(ctx context.Context, discovery map[Stre
 		// Log an informational notice if the key we'll be using for a backfill differs from
 		// the discovered primary key of a table.
 		if state.Mode == TableStatePreciseBackfill || state.Mode == TableStateUnfilteredBackfill {
-			logrus.WithFields(logrus.Fields{"stream": streamID, "key": state.KeyColumns}).Debug("using backfill key")
+			log.WithFields(log.Fields{"stream": streamID, "key": state.KeyColumns}).Debug("using backfill key")
 			if !slices.Equal(state.KeyColumns, discoveryInfo.PrimaryKey) {
-				logrus.WithFields(logrus.Fields{
+				log.WithFields(log.Fields{
 					"stream":      streamID,
 					"backfillKey": state.KeyColumns,
 					"databaseKey": discoveryInfo.PrimaryKey,
@@ -453,7 +453,7 @@ func (c *Capture) activatePendingStreams(ctx context.Context, discovery map[Stre
 	for _, binding := range c.BindingsCurrentlyBackfilling() {
 		if !c.Database.ShouldBackfill(binding.StreamID) {
 			var state = c.State.Streams[binding.StateKey]
-			logrus.WithFields(logrus.Fields{
+			log.WithFields(log.Fields{
 				"stream":  binding.StreamID,
 				"scanned": state.Scanned,
 			}).Info("skipping backfill for stream")
@@ -476,13 +476,13 @@ func (c *Capture) activatePendingStreams(ctx context.Context, discovery map[Stre
 // The fenceAfter argument is passed to the underlying replication stream, so that
 // it can make sure to stream changes for at least that length of time.
 func (c *Capture) streamToFence(ctx context.Context, replStream ReplicationStream, fenceAfter time.Duration, reportFlush bool) error {
-	logrus.WithField("fenceAfter", fenceAfter.String()).Info("streaming to fence")
+	log.WithField("fenceAfter", fenceAfter.String()).Info("streaming to fence")
 
 	// Log a warning and perform replication diagnostics if we don't observe the next fence within a few minutes
 	var diagnosticsTimeout = time.AfterFunc(fenceAfter+automatedDiagnosticsTimeout, func() {
-		logrus.Warn("replication streaming has been ongoing for an unexpectedly long amount of time, running replication diagnostics")
+		log.Warn("replication streaming has been ongoing for an unexpectedly long amount of time, running replication diagnostics")
 		if err := c.Database.ReplicationDiagnostics(ctx); err != nil {
-			logrus.WithField("err", err).Error("replication diagnostics error")
+			log.WithField("err", err).Error("replication diagnostics error")
 		}
 	})
 	defer diagnosticsTimeout.Stop()
@@ -490,7 +490,7 @@ func (c *Capture) streamToFence(ctx context.Context, replStream ReplicationStrea
 	// When streaming completes (because we've either reached the fence or encountered an error),
 	// log the number of events which have been processed.
 	var eventCount int
-	defer func() { logrus.WithField("events", eventCount).Info("processed replication events") }()
+	defer func() { log.WithField("events", eventCount).Info("processed replication events") }()
 
 	return replStream.StreamToFence(ctx, fenceAfter, func(event DatabaseEvent) error {
 		eventCount++
@@ -522,7 +522,7 @@ func (c *Capture) handleReplicationEvent(event DatabaseEvent) error {
 		if binding == nil {
 			return nil // Should be impossible, but safe to ignore
 		}
-		logrus.WithFields(logrus.Fields{"stream": event.StreamID, "cause": event.Cause}).Info("marking table as missing")
+		log.WithFields(log.Fields{"stream": event.StreamID, "cause": event.Cause}).Info("marking table as missing")
 		c.State.Streams[binding.StateKey] = &TableState{
 			Mode:     TableStateMissing,
 			Metadata: json.RawMessage("null"), // Explicit null to clear out old metadata
@@ -543,7 +543,7 @@ func (c *Capture) handleReplicationEvent(event DatabaseEvent) error {
 
 		var stateKey = binding.StateKey
 		if state, ok := c.State.Streams[stateKey]; ok {
-			logrus.WithField("stateKey", stateKey).Trace("stream metadata updated")
+			log.WithField("stateKey", stateKey).Trace("stream metadata updated")
 			state.Metadata = event.Metadata
 			state.dirty = true
 			c.State.Streams[stateKey] = state
@@ -565,7 +565,7 @@ func (c *Capture) handleReplicationEvent(event DatabaseEvent) error {
 
 	// Decide what to do with the change event based on the state of the table.
 	if tableState == nil || tableState.Mode == "" || tableState.Mode == TableStateIgnore {
-		logrus.WithFields(logrus.Fields{
+		log.WithFields(log.Fields{
 			"stream": streamID,
 			"op":     change.Operation,
 		}).Debug("ignoring stream")
@@ -605,7 +605,7 @@ func (c *Capture) backfillStreams(ctx context.Context, discovery map[StreamID]*D
 	// might be concurrently backfilling.
 	if len(streams) != 0 {
 		var streamID = streams[rand.Intn(len(streams))]
-		logrus.WithFields(logrus.Fields{
+		log.WithFields(log.Fields{
 			"count":    len(streams),
 			"selected": streamID,
 		}).Info("backfilling streams")
@@ -656,14 +656,14 @@ func (c *Capture) backfillStream(ctx context.Context, streamID string, discovery
 	}
 
 	// Update stream state to reflect backfill results
-	logrus.WithFields(logrus.Fields{
+	log.WithFields(log.Fields{
 		"stream": streamID,
 		"rows":   eventCount,
 	}).Info("processed backfill rows")
 	var state = c.State.Streams[stateKey]
 	state.BackfilledCount += eventCount
 	if backfillComplete {
-		logrus.WithField("stream", streamID).Info("backfill completed")
+		log.WithField("stream", streamID).Info("backfill completed")
 		state.Mode = TableStateActive
 		state.Scanned = nil
 	} else {
@@ -694,7 +694,7 @@ func (c *Capture) emitChange(event *ChangeEvent) error {
 		record = event.Before // After is never used.
 	}
 	if record == nil {
-		logrus.WithField("op", event.Operation).Warn("change event data map is nil")
+		log.WithField("op", event.Operation).Warn("change event data map is nil")
 		record = make(map[string]interface{})
 	}
 	record["_meta"] = &meta
@@ -708,7 +708,7 @@ func (c *Capture) emitChange(event *ChangeEvent) error {
 
 	var bs, err = json.Marshal(record)
 	if err != nil {
-		logrus.WithFields(logrus.Fields{
+		log.WithFields(log.Fields{
 			"document": fmt.Sprintf("%#v", record),
 			"stream":   streamID,
 			"err":      err,
@@ -742,7 +742,7 @@ func (c *Capture) emitState() error {
 	if err != nil {
 		return fmt.Errorf("error serializing state checkpoint: %w", err)
 	}
-	logrus.WithField("state", string(bs)).Trace("emitting state update")
+	log.WithField("state", string(bs)).Trace("emitting state update")
 	return c.Output.Checkpoint(bs, true)
 }
 
@@ -782,7 +782,7 @@ func (c *Capture) handleAcknowledgement(ctx context.Context, count int, replStre
 
 	var cursor = c.pending.cursors[count-1]
 	c.pending.cursors = c.pending.cursors[count:]
-	logrus.WithFields(logrus.Fields{
+	log.WithFields(log.Fields{
 		"count":  count,
 		"cursor": cursor,
 	}).Debug("acknowledged up to cursor")

--- a/sqlcapture/discovery.go
+++ b/sqlcapture/discovery.go
@@ -11,7 +11,7 @@ import (
 
 	pc "github.com/estuary/flow/go/protocols/capture"
 	"github.com/invopop/jsonschema"
-	"github.com/sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 )
 
 // DiscoverCatalog queries the database and generates discovered bindings
@@ -41,7 +41,7 @@ func DiscoverCatalog(ctx context.Context, db Database) ([]*pc.Response_Discovere
 
 	var catalog []*pc.Response_Discovered_Binding
 	for _, table := range tables {
-		var logEntry = logrus.WithFields(logrus.Fields{
+		var logEntry = log.WithFields(log.Fields{
 			"table":      table.Name,
 			"namespace":  table.Schema,
 			"primaryKey": table.PrimaryKey,
@@ -107,7 +107,7 @@ func DiscoverCatalog(ctx context.Context, db Database) ([]*pc.Response_Discovere
 			if err != nil {
 				// Unhandled types are translated to the catch-all schema {} but with
 				// a description clarifying that we don't have a better translation.
-				logrus.WithFields(logrus.Fields{
+				log.WithFields(log.Fields{
 					"error": err,
 					"type":  column.DataType,
 				}).Debug("error translating column type to JSON schema")
@@ -217,7 +217,7 @@ func DiscoverCatalog(ctx context.Context, db Database) ([]*pc.Response_Discovere
 			return nil, fmt.Errorf("error marshalling schema JSON: %w", err)
 		}
 
-		logrus.WithFields(logrus.Fields{
+		log.WithFields(log.Fields{
 			"table":     table.Name,
 			"namespace": table.Schema,
 			"columns":   table.Columns,
@@ -254,7 +254,7 @@ func DiscoverCatalog(ctx context.Context, db Database) ([]*pc.Response_Discovere
 	}
 
 	if len(catalog) == 0 {
-		logrus.Warn("no tables discovered; note that tables in system schemas will not be discovered and must be added manually if desired")
+		log.Warn("no tables discovered; note that tables in system schemas will not be discovered and must be added manually if desired")
 	}
 
 	return catalog, err

--- a/sqlcapture/main.go
+++ b/sqlcapture/main.go
@@ -288,8 +288,6 @@ func (d *Driver) Discover(ctx context.Context, req *pc.Request_Discover) (*pc.Re
 // Pull is a very long lived RPC through which the Flow runtime and a
 // Driver cooperatively execute an unbounded number of transactions.
 func (d *Driver) Pull(open *pc.Request_Open, stream *boilerplate.PullOutput) error {
-	log.Debug("connector started")
-
 	var state PersistentState
 	if len(open.StateJson) > 0 {
 		if err := pf.UnmarshalStrict(open.StateJson, &state); err != nil {

--- a/sqlcapture/main.go
+++ b/sqlcapture/main.go
@@ -333,12 +333,14 @@ func (d *Driver) Pull(open *pc.Request_Open, stream *boilerplate.PullOutput) err
 	}
 
 	var ctx = stream.Context()
+	log.WithField("eventType", "connectorStatus").Info("Connecting to database")
 	db, err := d.Connect(ctx, string(open.Capture.Name), open.Capture.ConfigJson)
 	if err != nil {
 		return fmt.Errorf("error connecting to database: %w", err)
 	}
 	defer db.Close(ctx)
 
+	log.WithField("eventType", "connectorStatus").Info("Verifying capture requirements")
 	var errs = db.SetupPrerequisites(ctx)
 
 	// Build a mapping from stream IDs to capture binding information


### PR DESCRIPTION
**Description:**

Adds some very generic lifecycle status logging to `source-boilerplate` and more fine-grained but still pretty brief status messages throughout the SQL CDC capture logic. With these changes a generic Go capture with no other logging will produce:

    Initializing connector   # Protocol initialization. May not be worth logging?
    Starting capture         # When the '.Pull()' method of the driver is invoked
    Capture started          # When the '.Ready()' message indicates it's started

And a SQL CDC connector will produce something like:

    Initializing connector            # Very Briefly
    Starting capture                  # Very Briefly
    Connecting to database            # For however long this takes, usually not much
    Verifying capture requirements    # For however long this takes, usually not much
    Capture started                   # Very Briefly
    Discovering database tables       # For however long this takes, usually not much
    Catching up on CDC history        # For however long this takes, usually not much
    Backfilling 1 out of 5 tables
    Streaming live changes

Obviously we discussed doing more than this during standup today and we still want that stuff too, but this is the simplest most trivial implementation of status logging imaginable and it probably still delivers a good 80-90% of what users want to know, so I figured it was worth stopping here and uploading this much right away for discussion.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2556)
<!-- Reviewable:end -->
