### PR TITLE
source-firestore: Configurable backfill intervals

### DIFF
--- a/source-firestore/.snapshots/TestSpec
+++ b/source-firestore/.snapshots/TestSpec
@@ -29,6 +29,11 @@
             "type": "boolean",
             "title": "Skip Automatic Discovery",
             "description": "When set the connector will skip automatic collection discovery. This generally only makes sense when the \"Extra Collections\" setting is used."
+          },
+          "min_backfill_interval": {
+            "type": "string",
+            "title": "Minimum Backfill Interval",
+            "description": "Controls how often a collection may be re-backfilled in the event of unrecoverable change stream failure. May be overridden by the per-resource setting."
           }
         },
         "additionalProperties": false,
@@ -72,6 +77,11 @@
         "pattern": "^(/([^/~]|~[01])+)*$",
         "title": "Restart Cursor Path",
         "description": "Optionally specifies a JSON pointer to some document property which increases monotonically and can be used as a restart cursor to optimize backfill behavior when streaming consistency is lost. Generally this only matters for collections with very high write volumes."
+      },
+      "min_backfill_interval": {
+        "type": "string",
+        "title": "Minimum Backfill Interval",
+        "description": "Controls how often a collection may be re-backfilled in the event of unrecoverable change stream failure. Overrides any other defaults for this particular resource."
       }
     },
     "type": "object",

--- a/source-firestore/main.go
+++ b/source-firestore/main.go
@@ -26,6 +26,8 @@ type resource struct {
 	BackfillMode      backfillMode `json:"backfillMode" jsonschema:"title=Backfill Mode,description=Configures the handling of data already in the collection. Refer to go.estuary.dev/source-firestore for details or just stick with 'async'. Has no effect if changed after a binding is added.,enum=async,enum=none,enum=sync"`
 	InitTimestamp     string       `json:"initTimestamp,omitempty" jsonschema:"title=Initial Replication Timestamp,description=Optionally overrides the initial replication timestamp (which is either Zero or Now depending on the backfill mode). Has no effect if changed after a binding is added."`
 	RestartCursorPath string       `json:"restartCursorPath,omitempty" jsonschema:"title=Restart Cursor Path,description=Optionally specifies a JSON pointer to some document property which increases monotonically and can be used as a restart cursor to optimize backfill behavior when streaming consistency is lost. Generally this only matters for collections with very high write volumes.,pattern=^(/([^/~]|~[01])+)*$"`
+
+	MinBackfillInterval string `json:"min_backfill_interval,omitempty" jsonschema:"title=Minimum Backfill Interval,description=Controls how often a collection may be re-backfilled in the event of unrecoverable change stream failure. Overrides any other defaults for this particular resource."`
 }
 
 var jsonPointerRegexp = regexp.MustCompile(`^(/([^/~]|~[01])+)*$`)
@@ -73,6 +75,8 @@ type advancedConfig struct {
 	ExtraCollections []string `json:"extra_collections,omitempty" jsonschema:"title=Extra Collections,description=A list of collection paths (in the form \"foo/*/bar/*/baz\") which will always be assumed to exist even if not found by autodiscovery. Useful for very rare collections which may not be reliably detected by discovery sampling of the dataset."`
 
 	SkipDiscovery bool `json:"skip_discovery,omitempty" jsonschema:"title=Skip Automatic Discovery,description=When set the connector will skip automatic collection discovery. This generally only makes sense when the \"Extra Collections\" setting is used."`
+
+	MinBackfillInterval string `json:"min_backfill_interval,omitempty" jsonschema:"title=Minimum Backfill Interval,description=Controls how often a collection may be re-backfilled in the event of unrecoverable change stream failure. May be overridden by the per-resource setting."`
 }
 
 var databasePathRe = regexp.MustCompile(`^projects/[^/]+/databases/[^/]+$`)

--- a/source-firestore/main_test.go
+++ b/source-firestore/main_test.go
@@ -628,7 +628,7 @@ func TestInitResourceStates(t *testing.T) {
 			fmt.Fprintf(out, "\n")
 		}
 		fmt.Fprintf(out, "--- %s ---\n", tc.name)
-		var outputStates, err = initResourceStates(tc.states, tc.bindings, testNow)
+		var outputStates, err = initResourceStates(&config{}, tc.states, tc.bindings, testNow)
 		if err != nil {
 			fmt.Fprintf(out, "error: %v\n", err)
 			continue


### PR DESCRIPTION
**Description:**

Adds a resource spec and advanced endpoint config setting for the minimum (re)backfill interval. If neither is set we will continue to apply the same "5m with a restart cursor and 24h otherwise" policy we always have, but if either is set we will use the specified interval instead. The resource level setting overrides the endpoint config, while the endpoint config allows users to set a default which will definitely be applied to any new bindings, so I think it's useful to have both.

I've tried to keep this PR limited to just adding that new setting, so it's worth noting that the current connector-restart behavior is absolutely terrible so I haven't even bothered updating it to account for the new customizable intervals. As just one concrete example, if change streaming happens to fail and then the connector restarts on its own before the forced-restart timeout fires, there will no longer be any sort of restart timeout and we just have to hope it restarts again after the backfill interval is reached.

I'm not bothering to fix that here because there is no simple fix for that issue, if/when we decide to tackle this we really just need to implement the ability to trigger new backfills without restarting the connector. This should be easier now than it used to be since we've removed some of the complications like needing to interrupt an ongoing backfill and managing a many-to-one binding to backfill state mapping, but it's still beyond the scope of this quick fix.

**Workflow steps:**

Nothing should change by default. Users may now customize the minimum re-backfill interval if they want it to be longer or shorter than our 24h default.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2763)
<!-- Reviewable:end -->
