### PR TITLE
source-zendesk-support-native: mark `schedules` and `sla_policies` as enterprise-only

### DIFF
--- a/source-zendesk-support-native/source_zendesk_support_native/resources.py
+++ b/source-zendesk-support-native/source_zendesk_support_native/resources.py
@@ -65,7 +65,12 @@ from .api import (
 )
 
 
-ENTERPRISE_STREAMS = ["audit_logs", "account_attributes"]
+ENTERPRISE_STREAMS = [
+    "audit_logs",
+    "account_attributes",
+    "schedules",
+    "sla_policies",
+]
 
 
 async def _is_enterprise_account(


### PR DESCRIPTION
**Description:**

Both the `/business_hours/schedules` and `/sla/policies` endpoints are only accessible for Enterprise tier or above Zendesk accounts, so we should conditionally discover them along with the other Enterprise-only streams.

It seems like there are also some other restrictions for other endpoints (ex: `/ticket_forms` is only for Professional or above accounts?). I haven't found good documentation from Zendesk yet about these types of restrictions, so rather than proactively guessing which streams are accessible on which tiers and potentially guessing wrong, I'd rather wait & address it when discovering a specific stream becomes a problem.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

Tested with `flowctl raw discover` with a non-Enterprise account. Confirmed the `schedules` and `sla_policies` are not discovered for non-Enterprise accounts.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2653)
<!-- Reviewable:end -->
