### PR TITLE
source-salesforce-native: misc. fixes

### DIFF
--- a/source-salesforce-native/source_salesforce_native/models.py
+++ b/source-salesforce-native/source_salesforce_native/models.py
@@ -21,6 +21,9 @@ from estuary_cdk.http import (
 )
 
 EARLIEST_VALID_DATE_IN_SALESFORCE = datetime(1700, 1, 1, tzinfo=UTC)
+# Salesforce was founded on 03FEB1999. As long as cursor values aren't backdated before this date (which only seems possible
+# for a select few of them), Salesforce's founding date should be a good start date for most users.
+SALESFORCE_FOUNDING_DATE = datetime(1999, 2, 3, tzinfo=UTC)
 
 
 OAUTH2_SPEC = OAuth2Spec(
@@ -109,12 +112,12 @@ class SalesforceResourceConfigWithSchedule(ResourceConfigWithSchedule):
 
 
 def default_start_date():
-    return EARLIEST_VALID_DATE_IN_SALESFORCE
+    return SALESFORCE_FOUNDING_DATE
 
 
 class EndpointConfig(BaseModel):
     start_date: AwareDatetime = Field(
-        description="UTC date and time in the format YYYY-MM-DDTHH:MM:SSZ. Any data generated before this date will not be replicated. If left blank, all data will be replicated.",
+        description="UTC date and time in the format YYYY-MM-DDTHH:MM:SSZ. Any data generated before this date will not be replicated. If left blank, the start date will be set to Salesforce's founding date (1999-02-03T00:00:00Z).",
         default_factory=default_start_date,
         ge=EARLIEST_VALID_DATE_IN_SALESFORCE,
     )
@@ -131,7 +134,7 @@ class EndpointConfig(BaseModel):
         window_size: Annotated[int, Field(
             description="Date window size for Bulk API 2.0 queries (in days). Typically left as the default unless Estuary Support or the connector logs indicate otherwise.",
             title="Window size",
-            default=180,
+            default=18250,
             gt=0,
         )]
 

--- a/source-salesforce-native/tests/snapshots/snapshots__spec__capture.stdout.json
+++ b/source-salesforce-native/tests/snapshots/snapshots__spec__capture.stdout.json
@@ -6,7 +6,7 @@
         "Advanced": {
           "properties": {
             "window_size": {
-              "default": 180,
+              "default": 18250,
               "description": "Date window size for Bulk API 2.0 queries (in days). Typically left as the default unless Estuary Support or the connector logs indicate otherwise.",
               "exclusiveMinimum": 0,
               "title": "Window size",
@@ -57,7 +57,7 @@
       },
       "properties": {
         "start_date": {
-          "description": "UTC date and time in the format YYYY-MM-DDTHH:MM:SSZ. Any data generated before this date will not be replicated. If left blank, all data will be replicated.",
+          "description": "UTC date and time in the format YYYY-MM-DDTHH:MM:SSZ. Any data generated before this date will not be replicated. If left blank, the start date will be set to Salesforce's founding date (1999-02-03T00:00:00Z).",
           "format": "date-time",
           "title": "Start Date",
           "type": "string"


### PR DESCRIPTION
**Description:**

After watching a couple `source-salesforce-native` tasks run in production, there are a handful of error causing backfills to progress slower than they could.

When processing large CSV files, the `BulkJobManager` would raise an error like:
```
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xe2 in position 1328047: unexpected end of data
```

This was happening because `BulkJobManager._process_csv_lines` was attempting to decode chunks completely when they arrived, and if a multi-byte character (like `"`) was split across chunks, decoding would fail and raise an error. Instead, the connector needs to incrementally decode chunks, carrying over bytes belonging to characters split across chunks. Python has a built-in incremental decoder to do just that, and the connector now uses it.

Another issue, the default `start_date` and `advanced.window_size` were too far in the past/too small. When a backfill started, it would check date windows 180 days wide starting in the year 1700. For a single stream to catch up to the present, it would have to spend ~600 requests of the daily 10,000 limit for the Bulk API. Even worse, these date windows before 1970 were empty - Salesforce data couldn't be created/updated before then, especially since Salesforce wasn't created until 1999. Moving the default start date up to the epoch and increasing the date window size should help avoid hitting the 10k request limit.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

Docs should be updated to reflect the new defaults. I have an open PR for the docs already, so I can make the updates there.

**Notes for reviewers:**

Tested on a local stack. Confirmed backfills no longer encounter the `UnicodeDecodeError`. Confirmed backfills do not use up as many Bulk API requests with the new default config settings.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2565)
<!-- Reviewable:end -->
