### PR TITLE
source-firestore: Validate minBackfillInterval settings

### DIFF
--- a/source-firestore/.snapshots/TestSpec
+++ b/source-firestore/.snapshots/TestSpec
@@ -30,10 +30,11 @@
             "title": "Skip Automatic Discovery",
             "description": "When set the connector will skip automatic collection discovery. This generally only makes sense when the \"Extra Collections\" setting is used."
           },
-          "min_backfill_interval": {
+          "minBackfillInterval": {
             "type": "string",
             "title": "Minimum Backfill Interval",
-            "description": "Controls how often a collection may be re-backfilled in the event of unrecoverable change stream failure. May be overridden by the per-resource setting."
+            "description": "Controls how often a collection may be re-backfilled in the event of unrecoverable change stream failure. May be overridden by the per-resource setting.",
+            "pattern": "^([0-9]+([.][0-9]+)?(h|m|s|ms))+$"
           }
         },
         "additionalProperties": false,
@@ -78,10 +79,11 @@
         "title": "Restart Cursor Path",
         "description": "Optionally specifies a JSON pointer to some document property which increases monotonically and can be used as a restart cursor to optimize backfill behavior when streaming consistency is lost. Generally this only matters for collections with very high write volumes."
       },
-      "min_backfill_interval": {
+      "minBackfillInterval": {
         "type": "string",
         "title": "Minimum Backfill Interval",
-        "description": "Controls how often a collection may be re-backfilled in the event of unrecoverable change stream failure. Overrides any other defaults for this particular resource."
+        "description": "Controls how often a collection may be re-backfilled in the event of unrecoverable change stream failure. Overrides any other defaults for this particular resource.",
+        "pattern": "^([0-9]+([.][0-9]+)?(h|m|s|ms))+$"
       }
     },
     "type": "object",

--- a/source-firestore/pull.go
+++ b/source-firestore/pull.go
@@ -260,10 +260,10 @@ func computeBackfillStartTime(cfg *config, res *resource, prevBackfill *backfill
 	// - Advanced Endpoint Config
 	// - Default to 24h if no cursor or 5m if there's a cursor
 	var delay time.Duration
-	if d, err := time.ParseDuration(res.MinBackfillInterval); err == nil && d > 0 {
-		delay = d
-	} else if d, err := time.ParseDuration(cfg.Advanced.MinBackfillInterval); err == nil && d > 0 {
-		delay = d
+	if res.MinBackfillInterval != "" {
+		delay, _ = time.ParseDuration(res.MinBackfillInterval) // Cannot fail, already validated
+	} else if cfg.Advanced.MinBackfillInterval != "" {
+		delay, _ = time.ParseDuration(cfg.Advanced.MinBackfillInterval) // Cannot fail, already validated
 	} else if hasRestartCursor {
 		delay = backfillRestartDelayWithRestartCursor
 	} else {


### PR DESCRIPTION
**Description:**

Renames `min_backfill_interval` to `minBackfillInterval` since we only have one capture using it at present and that's more consistent with other resource config settings (though sadly it's inconsistent with other advanced config properties -- there is no solution here that's consistent with everything because the state of these names is already an incoherent mess).

Adds validation logic so that non-empty settings on the capture or resource specs for the `minBackfillInterval` property are validated in the Validate() method as is appropriate.

Adds a validation regexp to the JSON schema so that users will be prevented from adding invalid settings in the UI even before it reaches the capture's validation logic.

**Workflow steps:**

It should be harder for users to end up with incorrect settings for this property. I'll go and fix the one capture that was previously using it.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2811)
<!-- Reviewable:end -->
