### PR TITLE
source-monday: stream items from response and handle null boards

### DIFF
--- a/source-monday/source_monday/graphql/boards.py
+++ b/source-monday/source_monday/graphql/boards.py
@@ -184,19 +184,20 @@ async def fetch_boards_with_retry(
 
                 chunks_to_process.extend([left_chunk, right_chunk])
 
+
 def create_board_validator(tracker: BoardNullTracker):
     def validate_board(board: Board) -> None:
-        if board.columns is None:
-            tracker.track_board_with_null_field(board.id, "columns")
-        if board.groups is None:
-            tracker.track_board_with_null_field(board.id, "groups")
-        if board.owners is None:
-            tracker.track_board_with_null_field(board.id, "owners")
-        if board.subscribers is None:
-            tracker.track_board_with_null_field(board.id, "subscribers")
-        if board.views is None:
-            tracker.track_board_with_null_field(board.id, "views")
+        if (
+            board.columns is None
+            or board.groups is None
+            or board.owners is None
+            or board.subscribers is None
+            or board.views is None
+        ):
+            tracker.track_board_with_auth_error(board.id)
+
     return validate_board
+
 
 async def _try_fetch_boards(
     http: HTTPSession,

--- a/source-monday/source_monday/graphql/items.py
+++ b/source-monday/source_monday/graphql/items.py
@@ -23,7 +23,7 @@ class BoardItems(BaseModel, extra="allow"):
 
 
 class ItemsPageRemainderData(GraphQLResponseData, extra="allow"):
-    boards: list[BoardItems] | None = None
+    boards: list[BoardItems | None] | None = None
     next_items_page: ItemsPage | None = None
 
 
@@ -45,6 +45,7 @@ ITEMS_LIMIT_BY_ID = 100
 class CursorCollector:
     def __init__(self):
         self.cursors: list[str] = []
+        self.null_board_count: int = 0
 
     def process(self, log: Logger, remainder: ItemsPageRemainder) -> None:
         log.debug("Processing ItemsPageRemainder for cursors")
@@ -55,8 +56,13 @@ class CursorCollector:
         if remainder.data.boards is not None:
             log.debug("Processing boards structure for cursors")
             boards_data = remainder.data.boards
-            
+
             for board_data in boards_data:
+                if not board_data:
+                    log.debug("Skipping empty board_data")
+                    self.null_board_count += 1
+                    continue
+
                 if not board_data.items_page:
                     log.debug(
                         "No items_page in board_data, skipping",
@@ -73,14 +79,16 @@ class CursorCollector:
         if remainder.data.next_items_page is not None:
             log.debug("Processing next_items_page structure for cursors")
             cursor = remainder.data.next_items_page.cursor
-            
+
             if cursor:
                 log.debug(f"Found cursor in next_items_page: {cursor}")
                 self.cursors.append(cursor)
 
-    def get_result(self, log: Logger) -> list[str]:
-        log.debug(f"Returning collected cursors: {self.cursors}")
-        return self.cursors
+    def get_result(self, log: Logger) -> tuple[list[str], int]:
+        log.debug(
+            f"Returning collected cursors and null board count: {self.cursors}, {self.null_board_count}"
+        )
+        return self.cursors, self.null_board_count
 
 
 async def fetch_items_by_id(
@@ -199,34 +207,38 @@ async def _stream_all_items_from_page(
     
     null_tracker = BoardNullTracker()
 
-    # Stream boards to capture board-level information and detect null items_page
-    # Then yield individual items from accessible boards
-    async for board in execute_query(
-        BoardItems,
+    async for item in execute_query(
+        Item,
         http,
         log,
-        "data.boards.item",
+        "data.boards.item.items_page.items.item",
         query,
         variables,
         remainder_cls=ItemsPageRemainder,
         remainder_processor=cursor_collector,
         null_tracker=null_tracker,
     ):
-        if board.items_page is None:
-            null_tracker.track_board_with_null_field(board.id, "items_page")
-        elif board.items_page.items is None:
-            null_tracker.track_board_with_null_field(board.id, "items")
-        elif board.items_page and board.items_page.items:
-            for item in board.items_page.items:
-                items_yielded += 1
-                yield item
+        items_yielded += 1
+        yield item
 
-    cursors = cursor_collector.get_result(log)
+    # When a board's items are not or fields on the items are not accessible to the user's
+    # API token, the response may contain a "null" entry in the `data.boards` list while other
+    # boards are present. While the API usually returns all other boards, it is safer to not
+    # try to assume or infer the board ID(s) from the response like we do elsewhere with the `BoardNullTracker`.
+    # Since the API response doesn't have the board ID with some fields "null", we can't infer the board ID
+    # reliably enough. Therefore, we just log a warning message with the list of the board IDs that were queried producing
+    # one or many USER_UNAUTHORIZED errors/"null" boards.
+    cursors, null_board_count = cursor_collector.get_result(log)
+
+    if null_board_count:
+        log.error(
+            f"Monday's API returned {null_board_count} 'null' boards when trying to retrieve items. "
+            f"However, there is not a reliable way to get the board IDs from the API response. The boards that were queried are: {variables['boardIds']}"
+        )
+
     while cursors:
         cursor = cursors.pop(0)
-        log.debug(
-            f"Processing cursor pagination, remaining cursors: {len(cursors)}"
-        )
+        log.debug(f"Processing cursor pagination, remaining cursors: {len(cursors)}")
 
         cursor_variables = {"cursor": cursor, "limit": ITEMS_LIMIT_BY_ID}
         cur_collector = CursorCollector()
@@ -244,7 +256,18 @@ async def _stream_all_items_from_page(
             items_yielded += 1
             yield item
 
-        next_cursors = cur_collector.get_result(log)
+        # Same comment as above, but for subsequent pages. However, if there are permission
+        # issues for a board, there won't be a second page to process for the board in question.
+        # This will handle the scenario where permissions change between querying the first page
+        # and the second page that could cause the board to not be accessible anymore.
+        next_cursors, null_board_count = cur_collector.get_result(log)
+
+        if null_board_count:
+            log.error(
+                f"Monday's API returned {null_board_count} 'null' boards when trying to retrieve the next page of items. "
+                f"However, there is not a reliable way to get the board IDs from the API response. The boards that were queried are: {variables['boardIds']}"
+            )
+
         if next_cursors:
             cursors.extend(next_cursors)
 


### PR DESCRIPTION
**Description:**

This PR addresses an issue observed where a previous change to gracefully handle unauthorized access to boards required a change to the items we streamed from the GraphQL responses via the `IncrementalJsonProcessor`. The prior change caused the streaming to work only for the first page of board items since the remainder processing no longer contained the cursors to collect for next page queries.

This commit reverts the streaming back to the lower-level `items` and uses the cursor collector to get the cursors as before, while also tracking nulls received for boards that are not accessible.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

Tested on local stack with large test account. Verified:
- more than 20 items backfilled for boards that have more
- cursors are collected and next page queries are executed
- results are still streamed from the response
- inaccessible boards that cause `USER_UNAUTHORIZED` errors are still handled gracefully

