### PR TITLE
parquet-schema: fix nullability evaluation & consider default values

### DIFF
--- a/materialize-boilerplate/stream-encode/parquet_schema.go
+++ b/materialize-boilerplate/stream-encode/parquet_schema.go
@@ -215,7 +215,7 @@ func ProjectionToParquetSchemaElement(p pf.Projection, opts ...ParquetSchemaOpti
 
 	out := ParquetSchemaElement{
 		Name:     p.Field,
-		Required: p.Inference.Exists == pf.Inference_MUST,
+		Required: !slices.Contains(p.Inference.Types, "null") && (p.Inference.Exists == pf.Inference_MUST || p.Inference.DefaultJson != nil),
 	}
 
 	if numFormat, ok := boilerplate.AsFormattedNumeric(&p); ok {


### PR DESCRIPTION
**Description:**

The nullability evaluation for parquet schema columns was previously just plain wrong, since it didn't account for a field that was always present but could be an explicit null, so that's been fixed.

As an enhancement, it will now also consider a column to be required if its types do not allow an explicit null & it has a default value. In this case it is guaranteed that the field will always have a value that is not null, since if it is absent the default will kick in. This makes things consistent with how the boilerplate Apply handling does not drop NOT NULL constraints for fields with a default value, which is important for Iceberg tables where a file with an optional column cannot be appended to a table where that column is required.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2694)
<!-- Reviewable:end -->
