### PR TITLE
source-mysql: Truncate logged RowsQueryEvent

### DIFF
--- a/source-mysql/replication.go
+++ b/source-mysql/replication.go
@@ -449,7 +449,16 @@ func (rs *mysqlReplicationStream) run(ctx context.Context, startCursor mysql.Pos
 			}
 		case *replication.RowsQueryEvent:
 			implicitFlush = true // Implicit FlushEvent conversion permitted
-			logrus.WithField("query", string(data.Query)).Debug("ignoring Rows Query Event")
+			var queryBytes = data.Query
+			var truncated = len(queryBytes) > 200
+			if truncated {
+				queryBytes = queryBytes[:200]
+			}
+			logrus.WithFields(logrus.Fields{
+				"query":        string(queryBytes),
+				"query_length": len(data.Query),
+				"truncated":    truncated,
+			}).Debug("ignoring Rows Query Event")
 		case *replication.IntVarEvent:
 			implicitFlush = true // Implicit FlushEvent conversion permitted
 			logrus.WithField("type", data.Type).WithField("value", data.Value).Debug("ignoring IntVar Event")


### PR DESCRIPTION
**Description:**

Apparently there is no limit on the worst-case size of these queries. They can reach hundreds of megabytes. We can't easily stop the client library from reading them into memory, but we can avoid compounding it with a bytes->string cast of the full value.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/3210)
<!-- Reviewable:end -->
