### PR TITLE
Add Drata exclusion label to source-gcs test bucket

### DIFF
--- a/tests/source-gcs/setup.sh
+++ b/tests/source-gcs/setup.sh
@@ -16,6 +16,7 @@ config_json_template='{
 export CONNECTOR_CONFIG="$(echo "$config_json_template" | envsubst | jq -c)"
 
 gsutil mb "gs://${TEST_STREAM}"
+gsutil label ch -l "drataexclude:test-equipment" "gs://${TEST_STREAM}"
 
 root_dir="$(git rev-parse --show-toplevel)"
 


### PR DESCRIPTION
## Summary
• Adds `drataexclude:test-equipment` label to GCS buckets created during source-gcs testing
• Automatically excludes test buckets from Drata compliance monitoring
• Eliminates need for manual exclusion of test infrastructure

## Test plan
- [x] Verified label is applied correctly by running test locally
- [x] Confirmed bucket cleanup still works properly
- [x] Tested gsutil label command executes without errors

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/3044)
<!-- Reviewable:end -->
