### PR TITLE
materialize-kafka: implement explicit delivery confirmation with fail-fast semantics

### DIFF
--- a/materialize-kafka/README.md
+++ b/materialize-kafka/README.md
@@ -1,0 +1,95 @@
+# Materialize Kafka
+
+A Flow materialization connector that publishes Flow collection documents to Apache Kafka topics as JSON or Avro messages.
+
+## What it does
+
+This connector materializes Flow collections into Kafka topics, supporting both JSON and Avro message formats. It handles:
+
+- **Topic Management**: Automatically creates topics with configurable partitions and replication factor
+- **Message Encoding**: Supports JSON and Avro formats with schema registry integration
+- **Authentication**: SASL authentication with multiple mechanisms (PLAIN, SCRAM-SHA-256, SCRAM-SHA-512)
+- **TLS/SSL**: Secure connections using system certificates
+- **Key Handling**: Materializes collection keys as Kafka message keys for proper partitioning
+
+## Architecture
+
+Built in Rust using the `rdkafka` crate, the connector implements the Flow materialization protocol:
+
+- **Protocol Handler** (`lib.rs`): Main entry point handling spec/validate/apply/open requests
+- **Configuration** (`configuration.rs`): Endpoint and resource configuration with JSON schema definitions
+- **Validation** (`validate.rs`): Connectivity checks and field constraint validation
+- **Application** (`apply.rs`): Topic creation and management
+- **Transaction Processing** (`transactor.rs`): Real-time message publishing with Flow protocol handling
+- **Schema Management** (`binding_info.rs`): Avro schema generation and registry integration
+
+### Protocol Implementation
+
+Implements Flow materialization protocol v3032023 with delta updates mode enabled. The transaction lifecycle:
+
+1. **Spec**: Returns configuration schemas and connector metadata
+2. **Validate**: Checks Kafka/schema registry connectivity, returns field constraints
+3. **Apply**: Creates missing Kafka topics (idempotent)
+4. **Open**: Begins transaction processing
+5. **Transaction Cycle**:
+   - **Flush**: Signals end of load phase (no-op for Kafka)
+   - **Store**: Documents immediately published as Kafka messages with delivery tracking
+   - **StartCommit**: Explicit delivery confirmations awaited (fail-fast on errors)
+   - **Acknowledge**: Transaction completion confirmed
+
+### Delivery Guarantees
+
+The connector uses a custom `AckTrackingContext` to ensure strong delivery guarantees:
+
+- **Producer Configuration**: Sets `acks=-1` (all in-sync replicas) and `enable.idempotence=true`  
+- **Explicit ACK Tracking**: Tracks pending vs. completed message deliveries with monotonic counters
+- **Fail-Fast Semantics**: `StartCommit` fails immediately on first delivery failure
+- **Guaranteed Delivery**: `StartCommit` only sent after ALL messages confirmed delivered
+- **Error Propagation**: Returns actual `KafkaError` details for proper error handling
+- **Timeout Visibility**: Uses default 5-minute message timeout to surface operational issues
+
+This eliminates the need for `producer.flush()` and provides stronger consistency than flush-only approaches, which only wait for messages to be sent, not confirmed delivered.
+
+### Delta Updates Mode
+
+The connector operates in delta updates mode, meaning it only processes document changes within each transaction without loading existing documents. This is optimal for Kafka's append-only semantics where the Load/Loaded protocol phases are skipped.
+
+### Message Flow
+
+Collection documents are converted to Kafka messages:
+- Keys from Flow collection keys for proper partitioning
+- Values from selected fields plus optional root document
+- JSON or Avro encoding based on configuration
+
+### Limitations
+
+- Avro format requires a schema registry
+- Schema subjects use a hash-based naming strategy (`{topic}-{schema_hash}`)
+- No support for custom partitioning strategies beyond key-based
+- Root document fields are always serialized as strings in Avro
+
+## Essential Types
+
+### EndpointConfig
+- `bootstrap_servers`: Kafka cluster connection string
+- `credentials`: Optional SASL authentication
+- `tls`: TLS configuration 
+- `message_format`: JSON or Avro
+- `schema_registry`: Required for Avro format
+- `topic_partitions`/`topic_replication_factor`: Topic creation settings
+
+### Resource  
+- `topic`: Target Kafka topic name
+
+### BindingInfo
+Runtime binding state including topic name, Avro schemas (if applicable), key pointers, and field names.
+
+## Getting Started
+
+1. **Build**: `cargo build --release`
+2. **Test**: `cargo test` 
+3. **Docker**: `docker build -t materialize-kafka .`
+
+The connector expects Flow protocol messages on stdin and responds on stdout. Use `flowctl` for local development and testing.
+
+For Avro format, ensure your schema registry is accessible and credentials are properly configured. JSON format works without additional dependencies.

