### PR TITLE
source-monday: add support for excluding specific board IDs in API calls via advanced configuration

### DIFF
--- a/source-monday/source_monday/graphql/__init__.py
+++ b/source-monday/source_monday/graphql/__init__.py
@@ -2,7 +2,6 @@ from .activity_logs import fetch_activity_logs
 from .boards import (
     fetch_boards_by_ids,
     fetch_boards_minimal,
-    fetch_boards_paginated,
     fetch_boards_with_retry,
 )
 from .constants import (
@@ -25,7 +24,6 @@ __all__ = [
     "fetch_activity_logs",
     "fetch_boards_by_ids",
     "fetch_boards_minimal",
-    "fetch_boards_paginated",
     "fetch_boards_with_retry",
     "fetch_items_by_id",
     "get_items_from_boards",

--- a/source-monday/source_monday/models.py
+++ b/source-monday/source_monday/models.py
@@ -64,6 +64,20 @@ class EndpointConfig(BaseModel):
         title="Authentication",
         discriminator="credentials_title",
     )
+    
+    class Advanced(BaseModel):
+        excluded_board_ids: list[str] = Field(
+            default_factory=list,
+            title="Excluded Board IDs",
+            description="List of board IDs to exclude from processing. Useful for boards that are known to cause issues (e.g., unauthorized to query activity logs) or are not relevant.",
+        )
+
+    advanced: Advanced = Field(
+        default_factory=Advanced, #type: ignore
+        title="Advanced Config",
+        description="Advanced settings for the connector.",
+        json_schema_extra={"advanced": True},
+    )
 
 
 ConnectorState = GenericConnectorState[ResourceState]
@@ -226,12 +240,12 @@ class ItemsBackfillCursor:
 
 
 IncrementalResourceFetchChangesFn = Callable[
-    [HTTPSession, Logger, LogCursor],
+    [HTTPSession, list[str], Logger, LogCursor],
     AsyncGenerator[BaseDocument | LogCursor, None],
 ]
 
 IncrementalResourceFetchPageFn = Callable[
-    [HTTPSession, Logger, PageCursor, LogCursor],
+    [HTTPSession, list[str], Logger, PageCursor, LogCursor],
     AsyncGenerator[BaseDocument | PageCursor, None],
 ]
 

--- a/source-monday/source_monday/resources.py
+++ b/source-monday/source_monday/resources.py
@@ -120,8 +120,8 @@ def incremental_resources(log: Logger, http: HTTPMixin, config: EndpointConfig):
             binding_index,
             state,
             task,
-            fetch_changes=functools.partial(fetch_changes_fn, http),
-            fetch_page=functools.partial(fetch_page_fn, http),
+            fetch_changes=functools.partial(fetch_changes_fn, http, config.advanced.excluded_board_ids),
+            fetch_page=functools.partial(fetch_page_fn, http, config.advanced.excluded_board_ids),
         )
 
     return [

--- a/source-monday/tests/snapshots/snapshots__spec__stdout.json
+++ b/source-monday/tests/snapshots/snapshots__spec__stdout.json
@@ -22,6 +22,20 @@
           ],
           "title": "AccessToken",
           "type": "object"
+        },
+        "Advanced": {
+          "properties": {
+            "excluded_board_ids": {
+              "description": "List of board IDs to exclude from processing. Useful for boards that are known to cause issues (e.g., unauthorized to query activity logs) or are not relevant.",
+              "items": {
+                "type": "string"
+              },
+              "title": "Excluded Board IDs",
+              "type": "array"
+            }
+          },
+          "title": "Advanced",
+          "type": "object"
         }
       },
       "properties": {
@@ -38,6 +52,12 @@
             }
           ],
           "title": "Authentication"
+        },
+        "advanced": {
+          "$ref": "#/$defs/Advanced",
+          "advanced": true,
+          "description": "Advanced settings for the connector.",
+          "title": "Advanced Config"
         }
       },
       "required": [


### PR DESCRIPTION
**Description:**

This pull request introduces functionality to exclude specific board IDs from processing in the `source-monday` connector. It also swaps the use of `fetch_boards_paginated` function with `fetch_boards_by_id` so the `boards` backfill can function can filter excluded boards. Otherwise, the `fetch_boards_paginated` would include the boards and a user may be excluding specific board that they do not have full access to which cause downstream `USER_UNAUTHORIZED` errors in queries. Below are the key changes grouped by theme:

The `boards` `fetch_page` (backfill) function did not fetch by board IDs and thus could not exclude boards specified in the configuration. The function was updated to use the `fetch_boards_by_id` instead so that we can filter out excluded IDs. This required the function to use a dictionary for a page cursor since the board IDs as a string cursor can be too large and other pagination strategies will be unreliable if the number of boards changes between invocations and restarts.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

- Ran on a local capture.
- Tested restart/resume/excluding problematic (improper permissions) boards.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/3086)
<!-- Reviewable:end -->
