### PR TITLE
source-oracle: optimise keyless backfill query

### DIFF
--- a/source-oracle/discovery.go
+++ b/source-oracle/discovery.go
@@ -209,6 +209,7 @@ func getTables(ctx context.Context, conn *sql.DB, selectedSchemas []string) ([]*
 const queryTableObjectIdentifiers = `SELECT OWNER, OBJECT_NAME, OBJECT_ID, DATA_OBJECT_ID FROM ALL_OBJECTS WHERE OBJECT_TYPE='TABLE'`
 
 type tableObject struct {
+	streamID     string
 	objectID     int
 	dataObjectID int
 }
@@ -241,7 +242,7 @@ func getTableObjectMappings(ctx context.Context, watermarksTable string, conn *s
 			return nil, fmt.Errorf("scanning table object identifier row: %w", err)
 		}
 
-		mapping[joinObjectID(objectID, dataObjectID)] = tableObject{objectID: objectID, dataObjectID: dataObjectID}
+		mapping[joinObjectID(objectID, dataObjectID)] = tableObject{streamID: sqlcapture.JoinStreamID(owner, tableName), objectID: objectID, dataObjectID: dataObjectID}
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err


### PR DESCRIPTION
**Description:**

- Ordering the whole table based on `ROWID`, and then filtering for a specific ROWID range is slow. With some testing I found that if we order ROWIDs on their own (without all the other columns), and then filter based on them, it is much faster and actually workable.
- I also realised we were capturing all logminer events for all discovered tables and only filtering them later after fetching, which was quite inefficient. Changed the logic so we filter out disabled tables as part of the query we send to logminer and have noticed a performance improvement.
- Lastly found that it is possible for a log file to have both an ARCHIVED file and an ACTIVE file, similar to ARCHIVED and CURRENT, so updated the logic to allow for that as well
- Would like to try this with a customer who is suffering from this issue before merging

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2650)
<!-- Reviewable:end -->
