### PR TITLE
source-facebook-marketing-native: Add feature flag support for sourced schemas

### DIFF
--- a/source-facebook-marketing-native/source_facebook_marketing_native/constants.py
+++ b/source-facebook-marketing-native/source_facebook_marketing_native/constants.py
@@ -1,2 +1,131 @@
+from typing import Any
+
 API_VERSION = "v23.0"
 BASE_URL = f"https://graph.facebook.com/{API_VERSION}"
+
+
+# Sourced schema for AdAccount - matches source-facebook-marketing/schemas/ad_account.json
+AD_ACCOUNT_SOURCED_SCHEMA = {
+    "type": "object",
+    "additionalProperties": False,
+    "properties": {
+        "account_id": {"type": "string"},
+        "amount_spent": {"type": "string"},
+        "balance": {"type": "string"},
+        "business_zip": {"type": "string"},
+        "business": {
+            "type": "object",
+            "additionalProperties": False,
+            "properties": {
+                "id": {"type": "string"},
+            },
+        },
+        "disable_reason": {"type": "number"},
+        "end_advertiser": {"type": "number"},
+        "fb_entity": {"type": "number"},
+        "funding_source": {"type": "number"},
+        "id": {"type": "string"},
+        "is_personal": {"type": "number"},
+        "min_campaign_group_spend_cap": {"type": "number"},
+        "min_daily_budget": {"type": "number"},
+        "owner": {"type": "number"},
+        "spend_cap": {"type": "string"},
+        "tax_id_status": {"type": "number"},
+        "tax_id_type": {"type": "string"},
+        "timezone_id": {"type": "number"},
+        "timezone_offset_hours_utc": {"type": "number"},
+    },
+    "required": ["id"],
+}
+
+
+# Sourced schema for AdCreative - matches source-facebook-marketing/schemas/ad_creatives.json
+AD_CREATIVE_SOURCED_SCHEMA = {
+    "type": "object",
+    "additionalProperties": False,
+    "properties": {
+        "account_id": {"type": "string"},
+        "actor_id": {"type": "string"},
+        "asset_feed_spec": {
+            "type": "object",
+            "additionalProperties": False,
+            "properties": {
+                "optimization_type": {
+                    "oneOf": [
+                        {
+                            "type": "array",
+                            "items": {"type": "string"},
+                        },
+                        {
+                            "type": "string",
+                        },
+                    ]
+                },
+            },
+        },
+        "id": {"type": "string"},
+        "object_id": {"type": "string"},
+        "object_story_spec": {
+            "type": "object",
+            "additionalProperties": False,
+            "properties": {
+                "page_id": {"type": "string"},
+                "link_data": {
+                    "type": "object",
+                    "additionalProperties": False,
+                    "properties": {
+                        "call_to_action": {
+                            "type": "object",
+                            "additionalProperties": False,
+                            "properties": {
+                                "value": {
+                                    "type": "object",
+                                    "additionalProperties": False,
+                                    "properties": {
+                                        "application": {"type": "string"},
+                                    },
+                                },
+                            },
+                        },
+                    },
+                },
+                "video_data": {
+                    "type": "object",
+                    "additionalProperties": False,
+                    "properties": {
+                        "call_to_action": {
+                            "type": "object",
+                            "additionalProperties": False,
+                            "properties": {
+                                "value": {
+                                    "type": "object",
+                                    "additionalProperties": False,
+                                    "properties": {
+                                        "application": {"type": "string"},
+                                    },
+                                },
+                            },
+                        },
+                        "video_id": {"type": "string"},
+                    },
+                },
+            },
+        },
+        "product_set_id": {"type": "string"},
+        "template_url_spec": {
+            "type": "object",
+            "additionalProperties": False,
+            "properties": {
+                "config": {
+                    "type": "object",
+                    "additionalProperties": False,
+                    "properties": {
+                        "app_id": {"type": "string"},
+                    },
+                },
+            },
+        },
+        "video_id": {"type": "string"},
+    },
+    "required": ["id"],
+}

--- a/source-facebook-marketing-native/tests/snapshots/snapshots__spec__capture.stdout.json
+++ b/source-facebook-marketing-native/tests/snapshots/snapshots__spec__capture.stdout.json
@@ -16,6 +16,12 @@
               "description": "Set to active if you want to fetch the thumbnail_url and store the result in thumbnail_data_url for each Ad Creative.",
               "title": "Fetch Thumbnail Images from Ad Creative",
               "type": "boolean"
+            },
+            "feature_flags": {
+              "default": "",
+              "description": "Comma-separated list of experimental feature flags to enable.",
+              "title": "Feature Flags",
+              "type": "string"
             }
           },
           "title": "Advanced",


### PR DESCRIPTION
**Description:**

Adds feature flag support for emitting sourced schemas in Facebook marketing connector.

- Introduced a new FeatureFlag enum to manage feature flags.
- Added a feature_flags field to the EndpointConfig model for experimental flags.
- Implemented has_feature_flag method to check if a specific feature flag is enabled.
- Updated AdAccount and AdCreative models to include a sourced_schema class method for legacy connector format.
- Modified full_refresh_resource and full_refresh_resources functions to utilize sourced schemas based on feature flag.
- Updated tests to reflect changes in the configuration and feature flags.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

