### PR TITLE
source-klaviyo-native: bound initial chunk size for events backfill

### DIFF
--- a/source-klaviyo-native/source_klaviyo_native/api/events.py
+++ b/source-klaviyo-native/source_klaviyo_native/api/events.py
@@ -220,7 +220,12 @@ class WorkManager:
     def _create_initial_chunks(self, start: datetime, end: datetime) -> list[DateChunk]:
         return [
             DateChunk(start=chunk_start, end=chunk_end)
-            for chunk_start, chunk_end in split_date_window(start, end, DEFAULT_BACKFILL_CONFIG.initial_chunks)
+            for chunk_start, chunk_end in split_date_window(
+                start=start,
+                end=end,
+                num_chunks=DEFAULT_BACKFILL_CONFIG.initial_chunks,
+                minimum_chunk_size=SMALLEST_KLAVIYO_DATETIME_GRAIN,
+            )
         ]
 
     async def _shutdown_monitor(self) -> None:


### PR DESCRIPTION
**Description:**

If the `events` backfill's start and end are close enough together, `split_date_window` could create chunks less than a second wide. The Klaviyo API doesn't support querying events in the same second, and the API returns an error like:
```json
{"errors":[{"id":"some_id","status":400,"code":"invalid","title":"Invalid input.","detail":"Datetime bounds 2025-10-27 02:59:59+00:00 (exclusive) to 2025-10-27 02:59:59+00:00 (inclusive) is empty or invalid","source":{"pointer":"datetime"},"links":{},"meta":{}}]}

```

To fix this, we need to place a lower bound on the initial chunk size with `minimum_chunk_size`. This ensures chunks are always at least 1 second wide.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

Tested with `flowctl preview`. Confirmed a capture previously hitting that API error no longer hits an error & completes the backfill.