### PR TITLE
materialize-sqlserver: ensure Tx rollback in case of panic

### DIFF
--- a/materialize-sqlserver/docker-compose.yaml
+++ b/materialize-sqlserver/docker-compose.yaml
@@ -1,5 +1,3 @@
-version: "3.7"
-
 services:
   sqlserver:
     image: 'mcr.microsoft.com/mssql/server:2022-latest'


### PR DESCRIPTION
**Description:**

If a panic occurs, rollback would not be called since it was guarded with `if err != nil`.  If a transaction is open when you call close on the connection it will hang waiting for it to end.

With this change, we always rollback unless we reach the end of the function, only then we disable the rollback.  This allows us to still use defer so we don't miss a placement later on.

After this change is applied I expect the connector will crash when the panic occurs.  It looks like the cause is that the *Stmt is nil but I'm not sure how.
```
#       0x47cf04        sync.runtime_SemacquireRWMutex+0x24                                     /usr/local/go/src/runtime/sema.go:105
#       0x48eba9        sync.(*RWMutex).Lock+0x69                                               /usr/local/go/src/sync/rwmutex.go:155
#       0x5380b4        database/sql.(*Conn).close+0x74                                         /usr/local/go/src/database/sql/sql.go:2138
#       0x1205fb9       database/sql.(*Conn).Close+0x39                                         /usr/local/go/src/database/sql/sql.go:2153
#       0x1205fa5       main.(*transactor).Destroy+0x25                                         /builder/materialize-sqlserver/driver.go:606
#       0x47b471        runtime.gopanic+0x131                                                   /usr/local/go/src/runtime/panic.go:792
#       0x47d998        runtime.panicmem+0x358                                                  /usr/local/go/src/runtime/panic.go:262
#       0x47d968        runtime.sigpanic+0x328                                                  /usr/local/go/src/runtime/signal_unix.go:925
#       0x539bb2        database/sql.(*Stmt).ExecContext+0x52                                   /usr/local/go/src/database/sql/sql.go:2644
#       0x1204764       main.(*transactor).Store+0x764                                          /builder/materialize-sqlserver/driver.go:542
#       0xb7222f        github.com/estuary/connectors/go/materialize.RunTransactions+0xdaf      /builder/go/materialize/transactor.go:305
#       0x1184af6       github.com/estuary/connectors/materialize-boilerplate.materialize+0x3d6 /builder/materialize-boilerplate/boilerplate.go:125
#       0x1184648       github.com/estuary/connectors/materialize-boilerplate.RunMain+0x748     /builder/materialize-boilerplate/boilerplate.go:76
#       0x120603b       main.main+0x5b                                                          /builder/materialize-sqlserver/driver.go:610
#       0x4464ea        runtime.main+0x28a                                                      /usr/local/go/src/runtime/proc.go:283
```

(Describe the high level scope of new or changed features)

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

