### PR TITLE
source-shopify-native: conditionally discover streams that capture PII

### DIFF
--- a/source-shopify-native/source_shopify_native/graphql/abandoned_checkouts.py
+++ b/source-shopify-native/source_shopify_native/graphql/abandoned_checkouts.py
@@ -8,6 +8,7 @@ from ..models import ShopifyGraphQLResource
 
 
 class AbandonedCheckouts(ShopifyGraphQLResource):
+    NAME = "abandoned_checkouts"
     QUERY = """
     id
     abandonedCheckoutUrl

--- a/source-shopify-native/source_shopify_native/graphql/collections/collections.py
+++ b/source-shopify-native/source_shopify_native/graphql/collections/collections.py
@@ -128,6 +128,7 @@ class _Collections(ShopifyGraphQLResource):
 
 
 class CustomCollections(_Collections):
+    NAME = "custom_collections"
     COLLECTION_TYPE = "custom"
 
     @staticmethod
@@ -142,6 +143,7 @@ class CustomCollections(_Collections):
 
 
 class SmartCollections(_Collections):
+    NAME = "smart_collections"
     COLLECTION_TYPE = "smart"
 
     @staticmethod

--- a/source-shopify-native/source_shopify_native/graphql/collections/metafields.py
+++ b/source-shopify-native/source_shopify_native/graphql/collections/metafields.py
@@ -3,6 +3,7 @@ from ..metafields import MetafieldsResource
 
 
 class CustomCollectionMetafields(MetafieldsResource):
+    NAME = "custom_collection_metafields"
     PARENT_ID_KEY = "gid://shopify/Collection/"
 
     @staticmethod
@@ -18,6 +19,7 @@ class CustomCollectionMetafields(MetafieldsResource):
 
 
 class SmartCollectionMetafields(MetafieldsResource):
+    NAME = "smart_collection_metafields"
     PARENT_ID_KEY = "gid://shopify/Collection/"
 
     @staticmethod

--- a/source-shopify-native/source_shopify_native/graphql/customers/customers.py
+++ b/source-shopify-native/source_shopify_native/graphql/customers/customers.py
@@ -6,6 +6,7 @@ from ...models import ShopifyGraphQLResource
 
 
 class Customers(ShopifyGraphQLResource):
+    NAME = "customers"
     QUERY = """
     displayName
     email

--- a/source-shopify-native/source_shopify_native/graphql/customers/metafields.py
+++ b/source-shopify-native/source_shopify_native/graphql/customers/metafields.py
@@ -3,6 +3,7 @@ from ..metafields import MetafieldsResource
 
 
 class CustomerMetafields(MetafieldsResource):
+    NAME = "customer_metafields"
     PARENT_ID_KEY = "gid://shopify/Customer/"
 
     @staticmethod

--- a/source-shopify-native/source_shopify_native/graphql/inventory/inventory_items.py
+++ b/source-shopify-native/source_shopify_native/graphql/inventory/inventory_items.py
@@ -6,6 +6,7 @@ from ...models import ShopifyGraphQLResource
 
 
 class InventoryItems(ShopifyGraphQLResource):
