### PR TITLE
source-{mysql,postgres,sqlserver}: Initial backfill cursor

### DIFF
--- a/source-mysql/replication.go
+++ b/source-mysql/replication.go
@@ -54,6 +54,12 @@ func (db *mysqlDatabase) ReplicationStream(ctx context.Context, startCursor stri
 		return nil, fmt.Errorf("invalid mysql address: %w", err)
 	}
 
+	// If we have no resume cursor but we do have an initial backfill cursor, use that as the start position.
+	if startCursor == "" && db.initialBackfillCursor != "" {
+		logrus.WithField("cursor", db.initialBackfillCursor).Info("using initial backfill cursor as start position")
+		startCursor = db.initialBackfillCursor
+	}
+
 	var pos mysql.Position
 	if startCursor != "" {
 		pos, err = parseCursor(startCursor)

--- a/source-oracle/main.go
+++ b/source-oracle/main.go
@@ -336,6 +336,11 @@ func decodeKeyFDB(t tuple.TupleElement) (interface{}, error) {
 }
 
 func (db *oracleDatabase) ShouldBackfill(streamID string) bool {
+	// Allow the setting "*.*" to skip backfilling any tables.
+	if db.config.Advanced.SkipBackfills == "*.*" {
+		return false
+	}
+
 	if db.config.Advanced.SkipBackfills != "" {
 		// This repeated splitting is a little inefficient, but this check is done at
 		// most once per table during connector startup and isn't really worth caching.

--- a/source-postgres/replication.go
+++ b/source-postgres/replication.go
@@ -37,6 +37,12 @@ func (db *postgresDatabase) ReplicationStream(ctx context.Context, startCursor s
 		return nil, fmt.Errorf("unable to connect to database for replication: %w", err)
 	}
 
+	// If we have no resume cursor but we do have an initial backfill cursor, use that as the start position.
+	if startCursor == "" && db.initialBackfillCursor != "" {
+		logrus.WithField("cursor", db.initialBackfillCursor).Info("using initial backfill cursor as start position")
+		startCursor = db.initialBackfillCursor
+	}
+
 	var slot, publication = db.config.Advanced.SlotName, db.config.Advanced.PublicationName
 
 	// Obtain the current WAL flush location on the server. We will need this either to

--- a/source-sqlserver/backfill.go
+++ b/source-sqlserver/backfill.go
@@ -13,6 +13,11 @@ import (
 // ShouldBackfill returns true if a given table's contents should be backfilled, given
 // that we intend to capture that table.
 func (db *sqlserverDatabase) ShouldBackfill(streamID string) bool {
+	// Allow the setting "*.*" to skip backfilling any tables.
+	if db.config.Advanced.SkipBackfills == "*.*" {
+		return false
+	}
+
 	if db.config.Advanced.SkipBackfills != "" {
 		// This repeated splitting is a little inefficient, but this check is done at
 		// most once per table during connector startup and isn't really worth caching.

--- a/source-sqlserver/replication.go
+++ b/source-sqlserver/replication.go
@@ -74,6 +74,12 @@ func (db *sqlserverDatabase) ReplicationStream(ctx context.Context, startCursor 
 		return nil, fmt.Errorf("error opening replication stream: %w", err)
 	}
 
+	// If we have no resume cursor but we do have an initial backfill cursor, use that as the start position.
+	if startCursor == "" && db.initialBackfillCursor != "" {
+		log.WithField("cursor", db.initialBackfillCursor).Info("using initial backfill cursor as start position")
+		startCursor = db.initialBackfillCursor
+	}
+
 	if startCursor == "" {
 		var maxLSN, err = cdcGetMaxLSN(ctx, db.conn)
 		if err != nil {

--- a/sqlcapture/capture.go
+++ b/sqlcapture/capture.go
@@ -174,7 +174,7 @@ func (c *Capture) Run(ctx context.Context) (err error) {
 		return fmt.Errorf("error reconciling capture state with bindings: %w", err)
 	}
 
-	log.WithField("eventType", "connectorStatus").Info("Initializing replication")
+	log.WithField("cursor", c.State.Cursor).WithField("eventType", "connectorStatus").Info("Initializing replication")
 	replStream, err := c.Database.ReplicationStream(ctx, c.State.Cursor)
 	if err != nil {
 		return fmt.Errorf("error creating replication stream: %w", err)


### PR DESCRIPTION
**Description:**

This commit adds two hidden features for internal use:
- For all three captures, setting the "Skip Backfills" advanced option to `*.*` will cause all tables to immediately transition to active without any backfilling. This lets us avoid needing to modify the capture mode for a whole bunch of bindings.
- For all three captures, it is possible to put a setting like `initial_backfill_cursor=12345` into the feature flags list. If this is done, the value `12345` will be used as the initial cursor value when there is no resume cursor, instead of the normal behavior of taking the current end of the WAL.

As a reminder, this is what cursor values look like for each DB:

    // MySQL
    binlog.12345:7890

    // PostgreSQL
    123/45678901

    // SQL Server
    ALUrCQADl2AAGA==

**Workflow steps:**

Set "Skip Backfills" to `"*.*"` and put `initial_backfill_cursor=XYZ` in the feature flags box when recreating a capture task which is intended to take over from a preexisting one at a specific WAL position.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2577)
<!-- Reviewable:end -->
