### PR TITLE
source-sftp: support aes256-cbc cipher

### DIFF
--- a/source-sftp/main.go
+++ b/source-sftp/main.go
@@ -145,6 +145,12 @@ var additionalKexAlgos = []string{
 	"diffie-hellman-group1-sha1",    // kexAlgoDH1SHA1
 }
 
+// additionalCiphers specifies any additional ciphers which we support which
+// aren't in the defaults from golang.org/x/crypto/ssh/common.go
+var additionalCiphers = []string{
+	"aes256-cbc",
+}
+
 func newSftpSource(ctx context.Context, cfg config) (filesource.Store, error) {
 	var user = cfg.Credentials.Username
 	if len(user) == 0 && len(cfg.Username) > 0 {
@@ -157,9 +163,10 @@ func newSftpSource(ctx context.Context, cfg config) (filesource.Store, error) {
 		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
 	}
 
-	// Extend the default list of key-exchange algorithms with a few additional ones we want to support.
+	// Extend the default list of key-exchange algorithms and ciphers with additional ones we want to support.
 	sshConfig.SetDefaults()
 	sshConfig.KeyExchanges = append(sshConfig.KeyExchanges, additionalKexAlgos...)
+	sshConfig.Ciphers = append(sshConfig.Ciphers, additionalCiphers...)
 
 	// Legacy authentication method
 	if cfg.Credentials.Type == "" && cfg.Password != "" {


### PR DESCRIPTION
**Description:**

a customer has a service which does not support any of the ones we support by default

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

