### PR TITLE
materializer: run Setup after creating namespaces

### DIFF
--- a/materialize-boilerplate/materializer.go
+++ b/materialize-boilerplate/materializer.go
@@ -427,17 +427,6 @@ func RunApply[EC EndpointConfiger, FC FieldConfiger, RC Resourcer[RC, EC], MT Ma
 	actionDescriptions := []string{}
 	actions := []ActionApplyFn{}
 
-	if desc, err := materializer.Setup(ctx, is); err != nil {
-		return nil, fmt.Errorf("running PreApply: %w", err)
-	} else if desc != "" {
-		actionDescriptions = append(actionDescriptions, desc)
-	}
-
-	common, err := computeCommonUpdates(req.LastMaterialization, req.Materialization, is)
-	if err != nil {
-		return nil, err
-	}
-
 	if !mCfg.NoCreateNamespaces {
 		// Create any required namespaces before other actions, which may
 		// include resource creation. Otherwise resources creation may fail due
@@ -464,6 +453,17 @@ func RunApply[EC EndpointConfiger, FC FieldConfiger, RC Resourcer[RC, EC], MT Ma
 				actionDescriptions = append(actionDescriptions, desc)
 			}
 		}
+	}
+
+	if desc, err := materializer.Setup(ctx, is); err != nil {
+		return nil, fmt.Errorf("running setup: %w", err)
+	} else if desc != "" {
+		actionDescriptions = append(actionDescriptions, desc)
+	}
+
+	common, err := computeCommonUpdates(req.LastMaterialization, req.Materialization, is)
+	if err != nil {
+		return nil, err
 	}
 
 	addAction := func(desc string, a ActionApplyFn) {


### PR DESCRIPTION
**Description:**

Materialization setup actions often require all namespaces to exist in order to run successfully. An example of this is SQL materializations that create a checkpoints table in the endpoint's configured schema.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2970)
<!-- Reviewable:end -->
