### PR TITLE
materialize-s3-iceberg/iceberg-ctl: Memory improvements

### DIFF
--- a/materialize-s3-iceberg/Dockerfile
+++ b/materialize-s3-iceberg/Dockerfile
@@ -49,6 +49,7 @@ COPY --from=pybuilder /opt/iceberg-ctl /opt/iceberg-ctl
 COPY --from=gobuilder /builder/connector /opt/materialize-s3-iceberg
 
 ENV GOMEMLIMIT=900MiB
+ENV PYMEMLIMIT=900
 ENV PYTHON_PATH=/opt/venv/bin/python
 
 LABEL FLOW_RUNTIME_PROTOCOL=materialize

--- a/materialize-s3-iceberg/iceberg-ctl/iceberg_ctl/__main__.py
+++ b/materialize-s3-iceberg/iceberg-ctl/iceberg_ctl/__main__.py
@@ -1,5 +1,7 @@
 import asyncio
 import json
+import os
+import resource
 import sys
 import time
 import traceback
@@ -425,4 +427,13 @@ def append_files(
 
 
 if __name__ == "__main__":
+    try:
+        # Configure Python memory limits based on PYMEMLIMIT environment variable.
+        # This variable is used so that Go and Python limits can be tuned in the
+        # same place in the connector Dockerfile.
+        if pymemlimit := os.getenv("PYMEMLIMIT"):
+            limit_bytes = int(pymemlimit) * 1024 * 1024
+            resource.setrlimit(resource.RLIMIT_AS, (limit_bytes, resource.RLIM_INFINITY))
+    except (ValueError, OSError) as e:
+        print(f"warning: failed to set memory limit from PYMEMLIMIT={pymemlimit}: {e}", file=sys.stderr, flush=True)
     run(auto_envvar_prefix="ICEBERG")


### PR DESCRIPTION
**Description:**

This PR adds two tweaks to hopefully reduce the likelihood of iceberg-ctl getting OOM killed:
1. We no longer reload the table metadata after committing a transaction. The reloaded metadata wasn't really used for anything except for a human-readable log message, and we have reason to suspect that the metadata was the driver of excessive memory usage here, so reloading it ~doubled that.
2. We now tell Python to try and stay under 900MiB if it can.