### PR TITLE
source-dynamodb: re-apply increased allowed connection limits

### DIFF
--- a/source-dynamodb/main.go
+++ b/source-dynamodb/main.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/aws/retry"
+	awsHTTP "github.com/aws/aws-sdk-go-v2/aws/transport/http"
 	awsConfig "github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
@@ -112,5 +113,7 @@ type client struct {
 }
 
 func main() {
+	awsHTTP.DefaultHTTPTransportMaxIdleConns = 100        // From 100.
+	awsHTTP.DefaultHTTPTransportMaxIdleConnsPerHost = 100 // From 10.
 	boilerplate.RunMain(new(driver))
 }


### PR DESCRIPTION
**Description:**

In 6d4def8 global concurrency limits were implemented for source-dynamodb. I think this did cut down on the number of new connections being created quite a bit, but there are still plenty being made, and so the increased idle connection limits are probably helpful to keep implemented.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2566)
<!-- Reviewable:end -->
