### PR TITLE
materialize-snowflake: support for Snowpipe streaming

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -74,15 +74,15 @@ require (
 	golang.org/x/crypto v0.36.0
 	golang.org/x/exp v0.0.0-20250305212735-054e65f0b394
 	golang.org/x/oauth2 v0.28.0
-	golang.org/x/sync v0.12.0
+	golang.org/x/sync v0.13.0
 	golang.org/x/text v0.23.0
 	golang.org/x/time v0.11.0
 	google.golang.org/api v0.226.0
 	google.golang.org/genproto v0.0.0-20250313205543-e70fdf4c4cb4
 	google.golang.org/grpc v1.71.0
-	google.golang.org/protobuf v1.36.5
+	google.golang.org/protobuf v1.36.6
 	gopkg.in/yaml.v3 v3.0.1
-	resty.dev/v3 v3.0.0-beta.1
+	resty.dev/v3 v3.0.0-beta.2
 	vitess.io/vitess v0.21.3
 )
 

--- a/go.sum
+++ b/go.sum
@@ -171,6 +171,8 @@ github.com/antlr4-go/antlr/v4 v4.13.1 h1:SqQKkuVZ+zWkMMNkjy5FZe5mr5WURWnlpmOuzYW
 github.com/antlr4-go/antlr/v4 v4.13.1/go.mod h1:GKmUxMtwp6ZgGwZSva4eWPC5mS6vUAmOABFgjdkM7Nw=
 github.com/apache/arrow-go/v18 v18.2.0 h1:QhWqpgZMKfWOniGPhbUxrHohWnooGURqL2R2Gg4SO1Q=
 github.com/apache/arrow-go/v18 v18.2.0/go.mod h1:Ic/01WSwGJWRrdAZcxjBZ5hbApNJ28K96jGYaxzzGUc=
+github.com/apache/arrow-go/v18 v18.2.1-0.20250408024827-e6b98ad56ea9 h1:dw4JAWxBXOO003+69RLvPKRhdFNdYJUdpSyXhWjxcb8=
+github.com/apache/arrow-go/v18 v18.2.1-0.20250408024827-e6b98ad56ea9/go.mod h1:YuNufaitlLWLtg307hWBeh58fUtiUTqyI+8vUK3RFUY=
 github.com/apache/arrow/go/arrow v0.0.0-20200730104253-651201b0f516/go.mod h1:QNYViu/X0HXDHw7m3KXzWSVXIbfUvJqBFe6Gj8/pYA0=
 github.com/apache/arrow/go/arrow v0.0.0-20211112161151-bc219186db40 h1:q4dksr6ICHXqG5hm0ZW5IHyeEJXoIJSOZeBLmWPNeIQ=
 github.com/apache/arrow/go/arrow v0.0.0-20211112161151-bc219186db40/go.mod h1:Q7yQnSMnLvcXlZ8RV+jwz/6y1rQTqbX6C82SndT52Zs=
@@ -1228,8 +1230,8 @@ golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.1.0/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.3.0/go.mod h1:FU7BRWz2tNW+3quACPkgCx/L+uEAv1htQ0V83Z9Rj+Y=
 golang.org/x/sync v0.6.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=
-golang.org/x/sync v0.12.0 h1:MHc5BpPuC30uJk597Ri8TV3CNZcTLu6B6z4lJy+g6Jw=
-golang.org/x/sync v0.12.0/go.mod h1:1dzgHSNfp02xaA81J2MS99Qcpr2w7fw1gpm99rleRqA=
+golang.org/x/sync v0.13.0 h1:AauUjRAJ9OSnvULf/ARrrVywoJDy0YS2AwQ98I37610=
+golang.org/x/sync v0.13.0/go.mod h1:1dzgHSNfp02xaA81J2MS99Qcpr2w7fw1gpm99rleRqA=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180909124046-d0be0721c37e/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
@@ -1415,8 +1417,8 @@ golang.org/x/xerrors v0.0.0-20240903120638-7835f813f4da/go.mod h1:NDW/Ps6MPRej6f
 gonum.org/v1/gonum v0.0.0-20180816165407-929014505bf4/go.mod h1:Y+Yx5eoAFn32cQvJDxZx5Dpnq+c3wtXuadVZAcxbbBo=
 gonum.org/v1/gonum v0.8.2/go.mod h1:oe/vMfY3deqTw+1EZJhuvEW2iwGF1bW9wwu7XCu0+v0=
 gonum.org/v1/gonum v0.9.3/go.mod h1:TZumC3NeyVQskjXqmyWt4S3bINhy7B4eYwW69EbyX+0=
-gonum.org/v1/gonum v0.15.1 h1:FNy7N6OUZVUaWG9pTiD+jlhdQ3lMP+/LcTpJ6+a8sQ0=
-gonum.org/v1/gonum v0.15.1/go.mod h1:eZTZuRFrzu5pcyjN5wJhcIhnUdNijYxX1T2IcrOGY0o=
+gonum.org/v1/gonum v0.16.0 h1:5+ul4Swaf3ESvrOnidPp4GZbzf0mxVQpDCYUQE7OJfk=
+gonum.org/v1/gonum v0.16.0/go.mod h1:fef3am4MQ93R2HHpKnLk4/Tbh/s0+wqD5nfa6Pnwy4E=
 gonum.org/v1/netlib v0.0.0-20190313105609-8cb42192e0e0/go.mod h1:wa6Ws7BG/ESfp6dHfk7C6KdzKA7wR7u/rKwOGE66zvw=
 gonum.org/v1/plot v0.0.0-20190515093506-e2840ee46a6b/go.mod h1:Wt8AAjI+ypCyYX3nZBvf6cAIx93T+c/OS2HFAYskSZc=
 gonum.org/v1/plot v0.9.0/go.mod h1:3Pcqqmp6RHvJI72kgb8fThyUnav364FOsdDo2aGW5lY=
@@ -1567,8 +1569,8 @@ google.golang.org/protobuf v1.25.0/go.mod h1:9JNX74DMeImyA3h4bdi1ymwjUzf21/xIlba
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
 google.golang.org/protobuf v1.27.1/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
-google.golang.org/protobuf v1.36.5 h1:tPhr+woSbjfYvY6/GPufUoYizxw1cF/yFoxJ2fmpwlM=
-google.golang.org/protobuf v1.36.5/go.mod h1:9fA7Ob0pmnwhb644+1+CVWFRbNajQ6iRojtC/QF5bRE=
+google.golang.org/protobuf v1.36.6 h1:z1NpPI8ku2WgiWnf+t9wTPsn6eP1L7ksHUlkfLvd9xY=
+google.golang.org/protobuf v1.36.6/go.mod h1:jduwjTPXsFjZGTmRluh+L6NjiWu7pchiJ2/5YcXBHnY=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
@@ -1633,8 +1635,8 @@ modernc.org/sqlite v1.36.1/go.mod h1:7MPwH7Z6bREicF9ZVUR78P1IKuxfZ8mRIDHD0iD+8TU
 nhooyr.io/websocket v1.8.7 h1:usjR2uOr/zjjkVMy0lW+PPohFok7PCow5sDjLgX4P4g=
 nhooyr.io/websocket v1.8.7/go.mod h1:B70DZP8IakI65RVQ51MsWP/8jndNma26DVA/nFSCgW0=
 nullprogram.com/x/optparse v1.0.0/go.mod h1:KdyPE+Igbe0jQUrVfMqDMeJQIJZEuyV7pjYmp6pbG50=
-resty.dev/v3 v3.0.0-beta.1 h1:EFhr5p7fbqbz6QKQFTUK7OF+rH//zEdihdVIA4t80VQ=
-resty.dev/v3 v3.0.0-beta.1/go.mod h1:OgkqiPvTDtOuV4MGZuUDhwOpkY8enjOsjjMzeOHefy4=
+resty.dev/v3 v3.0.0-beta.2 h1:xu4mGAdbCLuc3kbk7eddWfWm4JfhwDtdapwss5nCjnQ=
+resty.dev/v3 v3.0.0-beta.2/go.mod h1:OgkqiPvTDtOuV4MGZuUDhwOpkY8enjOsjjMzeOHefy4=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
 rsc.io/pdf v0.1.1/go.mod h1:n8OzWcQ6Sp37PL01nO98y4iUCRdTGarVfzxY20ICaU4=
 rsc.io/quote/v3 v3.1.0/go.mod h1:yEA65RcK8LyAZtP9Kv3t0HmxON59tX3rD+tICJqUlj0=

