### PR TITLE
source-shopify: add setuptools dependency to address path traversal v…

### DIFF
--- a/source-shopify/source_shopify/pyproject.toml
+++ b/source-shopify/source_shopify/pyproject.toml
@@ -13,6 +13,7 @@ license = "AGPL-3.0"
 python = "<3.12,>=3.7.1"
 requests = "^2.31.0"
 singer-sdk = "^0.33.0"
+setuptools = ">=78.1.1"
 
 [tool.poetry.dev-dependencies]
 pytest = "^6.2.5"


### PR DESCRIPTION
…ulnerability

Add setuptools>=78.1.1 dependency to address a path traversal vulnerability in PackageIndex.download that could allow arbitrary file writes.

Fixes dependabot issue 401

🤖 Generated with [Claude Code](https://claude.ai/code)

