### PR TITLE
mongo revert

### DIFF
--- a/source-mongodb/change_stream.go
+++ b/source-mongodb/change_stream.go
@@ -172,49 +172,37 @@ func (c *capture) streamChanges(
 
 	// Log progress while the change streams are running.
 	initialProcessed, initialEmitted, _ := c.changeStreamProgress()
-	logProgress := func() error {
-		nextProcessed, nextEmitted, clusterTimes := c.changeStreamProgress()
-		currentOpTime, err := getClusterOpTime(ctx, c.client)
-		if err != nil {
-			return fmt.Errorf("getting cluster op time: %w", err)
-		}
-
-		// "lag" is an estimate of how far behind we are on reading change
-		// streams event for each database change stream.
-		lag := make(map[string]string)
-		for db, latestEventTs := range clusterTimes {
-			lag[db] = (time.Duration(currentOpTime.T-latestEventTs.T) * time.Second).String()
-		}
-
-		if nextProcessed != initialProcessed {
-			log.WithFields(log.Fields{
-				"events":                nextProcessed - initialProcessed,
-				"docs":                  nextEmitted - initialEmitted,
-				"latestClusterOpTime":   currentOpTime,
-				"lastEventClusterTimes": clusterTimes,
-				"lag":                   lag,
-			}).Info("processed change stream events")
-		} else {
-			log.Info("change stream idle")
-		}
-
-		initialProcessed = nextProcessed
-		initialEmitted = nextEmitted
-		return nil
-	}
-
 	for {
 		select {
 		case <-time.After(streamLoggerInterval):
-			if err := logProgress(); err != nil {
-				return err
+			nextProcessed, nextEmitted, clusterTimes := c.changeStreamProgress()
+			currentOpTime, err := getClusterOpTime(ctx, c.client)
+			if err != nil {
+				return fmt.Errorf("getting cluster op time: %w", err)
 			}
+
+			// "lag" is an estimate of how far behind we are on reading change
+			// streams event for each database change stream.
+			lag := make(map[string]string)
+			for db, latestEventTs := range clusterTimes {
+				lag[db] = (time.Duration(currentOpTime.T-latestEventTs.T) * time.Second).String()
+			}
+
+			if nextProcessed != initialProcessed {
+				log.WithFields(log.Fields{
+					"events":                nextProcessed - initialProcessed,
+					"docs":                  nextEmitted - initialEmitted,
+					"latestClusterOpTime":   currentOpTime,
+					"lastEventClusterTimes": clusterTimes,
+					"lag":                   lag,
+				}).Info("processed change stream events")
+			} else {
+				log.Info("change stream idle")
+			}
+
+			initialProcessed = nextProcessed
+			initialEmitted = nextEmitted
 		case <-streamsDone.Done():
-			if err := logProgress(); err != nil {
-				// Avoid clobbering an error which is likely more causal if the
-				// change streams completed prematurely with an error.
-				log.WithError(err).Warn("error logging change stream progress")
-			}
 			return streamsDone.Err()
 		}
 	}

--- a/source-mongodb/change_stream.go
+++ b/source-mongodb/change_stream.go
@@ -169,22 +169,11 @@ func (c *capture) streamChanges(
 					log.WithFields(log.Fields{
 						"db":       s.db,
 						"attempts": catchUpAttempts,
-					}).Debug("change stream returned no documents during catch-up, retrying")
+					}).Info("change stream returned no documents during catch-up, retrying")
 					time.Sleep(1 * time.Second)
-					continue
 				} else if stopWhenCaughtUp && coordinator.gotCaughtUp(s.db, opTime) {
 					return nil
 				}
-				// Require 10 consecutive empty result sets to be considered
-				// caught-up when there is no event timestamp available for
-				// positive confirmation.
-				if catchUpAttempts > 1 {
-					log.WithFields(log.Fields{
-						"db":       s.db,
-						"attempts": catchUpAttempts,
-					}).Info("change stream catch-up retried and fetched documents")
-				}
-				catchUpAttempts = 0
 			}
 		})
 	}

--- a/source-mongodb/change_stream.go
+++ b/source-mongodb/change_stream.go
@@ -17,10 +17,6 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
-// disableRetriesForTesting can be set `true` when running tests that require
-// timely operation.
-var disableRetriesForTesting bool
-
 // changeStream associates a *mongo.ChangeStream with which database it is for.
 type changeStream struct {
 	ms *mongo.ChangeStream
@@ -158,20 +154,14 @@ func (c *capture) streamChanges(
 	group, groupCtx := errgroup.WithContext(ctx)
 
 	for _, s := range streams {
+		s := s
 		group.Go(func() error {
 			defer s.ms.Close(groupCtx)
 
-			var catchUpAttempts int
 			for {
 				if opTime, err := c.pullStream(groupCtx, s); err != nil {
 					return fmt.Errorf("change stream for %q: %w", s.db, err)
-				} else if catchUpAttempts++; stopWhenCaughtUp && opTime.IsZero() && catchUpAttempts < 10 && !disableRetriesForTesting {
-					log.WithFields(log.Fields{
-						"db":       s.db,
-						"attempts": catchUpAttempts,
-					}).Info("change stream returned no documents during catch-up, retrying")
-					time.Sleep(1 * time.Second)
-				} else if stopWhenCaughtUp && coordinator.gotCaughtUp(s.db, opTime) {
+				} else if coordinator.gotCaughtUp(s.db, opTime) && stopWhenCaughtUp {
 					return nil
 				}
 			}

--- a/source-mongodb/test_util.go
+++ b/source-mongodb/test_util.go
@@ -27,7 +27,6 @@ func testClient(t *testing.T) (*mongo.Client, config) {
 		return nil, config{}
 	}
 
-	disableRetriesForTesting = true
 	ctx := context.Background()
 
 	config := config{


### PR DESCRIPTION
**Description:**

Clean revert of the commits from #3097 and #3096.

This change had a bad interaction with captures using batch modes of capture, where there are change streams running concurrently with backfill tasks and there is a period where the change streams get priority over the backfill tasks until they are caught up. The change as-implemented would have these never signal that they were caught up, since `stopWhenCaughtUp` is actually false in this case, as they run continuously.

I'll have to think about this implementation more. I think the immediate need for it is resolved so it is fine to revert for now until I can come up with something better.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/3106)
<!-- Reviewable:end -->
