### PR TITLE
source-monday: handle new board_view_duplicated activity log event

### DIFF
--- a/source-monday/source_monday/models.py
+++ b/source-monday/source_monday/models.py
@@ -186,6 +186,7 @@ class ActivityLogEvents(StrEnum):
     BOARD_VIEW_CHANGED = "board_view_changed"
     BOARD_VIEW_ENABLED = "board_view_enabled"
     BOARD_VIEW_DISABLED = "board_view_disabled"
+    BOARD_VIEW_DUPLICATED = "board_view_duplicated"
     BOARD_WORKSPACE_ID_CHANGED = "board_workspace_id_changed"
     CHANGE_COLUMN_SETTINGS = "change_column_settings"
     CREATE_COLUMN = "create_column"
@@ -281,6 +282,7 @@ class ActivityLog(BaseModel, extra="allow"):
                 | ActivityLogEvents.BOARD_VIEW_ENABLED
                 | ActivityLogEvents.BOARD_VIEW_DISABLED
                 | ActivityLogEvents.BOARD_VIEW_DELETED
+                | ActivityLogEvents.BOARD_VIEW_DUPLICATED
                 | ActivityLogEvents.BOARD_WORKSPACE_ID_CHANGED
                 | ActivityLogEvents.CHANGE_COLUMN_SETTINGS
                 | ActivityLogEvents.UPDATE_BOARD_NICKNAME


### PR DESCRIPTION
**Description:**

Adds support for an Activity log event that we have not seen in production captures until recent.

- `board_view_duplicated` - as the name suggests; it occurs when a user duplicates a view within a board. This event contains the `board_id` and should be treated as a board-level incremental update and does require a sync for the items stream.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/3243)
<!-- Reviewable:end -->
