### PR TITLE
source-oracle-batch: use patched go-ora to avoid warning stdout

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -286,3 +286,5 @@ require (
 	gotest.tools/gotestsum v1.8.2 // indirect
 	nhooyr.io/websocket v1.8.7 // indirect
 )
+
+replace github.com/sijms/go-ora/v2 => github.com/mdibaiee/go-ora/v2 v2.8.25-0.20250609184222-7728c3757554

--- a/go.sum
+++ b/go.sum
@@ -754,6 +754,8 @@ github.com/mattn/go-sqlite3 v1.14.22/go.mod h1:Uh1q+B4BYcTPb+yiD3kU8Ct7aC0hY9fxU
 github.com/mattn/go-sqlite3 v2.0.3+incompatible h1:gXHsfypPkaMZrKbD5209QV9jbUTJKjyR5WD3HYQSd+U=
 github.com/mattn/go-sqlite3 v2.0.3+incompatible/go.mod h1:FPy6KqzDD04eiIsT53CuJW3U88zkxoIYsOqkbpncsNc=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
+github.com/mdibaiee/go-ora/v2 v2.8.25-0.20250609184222-7728c3757554 h1:MBB3wLazCXsQzlTDjV9K+RLv8tzZ9qk7HOBuetjrgwQ=
+github.com/mdibaiee/go-ora/v2 v2.8.25-0.20250609184222-7728c3757554/go.mod h1:QgFInVi3ZWyqAiJwzBQA+nbKYKH77tdp1PYoCqhR2dU=
 github.com/microsoft/go-mssqldb v1.8.0 h1:7cyZ/AT7ycDsEoWPIXibd+aVKFtteUNhDGf3aobP+tw=
 github.com/microsoft/go-mssqldb v1.8.0/go.mod h1:6znkekS3T2vp0waiMhen4GPU1BiAsrP+iXHcE7a7rFo=
 github.com/minio/asm2plan9s v0.0.0-20200509001527-cdd76441f9d8 h1:AMFGa4R4MiIpspGNG7Z948v4n35fFGB3RR3G/ry4FWs=
@@ -896,8 +898,6 @@ github.com/siddontang/go-log v0.0.0-20190221022429-1e957dd83bed h1:KMgQoLJGCq1Io
 github.com/siddontang/go-log v0.0.0-20190221022429-1e957dd83bed/go.mod h1:yFdBgwXP24JziuRl2NMUahT7nGLNOKi1SIiFxMttVD4=
 github.com/siddontang/goredis v0.0.0-20150324035039-760763f78400/go.mod h1:DDcKzU3qCuvj/tPnimWSsZZzvk9qvkvrIL5naVBPh5s=
 github.com/siddontang/rdb v0.0.0-20150307021120-fc89ed2e418d/go.mod h1:AMEsy7v5z92TR1JKMkLLoaOQk++LVnOKL3ScbJ8GNGA=
-github.com/sijms/go-ora/v2 v2.8.19 h1:7LoKZatDYGi18mkpQTR/gQvG9yOdtc7hPAex96Bqisc=
-github.com/sijms/go-ora/v2 v2.8.19/go.mod h1:EHxlY6x7y9HAsdfumurRfTd+v8NrEOTR3Xl4FWlH6xk=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
 github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ=

--- a/source-oracle-batch/driver.go
+++ b/source-oracle-batch/driver.go
@@ -56,7 +56,7 @@ const (
 
 	// Maximum number of concurrent polling operations to run at once. Might be
 	// worth making this configurable in the advanced endpoint settings.
-	maxConcurrentQueries = 1
+	maxConcurrentQueries = 5
 )
 
 // BatchSQLDriver represents a generic "batch SQL" capture behavior, parameterized


### PR DESCRIPTION
**Description:**

- The go-ora library we use was outputting warning lines to stdout, breaking flow runtime message format. Updated the library in a fork (see https://github.com/sijms/go-ora/pull/679) to output those warnings to stderr instead. Tested this locally

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2904)
<!-- Reviewable:end -->
