### PR TITLE
source-mysql-batch: Remove format:date for now

### DIFF
--- a/source-mysql-batch/.snapshots/TestDateAndTimeTypes-Discovery
+++ b/source-mysql-batch/.snapshots/TestDateAndTimeTypes-Discovery
@@ -60,7 +60,6 @@ Binding 0:
             ]
           },
           "date_col": {
-            "format": "date",
             "description": "(source type: date)",
             "type": [
               "string",

--- a/source-mysql-batch/discovery.go
+++ b/source-mysql-batch/discovery.go
@@ -428,7 +428,7 @@ var databaseTypeToJSON = map[string]basicColumnType{
 	"enum": {jsonTypes: []string{"string"}},
 	"set":  {jsonTypes: []string{"string"}},
 
-	"date": {jsonTypes: []string{"string"}, format: "date"},
+	"date": {jsonTypes: []string{"string"}}, // Not valid for format: date until we sanitize values like '0000-00-00' to valid RFC3339 dates
 
 	"datetime":  {jsonTypes: []string{"string"}},
 	"timestamp": {jsonTypes: []string{"string"}},


### PR DESCRIPTION
**Description:**

Looks like I did indeed miss an edge case when implementing the new more detailed type discovery. The goal of the newly detailed discovery types was/is purely to describe the current connector outputs and not to change those at the same time, so the correct solution is to remove the `format: date` on these strings for now.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2840)
<!-- Reviewable:end -->
