### PR TITLE
materialize-iceberg: remove python MergeBinding files safely

### DIFF
--- a/materialize-iceberg/transactor.go
+++ b/materialize-iceberg/transactor.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"math"
 	"path"
-	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -241,15 +240,18 @@ func (t *transactor) Acknowledge(ctx context.Context) (*pf.ConnectorState, error
 					return nil, fmt.Errorf("listing previously staged files for recovery transaction: %w", err)
 				}
 
-				for idx, checkpointUri := range pyMergeBinding.Files {
+				var files []string
+				for _, checkpointUri := range pyMergeBinding.Files {
 					if _, ok := extantFiles[checkpointUri]; !ok {
 						log.WithFields(log.Fields{
 							"file":    checkpointUri,
 							"binding": b.Mapped.StateKey,
 						}).Info("previously checkpointed file no longer exists")
-						pyMergeBinding.Files = slices.Delete(pyMergeBinding.Files, idx, idx+1)
+						continue
 					}
+					files = append(files, checkpointUri)
 				}
+				pyMergeBinding.Files = files
 
 				if len(pyMergeBinding.Files) == 0 {
 					log.WithFields(log.Fields{


### PR DESCRIPTION
**Description:**

Removing items from an array while ranging over it is tricky, better to make a copy.

**Workflow steps:**

No changes

**Documentation links affected:**

None

**Notes for reviewers:**

I don't know much about the surrounding code, but I think this should be contained.

```
slices.Delete[...](...)
	/usr/local/go/src/slices/slices.go:223
github.com/estuary/connectors/materialize-iceberg.(*transactor).Acknowledge(0xc000a94b08, {0x5e5e450, 0xc000dd1140})
	/builder/materialize-iceberg/transactor.go:250 +0x139a
github.com/estuary/connectors/go/materialize.RunTransactions.func3({0x7c6dd091c800, 0xc00096ce28}, 0x2000000020?, 0xc001d41420)
	/builder/go/materialize/transactor.go:201 +0x167
created by github.com/estuary/connectors/go/materialize.RunTransactions in goroutine 1
	/builder/go/materialize/transactor.go:267 +0xb7f
```

(anything that might help someone review this PR)

