### PR TITLE
materialize-iceberg: always create identity columns as required

### DIFF
--- a/materialize-iceberg/type_mapping.go
+++ b/materialize-iceberg/type_mapping.go
@@ -234,7 +234,7 @@ func appendProjectionsAsFields(dst *[]iceberg.NestedField, ps []boilerplate.Mapp
 			ID:       id,
 			Name:     p.Field,
 			Type:     p.Mapped.type_,
-			Required: p.MustExist,
+			Required: p.MustExist || p.IsPrimaryKey,
 			Doc:      strings.ReplaceAll(p.Comment, "\n", " - "), // Glue catalogs don't support newlines in field comments
 		})
 		ids = append(ids, id)


### PR DESCRIPTION
**Description:**

Materializations do not support nullable keys in general, and materialize-iceberg is no exception.

A non-required source collection field is allowed as a key if it has a default value set, and so if a key field has been selected we know it will never be null and should create the column for the key field accordingly. On a practical level, this is necessary since key fields are created as identity columns which cannot be not required.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2692)
<!-- Reviewable:end -->
