### PR TITLE
materialize-motherduck: use string columns for durations

### DIFF
--- a/materialize-motherduck/sqlgen.go
+++ b/materialize-motherduck/sqlgen.go
@@ -35,7 +35,6 @@ var duckDialect = func() sql.Dialect {
 				WithFormat: map[string]sql.MapProjectionFn{
 					"date":      sql.MapStatic("DATE"),
 					"date-time": sql.MapStatic("TIMESTAMP WITH TIME ZONE"),
-					"duration":  sql.MapStatic("INTERVAL"),
 					"time":      sql.MapStatic("TIME"),
 					"uuid":      sql.MapStatic("UUID"),
 				},


### PR DESCRIPTION
**Description:**

The previous INTERVAL column would not work with ISO 8601 duration strings, which is what Flow collections contain for `type: string, format: duration` fields.

duckdb uses a different format for these intervals, more like a Go duration string. We could probably parse & convert these duration strings, but there would also be the migration case to consider where we'd ideally want to get the duckdb INTERVAL values back to their original ISO 8601 strings. This would all be quite tricky to get right and doesn't seem worth it right now since these types of fields are very rare, and a string column will probably work fine for them anyway.

This change will make the connector no longer fail with a field like this is being materialized, and also prevent potential backfilling if one is being materialized but then changes to a regular string via schema widening. Going forward it will just always be a string.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

