### PR TITLE
materialize-mysql: make binary column compat with varchar

### DIFF
--- a/materialize-mysql/sqlgen.go
+++ b/materialize-mysql/sqlgen.go
@@ -109,7 +109,7 @@ var mysqlDialect = func(tzLocation *time.Location, database string, product stri
 			sql.OBJECT:  sql.MapStatic(jsonType),
 			sql.ARRAY:   sql.MapStatic(jsonType),
 			sql.BINARY: sql.MapPrimaryKey(
-				sql.MapStatic("VARCHAR(256)"),
+				sql.MapStatic("VARCHAR(256)", sql.AlsoCompatibleWith("varchar")),
 				sql.MapStatic("LONGTEXT"),
 			),
 			sql.MULTIPLE: jsonMapper,
@@ -384,7 +384,7 @@ CREATE TEMPORARY TABLE {{ template "temp_load_name" . }} (
 -- Templated truncation of the temporary load table:
 
 {{ define "truncateTempTable" }}
-` + tempTruncateCommand + ` {{ template "temp_load_name" . }};
+`+tempTruncateCommand+` {{ template "temp_load_name" . }};
 {{ end }}
 
 -- Templated load into the temporary load table:
@@ -443,7 +443,7 @@ SELECT * FROM (SELECT -1, NULL LIMIT 0) as nodoc
 
 {{ define "loadQueryNoFlowDocument" }}
 {{ if not $.DeltaUpdates -}}
-SELECT {{ $.Binding }}, ` + jsonBuildFunction + `(
+SELECT {{ $.Binding }}, `+jsonBuildFunction+`(
 {{- range $i, $col := $.RootLevelColumns}}
 	{{- if $i}},{{end}}
     {{Literal $col.Field}}, {{ template "uncast" (ColumnWithAlias $col "r") }}
@@ -528,7 +528,7 @@ FROM {{ template "temp_update_name" . }};
 
 
 {{ define "truncateUpdateTable" }}
-` + tempTruncateCommand + ` {{ template "temp_update_name" . }};
+`+tempTruncateCommand+` {{ template "temp_update_name" . }};
 {{ end }}
 
 
@@ -575,7 +575,7 @@ WHERE
 {{ end }}
 
 {{ define "truncateDeleteTable" }}
-` + tempTruncateCommand + ` {{ template "temp_delete_name" . }};
+`+tempTruncateCommand+` {{ template "temp_delete_name" . }};
 {{ end }}
 
 {{ define "installFence" }}

--- a/materialize-mysql/sqlgen_test.go
+++ b/materialize-mysql/sqlgen_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/bradleyjkemp/cupaloy"
+	boilerplate "github.com/estuary/connectors/materialize-boilerplate"
 	sql "github.com/estuary/connectors/materialize-sql"
 	pf "github.com/estuary/flow/go/protocols/flow"
 	"github.com/stretchr/testify/require"
@@ -96,4 +97,25 @@ func TestTimeColumn(t *testing.T) {
 	parsed, err := mapped.Converter("10:09:08.234567Z")
 	require.Equal(t, "10:09:08.234567", parsed)
 	require.NoError(t, err)
+}
+
+func TestBinaryPKColumn(t *testing.T) {
+	var mapped = testDialect.MapType(&sql.Projection{
+		Projection: pf.Projection{
+			IsPrimaryKey: true,
+			Inference: pf.Inference{
+				Types: []string{"string"},
+				String_: &pf.Inference_String{
+					ContentEncoding: "base64",
+				},
+				Exists: pf.Inference_MUST,
+			},
+		},
+	}, sql.FieldConfig{})
+	require.Equal(t, "VARCHAR(256) NOT NULL", mapped.DDL)
+
+	var existing = boilerplate.ExistingField{
+		Type: "VARCHAR",
+	}
+	require.True(t, mapped.Compatible(existing))
 }


### PR DESCRIPTION
**Description:**

The binary type must be compatible with varchar to allow forward matching.  This is because while we create the column as a `varchar(256)` we match only the exact column type without the length.

**Notes for reviewers:**

Several unrelated gofmt changes, but I think its best to make them.

