### PR TITLE
source-facebook-marketing: enable schema inference

### DIFF
--- a/source-facebook-marketing/source_facebook_marketing/__main__.py
+++ b/source-facebook-marketing/source_facebook_marketing/__main__.py
@@ -16,7 +16,7 @@ asyncio.run(
             accessTokenBody="",  # Uses query arguments.
             accessTokenHeaders={},
         ),
-        schema_inference=False,
+        schema_inference=True,
         should_emit_sourced_schemas=True,
     ).serve()
 )


### PR DESCRIPTION
**Description:**

Enable schema inference for `source-facebook-marketing`.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

Tested on a local stack that this works as intended following #3436 .

