### PR TITLE
source-postgres: Use pgxpool.Pool for query connection

### DIFF
--- a/source-postgres/replication.go
+++ b/source-postgres/replication.go
@@ -22,6 +22,7 @@ import (
 	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgproto3"
 	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/sirupsen/logrus"
 )
 
@@ -253,7 +254,9 @@ func (db *postgresDatabase) ReplicationStream(ctx context.Context, startCursorJS
 	}
 
 	var typeMap = pgtype.NewMap()
-	if err := registerDatatypeTweaks(ctx, db.conn, typeMap); err != nil {
+	if err := db.conn.AcquireFunc(ctx, func(conn *pgxpool.Conn) error {
+		return registerDatatypeTweaks(ctx, conn.Conn(), typeMap)
+	}); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
**Description:**

It's not uncommon in production for the query connection to be disconnected, especially if it's idle for more than a minute when replication gets busy.

Previously when that happened we would just propagate the error until it resulted in the capture failing, and then the task would be automatically restarted again after 5-10 minutes.

But that's dumb and inefficient when we could simply reconnect and continue operation as normal, the only reason we don't currently do that is that it's more work to implement. Except really it's not, we can just swap in pgxpool throughout and fix up a couple fiddly bits and there we go, now any time we go to use the connection after it's been idle for longer than 1 second (hard-coded pgxpool threshold) it will be pinged and recreated first if needed.

**Workflow steps:**

Nothing at all should change from a user-visible perspective except that we no longer have as many TCP connection errors. The test suite is unmodified and continues to pass.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/3079)
<!-- Reviewable:end -->
