### PR TITLE
source-klaviyo-native: add logging to troubleshoot deadlock

### DIFF
--- a/estuary-cdk/estuary_cdk/http.py
+++ b/estuary-cdk/estuary_cdk/http.py
@@ -509,6 +509,11 @@ class HTTPMixin(Mixin, HTTPSession):
                         try:
                             async for chunk in resp.content.iter_any():
                                 yield chunk
+                        except Exception as e:
+                            log.error("Encountered error while streaming response body.", {
+                                "exception": e,
+                            })
+                            raise e
                         finally:
                             await resp.release()
 


### PR DESCRIPTION
**Description:**

The `events` backfill deadlock I thought I resolved in 198618557e11070accff8f2d0e9516a4818ca4f7 is still happening. It rarely happens, and I haven't been able to replicate the deadlock on a local stack. What I've observed so far is that a worker stops logging anything after other workers hit a connection timeout error [here](https://github.com/estuary/connectors/blob/3b41f1e8d50c28e96a8b459df31663943a726c3e/estuary-cdk/estuary_cdk/http.py#L173-L176). I suspect some other error is occurring for that disappearing worker after it starts streaming the response body, and that's causing the worker to exit before the shutdown event is set.

It seems like the best chance of debugging this deadlock is when production captures hit it, so I've added more logging to help me investigate when it happens again.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

