### PR TITLE
source-intercom-native: fix log level for scroll endpoint error

### DIFF
--- a/source-intercom-native/source_intercom_native/api.py
+++ b/source-intercom-native/source_intercom_native/api.py
@@ -521,7 +521,7 @@ async def _scroll_companies(
                 )
             except HTTPError as err:
                 if err.code == 400 and bool(re.search(COMPANIES_SCROLL_IN_USE_BY_OTHER_APPLICATION_REGEX, err.message, re.DOTALL)):
-                    log.fatal(
+                    log.error(
                         "Unable to access the /companies/scroll endpoint because it's in use by a different application."
                         " Please ensure no other application is using the /companies/scroll endpoint or "
                         " configure the connector to use the alternative /companies/list endpoint."


### PR DESCRIPTION
**Description:**

When I built this connector, I mistakenly thought `log.fatal` would be presented nicely in the UI. I was mistaken, and I should have used `log.error` instead; `log.error` is presented better in the UI.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2743)
<!-- Reviewable:end -->
