### PR TITLE
materialize-snowflake: refresh bucket credentials more frequently 

### DIFF
--- a/go/materialize/logging.go
+++ b/go/materialize/logging.go
@@ -439,7 +439,7 @@ func (l *BindingEvents) StartedResourceCommit(path []string) {
 		l.activeStores[strings.Join(path, ".")] = time.Now()
 		l.mu.Unlock()
 
-		l.log(log.Fields{"round": l.round - 1, "resourcePath": path}, "started commiting documents for resource")
+		l.log(log.Fields{"round": l.round - 1, "resourcePath": path}, "started committing documents for resource")
 	})
 }
 
@@ -455,7 +455,7 @@ func (l *BindingEvents) FinishedResourceCommit(path []string) {
 			"round":        l.round - 1,
 			"resourcePath": path,
 			"took":         took.String(),
-		}, "finished commiting documents for resource")
+		}, "finished committing documents for resource")
 	})
 }
 

--- a/materialize-cratedb/driver.go
+++ b/materialize-cratedb/driver.go
@@ -438,7 +438,7 @@ func (d *transactor) Load(it *m.LoadIterator, loaded func(int, json.RawMessage) 
 	if err = rows.Err(); err != nil {
 		return fmt.Errorf("querying Loads: %w", err)
 	} else if err = txn.Commit(ctx); err != nil {
-		return fmt.Errorf("commiting Load transaction: %w", err)
+		return fmt.Errorf("committing Load transaction: %w", err)
 	}
 
 	return nil

--- a/materialize-mysql/driver.go
+++ b/materialize-mysql/driver.go
@@ -676,7 +676,7 @@ func (d *transactor) Load(it *m.LoadIterator, loaded func(int, json.RawMessage) 
 	}
 
 	if err = txn.Commit(); err != nil {
-		return fmt.Errorf("commiting Load transaction: %w", err)
+		return fmt.Errorf("committing Load transaction: %w", err)
 	}
 
 	return nil

--- a/materialize-postgres/driver.go
+++ b/materialize-postgres/driver.go
@@ -535,7 +535,7 @@ func (d *transactor) Load(it *m.LoadIterator, loaded func(int, json.RawMessage) 
 	if err = rows.Err(); err != nil {
 		return fmt.Errorf("querying Loads: %w", err)
 	} else if err = txn.Commit(ctx); err != nil {
-		return fmt.Errorf("commiting Load transaction: %w", err)
+		return fmt.Errorf("committing Load transaction: %w", err)
 	}
 
 	return nil

--- a/materialize-redshift/driver.go
+++ b/materialize-redshift/driver.go
@@ -593,7 +593,7 @@ func (d *transactor) Load(it *m.LoadIterator, loaded func(int, json.RawMessage) 
 	}
 
 	if err := txn.Commit(ctx); err != nil {
-		return fmt.Errorf("commiting load transaction: %w", err)
+		return fmt.Errorf("committing load transaction: %w", err)
 	}
 
 	return nil

--- a/materialize-snowflake/stream.go
+++ b/materialize-snowflake/stream.go
@@ -364,7 +364,7 @@ func (sm *streamManager) maybeInitializeBucket(ctx context.Context) error {
 		return fmt.Errorf("unknown stage location type %q", cfg.StageLocation.LocationType)
 	}
 
-	sm.bucketExpiresAt = time.Now().Add(30 * time.Minute)
+	sm.bucketExpiresAt = time.Now().Add(15 * time.Minute)
 	log.WithFields(log.Fields{
 		"locationType": cfg.StageLocation.LocationType,
 		"location":     cfg.StageLocation.Location,

--- a/materialize-sqlserver/driver.go
+++ b/materialize-sqlserver/driver.go
@@ -448,7 +448,7 @@ func (d *transactor) Load(it *m.LoadIterator, loaded func(int, json.RawMessage) 
 	}
 
 	if err = txn.Commit(); err != nil {
-		return fmt.Errorf("commiting Load transaction: %w", err)
+		return fmt.Errorf("committing Load transaction: %w", err)
 	}
 
 	return nil


### PR DESCRIPTION
**Description:**

We have seen expirations using the 30 minute window, so refresh every 15 minutes. There is very little cost to doing this more frequently.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/3232)
<!-- Reviewable:end -->
