### PR TITLE
source-jira-native: remove `editmeta` from the `expand` param for `issues`

### DIFF
--- a/source-jira-native/source_jira_native/api.py
+++ b/source-jira-native/source_jira_native/api.py
@@ -215,7 +215,7 @@ async def _fetch_issues_between(
         params["fields"] = "id,updated"
     else:
         params["fields"] = "*all"
-        params["expand"] = "renderedFields,transitions,operations,editmeta,changelog"
+        params["expand"] = "renderedFields,transitions,operations,changelog"
 
     while True:
         _, body = await http.request_stream(


### PR DESCRIPTION
**Description:**

Including `editmeta` when searching for issues can cause repeat 500 internal server errors on Jira's side with a message like `Cannot invoke \"com.atlassian.jira.issue.fields.config.FieldConfig.getScope()\" because \"config\" is null`.

Omitting `editmeta` avoids these 500 responses. The imported `source-jira-legacy` doesn't include `editmeta`, so any existing users likely won't expect us to fetch it. If they do request this, we can add some config options to let users control what's included in the `expand` param.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

Checked by hitting the API directly. A request that previously returned the 500 error mentioned above with `editmeta` included in the `expand` param no longer caused an error after removing `editmeta`.

