### PR TITLE
source-zendesk-support-native: add `ticket_activities` stream

### DIFF
--- a/source-zendesk-support-native/acmeCo/flow.yaml
+++ b/source-zendesk-support-native/acmeCo/flow.yaml
@@ -72,6 +72,10 @@ collections:
     schema: tags.schema.yaml
     key:
       - /_meta/row_id
+  acmeCo/ticket_activities:
+    schema: ticket_activities.schema.yaml
+    key:
+      - /id
   acmeCo/ticket_audits:
     schema: ticket_audits.schema.yaml
     key:

--- a/source-zendesk-support-native/acmeCo/ticket_activities.schema.yaml
+++ b/source-zendesk-support-native/acmeCo/ticket_activities.schema.yaml
@@ -1,0 +1,36 @@
+---
+$defs:
+  Meta:
+    properties:
+      op:
+        default: u
+        description: "Operation type (c: Create, u: Update, d: Delete)"
+        enum:
+          - c
+          - u
+          - d
+        title: Op
+        type: string
+      row_id:
+        default: -1
+        description: "Row ID of the Document, counting up from zero, or -1 if not known"
+        title: Row Id
+        type: integer
+    title: Meta
+    type: object
+additionalProperties: true
+properties:
+  _meta:
+    $ref: "#/$defs/Meta"
+    default:
+      op: u
+      row_id: -1
+    description: Document metadata
+  id:
+    title: Id
+    type: integer
+required:
+  - id
+title: ZendeskResource
+type: object
+x-infer-schema: true

--- a/source-zendesk-support-native/source_zendesk_support_native/models.py
+++ b/source-zendesk-support-native/source_zendesk_support_native/models.py
@@ -1,4 +1,5 @@
 from datetime import datetime, UTC, timedelta
+from enum import StrEnum
 import json
 from typing import Annotated, Any, Literal, TYPE_CHECKING
 
@@ -242,11 +243,21 @@ class TicketMetricEventsResponse(IncrementalCursorPaginatedResponse):
     resources: list[ZendeskResource] = Field(alias="ticket_metric_events")
 
 
+class TicketActivitiesResponse(IncrementalCursorPaginatedResponse):
+    resources: list[ZendeskResource] = Field(alias="activities")
+
+
+class FilterParam(StrEnum):
+    START_TIME = "start_time"
+    SINCE = "since"
+
+
 # Incremental resources that can be filtered by a start_time query param.
