### PR TITLE
filesink: feature flags and `uuidLogicalType` parameter for parquet writer

### DIFF
--- a/materialize-azure-blob-parquet/main.go
+++ b/materialize-azure-blob-parquet/main.go
@@ -12,9 +12,16 @@ import (
 	"github.com/estuary/flow/go/protocols/materialize"
 )
 
+var featureFlagDefaults = map[string]bool{}
+
 type config struct {
 	filesink.AzureBlobConfig
 	ParquetConfig filesink.ParquetConfig `json:"parquetConfig,omitempty" jsonschema:"title=Parquet Configuration,description=Configuration specific to materializing parquet files."`
+	Advanced      advancedConfig         `json:"advanced,omitempty" jsonschema:"title=Advanced Options,description=Options for advanced users. You should not typically need to modify these." jsonschema_extra:"advanced=true"`
+}
+
+type advancedConfig struct {
+	FeatureFlags string `json:"feature_flags,omitempty" jsonschema:"title=Feature Flags,description=This property is intended for Estuary internal use. You should only modify this field as directed by Estuary support."`
 }
 
 func (c config) Validate() error {
@@ -25,6 +32,10 @@ func (c config) Validate() error {
 	}
 
 	return nil
+}
+
+func (c config) FeatureFlags() (string, map[string]bool) {
+	return c.Advanced.FeatureFlags, featureFlagDefaults
 }
 
 func (c config) CommonConfig() filesink.CommonConfig {
@@ -44,10 +55,10 @@ var driver = filesink.FileDriver{
 		}
 		return cfg, nil
 	},
