### PR TITLE
source-intercom-native: fix `conversation_parts` bug that could cause missing data

### DIFF
--- a/source-intercom-native/source_intercom_native/resources.py
+++ b/source-intercom-native/source_intercom_native/resources.py
@@ -46,12 +46,12 @@ FULL_REFRESH_RESOURCES: list[tuple[str, str, str, str | None]] = [
 # Each tuple contains the resource's name and its fetch function.
 INCREMENTAL_DATE_WINDOW_RESOURCES: list[tuple[str, IncrementalDateWindowResourceFetchChangesFn]] = [
     ('contacts', fetch_contacts),
-    ('conversation_parts', fetch_conversations_parts),
 ]
 
 # Incremental resources that don't use date windows.
 # Each tuple contains the resource's name and its fetch function.
 INCREMENTAL_RESOURCES: list[tuple[str, IncrementalResourceFetchChangesFn]] = [
+    ('conversation_parts', fetch_conversations_parts),
     ('tickets', fetch_tickets),
     ('conversations', fetch_conversations),
 ]

--- a/source-intercom-native/tests/snapshots/snapshots__capture__capture.stdout.json
+++ b/source-intercom-native/tests/snapshots/snapshots__capture__capture.stdout.json
@@ -598,7 +598,7 @@
       "state": "open",
       "statistics": {
         "count_assignments": 0,
-        "count_conversation_parts": 7,
+        "count_conversation_parts": 11,
         "count_reopens": 0,
         "first_admin_reply_at": null,
         "first_assignment_at": null,
@@ -639,7 +639,7 @@
         "type": "topic.list"
       },
       "type": "conversation",
-      "updated_at": 1734097743,
+      "updated_at": 1743439247,
       "waiting_since": null
     }
   ],


### PR DESCRIPTION
**Description:**

`conversation_parts` works by fetching parts of updated conversations, then only yielding the parts that have been updated since the last log cursor. This was done to avoid yielding conversation parts that were previously yielded. However, this strategy has potential to miss data if another part is added to a conversation that's beyond the date window the connector is currently checking & the conversation is updated again before the connector checks the next date window.

For example, say there's a conversation `123` that had a part added to it at `1742999957`. The connector is checking the window of `1742999856` - `1742999956`. Before the connector finishes that date window, conversation `123` is updated again and it's `updated_at` is pushed to a later time `1743000057`.

Next, the connector checks the date window `1742999956` - `1743000056`. Conversation `123` is not included in this date window, so it's not checked for parts updated after `1742999956`.

Next, the connector checks the date window `1743000056` - `1743000356`. Conversation `123` is included, but the part that was added at `1742999957` is not yielded because it was updated before the most recent log cursor.

This commit greatly simplifies this logic for `conversation_parts` and aligns its checkpointing strategy with `conversations`. If we detect an updated conversation, we yield all of its parts no matter when they were updated. This should ensure the connector captures all parts for updated conversations.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

Tested on a local stack. Confirmed `conversation_parts` now yields every part of an updated conversation & yields checkpoints after every page when it's safe to do so (like `conversations`).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2600)
<!-- Reviewable:end -->
