### PR TITLE
source-mysql: Query timeouts, take N+1

### DIFF
--- a/source-mysql/discovery.go
+++ b/source-mysql/discovery.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/estuary/connectors/sqlcapture"
 	"github.com/estuary/flow/go/protocols/fdb/tuple"
-	"github.com/go-mysql-org/go-mysql/client"
 	"github.com/google/uuid"
 	"github.com/invopop/jsonschema"
 	"github.com/sirupsen/logrus"
@@ -470,7 +469,7 @@ const queryDiscoverTables = `
   FROM information_schema.tables
   WHERE table_schema NOT IN ('information_schema', 'performance_schema', 'mysql', 'sys');`
 
-func getTables(_ context.Context, conn *client.Conn, selectedSchemas []string) ([]*sqlcapture.DiscoveryInfo, error) {
+func getTables(_ context.Context, conn mysqlClient, selectedSchemas []string) ([]*sqlcapture.DiscoveryInfo, error) {
 	var results, err = conn.Execute(queryDiscoverTables)
 	if err != nil {
 		return nil, fmt.Errorf("error listing tables: %w", err)
@@ -540,7 +539,7 @@ const queryDiscoverColumns = `
   WHERE table_schema NOT IN ('information_schema', 'performance_schema', 'mysql', 'sys')
   ORDER BY table_schema, table_name, ordinal_position;`
 
-func (db *mysqlDatabase) getColumns(_ context.Context, conn *client.Conn) ([]sqlcapture.ColumnInfo, error) {
+func (db *mysqlDatabase) getColumns(_ context.Context, conn mysqlClient) ([]sqlcapture.ColumnInfo, error) {
 	var results, err = conn.Execute(queryDiscoverColumns)
 	if err != nil {
 		return nil, fmt.Errorf("error querying columns: %w", err)
@@ -900,7 +899,7 @@ SELECT table_schema, table_name, column_name, seq_in_index
 // primary keys. Table names are fully qualified as "<schema>.<name>", and
 // primary keys are represented as a list of column names, in the order that
 // they form the table's primary key.
-func getPrimaryKeys(_ context.Context, conn *client.Conn) (map[string][]string, error) {
+func getPrimaryKeys(_ context.Context, conn mysqlClient) (map[string][]string, error) {
 	var results, err = conn.Execute(queryDiscoverPrimaryKeys)
 	if err != nil {
 		return nil, fmt.Errorf("error querying primary keys: %w", err)
@@ -933,7 +932,7 @@ SELECT stat.table_schema, stat.table_name, stat.index_name, stat.column_name, st
   ORDER BY stat.table_schema, stat.table_name, stat.index_name, stat.seq_in_index
 `
 
-func getSecondaryIndexes(_ context.Context, conn *client.Conn) (map[string]map[string][]string, error) {
+func getSecondaryIndexes(_ context.Context, conn mysqlClient) (map[string]map[string][]string, error) {
 	var results, err = conn.Execute(queryDiscoverSecondaryIndices)
 	if err != nil {
 		return nil, fmt.Errorf("error querying secondary indexes: %w", err)

--- a/source-mysql/main.go
+++ b/source-mysql/main.go
@@ -256,12 +256,12 @@ func (db *mysqlDatabase) connect(_ context.Context) error {
 	//   we don't need to mention that and just return the with-TLS error.
 	if connWithTLS, errWithTLS := client.Connect(address, db.config.User, db.config.Password, db.config.Advanced.DBName, withTLS); errWithTLS == nil {
 		logrus.WithField("addr", address).Info("connected with TLS")
-		db.conn = &mysqlConnection{connWithTLS}
+		db.conn = &mysqlConnection{inner: connWithTLS, queryTimeout: DefaultQueryTimeout}
 	} else if errors.As(errWithTLS, &mysqlErr) && mysqlErr.Code == mysql.ER_ACCESS_DENIED_ERROR {
 		return cerrors.NewUserError(mysqlErr, "incorrect username or password")
 	} else if connWithoutTLS, errWithoutTLS := client.Connect(address, db.config.User, db.config.Password, db.config.Advanced.DBName); errWithoutTLS == nil {
 		logrus.WithField("addr", address).Info("connected without TLS")
-		db.conn = &mysqlConnection{connWithoutTLS}
+		db.conn = &mysqlConnection{inner: connWithoutTLS, queryTimeout: DefaultQueryTimeout}
 	} else if errors.As(errWithoutTLS, &mysqlErr) && mysqlErr.Code == mysql.ER_ACCESS_DENIED_ERROR {
 		logrus.WithFields(logrus.Fields{"withTLS": errWithTLS, "nonTLS": errWithoutTLS}).Error("unable to connect to database")
 		return cerrors.NewUserError(mysqlErr, "incorrect username or password")

--- a/source-mysql/prerequisites.go
+++ b/source-mysql/prerequisites.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/estuary/connectors/sqlcapture"
-	"github.com/go-mysql-org/go-mysql/client"
 	"github.com/go-mysql-org/go-mysql/mysql"
 	"github.com/sirupsen/logrus"
 )
@@ -159,7 +158,7 @@ func (db *mysqlDatabase) SetupTablePrerequisites(ctx context.Context, schema, ta
 	return nil
 }
 
-func getBinlogExpiry(conn *client.Conn) (time.Duration, error) {
+func getBinlogExpiry(conn mysqlClient) (time.Duration, error) {
 	// When running on Amazon RDS MySQL there's an RDS-specific configuration
 	// for binlog retention, so that takes precedence if it exists.
 	rdsRetentionHours, err := queryNumericVariable(conn, `SELECT name, value FROM mysql.rds_configuration WHERE name = 'binlog retention hours';`)
@@ -189,7 +188,7 @@ func getBinlogExpiry(conn *client.Conn) (time.Duration, error) {
 	return 365 * 24 * time.Hour, nil
 }
 
-func queryNumericVariable(conn *client.Conn, query string) (float64, error) {
+func queryNumericVariable(conn mysqlClient, query string) (float64, error) {
 	var results, err = conn.Execute(query)
 	if err != nil {
 		return 0, fmt.Errorf("error executing query %q: %w", query, err)


### PR DESCRIPTION
**Description:**

The go-mysql client library's handling of read/write timeouts is kind of awful for reasons I'd rather not get into. [Previously](https://github.com/estuary/connectors/pull/2674) we disengaged all timeouts in favor of implementing our own deadline on the initial connection, but it turns out this leaves us at a real risk of indefinite hangs in some cases if the network connection silently gets dropped.

So in this commit we take matters into our own hands and set a deadline on the underlying net.Conn, implementing a timeout on the entire query/execute operation. For most queries we have a default timeout of 60s, and for backfills we override that with a much more generous 6h timeout.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2701)
<!-- Reviewable:end -->
