### PR TITLE
source-postgres: Handle missing discovery info for column

### DIFF
--- a/source-postgres/backfill.go
+++ b/source-postgres/backfill.go
@@ -146,9 +146,9 @@ func (db *postgresDatabase) ScanTableChunk(ctx context.Context, info *sqlcapture
 		}
 
 		outputColumnNames[idx] = columnName
-		outputTranscoders[idx] = db.backfillJSONTranscoder(typeMap, &resultColumns[idx], columnInfo, isPrimaryKey)
+		outputTranscoders[idx] = db.constructJSONTranscoder(columnInfo.DataType, isPrimaryKey, typeMap, &resultColumns[idx])
 		if slices.Contains(keyColumns, columnName) {
-			rowKeyTranscoders[idx] = db.backfillFDBTranscoder(typeMap, &resultColumns[idx], columnInfo)
+			rowKeyTranscoders[idx] = db.constructFDBTranscoder(typeMap, &resultColumns[idx])
 		}
 	}
 	// Append the '_meta' column to the output column names list so event metadata can


### PR DESCRIPTION
**Description:**

We only use discovery info in a couple of limited spots during result value processing (and arguably we should try to remove those), mostly driving it based on the PostgreSQL datatype OID and the Go values that result from using those.

Previously we were perfectly happy for that data to be missing, just carrying on as best we could without the discovery-type special cases. This was broken as part of the big optimization refactoring, so here I'm streamlining the relevant code to just the values we actually use and then making it not an error if the discovered type is unknown.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/3113)
<!-- Reviewable:end -->
