### PR TITLE
source-oracle: track transactions across SCN ranges

### DIFF
--- a/source-oracle/.snapshots/TestCrossSCNTransactions
+++ b/source-oracle/.snapshots/TestCrossSCNTransactions
@@ -1,0 +1,10 @@
+# ================================
+# Collection "acmeCo/test/c__flow_test_logminer/t23135019": 2 Documents
+# ================================
+{"FULLNAME":"No Such State","POPULATION":"10000","STATE":"BB","YEAR":"1930","_meta":{"op":"c","source":{"schema":"C##FLOW_TEST_LOGMINER","snapshot":true,"table":"T23135019","row_id":"AAAAAAAAAAAAAAAAAA","rs_id":"111111111111111111","ssn":111}}}
+{"FULLNAME":"No Such State","POPULATION":"10000","STATE":"BB","YEAR":"1950","_meta":{"op":"u","source":{"ts_ms":1111111111111,"schema":"C##FLOW_TEST_LOGMINER","table":"T23135019","scn":11111111,"row_id":"AAAAAAAAAAAAAAAAAA","rs_id":"111111111111111111","ssn":111},"before":{"FULLNAME":"No Such State","POPULATION":"10000","STATE":"BB","YEAR":"1930"}}}
+# ================================
+# Final State Checkpoint
+# ================================
+{"bindingStateV1":{"C%23%23FLOW_TEST_LOGMINER%2FT23135019":{"backfilled":1,"key_columns":["YEAR","STATE"],"mode":"Active"}},"cursor":"11111111"}
+


### PR DESCRIPTION
**Description:**

- Prior to this pull-request we are asking Logminer to only give us committed transactions. That works well most of the time, but I just realised there is an edge case where I ask it for updates in a range [0, N], and then I ask it for updates in the range [N, M]…
It is possible that a transaction started at some point before N, but didn’t finish until some point after N. In this case, the transaction is split between the two ranges, and Logminer will not give us this transaction in either of the ranges if we ask it for committed transactions only!
The only way to get those is to not ask it for committed transactions only, which means we need to track transaction commits ourselves, and if we detect an incomplete transaction during this, we should try the next range while including the beginning of that incomplete transaction until we find its termination

Tested this by adding a test case, and watching the logs, basically what I see is:

In one of the SCN ranges, we see the `BEGIN` and `UPDATE` operation from Logminer, but we don't see `COMMIT` yet, we try again, this time keeping starting SCN of the next logminer query to include the `BEGIN` and `UPDATE` operations until we also see `COMMIT`, we then emit the full message and clean it up.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

