### PR TITLE
source-stripe-native: only capture from the most recent 100 connected accounts

### DIFF
--- a/source-stripe-native/source_stripe_native/resources.py
+++ b/source-stripe-native/source_stripe_native/resources.py
@@ -74,18 +74,16 @@ async def _fetch_connected_account_ids(
     url = f"{API}/accounts"
     params: dict[str, str | int] = {"limit": 100}
 
-    while True:
-        response = ListResult[Accounts].model_validate_json(
-            await http.request(log, url, params=params)
-        )
+    # We should paginate to get all connected account, but
+    # we've seen captures OOM when there are more than a few hundred accounts.
+    # While we figure out how to handle so many connected accounts without OOM-ing,
+    # only capture from the 100 most recent accounts.
+    response = ListResult[Accounts].model_validate_json(
+        await http.request(log, url, params=params)
+    )
 
-        for account in response.data:
-            account_ids.add(account.id)
-
-        if not response.has_more:
-            break
-
-        params["starting_after"] = response.data[-1].id
+    for account in response.data:
+        account_ids.add(account.id)
 
     return list(account_ids)
 


### PR DESCRIPTION
**Description:**

The connector is OOM-ing when there are thousands of connected accounts. We need to figure out a strategy to capture from that many connected accounts without OOM-ing. Unfortunately, that will likely take a significant amount of time. In the meantime while we're figuring that out, only capture from the 100 most recent connected accounts to avoid OOMs.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

Tested on a local stack. Confirmed the connector doesn't OOM when capturing from only 100 connected accounts.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2974)
<!-- Reviewable:end -->
