### PR TITLE
source-salesforce-native: fallback to REST when daily bulk job limit has been reached

### DIFF
--- a/source-salesforce-native/source_salesforce_native/api.py
+++ b/source-salesforce-native/source_salesforce_native/api.py
@@ -9,6 +9,7 @@ from .bulk_job_manager import (
     BulkJobError,
     BulkJobManager,
     CANNOT_FETCH_COMPOUND_DATA,
+    DAILY_MAX_BULK_API_QUERY_LIMIT_EXCEEDED,
     DAILY_MAX_BULK_API_QUERY_VOLUME_EXCEEDED,
     NOT_SUPPORTED_BY_BULK_API,
     MAX_BULK_QUERY_SET_SIZE,
@@ -204,7 +205,7 @@ async def backfill_incremental_resources(
             if CANNOT_FETCH_COMPOUND_DATA in err.errors or NOT_SUPPORTED_BY_BULK_API in err.errors:
                 log.info(f"{name} cannot be queried via the Bulk API. Attempting to use the REST API instead.", {"errors": err.errors})
                 should_fallback_to_rest_api = True
-            elif DAILY_MAX_BULK_API_QUERY_VOLUME_EXCEEDED in err.errors:
+            elif DAILY_MAX_BULK_API_QUERY_VOLUME_EXCEEDED in err.errors or DAILY_MAX_BULK_API_QUERY_LIMIT_EXCEEDED in err.errors:
                 log.info(f"{err.message}. Attempting to use the REST API instead.", {"errors": err.errors})
                 should_fallback_to_rest_api = True
 

--- a/source-salesforce-native/source_salesforce_native/bulk_job_manager.py
+++ b/source-salesforce-native/source_salesforce_native/bulk_job_manager.py
@@ -27,6 +27,7 @@ COUNT_HEADER = "Sforce-NumberOfRecords"
 CANNOT_FETCH_COMPOUND_DATA = r"Selecting compound data not supported in Bulk Query"
 NOT_SUPPORTED_BY_BULK_API = r"is not supported by the Bulk API"
 DAILY_MAX_BULK_API_QUERY_VOLUME_EXCEEDED = r"Max bulk v2 query result size stored (1000000000) kb per 24 hrs has been exceeded"
+DAILY_MAX_BULK_API_QUERY_LIMIT_EXCEEDED = r"Max bulk v2 query jobs (10000) per 24 hrs has been reached"
 
 
 CSV_CONFIG = CSVConfig(
@@ -82,6 +83,9 @@ class BulkJobManager:
             elif err.code == 400 and DAILY_MAX_BULK_API_QUERY_VOLUME_EXCEEDED in err.message:
                 msg = "Maximum size of bulk results per rolling 24 hour period (1 TB) has been exceeded."
                 raise BulkJobError(msg, body['query'], err.message)
+            elif err.code == 400 and DAILY_MAX_BULK_API_QUERY_LIMIT_EXCEEDED in err.message:
+                msg = "Maximum number of bulk jobs per rolling 24 hour period (10,000) has been exceeded."
+                raise BulkJobError(msg, body["query"], err.message)
             else:
                 raise
 


### PR DESCRIPTION
**Description:**

Very rarely, we've seen a production task hit the 24 hour rolling limit for the number of bulk jobs that can be submitted. Typically, this means the window size is too small and it should be increased to avoid submitting tons of super tiny bulk jobs. However, it could also happen if a user has many bindings enabled with a reasonable window size. Instead of crashing the connector when this limit is reached, we should fallback to using the REST API until Salesforce allows us to submit bulk jobs successfully again.

The handling for this is extremely similar to https://github.com/estuary/connectors/pull/2673 which handled when the bulk volume Salesforce allows in 24 hours is exceeded.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

