### PR TITLE
source-dynamics-365-finance-and-operations: fix CSV file path matching

### DIFF
--- a/source-dynamics-365-finance-and-operations/README.md
+++ b/source-dynamics-365-finance-and-operations/README.md
@@ -22,10 +22,10 @@ Data is stored in a container named: `dataverse-[environmentName]-[organizationU
 └── [timestamp-folders]/         # Time-stamped incremental update folders. Each folder contains changes that occurred within a specific time interval.
     ├── model.json               # Schema metadata snapshot for tables in this folder. May differ from global schema if schema changes occurred. Empty while folder is being written to.
     ├── [TableName1]/            # The name of the Dynamics 365 table that was changed.
-    │   ├── [TableName1]_xxx.csv # A headerless CSV containing changes made to the table. Multiple CSVs may exist per table.
-    │   └── [TableName1]_yyy.csv
+    │   ├── xxx.csv              # A headerless CSV containing changes made to the table. Multiple CSVs may exist per table.
+    │   └── yyy.csv
     └── [TableName2]/
-        └── [TableName2]_zzz.csv
+        └── zzz.csv
 ```
 
 ### Timestamp Folders
@@ -75,7 +75,7 @@ The schema can evolve over time as tables are modified in Dynamics 365, so diffe
 ## CSV File Structure
 
 ### Naming Convention
-CSV files are named: `[TableName]_[suffix].csv`
+CSV files are located in subdirectories named after the table: `[timestamp-folder]/[TableName]/[filename].csv`
 - Multiple CSV files may exist per table within a timestamp folder.
 - Files contain no column headers. Column definitions are found only in the corresponding `model.json`.
 

--- a/source-dynamics-365-finance-and-operations/source_dynamics_365_finance_and_operations/api.py
+++ b/source-dynamics-365-finance-and-operations/source_dynamics_365_finance_and_operations/api.py
@@ -113,7 +113,7 @@ async def read_csvs_in_folder(
         if (
             not metadata.isDirectory and
             metadata.name.endswith('.csv') and
-            metadata.name.startswith(f"{folder}/{table_name}")
+            metadata.name.startswith(f"{folder}/{table_name}/")
         ):
             csvs.append(metadata)
 


### PR DESCRIPTION
**Description:**

The `metadata.name.startswith` check to determine which CSVs a stream should read was overly broad. For example, the `dimensionattributevalue` stream was trying to read CSVs under `{timestamp_folder}/dimensionattributevalueset/`. 🤦 This is incorrect; we only want `dimensionattributevalue` to read CSVs under `{timestamp_folder}/dimensionattributevalue/`.

Adding a trailing `/` to this check fixes this bug & ensures streams only look for changes in their same named subfolders.

I also corrected incorrect file name formats in the README. The table name is a part of the path, but not part of the actual file name.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

Tested on a local stack. Confirmed `dimensionattributevalue` only tried to read CSVs whose path matches `{timestamp_folder}/dimensionattributevalue/`.

