### PR TITLE
materialize-motherduck: reduce max size for store documents

### DIFF
--- a/materialize-motherduck/.snapshots/TestSQLGeneration
+++ b/materialize-motherduck/.snapshots/TestSQLGeneration
@@ -141,7 +141,7 @@ SELECT * EXCLUDE (_flow_delete) FROM read_json(
 	['s3://bucket/file1', 's3://bucket/file2'],
 	format='newline_delimited',
 	compression='gzip',
-	maximum_object_size=1073741824,
+	maximum_object_size=67108864,
 	columns={
 		key1: 'BIGINT NOT NULL',
 		key2: 'BOOLEAN NOT NULL',
@@ -175,7 +175,7 @@ SELECT * EXCLUDE (_flow_delete) FROM read_json(
 	['s3://bucket/file1', 's3://bucket/file2'],
 	format='newline_delimited',
 	compression='gzip',
-	maximum_object_size=1073741824,
+	maximum_object_size=67108864,
 	columns={
 		"theKey": 'VARCHAR NOT NULL',
 		"aValue": 'BIGINT',


### PR DESCRIPTION
**Description:**

The value of `maximum_object_size` indirectly affects how much memory MotherDuck will allocate for parsing JSON.  By bringing this closer to the actual limit we should be avoid some memory issues.

Our messages are limited to 64MiB, and the document must be less than this amount to make space for other fields and grpc encoding.  I expect that the encoded ndjson will be of similar size and also fit within this limit.

**Workflow steps:**

NA

**Documentation links affected:**

NA

**Notes for reviewers:**


