### PR TITLE
source-jira-native: add `statuses` stream

### DIFF
--- a/source-jira-native/source_jira_native/resources.py
+++ b/source-jira-native/source_jira_native/resources.py
@@ -35,6 +35,7 @@ from .models import (
     ResourceState,
     ScreenTabFields,
     StandardPermissions,
+    Statuses,
     SystemAvatars,
     FULL_REFRESH_STREAMS,
     ISSUE_CHILD_STREAMS,
@@ -60,6 +61,7 @@ from .api import (
     snapshot_permissions,
     snapshot_project_child_resources,
     snapshot_screen_tab_fields,
+    snapshot_statuses,
     snapshot_system_avatars,
     url_base,
     ISSUE_JQL_SEARCH_LAG,
@@ -230,6 +232,13 @@ def _get_partial_snapshot_fn(
     elif issubclass(stream, ScreenTabFields):
         snapshot_fn = functools.partial(
             snapshot_screen_tab_fields,
+            http,
+            config.domain,
+            stream,
+        )
+    elif issubclass(stream, Statuses):
+        snapshot_fn = functools.partial(
+            snapshot_statuses,
             http,
             config.domain,
             stream,

--- a/source-jira-native/tests/snapshots/snapshots__discover__capture.stdout.json
+++ b/source-jira-native/tests/snapshots/snapshots__discover__capture.stdout.json
@@ -2068,6 +2068,54 @@
     ]
   },
   {
+    "recommendedName": "statuses",
+    "resourceConfig": {
+      "name": "statuses",
+      "interval": "PT1H"
+    },
+    "documentSchema": {
+      "$defs": {
+        "Meta": {
+          "properties": {
+            "op": {
+              "default": "u",
+              "description": "Operation type (c: Create, u: Update, d: Delete)",
+              "enum": [
+                "c",
+                "u",
+                "d"
+              ],
+              "title": "Op",
+              "type": "string"
+            },
+            "row_id": {
+              "default": -1,
+              "description": "Row ID of the Document, counting up from zero, or -1 if not known",
+              "title": "Row Id",
+              "type": "integer"
+            }
+          },
+          "title": "Meta",
+          "type": "object"
+        }
+      },
+      "additionalProperties": true,
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/Meta",
+          "description": "Document metadata"
+        }
+      },
+      "title": "FullRefreshResource",
+      "type": "object",
+      "x-infer-schema": true
+    },
+    "key": [
+      "/_meta/row_id"
+    ],
+    "disable": true
+  },
+  {
     "recommendedName": "system_avatars",
     "resourceConfig": {
       "name": "system_avatars",


### PR DESCRIPTION
**Description:**

Statuses can either be global or scoped to a specific project. To capture all statuses, we have to fetch global statuses then check individual projects for their statuses.

Note: when fetching project-scoped statuses, we can safely ignore classic projects. Classic (AKA company managed) projects only have global statuses, not project-scoped statuses.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

Tested on a local stack. Confirmed `statuses` completes and captures all expected data.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/connectors/3254)
<!-- Reviewable:end -->
