### PR TITLE
source-sqlserver-batch: Add SourcedSchema feature flag

### DIFF
--- a/source-sqlserver-batch/.snapshots/TestBinaryTypes-Capture
+++ b/source-sqlserver-batch/.snapshots/TestBinaryTypes-Capture
@@ -13,5 +13,5 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"binarytypes_537491":{"CursorNames":["id"],"CursorValues":[8],"LastPolled":"<TIMESTAMP>","DocumentCount":9}}}
+{"bindingStateV1":{"binarytypes_537491":{"CursorNames":["id"],"CursorValues":[8],"DocumentCount":9,"LastPolled":"<TIMESTAMP>"}}}
 

--- a/source-sqlserver-batch/.snapshots/TestDateAndTimeTypes-Capture
+++ b/source-sqlserver-batch/.snapshots/TestDateAndTimeTypes-Capture
@@ -14,5 +14,5 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"dateandtimetypes_307398":{"CursorNames":["id"],"CursorValues":[9],"LastPolled":"<TIMESTAMP>","DocumentCount":10}}}
+{"bindingStateV1":{"dateandtimetypes_307398":{"CursorNames":["id"],"CursorValues":[9],"DocumentCount":10,"LastPolled":"<TIMESTAMP>"}}}
 

--- a/source-sqlserver-batch/.snapshots/TestDatetimeLocation-Chicago
+++ b/source-sqlserver-batch/.snapshots/TestDatetimeLocation-Chicago
@@ -12,5 +12,5 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"datetimelocation_967996":{"CursorNames":null,"CursorValues":null,"LastPolled":"<TIMESTAMP>","DocumentCount":8}}}
+{"bindingStateV1":{"datetimelocation_967996":{"DocumentCount":8,"LastPolled":"<TIMESTAMP>"}}}
 

--- a/source-sqlserver-batch/.snapshots/TestDatetimeLocation-ExplicitNegativeOffset
+++ b/source-sqlserver-batch/.snapshots/TestDatetimeLocation-ExplicitNegativeOffset
@@ -12,5 +12,5 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"datetimelocation_967996":{"CursorNames":null,"CursorValues":null,"LastPolled":"<TIMESTAMP>","DocumentCount":8}}}
+{"bindingStateV1":{"datetimelocation_967996":{"DocumentCount":8,"LastPolled":"<TIMESTAMP>"}}}
 

--- a/source-sqlserver-batch/.snapshots/TestDatetimeLocation-ExplicitPositiveOffset
+++ b/source-sqlserver-batch/.snapshots/TestDatetimeLocation-ExplicitPositiveOffset
@@ -12,5 +12,5 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"datetimelocation_967996":{"CursorNames":null,"CursorValues":null,"LastPolled":"<TIMESTAMP>","DocumentCount":8}}}
+{"bindingStateV1":{"datetimelocation_967996":{"DocumentCount":8,"LastPolled":"<TIMESTAMP>"}}}
 

--- a/source-sqlserver-batch/.snapshots/TestDatetimeLocation-Tokyo
+++ b/source-sqlserver-batch/.snapshots/TestDatetimeLocation-Tokyo
@@ -12,5 +12,5 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"datetimelocation_967996":{"CursorNames":null,"CursorValues":null,"LastPolled":"<TIMESTAMP>","DocumentCount":8}}}
+{"bindingStateV1":{"datetimelocation_967996":{"DocumentCount":8,"LastPolled":"<TIMESTAMP>"}}}
 

--- a/source-sqlserver-batch/.snapshots/TestDatetimeLocation-UTC
+++ b/source-sqlserver-batch/.snapshots/TestDatetimeLocation-UTC
@@ -12,5 +12,5 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"datetimelocation_967996":{"CursorNames":null,"CursorValues":null,"LastPolled":"<TIMESTAMP>","DocumentCount":8}}}
+{"bindingStateV1":{"datetimelocation_967996":{"DocumentCount":8,"LastPolled":"<TIMESTAMP>"}}}
 

