### PR TITLE
source-facebook-marketing-native: Add level-specific fields to insights API requests

### DIFF
--- a/source-facebook-marketing-native/source_facebook_marketing_native/resources.py
+++ b/source-facebook-marketing-native/source_facebook_marketing_native/resources.py
@@ -49,6 +49,7 @@ from .models import (
     Activities,
     Images,
     Videos,
+    BaseAdsInsights,
     AdsInsights,
     AdsInsightsAgeAndGender,
     AdsInsightsCountry,
@@ -430,7 +431,7 @@ def incremental_resources(
         )
 
     def create_insights_resource(model: type[FacebookResource]) -> Resource:
-        assert issubclass(model, AdsInsights), "Model must be a subclass of AdsInsights"
+        assert issubclass(model, BaseAdsInsights), "Model must be a subclass of BaseAdsInsights"
 
         def create_fetch_page(account_id: str) -> Callable:
             return functools.partial(


### PR DESCRIPTION
**Description:**

**Summary**

- Adds full hierarchy fields (`campaign_id`, `campaign_name`, `adset_id`, `adset_name`) to default AdsInsights streams
- Validates custom insights field configurations against Facebook API level restrictions
- Refactors model hierarchy with `BaseAdsInsights` base class for proper multi-level support

**Schema Compatibility**

*This change is purely additive.* No fields were removed from any stream.

| Stream | Fields Before | Fields After | Change |
|--------|---------------|--------------|--------|
| `ads_insights` | 44 fields | 48 fields | +4 fields |
| `ads_insights_age_and_gender` | Inherited | Inherited | +4 fields |
| `ads_insights_country` | Inherited | Inherited | +4 fields |
| `ads_insights_region` | Inherited | Inherited | +4 fields |
| `ads_insights_dma` | Inherited | Inherited | +4 fields |
| `ads_insights_platform_and_device` | Inherited | Inherited | +4 fields |
| `ads_insights_action_type` | Inherited | Inherited | +4 fields |

**New fields added:** `campaign_id`, `campaign_name`, `adset_id`, `adset_name`

**Breaking Changes:** None. Existing schemas, custom insights configurations, and inheritance chains are preserved.

**Files Changed**
- `source_facebook_marketing_native/models.py` - Model hierarchy refactor
- `source_facebook_marketing_native/resources.py` - Updated type assertion

**Issue 1: Missing Level-Specific Fields in API Requests**

*Problem:* The `level_specific_fields()` method was defined but never called. Default insights requests were missing hierarchy fields, and custom insights didn't automatically include required level-specific ID fields.

*Solution:* Automatically include level-specific fields at model creation time:
- Updated default `AdsInsights.fields` to include full hierarchy fields
- Converted `level_specific_fields()` to a classmethod
- Updated `build_custom_ads_insights_model()` to merge level-specific fields with user fields

**Issue 2: Invalid Fields for Configured Level**

*Problem:* Facebook's API hierarchy is **Account → Campaign → Ad Set → Ad**. You can look UP (to parents) but not DOWN (to children). The connector was not validating this.

*Solution:* Added validation in `build_custom_ads_insights_model()`. Invalid fields now raise `ValidationError`:

```
Field 'ad_id' is not available at the 'adset' level. Facebook's API hierarchy is
Account → Campaign → Ad Set → Ad. You can only access fields from your configured
level and its parents (levels above), not from child levels (levels below).
```

**Issue 3: Model Hierarchy Didn't Support All Levels**

*Problem:* The original `AdsInsights` class had hardcoded `ad_id` as required and `level_specific_fields()` crashed for Account level.

*Solution:* Refactored to proper class hierarchy:

| Class | Purpose |
|-------|---------|
| `BaseAdsInsights` | Base class with universal fields (`account_id`, `date_start`) and level logic |
| `AdsInsights` | Concrete AD-level class with `ad_id` required |
| `AdsInsightsAgeAndGender`, etc. | Inherit from `AdsInsights` (all AD level) |
| `build_custom_ads_insights_model()` | Now inherits from `BaseAdsInsights`, dynamically adds level-specific ID |

**Field Availability by Level**

| Level | Required ID Field | Available Parent Fields |
|-------|------------------|------------------------|
| Account | (none) | account_id, account_name |
| Campaign | campaign_id | above + campaign_id, campaign_name |
| Ad Set | adset_id | above + adset_id, adset_name |
| Ad | ad_id | above + ad_id, ad_name |

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

Tested on a local stack and validated that the new fields that we expect to be present are and that various custom insights configurations with different levels work as expected.