--- a/go/blob/azure.go
+++ b/go/blob/azure.go
@@ -1,0 +1,116 @@
+package blob
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/url"
+	"strings"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob"
+)
+
+const defaultAzureEndpoint = "blob.core.windows.net"
+
+type azureBlobStoreConfig struct {
+	storageAccountKey string
+	sasToken          string
+	endpoint          string
+}
+
+type AzureConfigOption func(*azureBlobStoreConfig)
+
+func WithAzureStorageAccountKey(sak string) AzureConfigOption {
+	return func(cfg *azureBlobStoreConfig) {
+		cfg.storageAccountKey = sak
+	}
+}
+
+func WithAzureSasToken(token string) AzureConfigOption {
+	return func(cfg *azureBlobStoreConfig) {
+		cfg.sasToken = token
+	}
+}
+
+func WithAzureEndpoint(ep string) AzureConfigOption {
+	return func(cfg *azureBlobStoreConfig) {
+		cfg.endpoint = ep
+	}
+}
+
+var _ Bucket = (*AzureBlobBucket)(nil)
+
+type AzureBlobBucket struct {
+	client    *azblob.Client
+	container string
+}
+
+// NewAzureBlobBucket creates an Azure Blob object storage bucket. At least one
+// AzureConfigOption must be provided to specify authentication; either storage
+// account key or SAS token.
+func NewAzureBlobBucket(ctx context.Context, container string, accountName string, opts []AzureConfigOption) (*AzureBlobBucket, error) {
+	cfg := azureBlobStoreConfig{endpoint: defaultAzureEndpoint}
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+	if cfg.sasToken != "" && cfg.storageAccountKey != "" {
+		return nil, fmt.Errorf("cannot specify both sas token and storage account key")
+	}
+
+	serviceUrl, err := url.Parse(fmt.Sprintf("https://%s.%s/", accountName, cfg.endpoint))
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse service url: %w", err)
+	}
+
+	var client *azblob.Client
+	if cfg.sasToken != "" {
+		serviceUrl.RawQuery = strings.TrimPrefix(cfg.sasToken, "?")
+		if client, err = azblob.NewClientWithNoCredential(serviceUrl.String(), nil); err != nil {
+			return nil, fmt.Errorf("failed to create client with SAS token: %w", err)
+		}
+	} else if cfg.storageAccountKey != "" {
+		if cred, err := azblob.NewSharedKeyCredential(accountName, cfg.storageAccountKey); err != nil {
+			return nil, fmt.Errorf("failed to create storage client shared key credential: %w", err)
+		} else if client, err = azblob.NewClientWithSharedKeyCredential(serviceUrl.String(), cred, nil); err != nil {
+			return nil, fmt.Errorf("failed to create client with storage account key: %w", err)
+		}
+	} else {
+		return nil, fmt.Errorf("must specify either SAS token or storage account key")
+	}
+
+	return &AzureBlobBucket{
+		client:    client,
+		container: container,
+	}, nil
+}
+
+func (s *AzureBlobBucket) NewReader(ctx context.Context, key string) (io.ReadCloser, error) {
+	r, err := s.client.DownloadStream(ctx, s.container, key, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return r.Body, nil
+}
+
+func (s *AzureBlobBucket) NewWriter(ctx context.Context, key string, opts ...WriterOption) io.WriteCloser {
+	return newBlobWriteCloser(ctx, s.Upload, key, opts...)
+}
+
+func (s *AzureBlobBucket) Upload(ctx context.Context, key string, r io.Reader, opts ...WriterOption) error {
+	cfg := getWriterConfig(opts)
+
+	var uploadOpts *azblob.UploadStreamOptions
+	if cfg.metadata != nil {
+		uploadOpts = new(azblob.UploadStreamOptions)
+		meta := make(map[string]*string)
+		for k, v := range cfg.metadata {
+			meta[k] = &v
+		}
+		uploadOpts.Metadata = meta
+	}
+
+	_, err := s.client.UploadStream(ctx, s.container, key, r, uploadOpts)
+
+	return err
+}

--- a/go/blob/bucket.go
+++ b/go/blob/bucket.go
@@ -1,0 +1,86 @@
+// Package blob provides a high-level interface and specific implementations for
+// working with blobs on the common object storage providers.
+//
+// This may eventually replace the fragmented versions of these we have
+// scattered throughout the various captures and materializations, and it's
+// expected that the basic initial structure is enhanced as additional
+// requirements are incorporated.
+package blob
+
+import (
+	"context"
+	"io"
+)
+
+type writerConfig struct {
+	metadata map[string]string
+}
+
+type WriterOption func(*writerConfig)
+
+func WithObjectMetadata(metadata map[string]string) WriterOption {
+	return func(cfg *writerConfig) {
+		cfg.metadata = metadata
+	}
+}
+
+func getWriterConfig(opts []WriterOption) writerConfig {
+	var cfg writerConfig
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+	return cfg
+}
+
+// Bucket is a common interface for working with blob storage. Conceptually, a
+// Bucket is aligned with an S3 or GCS bucket, or an Azure Blob storage
+// "container".
+type Bucket interface {
+	// NewReader returns a stream of bytes for reading from the given key. The
+	// caller is responsible for closing the returned ReadCloser.
+	NewReader(ctx context.Context, key string) (io.ReadCloser, error)
+
+	// NewWriter returns a WriteCloser to write an object to the bucket. The
+	// object will be readable after Close returns.
+	NewWriter(ctx context.Context, key string, opts ...WriterOption) io.WriteCloser
+
+	// Upload uploads an object as a stream.
+	Upload(ctx context.Context, key string, r io.Reader, opts ...WriterOption) error
+}
+
+type uploadFn func(context.Context, string, io.Reader, ...WriterOption) error
+
+// blobWriteCloser adapts a synchronous uploadFn into an io.WriterCloser.
+type blobWriteCloser struct {
+	w     *io.PipeWriter
+	errCh chan (error)
+}
+
+func newBlobWriteCloser(ctx context.Context, u uploadFn, key string, opts ...WriterOption) *blobWriteCloser {
+	pr, pw := io.Pipe()
+	errCh := make(chan error, 1)
+	go func() {
+		err := u(ctx, key, pr, opts...)
+		if err != nil {
+			pr.CloseWithError(err)
+		}
+		errCh <- err
+	}()
+
+	return &blobWriteCloser{
+		w:     pw,
+		errCh: errCh,
+	}
+}
+
+func (w *blobWriteCloser) Close() error {
+	if err := w.w.Close(); err != nil {
+		return err
+	}
+
+	return <-w.errCh
+}
+
+func (w *blobWriteCloser) Write(p []byte) (int, error) {
+	return w.w.Write(p)
+}

--- a/go/blob/bucket_test.go
+++ b/go/blob/bucket_test.go
@@ -1,0 +1,68 @@
+package blob
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestBlobWriteCloser(t *testing.T) {
+	ctx := context.Background()
+	data := []byte("hello world")
+
+	t.Run("success", func(t *testing.T) {
+		fn := func(ctx context.Context, key string, r io.Reader, opts ...WriterOption) error {
+			var got bytes.Buffer
+			if _, err := io.Copy(&got, r); err != nil {
+				return err
+			} else if !bytes.Equal(got.Bytes(), data) {
+				return fmt.Errorf("got %q, want %q", got.Bytes(), data)
+			}
+
+			return nil
+		}
+
+		bwc := newBlobWriteCloser(ctx, fn, "foo")
+		_, err := bwc.Write(data)
+		require.NoError(t, err)
+		require.NoError(t, bwc.Close())
+	})
+
+	t.Run("error while writing", func(t *testing.T) {
+		fn := func(ctx context.Context, key string, r io.Reader, opts ...WriterOption) error {
+			buf := make([]byte, 1)
+			if _, err := r.Read(buf); err != nil {
+				return err
+			}
+
+			return errors.New("some error")
+		}
+
+		bwc := newBlobWriteCloser(ctx, fn, "foo")
+		_, err := bwc.Write(data)
+		require.Error(t, err)
+	})
+
+	t.Run("error after writing", func(t *testing.T) {
+		fn := func(ctx context.Context, key string, r io.Reader, opts ...WriterOption) error {
+			var got bytes.Buffer
+			if _, err := io.Copy(&got, r); err != nil {
+				return err
+			} else if !bytes.Equal(got.Bytes(), data) {
+				return fmt.Errorf("got %q, want %q", got.Bytes(), data)
+			}
+
+			return errors.New("some error")
+		}
+
+		bwc := newBlobWriteCloser(ctx, fn, "foo")
+		_, err := bwc.Write(data)
+		require.NoError(t, err)
+		require.Error(t, bwc.Close())
+	})
+}

--- a/go/blob/gcs.go
+++ b/go/blob/gcs.go
@@ -1,0 +1,56 @@
+package blob
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"cloud.google.com/go/storage"
+	"google.golang.org/api/option"
+)
+
+var _ Bucket = (*GCSBucket)(nil)
+
+type GCSBucket struct {
+	client *storage.Client
+	bucket string
+}
+
+// NewGCSBucket creates a GCS object storage bucket. At least one ClientOption
+// must be provided to specify authentication.
+func NewGCSBucket(ctx context.Context, bucket string, opts []option.ClientOption) (*GCSBucket, error) {
+	client, err := storage.NewClient(ctx, opts...)
+	if err != nil {
+		return nil, err
+	}
+
+	return &GCSBucket{
+		client: client,
+		bucket: bucket,
+	}, nil
+}
+
+func (s *GCSBucket) NewReader(ctx context.Context, key string) (io.ReadCloser, error) {
+	r, err := s.client.Bucket(s.bucket).Object(key).NewReader(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return r, nil
+}
+
+func (s *GCSBucket) NewWriter(ctx context.Context, key string, opts ...WriterOption) io.WriteCloser {
+	return newBlobWriteCloser(ctx, s.Upload, key, opts...)
+}
+
+func (s *GCSBucket) Upload(ctx context.Context, key string, r io.Reader, opts ...WriterOption) error {
+	w := s.client.Bucket(s.bucket).Object(key).NewWriter(ctx)
+	w.Metadata = getWriterConfig(opts).metadata
+	if _, err := io.Copy(w, r); err != nil {
+		return fmt.Errorf("copying r to w: %w", err)
+	} else if err := w.Close(); err != nil {
+		return fmt.Errorf("closing writer: %w", err)
+	}
+
+	return nil
+}

--- a/go/blob/s3.go
+++ b/go/blob/s3.go
@@ -1,0 +1,93 @@
+package blob
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/feature/s3/manager"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+)
+
+var _ Bucket = (*S3Bucket)(nil)
+
+type S3Bucket struct {
+	client   *s3.Client
+	bucket   string
+	uploader *manager.Uploader
+}
+
+// NewS3Bucket creates an S3 object storage bucket. clientOpts are optional, but
+// may be useful for things like an alternate endpoint. The region of the bucket
+// is determined automatically, if possible. If using an S3 endpoint other than
+// s3.amazonaws.com, set the region in one of the clientOpts if it is required
+// by the alternate endpoint.
+func NewS3Bucket(ctx context.Context, bucket string, creds aws.CredentialsProvider, clientOpts ...func(*s3.Options)) (*S3Bucket, error) {
+	configOpts := []func(*config.LoadOptions) error{
+		config.WithCredentialsProvider(creds),
+	}
+
+	if region, err := getBucketRegion(bucket); err == nil {
+		configOpts = append(configOpts, config.WithRegion(region))
+	}
+
+	cfg, err := config.LoadDefaultConfig(ctx, configOpts...)
+	if err != nil {
+		return nil, fmt.Errorf("creating aws config: %w", err)
+	}
+
+	s3Client := s3.NewFromConfig(cfg, clientOpts...)
+
+	return &S3Bucket{
+		client:   s3Client,
+		bucket:   bucket,
+		uploader: manager.NewUploader(s3Client),
+	}, nil
+}
+
+func (s *S3Bucket) NewReader(ctx context.Context, key string) (io.ReadCloser, error) {
+	r, err := s.client.GetObject(ctx, &s3.GetObjectInput{
+		Bucket: aws.String(s.bucket),
+		Key:    aws.String(key),
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return r.Body, nil
+}
+
+func (s *S3Bucket) NewWriter(ctx context.Context, key string, opts ...WriterOption) io.WriteCloser {
+	return newBlobWriteCloser(ctx, s.Upload, key, opts...)
+}
+
+func (s *S3Bucket) Upload(ctx context.Context, key string, r io.Reader, opts ...WriterOption) error {
+	_, err := s.uploader.Upload(ctx, &s3.PutObjectInput{
+		Bucket:   aws.String(s.bucket),
+		Key:      aws.String(key),
+		Body:     r,
+		Metadata: getWriterConfig(opts).metadata,
+	})
+
+	return err
+}
+
+func getBucketRegion(bucket string) (string, error) {
+	// It's apparently impossible to get the region of a bucket if you don't
+	// already know it using the AWS Go SDKs, but this silly mechanism actually
+	// seems to work 100% of the time.
+	resp, err := http.DefaultClient.Head(fmt.Sprintf("https://%s.s3.amazonaws.com", bucket))
+	if resp != nil && resp.Header != nil {
+		if bucketRegion := resp.Header.Get("x-amz-bucket-region"); bucketRegion != "" {
+			return bucketRegion, nil
+		}
+	}
+	if err != nil {
+		return "", err
+	}
+
+	return "", fmt.Errorf("could not find region for bucket %s", bucket)
+}

--- a/materialize-snowflake/.snapshots/TestSpecification
+++ b/materialize-snowflake/.snapshots/TestSpecification
@@ -221,6 +221,19 @@
         ],
         "title": "dbt Cloud Job Trigger",
         "description": "Trigger a dbt Job when new data is available"
+      },
+      "advanced": {
+        "properties": {
+          "feature_flags": {
+            "type": "string",
+            "title": "Feature Flags",
+            "description": "This property is intended for Estuary internal use. You should only modify this field as directed by Estuary support."
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "title": "Advanced Options",
+        "description": "Options for advanced users. You should not typically need to modify these."
       }
     },
     "type": "object",

--- a/materialize-snowflake/.snapshots/TestStreamDatatypes-BOOLEAN
+++ b/materialize-snowflake/.snapshots/TestStreamDatatypes-BOOLEAN
@@ -1,0 +1,8 @@
+--- Column Statistics ---
+{"rows":3,"columns":{"KEY":{"columnId":1,"nullCount":0,"maxStrValue":null,"minStrValue":null,"maxLength":0,"maxIntValue":2,"minIntValue":0,"maxRealValue":null,"minRealValue":null,"distinctValues":-1,"collation":null,"minStrNonCollated":null,"maxStrNonCollated":null},"VAL":{"columnId":2,"nullCount":1,"maxStrValue":null,"minStrValue":null,"maxLength":0,"maxIntValue":0,"minIntValue":0,"maxRealValue":null,"minRealValue":null,"distinctValues":-1,"collation":null,"minStrNonCollated":null,"maxStrNonCollated":null}}}
+
+--- Column Values ---
+key, val
+0, 1
+1, 0
+2, <nil>

--- a/materialize-snowflake/.snapshots/TestStreamDatatypes-DATE
+++ b/materialize-snowflake/.snapshots/TestStreamDatatypes-DATE
@@ -1,0 +1,9 @@
+--- Column Statistics ---
+{"rows":4,"columns":{"KEY":{"columnId":1,"nullCount":0,"maxStrValue":null,"minStrValue":null,"maxLength":0,"maxIntValue":3,"minIntValue":0,"maxRealValue":null,"minRealValue":null,"distinctValues":-1,"collation":null,"minStrNonCollated":null,"maxStrNonCollated":null},"VAL":{"columnId":2,"nullCount":1,"maxStrValue":null,"minStrValue":null,"maxLength":0,"maxIntValue":2932896,"minIntValue":-719528,"maxRealValue":null,"minRealValue":null,"distinctValues":-1,"collation":null,"minStrNonCollated":null,"maxStrNonCollated":null}}}
+
+--- Column Values ---
+key, val
+0, 2022-03-21T00:00:00Z
+1, <nil>
+2, 0000-01-01T00:00:00Z
+3, 9999-12-31T00:00:00Z

--- a/materialize-snowflake/.snapshots/TestStreamDatatypes-FLOAT
+++ b/materialize-snowflake/.snapshots/TestStreamDatatypes-FLOAT
@@ -1,0 +1,14 @@
+--- Column Statistics ---
+{"rows":9,"columns":{"KEY":{"columnId":1,"nullCount":0,"maxStrValue":null,"minStrValue":null,"maxLength":0,"maxIntValue":8,"minIntValue":0,"maxRealValue":null,"minRealValue":null,"distinctValues":-1,"collation":null,"minStrNonCollated":null,"maxStrNonCollated":null},"VAL":{"columnId":2,"nullCount":1,"maxStrValue":null,"minStrValue":null,"maxLength":0,"maxIntValue":0,"minIntValue":0,"maxRealValue":"Infinity","minRealValue":"-Infinity","distinctValues":-1,"collation":null,"minStrNonCollated":null,"maxStrNonCollated":null}}}
+
+--- Column Values ---
+key, val
+0, 1234
+1, <nil>
+2, 1234
+3, 4321.1234
+4, 1.79769313486232e+308
+5, 4.940656458e-324
+6, NaN
+7, inf
+8, -inf

--- a/materialize-snowflake/.snapshots/TestStreamDatatypes-INTEGER
+++ b/materialize-snowflake/.snapshots/TestStreamDatatypes-INTEGER
@@ -1,0 +1,16 @@
+--- Column Statistics ---
+{"rows":11,"columns":{"KEY":{"columnId":1,"nullCount":0,"maxStrValue":null,"minStrValue":null,"maxLength":0,"maxIntValue":10,"minIntValue":0,"maxRealValue":null,"minRealValue":null,"distinctValues":-1,"collation":null,"minStrNonCollated":null,"maxStrNonCollated":null},"VAL":{"columnId":2,"nullCount":1,"maxStrValue":null,"minStrValue":null,"maxLength":0,"maxIntValue":99999999999999999999999999999999999999,"minIntValue":-99999999999999999999999999999999999999,"maxRealValue":null,"minRealValue":null,"distinctValues":-1,"collation":null,"minStrNonCollated":null,"maxStrNonCollated":null}}}
+
+--- Column Values ---
+key, val
+0, -1
+1, 0
+2, 1
+3, 1234
+4, 9223372036854775807
+5, <nil>
+6, -9223372036854775808
+7, 184467440737095516160000
+8, -99999999999999999999999999999999999999
+9, 99999999999999999999999999999999999999
+10, 18446744073709551615

--- a/materialize-snowflake/.snapshots/TestStreamDatatypes-TEXT
+++ b/materialize-snowflake/.snapshots/TestStreamDatatypes-TEXT
@@ -1,0 +1,14 @@
+--- Column Statistics ---
+{"rows":9,"columns":{"KEY":{"columnId":1,"nullCount":0,"maxStrValue":null,"minStrValue":null,"maxLength":0,"maxIntValue":8,"minIntValue":0,"maxRealValue":null,"minRealValue":null,"distinctValues":-1,"collation":null,"minStrNonCollated":null,"maxStrNonCollated":null},"VAL":{"columnId":2,"nullCount":1,"maxStrValue":"7b22736f6d65223a22646f63227d","minStrValue":"","maxLength":14,"maxIntValue":0,"minIntValue":0,"maxRealValue":null,"minRealValue":null,"distinctValues":-1,"collation":null,"minStrNonCollated":null,"maxStrNonCollated":null}}}
+
+--- Column Values ---
+key, val
+0, hello
+1, 
+2, <nil>
+3, 1234
+4, true
+5, 4321
+6, 1234.1234
+7, [1,2,3]
+8, {"some":"doc"}

--- a/materialize-snowflake/.snapshots/TestStreamDatatypes-TIMESTAMP_LTZ
+++ b/materialize-snowflake/.snapshots/TestStreamDatatypes-TIMESTAMP_LTZ
@@ -1,0 +1,16 @@
+--- Column Statistics ---
+{"rows":11,"columns":{"KEY":{"columnId":1,"nullCount":0,"maxStrValue":null,"minStrValue":null,"maxLength":0,"maxIntValue":10,"minIntValue":0,"maxRealValue":null,"minRealValue":null,"distinctValues":-1,"collation":null,"minStrNonCollated":null,"maxStrNonCollated":null},"VAL":{"columnId":2,"nullCount":1,"maxStrValue":null,"minStrValue":null,"maxLength":0,"maxIntValue":253402387139999999999,"minIntValue":-62167305540000000000,"maxRealValue":null,"minRealValue":null,"distinctValues":-1,"collation":null,"minStrNonCollated":null,"maxStrNonCollated":null}}}
+
+--- Column Values ---
+key, val
+0, 2022-08-17T04:32:19.987654321Z
+1, 2022-08-17T02:32:19.987654321Z
+2, 2022-08-17T01:02:19.987654321Z
+3, 2022-08-17T11:32:19.987654321Z
+4, 0000-01-01T00:00:00Z
+5, -0001-12-31T00:01:00Z
+6, 0000-01-01T23:59:00Z
+7, 9999-12-31T23:59:59.999999999Z
+8, 9999-12-31T00:00:59.999999999Z
+9, 10000-01-01T23:58:59.999999999Z
+10, <nil>

--- a/materialize-snowflake/.snapshots/TestStreamDatatypes-TIMESTAMP_NTZ
+++ b/materialize-snowflake/.snapshots/TestStreamDatatypes-TIMESTAMP_NTZ
@@ -1,0 +1,16 @@
+--- Column Statistics ---
+{"rows":11,"columns":{"KEY":{"columnId":1,"nullCount":0,"maxStrValue":null,"minStrValue":null,"maxLength":0,"maxIntValue":10,"minIntValue":0,"maxRealValue":null,"minRealValue":null,"distinctValues":-1,"collation":null,"minStrNonCollated":null,"maxStrNonCollated":null},"VAL":{"columnId":2,"nullCount":1,"maxStrValue":null,"minStrValue":null,"maxLength":0,"maxIntValue":253402300799999999999,"minIntValue":-62167219200000000000,"maxRealValue":null,"minRealValue":null,"distinctValues":-1,"collation":null,"minStrNonCollated":null,"maxStrNonCollated":null}}}
+
+--- Column Values ---
+key, val
+0, 2022-08-17T04:32:19.987654321Z
+1, 2022-08-17T04:32:19.987654321Z
+2, 2022-08-17T04:32:19.987654321Z
+3, 2022-08-17T04:32:19.987654321Z
+4, 0000-01-01T00:00:00Z
+5, 0000-01-01T00:00:00Z
+6, 0000-01-01T00:00:00Z
+7, 9999-12-31T23:59:59.999999999Z
+8, 9999-12-31T23:59:59.999999999Z
+9, 9999-12-31T23:59:59.999999999Z
+10, <nil>

--- a/materialize-snowflake/.snapshots/TestStreamDatatypes-TIMESTAMP_TZ
+++ b/materialize-snowflake/.snapshots/TestStreamDatatypes-TIMESTAMP_TZ
@@ -1,0 +1,16 @@
+--- Column Statistics ---
+{"rows":11,"columns":{"KEY":{"columnId":1,"nullCount":0,"maxStrValue":null,"minStrValue":null,"maxLength":0,"maxIntValue":10,"minIntValue":0,"maxRealValue":null,"minRealValue":null,"distinctValues":-1,"collation":null,"minStrNonCollated":null,"maxStrNonCollated":null},"VAL":{"columnId":2,"nullCount":1,"maxStrValue":null,"minStrValue":null,"maxLength":0,"maxIntValue":4151744710901759999983617,"minIntValue":-1018549133967359999997121,"maxRealValue":null,"minRealValue":null,"distinctValues":-1,"collation":null,"minStrNonCollated":null,"maxStrNonCollated":null}}}
+
+--- Column Values ---
+key, val
+0, 2022-08-17T04:32:19.987654321Z
+1, 2022-08-17T02:32:19.987654321Z
+2, 2022-08-17T01:02:19.987654321Z
+3, 2022-08-17T11:32:19.987654321Z
+4, 0000-01-01T00:00:00Z
+5, -0001-12-31T00:01:00Z
+6, 0000-01-01T23:59:00Z
+7, 9999-12-31T23:59:59.999999999Z
+8, 9999-12-31T00:00:59.999999999Z
+9, 10000-01-01T23:58:59.999999999Z
+10, <nil>

--- a/materialize-snowflake/.snapshots/TestStreamDatatypes-VARIANT
+++ b/materialize-snowflake/.snapshots/TestStreamDatatypes-VARIANT
@@ -1,0 +1,20 @@
+--- Column Statistics ---
+{"rows":9,"columns":{"KEY":{"columnId":1,"nullCount":0,"maxStrValue":null,"minStrValue":null,"maxLength":0,"maxIntValue":8,"minIntValue":0,"maxRealValue":null,"minRealValue":null,"distinctValues":-1,"collation":null,"minStrNonCollated":null,"maxStrNonCollated":null},"VAL":{"columnId":2,"nullCount":1,"maxStrValue":"7b22736f6d65223a22646f63227d","minStrValue":"2222","maxLength":14,"maxIntValue":0,"minIntValue":0,"maxRealValue":null,"minRealValue":null,"distinctValues":-1,"collation":null,"minStrNonCollated":null,"maxStrNonCollated":null}}}
+
+--- Column Values ---
+key, val
+0, "hello"
+1, ""
+2, <nil>
+3, 1234
+4, true
+5, 4321
+6, 1234.1234
+7, [
+  1,
+  2,
+  3
+]
+8, {
+  "some": "doc"
+}

--- a/materialize-snowflake/bdec.go
+++ b/materialize-snowflake/bdec.go
@@ -1,0 +1,845 @@
+package main
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/md5"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"hash"
+	"io"
+	"math"
+	"math/big"
+	"path"
+	"slices"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/apache/arrow-go/v18/arrow/decimal128"
+	enc "github.com/estuary/connectors/materialize-boilerplate/stream-encode"
+	sql "github.com/estuary/connectors/materialize-sql"
+)
+
+const (
+	// BYTES_16_MB is the common Snowflake "maximum string length" of 16 MiB.
+	// Ref: https://github.com/snowflakedb/snowflake-ingest-java/blob/3cbaebfe26f59dc3a8b8e973649e3f1a1014438c/src/main/java/net/snowflake/ingest/streaming/internal/DataValidationUtil.java#L73
+	BYTES_16_MB = 16 * 1024 * 1024
+
+	// MAX_SEMI_STRUCTURED_LENGTH is the same as maxStrLen, but includes room
+	// for a little bit of overhead, apparently.
+	// Ref: https://github.com/snowflakedb/snowflake-ingest-java/blob/3cbaebfe26f59dc3a8b8e973649e3f1a1014438c/src/main/java/net/snowflake/ingest/streaming/internal/DataValidationUtil.java#L77
+	MAX_SEMI_STRUCTURED_LENGTH = BYTES_16_MB - 64
+
+	// MAX_LOB_LENGTH is the maximum length allowed for the "longest string"
+	// value of blob metadata. Values longer than this are truncated by
+	// `truncateBytesAsHex`.
+	// Ref: https://github.com/snowflakedb/snowflake-ingest-java/blob/3cbaebfe26f59dc3a8b8e973649e3f1a1014438c/src/main/java/net/snowflake/ingest/streaming/internal/BinaryStringUtils.java#L7
+	MAX_LOB_LENGTH = 32
+
+	// Bit mask for ensuring timezone offsets fit in 14 bits. Included here for
+	// parity with the Java SDK.
+	// Ref: https://github.com/snowflakedb/snowflake-ingest-java/blob/3cbaebfe26f59dc3a8b8e973649e3f1a1014438c/src/main/java/net/snowflake/ingest/streaming/internal/TimestampWrapper.java#L31-L41
+	MASK_OF_TIMEZONE = (1 << 14) - 1
+
+	// Always "bdec".
+	// Ref: https://github.com/snowflakedb/snowflake-ingest-java/blob/3cbaebfe26f59dc3a8b8e973649e3f1a1014438c/src/main/java/net/snowflake/ingest/utils/Constants.java#L55
+	BLOB_EXTENSION_TYPE = "bdec"
+
+	// For blobs we only write a single chunk and a chunk can only have a single
+	// row group, so this ends up being the size limit for the single row group
+	// written by the bdec writer.
+	// Ref: https://github.com/snowflakedb/snowflake-ingest-java/blob/3cbaebfe26f59dc3a8b8e973649e3f1a1014438c/src/main/java/net/snowflake/ingest/utils/ParameterProvider.java#L64C62-L64C79
+	MAX_CHUNK_SIZE_IN_BYTES_DEFAULT = 256 * 1024 * 1024
+)
+
+type bdecWriter struct {
+	pq        *enc.ParquetEncoder
+	blobStats *blobStatsTracker
+	cols      []tableColumn
+	done      bool
+}
+
+// bdecWriter writes bdec files, which are basically Parquet files with values
+// written in Snowflake's specific way. Various statistics about the file are
+// computed as well, the particulars of which are from from BlobBuilder.java of
+// the Java SDK. We've got our own streaming version of the encrypting and
+// hashing to match what is needed from that.
+func newBdecWriter(
+	w io.WriteCloser,
+	mappedColumns []*sql.Column,
+	existingColumns []tableColumn,
+	encryptionKey string,
+	fileName blobFileName,
+) (*bdecWriter, error) {
+	orderedCols, err := orderExistingColumns(mappedColumns, existingColumns)
+	if err != nil {
+		return nil, fmt.Errorf("making stream columns: %w", err)
+	}
+
+	metadata := map[string]string{"primaryFileId": path.Base(string(fileName))}
+	sch := make(enc.ParquetSchema, 0, len(orderedCols))
+	for _, col := range orderedCols {
+		e, err := makeSchemaElement(col)
+		if err != nil {
+			return nil, err
+		}
+		sch = append(sch, e)
+
+		if slices.Contains([]string{"array", "object", "variant"}, col.LogicalType) {
+			metadata[fmt.Sprintf("%d:obj_enc", col.Ordinal)] = "1"
+		}
+		metadata[strconv.Itoa(col.Ordinal)] = logicalTypeOrdinals[col.LogicalType] +
+			"," +
+			physicalTypeOrdinals[col.PhysicalType]
+	}
+
+	cipherStream, err := getCipherStream(encryptionKey, fileName)
+	if err != nil {
+		return nil, fmt.Errorf("getting cipher stream: %w", err)
+	}
+
+	blobStats := &blobStatsTracker{
+		fileName: fileName,
+		md5:      md5.New(),
+		start:    time.Now(),
+		w:        w,
+		stream:   cipherStream,
+	}
+
+	for _, c := range orderedCols {
+		blobStats.columns = append(blobStats.columns, &columnStatsTracker{
+			name:    c.Name,
+			ordinal: c.Ordinal,
+			// Text columns are obviously string-encoded, but variant columns
+			// are too, and must be included in the metadata statistics.
+			isStr: c.LogicalType == "text" || c.LogicalType == "variant",
+			// Similarly, more column types than you might expect are stored as
+			// 128-bit integers. This applies to even timestamp columns which
+			// use a decimal logical annotation.
+			isInt: slices.Contains([]string{"fixed", "date", "timestamp_ltz", "timestamp_ntz", "timestamp_tz"}, c.LogicalType),
+			isNum: c.LogicalType == "real",
+		})
+	}
+
+	pq := enc.NewParquetEncoder(
+		blobStats,
+		sch,
+		enc.WithParquetCompression(enc.Snappy),
+		enc.WithDisableDictionaryEncoding(), // not only for performance, but also to support some column types (VARIANT)
+		enc.WithParquetMetadata(metadata),
+		// We are effectively disabling the new row group creation logic in the
+		// Parquet writer and handling when the file and its single row group
+		// should be closed here.
+		enc.WithParquetRowGroupRowLimit(math.MaxInt64),
+		enc.WithParquetRowGroupByteLimit(math.MaxInt64),
+	)
+
+	return &bdecWriter{
+		pq:        pq,
+		blobStats: blobStats,
+		cols:      orderedCols,
+	}, nil
+}
+
+func (bw *bdecWriter) encodeRow(row []any) error {
+	for i, col := range bw.cols {
+		stats := bw.blobStats.columns[i]
+
+		// Write null values for table columns that aren't in our field
+		// selection, in addition to null values for fields in the field
+		// selection with null values.
+		if i >= len(row) || row[i] == nil {
+			if !col.Nullable {
+				return fmt.Errorf("attempted to write null value to non-nullable column %q", col.Name)
+			}
+			stats.nullCount++
+			continue
+		}
+
+		switch col.LogicalType {
+		case "fixed":
+			v, err := getInt(row[i])
+			if err != nil {
+				return fmt.Errorf("getInt for column %q: %w", col.Name, err)
+			}
+			row[i] = v
+			stats.nextInt(v)
+		case "text":
+			maxLength := BYTES_16_MB
+			if col.ByteLength != nil {
+				maxLength = *col.ByteLength
+			}
+			v, err := getStr(row[i], maxLength)
+			if err != nil {
+				return fmt.Errorf("getStr for column %q: %w", col.Name, err)
+			}
+			row[i] = v
+			stats.nextStr(v)
+		case "variant":
+			v, err := getStr(row[i], MAX_SEMI_STRUCTURED_LENGTH)
+			if err != nil {
+				return fmt.Errorf("getStr for column %q: %w", col.Name, err)
+			}
+			row[i] = v
+			stats.nextStr(v)
+		case "real":
+			v, err := getNum(row[i])
+			if err != nil {
+				return fmt.Errorf("getNum for column %q: %w", col.Name, err)
+			}
+			row[i] = v
+			stats.nextNum(v)
+		case "date":
+			// We are using the default parquet writer handling for dates here
+			// to write the value as an int32 primitive type with the "date"
+			// logical type as unix days. But we need to include it in the
+			// integer stats, and must parse it into an int128 here for that.
+			// The original value (a date string) is left as-is in the row, so
+			// we'll end up parsing it twice: Once here for stats, and once in
+			// the parquet writer.
+			v, err := getDateInt(row[i])
+			if err != nil {
+				return fmt.Errorf("getDateInt for column %q: %w", col.Name, err)
+			}
+			stats.nextInt(v)
+		case "timestamp_ltz", "timestamp_ntz", "timestamp_tz":
+			v, err := getTimestamp(row[i], col.LogicalType, *col.Scale)
+			if err != nil {
+				return fmt.Errorf("getTimestamp for column %q: %w", col.Name, err)
+			}
+			row[i] = v
+			stats.nextInt(v)
+		case "boolean":
+			// Boolean values use the default parquet writer as-is.
+		default:
+			return fmt.Errorf("unhandled Snowflake logical type %q for column %q", col.LogicalType, col.Name)
+		}
+	}
+
+	// If needed, extend the row of selected field values with null values for
+	// all the other pre-existing columns which aren't selected.
+	if len(row) < len(bw.cols) {
+		row = append(row, make([]any, len(bw.cols)-len(row))...)
+	}
+
+	if err := bw.pq.Encode(row); err != nil {
+		return fmt.Errorf("encoding row as parquet: %w", err)
+	}
+	if sz := bw.pq.ScratchSize(); sz >= MAX_CHUNK_SIZE_IN_BYTES_DEFAULT {
+		// Since only a single row group can be in a chunk and we only write one
+		// chunk per blob, this blob must be closed out now.
+		bw.blobStats.lengthUncompressed = sz
+		bw.done = true
+	}
+	bw.blobStats.rows++
+
+	return nil
+}
+
+func (bw *bdecWriter) close() error {
+	// TODO(whb): When calling Close() on the parquet writer, it will start
+	// furiously writing bytes of the output to its writer, which is a network
+	// pipe to object storage. This kind of spiky network traffic is probably
+	// not optimal for throughput, and it may be worth implementing a kind of
+	// async closing strategy here and/or in the parquet writer itself so that
+	// the completion of Close() can be awaited in the background while the next
+	// file is in progress.
+	if err := bw.pq.Close(); err != nil {
+		return fmt.Errorf("closing parquet writer: %w", err)
+	}
+
+	return nil
+}
+
+type blobStatsTracker struct {
+	// The Java SDK has separate concepts for flush start / build duration /
+	// upload duration, but we do them all simultaneously so there's really only
+	// a start and a finish.
+	start  time.Time
+	finish time.Time
+
+	fileName           blobFileName // from `getNextFileName`, does not include the common path prefix
+	md5                hash.Hash    // md5 checksum of the entire blob
+	rows               int          // total number of rows
+	length             int          // total number of bytes in the blob
+	lengthUncompressed int          // estimate of the uncompressed byte size of the blob's data
+
+	columns []*columnStatsTracker
+
+	// These are used for writing & encrypting bytes through the stats tracker.
+	w      io.WriteCloser
+	stream cipher.Stream
+	buf    []byte
+}
+
+func (bs *blobStatsTracker) Write(p []byte) (int, error) {
+	n := len(p)
+	if n > cap(bs.buf) {
+		bs.buf = slices.Grow(bs.buf, n-len(bs.buf))
+	}
+
+	bs.stream.XORKeyStream(bs.buf[:n], p)
+	if written, err := bs.w.Write(bs.buf[:n]); err != nil {
+		return written, fmt.Errorf("blobStatsTracker error writing to output: %w", err)
+	} else if written != n {
+		return written, fmt.Errorf("written bytes %d != expected bytes %d", written, n)
+	} else if hashed, err := bs.md5.Write(bs.buf[:n]); err != nil {
+		return written, fmt.Errorf("failed to write md5 for blob: %w", err)
+	} else if hashed != n {
+		return written, fmt.Errorf("hashed bytes %d != expected bytes %d", hashed, n)
+	}
+
+	bs.length += n
+	return n, nil
+}
+
+func (bs *blobStatsTracker) Close() error {
+	if err := bs.w.Close(); err != nil {
+		return fmt.Errorf("blobStatsTracker error closing output: %w", err)
+	}
+	bs.finish = time.Now()
+
+	return nil
+}
+
+type columnStatsTracker struct {
+	name    string
+	ordinal int
+
+	nullCount int
+	hasData   bool
+
+	// The isStr, isInt, and isNum flags are sanity checks and shouldn't
+	// strictly be necessary.
+	isStr    bool
+	strStats struct {
+		maxVal string
+		minVal string
+		maxLen int
+	}
+
+	isInt    bool
+	intStats struct {
+		maxVal decimal128.Num
+		minVal decimal128.Num
+	}
+
+	isNum    bool
+	numStats struct {
+		maxVal float64
+		minVal float64
+	}
+}
+
+func (cs *columnStatsTracker) nextStr(v string) {
+	if !cs.isStr {
+		panic(fmt.Sprintf("internal error: nextStr called on non-string column %q", cs.name))
+	}
+
+	if !cs.hasData {
+		cs.strStats.maxLen = len(v)
+		cs.strStats.maxVal = v
+		cs.strStats.minVal = v
+		cs.hasData = true
+		return
+	}
+
+	cs.strStats.maxLen = max(len(v), cs.strStats.maxLen)
+
+	if len(v) > MAX_LOB_LENGTH {
+		// These ultimately get truncated per truncateBytesAsHex, so there is no
+		// reason to buffer more than this length.
+		v = v[:MAX_LOB_LENGTH]
+	}
+	cs.strStats.maxVal = max(cs.strStats.maxVal, v)
+	cs.strStats.minVal = min(cs.strStats.minVal, v)
+}
+
+func (cs *columnStatsTracker) nextInt(v decimal128.Num) {
+	if !cs.isInt {
+		panic(fmt.Sprintf("internal error: nextInt called on non-int column %q", cs.name))
+	}
+
+	if !cs.hasData {
+		cs.intStats.maxVal = v
+		cs.intStats.minVal = v
+		cs.hasData = true
+		return
+	}
+
+	if v.Greater(cs.intStats.maxVal) {
+		cs.intStats.maxVal = v
+	}
+	if v.Less(cs.intStats.minVal) {
+		cs.intStats.minVal = v
+	}
+}
+
+func (cs *columnStatsTracker) nextNum(v float64) {
+	if !cs.isNum {
+		panic(fmt.Sprintf("internal error: nextNum called on non-num column %q", cs.name))
+	}
+
+	if !cs.hasData {
+		cs.numStats.maxVal = v
+		cs.numStats.minVal = v
+		cs.hasData = true
+		return
+	}
+
+	if v > cs.numStats.maxVal {
+		cs.numStats.maxVal = v
+	}
+	if v < cs.numStats.minVal {
+		cs.numStats.minVal = v
+	}
+}
+
+func getCipherStream(encryptionKey string, fileName blobFileName) (cipher.Stream, error) {
+	derivedKey, err := deriveKey(encryptionKey, fileName)
+	if err != nil {
+		return nil, fmt.Errorf("deriving key: %w", err)
+	}
+
+	block, err := aes.NewCipher(derivedKey)
+	if err != nil {
+		return nil, fmt.Errorf("creating cipher: %w", err)
+	}
+
+	// The initialization vector (iv) is always 0, since there is a single chunk
+	// per blob.
+	return cipher.NewCTR(block, make([]byte, aes.BlockSize)), nil
+}
+
+// reencrypt reads encrypted blob data from r, decrypts it using the encryption
+// key and original file name, and then re-encrypts it using the new file name
+// and writes the output to w. The blob metadata is updated in place.
+func reencrypt(
+	r io.Reader,
+	w io.Writer,
+	blob *blobMetadata,
+	encryptionKey string,
+	newFileName blobFileName,
+) error {
+	decryptStream, err := getCipherStream(encryptionKey, blobFileName(blob.Path))
+	if err != nil {
+		return fmt.Errorf("getting decryptStream: %w", err)
+	}
+
+	encryptStream, err := getCipherStream(encryptionKey, newFileName)
+	if err != nil {
+		return fmt.Errorf("getting encryptStream: %w", err)
+	}
+
+	downMd5 := md5.New()
+	upMd5 := md5.New()
+
+	buf := make([]byte, 64*1024)
+	for {
+		n, err := r.Read(buf)
+		if err != nil && !errors.Is(err, io.EOF) {
+			return fmt.Errorf("reading from r: %w", err)
+		} else if n == 0 {
+			break
+		}
+
+		if m, err := downMd5.Write(buf[:n]); err != nil {
+			return fmt.Errorf("writing to downMd5: %w", err)
+		} else if m != n {
+			return fmt.Errorf("written to downMd5 %d != expected bytes %d", m, n)
+		}
+
+		decryptStream.XORKeyStream(buf[:n], buf[:n])
+		encryptStream.XORKeyStream(buf[:n], buf[:n])
+
+		if m, err := upMd5.Write(buf[:n]); err != nil {
+			return fmt.Errorf("writing to upMd5: %w", err)
+		} else if m != n {
+			return fmt.Errorf("written to upMd5 %d != expected bytes %d", m, n)
+		} else if written, err := w.Write(buf[:n]); err != nil {
+			return fmt.Errorf("writing to w: %w", err)
+		} else if written != n {
+			return fmt.Errorf("written bytes %d != expected bytes %d", written, n)
+		}
+	}
+
+	downHash := hex.EncodeToString(downMd5.Sum(nil))
+	upHash := hex.EncodeToString(upMd5.Sum(nil))
+	if downHash != blob.MD5 || downHash != blob.Chunks[0].ChunkMD5 {
+		return fmt.Errorf("md5 mismatch: %s != %s", downHash, blob.MD5)
+	}
+
+	blob.Path = string(newFileName)
+	blob.MD5 = upHash
+	blob.Chunks[0].ChunkMD5 = upHash
+
+	return nil
+}
+
+// Ref: https://github.com/snowflakedb/snowflake-ingest-java/blob/3cbaebfe26f59dc3a8b8e973649e3f1a1014438c/src/main/java/net/snowflake/ingest/utils/Cryptor.java#L61-L74
+func deriveKey(secretKey string, diversifier blobFileName) ([]byte, error) {
+	decodedString, err := base64.StdEncoding.DecodeString(secretKey)
+	if err != nil {
+		return nil, err
+	}
+	concat := append(decodedString, []byte(diversifier)...)
+	derivedBytes := sha256.Sum256(concat)
+	return derivedBytes[:], nil
+}
+
+// Ref: https://github.com/snowflakedb/snowflake-ingest-java/blob/3cbaebfe26f59dc3a8b8e973649e3f1a1014438c/src/main/java/net/snowflake/ingest/streaming/internal/BinaryStringUtils.java
+func truncateBytesAsHex(bytes []byte, truncateUp bool) string {
+	if len(bytes) <= MAX_LOB_LENGTH {
+		return hex.EncodeToString(bytes)
+	}
+
+	result := make([]byte, MAX_LOB_LENGTH)
+	copy(result, bytes[:MAX_LOB_LENGTH])
+	if truncateUp {
+		var idx int
+		for idx = MAX_LOB_LENGTH - 1; idx >= 0; idx-- {
+			result[idx]++
+			if result[idx] != 0 {
+				break
+			}
+		}
+		if idx < 0 {
+			return "Z"
+		}
+	}
+
+	return hex.EncodeToString(result)
+}
+
+type unhandledColError struct {
+	msg string
+}
+
+func (u unhandledColError) Error() string {
+	return u.msg
+}
+
+func newUnhandledColError(format string, a ...any) error {
+	return &unhandledColError{
+		msg: fmt.Sprintf(format, a...),
+	}
+}
+
+// Loosely adapted from
+// https://github.com/snowflakedb/snowflake-ingest-java/blob/3cbaebfe26f59dc3a8b8e973649e3f1a1014438c/src/main/java/net/snowflake/ingest/streaming/internal/ParquetTypeGenerator.java#L77-L148
+func makeSchemaElement(col tableColumn) (enc.ParquetSchemaElement, error) {
+	fieldId := int32(col.Ordinal)
+	e := enc.ParquetSchemaElement{
+		Name:     col.Name,
+		Required: !col.Nullable,
+		FieldId:  &fieldId,
+	}
+
+	nilOrScale := func(s *int) string {
+		if s == nil {
+			return "<nil>"
+		}
+		return strconv.Itoa(*s)
+	}
+
+	switch col.LogicalType {
+	case "fixed":
+		if col.PhysicalType == "SB16" && col.Scale == nil || *col.Scale == 0 {
+			// A decimal with 0 precision, like a DECIMAL(38,0) that we use for
+			// integer columns.
+			e.DataType = enc.LogicalTypeDecimal
+			e.Scale = 0
+		} else {
+			return e, newUnhandledColError("fixed column with physical type %q and scale %s not supported", col.PhysicalType, nilOrScale(col.Scale))
+		}
+	case "text", "variant":
+		e.DataType = enc.LogicalTypeString
+	case "timestamp_ltz", "timestamp_ntz", "timestamp_tz":
+		if col.PhysicalType == "SB16" && col.Scale != nil && *col.Scale == 9 {
+			// A timestamp with nanosecond precision.
+			e.DataType = enc.LogicalTypeDecimal
+			e.Scale = 9
+		} else {
+			return e, newUnhandledColError("%s column with physical type %q and scale %s not supported", col.LogicalType, col.PhysicalType, nilOrScale(col.Scale))
+		}
+	case "date":
+		e.DataType = enc.LogicalTypeDate
+	case "boolean":
+		e.DataType = enc.PrimitiveTypeBoolean
+	case "real":
+		e.DataType = enc.PrimitiveTypeNumber
+	default:
+		return e, newUnhandledColError("unhandled type %q", col.Type)
+	}
+
+	return e, nil
+}
+
+// Ref: https://github.com/snowflakedb/snowflake-ingest-java/blob/3cbaebfe26f59dc3a8b8e973649e3f1a1014438c/src/main/java/net/snowflake/ingest/streaming/internal/AbstractRowBuffer.java#L46-L71
+var logicalTypeOrdinals = map[string]string{
+	"boolean":       "1",
+	"null":          "15",
+	"real":          "8",
+	"fixed":         "2",
+	"text":          "9",
+	"binary":        "10",
+	"date":          "7",
+	"time":          "6",
+	"timestamp_ltz": "3",
+	"timestamp_ntz": "4",
+	"timestamp_tz":  "5",
+	"array":         "13",
+	"object":        "12",
+	"variant":       "11",
+}
+
+// Ref: https://github.com/snowflakedb/snowflake-ingest-java/blob/3cbaebfe26f59dc3a8b8e973649e3f1a1014438c/src/main/java/net/snowflake/ingest/streaming/internal/AbstractRowBuffer.java#L107-L119
+var physicalTypeOrdinals = map[string]string{
+	"DOUBLE": "7",
+	"SB1":    "1",
+	"SB2":    "2",
+	"SB4":    "3",
+	"SB8":    "4",
+	"SB16":   "5",
+	"LOB":    "8",
+	"ROW":    "10",
+}
+
+// orderExistingColumns orders the existing columns by first aligning them with
+// the mapped columns from the field selection, followed by the rest of them in
+// the order they came back from the channel open request. Ordering them in this
+// way allows for rows of data to easily be correlated with the target column
+// for selected fields, and adding null values at the end for the rest.
+func orderExistingColumns(mappedColumns []*sql.Column, existingColumns []tableColumn) ([]tableColumn, error) {
+	findExisting := func(col *sql.Column) (tableColumn, error) {
+		var out tableColumn
+		idx := slices.IndexFunc(existingColumns, func(c tableColumn) bool {
+			// If the column was created with quotes, it will be reported as
+			// quoted. Otherwise column matching is case-insensitive.
+			if strings.HasPrefix(c.Name, `"`) && strings.HasSuffix(c.Name, `"`) {
+				return c.Name == col.Identifier
+			} else if strings.HasPrefix(c.Name, `"`) || strings.HasSuffix(c.Name, `"`) {
+				panic(fmt.Sprintf("internal error: malformed column name %q", c.Name))
+			} else {
+				return strings.EqualFold(c.Name, col.Identifier)
+			}
+		})
+		if idx == -1 {
+			return out, fmt.Errorf("existing column for %q not found", col.Identifier)
+		}
+
+		return existingColumns[idx], nil
+	}
+
+	out := make([]tableColumn, 0, len(existingColumns))
+	for _, mapped := range mappedColumns {
+		existing, err := findExisting(mapped)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, existing)
+	}
+
+	for _, existing := range existingColumns {
+		if !slices.Contains(out, existing) {
+			out = append(out, existing)
+		}
+	}
+
+	return out, nil
+}
+
+var (
+	maxSnowflakeInteger = func() decimal128.Num {
+		n, _ := decimal128.FromString(strings.Repeat("9", 38), 38, 0)
+		return n
+	}()
+
+	minSnowflakeInteger = func() decimal128.Num {
+		n, _ := decimal128.FromString("-"+strings.Repeat("9", 38), 38, 0)
+		return n
+	}()
+)
+
+func getInt(val any) (got decimal128.Num, err error) {
+	switch v := val.(type) {
+	case int:
+		got = decimal128.FromI64(int64(v))
+	case int64:
+		got = decimal128.FromI64(v)
+	case uint64:
+		got = decimal128.FromU64(v)
+	case float64:
+		if got, err = decimal128.FromFloat64(v, 38, 0); err != nil {
+			return
+		} else if got.Greater(maxSnowflakeInteger) || got.Less(minSnowflakeInteger) {
+			err = fmt.Errorf("float64-encoded integer value %q outside of Snowflake integer range", strconv.FormatFloat(v, 'f', -1, 64))
+		}
+	case *big.Int:
+		if v.BitLen() > 127 {
+			err = fmt.Errorf("big.Int value %q has more than 127 bits", v.String())
+			return
+		}
+		got = decimal128.FromBigInt(v)
+		if got.Greater(maxSnowflakeInteger) || got.Less(minSnowflakeInteger) {
+			err = fmt.Errorf("big.Int integer value %q outside of Snowflake integer range", v.String())
+		}
+	default:
+		err = fmt.Errorf("getInt unhandled type: %T", v)
+	}
+
+	return
+}
+
+func getStr(val any, maxByteLength int) (got string, err error) {
+	switch v := val.(type) {
+	case string:
+		got = v
+	case []byte:
+		got = string(v)
+	case json.RawMessage:
+		got = string(v)
+	case bool:
+		got = strconv.FormatBool(v)
+	case int:
+		got = strconv.Itoa(v)
+	case int64:
+		got = strconv.Itoa(int(v))
+	case uint64:
+		got = strconv.FormatUint(v, 10)
+	case float64:
+		got = strconv.FormatFloat(v, 'f', -1, 64)
+	default:
+		err = fmt.Errorf("getStr unhandled type: %T", v)
+	}
+
+	if len(got) > maxByteLength {
+		err = fmt.Errorf("string with length %d is too long: max allowed for this column is %d", len(got), maxByteLength)
+	}
+
+	return
+}
+
+func getNum(val any) (got float64, err error) {
+	switch v := val.(type) {
+	case float64:
+		got = v
+	case float32:
+		got = float64(v)
+	case int64:
+		got = float64(v)
+	case string:
+		// The sqlgen element converter converts these to strings for JSON
+		// serialization. It's kind of silly to have to convert them back again
+		// here, but the performance impact should be negligible.
+		switch v {
+		case "NaN":
+			got = math.NaN()
+		case "inf":
+			got = math.Inf(1)
+		case "-inf":
+			got = math.Inf(-1)
+		default:
+			err = fmt.Errorf("invalid string value %q for float64", v)
+		}
+	default:
+		err = fmt.Errorf("getNum unhandled type: %T", v)
+	}
+
+	return
+}
+
+// This is a copy from the parquet writer's "getDate" function, except it
+// returns a decimal128.
+func getDateInt(val any) (got decimal128.Num, err error) {
+	switch v := val.(type) {
+	case string:
+		if d, parseErr := time.Parse(time.DateOnly, v); parseErr != nil {
+			err = fmt.Errorf("unable to parse string %q as time.DateOnly: %w", v, parseErr)
+		} else {
+			unixSeconds := d.Unix()
+			unixDays := unixSeconds / 60 / 60 / 24
+			got = decimal128.FromI64(int64(unixDays))
+		}
+	default:
+		err = fmt.Errorf("getDateInt unhandled type: %T", v)
+	}
+
+	return
+
+}
+
+// Ref: https://github.com/snowflakedb/snowflake-ingest-java/blob/3cbaebfe26f59dc3a8b8e973649e3f1a1014438c/src/main/java/net/snowflake/ingest/streaming/internal/TimestampWrapper.java
+func getTimestamp(val any, logicalType string, scale int) (got decimal128.Num, err error) {
+	ts, ok := val.(string)
+	if !ok {
+		return got, fmt.Errorf("getTimestamp unhandled type: %T", val)
+	}
+
+	parsed, err := time.Parse(time.RFC3339Nano, ts)
+	if err != nil {
+		return got, fmt.Errorf("getTimestamp failed to parse input %q: %w", ts, err)
+	}
+
+	if logicalType == "timestamp_ltz" {
+		// These are always stored internally as UTC, and do not include the
+		// original timezone offset.
+		parsed = parsed.UTC()
+	} else if logicalType == "timestamp_ntz" {
+		// These ignore the zone offset completely and interpret the timestamp
+		// as a wall-clock time.
+		parsed = time.Date(
+			parsed.Year(), parsed.Month(), parsed.Day(),
+			parsed.Hour(), parsed.Minute(), parsed.Second(), parsed.Nanosecond(),
+			time.UTC,
+		)
+	}
+
+	fraction := (int64(parsed.Nanosecond()) / int64(math.Pow10(9-scale))) * int64(math.Pow10(9-scale))
+	got = decimal128.FromI64(parsed.Unix()).
+		Mul(decimal128.FromI64(int64(math.Pow10(9)))). // seconds to nanoseconds
+		Add(decimal128.FromI64(int64(fraction)))       // add in the truncated nanoseconds fraction
+
+	if scale != 9 {
+		// Downscale nanoseconds to the desired scale. We only need to do this
+		// if the scale is not 9 (for nanoseconds), and it should always be 9
+		// until we implement support for other scales. This is a (relatively)
+		// slow(er) operation because Div does allocations from creating new
+		// *big.Int's, although it probably won't be noticeable in practice. We
+		// may consider optimizing this in the future if it becomes an issue -
+		// allocation-free algorithms for this division do exist.
+		got, _ = got.Div(decimal128.FromI64(int64(math.Pow10(9 - scale))))
+	}
+
+	if logicalType == "timestamp_tz" {
+		// Must embed the timezone offset in the value.
+		_, timezoneOffsetSeconds := parsed.Zone()
+		offsetMin := timezoneOffsetSeconds / 60
+		if offsetMin < -1440 || offsetMin > 1440 {
+			// I don't know if this is possible to happen, but it is a check the
+			// Java SDK does so we'll do it too.
+			return got, fmt.Errorf("unexpected timezone offset %d", offsetMin)
+		}
+		offsetMin += 1440 // normalizes the range of possible offsets from [-1440, 1440] to [0, 2880]
+
+		// Shift left by 14 bits to make room for the offset, and then add the
+		// offset.
+		shift := 14
+		hi := got.HighBits()
+		lo := got.LowBits()
+		shifted := decimal128.New(
+			hi<<shift|int64(lo>>(64-shift)),
+			lo<<shift,
+		)
+		// The bitmask here shouldn't really be needed since we have already
+		// verified the offset is within [0, 2880], but oh well.
+		got = shifted.Add(decimal128.FromI64(int64(offsetMin & MASK_OF_TIMEZONE)))
+	}
+
+	return
+}

