### PR TITLE
source-monday: add newly observed activity log events

### DIFF
--- a/source-monday/source_monday/models.py
+++ b/source-monday/source_monday/models.py
@@ -191,6 +191,7 @@ class ActivityLogEvents(StrEnum):
     CREATE_PULSE = "create_pulse"
     DELETE_COLUMN = "delete_column"
     DELETE_GROUP = "delete_group"
+    DELETE_GROUP_PULSE = "delete_group_pulse"
     DELETE_PULSE = "delete_pulse"
     MOVE_PULSE_FROM_BOARD = "move_pulse_from_board"
     MOVE_PULSE_FROM_GROUP = "move_pulse_from_group"
@@ -198,6 +199,9 @@ class ActivityLogEvents(StrEnum):
     MOVE_PULSE_INTO_GROUP = "move_pulse_into_group"
     MOVE_SUBITEM = "move_subitem"
     REMOVE_OWNER = "remove_owner"
+    RESTORE_COLUMN = "restore_column"
+    RESTORE_GROUP = "restore_group"
+    RESTORE_PULSE = "restore_pulse"
     SUBSCRIBE = "subscribe"
     UPDATE_BOARD_NAME = "update_board_name"
     UPDATE_BOARD_NICKNAME = "update_board_nickname"
@@ -274,6 +278,7 @@ class ActivityLog(BaseModel, extra="allow"):
                 | ActivityLogEvents.BOARD_WORKSPACE_ID_CHANGED
                 | ActivityLogEvents.CHANGE_COLUMN_SETTINGS
                 | ActivityLogEvents.UPDATE_BOARD_NICKNAME
+                | ActivityLogEvents.RESTORE_GROUP
             ):
                 log.debug(f"Board change event: {self.event}")
                 ids = []
@@ -320,6 +325,8 @@ class ActivityLog(BaseModel, extra="allow"):
                 | ActivityLogEvents.BATCH_MOVE_PULSES_INTO_GROUP
                 | ActivityLogEvents.BATCH_DUPLICATE_PULSES
                 | ActivityLogEvents.MOVE_SUBITEM
+                | ActivityLogEvents.RESTORE_PULSE
+                | ActivityLogEvents.DELETE_GROUP_PULSE
             ):
                 log.debug(f"Item change event: {self.event}")
                 ids = []
@@ -369,6 +376,7 @@ class ActivityLog(BaseModel, extra="allow"):
                 | ActivityLogEvents.DELETE_COLUMN
                 | ActivityLogEvents.CREATE_GROUP
                 | ActivityLogEvents.DELETE_GROUP
+                | ActivityLogEvents.RESTORE_COLUMN
                 | ActivityLogEvents.UPDATE_GROUP_NAME
                 | ActivityLogEvents.UPDATE_COLUMN_NAME
                 | ActivityLogEvents.UPDATE_BOARD_NAME
@@ -405,7 +413,7 @@ class ActivityLog(BaseModel, extra="allow"):
                     item_ids.append(str(self.data.pulse_id))
                 if self.data.item_id:
                     item_ids.append(str(self.data.item_id))
-                
+
                 if stream == "boards":
                     if not board_ids:
                         raise ActivityLogProcessingError(
@@ -413,7 +421,7 @@ class ActivityLog(BaseModel, extra="allow"):
                             query=self.query,
                             variables=self.query_variables,
                         )
-                    
+
                     return ActivityLogEventType.BOARD_CHANGED, board_ids
                 if stream == "items":
                     if not item_ids:
@@ -422,7 +430,7 @@ class ActivityLog(BaseModel, extra="allow"):
                             query=self.query,
                             variables=self.query_variables,
                         )
-                    
+
                     return ActivityLogEventType.ITEM_CHANGED, item_ids
             case _:
                 raise ActivityLogProcessingError(


### PR DESCRIPTION
**Description:**

Observed new activity log events in production captures. This adds those to the model for processing.

Events and how they will  be handled:

- `DELETE_GROUP_PULSE` -  occurs when a group is deleted. Each item in the group will have this as an individual activity log entry to indicate that the item was deleted as part of the group deletion.
- `DELETE_GROUP` - occurs when a group is deleted. Will be a single activity log event that will be handled separately from the above event to refresh the `board` that was updated.
- `RESTORE_GROUP` - occurs if the group is restored. Will require a `board` fetch and all the board's `items` fetched since there is not an event that gives us the `item` IDs that were restored. Behaves the same as `RESTORE_COLUMN` and others.
- `RESTORE_COLUMN` - occurs when a column is deleted and later restored. Will only be a single activity log event. Similar to `RESTORE_GROUP`; we will need to fetch the `board` for the board's incremental task and all `items` for that board in the `items` incremental task.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/3156)
<!-- Reviewable:end -->
