### PR TITLE
source-salesforce-native: add `UserPass` authentication option

### DIFF
--- a/source-salesforce-native/poetry.lock
+++ b/source-salesforce-native/poetry.lock
@@ -1625,6 +1625,116 @@ requests-toolbelt = ">=1.0.0,<2.0.0"
 langsmith-pyo3 = ["langsmith-pyo3 (>=0.1.0rc2,<0.2.0)"]
 
 [[package]]
+name = "lxml"
+version = "6.0.0"
+description = "Powerful and Pythonic XML processing library combining libxml2/libxslt with the ElementTree API."
+optional = false
+python-versions = ">=3.8"
+groups = ["main"]
+files = [
+    {file = "lxml-6.0.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:35bc626eec405f745199200ccb5c6b36f202675d204aa29bb52e27ba2b71dea8"},
+    {file = "lxml-6.0.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:246b40f8a4aec341cbbf52617cad8ab7c888d944bfe12a6abd2b1f6cfb6f6082"},
+    {file = "lxml-6.0.0-cp310-cp310-manylinux2010_i686.manylinux2014_i686.manylinux_2_12_i686.manylinux_2_17_i686.whl", hash = "sha256:2793a627e95d119e9f1e19720730472f5543a6d84c50ea33313ce328d870f2dd"},
+    {file = "lxml-6.0.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:46b9ed911f36bfeb6338e0b482e7fe7c27d362c52fde29f221fddbc9ee2227e7"},
+    {file = "lxml-6.0.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:2b4790b558bee331a933e08883c423f65bbcd07e278f91b2272489e31ab1e2b4"},
+    {file = "lxml-6.0.0-cp310-cp310-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e2030956cf4886b10be9a0285c6802e078ec2391e1dd7ff3eb509c2c95a69b76"},
+    {file = "lxml-6.0.0-cp310-cp310-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4d23854ecf381ab1facc8f353dcd9adeddef3652268ee75297c1164c987c11dc"},
+    {file = "lxml-6.0.0-cp310-cp310-manylinux_2_31_armv7l.whl", hash = "sha256:43fe5af2d590bf4691531b1d9a2495d7aab2090547eaacd224a3afec95706d76"},
+    {file = "lxml-6.0.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:74e748012f8c19b47f7d6321ac929a9a94ee92ef12bc4298c47e8b7219b26541"},
+    {file = "lxml-6.0.0-cp310-cp310-musllinux_1_2_armv7l.whl", hash = "sha256:43cfbb7db02b30ad3926e8fceaef260ba2fb7df787e38fa2df890c1ca7966c3b"},
+    {file = "lxml-6.0.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:34190a1ec4f1e84af256495436b2d196529c3f2094f0af80202947567fdbf2e7"},
+    {file = "lxml-6.0.0-cp310-cp310-win32.whl", hash = "sha256:5967fe415b1920a3877a4195e9a2b779249630ee49ece22021c690320ff07452"},
+    {file = "lxml-6.0.0-cp310-cp310-win_amd64.whl", hash = "sha256:f3389924581d9a770c6caa4df4e74b606180869043b9073e2cec324bad6e306e"},
+    {file = "lxml-6.0.0-cp310-cp310-win_arm64.whl", hash = "sha256:522fe7abb41309e9543b0d9b8b434f2b630c5fdaf6482bee642b34c8c70079c8"},
+    {file = "lxml-6.0.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:4ee56288d0df919e4aac43b539dd0e34bb55d6a12a6562038e8d6f3ed07f9e36"},
+    {file = "lxml-6.0.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:b8dd6dd0e9c1992613ccda2bcb74fc9d49159dbe0f0ca4753f37527749885c25"},
+    {file = "lxml-6.0.0-cp311-cp311-manylinux2010_i686.manylinux2014_i686.manylinux_2_12_i686.manylinux_2_17_i686.whl", hash = "sha256:d7ae472f74afcc47320238b5dbfd363aba111a525943c8a34a1b657c6be934c3"},
+    {file = "lxml-6.0.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:5592401cdf3dc682194727c1ddaa8aa0f3ddc57ca64fd03226a430b955eab6f6"},
+    {file = "lxml-6.0.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:58ffd35bd5425c3c3b9692d078bf7ab851441434531a7e517c4984d5634cd65b"},
+    {file = "lxml-6.0.0-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f720a14aa102a38907c6d5030e3d66b3b680c3e6f6bc95473931ea3c00c59967"},
+    {file = "lxml-6.0.0-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c2a5e8d207311a0170aca0eb6b160af91adc29ec121832e4ac151a57743a1e1e"},
+    {file = "lxml-6.0.0-cp311-cp311-manylinux_2_31_armv7l.whl", hash = "sha256:2dd1cc3ea7e60bfb31ff32cafe07e24839df573a5e7c2d33304082a5019bcd58"},
+    {file = "lxml-6.0.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:2cfcf84f1defed7e5798ef4f88aa25fcc52d279be731ce904789aa7ccfb7e8d2"},
+    {file = "lxml-6.0.0-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:a52a4704811e2623b0324a18d41ad4b9fabf43ce5ff99b14e40a520e2190c851"},
+    {file = "lxml-6.0.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:c16304bba98f48a28ae10e32a8e75c349dd742c45156f297e16eeb1ba9287a1f"},
+    {file = "lxml-6.0.0-cp311-cp311-win32.whl", hash = "sha256:f8d19565ae3eb956d84da3ef367aa7def14a2735d05bd275cd54c0301f0d0d6c"},
+    {file = "lxml-6.0.0-cp311-cp311-win_amd64.whl", hash = "sha256:b2d71cdefda9424adff9a3607ba5bbfc60ee972d73c21c7e3c19e71037574816"},
+    {file = "lxml-6.0.0-cp311-cp311-win_arm64.whl", hash = "sha256:8a2e76efbf8772add72d002d67a4c3d0958638696f541734304c7f28217a9cab"},
+    {file = "lxml-6.0.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:78718d8454a6e928470d511bf8ac93f469283a45c354995f7d19e77292f26108"},
+    {file = "lxml-6.0.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:84ef591495ffd3f9dcabffd6391db7bb70d7230b5c35ef5148354a134f56f2be"},
+    {file = "lxml-6.0.0-cp312-cp312-manylinux2010_i686.manylinux2014_i686.manylinux_2_12_i686.manylinux_2_17_i686.whl", hash = "sha256:2930aa001a3776c3e2601cb8e0a15d21b8270528d89cc308be4843ade546b9ab"},
+    {file = "lxml-6.0.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:219e0431ea8006e15005767f0351e3f7f9143e793e58519dc97fe9e07fae5563"},
+    {file = "lxml-6.0.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:bd5913b4972681ffc9718bc2d4c53cde39ef81415e1671ff93e9aa30b46595e7"},
+    {file = "lxml-6.0.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:390240baeb9f415a82eefc2e13285016f9c8b5ad71ec80574ae8fa9605093cd7"},
+    {file = "lxml-6.0.0-cp312-cp312-manylinux_2_27_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:d6e200909a119626744dd81bae409fc44134389e03fbf1d68ed2a55a2fb10991"},
+    {file = "lxml-6.0.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ca50bd612438258a91b5b3788c6621c1f05c8c478e7951899f492be42defc0da"},
+    {file = "lxml-6.0.0-cp312-cp312-manylinux_2_31_armv7l.whl", hash = "sha256:c24b8efd9c0f62bad0439283c2c795ef916c5a6b75f03c17799775c7ae3c0c9e"},
+    {file = "lxml-6.0.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:afd27d8629ae94c5d863e32ab0e1d5590371d296b87dae0a751fb22bf3685741"},
+    {file = "lxml-6.0.0-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:54c4855eabd9fc29707d30141be99e5cd1102e7d2258d2892314cf4c110726c3"},
+    {file = "lxml-6.0.0-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:c907516d49f77f6cd8ead1322198bdfd902003c3c330c77a1c5f3cc32a0e4d16"},
+    {file = "lxml-6.0.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:36531f81c8214e293097cd2b7873f178997dae33d3667caaae8bdfb9666b76c0"},
+    {file = "lxml-6.0.0-cp312-cp312-win32.whl", hash = "sha256:690b20e3388a7ec98e899fd54c924e50ba6693874aa65ef9cb53de7f7de9d64a"},
+    {file = "lxml-6.0.0-cp312-cp312-win_amd64.whl", hash = "sha256:310b719b695b3dd442cdfbbe64936b2f2e231bb91d998e99e6f0daf991a3eba3"},
+    {file = "lxml-6.0.0-cp312-cp312-win_arm64.whl", hash = "sha256:8cb26f51c82d77483cdcd2b4a53cda55bbee29b3c2f3ddeb47182a2a9064e4eb"},
+    {file = "lxml-6.0.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:6da7cd4f405fd7db56e51e96bff0865b9853ae70df0e6720624049da76bde2da"},
+    {file = "lxml-6.0.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:b34339898bb556a2351a1830f88f751679f343eabf9cf05841c95b165152c9e7"},
+    {file = "lxml-6.0.0-cp313-cp313-manylinux2010_i686.manylinux2014_i686.manylinux_2_12_i686.manylinux_2_17_i686.whl", hash = "sha256:51a5e4c61a4541bd1cd3ba74766d0c9b6c12d6a1a4964ef60026832aac8e79b3"},
+    {file = "lxml-6.0.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d18a25b19ca7307045581b18b3ec9ead2b1db5ccd8719c291f0cd0a5cec6cb81"},
+    {file = "lxml-6.0.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d4f0c66df4386b75d2ab1e20a489f30dc7fd9a06a896d64980541506086be1f1"},
+    {file = "lxml-6.0.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9f4b481b6cc3a897adb4279216695150bbe7a44c03daba3c894f49d2037e0a24"},
+    {file = "lxml-6.0.0-cp313-cp313-manylinux_2_27_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:8a78d6c9168f5bcb20971bf3329c2b83078611fbe1f807baadc64afc70523b3a"},
+    {file = "lxml-6.0.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2ae06fbab4f1bb7db4f7c8ca9897dc8db4447d1a2b9bee78474ad403437bcc29"},
+    {file = "lxml-6.0.0-cp313-cp313-manylinux_2_31_armv7l.whl", hash = "sha256:1fa377b827ca2023244a06554c6e7dc6828a10aaf74ca41965c5d8a4925aebb4"},
+    {file = "lxml-6.0.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:1676b56d48048a62ef77a250428d1f31f610763636e0784ba67a9740823988ca"},
+    {file = "lxml-6.0.0-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:0e32698462aacc5c1cf6bdfebc9c781821b7e74c79f13e5ffc8bfe27c42b1abf"},
+    {file = "lxml-6.0.0-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:4d6036c3a296707357efb375cfc24bb64cd955b9ec731abf11ebb1e40063949f"},
+    {file = "lxml-6.0.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:7488a43033c958637b1a08cddc9188eb06d3ad36582cebc7d4815980b47e27ef"},
+    {file = "lxml-6.0.0-cp313-cp313-win32.whl", hash = "sha256:5fcd7d3b1d8ecb91445bd71b9c88bdbeae528fefee4f379895becfc72298d181"},
+    {file = "lxml-6.0.0-cp313-cp313-win_amd64.whl", hash = "sha256:2f34687222b78fff795feeb799a7d44eca2477c3d9d3a46ce17d51a4f383e32e"},
+    {file = "lxml-6.0.0-cp313-cp313-win_arm64.whl", hash = "sha256:21db1ec5525780fd07251636eb5f7acb84003e9382c72c18c542a87c416ade03"},
+    {file = "lxml-6.0.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:4eb114a0754fd00075c12648d991ec7a4357f9cb873042cc9a77bf3a7e30c9db"},
+    {file = "lxml-6.0.0-cp38-cp38-manylinux2010_i686.manylinux2014_i686.manylinux_2_12_i686.manylinux_2_17_i686.whl", hash = "sha256:7da298e1659e45d151b4028ad5c7974917e108afb48731f4ed785d02b6818994"},
+    {file = "lxml-6.0.0-cp38-cp38-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7bf61bc4345c1895221357af8f3e89f8c103d93156ef326532d35c707e2fb19d"},
+    {file = "lxml-6.0.0-cp38-cp38-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:63b634facdfbad421d4b61c90735688465d4ab3a8853ac22c76ccac2baf98d97"},
+    {file = "lxml-6.0.0-cp38-cp38-musllinux_1_2_x86_64.whl", hash = "sha256:e380e85b93f148ad28ac15f8117e2fd8e5437aa7732d65e260134f83ce67911b"},
+    {file = "lxml-6.0.0-cp38-cp38-win32.whl", hash = "sha256:185efc2fed89cdd97552585c624d3c908f0464090f4b91f7d92f8ed2f3b18f54"},
+    {file = "lxml-6.0.0-cp38-cp38-win_amd64.whl", hash = "sha256:f97487996a39cb18278ca33f7be98198f278d0bc3c5d0fd4d7b3d63646ca3c8a"},
+    {file = "lxml-6.0.0-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:85b14a4689d5cff426c12eefe750738648706ea2753b20c2f973b2a000d3d261"},
+    {file = "lxml-6.0.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:f64ccf593916e93b8d36ed55401bb7fe9c7d5de3180ce2e10b08f82a8f397316"},
+    {file = "lxml-6.0.0-cp39-cp39-manylinux2010_i686.manylinux2014_i686.manylinux_2_12_i686.manylinux_2_17_i686.whl", hash = "sha256:b372d10d17a701b0945f67be58fae4664fd056b85e0ff0fbc1e6c951cdbc0512"},
+    {file = "lxml-6.0.0-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:a674c0948789e9136d69065cc28009c1b1874c6ea340253db58be7622ce6398f"},
+    {file = "lxml-6.0.0-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:edf6e4c8fe14dfe316939711e3ece3f9a20760aabf686051b537a7562f4da91a"},
+    {file = "lxml-6.0.0-cp39-cp39-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:048a930eb4572829604982e39a0c7289ab5dc8abc7fc9f5aabd6fbc08c154e93"},
+    {file = "lxml-6.0.0-cp39-cp39-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c0b5fa5eda84057a4f1bbb4bb77a8c28ff20ae7ce211588d698ae453e13c6281"},
+    {file = "lxml-6.0.0-cp39-cp39-manylinux_2_31_armv7l.whl", hash = "sha256:c352fc8f36f7e9727db17adbf93f82499457b3d7e5511368569b4c5bd155a922"},
+    {file = "lxml-6.0.0-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:8db5dc617cb937ae17ff3403c3a70a7de9df4852a046f93e71edaec678f721d0"},
+    {file = "lxml-6.0.0-cp39-cp39-musllinux_1_2_armv7l.whl", hash = "sha256:2181e4b1d07dde53986023482673c0f1fba5178ef800f9ab95ad791e8bdded6a"},
+    {file = "lxml-6.0.0-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:b3c98d5b24c6095e89e03d65d5c574705be3d49c0d8ca10c17a8a4b5201b72f5"},
+    {file = "lxml-6.0.0-cp39-cp39-win32.whl", hash = "sha256:04d67ceee6db4bcb92987ccb16e53bef6b42ced872509f333c04fb58a3315256"},
+    {file = "lxml-6.0.0-cp39-cp39-win_amd64.whl", hash = "sha256:e0b1520ef900e9ef62e392dd3d7ae4f5fa224d1dd62897a792cf353eb20b6cae"},
+    {file = "lxml-6.0.0-cp39-cp39-win_arm64.whl", hash = "sha256:e35e8aaaf3981489f42884b59726693de32dabfc438ac10ef4eb3409961fd402"},
+    {file = "lxml-6.0.0-pp310-pypy310_pp73-macosx_10_15_x86_64.whl", hash = "sha256:dbdd7679a6f4f08152818043dbb39491d1af3332128b3752c3ec5cebc0011a72"},
+    {file = "lxml-6.0.0-pp310-pypy310_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:40442e2a4456e9910875ac12951476d36c0870dcb38a68719f8c4686609897c4"},
+    {file = "lxml-6.0.0-pp310-pypy310_pp73-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:db0efd6bae1c4730b9c863fc4f5f3c0fa3e8f05cae2c44ae141cb9dfc7d091dc"},
+    {file = "lxml-6.0.0-pp310-pypy310_pp73-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9ab542c91f5a47aaa58abdd8ea84b498e8e49fe4b883d67800017757a3eb78e8"},
+    {file = "lxml-6.0.0-pp310-pypy310_pp73-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:013090383863b72c62a702d07678b658fa2567aa58d373d963cca245b017e065"},
+    {file = "lxml-6.0.0-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:c86df1c9af35d903d2b52d22ea3e66db8058d21dc0f59842ca5deb0595921141"},
+    {file = "lxml-6.0.0-pp39-pypy39_pp73-macosx_10_15_x86_64.whl", hash = "sha256:4337e4aec93b7c011f7ee2e357b0d30562edd1955620fdd4aeab6aacd90d43c5"},
+    {file = "lxml-6.0.0-pp39-pypy39_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ae74f7c762270196d2dda56f8dd7309411f08a4084ff2dfcc0b095a218df2e06"},
+    {file = "lxml-6.0.0-pp39-pypy39_pp73-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:059c4cbf3973a621b62ea3132934ae737da2c132a788e6cfb9b08d63a0ef73f9"},
+    {file = "lxml-6.0.0-pp39-pypy39_pp73-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:17f090a9bc0ce8da51a5632092f98a7e7f84bca26f33d161a98b57f7fb0004ca"},
+    {file = "lxml-6.0.0-pp39-pypy39_pp73-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9da022c14baeec36edfcc8daf0e281e2f55b950249a455776f0d1adeeada4734"},
+    {file = "lxml-6.0.0-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:a55da151d0b0c6ab176b4e761670ac0e2667817a1e0dadd04a01d0561a219349"},
+    {file = "lxml-6.0.0.tar.gz", hash = "sha256:032e65120339d44cdc3efc326c9f660f5f7205f3a535c1fdbf898b29ea01fb72"},
+]
+
+[package.extras]
+cssselect = ["cssselect (>=0.7)"]
+html-clean = ["lxml_html_clean"]
+html5 = ["html5lib"]
+htmlsoup = ["BeautifulSoup4"]
+
+[[package]]
 name = "markdown-it-py"
 version = "3.0.0"
 description = "Python port of markdown-it. Markdown parsing, done right!"
