### PR TITLE
Wgd/2025 07 08 sqlserver optimization

### DIFF
--- a/source-sqlserver/backfill.go
+++ b/source-sqlserver/backfill.go
@@ -140,7 +140,7 @@ func (db *sqlserverDatabase) ScanTableChunk(ctx context.Context, info *sqlcaptur
 		log.WithField("fields", fields).Trace("got row")
 		var seqval = make([]byte, 10)
 		binary.BigEndian.PutUint64(seqval[2:], uint64(rowOffset))
-		var event = &sqlcapture.OldChangeEvent{
+		var event = &sqlserverChangeEvent{
 			Operation: sqlcapture.InsertOp,
 			RowKey:    rowKey,
 			Source: &sqlserverSourceInfo{

--- a/source-sqlserver/change.go
+++ b/source-sqlserver/change.go
@@ -1,0 +1,24 @@
+package main
+
+import (
+	"encoding/base64"
+	"fmt"
+)
+
+type sqlserverCommitEvent struct {
+	CommitLSN LSN
+}
+
+func (sqlserverCommitEvent) IsDatabaseEvent() {}
+func (sqlserverCommitEvent) IsCommitEvent()   {}
+
+func (evt *sqlserverCommitEvent) String() string {
+	return fmt.Sprintf("Commit(%X)", evt.CommitLSN)
+}
+
+func (evt *sqlserverCommitEvent) AppendJSON(buf []byte) ([]byte, error) {
+	// Since base64 strings never require escaping we can just splat it between quotes.
+	buf = append(buf, '"')
+	buf = base64.StdEncoding.AppendEncode(buf, evt.CommitLSN)
+	return append(buf, '"'), nil
+}

--- a/source-sqlserver/change.go
+++ b/source-sqlserver/change.go
@@ -4,6 +4,7 @@ import (
 	"encoding/base64"
 	"fmt"
 
+	"github.com/estuary/connectors/go/encrow"
 	"github.com/estuary/connectors/sqlcapture"
 	"github.com/segmentio/encoding/json"
 )
@@ -26,65 +27,149 @@ func (evt *sqlserverCommitEvent) AppendJSON(buf []byte) ([]byte, error) {
 	return append(buf, '"'), nil
 }
 
+// A jsonTranscoder is something which can transcode a SQL Server client library value into JSON.
+type jsonTranscoder interface {
+	TranscodeJSON(buf []byte, v any) ([]byte, error)
+}
+
+type jsonTranscoderFunc func(buf []byte, v any) ([]byte, error)
+
+func (f jsonTranscoderFunc) TranscodeJSON(buf []byte, v any) ([]byte, error) {
+	return f(buf, v)
+}
+
+// An fdbTranscoder is something which can transcode a SQL Server client library value into an FDB tuple value.
+type fdbTranscoder interface {
+	TranscodeFDB(buf []byte, v any) ([]byte, error)
+}
+
+type fdbTranscoderFunc func(buf []byte, v any) ([]byte, error)
+
+func (f fdbTranscoderFunc) TranscodeFDB(buf []byte, v any) ([]byte, error) { return f(buf, v) }
+
 type sqlserverChangeEvent struct {
-	Operation sqlcapture.ChangeOp
-	RowKey    []byte
-	Source    sqlcapture.SourceMetadata
-	Before    map[string]interface{}
-	After     map[string]interface{}
+	Shared *sqlserverChangeSharedInfo
+	Meta   sqlserverChangeMetadata `json:"_meta"`
+	RowKey []byte
+	Values []any
+}
+
+type sqlserverChangeSharedInfo struct {
+	StreamID    sqlcapture.StreamID // StreamID of the table this change event came from.
+	Shape       *encrow.Shape       // Shape of the document values, used to serialize them to JSON.
+	Transcoders []jsonTranscoder    // Transcoders for column values, in DB column order.
 }
 
 func (sqlserverChangeEvent) IsDatabaseEvent() {}
 func (sqlserverChangeEvent) IsChangeEvent()   {}
 
 func (e *sqlserverChangeEvent) String() string {
-	switch e.Operation {
+	switch e.Meta.Operation {
 	case sqlcapture.InsertOp:
-		return fmt.Sprintf("Insert(%s)", e.Source.Common().StreamID())
+		return fmt.Sprintf("Insert(%s)", e.Shared.StreamID)
 	case sqlcapture.UpdateOp:
-		return fmt.Sprintf("Update(%s)", e.Source.Common().StreamID())
+		return fmt.Sprintf("Update(%s)", e.Shared.StreamID)
 	case sqlcapture.DeleteOp:
-		return fmt.Sprintf("Delete(%s)", e.Source.Common().StreamID())
+		return fmt.Sprintf("Delete(%s)", e.Shared.StreamID)
 	}
-	return fmt.Sprintf("UnknownChange(%s)", e.Source.Common().StreamID())
+	return fmt.Sprintf("UnknownChange(%s)", e.Shared.StreamID)
 }
 
 func (e *sqlserverChangeEvent) StreamID() sqlcapture.StreamID {
-	return e.Source.Common().StreamID()
+	return e.Shared.StreamID
 }
 
 func (e *sqlserverChangeEvent) GetRowKey() []byte {
 	return e.RowKey
 }
 
-// MarshalJSON implements serialization of a ChangeEvent to JSON.
-//
-// Note that this implementation is destructive, but that's okay because
-// emitting the serialized JSON is the last thing we ever do with a change.
+// AppendJSON appends the JSON representation of the change event to the provided buffer.
 func (e *sqlserverChangeEvent) AppendJSON(buf []byte) ([]byte, error) {
-	var record map[string]any
-	var meta = struct {
-		Operation sqlcapture.ChangeOp       `json:"op"`
-		Source    sqlcapture.SourceMetadata `json:"source"`
-		Before    map[string]any            `json:"before,omitempty"`
-	}{
-		Operation: e.Operation,
-		Source:    e.Source,
-		Before:    nil,
-	}
-	switch e.Operation {
-	case sqlcapture.InsertOp:
-		record = e.After // Before is never used.
-	case sqlcapture.UpdateOp:
-		meta.Before, record = e.Before, e.After
-	case sqlcapture.DeleteOp:
-		record = e.Before // After is never used.
-	}
-	if record == nil {
-		record = make(map[string]any)
-	}
-	record["_meta"] = &meta
+	var shape = e.Shared.Shape
 
-	// Marshal to JSON and append to the provided buffer.
-	return json.Append(buf, record, json.EscapeHTML|json.SortMapKeys)
+	// The number of byte values should be one less than the shape's arity, because the last field of
+	// the shape is the metadata. Note that this also means there can never be an empty shape here.
+	if len(e.Values) != shape.Arity-1 {
+		return nil, fmt.Errorf("incorrect row arity: expected %d but got %d", shape.Arity, len(e.Values))
+	}
+
+	var err error
+	var subsequentField bool
+	buf = append(buf, '{')
+	for idx, vidx := range shape.Swizzle {
+		var val any
+		if vidx < len(e.Values) {
+			val = e.Values[vidx]
+		}
+		if subsequentField {
+			buf = append(buf, ',')
+		}
+		subsequentField = true
+		buf = append(buf, shape.Prefixes[idx]...)
+		if vidx < len(e.Values) {
+			buf, err = e.Shared.Transcoders[vidx].TranscodeJSON(buf, val)
+		} else {
+			buf, err = e.Meta.AppendJSON(buf) // The last value index is the metadata
+		}
+		if err != nil {
+			return nil, fmt.Errorf("error encoding field %q: %w", shape.Names[idx], err)
+		}
+	}
+	return append(buf, '}'), nil
+}
+
+type sqlserverChangeMetadata struct {
+	Operation sqlcapture.ChangeOp `json:"op"`
+	Source    sqlserverSourceInfo `json:"source"`
+}
+
+// AppendJSON appends the JSON representation of the change metadata to the provided buffer.
+func (meta *sqlserverChangeMetadata) AppendJSON(buf []byte) ([]byte, error) {
+	return json.Append(buf, meta, 0)
+}
+
+// sqlserverSourceInfo is source metadata for data capture events.
+type sqlserverSourceInfo struct {
+	sqlcapture.SourceCommon
+
+	LSN        LSN    `json:"lsn" jsonschema:"description=The LSN at which a CDC event occurred. Only set for CDC events, not backfills."`
+	SeqVal     []byte `json:"seqval" jsonschema:"description=Sequence value used to order changes to a row within a transaction. Only set for CDC events, not backfills."`
+	UpdateMask any    `json:"updateMask,omitempty" jsonschema:"description=A bit mask with a bit corresponding to each captured column identified for the capture instance. Only set for CDC events, not backfills."`
+}
+
+func (source *sqlserverSourceInfo) Common() sqlcapture.SourceCommon {
+	return source.SourceCommon
+}
+
+// AppendJSON appends the JSON representation of the change metadata to the provided buffer.
+func (source *sqlserverSourceInfo) AppendJSON(buf []byte) ([]byte, error) {
+	return json.Append(buf, source, 0)
+}
+
+func (db *sqlserverDatabase) backfillJSONTranscoder(columnType any) jsonTranscoder {
+	return jsonTranscoderFunc(func(buf []byte, v any) ([]byte, error) {
+		if translated, err := db.translateRecordField(columnType, v); err != nil {
+			return nil, fmt.Errorf("error translating value %v for JSON serialization: %w", v, err)
+		} else {
+			return json.Append(buf, translated, json.EscapeHTML|json.SortMapKeys)
+		}
+	})
+}
+
+func (db *sqlserverDatabase) backfillFDBTranscoder(columnType any) fdbTranscoder {
+	return fdbTranscoderFunc(func(buf []byte, v any) ([]byte, error) {
+		if translated, err := encodeKeyFDB(v, columnType); err != nil {
+			return nil, fmt.Errorf("error translating value %v for FDB serialization: %w", v, err)
+		} else {
+			return sqlcapture.AppendFDB(buf, translated)
+		}
+	})
+}
+
+func (db *sqlserverDatabase) replicationJSONTranscoder(columnType any) jsonTranscoder {
+	return db.backfillJSONTranscoder(columnType)
+}
+
+func (db *sqlserverDatabase) replicationFDBTranscoder(columnType any) fdbTranscoder {
+	return db.backfillFDBTranscoder(columnType)
 }

--- a/source-sqlserver/change.go
+++ b/source-sqlserver/change.go
@@ -3,6 +3,9 @@ package main
 import (
 	"encoding/base64"
 	"fmt"
+
+	"github.com/estuary/connectors/sqlcapture"
+	"github.com/segmentio/encoding/json"
 )
 
 type sqlserverCommitEvent struct {
@@ -21,4 +24,67 @@ func (evt *sqlserverCommitEvent) AppendJSON(buf []byte) ([]byte, error) {
 	buf = append(buf, '"')
 	buf = base64.StdEncoding.AppendEncode(buf, evt.CommitLSN)
 	return append(buf, '"'), nil
+}
+
+type sqlserverChangeEvent struct {
+	Operation sqlcapture.ChangeOp
+	RowKey    []byte
+	Source    sqlcapture.SourceMetadata
+	Before    map[string]interface{}
+	After     map[string]interface{}
+}
+
+func (sqlserverChangeEvent) IsDatabaseEvent() {}
+func (sqlserverChangeEvent) IsChangeEvent()   {}
+
+func (e *sqlserverChangeEvent) String() string {
+	switch e.Operation {
+	case sqlcapture.InsertOp:
+		return fmt.Sprintf("Insert(%s)", e.Source.Common().StreamID())
+	case sqlcapture.UpdateOp:
+		return fmt.Sprintf("Update(%s)", e.Source.Common().StreamID())
+	case sqlcapture.DeleteOp:
+		return fmt.Sprintf("Delete(%s)", e.Source.Common().StreamID())
+	}
+	return fmt.Sprintf("UnknownChange(%s)", e.Source.Common().StreamID())
+}
+
+func (e *sqlserverChangeEvent) StreamID() sqlcapture.StreamID {
+	return e.Source.Common().StreamID()
+}
+
+func (e *sqlserverChangeEvent) GetRowKey() []byte {
+	return e.RowKey
+}
+
+// MarshalJSON implements serialization of a ChangeEvent to JSON.
+//
+// Note that this implementation is destructive, but that's okay because
+// emitting the serialized JSON is the last thing we ever do with a change.
+func (e *sqlserverChangeEvent) AppendJSON(buf []byte) ([]byte, error) {
+	var record map[string]any
+	var meta = struct {
+		Operation sqlcapture.ChangeOp       `json:"op"`
+		Source    sqlcapture.SourceMetadata `json:"source"`
+		Before    map[string]any            `json:"before,omitempty"`
+	}{
+		Operation: e.Operation,
+		Source:    e.Source,
+		Before:    nil,
+	}
+	switch e.Operation {
+	case sqlcapture.InsertOp:
+		record = e.After // Before is never used.
+	case sqlcapture.UpdateOp:
+		meta.Before, record = e.Before, e.After
+	case sqlcapture.DeleteOp:
+		record = e.Before // After is never used.
+	}
+	if record == nil {
+		record = make(map[string]any)
+	}
+	record["_meta"] = &meta
+
+	// Marshal to JSON and append to the provided buffer.
+	return json.Append(buf, record, json.EscapeHTML|json.SortMapKeys)
 }

--- a/source-sqlserver/main_test.go
+++ b/source-sqlserver/main_test.go
@@ -236,6 +236,13 @@ func uniqueTableID(t testing.TB, extra ...string) string {
 	return fmt.Sprintf("%d", (x%900000)+100000)
 }
 
+func setShutdownAfterCaughtUp(t testing.TB, setting bool) {
+	t.Helper()
+	var prevSetting = sqlcapture.TestShutdownAfterCaughtUp
+	sqlcapture.TestShutdownAfterCaughtUp = setting
+	t.Cleanup(func() { sqlcapture.TestShutdownAfterCaughtUp = prevSetting })
+}
+
 // TestGeneric runs the generic sqlcapture test suite.
 func TestGeneric(t *testing.T) {
 	var tb = sqlserverTestBackend(t)

--- a/source-sqlserver/replication.go
+++ b/source-sqlserver/replication.go
@@ -650,7 +650,7 @@ func (rs *sqlserverReplicationStream) streamToWatermarkFence(ctx context.Context
 
 			// Mark the fence as reached when we observe a change event on the watermarks stream
 			// with the expected value.
-			if event, ok := event.(*sqlcapture.OldChangeEvent); ok {
+			if event, ok := event.(*sqlserverChangeEvent); ok {
 				if event.Operation != sqlcapture.DeleteOp && event.Source.Common().StreamID() == watermarkStreamID {
 					var actual = event.After["watermark"]
 					if actual == nil {
@@ -1181,7 +1181,7 @@ func (rs *sqlserverReplicationStream) pollTable(ctx context.Context, info *table
 			before = fields
 		}
 
-		var event = &sqlcapture.OldChangeEvent{
+		var event = &sqlserverChangeEvent{
 			Operation: operation,
 			RowKey:    rowKey,
 			Source: &sqlserverSourceInfo{

--- a/source-sqlserver/throughput_test.go
+++ b/source-sqlserver/throughput_test.go
@@ -1,0 +1,346 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/binary"
+	"encoding/json"
+	"fmt"
+	"math"
+	"os"
+	"regexp"
+	"testing"
+	"time"
+
+	boilerplate "github.com/estuary/connectors/source-boilerplate"
+	st "github.com/estuary/connectors/source-boilerplate/testing"
+	"github.com/estuary/connectors/sqlcapture"
+	pc "github.com/estuary/flow/go/protocols/capture"
+	pf "github.com/estuary/flow/go/protocols/flow"
+	protoio "github.com/gogo/protobuf/io"
+	"github.com/gogo/protobuf/proto"
+	log "github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+	broker_protocol "go.gazette.dev/core/broker/protocol"
+	consumer_protocol "go.gazette.dev/core/consumer/protocol"
+)
+
+var benchmarkTableShapes = map[string]struct {
+	Definition  string
+	InsertQuery string
+}{
+	// A table with relatively small rows made of integers and text.
+	"small_rows": {
+		Definition: `(
+			id BIGINT PRIMARY KEY,
+			x INTEGER,
+			y INTEGER,
+			z INTEGER,
+			a NVARCHAR(MAX),
+			b NVARCHAR(MAX),
+			c NVARCHAR(MAX)
+		)`,
+		InsertQuery: `
+			WITH NumberSeries AS (
+				SELECT %[2]d AS id
+				UNION ALL
+				SELECT id + 1 FROM NumberSeries WHERE id < %[3]d
+			)
+			INSERT INTO %[1]s (id, x, y, z, a, b, c)
+			SELECT
+				id,
+				id %% 7777,
+				id %% 131313,
+				id %% 33333333,
+				'text-' + CAST(id AS NVARCHAR(50)),
+				'text-' + CAST((id + 1) AS NVARCHAR(50)),
+				'text-' + CAST((id + 2) AS NVARCHAR(50))
+			FROM NumberSeries
+			OPTION (MAXRECURSION 0)
+		`,
+	},
+
+	// A table with many different types of columns.
+	"many_types": {
+		Definition: `(
+    	    id BIGINT PRIMARY KEY,
+    	    small_int SMALLINT,
+    	    normal_int INTEGER,
+    	    big_int BIGINT,
+    	    float_val FLOAT,
+    	    decimal_val DECIMAL(10,2),
+    	    text_val TEXT,
+    	    varchar_val VARCHAR(100),
+    	    bool_val BIT,
+    	    date_val DATE,
+    	    timestamp_val DATETIME2,
+    	    json_val NVARCHAR(MAX),
+    	    uuid_val UNIQUEIDENTIFIER,
+    	    array_val NVARCHAR(MAX)
+    	)`,
+		InsertQuery: `
+			WITH NumberSeries AS (
+				SELECT %[2]d AS id
+				UNION ALL
+				SELECT id + 1 FROM NumberSeries WHERE id < %[3]d
+			)
+			INSERT INTO %[1]s (
+				id, small_int, normal_int, big_int, float_val, decimal_val,
+				text_val, varchar_val, bool_val, date_val,
+				timestamp_val, json_val, uuid_val, array_val
+			)
+			SELECT
+				id,
+				CAST(id %% 32767 AS SMALLINT),
+				CAST(id %% 2147483647 AS INTEGER),
+				CAST((id %% 1000) * 1000000 AS BIGINT),
+				SQRT(CAST(id AS FLOAT)),
+				CAST((id %% 1000) * 3.14 AS DECIMAL(10,2)),
+				'text-' + CAST(id AS NVARCHAR(50)),
+				'varchar-' + LEFT(CONVERT(NVARCHAR(32), HASHBYTES('MD5', CAST(id AS NVARCHAR(50))), 2), 32),
+				CASE WHEN id %% 2 = 0 THEN 1 ELSE 0 END,
+				DATEADD(DAY, id %% 365, '2024-01-01'),
+				DATEADD(HOUR, id %% 8760, '2024-01-01 00:00:00'),
+				'{"key1":' + CAST(id %% 1000000 AS NVARCHAR(20)) + ',"key2":"value-' + CAST(id AS NVARCHAR(50)) + '","key3":[' + CAST(id %% 100 AS NVARCHAR(10)) + ',' + CAST((id %% 100) + 1 AS NVARCHAR(10)) + ',' + CAST((id %% 100) + 2 AS NVARCHAR(10)) + ']}',
+				NEWID(),
+				'[' + CAST(id %% 1000 AS NVARCHAR(10)) + ',' + CAST((id %% 1000) * 2 AS NVARCHAR(10)) + ',' + CAST((id %% 1000) * 3 AS NVARCHAR(10)) + ']'
+			FROM NumberSeries
+			OPTION (MAXRECURSION 0)
+		`,
+	},
+
+	// A table with larger rows consisting primarily of a large (4kB) text field.
+	"large_text": {
+		Definition: `(
+			id BIGINT PRIMARY KEY,
+			created_at DATETIME,
+			updated_at DATETIME,
+			content NVARCHAR(MAX)
+		)`,
+		InsertQuery: `
+			WITH NumberSeries AS (
+				SELECT %[2]d AS id
+				UNION ALL
+				SELECT id + 1 FROM NumberSeries WHERE id < %[3]d
+			)
+			INSERT INTO %[1]s (id, created_at, updated_at, content)
+			SELECT
+				id,
+				DATEADD(HOUR, id %% 8760, '2024-01-01 00:00:00'),
+				DATEADD(HOUR, id %% 8760, '2024-01-01 00:00:00'),
+				'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla posuere eu dolor sit amet dapibus. Donec vel semper nunc. Aenean metus mauris, volutpat et pharetra a, ornare ut ex. Nunc ut sagittis turpis, ut ultrices purus. Cras ante mi, faucibus eget tellus sed, ultrices fringilla diam. Aenean massa metus, lobortis et est sit amet, viverra suscipit justo. Morbi urna arcu, elementum aliquet tincidunt sed, euismod et risus. Maecenas pulvinar elit nec diam bibendum, nec tincidunt mauris cursus. Suspendisse dictum mauris a ex molestie, quis volutpat quam rhoncus. Nulla facilisi. Etiam sodales ligula ut risus vulputate, nec semper nibh fringilla.' +
+				'Quisque sit amet ex id augue laoreet lobortis. Sed ac libero convallis justo posuere dignissim at vel diam. Curabitur ac ornare ante. Integer a dolor ut dui ullamcorper scelerisque ut vel est. Curabitur dapibus ipsum ut sapien porta tempor. Vestibulum bibendum egestas purus, a euismod risus vehicula eu. Integer faucibus justo in ex sodales venenatis. Proin commodo tortor a maximus aliquam. Nam eu enim nulla. Proin ac erat augue. Aliquam eleifend sagittis lacus quis tempus. Donec nisi turpis, rhoncus at ultrices nec, faucibus eu odio. Integer consequat ex dolor, in cursus odio lacinia vitae. Sed aliquam, neque consectetur tristique rutrum, mauris ligula hendrerit dui, vitae dictum nibh lorem sed est. Fusce lobortis dictum augue dignissim fermentum. Aliquam faucibus congue nulla sed consectetur.' +
+				'Etiam non libero sapien. Morbi vitae fringilla est, ut efficitur lorem. Aliquam scelerisque viverra orci, vitae ullamcorper magna pellentesque sit amet. Quisque lobortis dignissim porttitor. Suspendisse gravida magna a consectetur sagittis. Suspendisse in diam ut nunc varius dictum. Proin nec quam euismod elit rhoncus mattis vel sed leo. Praesent purus nunc, tincidunt sit amet tempor vitae, imperdiet non mauris. Maecenas commodo hendrerit ex a interdum. Morbi placerat tortor id lorem pellentesque, ac luctus arcu molestie.' +
+				'Nullam sit amet tristique odio, ultrices semper lectus. Curabitur at maximus justo. Etiam nulla erat, commodo a metus in, condimentum pellentesque ipsum. Phasellus sed leo quis lectus suscipit ullamcorper. Proin eu ipsum in tortor fringilla consequat. Nullam ultrices mattis porta. Mauris orci nulla, finibus vel turpis nec, sagittis commodo odio. Aenean viverra metus leo. In hac habitasse platea dictumst. Vestibulum egestas gravida nibh non faucibus.' +
+				'Ut et magna dictum, vulputate nibh nec, varius magna. Quisque dignissim neque elementum, pulvinar turpis nec, suscipit lorem. Nulla ac dui id diam sodales pulvinar sed quis lorem. Suspendisse potenti. Praesent tristique ultricies pellentesque. Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Cras mollis, turpis id vehicula luctus, ante risus tincidunt sem, vitae dictum tortor tellus eget justo. Integer sed porttitor libero, sed ullamcorper sapien. Curabitur pretium nibh a tellus facilisis, non porttitor magna ultrices. Nam tincidunt ipsum volutpat erat porta, quis auctor mauris luctus. Integer ut leo turpis. Mauris egestas cursus diam, in euismod odio tempus non. Maecenas a orci vel nisi sodales mattis non a mauris. Integer molestie molestie dictum.' +
+				'Nulla facilisi. Nullam tristique bibendum enim at tristique. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris eget elit varius, elementum arcu sit amet, ultricies velit. Cras eu ex quis leo fringilla congue. Ut viverra a nibh nec semper. Fusce sodales ligula dolor, tristique finibus lorem iaculis ac. Etiam pellentesque vestibulum dolor vel mollis. In tristique lacus vehicula, hendrerit felis eu, auctor leo. Nam porta sapien dolor, eget euismod dui ullamcorper nec. In id placerat magna. Nam non elementum ligula. Cras scelerisque justo at libero finibus luctus. Proin orci lacus, vulputate vitae mauris id, tristique bibendum erat. Sed sollicitudin congue felis at sodales.' +
+				'Morbi at scelerisque nibh. Duis dapibus sollicitudin augue, quis volutpat ipsum varius id. Phasellus ut dolor fringilla, molestie turpis at, auctor nisl. Aliquam luctus vel.'
+			FROM NumberSeries
+			OPTION (MAXRECURSION 0)
+		`,
+	},
+}
+
+func createBenchmarkTable(ctx context.Context, t testing.TB, tb *testBackend, shape string) (string, string) {
+	t.Helper()
+	var uniqueID = uniqueTableID(t)
+	var tableName = tb.CreateTable(ctx, t, uniqueID, benchmarkTableShapes[shape].Definition)
+	return tableName, uniqueID
+}
+
+func insertBenchmarkRows(ctx context.Context, t testing.TB, tb *testBackend, shape string, tableName string, minID, maxID int) {
+	t.Helper()
+	log.WithFields(log.Fields{
+		"table": tableName,
+		"min":   minID,
+		"max":   maxID,
+		"count": maxID - minID,
+	}).Info("inserting benchmark rows")
+
+	// Insert rows in batches so we get periodic transaction commits
+	const batchSize = 5000
+	for i := minID; i < maxID; i += batchSize {
+		var j = i + batchSize
+		if j > maxID {
+			j = maxID
+		}
+		tb.Query(ctx, t, fmt.Sprintf(benchmarkTableShapes[shape].InsertQuery, tableName, i, j-1))
+	}
+}
+
+func benchBackfillN(b *testing.B, shape string, rowCount int) {
+	var ctx, tb = context.Background(), sqlserverTestBackend(b)
+	var tableName, uniqueID = createBenchmarkTable(ctx, b, tb, shape)
+	insertBenchmarkRows(ctx, b, tb, shape, tableName, 0, rowCount)
+
+	// Set up the capture. The backfill chunk size is set to the production default of
+	// 50k rows, and the validator is set to a special benchmark one which discards the
+	// output data but counts how many documents and bytes we get.
+	var cs = tb.CaptureSpec(ctx, b, regexp.MustCompile(uniqueID))
+	cs.EndpointSpec.(*Config).Advanced.BackfillChunkSize = 50000
+	cs.EndpointSpec.(*Config).Advanced.FeatureFlags = "replica_fencing"
+	cs.Sanitizers = nil // Don't waste time sanitizing the data, we're not validating against a snapshot
+	setShutdownAfterCaughtUp(b, true)
+
+	// Reset timer after setup
+	b.ResetTimer()
+
+	var totalOutputBytes int64
+	for b.Loop() {
+		totalOutputBytes += runBenchmarkCapture(ctx, b, cs)
+
+		// Reset state between iterations
+		cs.Checkpoint = nil
+	}
+
+	// Report rows/sec and MBps instead of ns/op
+	log.WithFields(log.Fields{
+		"rows":    b.N * rowCount,
+		"bytes":   totalOutputBytes,
+		"seconds": b.Elapsed().Seconds(),
+	}).Info("backfill benchmark complete")
+	b.ReportMetric(0, "ns/op")
+	b.ReportMetric(b.Elapsed().Seconds(), "seconds")
+	b.ReportMetric(float64(b.N*rowCount)/float64(b.Elapsed().Seconds()), "rows/sec")
+	b.ReportMetric(float64(totalOutputBytes)/float64(1000000*b.Elapsed().Seconds()), "MBps")
+}
+
+func runBenchmarkCapture(ctx context.Context, t testing.TB, cs *st.CaptureSpec) int64 {
+	t.Helper()
+	if os.Getenv("TEST_DATABASE") != "yes" {
+		t.Skipf("skipping %q capture: ${TEST_DATABASE} != \"yes\"", t.Name())
+	}
+
+	log.WithField("checkpoint", string(cs.Checkpoint)).Debug("running test capture")
+	endpointSpecJSON, err := json.Marshal(cs.EndpointSpec)
+	require.NoError(t, err)
+
+	var open proto.Message = &pc.Request{
+		Open: &pc.Request_Open{
+			StateJson: cs.Checkpoint,
+			Capture: &pf.CaptureSpec{
+				Name:       "acmeCo/test-capture/source-something",
+				ConfigJson: endpointSpecJSON,
+				Bindings:   cs.Bindings,
+				// Dummies to satisfy protocol validation, specific values shouldn't be important.
+				ShardTemplate: &consumer_protocol.ShardSpec{
+					Id: "capture/acmeCo/test-capture/source-something/69f23210cf8ccfcd/00000000-00000000",
+
+					MaxTxnDuration: 1 * time.Second,
+				},
+				RecoveryLogTemplate: &broker_protocol.JournalSpec{
+					Name:        broker_protocol.Journal("recovery/capture/acmeCo/test-capture/source-something/69f23210cf8ccfcd/00000000-00000000"),
+					Replication: 3,
+					Fragment: broker_protocol.JournalSpec_Fragment{
+						Length:           512 * 1024 * 1024, // 512 MiB
+						CompressionCodec: broker_protocol.CompressionCodec_GZIP,
+						RefreshInterval:  30 * time.Second,
+					},
+				},
+			},
+			Range: &pf.RangeSpec{
+				KeyBegin:    0,
+				KeyEnd:      math.MaxUint32,
+				RClockBegin: 0,
+				RClockEnd:   math.MaxUint32,
+			},
+		},
+	}
+
+	// Serialize the Open request into a byte buffer which will act as the input reader for the benchmark run.
+	var input bytes.Buffer
+	err = protoio.NewUint32DelimitedWriter(&input, binary.LittleEndian).WriteMsg(open)
+	require.NoError(t, err)
+
+	// Run the capture, with an output io.Writer that merely tallies up the number of bytes written.
+	var totalOutputBytes int64
+	var output = WriterFunc(func(bs []byte) (n int, err error) {
+		totalOutputBytes += int64(len(bs))
+		return len(bs), nil
+	})
+	require.NoError(t, boilerplate.InnerMain(ctx, cs.Driver, &input, output))
+	cs.Checkpoint = sqlcapture.FinalStateCheckpoint
+	return totalOutputBytes
+}
+
+type WriterFunc func(p []byte) (n int, err error)
+
+func (w WriterFunc) Write(p []byte) (n int, err error) {
+	return w(p)
+}
+
+func benchReplicationN(b *testing.B, shape string, rowCount int) {
+	var ctx, tb = context.Background(), sqlserverTestBackend(b)
+	var tableName, uniqueID = createBenchmarkTable(ctx, b, tb, shape)
+
+	// Set up the capture. The backfill chunk size is set to the production default of
+	// 50k rows, and the validator is set to a special benchmark one which discards the
+	// output data but counts how many documents and bytes we get.
+	var cs = tb.CaptureSpec(ctx, b, regexp.MustCompile(uniqueID))
+	cs.EndpointSpec.(*Config).Advanced.BackfillChunkSize = 50000
+	cs.Sanitizers = nil // Don't waste time sanitizing the data, we're not validating against a snapshot
+	setShutdownAfterCaughtUp(b, true)
+
+	// Insert a few rows to ensure the CDC instance is fully initialized.
+	var minID = 0
+	insertBenchmarkRows(ctx, b, tb, shape, tableName, minID, minID+100)
+	minID += 100
+
+	// Run the capture to get the initial backfill out of the way. Discard all outputs.
+	runBenchmarkCapture(ctx, b, cs)
+	b.ResetTimer()
+
+	var totalOutputBytes int64
+	for b.Loop() {
+		// Insert another batch of rows, excluding insert time from the benchmark timer
+		b.StopTimer()
+		insertBenchmarkRows(ctx, b, tb, shape, tableName, minID, minID+rowCount)
+		b.StartTimer()
+		minID += rowCount
+
+		// Run the capture, which should consume all the new rows via replication.
+		// Unlike the backfill benchmark we don't need to clear the checkpoint after
+		// each run because we actually want it to keep going and only consume new
+		// replication events from the current iteration.
+		totalOutputBytes += runBenchmarkCapture(ctx, b, cs)
+	}
+
+	// Report rows/sec and MBps instead of ns/op
+	log.WithFields(log.Fields{
+		"rows":    b.N * rowCount,
+		"bytes":   totalOutputBytes,
+		"seconds": b.Elapsed().Seconds(),
+	}).Info("backfill benchmark complete")
+	b.ReportMetric(0, "ns/op")
+	b.ReportMetric(b.Elapsed().Seconds(), "seconds")
+	b.ReportMetric(float64(b.N*rowCount)/float64(b.Elapsed().Seconds()), "rows/sec")
+	b.ReportMetric(float64(totalOutputBytes)/float64(1000000*b.Elapsed().Seconds()), "MBps")
+}
+
+const M = 1000000
+
+func BenchmarkBackfill_SmallRows_1M(b *testing.B)  { benchBackfillN(b, "small_rows", 1*M) }
+func BenchmarkBackfill_SmallRows_5M(b *testing.B)  { benchBackfillN(b, "small_rows", 5*M) }
+func BenchmarkBackfill_SmallRows_10M(b *testing.B) { benchBackfillN(b, "small_rows", 10*M) }
+
+func BenchmarkBackfill_ManyTypes_1M(b *testing.B)  { benchBackfillN(b, "many_types", 1*M) }
+func BenchmarkBackfill_ManyTypes_5M(b *testing.B)  { benchBackfillN(b, "many_types", 5*M) }
+func BenchmarkBackfill_ManyTypes_10M(b *testing.B) { benchBackfillN(b, "many_types", 10*M) }
+
+func BenchmarkBackfill_LargeText_100k(b *testing.B) { benchBackfillN(b, "large_text", 100_000) }
+func BenchmarkBackfill_LargeText_1M(b *testing.B)   { benchBackfillN(b, "large_text", 1*M) }
+func BenchmarkBackfill_LargeText_5M(b *testing.B)   { benchBackfillN(b, "large_text", 5*M) }
+func BenchmarkBackfill_LargeText_10M(b *testing.B)  { benchBackfillN(b, "large_text", 10*M) }
+
+func BenchmarkReplication_SmallRows_1M(b *testing.B)  { benchReplicationN(b, "small_rows", 1*M) }
+func BenchmarkReplication_SmallRows_5M(b *testing.B)  { benchReplicationN(b, "small_rows", 5*M) }
+func BenchmarkReplication_SmallRows_10M(b *testing.B) { benchReplicationN(b, "small_rows", 10*M) }
+
+func BenchmarkReplication_ManyTypes_1M(b *testing.B)  { benchReplicationN(b, "many_types", 1*M) }
+func BenchmarkReplication_ManyTypes_5M(b *testing.B)  { benchReplicationN(b, "many_types", 5*M) }
+func BenchmarkReplication_ManyTypes_10M(b *testing.B) { benchReplicationN(b, "many_types", 10*M) }
+
+func BenchmarkReplication_LargeText_100k(b *testing.B) { benchReplicationN(b, "large_text", 100_000) }
+func BenchmarkReplication_LargeText_1M(b *testing.B)   { benchReplicationN(b, "large_text", 1*M) }
+func BenchmarkReplication_LargeText_5M(b *testing.B)   { benchReplicationN(b, "large_text", 5*M) }
+func BenchmarkReplication_LargeText_10M(b *testing.B)  { benchReplicationN(b, "large_text", 10*M) }

--- a/source-sqlserver/throughput_test.go
+++ b/source-sqlserver/throughput_test.go
@@ -36,9 +36,9 @@ var benchmarkTableShapes = map[string]struct {
 			x INTEGER,
 			y INTEGER,
 			z INTEGER,
-			a NVARCHAR(MAX),
-			b NVARCHAR(MAX),
-			c NVARCHAR(MAX)
+			a NVARCHAR(64),
+			b NVARCHAR(64),
+			c NVARCHAR(64)
 		)`,
 		InsertQuery: `
 			WITH NumberSeries AS (
@@ -295,6 +295,7 @@ func benchReplicationN(b *testing.B, shape string, rowCount int) {
 		// Insert another batch of rows, excluding insert time from the benchmark timer
 		b.StopTimer()
 		insertBenchmarkRows(ctx, b, tb, shape, tableName, minID, minID+rowCount)
+		time.Sleep(1 * time.Second) // Ensure that the CDC worker has a chance to run
 		b.StartTimer()
 		minID += rowCount
 

--- a/sqlcapture/capture.go
+++ b/sqlcapture/capture.go
@@ -580,6 +580,7 @@ func (c *Capture) streamToFence(ctx context.Context, replStream ReplicationStrea
 	var workerCtx, cancelWorkerCtx = context.WithCancel(ctx) // Context for the commit buffering worker goroutine
 	defer cancelWorkerCtx()                                  // Ensure that the worker goroutine always exits when we do
 	var workerGroup errgroup.Group
+	defer cancelWorkerCtx() // Ensure that the worker goroutine is cancelled when we return
 	workerGroup.Go(func() error {
 		var ticker = time.NewTicker(commitBufferingInterval)
 		defer ticker.Stop()


### PR DESCRIPTION
**Description:**

Part of https://github.com/estuary/connectors/issues/2885

This PR is very much following in the footsteps of [the PostgreSQL Equivalent](https://github.com/estuary/connectors/pull/2990):

- Introducing automated throughput benchmarks
- Implementing SQL Server specific implementations of the commit event and change event interfaces
- Optimizing change event processing by:
  - Reusing memory where feasible. 
    - There's less of this in SQL Server than in PostgreSQL because we're leaving the replication channel in place and so we have to permit concurrent processing of multiple events.
    - It's not worth trying to eliminate this right now because the official MS SQL Server client library is the biggest elephant left in terms of wasteful concurrency overhead and memory allocations, and we're not fixing that right now.
  - Offloading as much of the change event processing as possible into shared metadata which can be reused across many changes.
  - Directly assembling the JSON representing a captured document instead of using reflection on a Go map.

Even before any of this work we're benefiting from a noticeable throughput bump thanks to the `sqlcapture` optimizations of the previous PR, I estimate that alone added about 50% throughput in most benchmark scenarios. After all the other optimizations we're theoretically capable of >100MBps on most datasets, and since that means we'll be primarily bottlenecked in the runtime _and_ most of the remaining fat to trim is in Microsoft's code and not ours, that seemed like a good place to stop even if the absolute improvement is smaller than it was for PostgreSQL.

As with any good optimization PR, test snapshots are entirely unaltered, so I'm reasonably confident I haven't broken anything important here.

One thing I'd like to note specifically: SQL Server is the worst of our SQL CDC connectors in terms of memory pressure. This is largely unavoidable -- a major part of the problem is that the MS client library maintains an internal buffer of up to 5 result rows from every query you execute (which in our case means both backfills and replication polling). These changes should still make things a _tiny_ bit better by reducing the amount of memory we use in processing the values once they arrive, but if we want to improve that situation more significantly we're going to need to issue more complicated backfill and replication polling queries which _explicitly name every column they're fetching_ and _ask the database to truncate the values before it even sends them_.