### PR TITLE
source-sentry: fix query parameter construction for issue backfills

### DIFF
--- a/source-sentry/source_sentry/api.py
+++ b/source-sentry/source_sentry/api.py
@@ -84,7 +84,7 @@ async def list_time_ranged_entity(
         }  # WARN: Matching the start timestamp will cause an HTTP 400 error
     )
 
-    async for item in list_entity(model, http, organization, log, extra_params):
+    async for item in list_entity(model, http, organization, log, params):
         yield item
 
 

--- a/source-sentry/tests/snapshots/snapshots__capture__stdout.json
+++ b/source-sentry/tests/snapshots/snapshots__capture__stdout.json
@@ -8,7 +8,8 @@
         "uuid": "DocUUIDPlaceholder-329Bb50aa48EAa9ef"
       },
       "id": "7000936",
-      "name": "production"
+      "name": "production",
+      "stats": "redacted-object"
     }
   ],
   [
@@ -93,7 +94,8 @@
           "name": "Estuary",
           "slug": "estuary"
         }
-      ]
+      ],
+      "stats": "redacted-object"
     }
   ],
   [
@@ -176,7 +178,8 @@
           "name": "Estuary",
           "slug": "estuary"
         }
-      ]
+      ],
+      "stats": "redacted-object"
     }
   ],
   [
@@ -264,7 +267,8 @@
           "name": "Estuary",
           "slug": "estuary"
         }
