### PR TITLE
materialize-webhook: Make relativePath required in resource config

### DIFF
--- a/materialize-webhook/driver.go
+++ b/materialize-webhook/driver.go
@@ -61,7 +61,7 @@ func (c config) Validate() error {
 }
 
 type resource struct {
-	RelativePath string `json:"relativePath,omitempty" jsonschema:"title=Relative Path,description=Path which is joined with the base Address to build a complete URL" jsonschema_extras:"x-collection-name=true"`
+	RelativePath string `json:"relativePath" jsonschema:"title=Relative Path,description=Path which is joined with the base Address to build a complete URL" jsonschema_extras:"x-collection-name=true"`
 }
 
 func (r resource) Validate() error {


### PR DESCRIPTION
estuary/flow#2001 introduced a change to validate that the `x-collection-name` field is required by the resource spec JSON schema. This connector did not previously mark that as required, so here's a commit to fix that.

