### PR TITLE
shopify-native: Add customAttributes to lineItems fetch of orders

### DIFF
--- a/source-shopify-native/source_shopify_native/graphql/orders/orders.py
+++ b/source-shopify-native/source_shopify_native/graphql/orders/orders.py
@@ -281,6 +281,10 @@ class Orders(ShopifyGraphQLResource):
                     id
                     legacyResourceId
                 }
+                customAttributes {
+                    key
+                    value
+                }
             }
         }
     }


### PR DESCRIPTION
**Description:**

`lineItems` of orders can have `customAttributes` (key-value pair). These get fetched now as well.

https://shopify.dev/docs/api/admin-graphql/latest/queries/orders#returns-edges.fields.node.lineItems.edges.node.customAttributes

