### PR TITLE
source-sqlserver-batch: Discover lengths of CHAR/BINARY columns

### DIFF
--- a/source-sqlserver-batch/.snapshots/TestFieldLengthDiscovery
+++ b/source-sqlserver-batch/.snapshots/TestFieldLengthDiscovery
@@ -1,0 +1,211 @@
+Binding 0:
+{
+    "resource_config_json": {
+      "name": "fieldlengthdiscovery_847554",
+      "schema": "dbo",
+      "table": "fieldlengthdiscovery_847554"
+    },
+    "resource_path": [
+      "fieldlengthdiscovery_847554"
+    ],
+    "collection": {
+      "name": "acmeCo/test/dbo/fieldlengthdiscovery_847554",
+      "read_schema_json": {
+        "type": "object",
+        "required": [
+          "_meta",
+          "id"
+        ],
+        "properties": {
+          "_meta": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$id": "https://github.com/estuary/connectors/source-sqlserver-batch/document-metadata",
+            "properties": {
+              "polled": {
+                "type": "string",
+                "format": "date-time",
+                "title": "Polled Timestamp",
+                "description": "The time at which the update query which produced this document as executed."
+              },
+              "index": {
+                "type": "integer",
+                "title": "Result Index",
+                "description": "The index of this document within the query execution which produced it."
+              },
+              "row_id": {
+                "type": "integer",
+                "title": "Row ID",
+                "description": "Row ID of the Document"
+              },
+              "op": {
+                "type": "string",
+                "enum": [
+                  "c",
+                  "u",
+                  "d"
+                ],
+                "title": "Change Operation",
+                "description": "Operation type (c: Create / u: Update / d: Delete)",
+                "default": "u"
+              },
+              "source": {
+                "properties": {
+                  "resource": {
+                    "type": "string",
+                    "description": "Resource name of the binding from which this document was captured."
+                  },
+                  "schema": {
+                    "type": "string",
+                    "description": "Database schema from which the document was read."
+                  },
+                  "table": {
+                    "type": "string",
+                    "description": "Database table from which the document was read."
+                  },
+                  "tag": {
+                    "type": "string",
+                    "description": "Optional 'Source Tag' property as defined in the endpoint configuration."
+                  }
+                },
+                "type": "object",
+                "required": [
+                  "resource"
+                ]
+              }
+            },
+            "type": "object",
+            "required": [
+              "polled",
+              "index",
+              "row_id",
+              "source"
+            ]
+          },
+          "binary_8": {
+            "maxLength": 8,
+            "minLength": 8,
+            "description": "(source type: binary)",
+            "contentEncoding": "base64",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "char_5": {
+            "maxLength": 5,
+            "minLength": 5,
+            "description": "(source type: char)",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "decimal_10_2": {
+            "format": "number",
+            "description": "(source type: decimal)",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "decimal_38_10": {
+            "format": "number",
+            "description": "(source type: decimal)",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "float_24": {
+            "description": "(source type: real)",
+            "type": [
+              "number",
+              "null"
+            ]
+          },
+          "float_53": {
+            "description": "(source type: float)",
+            "type": [
+              "number",
+              "null"
+            ]
+          },
+          "id": {
+            "type": "integer",
+            "description": "(source type: non-nullable int)"
+          },
+          "nchar_15": {
+            "maxLength": 15,
+            "minLength": 15,
+            "description": "(source type: nchar)",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "numeric_18_4": {
+            "format": "number",
+            "description": "(source type: numeric)",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "numeric_5_0": {
+            "format": "number",
+            "description": "(source type: numeric)",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "nvarchar_max": {
+            "description": "(source type: nvarchar)",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "varbinary_16": {
+            "maxLength": 16,
+            "description": "(source type: varbinary)",
+            "contentEncoding": "base64",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "varbinary_max": {
+            "description": "(source type: varbinary)",
+            "contentEncoding": "base64",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "varchar_100": {
+            "maxLength": 100,
+            "description": "(source type: varchar)",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "varchar_max": {
+            "description": "(source type: varchar)",
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "x-infer-schema": true
+      },
+      "key": [
+        "/id"
+      ],
+      "projections": null
+    },
+    "state_key": "fieldlengthdiscovery_847554"
+  }
+

--- a/source-sqlserver-batch/discovery.go
+++ b/source-sqlserver-batch/discovery.go
@@ -280,6 +280,8 @@ type basicColumnType struct {
 	format          string
 	nullable        bool
 	description     string
+	minLength       *uint64
+	maxLength       *uint64
 }
 
 func (ct *basicColumnType) JSONSchema() *jsonschema.Schema {
@@ -292,6 +294,10 @@ func (ct *basicColumnType) JSONSchema() *jsonschema.Schema {
 	if ct.contentEncoding != "" {
 		sch.Extras["contentEncoding"] = ct.contentEncoding // New in 2019-09.
 	}
+
+	// Copy the min/max lengths if present
+	sch.MinLength = ct.minLength
+	sch.MaxLength = ct.maxLength
 
 	if ct.jsonTypes != nil {
 		var types = append([]string(nil), ct.jsonTypes...)
@@ -313,7 +319,7 @@ func discoverColumns(ctx context.Context, db *sql.DB, discoverSchemas []string) 
 
 	fmt.Fprintf(query, "SELECT TABLE_SCHEMA, TABLE_NAME, COLUMN_NAME, ORDINAL_POSITION,")
 	fmt.Fprintf(query, " CASE WHEN IS_NULLABLE = 'YES' THEN 1 ELSE 0 END,")
-	fmt.Fprintf(query, " DATA_TYPE")
+	fmt.Fprintf(query, " DATA_TYPE, CHARACTER_MAXIMUM_LENGTH")
 	fmt.Fprintf(query, " FROM INFORMATION_SCHEMA.COLUMNS")
 	fmt.Fprintf(query, " WHERE TABLE_NAME != 'SYSTRANSCHEMAS'")
 	if len(discoverSchemas) > 0 {
@@ -346,7 +352,8 @@ func discoverColumns(ctx context.Context, db *sql.DB, discoverSchemas []string) 
 		var columnIndex int
 		var isNullable bool
 		var typeName string
-		if err := rows.Scan(&tableSchema, &tableName, &columnName, &columnIndex, &isNullable, &typeName); err != nil {
+		var charMaxLength sql.NullInt64
+		if err := rows.Scan(&tableSchema, &tableName, &columnName, &columnIndex, &isNullable, &typeName, &charMaxLength); err != nil {
 			return nil, fmt.Errorf("error scanning result row: %w", err)
 		}
 
@@ -355,6 +362,21 @@ func discoverColumns(ctx context.Context, db *sql.DB, discoverSchemas []string) 
 			dataType = basicColumnType{description: fmt.Sprintf("using catch-all schema for unknown type %q", typeName)}
 		}
 		dataType.nullable = isNullable
+
+		// Add length constraints for char/binary columns with defined lengths. A
+		// value of -1 is used for certain large-object types such as XML.
+		if charMaxLength.Valid && charMaxLength.Int64 > 0 {
+			var length = uint64(charMaxLength.Int64)
+			switch typeName {
+			case "char", "nchar", "binary":
+				// For fixed-length types, set both minLength and maxLength
+				dataType.minLength = &length
+				dataType.maxLength = &length
+			case "varchar", "nvarchar", "varbinary":
+				// For variable-length types, only set maxLength
+				dataType.maxLength = &length
+			}
+		}
 
 		// Append source type information to the description
 		if dataType.description != "" {

--- a/source-sqlserver-batch/main_test.go
+++ b/source-sqlserver-batch/main_test.go
@@ -1168,6 +1168,34 @@ func TestNonexistentCursor(t *testing.T) {
 	})
 }
 
+// TestFieldLengthDiscovery exercises discovery of column types with specific field lengths.
+func TestFieldLengthDiscovery(t *testing.T) {
+	var ctx, cs, control = context.Background(), testCaptureSpec(t), testControlClient(t)
+	var tableName, uniqueID = testTableName(t, uniqueTableID(t))
+	createTestTable(t, control, tableName, `(
+		id INT PRIMARY KEY,
+
+		char_5 CHAR(5),
+		varchar_100 VARCHAR(100),
+		varchar_max VARCHAR(MAX),
+		nchar_15 NCHAR(15),
+		nvarchar_max NVARCHAR(MAX),
+		binary_8 BINARY(8),
+		varbinary_16 VARBINARY(16),
+		varbinary_max VARBINARY(MAX),
+
+		decimal_10_2 DECIMAL(10,2),
+		decimal_38_10 DECIMAL(38,10),
+		numeric_5_0 NUMERIC(5,0),
+		numeric_18_4 NUMERIC(18,4),
+		float_24 FLOAT(24),
+		float_53 FLOAT(53),
+	)`)
+
+	cs.Bindings = discoverBindings(ctx, t, cs, regexp.MustCompile(uniqueID))
+	cupaloy.SnapshotT(t, summarizeBindings(t, cs.Bindings))
+}
+
 // TestSourceTag verifies the output of a capture with /advanced/source_tag set
 func TestSourceTag(t *testing.T) {
 	var ctx, cs, control = context.Background(), testCaptureSpec(t), testControlClient(t)


### PR DESCRIPTION
**Description:**

This commit adds `maxLength` and (depending on the column type) possibly `minLength` properties to JSON schemas for CHAR/VARCHAR and BINARY/VARBINARY columns. I believe these are the only columns that need it.

This _should_ be backwards-compatible in all cases. For write schemas with automatic updates it will of course be fine (provided the actual data we capture matches the discovered constraints) and if automatic updates are disabled it will be fine because the new constraints won't exist. For inferred schemas on existing collections this should be a no-op since they've already merged in a sourced schema with no such constraints (and inference will never make the length constraints tighter) and new collections will just have them from the get-go (which is the entire point).