### PR TITLE
source-kinesis: add periodic logging of capture progress

### DIFF
--- a/source-kinesis/connection.go
+++ b/source-kinesis/connection.go
@@ -67,12 +67,11 @@ func connect(ctx context.Context, cfg *Config) (*kinesis.Client, error) {
 		}),
 	}
 
+	var clientOpts []func(*kinesis.Options)
 	if cfg.Advanced.Endpoint != "" {
-		customResolver := aws.EndpointResolverWithOptionsFunc(func(service, region string, options ...interface{}) (aws.Endpoint, error) {
-			return aws.Endpoint{URL: cfg.Advanced.Endpoint}, nil
+		clientOpts = append(clientOpts, func(o *kinesis.Options) {
+			o.BaseEndpoint = &cfg.Advanced.Endpoint
 		})
-
-		opts = append(opts, awsConfig.WithEndpointResolverWithOptions(customResolver))
 	}
 
 	awsCfg, err := awsConfig.LoadDefaultConfig(ctx, opts...)
@@ -80,7 +79,7 @@ func connect(ctx context.Context, cfg *Config) (*kinesis.Client, error) {
 		return nil, fmt.Errorf("creating aws config: %w", err)
 	}
 
-	return kinesis.NewFromConfig(awsCfg), nil
+	return kinesis.NewFromConfig(awsCfg, clientOpts...), nil
 }
 
 type kinesisStream struct {

--- a/source-kinesis/main.go
+++ b/source-kinesis/main.go
@@ -136,6 +136,7 @@ func (d *driver) Pull(open *pc.Request_Open, stream *boilerplate.PullOutput) err
 		client:      client,
 		stream:      stream,
 		updateState: make(map[boilerplate.StateKey]map[string]*string),
+		stats:       make(map[string]map[string]shardStats),
 	}
 
 	if err := stream.Ready(false); err != nil {
@@ -166,6 +167,7 @@ func (d *driver) Pull(open *pc.Request_Open, stream *boilerplate.PullOutput) err
 			return c.readStream(groupCtx, streams[streamIdx], sk, i, maps.Clone(state.Streams[sk]))
 		})
 	}
+	group.Go(func() error { return c.statsLogger(groupCtx) })
 
 	return group.Wait()
 }


### PR DESCRIPTION
**Description:**

Right now, the capture will start up and log a few things, and then nothing forever until it restarts.

This adds some periodic logging of the capture's progress, to give an indication that it is still alive and doing stuff, and some insight into what the stuff is.

The output logs will look something like this:

```json
{
  "_meta": {
    "uuid": "48268d3c-26c8-11f0-8400-539167a7c504"
  },
  "shard": {
    "kind": "capture",
    "name": "bobCo/kinesistest/source-kinesis",
    "keyBegin": "00000000",
    "rClockBegin": "00000000",
    "build": "110304b7d400007e"
  },
  "ts": "2025-05-01T20:10:09Z",
  "level": "info",
  "message": "processed stream records",
  "fields": {
    "whbTestStreamOne": {
      "shardId-000000000000": {
        "docs": 75,
        "lag": "0s"
      },
      "shardId-000000000001": {
        "docs": 76,
        "lag": "0s"
      },
      "shardId-000000000002": {
        "docs": 65,
        "lag": "0s"
      },
      "shardId-000000000003": {
        "docs": 91,
        "lag": "0s"
      }
    },
    "whbTestStreamTwo": {
      "shardId-000000000000": {
        "docs": 84,
        "lag": "0s"
      },
      "shardId-000000000001": {
        "docs": 87,
        "lag": "0s"
      },
      "shardId-000000000002": {
        "docs": 71,
        "lag": "0s"
      },
      "shardId-000000000003": {
        "docs": 65,
        "lag": "0s"
      }
    }
  }
}
```

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2751)
<!-- Reviewable:end -->
