### PR TITLE
source-mysql: Add "tinyint1_as_bool" feature flag

### DIFF
--- a/source-mysql/.snapshots/TestFeatureFlagTinyintAsBool-Default-Capture
+++ b/source-mysql/.snapshots/TestFeatureFlagTinyintAsBool-Default-Capture
@@ -1,0 +1,16 @@
+# ================================
+# Collection "acmeCo/test/test/featureflagtinyintasbool_21925183": 8 Documents
+# ================================
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"FeatureFlagTinyintAsBool_21925183","cursor":"backfill:0"}},"id":1,"v_bool":1,"v_tinyint":1}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"FeatureFlagTinyintAsBool_21925183","cursor":"backfill:1"}},"id":2,"v_bool":0,"v_tinyint":0}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"FeatureFlagTinyintAsBool_21925183","cursor":"backfill:2"}},"id":3,"v_bool":1,"v_tinyint":2}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"FeatureFlagTinyintAsBool_21925183","cursor":"backfill:3"}},"id":4,"v_bool":0,"v_tinyint":127}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"FeatureFlagTinyintAsBool_21925183","cursor":"backfill:4"}},"id":5,"v_bool":1,"v_tinyint":-128}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"FeatureFlagTinyintAsBool_21925183","cursor":"backfill:5"}},"id":6,"v_bool":null,"v_tinyint":1}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"FeatureFlagTinyintAsBool_21925183","cursor":"backfill:6"}},"id":7,"v_bool":1,"v_tinyint":null}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"FeatureFlagTinyintAsBool_21925183","cursor":"backfill:7"}},"id":8,"v_bool":null,"v_tinyint":null}
+# ================================
+# Final State Checkpoint
+# ================================
+{"bindingStateV1":{"test%2FFeatureFlagTinyintAsBool_21925183":{"backfilled":8,"key_columns":["id"],"metadata":{"charset":"utf8mb4","schema":{"columns":["id","v_bool","v_tinyint"],"types":{"id":{"type":"int"},"v_bool":{"type":"tinyint"},"v_tinyint":{"type":"tinyint"}}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
+

--- a/source-mysql/.snapshots/TestFeatureFlagTinyintAsBool-Default-Discovery
+++ b/source-mysql/.snapshots/TestFeatureFlagTinyintAsBool-Default-Discovery
@@ -1,0 +1,139 @@
+Binding 0:
+{
+    "recommended_name": "test/featureflagtinyintasbool_21925183",
+    "resource_config_json": {
+      "namespace": "test",
+      "stream": "FeatureFlagTinyintAsBool_21925183"
+    },
+    "document_schema_json": {
+      "$defs": {
+        "TestFeatureFlagTinyintAsBool_21925183": {
+          "type": "object",
+          "required": [
+            "id"
+          ],
+          "$anchor": "TestFeatureFlagTinyintAsBool_21925183",
+          "properties": {
+            "id": {
+              "type": "integer",
+              "description": "(source type: non-nullable int)"
+            },
+            "v_bool": {
+              "description": "(source type: tinyint)",
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "v_tinyint": {
+              "description": "(source type: tinyint)",
+              "type": [
+                "integer",
+                "null"
+              ]
+            }
+          }
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "_meta": {
+                "properties": {
+                  "op": {
+                    "const": "d"
+                  }
+                }
+              }
+            }
+          },
+          "then": {
+            "reduce": {
+              "delete": true,
+              "strategy": "merge"
+            }
+          },
+          "else": {
+            "reduce": {
+              "strategy": "merge"
+            }
+          },
+          "required": [
+            "_meta"
+          ],
+          "properties": {
+            "_meta": {
+              "type": "object",
+              "required": [
+                "op",
+                "source"
+              ],
+              "properties": {
+                "before": {
+                  "$ref": "#TestFeatureFlagTinyintAsBool_21925183",
+                  "description": "Record state immediately before this change was applied.",
+                  "reduce": {
+                    "strategy": "firstWriteWins"
+                  }
+                },
+                "op": {
+                  "enum": [
+                    "c",
+                    "d",
+                    "u"
+                  ],
+                  "description": "Change operation type: 'c' Create/Insert, 'u' Update, 'd' Delete."
+                },
+                "source": {
+                  "$id": "https://github.com/estuary/connectors/source-mysql/mysql-source-info",
+                  "properties": {
+                    "ts_ms": {
+                      "type": "integer",
+                      "description": "Unix timestamp (in millis) at which this event was recorded by the database."
+                    },
+                    "schema": {
+                      "type": "string",
+                      "description": "Database schema (namespace) of the event."
+                    },
+                    "snapshot": {
+                      "type": "boolean",
+                      "description": "Snapshot is true if the record was produced from an initial table backfill and unset if produced from the replication log."
+                    },
+                    "table": {
+                      "type": "string",
+                      "description": "Database table of the event."
+                    },
+                    "cursor": {
+                      "type": "string",
+                      "description": "Cursor value representing the current position in the binlog."
+                    },
+                    "txid": {
+                      "type": "string",
+                      "description": "The global transaction identifier associated with a change by MySQL. Only set if GTIDs are enabled."
+                    }
+                  },
+                  "type": "object",
+                  "required": [
+                    "schema",
+                    "table",
+                    "cursor"
+                  ]
+                }
+              },
+              "reduce": {
+                "strategy": "merge"
+              }
+            }
+          }
+        },
+        {
+          "$ref": "#TestFeatureFlagTinyintAsBool_21925183"
+        }
+      ]
+    },
+    "key": [
+      "/id"
+    ]
+  }
+

--- a/source-mysql/.snapshots/TestFeatureFlagTinyintAsBool-Disabled-Capture
+++ b/source-mysql/.snapshots/TestFeatureFlagTinyintAsBool-Disabled-Capture
@@ -1,0 +1,16 @@
+# ================================
+# Collection "acmeCo/test/test/featureflagtinyintasbool_21925183": 8 Documents
+# ================================
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"FeatureFlagTinyintAsBool_21925183","cursor":"backfill:0"}},"id":1,"v_bool":1,"v_tinyint":1}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"FeatureFlagTinyintAsBool_21925183","cursor":"backfill:1"}},"id":2,"v_bool":0,"v_tinyint":0}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"FeatureFlagTinyintAsBool_21925183","cursor":"backfill:2"}},"id":3,"v_bool":1,"v_tinyint":2}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"FeatureFlagTinyintAsBool_21925183","cursor":"backfill:3"}},"id":4,"v_bool":0,"v_tinyint":127}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"FeatureFlagTinyintAsBool_21925183","cursor":"backfill:4"}},"id":5,"v_bool":1,"v_tinyint":-128}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"FeatureFlagTinyintAsBool_21925183","cursor":"backfill:5"}},"id":6,"v_bool":null,"v_tinyint":1}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"FeatureFlagTinyintAsBool_21925183","cursor":"backfill:6"}},"id":7,"v_bool":1,"v_tinyint":null}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"FeatureFlagTinyintAsBool_21925183","cursor":"backfill:7"}},"id":8,"v_bool":null,"v_tinyint":null}
+# ================================
+# Final State Checkpoint
+# ================================
+{"bindingStateV1":{"test%2FFeatureFlagTinyintAsBool_21925183":{"backfilled":8,"key_columns":["id"],"metadata":{"charset":"utf8mb4","schema":{"columns":["id","v_bool","v_tinyint"],"types":{"id":{"type":"int"},"v_bool":{"type":"tinyint"},"v_tinyint":{"type":"tinyint"}}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
+

--- a/source-mysql/.snapshots/TestFeatureFlagTinyintAsBool-Disabled-Discovery
+++ b/source-mysql/.snapshots/TestFeatureFlagTinyintAsBool-Disabled-Discovery
@@ -1,0 +1,139 @@
+Binding 0:
+{
+    "recommended_name": "test/featureflagtinyintasbool_21925183",
+    "resource_config_json": {
+      "namespace": "test",
+      "stream": "FeatureFlagTinyintAsBool_21925183"
+    },
+    "document_schema_json": {
+      "$defs": {
+        "TestFeatureFlagTinyintAsBool_21925183": {
+          "type": "object",
+          "required": [
+            "id"
+          ],
+          "$anchor": "TestFeatureFlagTinyintAsBool_21925183",
+          "properties": {
+            "id": {
+              "type": "integer",
+              "description": "(source type: non-nullable int)"
+            },
+            "v_bool": {
+              "description": "(source type: tinyint)",
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "v_tinyint": {
+              "description": "(source type: tinyint)",
+              "type": [
+                "integer",
+                "null"
+              ]
+            }
+          }
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "_meta": {
+                "properties": {
+                  "op": {
+                    "const": "d"
+                  }
+                }
+              }
+            }
+          },
+          "then": {
+            "reduce": {
+              "delete": true,
+              "strategy": "merge"
+            }
+          },
+          "else": {
+            "reduce": {
+              "strategy": "merge"
+            }
+          },
+          "required": [
+            "_meta"
+          ],
+          "properties": {
+            "_meta": {
+              "type": "object",
+              "required": [
+                "op",
+                "source"
+              ],
+              "properties": {
+                "before": {
+                  "$ref": "#TestFeatureFlagTinyintAsBool_21925183",
+                  "description": "Record state immediately before this change was applied.",
+                  "reduce": {
+                    "strategy": "firstWriteWins"
+                  }
+                },
+                "op": {
+                  "enum": [
+                    "c",
+                    "d",
+                    "u"
+                  ],
+                  "description": "Change operation type: 'c' Create/Insert, 'u' Update, 'd' Delete."
+                },
+                "source": {
+                  "$id": "https://github.com/estuary/connectors/source-mysql/mysql-source-info",
+                  "properties": {
+                    "ts_ms": {
+                      "type": "integer",
+                      "description": "Unix timestamp (in millis) at which this event was recorded by the database."
+                    },
+                    "schema": {
+                      "type": "string",
+                      "description": "Database schema (namespace) of the event."
+                    },
+                    "snapshot": {
+                      "type": "boolean",
+                      "description": "Snapshot is true if the record was produced from an initial table backfill and unset if produced from the replication log."
+                    },
+                    "table": {
+                      "type": "string",
+                      "description": "Database table of the event."
+                    },
+                    "cursor": {
+                      "type": "string",
+                      "description": "Cursor value representing the current position in the binlog."
+                    },
+                    "txid": {
+                      "type": "string",
+                      "description": "The global transaction identifier associated with a change by MySQL. Only set if GTIDs are enabled."
+                    }
+                  },
+                  "type": "object",
+                  "required": [
+                    "schema",
+                    "table",
+                    "cursor"
+                  ]
+                }
+              },
+              "reduce": {
+                "strategy": "merge"
+              }
+            }
+          }
+        },
+        {
+          "$ref": "#TestFeatureFlagTinyintAsBool_21925183"
+        }
+      ]
+    },
+    "key": [
+      "/id"
+    ]
+  }
+

--- a/source-mysql/.snapshots/TestFeatureFlagTinyintAsBool-Enabled-Capture
+++ b/source-mysql/.snapshots/TestFeatureFlagTinyintAsBool-Enabled-Capture
@@ -1,16 +1,16 @@
 # ================================
 # Collection "acmeCo/test/test/featureflagtinyintasbool_21925183": 8 Documents
 # ================================
-{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"FeatureFlagTinyintAsBool_21925183","cursor":"backfill:0"}},"id":1,"v_bool":1,"v_tinyint":1}
-{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"FeatureFlagTinyintAsBool_21925183","cursor":"backfill:1"}},"id":2,"v_bool":0,"v_tinyint":0}
-{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"FeatureFlagTinyintAsBool_21925183","cursor":"backfill:2"}},"id":3,"v_bool":1,"v_tinyint":2}
-{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"FeatureFlagTinyintAsBool_21925183","cursor":"backfill:3"}},"id":4,"v_bool":0,"v_tinyint":127}
-{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"FeatureFlagTinyintAsBool_21925183","cursor":"backfill:4"}},"id":5,"v_bool":1,"v_tinyint":-128}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"FeatureFlagTinyintAsBool_21925183","cursor":"backfill:0"}},"id":1,"v_bool":true,"v_tinyint":1}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"FeatureFlagTinyintAsBool_21925183","cursor":"backfill:1"}},"id":2,"v_bool":false,"v_tinyint":0}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"FeatureFlagTinyintAsBool_21925183","cursor":"backfill:2"}},"id":3,"v_bool":true,"v_tinyint":2}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"FeatureFlagTinyintAsBool_21925183","cursor":"backfill:3"}},"id":4,"v_bool":false,"v_tinyint":127}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"FeatureFlagTinyintAsBool_21925183","cursor":"backfill:4"}},"id":5,"v_bool":true,"v_tinyint":-128}
 {"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"FeatureFlagTinyintAsBool_21925183","cursor":"backfill:5"}},"id":6,"v_bool":null,"v_tinyint":1}
-{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"FeatureFlagTinyintAsBool_21925183","cursor":"backfill:6"}},"id":7,"v_bool":1,"v_tinyint":null}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"FeatureFlagTinyintAsBool_21925183","cursor":"backfill:6"}},"id":7,"v_bool":true,"v_tinyint":null}
 {"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"FeatureFlagTinyintAsBool_21925183","cursor":"backfill:7"}},"id":8,"v_bool":null,"v_tinyint":null}
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"test%2FFeatureFlagTinyintAsBool_21925183":{"backfilled":8,"key_columns":["id"],"metadata":{"charset":"utf8mb4","schema":{"columns":["id","v_bool","v_tinyint"],"types":{"id":{"type":"int"},"v_bool":{"type":"tinyint"},"v_tinyint":{"type":"tinyint"}}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
+{"bindingStateV1":{"test%2FFeatureFlagTinyintAsBool_21925183":{"backfilled":8,"key_columns":["id"],"metadata":{"charset":"utf8mb4","schema":{"columns":["id","v_bool","v_tinyint"],"types":{"id":{"type":"int"},"v_bool":{"type":"boolean"},"v_tinyint":{"type":"tinyint"}}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
 

--- a/source-mysql/.snapshots/TestFeatureFlagTinyintAsBool-Enabled-Capture
+++ b/source-mysql/.snapshots/TestFeatureFlagTinyintAsBool-Enabled-Capture
@@ -1,0 +1,16 @@
+# ================================
+# Collection "acmeCo/test/test/featureflagtinyintasbool_21925183": 8 Documents
+# ================================
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"FeatureFlagTinyintAsBool_21925183","cursor":"backfill:0"}},"id":1,"v_bool":1,"v_tinyint":1}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"FeatureFlagTinyintAsBool_21925183","cursor":"backfill:1"}},"id":2,"v_bool":0,"v_tinyint":0}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"FeatureFlagTinyintAsBool_21925183","cursor":"backfill:2"}},"id":3,"v_bool":1,"v_tinyint":2}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"FeatureFlagTinyintAsBool_21925183","cursor":"backfill:3"}},"id":4,"v_bool":0,"v_tinyint":127}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"FeatureFlagTinyintAsBool_21925183","cursor":"backfill:4"}},"id":5,"v_bool":1,"v_tinyint":-128}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"FeatureFlagTinyintAsBool_21925183","cursor":"backfill:5"}},"id":6,"v_bool":null,"v_tinyint":1}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"FeatureFlagTinyintAsBool_21925183","cursor":"backfill:6"}},"id":7,"v_bool":1,"v_tinyint":null}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"FeatureFlagTinyintAsBool_21925183","cursor":"backfill:7"}},"id":8,"v_bool":null,"v_tinyint":null}
+# ================================
+# Final State Checkpoint
+# ================================
+{"bindingStateV1":{"test%2FFeatureFlagTinyintAsBool_21925183":{"backfilled":8,"key_columns":["id"],"metadata":{"charset":"utf8mb4","schema":{"columns":["id","v_bool","v_tinyint"],"types":{"id":{"type":"int"},"v_bool":{"type":"tinyint"},"v_tinyint":{"type":"tinyint"}}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
+

--- a/source-mysql/.snapshots/TestFeatureFlagTinyintAsBool-Enabled-Discovery
+++ b/source-mysql/.snapshots/TestFeatureFlagTinyintAsBool-Enabled-Discovery
@@ -1,0 +1,139 @@
+Binding 0:
+{
+    "recommended_name": "test/featureflagtinyintasbool_21925183",
+    "resource_config_json": {
+      "namespace": "test",
+      "stream": "FeatureFlagTinyintAsBool_21925183"
+    },
+    "document_schema_json": {
+      "$defs": {
+        "TestFeatureFlagTinyintAsBool_21925183": {
+          "type": "object",
+          "required": [
+            "id"
+          ],
+          "$anchor": "TestFeatureFlagTinyintAsBool_21925183",
+          "properties": {
+            "id": {
+              "type": "integer",
+              "description": "(source type: non-nullable int)"
+            },
+            "v_bool": {
+              "description": "(source type: tinyint)",
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "v_tinyint": {
+              "description": "(source type: tinyint)",
+              "type": [
+                "integer",
+                "null"
+              ]
+            }
+          }
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "_meta": {
+                "properties": {
+                  "op": {
+                    "const": "d"
+                  }
+                }
+              }
+            }
+          },
+          "then": {
+            "reduce": {
+              "delete": true,
+              "strategy": "merge"
+            }
+          },
+          "else": {
+            "reduce": {
+              "strategy": "merge"
+            }
+          },
+          "required": [
+            "_meta"
+          ],
+          "properties": {
+            "_meta": {
+              "type": "object",
+              "required": [
+                "op",
+                "source"
+              ],
+              "properties": {
+                "before": {
+                  "$ref": "#TestFeatureFlagTinyintAsBool_21925183",
+                  "description": "Record state immediately before this change was applied.",
+                  "reduce": {
+                    "strategy": "firstWriteWins"
+                  }
+                },
+                "op": {
+                  "enum": [
+                    "c",
+                    "d",
+                    "u"
+                  ],
+                  "description": "Change operation type: 'c' Create/Insert, 'u' Update, 'd' Delete."
+                },
+                "source": {
+                  "$id": "https://github.com/estuary/connectors/source-mysql/mysql-source-info",
+                  "properties": {
+                    "ts_ms": {
+                      "type": "integer",
+                      "description": "Unix timestamp (in millis) at which this event was recorded by the database."
+                    },
+                    "schema": {
+                      "type": "string",
+                      "description": "Database schema (namespace) of the event."
+                    },
+                    "snapshot": {
+                      "type": "boolean",
+                      "description": "Snapshot is true if the record was produced from an initial table backfill and unset if produced from the replication log."
+                    },
+                    "table": {
+                      "type": "string",
+                      "description": "Database table of the event."
+                    },
+                    "cursor": {
+                      "type": "string",
+                      "description": "Cursor value representing the current position in the binlog."
+                    },
+                    "txid": {
+                      "type": "string",
+                      "description": "The global transaction identifier associated with a change by MySQL. Only set if GTIDs are enabled."
+                    }
+                  },
+                  "type": "object",
+                  "required": [
+                    "schema",
+                    "table",
+                    "cursor"
+                  ]
+                }
+              },
+              "reduce": {
+                "strategy": "merge"
+              }
+            }
+          }
+        },
+        {
+          "$ref": "#TestFeatureFlagTinyintAsBool_21925183"
+        }
+      ]
+    },
+    "key": [
+      "/id"
+    ]
+  }
+

--- a/source-mysql/.snapshots/TestFeatureFlagTinyintAsBool-Enabled-Discovery
+++ b/source-mysql/.snapshots/TestFeatureFlagTinyintAsBool-Enabled-Discovery
@@ -19,9 +19,9 @@ Binding 0:
               "description": "(source type: non-nullable int)"
             },
             "v_bool": {
-              "description": "(source type: tinyint)",
+              "description": "(source type: boolean)",
               "type": [
-                "integer",
+                "boolean",
                 "null"
               ]
             },

--- a/source-mysql/main.go
+++ b/source-mysql/main.go
@@ -33,6 +33,9 @@ var featureFlagDefaults = map[string]bool{
 	// When true, date columns will be discovered as `type: string, format: date`
 	// instead of simply `type: string`
 	"date_schema_format": true,
+
+	// When true, columns of type TINYINT(1) will be treated as booleans.
+	"tinyint1_as_bool": false,
 }
 
 type sshForwarding struct {


### PR DESCRIPTION
**Description:**

MySQL doesn't technically have a boolean type. If you declare a column of type `BOOLEAN` what actually happens is it gets treated as an alias for `TINYINT(1)` and similarly `TRUE` and `FALSE` are just aliases for one and zero.

However, in practice nobody would ever bother adding a display width parameter of 1 on a tinyint _except_ as the idiomatic way of getting a MySQL boolean column, so we can reliably assume that if we see a tinyint column that is specifically `TINYINT(1)` the user intended for it to be treated as a boolean.

This PR adds a "tinyint1_as_bool" feature flag, currently defaulting to off. When this flag is enabled, columns of type `TINYINT(1)` and only `TINYINT(1)` will be treated as booleans in both discovery and value translation.

We might want to make this the default going forward, but that's a separate concern.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2693)
<!-- Reviewable:end -->
