### PR TITLE
source-sqlserver: Fix rare map assignment panic

### DIFF
--- a/source-sqlserver/discovery.go
+++ b/source-sqlserver/discovery.go
@@ -88,7 +88,10 @@ func (db *sqlserverDatabase) DiscoverTables(ctx context.Context) (map[sqlcapture
 			details.ComputedColumns = computedColumns[streamID]
 		}
 		for _, columnName := range computedColumns[streamID] {
-			var info = table.Columns[columnName]
+			var info, ok = table.Columns[columnName]
+			if !ok {
+				continue
+			}
 			info.OmitColumn = true
 			table.Columns[columnName] = info
 		}


### PR DESCRIPTION
**Description:**

I have only ever seen this once in production, but since we run discovery at a regular cadence it really ought to be bulletproof and not able to randomly cause a panic if the computed-columns info and the main column metadata are out of sync.
