### PR TITLE
source-shopify-native: Add subscription_contracts 

### DIFF
--- a/source-shopify-native/acmeCo/flow.yaml
+++ b/source-shopify-native/acmeCo/flow.yaml
@@ -96,3 +96,7 @@ collections:
     schema: smart_collections.schema.yaml
     key:
       - /id
+  acmeCo/subscription_contracts:
+    schema: subscription_contracts.schema.yaml
+    key:
+      - /id

--- a/source-shopify-native/acmeCo/subscription_contracts.schema.yaml
+++ b/source-shopify-native/acmeCo/subscription_contracts.schema.yaml
@@ -1,0 +1,36 @@
+---
+$defs:
+  Meta:
+    properties:
+      op:
+        default: u
+        description: "Operation type (c: Create, u: Update, d: Delete)"
+        enum:
+          - c
+          - u
+          - d
+        title: Op
+        type: string
+      row_id:
+        default: -1
+        description: "Row ID of the Document, counting up from zero, or -1 if not known"
+        title: Row Id
+        type: integer
+    title: Meta
+    type: object
+additionalProperties: true
+properties:
+  _meta:
+    $ref: "#/$defs/Meta"
+    default:
+      op: u
+      row_id: -1
+    description: Document metadata
+  id:
+    title: Id
+    type: string
+required:
+  - id
+title: ShopifyGraphQLResource
+type: object
+x-infer-schema: true

--- a/source-shopify-native/source_shopify_native/graphql/__init__.py
+++ b/source-shopify-native/source_shopify_native/graphql/__init__.py
@@ -26,6 +26,7 @@ from .orders.orders import Orders
 from .orders.refunds import OrderRefunds
 from .orders.risks import OrderRisks
 from .orders.transactions import OrderTransactions
