### PR TITLE
source-facebook-marketing: adjust retention date validation for timezone handling

### DIFF
--- a/source-facebook-marketing/source_facebook_marketing/utils.py
+++ b/source-facebook-marketing/source_facebook_marketing/utils.py
@@ -29,6 +29,12 @@ def validate_start_date(start_date: DateTime) -> DateTime:
         # 2023-03-31 - 37 month = 2020-02-29 which is incorrect, should be 2020-03-01
         # that's why we're adjusting the date to the 1st day of the next month
         retention_date = retention_date.replace(month=retention_date.month + 1, day=1)
+    else:
+        # Facebook does not use UTC for the insights API and instead uses the
+        # user's timezone. To avoid timezone related issues when a user has a
+        # positive timezone offset, we add a day to the retention date so we're
+        # always within the retention period.
+        retention_date = retention_date.add(days=1)
 
     if start_date > now:
         message = f"The start date cannot be in the future. Set start date to today's date - {today}."


### PR DESCRIPTION
**Description:**

Facebook uses the user's timezone for the insights API, not UTC. We can't query for insights older than 37 months in the past, so `validate_start_date` pulls forward the start date to ensure we're submitting queries within that 37 month window. This works fine when the user's timezone is UTC or has a negative offset, but when a user has a positive offset (like +08:00), we end up pulling the start date up to 37 months and 1 day according to their timezone.

To avoid these timezone related issues, we can add a day to the originally calculated `retention_date` so we're always within the 37 month retention period.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

Tested on a local stack. Confirmed the capture no longer attempts to query insights beyond 37 months in the past when using a Facebook account with a positive timezone offset.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/3034)
<!-- Reviewable:end -->
