### PR TITLE
source-google-play: add to ci

### DIFF
--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -44,6 +44,7 @@ on:
       - "source-jira-native/**"
       - "source-looker/**"
       - "source-qualtrics/**"
+      - "source-google-play/**"
 
   pull_request:
     branches: [main]
@@ -89,6 +90,7 @@ on:
       - "source-jira-native/**"
       - "source-looker/**"
       - "source-qualtrics/**"
+      - "source-google-play/**"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -257,6 +259,10 @@ jobs:
             version: v1
             usage_rate: "1.0"
           - name: source-qualtrics
+            type: capture
+            version: v1
+            usage_rate: "1.0"
+          - name: source-google-play
             type: capture
             version: v1
             usage_rate: "1.0"

--- a/source-google-play/source_google_play/gcs.py
+++ b/source-google-play/source_google_play/gcs.py
@@ -13,9 +13,9 @@ _CSVRow = TypeVar('_CSVRow', bound=BaseModel)
 
 
 # Helpful docs around GCS endpoints.
-# https://cloud.google.com/storage/docs/json_api/v1/objects/get
-# https://cloud.google.com/storage/docs/json_api/v1/objects/list#list-object-glob
-# https://cloud.google.com/storage/docs/request-endpoints#encoding
+# Get metadata for one object - https://cloud.google.com/storage/docs/json_api/v1/objects/get
+# List metadata for objects - https://cloud.google.com/storage/docs/json_api/v1/objects/list#list-object-glob
+# Encoding URL path parts - https://cloud.google.com/storage/docs/request-endpoints#encoding
 
 
 class GCSFileMetadata(BaseModel):


### PR DESCRIPTION
**Description:**

I forgot to add the new `source-google-play` connector to the CI workflow in https://github.com/estuary/connectors/pull/3091. This PR fixes that so the package will be built and published.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/3095)
<!-- Reviewable:end -->
