### PR TITLE
source-hubspot-native: allow extra fields in the BatchResult response

### DIFF
--- a/source-hubspot-native/source_hubspot_native/models.py
+++ b/source-hubspot-native/source_hubspot_native/models.py
@@ -417,8 +417,8 @@ class SearchPageResult(BaseModel, Generic[Item], extra="forbid"):
 
 
 # Common shape of a v3 API batch read.
-class BatchResult(BaseModel, Generic[Item], extra="forbid"):
-    class Error(BaseModel, extra="forbid"):
+class BatchResult(BaseModel, Generic[Item], extra="allow"):
+    class Error(BaseModel, extra="allow"):
         status: Literal["error"]
         category: Literal["OBJECT_NOT_FOUND"]
         message: str

--- a/source-hubspot-native/tests/snapshots/snapshots__capture__stdout.json
+++ b/source-hubspot-native/tests/snapshots/snapshots__capture__stdout.json
@@ -29,7 +29,6 @@
         "hs_latest_source_data_1": "API",
         "hs_latest_source_data_2": "sample-contact",
         "hs_latest_source_timestamp": "2024-12-18T20:40:00Z",
-        "hs_lifecyclestage_lead_date": "2024-12-18T20:40:46.664Z",
         "hs_marketable_reason_id": "Sample Contact",
         "hs_marketable_reason_type": "SAMPLE_CONTACT",
         "hs_marketable_status": "true",
@@ -215,14 +214,6 @@
             "sourceType": "ANALYTICS",
             "timestamp": "2024-12-18T20:41:04.428000Z",
             "value": "2024-12-18T20:40:00Z"
-          }
-        ],
-        "hs_lifecyclestage_lead_date": [
-          {
-            "sourceId": "sample-contact",
-            "sourceType": "API",
-            "timestamp": "2024-12-18T20:40:46.664000Z",
-            "value": "2024-12-18T20:40:46.664Z"
           }
         ],
         "hs_marketable_reason_id": [
@@ -497,7 +488,6 @@
         "hs_latest_source_data_1": "API",
         "hs_latest_source_data_2": "sample-contact",
         "hs_latest_source_timestamp": "2024-12-18T20:40:00Z",
-        "hs_lifecyclestage_lead_date": "2024-12-18T20:40:45.833Z",
         "hs_marketable_reason_id": "Sample Contact",
         "hs_marketable_reason_type": "SAMPLE_CONTACT",
         "hs_marketable_status": "true",
@@ -681,14 +671,6 @@
             "sourceType": "ANALYTICS",
             "timestamp": "2024-12-18T20:40:52.988000Z",
             "value": "2024-12-18T20:40:00Z"
-          }
-        ],
-        "hs_lifecyclestage_lead_date": [
-          {
-            "sourceId": "sample-contact",
-            "sourceType": "INTERNAL_PROCESSING",
-            "timestamp": "2024-12-18T20:40:45.833000Z",
-            "value": "2024-12-18T20:40:45.833Z"
           }
         ],
         "hs_marketable_reason_id": [

--- a/source-hubspot-native/tests/snapshots/snapshots__discover__stdout.json
+++ b/source-hubspot-native/tests/snapshots/snapshots__discover__stdout.json
@@ -1756,5 +1756,153 @@
     "key": [
       "/id"
     ]
+  },
+  {
+    "recommendedName": "forms",
+    "resourceConfig": {
+      "name": "forms",
+      "interval": "PT5M"
+    },
+    "documentSchema": {
+      "$defs": {
+        "Meta": {
+          "properties": {
+            "op": {
+              "default": "u",
+              "description": "Operation type (c: Create, u: Update, d: Delete)",
+              "enum": [
+                "c",
+                "u",
+                "d"
+              ],
+              "title": "Op",
+              "type": "string"
+            },
+            "row_id": {
+              "default": -1,
+              "description": "Row ID of the Document, counting up from zero, or -1 if not known",
+              "title": "Row Id",
+              "type": "integer"
+            }
+          },
+          "title": "Meta",
+          "type": "object"
+        }
+      },
+      "additionalProperties": true,
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/Meta",
+          "default": {
+            "op": "u",
+            "row_id": -1
+          },
+          "description": "Document metadata"
+        },
+        "id": {
+          "title": "Id",
+          "type": "string"
+        },
+        "createdAt": {
+          "anyOf": [
+            {
+              "format": "date-time",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "title": "Createdat"
+        },
+        "updatedAt": {
+          "anyOf": [
+            {
+              "format": "date-time",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "title": "Updatedat"
+        }
+      },
+      "required": [
+        "id",
+        "createdAt",
+        "updatedAt"
+      ],
+      "title": "Form",
+      "type": "object",
+      "x-infer-schema": true
+    },
+    "key": [
+      "/_meta/row_id"
+    ]
+  },
+  {
+    "recommendedName": "form_submissions",
+    "resourceConfig": {
+      "name": "form_submissions",
+      "interval": "PT5M"
+    },
+    "documentSchema": {
+      "$defs": {
+        "Meta": {
+          "properties": {
+            "op": {
+              "default": "u",
+              "description": "Operation type (c: Create, u: Update, d: Delete)",
+              "enum": [
+                "c",
+                "u",
+                "d"
+              ],
+              "title": "Op",
+              "type": "string"
+            },
+            "row_id": {
+              "default": -1,
+              "description": "Row ID of the Document, counting up from zero, or -1 if not known",
+              "title": "Row Id",
+              "type": "integer"
+            }
+          },
+          "title": "Meta",
+          "type": "object"
+        }
+      },
+      "additionalProperties": true,
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/Meta",
+          "default": {
+            "op": "u",
+            "row_id": -1
+          },
+          "description": "Document metadata"
+        },
+        "submittedAt": {
+          "title": "Submittedat",
+          "type": "integer"
+        },
+        "formId": {
+          "title": "Formid",
+          "type": "string"
+        }
+      },
+      "required": [
+        "submittedAt",
+        "formId"
+      ],
+      "title": "FormSubmission",
+      "type": "object",
+      "x-infer-schema": true
+    },
+    "key": [
+      "/formId",
+      "/submittedAt"
+    ]
   }
 ]


### PR DESCRIPTION
**Description:**

Production `source-hubspot-native` captures are hitting this error:
```
runTransactions: readMessage: Task capture.engagements.incremental: 2 validation errors for BatchResult[Association]
requestedAt
  Extra inputs are not permitted [type=extra_forbidden, input_value=None, input_type=NoneType]
    For further information visit https://errors.pydantic.dev/2.11/v/extra_forbidden
links
  Extra inputs are not permitted [type=extra_forbidden, input_value={}, input_type=dict]
    For further information visit https://errors.pydantic.dev/2.11/v/extra_forbidden
```

It looks like Hubspot added a `requestedAt` and `links` field to the `BatchResult` response. The connector doesn't like these extra fields being present due to the `extra="forbid"` in the model, but it's fine to allow extra fields since the model still validates that the fields we do care about are always present.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

For the sake of getting a fix out fast, I didn't do much testing. But the change is simple & should address the error.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/3207)
<!-- Reviewable:end -->
