### PR TITLE
source-postgres: Add "create_replication_slot" feature flag

### DIFF
--- a/source-postgres/.snapshots/TestCaptureAfterSlotDropped-capture2
+++ b/source-postgres/.snapshots/TestCaptureAfterSlotDropped-capture2
@@ -2,4 +2,8 @@
 # Final State Checkpoint
 # ================================
 {"bindingStateV1":{"test%2Fcaptureafterslotdropped_46115540":{"backfilled":2,"key_columns":["id"],"mode":"Active"}},"cursor":"0/1111111"}
+# ================================
+# Captures Terminated With Errors
+# ================================
+error creating replication stream: unable to start replication: ERROR: replication slot "flow_slot" does not exist (SQLSTATE 42704)
 

--- a/source-postgres/.snapshots/TestCaptureAfterSlotDropped-capture3
+++ b/source-postgres/.snapshots/TestCaptureAfterSlotDropped-capture3
@@ -1,10 +1,9 @@
 # ================================
-# Collection "acmeCo/test/test/captureafterslotdropped_46115540": 2 Documents
-# ================================
-{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"captureafterslotdropped_46115540","loc":[11111111,11111111,11111111],"txid":111111}},"data":"six","id":6}
-{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"captureafterslotdropped_46115540","loc":[11111111,11111111,11111111],"txid":111111}},"data":"seven","id":7}
-# ================================
 # Final State Checkpoint
 # ================================
 {"bindingStateV1":{"test%2Fcaptureafterslotdropped_46115540":{"backfilled":2,"key_columns":["id"],"mode":"Active"}},"cursor":"0/1111111"}
+# ================================
+# Captures Terminated With Errors
+# ================================
+error creating replication stream: unable to start replication: ERROR: replication slot "flow_slot" does not exist (SQLSTATE 42704)
 

--- a/source-postgres/capture_test.go
+++ b/source-postgres/capture_test.go
@@ -529,9 +529,8 @@ func TestCaptureAfterSlotDropped(t *testing.T) {
 	tb.Insert(ctx, t, tableName, [][]any{{0, "zero"}, {1, "one"}})
 	t.Run("capture1", func(t *testing.T) { tests.VerifiedCapture(ctx, t, cs) })
 
-	// Drop the replication slot while the task is offline, and it should recreate
-	// the replication slot and then start failing because its saved position isn't
-	// valid any longer.
+	// Drop the replication slot while the task is offline. At startup it should
+	// fail because it has a non-empty resume cursor but the slot no longer exists.
 	tb.Insert(ctx, t, tableName, [][]any{{2, "two"}, {3, "three"}})
 	tb.Query(ctx, t, "SELECT pg_drop_replication_slot('flow_slot');")
 	tb.Insert(ctx, t, tableName, [][]any{{4, "four"}, {5, "five"}})

--- a/source-postgres/main.go
+++ b/source-postgres/main.go
@@ -179,6 +179,11 @@ var featureFlagDefaults = map[string]bool{
 	// When true (and so long as 'multidimensional_arrays' isn't also set) array columns are
 	// captured as a flat array of values in the JSON output.
 	"flatten_arrays": true,
+
+	// When true, the connector will manage replication slot creation and deletion automatically.
+	// This is the default, but advanced users could set `no_create_replication_slot` if they want
+	// to manage their replication slots manually instead.
+	"create_replication_slot": true,
 }
 
 // Validate checks that the configuration possesses all required properties.


### PR DESCRIPTION
**Description:**

The `create_replication_slot` flag setting is the default behavior and amounts to doing what we were already doing, but by adding a feature flag we can allow users to specify `no_create_replication_slot` in order to disable any automatic replication slot management on our part.

In conjunction with this change, I've reworked the "does the slot exist" validation check so that it never attempts to create the slot. This part is a change I've been meaning to make for a while, as once we've verified that the capture user has the REPLICATION role and that the slot doesn't already exist in another database, there is no way we could fail to recreate it later on when the capture proper starts.

The reason this is preferable is that it significantly reduces the chances of several error conditions:
1. The user fiddles with the slot name setting after having already triggered validation. When this happens, they can end up with an unused slot which possibly eats up WAL retention without bound.
2. The user fiddles with the database name setting after having run validation once. When this happens, prerequisite validation will fail with a "slot exists in wrong database" error when really if we hadn't been so eager there would be no problems.
3. The user runs validation and the slot is created, but then they don't ever actually publish the capture. This is similar to (1) and results in the same basic failure pattern of an unused slot retaining a potentially unbounded amount of WAL.

Much nicer to avoid all that mess by not creating slots during the validation process in the first place.

The check itself still exists so that it can detect the "slot does exist but in the wrong logical database" condition and so that we can provide a useful error when `no_create_replication_slot` is set but the user actually didn't create it themselves, but we will only autocreate the slot as part of the actual capture.

**Workflow steps:**

Nothing should change by default.

Users can specify feature flag setting `no_create_replication_slot` to be guaranteed that we will never create the replication slot ourselves.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2762)
<!-- Reviewable:end -->
