### PR TITLE
source-google-ads: add logging to debug hanging captures & add a request timeout

### DIFF
--- a/source-google-ads/tests/common.py
+++ b/source-google-ads/tests/common.py
@@ -6,7 +6,7 @@ import json
 
 from google.ads.googleads.errors import GoogleAdsException
 from google.ads.googleads.v19.errors.types.errors import GoogleAdsFailure
-
+from source_google_ads.google_ads import GRCP_TIMEOUT
 
 class MockSearchRequest:
     customer_id = "12345"
@@ -17,7 +17,7 @@ class MockSearchRequest:
 
 # Mocking Classes
 class MockGoogleAdsService:
-    def search(self, search_request):
+    def search(self, search_request, timeout=GRCP_TIMEOUT):
         return search_request
 
 

--- a/source-google-ads/tests/test_google_ads.py
+++ b/source-google-ads/tests/test_google_ads.py
@@ -3,6 +3,7 @@
 #
 
 from datetime import date
+import logging
 
 import pendulum
 import pytest
@@ -94,7 +95,7 @@ def test_interval_chunking():
         {"start_date": "2021-07-28", "end_date": "2021-08-06"},
         {"start_date": "2021-08-07", "end_date": "2021-08-15"},
     ]
-    intervals = chunk_date_range("2021-07-01", 14, "segments.date", "2021-08-15", range_days=10)
+    intervals = chunk_date_range(logging.Logger(name="test_logger"), "2021-07-01", 14, "segments.date", "2021-08-15", range_days=10)
 
     assert mock_intervals == intervals
 

--- a/source-google-ads/tests/test_source.py
+++ b/source-google-ads/tests/test_source.py
@@ -3,6 +3,7 @@
 #
 
 import re
+import logging
 from collections import namedtuple
 from unittest.mock import Mock
 
@@ -112,7 +113,7 @@ def test_chunk_date_range_without_end_date():
     conversion_window = 0
     field = "date"
     response = chunk_date_range(
-        start_date=start_date_str, conversion_window=conversion_window, field=field, end_date=None, days_of_data_storage=None, range_days=1
+        logger=logging.Logger(name="test_logger"), start_date=start_date_str, conversion_window=conversion_window, field=field, end_date=None, days_of_data_storage=None, range_days=1
     )
     expected_response = [
         {"start_date": "2022-01-25", "end_date": "2022-01-26"},
@@ -130,7 +131,7 @@ def test_chunk_date_range():
     end_date = "2021-05-04"
     conversion_window = 14
     field = "date"
-    response = chunk_date_range(start_date, conversion_window, field, end_date, range_days=10)
+    response = chunk_date_range(logging.Logger(name="test_logger"), start_date, conversion_window, field, end_date, range_days=10)
     assert [
         {"start_date": "2021-02-19", "end_date": "2021-02-28"},
         {"start_date": "2021-03-01", "end_date": "2021-03-10"},


### PR DESCRIPTION
**Description:**

We've observed several hanging `source-google-ads` captures in production. I've tried recreating a hanging capture locally, but I haven't been successful yet. I suspect it's an intermittent issue that would require running the capture for hours to replicate. To speed up debugging, I'm adding a ton of logging to identify where the connectors are getting stuck when it happens in production again. We can revert the logging commit later once the problem is addressed.

My leading suspicion is that the Google API is silently dropping connections, and the connector's stuck waiting on a response that will never arrive. So, I also wired in a rough timeout to catch this if/when it happens. It's set at 5 minutes right now (which seems like a pretty generous duration).

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

Tested on a local stack & confirmed the connector runs like it did before. I did observe some `TimeoutErrors` get raised, so _hopefully_ this mitigates the "hanging connector" issue🤞 .

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2894)
<!-- Reviewable:end -->
