### PR TITLE
source-pendo: fix collection keys for events and event aggregates

### DIFF
--- a/source-pendo/source_pendo/models.py
+++ b/source-pendo/source_pendo/models.py
@@ -75,14 +75,16 @@ class Report(FullRefreshResource):
 
 
 class IncrementalResource(FullRefreshResource):
-    primary_key: ClassVar[str]
+    primary_keys: ClassVar[list[str]]
     cursor_field: ClassVar[str]
+    identifying_field: ClassVar[str]
 
 
 class Account(IncrementalResource):
     entity_name: ClassVar[str] = "accounts"
     resource_name: ClassVar[str] = "Account"
-    primary_key: ClassVar[str] = "accountId"
+    identifying_field: ClassVar[str] = "accountId"
+    primary_keys: ClassVar[list[str]] = ["accountId"]
     cursor_field: ClassVar[str] = "metadata.auto.lastupdated"
 
     accountId: str
@@ -91,7 +93,8 @@ class Account(IncrementalResource):
 class Visitor(IncrementalResource):
     entity_name: ClassVar[str] = "visitors"
     resource_name: ClassVar[str] = "Visitor"
-    primary_key: ClassVar[str] = "visitorId"
+    identifying_field: ClassVar[str] = "visitorId"
+    primary_keys: ClassVar[list[str]] = ["visitorId"]
     cursor_field: ClassVar[str] = "metadata.auto.lastupdated"
 
     visitorId: str
@@ -100,27 +103,36 @@ class Visitor(IncrementalResource):
 class TrackType(IncrementalResource):
     entity_name: ClassVar[str] = "trackTypes"
     resource_name: ClassVar[str] = "TrackType"
-    primary_key: ClassVar[str] = "id"
+    identifying_field: ClassVar[str] = "id"
+    primary_keys: ClassVar[list[str]] = ["id"]
     cursor_field: ClassVar[str] = "lastUpdatedAt"
+
 
     id: str
 
 
 class BaseEvent(FullRefreshResource):
-    primary_key: ClassVar[str]
+    identifying_field: ClassVar[str]
+    primary_keys: ClassVar[list[str]]
+
+    accountId: str
+    appId: int
+    remoteIp: str
+    visitorId: str
+    userAgent: str
 
 
 class EventAggregate(BaseEvent):
-    appId: int
-    hour: int
-    remoteIp: str
+    server: str
+    firstTime: int
     lastTime: AwareDatetime
 
 
 class PageEvent(EventAggregate):
     entity_name: ClassVar[str] = "pageEvents"
     resource_name: ClassVar[str] = "PageEvents"
-    primary_key: ClassVar[str] = "pageId"
+    identifying_field: ClassVar[str] = "pageId"
+    primary_keys: ClassVar[list[str]] = ["pageId"]
 
     pageId: str
 
@@ -128,7 +140,8 @@ class PageEvent(EventAggregate):
 class FeatureEvent(EventAggregate):
     entity_name: ClassVar[str] = "featureEvents"
     resource_name: ClassVar[str] = "FeatureEvents"
-    primary_key: ClassVar[str] = "featureId"
+    identifying_field: ClassVar[str] = "featureId"
+    primary_keys: ClassVar[list[str]] = ["featureId"]
 
     featureId: str
 
@@ -136,21 +149,22 @@ class FeatureEvent(EventAggregate):
 class TrackEvent(EventAggregate):
     entity_name: ClassVar[str] = "trackEvents"
     resource_name: ClassVar[str] = "TrackEvents"
-    primary_key: ClassVar[str] = "trackTypeId"
+    identifying_field: ClassVar[str] = "trackTypeId"
+    primary_keys: ClassVar[list[str]] = ["trackTypeId"]
 
     trackTypeId: str
 
 
 class Event(BaseEvent):
-    appId: int
-    remoteIp: str
     guideTimestamp: AwareDatetime
