### PR TITLE
source-mongodb: advanced option to exclude specific collections from database change streams

### DIFF
--- a/source-mongodb/.snapshots/TestSpec
+++ b/source-mongodb/.snapshots/TestSpec
@@ -80,6 +80,11 @@
             "type": "boolean",
             "title": "Change Stream Exclusive Collection Filter",
             "description": "Add a MongoDB pipeline filter to database change streams to exclusively match events having enabled capture bindings. Should only be used if a small number of bindings are enabled."
+          },
+          "excludeCollections": {
+            "type": "string",
+            "title": "Exclude Collections",
+            "description": "Comma-separated list of collections to exclude from database change streams. Each one should be formatted as 'database_name:collection'. Cannot be set if exclusiveCollectionFilter is enabled."
           }
         },
         "additionalProperties": false,

--- a/source-mongodb/change_stream.go
+++ b/source-mongodb/change_stream.go
@@ -55,6 +55,7 @@ func (c *capture) initializeStreams(
 	changeStreamBindings []bindingInfo,
 	requestPreImages bool,
 	exclusiveCollectionFilter bool,
+	excludeCollections map[string][]string,
 ) ([]changeStream, error) {
 	var out []changeStream
 
@@ -100,6 +101,12 @@ func (c *capture) initializeStreams(
 			}
 
 			pl = append(pl, bson.D{{Key: "$match", Value: bson.D{{Key: "$or", Value: collectionFilters}}}})
+		} else if exclude := excludeCollections[db]; len(exclude) > 0 {
+			// Specifically exclude listed collections for this database.
+			pl = append(pl, bson.D{{Key: "$match", Value: bson.D{{
+				Key:   "ns.coll",
+				Value: bson.D{{Key: "$nin", Value: exclude}},
+			}}}})
 		}
 
 		opts := options.ChangeStream().SetFullDocument(options.UpdateLookup)

--- a/source-mongodb/change_stream_test.go
+++ b/source-mongodb/change_stream_test.go
@@ -142,7 +142,7 @@ func TestPullStream(t *testing.T) {
 				lastEventClusterTime: map[string]primitive.Timestamp{},
 			}
 
-			streams, err := c.initializeStreams(ctx, bindings, true, false)
+			streams, err := c.initializeStreams(ctx, bindings, true, false, map[string][]string{})
 			require.NoError(t, err)
 			require.Equal(t, 1, len(streams))
 


### PR DESCRIPTION
**Description:**

Sometimes a MongoDB collection is not being captured, but is part of a database
that is being captured. Normally this isn't a problem if the number and/or size
of change events for that MongoDB collection are small, but it can be
problematic otherwise & actually bog down the change stream processing.

This adds an advanced configuration option for these cases to allow MongoDB
collections to be exclude from the database change stream by way of a pipeline
filter.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2594)
<!-- Reviewable:end -->
