### PR TITLE
source-oracle{-batch}: fix primary key ordinal position discovery

### DIFF
--- a/source-oracle-batch/.snapshots/TestKeyDiscovery
+++ b/source-oracle-batch/.snapshots/TestKeyDiscovery
@@ -18,8 +18,8 @@ Binding 0:
         "required": [
           "_meta",
           "K_SMALLINT",
-          "K_INT",
           "K_BOOL",
+          "K_INT",
           "K_STR"
         ],
         "properties": {
@@ -64,8 +64,8 @@ Binding 0:
       },
       "key": [
         "/K_SMALLINT",
-        "/K_INT",
         "/K_BOOL",
+        "/K_INT",
         "/K_STR"
       ],
       "projections": null

--- a/source-oracle-batch/driver.go
+++ b/source-oracle-batch/driver.go
@@ -324,11 +324,11 @@ const defaultNumericPrecision = 38
 func discoverPrimaryKeys(ctx context.Context, db *sql.DB, discoverSchemas []string) ([]*discoveredPrimaryKey, error) {
 	var query = new(strings.Builder)
 
-	fmt.Fprintf(query, "SELECT t.owner, t.table_name, t.column_id, t.column_name,")
+	fmt.Fprintf(query, "SELECT t.owner, t.table_name, c.position, t.column_name,")
 	fmt.Fprintf(query, "t.data_type, t.data_precision, t.data_scale, t.data_length")
 	fmt.Fprintf(query, " FROM all_tab_columns t")
 	fmt.Fprintf(query, " INNER JOIN (")
-	fmt.Fprintf(query, "   SELECT c.owner, c.table_name, c.constraint_type, ac.column_name FROM all_constraints c")
+	fmt.Fprintf(query, "   SELECT c.owner, c.table_name, c.constraint_type, ac.column_name, ac.position FROM all_constraints c")
 	fmt.Fprintf(query, "     INNER JOIN all_cons_columns ac ON (")
 	fmt.Fprintf(query, "         c.constraint_name = ac.constraint_name")
 	fmt.Fprintf(query, "         AND c.table_name = ac.table_name")
@@ -339,7 +339,7 @@ func discoverPrimaryKeys(ctx context.Context, db *sql.DB, discoverSchemas []stri
 	fmt.Fprintf(query, " ON (t.owner = c.owner AND t.table_name = c.table_name AND t.column_name = c.column_name)")
 	fmt.Fprintf(query, " WHERE t.owner NOT IN ('SYS', 'SYSTEM', 'AUDSYS', 'CTXSYS', 'DVSYS', 'DBSFWUSER', 'DBSNMP', 'QSMADMIN_INTERNAL', 'LBACSYS', 'MDSYS', 'OJVMSYS', 'OLAPSYS', 'ORDDATA', 'ORDSYS', 'RDSADMIN', 'OUTLN', 'WMSYS', 'XDB', 'RMAN$CATALOG', 'MTSSYS', 'OML$METADATA', 'ODI_REPO_USER', 'RQSYS', 'PYQSYS', 'GGS_ADMIN', 'GSMADMIN_INTERNAL')")
 	fmt.Fprintf(query, " AND t.table_name NOT IN ('DBTOOLS$EXECUTION_HISTORY')")
-	fmt.Fprintf(query, " ORDER BY t.table_name, t.column_id")
+	fmt.Fprintf(query, " ORDER BY t.table_name, c.position")
 
 	rows, err := db.QueryContext(ctx, query.String())
 	if err != nil {

--- a/source-oracle-batch/main_test.go
+++ b/source-oracle-batch/main_test.go
@@ -268,7 +268,7 @@ func TestKeyDiscovery(t *testing.T) {
 
 	executeControlQuery(ctx, t, control, fmt.Sprintf("DROP TABLE %s", tableName))
 	t.Cleanup(func() { executeControlQuery(ctx, t, control, fmt.Sprintf("DROP TABLE %s", tableName)) })
-	executeControlQuery(ctx, t, control, fmt.Sprintf("CREATE TABLE %s(k_smallint SMALLINT, k_int INTEGER, k_bool NUMBER(1), k_str VARCHAR(8), data VARCHAR(200), PRIMARY KEY (k_smallint, k_int, k_bool, k_str))", tableName))
+	executeControlQuery(ctx, t, control, fmt.Sprintf("CREATE TABLE %s(k_smallint SMALLINT, k_int INTEGER, k_bool NUMBER(1), k_str VARCHAR(8), data VARCHAR(200), PRIMARY KEY (k_smallint, k_bool, k_int, k_str))", tableName))
 
 	cs.EndpointSpec.(*Config).Advanced.DiscoverSchemas = []string{"C##FLOW_TEST_LOGMINER"}
 	snapshotBindings(t, discoverStreams(ctx, t, cs, regexp.MustCompile(uniqueID)))

--- a/source-oracle/.snapshots/TestSchemaChanges-delete
+++ b/source-oracle/.snapshots/TestSchemaChanges-delete
@@ -5,5 +5,5 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"C%23%23FLOW_TEST_LOGMINER%2FT83287013":{"backfilled":1,"key_columns":["STATE","YEAR"],"mode":"Active"}},"cursor":"11111111"}
+{"bindingStateV1":{"C%23%23FLOW_TEST_LOGMINER%2FT83287013":{"backfilled":1,"key_columns":["YEAR","STATE"],"mode":"Active"}},"cursor":"11111111"}
 

--- a/source-oracle/.snapshots/TestSchemaChanges-init
+++ b/source-oracle/.snapshots/TestSchemaChanges-init
@@ -5,5 +5,5 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"C%23%23FLOW_TEST_LOGMINER%2FT83287013":{"backfilled":1,"key_columns":["STATE","YEAR"],"mode":"Active"}},"cursor":"11111111"}
+{"bindingStateV1":{"C%23%23FLOW_TEST_LOGMINER%2FT83287013":{"backfilled":1,"key_columns":["YEAR","STATE"],"mode":"Active"}},"cursor":"11111111"}
 

