### PR TITLE
source-oracle: clear rolled-back transactions from pending list

### DIFF
--- a/source-oracle/replication.go
+++ b/source-oracle/replication.go
@@ -813,7 +813,7 @@ func (s *replicationStream) pendingAndRollbackedTransactions(ctx context.Context
 				"rollbacks": rollbacks,
 				"commits":   commits,
 				"count":     count,
-			}).Debug("skipping rolled-back transaction")
+			}).Trace("skipping rolled-back transaction")
 		} else if commits == 0 {
 			pendingTXs[xid] = startSCN
 			logrus.WithFields(logrus.Fields{
@@ -822,7 +822,7 @@ func (s *replicationStream) pendingAndRollbackedTransactions(ctx context.Context
 				"commits":   commits,
 				"count":     count,
 				"startSCN":  startSCN,
-			}).Debug("found pending transaction")
+			}).Trace("found pending transaction")
 		} else {
 			// sanity check the query, this shouldn't happen
 			return nil, nil, fmt.Errorf("unexpected transaction with commit > 0, xid: %s, startSCN: %d, commits: %d, rollbacks: %d", xid, startSCN, commits, rollbacks)

--- a/source-oracle/replication.go
+++ b/source-oracle/replication.go
@@ -1052,6 +1052,18 @@ func (s *replicationStream) maximumLastDDLSCN(ctx context.Context) (SCN, error) 
 
 	var maximumDDLSCN SCN
 	if err := row.Scan(&maximumDDLSCN); err != nil {
+		// ORA-08180: no snapshot found based on specified time
+		// this is usually because the time is so recent a snapshot for that time has not
+		// materialized into a SCN, in these scenarios we use current SCN
+		if strings.Contains(err.Error(), "ORA-08180") {
+			var currentSCN SCN
+			var row = s.conn.QueryRowContext(ctx, "SELECT current_scn FROM V$DATABASE")
+			if err := row.Scan(&currentSCN); err != nil {
+				return 0, fmt.Errorf("fetching current SCN: %w", err)
+			}
+			return currentSCN, nil
+		}
+
 		return 0, fmt.Errorf("fetching maximum last DDL SCN: %w", err)
 	}
 

--- a/source-oracle/replication.go
+++ b/source-oracle/replication.go
@@ -700,7 +700,7 @@ func (s *replicationStream) capturePendingTransaction(ctx context.Context, tx tr
 func (s *replicationStream) decodeAndEmitMessage(ctx context.Context, msg logminerMessage) error {
 	var event, err = s.decodeMessage(msg)
 	if err != nil {
-		return err
+		return fmt.Errorf("decode message: %w", err)
 	}
 
 	select {
@@ -856,7 +856,7 @@ func (s *replicationStream) receiveMessages(ctx context.Context, startSCN, endSC
 		var info sql.NullString
 		var xidRaw []byte
 		if err := rows.Scan(&msg.SCN, &ts, &msg.Op, &redoSql, &undoSql, &tableName, &owner, &msg.Status, &info, &msg.RSID, &msg.SSN, &msg.CSF, &msg.ObjectID, &msg.DataObjectID, &xidRaw); err != nil {
-			return err
+			return fmt.Errorf("row scan: %w", err)
 		}
 
 		msg.XID = base64.StdEncoding.EncodeToString(xidRaw)
@@ -936,7 +936,7 @@ func (s *replicationStream) receiveMessages(ctx context.Context, startSCN, endSC
 			// last message was CSF, this one is not. This is the end of the continuation chain
 			if msg.CSF == 0 {
 				if err := s.handleTransactionBoundaries(ctx, *lastMsg); err != nil {
-					return err
+					return fmt.Errorf("handle transaction boundaries: %w", err)
 				}
 				fullMessages++
 			}
@@ -950,15 +950,15 @@ func (s *replicationStream) receiveMessages(ctx context.Context, startSCN, endSC
 		}
 
 		if err := s.handleTransactionBoundaries(ctx, msg); err != nil {
-			return err
+			return fmt.Errorf("handle transaction boundaries: %w", err)
 		}
 		fullMessages++
 	}
 
 	if err := rows.Err(); err != nil {
-		return err
+		return fmt.Errorf("rows error: %w", err)
 	} else if err := rows.Close(); err != nil {
-		return err
+		return fmt.Errorf("rows close: %w", err)
 	}
 
 	var finalSCN SCN

--- a/source-oracle/replication.go
+++ b/source-oracle/replication.go
@@ -603,6 +603,7 @@ func (s *replicationStream) poll(ctx context.Context, minSCN, maxSCN SCN, transa
 			// We will switch back to Online mode afterwards
 			var dictionaryMismatch = strings.Contains(strings.ToLower(err.Error()), "dictionary mismatch")
 			if dictionaryMismatch && s.dictionaryMode == DictionaryModeOnline && s.smartMode {
+				logrus.WithField("error", err).Info("smart mode: encountered dictionary mismatch")
 				s.dictionaryMode = DictionaryModeExtract
 				if lastDDLSCN, err := s.maximumLastDDLSCN(ctx); err != nil {
 					return err
@@ -610,7 +611,7 @@ func (s *replicationStream) poll(ctx context.Context, minSCN, maxSCN SCN, transa
 					s.lastDDLSCN = lastDDLSCN
 				}
 
-				logrus.WithField("lastDDLSCN", s.lastDDLSCN).Info("smart mode: encountered dictionary mismatch, switching to extract mode")
+				logrus.WithField("lastDDLSCN", s.lastDDLSCN).Info("smart mode: switching to extract mode")
 				continue
 			}
 			return fmt.Errorf("receive messages: %w", err)


### PR DESCRIPTION
**Description:**

- If a transaction is rolled back in a different SCN range than the original, we would sometimes let it stay in `pendingTransactions` forever...

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2765)
<!-- Reviewable:end -->
