### PR TITLE
source-postgres: Log and ignore NoticeResponse during replication

### DIFF
--- a/source-postgres/replication.go
+++ b/source-postgres/replication.go
@@ -497,6 +497,16 @@ func (s *replicationStream) relayChanges(ctx context.Context, callback func(even
 			} else {
 				return pgconn.ErrorResponseToPgError(&resp)
 			}
+		case MessageTypeNoticeResponse:
+			var resp pgproto3.NoticeResponse
+			if err := resp.Decode(msg[5:]); err != nil {
+				return fmt.Errorf("error decoding NoticeResponse: %w", err)
+			}
+			logrus.WithFields(logrus.Fields{
+				"level":   resp.Severity,
+				"message": resp.Message,
+			}).Info("received notice")
+			continue
 		default:
 			return fmt.Errorf("unexpected message type %q", msgType)
 		}


### PR DESCRIPTION
**Description:**

Honestly we might just ignore them outright (like we do when they arrive during the initial stream opening), but this is pretty rare and we've never seen notices _in the replication stream_ before, so I'd like to have logging tell us what it is. Might lower it to debug level after I see what the relevant production capture is telling us.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/3138)
<!-- Reviewable:end -->
