### PR TITLE
materialize-elasticsearch: support "routing" field config

### DIFF
--- a/materialize-elasticsearch/type_mapping.go
+++ b/materialize-elasticsearch/type_mapping.go
@@ -50,6 +50,7 @@ var numericStringTypes = map[m.StringWithNumericFormat]elasticPropertyType{
 
 type fieldConfig struct {
 	Keyword bool `json:"keyword"`
+	Routing bool `json:"routing"`
 }
 
 func (fc fieldConfig) Validate() error {

--- a/tests/materialize/materialize-elasticsearch/fetch.sh
+++ b/tests/materialize/materialize-elasticsearch/fetch.sh
@@ -18,3 +18,4 @@ exportIndexToJsonl index-duplicated-keys-delta-exclude-flow-doc
 exportIndexToJsonl index-multiple-data-types
 exportIndexToJsonl index-formatted-strings
 exportIndexToJsonl index-deletions
+exportIndexToJsonl index-compound-key

--- a/tests/materialize/materialize-elasticsearch/setup.sh
+++ b/tests/materialize/materialize-elasticsearch/setup.sh
@@ -35,10 +35,16 @@ resources_json_template='[
   {
     "resource": {
       "index": "index-duplicated-keys-standard",
-      "number_of_shards": 1,
+      "number_of_shards": 5,
       "delta_updates": false
     },
-    "source": "${TEST_COLLECTION_DUPLICATED_KEYS}"
+    "source": "${TEST_COLLECTION_DUPLICATED_KEYS}",
+    "fields": {
+      "recommended": true,
+      "include": {
+        "id": {"routing": true}
+      }
+    }
   },
   {
     "resource": {
@@ -90,6 +96,19 @@ resources_json_template='[
       "number_of_shards": 1
     },
     "source": "${TEST_COLLECTION_DELETIONS}"
+  },
+  {
+    "resource": {
+      "index": "index-compound-key",
+      "number_of_shards": 5
+    },
+    "source": "${TEST_COLLECTION_COMPOUND_KEY}",
+    "fields": {
+      "recommended": true,
+      "include": {
+        "yan": {"routing": true}
+      }
+    }
   }
 ]'
 

--- a/tests/materialize/materialize-elasticsearch/snapshot.json
+++ b/tests/materialize/materialize-elasticsearch/snapshot.json
@@ -1,6 +1,6 @@
 [
   "applied.actionDescription",
-  "create index \"index-simple\"\ncreate index \"index-duplicated-keys-standard\"\ncreate index \"index-duplicated-keys-delta\"\ncreate index \"index-duplicated-keys-delta-exclude-flow-doc\"\ncreate index \"index-multiple-data-types\"\ncreate index \"index-formatted-strings\"\ncreate index \"index-deletions\""
+  "create index \"index-simple\"\ncreate index \"index-duplicated-keys-standard\"\ncreate index \"index-duplicated-keys-delta\"\ncreate index \"index-duplicated-keys-delta-exclude-flow-doc\"\ncreate index \"index-multiple-data-types\"\ncreate index \"index-formatted-strings\"\ncreate index \"index-deletions\"\ncreate index \"index-compound-key\""
 ]
 [
   "connectorState",
@@ -1076,6 +1076,67 @@
       },
       "flow_published_at": "1970-01-01T02:00:27.000000000Z",
       "id": 3
+    }
+  ]
+}
+{
+  "index": "index-compound-key",
+  "rows": [
+    {
+      "flow_document": {
+        "_meta": {
+          "uuid": "dc675a80-1de2-11b2-8000-071353030311"
+        },
+        "num": 1,
+        "yan": "b",
+        "yin": "a"
+      },
+      "flow_published_at": "1970-01-01T02:00:09.000000000Z",
+      "num": 1,
+      "yan": "b",
+      "yin": "a"
+    },
+    {
+      "flow_document": {
+        "_meta": {
+          "uuid": "dcfff100-1de2-11b2-8000-071353030311"
+        },
+        "num": 2,
+        "yan": "a",
+        "yin": "b"
+      },
+      "flow_published_at": "1970-01-01T02:00:10.000000000Z",
+      "num": 2,
+      "yan": "a",
+      "yin": "b"
+    },
+    {
+      "flow_document": {
+        "_meta": {
+          "uuid": "dd988780-1de2-11b2-8000-071353030311"
+        },
+        "num": 3,
+        "yan": "",
+        "yin": "ab"
+      },
+      "flow_published_at": "1970-01-01T02:00:11.000000000Z",
+      "num": 3,
+      "yan": "",
+      "yin": "ab"
+    },
+    {
+      "flow_document": {
+        "_meta": {
+          "uuid": "de311e00-1de2-11b2-8000-071353030311"
+        },
+        "num": 4,
+        "yan": "ab",
+        "yin": ""
+      },
+      "flow_published_at": "1970-01-01T02:00:12.000000000Z",
+      "num": 4,
+      "yan": "ab",
+      "yin": ""
     }
   ]
 }


### PR DESCRIPTION
**Description:**

Adds support for a "routing" field configuration option, which designates a field in the collection key to be used as the routing parameter for Elasticsearch documents.

Updates the integration test configuration to use multiple shards for a couple of bindings, and add the routing config to one of the key fields.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

See https://github.com/estuary/flow/pull/2406

**Notes for reviewers:**

Manually tested to verify that:
- A non-key routing field is not allowed
- More than one routing field is not allowed
- Documents are routed to indexes correctly. The integration tests exercise this too, but I verified that documents are distributed as expected across shards and can be retrieved by queries with the routing key set, but not without it, as expected