--- a/source-oracle/.snapshots/TestSchemaChanges-insert-after
+++ b/source-oracle/.snapshots/TestSchemaChanges-insert-after
@@ -5,5 +5,5 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"C%23%23FLOW_TEST_LOGMINER%2FT83287013":{"backfilled":1,"key_columns":["STATE","YEAR"],"mode":"Active"}},"cursor":"11111111"}
+{"bindingStateV1":{"C%23%23FLOW_TEST_LOGMINER%2FT83287013":{"backfilled":1,"key_columns":["YEAR","STATE"],"mode":"Active"}},"cursor":"11111111"}
 

--- a/source-oracle/.snapshots/TestSchemaChanges-insert-before
+++ b/source-oracle/.snapshots/TestSchemaChanges-insert-before
@@ -5,5 +5,5 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"C%23%23FLOW_TEST_LOGMINER%2FT83287013":{"backfilled":1,"key_columns":["STATE","YEAR"],"mode":"Active"}},"cursor":"11111111"}
+{"bindingStateV1":{"C%23%23FLOW_TEST_LOGMINER%2FT83287013":{"backfilled":1,"key_columns":["YEAR","STATE"],"mode":"Active"}},"cursor":"11111111"}
 

--- a/source-oracle/.snapshots/TestSchemaChanges-update
+++ b/source-oracle/.snapshots/TestSchemaChanges-update
@@ -5,5 +5,5 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"C%23%23FLOW_TEST_LOGMINER%2FT83287013":{"backfilled":1,"key_columns":["STATE","YEAR"],"mode":"Active"}},"cursor":"11111111"}
+{"bindingStateV1":{"C%23%23FLOW_TEST_LOGMINER%2FT83287013":{"backfilled":1,"key_columns":["YEAR","STATE"],"mode":"Active"}},"cursor":"11111111"}
 

--- a/source-oracle/discovery.go
+++ b/source-oracle/discovery.go
@@ -254,9 +254,9 @@ func joinObjectID(objectID, dataObjectID int) string {
 }
 
 const queryDiscoverColumns = `
-SELECT t.owner, t.table_name, t.column_id, t.column_name, t.nullable, t.data_type, t.data_precision, t.data_scale, t.data_length, NVL2(c.constraint_type, 1, 0) as COL_IS_PK FROM all_tab_columns t
+SELECT t.owner, t.table_name, c.position, t.column_name, t.nullable, t.data_type, t.data_precision, t.data_scale, t.data_length, NVL2(c.constraint_type, 1, 0) as COL_IS_PK FROM all_tab_columns t
     LEFT JOIN (
-            SELECT c.owner, c.table_name, c.constraint_type, ac.column_name FROM all_constraints c
+            SELECT c.owner, c.table_name, c.constraint_type, ac.column_name, ac.position FROM all_constraints c
                 INNER JOIN all_cons_columns ac ON (
                     c.constraint_name = ac.constraint_name
                     AND c.table_name = ac.table_name
@@ -313,7 +313,8 @@ func getColumns(ctx context.Context, conn *sql.DB, tables []*sqlcapture.Discover
 		var dataLength int
 		var dataPrecision sql.NullInt16
 		var dataType string
-		if err := rows.Scan(&sc.TableSchema, &sc.TableName, &sc.Index, &sc.Name, &isNullableStr, &dataType, &dataPrecision, &dataScale, &dataLength, &isPrimaryKey); err != nil {
+		var keyOrdinalPosition sql.NullInt16
+		if err := rows.Scan(&sc.TableSchema, &sc.TableName, &keyOrdinalPosition, &sc.Name, &isNullableStr, &dataType, &dataPrecision, &dataScale, &dataLength, &isPrimaryKey); err != nil {
 			return nil, nil, fmt.Errorf("scanning column: %w", err)
 		}
 
@@ -324,6 +325,10 @@ func getColumns(ctx context.Context, conn *sql.DB, tables []*sqlcapture.Discover
 			precision = dataPrecision.Int16
 		} else {
 			precision = defaultNumericPrecision
+		}
+
+		if keyOrdinalPosition.Valid {
+			sc.Index = int(keyOrdinalPosition.Int16)
 		}
 
 		var t reflect.Type


### PR DESCRIPTION
**Description:**

- We were using the wrong value for the ordinal position of the primary key in Oracle, updated the test to cover this case and fixed it on both source-oracle and source-oracle-batch

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2579)
<!-- Reviewable:end -->
