### PR TITLE
source-mysql: Fix MySQL replication logging

### DIFF
--- a/go/common/slog_logrus_handler.go
+++ b/go/common/slog_logrus_handler.go
@@ -32,12 +32,12 @@ func (l *LogrusHandler) Handle(ctx context.Context, r slog.Record) error {
 
 	for _, attr := range l.withAttrs {
 		if attr.Key != "" {
-			entry = entry.WithField(attr.Key, attr.Value)
+			entry = entry.WithField(attr.Key, attr.Value.String())
 		}
 	}
 	for attr := range r.Attrs {
 		if attr.Key != "" {
-			entry = entry.WithField(attr.Key, attr.Value)
+			entry = entry.WithField(attr.Key, attr.Value.String())
 		}
 	}
 


### PR DESCRIPTION
**Description:**

Log messages from within the go-mysql client library's replication code are output to a 'slog' compatible logging interface which we adapt to the logrus logger we use everywhere else, but apparently there was a subtle bug in that adapter which doesn't show up in tests (because we marshal to a human-readable text format there) but which prevented field values from being serialized correctly in production (where JSON logging is used).