### PR TITLE
materialize-bigquery: configuration for disabling field truncation

### DIFF
--- a/materialize-bigquery/.snapshots/TestSpecification
+++ b/materialize-bigquery/.snapshots/TestSpecification
@@ -163,6 +163,11 @@
       },
       "advanced": {
         "properties": {
+          "disableFieldTruncation": {
+            "type": "boolean",
+            "title": "Disable Field Truncation",
+            "description": "Disables truncation of materialized fields. May result in errors for documents with extremely large values or complex nested structures."
+          },
           "feature_flags": {
             "type": "string",
             "title": "Feature Flags",

--- a/materialize-snowflake/.snapshots/TestSpecification
+++ b/materialize-snowflake/.snapshots/TestSpecification
@@ -227,7 +227,7 @@
           "disableFieldTruncation": {
             "type": "boolean",
             "title": "Disable Field Truncation",
-            "description": "Disables truncation of materialized fields. May result in errors when loading data into Snowflake for documents with extremely large values or complex nested structures."
+            "description": "Disables truncation of materialized fields. May result in errors for documents with extremely large values or complex nested structures."
           },
           "feature_flags": {
             "type": "string",

--- a/materialize-snowflake/config.go
+++ b/materialize-snowflake/config.go
@@ -39,7 +39,7 @@ type config struct {
 }
 
 type advancedConfig struct {
-	DisableFieldTruncation bool   `json:"disableFieldTruncation,omitempty" jsonschema:"title=Disable Field Truncation,description=Disables truncation of materialized fields. May result in errors when loading data into Snowflake for documents with extremely large values or complex nested structures."`
+	DisableFieldTruncation bool   `json:"disableFieldTruncation,omitempty" jsonschema:"title=Disable Field Truncation,description=Disables truncation of materialized fields. May result in errors for documents with extremely large values or complex nested structures."`
 	FeatureFlags           string `json:"feature_flags,omitempty" jsonschema:"title=Feature Flags,description=This property is intended for Estuary internal use. You should only modify this field as directed by Estuary support."`
 }
 


### PR DESCRIPTION
**Description:**

Adds a similar option as what was recently added for materialize-snowflake.

The BigQuery truncation behavior was a little more generous than the standard limits. Truncation is needed for BigQuery because you can't load a row that is larger than 20MiB through a normal query, so rows can't be arbitrarily large.

But most of the time a row will be smaller than that, so disabling truncation is a reasonable thing to do.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2935)
<!-- Reviewable:end -->
