### PR TITLE
materialize-databricks: support M2M OAuth

### DIFF
--- a/materialize-databricks/.snapshots/TestSpecification
+++ b/materialize-databricks/.snapshots/TestSpecification
@@ -56,6 +56,33 @@
               "personal_access_token"
             ],
             "title": "Personal Access Token"
+          },
+          {
+            "properties": {
+              "auth_type": {
+                "type": "string",
+                "const": "OAuth2 M2M",
+                "default": "OAuth2 M2M"
+              },
+              "client_id": {
+                "type": "string",
+                "title": "Client ID",
+                "description": "The OAuth2 client ID for your Databricks service principal",
+                "secret": true
+              },
+              "client_secret": {
+                "type": "string",
+                "title": "Client Secret",
+                "description": "The OAuth2 client secret for your Databricks service principal",
+                "secret": true
+              }
+            },
+            "required": [
+              "auth_type",
+              "client_id",
+              "client_secret"
+            ],
+            "title": "OAuth2 M2M"
           }
         ],
         "type": "object",

--- a/materialize-databricks/config_test.go
+++ b/materialize-databricks/config_test.go
@@ -50,6 +50,30 @@ func TestDatabricksConfig(t *testing.T) {
 	var noSchema = validConfig
 	noSchema.SchemaName = ""
 	require.Error(t, noSchema.Validate(), "expected validation error")
+
+	// OAuth2 M2M tests
+	var validOAuthConfig = config{
+		Address:     "db-something.cloud.databricks.com:400",
+		CatalogName: "mycatalog",
+		HTTPPath:    "/sql/1.0/warehouses/someid",
+		Credentials: credentialConfig{
+			AuthType:     "OAuth2 M2M",
+			ClientID:     "my-client-id",
+			ClientSecret: "my-client-secret",
+		},
+		SchemaName: "default",
+	}
+	require.NoError(t, validOAuthConfig.Validate())
+	var oauthUri = validOAuthConfig.ToURI()
+	require.Equal(t, "db-something.cloud.databricks.com:400/sql/1.0/warehouses/someid?authType=OauthM2M&catalog=mycatalog&clientID=my-client-id&clientSecret=my-client-secret&schema=default&userAgentEntry=Estuary+Technologies+Flow", oauthUri)
+
+	var noClientID = validOAuthConfig
+	noClientID.Credentials.ClientID = ""
+	require.Error(t, noClientID.Validate(), "expected validation error for missing client_id")
+
+	var noClientSecret = validOAuthConfig
+	noClientSecret.Credentials.ClientSecret = ""
+	require.Error(t, noClientSecret.Validate(), "expected validation error for missing client_secret")
 }
 
 func TestSpecification(t *testing.T) {


### PR DESCRIPTION
**Description:**

- Support Databricks M2M authentication

Tested locally by temporarily updating integration tests to use M2M authentication and I can see it works as usual 👍🏽

There is an additional "token fetched successfully" log in the connector when using m2M which comes from the databricks sql driver. I'm going to see if I can get a pull-request upstream to make that a DEBUG log instead of INFO as it is quite spammy.

P.S. CI tests are failing because Databricks has disabled our account for now, we are trying to restore access, but I ran the tests locally with my own account and it works

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

