### PR TITLE
materialize-elasticsearch: allow setting int field as keyword

### DIFF
--- a/materialize-elasticsearch/driver_test.go
+++ b/materialize-elasticsearch/driver_test.go
@@ -6,6 +6,7 @@ import (
 	"flag"
 	"fmt"
 	"io"
+	"os"
 	"slices"
 	"strings"
 	"testing"
@@ -33,6 +34,9 @@ func testConfig() *config {
 
 func TestValidateAndApply(t *testing.T) {
 	flag.Parse()
+	if os.Getenv("TEST_DATABASE") != "yes" {
+		t.Skipf("skipping %q: ${TEST_DATABASE} != \"yes\"", t.Name())
+	}
 
 	cfg := testConfig()
 

--- a/materialize-elasticsearch/type_mapping.go
+++ b/materialize-elasticsearch/type_mapping.go
@@ -80,7 +80,11 @@ func propForProjection(p *pf.Projection, types []string, fc fieldConfig) propert
 	case pf.JsonTypeBoolean:
 		return property{Type: elasticTypeBoolean}
 	case pf.JsonTypeInteger:
-		return property{Type: elasticTypeLong}
+		if fc.Keyword {
+			return property{Type: elasticTypeKeyword}
+		} else {
+			return property{Type: elasticTypeLong}
+		}
 	case pf.JsonTypeString:
 		inf := p.Inference.String_
 		if inf == nil {


### PR DESCRIPTION
**Description:**

A user may wish to index numeric types as keywords to improve lookup in term searches if they do not need to the field with range queries.

closes: https://github.com/estuary/flow/issues/2477

**Workflow steps:**

Edit the field configuration using flowctl or advanced spec editor.  Backfill will be required if there is existing data as it is not possible to change the mapping of a field.

**Documentation links affected:**

Field configuration docs would need tweaked to mention that keyword works with int fields as well.

https://docs.estuary.dev/reference/Connectors/materialization-connectors/Elasticsearch/#field-configuration

**Notes for reviewers:**

(anything that might help someone review this PR)

