### PR TITLE
materialize-postgres: Add Supabase variant

### DIFF
--- a/materialize-postgres/VARIANTS
+++ b/materialize-postgres/VARIANTS
@@ -3,3 +3,4 @@ materialize-alloydb
 materialize-amazon-aurora-postgres
 materialize-google-cloud-sql-postgres
 materialize-amazon-rds-postgres
+materialize-supabase-postgres


### PR DESCRIPTION
**Description:**

Adds Supabase as a PostgreSQL materialization variant for better Supabase discoverability.

The Postgres connector appears to already handle Supabase use cases (specifically, forbidding connection poolers), and I was successfully able to set up a Postgres materialization using a Supabase instance.

**Documentation links affected:**

I will add new reference docs for the Supabase variant.

**Notes for reviewers:**

Thanks for reviewing!

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/3088)
<!-- Reviewable:end -->
