### PR TITLE
source-zendesk-support-native: only conditionally discover during discovery

### DIFF
--- a/source-zendesk-support-native/source_zendesk_support_native/__init__.py
+++ b/source-zendesk-support-native/source_zendesk_support_native/__init__.py
@@ -13,7 +13,7 @@ from estuary_cdk.capture import (
     response,
 )
 
-from .resources import all_resources, validate_credentials
+from .resources import all_resources, enabled_resources, validate_credentials
 from .models import (
     ConnectorState,
     EndpointConfig,
@@ -49,7 +49,7 @@ class Connector(
         validate: request.Validate[EndpointConfig, ResourceConfig],
     ) -> response.Validated:
         await validate_credentials(log, self, validate.config)
-        resources = await all_resources(log, self, validate.config)
+        resources = await enabled_resources(log, self, validate.config, validate.bindings)
         resolved = common.resolve_bindings(validate.bindings, resources)
         return common.validated(resolved)
 
@@ -58,6 +58,6 @@ class Connector(
         log: Logger,
         open: request.Open[EndpointConfig, ResourceConfig, ConnectorState],
     ) -> tuple[response.Opened, Callable[[Task], Awaitable[None]]]:
-        resources = await all_resources(log, self, open.capture.config)
+        resources = await enabled_resources(log, self, open.capture.config, open.capture.bindings)
         resolved = common.resolve_bindings(open.capture.bindings, resources)
         return common.open(open, resolved)


### PR DESCRIPTION
**Description:**

With the introduction of the new OAuth pattern where access tokens can expire, it was possible for captures to become stuck trying to conditionally discover bindings in an `all_resources` invocation before attempting to rotate out expired credentials.

By only performing this conditional discovery logic during discovery (i.e. not during validate or open), the connector doesn't try to use expired credentials before rotating them out for a fresh set of valid credentials.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

Tested on a local stack. Confirmed bindings are only conditionally discovered as part of discovery. Filtering out resources in `enabled_bindings` based on which bindings are enabled works as expected.

