### PR TITLE
filesource: don't emit documents/checkpoints concurrently across bindings

### DIFF
--- a/filesource/filesource.go
+++ b/filesource/filesource.go
@@ -452,12 +452,6 @@ func (r *reader) makeParseConfig(obj ObjectInfo) *parser.Config {
 }
 
 func (r *reader) emit(lines []json.RawMessage) error {
-	for _, line := range lines {
-		if err := r.stream.Documents(r.binding, line); err != nil {
-			return err
-		}
-	}
-
 	var statePatch = CaptureState{
 		States: map[boilerplate.StateKey]State{
 			r.stateKey: r.state,
@@ -466,7 +460,7 @@ func (r *reader) emit(lines []json.RawMessage) error {
 
 	if encodedCheckpoint, err := json.Marshal(statePatch); err != nil {
 		return err
-	} else if err := r.stream.Checkpoint(encodedCheckpoint, true); err != nil {
+	} else if err := r.stream.DocumentsAndCheckpoint(encodedCheckpoint, true, r.binding, lines...); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
**Description:**

Added a mutex to the reader struct to synchronize access to the shared PullOutput stream operations across all bindings. This fixes a concurrency issue where multiple bindings could interleave their `Documents()` and `Checkpoint()` calls.

The mutex ensures that when one binding is writing documents or checkpoints, other bindings must wait, maintaining consistency of the output stream.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

We could update our `filesource` based connectors' docs with instructions on how to add multiple bindings with `flowctl` since they won't trample each others' states any more.

**Notes for reviewers:**

This isn't the most efficient solution - we _could_ allow separate bindings to emit documents, make sure the connector's state is always updated with the most recent state for each binding after each document emission (or some other kind of more involved coordination), then checkpoint. But that's a smidge more involved than adding a mutex, and I'd like to see if this works well enough for users' use cases before spending much more time on it.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2945)
<!-- Reviewable:end -->
