### PR TITLE
filesink: enable dualstack with feature_flag

### DIFF
--- a/filesink/store.go
+++ b/filesink/store.go
@@ -143,7 +143,7 @@ func (c S3StoreConfig) CredentialsProvider(ctx context.Context) (aws.Credentials
 	return nil, errors.New("unknown 'auth_type'")
 }
 
-func NewS3Store(ctx context.Context, cfg S3StoreConfig) (*S3Store, error) {
+func NewS3Store(ctx context.Context, cfg S3StoreConfig, featureFlags map[string]bool) (*S3Store, error) {
 	credProvider, err := cfg.CredentialsProvider(ctx)
 	if err != nil {
 		return nil, err
@@ -152,6 +152,9 @@ func NewS3Store(ctx context.Context, cfg S3StoreConfig) (*S3Store, error) {
 	opts := []func(*awsConfig.LoadOptions) error{
 		awsConfig.WithCredentialsProvider(credProvider),
 		awsConfig.WithRegion(cfg.Region),
+	}
+	if featureFlags["s3_use_dualstack_endpoints"] {
+		opts = append(opts, awsConfig.WithUseDualStackEndpoint(aws.DualStackEndpointStateEnabled))
 	}
 
 	if cfg.Endpoint != "" {

--- a/materialize-s3-csv/main.go
+++ b/materialize-s3-csv/main.go
@@ -57,7 +57,7 @@ var driver = filesink.FileDriver{
 		return cfg, nil
 	},
 	NewStore: func(ctx context.Context, c filesink.Config, featureFlags map[string]bool) (filesink.Store, error) {
-		return filesink.NewS3Store(ctx, c.(config).S3StoreConfig)
+		return filesink.NewS3Store(ctx, c.(config).S3StoreConfig, featureFlags)
 	},
 	NewWriter: func(c filesink.Config, featureFlags map[string]bool, b *pf.MaterializationSpec_Binding, w io.WriteCloser) (filesink.StreamWriter, error) {
 		return filesink.NewCsvStreamWriter(c.(config).CsvConfig, b, w), nil

--- a/materialize-s3-iceberg/driver.go
+++ b/materialize-s3-iceberg/driver.go
@@ -263,7 +263,7 @@ func (d *materialization) CheckPrerequisites(ctx context.Context) *cerrors.Prere
 		AWSAccessKeyID:     d.cfg.AWSAccessKeyID,
 		AWSSecretAccessKey: d.cfg.AWSSecretAccessKey,
 		Region:             d.cfg.Region,
-	})
+	}, nil)
 	if err != nil {
 		errs.Err(fmt.Errorf("creating s3 store: %w", err))
 		return errs
@@ -425,7 +425,7 @@ func (d *materialization) NewMaterializerTransactor(
 		AWSAccessKeyID:     d.cfg.AWSAccessKeyID,
 		AWSSecretAccessKey: d.cfg.AWSSecretAccessKey,
 		Region:             d.cfg.Region,
-	})
+	}, nil)
 	if err != nil {
 		return nil, fmt.Errorf("creating s3 store: %w", err)
 	}

--- a/materialize-s3-parquet/main.go
+++ b/materialize-s3-parquet/main.go
@@ -16,6 +16,8 @@ var featureFlagDefaults = map[string]bool{
 	// Starting on 18-Aug-2025 newly created parquet materializations will use
 	// STRING logical type for UUID fields, rather than a UUID logical type.
 	"uuid_logical_type": false,
+
+	"s3_use_dualstack_endpoints": false,
 }
 
 type config struct {
@@ -61,7 +63,7 @@ var driver = filesink.FileDriver{
 		return cfg, nil
 	},
 	NewStore: func(ctx context.Context, c filesink.Config, featureFlags map[string]bool) (filesink.Store, error) {
-		return filesink.NewS3Store(ctx, c.(config).S3StoreConfig)
+		return filesink.NewS3Store(ctx, c.(config).S3StoreConfig, featureFlags)
 	},
 	NewWriter: func(c filesink.Config, featureFlags map[string]bool, b *pf.MaterializationSpec_Binding, w io.WriteCloser) (filesink.StreamWriter, error) {
 		return filesink.NewParquetWriter(c.(config).ParquetConfig, b, w, featureFlags["uuid_logical_type"])


### PR DESCRIPTION
**Description:**

Use the dualstack endpoints if `s3_use_dualstack_endpoints` is enabled.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

