### PR TITLE
source-klaviyo-native: reduce default window size

### DIFF
--- a/source-klaviyo-native/source_klaviyo_native/models.py
+++ b/source-klaviyo-native/source_klaviyo_native/models.py
@@ -47,7 +47,7 @@ class EndpointConfig(BaseModel):
         window_size: Annotated[timedelta, Field(
             description="Date window size for the events backfill in ISO 8601 format. ex: P30D means 30 days, PT6H means 6 hours.",
             title="Window size",
-            default=timedelta(days=30),
+            default=timedelta(hours=1),
             ge=timedelta(seconds=30),
             le=timedelta(days=365),
         )]

--- a/source-klaviyo-native/tests/snapshots/snapshots__spec__capture.stdout.json
+++ b/source-klaviyo-native/tests/snapshots/snapshots__spec__capture.stdout.json
@@ -6,7 +6,7 @@
         "Advanced": {
           "properties": {
             "window_size": {
-              "default": "P30D",
+              "default": "PT1H",
               "description": "Date window size for the events backfill in ISO 8601 format. ex: P30D means 30 days, PT6H means 6 hours.",
               "format": "duration",
               "title": "Window size",


### PR DESCRIPTION
**Description:**

After seeing a few captures set up, it's clear that 30 days is too large for a default window size. There's a significant amount of data within these 30 days windows, and it takes a long time to process 30 day windows. I'd like to try using a smaller window size of 1 ~~day~~ hour & see if backfills progress more smoothly.

Spec snapshot changes are expected since I changed the default `advanced.window_size` value.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

