### PR TITLE
source-chargebee-native: support more streams and both product catalogs

### DIFF
--- a/source-chargebee-native/acmeCo/comments.schema.yaml
+++ b/source-chargebee-native/acmeCo/comments.schema.yaml
@@ -1,0 +1,45 @@
+---
+$defs:
+  CommentData:
+    additionalProperties: true
+    properties:
+      id:
+        title: Id
+        type: string
+    required:
+      - id
+    title: CommentData
+    type: object
+  Meta:
+    properties:
+      op:
+        default: u
+        description: "Operation type (c: Create, u: Update, d: Delete)"
+        enum:
+          - c
+          - u
+          - d
+        title: Op
+        type: string
+      row_id:
+        default: -1
+        description: "Row ID of the Document, counting up from zero, or -1 if not known"
+        title: Row Id
+        type: integer
+    title: Meta
+    type: object
+additionalProperties: true
+properties:
+  _meta:
+    $ref: "#/$defs/Meta"
+    default:
+      op: u
+      row_id: -1
+    description: Document metadata
+  comment:
+    $ref: "#/$defs/CommentData"
+required:
+  - comment
+title: Comment
+type: object
+x-infer-schema: true

--- a/source-chargebee-native/acmeCo/contacts.schema.yaml
+++ b/source-chargebee-native/acmeCo/contacts.schema.yaml
@@ -1,0 +1,31 @@
+---
+$defs:
+  Meta:
+    properties:
+      op:
+        default: u
+        description: "Operation type (c: Create, u: Update, d: Delete)"
+        enum:
+          - c
+          - u
+          - d
+        title: Op
+        type: string
+      row_id:
+        default: -1
+        description: "Row ID of the Document, counting up from zero, or -1 if not known"
+        title: Row Id
+        type: integer
+    title: Meta
+    type: object
+additionalProperties: true
+properties:
+  _meta:
+    $ref: "#/$defs/Meta"
+    default:
+      op: u
+      row_id: -1
+    description: Document metadata
+title: ChargebeeResource
+type: object
+x-infer-schema: true

--- a/source-chargebee-native/acmeCo/flow.yaml
+++ b/source-chargebee-native/acmeCo/flow.yaml
@@ -4,6 +4,14 @@ collections:
     schema: addons.schema.yaml
     key:
       - /addon/id
+  acmeCo/comments:
+    schema: comments.schema.yaml
+    key:
+      - /comment/id
+  acmeCo/contacts:
+    schema: contacts.schema.yaml
+    key:
+      - /_meta/row_id
   acmeCo/coupons:
     schema: coupons.schema.yaml
     key:
@@ -20,6 +28,10 @@ collections:
     schema: events.schema.yaml
     key:
       - /event/id
+  acmeCo/gifts:
+    schema: gifts.schema.yaml
+    key:
+      - /_meta/row_id
   acmeCo/hosted_pages:
     schema: hosted_pages.schema.yaml
     key:
@@ -40,6 +52,14 @@ collections:
     schema: plans.schema.yaml
     key:
       - /plan/id
+  acmeCo/promotional_credits:
+    schema: promotional_credits.schema.yaml
+    key:
+      - /promotional_credit/id
+  acmeCo/quote_line_groups:
+    schema: quote_line_groups.schema.yaml
+    key:
+      - /_meta/row_id
   acmeCo/quotes:
     schema: quotes.schema.yaml
     key:
@@ -52,10 +72,18 @@ collections:
     schema: subscriptions.schema.yaml
     key:
       - /subscription/id
+  acmeCo/subscriptions_with_scheduled_changes:
+    schema: subscriptions_with_scheduled_changes.schema.yaml
+    key:
+      - /_meta/row_id
   acmeCo/transactions:
     schema: transactions.schema.yaml
     key:
       - /transaction/id
+  acmeCo/unbilled_charges:
+    schema: unbilled_charges.schema.yaml
+    key:
+      - /_meta/row_id
   acmeCo/virtual_bank_accounts:
     schema: virtual_bank_accounts.schema.yaml
     key:

--- a/source-chargebee-native/acmeCo/gifts.schema.yaml
+++ b/source-chargebee-native/acmeCo/gifts.schema.yaml
@@ -1,0 +1,31 @@
+---
+$defs:
+  Meta:
+    properties:
+      op:
+        default: u
+        description: "Operation type (c: Create, u: Update, d: Delete)"
+        enum:
+          - c
+          - u
+          - d
+        title: Op
+        type: string
+      row_id:
+        default: -1
+        description: "Row ID of the Document, counting up from zero, or -1 if not known"
+        title: Row Id
+        type: integer
+    title: Meta
+    type: object
+additionalProperties: true
+properties:
+  _meta:
+    $ref: "#/$defs/Meta"
+    default:
+      op: u
+      row_id: -1
+    description: Document metadata
+title: ChargebeeResource
+type: object
+x-infer-schema: true

