### PR TITLE
source-sage-intacct: make PROJECT a snapshot binding

### DIFF
--- a/source-sage-intacct/source_sage_intacct/resources.py
+++ b/source-sage-intacct/source_sage_intacct/resources.py
@@ -37,13 +37,13 @@ INCREMENTAL_OBJECTS = {
     "VENDOR",
     "TRXCURRENCIES",
     "GLJOURNAL",
-    "PROJECT",
     "ITEM",
     "TASK",
 }
 
 SNAPSHOT_OBJECTS = {
     "COMPANYPREF",
+    "PROJECT",
 }
 
 # TODO: For "TAXSOLUTION", we don't have access to test this object, so we don't


### PR DESCRIPTION
**Description:**

There isn't really a way to capture deletion records for PROJECT objects since the audit history for these doesn't include the RECORDNO primary key, but we can infer deletions by using a snapshot binding.

I don't expect the PROJECT list to be very large, so a snapshot binding should work fine for it.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/3129)
<!-- Reviewable:end -->
