### PR TITLE
source-http-ingest: set `is_fallback_key` for discovered bindings

### DIFF
--- a/source-http-ingest/src/lib.rs
+++ b/source-http-ingest/src/lib.rs
@@ -465,6 +465,7 @@ fn discovered_webhook_collection(path: Option<&str>) -> DiscoveredBinding {
         }))
         .unwrap(),
         key: vec!["/_meta/webhookId".to_string()],
+        is_fallback_key: true,
         resource_path: resource_config.resource_path(),
     }
 }

--- a/source-http-ingest/src/snapshots/source_http_ingest__test__discover_backwards_compatibility.snap
+++ b/source-http-ingest/src/snapshots/source_http_ingest__test__discover_backwards_compatibility.snap
@@ -17,7 +17,8 @@ expression: result
       ],
       "resourcePath": [
         "webhook-data"
-      ]
+      ],
+      "isFallbackKey": true
     }
   ]
 }

--- a/source-http-ingest/src/snapshots/source_http_ingest__test__discover_with_paths.snap
+++ b/source-http-ingest/src/snapshots/source_http_ingest__test__discover_with_paths.snap
@@ -17,7 +17,8 @@ expression: result
       ],
       "resourcePath": [
         "/foo"
-      ]
+      ],
+      "isFallbackKey": true
     },
     {
       "recommendedName": "bar/baz",
@@ -32,7 +33,8 @@ expression: result
       ],
       "resourcePath": [
         "/bar/baz"
-      ]
+      ],
+      "isFallbackKey": true
     }
   ]
 }


### PR DESCRIPTION
**Description:**

When I updated the Flow protocol dependency in 0c7846f, I neglected to set the `is_fallback_key` for for source-http-ingest discovered bindings.

This was causing the build to fail, because Rust requires all struct fields to be explicitly set. And since we are setting it, we might as well make it True, since the synthetic webhook ID does indeed meet the criteria for a fallback key.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2877)
<!-- Reviewable:end -->
