### PR TITLE
materialize-boilerplate: skip nil actions during delete/create

### DIFF
--- a/materialize-boilerplate/materializer.go
+++ b/materialize-boilerplate/materializer.go
@@ -580,11 +580,24 @@ func RunApply[EC EndpointConfiger, FC FieldConfiger, RC Resourcer[RC, EC], MT Ma
 			} else if createDesc, createAction, err := materializer.CreateResource(ctx, *mapped); err != nil {
 				return nil, fmt.Errorf("getting CreateResource action to replace resource: %w", err)
 			} else {
-				addResourceAction(deleteDesc+"\n"+createDesc, func(ctx context.Context) error {
-					if err := deleteAction(ctx); err != nil {
-						return err
-					} else if err := createAction(ctx); err != nil {
-						return err
+				descs := make([]string, 2)
+				if deleteAction != nil {
+					descs = append(descs, deleteDesc)
+				}
+				if createAction != nil {
+					descs = append(descs, createDesc)
+				}
+				desc := strings.Join(descs, "\n")
+				addResourceAction(desc, func(ctx context.Context) error {
+					if deleteAction != nil {
+						if err := deleteAction(ctx); err != nil {
+							return err
+						}
+					}
+					if createAction != nil {
+						if err := createAction(ctx); err != nil {
+							return err
+						}
 					}
 					return nil
 				})


### PR DESCRIPTION
**Description:**

We allow a resource action to be nil and skip their execution, but when we run delete/create together we didn't handle the case where one or both are nil.  These must be ran together in a single action so provide ordering in case concurrency is enabled.

**Workflow steps:**

NA

**Documentation links affected:**

NA

**Notes for reviewers:**
