### PR TITLE
source-jira-native: fetch epics not associated with boards

### DIFF
--- a/source-jira-native/source_jira_native/models.py
+++ b/source-jira-native/source_jira_native/models.py
@@ -535,6 +535,7 @@ class BoardChildStream(FullRefreshStream):
 class Epics(BoardChildStream):
     name: ClassVar[str] = "epics"
     path: ClassVar[str] = "epic"
+    additional_jql: ClassVar[str] = "issueType='Epic'"
 
 
 class Sprints(BoardChildStream):

--- a/source-jira-native/source_jira_native/models.py
+++ b/source-jira-native/source_jira_native/models.py
@@ -529,7 +529,6 @@ class Boards(FullRefreshPaginatedStream):
 
 # Software API child streams
 class BoardChildStream(FullRefreshStream):
-    add_parent_id_to_documents: ClassVar[bool] = True
     api: ClassVar[JiraAPI] = JiraAPI.SOFTWARE
 
 
@@ -541,7 +540,6 @@ class Epics(BoardChildStream):
 class Sprints(BoardChildStream):
     name: ClassVar[str] = "sprints"
     path: ClassVar[str] = "sprint"
-    add_parent_id_to_documents: ClassVar[bool] = False
     disable: ClassVar[bool] = False
 
 


### PR DESCRIPTION
**Description:**

Users have noticed `source-jira-native` is missing epics that aren't associated with any boards. The current strategy of only fetching epics associated with boards obviously won't capture these board-less epics.

Epics can be retrieved using two different approaches:
1. Via boards associated with epics
2. Via an issue search (Jira treats epics as a special type of issue)

We should use both approaches for a few reasons:
- Issue searches find epics that aren't associated with any boards.
- Board-based retrieval handles next-gen issues/epics that can't be fetched via the `/rest/agile/1.0/epic/:epicId` endpoint.
- Board-based retrieval is more API request-efficient than individual epic fetches after an issue search. Multiple epics are returned in a single response when fetching them through associated boards.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

Tested on a local stack. Confirmed `epics` still completes & fetches additional records from the API via an issue search.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/3213)
<!-- Reviewable:end -->
