### PR TITLE
source-shopify-native: Add customAttributes to lineItems for orders

### DIFF
--- a/source-shopify-native/source_shopify_native/graphql/orders/orders.py
+++ b/source-shopify-native/source_shopify_native/graphql/orders/orders.py
@@ -281,6 +281,10 @@ class Orders(ShopifyGraphQLResource):
                     id
                     legacyResourceId
                 }
+                customAttributes {
+                    key
+                    value
+                }
             }
         }
     }

--- a/source-shopify-native/tests/snapshots/snapshots__capture__capture.stdout.json
+++ b/source-shopify-native/tests/snapshots/snapshots__capture__capture.stdout.json
@@ -596,6 +596,7 @@
         {
           "__parentId": "gid://shopify/Order/5714619858989",
           "currentQuantity": 1,
+          "customAttributes": [],
           "discountAllocations": [],
           "discountedTotalSet": {
             "presentmentMoney": {
@@ -707,6 +708,7 @@
         {
           "__parentId": "gid://shopify/Order/5714619858989",
           "currentQuantity": 1,
+          "customAttributes": [],
           "discountAllocations": [],
           "discountedTotalSet": {
             "presentmentMoney": {


### PR DESCRIPTION
**Description:**

This pull request adds support for retrieving custom attributes on order line items from Shopify, and updates the test snapshots to reflect this new data. The main change is the inclusion of the `customAttributes` field in the GraphQL query for orders, which allows us to access additional metadata associated with each line item.

Reference: https://shopify.dev/docs/api/admin-graphql/latest/queries/orders#returns-edges.fields.node.lineItems.edges.node.customAttributes

Closes: #3543 and adds @manuelgu as a Co-Author.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

