### PR TITLE
source-postgres: Emit non-null values in keyOnly tuples

### DIFF
--- a/source-postgres/replication.go
+++ b/source-postgres/replication.go
@@ -830,10 +830,9 @@ func (s *replicationStream) decodeTuple(
 
 	var fields = make(map[string]interface{})
 	for idx, col := range tuple.Columns {
-		if keyOnly && (rel.Columns[idx].Flags&1) == 0 {
-			// Skip non-key column because it may not be null-able,
-			// but will be null in this tuple encoding.
-			// Better to not emit it at all.
+		if keyOnly && (rel.Columns[idx].Flags&1) == 0 && col.DataType == 'n' {
+			// Skip null values of non-key columns in a key-only tuple because
+			// they aren't really null in the database.
 			continue
 		}
 		var colName = rel.Columns[idx].Name


### PR DESCRIPTION
**Description:**

In theory we're not supposed to get non-null values when the tuple type is 'K' and the flags column indicates that it's not a key column.

In practice, we're seeing a table with a normal primary-key replica identity and appropriately non-null values for those columns, but where every column is reported as non-key in the relation message. This is clearly a bug (possibly introduce by Amazon RDS customizations), but since it can happen in the real world it's something we have to deal with.

It seems reasonable that if we get a non-null value for a column we should capture it, and this edge case shouldn't ever happen _unless_ there's a bug in the "is this a key?" bitflag, so this is a pretty minimal fix for the issue.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2844)
<!-- Reviewable:end -->
