### PR TITLE
source-sqlserver: Treat all text as unpredictable

### DIFF
--- a/source-sqlserver/discovery.go
+++ b/source-sqlserver/discovery.go
@@ -149,10 +149,8 @@ func (db *sqlserverDatabase) DiscoverTables(ctx context.Context) (map[sqlcapture
 	for _, info := range tableMap {
 		for _, colName := range info.PrimaryKey {
 			var dataType = info.Columns[colName].DataType
-			if textType, ok := dataType.(*sqlserverTextColumnType); ok {
-				if !predictableCollation(textType) {
-					info.UnpredictableKeyOrdering = true
-				}
+			if _, ok := dataType.(*sqlserverTextColumnType); ok {
+				info.UnpredictableKeyOrdering = true
 			} else if dataType == "numeric" || dataType == "decimal" {
 				info.UnpredictableKeyOrdering = true
 			}


### PR DESCRIPTION
**Description:**

We have a ton of fancy logic in SQL Server for attempting to encode text strings such that the encoded FDB tuples sort in a lexicographic order which actually matches the source DB's collation ordering of those strings.

And that mostly works! Except apparently it has a subtle flaw we completely overlooked for like a year or two now. See, we treat the encoded "sort key" as a one-way function of the input, so we encode a string as a tuple (<tag>, <sort key>, <original string>) and then throw away the sorting key and use the original string as the key on decode. And this works, as long as you assume that strings are necessarily either less than or greater than each other. Which is mostly the case for primary keys!

But it's not the case if the string is a non-final element of a composite primary key. In that case you could have two strings which are considered equal under the source DB collation yet have different representations. For instance "foo" and "FOO". And then even though the encoded _sort keys_ are considered equal, the value parts are unequal and that part comes before any _subsequent_ parts of the composite primary key and screws up the overall key ordering.

And while it's possible to fix that, at this point I'm thinking that we have invested way too much time and effort into SQL Server text collation, and this is getting really dumb considering that MySQL and PostgreSQL just treat all text collation ordering as unable to be predicted and default to imprecise backfill semantics, and *we have never had a single complaint about that*.

So let's just be consistent. SQL Server text primary keys will also cause us to default to imprecise backfill order.