+    serverName: str
 
 
 class GuideEvent(Event):
     entity_name: ClassVar[str] = "guideEvents"
     resource_name: ClassVar[str] = "GuideEvents"
-    primary_key: ClassVar[str] = "guideId"
+    identifying_field: ClassVar[str] = "guideId"
+    primary_keys: ClassVar[list[str]] = ["guideId"]
 
     guideId: str
 
@@ -158,8 +172,10 @@ class GuideEvent(Event):
 class PollEvent(Event):
     entity_name: ClassVar[str] = "pollEvents"
     resource_name: ClassVar[str] = "PollEvents"
-    primary_key: ClassVar[str] = "pollId"
+    identifying_field: ClassVar[str] = "pollId"
+    primary_keys: ClassVar[list[str]] = ["guideId", "pollId"]
 
+    guideId: str
     pollId: str
 
 

--- a/source-pendo/source_pendo/resources.py
+++ b/source-pendo/source_pendo/resources.py
@@ -142,9 +142,9 @@ def incremental_resources(
     resources = [
         common.Resource(
             name=stream.resource_name,
-            key=[f"/{stream.primary_key}"],
+            key=sorted([f"/{key}" for key in stream.primary_keys]),
             model=stream,
-            open=functools.partial(open, stream.entity_name, stream, stream.cursor_field, stream.primary_key),
+            open=functools.partial(open, stream.entity_name, stream, stream.cursor_field, stream.identifying_field),
             initial_state=ResourceState(
                 inc=ResourceState.Incremental(cursor=cutoff),
                 backfill=ResourceState.Backfill(next_page=backfill_start_ts, cutoff=cutoff)
@@ -240,12 +240,22 @@ def events(
     backfill_start_ts = _dt_to_ms(datetime.fromisoformat(config.startDate))
     cutoff = datetime.now(tz=UTC) - API_EVENT_LAG
 
+    shared_keys = [
+        "/accountId",
+        "/appId",
+        "/guideTimestamp",
+        "/remoteIp",
+        "/serverName",
+        "/visitorId",
+        "/userAgent",
+    ]
+
     events = [
         common.Resource(
             name=stream.resource_name,
-            key=["/appId", "/guideTimestamp", "/remoteIp", f"/{stream.primary_key}"],
+            key=sorted(shared_keys + [f"/{key}" for key in stream.primary_keys]),
             model=stream,
-            open=functools.partial(open, stream.entity_name, stream, stream.primary_key),
+            open=functools.partial(open, stream.entity_name, stream, stream.identifying_field),
             initial_state=ResourceState(
                 inc=ResourceState.Incremental(cursor=cutoff),
                 backfill=ResourceState.Backfill(next_page=backfill_start_ts, cutoff=cutoff)
@@ -298,12 +308,23 @@ def aggregated_events(
     backfill_start_ts = _dt_to_ms(datetime.fromisoformat(config.startDate))
     cutoff = datetime.now(tz=UTC) - API_EVENT_LAG 
 
+    shared_keys = [
+        "/accountId",
+        "/appId",
+        "/firstTime",
+        "/lastTime",
+        "/remoteIp",
+        "/server",
+        "/visitorId",
+        "/userAgent",
+    ]
+
     events = [
         common.Resource(
             name=stream.resource_name,
-            key=["/appId", "/hour", "/remoteIp", f"/{stream.primary_key}"],
+            key=sorted(shared_keys + [f"/{key}" for key in stream.primary_keys]),
             model=stream,
-            open=functools.partial(open, stream.entity_name, stream, stream.primary_key),
+            open=functools.partial(open, stream.entity_name, stream, stream.identifying_field),
             initial_state=ResourceState(
                 inc=ResourceState.Incremental(cursor=cutoff),
                 backfill=ResourceState.Backfill(next_page=backfill_start_ts, cutoff=cutoff)

--- a/source-pendo/tests/snapshots/snapshots__discover__capture.stdout.json
+++ b/source-pendo/tests/snapshots/snapshots__discover__capture.stdout.json
@@ -521,6 +521,10 @@
           },
           "description": "Document metadata"
         },
+        "accountId": {
+          "title": "Accountid",
+          "type": "string"
+        },
         "appId": {
           "title": "Appid",
           "type": "integer"
@@ -529,9 +533,21 @@
           "title": "Remoteip",
           "type": "string"
         },
+        "visitorId": {
+          "title": "Visitorid",
+          "type": "string"
+        },
+        "userAgent": {
+          "title": "Useragent",
+          "type": "string"
+        },
         "guideTimestamp": {
           "format": "date-time",
           "title": "Guidetimestamp",
+          "type": "string"
+        },
+        "serverName": {
+          "title": "Servername",
           "type": "string"
         },
         "guideId": {
@@ -540,9 +556,13 @@
         }
       },
       "required": [
+        "accountId",
         "appId",
         "remoteIp",
+        "visitorId",
+        "userAgent",
         "guideTimestamp",
+        "serverName",
         "guideId"
       ],
       "title": "GuideEvent",
@@ -550,10 +570,14 @@
       "x-infer-schema": true
     },
     "key": [
+      "/accountId",
       "/appId",
+      "/guideId",
       "/guideTimestamp",
       "/remoteIp",
-      "/guideId"
+      "/serverName",
+      "/userAgent",
+      "/visitorId"
     ]
   },
   {
@@ -598,6 +622,10 @@
           },
           "description": "Document metadata"
         },
+        "accountId": {
+          "title": "Accountid",
+          "type": "string"
+        },
         "appId": {
           "title": "Appid",
           "type": "integer"
@@ -606,9 +634,25 @@
           "title": "Remoteip",
           "type": "string"
         },
+        "visitorId": {
+          "title": "Visitorid",
+          "type": "string"
+        },
+        "userAgent": {
+          "title": "Useragent",
+          "type": "string"
+        },
         "guideTimestamp": {
           "format": "date-time",
           "title": "Guidetimestamp",
+          "type": "string"
+        },
+        "serverName": {
+          "title": "Servername",
+          "type": "string"
+        },
+        "guideId": {
+          "title": "Guideid",
           "type": "string"
         },
         "pollId": {
@@ -617,9 +661,14 @@
         }
       },
       "required": [
+        "accountId",
         "appId",
         "remoteIp",
+        "visitorId",
+        "userAgent",
         "guideTimestamp",
+        "serverName",
+        "guideId",
         "pollId"
       ],
       "title": "PollEvent",
@@ -627,10 +676,15 @@
       "x-infer-schema": true
     },
     "key": [
+      "/accountId",
       "/appId",
+      "/guideId",
       "/guideTimestamp",
+      "/pollId",
       "/remoteIp",
-      "/pollId"
+      "/serverName",
+      "/userAgent",
+      "/visitorId"
     ]
   },
   {
@@ -675,17 +729,33 @@
           },
           "description": "Document metadata"
         },
+        "accountId": {
+          "title": "Accountid",
+          "type": "string"
+        },
         "appId": {
           "title": "Appid",
-          "type": "integer"
-        },
-        "hour": {
-          "title": "Hour",
           "type": "integer"
         },
         "remoteIp": {
           "title": "Remoteip",
           "type": "string"
+        },
+        "visitorId": {
+          "title": "Visitorid",
+          "type": "string"
+        },
+        "userAgent": {
+          "title": "Useragent",
+          "type": "string"
+        },
+        "server": {
+          "title": "Server",
+          "type": "string"
+        },
+        "firstTime": {
+          "title": "Firsttime",
+          "type": "integer"
         },
         "lastTime": {
           "format": "date-time",
@@ -698,9 +768,13 @@
         }
       },
       "required": [
+        "accountId",
         "appId",
-        "hour",
         "remoteIp",
+        "visitorId",
+        "userAgent",
+        "server",
+        "firstTime",
         "lastTime",
         "pageId"
       ],
@@ -709,10 +783,15 @@
       "x-infer-schema": true
     },
     "key": [
+      "/accountId",
       "/appId",
-      "/hour",
+      "/firstTime",
+      "/lastTime",
+      "/pageId",
       "/remoteIp",
-      "/pageId"
+      "/server",
+      "/userAgent",
+      "/visitorId"
     ]
   },
   {
@@ -757,17 +836,33 @@
           },
           "description": "Document metadata"
         },
