### PR TITLE
source-looker: add `user_attributes` and `user_attribute_values` streams

### DIFF
--- a/source-looker/source_looker/models.py
+++ b/source-looker/source_looker/models.py
@@ -197,18 +197,30 @@ class Users(LookerStream):
     path: ClassVar[str] = "users"
 
 
-class UserCredentialsEmbed(LookerStream):
+class UserCredentialsEmbed(LookerChildStream):
     name: ClassVar[str] = "user_credentials_embed"
     path: ClassVar[str] = "credentials_embed"
     parent: ClassVar[type[LookerStream]] = Users
     required_can_permission: ClassVar[str] = "show_creds"
 
 
-class UserRoles(LookerStream):
+class UserRoles(LookerChildStream):
     name: ClassVar[str] = "user_roles"
     path: ClassVar[str] = "roles"
     parent: ClassVar[type[LookerStream]] = Users
     required_can_permission: ClassVar[str] = "show_details"
+
+
+class UserAttributeValues(LookerChildStream):
+    name: ClassVar[str] = "user_attribute_values"
+    path: ClassVar[str] = "attribute_values"
+    parent: ClassVar[type[LookerStream]] = Users
+    required_can_permission: ClassVar[str] = "show_details"
+
+
+class UserAttributes(LookerStream):
+    name: ClassVar[str] = "user_attributes"
+    path: ClassVar[str] = "user_attributes"
 
 
 STREAMS = [
@@ -238,6 +250,10 @@ STREAMS = [
         "children": [
             {"stream": UserCredentialsEmbed},
             {"stream": UserRoles},
+            {"stream": UserAttributeValues},
         ]
-    }
+    },
+    {
+        "stream": UserAttributes,
+    },
 ]

--- a/source-looker/source_looker/resources.py
+++ b/source-looker/source_looker/resources.py
@@ -203,7 +203,7 @@ async def all_resources(
 
         return resources
 
-    # Concurrently check accessibility & build resoruces for all streams.
+    # Concurrently check accessibility & build resources for all streams.
     results = await asyncio.gather(
         *(
             build_resource_if_accessible_stream(element)


### PR DESCRIPTION
**Description:**

Adds the `user_attributes` and `user_attribute_values` streams to `source-looker`.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

The connector's documentation should be updated to include the two new streams.

**Notes for reviewers:**

Tested on a local stack. Confirmed both new streams capture data.

