### PR TITLE
source-{postgres,redshift}-batch: Add SourcedSchema feature flag

### DIFF
--- a/source-postgres-batch/.snapshots/TestArrayTypes-Discovery
+++ b/source-postgres-batch/.snapshots/TestArrayTypes-Discovery
@@ -61,7 +61,11 @@ Binding 0:
           },
           "id": {
             "type": "integer"
-          }
+          },
+          "int_array": {},
+          "real_array": {},
+          "text_array": {},
+          "uuid_array": {}
         },
         "x-infer-schema": true
       },

--- a/source-postgres-batch/.snapshots/TestAsyncCapture-Discovery
+++ b/source-postgres-batch/.snapshots/TestAsyncCapture-Discovery
@@ -59,6 +59,12 @@ Binding 0:
               "row_id"
             ]
           },
+          "data": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
           "id": {
             "type": "integer"
           }

--- a/source-postgres-batch/.snapshots/TestBinaryTypes-Discovery
+++ b/source-postgres-batch/.snapshots/TestBinaryTypes-Discovery
@@ -59,6 +59,43 @@ Binding 0:
               "row_id"
             ]
           },
+          "bit3_col": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "bit_col": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "bitvar5_col": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "bitvar_col": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "bool_col": {
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
+          "bytea_col": {
+            "contentEncoding": "base64",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
           "id": {
             "type": "integer"
           }

--- a/source-postgres-batch/.snapshots/TestCaptureFromView-DiscoveryWithViews
+++ b/source-postgres-batch/.snapshots/TestCaptureFromView-DiscoveryWithViews
@@ -61,6 +61,25 @@ Binding 0:
           },
           "id": {
             "type": "integer"
+          },
+          "name": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "updated_at": {
+            "format": "date-time",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "visible": {
+            "type": [
+              "boolean",
+              "null"
+            ]
           }
         },
         "x-infer-schema": true
@@ -127,6 +146,25 @@ Binding 1:
               "polled",
               "index",
               "row_id"
+            ]
+          },
+          "id": {
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "name": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "updated_at": {
+            "format": "date-time",
+            "type": [
+              "string",
+              "null"
             ]
           }
         },

--- a/source-postgres-batch/.snapshots/TestCaptureFromView-DiscoveryWithoutViews
+++ b/source-postgres-batch/.snapshots/TestCaptureFromView-DiscoveryWithoutViews
@@ -61,6 +61,25 @@ Binding 0:
           },
           "id": {
             "type": "integer"
+          },
+          "name": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "updated_at": {
+            "format": "date-time",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "visible": {
+            "type": [
+              "boolean",
+              "null"
+            ]
           }
         },
         "x-infer-schema": true

--- a/source-postgres-batch/.snapshots/TestCaptureWithEmptyPoll-Discovery
+++ b/source-postgres-batch/.snapshots/TestCaptureWithEmptyPoll-Discovery
@@ -59,6 +59,12 @@ Binding 0:
               "row_id"
             ]
           },
+          "data": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
           "id": {
             "type": "integer"
           }

--- a/source-postgres-batch/.snapshots/TestCaptureWithTwoColumnCursor-Discovery
+++ b/source-postgres-batch/.snapshots/TestCaptureWithTwoColumnCursor-Discovery
@@ -60,8 +60,26 @@ Binding 0:
               "row_id"
             ]
           },
+          "data": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
           "id": {
             "type": "integer"
+          },
+          "major": {
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "minor": {
+            "type": [
+              "integer",
+              "null"
+            ]
           }
         },
         "x-infer-schema": true

--- a/source-postgres-batch/.snapshots/TestCaptureWithUpdatedAtCursor-Discovery
+++ b/source-postgres-batch/.snapshots/TestCaptureWithUpdatedAtCursor-Discovery
@@ -59,8 +59,21 @@ Binding 0:
               "row_id"
             ]
           },
+          "data": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
           "id": {
             "type": "integer"
+          },
+          "updated_at": {
+            "format": "date-time",
+            "type": [
+              "string",
+              "null"
+            ]
           }
         },
         "x-infer-schema": true

--- a/source-postgres-batch/.snapshots/TestDateAndTimeTypes-Discovery
+++ b/source-postgres-batch/.snapshots/TestDateAndTimeTypes-Discovery
@@ -59,8 +59,48 @@ Binding 0:
               "row_id"
             ]
           },
+          "date_col": {
+            "format": "date-time",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
           "id": {
             "type": "integer"
+          },
+          "interval_col": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "time_col": {
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "timetz_col": {
+            "format": "time",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "ts_col": {
+            "format": "date-time",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "tstz_col": {
+            "format": "date-time",
+            "type": [
+              "string",
+              "null"
+            ]
           }
         },
         "x-infer-schema": true

--- a/source-postgres-batch/.snapshots/TestFeatureFlagEmitSourcedSchemas-Default
+++ b/source-postgres-batch/.snapshots/TestFeatureFlagEmitSourcedSchemas-Default
@@ -1,0 +1,10 @@
+# ================================
+# Collection "acmeCo/test/test_featureflagemitsourcedschemas_960966": 2 Documents
+# ================================
+{"_meta":{"polled":"<TIMESTAMP>","index":0,"row_id":0},"data":"hello","id":1,"txid":999999}
+{"_meta":{"polled":"<TIMESTAMP>","index":1,"row_id":1},"data":"world","id":2,"txid":999999}
+# ================================
+# Final State Checkpoint
+# ================================
+{"bindingStateV1":{"test_featureflagemitsourcedschemas_960966":{"BaseXID":999999,"CursorNames":["txid"],"DocumentCount":2,"LastPolled":"<TIMESTAMP>","Mode":"Incremental (XMIN)","NextXID":0,"ScanTID":""}}}
+

--- a/source-postgres-batch/.snapshots/TestFeatureFlagEmitSourcedSchemas-Disabled
+++ b/source-postgres-batch/.snapshots/TestFeatureFlagEmitSourcedSchemas-Disabled
@@ -1,0 +1,10 @@
+# ================================
+# Collection "acmeCo/test/test_featureflagemitsourcedschemas_960966": 2 Documents
+# ================================
+{"_meta":{"polled":"<TIMESTAMP>","index":0,"row_id":0},"data":"hello","id":1,"txid":999999}
+{"_meta":{"polled":"<TIMESTAMP>","index":1,"row_id":1},"data":"world","id":2,"txid":999999}
+# ================================
+# Final State Checkpoint
+# ================================
+{"bindingStateV1":{"test_featureflagemitsourcedschemas_960966":{"BaseXID":999999,"CursorNames":["txid"],"DocumentCount":2,"LastPolled":"<TIMESTAMP>","Mode":"Incremental (XMIN)","NextXID":0,"ScanTID":""}}}
+

--- a/source-postgres-batch/.snapshots/TestFeatureFlagEmitSourcedSchemas-Enabled
+++ b/source-postgres-batch/.snapshots/TestFeatureFlagEmitSourcedSchemas-Enabled
@@ -1,0 +1,11 @@
+# ================================
+# Collection "acmeCo/test/test_featureflagemitsourcedschemas_960966": 3 Documents
+# ================================
+{"type":"object","required":["_meta","id"],"additionalProperties":false,"properties":{"_meta":{"$schema":"https://json-schema.org/draft/2020-12/schema","$id":"https://github.com/estuary/connectors/source-postgres-batch/document-metadata","properties":{"polled":{"type":"string","format":"date-time","title":"Polled Timestamp","description":"The time at which the update query which produced this document as executed."},"index":{"type":"integer","title":"Result Index","description":"The index of this document within the query execution which produced it."},"row_id":{"type":"integer","title":"Row ID","description":"Row ID of the Document"},"op":{"type":"string","enum":["c","u","d"],"title":"Change Operation","description":"Operation type (c: Create / u: Update / d: Delete)","default":"u"}},"additionalProperties":false,"type":"object","required":["polled","index","row_id"],"additionalProperties":false},"data":{"type":["string"]},"id":{"type":"integer"}},"x-infer-schema":true}
+{"_meta":{"polled":"<TIMESTAMP>","index":0,"row_id":0},"data":"hello","id":1,"txid":999999}
+{"_meta":{"polled":"<TIMESTAMP>","index":1,"row_id":1},"data":"world","id":2,"txid":999999}
+# ================================
+# Final State Checkpoint
+# ================================
+{"bindingStateV1":{"test_featureflagemitsourcedschemas_960966":{"BaseXID":999999,"CursorNames":["txid"],"DocumentCount":2,"LastPolled":"<TIMESTAMP>","Mode":"Incremental (XMIN)","NextXID":0,"ScanTID":""}}}
+

--- a/source-postgres-batch/.snapshots/TestFeatureFlagKeylessRowID-Disabled-Discovery
+++ b/source-postgres-batch/.snapshots/TestFeatureFlagKeylessRowID-Disabled-Discovery
@@ -53,6 +53,18 @@ Binding 0:
               "polled",
               "index"
             ]
+          },
+          "data": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "value": {
+            "type": [
+              "integer",
+              "null"
+            ]
           }
         },
         "x-infer-schema": true

--- a/source-postgres-batch/.snapshots/TestFeatureFlagKeylessRowID-Enabled-Discovery
+++ b/source-postgres-batch/.snapshots/TestFeatureFlagKeylessRowID-Enabled-Discovery
@@ -54,6 +54,18 @@ Binding 0:
               "index",
               "row_id"
             ]
+          },
+          "data": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "value": {
+            "type": [
+              "integer",
+              "null"
+            ]
           }
         },
         "x-infer-schema": true

