### PR TITLE
materialize-azure-fabric-warehouse: fix edge case with lowercase "z" in timestamps

### DIFF
--- a/materialize-azure-fabric-warehouse/sqlgen.go
+++ b/materialize-azure-fabric-warehouse/sqlgen.go
@@ -40,7 +40,7 @@ func createDialect(featureFlags map[string]bool) sql.Dialect {
 	// Define base date/time mappings without primary key wrapper
 	dateMapping := sql.MapStatic("DATE", sql.UsingConverter(sql.ClampDate))
 	datetimeMapping := sql.MapStatic("DATETIME2(6)", sql.AlsoCompatibleWith("DATETIME2"), sql.UsingConverter(sql.ClampDatetime))
-	timeMapping := sql.MapStatic("TIME(6)", sql.AlsoCompatibleWith("TIME"))
+	timeMapping := sql.MapStatic("TIME(6)", sql.AlsoCompatibleWith("TIME"), sql.UsingConverter(sql.StringCastConverter(normalizeTime)))
 
 	// If feature flag is enabled, wrap with MapPrimaryKey to use string types for primary keys
 	if featureFlags["datetime_keys_as_string"] {
@@ -117,6 +117,10 @@ func createDialect(featureFlags map[string]bool) sql.Dialect {
 		MaxColumnCharLength:    0,
 		CaseInsensitiveColumns: true,
 	}
+}
+
+func normalizeTime(str string) (any, error) {
+	return strings.Replace(str, "z", "Z", 1), nil
 }
 
 func bitToStringCast(m sql.ColumnTypeMigration) string {

--- a/materialize-sql/element_converter.go
+++ b/materialize-sql/element_converter.go
@@ -166,6 +166,7 @@ const (
 // ClampDatetime provides handling for endpoints that do not accept "0000" as a year by replacing
 // these datetimes with minimumTimestamp.
 var ClampDatetime ElementConverter = StringCastConverter(func(str string) (interface{}, error) {
+	str = strings.Replace(str, "z", "Z", 1)
 	if parsed, err := time.Parse(time.RFC3339Nano, str); err != nil {
 		return nil, err
 	} else if parsed.Year() == 0 {


### PR DESCRIPTION
**Description:**

Azure Fabric Warehouse really hates timestamps with a lowercase "z", and so does the parsing logic used in `ClampDatetime`.

The Flow runtime & schema validation system thinks these are just fine though, so this is case that must be accommodated in connectors.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

