### PR TITLE
source-sqlserver: Flag to tolerate missed changes

### DIFF
--- a/source-sqlserver/main.go
+++ b/source-sqlserver/main.go
@@ -46,6 +46,12 @@ var featureFlagDefaults = map[string]bool{
 	// When true, the capture will use a fence mechanism based on observing CDC worker runs
 	// and LSN positions rather than the old watermark write mechanism.
 	"read_only": true,
+
+	// When true, the connector will tolerate missed changes in the CDC stream and will not
+	// trigger an automatic re-backfill if changes go missing. This may be useful if the CDC
+	// event data starts to expire before it can be captured, but should generally only be
+	// needed in exceptional circumstances when recovering from some sort of major breakage.
+	"tolerate_missed_changes": false,
 }
 
 // Config tells the connector how to connect to and interact with the source database.


### PR DESCRIPTION
**Description:**

As described in the flag comment, when `tolerate_missed_changes` is true the connector will tolerate missed changes in the CDC stream and will not trigger an automatic re-backfill if changes go missing. This may be useful if the CDC event data starts to expire before it can be captured, but should generally only be needed in exceptional circumstances when recovering from some sort of major breakage.

**Workflow steps:**

If `tolerate_missed_changes` is set in a capture's feature flags, then _**if**_ there is no valid capture instance whose start LSN is <= the current capture resume LSN, we'll instead just select the capture instance with the earliest start LSN and use that.

To the best of my knowledge, if we then go ahead and try to poll changes from the selected CDC instance starting at our desired resume LSN, SQL Server won't error out and will just give us data starting with the earliest changes that are still available. Which is exactly the behavior we want here. If I'm incorrect then we'll see impacted tasks failing and we'll need some additional handling, but at minimum they won't trigger the "oh let me to automatically re-backfill the entire table" case and we'll have time to fix things further.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2576)
<!-- Reviewable:end -->
