### PR TITLE
source-kinesis: don't try to make more than 5 requests per second

### DIFF
--- a/source-kinesis/connection.go
+++ b/source-kinesis/connection.go
@@ -7,12 +7,12 @@ import (
 	"slices"
 	"sync"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/aws/ratelimit"
 	"github.com/aws/aws-sdk-go-v2/aws/retry"
 	"github.com/aws/aws-sdk-go-v2/service/kinesis"
 	"golang.org/x/sync/errgroup"
 
-	"github.com/aws/aws-sdk-go-v2/aws"
 	awsConfig "github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/credentials"
 )


### PR DESCRIPTION
**Description:**

Kinesis has a 5 transactions per second limit for a single shard, and a GetRecords call counts against that.

Previously the backoff & retry logic of the SDK was used exclusively for managing this, but that's not ideal since the retry behavior is rather aggressive, and any time you exceed the provisioned throughput the server will close the connection. This was actually causing a lot of connection churn and occasional DNS resolution failures.

The fix here is to use a client-side rate limiter that respects the 5 TPS limit. Experimentally I have observed that this nearly eliminates the connection churn, and should improve the stability of the connector.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/3069)
<!-- Reviewable:end -->
