### PR TITLE
source-klaviyo-native: handle worker cancellation to avoid deadlocks

### DIFF
--- a/estuary-cdk/estuary_cdk/capture/base_capture_connector.py
+++ b/estuary-cdk/estuary_cdk/capture/base_capture_connector.py
@@ -21,7 +21,7 @@ from ..flow import (
 )
 from ..http import HTTPError, HTTPMixin, TokenSource
 from ..logger import FlowLogger
-from ..utils import sort_dict
+from ..utils import format_error_message, sort_dict
 
 class BaseCaptureConnector(
     BaseConnector[Request[EndpointConfig, ResourceConfig, _ConnectorState]],
@@ -122,11 +122,7 @@ class BaseCaptureConnector(
 
             # When capture() completes, the connector exits.
             if stopping.first_error:
-                msg = f"{stopping.first_error}"
-                # If the first_error doesn't have a meaningful string representation,
-                # set it to the exception type's name so something more useful is logged.
-                if msg == "":
-                    msg = f"{type(stopping.first_error).__name__}"
+                msg = format_error_message(stopping.first_error)
 
                 raise Stopped(
                     f"Task {stopping.first_error_task}: {msg}"

--- a/estuary-cdk/estuary_cdk/http.py
+++ b/estuary-cdk/estuary_cdk/http.py
@@ -30,6 +30,8 @@ from .flow import (
     GoogleServiceAccount,
     GoogleServiceAccountSpec,
 )
+from .utils import format_error_message
+
 
 DEFAULT_AUTHORIZATION_HEADER = "Authorization"
 DEFAULT_AUTHORIZATION_TOKEN_TYPE = "Bearer"
@@ -172,7 +174,7 @@ class HTTPSession(abc.ABC):
                 if attempt <= max_attempts:
                     log.warning(
                         f"Connection timeout error (will retry)",
-                        {"url": url, "method": method, "attempt": attempt, "error": str(e)}
+                        {"url": url, "method": method, "attempt": attempt, "error": format_error_message(e)}
                     )
                     attempt += 1
                 else:

--- a/estuary-cdk/estuary_cdk/http.py
+++ b/estuary-cdk/estuary_cdk/http.py
@@ -511,11 +511,6 @@ class HTTPMixin(Mixin, HTTPSession):
                         try:
                             async for chunk in resp.content.iter_any():
                                 yield chunk
-                        except Exception as e:
-                            log.error("Encountered error while streaming response body.", {
-                                "exception": e,
-                            })
-                            raise e
                         finally:
                             await resp.release()
 

--- a/estuary-cdk/estuary_cdk/utils.py
+++ b/estuary-cdk/estuary_cdk/utils.py
@@ -2,6 +2,16 @@ from collections.abc import Mapping
 from typing import Any
 
 
+def format_error_message(err: BaseException):
+    msg = f"{err}"
+    # If the exeption doesn't have a meaningful string representation,
+    # set it to the exception type's name so something more useful is logged.
+    if msg == "":
+        msg = f"{type(err).__name__}"
+
+    return msg
+
+
 def sort_dict(obj: Any) -> Any:
     if isinstance(obj, Mapping):
         return {k: sort_dict(v) for k, v in sorted(obj.items())}


### PR DESCRIPTION
**Description:**

#### Summary / tl;dr

This PR prevents the `events` backfill from deadlocking when a worker task is cancelled. Workers should never be cancelled during normal operation (the shutdown monitor and shutdown event coordinate when tasks should exit naturally), and a non-`TaskGroup` initiated cancellation is an exceptional condition that should stop processing and crash the connector. This PR does that by implementing `CancelledError` handling for workers.

#### Investigation

I observed `source-klaviyo-native` captures getting deadlocked in the `events` backfill. Previous PRs to troubleshoot/address the deadlock were:
- https://github.com/estuary/connectors/pull/3221
- https://github.com/estuary/connectors/pull/3238
- https://github.com/estuary/connectors/pull/3253

After the last PR, I saw a log like "Task chunk_worker_1 cancelled before the shutdown event was set." surrounded by "Connection timeout error (will retry)" logs when a connector deadlocked. After some digging, I discovered that when making a request with `aiohttp` it [keeps a reference](https://github.com/aio-libs/aiohttp/blob/33de07852848eb51e82ad4132bb7038b27c348ad/aiohttp/helpers.py#L673) to the currently running task and [cancels it](https://github.com/aio-libs/aiohttp/blob/33de07852848eb51e82ad4132bb7038b27c348ad/aiohttp/helpers.py#L713-L718) when the `aiohttp.ClientSession`'s total timeout is exceeded. `aiohttp` converts the resulting `CancelledError` into a `TimeoutError` when exiting the timer's context manager, but it's possible for that conversion to _not_ occur (like when the connector is outside of that context manager and streaming the response body). When that conversion doesn't happen, a `CancelledError` is raised in the worker task. The `TaskGroup` does not cancel other tasks if a task fails with a `CancelledError`, and the backfill ends up deadlocked since the connector is waiting for the cancelled worker to finish its work.

To prevent the deadlock from happening, the first cancelled worker converts the `CancelledError` into an `Exception` that _will_ cause the `TaskGroup` to cancel the other child tasks and bubble up the `Exception` through the connector. Instead of a deadlock, the connector crashes then gets restarted.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

I was able to replicate the original deadlock by reducing the `aiohttp.ClientSession`'s total timeout in `http.py` from 5 minutes (the default) to ~0.75 seconds. I also monkey patched in some logging to `aiohttp.helpers.TimerContext.timeout` to confirm when certain tasks were getting cancelled. That patch looked like:
```python
# Log when aiohttp cancels tasks
# Add this to the top of http.py after imports
import aiohttp.helpers
from logging import getLogger

# Store original method
_original_timeout = aiohttp.helpers.TimerContext.timeout

def logged_timeout(self):
    """Wrapped timeout to log task cancellations"""
    if not self._cancelled and self._tasks:
        log = getLogger(__name__)
        log.warning("aiohttp TimerContext.timeout() about to cancel tasks", {
            "task_count": len(self._tasks),
            "unique_tasks": len(set(self._tasks)),
            "tasks": [
                {
                    "task_name": task.get_name() if hasattr(task, 'get_name') else str(task),
                    "task_done": task.done(),
                    "task_cancelled": task.cancelled() if hasattr(task, 'cancelled') else False,
                }
                for task in self._tasks
            ]
        })

    # Always call original timeout function (no manual cancellation)
    return _original_timeout(self)

# Apply the wrapper
aiohttp.helpers.TimerContext.timeout = logged_timeout
```

I tested these changes on a local stack and confirmed that instead of deadlocking, the connector crashes when an `events` backfill worker task is cancelled.

I'm also leaving in a lot of the logging I added during troubleshooting just in case some other deadlock mechanism exists. I'm confident this PR will address the current deadlock mechanism, but I was also somewhat confident with my earlier attempts and I'd like to keep the logging in for now until I can confirm that production tasks are no longer deadlocking.