### PR TITLE
source-oracle: debug information for empty undoSQL

### DIFF
--- a/source-oracle/decode.go
+++ b/source-oracle/decode.go
@@ -159,11 +159,11 @@ func (s *replicationStream) decodeMessage(msg logminerMessage) (sqlcapture.Datab
 	}
 	ast, err := parser.Parse(msg.SQL)
 	if err != nil {
-		return nil, fmt.Errorf("parsing sql query %q: %w", msg.SQL, err)
+		return nil, fmt.Errorf("parsing sql query %v: %w", msg, err)
 	}
 	undoAST, err := parser.Parse(msg.UndoSQL)
 	if err != nil {
-		return nil, fmt.Errorf("parsing undo sql query %q: %w", msg.UndoSQL, err)
+		return nil, fmt.Errorf("parsing undo sql query %v: %w", msg, err)
 	}
 	var after, before map[string]any
 


### PR DESCRIPTION
**Description:**

- Recently a task hit this error:
```
failed to poll messages: receive messages: handle transaction boundaries: decode message: parsing undo sql query "": Code: INVALID_ARGUMENT
Query was empty
```

I'm not sure how this could happen, so adding more complete logging so I can see what the full message is so I can troubleshoot this

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

