### PR TITLE
estuary-cdk: add `tzdata` and `tzdata-legacy` to `common.Dockerfile`

### DIFF
--- a/estuary-cdk/common.Dockerfile
+++ b/estuary-cdk/common.Dockerfile
@@ -30,7 +30,9 @@ ARG USAGE_RATE
 
 RUN apt-get update && \
     apt install -y --no-install-recommends \
-    openssh-client
+    openssh-client \
+    tzdata \
+    tzdata-legacy
 
 LABEL FLOW_RUNTIME_PROTOCOL=${CONNECTOR_TYPE}
 LABEL FLOW_RUNTIME_CODEC=json


### PR DESCRIPTION
**Description:**

Some Python connectors have started failing due to the absence of the `tzdata` and `tzdata-legacy` packages (similar to https://github.com/estuary/connectors/pull/3169). Adding those packages into the `common.Dockerfile` makes them available.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

Tested on a local stack & confirmed a capture that was getting errors for a missing `tzdata` package now works fine.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/3241)
<!-- Reviewable:end -->
