### PR TITLE
source-oracle: track pending transactions and capture them separately

### DIFF
--- a/source-oracle/.snapshots/TestCrossSCNTransactions
+++ b/source-oracle/.snapshots/TestCrossSCNTransactions
@@ -6,5 +6,5 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"C%23%23FLOW_TEST_LOGMINER%2FT23135019":{"backfilled":1,"key_columns":["YEAR","STATE"],"mode":"Active"}},"cursor":"11111111"}
+{"bindingStateV1":{"C%23%23FLOW_TEST_LOGMINER%2FT23135019":{"backfilled":1,"key_columns":["YEAR","STATE"],"mode":"Active"}},"cursor":{"PendingTransactions":{"AAAAAAA=":{"MessageCount":1,"StartSCN":111111111"}},"SCN":111111111"}}
 

--- a/source-oracle/capture_test.go
+++ b/source-oracle/capture_test.go
@@ -538,10 +538,12 @@ func TestCrossSCNTransactions(t *testing.T) {
 				if err != nil {
 					t.Fatalf("unable to begin transaction query: %v", err)
 				}
+				logrus.Info("starting tx")
 				if _, err := tx.ExecContext(ctx, fmt.Sprintf("UPDATE %s SET year = '1950'", tableName)); err != nil {
 					t.Fatalf("unable to update transaction query: %v", err)
 				}
 				time.Sleep(5 * time.Second)
+				logrus.Info("committing tx")
 				if err := tx.Commit(); err != nil {
 					t.Fatalf("unable to commit transaction query: %v", err)
 				}

--- a/source-oracle/main_test.go
+++ b/source-oracle/main_test.go
@@ -88,12 +88,14 @@ func (tb *testBackend) UpperCaseMode() bool { return true }
 func (tb *testBackend) CaptureSpec(ctx context.Context, t testing.TB, streamMatchers ...*regexp.Regexp) *st.CaptureSpec {
 	var sanitizers = make(map[string]*regexp.Regexp)
 	sanitizers[`"scn":11111111`] = regexp.MustCompile(`"scn":([0-9]+)`)
-	sanitizers[`"cursor":"11111111"`] = regexp.MustCompile(`"cursor":"([0-9]+)"`)
 	sanitizers[`"row_id":"AAAAAAAAAAAAAAAAAA"`] = regexp.MustCompile(`"row_id":"[^"]+"`)
 	sanitizers[`"rs_id":"111111111111111111"`] = regexp.MustCompile(`"rs_id":"[^"]+"`)
 	sanitizers[`"ssn":111`] = regexp.MustCompile(`"ssn":[0-9]+`)
 	sanitizers[`"ts_ms":1111111111111`] = regexp.MustCompile(`"ts_ms":[0-9]+`)
 	sanitizers[`"scanned":"AAAAAAAAAAAAAAAA=="`] = regexp.MustCompile(`"scanned":"[^"]+"`)
+	sanitizers[`"AAAAAAA=":{"MessageCount"`] = regexp.MustCompile(`"[^"]+":{"MessageCount"`)
+	sanitizers[`"StartSCN":111111111"`] = regexp.MustCompile(`"StartSCN":[0-9]+`)
+	sanitizers[`"SCN":111111111"`] = regexp.MustCompile(`"SCN":[0-9]+`)
 
 	var cfg = tb.config
 	var cs = &st.CaptureSpec{

--- a/sqlcapture/capture.go
+++ b/sqlcapture/capture.go
@@ -239,6 +239,7 @@ func (c *Capture) Run(ctx context.Context) (err error) {
 			}
 
 			if TestShutdownAfterBackfill {
+				log.Info("Shutting down after backfill due to TestShutdownAfterBackfill")
 				return nil // In tests we sometimes want to shut down here
 			}
 			continue // Repeat the main loop from the top
@@ -248,6 +249,7 @@ func (c *Capture) Run(ctx context.Context) (err error) {
 		// a state checkpoint to ensure that streams reliably transition into the Active
 		// state during tests even if there is no backfill work to do.
 		if TestShutdownAfterCaughtUp {
+			log.Info("Shutting down after backfill due to TestShutdownAfterCaughtUp")
 			return c.emitState()
 		}
 


### PR DESCRIPTION
**Description:**

- Transactions can span across multiple SCN ranges, when that happens, we would previously keep track of their messages in memory, but for long / large transactions that would lead to memory issues.
- In order to avoid memory consumption when working with large transactions, we now keep track of the starting SCN of and the XID of pending transactions, and we persist this information as part of the checkpoint
- Once we see terminal operation for pending transactions, if it is a rollback, we remove the transaction from checkpoint, and if it is a commit, we initiate an ad-hoc capture of that specific transaction, this means we process the SCN range from the beginning of that large transaction to the commit as usual (still paginated), but this time we will ask Logminer to filter only the specific XID
- Note that I am also tracking message count for transactions. Since transactions have no association with a table, we have to inspect all transactions across the whole database, and a lot of them will be irrelevant for our use case, in these cases we will not see any other messages for those transactions because we filter for table ID, and insert / update / delete operations do have table IDs. This allows us to only initiate an ad-hoc capture if we know this table has had relevant operations for us

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2680)
<!-- Reviewable:end -->
