### PR TITLE
source-hubspot-native: expand `MISSING_SCOPE_REGEX`

### DIFF
--- a/source-hubspot-native/source_hubspot_native/resources.py
+++ b/source-hubspot-native/source_hubspot_native/resources.py
@@ -89,7 +89,8 @@ from .models import (
 
 MISSING_SCOPE_REGEX = (
     r"This app hasn't been granted all required scopes to make this call.|"
-    r"auth request is missing required '.+' scope"
+    r"auth request is missing required '.+' scope|"
+    r"does not have proper permissions"
 )
 
 


### PR DESCRIPTION
**Description:**

Depending on the authentication method used in a request, Hubspot may return a `403` error with an error message like `This oauth-token (some token details) does not have proper permissions!`. The current `MISSING_SCOPE_REGEX` doesn't match against that string, but it should.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

Tested on a local stack. Confirmed a failing discovery now succeeds since the connector now recognizes that error messages containing `does not have proper permissions` does indeed mean that the connector does not have proper permissions for that endpoint. 🫠 

