### PR TITLE
source-postgres: Cleaner XMIN filtering

### DIFF
--- a/source-postgres/capture_test.go
+++ b/source-postgres/capture_test.go
@@ -740,7 +740,7 @@ func TestXMINBackfill(t *testing.T) {
 	tb.Insert(ctx, t, tableName, [][]any{{0, "zero"}, {1, "one"}, {2, "two"}})
 
 	var lowerXID uint64
-	const queryXID = "SELECT (CASE WHEN pg_is_in_recovery() THEN txid_snapshot_xmax(txid_current_snapshot()) ELSE txid_current() END)"
+	const queryXID = "SELECT txid_snapshot_xmin(txid_current_snapshot())"
 	require.NoError(t, tb.control.QueryRow(ctx, queryXID).Scan(&lowerXID))
 
 	// Changes from after the minimum backfill XID can be observed.

--- a/source-postgres/discovery.go
+++ b/source-postgres/discovery.go
@@ -746,7 +746,7 @@ func getColumnDescriptions(ctx context.Context, conn *pgx.Conn) ([]columnDescrip
 
 func queryAndLogCurrentXID(ctx context.Context, conn *pgx.Conn) {
 	var xid uint64
-	const query = "SELECT (CASE WHEN pg_is_in_recovery() THEN txid_snapshot_xmax(txid_current_snapshot()) ELSE txid_current() END)"
+	const query = "SELECT txid_snapshot_xmin(txid_current_snapshot())"
 	if err := conn.QueryRow(ctx, query).Scan(&xid); err == nil {
 		logrus.WithField("xid", xid).Info("current transaction ID")
 	} else {


### PR DESCRIPTION
**Description:**

I've just spent the past couple of hours up to my eyeballs in PostgreSQL XIDs and the different `txid_snapshot_foo(...)` functions so I'm going to take this opportunity to clean up and simplify some of the PostgreSQL CDC logic around XMIN filtered backfills while it's fresh in my mind.

Strictly speaking only one of these changes is truly needed ASAP, using `compareXID32` to do the appropriate circular comparison for XMIN filtering in the result row processing.

The other stuff is just cleanups, because we don't need to be using a complicated case statement based on whether or not we are hitting a standby when the `txid_snapshot_xmin/xmax` bits work perfectly fine on the master DB as well.

**Workflow steps:**

Should be no functional changes except that the XMIN filtering will actually work correctly again on databases which have received 2^31 or more writes.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2649)
<!-- Reviewable:end -->
