### PR TITLE
materialize-iceberg: add namespace to table path

### DIFF
--- a/materialize-iceberg/driver.go
+++ b/materialize-iceberg/driver.go
@@ -318,7 +318,7 @@ func (d *materialization) CreateResource(ctx context.Context, res boilerplate.Ma
 
 	var location *string
 	if d.cfg.BaseLocation != "" {
-		base := strings.TrimSuffix(d.cfg.BaseLocation, "/") + "/" + sanitizeAndAppendHash(name)
+		base := strings.TrimSuffix(d.cfg.BaseLocation, "/") + "/" + sanitizeAndAppendHash(ns+"_"+name)
 		location = &base
 	}
 


### PR DESCRIPTION
**Description:**

If there are multiple tables with the same name but in different namespaces, they would previously use the same table path if the user configured a base location, as is the case when using a Glue catalog.

Among other things, this would cause orphan file cleanup to delete data/metadata files of the "other" table when the clean was run.

Going forward, include the namespace in the table base location, to ensure that base locations are globally unique per table.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

