### PR TITLE
materialize-iceberg: allow load result lines of any length

### DIFF
--- a/materialize-iceberg/transactor.go
+++ b/materialize-iceberg/transactor.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"math"
 	"path"
 	"slices"
 	"strconv"
@@ -365,6 +366,7 @@ func (t *transactor) loadWorker(ctx context.Context, loaded func(binding int, do
 		}
 
 		scanner := bufio.NewScanner(gzr)
+		scanner.Buffer(make([]byte, 0, 64*1024), math.MaxInt64)
 		for scanner.Scan() {
 			line := scanner.Bytes()
 			if commaIdx := bytes.IndexByte(line, '\u0000'); commaIdx == -1 {


### PR DESCRIPTION
**Description:**

The default line length limit of bufio.Scanner is 64KiB, which is quite a bit shorter than documents we commonly see.

There's no real reason for us to have any limit on this line length, since the data we are loading back is data we put there in the first place.

This change sets an initial relatively small buffer, but allows the scanner to resize it as large as it needs to based on the data received.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2747)
<!-- Reviewable:end -->
