### PR TITLE
source-postgres: Feature flag for truly multidimensional arrays

### DIFF
--- a/source-postgres/.snapshots/TestMultidimensionalArrays-Capture
+++ b/source-postgres/.snapshots/TestMultidimensionalArrays-Capture
@@ -1,0 +1,26 @@
+# ================================
+# Collection "acmeCo/test/test/multidimensionalarrays_82375147": 18 Documents
+# ================================
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"multidimensionalarrays_82375147","loc":[11111111,11111111,11111111]}},"arr":null,"id":1}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"multidimensionalarrays_82375147","loc":[11111111,11111111,11111111]}},"arr":[],"id":2}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"multidimensionalarrays_82375147","loc":[11111111,11111111,11111111]}},"arr":[],"id":3}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"multidimensionalarrays_82375147","loc":[11111111,11111111,11111111]}},"arr":["x"],"id":4}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"multidimensionalarrays_82375147","loc":[11111111,11111111,11111111]}},"arr":["x"],"id":5}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"multidimensionalarrays_82375147","loc":[11111111,11111111,11111111]}},"arr":["a","b","c","d"],"id":6}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"multidimensionalarrays_82375147","loc":[11111111,11111111,11111111]}},"arr":["a","b","c","d"],"id":7}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"multidimensionalarrays_82375147","loc":[11111111,11111111,11111111]}},"arr":["a","b","c","d","e","f","g","h","i","j","k","l","m","n","o","p","q","r","s","t","u","v","w","x"],"id":8}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"multidimensionalarrays_82375147","loc":[11111111,11111111,11111111]}},"arr":["a","b","c","d","e","f","g","h","i","j","k","l","m","n","o","p","q","r","s","t","u","v","w","x"],"id":9}
+{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"multidimensionalarrays_82375147","loc":[11111111,11111111,11111111],"txid":111111}},"arr":null,"id":11}
+{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"multidimensionalarrays_82375147","loc":[11111111,11111111,11111111],"txid":111111}},"arr":[],"id":12}
+{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"multidimensionalarrays_82375147","loc":[11111111,11111111,11111111],"txid":111111}},"arr":[],"id":13}
+{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"multidimensionalarrays_82375147","loc":[11111111,11111111,11111111],"txid":111111}},"arr":["x"],"id":14}
+{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"multidimensionalarrays_82375147","loc":[11111111,11111111,11111111],"txid":111111}},"arr":["x"],"id":15}
+{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"multidimensionalarrays_82375147","loc":[11111111,11111111,11111111],"txid":111111}},"arr":["a","b","c","d"],"id":16}
+{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"multidimensionalarrays_82375147","loc":[11111111,11111111,11111111],"txid":111111}},"arr":["a","b","c","d"],"id":17}
+{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"multidimensionalarrays_82375147","loc":[11111111,11111111,11111111],"txid":111111}},"arr":["a","b","c","d","e","f","g","h","i","j","k","l","m","n","o","p","q","r","s","t","u","v","w","x"],"id":18}
+{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"multidimensionalarrays_82375147","loc":[11111111,11111111,11111111],"txid":111111}},"arr":["a","b","c","d","e","f","g","h","i","j","k","l","m","n","o","p","q","r","s","t","u","v","w","x"],"id":19}
+# ================================
+# Final State Checkpoint
+# ================================
+{"bindingStateV1":{"test%2Fmultidimensionalarrays_82375147":{"backfilled":9,"key_columns":["id"],"mode":"Active"}},"cursor":"0/1111111"}
+

