### PR TITLE
estuary-cdk: reduce requests session timeout patch

### DIFF
--- a/estuary-cdk/estuary_cdk/requests_session_send_patch.py
+++ b/estuary-cdk/estuary_cdk/requests_session_send_patch.py
@@ -2,7 +2,7 @@ import requests
 
 # Airbyte's CDK does not set a timeout for HTTP requests, so we patch it to always have a timeout.
 
-DEFAULT_TIMEOUT = 60 * 60 * 6 # 6 hours
+DEFAULT_TIMEOUT = 60 * 60 * 2 # 2 hours
 
 lib_send = requests.Session.send
 


### PR DESCRIPTION
**Description:**

I've seen a handful of imported connectors hit the 6 hour session timeout limit recently. Reducing the timeout to 2 hours should help reduce the impact when this happens. I'd like to reduce it even further, but some imported connectors (at least `source-mixpanel-native` and its `export` stream) do take over an hour to complete a single request when it's streaming in a lot of records.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2591)
<!-- Reviewable:end -->
