### PR TITLE
source-google-ads: support call_view as a full refresh custom GAQL stream

### DIFF
--- a/source-google-ads/source_google_ads/custom_query_stream.py
+++ b/source-google-ads/source_google_ads/custom_query_stream.py
@@ -8,6 +8,13 @@ from typing import Any, Dict, Mapping
 from .streams import GoogleAdsStream, IncrementalGoogleAdsStream
 from .utils import GAQL
 
+# Google Ads says these fields are DATE data types, but
+# they don't match the ISO 8601 date or datetime formats.
+# They actually look like "2025-07-05 09:33:58".
+NON_DATE_FORMATTED_FIELDS = [
+    "call_view.start_call_date_time",
+    "call_view.end_call_date_time",
+]
 
 class CustomQueryMixin:
     def __init__(self, config, **kwargs):
@@ -75,7 +82,7 @@ class CustomQueryMixin:
             else:
                 output_type = [google_datatype_mapping.get(google_data_type, "string"), "null"]
                 field_value = {"type": output_type}
-                if google_data_type == "DATE":
+                if google_data_type == "DATE" and field not in NON_DATE_FORMATTED_FIELDS:
                     field_value["format"] = "date"
 
             local_json_schema["properties"][field] = field_value

--- a/source-google-ads/source_google_ads/source.py
+++ b/source-google-ads/source_google_ads/source.py
@@ -39,7 +39,7 @@ from .streams import (
 )
 from .utils import GAQL
 
-FULL_REFRESH_CUSTOM_TABLE = ["asset", "asset_group_listing_group_filter", "custom_audience", "geo_target_constant"]
+FULL_REFRESH_CUSTOM_TABLE = ["asset", "asset_group_listing_group_filter", "call_view", "custom_audience", "geo_target_constant"]
 
 
 class SourceGoogleAds(AbstractSource):


### PR DESCRIPTION


**Description:**

Google Ads' call_view resource does not have segments.date available, so our existing incremental custom query logic won't work for call_view - it assumes there's always a segments.date field that can be used as a cursor field. Adding call_view to the `FULL_REFRESH_CUSTOM_TABLE` list allows users to capture from this resource as a full refresh stream.

As an aside, it may be possible to incrementally capture from call_view using `end_call_date_time` as a cursor field, but re-wiring the connector to support that is a larger effort than I'd like to take on for this imported connector.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

Tested on a local stack. Confirmed:
- a custom query stream using the `call_view` table is supported in the config.
- all records from the `call_view` table are captured without errors.