### PR TITLE
source-monday: decrease request limits futher

### DIFF
--- a/source-monday/source_monday/api.py
+++ b/source-monday/source_monday/api.py
@@ -31,7 +31,7 @@ DEFAULT_BOARDS_PAGE_SIZE = 100
 # This is the number of boards we will fetch items for in a single fetch_page call.
 # However, the underlying GraphQL query will fetch items in smaller batches to balance
 # complexity and other API limitations.
-BOARDS_PER_ITEMS_PAGE = 15
+BOARDS_PER_ITEMS_PAGE = 10
 # Monday may be eventual consistency based on observed delays around 5-30 seconds seen in API responses
 # following batch updates. This is an estimated delay that hopefully covers the possible delay in updates.
 INCREMENTAL_SYNC_DELAY = timedelta(minutes=5)

--- a/source-monday/source_monday/graphql/items.py
+++ b/source-monday/source_monday/graphql/items.py
@@ -36,8 +36,8 @@ ItemsPageRemainder = GraphQLResponseRemainder[ItemsPageRemainderData]
 # to Monday can go higher based on the account's plan.
 MAX_CONCURRENT_ITEM_FETCHES = 5
 # The max complexity budget per request is 5 million and 10 million total per minute.
-BOARDS_PER_PAGE = 2
-ITEMS_PER_BOARD = 10
+BOARDS_PER_PAGE = 1
+ITEMS_PER_BOARD = 5
 ITEMS_LIMIT_BY_ID = 100
 
 


### PR DESCRIPTION
**Description:**

Experiment with even more of a decrease in request load. The user's capture is still struggling and this is the final experiment to see if this helps. Otherwise, there is an API or other issue not related to the connector from what I can tell.

NOTE: If this works, I will roll back the last two commits and try to use a dynamic approach instead as mentioned in #3521 

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

