### PR TITLE
source-postgres-batch: Fix statement timeout handling

### DIFF
--- a/source-postgres-batch/.snapshots/TestSpec
+++ b/source-postgres-batch/.snapshots/TestSpec
@@ -65,6 +65,19 @@
             "type": "string",
             "title": "Feature Flags",
             "description": "This property is intended for Estuary internal use. You should only modify this field as directed by Estuary support."
+          },
+          "statement_timeout": {
+            "type": "string",
+            "enum": [
+              "",
+              "30s",
+              "1m",
+              "5m",
+              "30m"
+            ],
+            "title": "Statement Timeout",
+            "description": "Overrides the default statement timeout for queries.",
+            "default": ""
           }
         },
         "additionalProperties": false,


### PR DESCRIPTION
**Description:**

I've gotten this one wrong twice now for subtle reasons so I actually sat down and put together a reliable repro case and verified that it works, however making the actual server-side query execution reliably take long enough to trigger a statement timeout requires either some ugly hacks or a ton of special-case plumbing that's only useful for that one job, so I'm not adding that test here.

However I think there is some utility to being able to override or set the default statement timeout via the advanced config, so I kept that bit in.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2655)
<!-- Reviewable:end -->
