### PR TITLE
filesink: add IAM support for S3

### DIFF
--- a/filesink/store.go
+++ b/filesink/store.go
@@ -37,8 +37,8 @@ type S3Store struct {
 }
 
 type AccessKeyCredentials struct {
-	AWSAccessKeyID     string `json:"aws_access_key_id" jsonschema:"title=AWS Access Key ID,description=Access Key ID for writing data to the bucket." jsonschema_extras:"order=1"`
-	AWSSecretAccessKey string `json:"aws_secret_access_key" jsonschema:"title=AWS Secret Access key,description=Secret Access Key for writing data to the bucket." jsonschema_extras:"secret=true,order=2"`
+	AWSAccessKeyID     string `json:"awsAccessKeyId" jsonschema:"title=AWS Access Key ID,description=Access Key ID for writing data to the bucket." jsonschema_extras:"order=1"`
+	AWSSecretAccessKey string `json:"awsSecretAccessKey" jsonschema:"title=AWS Secret Access key,description=Secret Access Key for writing data to the bucket." jsonschema_extras:"secret=true,order=2"`
 }
 
 type CredentialsConfig struct {
@@ -62,10 +62,10 @@ func (c *CredentialsConfig) Validate() error {
 	switch c.AuthType {
 	case AWSAccessKey:
 		if c.AWSAccessKeyID == "" {
-			return errors.New("missing 'aws_access_key_id'")
+			return errors.New("missing 'awsAccessKeyId'")
 		}
 		if c.AWSSecretAccessKey == "" {
-			return errors.New("missing 'aws_secret_access_key'")
+			return errors.New("missing 'awsSecretAccessKey'")
 		}
 		return nil
 	case AWSIAM:

--- a/filesink/store.go
+++ b/filesink/store.go
@@ -111,10 +111,8 @@ func (c S3StoreConfig) Validate() error {
 		if c.AWSSecretAccessKey == "" {
 			return errors.New("missing 'awsSecretAccessKey'")
 		}
-	} else {
-		if err := c.Credentials.Validate(); err != nil {
-			return err
-		}
+	} else if err := c.Credentials.Validate(); err != nil {
+		return err
 	}
 
 	if _, err := time.ParseDuration(c.UploadInterval); err != nil {

--- a/filesink/store.go
+++ b/filesink/store.go
@@ -37,8 +37,8 @@ type S3Store struct {
 }
 
 type AccessKeyCredentials struct {
-	AWSAccessKeyID     string `json:"awsAccessKeyId" jsonschema:"title=AWS Access Key ID,description=Access Key ID for writing data to the bucket." jsonschema_extras:"order=1"`
-	AWSSecretAccessKey string `json:"awsSecretAccessKey" jsonschema:"title=AWS Secret Access key,description=Secret Access Key for writing data to the bucket." jsonschema_extras:"secret=true,order=2"`
+	AWSAccessKeyID     string `json:"aws_access_key_id" jsonschema:"title=AWS Access Key ID,description=Access Key ID for writing data to the bucket." jsonschema_extras:"order=1"`
+	AWSSecretAccessKey string `json:"aws_secret_access_key" jsonschema:"title=AWS Secret Access key,description=Secret Access Key for writing data to the bucket." jsonschema_extras:"secret=true,order=2"`
 }
 
 type CredentialsConfig struct {
@@ -62,10 +62,10 @@ func (c *CredentialsConfig) Validate() error {
 	switch c.AuthType {
 	case AWSAccessKey:
 		if c.AWSAccessKeyID == "" {
-			return errors.New("missing 'awsAccessKeyId'")
+			return errors.New("missing 'aws_access_key_id'")
 		}
 		if c.AWSSecretAccessKey == "" {
-			return errors.New("missing 'awsSecretAccessKey'")
+			return errors.New("missing 'aws_secret_access_key'")
 		}
 		return nil
 	case AWSIAM:

--- a/filesink/store.go
+++ b/filesink/store.go
@@ -140,7 +140,7 @@ func (c S3StoreConfig) CredentialsProvider(ctx context.Context) (aws.Credentials
 		return credentials.NewStaticCredentialsProvider(
 			c.Credentials.AWSAccessKeyID, c.Credentials.AWSSecretAccessKey, ""), nil
 	case AWSIAM:
-		return c.Credentials.IAMTokens.AWSCredentialsProvider(), nil
+		return c.Credentials.IAMTokens.AWSCredentialsProvider()
 	}
 	return nil, errors.New("unknown 'auth_type'")
 }

--- a/go/auth/iam/config.go
+++ b/go/auth/iam/config.go
@@ -69,7 +69,7 @@ func (c *IAMConfig) ValidateIAM() error {
 			return errors.New("missing 'aws_region'")
 		}
 		if c.AWSRole == "" {
-			return errors.New("missing 'aws_role'")
+			return errors.New("missing 'aws_role_arn'")
 		}
 	case GCPIAM:
 		if c.GCPServiceAccount == "" {
@@ -102,7 +102,16 @@ func (c IAMTokens) Provider() string {
 	}
 }
 
-func (c IAMTokens) AWSCredentialsProvider() aws.CredentialsProvider {
+func (c IAMTokens) AWSCredentialsProvider() (aws.CredentialsProvider, error) {
+	if c.AWSAccessKeyID == "" {
+		return nil, errors.New("missing iam session 'aws_access_key_id'")
+	}
+	if c.AWSSecretAccessKey == "" {
+		return nil, errors.New("missing iam session 'aws_secret_access_key'")
+	}
+	if c.AWSSessionToken == "" {
+		return nil, errors.New("missing iam session 'aws_session_token'")
+	}
 	return credentials.StaticCredentialsProvider{
 		Value: aws.Credentials{
 			AccessKeyID:     c.AWSAccessKeyID,
@@ -110,7 +119,7 @@ func (c IAMTokens) AWSCredentialsProvider() aws.CredentialsProvider {
 			SessionToken:    c.AWSSessionToken,
 			Source:          "flow-iam-generated",
 		},
-	}
+	}, nil
 }
 
 func (c IAMTokens) GoogleToken() string {

--- a/go/auth/iam/config.go
+++ b/go/auth/iam/config.go
@@ -2,12 +2,12 @@ package iam
 
 import (
 	"errors"
+
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/credentials"
-	"github.com/invopop/jsonschema"
 	schemagen "github.com/estuary/connectors/go/schema-gen"
+	"github.com/invopop/jsonschema"
 )
-
 
 type AuthType string
 
@@ -18,7 +18,7 @@ const (
 )
 
 type AWSConfig struct {
-	AWSRegion string `json:"aws_region" jsonschema:"title=AWS Region,description=AWS Region of your database"`
+	AWSRegion string `json:"aws_region" jsonschema:"title=AWS Region,description=AWS Region of your resource"`
 	AWSRole   string `json:"aws_role_arn" jsonschema:"title=AWS Role ARN,description=AWS Role which has access to the resource which will be assumed by Flow"`
 }
 
@@ -39,7 +39,7 @@ type AWSTokens struct {
 }
 
 type GCPTokens struct {
-	GCPAccessToken  string `json:"gcp_access_token,omitempty"`
+	GCPAccessToken string `json:"gcp_access_token,omitempty"`
 }
 
 type AzureTokens struct {
@@ -131,7 +131,7 @@ func (IAMConfig) OneOfSubSchemas() []schemagen.OneOfSubSchemaT {
 
 func (c IAMConfig) JSONSchema() *jsonschema.Schema {
 	schema := schemagen.OneOfSchema("Authentication", "", "auth_type", string(AWSIAM),
-		c.OneOfSubSchemas()...
+		c.OneOfSubSchemas()...,
 	)
 
 	return schema

--- a/materialize-postgres/.snapshots/TestSpecification
+++ b/materialize-postgres/.snapshots/TestSpecification
@@ -73,7 +73,7 @@
               "aws_region": {
                 "type": "string",
                 "title": "AWS Region",
-                "description": "AWS Region of your database"
+                "description": "AWS Region of your resource"
               },
               "aws_role_arn": {
                 "type": "string",

--- a/materialize-postgres/driver.go
+++ b/materialize-postgres/driver.go
@@ -191,13 +191,16 @@ func (c config) ToURI(ctx context.Context) (string, error) {
 		case UserPassword:
 			pass = c.Credentials.Password
 		case AWSIAM:
-			var err error
+			credProvider, err := c.Credentials.AWSCredentialsProvider()
+			if err != nil {
+				return "", err
+			}
 			pass, err = auth.BuildAuthToken(
 				ctx,
 				ensurePort(c.Address),
 				c.Credentials.AWSRegion,
 				user,
-				c.Credentials.AWSCredentialsProvider(),
+				credProvider,
 			)
 			if err != nil {
 				return "", fmt.Errorf("building AWS auth token: %w", err)

--- a/materialize-s3-csv/.snapshots/TestSpec
+++ b/materialize-s3-csv/.snapshots/TestSpec
@@ -27,13 +27,13 @@
                 "default": "AWSAccessKey",
                 "order": 0
               },
-              "aws_access_key_id": {
+              "awsAccessKeyId": {
                 "type": "string",
                 "title": "AWS Access Key ID",
                 "description": "Access Key ID for writing data to the bucket.",
                 "order": 1
               },
-              "aws_secret_access_key": {
+              "awsSecretAccessKey": {
                 "type": "string",
                 "title": "AWS Secret Access key",
                 "description": "Secret Access Key for writing data to the bucket.",
@@ -43,8 +43,8 @@
             },
             "type": "object",
             "required": [
-              "aws_access_key_id",
-              "aws_secret_access_key"
+              "awsAccessKeyId",
+              "awsSecretAccessKey"
             ],
             "title": "Access Key"
           },

--- a/materialize-s3-csv/.snapshots/TestSpec
+++ b/materialize-s3-csv/.snapshots/TestSpec
@@ -9,24 +9,85 @@
         "description": "Bucket to store materialized objects.",
         "order": 0
       },
-      "awsAccessKeyId": {
-        "type": "string",
-        "title": "AWS Access Key ID",
-        "description": "Access Key ID for writing data to the bucket.",
-        "order": 1
-      },
-      "awsSecretAccessKey": {
-        "type": "string",
-        "title": "AWS Secret Access key",
-        "description": "Secret Access Key for writing data to the bucket.",
-        "order": 2,
-        "secret": true
-      },
-      "region": {
-        "type": "string",
-        "title": "Region",
-        "description": "Region of the bucket to write to.",
-        "order": 3
+      "credentials": {
+        "oneOf": [
+          {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$id": "https://github.com/estuary/connectors/filesink/access-key-credentials",
+            "properties": {
+              "auth_type": {
+                "type": "string",
+                "const": "AWSAccessKey",
+                "default": "AWSAccessKey",
+                "order": 0
+              },
+              "awsAccessKeyId": {
+                "type": "string",
+                "title": "AWS Access Key ID",
+                "description": "Access Key ID for writing data to the bucket.",
+                "order": 1
+              },
+              "awsSecretAccessKey": {
+                "type": "string",
+                "title": "AWS Secret Access key",
+                "description": "Secret Access Key for writing data to the bucket.",
+                "order": 2,
+                "secret": true
+              },
+              "awsRegion": {
+                "type": "string",
+                "title": "Region",
+                "description": "Region of the bucket to write to.",
+                "order": 3
+              }
+            },
+            "type": "object",
+            "required": [
+              "awsAccessKeyId",
+              "awsSecretAccessKey",
+              "awsRegion"
+            ],
+            "title": "Access Key"
+          },
+          {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$id": "https://github.com/estuary/connectors/go/auth/iam/aws-config",
+            "properties": {
+              "auth_type": {
+                "type": "string",
+                "const": "AWSIAM",
+                "default": "AWSIAM",
+                "order": 0
+              },
+              "aws_region": {
+                "type": "string",
+                "title": "AWS Region",
+                "description": "AWS Region of your resource"
+              },
+              "aws_role_arn": {
+                "type": "string",
+                "title": "AWS Role ARN",
+                "description": "AWS Role which has access to the resource which will be assumed by Flow"
+              }
+            },
+            "type": "object",
+            "required": [
+              "aws_region",
+              "aws_role_arn"
+            ],
+            "title": "AWS IAM"
+          }
+        ],
+        "type": "object",
+        "title": "Authentication",
+        "default": {
+          "auth_type": "AWSAccessKey"
+        },
+        "discriminator": {
+          "propertyName": "auth_type"
+        },
+        "order": 3,
+        "x-iam-auth": true
       },
       "uploadInterval": {
         "type": "string",
@@ -90,9 +151,7 @@
     "type": "object",
     "required": [
       "bucket",
-      "awsAccessKeyId",
-      "awsSecretAccessKey",
-      "region",
+      "credentials",
       "uploadInterval"
     ],
     "title": "EndpointConfig"

--- a/materialize-s3-csv/.snapshots/TestSpec
+++ b/materialize-s3-csv/.snapshots/TestSpec
@@ -9,6 +9,12 @@
         "description": "Bucket to store materialized objects.",
         "order": 0
       },
+      "region": {
+        "type": "string",
+        "title": "Region",
+        "description": "Region of the bucket to write to.",
+        "order": 3
+      },
       "credentials": {
         "oneOf": [
           {
@@ -33,19 +39,12 @@
                 "description": "Secret Access Key for writing data to the bucket.",
                 "order": 2,
                 "secret": true
-              },
-              "awsRegion": {
-                "type": "string",
-                "title": "Region",
-                "description": "Region of the bucket to write to.",
-                "order": 3
               }
             },
             "type": "object",
             "required": [
               "awsAccessKeyId",
-              "awsSecretAccessKey",
-              "awsRegion"
+              "awsSecretAccessKey"
             ],
             "title": "Access Key"
           },
@@ -86,7 +85,7 @@
         "discriminator": {
           "propertyName": "auth_type"
         },
-        "order": 3,
+        "order": 4,
         "x-iam-auth": true
       },
       "uploadInterval": {
@@ -100,25 +99,25 @@
         "title": "Upload Interval",
         "description": "Frequency at which files will be uploaded. Must be a valid Go duration string.",
         "default": "5m",
-        "order": 4
+        "order": 5
       },
       "prefix": {
         "type": "string",
         "title": "Prefix",
         "description": "Optional prefix that will be used to store objects.",
-        "order": 5
+        "order": 6
       },
       "fileSizeLimit": {
         "type": "integer",
         "title": "File Size Limit",
         "description": "Approximate maximum size of materialized files in bytes. Defaults to 10737418240 (10 GiB) if blank.",
-        "order": 6
+        "order": 7
       },
       "endpoint": {
         "type": "string",
         "title": "Custom S3 Endpoint",
         "description": "The S3 endpoint URI to connect to. Use if you're materializing to a compatible API that isn't provided by AWS. Should normally be left blank.",
-        "order": 7
+        "order": 8
       },
       "csvConfig": {
         "properties": {
@@ -151,6 +150,7 @@
     "type": "object",
     "required": [
       "bucket",
+      "region",
       "credentials",
       "uploadInterval"
     ],

--- a/materialize-s3-csv/.snapshots/TestSpec
+++ b/materialize-s3-csv/.snapshots/TestSpec
@@ -27,13 +27,13 @@
                 "default": "AWSAccessKey",
                 "order": 0
               },
-              "awsAccessKeyId": {
+              "aws_access_key_id": {
                 "type": "string",
                 "title": "AWS Access Key ID",
                 "description": "Access Key ID for writing data to the bucket.",
                 "order": 1
               },
-              "awsSecretAccessKey": {
+              "aws_secret_access_key": {
                 "type": "string",
                 "title": "AWS Secret Access key",
                 "description": "Secret Access Key for writing data to the bucket.",
@@ -43,8 +43,8 @@
             },
             "type": "object",
             "required": [
-              "awsAccessKeyId",
-              "awsSecretAccessKey"
+              "aws_access_key_id",
+              "aws_secret_access_key"
             ],
             "title": "Access Key"
           },

--- a/materialize-s3-parquet/.snapshots/TestSpec
+++ b/materialize-s3-parquet/.snapshots/TestSpec
@@ -27,13 +27,13 @@
                 "default": "AWSAccessKey",
                 "order": 0
               },
-              "aws_access_key_id": {
+              "awsAccessKeyId": {
                 "type": "string",
                 "title": "AWS Access Key ID",
                 "description": "Access Key ID for writing data to the bucket.",
                 "order": 1
               },
-              "aws_secret_access_key": {
+              "awsSecretAccessKey": {
                 "type": "string",
                 "title": "AWS Secret Access key",
                 "description": "Secret Access Key for writing data to the bucket.",
@@ -43,8 +43,8 @@
             },
             "type": "object",
             "required": [
-              "aws_access_key_id",
-              "aws_secret_access_key"
+              "awsAccessKeyId",
+              "awsSecretAccessKey"
             ],
             "title": "Access Key"
           },

--- a/materialize-s3-parquet/.snapshots/TestSpec
+++ b/materialize-s3-parquet/.snapshots/TestSpec
@@ -9,24 +9,85 @@
         "description": "Bucket to store materialized objects.",
         "order": 0
       },
-      "awsAccessKeyId": {
-        "type": "string",
-        "title": "AWS Access Key ID",
-        "description": "Access Key ID for writing data to the bucket.",
-        "order": 1
-      },
-      "awsSecretAccessKey": {
-        "type": "string",
-        "title": "AWS Secret Access key",
-        "description": "Secret Access Key for writing data to the bucket.",
-        "order": 2,
-        "secret": true
-      },
-      "region": {
-        "type": "string",
-        "title": "Region",
-        "description": "Region of the bucket to write to.",
-        "order": 3
+      "credentials": {
+        "oneOf": [
+          {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$id": "https://github.com/estuary/connectors/filesink/access-key-credentials",
+            "properties": {
+              "auth_type": {
+                "type": "string",
+                "const": "AWSAccessKey",
+                "default": "AWSAccessKey",
+                "order": 0
+              },
+              "awsAccessKeyId": {
+                "type": "string",
+                "title": "AWS Access Key ID",
+                "description": "Access Key ID for writing data to the bucket.",
+                "order": 1
+              },
+              "awsSecretAccessKey": {
+                "type": "string",
+                "title": "AWS Secret Access key",
+                "description": "Secret Access Key for writing data to the bucket.",
+                "order": 2,
+                "secret": true
+              },
+              "awsRegion": {
+                "type": "string",
+                "title": "Region",
+                "description": "Region of the bucket to write to.",
+                "order": 3
+              }
+            },
+            "type": "object",
+            "required": [
+              "awsAccessKeyId",
+              "awsSecretAccessKey",
+              "awsRegion"
+            ],
+            "title": "Access Key"
+          },
+          {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$id": "https://github.com/estuary/connectors/go/auth/iam/aws-config",
+            "properties": {
+              "auth_type": {
+                "type": "string",
+                "const": "AWSIAM",
+                "default": "AWSIAM",
+                "order": 0
+              },
+              "aws_region": {
+                "type": "string",
+                "title": "AWS Region",
+                "description": "AWS Region of your resource"
+              },
+              "aws_role_arn": {
+                "type": "string",
+                "title": "AWS Role ARN",
+                "description": "AWS Role which has access to the resource which will be assumed by Flow"
+              }
+            },
+            "type": "object",
+            "required": [
+              "aws_region",
+              "aws_role_arn"
+            ],
+            "title": "AWS IAM"
+          }
+        ],
+        "type": "object",
+        "title": "Authentication",
+        "default": {
+          "auth_type": "AWSAccessKey"
+        },
+        "discriminator": {
+          "propertyName": "auth_type"
+        },
+        "order": 3,
+        "x-iam-auth": true
       },
       "uploadInterval": {
         "type": "string",
@@ -96,9 +157,7 @@
     "type": "object",
     "required": [
       "bucket",
-      "awsAccessKeyId",
-      "awsSecretAccessKey",
-      "region",
+      "credentials",
       "uploadInterval"
     ],
     "title": "EndpointConfig"

--- a/materialize-s3-parquet/.snapshots/TestSpec
+++ b/materialize-s3-parquet/.snapshots/TestSpec
@@ -9,6 +9,12 @@
         "description": "Bucket to store materialized objects.",
         "order": 0
       },
+      "region": {
+        "type": "string",
+        "title": "Region",
+        "description": "Region of the bucket to write to.",
+        "order": 3
+      },
       "credentials": {
         "oneOf": [
           {
@@ -33,19 +39,12 @@
                 "description": "Secret Access Key for writing data to the bucket.",
                 "order": 2,
                 "secret": true
-              },
-              "awsRegion": {
-                "type": "string",
-                "title": "Region",
-                "description": "Region of the bucket to write to.",
-                "order": 3
               }
             },
             "type": "object",
             "required": [
               "awsAccessKeyId",
-              "awsSecretAccessKey",
-              "awsRegion"
+              "awsSecretAccessKey"
             ],
             "title": "Access Key"
           },
@@ -86,7 +85,7 @@
         "discriminator": {
           "propertyName": "auth_type"
         },
-        "order": 3,
+        "order": 4,
         "x-iam-auth": true
       },
       "uploadInterval": {
@@ -100,25 +99,25 @@
         "title": "Upload Interval",
         "description": "Frequency at which files will be uploaded. Must be a valid Go duration string.",
         "default": "5m",
-        "order": 4
+        "order": 5
       },
       "prefix": {
         "type": "string",
         "title": "Prefix",
         "description": "Optional prefix that will be used to store objects.",
-        "order": 5
+        "order": 6
       },
       "fileSizeLimit": {
         "type": "integer",
         "title": "File Size Limit",
         "description": "Approximate maximum size of materialized files in bytes. Defaults to 10737418240 (10 GiB) if blank.",
-        "order": 6
+        "order": 7
       },
       "endpoint": {
         "type": "string",
         "title": "Custom S3 Endpoint",
         "description": "The S3 endpoint URI to connect to. Use if you're materializing to a compatible API that isn't provided by AWS. Should normally be left blank.",
-        "order": 7
+        "order": 8
       },
       "parquetConfig": {
         "properties": {
@@ -157,6 +156,7 @@
     "type": "object",
     "required": [
       "bucket",
+      "region",
       "credentials",
       "uploadInterval"
     ],

--- a/materialize-s3-parquet/.snapshots/TestSpec
+++ b/materialize-s3-parquet/.snapshots/TestSpec
@@ -27,13 +27,13 @@
                 "default": "AWSAccessKey",
                 "order": 0
               },
-              "awsAccessKeyId": {
+              "aws_access_key_id": {
                 "type": "string",
                 "title": "AWS Access Key ID",
                 "description": "Access Key ID for writing data to the bucket.",
                 "order": 1
               },
-              "awsSecretAccessKey": {
+              "aws_secret_access_key": {
                 "type": "string",
                 "title": "AWS Secret Access key",
                 "description": "Secret Access Key for writing data to the bucket.",
@@ -43,8 +43,8 @@
             },
             "type": "object",
             "required": [
-              "awsAccessKeyId",
-              "awsSecretAccessKey"
+              "aws_access_key_id",
+              "aws_secret_access_key"
             ],
             "title": "Access Key"
           },

--- a/source-postgres/.snapshots/TestGeneric-SpecResponse
+++ b/source-postgres/.snapshots/TestGeneric-SpecResponse
@@ -67,7 +67,7 @@
               "aws_region": {
                 "type": "string",
                 "title": "AWS Region",
-                "description": "AWS Region of your database"
+                "description": "AWS Region of your resource"
               },
               "aws_role_arn": {
                 "type": "string",

--- a/source-postgres/main.go
+++ b/source-postgres/main.go
@@ -129,9 +129,9 @@ type authType string
 
 const (
 	UserPassword authType = "UserPassword"
-	GCPIAM authType = "GCPIAM"
-	AWSIAM authType = "AWSIAM"
-	AzureIAM authType = "AzureIAM"
+	GCPIAM       authType = "GCPIAM"
+	AWSIAM       authType = "AWSIAM"
+	AzureIAM     authType = "AzureIAM"
 )
 
 type userPassword struct {
@@ -150,7 +150,7 @@ func (credentialConfig) JSONSchema() *jsonschema.Schema {
 		schemagen.OneOfSubSchema("Password", userPassword{}, string(UserPassword)),
 	}
 	subSchemas = append(subSchemas, (iam.IAMConfig{}).OneOfSubSchemas()...)
-	
+
 	schema := schemagen.OneOfSchema("Authentication", "", "auth_type", string(UserPassword), subSchemas...)
 
 	return schema
@@ -325,13 +325,16 @@ func (c *Config) ToURI(ctx context.Context) (string, error) {
 		case UserPassword:
 			pass = c.Credentials.Password
 		case AWSIAM:
-			var err error
+			credProvider, err := c.Credentials.AWSCredentialsProvider()
+			if err != nil {
+				return "", err
+			}
 			pass, err = auth.BuildAuthToken(
 				ctx,
 				c.Address,
 				c.Credentials.AWSRegion,
 				user,
-				c.Credentials.AWSCredentialsProvider(),
+				credProvider,
 			)
 			if err != nil {
 				return "", fmt.Errorf("building AWS auth token: %w", err)


### PR DESCRIPTION
**Description:**

This adds support for AWS IAM to materialize-s3-parquet and materialize-s3-csv.  Users who wish to use IAM authentication will need to configure a Role according to our [documentation][1].

related: https://github.com/estuary/flow/issues/2123

[1]: https://docs.estuary.dev/guides/iam-auth/aws/

**Workflow steps:**

NA

**Documentation links affected:**

- https://github.com/estuary/flow/pull/2403

**Notes for reviewers:**

