### PR TITLE
materializations: don't log apply action for non-causal apply action failures

### DIFF
--- a/materialize-boilerplate/apply.go
+++ b/materialize-boilerplate/apply.go
@@ -2,6 +2,7 @@ package boilerplate
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"slices"
 	"strings"
@@ -228,12 +229,14 @@ func runActions(ctx context.Context, actions []ActionApplyFn, descriptions []str
 			i := i
 			group.Go(func() error {
 				if err := a(groupCtx); err != nil {
-					logrus.WithFields(logrus.Fields{
-						"actionIndex":       i,
-						"totalActions":      len(actions),
-						"actionDescription": descriptions[i],
-						"error":             fmt.Sprintf("%+v", err),
-					}).Error("error executing apply action")
+					if !errors.Is(err, context.Canceled) {
+						logrus.WithFields(logrus.Fields{
+							"actionIndex":       i,
+							"totalActions":      len(actions),
+							"actionDescription": descriptions[i],
+							"error":             fmt.Sprintf("%+v", err),
+						}).Error("error executing apply action")
+					}
 					return err
 				}
 				return nil


### PR DESCRIPTION
**Description:**

The apply action that fails will cause a context cancellation, and all other actions will then fail due to that context being cancelled. This causes a bunch of log spam and makes it very difficult to see which action it was that failed for something other than a context cancellation.

This change will make it so only the erroring action will log out its action.
**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2580)
<!-- Reviewable:end -->
