### PR TITLE
source-shopify-native: make window_size a duration

### DIFF
--- a/source-shopify-native/config.yaml
+++ b/source-shopify-native/config.yaml
@@ -4,7 +4,7 @@ credentials:
 store: estuary-alex-testing
 start_date: "2025-01-10T00:00:00Z"
 advanced:
-    window_size: 50000
+    window_size: P50000D
 sops:
     kms: []
     gcp_kms:
@@ -14,8 +14,8 @@ sops:
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2025-01-15T20:49:00Z"
-    mac: ENC[AES256_GCM,data:IcKCvsGVyeQnIAREIC/6nd47ozM6g+iGZAsfwvrllPTkkhjFKpFQF77c0OYKHU1rOFC7DXWFWtsMD/yKgeUMgclm2Vw7EBe6MLwtcWbagiZ7WsVIpzOXb6rbhRImcu8dFkaWgVS742llsOfCA/RZquTJ4OlOsWpGTdxZDhoIEaA=,iv:YEslMowXvReoZbgPMRqjwjanRQIBKUuY8UCLpmbc9Zk=,tag:2WAsc4HHDBX488FcSADg1g==,type:str]
+    lastmodified: "2025-09-05T13:06:45Z"
+    mac: ENC[AES256_GCM,data:I4FWGsOWyKxrI4ud+Ul5b8MR2qCOGeK0HyOtRnxpdC6cc2g7qa9o0ZNi70Uz+1LtigCfFgRKyJkU1lry7AFyPJsT9IEDo4mt/4+taSkoo7T1aFakwnN5GLDeD3j0ktKvlFXPt5/RoWGczTfgZ0U+q8IsjBF1gPPA2BgJ5+kP1S4=,iv:flzhyYQLxi/5vFPXywtE0ENHM67oWehJglMWHnvIclE=,tag:JXkLiXB8p/NHbj/UBqW69A==,type:str]
     pgp: []
     encrypted_suffix: _sops
-    version: 3.7.3
+    version: 3.9.0

--- a/source-shopify-native/source_shopify_native/api.py
+++ b/source-shopify-native/source_shopify_native/api.py
@@ -22,14 +22,14 @@ TARGET_FETCH_PAGE_INVOCATION_RUN_TIME = 60 * 5 # 5 minutes
 
 async def bulk_fetch_incremental(
     http: HTTPMixin,
-    window_size: int,
+    window_size: timedelta,
     bulk_job_manager: gql.bulk_job_manager.BulkJobManager,
     model: type[ShopifyGraphQLResource],
     log: Logger,
     log_cursor: LogCursor,
 ) -> AsyncGenerator[ShopifyGraphQLResource | LogCursor, None]:
     assert isinstance(log_cursor, datetime)
-    max_end = log_cursor + timedelta(days=window_size)
+    max_end = log_cursor + window_size
     end = min(max_end, datetime.now(tz=UTC))
     query = model.build_query(log_cursor, end)
 

--- a/source-shopify-native/source_shopify_native/models.py
+++ b/source-shopify-native/source_shopify_native/models.py
@@ -97,12 +97,12 @@ class EndpointConfig(BaseModel):
 
     class Advanced(BaseModel):
         window_size: Annotated[
-            int,
+            timedelta,
             Field(
-                description="Window size in days for incremental streams.",
+                description="Window size for incremental streams in ISO 8601 format. ex: P30D means 30 days, PT6H means 6 hours.",
                 title="Window Size",
-                default=30,
-                gt=0,
+                default=timedelta(days=30),
+                ge=timedelta(minutes=1),
             ),
         ]
 

--- a/source-shopify-native/tests/snapshots/snapshots__spec__capture.stdout.json
+++ b/source-shopify-native/tests/snapshots/snapshots__spec__capture.stdout.json
@@ -26,11 +26,11 @@
         "Advanced": {
           "properties": {
             "window_size": {
-              "default": 30,
-              "description": "Window size in days for incremental streams.",
-              "exclusiveMinimum": 0,
+              "default": "P30D",
+              "description": "Window size for incremental streams in ISO 8601 format. ex: P30D means 30 days, PT6H means 6 hours.",
+              "format": "duration",
               "title": "Window Size",
-              "type": "integer"
+              "type": "string"
             }
           },
           "title": "Advanced",


### PR DESCRIPTION
**Description:**

As a result of the change in 0671fb08f6f2e476707a69ceee2906ffceb8ee4e, Shopify filters results based off the exact datetimes we request rather than just the day portion of the datetimes. This also means we can support window sizes smaller than a day.

Similar to 6901bcda21131a3cf5bdbdf65417c115017f31ab, this commit make the config's `window_size` an ISO 8601 duration. This should be especially useful when there's enough data in a single day for a stream that either Shopify takes an extremely long time to complete a job or the connector gets timed out reading a job's results.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

The connector's docs should be updated to reflect that `advanced.window_size` is now an ISO 8601 duration.

**Notes for reviewers:**

Tested on a local stack. Confirmed the connector still captures data & uses the configured duration as the window size for bulk queries.

There's one active `source-shopify-native` capture that specifies a `window_size` in its config. I plan on manually moving it over from an integer to a duration after merging this PR.

