### PR TITLE
source-monday: add `board_disconnect` activity log

### DIFF
--- a/source-monday/source_monday/models.py
+++ b/source-monday/source_monday/models.py
@@ -172,6 +172,7 @@ class ActivityLogEvents(StrEnum):
     ARCHIVE_PULSE = "archive_pulse"
     BATCH_CHANGE_PULSES_COLUMN_VALUE = "batch_change_pulses_column_value"
     BOARD_DELETED = "board_deleted"
+    BOARD_DISCONNECT = "board_disconnect"
     BATCH_CREATE_PULSES = "batch_create_pulses"
     BATCH_DELETE_PULSES = "batch_delete_pulses"
     BATCH_DUPLICATE_PULSES = "batch_duplicate_pulses"
@@ -271,6 +272,7 @@ class ActivityLog(BaseModel, extra="allow"):
                 ActivityLogEvents.ARCHIVE_GROUP
                 | ActivityLogEvents.ADD_OWNER
                 | ActivityLogEvents.REMOVE_OWNER
+                | ActivityLogEvents.BOARD_DISCONNECT
                 | ActivityLogEvents.BOARD_VIEW_ADDED
                 | ActivityLogEvents.BOARD_VIEW_CHANGED
                 | ActivityLogEvents.BOARD_VIEW_ENABLED


### PR DESCRIPTION
**Description:**

Adding `BOARD_DISCONNECT` activity log event. I don't understand this event as much; However, the `board_id` is part of the `activity_log.data` field and it appears we should treat this event as a normal `board` refresh event.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/3157)
<!-- Reviewable:end -->
