### PR TITLE
source-outreach: fix page cursor extraction returning list instead of string

### DIFF
--- a/source-outreach/source_outreach/api.py
+++ b/source-outreach/source_outreach/api.py
@@ -33,9 +33,10 @@ def _extract_page_cursor(links: OutreachResponse.Links | None) -> str | None:
         return None
 
     parsed_url = urlparse(links.next)
-    params: dict[str, str] = parse_qs(parsed_url.query) #type: ignore
+    params = parse_qs(parsed_url.query)
 
-    return params.get('page[after]')
+    cursor_list = params.get('page[after]')
+    return cursor_list[0] if cursor_list else None
 
 
 async def backfill_resources(


### PR DESCRIPTION
**Description:**

The `_extract_page_cursor` function was using `parse_qs()` which returns `dict[str, list[str]]`, but treating the result as if it returned `dict[str, str]`. This caused pagination cursors to be saved as lists in connector state, leading to Pydantic validation errors on restart.

Fixed by properly extracting the first item from the parameter list.

Production tasks that have had lists checkpointed in their recovery logs will need to be deleted & recreated to be "reset" with a fresh recovery log. Otherwise, the connector will continue to receive a page cursor that's a list, and validation errors will continue to be raised by Pydantic since page cursors are not allowed to be lists. There's only one existing task, so I'll do this "capture reset" manually.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

