### PR TITLE
source-postgres: Fix XMIN backfill oversight

### DIFF
--- a/source-postgres/.snapshots/TestBackfillQueryGeneration
+++ b/source-postgres/.snapshots/TestBackfillQueryGeneration
@@ -14,9 +14,9 @@ SELECT * FROM "public"."users" ORDER BY "first_name", "last_name" LIMIT 100;
 SELECT * FROM "public"."users" WHERE ("first_name", "last_name") > ($1, $2) ORDER BY "first_name", "last_name" LIMIT 100;
 
 --- string_key_with_min_xid ---
-SELECT xmin::text AS xmin, * FROM "public"."users" WHERE ((RANDOM() < 0.001) OR ((xmin::text::bigint >= 3) AND ((((xmin::text::bigint - 12345::bigint)<<32)>>32) > 0) AND (((((CASE WHEN pg_is_in_recovery() THEN txid_snapshot_xmax(txid_current_snapshot()) ELSE txid_current() END) - xmin::text::bigint)<<32)>>32) >= 0))) ORDER BY "name" LIMIT 100;
+SELECT xmin::text AS xmin, * FROM "public"."users" WHERE ((RANDOM() < 0.001) OR ((xmin::text::bigint >= 3) AND ((((xmin::text::bigint - 12345::bigint)<<32)>>32) >= 0) AND ((((txid_snapshot_xmax(txid_current_snapshot()) - xmin::text::bigint)<<32)>>32) >= 0))) ORDER BY "name" LIMIT 100;
 
-SELECT xmin::text AS xmin, * FROM "public"."users" WHERE ("name") > ($1) AND ((RANDOM() < 0.001) OR ((xmin::text::bigint >= 3) AND ((((xmin::text::bigint - 12345::bigint)<<32)>>32) > 0) AND (((((CASE WHEN pg_is_in_recovery() THEN txid_snapshot_xmax(txid_current_snapshot()) ELSE txid_current() END) - xmin::text::bigint)<<32)>>32) >= 0))) ORDER BY "name" LIMIT 100;
+SELECT xmin::text AS xmin, * FROM "public"."users" WHERE ("name") > ($1) AND ((RANDOM() < 0.001) OR ((xmin::text::bigint >= 3) AND ((((xmin::text::bigint - 12345::bigint)<<32)>>32) >= 0) AND ((((txid_snapshot_xmax(txid_current_snapshot()) - xmin::text::bigint)<<32)>>32) >= 0))) ORDER BY "name" LIMIT 100;
 
 --- quoted_column_name ---
 SELECT * FROM "public"."special_users" ORDER BY "user-id", "group.name" COLLATE "C" LIMIT 100;

--- a/source-postgres/.snapshots/TestKeylessBackfillQueryGeneration
+++ b/source-postgres/.snapshots/TestKeylessBackfillQueryGeneration
@@ -2,6 +2,6 @@
 SELECT ctid, * FROM "public"."users" WHERE ctid > $1 LIMIT 100;
 
 --- with_xid_filtering ---
-SELECT ctid, xmin::text AS xmin, * FROM "public"."users" WHERE ctid > $1 AND ((RANDOM() < 0.001) OR ((xmin::text::bigint >= 3) AND ((((xmin::text::bigint - 12345::bigint)<<32)>>32) > 0) AND (((((CASE WHEN pg_is_in_recovery() THEN txid_snapshot_xmax(txid_current_snapshot()) ELSE txid_current() END) - xmin::text::bigint)<<32)>>32) >= 0))) LIMIT 100;
+SELECT ctid, xmin::text AS xmin, * FROM "public"."users" WHERE ctid > $1 AND ((RANDOM() < 0.001) OR ((xmin::text::bigint >= 3) AND ((((xmin::text::bigint - 12345::bigint)<<32)>>32) >= 0) AND ((((txid_snapshot_xmax(txid_current_snapshot()) - xmin::text::bigint)<<32)>>32) >= 0))) LIMIT 100;
 
 

--- a/source-postgres/backfill.go
+++ b/source-postgres/backfill.go
@@ -259,7 +259,7 @@ var columnBinaryKeyComparison = map[string]bool{
 func (db *postgresDatabase) backfillQueryFilterXMIN() string {
 	if db.config.Advanced.MinimumBackfillXID != "" {
 		const filterValidXID = "(xmin::text::bigint >= 3)"
-		var filterLowerXID = fmt.Sprintf("((((xmin::text::bigint - %s::bigint)<<32)>>32) > 0)", db.config.Advanced.MinimumBackfillXID)
+		var filterLowerXID = fmt.Sprintf("((((xmin::text::bigint - %s::bigint)<<32)>>32) >= 0)", db.config.Advanced.MinimumBackfillXID)
 
 		// Note: We use XMAX here because it's the largest of the "current XID" values and we never want to
 		// exclude anything except for rows whose xmin values are from earlier wraparound epochs.


### PR DESCRIPTION
**Description:**

Two issues, both of which I'm a bit confused how I failed to see them in the previous XMIN backfill tweaks PR but whatever:

- The lower-bound filter clause needs to be `>=` rather than `>` in order for our XMIN backfill test case to pass correctly.
- The query generation snapshots need to be updated

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2696)
<!-- Reviewable:end -->
