### PR TITLE
retain_existing_data_on_backfill: feature flag to disable table drops

### DIFF
--- a/materialize-azure-blob-parquet/main.go
+++ b/materialize-azure-blob-parquet/main.go
@@ -16,7 +16,7 @@ var featureFlagDefaults = map[string]bool{
 	// Starting on 18-Aug-2025 newly created parquet materializations will use
 	// STRING logical type for UUID fields, rather than a UUID logical type.
 	"uuid_logical_type": false,
-	"drop_table":        true,
+	"retain_existing_data_on_backfill": false,
 }
 
 type config struct {

--- a/materialize-azure-fabric-warehouse/driver.go
+++ b/materialize-azure-fabric-warehouse/driver.go
@@ -14,7 +14,7 @@ import (
 
 var featureFlagDefaults = map[string]bool{
 	"datetime_keys_as_string": true,
-	"drop_table":              true,
+	"retain_existing_data_on_backfill": false,
 }
 
 type advancedConfig struct {

--- a/materialize-bigquery/bigquery.go
+++ b/materialize-bigquery/bigquery.go
@@ -21,7 +21,7 @@ var featureFlagDefaults = map[string]bool{
 	// columns, instead of the historical behavior of strings.
 	"objects_and_arrays_as_json": true,
 	"datetime_keys_as_string":    true,
-	"drop_table":                 true,
+	"retain_existing_data_on_backfill": false,
 }
 
 type config struct {

--- a/materialize-boilerplate/materializer_test.go
+++ b/materialize-boilerplate/materializer_test.go
@@ -164,7 +164,7 @@ func TestRunApply(t *testing.T) {
 	}
 }
 
-func TestRunApplyNoDropTable(t *testing.T) {
+func TestRunApplyRetainExistingDataOnBackfill(t *testing.T) {
 	ctx := context.Background()
 
 	for _, tt := range []struct {
@@ -175,7 +175,7 @@ func TestRunApplyNoDropTable(t *testing.T) {
 		expectError  bool
 	}{
 		{
-			name:         "should not truncate resource when no_drop_table is set",
+			name:         "should not truncate resource when retain_existing_data_on_backfill is set",
 			originalSpec: loadMaterializerSpec(t, "base.flow.proto"),
 			newSpec:      loadMaterializerSpec(t, "backfill-nullable.flow.proto"),
 			want: testCalls{
@@ -185,7 +185,7 @@ func TestRunApplyNoDropTable(t *testing.T) {
 			expectError: false,
 		},
 		{
-			name:         "should error when drop/recreate is required and no_drop_table is set",
+			name:         "should error when drop/recreate is required and retain_existing_data_on_backfill is set",
 			originalSpec: loadMaterializerSpec(t, "base.flow.proto"),
 			newSpec:      loadMaterializerSpec(t, "backfill-key-change.flow.proto"),
 			want:         testCalls{
@@ -202,14 +202,14 @@ func TestRunApplyNoDropTable(t *testing.T) {
 				LastVersion:         "oldone",
 			}
 
-			// Parse the original spec's ConfigJson and set no_drop_table feature flag and set back on the req
+			// Parse the original spec's ConfigJson and set retain_existing_data_on_backfill feature flag and set back on the req
 			var config testEndpointConfiger
 			require.NoError(t, json.Unmarshal(req.Materialization.ConfigJson, &config))
 
-			// Modify config to disable drop_table
+			// Modify config to enable retain_existing_data_on_backfill
 			config.Config = map[string]any{
 				"advanced": map[string]any{
-					"feature_flags": "no_drop_table",
+					"feature_flags": "retain_existing_data_on_backfill",
 				},
 			}
 
@@ -224,7 +224,7 @@ func TestRunApplyNoDropTable(t *testing.T) {
 
 			if tt.expectError {
 				require.Error(t, err)
-				require.Contains(t, err.Error(), "drop_table")
+				require.Contains(t, err.Error(), "retain_existing_data_on_backfill")
 			} else {
 				require.NoError(t, err)
 				require.Equal(t, tt.want, *got)
@@ -343,7 +343,7 @@ func (c testEndpointConfiger) FeatureFlags() (string, map[string]bool) {
 	}
 
 	return featureFlags, map[string]bool{
-		"drop_table": true,
+		"retain_existing_data_on_backfill": false,
 	}
 }
 

--- a/materialize-boilerplate/validate_test.go
+++ b/materialize-boilerplate/validate_test.go
@@ -62,7 +62,7 @@ func TestValidate(t *testing.T) {
 			proposedSpec:       loadValidateSpec(t, "base.flow.proto"),
 			fieldNameTransform: simpleTestTransform,
 			maxFieldLength:     0,
-			featureFlags:       map[string]bool{"flow_document": true, "drop_table": true},
+			featureFlags:       map[string]bool{"flow_document": true, "retain_existing_data_on_backfill": false},
 		},
 		{
 			name:               "same binding again - standard updates",
@@ -72,7 +72,7 @@ func TestValidate(t *testing.T) {
 			proposedSpec:       loadValidateSpec(t, "base.flow.proto"),
 			fieldNameTransform: simpleTestTransform,
 			maxFieldLength:     0,
-			featureFlags:       map[string]bool{"flow_document": true, "drop_table": true},
+			featureFlags:       map[string]bool{"flow_document": true, "retain_existing_data_on_backfill": false},
 		},
 		{
 			name:               "new materialization - delta updates",
@@ -82,7 +82,7 @@ func TestValidate(t *testing.T) {
 			proposedSpec:       loadValidateSpec(t, "base.flow.proto"),
 			fieldNameTransform: simpleTestTransform,
 			maxFieldLength:     0,
-			featureFlags:       map[string]bool{"flow_document": true, "drop_table": true},
+			featureFlags:       map[string]bool{"flow_document": true, "retain_existing_data_on_backfill": false},
 		},
 		{
 			name:               "same binding again - delta updates",
@@ -92,7 +92,7 @@ func TestValidate(t *testing.T) {
 			proposedSpec:       loadValidateSpec(t, "base.flow.proto"),
 			fieldNameTransform: simpleTestTransform,
 			maxFieldLength:     0,
-			featureFlags:       map[string]bool{"flow_document": true, "drop_table": true},
+			featureFlags:       map[string]bool{"flow_document": true, "retain_existing_data_on_backfill": false},
 		},
 		{
 			name:               "binding update with incompatible changes",
@@ -102,7 +102,7 @@ func TestValidate(t *testing.T) {
 			proposedSpec:       loadValidateSpec(t, "incompatible-changes.flow.proto"),
 			fieldNameTransform: simpleTestTransform,
 			maxFieldLength:     0,
-			featureFlags:       map[string]bool{"flow_document": true, "drop_table": true},
+			featureFlags:       map[string]bool{"flow_document": true, "retain_existing_data_on_backfill": false},
 		},
 		{
 			name:               "fields exist in destination but not in collection",
@@ -112,7 +112,7 @@ func TestValidate(t *testing.T) {
 			proposedSpec:       loadValidateSpec(t, "fewer-fields.flow.proto"),
 			fieldNameTransform: simpleTestTransform,
 			maxFieldLength:     0,
-			featureFlags:       map[string]bool{"flow_document": true, "drop_table": true},
+			featureFlags:       map[string]bool{"flow_document": true, "retain_existing_data_on_backfill": false},
 		},
 		{
 			name:               "change root document projection for standard updates",
@@ -122,7 +122,7 @@ func TestValidate(t *testing.T) {
 			proposedSpec:       loadValidateSpec(t, "alternate-root.flow.proto"),
 			fieldNameTransform: simpleTestTransform,
 			maxFieldLength:     0,
-			featureFlags:       map[string]bool{"flow_document": true, "drop_table": true},
+			featureFlags:       map[string]bool{"flow_document": true, "retain_existing_data_on_backfill": false},
 		},
 		{
 			name:               "change root document projection for delta updates",
@@ -132,7 +132,7 @@ func TestValidate(t *testing.T) {
 			proposedSpec:       loadValidateSpec(t, "alternate-root.flow.proto"),
 			fieldNameTransform: simpleTestTransform,
 			maxFieldLength:     0,
-			featureFlags:       map[string]bool{"flow_document": true, "drop_table": true},
+			featureFlags:       map[string]bool{"flow_document": true, "retain_existing_data_on_backfill": false},
 		},
 		{
 			name:               "increment backfill counter",
@@ -142,7 +142,7 @@ func TestValidate(t *testing.T) {
 			proposedSpec:       loadValidateSpec(t, "increment-backfill.flow.proto"),
 			fieldNameTransform: simpleTestTransform,
 			maxFieldLength:     0,
-			featureFlags:       map[string]bool{"flow_document": true, "drop_table": true},
+			featureFlags:       map[string]bool{"flow_document": true, "retain_existing_data_on_backfill": false},
 		},
 		{
 			name:               "increment backfill counter for disabled -> enabled binding",
@@ -152,7 +152,7 @@ func TestValidate(t *testing.T) {
 			proposedSpec:       loadValidateSpec(t, "increment-backfill.flow.proto"),
 			fieldNameTransform: simpleTestTransform,
 			maxFieldLength:     0,
-			featureFlags:       map[string]bool{"flow_document": true, "drop_table": true},
+			featureFlags:       map[string]bool{"flow_document": true, "retain_existing_data_on_backfill": false},
 		},
 		{
 			name:               "table already exists with identical spec",
@@ -162,7 +162,7 @@ func TestValidate(t *testing.T) {
 			proposedSpec:       loadValidateSpec(t, "base.flow.proto"),
 			fieldNameTransform: simpleTestTransform,
 			maxFieldLength:     0,
-			featureFlags:       map[string]bool{"allow_existing_tables_for_new_bindings": true, "flow_document": true, "drop_table": true},
+			featureFlags:       map[string]bool{"allow_existing_tables_for_new_bindings": true, "flow_document": true, "retain_existing_data_on_backfill": false},
 		},
 		{
 			name:               "table already exists with incompatible proposed spec",
@@ -172,7 +172,7 @@ func TestValidate(t *testing.T) {
 			proposedSpec:       loadValidateSpec(t, "incompatible-changes.flow.proto"),
 			fieldNameTransform: simpleTestTransform,
 			maxFieldLength:     0,
-			featureFlags:       map[string]bool{"allow_existing_tables_for_new_bindings": true, "flow_document": true, "drop_table": true},
+			featureFlags:       map[string]bool{"allow_existing_tables_for_new_bindings": true, "flow_document": true, "retain_existing_data_on_backfill": false},
 		},
 		{
 			name:               "field names over the length limit are forbidden",
@@ -182,7 +182,7 @@ func TestValidate(t *testing.T) {
 			proposedSpec:       loadValidateSpec(t, "long-fields.flow.proto"),
 			fieldNameTransform: simpleTestTransform,
 			maxFieldLength:     20,
-			featureFlags:       map[string]bool{"flow_document": true, "drop_table": true},
+			featureFlags:       map[string]bool{"flow_document": true, "retain_existing_data_on_backfill": false},
 		},
 		{
 			name:               "can materialize a subset of key fields",
@@ -192,7 +192,7 @@ func TestValidate(t *testing.T) {
 			proposedSpec:       loadValidateSpec(t, "key-subset.flow.proto"),
 			fieldNameTransform: simpleTestTransform,
 			maxFieldLength:     0,
-			featureFlags:       map[string]bool{"flow_document": true, "drop_table": true},
+			featureFlags:       map[string]bool{"flow_document": true, "retain_existing_data_on_backfill": false},
 		},
 		{
 			name:               "cannot add or remove selected key fields for standard updates",
@@ -202,7 +202,7 @@ func TestValidate(t *testing.T) {
 			proposedSpec:       loadValidateSpec(t, "key-subset.flow.proto"),
 			fieldNameTransform: simpleTestTransform,
 			maxFieldLength:     0,
-			featureFlags:       map[string]bool{"flow_document": true, "drop_table": true},
+			featureFlags:       map[string]bool{"flow_document": true, "retain_existing_data_on_backfill": false},
 		},
 	}
 
@@ -232,7 +232,7 @@ func TestValidate(t *testing.T) {
 	t.Run("new binding with existing table - feature flag disabled (default)", func(t *testing.T) {
 		// Table exists but no lastBinding (new binding) - should error
 		is := testInfoSchemaFromSpec(t, loadValidateSpec(t, "base.flow.proto"), simpleTestTransform)
-		featureFlags := map[string]bool{"flow_document": true, "drop_table": true}
+		featureFlags := map[string]bool{"flow_document": true, "retain_existing_data_on_backfill": false}
 		validator := NewValidator(testConstrainter{featureFlags: featureFlags}, is, 0, true, nil) // No feature flags
 
 		_, err := validator.ValidateBinding(
@@ -251,7 +251,7 @@ func TestValidate(t *testing.T) {
 	t.Run("new binding with existing table - feature flag enabled", func(t *testing.T) {
 		// Table exists but no lastBinding (new binding) - should succeed with feature flag
 		is := testInfoSchemaFromSpec(t, loadValidateSpec(t, "base.flow.proto"), simpleTestTransform)
-		featureFlags := map[string]bool{"allow_existing_tables_for_new_bindings": true, "drop_table": true}
+		featureFlags := map[string]bool{"allow_existing_tables_for_new_bindings": true, "retain_existing_data_on_backfill": false}
 		validator := NewValidator(testConstrainter{featureFlags: featureFlags}, is, 0, true, featureFlags)
 
 		cs, err := validator.ValidateBinding(
@@ -271,7 +271,7 @@ func TestValidate(t *testing.T) {
 
 		// Use the simpleTestTransform which appends "_transformed" to field names
 		is := testInfoSchemaFromSpec(t, nil, simpleTestTransform)
-		featureFlags := map[string]bool{"flow_document": true, "drop_table": true}
+		featureFlags := map[string]bool{"flow_document": true, "retain_existing_data_on_backfill": false}
 		validator := NewValidator(testConstrainter{featureFlags: featureFlags}, is, 0, true, nil)
 
 		cs, err := validator.ValidateBinding(
@@ -299,7 +299,7 @@ func TestValidate(t *testing.T) {
 		// Use identity transform (no change to field names)
 		identityTransform := func(s string) string { return s }
 		is := testInfoSchemaFromSpec(t, nil, identityTransform)
-		featureFlags := map[string]bool{"flow_document": true, "drop_table": true}
+		featureFlags := map[string]bool{"flow_document": true, "retain_existing_data_on_backfill": false}
 		validator := NewValidator(testConstrainter{featureFlags: featureFlags}, is, 0, true, nil)
 
 		cs, err := validator.ValidateBinding(
@@ -326,7 +326,7 @@ func TestValidate(t *testing.T) {
 		proposed.Bindings[0].Collection.Projections[3].Field = "keyRenamedToSomethingThatIsReallyLong"
 
 		is := testInfoSchemaFromSpec(t, nil, simpleTestTransform)
-		featureFlags := map[string]bool{"flow_document": true, "drop_table": true}
+		featureFlags := map[string]bool{"flow_document": true, "retain_existing_data_on_backfill": false}
 		validator := NewValidator(testConstrainter{featureFlags: featureFlags}, is, 20, true, nil)
 
 		_, err := validator.ValidateBinding(
@@ -348,7 +348,7 @@ func TestValidate(t *testing.T) {
 		// it has already been materialized, and is either the root document projection or a
 		// collection key.
 		is := testInfoSchemaFromSpec(t, proposed, simpleTestTransform)
-		featureFlags := map[string]bool{"allow_existing_tables_for_new_bindings": true, "drop_table": true}
+		featureFlags := map[string]bool{"allow_existing_tables_for_new_bindings": true, "retain_existing_data_on_backfill": false}
 		validator := NewValidator(testConstrainter{featureFlags: featureFlags}, is, 20, true, featureFlags)
 
 		_, err := validator.ValidateBinding(
@@ -370,7 +370,7 @@ func TestValidate(t *testing.T) {
 		existing.Bindings[0].DeltaUpdates = true
 
 		is := testInfoSchemaFromSpec(t, existing, simpleTestTransform)
-		featureFlags := map[string]bool{"flow_document": true, "drop_table": true}
+		featureFlags := map[string]bool{"flow_document": true, "retain_existing_data_on_backfill": false}
 		validator := NewValidator(testConstrainter{featureFlags: featureFlags}, is, 0, true, nil)
 
 		// Enabled binding.
@@ -405,7 +405,7 @@ func TestValidate(t *testing.T) {
 		proposed.Bindings[0].DeltaUpdates = true
 
 		is := testInfoSchemaFromSpec(t, existing, simpleTestTransform)
-		featureFlags := map[string]bool{"flow_document": true, "drop_table": true}
+		featureFlags := map[string]bool{"flow_document": true, "retain_existing_data_on_backfill": false}
 		validator := NewValidator(testConstrainter{featureFlags: featureFlags}, is, 0, true, nil)
 
 		_, err := validator.ValidateBinding(
@@ -427,7 +427,7 @@ func TestValidate(t *testing.T) {
 		proposed.Bindings[0].Collection.Projections[3].Inference.DefaultJson = nil
 
 		is := testInfoSchemaFromSpec(t, nil, simpleTestTransform)
-		featureFlags := map[string]bool{"flow_document": true, "drop_table": true}
+		featureFlags := map[string]bool{"flow_document": true, "retain_existing_data_on_backfill": false}
 		validator := NewValidator(testConstrainter{featureFlags: featureFlags}, is, 0, true, nil)
 
 		_, err := validator.ValidateBinding(
@@ -446,7 +446,7 @@ func TestValidate(t *testing.T) {
 		proposed := loadValidateSpec(t, "nullable-key.flow.proto")
 
 		is := testInfoSchemaFromSpec(t, nil, simpleTestTransform)
-		featureFlags := map[string]bool{"flow_document": true, "drop_table": true}
+		featureFlags := map[string]bool{"flow_document": true, "retain_existing_data_on_backfill": false}
 		validator := NewValidator(testConstrainter{featureFlags: featureFlags}, is, 0, true, nil)
 
 		_, err := validator.ValidateBinding(
@@ -529,7 +529,7 @@ func TestFlowDocumentFeatureFlag(t *testing.T) {
 		existing := loadValidateSpec(t, "base.flow.proto")
 		is := testInfoSchemaFromSpec(t, existing, simpleTestTransform)
 
-		featureFlags := map[string]bool{"flow_document": true, "drop_table": true}
+		featureFlags := map[string]bool{"flow_document": true, "retain_existing_data_on_backfill": false}
 		validator := NewValidator(testConstrainter{featureFlags: featureFlags}, is, 0, true, featureFlags)
 		constraints, err := validator.validateNewBinding(collection, false, map[string]json.RawMessage{})
 		require.NoError(t, err)
@@ -551,7 +551,7 @@ func TestFlowDocumentFeatureFlag(t *testing.T) {
 		existing := loadValidateSpec(t, "base.flow.proto")
 		is := testInfoSchemaFromSpec(t, existing, simpleTestTransform)
 
-		featureFlags := map[string]bool{"flow_document": false, "drop_table": true}
+		featureFlags := map[string]bool{"flow_document": false, "retain_existing_data_on_backfill": false}
 		validator := NewValidator(testConstrainter{featureFlags: featureFlags}, is, 0, true, featureFlags)
 		constraints, err := validator.validateNewBinding(collection, false, map[string]json.RawMessage{})
 		require.NoError(t, err)
@@ -572,7 +572,7 @@ func TestFlowDocumentFeatureFlag(t *testing.T) {
 		existing := loadValidateSpec(t, "base.flow.proto")
 		is := testInfoSchemaFromSpec(t, existing, simpleTestTransform)
 
-		featureFlags := map[string]bool{"flow_document": false, "drop_table": true}
+		featureFlags := map[string]bool{"flow_document": false, "retain_existing_data_on_backfill": false}
 		validator := NewValidator(testConstrainter{featureFlags: featureFlags}, is, 0, true, featureFlags)
 		constraints, err := validator.validateNewBinding(collection, true, map[string]json.RawMessage{}) // Delta updates = true
 		require.NoError(t, err)

--- a/materialize-cratedb/driver.go
+++ b/materialize-cratedb/driver.go
@@ -26,7 +26,7 @@ import (
 )
 
 var featureFlagDefaults = map[string]bool{
-	"drop_table": true,
+	"retain_existing_data_on_backfill": false,
 }
 
 const (

--- a/materialize-databricks/config.go
+++ b/materialize-databricks/config.go
@@ -11,7 +11,7 @@ import (
 
 var featureFlagDefaults = map[string]bool{
 	"datetime_keys_as_string": true,
-	"drop_table":              true,
+	"retain_existing_data_on_backfill": false,
 }
 
 // config represents the endpoint configuration for sql server.

--- a/materialize-dynamodb/driver.go
+++ b/materialize-dynamodb/driver.go
@@ -21,7 +21,7 @@ import (
 )
 
 var featureFlagDefaults = map[string]bool{
-	"drop_table": true,
+	"retain_existing_data_on_backfill": false,
 }
 
 type config struct {

--- a/materialize-elasticsearch/driver.go
+++ b/materialize-elasticsearch/driver.go
@@ -24,7 +24,7 @@ import (
 )
 
 var featureFlagDefaults = map[string]bool{
-	"drop_table": true,
+	"retain_existing_data_on_backfill": false,
 }
 
 type sshForwarding struct {

--- a/materialize-gcs-csv/main.go
+++ b/materialize-gcs-csv/main.go
@@ -13,7 +13,7 @@ import (
 )
 
 var featureFlagDefaults = map[string]bool{
-	"drop_table": true,
+	"retain_existing_data_on_backfill": false,
 }
 
 type config struct {

--- a/materialize-gcs-parquet/main.go
+++ b/materialize-gcs-parquet/main.go
@@ -16,7 +16,7 @@ var featureFlagDefaults = map[string]bool{
 	// Starting on 18-Aug-2025 newly created parquet materializations will use
 	// STRING logical type for UUID fields, rather than a UUID logical type.
 	"uuid_logical_type": false,
-	"drop_table":        true,
+	"retain_existing_data_on_backfill": false,
 }
 
 type config struct {

--- a/materialize-motherduck/config.go
+++ b/materialize-motherduck/config.go
@@ -18,7 +18,7 @@ import (
 
 var featureFlagDefaults = map[string]bool{
 	"datetime_keys_as_string": true,
-	"drop_table":              true,
+	"retain_existing_data_on_backfill": false,
 }
 
 type config struct {

--- a/materialize-mysql/driver.go
+++ b/materialize-mysql/driver.go
@@ -29,7 +29,7 @@ import (
 
 var featureFlagDefaults = map[string]bool{
 	"datetime_keys_as_string": true,
-	"drop_table":              true,
+	"retain_existing_data_on_backfill": false,
 }
 
 type sshForwarding struct {

--- a/materialize-postgres/driver.go
+++ b/materialize-postgres/driver.go
@@ -51,7 +51,7 @@ const (
 
 var featureFlagDefaults = map[string]bool{
 	"datetime_keys_as_string": true,
-	"drop_table":              true,
+	"retain_existing_data_on_backfill": false,
 }
 
 func ctxWithQueryTimeout(ctx context.Context) (context.Context, context.CancelFunc) {

--- a/materialize-redshift/driver.go
+++ b/materialize-redshift/driver.go
@@ -53,9 +53,9 @@ const (
 )
 
 var featureFlagDefaults = map[string]bool{
-	"datetime_keys_as_string":    true,
-	"s3_use_dualstack_endpoints": false,
-	"drop_table":                 true,
+	"datetime_keys_as_string":          true,
+	"s3_use_dualstack_endpoints":       false,
+	"retain_existing_data_on_backfill": false,
 }
 
 type sshForwarding struct {

--- a/materialize-s3-csv/main.go
+++ b/materialize-s3-csv/main.go
@@ -13,7 +13,7 @@ import (
 )
 
 var featureFlagDefaults = map[string]bool{
-	"drop_table": true,
+	"retain_existing_data_on_backfill": false,
 }
 
 type config struct {

--- a/materialize-s3-iceberg/driver.go
+++ b/materialize-s3-iceberg/driver.go
@@ -25,7 +25,7 @@ import (
 )
 
 var featureFlagDefaults = map[string]bool{
-	"drop_table": true,
+	"retain_existing_data_on_backfill": false,
 }
 
 type catalogType string

--- a/materialize-s3-parquet/main.go
+++ b/materialize-s3-parquet/main.go
@@ -16,7 +16,7 @@ var featureFlagDefaults = map[string]bool{
 	// Starting on 18-Aug-2025 newly created parquet materializations will use
 	// STRING logical type for UUID fields, rather than a UUID logical type.
 	"uuid_logical_type": false,
-	"drop_table":        true,
+	"retain_existing_data_on_backfill": false,
 }
 
 type config struct {

--- a/materialize-snowflake/config.go
+++ b/materialize-snowflake/config.go
@@ -19,7 +19,7 @@ var featureFlagDefaults = map[string]bool{
 	// authentication.
 	"snowpipe_streaming":      true,
 	"datetime_keys_as_string": true,
-	"drop_table":              true,
+	"retain_existing_data_on_backfill": false,
 }
 
 type config struct {

--- a/materialize-sqlserver/driver.go
+++ b/materialize-sqlserver/driver.go
@@ -24,7 +24,7 @@ import (
 
 var featureFlagDefaults = map[string]bool{
 	"datetime_keys_as_string": true,
-	"drop_table":              true,
+	"retain_existing_data_on_backfill": false,
 }
 
 type sshForwarding struct {

--- a/materialize-starburst/starburst.go
+++ b/materialize-starburst/starburst.go
@@ -19,7 +19,7 @@ import (
 )
 
 var featureFlagDefaults = map[string]bool{
-	"drop_table": true,
+	"retain_existing_data_on_backfill": false,
 }
 
 // config represents the endpoint configuration for starburst.


### PR DESCRIPTION
**Description:**

If no_drop_table is set, and we would normally truncate the table, truncation will be skipped. If normally we would drop the table, we error out.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

