### PR TITLE
source-pendo: add `Account` stream

### DIFF
--- a/source-pendo/source_pendo/models.py
+++ b/source-pendo/source_pendo/models.py
@@ -81,6 +81,10 @@ class PollEvent(BaseDocument, extra="allow"):
     pollId: str
 
 
+class Account(BaseDocument, extra="allow"):
+    accountId: str
+
+
 class Visitor(BaseDocument, extra="allow"):
     visitorId: str
 
@@ -145,6 +149,7 @@ AGGREGATED_EVENT_TYPES: list[tuple[str, str, str, type[BaseDocument]]] = [
 
 # Supported incremental resource types, their corresponding resource name, their key, their updated_at field, and their model.
 INCREMENTAL_RESOURCE_TYPES: list[tuple[str, str, str, str, type[BaseDocument]]] = [
+    ("accounts", "Account", "accountId", "metadata.auto.lastupdated", Account),
     ("visitors", "Visitor", "visitorId", "metadata.auto.lastupdated", Visitor),
     ("trackTypes", "TrackType", "id", "lastUpdatedAt", TrackType),
 ]

--- a/source-pendo/tests/snapshots/snapshots__discover__capture.stdout.json
+++ b/source-pendo/tests/snapshots/snapshots__discover__capture.stdout.json
@@ -220,6 +220,68 @@
     ]
   },
   {
+    "recommendedName": "Account",
+    "resourceConfig": {
+      "name": "Account",
+      "interval": "PT5M"
+    },
+    "documentSchema": {
+      "$defs": {
+        "Meta": {
+          "properties": {
+            "op": {
+              "default": "u",
+              "description": "Operation type (c: Create, u: Update, d: Delete)",
+              "enum": [
+                "c",
+                "u",
+                "d"
+              ],
+              "title": "Op",
+              "type": "string"
+            },
+            "row_id": {
+              "default": -1,
+              "description": "Row ID of the Document, counting up from zero, or -1 if not known",
+              "title": "Row Id",
+              "type": "integer"
+            }
+          },
+          "title": "Meta",
+          "type": "object"
+        }
+      },
+      "additionalProperties": true,
+      "properties": {
+        "_meta": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/Meta"
+            }
+          ],
+          "default": {
+            "op": "u",
+            "row_id": -1
+          },
+          "description": "Document metadata"
+        },
+        "accountId": {
+          "title": "Accountid",
+          "type": "string"
+        }
+      },
+      "required": [
+        "accountId"
+      ],
+      "title": "Account",
+      "type": "object",
+      "x-infer-schema": true
+    },
+    "key": [
+      "/accountId"
+    ]
+  },
+  {
     "recommendedName": "Visitor",
     "resourceConfig": {
       "name": "Visitor",


### PR DESCRIPTION
**Description:**

Adds the `Account` stream to `source-pendo`.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

Connector documentation will need updated to reflect the added stream.

**Notes for reviewers:**

Tested on a local stack. Confirmed accounts are captured similarly to the `Visitor` stream.

A note for myself in the future: the `"appId": "expandAppIds(\"*\")"` field in the request body doesn't seem to do anything for the `accounts` source - I think Pendo ignores it. That's fine since that field essentially tells Pendo to return data for all accounts; although we need to provide that field for the `visitors` and `trackType` sources, returning data for all accounts is inherently what the `accounts` source does anyway.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/3010)
<!-- Reviewable:end -->
