### PR TITLE
source-apple-app-store: remove `BaseModel` bound from `TPaginatedResponse` TypeVar

### DIFF
--- a/source-apple-app-store/source_apple_app_store/client.py
+++ b/source-apple-app-store/source_apple_app_store/client.py
@@ -43,7 +43,7 @@ CSV_CONFIG = CSVConfig(
     encoding="utf-8",
 )
 
-TPaginatedResponse = TypeVar(name="TPaginatedResponse", bound=BaseModel)
+TPaginatedResponse = TypeVar(name="TPaginatedResponse")
 
 
 class App(BaseModel, extra="allow"):


### PR DESCRIPTION
**Description:**

This allows the `ApiResponse` generic in `_paginated_request` to work with `List[response_type]` since `List` is not of type `BaseModel`.

Error observed in production capture set up:

```
ERROR: Traceback (most recent call last):

  File "/opt/estuary-cdk/estuary_cdk/capture/base_capture_connector.py", line 83, in handle
    self._emit(Response(discovered=await self.discover(log, discover)))
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/source-apple-app-store/source_apple_app_store/__init__.py", line 42, in discover
    resources = await all_resources(log, self, discover.config)
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/source-apple-app-store/source_apple_app_store/resources.py", line 257, in all_resources
    *await analytics_resources(log, http, config),
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/source-apple-app-store/source_apple_app_store/resources.py", line 129, in analytics_resources
    app_ids = await client.list_apps()
    ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/source-apple-app-store/source_apple_app_store/client.py", line 105, in list_apps
    apps = await self._paginated_request(url, App, params)
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/source-apple-app-store/source_apple_app_store/client.py", line 87, in _paginated_request
    response = ApiResponse[List[response_type]].model_validate_json(
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/venv/lib/python3.12/site-packages/pydantic/main.py", line 746, in model_validate_json
    return cls.__pydantic_validator__.validate_json(
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
pydantic_core._pydantic_core.ValidationError: 1 validation error for ApiResponse[List[App]]
  links.next
    Field required [type=missing, input_value={'self': 'https://api.app....com/v1/apps?limit=200'}, input_type=dict]

For further information visit:
  https://errors.pydantic.dev/2.11/v/missing

file="/opt/estuary-cdk/estuary_cdk/__init__.py:152"
source="flow"
```

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

