### PR TITLE
materialize-motherduck: trim leading / in bucket paths

### DIFF
--- a/materialize-motherduck/config.go
+++ b/materialize-motherduck/config.go
@@ -196,6 +196,10 @@ func (c *config) toBucketAndPath(ctx context.Context) (blob.Bucket, string, erro
 		path = c.StagingBucket.BucketPathGCS
 	}
 
+	// If BucketPath starts with a /, trim it so we don't end up with repeated /
+	// chars in the URI and so the object key does not start with a /.
+	path = strings.TrimPrefix(path, "/")
+
 	return bucket, path, nil
 }
 


### PR DESCRIPTION
**Description:**

Adds back trimming a leading '/' for bucket paths which was removed in #2720, but is necessary for backwards compatibility with pre-existing tasks.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2730)
<!-- Reviewable:end -->
