### PR TITLE
source-postgres: Sample 0.1% of XMIN-excluded rows

### DIFF
--- a/source-postgres/.snapshots/TestBackfillQueryGeneration
+++ b/source-postgres/.snapshots/TestBackfillQueryGeneration
@@ -1,0 +1,31 @@
+--- integer_key_precise ---
+SELECT * FROM "public"."users" ORDER BY "id" LIMIT 100;
+
+SELECT * FROM "public"."users" WHERE ("id") > ($1) ORDER BY "id" LIMIT 100;
+
+--- string_key_imprecise ---
+SELECT * FROM "public"."users" ORDER BY "name" LIMIT 100;
+
+SELECT * FROM "public"."users" WHERE ("name") > ($1) ORDER BY "name" LIMIT 100;
+
+--- composite_key ---
+SELECT * FROM "public"."users" ORDER BY "first_name", "last_name" LIMIT 100;
+
+SELECT * FROM "public"."users" WHERE ("first_name", "last_name") > ($1, $2) ORDER BY "first_name", "last_name" LIMIT 100;
+
+--- string_key_with_min_xid ---
+SELECT xmin::text AS xmin, * FROM "public"."users" WHERE ((((((xmin::text::bigint - 12345::bigint)<<32)>>32) > 0 AND xmin::text::bigint >= 3)) OR (RANDOM() < 0.001)) ORDER BY "name" LIMIT 100;
+
+SELECT xmin::text AS xmin, * FROM "public"."users" WHERE ("name") > ($1) AND ((((((xmin::text::bigint - 12345::bigint)<<32)>>32) > 0 AND xmin::text::bigint >= 3)) OR (RANDOM() < 0.001)) ORDER BY "name" LIMIT 100;
+
+--- string_key_with_min_max_xid ---
+SELECT xmin::text AS xmin, * FROM "public"."users" WHERE ((((((xmin::text::bigint - 12345::bigint)<<32)>>32) > 0 AND xmin::text::bigint >= 3) AND ((((67890::bigint - xmin::text::bigint)<<32)>>32) > 0 AND xmin::text::bigint >= 3)) OR (RANDOM() < 0.001)) ORDER BY "name" LIMIT 100;
+
+SELECT xmin::text AS xmin, * FROM "public"."users" WHERE ("name") > ($1) AND ((((((xmin::text::bigint - 12345::bigint)<<32)>>32) > 0 AND xmin::text::bigint >= 3) AND ((((67890::bigint - xmin::text::bigint)<<32)>>32) > 0 AND xmin::text::bigint >= 3)) OR (RANDOM() < 0.001)) ORDER BY "name" LIMIT 100;
+
+--- quoted_column_name ---
+SELECT * FROM "public"."special_users" ORDER BY "user-id", "group.name" COLLATE "C" LIMIT 100;
+
+SELECT * FROM "public"."special_users" WHERE ("user-id", "group.name" COLLATE "C") > ($1, $2) ORDER BY "user-id", "group.name" COLLATE "C" LIMIT 100;
+
+

--- a/source-postgres/.snapshots/TestKeylessBackfillQueryGeneration
+++ b/source-postgres/.snapshots/TestKeylessBackfillQueryGeneration
@@ -1,0 +1,7 @@
+--- no_xid_filtering ---
+SELECT ctid, * FROM "public"."users" WHERE ctid > $1 LIMIT 100;
+
+--- with_xid_filtering ---
+SELECT ctid, xmin::text AS xmin, * FROM "public"."users" WHERE ctid > $1 AND ((((((xmin::text::bigint - 12345::bigint)<<32)>>32) > 0 AND xmin::text::bigint >= 3) AND ((((67890::bigint - xmin::text::bigint)<<32)>>32) > 0 AND xmin::text::bigint >= 3)) OR (RANDOM() < 0.001)) LIMIT 100;
+
+

