### PR TITLE
materialize-snowflake: load documents as compact JSON

### DIFF
--- a/materialize-snowflake/.snapshots/TestSQLGeneration
+++ b/materialize-snowflake/.snapshots/TestSQLGeneration
@@ -95,7 +95,7 @@ ALTER TABLE "a-schema".key_value ALTER COLUMN
 --- End alter table drop not nulls ---
 
 --- Begin "a-schema".key_value loadQuery ---
-SELECT 0, "a-schema".key_value.flow_document
+SELECT 0, TO_JSON("a-schema".key_value.flow_document)
 	FROM "a-schema".key_value
 	JOIN (
 		SELECT $1[0] AS key1, $1[1] AS key2, $1[2] AS "key!binary"

--- a/materialize-snowflake/sqlgen.go
+++ b/materialize-snowflake/sqlgen.go
@@ -216,7 +216,7 @@ ALTER TABLE {{$.Identifier}} ALTER COLUMN
 
 {{ define "loadQuery" }}
 {{ if $.Table.Document -}}
-SELECT {{ $.Table.Binding }}, {{ $.Table.Identifier }}.{{ $.Table.Document.Identifier }}
+SELECT {{ $.Table.Binding }}, TO_JSON({{ $.Table.Identifier }}.{{ $.Table.Document.Identifier }})
 	FROM {{ $.Table.Identifier }}
 	JOIN (
 		SELECT {{ range $ind, $bound := $.Bounds }}


### PR DESCRIPTION
**Description:**

Querying the VARIANT document column directly was actually returning results through the Go driver as pretty-printed JSON, which has a lot of extra whitespace. In extreme cases, this could cause the documents to exceed gRPC message size limits. In more common cases it is just wasteful.

Using the TO_JSON function causes these documents to be returned in their compact JSON representation instead.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/3164)
<!-- Reviewable:end -->
