### PR TITLE
filesink: include HTTP level timeout for S3Stores

### DIFF
--- a/filesink/store.go
+++ b/filesink/store.go
@@ -12,6 +12,7 @@ import (
 
 	storage "cloud.google.com/go/storage"
 	"github.com/aws/aws-sdk-go-v2/aws"
+	awsHttp "github.com/aws/aws-sdk-go-v2/aws/transport/http"
 	awsConfig "github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/feature/s3/manager"
@@ -158,6 +159,7 @@ func NewS3Store(ctx context.Context, cfg S3StoreConfig) (*S3Store, error) {
 	opts := []func(*awsConfig.LoadOptions) error{
 		awsConfig.WithCredentialsProvider(credProvider),
 		awsConfig.WithRegion(cfg.Region),
+		awsConfig.WithHTTPClient(awsHttp.NewBuildableClient().WithTimeout(uploadTimeout)),
 	}
 
 	if cfg.Endpoint != "" {


### PR DESCRIPTION
**Description:**

~~The timeout rolled out in https://github.com/estuary/connectors/pull/3501 didn't prevent a `materialize-s3-iceberg` materialization from hanging for more than 30 minutes.~~

~~After investigating the Go HTTP client implementation, I now think the issue is that when `http.Client.Timeout = 0` (the AWS SDK default), Go's HTTP client disables all timeout handling, including context timeouts.~~

~~Specifically, the `setRequestCancel` function in Go's `net/http/client.go` [returns early](https://github.com/golang/go/blob/8c41a482f9b7a101404cd0b417ac45abd441e598/src/net/http/client.go#L357-L359) when `Client.Timeout` is zero, bypassing the creation of any deadline context that would enforce the timeout. This means `context.WithTimeout` calls are effectively ignored during HTTP requests.~~

~~The AWS SDK's `BuildableClient` defaults to `clientTimeout = 0`, which translates to `http.Client.Timeout = 0`, disabling timeout enforcement. This allowed the S3 upload to hang indefinitely in `materialize-s3-iceberg`.~~

~~Setting an explicit non-zero timeout on the HTTP client should allow context cancellation to work properly, and having a non-zero timeout seems like a good decision too.~~

Edit: per the example Daniel posted below, the default HTTP client timeout most likely isn't the issue causing `materialize-s3-iceberg` to occasionally hang. On the slim off chance that it is, I'd like to merge this change, then get a stack trace to prove where the materialization is getting stuck when it likely hangs again.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

