### PR TITLE
source-pendo: add `Segment` stream

### DIFF
--- a/source-pendo/source_pendo/models.py
+++ b/source-pendo/source_pendo/models.py
@@ -74,6 +74,11 @@ class Report(FullRefreshResource):
     resource_name: ClassVar[str] = "Report"
 
 
+class Segment(FullRefreshResource):
+    entity_name: ClassVar[str] = "segment"
+    resource_name: ClassVar[str] = "Segment"
+
+
 class IncrementalResource(FullRefreshResource):
     primary_keys: ClassVar[list[str]]
     cursor_field: ClassVar[str]
@@ -191,6 +196,7 @@ FULL_REFRESH_RESOURCE_TYPES: list[type[FullRefreshResource]] = [
     Guide,
     Page,
     Report,
+    Segment,
 ]
 
 

--- a/source-pendo/tests/snapshots/snapshots__discover__capture.stdout.json
+++ b/source-pendo/tests/snapshots/snapshots__discover__capture.stdout.json
@@ -188,6 +188,53 @@
     ]
   },
   {
+    "recommendedName": "Segment",
+    "resourceConfig": {
+      "name": "Segment",
+      "interval": "PT5M"
+    },
+    "documentSchema": {
+      "$defs": {
+        "Meta": {
+          "properties": {
+            "op": {
+              "default": "u",
+              "description": "Operation type (c: Create, u: Update, d: Delete)",
+              "enum": [
+                "c",
+                "u",
+                "d"
+              ],
+              "title": "Op",
+              "type": "string"
+            },
+            "row_id": {
+              "default": -1,
+              "description": "Row ID of the Document, counting up from zero, or -1 if not known",
+              "title": "Row Id",
+              "type": "integer"
+            }
+          },
+          "title": "Meta",
+          "type": "object"
+        }
+      },
+      "additionalProperties": true,
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/Meta",
+          "description": "Document metadata"
+        }
+      },
+      "title": "FullRefreshResource",
+      "type": "object",
+      "x-infer-schema": true
+    },
+    "key": [
+      "/_meta/row_id"
+    ]
+  },
+  {
     "recommendedName": "Account",
     "resourceConfig": {
       "name": "Account",


### PR DESCRIPTION
**Description:**

Adds the `Segment` stream, another type of full refresh stream.

Note: The `/aggregation` endpoint does not support a `segments` object source, so we can't use it to query for segments incrementally like other resources.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

Connector documentation should be updated to reflect the new stream.

**Notes for reviewers:**

Tested on a local stack. Confirmed `Segment` captures the expected amount of data based on how many results are returned via the API.