### PR TITLE
source-datadog: support filtering logs with a user-provided query

### DIFF
--- a/source-datadog/source_datadog/api.py
+++ b/source-datadog/source_datadog/api.py
@@ -84,7 +84,6 @@ async def fetch_events_page(
     http: HTTPSession,
     base_url: str,
     common_headers: dict[str, str],
-    endpoint: str,
     resource_type: type[TResourceType],
     start_date: datetime,
     log: Logger,
@@ -94,7 +93,7 @@ async def fetch_events_page(
     assert isinstance(cutoff, datetime)
     assert page is None or isinstance(page, str)
 
-    url = f"{base_url}/{endpoint}"
+    url = f"{base_url}/{resource_type.PATH}"
     request_body = _build_search_request_body(start_date, cutoff, page)
 
     api_response = ApiResponse[list[resource_type]].model_validate_json(
@@ -124,7 +123,6 @@ async def fetch_events_changes(
     http: HTTPSession,
     base_url: str,
     common_headers: dict[str, str],
-    endpoint: str,
     resource_type: type[TResourceType],
     window_size: int,
     log: Logger,
@@ -133,7 +131,7 @@ async def fetch_events_changes(
 ) -> AsyncGenerator[TResourceType | LogCursor, None]:
     assert isinstance(log_cursor, datetime)
 
-    url = f"{base_url}/{endpoint}"
+    url = f"{base_url}/{resource_type.PATH}"
     last_seen_ts = log_cursor
     max_window_size = timedelta(days=window_size)
     end = min(datetime.now(tz=UTC), log_cursor + max_window_size)

--- a/source-datadog/source_datadog/api.py
+++ b/source-datadog/source_datadog/api.py
@@ -86,6 +86,7 @@ async def fetch_events_page(
     common_headers: dict[str, str],
     resource_type: type[TResourceType],
     start_date: datetime,
+    extra_filter_params: dict | None,
     log: Logger,
     page: PageCursor,
     cutoff: LogCursor,
@@ -94,7 +95,7 @@ async def fetch_events_page(
     assert page is None or isinstance(page, str)
 
     url = f"{base_url}/{resource_type.PATH}"
-    request_body = _build_search_request_body(start_date, cutoff, page)
+    request_body = _build_search_request_body(start_date, cutoff, page, extra_filter_params)
 
     api_response = ApiResponse[list[resource_type]].model_validate_json(
         await http.request(
@@ -125,9 +126,9 @@ async def fetch_events_changes(
     common_headers: dict[str, str],
     resource_type: type[TResourceType],
     window_size: int,
+    extra_filter_params: dict | None,
     log: Logger,
     log_cursor: LogCursor,
-    extra_filter_params: dict | None = None,
 ) -> AsyncGenerator[TResourceType | LogCursor, None]:
     assert isinstance(log_cursor, datetime)
 

--- a/source-datadog/source_datadog/models.py
+++ b/source-datadog/source_datadog/models.py
@@ -128,6 +128,7 @@ class ApiResponse(BaseModel, Generic[TApiResponse]):
 class DatadogResource(BaseDocument, extra="allow"):
     RESOURCE_NAME: ClassVar[str]
     PRIMARY_KEYS: ClassVar[list[str]]
+    PATH: ClassVar[str]
 
     id: str
 
@@ -142,8 +143,10 @@ class IncrementalResource(DatadogResource):
 class RealUserMonitoringResource(IncrementalResource):
     RESOURCE_NAME = "real_user_monitoring"
     PRIMARY_KEYS = ["/id"]
+    PATH = "/rum/events/search"
 
 
 class LogResource(IncrementalResource):
     RESOURCE_NAME = "logs"
     PRIMARY_KEYS = ["/id"]
+    PATH = "/logs/events/search"

--- a/source-datadog/source_datadog/resources.py
+++ b/source-datadog/source_datadog/resources.py
@@ -16,19 +16,14 @@ from .models import (
     LogResource
 )
 
-INCREMENTAL_RESOURCES: list[
-    tuple[
-        str,
-        type[IncrementalResource],
-    ]
-] = [
-    ("/rum/events/search", RealUserMonitoringResource),
-    ("/logs/events/search", LogResource),
+INCREMENTAL_RESOURCES: list[type[IncrementalResource]] = [
+    RealUserMonitoringResource,
+    LogResource,
 ]
 
 
 async def validate_credentials(log: Logger, http: HTTPSession, config: EndpointConfig):
-    url = f"{config.base_url}/logs/events/search"
+    url = f"{config.base_url}{LogResource.PATH}"
     headers = config.common_headers
     body = {
         "filter": {
@@ -63,7 +58,6 @@ def incremental_resources(
     config: EndpointConfig,
 ) -> list[common.Resource]:
     def open(
-        endpoint: str,
         resource: type[IncrementalResource],
         binding: CaptureBinding[ResourceConfig],
         binding_index: int,
@@ -81,7 +75,6 @@ def incremental_resources(
                 http,
                 config.base_url,
                 config.common_headers,
-                endpoint,
                 resource,
                 config.advanced.window_size,
             ),
@@ -90,7 +83,6 @@ def incremental_resources(
                 http,
                 config.base_url,
                 config.common_headers,
-                endpoint,
                 resource,
                 config.start_date,
             ),
@@ -105,7 +97,6 @@ def incremental_resources(
             model=resource,
             open=functools.partial(
                 open,
-                endpoint,
                 resource,
             ),
             initial_state=common.ResourceState(
@@ -117,7 +108,7 @@ def incremental_resources(
             ),
             schema_inference=True,
         )
-        for endpoint, resource in INCREMENTAL_RESOURCES
+        for resource in INCREMENTAL_RESOURCES
     ]
 
 

--- a/source-datadog/source_datadog/resources.py
+++ b/source-datadog/source_datadog/resources.py
@@ -65,6 +65,10 @@ def incremental_resources(
         task: Task,
         all_bindings,
     ):
+        extra_filter_params = None
+        if resource is LogResource and config.advanced.logs_query:
+            extra_filter_params = {"query": config.advanced.logs_query}
+
         common.open_binding(
             binding,
             binding_index,
@@ -77,6 +81,7 @@ def incremental_resources(
                 config.common_headers,
                 resource,
                 config.advanced.window_size,
+                extra_filter_params,
             ),
             fetch_page=functools.partial(
                 fetch_events_page,
@@ -85,6 +90,7 @@ def incremental_resources(
                 config.common_headers,
                 resource,
                 config.start_date,
+                extra_filter_params,
             ),
         )
 

--- a/source-datadog/tests/snapshots/snapshots__spec__stdout.json
+++ b/source-datadog/tests/snapshots/snapshots__spec__stdout.json
@@ -5,6 +5,20 @@
       "$defs": {
         "Advanced": {
           "properties": {
+            "logs_query": {
+              "anyOf": [
+                {
+                  "maxLength": 10000,
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "Query string to filter logs captured from Datadog. Uses Datadog's log search syntax described at https://docs.datadoghq.com/logs/explorer/search_syntax/. If not provided, all logs will be captured.",
+              "title": "Log Query Filter"
+            },
             "window_size": {
               "default": 30,
               "description": "Window size in days for incremental streams. The default of 30 days is recommended for most use cases.",


### PR DESCRIPTION
**Description:**

Often, users have a significant amount of logs in Datadog and they don't want to capture all of them. The `advanced.logs_query` config option lets users filter out which logs the connector captures.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

The connector's documentation should be updated to reflect the new config option.

**Notes for reviewers:**

Tested on a local stack. Confirmed the `advanced.logs_query` field is used when fetching `logs`.

