### PR TITLE
source-linkedin-ads-v2: upgrade API version

### DIFF
--- a/source-linkedin-ads-v2/source_linkedin_ads_v2/streams.py
+++ b/source-linkedin-ads-v2/source_linkedin_ads_v2/streams.py
@@ -19,7 +19,7 @@ from .utils import get_parent_stream_values, transform_data
 
 logger = logging.getLogger("airbyte")
 
-LINKEDIN_VERSION_API = "202404"
+LINKEDIN_VERSION_API = "202502"
 
 
 class LinkedinAdsStream(HttpStream, ABC):


### PR DESCRIPTION
**Description:**

The 202404 API verison has been sunset today, so we have to upgrade to a more recent version for the connector to work again.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

Confirmed API calls & the connector work again with the 202502 API version.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2679)
<!-- Reviewable:end -->
