### PR TITLE
source-kinesis: additional logging for reading shards

### DIFF
--- a/source-kinesis/capture.go
+++ b/source-kinesis/capture.go
@@ -305,7 +305,12 @@ func (c *capture) readShard(
 		}
 		iterator = res.NextShardIterator
 
+		if *res.MillisBehindLatest != 0 && len(res.Records) == 0 {
+			ll.WithField("MillisBehindLatest", *res.MillisBehindLatest).Info("shard is not current but returned no new data")
+		}
+
 		if *res.MillisBehindLatest == 0 && len(res.Records) == 0 {
+			ll.Debug("waiting before polling for new data since shard is caught up")
 			select {
 			case <-ctx.Done():
 				return ctx.Err()


### PR DESCRIPTION
**Description:**

It would be a little unusual for a shard to repeatedly return no new records from GetRecords while also lagging behind the latest point of the stream. But it would be expected for GetRecords to return no records if the stream was caught up with the latest. So log an Info level log for the former since it's something we want to know about if it is happening a lot, and a debug log for the latter since it is probably not generally as useful of a message.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2664)
<!-- Reviewable:end -->
