### PR TITLE
materialize-s3-iceberg: Build Cython Avro decoder

### DIFF
--- a/materialize-s3-iceberg/Dockerfile
+++ b/materialize-s3-iceberg/Dockerfile
@@ -6,6 +6,8 @@ FROM base AS pybuilder
 
 RUN apt-get update && \
     apt install -y --no-install-recommends \
+    build-essential \
+    python3-dev \
     python3-poetry
 
 RUN python -m venv /opt/venv


### PR DESCRIPTION
**Description:**

Currently the PyIceberg Avro decoder is falling back to a pure Python implementation because the Cython one isn't available. This is apparently considered bad, since it logs a warning rather than just silently moving on.

While investigating some mysterious commit failures in prod, I have become increasingly suspicious that the iceberg-ctl tool is getting OOM killed, although I have not entirely proven that's what is happening. And what a coincidence, a less-commonly-used pure-Python fallback decoder sure seems like the sort of thing that might use a bunch of extra memory while doing its job.

The Cython decoder appears to be unavailable simply because the .so file isn't getting built, because the build dependencies for doing that are unavailable. Adding them to the Python build stage appears to produce the .so file and cause the relevant package import to start succeeding.

It remains to be seen whether this will actually do anything to fix the actual production failures, but even if it doesn't, it's probably good to fix that warning message since the developers thought it merited a warning.