-      ]
+      ],
+      "stats": "redacted-object"
     }
   ],
   [
@@ -307,7 +311,8 @@
       "memberCount": 1,
       "name": "Estuary",
       "slug": "estuary",
-      "teamRole": "admin"
+      "teamRole": "admin",
+      "stats": "redacted-object"
     }
   ],
   [
@@ -356,7 +361,8 @@
         "version": {
           "raw": "v0.2"
         }
-      }
+      },
+      "stats": "redacted-object"
     }
   ],
   [
@@ -405,7 +411,978 @@
         "version": {
           "raw": "v0.1"
         }
-      }
+      },
+      "stats": "redacted-object"
+    }
+  ],
+  [
+    "acmeCo/Issues",
+    {
+      "_meta": {
+        "uuid": "DocUUIDPlaceholder-329Bb50aa48EAa9ef"
+      },
+      "annotations": [],
+      "assignedTo": null,
+      "count": "4",
+      "culprit": "__main__ in <module>",
+      "filtered": null,
+      "firstSeen": "2025-09-09T16:48:59Z",
+      "hasSeen": true,
+      "id": "6867557732",
+      "inbox": null,
+      "integrationIssues": [],
+      "isBookmarked": false,
+      "isPublic": false,
+      "isSubscribed": false,
+      "isUnhandled": true,
+      "issueCategory": "error",
+      "issueType": "error",
+      "lastSeen": "2025-09-09T16:49:37Z",
+      "latestEventHasAttachments": false,
+      "level": "error",
+      "lifetime": {
+        "count": "4",
+        "firstSeen": "2025-09-09T16:48:59.222102Z",
+        "lastSeen": "2025-09-09T16:49:37Z",
+        "stats": null,
+        "userCount": 0
+      },
+      "logger": null,
+      "metadata": {
+        "filename": "testing.py",
+        "function": "<module>",
+        "in_app_frame_mix": "in-app-only",
+        "initial_priority": 75,
+        "sdk": {
+          "name": "sentry.python",
+          "name_normalized": "sentry.python"
+        },
+        "title": null,
+        "type": "ZeroDivisionError",
+        "value": "division by zero"
+      },
+      "numComments": 0,
+      "owners": null,
+      "permalink": "https://estuary-94.sentry.io/issues/6867557732/",
+      "platform": "python",
+      "pluginActions": [],
+      "pluginIssues": [],
+      "priority": "high",
+      "priorityLockedAt": null,
+      "project": {
+        "id": "4509990551814144",
+        "name": "test-project",
+        "platform": "python",
+        "slug": "test-project"
+      },
+      "seerAutofixLastTriggered": null,
+      "seerFixabilityScore": null,
+      "sentryAppIssues": [],
+      "shareId": null,
+      "shortId": "TEST-PROJECT-1",
+      "stats": "redacted-object",
+      "status": "unresolved",
+      "statusDetails": {},
+      "subscriptionDetails": null,
+      "substatus": "ongoing",
+      "title": "ZeroDivisionError: division by zero",
+      "type": "error",
+      "userCount": 0
+    }
+  ],
+  [
+    "acmeCo/Issues",
+    {
+      "_meta": {
+        "uuid": "DocUUIDPlaceholder-329Bb50aa48EAa9ef"
+      },
+      "annotations": [],
+      "assignedTo": null,
+      "count": "3",
+      "culprit": "",
+      "filtered": null,
+      "firstSeen": "2025-09-09T16:48:59Z",
+      "hasSeen": true,
+      "id": "6867557737",
+      "inbox": null,
+      "integrationIssues": [],
+      "isBookmarked": false,
+      "isPublic": false,
+      "isSubscribed": false,
+      "isUnhandled": false,
+      "issueCategory": "error",
+      "issueType": "error",
+      "lastSeen": "2025-09-09T16:49:15Z",
+      "latestEventHasAttachments": false,
+      "level": "info",
+      "lifetime": {
+        "count": "3",
+        "firstSeen": "2025-09-09T16:48:59.193424Z",
+        "lastSeen": "2025-09-09T16:49:15Z",
+        "stats": null,
+        "userCount": 0
+      },
+      "logger": null,
+      "metadata": {
+        "initial_priority": 25,
+        "sdk": {
+          "name": "sentry.python",
+          "name_normalized": "sentry.python"
+        },
+        "title": "Test message from WSL2"
+      },
+      "numComments": 0,
+      "owners": null,
+      "permalink": "https://estuary-94.sentry.io/issues/6867557737/",
+      "platform": "python",
+      "pluginActions": [],
+      "pluginIssues": [],
+      "priority": "low",
+      "priorityLockedAt": null,
+      "project": {
+        "id": "4509990551814144",
+        "name": "test-project",
+        "platform": "python",
+        "slug": "test-project"
+      },
+      "seerAutofixLastTriggered": null,
+      "seerFixabilityScore": null,
+      "sentryAppIssues": [],
+      "shareId": null,
+      "shortId": "TEST-PROJECT-2",
+      "stats": "redacted-object",
+      "status": "unresolved",
+      "statusDetails": {},
+      "subscriptionDetails": null,
+      "substatus": "ongoing",
+      "title": "Test message from WSL2",
+      "type": "default",
+      "userCount": 0
+    }
+  ],
+  [
+    "acmeCo/Issues",
+    {
+      "_meta": {
+        "uuid": "DocUUIDPlaceholder-329Bb50aa48EAa9ef"
+      },
+      "annotations": [],
+      "assignedTo": null,
+      "count": "2",
+      "culprit": "__main__ in <module>",
+      "filtered": null,
+      "firstSeen": "2025-09-09T16:53:42Z",
+      "hasSeen": true,
+      "id": "6867565831",
+      "inbox": null,
+      "integrationIssues": [],
+      "isBookmarked": false,
+      "isPublic": false,
+      "isSubscribed": false,
+      "isUnhandled": true,
+      "issueCategory": "error",
+      "issueType": "error",
+      "lastSeen": "2025-09-09T16:53:46Z",
+      "latestEventHasAttachments": false,
+      "level": "error",
+      "lifetime": {
+        "count": "2",
+        "firstSeen": "2025-09-09T16:53:42.271103Z",
+        "lastSeen": "2025-09-09T16:53:46Z",
+        "stats": null,
+        "userCount": 0
+      },
+      "logger": null,
+      "metadata": {
+        "filename": "testing.py",
+        "function": "<module>",
+        "in_app_frame_mix": "in-app-only",
+        "initial_priority": 75,
+        "sdk": {
+          "name": "sentry.python",
+          "name_normalized": "sentry.python"
+        },
+        "title": null,
+        "type": "RuntimeError",
+        "value": "Error 1"
+      },
+      "numComments": 0,
+      "owners": null,
+      "permalink": "https://estuary-94.sentry.io/issues/6867565831/",
+      "platform": "python",
+      "pluginActions": [],
+      "pluginIssues": [],
+      "priority": "high",
+      "priorityLockedAt": null,
+      "project": {
+        "id": "4509990551814144",
+        "name": "test-project",
+        "platform": "python",
+        "slug": "test-project"
+      },
+      "seerAutofixLastTriggered": null,
+      "seerFixabilityScore": null,
+      "sentryAppIssues": [],
+      "shareId": null,
+      "shortId": "TEST-PROJECT-3",
+      "stats": "redacted-object",
+      "status": "unresolved",
+      "statusDetails": {},
+      "subscriptionDetails": null,
+      "substatus": "ongoing",
+      "title": "RuntimeError: Error 1",
+      "type": "error",
+      "userCount": 0
+    }
+  ],
+  [
+    "acmeCo/Issues",
+    {
+      "_meta": {
+        "uuid": "DocUUIDPlaceholder-329Bb50aa48EAa9ef"
+      },
+      "annotations": [],
+      "assignedTo": null,
+      "count": "31",
+      "culprit": "__main__ in generate_events",
+      "filtered": null,
+      "firstSeen": "2025-09-09T16:55:18Z",
+      "hasSeen": false,
+      "id": "6867568651",
+      "inbox": null,
+      "integrationIssues": [],
+      "isBookmarked": false,
+      "isPublic": false,
+      "isSubscribed": false,
+      "isUnhandled": false,
+      "issueCategory": "error",
+      "issueType": "error",
+      "lastSeen": "2025-09-09T17:15:27Z",
+      "latestEventHasAttachments": false,
+      "level": "error",
+      "lifetime": {
+        "count": "30",
+        "firstSeen": "2025-09-09T16:55:18.907913Z",
+        "lastSeen": "2025-09-09T17:15:27Z",
+        "stats": null,
+        "userCount": 0
+      },
+      "logger": null,
+      "metadata": {
+        "filename": "testing.py",
+        "function": "generate_events",
+        "in_app_frame_mix": "in-app-only",
+        "initial_priority": 75,
+        "sdk": {
+          "name": "sentry.python",
+          "name_normalized": "sentry.python"
+        },
+        "title": null,
+        "type": "ZeroDivisionError",
+        "value": "division by zero"
+      },
+      "numComments": 0,
+      "owners": null,
+      "permalink": "https://estuary-94.sentry.io/issues/6867568651/",
+      "platform": "python",
+      "pluginActions": [],
+      "pluginIssues": [],
+      "priority": "high",
+      "priorityLockedAt": null,
+      "project": {
+        "id": "4509990551814144",
+        "name": "test-project",
+        "platform": "python",
+        "slug": "test-project"
+      },
+      "seerAutofixLastTriggered": null,
+      "seerFixabilityScore": null,
+      "sentryAppIssues": [],
+      "shareId": null,
+      "shortId": "TEST-PROJECT-4",
+      "stats": "redacted-object",
+      "status": "unresolved",
+      "statusDetails": {},
+      "subscriptionDetails": null,
+      "substatus": "ongoing",
+      "title": "ZeroDivisionError: division by zero",
+      "type": "error",
+      "userCount": 0
+    }
+  ],
+  [
+    "acmeCo/Issues",
+    {
+      "_meta": {
+        "uuid": "DocUUIDPlaceholder-329Bb50aa48EAa9ef"
+      },
+      "annotations": [],
+      "assignedTo": null,
+      "count": "40",
+      "culprit": "__main__ in generate_events",
+      "filtered": null,
+      "firstSeen": "2025-09-09T16:55:18Z",
+      "hasSeen": false,
+      "id": "6867568670",
+      "inbox": null,
+      "integrationIssues": [],
+      "isBookmarked": false,
+      "isPublic": false,
+      "isSubscribed": false,
+      "isUnhandled": false,
+      "issueCategory": "error",
+      "issueType": "error",
+      "lastSeen": "2025-09-09T17:15:26Z",
+      "latestEventHasAttachments": false,
+      "level": "error",
+      "lifetime": {
+        "count": "40",
+        "firstSeen": "2025-09-09T16:55:18.501423Z",
+        "lastSeen": "2025-09-09T17:15:26Z",
+        "stats": null,
+        "userCount": 0
+      },
+      "logger": null,
+      "metadata": {
+        "filename": "testing.py",
+        "function": "generate_events",
+        "in_app_frame_mix": "in-app-only",
+        "initial_priority": 75,
+        "sdk": {
+          "name": "sentry.python",
+          "name_normalized": "sentry.python"
+        },
+        "title": null,
+        "type": "RuntimeError",
+        "value": "Test error 75 - RuntimeError"
+      },
+      "numComments": 0,
+      "owners": null,
+      "permalink": "https://estuary-94.sentry.io/issues/6867568670/",
+      "platform": "python",
+      "pluginActions": [],
+      "pluginIssues": [],
+      "priority": "high",
+      "priorityLockedAt": null,
+      "project": {
+        "id": "4509990551814144",
+        "name": "test-project",
+        "platform": "python",
+        "slug": "test-project"
+      },
+      "seerAutofixLastTriggered": null,
+      "seerFixabilityScore": null,
+      "sentryAppIssues": [],
+      "shareId": null,
+      "shortId": "TEST-PROJECT-5",
+      "stats": "redacted-object",
+      "status": "unresolved",
+      "statusDetails": {},
+      "subscriptionDetails": null,
+      "substatus": "ongoing",
+      "title": "RuntimeError: Test error 75 - RuntimeError",
+      "type": "error",
+      "userCount": 0
+    }
+  ],
+  [
+    "acmeCo/Issues",
+    {
+      "_meta": {
+        "uuid": "DocUUIDPlaceholder-329Bb50aa48EAa9ef"
+      },
+      "annotations": [],
+      "assignedTo": null,
+      "count": "30",
+      "culprit": "__main__ in generate_events",
+      "filtered": null,
+      "firstSeen": "2025-09-09T16:55:18Z",
+      "hasSeen": true,
+      "id": "6867568674",
+      "inbox": null,
+      "integrationIssues": [],
+      "isBookmarked": false,
+      "isPublic": false,
+      "isSubscribed": false,
+      "isUnhandled": false,
+      "issueCategory": "error",
+      "issueType": "error",
+      "lastSeen": "2025-09-09T17:15:27Z",
+      "latestEventHasAttachments": false,
+      "level": "error",
+      "lifetime": {
+        "count": "30",
+        "firstSeen": "2025-09-09T16:55:18.806519Z",
+        "lastSeen": "2025-09-09T17:15:27Z",
+        "stats": null,
+        "userCount": 0
+      },
+      "logger": null,
+      "metadata": {
+        "filename": "testing.py",
+        "function": "generate_events",
+        "in_app_frame_mix": "in-app-only",
+        "initial_priority": 75,
+        "sdk": {
+          "name": "sentry.python",
+          "name_normalized": "sentry.python"
+        },
+        "title": null,
+        "type": "FileNotFoundError",
+        "value": "[Errno 2] No such file or directory: 'nonexistent_file.txt'"
+      },
+      "numComments": 0,
+      "owners": null,
+      "permalink": "https://estuary-94.sentry.io/issues/6867568674/",
+      "platform": "python",
+      "pluginActions": [],
+      "pluginIssues": [],
+      "priority": "high",
+      "priorityLockedAt": null,
+      "project": {
+        "id": "4509990551814144",
+        "name": "test-project",
+        "platform": "python",
+        "slug": "test-project"
+      },
+      "seerAutofixLastTriggered": null,
+      "seerFixabilityScore": null,
+      "sentryAppIssues": [],
+      "shareId": null,
+      "shortId": "TEST-PROJECT-6",
+      "stats": "redacted-object",
+      "status": "unresolved",
+      "statusDetails": {},
+      "subscriptionDetails": null,
+      "substatus": "ongoing",
+      "title": "FileNotFoundError: [Errno 2] No such file or directory: 'nonexistent_file.txt'",
+      "type": "error",
+      "userCount": 0
+    }
+  ],
+  [
+    "acmeCo/Issues",
+    {
+      "_meta": {
+        "uuid": "DocUUIDPlaceholder-329Bb50aa48EAa9ef"
+      },
+      "annotations": [],
+      "assignedTo": null,
+      "count": "17",
+      "culprit": "__main__ in generate_events",
+      "filtered": null,
+      "firstSeen": "2025-09-09T16:55:18Z",
+      "hasSeen": false,
+      "id": "6867568677",
+      "inbox": null,
+      "integrationIssues": [],
+      "isBookmarked": false,
+      "isPublic": false,
+      "isSubscribed": false,
+      "isUnhandled": false,
+      "issueCategory": "error",
+      "issueType": "error",
+      "lastSeen": "2025-09-09T17:15:26Z",
+      "latestEventHasAttachments": false,
+      "level": "error",
+      "lifetime": {
+        "count": "17",
+        "firstSeen": "2025-09-09T16:55:18.269191Z",
+        "lastSeen": "2025-09-09T17:15:26Z",
+        "stats": null,
+        "userCount": 0
+      },
+      "logger": null,
+      "metadata": {
+        "filename": "testing.py",
+        "function": "generate_events",
+        "in_app_frame_mix": "in-app-only",
+        "initial_priority": 75,
+        "sdk": {
+          "name": "sentry.python",
+          "name_normalized": "sentry.python"
+        },
+        "title": null,
+        "type": "AttributeError",
+        "value": "'NoneType' object has no attribute 'nonexistent_attribute'"
+      },
+      "numComments": 0,
+      "owners": null,
+      "permalink": "https://estuary-94.sentry.io/issues/6867568677/",
+      "platform": "python",
+      "pluginActions": [],
+      "pluginIssues": [],
+      "priority": "high",
+      "priorityLockedAt": null,
+      "project": {
+        "id": "4509990551814144",
+        "name": "test-project",
+        "platform": "python",
+        "slug": "test-project"
+      },
+      "seerAutofixLastTriggered": null,
+      "seerFixabilityScore": null,
+      "sentryAppIssues": [],
+      "shareId": null,
+      "shortId": "TEST-PROJECT-7",
+      "stats": "redacted-object",
+      "status": "unresolved",
+      "statusDetails": {},
+      "subscriptionDetails": null,
+      "substatus": "ongoing",
+      "title": "AttributeError: 'NoneType' object has no attribute 'nonexistent_attribute'",
+      "type": "error",
+      "userCount": 0
+    }
+  ],
+  [
+    "acmeCo/Issues",
+    {
+      "_meta": {
+        "uuid": "DocUUIDPlaceholder-329Bb50aa48EAa9ef"
+      },
+      "annotations": [],
+      "assignedTo": null,
+      "count": "38",
+      "culprit": "__main__ in generate_events",
+      "filtered": null,
+      "firstSeen": "2025-09-09T16:55:18Z",
+      "hasSeen": false,
+      "id": "6867568681",
+      "inbox": null,
+      "integrationIssues": [],
+      "isBookmarked": false,
+      "isPublic": false,
+      "isSubscribed": false,
+      "isUnhandled": false,
+      "issueCategory": "error",
+      "issueType": "error",
+      "lastSeen": "2025-09-09T17:15:26Z",
+      "latestEventHasAttachments": false,
+      "level": "error",
+      "lifetime": {
+        "count": "38",
+        "firstSeen": "2025-09-09T16:55:18.705136Z",
+        "lastSeen": "2025-09-09T17:15:26Z",
+        "stats": null,
+        "userCount": 0
+      },
+      "logger": null,
+      "metadata": {
+        "filename": "testing.py",
+        "function": "generate_events",
+        "in_app_frame_mix": "in-app-only",
+        "initial_priority": 75,
+        "sdk": {
+          "name": "sentry.python",
+          "name_normalized": "sentry.python"
+        },
+        "title": null,
+        "type": "TypeError",
+        "value": "Test error 89 - TypeError"
+      },
+      "numComments": 0,
+      "owners": null,
+      "permalink": "https://estuary-94.sentry.io/issues/6867568681/",
+      "platform": "python",
+      "pluginActions": [],
+      "pluginIssues": [],
+      "priority": "high",
+      "priorityLockedAt": null,
+      "project": {
+        "id": "4509990551814144",
+        "name": "test-project",
+        "platform": "python",
+        "slug": "test-project"
+      },
+      "seerAutofixLastTriggered": null,
+      "seerFixabilityScore": null,
+      "sentryAppIssues": [],
+      "shareId": null,
+      "shortId": "TEST-PROJECT-8",
+      "stats": "redacted-object",
+      "status": "unresolved",
+      "statusDetails": {},
+      "subscriptionDetails": null,
+      "substatus": "ongoing",
+      "title": "TypeError: Test error 89 - TypeError",
+      "type": "error",
+      "userCount": 0
+    }
+  ],
+  [
+    "acmeCo/Issues",
+    {
+      "_meta": {
+        "uuid": "DocUUIDPlaceholder-329Bb50aa48EAa9ef"
+      },
+      "annotations": [],
+      "assignedTo": null,
+      "count": "27",
+      "culprit": "__main__ in generate_events",
+      "filtered": null,
+      "firstSeen": "2025-09-09T16:55:18Z",
+      "hasSeen": false,
+      "id": "6867568695",
+      "inbox": null,
+      "integrationIssues": [],
+      "isBookmarked": false,
+      "isPublic": false,
+      "isSubscribed": false,
+      "isUnhandled": false,
+      "issueCategory": "error",
+      "issueType": "error",
+      "lastSeen": "2025-09-09T17:15:27Z",
+      "latestEventHasAttachments": false,
+      "level": "error",
+      "lifetime": {
+        "count": "27",
+        "firstSeen": "2025-09-09T16:55:18.398588Z",
+        "lastSeen": "2025-09-09T17:15:27Z",
+        "stats": null,
+        "userCount": 0
+      },
+      "logger": null,
+      "metadata": {
+        "filename": "testing.py",
+        "function": "generate_events",
+        "in_app_frame_mix": "in-app-only",
+        "initial_priority": 75,
+        "sdk": {
+          "name": "sentry.python",
+          "name_normalized": "sentry.python"
+        },
+        "title": null,
+        "type": "IndexError",
+        "value": "list index out of range"
+      },
+      "numComments": 0,
+      "owners": null,
+      "permalink": "https://estuary-94.sentry.io/issues/6867568695/",
+      "platform": "python",
+      "pluginActions": [],
+      "pluginIssues": [],
+      "priority": "high",
+      "priorityLockedAt": null,
+      "project": {
+        "id": "4509990551814144",
+        "name": "test-project",
+        "platform": "python",
+        "slug": "test-project"
+      },
+      "seerAutofixLastTriggered": null,
+      "seerFixabilityScore": null,
+      "sentryAppIssues": [],
+      "shareId": null,
+      "shortId": "TEST-PROJECT-9",
+      "stats": "redacted-object",
+      "status": "unresolved",
+      "statusDetails": {},
+      "subscriptionDetails": null,
+      "substatus": "ongoing",
+      "title": "IndexError: list index out of range",
+      "type": "error",
+      "userCount": 0
+    }
+  ],
+  [
+    "acmeCo/Issues",
+    {
+      "_meta": {
+        "uuid": "DocUUIDPlaceholder-329Bb50aa48EAa9ef"
+      },
+      "annotations": [],
+      "assignedTo": null,
+      "count": "38",
+      "culprit": "__main__ in generate_events",
+      "filtered": null,
+      "firstSeen": "2025-09-09T16:55:19Z",
+      "hasSeen": true,
+      "id": "6867568698",
+      "inbox": null,
+      "integrationIssues": [],
+      "isBookmarked": false,
+      "isPublic": false,
+      "isSubscribed": false,
+      "isUnhandled": false,
+      "issueCategory": "error",
+      "issueType": "error",
+      "lastSeen": "2025-09-09T17:15:27Z",
+      "latestEventHasAttachments": false,
+      "level": "error",
+      "lifetime": {
+        "count": "38",
+        "firstSeen": "2025-09-09T16:55:19.110233Z",
+        "lastSeen": "2025-09-09T17:15:27Z",
+        "stats": null,
+        "userCount": 0
+      },
+      "logger": null,
+      "metadata": {
+        "filename": "testing.py",
+        "function": "generate_events",
+        "in_app_frame_mix": "in-app-only",
+        "initial_priority": 75,
+        "sdk": {
+          "name": "sentry.python",
+          "name_normalized": "sentry.python"
+        },
+        "title": null,
+        "type": "KeyError",
+        "value": "'nonexistent_key'"
+      },
+      "numComments": 0,
+      "owners": null,
+      "permalink": "https://estuary-94.sentry.io/issues/6867568698/",
+      "platform": "python",
+      "pluginActions": [],
+      "pluginIssues": [],
+      "priority": "high",
+      "priorityLockedAt": null,
+      "project": {
+        "id": "4509990551814144",
+        "name": "test-project",
+        "platform": "python",
+        "slug": "test-project"
+      },
+      "seerAutofixLastTriggered": null,
+      "seerFixabilityScore": null,
+      "sentryAppIssues": [],
+      "shareId": null,
+      "shortId": "TEST-PROJECT-A",
+      "stats": "redacted-object",
+      "status": "unresolved",
+      "statusDetails": {},
+      "subscriptionDetails": null,
+      "substatus": "ongoing",
+      "title": "KeyError: 'nonexistent_key'",
+      "type": "error",
+      "userCount": 0
+    }
+  ],
+  [
+    "acmeCo/Issues",
+    {
+      "_meta": {
+        "uuid": "DocUUIDPlaceholder-329Bb50aa48EAa9ef"
+      },
+      "annotations": [],
+      "assignedTo": null,
+      "count": "22",
+      "culprit": "__main__ in generate_events",
+      "filtered": null,
+      "firstSeen": "2025-09-09T16:55:20Z",
+      "hasSeen": true,
+      "id": "6867568723",
+      "inbox": null,
+      "integrationIssues": [],
+      "isBookmarked": false,
+      "isPublic": false,
+      "isSubscribed": false,
+      "isUnhandled": false,
+      "issueCategory": "error",
+      "issueType": "error",
+      "lastSeen": "2025-09-09T17:15:27Z",
+      "latestEventHasAttachments": false,
+      "level": "error",
+      "lifetime": {
+        "count": "22",
+        "firstSeen": "2025-09-09T16:55:20.637309Z",
+        "lastSeen": "2025-09-09T17:15:27Z",
+        "stats": null,
+        "userCount": 0
+      },
+      "logger": null,
+      "metadata": {
+        "filename": "testing.py",
+        "function": "generate_events",
+        "in_app_frame_mix": "in-app-only",
+        "initial_priority": 75,
+        "sdk": {
+          "name": "sentry.python",
+          "name_normalized": "sentry.python"
+        },
+        "title": null,
+        "type": "ValueError",
+        "value": "Test error 93 - ValueError"
+      },
+      "numComments": 0,
+      "owners": null,
+      "permalink": "https://estuary-94.sentry.io/issues/6867568723/",
+      "platform": "python",
+      "pluginActions": [],
+      "pluginIssues": [],
+      "priority": "high",
+      "priorityLockedAt": null,
+      "project": {
+        "id": "4509990551814144",
+        "name": "test-project",
+        "platform": "python",
+        "slug": "test-project"
+      },
+      "seerAutofixLastTriggered": null,
+      "seerFixabilityScore": null,
+      "sentryAppIssues": [],
+      "shareId": null,
+      "shortId": "TEST-PROJECT-B",
+      "stats": "redacted-object",
+      "status": "unresolved",
+      "statusDetails": {},
+      "subscriptionDetails": null,
+      "substatus": "ongoing",
+      "title": "ValueError: Test error 93 - ValueError",
+      "type": "error",
+      "userCount": 0
+    }
+  ],
+  [
+    "acmeCo/Issues",
+    {
+      "_meta": {
+        "uuid": "DocUUIDPlaceholder-329Bb50aa48EAa9ef"
+      },
+      "annotations": [],
+      "assignedTo": null,
+      "count": "28",
+      "culprit": "__main__ in generate_events",
+      "filtered": null,
+      "firstSeen": "2025-09-09T16:55:20Z",
+      "hasSeen": true,
+      "id": "6867568732",
+      "inbox": null,
+      "integrationIssues": [],
+      "isBookmarked": false,
+      "isPublic": false,
+      "isSubscribed": false,
+      "isUnhandled": false,
+      "issueCategory": "error",
+      "issueType": "error",
+      "lastSeen": "2025-09-09T17:15:27Z",
+      "latestEventHasAttachments": false,
+      "level": "error",
+      "lifetime": {
+        "count": "28",
+        "firstSeen": "2025-09-09T16:55:20.942286Z",
+        "lastSeen": "2025-09-09T17:15:27Z",
+        "stats": null,
+        "userCount": 0
+      },
+      "logger": null,
+      "metadata": {
+        "filename": "testing.py",
+        "function": "generate_events",
+        "in_app_frame_mix": "in-app-only",
+        "initial_priority": 75,
+        "sdk": {
+          "name": "sentry.python",
+          "name_normalized": "sentry.python"
+        },
+        "title": null,
+        "type": "TimeoutError",
+        "value": "Test error 98 - TimeoutError"
+      },
+      "numComments": 0,
+      "owners": null,
+      "permalink": "https://estuary-94.sentry.io/issues/6867568732/",
+      "platform": "python",
+      "pluginActions": [],
+      "pluginIssues": [],
+      "priority": "high",
+      "priorityLockedAt": null,
+      "project": {
+        "id": "4509990551814144",
+        "name": "test-project",
+        "platform": "python",
+        "slug": "test-project"
+      },
+      "seerAutofixLastTriggered": null,
+      "seerFixabilityScore": null,
+      "sentryAppIssues": [],
+      "shareId": null,
+      "shortId": "TEST-PROJECT-C",
+      "stats": "redacted-object",
+      "status": "unresolved",
+      "statusDetails": {},
+      "subscriptionDetails": null,
+      "substatus": "ongoing",
+      "title": "TimeoutError: Test error 98 - TimeoutError",
+      "type": "error",
+      "userCount": 0
+    }
+  ],
+  [
+    "acmeCo/Issues",
+    {
+      "_meta": {
+        "uuid": "DocUUIDPlaceholder-329Bb50aa48EAa9ef"
+      },
+      "annotations": [],
+      "assignedTo": null,
+      "count": "29",
+      "culprit": "__main__ in generate_events",
+      "filtered": null,
+      "firstSeen": "2025-09-09T16:55:21Z",
+      "hasSeen": false,
+      "id": "6867568773",
+      "inbox": null,
+      "integrationIssues": [],
+      "isBookmarked": false,
+      "isPublic": false,
+      "isSubscribed": false,
+      "isUnhandled": false,
+      "issueCategory": "error",
+      "issueType": "error",
+      "lastSeen": "2025-09-09T17:15:26Z",
+      "latestEventHasAttachments": false,
+      "level": "error",
+      "lifetime": {
+        "count": "29",
+        "firstSeen": "2025-09-09T16:55:21.757289Z",
+        "lastSeen": "2025-09-09T17:15:26Z",
+        "stats": null,
+        "userCount": 0
+      },
+      "logger": null,
+      "metadata": {
+        "filename": "testing.py",
+        "function": "generate_events",
+        "in_app_frame_mix": "in-app-only",
+        "initial_priority": 75,
+        "sdk": {
+          "name": "sentry.python",
+          "name_normalized": "sentry.python"
+        },
+        "title": null,
+        "type": "ConnectionError",
+        "value": "Test error 86 - ConnectionError"
+      },
+      "numComments": 0,
+      "owners": null,
+      "permalink": "https://estuary-94.sentry.io/issues/6867568773/",
+      "platform": "python",
+      "pluginActions": [],
+      "pluginIssues": [],
+      "priority": "high",
+      "priorityLockedAt": null,
+      "project": {
+        "id": "4509990551814144",
+        "name": "test-project",
+        "platform": "python",
+        "slug": "test-project"
+      },
+      "seerAutofixLastTriggered": null,
+      "seerFixabilityScore": null,
+      "sentryAppIssues": [],
+      "shareId": null,
+      "shortId": "TEST-PROJECT-D",
+      "stats": "redacted-object",
+      "status": "unresolved",
+      "statusDetails": {},
+      "subscriptionDetails": null,
+      "substatus": "ongoing",
+      "title": "ConnectionError: Test error 86 - ConnectionError",
+      "type": "error",
+      "userCount": 0
     }
   ]
 ]

--- a/source-sentry/tests/test_snapshots.py
+++ b/source-sentry/tests/test_snapshots.py
@@ -20,6 +20,9 @@ def test_capture(request, snapshot):
     assert result.returncode == 0
     lines = [json.loads(l) for l in result.stdout.splitlines()]
 
+    for line in lines:
+        line[1]["stats"] = "redacted-object"
+
     assert snapshot("stdout.json") == lines
 
 


### PR DESCRIPTION
**Description:**

This PR fixes an issue where the `start` and `end` parameters were not being passed to `list_entity`. This caused backfills to pull the entire issue history on every API request, which produced duplicate documents.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

