### PR TITLE
materialize-mysql: fix some edge cases

### DIFF
--- a/materialize-mysql/.snapshots/TestSQLGeneration
+++ b/materialize-mysql/.snapshots/TestSQLGeneration
@@ -3,7 +3,7 @@
 CREATE TABLE IF NOT EXISTS key_value (
 		key1 BIGINT NOT NULL COMMENT 'auto-generated projection of JSON at: /key1 with inferred types: [integer]',
 		key2 BOOLEAN NOT NULL COMMENT 'auto-generated projection of JSON at: /key2 with inferred types: [boolean]',
-		`key!binary` LONGTEXT NOT NULL COMMENT 'auto-generated projection of JSON at: /key!binary with inferred types: [string]',
+		`key!binary` VARCHAR(256) NOT NULL COMMENT 'auto-generated projection of JSON at: /key!binary with inferred types: [string]',
 		`array` JSON COMMENT 'auto-generated projection of JSON at: /array with inferred types: [array]',
 		`binary` LONGTEXT COMMENT 'auto-generated projection of JSON at: /binary with inferred types: [string]',
 		`boolean` BOOLEAN COMMENT 'auto-generated projection of JSON at: /boolean with inferred types: [boolean]',
@@ -45,7 +45,7 @@ auto-generated projection of JSON at: /_meta/uuid with inferred types: [string]'
 CREATE TEMPORARY TABLE flow_temp_load_table_0 (
 		key1 BIGINT NOT NULL,
 		key2 BOOLEAN NOT NULL,
-		`key!binary` LONGTEXT NOT NULL
+		`key!binary` VARCHAR(256) NOT NULL
 	,
 		PRIMARY KEY (key1, key2, `key!binary`)
 ) CHARACTER SET=utf8mb4 COLLATE=utf8mb4_bin;
@@ -65,7 +65,7 @@ CREATE TEMPORARY TABLE flow_temp_load_table_1 (
 CREATE TEMPORARY TABLE flow_temp_update_table_0 (
 		key1 BIGINT NOT NULL,
 		key2 BOOLEAN NOT NULL,
-		`key!binary` LONGTEXT NOT NULL,
+		`key!binary` VARCHAR(256) NOT NULL,
 		`array` JSON,
 		`binary` LONGTEXT,
 		`boolean` BOOLEAN,
@@ -152,7 +152,7 @@ SELECT 0, r.flow_document
 
 --- Begin delta_updates loadQuery ---
 
-SELECT * FROM (SELECT -1, CAST(NULL AS JSON) LIMIT 0) as nodoc
+SELECT * FROM (SELECT -1, NULL LIMIT 0) as nodoc
 
 --- End delta_updates loadQuery ---
 

--- a/materialize-mysql/sqlgen.go
+++ b/materialize-mysql/sqlgen.go
@@ -55,11 +55,14 @@ var mysqlDialect = func(tzLocation *time.Location, database string, product stri
 				sql.MapStatic("BIGINT"),
 				sql.MapStatic("NUMERIC(65,0)", sql.AlsoCompatibleWith("decimal")),
 			),
-			sql.NUMBER:   sql.MapStatic("DOUBLE PRECISION", sql.AlsoCompatibleWith("double")),
-			sql.BOOLEAN:  sql.MapStatic("BOOLEAN", sql.AlsoCompatibleWith("tinyint")),
-			sql.OBJECT:   sql.MapStatic(jsonType),
-			sql.ARRAY:    sql.MapStatic(jsonType),
-			sql.BINARY:   sql.MapStatic("LONGTEXT"),
+			sql.NUMBER:  sql.MapStatic("DOUBLE PRECISION", sql.AlsoCompatibleWith("double")),
+			sql.BOOLEAN: sql.MapStatic("BOOLEAN", sql.AlsoCompatibleWith("tinyint")),
+			sql.OBJECT:  sql.MapStatic(jsonType),
+			sql.ARRAY:   sql.MapStatic(jsonType),
+			sql.BINARY: sql.MapPrimaryKey(
+				sql.MapStatic("VARCHAR(256)"),
+				sql.MapStatic("LONGTEXT"),
+			),
 			sql.MULTIPLE: jsonMapper,
 			sql.STRING_INTEGER: sql.MapStringMaxLen(
 				sql.MapStatic("NUMERIC(65,0)", sql.AlsoCompatibleWith("decimal"), sql.UsingConverter(sql.StrToInt)),
@@ -182,17 +185,31 @@ func rfc3339ToTZ(loc *time.Location) sql.ElementConverter {
 }
 
 func rfc3339TimeToTZ(loc *time.Location) sql.ElementConverter {
-	return sql.StringCastConverter(func(str string) (interface{}, error) {
+	return sql.StringCastConverter(func(str string) (any, error) {
 		// sanity check, this should not happen
 		if loc == nil {
 			return nil, fmt.Errorf("no timezone has been specified either in server or in connector configuration, cannot materialize time field: Consider setting a timezone in your database or in the connector configuration to continue")
 		}
 
-		if t, err := time.Parse("15:04:05.999999999Z07:00", str); err != nil {
-			return nil, fmt.Errorf("could not parse %q as RFC3339 time: %w", str, err)
-		} else {
-			return t.In(loc).Format("15:04:05.999999999"), nil
+		normalized := strings.ReplaceAll(str, "z", "Z")
+		formats := []string{
+			"15:04:05.999999999Z07:00",
+			"15:04:05.999999999Z",
+			"15:04:05Z",
 		}
+
+		var t time.Time
+		var err error
+		for _, format := range formats {
+			if t, err = time.Parse(format, normalized); err == nil {
+				break
+			}
+		}
+		if err != nil {
+			return nil, fmt.Errorf("could not parse %q as time: %w", str, err)
+		}
+
+		return t.In(loc).Format("15:04:05.999999999"), nil
 	})
 }
 
@@ -323,7 +340,7 @@ SELECT {{ $.Binding }}, r.{{$.Document.Identifier}}
 		l.{{ $key.Identifier }} = r.{{ $key.Identifier }}
 	{{- end }}
 {{ else -}}
-SELECT * FROM (SELECT -1, CAST(NULL AS JSON) LIMIT 0) as nodoc
+SELECT * FROM (SELECT -1, NULL LIMIT 0) as nodoc
 {{ end }}
 {{ end }}
 


### PR DESCRIPTION
**Description:**

* For a BINARY key column from a field like `type: string, contentEncoding: base64`, make sure to use a VARCHAR(256) column since primary keys cannot use LONGTEXT.
* Fix handling of Zulu times, which are considered valid by the Flow runtime.
* Fix an issue with load query generation with delta updates bindings and MariaDB.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

