### PR TITLE
source-monday: improved error handling

### DIFF
--- a/source-monday/source_monday/graphql/query_executor.py
+++ b/source-monday/source_monday/graphql/query_executor.py
@@ -32,6 +32,59 @@ COMPLEXITY_RESET_WAIT_SECONDS = 60
 # Maximum number of retry attempts for transient GraphQL query failures
 MAX_RETRY_ATTEMPTS = 5
 
+# Error codes for specific exceptions returned by the GraphQL API
+INTERNAL_SERVER_ERROR_CODE = "INTERNAL_SERVER_ERROR"
+CURSOR_EXCEPTION_CODE = "CursorException"
+USER_UNAUTHORIZED_CODE = "USER_UNAUTHORIZED"
+USER_NOT_AUTHENTICATED_CODE = "USER_NOT_AUTHENTICATED"
+GRAPHQL_VALIDATION_FAILED_CODE = "GRAPHQL_VALIDATION_FAILED"
+INVALID_GRAPHQL_REQUEST_CODE = "INVALID_GRAPHQL_REQUEST"
+PARSING_ERROR_CODE = "PARSING_ERROR"
+UNDEFINED_FIELD_CODE = "undefinedField"
+UNDEFINED_TYPE_CODE = "undefinedType"
+BAD_REQUEST_CODE = "BadRequest"
+ARGUMENT_LITERAL_IS_INCOMPATIBLE_CODE = "argumentLiteralsIncompatible"
+RATE_LIMIT_EXCEEDED_CODE = "RATE_LIMIT_EXCEEDED"
+COMPLEXITY_EXCEPTION_CODE = "ComplexityException"
+COLUMN_VALUE_EXCEPTION_CODE = "ColumnValueException"
+RESOURCE_NOT_FOUND_EXCEPTION_CODE = "ResourceNotFoundException"
+
+RETRIABLE_ERRORS = {
+    INTERNAL_SERVER_ERROR_CODE,  # 500 - Server errors are often transient
+    RATE_LIMIT_EXCEEDED_CODE,
+    COMPLEXITY_EXCEPTION_CODE,
+}
+
+NON_RETRIABLE_ERRORS = {
+    USER_UNAUTHORIZED_CODE,
+    USER_NOT_AUTHENTICATED_CODE,
+    GRAPHQL_VALIDATION_FAILED_CODE,
+    INVALID_GRAPHQL_REQUEST_CODE,
+    PARSING_ERROR_CODE,
+    UNDEFINED_FIELD_CODE,
+    UNDEFINED_TYPE_CODE,
+    BAD_REQUEST_CODE,
+    ARGUMENT_LITERAL_IS_INCOMPATIBLE_CODE,
+    RESOURCE_NOT_FOUND_EXCEPTION_CODE,
+    COLUMN_VALUE_EXCEPTION_CODE,
+    CURSOR_EXCEPTION_CODE,
+}
+
+STATUS_CODE_PRIORITY = {
+    401: 1,
+    403: 2,
+    404: 3,
+    400: 4,
+    429: 5,
+    500: 6,
+    502: 7,
+    503: 8,
+    200: 99,  # Success (shouldn't raise but included for completeness)
+}
+
+DEFAULT_ERROR_STATUS_CODE = 500
+DEFAULT_RETRY_WAIT_SECONDS = 2
+
 TGraphqlData = TypeVar("TGraphqlData", bound=BaseModel)
 TRemainder = TypeVar("TRemainder", bound=GraphQLResponseRemainder, contravariant=True)
 
@@ -80,6 +133,62 @@ def _add_query_complexity(log: Logger, query: str) -> str:
     return query
 
 