--- a/source-sqlserver-batch/.snapshots/TestFeatureFlagEmitSourcedSchemas-Default
+++ b/source-sqlserver-batch/.snapshots/TestFeatureFlagEmitSourcedSchemas-Default
@@ -1,0 +1,10 @@
+# ================================
+# Collection "acmeCo/test/featureflagemitsourcedschemas_960966": 2 Documents
+# ================================
+{"_meta":{"polled":"<TIMESTAMP>","index":0,"row_id":0},"data":"hello","id":1}
+{"_meta":{"polled":"<TIMESTAMP>","index":1,"row_id":1},"data":"world","id":2}
+# ================================
+# Final State Checkpoint
+# ================================
+{"bindingStateV1":{"featureflagemitsourcedschemas_960966":{"DocumentCount":2,"LastPolled":"<TIMESTAMP>"}}}
+

--- a/source-sqlserver-batch/.snapshots/TestFeatureFlagEmitSourcedSchemas-Disabled
+++ b/source-sqlserver-batch/.snapshots/TestFeatureFlagEmitSourcedSchemas-Disabled
@@ -1,0 +1,10 @@
+# ================================
+# Collection "acmeCo/test/featureflagemitsourcedschemas_960966": 2 Documents
+# ================================
+{"_meta":{"polled":"<TIMESTAMP>","index":0,"row_id":0},"data":"hello","id":1}
+{"_meta":{"polled":"<TIMESTAMP>","index":1,"row_id":1},"data":"world","id":2}
+# ================================
+# Final State Checkpoint
+# ================================
+{"bindingStateV1":{"featureflagemitsourcedschemas_960966":{"DocumentCount":2,"LastPolled":"<TIMESTAMP>"}}}
+

--- a/source-sqlserver-batch/.snapshots/TestFeatureFlagEmitSourcedSchemas-Enabled
+++ b/source-sqlserver-batch/.snapshots/TestFeatureFlagEmitSourcedSchemas-Enabled
@@ -1,0 +1,11 @@
+# ================================
+# Collection "acmeCo/test/featureflagemitsourcedschemas_960966": 3 Documents
+# ================================
+{"type":"object","required":["_meta","id"],"additionalProperties":false,"properties":{"_meta":{"$schema":"https://json-schema.org/draft/2020-12/schema","$id":"https://github.com/estuary/connectors/source-sqlserver-batch/document-metadata","properties":{"polled":{"type":"string","format":"date-time","title":"Polled Timestamp","description":"The time at which the update query which produced this document as executed."},"index":{"type":"integer","title":"Result Index","description":"The index of this document within the query execution which produced it."},"row_id":{"type":"integer","title":"Row ID","description":"Row ID of the Document"},"op":{"type":"string","enum":["c","u","d"],"title":"Change Operation","description":"Operation type (c: Create / u: Update / d: Delete)","default":"u"}},"additionalProperties":false,"type":"object","required":["polled","index","row_id"],"additionalProperties":false},"data":{"type":["string"]},"id":{"type":"integer"}},"x-infer-schema":true}
+{"_meta":{"polled":"<TIMESTAMP>","index":0,"row_id":0},"data":"hello","id":1}
+{"_meta":{"polled":"<TIMESTAMP>","index":1,"row_id":1},"data":"world","id":2}
+# ================================
+# Final State Checkpoint
+# ================================
+{"bindingStateV1":{"featureflagemitsourcedschemas_960966":{"DocumentCount":2,"LastPolled":"<TIMESTAMP>"}}}
+

--- a/source-sqlserver-batch/.snapshots/TestIntegerTypes-Capture
+++ b/source-sqlserver-batch/.snapshots/TestIntegerTypes-Capture
@@ -9,5 +9,5 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"integertypes_795898":{"CursorNames":["id"],"CursorValues":[4],"LastPolled":"<TIMESTAMP>","DocumentCount":5}}}
+{"bindingStateV1":{"integertypes_795898":{"CursorNames":["id"],"CursorValues":[4],"DocumentCount":5,"LastPolled":"<TIMESTAMP>"}}}
 

