### PR TITLE
source-google-sheets-native: add service account authentication option

### DIFF
--- a/source-google-sheets-native/source_google_sheets_native/models.py
+++ b/source-google-sheets-native/source_google_sheets_native/models.py
@@ -12,12 +12,30 @@ from estuary_cdk.capture.common import (
     ResourceConfig,
     ResourceState,
 )
+from estuary_cdk.flow import (
+    GoogleServiceAccount,
+    GoogleServiceAccountSpec,
+)
 
+
+scopes = [
+    "https://www.googleapis.com/auth/spreadsheets.readonly",
+    "https://www.googleapis.com/auth/drive.readonly",
+]
 
 # TODO(johnny): Lift this string building into higher-order helpers.
 OAUTH2_SPEC = OAuth2Spec(
     provider="google",
-    authUrlTemplate="https://accounts.google.com/o/oauth2/auth?access_type=offline&prompt=consent&client_id={{#urlencode}}{{{ client_id }}}{{/urlencode}}&redirect_uri={{#urlencode}}{{{ redirect_uri }}}{{/urlencode}}&response_type=code&scope=https://www.googleapis.com/auth/spreadsheets.readonly https://www.googleapis.com/auth/drive.readonly&state={{#urlencode}}{{{ state }}}{{/urlencode}}",
+    authUrlTemplate=(
+        "https://accounts.google.com/o/oauth2/auth?"
+        "access_type=offline&"
+        "prompt=consent&"
+        "client_id={{#urlencode}}{{{ client_id }}}{{/urlencode}}&"
+        "redirect_uri={{#urlencode}}{{{ redirect_uri }}}{{/urlencode}}&"
+        "response_type=code&"
+        f"scope={" ".join(scopes)}&"
+        "state={{#urlencode}}{{{ state }}}{{/urlencode}}"
+    ),
     accessTokenUrlTemplate="https://oauth2.googleapis.com/token",
     accessTokenBody=(
         '{"grant_type": "authorization_code", "client_id": "{{{ client_id }}}", "client_secret": "{{{ client_secret }}}", "redirect_uri": "{{{ redirect_uri }}}", "code": "{{{ code }}}"}'
@@ -33,8 +51,12 @@ else:
     OAuth2Credentials = BaseOAuth2Credentials.for_provider(OAUTH2_SPEC.provider)
 
 
+GOOGLE_SPEC = GoogleServiceAccountSpec(
+    scopes=scopes,
+)
+
 class EndpointConfig(BaseModel):
-    credentials: OAuth2Credentials | AccessToken = Field(
+    credentials: OAuth2Credentials | GoogleServiceAccount | AccessToken = Field(
         discriminator="credentials_title",
         title="Authentication",
     )

--- a/source-google-sheets-native/source_google_sheets_native/resources.py
+++ b/source-google-sheets-native/source_google_sheets_native/resources.py
@@ -10,6 +10,7 @@ from estuary_cdk.http import HTTPSession, HTTPMixin, TokenSource
 
 from .models import (
     EndpointConfig,
+    GOOGLE_SPEC,
     OAUTH2_SPEC,
     ResourceConfig,
     ResourceState,
@@ -25,7 +26,7 @@ from .api import (
 async def all_resources(
     log: Logger, http: HTTPMixin, config: EndpointConfig
 ) -> list[common.Resource]:
-    http.token_source = TokenSource(oauth_spec=OAUTH2_SPEC, credentials=config.credentials)
+    http.token_source = TokenSource(oauth_spec=OAUTH2_SPEC, google_spec=GOOGLE_SPEC, credentials=config.credentials)
     spreadsheet_id = get_spreadsheet_id(config.spreadsheet_url)
 
     spreadsheet = await fetch_spreadsheet(log, http, spreadsheet_id)

--- a/source-google-sheets-native/tests/snapshots/snapshots__spec__stdout.json
+++ b/source-google-sheets-native/tests/snapshots/snapshots__spec__stdout.json
@@ -23,6 +23,30 @@
           "title": "AccessToken",
           "type": "object"
         },
+        "GoogleServiceAccount": {
+          "properties": {
+            "credentials_title": {
+              "const": "Google Service Account",
+              "default": "Google Service Account",
+              "order": 0,
+              "title": "Credentials Title",
+              "type": "string"
+            },
+            "service_account": {
+              "description": "Service account JSON key",
+              "multiline": true,
+              "order": 1,
+              "secret": true,
+              "title": "Google Service Account",
+              "type": "string"
+            }
+          },
+          "required": [
+            "service_account"
+          ],
+          "title": "GoogleServiceAccount",
+          "type": "object"
+        },
         "_OAuth2Credentials": {
           "properties": {
             "credentials_title": {
@@ -61,6 +85,7 @@
         "credentials": {
           "discriminator": {
             "mapping": {
+              "Google Service Account": "#/$defs/GoogleServiceAccount",
               "OAuth Credentials": "#/$defs/_OAuth2Credentials",
               "Private App Credentials": "#/$defs/AccessToken"
             },
@@ -69,6 +94,9 @@
           "oneOf": [
             {
               "$ref": "#/$defs/_OAuth2Credentials"
+            },
+            {
+              "$ref": "#/$defs/GoogleServiceAccount"
             },
             {
               "$ref": "#/$defs/AccessToken"


### PR DESCRIPTION
**Description:**

Add the `GoogleServiceAccount` credentials type to `source-google-sheets-native` so users can authenticate with a service account if they don't want to use OAuth.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

There's currently no documentation for this connector, so we should probably make some.

**Notes for reviewers:**

(anything that might help someone review this PR)

