### PR TITLE
source-postgres: Handle timestamptz values with 5-digit years

### DIFF
--- a/source-postgres/.snapshots/TestLongYearTimestamps
+++ b/source-postgres/.snapshots/TestLongYearTimestamps
@@ -1,10 +1,12 @@
 # ================================
+# Collection "acmeCo/test/test/longyeartimestamps_15366164": 4 Documents
+# ================================
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"longyeartimestamps_15366164","loc":[11111111,11111111,11111111]}},"created_at":"<TIMESTAMP>","description":"Recent date","id":1}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"longyeartimestamps_15366164","loc":[11111111,11111111,11111111]}},"created_at":"<TIMESTAMP>","description":"Far future date","id":2}
+{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"longyeartimestamps_15366164","loc":[11111111,11111111,11111111],"txid":111111}},"created_at":"<TIMESTAMP>","description":"Another recent date","id":4}
+{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"longyeartimestamps_15366164","loc":[11111111,11111111,11111111],"txid":111111}},"created_at":"<TIMESTAMP>","description":"Even further future","id":5}
+# ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"test%2Flongyeartimestamps_15366164":{"backfilled":0,"key_columns":null,"mode":"Pending","scanned":null}},"cursor":"0/1111111"}
-# ================================
-# Captures Terminated With Errors
-# ================================
-error performing backfill: error scanning table "test.longyeartimestamps_15366164": unable to get row values: parsing time "12345-06-07 01:09:10-07" as "2006-01-02 15:04:05.999999999Z07": cannot parse "5-06-07 01:09:10-07" as "-"
-error performing backfill: error scanning table "test.longyeartimestamps_15366164": unable to get row values: parsing time "12345-06-07 01:09:10-07" as "2006-01-02 15:04:05.999999999Z07": cannot parse "5-06-07 01:09:10-07" as "-"
+{"bindingStateV1":{"test%2Flongyeartimestamps_15366164":{"backfilled":2,"key_columns":["id"],"mode":"Active"}},"cursor":"0/1111111"}
 

--- a/source-postgres/.snapshots/TestLongYearTimestamps
+++ b/source-postgres/.snapshots/TestLongYearTimestamps
@@ -1,0 +1,10 @@
+# ================================
+# Final State Checkpoint
+# ================================
+{"bindingStateV1":{"test%2Flongyeartimestamps_15366164":{"backfilled":0,"key_columns":null,"mode":"Pending","scanned":null}},"cursor":"0/1111111"}
+# ================================
+# Captures Terminated With Errors
+# ================================
+error performing backfill: error scanning table "test.longyeartimestamps_15366164": unable to get row values: parsing time "12345-06-07 01:09:10-07" as "2006-01-02 15:04:05.999999999Z07": cannot parse "5-06-07 01:09:10-07" as "-"
+error performing backfill: error scanning table "test.longyeartimestamps_15366164": unable to get row values: parsing time "12345-06-07 01:09:10-07" as "2006-01-02 15:04:05.999999999Z07": cannot parse "5-06-07 01:09:10-07" as "-"
+

--- a/source-postgres/.snapshots/TestLongYearTimestamps
+++ b/source-postgres/.snapshots/TestLongYearTimestamps
@@ -1,10 +1,10 @@
 # ================================
 # Collection "acmeCo/test/test/longyeartimestamps_15366164": 4 Documents
 # ================================
-{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"longyeartimestamps_15366164","loc":[11111111,11111111,11111111]}},"created_at":"<TIMESTAMP>","description":"Recent date","id":1}
-{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"longyeartimestamps_15366164","loc":[11111111,11111111,11111111]}},"created_at":"<TIMESTAMP>","description":"Far future date","id":2}
-{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"longyeartimestamps_15366164","loc":[11111111,11111111,11111111],"txid":111111}},"created_at":"<TIMESTAMP>","description":"Another recent date","id":4}
-{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"longyeartimestamps_15366164","loc":[11111111,11111111,11111111],"txid":111111}},"created_at":"<TIMESTAMP>","description":"Even further future","id":5}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"longyeartimestamps_15366164","loc":[11111111,11111111,11111111]}},"created_at":"2023-01-01T04:30:45-08:00","description":"Recent date","id":1}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"longyeartimestamps_15366164","loc":[11111111,11111111,11111111]}},"created_at":"0000-01-01T00:00:00Z","description":"Far future date","id":2}
+{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"longyeartimestamps_15366164","loc":[11111111,11111111,11111111],"txid":111111}},"created_at":"2024-05-15T02:30:00-07:00","description":"Another recent date","id":4}
+{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"longyeartimestamps_15366164","loc":[11111111,11111111,11111111],"txid":111111}},"created_at":"0000-01-01T00:00:00Z","description":"Even further future","id":5}
 # ================================
 # Final State Checkpoint
 # ================================

--- a/source-postgres/.snapshots/TestScanKeyTimestamps
+++ b/source-postgres/.snapshots/TestScanKeyTimestamps
@@ -4,7 +4,7 @@
 # ================================
 # Collection "acmeCo/test/test/scankeytimestamps_26812649": 1 Documents
 # ================================