+def _get_primary_error_info(
+    errors: list[GraphQLError],
+) -> tuple[int, str | None, bool, int]:
+    """
+    Analyze multiple errors and determine the primary status code and whether to retry.
+
+    Returns: (status_code, error_code, should_retry, wait_seconds)
+    """
+    if not errors:
+        return DEFAULT_ERROR_STATUS_CODE, None, True, DEFAULT_RETRY_WAIT_SECONDS
+
+    error_details = []
+    for error in errors:
+        if error.extensions:
+            status_code = error.extensions.status_code
+            code = error.extensions.code
+            error_details.append(
+                {
+                    "status_code": status_code,
+                    "code": code,
+                    "error": error,
+                    "priority": STATUS_CODE_PRIORITY.get(status_code, 99)
+                    if status_code
+                    else 99,
+                }
+            )
+
+    if not error_details:
+        # No extensions found, treat as generic server error
+        return DEFAULT_ERROR_STATUS_CODE, None, True, DEFAULT_RETRY_WAIT_SECONDS
+
+    error_details.sort(key=lambda x: x["priority"])
+    primary_error = error_details[0]
+
+    code = primary_error["code"]
+    status_code = primary_error["status_code"]
+
+    if code in NON_RETRIABLE_ERRORS:
+        return status_code, code, False, 0
+    elif code == CURSOR_EXCEPTION_CODE:
+        return status_code, code, False, 0
+    elif code == RATE_LIMIT_EXCEEDED_CODE:
+        return status_code, code, True, 60
+    elif code == COMPLEXITY_EXCEPTION_CODE:
+        return status_code, code, True, 30
+    elif code in RETRIABLE_ERRORS:
+        return status_code, code, True, 2
+    else:
+        if status_code >= 500:
+            return status_code, code, True, 2
+        elif status_code >= 400:
+            return status_code, code, False, 0
+        else:
+            return status_code, code, True, 2
+
+
 async def execute_query(
     cls: type[TGraphqlData],
     http: HTTPSession,
@@ -107,6 +216,7 @@ async def execute_query(
 
     attempt = 1
     modified_query = _add_query_complexity(log, query)
+    reset_in_seconds = None
 
     while True:
         try:
@@ -134,6 +244,9 @@ async def execute_query(
 
             remainder = processor.get_remainder()
 
+            if remainder.data and remainder.data.complexity:
+                reset_in_seconds = remainder.data.complexity.reset_in_x_seconds
+
             if remainder.has_errors():
                 raise GraphQLQueryError(remainder.get_errors())
 
@@ -160,102 +273,95 @@ async def execute_query(
                             "threshold": LOW_COMPLEXITY_BUDGET,
                             "reset_wait_seconds": remainder.data.complexity.reset_in_x_seconds,
                             "query_complexity": remainder.data.complexity.query,
-                        }
+                        },
                     )
                     await asyncio.sleep(remainder.data.complexity.reset_in_x_seconds)
 
             return
 
         except GraphQLQueryError as e:
-            for error in e.errors:
-                if error.extensions:
-                    if error.extensions.complexity and error.extensions.maxComplexity:
-                        if error.extensions.complexity > error.extensions.maxComplexity:
-                            log.error(
-                                "GraphQL query permanently exceeds complexity limit - cannot be retried",
-                                {
-                                    "query_complexity": error.extensions.complexity,
-                                    "max_allowed_complexity": error.extensions.maxComplexity,
-                                    "complexity_ratio": round(error.extensions.complexity / error.extensions.maxComplexity, 2),
-                                    "query_preview": query[:200] + "..." if len(query) > 200 else query,
-                                    "variables": variables,
-                                    "json_path": json_path,
-                                    "response_model": cls.__name__,
-                                },
-                            )
-                            raise
+            status_code, error_code, should_retry, wait_seconds = (
+                _get_primary_error_info(e.errors)
+            )
+            if reset_in_seconds is not None:
+                wait_seconds = reset_in_seconds
 
-                if (
-                    "ComplexityException" in str(error)
-                    or "complexity" in str(error).lower()
-                ):
-                    log.warning(
-                        f"Hit complexity limit during query execution (attempt {attempt})",
-                        {
-                            "error": str(error),
-                            "will_retry_in_seconds": COMPLEXITY_RESET_WAIT_SECONDS,
-                        },
-                    )
-                    await asyncio.sleep(COMPLEXITY_RESET_WAIT_SECONDS)
-                    attempt += 1
-                    break
-
-            if attempt == MAX_RETRY_ATTEMPTS:
-                log.error(
-                    "GraphQL streaming query failed permanently",
+            log_context = {
+                "primary_status_code": status_code,
+                "primary_error_code": error_code,
+                "all_errors": [
                     {
-                        "total_attempts": attempt,
-                        "final_error": str(e),
-                        "variables": variables,
-                        "json_path": json_path,
-                        "response_model": cls.__name__,
-                    },
-                )
+                        "message": err.message,
+                        "code": err.extensions.code if err.extensions else None,
+                        "status_code": err.extensions.status_code
+                        if err.extensions
+                        else None,
+                    }
+                    for err in e.errors
+                ],
+                "attempt": attempt,
+                "max_attempts": MAX_RETRY_ATTEMPTS,
+                "will_retry": should_retry and attempt < MAX_RETRY_ATTEMPTS,
+            }
+
+            if not should_retry:
+                if error_code == CURSOR_EXCEPTION_CODE:
+                    log.error("Cursor expired - need new cursor", log_context)
+                    # TODO(jsmith): If this becomes a recurrent issue, consider
+                    # implementing a cursor refresh instead of failing
+                else:
+                    log.error(
+                        f"Non-retriable error with status {status_code}", log_context
+                    )
                 raise
 