--- a/source-postgres-batch/.snapshots/TestFullRefresh-Discovery
+++ b/source-postgres-batch/.snapshots/TestFullRefresh-Discovery
@@ -56,6 +56,12 @@ Binding 0:
               "row_id"
             ]
           },
+          "data": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
           "id": {
             "type": "integer"
           }

--- a/source-postgres-batch/.snapshots/TestGeometricTypes-Discovery
+++ b/source-postgres-batch/.snapshots/TestGeometricTypes-Discovery
@@ -59,8 +59,50 @@ Binding 0:
               "row_id"
             ]
           },
+          "box_col": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "circle_col": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
           "id": {
             "type": "integer"
+          },
+          "line_col": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "lseg_col": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "path_col": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "point_col": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "polygon_col": {
+            "type": [
+              "string",
+              "null"
+            ]
           }
         },
         "x-infer-schema": true

--- a/source-postgres-batch/.snapshots/TestIntegerTypes-Discovery
+++ b/source-postgres-batch/.snapshots/TestIntegerTypes-Discovery
@@ -59,7 +59,35 @@ Binding 0:
               "row_id"
             ]
           },
+          "bigint_col": {
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "bigserial_col": {
+            "type": "integer"
+          },
           "id": {
+            "type": "integer"
+          },
+          "int_col": {
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "oid_col": {},
+          "serial_col": {
+            "type": "integer"
+          },
+          "smallint_col": {
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "smallserial_col": {
             "type": "integer"
           }
         },

--- a/source-postgres-batch/.snapshots/TestJSONTypes-Discovery
+++ b/source-postgres-batch/.snapshots/TestJSONTypes-Discovery
@@ -61,6 +61,14 @@ Binding 0:
           },
           "id": {
             "type": "integer"
+          },
+          "json_col": {},
+          "jsonb_col": {},
+          "jsonpath_col": {
+            "type": [
+              "string",
+              "null"
+            ]
           }
         },
         "x-infer-schema": true

--- a/source-postgres-batch/.snapshots/TestKeyDiscovery
+++ b/source-postgres-batch/.snapshots/TestKeyDiscovery
@@ -63,6 +63,12 @@ Binding 0:
               "row_id"
             ]
           },
+          "data": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
           "k_bigint": {
             "type": "integer"
           },

--- a/source-postgres-batch/.snapshots/TestKeylessCapture-Discovery
+++ b/source-postgres-batch/.snapshots/TestKeylessCapture-Discovery
@@ -57,6 +57,18 @@ Binding 0:
               "index",
               "row_id"
             ]
+          },
+          "data": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "value": {
+            "type": [
+              "integer",
+              "null"
+            ]
           }
         },
         "x-infer-schema": true

--- a/source-postgres-batch/.snapshots/TestKeylessFullRefreshCapture-Discovery
+++ b/source-postgres-batch/.snapshots/TestKeylessFullRefreshCapture-Discovery
@@ -54,6 +54,18 @@ Binding 0:
               "index",
               "row_id"
             ]
+          },
+          "data": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "value": {
+            "type": [
+              "integer",
+              "null"
+            ]
           }
         },
         "x-infer-schema": true

--- a/source-postgres-batch/.snapshots/TestModificationsAndDeletions-Discovery
+++ b/source-postgres-batch/.snapshots/TestModificationsAndDeletions-Discovery
@@ -59,8 +59,20 @@ Binding 0:
               "row_id"
             ]
           },
+          "description": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
           "id": {
             "type": "integer"
+          },
+          "version": {
+            "type": [
+              "integer",
+              "null"
+            ]
           }
         },
         "x-infer-schema": true

--- a/source-postgres-batch/.snapshots/TestNetworkTypes-Discovery
+++ b/source-postgres-batch/.snapshots/TestNetworkTypes-Discovery
@@ -59,8 +59,32 @@ Binding 0:
               "row_id"
             ]
           },
+          "cidr_col": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
           "id": {
             "type": "integer"
+          },
+          "inet_col": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "macaddr8_col": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "macaddr_col": {
+            "type": [
+              "string",
+              "null"
+            ]
           }
         },
         "x-infer-schema": true

--- a/source-postgres-batch/.snapshots/TestNumericTypes-Discovery
+++ b/source-postgres-batch/.snapshots/TestNumericTypes-Discovery
@@ -59,8 +59,51 @@ Binding 0:
               "row_id"
             ]
           },
+          "decimal_col": {
+            "format": "number",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "double_col": {
+            "format": "number",
+            "type": [
+              "number",
+              "string",
+              "null"
+            ]
+          },
           "id": {
             "type": "integer"
+          },
+          "money_col": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "numeric_col": {
+            "format": "number",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "numeric_large_col": {
+            "format": "number",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "real_col": {
+            "format": "number",
+            "type": [
+              "number",
+              "string",
+              "null"
+            ]
           }
         },
         "x-infer-schema": true

--- a/source-postgres-batch/.snapshots/TestSchemaFilter-FilteredIn
+++ b/source-postgres-batch/.snapshots/TestSchemaFilter-FilteredIn
@@ -59,6 +59,12 @@ Binding 0:
               "row_id"
             ]
           },
+          "data": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
           "id": {
             "type": "integer"
           }

--- a/source-postgres-batch/.snapshots/TestSchemaFilter-Unfiltered
+++ b/source-postgres-batch/.snapshots/TestSchemaFilter-Unfiltered
@@ -59,6 +59,12 @@ Binding 0:
               "row_id"
             ]
           },
+          "data": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
           "id": {
             "type": "integer"
           }

--- a/source-postgres-batch/.snapshots/TestSimpleCapture-Discovery
+++ b/source-postgres-batch/.snapshots/TestSimpleCapture-Discovery
@@ -59,6 +59,12 @@ Binding 0:
               "row_id"
             ]
           },
+          "data": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
           "id": {
             "type": "integer"
           }

--- a/source-postgres-batch/.snapshots/TestStringTypes-Discovery
+++ b/source-postgres-batch/.snapshots/TestStringTypes-Discovery
@@ -59,8 +59,32 @@ Binding 0:
               "row_id"
             ]
           },
+          "bpchar_col": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "char_col": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
           "id": {
             "type": "integer"
+          },
+          "text_col": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "varchar_col": {
+            "type": [
+              "string",
+              "null"
+            ]
           }
         },
         "x-infer-schema": true

--- a/source-postgres-batch/.snapshots/TestUUIDType-Discovery
+++ b/source-postgres-batch/.snapshots/TestUUIDType-Discovery
@@ -61,6 +61,13 @@ Binding 0:
           },
           "id": {
             "type": "integer"
+          },
+          "uuid_col": {
+            "format": "uuid",
+            "type": [
+              "string",
+              "null"
+            ]
           }
         },
         "x-infer-schema": true

--- a/source-postgres-batch/.snapshots/TestXMLType-Discovery
+++ b/source-postgres-batch/.snapshots/TestXMLType-Discovery
@@ -61,6 +61,12 @@ Binding 0:
           },
           "id": {
             "type": "integer"
+          },
+          "xml_col": {
+            "type": [
+              "string",
+              "null"
+            ]
           }
         },
         "x-infer-schema": true

--- a/source-postgres-batch/main.go
+++ b/source-postgres-batch/main.go
@@ -25,6 +25,10 @@ var featureFlagDefaults = map[string]bool{
 	// When true, the fallback collection key for keyless source tables will be
 	// ["/_meta/row_id"] instead of ["/_meta/polled", "/_meta/index"].
 	"keyless_row_id": true,
+
+	// When set, discovered collection schemas will be emitted as SourcedSchema messages
+	// so that Flow can have access to 'official' schema information from the source DB.
+	"emit_sourced_schemas": false,
 }
 
 // Config tells the connector how to connect to and interact with the source database.

--- a/source-postgres-batch/main_test.go
+++ b/source-postgres-batch/main_test.go
@@ -1506,3 +1506,31 @@ func TestFeatureFlagKeylessRowID(t *testing.T) {
 		})
 	}
 }
+
+// TestFeatureFlagEmitSourcedSchemas runs a capture with the `emit_sourced_schemas` feature flag set.
+func TestFeatureFlagEmitSourcedSchemas(t *testing.T) {
+	var ctx, control = context.Background(), testControlClient(t)
+	var tableName, uniqueID = testTableName(t, uniqueTableID(t))
+	createTestTable(t, control, tableName, `(id INTEGER PRIMARY KEY, data TEXT)`)
+
+	executeControlQuery(t, control, fmt.Sprintf("INSERT INTO %s (id, data) VALUES (1, 'hello'), (2, 'world')", tableName))
+
+	for _, tc := range []struct {
+		name string
+		flag string
+	}{
+		{"Default", ""},
+		{"Enabled", "emit_sourced_schemas"},
+		{"Disabled", "no_emit_sourced_schemas"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var cs = testCaptureSpec(t)
+			cs.EndpointSpec.(*Config).Advanced.FeatureFlags = tc.flag
+			cs.Bindings = discoverBindings(ctx, t, cs, regexp.MustCompile(uniqueID))
+			setShutdownAfterQuery(t, true)
+
+			cs.Capture(ctx, t, nil)
+			cupaloy.SnapshotT(t, cs.Summary())
+		})
+	}
+}

--- a/source-postgres-batch/main_test.go
+++ b/source-postgres-batch/main_test.go
@@ -79,7 +79,7 @@ func testCaptureSpec(t testing.TB) *st.CaptureSpec {
 	return &st.CaptureSpec{
 		Driver:       postgresDriver,
 		EndpointSpec: endpointSpec,
-		Validator:    &st.OrderedCaptureValidator{},
+		Validator:    &st.OrderedCaptureValidator{IncludeSourcedSchemas: true},
 		Sanitizers:   sanitizers,
 	}
 }