--- a/source-postgres/backfill_test.go
+++ b/source-postgres/backfill_test.go
@@ -1,0 +1,128 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/bradleyjkemp/cupaloy"
+)
+
+func TestBackfillQueryGeneration(t *testing.T) {
+	var testCases = []struct {
+		name           string
+		isPrecise      bool
+		keyColumns     []string
+		columnTypes    map[string]interface{}
+		schemaName     string
+		tableName      string
+		minBackfillXID string
+		maxBackfillXID string
+	}{
+		{
+			name:        "integer_key_precise",
+			isPrecise:   true,
+			keyColumns:  []string{"id"},
+			columnTypes: map[string]interface{}{"id": "integer"},
+			schemaName:  "public",
+			tableName:   "users",
+		},
+		{
+			name:        "string_key_imprecise",
+			isPrecise:   false,
+			keyColumns:  []string{"name"},
+			columnTypes: map[string]interface{}{"name": "text"},
+			schemaName:  "public",
+			tableName:   "users",
+		},
+		{
+			name:        "composite_key",
+			isPrecise:   false,
+			keyColumns:  []string{"first_name", "last_name"},
+			columnTypes: map[string]interface{}{"first_name": "varchar", "last_name": "varchar"},
+			schemaName:  "public",
+			tableName:   "users",
+		},
+		{
+			name:           "string_key_with_min_xid",
+			isPrecise:      false,
+			keyColumns:     []string{"name"},
+			columnTypes:    map[string]interface{}{"name": "text"},
+			schemaName:     "public",
+			tableName:      "users",
+			minBackfillXID: "12345",
+		},
+		{
+			name:           "string_key_with_min_max_xid",
+			isPrecise:      false,
+			keyColumns:     []string{"name"},
+			columnTypes:    map[string]interface{}{"name": "text"},
+			schemaName:     "public",
+			tableName:      "users",
+			minBackfillXID: "12345",
+			maxBackfillXID: "67890",
+		},
+		{
+			name:        "quoted_column_name",
+			isPrecise:   true,
+			keyColumns:  []string{"user-id", "group.name"},
+			columnTypes: map[string]interface{}{"user-id": "integer", "group.name": "text"},
+			schemaName:  "public",
+			tableName:   "special_users",
+		},
+	}
+
+	var result = new(strings.Builder)
+	for _, tc := range testCases {
+		var db = &postgresDatabase{
+			config: &Config{
+				Advanced: advancedConfig{
+					MinimumBackfillXID: tc.minBackfillXID,
+					MaximumBackfillXID: tc.maxBackfillXID,
+					BackfillChunkSize:  100,
+				},
+			},
+		}
+		var startQuery = db.buildScanQuery(true, tc.isPrecise, tc.keyColumns, tc.columnTypes, tc.schemaName, tc.tableName)
+		var subsequentQuery = db.buildScanQuery(false, tc.isPrecise, tc.keyColumns, tc.columnTypes, tc.schemaName, tc.tableName)
+
+		// Add to cumulative result string
+		result.WriteString("--- " + tc.name + " ---\n")
+		result.WriteString(startQuery + "\n\n")
+		result.WriteString(subsequentQuery + "\n\n")
+	}
+	cupaloy.SnapshotT(t, result.String())
+}
+
+func TestKeylessBackfillQueryGeneration(t *testing.T) {
+	var testCases = []struct {
+		name           string
+		minBackfillXID string
+		maxBackfillXID string
+	}{
+		{
+			name: "no_xid_filtering",
+		},
+		{
+			name:           "with_xid_filtering",
+			minBackfillXID: "12345",
+			maxBackfillXID: "67890",
+		},
+	}
+
+	var result = new(strings.Builder)
+	for _, tc := range testCases {
+		var db = &postgresDatabase{
+			config: &Config{
+				Advanced: advancedConfig{
+					MinimumBackfillXID: tc.minBackfillXID,
+					MaximumBackfillXID: tc.maxBackfillXID,
+					BackfillChunkSize:  100,
+				},
+			},
+		}
+		var query = db.keylessScanQuery(nil, "public", "users")
+		result.WriteString("--- " + tc.name + " ---\n")
+		result.WriteString(query + "\n\n")
+	}
+	cupaloy.SnapshotT(t, result.String())
+}


### PR DESCRIPTION
**Description:**

When doing an XMIN filtered backfill, instead of reading out all rows and filtering solely on the client side, we can instead read out all rows satisfying the XID range _plus_ 0.1% of rows that don't.

This provides enough data movement to permit incremental progress through a table, while still eliminating 99.9% of unnecessary network throughput and connector CPU usage.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2603)
<!-- Reviewable:end -->
