### PR TITLE
source-mongodb: handle dropDatabase and invalidate events

### DIFF
--- a/source-mongodb/change_stream.go
+++ b/source-mongodb/change_stream.go
@@ -42,12 +42,11 @@ type namespace struct {
 }
 
 type bsonFields struct {
-	DocumentKey              docKey              `bson:"documentKey"`
-	OperationType            string              `bson:"operationType"`
-	FullDocument             bson.M              `bson:"fullDocument"`
-	FullDocumentBeforeChange bson.M              `bson:"fullDocumentBeforeChange"`
-	Ns                       namespace           `bson:"ns"`
-	ClusterTime              primitive.Timestamp `bson:"clusterTime"`
+	DocumentKey              docKey    `bson:"documentKey"`
+	OperationType            string    `bson:"operationType"`
+	FullDocument             bson.M    `bson:"fullDocument"`
+	FullDocumentBeforeChange bson.M    `bson:"fullDocumentBeforeChange"`
+	Ns                       namespace `bson:"ns"`
 }
 
 type changeEvent struct {
@@ -90,7 +89,6 @@ func (c *capture) initializeStreams(
 				"operationType":            1,
 				"fullDocument":             1,
 				"ns":                       1,
-				"clusterTime":              1,
 				"fullDocumentBeforeChange": 1,
 				"splitEvent":               1,
 			}}},
@@ -375,11 +373,6 @@ func (c *capture) readEvent(
 			// done prior to fully unmarshalling the change event BSON to
 			// fast-track bailing out on the very common case of events that
 			// are for collections that are not being captured.
-			if clusterTimeRaw, err := s.ms.Current.LookupErr("clusterTime"); err != nil {
-				return false, fmt.Errorf("looking up clusterTime: %w", err)
-			} else if err := clusterTimeRaw.Unmarshal(&ev.fields.ClusterTime); err != nil {
-				return false, fmt.Errorf("unmarshalling clusterTime: %w", err)
-			}
 			return
 		} else if err := s.ms.Decode(&ev.fields); err != nil {
 			return false, fmt.Errorf("change stream decoding document: %w", err)


### PR DESCRIPTION
**Description:**

Previously the connector would crash and require a backfill of all collections associated with a database if a tracked database was dropped. Now it will log out information about the `dropDatabase` and `invalidate` events and continue
running.

This could be improved by clearing out the state associated with the collections in the dropped database to avoid scenarios where a database is dropped, its collections removed from the capture via an autodiscover, and then later the database & collections are added back. In these cases data may be missed if documents are added to the collections before they are added back to the capture. This would be a more complicated change, and seems like a fairly rare scenario.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

