### PR TITLE
source-sqlserver: Fix shutdown deadlock

### DIFF
--- a/source-sqlserver/replication.go
+++ b/source-sqlserver/replication.go
@@ -741,7 +741,7 @@ func (rs *sqlserverReplicationStream) pollChanges(ctx context.Context) error {
 		// get an opportunity to observe the latest position.
 		var event = &sqlserverCommitEvent{CommitLSN: toLSN}
 		log.WithField("event", event).Trace("server lsn hasn't advanced, not polling any tables")
-		rs.events <- event
+		rs.emitEvent(ctx, event)
 		return nil
 	}
 
@@ -839,7 +839,7 @@ func (rs *sqlserverReplicationStream) pollChanges(ctx context.Context) error {
 
 	var event = &sqlserverCommitEvent{CommitLSN: toLSN}
 	log.WithField("event", event).Debug("checkpoint after polling")
-	rs.events <- event
+	rs.emitEvent(ctx, event)
 	rs.fromLSN = toLSN
 
 	return nil


### PR DESCRIPTION
**Description:**

In two places we were sending commit events directly to the events channel instead of using the emitEvent helper function which does the necessary context-cancellation logic, so it was possible for a task to deadlock with the replication thread blocked sending an event and the main thread blocked waiting for it to shut down.

