### PR TITLE
source-google-play: update year_month extraction regex

### DIFF
--- a/source-google-play/source_google_play/models.py
+++ b/source-google-play/source_google_play/models.py
@@ -138,7 +138,7 @@ class ReviewValidationContext(BaseValidationContext):
             A tuple containing the year and month as strings.
         """
         # Matches reviews_[anything]_YYYYMM[_optionalstuff].csv
-        pattern = r'reviews_[^_]+_(\d{6})(?:_[^.]*)?\.csv$'
+        pattern = r'reviews_.+_(\d{6})(?:_[^.]*)?\.csv$'
         match = re.search(pattern, filename)
 
         assert match, f"Filename does not match expected pattern: {filename}"


### PR DESCRIPTION
**Description:**

Update regular expression in `_extract_year_month` to allow package names containing underscores in review filenames. Previous regex pattern (`reviews_[^_]+_(\d{6})`) failed to match project names with underscores.

**Workflow steps:**

No changes to user-facing workflow - fix resolves an `AssertionError` when processing certain review files.

**Documentation links affected:**

No impact

**Notes for reviewers:**

Change to regular expression is strictly more permissive and maintains backwards compatibility. Pattern is only used in `ReviewValidationContext._extract_year_month()` and does not affect file discovery glob pattern