--- a/source-postgres/.snapshots/TestMultidimensionalArrays-Capture
+++ b/source-postgres/.snapshots/TestMultidimensionalArrays-Capture
@@ -5,20 +5,20 @@
 {"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"multidimensionalarrays_82375147","loc":[11111111,11111111,11111111]}},"arr":[],"id":2}
 {"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"multidimensionalarrays_82375147","loc":[11111111,11111111,11111111]}},"arr":[],"id":3}
 {"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"multidimensionalarrays_82375147","loc":[11111111,11111111,11111111]}},"arr":["x"],"id":4}
-{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"multidimensionalarrays_82375147","loc":[11111111,11111111,11111111]}},"arr":["x"],"id":5}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"multidimensionalarrays_82375147","loc":[11111111,11111111,11111111]}},"arr":[[["x"]]],"id":5}
 {"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"multidimensionalarrays_82375147","loc":[11111111,11111111,11111111]}},"arr":["a","b","c","d"],"id":6}
-{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"multidimensionalarrays_82375147","loc":[11111111,11111111,11111111]}},"arr":["a","b","c","d"],"id":7}
-{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"multidimensionalarrays_82375147","loc":[11111111,11111111,11111111]}},"arr":["a","b","c","d","e","f","g","h","i","j","k","l","m","n","o","p","q","r","s","t","u","v","w","x"],"id":8}
-{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"multidimensionalarrays_82375147","loc":[11111111,11111111,11111111]}},"arr":["a","b","c","d","e","f","g","h","i","j","k","l","m","n","o","p","q","r","s","t","u","v","w","x"],"id":9}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"multidimensionalarrays_82375147","loc":[11111111,11111111,11111111]}},"arr":[["a","b"],["c","d"]],"id":7}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"multidimensionalarrays_82375147","loc":[11111111,11111111,11111111]}},"arr":[[["a","b","c","d"],["e","f","g","h"],["i","j","k","l"]],[["m","n","o","p"],["q","r","s","t"],["u","v","w","x"]]],"id":8}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"multidimensionalarrays_82375147","loc":[11111111,11111111,11111111]}},"arr":[[[["a","b"],["c","d"]],[["e","f"],["g","h"]],[["i","j"],["k","l"]]],[[["m","n"],["o","p"]],[["q","r"],["s","t"]],[["u","v"],["w","x"]]]],"id":9}
 {"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"multidimensionalarrays_82375147","loc":[11111111,11111111,11111111],"txid":111111}},"arr":null,"id":11}
 {"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"multidimensionalarrays_82375147","loc":[11111111,11111111,11111111],"txid":111111}},"arr":[],"id":12}
 {"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"multidimensionalarrays_82375147","loc":[11111111,11111111,11111111],"txid":111111}},"arr":[],"id":13}
 {"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"multidimensionalarrays_82375147","loc":[11111111,11111111,11111111],"txid":111111}},"arr":["x"],"id":14}
-{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"multidimensionalarrays_82375147","loc":[11111111,11111111,11111111],"txid":111111}},"arr":["x"],"id":15}
+{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"multidimensionalarrays_82375147","loc":[11111111,11111111,11111111],"txid":111111}},"arr":[[["x"]]],"id":15}
 {"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"multidimensionalarrays_82375147","loc":[11111111,11111111,11111111],"txid":111111}},"arr":["a","b","c","d"],"id":16}
-{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"multidimensionalarrays_82375147","loc":[11111111,11111111,11111111],"txid":111111}},"arr":["a","b","c","d"],"id":17}
-{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"multidimensionalarrays_82375147","loc":[11111111,11111111,11111111],"txid":111111}},"arr":["a","b","c","d","e","f","g","h","i","j","k","l","m","n","o","p","q","r","s","t","u","v","w","x"],"id":18}
-{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"multidimensionalarrays_82375147","loc":[11111111,11111111,11111111],"txid":111111}},"arr":["a","b","c","d","e","f","g","h","i","j","k","l","m","n","o","p","q","r","s","t","u","v","w","x"],"id":19}
+{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"multidimensionalarrays_82375147","loc":[11111111,11111111,11111111],"txid":111111}},"arr":[["a","b"],["c","d"]],"id":17}
+{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"multidimensionalarrays_82375147","loc":[11111111,11111111,11111111],"txid":111111}},"arr":[[["a","b","c","d"],["e","f","g","h"],["i","j","k","l"]],[["m","n","o","p"],["q","r","s","t"],["u","v","w","x"]]],"id":18}
+{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"multidimensionalarrays_82375147","loc":[11111111,11111111,11111111],"txid":111111}},"arr":[[[["a","b"],["c","d"]],[["e","f"],["g","h"]],[["i","j"],["k","l"]]],[[["m","n"],["o","p"]],[["q","r"],["s","t"]],[["u","v"],["w","x"]]]],"id":19}
 # ================================
 # Final State Checkpoint
 # ================================

