### PR TITLE
materialize-elasticsearch: cap request retry delay

### DIFF
--- a/materialize-elasticsearch/driver.go
+++ b/materialize-elasticsearch/driver.go
@@ -257,7 +257,7 @@ func (c config) toClient(disableRetry bool) (*client, error) {
 			APIKey:              c.Credentials.ApiKey,
 			RetryOnStatus:       []int{429, 502, 503, 504},
 			RetryBackoff: func(i int) time.Duration {
-				d := time.Duration(1<<i) * time.Second
+				d := min(time.Duration(1<<i)*time.Second, 5*time.Second)
 				log.WithFields(log.Fields{
 					"attempt": i,
 					"delay":   d.String(),


### PR DESCRIPTION
**Description:**

Previously there was no upper limit on the retry delay for requests, and it would get very long if there was a request that was never going to succeed. This caps the retry delay to something reasonable, so that intermittent failures can be retried, but if they are doomed to fail they'll do so in a timely manner.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

