### PR TITLE
Allow TLS to be disabled for Kafka capture

### DIFF
--- a/source-kafka/README.md
+++ b/source-kafka/README.md
@@ -42,11 +42,41 @@ To connect to the cluster, you'll need to craft a `config.json` file that matche
 
 The Kafka cluster will need to be configured to allow client to connect. See the [`librdkafka` documentation on `bootstrap_servers`](https://github.com/edenhill/librdkafka/blob/master/CONFIGURATION.md#global-configuration-properties) for more information.
 
-Example:
+### Basic PLAINTEXT Configuration (No Authentication)
 
 ```json
 {
   "bootstrap_servers": "localhost:9092"
+}
+```
+
+### SASL_SSL Configuration (Secure with TLS)
+
+```json
+{
+  "bootstrap_servers": "localhost:9093",
+  "credentials": {
+    "auth_type": "user_password",
+    "mechanism": "PLAIN",
+    "username": "your_username",
+    "password": "your_password"
+  },
+  "tls": "system_certificates"
+}
+```
+
+### SASL_PLAINTEXT Configuration (SASL without TLS)
+
+```json
+{
+  "bootstrap_servers": "localhost:9094",
+  "credentials": {
+    "auth_type": "user_password",
+    "mechanism": "PLAIN",
+    "username": "your_username",
+    "password": "your_password"
+  },
+  "tls": "disabled"
 }
 ```
 

--- a/source-kafka/src/configuration.rs
+++ b/source-kafka/src/configuration.rs
@@ -54,6 +54,7 @@ impl std::fmt::Display for SaslMechanism {
 #[serde(rename_all = "snake_case")]
 pub enum TlsSettings {
     SystemCertificates,
+    Disabled,
 }
 
 #[derive(Serialize, Deserialize)]
@@ -191,7 +192,8 @@ impl JsonSchema for EndpointConfig {
                     "default": "system_certificates",
                     "description": "Controls how should TLS certificates be found or used.",
                     "enum": [
-                        "system_certificates"
+                        "system_certificates",
+                        "disabled"
                     ],
                     "title": "TLS Settings",
                     "type": "string",
@@ -352,8 +354,10 @@ impl EndpointConfig {
     fn security_protocol(&self) -> &'static str {
         match (&self.credentials, &self.tls) {
             (None, Some(TlsSettings::SystemCertificates)) => "SSL",
+            (None, Some(TlsSettings::Disabled)) => "PLAINTEXT",
             (None, None) => "PLAINTEXT",
             (Some(_), Some(TlsSettings::SystemCertificates)) => "SASL_SSL",
+            (Some(_), Some(TlsSettings::Disabled)) => "SASL_PLAINTEXT",
             (Some(_), None) => "SASL_PLAINTEXT",
         }
     }


### PR DESCRIPTION
Allow TLS to be disabled in kafka capture so SASL_PLAINTEXT can be used