### PR TITLE
sqlcapture: Logging tweaks

### DIFF
--- a/source-boilerplate/testing/testing.go
+++ b/source-boilerplate/testing/testing.go
@@ -152,7 +152,7 @@ func (cs *CaptureSpec) Capture(ctx context.Context, t testing.TB, callback func(
 		t.Skipf("skipping %q capture: ${TEST_DATABASE} != \"yes\"", t.Name())
 	}
 	log.WithFields(log.Fields{
-		"checkpoint": cs.Checkpoint,
+		"checkpoint": string(cs.Checkpoint),
 	}).Debug("running test capture")
 
 	endpointSpecJSON, err := json.Marshal(cs.EndpointSpec)

--- a/source-mysql/replication.go
+++ b/source-mysql/replication.go
@@ -1307,7 +1307,7 @@ func (rs *mysqlReplicationStream) StreamToFence(ctx context.Context, fenceAfter 
 					return fmt.Errorf("internal error: failed to parse flush event cursor value %q", event.Cursor)
 				}
 				if eventPosition.Compare(fencePosition) >= 0 {
-					logrus.WithField("cursor", event.Cursor).Debug("finished fenced streaming phase")
+					logrus.WithField("cursor", eventCursor).Debug("finished fenced streaming phase")
 					rs.fencePosition = eventPosition
 					return nil
 				}

--- a/source-postgres/replication.go
+++ b/source-postgres/replication.go
@@ -397,7 +397,7 @@ func (s *replicationStream) StreamToFence(ctx context.Context, fenceAfter time.D
 					return fmt.Errorf("internal error: failed to parse flush event cursor value %q", event.Cursor)
 				}
 				if eventLSN >= fenceLSN {
-					logrus.WithField("cursor", event.Cursor).Debug("finished fenced streaming phase")
+					logrus.WithField("cursor", eventCursor).Debug("finished fenced streaming phase")
 					s.previousFenceLSN = eventLSN
 					return nil
 				}


### PR DESCRIPTION
**Description:**

This commit makes two logging changes:
1. The sqlcapture logic will now maintain separate counts of the important event types and log the counts separately rather than a single opaque "events" count.
2. Fixes a handful of spots I noticed while testing the previous change where serialized JSON values were being logged as byte arrays `[65 66 67]` which is ugly. Most of these are new from the cursors-as-JSON refactoring I did yesterday, so I figured I'd just address those real quick while I was at it.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2691)
<!-- Reviewable:end -->
