### PR TITLE
source-salesforce-native: request a max set size when reading bulk job results

### DIFF
--- a/source-salesforce-native/source_salesforce_native/api.py
+++ b/source-salesforce-native/source_salesforce_native/api.py
@@ -11,6 +11,7 @@ from .bulk_job_manager import (
     CANNOT_FETCH_COMPOUND_DATA,
     DAILY_MAX_BULK_API_QUERY_VOLUME_EXCEEDED,
     NOT_SUPPORTED_BY_BULK_API,
+    MAX_BULK_QUERY_SET_SIZE,
 )
 from .rest_query_manager import RestQueryManager
 from .shared import dt_to_str, str_to_dt, now
@@ -23,7 +24,7 @@ from .models import (
 )
 
 REST_CHECKPOINT_INTERVAL = 2_000
-BULK_CHECKPOINT_INTERVAL = 200_000
+BULK_CHECKPOINT_INTERVAL = MAX_BULK_QUERY_SET_SIZE
 
 # We have reason to believe the Salesforce API is eventually consistent to some degree. Fivetran
 # re-fetches all records in the 5 minutes before their cursor value to combat eventual consistency.

--- a/source-salesforce-native/source_salesforce_native/bulk_job_manager.py
+++ b/source-salesforce-native/source_salesforce_native/bulk_job_manager.py
@@ -23,6 +23,7 @@ from .models import (
 INITIAL_SLEEP = 0.2
 MAX_SLEEP = 300
 ATTEMPT_LOG_THRESHOLD = 10
+MAX_BULK_QUERY_SET_SIZE = 200_000
 
 COUNT_HEADER = "Sforce-NumberOfRecords"
 CANNOT_FETCH_COMPOUND_DATA = r"Selecting compound data not supported in Bulk Query"
@@ -141,7 +142,9 @@ class BulkJobManager:
     async def _fetch_results(self, job_id: str) -> AsyncGenerator[dict[str, str], None]:
         url = f"{self.base_url}/{job_id}/results"
         request_headers = {"Accept-Encoding": "gzip"}
-        params: dict[str, str] = {}
+        params: dict[str, str | int] = {
+            "maxRecords": MAX_BULK_QUERY_SET_SIZE,
+        }
 
         while True:
             headers, body = await self.http.request_stream(self.log, url, params=params, headers=request_headers)


### PR DESCRIPTION
**Description:**

I noticed that some formula field backfills were progressing significantly slower than I expected. For example, it would take the better part of a day to fetch < 10 GB in the Opportunity stream.

It turns out, Salesforce [says](https://developer.salesforce.com/docs/atlas.en-us.api_asynch.meta/api_asynch/query_get_job_results.htm#:~:text=If%20you%20are,the%20maximum%20size.):

> If you are working with a very large number of query results, you may experience a timeout before receiving all the data from Salesforce. To prevent a timeout, specify the maximum number of records your client is expecting to receive in the maxRecords parameter. This splits the results into smaller sets with this value as the maximum size.

My own testing pointed to a timeout issue too; the connector was trying to fetch all results in a single HTTP request, Salesforce timed out (apparently silently) and stopped sending results, and the connector would hang on the `__anext__()` call in `AsyncByteReader.read` since Salesforce stopped sending data. Adding a `maxRecords` param does exactly what Salesforce says it should, and the connector ends up using multiple, shorter-lived requests to page through result sets instead of trying to get all results in a single request.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

Tested on a local stack. Confirmed that before adding a `maxRecords` parameter, reading bulk job results would eventually stall within `AsyncByteReader.read` trying to fetch more bytes from Salesforce. After adding the `maxRecords` parameter, the connector no longer stalls within `AsyncByteReader.read` and finishes paging through the result sets.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2683)
<!-- Reviewable:end -->
