### PR TITLE
source-chargebee-native: update document cursor value check against current log cursor

### DIFF
--- a/source-chargebee-native/source_chargebee_native/api.py
+++ b/source-chargebee-native/source_chargebee_native/api.py
@@ -230,7 +230,10 @@ async def fetch_resource_changes(
         has_results = True
 
         for doc in resource_data:
-            if doc.cursor_value > log_cursor:
+            if doc.cursor_value < log_cursor or doc.cursor_value > end_date.timestamp():
+                log.debug(
+                    f"Skipping document with cursor value {doc.cursor_value}. It falls outside the range of {log_cursor} and {end_date.timestamp()}."
+                )
                 continue
 
             max_updated_at = max(max_updated_at, _ts_to_dt(doc.cursor_value))
@@ -419,7 +422,13 @@ async def fetch_associated_resource_changes(
             has_results = True
 
             for doc in child_data:
-                if doc.cursor_value > log_cursor:
+                if (
+                    doc.cursor_value < log_cursor
+                    or doc.cursor_value > end_date.timestamp()
+                ):
+                    log.debug(
+                        f"Skipping child document with cursor value {doc.cursor_value}. It falls outside the range of {log_cursor} and {end_date.timestamp()}."
+                    )
                     continue
 
                 max_updated_at = max(max_updated_at, _ts_to_dt(doc.cursor_value))


### PR DESCRIPTION
**Description:**

The prior way of checking and continuing would ignore most, if not all, documents that we receive in a batch because the check was incorrect. This updates the check to ensure the documents are within the time window, logs a debug message, and continues if this happens.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2839)
<!-- Reviewable:end -->
