### PR TITLE
materialize-snowflake: quote schema names when listing tables

### DIFF
--- a/materialize-snowflake/client.go
+++ b/materialize-snowflake/client.go
@@ -87,9 +87,9 @@ func (c *client) InfoSchema(ctx context.Context, resourcePaths [][]string) (*boi
 		relevantExistingSchemasAndTables[loc.TableSchema] = []string{}
 		tables, err := runShowPaginated(ctx, c.xdb, func(cursor *string) string {
 			if cursor != nil {
-				return fmt.Sprintf("SHOW TERSE TABLES IN %s LIMIT %d FROM '%s';", loc.TableSchema, showQueryLimit, *cursor)
+				return fmt.Sprintf("SHOW TERSE TABLES IN %q LIMIT %d FROM '%s';", loc.TableSchema, showQueryLimit, *cursor)
 			} else {
-				return fmt.Sprintf("SHOW TERSE TABLES IN %s LIMIT %d;", loc.TableSchema, showQueryLimit)
+				return fmt.Sprintf("SHOW TERSE TABLES IN %q LIMIT %d;", loc.TableSchema, showQueryLimit)
 			}
 		})
 		if err != nil {


### PR DESCRIPTION
**Description:**

Schema names need to be quoted if they contain special characters in SHOW TABLES IN <schema> queries.

In general there is no reason to not simply quote them all the time, which is what this commit does for these SHOW queries.

Tested manually by running Validate with schema names containing hyphens. Previously these would not work and result in a syntax error, but now they will work.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

