### PR TITLE
source-salesforce-native: further reduce max set size for reading bulk job results

### DIFF
--- a/source-salesforce-native/source_salesforce_native/bulk_job_manager.py
+++ b/source-salesforce-native/source_salesforce_native/bulk_job_manager.py
@@ -24,7 +24,7 @@ from .models import (
 INITIAL_SLEEP = 0.2
 MAX_SLEEP = 300
 ATTEMPT_LOG_THRESHOLD = 10
-MAX_BULK_QUERY_SET_SIZE = 100_000
+MAX_BULK_QUERY_SET_SIZE = 25_000
 
 COUNT_HEADER = "Sforce-NumberOfRecords"
 CANNOT_FETCH_COMPOUND_DATA = r"Selecting compound data not supported in Bulk Query"


### PR DESCRIPTION
**Description:**

We've still seen instances of backfills hanging when reading bulk job results, albeit less frequently. I suspect the bulk job query set size I chose in https://github.com/estuary/connectors/pull/2756 is still too high to work well for all situations (mostly those with large document sizes), so I'm reducing it even further.

An alternative solution is to only checkpoint between HTTP requests for bulk jobs. That would avoid potentially lengthy checkpoints in the middle of the connector processing an HTTP response, but it would also complicate the cursor management logic & cause that logic to differ between REST API queries and Bulk API queries. Instead of sinking time into that solution, I'm reducing the max set size further since that's a much smaller & quicker change.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

Tested on a local stack with a bulk job that caused the a production capture to hang silently. Confirmed the connector works through the bulk job's results without hanging.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2768)
<!-- Reviewable:end -->
