### PR TITLE
source-datadog: Add query param to EndpointConfig model and search requests

### DIFF
--- a/source-datadog/source_datadog/api.py
+++ b/source-datadog/source_datadog/api.py
@@ -59,12 +59,14 @@ def check_response_for_partial_data(
 def _build_search_request_body(
     start_date: datetime,
     end_date: datetime,
+    query: str,
     page_cursor: str | None = None,
     extra_filter_params: dict | None = None,
 ) -> dict:
     filter_params = {
         "from": start_date.isoformat(),
         "to": end_date.isoformat(),
+        "query": query,
     }
 
     if extra_filter_params:
@@ -87,6 +89,7 @@ async def fetch_events_page(
     endpoint: str,
     resource_type: type[TResourceType],
     start_date: datetime,
+    query: str,
     log: Logger,
     page: PageCursor,
     cutoff: LogCursor,
@@ -95,7 +98,7 @@ async def fetch_events_page(
     assert page is None or isinstance(page, str)
 
     url = f"{base_url}/{endpoint}"
-    request_body = _build_search_request_body(start_date, cutoff, page)
+    request_body = _build_search_request_body(start_date, cutoff, query, page)
 
     api_response = ApiResponse[list[resource_type]].model_validate_json(
         await http.request(
@@ -127,6 +130,7 @@ async def fetch_events_changes(
     endpoint: str,
     resource_type: type[TResourceType],
     window_size: int,
+    query: str,
     log: Logger,
     log_cursor: LogCursor,
     extra_filter_params: dict | None = None,
@@ -143,7 +147,7 @@ async def fetch_events_changes(
         return
 
     request_body = _build_search_request_body(
-        log_cursor, end, None, extra_filter_params
+        log_cursor, end, query, None, extra_filter_params
     )
 
     count = 0

--- a/source-datadog/source_datadog/models.py
+++ b/source-datadog/source_datadog/models.py
@@ -65,6 +65,11 @@ class EndpointConfig(BaseModel):
         default_factory=default_start_date,
         le=datetime.now(tz=UTC),
     )
+    query: str = Field(
+        title="Query",
+        description="Query filter to apply when fetching events from Datadog. Must be compatible with Datadog log search syntax - as well as RUM search syntax when fetching RUM events. If left blank, all events will be fetched.",
+        default="*",
+    )
 
     class Advanced(BaseModel):
         window_size: Annotated[

--- a/source-datadog/source_datadog/resources.py
+++ b/source-datadog/source_datadog/resources.py
@@ -33,6 +33,7 @@ async def validate_credentials(log: Logger, http: HTTPSession, config: EndpointC
     body = {
         "filter": {
             "from": "now-1s",
+            "query": "*",
         },
         "page": {
             "limit": 1,
@@ -84,6 +85,7 @@ def incremental_resources(
                 endpoint,
                 resource,
                 config.advanced.window_size,
+                config.query,
             ),
             fetch_page=functools.partial(
                 fetch_events_page,
@@ -93,6 +95,7 @@ def incremental_resources(
                 endpoint,
                 resource,
                 config.start_date,
+                config.query,
             ),
         )
 

--- a/source-datadog/test.flow.yaml
+++ b/source-datadog/test.flow.yaml
@@ -14,6 +14,7 @@ captures:
             application_key: secret_application_key
           site: us5.datadoghq.com
           start_date: "2021-01-01T00:00:00Z"
+          query: "*"
           advanced:
             window_size: 30
     bindings: []

--- a/source-datadog/tests/conftest.py
+++ b/source-datadog/tests/conftest.py
@@ -1,0 +1,7 @@
+import pytest
+
+
+@pytest.fixture
+def anyio_backend():
+    """Configure anyio to only use asyncio backend for all tests."""
+    return "asyncio"

--- a/source-datadog/tests/snapshots/snapshots__spec__stdout.json
+++ b/source-datadog/tests/snapshots/snapshots__spec__stdout.json
@@ -78,6 +78,12 @@
           "title": "Start Date",
           "type": "string"
         },
+        "query": {
+          "default": "*",
+          "description": "Query filter to apply when fetching events from Datadog. Must be compatible with Datadog log search syntax - as well as RUM search syntax when fetching RUM events. If left blank, all events will be fetched.",
+          "title": "Query",
+          "type": "string"
+        },
         "advanced": {
           "$ref": "#/$defs/Advanced",
           "advanced": true,

--- a/source-datadog/tests/test_integration.py
+++ b/source-datadog/tests/test_integration.py
@@ -1,0 +1,68 @@
+import pytest
+from datetime import datetime, UTC
+from unittest.mock import AsyncMock, Mock
+from logging import Logger
+
+from source_datadog.models import EndpointConfig, ApiKey, LogResource
+from source_datadog.api import fetch_events_changes
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize(
+    "query,expected_query",
+    [
+        ("hello", "hello"),  # Custom query
+        (None, "*"),  # Default query
+    ],
+)
+async def test_query_from_config_used_in_api_request(query, expected_query):
+    """Integration test: verify that EndpointConfig.query is included in API requests."""
+
+    # Create a config with or without a specific query
+    config_params = {
+        "credentials": ApiKey(
+            access_token="test_key",
+            application_key="test_app_key"
+        ),
+        "site": "datadoghq.com",
+        "start_date": datetime(2021, 1, 1, tzinfo=UTC),
+    }
+    if query is not None:
+        config_params["query"] = query
+
+    config = EndpointConfig(**config_params)
+
+    # Mock HTTP session to capture the request
+    http_mock = AsyncMock()
+    captured_request_body = None
+
+    async def capture_request(log, url, method, headers, json):
+        nonlocal captured_request_body
+        captured_request_body = json
+        # Return a minimal valid response
+        return '{"data": [], "meta": {"status": "done"}}'
+
+    http_mock.request = capture_request
+
+    log = Mock(spec=Logger)
+
+    # Call fetch_events_changes which should use the query from config
+    log_cursor = datetime(2021, 1, 15, tzinfo=UTC)
+
+    result = [item async for item in fetch_events_changes(
+        http=http_mock,
+        base_url=config.base_url,
+        common_headers=config.common_headers,
+        endpoint="/logs/events/search",
+        resource_type=LogResource,
+        window_size=config.advanced.window_size,
+        log=log,
+        log_cursor=log_cursor,
+        query=config.query,  # Pass query from config
+    )]
+
+    # Verify the request body includes the query
+    assert captured_request_body is not None
+    assert "filter" in captured_request_body
+    assert "query" in captured_request_body["filter"]
+    assert captured_request_body["filter"]["query"] == expected_query


### PR DESCRIPTION
**Description:**

Adds a new query configuration field to the Datadog source connector that allows users to filter events using Datadog's search syntax. The query parameter is included in all API requests for both backfill and incremental sync operations. Defaults to Datadog API's default value of "*".

I added this as a top level config rather than an `extra_filter_params` dict since this is the only filter param shared by both logs and RUM search (except for `to` but that's not relevant to Flow syncs). I'll defer to the maintainers on what the preferred approach is. 

Currently this will apply the same filter to both log and RUM events. I suspect users will eventually want to be able to configure those separately but this felt like a simple path to getting the base functionality.

**Workflow steps:**

Users can now specify a query filter in their connector configuration to limit which events are captured from Datadog:

```
  endpoint:
    config:
      site: datadoghq.com
      start_date: "2021-01-01T00:00:00Z"
      query: "text_to_match"  # Filter events
```

If the query field is omitted or left blank, it defaults to "*" which fetches all events (preserving backward compatibility with existing configurations).

The query syntax must be compatible with:
  - https://docs.datadoghq.com/logs/explorer/search_syntax/ for log events
  - https://docs.datadoghq.com/real_user_monitoring/explorer/search_syntax/ for RUM events


**Documentation links affected**:

The connector documentation at https://github.com/estuary/flow/blob/master/site/docs/reference/Connectors/capture-connectors/datadog.md
Can make that change if this pr is approved.

**Notes for reviewers:**
 - Test coverage:
    - Snapshot tests validate the schema includes the new query field
    - Integration tests cover both explicit query values and default behavior
    - conftest.py added to configure pytest-anyio to use asyncio only (avoiding trio since it does not appear to be a dependency for this project)
 - Implementation details:
    - Query parameter added to _build_search_request_body() in api.py
    - Both fetch_events_page() (backfill) and fetch_events_changes() (incremental) now accept and use the query
