### PR TITLE
source-postgres: include a hidden discover_only_published in endpoint config schema

### DIFF
--- a/source-postgres/.snapshots/TestGeneric-SpecResponse
+++ b/source-postgres/.snapshots/TestGeneric-SpecResponse
@@ -229,6 +229,10 @@
             "type": "string",
             "title": "Feature Flags",
             "description": "This property is intended for Estuary internal use. You should only modify this field as directed by Estuary support."
+          },
+          "discover_only_published": {
+            "type": "boolean",
+            "x-hidden-field": true
           }
         },
         "additionalProperties": false,

--- a/source-postgres/main.go
+++ b/source-postgres/main.go
@@ -171,7 +171,7 @@ type advancedConfig struct {
 	SourceTag             string   `json:"source_tag,omitempty" jsonschema:"title=Source Tag,description=When set the capture will add this value as the property 'tag' in the source metadata of each document."`
 	FeatureFlags          string   `json:"feature_flags,omitempty" jsonschema:"title=Feature Flags,description=This property is intended for Estuary internal use. You should only modify this field as directed by Estuary support."`
 
-	DeprecatedDiscoverOnlyPublished bool `json:"discover_only_published,omitempty" jsonschema:"-"` // Unused, only supported to avoid breaking existing captures
+	DeprecatedDiscoverOnlyPublished bool `json:"discover_only_published,omitempty" jsonschema_extras:"x-hidden-field=true"` // Unused, only supported to avoid breaking existing captures
 }
 
 var featureFlagDefaults = map[string]bool{


### PR DESCRIPTION
**Description:**

Using `jsonschema:"-"` for the deprecated `discover_only_published` field causes it to be omitted from the connector's Spec response, and publications for captures that had `discover_only_published` set prior to its deprecation will fail since additional properties are not allowed in the endpoint config.

This commit changes `discover_only_published` from omitted from the schema via `jsonschema:"-"` to present in the schema but hidden with `jsonschema_extra:"x-hidden-field=true"`. This ensures publications for existing captures that already have `discover_only_published` can succeed.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

