### PR TITLE
source-mysql: Add flag `case_sensitive_table_names`

### DIFF
--- a/source-mysql/.snapshots/TestTableNamesIdenticalUnderCapitalization-Capture
+++ b/source-mysql/.snapshots/TestTableNamesIdenticalUnderCapitalization-Capture
@@ -1,0 +1,23 @@
+# ================================
+# Collection "acmeCo/test/test/TABLE_WITH_DIFFERENT_CASING": 6 Documents
+# ================================
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"TABLE_WITH_DIFFERENT_CASING","cursor":"backfill:0"}},"id":1,"x":101,"y":102}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"TABLE_WITH_DIFFERENT_CASING","cursor":"backfill:1"}},"id":2,"x":201,"y":202}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"TABLE_WITH_DIFFERENT_CASING","cursor":"backfill:2"}},"id":3,"x":301,"y":302}
+{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"TABLE_WITH_DIFFERENT_CASING","cursor":"binlog.000123:56789:123","txid":"11111111-1111-1111-1111-111111111111:111"}},"id":4,"x":401,"y":402}
+{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"TABLE_WITH_DIFFERENT_CASING","cursor":"binlog.000123:56789:123","txid":"11111111-1111-1111-1111-111111111111:111"}},"id":5,"x":501,"y":502}
+{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"TABLE_WITH_DIFFERENT_CASING","cursor":"binlog.000123:56789:123","txid":"11111111-1111-1111-1111-111111111111:111"}},"id":6,"x":601,"y":602}
+# ================================
+# Collection "acmeCo/test/test/table_with_different_casing": 6 Documents
+# ================================
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"table_with_different_casing","cursor":"backfill:0"}},"data":"zero","id":0}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"table_with_different_casing","cursor":"backfill:1"}},"data":"one","id":1}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"table_with_different_casing","cursor":"backfill:2"}},"data":"two","id":2}
+{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"table_with_different_casing","cursor":"binlog.000123:56789:123","txid":"11111111-1111-1111-1111-111111111111:111"}},"data":"three","id":3}
+{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"table_with_different_casing","cursor":"binlog.000123:56789:123","txid":"11111111-1111-1111-1111-111111111111:111"}},"data":"four","id":4}
+{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"table_with_different_casing","cursor":"binlog.000123:56789:123","txid":"11111111-1111-1111-1111-111111111111:111"}},"data":"five","id":5}
+# ================================
+# Final State Checkpoint
+# ================================
+{"bindingStateV1":{"test%2FTABLE_WITH_DIFFERENT_CASING":{"backfilled":3,"key_columns":["id"],"metadata":{"charset":"utf8mb4","schema":{"columns":["id","x","y"],"types":{"id":{"type":"int"},"x":{"type":"int"},"y":{"type":"int"}}}},"mode":"Active"},"test%2Ftable_with_different_casing":{"backfilled":3,"key_columns":["id"],"metadata":{"charset":"utf8mb4","schema":{"columns":["id","data"],"types":{"data":{"charset":"utf8mb4","type":"text"},"id":{"type":"int"}}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
+

--- a/source-mysql/.snapshots/TestTableNamesIdenticalUnderCapitalization-Discover
+++ b/source-mysql/.snapshots/TestTableNamesIdenticalUnderCapitalization-Discover
@@ -1,0 +1,267 @@
+Binding 0:
+{
+    "recommended_name": "test/TABLE_WITH_DIFFERENT_CASING",
+    "resource_config_json": {
+      "namespace": "test",
+      "stream": "TABLE_WITH_DIFFERENT_CASING"
+    },
+    "document_schema_json": {
+      "$defs": {
+        "TestTABLE_WITH_DIFFERENT_CASING": {
+          "type": "object",
+          "required": [
+            "id"
+          ],
+          "$anchor": "TestTABLE_WITH_DIFFERENT_CASING",
+          "properties": {
+            "id": {
+              "type": "integer",
+              "description": "(source type: non-nullable int)"
+            },
+            "x": {
+              "description": "(source type: int)",
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "y": {
+              "description": "(source type: int)",
+              "type": [
+                "integer",
+                "null"
+              ]
+            }
+          }
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "_meta": {
+                "properties": {
+                  "op": {
+                    "const": "d"
+                  }
+                }
+              }
+            }
+          },
+          "then": {
+            "reduce": {
+              "delete": true,
+              "strategy": "merge"
+            }
+          },
+          "else": {
+            "reduce": {
+              "strategy": "merge"
+            }
+          },
+          "required": [
+            "_meta"
+          ],
+          "properties": {
+            "_meta": {
+              "type": "object",
+              "required": [
+                "op",
+                "source"
+              ],
+              "properties": {
+                "before": {
+                  "$ref": "#TestTABLE_WITH_DIFFERENT_CASING",
+                  "description": "Record state immediately before this change was applied.",
+                  "reduce": {
+                    "strategy": "firstWriteWins"
+                  }
+                },
+                "op": {
+                  "enum": [
+                    "c",
+                    "d",
+                    "u"
+                  ],
+                  "description": "Change operation type: 'c' Create/Insert, 'u' Update, 'd' Delete."
+                },
+                "source": {
+                  "$id": "https://github.com/estuary/connectors/source-mysql/mysql-source-info",
+                  "properties": {
+                    "ts_ms": {
+                      "type": "integer",
+                      "description": "Unix timestamp (in millis) at which this event was recorded by the database."
+                    },
+                    "schema": {
+                      "type": "string",
+                      "description": "Database schema (namespace) of the event."
+                    },
+                    "snapshot": {
+                      "type": "boolean",
+                      "description": "Snapshot is true if the record was produced from an initial table backfill and unset if produced from the replication log."
+                    },
+                    "table": {
+                      "type": "string",
+                      "description": "Database table of the event."
+                    },
+                    "cursor": {
+                      "type": "string",
+                      "description": "Cursor value representing the current position in the binlog."
+                    },
+                    "txid": {
+                      "type": "string",
+                      "description": "The global transaction identifier associated with a change by MySQL. Only set if GTIDs are enabled."
+                    }
+                  },
+                  "type": "object",
+                  "required": [
+                    "schema",
+                    "table",
+                    "cursor"
+                  ]
+                }
+              },
+              "reduce": {
+                "strategy": "merge"
+              }
+            }
+          }
+        },
+        {
+          "$ref": "#TestTABLE_WITH_DIFFERENT_CASING"
+        }
+      ]
+    },
+    "key": [
+      "/id"
+    ]
+  }
+Binding 1:
+{
+    "recommended_name": "test/table_with_different_casing",
+    "resource_config_json": {
+      "namespace": "test",
+      "stream": "table_with_different_casing"
+    },
+    "document_schema_json": {
+      "$defs": {
+        "TestTable_with_different_casing": {
+          "type": "object",
+          "required": [
+            "id"
+          ],
+          "$anchor": "TestTable_with_different_casing",
+          "properties": {
+            "data": {
+              "type": "string",
+              "description": "(source type: non-nullable text)"
+            },
+            "id": {
+              "type": "integer",
+              "description": "(source type: non-nullable int)"
+            }
+          }
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "_meta": {
+                "properties": {
+                  "op": {
+                    "const": "d"
+                  }
+                }
+              }
+            }
+          },
+          "then": {
+            "reduce": {
+              "delete": true,
+              "strategy": "merge"
+            }
+          },
+          "else": {
+            "reduce": {
+              "strategy": "merge"
+            }
+          },
+          "required": [
+            "_meta"
+          ],
+          "properties": {
+            "_meta": {
+              "type": "object",
+              "required": [
+                "op",
+                "source"
+              ],
+              "properties": {
+                "before": {
+                  "$ref": "#TestTable_with_different_casing",
+                  "description": "Record state immediately before this change was applied.",
+                  "reduce": {
+                    "strategy": "firstWriteWins"
+                  }
+                },
+                "op": {
+                  "enum": [
+                    "c",
+                    "d",
+                    "u"
+                  ],
+                  "description": "Change operation type: 'c' Create/Insert, 'u' Update, 'd' Delete."
+                },
+                "source": {
+                  "$id": "https://github.com/estuary/connectors/source-mysql/mysql-source-info",
+                  "properties": {
+                    "ts_ms": {
+                      "type": "integer",
+                      "description": "Unix timestamp (in millis) at which this event was recorded by the database."
+                    },
+                    "schema": {
+                      "type": "string",
+                      "description": "Database schema (namespace) of the event."
+                    },
+                    "snapshot": {
+                      "type": "boolean",
+                      "description": "Snapshot is true if the record was produced from an initial table backfill and unset if produced from the replication log."
+                    },
+                    "table": {
+                      "type": "string",
+                      "description": "Database table of the event."
+                    },
+                    "cursor": {
+                      "type": "string",
+                      "description": "Cursor value representing the current position in the binlog."
+                    },
+                    "txid": {
+                      "type": "string",
+                      "description": "The global transaction identifier associated with a change by MySQL. Only set if GTIDs are enabled."
+                    }
+                  },
+                  "type": "object",
+                  "required": [
+                    "schema",
+                    "table",
+                    "cursor"
+                  ]
+                }
+              },
+              "reduce": {
+                "strategy": "merge"
+              }
+            }
+          }
+        },
+        {
+          "$ref": "#TestTable_with_different_casing"
+        }
+      ]
+    },
+    "key": [
+      "/id"
+    ]
+  }
+

--- a/source-mysql/backfill.go
+++ b/source-mysql/backfill.go
@@ -197,10 +197,10 @@ func quoteColumnName(name string) string {
 	return "`" + strings.ReplaceAll(name, "`", "``") + "`"
 }
 
-func (db *mysqlDatabase) explainQuery(streamID, query string, args []interface{}) {
+func (db *mysqlDatabase) explainQuery(streamID sqlcapture.StreamID, query string, args []interface{}) {
 	// Only EXPLAIN the backfill query once per connector invocation
 	if db.explained == nil {
-		db.explained = make(map[string]struct{})
+		db.explained = make(map[sqlcapture.StreamID]struct{})
 	}
 	if _, ok := db.explained[streamID]; ok {
 		return

--- a/source-mysql/capture_test.go
+++ b/source-mysql/capture_test.go
@@ -619,6 +619,8 @@ func TestTableNamesIdenticalUnderCapitalization(t *testing.T) {
 	tb.Query(ctx, t, fmt.Sprintf("DROP TABLE IF EXISTS %s", tableB))
 	tb.Query(ctx, t, fmt.Sprintf("CREATE TABLE %s(id INTEGER PRIMARY KEY, data TEXT NOT NULL)", tableA))
 	tb.Query(ctx, t, fmt.Sprintf("CREATE TABLE %s(id INTEGER PRIMARY KEY, x INTEGER, y INTEGER)", tableB))
+	t.Cleanup(func() { tb.Query(ctx, t, fmt.Sprintf("DROP TABLE IF EXISTS %s", tableA)) })
+	t.Cleanup(func() { tb.Query(ctx, t, fmt.Sprintf("DROP TABLE IF EXISTS %s", tableB)) })
 
 	var cs = tb.CaptureSpec(ctx, t)
 	cs.EndpointSpec.(*Config).Advanced.FeatureFlags = "case_sensitive_table_names"

--- a/source-mysql/database.go
+++ b/source-mysql/database.go
@@ -90,9 +90,9 @@ type mysqlDatabase struct {
 	config *Config
 	conn   mysqlClient
 
-	explained        map[string]struct{} // Tracks tables which have had an `EXPLAIN` run on them during this connector invocation.
-	datetimeLocation *time.Location      // The location in which to interpret DATETIME column values as timestamps.
-	includeTxIDs     map[string]bool     // Tracks which tables should have XID properties in their replication metadata.
+	explained        map[sqlcapture.StreamID]struct{} // Tracks tables which have had an `EXPLAIN` run on them during this connector invocation.
+	datetimeLocation *time.Location                   // The location in which to interpret DATETIME column values as timestamps.
+	includeTxIDs     map[sqlcapture.StreamID]bool     // Tracks which tables should have XID properties in their replication metadata.
 
 	featureFlags          map[string]bool // Parsed feature flag settings with defaults applied
 	initialBackfillCursor string          // When set, this cursor will be used instead of the current WAL end when a backfill resets the cursor

--- a/source-mysql/discovery.go
+++ b/source-mysql/discovery.go
@@ -65,15 +65,6 @@ func (db *mysqlDatabase) DiscoverTables(ctx context.Context) (map[sqlcapture.Str
 			continue // Ignore information about excluded tables
 		}
 
-		// The 'Stream IDs' used for table info lookup are case insensitive, so we
-		// need to double-check that there isn't a collision between two case variants
-		// of the same name.
-		if info.Schema != column.TableSchema || info.Name != column.TableName {
-			var nameA = fmt.Sprintf("%s.%s", info.Schema, info.Name)
-			var nameB = fmt.Sprintf("%s.%s", column.TableSchema, column.TableName)
-			return nil, fmt.Errorf("table name collision between %q and %q", nameA, nameB)
-		}
-
 		// Finally we can add to the column info map and column-name-ordering list
 		if info.Columns == nil {
 			info.Columns = make(map[string]sqlcapture.ColumnInfo)

--- a/source-mysql/main.go
+++ b/source-mysql/main.go
@@ -44,6 +44,12 @@ var featureFlagDefaults = map[string]bool{
 	// When set, discovered collection schemas will be emitted as SourcedSchema messages
 	// so that Flow can have access to 'official' schema information from the source DB.
 	"emit_sourced_schemas": false,
+
+	// When set, schema/table names will no longer be normalized to lowercase. This applies
+	// in two specific circumstances:
+	//   - Recommended Collection Names
+	//   - Internal StreamIDs
+	"case_sensitive_table_names": false,
 }
 
 type sshForwarding struct {
@@ -115,6 +121,10 @@ func connectMySQL(ctx context.Context, name string, cfg json.RawMessage) (sqlcap
 			forceResetCursor = strings.TrimPrefix(flag, "force_reset_cursor=")
 		}
 	}
+
+	// This is a bit hacky but it works fine since there's only ever one capture running at a time.
+	sqlcapture.LowercaseStreamIDs = !featureFlags["case_sensitive_table_names"]
+	sqlcapture.LowercaseRecommendedNames = !featureFlags["case_sensitive_table_names"]
 
 	var db = &mysqlDatabase{
 		config:                &config,

--- a/source-mysql/main.go
+++ b/source-mysql/main.go
@@ -432,7 +432,7 @@ func decodeKeyFDB(t tuple.TupleElement) (interface{}, error) {
 	return t, nil
 }
 
-func (db *mysqlDatabase) ShouldBackfill(streamID string) bool {
+func (db *mysqlDatabase) ShouldBackfill(streamID sqlcapture.StreamID) bool {
 	// As a special case, the solitary value '*.*' means that nothing should be
 	// backfilled. This makes certain sorts of operation which would otherwise
 	// require listing every single table in the database easier.
@@ -449,7 +449,7 @@ func (db *mysqlDatabase) ShouldBackfill(streamID string) bool {
 		// This repeated splitting is a little inefficient, but this check is done at
 		// most once per table during connector startup and isn't really worth caching.
 		for _, skipStreamID := range strings.Split(db.config.Advanced.SkipBackfills, ",") {
-			if strings.EqualFold(streamID, skipStreamID) {
+			if strings.EqualFold(streamID.String(), skipStreamID) {
 				return false
 			}
 		}
@@ -459,7 +459,7 @@ func (db *mysqlDatabase) ShouldBackfill(streamID string) bool {
 
 func (db *mysqlDatabase) RequestTxIDs(schema, table string) {
 	if db.includeTxIDs == nil {
-		db.includeTxIDs = make(map[string]bool)
+		db.includeTxIDs = make(map[sqlcapture.StreamID]bool)
 	}
 	db.includeTxIDs[sqlcapture.JoinStreamID(schema, table)] = true
 }

--- a/source-oracle/backfill.go
+++ b/source-oracle/backfill.go
@@ -178,8 +178,9 @@ func (db *oracleDatabase) WriteWatermark(ctx context.Context, watermark string) 
 }
 
 // WatermarksTable returns the name of the table to which WriteWatermarks writes UUIDs.
-func (db *oracleDatabase) WatermarksTable() string {
-	return strings.ToLower(db.config.Advanced.WatermarksTable)
+func (db *oracleDatabase) WatermarksTable() sqlcapture.StreamID {
+	var bits = strings.SplitN(db.config.Advanced.WatermarksTable, ".", 2)
+	return sqlcapture.JoinStreamID(bits[0], bits[1])
 }
 
 // The set of column types for which we need to specify `COLLATE BINARY` to get
@@ -299,7 +300,7 @@ func (db *oracleDatabase) buildScanQuery(start bool, info *sqlcapture.DiscoveryI
 	return query.String()
 }
 
-func (db *oracleDatabase) explainQuery(ctx context.Context, streamID, query string, args []interface{}) {
+func (db *oracleDatabase) explainQuery(ctx context.Context, streamID sqlcapture.StreamID, query string, args []interface{}) {
 	// Only EXPLAIN the backfill query once per connector invocation
 	if db.explained == nil {
 		db.explained = make(map[sqlcapture.StreamID]struct{})

--- a/source-oracle/discovery.go
+++ b/source-oracle/discovery.go
@@ -35,7 +35,7 @@ func (db *oracleDatabase) DiscoverTables(ctx context.Context) (map[sqlcapture.St
 	// Aggregate column and primary key information into DiscoveryInfo structs
 	// using a map from fully-qualified "<schema>.<name>" table names to
 	// the corresponding DiscoveryInfo.
-	var tableMap = make(map[string]*sqlcapture.DiscoveryInfo)
+	var tableMap = make(map[sqlcapture.StreamID]*sqlcapture.DiscoveryInfo)
 	for _, table := range tables {
 		var streamID = sqlcapture.JoinStreamID(table.Schema, table.Name)
 		if streamID == db.WatermarksTable() {
@@ -211,7 +211,7 @@ func getTables(ctx context.Context, conn *sql.DB, selectedSchemas []string) ([]*
 const queryTableObjectIdentifiers = `SELECT OWNER, OBJECT_NAME, OBJECT_ID, DATA_OBJECT_ID FROM ALL_OBJECTS WHERE OBJECT_TYPE='TABLE'`
 
 type tableObject struct {
-	streamID     string
+	streamID     sqlcapture.StreamID
 	objectID     int
 	dataObjectID int
 }
@@ -287,8 +287,8 @@ func (ct oracleColumnType) String() string {
 // SMALLINT, INT and INTEGER have a default precision 38 which is not included in the column information
 const defaultNumericPrecision = 38
 
-func getColumns(ctx context.Context, conn *sql.DB, tables []*sqlcapture.DiscoveryInfo) ([]sqlcapture.ColumnInfo, map[string][]string, error) {
-	var pks = make(map[string][]string)
+func getColumns(ctx context.Context, conn *sql.DB, tables []*sqlcapture.DiscoveryInfo) ([]sqlcapture.ColumnInfo, map[sqlcapture.StreamID][]string, error) {
+	var pks = make(map[sqlcapture.StreamID][]string)
 	var columns []sqlcapture.ColumnInfo
 
 	var ownersMap = make(map[string]bool)

--- a/source-oracle/main.go
+++ b/source-oracle/main.go
@@ -358,7 +358,7 @@ func decodeKeyFDB(t tuple.TupleElement) (interface{}, error) {
 	return t, nil
 }
 
-func (db *oracleDatabase) ShouldBackfill(streamID string) bool {
+func (db *oracleDatabase) ShouldBackfill(streamID sqlcapture.StreamID) bool {
 	// Allow the setting "*.*" to skip backfilling any tables.
 	if db.config.Advanced.SkipBackfills == "*.*" {
 		return false
@@ -368,7 +368,7 @@ func (db *oracleDatabase) ShouldBackfill(streamID string) bool {
 		// This repeated splitting is a little inefficient, but this check is done at
 		// most once per table during connector startup and isn't really worth caching.
 		for _, skipTableName := range strings.Split(db.config.Advanced.SkipBackfills, ",") {
-			if strings.EqualFold(streamID, skipTableName) {
+			if strings.EqualFold(streamID.String(), skipTableName) {
 				return false
 			}
 		}

--- a/source-postgres/backfill.go
+++ b/source-postgres/backfill.go
@@ -239,8 +239,9 @@ func (db *postgresDatabase) WriteWatermark(ctx context.Context, watermark string
 }
 
 // WatermarksTable returns the name of the table to which WriteWatermarks writes UUIDs.
-func (db *postgresDatabase) WatermarksTable() string {
-	return db.config.Advanced.WatermarksTable
+func (db *postgresDatabase) WatermarksTable() sqlcapture.StreamID {
+	var bits = strings.SplitN(db.config.Advanced.WatermarksTable, ".", 2)
+	return sqlcapture.JoinStreamID(bits[0], bits[1])
 }
 
 // The set of column types for which we need to specify `COLLATE "C"` to get
@@ -345,7 +346,7 @@ func quoteColumnName(name string) string {
 	return `"` + strings.ReplaceAll(name, `"`, `""`) + `"`
 }
 
-func (db *postgresDatabase) explainQuery(ctx context.Context, streamID, query string, args []interface{}) {
+func (db *postgresDatabase) explainQuery(ctx context.Context, streamID sqlcapture.StreamID, query string, args []interface{}) {
 	// Only EXPLAIN the backfill query once per connector invocation
 	if db.explained == nil {
 		db.explained = make(map[sqlcapture.StreamID]struct{})

--- a/source-postgres/main.go
+++ b/source-postgres/main.go
@@ -382,7 +382,7 @@ func (db *postgresDatabase) FallbackCollectionKey() []string {
 	return []string{"/_meta/source/loc/0", "/_meta/source/loc/1", "/_meta/source/loc/2"}
 }
 
-func (db *postgresDatabase) ShouldBackfill(streamID string) bool {
+func (db *postgresDatabase) ShouldBackfill(streamID sqlcapture.StreamID) bool {
 	// Allow the setting "*.*" to skip backfilling any tables.
 	if db.config.Advanced.SkipBackfills == "*.*" {
 		return false
@@ -392,7 +392,7 @@ func (db *postgresDatabase) ShouldBackfill(streamID string) bool {
 		// This repeated splitting is a little inefficient, but this check is done at
 		// most once per table during connector startup and isn't really worth caching.
 		for _, skipStreamID := range strings.Split(db.config.Advanced.SkipBackfills, ",") {
-			if streamID == strings.ToLower(skipStreamID) {
+			if strings.EqualFold(streamID.String(), skipStreamID) {
 				return false
 			}
 		}

--- a/source-sqlserver/backfill.go
+++ b/source-sqlserver/backfill.go
@@ -12,7 +12,7 @@ import (
 
 // ShouldBackfill returns true if a given table's contents should be backfilled, given
 // that we intend to capture that table.
-func (db *sqlserverDatabase) ShouldBackfill(streamID string) bool {
+func (db *sqlserverDatabase) ShouldBackfill(streamID sqlcapture.StreamID) bool {
 	// Allow the setting "*.*" to skip backfilling any tables.
 	if db.config.Advanced.SkipBackfills == "*.*" {
 		return false
@@ -22,7 +22,7 @@ func (db *sqlserverDatabase) ShouldBackfill(streamID string) bool {
 		// This repeated splitting is a little inefficient, but this check is done at
 		// most once per table during connector startup and isn't really worth caching.
 		for _, skipStreamID := range strings.Split(db.config.Advanced.SkipBackfills, ",") {
-			if streamID == strings.ToLower(skipStreamID) {
+			if strings.EqualFold(streamID.String(), skipStreamID) {
 				return false
 			}
 		}

--- a/source-sqlserver/discovery.go
+++ b/source-sqlserver/discovery.go
@@ -57,15 +57,6 @@ func (db *sqlserverDatabase) DiscoverTables(ctx context.Context) (map[sqlcapture
 			continue
 		}
 
-		// The 'Stream IDs' used for table info lookup are case insensitive, so we
-		// need to double-check that there isn't a collision between two case variants
-		// of the same name.
-		if info.Schema != column.TableSchema || info.Name != column.TableName {
-			var nameA = fmt.Sprintf("%s.%s", info.Schema, info.Name)
-			var nameB = fmt.Sprintf("%s.%s", column.TableSchema, column.TableName)
-			return nil, fmt.Errorf("table name collision between %q and %q", nameA, nameB)
-		}
-
 		if info.Columns == nil {
 			info.Columns = make(map[string]sqlcapture.ColumnInfo)
 		}

--- a/source-sqlserver/watermarks.go
+++ b/source-sqlserver/watermarks.go
@@ -5,12 +5,14 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/estuary/connectors/sqlcapture"
 	log "github.com/sirupsen/logrus"
 )
 
 // WatermarksTable returns the name of the table to which WriteWatermarks writes UUIDs.
-func (db *sqlserverDatabase) WatermarksTable() string {
-	return db.config.Advanced.WatermarksTable
+func (db *sqlserverDatabase) WatermarksTable() sqlcapture.StreamID {
+	var bits = strings.SplitN(db.config.Advanced.WatermarksTable, ".", 2)
+	return sqlcapture.JoinStreamID(bits[0], bits[1])
 }
 
 func (db *sqlserverDatabase) createWatermarksTable(ctx context.Context) error {

--- a/sqlcapture/capture.go
+++ b/sqlcapture/capture.go
@@ -854,9 +854,20 @@ func (s StreamID) String() string {
 	return fmt.Sprintf("%s.%s", s.Schema, s.Table)
 }
 
+// This is a temporary hack to allow us to plumb through a feature flag setting for
+// the gradual rollout of the "no longer lowercase stream IDs" behavior. This will
+// eventually be the standard for all connectors if we can do it without breaking
+// anything, but for now we want to be cautious and make it an opt-in.
+//
+// In an abstract sense we shouldn't be using a global variable for this, but as a
+// practical matter there's only ever one capture running at a time so this is fine.
+var LowercaseStreamIDs = true
+
 // JoinStreamID combines a namespace and a stream name into a dotted name like "public.foo_table".
 func JoinStreamID(namespace, stream string) StreamID {
-	namespace = strings.ToLower(namespace)
-	stream = strings.ToLower(stream)
+	if LowercaseStreamIDs {
+		namespace = strings.ToLower(namespace)
+		stream = strings.ToLower(stream)
+	}
 	return StreamID{Schema: namespace, Table: stream}
 }

--- a/sqlcapture/discovery.go
+++ b/sqlcapture/discovery.go
@@ -302,10 +302,15 @@ func generateCollectionSchema(db Database, table *DiscoveryInfo, fullWriteSchema
 // any occurences of '/' with '_' as well.
 var catalogNameSanitizerRe = regexp.MustCompile(`(?i)[^a-z0-9\-_.]`)
 
-func recommendedCatalogName(schema, table string) string {
-	var sanitizedSchema = catalogNameSanitizerRe.ReplaceAllString(strings.ToLower(schema), "_")
-	var sanitizedTable = catalogNameSanitizerRe.ReplaceAllString(strings.ToLower(table), "_")
+var LowercaseRecommendedNames = true
 
+func recommendedCatalogName(schema, table string) string {
+	if LowercaseRecommendedNames {
+		schema = strings.ToLower(schema)
+		table = strings.ToLower(table)
+	}
+	var sanitizedSchema = catalogNameSanitizerRe.ReplaceAllString(schema, "_")
+	var sanitizedTable = catalogNameSanitizerRe.ReplaceAllString(table, "_")
 	return sanitizedSchema + "/" + sanitizedTable
 }
 

--- a/sqlcapture/interface.go
+++ b/sqlcapture/interface.go
@@ -57,7 +57,7 @@ type SourceCommon struct {
 }
 
 // StreamID combines the Schema and Table properties using JoinStreamID()
-func (sc SourceCommon) StreamID() string {
+func (sc SourceCommon) StreamID() StreamID {
 	return JoinStreamID(sc.Schema, sc.Table)
 }
 
@@ -85,7 +85,7 @@ type FlushEvent struct {
 // MetadataEvent informs the generic sqlcapture logic about changes to
 // the per-table metadata JSON.
 type MetadataEvent struct {
-	StreamID string
+	StreamID StreamID
 	Metadata json.RawMessage
 }
 
@@ -148,7 +148,7 @@ type Database interface {
 	// Returns an empty instance of the source-specific metadata (used for JSON schema generation).
 	EmptySourceMetadata() SourceMetadata
 	// ShouldBackfill returns true if a given table's contents should be backfilled.
-	ShouldBackfill(streamID string) bool
+	ShouldBackfill(streamID StreamID) bool
 	// HistoryMode returns whether history mode (non-associative reduction of events) is enabled
 	HistoryMode() bool
 
@@ -187,7 +187,7 @@ type Database interface {
 // received for that table. It is permitted and necessary to activate some
 // tables before starting replication.
 type ReplicationStream interface {
-	ActivateTable(ctx context.Context, streamID string, keyColumns []string, info *DiscoveryInfo, metadata json.RawMessage) error
+	ActivateTable(ctx context.Context, streamID StreamID, keyColumns []string, info *DiscoveryInfo, metadata json.RawMessage) error
 	StartReplication(ctx context.Context, discovery map[StreamID]*DiscoveryInfo) error
 
 	// StreamToFence yields via the provided callback all change events between the

--- a/sqlcapture/main.go
+++ b/sqlcapture/main.go
@@ -81,7 +81,7 @@ func (r *Resource) SetDefaults() {}
 // Binding represents a capture binding.
 type Binding struct {
 	Index         uint32
-	StreamID      string
+	StreamID      StreamID
 	StateKey      boilerplate.StateKey
 	Resource      Resource
 	CollectionKey []string // JSON pointers
@@ -338,7 +338,7 @@ func (d *Driver) Pull(open *pc.Request_Open, stream *boilerplate.PullOutput) err
 	var errs = db.SetupPrerequisites(ctx)
 
 	// Build a mapping from stream IDs to capture binding information
-	var bindings = make(map[string]*Binding)
+	var bindings = make(map[StreamID]*Binding)
 	for idx, binding := range open.Capture.Bindings {
 		var res Resource
 		if err := pf.UnmarshalStrict(binding.ResourceConfigJson, &res); err != nil {

--- a/sqlcapture/tests/helpers.go
+++ b/sqlcapture/tests/helpers.go
@@ -16,6 +16,7 @@ import (
 	"github.com/bradleyjkemp/cupaloy"
 	st "github.com/estuary/connectors/source-boilerplate/testing"
 	"github.com/estuary/connectors/sqlcapture"
+	"github.com/estuary/flow/go/protocols/capture"
 	pf "github.com/estuary/flow/go/protocols/flow"
 	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
@@ -109,8 +110,13 @@ func DiscoverBindings(ctx context.Context, t testing.TB, tb TestBackend, streamM
 	}
 
 	// Translate discovery bindings into capture bindings.
+	return ConvertBindings(t, discovery)
+}
+
+func ConvertBindings(t testing.TB, discovered []*capture.Response_Discovered_Binding) []*pf.CaptureSpec_Binding {
+	t.Helper()
 	var bindings []*pf.CaptureSpec_Binding
-	for _, b := range discovery {
+	for _, b := range discovered {
 		var res sqlcapture.Resource
 		require.NoError(t, json.Unmarshal(b.ResourceConfigJson, &res))
 		var path = []string{res.Namespace, res.Stream}


### PR DESCRIPTION
**Description:**

This PR consists of:
- A fairly hefty refactoring which replaces the internal StreamID representation from a string to a struct type with separate schema and table name fields. This isn't strictly speaking necessary, but that refactoring is a good way of making sure that we are consistent in our usage of the IDs and have accounted for every edge case that might be impacted by changes to the StreamID representation.
- Removing the MySQL and SQL Server "tables whose names are identical but for capitalization are a fatal error and kill the entire capture" check. Even if we don't intend to fix case sensitivity everywhere else, this would probably be a good move because the check is probably more harmful than helpful since it's so over-broad.
- Adding a feature flag `case_sensitive_table_names` to `source-mysql` which has two very similar effects: it stops us from normalizing schema/table names to lowercase when constructing StreamID values, and similarly when computing the recommended collection name for a binding. It seems reasonable to tie those together, but I could see arguments that they ought to be separate flags.

**Workflow steps:**

In theory, nothing should change for any preexisting capture, since we're still normalizing everything to lowercase. When the `case_sensitive_table_names` feature flag is set on a MySQL capture it will actually be able to handle capturing from tables whose names are identical but for capitalization.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2800)
<!-- Reviewable:end -->
