### PR TITLE
source-apple-app-store: finalize implementation

### DIFF
--- a/estuary-cdk/estuary_cdk/gunzip_stream.py
+++ b/estuary-cdk/estuary_cdk/gunzip_stream.py
@@ -1,0 +1,35 @@
+import zlib
+from typing import AsyncGenerator
+
+class GunzipStream:
+    """
+    Incrementally decompress a stream of Gzip-compressed bytes from an async generator.
+    Usage:
+      async for chunk in GunzipStream(async_bytes):
+          ... # process decompressed bytes
+    """
+    def __init__(self, input: AsyncGenerator[bytes, None]):
+        self.input = input
+        self.decompressor = zlib.decompressobj(wbits=16 + zlib.MAX_WBITS)
+        self.done = False
+        self._input_iter = None
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        if self._input_iter is None:
+            self._input_iter = self._stream()
+        return await anext(self._input_iter)
+
+    async def _stream(self):
+        async for chunk in self.input:
+            if not chunk:
+                continue
+            data = self.decompressor.decompress(chunk)
+            if data:
+                yield data
+        # Flush any buffered data at the end of the stream
+        leftover = self.decompressor.flush()
+        if leftover:
+            yield leftover

--- a/estuary-cdk/estuary_cdk/http.py
+++ b/estuary-cdk/estuary_cdk/http.py
@@ -145,12 +145,13 @@ class HTTPSession(abc.ABC):
         params: dict[str, Any] | None = None,
         json: dict[str, Any] | None = None,
         form: dict[str, Any] | None = None,
+        _with_token: bool = True,  # Unstable internal API.
         headers: dict[str, Any] = {},
     ) -> tuple[Headers, BodyGeneratorFunction]:
         """Request a url and and return the raw response as a stream of bytes"""
 
         async def _do_request() -> tuple[Headers, BodyGeneratorFunction]:
-            return await self._request_stream(log, url, method, params, json, form, True, headers)
+            return await self._request_stream(log, url, method, params, json, form, _with_token, headers)
 
         return await self._retry_on_timeout(log, url, method, _do_request)
 

--- a/estuary-cdk/tests/test_gunzip_stream.py
+++ b/estuary-cdk/tests/test_gunzip_stream.py
@@ -1,0 +1,87 @@
+from typing import AsyncGenerator
+import gzip
+import pytest
+from estuary_cdk.gunzip_stream import GunzipStream
+
+
+async def bytes_gen(data: bytes) -> AsyncGenerator[bytes, None]:
+    chunk_size = 10
+    for i in range(0, len(data), chunk_size):
+        yield data[i : i + chunk_size]
+
+
+def create_gzip_content(content: bytes) -> bytes:
+    return gzip.compress(content)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "content, expected",
+    [
+        (b"line1\nline2\nline3\n", b"line1\nline2\nline3\n"),
+        (b"line1\nline2\nline3", b"line1\nline2\nline3"),
+        (b"", b""),
+        (b"single line without newline", b"single line without newline"),
+        (
+            b'{"id": 1, "value": "test1"}\n{"id": 2, "value": "test2"}\n',
+            b'{"id": 1, "value": "test1"}\n{"id": 2, "value": "test2"}\n',
+        ),
+        (b"no newline at end", b"no newline at end"),
+        (b"\n\nline with empty lines\n\n", b"\n\nline with empty lines\n\n"),
+        (b"A" * 1000, b"A" * 1000),  # Test larger content
+        (
+            b"Mixed content with\nnewlines and\ttabs\rand\x00null bytes",
+            b"Mixed content with\nnewlines and\ttabs\rand\x00null bytes",
+        ),
+    ],
+)
+async def test_gunzip_stream(content, expected):
+    gzipped_bytes = create_gzip_content(content)
+
+    actual = b""
+    async for chunk in GunzipStream(bytes_gen(gzipped_bytes)):
+        actual += chunk
+
+    assert actual == expected
+
+
+@pytest.mark.asyncio
+async def test_gunzip_stream_empty_content():
+    gzipped_bytes = create_gzip_content(b"")
+
+    actual = b""
+    async for chunk in GunzipStream(bytes_gen(gzipped_bytes)):
+        actual += chunk
+
+    assert actual == b""
+
+
+@pytest.mark.asyncio
+async def test_gunzip_stream_large_content():
+    large_content = b"This is a test line.\n" * 1000
+    gzipped_bytes = create_gzip_content(large_content)
+
+    actual = b""
+    chunk_count = 0
+    async for chunk in GunzipStream(bytes_gen(gzipped_bytes)):
+        actual += chunk
+        chunk_count += 1
+
+    assert actual == large_content
+    assert chunk_count > 1  # Ensure we got multiple chunks
+
+
+@pytest.mark.asyncio
+async def test_gunzip_stream_single_byte_chunks():
+    content = b"Hello, World!\nThis is a test.\n"
+    gzipped_bytes = create_gzip_content(content)
+
+    async def single_byte_gen(data: bytes) -> AsyncGenerator[bytes, None]:
+        for byte in data:
+            yield bytes([byte])
+
+    actual = b""
+    async for chunk in GunzipStream(single_byte_gen(gzipped_bytes)):
+        actual += chunk
+
+    assert actual == content

--- a/source-apple-app-store/acmeCo/app_crashes.schema.yaml
+++ b/source-apple-app-store/acmeCo/app_crashes.schema.yaml
@@ -27,37 +27,21 @@ properties:
       op: u
       row_id: -1
     description: Document metadata
-  app_id:
-    title: App Id
-    type: string
   Date:
     format: date
     title: Date
+    type: string
+  filename:
+    default: ""
+    title: Filename
     type: string
   row_number:
     description: Row sequence number for deduplication
     title: Row Number
     type: integer
-  App Apple Identifier:
-    title: App Apple Identifier
-    type: string
-  App Version:
-    title: App Version
-    type: string
-  Device:
-    title: Device
-    type: string
-  Platform Version:
-    title: Platform Version
-    type: string
 required:
-  - app_id
   - Date
   - row_number
