### PR TITLE
source-*-batch: Detect and error out if a cursor column is missing in query results

### DIFF
--- a/source-bigquery-batch/.snapshots/TestNonexistentCursor-Capture
+++ b/source-bigquery-batch/.snapshots/TestNonexistentCursor-Capture
@@ -1,0 +1,9 @@
+# ================================
+# Final State Checkpoint
+# ================================
+
+# ================================
+# Captures Terminated With Errors
+# ================================
+capture terminated with error: error polling binding "nonexistentcursor_140869": error executing query: googleapi: Error 400: Unrecognized name: updated_at at [2:12], invalidQuery
+

--- a/source-bigquery-batch/.snapshots/TestNonexistentCursor-Discovery
+++ b/source-bigquery-batch/.snapshots/TestNonexistentCursor-Discovery
@@ -1,0 +1,86 @@
+Binding 0:
+{
+    "resource_config_json": {
+      "name": "nonexistentcursor_140869",
+      "schema": "testdata",
+      "table": "nonexistentcursor_140869",
+      "cursor": [
+        "updated_at"
+      ]
+    },
+    "resource_path": [
+      "nonexistentcursor_140869"
+    ],
+    "collection": {
+      "name": "acmeCo/test/nonexistentcursor_140869",
+      "read_schema_json": {
+        "type": "object",
+        "required": [
+          "_meta",
+          "id"
+        ],
+        "properties": {
+          "_meta": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$id": "https://github.com/estuary/connectors/source-bigquery-batch/document-metadata",
+            "properties": {
+              "polled": {
+                "type": "string",
+                "format": "date-time",
+                "title": "Polled Timestamp",
+                "description": "The time at which the update query which produced this document as executed."
+              },
+              "index": {
+                "type": "integer",
+                "title": "Result Index",
+                "description": "The index of this document within the query execution which produced it."
+              },
+              "row_id": {
+                "type": "integer",
+                "title": "Row ID",
+                "description": "Row ID of the Document"
+              },
+              "op": {
+                "type": "string",
+                "enum": [
+                  "c",
+                  "u",
+                  "d"
+                ],
+                "title": "Change Operation",
+                "description": "Operation type (c: Create / u: Update / d: Delete)",
+                "default": "u"
+              }
+            },
+            "type": "object",
+            "required": [
+              "polled",
+              "index",
+              "row_id"
+            ]
+          },
+          "data": {
+            "description": "(source type: STRING)",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "id": {
+            "description": "(source type: INT64)",
+            "type": [
+              "integer",
+              "null"
+            ]
+          }
+        },
+        "x-infer-schema": true
+      },
+      "key": [
+        "/id"
+      ],
+      "projections": null
+    },
+    "state_key": "nonexistentcursor_140869"
+  }
+

--- a/source-bigquery-batch/driver.go
+++ b/source-bigquery-batch/driver.go
@@ -533,7 +533,11 @@ func (c *capture) poll(ctx context.Context, binding *bindingInfo) error {
 				fieldIndices[name] = idx
 			}
 			for _, cursorName := range cursorNames {
-				cursorIndices = append(cursorIndices, fieldIndices[cursorName])
+				if fieldIndex, ok := fieldIndices[cursorName]; ok {
+					cursorIndices = append(cursorIndices, fieldIndex)
+				} else {
+					return fmt.Errorf("cursor column %q not found in query results", cursorName)
+				}
 			}
 		}
 		if len(rowValues) != len(row)+1 {

--- a/source-bigquery-batch/main_test.go
+++ b/source-bigquery-batch/main_test.go
@@ -1333,3 +1333,23 @@ func TestFeatureFlagEmitSourcedSchemas(t *testing.T) {
 		})
 	}
 }
