### PR TITLE
materialize-motherduck: add merge bounds to load and store queries

### DIFF
--- a/materialize-motherduck/.snapshots/TestSQLGeneration
+++ b/materialize-motherduck/.snapshots/TestSQLGeneration
@@ -55,9 +55,9 @@ JOIN read_json(
 		"key!binary": 'VARCHAR NOT NULL'
 	}
 ) AS r
-	 ON  l.key1 = r.key1
+	 ON  l.key1 = r.key1 AND l.key1 >= 10 AND l.key1 <= 100
 	 AND l.key2 = r.key2
-	 AND l."key!binary" = r."key!binary"
+	 AND l."key!binary" = r."key!binary" AND l."key!binary" >= 'aGVsbG8K' AND l."key!binary" <= 'Z29vZGJ5ZQo='
 --- End ""."a-schema".key_value loadQuery ---
 
 --- Begin ""."a-schema".key_value storeDeleteQuery ---
@@ -89,9 +89,9 @@ USING read_json(
 		flow_document: 'JSON NOT NULL'
 	}
 ) AS r
-	 WHERE l.key1 = r.key1
+	 WHERE l.key1 = r.key1 AND l.key1 >= 10 AND l.key1 <= 100
 	 AND l.key2 = r.key2
-	 AND l."key!binary" = r."key!binary";
+	 AND l."key!binary" = r."key!binary" AND l."key!binary" >= 'aGVsbG8K' AND l."key!binary" <= 'Z29vZGJ5ZQo=';
 --- End ""."a-schema".key_value storeDeleteQuery ---
 
 --- Begin ""."a-schema".key_value storeQuery ---
@@ -124,25 +124,6 @@ SELECT * FROM read_json(
 	}
 ) WHERE flow_document != '"delete"';
 --- End ""."a-schema".key_value storeQuery ---
-
---- Begin ""."a-schema".delta_updates loadQuery ---
-SELECT * FROM (SELECT -1, CAST(NULL AS JSON) LIMIT 0) as nodoc
---- End ""."a-schema".delta_updates loadQuery ---
-
---- Begin ""."a-schema".delta_updates storeDeleteQuery ---
-DELETE FROM ""."a-schema".delta_updates AS l
-USING read_json(
-	['s3://bucket/file1', 's3://bucket/file2'],
-	format='newline_delimited',
-	compression='gzip',
-	columns={
-		"theKey": 'VARCHAR NOT NULL',
-		"aValue": 'BIGINT',
-		flow_published_at: 'TIMESTAMP WITH TIME ZONE NOT NULL'
-	}
-) AS r
-	 WHERE l."theKey" = r."theKey";
---- End ""."a-schema".delta_updates storeDeleteQuery ---
 
 --- Begin ""."a-schema".delta_updates storeQuery ---
 INSERT INTO ""."a-schema".delta_updates BY NAME

--- a/materialize-motherduck/sqlgen_test.go
+++ b/materialize-motherduck/sqlgen_test.go
@@ -28,21 +28,57 @@ func TestSQLGeneration(t *testing.T) {
 		},
 	)
 
-	for _, tbl := range tables {
-		for _, tpl := range []*template.Template{
-			tplLoadQuery,
-			tplStoreDeleteQuery,
-			tplStoreQuery,
-		} {
-			var testcase = tbl.Identifier + " " + tpl.Name()
+	for _, tpl := range []*template.Template{
+		tplLoadQuery,
+		tplStoreDeleteQuery,
+		tplStoreQuery,
+	} {
+		// Standard updates cases, which use merge bounds for load and merge
+		// queries.
+		tbl := tables[0]
+		require.False(t, tbl.DeltaUpdates)
+		var testcase = tbl.Identifier + " " + tpl.Name()
 
-			snap.WriteString("--- Begin " + testcase + " ---")
-			require.NoError(t, tpl.Execute(snap, &queryParams{
-				Table: tbl,
-				Files: []string{"s3://bucket/file1", "s3://bucket/file2"},
-			}))
-			snap.WriteString("--- End " + testcase + " ---\n\n")
+		bounds := []sql.MergeBound{
+			{
+				Column:       tbl.Keys[0],
+				LiteralLower: duckDialect.Literal(int64(10)),
+				LiteralUpper: duckDialect.Literal(int64(100)),
+			},
+			{
+				Column: tbl.Keys[1],
+				// No bounds - as would be the case for a boolean key, which
+				// would be a very weird key, but technically allowed.
+			},
+			{
+				Column:       tbl.Keys[2],
+				LiteralLower: duckDialect.Literal("aGVsbG8K"),
+				LiteralUpper: duckDialect.Literal("Z29vZGJ5ZQo="),
+			},
 		}
+
+		snap.WriteString("--- Begin " + testcase + " ---")
+		require.NoError(t, tpl.Execute(snap, &queryParams{
+			Table:  tbl,
+			Bounds: bounds,
+			Files:  []string{"s3://bucket/file1", "s3://bucket/file2"},
+		}))
+		snap.WriteString("--- End " + testcase + " ---\n\n")
+	}
+
+	{
+		// Delta updates only run stores, never loads or merges.
+		tpl := tplStoreQuery
+		tbl := tables[1]
+		require.True(t, tbl.DeltaUpdates)
+		var testcase = tbl.Identifier + " " + tpl.Name()
+
+		snap.WriteString("--- Begin " + testcase + " ---")
+		require.NoError(t, tpl.Execute(snap, &queryParams{
+			Table: tbl,
+			Files: []string{"s3://bucket/file1", "s3://bucket/file2"},
+		}))
+		snap.WriteString("--- End " + testcase + " ---\n\n")
 	}
 
 	cupaloy.SnapshotT(t, snap.String())


### PR DESCRIPTION
**Description:**

Adds merge bounds to load and store queries in MotherDuck, as we have added for the other warehouse materializations.

In the past I have mentioned a desire to have a more principled way to generally incorporate the "bounds" concept in materializations, since most of them will want access to those. My best idea for this so far is to incorporate them into the transactor, but that would also require more deeply incorporating the concept of "value converters" that materializations use to convert values to their specific needs. Probably a good idea, but a lot more work.

But there is an immediate use case for performance optimization of MotherDuck load queries, and following this pattern that we have used before is relatively simple and realistically I don't know if I'm ever going to get around to doing it in a more elegant way.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2788)
<!-- Reviewable:end -->