+        "accountId": {
+          "title": "Accountid",
+          "type": "string"
+        },
         "appId": {
           "title": "Appid",
-          "type": "integer"
-        },
-        "hour": {
-          "title": "Hour",
           "type": "integer"
         },
         "remoteIp": {
           "title": "Remoteip",
           "type": "string"
+        },
+        "visitorId": {
+          "title": "Visitorid",
+          "type": "string"
+        },
+        "userAgent": {
+          "title": "Useragent",
+          "type": "string"
+        },
+        "server": {
+          "title": "Server",
+          "type": "string"
+        },
+        "firstTime": {
+          "title": "Firsttime",
+          "type": "integer"
         },
         "lastTime": {
           "format": "date-time",
@@ -780,9 +875,13 @@
         }
       },
       "required": [
+        "accountId",
         "appId",
-        "hour",
         "remoteIp",
+        "visitorId",
+        "userAgent",
+        "server",
+        "firstTime",
         "lastTime",
         "featureId"
       ],
@@ -791,10 +890,15 @@
       "x-infer-schema": true
     },
     "key": [
+      "/accountId",
       "/appId",
-      "/hour",
+      "/featureId",
+      "/firstTime",
+      "/lastTime",
       "/remoteIp",
-      "/featureId"
+      "/server",
+      "/userAgent",
+      "/visitorId"
     ]
   },
   {
@@ -839,17 +943,33 @@
           },
           "description": "Document metadata"
         },