--- a/source-chargebee-native/acmeCo/promotional_credits.schema.yaml
+++ b/source-chargebee-native/acmeCo/promotional_credits.schema.yaml
@@ -1,0 +1,45 @@
+---
+$defs:
+  Meta:
+    properties:
+      op:
+        default: u
+        description: "Operation type (c: Create, u: Update, d: Delete)"
+        enum:
+          - c
+          - u
+          - d
+        title: Op
+        type: string
+      row_id:
+        default: -1
+        description: "Row ID of the Document, counting up from zero, or -1 if not known"
+        title: Row Id
+        type: integer
+    title: Meta
+    type: object
+  PromotionalCreditData:
+    additionalProperties: true
+    properties:
+      id:
+        title: Id
+        type: string
+    required:
+      - id
+    title: PromotionalCreditData
+    type: object
+additionalProperties: true
+properties:
+  _meta:
+    $ref: "#/$defs/Meta"
+    default:
+      op: u
+      row_id: -1
+    description: Document metadata
+  promotional_credit:
+    $ref: "#/$defs/PromotionalCreditData"
+required:
+  - promotional_credit
+title: PromotionalCredits
+type: object
+x-infer-schema: true

--- a/source-chargebee-native/acmeCo/quote_line_groups.schema.yaml
+++ b/source-chargebee-native/acmeCo/quote_line_groups.schema.yaml
@@ -1,0 +1,31 @@
+---
+$defs:
+  Meta:
+    properties:
+      op:
+        default: u
+        description: "Operation type (c: Create, u: Update, d: Delete)"
+        enum:
+          - c
+          - u
+          - d
+        title: Op
+        type: string
+      row_id:
+        default: -1
+        description: "Row ID of the Document, counting up from zero, or -1 if not known"
+        title: Row Id
+        type: integer
+    title: Meta
+    type: object
+additionalProperties: true
+properties:
+  _meta:
+    $ref: "#/$defs/Meta"
+    default:
+      op: u
+      row_id: -1
+    description: Document metadata
+title: ChargebeeResource
+type: object
+x-infer-schema: true

--- a/source-chargebee-native/acmeCo/subscriptions_with_scheduled_changes.schema.yaml
+++ b/source-chargebee-native/acmeCo/subscriptions_with_scheduled_changes.schema.yaml
@@ -1,0 +1,31 @@
+---
+$defs:
+  Meta:
+    properties:
+      op:
+        default: u
+        description: "Operation type (c: Create, u: Update, d: Delete)"
+        enum:
+          - c
+          - u
+          - d
+        title: Op
+        type: string
+      row_id:
+        default: -1
+        description: "Row ID of the Document, counting up from zero, or -1 if not known"
+        title: Row Id
+        type: integer
+    title: Meta
+    type: object
+additionalProperties: true
+properties:
+  _meta:
+    $ref: "#/$defs/Meta"
+    default:
+      op: u
+      row_id: -1
+    description: Document metadata
+title: ChargebeeResource
+type: object
+x-infer-schema: true

--- a/source-chargebee-native/acmeCo/unbilled_charges.schema.yaml
+++ b/source-chargebee-native/acmeCo/unbilled_charges.schema.yaml
@@ -1,0 +1,31 @@
+---
+$defs:
+  Meta:
+    properties:
+      op:
+        default: u
+        description: "Operation type (c: Create, u: Update, d: Delete)"
+        enum:
+          - c
+          - u
+          - d
+        title: Op
+        type: string
+      row_id:
+        default: -1
+        description: "Row ID of the Document, counting up from zero, or -1 if not known"
+        title: Row Id
+        type: integer
+    title: Meta
+    type: object
+additionalProperties: true
+properties:
+  _meta:
+    $ref: "#/$defs/Meta"
+    default:
+      op: u
+      row_id: -1
+    description: Document metadata
+title: ChargebeeResource
+type: object
+x-infer-schema: true

--- a/source-chargebee-native/source_chargebee_native/__init__.py
+++ b/source-chargebee-native/source_chargebee_native/__init__.py
@@ -14,8 +14,9 @@ from estuary_cdk.capture import (
 )
 from estuary_cdk.capture.common import ResourceConfig
 from estuary_cdk.http import HTTPMixin
+from estuary_cdk.flow import ValidationError
 
