### PR TITLE
source-monday: always capture active and archived boards/items

### DIFF
--- a/source-monday/source_monday/api.py
+++ b/source-monday/source_monday/api.py
@@ -10,7 +10,7 @@ from source_monday.graphql import (
     TEAMS,
     USERS,
     execute_query,
-    fetch_recently_updated,
+    fetch_activity_log_ids,
     fetch_boards,
     fetch_items_by_boards,
     fetch_items_by_ids,
@@ -38,7 +38,7 @@ async def fetch_boards_changes(
 
     max_updated_at = log_cursor
 
-    updated_ids = await fetch_recently_updated(
+    updated_ids = await fetch_activity_log_ids(
         "board",
         http,
         log,
@@ -74,7 +74,7 @@ async def fetch_boards_page(
 
     doc_count = 0
     async for board in fetch_boards(http, log, page=page, limit=limit):
-        if board.updated_at < cutoff:
+        if board.updated_at < cutoff and board.state != "deleted":
             yield board
             doc_count += 1
 
@@ -94,7 +94,7 @@ async def fetch_items_changes(
 
     max_updated_at = log_cursor
 
-    item_ids = await fetch_recently_updated(
+    item_ids = await fetch_activity_log_ids(
         "pulse",
         http,
         log,
@@ -145,7 +145,7 @@ async def fetch_items_page(
             board_id = item
             continue
 
-        if item.updated_at < cutoff:
+        if item.updated_at < cutoff and item.state != "deleted":
             yield item
             items_count += 1
 

--- a/source-monday/source_monday/models.py
+++ b/source-monday/source_monday/models.py
@@ -7,6 +7,7 @@ from typing import (
     Callable,
     Generic,
     TypeVar,
+    Literal,
 )
 import json
 
@@ -114,7 +115,11 @@ class GraphQLResponse(BaseModel, Generic[ResponseObject], extra="allow"):
 
 
 class ActivityLog(BaseModel, extra="allow"):
+    id: str
+    entity: str
+    event: str
     data: dict[str, Any] = Field(default_factory=dict)
+    created_at: str
 
     @field_validator("data", mode="before")
     @classmethod
@@ -140,8 +145,10 @@ class Board(BaseDocument, extra="allow"):
     class Workspace(BaseModel, extra="allow"):
         kind: str | None = None
 
+    id: str
     updated_at: AwareDatetime
     workspace: Workspace
+    state: Literal["all", "active", "archived", "deleted"]
 
 
 class BoardsResponse(BaseModel, extra="forbid"):
@@ -154,6 +161,7 @@ class ParentItemRef(BaseModel, extra="allow"):
 
 class Item(BaseDocument, extra="allow"):
     id: str
+    state: Literal["all", "active", "archived", "deleted"]
     parent_item: ParentItemRef | None = None
     updated_at: AwareDatetime
 
@@ -165,6 +173,7 @@ class ItemsPage(BaseModel, extra="allow"):
 
 class BoardItems(BaseModel, extra="allow"):
     id: str
+    state: str | None = None
     items_page: ItemsPage
 
 

--- a/source-monday/tests/snapshots/snapshots__capture__stdout.json
+++ b/source-monday/tests/snapshots/snapshots__capture__stdout.json
@@ -1,76 +1,5 @@
 [
   [
-    "acmeCo/teams",
-    {
-      "_meta": {
-        "op": "c",
-        "row_id": 0,
-        "uuid": "DocUUIDPlaceholder-329Bb50aa48EAa9ef"
-      },
-      "id": "1202780",
-      "name": "Team 1",
-      "owners": [
-        {
-          "id": "71985416"
-        }
-      ],
-      "picture_url": "https://cdn.monday.com/images/dapulse_team_default.png",
-      "users": [
-        {
-          "id": "71985416"
-        }
-      ]
-    }
-  ],
-  [
-    "acmeCo/users",
-    {
-      "_meta": {
-        "op": "c",
-        "row_id": 0,
-        "uuid": "DocUUIDPlaceholder-329Bb50aa48EAa9ef"
-      },
-      "birthday": null,
-      "country_code": "US",
-      "created_at": "2025-02-07T20:03:21Z",
-      "email": "justin@estuary.dev",
-      "enabled": true,
-      "id": "71985416",
-      "is_admin": true,
-      "is_guest": false,
-      "is_pending": false,
-      "is_verified": true,
-      "is_view_only": false,
-      "join_date": null,
-      "location": null,
-      "mobile_phone": null,
-      "name": "Justin Smith",
-      "phone": "",
-      "photo_original": "https://cdn1.monday.com/dapulse_default_photo.png",
-      "photo_small": "https://cdn1.monday.com/dapulse_default_photo.png",
-      "photo_thumb": "https://cdn1.monday.com/dapulse_default_photo.png",
-      "photo_thumb_small": "https://cdn1.monday.com/dapulse_default_photo.png",
-      "photo_tiny": "https://cdn1.monday.com/dapulse_default_photo.png",
-      "time_zone_identifier": "America/Chicago",
-      "title": null,
-      "url": "https://estuarydev.monday.com/users/71985416",
-      "utc_hours_diff": "redacted"
-    }
-  ],
-  [
-    "acmeCo/tags",
-    {
-      "_meta": {
-        "op": "c",
-        "row_id": 0,
-        "uuid": "DocUUIDPlaceholder-329Bb50aa48EAa9ef"
-      },
-      "color": "#579bfc",
-      "id": "25399873",
-      "name": "test"
-    }
-  ],
-  [
     "acmeCo/boards",
     {
       "_meta": {
@@ -175,96 +104,6 @@
         "id": "new_group29179"
       },
       "type": "board",
-      "updated_at": "redacted",
-      "updates": [],
-      "views": [],
-      "workspace": {
-        "description": null,
-        "id": "9823810",
-        "kind": "open",
-        "name": "Main workspace"
-      }
-    }
-  ],
-  [
-    "acmeCo/boards",
-    {
-      "_meta": {
-        "uuid": "DocUUIDPlaceholder-329Bb50aa48EAa9ef"
-      },
-      "board_kind": "public",
-      "columns": [
-        {
-          "archived": false,
-          "description": null,
-          "id": "name",
-          "settings_str": "{}",
-          "title": "Name",
-          "type": "name",
-          "width": 300
-        },
-        {
-          "archived": false,
-          "description": null,
-          "id": "person",
-          "settings_str": "{}",
-          "title": "Owner",
-          "type": "people",
-          "width": 98
-        },
-        {
-          "archived": false,
-          "description": null,
-          "id": "status",
-          "settings_str": "{\"done_colors\":[1],\"hide_footer\":true,\"labels\":{\"0\":\"Working on it\",\"1\":\"Done\",\"2\":\"Stuck\"},\"labels_positions_v2\":{\"0\":1,\"1\":2,\"2\":0,\"3\":3,\"4\":4,\"5\":9,\"6\":5,\"8\":6,\"9\":7,\"10\":8},\"labels_colors\":{\"0\":{\"color\":\"#fdab3d\",\"border\":\"#e99729\",\"var_name\":\"orange\"},\"1\":{\"color\":\"#00c875\",\"border\":\"#00b461\",\"var_name\":\"green-shadow\"},\"2\":{\"color\":\"#df2f4a\",\"border\":\"#ce3048\",\"var_name\":\"red-shadow\"}}}",
-          "title": "Status",
-          "type": "status",
-          "width": 136
-        },
-        {
-          "archived": false,
-          "description": null,
-          "id": "date0",
-          "settings_str": "{}",
-          "title": "Date",
-          "type": "date",
-          "width": 140
-        }
-      ],
-      "communication": null,
-      "creator": {
-        "id": "71985416"
-      },
-      "description": null,
-      "groups": [
-        {
-          "archived": false,
-          "color": "#579bfc",
-          "deleted": false,
-          "id": "topics",
-          "position": "65536",
-          "title": "Subitems"
-        }
-      ],
-      "id": "8483610893",
-      "name": "Subitems of Estuary",
-      "owners": [
-        {
-          "id": "71985416"
-        }
-      ],
-      "permissions": "everyone",
-      "state": "active",
-      "subscribers": [
-        {
-          "id": "71985416"
-        }
-      ],
-      "tags": [],
-      "top_group": {
-        "id": "topics"
-      },
-      "type": "sub_items_board",
       "updated_at": "redacted",
       "updates": [],
       "views": [],
@@ -430,267 +269,74 @@
     }
   ],
   [
-    "acmeCo/items",
+    "acmeCo/tags",
     {
       "_meta": {
+        "op": "c",
+        "row_id": 0,
         "uuid": "DocUUIDPlaceholder-329Bb50aa48EAa9ef"
       },
-      "assets": [],
-      "board": {
-        "id": "8483610893",
-        "name": "Subitems of Estuary"
-      },
-      "column_values": [
-        {
-          "id": "person",
-          "text": "",
-          "type": "people",
-          "value": null
-        },
-        {
-          "id": "status",
-          "text": null,
-          "type": "status",
-          "value": null
-        },
-        {
-          "id": "date0",
-          "text": "",
-          "type": "date",
-          "value": null
-        }
-      ],
-      "created_at": "2025-02-20T19:03:22Z",
-      "creator_id": "71985416",
-      "group": {
-        "id": "topics"
-      },
-      "id": "8531539316",
-      "name": "SubItem Number One",
-      "parent_item": {
-        "id": "8531390039"
-      },
-      "state": "active",
-      "subitems": [],
-      "subscribers": [
-        {
-          "id": "71985416"
-        }
-      ],
-      "updated_at": "redacted",
-      "updates": []
+      "color": "#579bfc",
+      "id": "25399873",
+      "name": "test"
     }
   ],
   [
-    "acmeCo/items",
+    "acmeCo/teams",
     {
       "_meta": {
+        "op": "c",
+        "row_id": 0,
         "uuid": "DocUUIDPlaceholder-329Bb50aa48EAa9ef"
       },
-      "assets": [],
-      "board": {
-        "id": "8483610893",
-        "name": "Subitems of Estuary"
-      },
-      "column_values": [
-        {
-          "id": "person",
-          "text": "",
-          "type": "people",
-          "value": null
-        },
-        {
-          "id": "status",
-          "text": null,
-          "type": "status",
-          "value": null
-        },
-        {
-          "id": "date0",
-          "text": "",
-          "type": "date",
-          "value": null
-        }
-      ],
-      "created_at": "2025-02-20T19:15:53Z",
-      "creator_id": "71985416",
-      "group": {
-        "id": "topics"
-      },
-      "id": "8531684828",
-      "name": "Second SubItem",
-      "parent_item": {
-        "id": "8531390039"
-      },
-      "state": "active",
-      "subitems": [],
-      "subscribers": [
+      "id": "1202780",
+      "name": "Team 1",
+      "owners": [
         {
           "id": "71985416"
         }
       ],
-      "updated_at": "redacted",
-      "updates": []
+      "picture_url": "https://cdn.monday.com/images/dapulse_team_default.png",
+      "users": [
+        {
+          "id": "71985416"
+        }
+      ]
     }
   ],
   [
-    "acmeCo/items",
+    "acmeCo/users",
     {
       "_meta": {
+        "op": "c",
+        "row_id": 0,
         "uuid": "DocUUIDPlaceholder-329Bb50aa48EAa9ef"
       },
-      "assets": [],
-      "board": {
-        "id": "8431289505",
-        "name": "Estuary"
-      },
-      "column_values": [
-        {
-          "id": "subitems_mkn5v6ah",
-          "text": null,
-          "type": "subtasks",
-          "value": null
-        },
-        {
-          "id": "project_owner",
-          "text": "",
-          "type": "people",
-          "value": null
-        },
-        {
-          "id": "project_status",
-          "text": "Not Started",
-          "type": "status",
-          "value": null
-        },
-        {
-          "id": "date",
-          "text": "",
-          "type": "date",
-          "value": null
-        },
-        {
-          "id": "tags_mkmy3r3g",
-          "text": "",
-          "type": "tags",
-          "value": null
-        }
-      ],
-      "created_at": "2025-02-24T02:14:12Z",
-      "creator_id": "71985416",
-      "group": {
-        "id": "new_group29179"
-      },
-      "id": "8547821762",
-      "name": "Parent Item 2",
-      "parent_item": null,
-      "state": "active",
-      "subitems": [
-        {
-          "assets": [],
-          "board": {
-            "id": "8483610893",
-            "name": "Subitems of Estuary"
-          },
-          "column_values": [
-            {
-              "id": "person",
-              "text": "",
-              "type": "people",
-              "value": null
-            },
-            {
-              "id": "status",
-              "text": null,
-              "type": "status",
-              "value": null
-            },
-            {
-              "id": "date0",
-              "text": "",
-              "type": "date",
-              "value": null
-            }
-          ],
-          "created_at": "2025-02-24T17:14:40Z",
-          "creator_id": "71985416",
-          "group": {
-            "id": "topics"
-          },
-          "id": "8553814342",
-          "name": "test",
-          "parent_item": {
-            "id": "8547821762"
-          },
-          "state": "active",
-          "subscribers": [
-            {
-              "id": "71985416"
-            }
-          ],
-          "updated_at": "2025-02-24T17:14:40Z",
-          "updates": []
-        }
-      ],
-      "subscribers": [
-        {
-          "id": "71985416"
-        }
-      ],
-      "updated_at": "redacted",
-      "updates": []
-    }
-  ],
-  [
-    "acmeCo/items",
-    {
-      "_meta": {
-        "uuid": "DocUUIDPlaceholder-329Bb50aa48EAa9ef"
-      },
-      "assets": [],
-      "board": {
-        "id": "8483610893",
-        "name": "Subitems of Estuary"
-      },
-      "column_values": [
-        {
-          "id": "person",
-          "text": "",
-          "type": "people",
-          "value": null
-        },
-        {
-          "id": "status",
-          "text": null,
-          "type": "status",
-          "value": null
-        },
-        {
-          "id": "date0",
-          "text": "",
-          "type": "date",
-          "value": null
-        }
-      ],
-      "created_at": "2025-02-24T17:14:40Z",
-      "creator_id": "71985416",
-      "group": {
-        "id": "topics"
-      },
-      "id": "8553814342",
-      "name": "test",
-      "parent_item": {
-        "id": "8547821762"
-      },
-      "state": "active",
-      "subitems": [],
-      "subscribers": [
-        {
-          "id": "71985416"
-        }
-      ],
-      "updated_at": "redacted",
-      "updates": []
+      "birthday": null,
+      "country_code": "US",
+      "created_at": "2025-02-07T20:03:21Z",
+      "email": "justin@estuary.dev",
+      "enabled": true,
+      "id": "71985416",
+      "is_admin": true,
+      "is_guest": false,
+      "is_pending": false,
+      "is_verified": true,
+      "is_view_only": false,
+      "join_date": null,
+      "location": null,
+      "mobile_phone": null,
+      "name": "Justin Smith",
+      "phone": "",
+      "photo_original": "https://cdn1.monday.com/dapulse_default_photo.png",
+      "photo_small": "https://cdn1.monday.com/dapulse_default_photo.png",
+      "photo_thumb": "https://cdn1.monday.com/dapulse_default_photo.png",
+      "photo_thumb_small": "https://cdn1.monday.com/dapulse_default_photo.png",
+      "photo_tiny": "https://cdn1.monday.com/dapulse_default_photo.png",
+      "time_zone_identifier": "America/Chicago",
+      "title": null,
+      "url": "https://estuarydev.monday.com/users/71985416",
+      "utc_hours_diff": "redacted"
     }
   ]
 ]

--- a/source-monday/tests/test_snapshots.py
+++ b/source-monday/tests/test_snapshots.py
@@ -17,22 +17,52 @@ def test_capture(request, snapshot):
             "--sessions",
             "1",
             "--delay",
-            "10s",
+            "60s",
         ],
         stdout=subprocess.PIPE,
         text=True,
     )
     assert result.returncode == 0
-    lines = [json.loads(l) for l in result.stdout.splitlines()[:50]]
-
-    for l in lines:
-        _stream, rec = l[0], l[1]
+    
+    lines = [json.loads(l) for l in result.stdout.splitlines()]
+    
+    stream_data = {}
+    for line in lines:
+        stream = line[0]
+        if stream not in stream_data:
+            stream_data[stream] = []
+        stream_data[stream].append(line[1])
+    
+    unique_stream_lines = []
+    for stream in sorted(stream_data.keys()):
+        records = stream_data[stream]
+        if not records:
+            continue
+            
+        # Create a stable sort key that considers multiple fields
+        def sort_key(r):
+            # Primary sort by id if available
+            primary = r.get('id', '')
+            # Secondary sort by name if available
+            secondary = r.get('name', '')
+            # Tertiary sort by board.id for items
+            tertiary = r.get('board', {}).get('id', '') if 'board' in r else ''
+            return (primary, secondary, tertiary)
+        
+        # Sort all records with the stable key
+        records.sort(key=sort_key)
+        
+        # Always take the first record after sorting
+        unique_stream_lines.append([stream, records[0]])
+    
+    for line in unique_stream_lines:
+        _stream, rec = line[0], line[1]
 
         for field in FIELDS_TO_REDACT:
             if field in rec:
                 rec[field] = 'redacted'
 
-    assert snapshot("stdout.json") == lines
+    assert snapshot("stdout.json") == unique_stream_lines
 
 
 def test_discover(request, snapshot):


### PR DESCRIPTION
**Description:**

This PR updates `source-monday` to handle `active` and `archived` boards and items. Previously this was defaulting to `active` only.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2900)
<!-- Reviewable:end -->
