### PR TITLE
materialize-mongodb: disable support for truncating resources

### DIFF
--- a/materialize-mongodb/driver.go
+++ b/materialize-mongodb/driver.go
@@ -133,8 +133,9 @@ func newMaterialization(ctx context.Context, materializationName string, cfg con
 
 func (d *materialization) Config() boilerplate.MaterializeCfg {
 	return boilerplate.MaterializeCfg{
-		ConcurrentApply:    true,
-		NoCreateNamespaces: true,
+		ConcurrentApply:     true,
+		NoCreateNamespaces:  true,
+		NoTruncateResources: true,
 	}
 }
 


### PR DESCRIPTION
**Description:**

Set `NoTruncateResources` for MongoDB materialization.  This materialization has not supported TruncateResource since it was added in [#3090](https://github.com/estuary/connectors/pull/3090/files#diff-40f53bb4e4160d9b7be44c3cbb9f76824c1cda2b3e0931d0bcb86ff4ce102468R204).

**Workflow steps:**

The connector will do a drop table and recreate on backfill.

**Documentation links affected:**

NA

**Notes for reviewers:**



