### PR TITLE
materialize-s3-iceberg: include s3_endpoint in spec

### DIFF
--- a/materialize-s3-iceberg/.snapshots/TestSpec
+++ b/materialize-s3-iceberg/.snapshots/TestSpec
@@ -146,6 +146,13 @@
         "title": "Upload Interval",
         "type": "string"
       },
+      "s3_endpoint": {
+        "default": "",
+        "description": "Custom S3 endpoint URL. If not provided, the default AWS S3 endpoint for the specified region will be used.",
+        "order": 7,
+        "title": "S3 Endpoint",
+        "type": "string"
+      },
       "catalog": {
         "discriminator": {
           "mapping": {
@@ -162,7 +169,7 @@
             "$ref": "#/$defs/GlueCatalogConfig"
           }
         ],
-        "order": 7,
+        "order": 8,
         "title": "Catalog"
       },
       "advanced": {
@@ -177,7 +184,7 @@
         ],
         "default": null,
         "description": "Options for advanced users. You should not typically need to modify these.",
-        "order": 8,
+        "order": 9,
         "title": "Advanced Options"
       }
     },

--- a/materialize-s3-iceberg/iceberg-ctl/iceberg_ctl/models.py
+++ b/materialize-s3-iceberg/iceberg-ctl/iceberg_ctl/models.py
@@ -89,14 +89,19 @@ class EndpointConfig(BaseModel):
         description="Frequency at which files will be uploaded. Must be a valid ISO8601 duration string no greater than 4 hours.",
         json_schema_extra={"order": 6},
     )
+    s3_endpoint: str = Field(
+        default="",
+        description="Custom S3 endpoint URL. If not provided, the default AWS S3 endpoint for the specified region will be used.",
+        json_schema_extra={"order": 7},
+    )
     catalog: RestCatalogConfig | GlueCatalogConfig = Field(
         discriminator="catalog_type",
         title="Catalog",
-        json_schema_extra={"order": 7},
+        json_schema_extra={"order": 8},
     )
     advanced: Optional[AdvancedConfig] = Field(
         default=None,
         title="Advanced Options",
         description="Options for advanced users. You should not typically need to modify these.",
-        json_schema_extra={"order": 8, "advanced": True},
+        json_schema_extra={"order": 9, "advanced": True},
     )


### PR DESCRIPTION
**Description:**

This connector's spec is in iceberg_ctl's python code! I had missed this

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

