### PR TITLE
materialize-snowflake: rename TIMESTAMP_NTZ options

### DIFF
--- a/materialize-snowflake/.snapshots/TestSpecification
+++ b/materialize-snowflake/.snapshots/TestSpecification
@@ -45,8 +45,8 @@
         "type": "string",
         "enum": [
           "TIMESTAMP_LTZ",
-          "TIMESTAMP_NTZ_DISCARD",
-          "TIMESTAMP_NTZ_NORMALIZE",
+          "TIMESTAMP_NTZ (discard TZ)",
+          "TIMESTAMP_NTZ (normalize to UTC)",
           "TIMESTAMP_TZ"
         ],
         "title": "Snowflake Timestamp Type",

--- a/materialize-snowflake/config.go
+++ b/materialize-snowflake/config.go
@@ -30,9 +30,9 @@ const (
 	// timestampTypeLTZ stores timestamp as UTC with automatic timezone normalization by Snowflake
 	timestampTypeLTZ snowflakeTimestampType = "TIMESTAMP_LTZ"
 	// timestampTypeNTZDiscard stores timestamp as wall-clock time without timezone, discarding source TZ
-	timestampTypeNTZDiscard snowflakeTimestampType = "TIMESTAMP_NTZ_DISCARD"
+	timestampTypeNTZDiscard snowflakeTimestampType = "TIMESTAMP_NTZ (discard TZ)"
 	// timestampTypeNTZNormalize stores timestamp as wall-clock time without timezone, normalizing to UTC first
-	timestampTypeNTZNormalize snowflakeTimestampType = "TIMESTAMP_NTZ_NORMALIZE"
+	timestampTypeNTZNormalize snowflakeTimestampType = "TIMESTAMP_NTZ (normalize to UTC)"
 	// timestampTypeTZ stores timestamp with associated timezone offset
 	timestampTypeTZ snowflakeTimestampType = "TIMESTAMP_TZ"
 )
@@ -78,7 +78,7 @@ type config struct {
 	Warehouse         string                           `json:"warehouse,omitempty" jsonschema:"title=Warehouse,description=The Snowflake virtual warehouse used to execute queries. Uses the default warehouse for the Snowflake user if left blank." jsonschema_extras:"order=5"`
 	Role              string                           `json:"role,omitempty" jsonschema:"title=Role,description=The user role used to perform actions." jsonschema_extras:"order=6"`
 	Account           string                           `json:"account,omitempty" jsonschema:"title=Account,description=Optional Snowflake account identifier." jsonschema_extras:"order=7,x-hidden-field=true"`
-	TimestampType     snowflakeTimestampType           `json:"timestamp_type" jsonschema:"title=Snowflake Timestamp Type,description=Controls how timestamp columns are stored in Snowflake.,enum=TIMESTAMP_LTZ,enum=TIMESTAMP_NTZ_DISCARD,enum=TIMESTAMP_NTZ_NORMALIZE,enum=TIMESTAMP_TZ" jsonschema_extras:"order=8"`
+	TimestampType     snowflakeTimestampType           `json:"timestamp_type" jsonschema:"title=Snowflake Timestamp Type,description=Controls how timestamp columns are stored in Snowflake.,enum=TIMESTAMP_LTZ,enum=TIMESTAMP_NTZ (discard TZ),enum=TIMESTAMP_NTZ (normalize to UTC),enum=TIMESTAMP_TZ" jsonschema_extras:"order=8"`
 	HardDelete        bool                             `json:"hardDelete,omitempty" jsonschema:"title=Hard Delete,description=If this option is enabled items deleted in the source will also be deleted from the destination. By default is disabled and _meta/op in the destination will signify whether rows have been deleted (soft-delete).,default=false" jsonschema_extras:"order=9"`
 	Credentials       *snowflake_auth.CredentialConfig `json:"credentials" jsonschema:"title=Authentication"`
 	Schedule          m.ScheduleConfig                 `json:"syncSchedule,omitempty" jsonschema:"title=Sync Schedule,description=Configure schedule of transactions for the materialization."`


### PR DESCRIPTION
**Description:**

- Got the feedback from Johnny that we should rename these option values to make it clear the value from Snowflake is TIMESTAMP_NTZ, and the discard or normalise parts are specific to the connector
- Rename options for timestamp type mapping
- Ran integration tests locally with TIMESTAMP_NTZ (discard TZ) and TIMESTAMP_NTZ (normalise to UTC) to make sure the values work correctly

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