+        "accountId": {
+          "title": "Accountid",
+          "type": "string"
+        },
         "appId": {
           "title": "Appid",
-          "type": "integer"
-        },
-        "hour": {
-          "title": "Hour",
           "type": "integer"
         },
         "remoteIp": {
           "title": "Remoteip",
           "type": "string"
+        },
+        "visitorId": {
+          "title": "Visitorid",
+          "type": "string"
+        },
+        "userAgent": {
+          "title": "Useragent",
+          "type": "string"
+        },
+        "server": {
+          "title": "Server",
+          "type": "string"
+        },
+        "firstTime": {
+          "title": "Firsttime",
+          "type": "integer"
         },
         "lastTime": {
           "format": "date-time",
@@ -862,9 +982,13 @@
         }
       },
       "required": [
+        "accountId",
         "appId",
-        "hour",
         "remoteIp",
+        "visitorId",
+        "userAgent",
+        "server",
+        "firstTime",
         "lastTime",
         "trackTypeId"
       ],
@@ -873,10 +997,15 @@
       "x-infer-schema": true
     },
     "key": [
+      "/accountId",
       "/appId",
-      "/hour",
+      "/firstTime",
+      "/lastTime",
       "/remoteIp",
-      "/trackTypeId"
+      "/server",
+      "/trackTypeId",
+      "/userAgent",
+      "/visitorId"
     ]
   }
 ]


### PR DESCRIPTION
**Description:**

The collection keys for the events and event aggregates resources were insufficient to uniquely identify records, causing de-duplication through the platform on non-duplicate data. This PR fixes the collection keys for events and event aggregates.

The change in collection keys will cause collections to be re-versioned and to be backfilled for all existing captures.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

Tested on a local stack. Confirmed unique API records are no longer de-duplicated - the new keys sufficiently identify unique records.

This PR should be merged into `main` after https://github.com/estuary/connectors/pull/3186.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/3191)
<!-- Reviewable:end -->