-from source_chargebee_native.resources import all_resources, validate_credentials
+from source_chargebee_native.resources import all_resources, validate_credentials_and_configuration
 from source_chargebee_native.models import (
     ConnectorState,
     EndpointConfig,
@@ -48,7 +49,19 @@ class Connector(
         log: Logger,
         validate: request.Validate[EndpointConfig, ResourceConfig],
     ) -> response.Validated:
-        await validate_credentials(log, self, validate.config)
+        await validate_credentials_and_configuration(log, self, validate.config)
+
+        if (
+            validate.lastCapture
+            and validate.lastCapture.config.config.get("product_catalog")
+            != validate.config.product_catalog
+        ):
+            raise ValidationError(
+                [
+                    "Cannot change the `product_catalog` property after the connector has been created."
+                ]
+            )
+
         resources = await all_resources(log, self, validate.config)
         resolved = common.resolve_bindings(validate.bindings, resources)
         return common.validated(resolved)

--- a/source-chargebee-native/source_chargebee_native/api.py
+++ b/source-chargebee-native/source_chargebee_native/api.py
@@ -11,6 +11,7 @@ from source_chargebee_native.models import (
     APIResponse,
     ChargebeeResource,
     IncrementalChargebeeResource,
+    AssociationConfig,
 )
 
 
@@ -37,15 +38,17 @@ async def _fetch_resource_data(
     offset: str | None = None,
     include_deleted: bool = False,
     resource_type: type[ChargebeeResourceType] = ChargebeeResource,
+    filter_params: dict[str, str] | None = None,
+    returns_list: bool = True,
 ) -> tuple[list[ChargebeeResourceType], str | None]:
     url = f"https://{site}.chargebee.com/api/v2/{resource_name}"
 
-    params: dict[str, int | str | list[int]] = {
-        "limit": MAX_PAGE_LIMIT,
-    }
+    params: dict[str, int | str | list[int]] = {}
 
-    if offset is not None:
-        params["offset"] = offset
+    if returns_list:
+        params["limit"] = MAX_PAGE_LIMIT
+        if offset is not None:
+            params["offset"] = offset
 
     if issubclass(resource_type, IncrementalChargebeeResource):
         cursor_field = resource_type.CURSOR_FIELD
@@ -62,6 +65,9 @@ async def _fetch_resource_data(
     if include_deleted:
         params["include_deleted"] = "true"
 
+    if filter_params:
+        params.update(filter_params)
+
     response = APIResponse[resource_type].model_validate_json(
         await http.request(log, url, params=params)
     )
@@ -77,6 +83,7 @@ async def snapshot_resource(
     site: str,
     resource_name: str,
     log: Logger,
+    filter_params: dict[str, str] | None = None,
 ) -> AsyncGenerator[ChargebeeResource, None]:
     offset = None
 
@@ -87,6 +94,7 @@ async def snapshot_resource(
             site,
             resource_name,
             offset=offset,
+            filter_params=filter_params,
         )
 
         if not resource_data:
@@ -170,7 +178,7 @@ async def fetch_resource_changes(
         has_results = True
 
         for doc in resource_data:
-            max_updated_at = max(max_updated_at, _ts_to_dt(doc.updated_at))
+            max_updated_at = max(max_updated_at, _ts_to_dt(doc.cursor_value))
 
             if doc.deleted:
                 doc.meta_ = doc.Meta(op="d")
@@ -181,6 +189,178 @@ async def fetch_resource_changes(
             break
 
         offset = next_offset
+
+    if has_results:
+        yield _dt_to_ts(max_updated_at + timedelta(seconds=1))
+
+
+async def _get_parent_ids(
+    http: HTTPSession,
+    site: str,
+    association_config: AssociationConfig,
+    log: Logger,
+) -> list[str]:
+    parent_ids = []
+    async for parent in snapshot_resource(
+        http,
+        site,
+        association_config.parent_resource,
+        log,
+        filter_params=association_config.parent_filter_params,
+    ):
+        parent_data = parent.model_dump()
+        parent_ids.append(
+            parent_data[association_config.parent_response_key][association_config.parent_key_field]
+        )
+
+    return parent_ids
+
+
+async def snapshot_associated_resource(
+    http: HTTPSession,
+    site: str,
+    association_config: AssociationConfig,
+    log: Logger,
+) -> AsyncGenerator[ChargebeeResource, None]:
+    parent_ids = await _get_parent_ids(
+        http,
+        site,
+        association_config,
+        log,
+    )
+
+    for parent_id in parent_ids:
+        endpoint = association_config.endpoint_pattern.format(
+            parent=association_config.parent_resource, id=parent_id
+        )
+
+        offset = None
+        while True:
+            resource_data, next_offset = await _fetch_resource_data(
+                http,
+                log,
+                site,
+                endpoint,
+                offset=offset,
+                returns_list=association_config.returns_list,
+            )
+
+            if not resource_data:
+                break
+
+            for doc in resource_data:
+                yield doc
+
+            if not next_offset:
+                break
+
+            offset = next_offset
+
+
+async def fetch_associated_resource_page(
+    http: HTTPSession,
+    site: str,
+    association_config: AssociationConfig,
+    resource_type: type[IncrementalChargebeeResource],
+    start_date: datetime,
+    log: Logger,
+    offset: PageCursor | None,
+    cutoff: LogCursor,
+) -> AsyncGenerator[ChargebeeResource | PageCursor, None]:
+    assert isinstance(cutoff, datetime)
+    assert isinstance(offset, str | None)
+
+    parent_ids = await _get_parent_ids(
+        http,
+        site,
+        association_config,
+        log,
+    )
+
+    for parent_id in parent_ids:
+        endpoint = association_config.endpoint_pattern.format(
+            parent=association_config.parent_resource, id=parent_id
+        )
+
+        child_data, next_offset = await _fetch_resource_data(
+            http,
+            log,
+            site,
+            endpoint,
+            start_date,
+            cutoff,
+            offset,
+            False,
+            resource_type,
+        )
+
+        if not child_data:
+            continue
+
+        for doc in child_data:
+            yield doc
+
+        if next_offset:
+            yield next_offset
+
+
+async def fetch_associated_resource_changes(
+    http: HTTPSession,
+    site: str,
+    association_config: AssociationConfig,
+    resource_type: type[IncrementalChargebeeResource],
+    log: Logger,
+    log_cursor: LogCursor,
+) -> AsyncGenerator[ChargebeeResource | LogCursor, None]:
+    assert isinstance(log_cursor, int)
+
+    max_updated_at = _ts_to_dt(log_cursor)
+    has_results = False
+    end_date = min(max_updated_at + timedelta(days=30), datetime.now(tz=UTC))
+
+    parent_ids = await _get_parent_ids(
+        http,
+        site,
+        association_config,
+        log,
+    )
+
+    for parent_id in parent_ids:
+        endpoint = association_config.endpoint_pattern.format(
+            parent=association_config.parent_resource, id=parent_id
+        )
+        offset = None
+
+        while True:
+            child_data, next_offset = await _fetch_resource_data(
+                http,
+                log,
+                site,
+                endpoint,
+                max_updated_at,
+                end_date,
+                offset,
+                True,
+                resource_type,
+            )
+
+            if not child_data:
+                break
+
+            has_results = True
+
+            for doc in child_data:
+                max_updated_at = max(max_updated_at, _ts_to_dt(doc.cursor_value))
+
+                if doc.deleted:
+                    doc.meta_ = doc.Meta(op="d")
+
+                yield doc
+
+            if not next_offset:
+                break
+
+            offset = next_offset
 
     if has_results:
         yield _dt_to_ts(max_updated_at + timedelta(seconds=1))

--- a/source-chargebee-native/source_chargebee_native/resources.py
+++ b/source-chargebee-native/source_chargebee_native/resources.py
@@ -11,7 +11,11 @@ from source_chargebee_native.models import (
     EndpointConfig,
     ChargebeeResource,
     IncrementalChargebeeResource,
+    AssociationConfig,
+    ChargebeeConfiguration,
+    APIResponse,
     Customer,
+    Comment,
     Subscription,
     Addon,
     AttachedItem,
@@ -26,6 +30,7 @@ from source_chargebee_native.models import (
     Order,
     PaymentSource,
     Plan,
+    PromotionalCredits,
     Quote,
     Transaction,
     VirtualBankAccount,
@@ -34,92 +39,136 @@ from source_chargebee_native.api import (
     snapshot_resource,
     fetch_resource_page,
     fetch_resource_changes,
+    snapshot_associated_resource,
+    fetch_associated_resource_page,
+    fetch_associated_resource_changes,
 )
 
 
-# TODO(jsmith): revisit
-# PARENT_CHILD_RESOURCES: dict[str, tuple[str, str]] = {
-#     "contacts": ("customers", "id"),  # (parent_resource, parent_key_field)
-#     "subscriptions_with_scheduled_changes": ("subscriptions", "id"),
-# }
+RESTRICTED_RESOURCES = [
+    "quotes",  # Requires Performance or Enterprise Chargebee subscription plan
+    "quote_line_groups",  # Requires Performance or Enterprise Chargebee subscription plan
+]
 
-STANDALONE_FULL_REFRESH_RESOURCES: dict[Literal["1.0", "2.0"], list[str]] = {
+COMMON_STANDALONE_FULL_REFRESH_RESOURCES = [
+    "site_migration_details",
+    "quote_line_groups",
+    "gifts",
+    "unbilled_charges",
+]
+
+FULL_REFRESH_RESOURCES: dict[Literal["1.0", "2.0"], list[str]] = {
     "1.0": [
-        # "comments", # TODO(jsmith): revisit - potentially incremental
-        # "gifts", # TODO(jsmith): revisit - potential client-side filtering
-        # "promotional_credits", # TODO(jsmith): revisit - potentially incremental
-        "site_migration_details",
-        # "unbilled_charges", # TODO(jsmith): revisit - potential client-side filtering
-        # "quote_line_groups", # TODO(jsmith): add this back in after figuring out the best way to handle 404 (quotes feature not enabled)
+        *COMMON_STANDALONE_FULL_REFRESH_RESOURCES,
     ],
     "2.0": [
-        # "comments", # TODO(jsmith): revisit - potentially incremental
-        # "differential_prices", # TODO(jsmith): revisit
-        # "gifts", # TODO(jsmith): revisit - potential client-side filtering
-        # "promotional_credits", # TODO(jsmith): revisit - potentially incremental
-        "site_migration_details",
-        # "unbilled_charges", # TODO(jsmith): revisit - potential client-side filtering
-        # "quote_line_groups", # TODO(jsmith): add this back in after figuring out the best way to handle 404 (quotes feature not enabled)
+        *COMMON_STANDALONE_FULL_REFRESH_RESOURCES,
+        "differential_prices",
     ],
 }
 
-# TODO(jsmith): revisit
-# CHILD_FULL_REFRESH_RESOURCES: list[str] = [
-#     "contacts",
-#     "subscriptions_with_scheduled_changes",
-# ]
+COMMON_INCREMENTAL_RESOURCES: list[tuple[str, type[IncrementalChargebeeResource]]] = [
+    ("comments", Comment),
+    ("coupons", Coupon),
+    ("credit_notes", CreditNote),
+    ("customers", Customer),
+    ("events", Event),
+    ("hosted_pages", HostedPage),
+    ("invoices", Invoice),
+    ("orders", Order),
+    ("payment_sources", PaymentSource),
+    ("promotional_credits", PromotionalCredits),
+    ("quotes", Quote),
+    ("subscriptions", Subscription),
+    ("transactions", Transaction),
+    ("virtual_bank_accounts", VirtualBankAccount),
+]
 
 INCREMENTAL_RESOURCES: dict[
     Literal["1.0", "2.0"], list[tuple[str, type[IncrementalChargebeeResource]]]
 ] = {
     "1.0": [
+        *COMMON_INCREMENTAL_RESOURCES,
         ("addons", Addon),
-        ("coupons", Coupon),
-        ("credit_notes", CreditNote),
-        ("customers", Customer),
-        ("events", Event),
-        ("hosted_pages", HostedPage),
-        ("invoices", Invoice),
-        ("orders", Order),
-        ("payment_sources", PaymentSource),
         ("plans", Plan),
-        ("quotes", Quote),
-        ("subscriptions", Subscription),
-        ("transactions", Transaction),
-        ("virtual_bank_accounts", VirtualBankAccount),
     ],
     "2.0": [
-        ("addons", Addon),
-        ("attached_items", AttachedItem),
-        ("coupons", Coupon),
-        ("credit_notes", CreditNote),
-        ("customers", Customer),
-        ("events", Event),
-        ("hosted_pages", HostedPage),
-        ("invoices", Invoice),
+        *COMMON_INCREMENTAL_RESOURCES,
         ("items", Item),
         ("item_prices", ItemPrice),
         ("item_families", ItemFamily),
-        ("orders", Order),
-        ("payment_sources", PaymentSource),
-        ("plans", Plan),
-        ("quotes", Quote),
-        ("subscriptions", Subscription),
-        ("transactions", Transaction),
-        ("virtual_bank_accounts", VirtualBankAccount),
     ],
 }
 
+COMMON_ASSOCIATED_FULL_REFRESH_RESOURCES: dict[str, AssociationConfig] = {
+    "contacts": AssociationConfig(
+        parent_resource="customers",
+        parent_response_key="customer",
+        parent_key_field="id",
+        endpoint_pattern="{parent}/{id}/contacts",
+        returns_list=True,
+    ),
+    "subscriptions_with_scheduled_changes": AssociationConfig(
+        parent_resource="subscriptions",
+        parent_response_key="subscription",
+        parent_key_field="id",
+        endpoint_pattern="{parent}/{id}/retrieve_with_scheduled_changes",
+        parent_filter_params={
+            "has_scheduled_changes[is]": "true"
+        },  # Filter to prevent 400 error when no scheduled changes
+        returns_list=False,
+    ),
+}
 
-async def validate_credentials(log: Logger, http: HTTPMixin, config: EndpointConfig):
+ASSOCIATED_FULL_REFRESH_RESOURCES: dict[Literal["1.0", "2.0"], dict[str, AssociationConfig]] = {
+    "1.0": {
+        **COMMON_ASSOCIATED_FULL_REFRESH_RESOURCES,
+    },
+    "2.0": {
+        **COMMON_ASSOCIATED_FULL_REFRESH_RESOURCES,
+    },
+}
+
+COMMON_ASSOCIATED_INCREMENTAL_RESOURCES: dict[
+    str, tuple[AssociationConfig, type[IncrementalChargebeeResource]]
+] = {}
+
+ASSOCIATED_INCREMENTAL_RESOURCES: dict[
+    Literal["1.0", "2.0"],
+    dict[str, tuple[AssociationConfig, type[IncrementalChargebeeResource]]],
+] = {
+    "1.0": {
+        **COMMON_ASSOCIATED_INCREMENTAL_RESOURCES,
+    },
+    "2.0": {
+        **COMMON_ASSOCIATED_INCREMENTAL_RESOURCES,
+        "attached_items": (
+            AssociationConfig(
+                parent_resource="items",
+                parent_response_key="item",
+                parent_key_field="id",
+                endpoint_pattern="{parent}/{id}/attached_items",
+                returns_list=True,
+            ),
+            AttachedItem,
+        ),
+    },
+}
+
+
+async def validate_credentials_and_configuration(
+    log: Logger, http: HTTPMixin, config: EndpointConfig
+):
     http.token_source = TokenSource(
         oauth_spec=None,
         credentials=config.credentials,
     )
-    url = f"https://{config.site}.chargebee.com/api/v2/customers"
+    url = f"https://{config.site}.chargebee.com/api/v2/configurations"
 
     try:
-        await http.request(log, url)
+        configuration = APIResponse[ChargebeeConfiguration].model_validate_json(
+            await http.request(log, url)
+        )
     except HTTPError as err:
         msg = "Unknown error occurred."
         if err.code == 401:
@@ -129,14 +178,45 @@ async def validate_credentials(log: Logger, http: HTTPMixin, config: EndpointCon
 
         raise ValidationError([msg])
 
+    if not configuration.configurations or len(configuration.configurations) != 1:
+        raise ValidationError(
+            [
+                "Encountered error validating configuration.\n\n"
+                "Please ensure that the provided configuration is correct."
+            ]
+        )
+
+    if configuration.configurations[0].product_catalog != config.product_catalog:
+        raise ValidationError(
+            [
+                "Encountered error validating configuration.\n\n"
+                "Please ensure that the provided product catalog version is correct.\n\n"
+                f"Provided: {config.product_catalog}, Actual: {configuration.configurations[0].product_catalog}."
+            ]
+        )
+
+
+async def check_feature_availability(
+    log: Logger,
+    http: HTTPMixin,
+    site: str,
+    feature: str,
+) -> bool:
+    try:
+        url = f"https://{site}.chargebee.com/api/v2/{feature}"
+        await http.request(log, url, params={"limit": 1})
+        return True
+    except HTTPError as err:
+        if err.code == 404:
+            return False
+        raise
+
 
 async def full_refresh_resources(
     log: Logger,
     http: HTTPMixin,
     config: EndpointConfig,
 ) -> list[common.Resource]:
-    resources = []
-
     def open_standalone(
         resource_name: str,
         binding: CaptureBinding[common.ResourceConfig],
@@ -159,22 +239,25 @@ async def full_refresh_resources(
             tombstone=ChargebeeResource(_meta=ChargebeeResource.Meta(op="d")),
         )
 
-    for name in STANDALONE_FULL_REFRESH_RESOURCES[config.product_catalog]:
-        resources.append(
-            common.Resource(
-                name=name,
-                key=["/_meta/row_id"],
-                model=ChargebeeResource,
-                open=functools.partial(open_standalone, name),
-                initial_state=common.ResourceState(),
-                initial_config=common.ResourceConfig(
-                    name=name, interval=timedelta(minutes=2)
-                ),
-                schema_inference=True,
-            )
-        )
+    available_resources = []
+    for name in FULL_REFRESH_RESOURCES[config.product_catalog]:
+        if name in RESTRICTED_RESOURCES:
+            if not await check_feature_availability(log, http, config.site, name):
+                continue
+        available_resources.append(name)
 
-    return resources
+    return [
+        common.Resource(
+            name=name,
+            key=["/_meta/row_id"],
+            model=ChargebeeResource,
+            open=functools.partial(open_standalone, name),
+            initial_state=common.ResourceState(),
+            initial_config=common.ResourceConfig(name=name, interval=timedelta(hours=1)),
+            schema_inference=True,
+        )
+        for name in available_resources
+    ]
 
 
 async def incremental_resources(
@@ -215,27 +298,154 @@ async def incremental_resources(
 
     cutoff = datetime.now(tz=UTC)
 
+    available_resources = []
+    for name, resource_type in INCREMENTAL_RESOURCES[config.product_catalog]:
+        if name in RESTRICTED_RESOURCES:
+            if not await check_feature_availability(log, http, config.site, name):
+                continue
+        available_resources.append((name, resource_type))
+
     return [
         common.Resource(
             name=name,
-            key=[resource_type.RESOURCE_KEY_JSON_PATH],
+            key=[resource_type.get_resource_key_json_path()],
             model=resource_type,
             open=functools.partial(open, name, resource_type),
             initial_state=common.ResourceState(
                 inc=common.ResourceState.Incremental(cursor=int(cutoff.timestamp())),
                 backfill=common.ResourceState.Backfill(cutoff=cutoff, next_page=None),
             ),
-            initial_config=common.ResourceConfig(
-                name=name, interval=timedelta(minutes=2)
-            ),
+            initial_config=common.ResourceConfig(name=name, interval=timedelta(minutes=2)),
             schema_inference=True,
         )
-        for name, resource_type in INCREMENTAL_RESOURCES[config.product_catalog]
+        for name, resource_type in available_resources
+    ]
+
+
+async def associated_full_refresh_resources(
+    log: Logger,
+    http: HTTPMixin,
+    config: EndpointConfig,
+) -> list[common.Resource]:
+    def open_child(
+        association_config: AssociationConfig,
+        binding: CaptureBinding[common.ResourceConfig],
+        binding_index: int,
+        state: common.ResourceState,
+        task: Task,
+        all_bindings,
+    ):
+        common.open_binding(
+            binding,
+            binding_index,
+            state,
+            task,
+            fetch_snapshot=functools.partial(
+                snapshot_associated_resource,
+                http,
+                config.site,
+                association_config,
+            ),
+            tombstone=ChargebeeResource(_meta=ChargebeeResource.Meta(op="d")),
+        )
+
+    available_resources = []
+    for name, association_config in ASSOCIATED_FULL_REFRESH_RESOURCES[
+        config.product_catalog
+    ].items():
+        if name in RESTRICTED_RESOURCES:
+            if not await check_feature_availability(log, http, config.site, name):
+                continue
+        available_resources.append((name, association_config))
+
+    return [
+        common.Resource(
+            name=name,
+            key=["/_meta/row_id"],
+            model=ChargebeeResource,
+            open=functools.partial(open_child, association_config),
+            initial_state=common.ResourceState(),
+            initial_config=common.ResourceConfig(name=name, interval=timedelta(minutes=2)),
+            schema_inference=True,
+        )
+        for name, association_config in available_resources
+    ]
+
+
+async def associated_incremental_resources(
+    log: Logger,
+    http: HTTPMixin,
+    config: EndpointConfig,
+) -> list[common.Resource]:
+    def open_incremental_child(
+        association_config: AssociationConfig,
+        resource_type: type[IncrementalChargebeeResource],
+        binding: CaptureBinding[common.ResourceConfig],
+        binding_index: int,
+        state: common.ResourceState,
+        task: Task,
+        all_bindings,
+    ):
+        common.open_binding(
+            binding,
+            binding_index,
+            state,
+            task,
+            fetch_page=functools.partial(
+                fetch_associated_resource_page,
+                http,
+                config.site,
+                association_config,
+                resource_type,
+                config.start_date,
+            ),
+            fetch_changes=functools.partial(
+                fetch_associated_resource_changes,
+                http,
+                config.site,
+                association_config,
+                resource_type,
+            ),
+        )
+
+    cutoff = datetime.now(tz=UTC)
+    available_resources = []
+    for name, (association_config, resource_type) in ASSOCIATED_INCREMENTAL_RESOURCES[
+        config.product_catalog
+    ].items():
+        if name in RESTRICTED_RESOURCES:
+            if not await check_feature_availability(log, http, config.site, name):
+                continue
+        available_resources.append((name, (association_config, resource_type)))
+
+    return [
+        common.Resource(
+            name=name,
+            key=[resource_type.get_resource_key_json_path()],
+            model=resource_type,
+            open=functools.partial(
+                open_incremental_child,
+                association_config,
+                resource_type,
+            ),
+            initial_state=common.ResourceState(
+                inc=common.ResourceState.Incremental(cursor=int(cutoff.timestamp())),
+                backfill=common.ResourceState.Backfill(cutoff=cutoff, next_page=None),
+            ),
+            initial_config=common.ResourceConfig(name=name, interval=timedelta(minutes=2)),
+            schema_inference=True,
+        )
+        for name, (
+            association_config,
+            resource_type,
+        ) in available_resources
     ]
 
 
 async def all_resources(
-    log: Logger, http: HTTPMixin, config: EndpointConfig
+    log: Logger,
+    http: HTTPMixin,
+    config: EndpointConfig,
 ) -> list[common.Resource]:
     http.token_source = TokenSource(
         oauth_spec=None,
@@ -245,4 +455,6 @@ async def all_resources(
     return [
         *await full_refresh_resources(log, http, config),
         *await incremental_resources(log, http, config),
+        *await associated_full_refresh_resources(log, http, config),
+        *await associated_incremental_resources(log, http, config),
     ]

--- a/source-chargebee-native/test.flow.yaml
+++ b/source-chargebee-native/test.flow.yaml
@@ -19,12 +19,24 @@ captures:
     bindings:
       - resource:
           name: site_migration_details
-          interval: PT2M
+          interval: PT1H
         target: acmeCo/site_migration_details
       - resource:
-          name: addons
+          name: quote_line_groups
           interval: PT2M
-        target: acmeCo/addons
+        target: acmeCo/quote_line_groups
+      - resource:
+          name: gifts
+          interval: PT1H
+        target: acmeCo/gifts
+      - resource:
+          name: unbilled_charges
+          interval: PT1H
+        target: acmeCo/unbilled_charges
+      - resource:
+          name: comments
+          interval: PT2M
+        target: acmeCo/comments
       - resource:
           name: coupons
           interval: PT2M
@@ -58,9 +70,9 @@ captures:
           interval: PT2M
         target: acmeCo/payment_sources
       - resource:
-          name: plans
+          name: promotional_credits
           interval: PT2M
-        target: acmeCo/plans
+        target: acmeCo/promotional_credits
       - resource:
           name: quotes
           interval: PT2M
@@ -77,3 +89,19 @@ captures:
           name: virtual_bank_accounts
           interval: PT2M
         target: acmeCo/virtual_bank_accounts
+      - resource:
+          name: addons
+          interval: PT2M
+        target: acmeCo/addons
+      - resource:
+          name: plans
+          interval: PT2M
+        target: acmeCo/plans
+      - resource:
+          name: contacts
+          interval: PT2M
+        target: acmeCo/contacts
+      - resource:
+          name: subscriptions_with_scheduled_changes
+          interval: PT2M
+        target: acmeCo/subscriptions_with_scheduled_changes

--- a/source-chargebee-native/tests/snapshots/snapshots__spec__stdout.json
+++ b/source-chargebee-native/tests/snapshots/snapshots__spec__stdout.json
@@ -58,9 +58,12 @@
           "type": "string"
         },
         "product_catalog": {
-          "const": "1.0",
           "default": "1.0",
           "description": "The product catalog version to use.",
+          "enum": [
+            "1.0",
+            "2.0"
+          ],
           "title": "Product Catalog",
           "type": "string"
         }


### PR DESCRIPTION
**Description:**

Addresses: #2524 
Follow up to the following PR: #2583 

This expands the connector's resource handling capabilities:

Resource Additions:
- Added new Pydantic models, bindings, etc. for:
  * Comments (with incremental sync support via created_at cursor)
  * Contacts
  * Gifts
  * Promotional Credits
  * Quote Line Groups (requires Performance/Enterprise plan)
  * Subscriptions with Scheduled Changes
  * Unbilled Charges

Configuration Improvements:
- Updated resource configurations to support both Product Catalog 1.0 and 2.0
- Enhanced validation logic for resource-specific configurations
- Added proper type hints and validation rules for all new schemas

API Integration Enhancements:
- Improved handling of associated resources with parent-child relationships
- Added support for filtering in associated resource queries
- Implemented proper cursor handling for incremental syncs

This enhancement provides broader coverage of Chargebee's API capabilities while maintaining proper error handling through the API's native responses.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2605)
<!-- Reviewable:end -->
