### PR TITLE
source-postgres: Fix docker-compose.yaml for v18

### DIFF
--- a/source-postgres-batch/docker-compose.yaml
+++ b/source-postgres-batch/docker-compose.yaml
@@ -19,7 +19,7 @@ services:
       - type: bind
         source: ./docker-initdb.sh
         target: /docker-entrypoint-initdb.d/init-user-db.sh
-      - postgres_data:/var/lib/postgresql/data
+      - postgres_data:/var/lib/postgresql
 
 networks:
   flow-test:

--- a/source-postgres/docker-compose.yaml
+++ b/source-postgres/docker-compose.yaml
@@ -1,5 +1,3 @@
-version: "3.7"
-
 services:
   db:
     image: 'postgres:latest'
@@ -24,7 +22,7 @@ services:
       - type: bind
         source: ../tests/files/b.csv
         target: /b.csv
-      - postgres_data:/var/lib/postgresql/data
+      - postgres_data:/var/lib/postgresql
 
 networks:
   flow-test:


### PR DESCRIPTION
**Description:**

Apparently the PostgreSQL v18 docker image is now live and the docker-compose.yaml has to be tweaked slightly. I have verified that this doesn't appear to cause any trouble if/when I need to run a lower version locally (but if it did we'd probably still need to make this change and just add a comment noting to also change the mount path when testing older releases).