### PR TITLE
materialize-iceberg: add pagination for list tables

### DIFF
--- a/materialize-iceberg/catalog/catalog.go
+++ b/materialize-iceberg/catalog/catalog.go
@@ -280,7 +280,7 @@ func (c *Catalog) ListNamespaces(ctx context.Context) ([]string, error) {
 			params = append(params, []string{"pageToken", pageToken})
 		}
 
-		res, err := doGet[resp](ctx, c, "/namespaces")
+		res, err := doGet[resp](ctx, c, "/namespaces", params)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
**Description:**

AWS glue appears to have a maximum size of 100 tables per response.  This adds pagination over additional pages so that we retrieve the full list of tables.  I have also added pagination for namespaces, though this is harder to test since we don't have any instances with so many namespaces.

**Workflow steps:**

None

**Documentation links affected:**

None

**Notes for reviewers:**

~~Should probably circle back and do this for ListNamespaces as well.~~

