### PR TITLE
source-mysql: Ignore INTVAR_EVENTs

### DIFF
--- a/source-mysql/replication.go
+++ b/source-mysql/replication.go
@@ -628,6 +628,9 @@ func (rs *mysqlReplicationStream) run(ctx context.Context, startCursor mysql.Pos
 		case *replication.RowsQueryEvent:
 			implicitFlush = true // Implicit FlushEvent conversion permitted
 			logrus.WithField("query", string(data.Query)).Debug("ignoring Rows Query Event")
+		case *replication.IntVarEvent:
+			implicitFlush = true // Implicit FlushEvent conversion permitted
+			logrus.WithField("type", data.Type).WithField("value", data.Value).Debug("ignoring IntVar Event")
 		default:
 			return fmt.Errorf("unhandled event type: %q", event.Header.EventType)
 		}


### PR DESCRIPTION
**Description:**

It's a bit weird and normally we shouldn't be seeing these in the binlog unless something screwy is going on with query events and the binlog format, but they are not themselves an issue, we just don't care about this event type.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2870)
<!-- Reviewable:end -->
