### PR TITLE
source-salesforce-native: increase csv field size limit

### DIFF
--- a/source-salesforce-native/source_salesforce_native/bulk_job_manager.py
+++ b/source-salesforce-native/source_salesforce_native/bulk_job_manager.py
@@ -2,9 +2,11 @@ import asyncio
 import aiocsv
 import aiocsv.protocols
 import codecs
+import csv
 from datetime import datetime
 from logging import Logger
 import re
+import sys
 from typing import Any, AsyncGenerator
 
 from estuary_cdk.http import HTTPSession, HTTPError
@@ -25,6 +27,11 @@ ATTEMPT_LOG_THRESHOLD = 10
 COUNT_HEADER = "Sforce-NumberOfRecords"
 CANNOT_FETCH_COMPOUND_DATA = r"Selecting compound data not supported in Bulk Query"
 NOT_SUPPORTED_BY_BULK_API = r"is not supported by the Bulk API"
+
+
+# Python's csv module has a default field size limit of 131,072 bytes, and it will raise an _csv.Error exception if a field value
+# is larger than that limit. Some users have fields larger than 131,072 bytes, so we max out the limit.
+csv.field_size_limit(sys.maxsize)
 
 
 class BulkJobError(RuntimeError):


### PR DESCRIPTION
**Description:**

Python's `csv` module has a default field size limit of 131,072 bytes, and it will raise a `_csv.Error` exception if a field value is larger than that limit. Some users have fields larger than 131,072 bytes in their Salesforce accounts (ex: entire email bodies), so we increase the limit to 10 MiB, which should be sufficiently large.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

Tested on a local stack with a Salesforce account that has field values over 131,072 bytes. Confirmed raising the field size limit to 10 MiB allowed the connector to progress, processing the CSV's rows & finishing the backfill.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2609)
<!-- Reviewable:end -->
