### PR TITLE
source-snowflake: remove `account` config input

### DIFF
--- a/source-snowflake/.snapshots/TestConfigURI-Optional_Parameters
+++ b/source-snowflake/.snapshots/TestConfigURI-Optional_Parameters
@@ -1,1 +1,1 @@
-alex:some%2Bcomplex%2Fpassword@orgname-accountname.snowflakecomputing.com:443?GO_QUERY_RESULT_FORMAT=json&account=myaccount&client_session_keep_alive=true&database=mydb&warehouse=mywarehouse
+alex:some%2Bcomplex%2Fpassword@orgname-accountname.snowflakecomputing.com:443?GO_QUERY_RESULT_FORMAT=json&client_session_keep_alive=true&database=mydb&warehouse=mywarehouse

--- a/source-snowflake/README.md
+++ b/source-snowflake/README.md
@@ -22,10 +22,19 @@ Example `flow.yaml` for discovery:
           connector:
             image: "ghcr.io/estuary/source-snowflake:v1"
             config:
+              credentials:
+                auth_type: jwt
+                user: snowflake_user
+                privateKey: |
+                  -----BEGIN PRIVATE KEY-----
+                  MIIEv....
+                  ...
+                  ...
+                  ...
+                  ...
+                  ...
+                  -----END PRIVATE KEY-----
               host: bn92689.us-central1.gcp.snowflakecomputing.com
-              account: bn92689
-              user: USERNAME
-              password: secret1234
               database: CONNECTOR_TESTING
               warehouse: COMPUTE_WH
         bindings: []

--- a/source-snowflake/config_test.go
+++ b/source-snowflake/config_test.go
@@ -24,7 +24,6 @@ func TestConfigURI(t *testing.T) {
 			Host:      "orgname-accountname.snowflakecomputing.com",
 			Database:  "mydb",
 			Warehouse: "mywarehouse",
-			Account:   "myaccount",
 			Credentials: &snowflake_auth.CredentialConfig{
 				AuthType:   snowflake_auth.UserPass,
 				User:       "alex",

--- a/source-snowflake/main.go
+++ b/source-snowflake/main.go
@@ -28,7 +28,6 @@ type config struct {
 	Host        string                           `json:"host" jsonschema:"title=Host URL,description=The Snowflake Host used for the connection. Must include the account identifier and end in .snowflakecomputing.com. Example: orgname-accountname.snowflakecomputing.com (do not include the protocol)." jsonschema_extras:"order=0,pattern=^[^/:]+.snowflakecomputing.com$"`
 	Database    string                           `json:"database" jsonschema:"title=Database,description=The database name to capture from." jsonschema_extras:"order=1"`
 	Warehouse   string                           `json:"warehouse,omitempty" jsonschema:"title=Warehouse,description=The Snowflake virtual warehouse used to execute queries. Uses the default warehouse for the Snowflake user if left blank." jsonschema_extras:"order=2"`
-	Account     string                           `json:"account,omitempty" jsonschema:"title=Account,description=Optional Snowflake account identifier." jsonschema_extras:"order=3,x-hidden-field=true"`
 	Credentials *snowflake_auth.CredentialConfig `json:"credentials" jsonschema:"title=Authentication"`
 	Advanced    advancedConfig                   `json:"advanced,omitempty" jsonschema:"title=Advanced Options,description=Options for advanced users. You should not typically need to modify these." jsonschema_extra:"advanced=true"`
 }
@@ -107,10 +106,6 @@ func (c *config) ToURI() (string, error) {
 	// Optional params
 	if c.Warehouse != "" {
 		queryParams.Add("warehouse", c.Warehouse)
-	}
-
-	if c.Account != "" {
-		queryParams.Add("account", c.Account)
 	}
 
 	// Authentication

--- a/source-snowflake/main_test.go
+++ b/source-snowflake/main_test.go
@@ -24,7 +24,6 @@ import (
 
 var (
 	dbHost      = flag.String("db_host", "bn92689.us-central1.gcp.snowflakecomputing.com", "The Snowflake host to use for tests")
-	dbAccount   = flag.String("db_account", "bn92689", "The Snowflake account ID to use for tests")
 	dbName      = flag.String("db_name", "CONNECTOR_TESTING", "The database to use for tests")
 	dbWarehouse = flag.String("db_warehouse", "COMPUTE_WH", "The warehouse to execute test queries in")
 	dbSchema    = flag.String("db_schema", "PUBLIC", "The schema to execute test queries in")
@@ -77,7 +76,6 @@ func snowflakeTestBackend(t *testing.T) *testBackend {
 	}
 	controlURI, err := (&config{
 		Host:      *dbHost,
-		Account:   *dbAccount,
 		Database:  *dbName,
 		Warehouse: *dbWarehouse,
 		Credentials: &snowflake_auth.CredentialConfig{
@@ -99,7 +97,6 @@ func snowflakeTestBackend(t *testing.T) *testBackend {
 	// Construct the capture config
 	var captureConfig = config{
 		Host:      *dbHost,
-		Account:   *dbAccount,
 		Database:  *dbName,
 		Warehouse: *dbWarehouse,
 		Credentials: &snowflake_auth.CredentialConfig{


### PR DESCRIPTION
**Description:**

As a follow up to 8bd108c4cd4e4757eb4d5be49c0548b489180ab1, the `account` config input is getting removed. We haven't observed any reason to include `account` when building the DSN for a Snowflake connection, so it's easier on both us & users to not ask for it at all.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

