### PR TITLE
source-monday: fix `items.backfill` completion

### DIFF
--- a/source-monday/source_monday/api.py
+++ b/source-monday/source_monday/api.py
@@ -383,34 +383,39 @@ async def fetch_items_page(
         # Emit a cursor to checkpoint the complete dictionary of boards
         yield cursor.create_initial_cursor()
     else:
-        # Identify deleted boards to exclude from processing since they can be deleted between
-        # invocation of the fetch_items_page and will cause continuous INTERNAL_SERVER_ERROR issues if not handled properly
-        deleted_board_ids = []
-        current_board_ids = set()
-        async for board in fetch_boards_minimal(http, log):
-            current_board_ids.add(board.id)
-            if board.state == "deleted":
-                deleted_board_ids.append(board.id)
+        temp_cursor = ItemsBackfillCursor.from_cursor_dict(page)
 
-        # Also check for boards that existed in cursor but no longer exist at all.
-        # This has not happened yet, but might happen in the future if a board is deleted before being processed
-        # and the capture is disabled for 30+ days and Monday removes the board from the "Recycle Bin" which might
-        # mean the ID is no longer returned in the API response.
-        for board_id in page.keys():
-            if board_id not in current_board_ids:
-                deleted_board_ids.append(board_id)
+        # Only emit deletion patches when we actually have boards left to process.
+        # Otherwise, we will never "complete" backfill and the UI will show 1 binding
+        # is still backfilling since the function will be yielding a cursor before returning.
+        if temp_cursor.get_next_boards(BOARDS_PER_ITEMS_PAGE):
+            # Identify deleted boards to exclude from processing since they can be deleted between
+            # invocation of the fetch_items_page and will cause continuous INTERNAL_SERVER_ERROR issues if not handled properly
+            deleted_board_ids = []
+            current_board_ids = set()
+            async for board in fetch_boards_minimal(http, log):
+                current_board_ids.add(board.id)
+                if board.state == "deleted" and board.id in page.keys():
+                    deleted_board_ids.append(board.id)
 
-        # Emit completion patch for deleted boards to mark them as done
-        if deleted_board_ids:
-            temp_cursor = ItemsBackfillCursor.from_cursor_dict(page)
-            deleted_completion_patch = temp_cursor.create_completion_patch(deleted_board_ids)
-            yield deleted_completion_patch
-            log.debug(f"Marked {len(deleted_board_ids)} deleted boards as completed", {
-                "deleted_board_ids": deleted_board_ids
-            })
+            # Also check for boards that existed in cursor but no longer exist at all.
+            # This has not happened yet, but might happen in the future if a board is deleted before being processed
+            # and the capture is disabled for 30+ days and Monday removes the board from the "Recycle Bin" which might
+            # mean the ID is no longer returned in the API response.
+            for board_id in page.keys():
+                if board_id not in current_board_ids:
+                    deleted_board_ids.append(board_id)
 
-            for board_id in deleted_board_ids:
-                page.pop(board_id, None)
+            # Emit completion patch for deleted boards to mark them as done
+            if deleted_board_ids:
+                deleted_completion_patch = temp_cursor.create_completion_patch(deleted_board_ids)
+                yield deleted_completion_patch
+                log.debug(f"Marked {len(deleted_board_ids)} deleted boards as completed", {
+                    "deleted_board_ids": deleted_board_ids
+                })
+
+                for board_id in deleted_board_ids:
+                    page.pop(board_id, None)
 
         cursor = ItemsBackfillCursor.from_cursor_dict(page)
 


### PR DESCRIPTION
**Description:**

The `items.backfill` task currently doesn't fully complete since it is always emitting a deletion patch cursor even if all the boards in the `PageCursor` are backfilled. That incorrectly shows to the user `Backfilling 1 out of 5 bindings` in the UI.

This PR adds a check to make sure we are only emitting a patch cursor for deleted boards when there are actually boards to process.

Moves the `temp_cursor` definition up and then calls `if temp_cursor.get_next_boards(BOARDS_PER_ITEMS_PAGE):` and moves the prior logic under the `if` conditional.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/3154)
<!-- Reviewable:end -->
