### PR TITLE
source-datadog: increase max page size

### DIFF
--- a/source-datadog/source_datadog/api.py
+++ b/source-datadog/source_datadog/api.py
@@ -12,7 +12,7 @@ from .models import (
 
 TResourceType = TypeVar("TResourceType", bound=IncrementalResource)
 
-MAX_PAGE_SIZE = 100
+MAX_PAGE_SIZE = 1_000
 CHECKPOINT_INTERVAL = 1_000
 MIN_INCREMENTAL_WINDOW_SIZE = timedelta(minutes=1)
 


### PR DESCRIPTION
**Description:**

The maximum limit is 1,000 per the Datadog [docs](https://docs.datadoghq.com/logs/guide/access-your-log-data-programmatically/#limit-the-number-of-results-retrieved). I verified that API requests with a limit of 1,000 succeed.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

