### PR TITLE
source-jira-native: increase eventual consistency horizon & capture more issue fields

### DIFF
--- a/source-jira-native/source_jira_native/models.py
+++ b/source-jira-native/source_jira_native/models.py
@@ -213,7 +213,7 @@ class ApplicationRoles(FullRefreshArrayedStream):
     path: ClassVar[str] = "applicationrole"
 
 
-class IssueFields(FullRefreshArrayedStream):
+class IssueFields(FullRefreshStream):
     name: ClassVar[str] = "issue_fields"
     path: ClassVar[str] = "field"
     disable: ClassVar[bool] = False

--- a/source-jira-native/source_jira_native/resources.py
+++ b/source-jira-native/source_jira_native/resources.py
@@ -24,6 +24,7 @@ from .models import (
     IssueChildStream,
     IssueCustomFieldContexts,
     IssueCustomFieldOptions,
+    IssueFields,
     JiraAPI,
     JiraResource,
     Labels,
@@ -55,6 +56,7 @@ from .api import (
     snapshot_filter_sharing,
     snapshot_issue_custom_field_contexts,
     snapshot_issue_custom_field_options,
+    snapshot_issue_fields,
     snapshot_labels,
     snapshot_nested_arrayed_resources,
     snapshot_non_paginated_arrayed_resources,
@@ -216,6 +218,13 @@ def _get_partial_snapshot_fn(
     elif issubclass(stream, FilterSharing):
         snapshot_fn = functools.partial(
             snapshot_filter_sharing,
+            http,
+            config.domain,
+            stream,
+        )
+    elif issubclass(stream, IssueFields):
+        snapshot_fn = functools.partial(
+            snapshot_issue_fields,
             http,
             config.domain,
             stream,


### PR DESCRIPTION
**Description:**

This PR's scope includes:
- Increasing the eventual consistency horizon from 2 hours to 12 hours. We've observed the capture has still missed issues with the 2 hour horizon, and increasing the horizon 6x should ensure the Jira API returns consistent results for `issues`.
- Capturing `issue_fields` from both `/field` and `/field/search` endpoints. These endpoints return slightly different sets of fields, and we should query both to get a fuller picture of the fields in a user's Jira account.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

Tested on a local stack. Confirmed more documents are included in the snapshots for `issue_fields`, `issue_custom_field_contexts`, and `issue_custom_field_options`.

