### PR TITLE
materializer: do not try to re-create columns that are case insensitive which already exist

### DIFF
--- a/materialize-boilerplate/apply.go
+++ b/materialize-boilerplate/apply.go
@@ -84,7 +84,7 @@ func ApplyChanges(ctx context.Context, req *pm.Request_Apply, applier Applier, i
 		}
 	}
 
-	computed, err := computeCommonUpdates(req.LastMaterialization, req.Materialization, is)
+	computed, err := computeCommonUpdates(req.LastMaterialization, req.Materialization, is, false)
 	if err != nil {
 		return nil, fmt.Errorf("computing common updates: %w", err)
 	}
@@ -156,7 +156,7 @@ type computedUpdates struct {
 	updatedBindings  map[int]BindingUpdate
 }
 
-func computeCommonUpdates(last, next *pf.MaterializationSpec, is *InfoSchema) (*computedUpdates, error) {
+func computeCommonUpdates(last, next *pf.MaterializationSpec, is *InfoSchema, caseInsensitiveFields bool) (*computedUpdates, error) {
 	out := computedUpdates{
 		updatedBindings: make(map[int]BindingUpdate),
 	}

--- a/materialize-boilerplate/apply_test.go
+++ b/materialize-boilerplate/apply_test.go
@@ -213,7 +213,7 @@ func testInfoSchemaFromSpec(t *testing.T, s *pf.MaterializationSpec, transform f
 		return out
 	}
 
-	is := NewInfoSchema(transformPath, transform)
+	is := NewInfoSchema(transformPath, transform, false)
 
 	if s == nil || len(s.Bindings)+len(s.InactiveBindings) == 0 {
 		return is

--- a/materialize-boilerplate/info_schema_test.go
+++ b/materialize-boilerplate/info_schema_test.go
@@ -26,7 +26,7 @@ func TestInfoSchema(t *testing.T) {
 		return strings.TrimSuffix(in, "_transformed")
 	}
 
-	is := NewInfoSchema(transformPath, transform)
+	is := NewInfoSchema(transformPath, transform, true)
 
 	nullableField := ExistingField{
 		Name:               transform("nullableField"),
@@ -64,6 +64,10 @@ func TestInfoSchema(t *testing.T) {
 		got = res2.GetField(untransform(nonNullableField.Name))
 		require.Equal(t, nonNullableField, *got)
 
+		// Case insensitive match.
+		got = res1.GetField(strings.ToLower(untransform(nullableField.Name)))
+		require.Equal(t, nullableField, *got)
+
 		// Resource doesn't have the field.
 		got = res2.GetField(untransform(nullableField.Name))
 		require.Nil(t, got)
@@ -89,6 +93,14 @@ func TestInfoSchema(t *testing.T) {
 		require.NoError(t, err)
 		require.False(t, got)
 
+		// Case insensitive match.
+		fs = pf.FieldSelection{
+			Values: []string{strings.ToLower(untransform(nullableField.Name))},
+		}
+		got, err = is.inSelectedFields(nullableField.Name, fs)
+		require.NoError(t, err)
+		require.True(t, got)
+
 		// Ambiguous case.
 		fs = pf.FieldSelection{
 			Values: []string{untransform(nullableField.Name), untransform(nullableField.Name)},
@@ -112,6 +124,7 @@ func TestInfoSchema(t *testing.T) {
 				return out
 			},
 			translate,
+			false,
 		)
 
 		paths := [][]string{

--- a/materialize-boilerplate/materializer.go
+++ b/materialize-boilerplate/materializer.go
@@ -450,7 +450,7 @@ func RunApply[EC EndpointConfiger, FC FieldConfiger, RC Resourcer[RC, EC], MT Ma
 		actionDescriptions = append(actionDescriptions, desc)
 	}
 
-	common, err := computeCommonUpdates(req.LastMaterialization, req.Materialization, is)
+	common, err := computeCommonUpdates(req.LastMaterialization, req.Materialization, is, mCfg.CaseInsensitiveFields)
 	if err != nil {
 		return nil, err
 	}
@@ -628,7 +628,7 @@ func initInfoSchema(cfg MaterializeCfg) *InfoSchema {
 		translateField = cfg.Translate
 	}
 
-	return NewInfoSchema(locatePath, translateField)
+	return NewInfoSchema(locatePath, translateField, cfg.CaseInsensitiveFields)
 }
 
 func buildMappedBinding[EC EndpointConfiger, FC FieldConfiger, RC Resourcer[RC, EC], MT MappedTyper](

--- a/materialize-redshift/driver_test.go
+++ b/materialize-redshift/driver_test.go
@@ -25,7 +25,11 @@ func mustGetCfg(t *testing.T) config {
 		return config{}
 	}
 
-	out := config{}
+	out := config{
+		Advanced: advancedConfig{
+			FeatureFlags: "allow_existing_tables_for_new_bindings",
+		},
+	}
 
 	for _, prop := range []struct {
 		key  string

--- a/materialize-s3-iceberg/driver_test.go
+++ b/materialize-s3-iceberg/driver_test.go
@@ -77,6 +77,7 @@ func TestValidateAndApply(t *testing.T) {
 			is := boilerplate.NewInfoSchema(
 				func(rp []string) []string { return rp },
 				func(f string) string { return f },
+				true,
 			)
 			require.NoError(t, catalog.populateInfoSchema(ctx, is, [][]string{path}))
 

--- a/materialize-sql-v2/validate_test.go
+++ b/materialize-sql-v2/validate_test.go
@@ -138,7 +138,7 @@ func testInfoSchemaFromSpec(t *testing.T, s *pf.MaterializationSpec, transform f
 		return out
 	}
 
-	is := boilerplate.NewInfoSchema(transformPath, transform)
+	is := boilerplate.NewInfoSchema(transformPath, transform, false)
 
 	if s == nil || len(s.Bindings) == 0 {
 		return is

--- a/materialize-sql/std_sql.go
+++ b/materialize-sql/std_sql.go
@@ -328,6 +328,7 @@ func StdFetchInfoSchema(
 	is := boilerplate.NewInfoSchema(
 		ToLocatePathFn(dialect.TableLocator),
 		dialect.ColumnLocator,
+		dialect.CaseInsensitiveColumns,
 	)
 
 	if len(resourcePaths) == 0 {

--- a/materialize-sql/validate_test.go
+++ b/materialize-sql/validate_test.go
@@ -138,7 +138,7 @@ func testInfoSchemaFromSpec(t *testing.T, s *pf.MaterializationSpec, transform f
 		return out
 	}
 
-	is := boilerplate.NewInfoSchema(transformPath, transform)
+	is := boilerplate.NewInfoSchema(transformPath, transform, false)
 
 	if s == nil || len(s.Bindings) == 0 {
 		return is


### PR DESCRIPTION
**Description:**

If a destination system does not allow materialized fields to differ in capitalization but does report out its fields while preserving their casing, don't try to create a new field even if the source Flow collection field has a different casing. By definition it won't work, so we should just proceed and assume that the pre-existing field is going to be used for the Flow field even though it has a different casing.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/3035)
<!-- Reviewable:end -->
