### PR TITLE
source-postgres: Filter backfill XMIN on client side

### DIFF
--- a/source-sqlserver/backfill.go
+++ b/source-sqlserver/backfill.go
@@ -31,7 +31,7 @@ func (db *sqlserverDatabase) ShouldBackfill(streamID string) bool {
 }
 
 // ScanTableChunk fetches a chunk of rows from the specified table, resuming from the `resumeAfter` row key if non-nil.
-func (db *sqlserverDatabase) ScanTableChunk(ctx context.Context, info *sqlcapture.DiscoveryInfo, state *sqlcapture.TableState, callback func(event *sqlcapture.ChangeEvent) error) (bool, error) {
+func (db *sqlserverDatabase) ScanTableChunk(ctx context.Context, info *sqlcapture.DiscoveryInfo, state *sqlcapture.TableState, callback func(event *sqlcapture.ChangeEvent) error) (bool, []byte, error) {
 	var keyColumns = state.KeyColumns
 	var resumeAfter = state.Scanned
 	var schema, table = info.Schema, info.Name
@@ -62,10 +62,10 @@ func (db *sqlserverDatabase) ScanTableChunk(ctx context.Context, info *sqlcaptur
 		if resumeAfter != nil {
 			var resumeKey, err = sqlcapture.UnpackTuple(resumeAfter, decodeKeyFDB)
 			if err != nil {
-				return false, fmt.Errorf("error unpacking resume key for %q: %w", streamID, err)
+				return false, nil, fmt.Errorf("error unpacking resume key for %q: %w", streamID, err)
 			}
 			if len(resumeKey) != len(keyColumns) {
-				return false, fmt.Errorf("expected %d resume-key values but got %d", len(keyColumns), len(resumeKey))
+				return false, nil, fmt.Errorf("expected %d resume-key values but got %d", len(keyColumns), len(resumeKey))
 			}
 			log.WithFields(log.Fields{
 				"stream":     streamID,
@@ -82,20 +82,20 @@ func (db *sqlserverDatabase) ScanTableChunk(ctx context.Context, info *sqlcaptur
 			query = db.buildScanQuery(true, keyColumns, columnTypes, schema, table)
 		}
 	default:
-		return false, fmt.Errorf("invalid backfill mode %q", state.Mode)
+		return false, nil, fmt.Errorf("invalid backfill mode %q", state.Mode)
 	}
 
 	log.WithFields(log.Fields{"query": query, "args": args}).Debug("executing query")
 	rows, err := db.conn.QueryContext(ctx, query, args...)
 	if err != nil {
-		return false, fmt.Errorf("unable to execute query %q: %w", query, err)
+		return false, nil, fmt.Errorf("unable to execute query %q: %w", query, err)
 	}
 	defer rows.Close()
 
 	// Set up the necessary slices for generic scanning over query rows
 	cnames, err := rows.Columns()
 	if err != nil {
-		return false, err
+		return false, nil, err
 	}
 	var vals = make([]any, len(cnames))
 	var vptrs = make([]any, len(vals))
@@ -104,11 +104,12 @@ func (db *sqlserverDatabase) ScanTableChunk(ctx context.Context, info *sqlcaptur
 	}
 
 	// Iterate over the result set appending change events to the list
-	var resultRows int // Count of rows received within the current backfill chunk
+	var resultRows int    // Count of rows received within the current backfill chunk
+	var nextRowKey []byte // The row key from which a subsequent backfill chunk should resume
 	var rowOffset = state.BackfilledCount
 	for rows.Next() {
 		if err := rows.Scan(vptrs...); err != nil {
-			return false, fmt.Errorf("error scanning result row: %w", err)
+			return false, nil, fmt.Errorf("error scanning result row: %w", err)
 		}
 		var fields = make(map[string]interface{})
 		for idx, name := range cnames {
@@ -127,11 +128,13 @@ func (db *sqlserverDatabase) ScanTableChunk(ctx context.Context, info *sqlcaptur
 		} else {
 			rowKey, err = sqlcapture.EncodeRowKey(keyColumns, fields, columnTypes, encodeKeyFDB)
 			if err != nil {
-				return false, fmt.Errorf("error encoding row key for %q: %w", streamID, err)
+				return false, nil, fmt.Errorf("error encoding row key for %q: %w", streamID, err)
 			}
 		}
+		nextRowKey = rowKey
+
 		if err := db.translateRecordFields(columnTypes, fields); err != nil {
-			return false, fmt.Errorf("error backfilling table %q: %w", table, err)
+			return false, nil, fmt.Errorf("error backfilling table %q: %w", table, err)
 		}
 
 		log.WithField("fields", fields).Trace("got row")
@@ -153,14 +156,14 @@ func (db *sqlserverDatabase) ScanTableChunk(ctx context.Context, info *sqlcaptur
 			After:  fields,
 		}
 		if err := callback(event); err != nil {
-			return false, fmt.Errorf("error processing change event: %w", err)
+			return false, nil, fmt.Errorf("error processing change event: %w", err)
 		}
 		resultRows++
 		rowOffset++
 	}
 
 	var backfillComplete = resultRows < db.config.Advanced.BackfillChunkSize
-	return backfillComplete, rows.Err()
+	return backfillComplete, nextRowKey, rows.Err()
 }
 
 func (db *sqlserverDatabase) keylessScanQuery(_ *sqlcapture.DiscoveryInfo, schemaName, tableName string) string {

--- a/sqlcapture/interface.go
+++ b/sqlcapture/interface.go
@@ -140,7 +140,7 @@ type Database interface {
 
 	// ScanTableChunk fetches a chunk of rows from the specified table, resuming from the `resumeAfter` row key if non-nil.
 	// The `backfillComplete` boolean will be true after scanning the final chunk of the table.
-	ScanTableChunk(ctx context.Context, info *DiscoveryInfo, state *TableState, callback func(event *ChangeEvent) error) (backfillComplete bool, err error)
+	ScanTableChunk(ctx context.Context, info *DiscoveryInfo, state *TableState, callback func(event *ChangeEvent) error) (backfillComplete bool, nextRowKey []byte, err error)
 	// DiscoverTables queries the database for the latest information about tables available for capture.
 	DiscoverTables(ctx context.Context) (map[StreamID]*DiscoveryInfo, error)
 	// TranslateDBToJSONType returns JSON schema information about the provided database column type.


### PR DESCRIPTION
**Description:**

As currently implemented, XMIN backfills have a problem.

The fundamental issue with XMIN backfills as they exist today is that we literally just slap in a `WHERE {xmin is within the specified range} filter or filters into the backfill queries without changing anything else about our behavior. And the problem with this is that our backfill logic is built around the assumption that we are getting result rows back.

This turns out to not be the case when doing an XMIN backfill of a large table (the only kind worth using XMIN backfills on) whose primary keys are mostly ordered (that is, most writes will be at the very end of the table).

What happens in this case is we tell the DB "hey can you give me any rows newer than {min_xid} and stop after N" and the DB says "Sure, I can do that!" and then it goes off and scans over the entire table and if we're lucky it eventually finishes that, many hours later, and gives us back the first N new rows, after which point we can start issuing much faster queries to read out the rest of the new data after those ones.

But if anything interrupts that incremental scan, we have no recourse but to start all over again from the beginning.

And this is clearly dumb, because our backfill queries proceed according to primary key (or CTID) order, so if we _knew_ how far the scan had gotten we could tell the DB to start from that point. But the only way we learn about that progress is when we get back a result row, so that doesn't work right when the result set is heavily filtered.

This commit removes the DB-side filtering in favor of doing that filtering on the client side, and implements a bit of additional plumbing so that the backfill implementation can keep track of a "resume from here" key separate from any actual ChangeEvents it outputs.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2592)
<!-- Reviewable:end -->
