### PR TITLE
source-kinesis: bump allowed idle connections to avoid excessive re-creation

### DIFF
--- a/source-kinesis/main.go
+++ b/source-kinesis/main.go
@@ -7,6 +7,7 @@ import (
 	"maps"
 	"slices"
 
+	awsHTTP "github.com/aws/aws-sdk-go-v2/aws/transport/http"
 	schemagen "github.com/estuary/connectors/go/schema-gen"
 	boilerplate "github.com/estuary/connectors/source-boilerplate"
 	pc "github.com/estuary/flow/go/protocols/capture"
@@ -177,6 +178,8 @@ func (d *driver) Apply(ctx context.Context, req *pc.Request_Apply) (*pc.Response
 }
 
 func main() {
+	awsHTTP.DefaultHTTPTransportMaxIdleConns = 100        // From 100.
+	awsHTTP.DefaultHTTPTransportMaxIdleConnsPerHost = 100 // From 10.
 	boilerplate.RunMain(new(driver))
 }
 


### PR DESCRIPTION
**Description:**

Applies an identical change as was made to source-dynamodb to improve connection re-use and minimize DNS resolution requests.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/3048)
<!-- Reviewable:end -->
