### PR TITLE
source-boilerplate: Ensure stdout buffer flush on exit

### DIFF
--- a/source-boilerplate/boilerplate.go
+++ b/source-boilerplate/boilerplate.go
@@ -73,7 +73,7 @@ func RunMain(connector Connector) {
 	log.WithField("eventType", "connectorStatus").Info("Initializing connector")
 
 	var ctx, _ = signal.NotifyContext(context.Background(), syscall.SIGTERM, syscall.SIGINT)
-	var stream pc.Connector_CaptureServer
+	var stream streamCodec
 
 	switch codec := getEnvDefault("FLOW_RUNTIME_CODEC", "proto"); codec {
 	case "proto":
@@ -95,7 +95,13 @@ func RunMain(connector Connector) {
 
 	var server = ConnectorServer{connector}
 
-	if err := server.Capture(stream); err != nil {
+	var err = server.Capture(stream)
+
+	// Ensure we flush any buffered output before exiting. Since we use os.Exit() to
+	// terminate the process we can't rely on a defer for this.
+	stream.Flush()
+
+	if err != nil {
 		cerrors.HandleFinalError(err)
 	}
 	os.Exit(0)
@@ -315,7 +321,14 @@ func (out *PullOutput) SourcedSchema(binding int, schema json.RawMessage) error 
 	return nil
 }
 
-func newProtoCodec(ctx context.Context) pc.Connector_CaptureServer {
+type streamCodec interface {
+	pc.Connector_CaptureServer
+
+	// Since we buffer writes internally, we need to guarantee that the buffer is flushed during shutdown.
+	Flush() error
+}
+
+func newProtoCodec(ctx context.Context) streamCodec {
 	var bw = bufio.NewWriterSize(os.Stdout, outputWriteBuffer)
 	return &protoCodec{
 		ctx: ctx,
@@ -330,6 +343,10 @@ type protoCodec struct {
 	r   *bufio.Reader
 	bw  *bufio.Writer
 	pw  protoio.Writer
+}
+
+func (c *protoCodec) Flush() error {
+	return c.bw.Flush()
 }
 
 func (c *protoCodec) Context() context.Context {
@@ -428,7 +445,7 @@ func (c *protoCodec) peekMessage(size int) ([]byte, error) {
 	return nil, fmt.Errorf("reading message (into buffer): %w", err)
 }
 
-func newJsonCodec(ctx context.Context) pc.Connector_CaptureServer {
+func newJsonCodec(ctx context.Context) streamCodec {
 	var bw = bufio.NewWriterSize(os.Stdout, outputWriteBuffer)
 	return &jsonCodec{
 		ctx: ctx,
@@ -454,6 +471,10 @@ type jsonCodec struct {
 	unmarshaler jsonpb.Unmarshaler
 	decoder     *json.Decoder
 	bw          *bufio.Writer
+}
+
+func (c *jsonCodec) Flush() error {
+	return c.bw.Flush()
 }
 
 func (c *jsonCodec) Context() context.Context {


### PR DESCRIPTION
**Description:**

We have a 1MiB buffer on writes to stdout, which is normally flushed after each non-document message. (The reason for that being that it improves throughput if we allow multiple docs in a transaction to be batched up into a single stdout write).

The problem arises if we output >1MiB worth of data in a single Flow transaction, and then the connector errors out before emitting a checkpoint. One way this might happen is if a fatal error occurs partway through a backfill chunk, where the total amount of data is >1MiB.

Since the buffer is 1MiB and we've already written >1MiB of data to it, it will have flushed to stdout at least once. But the buffer doesn't care about our message framing, so it will likely have split the final message in half. Which is fine in normal operation since we'll eventually write a checkpoint and flush the remaining transaction data, but when a fatal error occurs we never reach the checkpoint and flush, which means we just exit with a partial final message output.

This commit fixes that by ensuring we always flush the buffer on shutdown regardless of error status.

I don't believe there's an equivalent fix to be made in the materialization boilerplate because the output writer there is unbuffered.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2833)
<!-- Reviewable:end -->
