### PR TITLE
source-pendo: delay event & event aggregates incremental tasks

### DIFF
--- a/source-pendo/source_pendo/resources.py
+++ b/source-pendo/source_pendo/resources.py
@@ -30,13 +30,9 @@ from .api import (
     snapshot_metadata,
     _dt_to_ms,
     API,
+    API_EVENT_LAG,
 )
 
-# Event data for a given hour isn't available via the API until ~4-6 hours afterwards.
-# This isn't mentioned in Pendo's docs but has been observed empirically. We shift the
-# cutoff between backfills & incremental replication back multiple hours to ensure we're
-# only backfilling date windows where event data should be available in the API.
-API_EVENT_LAG = 12
 
 AUTHORIZATION_HEADER = "x-pendo-integration-key"
 
@@ -138,7 +134,7 @@ def incremental_resources(
         )
 
     backfill_start_ts = _dt_to_ms(datetime.fromisoformat(config.startDate))
-    cutoff = datetime.now(tz=UTC) - timedelta(hours=API_EVENT_LAG) 
+    cutoff = datetime.now(tz=UTC) - API_EVENT_LAG
 
     resources = [
         common.Resource(
@@ -239,7 +235,7 @@ def events(
         )
 
     backfill_start_ts = _dt_to_ms(datetime.fromisoformat(config.startDate))
-    cutoff = datetime.now(tz=UTC) - timedelta(hours=API_EVENT_LAG)
+    cutoff = datetime.now(tz=UTC) - API_EVENT_LAG
 
     events = [
         common.Resource(
@@ -297,7 +293,7 @@ def aggregated_events(
         )
 
     backfill_start_ts = _dt_to_ms(datetime.fromisoformat(config.startDate))
-    cutoff = datetime.now(tz=UTC) - timedelta(hours=API_EVENT_LAG) 
+    cutoff = datetime.now(tz=UTC) - API_EVENT_LAG 
 
     events = [
         common.Resource(


### PR DESCRIPTION
**Description:**

I noted in 6d90c5f that there are delays between when events occur & when they are available via the Pendo API. I previously assumed events appear sequentially & we don't need to be worried about the API being eventually consistent. Well, we've found evidence that the Pendo API is eventually consistent with its events related endpoints and need to handle it.

This PR limits how recent the data the events & event aggregates incremental tasks capture; if data is beyond the eventual consistency horizon defined by `API_EVENTS_LAG`, then it doesn't get returned by the Pendo API & the connector doesn't see or capture it.

I reduced the `API_EVENTS_LAG` from 12 hours to 8 hours as well. 12 hours was too conservative, but it didn't have an ongoing impact since it was only used to shift the cutoff between backfill & incremental tasks. I previously observed events showing up between 4-6 hours late and my most recent investigation aligns with that, so a lag of 8 hours seems sufficient.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

Tested via API calls & on a local stack. Confirmed:
- The Pendo API does not return events / event aggregates beyond `upper_bound` when it's specified.
- The events & event aggregate streams capture the missing data when retreading earlier date ranges.
  - This tells me that the incremental & backfill strategies are fine - the missing data is due to eventual consistency challenges, not that the capturing strategy is flawed.
- The event & event aggregate streams do not capture data more recent than the `horizon`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/3178)
<!-- Reviewable:end -->