-            retry_delay = attempt * 2
-            log.warning(
-                "GraphQL query failed - retrying with exponential backoff",
-                {
-                    "error": str(e),
-                    "attempt": attempt,
-                    "max_attempts": MAX_RETRY_ATTEMPTS,
-                    "query_preview": modified_query[:100] + "..." if len(modified_query) > 100 else modified_query,
-                    "variables": variables,
-                    "json_path": json_path,
-                    "response_model": cls.__name__,
-                    "retry_delay_seconds": retry_delay,
-                },
-            )
-            await asyncio.sleep(retry_delay)
+            if attempt >= MAX_RETRY_ATTEMPTS:
+                log.error("Max retries exhausted", log_context)
+                raise
+
+            if error_code == RATE_LIMIT_EXCEEDED_CODE:
+                log.warning(f"Rate limit hit, waiting {wait_seconds}s", log_context)
+            elif error_code == COMPLEXITY_EXCEPTION_CODE:
+                log.warning(
+                    f"Complexity limit hit, waiting {wait_seconds}s", log_context
+                )
+            else:
+                wait_seconds = min(wait_seconds * attempt, 60)
+                log.warning(f"Retriable error, waiting {wait_seconds}s", log_context)
+
+            await asyncio.sleep(wait_seconds)
             attempt += 1
 
+        except ValidationError as e:
+            log.error(
+                "Response validation failed",
+                {
+                    "error": str(e),
+                    "attempt": attempt,
+                },
+            )
+            raise
+
         except Exception as e:
-            if attempt == MAX_RETRY_ATTEMPTS or isinstance(e, ValidationError):
+            if attempt >= MAX_RETRY_ATTEMPTS:
                 log.error(
-                    "GraphQL streaming query failed permanently",
+                    "Unexpected error after max retries",
                     {
-                        "total_attempts": attempt,
-                        "final_error": str(e),
-                        "variables": variables,
-                        "json_path": json_path,
-                        "response_model": cls.__name__,
+                        "error": str(e),
+                        "error_type": type(e).__name__,
+                        "attempt": attempt,
                     },
                 )
                 raise
 
+            wait_seconds = min(2 * attempt, 30)
             log.warning(
-                "GraphQL streaming query failed, will retry",
+                f"Unexpected error, retrying in {wait_seconds}s",
                 {
                     "error": str(e),
+                    "error_type": type(e).__name__,
                     "attempt": attempt,
-                    "query": modified_query,
-                    "variables": variables,
-                    "json_path": json_path,
-                    "response_model": cls.__name__,
-                    "next_retry_delay_s": attempt * 2,
                 },
             )
-
-            await asyncio.sleep(attempt * 2)
+            await asyncio.sleep(wait_seconds)
             attempt += 1

--- a/source-monday/source_monday/models.py
+++ b/source-monday/source_monday/models.py
@@ -79,6 +79,7 @@ class GraphQLError(BaseModel, extra="allow"):
         code: str = Field(
             default="INTERNAL_SERVER_ERROR"
         )  # Default code for errors if the API does not specify one.
+        status_code: int | None = None
         complexity: int | None = None
         maxComplexity: int | None = None
 


### PR DESCRIPTION
**Description:**

