### PR TITLE
dockerfiles: Fix Dockerfile FROM/AS casing and CMD warnings

### DIFF
--- a/base-image/Dockerfile
+++ b/base-image/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 debian:stable-slim as debian
+FROM --platform=linux/amd64 debian:stable-slim AS debian
 
 RUN apt-get update && apt-get install -y openssh-client ca-certificates curl
 

--- a/estuary-cdk/common.Dockerfile
+++ b/estuary-cdk/common.Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
-FROM python:3.12-slim as base
-FROM base as builder
+FROM python:3.12-slim AS base
+FROM base AS builder
 
 ARG CONNECTOR_NAME
 
@@ -18,7 +18,7 @@ COPY estuary-cdk /opt/estuary-cdk
 RUN poetry install
 
 
-FROM base as runner
+FROM base AS runner
 
 ARG CONNECTOR_NAME
 ARG CONNECTOR_TYPE
@@ -44,4 +44,4 @@ COPY --from=ghcr.io/estuary/network-tunnel:dev /flow-network-tunnel /usr/bin/flo
 ENV DOCS_URL=${DOCS_URL}
 ENV CONNECTOR_NAME=${CONNECTOR_NAME}
 
-CMD /opt/venv/bin/python -m $(echo "$CONNECTOR_NAME" | tr '-' '_')
+CMD ["/bin/sh", "-c", "/opt/venv/bin/python -m $(echo \"$CONNECTOR_NAME\" | tr '-' '_')"]

--- a/materialize-azure-blob-parquet/Dockerfile
+++ b/materialize-azure-blob-parquet/Dockerfile
@@ -2,7 +2,7 @@ ARG BASE_IMAGE=ghcr.io/estuary/base-image:v1
 
 # Build Stage
 ################################################################################
-FROM --platform=linux/amd64 golang:1.24-bullseye as builder
+FROM --platform=linux/amd64 golang:1.24-bullseye AS builder
 
 WORKDIR /builder
 

--- a/materialize-azure-fabric-warehouse/Dockerfile
+++ b/materialize-azure-fabric-warehouse/Dockerfile
@@ -2,7 +2,7 @@ ARG BASE_IMAGE=ghcr.io/estuary/base-image:v1
 
 # Build Stage
 ################################################################################
-FROM --platform=linux/amd64 golang:1.24-bullseye as builder
+FROM --platform=linux/amd64 golang:1.24-bullseye AS builder
 
 WORKDIR /builder
 

--- a/materialize-bigquery/Dockerfile
+++ b/materialize-bigquery/Dockerfile
@@ -2,7 +2,7 @@ ARG BASE_IMAGE=ghcr.io/estuary/base-image:v1
 
 # Build Stage
 ################################################################################
-FROM golang:1.24-bullseye as builder
+FROM golang:1.24-bullseye AS builder
 
 WORKDIR /builder
 

--- a/materialize-cratedb/Dockerfile
+++ b/materialize-cratedb/Dockerfile
@@ -2,7 +2,7 @@ ARG BASE_IMAGE=ghcr.io/estuary/base-image:v1
 
 # Build Stage
 ################################################################################
-FROM --platform=linux/amd64 golang:1.24-bullseye as builder
+FROM --platform=linux/amd64 golang:1.24-bullseye AS builder
 
 WORKDIR /builder
 

--- a/materialize-databricks/Dockerfile
+++ b/materialize-databricks/Dockerfile
@@ -2,7 +2,7 @@ ARG BASE_IMAGE=ghcr.io/estuary/base-image:v1
 
 # Build Stage
 ################################################################################
-FROM --platform=linux/amd64 golang:1.24-bullseye as builder
+FROM --platform=linux/amd64 golang:1.24-bullseye AS builder
 
 WORKDIR /builder
 

--- a/materialize-dynamodb/Dockerfile
+++ b/materialize-dynamodb/Dockerfile
@@ -2,7 +2,7 @@ ARG BASE_IMAGE=ghcr.io/estuary/base-image:v1
 
 # Build Stage
 ################################################################################
