### PR TITLE
source-salesforce-native: add `SurveyQuestion` and `SurveyQuestionResponse` standard objects

### DIFF
--- a/source-salesforce-native/source_salesforce_native/supported_standard_objects.py
+++ b/source-salesforce-native/source_salesforce_native/supported_standard_objects.py
@@ -4579,6 +4579,12 @@ SUPPORTED_STANDARD_OBJECTS: dict[str, ObjectDetails] = {
     "SurveyInvitation": {
         "cursor_field": CursorFields.SYSTEM_MODSTAMP
     },
+    "SurveyQuestion": {
+        "cursor_field": CursorFields.SYSTEM_MODSTAMP,
+    },
+    "SurveyQuestionResponse": {
+        "cursor_field": CursorFields.SYSTEM_MODSTAMP,
+    },
     "SurveyQuestionScore": {
         "cursor_field": CursorFields.SYSTEM_MODSTAMP
     },


### PR DESCRIPTION
**Description:**

Users have asked for `SurveyQuestion` and `SurveyQuestionResponse` standard object to be added to the list of supported standard objects. I confirmed they both have the `SystemModstamp` field and can be queried via the REST API without using a `WHERE` or `LIMIT` clause (i.e. the connector can currently support capturing these objects).

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