@@ -1732,6 +1842,18 @@ markers = "python_full_version < \"3.12.4\""
 files = [
     {file = "mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8"},
     {file = "mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba"},
+]
+
+[[package]]
+name = "more-itertools"
+version = "10.7.0"
+description = "More routines for operating on iterables, beyond itertools"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "more_itertools-10.7.0-py3-none-any.whl", hash = "sha256:d43980384673cb07d2f7d2d918c616b30c659c089ee23953f601d6609c67510e"},
+    {file = "more_itertools-10.7.0.tar.gz", hash = "sha256:9fddd5403be01a94b204faadcff459ec3568cf110265d3c54323e1e866ad29d3"},
 ]
 
 [[package]]
@@ -2836,6 +2958,9 @@ files = [
     {file = "pyjwt-2.10.1.tar.gz", hash = "sha256:3cc5772eb20009233caf06e9d8a0577824723b44e6648ee0a2aedb6cf9381953"},
 ]
 
+[package.dependencies]
+cryptography = {version = ">=3.4.0", optional = true, markers = "extra == \"crypto\""}
+
 [package.extras]
 crypto = ["cryptography (>=3.4.0)"]
 dev = ["coverage[toml] (==5.0.4)", "cryptography (>=3.4.0)", "pre-commit", "pytest (>=6.0.0,<7.0.0)", "sphinx", "sphinx-rtd-theme", "zope.interface"]
