### PR TITLE
source-mongodb: log when backfills start for a table

### DIFF
--- a/source-mongodb/backfill.go
+++ b/source-mongodb/backfill.go
@@ -242,6 +242,7 @@ func (c *capture) doBackfill(
 		"collection":         binding.resource.Collection,
 		"estimatedTotalDocs": estimatedTotalDocs,
 	})
+	logEntry.Info("starting backfill for collection")
 
 	for {
 		select {


### PR DESCRIPTION
**Description:**

Adds a log for when backfills start for a table, to complement the logs about when they are done.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2744)
<!-- Reviewable:end -->
