### PR TITLE
source monday: use dict page cursor for items backfill

### DIFF
--- a/estuary-cdk/estuary_cdk/utils.py
+++ b/estuary-cdk/estuary_cdk/utils.py
@@ -1,9 +1,38 @@
 from collections.abc import Mapping
 from typing import Any
 
+
 def sort_dict(obj: Any) -> Any:
     if isinstance(obj, Mapping):
         return {k: sort_dict(v) for k, v in sorted(obj.items())}
     if isinstance(obj, list):
         return [sort_dict(item) for item in obj]
     return obj
+
+
+def json_merge_patch(target: dict, patch: dict) -> None:
+    """
+    Apply JSON Merge Patch (RFC 7396) to target dictionary in-place.
+
+    Args:
+        target: The dictionary to be modified
+        patch: The patch to apply
+
+    Semantics:
+        - null values remove keys from target
+        - nested objects are recursively merged
+        - arrays and primitives are replaced entirely
+    """
+
+    for key, value in patch.items():
+        if value is None:
+            # Remove the key if value is None
+            target.pop(key, None)
+        elif (
+            isinstance(value, dict) and key in target and isinstance(target[key], dict)
+        ):
+            # Recursively merge dictionaries
+            json_merge_patch(target[key], value)
+        else:
+            # Replace the value (including arrays)
+            target[key] = value

--- a/source-monday/source_monday/graphql/__init__.py
+++ b/source-monday/source_monday/graphql/__init__.py
@@ -12,7 +12,7 @@ from .constants import (
     TEAMS,
     USERS,
 )
