### PR TITLE
source-monday: handle update_board_granular_permissions activity log

### DIFF
--- a/source-monday/source_monday/models.py
+++ b/source-monday/source_monday/models.py
@@ -210,6 +210,7 @@ class ActivityLogEvents(StrEnum):
     SUBSCRIBE = "subscribe"
     UPDATE_BOARD_NAME = "update_board_name"
     UPDATE_BOARD_NICKNAME = "update_board_nickname"
+    UPDATE_BOARD_GRANULAR_PERMISSIONS = "update_board_granular_permissions"
     UPDATE_BOARD_PERMISSIONS = "update_board_permissions"
     UPDATE_COLUMN_NAME = "update_column_name"
     UPDATE_COLUMN_VALUE = "update_column_value"
@@ -290,6 +291,7 @@ class ActivityLog(BaseModel, extra="allow"):
                 | ActivityLogEvents.BOARD_WORKSPACE_ID_CHANGED
                 | ActivityLogEvents.CHANGE_COLUMN_SETTINGS
                 | ActivityLogEvents.UPDATE_BOARD_NICKNAME
+                | ActivityLogEvents.UPDATE_BOARD_GRANULAR_PERMISSIONS
                 | ActivityLogEvents.UPDATE_BOARD_PERMISSIONS
                 | ActivityLogEvents.RESTORE_GROUP
             ):


### PR DESCRIPTION
**Description:**

We've observed another new activity log type, `update_board_granular_permissions`. It should be considered a `BOARD_CHANGED` event type just like the similar
`update_board_permissions` activity log.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

