### PR TITLE
materialize-s3-iceberg: pass through parsed field config to projectionToParquetSchemaElement

### DIFF
--- a/materialize-boilerplate/materializer.go
+++ b/materialize-boilerplate/materializer.go
@@ -532,7 +532,13 @@ func RunApply[EC EndpointConfiger, FC FieldConfiger, RC Resourcer[RC, EC], MT Ma
 				// created with that source field type. This scenario would
 				// involve one invoked Apply RPC racing with another, which is
 				// not likely, but perhaps not totally impossible.
-				return nil, fmt.Errorf("existing field %q has incompatible type %q that cannot be migrated", p.Field, p.Mapped.String())
+				return nil, fmt.Errorf(
+					"existing field type mismatch for field %q of binding %q: existing %q vs %q is incompatible and cannot be migrated",
+					existingField.Name,
+					mb.ResourcePath,
+					existingField.Type,
+					p.Mapped.String(),
+				)
 			}
 		}
 

--- a/materialize-s3-iceberg/driver.go
+++ b/materialize-s3-iceberg/driver.go
@@ -344,7 +344,7 @@ func (d *materialization) NewConstraint(p pf.Projection, deltaUpdates bool, fc f
 }
 
 func (d *materialization) MapType(p boilerplate.Projection, fc fieldConfig) (mappedType, boilerplate.ElementConverter) {
-	s, err := projectionToParquetSchemaElement(p.Projection, nil)
+	s, err := projectionToParquetSchemaElement(p.Projection, fc)
 	if err != nil {
 		return mappedType{}, nil
 	}


### PR DESCRIPTION
**Description:**

Fixes a bug where the parsed field config was not being passed to the `projectionToParquetSchemaElement` function, which is currently necessary for the "ignoreStringFormat" field configuration option to work.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/3030)
<!-- Reviewable:end -->