--- a/source-redshift-batch/.snapshots/TestFeatureFlagEmitSourcedSchemas-Default
+++ b/source-redshift-batch/.snapshots/TestFeatureFlagEmitSourcedSchemas-Default
@@ -1,0 +1,10 @@
+# ================================
+# Collection "acmeCo/test/featureflagemitsourcedschemas_960966": 2 Documents
+# ================================
+{"_meta":{"polled":"<TIMESTAMP>","index":0,"row_id":0},"data":"hello","id":1}
+{"_meta":{"polled":"<TIMESTAMP>","index":1,"row_id":1},"data":"world","id":2}
+# ================================
+# Final State Checkpoint
+# ================================
+{"bindingStateV1":{"featureflagemitsourcedschemas_960966":{"CursorNames":null,"CursorValues":null,"LastPolled":"<TIMESTAMP>","DocumentCount":2}}}
+

--- a/source-redshift-batch/.snapshots/TestFeatureFlagEmitSourcedSchemas-Disabled
+++ b/source-redshift-batch/.snapshots/TestFeatureFlagEmitSourcedSchemas-Disabled
@@ -1,0 +1,10 @@
+# ================================
+# Collection "acmeCo/test/featureflagemitsourcedschemas_960966": 2 Documents
+# ================================
+{"_meta":{"polled":"<TIMESTAMP>","index":0,"row_id":0},"data":"hello","id":1}
+{"_meta":{"polled":"<TIMESTAMP>","index":1,"row_id":1},"data":"world","id":2}
+# ================================
+# Final State Checkpoint
+# ================================
+{"bindingStateV1":{"featureflagemitsourcedschemas_960966":{"CursorNames":null,"CursorValues":null,"LastPolled":"<TIMESTAMP>","DocumentCount":2}}}
+

--- a/source-redshift-batch/.snapshots/TestFeatureFlagEmitSourcedSchemas-Enabled
+++ b/source-redshift-batch/.snapshots/TestFeatureFlagEmitSourcedSchemas-Enabled
@@ -1,0 +1,11 @@
+# ================================
+# Collection "acmeCo/test/featureflagemitsourcedschemas_960966": 3 Documents
+# ================================
+{"type":"object","required":["_meta","id"],"additionalProperties":false,"properties":{"_meta":{"$schema":"https://json-schema.org/draft/2020-12/schema","$id":"https://github.com/estuary/connectors/source-redshift-batch/document-metadata","properties":{"polled":{"type":"string","format":"date-time","title":"Polled Timestamp","description":"The time at which the update query which produced this document as executed."},"index":{"type":"integer","title":"Result Index","description":"The index of this document within the query execution which produced it."},"row_id":{"type":"integer","title":"Row ID","description":"Row ID of the Document"},"op":{"type":"string","enum":["c","u","d"],"title":"Change Operation","description":"Operation type (c: Create / u: Update / d: Delete)","default":"u"}},"additionalProperties":false,"type":"object","required":["polled","index","row_id"],"additionalProperties":false},"data":{"type":["string"]},"id":{"type":"integer"}}}
+{"_meta":{"polled":"<TIMESTAMP>","index":0,"row_id":0},"data":"hello","id":1}
+{"_meta":{"polled":"<TIMESTAMP>","index":1,"row_id":1},"data":"world","id":2}
+# ================================
+# Final State Checkpoint
+# ================================
+{"bindingStateV1":{"featureflagemitsourcedschemas_960966":{"CursorNames":null,"CursorValues":null,"LastPolled":"<TIMESTAMP>","DocumentCount":2}}}
+

