### PR TITLE
source-google-analytics-data-api-native: support metricAggregations

### DIFF
--- a/source-google-analytics-data-api-native/config.yaml
+++ b/source-google-analytics-data-api-native/config.yaml
@@ -1,4 +1,4 @@
-custom_reports: '[{"name": "my_custom_report_with_a_filter", "dimensions": ["date", "browser"], "metrics": ["totalUsers"], "dimensionFilter": {"filter": {"fieldName": "browser", "stringFilter": {"value": "Chrome"}}}}]'
+custom_reports: '[{"name":"my_custom_report_with_a_filter","dimensions":["date","browser"],"metrics":["totalUsers"],"dimensionFilter":{"filter":{"fieldName":"browser","stringFilter":{"value":"Chrome"}}},"metricAggregations":["TOTAL","MINIMUM","MAXIMUM"]}]'
 credentials:
     credentials_title: OAuth Credentials
     client_id_sops: ENC[AES256_GCM,data:5xiK/bKNLundU1KFZbnE2omS67SqMF2Qo7vNVVsHOcbwVH26eKGdCKp0isKEsq4FgMKIKddx42bU+F3VaS5hxIi+62wvKW3MYQ==,iv:gr2U2fsO6wf08/hHPzdBv3UNwjn1m+A5gfdAgD8MRQU=,tag:QUHU9w7g7SZ3JSWLow3Y2w==,type:str]
@@ -15,8 +15,8 @@ sops:
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2025-02-07T19:04:41Z"
-    mac: ENC[AES256_GCM,data:Baef8+VyQ9ZqonlMbrwANTEDqA0jMLm6HPPOT8uxT49R/1KpIAnyCsQHHP2sVcX4EpG8kMmjqdQVMXlyfayLJRj9LCR/XVYTXURZVdSyrx5DiTT92minPCOgtuWTmfqAfTHo376c/6Gd3ccbypBvk/f1F7/1tRPdNf0fprKVMxo=,iv:ZiqDK5MzkFSj8mC0sHcXQKZGqLXE6D0E3hit3fQMJlM=,tag:zuBFp4S5zRinv2M7Vgo4Pg==,type:str]
+    lastmodified: "2025-04-17T15:36:39Z"
+    mac: ENC[AES256_GCM,data:BzVWXQYB1xUKJCqFg/kgw+hxH7JiLHWEu/07fcwMrY0W4/hX6ELuzBGpKw9YlZKQDJSMVUtqN89Uumet3fr/m6ZET+nkUDFWH2taJsM4N+6T2y+gx1YT8zdZ+cP7nuyW0x/e4WPnUuDkkj64ZNaXbSDZLJdwRL3kaeDUcyTShtE=,iv:K8YAH2xhQI9HthjQTKzyFjk/dNW6QrwXqMPHlT78EN4=,tag:76FOwZZr7NJtaT/QPv/upA==,type:str]
     pgp: []
     encrypted_suffix: _sops
     version: 3.7.3

--- a/source-google-analytics-data-api-native/source_google_analytics_data_api_native/resources.py
+++ b/source-google-analytics-data-api-native/source_google_analytics_data_api_native/resources.py
@@ -23,6 +23,7 @@ from .models import (
     ResourceState,
     OAUTH2_SPEC,
     create_report_doc_model,
+    MetricAggregation,
     Report,
     ReportDocument,
 )
@@ -89,6 +90,8 @@ async def validate_custom_reports_json(
 
         raise ValidationError([msg])
 
+    valid_metric_aggregations = [a.value for a in MetricAggregation]
+
     for custom_report_details in custom_reports:
         try:
             assert isinstance(custom_report_details, dict)
@@ -103,6 +106,11 @@ async def validate_custom_reports_json(
             for metric in model.metrics:
                 if metric not in valid_metrics:
                     errors.append(f'"{metric}" in report "{model.name}" is not a valid metric. Consult {VALID_METRICS_DOCS_URL} for a list of valid metrics.')
+
+            if model.metricAggregations:
+                for aggregation in model.metricAggregations:
+                    if aggregation not in valid_metric_aggregations:
+                        errors.append(f'"{aggregation} in report "{model.name}" is not a supported metric aggregation. Supported metric aggregations are {valid_metric_aggregations}.')
 
         except (AssertionError, ModelValidationError) as err:
             if isinstance(err, AssertionError):


### PR DESCRIPTION
**Description:**

Users have requested support for [`metricAggregations`](https://developers.google.com/analytics/devguides/reporting/data/v1/rest/v1beta/MetricAggregation) for reports. These aggregations are returned under separate top-level fields (like "totals") intead of within the `rows` field of the response. For example, when using a "TOTAL" metric aggregation, the response can look like:
```json
{
  "dimensionHeaders": [...],
  "metricHeaders": [...],
  "rows": [...],
  "totals": [
    {
      "dimensionValues": [
        {
          "value": "RESERVED_TOTAL"
        }
      ],
      "metricValues": [
        {
          "value": "64"
        }
      ]
    }
  ],
  ...
}

```

We can treat aggregates like the other rows inside the `rows` field when they're present, and their dimension values will indicate the type of aggregation (ex: "RESERVED_TOTAL").

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

The connector docs should be updated to reflect that `metricAggregations` are supported and provide an example of a custom report with valid `metricAggregations`.

**Notes for reviewers:**

Tested on a local stack. Confirmed:
- Aggregates are emitted as separate documents with the appropriate dimension value for the aggregate (ex: "RESERVED_TOTAL").
- Providing an invalid value in `metricAggregations` raises a validation error stating which provided value is not supported.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2685)
<!-- Reviewable:end -->