+
+// TestNonexistentCursor exercises the situation of a capture whose configured
+// cursor column doesn't actually exist.
+func TestNonexistentCursor(t *testing.T) {
+	var ctx, cs, control = context.Background(), testCaptureSpec(t), testBigQueryClient(t)
+	var tableName, uniqueID = testTableName(t, uniqueTableID(t))
+	createTestTable(ctx, t, control, tableName, `(id INTEGER PRIMARY KEY NOT ENFORCED, data STRING)`)
+	executeSetupQuery(ctx, t, control, fmt.Sprintf("INSERT INTO %s (id, data) VALUES (1, 'hello'), (2, 'world')", tableName))
+
+	cs.Bindings = discoverBindings(ctx, t, cs, regexp.MustCompile(uniqueID))
+	setCursorColumns(t, cs.Bindings[0], "updated_at") // Nonexistent column
+
+	t.Run("Discovery", func(t *testing.T) { cupaloy.SnapshotT(t, summarizeBindings(t, cs.Bindings)) })
+
+	t.Run("Capture", func(t *testing.T) {
+		setShutdownAfterQuery(t, true)
+		cs.Capture(ctx, t, nil)
+		cupaloy.SnapshotT(t, cs.Summary())
+	})
+}

--- a/source-mysql-batch/.snapshots/TestNonexistentCursor-Capture
+++ b/source-mysql-batch/.snapshots/TestNonexistentCursor-Capture
@@ -1,0 +1,9 @@
+# ================================
+# Final State Checkpoint
+# ================================
+
+# ================================
+# Captures Terminated With Errors
+# ================================
+capture terminated with error: error polling binding "test_nonexistentcursor_140869": error preparing query "SELECT * FROM `test`.`nonexistentcursor_140869` ORDER BY `updated_at`;": ERROR 1054 (42S22): Unknown column 'updated_at' in 'order clause'
+

--- a/source-mysql-batch/.snapshots/TestNonexistentCursor-Discovery
+++ b/source-mysql-batch/.snapshots/TestNonexistentCursor-Discovery
@@ -1,0 +1,83 @@
+Binding 0:
+{
+    "resource_config_json": {
+      "name": "test_nonexistentcursor_140869",
+      "schema": "test",
+      "table": "nonexistentcursor_140869",
+      "cursor": [
+        "updated_at"
+      ]
+    },
+    "resource_path": [
+      "test_nonexistentcursor_140869"
+    ],
+    "collection": {
+      "name": "acmeCo/test/test_nonexistentcursor_140869",
+      "read_schema_json": {
+        "type": "object",
+        "required": [
+          "_meta",
+          "id"
+        ],
+        "properties": {
+          "_meta": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$id": "https://github.com/estuary/connectors/source-mysql-batch/document-metadata",
+            "properties": {
+              "polled": {
+                "type": "string",
+                "format": "date-time",
+                "title": "Polled Timestamp",
+                "description": "The time at which the update query which produced this document as executed."
+              },
+              "index": {
+                "type": "integer",
+                "title": "Result Index",
+                "description": "The index of this document within the query execution which produced it."
+              },
+              "row_id": {
+                "type": "integer",
+                "title": "Row ID",
+                "description": "Row ID of the Document"
+              },
+              "op": {
+                "type": "string",
+                "enum": [
+                  "c",
+                  "u",
+                  "d"
+                ],
+                "title": "Change Operation",
+                "description": "Operation type (c: Create / u: Update / d: Delete)",
+                "default": "u"
+              }
+            },
+            "type": "object",
+            "required": [
+              "polled",
+              "index",
+              "row_id"
+            ]
+          },
+          "data": {
+            "description": "(source type: text)",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "id": {
+            "type": "integer",
+            "description": "(source type: non-nullable int)"
+          }
+        },
+        "x-infer-schema": true
+      },
+      "key": [
+        "/id"
+      ],
+      "projections": null
+    },
+    "state_key": "test_nonexistentcursor_140869"
+  }
+