-FROM --platform=linux/amd64 golang:1.24-bullseye as builder
+FROM --platform=linux/amd64 golang:1.24-bullseye AS builder
 
 WORKDIR /builder
 

--- a/materialize-elasticsearch/Dockerfile
+++ b/materialize-elasticsearch/Dockerfile
@@ -2,7 +2,7 @@ ARG BASE_IMAGE=ghcr.io/estuary/base-image:v1
 
 # Build Stage
 ################################################################################
-FROM --platform=linux/amd64 golang:1.24-bullseye as builder
+FROM --platform=linux/amd64 golang:1.24-bullseye AS builder
 
 WORKDIR /builder
 

--- a/materialize-firebolt/Dockerfile
+++ b/materialize-firebolt/Dockerfile
@@ -2,7 +2,7 @@ ARG BASE_IMAGE=ghcr.io/estuary/base-image:v1
 
 # Build Stage
 ################################################################################
-FROM --platform=linux/amd64 golang:1.24-bullseye as builder
+FROM --platform=linux/amd64 golang:1.24-bullseye AS builder
 
 WORKDIR /builder
 

--- a/materialize-gcs-csv/Dockerfile
+++ b/materialize-gcs-csv/Dockerfile
@@ -2,7 +2,7 @@ ARG BASE_IMAGE=ghcr.io/estuary/base-image:v1
 
 # Build Stage
 ################################################################################
-FROM --platform=linux/amd64 golang:1.24-bullseye as builder
+FROM --platform=linux/amd64 golang:1.24-bullseye AS builder
 
 WORKDIR /builder
 

--- a/materialize-gcs-parquet/Dockerfile
+++ b/materialize-gcs-parquet/Dockerfile
@@ -2,7 +2,7 @@ ARG BASE_IMAGE=ghcr.io/estuary/base-image:v1
 
 # Build Stage
 ################################################################################
-FROM --platform=linux/amd64 golang:1.24-bullseye as builder
+FROM --platform=linux/amd64 golang:1.24-bullseye AS builder
 
 WORKDIR /builder
 

--- a/materialize-google-pubsub/Dockerfile
+++ b/materialize-google-pubsub/Dockerfile
@@ -2,7 +2,7 @@ ARG BASE_IMAGE=ghcr.io/estuary/base-image:v1
 
 # Build Stage
 ################################################################################
-FROM --platform=linux/amd64 golang:1.24-bullseye as builder
+FROM --platform=linux/amd64 golang:1.24-bullseye AS builder
 
 WORKDIR /builder
 

--- a/materialize-google-sheets/Dockerfile
+++ b/materialize-google-sheets/Dockerfile
@@ -2,7 +2,7 @@ ARG BASE_IMAGE=ghcr.io/estuary/base-image:v1
 
 # Build Stage
 ################################################################################
-FROM golang:1.24-bullseye as builder
+FROM golang:1.24-bullseye AS builder
 
 WORKDIR /builder
 

--- a/materialize-iceberg/Dockerfile
+++ b/materialize-iceberg/Dockerfile
@@ -2,7 +2,7 @@ ARG BASE_IMAGE=ghcr.io/estuary/base-image:v1
 
 # Build Stage
 ################################################################################
-FROM --platform=linux/amd64 golang:1.24-bullseye as builder
+FROM --platform=linux/amd64 golang:1.24-bullseye AS builder
 
 WORKDIR /builder
 

--- a/materialize-kafka/Dockerfile
+++ b/materialize-kafka/Dockerfile
@@ -2,7 +2,7 @@ ARG BASE_IMAGE=ghcr.io/estuary/base-image:v1
 
 # Build Stage
 ################################################################################
-FROM golang:1.24-bullseye as builder
+FROM golang:1.24-bullseye AS builder
 
 RUN apt-get update \
     && apt-get install -y curl ca-certificates pkg-config cmake g++ libssl-dev libsasl2-dev \

