### PR TITLE
source-mixpanel-native: fix `export` stream to use attribution window

### DIFF
--- a/source-mixpanel-native/source_mixpanel_native/streams/export.py
+++ b/source-mixpanel-native/source_mixpanel_native/streams/export.py
@@ -225,10 +225,13 @@ class Export(DateSlicesMixin, IncrementalMixpanelStream):
     ) -> MutableMapping[str, Any]:
         params = super().request_params(stream_state, stream_slice, next_page_token)
         # additional filter by timestamp because required start date and end date only allow to filter by date
+        # Only apply this filter when not re-capturing events in the attribution window.
         cursor_param = stream_slice.get(self.cursor_field)
-        if cursor_param:
+        use_attribution_window = stream_slice.get("use_attribution_window")
+        if not use_attribution_window and cursor_param:
             timestamp = int(pendulum.parse(cursor_param).timestamp())
             params["where"] = f'properties["$time"]>=datetime({timestamp})'
+
         return params
 
     def request_kwargs(


### PR DESCRIPTION
**Description:**

The `export` stream was applying a timestamp filter on every incremental sync, which prevented the attribution window from working correctly. Even though the date range was moved back by the attribution window, the timestamp filter would exclude any events older than the last cursor value, causing late-arriving or backdated events to be missed.

Now, the timestamp filter is only applied when the attribution window is not being used. This means updates within the same day are fully incremental and avoid emitting duplicate data, and on the first sweep on a new day all events from previous days are re-captured.

This ensures that events backdated within the attribution window are captured on subsequent syncs once per day.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

Tested on a local stack. Confirmed the attribution window is used for the first sync of each day when the `export` stream is caught up and replicating incrementally.