--- a/source-mysql-batch/driver.go
+++ b/source-mysql-batch/driver.go
@@ -582,7 +582,11 @@ func (c *capture) poll(ctx context.Context, binding *bindingInfo) error {
 				fieldIndices[name] = idx
 			}
 			for _, cursorName := range cursorNames {
-				cursorIndices = append(cursorIndices, fieldIndices[cursorName])
+				if fieldIndex, ok := fieldIndices[cursorName]; ok {
+					cursorIndices = append(cursorIndices, fieldIndex)
+				} else {
+					return fmt.Errorf("cursor column %q not found in query result", cursorName)
+				}
 			}
 		}
 

--- a/source-mysql-batch/main_test.go
+++ b/source-mysql-batch/main_test.go
@@ -1052,3 +1052,23 @@ func TestFeatureFlagEmitSourcedSchemas(t *testing.T) {
 		})
 	}
 }
+
+// TestNonexistentCursor exercises the situation of a capture whose configured
+// cursor column doesn't actually exist.
+func TestNonexistentCursor(t *testing.T) {
+	var ctx, cs, control = context.Background(), testCaptureSpec(t), testMySQLClient(t)
+	var tableName, uniqueID = testTableName(t, uniqueTableID(t))
+	createTestTable(t, control, tableName, `(id INTEGER PRIMARY KEY, data TEXT)`)
+	executeControlQuery(t, control, fmt.Sprintf("INSERT INTO %s (id, data) VALUES (1, 'hello'), (2, 'world')", tableName))
+
+	cs.Bindings = discoverBindings(ctx, t, cs, regexp.MustCompile(uniqueID))
+	setResourceCursor(t, cs.Bindings[0], "updated_at") // Nonexistent column
+
+	t.Run("Discovery", func(t *testing.T) { cupaloy.SnapshotT(t, summarizeBindings(t, cs.Bindings)) })
+
+	t.Run("Capture", func(t *testing.T) {
+		setShutdownAfterQuery(t, true)
+		cs.Capture(ctx, t, nil)
+		cupaloy.SnapshotT(t, cs.Summary())
+	})
+}

--- a/source-oracle-batch/driver.go
+++ b/source-oracle-batch/driver.go
@@ -494,7 +494,11 @@ func (c *capture) poll(ctx context.Context, binding *bindingInfo) error {
 	}
 	var cursorIndices []int
 	for _, cursorName := range cursorNames {
-		cursorIndices = append(cursorIndices, columnIndices[cursorName])
+		if columnIndex, ok := columnIndices[cursorName]; ok {
+			cursorIndices = append(cursorIndices, columnIndex)
+		} else {
+			return fmt.Errorf("cursor column %q not found in query result", cursorName)
+		}
 	}
 
 	var columnValues = make([]any, len(columnNames))

--- a/source-postgres-batch/.snapshots/TestNonexistentCursor-Capture
+++ b/source-postgres-batch/.snapshots/TestNonexistentCursor-Capture
@@ -1,0 +1,9 @@
+# ================================
+# Final State Checkpoint
+# ================================
+
+# ================================
+# Captures Terminated With Errors
+# ================================
+capture terminated with error: error polling binding "test_nonexistentcursor_140869": error executing query: ERROR: column "updated_at" does not exist (SQLSTATE 42703)
+

