### PR TITLE
source-dynamodb: enforce global concurrency limits for requesting data

### DIFF
--- a/materialize-dynamodb/main.go
+++ b/materialize-dynamodb/main.go
@@ -1,12 +1,9 @@
 package main
 
 import (
-	awsHTTP "github.com/aws/aws-sdk-go-v2/aws/transport/http"
 	boilerplate "github.com/estuary/connectors/materialize-boilerplate"
 )
 
 func main() {
-	awsHTTP.DefaultHTTPTransportMaxIdleConns = 100        // From 100.
-	awsHTTP.DefaultHTTPTransportMaxIdleConnsPerHost = 100 // From 10.
 	boilerplate.RunMain(driver{})
 }

--- a/source-dynamodb/capture.go
+++ b/source-dynamodb/capture.go
@@ -13,6 +13,7 @@ import (
 	streamTypes "github.com/aws/aws-sdk-go-v2/service/dynamodbstreams/types"
 	boilerplate "github.com/estuary/connectors/source-boilerplate"
 	log "github.com/sirupsen/logrus"
+	"golang.org/x/sync/semaphore"
 	"golang.org/x/time/rate"
 )
 
@@ -51,6 +52,7 @@ type capture struct {
 	state captureState
 
 	listShardsLimiter *rate.Limiter
+	sem               *semaphore.Weighted
 }
 
 func (c *capture) getSegmentState(sk boilerplate.StateKey, segment int) segmentState {

--- a/source-dynamodb/main.go
+++ b/source-dynamodb/main.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/aws/retry"
-	awsHTTP "github.com/aws/aws-sdk-go-v2/aws/transport/http"
 	awsConfig "github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
@@ -113,7 +112,5 @@ type client struct {
 }
 
 func main() {
-	awsHTTP.DefaultHTTPTransportMaxIdleConns = 100        // From 100.
-	awsHTTP.DefaultHTTPTransportMaxIdleConnsPerHost = 100 // From 10.
 	boilerplate.RunMain(new(driver))
 }


### PR DESCRIPTION
**Description:**

Previously concurrency limits were enforced only on a per-table basis, which can
result in very large numbers of concurrent requests if there are a lot of active
tables.

This adds a semaphore that will be used across all tables for both backfill
processes and streaming processes to limit the maximum number of in-flight
network requests and emitting of retrieved documents. This should prevent
excessive amounts of new HTTP connections from being created if the client
connection pool is exceeded, and also mitigate possible OOM scenarios if many
concurrent processes are holding onto data at the same time.

Closes https://github.com/estuary/connectors/issues/2562

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2563)
<!-- Reviewable:end -->
