### PR TITLE
filesink: support castToString field config for parquet

### DIFF
--- a/materialize-azure-blob-parquet/main.go
+++ b/materialize-azure-blob-parquet/main.go
@@ -47,7 +47,7 @@ var driver = filesink.FileDriver{
 	NewStore: func(ctx context.Context, c filesink.Config) (filesink.Store, error) {
 		return filesink.NewAzureBlob(ctx, c.(config).AzureBlobConfig)
 	},
-	NewEncoder: func(c filesink.Config, b *pf.MaterializationSpec_Binding, w io.WriteCloser) filesink.StreamEncoder {
+	NewEncoder: func(c filesink.Config, b *pf.MaterializationSpec_Binding, w io.WriteCloser) (filesink.StreamEncoder, error) {
 		return filesink.NewParquetStreamEncoder(c.(config).ParquetConfig, b, w)
 	},
 	NewConstraints: func(p *pf.Projection) *materialize.Response_Validated_Constraint {

--- a/materialize-gcs-csv/main.go
+++ b/materialize-gcs-csv/main.go
@@ -47,8 +47,8 @@ var driver = filesink.FileDriver{
 	NewStore: func(ctx context.Context, c filesink.Config) (filesink.Store, error) {
 		return filesink.NewGCSStore(ctx, c.(config).GCSStoreConfig)
 	},
-	NewEncoder: func(c filesink.Config, b *pf.MaterializationSpec_Binding, w io.WriteCloser) filesink.StreamEncoder {
-		return filesink.NewCsvStreamEncoder(c.(config).CsvConfig, b, w)
+	NewEncoder: func(c filesink.Config, b *pf.MaterializationSpec_Binding, w io.WriteCloser) (filesink.StreamEncoder, error) {
+		return filesink.NewCsvStreamEncoder(c.(config).CsvConfig, b, w), nil
 	},
 	NewConstraints: func(p *pf.Projection) *materialize.Response_Validated_Constraint {
 		return filesink.StdConstraints(p)

--- a/materialize-gcs-parquet/main.go
+++ b/materialize-gcs-parquet/main.go
@@ -47,7 +47,7 @@ var driver = filesink.FileDriver{
 	NewStore: func(ctx context.Context, c filesink.Config) (filesink.Store, error) {
 		return filesink.NewGCSStore(ctx, c.(config).GCSStoreConfig)
 	},
-	NewEncoder: func(c filesink.Config, b *pf.MaterializationSpec_Binding, w io.WriteCloser) filesink.StreamEncoder {
+	NewEncoder: func(c filesink.Config, b *pf.MaterializationSpec_Binding, w io.WriteCloser) (filesink.StreamEncoder, error) {
 		return filesink.NewParquetStreamEncoder(c.(config).ParquetConfig, b, w)
 	},
 	NewConstraints: func(p *pf.Projection) *materialize.Response_Validated_Constraint {

--- a/materialize-s3-csv/main.go
+++ b/materialize-s3-csv/main.go
@@ -47,8 +47,8 @@ var driver = filesink.FileDriver{
 	NewStore: func(ctx context.Context, c filesink.Config) (filesink.Store, error) {
 		return filesink.NewS3Store(ctx, c.(config).S3StoreConfig)
 	},
-	NewEncoder: func(c filesink.Config, b *pf.MaterializationSpec_Binding, w io.WriteCloser) filesink.StreamEncoder {
-		return filesink.NewCsvStreamEncoder(c.(config).CsvConfig, b, w)
+	NewEncoder: func(c filesink.Config, b *pf.MaterializationSpec_Binding, w io.WriteCloser) (filesink.StreamEncoder, error) {
+		return filesink.NewCsvStreamEncoder(c.(config).CsvConfig, b, w), nil
 	},
 	NewConstraints: func(p *pf.Projection) *materialize.Response_Validated_Constraint {
 		return filesink.StdConstraints(p)

--- a/materialize-s3-iceberg/type_mapping.go
+++ b/materialize-s3-iceberg/type_mapping.go
@@ -82,7 +82,7 @@ func projectionToParquetSchemaElement(p pf.Projection, fc fieldConfig) (enc.Parq
 		p.Inference.String_.Format = ""
 	}
 
-	return enc.ProjectionToParquetSchemaElement(p, schemaOptions...), nil
+	return enc.ProjectionToParquetSchemaElement(p, false, schemaOptions...), nil
 }
 
 func parquetTypeToIcebergType(pqt enc.ParquetDataType) icebergType {

--- a/materialize-s3-parquet/main.go
+++ b/materialize-s3-parquet/main.go
@@ -47,7 +47,7 @@ var driver = filesink.FileDriver{
 	NewStore: func(ctx context.Context, c filesink.Config) (filesink.Store, error) {
 		return filesink.NewS3Store(ctx, c.(config).S3StoreConfig)
 	},
-	NewEncoder: func(c filesink.Config, b *pf.MaterializationSpec_Binding, w io.WriteCloser) filesink.StreamEncoder {
+	NewEncoder: func(c filesink.Config, b *pf.MaterializationSpec_Binding, w io.WriteCloser) (filesink.StreamEncoder, error) {
 		return filesink.NewParquetStreamEncoder(c.(config).ParquetConfig, b, w)
 	},
 	NewConstraints: func(p *pf.Projection) *materialize.Response_Validated_Constraint {


### PR DESCRIPTION
**Description:**

Adds support for the `castToString` field configuration option in `filesink`, allowing fields to be cast to string format when writing to parquet files. The current motivator is that sometimes people want to read UUID values as strings rather than the UUID logical type due to downstream compatibility issues.

It didn't make much sense to me to add this to the CSV writer also, since CSV files are always strings for everything.

Manually tested with an S3 parquet materialization with the field config on and off. You get the same UUID "value", either as a proper binary UUID logical type, or as a varchar.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/3064)
<!-- Reviewable:end -->
