### PR TITLE
sqlcapture: Emit checkpoint after SourcedSchemas

### DIFF
--- a/sqlcapture/capture.go
+++ b/sqlcapture/capture.go
@@ -220,6 +220,8 @@ func (c *Capture) Run(ctx context.Context) (err error) {
 				return fmt.Errorf("error discovering database tables: %w", err)
 			} else if err := c.emitSourcedSchemas(discovery); err != nil {
 				return err
+			} else if err := c.emitState(); err != nil { // Emit state so any SourcedSchema changes commit immediately.
+				return err
 			}
 			// If any streams are currently pending, initialize them so they can start backfilling.
 			if err := c.activatePendingStreams(ctx, discovery, replStream); err != nil {


### PR DESCRIPTION
**Description:**

This avoids an extra one-minute delay when the DB is idle.
