### PR TITLE
source-monday: fix handling of empty item responses items backfill

### DIFF
--- a/source-monday/source_monday/graphql.py
+++ b/source-monday/source_monday/graphql.py
@@ -358,9 +358,8 @@ async def fetch_items_by_boards(
     page: int,
     itemsLimit: int,
 ) -> AsyncGenerator[Item | str, None]:
-    """
-    Note: If `board_ids` is not provided, items from all boards will be fetched.
-    """
+    board_cursors: dict[str, str] = {}
+
     response = await execute_query(
         ItemsByBoardResponse,
         http,
@@ -372,17 +371,17 @@ async def fetch_items_by_boards(
             "itemsLimit": itemsLimit,
         },
     )
+
     if not response.data or not response.data.boards:
         log.debug(
             f"Received empty response for page {page} with itemsLimit {itemsLimit}"
         )
         return
 
-    board_cursors: dict[str, str] = {}
-    board_id = None
-
     board = response.data.boards[0]
     items_page = board.items_page
+    board_id = board.id
+
     if items_page.cursor:
         board_cursors[board.id] = items_page.cursor
     else:
@@ -390,7 +389,6 @@ async def fetch_items_by_boards(
 
     for item in items_page.items:
         log.debug(f"Yielding item {item.id} from board {board.id}")
-        board_id = board.id
         yield item
 
     # Monday returns a cursor for each board's items_page. We use this cursor to fetch next items.
@@ -424,7 +422,6 @@ async def fetch_items_by_boards(
                 continue
 
             for item in items_page.items:
-                board_id = b_id
                 yield item
 
             next_cursor = response.data.next_items_page.cursor
@@ -437,10 +434,9 @@ async def fetch_items_by_boards(
     log.debug(
         f"Finished fetching items for board {board_id}. Remaining cursors: {board_cursors.keys()}"
     )
-    if board_id is not None:
-        # This indicates that there was a board for this page, but no items were found.
-        # We should still yield the board ID so that the caller can continue pagination of the boards to get items.
-        yield board_id
+    # Yield the board ID in case we did not have items to yield for this board.
+    # This ensures that the caller continues to the next page of boards.
+    yield board_id
 
 
 ACTIVITY_LOGS = """


### PR DESCRIPTION
**Description:**

There was a small bug introduced in a minor refactor that was apparently not tested as expected. We were backfilling up to the point a board did not have any items. This ensures that we backfill until there are no more boards. That is a key distinction since we want to check each board for items to backfill rather than stopping early when a board may not have items to backfill.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2775)
<!-- Reviewable:end -->
