### PR TITLE
source-postgres: Handle ErrorResponse messages

### DIFF
--- a/source-postgres/replication.go
+++ b/source-postgres/replication.go
@@ -487,6 +487,13 @@ func (s *replicationStream) relayChanges(ctx context.Context, callback func(even
 			continue // Ignore and keep looking for something we care about.
 		case MessageTypeCopyData: // CopyData messages are all we care about during replication streaming
 			data = msg[5:]
+		case MessageTypeErrorResponse:
+			var resp pgproto3.ErrorResponse
+			if err := resp.Decode(msg[5:]); err != nil {
+				return fmt.Errorf("error decoding ErrorResponse: %w", err)
+			} else {
+				return pgconn.ErrorResponseToPgError(&resp)
+			}
 		default:
 			return fmt.Errorf("unexpected message type %q", msgType)
 		}


### PR DESCRIPTION
**Description:**

We already handled errors _starting_ replication, but they can also occur during the stream when we're expecting the next CDC event, and we should report them as a proper error there too.
