### PR TITLE
source-salesforce-native: reduce max set size for reading bulk job results

### DIFF
--- a/source-salesforce-native/source_salesforce_native/bulk_job_manager.py
+++ b/source-salesforce-native/source_salesforce_native/bulk_job_manager.py
@@ -24,7 +24,7 @@ from .models import (
 INITIAL_SLEEP = 0.2
 MAX_SLEEP = 300
 ATTEMPT_LOG_THRESHOLD = 10
-MAX_BULK_QUERY_SET_SIZE = 200_000
+MAX_BULK_QUERY_SET_SIZE = 100_000
 
 COUNT_HEADER = "Sforce-NumberOfRecords"
 CANNOT_FETCH_COMPOUND_DATA = r"Selecting compound data not supported in Bulk Query"


### PR DESCRIPTION
**Description:**

I noticed that for a normal backfill when there are a significant number of records in a date window & these records are potentially large (like `EmailMessage`s), the connector sometimes hangs when reading results. I suspect this is the same problem I tried to address in https://github.com/estuary/connectors/pull/2683, but the max set size I chose is still too high, so the connector can sometimes _still_ take too long to finish a single HTTP request & Salesforce times out the connection silently. I'd like to see if reducing the max set size helps.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2756)
<!-- Reviewable:end -->