--- a/source-postgres-batch/.snapshots/TestNonexistentCursor-Discovery
+++ b/source-postgres-batch/.snapshots/TestNonexistentCursor-Discovery
@@ -1,0 +1,83 @@
+Binding 0:
+{
+    "resource_config_json": {
+      "name": "test_nonexistentcursor_140869",
+      "schema": "test",
+      "table": "nonexistentcursor_140869",
+      "cursor": [
+        "updated_at"
+      ]
+    },
+    "resource_path": [
+      "test_nonexistentcursor_140869"
+    ],
+    "collection": {
+      "name": "acmeCo/test/test_nonexistentcursor_140869",
+      "read_schema_json": {
+        "type": "object",
+        "required": [
+          "_meta",
+          "id"
+        ],
+        "properties": {
+          "_meta": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$id": "https://github.com/estuary/connectors/source-postgres-batch/document-metadata",
+            "properties": {
+              "polled": {
+                "type": "string",
+                "format": "date-time",
+                "title": "Polled Timestamp",
+                "description": "The time at which the update query which produced this document as executed."
+              },
+              "index": {
+                "type": "integer",
+                "title": "Result Index",
+                "description": "The index of this document within the query execution which produced it."
+              },
+              "row_id": {
+                "type": "integer",
+                "title": "Row ID",
+                "description": "Row ID of the Document"
+              },
+              "op": {
+                "type": "string",
+                "enum": [
+                  "c",
+                  "u",
+                  "d"
+                ],
+                "title": "Change Operation",
+                "description": "Operation type (c: Create / u: Update / d: Delete)",
+                "default": "u"
+              }
+            },
+            "type": "object",
+            "required": [
+              "polled",
+              "index",
+              "row_id"
+            ]
+          },
+          "data": {
+            "description": "(source type: text)",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "id": {
+            "type": "integer",
+            "description": "(source type: non-nullable int4)"
+          }
+        },
+        "x-infer-schema": true
+      },
+      "key": [
+        "/id"
+      ],
+      "projections": null
+    },
+    "state_key": "test_nonexistentcursor_140869"
+  }
+

--- a/source-postgres-batch/driver.go
+++ b/source-postgres-batch/driver.go
@@ -626,7 +626,11 @@ func (c *capture) pollCustomQuery(ctx context.Context, binding *bindingInfo) err
 	}
 	var cursorIndices []int
 	for _, cursorName := range cursorNames {
-		cursorIndices = append(cursorIndices, columnIndices[cursorName])
+		if columnIndex, ok := columnIndices[cursorName]; ok {
+			cursorIndices = append(cursorIndices, columnIndex)
+		} else {
+			return fmt.Errorf("cursor column %q not found in query result", cursorName)
+		}
 	}
 
 	var columnValues = make([]any, len(columnNames))

--- a/source-postgres-batch/main_test.go
+++ b/source-postgres-batch/main_test.go
@@ -1539,3 +1539,23 @@ func TestFeatureFlagEmitSourcedSchemas(t *testing.T) {
 		})
 	}
 }
+
+// TestNonexistentCursor exercises the situation of a capture whose configured
+// cursor column doesn't actually exist.
+func TestNonexistentCursor(t *testing.T) {
+	var ctx, cs, control = context.Background(), testCaptureSpec(t), testControlClient(t)
+	var tableName, uniqueID = testTableName(t, uniqueTableID(t))
+	createTestTable(t, control, tableName, `(id INTEGER PRIMARY KEY, data TEXT)`)
+	executeControlQuery(t, control, fmt.Sprintf("INSERT INTO %s (id, data) VALUES (1, 'hello'), (2, 'world')", tableName))
+
+	cs.Bindings = discoverBindings(ctx, t, cs, regexp.MustCompile(uniqueID))
+	setResourceCursor(t, cs.Bindings[0], "updated_at") // Nonexistent column
+
+	t.Run("Discovery", func(t *testing.T) { cupaloy.SnapshotT(t, summarizeBindings(t, cs.Bindings)) })
+
+	t.Run("Capture", func(t *testing.T) {
+		setShutdownAfterQuery(t, true)
+		cs.Capture(ctx, t, nil)
+		cupaloy.SnapshotT(t, cs.Summary())
+	})
+}

--- a/source-redshift-batch/.snapshots/TestNonexistentCursor-Capture
+++ b/source-redshift-batch/.snapshots/TestNonexistentCursor-Capture
@@ -1,0 +1,9 @@
+# ================================
+# Final State Checkpoint
+# ================================
+
+# ================================
+# Captures Terminated With Errors
+# ================================
+capture terminated with error: error polling binding "nonexistentcursor_140869": error executing query: ERROR: column "updated_at" does not exist in nonexistentcursor_140869 (SQLSTATE 42703)
+

