### PR TITLE
source-shopify-native: add support for line items to orders binding

### DIFF
--- a/source-shopify-native/tests/snapshots/snapshots__capture__capture.stdout.json
+++ b/source-shopify-native/tests/snapshots/snapshots__capture__capture.stdout.json
@@ -541,6 +541,230 @@
       "estimatedTaxes": false,
       "id": "gid://shopify/Order/5714619858989",
       "legacyResourceId": "5714619858989",
+      "lineItems": [
+        {
+          "__parentId": "gid://shopify/Order/5714619858989",
+          "currentQuantity": 1,
+          "discountAllocations": [],
+          "discountedTotalSet": {
+            "presentmentMoney": {
+              "amount": "25.0",
+              "currencyCode": "USD"
+            },
+            "shopMoney": {
+              "amount": "25.0",
+              "currencyCode": "USD"
+            }
+          },
+          "discountedUnitPriceAfterAllDiscountsSet": {
+            "presentmentMoney": {
+              "amount": "25.0",
+              "currencyCode": "USD"
+            },
+            "shopMoney": {
+              "amount": "25.0",
+              "currencyCode": "USD"
+            }
+          },
+          "discountedUnitPriceSet": {
+            "presentmentMoney": {
+              "amount": "25.0",
+              "currencyCode": "USD"
+            },
+            "shopMoney": {
+              "amount": "25.0",
+              "currencyCode": "USD"
+            }
+          },
+          "duties": [],
+          "id": "gid://shopify/LineItem/14150963134509",
+          "image": {
+            "originalSrc": "https://cdn.shopify.com/s/files/1/0663/4006/1229/files/gift_card.png?v=1736867416"
+          },
+          "isGiftCard": true,
+          "lineItemGroup": null,
+          "nonFulfillableQuantity": 0,
+          "originalTotalSet": {
+            "presentmentMoney": {
+              "amount": "25.0",
+              "currencyCode": "USD"
+            },
+            "shopMoney": {
+              "amount": "25.0",
+              "currencyCode": "USD"
+            }
+          },
+          "originalUnitPriceSet": {
+            "presentmentMoney": {
+              "amount": "25.0",
+              "currencyCode": "USD"
+            },
+            "shopMoney": {
+              "amount": "25.0",
+              "currencyCode": "USD"
+            }
+          },
+          "product": {
+            "id": "gid://shopify/Product/8086707830829",
+            "legacyResourceId": "8086707830829"
+          },
+          "quantity": 1,
+          "refundableQuantity": 1,
+          "requiresShipping": false,
+          "sellingPlan": null,
+          "sku": null,
+          "taxLines": [],
+          "taxable": false,
+          "totalDiscountSet": {
+            "presentmentMoney": {
+              "amount": "0.0",
+              "currencyCode": "USD"
+            },
+            "shopMoney": {
+              "amount": "0.0",
+              "currencyCode": "USD"
+            }
+          },
+          "unfulfilledDiscountedTotalSet": {
+            "presentmentMoney": {
+              "amount": "25.0",
+              "currencyCode": "USD"
+            },
+            "shopMoney": {
+              "amount": "25.0",
+              "currencyCode": "USD"
+            }
+          },
+          "unfulfilledOriginalTotalSet": {
+            "presentmentMoney": {
+              "amount": "25.0",
+              "currencyCode": "USD"
+            },
+            "shopMoney": {
+              "amount": "25.0",
+              "currencyCode": "USD"
+            }
+          },
+          "unfulfilledQuantity": 1,
+          "variant": {
+            "id": "gid://shopify/ProductVariant/43217823367213",
+            "legacyResourceId": "43217823367213",
+            "sku": null
+          },
+          "vendor": "Snowboard Vendor"
+        },
+        {
+          "__parentId": "gid://shopify/Order/5714619858989",
+          "currentQuantity": 1,
+          "discountAllocations": [],
+          "discountedTotalSet": {
+            "presentmentMoney": {
+              "amount": "50.0",
+              "currencyCode": "USD"
+            },
+            "shopMoney": {
+              "amount": "50.0",
+              "currencyCode": "USD"
+            }
+          },
+          "discountedUnitPriceAfterAllDiscountsSet": {
+            "presentmentMoney": {
+              "amount": "50.0",
+              "currencyCode": "USD"
+            },
+            "shopMoney": {
+              "amount": "50.0",
+              "currencyCode": "USD"
+            }
+          },
+          "discountedUnitPriceSet": {
+            "presentmentMoney": {
+              "amount": "50.0",
+              "currencyCode": "USD"
+            },
+            "shopMoney": {
+              "amount": "50.0",
+              "currencyCode": "USD"
+            }
+          },
+          "duties": [],
+          "id": "gid://shopify/LineItem/14150963167277",
+          "image": {
+            "originalSrc": "https://cdn.shopify.com/s/files/1/0663/4006/1229/files/gift_card.png?v=1736867416"
+          },
+          "isGiftCard": true,
+          "lineItemGroup": null,
+          "nonFulfillableQuantity": 0,
+          "originalTotalSet": {
+            "presentmentMoney": {
+              "amount": "50.0",
+              "currencyCode": "USD"
+            },
+            "shopMoney": {
+              "amount": "50.0",
+              "currencyCode": "USD"
+            }
+          },
+          "originalUnitPriceSet": {
+            "presentmentMoney": {
+              "amount": "50.0",
+              "currencyCode": "USD"
+            },
+            "shopMoney": {
+              "amount": "50.0",
+              "currencyCode": "USD"
+            }
+          },
+          "product": {
+            "id": "gid://shopify/Product/8086707830829",
+            "legacyResourceId": "8086707830829"
+          },
+          "quantity": 1,
+          "refundableQuantity": 1,
+          "requiresShipping": false,
+          "sellingPlan": null,
+          "sku": null,
+          "taxLines": [],
+          "taxable": false,
+          "totalDiscountSet": {
+            "presentmentMoney": {
+              "amount": "0.0",
+              "currencyCode": "USD"
+            },
+            "shopMoney": {
+              "amount": "0.0",
+              "currencyCode": "USD"
+            }
+          },
+          "unfulfilledDiscountedTotalSet": {
+            "presentmentMoney": {
+              "amount": "50.0",
+              "currencyCode": "USD"
+            },
+            "shopMoney": {
+              "amount": "50.0",
+              "currencyCode": "USD"
+            }
+          },
+          "unfulfilledOriginalTotalSet": {
+            "presentmentMoney": {
+              "amount": "50.0",
+              "currencyCode": "USD"
+            },
+            "shopMoney": {
+              "amount": "50.0",
+              "currencyCode": "USD"
+            }
+          },
+          "unfulfilledQuantity": 1,
+          "variant": {
+            "id": "gid://shopify/ProductVariant/43217823399981",
+            "legacyResourceId": "43217823399981",
+            "sku": null
+          },
+          "vendor": "Snowboard Vendor"
+        }
+      ],
       "merchantOfRecordApp": null,
       "name": "#1001",
       "note": "Testing a note.",


### PR DESCRIPTION
**Description:**

This pull request enhances the `Orders` class in the Shopify GraphQL integration by adding support for detailed line item data. It also updates the `process_result` method to handle line items and adjusts the test snapshots to reflect these changes.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

This is a simple query update, so I did not test in a local stack. I did test with `flowctl preview` and verified the snapshots were updated too. The test account we use for this connector has one line item with a `discountedUnitPriceSet` of 524.96 USD (after per-item discount) which should show the price paid at order fulfillment. However, there are many prices and information that Shopify offers, so I went ahead added all top-level objects in `lineItems` that were of type `MoneyBag` and other identifying, quantity, or tax information useful in reporting (according to ChatGPT).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/3013)
<!-- Reviewable:end -->
