### PR TITLE
filesink: activate `uuid_logical_type` feature flag for parquet materializations

### DIFF
--- a/materialize-azure-blob-parquet/main.go
+++ b/materialize-azure-blob-parquet/main.go
@@ -12,7 +12,11 @@ import (
 	"github.com/estuary/flow/go/protocols/materialize"
 )
 
-var featureFlagDefaults = map[string]bool{}
+var featureFlagDefaults = map[string]bool{
+	// Starting on 18-Aug-2025 newly created parquet materializations will use
+	// STRING logical type for UUID fields, rather than a UUID logical type.
+	"uuid_logical_type": false,
+}
 
 type config struct {
 	filesink.AzureBlobConfig
@@ -59,7 +63,7 @@ var driver = filesink.FileDriver{
 		return filesink.NewAzureBlob(ctx, c.(config).AzureBlobConfig)
 	},
 	NewWriter: func(c filesink.Config, featureFlags map[string]bool, b *pf.MaterializationSpec_Binding, w io.WriteCloser) (filesink.StreamWriter, error) {
-		return filesink.NewParquetWriter(c.(config).ParquetConfig, b, w, true)
+		return filesink.NewParquetWriter(c.(config).ParquetConfig, b, w, featureFlags["uuid_logical_type"])
 	},
 	NewConstraints: func(p *pf.Projection) *materialize.Response_Validated_Constraint {
 		return filesink.StdConstraints(p)

--- a/materialize-gcs-parquet/main.go
+++ b/materialize-gcs-parquet/main.go
@@ -12,7 +12,11 @@ import (
 	"github.com/estuary/flow/go/protocols/materialize"
 )
 
-var featureFlagDefaults = map[string]bool{}
+var featureFlagDefaults = map[string]bool{
+	// Starting on 18-Aug-2025 newly created parquet materializations will use
+	// STRING logical type for UUID fields, rather than a UUID logical type.
+	"uuid_logical_type": false,
+}
 
 type config struct {
 	filesink.GCSStoreConfig
@@ -59,7 +63,7 @@ var driver = filesink.FileDriver{
 		return filesink.NewGCSStore(ctx, c.(config).GCSStoreConfig)
 	},
 	NewWriter: func(c filesink.Config, featureFlags map[string]bool, b *pf.MaterializationSpec_Binding, w io.WriteCloser) (filesink.StreamWriter, error) {
-		return filesink.NewParquetWriter(c.(config).ParquetConfig, b, w, true)
+		return filesink.NewParquetWriter(c.(config).ParquetConfig, b, w, featureFlags["uuid_logical_type"])
 	},
 	NewConstraints: func(p *pf.Projection) *materialize.Response_Validated_Constraint {
 		return filesink.StdConstraints(p)

--- a/materialize-s3-parquet/main.go
+++ b/materialize-s3-parquet/main.go
@@ -12,7 +12,11 @@ import (
 	"github.com/estuary/flow/go/protocols/materialize"
 )
 
-var featureFlagDefaults = map[string]bool{}
+var featureFlagDefaults = map[string]bool{
+	// Starting on 18-Aug-2025 newly created parquet materializations will use
+	// STRING logical type for UUID fields, rather than a UUID logical type.
+	"uuid_logical_type": false,
+}
 
 type config struct {
 	filesink.S3StoreConfig
@@ -59,7 +63,7 @@ var driver = filesink.FileDriver{
 		return filesink.NewS3Store(ctx, c.(config).S3StoreConfig)
 	},
 	NewWriter: func(c filesink.Config, featureFlags map[string]bool, b *pf.MaterializationSpec_Binding, w io.WriteCloser) (filesink.StreamWriter, error) {
-		return filesink.NewParquetWriter(c.(config).ParquetConfig, b, w, true)
+		return filesink.NewParquetWriter(c.(config).ParquetConfig, b, w, featureFlags["uuid_logical_type"])
 	},
 	NewConstraints: func(p *pf.Projection) *materialize.Response_Validated_Constraint {
 		return filesink.StdConstraints(p)


### PR DESCRIPTION
**Description:**

The `uuid_logical_type` feature flag will control if `type: string, format: uuid` fields are materialized as UUID logical types in parquet if set, or strings if not.

The default going forward will be to materialize these as strings since that has the broadest compatibility. Existing tasks have had the flag retroactively set, to preserve their existing behavior.

Closes #3182 

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/3187)
<!-- Reviewable:end -->