-{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"scankeytimestamps_26812649","loc":[11111111,11111111,11111111]}},"data":"aood","ts":"<TIMESTAMP>"}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"scankeytimestamps_26812649","loc":[11111111,11111111,11111111]}},"data":"aood","ts":"1991-08-31T12:34:56Z"}
 # ================================
 # Final State Checkpoint
 # ================================
@@ -17,7 +17,7 @@
 # ================================
 # Collection "acmeCo/test/test/scankeytimestamps_26812649": 1 Documents
 # ================================
-{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"scankeytimestamps_26812649","loc":[11111111,11111111,11111111]}},"data":"xwxt","ts":"<TIMESTAMP>"}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"scankeytimestamps_26812649","loc":[11111111,11111111,11111111]}},"data":"xwxt","ts":"1991-08-31T12:34:56.111Z"}
 # ================================
 # Final State Checkpoint
 # ================================
@@ -30,7 +30,7 @@
 # ================================
 # Collection "acmeCo/test/test/scankeytimestamps_26812649": 1 Documents
 # ================================
-{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"scankeytimestamps_26812649","loc":[11111111,11111111,11111111]}},"data":"tpxi","ts":"<TIMESTAMP>"}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"scankeytimestamps_26812649","loc":[11111111,11111111,11111111]}},"data":"tpxi","ts":"1991-08-31T12:34:56.222Z"}
 # ================================
 # Final State Checkpoint
 # ================================
@@ -43,7 +43,7 @@
 # ================================
 # Collection "acmeCo/test/test/scankeytimestamps_26812649": 1 Documents
 # ================================
-{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"scankeytimestamps_26812649","loc":[11111111,11111111,11111111]}},"data":"jvqz","ts":"<TIMESTAMP>"}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"scankeytimestamps_26812649","loc":[11111111,11111111,11111111]}},"data":"jvqz","ts":"1991-08-31T12:34:56.333Z"}
 # ================================
 # Final State Checkpoint
 # ================================
@@ -56,7 +56,7 @@
 # ================================
 # Collection "acmeCo/test/test/scankeytimestamps_26812649": 1 Documents
 # ================================
-{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"scankeytimestamps_26812649","loc":[11111111,11111111,11111111]}},"data":"juwf","ts":"<TIMESTAMP>"}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"scankeytimestamps_26812649","loc":[11111111,11111111,11111111]}},"data":"juwf","ts":"1991-08-31T12:34:56.444Z"}
 # ================================
 # Final State Checkpoint
 # ================================
@@ -69,7 +69,7 @@
 # ================================
 # Collection "acmeCo/test/test/scankeytimestamps_26812649": 1 Documents
 # ================================
-{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"scankeytimestamps_26812649","loc":[11111111,11111111,11111111]}},"data":"znzn","ts":"<TIMESTAMP>"}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"scankeytimestamps_26812649","loc":[11111111,11111111,11111111]}},"data":"znzn","ts":"1991-08-31T12:34:56.555Z"}
 # ================================
 # Final State Checkpoint
 # ================================
@@ -82,7 +82,7 @@
 # ================================
 # Collection "acmeCo/test/test/scankeytimestamps_26812649": 1 Documents
 # ================================
-{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"scankeytimestamps_26812649","loc":[11111111,11111111,11111111]}},"data":"zocp","ts":"<TIMESTAMP>"}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"scankeytimestamps_26812649","loc":[11111111,11111111,11111111]}},"data":"zocp","ts":"1991-08-31T12:34:56.666Z"}
 # ================================
 # Final State Checkpoint
 # ================================
@@ -95,7 +95,7 @@
 # ================================
 # Collection "acmeCo/test/test/scankeytimestamps_26812649": 1 Documents
 # ================================
-{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"scankeytimestamps_26812649","loc":[11111111,11111111,11111111]}},"data":"pxoi","ts":"<TIMESTAMP>"}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"scankeytimestamps_26812649","loc":[11111111,11111111,11111111]}},"data":"pxoi","ts":"1991-08-31T12:34:56.777Z"}
 # ================================
 # Final State Checkpoint
 # ================================
@@ -108,7 +108,7 @@
 # ================================
 # Collection "acmeCo/test/test/scankeytimestamps_26812649": 1 Documents
 # ================================
-{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"scankeytimestamps_26812649","loc":[11111111,11111111,11111111]}},"data":"vdug","ts":"<TIMESTAMP>"}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"scankeytimestamps_26812649","loc":[11111111,11111111,11111111]}},"data":"vdug","ts":"1991-08-31T12:34:56.888Z"}
 # ================================
 # Final State Checkpoint
 # ================================
@@ -121,7 +121,7 @@
 # ================================
 # Collection "acmeCo/test/test/scankeytimestamps_26812649": 1 Documents
 # ================================
