### PR TITLE
source-klaviyo-native: handle events for deleted campaigns

### DIFF
--- a/source-klaviyo-native/source_klaviyo_native/models.py
+++ b/source-klaviyo-native/source_klaviyo_native/models.py
@@ -267,8 +267,12 @@ class Events(IncrementalStream):
         # with the event.
         if flow_id := event_properties.get("$flow", None):
             values["flow_id"] = flow_id
-        elif _ := event_properties.get("Campaign Name", None):
-            values["campaign_id"] = event_properties["$message"]
+        elif event_properties.get("Campaign Name", None):
+            # Events associated with deleted campaigns do not have a
+            # $message field present with the deleted campaign's id.
+            campaign_id = event_properties.get("$message", None)
+            if campaign_id:
+                values["campaign_id"] = campaign_id
 
         return values
 


### PR DESCRIPTION
**Description:**

In events associated with campaigns, the `$message` field contains the campaign id. The imported `source-klaviyo` connector lifted that campaign id up to the top level, and the native `source-klaviyo-native` connector continues to do that. However, events associated with deleted campaigns do _not_ have a `$message` field at all; this is likely because the campaign has been deleted in Klaviyo and its id no longer exists. This PR updates the native connector to handle events for deleted campaigns.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

Tested on a local stack. Confirmed the connector can process events for deleted campaigns without crashing.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/3219)
<!-- Reviewable:end -->
