### PR TITLE
Wb/md revert

### DIFF
--- a/materialize-boilerplate/stream-encode/csv.go
+++ b/materialize-boilerplate/stream-encode/csv.go
@@ -136,6 +136,8 @@ func (w *csvWriter) writeRow(row []any) error {
 			w.buf = strconv.AppendInt(w.buf, value, 10)
 		case int:
 			w.buf = strconv.AppendInt(w.buf, int64(value), 10)
+		case uint64:
+			w.buf = strconv.AppendUint(w.buf, value, 10)
 		case float64:
 			w.buf = strconv.AppendFloat(w.buf, value, 'f', -1, 64)
 		case float32:


### PR DESCRIPTION
**Description:**

Reverts a recent speculative addition to materialize-motherduck that was intended to prevent intermittent crashes due to missing credentials - it didn't end up working, so back to the drawing board.

Also a tiny unrelated fix to the CSV writer to make it correctly handle uint64 values received from the runtime.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2715)
<!-- Reviewable:end -->