-  - App Apple Identifier
-  - App Version
-  - Device
-  - Platform Version
 title: AppCrashesReportRow
 type: object
 x-infer-schema: true

--- a/source-apple-app-store/acmeCo/app_downloads_detailed.schema.yaml
+++ b/source-apple-app-store/acmeCo/app_downloads_detailed.schema.yaml
@@ -19,7 +19,7 @@ $defs:
     title: Meta
     type: object
 additionalProperties: true
-description: "References:\n    - https://developer.apple.com/documentation/analytics-reports/app-sessions"
+description: "References:\n    - https://developer.apple.com/documentation/analytics-reports/app-download"
 properties:
   _meta:
     $ref: "#/$defs/Meta"
@@ -32,6 +32,7 @@ properties:
     title: Date
     type: string
   filename:
+    default: ""
     title: Filename
     type: string
   row_number:
@@ -40,8 +41,7 @@ properties:
     type: integer
 required:
   - Date
-  - filename
   - row_number
-title: AppSessionsDetailedReportRow
+title: AppDownloadsDetailedReportRow
 type: object
 x-infer-schema: true

--- a/source-apple-app-store/acmeCo/app_sessions_detailed.schema.yaml
+++ b/source-apple-app-store/acmeCo/app_sessions_detailed.schema.yaml
@@ -19,7 +19,7 @@ $defs:
     title: Meta
     type: object
 additionalProperties: true
-description: "References:\n    - https://developer.apple.com/documentation/analytics-reports/app-installs"
+description: "References:\n    - https://developer.apple.com/documentation/analytics-reports/app-sessions"
 properties:
   _meta:
     $ref: "#/$defs/Meta"
@@ -27,41 +27,21 @@ properties:
       op: u
       row_id: -1
     description: Document metadata
-  app_id:
-    title: App Id
-    type: string
   Date:
     format: date
     title: Date
+    type: string
+  filename:
+    default: ""
+    title: Filename
     type: string
   row_number:
     description: Row sequence number for deduplication
     title: Row Number
     type: integer
-  App Apple Identifier:
-    title: App Apple Identifier
-    type: string
-  App Version:
-    title: App Version
-    type: string
-  Device:
-    title: Device
-    type: string
-  Platform Version:
-    title: Platform Version
-    type: string
-  Event Type:
-    title: Event Type
-    type: string
 required:
-  - app_id
   - Date
   - row_number
-  - App Apple Identifier
-  - App Version
-  - Device
-  - Platform Version
-  - Event Type
-title: AppStoreInstallsReportRow
+title: AppSessionsDetailedReportRow
 type: object
 x-infer-schema: true

--- a/source-apple-app-store/acmeCo/app_store_discovery_and_engagement_detailed.schema.yaml
+++ b/source-apple-app-store/acmeCo/app_store_discovery_and_engagement_detailed.schema.yaml
@@ -19,7 +19,7 @@ $defs:
     title: Meta
     type: object
 additionalProperties: true
-description: "References:\n    - https://developer.apple.com/documentation/analytics-reports/app-download"
+description: "References:\n    - https://developer.apple.com/documentation/analytics-reports/app-store-discovery-and-engagement"
 properties:
   _meta:
     $ref: "#/$defs/Meta"
@@ -27,37 +27,21 @@ properties:
       op: u
       row_id: -1
     description: Document metadata
-  app_id:
-    title: App Id
-    type: string
   Date:
     format: date
     title: Date
+    type: string
+  filename:
+    default: ""
+    title: Filename
     type: string
   row_number:
     description: Row sequence number for deduplication
     title: Row Number
     type: integer
-  App Apple Identifier:
-    title: App Apple Identifier
-    type: string
-  App Version:
-    title: App Version
-    type: string
-  Device:
-    title: Device
-    type: string
-  Platform Version:
-    title: Platform Version
-    type: string
 required:
-  - app_id
   - Date
   - row_number
-  - App Apple Identifier
-  - App Version
-  - Device
-  - Platform Version
-title: AppDownloadsReportRow
+title: AppStoreDiscoveryAndEngagementDetailedReportRow
 type: object
 x-infer-schema: true

--- a/source-apple-app-store/acmeCo/app_store_installs_and_deletions_detailed.schema.yaml
+++ b/source-apple-app-store/acmeCo/app_store_installs_and_deletions_detailed.schema.yaml
@@ -19,7 +19,7 @@ $defs:
     title: Meta
     type: object
 additionalProperties: true
-description: "References:\n    - https://developer.apple.com/documentation/analytics-reports/app-store-discovery-and-engagement"
+description: "References:\n    - https://developer.apple.com/documentation/analytics-reports/app-installs"
 properties:
   _meta:
     $ref: "#/$defs/Meta"
@@ -27,37 +27,21 @@ properties:
       op: u
       row_id: -1
     description: Document metadata
-  app_id:
-    title: App Id
-    type: string
   Date:
     format: date
     title: Date
+    type: string
+  filename:
+    default: ""
+    title: Filename
     type: string
   row_number:
     description: Row sequence number for deduplication
     title: Row Number
     type: integer
-  App Apple Identifier:
-    title: App Apple Identifier
-    type: string
-  Device:
-    title: Device
-    type: string
-  Platform Version:
-    title: Platform Version
-    type: string
-  Event Type:
-    title: Event Type
-    type: string
 required:
-  - app_id
   - Date
   - row_number
-  - App Apple Identifier
-  - Device
-  - Platform Version
-  - Event Type
-title: AppStoreDiscoveryAndEngagementReportRow
+title: AppStoreInstallsDetailedReportRow
 type: object
 x-infer-schema: true

--- a/source-apple-app-store/acmeCo/flow.yaml
+++ b/source-apple-app-store/acmeCo/flow.yaml
@@ -3,22 +3,12 @@ collections:
   acmeCo/app_crashes:
     schema: app_crashes.schema.yaml
     key:
-      - /App Apple Identifier
-      - /App Version
-      - /Date
-      - /Device
-      - /Platform Version
-      - /app_id
+      - /filename
       - /row_number
