### PR TITLE
source-shopify-native: only cancel ongoing jobs when opening bindings

### DIFF
--- a/source-shopify-native/source_shopify_native/__init__.py
+++ b/source-shopify-native/source_shopify_native/__init__.py
@@ -58,6 +58,6 @@ class Connector(
         log: Logger,
         open: request.Open[EndpointConfig, ResourceConfig, ConnectorState],
     ) -> tuple[response.Opened, Callable[[Task], Awaitable[None]]]:
-        resources = await all_resources(log, self, open.capture.config)
+        resources = await all_resources(log, self, open.capture.config, should_cancel_ongoing_job=True)
         resolved = common.resolve_bindings(open.capture.bindings, resources)
         return common.open(open, resolved)


### PR DESCRIPTION
**Description:**

I've noticed unexpected logs in production captures, stating `BulkJobError: Unanticipated status CANCELING for job gid://shopify/BulkOperation/123456789.` This has been logged right after the same bulk job completed, which is a little perplexing. I'm suspecting that we're canceling our own ongoing bulk jobs during auto-discovers, causing these failures & seemingly random bulk job cancellations.

The connector should now only cancel bulk jobs only after receiving an `Open`, and auto-discovers shouldn't cancel bulk jobs any more.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2769)
<!-- Reviewable:end -->
