### PR TITLE
materialize-snowflake: log failed blob metadata if a streaming blob fails to be written

### DIFF
--- a/materialize-snowflake/stream.go
+++ b/materialize-snowflake/stream.go
@@ -270,6 +270,7 @@ func (sm *streamManager) write(ctx context.Context, blobs []*blobMetadata) error
 				}
 
 				if err := sm.c.write(ctx, blob); err != nil {
+					log.WithField("blob", blob).Warn("blob metadata")
 					return fmt.Errorf("failed to write renamed blob: %w", err)
 				}
 				ll.Info("successfully registered renamed blob")


### PR DESCRIPTION
**Description:**

Log failed blob metadata if a streaming blob fails to be written.

We try to rename a blob if it errors on a "malformed request" because that is usually just that the blob is too old and needs a new file name generated, but if it still fails after that we need to know more about the metadata for debugging.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/3175)
<!-- Reviewable:end -->
