### PR TITLE
materializer: create default namespace if it doesn't exist 

### DIFF
--- a/materialize-azure-fabric-warehouse/driver.go
+++ b/materialize-azure-fabric-warehouse/driver.go
@@ -81,6 +81,10 @@ func (c config) db() (*stdsql.DB, error) {
 	return db, nil
 }
 
+func (c config) DefaultNamespace() string {
+	return c.Schema
+}
+
 func (c config) FeatureFlags() (string, map[string]bool) {
 	return c.Advanced.FeatureFlags, featureFlagDefaults
 }

--- a/materialize-azure-fabric-warehouse/sqlgen.go
+++ b/materialize-azure-fabric-warehouse/sqlgen.go
@@ -84,6 +84,7 @@ var dialect = func() sql.Dialect {
 		TableLocatorer: sql.TableLocatorFn(func(path []string) sql.InfoTableLocation {
 			return sql.InfoTableLocation{TableSchema: path[1], TableName: path[2]}
 		}),
+		SchemaLocatorer: sql.SchemaLocatorFn(func(schema string) string { return schema }),
 		ColumnLocatorer: sql.ColumnLocatorFn(func(field string) string { return field }),
 		Identifierer: sql.IdentifierFn(sql.JoinTransform(".",
 			sql.PassThroughTransform(

--- a/materialize-bigquery/bigquery.go
+++ b/materialize-bigquery/bigquery.go
@@ -111,6 +111,10 @@ func (c config) client(ctx context.Context, ep *sql.Endpoint[config]) (*client, 
 	}, nil
 }
 
+func (c config) DefaultNamespace() string {
+	return c.Dataset
+}
+
 func (c config) FeatureFlags() (string, map[string]bool) {
 	return c.Advanced.FeatureFlags, featureFlagDefaults
 }

--- a/materialize-bigquery/sqlgen.go
+++ b/materialize-bigquery/sqlgen.go
@@ -123,6 +123,7 @@ func bqDialect(objAndArrayAsJson bool) sql.Dialect {
 				TableName:   translateFlowIdentifier(path[2]),
 			}
 		}),
+		SchemaLocatorer: sql.SchemaLocatorFn(func(schema string) string { return schema }),
 		ColumnLocatorer: sql.ColumnLocatorFn(func(field string) string { return translateFlowIdentifier(field) }),
 		Identifierer: sql.IdentifierFn(sql.JoinTransform(".",
 			identifierSanitizer(sql.PassThroughTransform(

--- a/materialize-boilerplate/apply_test.go
+++ b/materialize-boilerplate/apply_test.go
@@ -158,7 +158,7 @@ func testInfoSchemaFromSpec(t *testing.T, s *pf.MaterializationSpec, transform f
 		return out
 	}
 
-	is := NewInfoSchema(transformPath, transform, false)
+	is := NewInfoSchema(transformPath, transform, transform, false)
 
 	if s == nil || len(s.Bindings)+len(s.InactiveBindings) == 0 {
 		return is

--- a/materialize-boilerplate/materializer_test.go
+++ b/materialize-boilerplate/materializer_test.go
@@ -241,6 +241,10 @@ func (c testEndpointConfiger) Validate() error {
 	return nil
 }
 
+func (c testEndpointConfiger) DefaultNamespace() string {
+	return ""
+}
+
 func (c testEndpointConfiger) FeatureFlags() (string, map[string]bool) {
 	return "", nil
 }

--- a/materialize-cratedb/driver.go
+++ b/materialize-cratedb/driver.go
@@ -71,6 +71,10 @@ type advancedConfig struct {
 	FeatureFlags string `json:"feature_flags,omitempty" jsonschema:"title=Feature Flags,description=This property is intended for Estuary internal use. You should only modify this field as directed by Estuary support."`
 }
 
+func (c config) DefaultNamespace() string {
+	return c.Schema
+}
+
 func (c config) FeatureFlags() (string, map[string]bool) {
 	return c.Advanced.FeatureFlags, featureFlagDefaults
 }

--- a/materialize-cratedb/sqlgen.go
+++ b/materialize-cratedb/sqlgen.go
@@ -85,6 +85,7 @@ var crateDialect = func() sql.Dialect {
 				return sql.InfoTableLocation{TableSchema: path[0], TableName: normalizeColumn(path[1])}
 			}
 		}),
+		SchemaLocatorer: sql.SchemaLocatorFn(func(schema string) string { return schema }),
 		ColumnLocatorer: sql.ColumnLocatorFn(func(field string) string { return normalizeColumn(field) }),
 		Identifierer: sql.IdentifierFn(sql.JoinTransform(".",
 			identifierSanitizer(sql.PassThroughTransform(

--- a/materialize-databricks/config.go
+++ b/materialize-databricks/config.go
@@ -121,6 +121,10 @@ func (c config) Validate() error {
 	return c.Credentials.Validate()
 }
 
+func (c config) DefaultNamespace() string {
+	return c.SchemaName
+}
+
 func (c config) FeatureFlags() (string, map[string]bool) {
 	return c.Advanced.FeatureFlags, featureFlagDefaults
 }

--- a/materialize-databricks/sqlgen.go
+++ b/materialize-databricks/sqlgen.go
@@ -75,6 +75,7 @@ var databricksDialect = func() sql.Dialect {
 				TableName:   strings.ToLower(path[1]),
 			}
 		}),
+		SchemaLocatorer: sql.SchemaLocatorFn(func(schema string) string { return strings.ToLower(schema) }),
 		ColumnLocatorer: sql.ColumnLocatorFn(func(field string) string { return translateFlowField(field) }),
 		Identifierer: sql.IdentifierFn(func(path ...string) string {
 			// Sanitize column names per Databricks' restrictions. Table names do not have to be

--- a/materialize-dynamodb/driver.go
+++ b/materialize-dynamodb/driver.go
@@ -50,6 +50,10 @@ func (c config) Validate() error {
 	return nil
 }
 
+func (c config) DefaultNamespace() string {
+	return ""
+}
+
 func (c config) FeatureFlags() (string, map[string]bool) {
 	return c.Advanced.FeatureFlags, featureFlagDefaults
 }
@@ -219,7 +223,7 @@ func newMaterialization(ctx context.Context, materializationName string, cfg con
 
 func (d *materialization) Config() boilerplate.MaterializeCfg {
 	return boilerplate.MaterializeCfg{
-		Translate:           func(f string) string { return f },
+		TranslateField:      func(f string) string { return f },
 		ConcurrentApply:     true,
 		NoCreateNamespaces:  true,
 		NoTruncateResources: true,

--- a/materialize-elasticsearch/driver.go
+++ b/materialize-elasticsearch/driver.go
@@ -226,6 +226,10 @@ func (c config) Validate() error {
 	return c.Credentials.Validate()
 }
 
+func (c config) DefaultNamespace() string {
+	return ""
+}
+
 func (c config) FeatureFlags() (string, map[string]bool) {
 	return c.Advanced.FeatureFlags, featureFlagDefaults
 }
@@ -420,7 +424,7 @@ func newMaterialization(ctx context.Context, materializationName string, cfg con
 
 func (d *materialization) Config() boilerplate.MaterializeCfg {
 	return boilerplate.MaterializeCfg{
-		Translate:           translateField,
+		TranslateField:      translateField,
 		ConcurrentApply:     true,
 		NoCreateNamespaces:  true,
 		NoTruncateResources: true,

--- a/materialize-iceberg/config.go
+++ b/materialize-iceberg/config.go
@@ -102,6 +102,10 @@ func (c config) Validate() error {
 	return nil
 }
 
+func (c config) DefaultNamespace() string {
+	return c.Namespace
+}
+
 func (c config) FeatureFlags() (raw string, defaults map[string]bool) {
 	return c.Advanced.FeatureFlags, make(map[string]bool)
 }

--- a/materialize-iceberg/driver.go
+++ b/materialize-iceberg/driver.go
@@ -137,7 +137,7 @@ func (d *materialization) Config() boilerplate.MaterializeCfg {
 	}
 
 	return boilerplate.MaterializeCfg{
-		Translate:             translate,
+		TranslateField:        translate,
 		ConcurrentApply:       true,
 		MaxFieldLength:        255,
 		CaseInsensitiveFields: true,

--- a/materialize-mongodb/config.go
+++ b/materialize-mongodb/config.go
@@ -47,6 +47,10 @@ func (c config) Validate() error {
 	return nil
 }
 
+func (c config) DefaultNamespace() string {
+	return ""
+}
+
 func (c config) FeatureFlags() (string, map[string]bool) {
 	return "", make(map[string]bool)
 }

--- a/materialize-motherduck/config.go
+++ b/materialize-motherduck/config.go
@@ -106,6 +106,10 @@ func (c config) Validate() error {
 	return nil
 }
 
+func (c config) DefaultNamespace() string {
+	return c.Schema
+}
+
 func (c config) FeatureFlags() (string, map[string]bool) {
 	return c.Advanced.FeatureFlags, featureFlagDefaults
 }

--- a/materialize-motherduck/sqlgen.go
+++ b/materialize-motherduck/sqlgen.go
@@ -56,6 +56,7 @@ var duckDialect = func() sql.Dialect {
 		TableLocatorer: sql.TableLocatorFn(func(path []string) sql.InfoTableLocation {
 			return sql.InfoTableLocation{TableSchema: path[1], TableName: path[2]}
 		}),
+		SchemaLocatorer: sql.SchemaLocatorFn(func(schema string) string { return schema }),
 		ColumnLocatorer: sql.ColumnLocatorFn(func(field string) string { return field }),
 		Identifierer: sql.IdentifierFn(sql.JoinTransform(".",
 			sql.PassThroughTransform(

--- a/materialize-mysql/driver.go
+++ b/materialize-mysql/driver.go
@@ -100,6 +100,10 @@ func (c config) Validate() error {
 	return nil
 }
 
+func (c config) DefaultNamespace() string {
+	return ""
+}
+
 func (c config) FeatureFlags() (string, map[string]bool) {
 	return c.Advanced.FeatureFlags, featureFlagDefaults
 }

--- a/materialize-mysql/sqlgen.go
+++ b/materialize-mysql/sqlgen.go
@@ -118,6 +118,7 @@ var mysqlDialect = func(tzLocation *time.Location, database string, product stri
 			// name of the database.
 			return sql.InfoTableLocation{TableSchema: database, TableName: path[0]}
 		}),
+		SchemaLocatorer: sql.SchemaLocatorFn(func(schema string) string { return schema }),
 		ColumnLocatorer: sql.ColumnLocatorFn(func(field string) string { return translateFlowIdentifier(field) }),
 		Identifierer: sql.IdentifierFn(sql.JoinTransform(".",
 			identifierSanitizer(sql.PassThroughTransform(

--- a/materialize-postgres/driver.go
+++ b/materialize-postgres/driver.go
@@ -81,6 +81,10 @@ type advancedConfig struct {
 	FeatureFlags string `json:"feature_flags,omitempty" jsonschema:"title=Feature Flags,description=This property is intended for Estuary internal use. You should only modify this field as directed by Estuary support."`
 }
 
+func (c config) DefaultNamespace() string {
+	return c.Schema
+}
+
 func (c config) FeatureFlags() (string, map[string]bool) {
 	return c.Advanced.FeatureFlags, featureFlagDefaults
 }

--- a/materialize-postgres/sqlgen.go
+++ b/materialize-postgres/sqlgen.go
@@ -72,6 +72,7 @@ var pgDialect = func() sql.Dialect {
 				return sql.InfoTableLocation{TableSchema: truncatedIdentifier(path[0]), TableName: truncatedIdentifier(path[1])}
 			}
 		}),
+		SchemaLocatorer: sql.SchemaLocatorFn(func(schema string) string { return truncatedIdentifier(schema) }),
 		ColumnLocatorer: sql.ColumnLocatorFn(func(field string) string { return truncatedIdentifier(field) }),
 		Identifierer: sql.IdentifierFn(sql.JoinTransform(".",
 			sql.PassThroughTransform(

--- a/materialize-redshift/driver.go
+++ b/materialize-redshift/driver.go
@@ -118,6 +118,10 @@ func (c config) effectiveBucketPath() string {
 	return strings.TrimPrefix(c.BucketPath, "/")
 }
 
+func (c config) DefaultNamespace() string {
+	return c.Schema
+}
+
 func (c config) FeatureFlags() (string, map[string]bool) {
 	return c.Advanced.FeatureFlags, featureFlagDefaults
 }

--- a/materialize-redshift/sqlgen.go
+++ b/materialize-redshift/sqlgen.go
@@ -125,6 +125,7 @@ var rsDialect = func(caseSensitiveIdentifierEnabled bool) sql.Dialect {
 				}
 			}
 		}),
+		SchemaLocatorer: sql.SchemaLocatorFn(func(schema string) string { return identifierTransform(schema) }),
 		ColumnLocatorer: sql.ColumnLocatorFn(func(field string) string {
 			return identifierTransform(field)
 		}),

--- a/materialize-s3-iceberg/driver.go
+++ b/materialize-s3-iceberg/driver.go
@@ -107,6 +107,10 @@ func (c config) Validate() error {
 	return nil
 }
 
+func (c config) DefaultNamespace() string {
+	return ""
+}
+
 func (c config) FeatureFlags() (string, map[string]bool) {
 	return c.Advanced.FeatureFlags, featureFlagDefaults
 }

--- a/materialize-s3-iceberg/driver_test.go
+++ b/materialize-s3-iceberg/driver_test.go
@@ -77,6 +77,7 @@ func TestValidateAndApply(t *testing.T) {
 			is := boilerplate.NewInfoSchema(
 				func(rp []string) []string { return rp },
 				func(f string) string { return f },
+				func(f string) string { return f },
 				true,
 			)
 			require.NoError(t, catalog.populateInfoSchema(ctx, is, [][]string{path}))

--- a/materialize-snowflake/config.go
+++ b/materialize-snowflake/config.go
@@ -39,18 +39,24 @@ type advancedConfig struct {
 	FeatureFlags           string `json:"feature_flags,omitempty" jsonschema:"title=Feature Flags,description=This property is intended for Estuary internal use. You should only modify this field as directed by Estuary support."`
 }
 
-// toURI manually builds the DSN connection string.
-func (c config) toURI(tenant string) (string, error) {
+// toURI manually builds the DSN connection string. Most uses should set
+// `includeSchema`, to preserve legacy behavior where having the schema set on
+// the connection level is necessary for queries involving tables that don't
+// have the schema as part of their resource path.
+func (c config) toURI(tenant string, includeSchema bool) (string, error) {
 	var uri = url.URL{
 		Host: c.Host + ":443",
 	}
 
 	queryParams := make(url.Values)
 
+	if includeSchema {
+		queryParams.Add("schema", c.Schema)
+	}
+
 	// Required params
 	queryParams.Add("application", fmt.Sprintf("%s_EstuaryFlow", tenant))
 	queryParams.Add("database", c.Database)
-	queryParams.Add("schema", c.Schema)
 	// GO_QUERY_RESULT_FORMAT is json in order to enable stream downloading of load results.
 	queryParams.Add("GO_QUERY_RESULT_FORMAT", "json")
 	// By default Snowflake expects the number of statements to be provided

--- a/materialize-snowflake/config.go
+++ b/materialize-snowflake/config.go
@@ -116,6 +116,10 @@ func validHost(h string) error {
 	return nil
 }
 
+func (c config) DefaultNamespace() string {
+	return c.Schema
+}
+
 func (c config) FeatureFlags() (string, map[string]bool) {
 	return c.Advanced.FeatureFlags, featureFlagDefaults
 }

--- a/materialize-snowflake/config_test.go
+++ b/materialize-snowflake/config_test.go
@@ -39,7 +39,7 @@ func TestConfigURI(t *testing.T) {
 	} {
 		t.Run(name, func(t *testing.T) {
 			require.NoError(t, cfg.Validate())
-			uri, err := cfg.toURI("mytenant")
+			uri, err := cfg.toURI("mytenant", true)
 			require.NoError(t, err)
 			cupaloy.SnapshotT(t, uri)
 		})

--- a/materialize-snowflake/pipe.go
+++ b/materialize-snowflake/pipe.go
@@ -126,7 +126,7 @@ func generateJWTToken(key *rsa.PrivateKey, user string, accountName string) (str
 func NewPipeClient(cfg *config, accountName string, tenant string) (*PipeClient, error) {
 	httpClient := http.Client{}
 
-	var dsn, err = cfg.toURI(tenant)
+	var dsn, err = cfg.toURI(tenant, true)
 	if err != nil {
 		return nil, fmt.Errorf("building snowflake dsn: %w", err)
 	}

--- a/materialize-snowflake/snowflake.go
+++ b/materialize-snowflake/snowflake.go
@@ -92,7 +92,7 @@ func newSnowflakeDriver() *sql.Driver[config, tableConfig] {
 				"tenant":   tenant,
 			}).Info("opening Snowflake")
 
-			dsn, err := cfg.toURI(tenant)
+			dsn, err := cfg.toURI(tenant, false)
 			if err != nil {
 				return nil, fmt.Errorf("building snowflake dsn: %w", err)
 			}
@@ -213,7 +213,7 @@ func newTransactor(
 ) (m.Transactor, error) {
 	var cfg = ep.Config
 
-	dsn, err := cfg.toURI(ep.Tenant)
+	dsn, err := cfg.toURI(ep.Tenant, true)
 	if err != nil {
 		return nil, fmt.Errorf("building snowflake dsn: %w", err)
 	}

--- a/materialize-snowflake/snowflake_test.go
+++ b/materialize-snowflake/snowflake_test.go
@@ -68,7 +68,7 @@ func TestValidateAndApply(t *testing.T) {
 		Schema: "PUBLIC",
 	}
 
-	dsn, err := cfg.toURI("testing")
+	dsn, err := cfg.toURI("testing", true)
 	require.NoError(t, err)
 
 	db, err := stdsql.Open("snowflake", dsn)
@@ -105,7 +105,7 @@ func TestValidateAndApplyMigrations(t *testing.T) {
 		Schema: "PUBLIC",
 	}
 
-	dsn, err := cfg.toURI("testing")
+	dsn, err := cfg.toURI("testing", true)
 	require.NoError(t, err)
 
 	db, err := stdsql.Open("snowflake", dsn)

--- a/materialize-snowflake/sqlgen.go
+++ b/materialize-snowflake/sqlgen.go
@@ -112,9 +112,8 @@ var snowflakeDialect = func(configSchema string, timestampMapping timestampTypeM
 				}
 			}
 		}),
-		ColumnLocatorer: sql.ColumnLocatorFn(func(field string) string {
-			return translateIdentifier(field)
-		}),
+		SchemaLocatorer: sql.SchemaLocatorFn(func(schema string) string { return translateIdentifier(schema) }),
+		ColumnLocatorer: sql.ColumnLocatorFn(func(field string) string { return translateIdentifier(field) }),
 		Identifierer: sql.IdentifierFn(sql.JoinTransform(".",
 			sql.PassThroughTransform(
 				isSimpleIdentifier,

--- a/materialize-snowflake/stream_test.go
+++ b/materialize-snowflake/stream_test.go
@@ -28,7 +28,7 @@ func TestStreamManager(t *testing.T) {
 
 	cfg := mustGetCfg(t)
 
-	dsn, err := cfg.toURI("estuary")
+	dsn, err := cfg.toURI("estuary", true)
 	require.NoError(t, err)
 
 	db, err := stdsql.Open("snowflake", dsn)
@@ -451,7 +451,7 @@ func TestStreamDatatypes(t *testing.T) {
 
 	cfg := mustGetCfg(t)
 
-	dsn, err := cfg.toURI("estuary")
+	dsn, err := cfg.toURI("estuary", true)
 	require.NoError(t, err)
 
 	db, err := stdsql.Open("snowflake", dsn)

--- a/materialize-sql/dialect.go
+++ b/materialize-sql/dialect.go
@@ -10,6 +10,7 @@ import (
 // Dialect encapsulates many specifics of an Endpoint's interpretation of SQL.
 type Dialect struct {
 	TableLocatorer
+	SchemaLocatorer
 	ColumnLocatorer
 	Identifierer
 	Literaler
@@ -48,6 +49,12 @@ type InfoTableLocation struct {
 	TableName   string
 }
 
+// SchemaLocatorer translates a schema name from a Flow configuration into the value used to locate
+// that schema in the INFORMATION_SCHEMA view for the endpoint.
+type SchemaLocatorer interface {
+	SchemaLocator(field string) string
+}
+
 // ColumnLocatorer translates a field name from a Flow collection spec into the value used to locate
 // that field in the INFORMATION_SCHEMA view for the endpoint. This is similar to how an
 // InfoTableLocation must apply connector-specific transforms for the TableSchema and TableName.
@@ -83,6 +90,11 @@ type TypeMapper interface {
 type TableLocatorFn func(path []string) InfoTableLocation
 
 func (f TableLocatorFn) TableLocator(path []string) InfoTableLocation { return f(path) }
+
+// SchemaLocatorFn is a function that implements SchemaLocatorer.
+type SchemaLocatorFn func(field string) string
+
+func (f SchemaLocatorFn) SchemaLocator(field string) string { return f(field) }
 
 // ColumnLocatorFn is a function that implements ColumnLocatorer.
 type ColumnLocatorFn func(field string) string

--- a/materialize-sql/driver.go
+++ b/materialize-sql/driver.go
@@ -125,7 +125,8 @@ func (s *sqlMaterialization[EC, RC]) Config() boilerplate.MaterializeCfg {
 
 	return boilerplate.MaterializeCfg{
 		Locate:                ToLocatePathFn(s.endpoint.Dialect.TableLocator),
-		Translate:             s.endpoint.ColumnLocator,
+		TranslateNamespace:    s.endpoint.SchemaLocator,
+		TranslateField:        s.endpoint.ColumnLocator,
 		MaxFieldLength:        s.endpoint.Dialect.MaxColumnCharLength,
 		CaseInsensitiveFields: s.endpoint.Dialect.CaseInsensitiveColumns,
 		ConcurrentApply:       s.endpoint.ConcurrentApply,

--- a/materialize-sql/validate_test.go
+++ b/materialize-sql/validate_test.go
@@ -139,7 +139,7 @@ func testInfoSchemaFromSpec(t *testing.T, s *pf.MaterializationSpec, transform f
 		return out
 	}
 
-	is := boilerplate.NewInfoSchema(transformPath, transform, false)
+	is := boilerplate.NewInfoSchema(transformPath, transform, transform, false)
 
 	if s == nil || len(s.Bindings) == 0 {
 		return is

--- a/materialize-sqlite/sqlgen.go
+++ b/materialize-sqlite/sqlgen.go
@@ -28,6 +28,7 @@ var sqliteDialect = func() sql.Dialect {
 		// TableLocator and ColumnLocator are not used for sqlite, since sqlite re-creates all tables
 		// from scratch every time it starts up.
 		TableLocatorer:  sql.TableLocatorFn(func(path []string) sql.InfoTableLocation { return sql.InfoTableLocation{} }),
+		SchemaLocatorer: sql.SchemaLocatorFn(func(schema string) string { return schema }),
 		ColumnLocatorer: sql.ColumnLocatorFn(func(field string) string { return field }),
 		Identifierer: sql.IdentifierFn(sql.JoinTransform(".",
 			sql.PassThroughTransform(

--- a/materialize-sqlite/sqlite.go
+++ b/materialize-sqlite/sqlite.go
@@ -31,6 +31,10 @@ func (c config) Validate() error {
 	return nil
 }
 
+func (c config) DefaultNamespace() string {
+	return ""
+}
+
 func (c config) FeatureFlags() (string, map[string]bool) {
 	return "", make(map[string]bool)
 }

--- a/materialize-sqlserver/driver.go
+++ b/materialize-sqlserver/driver.go
@@ -74,6 +74,10 @@ func (c config) Validate() error {
 	return nil
 }
 
+func (c config) DefaultNamespace() string {
+	return c.Schema
+}
+
 func (c config) FeatureFlags() (string, map[string]bool) {
 	return c.Advanced.FeatureFlags, featureFlagDefaults
 }

--- a/materialize-sqlserver/sqlgen.go
+++ b/materialize-sqlserver/sqlgen.go
@@ -107,6 +107,7 @@ var sqlServerDialect = func(collation string, defaultSchema string) sql.Dialect 
 				return sql.InfoTableLocation{TableSchema: path[0], TableName: path[1]}
 			}
 		}),
+		SchemaLocatorer: sql.SchemaLocatorFn(func(schema string) string { return schema }),
 		ColumnLocatorer: sql.ColumnLocatorFn(func(field string) string { return field }),
 		Identifierer: sql.IdentifierFn(sql.JoinTransform(".",
 			sql.PassThroughTransform(

--- a/materialize-starburst/sqlgen.go
+++ b/materialize-starburst/sqlgen.go
@@ -100,9 +100,8 @@ var starburstDialect = func(dateMapper sql.MapProjectionFn, dateTimeMapper sql.M
 				}
 			}
 		}),
-		ColumnLocatorer: sql.ColumnLocatorFn(func(field string) string {
-			return strings.ToLower(field)
-		}),
+		SchemaLocatorer: sql.SchemaLocatorFn(func(schema string) string { return strings.ToLower(schema) }),
+		ColumnLocatorer: sql.ColumnLocatorFn(func(field string) string { return strings.ToLower(field) }),
 		Identifierer: sql.IdentifierFn(sql.JoinTransform(".",
 			sql.PassThroughTransform(
 				isSimpleIdentifier,

--- a/materialize-starburst/starburst.go
+++ b/materialize-starburst/starburst.go
@@ -81,6 +81,10 @@ func (c config) Validate() error {
 	return nil
 }
 
+func (c config) DefaultNamespace() string {
+	return ""
+}
+
 func (c config) FeatureFlags() (string, map[string]bool) {
 	return c.Advanced.FeatureFlags, make(map[string]bool)
 }


### PR DESCRIPTION
**Description:**

Create the "default namespace" if it doesn't exist. This default namespace is set in the endpoint configuration, and is intended to apply to bindings that don't otherwise have an explicit namespace set. The concrete example is most SQL materializations, for which there is a top-level default schema to use, but can be overridden per resource.

There is the typical gnarly handling related to determining if a namespace already exists in the destination vs. the user's configured value. These won't always match up exactly, since some systems will do things like changing the capitalization of the create namespace vs. what is input. Sometimes this is even determined dynamically, like in Redshift where we support clusters with case-sensitive identifiers enabled.

The default namespace may not be the namespace for any of the configured bindings if they all have some other explicit namespace. An example of when this is important is for SQL materializations where a checkpoints table must be created in the schema from the endpoint configuration, but that schema may not exist or be otherwise created if all of the bindings have a different one set.

A little bit of extra work was needed for `materialize-bigquery` and `materialize-snowflake` to get this fully operation for those connectors.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/3173)
<!-- Reviewable:end -->