-  acmeCo/app_downloads:
-    schema: app_downloads.schema.yaml
+  acmeCo/app_downloads_detailed:
+    schema: app_downloads_detailed.schema.yaml
     key:
-      - /App Apple Identifier
-      - /App Version
-      - /Date
-      - /Device
-      - /Platform Version
-      - /app_id
+      - /filename
       - /row_number
   acmeCo/app_reviews:
     schema: app_reviews.schema.yaml
@@ -28,28 +18,20 @@ collections:
   acmeCo/app_sessions:
     schema: app_sessions.schema.yaml
     key:
-      - /App Apple Identifier
-      - /App Version
-      - /Date
-      - /Device
-      - /app_id
+      - /filename
       - /row_number
-  acmeCo/app_store_discovery_and_engagement:
-    schema: app_store_discovery_and_engagement.schema.yaml
+  acmeCo/app_sessions_detailed:
+    schema: app_sessions_detailed.schema.yaml
     key:
-      - /App Apple Identifier
-      - /Date
-      - /Event Type
-      - /Platform Version
-      - /app_id
+      - /filename
       - /row_number
-  acmeCo/app_store_installs_and_deletions:
-    schema: app_store_installs_and_deletions.schema.yaml
+  acmeCo/app_store_discovery_and_engagement_detailed:
+    schema: app_store_discovery_and_engagement_detailed.schema.yaml
     key:
-      - /App Apple Identifier
-      - /App Version
-      - /Date
-      - /Event Type
-      - /Platform Version
-      - /app_id
+      - /filename
+      - /row_number
+  acmeCo/app_store_installs_and_deletions_detailed:
+    schema: app_store_installs_and_deletions_detailed.schema.yaml
+    key:
+      - /filename
       - /row_number

--- a/source-apple-app-store/source_apple_app_store/api.py
+++ b/source-apple-app-store/source_apple_app_store/api.py
@@ -1,15 +1,14 @@
 import asyncio
 from datetime import UTC, date, datetime, timedelta
 from logging import Logger
-from typing import AsyncGenerator, Optional
+from typing import AsyncGenerator
 
 from estuary_cdk.capture.common import LogCursor, PageCursor
 from estuary_cdk.http import HTTPError
 
 from source_apple_app_store.utils import (
-    dt_to_str,
     str_to_date,
-    str_to_dt,
+    date_to_str,
 )
 
 from .client import AppleAppStoreClient
@@ -51,7 +50,7 @@ async def _get_or_create_analytics_report_request(
             )
 
             for report_req in report_requests:
-                if report_req.attributes.stoppingDueToInactivity:
+                if report_req.attributes.stoppedDueToInactivity:
                     log.warning(
                         f"Found report request with id {report_req.id}, but the report is inactive due to inactivity."
                     )
