### PR TITLE
source-mongodb: use latest op time decoded from resume tokens

### DIFF
--- a/source-mongodb/change_stream_test.go
+++ b/source-mongodb/change_stream_test.go
@@ -151,7 +151,7 @@ func TestPullStream(t *testing.T) {
 
 			ts, err := c.pullStream(ctx, stream)
 			require.NoError(t, err)
-			require.True(t, ts.IsZero())
+			require.False(t, ts.IsZero())
 
 			tt.setup(t)
 

--- a/source-mongodb/coordinator_test.go
+++ b/source-mongodb/coordinator_test.go
@@ -47,7 +47,7 @@ func TestBatchStreamCoordinator(t *testing.T) {
 	default:
 	}
 
-	require.True(t, coord.gotCaughtUp("second", primitive.Timestamp{}))
+	require.True(t, coord.gotCaughtUp("second", primitive.Timestamp{T: 1001}))
 	require.True(t, coord.gotCaughtUp("third", primitive.Timestamp{T: 1001}))
 
 	select {

--- a/source-mongodb/test_util.go
+++ b/source-mongodb/test_util.go
@@ -27,7 +27,6 @@ func testClient(t *testing.T) (*mongo.Client, config) {
 		return nil, config{}
 	}
 
-	disableRetriesForTesting = true
 	ctx := context.Background()
 
 	config := config{


### PR DESCRIPTION
**Description:**

Operation times can be extracted from change stream resume tokens, even if the resume token doesn't correspond to a document event.

This ensures that the operation time will always be known when polling a change stream, which provides better observability for how caught up the connector is in reading the change stream (it won't artificially appear stalled when there are no document events for a while), and also a confirmation of when the change stream is caught up with the latest cluster time watermark.

Using these extracted operation times allows for removal of the clunky catch-up retry mechanism, which was a work-around for handling change streams that would return no events even when they were not caught up. It will now be known from the extracted timestamp that the change stream is still behind (or not), and should be polled again.

The experimental logging that I added previously is being removed with this commit, since I have used it to verify that all known MongoDB versions work with this operation time extraction mechanism.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/3166)
<!-- Reviewable:end -->
