### PR TITLE
source-postgres: Only check watermarks table in non-readonly mode

### DIFF
--- a/source-postgres/replication.go
+++ b/source-postgres/replication.go
@@ -1212,7 +1212,9 @@ func (db *postgresDatabase) ReplicationDiagnostics(ctx context.Context) error {
 		}
 	}
 
-	query("SELECT * FROM " + db.WatermarksTable().String() + ";")
+	if !db.config.Advanced.ReadOnlyCapture {
+		query("SELECT * FROM " + db.WatermarksTable().String() + ";")
+	}
 	query("SELECT * FROM pg_replication_slots;")
 	query("SELECT pg_current_wal_flush_lsn(), pg_current_wal_insert_lsn(), pg_current_wal_lsn();")
 	return nil


### PR DESCRIPTION
**Description:**

Our automatic replication diagnostics previously issued a `SELECT * FROM <watermarks>` query just to check what that table looked like, but really we should only do that in the mode where we expect the watermarks table to exist and be written to.