--- a/materialize-mongodb/Dockerfile
+++ b/materialize-mongodb/Dockerfile
@@ -2,7 +2,7 @@ ARG BASE_IMAGE=ghcr.io/estuary/base-image:v1
 
 # Build Stage
 ################################################################################
-FROM --platform=linux/amd64 golang:1.24-bullseye as builder
+FROM --platform=linux/amd64 golang:1.24-bullseye AS builder
 
 WORKDIR /builder
 

--- a/materialize-motherduck/Dockerfile
+++ b/materialize-motherduck/Dockerfile
@@ -2,7 +2,7 @@ ARG BASE_IMAGE=ghcr.io/estuary/base-image:v1
 
 # Build Stage
 ################################################################################
-FROM --platform=linux/amd64 golang:1.24-bullseye as builder
+FROM --platform=linux/amd64 golang:1.24-bullseye AS builder
 
 WORKDIR /builder
 

--- a/materialize-mysql/Dockerfile
+++ b/materialize-mysql/Dockerfile
@@ -2,7 +2,7 @@ ARG BASE_IMAGE=ghcr.io/estuary/base-image:v1
 
 # Build Stage
 ################################################################################
-FROM --platform=linux/amd64 golang:1.24-bullseye as builder
+FROM --platform=linux/amd64 golang:1.24-bullseye AS builder
 
 WORKDIR /builder
 

--- a/materialize-pinecone/Dockerfile
+++ b/materialize-pinecone/Dockerfile
@@ -2,7 +2,7 @@ ARG BASE_IMAGE=ghcr.io/estuary/base-image:v1
 
 # Build Stage
 ################################################################################
-FROM --platform=linux/amd64 golang:1.24-bullseye as builder
+FROM --platform=linux/amd64 golang:1.24-bullseye AS builder
 
 WORKDIR /builder
 

--- a/materialize-postgres/Dockerfile
+++ b/materialize-postgres/Dockerfile
@@ -2,7 +2,7 @@ ARG BASE_IMAGE=ghcr.io/estuary/base-image:v1
 
 # Build Stage
 ################################################################################
-FROM --platform=linux/amd64 golang:1.24-bullseye as builder
+FROM --platform=linux/amd64 golang:1.24-bullseye AS builder
 
 WORKDIR /builder
 

--- a/materialize-redshift/Dockerfile
+++ b/materialize-redshift/Dockerfile
@@ -2,7 +2,7 @@ ARG BASE_IMAGE=ghcr.io/estuary/base-image:v1
 
 # Build Stage
 ################################################################################
-FROM --platform=linux/amd64 golang:1.24-bullseye as builder
+FROM --platform=linux/amd64 golang:1.24-bullseye AS builder
 
 WORKDIR /builder
 

--- a/materialize-s3-csv/Dockerfile
+++ b/materialize-s3-csv/Dockerfile
@@ -2,7 +2,7 @@ ARG BASE_IMAGE=ghcr.io/estuary/base-image:v1
 
 # Build Stage
 ################################################################################
-FROM --platform=linux/amd64 golang:1.24-bullseye as builder
+FROM --platform=linux/amd64 golang:1.24-bullseye AS builder
 
 WORKDIR /builder
 

--- a/materialize-s3-iceberg/Dockerfile
+++ b/materialize-s3-iceberg/Dockerfile
@@ -1,8 +1,8 @@
-FROM python:3.12-slim-bookworm as base
+FROM python:3.12-slim-bookworm AS base
 
 # Python build stage
 ################################################################################
-FROM base as pybuilder
+FROM base AS pybuilder
 
 RUN apt-get update && \
     apt install -y --no-install-recommends \
@@ -19,7 +19,7 @@ RUN poetry install
 
 # Go build stage
 ################################################################################
-FROM --platform=linux/amd64 golang:1.24-bullseye as gobuilder
+FROM --platform=linux/amd64 golang:1.24-bullseye AS gobuilder
 
 WORKDIR /builder
 
