### PR TITLE
snowflake: fix SHOW PIPES scan destination count

### DIFF
--- a/materialize-snowflake/snowflake.go
+++ b/materialize-snowflake/snowflake.go
@@ -1019,7 +1019,7 @@ func (d *transactor) cleanupPipes(ctx context.Context, currentPipeNames []string
 		// a string value to discard all the columns we don't want from SHOW PIPES
 		var x stdsql.NullString
 		var created time.Time
-		if err := rows.Scan(&created, &name, &db, &schema, &x, &x, &x, &x, &x, &x, &x, &x, &x, &x, &x); err != nil {
+		if err := rows.Scan(&created, &name, &db, &schema, &x, &x, &x, &x, &x, &x, &x, &x, &x, &x); err != nil {
 			return fmt.Errorf("scanning pipe: %w", err)
 		}
 


### PR DESCRIPTION
**Description:**

- Snowflake seems to be now returning 14 columns instead of 15, despite their docs also showing 15

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2770)
<!-- Reviewable:end -->
