### PR TITLE
source-stripe-native: handle eventual consistency

### DIFF
--- a/source-stripe-native/source_stripe_native/api.py
+++ b/source-stripe-native/source_stripe_native/api.py
@@ -40,6 +40,16 @@ DO_NOT_HAVE_PLATFORM_CONTROLS_REGEX = r"You cannot perform this request as you d
 EVENT_NO_LONGER_RETAINED = r"is no longer available because it's aged out of our retention policy"
 
 
+# We have reason to believe the Stripe's Events API is eventually consistent. Examples of how to handle this
+# are written in the following article: https://blog.sequin.io/finding-and-fixing-eventual-consistency-with-stripe-events.
+# The approach in the article aims is to ensure the incremental tasks never fetch data more recent than 5 seconds in the past.
+# This is a good approach, however, we err on the side of caution and set the lag to 1 minute to ensure we don't miss any events.
+# This caps how "real-time" the streams can be but it's a simple fix that easily rolled back if we come up with a
+# better solution. The default interval is already 5 minutes, so the connector is not really "real-time" anyway.
+LAG = timedelta(minutes=1)
+MIN_INCREMENTAL_INTERVAL = timedelta(minutes=1)
+
+
 def add_event_types(
     params: dict[str, str | int], event_types: dict[str, Literal["c", "u", "d"]]
 ):
@@ -81,6 +91,15 @@ async def fetch_incremental(
     url = f"{API}/events"
     parameters: dict[str, str | int] = {"limit": MAX_PAGE_LIMIT}
     parameters = add_event_types(parameters, cls.EVENT_TYPES)
+    end = datetime.now(tz=UTC) - LAG
+
+    if end < log_cursor or (end - log_cursor < MIN_INCREMENTAL_INTERVAL):
+        # Return early and sleep if the end date is before the log cursor
+        # or the difference between the end date and log cursor is less than
+        # the minimum incremental interval.
+        return
+
+    parameters["created[lte]"] = int(end.timestamp())
     headers = {}
     account_id = (
         connected_account_id
@@ -240,6 +259,15 @@ async def fetch_incremental_substreams(
     url = f"{API}/events"
     parameters: dict[str, str | int] = {"limit": MAX_PAGE_LIMIT}
     parameters = add_event_types(parameters, cls_child.EVENT_TYPES)
+    end = datetime.now(tz=UTC) - LAG
+
+    if end < log_cursor or (end - log_cursor < MIN_INCREMENTAL_INTERVAL):
+        # Return early and sleep if the end date is before the log cursor
+        # or the difference between the end date and log cursor is less than
+        # the minimum incremental interval.
+        return
+
+    parameters["created[lte]"] = int(end.timestamp())
     max_ts = log_cursor
     headers = {}
     account_id = (
@@ -577,6 +605,15 @@ async def fetch_incremental_usage_records(
     url = f"{API}/events"
     parameters: dict[str, str | int] = {"limit": MAX_PAGE_LIMIT}
     parameters = add_event_types(parameters, cls_child.EVENT_TYPES)
+    end = datetime.now(tz=UTC) - LAG
+
+    if end < log_cursor or (end - log_cursor < MIN_INCREMENTAL_INTERVAL):
+        # Return early and sleep if the end date is before the log cursor
+        # or the difference between the end date and log cursor is less than
+        # the minimum incremental interval.
+        return
+
+    parameters["created[lte]"] = int(end.timestamp())
     max_ts = log_cursor
     headers = {}
     account_id = (


### PR DESCRIPTION
**Description:**

We have evidence that Stripe's Events API is eventually consistent. Examples from [Sequin](https://blog.sequin.io/finding-and-fixing-eventual-consistency-with-stripe-events/) show how to combat this by yielding a cursor only if it is older than 5 seconds, otherwise do not update the cursor. This approach has been augmented for Estuary's connector to never fetch data that's more recent than 1 minute in the past by just returning and waiting for the connectors interval to pass. This means the most "real-time" the connector can be is 1 minutes (often a little more due to the default 5 minute interval), but it hopefully helps avoid eventual consistency issues causing the connector to miss updates.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2731)
<!-- Reviewable:end -->