@@ -40,7 +40,7 @@ RUN go build -o ./connector -v ./materialize-s3-iceberg
 # Runtime stage
 ################################################################################
 
-FROM base as runner
+FROM base AS runner
 
 COPY --from=pybuilder /opt/venv /opt/venv
 COPY --from=pybuilder /opt/iceberg-ctl /opt/iceberg-ctl

--- a/materialize-s3-parquet/Dockerfile
+++ b/materialize-s3-parquet/Dockerfile
@@ -2,7 +2,7 @@ ARG BASE_IMAGE=ghcr.io/estuary/base-image:v1
 
 # Build Stage
 ################################################################################
-FROM --platform=linux/amd64 golang:1.24-bullseye as builder
+FROM --platform=linux/amd64 golang:1.24-bullseye AS builder
 
 WORKDIR /builder
 

--- a/materialize-slack/Dockerfile
+++ b/materialize-slack/Dockerfile
@@ -2,7 +2,7 @@ ARG BASE_IMAGE=ghcr.io/estuary/base-image:v1
 
 # Build Stage
 ################################################################################
-FROM --platform=linux/amd64 golang:1.24-bullseye as builder
+FROM --platform=linux/amd64 golang:1.24-bullseye AS builder
 
 WORKDIR /builder
 

--- a/materialize-snowflake/Dockerfile
+++ b/materialize-snowflake/Dockerfile
@@ -2,7 +2,7 @@ ARG BASE_IMAGE=ghcr.io/estuary/base-image:v1
 
 # Build Stage
 ################################################################################
-FROM golang:1.24-bullseye as builder
+FROM golang:1.24-bullseye AS builder
 
 WORKDIR /builder
 

--- a/materialize-sqlite/Dockerfile
+++ b/materialize-sqlite/Dockerfile
@@ -2,7 +2,7 @@ ARG BASE_IMAGE=ghcr.io/estuary/base-image:v1
 
 # Build Stage
 ################################################################################
-FROM --platform=linux/amd64 golang:1.24-bullseye as builder
+FROM --platform=linux/amd64 golang:1.24-bullseye AS builder
 
 WORKDIR /builder
 

--- a/materialize-sqlserver/Dockerfile
+++ b/materialize-sqlserver/Dockerfile
@@ -2,7 +2,7 @@ ARG BASE_IMAGE=ghcr.io/estuary/base-image:v1
 
 # Build Stage
 ################################################################################
-FROM --platform=linux/amd64 golang:1.24-bullseye as builder
+FROM --platform=linux/amd64 golang:1.24-bullseye AS builder
 
 WORKDIR /builder
 

--- a/materialize-starburst/Dockerfile
+++ b/materialize-starburst/Dockerfile
@@ -2,7 +2,7 @@ ARG BASE_IMAGE=ghcr.io/estuary/base-image:v1
 
 # Build Stage
 ################################################################################
-FROM --platform=linux/amd64 golang:1.24-bullseye as builder
+FROM --platform=linux/amd64 golang:1.24-bullseye AS builder
 
 WORKDIR /builder
 

--- a/materialize-webhook/Dockerfile
+++ b/materialize-webhook/Dockerfile
@@ -2,7 +2,7 @@ ARG BASE_IMAGE=ghcr.io/estuary/base-image:v1
 
 # Build Stage
 ################################################################################
-FROM golang:1.24-bullseye as builder
+FROM golang:1.24-bullseye AS builder
 
 WORKDIR /builder
 

--- a/python/Dockerfile
+++ b/python/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-FROM python:3.11-slim as builder
+FROM python:3.11-slim AS builder
 
 ARG CONNECTOR_NAME
 # Adapted from here: https://github.com/orgs/python-poetry/discussions/1879#discussioncomment-7284113
@@ -61,4 +61,4 @@ COPY --from=builder /builder/python ./python
 
 # Arg substitution in CMD doesn't seem to work
 ENV CONNECTOR_NAME=$CONNECTOR_NAME
