### PR TITLE
source-oracle-batch: Add /_meta/source and 'Source Tag' config

### DIFF
--- a/source-oracle-batch/.snapshots/TestSpec
+++ b/source-oracle-batch/.snapshots/TestSpec
@@ -56,6 +56,11 @@
             "title": "SSL Mode",
             "description": "Overrides SSL connection behavior by setting the 'sslmode' parameter."
           },
+          "source_tag": {
+            "type": "string",
+            "title": "Source Tag",
+            "description": "When set the capture will add this value as the property 'tag' in the source metadata of each document."
+          },
           "feature_flags": {
             "type": "string",
             "title": "Feature Flags",

--- a/source-oracle-batch/discovery.go
+++ b/source-oracle-batch/discovery.go
@@ -129,6 +129,9 @@ func generateCollectionSchema(cfg *Config, table *discoveredTable, fullWriteSche
 	}
 	if fullWriteSchema {
 		metadataSchema.AdditionalProperties = nil
+		if sourceSchema, ok := metadataSchema.Properties.Get("source"); ok {
+			sourceSchema.AdditionalProperties = nil
+		}
 	} else {
 		metadataSchema.Extras["additionalProperties"] = false
 	}

--- a/source-oracle-batch/main.go
+++ b/source-oracle-batch/main.go
@@ -41,6 +41,7 @@ type advancedConfig struct {
 	PollSchedule    string   `json:"poll,omitempty" jsonschema:"title=Default Polling Schedule,description=When and how often to execute fetch queries. Accepts a Go duration string like '5m' or '6h' for frequency-based polling or a string like 'daily at 12:34Z' to poll at a specific time (specified in UTC) every day. Defaults to '5m' if unset." jsonschema_extras:"pattern=^([-+]?([0-9]+([.][0-9]+)?(h|m|s|ms))+|daily at [0-9][0-9]?:[0-9]{2}Z)$"`
 	DiscoverSchemas []string `json:"discover_schemas,omitempty" jsonschema:"title=Discovery Schema Selection,description=If this is specified only tables in the selected schema(s) will be automatically discovered. Omit all entries to discover tables from all schemas."`
 	SSLMode         string   `json:"sslmode,omitempty" jsonschema:"title=SSL Mode,description=Overrides SSL connection behavior by setting the 'sslmode' parameter.,enum=disable,enum=allow,enum=prefer,enum=require,enum=verify-ca,enum=verify-full"`
+	SourceTag       string   `json:"source_tag,omitempty" jsonschema:"title=Source Tag,description=When set the capture will add this value as the property 'tag' in the source metadata of each document."`
 	FeatureFlags    string   `json:"feature_flags,omitempty" jsonschema:"title=Feature Flags,description=This property is intended for Estuary internal use. You should only modify this field as directed by Estuary support."`
 
 	parsedFeatureFlags map[string]bool // Parsed feature flags setting with defaults applied


### PR DESCRIPTION
**Description:**

A copy-paste of https://github.com/estuary/connectors/pull/3245 for batch Oracle.

This PR adds the "Source Tag" advanced configuration property (https://github.com/estuary/connectors/issues/3240) to `source-oracle-batch`. This is a bit more complicated than it was for the SQL CDC connectors because we didn't have a `/_meta/source` object to add it to, so this PR has to add that as well and gives it a few other possibly-useful values while we're at it.

**Workflow steps:**

No action is required unless the user needs a "Source Tag" property set. If such a property is needed, the user should set it as their `/advanced/source_tag` endpoint config property and it will be added to all documents as `/_meta/source/tag`.

**Notes for reviewers:**

This is really a very straightforward copy-paste of the `source-postgres-batch` implementation of this stuff (https://github.com/estuary/connectors/pull/3245). I ran into some trouble regenerating the test snapshots that require hitting an actual target database, so that part still needs to be done here.
