### PR TITLE
connectors: install curl for all Go connectors

### DIFF
--- a/base-image/Dockerfile
+++ b/base-image/Dockerfile
@@ -1,6 +1,6 @@
 FROM --platform=linux/amd64 debian:stable-slim as debian
 
-RUN apt-get update && apt-get install -y openssh-client ca-certificates
+RUN apt-get update && apt-get install -y openssh-client ca-certificates curl
 
 # Create a non-privileged "nonroot" user.
 RUN useradd nonroot --create-home --shell /usr/sbin/nologin

--- a/materialize-bigquery/Dockerfile
+++ b/materialize-bigquery/Dockerfile
@@ -29,10 +29,6 @@ RUN go build -tags nozstd -v -o ./connector ./materialize-bigquery/cmd/connector
 ################################################################################
 FROM ${BASE_IMAGE}
 
-RUN apt-get update -y \
-    && apt-get install --no-install-recommends -y ca-certificates \
-    && rm -rf /var/lib/apt/lists/*
-
 # Avoid running the connector as root.
 USER nonroot:nonroot
 

--- a/materialize-databricks/Dockerfile
+++ b/materialize-databricks/Dockerfile
@@ -29,13 +29,6 @@ RUN go build -tags nozstd -v -o ./connector ./materialize-databricks/...
 ################################################################################
 FROM ${BASE_IMAGE}
 
-RUN apt-get update -y \
-     && apt-get install --no-install-recommends -y \
-     ca-certificates \
-     curl \
-     unzip \
-     && rm -rf /var/lib/apt/lists/*
-
 WORKDIR /connector
 ENV PATH="/connector:$PATH"
 

--- a/materialize-sqlserver/Dockerfile
+++ b/materialize-sqlserver/Dockerfile
@@ -29,13 +29,6 @@ RUN go build -tags nozstd -v -o ./connector ./materialize-sqlserver/...
 ################################################################################
 FROM ${BASE_IMAGE}
 
-RUN apt-get update -y \
-     && apt-get install --no-install-recommends -y \
-     ca-certificates \
-     curl \
-     unzip \
-     && rm -rf /var/lib/apt/lists/*
-
 WORKDIR /connector
 ENV PATH="/connector:$PATH"
 

--- a/materialize-starburst/Dockerfile
+++ b/materialize-starburst/Dockerfile
@@ -26,13 +26,6 @@ RUN go build -tags nozstd -v -o ./connector ./materialize-starburst/...
 ################################################################################
 FROM ${BASE_IMAGE}
 
-RUN apt-get update -y \
-     && apt-get install --no-install-recommends -y \
-     ca-certificates \
-     curl \
-     unzip \
-     && rm -rf /var/lib/apt/lists/*
-
 WORKDIR /connector
 ENV PATH="/connector:$PATH"
 


### PR DESCRIPTION
**Description:**

`curl` is generally useful to have available in a connector image to access Go's pprof HTTP server, so install it by default rather than needing to rely on annoying workarounds.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

The automated CI tests aren't really effective for a change like this, since all connector images use the base image tagged as `v1`, rather than the one that is built on this branch. But I did spot check a connector container built with the image pushed by this branch, and it worked as expected. There's a bit of cleanup to some of the materialization dockerfiles where they are installing some redundant things as well.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2752)
<!-- Reviewable:end -->
