### PR TITLE
source-google-analytics-data-api-native: increase default resource interval

### DIFF
--- a/source-google-analytics-data-api-native/source_google_analytics_data_api_native/resources.py
+++ b/source-google-analytics-data-api-native/source_google_analytics_data_api_native/resources.py
@@ -209,7 +209,7 @@ def reports(
                 backfill=ResourceState.Backfill(cutoff=cutoff, next_page=dt_to_str(start))
             ),
             initial_config=ResourceConfig(
-                name=report.name, interval=timedelta(minutes=30)
+                name=report.name, interval=timedelta(hours=12)
             ),
             schema_inference=True,
         )

--- a/source-google-analytics-data-api-native/tests/snapshots/snapshots__discover__capture.stdout.json
+++ b/source-google-analytics-data-api-native/tests/snapshots/snapshots__discover__capture.stdout.json
@@ -3,7 +3,7 @@
     "recommendedName": "daily_active_users",
     "resourceConfig": {
       "name": "daily_active_users",
-      "interval": "PT30M"
+      "interval": "PT12H"
     },
     "documentSchema": {
       "$defs": {
@@ -73,7 +73,7 @@
     "recommendedName": "devices",
     "resourceConfig": {
       "name": "devices",
-      "interval": "PT30M"
+      "interval": "PT12H"
     },
     "documentSchema": {
       "$defs": {
@@ -161,7 +161,7 @@
     "recommendedName": "four_weekly_active_users",
     "resourceConfig": {
       "name": "four_weekly_active_users",
-      "interval": "PT30M"
+      "interval": "PT12H"
     },
     "documentSchema": {
       "$defs": {
@@ -231,7 +231,7 @@
     "recommendedName": "locations",
     "resourceConfig": {
       "name": "locations",
-      "interval": "PT30M"
+      "interval": "PT12H"
     },
     "documentSchema": {
       "$defs": {
@@ -319,7 +319,7 @@
     "recommendedName": "my_custom_report_with_a_filter",
     "resourceConfig": {
       "name": "my_custom_report_with_a_filter",
-      "interval": "PT30M"
+      "interval": "PT12H"
     },
     "documentSchema": {
       "$defs": {
@@ -395,7 +395,7 @@
     "recommendedName": "pages",
     "resourceConfig": {
       "name": "pages",
-      "interval": "PT30M"
+      "interval": "PT12H"
     },
     "documentSchema": {
       "$defs": {
@@ -477,7 +477,7 @@
     "recommendedName": "traffic_sources",
     "resourceConfig": {
       "name": "traffic_sources",
-      "interval": "PT30M"
+      "interval": "PT12H"
     },
     "documentSchema": {
       "$defs": {
@@ -559,7 +559,7 @@
     "recommendedName": "website_overview",
     "resourceConfig": {
       "name": "website_overview",
-      "interval": "PT30M"
+      "interval": "PT12H"
     },
     "documentSchema": {
       "$defs": {
@@ -629,7 +629,7 @@
     "recommendedName": "weekly_active_users",
     "resourceConfig": {
       "name": "weekly_active_users",
-      "interval": "PT30M"
+      "interval": "PT12H"
     },
     "documentSchema": {
       "$defs": {


### PR DESCRIPTION
**Description:**

Users frequently do not want to re-capture the same day's reports every 30 minutes. Instead, default to a longer interval so users don't have to push the interval out themselves as often.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

Connector docs should be updated to reflect the new default value of 12 hours.

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/3025)
<!-- Reviewable:end -->
