### PR TITLE
source-jira-native: check permissions for streams using the Service Management API

### DIFF
--- a/source-jira-native/source_jira_native/models.py
+++ b/source-jira-native/source_jira_native/models.py
@@ -752,5 +752,9 @@ PERMISSION_BLOCKED_STREAMS: list[tuple[list[StandardPermissions], list[type[Stre
     (
         [StandardPermissions.USER_PICKER],
         [Users, Groups]
+    ),
+    (
+        [StandardPermissions.SERVICEDESK_AGENT],
+        [ServiceDesks, RequestTypes]
     )
 ]


### PR DESCRIPTION
**Description:**

If the `SERVICEDESK_AGENT` permission doesn't exist for the user's Jira instance or the user doesn't have that permission granted, we shouldn't discover any of the Service Management API streams since they'll fail with a 403 Forbidden error.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

Confirmed that if a user doesn't have the `SERVICEDESK_AGENT` permission granted or that permission doesn't exist in their Jira instance, the Service Management API streams are not discovered.

