### PR TITLE
source-saleforce-native: misc fixes

### DIFF
--- a/source-salesforce-native/source_salesforce_native/bulk_job_manager.py
+++ b/source-salesforce-native/source_salesforce_native/bulk_job_manager.py
@@ -222,7 +222,11 @@ class BulkJobManager:
             case SoapTypes.BOOLEAN:
                 transformed_value = self._bool_str_to_bool(value)
             case SoapTypes.INTEGER | SoapTypes.LONG:
-                transformed_value = int(value)
+                # Salesforce's Bulk API returns "0.0" for integer fields when their value is 0.
+                if value == "0.0":
+                    transformed_value = 0
+                else:
+                    transformed_value = int(value)
             case SoapTypes.DOUBLE:
                 transformed_value = float(value)
             case SoapTypes.ANY_TYPE:

--- a/source-salesforce-native/source_salesforce_native/supported_standard_objects.py
+++ b/source-salesforce-native/source_salesforce_native/supported_standard_objects.py
@@ -1945,9 +1945,6 @@ SUPPORTED_STANDARD_OBJECTS: dict[str, ObjectDetails] = {
     "RecordAction": {
         "cursor_field": CursorFields.SYSTEM_MODSTAMP
     },
-    "RecordActionHistory": {
-        "cursor_field": CursorFields.SYSTEM_MODSTAMP
-    },
     "RecordType": {
         "cursor_field": CursorFields.SYSTEM_MODSTAMP
     },

--- a/source-salesforce-native/source_salesforce_native/supported_standard_objects.py
+++ b/source-salesforce-native/source_salesforce_native/supported_standard_objects.py
@@ -1016,9 +1016,6 @@ SUPPORTED_STANDARD_OBJECTS: dict[str, ObjectDetails] = {
     "EntitlementTemplate": {
         "cursor_field": CursorFields.SYSTEM_MODSTAMP
     },
-    "EntityDefinition": {
-        "cursor_field": CursorFields.LAST_MODIFIED_DATE
-    },
     "EntityMilestone": {
         "cursor_field": CursorFields.SYSTEM_MODSTAMP
     },


### PR DESCRIPTION
**Description:**

This PR addresses/avoids issues a new capture is hitting:
- `RecordActionHistory` can't be queried by any cursor fields, despite cursor fields being present in the object.
- `EntityDefinition` can't be queried without using a `LIMIT`.
- The Bulk API sometimes returns `"0.0"` for standard integer fields when the field's value is the integer `0`.

More details are in the individual commits.

No captures except the newest one have `RecordActionHistory` or `EntityDefinition` enabled. The single capture that _does_ have it enabled has all 800+ bindings enabled. I highly doubt they want these two specific bindings, and if it turns out that they do, we can prioritize figuring out how to capture them at that point.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2820)
<!-- Reviewable:end -->
