### PR TITLE
source-shopify-native: improve bulk job logging

### DIFF
--- a/source-shopify-native/source_shopify_native/api.py
+++ b/source-shopify-native/source_shopify_native/api.py
@@ -24,7 +24,7 @@ async def fetch_incremental(
     end = min(max_end, datetime.now(tz=UTC))
     query = model.build_query(log_cursor, end)
 
-    url = await bulk_job_manager.execute(query)
+    url = await bulk_job_manager.execute(model, query)
 
     if url is None:
         log.info(
@@ -51,7 +51,7 @@ async def fetch_full_refresh(
     end = datetime.now(tz=UTC)
     query = model.build_query(start_date, end)
 
-    url = await bulk_job_manager.execute(query)
+    url = await bulk_job_manager.execute(model, query)
 
     if url is None:
         log.info(

--- a/source-shopify-native/source_shopify_native/models.py
+++ b/source-shopify-native/source_shopify_native/models.py
@@ -242,7 +242,7 @@ class ShopDetails(BaseModel, extra="allow"):
 class ShopifyGraphQLResource(BaseDocument, extra="allow"):
     QUERY: ClassVar[str] = ""
     FRAGMENTS: ClassVar[list[str]] = []
-    NAME: ClassVar[str] = ""  # Add NAME class variable for resource name
+    NAME: ClassVar[str] = ""
 
     id: str
 


### PR DESCRIPTION
**Description:**

Cleaned up some extraneous code & improved logging for bulk jobs - it's now easier to figure out what stream a job belongs to and how long a job has been running. We recently had a capture wait 8+ hours for Shopify to finish a bulk job, and the connector choked on a timeout error shortly afterwards, wasting all that waiting around. It'll be easier to detect this type of situation with the improved logging.

I'd like to re-evaluate the overall logging strategy for the `BulkJobManager` once the connector gets a bit more use; we probably don't need to log out every time the connector sleeps once we have more confidence that it's running correctly.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2959)
<!-- Reviewable:end -->