-from .items import fetch_items_by_id, BoardItemIterator
+from .items import fetch_items_by_id, get_items_from_boards
 from .query_executor import execute_query
 
 __all__ = [
@@ -28,5 +28,5 @@ __all__ = [
     "fetch_boards_paginated",
     "fetch_boards_with_retry",
     "fetch_items_by_id",
-    "BoardItemIterator",
+    "get_items_from_boards",
 ]

--- a/source-monday/source_monday/graphql/boards.py
+++ b/source-monday/source_monday/graphql/boards.py
@@ -51,19 +51,18 @@ async def fetch_boards_minimal(
     log: Logger,
 ) -> AsyncGenerator[Board, None]:
     query = """
-    query ($limit: Int = 500, $page: Int = 1, $state: State = all) {
+    query ($limit: Int = 10000, $page: Int = 1, $state: State = all) {
         boards(limit: $limit, page: $page, state: $state, order_by: created_at) {
             id
             name
             state
             updated_at
-            items_count
         }
     }
     """
 
     page = 1
-    limit = 500
+    limit = 10000
 
     while True:
         variables = {

--- a/source-monday/source_monday/graphql/items.py
+++ b/source-monday/source_monday/graphql/items.py
@@ -1,7 +1,6 @@
 import itertools
-from datetime import datetime
 from logging import Logger
-from typing import AsyncGenerator, Callable
+from typing import AsyncGenerator
 
 from aiostream.stream import merge
 from estuary_cdk.http import HTTPSession
@@ -22,6 +21,7 @@ class BoardItems(BaseModel, extra="allow"):
 
 class ItemsPageRemainderData(GraphQLResponseData, extra="allow"):
     boards: list[BoardItems] | None = None
+    next_items_page: ItemsPage | None = None
 
 
 ItemsPageRemainder = GraphQLResponseRemainder[ItemsPageRemainderData]
@@ -42,28 +42,17 @@ ITEMS_LIMIT_BY_ID = 100
 class CursorCollector:
     def __init__(self):
         self.cursors: list[str] = []
-        self.oldest_board_updated_at: datetime | None = None
 
     def process(self, log: Logger, remainder: ItemsPageRemainder) -> None:
         log.debug("Processing ItemsPageRemainder for cursors")
-        if remainder.data:
-            if remainder.data.boards is None:
-                log.debug(
-                    "No boards found in remainder data, skipping cursor processing"
-                )
-                return
-            else:
-                self.oldest_board_updated_at = min(
-                    (board.updated_at for board in remainder.data.boards),
-                    default=None,
-                )
-                boards_data = remainder.data.boards
+        if not remainder.data:
+            log.debug("No data in remainder, skipping cursor processing")
+            return
 
-            log.debug(
-                f"Oldest board updated at: {self.oldest_board_updated_at}",
-                {"all_updated_at": [board.updated_at for board in boards_data]},
-            )
-
+        if remainder.data.boards is not None:
+            log.debug("Processing boards structure for cursors")
+            boards_data = remainder.data.boards
+            
             for board_data in boards_data:
                 if not board_data.items_page:
                     log.debug(
@@ -74,19 +63,21 @@ class CursorCollector:
 
                 log.debug("Found items_page in board_data", {"board_data": board_data})
                 cursor = board_data.items_page.cursor
+
                 if cursor:
                     self.cursors.append(cursor)
+
+        if remainder.data.next_items_page is not None:
+            log.debug("Processing next_items_page structure for cursors")
+            cursor = remainder.data.next_items_page.cursor
+            
+            if cursor:
+                log.debug(f"Found cursor in next_items_page: {cursor}")
+                self.cursors.append(cursor)
 
     def get_result(self, log: Logger) -> list[str]:
         log.debug(f"Returning collected cursors: {self.cursors}")
         return self.cursors
-
-    def get_cursors(self, log: Logger) -> list[str]:
-        """Alias for get_result."""
-        return self.get_result(log)
-
-    def get_oldest_board_updated_at(self) -> datetime | None:
-        return self.oldest_board_updated_at
 
 
 async def fetch_items_by_id(
@@ -134,132 +125,116 @@ async def _fetch_items(
         yield item
 
 
-class BoardItemIterator:
-    def __init__(
-        self,
-        http: HTTPSession,
-        log: Logger,
+async def get_items_from_boards(
+    http: HTTPSession,
+    log: Logger,
+    board_ids: list[str],
+    items_limit: int = ITEMS_PER_BOARD,
+) -> AsyncGenerator[Item, None]:
+    if not board_ids or len(board_ids) == 0:
+        log.error("get_items_from_boards requires a non-empty list of board IDs.")
+        raise ValueError("get_items_from_boards requires a non-empty list of board IDs.")
+
+    log.debug(f"Fetching items for boards {board_ids}.")
+
+    if items_limit is None or items_limit <= 0:
+        log.error("Invalid items_limit provided, must provide an integer greater than 0.")
+        raise ValueError("Invalid items_limit provided, must provide an integer greater than 0.")
+
+    elif items_limit > ITEMS_PER_BOARD:
+        log.warning(
+            f"items_limit {items_limit} exceeds maximum of {ITEMS_PER_BOARD}, using {ITEMS_PER_BOARD}."
+        )
+        items_limit = ITEMS_PER_BOARD
+
+    for batch_ids in itertools.batched(board_ids, BOARDS_PER_PAGE):
+        batch_ids_list = list(batch_ids)
+        log.debug(f"Processing batch with board IDs: {batch_ids_list}")
+
+        variables = {
+            "boardIds": batch_ids_list,
+            "boardsLimit": len(batch_ids_list),
+            "boardsPage": 1,
+            "itemsLimit": items_limit,
+            "state": "all",
+        }
+
+        batch_cursor_collector = CursorCollector()
+
+        async for item in _stream_all_items_from_page(
+            http,
+            log,
+            ITEMS,
+            variables,
+            batch_cursor_collector,
+            batch_ids_list,
+        ):
+            yield item
+
+async def _stream_all_items_from_page(
+    http: HTTPSession,
+    log: Logger,
+    query: str,
+    variables: dict,
+    cursor_collector: CursorCollector,
+    board_ids: list[str],
+) -> AsyncGenerator[Item, None]:
+    """
+    Stream all items from boards on this page, handling cursor pagination internally.
+
+    The internal cursor handling is needed because Monday's API uses a cursor-based pagination
+    for items within each board, where the cursor is specific to the board's items_page and
+    expires after 60-minutes.
+    """
+
+    items_yielded = 0
+    async for item in execute_query(
+        Item,
+        http,
+        log,
+        "data.boards.item.items_page.items.item",
+        query,
+        variables,
+        remainder_cls=ItemsPageRemainder,
+        remainder_processor=cursor_collector,
     ):
-        self.http = http
-        self.log = log
+        items_yielded += 1
+        yield item
 
-    async def get_items_from_boards(
-        self,
-        board_ids: list[str],
-        max_items_count: int | None = None,
-    ) -> tuple[AsyncGenerator[Item, None], Callable[[], datetime | None]]:
-        if not board_ids or len(board_ids) == 0:
-            self.log.debug("No board IDs provided, returning empty generator")
-            return self._empty_items_generator(), lambda: None
+    cursors = cursor_collector.get_result(log)
+    while cursors:
+        cursor = cursors.pop(0)
+        log.debug(
+            f"Processing cursor pagination, remaining cursors: {len(cursors)}"
+        )
 
-        self.log.debug(f"Fetching items for boards {board_ids}.")
+        cursor_variables = {"cursor": cursor, "limit": ITEMS_LIMIT_BY_ID}
+        cur_collector = CursorCollector()
 
-        oldest_board_updated_at: datetime | None = None
-
-        async def batched_items_generator() -> AsyncGenerator[Item, None]:
-            nonlocal oldest_board_updated_at
-
-            for batch_ids in itertools.batched(board_ids, BOARDS_PER_PAGE):
-                batch_ids_list = list(batch_ids)
-                self.log.debug(f"Processing batch with board IDs: {batch_ids_list}")
-
-                variables = {
-                    "boardIds": batch_ids_list,
-                    "boardsLimit": len(batch_ids_list),
-                    "boardsPage": 1,
-                    "itemsLimit": min(max_items_count or ITEMS_PER_BOARD, ITEMS_PER_BOARD),
-                    "state": "all",
-                }
-
-                batch_cursor_collector = CursorCollector()
-
-                async for item in self._stream_all_items_from_page(
-                    ITEMS,
-                    variables,
-                    batch_cursor_collector,
-                    batch_ids_list,
-                ):
-                    yield item
-
-                batch_oldest = batch_cursor_collector.get_oldest_board_updated_at()
-
-                if batch_oldest is not None:
-                    if (
-                        oldest_board_updated_at is None
-                        or batch_oldest < oldest_board_updated_at
-                    ):
-                        oldest_board_updated_at = batch_oldest
-
-        return batched_items_generator(), lambda: oldest_board_updated_at
-
-    async def _empty_items_generator(self) -> AsyncGenerator[Item, None]:
-        """Return empty items generator when no boards to process."""
-        return
-        yield  # Unreachable, but needed for generator
-
-    async def _stream_all_items_from_page(
-        self,
-        query: str,
-        variables: dict,
-        cursor_collector: CursorCollector,
-        board_ids: list[str],
-    ) -> AsyncGenerator[Item, None]:
-        """
-        Stream all items from boards on this page, handling cursor pagination internally.
-
-        The internal cursor handling is needed because Monday's API uses a cursor-based pagination
-        for items within each board, where the cursor is specific to the board's items_page and
-        expires after 60-minutes.
-        """
-
-        items_yielded = 0
         async for item in execute_query(
             Item,
-            self.http,
-            self.log,
-            "data.boards.item.items_page.items.item",
-            query,
-            variables,
+            http,
+            log,
+            "data.next_items_page.items.item",
+            NEXT_ITEMS,
+            cursor_variables,
             remainder_cls=ItemsPageRemainder,
-            remainder_processor=cursor_collector,
+            remainder_processor=cur_collector,
         ):
             items_yielded += 1
             yield item
 
-        cursors = cursor_collector.get_result(self.log)
-        while cursors:
-            cursor = cursors.pop(0)
-            self.log.debug(
-                f"Processing cursor pagination, remaining cursors: {len(cursors)}"
-            )
+        next_cursors = cur_collector.get_result(log)
+        if next_cursors:
+            cursors.extend(next_cursors)
 
-            cursor_variables = {"cursor": cursor, "limit": ITEMS_LIMIT_BY_ID}
-            cur_collector = CursorCollector()
-
-            async for item in execute_query(
-                Item,
-                self.http,
-                self.log,
-                "data.next_items_page.items.item",
-                NEXT_ITEMS,
-                cursor_variables,
-                remainder_cls=ItemsPageRemainder,
-                remainder_processor=cur_collector,
-            ):
-                items_yielded += 1
-                yield item
-
-            next_cursors = cur_collector.get_result(self.log)
-            if next_cursors:
-                cursors.extend(next_cursors)
-
-        self.log.debug(
-            "Items fetched.",
-            {
-                "boards": board_ids,
-                "items_yielded": items_yielded,
-            },
-        )
+    log.debug(
+        "Items fetched.",
+        {
+            "boards": board_ids,
+            "items_yielded": items_yielded,
+        },
+    )
 
 
 _ITEM_FIELDS = """

--- a/source-monday/source_monday/graphql/items.py
+++ b/source-monday/source_monday/graphql/items.py
@@ -131,7 +131,7 @@ async def get_items_from_boards(
     board_ids: list[str],
     items_limit: int = ITEMS_PER_BOARD,
 ) -> AsyncGenerator[Item, None]:
-    if not board_ids or len(board_ids) == 0:
+    if len(board_ids) == 0:
         log.error("get_items_from_boards requires a non-empty list of board IDs.")
         raise ValueError("get_items_from_boards requires a non-empty list of board IDs.")
 

--- a/source-monday/source_monday/models.py
+++ b/source-monday/source_monday/models.py
@@ -166,10 +166,6 @@ class Board(IncrementalResource):
         default=None,
         json_schema_extra=lambda x: x.pop("default"),  # type: ignore
     )
-    items_count: int | None = Field(
-        default=None,
-        json_schema_extra=lambda x: x.pop("default"),  # type: ignore
-    )
 
 
 class Item(IncrementalResource):


### PR DESCRIPTION
**Description:**

See #3047 (https://github.com/estuary/connectors/pull/3047#discussion_r2210885256) for more context.

This pull request introduces enhancements to cursor handling, backfill logic, and JSON merge patch functionality in the Estuary CDK and Source Monday integrations. The changes aim to improve efficiency, scalability, and fault tolerance, particularly in handling paginated data and structured cursors for the `items` stream. This PR also simplified the `items.py` `BoardItemIterator` by removing the unnecessary class that wrapped the functions. Below is a categorized summary of the most important changes:

### Cursor Handling Enhancements
* Added a new `CURSOR_MARKER` constant and utility functions (`is_cursor_dict`, `make_cursor_dict`, `pop_cursor_marker`) to support dict-based cursors for structured and granular progress tracking. (`estuary-cdk/estuary_cdk/capture/common.py`, [estuary-cdk/estuary_cdk/capture/common.pyL53-R78](diffhunk://#diff-d443ad237b6f5eced65fc3664821174f5e071c5f22e257863ce8a144c848aeedL53-R78))
* Updated the `PageCursor` type to include `dict` for structured cursors and added support for JSON merge patches to enable efficient incremental updates. (`estuary-cdk/estuary_cdk/capture/common.py`, [estuary-cdk/estuary_cdk/capture/common.pyL53-R78](diffhunk://#diff-d443ad237b6f5eced65fc3664821174f5e071c5f22e257863ce8a144c848aeedL53-R78))

### Backfill Logic Improvements
* Refactored the `_binding_backfill_task` function to handle dict-based cursors, including logic for JSON merge patches and proper checkpointing of incremental updates. (`estuary-cdk/estuary_cdk/capture/common.py`, [estuary-cdk/estuary_cdk/capture/common.pyL882-R912](diffhunk://#diff-d443ad237b6f5eced65fc3664821174f5e071c5f22e257863ce8a144c848aeedL882-R912))
* Introduced `_initialize_connector_state` as a helper function for better encapsulation of connector state initialization. (`estuary-cdk/estuary_cdk/capture/common.py`, [estuary-cdk/estuary_cdk/capture/common.pyR869](diffhunk://#diff-d443ad237b6f5eced65fc3664821174f5e071c5f22e257863ce8a144c848aeedR869))

### JSON Merge Patch Implementation
* Added a new `json_merge_patch` utility function to apply RFC 7396-compliant JSON merge patches, enabling efficient in-place updates to dictionaries. (`estuary-cdk/estuary_cdk/utils.py`, [estuary-cdk/estuary_cdk/utils.pyR4-R38](diffhunk://#diff-a18aebae1b21fadd9b725b63d7c1ab0381f0f33b603577f1633a07dfc676d994R4-R38))

### Source Monday Integration Updates
* Replaced `BoardItemIterator` with `get_items_from_boards` for improved cursor handling and streamlined item fetching. (`source-monday/source_monday/api.py`, [[1]](diffhunk://#diff-cc514bfee465c3b93444be0e133e25cc315861b0a142a774ad06365dba1aa96aL15-R15) [[2]](diffhunk://#diff-cc514bfee465c3b93444be0e133e25cc315861b0a142a774ad06365dba1aa96aL276-R281)
* Updated the `fetch_items_page` function to use dict-based cursors for granular progress tracking and efficient recovery. (`source-monday/source_monday/api.py`, [source-monday/source_monday/api.pyL320-R399](diffhunk://#diff-cc514bfee465c3b93444be0e133e25cc315861b0a142a774ad06365dba1aa96aL320-R399))

### GraphQL Query and Cursor Processing Refinements
* Increased the `fetch_boards_minimal` query limit from 500 to 10,000 for better scalability. (`source-monday/source_monday/graphql/boards.py`, [source-monday/source_monday/graphql/boards.pyL54-R65](diffhunk://#diff-96482155f04d0db6591736b6fcf4c944f34a3aabe87191c0d33af0371cdbbba7L54-R65))
* Simplified the `CursorCollector` class by removing unused attributes and improving cursor processing for nested structures like `next_items_page`. (`source-monday/source_monday/graphql/items.py`, [[1]](diffhunk://#diff-4abc9a989ed27f1ab56e4b8dfaacc9318eb405bbcd3348c52a802f1c4bfd967fL45-R54) [[2]](diffhunk://#diff-4abc9a989ed27f1ab56e4b8dfaacc9318eb405bbcd3348c52a802f1c4bfd967fR66-L90)

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

I tested this on a local stack.

- Verified the backfill for the `items` stream works as expected.
  - The initial page cursor was populated and checkpointed.
  - The `fetch_items_page` invocations fetched items for all boards in the current invocation and emitted a patch checkpoint for those boards in the form `{"board1": None, "board2": None}` to remove those boards from the connector state and not bloat the recovery log.
- I tested that restarting the capture works and that the connector started on the proper page.
- I used `gazctl` to read the Gazette recovery log and verified at that lower-level the recovery log only contained the initial full checkpointed pager cursor dictionary followed by incremental patches or updates which were setting board IDs to `null` (i.e., removing them from the state by merge patching).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/3068)
<!-- Reviewable:end -->
