### PR TITLE
source-http-ingest: set resource paths in discover response

### DIFF
--- a/source-http-ingest/src/lib.rs
+++ b/source-http-ingest/src/lib.rs
@@ -465,7 +465,7 @@ fn discovered_webhook_collection(path: Option<&str>) -> DiscoveredBinding {
         }))
         .unwrap(),
         key: vec!["/_meta/webhookId".to_string()],
-        resource_path: Vec::new(), // deprecated field
+        resource_path: resource_config.resource_path(),
     }
 }
 

--- a/source-http-ingest/src/snapshots/source_http_ingest__test__discover_backwards_compatibility.snap
+++ b/source-http-ingest/src/snapshots/source_http_ingest__test__discover_backwards_compatibility.snap
@@ -14,6 +14,9 @@ expression: result
       },
       "key": [
         "/_meta/webhookId"
+      ],
+      "resourcePath": [
+        "webhook-data"
       ]
     }
   ]

--- a/source-http-ingest/src/snapshots/source_http_ingest__test__discover_with_paths.snap
+++ b/source-http-ingest/src/snapshots/source_http_ingest__test__discover_with_paths.snap
@@ -14,6 +14,9 @@ expression: result
       },
       "key": [
         "/_meta/webhookId"
+      ],
+      "resourcePath": [
+        "/foo"
       ]
     },
     {
@@ -26,6 +29,9 @@ expression: result
       },
       "key": [
         "/_meta/webhookId"
+      ],
+      "resourcePath": [
+        "/bar/baz"
       ]
     }
   ]

--- a/source-http-ingest/tests/snapshots/test__discover.snap
+++ b/source-http-ingest/tests/snapshots/test__discover.snap
@@ -59,7 +59,10 @@ expression: result
           "idFromHeader": null,
           "path": "/webhook-data",
           "stream": "/webhook-data"
-        }
+        },
+        "resourcePath": [
+          "/webhook-data"
+        ]
       },
       {
         "documentSchema": {
@@ -128,7 +131,10 @@ expression: result
           "idFromHeader": null,
           "path": "/path/a/{paramA}/b/{paramB}",
           "stream": "/path/a/{paramA}/b/{paramB}"
-        }
+        },
+        "resourcePath": [
+          "/path/a/{paramA}/b/{paramB}"
+        ]
       }
     ]
   }


### PR DESCRIPTION
Populates the resource path in discover responses, which is once again required.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2837)
<!-- Reviewable:end -->
