### PR TITLE
source-outreach: remove `access_token` and `expires_in` from `accessTokenResponseMap`

### DIFF
--- a/source-outreach/source_outreach/models.py
+++ b/source-outreach/source_outreach/models.py
@@ -104,9 +104,7 @@ OAUTH2_SPEC = OAuth2Spec(
     ),
     accessTokenUrlTemplate="https://api.outreach.io/oauth/token",
     accessTokenResponseMap={
-        "access_token": "/access_token",
         "refresh_token": "/refresh_token",
-        "expires_in": "/expires_in",
     },
     accessTokenHeaders={
         "Content-Type": "application/json",

--- a/source-outreach/tests/snapshots/snapshots__spec__capture.stdout.json
+++ b/source-outreach/tests/snapshots/snapshots__spec__capture.stdout.json
@@ -111,8 +111,6 @@
         "Content-Type": "application/json"
       },
       "accessTokenResponseMap": {
-        "access_token": "/access_token",
-        "expires_in": "/expires_in",
         "refresh_token": "/refresh_token"
       }
     },


### PR DESCRIPTION
**Description:**

Including `access_token` and `expires_in` in the OAuth2 spec's `accessTokenResponseMap` ended up including them in the endpoint config's credentials. This was not intended; we only want the refresh token in the config, and the other access token response fields shouldn't persist across connector invocations.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

Confirmed that removing `access_token` and `expires_in` from the `accessTokenResponseMap` in this connector's row in the `connectors` table caused the same named fields to not be included in the endpoint config.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2841)
<!-- Reviewable:end -->