+from .subscriptions.subscription_contracts import SubscriptionContracts
 
 
 __all__ = [
@@ -55,4 +56,5 @@ __all__ = [
     "OrderRefunds",
     "OrderRisks",
     "OrderTransactions",
+    "SubscriptionContracts",
 ]

--- a/source-shopify-native/source_shopify_native/graphql/subscriptions/__init__.py
+++ b/source-shopify-native/source_shopify_native/graphql/subscriptions/__init__.py
@@ -1,0 +1,3 @@
+from .subscription_contracts import SubscriptionContracts
+
+__all__ = ["SubscriptionContracts"]

--- a/source-shopify-native/source_shopify_native/graphql/subscriptions/subscription_contracts.py
+++ b/source-shopify-native/source_shopify_native/graphql/subscriptions/subscription_contracts.py
@@ -1,0 +1,200 @@
+from datetime import datetime
+from logging import Logger
+from typing import AsyncGenerator
+
+from ...models import ShopifyGraphQLResource, SortKey
+
+
+class SubscriptionContracts(ShopifyGraphQLResource):
+    NAME = "subscription_contracts"
+    QUERY_ROOT = "subscriptionContracts"
+    SORT_KEY = SortKey.UPDATED_AT
+    SHOULD_USE_BULK_QUERIES = False
+    QUERY = """
+    id
+    createdAt
+    updatedAt
+    status
+    nextBillingDate
+    currencyCode
+    note
+    revisionId
+    app {
+        id
+    }
+    appAdminUrl
+    customer {
+        id
+        legacyResourceId
+    }
+    customerPaymentMethod {
+        id
+        instrument
+    }
+    billingPolicy {
+        interval
+        intervalCount
+    }
+    deliveryPolicy {
+        interval
+        intervalCount
+    }
+    deliveryPrice {
+        amount
+        currencyCode
+    }
+    deliveryMethod {
+        __typename
+        ... on SubscriptionDeliveryMethodPickup {
+            pickupOption {
+                code
+                description
+                location {
+                    address {
+                        address1
+                        address2
+                        city
+                        country
+                        countryCode
+                        formatted
+                        latitude
+                        longitude
+                        phone
+                        province
+                        provinceCode
+                        zip
+                    }
+                    createdAt
+                    id
+                }
+                presentmentTitle
+                title
+            }
+        }
+        ... on SubscriptionDeliveryMethodLocalDelivery {
+            address {
+                address1
+                address2
+                city
+                company
+                coordinatesValidated
+                country
+                countryCodeV2
+                firstName
+                formatted
+                formattedArea
+                id
+                lastName
+                latitude
+                longitude
+                name
+                phone
+                province
+                provinceCode
+                timeZone
+                zip
+            }
+            localDeliveryOption {
+                code
+                description
+                instructions
+                phone
+                presentmentTitle
+                title
+            }
+        }
+        ... on SubscriptionDeliveryMethodShipping {
+            address {
+                address1
+                address2
+                city
+                company
+                coordinatesValidated
+                country
+                countryCodeV2
+                firstName
+                formatted
+                formattedArea
+                id
+                lastName
+                latitude
+                longitude
+                name
+                phone
+                province
+                provinceCode
+                timeZone
+                zip
+            }
+            shippingOption {
+                code
+                description
+                presentmentTitle
+                title
+            }
+        }
+    }
+    customAttributes {
+        key
+        value
+    }
+    lines(first: 250) {
+        edges {
+            node {
+                id
+                quantity
+                variantId
+                productId
+                sellingPlanId
+                sellingPlanName
+                currentPrice {
+                    amount
+                    currencyCode
+                }
+                lineDiscountedPrice {
+                    amount
+                    currencyCode
+                }
+                pricingPolicy {
+                    basePrice {
+                        amount
+                        currencyCode
+                    }
+                }
+            }
+        }
+    }
+    linesCount {
+        count
+    }
+    lastBillingAttemptErrorType
+    lastPaymentStatus
+    originOrder {
+        id
+        name
+        number
+    }
+    """
+
+    @staticmethod
+    def build_query(
+        start: datetime,
+        end: datetime,
+        first: int | None = None,
+        after: str | None = None,
+    ) -> str:
+        return SubscriptionContracts.build_query_with_fragment(
+            start,
+            end,
+            first=first,
+            after=after,
+        )
+
+    @staticmethod
+    async def process_result(
+        log: Logger, lines: AsyncGenerator[bytes, None]
+    ) -> AsyncGenerator[dict, None]:
+        async for record in SubscriptionContracts._process_result(
+            log, lines, "gid://shopify/SubscriptionContract/"
+        ):
+            yield record

--- a/source-shopify-native/source_shopify_native/models.py
+++ b/source-shopify-native/source_shopify_native/models.py
@@ -37,6 +37,7 @@ scopes = [
     "read_fulfillments",
     "read_customers",
     "read_publications",
+    "read_own_subscription_contracts",
 ]
 
 OAUTH2_SPEC = OAuth2Spec(

--- a/source-shopify-native/source_shopify_native/resources.py
+++ b/source-shopify-native/source_shopify_native/resources.py
@@ -59,6 +59,7 @@ INCREMENTAL_RESOURCES: list[type[ShopifyGraphQLResource]] = [
     gql.SmartCollectionMetafields,
     gql.Locations,
     gql.LocationMetafields,
+    gql.SubscriptionContracts,
 ]
 
 


### PR DESCRIPTION
**Description:**

Add `subscription_contracts` as a resource to the Shopify GQL connector. 

**Workflow steps:**

It's an extension to the existing connector for shopify-native (using the GraphQL API). The resources (=SubscriptionContract) will be fetched if available.

**Documentation links affected:**

https://docs.estuary.dev/reference/Connectors/capture-connectors/shopify-native/

**Notes for reviewers:**

Shopify Apps are only allowed to fetch the subscription contracts that they have created themselves (hence the `read_own_subscription_contracts` scope).

