### PR TITLE
source-google-ads: support custom GAQL streams

### DIFF
--- a/source-google-ads/connector_config.yaml
+++ b/source-google-ads/connector_config.yaml
@@ -6,6 +6,10 @@ credentials:
     refresh_token_sops: ENC[AES256_GCM,data:bNgS+zsZZnTrpn3zbc1V/eRD/WhlUKr7SN42FC3jx5C031SdMR5qtE2MapYRw6Y1f2Kojzj4FZh10b2oRMY8MovrTRx7eNILfNFsWVZwUJe3D0L/ETk1SCMU/BfvOFhfNW3sqcS4AA==,iv:dIT7FRHpn0zcausNIxQzguQO7RC4Rcvu9ycBMOhzOeU=,tag:EuC/r3mrEHqjPTcWDj5Xpw==,type:str]
 customer_id: "6458773721"
 start_date: "2022-01-01"
+custom_queries:
+    - query: SELECT segments.ad_destination_type, segments.ad_network_type, segments.day_of_week, customer.auto_tagging_enabled, customer.id, metrics.conversions, campaign.start_date FROM campaign
+      primary_key: customer.id
+      table_name: my_custom_query
 sops:
     kms: []
     gcp_kms:
@@ -15,8 +19,8 @@ sops:
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2024-02-01T15:12:59Z"
-    mac: ENC[AES256_GCM,data:kuLSbiCpD9A3PkLg4pEVxYWj8PFXXmoYrH/XGVKZcoJgNUlMehvfcrB2XKIfEnE/lEE9jyQNGMMExwXKFyLrSbT4dwR7rkjD3aW1yyoFaSmAcDReQKKkhhXd+vaOIOgvH0Rjap3btyKSF6M5/WjMo/eM15C4l4Z0809d7dzONvI=,iv:c8YHHO36hDWU7AFgChk+tHcE99krMmbo4UcuTGknSY0=,tag:yLyvkC55JnKSzznTN23Gjw==,type:str]
+    lastmodified: "2025-06-11T20:26:18Z"
+    mac: ENC[AES256_GCM,data:ib9b0KKu+2DAQNWCkMo9PbKvy7Rb96nQptk/TvGNAK9RzXuC77zZoAaZtmz9w68M33f128e+6o8XQYXo5K3uA69YUPhU2LpdncQprKjklZIpuKVt5DoUPAoFRAFXqrXu/g53OqCnqOYce3BPAmpDQ55DViRzcH9Vds7/qzvVxqM=,iv:8qMqKbPhk2tmnwlrubW32WAb5eLmHWKjENcnfA7XtlI=,tag:yEVCxLdJ8Ar304phxFsyoA==,type:str]
     pgp: []
     encrypted_suffix: _sops
-    version: 3.7.3
+    version: 3.9.0

--- a/source-google-ads/source_google_ads/custom_query_stream.py
+++ b/source-google-ads/source_google_ads/custom_query_stream.py
@@ -15,14 +15,10 @@ class CustomQueryMixin:
         super().__init__(**kwargs)
 
     @property
-    def primary_key(self) -> str:
-        """
-        The primary_key option is disabled. Config should not provide the primary key.
-        It will be ignored if provided.
-        If you need to enable it, uncomment the next line instead of `return None` and modify your config
-        """
-        # return self.config.get("primary_key") or None
-        return None
+    def primary_key(self) -> list[str]:
+        input = self.config.get("primary_key")
+        keys = input.strip().split(",")
+        return [k.strip() for k in keys]
 
     @property
     def name(self):

--- a/source-google-ads/source_google_ads/source.py
+++ b/source-google-ads/source_google_ads/source.py
@@ -49,7 +49,7 @@ class SourceGoogleAds(AbstractSource):
             config.pop("end_date")
         for query in config.get("custom_queries", []):
             try:
-                query["query"] = GAQL.parse(query["query"])
+                query["query"] = GAQL.parse(str(query["query"]))
             except ValueError:
                 message = f"The custom GAQL query {query['table_name']} failed. Validate your GAQL query with the Google Ads query validator. https://developers.google.com/google-ads/api/fields/v19/query_validator"
                 raise AirbyteTracedException(message=message, failure_type=FailureType.config_error)
@@ -112,8 +112,6 @@ class SourceGoogleAds(AbstractSource):
                             f"Please remove metrics fields in your custom query: {query}."
                         )
                     if query.resource_name not in FULL_REFRESH_CUSTOM_TABLE:
