### PR TITLE
source-stripe-native: memory usage improvements for connected accounts

### DIFF
--- a/estuary-cdk/estuary_cdk/capture/common.py
+++ b/estuary-cdk/estuary_cdk/capture/common.py
@@ -573,14 +573,14 @@ def open(
                     ):
                         initialized_backfill_state = resource.initial_state.backfill
                         initialized_backfill_state.cutoff = state.inc.cursor
-                        state.backfill = initialized_backfill_state
+                        state.backfill = initialized_backfill_state.model_copy(deep=True)
                     # In all other cases, wipe the state back to the initial state.
                     else:
-                        state = resource.initial_state
+                        state = resource.initial_state.model_copy(deep=True)
 
                     state.is_connector_initiated = True
                 else:
-                    state = resource.initial_state
+                    state = resource.initial_state.model_copy(deep=True)
 
                 state.last_initialized = NOW
 


### PR DESCRIPTION
**Description:**

This PR's scope includes:
- Create deep copies of the `initial_state` when initializing a binding's state in `estuary-cdk`. This prevents unintended mutations to `initial_state` via `state`.
- Generate `initial_state` and `all_account_ids` once in `source-stripe-native`. Instead of generating these potentially large objects for _each_ binding and holding it in memory, it makes sense to only generate them once since they're calculated to the same value.

See individual commits for more details.

The memory unlocked by these improvements can be used to concurrently capture from more connected accounts. But before changing those settings, I'd like to observe and note how much these improvements affect actual production captures' memory usages. After noting how much these changes gain us, I'll put up a separate PR that tweaks settings in `priority_capture.py` to concurrently capture from more accounts.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

Tested on a local stack. With ~7,000 connected accounts all still needing to be backfilled, the connector's memory usage was ~65% (down from 80%).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/3074)
<!-- Reviewable:end -->
