### PR TITLE
source-mysql: Only EXPLAIN, don't ANALYZE queries

### DIFF
--- a/source-mysql/backfill.go
+++ b/source-mysql/backfill.go
@@ -207,20 +207,14 @@ func (db *mysqlDatabase) explainQuery(streamID, query string, args []interface{}
 	}
 	db.explained[streamID] = struct{}{}
 
-	// Ask the database to analyze the backfill query.
-	// ANALYZE is not universally supported, so try a few forms.
-	var explainResult, err = db.conn.Execute("ANALYZE "+query, args...)
-	if err != nil {
-		explainResult, err = db.conn.Execute("EXPLAIN ANALYZE "+query, args...)
-	}
-	if err != nil {
-		explainResult, err = db.conn.Execute("EXPLAIN "+query, args...)
-	}
+	// Ask the database to explain the backfill query execution plan.
+	var explainResult, err = db.conn.Execute("EXPLAIN "+query, args...)
 	if err != nil {
 		logrus.WithFields(logrus.Fields{
 			"query": query,
+			"args":  args,
 			"err":   err,
-		}).Warn("unable to explain query")
+		}).Warn("failed to explain query")
 		return
 	}
 	defer explainResult.Close()


### PR DESCRIPTION
**Description:**

Sometimes our backfill queries will be rather slow, for instance when we're doing a keyless backfill and we've reached a significant offset already. Running `EXPLAIN ANALYZE` asks the database to run the query and discard the result, which effectively means that the first query will be twice as slow. And in general we're not reading the explain output unless something's gone wrong, and even when we do a normal `EXPLAIN` is sufficient to answer questions like "is an index being used".

Also as a practical matter, the EXPLAIN query is currently subject to the default one-minute timeout we apply to non-backfill queries, and there appears to be something going wrong when we try to run a subsequent query after one has timed out (which in theory should work, but empirically it clearly isn't), which means that if a backfill query would take >1m to execute then the `EXPLAIN ANALYZE` fails and then our subsequent actual backfill query fails too. We could fix that by extending the timeout for explain queries, but as previously noted we probably shouldn't be using `ANALYZE` any- way.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2714)
<!-- Reviewable:end -->
