### PR TITLE
materialize-kafka: add producer context to track message delivery status

### DIFF
--- a/materialize-kafka/src/apply.rs
+++ b/materialize-kafka/src/apply.rs
@@ -65,7 +65,7 @@ pub async fn do_apply(req: Apply) -> Result<String> {
         .into_iter()
         .filter_map(|res| match res {
             Ok(t) => Some(Ok(t)),
-            Err((_, err_code)) if err_code == RDKafkaErrorCode::TopicAlreadyExists => None,
+            Err((_, RDKafkaErrorCode::TopicAlreadyExists)) => None,
             Err((err_msg, err_code)) => Some(Err(anyhow::anyhow!(
                 "failed to create topic: {} (code {})",
                 err_msg,

--- a/materialize-kafka/tests/snapshots/test__spec.snap
+++ b/materialize-kafka/tests/snapshots/test__spec.snap
@@ -12,6 +12,20 @@ expression: "serde_json::to_string_pretty(&got).unwrap()"
         "title": "Bootstrap Servers",
         "type": "string"
       },
+      "compression": {
+        "default": "lz4",
+        "description": "Compression algorithm to use for messages. Note that not all Kafka brokers support all compression algorithms.",
+        "enum": [
+          "none",
+          "gzip",
+          "lz4",
+          "snappy",
+          "zstd"
+        ],
+        "order": 4,
+        "title": "Compression",
+        "type": "string"
+      },
       "credentials": {
         "description": "The connection details for authenticating a client connection to Kafka via SASL. When not provided, the client connection will attempt to use PLAINTEXT (insecure) protocol. This must only be used in dev/test environments.",
         "discriminator": {
@@ -75,7 +89,7 @@ expression: "serde_json::to_string_pretty(&got).unwrap()"
       },
       "schema_registry": {
         "description": "Connection details for interacting with a schema registry. This is necessary for materializing messages with Avro encoding.",
-        "order": 4,
+        "order": 5,
         "properties": {
           "endpoint": {
             "description": "Schema registry API endpoint. For example: https://registry-id.us-east-2.aws.confluent.cloud",
@@ -118,14 +132,14 @@ expression: "serde_json::to_string_pretty(&got).unwrap()"
       "topic_partitions": {
         "default": 6,
         "description": "The number of partitions to create new topics with.",
-        "order": 5,
+        "order": 6,
         "title": "Topic Partitions",
         "type": "integer"
       },
       "topic_replication_factor": {
         "default": 3,
         "description": "The replication factor to create new topics with.",
-        "order": 6,
+        "order": 7,
         "title": "Topic Replication Factor",
         "type": "integer"
       }

--- a/materialize-kafka/tests/test.flow.yaml
+++ b/materialize-kafka/tests/test.flow.yaml
@@ -11,6 +11,7 @@ materializations:
           topic_partitions: 3
           topic_replication_factor: 1
           message_format: Avro
+          compression: none
           schema_registry:
             schema_registry_type: confluent_schema_registry
             endpoint: http://localhost:8081
@@ -38,6 +39,7 @@ materializations:
           topic_partitions: 3
           topic_replication_factor: 1
           message_format: JSON
+          compression: gzip
     bindings:
       - resource:
           topic: test_topic_json_1

--- a/tests/materialize/materialize-kafka/setup.sh
+++ b/tests/materialize/materialize-kafka/setup.sh
@@ -9,7 +9,8 @@ config_json_template='{
     "bootstrap_servers": "materialize-kafka-db-1.flow-test:9092",
     "topic_partitions": 3,
     "topic_replication_factor": 1,
-    "message_format": "JSON"
+    "message_format": "JSON",
+    "compression": "lz4"
 }'
 
 resources_json_template='[


### PR DESCRIPTION
**Description:**

* Fixes an issue with message delivery to ensure that all messages for a transaction are delivered successfully before acknowledging the transaction to the Flow runtime.
* Also adds an option to configure the compression algorithm that is used for messages, since sometimes the hard-coded lz4 default doesn't work for the broker / system being materialized to.

Existing tasks will need their endpoint configs updated to set an explicit `lz4` for compression in order for them to keep working. There's only a handful, so it shouldn't be a huge effort to get these updated.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

