### PR TITLE
source-klaviyo: add setuptools dependency to address path traversal v…

### DIFF
--- a/source-klaviyo/pyproject.toml
+++ b/source-klaviyo/pyproject.toml
@@ -9,6 +9,7 @@ airbyte-cdk = "^0.52"
 estuary-cdk = {path="../estuary-cdk", develop = true}
 pydantic = "==1.10.14"
 python = "^3.12"
+setuptools = ">=78.1.1"
 
 [tool.poetry.group.dev.dependencies]
 debugpy = "^1.8.0"


### PR DESCRIPTION
Add setuptools>=78.1.1 dependency to address a path traversal vulnerability in PackageIndex.download that could allow arbitrary file writes.

🤖 Generated with [Claude Code](https://claude.ai/code)

Fixes dependabot alert 413