@@ -3336,6 +3461,21 @@ security = ["itsdangerous (>=2.0)"]
 yaml = ["pyyaml (>=6.0.1)"]
 
 [[package]]
+name = "requests-file"
+version = "2.1.0"
+description = "File transport adapter for Requests"
+optional = false
+python-versions = "*"
+groups = ["main"]
+files = [
+    {file = "requests_file-2.1.0-py2.py3-none-any.whl", hash = "sha256:cf270de5a4c5874e84599fc5778303d496c10ae5e870bfa378818f35d21bda5c"},
+    {file = "requests_file-2.1.0.tar.gz", hash = "sha256:0f549a3f3b0699415ac04d167e9cb39bccfb730cb832b4d20be3d9867356e658"},
+]
+
+[package.dependencies]
+requests = ">=1.0.0"
+
+[[package]]
 name = "requests-toolbelt"
 version = "1.0.0"
 description = "A utility belt for advanced users of python-requests"
@@ -3483,6 +3623,25 @@ doc = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "pygments-
 enabler = ["pytest-enabler (>=2.2)"]
 test = ["build[virtualenv] (>=1.0.3)", "filelock (>=3.4.0)", "ini2toml[lite] (>=0.14)", "jaraco.develop (>=7.21) ; python_version >= \"3.9\" and sys_platform != \"cygwin\"", "jaraco.envs (>=2.2)", "jaraco.path (>=3.7.2)", "jaraco.test (>=5.5)", "packaging (>=24.2)", "pip (>=19.1)", "pyproject-hooks (!=1.1)", "pytest (>=6,!=8.1.*)", "pytest-home (>=0.5)", "pytest-perf ; sys_platform != \"cygwin\"", "pytest-subprocess", "pytest-timeout", "pytest-xdist (>=3)", "tomli-w (>=1.0.0)", "virtualenv (>=13.0.0)", "wheel (>=0.44.0)"]
 type = ["importlib_metadata (>=7.0.2) ; python_version < \"3.10\"", "jaraco.develop (>=7.21) ; sys_platform != \"cygwin\"", "mypy (==1.14.*)", "pytest-mypy"]
