### PR TITLE
materialize-snowflake: use SHOW PIPES to avoid waking up warehouse

### DIFF
--- a/materialize-snowflake/pipe.go
+++ b/materialize-snowflake/pipe.go
@@ -32,7 +32,11 @@ type pipeParts struct {
 }
 
 func (parts *pipeParts) toPipeName() string {
-	return strings.ToUpper(fmt.Sprintf("%s.%s.FLOW_PIPE_%s_%s_%s_%s", parts.Catalog, parts.Schema, parts.Binding, parts.KeyBegin, parts.Version, parts.TableName))
+	return strings.ToUpper(fmt.Sprintf("FLOW_PIPE_%s_%s_%s_%s", parts.Binding, parts.KeyBegin, parts.Version, parts.TableName))
+}
+
+func (parts *pipeParts) toQualifiedName() string {
+	return strings.ToUpper(fmt.Sprintf("%s.%s.%s", parts.Catalog, parts.Schema, parts.toPipeName()))
 }
 
 // Deconstruct a pipeName into its constituent parts


### PR DESCRIPTION
**Description:**

- Switch back to using `SHOW PIPES` for `pipeExists` and for the new `cleanupPipes`. I had forgotten the original reason behind using it: to not wake up the warehouse!
- Do not run `cleanupPipes` if there are no current pipes.
- Tested with integration tests and some manual logging

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2667)
<!-- Reviewable:end -->
