### PR TITLE
materialize-s3-iceberg: remove suspicious logs

### DIFF
--- a/materialize-s3-iceberg/transactor.go
+++ b/materialize-s3-iceberg/transactor.go
@@ -151,17 +151,10 @@ func (t *transactor) Store(it *m.StoreIterator) (m.StartCommitFunc, error) {
 		states[b.stateKey].FileKeys = append(states[b.stateKey].FileKeys, s3Path)
 
 		group.Go(func() error {
-			ll := log.WithFields(log.Fields{
-				"path":  s3Path,
-				"table": pathToFQN(b.path),
-			})
-
-			ll.Info("started uploading file")
 			if err := t.store.PutStream(ctx, r, key); err != nil {
 				r.CloseWithError(err)
 				return fmt.Errorf("uploading file: %w", err)
 			}
-			ll.Info("finished uploading file")
 
 			return nil
 		})


### PR DESCRIPTION
**Description:**

We've observed a `materialize-s3-iceberg` task hang on the "started uploading file" log a few times and have not been able to pinpoint what the root cause is for the deadlock.

As an experiment, we want to try removing the logs & see if the deadlock still occurs.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

