### PR TITLE
source-salesforce-native: discover custom share, feed, and metadata objects

### DIFF
--- a/source-salesforce-native/source_salesforce_native/resources.py
+++ b/source-salesforce-native/source_salesforce_native/resources.py
@@ -10,8 +10,9 @@ from estuary_cdk.capture.common import ReductionStrategy
 from estuary_cdk.http import HTTPMixin
 
 from .supported_standard_objects import (
-    COMMON_CUSTOM_OBJECT_DETAILS,
-    COMMON_CUSTOM_OBJECT_HISTORY_DETAILS,
+    CUSTOM_OBJECT_WITH_SYSTEM_MODSTAMP_DETAILS,
+    CUSTOM_OBJECT_WITH_CREATED_DATE_DETAILS,
+    CUSTOM_OBJECT_WITH_LAST_MODIFIED_DATE_DETAILS,
     SUPPORTED_STANDARD_OBJECTS,
 
 )
@@ -42,7 +43,10 @@ from .api import (
 
 
 CUSTOM_OBJECT_SUFFIX = '__c'
+CUSTOM_OBJECT_FEED_SUFFIX = '__Feed'
+CUSTOM_OBJECT_METADATA_SUFFIX = '__mdt'
 CUSTOM_OBJECT_HISTORY_SUFFIX = '__History'
+CUSTOM_OBJECT_SHARE_SUFFIX = '__Share'
 BUILD_RESOURCE_SEMAPHORE_LIMIT = 15
 
 
@@ -218,13 +222,27 @@ async def _object_to_resource(
         name: str,
         should_fetch_fields: bool = False,
     ) -> common.Resource | None:
-    is_custom_object = name.endswith(CUSTOM_OBJECT_SUFFIX)
-    is_custom_object_history = name.endswith(CUSTOM_OBJECT_HISTORY_SUFFIX)
 
-    if is_custom_object:
-        details = COMMON_CUSTOM_OBJECT_DETAILS
-    elif is_custom_object_history:
-        details = COMMON_CUSTOM_OBJECT_HISTORY_DETAILS
+    is_custom_object_with_system_modstamp = (
+        name.endswith(CUSTOM_OBJECT_SUFFIX)
+        or name.endswith(CUSTOM_OBJECT_FEED_SUFFIX)
+        or name.endswith(CUSTOM_OBJECT_METADATA_SUFFIX)
+    )
+
+    is_custom_object_with_last_modified_date = (
+        name.endswith(CUSTOM_OBJECT_SHARE_SUFFIX)
+    )
+
+    is_custom_object_with_created_date = (
+        name.endswith(CUSTOM_OBJECT_HISTORY_SUFFIX)
+    )
+
+    if is_custom_object_with_system_modstamp:
+        details = CUSTOM_OBJECT_WITH_SYSTEM_MODSTAMP_DETAILS
+    elif is_custom_object_with_last_modified_date:
+        details = CUSTOM_OBJECT_WITH_LAST_MODIFIED_DATE_DETAILS
+    elif is_custom_object_with_created_date:
+        details = CUSTOM_OBJECT_WITH_CREATED_DATE_DETAILS
     else:
         details = SUPPORTED_STANDARD_OBJECTS.get(name, None)
 

--- a/source-salesforce-native/source_salesforce_native/supported_standard_objects.py
+++ b/source-salesforce-native/source_salesforce_native/supported_standard_objects.py
@@ -19,12 +19,16 @@ class ObjectDetails(TypedDict, total=False):
     is_supported_by_bulk_api: Optional[bool] # If absent, the object is supported by the Bulk API. If present and False, the object is not supported by the Bulk API.
 
 
-COMMON_CUSTOM_OBJECT_DETAILS: ObjectDetails = {
+CUSTOM_OBJECT_WITH_SYSTEM_MODSTAMP_DETAILS: ObjectDetails = {
     "cursor_field": CursorFields.SYSTEM_MODSTAMP,
 }
 
-COMMON_CUSTOM_OBJECT_HISTORY_DETAILS: ObjectDetails = {
+CUSTOM_OBJECT_WITH_CREATED_DATE_DETAILS: ObjectDetails = {
     "cursor_field": CursorFields.CREATED_DATE,
+}
+
+CUSTOM_OBJECT_WITH_LAST_MODIFIED_DATE_DETAILS: ObjectDetails = {
+    "cursor_field": CursorFields.LAST_MODIFIED_DATE,
 }
 
 


### PR DESCRIPTION
**Description:**

There are a few special custom objects that don't end in `__c`, and users are asking us to support them. This PR adds a few we're currently being asked about.

[Feeds](https://developer.salesforce.com/docs/atlas.en-us.object_reference.meta/object_reference/sforce_api_objects_customobject__feed.htm) for custom objects end in `__Feed` and always have a `SystemModstamp` field.

Custom [metadata](https://developer.salesforce.com/docs/atlas.en-us.object_reference.meta/object_reference/sforce_api_objects_custommetadatatype__mdt.htm) end in `__mdt` and always have a `SystemModstamp` field.

Sharing rules for custom objects end in `__Share` and always have a `LastModifiedDate` field.

There are other special, custom objects we don't support (like [change events](https://developer.salesforce.com/docs/atlas.en-us.object_reference.meta/object_reference/sforce_api_associated_objects_change_event.htm) ending in `__ChangeEvent`), but no one is asking about these and it seems like these would need some additional special handling beyond what's already in the connector (ex: there may be query restrictions or a parent-child relationship).

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

Tested on a local stack. Confirmed objects ending in `__Share`, `__Feed`, and `__mdt` are discovered as possible bindings & the connector captures data for them like other incremental streams.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2687)
<!-- Reviewable:end -->
