### PR TITLE
source-oracle-batch: Set `emit_sourced_schemas` by default

### DIFF
--- a/source-oracle-batch/.snapshots/TestBasicDatatypes-Capture
+++ b/source-oracle-batch/.snapshots/TestBasicDatatypes-Capture
@@ -1,6 +1,7 @@
 # ================================
-# Collection "acmeCo/test/c__flow_test_batch_basic_datatypes_13111208": 1 Documents
+# Collection "acmeCo/test/c__flow_test_batch_basic_datatypes_13111208": 2 Documents
 # ================================
+{"type":"object","required":["_meta","ID"],"additionalProperties":false,"properties":{"A_BOOL":{"description":"(source type: non-nullable NUMBER)","type":["integer"]},"A_DATE":{"description":"(source type: non-nullable DATE)","type":["string"]},"A_INT":{"format":"integer","description":"(source type: non-nullable NUMBER)","type":["string"]},"A_TS":{"description":"(source type: non-nullable TIMESTAMP(6))","type":["string"]},"A_TSTZ":{"format":"date-time","description":"(source type: non-nullable TIMESTAMP(6) WITH TIME ZONE)","type":["string"]},"ID":{"type":"string","format":"integer","description":"(source type: NUMBER)"},"_meta":{"$schema":"https://json-schema.org/draft/2020-12/schema","$id":"https://github.com/estuary/connectors/source-oracle-batch/document-metadata","properties":{"polled":{"type":"string","format":"date-time","title":"Polled Timestamp","description":"The time at which the update query which produced this document as executed."},"index":{"type":"integer","title":"Result Index","description":"The index of this document within the query execution which produced it."}},"additionalProperties":false,"type":"object","required":["polled","index"],"additionalProperties":false}},"x-infer-schema":true}
 {"A_BOOL":"1","A_DATE":"2024-02-26T00:00:00Z","A_INT":"-12","A_TS":"2024-02-26T12:34:56Z","A_TSTZ":"2024-02-26T12:34:56Z","ID":"100","TXID":"999999","_meta":{"polled":"<TIMESTAMP>","index":999}}
 # ================================
 # Final State Checkpoint

--- a/source-oracle-batch/.snapshots/TestDecimals
+++ b/source-oracle-batch/.snapshots/TestDecimals
@@ -1,6 +1,7 @@
 # ================================
-# Collection "acmeCo/test/c__flow_test_batch_decimals_75319739": 2 Documents
+# Collection "acmeCo/test/c__flow_test_batch_decimals_75319739": 3 Documents
 # ================================
+{"type":"object","required":["_meta","ID"],"additionalProperties":false,"properties":{"ID":{"type":"string","format":"integer","description":"(source type: NUMBER)"},"X":{"description":"(source type: non-nullable NUMBER)","type":["number"]},"Y":{"format":"number","description":"(source type: non-nullable NUMBER)","type":["string"]},"_meta":{"$schema":"https://json-schema.org/draft/2020-12/schema","$id":"https://github.com/estuary/connectors/source-oracle-batch/document-metadata","properties":{"polled":{"type":"string","format":"date-time","title":"Polled Timestamp","description":"The time at which the update query which produced this document as executed."},"index":{"type":"integer","title":"Result Index","description":"The index of this document within the query execution which produced it."}},"additionalProperties":false,"type":"object","required":["polled","index"],"additionalProperties":false}},"x-infer-schema":true}
 {"ID":"1","TXID":"999999","X":"98.7654","Y":"123456789101112.123456789101112","_meta":{"polled":"<TIMESTAMP>","index":999}}
 {"ID":"0","TXID":"999999","X":"12.3456","Y":"1234567890","_meta":{"polled":"<TIMESTAMP>","index":999}}
 # ================================

--- a/source-oracle-batch/.snapshots/TestFeatureFlagEmitSourcedSchemas-Default
+++ b/source-oracle-batch/.snapshots/TestFeatureFlagEmitSourcedSchemas-Default
@@ -1,6 +1,7 @@
 # ================================
-# Collection "acmeCo/test/c__flow_test_batch_featureflagemitsourcedschemas_960966": 2 Documents
+# Collection "acmeCo/test/c__flow_test_batch_featureflagemitsourcedschemas_960966": 3 Documents
 # ================================
