### PR TITLE
materialize-s3-iceberg: Even more exit status info

### DIFF
--- a/materialize-s3-iceberg/icebergctl.go
+++ b/materialize-s3-iceberg/icebergctl.go
@@ -59,7 +59,8 @@ func runIcebergctl(ctx context.Context, cfg *config, args ...string) ([]byte, er
 	out, err := cmd.Output()
 	if err != nil {
 		if exitErr, ok := err.(*exec.ExitError); ok {
-			return nil, fmt.Errorf("error running iceberg_ctl (exit code %d): %s", exitErr.ExitCode(), string(exitErr.Stderr))
+			return nil, fmt.Errorf("error running iceberg_ctl (exit code %d, state: %s): %s",
+				exitErr.ExitCode(), exitErr.ProcessState.String(), string(exitErr.Stderr))
 		}
 
 		return nil, err


### PR DESCRIPTION
**Description:**

Adds even more exit status information when iceberg-ctl fails.
