### PR TITLE
materialize-snowflake: use correct table identifier in stream manager

### DIFF
--- a/materialize-snowflake/snowflake.go
+++ b/materialize-snowflake/snowflake.go
@@ -304,7 +304,7 @@ func (d *transactor) addBinding(ctx context.Context, target sql.Table, streaming
 
 	if b.target.DeltaUpdates && d.cfg.Credentials.AuthType == snowflake_auth.JWT && streamingEnabled {
 		loc := d.ep.Dialect.TableLocator(b.target.Path)
-		if err := d.streamManager.addBinding(ctx, loc.TableSchema, target); err != nil {
+		if err := d.streamManager.addBinding(ctx, loc.TableSchema, d.ep.Identifier(loc.TableName), target); err != nil {
 			var apiError *streamingApiError
 			var colError *unhandledColError
 			if errors.As(err, &apiError) && apiError.Code == 55 {

--- a/materialize-snowflake/stream.go
+++ b/materialize-snowflake/stream.go
@@ -92,8 +92,8 @@ func newStreamManager(cfg *config, materialization string, tenant string, accoun
 	}, nil
 }
 
-func (sm *streamManager) addBinding(ctx context.Context, schema string, table sql.Table) error {
-	channel, err := sm.c.openChannel(ctx, schema, table.Identifier, sm.channelName)
+func (sm *streamManager) addBinding(ctx context.Context, schema string, table string, target sql.Table) error {
+	channel, err := sm.c.openChannel(ctx, schema, table, sm.channelName)
 	if err != nil {
 		return fmt.Errorf("openChannel: %w", err)
 	}
@@ -105,8 +105,8 @@ func (sm *streamManager) addBinding(ctx context.Context, schema string, table sq
 		}
 	}
 
-	sm.tableStreams[table.Binding] = &tableStream{
-		mappedColumns: table.Columns(),
+	sm.tableStreams[target.Binding] = &tableStream{
+		mappedColumns: target.Columns(),
 		channel:       channel,
 	}
 

--- a/materialize-snowflake/stream_test.go
+++ b/materialize-snowflake/stream_test.go
@@ -86,7 +86,7 @@ func TestStreamManager(t *testing.T) {
 		sm, err := newStreamManager(&cfg, "testing", "testing", accountName, 0)
 		require.NoError(t, err)
 
-		require.NoError(t, sm.addBinding(ctx, cfg.Schema, table))
+		require.NoError(t, sm.addBinding(ctx, cfg.Schema, table.Identifier, table))
 
 		require.NoError(t, sm.encodeRow(ctx, 0, []any{"key1", "hello1", "world1"}))
 		require.NoError(t, sm.encodeRow(ctx, 0, []any{"key2", "hello2", "world2"}))
@@ -116,7 +116,7 @@ func TestStreamManager(t *testing.T) {
 		// A second invocation invalidates the first.
 		ssm, err := newStreamManager(&cfg, "testing", "testing", accountName, 0)
 		require.NoError(t, err)
-		require.NoError(t, ssm.addBinding(ctx, cfg.Schema, table))
+		require.NoError(t, ssm.addBinding(ctx, cfg.Schema, table.Identifier, table))
 
 		require.NoError(t, sm.encodeRow(ctx, 0, []any{"key4", "hello4", "world4"}))
 		require.NoError(t, sm.encodeRow(ctx, 0, []any{"key5", "hello5", "world5"}))
@@ -179,7 +179,7 @@ func TestStreamManager(t *testing.T) {
 		sm, err := newStreamManager(&cfg, "testing", "testing", accountName, 0)
 		require.NoError(t, err)
 
-		require.NoError(t, sm.addBinding(ctx, cfg.Schema, table))
+		require.NoError(t, sm.addBinding(ctx, cfg.Schema, table.Identifier, table))
 
 		require.NoError(t, sm.encodeRow(ctx, 0, []any{"key1", "hello1", "world1"}))
 		require.NoError(t, sm.encodeRow(ctx, 0, []any{"key2", "hello2", "world2"}))
@@ -251,7 +251,7 @@ func TestStreamManager(t *testing.T) {
 		require.NoError(t, err)
 
 		for _, tbl := range tables {
-			require.NoError(t, sm.addBinding(ctx, cfg.Schema, tbl))
+			require.NoError(t, sm.addBinding(ctx, cfg.Schema, tbl.Identifier, tbl))
 		}
 
 		require.NoError(t, sm.encodeRow(ctx, 0, []any{"key1", "hello1", "world1"}))
@@ -368,7 +368,7 @@ func TestStreamManager(t *testing.T) {
 
 		sm, err := newStreamManager(&cfg, "testing", "testing", accountName, 0)
 		require.NoError(t, err)
-		require.NoError(t, sm.addBinding(ctx, cfg.Schema, tbl))
+		require.NoError(t, sm.addBinding(ctx, cfg.Schema, tbl.Identifier, tbl))
 
 		require.NoError(t, sm.encodeRow(ctx, 0, []any{"key1", "hello1", "goodbye1", "aloha1"}))
 		require.NoError(t, sm.encodeRow(ctx, 0, []any{"key2", "hello2", "goodbye2", "aloha2"}))
@@ -486,7 +486,7 @@ func TestStreamDatatypes(t *testing.T) {
 			sm, err := newStreamManager(&cfg, "testing", "testing", accountName, 0)
 			require.NoError(t, err)
 
-			require.NoError(t, sm.addBinding(ctx, cfg.Schema, tbl))
+			require.NoError(t, sm.addBinding(ctx, cfg.Schema, tbl.Identifier, tbl))
 
 			for i, val := range tt.vals {
 				require.NoError(t, sm.encodeRow(ctx, 0, []any{i, val}))


### PR DESCRIPTION
**Description:**

The table name and table schema are separate inputs to the Snowpipe streaming API. Previously if there was an alternate schema for a binding, the fully qualified identifier was being used as the table name, which would cause "table not found" errors.

This fix uses only the table name part for the table name.

I tested this manually using a materialization config with several bindings, where some of them have an alternate schema specified.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/3039)
<!-- Reviewable:end -->
