### PR TITLE
materialize-snowflake: fix bdec writing when column chunks are numerous

### DIFF
--- a/tests/materialize/materialize-snowflake/checks.sh
+++ b/tests/materialize/materialize-snowflake/checks.sh
@@ -9,6 +9,7 @@ $SED_CMD -i'' 's/"PipeStartTime": ".\{1,\}"/"PipeStartTime": "<timestamp>"/g' ${
 $SED_CMD -i'' 's/"path": ".*"/"path": "<path>"/g' ${SNAPSHOT}
 $SED_CMD -i'' 's/"md5": ".*"/"md5": "<md5>"/g' ${SNAPSHOT}
 $SED_CMD -i'' 's/"chunk_length": [0-9]\+/"chunk_length": "<chunk_length>"/g' ${SNAPSHOT}
+$SED_CMD -i'' 's/"chunk_length_uncompressed": [0-9]\+/"chunk_length_uncompressed": "<chunk_length_uncompressed>"/g' ${SNAPSHOT}
 $SED_CMD -i'' 's/"chunk_md5": ".*"/"chunk_md5": "<chunk_md5>"/g' ${SNAPSHOT}
 $SED_CMD -i'' 's/"encryption_key_id": [0-9]\+/"encryption_key_id": "<encryption_key_id>"/g' ${SNAPSHOT}
 $SED_CMD -i'' 's/"first_insert_time_in_ms": [0-9]\+/"first_insert_time_in_ms": "<first_insert_time_in_ms>"/g' ${SNAPSHOT}

--- a/tests/materialize/materialize-snowflake/snapshot.json
+++ b/tests/materialize/materialize-snowflake/snapshot.json
@@ -37,7 +37,7 @@
                 "table": "\"duplicate keys @ with spaces\"",
                 "chunk_start_offset": 0,
                 "chunk_length": "<chunk_length>",
-                "chunk_length_uncompressed": 0,
+                "chunk_length_uncompressed": "<chunk_length_uncompressed>",
                 "channels": [
                   {
                     "channel_name": "TESTS_MATERIALIZE_SNOWFLAKE_MATE_99A06F45B5F50222_00000000",
@@ -144,7 +144,7 @@
                 "table": "DUPLICATE_KEYS_DELTA",
                 "chunk_start_offset": 0,
                 "chunk_length": "<chunk_length>",
-                "chunk_length_uncompressed": 0,
+                "chunk_length_uncompressed": "<chunk_length_uncompressed>",
                 "channels": [
                   {
                     "channel_name": "TESTS_MATERIALIZE_SNOWFLAKE_MATE_99A06F45B5F50222_00000000",
@@ -251,7 +251,7 @@
                 "table": "DUPLICATE_KEYS_DELTA_EXCLUDE_FLOW_DOC",
                 "chunk_start_offset": 0,
                 "chunk_length": "<chunk_length>",
-                "chunk_length_uncompressed": 0,
+                "chunk_length_uncompressed": "<chunk_length_uncompressed>",
                 "channels": [
                   {
                     "channel_name": "TESTS_MATERIALIZE_SNOWFLAKE_MATE_99A06F45B5F50222_00000000",
@@ -438,7 +438,7 @@
                 "table": "\"duplicate keys @ with spaces\"",
                 "chunk_start_offset": 0,
                 "chunk_length": "<chunk_length>",
-                "chunk_length_uncompressed": 0,
+                "chunk_length_uncompressed": "<chunk_length_uncompressed>",
                 "channels": [
                   {
                     "channel_name": "TESTS_MATERIALIZE_SNOWFLAKE_MATE_99A06F45B5F50222_00000000",
@@ -545,7 +545,7 @@
                 "table": "DUPLICATE_KEYS_DELTA",
                 "chunk_start_offset": 0,
                 "chunk_length": "<chunk_length>",
-                "chunk_length_uncompressed": 0,
+                "chunk_length_uncompressed": "<chunk_length_uncompressed>",
                 "channels": [
                   {
                     "channel_name": "TESTS_MATERIALIZE_SNOWFLAKE_MATE_99A06F45B5F50222_00000000",
@@ -652,7 +652,7 @@
                 "table": "DUPLICATE_KEYS_DELTA_EXCLUDE_FLOW_DOC",
                 "chunk_start_offset": 0,
                 "chunk_length": "<chunk_length>",
-                "chunk_length_uncompressed": 0,
+                "chunk_length_uncompressed": "<chunk_length_uncompressed>",
                 "channels": [
                   {
                     "channel_name": "TESTS_MATERIALIZE_SNOWFLAKE_MATE_99A06F45B5F50222_00000000",
@@ -812,7 +812,7 @@
                 "table": "\"duplicate keys @ with spaces\"",
                 "chunk_start_offset": 0,
                 "chunk_length": "<chunk_length>",
-                "chunk_length_uncompressed": 0,
+                "chunk_length_uncompressed": "<chunk_length_uncompressed>",
                 "channels": [
                   {
                     "channel_name": "TESTS_MATERIALIZE_SNOWFLAKE_MATE_99A06F45B5F50222_00000000",
@@ -919,7 +919,7 @@
                 "table": "DUPLICATE_KEYS_DELTA",
                 "chunk_start_offset": 0,
                 "chunk_length": "<chunk_length>",
-                "chunk_length_uncompressed": 0,
+                "chunk_length_uncompressed": "<chunk_length_uncompressed>",
                 "channels": [
                   {
                     "channel_name": "TESTS_MATERIALIZE_SNOWFLAKE_MATE_99A06F45B5F50222_00000000",
@@ -1026,7 +1026,7 @@
                 "table": "DUPLICATE_KEYS_DELTA_EXCLUDE_FLOW_DOC",
                 "chunk_start_offset": 0,
                 "chunk_length": "<chunk_length>",
-                "chunk_length_uncompressed": 0,
+                "chunk_length_uncompressed": "<chunk_length_uncompressed>",
                 "channels": [
                   {
                     "channel_name": "TESTS_MATERIALIZE_SNOWFLAKE_MATE_99A06F45B5F50222_00000000",
@@ -1158,7 +1158,7 @@
                   }
                 ],
                 "chunk_length": "<chunk_length>",
-                "chunk_length_uncompressed": 0,
+                "chunk_length_uncompressed": "<chunk_length_uncompressed>",
                 "chunk_md5": "<chunk_md5>",
                 "chunk_start_offset": 0,
                 "database": "ESTUARY_DB",
@@ -1264,7 +1264,7 @@
                   }
                 ],
                 "chunk_length": "<chunk_length>",
-                "chunk_length_uncompressed": 0,
+                "chunk_length_uncompressed": "<chunk_length_uncompressed>",
                 "chunk_md5": "<chunk_md5>",
                 "chunk_start_offset": 0,
                 "database": "ESTUARY_DB",
@@ -1370,7 +1370,7 @@
                   }
                 ],
                 "chunk_length": "<chunk_length>",
-                "chunk_length_uncompressed": 0,
+                "chunk_length_uncompressed": "<chunk_length_uncompressed>",
                 "chunk_md5": "<chunk_md5>",
                 "chunk_start_offset": 0,
                 "database": "ESTUARY_DB",


### PR DESCRIPTION
**Description:**

A bdec blob can only have a single row group. The previous logic was flawed because it assumed that row group creation was directed only by the bytes contained in the row group, but there is a secondary control where if a row group has a huge number of column chunks (e.g. because there are many selected fields), row groups are written more frequently to manage connector memory.

This implements a more direct accounting, where the number of row groups written is made available via the parquet writer, and the bdec blob can be closed out immediately after the first row group is written.

I also fixed a minor problem where the uncompressed length of the bdec blob was being set incorrectly. It is now taken directly from the reported metadata of the parquet file, once the file is closed.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/3251)
<!-- Reviewable:end -->