--- a/source-sqlserver-batch/.snapshots/TestNumericTypes-Capture
+++ b/source-sqlserver-batch/.snapshots/TestNumericTypes-Capture
@@ -10,5 +10,5 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"numerictypes_559424":{"CursorNames":["id"],"CursorValues":[5],"LastPolled":"<TIMESTAMP>","DocumentCount":6}}}
+{"bindingStateV1":{"numerictypes_559424":{"CursorNames":["id"],"CursorValues":[5],"DocumentCount":6,"LastPolled":"<TIMESTAMP>"}}}
 

--- a/source-sqlserver-batch/.snapshots/TestStringTypes-Capture
+++ b/source-sqlserver-batch/.snapshots/TestStringTypes-Capture
@@ -14,5 +14,5 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"stringtypes_339419":{"CursorNames":["id"],"CursorValues":[9],"LastPolled":"<TIMESTAMP>","DocumentCount":10}}}
+{"bindingStateV1":{"stringtypes_339419":{"CursorNames":["id"],"CursorValues":[9],"DocumentCount":10,"LastPolled":"<TIMESTAMP>"}}}
 

--- a/source-sqlserver-batch/.snapshots/TestUUIDType-Capture
+++ b/source-sqlserver-batch/.snapshots/TestUUIDType-Capture
@@ -15,5 +15,5 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"uuidtype_694251":{"CursorNames":["id"],"CursorValues":[10],"LastPolled":"<TIMESTAMP>","DocumentCount":11}}}
+{"bindingStateV1":{"uuidtype_694251":{"CursorNames":["id"],"CursorValues":[10],"DocumentCount":11,"LastPolled":"<TIMESTAMP>"}}}
 

--- a/source-sqlserver-batch/.snapshots/TestXMLType-Capture
+++ b/source-sqlserver-batch/.snapshots/TestXMLType-Capture
@@ -15,5 +15,5 @@
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"xmltype_831740":{"CursorNames":["id"],"CursorValues":[10],"LastPolled":"<TIMESTAMP>","DocumentCount":11}}}
+{"bindingStateV1":{"xmltype_831740":{"CursorNames":["id"],"CursorValues":[10],"DocumentCount":11,"LastPolled":"<TIMESTAMP>"}}}
 

--- a/source-sqlserver-batch/discovery.go
+++ b/source-sqlserver-batch/discovery.go
@@ -246,13 +246,17 @@ type discoveredColumn struct {
 	Table       string     // The name of the table with this column
 	Name        string     // The name of the column
 	Index       int        // The ordinal position of the column within a row
-	IsNullable  bool       // Whether the column can be null
 	DataType    columnType // The datatype of the column
 	Description *string    // The description of the column, if present and known
 }
 
 type columnType interface {
+	IsNullable() bool
 	JSONSchema() *jsonschema.Schema
+}
+
+func (ct *basicColumnType) IsNullable() bool {
+	return ct.nullable
 }
 
 type basicColumnType struct {
@@ -337,12 +341,11 @@ func discoverColumns(ctx context.Context, db *sql.DB, discoverSchemas []string) 
 		dataType.nullable = isNullable
 
 		var column = &discoveredColumn{
-			Schema:     tableSchema,
-			Table:      tableName,
-			Name:       columnName,
-			Index:      columnIndex,
-			IsNullable: isNullable,
-			DataType:   &dataType,
+			Schema:   tableSchema,
+			Table:    tableName,
+			Name:     columnName,
+			Index:    columnIndex,
+			DataType: &dataType,
 		}
 		columns = append(columns, column)
 	}

--- a/source-sqlserver-batch/discovery.go
+++ b/source-sqlserver-batch/discovery.go
@@ -167,11 +167,13 @@ func generateCollectionSchema(cfg *Config, table *discoveredTable, fullWriteSche
 
 	// If the table has a primary key then convert it to a collection key, otherwise
 	// recommend an appropriate fallback collection key.
-	var collectionKey = fallbackKey
+	var collectionKey []string
 	if keyColumns != nil {
 		for _, colName := range keyColumns {
 			collectionKey = append(collectionKey, primaryKeyToCollectionKey(colName))
 		}
+	} else {
+		collectionKey = fallbackKey
 	}
 	return json.RawMessage(bs), collectionKey, nil
 }

--- a/source-sqlserver-batch/driver.go
+++ b/source-sqlserver-batch/driver.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"slices"
 	"strings"
