### PR TITLE
source-kinesis: improve record parsing

### DIFF
--- a/source-kinesis/.snapshots/TestCaptureParsing
+++ b/source-kinesis/.snapshots/TestCaptureParsing
@@ -1,9 +1,9 @@
 # ================================
 # Collection "": 3 Documents
 # ================================
-{"_meta":{"partition_key":"anyPartitionKey","sequence_number":"<SEQUENCE_NUM>","source":{"shard":"shardId-000000000001","stream":"test-stream-parsing"}},"int1":-4974660706199429000,"int1AsStr":"-4974660706199429123","int2":9223372036854776000,"int2AsStr":"9223372036854775807"}
-{"_meta":{"source":{"userSourceField1":"clobbered"},"userMetaField1":"hello2","userMetaField2":"world2"},"other":"value"}
-{"_meta":{"userMetaField1":"hello1","userMetaField2":"world1"},"other":"value"}
+{"_meta":{"partition_key":"anyPartitionKey","sequence_number":"<SEQUENCE_NUM>","source":{"shard":"shardId-000000000001","stream":"test-stream-parsing"},"userMetaField1":"hello1","userMetaField2":"world1"},"other":"value"}
+{"_meta":{"partition_key":"anyPartitionKey","sequence_number":"<SEQUENCE_NUM>","source":{"shard":"shardId-000000000001","stream":"test-stream-parsing"},"userMetaField1":"hello2","userMetaField2":"world2"},"other":"value"}
+{"_meta":{"partition_key":"anyPartitionKey","sequence_number":"<SEQUENCE_NUM>","source":{"shard":"shardId-000000000001","stream":"test-stream-parsing"}},"int1":-4974660706199429123,"int1AsStr":"-4974660706199429123","int2":9223372036854775807,"int2AsStr":"9223372036854775807"}
 # ================================
 # Final State Checkpoint
 # ================================

--- a/source-kinesis/.snapshots/TestCaptureParsing
+++ b/source-kinesis/.snapshots/TestCaptureParsing
@@ -1,0 +1,11 @@
+# ================================
+# Collection "": 3 Documents
+# ================================
+{"_meta":{"partition_key":"anyPartitionKey","sequence_number":"<SEQUENCE_NUM>","source":{"shard":"shardId-000000000001","stream":"test-stream-parsing"}},"int1":-4974660706199429000,"int1AsStr":"-4974660706199429123","int2":9223372036854776000,"int2AsStr":"9223372036854775807"}
+{"_meta":{"source":{"userSourceField1":"clobbered"},"userMetaField1":"hello2","userMetaField2":"world2"},"other":"value"}
+{"_meta":{"userMetaField1":"hello1","userMetaField2":"world1"},"other":"value"}
+# ================================
+# Final State Checkpoint
+# ================================
+{"bindingStateV1":{"test-stream-parsing.v0":{"shardId-000000000001":"<SEQUENCE_NUM>"}}}
+


### PR DESCRIPTION
**Description:**

Use a skim parsing strategy for Kinesis JSON records, where only the top-level fields are parsed to allow for inserting our metadata into the document. This eliminates the unfortunate prior side-effect where large integer values were
being approximated due to their internal handing when parsed into a `map[string]any`. It should also be a little more performant, since we don't really care about anything beyond the top-level of fields.

Implementing this required thinking about what happens if the data from Kinesis already has a "_meta" property. We will do a shallow merge of the properties from an existing `_meta` object, giving preference to our own fields to avoid clobbering the required connector metadata.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2832)
<!-- Reviewable:end -->
