### PR TITLE
source-dynamics-365-finance-and-operations: remove DataType enum

### DIFF
--- a/source-dynamics-365-finance-and-operations/README.md
+++ b/source-dynamics-365-finance-and-operations/README.md
@@ -64,7 +64,7 @@ The schema can evolve over time as tables are modified in Dynamics 365, so diffe
       "attributes": [
         {
           "name": "ColumnName",
-          "dataType": "string|int64|boolean|dateTime|decimal|guid"
+          "dataType": "string|int64|boolean|dateTime|decimal|guid|dateTimeOffset"
         }
       ]
     }

--- a/source-dynamics-365-finance-and-operations/source_dynamics_365_finance_and_operations/models.py
+++ b/source-dynamics-365-finance-and-operations/source_dynamics_365_finance_and_operations/models.py
@@ -42,20 +42,11 @@ class EndpointConfig(BaseModel):
 ConnectorState = GenericConnectorState[ResourceState]
 
 
-class DataType(StrEnum):
-    BOOLEAN = "boolean"
-    DATETIME = "dateTime"
-    DECIMAL = "decimal"
-    GUID = "guid"
-    INT64 = "int64"
-    STRING = "string"
-
-
 class ModelDotJson(BaseModel, extra="allow"):
     class Entity(BaseModel, extra="allow"):
         class Attribute(BaseModel, extra="allow"):
             name: str
-            dataType: DataType
+            dataType: str
 
         type_: str = Field(alias="$type")
         name: str
@@ -71,7 +62,7 @@ class ModelDotJson(BaseModel, extra="allow"):
 class BaseTable(BaseCSVRow, extra="allow"):
     name: ClassVar[str]
     field_names: ClassVar[list[str]]
-    field_types: ClassVar[dict[str, DataType]]
+    field_types: ClassVar[dict[str, str]]
 
     Id: str
     IsDelete: bool | None
@@ -81,7 +72,7 @@ class BaseTable(BaseCSVRow, extra="allow"):
     def convert_boolean_fields(cls, values: dict) -> dict:
         if hasattr(cls, 'field_types'):
             for field_name, value in values.items():
-                if (cls.field_types.get(field_name) == DataType.BOOLEAN) and value is not None:
+                if (cls.field_types.get(field_name) == "boolean") and value is not None:
                     assert isinstance(value, str)
                     values[field_name] = value.lower() == 'true'
         return values


### PR DESCRIPTION
**Description:**

The `DataType` string enum was incomplete and missing a valid data type (dateTimeOffset). This was causing cryptic errors during discovery like "Some resource was exhausted.".

I originally included the `DataType` enum when I was planning on using `SourcedSchema`s to aid when building up the schemas for those messages, but since the connector ended up not using `SourcedSchema`s, the `DataType` enum is primarily documentation for `model.json` contents. This can be sufficiently documented in the `README.md`, and the connector doesn't need to keep the `DataType` enum around or use it during validation.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

Tested on a local stack. Confirmed discovery now succeeds when a `model.json` includes `dateTimeOffset` as a field's data type.