-CMD python -m $CONNECTOR_NAME
+CMD ["/bin/sh", "-c", "python -m $CONNECTOR_NAME"]

--- a/source-alpaca/Dockerfile
+++ b/source-alpaca/Dockerfile
@@ -1,6 +1,6 @@
 # Build Stage
 ################################################################################
-FROM golang:1.24-bullseye as builder
+FROM golang:1.24-bullseye AS builder
 
 WORKDIR /builder
 

--- a/source-azure-blob-storage/Dockerfile
+++ b/source-azure-blob-storage/Dockerfile
@@ -2,7 +2,7 @@ ARG BASE_IMAGE=ghcr.io/estuary/base-image:v1
 
 # Build Stage
 ################################################################################
-FROM golang:1.24-bullseye as builder
+FROM golang:1.24-bullseye AS builder
 
 WORKDIR /builder
 

--- a/source-bigquery-batch/Dockerfile
+++ b/source-bigquery-batch/Dockerfile
@@ -2,7 +2,7 @@ ARG BASE_IMAGE=ghcr.io/estuary/base-image:v1
 
 # Build Stage
 ################################################################################
-FROM golang:1.24-bullseye as builder
+FROM golang:1.24-bullseye AS builder
 
 WORKDIR /builder
 

--- a/source-dropbox/Dockerfile
+++ b/source-dropbox/Dockerfile
@@ -2,7 +2,7 @@ ARG BASE_IMAGE=ghcr.io/estuary/base-image:v1
 
 # Build Stage
 ################################################################################
-FROM golang:1.24-bullseye as builder
+FROM golang:1.24-bullseye AS builder
 
 WORKDIR /builder
 

--- a/source-dynamodb/Dockerfile
+++ b/source-dynamodb/Dockerfile
@@ -1,6 +1,6 @@
 # Build Stage
 ################################################################################
-FROM golang:1.24-bullseye as builder
+FROM golang:1.24-bullseye AS builder
 
 WORKDIR /builder
 

--- a/source-firestore/Dockerfile
+++ b/source-firestore/Dockerfile
@@ -2,7 +2,7 @@ ARG BASE_IMAGE=ghcr.io/estuary/base-image:v1
 
 # Build Stage
 ################################################################################
-FROM golang:1.24-bullseye as builder
+FROM golang:1.24-bullseye AS builder
 
 WORKDIR /builder
 

--- a/source-gcs/Dockerfile
+++ b/source-gcs/Dockerfile
@@ -2,7 +2,7 @@ ARG BASE_IMAGE=ghcr.io/estuary/base-image:v1
 
 # Build Stage
 ################################################################################
-FROM golang:1.24-bullseye as builder
+FROM golang:1.24-bullseye AS builder
 
 WORKDIR /builder
 

--- a/source-google-drive/Dockerfile
+++ b/source-google-drive/Dockerfile
@@ -2,7 +2,7 @@ ARG BASE_IMAGE=ghcr.io/estuary/base-image:v1
 
 # Build Stage
 ################################################################################
-FROM golang:1.24-bullseye as builder
+FROM golang:1.24-bullseye AS builder
 
 WORKDIR /builder
 

--- a/source-google-pubsub/Dockerfile
+++ b/source-google-pubsub/Dockerfile
@@ -2,7 +2,7 @@ ARG BASE_IMAGE=ghcr.io/estuary/base-image:v1
 
 # Build Stage
 ################################################################################
-FROM golang:1.24-bullseye as builder
+FROM golang:1.24-bullseye AS builder
 
 WORKDIR /builder
 

--- a/source-hello-world/Dockerfile
+++ b/source-hello-world/Dockerfile
@@ -2,7 +2,7 @@ ARG BASE_IMAGE=ghcr.io/estuary/base-image:v1
 
 # Build Stage
 ################################################################################
-FROM golang:1.24-bullseye as builder
+FROM golang:1.24-bullseye AS builder
 
 WORKDIR /builder
 

