### PR TITLE
source-hubspot-native: add `marketing_emails` stream

### DIFF
--- a/source-hubspot-native/source_hubspot_native/models.py
+++ b/source-hubspot-native/source_hubspot_native/models.py
@@ -147,6 +147,7 @@ class Names(StrEnum):
     carts = auto()
     partner_clients = auto()
     marketing_event = auto()
+    marketing_emails = auto()
 
 
 # A Property is a HubSpot or HubSpot-user defined attribute that's
@@ -198,6 +199,11 @@ class FormSubmission(BaseDocument, extra="allow"):
         assert "formId" not in values
         values["formId"] = info.context.form_id
         return values
+
+
+class MarketingEmail(BaseDocument, extra="allow"):
+    id: str
+    updatedAt: AwareDatetime
 
 
 # Base Struct for all CRM Objects within HubSpot.

--- a/source-hubspot-native/tests/snapshots/snapshots__discover__stdout.json
+++ b/source-hubspot-native/tests/snapshots/snapshots__discover__stdout.json
@@ -1852,5 +1852,64 @@
       "/formId",
       "/submittedAt"
     ]
+  },
+  {
+    "recommendedName": "marketing_emails",
+    "resourceConfig": {
+      "name": "marketing_emails"
+    },
+    "documentSchema": {
+      "$defs": {
+        "Meta": {
+          "properties": {
+            "op": {
+              "default": "u",
+              "description": "Operation type (c: Create, u: Update, d: Delete)",
+              "enum": [
+                "c",
+                "u",
+                "d"
+              ],
+              "title": "Op",
+              "type": "string"
+            },
+            "row_id": {
+              "default": -1,
+              "description": "Row ID of the Document, counting up from zero, or -1 if not known",
+              "title": "Row Id",
+              "type": "integer"
+            }
+          },
+          "title": "Meta",
+          "type": "object"
+        }
+      },
+      "additionalProperties": true,
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/Meta",
+          "description": "Document metadata"
+        },
+        "id": {
+          "title": "Id",
+          "type": "string"
+        },
+        "updatedAt": {
+          "format": "date-time",
+          "title": "Updatedat",
+          "type": "string"
+        }
+      },
+      "required": [
+        "id",
+        "updatedAt"
+      ],
+      "title": "MarketingEmail",
+      "type": "object",
+      "x-infer-schema": true
+    },
+    "key": [
+      "/id"
+    ]
   }
 ]


### PR DESCRIPTION
**Description:**

Hubspot is deprecating the `/marketing-emails/v1` API at the beginning of next month. That API is used in the imported `source-hubpot`'s `marketing-emails` stream, which will break once the API stops accepting requests. There are extremely significant differences between the data returned by `/marketing-emails/v1/emails/with-statistics` endpoint and the new `/marketing/v3/emails` endpoint that's suppose to be the replacement. There's no way the imported `source-hubspot` connector could be updated to _not_ make this a big breaking change.

Instead, we're adding the `marketing_emails` stream to the native `source-hubspot-native` connector. It will capture data from the `/marketing/v3/emails` endpoint without worrying about maintaining compatibility with the soon-to-be-sunset v1 endpoint.

Discover snapshot changes are expected due to the addition of the new stream.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

`source-hubspot-native`'s documentation should be updated to reflect the new `marketing_emails` stream.

**Notes for reviewers:**

Tested on a local stack. Confirmed all expected documents are captured and the `marketing_emails` stream is only discovered if the provided credentials can successfully access the associated endpoint.

Note: we'll need to remove the `marketing_emails` stream from `source-hubspot` once the v1 endpoint stops working. If Hubspot does indeed sunset it on 01OCT2025, we'll be doing that pretty soon.