-# Tuples contain the name, path, cursor field, and response model for each resource. 
-INCREMENTAL_CURSOR_PAGINATED_RESOURCES: list[tuple[str, str, str, type[IncrementalCursorPaginatedResponse]]] = [
-    ("ticket_skips", "skips", "updated_at", TicketSkipsResponse),
-    ("ticket_metric_events", "incremental/ticket_metric_events", "time", TicketMetricEventsResponse)
+# Tuples contain the name, path, filter param name, cursor field, and response model for each resource. 
+INCREMENTAL_CURSOR_PAGINATED_RESOURCES: list[tuple[str, str, FilterParam, str, type[IncrementalCursorPaginatedResponse]]] = [
+    ("ticket_skips", "skips", FilterParam.START_TIME, "updated_at", TicketSkipsResponse),
+    ("ticket_metric_events", "incremental/ticket_metric_events", FilterParam.START_TIME, "time", TicketMetricEventsResponse),
+    ("ticket_activities", "activities", FilterParam.START_TIME, "updated_at", TicketActivitiesResponse),
 ]
 
 

--- a/source-zendesk-support-native/source_zendesk_support_native/resources.py
+++ b/source-zendesk-support-native/source_zendesk_support_native/resources.py
@@ -12,6 +12,7 @@ from .models import (
     ClientSideIncrementalOffsetPaginatedResponse,
     ClientSideIncrementalCursorPaginatedResponse,
     EndpointConfig,
+    FilterParam,
     FullRefreshResponse,
     FullRefreshOffsetPaginatedResponse,
     FullRefreshCursorPaginatedResponse,
@@ -488,6 +489,7 @@ def incremental_cursor_paginated_resources(
 
     def open(
         path: str,
+        filter_param: FilterParam,
         cursor_field: str,
         response_model: type[IncrementalCursorPaginatedResponse],
         binding: CaptureBinding[ResourceConfig],
@@ -506,6 +508,7 @@ def incremental_cursor_paginated_resources(
                 http,
                 config.subdomain,
                 path,
+                filter_param,
                 cursor_field,
                 response_model,
             ),
@@ -514,6 +517,7 @@ def incremental_cursor_paginated_resources(
                 http,
                 config.subdomain,
                 path,
+                filter_param,
                 cursor_field,
                 response_model,
                 config.start_date,
@@ -527,7 +531,7 @@ def incremental_cursor_paginated_resources(
             name=name,
             key=["/id"],
             model=ZendeskResource,
-            open=functools.partial(open, path, cursor_field, response_model),
+            open=functools.partial(open, path, filter_param, cursor_field, response_model),
             initial_state=ResourceState(
                 inc=ResourceState.Incremental(cursor=cutoff),
                 backfill=ResourceState.Backfill(cutoff=cutoff, next_page=None)
@@ -537,7 +541,7 @@ def incremental_cursor_paginated_resources(
             ),
             schema_inference=True,
         )
-        for (name, path, cursor_field, response_model) in INCREMENTAL_CURSOR_PAGINATED_RESOURCES
+        for (name, path, filter_param, cursor_field, response_model) in INCREMENTAL_CURSOR_PAGINATED_RESOURCES
     ]
 
     return resources

--- a/source-zendesk-support-native/test.flow.yaml
+++ b/source-zendesk-support-native/test.flow.yaml
@@ -92,6 +92,10 @@ captures:
           interval: PT5M
         target: acmeCo/ticket_metric_events
       - resource:
+          name: ticket_activities
+          interval: PT5M
+        target: acmeCo/ticket_activities
+      - resource:
           name: organizations
           interval: PT5M
         target: acmeCo/organizations

--- a/source-zendesk-support-native/tests/snapshots/snapshots__discover__capture.stdout.json
+++ b/source-zendesk-support-native/tests/snapshots/snapshots__discover__capture.stdout.json
@@ -1076,6 +1076,64 @@
     ]
   },
   {
+    "recommendedName": "ticket_activities",
+    "resourceConfig": {
+      "name": "ticket_activities",
+      "interval": "PT5M"
+    },
+    "documentSchema": {
+      "$defs": {
+        "Meta": {
+          "properties": {
+            "op": {
+              "default": "u",
+              "description": "Operation type (c: Create, u: Update, d: Delete)",
+              "enum": [
+                "c",
+                "u",
+                "d"
+              ],
+              "title": "Op",
+              "type": "string"
+            },
+            "row_id": {
+              "default": -1,
+              "description": "Row ID of the Document, counting up from zero, or -1 if not known",
+              "title": "Row Id",
+              "type": "integer"
+            }
+          },
+          "title": "Meta",
+          "type": "object"
+        }
+      },
+      "additionalProperties": true,
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/Meta",
+          "default": {
+            "op": "u",
+            "row_id": -1
+          },
+          "description": "Document metadata"
+        },
+        "id": {
+          "title": "Id",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "id"
+      ],
+      "title": "ZendeskResource",
+      "type": "object",
+      "x-infer-schema": true
+    },
+    "key": [
+      "/id"
+    ]
+  },
+  {
     "recommendedName": "ticket_audits",
     "resourceConfig": {
       "name": "ticket_audits",

--- a/source-zendesk-support-native/tests/test_snapshots.py
+++ b/source-zendesk-support-native/tests/test_snapshots.py
@@ -6,6 +6,9 @@ def test_capture(request, snapshot):
     OMITTED_STREAMS = [
         "acmeCo/audit_logs",
         "acmeCo/tags",
+        # The Zendesk API only returns the past 30 days of ticket_activities,
+        # so we can't reliably include ticket_activities in the capture snapshot.
+        "acmeCo/ticket_activities",
     ]
 
     result = subprocess.run(


### PR DESCRIPTION
**Description:**

Adds the `ticket_activities` binding as an incremental cursor paginated stream. The `/ticket_activities` endpoint accepts a `since` parameter for filtering results & requires the value to be an ISO 8601 UTC datetime, which are both different from the existing incremental cursor paginated streams. Both `fetch_incremental_cursor_paginated_resources` and `backfill_cursor_paginated_resources` have been updated to handle this.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

The connector docs should be updated to reflect the new stream.

**Notes for reviewers:**

Tested on a local stack. Confirmed:
- existing incremental cursor paginated streams `ticket_skips` and `ticket_metric_events` behave the same.
- `ticket_activities` captures the expected number of documents.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2639)
<!-- Reviewable:end -->