@@ -73,92 +72,46 @@ async def _get_or_create_analytics_report_request(
     return report_request_id
 
 
-async def _select_valid_report_instance(
+async def _select_valid_report_instances(
     log: Logger,
     client: AppleAppStoreClient,
-    app_id: str,
     model: type[AppleAnalyticsRow],
     report_request_id: str,
     granularity: AnalyticsReportGranularity,
-    start_date: Optional[date] = None,
-    end_date: Optional[date] = None,
-) -> Optional[AnalyticsReportInstance]:
+    start_date: date | None = None,
+    end_date: date | None = None,
+) -> list[AnalyticsReportInstance]:
     analytics_reports = await client.list_analytics_reports(report_request_id)
-    log.debug(
-        f"Found {len(analytics_reports)} analytics report(s) for app {app_id}",
-        {
-            "report_name": model.report_name,
-            "report_request_id": report_request_id,
-        },
-    )
 
+    target_report = None
     for report in analytics_reports:
         report_details = await client.get_analytics_report_details(report.id)
-        if report_details.attributes.name != model.report_name:
-            log.debug(
-                f"Skipping report {report_details.attributes.name}",
-                {
-                    "report_request_id": report_request_id,
-                    "report_id": report.id,
-                    "report_name": model.report_name,
-                    "response_report_name": report_details.attributes.name,
-                },
-            )
+        if report_details.attributes.name == model.report_name:
+            target_report = report
+            break
+
+    if not target_report:
+        return []
+
+    report_instances = await client.list_analytic_report_instances(
+        target_report.id,
+        granularity,
+    )
+
+    valid_instances = []
+    for instance in report_instances:
+        if instance.attributes.granularity != granularity:
             continue
 
-        log.debug(f"Found report {report_details.attributes.name}")
-        report_instances = await client.list_analytic_report_instances(
-            report.id,
-            granularity,
-        )
-        log.debug(f"Found {len(report_instances)} instances")
+        processing_date = instance.attributes.processingDate
+        if start_date and processing_date < start_date:
+            continue
+        if end_date and processing_date > end_date:
+            continue
 
-        for instance in report_instances:
-            if start_date:
-                if instance.attributes.processingDate < start_date:
-                    log.debug(
-                        f"Skipping analytics report instance {instance.id} for app {app_id} because the processing date is before {start_date}",
-                        {
-                            "report_name": model.report_name,
-                            "report_request_id": report_request_id,
-                            "report_id": report.id,
-                            "instance_id": instance.id,
-                            "start_date": start_date,
-                            "end_date": end_date,
-                        },
-                    )
-                    continue
-            elif end_date:
-                if instance.attributes.processingDate > end_date:
-                    log.debug(
-                        f"Skipping analytics report instance {instance.id} for app {app_id} because the processing date is after {end_date}",
-                        {
-                            "report_name": model.report_name,
-                            "report_request_id": report_request_id,
-                            "report_id": report.id,
-                            "instance_id": instance.id,
-                            "start_date": start_date,
-                            "end_date": end_date,
-                        },
-                    )
-                    continue
-            elif instance.attributes.granularity != granularity:
-                log.debug(
-                    f"Skipping analytics report instance {instance.id} for app {app_id} because the granularity is not {granularity}",
-                    {
-                        "report_name": model.report_name,
-                        "report_request_id": report_request_id,
-                        "report_id": report.id,
-                        "instance_id": instance.id,
-                        "start_date": start_date,
-                        "end_date": end_date,
-                    },
-                )
-                continue
+        valid_instances.append(instance)
 
-            return instance
-
-    return None
+    return valid_instances
 
 
 async def _stream_analytics_report_data(
@@ -188,11 +141,12 @@ async def _stream_analytics_report_data(
                 "report_name": model.report_name,
                 "instance_id": instance.id,
                 "segment_id": segment.id,
+                "segment_filename": segment.filename,
             },
         )
 
         async for row in client.stream_tsv_data(
-            app_id, segment.attributes.url, model
+            segment.filename, segment.attributes.url, model
         ):
             yield row
 
@@ -207,11 +161,8 @@ async def _ongoing_analytics_report_request_exists(
     )
 
     for report_request in report_requests:
-        if (
-            report_request.attributes.accessType
-            == AnalyticsReportAccessType.ONGOING
-        ):
-            if not report_request.attributes.stoppingDueToInactivity:
+        if report_request.attributes.accessType == AnalyticsReportAccessType.ONGOING:
+            if not report_request.attributes.stoppedDueToInactivity:
                 return True
 
     return False
@@ -226,15 +177,7 @@ async def fetch_incremental_analytics(
 ) -> AsyncGenerator[AppleAnalyticsRow | LogCursor, None]:
     assert isinstance(log_cursor, datetime)
 
-    # The code below this return is a best-effort implementation to fetch the analytics report data
-    # based on Apple App Store Connect API documentation. It boils down to the following steps:
-    # 1. Get or create the ONGOING analytics report request for the app.
-    # 2. Get the report request ID for the ONGOING report request.
-    # 3. Select a valid report instance for the app and model based on the log_cursor.
-    # 4. Stream the analytics report data for the report instance.
-    #
-    # Once we have valid credentials, development can continue and we can iterate on the code.
-    return
+    last_processed_date = log_cursor
 
     report_request_id = await _get_or_create_analytics_report_request(
         log,
@@ -244,16 +187,22 @@ async def fetch_incremental_analytics(
     )
 
     now = datetime.now(tz=UTC)
-    current_lag = now - log_cursor
+    current_lag = now.date() - last_processed_date
+    start_date = last_processed_date + timedelta(days=1)
 
-    report_instance = await _select_valid_report_instance(
+    report_instances = await _select_valid_report_instances(
         log,
         client,
-        app_id,
         model,
         report_request_id,
         AnalyticsReportGranularity.DAILY,
-        log_cursor.date(),
+        start_date,
+    )
+
+    report_instance = min(
+        report_instances,
+        key=lambda x: x.attributes.processingDate,
+        default=None,
     )
 
     if not report_instance:
@@ -267,27 +216,8 @@ async def fetch_incremental_analytics(
                 "current_lag": current_lag,
             },
         )
-        if current_lag > model.completeness_lag:
-            new_cursor = (log_cursor + timedelta(days=1)).replace(
-                hour=0, minute=0, second=0, microsecond=0
-            )
-
-            log.warning(
-                "Yielding a new cursor to continue incremental processing in case the report does not have data for the current date.",
-                {
-                    "report_name": model.report_name,
-                    "previous_log_cursor": log_cursor,
-                    "new_log_cursor": new_cursor,
-                    "completeness_lag": model.completeness_lag,
-                    "current_lag": current_lag,
-                },
-            )
-            yield new_cursor
 
         return
-
-    processed_report_for_date = False
-    doc_count = 0
 
     async for row in _stream_analytics_report_data(
         log,
@@ -296,38 +226,13 @@ async def fetch_incremental_analytics(
         model,
         report_instance,
     ):
-        processed_report_for_date = True
-        if row.record_date > log_cursor:
-            doc_count += 1
-            yield row
+        yield row
 
-    if processed_report_for_date:
-        new_cursor = (log_cursor + timedelta(days=1)).replace(
-            hour=0, minute=0, second=0, microsecond=0
-        )
-        log.info(
-            "Incremental processing completed",
-            {
-                "report_name": model.report_name,
-                "previous_log_cursor": log_cursor,
-                "new_log_cursor": new_cursor,
-                "doc_count": doc_count,
-            },
-        )
-        yield new_cursor
-    else:
-        # This may indicate that the report did not have any data segments even though there
-        # was a report instance with a processed date matching our log_cursor. Return without
-        # yielding a new cursor in case the report is not yet available, yet shown in the API.
-        log.warning(
-            "No data segments found for report",
-            {
-                "report_name": model.report_name,
-                "log_cursor": log_cursor,
-                "report_instance_id": report_instance.id,
-            },
-        )
-        return
+    new_cursor = datetime.combine(
+        report_instance.attributes.processingDate, datetime.min.time()
+    ).replace(tzinfo=UTC)
+
+    yield new_cursor
 
 
 async def fetch_backfill_analytics(
@@ -335,7 +240,7 @@ async def fetch_backfill_analytics(
     app_id: str,
     model: type[AppleAnalyticsRow],
     log: Logger,
-    page: Optional[PageCursor],
+    page: PageCursor | None,
     cutoff: LogCursor,
 ) -> AsyncGenerator[AppleAnalyticsRow | PageCursor, None]:
     """
@@ -349,157 +254,88 @@ async def fetch_backfill_analytics(
         1. Parse page cursor to determine target report instance processed date and last check time
         2. Verify an ONGOING analytics report request exists for the app
         3. Get or create a ONE_TIME_SNAPSHOT analytics report request
-        4. Look for report instance with the target processed date (within cutoff + completeness_lag range)
-        5. If found: stream data and advance to next processed date
-        6. If not found: check if we've waited long enough (> completeness_lag) to give up or continue waiting
-
-    Page Cursor Format:
-        "YYYY-MM-DD:ISO_DATETIME" where:
-        - YYYY-MM-DD: Target processed date for the report instance we're waiting for
-        - ISO_DATETIME: When we last checked for this report instance (to calculate wait time since reports can take time to generate)
-
-    Completion Logic:
-        - Backfill completes when (next_processed_date - completeness_lag) > cutoff - i.e., the reports oldest data is past the cutoff date
-        - This ensures the next report instance would only contain data already handled by incremental
-        - If no report instance found after waiting > completeness_lag, backfill terminates
-
-    Wait Logic:
-        - If target report instance not found and wait time > completeness_lag: terminate backfill
-        - If target report instance not found and wait time <= completeness_lag: yield cursor to wait longer
+        4. Look for report instance with the target processed date > page (last_processed_date)
 
     Notes:
-        - Report instances are expected to have processed dates in chronological order; However, it is uknown if there
-        are gaps in the processed dates. If that is the case, the wait and completion logic will change to handle this.
+        - Report instances are expected to have processed dates in chronological order. This has been observed in testing.
         - Only processes data if an ONGOING report request exists (prerequisite for proper setup); Does not guarantee data completeness since the ONE_TIME_SNAPSHOT
         could have still been created before the ONGOING report request was created. There is no way to know the creation time of these requests according to documentation.
-        - Report instances contain data from processed_date back to (processed_date - completeness_lag)
-        - Completeness lag varies by report type (48 hours to 5+ days per Apple documentation)
-        - Initial run starts from 1970-01-01 to find the oldest available report instance
     """
 
     assert isinstance(cutoff, datetime)
     assert page is None or isinstance(page, str)
 
-    # The code below this return is a best-effort implementation to fetch the analytics report data
-    # based on Apple App Store Connect API documentation. It boils down to the following steps:
-    # 1. Get or create the ONE_TIME_SNAPSHOT analytics report request for the app if there is an ONGOING report request.
-    # 2. Get the report request ID for the ONE_TIME_SNAPSHOT report request.
-    # 3. Select a valid report instance for the app and model based on the page cursor.
-    # 4. Stream the analytics report data for the report instance.
-    # 5. Stop when the next processed date is greater than the cutoff date or there are no more report instances to process.
-    #
-    # Once we have valid credentials, development can continue and we can iterate on the code.
-    return
-
     if not page:
-        next_processed_date = date.fromisoformat("1970-01-01")
-        last_checked_datetime = None
+        last_processed_date = date.fromisoformat("1970-01-01")
+        start_date = last_processed_date
     else:
-        parts = page.split(":")
-        assert len(parts) == 2, f"Invalid page format: {page}"
-
-        next_processed_date = str_to_date(parts[0])
-        last_checked_datetime = str_to_dt(parts[1])
+        last_processed_date = str_to_date(page)
+        start_date = last_processed_date + timedelta(days=1)
 
     ongoing_report_exists = await _ongoing_analytics_report_request_exists(
         client,
         app_id,
     )
 
-    if ongoing_report_exists:
-        report_request_id = await _get_or_create_analytics_report_request(
-            log,
-            client,
-            app_id,
-            AnalyticsReportAccessType.ONE_TIME_SNAPSHOT,
+    if not ongoing_report_exists:
+        log.warning(
+            f"Delaying backfill for {model.report_name} since an ONGOING report request does not exist for {app_id} yet. "
+            "Backfill requires an existing ONGOING report request to ensure proper data continuity.",
+            {
+                "app_id": app_id,
+                "report_name": model.report_name,
+            },
+        )
+        await asyncio.sleep(30)
+        yield date_to_str(last_processed_date)
+        return
+
+    report_request_id = await _get_or_create_analytics_report_request(
+        log,
+        client,
+        app_id,
+        AnalyticsReportAccessType.ONE_TIME_SNAPSHOT,
+    )
+
+    report_instances = await _select_valid_report_instances(
+        log,
+        client,
+        model,
+        report_request_id,
+        AnalyticsReportGranularity.DAILY,
+        start_date,
+    )
+
+    report_instance = min(
+        report_instances,
+        key=lambda x: x.attributes.processingDate,
+        default=None,
+    )
+
+    if not report_instance:
+        log.warning(
+            f"Report instance not found for app {app_id} and report request {report_request_id}",
+            {
+                "app_id": app_id,
+                "report_name": model.report_name,
+                "report_request_id": report_request_id,
+            },
         )
 
-        log.debug(
-            f"Found or created report request {report_request_id} for app {app_id}"
-        )
-
-        report_instance_check_datetime = datetime.now(tz=UTC)
-        end_date = cutoff + model.completeness_lag
-        current_lag = (
-            (report_instance_check_datetime - last_checked_datetime)
-            if last_checked_datetime
-            else None
-        )
-
-        report_instance = await _select_valid_report_instance(
+        yield date_to_str(last_processed_date)
+    else:
+        async for row in _stream_analytics_report_data(
             log,
             client,
             app_id,
             model,
-            report_request_id,
-            AnalyticsReportGranularity.DAILY,
-            next_processed_date,
-            end_date,
-        )
-
-        if (
-            not report_instance
-            and current_lag
-            and current_lag > model.completeness_lag
+            report_instance,
         ):
-            # Only complete backfill if the current lag is greater than the completeness lag
-            # otherwise, we may still be waiting for the report to be generated by Apple
-            log.warning(
-                f"Report instance not found after {model.completeness_lag} days. Report request may be outdated.",
-                {
-                    "app_id": app_id,
-                    "report_name": model.report_name,
-                    "report_request_id": report_request_id,
-                },
-            )
-            return
+            if row.record_date <= cutoff.date():
+                yield row
 
-        if not report_instance:
-            log.warning(
-                f"Report instance not found for app {app_id} and report request {report_request_id}",
-                {
-                    "app_id": app_id,
-                    "report_name": model.report_name,
-                    "report_request_id": report_request_id,
-                },
-            )
-
-            cursor = f"{next_processed_date}:{dt_to_str(report_instance_check_datetime)}"
-            yield cursor
-        else:
-            async for row in _stream_analytics_report_data(
-                log,
-                client,
-                app_id,
-                model,
-                report_instance,
-            ):
-                if row.record_date <= cutoff:
-                    yield row
-
-            new_processed_date = next_processed_date + timedelta(days=1)
-            new_processed_start_date = (
-                new_processed_date - model.completeness_lag
-            )
-
-            if new_processed_start_date > cutoff:
-                # Data completeness lag tells us that the next report date we would try to process would only contain data that is for new data
-                # that the incremental task is already responsible for processing.
-                log.debug(
-                    f"Completed backfilling {model.report_name} for {app_id}. The next date to process will only contain data from {new_processed_start_date} to {new_processed_date}",
-                    {
-                        "last_processed_date": next_processed_date,
-                        "last_checked_datetime": last_checked_datetime,
-                        "next_processed_start_date": new_processed_start_date,
-                        "next_processed_date": new_processed_date,
-                        "end_date": end_date,
-                    },
-                )
-                return
-
-            # Emit a checkpoint for the backfill to process the next processed date with an updated last report instance check datetime
-            cursor = f"{new_processed_date}:{dt_to_str(report_instance_check_datetime)}"
-            yield cursor
+        if report_instance.attributes.processingDate <= cutoff.date():
+            yield date_to_str(report_instance.attributes.processingDate)
 
 
 async def fetch_incremental_reviews(
@@ -509,8 +345,6 @@ async def fetch_incremental_reviews(
     log_cursor: LogCursor,
 ) -> AsyncGenerator[AppReview | LogCursor, None]:
     assert isinstance(log_cursor, datetime)
-
-    return
 
     cursor = None
     max_created_date = log_cursor
@@ -525,9 +359,7 @@ async def fetch_incremental_reviews(
             if review.attributes.createdDate >= log_cursor:
                 review.app_id = app_id
                 yield review
-                max_created_date = max(
-                    max_created_date, review.attributes.createdDate
-                )
+                max_created_date = max(max_created_date, review.attributes.createdDate)
                 found_new_reviews = True
             else:
                 # Reviews are ordered by newest first, so we can stop iterating
@@ -548,13 +380,11 @@ async def fetch_backfill_reviews(
     client: AppleAppStoreClient,
     app_id: str,
     log: Logger,
-    page_cursor: Optional[PageCursor],
+    page_cursor: PageCursor | None,
     cutoff: LogCursor,
 ) -> AsyncGenerator[AppReview | PageCursor, None]:
     assert isinstance(cutoff, datetime)
     assert page_cursor is None or isinstance(page_cursor, str)
-
-    return
 
     reviews, cursor = await client.list_app_reviews(app_id, page_cursor)
 

--- a/source-apple-app-store/source_apple_app_store/client.py
+++ b/source-apple-app-store/source_apple_app_store/client.py
@@ -111,7 +111,7 @@ class AppleAppStoreClient:
         app_id: str,
         report_type: AnalyticsReportAccessType,
     ) -> AnalyticsReportRequest:
-        url = f"{API_BASE}/apps/{app_id}/analyticsReportRequests"
+        url = f"{API_BASE}/analyticsReportRequests"
 
         body = {
             "data": {
@@ -153,7 +153,7 @@ class AppleAppStoreClient:
 
         url = f"{API_BASE}/apps/{app_id}/analyticsReportRequests"
         params = {
-            "fields[analyticsReportRequests]": "accessType,stoppingDueToInactivity",
+            "fields[analyticsReportRequests]": "accessType,stoppedDueToInactivity",
             "filter[accessType]": access_type.value,
             "limit": limit,
         }
@@ -270,6 +270,7 @@ class AppleAppStoreClient:
                 app_id,
                 report_type,
             )
+            self.log.debug(f"Created report request {created_report_request.id} for app {app_id}")
             return created_report_request.id
         except HTTPError as e:
             if e.code == 409:
@@ -278,6 +279,7 @@ class AppleAppStoreClient:
                     report_type,
                 )
                 for request in report_requests:
+                    self.log.debug(f"Checking request {request.id} for app {app_id}")
                     # assuming there is only one request
                     return request.id
             raise

--- a/source-apple-app-store/source_apple_app_store/models.py
+++ b/source-apple-app-store/source_apple_app_store/models.py
@@ -1,5 +1,4 @@
-import csv
-import os
+from urllib.parse import urlparse
 from datetime import datetime, date, timedelta
 from enum import StrEnum
 from logging import Logger
@@ -183,7 +182,7 @@ class AppleAnalyticsRow(BaseDocument):
     )
 
     record_date: date = Field(..., alias="Date")
-    filename: str = Field(default="")
+    filename: str
     row_number: int = Field(description="Row sequence number for deduplication")
 
     @model_validator(mode="before")
@@ -288,8 +287,6 @@ class AnalyticsReportSegment(BaseModel, extra="allow"):
 
     @model_validator(mode="after")
     def extract_filename_from_url(self):
-        from urllib.parse import urlparse
-
         url = self.attributes.url
         parsed_url = urlparse(url)
 

--- a/source-apple-app-store/source_apple_app_store/resources.py
+++ b/source-apple-app-store/source_apple_app_store/resources.py
@@ -20,24 +20,24 @@ from .models import (
     ApiFetchChangesFn,
     ApiFetchPageFn,
     AppCrashesReportRow,
-    AppDownloadsReportRow,
+    AppDownloadsDetailedReportRow,
     AppleAnalyticsRow,
     AppleResource,
     AppReview,
-    AppSessionsReportRow,
-    AppStoreDiscoveryAndEngagementReportRow,
-    AppStoreInstallsReportRow,
+    AppSessionsDetailedReportRow,
+    AppStoreDiscoveryAndEngagementDetailedReportRow,
+    AppStoreInstallsDetailedReportRow,
     ConnectorState,
     EndpointConfig,
     ResourceState,
 )
 
 ANALYTICS_RESOURCES: list[type[AppleAnalyticsRow]] = [
-    AppSessionsReportRow,
+    AppSessionsDetailedReportRow,
     AppCrashesReportRow,
-    AppDownloadsReportRow,
-    AppStoreInstallsReportRow,
-    AppStoreDiscoveryAndEngagementReportRow,
+    AppDownloadsDetailedReportRow,
+    AppStoreInstallsDetailedReportRow,
+    AppStoreDiscoveryAndEngagementDetailedReportRow,
 ]
 API_RESOURCES: list[
     tuple[type[AppleResource], ApiFetchPageFn, ApiFetchChangesFn]

--- a/source-apple-app-store/source_apple_app_store/utils.py
+++ b/source-apple-app-store/source_apple_app_store/utils.py
@@ -14,3 +14,6 @@ def str_to_dt(string: str) -> datetime:
 
 def str_to_date(string: str) -> date:
     return datetime.strptime(string, DATE_STRING_FORMAT).date()
+
+def date_to_str(date: date) -> str:
+    return date.strftime(DATE_STRING_FORMAT)

--- a/source-apple-app-store/test.flow.yaml
+++ b/source-apple-app-store/test.flow.yaml
@@ -25,26 +25,28 @@ captures:
             - "789"
     bindings:
       - resource:
-          name: app_sessions
+          name: app_sessions_detailed
           interval: PT1H
-        target: acmeCo/app_sessions
+        target: acmeCo/app_sessions_detailed
       - resource:
           name: app_crashes
           interval: PT1H
         target: acmeCo/app_crashes
       - resource:
-          name: app_downloads
+          name: app_downloads_detailed
           interval: PT1H
-        target: acmeCo/app_downloads
+        target: acmeCo/app_downloads_detailed
       - resource:
-          name: app_store_installs_and_deletions
+          name: app_store_installs_and_deletions_detailed
           interval: PT1H
-        target: acmeCo/app_store_installs_and_deletions
+        target: acmeCo/app_store_installs_and_deletions_detailed
       - resource:
-          name: app_store_discovery_and_engagement
+          name: app_store_discovery_and_engagement_detailed
           interval: PT1H
-        target: acmeCo/app_store_discovery_and_engagement
+        target: acmeCo/app_store_discovery_and_engagement_detailed
       - resource:
           name: app_reviews
           interval: PT1H
         target: acmeCo/app_reviews
+    shards:
+      logLevel: debug

--- a/source-apple-app-store/tests/snapshots/snapshots__discover__stdout.json
+++ b/source-apple-app-store/tests/snapshots/snapshots__discover__stdout.json
@@ -38,64 +38,39 @@
           "$ref": "#/$defs/Meta",
           "description": "Document metadata"
         },
-        "app_id": {
-          "title": "App Id",
-          "type": "string"
-        },
         "Date": {
           "format": "date",
           "title": "Date",
+          "type": "string"
+        },
+        "filename": {
+          "title": "Filename",
           "type": "string"
         },
         "row_number": {
           "description": "Row sequence number for deduplication",
           "title": "Row Number",
           "type": "integer"
-        },
-        "App Apple Identifier": {
-          "title": "App Apple Identifier",
-          "type": "string"
-        },
-        "App Version": {
-          "title": "App Version",
-          "type": "string"
-        },
-        "Device": {
-          "title": "Device",
-          "type": "string"
-        },
-        "Platform Version": {
-          "title": "Platform Version",
-          "type": "string"
         }
       },
       "required": [
-        "app_id",
         "Date",
-        "row_number",
-        "App Apple Identifier",
-        "App Version",
-        "Device",
-        "Platform Version"
+        "filename",
+        "row_number"
       ],
       "title": "AppCrashesReportRow",
       "type": "object",
       "x-infer-schema": true
     },
     "key": [
-      "/App Apple Identifier",
-      "/App Version",
-      "/Date",
-      "/Device",
-      "/Platform Version",
-      "/app_id",
+      "/filename",
       "/row_number"
     ]
   },
   {
-    "recommendedName": "app_downloads",
+    "recommendedName": "app_downloads_detailed",
     "resourceConfig": {
-      "name": "app_downloads",
+      "name": "app_downloads_detailed",
       "interval": "PT1H"
     },
     "documentSchema": {
@@ -131,57 +106,32 @@
           "$ref": "#/$defs/Meta",
           "description": "Document metadata"
         },
-        "app_id": {
-          "title": "App Id",
-          "type": "string"
-        },
         "Date": {
           "format": "date",
           "title": "Date",
+          "type": "string"
+        },
+        "filename": {
+          "title": "Filename",
           "type": "string"
         },
         "row_number": {
           "description": "Row sequence number for deduplication",
           "title": "Row Number",
           "type": "integer"
-        },
-        "App Apple Identifier": {
-          "title": "App Apple Identifier",
-          "type": "string"
-        },
-        "App Version": {
-          "title": "App Version",
-          "type": "string"
-        },
-        "Device": {
-          "title": "Device",
-          "type": "string"
-        },
-        "Platform Version": {
-          "title": "Platform Version",
-          "type": "string"
         }
       },
       "required": [
-        "app_id",
         "Date",
-        "row_number",
-        "App Apple Identifier",
-        "App Version",
-        "Device",
-        "Platform Version"
+        "filename",
+        "row_number"
       ],
-      "title": "AppDownloadsReportRow",
+      "title": "AppDownloadsDetailedReportRow",
       "type": "object",
       "x-infer-schema": true
     },
     "key": [
-      "/App Apple Identifier",
-      "/App Version",
-      "/Date",
-      "/Device",
-      "/Platform Version",
-      "/app_id",
+      "/filename",
       "/row_number"
     ]
   },
@@ -265,9 +215,9 @@
     ]
   },
   {
-    "recommendedName": "app_sessions",
+    "recommendedName": "app_sessions_detailed",
     "resourceConfig": {
-      "name": "app_sessions",
+      "name": "app_sessions_detailed",
       "interval": "PT1H"
     },
     "documentSchema": {
@@ -303,58 +253,39 @@
           "$ref": "#/$defs/Meta",
           "description": "Document metadata"
         },
-        "app_id": {
-          "title": "App Id",
-          "type": "string"
-        },
         "Date": {
           "format": "date",
           "title": "Date",
+          "type": "string"
+        },
+        "filename": {
+          "title": "Filename",
           "type": "string"
         },
         "row_number": {
           "description": "Row sequence number for deduplication",
           "title": "Row Number",
           "type": "integer"
-        },
-        "App Apple Identifier": {
-          "title": "App Apple Identifier",
-          "type": "string"
-        },
-        "App Version": {
-          "title": "App Version",
-          "type": "string"
-        },
-        "Device": {
-          "title": "Device",
-          "type": "string"
         }
       },
       "required": [
-        "app_id",
         "Date",
-        "row_number",
-        "App Apple Identifier",
-        "App Version",
-        "Device"
+        "filename",
+        "row_number"
       ],
