### PR TITLE
source-sqlserver: check for encryption of connection

### DIFF
--- a/source-sqlserver/prerequisites.go
+++ b/source-sqlserver/prerequisites.go
@@ -25,6 +25,7 @@ func (db *sqlserverDatabase) SetupPrerequisites(ctx context.Context) []error {
 		db.prerequisiteChangeTableCleanup,
 		db.prerequisiteCaptureInstanceManagement,
 		db.prerequisiteMaximumLSN,
+		db.prerequisiteConnectionEncryption,
 	}
 	if db.featureFlags["read_only"] {
 		checks = append(checks,
@@ -167,6 +168,28 @@ func (db *sqlserverDatabase) prerequisiteCaptureInstanceManagement(ctx context.C
 	} else if !hasPermission {
 		return fmt.Errorf("user %q does not have the \"db_owner\" role which is required for automatic change table cleanup", db.config.User)
 	}
+	return nil
+}
+
+func (db *sqlserverDatabase) prerequisiteConnectionEncryption(ctx context.Context) error {
+	var sessionId int
+	if err := db.conn.QueryRowContext(ctx, `SELECT @@SPID;`).Scan(&sessionId); err != nil {
+		log.Warn(fmt.Errorf("unable to query @@SPID: %w", err))
+	}
+
+	var encryptOption bool
+	if err := db.conn.QueryRowContext(ctx, `SELECT encrypt_option FROM sys.dm_exec_connections WHERE session_id = @@SPID;`).Scan(&encryptOption); err != nil {
+		log.WithFields(log.Fields{
+			"err":       err,
+			"sessionId": sessionId,
+		}).Debug("unable to query connection encryption option")
+	} else {
+		log.WithFields(log.Fields{
+			"encrypted": encryptOption,
+			"sessionId": sessionId,
+		}).Info("connection encryption option")
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
**Description:**

We already enable encryption and we have the default tlsmin=1.2, but a customer is insisting on making sure the connection is encrypted, so here is a log message to make sure the connection is encrypted.

There is no failure mode for this check, we always pass, and only log a DEBUG if we can't check for the status, this is intentionally a debug log to avoid freaking users out about encryption. Checking the status requires `VIEW SERVER STATE` permission which is quite broad and we will likely not have in most scenarios.

Logging the session ID allows an administrator from the customer side to check for encryption status themselves.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2589)
<!-- Reviewable:end -->
