### PR TITLE
materialize-boilerplate: log size of staged files at debug level

### DIFF
--- a/materialize-boilerplate/staged_files.go
+++ b/materialize-boilerplate/staged_files.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/estuary/connectors/go/blob"
 	"github.com/google/uuid"
+	log "github.com/sirupsen/logrus"
 )
 
 // Writer is any streaming writer that can be used to write rows to files.
@@ -222,9 +223,21 @@ func (f *stagedFile) flushFile() error {
 		return nil
 	}
 
+	fileSize := f.writer.Written()
 	if err := f.writer.Close(); err != nil {
 		return fmt.Errorf("closing writer: %w", err)
 	}
+
+	var fileName string
+	if len(f.uploaded) > 0 {
+		fileName = f.uploaded[len(f.uploaded)-1]
+	}
+
+	log.WithFields(log.Fields{
+		"file_size_bytes": fileSize,
+		"file_name":       fileName,
+	}).Debug("flushed staged file")
+
 	f.writer = nil
 
 	return nil


### PR DESCRIPTION
**Description:**

To help debug OOM issue in destinations, it would be helpful to know the size of staged files before destinations attempt to process them. I think adding a debug log in `materialize-boilerplate/staged_files.go` makes sense so we can get this info in the logs, especially since materializations may clean up staged files before exiting and the staged files can't be investigated after the fact.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