-      "title": "AppSessionsReportRow",
+      "title": "AppSessionsDetailedReportRow",
       "type": "object",
       "x-infer-schema": true
     },
     "key": [
-      "/App Apple Identifier",
-      "/App Version",
-      "/Date",
-      "/Device",
-      "/app_id",
+      "/filename",
       "/row_number"
     ]
   },
   {
-    "recommendedName": "app_store_discovery_and_engagement",
+    "recommendedName": "app_store_discovery_and_engagement_detailed",
     "resourceConfig": {
-      "name": "app_store_discovery_and_engagement",
+      "name": "app_store_discovery_and_engagement_detailed",
       "interval": "PT1H"
     },
     "documentSchema": {
@@ -390,63 +321,39 @@
           "$ref": "#/$defs/Meta",
           "description": "Document metadata"
         },
-        "app_id": {
-          "title": "App Id",
-          "type": "string"
-        },
         "Date": {
           "format": "date",
           "title": "Date",
+          "type": "string"
+        },
+        "filename": {
+          "title": "Filename",
           "type": "string"
         },
         "row_number": {
           "description": "Row sequence number for deduplication",
           "title": "Row Number",
           "type": "integer"
-        },
-        "App Apple Identifier": {
-          "title": "App Apple Identifier",
-          "type": "string"
-        },
-        "Device": {
-          "title": "Device",
-          "type": "string"
-        },
-        "Platform Version": {
-          "title": "Platform Version",
-          "type": "string"
-        },
-        "Event Type": {
-          "title": "Event Type",
-          "type": "string"
         }
       },
       "required": [
-        "app_id",
         "Date",
-        "row_number",
-        "App Apple Identifier",
-        "Device",
-        "Platform Version",
-        "Event Type"
+        "filename",
+        "row_number"
       ],
