### PR TITLE
materialize-motherduck: uuid to string migrations

### DIFF
--- a/materialize-motherduck/sqlgen.go
+++ b/materialize-motherduck/sqlgen.go
@@ -52,6 +52,7 @@ var duckDialect = func() sql.Dialect {
 			"date":                     {sql.NewMigrationSpec([]string{"varchar"})},
 			"timestamp with time zone": {sql.NewMigrationSpec([]string{"varchar"}, sql.WithCastSQL(datetimeToStringCast))},
 			"time":                     {sql.NewMigrationSpec([]string{"varchar"})},
+			"uuid":                     {sql.NewMigrationSpec([]string{"varchar"})},
 			"*":                        {sql.NewMigrationSpec([]string{"json"}, sql.WithCastSQL(toJsonCast))},
 		},
 		TableLocatorer: sql.TableLocatorFn(func(path []string) sql.InfoTableLocation {


### PR DESCRIPTION
**Description:**

duckdb supports a specific UUID column type, and we'll use that for `type: string, format: uuid` fields.

This adds a migration for the widening of such a field to just `type: string`.

It works using the basic `CAST THING AS OTHER` default SQL casting query.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

