### PR TITLE
materialize-snowflake: retry harder on transient errors

### DIFF
--- a/materialize-snowflake/.snapshots/TestConfigURI-Optional_Parameters
+++ b/materialize-snowflake/.snapshots/TestConfigURI-Optional_Parameters
@@ -1,1 +1,1 @@
-alex:mysecret@orgname-accountname.snowflakecomputing.com:443?GO_QUERY_RESULT_FORMAT=json&MULTI_STATEMENT_COUNT=0&account=myaccount&application=EstuaryFlow&client_session_keep_alive=true&database=mydb&maxRetryCount=10&role=myrole&schema=myschema&warehouse=mywarehouse
+alex:mysecret@orgname-accountname.snowflakecomputing.com:443?GO_QUERY_RESULT_FORMAT=json&MULTI_STATEMENT_COUNT=0&account=myaccount&application=EstuaryFlow&client_session_keep_alive=true&database=mydb&maxRetryCount=35&role=myrole&schema=myschema&warehouse=mywarehouse

--- a/materialize-snowflake/.snapshots/TestConfigURI-User_&_Password_Authentication
+++ b/materialize-snowflake/.snapshots/TestConfigURI-User_&_Password_Authentication
@@ -1,1 +1,1 @@
-will:some%2Bcomplex%2Fpassword@orgname-accountname.snowflakecomputing.com:443?GO_QUERY_RESULT_FORMAT=json&MULTI_STATEMENT_COUNT=0&application=EstuaryFlow&client_session_keep_alive=true&database=mydb&maxRetryCount=10&schema=myschema
+will:some%2Bcomplex%2Fpassword@orgname-accountname.snowflakecomputing.com:443?GO_QUERY_RESULT_FORMAT=json&MULTI_STATEMENT_COUNT=0&application=EstuaryFlow&client_session_keep_alive=true&database=mydb&maxRetryCount=35&schema=myschema

--- a/materialize-snowflake/config.go
+++ b/materialize-snowflake/config.go
@@ -66,7 +66,10 @@ func (c config) toURI(includeSchema bool) (string, error) {
 	// client_session_keep_alive causes the driver to issue a periodic keepalive request.
 	// Without this, the authentication token will expire after 4 hours of inactivity.
 	queryParams.Add("client_session_keep_alive", "true")
-	queryParams.Add("maxRetryCount", "10")
+	// The default maxRetryCount is 7, and the backoff time is 16 seconds. This
+	// bumps that up quite a bit, to continue attempting retryable errors for
+	// about 10 minutes before crashing.
+	queryParams.Add("maxRetryCount", "35")
 
 	// Optional params
 	if c.Warehouse != "" {


### PR DESCRIPTION
**Description:**

Brings back the change from https://github.com/estuary/connectors/commit/61e23d4965e4b21d65cf2fe71b56f5af3b0d4aa2 that I had reverted. I'm still not sure if it is really necessary, but we've seen that these network failures are indeed quite transient, and sometimes don't happen for days on end before starting to happen again quite frequently. So it may have been too early to know if we can get by without retrying in our application code.

Also bumps up the `maxRetryCount` config quite a bit so that errors are retried for longer, up to about 10 minutes by my estimation. Since we do continue to see failures at 10 retries, it seems that the i/o issues might be more persistent and require more patience to resolve.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

