### PR TITLE
source-pendo: refactor & use IncrementalJSONProcessor

### DIFF
--- a/source-pendo/source_pendo/api.py
+++ b/source-pendo/source_pendo/api.py
@@ -7,7 +7,15 @@ from estuary_cdk.capture.common import BaseDocument, LogCursor, PageCursor
 import estuary_cdk.emitted_changes_cache as cache
 from estuary_cdk.http import HTTPSession
 
-from .models import PageEvent, FeatureEvent, TrackEvent, GuideEvent, PollEvent, AggregatedEventResponse, EventResponse, Resource, Metadata, ResourceResponse
+from .models import (
+    AggregatedEventResponse,
+    Event,
+    EventAggregate,
+    EventResponse,
+    Metadata,
+    Resource,
+    ResourceResponse,
+)
 
 API = "https://app.pendo.io/api/v1"
 RESPONSE_LIMIT = 50000
@@ -274,11 +282,11 @@ async def snapshot_metadata(
 async def fetch_events(
         http: HTTPSession,
         entity: str,
-        model: type[BaseDocument],
+        model: type[Event],
         identifying_field: str,
         log: Logger,
         log_cursor: LogCursor,
-) -> AsyncGenerator[GuideEvent | PollEvent | LogCursor, None]:
+) -> AsyncGenerator[Event | LogCursor, None]:
     assert isinstance(log_cursor, datetime)
     url = f"{API}/aggregation"
     last_dt = log_cursor
@@ -358,12 +366,12 @@ async def fetch_events(
 async def backfill_events(
         http: HTTPSession,
         entity: str,
-        model: type[BaseDocument],
+        model: type[Event],
         identifying_field: str,
         log: Logger,
         page_cursor: PageCursor | None,
         cutoff: LogCursor,
-) -> AsyncGenerator[GuideEvent | PollEvent | PageCursor, None]:
+) -> AsyncGenerator[Event | PageCursor, None]:
     assert isinstance(page_cursor, int)
     assert isinstance(cutoff, datetime)
     url = f"{API}/aggregation"
@@ -437,11 +445,11 @@ async def backfill_events(
 async def fetch_aggregated_events(
         http: HTTPSession,
         entity: str,
-        model: type[BaseDocument],
+        model: type[EventAggregate],
         identifying_field: str,
         log: Logger,
         log_cursor: LogCursor,
-) -> AsyncGenerator[PageEvent | FeatureEvent | TrackEvent | LogCursor, None]:
+) -> AsyncGenerator[EventAggregate | LogCursor, None]:
     assert isinstance(log_cursor, datetime)
     url = f"{API}/aggregation"
     last_dt = log_cursor
@@ -522,12 +530,12 @@ async def fetch_aggregated_events(
 async def backfill_aggregated_events(
         http: HTTPSession,
         entity: str,
-        model: type[BaseDocument],
+        model: type[EventAggregate],
         identifying_field: str,
         log: Logger,
         page_cursor: PageCursor | None,
         cutoff: LogCursor,
-) -> AsyncGenerator[PageEvent | FeatureEvent | TrackEvent | PageCursor, None]:
+) -> AsyncGenerator[EventAggregate | PageCursor, None]:
     assert isinstance(page_cursor, int)
     assert isinstance(cutoff, datetime)
     url = f"{API}/aggregation"

--- a/source-pendo/source_pendo/models.py
+++ b/source-pendo/source_pendo/models.py
@@ -163,22 +163,6 @@ class PollEvent(Event):
     pollId: str
 
 
-class EventResponse(BaseDocument, extra="forbid"):
-    startTime: int
-    results: list[Event]
-
-
-class AggregatedEventResponse(BaseDocument, extra="forbid"):
-    startTime: int
-    results: list[EventAggregate]
-
-
-_ResourceType = TypeVar('_ResourceType', bound=BaseDocument)
-
-class ResourceResponse(BaseModel, Generic[_ResourceType]):
-    results: list[_ResourceType]
-
-
 # Supported snapshot resource types.
 # Most, if not all, of these snapshot resources could be moved over
 # to be incremental resources listed in INCREMENTAL_RESOURCE_TYPES.

--- a/source-pendo/source_pendo/models.py
+++ b/source-pendo/source_pendo/models.py
@@ -42,42 +42,36 @@ class Metadata(BaseDocument, extra="allow"):
     pass
 
 
-# Event streams have slightly different required fields, so we have models for each event type.
-class PageEvent(BaseDocument, extra="allow"):
+class EventAggregate(BaseDocument, extra="allow"):
     appId: int
     hour: int
     remoteIp: str
     lastTime: AwareDatetime
+
+
+class PageEvent(EventAggregate):
     pageId: str
 
 
-class FeatureEvent(BaseDocument, extra="allow"):
-    appId: int
-    hour: int
-    remoteIp: str
-    lastTime: AwareDatetime
+class FeatureEvent(EventAggregate):
     featureId: str
 
 
-class TrackEvent(BaseDocument, extra="allow"):
-    appId: int
-    hour: int
-    remoteIp: str
-    lastTime: AwareDatetime
+class TrackEvent(EventAggregate):
     trackTypeId: str
 
 
