### PR TITLE
source-monday: decrease request limits

### DIFF
--- a/source-monday/source_monday/api.py
+++ b/source-monday/source_monday/api.py
@@ -31,7 +31,7 @@ DEFAULT_BOARDS_PAGE_SIZE = 100
 # This is the number of boards we will fetch items for in a single fetch_page call.
 # However, the underlying GraphQL query will fetch items in smaller batches to balance
 # complexity and other API limitations.
-BOARDS_PER_ITEMS_PAGE = 25
+BOARDS_PER_ITEMS_PAGE = 15
 # Monday may be eventual consistency based on observed delays around 5-30 seconds seen in API responses
 # following batch updates. This is an estimated delay that hopefully covers the possible delay in updates.
 INCREMENTAL_SYNC_DELAY = timedelta(minutes=5)

--- a/source-monday/source_monday/graphql/items.py
+++ b/source-monday/source_monday/graphql/items.py
@@ -35,10 +35,9 @@ ItemsPageRemainder = GraphQLResponseRemainder[ItemsPageRemainderData]
 # that often, but we still limit it to avoid overwhelming the API even though the maximum concurrent requests
 # to Monday can go higher based on the account's plan.
 MAX_CONCURRENT_ITEM_FETCHES = 5
-# These limits combined use ~1.8 Million API complexity units per request.
-# The max per request is 5 million and 10 million per minute.
-BOARDS_PER_PAGE = 4
-ITEMS_PER_BOARD = 20
+# The max complexity budget per request is 5 million and 10 million total per minute.
+BOARDS_PER_PAGE = 2
+ITEMS_PER_BOARD = 10
 ITEMS_LIMIT_BY_ID = 100
 
 


### PR DESCRIPTION
**Description:**

Decreases request limits to see if this helps a customer's capture with API timeout errors. I am unable to test this with a test account with the same size data and other limitations/factors.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

