### PR TITLE
materialize-redshift: add s3 dualstack feature flag

### DIFF
--- a/materialize-redshift/client.go
+++ b/materialize-redshift/client.go
@@ -18,6 +18,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	awsHttp "github.com/aws/smithy-go/transport/http"
+	"github.com/estuary/connectors/go/common"
 	cerrors "github.com/estuary/connectors/go/connector-errors"
 	boilerplate "github.com/estuary/connectors/materialize-boilerplate"
 	sql "github.com/estuary/connectors/materialize-sql"
@@ -185,7 +186,9 @@ func preReqs(ctx context.Context, cfg config) *cerrors.PrereqErr {
 		errs.Err(err)
 	}
 
-	s3client, err := cfg.toS3Client(ctx)
+	parsedFlags := common.ParseFeatureFlags(cfg.Advanced.FeatureFlags, featureFlagDefaults)
+
+	s3client, err := cfg.toS3Client(ctx, parsedFlags)
 	if err != nil {
 		// This is not caused by invalid S3 credentials, and would most likely be a logic error in
 		// the connector code.


### PR DESCRIPTION
**Description:**

Add a feature flag for that enables dualstack endpoints for S3 calls.  Without this option the Go client uses the IPv4 only endpoint.  This doesn't guarantee that the client will use IPv6, only that it has that option and it should use the Happy Eyeballs algorithm to choose.

Why is this a feature flag?  I'm not sure if it will help or not with the io timeout issues we are seeing and this is just my way of procrastinating the decision if to make it a real (probably advanced) option.

**Workflow steps:**

Set `s3_use_dualstack_endpoints` to enable.

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

