### PR TITLE
sqlcapture: Mark secondary indices as fallback keys

### DIFF
--- a/source-mysql/.snapshots/TestGeneric-KeylessDiscovery
+++ b/source-mysql/.snapshots/TestGeneric-KeylessDiscovery
@@ -140,6 +140,7 @@ Binding 0:
     },
     "key": [
       "/_meta/source/cursor"
-    ]
+    ],
+    "is_fallback_key": true
   }
 

--- a/source-mysql/.snapshots/TestSecondaryIndexDiscovery-index_and_fk
+++ b/source-mysql/.snapshots/TestSecondaryIndexDiscovery-index_and_fk
@@ -128,6 +128,7 @@ Binding 0:
     },
     "key": [
       "/id"
-    ]
+    ],
+    "is_fallback_key": true
   }
 

--- a/source-mysql/.snapshots/TestSecondaryIndexDiscovery-index_only
+++ b/source-mysql/.snapshots/TestSecondaryIndexDiscovery-index_only
@@ -141,6 +141,7 @@ Binding 0:
     "key": [
       "/k2",
       "/k3"
-    ]
+    ],
+    "is_fallback_key": true
   }
 

--- a/source-mysql/.snapshots/TestSecondaryIndexDiscovery-nonunique_index
+++ b/source-mysql/.snapshots/TestSecondaryIndexDiscovery-nonunique_index
@@ -137,6 +137,7 @@ Binding 0:
     },
     "key": [
       "/_meta/source/cursor"
-    ]
+    ],
+    "is_fallback_key": true
   }
 

--- a/source-mysql/.snapshots/TestSecondaryIndexDiscovery-nothing
+++ b/source-mysql/.snapshots/TestSecondaryIndexDiscovery-nothing
@@ -137,6 +137,7 @@ Binding 0:
     },
     "key": [
       "/_meta/source/cursor"
-    ]
+    ],
+    "is_fallback_key": true
   }
 

--- a/source-mysql/.snapshots/TestSecondaryIndexDiscovery-nullable_index
+++ b/source-mysql/.snapshots/TestSecondaryIndexDiscovery-nullable_index
@@ -143,6 +143,7 @@ Binding 0:
     },
     "key": [
       "/_meta/source/cursor"
-    ]
+    ],
+    "is_fallback_key": true
   }
 

--- a/source-mysql/discovery.go
+++ b/source-mysql/discovery.go
@@ -135,6 +135,7 @@ func (db *mysqlDatabase) DiscoverTables(ctx context.Context) (map[sqlcapture.Str
 				"index": selectedIndex,
 			}).Debug("selected secondary index as table key")
 			info.PrimaryKey = indexColumns[selectedIndex]
+			info.FallbackKey = true
 		} else {
 			logrus.WithField("table", streamID).Debug("no secondary index is suitable")
 		}

--- a/source-postgres/.snapshots/TestGeneric-KeylessDiscovery
+++ b/source-postgres/.snapshots/TestGeneric-KeylessDiscovery
@@ -151,6 +151,7 @@ Binding 0:
       "/_meta/source/loc/0",
       "/_meta/source/loc/1",
       "/_meta/source/loc/2"
-    ]
+    ],
+    "is_fallback_key": true
   }
 

--- a/source-postgres/.snapshots/TestSecondaryIndexDiscovery-index_only
+++ b/source-postgres/.snapshots/TestSecondaryIndexDiscovery-index_only
@@ -146,6 +146,7 @@ Binding 0:
     "key": [
       "/k2",
       "/k3"
-    ]
+    ],
+    "is_fallback_key": true
   }
 

--- a/source-postgres/.snapshots/TestSecondaryIndexDiscovery-nonunique_index
+++ b/source-postgres/.snapshots/TestSecondaryIndexDiscovery-nonunique_index
@@ -144,6 +144,7 @@ Binding 0:
       "/_meta/source/loc/0",
       "/_meta/source/loc/1",
       "/_meta/source/loc/2"
-    ]
+    ],
+    "is_fallback_key": true
   }
 

--- a/source-postgres/.snapshots/TestSecondaryIndexDiscovery-nothing
+++ b/source-postgres/.snapshots/TestSecondaryIndexDiscovery-nothing
@@ -144,6 +144,7 @@ Binding 0:
       "/_meta/source/loc/0",
       "/_meta/source/loc/1",
       "/_meta/source/loc/2"
-    ]
+    ],
+    "is_fallback_key": true
   }
 

--- a/source-postgres/.snapshots/TestSecondaryIndexDiscovery-nullable_index
+++ b/source-postgres/.snapshots/TestSecondaryIndexDiscovery-nullable_index
@@ -150,6 +150,7 @@ Binding 0:
       "/_meta/source/loc/0",
       "/_meta/source/loc/1",
       "/_meta/source/loc/2"
-    ]
+    ],
+    "is_fallback_key": true
   }
 

--- a/source-postgres/discovery.go
+++ b/source-postgres/discovery.go
@@ -174,6 +174,7 @@ func (db *postgresDatabase) DiscoverTables(ctx context.Context) (map[sqlcapture.
 				"index": selectedIndex,
 			}).Debug("selected secondary index as table key")
 			info.PrimaryKey = indexColumns[selectedIndex]