--- a/source-http-file/Dockerfile
+++ b/source-http-file/Dockerfile
@@ -2,7 +2,7 @@ ARG BASE_IMAGE=ghcr.io/estuary/base-image:v1
 
 # Build Stage
 ################################################################################
-FROM golang:1.24-bullseye as builder
+FROM golang:1.24-bullseye AS builder
 
 WORKDIR /builder
 

--- a/source-http-ingest/Dockerfile
+++ b/source-http-ingest/Dockerfile
@@ -2,7 +2,7 @@ ARG BASE_IMAGE=ghcr.io/estuary/base-image:v1
 
 # Build Stage
 ################################################################################
-FROM golang:1.24-bullseye as builder
+FROM golang:1.24-bullseye AS builder
 
 RUN apt-get update \
     && apt-get install -y curl ca-certificates pkg-config cmake g++ protobuf-compiler \

--- a/source-kafka/Dockerfile
+++ b/source-kafka/Dockerfile
@@ -2,7 +2,7 @@ ARG BASE_IMAGE=ghcr.io/estuary/base-image:v1
 
 # Build Stage
 ################################################################################
-FROM golang:1.24-bullseye as builder
+FROM golang:1.24-bullseye AS builder
 
 RUN apt-get update \
     && apt-get install -y curl ca-certificates pkg-config cmake g++ libssl-dev libsasl2-dev \

--- a/source-kinesis/Dockerfile
+++ b/source-kinesis/Dockerfile
@@ -2,7 +2,7 @@ ARG BASE_IMAGE=ghcr.io/estuary/base-image:v1
 
 # Build Stage
 ################################################################################
-FROM golang:1.24-bullseye as builder
+FROM golang:1.24-bullseye AS builder
 
 WORKDIR /builder
 

--- a/source-mongodb/Dockerfile
+++ b/source-mongodb/Dockerfile
@@ -1,6 +1,6 @@
 # Build Stage
 ################################################################################
-FROM golang:1.24-bullseye as builder
+FROM golang:1.24-bullseye AS builder
 
 WORKDIR /builder
 

--- a/source-mysql-batch/Dockerfile
+++ b/source-mysql-batch/Dockerfile
@@ -2,7 +2,7 @@ ARG BASE_IMAGE=ghcr.io/estuary/base-image:v1
 
 # Build Stage
 ################################################################################
-FROM golang:1.24-bullseye as builder
+FROM golang:1.24-bullseye AS builder
 
 WORKDIR /builder
 

--- a/source-mysql/Dockerfile
+++ b/source-mysql/Dockerfile
@@ -2,7 +2,7 @@ ARG BASE_IMAGE=ghcr.io/estuary/base-image:v1
 
 # Build Stage
 ################################################################################
-FROM golang:1.24-bullseye as builder
+FROM golang:1.24-bullseye AS builder
 
 WORKDIR /builder
 

--- a/source-oracle-batch/Dockerfile
+++ b/source-oracle-batch/Dockerfile
@@ -2,7 +2,7 @@ ARG BASE_IMAGE=ghcr.io/estuary/base-image:v1
 
 # Build Stage
 ################################################################################
-FROM golang:1.24-bullseye as builder
+FROM golang:1.24-bullseye AS builder
 
 WORKDIR /builder
 

--- a/source-oracle/Dockerfile
+++ b/source-oracle/Dockerfile
@@ -2,7 +2,7 @@ ARG BASE_IMAGE=ghcr.io/estuary/base-image:v1
 
 # Build Stage
 ################################################################################
-FROM golang:1.24-bullseye as builder
+FROM golang:1.24-bullseye AS builder
 
 WORKDIR /builder
 

--- a/source-postgres-batch/Dockerfile
+++ b/source-postgres-batch/Dockerfile
@@ -2,7 +2,7 @@ ARG BASE_IMAGE=ghcr.io/estuary/base-image:v1
 
 # Build Stage
 ################################################################################
