### PR TITLE
source-snowflake: add optional input for role

### DIFF
--- a/source-snowflake/.snapshots/TestConfigURI-Optional_Parameters
+++ b/source-snowflake/.snapshots/TestConfigURI-Optional_Parameters
@@ -1,1 +1,1 @@
-alex:some%2Bcomplex%2Fpassword@orgname-accountname.snowflakecomputing.com:443?GO_QUERY_RESULT_FORMAT=json&client_session_keep_alive=true&database=mydb&warehouse=mywarehouse
+alex:some%2Bcomplex%2Fpassword@orgname-accountname.snowflakecomputing.com:443?GO_QUERY_RESULT_FORMAT=json&client_session_keep_alive=true&database=mydb&role=myrole&warehouse=mywarehouse

--- a/source-snowflake/config_test.go
+++ b/source-snowflake/config_test.go
@@ -24,6 +24,7 @@ func TestConfigURI(t *testing.T) {
 			Host:      "orgname-accountname.snowflakecomputing.com",
 			Database:  "mydb",
 			Warehouse: "mywarehouse",
+			Role:      "myrole",
 			Credentials: &snowflake_auth.CredentialConfig{
 				AuthType:   snowflake_auth.UserPass,
 				User:       "alex",

--- a/source-snowflake/main.go
+++ b/source-snowflake/main.go
@@ -28,6 +28,7 @@ type config struct {
 	Host        string                           `json:"host" jsonschema:"title=Host URL,description=The Snowflake Host used for the connection. Must include the account identifier and end in .snowflakecomputing.com. Example: orgname-accountname.snowflakecomputing.com (do not include the protocol)." jsonschema_extras:"order=0,pattern=^[^/:]+.snowflakecomputing.com$"`
 	Database    string                           `json:"database" jsonschema:"title=Database,description=The database name to capture from." jsonschema_extras:"order=1"`
 	Warehouse   string                           `json:"warehouse,omitempty" jsonschema:"title=Warehouse,description=The Snowflake virtual warehouse used to execute queries. Uses the default warehouse for the Snowflake user if left blank." jsonschema_extras:"order=2"`
+	Role        string                           `json:"role,omitempty" jsonschema:"title=Role,description=The user role used to perform actions." jsonschema_extras:"order=3"`
 	Credentials *snowflake_auth.CredentialConfig `json:"credentials" jsonschema:"title=Authentication"`
 	Advanced    advancedConfig                   `json:"advanced,omitempty" jsonschema:"title=Advanced Options,description=Options for advanced users. You should not typically need to modify these." jsonschema_extra:"advanced=true"`
 }
@@ -106,6 +107,10 @@ func (c *config) ToURI() (string, error) {
 	// Optional params
 	if c.Warehouse != "" {
 		queryParams.Add("warehouse", c.Warehouse)
+	}
+
+	if c.Role != "" {
+		queryParams.Add("role", c.Role)
 	}
 
 	// Authentication


### PR DESCRIPTION
**Description:**

A user correctly pointed out that we should accept an input for which role to use when querying Snowflake. This PR adds that input.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

Connector documentation should be updated to reflect the new, optional input.

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/3023)
<!-- Reviewable:end -->
