### PR TITLE
sqlcapture: Omit reduction on /_meta/source in SourcedSchemas

### DIFF
--- a/sqlcapture/discovery.go
+++ b/sqlcapture/discovery.go
@@ -112,7 +112,7 @@ func generateCollectionSchema(db Database, table *DiscoveryInfo, fullWriteSchema
 	}).Reflect(db.EmptySourceMetadata())
 	sourceSchema.Version = ""
 
-	if db.HistoryMode() {
+	if db.HistoryMode() && fullWriteSchema {
 		sourceSchema.Extras = map[string]interface{}{
 			"reduce": map[string]interface{}{
 				"strategy":    "lastWriteWins",


### PR DESCRIPTION
**Description:**

When history mode is enabled we add a reduction annotation to the /_meta/source property, but as with other reduction annotations this shouldn't be present in a SourcedSchema update, only in the write schema.