+	"sync"
 	"text/template"
 	"time"
 
@@ -46,6 +47,11 @@ const (
 	// Maximum number of concurrent polling operations to run at once. Might be
 	// worth making this configurable in the advanced endpoint settings.
 	maxConcurrentQueries = 1
+
+	// The minimum time between schema discovery operations. This avoids situations
+	// where we have a ton of bindings all coming due for polling around the same
+	// time and just keep running discovery over and over.
+	minDiscoveryInterval = 5 * time.Minute
 )
 
 var (
@@ -289,6 +295,11 @@ type capture struct {
 	Output    *boilerplate.PullOutput
 	Sempahore *semaphore.Weighted
 
+	shared struct {
+		sync.RWMutex
+		lastDiscoveryTime time.Time // The last time we ran schema discovery.
+	}
+
 	TranslateValue func(cfg *Config, val any, databaseTypeName string) (any, error)
 }
 
@@ -315,6 +326,11 @@ func (s *captureState) Validate() error {
 }
 
 func (c *capture) Run(ctx context.Context) error {
+	// Always discover and output SourcedSchemas once at startup.
+	if err := c.emitSourcedSchemas(ctx); err != nil {
+		return err
+	}
+
 	var eg, workerCtx = errgroup.WithContext(ctx)
 	for _, binding := range c.Bindings {
 		var binding = binding // Copy for goroutine closure
@@ -322,6 +338,43 @@ func (c *capture) Run(ctx context.Context) error {
 	}
 	if err := eg.Wait(); err != nil {
 		return fmt.Errorf("capture terminated with error: %w", err)
+	}
+	return nil
+}
+
+func (c *capture) emitSourcedSchemas(ctx context.Context) error {
+	if !c.Config.Advanced.parsedFeatureFlags["emit_sourced_schemas"] {
+		return nil
+	}
+
+	c.shared.Lock()
+	defer c.shared.Unlock()
+
+	// Skip re-running discovery and emitting schemas if we just did it.
+	if time.Since(c.shared.lastDiscoveryTime) < minDiscoveryInterval {
+		return nil
+	}
+	c.shared.lastDiscoveryTime = time.Now()
+
+	// Discover tables and emit SourcedSchema updates
+	var tableInfo, err = c.Driver.discoverTables(ctx, c.DB, c.Config)
+	if err != nil {
+		return fmt.Errorf("error discovering tables: %w", err)
+	}
+	for _, binding := range c.Bindings {
+		if binding.resource.SchemaName == "" || binding.resource.TableName == "" || binding.resource.Template != "" {
+			continue // Skip bindings with no schema/table or a custom query because we can't know what their schema will look like just from discovery info
+		}
+		var tableID = binding.resource.SchemaName + "." + binding.resource.TableName
+		var table, ok = tableInfo[tableID]
+		if !ok {
+			continue // Skip bindings for which we don't have any corresponding discovery information
+		}
+		if schema, _, err := generateCollectionSchema(c.Config, table, false); err != nil {
+			return fmt.Errorf("error generating schema for table %q: %w", tableID, err)
+		} else if err := c.Output.SourcedSchema(binding.index, schema); err != nil {
+			return fmt.Errorf("error emitting schema for table %q: %w", tableID, err)
+		}
 	}
 	return nil
 }
@@ -397,6 +450,11 @@ func (c *capture) worker(ctx context.Context, binding *bindingInfo) error {
 }
 
 func (c *capture) poll(ctx context.Context, binding *bindingInfo) error {
+	// Trigger rediscovery and output new SourcedSchemas before each polling operation.
+	if err := c.emitSourcedSchemas(ctx); err != nil {
+		return err
+	}
+
 	var res = binding.resource
 	var stateKey = binding.stateKey
 	var state, ok = c.State.Streams[stateKey]

--- a/source-sqlserver-batch/driver.go
+++ b/source-sqlserver-batch/driver.go
@@ -18,6 +18,7 @@ import (
 	pf "github.com/estuary/flow/go/protocols/flow"
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/sync/errgroup"
+	"golang.org/x/sync/semaphore"
 )
 
 const (
@@ -41,6 +42,10 @@ const (
 	// This timeout can be less generous, because after the first row is received we
 	// ought to be getting a consistent stream of results until the query completes.
 	pollingWatchdogTimeout = 15 * time.Minute
+
+	// Maximum number of concurrent polling operations to run at once. Might be
+	// worth making this configurable in the advanced endpoint settings.
+	maxConcurrentQueries = 1
 )
 
 var (
@@ -214,6 +219,7 @@ func (drv *BatchSQLDriver) Pull(open *pc.Request_Open, stream *boilerplate.PullO
 		Bindings:       bindings,
 		Output:         stream,
 		TranslateValue: drv.TranslateValue,
+		Sempahore:      semaphore.NewWeighted(maxConcurrentQueries),
 	}
 	return capture.Run(stream.Context())
 }
@@ -275,12 +281,14 @@ func updateResourceStates(prevState captureState, bindings []bindingInfo) (captu
 }
 
 type capture struct {
-	Driver         *BatchSQLDriver
-	Config         *Config
-	State          *captureState
-	DB             *sql.DB
-	Bindings       []bindingInfo
-	Output         *boilerplate.PullOutput
+	Driver    *BatchSQLDriver
+	Config    *Config
+	State     *captureState
+	DB        *sql.DB
+	Bindings  []bindingInfo
+	Output    *boilerplate.PullOutput
+	Sempahore *semaphore.Weighted
+
 	TranslateValue func(cfg *Config, val any, databaseTypeName string) (any, error)
 }
 
@@ -308,13 +316,7 @@ func (s *captureState) Validate() error {
 
 func (c *capture) Run(ctx context.Context) error {
 	var eg, workerCtx = errgroup.WithContext(ctx)
-	for idx, binding := range c.Bindings {
-		if idx > 0 {
-			// Slightly stagger worker thread startup. Five seconds should be long
-			// enough for most fast queries to complete their first execution, and
-			// the hope is this reduces peak load on both the database and us.
-			time.Sleep(5 * time.Second)
-		}
+	for _, binding := range c.Bindings {
 		var binding = binding // Copy for goroutine closure
 		eg.Go(func() error { return c.worker(workerCtx, &binding) })
 	}
@@ -326,18 +328,67 @@ func (c *capture) Run(ctx context.Context) error {
 
 func (c *capture) worker(ctx context.Context, binding *bindingInfo) error {
 	var res = binding.resource
+	var stateKey = binding.stateKey
+	var state, ok = c.State.Streams[stateKey]
+	if !ok {
+		return fmt.Errorf("internal error: no state for stream %q", res.Name)
+	}
+
+	// Polling schedule can be configured per binding. If unset, falls back to the connector default.
+	var pollScheduleStr = c.Config.Advanced.PollSchedule
+	if res.PollSchedule != "" {
+		pollScheduleStr = res.PollSchedule
+	}
+	var pollSchedule, err = schedule.Parse(pollScheduleStr)
+	if err != nil {
+		return fmt.Errorf("failed to parse polling schedule %q: %w", pollScheduleStr, err)
+	}
+
 	log.WithFields(log.Fields{
 		"name":   res.Name,
-		"schema": res.SchemaName,
-		"table":  res.TableName,
+		"tmpl":   res.Template,
 		"cursor": res.Cursor,
-		"poll":   res.PollSchedule,
+		"poll":   pollSchedule,
+		"last":   state.LastPolled.Format(time.RFC3339Nano),
 	}).Info("starting worker")
 
 	for ctx.Err() == nil {
-		if err := c.poll(ctx, binding); err != nil {
-			return fmt.Errorf("error polling binding %q: %w", res.Name, err)
+		time.Sleep(100 * time.Millisecond) // Short delay to make startup logs tidier
+
+		// Wait for next scheduled polling cycle.
+		if err := schedule.WaitForNext(ctx, pollSchedule, state.LastPolled); err != nil {
+			return err
 		}
+		var pollTime = time.Now().UTC()
+		log.WithFields(log.Fields{
+			"name": res.Name,
+			"poll": pollScheduleStr,
+			"prev": state.LastPolled.Format(time.RFC3339Nano),
+		}).Info("ready to poll")
+
+		time.Sleep(100 * time.Millisecond) // Short delay to make startup logs tidier
+
+		// Acquire semaphore and execute polling operation.
+		if err := c.Sempahore.Acquire(ctx, 1); err != nil {
+			return fmt.Errorf("error acquiring semaphore: %w", err)
+		}
+		if err := func() error {
+			// Ensure that the semaphore is released when we finish polling.
+			defer c.Sempahore.Release(1)
+			log.WithFields(log.Fields{"name": res.Name}).Info("polling binding")
+			if err := c.poll(ctx, binding); err != nil {
+				return fmt.Errorf("error polling binding %q: %w", res.Name, err)
+			}
+			return nil
+		}(); err != nil {
+			return err
+		}
+
+		state.LastPolled = pollTime
+		if err := c.streamStateCheckpoint(stateKey, state); err != nil {
+			return err
+		}
+
 		if TestShutdownAfterQuery {
 			return nil // In tests, we want each worker to shut down after one poll
 		}
@@ -365,29 +416,6 @@ func (c *capture) poll(ctx context.Context, binding *bindingInfo) error {
 	//   could either be a full refresh or the initial query of an incremental binding.
 	var isFullRefresh = len(cursorNames) == 0
 	var isInitialBackfill = len(cursorValues) == 0
-
-	// Polling schedule can be configured per binding. If unset, falls back to the
-	// connector global polling schedule.
-	var pollScheduleStr = c.Config.Advanced.PollSchedule
-	if res.PollSchedule != "" {
-		pollScheduleStr = res.PollSchedule
-	}
-	var pollSchedule, err = schedule.Parse(pollScheduleStr)
-	if err != nil {
-		return fmt.Errorf("failed to parse polling schedule %q: %w", pollScheduleStr, err)
-	}
-	log.WithFields(log.Fields{
-		"name": res.Name,
-		"poll": pollScheduleStr,
-		"prev": state.LastPolled.Format(time.RFC3339Nano),
-	}).Info("waiting for next scheduled poll")
-	if err := schedule.WaitForNext(ctx, pollSchedule, state.LastPolled); err != nil {
-		return err
-	}
-	log.WithFields(log.Fields{
-		"name": res.Name,
-		"poll": pollScheduleStr,
-	}).Info("ready to poll")
 
 	query, err := c.Driver.buildQuery(res, state)
 	if err != nil {

--- a/source-sqlserver-batch/main.go
+++ b/source-sqlserver-batch/main.go
@@ -24,7 +24,9 @@ import (
 )
 
 var featureFlagDefaults = map[string]bool{
-	// No feature flags for this connector (yet)
+	// When set, discovered collection schemas will be emitted as SourcedSchema messages
+	// so that Flow can have access to 'official' schema information from the source DB.
+	"emit_sourced_schemas": false,
 }
 
 // Config tells the connector how to connect to and interact with the source database.


### PR DESCRIPTION
**Description:**

As with https://github.com/estuary/connectors/pull/2798 and https://github.com/estuary/connectors/pull/2805, this PR modifies another batch SQL connector to:

1. Implement full column and type discovery. All columns of discovered tables will now be included in discovered (write) schemas with appropriate JSON schema types, rather than just primary-key columns with somewhat half-assed type translation.
2. Add the `emit_sourced_schema` feature flag, default off. When enabled, the capture will run discovery and output SourcedSchema updates immediately prior to polling a binding (subject to a minimum interval between rediscoveries, which is currently set to 5 minutes).

This is part of https://github.com/estuary/flow/issues/1919

**Workflow steps:**

All capture tasks will now autodiscover a more detailed write schema. In theory this could lead to failures of preexisting captures if the discovered schema generation doesn't actually match what we output for a specific column type, but such errors should be easy enough to fix as a fast-follow so long as I merge this at a time when I'm prepared to keep a close eye on things for the next few hours.

To start getting SourcedSchema updates, the user will need to set the emit_sourced_schemas feature flag. This will probably become the default at some point in the near future, either for new captures or across the board.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2821)
<!-- Reviewable:end -->
