### PR TITLE
sqlcapture: Refactor cursor to json.RawMessage

### DIFF
--- a/sqlcapture/capture.go
+++ b/sqlcapture/capture.go
@@ -37,7 +37,7 @@ var (
 // PersistentState represents the part of a connector's state which can be serialized
 // and emitted in a state checkpoint, and resumed from after a restart.
 type PersistentState struct {
-	Cursor  string                               `json:"cursor"`                   // The replication cursor of the most recent 'Commit' event
+	Cursor  json.RawMessage                      `json:"cursor"`                   // The replication cursor of the most recent 'Commit' event
 	Streams map[boilerplate.StateKey]*TableState `json:"bindingStateV1,omitempty"` // A mapping from runtime-provided state keys to table-specific state.
 }
 
@@ -139,7 +139,7 @@ type Capture struct {
 	// acknowledgement-relaying goroutine receives an Acknowledge message.
 	pending struct {
 		sync.Mutex
-		cursors []string
+		cursors []json.RawMessage
 	}
 }
 
@@ -338,7 +338,7 @@ func (c *Capture) reconcileStateWithBindings(_ context.Context) error {
 		} else {
 			log.Info("capture has no bindings, resetting replication cursor")
 		}
-		c.State.Cursor = ""
+		c.State.Cursor = nil
 	}
 
 	// Emit the new state to stdout. This isn't strictly necessary but it helps to make

--- a/sqlcapture/interface.go
+++ b/sqlcapture/interface.go
@@ -79,7 +79,7 @@ type ChangeEvent struct {
 // FlushEvent informs the generic sqlcapture logic about transaction boundaries.
 type FlushEvent struct {
 	// The cursor value at which the current transaction was committed.
-	Cursor string
+	Cursor json.RawMessage
 }
 
 // MetadataEvent informs the generic sqlcapture logic about changes to
@@ -136,7 +136,7 @@ type Database interface {
 	Close(ctx context.Context) error
 	// ReplicationStream constructs a new ReplicationStream object, from which
 	// a neverending sequence of change events can be read.
-	ReplicationStream(ctx context.Context, startCursor string) (ReplicationStream, error)
+	ReplicationStream(ctx context.Context, startCursor json.RawMessage) (ReplicationStream, error)
 
 	// ScanTableChunk fetches a chunk of rows from the specified table, resuming from the `resumeAfter` row key if non-nil.
 	// The `backfillComplete` boolean will be true after scanning the final chunk of the table.
@@ -199,7 +199,7 @@ type ReplicationStream interface {
 	// that indefinite streaming doesn't busy-loop on an idle database.
 	StreamToFence(ctx context.Context, fenceAfter time.Duration, callback func(event DatabaseEvent) error) error
 
-	Acknowledge(ctx context.Context, cursor string) error
+	Acknowledge(ctx context.Context, cursor json.RawMessage) error
 	Close(ctx context.Context) error
 }
 

--- a/sqlcapture/main.go
+++ b/sqlcapture/main.go
@@ -306,11 +306,7 @@ func (d *Driver) Pull(open *pc.Request_Open, stream *boilerplate.PullOutput) err
 	// value at which the replacement should occur, so the replacements are very narrowly
 	// scoped.
 	var hackyCursorReplacements = map[string]map[string]string{
-		"TASKHASH415b69936fe1324600d67943e50235fc57fb7e0196b8f5f0TASKHASH": {"binlog.000123:456789": "binlog.000123:456789"}, // Example
-
-		// Added 2025-02-18
-		"cec31becf409bcdd486898a57a02850ad73d1fdf04d0fce71663e913f339778e": {"mysql-bin.079013:2708461504": "mysql-bin.079013:4"},
-		"7414746d7079ddf14cb3afff10762f873b99dc8e66d63a9ed98d6bde40b46080": {"mysql-bin.079013:2717599422": "mysql-bin.079013:4"},
+		"TASKHASH415b69936fe1324600d67943e50235fc57fb7e0196b8f5f0TASKHASH": {`"binlog.000123:456789"`: `"binlog.000123:456789"`}, // Example
 	}
 	var hasher = sha256.New()
 	hasher.Write([]byte(open.Capture.Name))
@@ -320,13 +316,13 @@ func (d *Driver) Pull(open *pc.Request_Open, stream *boilerplate.PullOutput) err
 		"cursor":   state.Cursor,
 	}).Debug("checking for cursor replacements")
 	if replacementsForTask, ok := hackyCursorReplacements[nameHash]; ok {
-		if replacementForCursor, ok := replacementsForTask[state.Cursor]; ok {
+		if replacementForCursor, ok := replacementsForTask[string(state.Cursor)]; ok {
 			log.WithFields(log.Fields{
 				"namehash":  nameHash,
 				"oldCursor": state.Cursor,
 				"newCursor": replacementForCursor,
 			}).Warn("cursor replacement triggered")
-			state.Cursor = replacementForCursor
+			state.Cursor = json.RawMessage(replacementForCursor)
 		}
 	}
 


### PR DESCRIPTION
**Description:**

The day we kept putting off has finally come, we finally need to represent replication stream state as something more complex than a simple LSN cursor into the WAL.

This commit should have no observable effect on its own. The representation of our current string cursors in state checkpoints is unchanged, all we've done is leave the bytes makine up that quoted string unparsed inside the generic machinery and made the database-specific logic do a bit more work to quote and unquote them.

But this will allow Oracle to migrate to a more complex object as its cursor value without the need for an ugly "JSON serialized and then quoted inside another JSON string" bit of nesting.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2682)
<!-- Reviewable:end -->
