### PR TITLE
source-hubspot-native: hide access token auth in UI

### DIFF
--- a/source-hubspot-native/tests/snapshots/snapshots__spec__stdout.json
+++ b/source-hubspot-native/tests/snapshots/snapshots__spec__stdout.json
@@ -69,9 +69,6 @@
           "oneOf": [
             {
               "$ref": "#/$defs/_OAuth2Credentials"
-            },
-            {
-              "$ref": "#/$defs/AccessToken"
             }
           ],
           "title": "Authentication"


### PR DESCRIPTION
**Description:**

In order to publish this connector in the HubSpot marketplace, HubSpot requires that "setup documentation [and] in platform experience should not include an app that requires API keys in order to be installed". Essentially, users should only be presented the option to authenticate with OAuth in the UI.

There are already existing captures authenticating with access tokens, so we can't simply strip out support for access token authentication. Patching model_json_schema to remove AccessToken makes OAuth2 the only authentication option in the UI, and effectively "hides" the capability to use access tokens. This should satisfy HubSpot's requirement while retaining support for access token authentication for already created captures.

Editing an existing capture that authenticates with an access token will either have to be done via `flowctl` to maintain the access token auth option or will have to be re-authenticated with OAuth2 in the UI.

Addresses a portion of this [draft issue](https://github.com/orgs/estuary/projects/13?pane=issue&itemId=90884122).

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

This connector's docs need updated to reflect that OAuth2 is the only way to authenticate the connector (this is _also_ required before listing the connector in HubSpot's marketplace).

**Notes for reviewers:**

Tested on a local stack. Confirmed:
- access token auth is no longer shown as an authentication option in the UI.
![image](https://github.com/user-attachments/assets/9a625f2b-1665-4b19-a831-194b48a5560f)
- an existing capture using access token authentication still works.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2797)
<!-- Reviewable:end -->
