### PR TITLE
source-postgres: Avoid nil dereference in edge case

### DIFF
--- a/source-postgres/datatypes.go
+++ b/source-postgres/datatypes.go
@@ -443,15 +443,19 @@ func formatRFC3339(t time.Time) (any, error) {
 
 func (db *postgresDatabase) translateArray(column *sqlcapture.ColumnInfo, isPrimaryKey bool, x pgtype.Array[any]) (any, error) {
 	// Construct a ColumnInfo representing a theoretical scalar version of the array column
-	var scalarColumn = *column
-	if str, ok := scalarColumn.DataType.(string); ok {
-		scalarColumn.DataType = strings.TrimLeft(str, "_")
+	var scalarColumn *sqlcapture.ColumnInfo
+	if column != nil {
+		var copyColumn = *column
+		scalarColumn = &copyColumn
+		if str, ok := scalarColumn.DataType.(string); ok {
+			scalarColumn.DataType = strings.TrimLeft(str, "_")
+		}
 	}
 
 	// Translate the values of x.Elements in place (since we're discarding the original
 	// pgtype.Array value after this).
 	for idx := range x.Elements {
-		var translated, err = db.translateRecordField(&scalarColumn, isPrimaryKey, x.Elements[idx])
+		var translated, err = db.translateRecordField(scalarColumn, isPrimaryKey, x.Elements[idx])
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
**Description:**

The translateArray function constructs a "hypothetical scalar equivalent" column metadata which is used for the recursive translation of element values, however in some edge cases we may not actually have column metadata for the value in the first place.

If that happens, we should roll with it and produce a nil value for the scalar equivalent column as well.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2779)
<!-- Reviewable:end -->
