### PR TITLE
stream-encode: a couple of minor performance tweaks

### DIFF
--- a/materialize-boilerplate/stream-encode/csv.go
+++ b/materialize-boilerplate/stream-encode/csv.go
@@ -10,6 +10,7 @@ import (
 	"strconv"
 	"unicode"
 	"unicode/utf8"
+	"unsafe"
 
 	"github.com/klauspost/compress/gzip"
 )
@@ -126,7 +127,9 @@ func (w *csvWriter) writeRow(row []any) error {
 		case []byte:
 			w.buf = w.appendString(w.buf, value)
 		case string:
-			w.buf = w.appendString(w.buf, []byte(value))
+			// Safety: This value is immediately written to the output and never
+			// modified.
+			w.buf = w.appendString(w.buf, unsafe.Slice(unsafe.StringData(value), len(value)))
 		case bool:
 			w.buf = strconv.AppendBool(w.buf, value)
 		case int64:


### PR DESCRIPTION
**Description:**

For both CSV and Parquet writing, we can avoid allocating unnecessary for string values by creating a read-only view of the string's bytes. This doesn't make a huge difference, but it is obviously safe to do and every little bit helps on these hot paths.

Also fixes a more significant omission in Parquet writing where pre-serialized RawMessages did not have a fast-path, and were going through the (slow) JSON serialization process. Adding the RawMessage case avoids that overhead.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2659)
<!-- Reviewable:end -->
