### PR TITLE
source-pendo: add `TrackType` & `Visitor` streams, capture from all applications

### DIFF
--- a/source-pendo/source_pendo/api.py
+++ b/source-pendo/source_pendo/api.py
@@ -56,12 +56,15 @@ def generate_events_body(
             "pipeline": [
                 {
                     "source": {
-                        entity: None,
+                        entity: {
+                            # Capture events for all applications within this Pendo subscription.
+                            "appId": "expandAppIds(\"*\")",
+                        },
                         "timeSeries": {
                             "period": "hourRange",
                             "first": f"{lower_bound}",
                             # If an upper bound isn't specified, retrieve all events up to the present.
-                            "last": f"{upper_bound or "now()"}"
+                            "last": f"{upper_bound or 'now()'}"
                         }
                     }
                 },
@@ -127,12 +130,15 @@ def generate_event_aggregates_body(
             "pipeline": [
                 {
                     "source": {
-                        entity: None,
+                        entity: {
+                            # Capture events for all applications within this Pendo subscription.
+                            "appId": "expandAppIds(\"*\")",
+                        },
                         "timeSeries": {
                             "period": "hourRange",
                             "first": f"{lower_bound}",
                             # If an upper bound isn't specified, retrieve all events up to the present.
-                            "last": f"{upper_bound or "now()"}"
+                            "last": f"{upper_bound or 'now()'}"
                         }
                     }
                 },
@@ -161,7 +167,13 @@ async def fetch_resources(
 ) -> AsyncGenerator[Resource, None]:
     url = f"{API}/{entity}"
 
-    resources = TypeAdapter(list[Resource]).validate_json(await http.request(log, url))
+    params = {
+        # The expand query parameter tells Pendo to return data for all
+        # applications associated with the Pendo subscription.
+        "expand": "*",
+    }
+
+    resources = TypeAdapter(list[Resource]).validate_json(await http.request(log, url, params=params))
 
     for resource in resources:
         yield resource

--- a/source-pendo/source_pendo/api.py
+++ b/source-pendo/source_pendo/api.py
@@ -4,14 +4,19 @@ from typing import AsyncGenerator
 import pendulum
 from pydantic import TypeAdapter
 from estuary_cdk.capture.common import BaseDocument, LogCursor, PageCursor
+import estuary_cdk.emitted_changes_cache as cache
 from estuary_cdk.http import HTTPSession
 
-from .models import PageEvent, FeatureEvent, TrackEvent, GuideEvent, PollEvent, AggregatedEventResponse,EventResponse, Resource, Metadata
+from .models import PageEvent, FeatureEvent, TrackEvent, GuideEvent, PollEvent, AggregatedEventResponse, EventResponse, Resource, Metadata, ResourceResponse
 
 API = "https://app.pendo.io/api/v1"
 RESPONSE_LIMIT = 50000
-# Use a date window size of 1 day for backfills.
-DATE_WINDOW_SIZE_IN_DAYS = 1
+# Use a date window size of 1 day for event backfills since there can be a huge
+# number of events in a small timespan.
+EVENT_DATE_WINDOW_SIZE_IN_DAYS = 1
+# Use a moderately sized date window for resource backfills.
+RESOURCE_DATE_WINDOW_SIZE_IN_DAYS = 30
+
 
 def _dt_to_ms(dt: datetime) -> int:
     return int(dt.timestamp() * 1000)
@@ -160,7 +165,71 @@ def generate_event_aggregates_body(
     return body
 
 
-async def fetch_resources(
+def generate_resources_body(
+        entity: str,
+        updated_at_field: str,
+        identifying_field: str,
+        lower_bound: int,
+        upper_bound: int | None = None,
+        last_seen_id: str | None = None,
+):
+    """
+    Builds the request body to retrieve resources from the Pendo API.
+
+    Pendo's resource aggregation endpoints require a JSON body with various fields.
+    See https://engageapi.pendo.io/#3f5fdb6d-02da-4441-b4d1-75f795ba248c. We use
+    their filtering and sorting capabilities to paginate through documents in 
+    ascending order. Each document returned represents a single resource.
+    """
+
+    # If we have an ID that we saw last, get the remaining resources for that specific timestamp. 
+    # Otherwise, get as many resources as we can since the last timestamp.
+    #
+    # The filter condition uses:
+    #  updated_at_field: the last time the resource was updated
+    # identifying_field: the unique ID for the associated Pendo resource. Used as a second filter when
+    #                    there are more resources in Pendo with the same updated_at_field than we can retrieve in
+    #                    a single API query.
+    if last_seen_id:
+        filter_condition = f"{updated_at_field} == {lower_bound} && {identifying_field} >= \"{last_seen_id}\""
+    else:
+        filter_condition = f"{updated_at_field} >= {lower_bound}"
+        if upper_bound:
+            filter_condition += f" && {updated_at_field} <= {upper_bound}"
+
+    body = {
+        "response": {
+            "mimeType": "application/json"
+        },
+        "request": {
+            "pipeline": [
+                {
+                    "source": {
+                        entity: {
+                            # Capture resources for all applications within this Pendo subscription.
+                            "appId": "expandAppIds(\"*\")",
+                        },
+                    }
+                },
+                {
+                    "filter": filter_condition
+                },
+                # Resources are sorted first by their updated_at_field, then by their
+                # identifying_field if they have the same updated_at_field value.
+                {
+                    "sort": [f"{updated_at_field}", f"{identifying_field}"]
+                },
+                {
+                    "limit": RESPONSE_LIMIT
+                }
+            ]
+        }
+    }
+
+    return body
+
+
+async def snapshot_resources(
         http: HTTPSession,
         entity: str,
         log: Logger,
@@ -179,7 +248,7 @@ async def fetch_resources(
         yield resource
 
 
-async def fetch_metadata(
+async def snapshot_metadata(
         http: HTTPSession,
         entity: str,
         log: Logger,
@@ -275,7 +344,7 @@ async def backfill_events(
     assert isinstance(cutoff, datetime)
     url = f"{API}/aggregation"
     last_dt = _ms_to_dt(page_cursor)
-    upper_bound_dt = last_dt + timedelta(days=DATE_WINDOW_SIZE_IN_DAYS)
+    upper_bound_dt = last_dt + timedelta(days=EVENT_DATE_WINDOW_SIZE_IN_DAYS)
 
     # If we've reached or exceeded the cutoff date, stop backfilling.
     if last_dt >= cutoff:
@@ -308,7 +377,7 @@ async def backfill_events(
 
     if doc_count == 0:
         # If there were no documents, we need to move the cursor forward to slide forward our date window.
-        yield _dt_to_ms(last_dt + timedelta(days=DATE_WINDOW_SIZE_IN_DAYS))
+        yield _dt_to_ms(last_dt + timedelta(days=EVENT_DATE_WINDOW_SIZE_IN_DAYS))
     elif last_dt > _ms_to_dt(page_cursor):
         # If there were documents and the last one has a later timestamp than our cursor,
         # then update the cursor to the later timestamp.
@@ -424,7 +493,7 @@ async def backfill_aggregated_events(
     assert isinstance(cutoff, datetime)
     url = f"{API}/aggregation"
     last_dt = _ms_to_dt(page_cursor)
-    upper_bound_dt = last_dt + timedelta(days=DATE_WINDOW_SIZE_IN_DAYS)
+    upper_bound_dt = last_dt + timedelta(days=EVENT_DATE_WINDOW_SIZE_IN_DAYS)
 
     # If we've reached or exceeded the cutoff date, stop backfilling.
     if last_dt >= cutoff:
@@ -457,7 +526,7 @@ async def backfill_aggregated_events(
 
     if doc_count == 0:
         # If there were no documents, we need to move the cursor forward to slide forward our date window.
-        yield _dt_to_ms(last_dt + timedelta(days=DATE_WINDOW_SIZE_IN_DAYS))
+        yield _dt_to_ms(last_dt + timedelta(days=EVENT_DATE_WINDOW_SIZE_IN_DAYS))
     elif last_dt > _ms_to_dt(page_cursor):
         # If there were documents and the last one has a later timestamp than our cursor, then update
         # the cursor to the later timestamp.
@@ -483,6 +552,176 @@ async def backfill_aggregated_events(
 
                 aggregate.meta_ = model.Meta(op="c")
                 yield aggregate
+
+            if doc_count < RESPONSE_LIMIT:
+                break
+
+        yield _dt_to_ms(last_dt + timedelta(milliseconds=1))
+
+
+# _get_field extracts a field from a document. The field could be
+# nested somewhere within document. ex: metadata.auto.lastupdated
+def _get_field(doc: BaseDocument, field: str, log: Logger,):
+    keys = field.split('.')
+    value = doc.model_dump()
+    for key in keys:
+        value = value.get(key)
+        if value is None:
+            raise RuntimeError(f"No field \"{field}\" present in document.")
+
+    return value
+
+
+def _extract_updated_at(doc: BaseDocument, updated_at_field: str, log: Logger) -> datetime:
+    ms = _get_field(doc, updated_at_field, log)
+    assert isinstance(ms, int)
+    return _ms_to_dt(ms)
+
+
+async def fetch_resources(
+        http: HTTPSession,
+        entity: str,
+        model: type[BaseDocument],
+        updated_at_field: str,
+        identifying_field: str,
+        log: Logger,
+        log_cursor: LogCursor,
+) -> AsyncGenerator[BaseDocument | LogCursor, None]:
+    assert isinstance(log_cursor, datetime)
+    url = f"{API}/aggregation"
+    last_dt = log_cursor
+    last_ts = _dt_to_ms(last_dt)
+
+    body = generate_resources_body(entity=entity, updated_at_field=updated_at_field, identifying_field=identifying_field, lower_bound=last_ts)
+
+    response_model = TypeAdapter(ResourceResponse[model])
+    response = response_model.validate_json(await http.request(log, url, method="POST", json=body))
+
+    doc_count = 0
+    last_seen_id = ""
+    for resource in response.results:
+        updated_at_dt = _extract_updated_at(resource, updated_at_field, log)
+        # Due to how we're querying the API with the "sort" and "filter" operators, 
+        # we don't expect to receive documents out of order.
+        if updated_at_dt < last_dt:
+            raise RuntimeError(
+                f"Received resources out of time order: Current resource timestamp is {updated_at_dt} vs. prior timestamp {last_dt}"
+            )
+
+        doc_count += 1
+        last_dt = updated_at_dt
+        last_seen_id = getattr(resource, identifying_field)
+
+        if cache.should_yield(entity, last_seen_id, updated_at_dt):
+            yield resource
+
+    if doc_count == 0:
+        # If there were no documents, don't update the cursor.
+        return
+    elif last_dt > log_cursor:
+        # If there was at least one document and the last document's timestamp is
+        # later than the cursor, update the cursor.
+        yield last_dt
+    elif last_dt == log_cursor:
+        # If the last document has the same timestamp as our cursor, fetch the remaining documents with
+        # this timestamp & increment the cursor by 1 afterwards.
+        while True:
+            body = generate_resources_body(entity=entity, updated_at_field=updated_at_field, identifying_field=identifying_field, lower_bound=last_ts, last_seen_id=last_seen_id)
+            response = response_model.validate_json(await http.request(log, url, method="POST", json=body))
+
+            doc_count = 0
+            for resource in response.results:
+                updated_at_dt = _extract_updated_at(resource, updated_at_field, log)
+                if updated_at_dt < last_dt:
+                    raise RuntimeError(
+                        f"Received events out of time order: Current event timestamp is {updated_at_dt} vs. prior timestamp {last_dt}"
+                    )
+
+                doc_count += 1
+                last_seen_id = getattr(resource, identifying_field)
+
+                if cache.should_yield(entity, last_seen_id, updated_at_dt):
+                    yield resource
+
+            if doc_count < RESPONSE_LIMIT:
+                break
+
+        yield last_dt + timedelta(milliseconds=1)
+
+
+async def backfill_resources(
+        http: HTTPSession,
+        entity: str,
+        model: type[BaseDocument],
+        updated_at_field: str,
+        identifying_field: str,
+        log: Logger,
+        page_cursor: PageCursor | None,
+        cutoff: LogCursor,
+) -> AsyncGenerator[BaseDocument | PageCursor, None]:
+    assert isinstance(page_cursor, int)
+    assert isinstance(cutoff, datetime)
+    url = f"{API}/aggregation"
+    last_dt = _ms_to_dt(page_cursor)
+    upper_bound_dt = last_dt + timedelta(days=RESOURCE_DATE_WINDOW_SIZE_IN_DAYS)
+
+    # If we've reached or exceeded the cutoff date, stop backfilling.
+    if last_dt >= cutoff:
+        return
+
+    last_ts = _dt_to_ms(last_dt)
+    upper_bound_ts = _dt_to_ms(upper_bound_dt)
+
+    body = generate_resources_body(entity=entity, updated_at_field=updated_at_field, identifying_field=identifying_field, lower_bound=last_ts, upper_bound=upper_bound_ts)
+    response_model = TypeAdapter(ResourceResponse[model])
+    response = response_model.validate_json(await http.request(log, url, method="POST", json=body))
+
+    doc_count = 0
+    last_seen_id = ""
+    for resource in response.results:
+        updated_at_dt = _extract_updated_at(resource, updated_at_field, log)
+        # Due to how we're querying the API with the "sort" and "filter" operators, 
+        # we don't expect to receive documents out of order.
+        if updated_at_dt < last_dt:
+            raise RuntimeError(
+                f"Received events out of time order: Current event timestamp is {updated_at_dt} vs. prior timestamp {last_dt}"
+            )
+
+        if updated_at_dt >= cutoff:
+            return
+
+        doc_count += 1
+        last_dt = updated_at_dt
+        last_seen_id = getattr(resource, identifying_field)
+
+        yield resource
+
+    if doc_count == 0:
+        # If there were no documents, we need to move the cursor forward to slide forward our date window.
+        yield _dt_to_ms(last_dt + timedelta(days=RESOURCE_DATE_WINDOW_SIZE_IN_DAYS))
+    elif last_dt > _ms_to_dt(page_cursor):
+        # If there were documents and the last one has a later timestamp than our cursor, then update
+        # the cursor to the later timestamp.
+        yield _dt_to_ms(last_dt)
+    elif last_dt == _ms_to_dt(page_cursor):
+        # If the last document has the same timestamp as our cursor, fetch the remaining documents with
+        # this timestamp & increment the cursor by 1 afterwards.
+        while True:
+            body = generate_resources_body(entity=entity, updated_at_field=updated_at_field, identifying_field=identifying_field, lower_bound=last_ts, upper_bound=upper_bound_ts, last_seen_id=last_seen_id)
+            response = response_model.validate_json(await http.request(log, url, method="POST", json=body))
+
+            doc_count = 0
+            for resource in response.results:
+                updated_at_dt = _extract_updated_at(resource, updated_at_field, log)
+                if updated_at_dt < last_dt:
+                    raise RuntimeError(
+                        f"Received events out of time order: Current event timestamp is {updated_at_dt} vs. prior timestamp {last_dt}"
+                    )
+
+                doc_count += 1
+                last_seen_id = getattr(resource, identifying_field)
+
+                yield resource
 
             if doc_count < RESPONSE_LIMIT:
                 break

--- a/source-pendo/tests/snapshots/snapshots__discover__capture.stdout.json
+++ b/source-pendo/tests/snapshots/snapshots__discover__capture.stdout.json
@@ -220,6 +220,130 @@
     ]
   },
   {
+    "recommendedName": "Visitor",
+    "resourceConfig": {
+      "name": "Visitor",
+      "interval": "PT5M"
+    },
+    "documentSchema": {
+      "$defs": {
+        "Meta": {
+          "properties": {
+            "op": {
+              "default": "u",
+              "description": "Operation type (c: Create, u: Update, d: Delete)",
+              "enum": [
+                "c",
+                "u",
+                "d"
+              ],
+              "title": "Op",
+              "type": "string"
+            },
+            "row_id": {
+              "default": -1,
+              "description": "Row ID of the Document, counting up from zero, or -1 if not known",
+              "title": "Row Id",
+              "type": "integer"
+            }
+          },
+          "title": "Meta",
+          "type": "object"
+        }
+      },
+      "additionalProperties": true,
+      "properties": {
+        "_meta": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/Meta"
+            }
+          ],
+          "default": {
+            "op": "u",
+            "row_id": -1
+          },
+          "description": "Document metadata"
+        },
+        "visitorId": {
+          "title": "Visitorid",
+          "type": "string"
+        }
+      },
+      "required": [
+        "visitorId"
+      ],
+      "title": "Visitor",
+      "type": "object",
+      "x-infer-schema": true
+    },
+    "key": [
+      "/visitorId"
+    ]
+  },
+  {
+    "recommendedName": "TrackType",
+    "resourceConfig": {
+      "name": "TrackType",
+      "interval": "PT5M"
+    },
+    "documentSchema": {
+      "$defs": {
+        "Meta": {
+          "properties": {
+            "op": {
+              "default": "u",
+              "description": "Operation type (c: Create, u: Update, d: Delete)",
+              "enum": [
+                "c",
+                "u",
+                "d"
+              ],
+              "title": "Op",
+              "type": "string"
+            },
+            "row_id": {
+              "default": -1,
+              "description": "Row ID of the Document, counting up from zero, or -1 if not known",
+              "title": "Row Id",
+              "type": "integer"
+            }
+          },
+          "title": "Meta",
+          "type": "object"
+        }
+      },
+      "additionalProperties": true,
+      "properties": {
+        "_meta": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/Meta"
+            }
+          ],
+          "default": {
+            "op": "u",
+            "row_id": -1
+          },
+          "description": "Document metadata"
+        },
+        "id": {
+          "title": "Id",
+          "type": "string"
+        }
+      },
+      "required": [
+        "id"
+      ],
+      "title": "TrackType",
+      "type": "object",
+      "x-infer-schema": true
+    },
+    "key": [
+      "/id"
+    ]
+  },
+  {
     "recommendedName": "AccountMetadata",
     "resourceConfig": {
       "name": "AccountMetadata",


### PR DESCRIPTION
**Description:**

This PR's scope includes:
- Capturing data for all applications within a single Pendo subscription.
- Adding the [`TrackType`](https://engageapi.pendo.io/#9f83f648-4fe7-45db-b30d-963679af6304) and [`Visitor`](https://engageapi.pendo.io/#dd943e68-5bff-4a1a-9891-b55638ae2c3d) streams that capture the same named resources from Pendo's aggregation API.

Some existing streams (`Page`, `Guide`, etc.) could also be captured incrementally via the aggregation API, and that would be better than constantly taking snapshots of all pages, guides, etc. like we currently do. But that would also require changing the primary key for those streams, and that'd impact existing Pendo captures. Changing those streams from full refresh to incremental can be done later when we have more time to generalize the connector's code & potentially bump the connector version.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

Documentation should be updated to reflect the added streams.

**Notes for reviewers:**

Tested on a local stack. Confirmed data is captured for `Track` & `Visitor` streams. Confirmed data for more than just the default application is captured from the user's Pendo subscription.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2799)
<!-- Reviewable:end -->
