### PR TITLE
source-facebook-marketing-native: update reverse incremental semantics

### DIFF
--- a/source-facebook-marketing-native/source_facebook_marketing_native/api.py
+++ b/source-facebook-marketing-native/source_facebook_marketing_native/api.py
@@ -302,7 +302,7 @@ async def fetch_changes_reverse_order(
                 )
 
                 # Since data is in DESC order, stop when we reach items older than cursor
-                if doc_cursor < log_cursor:
+                if doc_cursor <= log_cursor:
                     break
 
                 has_results = True


### PR DESCRIPTION
**Description:**

This pull request makes a minor adjustment to the logic for fetching changes in reverse order. The comparison condition for stopping the data fetch has been updated to be inclusive, ensuring that items with a cursor equal to the log cursor are also considered as the stopping point / ignored.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