--- a/materialize-kafka/src/apply.rs
+++ b/materialize-kafka/src/apply.rs
@@ -65,7 +65,7 @@ pub async fn do_apply(req: Apply) -> Result<String> {
         .into_iter()
         .filter_map(|res| match res {
             Ok(t) => Some(Ok(t)),
-            Err((_, err_code)) if err_code == RDKafkaErrorCode::TopicAlreadyExists => None,
+            Err((_, RDKafkaErrorCode::TopicAlreadyExists)) => None,
             Err((err_msg, err_code)) => Some(Err(anyhow::anyhow!(
                 "failed to create topic: {} (code {})",
                 err_msg,

--- a/materialize-kafka/tests/snapshots/test__spec.snap
+++ b/materialize-kafka/tests/snapshots/test__spec.snap
@@ -12,6 +12,20 @@ expression: "serde_json::to_string_pretty(&got).unwrap()"
         "title": "Bootstrap Servers",
         "type": "string"
       },
+      "compression": {
+        "default": "lz4",
+        "description": "Compression algorithm to use for messages. Note that not all Kafka brokers support all compression algorithms.",
+        "enum": [
+          "none",
+          "gzip",
+          "lz4",
+          "snappy",
+          "zstd"
+        ],
+        "order": 4,
+        "title": "Compression",
+        "type": "string"
+      },
       "credentials": {
         "description": "The connection details for authenticating a client connection to Kafka via SASL. When not provided, the client connection will attempt to use PLAINTEXT (insecure) protocol. This must only be used in dev/test environments.",
         "discriminator": {
@@ -75,7 +89,7 @@ expression: "serde_json::to_string_pretty(&got).unwrap()"
       },
       "schema_registry": {
         "description": "Connection details for interacting with a schema registry. This is necessary for materializing messages with Avro encoding.",
-        "order": 4,
+        "order": 5,
         "properties": {
           "endpoint": {
             "description": "Schema registry API endpoint. For example: https://registry-id.us-east-2.aws.confluent.cloud",
@@ -118,14 +132,14 @@ expression: "serde_json::to_string_pretty(&got).unwrap()"
       "topic_partitions": {
         "default": 6,
         "description": "The number of partitions to create new topics with.",
-        "order": 5,
+        "order": 6,
         "title": "Topic Partitions",
         "type": "integer"
       },
       "topic_replication_factor": {
         "default": 3,
         "description": "The replication factor to create new topics with.",
-        "order": 6,
+        "order": 7,
         "title": "Topic Replication Factor",
         "type": "integer"
       }

--- a/materialize-kafka/tests/test.flow.yaml
+++ b/materialize-kafka/tests/test.flow.yaml
@@ -11,6 +11,7 @@ materializations:
           topic_partitions: 3
           topic_replication_factor: 1
           message_format: Avro
+          compression: none
           schema_registry:
             schema_registry_type: confluent_schema_registry
             endpoint: http://localhost:8081
@@ -38,6 +39,7 @@ materializations:
           topic_partitions: 3
           topic_replication_factor: 1
           message_format: JSON
+          compression: gzip
     bindings:
       - resource:
           topic: test_topic_json_1

--- a/tests/materialize/materialize-kafka/setup.sh
+++ b/tests/materialize/materialize-kafka/setup.sh
@@ -9,7 +9,8 @@ config_json_template='{
     "bootstrap_servers": "materialize-kafka-db-1.flow-test:9092",
     "topic_partitions": 3,
     "topic_replication_factor": 1,
-    "message_format": "JSON"
+    "message_format": "JSON",
+    "compression": "lz4"
 }'
 
 resources_json_template='[


### PR DESCRIPTION
Replace producer.flush() with custom AckTrackingContext that provides:
- Explicit delivery confirmation via ProducerContext callbacks
- Fail-fast on first delivery failure with proper error propagation
- Enhanced producer config (acks=-1, enable.idempotence=true)

This eliminates silent failures during broker instability by ensuring
StartCommit only proceeds after confirmed delivery of ALL messages.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2901)
<!-- Reviewable:end -->