-      "title": "AppStoreDiscoveryAndEngagementReportRow",
+      "title": "AppStoreDiscoveryAndEngagementDetailedReportRow",
       "type": "object",
       "x-infer-schema": true
     },
     "key": [
-      "/App Apple Identifier",
-      "/Date",
-      "/Event Type",
-      "/Platform Version",
-      "/app_id",
+      "/filename",
       "/row_number"
     ]
   },
   {
-    "recommendedName": "app_store_installs_and_deletions",
+    "recommendedName": "app_store_installs_and_deletions_detailed",
     "resourceConfig": {
-      "name": "app_store_installs_and_deletions",
+      "name": "app_store_installs_and_deletions_detailed",
       "interval": "PT1H"
     },
     "documentSchema": {
@@ -482,62 +389,32 @@
           "$ref": "#/$defs/Meta",
           "description": "Document metadata"
         },
-        "app_id": {
-          "title": "App Id",
-          "type": "string"
-        },
         "Date": {
           "format": "date",
           "title": "Date",
+          "type": "string"
+        },
+        "filename": {
+          "title": "Filename",
           "type": "string"
         },
         "row_number": {
           "description": "Row sequence number for deduplication",
           "title": "Row Number",
           "type": "integer"
-        },
-        "App Apple Identifier": {
-          "title": "App Apple Identifier",
-          "type": "string"
-        },
-        "App Version": {
-          "title": "App Version",
-          "type": "string"
-        },
-        "Device": {
-          "title": "Device",
-          "type": "string"
-        },
-        "Platform Version": {
-          "title": "Platform Version",
-          "type": "string"
-        },
-        "Event Type": {
-          "title": "Event Type",
-          "type": "string"
         }
       },
       "required": [
-        "app_id",
         "Date",
-        "row_number",
-        "App Apple Identifier",
-        "App Version",
-        "Device",
-        "Platform Version",
-        "Event Type"
+        "filename",
+        "row_number"
       ],
