### PR TITLE
source-hubspot-native: allow extra fields in responses

### DIFF
--- a/source-hubspot-native/source_hubspot_native/models.py
+++ b/source-hubspot-native/source_hubspot_native/models.py
@@ -157,7 +157,7 @@ class Property(BaseDocument, extra="allow"):
     hubspotObject: str = "unknown"  # Added by us.
 
 
-class Properties(BaseDocument, extra="forbid"):
+class Properties(BaseDocument, extra="allow"):
     results: list[Property]
 
 
@@ -166,7 +166,7 @@ class DealPipeline(BaseDocument, extra="allow"):
     updatedAt: AwareDatetime | None
 
 
-class DealPipelines(BaseDocument, extra="forbid"):
+class DealPipelines(BaseDocument, extra="allow"):
     results: list[DealPipeline]
 
 
@@ -390,12 +390,12 @@ Item = TypeVar("Item")
 
 # Common shape of a v3 API paged listing for a GET request to the objects endpoint for a particular
 # object.
-class PageResult(BaseModel, Generic[Item], extra="forbid"):
-    class Cursor(BaseModel, extra="forbid"):
+class PageResult(BaseModel, Generic[Item], extra="allow"):
+    class Cursor(BaseModel, extra="allow"):
         after: str
         link: str
 
-    class Paging(BaseModel, extra="forbid"):
+    class Paging(BaseModel, extra="allow"):
         next: "PageResult.Cursor"
 
     results: list[Item]
@@ -404,11 +404,11 @@ class PageResult(BaseModel, Generic[Item], extra="forbid"):
 
 # Common shape of a v3 search API listing, which is the same as PageResult but includes a field for
 # the total number of records returned, and doesn't have a "link" in the paging.next object.
-class SearchPageResult(BaseModel, Generic[Item], extra="forbid"):
-    class Cursor(BaseModel, extra="forbid"):
+class SearchPageResult(BaseModel, Generic[Item], extra="allow"):
+    class Cursor(BaseModel, extra="allow"):
         after: str
 
-    class Paging(BaseModel, extra="forbid"):
+    class Paging(BaseModel, extra="allow"):
         next: "SearchPageResult.Cursor"
 
     results: list[Item]
@@ -540,7 +540,7 @@ class EmailEvent(BaseDocument, extra="allow"):
     )
 
 
-class EmailEventsResponse(BaseModel, extra="forbid"):
+class EmailEventsResponse(BaseModel, extra="allow"):
     hasMore: bool
     offset: str
     events: list[EmailEvent]


### PR DESCRIPTION
**Description:**

This PR is a follow up to https://github.com/estuary/connectors/pull/3207. Instead of reactively changing the response models to allow extra fields whenever Hubspot decides to add a few fields, I'd rather proactively prevent connectors from crashing due to extra fields.

There are still a couple `extra="forbid"`s left in some models, but most are for documents that get emitted, and it seems like we would actually care if Hubspot adds extra fields to those.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

