### PR TITLE
source-salesforce-native: improve integer conversion handling for Bulk API records

### DIFF
--- a/source-salesforce-native/source_salesforce_native/models.py
+++ b/source-salesforce-native/source_salesforce_native/models.py
@@ -418,11 +418,9 @@ class SalesforceRecord(BaseDocument, extra="allow"):
             case SoapTypes.BOOLEAN:
                 transformed_value = cls._bool_str_to_bool(value)
             case SoapTypes.INTEGER | SoapTypes.LONG:
-                # Salesforce's Bulk API returns "0.0" for integer fields when their value is 0.
-                if value == "0.0":
-                    transformed_value = 0
-                else:
-                    transformed_value = int(value)
+                # Sometimes even standard Salesforce integer fields _actually_ contain floats. So
+                # we try to convert them to integers first and fallback to converting to floats.
+                transformed_value = cls._str_to_number(value)
             case SoapTypes.DOUBLE:
                 transformed_value = float(value)
             case SoapTypes.ANY_TYPE:


### PR DESCRIPTION
**Description:**

Turns out that sometimes Salesforce says a standard field is `xsd:int`/`xsd:long` but the field actually contains float values. The REST API keeps the type Salesforce sends these fields to us, but the Bulk API returns everything as strings since we're reading from CSVs & we convert them to the appropriate type. Our previous handling choked on supposedly integer type fields containing values like `"47.0"`, but the existing `_str_to_number` function handles this fine.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

I didn't test this on a local stack, but it should work fine. I did do some REPL sanity checks to confirm the expected behavior:
```python
int("47") # returns 47
int("47.0") # raises ValueError
float("47.0") # returns 47.0
float("nonsense") # raises ValueError
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/3089)
<!-- Reviewable:end -->