-                        if IncrementalCustomQuery.cursor_field in query.fields:
-                            return False, f"Custom query should not contain {IncrementalCustomQuery.cursor_field}"
                         query = IncrementalCustomQuery.insert_segments_date_expr(query, "1980-01-01", "1980-01-01")
                     query = query.set_limit(1)
                     response = google_api.send_request(str(query), customer_id=customer.id)

--- a/source-google-ads/source_google_ads/spec.json
+++ b/source-google-ads/source_google_ads/spec.json
@@ -89,7 +89,7 @@
         "order": 3,
         "items": {
           "type": "object",
-          "required": ["query", "table_name"],
+          "required": ["query", "table_name", "primary_key"],
           "properties": {
             "query": {
               "type": "string",
@@ -103,6 +103,11 @@
               "type": "string",
               "title": "Destination Table Name",
               "description": "The table name in your destination database for choosen query."
+            },
+            "primary_key": {
+                "type": "string",
+                "title": "Destination Table Primary Key",
+                "description": "The primary key in your destination database. Accepts a comma delimited string of fields present in your query."
             }
           }
         }

--- a/source-google-ads/tests/snapshots/snapshots__discover__capture.stdout.json
+++ b/source-google-ads/tests/snapshots/snapshots__discover__capture.stdout.json
@@ -5348,5 +5348,115 @@
       "/ad_group.id",
       "/ad_group_criterion.criterion_id"
     ]
+  },
+  {
+    "recommendedName": "my_custom_query",
+    "resourceConfig": {
+      "stream": "my_custom_query",
+      "syncMode": "incremental",
+      "cursorField": [
+        "segments.date"
+      ]
+    },
+    "documentSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "segments.ad_destination_type": {
+          "type": "string",
+          "enum": [
+            "APP_DEEP_LINK",
+            "APP_STORE",
+            "LEAD_FORM",
+            "LOCATION_LISTING",
+            "MAP_DIRECTIONS",
+            "MESSAGE",
+            "NOT_APPLICABLE",
+            "PHONE_CALL",
+            "UNKNOWN",
+            "UNMODELED_FOR_CONVERSIONS",
+            "UNSPECIFIED",
+            "WEBSITE",
+            "YOUTUBE"
+          ]
+        },
+        "segments.ad_network_type": {
+          "type": "string",
+          "enum": [
+            "CONTENT",
+            "GOOGLE_OWNED_CHANNELS",
+            "GOOGLE_TV",
+            "MIXED",
+            "SEARCH",
+            "SEARCH_PARTNERS",
+            "UNKNOWN",
+            "UNSPECIFIED",
+            "YOUTUBE"
+          ]
+        },
+        "segments.day_of_week": {
+          "type": "string",
+          "enum": [
+            "FRIDAY",
+            "MONDAY",
+            "SATURDAY",
+            "SUNDAY",
+            "THURSDAY",
+            "TUESDAY",
+            "UNKNOWN",
+            "UNSPECIFIED",
+            "WEDNESDAY"
+          ]
+        },
+        "customer.auto_tagging_enabled": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "customer.id": {
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "metrics.conversions": {
+          "type": [
+            "number",
+            "null"
+          ]
+        },
+        "campaign.start_date": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "format": "date"
+        },
+        "segments.date": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "format": "date"
+        },
+        "_meta": {
+          "type": "object",
+          "properties": {
+            "row_id": {
+              "type": "integer"
+            }
+          },
+          "required": [
+            "row_id"
+          ]
+        }
+      },
+      "additionalProperties": true,
+      "x-infer-schema": true
+    },
+    "key": [
+      "/customer.id"
+    ]
   }
 ]

--- a/source-google-ads/tests/snapshots/snapshots__spec__capture.stdout.json
+++ b/source-google-ads/tests/snapshots/snapshots__spec__capture.stdout.json
@@ -102,7 +102,8 @@
             "type": "object",
             "required": [
               "query",
-              "table_name"
+              "table_name",
+              "primary_key"
             ],
             "properties": {
               "query": {
@@ -117,6 +118,11 @@
                 "type": "string",
                 "title": "Destination Table Name",
                 "description": "The table name in your destination database for choosen query."
+              },
+              "primary_key": {
+                "type": "string",
+                "title": "Destination Table Primary Key",
+                "description": "The primary key in your destination database. Accepts a comma delimited string of fields present in your query."
               }
             }
           }


### PR DESCRIPTION
**Description:**

Custom GAQL streams didn't work with Flow because no primary keys were specified for them. This PR adds a `primary_key` field for every custom GAQL stream so users can specify what the primary keys are & successfully set up custom GAQL streams.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

Connector docs should be updated with the new custom GAQL stream config.

**Notes for reviewers:**

Tested on a local stack. Confirmed a custom GAQL stream works & runs incrementally.