--- a/materialize-snowflake/bdec_test.go
+++ b/materialize-snowflake/bdec_test.go
@@ -1,0 +1,281 @@
+package main
+
+import (
+	"bytes"
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/md5"
+	"crypto/rand"
+	stdsql "database/sql"
+	"encoding/binary"
+	"encoding/hex"
+	"fmt"
+	"math/big"
+	"os"
+	"path"
+	"strings"
+	"testing"
+
+	sql "github.com/estuary/connectors/materialize-sql"
+	"github.com/stretchr/testify/require"
+
+	_ "github.com/marcboeker/go-duckdb/v2"
+)
+
+func TestBdecWriter(t *testing.T) {
+	mappedColumns := []*sql.Column{
+		{Identifier: "col1"},
+		{Identifier: "col2"},
+	}
+	bl := 1 << 18
+	existingColumns := []tableColumn{
+		{Name: "col1", Type: "text", LogicalType: "text", PhysicalType: "LOB", ByteLength: &bl, Ordinal: 1},
+		{Name: "col2", Type: "text", LogicalType: "text", PhysicalType: "LOB", ByteLength: &bl, Ordinal: 2},
+	}
+
+	tmpFile, err := os.CreateTemp(t.TempDir(), "test-file.parquet")
+	require.NoError(t, err)
+	defer tmpFile.Close()
+
+	encryptionKey := "aGVsbG8K"
+	fileName := blobFileName(tmpFile.Name())
+	key, err := deriveKey(encryptionKey, fileName)
+	require.NoError(t, err)
+
+	w, err := newBdecWriter(tmpFile, mappedColumns, existingColumns, encryptionKey, fileName)
+	require.NoError(t, err)
+
+	require.NoError(t, w.encodeRow([]any{"hello1", "world1"}))
+	require.NoError(t, w.encodeRow([]any{"hello2", "world2"}))
+	require.NoError(t, w.encodeRow([]any{"hello3", "world3"}))
+	require.NoError(t, w.close())
+
+	got, err := os.ReadFile(tmpFile.Name())
+	require.NoError(t, err)
+
+	outputFile := path.Join(t.TempDir(), "out.parquet")
+	dec := decrypt(t, got, key, 0)
+	require.NoError(t, os.WriteFile(outputFile, dec, 0644))
+
+	db, err := stdsql.Open("duckdb", "")
+	require.NoError(t, err)
+	defer db.Close()
+
+	rows, err := db.Query(fmt.Sprintf("SELECT * FROM '%s' ORDER BY col1", outputFile))
+	require.NoError(t, err)
+	defer rows.Close()
+
+	gotRows := [][]string{}
+	for rows.Next() {
+		var col1, col2 string
+		require.NoError(t, rows.Scan(&col1, &col2))
+		gotRows = append(gotRows, []string{col1, col2})
+	}
+	require.NoError(t, rows.Err())
+
+	require.Equal(t, [][]string{
+		{"hello1", "world1"},
+		{"hello2", "world2"},
+		{"hello3", "world3"}},
+		gotRows,
+	)
+}
+
+func BenchmarkBlobStatsWrite(b *testing.B) {
+	encryptionKey := "aGVsbG8K"
+	diversifier := blobFileName("test-file.parquet")
+	derivedKey, err := deriveKey(encryptionKey, diversifier)
+	require.NoError(b, err)
+
+	block, err := aes.NewCipher(derivedKey)
+	require.NoError(b, err)
+
+	w := &blobStatsTracker{
+		md5:    md5.New(),
+		w:      discardWriteCloser{},
+		stream: cipher.NewCTR(block, make([]byte, aes.BlockSize)),
+	}
+
+	chunkSize := 4 * 1024
+	data := make([]byte, chunkSize)
+	if _, err := rand.Read(data); err != nil {
+		b.Fatal(err)
+	}
+
+	b.ResetTimer()
+	for b.Loop() {
+		if _, err := w.Write(data); err != nil {
+			b.Fatal(err)
+		}
+		b.SetBytes(int64(chunkSize))
+	}
+}
+
+func TestReencrypt(t *testing.T) {
+	input := make([]byte, 1024*1024+3)
+	_, err := rand.Read(input)
+	require.NoError(t, err)
+	encryptionKey := "aGVsbG8K"
+	oldFileName := blobFileName("old")
+	newFileName := blobFileName("new")
+
+	// Simulate the originally encrypted data.
+	encryptStream, err := getCipherStream(encryptionKey, oldFileName)
+	if err != nil {
+		t.Fatalf("getCipherStream (encrypt): %v", err)
+	}
+
+	encrypted := make([]byte, len(input))
+	encryptStream.XORKeyStream(encrypted, input)
+
+	sum := md5.Sum(encrypted)
+	hsh := hex.EncodeToString(sum[:])
+
+	blob := &blobMetadata{
+		Path:   string(oldFileName),
+		MD5:    hsh,
+		Chunks: []uploadChunkMetadata{{ChunkMD5: hsh}},
+	}
+
+	var in = bytes.NewReader(encrypted)
+	var out bytes.Buffer
+
+	require.NoError(t, reencrypt(in, &out, blob, encryptionKey, newFileName))
+
+	// The re-encrypted file matches the original input.
+	newKey, err := deriveKey(encryptionKey, newFileName)
+	require.NoError(t, err)
+	got := decrypt(t, out.Bytes(), newKey, 0)
+	require.Equal(t, input, got)
+
+	// The blob metadata has been updated.
+	sum = md5.Sum(out.Bytes())
+	hsh = hex.EncodeToString(sum[:])
+	require.Equal(t, string(newFileName), blob.Path)
+	require.Equal(t, hsh, blob.MD5)
+	require.Equal(t, hsh, blob.Chunks[0].ChunkMD5)
+}
+
+func TestTruncateBytesAsHex(t *testing.T) {
+	for _, tt := range []struct {
+		input      string
+		want       string
+		truncateUp bool
+	}{
+		{input: "", want: "", truncateUp: true},
+		{input: "", want: "", truncateUp: false},
+		{input: "aaaa", want: "61616161", truncateUp: true},
+		{input: "aaaa", want: "61616161", truncateUp: false},
+		{input: strings.Repeat("a", 31), want: strings.Repeat("61", 31), truncateUp: true},
+		{input: strings.Repeat("a", 31), want: strings.Repeat("61", 31), truncateUp: false},
+		{input: strings.Repeat("a", 32), want: strings.Repeat("61", 32), truncateUp: true},
+		{input: strings.Repeat("a", 32), want: strings.Repeat("61", 32), truncateUp: false},
+		{input: strings.Repeat("a", 33), want: strings.Repeat("61", 31) + "62", truncateUp: true},
+		{input: strings.Repeat("a", 33), want: strings.Repeat("61", 32), truncateUp: false},
+		{input: strings.Repeat(string([]byte{0xff}), 33), want: "Z", truncateUp: true},
+		{input: strings.Repeat(string([]byte{0xff}), 33), want: strings.Repeat("ff", 32), truncateUp: false},
+	} {
+		require.Equal(t, tt.want, truncateBytesAsHex([]byte(tt.input), tt.truncateUp))
+	}
+}
+
+func TestGetInt(t *testing.T) {
+	tooBig, _ := new(big.Int).SetString("99999999999999999999999999999999999999", 10)
+	tooBig = tooBig.Add(tooBig, big.NewInt(1))
+	tooSmall, _ := new(big.Int).SetString("99999999999999999999999999999999999999", 10)
+	tooSmall = tooSmall.Sub(tooSmall, big.NewInt(-1))
+
+	var err error
+	_, err = getInt(tooBig)
+	require.Error(t, err)
+	_, err = getInt(tooSmall)
+	require.Error(t, err)
+}
+
+func TestGetTimestamp(t *testing.T) {
+	for _, tt := range []struct {
+		input       string
+		want        string
+		logicalType string
+	}{
+		{input: "2022-08-17T04:32:19.987654321Z", want: "1660710739987654321", logicalType: "timestamp_ltz"},
+		{input: "2022-08-17T04:32:19.987654321+02:00", want: "1660703539987654321", logicalType: "timestamp_ltz"},
+		{input: "2022-08-17T04:32:19.987654321+03:30", want: "1660698139987654321", logicalType: "timestamp_ltz"},
+		{input: "2022-08-17T04:32:19.987654321-07:00", want: "1660735939987654321", logicalType: "timestamp_ltz"},
+		{input: "0000-01-01T00:00:00.000000000Z", want: "-62167219200000000000", logicalType: "timestamp_ltz"},
+		{input: "0000-01-01T00:00:00.000000000+23:59", want: "-62167305540000000000", logicalType: "timestamp_ltz"},
+		{input: "0000-01-01T00:00:00.000000000-23:59", want: "-62167132860000000000", logicalType: "timestamp_ltz"},
+		{input: "9999-12-31T23:59:59.999999999Z", want: "253402300799999999999", logicalType: "timestamp_ltz"},
+		{input: "9999-12-31T23:59:59.999999999+23:59", want: "253402214459999999999", logicalType: "timestamp_ltz"},
+		{input: "9999-12-31T23:59:59.999999999-23:59", want: "253402387139999999999", logicalType: "timestamp_ltz"},
+
+		{input: "2022-08-17T04:32:19.987654321Z", want: "1660710739987654321", logicalType: "timestamp_ntz"},
+		{input: "2022-08-17T04:32:19.987654321+02:00", want: "1660710739987654321", logicalType: "timestamp_ntz"},
+		{input: "2022-08-17T04:32:19.987654321+03:30", want: "1660710739987654321", logicalType: "timestamp_ntz"},
+		{input: "2022-08-17T04:32:19.987654321-07:00", want: "1660710739987654321", logicalType: "timestamp_ntz"},
+		{input: "0000-01-01T00:00:00.000000000Z", want: "-62167219200000000000", logicalType: "timestamp_ntz"},
+		{input: "0000-01-01T00:00:00.000000000+23:59", want: "-62167219200000000000", logicalType: "timestamp_ntz"},
+		{input: "0000-01-01T00:00:00.000000000-23:59", want: "-62167219200000000000", logicalType: "timestamp_ntz"},
+		{input: "9999-12-31T23:59:59.999999999Z", want: "253402300799999999999", logicalType: "timestamp_ntz"},
+		{input: "9999-12-31T23:59:59.999999999+23:59", want: "253402300799999999999", logicalType: "timestamp_ntz"},
+		{input: "9999-12-31T23:59:59.999999999-23:59", want: "253402300799999999999", logicalType: "timestamp_ntz"},
+
+		{input: "2022-08-17T04:32:19.987654321Z", want: "27209084763957728396704", logicalType: "timestamp_tz"},
+		{input: "2022-08-17T04:32:19.987654321+02:00", want: "27208966799157728396824", logicalType: "timestamp_tz"},
+		{input: "2022-08-17T04:32:19.987654321+03:30", want: "27208878325557728396914", logicalType: "timestamp_tz"},
+		{input: "2022-08-17T04:32:19.987654321-07:00", want: "27209497640757728396284", logicalType: "timestamp_tz"},
+		{input: "0000-01-01T00:00:00.000000000Z", want: "-1018547719372799999998560", logicalType: "timestamp_tz"},
+		{input: "0000-01-01T00:00:00.000000000+23:59", want: "-1018549133967359999997121", logicalType: "timestamp_tz"},
+		{input: "0000-01-01T00:00:00.000000000-23:59", want: "-1018546304778239999999999", logicalType: "timestamp_tz"},
+		{input: "9999-12-31T23:59:59.999999999Z", want: "4151743296307199999985056", logicalType: "timestamp_tz"},
+		{input: "9999-12-31T23:59:59.999999999+23:59", want: "4151741881712639999986495", logicalType: "timestamp_tz"},
+		{input: "9999-12-31T23:59:59.999999999-23:59", want: "4151744710901759999983617", logicalType: "timestamp_tz"},
+	} {
+		t.Run(tt.input+"_"+tt.logicalType, func(t *testing.T) {
+			got, err := getTimestamp(tt.input, tt.logicalType, 9)
+			require.NoError(t, err)
+			require.Equal(t, tt.want, got.BigInt().String())
+		})
+	}
+}
+
+func BenchmarkGetTimestamp(b *testing.B) {
+	input := "2025-04-15T19:23:47.583294617Z"
+	b.Run("fast path", func(b *testing.B) {
+		b.ResetTimer()
+		for b.Loop() {
+			if _, err := getTimestamp(input, "timestamp_tz", 9); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+
+	b.Run("slow path", func(b *testing.B) {
+		b.ResetTimer()
+		for b.Loop() {
+			if _, err := getTimestamp(input, "timestamp_tz", 8); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+}
+
+type discardWriteCloser struct{}
+
+func (discardWriteCloser) Write(in []byte) (int, error) { return len(in), nil }
+func (discardWriteCloser) Close() error                 { return nil }
+
+func decrypt(t *testing.T, enc []byte, key []byte, iv uint64) []byte {
+	t.Helper()
+
+	block, err := aes.NewCipher(key)
+	require.NoError(t, err)
+	ivBytes := make([]byte, aes.BlockSize)
+	binary.BigEndian.PutUint64(ivBytes[8:], iv)
+	decStream := cipher.NewCTR(block, ivBytes)
+
+	dec := make([]byte, len(enc))
+	decStream.XORKeyStream(dec, enc)
+
+	return dec
+}

--- a/materialize-snowflake/config.go
+++ b/materialize-snowflake/config.go
@@ -17,8 +17,12 @@ import (
 	orderedmap "github.com/wk8/go-ordered-map/v2"
 )
 
-// config represents the endpoint configuration for snowflake.
-// It must match the one defined for the source specs (flow.yaml) in Rust.
+var featureFlagDefaults = map[string]bool{
+	// Use Snowpipe streaming for delta-updates bindings that use JWT
+	// authentication.
+	"snowpipe_streaming": false,
+}
+
 type config struct {
 	Host          string                     `json:"host" jsonschema:"title=Host (Account URL),description=The Snowflake Host used for the connection. Must include the account identifier and end in .snowflakecomputing.com. Example: orgname-accountname.snowflakecomputing.com (do not include the protocol)." jsonschema_extras:"order=0,pattern=^[^/:]+.snowflakecomputing.com$"`
 	Database      string                     `json:"database" jsonschema:"title=Database,description=The SQL database to connect to." jsonschema_extras:"order=3"`
@@ -30,6 +34,12 @@ type config struct {
 	Credentials   credentialConfig           `json:"credentials" jsonschema:"title=Authentication"`
 	Schedule      boilerplate.ScheduleConfig `json:"syncSchedule,omitempty" jsonschema:"title=Sync Schedule,description=Configure schedule of transactions for the materialization."`
 	DBTJobTrigger dbt.JobConfig              `json:"dbt_job_trigger,omitempty" jsonschema:"title=dbt Cloud Job Trigger,description=Trigger a dbt Job when new data is available"`
+
+	Advanced advancedConfig `json:"advanced,omitempty" jsonschema:"title=Advanced Options,description=Options for advanced users. You should not typically need to modify these." jsonschema_extra:"advanced=true"`
+}
+
+type advancedConfig struct {
+	FeatureFlags string `json:"feature_flags,omitempty" jsonschema:"title=Feature Flags,description=This property is intended for Estuary internal use. You should only modify this field as directed by Estuary support."`
 }
 
 // toURI manually builds the DSN connection string.

--- a/materialize-snowflake/pipe.go
+++ b/materialize-snowflake/pipe.go
@@ -71,7 +71,7 @@ func sanitizeAndAppendHash(tableName string) string {
 		limited = sanitizedTable[:32]
 	}
 
-	return fmt.Sprintf("%s_%016X", limited, xxhash.Sum64String(sanitizedTable))
+	return fmt.Sprintf("%s_%016X", limited, xxhash.Sum64String(tableName))
 }
 
 type PipeClient struct {

--- a/materialize-snowflake/snowflake_test.go
+++ b/materialize-snowflake/snowflake_test.go
@@ -26,7 +26,7 @@ func mustGetCfg(t *testing.T) config {
 
 	out := config{
 		Credentials: credentialConfig{
-			AuthType: UserPass,
+			AuthType: JWT,
 		},
 	}
 
@@ -37,12 +37,15 @@ func mustGetCfg(t *testing.T) config {
 		{"SNOWFLAKE_HOST", &out.Host},
 		{"SNOWFLAKE_ACCOUNT", &out.Account},
 		{"SNOWFLAKE_USER", &out.Credentials.User},
-		{"SNOWFLAKE_PASSWORD", &out.Credentials.Password},
 		{"SNOWFLAKE_DATABASE", &out.Database},
 		{"SNOWFLAKE_SCHEMA", &out.Schema},
 	} {
 		*prop.dest = os.Getenv(prop.key)
 	}
+
+	key, err := os.ReadFile(os.Getenv("SNOWFLAKE_PRIVATE_KEY_PATH"))
+	require.NoError(t, err)
+	out.Credentials.PrivateKey = string(key)
 
 	if err := out.Validate(); err != nil {
 		t.Fatal(err)

--- a/materialize-snowflake/stream.go
+++ b/materialize-snowflake/stream.go
@@ -1,0 +1,536 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"path"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	"github.com/estuary/connectors/go/blob"
+	sql "github.com/estuary/connectors/materialize-sql"
+	log "github.com/sirupsen/logrus"
+	"golang.org/x/exp/maps"
+	"golang.org/x/oauth2"
+	"google.golang.org/api/option"
+)
+
+// channelName produces a reasonably readable channel name that is globally
+// unique per materialization and shard. Channels are specific to a table, so
+// there is no need to include the database or schema in the name, and they can
+// be at least 1000 characters long. It's important for the channel name to
+// never change to maintain data consistency.
+func channelName(materialization string, keyBegin uint32) string {
+	return sanitizeAndAppendHash(materialization) + "_" + fmt.Sprintf("%08x", keyBegin)
+}
+
+type tableStream struct {
+	mappedColumns []*sql.Column
+	channel       *channel
+}
+
+// streamManager is a high-level orchestrator for Snowpipe streaming operations,
+// which mostly entails writing rows of data for bindings and registering the
+// resulting blobs to tables.
+type streamManager struct {
+	c            *streamClient
+	tableStreams map[int]*tableStream
+	tenant       string // used for the `ingestclientname` metadata
+	keyBegin     uint32
+	channelName  string
+
+	// Returned from the "configure" API.
+	prefix       string
+	deploymentId int
+	bucketPath   string
+
+	// For writing blob data to object storage.
+	bucket          blob.Bucket
+	bucketExpiresAt time.Time
+	bdecWriter      *bdecWriter
+	counter         int
+	lastBinding     int // bookkeeping for when to flush the writer when a new binding starts writing rows
+
+	blobStats map[int][]*blobStatsTracker
+}
+
+func newStreamManager(cfg *config, materialization string, tenant string, account string, keyBegin uint32) (*streamManager, error) {
+	c, err := newStreamClient(cfg, account)
+	if err != nil {
+		return nil, fmt.Errorf("newStreamClient: %w", err)
+	}
+
+	return &streamManager{
+		c:            c,
+		tableStreams: make(map[int]*tableStream),
+		tenant:       tenant,
+		keyBegin:     keyBegin,
+		channelName:  channelName(materialization, keyBegin),
+		lastBinding:  -1,
+		blobStats:    make(map[int][]*blobStatsTracker),
+		counter:      0,
+	}, nil
+}
+
+func (sm *streamManager) addBinding(ctx context.Context, schema string, table sql.Table) error {
+	channel, err := sm.c.openChannel(ctx, schema, table.Identifier, sm.channelName)
+	if err != nil {
+		return fmt.Errorf("openChannel: %w", err)
+	}
+
+	// Verify that we support this table's columns for Snowpipe streaming.
+	for _, col := range channel.TableColumns {
+		if _, err := makeSchemaElement(col); err != nil {
+			return err
+		}
+	}
+
+	sm.tableStreams[table.Binding] = &tableStream{
+		mappedColumns: table.Columns(),
+		channel:       channel,
+	}
+
+	return nil
+}
+
+func (sm *streamManager) encodeRow(ctx context.Context, binding int, row []any) error {
+	if sm.lastBinding != -1 && binding != sm.lastBinding {
+		if err := sm.finishBlob(); err != nil {
+			return fmt.Errorf("finishBlob: %w", err)
+		}
+	}
+	sm.lastBinding = binding
+
+	if sm.bdecWriter == nil {
+		if err := sm.startNewBlob(ctx, binding); err != nil {
+			return fmt.Errorf("startNewBlob: %w", err)
+		}
+	}
+
+	if err := sm.bdecWriter.encodeRow(row); err != nil {
+		return fmt.Errorf("bdecWriter encodeRow: %w", err)
+	}
+
+	if sm.bdecWriter.done {
+		if err := sm.finishBlob(); err != nil {
+			return fmt.Errorf("finishBlob: %w", err)
+		}
+	}
+
+	return nil
+}
+
+func (sm *streamManager) finishBlob() error {
+	if sm.bdecWriter == nil {
+		return nil
+	}
+
+	if err := sm.bdecWriter.close(); err != nil {
+		return fmt.Errorf("bdecWriter close: %w", err)
+	}
+	sm.blobStats[sm.lastBinding] = append(sm.blobStats[sm.lastBinding], sm.bdecWriter.blobStats)
+	sm.bdecWriter = nil
+
+	return nil
+}
+
+func (sm *streamManager) startNewBlob(ctx context.Context, binding int) error {
+	if err := sm.maybeInitializeBucket(ctx); err != nil {
+		return fmt.Errorf("initializing bucket: %w", err)
+	}
+
+	fName := sm.getNextFileName(time.Now(), fmt.Sprintf("%s_%d", sm.prefix, sm.deploymentId))
+	w := sm.bucket.NewWriter(ctx, path.Join(sm.bucketPath, string(fName)), sm.objMetadata())
+
+	ts := sm.tableStreams[binding]
+	bdecWriter, err := newBdecWriter(w, ts.mappedColumns, ts.channel.TableColumns, ts.channel.EncryptionKey, fName)
+	if err != nil {
+		return fmt.Errorf("newBdecWriter: %w", err)
+	}
+	sm.bdecWriter = bdecWriter
+
+	return nil
+}
+
+func (sm *streamManager) objMetadata() blob.WriterOption {
+	return blob.WithObjectMetadata(map[string]string{
+		"ingestclientname": fmt.Sprintf("%s_EstuaryFlow", sm.tenant),
+		"ingestclientkey":  sm.prefix,
+	})
+}
+
+func (sm *streamManager) flush(baseToken string) (map[int][]*blobMetadata, error) {
+	if sm.bdecWriter != nil {
+		if err := sm.finishBlob(); err != nil {
+			return nil, fmt.Errorf("finishBlob: %w", err)
+		}
+	}
+
+	out := make(map[int][]*blobMetadata)
+	for binding, trackedBlobs := range sm.blobStats {
+		for idx, trackedBlob := range trackedBlobs {
+			out[binding] = append(out[binding], generateBlobMetadata(
+				trackedBlob,
+				sm.tableStreams[binding].channel,
+				blobToken(baseToken, idx)),
+			)
+		}
+	}
+	maps.Clear(sm.blobStats)
+
+	return out, nil
+}
+
+// write registers a series of blobs to the table. All the blobs must be for the
+// same table.
+//
+// Exactly-once semantics are achieved using the offset tokens for the blobs:
+// The offset token consists of the "base" token which is a string, and for each
+// blob it is appended with a sequential counter, starting at 0. So if there are
+// multiple blobs to append, they are organized with offset tokens like
+// "basetoken:0", "basetoken:1", "basetoken:2" etc.
+//
+// Blobs are registered in this order, and it's possible that only some of the
+// blobs get registered in a single Acknowledge before the connector fails for
+// some reason, or all of the blobs get registered but the Acknowledge response
+// is not persisted to the runtime before the connector restarts. The Snowpipe
+// channel itself persists the last registered token, and this allows us to
+// filter out blobs that had previously been registered and don't need
+// registered again on a re-attempt of an Acknowledge.
+func (sm *streamManager) write(ctx context.Context, blobs []*blobMetadata) error {
+	if err := validWriteBlobs(blobs); err != nil {
+		return fmt.Errorf("validWriteBlobs: %w", err)
+	}
+
+	var schema = blobs[0].Chunks[0].Schema
+	var table = blobs[0].Chunks[0].Table
+	var channelName = blobs[0].Chunks[0].Channels[0].Channel
+	var thisChannel *channel
+	for _, v := range sm.tableStreams {
+		matches := v.channel.Schema == schema && v.channel.Table == table && v.channel.Channel == channelName
+		if matches && thisChannel != nil {
+			return fmt.Errorf("internal error: found duplicate channel %s in tableStreams", channelName)
+		} else if matches {
+			thisChannel = v.channel
+		}
+	}
+	if thisChannel == nil {
+		return fmt.Errorf("unknown channel %s", channelName)
+	}
+
+	for _, blob := range blobs {
+		blobToken := blob.Chunks[0].Channels[0].OffsetToken
+		currentChannelToken := thisChannel.OffsetToken
+		if shouldWrite, err := shouldWriteNextToken(blobToken, currentChannelToken); err != nil {
+			return fmt.Errorf("shouldWriteNextToken: %w", err)
+		} else if !shouldWrite {
+			continue
+		}
+
+		blob.Chunks[0].Channels[0].ClientSequencer = thisChannel.ClientSequencer
+		blob.Chunks[0].Channels[0].RowSequencer = thisChannel.RowSequencer + 1
+
+		if err := sm.c.write(ctx, blob); err != nil {
+			var apiError *streamingApiError
+			if errors.As(err, &apiError) && apiError.Code == 38 {
+				// The "blob has wrong format or extension" error occurs if the
+				// blob was written not-so-recently; apparently anything older
+				// than an hour or so is rejected by what seems to be a
+				// server-side check the examines the name of the file, which
+				// contains the timestamp it was written.
+				//
+				// In these cases, which may arise from re-enabling a disabled
+				// binding / materialization, or extended outages, we have to
+				// download the file and re-upload it with an up-to-date name.
+				//
+				// This should be quite rare, even more rare than one may think,
+				// since blob registration tokens are persisted in Snowflake
+				// rather than exclusively managed by our Acknowledge
+				// checkpoints. But it is still technically possible and so it
+				// is handled with this.
+				if err := sm.maybeInitializeBucket(ctx); err != nil {
+					return fmt.Errorf("initializing bucket to rename: %w", err)
+				}
+				nextName := sm.getNextFileName(time.Now(), fmt.Sprintf("%s_%d", sm.prefix, sm.deploymentId))
+
+				ll := log.WithFields(log.Fields{
+					"oldName": blob.Path,
+					"newName": nextName,
+					"token":   blobToken,
+				})
+				ll.Info("attempting to register blob with malformed name by renaming")
+
+				if err := sm.renameBlob(ctx, blob, thisChannel.EncryptionKey, nextName); err != nil {
+					return fmt.Errorf("renameBlob: %w", err)
+				}
+
+				if err := sm.c.write(ctx, blob); err != nil {
+					return fmt.Errorf("failed to write renamed blob: %w", err)
+				}
+				ll.Info("successfully registered renamed blob")
+			} else {
+				return fmt.Errorf("write: %w", err)
+			}
+		}
+
+		thisChannel.RowSequencer++
+		thisChannel.OffsetToken = &blobToken
+	}
+
+	// We don't need to wait for each individual token to be persisted, but need
+	// to wait to the final one to be persisted for our idempotency strategy to
+	// work.
+	if err := sm.c.waitForTokenPersisted(
+		ctx,
+		*thisChannel.OffsetToken,
+		thisChannel.ClientSequencer,
+		blobs[0].Chunks[0].Schema,
+		blobs[0].Chunks[0].Table,
+		channelName,
+	); err != nil {
+		return fmt.Errorf("waitForTokenPersisted: %w", err)
+	}
+
+	return nil
+}
+
+func (sm *streamManager) renameBlob(ctx context.Context, blob *blobMetadata, encryptionKey string, newName blobFileName) error {
+	r, err := sm.bucket.NewReader(ctx, path.Join(sm.bucketPath, blob.Path))
+	if err != nil {
+		return fmt.Errorf("NewReader: %w", err)
+	}
+	w := sm.bucket.NewWriter(ctx, path.Join(sm.bucketPath, string(newName)), sm.objMetadata())
+
+	if err := reencrypt(r, w, blob, encryptionKey, newName); err != nil {
+		return fmt.Errorf("reencrypt: %w", err)
+	} else if err := r.Close(); err != nil {
+		return fmt.Errorf("closing r: %w", err)
+	} else if err := w.Close(); err != nil {
+		return fmt.Errorf("closing w: %w", err)
+	}
+
+	return nil
+}
+
+// maybeInitializeBucket retrieves blob storage parameters and initializes the
+// appropriate blob storage bucket. A basic expiry mechanism is used to prevent
+// this from being re-done too frequently.
+func (sm *streamManager) maybeInitializeBucket(ctx context.Context) error {
+	if time.Now().Before(sm.bucketExpiresAt) {
+		return nil
+	}
+
+	cfg, err := sm.c.configure(ctx)
+	if err != nil {
+		return fmt.Errorf("configuring channel: %w", err)
+	}
+
+	parts := strings.Split(cfg.StageLocation.Location, "/")
+	bucket := parts[0]
+	sm.bucketPath = path.Join(parts[1:]...)
+	sm.prefix = cfg.Prefix
+	sm.deploymentId = cfg.DeploymentID
+
+	switch cfg.StageLocation.LocationType {
+	case "S3":
+		provider := credentials.NewStaticCredentialsProvider(
+			cfg.StageLocation.Creds.AwsKeyId,
+			cfg.StageLocation.Creds.AwsSecretKey,
+			cfg.StageLocation.Creds.AwsToken,
+		)
+		if sm.bucket, err = blob.NewS3Bucket(ctx, bucket, provider); err != nil {
+			return fmt.Errorf("new s3 blob bucket: %w", err)
+		}
+	case "GCS":
+		opts := []option.ClientOption{
+			option.WithTokenSource(oauth2.StaticTokenSource(&oauth2.Token{
+				AccessToken: cfg.StageLocation.Creds.GcsAccessToken,
+			})),
+		}
+		if sm.bucket, err = blob.NewGCSBucket(ctx, bucket, opts); err != nil {
+			return fmt.Errorf("new gcs blob bucket: %w", err)
+		}
+	case "AZURE":
+		opts := []blob.AzureConfigOption{
+			blob.WithAzureSasToken(cfg.StageLocation.Creds.AzureSasToken),
+			blob.WithAzureEndpoint(cfg.StageLocation.Endpoint),
+		}
+		if sm.bucket, err = blob.NewAzureBlobBucket(ctx, bucket, cfg.StageLocation.StorageAccount, opts); err != nil {
+			return fmt.Errorf("new azure blob bucket: %w", err)
+		}
+	default:
+		return fmt.Errorf("unknown stage location type %q", cfg.StageLocation.LocationType)
+	}
+
+	sm.bucketExpiresAt = time.Now().Add(30 * time.Minute)
+	log.WithFields(log.Fields{
+		"locationType": cfg.StageLocation.LocationType,
+		"location":     cfg.StageLocation.Location,
+		"prefix":       cfg.Prefix,
+		"deploymentId": cfg.DeploymentID,
+	}).Info("configured bucket for Snowpipe streaming")
+
+	return nil
+}
+
+// blobFileName is the file name for a blob, which is part of the file key. It
+// is also used as the "diversifier" for encryption. It's just a string, but
+// this custom type helps keeps its usage comprehensible in both of these
+// capacities.
+type blobFileName string
+
+// Gets the next file name, with "next" being relative to the tracked counter.
+// The threadID is for the Java thread, so any random int value should work.
+//
+// The names of these files need to be globally unique and the timestamp parts
+// have only second resolution. The client prefix includes a random nonce from
+// the stream configure response that appears to change every time, so that
+// should be sufficient.
+//
+// This code is written kind of weirdly so that it matches the Java SDK as
+// closely as possible, since the filenames must be constructed in exactly the
+// same way.
+//
+// Ref:
+// https://github.com/snowflakedb/snowflake-ingest-java/blob/3cbaebfe26f59dc3a8b8e973649e3f1a1014438c/src/main/java/net/snowflake/ingest/streaming/internal/InternalStageManager.java#L161-L206
+func (sm *streamManager) getNextFileName(calendar time.Time, clientPrefix string) blobFileName {
+	calendar = calendar.UTC()
+	year := strconv.Itoa(calendar.Year())
+	month := strconv.Itoa(int(calendar.Month()))
+	day := strconv.Itoa(calendar.Day())
+	hour := strconv.Itoa(calendar.Hour())
+	minute := strconv.Itoa(calendar.Minute())
+	timestamp := calendar.Unix()
+	blobShortName := strconv.FormatInt(timestamp, 36) +
+		"_" +
+		clientPrefix +
+		"_" +
+		strconv.Itoa(int(sm.keyBegin)) +
+		"_" +
+		strconv.Itoa(sm.getAndIncrementCounter()) +
+		"." +
+		BLOB_EXTENSION_TYPE
+
+	return blobFileName(year + "/" + month + "/" + day + "/" + hour + "/" + minute + "/" + blobShortName)
+}
+
+func (sm *streamManager) getAndIncrementCounter() int {
+	out := sm.counter
+	sm.counter++
+	return out
+}
+
+// blobToken encodes `baseToken`, which is per-transaction, and the counter `n`
+// which is based on the number of blobs written for the specific binding within
+// the transaction. In typical streaming cases there will only be a single blob
+// in a transaction, but larger backfill scenarios may write out more than one
+// blob since there is a limit on how large a single blob can be.
+func blobToken(baseToken string, n int) string {
+	return fmt.Sprintf("%s:%d", baseToken, n)
+}
+
+// shouldWriteNextToken determines if a blob with the `next` token should be
+// written or not, based on the `current` persisted token. Generally this means
+// if the `n` value for `next` is exactly one larger than `current` (or there is
+// no `current`), the blob should be written.
+func shouldWriteNextToken(next string, current *string) (bool, error) {
+	if current == nil {
+		// Maybe this should be more strict and error out unless `next` is the
+		// first one in the sequence, but that would block cases where a user
+		// has manually dropped a table for some reason.
+		return true, nil
+	}
+
+	currentToken := *current
+	nextBase, nextN, err := splitToken(next)
+	if err != nil {
+		return false, err
+	}
+	currentBase, currentN, err := splitToken(currentToken)
+	if err != nil {
+		return false, err
+	}
+
+	if nextBase != currentBase && nextN != 0 {
+		return false, fmt.Errorf("expected blob token %s to start a new sequence (current: %s)", next, currentToken)
+	} else if nextBase == currentBase && nextN <= currentN {
+		return false, nil
+	} else if nextBase == currentBase && nextN != currentN+1 {
+		return false, fmt.Errorf("expected blob token %s to be written immediately after %s", next, currentToken)
+	}
+
+	return true, nil
+}
+
+func splitToken(token string) (string, int, error) {
+	idx := strings.Index(token, ":")
+	if idx == -1 {
+		return "", 0, fmt.Errorf("invalid token %q: no ':' found", token)
+	} else if idx == 0 {
+		return "", 0, fmt.Errorf("invalid token %q: no base token found", token)
+	} else if idx == len(token)-1 {
+		return "", 0, fmt.Errorf("invalid token %q: no number found", token)
+	}
+
+	baseToken := token[:idx]
+	nStr := token[idx+1:]
+	n, err := strconv.Atoi(nStr)
+	if err != nil {
+		return "", 0, err
+	}
+
+	return baseToken, n, nil
+}
+
+// validWriteBlobs does some sanity checking the a series of blobs is valid to
+// write per our invariants. Theoretically this shouldn't be needed, but is a
+// nice guard against some hypothetical bugs which would otherwise be more
+// difficult to troubleshoot.
+func validWriteBlobs(blobs []*blobMetadata) error {
+	var baseToken, channelName, schema, table, database string
+	var n int
+	for _, blob := range blobs {
+		if l := len(blob.Chunks); l != 1 {
+			return fmt.Errorf("internal error: expected chunks to have length 1 but was %d", l)
+		} else if l := len(blob.Chunks[0].Channels); l != 1 {
+			return fmt.Errorf("internal error: expected chunk channel to have length 1 but was %d", l)
+		}
+
+		persistToken := blob.Chunks[0].Channels[0].OffsetToken
+		token, thisN, err := splitToken(persistToken)
+		if err != nil {
+			return fmt.Errorf("invalid token %q: %w", persistToken, err)
+		}
+
+		if baseToken == "" {
+			baseToken = token
+			channelName = blob.Chunks[0].Channels[0].Channel
+			schema = blob.Chunks[0].Schema
+			table = blob.Chunks[0].Table
+			database = blob.Chunks[0].Database
+			n = thisN
+			continue
+		}
+
+		if baseToken != token {
+			return fmt.Errorf("expected all blobs to have the same base token %q but got %q", baseToken, token)
+		} else if channelName != blob.Chunks[0].Channels[0].Channel {
+			return fmt.Errorf("expected all blobs to have the same channel %q but got %q", channelName, blob.Chunks[0].Channels[0].Channel)
+		} else if schema != blob.Chunks[0].Schema {
+			return fmt.Errorf("expected all blobs to have the same schema %q but got %q", schema, blob.Chunks[0].Schema)
+		} else if table != blob.Chunks[0].Table {
+			return fmt.Errorf("expected all blobs to have the same table %q but got %q", table, blob.Chunks[0].Table)
+		} else if database != blob.Chunks[0].Database {
+			return fmt.Errorf("expected all blobs to have the same database %q but got %q", database, blob.Chunks[0].Database)
+		} else if n+1 != thisN {
+			return fmt.Errorf("expected blob tokens to be in ascending order but got %d vs %d", thisN, n)
+		}
+
+		n = thisN
+	}
+
+	return nil
+}

--- a/materialize-snowflake/stream_http.go
+++ b/materialize-snowflake/stream_http.go
@@ -1,0 +1,564 @@
+package main
+
+import (
+	"context"
+	"crypto/rsa"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"math"
+	"path"
+	"sync"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+	"resty.dev/v3"
+)
+
+type fileColumnProperties struct {
+	ColumnOrdinal     int             `json:"columnId"`
+	NullCount         int             `json:"nullCount"`
+	MaxStrValue       *string         `json:"maxStrValue"` // hex-encoded & truncated up to 32 bytes
+	MinStrValue       *string         `json:"minStrValue"` // hex-encoded & truncated down to 32 bytes
+	MaxLength         int             `json:"maxLength"`   // maximum string length
+	MaxIntValue       json.RawMessage `json:"maxIntValue"`
+	MinIntValue       json.RawMessage `json:"minIntValue"`
+	MaxRealValue      json.RawMessage `json:"maxRealValue"`
+	MinRealValue      json.RawMessage `json:"minRealValue"`
+	DistinctValues    int             `json:"distinctValues"`    // always -1
+	Collation         *string         `json:"collation"`         // always null
+	MinStrNonCollated *string         `json:"minStrNonCollated"` // always null
+	MaxStrNonCollated *string         `json:"maxStrNonCollated"` // always null
+}
+
+type eps struct {
+	Rows    int                             `json:"rows"`
+	Columns map[string]fileColumnProperties `json:"columns"`
+}
+
+type tableColumn struct {
+	Name         string `json:"name"`
+	Type         string `json:"type"`
+	LogicalType  string `json:"logical_type"`
+	PhysicalType string `json:"physical_type"`
+	Precision    *int   `json:"precision"`
+	Scale        *int   `json:"scale"`
+	ByteLength   *int   `json:"byte_length"`
+	Length       *int   `json:"length"`
+	Nullable     bool   `json:"nullable"`
+	Ordinal      int    `json:"ordinal"`
+}
+
+type channelMetadata struct {
+	ClientSequencer int           `json:"client_sequencer"`
+	RowSequencer    int           `json:"row_sequencer"`
+	EncryptionKeyId int           `json:"encryption_key_id"`
+	EncryptionKey   string        `json:"encryption_key"`
+	TableColumns    []tableColumn `json:"table_columns"`
+	OffsetToken     *string       `json:"offset_token"`
+}
+
+type uploadChunkChannelMetadata struct {
+	Channel         string `json:"channel_name"`
+	ClientSequencer int    `json:"client_sequencer"`
+	RowSequencer    int    `json:"row_sequencer"`
+	OffsetToken     string `json:"offset_token"`
+	// Not included: last_token and next_token, which we don't do anything with
+	// and don't seem to have any effect.
+}
+
+type uploadChunkMetadata struct {
+	Database                string                       `json:"database"`
+	Schema                  string                       `json:"schema"`
+	Table                   string                       `json:"table"`
+	ChunkStartOffset        int                          `json:"chunk_start_offset"`
+	ChunkLength             int                          `json:"chunk_length"`
+	ChunkLengthUncompressed int                          `json:"chunk_length_uncompressed"`
+	Channels                []uploadChunkChannelMetadata `json:"channels"`
+	ChunkMD5                string                       `json:"chunk_md5"` // hex encoded
+	EPS                     eps                          `json:"eps"`
+	EncryptionKeyID         int                          `json:"encryption_key_id"`
+	FirstInsertTimeInMillis int64                        `json:"first_insert_time_in_ms"`
+	LastInsertTimeInMillis  int64                        `json:"last_insert_time_in_ms"`
+}
+
+type blobStats struct {
+	FlushStartMs     int64 `json:"flush_start_ms"`
+	BuildDurationMs  int64 `json:"build_duration_ms"`
+	UploadDurationMs int64 `json:"upload_duration_ms"`
+}
+
+type blobMetadata struct {
+	Path        string                `json:"path"`
+	MD5         string                `json:"md5"` // hex encoded
+	Chunks      []uploadChunkMetadata `json:"chunks"`
+	BDECVersion int                   `json:"bdec_version"` // always 3
+	BlobStats   blobStats             `json:"blob_stats"`
+}
+
+type streamConfig struct {
+	Prefix        string `json:"prefix"`
+	StageLocation struct {
+		LocationType   string `json:"locationType"`
+		Location       string `json:"location"`
+		StorageAccount string `json:"storageAccount"` // for Azure
+		Endpoint       string `json:"endPoint"`       // for Azure
+		Creds          struct {
+			// For AWS authorization.
+			AwsKeyId     string `json:"AWS_KEY_ID"`
+			AwsSecretKey string `json:"AWS_SECRET_KEY"`
+			AwsToken     string `json:"AWS_TOKEN"`
+
+			// For GCS authorization.
+			GcsAccessToken string `json:"GCS_ACCESS_TOKEN"`
+
+			// For Azure authorization.
+			AzureSasToken string `json:"AZURE_SAS_TOKEN"`
+		} `json:"creds"`
+	} `json:"stage_location"`
+	DeploymentID int    `json:"deployment_id"`
+	Message      string `json:"message"`
+	StatusCode   int    `json:"status_code"`
+}
+
+type channel struct {
+	Channel         string        `json:"channel"`
+	Database        string        `json:"database"`
+	Schema          string        `json:"schema"`
+	Table           string        `json:"table"`
+	OffsetToken     *string       `json:"offset_token"`
+	ClientSequencer int           `json:"client_sequencer"`
+	RowSequencer    int           `json:"row_sequencer"`
+	EncryptionKey   string        `json:"encryption_key"`
+	EncryptionKeyId int           `json:"encryption_key_id"`
+	TableColumns    []tableColumn `json:"table_columns"`
+	Message         string        `json:"message"`
+	StatusCode      int           `json:"status_code"`
+}
+
+type writeResponse struct {
+	Blobs []struct {
+		Chunks []struct {
+			Channels []struct {
+				Channel         string `json:"channel"`
+				ClientSequencer int    `json:"client_sequencer"`
+				StatusCode      int    `json:"status_code"`
+			} `json:"channels"`
+			Database string `json:"database"`
+			Schema   string `json:"schema"`
+			Table    string `json:"table"`
+		} `json:"chunks"`
+	} `json:"blobs"`
+	Message    string `json:"message"`
+	StatusCode int    `json:"status_code"`
+}
+
+type channelStatusResponse struct {
+	Channels []struct {
+		PersistedClientSequencer int    `json:"persisted_client_sequencer"`
+		PersistedRowSequencer    int    `json:"persisted_row_sequencer"`
+		PersistedOffsetToken     string `json:"persisted_offset_token"`
+		StatusCode               int    `json:"status_code"`
+	} `json:"channels"`
+	Message    string `json:"message"`
+	StatusCode int    `json:"status_code"`
+}
+
+type streamClient struct {
+	r        *resty.Client
+	key      *rsa.PrivateKey
+	user     string
+	database string
+	account  string
+	role     *string
+
+	mu          sync.Mutex
+	cachedToken string
+	expiry      time.Time
+}
+
+func newStreamClient(cfg *config, account string) (*streamClient, error) {
+	var role *string
+
+	key, err := cfg.Credentials.privateKey()
+	if err != nil {
+		return nil, err
+	}
+	if cfg.Role != "" {
+		role = &cfg.Role
+	}
+
+	return &streamClient{
+		r:        resty.New().SetBaseURL(fmt.Sprintf("https://") + path.Join(cfg.Host, "v1/streaming")),
+		key:      key,
+		user:     cfg.Credentials.User,
+		database: cfg.Database,
+		account:  account,
+		role:     role,
+	}, nil
+}
+
+func (s *streamClient) configure(ctx context.Context) (*streamConfig, error) {
+	type req struct {
+		Role *string `json:"role;omitempty"`
+	}
+
+	res, err := post[streamConfig](ctx, s, "/client/configure", req{
+		Role: s.role,
+	})
+	if err != nil {
+		return nil, err
+	} else if err := getErrorByCode(res.StatusCode); err != nil {
+		return nil, fmt.Errorf("request was not successful: %w", err)
+	} else if res.Message != "Success" {
+		return nil, fmt.Errorf("unexpected response message: %s", res.Message)
+	}
+
+	return res, nil
+}
+
+func (s *streamClient) openChannel(ctx context.Context, schema, table, name string) (*channel, error) {
+	type req struct {
+		Role      *string `json:"role,omitempty"`
+		Database  string  `json:"database"`
+		Schema    string  `json:"schema"`
+		Table     string  `json:"table"`
+		Channel   string  `json:"channel"`
+		WriteMode string  `json:"write_mode"`
+	}
+
+	res, err := post[channel](ctx, s, "/channels/open", req{
+		Role:      s.role,
+		Database:  s.database,
+		Schema:    schema,
+		Table:     table,
+		Channel:   name,
+		WriteMode: "CLOUD_STORAGE",
+	})
+	if err != nil {
+		return nil, err
+	} else if err := getErrorByCode(res.StatusCode); err != nil {
+		return nil, fmt.Errorf("request was not successful: %w", err)
+	} else if res.Message != "Success" {
+		return nil, fmt.Errorf("unexpected response message: %s", res.Message)
+	}
+
+	return res, nil
+}
+
+func (s *streamClient) write(ctx context.Context, blob *blobMetadata) error {
+	type req struct {
+		Role  *string         `json:"role,omitempty"`
+		Blobs []*blobMetadata `json:"blobs"`
+	}
+
+	res, err := post[writeResponse](ctx, s, "/channels/write/blobs", req{
+		Role: s.role,
+		Blobs: []*blobMetadata{
+			blob,
+		},
+	})
+	if err != nil {
+		return err
+	} else if err := getErrorByCode(res.StatusCode); err != nil {
+		return fmt.Errorf("request was not successful: %w", err)
+	} else if res.Message != "Success" {
+		return fmt.Errorf("unexpected response message: %s", res.Message)
+	}
+
+	for _, blob := range res.Blobs {
+		for _, chunk := range blob.Chunks {
+			for _, channel := range chunk.Channels {
+				if err := getErrorByCode(channel.StatusCode); err != nil {
+					return fmt.Errorf("failed to write chunk (schema: %s, table %s): %w", chunk.Database, chunk.Table, err)
+				}
+			}
+		}
+	}
+
+	return nil
+}
+
+func (s *streamClient) channelStatus(ctx context.Context, clientSeq int, schema, table, name string) (*channelStatusResponse, error) {
+	type channelReq struct {
+		Table           string `json:"table"`
+		Database        string `json:"database"`
+		Schema          string `json:"schema"`
+		Name            string `json:"channel_name"`
+		ClientSequencer int    `json:"client_sequencer"`
+	}
+
+	type req struct {
+		Role     *string      `json:"role,omitempty"`
+		Channels []channelReq `json:"channels"`
+	}
+
+	res, err := post[channelStatusResponse](ctx, s, "/channels/status", req{
+		Role: s.role,
+		Channels: []channelReq{
+			{
+				Table:           table,
+				Database:        s.database,
+				Schema:          schema,
+				Name:            name,
+				ClientSequencer: clientSeq,
+			},
+		},
+	})
+	if err != nil {
+		return nil, err
+	} else if err := getErrorByCode(res.StatusCode); err != nil {
+		return nil, fmt.Errorf("request was not successful: %w", err)
+	} else if res.Message != "Success" {
+		return nil, fmt.Errorf("unexpected response message: %s", res.Message)
+	}
+
+	for _, channel := range res.Channels {
+		if err := getErrorByCode(channel.StatusCode); err != nil {
+			return nil, fmt.Errorf("failed to get channel status (schema: %s, table %s): %w", schema, table, err)
+		}
+	}
+
+	return res, nil
+}
+
+func (s *streamClient) waitForTokenPersisted(ctx context.Context, token string, clientSeq int, schema, table, name string) error {
+	maxBackoff := 1 * time.Second
+	backoff := 100 * time.Millisecond
+	ts := time.Now()
+	for n := 1; ; n++ {
+		if status, err := s.channelStatus(ctx, clientSeq, schema, table, name); err != nil {
+			return err
+		} else if len(status.Channels) != 1 {
+			return fmt.Errorf("expected 1 channel but got %d", len(status.Channels))
+		} else if status.Channels[0].PersistedOffsetToken == token {
+			break
+		}
+
+		if n > 10 {
+			log.WithFields(log.Fields{
+				"attempt": n,
+				"schema":  schema,
+				"table":   table,
+				"token":   token,
+			}).Info("channel offset token not yet persisted")
+		}
+
+		time.Sleep(backoff)
+		backoff = min(backoff*2, maxBackoff)
+	}
+
+	log.WithFields(log.Fields{
+		"schema": schema,
+		"table":  table,
+		"token":  token,
+		"took":   time.Since(ts).String(),
+	}).Debug("channel offset token persisted")
+
+	return nil
+}
+
+func post[T any](ctx context.Context, c *streamClient, path string, body any) (*T, error) {
+	c.mu.Lock()
+	var token string
+	if err := func() error {
+		defer c.mu.Unlock()
+
+		if time.Until(c.expiry).Minutes() < 5 {
+			var err error
+			c.cachedToken, c.expiry, err = generateJWTToken(c.key, c.user, c.account)
+			if err != nil {
+				return err
+			}
+		}
+
+		token = c.cachedToken
+		return nil
+	}(); err != nil {
+		return nil, err
+	}
+
+	req := c.r.
+		NewRequest().
+		WithContext(ctx).
+		SetHeader("Accept", "application/json").
+		SetHeader("User-Agent", "EstuaryTechnologiesFlow/2.0.0"). // A semver >= 2.0.0 seems to be necessary for GCS to return Oauth client credentials rather than pre-signed URLs
+		SetAuthToken(token).
+		SetError(&streamingApiError{})
+
+	var res T
+	got, err := req.SetResult(&res).SetBody(body).Post(path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to POST %s: %w", path, err)
+	}
+	if !got.IsSuccess() {
+		return nil, fmt.Errorf("failed to POST %s: %s: %w", got.Request.URL, got.Status(), got.Error().(error))
+	}
+
+	return &res, nil
+}
+
+// Ref: https://github.com/snowflakedb/snowflake-ingest-java/blob/3cbaebfe26f59dc3a8b8e973649e3f1a1014438c/src/main/java/net/snowflake/ingest/streaming/internal/StreamingIngestResponseCode.java
+var streamingIngestResponseCodes = map[int]string{
+	4:  "the supplied table does not exist or is not authorized",
+	5:  "channel limit exceeded for the given table, please contact Snowflake support to raise this limit",
+	6:  "Snowpipe Streaming is not supported on the type of table resolved, or the table contains columns that are either AUTOINCREMENT or IDENTITY columns or a column with a default value",
+	7:  "the table has exceeded its limit of outstanding registration requests, please wait before calling the insertRow or insertRows API",
+	8:  "the supplied database does not exist or is not authorized",
+	9:  "the supplied schema does not exist or is not authorized",
+	10: "Snowflake experienced a transient exception, please retry the request",
+	11: "malformed request: missing blobs in request",
+	12: "malformed request: missing chunks for blob in request",
+	13: "malformed request: missing channels for chunk for blob in request",
+	14: "malformed request: missing blob path",
+	15: "malformed request: missing database in request",
+	16: "malformed request: missing schema in request",
+	17: "malformed request: missing table in request",
+	18: "malformed request: missing channel name in request",
+	19: "the requested channel no longer exists, most likely due to inactivity. Please re-open the channel",
+	20: "the channel is owned by another writer at this time. Either re-open the channel to gain exclusive write ownership or close the channel and let the other writer continue",
+	21: "the client provided an out-of-order message, please reopen the channel",
+	22: "another channel managed by this client had an issue which is preventing the current channel from ingesting data. Please re-open the channel",
+	23: "malformed request: duplicate channel in chunk",
+	24: "malformed request: missing client sequencer in request",
+	25: "the channel does not exist or is not authorized",
+	26: "the requested row sequencer is committed",
+	27: "the requested row sequencer is not committed",
+	28: "malformed request: missing chunk MD5 in request",
+	29: "malformed request: missing ep_info in request",
+	30: "malformed request: invalid chunk length",
+	31: "malformed request: invalid row count in ep_info",
+	32: "malformed request: invalid column in ep_info",
+	33: "malformed request: invalid ep_info (generic)",
+	34: "malformed request: invalid blob name",
+	36: "the channel must be reopened",
+	37: "malformed request: missing role in request",
+	38: "malformed request: blob has wrong format or extension",
+	39: "malformed request: blob missing MD5",
+	40: "a schema change occurred on the table, please re-open the channel and supply the missing data",
+	41: "duplicated blob in request",
+	42: "unsupported blob file version",
+	43: "outdated Client SDK. Please update your SDK to the latest version",
+	44: "malformed request: undefined user agent header",
+	45: "malformed request: malformed user agent header",
+	46: "interleaving among tables is not supported at this time",
+	47: "table is read-only",
+	48: "the request contains invalid column metadata, please contact Snowflake support",
+	49: "ingestion into this table is not allowed at this time, please contact Snowflake support",
+	// I'm not sure what 50...54 are, as they aren't listed in the same place. I
+	// found error code 55 by experimentation.
+	55: "Snowpipe Streaming does not support columns of type AUTOINCREMENT, IDENTITY, GEO, or columns with a default value or collation",
+}
+
+type streamingApiError struct {
+	Code    int    `json:"status_code"`
+	Message string `json:"message"`
+}
+
+func (e *streamingApiError) Error() string {
+	return fmt.Sprintf("%s (code %d)", e.Message, e.Code)
+}
+
+func getErrorByCode(code int) error {
+	if code == 0 {
+		return nil
+	}
+
+	if msg, ok := streamingIngestResponseCodes[code]; ok {
+		return &streamingApiError{Code: code, Message: msg}
+	}
+
+	return fmt.Errorf("unknown status message for code %d", code)
+}
+
+func generateBlobMetadata(
+	tracked *blobStatsTracker,
+	channel *channel,
+	token string,
+) *blobMetadata {
+	md5 := hex.EncodeToString(tracked.md5.Sum(nil))
+
+	out := blobMetadata{
+		Path:        string(tracked.fileName),
+		MD5:         md5,
+		BDECVersion: 3,
+		BlobStats: blobStats{
+			FlushStartMs:     tracked.start.UnixMilli(),
+			BuildDurationMs:  tracked.finish.Sub(tracked.start).Milliseconds(),
+			UploadDurationMs: tracked.finish.Sub(tracked.start).Milliseconds(),
+		},
+	}
+
+	chunkMeta := uploadChunkMetadata{
+		Database:                channel.Database,
+		Schema:                  channel.Schema,
+		Table:                   channel.Table,
+		ChunkStartOffset:        0,
+		ChunkLength:             tracked.length,
+		ChunkLengthUncompressed: tracked.lengthUncompressed,
+		Channels: []uploadChunkChannelMetadata{
+			{
+				Channel:         channel.Channel,
+				ClientSequencer: 0, // not checkpointed
+				RowSequencer:    0, // not checkpointed
+				OffsetToken:     token,
+			},
+		},
+		ChunkMD5: md5,
+		EPS: eps{
+			Rows:    tracked.rows,
+			Columns: make(map[string]fileColumnProperties),
+		},
+		EncryptionKeyID:         channel.EncryptionKeyId,
+		FirstInsertTimeInMillis: tracked.start.UnixMilli(),
+		LastInsertTimeInMillis:  tracked.finish.UnixMilli(),
+	}
+
+	for _, col := range tracked.columns {
+		props := fileColumnProperties{
+			ColumnOrdinal:  col.ordinal,
+			NullCount:      col.nullCount,
+			DistinctValues: -1,
+		}
+
+		if col.isInt {
+			props.MaxIntValue = json.RawMessage(col.intStats.maxVal.BigInt().String())
+			props.MinIntValue = json.RawMessage(col.intStats.minVal.BigInt().String())
+		} else if col.isNum {
+			props.MaxRealValue = marshalFloat(col.numStats.maxVal)
+			props.MinRealValue = marshalFloat(col.numStats.minVal)
+		} else if col.isStr {
+			maxHex := truncateBytesAsHex([]byte(col.strStats.maxVal), true)
+			minHex := truncateBytesAsHex([]byte(col.strStats.minVal), false)
+			props.MaxLength = col.strStats.maxLen
+			props.MaxStrValue = &maxHex
+			props.MinStrValue = &minHex
+		}
+
+		if !col.isInt {
+			props.MaxIntValue = json.RawMessage([]byte("0"))
+			props.MinIntValue = json.RawMessage([]byte("0"))
+		}
+
+		chunkMeta.EPS.Columns[col.name] = props
+	}
+
+	out.Chunks = []uploadChunkMetadata{chunkMeta}
+
+	return &out
+}
+
+// marshalFloat writes special float values to be compatible with the metadata
+// that Snowpipe expects.
+func marshalFloat(f float64) json.RawMessage {
+	if math.IsNaN(f) {
+		return json.RawMessage(`"NaN"`)
+	} else if math.IsInf(f, -1) {
+		return json.RawMessage(`"-Infinity"`)
+	} else if math.IsInf(f, 1) {
+		return json.RawMessage(`"Infinity"`)
+	}
+	b, _ := json.Marshal(f)
+
+	return b
+}

--- a/materialize-snowflake/stream_test.go
+++ b/materialize-snowflake/stream_test.go
@@ -1,0 +1,746 @@
+package main
+
+import (
+	"context"
+	stdsql "database/sql"
+	"encoding/json"
+	"fmt"
+	"math"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/bradleyjkemp/cupaloy"
+	sql "github.com/estuary/connectors/materialize-sql"
+	"github.com/stretchr/testify/require"
+)
+
+func TestChannelName(t *testing.T) {
+	require.Equal(t, "testing_4E7A62CBF3428987_00000000", channelName("testing", 0))
+	require.Equal(t, "testing_4E7A62CBF3428987_000004d2", channelName("testing", 1234))
+	require.Equal(t, "some_other_stuff__816D5E80F9E632A7_000004d2", channelName("some/other-stuff!", 1234))
+	require.Equal(t, "long_long_long_long_long_long_lo_05A28455EE5956EB_00000000", channelName(strings.Repeat("long/", 10), 0))
+	require.Equal(t, "long_long_long_long_long_long_lo_135047533004DC65_00000000", channelName(strings.Repeat("long!", 10), 0))
+}
+
+func TestStreamManager(t *testing.T) {
+	ctx := context.Background()
+
+	cfg := mustGetCfg(t)
+
+	dsn, err := cfg.toURI("estuary")
+	require.NoError(t, err)
+
+	db, err := stdsql.Open("snowflake", dsn)
+	require.NoError(t, err)
+	defer db.Close()
+
+	var accountName string
+	require.NoError(t, db.QueryRowContext(ctx, "SELECT CURRENT_ACCOUNT()").Scan(&accountName))
+
+	verify := func(t *testing.T, query string, want [][]any) {
+		t.Helper()
+
+		rows, err := db.Query(query)
+		require.NoError(t, err)
+		defer rows.Close()
+
+		cols, err := rows.Columns()
+		require.NoError(t, err)
+
+		var got [][]any
+		for rows.Next() {
+			var data = make([]any, len(cols))
+			var ptrs = make([]any, len(cols))
+			for i := range data {
+				ptrs[i] = &data[i]
+			}
+			require.NoError(t, rows.Scan(ptrs...))
+			got = append(got, data)
+		}
+
+		require.Equal(t, want, got)
+	}
+
+	t.Run("lifecycle", func(t *testing.T) {
+		table := sql.Table{
+			TableShape: sql.TableShape{
+				Binding: 0,
+			},
+			Identifier: `STREAM_TEST`,
+			Keys:       []sql.Column{{Identifier: `key`}},
+			Values:     []sql.Column{{Identifier: `firstcol`}, {Identifier: `secondcol`}},
+			Document:   nil,
+		}
+
+		cleanup := func(t *testing.T) {
+			t.Helper()
+			_, err = db.ExecContext(ctx, "DROP TABLE IF EXISTS STREAM_TEST;")
+		}
+		defer cleanup(t)
+
+		cleanup(t)
+		_, err = db.ExecContext(ctx, `CREATE TABLE STREAM_TEST (key TEXT, firstcol TEXT, secondcol TEXT);`)
+		require.NoError(t, err)
+
+		sm, err := newStreamManager(&cfg, "testing", "testing", accountName, 0)
+		require.NoError(t, err)
+
+		require.NoError(t, sm.addBinding(ctx, cfg.Schema, table))
+
+		require.NoError(t, sm.encodeRow(ctx, 0, []any{"key1", "hello1", "world1"}))
+		require.NoError(t, sm.encodeRow(ctx, 0, []any{"key2", "hello2", "world2"}))
+		require.NoError(t, sm.encodeRow(ctx, 0, []any{"key3", "hello3", "world3"}))
+		blobs, err := sm.flush("the-token-1")
+		require.NoError(t, err)
+		require.Equal(t, 1, len(blobs))
+		require.Equal(t, 1, len(blobs[0]))
+
+		require.NoError(t, sm.write(ctx, blobs[0]))
+
+		verify(t, "SELECT * FROM STREAM_TEST ORDER BY key", [][]any{
+			{"key1", "hello1", "world1"},
+			{"key2", "hello2", "world2"},
+			{"key3", "hello3", "world3"},
+		})
+
+		// Write the same token again, it is not added to the table.
+		require.NoError(t, sm.write(ctx, blobs[0]))
+
+		verify(t, "SELECT * FROM STREAM_TEST ORDER BY key", [][]any{
+			{"key1", "hello1", "world1"},
+			{"key2", "hello2", "world2"},
+			{"key3", "hello3", "world3"},
+		})
+
+		// A second invocation invalidates the first.
+		ssm, err := newStreamManager(&cfg, "testing", "testing", accountName, 0)
+		require.NoError(t, err)
+		require.NoError(t, ssm.addBinding(ctx, cfg.Schema, table))
+
+		require.NoError(t, sm.encodeRow(ctx, 0, []any{"key4", "hello4", "world4"}))
+		require.NoError(t, sm.encodeRow(ctx, 0, []any{"key5", "hello5", "world5"}))
+		require.NoError(t, sm.encodeRow(ctx, 0, []any{"key6", "hello6", "world6"}))
+		blobs, err = sm.flush("the-token-2")
+		require.NoError(t, err)
+		require.Equal(t, 1, len(blobs))
+		require.Equal(t, 1, len(blobs[0]))
+
+		// The original invocation will error and not write any data.
+		require.Error(t, sm.write(ctx, blobs[0]))
+		verify(t, "SELECT * FROM STREAM_TEST ORDER BY key", [][]any{
+			{"key1", "hello1", "world1"},
+			{"key2", "hello2", "world2"},
+			{"key3", "hello3", "world3"},
+		})
+
+		// But the second one will work.
+		require.NoError(t, sm.encodeRow(ctx, 0, []any{"key4", "hello4", "world4"}))
+		require.NoError(t, sm.encodeRow(ctx, 0, []any{"key5", "hello5", "world5"}))
+		require.NoError(t, sm.encodeRow(ctx, 0, []any{"key6", "hello6", "world6"}))
+		blobs, err = sm.flush("the-token-2")
+		require.NoError(t, err)
+		require.Equal(t, 1, len(blobs))
+		require.Equal(t, 1, len(blobs[0]))
+
+		require.NoError(t, ssm.write(ctx, blobs[0]))
+
+		verify(t, "SELECT * FROM STREAM_TEST ORDER BY key", [][]any{
+			{"key1", "hello1", "world1"},
+			{"key2", "hello2", "world2"},
+			{"key3", "hello3", "world3"},
+			{"key4", "hello4", "world4"},
+			{"key5", "hello5", "world5"},
+			{"key6", "hello6", "world6"},
+		})
+	})
+
+	t.Run("multiple blobs", func(t *testing.T) {
+		table := sql.Table{
+			TableShape: sql.TableShape{
+				Binding: 0,
+			},
+			Identifier: `STREAM_TEST`,
+			Keys:       []sql.Column{{Identifier: `key`}},
+			Values:     []sql.Column{{Identifier: `firstcol`}, {Identifier: `secondcol`}},
+			Document:   nil,
+		}
+
+		cleanup := func(t *testing.T) {
+			t.Helper()
+			_, err = db.ExecContext(ctx, "DROP TABLE IF EXISTS STREAM_TEST;")
+		}
+		defer cleanup(t)
+
+		cleanup(t)
+		_, err = db.ExecContext(ctx, `CREATE TABLE STREAM_TEST (key TEXT, firstcol TEXT, secondcol TEXT);`)
+		require.NoError(t, err)
+
+		sm, err := newStreamManager(&cfg, "testing", "testing", accountName, 0)
+		require.NoError(t, err)
+
+		require.NoError(t, sm.addBinding(ctx, cfg.Schema, table))
+
+		require.NoError(t, sm.encodeRow(ctx, 0, []any{"key1", "hello1", "world1"}))
+		require.NoError(t, sm.encodeRow(ctx, 0, []any{"key2", "hello2", "world2"}))
+		require.NoError(t, sm.encodeRow(ctx, 0, []any{"key3", "hello3", "world3"}))
+		require.NoError(t, sm.finishBlob())
+		require.NoError(t, sm.encodeRow(ctx, 0, []any{"key4", "hello4", "world4"}))
+		require.NoError(t, sm.encodeRow(ctx, 0, []any{"key5", "hello5", "world5"}))
+		require.NoError(t, sm.encodeRow(ctx, 0, []any{"key6", "hello6", "world6"}))
+		blobs, err := sm.flush("the-token-1")
+		require.NoError(t, err)
+		require.Equal(t, 1, len(blobs))
+		require.Equal(t, 2, len(blobs[0]))
+
+		require.NoError(t, sm.write(ctx, blobs[0]))
+
+		verify(t, "SELECT * FROM STREAM_TEST ORDER BY key", [][]any{
+			{"key1", "hello1", "world1"},
+			{"key2", "hello2", "world2"},
+			{"key3", "hello3", "world3"},
+			{"key4", "hello4", "world4"},
+			{"key5", "hello5", "world5"},
+			{"key6", "hello6", "world6"},
+		})
+	})
+
+	t.Run("multiple bindings and transactions", func(t *testing.T) {
+		keys := []sql.Column{{Identifier: `key`}}
+		values := []sql.Column{{Identifier: `firstcol`}, {Identifier: `secondcol`}}
+		tables := []sql.Table{
+			{
+				TableShape: sql.TableShape{Binding: 0},
+				Identifier: `STREAM_TEST_1`,
+				Keys:       keys,
+				Values:     values,
+				Document:   nil,
+			},
+			{
+				TableShape: sql.TableShape{Binding: 1},
+				Identifier: `STREAM_TEST_2`,
+				Keys:       keys,
+				Values:     values,
+				Document:   nil,
+			},
+			{
+				TableShape: sql.TableShape{Binding: 2},
+				Identifier: `STREAM_TEST_3`,
+				Keys:       keys,
+				Values:     values,
+				Document:   nil,
+			},
+		}
+
+		cleanup := func(t *testing.T) {
+			t.Helper()
+			for _, tbl := range tables {
+				_, err = db.ExecContext(ctx, "DROP TABLE IF EXISTS "+tbl.Identifier+";")
+				require.NoError(t, err)
+			}
+		}
+		defer cleanup(t)
+
+		cleanup(t)
+		for _, tbl := range tables {
+			_, err = db.ExecContext(ctx, `CREATE TABLE `+tbl.Identifier+` (key TEXT, firstcol TEXT, secondcol TEXT);`)
+			require.NoError(t, err)
+		}
+
+		sm, err := newStreamManager(&cfg, "testing", "testing", accountName, 0)
+		require.NoError(t, err)
+
+		for _, tbl := range tables {
+			require.NoError(t, sm.addBinding(ctx, cfg.Schema, tbl))
+		}
+
+		require.NoError(t, sm.encodeRow(ctx, 0, []any{"key1", "hello1", "world1"}))
+		require.NoError(t, sm.encodeRow(ctx, 0, []any{"key2", "hello2", "world2"}))
+		require.NoError(t, sm.encodeRow(ctx, 0, []any{"key3", "hello3", "world3"}))
+		blobs, err := sm.flush("the-token-1")
+		require.NoError(t, err)
+		require.Equal(t, 1, len(blobs))
+		require.Equal(t, 1, len(blobs[0]))
+		require.NoError(t, sm.write(ctx, blobs[0]))
+
+		require.NoError(t, sm.encodeRow(ctx, 0, []any{"key4", "hello4", "world4"}))
+		require.NoError(t, sm.encodeRow(ctx, 0, []any{"key5", "hello5", "world5"}))
+		require.NoError(t, sm.encodeRow(ctx, 0, []any{"key6", "hello6", "world6"}))
+		require.NoError(t, sm.encodeRow(ctx, 1, []any{"key4", "hello4", "world4"}))
+		require.NoError(t, sm.encodeRow(ctx, 1, []any{"key5", "hello5", "world5"}))
+		require.NoError(t, sm.encodeRow(ctx, 1, []any{"key6", "hello6", "world6"}))
+		require.NoError(t, sm.encodeRow(ctx, 2, []any{"key4", "hello4", "world4"}))
+		require.NoError(t, sm.encodeRow(ctx, 2, []any{"key5", "hello5", "world5"}))
+		require.NoError(t, sm.encodeRow(ctx, 2, []any{"key6", "hello6", "world6"}))
+		blobs, err = sm.flush("the-token-2")
+		require.NoError(t, err)
+		require.Equal(t, 3, len(blobs))
+		for _, blob := range blobs {
+			require.Equal(t, 1, len(blob))
+			require.NoError(t, sm.write(ctx, blob))
+		}
+
+		// Noop commit.
+		blobs, err = sm.flush("the-token-3")
+		require.NoError(t, err)
+		require.Equal(t, 0, len(blobs))
+
+		require.NoError(t, sm.encodeRow(ctx, 0, []any{"key7", "hello7", "world7"}))
+		require.NoError(t, sm.encodeRow(ctx, 0, []any{"key8", "hello8", "world8"}))
+		require.NoError(t, sm.encodeRow(ctx, 0, []any{"key9", "hello9", "world9"}))
+		require.NoError(t, sm.encodeRow(ctx, 2, []any{"key7", "hello7", "world7"}))
+		require.NoError(t, sm.encodeRow(ctx, 2, []any{"key8", "hello8", "world8"}))
+		require.NoError(t, sm.encodeRow(ctx, 2, []any{"key9", "hello9", "world9"}))
+		blobs, err = sm.flush("the-token-3")
+		require.NoError(t, err)
+		require.Equal(t, 2, len(blobs))
+		for _, blob := range blobs {
+			require.Equal(t, 1, len(blob))
+			require.NoError(t, sm.write(ctx, blob))
+		}
+
+		verify(t, "SELECT * FROM "+tables[0].Identifier+" ORDER BY key", [][]any{
+			{"key1", "hello1", "world1"},
+			{"key2", "hello2", "world2"},
+			{"key3", "hello3", "world3"},
+			{"key4", "hello4", "world4"},
+			{"key5", "hello5", "world5"},
+			{"key6", "hello6", "world6"},
+			{"key7", "hello7", "world7"},
+			{"key8", "hello8", "world8"},
+			{"key9", "hello9", "world9"},
+		})
+
+		verify(t, "SELECT * FROM "+tables[1].Identifier+" ORDER BY key", [][]any{
+			{"key4", "hello4", "world4"},
+			{"key5", "hello5", "world5"},
+			{"key6", "hello6", "world6"},
+		})
+
+		verify(t, "SELECT * FROM "+tables[2].Identifier+" ORDER BY key", [][]any{
+			{"key4", "hello4", "world4"},
+			{"key5", "hello5", "world5"},
+			{"key6", "hello6", "world6"},
+			{"key7", "hello7", "world7"},
+			{"key8", "hello8", "world8"},
+			{"key9", "hello9", "world9"},
+		})
+	})
+
+	t.Run("non-selected columns and quoted columns", func(t *testing.T) {
+		keys := []sql.Column{{Identifier: `key`}}
+		values := []sql.Column{
+			{Identifier: `" Column WiTh ""quotes"" and ""\""spaces"""" ,;{}().-� 𐀀 嶲 "`},
+			{Identifier: `"1234startsWithNumbers"`},
+			{Identifier: `"$dollar$signs.here#andotherstuff"`},
+		}
+		tbl := sql.Table{
+			TableShape: sql.TableShape{Binding: 0},
+			Identifier: `STREAM_TEST_QUOTED_COLUMNS`,
+			Keys:       keys,
+			Values:     values,
+			Document:   nil,
+		}
+
+		cleanup := func(t *testing.T) {
+			t.Helper()
+			_, err = db.ExecContext(ctx, "DROP TABLE IF EXISTS "+tbl.Identifier+";")
+			require.NoError(t, err)
+		}
+		defer cleanup(t)
+
+		cleanup(t)
+
+		createQuery := `
+		CREATE TABLE STREAM_TEST_QUOTED_COLUMNS(
+			someothercolumn TEXT,
+			key TEXT NOT NULL,
+			" Column WiTh ""quotes"" and ""\""spaces"""" ,;{}().-� 𐀀 嶲 " TEXT NOT NULL,
+			yetanothercolumn TEXT,
+			"1234startsWithNumbers" TEXT NOT NULL,
+			"$dollar$signs.here#andotherstuff" TEXT NOT NULL,
+			"finalColumn" TEXT
+		);
+		`
+
+		_, err = db.ExecContext(ctx, createQuery)
+		require.NoError(t, err)
+
+		sm, err := newStreamManager(&cfg, "testing", "testing", accountName, 0)
+		require.NoError(t, err)
+		require.NoError(t, sm.addBinding(ctx, cfg.Schema, tbl))
+
+		require.NoError(t, sm.encodeRow(ctx, 0, []any{"key1", "hello1", "goodbye1", "aloha1"}))
+		require.NoError(t, sm.encodeRow(ctx, 0, []any{"key2", "hello2", "goodbye2", "aloha2"}))
+		require.NoError(t, sm.encodeRow(ctx, 0, []any{"key3", "hello3", "goodbye3", "aloha3"}))
+		blobs, err := sm.flush("token")
+		require.NoError(t, err)
+		require.Equal(t, 1, len(blobs))
+		require.Equal(t, 1, len(blobs[0]))
+		require.NoError(t, sm.write(ctx, blobs[0]))
+
+		verify(t, "SELECT * FROM "+tbl.Identifier+" ORDER BY key", [][]any{
+			{nil, "key1", "hello1", nil, "goodbye1", "aloha1", nil},
+			{nil, "key2", "hello2", nil, "goodbye2", "aloha2", nil},
+			{nil, "key3", "hello3", nil, "goodbye3", "aloha3", nil},
+		})
+	})
+}
+
+func TestStreamDatatypes(t *testing.T) {
+	ctx := context.Background()
+
+	cfg := mustGetCfg(t)
+
+	dsn, err := cfg.toURI("estuary")
+	require.NoError(t, err)
+
+	db, err := stdsql.Open("snowflake", dsn)
+	require.NoError(t, err)
+	defer db.Close()
+
+	var accountName string
+	require.NoError(t, db.QueryRowContext(ctx, "SELECT CURRENT_ACCOUNT()").Scan(&accountName))
+
+	var templates = renderTemplates(testDialect)
+
+	testTableBaseName := "STREAM_TEST_DATATYPES"
+
+	timestamps := []any{
+		"2022-08-17T04:32:19.987654321Z",
+		"2022-08-17T04:32:19.987654321+02:00",
+		"2022-08-17T04:32:19.987654321+03:30",
+		"2022-08-17T04:32:19.987654321-07:00",
+		"0000-01-01T00:00:00.000000000Z",
+		"0000-01-01T00:00:00.000000000+23:59",
+		"0000-01-01T00:00:00.000000000-23:59",
+		"9999-12-31T23:59:59.999999999Z",
+		"9999-12-31T23:59:59.999999999+23:59",
+		"9999-12-31T23:59:59.999999999-23:59",
+		nil,
+	}
+
+	for _, tt := range []struct {
+		ddl  string
+		vals []any
+	}{
+		{
+			ddl:  "INTEGER",
+			vals: []any{-1, 0, 1, 1234, math.MaxInt64, nil, math.MinInt64, float64(math.MaxUint64) * 10_000, minSnowflakeInteger.BigInt(), maxSnowflakeInteger.BigInt(), uint64(math.MaxUint64)},
+		},
+		{
+			ddl:  "TEXT",
+			vals: []any{"hello", "", nil, 1234, true, uint64(4321), 1234.1234, []byte("[1,2,3]"), json.RawMessage([]byte(`{"some":"doc"}`))},
+		},
+		{
+			ddl:  "VARIANT",
+			vals: []any{`"hello"`, `""`, nil, 1234, true, uint64(4321), 1234.1234, []byte("[1,2,3]"), json.RawMessage([]byte(`{"some":"doc"}`))},
+		},
+		{
+			ddl:  "BOOLEAN",
+			vals: []any{true, false, nil},
+		},
+		{
+			ddl:  "FLOAT",
+			vals: []any{int64(1234), nil, 1234.0, 4321.1234, math.MaxFloat64, math.SmallestNonzeroFloat64, "NaN", "inf", "-inf"},
+		},
+		{
+			ddl:  "DATE",
+			vals: []any{"2022-03-21", nil, "0000-01-01", "9999-12-31"},
+		},
+		{
+			ddl:  "TIMESTAMP_LTZ",
+			vals: timestamps,
+		},
+		{
+			ddl:  "TIMESTAMP_TZ",
+			vals: timestamps,
+		},
+		{
+			ddl:  "TIMESTAMP_NTZ",
+			vals: timestamps,
+		},
+	} {
+		t.Run(tt.ddl, func(t *testing.T) {
+			tbl := sql.Table{
+				TableShape: sql.TableShape{Binding: 0, DeltaUpdates: true},
+				Identifier: testTableBaseName + "_" + tt.ddl,
+				Keys:       []sql.Column{{Identifier: `key`, MappedType: sql.MappedType{DDL: "INTEGER"}}},
+				Values:     []sql.Column{{Identifier: `val`, MappedType: sql.MappedType{DDL: tt.ddl}}},
+				Document:   nil,
+			}
+			cleanup := func(t *testing.T) {
+				t.Helper()
+				_, err = db.ExecContext(ctx, fmt.Sprintf("DROP TABLE IF EXISTS %s;", tbl.Identifier))
+			}
+			defer cleanup(t)
+
+			cleanup(t)
+
+			var createQuery strings.Builder
+			require.NoError(t, templates.createTargetTable.Execute(&createQuery, &tbl))
+
+			_, err = db.ExecContext(ctx, createQuery.String())
+			require.NoError(t, err)
+
+			sm, err := newStreamManager(&cfg, "testing", "testing", accountName, 0)
+			require.NoError(t, err)
+
+			require.NoError(t, sm.addBinding(ctx, cfg.Schema, tbl))
+
+			for i, val := range tt.vals {
+				require.NoError(t, sm.encodeRow(ctx, 0, []any{i, val}))
+			}
+
+			blobs, err := sm.flush("token")
+			require.NoError(t, err)
+			require.Equal(t, 1, len(blobs))
+			require.Equal(t, 1, len(blobs[0]))
+			require.NoError(t, sm.write(ctx, blobs[0]))
+
+			var snap strings.Builder
+			eps, err := json.Marshal(blobs[0][0].Chunks[0].EPS)
+			require.NoError(t, err)
+			snap.WriteString("--- Column Statistics ---\n")
+			snap.Write(eps)
+
+			got, err := sql.StdDumpTable(ctx, db, tbl)
+			require.NoError(t, err)
+			snap.WriteString("\n\n--- Column Values ---\n")
+			snap.WriteString(got)
+
+			cupaloy.SnapshotT(t, snap.String())
+		})
+	}
+}
+
+func TestGetNextFileName(t *testing.T) {
+	calendar, err := time.Parse(time.RFC3339Nano, "2025-04-03T13:40:36.434227277Z")
+	require.NoError(t, err)
+
+	clientPrefix := "asdfasdf_1234"
+
+	sm := &streamManager{keyBegin: 5678}
+
+	for idx := range 5 {
+		require.Equal(t,
+			fmt.Sprintf("2025/4/3/13/40/su59zo_asdfasdf_1234_5678_%d.bdec", idx),
+			string(sm.getNextFileName(calendar, clientPrefix)),
+		)
+	}
+}
+
+func TestShouldWriteNextToken(t *testing.T) {
+	strPtr := func(s string) *string { return &s }
+
+	for _, tt := range []struct {
+		name         string
+		blobToken    string
+		currentToken *string
+		want         bool
+		wantErr      bool
+	}{
+		{
+			name:         "no current token",
+			blobToken:    "the-token-1:0",
+			currentToken: nil,
+			want:         true,
+			wantErr:      false,
+		},
+		{
+			name:         "same token",
+			blobToken:    "the-token-1:0",
+			currentToken: strPtr("the-token-1:0"),
+			want:         false,
+			wantErr:      false,
+		},
+		{
+			name:         "next in sequence",
+			blobToken:    "the-token-1:2",
+			currentToken: strPtr("the-token-1:1"),
+			want:         true,
+			wantErr:      false,
+		},
+		{
+			name:         "prior in sequence",
+			blobToken:    "the-token-1:1",
+			currentToken: strPtr("the-token-1:2"),
+			want:         false,
+			wantErr:      false,
+		},
+		{
+			name:         "start new token sequence",
+			blobToken:    "the-token-2:0",
+			currentToken: strPtr("the-token-1:2"),
+			want:         true,
+			wantErr:      false,
+		},
+		{
+			name:         "wrong token",
+			blobToken:    "the-token-2:1",
+			currentToken: strPtr("the-token-1:2"),
+			want:         false,
+			wantErr:      true,
+		},
+		{
+			name:         "malformed current",
+			blobToken:    "the-token-2:1",
+			currentToken: strPtr("wrong:asdf"),
+			want:         false,
+			wantErr:      true,
+		},
+		{
+			name:         "malformed blob",
+			blobToken:    "wrong",
+			currentToken: strPtr("the-token-1:2"),
+			want:         false,
+			wantErr:      true,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := shouldWriteNextToken(tt.blobToken, tt.currentToken)
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestValidWriteBlobs(t *testing.T) {
+	makeChunkMeta := func(db, sch, tbl, ch, tok string) uploadChunkMetadata {
+		return uploadChunkMetadata{
+			Database: db,
+			Schema:   sch,
+			Table:    tbl,
+			Channels: []uploadChunkChannelMetadata{{Channel: ch, OffsetToken: tok}},
+		}
+	}
+
+	db := "db"
+	sch := "sch"
+	tbl := "tbl"
+	ch := "ch"
+
+	for _, tt := range []struct {
+		name  string
+		blobs []*blobMetadata
+		valid bool
+	}{
+		{
+			name: "single blob",
+			blobs: []*blobMetadata{
+				{Chunks: []uploadChunkMetadata{makeChunkMeta(db, sch, tbl, ch, "token:1")}},
+			},
+			valid: true,
+		},
+		{
+			name: "multi blob",
+			blobs: []*blobMetadata{
+				{Chunks: []uploadChunkMetadata{makeChunkMeta(db, sch, tbl, ch, "token:1")}},
+				{Chunks: []uploadChunkMetadata{makeChunkMeta(db, sch, tbl, ch, "token:2")}},
+				{Chunks: []uploadChunkMetadata{makeChunkMeta(db, sch, tbl, ch, "token:3")}},
+			},
+			valid: true,
+		},
+		{
+			name: "wrong base token",
+			blobs: []*blobMetadata{
+				{Chunks: []uploadChunkMetadata{makeChunkMeta(db, sch, tbl, ch, "token:1")}},
+				{Chunks: []uploadChunkMetadata{makeChunkMeta(db, sch, tbl, ch, "other:2")}},
+				{Chunks: []uploadChunkMetadata{makeChunkMeta(db, sch, tbl, ch, "token:3")}},
+			},
+			valid: false,
+		},
+		{
+			name: "out of order",
+			blobs: []*blobMetadata{
+				{Chunks: []uploadChunkMetadata{makeChunkMeta(db, sch, tbl, ch, "token:1")}},
+				{Chunks: []uploadChunkMetadata{makeChunkMeta(db, sch, tbl, ch, "token:3")}},
+				{Chunks: []uploadChunkMetadata{makeChunkMeta(db, sch, tbl, ch, "token:2")}},
+			},
+			valid: false,
+		},
+		{
+			name: "more than one chunk in a single blob",
+			blobs: []*blobMetadata{
+				{Chunks: []uploadChunkMetadata{
+					makeChunkMeta(db, sch, tbl, ch, "token:1"),
+					makeChunkMeta(db, sch, tbl, ch, "token:2"),
+				}},
+			},
+			valid: false,
+		},
+		{
+			name: "more than one channel in a single chunk",
+			blobs: []*blobMetadata{
+				{Chunks: []uploadChunkMetadata{
+					{
+						Database: db,
+						Schema:   sch,
+						Table:    tbl,
+						Channels: []uploadChunkChannelMetadata{
+							{Channel: ch, OffsetToken: "token:1"},
+							{Channel: ch, OffsetToken: "token:2"},
+						},
+					},
+				}},
+			},
+			valid: false,
+		},
+		{
+			name: "different databases",
+			blobs: []*blobMetadata{
+				{Chunks: []uploadChunkMetadata{makeChunkMeta(db, sch, tbl, ch, "token:1")}},
+				{Chunks: []uploadChunkMetadata{makeChunkMeta(db+"other", sch, tbl, ch, "token:2")}},
+				{Chunks: []uploadChunkMetadata{makeChunkMeta(db, sch, tbl, ch, "token:3")}},
+			},
+			valid: false,
+		},
+		{
+			name: "different schemas",
+			blobs: []*blobMetadata{
+				{Chunks: []uploadChunkMetadata{makeChunkMeta(db, sch, tbl, ch, "token:1")}},
+				{Chunks: []uploadChunkMetadata{makeChunkMeta(db, sch+"other", tbl, ch, "token:2")}},
+				{Chunks: []uploadChunkMetadata{makeChunkMeta(db, sch, tbl, ch, "token:3")}},
+			},
+			valid: false,
+		},
+		{
+			name: "different tables",
+			blobs: []*blobMetadata{
+				{Chunks: []uploadChunkMetadata{makeChunkMeta(db, sch, tbl, ch, "token:1")}},
+				{Chunks: []uploadChunkMetadata{makeChunkMeta(db, sch, tbl, ch, "token:2")}},
+				{Chunks: []uploadChunkMetadata{makeChunkMeta(db, sch, tbl+"other", ch, "token:3")}},
+			},
+			valid: false,
+		},
+		{
+			name: "different channels",
+			blobs: []*blobMetadata{
+				{Chunks: []uploadChunkMetadata{makeChunkMeta(db, sch, tbl, ch+"other", "token:1")}},
+				{Chunks: []uploadChunkMetadata{makeChunkMeta(db, sch, tbl, ch, "token:2")}},
+				{Chunks: []uploadChunkMetadata{makeChunkMeta(db, sch, tbl, ch, "token:3")}},
+			},
+			valid: false,
+		},
+		{
+			name: "malformed token",
+			blobs: []*blobMetadata{
+				{Chunks: []uploadChunkMetadata{{Channels: []uploadChunkChannelMetadata{{OffsetToken: "asdf"}}}}},
+			},
+			valid: false,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validWriteBlobs(tt.blobs)
+			if tt.valid {
+				require.NoError(t, err)
+			} else {
+				require.Error(t, err)
+			}
+		})
+	}
+}

--- a/materialize-sql/std_sql.go
+++ b/materialize-sql/std_sql.go
@@ -7,8 +7,8 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"math/big"
 	"slices"
-	"strconv"
 	"strings"
 	"time"
 
@@ -239,7 +239,7 @@ func (col *anyColumn) Scan(i interface{}) error {
 		// database or local timezone.
 		sval = ii.UTC().Format(time.RFC3339Nano)
 	case string:
-		if _, err := strconv.Atoi(ii); err == nil {
+		if _, ok := new(big.Int).SetString(ii, 10); ok {
 			// Snowflake integer value columns scan into an interface{} with a concrete type of
 			// string.
 			sval = fmt.Sprint(i)

--- a/tests/materialize/materialize-snowflake/snapshot.json
+++ b/tests/materialize/materialize-snowflake/snapshot.json
@@ -17,6 +17,7 @@
         "Table": "deletions",
         "Query": "\nCOPY INTO deletions (\n\tid, \"_meta/op\", flow_published_at, flow_document\n) FROM (\n\tSELECT $1[0] AS id, $1[1] AS \"_meta/op\", $1[2] AS flow_published_at, $1[3] AS flow_document\n\tFROM <uuid>\n);\n",
         "StagedDir": "<uuid>",
+        "StreamBlobs": null,
         "PipeName": "",
         "PipeFiles": null,
         "Version": ""
@@ -25,6 +26,7 @@
         "Table": "\"duplicate keys @ with spaces\"",
         "Query": "",
         "StagedDir": "<uuid>",
+        "StreamBlobs": null,
         "PipeName": "ESTUARY_DB.ESTUARY_SCHEMA.FLOW_PIPE_4_00000000_FFFFFFFFFFFFFFFF_DUPLICATE_KEYS___WITH_SPACES_69560B841F9AAA81",
         "PipeFiles": [
           {
@@ -38,6 +40,7 @@
         "Table": "duplicate_keys_delta",
         "Query": "",
         "StagedDir": "<uuid>",
+        "StreamBlobs": null,
         "PipeName": "ESTUARY_DB.ESTUARY_SCHEMA.FLOW_PIPE_2_00000000_FFFFFFFFFFFFFFFF_DUPLICATE_KEYS_DELTA_004B23684AF8F596",
         "PipeFiles": [
           {
@@ -51,6 +54,7 @@
         "Table": "duplicate_keys_delta_exclude_flow_doc",
         "Query": "",
         "StagedDir": "<uuid>",
+        "StreamBlobs": null,
         "PipeName": "ESTUARY_DB.ESTUARY_SCHEMA.FLOW_PIPE_3_00000000_FFFFFFFFFFFFFFFF_DUPLICATE_KEYS_DELTA_EXCLUDE_FLO_355992F22E69242D",
         "PipeFiles": [
           {
@@ -64,6 +68,7 @@
         "Table": "duplicate_keys_standard",
         "Query": "\nCOPY INTO duplicate_keys_standard (\n\tid, flow_published_at, int, str, flow_document\n) FROM (\n\tSELECT $1[0] AS id, $1[1] AS flow_published_at, $1[2] AS int, $1[3] AS str, $1[4] AS flow_document\n\tFROM <uuid>\n);\n",
         "StagedDir": "<uuid>",
+        "StreamBlobs": null,
         "PipeName": "",
         "PipeFiles": null,
         "Version": ""
@@ -72,6 +77,7 @@
         "Table": "formatted_strings",
         "Query": "\nCOPY INTO formatted_strings (\n\tid, date, datetime, flow_published_at, int_and_str, int_str, num_and_str, num_str, time, flow_document\n) FROM (\n\tSELECT $1[0] AS id, $1[1] AS date, $1[2] AS datetime, $1[3] AS flow_published_at, $1[4] AS int_and_str, $1[5] AS int_str, $1[6] AS num_and_str, $1[7] AS num_str, $1[8] AS time, $1[9] AS flow_document\n\tFROM <uuid>\n);\n",
         "StagedDir": "<uuid>",
+        "StreamBlobs": null,
         "PipeName": "",
         "PipeFiles": null,
         "Version": ""
@@ -80,6 +86,7 @@
         "Table": "multiple_types",
         "Query": "\nCOPY INTO multiple_types (\n\tid, array_int, binary_field, bool_field, float_field, flow_published_at, multiple, nested, nullable_int, str_field, flow_document\n) FROM (\n\tSELECT $1[0] AS id, NULLIF($1[1], PARSE_JSON('null')) AS array_int, $1[2] AS binary_field, $1[3] AS bool_field, $1[4] AS float_field, $1[5] AS flow_published_at, NULLIF($1[6], PARSE_JSON('null')) AS multiple, NULLIF($1[7], PARSE_JSON('null')) AS nested, $1[8] AS nullable_int, $1[9] AS str_field, $1[10] AS flow_document\n\tFROM <uuid>\n);\n",
         "StagedDir": "<uuid>",
+        "StreamBlobs": null,
         "PipeName": "",
         "PipeFiles": null,
         "Version": ""
@@ -88,6 +95,7 @@
         "Table": "simple",
         "Query": "\nCOPY INTO simple (\n\tid, canary, flow_published_at, flow_document\n) FROM (\n\tSELECT $1[0] AS id, $1[1] AS canary, $1[2] AS flow_published_at, $1[3] AS flow_document\n\tFROM <uuid>\n);\n",
         "StagedDir": "<uuid>",
+        "StreamBlobs": null,
         "PipeName": "",
         "PipeFiles": null,
         "Version": ""
@@ -96,6 +104,7 @@
         "Table": "string_escaped_key",
         "Query": "\nCOPY INTO string_escaped_key (\n\tid, counter, flow_published_at, flow_document\n) FROM (\n\tSELECT $1[0] AS id, $1[1] AS counter, $1[2] AS flow_published_at, $1[3] AS flow_document\n\tFROM <uuid>\n);\n",
         "StagedDir": "<uuid>",
+        "StreamBlobs": null,
         "PipeName": "",
         "PipeFiles": null,
         "Version": ""
@@ -104,6 +113,7 @@
         "Table": "symbols",
         "Query": "\nCOPY INTO symbols (\n\t\"testing (%s)\", flow_published_at, id, flow_document\n) FROM (\n\tSELECT $1[0] AS \"testing (%s)\", $1[1] AS flow_published_at, $1[2] AS id, $1[3] AS flow_document\n\tFROM <uuid>\n);\n",
         "StagedDir": "<uuid>",
+        "StreamBlobs": null,
         "PipeName": "",
         "PipeFiles": null,
         "Version": ""
@@ -112,6 +122,7 @@
         "Table": "unsigned_bigint",
         "Query": "\nCOPY INTO unsigned_bigint (\n\tid, flow_published_at, unsigned_bigint, flow_document\n) FROM (\n\tSELECT $1[0] AS id, $1[1] AS flow_published_at, $1[2] AS unsigned_bigint, $1[3] AS flow_document\n\tFROM <uuid>\n);\n",
         "StagedDir": "<uuid>",
+        "StreamBlobs": null,
         "PipeName": "",
         "PipeFiles": null,
         "Version": ""
@@ -128,6 +139,7 @@
         "Table": "deletions",
         "Query": "\nMERGE INTO deletions AS l\nUSING (\n\tSELECT $1[0] AS id, $1[1] AS \"_meta/op\", $1[2] AS flow_published_at, $1[3] AS flow_document\n\tFROM <uuid>\n) AS r\nON \n\tl.id = r.id AND l.id >= 1 AND l.id <= 3\nWHEN MATCHED AND r.flow_document='delete' THEN\n\tDELETE\nWHEN MATCHED THEN\n\tUPDATE SET l.\"_meta/op\" = r.\"_meta/op\", l.flow_published_at = r.flow_published_at, l.flow_document = r.flow_document\nWHEN NOT MATCHED and r.flow_document!='delete' THEN\n\tINSERT (id, \"_meta/op\", flow_published_at, flow_document)\n\tVALUES (r.id, r.\"_meta/op\", r.flow_published_at, r.flow_document);\n",
         "StagedDir": "<uuid>",
+        "StreamBlobs": null,
         "PipeName": "",
         "PipeFiles": null,
         "Version": "ffffffffffffffff"
@@ -136,6 +148,7 @@
         "Table": "\"duplicate keys @ with spaces\"",
         "Query": "",
         "StagedDir": "<uuid>",
+        "StreamBlobs": null,
         "PipeName": "ESTUARY_DB.ESTUARY_SCHEMA.FLOW_PIPE_4_00000000_FFFFFFFFFFFFFFFF_DUPLICATE_KEYS___WITH_SPACES_69560B841F9AAA81",
         "PipeFiles": [
           {
@@ -149,6 +162,7 @@
         "Table": "duplicate_keys_delta",
         "Query": "",
         "StagedDir": "<uuid>",
+        "StreamBlobs": null,
         "PipeName": "ESTUARY_DB.ESTUARY_SCHEMA.FLOW_PIPE_2_00000000_FFFFFFFFFFFFFFFF_DUPLICATE_KEYS_DELTA_004B23684AF8F596",
         "PipeFiles": [
           {
@@ -162,6 +176,7 @@
         "Table": "duplicate_keys_delta_exclude_flow_doc",
         "Query": "",
         "StagedDir": "<uuid>",
+        "StreamBlobs": null,
         "PipeName": "ESTUARY_DB.ESTUARY_SCHEMA.FLOW_PIPE_3_00000000_FFFFFFFFFFFFFFFF_DUPLICATE_KEYS_DELTA_EXCLUDE_FLO_355992F22E69242D",
         "PipeFiles": [
           {
@@ -175,6 +190,7 @@
         "Table": "duplicate_keys_standard",
         "Query": "\nMERGE INTO duplicate_keys_standard AS l\nUSING (\n\tSELECT $1[0] AS id, $1[1] AS flow_published_at, $1[2] AS int, $1[3] AS str, $1[4] AS flow_document\n\tFROM <uuid>\n) AS r\nON \n\tl.id = r.id AND l.id >= 1 AND l.id <= 5\nWHEN MATCHED AND r.flow_document='delete' THEN\n\tDELETE\nWHEN MATCHED THEN\n\tUPDATE SET l.flow_published_at = r.flow_published_at, l.int = r.int, l.str = r.str, l.flow_document = r.flow_document\nWHEN NOT MATCHED and r.flow_document!='delete' THEN\n\tINSERT (id, flow_published_at, int, str, flow_document)\n\tVALUES (r.id, r.flow_published_at, r.int, r.str, r.flow_document);\n",
         "StagedDir": "<uuid>",
+        "StreamBlobs": null,
         "PipeName": "",
         "PipeFiles": null,
         "Version": "ffffffffffffffff"
@@ -183,6 +199,7 @@
         "Table": "formatted_strings",
         "Query": "\nCOPY INTO formatted_strings (\n\tid, date, datetime, flow_published_at, int_and_str, int_str, num_and_str, num_str, time, flow_document\n) FROM (\n\tSELECT $1[0] AS id, $1[1] AS date, $1[2] AS datetime, $1[3] AS flow_published_at, $1[4] AS int_and_str, $1[5] AS int_str, $1[6] AS num_and_str, $1[7] AS num_str, $1[8] AS time, $1[9] AS flow_document\n\tFROM <uuid>\n);\n",
         "StagedDir": "<uuid>",
+        "StreamBlobs": null,
         "PipeName": "",
         "PipeFiles": null,
         "Version": ""
@@ -191,6 +208,7 @@
         "Table": "multiple_types",
         "Query": "\nMERGE INTO multiple_types AS l\nUSING (\n\tSELECT $1[0] AS id, NULLIF($1[1], PARSE_JSON('null')) AS array_int, $1[2] AS binary_field, $1[3] AS bool_field, $1[4] AS float_field, $1[5] AS flow_published_at, NULLIF($1[6], PARSE_JSON('null')) AS multiple, NULLIF($1[7], PARSE_JSON('null')) AS nested, $1[8] AS nullable_int, $1[9] AS str_field, $1[10] AS flow_document\n\tFROM <uuid>\n) AS r\nON \n\tl.id = r.id AND l.id >= 1 AND l.id <= 10\nWHEN MATCHED AND r.flow_document='delete' THEN\n\tDELETE\nWHEN MATCHED THEN\n\tUPDATE SET l.array_int = r.array_int, l.binary_field = r.binary_field, l.bool_field = r.bool_field, l.float_field = r.float_field, l.flow_published_at = r.flow_published_at, l.multiple = r.multiple, l.nested = r.nested, l.nullable_int = r.nullable_int, l.str_field = r.str_field, l.flow_document = r.flow_document\nWHEN NOT MATCHED and r.flow_document!='delete' THEN\n\tINSERT (id, array_int, binary_field, bool_field, float_field, flow_published_at, multiple, nested, nullable_int, str_field, flow_document)\n\tVALUES (r.id, r.array_int, r.binary_field, r.bool_field, r.float_field, r.flow_published_at, r.multiple, r.nested, r.nullable_int, r.str_field, r.flow_document);\n",
         "StagedDir": "<uuid>",
+        "StreamBlobs": null,
         "PipeName": "",
         "PipeFiles": null,
         "Version": "ffffffffffffffff"
@@ -199,6 +217,7 @@
         "Table": "simple",
         "Query": "\nCOPY INTO simple (\n\tid, canary, flow_published_at, flow_document\n) FROM (\n\tSELECT $1[0] AS id, $1[1] AS canary, $1[2] AS flow_published_at, $1[3] AS flow_document\n\tFROM <uuid>\n);\n",
         "StagedDir": "<uuid>",
+        "StreamBlobs": null,
         "PipeName": "",
         "PipeFiles": null,
         "Version": ""
@@ -207,6 +226,7 @@
         "Table": "string_escaped_key",
         "Query": "\nMERGE INTO string_escaped_key AS l\nUSING (\n\tSELECT $1[0] AS id, $1[1] AS counter, $1[2] AS flow_published_at, $1[3] AS flow_document\n\tFROM <uuid>\n) AS r\nON \n\tl.id = r.id AND l.id >= '\\\\he \\\\ '' \" `llo`' AND l.id <= '\\\\he \\\\ '' \" `llo`'\nWHEN MATCHED AND r.flow_document='delete' THEN\n\tDELETE\nWHEN MATCHED THEN\n\tUPDATE SET l.counter = r.counter, l.flow_published_at = r.flow_published_at, l.flow_document = r.flow_document\nWHEN NOT MATCHED and r.flow_document!='delete' THEN\n\tINSERT (id, counter, flow_published_at, flow_document)\n\tVALUES (r.id, r.counter, r.flow_published_at, r.flow_document);\n",
         "StagedDir": "<uuid>",
+        "StreamBlobs": null,
         "PipeName": "",
         "PipeFiles": null,
         "Version": "ffffffffffffffff"
@@ -223,6 +243,7 @@
         "Table": "\"duplicate keys @ with spaces\"",
         "Query": "",
         "StagedDir": "<uuid>",
+        "StreamBlobs": null,
         "PipeName": "ESTUARY_DB.ESTUARY_SCHEMA.FLOW_PIPE_4_00000000_FFFFFFFFFFFFFFFF_DUPLICATE_KEYS___WITH_SPACES_69560B841F9AAA81",
         "PipeFiles": [
           {
@@ -236,6 +257,7 @@
         "Table": "duplicate_keys_delta",
         "Query": "",
         "StagedDir": "<uuid>",
+        "StreamBlobs": null,
         "PipeName": "ESTUARY_DB.ESTUARY_SCHEMA.FLOW_PIPE_2_00000000_FFFFFFFFFFFFFFFF_DUPLICATE_KEYS_DELTA_004B23684AF8F596",
         "PipeFiles": [
           {
@@ -249,6 +271,7 @@
         "Table": "duplicate_keys_delta_exclude_flow_doc",
         "Query": "",
         "StagedDir": "<uuid>",
+        "StreamBlobs": null,
         "PipeName": "ESTUARY_DB.ESTUARY_SCHEMA.FLOW_PIPE_3_00000000_FFFFFFFFFFFFFFFF_DUPLICATE_KEYS_DELTA_EXCLUDE_FLO_355992F22E69242D",
         "PipeFiles": [
           {
@@ -262,6 +285,7 @@
         "Table": "duplicate_keys_standard",
         "Query": "\nCOPY INTO duplicate_keys_standard (\n\tid, flow_published_at, int, str, flow_document\n) FROM (\n\tSELECT $1[0] AS id, $1[1] AS flow_published_at, $1[2] AS int, $1[3] AS str, $1[4] AS flow_document\n\tFROM <uuid>\n);\n",
         "StagedDir": "<uuid>",
+        "StreamBlobs": null,
         "PipeName": "",
         "PipeFiles": null,
         "Version": ""

--- a/tests/materialize/materialize-snowflake/snapshot.json
+++ b/tests/materialize/materialize-snowflake/snapshot.json
@@ -25,7 +25,7 @@
         "Table": "\"duplicate keys @ with spaces\"",
         "Query": "",
         "StagedDir": "<uuid>",
-        "PipeName": "ESTUARY_DB.ESTUARY_SCHEMA.FLOW_PIPE_4_00000000_FFFFFFFFFFFFFFFF_DUPLICATE_KEYS___WITH_SPACES_68037661614FE673",
+        "PipeName": "ESTUARY_DB.ESTUARY_SCHEMA.FLOW_PIPE_4_00000000_FFFFFFFFFFFFFFFF_DUPLICATE_KEYS___WITH_SPACES_69560B841F9AAA81",
         "PipeFiles": [
           {
             "Path": "<uuid>",
@@ -136,7 +136,7 @@
         "Table": "\"duplicate keys @ with spaces\"",
         "Query": "",
         "StagedDir": "<uuid>",
-        "PipeName": "ESTUARY_DB.ESTUARY_SCHEMA.FLOW_PIPE_4_00000000_FFFFFFFFFFFFFFFF_DUPLICATE_KEYS___WITH_SPACES_68037661614FE673",
+        "PipeName": "ESTUARY_DB.ESTUARY_SCHEMA.FLOW_PIPE_4_00000000_FFFFFFFFFFFFFFFF_DUPLICATE_KEYS___WITH_SPACES_69560B841F9AAA81",
         "PipeFiles": [
           {
             "Path": "<uuid>",
@@ -223,7 +223,7 @@
         "Table": "\"duplicate keys @ with spaces\"",
         "Query": "",
         "StagedDir": "<uuid>",
-        "PipeName": "ESTUARY_DB.ESTUARY_SCHEMA.FLOW_PIPE_4_00000000_FFFFFFFFFFFFFFFF_DUPLICATE_KEYS___WITH_SPACES_68037661614FE673",
+        "PipeName": "ESTUARY_DB.ESTUARY_SCHEMA.FLOW_PIPE_4_00000000_FFFFFFFFFFFFFFFF_DUPLICATE_KEYS___WITH_SPACES_69560B841F9AAA81",
         "PipeFiles": [
           {
             "Path": "<uuid>",
@@ -281,7 +281,7 @@
             "Size": 238
           }
         ],
-        "PipeName": "ESTUARY_DB.ESTUARY_SCHEMA.FLOW_PIPE_4_00000000_FFFFFFFFFFFFFFFF_DUPLICATE_KEYS___WITH_SPACES_68037661614FE673",
+        "PipeName": "ESTUARY_DB.ESTUARY_SCHEMA.FLOW_PIPE_4_00000000_FFFFFFFFFFFFFFFF_DUPLICATE_KEYS___WITH_SPACES_69560B841F9AAA81",
         "Query": "",
         "StagedDir": "<uuid>",
         "Table": "\"duplicate keys @ with spaces\"",


### PR DESCRIPTION
**Description:**

Adds a new mode of operation for Snowflake bindings that use delta updates - [Snowpipe streaming](https://docs.snowflake.com/en/user-guide/data-load-snowpipe-streaming-overview). As implemented here, this will use the post-commit apply pattern to achieve exactly-once semantics.

This includes a fair amount of code ported over from the Java Snowflake Ingest SDK for the specifics related to writing the data files and interacting with the Streaming HTTP API to write data from those files, which is primary in the `bdec.go` and `stream_http.go` file. Our materialization-specific logic is in `stream.go`, as well as being sprinkled in the 2 previously mentioned ones. For example, we aren't reading the entirety of a transaction into memory like the Java SDK does, and instead use a byte-streaming version of the data writing & encryption that is in `bdec.go`.

The individual commit messages have more details, and I tried to lay them out in a reasonable way for reviewing.

An overall objective of this set of changes is to make the code as defensive as possible, since bugs on our end are more likely to result in corrupt tables that require backfilling when using streaming, rather than possibly getting a useful error message back from Snowflake like we (sometimes) do when running queries. To that end, streaming will only be enabled for now if the binding uses delta updates & JWT authentication, _and_ the materialization has the `snowflake_streaming` feature flag set. 

For now there are 3 possible modes of operation for a delta updates binding:
1. Using `COPY INTO` queries, if password auth is used. 
2. Using "regular" Snowpipe, if the `snowflake_streaming` feature flag is not set or the table doesn't support streaming
3. Using Snowpipe streaming if it is and does

Long-term, I'm not sure if we need all 3 of those. There are [limitations](https://docs.snowflake.com/en/user-guide/data-load-snowpipe-streaming-overview#limitations) on tables that support Snowpipe streaming, so we'll never be able to use it 100% of the time for delta updates tables, but it will probably be quite rare that we can't use it. A possible eventual strategy would be to use Snowpipe streaming if possible, and if not fall back to "something", where that "something" is either regular Snowpipe or `COPY INTO`. For now we'll keep them all though, since we still need them.

My thought is to keep Snowpipe streaming gated behind the feature flag for a while, until we get some opt-in usage of it to verify that it works as expected. Then it would be possible to enable it for all new materializations, and after a while even enable it retroactively on existing ones.

Closes https://github.com/estuary/connectors/issues/2676

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

The docs will eventually need some updates for Snowpipe streaming, although its usage should be pretty transparent to the user once the feature flag is enabled by default

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2698)
<!-- Reviewable:end -->
