### PR TITLE
materialize-cratedb: Set sql.STRING_NUMBER to 'DOUBLE PRECISION' 

### DIFF
--- a/materialize-cratedb/sqlgen.go
+++ b/materialize-cratedb/sqlgen.go
@@ -35,7 +35,7 @@ var crateDialect = func() sql.Dialect {
 			sql.BINARY:         sql.MapStatic("TEXT", sql.AlsoCompatibleWith("character varying")),
 			sql.MULTIPLE:       sql.MapStatic("OBJECT", sql.UsingConverter(sql.ToJsonBytes)),
 			sql.STRING_INTEGER: sql.MapStatic("NUMERIC(18, 0)", sql.AlsoCompatibleWith("numeric"), sql.AlsoCompatibleWith("integer")),
-			sql.STRING_NUMBER:  sql.MapStatic("NUMERIC(18, 0)", sql.AlsoCompatibleWith("numeric"), sql.AlsoCompatibleWith("integer")),
+			sql.STRING_NUMBER:  sql.MapStatic("DOUBLE PRECISION", sql.AlsoCompatibleWith("numeric"), sql.AlsoCompatibleWith("integer")),
 			sql.STRING: sql.MapString(sql.StringMappings{
 				Fallback: sql.MapStatic(
 					"TEXT",


### PR DESCRIPTION
**Description:**
Minor type assignment change, fixes https://github.com/crate/cratedb-estuary/issues/12

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2764)
<!-- Reviewable:end -->
