### PR TITLE
source-monday: update pagination handling for boards and items in API requests

### DIFF
--- a/source-monday/source_monday/models.py
+++ b/source-monday/source_monday/models.py
@@ -1,5 +1,4 @@
 from logging import Logger
-from datetime import datetime, UTC
 from typing import (
     TYPE_CHECKING,
     Annotated,
@@ -7,7 +6,6 @@ from typing import (
     AsyncGenerator,
     Callable,
     Generic,
-    Literal,
     TypeVar,
 )
 import json

--- a/source-monday/source_monday/resources.py
+++ b/source-monday/source_monday/resources.py
@@ -57,7 +57,7 @@ async def validate_credentials(log: Logger, http: HTTPMixin, config: EndpointCon
         raise ValidationError([msg])
 
 
-def full_refresh_resouces(log: Logger, http: HTTPMixin, config: EndpointConfig):
+def full_refresh_resources(log: Logger, http: HTTPMixin, config: EndpointConfig):
     def open(
         fetch_snapshot_fn: FullRefreshResourceFetchFn,
         limit: int,
@@ -137,6 +137,6 @@ async def all_resources(
     http.token_source = TokenSource(oauth_spec=None, credentials=config.credentials)
 
     return [
-        *full_refresh_resouces(log, http, config),
+        *full_refresh_resources(log, http, config),
         *incremental_resources(log, http, config),
     ]

--- a/source-monday/tests/snapshots/snapshots__capture__stdout.json
+++ b/source-monday/tests/snapshots/snapshots__capture__stdout.json
@@ -437,6 +437,110 @@
       },
       "assets": [],
       "board": {
+        "id": "8483610893",
+        "name": "Subitems of Estuary"
+      },
+      "column_values": [
+        {
+          "id": "person",
+          "text": "",
+          "type": "people",
+          "value": null
+        },
+        {
+          "id": "status",
+          "text": null,
+          "type": "status",
+          "value": null
+        },
+        {
+          "id": "date0",
+          "text": "",
+          "type": "date",
+          "value": null
+        }
+      ],
+      "created_at": "2025-02-20T19:03:22Z",
+      "creator_id": "71985416",
+      "group": {
+        "id": "topics"
+      },
+      "id": "8531539316",
+      "name": "SubItem Number One",
+      "parent_item": {
+        "id": "8531390039"
+      },
+      "state": "active",
+      "subitems": [],
+      "subscribers": [
+        {
+          "id": "71985416"
+        }
+      ],
+      "updated_at": "redacted",
+      "updates": []
+    }
+  ],
+  [
+    "acmeCo/items",
+    {
+      "_meta": {
+        "uuid": "DocUUIDPlaceholder-329Bb50aa48EAa9ef"
+      },
+      "assets": [],
+      "board": {
+        "id": "8483610893",
+        "name": "Subitems of Estuary"
+      },
+      "column_values": [
+        {
+          "id": "person",
+          "text": "",
+          "type": "people",
+          "value": null
+        },
+        {
+          "id": "status",
+          "text": null,
+          "type": "status",
+          "value": null
+        },
+        {
+          "id": "date0",
+          "text": "",
+          "type": "date",
+          "value": null
+        }
+      ],
+      "created_at": "2025-02-20T19:15:53Z",
+      "creator_id": "71985416",
+      "group": {
+        "id": "topics"
+      },
+      "id": "8531684828",
+      "name": "Second SubItem",
+      "parent_item": {
+        "id": "8531390039"
+      },
+      "state": "active",
+      "subitems": [],
+      "subscribers": [
+        {
+          "id": "71985416"
+        }
+      ],
+      "updated_at": "redacted",
+      "updates": []
+    }
+  ],
+  [
+    "acmeCo/items",
+    {
+      "_meta": {
+        "uuid": "DocUUIDPlaceholder-329Bb50aa48EAa9ef"
+      },
+      "assets": [],
+      "board": {
         "id": "8431289505",
         "name": "Estuary"
       },
@@ -528,6 +632,58 @@
           "updates": []
         }
       ],
+      "subscribers": [
+        {
+          "id": "71985416"
+        }
+      ],
+      "updated_at": "redacted",
+      "updates": []
+    }
+  ],
+  [
+    "acmeCo/items",
+    {
+      "_meta": {
+        "uuid": "DocUUIDPlaceholder-329Bb50aa48EAa9ef"
+      },
+      "assets": [],
+      "board": {
+        "id": "8483610893",
+        "name": "Subitems of Estuary"
+      },
+      "column_values": [
+        {
+          "id": "person",
+          "text": "",
+          "type": "people",
+          "value": null
+        },
+        {
+          "id": "status",
+          "text": null,
+          "type": "status",
+          "value": null
+        },
+        {
+          "id": "date0",
+          "text": "",
+          "type": "date",
+          "value": null
+        }
+      ],
+      "created_at": "2025-02-24T17:14:40Z",
+      "creator_id": "71985416",
+      "group": {
+        "id": "topics"
+      },
+      "id": "8553814342",
+      "name": "test",
+      "parent_item": {
+        "id": "8547821762"
+      },
+      "state": "active",
+      "subitems": [],
       "subscribers": [
         {
           "id": "71985416"


### PR DESCRIPTION
**Description:**

This aims to fix missing items due to incorrect pagination of boards. Previously the backfill for `items` would only backfill the first 25 `boards` since we did not paginate through the boards in the `ITEMS` query.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2760)
<!-- Reviewable:end -->
