### PR TITLE
Potential fix for code scanning alert no. 25: Potentially unsafe quoting

### DIFF
--- a/source-google-drive/main.go
+++ b/source-google-drive/main.go
@@ -232,48 +232,51 @@ func readdirAll(client *drive.FilesService, ctx context.Context, folderID string
 }
 
 func configSchema(parserSchema json.RawMessage) json.RawMessage {
-	var credentialSchema, _ = json.Marshal(google_auth.CredentialConfig{}.JSONSchema())
+	var credentialSchema, _ = google_auth.CredentialConfig{}.JSONSchema()
 
-	return json.RawMessage(`{
+	var schema = map[string]interface{}{
 		"$schema": "http://json-schema.org/draft-07/schema#",
 		"title":   "Google Drive Source",
 		"type":    "object",
-		"required": [
+		"required": []string{
 			"folderUrl",
-			"credentials"
-		],
-		"properties": {
-			"folderUrl": {
+			"credentials",
+		},
+		"properties": map[string]interface{}{
+			"folderUrl": map[string]interface{}{
 				"type":        "string",
 				"title":       "Folder URL",
 				"description": "URL of the Google Drive Folder to be captured from.",
-				"order":       1
+				"order":       1,
 			},
-			"credentials": ` + string(credentialSchema) + `,
-			"matchKeys": {
+			"credentials": credentialSchema,
+			"matchKeys": map[string]interface{}{
 				"type":        "string",
 				"title":       "Match Keys",
 				"format":      "regex",
 				"description": "Filter applied to file paths under the folder URL. If provided, only files whose paths (relative to the folder) match this regex will be read. For example, you can use \".*\\.json\" to only capture json files.",
-				"order":       3
+				"order":       3,
 			},
-			"advanced": {
-				"properties": {
-				  "ascendingKeys": {
-					"type":        "boolean",
-					"title":       "Ascending Keys",
-					"description": "Improve sync speeds by listing files from the end of the last sync, rather than listing the entire bucket prefix. This requires that you write objects in ascending lexicographic order, such as an RFC-3339 timestamp, so that key ordering matches modification time ordering. For more information see https://go.estuary.dev/fOMT4s.",
-					"default":     false
-				  }
+			"advanced": map[string]interface{}{
+				"properties": map[string]interface{}{
+					"ascendingKeys": map[string]interface{}{
+						"type":        "boolean",
+						"title":       "Ascending Keys",
+						"description": "Improve sync speeds by listing files from the end of the last sync, rather than listing the entire bucket prefix. This requires that you write objects in ascending lexicographic order, such as an RFC-3339 timestamp, so that key ordering matches modification time ordering. For more information see https://go.estuary.dev/fOMT4s.",
+						"default":     false,
+					},
 				},
 				"additionalProperties": false,
-				"type": "object",
-				"description": "Options for advanced users. You should not typically need to modify these.",
-				"advanced": true
+				"type":                 "object",
+				"description":          "Options for advanced users. You should not typically need to modify these.",
+				"advanced":             true,
 			},
-			"parser": ` + string(parserSchema) + `
-		}
-    }`)
+			"parser": json.RawMessage(parserSchema),
+		},
+	}
+
+	var result, _ = json.Marshal(schema)
+	return json.RawMessage(result)
 }
 
 func main() {


### PR DESCRIPTION
Potential fix for [https://github.com/estuary/connectors/security/code-scanning/25](https://github.com/estuary/connectors/security/code-scanning/25)

To fix the issue, we need to ensure that the `credentialSchema` is properly escaped before embedding it into the JSON string. The safest approach is to use `json.Marshal` to construct the entire JSON object, avoiding manual string concatenation. This ensures that all embedded values are correctly escaped and prevents potential vulnerabilities.

Specifically:
1. Replace the manual string concatenation with a structured approach using Go's `map` or `struct` to define the JSON schema.
2. Use `json.Marshal` to serialize the entire schema, ensuring that all values are properly escaped.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2737)
<!-- Reviewable:end -->
