### PR TITLE
estuary-cdk: prevent `RateLimiter.delay` from growing larger than 5 minutes

### DIFF
--- a/estuary-cdk/estuary_cdk/http.py
+++ b/estuary-cdk/estuary_cdk/http.py
@@ -308,9 +308,12 @@ class RateLimiter:
     It initially uses quadratic decrease of `delay` until a first failure is
     encountered. Additional failures result in quadratic increase, while
     successes apply a linear decay.
+
+    To avoid excessively long delays, `delay` cannot grow larger than `MAX_DELAY`.
     """
 
     delay: float = 1.0
+    MAX_DELAY: float = 300.0 # 5 minutes
     gain: float = 0.01
 
     failed: int = 0
@@ -329,6 +332,7 @@ class RateLimiter:
             update = cur_delay * (1 - self.gain)
 
         self.delay = (1 - self.gain) * self.delay + self.gain * update
+        self.delay = min(self.delay, self.MAX_DELAY)
 
     @property
     def error_ratio(self) -> float:


### PR DESCRIPTION
**Description:**

We've seen infrequent cases where a connector is rate limited for an extended period of time (often when another ingestion tool is contributing to API rate limits), causing the `RateLimiter.delay` to grow to an absurd value. In one case, it grew to 43 minutes!

This causes multiple problems:
- With the low delay decay rate, it would take hours/days to reduce the delay to a reasonable amount (ex: if the delay grew to 43 minutes, the delay would only decay to 39 minutes after 1,000 successful requests. And keep in mind that we'd be waiting 39+ minutes between successful requests in most streams too).
- For streams that make multiple HTTP requests in a `fetch_foobar` invocation, those streams could spend multiple hours/days before yielding control back to the CDK & checking if the `stopping` event is set. This prevents the 24 hour graceful restart interval we want to maintain.

This PR takes a simple approach to solving these problems: prevent the delay from growing larger than 5 minutes. There are more sophisticated approaches that might work a little better (use a more aggressive decay, allow the delay to grow unbounded but reduce it immediately to 5 minutes upon a successful request), but I'd like to see if this simpler approach is sufficient before spending more time on this.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

