### PR TITLE
source-sqlserver: Backfill Timeout of 2h

### DIFF
--- a/source-sqlserver/replication.go
+++ b/source-sqlserver/replication.go
@@ -532,7 +532,7 @@ func (rs *sqlserverReplicationStream) tryToEstablishFencePosition(ctx context.Co
 			}).Debug("queried CDC job config")
 			rs.maxTransactionsPerScanSession = jobConfig.MaxTrans
 		} else {
-			log.WithField("err", err).Warn("failed to query CDC job config")
+			log.WithField("err", err).Debug("unable to query CDC job config, assuming default")
 			rs.maxTransactionsPerScanSession = 500 // Default is 500 transactions per log scan session
 		}
 	}


### PR DESCRIPTION
**Description:**

As requested [via Slack](https://estuaryworkspace.slack.com/archives/C03Q2NRFKDL/p1753714766315249?thread_ts=1753458823.687029&cid=C03Q2NRFKDL), this PR adds a two-hour watchdog timeout to SQL Server backfills. If we're waiting on a backfill query and no rows are received for two hours, the capture will error out.

This two hour timeout is simultaneously absurdly generous for the common case and possibly too short for some niche edge cases, but in practice that's fine because in the common case we never hit the timeout and those edge cases are usually going to have a bad time no matter what we do. This is a story we're pretty familiar with from other SQL database connectors, honestly, and there will probably never be a 100% perfect solution for all captures, but having _any_ timeout here is valuable because it means we can rely on a capture doing _something_ eventually, so it helps reduce the "is the task wedged or just sitting patiently" sort of ambiguity.