+
+[[package]]
+name = "simple-salesforce"
+version = "1.12.6"
+description = "A basic Salesforce.com REST API client."
+optional = false
+python-versions = "*"
+groups = ["main"]
+files = [
+    {file = "simple-salesforce-1.12.6.tar.gz", hash = "sha256:77590606c781905f6b75430562951dd2b062438da7f55fca2b61e4cde31df15b"},
+    {file = "simple_salesforce-1.12.6-py2.py3-none-any.whl", hash = "sha256:66c74bee88d09ace46e4fc9c2f6b47c0d012817a764f70a5455d6dc2c7ed635c"},
+]
+
+[package.dependencies]
+more-itertools = "*"
+pyjwt = {version = "*", extras = ["crypto"]}
+requests = ">=2.22.0"
+typing-extensions = "*"
+zeep = "*"
 
 [[package]]
 name = "six"
@@ -4222,7 +4381,35 @@ idna = ">=2.0"
 multidict = ">=4.0"
 propcache = ">=0.2.1"
 
+[[package]]
+name = "zeep"
+version = "4.3.1"
+description = "A Python SOAP client"
+optional = false
+python-versions = ">=3.8"
+groups = ["main"]
+files = [
+    {file = "zeep-4.3.1-py3-none-any.whl", hash = "sha256:a637aa7eedb6330bb27e8c94c5233ddf23553904323adf9398f8cf5025acb216"},
+    {file = "zeep-4.3.1.tar.gz", hash = "sha256:f45385e9e1b09d5550e0f51ab9fa7c6842713cab7194139372fd82a99c56a06e"},
+]
+
+[package.dependencies]
+attrs = ">=17.2.0"
+isodate = ">=0.5.4"
+lxml = ">=4.6.0"
+platformdirs = ">=1.4.0"
+pytz = "*"
+requests = ">=2.7.0"
+requests-file = ">=1.5.1"
+requests-toolbelt = ">=0.7.1"
+
+[package.extras]
+async = ["httpx (>=0.15.0)"]
+docs = ["sphinx (>=1.4.0)"]
+test = ["coverage[toml] (==7.6.2)", "flake8 (==7.1.1)", "flake8-blind-except (==0.2.1)", "flake8-debugger (==4.1.2)", "flake8-imports (==0.1.1)", "freezegun (==1.5.1)", "isort (==5.13.2)", "pretend (==1.0.9)", "pytest (==8.3.3)", "pytest-asyncio", "pytest-cov (==5.0.0)", "pytest-httpx", "requests-mock (==1.12.1)"]
+xmlsec = ["xmlsec (>=0.6.1)"]
+
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.11"
-content-hash = "1a58ba623bc001fc4a5888923738cf03020f2c4af81b375e02104841bf2ae1eb"
+content-hash = "a6a98abb7d5e1956a7d5dc82f15abd1e3c911bc3dde3644a18c5e3cebf53f8ee"

