### PR TITLE
materialize-snowflake: do not enforce VARIANT max length if account supports it

### DIFF
--- a/materialize-snowflake/bdec_test.go
+++ b/materialize-snowflake/bdec_test.go
@@ -42,7 +42,7 @@ func TestBdecWriter(t *testing.T) {
 	key, err := deriveKey(encryptionKey, fileName)
 	require.NoError(t, err)
 
-	w, err := newBdecWriter(tmpFile, mappedColumns, existingColumns, encryptionKey, fileName)
+	w, err := newBdecWriter(tmpFile, mappedColumns, existingColumns, encryptionKey, fileName, false)
 	require.NoError(t, err)
 
 	require.NoError(t, w.encodeRow([]any{"hello1", "world1"}))

--- a/materialize-snowflake/snowflake_test.go
+++ b/materialize-snowflake/snowflake_test.go
@@ -10,11 +10,11 @@ import (
 	"testing"
 
 	"github.com/bradleyjkemp/cupaloy"
+	snowflake_auth "github.com/estuary/connectors/go/auth/snowflake"
 	boilerplate "github.com/estuary/connectors/materialize-boilerplate"
 	sql "github.com/estuary/connectors/materialize-sql-v2"
 	pm "github.com/estuary/flow/go/protocols/materialize"
 	"github.com/stretchr/testify/require"
-	snowflake_auth "github.com/estuary/connectors/go/auth/snowflake"
 
 	_ "github.com/snowflakedb/gosnowflake"
 )


### PR DESCRIPTION
**Description:**

The Snowflake behavior change 2025_03 bundle allows VARIANT columns to be extremely large, up to 128 MB. If this bundle is enabled we don't need to check that VARIANT values are too large.

It could still technically be disabled if the user has opted their account out of the bundle. In a couple of months this is slated to be enabled everywhere all the time no matter what, and we can remove most of this code then.

Closes https://github.com/estuary/connectors/issues/3060

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/3061)
<!-- Reviewable:end -->
