### PR TITLE
estuary-cdk: support `SourcedSchema` messages

### DIFF
--- a/estuary-cdk/estuary_cdk/capture/common.py
+++ b/estuary-cdk/estuary_cdk/capture/common.py
@@ -60,6 +60,17 @@ and "no pages remain" in a response context.
 class Triggers(Enum):
     BACKFILL = "BACKFILL"
 
+@dataclass
+class SourcedSchema:
+    """
+    SourcedSchema encapsulates a source-defined schema for a specific binding.
+    SourcedSchemas are used to inform the runtime about types & metadata that
+    aren't easily inferred by inspecting specific documents. The runtime
+    widens inferred schemas to accommodate the current inferred schema along
+    with any SourcedSchemas.
+    """
+    value: dict[str, Any]
+
 
 class BaseDocument(BaseModel):
     class Meta(BaseModel):

--- a/estuary-cdk/estuary_cdk/capture/response.py
+++ b/estuary-cdk/estuary_cdk/capture/response.py
@@ -1,4 +1,4 @@
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from typing import Generic, Any
 
 from ..flow import ResourceConfig, ConnectorState, ConnectorStateUpdate
@@ -35,6 +35,13 @@ class Opened(BaseModel):
 class Captured(BaseModel):
     binding: int
     doc: Any
+
+
+class SourcedSchema(BaseModel):
+    binding: int
+    # Pydantic's BaseModel already has a schema_json field, and it complains if we overwrite it.
+    # We use a serialization alias to avoid Pydantic's complaints and serialize the field name correctly.
+    schemaJson: dict = Field(serialization_alias="schema_json")
 
 
 class Checkpoint(BaseModel, Generic[ConnectorState]):


### PR DESCRIPTION
**Description:**

The Flow runtime has recently been updated to support `SourcedSchema` messages - schemas emitted by capture connectors to inform the runtime of some source-defined schema. See https://github.com/estuary/flow/pull/1946 for more details.

This PR adds support in our CDK for emitting `SourcedSchema` messages. `SourcedSchema` messages are written to each task's buffer and emitted as part of the next checkpoint.

`SourcedSchema` messages should be emitted after `open` is called. They can be emitted when opening a resource, like below:

```python
def open(
    binding: CaptureBinding[ResourceConfig],
    binding_index: int,
    state: ResourceState,
    task: Task,
    all_bindings,
):
    schema = {
        "additionalProperties": False,
        "type": "object",
        "properties": {
            "myPropertyName": {
                "type": "string",
                "format": "integer",
            }
        }
    }
    # Emit the schema.
    task.sourced_schema(binding_index, schema)
    # Checkpoint an empty connector state so the SourcedSchema response will be applied to the inferred schema.
    task.checkpoint(state=ConnectorState())
```

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

Tested on a local stack. Confirmed that `SourcedSchema`s emitted when opening a resource causes the binding's inferred schema to widen & accommodate whatever fields were specified in the `SourcedSchema`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2710)
<!-- Reviewable:end -->
