### PR TITLE
estuary-cdk: retry one more connection error

### DIFF
--- a/estuary-cdk/estuary_cdk/http.py
+++ b/estuary-cdk/estuary_cdk/http.py
@@ -465,6 +465,7 @@ class HTTPMixin(Mixin, HTTPSession):
                 ConnectionResetError,                # TCP connection reset
                 aiohttp.ClientOSError,               # OS errors (like BrokenPipeError) during request sending
                 aiohttp.ClientConnectionResetError,  # Connection reset errors
+                aiohttp.ServerDisconnectedError,     # Server disconnections
             ) as e:
                 if attempt <= max_attempts:
                     log.warning(

--- a/source-shopify-native/source_shopify_native/graphql/README.md
+++ b/source-shopify-native/source_shopify_native/graphql/README.md
@@ -4,7 +4,7 @@ This subpackage provides the `BulkJobManager` for [executing bulk query jobs](ht
 
 ## `BulkJobManager`
 
-The `BulkJobManager` is responsible for submitting queries, checking the status of those queries, and retrieving the URL containing query results. Parsing the query results is the handled elsewhere. The `BulkJobManager` can also cancel queries, although that functionality is currently only used upon connector start up to clean up ongoing queries between connector restarts.
+The `BulkJobManager` is responsible for submitting queries, checking the status of those queries, and retrieving the URL containing query results. Parsing query results is handled by the `process_result` static method defined on each stream's Pydantic model. The `BulkJobManager` can also cancel queries, although that functionality is currently only used upon connector start up to clean up ongoing queries between connector restarts.
 
 
 ## `{stream_name}.py`


### PR DESCRIPTION
**Description:**

I missed adding `aiohttp.ServerDisconnectedError` to the list of new errors to retry in https://github.com/estuary/connectors/pull/3329. `aiohttp.ServerDisconnectedError` can be raised both when establishing the connection and when streaming the response body, but the CDK only retries when establishing a connection so it's safe to retry them.

Note: like in that earlier PR, I included a small update to a CDK connector to trigger GH workflow that runs Python connector tests & build images.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