+			info.FallbackKey = true
 		} else {
 			logrus.WithField("table", streamID).Debug("no secondary index is suitable")
 		}

--- a/source-sqlserver/.snapshots/TestComputedPrimaryKey-discovery
+++ b/source-sqlserver/.snapshots/TestComputedPrimaryKey-discovery
@@ -133,6 +133,7 @@ Binding 0:
     "key": [
       "/_meta/source/lsn",
       "/_meta/source/seqval"
-    ]
+    ],
+    "is_fallback_key": true
   }
 

--- a/source-sqlserver/.snapshots/TestGeneric-KeylessDiscovery
+++ b/source-sqlserver/.snapshots/TestGeneric-KeylessDiscovery
@@ -147,6 +147,7 @@ Binding 0:
     "key": [
       "/_meta/source/lsn",
       "/_meta/source/seqval"
-    ]
+    ],
+    "is_fallback_key": true
   }
 

--- a/source-sqlserver/.snapshots/TestIndexIncludedDiscovery
+++ b/source-sqlserver/.snapshots/TestIndexIncludedDiscovery
@@ -147,6 +147,7 @@ Binding 0:
     "key": [
       "/k2",
       "/k3"
-    ]
+    ],
+    "is_fallback_key": true
   }
 

--- a/source-sqlserver/.snapshots/TestSecondaryIndexDiscovery-index_only
+++ b/source-sqlserver/.snapshots/TestSecondaryIndexDiscovery-index_only
@@ -147,6 +147,7 @@ Binding 0:
     "key": [
       "/k2",
       "/k3"
-    ]
+    ],
+    "is_fallback_key": true
   }
 

--- a/source-sqlserver/.snapshots/TestSecondaryIndexDiscovery-nonunique_index
+++ b/source-sqlserver/.snapshots/TestSecondaryIndexDiscovery-nonunique_index
@@ -144,6 +144,7 @@ Binding 0:
     "key": [
       "/_meta/source/lsn",
       "/_meta/source/seqval"
-    ]
+    ],
+    "is_fallback_key": true
   }
 

--- a/source-sqlserver/.snapshots/TestSecondaryIndexDiscovery-nothing
+++ b/source-sqlserver/.snapshots/TestSecondaryIndexDiscovery-nothing
@@ -144,6 +144,7 @@ Binding 0:
     "key": [
       "/_meta/source/lsn",
       "/_meta/source/seqval"
-    ]
+    ],
+    "is_fallback_key": true
   }
 

--- a/source-sqlserver/.snapshots/TestSecondaryIndexDiscovery-nullable_index
+++ b/source-sqlserver/.snapshots/TestSecondaryIndexDiscovery-nullable_index
@@ -150,6 +150,7 @@ Binding 0:
     "key": [
       "/_meta/source/lsn",
       "/_meta/source/seqval"
-    ]
+    ],
+    "is_fallback_key": true
   }
 

--- a/source-sqlserver/discovery.go
+++ b/source-sqlserver/discovery.go
@@ -134,6 +134,7 @@ func (db *sqlserverDatabase) DiscoverTables(ctx context.Context) (map[sqlcapture
 				"index": selectedIndex,
 			}).Debug("selected secondary index as table key")
 			info.PrimaryKey = indexColumns[selectedIndex]
+			info.FallbackKey = true
 		} else {
 			log.WithField("table", streamID).Debug("no secondary index is suitable")
 		}

--- a/sqlcapture/capture.go
+++ b/sqlcapture/capture.go
@@ -924,7 +924,7 @@ func (c *Capture) emitSourcedSchemas(discovery map[StreamID]*DiscoveryInfo) erro
 		if !info.EmitSourcedSchemas {
 			continue // Only emit SourcedSchema updates for tables with the feature enabled
 		}
-		var collectionSchema, _, err = generateCollectionSchema(c.Database, info, false)
+		var collectionSchema, _, _, err = generateCollectionSchema(c.Database, info, false)
 		if err != nil {
 			log.WithError(err).WithField("stream", binding.StreamID).Error("error generating schema")
 			continue

--- a/sqlcapture/interface.go
+++ b/sqlcapture/interface.go
@@ -282,6 +282,7 @@ type DiscoveryInfo struct {
 	Schema      string                // The schema (a namespace, in normal parlance) which contains the table.
 	Columns     map[string]ColumnInfo // Information about each column of the table.
 	PrimaryKey  []string              // An ordered list of the column names which together form the table's primary key.
+	FallbackKey bool                  // True if the 'Primary Key' is actually a unique secondary index chosen as a fallback.
 	ColumnNames []string              // The names of all columns, in the table's natural order.
 	BaseTable   bool                  // True if the table type is 'BASE TABLE' and false for views or other not-physical-table entities.
 	OmitBinding bool                  // True if the table should be omitted from discovery catalog generation.


### PR DESCRIPTION
**Description:**

This fixes https://github.com/estuary/connectors/issues/3334

Also adds the `IsFallbackKey: true` for truly keyless tables' fallback keys, because apparently we never actually used the new flag before.

