### PR TITLE
source-monday: handle template boards

### DIFF
--- a/source-monday/source_monday/models.py
+++ b/source-monday/source_monday/models.py
@@ -139,7 +139,11 @@ class Tag(BaseDocument, extra="allow"):
 
 
 class Board(BaseDocument, extra="allow"):
+    class Workspace(BaseModel, extra="allow"):
+        kind: str | None = None
+    
     updated_at: AwareDatetime
+    workspace: Workspace
 
 
 class BoardsResponse(BaseModel, extra="forbid"):

--- a/source-monday/tests/snapshots/snapshots__capture__stdout.json
+++ b/source-monday/tests/snapshots/snapshots__capture__stdout.json
@@ -292,7 +292,7 @@
           "id": "subitems_mkn5v6ah",
           "text": null,
           "type": "subtasks",
-          "value": "{\"changed_at\":\"2025-02-20 19:15:53 +0000\",\"linkedPulseIds\":[{\"linkedPulseId\":8531539316},{\"linkedPulseId\":8531684828}]}"
+          "value": null
         },
         {
           "id": "project_owner",
@@ -445,7 +445,7 @@
           "id": "subitems_mkn5v6ah",
           "text": null,
           "type": "subtasks",
-          "value": "{\"changed_at\":\"2025-02-24 17:14:40 +0000\",\"linkedPulseIds\":[{\"linkedPulseId\":8553814342}]}"
+          "value": null
         },
         {
           "id": "project_owner",


### PR DESCRIPTION
**Description:**

- Added API response errors.
- Updated `fetch_boards` to first attempt fetching boards with the 'kind' field, falling back to individual board queries if necessary.
- Added logging for better traceability of query failures and retries.
- Modified `Board` model to include a nested `Workspace` model for better structure and clarity.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2643)
<!-- Reviewable:end -->