-{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"scankeytimestamps_26812649","loc":[11111111,11111111,11111111]}},"data":"xerk","ts":"<TIMESTAMP>"}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"scankeytimestamps_26812649","loc":[11111111,11111111,11111111]}},"data":"xerk","ts":"1991-08-31T12:34:56.999Z"}
 # ================================
 # Final State Checkpoint
 # ================================

--- a/source-postgres/.snapshots/TestSpecialTemporalValues
+++ b/source-postgres/.snapshots/TestSpecialTemporalValues
@@ -1,13 +1,13 @@
 # ================================
 # Collection "acmeCo/test/test/specialtemporalvalues_33220241": 8 Documents
 # ================================
-{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"specialtemporalvalues_33220241","loc":[11111111,11111111,11111111]}},"a_date":"1970-01-01","a_time":null,"a_timestamp":"<TIMESTAMP>","id":0}
-{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"specialtemporalvalues_33220241","loc":[11111111,11111111,11111111]}},"a_date":"9999-12-31","a_time":null,"a_timestamp":"<TIMESTAMP>","id":1}
-{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"specialtemporalvalues_33220241","loc":[11111111,11111111,11111111]}},"a_date":"0000-01-01","a_time":null,"a_timestamp":"<TIMESTAMP>","id":2}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"specialtemporalvalues_33220241","loc":[11111111,11111111,11111111]}},"a_date":"1970-01-01","a_time":null,"a_timestamp":"1970-01-01T00:00:00Z","id":0}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"specialtemporalvalues_33220241","loc":[11111111,11111111,11111111]}},"a_date":"9999-12-31","a_time":null,"a_timestamp":"9999-12-31T23:59:59Z","id":1}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"specialtemporalvalues_33220241","loc":[11111111,11111111,11111111]}},"a_date":"0000-01-01","a_time":null,"a_timestamp":"0000-01-01T00:00:00Z","id":2}
 {"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"specialtemporalvalues_33220241","loc":[11111111,11111111,11111111]}},"a_date":null,"a_time":"00:00:00Z","a_timestamp":null,"id":3}
-{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"specialtemporalvalues_33220241","loc":[11111111,11111111,11111111],"txid":111111}},"a_date":"1970-01-01","a_time":null,"a_timestamp":"<TIMESTAMP>","id":10}
-{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"specialtemporalvalues_33220241","loc":[11111111,11111111,11111111],"txid":111111}},"a_date":"9999-12-31","a_time":null,"a_timestamp":"<TIMESTAMP>","id":11}
-{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"specialtemporalvalues_33220241","loc":[11111111,11111111,11111111],"txid":111111}},"a_date":"0000-01-01","a_time":null,"a_timestamp":"<TIMESTAMP>","id":12}
+{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"specialtemporalvalues_33220241","loc":[11111111,11111111,11111111],"txid":111111}},"a_date":"1970-01-01","a_time":null,"a_timestamp":"1970-01-01T00:00:00Z","id":10}
+{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"specialtemporalvalues_33220241","loc":[11111111,11111111,11111111],"txid":111111}},"a_date":"9999-12-31","a_time":null,"a_timestamp":"9999-12-31T23:59:59Z","id":11}
+{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"specialtemporalvalues_33220241","loc":[11111111,11111111,11111111],"txid":111111}},"a_date":"0000-01-01","a_time":null,"a_timestamp":"0000-01-01T00:00:00Z","id":12}
 {"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"specialtemporalvalues_33220241","loc":[11111111,11111111,11111111],"txid":111111}},"a_date":null,"a_time":"00:00:00Z","a_timestamp":null,"id":13}
 # ================================
 # Final State Checkpoint

--- a/source-postgres/main_test.go
+++ b/source-postgres/main_test.go
@@ -107,7 +107,6 @@ func (tb *testBackend) lowerTuningParameters(t testing.TB) {
 
 func (tb *testBackend) CaptureSpec(ctx context.Context, t testing.TB, streamMatchers ...*regexp.Regexp) *st.CaptureSpec {
 	var sanitizers = make(map[string]*regexp.Regexp)
-	sanitizers[`"<TIMESTAMP>"`] = regexp.MustCompile(`"[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(\.[0-9]+)?(Z|-[0-9]+:[0-9]+)"`)
 	sanitizers[`"loc":[11111111,11111111,11111111]`] = regexp.MustCompile(`"loc":\[(-1|[0-9]+),[0-9]+,[0-9]+\]`)
 	sanitizers[`"cursor":"0/1111111"`] = regexp.MustCompile(`"cursor":"[0-9A-F]+/[0-9A-F]+"`)
 	sanitizers[`"ts_ms":1111111111111`] = regexp.MustCompile(`"ts_ms":[0-9]+`)


### PR DESCRIPTION
**Description:**

This was a regression, previously 5-digit years worked correctly because we handled parsing issues during replication and during backfills the values came in as Unix microsecond timestamps which didn't need parsing. A while back we switched that over to use the text representation in backfills as well (because that way the timestamps from backfills and replication are consistently represented with the same time zone), but that meant that 5-digit years were no longer handled correctly and it took this long for somebody to hit that edge case.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2619)
<!-- Reviewable:end -->
