### PR TITLE
source-hubspot-native: filter contact lists in memory

### DIFF
--- a/source-hubspot-native/acmeCo/contact_lists.schema.yaml
+++ b/source-hubspot-native/acmeCo/contact_lists.schema.yaml
@@ -26,6 +26,10 @@ properties:
   listId:
     title: Listid
     type: integer
+  objectTypeId:
+    const: 0-1
+    title: Objecttypeid
+    type: string
   updatedAt:
     format: date-time
     title: Updatedat
@@ -36,6 +40,7 @@ properties:
     type: object
 required:
   - listId
+  - objectTypeId
   - updatedAt
   - additionalProperties
 title: ContactList

--- a/source-hubspot-native/source_hubspot_native/models.py
+++ b/source-hubspot-native/source_hubspot_native/models.py
@@ -26,6 +26,9 @@ from estuary_cdk.capture.common import (
 )
 from pydantic import AwareDatetime, BaseModel, Field, model_validator, ValidationInfo
 
+OBJECT_TYPE_IDS = {"contact": "0-1", "contact_list": "0-45"}
+ContactTypeId = Literal["0-1"]
+
 scopes = [
     "crm.lists.read",
     "crm.objects.companies.read",
@@ -615,8 +618,13 @@ class CustomObjectSearchResult(BaseModel):
     properties: Properties
 
 
+class List(BaseDocument, extra="allow"):
+    objectTypeId: str
+
+
 class ContactList(BaseDocument, extra="allow"):
     listId: int
+    objectTypeId: ContactTypeId
     updatedAt: AwareDatetime
     additionalProperties: dict[str, Any]
 
@@ -630,8 +638,8 @@ class ContactList(BaseDocument, extra="allow"):
         return datetime.fromtimestamp(last_modified_timestamp, tz=UTC)
 
 
-class ContactListSearch(BaseModel, extra="allow"):
-    lists: list[ContactList]
+class ListSearch(BaseModel, extra="allow"):
+    lists: list[Annotated[ContactList | List, Field(union_mode="left_to_right")]]
 
     hasMore: bool
     offset: int

--- a/source-hubspot-native/tests/snapshots/snapshots__capture__stdout.json
+++ b/source-hubspot-native/tests/snapshots/snapshots__capture__stdout.json
@@ -456,7 +456,7 @@
         ]
       },
       "updatedAt": "2024-12-18T20:55:46.691000Z",
-      "url": "https://app.hubspot.com/go-to/48603990/0-1/86000071941"
+      "url": "https://app.hubspot.com/contacts/48603990/record/0-1/86000071941"
     }
   ],
   [
@@ -898,7 +898,7 @@
         ]
       },
       "updatedAt": "2024-12-18T20:55:47.220000Z",
-      "url": "https://app.hubspot.com/go-to/48603990/0-1/86013551115"
+      "url": "https://app.hubspot.com/contacts/48603990/record/0-1/86013551115"
     }
   ],
   [

--- a/source-hubspot-native/tests/snapshots/snapshots__discover__stdout.json
+++ b/source-hubspot-native/tests/snapshots/snapshots__discover__stdout.json
@@ -1954,6 +1954,11 @@
           "title": "Listid",
           "type": "integer"
         },
+        "objectTypeId": {
+          "const": "0-1",
+          "title": "Objecttypeid",
+          "type": "string"
+        },
         "updatedAt": {
           "format": "date-time",
           "title": "Updatedat",
@@ -1967,6 +1972,7 @@
       },
       "required": [
         "listId",
+        "objectTypeId",
         "updatedAt",
         "additionalProperties"
       ],


### PR DESCRIPTION
**Description:**

Turns out the list search API endpoint doesn't support object type id querying, so in-memory filter had to be implemented.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

