### PR TITLE
source-datadog: validate credentials with the `/logs` endpoint

### DIFF
--- a/source-datadog/source_datadog/resources.py
+++ b/source-datadog/source_datadog/resources.py
@@ -28,17 +28,15 @@ INCREMENTAL_RESOURCES: list[
 
 
 async def validate_credentials(log: Logger, http: HTTPSession, config: EndpointConfig):
-    url = f"{config.base_url}/rum/events/search"
+    url = f"{config.base_url}/logs/events/search"
     headers = config.common_headers
     body = {
         "filter": {
             "from": "now-1s",
-            "query": "*",
         },
         "page": {
             "limit": 1,
         },
-        "sort": "timestamp",
     }
 
     try:


### PR DESCRIPTION
**Description:**

Not all users have RUM events enabled, and `validate_credentials` is preventing those users from setting up a capture even if they have valid credentials.

Instead of using the `/rum` endpoint, we should use an always accessible endpoint to validate credentials. I suspect `/logs` is one such endpoint since there are no required permissions for it listed in the API docs.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

Confirmed existing users and the one that doesn't have access to the `/rum` endpoint do have access to the `/logs` endpoint.

