### PR TITLE
materializations: handle transitions for bindings that are being re-enabled

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,7 @@ require (
 	github.com/databricks/databricks-sql-go v1.6.2-0.20250318155202-2a39cfaf0c27
 	github.com/dropbox/dropbox-sdk-go-unofficial/v6 v6.0.5
 	github.com/elastic/go-elasticsearch/v8 v8.9.0
-	github.com/estuary/flow v0.5.9
+	github.com/estuary/flow v0.5.11
 	github.com/estuary/vitess v0.15.10
 	github.com/evanphx/json-patch/v5 v5.9.0
 	github.com/firebolt-db/firebolt-go-sdk v1.2.0
@@ -69,7 +69,7 @@ require (
 	github.com/wk8/go-ordered-map/v2 v2.1.8
 	github.com/xitongsys/parquet-go v1.6.2
 	github.com/xitongsys/parquet-go-source v0.0.0-20220527110425-ba4adb87a31b
-	go.gazette.dev/core v0.100.0
+	go.gazette.dev/core v0.100.1-0.20250207175303-fa8573fb50d6
 	go.mongodb.org/mongo-driver v1.16.1
 	golang.org/x/crypto v0.36.0
 	golang.org/x/exp v0.0.0-20250305212735-054e65f0b394

--- a/go.sum
+++ b/go.sum
@@ -388,6 +388,8 @@ github.com/envoyproxy/protoc-gen-validate v1.2.1 h1:DEo3O99U8j4hBFwbJfrz9VtgcDfU
 github.com/envoyproxy/protoc-gen-validate v1.2.1/go.mod h1:d/C80l/jxXLdfEIhX1W2TmLfsJ31lvEjwamM4DxlWXU=
 github.com/estuary/flow v0.5.9 h1:AhZ/gomj9avI5zQ9T8OTMQfWTPRDsipMMHIMpp5i3GA=
 github.com/estuary/flow v0.5.9/go.mod h1:fRYaE62AKCeBcthEs+M+Ofc9L7AQdRaNKjES3+tFziM=
+github.com/estuary/flow v0.5.11 h1:eDvDEt63OALMawF+IvkRq9nQ2H0TW+jMcIGKwEAXNac=
+github.com/estuary/flow v0.5.11/go.mod h1:8dGk6U3BB/GP2ODc976mqZSHFF6AlmdsQNYO1O9cpPc=
 github.com/estuary/vitess v0.15.10 h1:oXJgcG0HGZWuwjdvSp4pIFIAXtKLaR9Fl9VBynSszFA=
 github.com/estuary/vitess v0.15.10/go.mod h1:rSIE8UMfexjblBloleGw6BqQIKggGmU91TduCNIaJEA=
 github.com/evanphx/json-patch/v5 v5.9.0 h1:kcBlZQbplgElYIlo/n1hJbls2z/1awpXxpRi0/FOJfg=
@@ -1026,6 +1028,8 @@ go.etcd.io/etcd/client/v3 v3.5.17 h1:o48sINNeWz5+pjy/Z0+HKpj/xSnBkuVhVvXkjEXbqZY
 go.etcd.io/etcd/client/v3 v3.5.17/go.mod h1:j2d4eXTHWkT2ClBgnnEPm/Wuu7jsqku41v9DZ3OtjQo=
 go.gazette.dev/core v0.100.0 h1:lOSwhWIuZhYZ+br/4LN/osEfP6yQ+J1qM8pxuXmoD0I=
 go.gazette.dev/core v0.100.0/go.mod h1:1rj+daAL/cy+dt9XZGzsLBJl5BeLkeCiRmlcHaSCH/I=
+go.gazette.dev/core v0.100.1-0.20250207175303-fa8573fb50d6 h1:Qp/RmeWjMLFhTgCnV8Uf/zRC1/biWLoQ7s5FFckuimg=
+go.gazette.dev/core v0.100.1-0.20250207175303-fa8573fb50d6/go.mod h1:sMIAhwRUE9i9kk1tUrifv/tDDEC3dqx3GtvAiaBeHu4=
 go.mongodb.org/mongo-driver v1.16.1 h1:rIVLL3q0IHM39dvE+z2ulZLp9ENZKThVfuvN/IiN4l8=
 go.mongodb.org/mongo-driver v1.16.1/go.mod h1:oB6AhJQvFQL4LEHyXi6aJzQJtBiTQHiAd83l0GdFaiw=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=

--- a/materialize-azure-fabric-warehouse/.snapshots/TestValidateAndApply
+++ b/materialize-azure-fabric-warehouse/.snapshots/TestValidateAndApply
@@ -5,7 +5,7 @@ Big Schema Initial Constraints:
 {"Field":"flow_document","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The root document should usually be materialized"}
 {"Field":"flow_published_at","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The projection has a single scalar type"}
 {"Field":"intField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The projection has a single scalar type"}
-{"Field":"key","Type":2,"TypeString":"LOCATION_REQUIRED","Reason":"All Locations that are part of the collections key are required"}
+{"Field":"key","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"All Locations that are part of the collections key are recommended"}
 {"Field":"multipleField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This field is able to be materialized"}
 {"Field":"nullField","Type":5,"TypeString":"FIELD_FORBIDDEN","Reason":"Cannot materialize a field where the only possible type is 'null'"}
 {"Field":"numField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The projection has a single scalar type"}
@@ -198,7 +198,7 @@ Big Schema Changed Types With Table Replacement Constraints:
 {"Field":"flow_document","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The root document should usually be materialized"}
 {"Field":"flow_published_at","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The projection has a single scalar type"}
 {"Field":"intField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The projection has a single scalar type"}
-{"Field":"key","Type":2,"TypeString":"LOCATION_REQUIRED","Reason":"All Locations that are part of the collections key are required"}
+{"Field":"key","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"All Locations that are part of the collections key are recommended"}
 {"Field":"multipleField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This field is able to be materialized"}
 {"Field":"nullField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"Object fields may be materialized"}
 {"Field":"numField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The projection has a single scalar type"}

--- a/materialize-bigquery/.snapshots/TestValidateAndApply
+++ b/materialize-bigquery/.snapshots/TestValidateAndApply
@@ -5,7 +5,7 @@ Big Schema Initial Constraints:
 {"Field":"flow_document","Type":2,"TypeString":"LOCATION_REQUIRED","Reason":"The root document must be materialized"}
 {"Field":"flow_published_at","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The projection has a single scalar type"}
 {"Field":"intField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The projection has a single scalar type"}
-{"Field":"key","Type":2,"TypeString":"LOCATION_REQUIRED","Reason":"All Locations that are part of the collections key are required"}
+{"Field":"key","Type":2,"TypeString":"LOCATION_REQUIRED","Reason":"The first collection key component is required to be included for standard updates"}
 {"Field":"multipleField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This field is able to be materialized"}
 {"Field":"nullField","Type":5,"TypeString":"FIELD_FORBIDDEN","Reason":"Cannot materialize a field where the only possible type is 'null'"}
 {"Field":"numField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The projection has a single scalar type"}
@@ -198,7 +198,7 @@ Big Schema Changed Types With Table Replacement Constraints:
 {"Field":"flow_document","Type":2,"TypeString":"LOCATION_REQUIRED","Reason":"The root document must be materialized"}
 {"Field":"flow_published_at","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The projection has a single scalar type"}
 {"Field":"intField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The projection has a single scalar type"}
-{"Field":"key","Type":2,"TypeString":"LOCATION_REQUIRED","Reason":"All Locations that are part of the collections key are required"}
+{"Field":"key","Type":2,"TypeString":"LOCATION_REQUIRED","Reason":"The first collection key component is required to be included for standard updates"}
 {"Field":"multipleField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This field is able to be materialized"}
 {"Field":"nullField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"Object fields may be materialized"}
 {"Field":"numField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The projection has a single scalar type"}

--- a/materialize-boilerplate/.snapshots/TestApply
+++ b/materialize-boilerplate/.snapshots/TestApply
@@ -14,5 +14,9 @@ create resource for ["extra_collection"]
 delete resource ["key_value"]
 create resource for ["key_value"]
 
+* replace binding disabled -> enabled:
+delete resource ["key_value"]
+create resource for ["key_value"]
+
 * field is newly nullable:
 update resource for ["key_value"] [new projections: 0, newly nullable fields: 1, newly delta updates: false]

--- a/materialize-boilerplate/.snapshots/TestValidate
+++ b/materialize-boilerplate/.snapshots/TestValidate
@@ -110,6 +110,19 @@ increment backfill counter:
 {"Field":"scalarValue","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The projection has a single scalar type"}
 {"Field":"second_root","Type":5,"TypeString":"FIELD_FORBIDDEN","Reason":"Only a single root document projection can be materialized for standard updates"}
 
+increment backfill counter for disabled -> enabled binding:
+{"Field":"_meta/flow_truncated","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The projection has a single scalar type"}
+{"Field":"flow_document","Type":2,"TypeString":"LOCATION_REQUIRED","Reason":"The root document is required for a standard updates materialization"}
+{"Field":"flow_published_at","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The projection has a single scalar type"}
+{"Field":"key","Type":2,"TypeString":"LOCATION_REQUIRED","Reason":"The first collection key component is required to be included for standard updates"}
+{"Field":"multiple","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This field is able to be materialized"}
+{"Field":"nonScalarValue","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This field is able to be materialized"}
+{"Field":"nullValue","Type":5,"TypeString":"FIELD_FORBIDDEN","Reason":"Cannot materialize this field"}
+{"Field":"numericString","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The projection has a single scalar type"}
+{"Field":"optional","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This field is able to be materialized"}
+{"Field":"scalarValue","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The projection has a single scalar type"}
+{"Field":"second_root","Type":5,"TypeString":"FIELD_FORBIDDEN","Reason":"Only a single root document projection can be materialized for standard updates"}
+
 table already exists with identical spec:
 {"Field":"_meta/flow_truncated","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The projection has a single scalar type"}
 {"Field":"flow_document","Type":1,"TypeString":"FIELD_REQUIRED","Reason":"This field is the document in the current materialization"}

--- a/materialize-boilerplate/apply.go
+++ b/materialize-boilerplate/apply.go
@@ -165,7 +165,7 @@ func computeCommonUpdates(last, next *pf.MaterializationSpec, is *InfoSchema) (*
 		// The existing binding spec is used to extract various properties that can't be learned
 		// from introspecting the destination system, such as the backfill counter and if the
 		// materialization was previously delta updates.
-		lastBinding := findExistingBinding(nextBinding.ResourcePath, last)
+		lastBinding := findLastBinding(nextBinding.ResourcePath, last)
 		if existingResource := is.GetResource(nextBinding.ResourcePath); existingResource == nil {
 			// Resource does not yet exist, and must be created.
 			out.newBindings = append(out.newBindings, bindingIdx)

--- a/materialize-boilerplate/apply_test.go
+++ b/materialize-boilerplate/apply_test.go
@@ -79,6 +79,12 @@ func TestApply(t *testing.T) {
 			want:         testResults{deletedResources: 1, createdResources: 1},
 		},
 		{
+			name:         "replace binding disabled -> enabled",
+			originalSpec: specWithBindingsDisabled(loadApplySpec(t, "base.flow.proto")),
+			newSpec:      loadApplySpec(t, "replace-original-binding.flow.proto"),
+			want:         testResults{deletedResources: 1, createdResources: 1},
+		},
+		{
 			name:         "field is newly nullable",
 			originalSpec: loadApplySpec(t, "base.flow.proto"),
 			newSpec:      loadApplySpec(t, "make-nullable.flow.proto"),
@@ -209,11 +215,11 @@ func testInfoSchemaFromSpec(t *testing.T, s *pf.MaterializationSpec, transform f
 
 	is := NewInfoSchema(transformPath, transform)
 
-	if s == nil || len(s.Bindings) == 0 {
+	if s == nil || len(s.Bindings)+len(s.InactiveBindings) == 0 {
 		return is
 	}
 
-	for _, b := range s.Bindings {
+	for _, b := range append(s.Bindings, s.InactiveBindings...) {
 		res := is.PushResource(transformPath(b.ResourcePath)...)
 		for _, f := range b.FieldSelection.AllFields() {
 			proj := *b.Collection.GetProjection(f)

--- a/materialize-boilerplate/validate.go
+++ b/materialize-boilerplate/validate.go
@@ -65,16 +65,16 @@ func (v Validator) ValidateBinding(
 	fieldConfigJsonMap map[string]json.RawMessage,
 	lastSpec *pf.MaterializationSpec,
 ) (map[string]*pm.Response_Validated_Constraint, error) {
-	existingBinding := findExistingBinding(path, lastSpec)
+	lastBinding := findLastBinding(path, lastSpec)
 	existingResource := v.is.GetResource(path)
 
-	if existingBinding != nil && existingBinding.Backfill > backfill {
+	if lastBinding != nil && lastBinding.Backfill > backfill {
 		// Sanity check: Don't allow backfill counters to decrease.
 		return nil, fmt.Errorf(
 			"backfill count %d is less than previously applied count of %d (%s)",
 			backfill,
-			existingBinding.Backfill,
-			existingBinding.Collection.Name,
+			lastBinding.Backfill,
+			lastBinding.Collection.Name,
 		)
 	}
 
@@ -96,7 +96,7 @@ func (v Validator) ValidateBinding(
 
 	var err error
 	var constraints map[string]*pm.Response_Validated_Constraint
-	if existingResource == nil || (existingBinding != nil && backfill != existingBinding.Backfill) {
+	if existingResource == nil || (lastBinding != nil && backfill != lastBinding.Backfill) {
 		// Always validate as a new table if the existing table doesn't exist, since there is no
 		// existing table to be incompatible with. Also validate as a new table if we are going to
 		// be replacing the table.
@@ -104,12 +104,12 @@ func (v Validator) ValidateBinding(
 			return nil, err
 		}
 	} else {
-		if existingBinding != nil && existingBinding.DeltaUpdates && !deltaUpdates {
+		if lastBinding != nil && lastBinding.DeltaUpdates && !deltaUpdates {
 			// We allow a binding to switch from standard => delta updates but not the other
 			// way. This is because a standard materialization is trivially a valid
 			// delta-updates materialization.
 			return nil, fmt.Errorf("changing from delta updates to standard updates is not allowed")
-		} else if constraints, err = v.validateMatchesExistingBinding(*existingResource, existingBinding, boundCollection, deltaUpdates, fieldConfigJsonMap); err != nil {
+		} else if constraints, err = v.validateMatchesExistingResource(*existingResource, lastBinding, boundCollection, deltaUpdates, fieldConfigJsonMap); err != nil {
 			return nil, err
 		}
 	}
@@ -179,9 +179,9 @@ func isOptional(c pm.Response_Validated_Constraint_Type) bool {
 		c == pm.Response_Validated_Constraint_FIELD_OPTIONAL
 }
 
-func (v Validator) validateMatchesExistingBinding(
+func (v Validator) validateMatchesExistingResource(
 	existingResource ExistingResource,
-	existingBinding *pf.MaterializationSpec_Binding,
+	lastBinding *pf.MaterializationSpec_Binding,
 	boundCollection pf.CollectionSpec,
 	deltaUpdates bool,
 	fieldConfigJsonMap map[string]json.RawMessage,
@@ -207,7 +207,7 @@ func (v Validator) validateMatchesExistingBinding(
 			// Only the originally selected root document projection is allowed to be selected for
 			// changes to a standard updates materialization. If there is no previously persisted
 			// spec, the first root document projection is selected as the root document.
-			if (existingBinding != nil && p.Field == existingBinding.FieldSelection.Document) || (existingBinding == nil && len(docFields) == 1) {
+			if (lastBinding != nil && p.Field == lastBinding.FieldSelection.Document) || (lastBinding == nil && len(docFields) == 1) {
 				c = &pm.Response_Validated_Constraint{
 					Type:   pm.Response_Validated_Constraint_FIELD_REQUIRED,
 					Reason: "This field is the document in the current materialization",
@@ -229,8 +229,8 @@ func (v Validator) validateMatchesExistingBinding(
 						"Cannot materialize root document projection '%s' because field '%s' is already being materialized as the document",
 						p.Field,
 						func() string {
-							if existingBinding != nil {
-								return existingBinding.FieldSelection.Document
+							if lastBinding != nil {
+								return lastBinding.FieldSelection.Document
 							} else {
 								return docFields[0]
 							}
@@ -238,7 +238,7 @@ func (v Validator) validateMatchesExistingBinding(
 					),
 				}
 			}
-		} else if !deltaUpdates && p.IsPrimaryKey && existingBinding != nil && !slices.Contains(existingBinding.FieldSelection.Keys, p.Field) {
+		} else if !deltaUpdates && p.IsPrimaryKey && lastBinding != nil && !slices.Contains(lastBinding.FieldSelection.Keys, p.Field) {
 			// Locations that are part of the primary key may not be added without backfilling the binding
 			c = &pm.Response_Validated_Constraint{
 				Type:   pm.Response_Validated_Constraint_FIELD_FORBIDDEN,
@@ -248,7 +248,7 @@ func (v Validator) validateMatchesExistingBinding(
 			// Projections that would result in ambiguous materialized fields are forbidden if a
 			// different ambiguous projection has already been selected, or optional if none have
 			// yet been selected.
-			if existingBinding != nil && slices.Contains(existingBinding.FieldSelection.AllFields(), p.Field) {
+			if lastBinding != nil && slices.Contains(lastBinding.FieldSelection.AllFields(), p.Field) {
 				// This field has already been selected as the ambiguous field to materialize.
 				if existingField := existingResource.GetField(p.Field); existingField != nil {
 					// If the field already exists in the destination, make sure
@@ -262,7 +262,7 @@ func (v Validator) validateMatchesExistingBinding(
 						Reason: "This location is part of the current materialization",
 					}
 				}
-			} else if existingBinding != nil && v.ambiguousFieldIsSelected(p, existingBinding.FieldSelection.AllFields()) {
+			} else if lastBinding != nil && v.ambiguousFieldIsSelected(p, lastBinding.FieldSelection.AllFields()) {
 				// A different field has been selected, so this one can't be.
 				c = &pm.Response_Validated_Constraint{
 					Type: pm.Response_Validated_Constraint_FIELD_FORBIDDEN,
@@ -306,9 +306,9 @@ func (v Validator) validateMatchesExistingBinding(
 		// destination. This is primarily to produce more useful constraints for systems that do
 		// not have "columns" that can be inspected, but still support field selection (ex:
 		// materialize-dynamodb), so that selected fields can continue to be recommended.
-		if existingBinding != nil &&
+		if lastBinding != nil &&
 			c.Type == pm.Response_Validated_Constraint_FIELD_OPTIONAL &&
-			slices.Contains(existingBinding.FieldSelection.AllFields(), p.Field) {
+			slices.Contains(lastBinding.FieldSelection.AllFields(), p.Field) {
 			c = &pm.Response_Validated_Constraint{
 				Type:   pm.Response_Validated_Constraint_LOCATION_RECOMMENDED,
 				Reason: "This location is part of the current materialization",
@@ -318,7 +318,7 @@ func (v Validator) validateMatchesExistingBinding(
 		constraints[p.Field] = c
 	}
 
-	if existingBinding != nil && !deltaUpdates && !slices.Contains(docFields, existingBinding.FieldSelection.Document) {
+	if lastBinding != nil && !deltaUpdates && !slices.Contains(docFields, lastBinding.FieldSelection.Document) {
 		// For standard updates, the proposed binding must still have the original document field
 		// from a prior specification, if that's known. If it doesn't, make sure to fail the build
 		// with a constraint on a root document projection that it does have.
@@ -326,7 +326,7 @@ func (v Validator) validateMatchesExistingBinding(
 			Type: pm.Response_Validated_Constraint_UNSATISFIABLE,
 			Reason: fmt.Sprintf(
 				"The root document must be materialized as field '%s'",
-				existingBinding.FieldSelection.Document,
+				lastBinding.FieldSelection.Document,
 			),
 		}
 	}
@@ -426,8 +426,8 @@ func (v Validator) ambiguousFieldIsSelected(p pf.Projection, fieldSelection []st
 	return false
 }
 
-// findExistingBinding locates a binding within an previously applied or validated specification.
-func findExistingBinding(resourcePath []string, lastSpec *pf.MaterializationSpec) *pf.MaterializationSpec_Binding {
+// findLastBinding locates a binding within an previously applied or validated specification.
+func findLastBinding(resourcePath []string, lastSpec *pf.MaterializationSpec) *pf.MaterializationSpec_Binding {
 	if lastSpec == nil {
 		return nil // Binding is trivially not found
 	}
@@ -436,6 +436,18 @@ func findExistingBinding(resourcePath []string, lastSpec *pf.MaterializationSpec
 			return existingBinding
 		}
 	}
+
+	// For the purposes of Validate and Apply actions, a binding that was
+	// previously disabled should be considered as the "last binding" for
+	// evaluating the current (enabled) binding. This ensures that bindings are
+	// correctly backfilled and invalid configuration transitions are not
+	// allowed, even if the binding was disabled and then is re-enabled.
+	for _, inactiveBinding := range lastSpec.InactiveBindings {
+		if slices.Equal(resourcePath, inactiveBinding.ResourcePath) {
+			return inactiveBinding
+		}
+	}
+
 	return nil
 }
 

--- a/materialize-motherduck/.snapshots/TestValidateAndApply
+++ b/materialize-motherduck/.snapshots/TestValidateAndApply
@@ -5,7 +5,7 @@ Big Schema Initial Constraints:
 {"Field":"flow_document","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The root document should usually be materialized"}
 {"Field":"flow_published_at","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The projection has a single scalar type"}
 {"Field":"intField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The projection has a single scalar type"}
-{"Field":"key","Type":2,"TypeString":"LOCATION_REQUIRED","Reason":"All Locations that are part of the collections key are required"}
+{"Field":"key","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"All Locations that are part of the collections key are recommended"}
 {"Field":"multipleField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This field is able to be materialized"}
 {"Field":"nullField","Type":5,"TypeString":"FIELD_FORBIDDEN","Reason":"Cannot materialize a field where the only possible type is 'null'"}
 {"Field":"numField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The projection has a single scalar type"}
@@ -198,7 +198,7 @@ Big Schema Changed Types With Table Replacement Constraints:
 {"Field":"flow_document","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The root document should usually be materialized"}
 {"Field":"flow_published_at","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The projection has a single scalar type"}
 {"Field":"intField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The projection has a single scalar type"}
-{"Field":"key","Type":2,"TypeString":"LOCATION_REQUIRED","Reason":"All Locations that are part of the collections key are required"}
+{"Field":"key","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"All Locations that are part of the collections key are recommended"}
 {"Field":"multipleField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This field is able to be materialized"}
 {"Field":"nullField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"Object fields may be materialized"}
 {"Field":"numField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The projection has a single scalar type"}

--- a/materialize-mysql/.snapshots/TestValidateAndApply
+++ b/materialize-mysql/.snapshots/TestValidateAndApply
@@ -5,7 +5,7 @@ Big Schema Initial Constraints:
 {"Field":"flow_document","Type":2,"TypeString":"LOCATION_REQUIRED","Reason":"The root document must be materialized"}
 {"Field":"flow_published_at","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The projection has a single scalar type"}
 {"Field":"intField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The projection has a single scalar type"}
-{"Field":"key","Type":2,"TypeString":"LOCATION_REQUIRED","Reason":"All Locations that are part of the collections key are required"}
+{"Field":"key","Type":2,"TypeString":"LOCATION_REQUIRED","Reason":"The first collection key component is required to be included for standard updates"}
 {"Field":"multipleField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This field is able to be materialized"}
 {"Field":"nullField","Type":5,"TypeString":"FIELD_FORBIDDEN","Reason":"Cannot materialize a field where the only possible type is 'null'"}
 {"Field":"numField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The projection has a single scalar type"}
@@ -198,7 +198,7 @@ Big Schema Changed Types With Table Replacement Constraints:
 {"Field":"flow_document","Type":2,"TypeString":"LOCATION_REQUIRED","Reason":"The root document must be materialized"}
 {"Field":"flow_published_at","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The projection has a single scalar type"}
 {"Field":"intField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The projection has a single scalar type"}
-{"Field":"key","Type":2,"TypeString":"LOCATION_REQUIRED","Reason":"All Locations that are part of the collections key are required"}
+{"Field":"key","Type":2,"TypeString":"LOCATION_REQUIRED","Reason":"The first collection key component is required to be included for standard updates"}
 {"Field":"multipleField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This field is able to be materialized"}
 {"Field":"nullField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"Object fields may be materialized"}
 {"Field":"numField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The projection has a single scalar type"}

--- a/materialize-postgres/.snapshots/TestValidateAndApply
+++ b/materialize-postgres/.snapshots/TestValidateAndApply
@@ -5,7 +5,7 @@ Big Schema Initial Constraints:
 {"Field":"flow_document","Type":2,"TypeString":"LOCATION_REQUIRED","Reason":"The root document must be materialized"}
 {"Field":"flow_published_at","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The projection has a single scalar type"}
 {"Field":"intField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The projection has a single scalar type"}
-{"Field":"key","Type":2,"TypeString":"LOCATION_REQUIRED","Reason":"All Locations that are part of the collections key are required"}
+{"Field":"key","Type":2,"TypeString":"LOCATION_REQUIRED","Reason":"The first collection key component is required to be included for standard updates"}
 {"Field":"multipleField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This field is able to be materialized"}
 {"Field":"nullField","Type":5,"TypeString":"FIELD_FORBIDDEN","Reason":"Cannot materialize a field where the only possible type is 'null'"}
 {"Field":"numField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The projection has a single scalar type"}
@@ -198,7 +198,7 @@ Big Schema Changed Types With Table Replacement Constraints:
 {"Field":"flow_document","Type":2,"TypeString":"LOCATION_REQUIRED","Reason":"The root document must be materialized"}
 {"Field":"flow_published_at","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The projection has a single scalar type"}
 {"Field":"intField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The projection has a single scalar type"}
-{"Field":"key","Type":2,"TypeString":"LOCATION_REQUIRED","Reason":"All Locations that are part of the collections key are required"}
+{"Field":"key","Type":2,"TypeString":"LOCATION_REQUIRED","Reason":"The first collection key component is required to be included for standard updates"}
 {"Field":"multipleField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This field is able to be materialized"}
 {"Field":"nullField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"Object fields may be materialized"}
 {"Field":"numField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The projection has a single scalar type"}

--- a/materialize-redshift/.snapshots/TestValidateAndApply
+++ b/materialize-redshift/.snapshots/TestValidateAndApply
@@ -5,7 +5,7 @@ Big Schema Initial Constraints:
 {"Field":"flow_document","Type":2,"TypeString":"LOCATION_REQUIRED","Reason":"The root document must be materialized"}
 {"Field":"flow_published_at","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The projection has a single scalar type"}
 {"Field":"intField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The projection has a single scalar type"}
-{"Field":"key","Type":2,"TypeString":"LOCATION_REQUIRED","Reason":"All Locations that are part of the collections key are required"}
+{"Field":"key","Type":2,"TypeString":"LOCATION_REQUIRED","Reason":"The first collection key component is required to be included for standard updates"}
 {"Field":"multipleField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This field is able to be materialized"}
 {"Field":"nullField","Type":5,"TypeString":"FIELD_FORBIDDEN","Reason":"Cannot materialize a field where the only possible type is 'null'"}
 {"Field":"numField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The projection has a single scalar type"}
@@ -198,7 +198,7 @@ Big Schema Changed Types With Table Replacement Constraints:
 {"Field":"flow_document","Type":2,"TypeString":"LOCATION_REQUIRED","Reason":"The root document must be materialized"}
 {"Field":"flow_published_at","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The projection has a single scalar type"}
 {"Field":"intField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The projection has a single scalar type"}
-{"Field":"key","Type":2,"TypeString":"LOCATION_REQUIRED","Reason":"All Locations that are part of the collections key are required"}
+{"Field":"key","Type":2,"TypeString":"LOCATION_REQUIRED","Reason":"The first collection key component is required to be included for standard updates"}
 {"Field":"multipleField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This field is able to be materialized"}
 {"Field":"nullField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"Object fields may be materialized"}
 {"Field":"numField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The projection has a single scalar type"}

--- a/materialize-snowflake/.snapshots/TestValidateAndApply
+++ b/materialize-snowflake/.snapshots/TestValidateAndApply
@@ -5,7 +5,7 @@ Big Schema Initial Constraints:
 {"Field":"flow_document","Type":2,"TypeString":"LOCATION_REQUIRED","Reason":"The root document must be materialized"}
 {"Field":"flow_published_at","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The projection has a single scalar type"}
 {"Field":"intField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The projection has a single scalar type"}
-{"Field":"key","Type":2,"TypeString":"LOCATION_REQUIRED","Reason":"All Locations that are part of the collections key are required"}
+{"Field":"key","Type":2,"TypeString":"LOCATION_REQUIRED","Reason":"The first collection key component is required to be included for standard updates"}
 {"Field":"multipleField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This field is able to be materialized"}
 {"Field":"nullField","Type":5,"TypeString":"FIELD_FORBIDDEN","Reason":"Cannot materialize a field where the only possible type is 'null'"}
 {"Field":"numField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The projection has a single scalar type"}
@@ -198,7 +198,7 @@ Big Schema Changed Types With Table Replacement Constraints:
 {"Field":"flow_document","Type":2,"TypeString":"LOCATION_REQUIRED","Reason":"The root document must be materialized"}
 {"Field":"flow_published_at","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The projection has a single scalar type"}
 {"Field":"intField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The projection has a single scalar type"}
-{"Field":"key","Type":2,"TypeString":"LOCATION_REQUIRED","Reason":"All Locations that are part of the collections key are required"}
+{"Field":"key","Type":2,"TypeString":"LOCATION_REQUIRED","Reason":"The first collection key component is required to be included for standard updates"}
 {"Field":"multipleField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This field is able to be materialized"}
 {"Field":"nullField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"Object fields may be materialized"}
 {"Field":"numField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The projection has a single scalar type"}

--- a/materialize-sqlserver/.snapshots/TestValidateAndApply
+++ b/materialize-sqlserver/.snapshots/TestValidateAndApply
@@ -5,7 +5,7 @@ Big Schema Initial Constraints:
 {"Field":"flow_document","Type":2,"TypeString":"LOCATION_REQUIRED","Reason":"The root document must be materialized"}
 {"Field":"flow_published_at","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The projection has a single scalar type"}
 {"Field":"intField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The projection has a single scalar type"}
-{"Field":"key","Type":2,"TypeString":"LOCATION_REQUIRED","Reason":"All Locations that are part of the collections key are required"}
+{"Field":"key","Type":2,"TypeString":"LOCATION_REQUIRED","Reason":"The first collection key component is required to be included for standard updates"}
 {"Field":"multipleField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This field is able to be materialized"}
 {"Field":"nullField","Type":5,"TypeString":"FIELD_FORBIDDEN","Reason":"Cannot materialize a field where the only possible type is 'null'"}
 {"Field":"numField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The projection has a single scalar type"}
@@ -198,7 +198,7 @@ Big Schema Changed Types With Table Replacement Constraints:
 {"Field":"flow_document","Type":2,"TypeString":"LOCATION_REQUIRED","Reason":"The root document must be materialized"}
 {"Field":"flow_published_at","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The projection has a single scalar type"}
 {"Field":"intField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The projection has a single scalar type"}
-{"Field":"key","Type":2,"TypeString":"LOCATION_REQUIRED","Reason":"All Locations that are part of the collections key are required"}
+{"Field":"key","Type":2,"TypeString":"LOCATION_REQUIRED","Reason":"The first collection key component is required to be included for standard updates"}
 {"Field":"multipleField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This field is able to be materialized"}
 {"Field":"nullField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"Object fields may be materialized"}
 {"Field":"numField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The projection has a single scalar type"}


### PR DESCRIPTION
**Description:**

A binding that was previously disabled and is now enabled and getting an increment to its backfill counter will now properly re-backfill, as well as other (arguably) less important things like preventing a change from delta updates to standard updates and which root document projection is selected.

All of the TestValidateAndApply snapshot updates are unrelated to this change (see 5fadfbf), but I ran them all just to make sure nothing else changed.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

