### PR TITLE
source-mysql: Fix MySQL enum discovery

### DIFF
--- a/source-mysql/.snapshots/TestTrickyEnumValues
+++ b/source-mysql/.snapshots/TestTrickyEnumValues
@@ -1,0 +1,147 @@
+Binding 0:
+{
+    "recommended_name": "test/trickyenumvalues_752804",
+    "resource_config_json": {
+      "namespace": "test",
+      "stream": "TrickyEnumValues_752804"
+    },
+    "document_schema_json": {
+      "$defs": {
+        "TestTrickyEnumValues_752804": {
+          "type": "object",
+          "required": [
+            "id"
+          ],
+          "$anchor": "TestTrickyEnumValues_752804",
+          "properties": {
+            "category": {
+              "description": "(source type: enum)",
+              "enum": [
+                "",
+                "A",
+                "B (Parentheses)",
+                "",
+                "Internal'Quote",
+                "Internal,Comma",
+                "Internal\nNewline",
+                "Internal;Semicolon",
+                "   Leading Spaces",
+                "Trailing Spaces",
+                "Z",
+                null
+              ],
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "id": {
+              "type": "integer",
+              "description": "(source type: non-nullable int)"
+            }
+          }
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "_meta": {
+                "properties": {
+                  "op": {
+                    "const": "d"
+                  }
+                }
+              }
+            }
+          },
+          "then": {
+            "reduce": {
+              "delete": true,
+              "strategy": "merge"
+            }
+          },
+          "else": {
+            "reduce": {
+              "strategy": "merge"
+            }
+          },
+          "required": [
+            "_meta"
+          ],
+          "properties": {
+            "_meta": {
+              "type": "object",
+              "required": [
+                "op",
+                "source"
+              ],
+              "properties": {
+                "before": {
+                  "$ref": "#TestTrickyEnumValues_752804",
+                  "description": "Record state immediately before this change was applied.",
+                  "reduce": {
+                    "strategy": "firstWriteWins"
+                  }
+                },
+                "op": {
+                  "enum": [
+                    "c",
+                    "d",
+                    "u"
+                  ],
+                  "description": "Change operation type: 'c' Create/Insert, 'u' Update, 'd' Delete."
+                },
+                "source": {
+                  "$id": "https://github.com/estuary/connectors/source-mysql/mysql-source-info",
+                  "properties": {
+                    "ts_ms": {
+                      "type": "integer",
+                      "description": "Unix timestamp (in millis) at which this event was recorded by the database."
+                    },
+                    "schema": {
+                      "type": "string",
+                      "description": "Database schema (namespace) of the event."
+                    },
+                    "snapshot": {
+                      "type": "boolean",
+                      "description": "Snapshot is true if the record was produced from an initial table backfill and unset if produced from the replication log."
+                    },
+                    "table": {
+                      "type": "string",
+                      "description": "Database table of the event."
+                    },
+                    "cursor": {
+                      "type": "string",
+                      "description": "Cursor value representing the current position in the binlog."
+                    },
+                    "txid": {
+                      "type": "string",
+                      "description": "The global transaction identifier associated with a change by MySQL. Only set if GTIDs are enabled."
+                    }
+                  },
+                  "type": "object",
+                  "required": [
+                    "schema",
+                    "table",
+                    "cursor"
+                  ]
+                }
+              },
+              "reduce": {
+                "strategy": "merge"
+              }
+            }
+          }
+        },
+        {
+          "$ref": "#TestTrickyEnumValues_752804"
+        }
+      ],
+      "x-infer-schema": true
+    },
+    "key": [
+      "/id"
+    ]
+  }
+

--- a/source-mysql/discovery_test.go
+++ b/source-mysql/discovery_test.go
@@ -58,3 +58,10 @@ func TestSecondaryIndexDiscovery(t *testing.T) {
 		tb.CaptureSpec(ctx, t).VerifyDiscover(ctx, t, regexp.MustCompile(regexp.QuoteMeta(uniqueString)))
 	})
 }
+
+// TestTrickyEnumValues tests some "gotcha" enum values to make sure the discovery parsing logic is robust.
+func TestTrickyEnumValues(t *testing.T) {
+	var tb, ctx, uniqueID = mysqlTestBackend(t), context.Background(), uniqueTableID(t)
+	tb.CreateTable(ctx, t, uniqueID, `(id INTEGER PRIMARY KEY, category ENUM('A', 'B (Parentheses)', '', 'Internal''Quote', 'Internal,Comma', 'Internal\nNewline', 'Internal;Semicolon', '   Leading Spaces', 'Trailing Spaces   ', 'Z'))`)
+	tb.CaptureSpec(ctx, t).VerifyDiscover(ctx, t, regexp.MustCompile(uniqueID))
+}

--- a/source-mysql/replication.go
+++ b/source-mysql/replication.go
@@ -1068,25 +1068,6 @@ func translateDataType(meta *mysqlTableMetadata, t *sqlparser.ColumnType) any {
 	}
 }
 
-// unquoteEnumValues applies MySQL single-quote-unescaping to a list of single-quoted
-// escaped string values such as the EnumValues list returned by the Vitess SQL Parser
-// package when parsing a DDL query involving enum/set values.
-//
-// The single-quote wrapping and escaping of these strings is clearly deliberate, as
-// under the hood the package actually tokenizes the strings to raw values and then
-// explicitly calls `encodeSQLString()` to re-wrap them when building the AST. The
-// actual reason for doing this is unknown however, and it makes very little sense.
-//
-// So whatever, here's a helper function to undo that escaping and get back down to
-// the raw strings again.
-func unquoteEnumValues(values []string) []string {
-	var unquoted []string
-	for _, qval := range values {
-		unquoted = append(unquoted, unquoteMySQLString(qval))
-	}
-	return unquoted
-}
-
 func resolveTableName(defaultSchema string, name sqlparser.TableName) sqlcapture.StreamID {
 	var schema, table = name.Qualifier.String(), name.Name.String()
 	if schema == "" {


### PR DESCRIPTION
**Description:**

The previous MySQL enum discovery logic was pretty hacky and had several edge cases, one of which a production capture recently ran into. This commit rips that decoding logic out entirely and swaps it out for reusing the same Vitess SQL parser we already use for replication DDL query handling.

There might be a more elegant way to ask it to parse an enum type, but I briefly checked and didn't see one so simply splatting the type definition into a dummy `CREATE TABLE` statement seemed like a decent enough workaround.