### PR TITLE
materialize-motherduck: greatly increase maximum_object_size

### DIFF
--- a/materialize-motherduck/.snapshots/TestSQLGeneration
+++ b/materialize-motherduck/.snapshots/TestSQLGeneration
@@ -100,6 +100,7 @@ SELECT * FROM read_json(
 	['s3://bucket/file1', 's3://bucket/file2'],
 	format='newline_delimited',
 	compression='gzip',
+	maximum_object_size=1073741824,
 	columns={
 		key1: 'BIGINT NOT NULL',
 		key2: 'BOOLEAN NOT NULL',
@@ -131,6 +132,7 @@ SELECT * FROM read_json(
 	['s3://bucket/file1', 's3://bucket/file2'],
 	format='newline_delimited',
 	compression='gzip',
+	maximum_object_size=1073741824,
 	columns={
 		"theKey": 'VARCHAR NOT NULL',
 		"aValue": 'BIGINT',

--- a/materialize-motherduck/sqlgen.go
+++ b/materialize-motherduck/sqlgen.go
@@ -169,6 +169,7 @@ SELECT * FROM read_json(
 	],
 	format='newline_delimited',
 	compression='gzip',
+	maximum_object_size=1073741824,
 	columns={
 	{{- range $ind, $col := $.Columns }}
 		{{- if $ind }},{{ end }}


### PR DESCRIPTION
**Description:**

There is no reason we'd want to fail the materialization if the rows to store are too large. duckdb itself doesn't have any kind of limit, and I don't know of anything specific for MotherDuck either.

Practically the Flow runtime has a maximum size limit of 64 MiB for a single documents, so setting this `maximum_object_size` to a huge value like 1 GiB should effectively disable it.

Even if there are some kinds of limits in the duckdb / MotherDuck architecture, our 64 MiB single document limit is probably below whatever those are.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/3085)
<!-- Reviewable:end -->
