### PR TITLE
estuary-cdk: connectorStatus logging for captures that use common.open_binding

### DIFF
--- a/estuary-cdk/estuary_cdk/capture/base_capture_connector.py
+++ b/estuary-cdk/estuary_cdk/capture/base_capture_connector.py
@@ -1,3 +1,4 @@
+from estuary_cdk.capture.connector_status import ConnectorStatus
 from pydantic import BaseModel
 from typing import Generic, Awaitable, Any, BinaryIO, Callable
 from logging import Logger
@@ -109,11 +110,13 @@ class BaseCaptureConnector(
 
                 task = Task(
                     log.getChild("capture"),
+                    ConnectorStatus(log, stopping, tg),
                     "capture",
                     self.output,
                     stopping,
                     tg,
                 )
+                log.event.status("Capture started")
                 await capture(task)
 
             # When capture() completes, the connector exits.

--- a/estuary-cdk/estuary_cdk/capture/common.py
+++ b/estuary-cdk/estuary_cdk/capture/common.py
@@ -632,6 +632,7 @@ def open_binding(
     the state for each subtask in state.inc, state.backfill, or state.snapshot.
     """
 
+    task.connector_status.inc_binding_count()
     prefix = ".".join(binding.resourceConfig.path())
 
     if fetch_changes:
@@ -687,6 +688,7 @@ def open_binding(
             subtask_id: str | None = None,
         ):
             assert state and not isinstance(state, dict)
+            task.connector_status.inc_backfilling(binding_index)
             await _binding_backfill_task(
                 binding,
                 binding_index,
@@ -697,6 +699,7 @@ def open_binding(
                 task,
                 subtask_id,
             )
+            task.connector_status.dec_backfilling(binding_index)
 
         if isinstance(fetch_page, dict):
             assert resource_state.backfill and isinstance(resource_state.backfill, dict)

--- a/estuary-cdk/estuary_cdk/capture/connector_status.py
+++ b/estuary-cdk/estuary_cdk/capture/connector_status.py
@@ -1,0 +1,69 @@
+import asyncio
+from asyncio import TaskGroup
+from collections import defaultdict
+import typing
+
+from estuary_cdk.logger import FlowLogger
+
+if typing.TYPE_CHECKING:
+    from estuary_cdk.capture.task import Task
+    StoppingType = Task.Stopping
+else:
+    StoppingType = typing.Any
+
+
+class ConnectorStatus:
+    """
+    Centralized instrumentation and logging of connectorStatus messages.
+
+    For captures that use common.open_binding(), this keeps track of how many
+    bindings there are in total, and how many are backfilling. Changes to these
+    counts will be logged as connectorStatus's.
+    """
+
+    def __init__(self, log: FlowLogger, stopping: StoppingType, tg: TaskGroup):
+        async def periodic_log():
+            # Allow some initial setup time for bindings to be registered before
+            # starting to poll for status changes every second.
+            await asyncio.sleep(5)
+            while not stopping.event.is_set():
+                self._log_status()
+                await asyncio.sleep(1)
+
+        tg.create_task(periodic_log())
+
+        self.log = log
+        self.binding_count = 0
+        self.binding_backfill_counts = defaultdict(int)
+        self.should_log = False
+
+    def inc_binding_count(self):
+        self.binding_count += 1
+        self.should_log = True
+
+    def inc_backfilling(self, binding_idx: int):
+        self.binding_backfill_counts[binding_idx] += 1
+        self.should_log = True
+
+    def dec_backfilling(self, binding_idx: int):
+        if binding_idx not in self.binding_backfill_counts:
+            raise Exception(
+                f"cannot decrement backfilling count for binding idx {binding_idx} because it is not in binding_backfill_counts"
+            )
+
+        self.binding_backfill_counts[binding_idx] -= 1
+        if self.binding_backfill_counts[binding_idx] == 0:
+            del self.binding_backfill_counts[binding_idx]
+
+        self.should_log = True
+
+    def _log_status(self):
+        if not self.should_log:
+            return
+
+        if (backfill_count := len(self.binding_backfill_counts)) > 0:
+            self.log.event.status(f"Backfilling {backfill_count} out of {self.binding_count} bindings")
+        else:
+            self.log.event.status(f"Streaming change events (all {self.binding_count} bindings are backfilled)")
+
+        self.should_log = False

--- a/estuary-cdk/estuary_cdk/capture/task.py
+++ b/estuary-cdk/estuary_cdk/capture/task.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass
 import decimal
+from estuary_cdk.capture.connector_status import ConnectorStatus
 from pydantic import Field
 from typing import Generic, Awaitable, Any, BinaryIO, Callable
 import orjson
@@ -72,6 +73,9 @@ class Task:
     log: Logger
     """Attached Logger of this Task instance, to use for scoped logging."""
 
+    connector_status: ConnectorStatus
+    """Shared ConnectorStatus instance of the entire capture."""
+
     @dataclass
     class Stopping:
         """
@@ -102,6 +106,7 @@ class Task:
     def __init__(
         self,
         log: Logger,
+        connector_status: ConnectorStatus,
         name: str,
         output: BinaryIO,
         stopping: Stopping,
@@ -113,6 +118,7 @@ class Task:
         self._output = output
         self._tg = tg
         self.log = log
+        self.connector_status = connector_status
         self.stopping = stopping
 
     def captured(self, binding: int, document: Any):
@@ -186,6 +192,7 @@ class Task:
                 try:
                     t = Task(
                         child_log,
+                        parent.connector_status,
                         child_name,
                         parent._output,
                         parent.stopping,


### PR DESCRIPTION
**Description:**

Adds some general logging of connectorStatus events for captures that use common.open_binding, which is currently ~all of them.

It is modeled after the SQL captures, which indicate how many bindings are still backfilling, or if they are all backfilled.

The CDK is highly async, with tasks that can spawn subtasks, and the structure of the CDK status logging reflects that. There's no primary loop that drives backfills & incremental captures in turn (they all kind of run at the same time), so the status logging itself runs on a polling loop that checks for any changes in the metrics we are logging about.

Closes [#2738](https://github.com/estuary/connectors/issues/2738)

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2790)
<!-- Reviewable:end -->
