### PR TITLE
Optimize Python connector Dockerfile build steps

### DIFF
--- a/estuary-cdk/common.Dockerfile
+++ b/estuary-cdk/common.Dockerfile
@@ -12,11 +12,14 @@ RUN python -m venv /opt/venv
 ENV VIRTUAL_ENV=/opt/venv
 
 WORKDIR /opt/${CONNECTOR_NAME}
-COPY ${CONNECTOR_NAME} /opt/${CONNECTOR_NAME}
+COPY ${CONNECTOR_NAME}/pyproject.toml ${CONNECTOR_NAME}/poetry.lock /opt/${CONNECTOR_NAME}
 COPY estuary-cdk /opt/estuary-cdk
 
-RUN poetry install
+RUN poetry install --no-root
 
+COPY ${CONNECTOR_NAME} /opt/${CONNECTOR_NAME}
+
+RUN poetry install
 
 FROM base AS runner
 


### PR DESCRIPTION
**Description:**

**Description:**

This pull request optimizes the Docker build process for Python connectors by implementing Docker layer caching for Poetry dependencies. The changes restructure the Dockerfile to:

1. First copy only `pyproject.toml` and `poetry.lock` files
2. Run `poetry install --no-root` to install dependencies without the source code
3. Then copy the full source code and run `poetry install` again to complete the installation

This approach leverages Docker's layer caching mechanism - dependency layers are only rebuilt when `pyproject.toml` or `poetry.lock` change, not when source code changes.

*Benefits:*

This provides time savings during local development and testing cycles, as Poetry dependencies don't need to be reinstalled on every source code change. It also offers potential CI/CD build time improvements when dependency files haven't changed between builds, resulting in faster feedback loops or less build minutes over time.

*Technical Details:*

- Modified `estuary-cdk/common.Dockerfile` to separate dependency installation from source code copying
- Uses `poetry install --no-root` for initial dependency installation
- Follows Docker best practices for layer optimization

**Workflow Impact:**

No changes to existing workflows - this is purely a build optimization that maintains the same final container image and functionality.


**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

