### PR TITLE
source-facebook-marketing - support custom insights streams at non-ad level

### DIFF
--- a/source-facebook-marketing/source_facebook_marketing/schemas/ads_insights.json
+++ b/source-facebook-marketing/source_facebook_marketing/schemas/ads_insights.json
@@ -28,7 +28,7 @@
       "type": ["null", "string"]
     },
     "adset_id": {
-      "type": ["null", "string"]
+      "type": ["string"]
     },
     "adset_name": {
       "type": ["null", "string"]
@@ -49,7 +49,7 @@
       "type": ["null", "string"]
     },
     "campaign_id": {
-      "type": ["null", "string"]
+      "type": ["string"]
     },
     "campaign_name": {
       "type": ["null", "string"]
@@ -311,6 +311,5 @@
       "$ref": "ads_action_stats.json"
     }
   },
-  "type": ["object"],
-  "required": ["account_id", "ad_id", "date_start"]
+  "type": ["object"]
 }

--- a/source-facebook-marketing/source_facebook_marketing/source.py
+++ b/source-facebook-marketing/source_facebook_marketing/source.py
@@ -232,7 +232,7 @@ class SourceFacebookMarketing(AbstractSource):
                 end_date=insight.end_date or config.end_date,
                 insights_lookback_window=insight.insights_lookback_window or config.insights_lookback_window,
                 level=insight.level,
-                source_defined_primary_key=["ad_id"]
+                is_custom_stream=True,
             )
             streams.append(stream)
         return streams

--- a/source-facebook-marketing/source_facebook_marketing/streams/base_insight_streams.py
+++ b/source-facebook-marketing/source_facebook_marketing/streams/base_insight_streams.py
@@ -136,28 +136,25 @@ class AdsInsights(FBMarketingIncrementalStream):
             return "adset_id"
         elif self.level == "campaign":
             return "campaign_id"
-        elif self.level == "account":
-            return "account_id"
         else:
             raise RuntimeError(
                 f"Unexpected level {self.level} for AdsInsights stream. "
-                f"Expected one of: account, campaign, adset, ad. "
+                f"Expected one of: campaign, adset, ad. "
                 f"Please check your configuration."
             )
 
     def level_specific_fields(self) -> List[str]:
-        if self.level == "account":
-            return self.ACCOUNT_FIELDS
-        elif self.level == "campaign":
-            return self.ACCOUNT_FIELDS + self.CAMPAIGN_FIELDS
+        common_fields = self.ACCOUNT_FIELDS + self.CAMPAIGN_FIELDS
+        if self.level == "campaign":
+            return common_fields
         elif self.level == "adset":
-            return self.ACCOUNT_FIELDS + self.CAMPAIGN_FIELDS + self.ADSET_FIELDS
+            return common_fields + self.ADSET_FIELDS
         elif self.level == "ad":
-            return self.ACCOUNT_FIELDS + self.CAMPAIGN_FIELDS + self.ADSET_FIELDS + self.AD_FIELDS
+            return common_fields + self.ADSET_FIELDS + self.AD_FIELDS
         else:
             raise RuntimeError(
                 f"Unexpected level {self.level} for AdsInsights stream. "
-                f"Expected one of: account, campaign, adset, ad. "
+                f"Expected one of: campaign, adset, ad. "
                 f"Please check your configuration."
             )
 

--- a/source-facebook-marketing/tests/snapshots/snapshots__discover__capture.stdout.json
+++ b/source-facebook-marketing/tests/snapshots/snapshots__discover__capture.stdout.json
@@ -12537,7 +12537,6 @@
         },
         "adset_id": {
           "type": [
-            "null",
             "string"
           ]
         },
@@ -12579,7 +12578,6 @@
         },
         "campaign_id": {
           "type": [
-            "null",
             "string"
           ]
         },
@@ -15874,9 +15872,9 @@
       ]
     },
     "key": [
-      "/date_start",
       "/account_id",
-      "/ad_id"
+      "/ad_id",
+      "/date_start"
     ]
   },
   {
@@ -16218,7 +16216,6 @@
         },
         "adset_id": {
           "type": [
-            "null",
             "string"
           ]
         },
@@ -16260,7 +16257,6 @@
         },
         "campaign_id": {
           "type": [
-            "null",
             "string"
           ]
         },
@@ -19569,10 +19565,10 @@
       ]
     },
     "key": [
-      "/date_start",
       "/account_id",
       "/ad_id",
       "/age",
+      "/date_start",
       "/gender"
     ]
   },