--- a/source-redshift-batch/discovery.go
+++ b/source-redshift-batch/discovery.go
@@ -1,0 +1,522 @@
+package main
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"regexp"
+	"slices"
+	"strings"
+
+	pc "github.com/estuary/flow/go/protocols/capture"
+	pf "github.com/estuary/flow/go/protocols/flow"
+	"github.com/invopop/jsonschema"
+	log "github.com/sirupsen/logrus"
+	"golang.org/x/sync/errgroup"
+)
+
+// Discover enumerates tables and views from `information_schema.tables` and generates
+// placeholder capture queries for those tables.
+func (drv *BatchSQLDriver) Discover(ctx context.Context, req *pc.Request_Discover) (*pc.Response_Discovered, error) {
+	var cfg Config
+	if err := pf.UnmarshalStrict(req.ConfigJson, &cfg); err != nil {
+		return nil, fmt.Errorf("parsing endpoint config: %w", err)
+	}
+	cfg.SetDefaults()
+
+	var db, err = drv.Connect(ctx, &cfg)
+	if err != nil {
+		return nil, err
+	}
+	defer db.Close()
+
+	tableInfo, err := drv.discoverTables(ctx, db, &cfg)
+	if err != nil {
+		return nil, fmt.Errorf("error discovering tables: %w", err)
+	}
+
+	// Generate discovery resource and collection schema for this table
+	var bindings []*pc.Response_Discovered_Binding
+	for tableID, table := range tableInfo {
+		var recommendedName = recommendedCatalogName(table.Schema, table.Name)
+		var res, err = drv.GenerateResource(&cfg, recommendedName, table.Schema, table.Name, table.Type)
+		if err != nil {
+			log.WithFields(log.Fields{
+				"reason": err,
+				"table":  tableID,
+				"type":   table.Type,
+			}).Warn("unable to generate resource spec")
+			continue
+		}
+		resourceConfigJSON, err := json.Marshal(res)
+		if err != nil {
+			return nil, fmt.Errorf("error serializing resource spec: %w", err)
+		}
+
+		// Generate a collection schema from the column types and key column names of this table.
+		generatedSchema, collectionKey, err := generateCollectionSchema(&cfg, table, true)
+		if err != nil {
+			log.WithFields(log.Fields{"table": tableID, "err": err}).Warn("unable to generate collection schema")
+			continue
+		}
+
+		bindings = append(bindings, &pc.Response_Discovered_Binding{
+			RecommendedName:    recommendedName,
+			ResourceConfigJson: resourceConfigJSON,
+			DocumentSchemaJson: generatedSchema,
+			Key:                collectionKey,
+			ResourcePath:       []string{res.Name},
+		})
+	}
+
+	return &pc.Response_Discovered{Bindings: bindings}, nil
+}
+
+func (drv *BatchSQLDriver) discoverTables(ctx context.Context, db *sql.DB, cfg *Config) (map[string]*discoveredTable, error) {
+	// Run discovery queries in parallel for lower discovery latency on large databases.
+	// TODO(wgd): See if there's a nice context-and-errors-aware promise library we could use
+	// here instead of just doing the same copy-paste channels-and-errgroup pattern thrice.
+	var tablesCh = make(chan []*discoveredTable, 1)
+	var columnsCh = make(chan []*discoveredColumn, 1)
+	var keysCh = make(chan []*discoveredPrimaryKey, 1)
+	var workerGroup, workerCtx = errgroup.WithContext(ctx)
+	workerGroup.Go(func() error {
+		tables, err := discoverTables(workerCtx, db, cfg.Advanced.DiscoverSchemas)
+		if err != nil {
+			return fmt.Errorf("error listing tables: %w", err)
+		}
+		tablesCh <- tables
+		return nil
+	})
+	workerGroup.Go(func() error {
+		columns, err := discoverColumns(workerCtx, db, cfg.Advanced.DiscoverSchemas)
+		if err != nil {
+			return fmt.Errorf("error listing columns: %w", err)
+		}
+		columnsCh <- columns
+		return nil
+	})
+	workerGroup.Go(func() error {
+		keys, err := discoverPrimaryKeys(workerCtx, db, cfg.Advanced.DiscoverSchemas)
+		if err != nil {
+			return fmt.Errorf("error listing primary keys: %w", err)
+		}
+		keysCh <- keys
+		return nil
+	})
+	if err := workerGroup.Wait(); err != nil {
+		return nil, err
+	}
+	var tables = <-tablesCh
+	var columns = <-columnsCh
+	var keys = <-keysCh
+
+	// Aggregate information by table
+	var tableInfo = make(map[string]*discoveredTable)
+	for _, table := range tables {
+		var tableID = table.Schema + "." + table.Name
+		tableInfo[tableID] = table
+	}
+	for _, column := range columns {
+		var tableID = column.Schema + "." + column.Table
+		if table, ok := tableInfo[tableID]; ok {
+			table.columns = append(table.columns, column)
+			if column.Index != len(table.columns) {
+				return nil, fmt.Errorf("internal error: column %q of table %q appears out of order", column.Name, tableID)
+			}
+		}
+	}
+	for _, key := range keys {
+		var tableID = key.Schema + "." + key.Table
+		if table, ok := tableInfo[tableID]; ok {
+			table.keys = append(table.keys, key)
+			if key.Index != len(table.keys) {
+				return nil, fmt.Errorf("internal error: primary key column %q of table %q appears out of order", key.Column, tableID)
+			}
+		}
+	}
+	return tableInfo, nil
+}
+
+var (
+	// The fallback key of discovered collections when the source table has no primary key.
+	fallbackKey = []string{"/_meta/row_id"}
+
+	// Before the /_meta/row_id property was added, captures left the collection key empty
+	// for tables without a source PK, forcing users to pick one themselves.
+	fallbackKeyOld = []string{}
+)
+
+func generateCollectionSchema(cfg *Config, table *discoveredTable, includeNullability bool) (json.RawMessage, []string, error) {
+	// Extract useful key and column type information
+	var keyColumns []string
+	for _, key := range table.keys {
+		keyColumns = append(keyColumns, key.Column)
+	}
+	var columnTypes = make(map[string]columnType)
+	for _, column := range table.columns {
+		columnTypes[column.Name] = column.DataType
+	}
+
+	// Generate schema for the metadata via reflection
+	var reflector = jsonschema.Reflector{
+		ExpandedStruct: true,
+		DoNotReference: true,
+	}
+	var metadataSchema = reflector.ReflectFromType(reflect.TypeOf(documentMetadata{}))
+	if !cfg.Advanced.parsedFeatureFlags["keyless_row_id"] { // Don't include row_id as required on old captures with keyless_row_id off
+		metadataSchema.Required = slices.DeleteFunc(metadataSchema.Required, func(s string) bool { return s == "row_id" })
+	}
+	metadataSchema.Definitions = nil
+	metadataSchema.AdditionalProperties = nil
+
+	var required = append([]string{"_meta"}, keyColumns...)
+	var properties = map[string]*jsonschema.Schema{
+		"_meta": metadataSchema,
+	}
+	for colName, colType := range columnTypes {
+		var colSchema = colType.JSONSchema()
+		if types, ok := colSchema.Extras["type"].([]string); ok && len(types) > 1 && !includeNullability {
+			// Remove null as an option when there are multiple type options and we don't want nullability
+			colSchema.Extras["type"] = slices.DeleteFunc(types, func(t string) bool { return t == "null" })
+		}
+		properties[colName] = colSchema
+	}
+
+	var extras = map[string]any{
+		"properties": properties,
+	}
+	if cfg.Advanced.parsedFeatureFlags["use_schema_inference"] {
+		extras["x-infer-schema"] = true
+	}
+	var schema = &jsonschema.Schema{
+		Type:                 "object",
+		Required:             required,
+		AdditionalProperties: nil,
+		Extras:               extras,
+	}
+
+	// Marshal schema to JSON
+	bs, err := json.Marshal(schema)
+	if err != nil {
+		return nil, nil, fmt.Errorf("error serializing schema: %w", err)
+	}
+
+	// If the table has a primary key then convert it to a collection key, otherwise
+	// recommend an appropriate fallback collection key.
+	var collectionKey []string
+	if keyColumns != nil {
+		for _, colName := range keyColumns {
+			collectionKey = append(collectionKey, primaryKeyToCollectionKey(colName))
+		}
+	} else {
+		collectionKey = fallbackKey
+		if !cfg.Advanced.parsedFeatureFlags["keyless_row_id"] {
+			collectionKey = fallbackKeyOld
+		}
+	}
+
+	return json.RawMessage(bs), collectionKey, nil
+}
+
+// primaryKeyToCollectionKey converts a database primary key column name into a Flow collection key
+// JSON pointer with escaping for '~' and '/' applied per RFC6901.
+func primaryKeyToCollectionKey(key string) string {
+	// Any encoded '~' must be escaped first to prevent a second escape on escaped '/' values as
+	// '~1'.
+	key = strings.ReplaceAll(key, "~", "~0")
+	key = strings.ReplaceAll(key, "/", "~1")
+	return "/" + key
+}
+
+type discoveredTable struct {
+	Schema string
+	Name   string
+	Type   string // Usually 'BASE TABLE' or 'VIEW'
+
+	columns []*discoveredColumn
+	keys    []*discoveredPrimaryKey
+}
+
+func discoverTables(ctx context.Context, db *sql.DB, discoverSchemas []string) ([]*discoveredTable, error) {
+	var query = new(strings.Builder)
+	var args []any
+
+	fmt.Fprintf(query, "SELECT nc.nspname AS table_schema,")
+	fmt.Fprintf(query, "       c.relname AS table_name,")
+	fmt.Fprintf(query, "       CASE")
+	fmt.Fprintf(query, "         WHEN c.relkind = ANY (ARRAY['r'::\"char\", 'p'::\"char\"]) THEN 'BASE TABLE'::text")
+	fmt.Fprintf(query, "         WHEN c.relkind = 'v'::\"char\" THEN 'VIEW'::text")
+	fmt.Fprintf(query, "         WHEN c.relkind = 'f'::\"char\" THEN 'FOREIGN'::text")
+	fmt.Fprintf(query, "         ELSE ''::text")
+	fmt.Fprintf(query, "       END::information_schema.character_data AS table_type")
+	fmt.Fprintf(query, " FROM pg_catalog.pg_class c")
+	fmt.Fprintf(query, " JOIN pg_catalog.pg_namespace nc ON (nc.oid = c.relnamespace)")
+	fmt.Fprintf(query, " WHERE c.relkind IN ('r', 'p', 'v', 'f')")
+	if len(discoverSchemas) > 0 {
+		fmt.Fprintf(query, "  AND nc.nspname = ANY ($1)")
+		args = append(args, discoverSchemas)
+	} else {
+		fmt.Fprintf(query, "  AND nc.nspname NOT IN ('pg_catalog', 'pg_internal', 'information_schema', 'catalog_history', 'cron')")
+	}
+	fmt.Fprintf(query, ";")
+
+	rows, err := db.QueryContext(ctx, query.String(), args...)
+	if err != nil {
+		return nil, fmt.Errorf("error executing discovery query %q: %w", query.String(), err)
+	}
+	defer rows.Close()
+
+	var tables []*discoveredTable
+	for rows.Next() {
+		var tableSchema, tableName, tableType string
+		if err := rows.Scan(&tableSchema, &tableName, &tableType); err != nil {
+			return nil, fmt.Errorf("error scanning result row: %w", err)
+		}
+		tables = append(tables, &discoveredTable{
+			Schema: tableSchema,
+			Name:   tableName,
+			Type:   tableType,
+		})
+	}
+	return tables, nil
+}
+
+type discoveredColumn struct {
+	Schema      string     // The schema in which the table resides
+	Table       string     // The name of the table with this column
+	Name        string     // The name of the column
+	Index       int        // The ordinal position of the column within a row
+	IsNullable  bool       // Whether the column can be null
+	DataType    columnType // The datatype of the column
+	Description *string    // The description of the column, if present and known
+}
+
+type columnType interface {
+	JSONSchema() *jsonschema.Schema
+}
+
+type basicColumnType struct {
+	jsonTypes       []string
+	contentEncoding string
+	format          string
+	nullable        bool
+	description     string
+}
+
+func (ct *basicColumnType) JSONSchema() *jsonschema.Schema {
+	var sch = &jsonschema.Schema{
+		Format: ct.format,
+		Extras: make(map[string]interface{}),
+	}
+
+	if ct.contentEncoding != "" {
+		sch.Extras["contentEncoding"] = ct.contentEncoding // New in 2019-09.
+	}
+
+	if ct.jsonTypes != nil {
+		var types = append([]string(nil), ct.jsonTypes...)
+		if ct.nullable {
+			types = append(types, "null")
+		}
+		if len(types) == 1 {
+			sch.Type = types[0]
+		} else {
+			sch.Extras["type"] = types
+		}
+	}
+	return sch
+}
+
+func discoverColumns(ctx context.Context, db *sql.DB, discoverSchemas []string) ([]*discoveredColumn, error) {
+	var query = new(strings.Builder)
+	var args []any
+	fmt.Fprintf(query, "SELECT nc.nspname as table_schema,")
+	fmt.Fprintf(query, "       c.relname as table_name,")
+	fmt.Fprintf(query, "       a.attname as column_name,")
+	fmt.Fprintf(query, "       a.attnum as column_index,")
+	fmt.Fprintf(query, "       NOT (a.attnotnull OR (t.typtype = 'd' AND t.typnotnull)) AS is_nullable,")
+	fmt.Fprintf(query, "       COALESCE(bt.typname, t.typname) AS udt_name,")
+	fmt.Fprintf(query, "       t.typtype::text AS typtype")
+	fmt.Fprintf(query, "  FROM pg_catalog.pg_attribute a")
+	fmt.Fprintf(query, "  JOIN pg_catalog.pg_type t ON a.atttypid = t.oid")
+	fmt.Fprintf(query, "  JOIN pg_catalog.pg_class c ON a.attrelid = c.oid")
+	fmt.Fprintf(query, "  JOIN pg_catalog.pg_namespace nc ON c.relnamespace = nc.oid")
+	fmt.Fprintf(query, "  LEFT JOIN (pg_catalog.pg_type bt JOIN pg_namespace nbt ON bt.typnamespace = nbt.oid)")
+	fmt.Fprintf(query, "    ON t.typtype = 'd'::\"char\" AND t.typbasetype = bt.oid")
+	fmt.Fprintf(query, "  WHERE a.attnum > 0")
+	fmt.Fprintf(query, "    AND NOT a.attisdropped")
+	fmt.Fprintf(query, "    AND c.relkind IN ('r', 'p', 'v', 'f')")
+	if len(discoverSchemas) > 0 {
+		fmt.Fprintf(query, "    AND nc.nspname = ANY ($1)")
+		args = append(args, discoverSchemas)
+	} else {
+		fmt.Fprintf(query, "    AND nc.nspname NOT IN ('pg_catalog', 'pg_internal', 'information_schema', 'catalog_history', 'cron')")
+	}
+	fmt.Fprintf(query, "  ORDER BY nc.nspname, c.relname, a.attnum;")
+
+	rows, err := db.QueryContext(ctx, query.String(), args...)
+	if err != nil {
+		return nil, fmt.Errorf("error executing discovery query %q: %w", query.String(), err)
+	}
+	defer rows.Close()
+
+	var columns []*discoveredColumn
+	for rows.Next() {
+		var tableSchema, tableName, columnName string
+		var columnIndex int
+		var isNullable bool
+		var typeName, typeType string
+		if err := rows.Scan(&tableSchema, &tableName, &columnName, &columnIndex, &isNullable, &typeName, &typeType); err != nil {
+			return nil, fmt.Errorf("error scanning result row: %w", err)
+		}
+
+		// Decode column type information into a usable form
+		var dataType basicColumnType
+		switch typeType {
+		case "e": // enum values are captured as strings
+			dataType = basicColumnType{jsonTypes: []string{"string"}}
+		case "r", "m": // ranges and multiranges are captured as strings
+			dataType = basicColumnType{jsonTypes: []string{"string"}}
+		default:
+			var ok bool
+			dataType, ok = databaseTypeToJSON[typeName]
+			if !ok {
+				dataType = basicColumnType{description: fmt.Sprintf("using catch-all schema for unknown type %q", typeName)}
+			}
+		}
+		dataType.nullable = isNullable
+
+		columns = append(columns, &discoveredColumn{
+			Schema:     tableSchema,
+			Table:      tableName,
+			Name:       columnName,
+			Index:      columnIndex,
+			IsNullable: isNullable,
+			DataType:   &dataType,
+		})
+	}
+	return columns, nil
+}
+
+type discoveredPrimaryKey struct {
+	Schema string
+	Table  string
+	Column string
+	Index  int
+}
+
+func discoverPrimaryKeys(ctx context.Context, db *sql.DB, discoverSchemas []string) ([]*discoveredPrimaryKey, error) {
+	var query = new(strings.Builder)
+	var args []any
+
+	fmt.Fprintf(query, "SELECT nr.nspname::information_schema.sql_identifier AS table_schema,")
+	fmt.Fprintf(query, "       r.relname::information_schema.sql_identifier AS table_name,")
+	fmt.Fprintf(query, "       a.attname::information_schema.sql_identifier AS column_name,")
+	fmt.Fprintf(query, "       pos.n::information_schema.cardinal_number AS ordinal_position")
+	fmt.Fprintf(query, "  FROM pg_namespace nr,")
+	fmt.Fprintf(query, "       pg_class r,")
+	fmt.Fprintf(query, "       pg_attribute a,")
+	fmt.Fprintf(query, "       pg_constraint c,")
+	fmt.Fprintf(query, "       generate_series(1,100,1) pos(n)")
+	fmt.Fprintf(query, "  WHERE nr.oid = r.relnamespace")
+	fmt.Fprintf(query, "    AND r.oid = a.attrelid")
+	fmt.Fprintf(query, "    AND r.oid = c.conrelid")
+	fmt.Fprintf(query, "    AND c.conkey[pos.n] = a.attnum")
+	fmt.Fprintf(query, "    AND NOT a.attisdropped")
+	fmt.Fprintf(query, "    AND c.contype = 'p'::\"char\"")
+	fmt.Fprintf(query, "    AND r.relkind = 'r'::\"char\"")
+	if len(discoverSchemas) > 0 {
+		fmt.Fprintf(query, "    AND nr.nspname = ANY ($1)")
+		args = append(args, discoverSchemas)
+	} else {
+		fmt.Fprintf(query, "    AND nr.nspname NOT IN ('pg_catalog', 'pg_internal', 'information_schema', 'catalog_history', 'cron')")
+	}
+	fmt.Fprintf(query, "  ORDER BY r.relname, pos.n;")
+
+	rows, err := db.QueryContext(ctx, query.String(), args...)
+	if err != nil {
+		return nil, fmt.Errorf("error executing discovery query %q: %w", query.String(), err)
+	}
+	defer rows.Close()
+
+	var keys []*discoveredPrimaryKey
+	for rows.Next() {
+		var tableSchema, tableName, columnName string
+		var ordinalPosition int
+		if err := rows.Scan(&tableSchema, &tableName, &columnName, &ordinalPosition); err != nil {
+			return nil, fmt.Errorf("error scanning result row: %w", err)
+		}
+
+		keys = append(keys, &discoveredPrimaryKey{
+			Schema: tableSchema,
+			Table:  tableName,
+			Column: columnName,
+			Index:  ordinalPosition,
+		})
+	}
+	return keys, nil
+}
+
+var databaseTypeToJSON = map[string]basicColumnType{
+	"bool": {jsonTypes: []string{"boolean"}},
+
+	"int2": {jsonTypes: []string{"integer"}},
+	"int4": {jsonTypes: []string{"integer"}},
+	"int8": {jsonTypes: []string{"integer"}},
+
+	"numeric": {jsonTypes: []string{"string"}, format: "number"},
+	"float4":  {jsonTypes: []string{"number", "string"}, format: "number"},
+	"float8":  {jsonTypes: []string{"number", "string"}, format: "number"},
+
+	"varchar": {jsonTypes: []string{"string"}},
+	"bpchar":  {jsonTypes: []string{"string"}},
+	"text":    {jsonTypes: []string{"string"}},
+	"bytea":   {jsonTypes: []string{"string"}, contentEncoding: "base64"},
+	"xml":     {jsonTypes: []string{"string"}},
+	"bit":     {jsonTypes: []string{"string"}},
+	"varbit":  {jsonTypes: []string{"string"}},
+
+	"json":     {},
+	"jsonb":    {},
+	"jsonpath": {jsonTypes: []string{"string"}},
+
+	// Domain-Specific Types
+	"date":        {jsonTypes: []string{"string"}, format: "date-time"},
+	"timestamp":   {jsonTypes: []string{"string"}, format: "date-time"},
+	"timestamptz": {jsonTypes: []string{"string"}, format: "date-time"},
+	"time":        {jsonTypes: []string{"integer"}},
+	"timetz":      {jsonTypes: []string{"string"}, format: "time"},
+	"interval":    {jsonTypes: []string{"string"}},
+	"money":       {jsonTypes: []string{"string"}},
+	"point":       {jsonTypes: []string{"string"}},
+	"line":        {jsonTypes: []string{"string"}},
+	"lseg":        {jsonTypes: []string{"string"}},
+	"box":         {jsonTypes: []string{"string"}},
+	"path":        {jsonTypes: []string{"string"}},
+	"polygon":     {jsonTypes: []string{"string"}},
+	"circle":      {jsonTypes: []string{"string"}},
+	"inet":        {jsonTypes: []string{"string"}},
+	"cidr":        {jsonTypes: []string{"string"}},
+	"macaddr":     {jsonTypes: []string{"string"}},
+	"macaddr8":    {jsonTypes: []string{"string"}},
+	"tsvector":    {jsonTypes: []string{"string"}},
+	"tsquery":     {jsonTypes: []string{"string"}},
+	"uuid":        {jsonTypes: []string{"string"}, format: "uuid"},
+}
+
+var catalogNameSanitizerRe = regexp.MustCompile(`(?i)[^a-z0-9\-_.]`)
+
+func recommendedCatalogName(schema, table string) string {
+	var catalogName string
+	// Omit 'default schema' names for Postgres and SQL Server. There is
+	// no default schema for MySQL databases.
+	if schema == "public" || schema == "dbo" {
+		catalogName = table
+	} else {
+		catalogName = schema + "_" + table
+	}
+	return catalogNameSanitizerRe.ReplaceAllString(strings.ToLower(catalogName), "_")
+}

