### PR TITLE
source-monday: handle new board_view_locked activity log

### DIFF
--- a/source-monday/source_monday/models.py
+++ b/source-monday/source_monday/models.py
@@ -189,6 +189,7 @@ class ActivityLogEvents(StrEnum):
     BOARD_VIEW_DISABLED = "board_view_disabled"
     BOARD_VIEW_DUPLICATED = "board_view_duplicated"
     BOARD_VIEW_REGENERATE_TOKEN = "board_view_regenerate_token"
+    BOARD_VIEW_LOCKED = "board_view_locked"
     BOARD_WORKSPACE_ID_CHANGED = "board_workspace_id_changed"
     CHANGE_COLUMN_SETTINGS = "change_column_settings"
     CREATE_COLUMN = "create_column"
@@ -288,6 +289,7 @@ class ActivityLog(BaseModel, extra="allow"):
                 | ActivityLogEvents.BOARD_VIEW_DELETED
                 | ActivityLogEvents.BOARD_VIEW_DUPLICATED
                 | ActivityLogEvents.BOARD_VIEW_REGENERATE_TOKEN
+                | ActivityLogEvents.BOARD_VIEW_LOCKED
                 | ActivityLogEvents.BOARD_WORKSPACE_ID_CHANGED
                 | ActivityLogEvents.CHANGE_COLUMN_SETTINGS
                 | ActivityLogEvents.UPDATE_BOARD_NICKNAME


### PR DESCRIPTION
**Description:**

Handles a new activity log never seen before: `board_view_locked`. This is a board level event that will require all board items to be synced again. Added to board level case statement.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

