### PR TITLE
source-mongodb: retries on empty change stream results during catch-up take 2

### DIFF
--- a/source-mongodb/change_stream.go
+++ b/source-mongodb/change_stream.go
@@ -193,37 +193,49 @@ func (c *capture) streamChanges(
 
 	// Log progress while the change streams are running.
 	initialProcessed, initialEmitted, _ := c.changeStreamProgress()
+	logProgress := func() error {
+		nextProcessed, nextEmitted, clusterTimes := c.changeStreamProgress()
+		currentOpTime, err := getClusterOpTime(ctx, c.client)
+		if err != nil {
+			return fmt.Errorf("getting cluster op time: %w", err)
+		}
+
+		// "lag" is an estimate of how far behind we are on reading change
+		// streams event for each database change stream.
+		lag := make(map[string]string)
+		for db, latestEventTs := range clusterTimes {
+			lag[db] = (time.Duration(currentOpTime.T-latestEventTs.T) * time.Second).String()
+		}
+
+		if nextProcessed != initialProcessed {
+			log.WithFields(log.Fields{
+				"events":                nextProcessed - initialProcessed,
+				"docs":                  nextEmitted - initialEmitted,
+				"latestClusterOpTime":   currentOpTime,
+				"lastEventClusterTimes": clusterTimes,
+				"lag":                   lag,
+			}).Info("processed change stream events")
+		} else {
+			log.Info("change stream idle")
+		}
+
+		initialProcessed = nextProcessed
+		initialEmitted = nextEmitted
+		return nil
+	}
+
 	for {
 		select {
 		case <-time.After(streamLoggerInterval):
-			nextProcessed, nextEmitted, clusterTimes := c.changeStreamProgress()
-			currentOpTime, err := getClusterOpTime(ctx, c.client)
-			if err != nil {
-				return fmt.Errorf("getting cluster op time: %w", err)
+			if err := logProgress(); err != nil {
+				return err
 			}
-
-			// "lag" is an estimate of how far behind we are on reading change
-			// streams event for each database change stream.
-			lag := make(map[string]string)
-			for db, latestEventTs := range clusterTimes {
-				lag[db] = (time.Duration(currentOpTime.T-latestEventTs.T) * time.Second).String()
-			}
-
-			if nextProcessed != initialProcessed {
-				log.WithFields(log.Fields{
-					"events":                nextProcessed - initialProcessed,
-					"docs":                  nextEmitted - initialEmitted,
-					"latestClusterOpTime":   currentOpTime,
-					"lastEventClusterTimes": clusterTimes,
-					"lag":                   lag,
-				}).Info("processed change stream events")
-			} else {
-				log.Info("change stream idle")
-			}
-
-			initialProcessed = nextProcessed
-			initialEmitted = nextEmitted
 		case <-streamsDone.Done():
+			if err := logProgress(); err != nil {
+				// Avoid clobbering an error which is likely more causal if the
+				// change streams completed prematurely with an error.
+				log.WithError(err).Warn("error logging change stream progress")
+			}
 			return streamsDone.Err()
 		}
 	}

--- a/source-mongodb/test_util.go
+++ b/source-mongodb/test_util.go
@@ -27,6 +27,7 @@ func testClient(t *testing.T) (*mongo.Client, config) {
 		return nil, config{}
 	}
 
+	disableRetriesForTesting = true
 	ctx := context.Background()
 
 	config := config{


### PR DESCRIPTION
**Description:**

Commit 45884eb was an initial, but flawed attempt to accomplish this, which was reverted while I thought harder about how to do it correctly.

The general idea is that we have observed MongoDB change streams actually returning no results from `TryNext` even if there are more results, so we can't reliably treat the lack of results as a positive indication that the stream is caught up. Retrying a few times over the course of ~seconds seems to reliably get records if there are any though, so when a stream is being "caught up", it needs to be retried a few times if it gets no results, but has not yet observed an event timestamp later than the cluster op time watermark. This is almost exclusively relevant to databases with large existing tables that are backfilling, but no change events being generated from them.

The flaw from the initial attempt was about batch bindings running concurrently with change stream bindings that had completed their backfill. For these, it is important that `coordinator.gotCaughtUp` is reached, so that the backfill / stream coordinator apparatus can know when streams are caught up, and backfills can resume.

This change addresses the need for retries while also making sure `coordinator.gotCaughtUp` is hit.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/3117)
<!-- Reviewable:end -->