--- a/source-redshift-batch/.snapshots/TestNonexistentCursor-Discovery
+++ b/source-redshift-batch/.snapshots/TestNonexistentCursor-Discovery
@@ -1,0 +1,83 @@
+Binding 0:
+{
+    "resource_config_json": {
+      "name": "nonexistentcursor_140869",
+      "schema": "public",
+      "table": "nonexistentcursor_140869",
+      "cursor": [
+        "updated_at"
+      ]
+    },
+    "resource_path": [
+      "nonexistentcursor_140869"
+    ],
+    "collection": {
+      "name": "acmeCo/test/nonexistentcursor_140869",
+      "read_schema_json": {
+        "type": "object",
+        "required": [
+          "_meta",
+          "id"
+        ],
+        "properties": {
+          "_meta": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$id": "https://github.com/estuary/connectors/source-redshift-batch/document-metadata",
+            "properties": {
+              "polled": {
+                "type": "string",
+                "format": "date-time",
+                "title": "Polled Timestamp",
+                "description": "The time at which the update query which produced this document as executed."
+              },
+              "index": {
+                "type": "integer",
+                "title": "Result Index",
+                "description": "The index of this document within the query execution which produced it."
+              },
+              "row_id": {
+                "type": "integer",
+                "title": "Row ID",
+                "description": "Row ID of the Document"
+              },
+              "op": {
+                "type": "string",
+                "enum": [
+                  "c",
+                  "u",
+                  "d"
+                ],
+                "title": "Change Operation",
+                "description": "Operation type (c: Create / u: Update / d: Delete)",
+                "default": "u"
+              }
+            },
+            "type": "object",
+            "required": [
+              "polled",
+              "index",
+              "row_id"
+            ]
+          },
+          "data": {
+            "description": "(source type: varchar)",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "id": {
+            "type": "integer",
+            "description": "(source type: non-nullable int4)"
+          }
+        },
+        "x-infer-schema": true
+      },
+      "key": [
+        "/id"
+      ],
+      "projections": null
+    },
+    "state_key": "nonexistentcursor_140869"
+  }
+

--- a/source-redshift-batch/driver.go
+++ b/source-redshift-batch/driver.go
@@ -491,7 +491,11 @@ func (c *capture) poll(ctx context.Context, binding *bindingInfo, tmpl *template
 	}
 	var cursorIndices []int
 	for _, cursorName := range cursorNames {
-		cursorIndices = append(cursorIndices, columnIndices[cursorName])
+		if columnIndex, ok := columnIndices[cursorName]; ok {
+			cursorIndices = append(cursorIndices, columnIndex)
+		} else {
+			return fmt.Errorf("cursor column %q not found in query result", cursorName)
+		}
 	}
 
 	var columnValues = make([]any, len(columnNames))

--- a/source-sqlserver-batch/.snapshots/TestNonexistentCursor-Capture
+++ b/source-sqlserver-batch/.snapshots/TestNonexistentCursor-Capture
@@ -1,0 +1,9 @@
+# ================================
+# Final State Checkpoint
+# ================================
+
+# ================================
+# Captures Terminated With Errors
+# ================================
+capture terminated with error: error polling binding "nonexistentcursor_140869": error executing query: mssql: Invalid column name 'updated_at'.
+