--- a/source-postgres/.snapshots/TestMultidimensionalArrays-Discovery
+++ b/source-postgres/.snapshots/TestMultidimensionalArrays-Discovery
@@ -15,12 +15,6 @@ Binding 0:
           "$anchor": "TestMultidimensionalarrays_82375147",
           "properties": {
             "arr": {
-              "items": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
               "description": "(source type: _text)",
               "type": [
                 "array",

--- a/source-postgres/.snapshots/TestMultidimensionalArrays-Discovery
+++ b/source-postgres/.snapshots/TestMultidimensionalArrays-Discovery
@@ -1,0 +1,143 @@
+Binding 0:
+{
+    "recommended_name": "test/multidimensionalarrays_82375147",
+    "resource_config_json": {
+      "namespace": "test",
+      "stream": "multidimensionalarrays_82375147"
+    },
+    "document_schema_json": {
+      "$defs": {
+        "TestMultidimensionalarrays_82375147": {
+          "type": "object",
+          "required": [
+            "id"
+          ],
+          "$anchor": "TestMultidimensionalarrays_82375147",
+          "properties": {
+            "arr": {
+              "items": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "description": "(source type: _text)",
+              "type": [
+                "array",
+                "null"
+              ]
+            },
+            "id": {
+              "type": "integer",
+              "description": "(source type: non-nullable int4)"
+            }
+          }
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "_meta": {
+                "properties": {
+                  "op": {
+                    "const": "d"
+                  }
+                }
+              }
+            }
+          },
+          "then": {
+            "reduce": {
+              "delete": true,
+              "strategy": "merge"
+            }
+          },
+          "else": {
+            "reduce": {
+              "strategy": "merge"
+            }
+          },
+          "required": [
+            "_meta"
+          ],
+          "properties": {
+            "_meta": {
+              "type": "object",
+              "required": [
+                "op",
+                "source"
+              ],
+              "properties": {
+                "before": {
+                  "$ref": "#TestMultidimensionalarrays_82375147",
+                  "description": "Record state immediately before this change was applied.",
+                  "reduce": {
+                    "strategy": "firstWriteWins"
+                  }
+                },
+                "op": {
+                  "enum": [
+                    "c",
+                    "d",
+                    "u"
+                  ],
+                  "description": "Change operation type: 'c' Create/Insert, 'u' Update, 'd' Delete."
+                },
+                "source": {
+                  "$id": "https://github.com/estuary/connectors/source-postgres/postgres-source",
+                  "properties": {
+                    "ts_ms": {
+                      "type": "integer",
+                      "description": "Unix timestamp (in millis) at which this event was recorded by the database."
+                    },
+                    "schema": {
+                      "type": "string",
+                      "description": "Database schema (namespace) of the event."
+                    },
+                    "snapshot": {
+                      "type": "boolean",
+                      "description": "Snapshot is true if the record was produced from an initial table backfill and unset if produced from the replication log."
+                    },
+                    "table": {
+                      "type": "string",
+                      "description": "Database table of the event."
+                    },
+                    "loc": {
+                      "items": {
+                        "type": "integer"
+                      },
+                      "type": "array",
+                      "maxItems": 3,
+                      "minItems": 3,
+                      "description": "Location of this WAL event as [last Commit.EndLSN; event LSN; current Begin.FinalLSN]. See https://www.postgresql.org/docs/current/protocol-logicalrep-message-formats.html"
+                    },
+                    "txid": {
+                      "type": "integer",
+                      "description": "The 32-bit transaction ID assigned by Postgres to the commit which produced this change."
+                    }
+                  },
+                  "type": "object",
+                  "required": [
+                    "schema",
+                    "table",
+                    "loc"
+                  ]
+                }
+              },
+              "reduce": {
+                "strategy": "merge"
+              }
+            }
+          }
+        },
+        {
+          "$ref": "#TestMultidimensionalarrays_82375147"
+        }
+      ]
+    },
+    "key": [
+      "/id"
+    ]
+  }
+


### PR DESCRIPTION
**Description:**

Implements a new feature flag `multidimensional_arrays`. When set, PostgreSQL array types will be discovered as merely `{type: array}` without any element type information at all, but the capture output will be unflattened back into nested arrays of the appropriate dimensionality.

So for instance the array `[[a,b],[c,d]]` can be represented as such instead of flattened out to `[a, b, c, d]`.

**Workflow steps:**

Set the `multidimensional_arrays` feature flag in the advanced settings for the capture. This flag is not going to become the default, but it's present for power users.

**Notes for reviewers:**

I'm not sure if the test coverage for array unflattening is sufficient or not. On the one hand it seems to work both on simple cases like a 1D 4-element array vs a 2x2 array and even on 2x3x4 vs 2x3x2x2 arrays. On the other hand the logic I wrote worked on the first try and for this sort of function that makes me _deeply uncomfortable_ so I keep looking for some sort of catch, but I don't really see any other edge cases that seem important to cover.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2627)
<!-- Reviewable:end -->
