### PR TITLE
source-monday: Remove board cache and simplify backfill pagination

### DIFF
--- a/source-monday/source_monday/api.py
+++ b/source-monday/source_monday/api.py
@@ -10,9 +10,9 @@ from source_monday.graphql import (
     fetch_activity_logs,
     fetch_boards_by_ids,
     fetch_boards_minimal,
+    fetch_boards_paginated,
     fetch_items_by_ids,
     fetch_items,
-    fetch_boards_with_retry,
     TEAMS,
     USERS,
     TAGS,
@@ -37,7 +37,6 @@ FULL_REFRESH_RESOURCES: list[tuple[str, str]] = [
 ]
 
 
-_boards_backfill_cache: list[str] = []
 
 
 async def fetch_boards_changes(
@@ -92,7 +91,7 @@ async def fetch_boards_changes(
             )
             continue
 
-        if "delete" in activity_log.event:
+        if "board_deleted" in activity_log.event:
             deleted_board = Board(
                 id=activity_log.resource_id,
                 updated_at=created_at,
@@ -152,48 +151,24 @@ async def fetch_boards_page(
 
     limit = 100
     docs_emitted = 0
+    boards_fetched = 0
 
-    if not _boards_backfill_cache:
-        log.debug("Fetching initial boards for backfill cache")
+    log.debug(f"Processing page {page} with limit {limit}")
 
-        async for board in fetch_boards_minimal(http, log):
-            if board.updated_at <= cutoff:
-                _boards_backfill_cache.append(board.id)
+    async for board in fetch_boards_paginated(http, log, page, limit):
+        boards_fetched += 1
+        
+        if board.updated_at <= cutoff and board.state != "deleted":
+            docs_emitted += 1
+            yield board
 
-        log.debug(
-            f"Populated backfill cache with {len(_boards_backfill_cache)} boards for cutoff {cutoff}"
-        )
-
-    log.debug(
-        f"Processing page {page} with limit {limit} from cache of {len(_boards_backfill_cache)} boards"
-    )
-
-    boards_in_page = 0
-    async for board in fetch_boards_with_retry(
-        http,
-        log,
-        ids=_boards_backfill_cache,
-        page=page,
-        limit=limit,
-    ):
-        boards_in_page += 1
-        if board.updated_at <= cutoff:
-            if board.state != "deleted":
-                docs_emitted += 1
-                yield board
-
-    start_idx = (page - 1) * limit
-    end_idx = start_idx + limit
-    has_more_pages = end_idx < len(_boards_backfill_cache)
-
-    if has_more_pages:
+    if boards_fetched > 0:
         log.debug(
             f"Boards backfill completed for page {page}",
             {
                 "board_page": page,
                 "qualifying_boards": docs_emitted,
-                "boards_in_page": boards_in_page,
-                "total_cache_size": len(_boards_backfill_cache),
+                "boards_fetched": boards_fetched,
                 "next_page": page + 1,
             },
         )
@@ -204,9 +179,8 @@ async def fetch_boards_page(
             {
                 "board_page": page,
                 "qualifying_boards": docs_emitted,
-                "boards_in_page": boards_in_page,
-                "total_cache_size": len(_boards_backfill_cache),
-                "reason": "no_more_pages",
+                "boards_fetched": boards_fetched,
+                "reason": "no_more_boards",
             },
         )
         return
@@ -270,7 +244,7 @@ async def fetch_items_changes(
             )
             continue
 
-        if "delete" in activity_log.event:
+        if "delete_pulse" in activity_log.event:
             deleted_item = Item(
                 id=activity_log.resource_id,
                 updated_at=created_at,

--- a/source-monday/source_monday/graphql/__init__.py
+++ b/source-monday/source_monday/graphql/__init__.py
@@ -2,6 +2,7 @@ from .activity_logs import fetch_activity_logs
 from .boards import (
     fetch_boards_by_ids,
     fetch_boards_minimal,
+    fetch_boards_paginated,
     fetch_boards_with_retry,
 )
 from .constants import (
@@ -27,6 +28,7 @@ __all__ = [
     "fetch_activity_logs",
     "fetch_boards_by_ids",
     "fetch_boards_minimal",
+    "fetch_boards_paginated",
     "fetch_items_by_ids",
     "fetch_items",
     "fetch_boards_with_retry",

--- a/source-monday/source_monday/graphql/boards.py
+++ b/source-monday/source_monday/graphql/boards.py
@@ -89,6 +89,32 @@ async def fetch_boards_minimal(
         page += 1
 
 
+async def fetch_boards_paginated(
+    http: HTTPSession,
+    log: Logger,
+    page: int = 1,
+    limit: int = 100,
+) -> AsyncGenerator[Board, None]:
+    variables = {
+        "limit": limit,
+        "page": page,
+        "state": "all",
+    }
+    
+    log.debug(f"Fetching boards for page {page} with limit {limit}")
+    
+    boards_in_page = 0
+    try:
+        async for board in _try_fetch_boards(http, log, variables):
+            boards_in_page += 1
+            yield board
+    except GraphQLQueryError as e:
+        log.error(f"Failed to fetch boards for page {page}: {e}")
+        raise
+    
+    log.debug(f"Page {page} returned {boards_in_page} boards")
+
+
 async def fetch_boards_with_retry(
     http: HTTPSession,
     log: Logger,


### PR DESCRIPTION
**Description:**

Eliminates the global `_boards_backfill_cache` and replaces complex cache-based pagination with direct board pagination, resolving critical data consistency issues in backfill operations.

### Problem

The existing board backfill implementation had several critical issues:

- **Double API calls**: `fetch_boards_minimal()` to populate cache, then `fetch_boards_with_retry()` to fetch full data
- **Cache coordination complexity**: Managing cache state across restarts and incremental sync transitions
- **Missing boards**: Cache population could miss active/archived boards due to state filtering inconsistencies

### Solution

- **Removed** global `_boards_backfill_cache` entirely
- **Added** `fetch_boards_paginated()` for direct board pagination without ID lists
- **Simplified** `fetch_boards_page()` to use inline filtering during iteration
- **Unified** board state filtering logic (`<= cutoff && != "deleted"`)

### Benefits

- **Performance**: Single API call per page instead of double fetching
- **Reliability**: No cache miss scenarios or state coordination issues  
- **Memory**: Eliminated potentially large in-memory cache
- **Maintainability**: Reduced code complexity

### Impact

- Resolves board backfill missing active/archived boards
- Eliminates restart scenarios where cache state becomes inconsistent
- Reduces memory usage during large dataset processing
- Improves backfill performance and reliability

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

I tested this on a local stack and then manually queried all active, archived, and deleted boards and observed that all boards were backfilled even through various restarts using `flowctl-go shards unassign`. The backfill consistently picked back up on the last checkpointed page and reliably fetched all boards.

Additionally, there was one board that was backfilled before it was deleted. The incremental task captured the delete of that board soon after it was backfilled.

