### PR TITLE
source-shopify-native: fix queries' timestamps

### DIFF
--- a/source-shopify-native/source_shopify_native/graphql/common.py
+++ b/source-shopify-native/source_shopify_native/graphql/common.py
@@ -7,19 +7,6 @@ def dt_to_str(dt: datetime) -> str:
     return dt.strftime(DATETIME_STRING_FORMAT)
 
 
-# Shopify's bulk GraphQL queries round our "updated_at" datetime queries down to the earliest midnight.
-# Meaning, if our end datetime was 2025-01-16T12:00:00Z, then Shopify would round it down to 2025-01-16T00:00:00Z.
-# Effectively, we would miss all updates in the current day until midnight of the next day. To avoid this, the
-# round_to_latest_midnight function rounds queries' end datetimes to midnight of the next day.
-def round_to_latest_midnight(dt: datetime) -> datetime:
-    if dt.time() == datetime.min.time():
-        return dt
-    else:
-        return (dt + timedelta(days=1)).replace(
-            hour=0, minute=0, second=0, microsecond=0
-        )
-
-
 money_bag_fragment = """
 fragment _MoneyBagFields on MoneyBag {
     shopMoney {

--- a/source-shopify-native/source_shopify_native/models.py
+++ b/source-shopify-native/source_shopify_native/models.py
@@ -22,7 +22,7 @@ from estuary_cdk.capture.common import (
 from estuary_cdk.capture.common import (
     ConnectorState as GenericConnectorState,
 )
-from .graphql.common import dt_to_str, round_to_latest_midnight
+from .graphql.common import dt_to_str
 
 
 scopes = [
@@ -292,12 +292,12 @@ class ShopifyGraphQLResource(BaseDocument, extra="allow"):
         includeUpdatedAt: bool = True,
     ) -> str:
         lower_bound = dt_to_str(start)
-        upper_bound = dt_to_str(round_to_latest_midnight(end))
+        upper_bound = dt_to_str(end)
 
         query = f"""
         {{
             {query_root}(
-                query: "updated_at:>={lower_bound} AND updated_at:<={upper_bound} {"AND " + query.strip() if query else ""}"
+                query: "updated_at:>='{lower_bound}' AND updated_at:<='{upper_bound}' {"AND " + query.strip() if query else ""}"
                 {f"sortKey: {sort_key}" if sort_key else ""}
             ) {{
                 edges {{


### PR DESCRIPTION
**Description:**

Not escaping timestamps in search query filters causes Shopify to ignore the time portion of the timestamp & fallback to using the user's timezone. Wrapping the timestamps in single quotes causes Shopify to correctly parse them & use the timezone we request (UTC). This Shopify [community discussion](https://community.shopify.com/t/graphql-createdat-date-range-missing-orders/9076/2) mentions this behavior, and I've verified it with API calls.

Since the timestamps in our search query filters are parsed correctly and Shopify no longer rounds these timestamps, the `round_to_latest_midnight` helper function is no longer needed.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

Confirmed tests still pass (i.e. the connector still runs fine). Confirmed via API calls that wrapping timestamps in single quotes causes Shopify to parse them correctly & the search results are _actually_ filtered to only those within the requested timestamp range.

