### PR TITLE
source-{cdk connectors}: remove duplicate `HTTPMixin` from `Connector`

### DIFF
--- a/source-braintree-native/source_braintree_native/__init__.py
+++ b/source-braintree-native/source_braintree_native/__init__.py
@@ -12,7 +12,6 @@ from estuary_cdk.capture import (
     request,
     response,
 )
-from estuary_cdk.http import HTTPMixin
 
 from .resources import all_resources, validate_credentials
 from .models import (
@@ -24,7 +23,6 @@ from .models import (
 
 class Connector(
     BaseCaptureConnector[EndpointConfig, ResourceConfigWithSchedule, ConnectorState],
-    HTTPMixin,
 ):
     def request_class(self):
         return Request[EndpointConfig, ResourceConfigWithSchedule, ConnectorState]

--- a/source-chargebee-native/source_chargebee_native/__init__.py
+++ b/source-chargebee-native/source_chargebee_native/__init__.py
@@ -13,7 +13,6 @@ from estuary_cdk.capture import (
     response,
 )
 from estuary_cdk.capture.common import ResourceConfig
-from estuary_cdk.http import HTTPMixin
 from estuary_cdk.flow import ValidationError
 
 from source_chargebee_native.resources import all_resources, validate_credentials_and_configuration
@@ -25,7 +24,6 @@ from source_chargebee_native.models import (
 
 class Connector(
     BaseCaptureConnector[EndpointConfig, ResourceConfig, ConnectorState],
-    HTTPMixin,
 ):
     def request_class(self):
         return Request[EndpointConfig, ResourceConfig, ConnectorState]

--- a/source-front/source_front/__init__.py
+++ b/source-front/source_front/__init__.py
@@ -12,7 +12,6 @@ from estuary_cdk.capture import (
     request,
     response,
 )
-from estuary_cdk.http import HTTPMixin
 
 from .resources import all_resources, validate_credentials
 from .models import (
@@ -24,7 +23,6 @@ from .models import (
 
 class Connector(
     BaseCaptureConnector[EndpointConfig, ResourceConfig, ConnectorState],
-    HTTPMixin,
 ):
     def request_class(self):
         return Request[EndpointConfig, ResourceConfig, ConnectorState]

--- a/source-gainsight-nxt/source_gainsight_nxt/__init__.py
+++ b/source-gainsight-nxt/source_gainsight_nxt/__init__.py
@@ -13,7 +13,6 @@ from estuary_cdk.capture import (
     response,
 )
 from estuary_cdk.capture.common import ResourceConfig
-from estuary_cdk.http import HTTPMixin
 
 from source_gainsight_nxt.resources import all_resources, validate_credentials
 from source_gainsight_nxt.models import (
@@ -24,7 +23,6 @@ from source_gainsight_nxt.models import (
 
 class Connector(
     BaseCaptureConnector[EndpointConfig, ResourceConfig, ConnectorState],
-    HTTPMixin,
 ):
     def request_class(self):
         return Request[EndpointConfig, ResourceConfig, ConnectorState]

--- a/source-genesys/source_genesys/__init__.py
+++ b/source-genesys/source_genesys/__init__.py
@@ -12,7 +12,6 @@ from estuary_cdk.capture import (
     request,
     response,
 )
-from estuary_cdk.http import HTTPMixin
 
 from .resources import all_resources, validate_credentials
 from .models import (
@@ -24,7 +23,6 @@ from .models import (
 
 class Connector(
     BaseCaptureConnector[EndpointConfig, ResourceConfig, ConnectorState],
-    HTTPMixin,
 ):
     def request_class(self):
         return Request[EndpointConfig, ResourceConfig, ConnectorState]

--- a/source-gladly/source_gladly/__init__.py
+++ b/source-gladly/source_gladly/__init__.py
@@ -12,7 +12,6 @@ from estuary_cdk.capture import (
     request,
     response,
 )
-from estuary_cdk.http import HTTPMixin
 
 from .resources import all_resources
 from .models import (
@@ -24,7 +23,6 @@ from .models import (
 
 class Connector(
     BaseCaptureConnector[EndpointConfig, ResourceConfig, ConnectorState],
-    HTTPMixin,
 ):
     def request_class(self):
         return Request[EndpointConfig, ResourceConfig, ConnectorState]

--- a/source-google-analytics-data-api-native/source_google_analytics_data_api_native/__init__.py
+++ b/source-google-analytics-data-api-native/source_google_analytics_data_api_native/__init__.py
@@ -12,7 +12,6 @@ from estuary_cdk.capture import (
     request,
     response,
 )
-from estuary_cdk.http import HTTPMixin
 
 from .resources import all_resources, validate_config, validate_custom_reports_json
 from .models import (
@@ -25,7 +24,6 @@ from .models import (
 
 class Connector(
     BaseCaptureConnector[EndpointConfig, ResourceConfig, ConnectorState],
-    HTTPMixin,
 ):
     def request_class(self):
         return Request[EndpointConfig, ResourceConfig, ConnectorState]

--- a/source-google-sheets-native/source_google_sheets_native/__init__.py
+++ b/source-google-sheets-native/source_google_sheets_native/__init__.py
@@ -12,7 +12,6 @@ from estuary_cdk.capture import (
     request,
     response,
 )
-from estuary_cdk.http import HTTPMixin
 
 from .resources import all_resources
 from .models import (
@@ -25,7 +24,6 @@ from .models import (
 
 class Connector(
     BaseCaptureConnector[EndpointConfig, ResourceConfig, ConnectorState],
-    HTTPMixin,
 ):
     def request_class(self):
         return Request[EndpointConfig, ResourceConfig, ConnectorState]

--- a/source-hubspot-native/source_hubspot_native/__init__.py
+++ b/source-hubspot-native/source_hubspot_native/__init__.py
@@ -10,7 +10,6 @@ from estuary_cdk.capture import (
     request,
     response,
 )
-from estuary_cdk.http import HTTPMixin
 
 from .resources import all_resources
 from .models import (
@@ -23,7 +22,6 @@ from .models import (
 
 class Connector(
     BaseCaptureConnector[EndpointConfig, ResourceConfig, ConnectorState],
-    HTTPMixin,
 ):
     def request_class(self):
         return Request[EndpointConfig, ResourceConfig, ConnectorState]

--- a/source-impact-native/source_impact_native/__init__.py
+++ b/source-impact-native/source_impact_native/__init__.py
@@ -10,7 +10,6 @@ from estuary_cdk.capture import (
     request,
     response,
 )
-from estuary_cdk.http import HTTPMixin
 
 from .resources import all_resources
 from .models import (
@@ -22,7 +21,6 @@ from .models import (
 
 class Connector(
     BaseCaptureConnector[EndpointConfig, ResourceConfig, ConnectorState],
-    HTTPMixin,
 ):
     def request_class(self):
         return Request[EndpointConfig, ResourceConfig, ConnectorState]

--- a/source-intercom-native/source_intercom_native/__init__.py
+++ b/source-intercom-native/source_intercom_native/__init__.py
@@ -12,7 +12,6 @@ from estuary_cdk.capture import (
     request,
     response,
 )
-from estuary_cdk.http import HTTPMixin
 
 from .resources import all_resources, validate_credentials
 from .models import (
@@ -25,7 +24,6 @@ from .models import (
 
 class Connector(
     BaseCaptureConnector[EndpointConfig, ResourceConfig, ConnectorState],
-    HTTPMixin,
 ):
     def request_class(self):
         return Request[EndpointConfig, ResourceConfig, ConnectorState]

--- a/source-iterate/source_iterate/__init__.py
+++ b/source-iterate/source_iterate/__init__.py
@@ -12,7 +12,6 @@ from estuary_cdk.capture import (
     request,
     response,
 )
-from estuary_cdk.http import HTTPMixin
 
 from .resources import all_resources, validate_credentials
 from .models import (
@@ -24,7 +23,6 @@ from .models import (
 
 class Connector(
     BaseCaptureConnector[EndpointConfig, ResourceConfig, ConnectorState],
-    HTTPMixin,
 ):
     def request_class(self):
         return Request[EndpointConfig, ResourceConfig, ConnectorState]

--- a/source-monday/source_monday/__init__.py
+++ b/source-monday/source_monday/__init__.py
@@ -13,7 +13,6 @@ from estuary_cdk.capture.common import ResourceConfig
 from estuary_cdk.flow import (
     ConnectorSpec,
 )
-from estuary_cdk.http import HTTPMixin
 
 from source_monday.models import ConnectorState, EndpointConfig
 from source_monday.resources import all_resources, validate_credentials
@@ -21,7 +20,6 @@ from source_monday.resources import all_resources, validate_credentials
 
 class Connector(
     BaseCaptureConnector[EndpointConfig, ResourceConfig, ConnectorState],
-    HTTPMixin,
 ):
     def request_class(self):
         return Request[EndpointConfig, ResourceConfig, ConnectorState]

--- a/source-oracle-flashback/source_oracle_flashback/__init__.py
+++ b/source-oracle-flashback/source_oracle_flashback/__init__.py
@@ -11,7 +11,6 @@ from estuary_cdk.capture import (
     request,
     response,
 )
-from estuary_cdk.http import HTTPMixin
 
 from .ssh_tunnel import ssh_tunnel
 
@@ -37,7 +36,6 @@ from .models import (
 
 class Connector(
     BaseCaptureConnector[EndpointConfig, ResourceConfig, ConnectorState],
-    HTTPMixin,
 ):
     def request_class(self):
         return Request[EndpointConfig, ResourceConfig, ConnectorState]

--- a/source-pendo/source_pendo/__init__.py
+++ b/source-pendo/source_pendo/__init__.py
@@ -12,7 +12,6 @@ from estuary_cdk.capture import (
     request,
     response,
 )
-from estuary_cdk.http import HTTPMixin
 
 from .resources import all_resources, validate_api_key
 from .models import (
@@ -24,7 +23,6 @@ from .models import (
 
 class Connector(
     BaseCaptureConnector[EndpointConfig, ResourceConfig, ConnectorState],
-    HTTPMixin,
 ):
     def request_class(self):
         return Request[EndpointConfig, ResourceConfig, ConnectorState]

--- a/source-salesforce-native/source_salesforce_native/__init__.py
+++ b/source-salesforce-native/source_salesforce_native/__init__.py
@@ -12,7 +12,6 @@ from estuary_cdk.capture import (
     request,
     response,
 )
-from estuary_cdk.http import HTTPMixin
 
 from .resources import all_resources, enabled_resources
 from .models import (
@@ -25,7 +24,6 @@ from .models import (
 
 class Connector(
     BaseCaptureConnector[EndpointConfig, SalesforceResourceConfigWithSchedule, ConnectorState],
-    HTTPMixin,
 ):
     def request_class(self):
         return Request[EndpointConfig, SalesforceResourceConfigWithSchedule, ConnectorState]

--- a/source-shopify-native/source_shopify_native/__init__.py
+++ b/source-shopify-native/source_shopify_native/__init__.py
@@ -12,7 +12,6 @@ from estuary_cdk.capture import (
     request,
     response,
 )
-from estuary_cdk.http import HTTPMixin
 
 from .resources import all_resources, validate_credentials
 from .models import (
@@ -25,7 +24,6 @@ from .models import (
 
 class Connector(
     BaseCaptureConnector[EndpointConfig, ResourceConfig, ConnectorState],
-    HTTPMixin,
 ):
     def request_class(self):
         return Request[EndpointConfig, ResourceConfig, ConnectorState]

--- a/source-stripe-native/source_stripe_native/__init__.py
+++ b/source-stripe-native/source_stripe_native/__init__.py
@@ -11,7 +11,6 @@ from estuary_cdk.capture import (
     response,
 )
 from estuary_cdk.capture.common import ResourceConfig
-from estuary_cdk.http import HTTPMixin
 from estuary_cdk.flow import ValidationError
 
 from .resources import all_resources
@@ -23,7 +22,6 @@ from .models import (
 
 class Connector(
     BaseCaptureConnector[EndpointConfig, ResourceConfig, ConnectorState],
-    HTTPMixin,
 ):
     def request_class(self):
         return Request[EndpointConfig, ResourceConfig, ConnectorState]

--- a/source-zendesk-support-native/source_zendesk_support_native/__init__.py
+++ b/source-zendesk-support-native/source_zendesk_support_native/__init__.py
@@ -12,7 +12,6 @@ from estuary_cdk.capture import (
     request,
     response,
 )
-from estuary_cdk.http import HTTPMixin
 
 from .resources import all_resources, validate_credentials
 from .models import (
@@ -25,7 +24,6 @@ from .models import (
 
 class Connector(
     BaseCaptureConnector[EndpointConfig, ResourceConfig, ConnectorState],
-    HTTPMixin,
 ):
     def request_class(self):
         return Request[EndpointConfig, ResourceConfig, ConnectorState]


### PR DESCRIPTION
When I made the CDK's `BaseCaptureConnector` mixin `HTTPMixin` in https://github.com/estuary/connectors/pull/2699, I missed removing the duplicate `HTTPMixin` for the individual connectors inheriting from `BaseCaptureConnector`. This is causing those connectors to log errors like `Unclosed client session client_session: <aiohttp.client.ClientSession object at 0x75a0c8534710>` since we're entering the `HTTPMixin` twice, creating a second client session, and never closing it.

This commit removes the duplicate `HTTPMixin` from CDK connectors that are logging that error.

**Description:**

(Describe the high level scope of new or changed features)

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2718)
<!-- Reviewable:end -->
