### PR TITLE
source-sqlserver: Never emit nulls on NOT NULL column deletions

### DIFF
--- a/source-sqlserver/.snapshots/TestBitNotNullDeletion
+++ b/source-sqlserver/.snapshots/TestBitNotNullDeletion
@@ -1,0 +1,24 @@
+# ================================
+# Collection "acmeCo/test/dbo/test_bitnotnulldeletion_32831599": 16 Documents
+# ================================
+{"_meta":{"op":"c","source":{"schema":"dbo","snapshot":true,"table":"test_BitNotNullDeletion_32831599","lsn":"","seqval":"AAAAAAAAAAAAAA=="}},"id":100,"v_a":true,"v_b":true,"v_c":true,"v_d":true}
+{"_meta":{"op":"c","source":{"schema":"dbo","snapshot":true,"table":"test_BitNotNullDeletion_32831599","lsn":"","seqval":"AAAAAAAAAAAAAA=="}},"id":101,"v_a":false,"v_b":false,"v_c":false,"v_d":false}
+{"_meta":{"op":"c","source":{"schema":"dbo","snapshot":true,"table":"test_BitNotNullDeletion_32831599","lsn":"","seqval":"AAAAAAAAAAAAAA=="}},"id":102,"v_a":null,"v_b":true,"v_c":true,"v_d":true}
+{"_meta":{"op":"c","source":{"schema":"dbo","snapshot":true,"table":"test_BitNotNullDeletion_32831599","lsn":"","seqval":"AAAAAAAAAAAAAA=="}},"id":103,"v_a":null,"v_b":false,"v_c":false,"v_d":false}
+{"_meta":{"op":"d","source":{"schema":"dbo","table":"test_BitNotNullDeletion_32831599","lsn":"AAAAAAAAAAAAAA==","seqval":"AAAAAAAAAAAAAA==","updateMask":"Hw=="}},"id":100,"v_a":true,"v_b":true,"v_c":true,"v_d":true}
+{"_meta":{"op":"d","source":{"schema":"dbo","table":"test_BitNotNullDeletion_32831599","lsn":"AAAAAAAAAAAAAA==","seqval":"AAAAAAAAAAAAAA==","updateMask":"Hw=="}},"id":101,"v_a":false,"v_b":false,"v_c":false,"v_d":false}
+{"_meta":{"op":"d","source":{"schema":"dbo","table":"test_BitNotNullDeletion_32831599","lsn":"AAAAAAAAAAAAAA==","seqval":"AAAAAAAAAAAAAA==","updateMask":"Hw=="}},"id":102,"v_a":null,"v_b":true,"v_c":true,"v_d":true}
+{"_meta":{"op":"d","source":{"schema":"dbo","table":"test_BitNotNullDeletion_32831599","lsn":"AAAAAAAAAAAAAA==","seqval":"AAAAAAAAAAAAAA==","updateMask":"Hw=="}},"id":103,"v_a":null,"v_b":false,"v_c":false,"v_d":false}
+{"_meta":{"op":"c","source":{"schema":"dbo","table":"test_BitNotNullDeletion_32831599","lsn":"AAAAAAAAAAAAAA==","seqval":"AAAAAAAAAAAAAA==","updateMask":"Hw=="}},"id":200,"v_a":true,"v_b":true,"v_c":true,"v_d":true}
+{"_meta":{"op":"c","source":{"schema":"dbo","table":"test_BitNotNullDeletion_32831599","lsn":"AAAAAAAAAAAAAA==","seqval":"AAAAAAAAAAAAAA==","updateMask":"Hw=="}},"id":201,"v_a":false,"v_b":false,"v_c":false,"v_d":false}
+{"_meta":{"op":"c","source":{"schema":"dbo","table":"test_BitNotNullDeletion_32831599","lsn":"AAAAAAAAAAAAAA==","seqval":"AAAAAAAAAAAAAA==","updateMask":"Hw=="}},"id":202,"v_a":null,"v_b":true,"v_c":true,"v_d":true}
+{"_meta":{"op":"c","source":{"schema":"dbo","table":"test_BitNotNullDeletion_32831599","lsn":"AAAAAAAAAAAAAA==","seqval":"AAAAAAAAAAAAAA==","updateMask":"Hw=="}},"id":203,"v_a":null,"v_b":false,"v_c":false,"v_d":false}
+{"_meta":{"op":"d","source":{"schema":"dbo","table":"test_BitNotNullDeletion_32831599","lsn":"AAAAAAAAAAAAAA==","seqval":"AAAAAAAAAAAAAA==","updateMask":"Hw=="}},"id":200,"v_a":true,"v_b":true,"v_c":true,"v_d":true}
+{"_meta":{"op":"d","source":{"schema":"dbo","table":"test_BitNotNullDeletion_32831599","lsn":"AAAAAAAAAAAAAA==","seqval":"AAAAAAAAAAAAAA==","updateMask":"Hw=="}},"id":201,"v_a":false,"v_b":false,"v_c":false,"v_d":false}
+{"_meta":{"op":"d","source":{"schema":"dbo","table":"test_BitNotNullDeletion_32831599","lsn":"AAAAAAAAAAAAAA==","seqval":"AAAAAAAAAAAAAA==","updateMask":"Hw=="}},"id":202,"v_a":null,"v_b":true,"v_c":true,"v_d":true}
+{"_meta":{"op":"d","source":{"schema":"dbo","table":"test_BitNotNullDeletion_32831599","lsn":"AAAAAAAAAAAAAA==","seqval":"AAAAAAAAAAAAAA==","updateMask":"Hw=="}},"id":203,"v_a":null,"v_b":false,"v_c":false,"v_d":false}
+# ================================
+# Final State Checkpoint
+# ================================
+{"bindingStateV1":{"dbo%2Ftest_BitNotNullDeletion_32831599":{"backfilled":4,"key_columns":["id"],"mode":"Active"}},"cursor":"AAAAAAAAAAAAAA=="}
+


### PR DESCRIPTION
**Description:**

We have now observed multiple unrelated SQL Server captures in production where a `BIT NOT NULL` column is/was captured as a null value in a deletion event. This should never happen [1] and is a pretty clear-cut violation of the documented CDC behavior around deletions, but nonetheless it's happened and continues happening so we need to deal with it somehow.

This PR fixes the entire class of issues by extending the existing "omit null values of image/text/ntext column in deletes" logic to also apply to null values of any column which should be non-nullable according to the source table schema.

[1] I suspect that there's an actual database bug here, possibly related to the decoding of multiple `BIT NOT NULL` columns packed into whatever sort of bitfield the SQL Server WAL encoding uses. In all cases where we've observed this happening, the table had multiple `BIT NOT NULL` columns, of which only one was impacted in this way, and in at least one case it was also the last column of the table.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2796)
<!-- Reviewable:end -->
