### PR TITLE
materialize-snowflake: a more thorough pipe cleanup

### DIFF
--- a/materialize-snowflake/snowflake.go
+++ b/materialize-snowflake/snowflake.go
@@ -893,7 +893,7 @@ func (d *transactor) deleteFiles(ctx context.Context, files []string) error {
 }
 
 func (d *transactor) dropPipe(ctx context.Context, pipeName string) error {
-	if _, err := d.db.ExecContext(ctx, fmt.Sprintf("DROP PIPE %s", pipeName)); err != nil {
+	if _, err := d.db.ExecContext(ctx, fmt.Sprintf("DROP PIPE IF EXISTS %s", pipeName)); err != nil {
 		return fmt.Errorf("dropping pipe %q: %w", pipeName, err)
 	}
 	return nil

--- a/tests/materialize/materialize-snowflake/snapshot.json
+++ b/tests/materialize/materialize-snowflake/snapshot.json
@@ -25,7 +25,7 @@
         "Table": "\"duplicate keys @ with spaces\"",
         "Query": "",
         "StagedDir": "<uuid>",
-        "PipeName": "ESTUARY_DB.ESTUARY_SCHEMA.FLOW_PIPE_4_00000000_FFFFFFFFFFFFFFFF_DUPLICATE_KEYS___WITH_SPACE_0BB06E303920B3D1",
+        "PipeName": "ESTUARY_DB.ESTUARY_SCHEMA.FLOW_PIPE_4_00000000_FFFFFFFFFFFFFFFF_DUPLICATE_KEYS___WITH_SPACES_68037661614FE673",
         "PipeFiles": [
           {
             "Path": "<uuid>",
@@ -38,7 +38,7 @@
         "Table": "duplicate_keys_delta",
         "Query": "",
         "StagedDir": "<uuid>",
-        "PipeName": "ESTUARY_DB.ESTUARY_SCHEMA.FLOW_PIPE_2_00000000_FFFFFFFFFFFFFFFF_DUPLICATE_KEYS_DELTA_C802629B0C479E73",
+        "PipeName": "ESTUARY_DB.ESTUARY_SCHEMA.FLOW_PIPE_2_00000000_FFFFFFFFFFFFFFFF_DUPLICATE_KEYS_DELTA_004B23684AF8F596",
         "PipeFiles": [
           {
             "Path": "<uuid>",
@@ -51,7 +51,7 @@
         "Table": "duplicate_keys_delta_exclude_flow_doc",
         "Query": "",
         "StagedDir": "<uuid>",
-        "PipeName": "ESTUARY_DB.ESTUARY_SCHEMA.FLOW_PIPE_3_00000000_FFFFFFFFFFFFFFFF_DUPLICATE_KEYS_DELTA_EXCLUD_16569B91BDEEA67F",
+        "PipeName": "ESTUARY_DB.ESTUARY_SCHEMA.FLOW_PIPE_3_00000000_FFFFFFFFFFFFFFFF_DUPLICATE_KEYS_DELTA_EXCLUDE_FLO_355992F22E69242D",
         "PipeFiles": [
           {
             "Path": "<uuid>",
@@ -136,7 +136,7 @@
         "Table": "\"duplicate keys @ with spaces\"",
         "Query": "",
         "StagedDir": "<uuid>",
-        "PipeName": "ESTUARY_DB.ESTUARY_SCHEMA.FLOW_PIPE_4_00000000_FFFFFFFFFFFFFFFF_DUPLICATE_KEYS___WITH_SPACE_0BB06E303920B3D1",
+        "PipeName": "ESTUARY_DB.ESTUARY_SCHEMA.FLOW_PIPE_4_00000000_FFFFFFFFFFFFFFFF_DUPLICATE_KEYS___WITH_SPACES_68037661614FE673",
         "PipeFiles": [
           {
             "Path": "<uuid>",
@@ -149,7 +149,7 @@
         "Table": "duplicate_keys_delta",
         "Query": "",
         "StagedDir": "<uuid>",
-        "PipeName": "ESTUARY_DB.ESTUARY_SCHEMA.FLOW_PIPE_2_00000000_FFFFFFFFFFFFFFFF_DUPLICATE_KEYS_DELTA_C802629B0C479E73",
+        "PipeName": "ESTUARY_DB.ESTUARY_SCHEMA.FLOW_PIPE_2_00000000_FFFFFFFFFFFFFFFF_DUPLICATE_KEYS_DELTA_004B23684AF8F596",
         "PipeFiles": [
           {
             "Path": "<uuid>",
@@ -162,7 +162,7 @@
         "Table": "duplicate_keys_delta_exclude_flow_doc",
         "Query": "",
         "StagedDir": "<uuid>",
-        "PipeName": "ESTUARY_DB.ESTUARY_SCHEMA.FLOW_PIPE_3_00000000_FFFFFFFFFFFFFFFF_DUPLICATE_KEYS_DELTA_EXCLUD_16569B91BDEEA67F",
+        "PipeName": "ESTUARY_DB.ESTUARY_SCHEMA.FLOW_PIPE_3_00000000_FFFFFFFFFFFFFFFF_DUPLICATE_KEYS_DELTA_EXCLUDE_FLO_355992F22E69242D",
         "PipeFiles": [
           {
             "Path": "<uuid>",
@@ -223,7 +223,7 @@
         "Table": "\"duplicate keys @ with spaces\"",
         "Query": "",
         "StagedDir": "<uuid>",
-        "PipeName": "ESTUARY_DB.ESTUARY_SCHEMA.FLOW_PIPE_4_00000000_FFFFFFFFFFFFFFFF_DUPLICATE_KEYS___WITH_SPACE_0BB06E303920B3D1",
+        "PipeName": "ESTUARY_DB.ESTUARY_SCHEMA.FLOW_PIPE_4_00000000_FFFFFFFFFFFFFFFF_DUPLICATE_KEYS___WITH_SPACES_68037661614FE673",
         "PipeFiles": [
           {
             "Path": "<uuid>",
@@ -236,7 +236,7 @@
         "Table": "duplicate_keys_delta",
         "Query": "",
         "StagedDir": "<uuid>",
-        "PipeName": "ESTUARY_DB.ESTUARY_SCHEMA.FLOW_PIPE_2_00000000_FFFFFFFFFFFFFFFF_DUPLICATE_KEYS_DELTA_C802629B0C479E73",
+        "PipeName": "ESTUARY_DB.ESTUARY_SCHEMA.FLOW_PIPE_2_00000000_FFFFFFFFFFFFFFFF_DUPLICATE_KEYS_DELTA_004B23684AF8F596",
         "PipeFiles": [
           {
             "Path": "<uuid>",
@@ -249,7 +249,7 @@
         "Table": "duplicate_keys_delta_exclude_flow_doc",
         "Query": "",
         "StagedDir": "<uuid>",
-        "PipeName": "ESTUARY_DB.ESTUARY_SCHEMA.FLOW_PIPE_3_00000000_FFFFFFFFFFFFFFFF_DUPLICATE_KEYS_DELTA_EXCLUD_16569B91BDEEA67F",
+        "PipeName": "ESTUARY_DB.ESTUARY_SCHEMA.FLOW_PIPE_3_00000000_FFFFFFFFFFFFFFFF_DUPLICATE_KEYS_DELTA_EXCLUDE_FLO_355992F22E69242D",
         "PipeFiles": [
           {
             "Path": "<uuid>",
@@ -281,7 +281,7 @@
             "Size": 238
           }
         ],
-        "PipeName": "ESTUARY_DB.ESTUARY_SCHEMA.FLOW_PIPE_4_00000000_FFFFFFFFFFFFFFFF_DUPLICATE_KEYS___WITH_SPACE_0BB06E303920B3D1",
+        "PipeName": "ESTUARY_DB.ESTUARY_SCHEMA.FLOW_PIPE_4_00000000_FFFFFFFFFFFFFFFF_DUPLICATE_KEYS___WITH_SPACES_68037661614FE673",
         "Query": "",
         "StagedDir": "<uuid>",
         "Table": "\"duplicate keys @ with spaces\"",
@@ -294,7 +294,7 @@
             "Size": 238
           }
         ],
-        "PipeName": "ESTUARY_DB.ESTUARY_SCHEMA.FLOW_PIPE_2_00000000_FFFFFFFFFFFFFFFF_DUPLICATE_KEYS_DELTA_C802629B0C479E73",
+        "PipeName": "ESTUARY_DB.ESTUARY_SCHEMA.FLOW_PIPE_2_00000000_FFFFFFFFFFFFFFFF_DUPLICATE_KEYS_DELTA_004B23684AF8F596",
         "Query": "",
         "StagedDir": "<uuid>",
         "Table": "duplicate_keys_delta",
@@ -307,7 +307,7 @@
             "Size": 116
           }
         ],
-        "PipeName": "ESTUARY_DB.ESTUARY_SCHEMA.FLOW_PIPE_3_00000000_FFFFFFFFFFFFFFFF_DUPLICATE_KEYS_DELTA_EXCLUD_16569B91BDEEA67F",
+        "PipeName": "ESTUARY_DB.ESTUARY_SCHEMA.FLOW_PIPE_3_00000000_FFFFFFFFFFFFFFFF_DUPLICATE_KEYS_DELTA_EXCLUDE_FLO_355992F22E69242D",
         "Query": "",
         "StagedDir": "<uuid>",
         "Table": "duplicate_keys_delta_exclude_flow_doc",


### PR DESCRIPTION
**Description:**

- Instead of only cleaning up pipes after finishing a transaction for that specific pipe name as compared to a previous version, clean up all extra `FLOW_PIPE_%` pipes that are not pending use by checkpoint items and share the same table name and keyBegin
- While I was at it, improved our `pipeExists` logic to be more precise and likely more performant as well
- Tested this with our integration tests

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2613)
<!-- Reviewable:end -->
