### PR TITLE
source-monday: handle new activity log event

### DIFF
--- a/source-monday/source_monday/models.py
+++ b/source-monday/source_monday/models.py
@@ -183,6 +183,7 @@ class ActivityLogEvents(StrEnum):
     BOARD_VIEW_ADDED = "board_view_added"
     BOARD_VIEW_CHANGED = "board_view_changed"
     BOARD_VIEW_ENABLED = "board_view_enabled"
+    BOARD_VIEW_DELETED = "board_view_deleted"
     BOARD_WORKSPACE_ID_CHANGED = "board_workspace_id_changed"
     CHANGE_COLUMN_SETTINGS = "change_column_settings"
     CREATE_COLUMN = "create_column"
@@ -226,7 +227,7 @@ class ActivityLogEventData(BaseModel, extra="allow"):
 
 class ActivityLog(BaseModel, extra="allow"):
     entity: Literal["board", "pulse"]
-    event: ActivityLogEvents
+    event: str
     data: ActivityLogEventData
     created_at: str
     # Set by the connector for logging purposes. These are only None
@@ -269,6 +270,7 @@ class ActivityLog(BaseModel, extra="allow"):
                 | ActivityLogEvents.BOARD_VIEW_ADDED
                 | ActivityLogEvents.BOARD_VIEW_CHANGED
                 | ActivityLogEvents.BOARD_VIEW_ENABLED
+                | ActivityLogEvents.BOARD_VIEW_DELETED
                 | ActivityLogEvents.BOARD_WORKSPACE_ID_CHANGED
                 | ActivityLogEvents.CHANGE_COLUMN_SETTINGS
                 | ActivityLogEvents.UPDATE_BOARD_NICKNAME


### PR DESCRIPTION
**Description:**

Adds `BOARD_VIEW_DELETED` event to ActivityLogEvents and updates ActivityLog to accept string events in the model so that the default `case` in `get_event_result` is reached. Before, we would see a Pydantic validation error. The match-case still works as before, but now the default case is reachable with a custom validation error thrown that is easier to read in logs.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

Tested with `flowctl preview` to verify the event processing logic still works as it did before with a few tests that test the default `case` custom exception.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/3142)
<!-- Reviewable:end -->
