### PR TITLE
source-postgres: Increase replication buffer to 512MiB

### DIFF
--- a/source-postgres/replication.go
+++ b/source-postgres/replication.go
@@ -59,7 +59,7 @@ var (
 	rxBufferInitialSize = 1 * 1024 * 1024
 
 	// rxBufferMaximumSize is the maximum size to which the receive buffer may grow, and thus also the maximum size of a single message we can handle.
-	rxBufferMaximumSize = 400 * 1024 * 1024
+	rxBufferMaximumSize = 512 * 1024 * 1024
 )
 
 // A replicationStream represents the process of receiving PostgreSQL


### PR DESCRIPTION
**Description:**

This buffer was intentionally sized very conservatively to ensure we can give a useful error instead of OOMing, but 400->512MiB is probably still safe.