### PR TITLE
source-iterable: fix checkpointing behavior for `IterableExportStream` and family

### DIFF
--- a/source-iterable/source_iterable/streams.py
+++ b/source-iterable/source_iterable/streams.py
@@ -786,10 +786,14 @@ class Users(IterableExportStreamRanged):
 
 
     def read_records(self, **kwargs) -> Iterable[Mapping[str, Any]]:
-        for record in super().read_records(**kwargs):
+        # These datetime fields are not ISO 8601 compliant, so we re-format them so they comply
+        # with their schematized format: datetime annotation.
+        DATETIME_FIELDS_TO_FORMAT = ["signupDate", "shopify_created_at", "shopify_updated_at"]
 
-            if record.get("signupDate"):
-                record["signupDate"] = datetime.strptime(record["signupDate"], "%Y-%m-%d %H:%M:%S %z")
+        for record in super().read_records(**kwargs):
+            for field in DATETIME_FIELDS_TO_FORMAT:
+                if record.get(field):
+                    record[field] = datetime.strptime(record[field], "%Y-%m-%d %H:%M:%S %z")
             yield record
 
 


### PR DESCRIPTION
**Description:**

Previously, the `IterableExportStream` streams would checkpoint state while processing records in a single response, inspecting the cursor field of each record & yielding it if it's more recent than the state. This works fine if records returned by the API are sorted based on their cursor fields, but the API does no such sorting. Because of that, the connector's state can jump ahead if it's restarted in the middle of processing a response. We've seen this cause lots of missing data.

Since we can't sort the API's results, the connector's been updated to checkpoint the end of the date window after processing all records in the date window. This ensures all records between the start & end are captured before checkpointing, preventing the connector's state from jumping ahead due to a restart.

I also fixed a couple schema violations for `users` as well.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

Tested on a local stack. Confirmed `users` captures significantly more records (300k vs. 39k) and transitioning from the old checkpointing behavior to the new behavior does not cause errors. 

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2772)
<!-- Reviewable:end -->
