### PR TITLE
source-zendesk-support-native: add `ticket_id` field to ticket child resources

### DIFF
--- a/source-zendesk-support-native/source_zendesk_support_native/api.py
+++ b/source-zendesk-support-native/source_zendesk_support_native/api.py
@@ -33,6 +33,7 @@ from .models import (
     PostCommentVotesResponse,
     INCREMENTAL_CURSOR_EXPORT_TYPES,
     FilterParam,
+    TicketChildResourceValidationContext,
 )
 
 CHECKPOINT_INTERVAL = 1000
@@ -676,9 +677,12 @@ async def _fetch_ticket_child_resources(
         params: dict[str, str | int] = {
             "page[size]": CURSOR_PAGINATION_PAGE_SIZE,
         }
+        context = TicketChildResourceValidationContext(ticket_id=ticket_id)
+
         while True:
             response = response_model.model_validate_json(
-                await http.request(log, url, params=params)
+                await http.request(log, url, params=params),
+                context=context
             )
 
             for resource in response.resources:

--- a/source-zendesk-support-native/tests/snapshots/snapshots__capture__capture.stdout.json
+++ b/source-zendesk-support-native/tests/snapshots/snapshots__capture__capture.stdout.json
@@ -669,6 +669,7 @@
       },
       "plain_body": "Can I still cancel my order?",
       "public": true,
+      "ticket_id": 12,
       "type": "Comment",
       "via": {
         "channel": "sample_ticket",


### PR DESCRIPTION
**Description:**

Zendesk does not include the `ticket_id` in the `ticket_comments` stream, and users have asked for a `ticket_id` to be present in these documents. We already query ticket comments by using the ticket id in the API request's path, so it's fairly reasonable to add that id as a top level `ticket_id` field. This commit does just that; it adds `ticket_id` to any ticket child resources that don't already have a `ticket_id` field present.

Capture snapshot changes are expected - there's now a `ticket_id` field in `ticket_comments` documents.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

Confirmed `pytest` passes and shows a `ticket_id` field is present in `ticket_comments` documents.

