### PR TITLE
source-braintree-native: ignore non credit card verifications in `credit_card_verifications`

### DIFF
--- a/source-braintree-native/source_braintree_native/models.py
+++ b/source-braintree-native/source_braintree_native/models.py
@@ -139,6 +139,20 @@ class TransactionSearchResponse(SearchResponse):
 class CreditCardVerificationSearchResponse(SearchResponse):
     class CreditCardVerifications(SearchResponseResources):
         resource: SearchResponseResource = Field(alias="verification", default=None)
+        # Sometimes, Braintree's API returns records that are not credit card
+        # verifications in a CreditCardVerificationSearchResponse. These are completely
+        # different records, and shouldn't be returned in the API response in the first place.
+        # Braintree's official Python SDK filters out/ignores records that aren't credit card
+        # verifications, so we do the same.
+        #
+        # We could ignore any extra fields when validating the model to solve this. However,
+        # Braintree's API is not formally documented and we reversed engineered how the API
+        # works via the Braintree SDK, so I have low confidence that Braintree won't make
+        # breaking changes to the API. I'd like to know if any API responses deviate from
+        # the shape we expect, so instead of ignoring all extra fields, I'm choosing
+        # to exclude specific fields and still fail validation if any unexpected
+        # fields exist in the response.
+        us_bank_account_verification: Any = Field(exclude=True, default=None)
 
     resources: CreditCardVerifications = Field(alias="credit_card_verifications")
 


### PR DESCRIPTION
**Description:**

Very rarely, Braintree's API returns records that are not credit card verifications in a `CreditCardVerificationSearchResponse`. These are completely different records and shouldn't be returned in the API response in the first place. Braintree's official Python SDK filters out/ignores records that aren't credit card verifications, so we should do the same.

We could ignore any extra fields when validating the model to solve this. However, Braintree's API is not formally documented and we reversed engineered how the API works via the Braintree SDK, so I have low confidence that Braintree won't make breaking changes to the API. I'd like to know if any API responses deviate from the shape we expect, so instead of ignoring all extra fields, I'm choosing to exclude specific fields and still fail validation if any unexpected fields exist in the response.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

Tested on a local stack. I confirmed the problematic stray `us_bank_account_verification` record is ignored.

I also confirmed that Braintree's Python SDK does _not_ return the stray `us_bank_account_verification` record that's in the credit card verifications search API response:
```python
import braintree

  braintree.Configuration.configure(
      environment=getattr(braintree.Environment, environment.title()),
      merchant_id=merchant_id,
      public_key=public_key,
      private_key=private_key
  )

collection = braintree.CreditCardVerification.search(
    braintree.CreditCardVerificationSearch.id == "the_problematic_us_bank_account_verification_id"
)

count = 0

for verification in collection.items:
    count += 1
    print(verification) # Nothing is printed.

print(f"Found {count} verifications.") # Prints "Found 0 verifications."
```