-      "title": "AppStoreInstallsReportRow",
+      "title": "AppStoreInstallsDetailedReportRow",
       "type": "object",
       "x-infer-schema": true
     },
     "key": [
-      "/App Apple Identifier",
-      "/App Version",
-      "/Date",
-      "/Event Type",
-      "/Platform Version",
-      "/app_id",
+      "/filename",
       "/row_number"
     ]
   }


### PR DESCRIPTION
**Description:**

This PR finalizes the implementation of the Apple App store capture connector after seeing it used and finding out more about the quirks in Apple's API and asynchronous Analytics Report endpoints.

Introduces a `GunzipStream` class in the CDK for streaming uncompressed bytes from a Gzip encoded file returned from APIs with the `Content-Type` header set to `application/gzip`. This is not automatically decompressed by `aiohttp` and requires manual decompression, which this class will do via the built in `zlib` Python library.

Additionally, this PR simplifies the analytics report incremental streams page and log cursors to only change when we process a report. I.e., We assume (and have observed this behavior thus far) the analytics reports are processed and provided via the API in chronological / monotonically increasing order. Upon seeing a report with a `processingDate` within our window we are backfilling or incrementally capturing data we process that report and then yield that as the next cursor. Backfill will stop when the last processed date is equal to the cutoff.

Lastly, the collection key for analytics report documents are selected to be the filename path provided by Apple in the AWS-Signed URL when finding report instances to process. This is combined with a synthetic `row_number` as an offset for that particular file. For example: `{...., "filename":"reports/<app_id>/discovery_and_engagement_detail/daily/snapshot/<date>/<some_id>/<some_unique_filename>.csv.gz","row_number":42936}`. This ensures we have a unique and distinguishable collection key. Note:  when working with the data it was observed that certain fields can be `null` when they are expected to be valid string values that were required for a proper composite key made up of the file's data. Because of that reason, I have selected to use the filename/row_number as stated.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

New documentation: https://github.com/estuary/flow/pull/2364

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/3216)
<!-- Reviewable:end -->
