### PR TITLE
source-postgres: Set additionalProperties to false on array objects

### DIFF
--- a/source-postgres/.snapshots/TestFeatureFlagFlattenArrays-Disabled-Discovery
+++ b/source-postgres/.snapshots/TestFeatureFlagFlattenArrays-Disabled-Discovery
@@ -24,6 +24,7 @@ Binding 0:
                 "elements"
               ],
               "description": "(source type: _int4)",
+              "additionalProperties": false,
               "properties": {
                 "dimensions": {
                   "items": {
@@ -52,6 +53,7 @@ Binding 0:
                 "elements"
               ],
               "description": "(source type: _int4)",
+              "additionalProperties": false,
               "properties": {
                 "dimensions": {
                   "items": {
@@ -80,6 +82,7 @@ Binding 0:
                 "elements"
               ],
               "description": "(source type: _text)",
+              "additionalProperties": false,
               "properties": {
                 "dimensions": {
                   "items": {

--- a/source-postgres/discovery.go
+++ b/source-postgres/discovery.go
@@ -327,6 +327,7 @@ func (db *postgresDatabase) TranslateDBToJSONType(column sqlcapture.ColumnInfo, 
 						Items: colSchema.toType(),
 					},
 				},
+				"additionalProperties": false,
 			},
 			Required: []string{"dimensions", "elements"},
 		}


### PR DESCRIPTION
**Description:**

When we capture arrays as {dimensions, elements} tuples, we need the generated JSON schema type to set `additionalProperties: false` in SourcedSchemas (because for schema inference purposes we always want to forbid additional properties). But since these values will never have additional properties we'll just add it unconditionally to the write schema for simplicity.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2881)
<!-- Reviewable:end -->
