### PR TITLE
materialize-boilerplate: collection name in backfill counter error

### DIFF
--- a/materialize-boilerplate/validate.go
+++ b/materialize-boilerplate/validate.go
@@ -71,9 +71,10 @@ func (v Validator) ValidateBinding(
 	if existingBinding != nil && existingBinding.Backfill > backfill {
 		// Sanity check: Don't allow backfill counters to decrease.
 		return nil, fmt.Errorf(
-			"backfill count %d is less than previously applied count of %d",
+			"backfill count %d is less than previously applied count of %d (%s)",
 			backfill,
 			existingBinding.Backfill,
+			existingBinding.Collection.Name,
 		)
 	}
 

--- a/materialize-boilerplate/validate_test.go
+++ b/materialize-boilerplate/validate_test.go
@@ -3,6 +3,7 @@ package boilerplate
 import (
 	"embed"
 	"encoding/json"
+	"fmt"
 	"path/filepath"
 	"reflect"
 	"strings"
@@ -294,7 +295,7 @@ func TestValidate(t *testing.T) {
 			existing,
 		)
 
-		require.ErrorContains(t, err, "backfill count 0 is less than previously applied count of 1")
+		require.ErrorContains(t, err, fmt.Sprintf("backfill count 0 is less than previously applied count of 1 (%s)", proposed.Bindings[0].Collection.Name))
 	})
 
 	t.Run("can't switch from delta to standard updates", func(t *testing.T) {


### PR DESCRIPTION
**Description:**

- It is hard for users to find out which collection is affected in large tasks

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2587)
<!-- Reviewable:end -->
