### PR TITLE
update Flow dependencies for Rust connectors 

### DIFF
--- a/materialize-kafka/Cargo.lock
+++ b/materialize-kafka/Cargo.lock
@@ -117,7 +117,7 @@ checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 [[package]]
 name = "avro"
 version = "0.0.0"
-source = "git+https://github.com/estuary/flow#be7a697bebea55b96e91c5b3ae0bd4a8c2d714a2"
+source = "git+https://github.com/estuary/flow#c6e532cf0a669ee3ba15cda77ba06b7ba91596cd"
 dependencies = [
  "apache-avro",
  "doc",
@@ -413,7 +413,7 @@ dependencies = [
 [[package]]
 name = "doc"
 version = "0.0.0"
-source = "git+https://github.com/estuary/flow#be7a697bebea55b96e91c5b3ae0bd4a8c2d714a2"
+source = "git+https://github.com/estuary/flow#c6e532cf0a669ee3ba15cda77ba06b7ba91596cd"
 dependencies = [
  "base64 0.13.1",
  "bigdecimal 0.3.1",
@@ -1073,7 +1073,7 @@ dependencies = [
 [[package]]
 name = "json"
 version = "0.0.0"
-source = "git+https://github.com/estuary/flow#be7a697bebea55b96e91c5b3ae0bd4a8c2d714a2"
+source = "git+https://github.com/estuary/flow#c6e532cf0a669ee3ba15cda77ba06b7ba91596cd"
 dependencies = [
  "addr",
  "bigdecimal 0.3.1",
@@ -1610,7 +1610,7 @@ dependencies = [
 [[package]]
 name = "proto-flow"
 version = "0.0.0"
-source = "git+https://github.com/estuary/flow#be7a697bebea55b96e91c5b3ae0bd4a8c2d714a2"
+source = "git+https://github.com/estuary/flow#c6e532cf0a669ee3ba15cda77ba06b7ba91596cd"
 dependencies = [
  "bytes",
  "pbjson",
@@ -1625,7 +1625,7 @@ dependencies = [
 [[package]]
 name = "proto-gazette"
 version = "0.0.0"
-source = "git+https://github.com/estuary/flow#be7a697bebea55b96e91c5b3ae0bd4a8c2d714a2"
+source = "git+https://github.com/estuary/flow#c6e532cf0a669ee3ba15cda77ba06b7ba91596cd"
 dependencies = [
  "bytes",
  "pbjson",
@@ -2573,7 +2573,7 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 [[package]]
 name = "tuple"
 version = "0.0.0"
-source = "git+https://github.com/estuary/flow#be7a697bebea55b96e91c5b3ae0bd4a8c2d714a2"
+source = "git+https://github.com/estuary/flow#c6e532cf0a669ee3ba15cda77ba06b7ba91596cd"
 dependencies = [
  "memchr",
  "serde_json",

--- a/materialize-kafka/src/validate.rs
+++ b/materialize-kafka/src/validate.rs
@@ -1,6 +1,6 @@
 use anyhow::{Context, Result};
 use proto_flow::{
-    flow::{MaterializationSpec, Projection},
+    flow::{MaterializationSpec, Projection, SerPolicy},
     materialize::{
         request::Validate,
         response::validated::{constraint, Binding, Constraint},
@@ -61,6 +61,11 @@ pub async fn do_validate(req: Validate) -> Result<Vec<Binding>> {
                     .collect(),
                 resource_path: vec![res.topic],
                 delta_updates: true,
+                ser_policy: Some(SerPolicy {
+                    str_truncate_after: 1 << 16,
+                    nested_obj_truncate_after: 1000,
+                    array_truncate_after: 1000,
+                }),
             })
         })
         .collect::<Result<Vec<Binding>>>()

--- a/source-http-ingest/Cargo.lock
+++ b/source-http-ingest/Cargo.lock
@@ -64,7 +64,7 @@ dependencies = [
 [[package]]
 name = "allocator"
 version = "0.0.0"
-source = "git+https://github.com/estuary/flow#be7a697bebea55b96e91c5b3ae0bd4a8c2d714a2"
+source = "git+https://github.com/estuary/flow#c6e532cf0a669ee3ba15cda77ba06b7ba91596cd"
 dependencies = [
  "jemalloc-ctl",
  "jemallocator",
@@ -503,7 +503,7 @@ dependencies = [
 [[package]]
 name = "doc"
 version = "0.0.0"
-source = "git+https://github.com/estuary/flow#be7a697bebea55b96e91c5b3ae0bd4a8c2d714a2"
+source = "git+https://github.com/estuary/flow#c6e532cf0a669ee3ba15cda77ba06b7ba91596cd"
 dependencies = [
  "base64 0.13.1",
  "bigdecimal",
@@ -1141,7 +1141,7 @@ dependencies = [
 [[package]]
 name = "json"
 version = "0.0.0"
-source = "git+https://github.com/estuary/flow#be7a697bebea55b96e91c5b3ae0bd4a8c2d714a2"
+source = "git+https://github.com/estuary/flow#c6e532cf0a669ee3ba15cda77ba06b7ba91596cd"
 dependencies = [
  "addr",
  "bigdecimal",
@@ -1268,7 +1268,7 @@ dependencies = [
 [[package]]
 name = "models"
 version = "0.0.0"
-source = "git+https://github.com/estuary/flow#be7a697bebea55b96e91c5b3ae0bd4a8c2d714a2"
+source = "git+https://github.com/estuary/flow#c6e532cf0a669ee3ba15cda77ba06b7ba91596cd"
 dependencies = [
  "anyhow",
  "caseless",
@@ -1641,12 +1641,12 @@ dependencies = [
 [[package]]
 name = "proto-build"
 version = "0.0.0"
-source = "git+https://github.com/estuary/flow#be7a697bebea55b96e91c5b3ae0bd4a8c2d714a2"
+source = "git+https://github.com/estuary/flow#c6e532cf0a669ee3ba15cda77ba06b7ba91596cd"
 
 [[package]]
 name = "proto-flow"
 version = "0.0.0"
-source = "git+https://github.com/estuary/flow#be7a697bebea55b96e91c5b3ae0bd4a8c2d714a2"
+source = "git+https://github.com/estuary/flow#c6e532cf0a669ee3ba15cda77ba06b7ba91596cd"
 dependencies = [
  "bytes",
  "pbjson",
@@ -1665,7 +1665,7 @@ dependencies = [
 [[package]]
 name = "proto-gazette"
 version = "0.0.0"
-source = "git+https://github.com/estuary/flow#be7a697bebea55b96e91c5b3ae0bd4a8c2d714a2"
+source = "git+https://github.com/estuary/flow#c6e532cf0a669ee3ba15cda77ba06b7ba91596cd"
 dependencies = [
  "bytes",
  "pbjson",
@@ -2681,7 +2681,7 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 [[package]]
 name = "tuple"
 version = "0.0.0"
-source = "git+https://github.com/estuary/flow#be7a697bebea55b96e91c5b3ae0bd4a8c2d714a2"
+source = "git+https://github.com/estuary/flow#c6e532cf0a669ee3ba15cda77ba06b7ba91596cd"
 dependencies = [
  "memchr",
  "serde_json",

--- a/source-kafka/Cargo.lock
+++ b/source-kafka/Cargo.lock
@@ -690,7 +690,7 @@ dependencies = [
 [[package]]
 name = "doc"
 version = "0.0.0"
-source = "git+https://github.com/estuary/flow#be7a697bebea55b96e91c5b3ae0bd4a8c2d714a2"
+source = "git+https://github.com/estuary/flow#c6e532cf0a669ee3ba15cda77ba06b7ba91596cd"
 dependencies = [
  "base64 0.13.1",
  "bigdecimal 0.3.1",
@@ -1377,7 +1377,7 @@ dependencies = [
 [[package]]
 name = "json"
 version = "0.0.0"
-source = "git+https://github.com/estuary/flow#be7a697bebea55b96e91c5b3ae0bd4a8c2d714a2"
+source = "git+https://github.com/estuary/flow#c6e532cf0a669ee3ba15cda77ba06b7ba91596cd"
 dependencies = [
  "addr",
  "bigdecimal 0.3.1",
@@ -1942,7 +1942,7 @@ dependencies = [
 [[package]]
 name = "proto-flow"
 version = "0.0.0"
-source = "git+https://github.com/estuary/flow#be7a697bebea55b96e91c5b3ae0bd4a8c2d714a2"
+source = "git+https://github.com/estuary/flow#c6e532cf0a669ee3ba15cda77ba06b7ba91596cd"
 dependencies = [
  "bytes",
  "pbjson",
@@ -1957,7 +1957,7 @@ dependencies = [
 [[package]]
 name = "proto-gazette"
 version = "0.0.0"
-source = "git+https://github.com/estuary/flow#be7a697bebea55b96e91c5b3ae0bd4a8c2d714a2"
+source = "git+https://github.com/estuary/flow#c6e532cf0a669ee3ba15cda77ba06b7ba91596cd"
 dependencies = [
  "bytes",
  "pbjson",
@@ -3026,7 +3026,7 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 [[package]]
 name = "tuple"
 version = "0.0.0"
-source = "git+https://github.com/estuary/flow#be7a697bebea55b96e91c5b3ae0bd4a8c2d714a2"
+source = "git+https://github.com/estuary/flow#c6e532cf0a669ee3ba15cda77ba06b7ba91596cd"
 dependencies = [
  "memchr",
  "serde_json",


### PR DESCRIPTION
**Description:**

Updates the Flow dependency for Rust connectors. Also adds the specific serialization policy that materialize-kafka should use, which is the same as the hard-coded policy that is currently in the Flow runtime.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2873)
<!-- Reviewable:end -->
