### PR TITLE
materialize-bigquery: convert to materialize-sql-v2 and other refactorings

### DIFF
--- a/go/blob/gcs.go
+++ b/go/blob/gcs.go
@@ -79,6 +79,11 @@ func (b *GCSBucket) Delete(ctx context.Context, uris []string) error {
 		}
 		group.Go(func() error {
 			if err := b.client.Bucket(bucket).Object(key).Delete(groupCtx); err != nil {
+				var gErr *googleapi.Error
+				if errors.As(err, &gErr) && gErr.Code == http.StatusNotFound {
+					return nil
+				}
+
 				return fmt.Errorf("deleting blob %q: %w", uri, err)
 			}
 			return nil

--- a/materialize-azure-fabric-warehouse/transactor.go
+++ b/materialize-azure-fabric-warehouse/transactor.go
@@ -43,6 +43,7 @@ type transactor struct {
 
 func newTransactor(
 	ctx context.Context,
+	featureFlags map[string]bool,
 	ep *sql.Endpoint[config],
 	fence sql.Fence,
 	bindings []sql.Table,

--- a/materialize-bigquery/Dockerfile
+++ b/materialize-bigquery/Dockerfile
@@ -17,11 +17,11 @@ COPY flow-bin/flowctl-go /usr/local/bin/flowctl-go
 COPY go                      ./go
 COPY materialize-boilerplate ./materialize-boilerplate
 COPY materialize-bigquery    ./materialize-bigquery
-COPY materialize-sql         ./materialize-sql
+COPY materialize-sql-v2      ./materialize-sql-v2
 COPY testsupport             ./testsupport
 
 # Test and build the connector.
-RUN go test  -tags nozstd -v ./materialize-sql/...
+RUN go test  -tags nozstd -v ./materialize-sql-v2/...
 RUN go test  -tags nozstd -v ./materialize-bigquery/...
 RUN go build -tags nozstd -v -o ./connector ./materialize-bigquery/cmd/connector
 

--- a/materialize-bigquery/bigquery.go
+++ b/materialize-bigquery/bigquery.go
@@ -170,8 +170,7 @@ func newBigQueryDriver() *sql.Driver[config, tableConfig] {
 				"bucket_path": cfg.BucketPath,
 			}).Info("creating bigquery endpoint")
 
-			objAndArrayAsJson := featureFlags["objects_and_arrays_as_json"]
-			dialect := bqDialect(objAndArrayAsJson)
+			dialect := bqDialect(featureFlags["objects_and_arrays_as_json"])
 			templates := renderTemplates(dialect)
 
 			// BigQuery's default SerPolicy has historically had limits of 1500
@@ -192,7 +191,7 @@ func newBigQueryDriver() *sql.Driver[config, tableConfig] {
 				MetaCheckpoints:     sql.FlowCheckpointsTable([]string{cfg.ProjectID, cfg.Dataset}),
 				NewClient:           newClient,
 				CreateTableTemplate: templates.createTargetTable,
-				NewTransactor:       prepareNewTransactor(dialect, templates, objAndArrayAsJson),
+				NewTransactor:       prepareNewTransactor(templates),
 				Tenant:              tenant,
 				ConcurrentApply:     true,
 				Options: boilerplate.MaterializeOptions{

--- a/materialize-bigquery/bigquery.go
+++ b/materialize-bigquery/bigquery.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 
 	"cloud.google.com/go/bigquery"
-	storage "cloud.google.com/go/storage"
 	"github.com/estuary/connectors/go/dbt"
 	boilerplate "github.com/estuary/connectors/materialize-boilerplate"
 	sql "github.com/estuary/connectors/materialize-sql-v2"
@@ -105,16 +104,10 @@ func (c config) client(ctx context.Context, ep *sql.Endpoint[config]) (*client, 
 		return nil, fmt.Errorf("enabling storage read client: %w", err)
 	}
 
-	cloudStorageClient, err := storage.NewClient(ctx, clientOpts...)
-	if err != nil {
-		return nil, fmt.Errorf("creating cloud storage client: %w", err)
-	}
-
 	return &client{
-		bigqueryClient:     bigqueryClient,
-		cloudStorageClient: cloudStorageClient,
-		cfg:                c,
-		ep:                 ep,
+		bigqueryClient: bigqueryClient,
+		cfg:            c,
+		ep:             ep,
 	}, nil
 }
 

--- a/materialize-bigquery/binding.go
+++ b/materialize-bigquery/binding.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 
 	"cloud.google.com/go/bigquery"
-	sql "github.com/estuary/connectors/materialize-sql"
+	sql "github.com/estuary/connectors/materialize-sql-v2"
 )
 
 type binding struct {

--- a/materialize-bigquery/binding.go
+++ b/materialize-bigquery/binding.go
@@ -12,10 +12,9 @@ type binding struct {
 	target         sql.Table
 	storeInsertSQL string
 
-	loadFile         *stagedFile
-	storeFile        *stagedFile
+	loadSchema       bigquery.Schema
+	storeSchema      bigquery.Schema
 	tempTableName    string
-	hasData          bool
 	mustMerge        bool
 	loadMergeBounds  *sql.MergeBoundsBuilder
 	storeMergeBounds *sql.MergeBoundsBuilder

--- a/materialize-bigquery/sqlgen.go
+++ b/materialize-bigquery/sqlgen.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"text/template"
 
-	sql "github.com/estuary/connectors/materialize-sql"
+	sql "github.com/estuary/connectors/materialize-sql-v2"
 	"github.com/estuary/flow/go/protocols/fdb/tuple"
 )
 

--- a/materialize-bigquery/sqlgen_test.go
+++ b/materialize-bigquery/sqlgen_test.go
@@ -5,7 +5,7 @@ import (
 	"text/template"
 
 	"github.com/bradleyjkemp/cupaloy"
-	sql "github.com/estuary/connectors/materialize-sql"
+	sql "github.com/estuary/connectors/materialize-sql-v2"
 	"github.com/stretchr/testify/require"
 )
 
@@ -17,13 +17,8 @@ func TestSQLGeneration(t *testing.T) {
 	snap, tables := sql.RunSqlGenTests(
 		t,
 		testDialect,
-		func(table string, delta bool) sql.Resource {
-			return tableConfig{
-				Table:     table,
-				Delta:     delta,
-				projectID: "projectID",
-				Dataset:   "dataset",
-			}
+		func(table string) []string {
+			return []string{"projectID", "dataset", table}
 		},
 		sql.TestTemplates{
 			TableTemplates: []*template.Template{

--- a/materialize-bigquery/transactor.go
+++ b/materialize-bigquery/transactor.go
@@ -36,12 +36,11 @@ type transactor struct {
 }
 
 func prepareNewTransactor(
-	dialect sql.Dialect,
 	templates templates,
-	objAndArrayAsJson bool,
-) func(context.Context, *sql.Endpoint[config], sql.Fence, []sql.Table, pm.Request_Open, *boilerplate.InfoSchema, *boilerplate.BindingEvents) (m.Transactor, error) {
+) func(context.Context, map[string]bool, *sql.Endpoint[config], sql.Fence, []sql.Table, pm.Request_Open, *boilerplate.InfoSchema, *boilerplate.BindingEvents) (m.Transactor, error) {
 	return func(
 		ctx context.Context,
+		featureFlags map[string]bool,
 		ep *sql.Endpoint[config],
 		fence sql.Fence,
 		bindings []sql.Table,
@@ -57,9 +56,9 @@ func prepareNewTransactor(
 		t := &transactor{
 			cfg:               ep.Config,
 			fence:             &fence,
-			dialect:           dialect,
+			dialect:           ep.Dialect,
 			templates:         templates,
-			objAndArrayAsJson: objAndArrayAsJson,
+			objAndArrayAsJson: featureFlags["objects_and_arrays_as_json"],
 			client:            client,
 			bucketPath:        ep.Config.BucketPath,
 			bucket:            ep.Config.Bucket,

--- a/materialize-motherduck/driver.go
+++ b/materialize-motherduck/driver.go
@@ -71,6 +71,7 @@ type transactor struct {
 
 func newTransactor(
 	ctx context.Context,
+	featureFlags map[string]bool,
 	ep *sql.Endpoint[config],
 	fence sql.Fence,
 	bindings []sql.Table,

--- a/materialize-sql-v2/driver.go
+++ b/materialize-sql-v2/driver.go
@@ -79,6 +79,7 @@ func (d *Driver[EC, RC]) NewTransactor(ctx context.Context, req pm.Request_Open,
 
 type sqlMaterialization[EC boilerplate.EndpointConfiger, RC boilerplate.Resourcer[RC, EC]] struct {
 	materializationName string
+	featureFlags        map[string]bool
 	driver              *Driver[EC, RC]
 	endpoint            *Endpoint[EC]
 	client              Client
@@ -101,6 +102,7 @@ func (d *Driver[EC, RC]) newMaterialization(ctx context.Context, materialization
 
 	return &sqlMaterialization[EC, RC]{
 		materializationName: materializationName,
+		featureFlags:        featureFlags,
 		driver:              d,
 		endpoint:            endpoint,
 		client:              client,
@@ -378,7 +380,7 @@ func (s *sqlMaterialization[EC, RC]) NewMaterializerTransactor(
 		}
 	}
 
-	transactor, err := s.endpoint.NewTransactor(ctx, s.endpoint, fence, tables, open, &is, be)
+	transactor, err := s.endpoint.NewTransactor(ctx, s.featureFlags, s.endpoint, fence, tables, open, &is, be)
 	if err != nil {
 		return nil, fmt.Errorf("building transactor: %w", err)
 	}

--- a/materialize-sql-v2/endpoint.go
+++ b/materialize-sql-v2/endpoint.go
@@ -90,9 +90,9 @@ type Fence struct {
 }
 
 // Endpoint is a driver description of the SQL endpoint being driven.
-type Endpoint[T boilerplate.EndpointConfiger] struct {
+type Endpoint[EC boilerplate.EndpointConfiger] struct {
 	// Config is an implementation-specific type for the Endpoint configuration.
-	Config T
+	Config EC
 	// Dialect of the Endpoint.
 	Dialect
 	// MetaCheckpoints is the checkpoints meta-table of the Endpoint.
@@ -102,11 +102,20 @@ type Endpoint[T boilerplate.EndpointConfiger] struct {
 	SerPolicy *flow.SerPolicy
 	// NewClient creates a client, which provides Endpoint-specific methods for performing
 	// operations with the Endpoint store.
-	NewClient func(context.Context, *Endpoint[T]) (Client, error)
+	NewClient func(context.Context, *Endpoint[EC]) (Client, error)
 	// CreateTableTemplate evaluates a Table into an endpoint statement which creates it.
 	CreateTableTemplate *template.Template
 	// NewTransactor returns a Transactor ready for pm.RunTransactions.
-	NewTransactor func(ctx context.Context, _ *Endpoint[T], _ Fence, bindings []Table, open pm.Request_Open, is *boilerplate.InfoSchema, be *boilerplate.BindingEvents) (m.Transactor, error)
+	NewTransactor func(
+		ctx context.Context,
+		featureFlags map[string]bool,
+		_ *Endpoint[EC],
+		_ Fence,
+		bindings []Table,
+		open pm.Request_Open,
+		is *boilerplate.InfoSchema,
+		be *boilerplate.BindingEvents,
+	) (m.Transactor, error)
 	// Tenant owning this task, as determined from the task name.
 	Tenant string
 	// ConcurrentApply of Apply actions, for system that may benefit from a scatter/gather strategy

--- a/materialize-sqlite/sqlite.go
+++ b/materialize-sqlite/sqlite.go
@@ -142,6 +142,7 @@ func (c *client) Close() {
 
 func newTransactor(
 	ctx context.Context,
+	featureFlags map[string]bool,
 	ep *sql.Endpoint[config],
 	fence sql.Fence,
 	bindings []sql.Table,

--- a/materialize-sqlserver/driver.go
+++ b/materialize-sqlserver/driver.go
@@ -247,9 +247,10 @@ type transactor struct {
 
 func prepareNewTransactor(
 	templates templates,
-) func(context.Context, *sql.Endpoint[config], sql.Fence, []sql.Table, pm.Request_Open, *boilerplate.InfoSchema, *boilerplate.BindingEvents) (m.Transactor, error) {
+) func(context.Context, map[string]bool, *sql.Endpoint[config], sql.Fence, []sql.Table, pm.Request_Open, *boilerplate.InfoSchema, *boilerplate.BindingEvents) (m.Transactor, error) {
 	return func(
 		ctx context.Context,
+		featureFlags map[string]bool,
 		ep *sql.Endpoint[config],
 		fence sql.Fence,
 		bindings []sql.Table,

--- a/materialize-starburst/starburst.go
+++ b/materialize-starburst/starburst.go
@@ -164,6 +164,7 @@ type transactor struct {
 
 func newTransactor(
 	ctx context.Context,
+	featureFlags map[string]bool,
 	ep *sql.Endpoint[config],
 	_ sql.Fence,
 	tables []sql.Table,


### PR DESCRIPTION
**Description:**

Adapts the connector to use `materialize-sql-v2`, which is mostly the same kind of mechanical change as the several that have been done before this.

Also a couple of other refactorings, which are primarily motivated by the work that will come with #1436 to avoid making that eventual PR larger than it needs to be:
- Change the way parsed feature flags are made available in `NewTransactor`
- Use the common `StagedFiles` and `blob.Bucket` constructs for dealing with staged files

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

