### PR TITLE
Revert "materialize-snowflake: retry failed PUTs to stage a few times"

### DIFF
--- a/materialize-snowflake/staged_file.go
+++ b/materialize-snowflake/staged_file.go
@@ -9,7 +9,6 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
-	"time"
 
 	"github.com/estuary/connectors/go/writer"
 	"github.com/google/uuid"
@@ -212,30 +211,12 @@ func (f *stagedFile) putWorker(ctx context.Context, db *stdsql.DB, filePaths <-c
 			file, f.uuid,
 		)
 		var source, target, sourceSize, targetSize, sourceCompression, targetCompression, status, message string
-		var attempt int
-		// Retry a few times on errors since there are occasionally transient
-		// network errors when running PUT queries.
-		for attempt = 1; ; attempt++ {
-			// NB: Not using QueryRowContext here since the Go Snowflake driver
-			// retains contexts internally, and this worker is called with a context
-			// that is cancelled after group.Wait() returns.
-			err := db.QueryRow(query).Scan(&source, &target, &sourceSize, &targetSize, &sourceCompression, &targetCompression, &status, &message)
-			if err != nil && attempt > 3 {
-				return fmt.Errorf("putWorker PUT to stage: %w", err)
-			} else if err != nil {
-				delay := time.Duration(attempt) * time.Second
-				log.WithFields(log.Fields{
-					"attempt": attempt,
-					"delay":   delay,
-				}).WithError(err).Info("putWorker retrying PUT to stage")
-				time.Sleep(delay)
-				continue
-			}
-
-			break
-		}
-
-		if !strings.EqualFold("uploaded", status) {
+		// NB: Not using QueryRowContext here since the Go Snowflake driver
+		// retains contexts internally, and this worker is called with a context
+		// that is cancelled after group.Wait() returns.
+		if err := db.QueryRow(query).Scan(&source, &target, &sourceSize, &targetSize, &sourceCompression, &targetCompression, &status, &message); err != nil {
+			return fmt.Errorf("putWorker PUT to stage: %w", err)
+		} else if !strings.EqualFold("uploaded", status) {
 			return fmt.Errorf("putWorker PUT to stage unexpected upload status: %s", status)
 		}
 


### PR DESCRIPTION
**Description:**

This reverts commit 61e23d4965e4b21d65cf2fe71b56f5af3b0d4aa2.

The change here does not seem necessary after bfa06dc, which added the retry parameter for the Snowflake connection string. That apparently took care of the issue by itself, and this janky retry logic is no longer needed.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

