### PR TITLE
source-mixpanel-native: fix `should_use_attribution_window` logic

### DIFF
--- a/source-mixpanel-native/source_mixpanel_native/streams/base.py
+++ b/source-mixpanel-native/source_mixpanel_native/streams/base.py
@@ -215,7 +215,7 @@ class DateSlicesMixin:
         # attribution window once per day when the stream is caught up &
         # replicating incrementally to avoid constantly emitting duplicate
         # data.
-        should_use_attribution_window = today - start_date <= timedelta(days=1)
+        should_use_attribution_window = today - start_date == timedelta(days=1)
 
         if should_use_attribution_window:
             start_date = start_date - timedelta(days=self.attribution_window)


### PR DESCRIPTION
**Description:**

The conditional for `should_use_attribution_window` added in https://github.com/estuary/connectors/pull/3546 should only be true when `today` and `start_date` are exactly one day apart, _not_ when they're the same day. We only want to use the attribution window when syncing at the boundary of a day, not when syncing within the same day.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

