### PR TITLE
source-stripe-native: fix bug with validating changing capture_connected accounts

### DIFF
--- a/source-stripe-native/source_stripe_native/__init__.py
+++ b/source-stripe-native/source_stripe_native/__init__.py
@@ -51,7 +51,7 @@ class Connector(
         if (
             not validate.lastCapture
             or (
-                validate.lastCapture.config.config.get("capture_connected_accounts")
+                validate.lastCapture.config.config.get("capture_connected_accounts", False)
                 == validate.config.capture_connected_accounts
             )
             or not validate.lastCapture.bindings


### PR DESCRIPTION
**Description:**

If the last config did not have a `capture_connected_accounts` field (like before the connected accounts functionality was introduced), the current code that retrieves the `capture_connected_accounts` value from the last config will default to returning `None`, and we'll end up comparing `None` to some boolean value. If the field is missing, it should return `False` instead so the connector doesn't incorrectly think `capture_connected_accounts` has changed when the config goes from not having the field to having it present & set to `False`.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

Tested on a local stack. I confirmed that the `Cannot change the `capture_connected_accounts` property without backfilling all collections again.` error is not raised when going from a config that doesn't have the `capture_connected_accounts` property present to a config that has it present & set to `False`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2662)
<!-- Reviewable:end -->
