### PR TITLE
source-google-analytics-data-api-native: validate dimension and metric counts in custom reports

### DIFF
--- a/source-google-analytics-data-api-native/source_google_analytics_data_api_native/models.py
+++ b/source-google-analytics-data-api-native/source_google_analytics_data_api_native/models.py
@@ -118,8 +118,8 @@ class MetricAggregation(StrEnum):
 # Report represents a valid configured report stream.
 class Report(BaseModel, extra="forbid"):
     name: str
-    dimensions: Annotated[list[str], MinLen(1)]
-    metrics: Annotated[list[str], MinLen(1)]
+    dimensions: list[str]
+    metrics: list[str]
     # TODO(bair): Improve validation of dimensionFilters and metricFilters.
     # Valid variations of these fields are described here: https://developers.google.com/analytics/devguides/reporting/data/v1/rest/v1beta/FilterExpression.
     dimensionFilter: Optional[dict[str, Any]] = None

--- a/source-google-analytics-data-api-native/source_google_analytics_data_api_native/resources.py
+++ b/source-google-analytics-data-api-native/source_google_analytics_data_api_native/resources.py
@@ -36,7 +36,8 @@ from .default_reports import DEFAULT_REPORTS
 
 VALID_DIMENSIONS_DOCS_URL = "https://developers.google.com/analytics/devguides/reporting/data/v1/api-schema#dimensions"
 VALID_METRICS_DOCS_URL = "https://developers.google.com/analytics/devguides/reporting/data/v1/api-schema#metrics"
-
+MAX_DIMESIONS_COUNT = 9
+MAX_METRICS_COUNT = 10
 
 async def _validate_credentials(
     log: Logger, http: HTTPMixin, config: EndpointConfig
@@ -99,9 +100,21 @@ async def validate_custom_reports_json(
             if model.name in default_report_names:
                 errors.append(f'Custom report name "{model.name}" already exists as a default report. Please rename the custom report.')
 
+            dimensions_count = len(model.dimensions)
+            if dimensions_count == 0:
+                errors.append(f'Report "{model.name}" has 0 dimensions. Reports must contain between 1 - {MAX_DIMESIONS_COUNT} dimensions.')
+            elif dimensions_count > MAX_DIMESIONS_COUNT:
+                errors.append(f'Report "{model.name}" has {dimensions_count} dimensions. There can only be up to {MAX_DIMESIONS_COUNT} dimensions per report.')
+
             for dimension in model.dimensions:
                 if dimension not in valid_dimensions:
                     errors.append(f'"{dimension}" in report "{model.name}" is not a valid dimension. Consult {VALID_DIMENSIONS_DOCS_URL} for a list of valid dimensions.')
+
+            metrics_count = len(model.metrics)
+            if metrics_count == 0:
+                errors.append(f'Report "{model.name}" has 0 metrics. Reports must contain between 1 - {MAX_METRICS_COUNT} metrics.')
+            elif metrics_count > MAX_METRICS_COUNT:
+                errors.append(f'Report "{model.name}" has {metrics_count} metrics. There can only be up to {MAX_METRICS_COUNT} dimensions per report.')
 
             for metric in model.metrics:
                 if metric not in valid_metrics:


### PR DESCRIPTION
**Description:**

Google enforces that reports have between 1 - 9 dimensions and between 1 - 10 metrics. This PR improves our validation of custom reports to also enforce those limitations & print out a clear error message if a custom report has too few/too many dimensions or metrics.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

The custom reports section of the connector docs should be updated to mention that there must be between 1-9 dimensions and 1-10 metrics for custom reports.

**Notes for reviewers:**

Tested input validation on a local stack. Confirmed trying to use a custom report with too few/too many dimensions or metrics raises a validation error with clear error messages.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2719)
<!-- Reviewable:end -->
