### PR TITLE
materialize-elasticsearch: allow manual index mapping

### DIFF
--- a/materialize-boilerplate/info_schema.go
+++ b/materialize-boilerplate/info_schema.go
@@ -17,6 +17,7 @@ type ExistingField struct {
 	Type               string
 	CharacterMaxLength int
 	HasDefault         bool
+	Format             string
 }
 
 // Existing resource contains information about a materialized resource in an

--- a/materialize-elasticsearch/client.go
+++ b/materialize-elasticsearch/client.go
@@ -140,6 +140,7 @@ func (c *client) populateInfoSchema(ctx context.Context, is *boilerplate.InfoSch
 				Nullable:           true,
 				Type:               string(prop.Type),
 				CharacterMaxLength: 0,
+				Format:             prop.Format,
 			})
 		}
 	}


### PR DESCRIPTION
**Description:**

Users can now specify the type and format for any mapping, similar to how it is allowed for the sql materializations.  Only types that we currently support can be set.  The format parameter can be used with date fields to allow different formats, such as a long that represents a unix timestamp.

The method can be used to replicate the current keyword: true option by setting the type to keyword.  I plan to de-emphasize that method in the documentation.

It would be nice to allow materializations to have their own ExistingResource type so that they don't all need to share, in particular, the ExistingField struct.  This would be a good follow-up change.

**Workflow steps:**

User must set the mapping in the field configuration, check doc link.

**Documentation links affected:**

https://github.com/estuary/flow/pull/2520

**Notes for reviewers:**

(anything that might help someone review this PR)

