### PR TITLE
source-sqlserver: Make "Automatic Change Table Cleanup" less aggressive

### DIFF
--- a/source-sqlserver/main_test.go
+++ b/source-sqlserver/main_test.go
@@ -339,6 +339,11 @@ func TestCaptureInstanceCleanup(t *testing.T) {
 		t.Skip("skipping test in short mode.")
 	}
 
+	// Lower the cleanup interval for the purposes of speedy test execution
+	var oldInterval = cdcCleanupInterval
+	t.Cleanup(func() { cdcCleanupInterval = oldInterval })
+	cdcCleanupInterval = 5 * time.Second
+
 	var tb, ctx = sqlserverTestBackend(t), context.Background()
 	for _, tc := range []struct {
 		Name     string

--- a/source-sqlserver/replication.go
+++ b/source-sqlserver/replication.go
@@ -30,7 +30,6 @@ const (
 	cdcPollingWorkers     = 4                      // Number of parallel worker threads to execute CDC polling operations
 	cdcCleanupWorkers     = 4                      // Number of parallel worker threads to execute table cleanup operations
 	cdcPollingInterval    = 500 * time.Millisecond // How frequently to perform CDC polling
-	cdcCleanupInterval    = 15 * time.Minute       // How frequently to perform CDC table cleanup
 	cdcManagementInterval = 30 * time.Second       // How frequently to perform CDC instance management
 
 	// streamToFenceWatchdogTimeout is the length of time after which a stream-to-fence
@@ -49,6 +48,11 @@ const (
 	// on the actual `pollinginterval` setting in `cdc.dbo_jobs`. I suspect this will never
 	// actually be an issue.
 	establishFenceTimeout = 5 * time.Minute
+)
+
+// Constants which need to be changed in tests
+var (
+	cdcCleanupInterval = 15 * time.Minute // How frequently to perform CDC table cleanup
 )
 
 // LSN is just a type alias for []byte to make the code that works with LSN values a bit clearer.


### PR DESCRIPTION
**Description:**

Previously the "Automatic Change Table Cleanup" feature was absurdly aggressive, running every 15 seconds and executing up to 16 parallel worker threads to clean up the target tables. There is, quite frankly, no good reason to run it that often or to run that many concurrent instances of the same query which will all want to acquire the same locks.

If you want some concrete justification for increasing the cleanup interval, consider that if the capture task fails it could easily take 5-15 minutes before it gets restarted again anyway. Anything which relies on us performing cleanup more frequently than that is already destined to break sooner or later. So let's change the interval from 15s to 15m and thereby reduce the load on the target database by ~60x.

**Workflow steps:**

None, this is a change to some hard-coded constants and will impact all source-sqlserver captures.