@@ -19915,7 +19911,6 @@
         },
         "adset_id": {
           "type": [
-            "null",
             "string"
           ]
         },
@@ -19957,7 +19952,6 @@
         },
         "campaign_id": {
           "type": [
-            "null",
             "string"
           ]
         },
@@ -23259,10 +23253,10 @@
       ]
     },
     "key": [
-      "/date_start",
       "/account_id",
       "/ad_id",
-      "/country"
+      "/country",
+      "/date_start"
     ]
   },
   {
@@ -23604,7 +23598,6 @@
         },
         "adset_id": {
           "type": [
-            "null",
             "string"
           ]
         },
@@ -23646,7 +23639,6 @@
         },
         "campaign_id": {
           "type": [
-            "null",
             "string"
           ]
         },
@@ -26948,9 +26940,9 @@
       ]
     },
     "key": [
-      "/date_start",
       "/account_id",
       "/ad_id",
+      "/date_start",
       "/region"
     ]
   },
@@ -27293,7 +27285,6 @@
         },
         "adset_id": {
           "type": [
-            "null",
             "string"
           ]
         },
@@ -27335,7 +27326,6 @@
         },
         "campaign_id": {
           "type": [
-            "null",
             "string"
           ]
         },
@@ -30637,9 +30627,9 @@
       ]
     },
     "key": [
-      "/date_start",
       "/account_id",
       "/ad_id",
+      "/date_start",
       "/dma"
     ]
   },
@@ -30982,7 +30972,6 @@
         },
         "adset_id": {
           "type": [
-            "null",
             "string"
           ]
         },
@@ -31024,7 +31013,6 @@
         },
         "campaign_id": {
           "type": [
-            "null",
             "string"
           ]
         },
@@ -34340,12 +34328,12 @@
       ]
     },
     "key": [
-      "/date_start",
       "/account_id",
       "/ad_id",
-      "/publisher_platform",
+      "/date_start",
+      "/impression_device",
       "/platform_position",
-      "/impression_device"
+      "/publisher_platform"
     ]
   },
   {
@@ -34687,7 +34675,6 @@
         },
         "adset_id": {
           "type": [
-            "null",
             "string"
           ]
         },
@@ -34729,7 +34716,6 @@
         },
         "campaign_id": {
           "type": [
-            "null",
             "string"
           ]
         },
@@ -38024,9 +38010,9 @@
       ]
     },
     "key": [
-      "/date_start",
       "/account_id",
-      "/ad_id"
+      "/ad_id",
+      "/date_start"
     ]
   },
   {
@@ -38860,7 +38846,6 @@
         },
         "adset_id": {
           "type": [
-            "null",
             "string"
           ]
         },
@@ -38872,7 +38857,6 @@
         },
         "campaign_id": {
           "type": [
-            "null",
             "string"
           ]
         },
@@ -39022,9 +39006,9 @@
       ]
     },
     "key": [
-      "/date_start",
       "/account_id",
       "/ad_id",
+      "/date_start",
       "/publisher_platform"
     ]
   }

--- a/source-facebook-marketing/tests/snapshots/snapshots__spec__capture.stdout.json
+++ b/source-facebook-marketing/tests/snapshots/snapshots__spec__capture.stdout.json
@@ -73,8 +73,7 @@
                 "enum": [
                   "ad",
                   "adset",
-                  "campaign",
-                  "account"
+                  "campaign"
                 ],
                 "type": "string"
               },


### PR DESCRIPTION
**Description:**

Prevously, custom insight streams always used the `ad_id` field as part of the primary key. That's all well and good for `ad` level insights, but at any other level the `ad_id` field is not present in the returned records. Instead, there are fields like `campaign_id`, `adset_id`, etc. that should be used as part of the primary key.

This PR adds handling to automatically determine the primary key for custom insight streams based on its level. We're also now adding these required fields into the fields specified by the user so we know they'll always be present in documents.

I've also removed the option to choose `account` as a level for custom insights. There are no users attempting to create account level custom insights, and I could not successfully get any account level insights out of Facebook's API. The connector was previously treating account level insights exactly like ad level ones, so I removed the illusion of choice between the two. If someone comes along later and requests account level insights, we can figure out how to do that then.



**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

Tested on a local stack. Confirmed:
- Custom insight streams at the `ad`, `adset`, and `campaign`, and levels have the appropriate primary keys & successfully capture data.
- Selecting no fields for a custom insight stream defaults to capturing all eligible fields specified in `ads_insights.json`. 
  - Note: This isn't the behavior I'd implement if someone decided to not select any fields, but that's how the connector has behaved previously & at least one user is already relying on that behavior.

