### PR TITLE
source-dynamodb: add IAM role support

### DIFF
--- a/source-dynamodb/.snapshots/TestSpec
+++ b/source-dynamodb/.snapshots/TestSpec
@@ -3,24 +3,84 @@
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$id": "https://github.com/estuary/connectors/source-dynamodb/config",
     "properties": {
-      "awsAccessKeyId": {
-        "type": "string",
-        "title": "Access Key ID",
-        "description": "AWS Access Key ID for capturing from the DynamoDB table.",
-        "order": 1
-      },
-      "awsSecretAccessKey": {
-        "type": "string",
-        "title": "Secret Access Key",
-        "description": "AWS Secret Access Key for capturing from the DynamoDB table.",
-        "order": 2,
-        "secret": true
-      },
       "region": {
         "type": "string",
         "title": "Region",
         "description": "Region of the DynamoDB table.",
-        "order": 3
+        "order": 1
+      },
+      "credentials": {
+        "oneOf": [
+          {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$id": "https://github.com/estuary/connectors/source-dynamodb/access-key-credentials",
+            "properties": {
+              "auth_type": {
+                "type": "string",
+                "const": "AWSAccessKey",
+                "default": "AWSAccessKey",
+                "order": 0
+              },
+              "aws_access_key_id": {
+                "type": "string",
+                "title": "AWS Access Key ID",
+                "description": "AWS Access Key ID for capturing from the DynamoDB table.",
+                "order": 1
+              },
+              "aws_secret_access_key": {
+                "type": "string",
+                "title": "AWS Secret Access key",
+                "description": "AWS Access Key ID for capturing from the DynamoDB table.",
+                "order": 2,
+                "secret": true
+              }
+            },
+            "type": "object",
+            "required": [
+              "aws_access_key_id",
+              "aws_secret_access_key"
+            ],
+            "title": "Access Key"
+          },
+          {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$id": "https://github.com/estuary/connectors/go/auth/iam/aws-config",
+            "properties": {
+              "auth_type": {
+                "type": "string",
+                "const": "AWSIAM",
+                "default": "AWSIAM",
+                "order": 0
+              },
+              "aws_region": {
+                "type": "string",
+                "title": "AWS Region",
+                "description": "AWS Region of your resource"
+              },
+              "aws_role_arn": {
+                "type": "string",
+                "title": "AWS Role ARN",
+                "description": "AWS Role which has access to the resource which will be assumed by Flow"
+              }
+            },
+            "type": "object",
+            "required": [
+              "aws_region",
+              "aws_role_arn"
+            ],
+            "title": "AWS IAM"
+          }
+        ],
+        "type": "object",
+        "title": "Authentication",
+        "default": {
+          "auth_type": "AWSAccessKey"
+        },
+        "discriminator": {
+          "propertyName": "auth_type"
+        },
+        "order": 2,
+        "x-iam-auth": true
       },
       "advanced": {
         "properties": {
@@ -48,9 +108,8 @@
     },
     "type": "object",
     "required": [
-      "awsAccessKeyId",
-      "awsSecretAccessKey",
-      "region"
+      "region",
+      "credentials"
     ],
     "title": "Source DynamoDB Spec"
   },

--- a/source-dynamodb/main.go
+++ b/source-dynamodb/main.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"context"
+	"encoding/json"
+	"errors"
 	"fmt"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -11,13 +13,85 @@ import (
 	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodbstreams"
+	"github.com/estuary/connectors/go/auth/iam"
+	schemagen "github.com/estuary/connectors/go/schema-gen"
 	boilerplate "github.com/estuary/connectors/source-boilerplate"
+	"github.com/invopop/jsonschema"
 )
 
+type AuthType string
+
+const (
+	AWSAccessKey AuthType = "AWSAccessKey"
+	AWSIAM       AuthType = "AWSIAM"
+)
+
+type CredentialsConfig struct {
+	AuthType AuthType `json:"auth_type"`
+
+	AccessKeyCredentials
+	iam.IAMConfig
+}
+
+func (CredentialsConfig) JSONSchema() *jsonschema.Schema {
+	subSchemas := []schemagen.OneOfSubSchemaT{
+		schemagen.OneOfSubSchema("Access Key", AccessKeyCredentials{}, string(AWSAccessKey)),
+	}
+	subSchemas = append(subSchemas,
+		schemagen.OneOfSubSchema("AWS IAM", iam.AWSConfig{}, string(AWSIAM)))
+
+	return schemagen.OneOfSchema("Authentication", "", "auth_type", string(AWSAccessKey), subSchemas...)
+}
+
+func (c *CredentialsConfig) Validate() error {
+	switch c.AuthType {
+	case AWSAccessKey:
+		if c.AWSAccessKeyID == "" {
+			return errors.New("missing 'aws_access_key_id'")
+		}
+		if c.AWSSecretAccessKey == "" {
+			return errors.New("missing 'aws_secret_access_key'")
+		}
+		return nil
+	case AWSIAM:
+		if err := c.ValidateIAM(); err != nil {
+			return err
+		}
+		return nil
+	}
+	return fmt.Errorf("unknown 'auth_type'")
+}
+
+// Since the AccessKeyCredentials and IAMConfig have conflicting JSON field names, only parse
+// the embedded struct of interest.
+func (c *CredentialsConfig) UnmarshalJSON(data []byte) error {
+	var discriminator struct {
+		AuthType AuthType `json:"auth_type"`
+	}
+	if err := json.Unmarshal(data, &discriminator); err != nil {
+		return err
+	}
+	c.AuthType = discriminator.AuthType
+
+	switch c.AuthType {
+	case AWSAccessKey:
+		return json.Unmarshal(data, &c.AccessKeyCredentials)
+	case AWSIAM:
+		return json.Unmarshal(data, &c.IAMConfig)
+	}
+	return fmt.Errorf("unexpected auth_type: %s", c.AuthType)
+}
+
+type AccessKeyCredentials struct {
+	AWSAccessKeyID     string `json:"aws_access_key_id" jsonschema:"title=AWS Access Key ID,description=AWS Access Key ID for capturing from the DynamoDB table." jsonschema_extras:"order=1"`
+	AWSSecretAccessKey string `json:"aws_secret_access_key" jsonschema:"title=AWS Secret Access key,description=AWS Access Key ID for capturing from the DynamoDB table." jsonschema_extras:"secret=true,order=2"`
+}
+
 type config struct {
-	AWSAccessKeyID     string `json:"awsAccessKeyId" jsonschema:"title=Access Key ID,description=AWS Access Key ID for capturing from the DynamoDB table." jsonschema_extras:"order=1"`
-	AWSSecretAccessKey string `json:"awsSecretAccessKey" jsonschema:"title=Secret Access Key,description=AWS Secret Access Key for capturing from the DynamoDB table." jsonschema_extras:"secret=true,order=2"`
-	Region             string `json:"region" jsonschema:"title=Region,description=Region of the DynamoDB table." jsonschema_extras:"order=3"`
+	AWSAccessKeyID     string             `json:"awsAccessKeyId" jsonschema:"-"`
+	AWSSecretAccessKey string             `json:"awsSecretAccessKey" jsonschema:"-" jsonschema_extras:"secret=true"`
+	Region             string             `json:"region" jsonschema:"title=Region,description=Region of the DynamoDB table." jsonschema_extras:"order=1"`
+	Credentials        *CredentialsConfig `json:"credentials" jsonschema:"title=Authentication" jsonschema_extras:"x-iam-auth=true,order=2"`
 
 	Advanced advancedConfig `json:"advanced,omitempty" jsonschema:"title=Advanced Options,description=Options for advanced users. You should not typically need to modify these." jsonschema_extra:"advanced=true"`
 }
@@ -30,14 +104,23 @@ type advancedConfig struct {
 
 func (c *config) Validate() error {
 	var requiredProperties = [][]string{
-		{"awsAccessKeyId", c.AWSAccessKeyID},
-		{"awsSecretAccessKey", c.AWSSecretAccessKey},
 		{"region", c.Region},
 	}
 	for _, req := range requiredProperties {
 		if req[1] == "" {
 			return fmt.Errorf("missing '%s'", req[0])
 		}
+	}
+
+	if c.Credentials == nil {
+		if c.AWSAccessKeyID == "" {
+			return errors.New("missing 'awsAccessKeyId'")
+		}
+		if c.AWSSecretAccessKey == "" {
+			return errors.New("missing 'awsSecretAccessKey'")
+		}
+	} else if err := c.Credentials.Validate(); err != nil {
+		return err
 	}
 
 	if c.Advanced.BackfillSegments < 0 {
@@ -48,6 +131,21 @@ func (c *config) Validate() error {
 	}
 
 	return nil
+}
+
+func (c *config) CredentialsProvider(ctx context.Context) (aws.CredentialsProvider, error) {
+	if c.Credentials == nil {
+		return credentials.NewStaticCredentialsProvider(c.AWSAccessKeyID, c.AWSSecretAccessKey, ""), nil
+	}
+
+	switch c.Credentials.AuthType {
+	case AWSAccessKey:
+		return credentials.NewStaticCredentialsProvider(
+			c.Credentials.AWSAccessKeyID, c.Credentials.AWSSecretAccessKey, ""), nil
+	case AWSIAM:
+		return c.Credentials.IAMTokens.AWSCredentialsProvider()
+	}
+	return nil, errors.New("unknown 'auth_type'")
 }
 
 type resource struct {
@@ -73,10 +171,13 @@ func (r *resource) Validate() error {
 }
 
 func (c *config) toClient(ctx context.Context) (*client, error) {
+	credProvider, err := c.CredentialsProvider(ctx)
+	if err != nil {
+		return nil, err
+	}
+
 	opts := []func(*awsConfig.LoadOptions) error{
-		awsConfig.WithCredentialsProvider(
-			credentials.NewStaticCredentialsProvider(c.AWSAccessKeyID, c.AWSSecretAccessKey, ""),
-		),
+		awsConfig.WithCredentialsProvider(credProvider),
 		awsConfig.WithRegion(c.Region),
 		awsConfig.WithRetryer(func() aws.Retryer {
 			// Bump up the number of retry maximum attempts from the default of 3. The maximum retry


### PR DESCRIPTION
**Description:**

Add support for authentication using a IAM role.

**Workflow steps:**

User can enter the access key credentials or the IAM credentials.  To use the IAM credentials you must setup an Identity Provider as [documented](https://docs.estuary.dev/guides/iam-auth/aws/)

**Documentation links affected:**

Documentation changes: https://github.com/estuary/flow/pull/2516

**Notes for reviewers:**

related: https://github.com/estuary/connectors/issues/3432