--- a/source-salesforce-native/pyproject.toml
+++ b/source-salesforce-native/pyproject.toml
@@ -9,6 +9,7 @@ estuary-cdk = {path="../estuary-cdk", develop = true}
 pydantic = "^2"
 python = "^3.11"
 aiohttp = "^3.11.15"
+simple-salesforce = "^1.12.6"
 
 [tool.poetry.group.dev.dependencies]
 debugpy = "^1.8.0"

--- a/source-salesforce-native/source_salesforce_native/__init__.py
+++ b/source-salesforce-native/source_salesforce_native/__init__.py
@@ -17,9 +17,9 @@ from .resources import all_resources, enabled_resources
 from .models import (
     ConnectorState,
     EndpointConfig,
-    OAUTH2_SPEC,
     SalesforceResourceConfigWithSchedule,
 )
+from .auth import OAUTH2_SPEC
 
 
 class Connector(

--- a/source-salesforce-native/source_salesforce_native/auth.py
+++ b/source-salesforce-native/source_salesforce_native/auth.py
@@ -1,7 +1,10 @@
-
-from typing import TYPE_CHECKING
+import dataclasses
+from logging import Logger
+import time
+from typing import Literal, TYPE_CHECKING
 
 from pydantic import (
+    BaseModel,
     Field,
 )
 from estuary_cdk.capture.common import (
@@ -9,9 +12,13 @@ from estuary_cdk.capture.common import (
     OAuth2Spec,
 )
 from estuary_cdk.http import (
+    HTTPSession,
     TokenSource,
 )
+from simple_salesforce.login import SalesforceLogin
 
+
+from .shared import VERSION
 
 
 OAUTH2_SPEC = OAuth2Spec(
@@ -47,6 +54,39 @@ OAUTH2_SPEC = OAuth2Spec(
 # Mustache templates in accessTokenUrlTemplate are not interpolated within the connector, so update_oauth_spec reassigns it for use within the connector.
 def update_oauth_spec(is_sandbox: bool):
     OAUTH2_SPEC.accessTokenUrlTemplate = f"https://{'test' if is_sandbox else 'login'}.salesforce.com/services/oauth2/token"
+
+
+class UserPass(BaseModel):
+    credentials_title: Literal["Username, Password, & Security Token"] = Field(
+        default="Username, Password, & Security Token",
+        json_schema_extra={"type": "string", "order": 0},
+    )
+    username: str = Field(
+        title="Username",
+        json_schema_extra={"order": 1},
+    )
+    password: str = Field(
+        title="Password",
+        json_schema_extra={"secret": True, "order": 2},
+    )
+    security_token: str = Field(
+        title="Security Token",
+        json_schema_extra={"secret": True, "order": 3},
+    )
+
+    def fetch_access_token_and_instance_url(self, is_sandbox: bool) -> tuple[str, str]:
+        access_token, instance_url = SalesforceLogin(
+            username=self.username,
+            password=self.password,
+            security_token=self.security_token,
+            domain="test" if is_sandbox else "login",
+            sf_version=VERSION,
+        )
+
+        if not instance_url.startswith("https://"):
+            instance_url = "https://" + instance_url
+
+        return (access_token, instance_url)
 
 
 class SalesforceOAuth2Credentials(BaseOAuth2Credentials):
@@ -85,6 +125,35 @@ else:
 # to be 2 hours. More importantly, each time the access token is used, it's validity is extended. Meaning that as long
 # as the access token is actively used, it shouldn't expire. Setting an expires_in of 1 hour should be a 
 # safe fallback in case a user changes all enabled bindings' intervals to an hour or greater.
+@dataclasses.dataclass
 class SalesforceTokenSource(TokenSource):
     class AccessTokenResponse(TokenSource.AccessTokenResponse):
         expires_in: int = 1 * 60 * 60
+
+    # These fields must be keyword-only because the parent TokenSource class has fields with default values.
+    # In Python dataclasses, you cannot define fields without defaults after fields with defaults
+    # unless the new fields are marked as keyword-only using dataclasses.field(kw_only=True).
+    credentials: UserPass | OAuth2Credentials = dataclasses.field(kw_only=True)
+    is_sandbox: bool = dataclasses.field(kw_only=True)
+
+    async def fetch_token(self, log: Logger, session: HTTPSession) -> tuple[str, str]:
+        if isinstance(self.credentials, UserPass):
+            current_time = time.time()
+
+            if self._access_token is not None:
+                assert isinstance(self._access_token, self.AccessTokenResponse)
+
+                horizon = self._fetched_at + self._access_token.expires_in * 0.75
+
+                if current_time < horizon:
+                    return (self.authorization_token_type, self._access_token.access_token)
+
+            self._fetched_at = int(current_time)
+            access_token, _ = self.credentials.fetch_access_token_and_instance_url(is_sandbox=self.is_sandbox)
+            self._access_token = SalesforceTokenSource.AccessTokenResponse(
+                access_token=access_token,
+                token_type=self.authorization_token_type,
+            )
+            return (self.authorization_token_type, self._access_token.access_token)
+        else:
+            return await super().fetch_token(log, session)

--- a/source-salesforce-native/source_salesforce_native/auth.py
+++ b/source-salesforce-native/source_salesforce_native/auth.py
@@ -1,0 +1,90 @@
+
+from typing import TYPE_CHECKING
+
+from pydantic import (
+    Field,
+)
+from estuary_cdk.capture.common import (
+    BaseOAuth2Credentials,
+    OAuth2Spec,
+)
+from estuary_cdk.http import (
+    TokenSource,
+)
+
+
+
+OAUTH2_SPEC = OAuth2Spec(
+    provider="salesforce",
+    authUrlTemplate=(
+        "https://"
+        r"{{#config.is_sandbox}}test{{/config.is_sandbox}}{{^config.is_sandbox}}login{{/config.is_sandbox}}"
+        ".salesforce.com/services/oauth2/authorize?"
+        r"client_id={{#urlencode}}{{{ client_id }}}{{/urlencode}}"
+        r"&redirect_uri={{#urlencode}}{{{ redirect_uri }}}{{/urlencode}}"
+        r"&response_type=code"
+        r"&state={{#urlencode}}{{{ state }}}{{/urlencode}}"
+    ),
+    accessTokenUrlTemplate=(
+        "https://"
+        r"{{#config.is_sandbox}}test{{/config.is_sandbox}}{{^config.is_sandbox}}login{{/config.is_sandbox}}"
+        ".salesforce.com/services/oauth2/token"
+    ),
+    accessTokenHeaders={"content-type": "application/x-www-form-urlencoded"},
+    accessTokenBody=(
+        "grant_type=authorization_code"
+        r"&client_id={{#urlencode}}{{{ client_id }}}{{/urlencode}}"
+        r"&client_secret={{#urlencode}}{{{ client_secret }}}{{/urlencode}}"
+        r"&redirect_uri={{#urlencode}}{{{ redirect_uri }}}{{/urlencode}}"
+        r"&code={{#urlencode}}{{{ code }}}{{/urlencode}}"
+    ),
+    accessTokenResponseMap={
+        "refresh_token": "/refresh_token",
+        "instance_url": "/instance_url",
+    },
+)
+
+# Mustache templates in accessTokenUrlTemplate are not interpolated within the connector, so update_oauth_spec reassigns it for use within the connector.
+def update_oauth_spec(is_sandbox: bool):
+    OAUTH2_SPEC.accessTokenUrlTemplate = f"https://{'test' if is_sandbox else 'login'}.salesforce.com/services/oauth2/token"
+
+
+class SalesforceOAuth2Credentials(BaseOAuth2Credentials):
+    instance_url: str = Field(
+        title="Instance URL",
+    )
+
+    @staticmethod
+    def for_provider(provider: str) -> type["SalesforceOAuth2Credentials"]:
+        """
+        Builds an OAuth2Credentials model for the given OAuth2 `provider`.
+        This routine is only available in Pydantic V2 environments.
+        """
+        from pydantic import ConfigDict
+
+        class _OAuth2Credentials(SalesforceOAuth2Credentials):
+            model_config = ConfigDict(
+                json_schema_extra={"x-oauth2-provider": provider},
+                title="OAuth",
+            )
+
+            def _you_must_build_oauth2_credentials_for_a_provider(self): ...
+
+        return _OAuth2Credentials
+
+
+if TYPE_CHECKING:
+    OAuth2Credentials = SalesforceOAuth2Credentials
+else:
+    OAuth2Credentials = SalesforceOAuth2Credentials.for_provider(OAUTH2_SPEC.provider)
+
+
+# The access token response does not contain any field indicating if/when the access token we receive expires.
+# The default TokenSource.AccessTokenResponse.expires_in is 0, causing every request to fetch a new access token.
+# The actual expires_in value depends on the session settings in the user's Salesforce account. The default seems
+# to be 2 hours. More importantly, each time the access token is used, it's validity is extended. Meaning that as long
+# as the access token is actively used, it shouldn't expire. Setting an expires_in of 1 hour should be a 
+# safe fallback in case a user changes all enabled bindings' intervals to an hour or greater.
+class SalesforceTokenSource(TokenSource):
+    class AccessTokenResponse(TokenSource.AccessTokenResponse):
+        expires_in: int = 1 * 60 * 60

--- a/source-salesforce-native/source_salesforce_native/models.py
+++ b/source-salesforce-native/source_salesforce_native/models.py
@@ -1,6 +1,6 @@
 from datetime import datetime, UTC
 from enum import StrEnum
-from typing import Any, TYPE_CHECKING, Iterator, Annotated, ClassVar
+from typing import Any, Iterator, Annotated, ClassVar
 
 from pydantic import (
     AwareDatetime,
@@ -12,8 +12,6 @@ from pydantic import (
 )
 from estuary_cdk.capture.common import (
     BaseDocument,
-    BaseOAuth2Credentials,
-    OAuth2Spec,
     ResourceConfigWithSchedule,
     CRON_REGEX,
     ResourceState,
@@ -21,10 +19,8 @@ from estuary_cdk.capture.common import (
 from estuary_cdk.capture.common import (
     ConnectorState as GenericConnectorState,
 )
-from estuary_cdk.http import (
-    TokenSource,
-)
 
+from .auth import OAuth2Credentials
 from .shared import dt_to_str, str_to_dt
 
 
@@ -32,82 +28,6 @@ EARLIEST_VALID_DATE_IN_SALESFORCE = datetime(1700, 1, 1, tzinfo=UTC)
 # Salesforce was founded on 03FEB1999. As long as cursor values aren't backdated before this date (which only seems possible
 # for a select few of them), Salesforce's founding date should be a good start date for most users.
 SALESFORCE_FOUNDING_DATE = datetime(1999, 2, 3, tzinfo=UTC)
-
-
-OAUTH2_SPEC = OAuth2Spec(
-    provider="salesforce",
-    authUrlTemplate=(
-        "https://"
-        r"{{#config.is_sandbox}}test{{/config.is_sandbox}}{{^config.is_sandbox}}login{{/config.is_sandbox}}"
-        ".salesforce.com/services/oauth2/authorize?"
-        r"client_id={{#urlencode}}{{{ client_id }}}{{/urlencode}}"
-        r"&redirect_uri={{#urlencode}}{{{ redirect_uri }}}{{/urlencode}}"
-        r"&response_type=code"
-        r"&state={{#urlencode}}{{{ state }}}{{/urlencode}}"
-    ),
-    accessTokenUrlTemplate=(
-        "https://"
-        r"{{#config.is_sandbox}}test{{/config.is_sandbox}}{{^config.is_sandbox}}login{{/config.is_sandbox}}"
-        ".salesforce.com/services/oauth2/token"
-    ),
-    accessTokenHeaders={"content-type": "application/x-www-form-urlencoded"},
-    accessTokenBody=(
-        "grant_type=authorization_code"
-        r"&client_id={{#urlencode}}{{{ client_id }}}{{/urlencode}}"
-        r"&client_secret={{#urlencode}}{{{ client_secret }}}{{/urlencode}}"
-        r"&redirect_uri={{#urlencode}}{{{ redirect_uri }}}{{/urlencode}}"
-        r"&code={{#urlencode}}{{{ code }}}{{/urlencode}}"
-    ),
-    accessTokenResponseMap={
-        "refresh_token": "/refresh_token",
-        "instance_url": "/instance_url",
-    },
-)
-
-# Mustache templates in accessTokenUrlTemplate are not interpolated within the connector, so update_oauth_spec reassigns it for use within the connector.
-def update_oauth_spec(is_sandbox: bool):
-    OAUTH2_SPEC.accessTokenUrlTemplate = f"https://{'test' if is_sandbox else 'login'}.salesforce.com/services/oauth2/token"
-
-
-# The access token response does not contain any field indicating if/when the access token we receive expires.
-# The default TokenSource.AccessTokenResponse.expires_in is 0, causing every request to fetch a new access token.
-# The actual expires_in value depends on the session settings in the user's Salesforce account. The default seems
-# to be 2 hours. More importantly, each time the access token is used, it's validity is extended. Meaning that as long
-# as the access token is actively used, it shouldn't expire. Setting an expires_in of 1 hour should be a 
-# safe fallback in case a user changes all enabled bindings' intervals to an hour or greater.
-class SalesforceTokenSource(TokenSource):
-    class AccessTokenResponse(TokenSource.AccessTokenResponse):
-        expires_in: int = 1 * 60 * 60
-
-
-class SalesforceOAuth2Credentials(BaseOAuth2Credentials):
-    instance_url: str = Field(
-        title="Instance URL",
-    )
-
-    @staticmethod
-    def for_provider(provider: str) -> type["SalesforceOAuth2Credentials"]:
-        """
-        Builds an OAuth2Credentials model for the given OAuth2 `provider`.
-        This routine is only available in Pydantic V2 environments.
-        """
-        from pydantic import ConfigDict
-
-        class _OAuth2Credentials(SalesforceOAuth2Credentials):
-            model_config = ConfigDict(
-                json_schema_extra={"x-oauth2-provider": provider},
-                title="OAuth",
-            )
-
-            def _you_must_build_oauth2_credentials_for_a_provider(self): ...
-
-        return _OAuth2Credentials
-
-
-if TYPE_CHECKING:
-    OAuth2Credentials = SalesforceOAuth2Credentials
-else:
-    OAuth2Credentials = SalesforceOAuth2Credentials.for_provider(OAUTH2_SPEC.provider)
 
 
 class SalesforceResourceConfigWithSchedule(ResourceConfigWithSchedule):

--- a/source-salesforce-native/source_salesforce_native/models.py
+++ b/source-salesforce-native/source_salesforce_native/models.py
@@ -20,7 +20,7 @@ from estuary_cdk.capture.common import (
     ConnectorState as GenericConnectorState,
 )
 
-from .auth import OAuth2Credentials
+from .auth import OAuth2Credentials, UserPass
 from .shared import dt_to_str, str_to_dt
 
 
@@ -54,7 +54,7 @@ class EndpointConfig(BaseModel):
         description="Toggle if you're using a Salesforce Sandbox.",
         default=False,
     )
-    credentials: OAuth2Credentials = Field(
+    credentials: OAuth2Credentials | UserPass = Field(
         discriminator="credentials_title",
         title="Authentication",
     )

--- a/source-salesforce-native/source_salesforce_native/resources.py
+++ b/source-salesforce-native/source_salesforce_native/resources.py
@@ -24,15 +24,12 @@ from .models import (
     SalesforceResourceConfigWithSchedule,
     ResourceState,
     ConnectorState,
-    SalesforceTokenSource,
     GlobalDescribeObjectsResponse,
     SOAP_TYPES_NOT_SUPPORTED_BY_BULK_API,
     FieldDetailsDict,
     SObject,
-    OAUTH2_SPEC,
     FullRefreshResource,
     SalesforceResource,
-    update_oauth_spec,
     create_salesforce_model,
 )
 from .api import (
@@ -40,7 +37,11 @@ from .api import (
     backfill_incremental_resources,
     fetch_incremental_resources,
 )
-
+from .auth import (
+    SalesforceTokenSource,
+    OAUTH2_SPEC,
+    update_oauth_spec,
+)
 
 CUSTOM_OBJECT_SUFFIX = '__c'
 CUSTOM_OBJECT_FEED_SUFFIX = '__Feed'

--- a/source-salesforce-native/tests/snapshots/snapshots__spec__capture.stdout.json
+++ b/source-salesforce-native/tests/snapshots/snapshots__spec__capture.stdout.json
@@ -16,6 +16,41 @@
           "title": "Advanced",
           "type": "object"
         },
+        "UserPass": {
+          "properties": {
+            "credentials_title": {
+              "const": "Username, Password, & Security Token",
+              "default": "Username, Password, & Security Token",
+              "order": 0,
+              "title": "Credentials Title",
+              "type": "string"
+            },
+            "username": {
+              "order": 1,
+              "title": "Username",
+              "type": "string"
+            },
+            "password": {
+              "order": 2,
+              "secret": true,
+              "title": "Password",
+              "type": "string"
+            },
+            "security_token": {
+              "order": 3,
+              "secret": true,
+              "title": "Security Token",
+              "type": "string"
+            }
+          },
+          "required": [
+            "username",
+            "password",
+            "security_token"
+          ],
+          "title": "UserPass",
+          "type": "object"
+        },
         "_OAuth2Credentials": {
           "properties": {
             "credentials_title": {
@@ -71,13 +106,17 @@
         "credentials": {
           "discriminator": {
             "mapping": {
-              "OAuth Credentials": "#/$defs/_OAuth2Credentials"
+              "OAuth Credentials": "#/$defs/_OAuth2Credentials",
+              "Username, Password, & Security Token": "#/$defs/UserPass"
             },
             "propertyName": "credentials_title"
           },
           "oneOf": [
             {
               "$ref": "#/$defs/_OAuth2Credentials"
+            },
+            {
+              "$ref": "#/$defs/UserPass"
             }
           ],
           "title": "Authentication"


### PR DESCRIPTION
**Description:**

Some users are unable to authenticate with OAuth to their production Salesforce instance. One such case is when their Salesforce uses Okta SSO. Users have requested an option to authenticate with a service account (non-SSO) with username, password, and security token as an alternative to OAuth.

By using the [SOAP `login()` call](https://developer.salesforce.com/docs/atlas.en-us.api.meta/api/sforce_api_calls_login.htm) to retrieve an access token and the instance domain, we can support authentication via username, password, and security token. Instead of making SOAP calls ourselves, the `simple-salesforce` package has a handy `SalesforceLogin` function that handles this for us.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

Connector documentation should be updated to include the new authentication option.

**Notes for reviewers:**

I recommend reviewing commit-by-commit. I re-organized the authentication related code into `auth.py` in the first commit. The actual functional changes are in the second commit.

Tested on a local stack. Confirmed:
- The connector captures data when using `UserPass` credentials.
- If the access token is close to expiring, a new one is fetched.
- The connector still works with OAuth credentials.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/3180)
<!-- Reviewable:end -->