--- a/source-sqlserver-batch/.snapshots/TestNonexistentCursor-Discovery
+++ b/source-sqlserver-batch/.snapshots/TestNonexistentCursor-Discovery
@@ -1,0 +1,81 @@
+Binding 0:
+{
+    "resource_config_json": {
+      "name": "nonexistentcursor_140869",
+      "schema": "dbo",
+      "table": "nonexistentcursor_140869",
+      "cursor": [
+        "updated_at"
+      ]
+    },
+    "resource_path": [
+      "nonexistentcursor_140869"
+    ],
+    "collection": {
+      "name": "acmeCo/test/nonexistentcursor_140869",
+      "read_schema_json": {
+        "type": "object",
+        "required": [
+          "_meta",
+          "id"
+        ],
+        "properties": {
+          "_meta": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$id": "https://github.com/estuary/connectors/source-sqlserver-batch/document-metadata",
+            "properties": {
+              "polled": {
+                "type": "string",
+                "format": "date-time",
+                "title": "Polled Timestamp",
+                "description": "The time at which the update query which produced this document as executed."
+              },
+              "index": {
+                "type": "integer",
+                "title": "Result Index",
+                "description": "The index of this document within the query execution which produced it."
+              },
+              "row_id": {
+                "type": "integer",
+                "title": "Row ID",
+                "description": "Row ID of the Document"
+              },
+              "op": {
+                "type": "string",
+                "enum": [
+                  "c",
+                  "u",
+                  "d"
+                ],
+                "title": "Change Operation",
+                "description": "Operation type (c: Create / u: Update / d: Delete)",
+                "default": "u"
+              }
+            },
+            "type": "object",
+            "required": [
+              "polled",
+              "index",
+              "row_id"
+            ]
+          },
+          "data": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "id": {
+            "type": "integer"
+          }
+        },
+        "x-infer-schema": true
+      },
+      "key": [
+        "/id"
+      ],
+      "projections": null
+    },
+    "state_key": "nonexistentcursor_140869"
+  }
+

--- a/source-sqlserver-batch/driver.go
+++ b/source-sqlserver-batch/driver.go
@@ -531,7 +531,11 @@ func (c *capture) poll(ctx context.Context, binding *bindingInfo) error {
 	}
 	var cursorIndices []int
 	for _, cursorName := range cursorNames {
-		cursorIndices = append(cursorIndices, columnIndices[cursorName])
+		if columnIndex, ok := columnIndices[cursorName]; ok {
+			cursorIndices = append(cursorIndices, columnIndex)
+		} else {
+			return fmt.Errorf("cursor column %q not found in query result", cursorName)
+		}
 	}
 
 	var columnValues = make([]any, len(columnNames))

--- a/source-sqlserver-batch/main_test.go
+++ b/source-sqlserver-batch/main_test.go
@@ -1145,3 +1145,23 @@ func TestFeatureFlagEmitSourcedSchemas(t *testing.T) {
 		})
 	}
 }
+
+// TestNonexistentCursor exercises the situation of a capture whose configured
+// cursor column doesn't actually exist.
+func TestNonexistentCursor(t *testing.T) {
+	var ctx, cs, control = context.Background(), testCaptureSpec(t), testControlClient(t)
+	var tableName, uniqueID = testTableName(t, uniqueTableID(t))
+	createTestTable(t, control, tableName, `(id INTEGER PRIMARY KEY, data TEXT)`)
+	executeControlQuery(t, control, fmt.Sprintf("INSERT INTO %s (id, data) VALUES (1, 'hello'), (2, 'world')", tableName))
+
+	cs.Bindings = discoverBindings(ctx, t, cs, regexp.MustCompile(uniqueID))
+	setResourceCursor(t, cs.Bindings[0], "updated_at") // Nonexistent column
+
+	t.Run("Discovery", func(t *testing.T) { cupaloy.SnapshotT(t, summarizeBindings(t, cs.Bindings)) })
+
+	t.Run("Capture", func(t *testing.T) {
+		setShutdownAfterQuery(t, true)
+		cs.Capture(ctx, t, nil)
+		cupaloy.SnapshotT(t, cs.Summary())
+	})
+}


### PR DESCRIPTION
**Description:**

Detects and errors out if one of the configured cursor properties is not present in the results of a polling query. However, as demonstrated in the new tests/snapshots, this can only be detected after the query successfully executes and starts returning results, so _usually_ it should never happen.

In fact I'm still trying to figure out whether/why it's happening in BigQuery at all here. But evidently it can in at least some edge case, so it seems prudent to add the appropriate sanity checking to all the batch SQL connectors, since checking properly is a one-time cost paid only during the setup at the start of a polling operation anyway.

