### PR TITLE
materializer: make incompatible fields with no migration support a warning instead of an error during Apply

### DIFF
--- a/materialize-boilerplate/materializer.go
+++ b/materialize-boilerplate/materializer.go
@@ -532,13 +532,12 @@ func RunApply[EC EndpointConfiger, FC FieldConfiger, RC Resourcer[RC, EC], MT Ma
 				// created with that source field type. This scenario would
 				// involve one invoked Apply RPC racing with another, which is
 				// not likely, but perhaps not totally impossible.
-				return nil, fmt.Errorf(
-					"existing field type mismatch for field %q of binding %q: existing %q vs %q is incompatible and cannot be migrated",
-					existingField.Name,
-					mb.ResourcePath,
-					existingField.Type,
-					p.Mapped.String(),
-				)
+				log.WithFields(log.Fields{
+					"resourcePath": mb.ResourcePath,
+					"field":        p.Field,
+					"existingType": existingField.Type,
+					"mappedType":   p.Mapped.String(),
+				}).Warn("existing field type mismatch without migration support")
 			}
 		}
 


### PR DESCRIPTION
**Description:**

We might as well try to materialize the data into the existing field, even if we can't confirm it has a compatible "column", if we've gotten to the point of calling Apply.

So instead of failing the connector, log a warning message that will probably be what we reference when/if the connector does fail later on.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

