### PR TITLE
source-postgres: Partitioned CTID backfill fixes

### DIFF
--- a/source-postgres/.snapshots/TestPartitionedCTIDBackfill
+++ b/source-postgres/.snapshots/TestPartitionedCTIDBackfill
@@ -1,10 +1,10 @@
 # ================================
-# Collection "acmeCo/test/test/partitionedctidbackfill_254933": 471 Documents
+# Collection "acmeCo/test/test/partitionedctidbackfill_254933": 2999999 Documents
 # ================================
-Checksum: faef88466476b2c8474821a1e3c8cecc9fa8efbfd4ec67a89db3df49a993ab6e
-Total Bytes: 83308
+Checksum: 5d6084a33ab48341b6fcc35c67f9753cea138b892f04176e78c1a111f984e65d
+Total Bytes: 537777612
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"test%2Fpartitionedctidbackfill_254933":{"backfilled":471,"mode":"Active"}},"cursor":"0/1111111"}
+{"bindingStateV1":{"test%2Fpartitionedctidbackfill_254933":{"backfilled":2999999,"mode":"Active"}},"cursor":"0/1111111"}
 

--- a/source-postgres/.snapshots/TestPartitionedCTIDBackfill
+++ b/source-postgres/.snapshots/TestPartitionedCTIDBackfill
@@ -1,0 +1,10 @@
+# ================================
+# Collection "acmeCo/test/test/partitionedctidbackfill_254933": 471 Documents
+# ================================
+Checksum: faef88466476b2c8474821a1e3c8cecc9fa8efbfd4ec67a89db3df49a993ab6e
+Total Bytes: 83308
+# ================================
+# Final State Checkpoint
+# ================================
+{"bindingStateV1":{"test%2Fpartitionedctidbackfill_254933":{"backfilled":471,"mode":"Active"}},"cursor":"0/1111111"}
+

--- a/source-postgres/capture_test.go
+++ b/source-postgres/capture_test.go
@@ -845,6 +845,7 @@ func TestPartitionedCTIDBackfill(t *testing.T) {
 	// Run a CTID backfill of the root table
 	var cs = tb.CaptureSpec(ctx, t, regexp.MustCompile(uniqueID))
 	cs.Validator = &st.ChecksumValidator{}
+	cs.EndpointSpec.(*Config).Advanced.BackfillChunkSize = 50000 // Default prod chunk size since this table has millions of rows
 	setShutdownAfterCaughtUp(t, true)
 	setResourceBackfillMode(t, cs.Bindings[0], sqlcapture.BackfillModeWithoutKey)
 	cs.Capture(ctx, t, nil)


### PR DESCRIPTION
**Description:**

This PR fixes the CTID backfill maximum page size and pages-per-chunk heuristics so that they work correctly on partitioned tables, and adds a test case demonstrating that the new logic works as intended.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2890)
<!-- Reviewable:end -->
