### PR TITLE
source-dynamodb: mark shard finished only if full shard read

### DIFF
--- a/source-dynamodb/stream.go
+++ b/source-dynamodb/stream.go
@@ -297,7 +297,7 @@ func (c *capture) readShard(
 		if lastItemIdx > 0 || recs.NextShardIterator == nil {
 			newState := shardState{
 				LastReadSequence: lastReadSeq,
-				FinishedReading:  recs.NextShardIterator == nil,
+				FinishedReading:  !reachedHorizon && recs.NextShardIterator == nil,
 			}
 
 			if err := c.emitStream(t.bindingIdx, t.stateKey, *shard.ShardId, newState, recs.Records[:lastItemIdx], t.keyFields); err != nil {


### PR DESCRIPTION
**Description:**

When reading streams during backfill, we set a horizon to delay the reading of change records to avoid older backfill records from being written after a new change during the horizon window.  When doing this, we may read only part of a shard.  If the shard is  closed but isn't fully read, we wouldn't return to the shard later.

This could cause records near the end of the shard to be missed during backfill.

To fix this, if the shard is only partially read we no longer mark the shard as finished.  Later we will get a new shard iterator after the lastReadSeq id.

**Workflow steps:**

Automatic during backfill.

**Documentation links affected:**

NA

**Notes for reviewers:**

With dynamodb streams, change records are stored in "shards".  New records are added to the shards as changes are made, for awhile, but eventually the shard is closed.  Once closed no new records are added to that shard but the shard is still available to be read from for 24h.  Shards are open for an undefined amount of time, but comments indicate it is around 4h generally.

