### PR TITLE
source-chargebee-native: ensure API request interval is valid

### DIFF
--- a/source-chargebee-native/source_chargebee_native/models.py
+++ b/source-chargebee-native/source_chargebee_native/models.py
@@ -53,6 +53,7 @@ class EndpointConfig(BaseModel):
         description="UTC date and time in the format YYYY-MM-DDTHH:MM:SSZ. Any data before this date will not be replicated. If left blank, defaults to 30 days before current time.",
         title="Start Date",
         default_factory=default_start_date,
+        le=datetime.now(tz=UTC),
     )
     product_catalog: Literal["1.0", "2.0"] = Field(
         description="The product catalog version to use.",


### PR DESCRIPTION
**Description:**

This PR should fix an issue identified in a capture where the `start` was after the `end`  end time for `created_at[between]` and `updated_at[between]` for incremental `fetch_changes` due to updating the `max_updated_at` timestamp in the `while` loop without checking that it is before the `log_cursor` and simultaneously using the `max_updated_at` in the API request instead of using the same `start`/`end` times for the API requests.

This PR introduces a check that will skip yielding documents if the `updated_at` is beyond the `log_cursor` and keeps the `start` time for the API requests the same. Additionally, there is a `le=datetime.now(tz=UTC)` check on the `EndpointConfig` model which will prevent the user from specifying a `start_date` that is in the future.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2740)
<!-- Reviewable:end -->
