### PR TITLE
materialize-cratedb: Change integer type mapping to more accurate types

### DIFF
--- a/materialize-cratedb/sqlgen.go
+++ b/materialize-cratedb/sqlgen.go
@@ -26,15 +26,18 @@ var jsonConverter sql.ElementConverter = func(te tuple.TupleElement) (interface{
 var crateDialect = func() sql.Dialect {
 	mapper := sql.NewDDLMapper(
 		sql.FlatTypeMappings{
-			sql.INTEGER:        sql.MapStatic("NUMERIC(22, 0)", sql.AlsoCompatibleWith("numeric"), sql.AlsoCompatibleWith("integer")),
+			sql.INTEGER: sql.MapSignedInt64(
+				sql.MapStatic("BIGINT", sql.AlsoCompatibleWith("integer")),
+				sql.MapStatic("NUMERIC(20)", sql.AlsoCompatibleWith("numeric")),
+			),
 			sql.NUMBER:         sql.MapStatic("DOUBLE PRECISION"),
 			sql.BOOLEAN:        sql.MapStatic("BOOLEAN"),
 			sql.OBJECT:         sql.MapStatic("OBJECT"),
 			sql.ARRAY:          sql.MapStatic("TEXT", sql.UsingConverter(jsonConverter)),
 			sql.BINARY:         sql.MapStatic("TEXT", sql.AlsoCompatibleWith("character varying")),
 			sql.MULTIPLE:       sql.MapStatic("OBJECT", sql.UsingConverter(sql.ToJsonBytes)),
-			sql.STRING_INTEGER: sql.MapStatic("NUMERIC(22, 0)", sql.AlsoCompatibleWith("numeric"), sql.AlsoCompatibleWith("integer")),
-			sql.STRING_NUMBER:  sql.MapStatic("NUMERIC(22, 0)", sql.AlsoCompatibleWith("numeric"), sql.AlsoCompatibleWith("integer")),
+			sql.STRING_INTEGER: sql.MapStatic("NUMERIC(18, 0)", sql.AlsoCompatibleWith("numeric"), sql.AlsoCompatibleWith("integer")),
+			sql.STRING_NUMBER:  sql.MapStatic("NUMERIC(18, 0)", sql.AlsoCompatibleWith("numeric"), sql.AlsoCompatibleWith("integer")),
 			sql.STRING: sql.MapString(sql.StringMappings{
 				Fallback: sql.MapStatic(
 					"TEXT",


### PR DESCRIPTION
**Description:**
Change the integer types to adapt to the maximun/minimun in the schema with `MapSignedInt64`
Fixes https://github.com/crate/cratedb-estuary/issues/4
**Notes for reviewers:**
Tests still don't pass, that's because currently CrateDB does not permit to insert u64 values in objects, tracked https://github.com/crate/crate/issues/17669

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2758)
<!-- Reviewable:end -->
