### PR TITLE
source-snowflake: add JWT auth and make `account` field optional/hidden

### DIFF
--- a/go/auth/snowflake/.snapshots/TestConfigSchema
+++ b/go/auth/snowflake/.snapshots/TestConfigSchema
@@ -1,0 +1,71 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/estuary/connectors/go/auth/snowflake/credential-config",
+  "oneOf": [
+    {
+      "properties": {
+        "auth_type": {
+          "type": "string",
+          "const": "jwt",
+          "default": "jwt"
+        },
+        "user": {
+          "type": "string",
+          "title": "User",
+          "description": "The Snowflake user login name",
+          "order": 1
+        },
+        "private_key": {
+          "type": "string",
+          "title": "Private Key",
+          "description": "Private Key to be used to sign the JWT token",
+          "multiline": true,
+          "order": 2,
+          "secret": true
+        }
+      },
+      "required": [
+        "auth_type",
+        "private_key"
+      ],
+      "title": "Private Key (JWT)"
+    },
+    {
+      "properties": {
+        "auth_type": {
+          "type": "string",
+          "const": "user_password",
+          "default": "user_password"
+        },
+        "user": {
+          "type": "string",
+          "title": "User",
+          "description": "The Snowflake user login name",
+          "order": 1
+        },
+        "password": {
+          "type": "string",
+          "title": "Password",
+          "description": "The password for the provided user",
+          "order": 2,
+          "secret": true
+        }
+      },
+      "required": [
+        "auth_type",
+        "user",
+        "password"
+      ],
+      "title": "User Password"
+    }
+  ],
+  "type": "object",
+  "title": "Test Config Schema",
+  "description": "Snowflake Credentials",
+  "default": {
+    "auth_type": "jwt"
+  },
+  "discriminator": {
+    "propertyName": "auth_type"
+  }
+}

