### PR TITLE
source-postgres-batch: Allow reltuples to be a float

### DIFF
--- a/source-postgres-batch/driver.go
+++ b/source-postgres-batch/driver.go
@@ -1057,10 +1057,10 @@ func compareXID32(a, b uint32) int {
 }
 
 type postgresTableStatistics struct {
-	RelPages       int64 // Approximate number of pages in the table
-	RelTuples      int64 // Approximate number of live tuples in the table
-	MaxPageID      int64 // Conservative upper bound for the maximum page ID
-	PartitionCount int   // Number of partitions for the table, including the parent table itself
+	RelPages       int64   // Approximate number of pages in the table
+	RelTuples      float64 // Approximate number of live tuples in the table
+	MaxPageID      int64   // Conservative upper bound for the maximum page ID
+	PartitionCount int     // Number of partitions for the table, including the parent table itself
 }
 
 const tableStatisticsQuery = `


### PR DESCRIPTION
**Description:**

The source column is a `float4` and this appears to be a difference in behavior between using PGX directly (in source-postgres) and as a Go sql.DB driver (in source-postgres-batch). In the former case a non-integer value will be rounded or truncated, but in the latter it errors out if the value is not an integer, so non-integer reltuples values are causing errors even though the function is a direct copy- paste from source-postgres _and_ it works fine in local testing if the reltuples value is an integer.

At least I'm pretty sure that's what is happening here.