### PR TITLE
source-shopify-native: fix job cancellation logic

### DIFF
--- a/source-shopify-native/source_shopify_native/models.py
+++ b/source-shopify-native/source_shopify_native/models.py
@@ -151,10 +151,9 @@ class BulkOperationDetails(BaseModel, extra="allow"):
     errorCode: BulkOperationErrorCodes | None
 
 
-class UserErrors(BaseModel, extra="forbid"):
+class UserErrors(BaseModel, extra="allow"):
     field: str | list[str] | None
     message: str
-    code: BulkOperationUserErrorCodes
 
 
 class BulkJobCancelResponse(BaseModel, extra="allow"):
@@ -182,11 +181,15 @@ class BulkSpecificJobResponse(BaseModel, extra="allow"):
     data: Data
 
 
+class BulkOperationUserErrors(UserErrors):
+    code: BulkOperationUserErrorCodes
+
+
 class BulkJobSubmitResponse(BaseModel, extra="allow"):
     class Data(BaseModel, extra="forbid"):
         class BulkOperationRunQuery(BaseModel, extra="forbid"):
             bulkOperation: BulkOperationDetails | None
-            userErrors: list[UserErrors]
+            userErrors: list[BulkOperationUserErrors]
 
         bulkOperationRunQuery: BulkOperationRunQuery
 


### PR DESCRIPTION
**Description:**

There were a few bugs in the original job cancellation logic:
- The job id needs to be enclosed in double quotes in the `bulkOperationCancel` query. 🤦 
- When a job is `CANCELLING`, Shopify does not allow us to submit any more jobs until the ongoing job is `CANCELED` or `COMPLETED`.
- `UserErrors` for job deletions don't include a `code` field, but `UserErrors` for submitting jobs do include a `code` field.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

Tested on a local stack. Confirmed the connector can successfully cancel & wait for the cancellation of an existing bulk job.