--- a/go/auth/snowflake/config.go
+++ b/go/auth/snowflake/config.go
@@ -1,0 +1,155 @@
+package snowflake
+
+import (
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+	"fmt"
+	"strings"
+
+	"github.com/invopop/jsonschema"
+	orderedmap "github.com/wk8/go-ordered-map/v2"
+)
+
+const (
+	UserPass = "user_password" // username and password
+	JWT      = "jwt"           // JWT, needs a private key
+)
+
+type CredentialConfig struct {
+	AuthType   string `json:"auth_type"`
+	User       string `json:"user"`
+	Password   string `json:"password"`
+	PrivateKey string `json:"private_key"`
+}
+
+func (c *CredentialConfig) Validate() error {
+	switch c.AuthType {
+	case UserPass:
+		return c.validateUserPassCreds()
+	case JWT:
+		return c.validateJWTCreds()
+	default:
+		return fmt.Errorf("invalid credentials auth type %q", c.AuthType)
+	}
+}
+
+func (c *CredentialConfig) validateUserPassCreds() error {
+	if c.User == "" {
+		return fmt.Errorf("missing user")
+	}
+	if c.Password == "" {
+		return fmt.Errorf("missing password")
+	}
+
+	return nil
+}
+
+func (c *CredentialConfig) validateJWTCreds() error {
+	if c.User == "" {
+		return fmt.Errorf("missing user")
+	}
+	if c.PrivateKey == "" {
+		return fmt.Errorf("missing private_key")
+	}
+
+	if _, err := c.ParsePrivateKey(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (c *CredentialConfig) ParsePrivateKey() (*rsa.PrivateKey, error) {
+	if c.AuthType == JWT {
+		// When providing the PEM file in a JSON file, newlines can't be specified unless
+		// escaped, so here we allow an escape hatch to parse these PEM files
+		var pkString = strings.ReplaceAll(c.PrivateKey, "\\n", "\n")
+		var block, _ = pem.Decode([]byte(pkString))
+		if block == nil {
+			return nil, fmt.Errorf("invalid private key: must be PEM format")
+		} else if key, err := x509.ParsePKCS8PrivateKey(block.Bytes); err != nil {
+			return nil, fmt.Errorf("parsing private key: %w", err)
+		} else {
+			return key.(*rsa.PrivateKey), nil
+		}
+	}
+
+	return nil, fmt.Errorf("only supported with JWT authentication")
+}
+
+// JSONSchema allows for the schema to be (semi-)manually specified when used with the
+// github.com/invopop/jsonschema package in go-schema-gen, to fullfill the required schema shape for
+// our oauth
+func (CredentialConfig) JSONSchema() *jsonschema.Schema {
+	uProps := orderedmap.New[string, *jsonschema.Schema]()
+	uProps.Set("auth_type", &jsonschema.Schema{
+		Type:    "string",
+		Default: UserPass,
+		Const:   UserPass,
+	})
+	uProps.Set("user", &jsonschema.Schema{
+		Title:       "User",
+		Description: "The Snowflake user login name",
+		Type:        "string",
+		Extras: map[string]interface{}{
+			"order": 1,
+		},
+	})
+	uProps.Set("password", &jsonschema.Schema{
+		Title:       "Password",
+		Description: "The password for the provided user",
+		Type:        "string",
+		Extras: map[string]interface{}{
+			"secret": true,
+			"order":  2,
+		},
+	})
+
+	jwtProps := orderedmap.New[string, *jsonschema.Schema]()
+	jwtProps.Set("auth_type", &jsonschema.Schema{
+		Type:    "string",
+		Default: JWT,
+		Const:   JWT,
+	})
+	jwtProps.Set("user", &jsonschema.Schema{
+		Title:       "User",
+		Description: "The Snowflake user login name",
+		Type:        "string",
+		Extras: map[string]interface{}{
+			"order": 1,
+		},
+	})
+	jwtProps.Set("private_key", &jsonschema.Schema{
+		Title:       "Private Key",
+		Description: "Private Key to be used to sign the JWT token",
+		Type:        "string",
+		Extras: map[string]interface{}{
+			"secret":    true,
+			"multiline": true,
+			"order":     2,
+		},
+	})
+
+	return &jsonschema.Schema{
+		Title:       "Authentication",
+		Description: "Snowflake Credentials",
+		Default:     map[string]string{"auth_type": JWT},
+		OneOf: []*jsonschema.Schema{
+			{
+				Title:      "Private Key (JWT)",
+				Required:   []string{"auth_type", "private_key"},
+				Properties: jwtProps,
+			},
+			{
+				Title:      "User Password",
+				Required:   []string{"auth_type", "user", "password"},
+				Properties: uProps,
+			},
+		},
+		Extras: map[string]interface{}{
+			"discriminator": map[string]string{"propertyName": "auth_type"},
+		},
+		Type: "object",
+	}
+}

--- a/go/auth/snowflake/config_test.go
+++ b/go/auth/snowflake/config_test.go
@@ -1,0 +1,78 @@
+package snowflake
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/bradleyjkemp/cupaloy"
+	schemagen "github.com/estuary/connectors/go/schema-gen"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConfigSchema(t *testing.T) {
+	t.Parallel()
+
+	schema := schemagen.GenerateSchema("Test Config Schema", CredentialConfig{})
+	formatted, err := json.MarshalIndent(schema, "", "  ")
+	require.NoError(t, err)
+	cupaloy.SnapshotT(t, formatted)
+}
+
+func TestConfigValidate(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		conf CredentialConfig
+		want error
+	}{
+		{
+			name: "invalid auth type",
+			conf: CredentialConfig{
+				AuthType: "Invalid",
+			},
+			want: fmt.Errorf("invalid credentials auth type %q", "Invalid"),
+		},
+		{
+			name: "missing user",
+			conf: CredentialConfig{
+				AuthType: UserPass,
+				Password: "mypassword",
+			},
+			want: fmt.Errorf("missing user"),
+		},
+		{
+			name: "missing password",
+			conf: CredentialConfig{
+				AuthType: UserPass,
+				User:     "myuser",
+			},
+			want: fmt.Errorf("missing password"),
+		},
+		{
+			name: "invalid private key",
+			conf: CredentialConfig{
+				AuthType:   JWT,
+				User:       "myuser",
+				PrivateKey: "some-invalid-key",
+			},
+			want: fmt.Errorf("invalid private key: must be PEM format"),
+		},
+		{
+			name: "missing private key",
+			conf: CredentialConfig{
+				AuthType: JWT,
+				User:     "myuser",
+			},
+			want: fmt.Errorf("missing private_key"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.conf.Validate()
+			require.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/materialize-snowflake/config_test.go
+++ b/materialize-snowflake/config_test.go
@@ -5,6 +5,8 @@ import (
 
 	"github.com/bradleyjkemp/cupaloy"
 	"github.com/stretchr/testify/require"
+
+	snowflake_auth "github.com/estuary/connectors/go/auth/snowflake"
 )
 
 func TestConfigURI(t *testing.T) {
@@ -13,11 +15,11 @@ func TestConfigURI(t *testing.T) {
 			Host:     "orgname-accountname.snowflakecomputing.com",
 			Database: "mydb",
 			Schema:   "myschema",
-			Credentials: credentialConfig{
-				UserPass,
-				"will",
-				"some+complex/password",
-				"non-existant-jwt",
+			Credentials: &snowflake_auth.CredentialConfig{
+				AuthType:   snowflake_auth.UserPass,
+				User:       "will",
+				Password:   "some+complex/password",
+				PrivateKey: "non-existant-jwt",
 			},
 		},
 		"Optional Parameters": {
@@ -27,11 +29,11 @@ func TestConfigURI(t *testing.T) {
 			Warehouse: "mywarehouse",
 			Role:      "myrole",
 			Account:   "myaccount",
-			Credentials: credentialConfig{
-				UserPass,
-				"alex",
-				"mysecret",
-				"non-existant-jwt",
+			Credentials: &snowflake_auth.CredentialConfig{
+				AuthType:   snowflake_auth.UserPass,
+				User:       "alex",
+				Password:   "mysecret",
+				PrivateKey: "non-existant-jwt",
 			},
 		},
 	} {

--- a/materialize-snowflake/pipe.go
+++ b/materialize-snowflake/pipe.go
@@ -136,7 +136,7 @@ func NewPipeClient(cfg *config, accountName string, tenant string) (*PipeClient,
 		return nil, fmt.Errorf("parsing snowflake dsn: %w", err)
 	}
 
-	key, err := cfg.Credentials.privateKey()
+	key, err := cfg.Credentials.ParsePrivateKey()
 	if err != nil {
 		return nil, err
 	}
@@ -198,7 +198,7 @@ const userAgent = "Estuary Technologies Flow"
 
 func (c *PipeClient) refreshJWT() error {
 	if time.Until(c.expiry).Minutes() < 5 {
-		var key, err = c.cfg.Credentials.privateKey()
+		var key, err = c.cfg.Credentials.ParsePrivateKey()
 		if err != nil {
 			return err
 		}

--- a/materialize-snowflake/snowflake_test.go
+++ b/materialize-snowflake/snowflake_test.go
@@ -14,6 +14,7 @@ import (
 	sql "github.com/estuary/connectors/materialize-sql"
 	pm "github.com/estuary/flow/go/protocols/materialize"
 	"github.com/stretchr/testify/require"
+	snowflake_auth "github.com/estuary/connectors/go/auth/snowflake"
 
 	_ "github.com/snowflakedb/gosnowflake"
 )
@@ -25,8 +26,8 @@ func mustGetCfg(t *testing.T) config {
 	}
 
 	out := config{
-		Credentials: credentialConfig{
-			AuthType: JWT,
+		Credentials: &snowflake_auth.CredentialConfig{
+			AuthType: snowflake_auth.JWT,
 		},
 	}
 

--- a/materialize-snowflake/stream_http.go
+++ b/materialize-snowflake/stream_http.go
@@ -180,7 +180,7 @@ type streamClient struct {
 func newStreamClient(cfg *config, account string) (*streamClient, error) {
 	var role *string
 
-	key, err := cfg.Credentials.privateKey()
+	key, err := cfg.Credentials.ParsePrivateKey()
 	if err != nil {
 		return nil, err
 	}

--- a/source-snowflake/.snapshots/TestConfigURI-Optional_Parameters
+++ b/source-snowflake/.snapshots/TestConfigURI-Optional_Parameters
@@ -1,0 +1,1 @@
+alex:some%2Bcomplex%2Fpassword@orgname-accountname.snowflakecomputing.com:443?GO_QUERY_RESULT_FORMAT=json&account=myaccount&client_session_keep_alive=true&database=mydb&ocspFailOpen=true&validateDefaultParameters=true&warehouse=mywarehouse

--- a/source-snowflake/.snapshots/TestConfigURI-Optional_Parameters
+++ b/source-snowflake/.snapshots/TestConfigURI-Optional_Parameters
@@ -1,1 +1,1 @@
-alex:some%2Bcomplex%2Fpassword@orgname-accountname.snowflakecomputing.com:443?GO_QUERY_RESULT_FORMAT=json&account=myaccount&client_session_keep_alive=true&database=mydb&ocspFailOpen=true&validateDefaultParameters=true&warehouse=mywarehouse
+alex:some%2Bcomplex%2Fpassword@orgname-accountname.snowflakecomputing.com:443?GO_QUERY_RESULT_FORMAT=json&account=myaccount&client_session_keep_alive=true&database=mydb&warehouse=mywarehouse

--- a/source-snowflake/.snapshots/TestConfigURI-User_&_Password_Authentication
+++ b/source-snowflake/.snapshots/TestConfigURI-User_&_Password_Authentication
@@ -1,0 +1,1 @@
+will:some%2Bcomplex%2Fpassword@orgname-accountname.snowflakecomputing.com:443?GO_QUERY_RESULT_FORMAT=json&account=myaccount&client_session_keep_alive=true&database=mydb&ocspFailOpen=true&validateDefaultParameters=true

--- a/source-snowflake/.snapshots/TestConfigURI-User_&_Password_Authentication
+++ b/source-snowflake/.snapshots/TestConfigURI-User_&_Password_Authentication
@@ -1,1 +1,1 @@
-will:some%2Bcomplex%2Fpassword@orgname-accountname.snowflakecomputing.com:443?GO_QUERY_RESULT_FORMAT=json&account=myaccount&client_session_keep_alive=true&database=mydb&ocspFailOpen=true&validateDefaultParameters=true
+will:some%2Bcomplex%2Fpassword@orgname-accountname.snowflakecomputing.com:443?GO_QUERY_RESULT_FORMAT=json&client_session_keep_alive=true&database=mydb

--- a/source-snowflake/config_test.go
+++ b/source-snowflake/config_test.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/bradleyjkemp/cupaloy"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConfigURI(t *testing.T) {
+	for name, cfg := range map[string]config{
+		"User & Password Authentication": {
+			Host:     "orgname-accountname.snowflakecomputing.com",
+			Database: "mydb",
+			User:     "will",
+			Account:  "myaccount",
+			Password: "some+complex/password",
+		},
+		"Optional Parameters": {
+			Host:      "orgname-accountname.snowflakecomputing.com",
+			Database:  "mydb",
+			User:      "alex",
+			Password:  "some+complex/password",
+			Warehouse: "mywarehouse",
+			Account:   "myaccount",
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			require.NoError(t, cfg.Validate())
+			uri := cfg.ToURI()
+			cupaloy.SnapshotT(t, uri)
+		})
+	}
+}

--- a/source-snowflake/config_test.go
+++ b/source-snowflake/config_test.go
@@ -13,7 +13,6 @@ func TestConfigURI(t *testing.T) {
 			Host:     "orgname-accountname.snowflakecomputing.com",
 			Database: "mydb",
 			User:     "will",
-			Account:  "myaccount",
 			Password: "some+complex/password",
 		},
 		"Optional Parameters": {

--- a/source-snowflake/config_test.go
+++ b/source-snowflake/config_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/bradleyjkemp/cupaloy"
+	snowflake_auth "github.com/estuary/connectors/go/auth/snowflake"
 	"github.com/stretchr/testify/require"
 )
 
@@ -12,21 +13,30 @@ func TestConfigURI(t *testing.T) {
 		"User & Password Authentication": {
 			Host:     "orgname-accountname.snowflakecomputing.com",
 			Database: "mydb",
-			User:     "will",
-			Password: "some+complex/password",
+			Credentials: &snowflake_auth.CredentialConfig{
+				AuthType:   snowflake_auth.UserPass,
+				User:       "will",
+				Password:   "some+complex/password",
+				PrivateKey: "non-existant-jwt",
+			},
 		},
 		"Optional Parameters": {
 			Host:      "orgname-accountname.snowflakecomputing.com",
 			Database:  "mydb",
-			User:      "alex",
-			Password:  "some+complex/password",
 			Warehouse: "mywarehouse",
 			Account:   "myaccount",
+			Credentials: &snowflake_auth.CredentialConfig{
+				AuthType:   snowflake_auth.UserPass,
+				User:       "alex",
+				Password:   "some+complex/password",
+				PrivateKey: "non-existant-jwt",
+			},
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
 			require.NoError(t, cfg.Validate())
-			uri := cfg.ToURI()
+			uri, err := cfg.ToURI()
+			require.NoError(t, err)
 			cupaloy.SnapshotT(t, uri)
 		})
 	}

--- a/source-snowflake/database.go
+++ b/source-snowflake/database.go
@@ -16,7 +16,7 @@ import (
 func connectSnowflake(ctx context.Context, cfg *config) (*sql.DB, error) {
 	log.WithFields(log.Fields{
 		"host":     cfg.Host,
-		"user":     cfg.User,
+		"user":     cfg.Credentials.User,
 		"database": cfg.Database,
 	}).Info("connecting to database")
 
@@ -26,7 +26,12 @@ func connectSnowflake(ctx context.Context, cfg *config) (*sql.DB, error) {
 	// it is our normal error propagation will handle it.
 	gosnowflake.GetLogger().SetOutput(io.Discard)
 
-	var conn, err = sql.Open("snowflake", cfg.ToURI())
+	dsn, err := cfg.ToURI()
+	if err != nil {
+		return nil, fmt.Errorf("error generating DSN: %w", err)
+	}
+
+	conn, err := sql.Open("snowflake", dsn)
 	if err != nil {
 		return nil, fmt.Errorf("unable to connect to database: %w", err)
 	}


### PR DESCRIPTION
**Description:**

The scope of this PR includes:
 - Make the `account` field optional & hidden for `source-snowflake` (similar to the work done for `materialize-snowflake` in https://github.com/estuary/connectors/pull/1725)
 - Move the common Snowflake authentication config code between `source-snowflake` and `materialize-snowflake` into the `go/auth/snowflake` package.
 - Update `source-snowflake` to support JWT authentication.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

Documentation for `source-snowflake` should be updated to reflect the new JWT authentication option.

**Notes for reviewers:**

Tested on a local stack. Confirmed with `source-snowflake` that:
- JWT authentication works to create a capture and replicate data from Snowflake.
- The DSN built with `config.ToURI` works for connecting to Snowflake.
- The `account` field is hidden in the UI. Captures that set the `account` field will continue to work, but the field won't be editable via the UI. Editing the `account` field will require using `flowctl`.

We have very few enabled, working `source-snowflake` captures. I plan to remove the `account` field from their specs after merging this PR, confirm those captures still work, then put up another PR to remove `account` altogether for `source-snowflake` since it seems like it's not needed for connecting to Snowflake.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/3012)
<!-- Reviewable:end -->
