### PR TITLE
materializer: add "always_drop_tables_on_backfill" feature flag

### DIFF
--- a/materialize-boilerplate/materializer.go
+++ b/materialize-boilerplate/materializer.go
@@ -560,7 +560,7 @@ func RunApply[EC EndpointConfiger, FC FieldConfiger, RC Resourcer[RC, EC], MT Ma
 
 		}
 
-		if !mCfg.NoTruncateResources && doTruncate {
+		if !mCfg.NoTruncateResources && !parsedFlags["always_drop_tables_on_backfill"] && doTruncate {
 			if desc, action, err := materializer.TruncateResource(ctx, thisBinding.ResourcePath); err != nil {
 				return nil, fmt.Errorf("getting TruncateResource action: %w", err)
 			} else {


### PR DESCRIPTION
**Description:**

Adds a new feature flag that will cause a materialization to always drop & re-create tables when the backfill counter is incremented, rather than trying to truncate them, even if the existing table is believed to be compatible with the proposed specification.

This is meant to be a workaround in situations where the connector logic has some deficiency in recognizing that an existing table is incompatible with new changes and the only way to proceed is to drop & re-create the table. In these cases, the best long-term solution is to fix the connector code, but as that can often be a non-trivial task, this flag provides a way to work around the issue in the short term.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

