### PR TITLE
source-facebook-marketing-native: Remove `failed_delivery_checks` field from `ad_account` stream

### DIFF
--- a/source-facebook-marketing-native/source_facebook_marketing_native/models.py
+++ b/source-facebook-marketing-native/source_facebook_marketing_native/models.py
@@ -680,7 +680,7 @@ InsightsFetchChangesFn = Callable[
 class AdAccount(FacebookResource):
     name: ClassVar[str] = ResourceName.AD_ACCOUNT
     primary_keys: ClassVar[list[str]] = ["/id"]
-    endpoint: ClassVar[str] = "/"
+    endpoint: ClassVar[str] = ""
     fields: ClassVar[list[str]] = [
         F.ID,
         F.ACCOUNT_ID,
@@ -704,7 +704,6 @@ class AdAccount(FacebookResource):
         F.END_ADVERTISER,
         F.END_ADVERTISER_NAME,
         F.EXTENDED_CREDIT_INVOICE_GROUP,
-        F.FAILED_DELIVERY_CHECKS,
         F.FB_ENTITY,
         F.FUNDING_SOURCE,
         F.FUNDING_SOURCE_DETAILS,


### PR DESCRIPTION
**Description:**

This field was causing HTTP `500` responses and it was not clear why. Removing this until the field is needed or we can figure out the root cause. Regardless of how the field was requested in the `ad_account` request (by itself or with other fields) produced this error and FB's API response was empty other than the HTTP status.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

