### PR TITLE
source-mongodb: prefer startAfter to resumeAfter

### DIFF
--- a/source-mongodb/change_stream.go
+++ b/source-mongodb/change_stream.go
@@ -64,6 +64,7 @@ func (c *capture) initializeStreams(
 	changeStreamBindings []bindingInfo,
 	maxAwaitTime *time.Duration,
 	requestPreImages bool,
+	useStartAfter bool,
 	exclusiveCollectionFilter bool,
 	excludeCollections map[string][]string,
 ) ([]*changeStream, error) {
@@ -130,7 +131,11 @@ func (c *capture) initializeStreams(
 
 		if t, ok := c.state.DatabaseResumeTokens[db]; ok {
 			logEntry = logEntry.WithField("resumeToken", t)
-			opts = opts.SetResumeAfter(t)
+			if useStartAfter {
+				opts = opts.SetStartAfter(t)
+			} else {
+				opts = opts.SetResumeAfter(t)
+			}
 		}
 
 		ms, err := c.client.Database(db).Watch(ctx, pl, opts)

--- a/source-mongodb/change_stream_test.go
+++ b/source-mongodb/change_stream_test.go
@@ -142,7 +142,7 @@ func TestPullStream(t *testing.T) {
 				lastEventClusterTime: map[string]primitive.Timestamp{},
 			}
 
-			streams, err := c.initializeStreams(ctx, bindings, nil, true, false, map[string][]string{})
+			streams, err := c.initializeStreams(ctx, bindings, nil, true, true, false, map[string][]string{})
 			require.NoError(t, err)
 			require.Equal(t, 1, len(streams))
 


### PR DESCRIPTION
**Description:**

The startAfter parameter allows resuming a change stream more consistently than resumeAfter. Namely, if the capture is using the "change stream exclusive collection filter" option and a collection is disabled from the capture where a
document from that collection generated the last persisted resume token, startAfter will allow the change stream to be resumed whereas resumeAfter won't.

I don't really see any downside to using startAfter whenever it is supported by MongoDB, which is all reasonably modern versions. A database-level change stream like we use will get invalidated if the database is dropped, and startAfter will
resume the change stream if the database is later re-created vs. resumeAfter which will continue to fail, but this seems like a pretty extreme edge case and if users are doing that we'll at least have logging about it from the first commit.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/3188)
<!-- Reviewable:end -->
