### PR TITLE
source-salesforce-native: fix RestQueryManager to handle multiple large field chunks

### DIFF
--- a/source-salesforce-native/source_salesforce_native/shared.py
+++ b/source-salesforce-native/source_salesforce_native/shared.py
@@ -40,12 +40,3 @@ def build_query(
         query += f" ORDER BY {cursor_field} ASC"
 
     return query
-
-
-T = TypeVar('T')
-
-async def async_enumerate(iter: AsyncIterable[T], start: int = 0) -> AsyncIterator[tuple[int, T]]:
-    index = 0
-    async for item in iter:
-        yield index, item
-        index += 1


### PR DESCRIPTION
**Description:**

In the initial version of `source-salesforce-native`, I made an assumption that all REST API queries would use the same page size. It turns out I was wrong; Salesforce dynamically reduces the page size for a query depending on how much data it returns. This means that when the connector uses more than one `Query` to fetch fields, it's possible for those queries to have different page sizes, and fields for a specific record could be on different pages for each query (ex: a set of fields could be on page 5 of query 1 but the other set of fields could be on page 6 of query 2). This breaks assumptions the `RestQueryManager` relied on.

To fix this, the `RestQueryManager` now builds records up across pages of separate queries, keeping records in memory until they're completed & yielding them in the order they were originally received. Some effort has been made to reduce how many records are kept in memory (ex: try to keep each query's overall progress as close to each other as possible, delete a record after all fields are merged into it).

There's future room for improved memory usage if needed. Primarily, the connector could discard incomplete records that have a cursor value that's before the most recently yielded record's cursor value. These incomplete records were updated between kicking off the individual queries, so the current set of queries won't capture all fields for them & we'll fully capture them on a future incremental sweep. I don't anticipate this will be an issue since the window between kicking off queries should be fairly small, but it's something to keep in mind if we see memory issues later.

A side note, the `RestQueryManager` was built with the assumption that chunking up fields across separate would always use a page size of 2,000, making it a faster way to retrieve records than using the `FIELDS(ALL)` syntax that requires a `LIMIT 200` clause. However, since Salesforce dynamically reduces the page size, this assumption also may not hold water when there are a large number of fields. Another potential future improvement, it may be worth investigating using the `FIELDS(ALL)` syntax when we'd end up using more than one chunk & see if we'd yield completed records faster than explicitly specifying the fields.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

Tested on a local stack with a couple Salesforce accounts containing a non-trivial amount of data. Confirmed for the `RestQueryManager`:
- records are built up across pages of queries.
- records are yielded in ascending order of their cursor field.
- memory usage is not significantly different from before (hovered between 6-8% with a couple streams enabled).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2557)
<!-- Reviewable:end -->
