### PR TITLE
source-klaviyo-native: make window_size an ISO 8601 duration

### DIFF
--- a/source-klaviyo-native/source_klaviyo_native/api/events.py
+++ b/source-klaviyo-native/source_klaviyo_native/api/events.py
@@ -337,7 +337,7 @@ async def subdivision_worker(
 
 async def backfill_events(
     http: HTTPSession,
-    window_size: int,
+    window_size: timedelta,
     log: Logger,
     page: PageCursor,
     cutoff: LogCursor,
@@ -349,7 +349,7 @@ async def backfill_events(
     if start >= cutoff:
         return
 
-    end = min(start + timedelta(days=window_size), cutoff)
+    end = min(start + window_size, cutoff)
 
     work_manager = WorkManager(
         http=http,

--- a/source-klaviyo-native/source_klaviyo_native/models.py
+++ b/source-klaviyo-native/source_klaviyo_native/models.py
@@ -44,12 +44,12 @@ class EndpointConfig(BaseModel):
         title="Authentication",
     )
     class Advanced(BaseModel):
-        window_size: Annotated[int, Field(
-            description="Date window size for the events backfill in days.",
+        window_size: Annotated[timedelta, Field(
+            description="Date window size for the events backfill in ISO 8601 format. ex: P30D means 30 days, PT6H means 6 hours.",
             title="Window size",
-            default=30,
-            gt=0,
-            le=365,
+            default=timedelta(days=30),
+            ge=timedelta(seconds=30),
+            le=timedelta(days=365),
         )]
 
     advanced: Advanced = Field(

--- a/source-klaviyo-native/tests/snapshots/snapshots__spec__capture.stdout.json
+++ b/source-klaviyo-native/tests/snapshots/snapshots__spec__capture.stdout.json
@@ -6,12 +6,11 @@
         "Advanced": {
           "properties": {
             "window_size": {
-              "default": 30,
-              "description": "Date window size for the events backfill in days.",
-              "exclusiveMinimum": 0,
-              "maximum": 365,
+              "default": "P30D",
+              "description": "Date window size for the events backfill in ISO 8601 format. ex: P30D means 30 days, PT6H means 6 hours.",
+              "format": "duration",
               "title": "Window size",
-              "type": "integer"
+              "type": "string"
             }
           },
           "title": "Advanced",


### PR DESCRIPTION
**Description:**

Users have varying amounts of event data in their Klaviyo accounts, and some users have enough data that it still takes a while (15+ minutes) to get all event data for a single day. Allowing users to specify an ISO 8601 duration as the window_size lets them select a value smaller than 1 day, and this increases the frequency the connector checkpoints its progress by virtue of checking a smaller date window.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

The connector's docs should be updated to reflect that `advanced.window_size` is now an ISO 8601 duration.

**Notes for reviewers:**

Tested on a local stack. Confirmed the connector still captures data & uses the configured duration as the window size.

There's a single `source-klaviyo-native` capture in production that will need its `advanced.window_size` value updated to be an ISO 8601 duration. I plan to do that manually after this PR is merged.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/3189)
<!-- Reviewable:end -->
