### PR TITLE
source-facebook-marketing-native: ensure action breakdowns field validator can handle none value

### DIFF
--- a/source-facebook-marketing-native/source_facebook_marketing_native/models.py
+++ b/source-facebook-marketing-native/source_facebook_marketing_native/models.py
@@ -340,7 +340,10 @@ class InsightsConfig(CommonConfigMixin):
 
     @field_validator("action_breakdowns")
     @classmethod
-    def validate_action_breakdowns(cls, v: str) -> str:
+    def validate_action_breakdowns(cls, v: str | None) -> str | None:
+        if v is None:
+            return v
+
         fields = str_to_list(v)
         invalid = [ab for ab in fields if ab not in AD_INSIGHTS_VALID_ACTION_BREAKDOWNS]
         if invalid:


### PR DESCRIPTION
**Description:**

This pull request updates the `validate_action_breakdowns` method in `source_facebook_marketing_native/models.py` to handle `None` values. The main change allows the method to accept and return `None`, preventing errors when the input is `None` and fed into `str_to_list` utility.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

Tested on a local stack during `Airbyte` -> `Native` migration process.

