### PR TITLE
materialize-snowflake: start new streaming blob based on time as well as size

### DIFF
--- a/materialize-snowflake/stream.go
+++ b/materialize-snowflake/stream.go
@@ -114,7 +114,9 @@ func (sm *streamManager) writeRow(ctx context.Context, binding int, row []any) e
 		return fmt.Errorf("bdecWriter writeRow: %w", err)
 	}
 
-	if sm.bdecWriter.done {
+	// Start a new blob based on the size of the current blob, or expiration of
+	// the blob storage bucket credentials.
+	if sm.bdecWriter.done || time.Now().After(sm.bucketExpiresAt) {
 		if err := sm.finishBlob(); err != nil {
 			return fmt.Errorf("finishBlob: %w", err)
 		}


### PR DESCRIPTION
**Description:**

I have theorized that certain scenarios could arise where we'd be streaming into the same blob file for a very long time, without exceeding its size limit. Such a case may arise from data that is able to be highly compressed by parquet run-length encoding, for example.

In a case like this the AWS/etc. credentials could expire in the midst of a streaming upload.

I think we might actually be seeing this happen in practice, so this adds an additional condition to starting a new blob based on credential expiration time, in addition to blob size.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/3230)
<!-- Reviewable:end -->
