### PR TITLE
materialize-snowflake: hide account input

### DIFF
--- a/materialize-snowflake/.snapshots/TestSpecification
+++ b/materialize-snowflake/.snapshots/TestSpecification
@@ -38,7 +38,8 @@
         "type": "string",
         "title": "Account",
         "description": "Optional Snowflake account identifier.",
-        "order": 7
+        "order": 7,
+        "x-hidden-field": true
       },
       "hardDelete": {
         "type": "boolean",

--- a/materialize-snowflake/config.go
+++ b/materialize-snowflake/config.go
@@ -26,7 +26,7 @@ type config struct {
 	Schema        string                           `json:"schema" jsonschema:"title=Schema,description=Database schema for bound collection tables (unless overridden within the binding resource configuration)." jsonschema_extras:"order=4"`
 	Warehouse     string                           `json:"warehouse,omitempty" jsonschema:"title=Warehouse,description=The Snowflake virtual warehouse used to execute queries. Uses the default warehouse for the Snowflake user if left blank." jsonschema_extras:"order=5"`
 	Role          string                           `json:"role,omitempty" jsonschema:"title=Role,description=The user role used to perform actions." jsonschema_extras:"order=6"`
-	Account       string                           `json:"account,omitempty" jsonschema:"title=Account,description=Optional Snowflake account identifier." jsonschema_extras:"order=7"`
+	Account       string                           `json:"account,omitempty" jsonschema:"title=Account,description=Optional Snowflake account identifier." jsonschema_extras:"order=7,x-hidden-field=true"`
 	HardDelete    bool                             `json:"hardDelete,omitempty" jsonschema:"title=Hard Delete,description=If this option is enabled items deleted in the source will also be deleted from the destination. By default is disabled and _meta/op in the destination will signify whether rows have been deleted (soft-delete).,default=false" jsonschema_extras:"order=8"`
 	Credentials   *snowflake_auth.CredentialConfig `json:"credentials" jsonschema:"title=Authentication"`
 	Schedule      boilerplate.ScheduleConfig       `json:"syncSchedule,omitempty" jsonschema:"title=Sync Schedule,description=Configure schedule of transactions for the materialization."`


### PR DESCRIPTION
**Description:**

Similar to `source-snowflake` in 8bd108c4cd4e4757eb4d5be49c0548b489180ab1, we heavily suspect the `account` field isn't needed when connecting to Snowflake. Although we're ~99% sure of that, the potential blast radius of that 1% chance is fairly large since there are a huge number of `materialize-snowflake` materializations in production.

To fully remove the `account` input, we'd need to be 100% certain it's not needed, maybe by querying Snowflake for the current account then logging out that value and whatever `account` is specified in the config, if any. That'd take a lot of manual effort and checking though, and there's not much benefit to doing so other than getting `source-snowflake`'s and `materialize-snowflake`'s configs more aligned. So until we prioritize that work, we can simply hide the `account` field in the UI with `x-hidden-field`. This maintains any existing `account`s while disallowing the addition of `account` when setting up or editing a materialization. Changing the `account` for existing materializations will require using `flowctl`, but I think it's unlikely users will need to change the configured account after initial setup.

If we decide that we _do_ need to allow users to edit the `account` via the UI, this change is easily rolled back.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

The connector's documentation should be updated to remove the `account` field.

**Notes for reviewers:**

Tested using `x-hidden-field` and republishing a spec on a local stack. Confirmed that values set before a field is hidden are preserved when editing & publishing a spec in the UI after the field is hidden.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/3017)
<!-- Reviewable:end -->
