### PR TITLE
materialize-motherduck: support datetime to string migration

### DIFF
--- a/materialize-motherduck/.snapshots/TestValidateAndApplyMigrations
+++ b/materialize-motherduck/.snapshots/TestValidateAndApplyMigrations
@@ -45,14 +45,14 @@ Migratable Changes Before Apply Schema:
 
 
 Migratable Changes Before Apply Data:
-key (VARCHAR), _meta/flow_truncated (BOOLEAN), boolWidenedToJson (BOOLEAN), dateValue (DATE), datetimeValue (TIMESTAMPTZ), flow_published_at (TIMESTAMPTZ), int64 (BIGINT), int64ToNumber (HUGEINT), intToNumber (BIGINT), intWidenedToJson (BIGINT), multiple (VARCHAR), nonScalarValue (VARCHAR), numericString (HUGEINT), optional (VARCHAR), requiredNumeric (HUGEINT), scalarValue (VARCHAR), second_root (VARCHAR), stringWidenedToJson (VARCHAR), timeValue (TIME), flow_document (VARCHAR)
-1, false, true, 2024-01-01T00:00:00Z, 2024-01-01T06:01:01.111111Z, 2024-09-13T05:01:01Z, 1, 10000000000000000000, 9223372036854775807, 999, <nil>, <nil>, 123, <nil>, 456, test, map[], hello, 0001-01-01T01:01:01Z, map[]
+key (VARCHAR), _meta/flow_truncated (BOOLEAN), boolWidenedToJson (BOOLEAN), dateValue (DATE), datetimeValue (TIMESTAMPTZ), flow_document (JSON), flow_published_at (TIMESTAMPTZ), int64 (BIGINT), int64ToNumber (HUGEINT), intToNumber (BIGINT), intWidenedToJson (BIGINT), multiple (JSON), nonScalarValue (JSON), numericString (HUGEINT), optional (JSON), requiredNumeric (HUGEINT), scalarValue (VARCHAR), stringWidenedToJson (VARCHAR), timeValue (TIME), second_root (JSON)
+1, false, true, 2024-01-01T00:00:00Z, 2024-01-01T06:01:01.111111Z, map[], 2024-09-13T05:01:01Z, 1, 10000000000000000000, 9223372036854775807, 999, <nil>, <nil>, 123, <nil>, 456, test, hello, 0001-01-01T01:01:01Z, map[]
 
 Migratable Changes Constraints:
 {"Field":"_meta/flow_truncated","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
 {"Field":"boolWidenedToJson","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
 {"Field":"dateValue","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"datetimeValue","Type":6,"TypeString":"INCOMPATIBLE","Reason":"Field 'datetimeValue' is already being materialized as endpoint type 'TIMESTAMP WITH TIME ZONE' but endpoint type 'VARCHAR' is required by its schema '{ type: [string] }'"}
+{"Field":"datetimeValue","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
 {"Field":"flow_document","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
 {"Field":"flow_published_at","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
 {"Field":"int64","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
@@ -75,7 +75,7 @@ Migratable Changes Applied Schema:
 {"Name":"_meta/flow_truncated","Nullable":"NO","Type":"BOOLEAN"}
 {"Name":"boolWidenedToJson","Nullable":"YES","Type":"JSON"}
 {"Name":"dateValue","Nullable":"YES","Type":"VARCHAR"}
-{"Name":"datetimeValue","Nullable":"YES","Type":"TIMESTAMP WITH TIME ZONE"}
+{"Name":"datetimeValue","Nullable":"YES","Type":"VARCHAR"}
 {"Name":"flow_document","Nullable":"NO","Type":"JSON"}
 {"Name":"flow_published_at","Nullable":"NO","Type":"TIMESTAMP WITH TIME ZONE"}
 {"Name":"int64","Nullable":"YES","Type":"HUGEINT"}
@@ -95,6 +95,6 @@ Migratable Changes Applied Schema:
 
 
 Migratable Changes Applied Data:
-key (VARCHAR), _meta/flow_truncated (BOOLEAN), datetimeValue (TIMESTAMPTZ), flow_published_at (TIMESTAMPTZ), multiple (VARCHAR), nonScalarValue (VARCHAR), optional (VARCHAR), scalarValue (VARCHAR), second_root (VARCHAR), flow_document (VARCHAR), boolWidenedToJson (VARCHAR), dateValue (VARCHAR), int64 (HUGEINT), int64ToNumber (DOUBLE), intToNumber (DOUBLE), intWidenedToJson (VARCHAR), numericString (VARCHAR), requiredNumeric (VARCHAR), stringWidenedToJson (VARCHAR), timeValue (VARCHAR)
-1, false, 2024-01-01T06:01:01.111111Z, 2024-09-13T05:01:01Z, <nil>, <nil>, <nil>, test, map[], map[], true, 2024-01-01, 1, 1e+19, 9.223372036854776e+18, 999, 123, 456, hello, 01:01:01
+key (VARCHAR), _meta/flow_truncated (BOOLEAN), flow_document (JSON), flow_published_at (TIMESTAMPTZ), multiple (JSON), nonScalarValue (JSON), optional (JSON), scalarValue (VARCHAR), second_root (JSON), boolWidenedToJson (JSON), dateValue (VARCHAR), datetimeValue (VARCHAR), int64 (HUGEINT), int64ToNumber (DOUBLE), intToNumber (DOUBLE), intWidenedToJson (JSON), numericString (VARCHAR), requiredNumeric (VARCHAR), stringWidenedToJson (JSON), timeValue (VARCHAR)
+1, false, map[], 2024-09-13T05:01:01Z, <nil>, <nil>, <nil>, test, map[], true, 2024-01-01, 2024-01-01T06:01:01.111111Z, 1, 1e+19, 9.223372036854776e+18, 999, 123, 456, hello, 01:01:01
 

--- a/materialize-motherduck/sqlgen.go
+++ b/materialize-motherduck/sqlgen.go
@@ -46,12 +46,13 @@ var duckDialect = func() sql.Dialect {
 
 	return sql.Dialect{
 		MigratableTypes: sql.MigrationSpecs{
-			"double":  {sql.NewMigrationSpec([]string{"varchar"})},
-			"bigint":  {sql.NewMigrationSpec([]string{"double", "hugeint", "varchar"})},
-			"hugeint": {sql.NewMigrationSpec([]string{"double", "varchar"})},
-			"date":    {sql.NewMigrationSpec([]string{"varchar"})},
-			"time":    {sql.NewMigrationSpec([]string{"varchar"})},
-			"*":       {sql.NewMigrationSpec([]string{"json"}, sql.WithCastSQL(toJsonCast))},
+			"double":                   {sql.NewMigrationSpec([]string{"varchar"})},
+			"bigint":                   {sql.NewMigrationSpec([]string{"double", "hugeint", "varchar"})},
+			"hugeint":                  {sql.NewMigrationSpec([]string{"double", "varchar"})},
+			"date":                     {sql.NewMigrationSpec([]string{"varchar"})},
+			"timestamp with time zone": {sql.NewMigrationSpec([]string{"varchar"}, sql.WithCastSQL(datetimeToStringCast))},
+			"time":                     {sql.NewMigrationSpec([]string{"varchar"})},
+			"*":                        {sql.NewMigrationSpec([]string{"json"}, sql.WithCastSQL(toJsonCast))},
 		},
 		TableLocatorer: sql.TableLocatorFn(func(path []string) sql.InfoTableLocation {
 			return sql.InfoTableLocation{TableSchema: path[1], TableName: path[2]}
@@ -75,12 +76,9 @@ var duckDialect = func() sql.Dialect {
 	}
 }()
 
-/* TODO: Unfortunately I have not been able to get this working, I keep getting an error about this
-   function not existing... which is strange
-
 func datetimeToStringCast(migration sql.ColumnTypeMigration) string {
 	return fmt.Sprintf(`strftime(timezone('UTC', %s), '%%Y-%%m-%%dT%%H:%%M:%%S.%%fZ')`, migration.Identifier)
-}*/
+}
 
 func toJsonCast(migration sql.ColumnTypeMigration) string {
 	return fmt.Sprintf(`to_json(%s)`, migration.Identifier)


### PR DESCRIPTION
**Description:**

This must have started working with recent MotherDuck/duckdb updates, because all I needed to do was uncomment the migration function and add the mapping to the migration specs.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

The migration test snapshots get scrambled every time the tests are manually run. I'm not sure what was going on with the JSON columns having been VARCHAR before, but things at least look correct now on a fresh run.

