### PR TITLE
source-salesforce-native: add two more standard objects

### DIFF
--- a/source-salesforce-native/source_salesforce_native/supported_standard_objects.py
+++ b/source-salesforce-native/source_salesforce_native/supported_standard_objects.py
@@ -1253,6 +1253,12 @@ SUPPORTED_STANDARD_OBJECTS: dict[str, ObjectDetails] = {
     "InvoiceShare": {
         "cursor_field": CursorFields.LAST_MODIFIED_DATE
     },
+    "Knowledge__ka": {
+        "cursor_field": CursorFields.SYSTEM_MODSTAMP
+    },
+    "Knowledge__kav": {
+        "cursor_field": CursorFields.SYSTEM_MODSTAMP
+    },
     "KnowledgeableUser": {
         "cursor_field": CursorFields.SYSTEM_MODSTAMP
     },


### PR DESCRIPTION
**Description:**

Users are requesting the addition of the `Knowledge__ka` and `Knowledge__kav` standard objects. They both have a `SystemModstamp` field and can be queried via the REST and Bulk APIs, so simply adding them to `supported_standard_objects.py` should let these objects be discovered.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

I verified that both `Knowledge__ka` and `Knowledge__kav` are standard objects, have a valid cursor field (`SystemModstamp`), and can be queried via the REST and Bulk APIs.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/3159)
<!-- Reviewable:end -->