-FROM golang:1.24-bullseye as builder
+FROM golang:1.24-bullseye AS builder
 
 WORKDIR /builder
 

--- a/source-postgres/Dockerfile
+++ b/source-postgres/Dockerfile
@@ -2,7 +2,7 @@ ARG BASE_IMAGE=ghcr.io/estuary/base-image:v1
 
 # Build Stage
 ################################################################################
-FROM golang:1.24-bullseye as builder
+FROM golang:1.24-bullseye AS builder
 
 WORKDIR /builder
 

--- a/source-redshift-batch/Dockerfile
+++ b/source-redshift-batch/Dockerfile
@@ -2,7 +2,7 @@ ARG BASE_IMAGE=ghcr.io/estuary/base-image:v1
 
 # Build Stage
 ################################################################################
-FROM golang:1.24-bullseye as builder
+FROM golang:1.24-bullseye AS builder
 
 WORKDIR /builder
 

--- a/source-s3/Dockerfile
+++ b/source-s3/Dockerfile
@@ -2,7 +2,7 @@ ARG BASE_IMAGE=ghcr.io/estuary/base-image:v1
 
 # Build Stage
 ################################################################################
-FROM golang:1.24-bullseye as builder
+FROM golang:1.24-bullseye AS builder
 
 WORKDIR /builder
 

--- a/source-sftp/Dockerfile
+++ b/source-sftp/Dockerfile
@@ -2,7 +2,7 @@ ARG BASE_IMAGE=ghcr.io/estuary/base-image:v1
 
 # Build Stage
 ################################################################################
-FROM golang:1.24-bullseye as builder
+FROM golang:1.24-bullseye AS builder
 
 WORKDIR /builder
 

--- a/source-snowflake/Dockerfile
+++ b/source-snowflake/Dockerfile
@@ -2,7 +2,7 @@ ARG BASE_IMAGE=ghcr.io/estuary/base-image:v1
 
 # Build Stage
 ################################################################################
-FROM golang:1.24-bullseye as builder
+FROM golang:1.24-bullseye AS builder
 
 WORKDIR /builder
 

--- a/source-sqlserver-batch/Dockerfile
+++ b/source-sqlserver-batch/Dockerfile
@@ -2,7 +2,7 @@ ARG BASE_IMAGE=ghcr.io/estuary/base-image:v1
 
 # Build Stage
 ################################################################################
-FROM golang:1.24-bullseye as builder
+FROM golang:1.24-bullseye AS builder
 
 WORKDIR /builder
 

--- a/source-sqlserver/Dockerfile
+++ b/source-sqlserver/Dockerfile
@@ -2,7 +2,7 @@ ARG BASE_IMAGE=ghcr.io/estuary/base-image:v1
 
 # Build Stage
 ################################################################################
-FROM golang:1.24-bullseye as builder
+FROM golang:1.24-bullseye AS builder
 
 WORKDIR /builder
 

--- a/source-test/Dockerfile
+++ b/source-test/Dockerfile
@@ -2,7 +2,7 @@ ARG BASE_IMAGE=ghcr.io/estuary/base-image:v1
 
 # Build Stage
 ################################################################################
-FROM golang:1.24-bullseye as builder
+FROM golang:1.24-bullseye AS builder
 
 WORKDIR /builder
 


### PR DESCRIPTION
I got tired of seeing a ton of Dockerfile warnings when reviewing PRs, so I used up some of the soon-to-expire Claude credits to work through & address those warnings. The warnings were:
1. FromAsCasing: 'as' and 'FROM' keywords' casing do not match
2. JSONArgsRecommended: JSON arguments recommended for CMD to prevent unintended behavior related to OS signals
  i. This is now suppressed by no longer relying on Docker's implicit shell invocation. Since the shell invocation is now explicit, that warning is not shown.

🤖 Generated with [Claude Code](https://claude.ai/code)

**Description:**

(Describe the high level scope of new or changed features)

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/3003)
<!-- Reviewable:end -->