--- a/source-redshift-batch/discovery.go
+++ b/source-redshift-batch/discovery.go
@@ -149,7 +149,7 @@ var (
 	fallbackKeyOld = []string{}
 )
 
-func generateCollectionSchema(cfg *Config, table *discoveredTable, includeNullability bool) (json.RawMessage, []string, error) {
+func generateCollectionSchema(cfg *Config, table *discoveredTable, fullWriteSchema bool) (json.RawMessage, []string, error) {
 	// Extract useful key and column type information
 	var keyColumns []string
 	for _, key := range table.keys {
@@ -162,15 +162,23 @@ func generateCollectionSchema(cfg *Config, table *discoveredTable, includeNullab
 
 	// Generate schema for the metadata via reflection
 	var reflector = jsonschema.Reflector{
-		ExpandedStruct: true,
-		DoNotReference: true,
+		ExpandedStruct:            true,
+		DoNotReference:            true,
+		AllowAdditionalProperties: fullWriteSchema,
 	}
 	var metadataSchema = reflector.ReflectFromType(reflect.TypeOf(documentMetadata{}))
 	if !cfg.Advanced.parsedFeatureFlags["keyless_row_id"] { // Don't include row_id as required on old captures with keyless_row_id off
 		metadataSchema.Required = slices.DeleteFunc(metadataSchema.Required, func(s string) bool { return s == "row_id" })
 	}
 	metadataSchema.Definitions = nil
-	metadataSchema.AdditionalProperties = nil
+	if metadataSchema.Extras == nil {
+		metadataSchema.Extras = make(map[string]any)
+	}
+	if fullWriteSchema {
+		metadataSchema.AdditionalProperties = nil
+	} else {
+		metadataSchema.Extras["additionalProperties"] = false
+	}
 
 	var required = append([]string{"_meta"}, keyColumns...)
 	var properties = map[string]*jsonschema.Schema{
@@ -178,7 +186,7 @@ func generateCollectionSchema(cfg *Config, table *discoveredTable, includeNullab
 	}
 	for colName, colType := range columnTypes {
 		var colSchema = colType.JSONSchema()
-		if types, ok := colSchema.Extras["type"].([]string); ok && len(types) > 1 && !includeNullability {
+		if types, ok := colSchema.Extras["type"].([]string); ok && len(types) > 1 && !fullWriteSchema {
 			// Remove null as an option when there are multiple type options and we don't want nullability
 			colSchema.Extras["type"] = slices.DeleteFunc(types, func(t string) bool { return t == "null" })
 		}
@@ -192,10 +200,12 @@ func generateCollectionSchema(cfg *Config, table *discoveredTable, includeNullab
 		extras["x-infer-schema"] = true
 	}
 	var schema = &jsonschema.Schema{
-		Type:                 "object",
-		Required:             required,
-		AdditionalProperties: nil,
-		Extras:               extras,
+		Type:     "object",
+		Required: required,
+		Extras:   extras,
+	}
+	if !fullWriteSchema {
+		schema.Extras["additionalProperties"] = false
 	}
 
 	// Marshal schema to JSON

--- a/source-redshift-batch/driver.go
+++ b/source-redshift-batch/driver.go
@@ -5,8 +5,6 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
-	"reflect"
-	"regexp"
 	"slices"
 	"strings"
 	"text/template"
@@ -18,7 +16,6 @@ import (
 	boilerplate "github.com/estuary/connectors/source-boilerplate"
 	pc "github.com/estuary/flow/go/protocols/capture"
 	pf "github.com/estuary/flow/go/protocols/flow"
-	"github.com/invopop/jsonschema"
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/sync/errgroup"
 )
@@ -113,57 +110,6 @@ type documentMetadata struct {
 	Op     string    `json:"op,omitempty" jsonschema:"title=Change Operation,description=Operation type (c: Create / u: Update / d: Delete),enum=c,enum=u,enum=d,default=u"`
 }
 
-var (
-	// The fallback key of discovered collections when the source table has no primary key.
-	fallbackKey = []string{"/_meta/row_id"}
-
-	// Before the /_meta/row_id property was added, captures left the collection key empty
-	// for tables without a source PK, forcing users to pick one themselves.
-	fallbackKeyOld = []string{}
-)
-
-func generateCollectionSchema(cfg *Config, keyColumns []string, columnTypes map[string]columnType, useSchemaInference bool) (json.RawMessage, error) {
-	// Generate schema for the metadata via reflection
-	var reflector = jsonschema.Reflector{
-		ExpandedStruct: true,
-		DoNotReference: true,
-	}
-	var metadataSchema = reflector.ReflectFromType(reflect.TypeOf(documentMetadata{}))
-	if !cfg.Advanced.parsedFeatureFlags["keyless_row_id"] { // Don't include row_id as required on old captures with keyless_row_id off
-		metadataSchema.Required = slices.DeleteFunc(metadataSchema.Required, func(s string) bool { return s == "row_id" })
-	}
-	metadataSchema.Definitions = nil
-	metadataSchema.AdditionalProperties = nil
-
-	var required = append([]string{"_meta"}, keyColumns...)
-	var properties = map[string]*jsonschema.Schema{
-		"_meta": metadataSchema,
-	}
-	for colName, colType := range columnTypes {
-		properties[colName] = colType.JSONSchema()
-	}
-
-	var extras = map[string]any{
-		"properties": properties,
-	}
-	if useSchemaInference {
-		extras["x-infer-schema"] = true
-	}
-	var schema = &jsonschema.Schema{
-		Type:                 "object",
-		Required:             required,
-		AdditionalProperties: nil,
-		Extras:               extras,
-	}
-
-	// Marshal schema to JSON
-	bs, err := json.Marshal(schema)
-	if err != nil {
-		return nil, fmt.Errorf("error serializing schema: %w", err)
-	}
-	return json.RawMessage(bs), nil
-}
-
 // Spec returns metadata about the capture connector.
 func (drv *BatchSQLDriver) Spec(ctx context.Context, req *pc.Request_Spec) (*pc.Response_Spec, error) {
 	resourceSchema, err := schemagen.GenerateSchema("Batch SQL Resource Spec", &Resource{}).MarshalJSON()
@@ -182,439 +128,6 @@ func (drv *BatchSQLDriver) Spec(ctx context.Context, req *pc.Request_Spec) (*pc.
 // Apply does nothing for batch SQL captures.
 func (BatchSQLDriver) Apply(ctx context.Context, req *pc.Request_Apply) (*pc.Response_Applied, error) {
 	return &pc.Response_Applied{ActionDescription: ""}, nil
-}
-
-// Discover enumerates tables and views from `information_schema.tables` and generates
-// placeholder capture queries for thos tables.
-func (drv *BatchSQLDriver) Discover(ctx context.Context, req *pc.Request_Discover) (*pc.Response_Discovered, error) {
-	var cfg Config
-	if err := pf.UnmarshalStrict(req.ConfigJson, &cfg); err != nil {
-		return nil, fmt.Errorf("parsing endpoint config: %w", err)
-	}
-	cfg.SetDefaults()
-
-	var db, err = drv.Connect(ctx, &cfg)
-	if err != nil {
-		return nil, err
-	}
-	defer db.Close()
-
-	// Run discovery queries in parallel for lower discovery latency on large databases.
-	// TODO(wgd): See if there's a nice context-and-errors-aware promise library we could use
-	// here instead of just doing the same copy-paste channels-and-errgroup pattern thrice.
-	var tablesCh = make(chan []*discoveredTable, 1)
-	var columnsCh = make(chan []*discoveredColumn, 1)
-	var keysCh = make(chan []*discoveredPrimaryKey, 1)
-	var workerGroup, workerCtx = errgroup.WithContext(ctx)
-	workerGroup.Go(func() error {
-		tables, err := discoverTables(workerCtx, db, cfg.Advanced.DiscoverSchemas)
-		if err != nil {
-			return fmt.Errorf("error listing tables: %w", err)
-		}
-		tablesCh <- tables
-		return nil
-	})
-	workerGroup.Go(func() error {
-		columns, err := discoverColumns(workerCtx, db, cfg.Advanced.DiscoverSchemas)
-		if err != nil {
-			return fmt.Errorf("error listing columns: %w", err)
-		}
-		columnsCh <- columns
-		return nil
-	})
-	workerGroup.Go(func() error {
-		keys, err := discoverPrimaryKeys(workerCtx, db, cfg.Advanced.DiscoverSchemas)
-		if err != nil {
-			return fmt.Errorf("error listing primary keys: %w", err)
-		}
-		keysCh <- keys
-		return nil
-	})
-	if err := workerGroup.Wait(); err != nil {
-		return nil, err
-	}
-	var tables = <-tablesCh
-	var columns = <-columnsCh
-	var keys = <-keysCh
-
-	// Aggregate column information by table
-	var columnsByTable = make(map[string][]*discoveredColumn)
-	for _, column := range columns {
-		var tableID = column.Schema + "." + column.Table
-		columnsByTable[tableID] = append(columnsByTable[tableID], column)
-		if column.Index != len(columnsByTable[tableID]) {
-			return nil, fmt.Errorf("internal error: column %q of table %q appears out of order", column.Name, tableID)
-		}
-	}
-
-	// Aggregate primary-key information by table
-	var keysByTable = make(map[string][]*discoveredPrimaryKey)
-	for _, key := range keys {
-		var tableID = key.Schema + "." + key.Table
-		keysByTable[tableID] = append(keysByTable[tableID], key)
-		if key.Index != len(keysByTable[tableID]) {
-			return nil, fmt.Errorf("internal error: primary key column %q of table %q appears out of order", key.Column, tableID)
-		}
-	}
-
-	// Generate discovery resource and collection schema for this table
-	var bindings []*pc.Response_Discovered_Binding
-	for _, table := range tables {
-		var tableID = table.Schema + "." + table.Name
-
-		var recommendedName = recommendedCatalogName(table.Schema, table.Name)
-		var res, err = drv.GenerateResource(&cfg, recommendedName, table.Schema, table.Name, table.Type)
-		if err != nil {
-			log.WithFields(log.Fields{
-				"reason": err,
-				"table":  tableID,
-				"type":   table.Type,
-			}).Warn("unable to generate resource spec")
-			continue
-		}
-		resourceConfigJSON, err := json.Marshal(res)
-		if err != nil {
-			return nil, fmt.Errorf("error serializing resource spec: %w", err)
-		}
-
-		// Generate a collection schema from the column types and key column names of this table.
-		var keyColumns []string
-		for _, key := range keysByTable[tableID] {
-			keyColumns = append(keyColumns, key.Column)
-		}
-
-		var columnTypes = make(map[string]columnType)
-		for _, column := range columnsByTable[tableID] {
-			columnTypes[column.Name] = column.DataType
-		}
-
-		generatedSchema, err := generateCollectionSchema(&cfg, keyColumns, columnTypes, cfg.Advanced.parsedFeatureFlags["use_schema_inference"])
-		if err != nil {
-			log.WithFields(log.Fields{"table": tableID, "err": err}).Warn("unable to generate collection schema")
-			continue
-		}
-
-		// If the table has a primary key then convert it to a collection key, otherwise
-		// recommend an appropriate fallback collection key.
-		var collectionKey []string
-		if keyColumns != nil {
-			for _, colName := range keyColumns {
-				collectionKey = append(collectionKey, primaryKeyToCollectionKey(colName))
-			}
-		} else {
-			collectionKey = fallbackKey
-			if !cfg.Advanced.parsedFeatureFlags["keyless_row_id"] {
-				collectionKey = fallbackKeyOld
-			}
-		}
-
-		bindings = append(bindings, &pc.Response_Discovered_Binding{
-			RecommendedName:    recommendedName,
-			ResourceConfigJson: resourceConfigJSON,
-			DocumentSchemaJson: generatedSchema,
-			Key:                collectionKey,
-			ResourcePath:       []string{res.Name},
-		})
-	}
-
-	return &pc.Response_Discovered{Bindings: bindings}, nil
-}
-
-// primaryKeyToCollectionKey converts a database primary key column name into a Flow collection key
-// JSON pointer with escaping for '~' and '/' applied per RFC6901.
-func primaryKeyToCollectionKey(key string) string {
-	// Any encoded '~' must be escaped first to prevent a second escape on escaped '/' values as
-	// '~1'.
-	key = strings.ReplaceAll(key, "~", "~0")
-	key = strings.ReplaceAll(key, "/", "~1")
-	return "/" + key
-}
-
-type discoveredTable struct {
-	Schema string
-	Name   string
-	Type   string // Usually 'BASE TABLE' or 'VIEW'
-}
-
-func discoverTables(ctx context.Context, db *sql.DB, discoverSchemas []string) ([]*discoveredTable, error) {
-	var query = new(strings.Builder)
-	var args []any
-
-	fmt.Fprintf(query, "SELECT nc.nspname AS table_schema,")
-	fmt.Fprintf(query, "       c.relname AS table_name,")
-	fmt.Fprintf(query, "       CASE")
-	fmt.Fprintf(query, "         WHEN c.relkind = ANY (ARRAY['r'::\"char\", 'p'::\"char\"]) THEN 'BASE TABLE'::text")
-	fmt.Fprintf(query, "         WHEN c.relkind = 'v'::\"char\" THEN 'VIEW'::text")
-	fmt.Fprintf(query, "         WHEN c.relkind = 'f'::\"char\" THEN 'FOREIGN'::text")
-	fmt.Fprintf(query, "         ELSE ''::text")
-	fmt.Fprintf(query, "       END::information_schema.character_data AS table_type")
-	fmt.Fprintf(query, " FROM pg_catalog.pg_class c")
-	fmt.Fprintf(query, " JOIN pg_catalog.pg_namespace nc ON (nc.oid = c.relnamespace)")
-	fmt.Fprintf(query, " WHERE c.relkind IN ('r', 'p', 'v', 'f')")
-	if len(discoverSchemas) > 0 {
-		fmt.Fprintf(query, "  AND nc.nspname = ANY ($1)")
-		args = append(args, discoverSchemas)
-	} else {
-		fmt.Fprintf(query, "  AND nc.nspname NOT IN ('pg_catalog', 'pg_internal', 'information_schema', 'catalog_history', 'cron')")
-	}
-	fmt.Fprintf(query, ";")
-
-	rows, err := db.QueryContext(ctx, query.String(), args...)
-	if err != nil {
-		return nil, fmt.Errorf("error executing discovery query %q: %w", query.String(), err)
-	}
-	defer rows.Close()
-
-	var tables []*discoveredTable
-	for rows.Next() {
-		var tableSchema, tableName, tableType string
-		if err := rows.Scan(&tableSchema, &tableName, &tableType); err != nil {
-			return nil, fmt.Errorf("error scanning result row: %w", err)
-		}
-		tables = append(tables, &discoveredTable{
-			Schema: tableSchema,
-			Name:   tableName,
-			Type:   tableType,
-		})
-	}
-	return tables, nil
-}
-
-type discoveredColumn struct {
-	Schema      string     // The schema in which the table resides
-	Table       string     // The name of the table with this column
-	Name        string     // The name of the column
-	Index       int        // The ordinal position of the column within a row
-	IsNullable  bool       // Whether the column can be null
-	DataType    columnType // The datatype of the column
-	Description *string    // The description of the column, if present and known
-}
-
-type columnType interface {
-	JSONSchema() *jsonschema.Schema
-}
-
-type basicColumnType struct {
-	jsonTypes       []string
-	contentEncoding string
-	format          string
-	nullable        bool
-	description     string
-}
-
-func (ct *basicColumnType) JSONSchema() *jsonschema.Schema {
-	var sch = &jsonschema.Schema{
-		Format: ct.format,
-		Extras: make(map[string]interface{}),
-	}
-
-	if ct.contentEncoding != "" {
-		sch.Extras["contentEncoding"] = ct.contentEncoding // New in 2019-09.
-	}
-
-	if ct.jsonTypes != nil {
-		var types = append([]string(nil), ct.jsonTypes...)
-		if ct.nullable {
-			types = append(types, "null")
-		}
-		if len(types) == 1 {
-			sch.Type = types[0]
-		} else {
-			sch.Extras["type"] = types
-		}
-	}
-	return sch
-}
-
-func discoverColumns(ctx context.Context, db *sql.DB, discoverSchemas []string) ([]*discoveredColumn, error) {
-	var query = new(strings.Builder)
-	var args []any
-	fmt.Fprintf(query, "SELECT nc.nspname as table_schema,")
-	fmt.Fprintf(query, "       c.relname as table_name,")
-	fmt.Fprintf(query, "       a.attname as column_name,")
-	fmt.Fprintf(query, "       a.attnum as column_index,")
-	fmt.Fprintf(query, "       NOT (a.attnotnull OR (t.typtype = 'd' AND t.typnotnull)) AS is_nullable,")
-	fmt.Fprintf(query, "       COALESCE(bt.typname, t.typname) AS udt_name,")
-	fmt.Fprintf(query, "       t.typtype::text AS typtype")
-	fmt.Fprintf(query, "  FROM pg_catalog.pg_attribute a")
-	fmt.Fprintf(query, "  JOIN pg_catalog.pg_type t ON a.atttypid = t.oid")
-	fmt.Fprintf(query, "  JOIN pg_catalog.pg_class c ON a.attrelid = c.oid")
-	fmt.Fprintf(query, "  JOIN pg_catalog.pg_namespace nc ON c.relnamespace = nc.oid")
-	fmt.Fprintf(query, "  LEFT JOIN (pg_catalog.pg_type bt JOIN pg_namespace nbt ON bt.typnamespace = nbt.oid)")
-	fmt.Fprintf(query, "    ON t.typtype = 'd'::\"char\" AND t.typbasetype = bt.oid")
-	fmt.Fprintf(query, "  WHERE a.attnum > 0")
-	fmt.Fprintf(query, "    AND NOT a.attisdropped")
-	fmt.Fprintf(query, "    AND c.relkind IN ('r', 'p', 'v', 'f')")
-	if len(discoverSchemas) > 0 {
-		fmt.Fprintf(query, "    AND nc.nspname = ANY ($1)")
-		args = append(args, discoverSchemas)
-	} else {
-		fmt.Fprintf(query, "    AND nc.nspname NOT IN ('pg_catalog', 'pg_internal', 'information_schema', 'catalog_history', 'cron')")
-	}
-	fmt.Fprintf(query, "  ORDER BY nc.nspname, c.relname, a.attnum;")
-
-	rows, err := db.QueryContext(ctx, query.String(), args...)
-	if err != nil {
-		return nil, fmt.Errorf("error executing discovery query %q: %w", query.String(), err)
-	}
-	defer rows.Close()
-
-	var columns []*discoveredColumn
-	for rows.Next() {
-		var tableSchema, tableName, columnName string
-		var columnIndex int
-		var isNullable bool
-		var typeName, typeType string
-		if err := rows.Scan(&tableSchema, &tableName, &columnName, &columnIndex, &isNullable, &typeName, &typeType); err != nil {
-			return nil, fmt.Errorf("error scanning result row: %w", err)
-		}
-
-		// Decode column type information into a usable form
-		var dataType basicColumnType
-		switch typeType {
-		case "e": // enum values are captured as strings
-			dataType = basicColumnType{jsonTypes: []string{"string"}}
-		case "r", "m": // ranges and multiranges are captured as strings
-			dataType = basicColumnType{jsonTypes: []string{"string"}}
-		default:
-			var ok bool
-			dataType, ok = databaseTypeToJSON[typeName]
-			if !ok {
-				dataType = basicColumnType{description: fmt.Sprintf("using catch-all schema for unknown type %q", typeName)}
-			}
-		}
-		dataType.nullable = isNullable
-
-		columns = append(columns, &discoveredColumn{
-			Schema:     tableSchema,
-			Table:      tableName,
-			Name:       columnName,
-			Index:      columnIndex,
-			IsNullable: isNullable,
-			DataType:   &dataType,
-		})
-	}
-	return columns, nil
-}
-
-type discoveredPrimaryKey struct {
-	Schema string
-	Table  string
-	Column string
-	Index  int
-}
-
-func discoverPrimaryKeys(ctx context.Context, db *sql.DB, discoverSchemas []string) ([]*discoveredPrimaryKey, error) {
-	var query = new(strings.Builder)
-	var args []any
-
-	fmt.Fprintf(query, "SELECT nr.nspname::information_schema.sql_identifier AS table_schema,")
-	fmt.Fprintf(query, "       r.relname::information_schema.sql_identifier AS table_name,")
-	fmt.Fprintf(query, "       a.attname::information_schema.sql_identifier AS column_name,")
-	fmt.Fprintf(query, "       pos.n::information_schema.cardinal_number AS ordinal_position")
-	fmt.Fprintf(query, "  FROM pg_namespace nr,")
-	fmt.Fprintf(query, "       pg_class r,")
-	fmt.Fprintf(query, "       pg_attribute a,")
-	fmt.Fprintf(query, "       pg_constraint c,")
-	fmt.Fprintf(query, "       generate_series(1,100,1) pos(n)")
-	fmt.Fprintf(query, "  WHERE nr.oid = r.relnamespace")
-	fmt.Fprintf(query, "    AND r.oid = a.attrelid")
-	fmt.Fprintf(query, "    AND r.oid = c.conrelid")
-	fmt.Fprintf(query, "    AND c.conkey[pos.n] = a.attnum")
-	fmt.Fprintf(query, "    AND NOT a.attisdropped")
-	fmt.Fprintf(query, "    AND c.contype = 'p'::\"char\"")
-	fmt.Fprintf(query, "    AND r.relkind = 'r'::\"char\"")
-	if len(discoverSchemas) > 0 {
-		fmt.Fprintf(query, "    AND nr.nspname = ANY ($1)")
-		args = append(args, discoverSchemas)
-	} else {
-		fmt.Fprintf(query, "    AND nr.nspname NOT IN ('pg_catalog', 'pg_internal', 'information_schema', 'catalog_history', 'cron')")
-	}
-	fmt.Fprintf(query, "  ORDER BY r.relname, pos.n;")
-
-	rows, err := db.QueryContext(ctx, query.String(), args...)
-	if err != nil {
-		return nil, fmt.Errorf("error executing discovery query %q: %w", query.String(), err)
-	}
-	defer rows.Close()
-
-	var keys []*discoveredPrimaryKey
-	for rows.Next() {
-		var tableSchema, tableName, columnName string
-		var ordinalPosition int
-		if err := rows.Scan(&tableSchema, &tableName, &columnName, &ordinalPosition); err != nil {
-			return nil, fmt.Errorf("error scanning result row: %w", err)
-		}
-
-		keys = append(keys, &discoveredPrimaryKey{
-			Schema: tableSchema,
-			Table:  tableName,
-			Column: columnName,
-			Index:  ordinalPosition,
-		})
-	}
-	return keys, nil
-}
-
-var databaseTypeToJSON = map[string]basicColumnType{
-	"bool": {jsonTypes: []string{"boolean"}},
-
-	"int2": {jsonTypes: []string{"integer"}},
-	"int4": {jsonTypes: []string{"integer"}},
-	"int8": {jsonTypes: []string{"integer"}},
-
-	"numeric": {jsonTypes: []string{"string"}, format: "number"},
-	"float4":  {jsonTypes: []string{"number", "string"}, format: "number"},
-	"float8":  {jsonTypes: []string{"number", "string"}, format: "number"},
-
-	"varchar": {jsonTypes: []string{"string"}},
-	"bpchar":  {jsonTypes: []string{"string"}},
-	"text":    {jsonTypes: []string{"string"}},
-	"bytea":   {jsonTypes: []string{"string"}, contentEncoding: "base64"},
-	"xml":     {jsonTypes: []string{"string"}},
-	"bit":     {jsonTypes: []string{"string"}},
-	"varbit":  {jsonTypes: []string{"string"}},
-
-	"json":     {},
-	"jsonb":    {},
-	"jsonpath": {jsonTypes: []string{"string"}},
-
-	// Domain-Specific Types
-	"date":        {jsonTypes: []string{"string"}, format: "date-time"},
-	"timestamp":   {jsonTypes: []string{"string"}, format: "date-time"},
-	"timestamptz": {jsonTypes: []string{"string"}, format: "date-time"},
-	"time":        {jsonTypes: []string{"integer"}},
-	"timetz":      {jsonTypes: []string{"string"}, format: "time"},
-	"interval":    {jsonTypes: []string{"string"}},
-	"money":       {jsonTypes: []string{"string"}},
-	"point":       {jsonTypes: []string{"string"}},
-	"line":        {jsonTypes: []string{"string"}},
-	"lseg":        {jsonTypes: []string{"string"}},
-	"box":         {jsonTypes: []string{"string"}},
-	"path":        {jsonTypes: []string{"string"}},
-	"polygon":     {jsonTypes: []string{"string"}},
-	"circle":      {jsonTypes: []string{"string"}},
-	"inet":        {jsonTypes: []string{"string"}},
-	"cidr":        {jsonTypes: []string{"string"}},
-	"macaddr":     {jsonTypes: []string{"string"}},
-	"macaddr8":    {jsonTypes: []string{"string"}},
-	"tsvector":    {jsonTypes: []string{"string"}},
-	"tsquery":     {jsonTypes: []string{"string"}},
-	"uuid":        {jsonTypes: []string{"string"}, format: "uuid"},
-}
-
-var catalogNameSanitizerRe = regexp.MustCompile(`(?i)[^a-z0-9\-_.]`)
-
-func recommendedCatalogName(schema, table string) string {
-	var catalogName string
-	// Omit 'default schema' names for Postgres and SQL Server. There is
-	// no default schema for MySQL databases.
-	if schema == "public" || schema == "dbo" {
-		catalogName = table
-	} else {
-		catalogName = schema + "_" + table
-	}
-	return catalogNameSanitizerRe.ReplaceAllString(strings.ToLower(catalogName), "_")
 }
 
 // Validate checks that the configuration appears correct and that we can connect
@@ -761,6 +274,10 @@ func (s *captureState) Validate() error {
 }
 
 func (c *capture) Run(ctx context.Context) error {
+	if err := c.emitSourcedSchemas(ctx); err != nil {
+		return err
+	}
+
 	var eg, workerCtx = errgroup.WithContext(ctx)
 	for idx, binding := range c.Bindings {
 		if idx > 0 {
@@ -774,6 +291,32 @@ func (c *capture) Run(ctx context.Context) error {
 	}
 	if err := eg.Wait(); err != nil {
 		return fmt.Errorf("capture terminated with error: %w", err)
+	}
+	return nil
+}
+
+func (c *capture) emitSourcedSchemas(ctx context.Context) error {
+	// Discover tables and emit SourcedSchema updates
+	if c.Config.Advanced.parsedFeatureFlags["emit_sourced_schemas"] {
+		var tableInfo, err = c.Driver.discoverTables(ctx, c.DB, c.Config)
+		if err != nil {
+			return fmt.Errorf("error discovering tables: %w", err)
+		}
+		for _, binding := range c.Bindings {
+			if binding.resource.SchemaName == "" || binding.resource.TableName == "" || binding.resource.Template != "" {
+				continue // Skip bindings with no schema/table or a custom query because we can't know what their schema will look like just from discovery info
+			}
+			var tableID = binding.resource.SchemaName + "." + binding.resource.TableName
+			var table, ok = tableInfo[tableID]
+			if !ok {
+				continue // Skip bindings for which we don't have any corresponding discovery information
+			}
+			if schema, _, err := generateCollectionSchema(c.Config, table, false); err != nil {
+				return fmt.Errorf("error generating schema for table %q: %w", tableID, err)
+			} else if err := c.Output.SourcedSchema(binding.index, schema); err != nil {
+				return fmt.Errorf("error emitting schema for table %q: %w", tableID, err)
+			}
+		}
 	}
 	return nil
 }

--- a/source-redshift-batch/main.go
+++ b/source-redshift-batch/main.go
@@ -25,6 +25,10 @@ var featureFlagDefaults = map[string]bool{
 	// used _in addition to_ the full column/types discovery we already do.
 	"use_schema_inference": false,
 
+	// When set, discovered collection schemas will be emitted as SourcedSchema messages
+	// so that Flow can have access to 'official' schema information from the source DB.
+	"emit_sourced_schemas": false,
+
 	// When true, the fallback collection key for keyless source tables will be
 	// ["/_meta/row_id"] instead of [].
 	"keyless_row_id": true,

--- a/source-redshift-batch/main_test.go
+++ b/source-redshift-batch/main_test.go
@@ -109,7 +109,7 @@ func testCaptureSpec(t testing.TB) *st.CaptureSpec {
 	return &st.CaptureSpec{
 		Driver:       redshiftDriver,
 		EndpointSpec: endpointSpec,
-		Validator:    &st.OrderedCaptureValidator{},
+		Validator:    &st.OrderedCaptureValidator{IncludeSourcedSchemas: true},
 		Sanitizers:   sanitizers,
 	}
 }
@@ -620,6 +620,7 @@ func TestCaptureFromView(t *testing.T) {
 	var viewName, viewID = testTableName(t, uniqueTableID(t, "view"))
 
 	// Create base table and view
+	executeControlQuery(t, control, fmt.Sprintf("DROP VIEW IF EXISTS %s", viewName))
 	createTestTable(t, control, baseTableName, `(
         id INTEGER PRIMARY KEY,
         name TEXT,

--- a/source-redshift-batch/main_test.go
+++ b/source-redshift-batch/main_test.go
@@ -677,3 +677,31 @@ func TestCaptureFromView(t *testing.T) {
 		cupaloy.SnapshotT(t, cs.Summary())
 	})
 }
+
+// TestFeatureFlagEmitSourcedSchemas runs a capture with the `emit_sourced_schemas` feature flag set.
+func TestFeatureFlagEmitSourcedSchemas(t *testing.T) {
+	var ctx, control = context.Background(), testControlClient(t)
+	var tableName, uniqueID = testTableName(t, uniqueTableID(t))
+	createTestTable(t, control, tableName, `(id INTEGER PRIMARY KEY, data TEXT)`)
+
+	executeControlQuery(t, control, fmt.Sprintf("INSERT INTO %s (id, data) VALUES (1, 'hello'), (2, 'world')", tableName))
+
+	for _, tc := range []struct {
+		name string
+		flag string
+	}{
+		{"Default", ""},
+		{"Enabled", "emit_sourced_schemas"},
+		{"Disabled", "no_emit_sourced_schemas"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var cs = testCaptureSpec(t)
+			cs.EndpointSpec.(*Config).Advanced.FeatureFlags = tc.flag
+			cs.Bindings = discoverBindings(ctx, t, cs, regexp.MustCompile(uniqueID))
+			setShutdownAfterQuery(t, true)
+
+			cs.Capture(ctx, t, nil)
+			cupaloy.SnapshotT(t, cs.Summary())
+		})
+	}
+}


### PR DESCRIPTION
**Description:**

This PR adds the `emit_sourced_schemas` feature flag to `source-postgres-batch` and `source-redshift-batch`, along with full column type discovery for `source-postgres-batch` (which Redshift already had).

**Workflow steps:**

Nothing changes by default yet, but when the `emit_sourced_schemas` flag is set they will be generated so that we can pick up the schemas of empty tables and introduce newly added columns before processing any new rows.