### PR TITLE
source-google-play: remove bucket name validation

### DIFF
--- a/source-google-play/source_google_play/models.py
+++ b/source-google-play/source_google_play/models.py
@@ -21,10 +21,6 @@ from pydantic import AwareDatetime, BaseModel, Field, model_validator, Validatio
 
 EPOCH = datetime(1970, 1, 1, tzinfo=UTC)
 
-# Valid bucket names for Google Cloud Storage that contain Google Play data start with "pubsite_prod_rev".
-BUCKET_REGEX = r"^pubsite_prod_rev.*$"
-
-
 GOOGLE_SPEC = GoogleServiceAccountSpec(
     scopes=[
         "https://www.googleapis.com/auth/devstorage.read_only",
@@ -39,9 +35,8 @@ def default_start_date():
 
 class EndpointConfig(BaseModel):
     bucket: str = Field(
-        description="The bucket containing your Google Play data. The bucket starts with pubsite_prod_rev. For example, pubsite_prod_rev_01234567890987654321.",
+        description="The bucket containing your Google Play data. The bucket starts with pubsite_prod. For example, pubsite_prod_<some_identifier>.",
         title="Bucket",
-        pattern=BUCKET_REGEX,
     )
     start_date: AwareDatetime = Field(
         description="UTC date and time in the format YYYY-MM-DDTHH:MM:SSZ. Any data generated before this date will not be replicated. If left blank, the start date will be set to 30 days before the present.",

--- a/source-google-play/tests/snapshots/snapshots__spec__capture.stdout.json
+++ b/source-google-play/tests/snapshots/snapshots__spec__capture.stdout.json
@@ -30,8 +30,7 @@
       },
       "properties": {
         "bucket": {
-          "description": "The bucket containing your Google Play data. The bucket starts with pubsite_prod_rev. For example, pubsite_prod_rev_01234567890987654321.",
-          "pattern": "^pubsite_prod_rev.*$",
+          "description": "The bucket containing your Google Play data. The bucket starts with pubsite_prod. For example, pubsite_prod_<some_identifier>.",
           "title": "Bucket",
           "type": "string"
         },


### PR DESCRIPTION
**Description:**

It turns out the Google Play docs aren't completely accurate. They say the bucket will start with `pubsite_prod_rev_<some_identifier>`, but it's possible for buckets to look like `pubsite_prod_<some_identifier>`. I'm removing the bucket name validation entirely for now; once the connector gets some use, we can add this validation back in if entering an incorrect bucket name is a frequent failure point during setup.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

Confirmed there's no validation on the bucket name when creating a capture.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/3118)
<!-- Reviewable:end -->
