### PR TITLE
source-{mysql,postgres,sqlserver}: Add 'force_reset_cursor=XYZ'

### DIFF
--- a/source-mysql/main.go
+++ b/source-mysql/main.go
@@ -95,9 +95,13 @@ func connectMySQL(ctx context.Context, name string, cfg json.RawMessage) (sqlcap
 	// The alternative would be that we'd have to add a visible advanced option for what is really just
 	// an internal mechanism for us to use.
 	var initialBackfillCursor string
+	var forceResetCursor string
 	for flag, value := range featureFlags {
 		if strings.HasPrefix(flag, "initial_backfill_cursor=") && value {
 			initialBackfillCursor = strings.TrimPrefix(flag, "initial_backfill_cursor=")
+		}
+		if strings.HasPrefix(flag, "force_reset_cursor=") && value {
+			forceResetCursor = strings.TrimPrefix(flag, "force_reset_cursor=")
 		}
 	}
 
@@ -105,6 +109,7 @@ func connectMySQL(ctx context.Context, name string, cfg json.RawMessage) (sqlcap
 		config:                &config,
 		featureFlags:          featureFlags,
 		initialBackfillCursor: initialBackfillCursor,
+		forceResetCursor:      forceResetCursor,
 	}
 	if err := db.connect(ctx); err != nil {
 		return nil, err
@@ -221,6 +226,7 @@ type mysqlDatabase struct {
 
 	featureFlags          map[string]bool // Parsed feature flag settings with defaults applied
 	initialBackfillCursor string          // When set, this cursor will be used instead of the current WAL end when a backfill resets the cursor
+	forceResetCursor      string          // When set, this cursor will be used instead of the checkpointed one regardless of backfilling. DO NOT USE unless you know exactly what you're doing.
 }
 
 func (db *mysqlDatabase) HistoryMode() bool {

--- a/source-mysql/replication.go
+++ b/source-mysql/replication.go
@@ -60,6 +60,12 @@ func (db *mysqlDatabase) ReplicationStream(ctx context.Context, startCursor stri
 		startCursor = db.initialBackfillCursor
 	}
 
+	// If the `force_reset_cursor=XYZ` hackery flag is set, use that as the start position regardless of anything else.
+	if db.forceResetCursor != "" {
+		logrus.WithField("cursor", db.forceResetCursor).Info("forcibly modified resume cursor")
+		startCursor = db.forceResetCursor
+	}
+
 	var pos mysql.Position
 	if startCursor != "" {
 		pos, err = parseCursor(startCursor)

--- a/source-postgres/main.go
+++ b/source-postgres/main.go
@@ -86,9 +86,13 @@ func connectPostgres(ctx context.Context, name string, cfg json.RawMessage) (sql
 	// The alternative would be that we'd have to add a visible advanced option for what is really just
 	// an internal mechanism for us to use.
 	var initialBackfillCursor string
+	var forceResetCursor string
 	for flag, value := range featureFlags {
 		if strings.HasPrefix(flag, "initial_backfill_cursor=") && value {
 			initialBackfillCursor = strings.TrimPrefix(flag, "initial_backfill_cursor=")
+		}
+		if strings.HasPrefix(flag, "force_reset_cursor=") && value {
+			forceResetCursor = strings.TrimPrefix(flag, "force_reset_cursor=")
 		}
 	}
 
@@ -96,6 +100,7 @@ func connectPostgres(ctx context.Context, name string, cfg json.RawMessage) (sql
 		config:                &config,
 		featureFlags:          featureFlags,
 		initialBackfillCursor: initialBackfillCursor,
+		forceResetCursor:      forceResetCursor,
 	}
 	if err := db.connect(ctx); err != nil {
 		return nil, err
@@ -271,6 +276,7 @@ type postgresDatabase struct {
 
 	featureFlags          map[string]bool // Parsed feature flag settings with defaults applied
 	initialBackfillCursor string          // When set, this cursor will be used instead of the current WAL end when a backfill resets the cursor
+	forceResetCursor      string          // When set, this cursor will be used instead of the checkpointed one regardless of backfilling. DO NOT USE unless you know exactly what you're doing.
 }
 
 func (db *postgresDatabase) HistoryMode() bool {

--- a/source-postgres/replication.go
+++ b/source-postgres/replication.go
@@ -43,6 +43,12 @@ func (db *postgresDatabase) ReplicationStream(ctx context.Context, startCursor s
 		startCursor = db.initialBackfillCursor
 	}
 
+	// If the `force_reset_cursor=XYZ` hackery flag is set, use that as the start position regardless of anything else.
+	if db.forceResetCursor != "" {
+		logrus.WithField("cursor", db.forceResetCursor).Info("forcibly modified resume cursor")
+		startCursor = db.forceResetCursor
+	}
+
 	var slot, publication = db.config.Advanced.SlotName, db.config.Advanced.PublicationName
 
 	// Obtain the current WAL flush location on the server. We will need this either to

--- a/source-sqlserver/replication.go
+++ b/source-sqlserver/replication.go
@@ -80,6 +80,12 @@ func (db *sqlserverDatabase) ReplicationStream(ctx context.Context, startCursor 
 		startCursor = db.initialBackfillCursor
 	}
 
+	// If the `force_reset_cursor=XYZ` hackery flag is set, use that as the start position regardless of anything else.
+	if db.forceResetCursor != "" {
+		log.WithField("cursor", db.forceResetCursor).Info("forcibly modified resume cursor")
+		startCursor = db.forceResetCursor
+	}
+
 	if startCursor == "" {
 		var maxLSN, err = cdcGetMaxLSN(ctx, db.conn)
 		if err != nil {


### PR DESCRIPTION
**Description:**

This is like the 'initial_backfill_cursor=XYZ' flag hackery, but it doesn't even require that you perform a backfill to trigger it. This should generally be set, and then you watch it take effect, and then you immediately publish another change to unset it again.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2581)
<!-- Reviewable:end -->