-	NewStore: func(ctx context.Context, c filesink.Config) (filesink.Store, error) {
+	NewStore: func(ctx context.Context, c filesink.Config, featureFlags map[string]bool) (filesink.Store, error) {
 		return filesink.NewAzureBlob(ctx, c.(config).AzureBlobConfig)
 	},
-	NewWriter: func(c filesink.Config, b *pf.MaterializationSpec_Binding, w io.WriteCloser) (filesink.StreamWriter, error) {
+	NewWriter: func(c filesink.Config, featureFlags map[string]bool, b *pf.MaterializationSpec_Binding, w io.WriteCloser) (filesink.StreamWriter, error) {
 		return filesink.NewParquetWriter(c.(config).ParquetConfig, b, w)
 	},
 	NewConstraints: func(p *pf.Projection) *materialize.Response_Validated_Constraint {

--- a/materialize-azure-blob-parquet/main.go
+++ b/materialize-azure-blob-parquet/main.go
@@ -59,7 +59,7 @@ var driver = filesink.FileDriver{
 		return filesink.NewAzureBlob(ctx, c.(config).AzureBlobConfig)
 	},
 	NewWriter: func(c filesink.Config, featureFlags map[string]bool, b *pf.MaterializationSpec_Binding, w io.WriteCloser) (filesink.StreamWriter, error) {
-		return filesink.NewParquetWriter(c.(config).ParquetConfig, b, w)
+		return filesink.NewParquetWriter(c.(config).ParquetConfig, b, w, true)
 	},
 	NewConstraints: func(p *pf.Projection) *materialize.Response_Validated_Constraint {
 		return filesink.StdConstraints(p)

--- a/materialize-gcs-csv/main.go
+++ b/materialize-gcs-csv/main.go
@@ -12,9 +12,16 @@ import (
 	"github.com/estuary/flow/go/protocols/materialize"
 )
 
+var featureFlagDefaults = map[string]bool{}
+
 type config struct {
 	filesink.GCSStoreConfig
 	CsvConfig filesink.CsvConfig `json:"csvConfig,omitempty" jsonschema:"title=CSV Configuration,description=Configuration specific to materializing CSV files."`
+	Advanced  advancedConfig     `json:"advanced,omitempty" jsonschema:"title=Advanced Options,description=Options for advanced users. You should not typically need to modify these." jsonschema_extra:"advanced=true"`
+}
+
+type advancedConfig struct {
+	FeatureFlags string `json:"feature_flags,omitempty" jsonschema:"title=Feature Flags,description=This property is intended for Estuary internal use. You should only modify this field as directed by Estuary support."`
 }
 
 func (c config) Validate() error {
@@ -25,6 +32,10 @@ func (c config) Validate() error {
 	}
 
 	return nil
+}
+
+func (c config) FeatureFlags() (string, map[string]bool) {
+	return c.Advanced.FeatureFlags, featureFlagDefaults
 }
 
 func (c config) CommonConfig() filesink.CommonConfig {
@@ -44,10 +55,10 @@ var driver = filesink.FileDriver{
 		}
 		return cfg, nil
 	},
-	NewStore: func(ctx context.Context, c filesink.Config) (filesink.Store, error) {
+	NewStore: func(ctx context.Context, c filesink.Config, featureFlags map[string]bool) (filesink.Store, error) {
 		return filesink.NewGCSStore(ctx, c.(config).GCSStoreConfig)
 	},
-	NewWriter: func(c filesink.Config, b *pf.MaterializationSpec_Binding, w io.WriteCloser) (filesink.StreamWriter, error) {
+	NewWriter: func(c filesink.Config, featureFlags map[string]bool, b *pf.MaterializationSpec_Binding, w io.WriteCloser) (filesink.StreamWriter, error) {
 		return filesink.NewCsvStreamWriter(c.(config).CsvConfig, b, w), nil
 	},
 	NewConstraints: func(p *pf.Projection) *materialize.Response_Validated_Constraint {

--- a/materialize-gcs-parquet/main.go
+++ b/materialize-gcs-parquet/main.go
@@ -59,7 +59,7 @@ var driver = filesink.FileDriver{
 		return filesink.NewGCSStore(ctx, c.(config).GCSStoreConfig)
 	},
 	NewWriter: func(c filesink.Config, featureFlags map[string]bool, b *pf.MaterializationSpec_Binding, w io.WriteCloser) (filesink.StreamWriter, error) {
-		return filesink.NewParquetWriter(c.(config).ParquetConfig, b, w)
+		return filesink.NewParquetWriter(c.(config).ParquetConfig, b, w, true)
 	},
 	NewConstraints: func(p *pf.Projection) *materialize.Response_Validated_Constraint {
 		return filesink.StdConstraints(p)

--- a/materialize-gcs-parquet/main.go
+++ b/materialize-gcs-parquet/main.go
@@ -12,9 +12,16 @@ import (
 	"github.com/estuary/flow/go/protocols/materialize"
 )
 
+var featureFlagDefaults = map[string]bool{}
+
 type config struct {
 	filesink.GCSStoreConfig
 	ParquetConfig filesink.ParquetConfig `json:"parquetConfig,omitempty" jsonschema:"title=Parquet Configuration,description=Configuration specific to materializing parquet files."`
+	Advanced      advancedConfig         `json:"advanced,omitempty" jsonschema:"title=Advanced Options,description=Options for advanced users. You should not typically need to modify these." jsonschema_extra:"advanced=true"`
+}
+
+type advancedConfig struct {
+	FeatureFlags string `json:"feature_flags,omitempty" jsonschema:"title=Feature Flags,description=This property is intended for Estuary internal use. You should only modify this field as directed by Estuary support."`
 }
 
 func (c config) Validate() error {
@@ -25,6 +32,10 @@ func (c config) Validate() error {
 	}
 
 	return nil
+}
+
+func (c config) FeatureFlags() (string, map[string]bool) {
+	return c.Advanced.FeatureFlags, featureFlagDefaults
 }
 
 func (c config) CommonConfig() filesink.CommonConfig {
@@ -44,10 +55,10 @@ var driver = filesink.FileDriver{
 		}
 		return cfg, nil
 	},
-	NewStore: func(ctx context.Context, c filesink.Config) (filesink.Store, error) {
+	NewStore: func(ctx context.Context, c filesink.Config, featureFlags map[string]bool) (filesink.Store, error) {
 		return filesink.NewGCSStore(ctx, c.(config).GCSStoreConfig)
 	},
-	NewWriter: func(c filesink.Config, b *pf.MaterializationSpec_Binding, w io.WriteCloser) (filesink.StreamWriter, error) {
+	NewWriter: func(c filesink.Config, featureFlags map[string]bool, b *pf.MaterializationSpec_Binding, w io.WriteCloser) (filesink.StreamWriter, error) {
 		return filesink.NewParquetWriter(c.(config).ParquetConfig, b, w)
 	},
 	NewConstraints: func(p *pf.Projection) *materialize.Response_Validated_Constraint {

--- a/materialize-s3-csv/main.go
+++ b/materialize-s3-csv/main.go
@@ -12,9 +12,16 @@ import (
 	"github.com/estuary/flow/go/protocols/materialize"
 )
 
+var featureFlagDefaults = map[string]bool{}
+
 type config struct {
 	filesink.S3StoreConfig
 	CsvConfig filesink.CsvConfig `json:"csvConfig,omitempty" jsonschema:"title=CSV Configuration,description=Configuration specific to materializing CSV files."`
+	Advanced  advancedConfig     `json:"advanced,omitempty" jsonschema:"title=Advanced Options,description=Options for advanced users. You should not typically need to modify these." jsonschema_extra:"advanced=true"`
+}
+
+type advancedConfig struct {
+	FeatureFlags string `json:"feature_flags,omitempty" jsonschema:"title=Feature Flags,description=This property is intended for Estuary internal use. You should only modify this field as directed by Estuary support."`
 }
 
 func (c config) Validate() error {
@@ -25,6 +32,10 @@ func (c config) Validate() error {
 	}
 
 	return nil
+}
+
+func (c config) FeatureFlags() (string, map[string]bool) {
+	return c.Advanced.FeatureFlags, featureFlagDefaults
 }
 
 func (c config) CommonConfig() filesink.CommonConfig {
@@ -44,10 +55,10 @@ var driver = filesink.FileDriver{
 		}
 		return cfg, nil
 	},
-	NewStore: func(ctx context.Context, c filesink.Config) (filesink.Store, error) {
+	NewStore: func(ctx context.Context, c filesink.Config, featureFlags map[string]bool) (filesink.Store, error) {
 		return filesink.NewS3Store(ctx, c.(config).S3StoreConfig)
 	},
-	NewWriter: func(c filesink.Config, b *pf.MaterializationSpec_Binding, w io.WriteCloser) (filesink.StreamWriter, error) {
+	NewWriter: func(c filesink.Config, featureFlags map[string]bool, b *pf.MaterializationSpec_Binding, w io.WriteCloser) (filesink.StreamWriter, error) {
 		return filesink.NewCsvStreamWriter(c.(config).CsvConfig, b, w), nil
 	},
 	NewConstraints: func(p *pf.Projection) *materialize.Response_Validated_Constraint {

--- a/materialize-s3-parquet/main.go
+++ b/materialize-s3-parquet/main.go
@@ -12,9 +12,16 @@ import (
 	"github.com/estuary/flow/go/protocols/materialize"
 )
 
+var featureFlagDefaults = map[string]bool{}
+
 type config struct {
 	filesink.S3StoreConfig
 	ParquetConfig filesink.ParquetConfig `json:"parquetConfig,omitempty" jsonschema:"title=Parquet Configuration,description=Configuration specific to materializing parquet files."`
+	Advanced      advancedConfig         `json:"advanced,omitempty" jsonschema:"title=Advanced Options,description=Options for advanced users. You should not typically need to modify these." jsonschema_extra:"advanced=true"`
+}
+
+type advancedConfig struct {
+	FeatureFlags string `json:"feature_flags,omitempty" jsonschema:"title=Feature Flags,description=This property is intended for Estuary internal use. You should only modify this field as directed by Estuary support."`
 }
 
 func (c config) Validate() error {
@@ -25,6 +32,10 @@ func (c config) Validate() error {
 	}
 
 	return nil
+}
+
+func (c config) FeatureFlags() (string, map[string]bool) {
+	return c.Advanced.FeatureFlags, featureFlagDefaults
 }
 
 func (c config) CommonConfig() filesink.CommonConfig {
@@ -44,10 +55,10 @@ var driver = filesink.FileDriver{
 		}
 		return cfg, nil
 	},
-	NewStore: func(ctx context.Context, c filesink.Config) (filesink.Store, error) {
+	NewStore: func(ctx context.Context, c filesink.Config, featureFlags map[string]bool) (filesink.Store, error) {
 		return filesink.NewS3Store(ctx, c.(config).S3StoreConfig)
 	},
-	NewWriter: func(c filesink.Config, b *pf.MaterializationSpec_Binding, w io.WriteCloser) (filesink.StreamWriter, error) {
+	NewWriter: func(c filesink.Config, featureFlags map[string]bool, b *pf.MaterializationSpec_Binding, w io.WriteCloser) (filesink.StreamWriter, error) {
 		return filesink.NewParquetWriter(c.(config).ParquetConfig, b, w)
 	},
 	NewConstraints: func(p *pf.Projection) *materialize.Response_Validated_Constraint {

--- a/materialize-s3-parquet/main.go
+++ b/materialize-s3-parquet/main.go
@@ -59,7 +59,7 @@ var driver = filesink.FileDriver{
 		return filesink.NewS3Store(ctx, c.(config).S3StoreConfig)
 	},
 	NewWriter: func(c filesink.Config, featureFlags map[string]bool, b *pf.MaterializationSpec_Binding, w io.WriteCloser) (filesink.StreamWriter, error) {
-		return filesink.NewParquetWriter(c.(config).ParquetConfig, b, w)
+		return filesink.NewParquetWriter(c.(config).ParquetConfig, b, w, true)
 	},
 	NewConstraints: func(p *pf.Projection) *materialize.Response_Validated_Constraint {
 		return filesink.StdConstraints(p)


### PR DESCRIPTION
**Description:**

Broadly adds support for feature flags to filesink materializations.

Also adds a functionality for parquet materializations that will control if UUID source fields are materialized as native UUID logical types, or as strings. In the near future this will be controlled by a feature flag, but for now it is hard-coded as `true`, since that preserves backward compatibility.

I will thread the feature flag value through after this has merged and all existing tasks have the `uuid_logical_type` (working title, not finalized) feature flag set. Then going forward, newly created tasks will materialized UUID fields as strings.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