+{"type":"object","required":["_meta","ID"],"additionalProperties":false,"properties":{"DATA":{"description":"(source type: non-nullable VARCHAR2)","type":["string"]},"ID":{"type":"string","format":"integer","description":"(source type: NUMBER)"},"_meta":{"$schema":"https://json-schema.org/draft/2020-12/schema","$id":"https://github.com/estuary/connectors/source-oracle-batch/document-metadata","properties":{"polled":{"type":"string","format":"date-time","title":"Polled Timestamp","description":"The time at which the update query which produced this document as executed."},"index":{"type":"integer","title":"Result Index","description":"The index of this document within the query execution which produced it."}},"additionalProperties":false,"type":"object","required":["polled","index"],"additionalProperties":false}},"x-infer-schema":true}
 {"DATA":"world","ID":"2","TXID":"999999","_meta":{"polled":"<TIMESTAMP>","index":999}}
 {"DATA":"hello","ID":"1","TXID":"999999","_meta":{"polled":"<TIMESTAMP>","index":999}}
 # ================================

--- a/source-oracle-batch/.snapshots/TestFloatNaNs-Capture
+++ b/source-oracle-batch/.snapshots/TestFloatNaNs-Capture
@@ -1,6 +1,7 @@
 # ================================
-# Collection "acmeCo/test/c__flow_test_batch_float_nans_10511": 3 Documents
+# Collection "acmeCo/test/c__flow_test_batch_float_nans_10511": 4 Documents
 # ================================
+{"type":"object","required":["_meta","ID"],"additionalProperties":false,"properties":{"A_DOUBLE":{"description":"using catch-all schema (source type: non-nullable BINARY_DOUBLE)"},"A_FLOAT":{"description":"using catch-all schema (source type: non-nullable BINARY_FLOAT)"},"ID":{"type":"string","format":"integer","description":"(source type: NUMBER)"},"_meta":{"$schema":"https://json-schema.org/draft/2020-12/schema","$id":"https://github.com/estuary/connectors/source-oracle-batch/document-metadata","properties":{"polled":{"type":"string","format":"date-time","title":"Polled Timestamp","description":"The time at which the update query which produced this document as executed."},"index":{"type":"integer","title":"Result Index","description":"The index of this document within the query execution which produced it."}},"additionalProperties":false,"type":"object","required":["polled","index"],"additionalProperties":false}},"x-infer-schema":true}
 {"A_DOUBLE":2,"A_FLOAT":"NaN","ID":"0","TXID":"999999","_meta":{"polled":"<TIMESTAMP>","index":999}}
 {"A_DOUBLE":"Infinity","A_FLOAT":"-Infinity","ID":"2","TXID":"999999","_meta":{"polled":"<TIMESTAMP>","index":999}}
 {"A_DOUBLE":"NaN","A_FLOAT":3,"ID":"1","TXID":"999999","_meta":{"polled":"<TIMESTAMP>","index":999}}

--- a/source-oracle-batch/main.go
+++ b/source-oracle-batch/main.go
@@ -23,7 +23,7 @@ import (
 var featureFlagDefaults = map[string]bool{
 	// When set, discovered collection schemas will be emitted as SourcedSchema messages
 	// so that Flow can have access to 'official' schema information from the source DB.
-	"emit_sourced_schemas": false,
+	"emit_sourced_schemas": true,
 }
 
 // Config tells the connector how to connect to and interact with the source database.

--- a/source-oracle-batch/main_test.go
+++ b/source-oracle-batch/main_test.go
@@ -52,6 +52,10 @@ func TestBasicCapture(t *testing.T) {
 	var uniqueID = "826935"
 	var tableName = fmt.Sprintf("c##flow_test_batch.basic_capture_%s", uniqueID)
 
+	// Ignore SourcedSchema updates as their precise position in the change stream is
+	// unpredictable when we're restarting the capture in parallel with changes.
+	cs.Validator = &st.OrderedCaptureValidator{IncludeSourcedSchemas: false}
+
 	executeControlQuery(ctx, t, control, fmt.Sprintf("DROP TABLE %s", tableName))
 	t.Cleanup(func() { executeControlQuery(ctx, t, control, fmt.Sprintf("DROP TABLE %s", tableName)) })
 	executeControlQuery(ctx, t, control, fmt.Sprintf("CREATE TABLE %s(id INTEGER PRIMARY KEY, data VARCHAR(200)) ROWDEPENDENCIES", tableName))


### PR DESCRIPTION
**Description:**

Feature flag default change, to be merged after setting `no_emit_sourced_schemas` on preexisting captures.

Part of https://github.com/estuary/flow/issues/1919

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2856)
<!-- Reviewable:end -->
