### PR TITLE
source-incident-io: capture incidents of all modes

### DIFF
--- a/source-incident-io/source_incident_io/api.py
+++ b/source-incident-io/source_incident_io/api.py
@@ -187,6 +187,14 @@ async def _fetch_incidents_between(
         "page_size": stream.page_size,
         # The "updated_at[date_range]" query parameter is inclusive of both bounds.
         "updated_at[date_range]": f"{start.date()}~{end.date()}",
+        # Only standard and retrospective incidents are included by default. We must
+        # explicitly specify incident modes to capture the other types of incidents.
+        "mode[one_of]": [
+            "standard",
+            "retrospective",
+            "test",
+            "tutorial",
+        ]
     }
 
     async for incident in _paginate_through_resources(http, stream, params, log):


### PR DESCRIPTION
**Description:**

The incident.io API defaults to only returning standard and retrospective incidents. We have to explicitly specify which incident modes we want in order to capture the other two modes.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

Tested with `flowctl preview`. Confirmed the expected number of documents are returned for the `incidents` stream.

