### PR TITLE
materialize-s3-iceberg: add name mapping property on table creation

### DIFF
--- a/materialize-s3-iceberg/iceberg-ctl/iceberg_ctl/__main__.py
+++ b/materialize-s3-iceberg/iceberg-ctl/iceberg_ctl/__main__.py
@@ -10,6 +10,7 @@ from click import Context
 from iceberg_ctl.models import EndpointConfig, GlueCatalogConfig, RestCatalogConfig
 from pydantic import BaseModel, TypeAdapter
 from pyiceberg.catalog import Catalog
+from pyiceberg.table import TableProperties
 from pyiceberg.catalog.glue import GlueCatalog
 from pyiceberg.catalog.rest import RestCatalog
 from pyiceberg.io import PY_IO_IMPL
@@ -246,7 +247,12 @@ def create_table(
         for idx, f in enumerate(table_create.fields)
     ]
 
-    catalog.create_table(table, Schema(*columns), table_create.location)
+    schema = Schema(*columns)
+    catalog.create_table(table, schema, table_create.location,
+        properties={
+            TableProperties.DEFAULT_NAME_MAPPING: schema.name_mapping.model_dump_json()
+        },
+    )
     log(f"create_table: created table {table}")
 
 

--- a/materialize-s3-iceberg/transactor.go
+++ b/materialize-s3-iceberg/transactor.go
@@ -253,9 +253,9 @@ func (t *transactor) Acknowledge(ctx context.Context) (*pf.ConnectorState, error
 		}
 
 		ll := log.WithFields(log.Fields{
-			"table":             pathToFQN(b.path),
-			"previousCheckoint": bindingState.PreviousCheckpoint,
-			"currentCheckpoint": bindingState.CurrentCheckpoint,
+			"table":              pathToFQN(b.path),
+			"previousCheckpoint": bindingState.PreviousCheckpoint,
+			"currentCheckpoint":  bindingState.CurrentCheckpoint,
 		})
 
 		ll.Info("starting appendFiles for table")


### PR DESCRIPTION
**Description:**

Previously this property would not be set on table creation, and the name mapping would be added when the first file was added.  It can be useful to have this property set on initial table creation so that it doesn't appear to change.

**Workflow steps:**

This will apply automatically for new tables or if the table is recreated.

**Documentation links affected:**

NA

