### PR TITLE
Fix/normalize column names

### DIFF
--- a/materialize-cratedb/driver.go
+++ b/materialize-cratedb/driver.go
@@ -167,9 +167,9 @@ func (r tableConfig) Validate() error {
 
 func (c tableConfig) Path() sql.TablePath {
 	if c.Schema != "" {
-		return []string{c.Schema, c.Table}
+		return []string{c.Schema, normalizeColumn(c.Table)}
 	}
-	return []string{c.Table}
+	return []string{normalizeColumn(c.Table)}
 }
 
 func (c tableConfig) DeltaUpdates() bool {
@@ -178,7 +178,7 @@ func (c tableConfig) DeltaUpdates() bool {
 
 func newPostgresDriver() *sql.Driver {
 	return &sql.Driver{
-		DocumentationURL: "https://go.estuary.dev/materialize-postgresql",
+		DocumentationURL: "https://go.estuary.dev/materialize-cratedb",
 		EndpointSpecType: new(config),
 		ResourceSpecType: new(tableConfig),
 		StartTunnel: func(ctx context.Context, conf any) error {
@@ -358,6 +358,7 @@ func (t *transactor) addBinding(ctx context.Context, target sql.Table, is *boile
 	t.bindings = append(t.bindings, b)
 
 	var w strings.Builder
+
 	if err := tplCreateLoadTable.Execute(&w, &b.target); err != nil {
 		return fmt.Errorf("executing createLoadTable template: %w", err)
 	} else if _, err := t.load.conn.Exec(ctx, w.String()); err != nil {

--- a/materialize-cratedb/sqlgen.go
+++ b/materialize-cratedb/sqlgen.go
@@ -3,12 +3,10 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	sql "github.com/estuary/connectors/materialize-sql"
 	"github.com/estuary/flow/go/protocols/fdb/tuple"
 	"slices"
 	"strings"
-	"unicode/utf8"
-
-	sql "github.com/estuary/connectors/materialize-sql"
 )
 
 var jsonConverter sql.ElementConverter = func(te tuple.TupleElement) (interface{}, error) {
@@ -78,12 +76,12 @@ var crateDialect = func() sql.Dialect {
 			if len(path) == 1 {
 				// A schema isn't required to be set on the endpoint or any resource, and if its empty the
 				// default postgres schema "public" will implicitly be used.
-				return sql.InfoTableLocation{TableSchema: "doc", TableName: truncatedIdentifier(path[0])}
+				return sql.InfoTableLocation{TableSchema: "doc", TableName: path[0]}
 			} else {
-				return sql.InfoTableLocation{TableSchema: truncatedIdentifier(path[0]), TableName: truncatedIdentifier(path[1])}
+				return sql.InfoTableLocation{TableSchema: path[0], TableName: path[1]}
 			}
 		}),
-		ColumnLocatorer: sql.ColumnLocatorFn(func(field string) string { return truncatedIdentifier(field) }),
+		ColumnLocatorer: sql.ColumnLocatorFn(func(field string) string { return field }),
 		Identifierer: sql.IdentifierFn(sql.JoinTransform(".",
 			sql.PassThroughTransform(
 				func(s string) bool {
@@ -97,7 +95,6 @@ var crateDialect = func() sql.Dialect {
 			return fmt.Sprintf("$%d", index+1)
 		}),
 		TypeMapper:             mapper,
-		MaxColumnCharLength:    0, // Postgres automatically truncates column names that are too long
 		CaseInsensitiveColumns: false,
 	}
 }()
@@ -313,26 +310,3 @@ UPDATE {{ Identifier $.TablePath }}
 	tplInstallFence      = tplAll.Lookup("installFence")
 	tplUpdateFence       = tplAll.Lookup("updateFence")
 )
-
-// truncatedIdentifier produces a truncated form of an identifier, in accordance with Postgres'
-// automatic truncation of identifiers that are over 63 bytes in length. For example, if a Flow
-// collection or field name is over 63 bytes in length, Postgres will let a table/column be created
-// with that as an identifier, but automatically truncates the identifier when interacting with it.
-// This means we have to be aware of this possible truncation when querying the information_schema
-// view.
-func truncatedIdentifier(in string) string {
-	maxByteLength := 63
-
-	if len(in) <= maxByteLength {
-		return in
-	}
-
-	bytes := []byte(in)
-	for maxByteLength >= 0 && !utf8.Valid(bytes[:maxByteLength]) {
-		// Don't mangle multi-byte characters; this seems to be consistent with Postgres truncation
-		// as well.
-		maxByteLength -= 1
-	}
-
-	return string(bytes[:maxByteLength])
-}

--- a/tests/materialize/fixture.json
+++ b/tests/materialize/fixture.json
@@ -93,5 +93,9 @@
     ["tests/duplicated-keys", { "id": 8, "int": 13, "str": "str 13"}],
     ["tests/duplicated-keys", { "id": 9, "int": 14, "str": "str 14"}],
     ["tests/duplicated-keys", { "id": 10, "int": 15, "str": "str 15"}]
+  ],
+  [
+    ["tests/underscore-column", { "_id":  1, "__some_field":  "str1"}],
+    ["tests/underscore-column", { "_id":  2, "__some_field":  "str2"}]
   ]
 ]

--- a/tests/materialize/flow.json.template
+++ b/tests/materialize/flow.json.template
@@ -162,6 +162,17 @@
           "reduce": { "strategy": "merge" }
        },
        "key": ["/id"]
+    },
+    "tests/underscore-column": {
+       "schema": {
+       "properties": {
+           "_id": {"type": "integer"},
+           "__some_field": { "type": "string" }
+          },
+          "required": ["_id", "__some_field"],
+          "type": "object"
+       },
+       "key": ["/_id"]
     }
   },
 

--- a/tests/materialize/materialize-cratedb/setup.sh
+++ b/tests/materialize/materialize-cratedb/setup.sh
@@ -87,12 +87,6 @@ resources_json_template='[
   },
   {
     "resource": {
-      "table": "unsigned_bigint"
-    },
-    "source": "${TEST_COLLECTION_UNSIGNED_BIGINT}"
-  },
-  {
-    "resource": {
       "table": "deletions"
     },
     "source": "${TEST_COLLECTION_DELETIONS}"

--- a/tests/materialize/materialize-cratedb/setup.sh
+++ b/tests/materialize/materialize-cratedb/setup.sh
@@ -36,6 +36,12 @@ resources_json_template='[
     "source": "${TEST_COLLECTION_DUPLICATED_KEYS}"
   },
   {
+  "resource":{
+      "table": "underscore_column"
+    },
+    "source": "${TEST_COLLECTION_UNDERSCORE_COLUMN}"
+  },
+  {
     "resource": {
       "table": "duplicate_keys_delta",
       "delta_updates": true

--- a/tests/materialize/run.sh
+++ b/tests/materialize/run.sh
@@ -50,6 +50,7 @@ export TEST_COLLECTION_UNSIGNED_BIGINT="tests/unsigned-bigint"
 export TEST_COLLECTION_DELETIONS="tests/deletions"
 export TEST_COLLECTION_BINARY_KEY="tests/binary-key"
 export TEST_COLLECTION_STRING_ESCAPED_KEY="tests/string-escaped-key"
+export TEST_COLLECTION_UNDERSCORE_COLUMN="tests/underscore-column"
 
 function decrypt_config {
   sops --output-type json --decrypt $1 | jq 'walk( if type == "object" then with_entries(.key |= rtrimstr("_sops")) else . end)' 


### PR DESCRIPTION
**Description:**
Some column names CrateDB does not allow, for example _id, since it's a system reserved column, because of this, any column that starts with underscore is not valid.

Fixes https://github.com/crate/cratedb-estuary/issues/13

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2766)
<!-- Reviewable:end -->
