### PR TITLE
source-mysql: Schema filtering on DB side

### DIFF
--- a/source-mysql/.snapshots/TestSchemaWhitelist-Default
+++ b/source-mysql/.snapshots/TestSchemaWhitelist-Default
@@ -1,0 +1,133 @@
+Binding 0:
+{
+    "recommended_name": "test/schemawhitelist_974315",
+    "resource_config_json": {
+      "namespace": "test",
+      "stream": "SchemaWhitelist_974315"
+    },
+    "document_schema_json": {
+      "$defs": {
+        "TestSchemaWhitelist_974315": {
+          "type": "object",
+          "required": [
+            "id"
+          ],
+          "$anchor": "TestSchemaWhitelist_974315",
+          "properties": {
+            "data": {
+              "description": "(source type: text)",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "id": {
+              "type": "integer",
+              "description": "(source type: non-nullable int)"
+            }
+          }
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "_meta": {
+                "properties": {
+                  "op": {
+                    "const": "d"
+                  }
+                }
+              }
+            }
+          },
+          "then": {
+            "reduce": {
+              "delete": true,
+              "strategy": "merge"
+            }
+          },
+          "else": {
+            "reduce": {
+              "strategy": "merge"
+            }
+          },
+          "required": [
+            "_meta"
+          ],
+          "properties": {
+            "_meta": {
+              "type": "object",
+              "required": [
+                "op",
+                "source"
+              ],
+              "properties": {
+                "before": {
+                  "$ref": "#TestSchemaWhitelist_974315",
+                  "description": "Record state immediately before this change was applied.",
+                  "reduce": {
+                    "strategy": "firstWriteWins"
+                  }
+                },
+                "op": {
+                  "enum": [
+                    "c",
+                    "d",
+                    "u"
+                  ],
+                  "description": "Change operation type: 'c' Create/Insert, 'u' Update, 'd' Delete."
+                },
+                "source": {
+                  "$id": "https://github.com/estuary/connectors/source-mysql/mysql-source-info",
+                  "properties": {
+                    "ts_ms": {
+                      "type": "integer",
+                      "description": "Unix timestamp (in millis) at which this event was recorded by the database."
+                    },
+                    "schema": {
+                      "type": "string",
+                      "description": "Database schema (namespace) of the event."
+                    },
+                    "snapshot": {
+                      "type": "boolean",
+                      "description": "Snapshot is true if the record was produced from an initial table backfill and unset if produced from the replication log."
+                    },
+                    "table": {
+                      "type": "string",
+                      "description": "Database table of the event."
+                    },
+                    "cursor": {
+                      "type": "string",
+                      "description": "Cursor value representing the current position in the binlog."
+                    },
+                    "txid": {
+                      "type": "string",
+                      "description": "The global transaction identifier associated with a change by MySQL. Only set if GTIDs are enabled."
+                    }
+                  },
+                  "type": "object",
+                  "required": [
+                    "schema",
+                    "table",
+                    "cursor"
+                  ]
+                }
+              },
+              "reduce": {
+                "strategy": "merge"
+              }
+            }
+          }
+        },
+        {
+          "$ref": "#TestSchemaWhitelist_974315"
+        }
+      ],
+      "x-infer-schema": true
+    },
+    "key": [
+      "/id"
+    ]
+  }
+

--- a/source-mysql/.snapshots/TestSchemaWhitelist-Excluded
+++ b/source-mysql/.snapshots/TestSchemaWhitelist-Excluded
@@ -1,0 +1,1 @@
+(no output)

--- a/source-mysql/.snapshots/TestSchemaWhitelist-Included
+++ b/source-mysql/.snapshots/TestSchemaWhitelist-Included
@@ -1,0 +1,133 @@
+Binding 0:
+{
+    "recommended_name": "test/schemawhitelist_974315",
+    "resource_config_json": {
+      "namespace": "test",
+      "stream": "SchemaWhitelist_974315"
+    },
+    "document_schema_json": {
+      "$defs": {
+        "TestSchemaWhitelist_974315": {
+          "type": "object",
+          "required": [
+            "id"
+          ],
+          "$anchor": "TestSchemaWhitelist_974315",
+          "properties": {
+            "data": {
+              "description": "(source type: text)",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "id": {
+              "type": "integer",
+              "description": "(source type: non-nullable int)"
+            }
+          }
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "_meta": {
+                "properties": {
+                  "op": {
+                    "const": "d"
+                  }
+                }
+              }
+            }
+          },
+          "then": {
+            "reduce": {
+              "delete": true,
+              "strategy": "merge"
+            }
+          },
+          "else": {
+            "reduce": {
+              "strategy": "merge"
+            }
+          },
+          "required": [
+            "_meta"
+          ],
+          "properties": {
+            "_meta": {
+              "type": "object",
+              "required": [
+                "op",
+                "source"
+              ],
+              "properties": {
+                "before": {
+                  "$ref": "#TestSchemaWhitelist_974315",
+                  "description": "Record state immediately before this change was applied.",
+                  "reduce": {
+                    "strategy": "firstWriteWins"
+                  }
+                },
+                "op": {
+                  "enum": [
+                    "c",
+                    "d",
+                    "u"
+                  ],
+                  "description": "Change operation type: 'c' Create/Insert, 'u' Update, 'd' Delete."
+                },
+                "source": {
+                  "$id": "https://github.com/estuary/connectors/source-mysql/mysql-source-info",
+                  "properties": {
+                    "ts_ms": {
+                      "type": "integer",
+                      "description": "Unix timestamp (in millis) at which this event was recorded by the database."
+                    },
+                    "schema": {
+                      "type": "string",
+                      "description": "Database schema (namespace) of the event."
+                    },
+                    "snapshot": {
+                      "type": "boolean",
+                      "description": "Snapshot is true if the record was produced from an initial table backfill and unset if produced from the replication log."
+                    },
+                    "table": {
+                      "type": "string",
+                      "description": "Database table of the event."
+                    },
+                    "cursor": {
+                      "type": "string",
+                      "description": "Cursor value representing the current position in the binlog."
+                    },
+                    "txid": {
+                      "type": "string",
+                      "description": "The global transaction identifier associated with a change by MySQL. Only set if GTIDs are enabled."
+                    }
+                  },
+                  "type": "object",
+                  "required": [
+                    "schema",
+                    "table",
+                    "cursor"
+                  ]
+                }
+              },
+              "reduce": {
+                "strategy": "merge"
+              }
+            }
+          }
+        },
+        {
+          "$ref": "#TestSchemaWhitelist_974315"
+        }
+      ],
+      "x-infer-schema": true
+    },
+    "key": [
+      "/id"
+    ]
+  }
+


### PR DESCRIPTION
**Description:**

Previously we applied schema whitelisting by filtering the set of result rows coming back from `getTables`, but apparently there exist databases in production where there's enough data to drive the connector to OOM, so this PR changes things so that all of our MySQL discovery queries will simply ask the database to apply the configured schema selection as part of the query.

Eventually we'll probably do this for all databases in both the CDC and batch connectors, but currently it's pretty ad-hoc and we're just fixing it for specific databases when it becomes an actual problem.