### PR TITLE
source-monday: enhance error handling and boards Pydantic model

### DIFF
--- a/source-monday/source_monday/models.py
+++ b/source-monday/source_monday/models.py
@@ -69,10 +69,11 @@ class EndpointConfig(BaseModel):
         limit: Annotated[
             int,
             Field(
-                description="Limit used in queries for incremental streams. This should be left as the default value unless connector errors indicate a smaller limit is required.",
+                description="Limit used in queries for incremental streams. For items, this can be up to 500. For other resources, the limit may be lower. This should be left as the default value unless connector errors indicate a smaller limit is required.",
                 title="Limit",
-                default=5,
+                default=100,
                 gt=0,
+                le=500,
             ),
         ]
 
@@ -152,7 +153,7 @@ class Board(BaseDocument, extra="allow"):
 
 
 class BoardsResponse(BaseModel, extra="forbid"):
-    boards: list[Board]
+    boards: list[Board] | None = None
 
 
 class ParentItemRef(BaseModel, extra="allow"):

--- a/source-monday/tests/snapshots/snapshots__spec__stdout.json
+++ b/source-monday/tests/snapshots/snapshots__spec__stdout.json
@@ -27,9 +27,10 @@
           "additionalProperties": false,
           "properties": {
             "limit": {
-              "default": 5,
-              "description": "Limit used in queries for incremental streams. This should be left as the default value unless connector errors indicate a smaller limit is required.",
+              "default": 100,
+              "description": "Limit used in queries for incremental streams. For items, this can be up to 500. For other resources, the limit may be lower. This should be left as the default value unless connector errors indicate a smaller limit is required.",
               "exclusiveMinimum": 0,
+              "maximum": 500,
               "title": "Limit",
               "type": "integer"
             }


### PR DESCRIPTION
**Description:**

The `source-monday` connector has shown to miss boards during backfill. In testing, I found that the query to get `boards` may return nothing if there are no boards to get. This would fail before due to the Pydantic model type being wrong. I've updated this and added a few more updates for error handling.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

- _Tested locally - I was able to see all the boards captured in a backfill without any issues. I am not confident this fixes everything, but it seems this does fix the boards backfilll issue._

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2937)
<!-- Reviewable:end -->
