### PR TITLE
materialization-specific serialization policies

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,7 @@ require (
 	github.com/databricks/databricks-sql-go v1.6.2-0.20250318155202-2a39cfaf0c27
 	github.com/dropbox/dropbox-sdk-go-unofficial/v6 v6.0.5
 	github.com/elastic/go-elasticsearch/v8 v8.9.0
-	github.com/estuary/flow v0.5.12-0.20250318185640-35c8aab61898
+	github.com/estuary/flow v0.5.13
 	github.com/estuary/vitess v0.15.10
 	github.com/evanphx/json-patch/v5 v5.9.0
 	github.com/firebolt-db/firebolt-go-sdk v1.2.0
@@ -70,7 +70,7 @@ require (
 	github.com/wk8/go-ordered-map/v2 v2.1.8
 	github.com/xitongsys/parquet-go v1.6.2
 	github.com/xitongsys/parquet-go-source v0.0.0-20220527110425-ba4adb87a31b
-	go.gazette.dev/core v0.100.1-0.20250302181532-7ffcbe33bb2d
+	go.gazette.dev/core v0.100.1-0.20250509034818-0bfec5851754
 	go.mongodb.org/mongo-driver v1.16.1
 	golang.org/x/crypto v0.37.0
 	golang.org/x/exp v0.0.0-20250305212735-054e65f0b394

--- a/go.sum
+++ b/go.sum
@@ -390,8 +390,8 @@ github.com/envoyproxy/go-control-plane/ratelimit v0.1.0/go.mod h1:Wk+tMFAFbCXaJP
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/envoyproxy/protoc-gen-validate v1.2.1 h1:DEo3O99U8j4hBFwbJfrz9VtgcDfUKS7KJ7spH3d86P8=
 github.com/envoyproxy/protoc-gen-validate v1.2.1/go.mod h1:d/C80l/jxXLdfEIhX1W2TmLfsJ31lvEjwamM4DxlWXU=
-github.com/estuary/flow v0.5.12-0.20250318185640-35c8aab61898 h1:BH8YvZzwk7kxp0vE+L8KiIQ9NHu23nBDve1VbevI4dw=
-github.com/estuary/flow v0.5.12-0.20250318185640-35c8aab61898/go.mod h1:+iUAI9gBvAe2woer9yhEsMFda/b4U6QA1a/36TFZ40w=
+github.com/estuary/flow v0.5.13 h1:O1UVJn0AnAUgXwyK2JR0eGTlbbo44vvwiCTLQzAG1TQ=
+github.com/estuary/flow v0.5.13/go.mod h1:JScLFw4Y8hTvxTsmKgfi7mKvmfcsb38YbU4ZDtRM8DY=
 github.com/estuary/vitess v0.15.10 h1:oXJgcG0HGZWuwjdvSp4pIFIAXtKLaR9Fl9VBynSszFA=
 github.com/estuary/vitess v0.15.10/go.mod h1:rSIE8UMfexjblBloleGw6BqQIKggGmU91TduCNIaJEA=
 github.com/evanphx/json-patch/v5 v5.9.0 h1:kcBlZQbplgElYIlo/n1hJbls2z/1awpXxpRi0/FOJfg=
@@ -1034,8 +1034,8 @@ go.etcd.io/etcd/client/pkg/v3 v3.5.17 h1:XxnDXAWq2pnxqx76ljWwiQ9jylbpC4rvkAeRVOU
 go.etcd.io/etcd/client/pkg/v3 v3.5.17/go.mod h1:4DqK1TKacp/86nJk4FLQqo6Mn2vvQFBmruW3pP14H/w=
 go.etcd.io/etcd/client/v3 v3.5.17 h1:o48sINNeWz5+pjy/Z0+HKpj/xSnBkuVhVvXkjEXbqZY=
 go.etcd.io/etcd/client/v3 v3.5.17/go.mod h1:j2d4eXTHWkT2ClBgnnEPm/Wuu7jsqku41v9DZ3OtjQo=
-go.gazette.dev/core v0.100.1-0.20250302181532-7ffcbe33bb2d h1:5wp/gegowMRCuFXBH2uvvTfnj+0Fsj8LqNhwo63SmN0=
-go.gazette.dev/core v0.100.1-0.20250302181532-7ffcbe33bb2d/go.mod h1:sMIAhwRUE9i9kk1tUrifv/tDDEC3dqx3GtvAiaBeHu4=
+go.gazette.dev/core v0.100.1-0.20250509034818-0bfec5851754 h1:Lza9QSUrQtnaTldL0WEjkdT2uZfUgK3H8cCIS/eRfTM=
+go.gazette.dev/core v0.100.1-0.20250509034818-0bfec5851754/go.mod h1:WK/NPg8XSABEwrtlxcFx2t/jZYETIKjW0hywktRA5Z0=
 go.mongodb.org/mongo-driver v1.16.1 h1:rIVLL3q0IHM39dvE+z2ulZLp9ENZKThVfuvN/IiN4l8=
 go.mongodb.org/mongo-driver v1.16.1/go.mod h1:oB6AhJQvFQL4LEHyXi6aJzQJtBiTQHiAd83l0GdFaiw=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=

--- a/materialize-boilerplate/ser_policy.go
+++ b/materialize-boilerplate/ser_policy.go
@@ -1,0 +1,22 @@
+package boilerplate
+
+import pf "github.com/estuary/flow/go/protocols/flow"
+
+var (
+	// SerPolicyStd is a general, conservative serialization policy that has
+	// been used by materializations historically that have limitations on how
+	// long their materialized fields can be.
+	SerPolicyStd = &pf.SerPolicy{
+		StrTruncateAfter:       1 << 16, // 64 KiB
+		NestedObjTruncateAfter: 1000,
+		ArrayTruncateAfter:     1000,
+	}
+
+	// SerPolicyDisabled is a serialization policy that completely disables
+	// truncation of strings, nested objects, and arrays.
+	SerPolicyDisabled = &pf.SerPolicy{
+		StrTruncateAfter:       0,
+		NestedObjTruncateAfter: 0,
+		ArrayTruncateAfter:     0,
+	}
+)

--- a/materialize-snowflake/.snapshots/TestSpecification
+++ b/materialize-snowflake/.snapshots/TestSpecification
@@ -224,6 +224,11 @@
       },
       "advanced": {
         "properties": {
+          "disableFieldTruncation": {
+            "type": "boolean",
+            "title": "Disable Field Truncation",
+            "description": "Disables truncation of materialized fields. May result in errors when loading data into Snowflake for documents with extremely large values or complex nested structures."
+          },
           "feature_flags": {
             "type": "string",
             "title": "Feature Flags",

--- a/materialize-snowflake/config.go
+++ b/materialize-snowflake/config.go
@@ -39,7 +39,8 @@ type config struct {
 }
 
 type advancedConfig struct {
-	FeatureFlags string `json:"feature_flags,omitempty" jsonschema:"title=Feature Flags,description=This property is intended for Estuary internal use. You should only modify this field as directed by Estuary support."`
+	DisableFieldTruncation bool   `json:"disableFieldTruncation,omitempty" jsonschema:"title=Disable Field Truncation,description=Disables truncation of materialized fields. May result in errors when loading data into Snowflake for documents with extremely large values or complex nested structures."`
+	FeatureFlags           string `json:"feature_flags,omitempty" jsonschema:"title=Feature Flags,description=This property is intended for Estuary internal use. You should only modify this field as directed by Estuary support."`
 }
 
 // toURI manually builds the DSN connection string.

--- a/materialize-snowflake/snowflake.go
+++ b/materialize-snowflake/snowflake.go
@@ -124,12 +124,15 @@ func newSnowflakeDriver() *sql.Driver {
 			var dialect = snowflakeDialect(parsed.Schema, timestampTypeMapping)
 			var templates = renderTemplates(dialect)
 
+			serPolicy := boilerplate.SerPolicyStd
+			if parsed.Advanced.DisableFieldTruncation {
+				serPolicy = boilerplate.SerPolicyDisabled
+			}
+
 			return &sql.Endpoint{
-				Config:  parsed,
-				Dialect: dialect,
-				// Snowflake does not use the checkpoint table, instead we use the recovery log
-				// as the authoritative checkpoint and idempotent apply pattern
-				MetaCheckpoints:     nil,
+				Config:              parsed,
+				Dialect:             dialect,
+				SerPolicy:           serPolicy,
 				NewClient:           newClient,
 				CreateTableTemplate: templates.createTargetTable,
 				NewResource:         newTableConfig,

--- a/materialize-sql/driver.go
+++ b/materialize-sql/driver.go
@@ -149,6 +149,7 @@ func (d *Driver) Validate(ctx context.Context, req *pm.Request_Validate) (*pm.Re
 				Constraints:  constraints,
 				DeltaUpdates: res.DeltaUpdates(),
 				ResourcePath: res.Path(),
+				SerPolicy:    endpoint.SerPolicy,
 			})
 	}
 

--- a/materialize-sql/endpoint.go
+++ b/materialize-sql/endpoint.go
@@ -6,6 +6,7 @@ import (
 
 	m "github.com/estuary/connectors/go/protocols/materialize"
 	boilerplate "github.com/estuary/connectors/materialize-boilerplate"
+	"github.com/estuary/flow/go/protocols/flow"
 	pf "github.com/estuary/flow/go/protocols/flow"
 	pm "github.com/estuary/flow/go/protocols/materialize"
 )
@@ -92,6 +93,8 @@ type Endpoint struct {
 	// MetaCheckpoints is the checkpoints meta-table of the Endpoint.
 	// It's optional, and won't be created or used if it's nil.
 	MetaCheckpoints *TableShape
+	// Serialization policy to use for all bindings of this materialization.
+	SerPolicy *flow.SerPolicy
 	// NewClient creates a client, which provides Endpoint-specific methods for performing
 	// operations with the Endpoint store.
 	NewClient func(context.Context, *Endpoint) (Client, error)


### PR DESCRIPTION
**Description:**

Allow connectors to define their serialization policy, rather than relying on hard-coded values in the runtime.

Technically this can be set per-binding in the protocol, but for now it will be exposed in connector configurations as a simple "disable field truncation entirely" advanced option.

`materialize-snowflake` is updated to have this configuration option available, since it is the currently-known use case for such a thing.

Depends on https://github.com/estuary/flow/pull/2179 having been merged & deployed. ~TODO: Update the flow pin in this PR once that is done to a SHA from the main branch.~ - done

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2865)
<!-- Reviewable:end -->
