### PR TITLE
source-azure-blob-storage: reset index after fetching the next page

### DIFF
--- a/source-azure-blob-storage/main.go
+++ b/source-azure-blob-storage/main.go
@@ -249,6 +249,7 @@ func (l *azureBlobListing) getPage() (*azblob.ListBlobsFlatResponse, error) {
 
 	l.page = page
 	l.currentPageLength = len(page.Segment.BlobItems)
+	l.index = 0
 
 	return &page, nil
 }


### PR DESCRIPTION
**Description:**

We need to reset the index back to 0 when we start reading files on a new page, otherwise the connector will try to use the index from the previous page and panic with an `index out of range` error.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/3127)
<!-- Reviewable:end -->
