### PR TITLE
materialize-snowflake: make JWT auth the default

### DIFF
--- a/materialize-snowflake/.snapshots/TestSpecification
+++ b/materialize-snowflake/.snapshots/TestSpecification
@@ -53,34 +53,6 @@
             "properties": {
               "auth_type": {
                 "type": "string",
-                "const": "user_password",
-                "default": "user_password"
-              },
-              "user": {
-                "type": "string",
-                "title": "User",
-                "description": "The Snowflake user login name",
-                "order": 1
-              },
-              "password": {
-                "type": "string",
-                "title": "Password",
-                "description": "The password for the provided user",
-                "order": 2,
-                "secret": true
-              }
-            },
-            "required": [
-              "auth_type",
-              "user",
-              "password"
-            ],
-            "title": "User Password"
-          },
-          {
-            "properties": {
-              "auth_type": {
-                "type": "string",
                 "const": "jwt",
                 "default": "jwt"
               },
@@ -104,12 +76,40 @@
               "private_key"
             ],
             "title": "Private Key (JWT)"
+          },
+          {
+            "properties": {
+              "auth_type": {
+                "type": "string",
+                "const": "user_password",
+                "default": "user_password"
+              },
+              "user": {
+                "type": "string",
+                "title": "User",
+                "description": "The Snowflake user login name",
+                "order": 1
+              },
+              "password": {
+                "type": "string",
+                "title": "Password",
+                "description": "The password for the provided user",
+                "order": 2,
+                "secret": true
+              }
+            },
+            "required": [
+              "auth_type",
+              "user",
+              "password"
+            ],
+            "title": "User Password"
           }
         ],
         "type": "object",
         "title": "Authentication",
         "default": {
-          "auth_type": "user_password"
+          "auth_type": "jwt"
         },
         "discriminator": {
           "propertyName": "auth_type"

--- a/materialize-snowflake/client.go
+++ b/materialize-snowflake/client.go
@@ -271,6 +271,10 @@ func preReqs(ctx context.Context, conf any, tenant string) *cerrors.PrereqErr {
 			case 390189:
 				err = fmt.Errorf("role %q does not exist", cfg.Role)
 			}
+
+			if strings.Contains(sfError.Message, "MFA with TOTP is required.") {
+				err = fmt.Errorf("username/password authentication is not supported for your account - try a different authentication method")
+			}
 		}
 
 		errs.Err(err)

--- a/materialize-snowflake/config.go
+++ b/materialize-snowflake/config.go
@@ -270,17 +270,17 @@ func (credentialConfig) JSONSchema() *jsonschema.Schema {
 	return &jsonschema.Schema{
 		Title:       "Authentication",
 		Description: "Snowflake Credentials",
-		Default:     map[string]string{"auth_type": UserPass},
+		Default:     map[string]string{"auth_type": JWT},
 		OneOf: []*jsonschema.Schema{
-			{
-				Title:      "User Password",
-				Required:   []string{"auth_type", "user", "password"},
-				Properties: uProps,
-			},
 			{
 				Title:      "Private Key (JWT)",
 				Required:   []string{"auth_type", "private_key"},
 				Properties: jwtProps,
+			},
+			{
+				Title:      "User Password",
+				Required:   []string{"auth_type", "user", "password"},
+				Properties: uProps,
 			},
 		},
 		Extras: map[string]interface{}{


### PR DESCRIPTION
**Description:**

Snowflake has deprecated support for username/password authentication, and attempting to use username/password auth with a non-legacy account spits out an error message complaining about MFA & TOTP. Instead of trying that, users should just use JWT authentication. When we receive that MFA/TOTP error, we intercept it & provide a nicer error message pushing users in the JWT auth direction.

Additionally, JWT auth is the default option when users try to create a materialization, so hopefully that also pushes folks down the JWT auth path.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

Tested on a local stack. Confirmed JWT auth is the default option already selected when creating a materialization.
![image](https://github.com/user-attachments/assets/6bac3af5-eaaa-4a10-80b1-4e4f394b320c)

The full error message from Snowflake that we now intercept is `MFA with TOTP is required. To authenticate, provide both your password and a current TOTP passcode.` I wasn't able to test out the error interception change - my Snowflake account already had MFA authentication set up. Snowflake's docs also don't specify what the error code is for that error. The simple `strings.Contains` check should work for now though, especially since we plan on removing username/password authentication as an option in the somewhat near future & we won't need this check long-term.
