### PR TITLE
source-shopify-native: show `AccessToken` as first option under "Authentication"

### DIFF
--- a/source-shopify-native/source_shopify_native/models.py
+++ b/source-shopify-native/source_shopify_native/models.py
@@ -83,7 +83,7 @@ class EndpointConfig(BaseModel):
         title="Shopify Store",
         description="Shopify store ID. Use the prefix of your admin URL e.g. https://{YOUR_STORE}.myshopify.com/admin",
     )
-    credentials: OAuth2Credentials | AccessToken = Field(
+    credentials: AccessToken | OAuth2Credentials = Field(
         discriminator="credentials_title",
         title="Authentication",
     )

--- a/source-shopify-native/tests/snapshots/snapshots__spec__capture.stdout.json
+++ b/source-shopify-native/tests/snapshots/snapshots__spec__capture.stdout.json
@@ -86,10 +86,10 @@
           },
           "oneOf": [
             {
-              "$ref": "#/$defs/_OAuth2Credentials"
+              "$ref": "#/$defs/AccessToken"
             },
             {
-              "$ref": "#/$defs/AccessToken"
+              "$ref": "#/$defs/_OAuth2Credentials"
             }
           ],
           "title": "Authentication"


### PR DESCRIPTION
**Description:**

Until our Shopify OAuth app is ready & the OAuth authentication option works, show the `AccessToken` auth option first.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

Confirmed on a local stack that the `AccessToken` option shows up first instead of OAuth.

![image](https://github.com/user-attachments/assets/9d34986b-0f98-4f66-8de6-348d76fb2cff)


<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2905)
<!-- Reviewable:end -->
