### PR TITLE
source-sqlserver: Assume primary on error

### DIFF
--- a/source-sqlserver/replication.go
+++ b/source-sqlserver/replication.go
@@ -1487,7 +1487,8 @@ func isReplicaDatabase(ctx context.Context, conn *sql.DB) (bool, error) {
 
 	var isReplica bool
 	if err := conn.QueryRowContext(ctx, query).Scan(&isReplica); err != nil {
-		return false, fmt.Errorf("error determining replica status: %w", err)
+		log.WithError(err).Warn("error determining replica status, assuming primary")
+		return false, nil
 	}
 	return isReplica, nil
 }


### PR DESCRIPTION
**Description:**

If the `isReplicaDatabase()` function encounters an error, it will now assume that this is not a replica instead of erroring out. The main reason we're likely to see this is on databases which don't even have a `sys.dm_hadr_database_replica_states` table, so erring on the side of assuming it's the primary DB should always be fine.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2601)
<!-- Reviewable:end -->
