### PR TITLE
estuary-cdk: retry more HTTP connection errors

### DIFF
--- a/estuary-cdk/estuary_cdk/http.py
+++ b/estuary-cdk/estuary_cdk/http.py
@@ -84,7 +84,7 @@ class HTTPSession(abc.ABC):
         json: dict[str, Any] | None = None,
         form: dict[str, Any] | None = None,
         _with_token: bool = True,  # Unstable internal API.
-        headers: dict[str, Any] = {},
+        headers: dict[str, Any] | None = None,
     ) -> bytes:
         """Request a url and return its body as bytes"""
 
@@ -112,7 +112,7 @@ class HTTPSession(abc.ABC):
         json: dict[str, Any] | None = None,
         form: dict[str, Any] | None = None,
         delim: bytes = b"\n",
-        headers: dict[str, Any] = {}
+        headers: dict[str, Any] | None = None,
     ) -> tuple[Headers, BodyGeneratorFunction]:
         """Request a url and return its response as streaming lines, as they arrive"""
 
@@ -142,7 +142,7 @@ class HTTPSession(abc.ABC):
         json: dict[str, Any] | None = None,
         form: dict[str, Any] | None = None,
         _with_token: bool = True,  # Unstable internal API.
-        headers: dict[str, Any] = {},
+        headers: dict[str, Any] | None = None,
     ) -> tuple[Headers, BodyGeneratorFunction]:
         """Request a url and and return the raw response as a stream of bytes"""
 
@@ -159,7 +159,7 @@ class HTTPSession(abc.ABC):
         json: dict[str, Any] | None,
         form: dict[str, Any] | None,
         _with_token: bool,
-        headers: dict[str, Any] = {},
+        headers: dict[str, Any] | None = None,
     ) -> HeadersAndBodyGenerator: ...
 
     # TODO(johnny): This is an unstable API.
@@ -484,8 +484,11 @@ class HTTPMixin(Mixin, HTTPSession):
         json: dict[str, Any] | None,
         form: dict[str, Any] | None,
         _with_token: bool,
-        headers: dict[str, Any] = {},
+        headers: dict[str, Any] | None = None,
     ) -> HeadersAndBodyGenerator:
+        if headers is None:
+            headers = {}
+
         while True:
             cur_delay = self.rate_limiter.delay
             await asyncio.sleep(cur_delay)

--- a/source-hubspot/tests/snapshots/snapshots__capture__capture.stdout.json
+++ b/source-hubspot/tests/snapshots/snapshots__capture__capture.stdout.json
@@ -738,7 +738,7 @@
         "hs_user_ids_of_all_notification_unfollowers": null,
         "hs_user_ids_of_all_owners": "73074756",
         "hs_was_imported": null,
-        "hs_weighted_pipeline_in_company_currency": null,
+        "hs_weighted_pipeline_in_company_currency": 8.6,
         "hubspot_owner_assigneddate": "2025-04-03T12:59:10.726000+00:00",
         "hubspot_owner_id": "904875188",
         "hubspot_team_id": null,


### PR DESCRIPTION
**Description:**

We've observed more errors beyond `asyncio.TimeoutError` that crash connectors when trying to establish an HTTP connection. As long as these errors occur before any data is consumed by the connector, these connection-related errors are safe to retry.

What's tricky is some error types could be raised when establishing the connection _or_ reading the response body. To ensure we only retry errors when establishing the connection, I refactored the retry logic to live in `HTTPMixin._request_stream` and only apply when establishing the connection instead of for the entirety of `HTTPMixin._request_stream`.

Note: the GH workflow that builds CDK connectors doesn't run if there's _only_ CDK changes, so I updated `source-hubspot`'s failing capture snapshot to trigger a rebuild of all CDK connectors.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

Tested on a local stack. Confirmed HTTP requests are still made and succeed.