+    NAME = "inventory_items"
     QUERY = """
     id
     legacyResourceId

--- a/source-shopify-native/source_shopify_native/graphql/inventory/inventory_levels.py
+++ b/source-shopify-native/source_shopify_native/graphql/inventory/inventory_levels.py
@@ -7,6 +7,7 @@ from ...models import ShopifyGraphQLResource
 
 
 class InventoryLevels(ShopifyGraphQLResource):
+    NAME = "inventory_levels"
     QUERY = """
     inventoryLevels {
         edges {

--- a/source-shopify-native/source_shopify_native/graphql/locations/locations.py
+++ b/source-shopify-native/source_shopify_native/graphql/locations/locations.py
@@ -6,6 +6,7 @@ from ...models import ShopifyGraphQLResource
 
 
 class Locations(ShopifyGraphQLResource):
+    NAME = "locations"
     QUERY = """
     id
     name

--- a/source-shopify-native/source_shopify_native/graphql/locations/metafields.py
+++ b/source-shopify-native/source_shopify_native/graphql/locations/metafields.py
@@ -3,6 +3,7 @@ from ..metafields import MetafieldsResource
 
 
 class LocationMetafields(MetafieldsResource):
+    NAME = "location_metafields"
     PARENT_ID_KEY = "gid://shopify/Location/"
 
     @staticmethod

--- a/source-shopify-native/source_shopify_native/graphql/orders/agreements.py
+++ b/source-shopify-native/source_shopify_native/graphql/orders/agreements.py
@@ -8,6 +8,7 @@ from ...models import ShopifyGraphQLResource
 
 
 class OrderAgreements(ShopifyGraphQLResource):
+    NAME = "order_agreements"
     QUERY = """
     agreements {
         edges {

--- a/source-shopify-native/source_shopify_native/graphql/orders/fulfillment_orders.py
+++ b/source-shopify-native/source_shopify_native/graphql/orders/fulfillment_orders.py
@@ -7,6 +7,7 @@ from ...models import ShopifyGraphQLResource
 
 
 class FulfillmentOrders(ShopifyGraphQLResource):
+    NAME = "fulfillment_orders"
     QUERY = """
     id
     fulfillmentOrders {

--- a/source-shopify-native/source_shopify_native/graphql/orders/fulfillments.py
+++ b/source-shopify-native/source_shopify_native/graphql/orders/fulfillments.py
@@ -6,6 +6,7 @@ from ...models import ShopifyGraphQLResource
 
 
 class Fulfillments(ShopifyGraphQLResource):
+    NAME = "fulfillments"
     QUERY = """
     fulfillments {
         id

--- a/source-shopify-native/source_shopify_native/graphql/orders/metafields.py
+++ b/source-shopify-native/source_shopify_native/graphql/orders/metafields.py
@@ -3,6 +3,7 @@ from ..metafields import MetafieldsResource
 
 
 class OrderMetafields(MetafieldsResource):
+    NAME = "order_metafields"
     PARENT_ID_KEY = "gid://shopify/Order/"
 
     @staticmethod

--- a/source-shopify-native/source_shopify_native/graphql/orders/orders.py
+++ b/source-shopify-native/source_shopify_native/graphql/orders/orders.py
@@ -8,6 +8,7 @@ from ...models import ShopifyGraphQLResource
 
 
 class Orders(ShopifyGraphQLResource):
+    NAME = "orders"
     QUERY = """
     app {
         id

--- a/source-shopify-native/source_shopify_native/graphql/orders/refunds.py
+++ b/source-shopify-native/source_shopify_native/graphql/orders/refunds.py
@@ -7,6 +7,7 @@ from ...models import ShopifyGraphQLResource
 
 
 class OrderRefunds(ShopifyGraphQLResource):
+    NAME = "order_refunds"
     QUERY = """
     displayFinancialStatus
     displayFulfillmentStatus

--- a/source-shopify-native/source_shopify_native/graphql/orders/risks.py
+++ b/source-shopify-native/source_shopify_native/graphql/orders/risks.py
@@ -6,6 +6,7 @@ from ...models import ShopifyGraphQLResource
 
 
 class OrderRisks(ShopifyGraphQLResource):
+    NAME = "order_risks"
     QUERY = """
     risk {
         recommendation

--- a/source-shopify-native/source_shopify_native/graphql/orders/transactions.py
+++ b/source-shopify-native/source_shopify_native/graphql/orders/transactions.py
@@ -7,6 +7,7 @@ from ...models import ShopifyGraphQLResource
 
 
 class OrderTransactions(ShopifyGraphQLResource):
+    NAME = "order_transactions"
     QUERY = """
     transactions {
         id

--- a/source-shopify-native/source_shopify_native/graphql/products/media.py
+++ b/source-shopify-native/source_shopify_native/graphql/products/media.py
@@ -7,6 +7,7 @@ from source_shopify_native.models import ShopifyGraphQLResource
 
 
 class ProductMedia(ShopifyGraphQLResource):
+    NAME = "product_media"
     QUERY = """
     media(query:"media_type:IMAGE") {
         edges {

--- a/source-shopify-native/source_shopify_native/graphql/products/metafields.py
+++ b/source-shopify-native/source_shopify_native/graphql/products/metafields.py
@@ -3,6 +3,7 @@ from ..metafields import MetafieldsResource
 
 
 class ProductMetafields(MetafieldsResource):
+    NAME = "product_metafields"
     PARENT_ID_KEY = "gid://shopify/Product/"
 
     @staticmethod

--- a/source-shopify-native/source_shopify_native/graphql/products/products.py
+++ b/source-shopify-native/source_shopify_native/graphql/products/products.py
@@ -7,6 +7,7 @@ from source_shopify_native.models import ShopifyGraphQLResource
 
 
 class Products(ShopifyGraphQLResource):
+    NAME = "products"
     QUERY = """
     title
     bodyHtml

--- a/source-shopify-native/source_shopify_native/graphql/products/variants.py
+++ b/source-shopify-native/source_shopify_native/graphql/products/variants.py
@@ -7,6 +7,7 @@ from source_shopify_native.models import ShopifyGraphQLResource
 
 
 class ProductVariants(ShopifyGraphQLResource):
+    NAME = "product_variants"
     QUERY = """
     variants {
         edges {

--- a/source-shopify-native/source_shopify_native/models.py
+++ b/source-shopify-native/source_shopify_native/models.py
@@ -196,9 +196,53 @@ class BulkJobSubmitResponse(BaseModel, extra="allow"):
     data: Data
 
 
+# Names of Shopify plan types. Some plan types do not have access
+# to certain resources (ex: BASIC and STARTER plans cannot access PII, like customer data).
+class PlanName(StrEnum):
+    STARTER = "Starter"
+    BASIC = "Basic"
+    SHOPIFY = "Shopify"
+    ADVANCED = "Advanced"
+    PLUS = "Plus"
+    SHOPIFY_PLUS = "Shopify Plus"
+
+
+class ShopDetails(BaseModel, extra="allow"):
+    class Data(BaseModel, extra="forbid"):
+        class Shop(BaseModel, extra="forbid"):
+            class Plan(BaseModel, extra="forbid"):
+                # The displayName field will be deprecated in the future,
+                # but its replacement publicDisplayName is not available
+                # on the current API version 2025-04.
+                displayName: str
+                partnerDevelopment: bool
+                shopifyPlus: bool
+
+            plan: Plan
+
+        shop: Shop
+
+    data: Data
+
+    @staticmethod
+    def query() -> str:
+        return """
+        {
+            shop {
+                plan {
+                    displayName
+                    partnerDevelopment
+                    shopifyPlus
+                }
+            }
+        }
+        """
+
+
 class ShopifyGraphQLResource(BaseDocument, extra="allow"):
     QUERY: ClassVar[str] = ""
     FRAGMENTS: ClassVar[list[str]] = []
+    NAME: ClassVar[str] = ""  # Add NAME class variable for resource name
 
     id: str
 


### PR DESCRIPTION
**Description:**

Only specific Shopify plans can access PII data that's fetched via the `customers`, `orders`, and `fulfillment_orders` streams. The connector now discovers that stream if the Shopify plan is a Plus or higher account, is a partner development account, or is not one of the known non-PII plans (Basic & Starter) AND the connector is using an access token from the user's custom Shopify app (i.e. not our public OAuth app).

Additionally, the name of each resource was moved into the `ShopifyGraphQLResource` class to reduce a little duplication & make it easier to filter out specific resources after they're instantiated.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

Connector docs could be updated to reflect why `customers` & friends may not be discovered for some users & we could link to Shopify's [documentation](https://help.shopify.com/en/manual/apps/app-types/custom-apps) for the finer details.

**Notes for reviewers:**

Confirmed that when authenticating with an `AccessToken` and a "Basic" Shopify plan, `customers` & friends are not discovered. When authenticating with an `AccessToken` and a non-"Basic" or "Starter" plan, `customers` & friends are discovered.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2948)
<!-- Reviewable:end -->
