### PR TITLE
source-jira-native: handle more permission issues

### DIFF
--- a/source-jira-native/source_jira_native/models.py
+++ b/source-jira-native/source_jira_native/models.py
@@ -87,6 +87,16 @@ ConnectorState = GenericConnectorState[ResourceState]
 APIRecord = dict[str, Any]
 
 
+class AbbreviatedProject(BaseModel):
+    model_config = {"extra": "ignore"}
+    
+    class ProjectPermissions(BaseModel):
+        canEdit: bool
+
+    id: str
+    permissions: ProjectPermissions
+
+
 class FullRefreshResource(BaseDocument, extra="allow"):
     pass
 


### PR DESCRIPTION
**Description:**

This PR's scope includes:
- Conditionally discover more of the existing streams based on the provided credentials' permissions.
  - I'm not 100% certain this covers all possible permission issues, but it addresses the permissions issues we've observed so far that stop us from accessing an endpoint. Instead of attempting to interpret Jira's docs on which endpoints require what permissions (and potentially interpreting it incorrectly), I prefer to wait and see concrete instances of permission issues before changing discovery logic.
- Avoid making requests for `project_emails` that we know will fail.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

Tested on a local stack. Confirmed the streams added to `PERMISSION_BLOCKED_STREAMS` are conditionally discovered and that `project_emails` only fetches records for projects we have permission to edit.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/3040)
<!-- Reviewable:end -->
