### PR TITLE
materialize-snowflake: add maxRetryCount parameter to connection string

### DIFF
--- a/materialize-snowflake/.snapshots/TestConfigURI-Optional_Parameters
+++ b/materialize-snowflake/.snapshots/TestConfigURI-Optional_Parameters
@@ -1,1 +1,1 @@
-alex:mysecret@orgname-accountname.snowflakecomputing.com:443?GO_QUERY_RESULT_FORMAT=json&MULTI_STATEMENT_COUNT=0&account=myaccount&application=EstuaryFlow&client_session_keep_alive=true&database=mydb&role=myrole&schema=myschema&warehouse=mywarehouse
+alex:mysecret@orgname-accountname.snowflakecomputing.com:443?GO_QUERY_RESULT_FORMAT=json&MULTI_STATEMENT_COUNT=0&account=myaccount&application=EstuaryFlow&client_session_keep_alive=true&database=mydb&maxRetryCount=10&role=myrole&schema=myschema&warehouse=mywarehouse

--- a/materialize-snowflake/.snapshots/TestConfigURI-User_&_Password_Authentication
+++ b/materialize-snowflake/.snapshots/TestConfigURI-User_&_Password_Authentication
@@ -1,1 +1,1 @@
-will:some%2Bcomplex%2Fpassword@orgname-accountname.snowflakecomputing.com:443?GO_QUERY_RESULT_FORMAT=json&MULTI_STATEMENT_COUNT=0&application=EstuaryFlow&client_session_keep_alive=true&database=mydb&schema=myschema
+will:some%2Bcomplex%2Fpassword@orgname-accountname.snowflakecomputing.com:443?GO_QUERY_RESULT_FORMAT=json&MULTI_STATEMENT_COUNT=0&application=EstuaryFlow&client_session_keep_alive=true&database=mydb&maxRetryCount=10&schema=myschema

--- a/materialize-snowflake/config.go
+++ b/materialize-snowflake/config.go
@@ -66,6 +66,7 @@ func (c config) toURI(includeSchema bool) (string, error) {
 	// client_session_keep_alive causes the driver to issue a periodic keepalive request.
 	// Without this, the authentication token will expire after 4 hours of inactivity.
 	queryParams.Add("client_session_keep_alive", "true")
+	queryParams.Add("maxRetryCount", "10")
 
 	// Optional params
 	if c.Warehouse != "" {


### PR DESCRIPTION
**Description:**

We don't use the Go Snowflake driver's Config struct to build a DSN anymore since we have the "account" as an optional input, but that Config will automatically add a `maxRetryCount` parameter with a default value of 7 to connection strings.

There is some observational evidence that transient errors are not getting retried for basic queries, although somehow PUT queries do seem to get retried internally by the driver.

This adds `maxRetryCount=10` to our connection strings to ensure that retryable failures are retried in general.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