-class GuideEvent(BaseDocument, extra="allow"):
+class Event(BaseDocument, extra="allow"):
     appId: int
     remoteIp: str
     guideTimestamp: AwareDatetime
+
+
+class GuideEvent(Event):
     guideId: str
 
 
-class PollEvent(BaseDocument, extra="allow"):
-    appId: int
-    remoteIp: str
-    guideTimestamp: AwareDatetime
+class PollEvent(Event):
     pollId: str
 
 
@@ -95,19 +89,18 @@ class TrackType(BaseDocument, extra="allow"):
 
 class EventResponse(BaseDocument, extra="forbid"):
     startTime: int
-    results: list[GuideEvent | PollEvent]
+    results: list[Event]
 
 
 class AggregatedEventResponse(BaseDocument, extra="forbid"):
     startTime: int
-    results: list[PageEvent | FeatureEvent | TrackEvent]
+    results: list[EventAggregate]
 
 
 _ResourceType = TypeVar('_ResourceType', bound=BaseDocument)
 
 class ResourceResponse(BaseModel, Generic[_ResourceType]):
     results: list[_ResourceType]
-
 
 
 # Supported snapshot resource types and their corresponding name.
@@ -133,14 +126,14 @@ METADATA_TYPES: list[tuple[str, str]] = [
 
 
 # Supported event types, their corresponding name, their keys, and their model.
-EVENT_TYPES: list[tuple[str, str, str, type[BaseDocument]]] = [
+EVENT_TYPES: list[tuple[str, str, str, type[Event]]] = [
     ("guideEvents", "GuideEvents", "guideId", GuideEvent),
     ("pollEvents", "PollEvents", "pollId", PollEvent),
 ]
 
 
 # Supported aggregated event types, their corresponding resource name, their keys, and their model.
-AGGREGATED_EVENT_TYPES: list[tuple[str, str, str, type[BaseDocument]]] = [
+AGGREGATED_EVENT_TYPES: list[tuple[str, str, str, type[EventAggregate]]] = [
     ("pageEvents", "PageEvents", "pageId", PageEvent),
     ("featureEvents", "FeatureEvents", "featureId", FeatureEvent),
     ("trackEvents", "TrackEvents", "trackTypeId", TrackEvent),

--- a/source-pendo/source_pendo/resources.py
+++ b/source-pendo/source_pendo/resources.py
@@ -11,6 +11,8 @@ from .models import (
     EndpointConfig,
     ResourceConfig,
     ResourceState,
+    Event,
+    EventAggregate,
     Resource,
     Metadata,
     FULL_REFRESH_RESOURCE_TYPES,
@@ -205,7 +207,7 @@ def events(
 ) -> list[common.Resource]:
     def open(
         entity: str,
-        model: type[common.BaseDocument],
+        model: type[Event],
         identifying_field: str,
         binding: CaptureBinding[ResourceConfig],
         binding_index: int,
@@ -263,7 +265,7 @@ def aggregated_events(
 ) -> list[common.Resource]:
     def open(
         entity: str,
-        model: type[common.BaseDocument],
+        model: type[EventAggregate],
         identifying_field: str,
         binding: CaptureBinding[ResourceConfig],
         binding_index: int,

--- a/source-pendo/tests/snapshots/snapshots__discover__capture.stdout.json
+++ b/source-pendo/tests/snapshots/snapshots__discover__capture.stdout.json
@@ -42,7 +42,7 @@
           "description": "Document metadata"
         }
       },
-      "title": "Resource",
+      "title": "FullRefreshResource",
       "type": "object",
       "x-infer-schema": true
     },
@@ -93,7 +93,7 @@
           "description": "Document metadata"
         }
       },
-      "title": "Resource",
+      "title": "FullRefreshResource",
       "type": "object",
       "x-infer-schema": true
     },
@@ -144,7 +144,7 @@
           "description": "Document metadata"
         }
       },
-      "title": "Resource",
+      "title": "FullRefreshResource",
       "type": "object",
       "x-infer-schema": true
     },
@@ -195,7 +195,7 @@
           "description": "Document metadata"
         }
       },
-      "title": "Resource",
+      "title": "FullRefreshResource",
       "type": "object",
       "x-infer-schema": true
     },


### PR DESCRIPTION
**Description:**

`source-pendo` was the first native connector I built, and it doesn't follow a lot of the more standard conventions more recently built connectors follow. It also occasionally has OOM failures when backfilling the various event & event aggregates bindings.

This PR's scope includes:
- Refactoring `source-pendo` to bring it more in line with the conventions followed by other native connectors & to make maintaining the connector easier.
  - The refactors are all in the first three commits. No functional changes were made in these commits.
- Using the `IncrementalJSONProcessor` to reduce memory usage & avoid OOMs.

I'd recommend reviewing commit-by-commit. It looks like there's a lot of changes, but most of it is re-organization of the existing code. The only functional change is the switch to use the `IncrementalJSONProcessor`.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

Tested on a local stack. Confirmed all streams still work as they did before, and that the connector no longer OOMs when backfilling multiple streams (memory usage hovered around ~12% during the backfills).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/3186)
<!-- Reviewable:end -->
