### PR TITLE
source-sqlserver: Truncate oversized fields to 8MiB

### DIFF
--- a/source-boilerplate/testing/testing.go
+++ b/source-boilerplate/testing/testing.go
@@ -450,7 +450,8 @@ type ChecksumValidator struct {
 }
 
 type checksumValidatorState struct {
-	count    int
+	docs     int
+	bytes    int
 	checksum [32]byte
 }
 
@@ -470,7 +471,8 @@ func (v *ChecksumValidator) Output(collection string, data json.RawMessage) {
 }
 
 func (s *checksumValidatorState) reduce(data json.RawMessage) {
-	s.count++
+	s.docs++
+	s.bytes += len(data)
 	var docSum = sha256.Sum256([]byte(data))
 	for idx := range s.checksum {
 		s.checksum[idx] ^= docSum[idx]
@@ -486,9 +488,10 @@ func (v *ChecksumValidator) Summarize(w io.Writer) error {
 
 	for _, name := range names {
 		fmt.Fprintf(w, "# ================================\n")
-		fmt.Fprintf(w, "# Collection %q: %d Documents\n", name, v.collections[name].count)
+		fmt.Fprintf(w, "# Collection %q: %d Documents\n", name, v.collections[name].docs)
 		fmt.Fprintf(w, "# ================================\n")
 		fmt.Fprintf(w, "Checksum: %x\n", v.collections[name].checksum)
+		fmt.Fprintf(w, "Total Bytes: %d\n", v.collections[name].bytes)
 	}
 	return nil
 }

--- a/source-postgres/.snapshots/TestCaptureOversizedFields
+++ b/source-postgres/.snapshots/TestCaptureOversizedFields
@@ -2,6 +2,7 @@
 # Collection "acmeCo/test/test/captureoversizedfields_64819605": 4 Documents
 # ================================
 Checksum: 56f577e8541fcf154d84abc1b112056166e1c612e9fc7f3a3b96928396640401
+Total Bytes: 78294816
 # ================================
 # Final State Checkpoint
 # ================================

--- a/source-postgres/.snapshots/TestCaptureOversizedFields-Replication
+++ b/source-postgres/.snapshots/TestCaptureOversizedFields-Replication
@@ -2,6 +2,7 @@
 # Collection "acmeCo/test/test/captureoversizedfields_64819605": 4 Documents
 # ================================
 Checksum: a1dc8700ee7807ae5af70074904ad5ed775974dac8f93759e943ed6a5111bde8
+Total Bytes: 78294896
 # ================================
 # Final State Checkpoint
 # ================================

--- a/source-sqlserver/.snapshots/TestOversizedFields
+++ b/source-sqlserver/.snapshots/TestOversizedFields
@@ -1,0 +1,10 @@
+# ================================
+# Collection "acmeCo/test/dbo/test_oversizedfields_81647037": 2 Documents
+# ================================
+Checksum: d2ddab4fa9e99ba53674a1f7d58bc3e850639beec76d5694138d80796df166c8
+Total Bytes: 95071362
+# ================================
+# Final State Checkpoint
+# ================================
+{"bindingStateV1":{"dbo%2Ftest_OversizedFields_81647037":{"backfilled":1,"key_columns":["id"],"mode":"Active"}},"cursor":"AAAAAAAAAAAAAA=="}
+

--- a/source-sqlserver/datatypes.go
+++ b/source-sqlserver/datatypes.go
@@ -36,6 +36,10 @@ const (
 	// field is ignored and we just use the original input string, since that
 	// way the collation-sortable encoding doesn't have to be reversible.
 	collatedTextTag = "ctext"
+
+	// The maximum size of a single column's value. Values larger than this threshold
+	// will be truncated to fit. Arbitrarily set at 8MiB.
+	truncateColumnThreshold = 8 * 1024 * 1024
 )
 
 func encodeKeyFDB(key, ktype interface{}) (tuple.TupleElement, error) {
@@ -143,6 +147,15 @@ func (db *sqlserverDatabase) translateRecordField(columnType interface{}, val in
 			}
 			return u.String(), nil
 		}
+		if len(val) > truncateColumnThreshold {
+			val = val[:truncateColumnThreshold]
+		}
+		return val, nil
+	case string:
+		if len(val) > truncateColumnThreshold {
+			val = val[:truncateColumnThreshold]
+		}
+		return val, nil
 	case time.Time:
 		switch columnType {
 		case "date":

--- a/source-sqlserver/docker-initdb.sh
+++ b/source-sqlserver/docker-initdb.sh
@@ -12,6 +12,10 @@ CREATE DATABASE test;
 GO
 USE test;
 GO
+EXECUTE sp_configure 'max text repl size', -1;
+GO
+RECONFIGURE;
+GO
 EXEC sys.sp_cdc_enable_db;
 GO
 CREATE LOGIN flow_capture WITH PASSWORD = 'we2rie1E';

--- a/source-sqlserver/main_test.go
+++ b/source-sqlserver/main_test.go
@@ -177,7 +177,7 @@ func (tb *testBackend) Insert(ctx context.Context, t testing.TB, table string, r
 	var tx, err = tb.control.BeginTx(ctx, nil)
 	require.NoErrorf(t, err, "begin transaction")
 
-	log.WithFields(log.Fields{"table": table, "count": len(rows), "first": rows[0]}).Debug("inserting data")
+	log.WithFields(log.Fields{"table": table, "count": len(rows)}).Debug("inserting data")
 	var query = fmt.Sprintf(`INSERT INTO %s VALUES %s`, table, argsTuple(len(rows[0])))
 	for _, row := range rows {
 		log.WithFields(log.Fields{"table": table, "row": row, "query": query}).Trace("inserting row")


### PR DESCRIPTION
**Description:**

Same as we do for PostgreSQL, this PR adds a simple "if length > 8MiB truncate to 8MiB" check for SQL Server's "Large Object" types (text and image and varchar/varbinary(max)). This doesn't make it impossible for a document to exceed Flow's 64MiB limit, but it's a decent starting point that catches the common case where there's just one really huge column in a table.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2700)
<!-- Reviewable:end -->
