### PR TITLE
source-stripe-native: improve connected account processing

### DIFF
--- a/source-stripe-native/source_stripe_native/api.py
+++ b/source-stripe-native/source_stripe_native/api.py
@@ -168,6 +168,12 @@ async def fetch_incremental(
 
     if max_ts != log_cursor:
         yield max_ts + timedelta(milliseconds=1)  # startTimestamp is inclusive.
+    elif connected_account_id and end > log_cursor:
+        # If there were no events and we are capturing a connected account, move the cursor
+        # forward. This is necessary since we can't process all connected accounts in a single
+        # connector invocation, and we try to fairly rotated which connected accounts are processed
+        # based on how old their incremental cursors are.
+        yield end
 
 
 async def fetch_backfill(
@@ -343,6 +349,12 @@ async def fetch_incremental_substreams(
             break
     if max_ts != log_cursor:
         yield max_ts + timedelta(milliseconds=1)  # startTimestamp is inclusive.
+    elif connected_account_id and end > log_cursor:
+        # If there were no events and we are capturing a connected account, move the cursor
+        # forward. This is necessary since we can't process all connected accounts in a single
+        # connector invocation, and we try to fairly rotated which connected accounts are processed
+        # based on how old their incremental cursors are.
+        yield end
 
 
 async def fetch_backfill_substreams(
@@ -575,6 +587,8 @@ async def fetch_incremental_no_events(
     if account_id:
         headers["Stripe-Account"] = account_id
 
+    end = datetime.now(tz=UTC) - LAG
+
     while iterating:
         resources = ListResult[cls].model_validate_json(
             await http.request(
@@ -606,6 +620,12 @@ async def fetch_incremental_no_events(
 
     if max_ts != log_cursor:
         yield max_ts + timedelta(milliseconds=1)  # startTimestamp is inclusive.
+    elif connected_account_id and end > log_cursor:
+        # If there were no events and we are capturing a connected account, move the cursor
+        # forward. This is necessary since we can't process all connected accounts in a single
+        # connector invocation, and we try to fairly rotated which connected accounts are processed
+        # based on how old their incremental cursors are.
+        yield end
 
 
 async def fetch_incremental_usage_records(
@@ -702,6 +722,12 @@ async def fetch_incremental_usage_records(
 
     if max_ts != log_cursor:
         yield max_ts + timedelta(milliseconds=1)  # startTimestamp is inclusive.
+    elif connected_account_id and end > log_cursor:
+        # If there were no events and we are capturing a connected account, move the cursor
+        # forward. This is necessary since we can't process all connected accounts in a single
+        # connector invocation, and we try to fairly rotated which connected accounts are processed
+        # based on how old their incremental cursors are.
+        yield end
 
 
 async def fetch_backfill_usage_records(


### PR DESCRIPTION
**Description:**

When a user has hundreds/thousands of connected accounts, the connector can't process all of them at once without running out of memory. I suspect the memory overhead of 500,000+ subtasks (~6,500 connected accounts × 41 bindings × 2 subtasks per binding) pushes the connector over the 1 GB memory limit.

This PR implements account processing limits and automatic restarts to handle large numbers of connected Stripe accounts while avoiding memory issues.

- Process max 100 accounts per run using intelligent prioritization:
  1. Accounts with incomplete backfills (ensures data completeness)
  2. Accounts with oldest incremental cursors (fair rotation)
- Automatic connector restarts every 30 minutes to cover all accounts
- Move incremental cursors forward when there are no updates for a connected account, ensuring the prioritization algorithm works correctly and doesn't constantly prioritize inactive accounts.

This approach assumes:
- 30 minutes is a reasonable amount of time to allow subtasks to process a good chunk / all of their backfills.
- The rate of accounts being connected to a user's primary Stripe account is less than 100 accounts / 30 minutes. If the rate is faster than that, it's possible the connector can't process accounts faster than they're being connected. Accounts that haven't completed their backfill would constantly get prioritized, accounts that have completed their backfill would never get prioritized (meaning we wouldn't fetch their incremental updates), and it'd look like we're missing data. I'm hopeful that a 100 accounts / 30 minutes rate isn't realistic & that accounts would be added slower than that, but it's a new, possible "missing data" scenario to keep in mind.


This approach isn't truly ideal; it'd be best if we could process all connected accounts simultaneously. A way to do that is to shard the capture and assign a subset of connected accounts to each shard. That'd spread the overall memory overhead across shard & avoid OOMs. However, the CDK doesn't currently support sharding captures, and that's a pretty significant effort that will need prioritized if we want to do that. In the meantime, the alternative strategy implemented in this PR should work ok.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

Tested on a local stack. Confirmed:
- only 100 connected accounts are processed in a single connector invocation.
- connected accounts are prioritized first based on their backfill status (is it complete?) and second based on how old their incremental cursors are.
- the connector doesn't OOM, although it can still use up a lot of memory. Captures I've tested have hovered around ~61% memory usage.
- when capturing from connected accounts, the `stopping` event is set every 30 minutes & a new set of connected accounts are prioritized on the next connector invocation.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/2983)
<!-- Reviewable:end -->
