### PR TITLE
source-firestore: Don't interrupt ongoing backfills

### DIFF
--- a/source-firestore/.snapshots/TestInitResourceStates
+++ b/source-firestore/.snapshots/TestInitResourceStates
@@ -43,7 +43,8 @@ users%2F%2A%2Fdocs:
     "Completed": false,
     "Cursor": "users/123/docs/456",
     "MTime": "2024-05-30T11:15:00Z"
-  }
+  },
+  "Inconsistent": true
 }
 
 --- inconsistent state with completed backfill should schedule new backfill ---

--- a/source-firestore/.snapshots/TestInitResourceStates
+++ b/source-firestore/.snapshots/TestInitResourceStates
@@ -1,0 +1,60 @@
+--- new binding with no previous state ---
+users%2F%2A%2Fdocs:
+{
+  "ReadTime": "2024-05-30T12:00:00Z",
+  "Backfill": {
+    "StartAfter": "2024-05-30T12:00:00Z",
+    "Completed": false,
+    "Cursor": "",
+    "MTime": "0001-01-01T00:00:00Z"
+  }
+}
+
+--- still consistent with ongoing backfill should continue backfill ---
+users%2F%2A%2Fdocs:
+{
+  "ReadTime": "2024-05-30T11:00:00Z",
+  "Backfill": {
+    "StartAfter": "2024-05-30T11:30:00Z",
+    "Completed": false,
+    "Cursor": "users/123/docs/456",
+    "MTime": "2024-05-30T11:15:00Z"
+  }
+}
+
+--- still consistent with completed backfill should preserve that ---
+users%2F%2A%2Fdocs:
+{
+  "ReadTime": "2024-05-30T11:00:00Z",
+  "Backfill": {
+    "StartAfter": "2024-05-30T10:00:00Z",
+    "Completed": true,
+    "Cursor": "",
+    "MTime": "0001-01-01T00:00:00Z"
+  }
+}
+
+--- inconsistent state with ongoing backfill should continue backfill ---
+users%2F%2A%2Fdocs:
+{
+  "ReadTime": "2024-05-30T12:00:00Z",
+  "Backfill": {
+    "StartAfter": "2024-05-30T11:30:00Z",
+    "Completed": false,
+    "Cursor": "users/123/docs/456",
+    "MTime": "2024-05-30T11:15:00Z"
+  }
+}
+
+--- inconsistent state with completed backfill should schedule new backfill ---
+users%2F%2A%2Fdocs:
+{
+  "ReadTime": "2024-05-30T12:00:00Z",
+  "Backfill": {
+    "StartAfter": "2024-05-31T10:00:00Z",
+    "Completed": false,
+    "Cursor": "",
+    "MTime": "0001-01-01T00:00:00Z"
+  }
+}
+

--- a/source-firestore/pull.go
+++ b/source-firestore/pull.go
@@ -237,6 +237,7 @@ func initResourceStates(prevStates map[boilerplate.StateKey]*resourceState, bind
 		// otherwise we need to initialize a new backfill.
 		if prevState.Backfill != nil && !prevState.Backfill.Completed {
 			state.Backfill = prevState.Backfill
+			state.Inconsistent = true // Still inconsistent for later
 		} else if res.BackfillMode == backfillModeAsync {
 			state.Backfill = &backfillState{
 				StartAfter: computeBackfillStartTime(


### PR DESCRIPTION
**Description:**

When change streaming fails to catch up, we allow the change stream to "skip ahead" and flag the binding as inconsistent so we can run another backfill in the future.

But previously, if change streaming failed repeatedly during an ongoing backfill, that backfill would keep getting interrupted and rescheduled for 24 hours in the future. This meant that a really flaky stream in conjunction with frequent task restarts could prevent the backfill from ever getting anything done, because it would keep on getting through just a small bit of the data, then the task would restart, we'd see the 'Inconsistent: true' flag, and we'd interrupt the backfill and schedule it to start over from the top the next day.

The solution is that we should never interrupt an ongoing backfill, once started we should see it through and then run _another_ one afterwards (subject to our minimum delay between backfills) to resolve the inconsistent flag.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2689)
<!-- Reviewable:end -->
