### PR TITLE
materialize: add folded field constraint support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,7 @@ require (
 	github.com/databricks/databricks-sql-go v1.6.2-0.20250318155202-2a39cfaf0c27
 	github.com/dropbox/dropbox-sdk-go-unofficial/v6 v6.0.5
 	github.com/elastic/go-elasticsearch/v8 v8.9.0
-	github.com/estuary/flow v0.5.13
+	github.com/estuary/flow v0.5.16-0.20250611214225-05aeefebe274
 	github.com/estuary/vitess v0.15.10
 	github.com/evanphx/json-patch/v5 v5.9.0
 	github.com/firebolt-db/firebolt-go-sdk v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -390,8 +390,8 @@ github.com/envoyproxy/go-control-plane/ratelimit v0.1.0/go.mod h1:Wk+tMFAFbCXaJP
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/envoyproxy/protoc-gen-validate v1.2.1 h1:DEo3O99U8j4hBFwbJfrz9VtgcDfUKS7KJ7spH3d86P8=
 github.com/envoyproxy/protoc-gen-validate v1.2.1/go.mod h1:d/C80l/jxXLdfEIhX1W2TmLfsJ31lvEjwamM4DxlWXU=
-github.com/estuary/flow v0.5.13 h1:O1UVJn0AnAUgXwyK2JR0eGTlbbo44vvwiCTLQzAG1TQ=
-github.com/estuary/flow v0.5.13/go.mod h1:JScLFw4Y8hTvxTsmKgfi7mKvmfcsb38YbU4ZDtRM8DY=
+github.com/estuary/flow v0.5.16-0.20250611214225-05aeefebe274 h1:yf4HVRqyegp1Fm/Xkuzz0ZEFxvdJ9pUc67MGHsxwYVM=
+github.com/estuary/flow v0.5.16-0.20250611214225-05aeefebe274/go.mod h1:JScLFw4Y8hTvxTsmKgfi7mKvmfcsb38YbU4ZDtRM8DY=
 github.com/estuary/vitess v0.15.10 h1:oXJgcG0HGZWuwjdvSp4pIFIAXtKLaR9Fl9VBynSszFA=
 github.com/estuary/vitess v0.15.10/go.mod h1:rSIE8UMfexjblBloleGw6BqQIKggGmU91TduCNIaJEA=
 github.com/evanphx/json-patch/v5 v5.9.0 h1:kcBlZQbplgElYIlo/n1hJbls2z/1awpXxpRi0/FOJfg=

--- a/materialize-boilerplate/validate.go
+++ b/materialize-boilerplate/validate.go
@@ -134,6 +134,14 @@ func (v Validator) ValidateBinding(
 		}
 	}
 
+	// Set folded field for each constraint where field translation changes the field name.
+	// This applies to both new and existing fields, ensuring complete coverage.
+	for field, constraint := range constraints {
+		if t := v.is.translateField(field); t != field {
+			constraint.FoldedField = t
+		}
+	}
+
 	return forbidLongFields(v.maxFieldLength, boundCollection, constraints)
 }
 


### PR DESCRIPTION
Implement folded field support in materialization connectors by setting the
FoldedField constraint when field names would be transformed during validation.

This enables proper field mapping when column names are modified by dialect-
specific transformations like case conversion or character translation.

A future control plane change will enforce disambiguation of folded
fields.

**Workflow steps:**

- FoldedField is now populated in Validated responses

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2928)
<!-- Reviewable:end -->
