### PR TITLE
source-jira-native: add `sprint_issues` stream

### DIFF
--- a/source-jira-native/source_jira_native/models.py
+++ b/source-jira-native/source_jira_native/models.py
@@ -549,6 +549,10 @@ class BoardChildStream(FullRefreshStream):
     api: ClassVar[JiraAPI] = JiraAPI.SOFTWARE
 
 
+class SprintIssuesResponse(PaginatedResponse):
+    values: list[APIRecord] = Field(alias="issues")
+
+
 class Epics(BoardChildStream):
     name: ClassVar[str] = "epics"
     path: ClassVar[str] = "epic"
@@ -559,6 +563,16 @@ class Sprints(BoardChildStream):
     name: ClassVar[str] = "sprints"
     path: ClassVar[str] = "sprint"
     disable: ClassVar[bool] = False
+
+
+class SprintIssues(FullRefreshStream):
+    api: ClassVar[JiraAPI] = JiraAPI.SOFTWARE
+    name: ClassVar[str] = "sprint_issues"
+    path: ClassVar[str] = "issue"
+    extra_params: ClassVar[Optional[dict[str, str]]] = {
+        "fields": "id",
+        "jql": "ORDER BY id"
+    }
 
 
 # Service Managmement API Streams
@@ -627,6 +641,7 @@ FULL_REFRESH_STREAMS: list[type[FullRefreshStream]] = [
     ScreenTabs,
     Screens,
     ServiceDesks,
+    SprintIssues,
     Sprints,
     Statuses,
     SystemAvatars,

--- a/source-jira-native/source_jira_native/resources.py
+++ b/source-jira-native/source_jira_native/resources.py
@@ -35,6 +35,7 @@ from .models import (
     ResourceConfig,
     ResourceState,
     ScreenTabFields,
+    SprintIssues,
     StandardPermissions,
     Statuses,
     SystemAvatars,
@@ -62,6 +63,7 @@ from .api import (
     snapshot_permissions,
     snapshot_project_child_resources,
     snapshot_screen_tab_fields,
+    snapshot_sprint_issues,
     snapshot_statuses,
     snapshot_system_avatars,
     url_base,
@@ -260,6 +262,13 @@ def _get_partial_snapshot_fn(
             config.domain,
             stream,
             timezone,
+        )
+    elif issubclass(stream, SprintIssues):
+        snapshot_fn = functools.partial(
+            snapshot_sprint_issues,
+            http,
+            config.domain,
+            stream,
         )
     elif issubclass(stream, BoardChildStream):
         snapshot_fn = functools.partial(

--- a/source-jira-native/tests/snapshots/snapshots__discover__capture.stdout.json
+++ b/source-jira-native/tests/snapshots/snapshots__discover__capture.stdout.json
@@ -2021,6 +2021,54 @@
     "disable": true
   },
   {
+    "recommendedName": "sprint_issues",
+    "resourceConfig": {
+      "name": "sprint_issues",
+      "interval": "PT1H"
+    },
+    "documentSchema": {
+      "$defs": {
+        "Meta": {
+          "properties": {
+            "op": {
+              "default": "u",
+              "description": "Operation type (c: Create, u: Update, d: Delete)",
+              "enum": [
+                "c",
+                "u",
+                "d"
+              ],
+              "title": "Op",
+              "type": "string"
+            },
+            "row_id": {
+              "default": -1,
+              "description": "Row ID of the Document, counting up from zero, or -1 if not known",
+              "title": "Row Id",
+              "type": "integer"
+            }
+          },
+          "title": "Meta",
+          "type": "object"
+        }
+      },
+      "additionalProperties": true,
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/Meta",
+          "description": "Document metadata"
+        }
+      },
+      "title": "FullRefreshResource",
+      "type": "object",
+      "x-infer-schema": true
+    },
+    "key": [
+      "/_meta/row_id"
+    ],
+    "disable": true
+  },
+  {
     "recommendedName": "sprints",
     "resourceConfig": {
       "name": "sprints",


### PR DESCRIPTION
**Description:**

`sprint_issues`'s sole purpose is to serve as a join table between sprints and issues. `issues` already contains data for each issue, and `sprints` already contains data for each sprint, so we don't need to nor want to duplicate that data across multiple streams.

Jira does not expose a way to reliably detect when an issue is associated with a sprint, so we're not able to incrementally replicate `sprint_issues` and have to make it a full refresh stream instead.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

The connector's docs should be updated to reflect the newly added `sprint_issues` stream that hits the [`/rest/agile/1.0/sprint/{sprintId}/issue` endpoint](https://developer.atlassian.com/cloud/jira/software/rest/api-group-sprint/#api-rest-agile-1-0-sprint-sprintid-issue-get).

**Notes for reviewers:**

Tested on a local stack. Confirmed `sprint_issues` captures all expected documents for a few different Jira accounts. 

