### PR TITLE
source-klaviyo-native: add worker health check to prevent deadlocks

### DIFF
--- a/source-klaviyo-native/source_klaviyo_native/api/events.py
+++ b/source-klaviyo-native/source_klaviyo_native/api/events.py
@@ -153,6 +153,33 @@ class WorkManager:
     def are_active_workers(self) -> bool:
         return self._active_worker_count > 0
 
+    def worker_health_check(self) -> None:
+        alive_workers = [task for task in self.worker_tasks if not task.done()]
+        expected_count = len(self.worker_tasks)
+        actual_count = len(alive_workers)
+
+        if actual_count != expected_count:
+            missing_count = expected_count - actual_count
+
+            missing_workers = []
+            for task in self.worker_tasks:
+                if task.done():
+                    worker_name = task.get_name()
+                    exception = task.exception()
+                    missing_workers.append({
+                        "name": worker_name,
+                        "exception": str(exception) if exception else "completed without exception"
+                    })
+
+            self.log.error("Worker health check failed.", {
+                "active_worker_count": self._active_worker_count,
+                "expected_worker_count": expected_count,
+                "missing_worker_count": missing_count,
+                "missing_workers": missing_workers,
+            })
+
+            raise RuntimeError("worker health check failed")
+
     async def fetch_events_between(
         self,
         start: datetime,
@@ -215,6 +242,8 @@ class WorkManager:
 
     async def _shutdown_monitor(self) -> None:
         while not self.shutdown_event.is_set():
+            self.worker_health_check()
+
             if not self.are_active_workers() and self.queue_manager.are_all_queues_empty():
                 self.log.debug("All work complete - shutdown monitor initiating shutdown")
                 self.shutdown_event.set()


### PR DESCRIPTION
**Description:**

I noticed a production capture was deadlocked in the `events` backfill with no progress for ~8 hours. Injecting a SIGQUIT showed that the subdivision worker, shutdown monitor, and 4 out of 5 chunk worker tasks were still running. One chunk worker task was not included in the logs after the SIGQUIT, meaning it was no longer running. I suspect the deadlock occurred from this chunk worker exiting without decrementing the active worker count, and this prevented the shutdown monitor from detecting that all work was done.

I'm still investigating _how_ that chunk worker could have exited without decrementing the active worker count or raising an exception that propagates through the `TaskGroup`. In the meantime, implementing a health check that fails if any workers exit before the shutdown event is set should prevent these types of deadlocks.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

Tested on a local stack by forcing a chunk worker to exit after 15 seconds. Confirmed that the health check fails & crashes the connector when a worker exits before the shutdown event is set.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/3221)
<!-- Reviewable:end -->
