### PR TITLE
materialize-motherduck: bucket name validation & missing credentials fix

### DIFF
--- a/materialize-motherduck/.snapshots/TestSpecification
+++ b/materialize-motherduck/.snapshots/TestSpecification
@@ -26,8 +26,9 @@
       "bucket": {
         "type": "string",
         "title": "S3 Staging Bucket",
-        "description": "Name of the S3 bucket to use for staging data loads.",
-        "order": 3
+        "description": "Name of the S3 bucket to use for staging data loads. Must not contain dots (.)",
+        "order": 3,
+        "pattern": "^[^.]*$"
       },
       "awsAccessKeyId": {
         "type": "string",

--- a/materialize-motherduck/driver.go
+++ b/materialize-motherduck/driver.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"path"
 	"strings"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awsConfig "github.com/aws/aws-sdk-go-v2/config"
@@ -221,6 +222,30 @@ func newTransactor(
 	if err != nil {
 		return nil, nil, fmt.Errorf("creating connection: %w", err)
 	}
+
+	// Arrange for periodically refreshing the staging bucket storage
+	// credentials. For as-of-yet unknown reasons, these seem to expire after a
+	// variable amount of time, on the order of several hours, which results in
+	// an error along the lines of "Missing or invalid credentials".
+	go func() {
+		for {
+			select {
+			case <-time.After(30 * time.Minute):
+				for idx, c := range []string{
+					fmt.Sprintf("SET s3_access_key_id='%s'", cfg.AWSAccessKeyID),
+					fmt.Sprintf("SET s3_secret_access_key='%s';", cfg.AWSSecretAccessKey),
+					fmt.Sprintf("SET s3_region='%s';", cfg.Region),
+				} {
+					if _, err := conn.ExecContext(ctx, c); err != nil {
+						log.Fatal(fmt.Errorf("executing credentials refresh command %d: %w", idx, err))
+					}
+				}
+			case <-ctx.Done():
+				return
+			}
+			log.Debug("refreshed staging bucket storage credentials")
+		}
+	}()
 
 	t := &transactor{
 		cfg:      cfg,


### PR DESCRIPTION
**Description:**

Adds a check on bucket names to make sure they don't contain dots since that breaks SSL verification. Also a speculative fix for the "Missing credentials" error that seems to occasionally happen.

Closes https://github.com/estuary/connectors/issues/2702

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2703)
<!-- Reviewable:end -->
