### PR TITLE
source-apple-app-store: properly hide the `access_token` endpoint config field in the UI

### DIFF
--- a/source-apple-app-store/source_apple_app_store/models.py
+++ b/source-apple-app-store/source_apple_app_store/models.py
@@ -49,7 +49,7 @@ class AppleCredentials(AccessToken):
     )
     access_token: str = Field(
         default="",  # Set to empty string by default because it will be generated dynamically by the patched TokenSource
-        json_schema_extra={"secret": True, "hidden": True},
+        json_schema_extra={"secret": True, "x-hidden-field": True},
     )
     private_key: str = Field(
         title="Private Key",

--- a/source-apple-app-store/tests/snapshots/snapshots__spec__stdout.json
+++ b/source-apple-app-store/tests/snapshots/snapshots__spec__stdout.json
@@ -13,10 +13,10 @@
             },
             "access_token": {
               "default": "",
-              "hidden": true,
               "secret": true,
               "title": "Access Token",
-              "type": "string"
+              "type": "string",
+              "x-hidden-field": true
             },
             "private_key": {
               "description": "The contents of the private key file (.p8) downloaded from App Store Connect. Include the entire contents including BEGIN and END markers.",


### PR DESCRIPTION
**Description:**

Properly hide the `access_token` from the Endpoint Config in the UI since it is automatically set by the custom authentication token source with a valid auto-refreshed JWT token.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

Tested on local stack. Discovery still works and the `access_token` is hidden.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/3122)
<!-- Reviewable:end -->
