### PR TITLE
source-monday: remove infinite loop

### DIFF
--- a/source-monday/source_monday/api.py
+++ b/source-monday/source_monday/api.py
@@ -313,20 +313,19 @@ async def fetch_items_changes(
             },
         )
 
-        while True:
-            async for item in get_items_from_boards(
-                http,
-                log,
-                list(board_ids_to_backfill),
-            ):
-                # For board-level item refresh, the items' updated_at field is not guaranteed to change.
-                # We will emit all items in this case, but not update the max_updated_at_in_window
-                # For example, if a board and items is duplicated, the board's updated_at will be updated,
-                # but the items' updated_at could be some historical value (e.g., 2019-09-01T00:00:00Z).
-                if item.state == "deleted":
-                    item.meta_ = Item.Meta(op="d")
+        async for item in get_items_from_boards(
+            http,
+            log,
+            list(board_ids_to_backfill),
+        ):
+            # For board-level item refresh, the items' updated_at field is not guaranteed to change.
+            # We will emit all items in this case, but not update the max_updated_at_in_window
+            # For example, if a board and items is duplicated, the board's updated_at will be updated,
+            # but the items' updated_at could be some historical value (e.g., 2019-09-01T00:00:00Z).
+            if item.state == "deleted":
+                item.meta_ = Item.Meta(op="d")
 
-                yield item
+            yield item
 
     if max_change_dt > log_cursor:
         new_cursor = (max_change_dt + timedelta(seconds=1)).replace(microsecond=0)


### PR DESCRIPTION
**Description:**

Somehow I missed this unnecessary infinite loop that is causing a production capture to hang indefinitely. Other tasks are yielding to stop due to the Monday API having transient `INTERNAL_SERVER` and Timeout errors, but the `items.incremental` task has been hung for 2+ days due to this loop.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

