### PR TITLE
source-stripe-native: fix prioritization bug for connected accounts

### DIFF
--- a/source-stripe-native/source_stripe_native/resources.py
+++ b/source-stripe-native/source_stripe_native/resources.py
@@ -712,7 +712,6 @@ def no_events_object(
         all_bindings,
     ):
         if not connected_account_ids:
-            # Handle single platform account case (no connected accounts)
             fetch_changes_fns = functools.partial(
                 fetch_incremental_no_events,
                 cls,


### PR DESCRIPTION
**Description:**

Multiple "backfill is yielding to work item cancellation" messages were getting logged when capturing from connected accounts, which I did not anticipate. When building the `PriorityQueueManager`, I intended for any ongoing backfills to be allowed to continue with a deterministic priority mechanism. However, I messed up the logic in `_refresh_work_queue` when determining what accounts should have their work canceled.

This PR fixes that bug; we now correctly remove any of the prioritized account ids from the set of accounts with active work to determine what work should be canceled.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

I didn't test on a local stack since this is a fairly straight-forward change.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/3018)
<!-- Reviewable:end -->
