### PR TITLE
materialize-iceberg: advanced config option to create all table columns as lowercase

### DIFF
--- a/materialize-iceberg/.snapshots/TestSpec
+++ b/materialize-iceberg/.snapshots/TestSpec
@@ -324,6 +324,19 @@
         ],
         "title": "dbt Cloud Job Trigger",
         "description": "Trigger a dbt Job when new data is available"
+      },
+      "advanced": {
+        "properties": {
+          "lowercase_column_names": {
+            "type": "boolean",
+            "title": "Lowercase Column Names",
+            "description": "Create all columns with lowercase names. This is necessary for compatibility with some systems such as querying S3 Table Buckets with Athena."
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "title": "Advanced Options",
+        "description": "Options for advanced users. You should not typically need to modify these."
       }
     },
     "type": "object",

--- a/materialize-iceberg/.snapshots/TestValidateAndApplyLowercaseColumnNames
+++ b/materialize-iceberg/.snapshots/TestValidateAndApplyLowercaseColumnNames
@@ -1,0 +1,362 @@
+Big Schema Initial Constraints:
+{"Field":"_meta/flow_truncated","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"Metadata fields are able to be materialized"}
+{"Field":"arrayField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This field is able to be materialized"}
+{"Field":"boolField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The projection has a single scalar type"}
+{"Field":"flow_document","Type":2,"TypeString":"LOCATION_REQUIRED","Reason":"The root document must be materialized"}
+{"Field":"flow_published_at","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The projection has a single scalar type"}
+{"Field":"intField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The projection has a single scalar type"}
+{"Field":"key","Type":2,"TypeString":"LOCATION_REQUIRED","Reason":"All Locations that are part of the collections key are required"}
+{"Field":"multipleField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This field is able to be materialized"}
+{"Field":"nullField","Type":5,"TypeString":"FIELD_FORBIDDEN","Reason":"Cannot materialize a field where the only possible type is 'null'"}
+{"Field":"numField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The projection has a single scalar type"}
+{"Field":"objField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"Object fields may be materialized"}
+{"Field":"stringDateField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The projection has a single scalar type"}
+{"Field":"stringDateTimeField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The projection has a single scalar type"}
+{"Field":"stringDurationField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The projection has a single scalar type"}
+{"Field":"stringEmailField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The projection has a single scalar type"}
+{"Field":"stringField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The projection has a single scalar type"}
+{"Field":"stringHostnameField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The projection has a single scalar type"}
+{"Field":"stringIdnEmailField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The projection has a single scalar type"}
+{"Field":"stringIdnHostnameField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The projection has a single scalar type"}
+{"Field":"stringIntegerField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The projection has a single scalar type"}
+{"Field":"stringIpv4Field","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The projection has a single scalar type"}
+{"Field":"stringIpv6Field","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The projection has a single scalar type"}
+{"Field":"stringIriField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The projection has a single scalar type"}
+{"Field":"stringIriReferenceField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The projection has a single scalar type"}
+{"Field":"stringJsonPointerField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The projection has a single scalar type"}
+{"Field":"stringMacAddr8Field","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The projection has a single scalar type"}
+{"Field":"stringMacAddrField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The projection has a single scalar type"}
+{"Field":"stringNumberField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The projection has a single scalar type"}
+{"Field":"stringRegexField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The projection has a single scalar type"}
+{"Field":"stringRelativeJsonPointerField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The projection has a single scalar type"}
+{"Field":"stringTimeField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The projection has a single scalar type"}
+{"Field":"stringUint32Field","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The projection has a single scalar type"}
+{"Field":"stringUint64Field","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The projection has a single scalar type"}
+{"Field":"stringUriField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The projection has a single scalar type"}
+{"Field":"stringUriReferenceField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The projection has a single scalar type"}
+{"Field":"stringUriTemplateField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The projection has a single scalar type"}
+{"Field":"stringUuidField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The projection has a single scalar type"}
+
+Big Schema Re-validated Constraints:
+{"Field":"_meta/flow_truncated","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"arrayField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"boolField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"flow_document","Type":1,"TypeString":"FIELD_REQUIRED","Reason":"This field is the document in the current materialization"}
+{"Field":"flow_published_at","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"intField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"key","Type":1,"TypeString":"FIELD_REQUIRED","Reason":"This field is a key in the current materialization"}
+{"Field":"multipleField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"nullField","Type":5,"TypeString":"FIELD_FORBIDDEN","Reason":"Cannot materialize a field where the only possible type is 'null'"}
+{"Field":"numField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"objField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"stringDateField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"stringDateTimeField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"stringDurationField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"stringEmailField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"stringField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"stringHostnameField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"stringIdnEmailField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"stringIdnHostnameField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"stringIntegerField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"stringIpv4Field","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"stringIpv6Field","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"stringIriField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"stringIriReferenceField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"stringJsonPointerField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"stringMacAddr8Field","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"stringMacAddrField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"stringNumberField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"stringRegexField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"stringRelativeJsonPointerField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"stringTimeField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"stringUint32Field","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"stringUint64Field","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"stringUriField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"stringUriReferenceField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"stringUriTemplateField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"stringUuidField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+
+Big Schema Changed Types Constraints:
+{"Field":"_meta/flow_truncated","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"arrayField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"boolField","Type":6,"TypeString":"UNSATISFIABLE","Reason":"Field 'boolField' is already being materialized as endpoint type 'BOOLEAN' but endpoint type 'LONG' is required by its schema '{ type: [integer] }'"}
+{"Field":"flow_document","Type":1,"TypeString":"FIELD_REQUIRED","Reason":"This field is the document in the current materialization"}
+{"Field":"flow_published_at","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"intField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"key","Type":1,"TypeString":"FIELD_REQUIRED","Reason":"This field is a key in the current materialization"}
+{"Field":"multipleField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"nullField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"Object fields may be materialized"}
+{"Field":"numField","Type":6,"TypeString":"UNSATISFIABLE","Reason":"Field 'numField' is already being materialized as endpoint type 'DOUBLE' but endpoint type 'BOOLEAN' is required by its schema '{ type: [boolean] }'"}
+{"Field":"objField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"stringDateField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"stringDateTimeField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"stringDurationField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"stringEmailField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"stringField","Type":6,"TypeString":"UNSATISFIABLE","Reason":"Field 'stringField' is already being materialized as endpoint type 'STRING' but endpoint type 'LONG' is required by its schema '{ type: [integer] }'"}
+{"Field":"stringHostnameField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"stringIdnEmailField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"stringIdnHostnameField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"stringIntegerField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"stringIpv4Field","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"stringIpv6Field","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"stringIriField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"stringIriReferenceField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"stringJsonPointerField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"stringMacAddr8Field","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"stringMacAddrField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"stringNumberField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"stringRegexField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"stringRelativeJsonPointerField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"stringTimeField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"stringUint32Field","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"stringUint64Field","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"stringUriField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"stringUriReferenceField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"stringUriTemplateField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"stringUuidField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+
+Big Schema Materialized Resource Schema With All Fields Required:
+table {
+	1: key: required string (auto-generated projection of JSON at: /key with inferred types: [string])
+	2: _meta/flow_truncated: required boolean (Flow truncation indicator - Indicates whether any of the materialized values for this row have been truncated to make them fit inside the limitations of the destination system. - auto-generated projection of JSON at: /_meta/flow_truncated with inferred types: [boolean])
+	3: arrayfield: required string (auto-generated projection of JSON at: /arrayField with inferred types: [array])
+	4: boolfield: required boolean (auto-generated projection of JSON at: /boolField with inferred types: [boolean])
+	5: flow_published_at: required timestamptz (Flow Publication Time - Flow publication date-time of this document - auto-generated projection of JSON at: /_meta/uuid with inferred types: [string])
+	6: intfield: required long (auto-generated projection of JSON at: /intField with inferred types: [integer])
+	7: multiplefield: required string (auto-generated projection of JSON at: /multipleField with inferred types: [integer object string])
+	8: numfield: required double (auto-generated projection of JSON at: /numField with inferred types: [number])
+	9: objfield: required string (auto-generated projection of JSON at: /objField with inferred types: [object])
+	10: stringdatefield: required date (auto-generated projection of JSON at: /stringDateField with inferred types: [string])
+	11: stringdatetimefield: required timestamptz (auto-generated projection of JSON at: /stringDateTimeField with inferred types: [string])
+	12: stringdurationfield: required string (auto-generated projection of JSON at: /stringDurationField with inferred types: [string])
+	13: stringemailfield: required string (auto-generated projection of JSON at: /stringEmailField with inferred types: [string])
+	14: stringfield: required string (auto-generated projection of JSON at: /stringField with inferred types: [string])
+	15: stringhostnamefield: required string (auto-generated projection of JSON at: /stringHostnameField with inferred types: [string])
+	16: stringidnemailfield: required string (auto-generated projection of JSON at: /stringIdnEmailField with inferred types: [string])
+	17: stringidnhostnamefield: required string (auto-generated projection of JSON at: /stringIdnHostnameField with inferred types: [string])
+	18: stringintegerfield: required decimal(38, 0) (auto-generated projection of JSON at: /stringIntegerField with inferred types: [string])
+	19: stringipv4field: required string (auto-generated projection of JSON at: /stringIpv4Field with inferred types: [string])
+	20: stringipv6field: required string (auto-generated projection of JSON at: /stringIpv6Field with inferred types: [string])
+	21: stringirifield: required string (auto-generated projection of JSON at: /stringIriField with inferred types: [string])
+	22: stringirireferencefield: required string (auto-generated projection of JSON at: /stringIriReferenceField with inferred types: [string])
+	23: stringjsonpointerfield: required string (auto-generated projection of JSON at: /stringJsonPointerField with inferred types: [string])
+	24: stringmacaddr8field: required string (auto-generated projection of JSON at: /stringMacAddr8Field with inferred types: [string])
+	25: stringmacaddrfield: required string (auto-generated projection of JSON at: /stringMacAddrField with inferred types: [string])
+	26: stringnumberfield: required double (auto-generated projection of JSON at: /stringNumberField with inferred types: [string])
+	27: stringregexfield: required string (auto-generated projection of JSON at: /stringRegexField with inferred types: [string])
+	28: stringrelativejsonpointerfield: required string (auto-generated projection of JSON at: /stringRelativeJsonPointerField with inferred types: [string])
+	29: stringtimefield: required string (auto-generated projection of JSON at: /stringTimeField with inferred types: [string])
+	30: stringuint32field: required decimal(38, 0) (auto-generated projection of JSON at: /stringUint32Field with inferred types: [string])
+	31: stringuint64field: required decimal(38, 0) (auto-generated projection of JSON at: /stringUint64Field with inferred types: [string])
+	32: stringurifield: required string (auto-generated projection of JSON at: /stringUriField with inferred types: [string])
+	33: stringurireferencefield: required string (auto-generated projection of JSON at: /stringUriReferenceField with inferred types: [string])
+	34: stringuritemplatefield: required string (auto-generated projection of JSON at: /stringUriTemplateField with inferred types: [string])
+	35: stringuuidfield: required string (auto-generated projection of JSON at: /stringUuidField with inferred types: [string])
+	36: flow_document: required string (auto-generated projection of the root document with inferred types: [object])
+}
+
+Big Schema Materialized Resource Schema With No Fields Required:
+table {
+	1: key: required string (auto-generated projection of JSON at: /key with inferred types: [string])
+	2: _meta/flow_truncated: required boolean (Flow truncation indicator - Indicates whether any of the materialized values for this row have been truncated to make them fit inside the limitations of the destination system. - auto-generated projection of JSON at: /_meta/flow_truncated with inferred types: [boolean])
+	3: arrayfield: optional string (auto-generated projection of JSON at: /arrayField with inferred types: [array])
+	4: boolfield: optional boolean (auto-generated projection of JSON at: /boolField with inferred types: [boolean])
+	5: flow_published_at: required timestamptz (Flow Publication Time - Flow publication date-time of this document - auto-generated projection of JSON at: /_meta/uuid with inferred types: [string])
+	6: intfield: optional long (auto-generated projection of JSON at: /intField with inferred types: [integer])
+	7: multiplefield: optional string (auto-generated projection of JSON at: /multipleField with inferred types: [integer object string])
+	8: numfield: optional double (auto-generated projection of JSON at: /numField with inferred types: [number])
+	9: objfield: optional string (auto-generated projection of JSON at: /objField with inferred types: [object])
+	10: stringdatefield: optional date (auto-generated projection of JSON at: /stringDateField with inferred types: [string])
+	11: stringdatetimefield: optional timestamptz (auto-generated projection of JSON at: /stringDateTimeField with inferred types: [string])
+	12: stringdurationfield: optional string (auto-generated projection of JSON at: /stringDurationField with inferred types: [string])
+	13: stringemailfield: optional string (auto-generated projection of JSON at: /stringEmailField with inferred types: [string])
+	14: stringfield: optional string (auto-generated projection of JSON at: /stringField with inferred types: [string])
+	15: stringhostnamefield: optional string (auto-generated projection of JSON at: /stringHostnameField with inferred types: [string])
+	16: stringidnemailfield: optional string (auto-generated projection of JSON at: /stringIdnEmailField with inferred types: [string])
+	17: stringidnhostnamefield: optional string (auto-generated projection of JSON at: /stringIdnHostnameField with inferred types: [string])
+	18: stringintegerfield: optional decimal(38, 0) (auto-generated projection of JSON at: /stringIntegerField with inferred types: [string])
+	19: stringipv4field: optional string (auto-generated projection of JSON at: /stringIpv4Field with inferred types: [string])
+	20: stringipv6field: optional string (auto-generated projection of JSON at: /stringIpv6Field with inferred types: [string])
+	21: stringirifield: optional string (auto-generated projection of JSON at: /stringIriField with inferred types: [string])
+	22: stringirireferencefield: optional string (auto-generated projection of JSON at: /stringIriReferenceField with inferred types: [string])
+	23: stringjsonpointerfield: optional string (auto-generated projection of JSON at: /stringJsonPointerField with inferred types: [string])
+	24: stringmacaddr8field: optional string (auto-generated projection of JSON at: /stringMacAddr8Field with inferred types: [string])
+	25: stringmacaddrfield: optional string (auto-generated projection of JSON at: /stringMacAddrField with inferred types: [string])
+	26: stringnumberfield: optional double (auto-generated projection of JSON at: /stringNumberField with inferred types: [string])
+	27: stringregexfield: optional string (auto-generated projection of JSON at: /stringRegexField with inferred types: [string])
+	28: stringrelativejsonpointerfield: optional string (auto-generated projection of JSON at: /stringRelativeJsonPointerField with inferred types: [string])
+	29: stringtimefield: optional string (auto-generated projection of JSON at: /stringTimeField with inferred types: [string])
+	30: stringuint32field: optional decimal(38, 0) (auto-generated projection of JSON at: /stringUint32Field with inferred types: [string])
+	31: stringuint64field: optional decimal(38, 0) (auto-generated projection of JSON at: /stringUint64Field with inferred types: [string])
+	32: stringurifield: optional string (auto-generated projection of JSON at: /stringUriField with inferred types: [string])
+	33: stringurireferencefield: optional string (auto-generated projection of JSON at: /stringUriReferenceField with inferred types: [string])
+	34: stringuritemplatefield: optional string (auto-generated projection of JSON at: /stringUriTemplateField with inferred types: [string])
+	35: stringuuidfield: optional string (auto-generated projection of JSON at: /stringUuidField with inferred types: [string])
+	36: flow_document: required string (auto-generated projection of the root document with inferred types: [object])
+}
+
+Big Schema Changed Types With Table Replacement Constraints:
+{"Field":"_meta/flow_truncated","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"Metadata fields are able to be materialized"}
+{"Field":"arrayField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"Object fields may be materialized"}
+{"Field":"boolField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The projection has a single scalar type"}
+{"Field":"flow_document","Type":2,"TypeString":"LOCATION_REQUIRED","Reason":"The root document must be materialized"}
+{"Field":"flow_published_at","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The projection has a single scalar type"}
+{"Field":"intField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The projection has a single scalar type"}
+{"Field":"key","Type":2,"TypeString":"LOCATION_REQUIRED","Reason":"All Locations that are part of the collections key are required"}
+{"Field":"multipleField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This field is able to be materialized"}
+{"Field":"nullField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"Object fields may be materialized"}
+{"Field":"numField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The projection has a single scalar type"}
+{"Field":"objField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The projection has a single scalar type"}
+{"Field":"stringDateField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The projection has a single scalar type"}
+{"Field":"stringDateTimeField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The projection has a single scalar type"}
+{"Field":"stringDurationField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The projection has a single scalar type"}
+{"Field":"stringEmailField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The projection has a single scalar type"}
+{"Field":"stringField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The projection has a single scalar type"}
+{"Field":"stringHostnameField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The projection has a single scalar type"}
+{"Field":"stringIdnEmailField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The projection has a single scalar type"}
+{"Field":"stringIdnHostnameField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The projection has a single scalar type"}
+{"Field":"stringIntegerField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The projection has a single scalar type"}
+{"Field":"stringIpv4Field","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The projection has a single scalar type"}
+{"Field":"stringIpv6Field","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The projection has a single scalar type"}
+{"Field":"stringIriField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The projection has a single scalar type"}
+{"Field":"stringIriReferenceField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The projection has a single scalar type"}
+{"Field":"stringJsonPointerField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The projection has a single scalar type"}
+{"Field":"stringMacAddr8Field","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The projection has a single scalar type"}
+{"Field":"stringMacAddrField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The projection has a single scalar type"}
+{"Field":"stringNumberField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The projection has a single scalar type"}
+{"Field":"stringRegexField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The projection has a single scalar type"}
+{"Field":"stringRelativeJsonPointerField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The projection has a single scalar type"}
+{"Field":"stringTimeField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The projection has a single scalar type"}
+{"Field":"stringUint32Field","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The projection has a single scalar type"}
+{"Field":"stringUint64Field","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The projection has a single scalar type"}
+{"Field":"stringUriField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The projection has a single scalar type"}
+{"Field":"stringUriReferenceField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The projection has a single scalar type"}
+{"Field":"stringUriTemplateField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The projection has a single scalar type"}
+{"Field":"stringUuidField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The projection has a single scalar type"}
+
+Big Schema Materialized Resource Schema Changed Types With Table Replacement:
+table {
+	1: key: required string (auto-generated projection of JSON at: /key with inferred types: [string])
+	2: _meta/flow_truncated: required boolean (Flow truncation indicator - Indicates whether any of the materialized values for this row have been truncated to make them fit inside the limitations of the destination system. - auto-generated projection of JSON at: /_meta/flow_truncated with inferred types: [boolean])
+	3: arrayfield: required string (auto-generated projection of JSON at: /arrayField with inferred types: [object])
+	4: boolfield: required long (auto-generated projection of JSON at: /boolField with inferred types: [integer])
+	5: flow_published_at: required timestamptz (Flow Publication Time - Flow publication date-time of this document - auto-generated projection of JSON at: /_meta/uuid with inferred types: [string])
+	6: intfield: required string (auto-generated projection of JSON at: /intField with inferred types: [string])
+	7: multiplefield: required string (auto-generated projection of JSON at: /multipleField with inferred types: [boolean integer object string])
+	8: nullfield: optional string (auto-generated projection of JSON at: /nullField with inferred types: [null object])
+	9: numfield: required boolean (auto-generated projection of JSON at: /numField with inferred types: [boolean])
+	10: objfield: required string (auto-generated projection of JSON at: /objField with inferred types: [string])
+	11: stringdatefield: required string (auto-generated projection of JSON at: /stringDateField with inferred types: [string])
+	12: stringdatetimefield: required string (auto-generated projection of JSON at: /stringDateTimeField with inferred types: [string])
+	13: stringdurationfield: required string (auto-generated projection of JSON at: /stringDurationField with inferred types: [string])
+	14: stringemailfield: required string (auto-generated projection of JSON at: /stringEmailField with inferred types: [string])
+	15: stringfield: required long (auto-generated projection of JSON at: /stringField with inferred types: [integer])
+	16: stringhostnamefield: required string (auto-generated projection of JSON at: /stringHostnameField with inferred types: [string])
+	17: stringidnemailfield: required string (auto-generated projection of JSON at: /stringIdnEmailField with inferred types: [string])
+	18: stringidnhostnamefield: required string (auto-generated projection of JSON at: /stringIdnHostnameField with inferred types: [string])
+	19: stringintegerfield: required string (auto-generated projection of JSON at: /stringIntegerField with inferred types: [string])
+	20: stringipv4field: required string (auto-generated projection of JSON at: /stringIpv4Field with inferred types: [string])
+	21: stringipv6field: required string (auto-generated projection of JSON at: /stringIpv6Field with inferred types: [string])
+	22: stringirifield: required string (auto-generated projection of JSON at: /stringIriField with inferred types: [string])
+	23: stringirireferencefield: required string (auto-generated projection of JSON at: /stringIriReferenceField with inferred types: [string])
+	24: stringjsonpointerfield: required string (auto-generated projection of JSON at: /stringJsonPointerField with inferred types: [string])
+	25: stringmacaddr8field: required string (auto-generated projection of JSON at: /stringMacAddr8Field with inferred types: [string])
+	26: stringmacaddrfield: required string (auto-generated projection of JSON at: /stringMacAddrField with inferred types: [string])
+	27: stringnumberfield: required string (auto-generated projection of JSON at: /stringNumberField with inferred types: [string])
+	28: stringregexfield: required string (auto-generated projection of JSON at: /stringRegexField with inferred types: [string])
+	29: stringrelativejsonpointerfield: required string (auto-generated projection of JSON at: /stringRelativeJsonPointerField with inferred types: [string])
+	30: stringtimefield: required string (auto-generated projection of JSON at: /stringTimeField with inferred types: [string])
+	31: stringuint32field: required string (auto-generated projection of JSON at: /stringUint32Field with inferred types: [string])
+	32: stringuint64field: required string (auto-generated projection of JSON at: /stringUint64Field with inferred types: [string])
+	33: stringurifield: required string (auto-generated projection of JSON at: /stringUriField with inferred types: [string])
+	34: stringurireferencefield: required string (auto-generated projection of JSON at: /stringUriReferenceField with inferred types: [string])
+	35: stringuritemplatefield: required string (auto-generated projection of JSON at: /stringUriTemplateField with inferred types: [string])
+	36: stringuuidfield: required string (auto-generated projection of JSON at: /stringUuidField with inferred types: [string])
+	37: flow_document: required string (auto-generated projection of the root document with inferred types: [object])
+}
+
+add a single field:
+table {
+	1: key: required string (auto-generated projection of JSON at: /key with inferred types: [string])
+	2: _meta/flow_truncated: required boolean (Flow truncation indicator - Indicates whether any of the materialized values for this row have been truncated to make them fit inside the limitations of the destination system. - auto-generated projection of JSON at: /_meta/flow_truncated with inferred types: [boolean])
+	3: flow_published_at: required timestamptz (Flow Publication Time - Flow publication date-time of this document - auto-generated projection of JSON at: /_meta/uuid with inferred types: [string])
+	4: optionalboolean: optional boolean (auto-generated projection of JSON at: /optionalBoolean with inferred types: [boolean])
+	5: optionalinteger: optional long (auto-generated projection of JSON at: /optionalInteger with inferred types: [integer])
+	6: optionalobject: optional string (auto-generated projection of JSON at: /optionalObject with inferred types: [object])
+	7: optionalstring: optional string (auto-generated projection of JSON at: /optionalString with inferred types: [string])
+	8: requiredboolean: required boolean (auto-generated projection of JSON at: /requiredBoolean with inferred types: [boolean])
+	9: requiredinteger: required long (auto-generated projection of JSON at: /requiredInteger with inferred types: [integer])
+	10: requiredobject: required string (auto-generated projection of JSON at: /requiredObject with inferred types: [object])
+	11: requiredstring: required string (auto-generated projection of JSON at: /requiredString with inferred types: [string])
+	12: flow_document: required string (user-provided projection of the root document with inferred types: [object])
+	13: addedoptionalstring: optional string (auto-generated projection of JSON at: /addedOptionalString with inferred types: [string])
+}
+
+remove a single optional field:
+table {
+	1: key: required string (auto-generated projection of JSON at: /key with inferred types: [string])
+	2: _meta/flow_truncated: required boolean (Flow truncation indicator - Indicates whether any of the materialized values for this row have been truncated to make them fit inside the limitations of the destination system. - auto-generated projection of JSON at: /_meta/flow_truncated with inferred types: [boolean])
+	3: flow_published_at: required timestamptz (Flow Publication Time - Flow publication date-time of this document - auto-generated projection of JSON at: /_meta/uuid with inferred types: [string])
+	4: optionalboolean: optional boolean (auto-generated projection of JSON at: /optionalBoolean with inferred types: [boolean])
+	5: optionalinteger: optional long (auto-generated projection of JSON at: /optionalInteger with inferred types: [integer])
+	6: optionalobject: optional string (auto-generated projection of JSON at: /optionalObject with inferred types: [object])
+	7: optionalstring: optional string (auto-generated projection of JSON at: /optionalString with inferred types: [string])
+	8: requiredboolean: required boolean (auto-generated projection of JSON at: /requiredBoolean with inferred types: [boolean])
+	9: requiredinteger: required long (auto-generated projection of JSON at: /requiredInteger with inferred types: [integer])
+	10: requiredobject: required string (auto-generated projection of JSON at: /requiredObject with inferred types: [object])
+	11: requiredstring: required string (auto-generated projection of JSON at: /requiredString with inferred types: [string])
+	12: flow_document: required string (user-provided projection of the root document with inferred types: [object])
+}
+
+remove a single required field:
+table {
+	1: key: required string (auto-generated projection of JSON at: /key with inferred types: [string])
+	2: _meta/flow_truncated: required boolean (Flow truncation indicator - Indicates whether any of the materialized values for this row have been truncated to make them fit inside the limitations of the destination system. - auto-generated projection of JSON at: /_meta/flow_truncated with inferred types: [boolean])
+	3: flow_published_at: required timestamptz (Flow Publication Time - Flow publication date-time of this document - auto-generated projection of JSON at: /_meta/uuid with inferred types: [string])
+	4: optionalboolean: optional boolean (auto-generated projection of JSON at: /optionalBoolean with inferred types: [boolean])
+	5: optionalinteger: optional long (auto-generated projection of JSON at: /optionalInteger with inferred types: [integer])
+	6: optionalobject: optional string (auto-generated projection of JSON at: /optionalObject with inferred types: [object])
+	7: optionalstring: optional string (auto-generated projection of JSON at: /optionalString with inferred types: [string])
+	8: requiredboolean: required boolean (auto-generated projection of JSON at: /requiredBoolean with inferred types: [boolean])
+	9: requiredinteger: required long (auto-generated projection of JSON at: /requiredInteger with inferred types: [integer])
+	10: requiredobject: required string (auto-generated projection of JSON at: /requiredObject with inferred types: [object])
+	11: requiredstring: optional string (auto-generated projection of JSON at: /requiredString with inferred types: [string])
+	12: flow_document: required string (user-provided projection of the root document with inferred types: [object])
+}
+
+add and remove many fields:
+table {
+	1: key: required string (auto-generated projection of JSON at: /key with inferred types: [string])
+	2: _meta/flow_truncated: required boolean (Flow truncation indicator - Indicates whether any of the materialized values for this row have been truncated to make them fit inside the limitations of the destination system. - auto-generated projection of JSON at: /_meta/flow_truncated with inferred types: [boolean])
+	3: flow_published_at: required timestamptz (Flow Publication Time - Flow publication date-time of this document - auto-generated projection of JSON at: /_meta/uuid with inferred types: [string])
+	4: optionalboolean: optional boolean (auto-generated projection of JSON at: /optionalBoolean with inferred types: [boolean])
+	5: optionalinteger: optional long (auto-generated projection of JSON at: /optionalInteger with inferred types: [integer])
+	6: optionalobject: optional string (auto-generated projection of JSON at: /optionalObject with inferred types: [object])
+	7: optionalstring: optional string (auto-generated projection of JSON at: /optionalString with inferred types: [string])
+	8: requiredboolean: required boolean (auto-generated projection of JSON at: /requiredBoolean with inferred types: [boolean])
+	9: requiredinteger: required long (auto-generated projection of JSON at: /requiredInteger with inferred types: [integer])
+	10: requiredobject: optional string (auto-generated projection of JSON at: /requiredObject with inferred types: [object])
+	11: requiredstring: optional string (auto-generated projection of JSON at: /requiredString with inferred types: [string])
+	12: flow_document: required string (user-provided projection of the root document with inferred types: [object])
+	13: addedoptionalstring: optional string (auto-generated projection of JSON at: /addedOptionalString with inferred types: [string])
+	14: addedrequiredstring: required string (auto-generated projection of JSON at: /addedRequiredString with inferred types: [string])
+}
+
+Challenging Field Names Materialized Columns:
+table {
+	1:  ,;{}().- problematickey � 𐀀 嶲 : required string (auto-generated projection of JSON at: / ,;{}().- problematicKey � 𐀀 嶲  with inferred types: [string])
+	2: _id: required string (auto-generated projection of JSON at: /_id with inferred types: [string])
+	3:  ,;{}().- problematicvalue � 𐀀 嶲 : optional string (auto-generated projection of JSON at: / ,;{}().- problematicValue � 𐀀 嶲  with inferred types: [string])
+	4: $dollar$signs: optional string (auto-generated projection of JSON at: /$dollar$signs with inferred types: [string])
+	5: 123: optional string (auto-generated projection of JSON at: /123 with inferred types: [string])
+	6: 123startswithdigits: optional string (auto-generated projection of JSON at: /123startsWithDigits with inferred types: [string])
+	7: a"string`with`quote'characters: optional string (auto-generated projection of JSON at: /a"string`with`quote'characters with inferred types: [string])
+	8: flow_published_at: required timestamptz (Flow Publication Time - Flow publication date-time of this document - auto-generated projection of JSON at: /_meta/uuid with inferred types: [string])
+	9: value with separated words: optional string (auto-generated projection of JSON at: /value with separated words with inferred types: [string])
+	10: value-with-separated-words: optional string (auto-generated projection of JSON at: /value-with-separated-words with inferred types: [string])
+	11: value.with-separated_words: optional string (auto-generated projection of JSON at: /value.with-separated_words with inferred types: [string])
+	12: value.with.separated.words: optional string (auto-generated projection of JSON at: /value.with.separated.words with inferred types: [string])
+	13: value_with_separated_words: optional string (auto-generated projection of JSON at: /value_with_separated_words with inferred types: [string])
+	14: flow_document: required string (auto-generated projection of the root document with inferred types: [object])
+}
+

--- a/materialize-iceberg/config.go
+++ b/materialize-iceberg/config.go
@@ -35,6 +35,12 @@ type config struct {
 	Compute               computeConfig              `json:"compute"`
 	Schedule              boilerplate.ScheduleConfig `json:"syncSchedule,omitempty" jsonschema:"title=Sync Schedule,description=Configure schedule of transactions for the materialization."`
 	DBTJobTrigger         dbt.JobConfig              `json:"dbt_job_trigger,omitempty" jsonschema:"title=dbt Cloud Job Trigger,description=Trigger a dbt Job when new data is available"`
+
+	Advanced advancedConfig `json:"advanced,omitempty" jsonschema:"title=Advanced Options,description=Options for advanced users. You should not typically need to modify these." jsonschema_extra:"advanced=true"`
+}
+
+type advancedConfig struct {
+	LowercaseColumnNames bool `json:"lowercase_column_names,omitempty" jsonschema:"title=Lowercase Column Names,description=Create all columns with lowercase names. This is necessary for compatibility with some systems such as querying S3 Table Buckets with Athena."`
 }
 
 func (c config) Validate() error {

--- a/materialize-iceberg/sqlgen_test.go
+++ b/materialize-iceberg/sqlgen_test.go
@@ -23,19 +23,19 @@ func TestTemplates(t *testing.T) {
 	}
 
 	keys := []boilerplate.MappedProjection[mapped]{
-		{Projection: makeProjection("first-key"), Mapped: mapped{iceberg.StringType{}}},
-		{Projection: makeProjection("second-key"), Mapped: mapped{iceberg.BinaryType{}}},
-		{Projection: makeProjection("third-key"), Mapped: mapped{iceberg.Int64Type{}}},
+		{Projection: makeProjection("first-key"), Mapped: mapped{iceberg.StringType{}, "first-key"}},
+		{Projection: makeProjection("second-key"), Mapped: mapped{iceberg.BinaryType{}, "second-key"}},
+		{Projection: makeProjection("third-key"), Mapped: mapped{iceberg.Int64Type{}, "third-key"}},
 	}
 
 	values := []boilerplate.MappedProjection[mapped]{
-		{Projection: makeProjection("first-val"), Mapped: mapped{iceberg.StringType{}}},
-		{Projection: makeProjection("second-val"), Mapped: mapped{iceberg.StringType{}}},
-		{Projection: makeProjection("third-val"), Mapped: mapped{iceberg.BinaryType{}}},
-		{Projection: makeProjection("fourth-val"), Mapped: mapped{iceberg.StringType{}}},
+		{Projection: makeProjection("first-val"), Mapped: mapped{iceberg.StringType{}, "first-val"}},
+		{Projection: makeProjection("second-val"), Mapped: mapped{iceberg.StringType{}, "second-val"}},
+		{Projection: makeProjection("third-val"), Mapped: mapped{iceberg.BinaryType{}, "third-val"}},
+		{Projection: makeProjection("fourth-val"), Mapped: mapped{iceberg.StringType{}, "fourth-val"}},
 	}
 
-	doc := &boilerplate.MappedProjection[mapped]{Projection: makeProjection("flow_document"), Mapped: mapped{iceberg.StringType{}}}
+	doc := &boilerplate.MappedProjection[mapped]{Projection: makeProjection("flow_document"), Mapped: mapped{iceberg.StringType{}, "flow_document"}}
 
 	input := templateInput{
 		binding: binding{
@@ -70,17 +70,17 @@ func TestTemplates(t *testing.T) {
 		ResourcePath: []string{"some", "table"},
 		Migrations: []migrateColumn{
 			{
-				Field:      "long_to_decimal",
+				Name:       "long_to_decimal",
 				FromType:   "long",
 				TargetType: iceberg.DecimalTypeOf(38, 0),
 			},
 			{
-				Field:      "datetime_to_string",
+				Name:       "datetime_to_string",
 				FromType:   "timestamptz",
 				TargetType: iceberg.StringType{},
 			},
 			{
-				Field:      "binary_to_string",
+				Name:       "binary_to_string",
 				FromType:   "binary",
 				TargetType: iceberg.StringType{},
 			},

--- a/materialize-iceberg/type_mapping_test.go
+++ b/materialize-iceberg/type_mapping_test.go
@@ -44,7 +44,7 @@ func TestComputeSchemas(t *testing.T) {
 				},
 				MustExist: mustExist,
 			},
-			Mapped: mapped{type_: type_},
+			Mapped: mapped{type_: type_, Name: field},
 		}
 	}
 


### PR DESCRIPTION
**Description:**

Querying S3 table bucket tables with Athena doesn't work unless all the column names are lowercase. This seems pretty dumb and hopefully AWS fixes that eventually, but for now we have to accommodate it since that is a pretty obvious use case if you are using S3 tables.

We already had the general restriction that column names that differed only in caps weren't allowed since Glue etc. don't like that, so adding this option is too disruptive.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

The docs will need updated for this new config option, and should mention something about it in the section about S3 table buckets.

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2713)
<!-- Reviewable:end -->
