### PR TITLE
source-mongodb: advanced options for change streams

### DIFF
--- a/source-mongodb/.snapshots/TestSpec
+++ b/source-mongodb/.snapshots/TestSpec
@@ -76,6 +76,16 @@
       },
       "advanced": {
         "properties": {
+          "maxAwaitTime": {
+            "type": "string",
+            "title": "Max Await Time",
+            "description": "Maximum time to wait for new change stream events before returning an empty batch. Defaults to 1 second. Accepts a Go duration string like '10s'."
+          },
+          "disablePreImages": {
+            "type": "boolean",
+            "title": "Disable Pre-Images",
+            "description": "Disable requesting pre-images even if the MongoDB deployment supports them and they are enabled for collections."
+          },
           "exclusiveCollectionFilter": {
             "type": "boolean",
             "title": "Change Stream Exclusive Collection Filter",

--- a/source-mongodb/change_stream.go
+++ b/source-mongodb/change_stream.go
@@ -65,6 +65,7 @@ type changeEvent struct {
 func (c *capture) initializeStreams(
 	ctx context.Context,
 	changeStreamBindings []bindingInfo,
+	maxAwaitTime *time.Duration,
 	requestPreImages bool,
 	exclusiveCollectionFilter bool,
 	excludeCollections map[string][]string,
@@ -122,6 +123,9 @@ func (c *capture) initializeStreams(
 		}
 
 		opts := options.ChangeStream().SetFullDocument(options.UpdateLookup)
+		if maxAwaitTime != nil {
+			opts = opts.SetMaxAwaitTime(*maxAwaitTime)
+		}
 		if requestPreImages {
 			opts = opts.SetFullDocumentBeforeChange(options.WhenAvailable)
 			pl = append(pl, bson.D{{Key: "$changeStreamSplitLargeEvent", Value: bson.D{}}}) // must be the last stage in the pipeline

--- a/source-mongodb/change_stream_test.go
+++ b/source-mongodb/change_stream_test.go
@@ -142,7 +142,7 @@ func TestPullStream(t *testing.T) {
 				lastEventClusterTime: map[string]primitive.Timestamp{},
 			}
 
-			streams, err := c.initializeStreams(ctx, bindings, true, false, map[string][]string{})
+			streams, err := c.initializeStreams(ctx, bindings, nil, true, false, map[string][]string{})
 			require.NoError(t, err)
 			require.Equal(t, 1, len(streams))
 


### PR DESCRIPTION
**Description:**

Adds a couple of advanced configuration options for change streams, to set a larger maxAwaitTime and to completely disable pre-images.

These options may be useful for high-volume change streams, where the server takes longer to respond with ready change events, and pre-images are not needed but cannot be disabled for collections on the database side.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

The source-mongodb documentation will need updated to reflect these options.

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/3151)
<!-- Reviewable:end -->
