### PR TITLE
materialize-snowflake: increase document sizes with default SerPolicy

### DIFF
--- a/materialize-snowflake/bdec_test.go
+++ b/materialize-snowflake/bdec_test.go
@@ -42,7 +42,7 @@ func TestBdecWriter(t *testing.T) {
 	key, err := deriveKey(encryptionKey, fileName)
 	require.NoError(t, err)
 
-	w, err := newBdecWriter(tmpFile, mappedColumns, existingColumns, encryptionKey, fileName, false)
+	w, err := newBdecWriter(tmpFile, mappedColumns, existingColumns, encryptionKey, fileName)
 	require.NoError(t, err)
 
 	require.NoError(t, w.writeRow([]any{"hello1", "world1"}))

--- a/materialize-snowflake/snowflake.go
+++ b/materialize-snowflake/snowflake.go
@@ -226,30 +226,10 @@ func newTransactor(
 	var sm *streamManager
 	var pipeClient *PipeClient
 	if cfg.Credentials.AuthType == snowflake_auth.JWT {
-		// TODO(whb): Behavior change bundle 2025_03 allows for very large
-		// VARIANT columns. If that is enabled we don't need to enforce the
-		// maximum size limit for them. As of July 2025 it is enabled by
-		// default, so unless it is explicitly disabled it will be on
-		// everywhere. In August 2025 it is slated to be released, at which
-		// point there will be no way for it to ever be disabled and we can
-		// remove this check entirely and just never enforce a size limit on
-		// VARIANT columns.
-		enforceVariantMaxLength := true
-		var bcb2025_03 string
-		if err := db.QueryRow("SELECT SYSTEM$BEHAVIOR_CHANGE_BUNDLE_STATUS('2025_03')").Scan(&bcb2025_03); err != nil {
-			return nil, fmt.Errorf("fetching behavior change bundle 2025_03 status: %w", err)
-		}
-		if strings.EqualFold(bcb2025_03, "ENABLED") || strings.EqualFold(bcb2025_03, "RELEASED") {
-			enforceVariantMaxLength = false
-		}
-		if !enforceVariantMaxLength {
-			log.WithField("BEHAVIOR_CHANGE_BUNDLE_STATUS('2025_03')", bcb2025_03).Info("not enforcing maximum length for VARIANT columns when using Snowpipe streaming")
-		}
-
 		var accountName string
 		if err := db.QueryRowContext(ctx, "SELECT CURRENT_ACCOUNT()").Scan(&accountName); err != nil {
 			return nil, fmt.Errorf("fetching current account name: %w", err)
-		} else if sm, err = newStreamManager(&cfg, open.Materialization.TaskName(), ep.Tenant, accountName, open.Range.KeyBegin, enforceVariantMaxLength); err != nil {
+		} else if sm, err = newStreamManager(&cfg, open.Materialization.TaskName(), ep.Tenant, accountName, open.Range.KeyBegin); err != nil {
 			return nil, fmt.Errorf("newStreamManager: %w", err)
 		} else if pipeClient, err = NewPipeClient(&cfg, accountName, ep.Tenant); err != nil {
 			return nil, fmt.Errorf("NewPipeClient: %w", err)

--- a/materialize-snowflake/stream.go
+++ b/materialize-snowflake/stream.go
@@ -36,12 +36,11 @@ type tableStream struct {
 // which mostly entails writing rows of data for bindings and registering the
 // resulting blobs to tables.
 type streamManager struct {
-	c                       *streamClient
-	tableStreams            map[int]*tableStream
-	tenant                  string // used for the `ingestclientname` metadata
-	keyBegin                uint32
-	channelName             string
-	enforceVariantMaxLength bool
+	c            *streamClient
+	tableStreams map[int]*tableStream
+	tenant       string // used for the `ingestclientname` metadata
+	keyBegin     uint32
+	channelName  string
 
 	// Returned from the "configure" API.
 	prefix       string
@@ -58,22 +57,21 @@ type streamManager struct {
 	blobStats map[int][]*blobStatsTracker
 }
 
-func newStreamManager(cfg *config, materialization string, tenant string, account string, keyBegin uint32, enforceVariantMaxLength bool) (*streamManager, error) {
+func newStreamManager(cfg *config, materialization string, tenant string, account string, keyBegin uint32) (*streamManager, error) {
 	c, err := newStreamClient(cfg, account)
 	if err != nil {
 		return nil, fmt.Errorf("newStreamClient: %w", err)
 	}
 
 	return &streamManager{
-		c:                       c,
-		tableStreams:            make(map[int]*tableStream),
-		tenant:                  tenant,
-		keyBegin:                keyBegin,
-		channelName:             channelName(materialization, keyBegin),
-		lastBinding:             -1,
-		blobStats:               make(map[int][]*blobStatsTracker),
-		counter:                 0,
-		enforceVariantMaxLength: enforceVariantMaxLength,
+		c:            c,
+		tableStreams: make(map[int]*tableStream),
+		tenant:       tenant,
+		keyBegin:     keyBegin,
+		channelName:  channelName(materialization, keyBegin),
+		lastBinding:  -1,
+		blobStats:    make(map[int][]*blobStatsTracker),
+		counter:      0,
 	}, nil
 }
 
@@ -148,7 +146,7 @@ func (sm *streamManager) startNewBlob(ctx context.Context, binding int) error {
 	w := sm.bucket.NewWriter(ctx, path.Join(sm.bucketPath, string(fName)), sm.objMetadata())
 
 	ts := sm.tableStreams[binding]
-	bdecWriter, err := newBdecWriter(w, ts.mappedColumns, ts.channel.TableColumns, ts.channel.EncryptionKey, fName, sm.enforceVariantMaxLength)
+	bdecWriter, err := newBdecWriter(w, ts.mappedColumns, ts.channel.TableColumns, ts.channel.EncryptionKey, fName)
 	if err != nil {
 		return fmt.Errorf("newBdecWriter: %w", err)
 	}

--- a/materialize-snowflake/stream_http.go
+++ b/materialize-snowflake/stream_http.go
@@ -384,7 +384,7 @@ func post[T any](ctx context.Context, c *streamClient, path string, body any) (*
 		NewRequest().
 		WithContext(ctx).
 		SetHeader("Accept", "application/json").
-		SetHeader("User-Agent", "EstuaryTechnologiesFlow/2.0.0"). // A semver >= 2.0.0 seems to be necessary for GCS to return Oauth client credentials rather than pre-signed URLs
+		SetHeader("User-Agent", "EstuaryTechnologiesFlow/4.0.0"). // A semver >= 2.0.0 seems to be necessary for GCS to return Oauth client credentials rather than pre-signed URLs
 		SetAuthToken(token).
 		SetError(&streamingApiError{})
 

--- a/materialize-snowflake/stream_test.go
+++ b/materialize-snowflake/stream_test.go
@@ -83,7 +83,7 @@ func TestStreamManager(t *testing.T) {
 		_, err = db.ExecContext(ctx, `CREATE TABLE STREAM_TEST (key TEXT, firstcol TEXT, secondcol TEXT);`)
 		require.NoError(t, err)
 
-		sm, err := newStreamManager(&cfg, "testing", "testing", accountName, 0, false)
+		sm, err := newStreamManager(&cfg, "testing", "testing", accountName, 0)
 		require.NoError(t, err)
 
 		require.NoError(t, sm.addBinding(ctx, cfg.Schema, table.Identifier, table))
@@ -114,7 +114,7 @@ func TestStreamManager(t *testing.T) {
 		})
 
 		// A second invocation invalidates the first.
-		ssm, err := newStreamManager(&cfg, "testing", "testing", accountName, 0, false)
+		ssm, err := newStreamManager(&cfg, "testing", "testing", accountName, 0)
 		require.NoError(t, err)
 		require.NoError(t, ssm.addBinding(ctx, cfg.Schema, table.Identifier, table))
 
@@ -176,7 +176,7 @@ func TestStreamManager(t *testing.T) {
 		_, err = db.ExecContext(ctx, `CREATE TABLE STREAM_TEST (key TEXT, firstcol TEXT, secondcol TEXT);`)
 		require.NoError(t, err)
 
-		sm, err := newStreamManager(&cfg, "testing", "testing", accountName, 0, false)
+		sm, err := newStreamManager(&cfg, "testing", "testing", accountName, 0)
 		require.NoError(t, err)
 
 		require.NoError(t, sm.addBinding(ctx, cfg.Schema, table.Identifier, table))
@@ -247,7 +247,7 @@ func TestStreamManager(t *testing.T) {
 			require.NoError(t, err)
 		}
 
-		sm, err := newStreamManager(&cfg, "testing", "testing", accountName, 0, false)
+		sm, err := newStreamManager(&cfg, "testing", "testing", accountName, 0)
 		require.NoError(t, err)
 
 		for _, tbl := range tables {
@@ -366,7 +366,7 @@ func TestStreamManager(t *testing.T) {
 		_, err = db.ExecContext(ctx, createQuery)
 		require.NoError(t, err)
 
-		sm, err := newStreamManager(&cfg, "testing", "testing", accountName, 0, false)
+		sm, err := newStreamManager(&cfg, "testing", "testing", accountName, 0)
 		require.NoError(t, err)
 		require.NoError(t, sm.addBinding(ctx, cfg.Schema, tbl.Identifier, tbl))
 
@@ -416,17 +416,7 @@ func TestStreamManager(t *testing.T) {
 		_, err = db.ExecContext(ctx, `CREATE TABLE STREAM_TEST (key TEXT, firstcol VARIANT);`)
 		require.NoError(t, err)
 
-		{
-			// With enforceVariantMaxLength set to true, a large VARIANT value
-			// can't be written.
-			sm, err := newStreamManager(&cfg, "testing", "testing", accountName, 0, true)
-			require.NoError(t, err)
-			require.NoError(t, sm.addBinding(ctx, cfg.Schema, table.Identifier, table))
-			require.Error(t, sm.writeRow(ctx, 0, []any{"key1", json.RawMessage(data)}))
-		}
-
-		// But it can be written and read when enforceVariantMaxLength is false.
-		sm, err := newStreamManager(&cfg, "testing", "testing", accountName, 0, false)
+		sm, err := newStreamManager(&cfg, "testing", "testing", accountName, 0)
 		require.NoError(t, err)
 		require.NoError(t, sm.addBinding(ctx, cfg.Schema, table.Identifier, table))
 		require.NoError(t, sm.writeRow(ctx, 0, []any{"key1", json.RawMessage(data)}))
@@ -542,7 +532,7 @@ func TestStreamDatatypes(t *testing.T) {
 			_, err = db.ExecContext(ctx, createQuery.String())
 			require.NoError(t, err)
 
-			sm, err := newStreamManager(&cfg, "testing", "testing", accountName, 0, false)
+			sm, err := newStreamManager(&cfg, "testing", "testing", accountName, 0)
 			require.NoError(t, err)
 
 			require.NoError(t, sm.addBinding(ctx, cfg.Schema, tbl.Identifier, tbl))


### PR DESCRIPTION
**Description:**

A few updates related to Snowflake's new larger VARIANT size limits. See individual commits for more details.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

