### PR TITLE
estuary-cdk: dont block on `periodic_log`

### DIFF
--- a/estuary-cdk/estuary_cdk/capture/base_capture_connector.py
+++ b/estuary-cdk/estuary_cdk/capture/base_capture_connector.py
@@ -110,7 +110,7 @@ class BaseCaptureConnector(
 
                 task = Task(
                     log.getChild("capture"),
-                    ConnectorStatus(log, stopping, tg),
+                    ConnectorStatus(log, stopping),
                     "capture",
                     self.output,
                     stopping,

--- a/estuary-cdk/estuary_cdk/capture/connector_status.py
+++ b/estuary-cdk/estuary_cdk/capture/connector_status.py
@@ -1,5 +1,4 @@
 import asyncio
-from asyncio import TaskGroup
 from collections import defaultdict
 import typing
 
@@ -21,7 +20,7 @@ class ConnectorStatus:
     counts will be logged as connectorStatus's.
     """
 
-    def __init__(self, log: FlowLogger, stopping: StoppingType, tg: TaskGroup):
+    def __init__(self, log: FlowLogger, stopping: StoppingType):
         async def periodic_log():
             # Allow some initial setup time for bindings to be registered before
             # starting to poll for status changes every second.
@@ -30,7 +29,10 @@ class ConnectorStatus:
                 self._log_status()
                 await asyncio.sleep(1)
 
-        tg.create_task(periodic_log())
+        # Periodically log connector statuses.
+        # We don't do this within a TaskGroup because we don't
+        # want to block on it.
+        asyncio.create_task(periodic_log())
 
         self.log = log
         self.binding_count = 0


### PR DESCRIPTION
**Description:**

We've noticed imported Airbyte connectors using the `CaptureShim` have not been exiting after completing a sweep. This is likely due to the `periodic_log` coroutine being created in the top level `TaskGroup` and blocking on it. To avoid this, we're now kicking off `periodic_log` outside of the `TaskGroup`, like we do with `periodic_stop`.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2804)
<!-- Reviewable:end -->