This change improves error handling for the Monday.com GraphQL API client by explicitly addressing the **list of errors** that may be returned in a single GraphQL response. When a query results in multiple errors (e.g., due to partial failures, field-level issues, or concurrent problems), the system now **analyzes all errors, determines their status codes, and surfaces the most actionable (highest priority) status code** to the caller. This approach also clearly marks which errors are non-retriable (e.g., permission, validation, or schema issues), which should be retried (e.g., rate limits, server errors which are typically transient), and which require special handling (e.g., cursor expiry).

Note: the cursor expiry is not handled as a special case currently. The code will log and raise an error since the retry strategy for Monday's internal short-lived cursors for `items` pages may not be needed. This is logged and marked with a `TODO` to preserve the option later to handle this if it becomes an issue. However, if that is the case later there may be performance issues that are the root cause anyway.

### Error Code to Status Code Mappings (Common examples seen in production or testing)

| Error Code                        | Typical Status Code | Description                                 |
|-----------------------------------|--------------------|---------------------------------------------|
| `USER_UNAUTHORIZED`               | 403                | Permission denied                           |
| `RATE_LIMIT_EXCEEDED`             | 429                | API rate limit hit                          |
| `INTERNAL_SERVER_ERROR`           | 500                | Server-side failure                         |
|      `...`       | 200*               |    ` ...`      |

\*Some platform logic errors may return HTTP 200 with a GraphQL error in the `errors` array.

### Handling Multiple Errors in a Single Response

When querying for multiple boards, for example, a few boards may not be in scope for the provided `access_token` and thus may return partial results in the `data` portion of the response and a list of `errors` indicating `USER_UNAUTHORIZED`. This information can be analyzed to determine which boards are specifically out of scope and inaccessible to the user provided `access_token`; However, for now this PR just logs and raises the errors.

- **The `errors` Array**: Every GraphQL response can contain multiple errors, each with its own `extensions.code` and potentially a `status_code`.
- **Priority**: When multiple errors occur, surface the one with the most actionable status code (e.g., 401 > 403 > 404 > 400 > 429 > 500).
- **Logging**: Always log all errors for observability and debugging, not just the "primary" one.
- **Retry Logic**: Retry only retriable errors (e.g., rate limits, server errors). Non-retriable errors (auth, validation, not found) should be surfaced immediately.
- **Special Cases**: For `CursorException`, consider whether the cursor can be refreshed and the query retried with the new cursor.

### Useful Info

**Multi-Error Handling**  
Each GraphQL response can contain an `"errors"` array; our logic explicitly iterates this list, collects all error codes and status codes, and **chooses the most severe status code** for the final decision (e.g., a 401 auth error overrides a 429 rate limit for reporting purposes).

**Status Code Prioritization**  
We apply a **priority order** (e.g., 401 > 403 > 404 > 400 > 429 > 500) to ensure the most relevant error is surfaced, simplifying client error handling and monitoring.

**Retryability Rules**  
**Non-retriable errors** (schema, validation, auth, 4xx) are surfaced immediately, **retriable errors** (rate limits, complexity, 5xx) are retried with appropriate delays, and **cursor errors** are handled as a special case.

**Structured Logging**  
All errors, their codes, and statuses are logged in detail for observability and debugging, including their positions in the query and any variables.

**Dynamic Cursor Refresh**  
If the cursor has expired, we can later update the `TODO` with logic for refreshing ephemeral cursors returned by Monday.com when paging board `items`.

**Safely Extensible**  
This PR does not provide an exhaustive list of errors; However, new error codes are easily added.

### References:

- **Monday.com GraphQL API documentation** (structure of error lists, `status_code`, and `code` in extensions)
- **GraphQL specification** (multi-error responses with `errors` array)
- **HTTP status code best practices** (retry semantics for 4xx vs 5xx)
- **Observed Monday.com error codes** (cursor, complexity, rate limiting, etc.)
- **Monday.com developer changelog** (for API changes and new error codes)
- **Example production logs** (for edge cases and real-world error patterns)

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

- Tested on two production captures that were exhibiting different behaviors.
  - One had `USER_UNAUTHORIZED` errors that were surfacing as "retriable" errors. After testing with this PR, the capture failed as it should for authorization issues.
  - The other did not have issues present and worked before and after this PR, so there were no breaking changes observed.
- Tested a few other complexity limit scenarios by increasing limits triggering max complexity per query exceptions. This also worked as expected.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/3083)
<!-- Reviewable:end -->
