### PR TITLE
s/jsonschema_extra/jsonschema_extras/g

### DIFF
--- a/materialize-azure-blob-parquet/.snapshots/TestSpec
+++ b/materialize-azure-blob-parquet/.snapshots/TestSpec
@@ -78,7 +78,8 @@
         "additionalProperties": false,
         "type": "object",
         "title": "Advanced Options",
-        "description": "Options for advanced users. You should not typically need to modify these."
+        "description": "Options for advanced users. You should not typically need to modify these.",
+        "advanced": true
       }
     },
     "type": "object",

--- a/materialize-azure-blob-parquet/main.go
+++ b/materialize-azure-blob-parquet/main.go
@@ -22,7 +22,7 @@ var featureFlagDefaults = map[string]bool{
 type config struct {
 	filesink.AzureBlobConfig
 	ParquetConfig filesink.ParquetConfig `json:"parquetConfig,omitempty" jsonschema:"title=Parquet Configuration,description=Configuration specific to materializing parquet files."`
-	Advanced      advancedConfig         `json:"advanced,omitempty" jsonschema:"title=Advanced Options,description=Options for advanced users. You should not typically need to modify these." jsonschema_extra:"advanced=true"`
+	Advanced      advancedConfig         `json:"advanced,omitempty" jsonschema:"title=Advanced Options,description=Options for advanced users. You should not typically need to modify these." jsonschema_extras:"advanced=true"`
 }
 
 type advancedConfig struct {

--- a/materialize-azure-fabric-warehouse/.snapshots/TestSpecification
+++ b/materialize-azure-fabric-warehouse/.snapshots/TestSpecification
@@ -190,7 +190,8 @@
         "additionalProperties": false,
         "type": "object",
         "title": "Advanced Options",
-        "description": "Options for advanced users. You should not typically need to modify these."
+        "description": "Options for advanced users. You should not typically need to modify these.",
+        "advanced": true
       }
     },
     "type": "object",

--- a/materialize-azure-fabric-warehouse/driver.go
+++ b/materialize-azure-fabric-warehouse/driver.go
@@ -36,7 +36,7 @@ type config struct {
 	Schedule           m.ScheduleConfig `json:"syncSchedule,omitempty" jsonschema:"title=Sync Schedule,description=Configure schedule of transactions for the materialization."`
 	DBTJobTrigger      dbt.JobConfig    `json:"dbt_job_trigger,omitempty" jsonschema:"title=dbt Cloud Job Trigger,description=Trigger a dbt job when new data is available"`
 
-	Advanced advancedConfig `json:"advanced,omitempty" jsonschema:"title=Advanced Options,description=Options for advanced users. You should not typically need to modify these." jsonschema_extra:"advanced=true"`
+	Advanced advancedConfig `json:"advanced,omitempty" jsonschema:"title=Advanced Options,description=Options for advanced users. You should not typically need to modify these." jsonschema_extras:"advanced=true"`
 }
 
 func (c config) Validate() error {

--- a/materialize-bigquery/.snapshots/TestSpecification
+++ b/materialize-bigquery/.snapshots/TestSpecification
@@ -183,7 +183,8 @@
         "additionalProperties": false,
         "type": "object",
         "title": "Advanced Options",
-        "description": "Options for advanced users. You should not typically need to modify these."
+        "description": "Options for advanced users. You should not typically need to modify these.",
+        "advanced": true
       }
     },
     "type": "object",

--- a/materialize-bigquery/bigquery.go
+++ b/materialize-bigquery/bigquery.go
@@ -36,7 +36,7 @@ type config struct {
 	Schedule         m.ScheduleConfig `json:"syncSchedule,omitempty" jsonschema:"title=Sync Schedule,description=Configure schedule of transactions for the materialization."`
 	DBTJobTrigger    dbt.JobConfig    `json:"dbt_job_trigger,omitempty" jsonschema:"title=dbt Cloud Job Trigger,description=Trigger a dbt job when new data is available"`
 
-	Advanced advancedConfig `json:"advanced,omitempty" jsonschema:"title=Advanced Options,description=Options for advanced users. You should not typically need to modify these." jsonschema_extra:"advanced=true"`
+	Advanced advancedConfig `json:"advanced,omitempty" jsonschema:"title=Advanced Options,description=Options for advanced users. You should not typically need to modify these." jsonschema_extras:"advanced=true"`
 }
 
 type advancedConfig struct {

--- a/materialize-databricks/.snapshots/TestSpecification
+++ b/materialize-databricks/.snapshots/TestSpecification
@@ -219,7 +219,8 @@
         "additionalProperties": false,
         "type": "object",
         "title": "Advanced Options",
-        "description": "Options for advanced users. You should not typically need to modify these."
+        "description": "Options for advanced users. You should not typically need to modify these.",
+        "advanced": true
       }
     },
     "type": "object",

--- a/materialize-databricks/config.go
+++ b/materialize-databricks/config.go
@@ -27,7 +27,7 @@ type config struct {
 	Schedule      m.ScheduleConfig `json:"syncSchedule,omitempty" jsonschema:"title=Sync Schedule,description=Configure schedule of transactions for the materialization."`
 	DBTJobTrigger dbt.JobConfig    `json:"dbt_job_trigger,omitempty" jsonschema:"title=dbt Cloud Job Trigger,description=Trigger a dbt Job when new data is available"`
 
-	Advanced advancedConfig `json:"advanced,omitempty" jsonschema:"title=Advanced Options,description=Options for advanced users. You should not typically need to modify these." jsonschema_extra:"advanced=true"`
+	Advanced advancedConfig `json:"advanced,omitempty" jsonschema:"title=Advanced Options,description=Options for advanced users. You should not typically need to modify these." jsonschema_extras:"advanced=true"`
 }
 
 type advancedConfig struct {

--- a/materialize-dynamodb/.snapshots/TestSpec
+++ b/materialize-dynamodb/.snapshots/TestSpec
@@ -98,7 +98,8 @@
         "additionalProperties": false,
         "type": "object",
         "title": "Advanced Options",
-        "description": "Options for advanced users. You should not typically need to modify these."
+        "description": "Options for advanced users. You should not typically need to modify these.",
+        "advanced": true
       }
     },
     "type": "object",

--- a/materialize-dynamodb/driver.go
+++ b/materialize-dynamodb/driver.go
@@ -101,7 +101,7 @@ type config struct {
 	Region             string             `json:"region" jsonschema:"title=Region,description=Region of the materialized tables." jsonschema_extras:"order=1"`
 	Credentials        *CredentialsConfig `json:"credentials" jsonschema:"title=Authentication" jsonschema_extras:"x-iam-auth=true,order=2"`
 
-	Advanced advancedConfig `json:"advanced,omitempty" jsonschema:"title=Advanced Options,description=Options for advanced users. You should not typically need to modify these." jsonschema_extra:"advanced=true"`
+	Advanced advancedConfig `json:"advanced,omitempty" jsonschema:"title=Advanced Options,description=Options for advanced users. You should not typically need to modify these." jsonschema_extras:"advanced=true"`
 }
 
 type advancedConfig struct {

--- a/materialize-gcs-csv/.snapshots/TestSpec
+++ b/materialize-gcs-csv/.snapshots/TestSpec
@@ -67,7 +67,8 @@
         "additionalProperties": false,
         "type": "object",
         "title": "Advanced Options",
-        "description": "Options for advanced users. You should not typically need to modify these."
+        "description": "Options for advanced users. You should not typically need to modify these.",
+        "advanced": true
       }
     },
     "type": "object",

--- a/materialize-gcs-csv/main.go
+++ b/materialize-gcs-csv/main.go
@@ -19,7 +19,7 @@ var featureFlagDefaults = map[string]bool{
 type config struct {
 	filesink.GCSStoreConfig
 	CsvConfig filesink.CsvConfig `json:"csvConfig,omitempty" jsonschema:"title=CSV Configuration,description=Configuration specific to materializing CSV files."`
-	Advanced  advancedConfig     `json:"advanced,omitempty" jsonschema:"title=Advanced Options,description=Options for advanced users. You should not typically need to modify these." jsonschema_extra:"advanced=true"`
+	Advanced  advancedConfig     `json:"advanced,omitempty" jsonschema:"title=Advanced Options,description=Options for advanced users. You should not typically need to modify these." jsonschema_extras:"advanced=true"`
 }
 
 type advancedConfig struct {

--- a/materialize-gcs-parquet/.snapshots/TestSpec
+++ b/materialize-gcs-parquet/.snapshots/TestSpec
@@ -73,7 +73,8 @@
         "additionalProperties": false,
         "type": "object",
         "title": "Advanced Options",
-        "description": "Options for advanced users. You should not typically need to modify these."
+        "description": "Options for advanced users. You should not typically need to modify these.",
+        "advanced": true
       }
     },
     "type": "object",

--- a/materialize-gcs-parquet/main.go
+++ b/materialize-gcs-parquet/main.go
@@ -22,7 +22,7 @@ var featureFlagDefaults = map[string]bool{
 type config struct {
 	filesink.GCSStoreConfig
 	ParquetConfig filesink.ParquetConfig `json:"parquetConfig,omitempty" jsonschema:"title=Parquet Configuration,description=Configuration specific to materializing parquet files."`
-	Advanced      advancedConfig         `json:"advanced,omitempty" jsonschema:"title=Advanced Options,description=Options for advanced users. You should not typically need to modify these." jsonschema_extra:"advanced=true"`
+	Advanced      advancedConfig         `json:"advanced,omitempty" jsonschema:"title=Advanced Options,description=Options for advanced users. You should not typically need to modify these." jsonschema_extras:"advanced=true"`
 }
 
 type advancedConfig struct {

--- a/materialize-iceberg/.snapshots/TestSpec
+++ b/materialize-iceberg/.snapshots/TestSpec
@@ -403,7 +403,8 @@
         "additionalProperties": false,
         "type": "object",
         "title": "Advanced Options",
-        "description": "Options for advanced users. You should not typically need to modify these."
+        "description": "Options for advanced users. You should not typically need to modify these.",
+        "advanced": true
       }
     },
     "type": "object",

--- a/materialize-iceberg/config.go
+++ b/materialize-iceberg/config.go
@@ -41,7 +41,7 @@ type config struct {
 	Schedule              m.ScheduleConfig      `json:"syncSchedule,omitempty" jsonschema:"title=Sync Schedule,description=Configure schedule of transactions for the materialization."`
 	DBTJobTrigger         dbt.JobConfig         `json:"dbt_job_trigger,omitempty" jsonschema:"title=dbt Cloud Job Trigger,description=Trigger a dbt Job when new data is available"`
 
-	Advanced advancedConfig `json:"advanced,omitempty" jsonschema:"title=Advanced Options,description=Options for advanced users. You should not typically need to modify these." jsonschema_extra:"advanced=true"`
+	Advanced advancedConfig `json:"advanced,omitempty" jsonschema:"title=Advanced Options,description=Options for advanced users. You should not typically need to modify these." jsonschema_extras:"advanced=true"`
 }
 
 type advancedConfig struct {

--- a/materialize-motherduck/.snapshots/TestSpecification
+++ b/materialize-motherduck/.snapshots/TestSpecification
@@ -215,7 +215,8 @@
         "additionalProperties": false,
         "type": "object",
         "title": "Advanced Options",
-        "description": "Options for advanced users. You should not typically need to modify these."
+        "description": "Options for advanced users. You should not typically need to modify these.",
+        "advanced": true
       }
     },
     "type": "object",

--- a/materialize-motherduck/config.go
+++ b/materialize-motherduck/config.go
@@ -30,7 +30,7 @@ type config struct {
 	StagingBucket stagingBucketConfig `json:"stagingBucket" jsonschema_extras:"order=4"`
 	Schedule      m.ScheduleConfig    `json:"syncSchedule,omitempty" jsonschema:"title=Sync Schedule,description=Configure schedule of transactions for the materialization."`
 
-	Advanced advancedConfig `json:"advanced,omitempty" jsonschema:"title=Advanced Options,description=Options for advanced users. You should not typically need to modify these." jsonschema_extra:"advanced=true"`
+	Advanced advancedConfig `json:"advanced,omitempty" jsonschema:"title=Advanced Options,description=Options for advanced users. You should not typically need to modify these." jsonschema_extras:"advanced=true"`
 }
 
 type advancedConfig struct {

--- a/materialize-redshift/.snapshots/TestSpecification
+++ b/materialize-redshift/.snapshots/TestSpecification
@@ -229,7 +229,8 @@
         "additionalProperties": false,
         "type": "object",
         "title": "Advanced Options",
-        "description": "Options for advanced users. You should not typically need to modify these."
+        "description": "Options for advanced users. You should not typically need to modify these.",
+        "advanced": true
       }
     },
     "type": "object",

--- a/materialize-redshift/driver.go
+++ b/materialize-redshift/driver.go
@@ -88,7 +88,7 @@ type config struct {
 	DBTJobTrigger      dbt.JobConfig    `json:"dbt_job_trigger,omitempty" jsonschema:"title=dbt Cloud Job Trigger,description=Trigger a dbt Job when new data is available"`
 	NetworkTunnel      *tunnelConfig    `json:"networkTunnel,omitempty" jsonschema:"title=Network Tunnel,description=Connect to your Redshift cluster through an SSH server that acts as a bastion host for your network."`
 
-	Advanced advancedConfig `json:"advanced,omitempty" jsonschema:"title=Advanced Options,description=Options for advanced users. You should not typically need to modify these." jsonschema_extra:"advanced=true"`
+	Advanced advancedConfig `json:"advanced,omitempty" jsonschema:"title=Advanced Options,description=Options for advanced users. You should not typically need to modify these." jsonschema_extras:"advanced=true"`
 }
 
 func (c config) Validate() error {

--- a/materialize-s3-csv/.snapshots/TestSpec
+++ b/materialize-s3-csv/.snapshots/TestSpec
@@ -144,7 +144,8 @@
         "additionalProperties": false,
         "type": "object",
         "title": "Advanced Options",
-        "description": "Options for advanced users. You should not typically need to modify these."
+        "description": "Options for advanced users. You should not typically need to modify these.",
+        "advanced": true
       }
     },
     "type": "object",

--- a/materialize-s3-csv/main.go
+++ b/materialize-s3-csv/main.go
@@ -19,7 +19,7 @@ var featureFlagDefaults = map[string]bool{
 type config struct {
 	filesink.S3StoreConfig
 	CsvConfig filesink.CsvConfig `json:"csvConfig,omitempty" jsonschema:"title=CSV Configuration,description=Configuration specific to materializing CSV files."`
-	Advanced  advancedConfig     `json:"advanced,omitempty" jsonschema:"title=Advanced Options,description=Options for advanced users. You should not typically need to modify these." jsonschema_extra:"advanced=true"`
+	Advanced  advancedConfig     `json:"advanced,omitempty" jsonschema:"title=Advanced Options,description=Options for advanced users. You should not typically need to modify these." jsonschema_extras:"advanced=true"`
 }
 
 type advancedConfig struct {

--- a/materialize-s3-iceberg/driver.go
+++ b/materialize-s3-iceberg/driver.go
@@ -47,7 +47,7 @@ type config struct {
 	Prefix             string         `json:"prefix,omitempty"`
 	S3Endpoint         string         `json:"s3_endpoint,omitempty"`
 	Catalog            catalogConfig  `json:"catalog"`
-	Advanced           advancedConfig `json:"advanced,omitempty" jsonschema:"title=Advanced Options,description=Options for advanced users. You should not typically need to modify these." jsonschema_extra:"advanced=true"`
+	Advanced           advancedConfig `json:"advanced,omitempty" jsonschema:"title=Advanced Options,description=Options for advanced users. You should not typically need to modify these." jsonschema_extras:"advanced=true"`
 }
 
 type catalogConfig struct {

--- a/materialize-s3-parquet/.snapshots/TestSpec
+++ b/materialize-s3-parquet/.snapshots/TestSpec
@@ -150,7 +150,8 @@
         "additionalProperties": false,
         "type": "object",
         "title": "Advanced Options",
-        "description": "Options for advanced users. You should not typically need to modify these."
+        "description": "Options for advanced users. You should not typically need to modify these.",
+        "advanced": true
       }
     },
     "type": "object",

--- a/materialize-s3-parquet/main.go
+++ b/materialize-s3-parquet/main.go
@@ -22,7 +22,7 @@ var featureFlagDefaults = map[string]bool{
 type config struct {
 	filesink.S3StoreConfig
 	ParquetConfig filesink.ParquetConfig `json:"parquetConfig,omitempty" jsonschema:"title=Parquet Configuration,description=Configuration specific to materializing parquet files."`
-	Advanced      advancedConfig         `json:"advanced,omitempty" jsonschema:"title=Advanced Options,description=Options for advanced users. You should not typically need to modify these." jsonschema_extra:"advanced=true"`
+	Advanced      advancedConfig         `json:"advanced,omitempty" jsonschema:"title=Advanced Options,description=Options for advanced users. You should not typically need to modify these." jsonschema_extras:"advanced=true"`
 }
 
 type advancedConfig struct {

--- a/materialize-snowflake/.snapshots/TestSpecification
+++ b/materialize-snowflake/.snapshots/TestSpecification
@@ -257,7 +257,8 @@
         "additionalProperties": false,
         "type": "object",
         "title": "Advanced Options",
-        "description": "Options for advanced users. You should not typically need to modify these."
+        "description": "Options for advanced users. You should not typically need to modify these.",
+        "advanced": true
       }
     },
     "type": "object",

--- a/materialize-snowflake/config.go
+++ b/materialize-snowflake/config.go
@@ -83,7 +83,7 @@ type config struct {
 	Credentials       *snowflake_auth.CredentialConfig `json:"credentials" jsonschema:"title=Authentication"`
 	Schedule          m.ScheduleConfig                 `json:"syncSchedule,omitempty" jsonschema:"title=Sync Schedule,description=Configure schedule of transactions for the materialization."`
 	DBTJobTrigger     dbt.JobConfig                    `json:"dbt_job_trigger,omitempty" jsonschema:"title=dbt Cloud Job Trigger,description=Trigger a dbt Job when new data is available"`
-	Advanced          advancedConfig                   `json:"advanced,omitempty" jsonschema:"title=Advanced Options,description=Options for advanced users. You should not typically need to modify these." jsonschema_extra:"advanced=true"`
+	Advanced          advancedConfig                   `json:"advanced,omitempty" jsonschema:"title=Advanced Options,description=Options for advanced users. You should not typically need to modify these." jsonschema_extras:"advanced=true"`
 }
 
 type advancedConfig struct {

--- a/materialize-sqlserver/.snapshots/TestSpecification
+++ b/materialize-sqlserver/.snapshots/TestSpecification
@@ -147,7 +147,8 @@
         "additionalProperties": false,
         "type": "object",
         "title": "Advanced Options",
-        "description": "Options for advanced users. You should not typically need to modify these."
+        "description": "Options for advanced users. You should not typically need to modify these.",
+        "advanced": true
       }
     },
     "type": "object",

--- a/materialize-sqlserver/driver.go
+++ b/materialize-sqlserver/driver.go
@@ -54,7 +54,7 @@ type config struct {
 
 	NetworkTunnel *tunnelConfig `json:"networkTunnel,omitempty" jsonschema:"title=Network Tunnel,description=Connect to your system through an SSH server that acts as a bastion host for your network."`
 
-	Advanced advancedConfig `json:"advanced,omitempty" jsonschema:"title=Advanced Options,description=Options for advanced users. You should not typically need to modify these." jsonschema_extra:"advanced=true"`
+	Advanced advancedConfig `json:"advanced,omitempty" jsonschema:"title=Advanced Options,description=Options for advanced users. You should not typically need to modify these." jsonschema_extras:"advanced=true"`
 }
 
 // Validate the configuration.

--- a/materialize-starburst/starburst.go
+++ b/materialize-starburst/starburst.go
@@ -38,7 +38,7 @@ type config struct {
 
 	Schedule m.ScheduleConfig `json:"syncSchedule,omitempty" jsonschema:"title=Sync Schedule,description=Configure schedule of transactions for the materialization."`
 
-	Advanced advancedConfig `json:"advanced,omitempty" jsonschema:"title=Advanced Options,description=Options for advanced users. You should not typically need to modify these." jsonschema_extra:"advanced=true"`
+	Advanced advancedConfig `json:"advanced,omitempty" jsonschema:"title=Advanced Options,description=Options for advanced users. You should not typically need to modify these." jsonschema_extras:"advanced=true"`
 }
 
 type advancedConfig struct {

--- a/source-alpaca/.snapshots/TestSpec
+++ b/source-alpaca/.snapshots/TestSpec
@@ -73,7 +73,8 @@
         "additionalProperties": false,
         "type": "object",
         "title": "Advanced Options",
-        "description": "Options for advanced users. You should not typically need to modify these."
+        "description": "Options for advanced users. You should not typically need to modify these.",
+        "advanced": true
       }
     },
     "type": "object",

--- a/source-alpaca/main.go
+++ b/source-alpaca/main.go
@@ -39,7 +39,7 @@ type config struct {
 	Feed         string         `json:"feed" jsonschema:"title=Feed,description=The feed to pull market data from.,enum=iex,enum=sip"`
 	Symbols      string         `json:"symbols" jsonschema:"title=Symbols,description=Comma separated list of symbols to monitor." jsonschema_extras:"multiline=true"`
 	StartDate    time.Time      `json:"start_date" jsonschema:"title=Start Date,description=Get trades starting at this date. Has no effect if changed after the capture has started. Must be no earlier than 2016-01-01T00:00:00Z."`
-	Advanced     advancedConfig `json:"advanced,omitempty" jsonschema:"title=Advanced Options,description=Options for advanced users. You should not typically need to modify these." jsonschema_extra:"advanced=true"`
+	Advanced     advancedConfig `json:"advanced,omitempty" jsonschema:"title=Advanced Options,description=Options for advanced users. You should not typically need to modify these." jsonschema_extras:"advanced=true"`
 
 	effectiveMaxBackfillInterval time.Duration
 	effectiveMinBackfillInterval time.Duration

--- a/source-bigquery-batch/.snapshots/TestSpec
+++ b/source-bigquery-batch/.snapshots/TestSpec
@@ -50,7 +50,8 @@
         "additionalProperties": false,
         "type": "object",
         "title": "Advanced Options",
-        "description": "Options for advanced users. You should not typically need to modify these."
+        "description": "Options for advanced users. You should not typically need to modify these.",
+        "advanced": true
       }
     },
     "type": "object",

--- a/source-bigquery-batch/main.go
+++ b/source-bigquery-batch/main.go
@@ -36,7 +36,7 @@ type Config struct {
 	CredentialsJSON string `json:"credentials_json" jsonschema:"title=Service Account JSON,description=The JSON credentials of the service account to use for authorization." jsonschema_extras:"secret=true,multiline=true,order=1"`
 	Dataset         string `json:"dataset" jsonschema:"title=Dataset,description=BigQuery dataset to discover tables within." jsonschema_extras:"order=2"`
 
-	Advanced advancedConfig `json:"advanced,omitempty" jsonschema:"title=Advanced Options,description=Options for advanced users. You should not typically need to modify these." jsonschema_extra:"advanced=true"`
+	Advanced advancedConfig `json:"advanced,omitempty" jsonschema:"title=Advanced Options,description=Options for advanced users. You should not typically need to modify these." jsonschema_extras:"advanced=true"`
 }
 
 type advancedConfig struct {

--- a/source-dynamodb/.snapshots/TestSpec
+++ b/source-dynamodb/.snapshots/TestSpec
@@ -103,7 +103,8 @@
         "additionalProperties": false,
         "type": "object",
         "title": "Advanced Options",
-        "description": "Options for advanced users. You should not typically need to modify these."
+        "description": "Options for advanced users. You should not typically need to modify these.",
+        "advanced": true
       }
     },
     "type": "object",

--- a/source-dynamodb/main.go
+++ b/source-dynamodb/main.go
@@ -93,7 +93,7 @@ type config struct {
 	Region             string             `json:"region" jsonschema:"title=Region,description=Region of the DynamoDB table." jsonschema_extras:"order=1"`
 	Credentials        *CredentialsConfig `json:"credentials" jsonschema:"title=Authentication" jsonschema_extras:"x-iam-auth=true,order=2"`
 
-	Advanced advancedConfig `json:"advanced,omitempty" jsonschema:"title=Advanced Options,description=Options for advanced users. You should not typically need to modify these." jsonschema_extra:"advanced=true"`
+	Advanced advancedConfig `json:"advanced,omitempty" jsonschema:"title=Advanced Options,description=Options for advanced users. You should not typically need to modify these." jsonschema_extras:"advanced=true"`
 }
 
 type advancedConfig struct {

--- a/source-firestore/.snapshots/TestSpec
+++ b/source-firestore/.snapshots/TestSpec
@@ -40,7 +40,8 @@
         "additionalProperties": false,
         "type": "object",
         "title": "Advanced Options",
-        "description": "Options for advanced users. You should not typically need to modify these."
+        "description": "Options for advanced users. You should not typically need to modify these.",
+        "advanced": true
       }
     },
     "type": "object",

--- a/source-firestore/main.go
+++ b/source-firestore/main.go
@@ -73,7 +73,7 @@ type config struct {
 	// Optional name of the database to capture from
 	DatabasePath string `json:"database,omitempty" jsonschema:"title=Database,description=Optional name of the database to capture from. Leave blank to autodetect. Typically \"projects/$PROJECTID/databases/(default)\"."`
 
-	Advanced advancedConfig `json:"advanced,omitempty" jsonschema:"title=Advanced Options,description=Options for advanced users. You should not typically need to modify these." jsonschema_extra:"advanced=true"`
+	Advanced advancedConfig `json:"advanced,omitempty" jsonschema:"title=Advanced Options,description=Options for advanced users. You should not typically need to modify these." jsonschema_extras:"advanced=true"`
 }
 
 type advancedConfig struct {

--- a/source-mysql-batch/.snapshots/TestSpec
+++ b/source-mysql-batch/.snapshots/TestSpec
@@ -61,7 +61,8 @@
         "additionalProperties": false,
         "type": "object",
         "title": "Advanced Options",
-        "description": "Options for advanced users. You should not typically need to modify these."
+        "description": "Options for advanced users. You should not typically need to modify these.",
+        "advanced": true
       },
       "networkTunnel": {
         "properties": {

--- a/source-mysql-batch/main.go
+++ b/source-mysql-batch/main.go
@@ -36,7 +36,7 @@ type Config struct {
 	Address  string         `json:"address" jsonschema:"title=Server Address,description=The host or host:port at which the database can be reached." jsonschema_extras:"order=0"`
 	User     string         `json:"user" jsonschema:"default=flow_capture,description=The database user to authenticate as." jsonschema_extras:"order=1"`
 	Password string         `json:"password" jsonschema:"description=Password for the specified database user." jsonschema_extras:"secret=true,order=2"`
-	Advanced advancedConfig `json:"advanced,omitempty" jsonschema:"title=Advanced Options,description=Options for advanced users. You should not typically need to modify these." jsonschema_extra:"advanced=true"`
+	Advanced advancedConfig `json:"advanced,omitempty" jsonschema:"title=Advanced Options,description=Options for advanced users. You should not typically need to modify these." jsonschema_extras:"advanced=true"`
 
 	NetworkTunnel *networkTunnel.TunnelConfig `json:"networkTunnel,omitempty" jsonschema:"title=Network Tunnel,description=Connect to your system through an SSH server that acts as a bastion host for your network."`
 }

--- a/source-mysql/.snapshots/TestGeneric-SpecResponse
+++ b/source-mysql/.snapshots/TestGeneric-SpecResponse
@@ -101,7 +101,8 @@
         "additionalProperties": false,
         "type": "object",
         "title": "Advanced Options",
-        "description": "Options for advanced users. You should not typically need to modify these."
+        "description": "Options for advanced users. You should not typically need to modify these.",
+        "advanced": true
       },
       "networkTunnel": {
         "properties": {

--- a/source-mysql/main.go
+++ b/source-mysql/main.go
@@ -145,7 +145,7 @@ type Config struct {
 	Password    string         `json:"password" jsonschema:"title=Login Password,description=Password for the specified database user." jsonschema_extras:"secret=true,order=2"`
 	Timezone    string         `json:"timezone,omitempty" jsonschema:"title=Timezone,description=Timezone to use when capturing datetime columns. Should normally be left blank to use the database's 'time_zone' system variable. Only required if the 'time_zone' system variable cannot be read and columns with type datetime are being captured. Must be a valid IANA time zone name or +HH:MM offset. Takes precedence over the 'time_zone' system variable if both are set (go.estuary.dev/80J6rX)." jsonschema_extras:"order=3"`
 	HistoryMode bool           `json:"historyMode" jsonschema:"default=false,description=Capture change events without reducing them to a final state." jsonschema_extras:"order=4"`
-	Advanced    advancedConfig `json:"advanced,omitempty" jsonschema:"title=Advanced Options,description=Options for advanced users. You should not typically need to modify these." jsonschema_extra:"advanced=true"`
+	Advanced    advancedConfig `json:"advanced,omitempty" jsonschema:"title=Advanced Options,description=Options for advanced users. You should not typically need to modify these." jsonschema_extras:"advanced=true"`
 
 	NetworkTunnel *tunnelConfig `json:"networkTunnel,omitempty" jsonschema:"title=Network Tunnel,description=Connect to your system through an SSH server that acts as a bastion host for your network."`
 }

--- a/source-oracle-batch/.snapshots/TestSpec
+++ b/source-oracle-batch/.snapshots/TestSpec
@@ -70,7 +70,8 @@
         "additionalProperties": false,
         "type": "object",
         "title": "Advanced Options",
-        "description": "Options for advanced users. You should not typically need to modify these."
+        "description": "Options for advanced users. You should not typically need to modify these.",
+        "advanced": true
       },
       "networkTunnel": {
         "properties": {

--- a/source-oracle-batch/main.go
+++ b/source-oracle-batch/main.go
@@ -32,7 +32,7 @@ type Config struct {
 	User     string         `json:"user" jsonschema:"default=flow_capture,description=The database user to authenticate as." jsonschema_extras:"order=1"`
 	Password string         `json:"password" jsonschema:"description=Password for the specified database user." jsonschema_extras:"secret=true,order=2"`
 	Database string         `json:"database" jsonschema:"default=ORCL,description=Logical database name to capture from." jsonschema_extras:"order=3"`
-	Advanced advancedConfig `json:"advanced,omitempty" jsonschema:"title=Advanced Options,description=Options for advanced users. You should not typically need to modify these." jsonschema_extra:"advanced=true"`
+	Advanced advancedConfig `json:"advanced,omitempty" jsonschema:"title=Advanced Options,description=Options for advanced users. You should not typically need to modify these." jsonschema_extras:"advanced=true"`
 
 	NetworkTunnel *networkTunnel.TunnelConfig `json:"networkTunnel,omitempty" jsonschema:"title=Network Tunnel,description=Connect to your system through an SSH server that acts as a bastion host for your network."`
 }

--- a/source-oracle/.snapshots/TestGeneric-SpecResponse
+++ b/source-oracle/.snapshots/TestGeneric-SpecResponse
@@ -94,7 +94,8 @@
         "additionalProperties": false,
         "type": "object",
         "title": "Advanced Options",
-        "description": "Options for advanced users. You should not typically need to modify these."
+        "description": "Options for advanced users. You should not typically need to modify these.",
+        "advanced": true
       },
       "networkTunnel": {
         "properties": {

--- a/source-oracle/main.go
+++ b/source-oracle/main.go
@@ -135,7 +135,7 @@ type Config struct {
 	Database    string `json:"database" jsonschema:"default=ORCL,description=Logical database name to capture from." jsonschema_extras:"order=3"`
 	HistoryMode bool   `json:"historyMode" jsonschema:"default=false,description=Capture change events without reducing them to a final state." jsonschema_extras:"order=5"`
 
-	Advanced advancedConfig `json:"advanced,omitempty" jsonschema:"title=Advanced Options,description=Options for advanced users. You should not typically need to modify these." jsonschema_extra:"advanced=true"`
+	Advanced advancedConfig `json:"advanced,omitempty" jsonschema:"title=Advanced Options,description=Options for advanced users. You should not typically need to modify these." jsonschema_extras:"advanced=true"`
 
 	NetworkTunnel *tunnelConfig `json:"networkTunnel,omitempty" jsonschema:"title=Network Tunnel,description=Connect to your system through an SSH server that acts as a bastion host for your network."`
 }

--- a/source-postgres-batch/.snapshots/TestSpec
+++ b/source-postgres-batch/.snapshots/TestSpec
@@ -88,7 +88,8 @@
         "additionalProperties": false,
         "type": "object",
         "title": "Advanced Options",
-        "description": "Options for advanced users. You should not typically need to modify these."
+        "description": "Options for advanced users. You should not typically need to modify these.",
+        "advanced": true
       },
       "networkTunnel": {
         "properties": {

--- a/source-postgres-batch/main.go
+++ b/source-postgres-batch/main.go
@@ -37,7 +37,7 @@ type Config struct {
 	User     string         `json:"user" jsonschema:"default=flow_capture,description=The database user to authenticate as." jsonschema_extras:"order=1"`
 	Password string         `json:"password" jsonschema:"description=Password for the specified database user." jsonschema_extras:"secret=true,order=2"`
 	Database string         `json:"database" jsonschema:"default=postgres,description=Logical database name to capture from." jsonschema_extras:"order=3"`
-	Advanced advancedConfig `json:"advanced,omitempty" jsonschema:"title=Advanced Options,description=Options for advanced users. You should not typically need to modify these." jsonschema_extra:"advanced=true"`
+	Advanced advancedConfig `json:"advanced,omitempty" jsonschema:"title=Advanced Options,description=Options for advanced users. You should not typically need to modify these." jsonschema_extras:"advanced=true"`
 
 	NetworkTunnel *networkTunnel.TunnelConfig `json:"networkTunnel,omitempty" jsonschema:"title=Network Tunnel,description=Connect to your system through an SSH server that acts as a bastion host for your network."`
 }

--- a/source-postgres/.snapshots/TestGeneric-SpecResponse
+++ b/source-postgres/.snapshots/TestGeneric-SpecResponse
@@ -238,7 +238,8 @@
         "additionalProperties": false,
         "type": "object",
         "title": "Advanced Options",
-        "description": "Options for advanced users. You should not typically need to modify these."
+        "description": "Options for advanced users. You should not typically need to modify these.",
+        "advanced": true
       },
       "networkTunnel": {
         "properties": {

--- a/source-postgres/main.go
+++ b/source-postgres/main.go
@@ -120,7 +120,7 @@ type Config struct {
 	Database    string            `json:"database" jsonschema:"default=postgres,description=Logical database name to capture from." jsonschema_extras:"order=2"`
 	HistoryMode bool              `json:"historyMode" jsonschema:"default=false,description=Capture change events without reducing them to a final state." jsonschema_extras:"order=3"`
 	Credentials *credentialConfig `json:"credentials" jsonschema:"title=Authentication" jsonschema_extras:"order=4,x-iam-auth=true"`
-	Advanced    advancedConfig    `json:"advanced,omitempty" jsonschema:"title=Advanced Options,description=Options for advanced users. You should not typically need to modify these." jsonschema_extra:"advanced=true"`
+	Advanced    advancedConfig    `json:"advanced,omitempty" jsonschema:"title=Advanced Options,description=Options for advanced users. You should not typically need to modify these." jsonschema_extras:"advanced=true"`
 
 	NetworkTunnel *tunnelConfig `json:"networkTunnel,omitempty" jsonschema:"title=Network Tunnel,description=Connect to your system through an SSH server that acts as a bastion host for your network."`
 }

--- a/source-redshift-batch/.snapshots/TestSpec
+++ b/source-redshift-batch/.snapshots/TestSpec
@@ -75,7 +75,8 @@
         "additionalProperties": false,
         "type": "object",
         "title": "Advanced Options",
-        "description": "Options for advanced users. You should not typically need to modify these."
+        "description": "Options for advanced users. You should not typically need to modify these.",
+        "advanced": true
       },
       "networkTunnel": {
         "properties": {

--- a/source-redshift-batch/main.go
+++ b/source-redshift-batch/main.go
@@ -41,7 +41,7 @@ type Config struct {
 	User     string         `json:"user" jsonschema:"default=flow_capture,description=The database user to authenticate as." jsonschema_extras:"order=1"`
 	Password string         `json:"password" jsonschema:"description=Password for the specified database user." jsonschema_extras:"secret=true,order=2"`
 	Database string         `json:"database" jsonschema:"default=dev,description=Logical database name to capture from." jsonschema_extras:"order=3"`
-	Advanced advancedConfig `json:"advanced,omitempty" jsonschema:"title=Advanced Options,description=Options for advanced users. You should not typically need to modify these." jsonschema_extra:"advanced=true"`
+	Advanced advancedConfig `json:"advanced,omitempty" jsonschema:"title=Advanced Options,description=Options for advanced users. You should not typically need to modify these." jsonschema_extras:"advanced=true"`
 
 	NetworkTunnel *networkTunnel.TunnelConfig `json:"networkTunnel,omitempty" jsonschema:"title=Network Tunnel,description=Connect to your system through an SSH server that acts as a bastion host for your network."`
 }

--- a/source-snowflake/.snapshots/TestSpec
+++ b/source-snowflake/.snapshots/TestSpec
@@ -117,7 +117,8 @@
         "additionalProperties": false,
         "type": "object",
         "title": "Advanced Options",
-        "description": "Options for advanced users. You should not typically need to modify these."
+        "description": "Options for advanced users. You should not typically need to modify these.",
+        "advanced": true
       }
     },
     "type": "object",

--- a/source-snowflake/main.go
+++ b/source-snowflake/main.go
@@ -30,7 +30,7 @@ type config struct {
 	Warehouse   string                           `json:"warehouse,omitempty" jsonschema:"title=Warehouse,description=The Snowflake virtual warehouse used to execute queries. Uses the default warehouse for the Snowflake user if left blank." jsonschema_extras:"order=2"`
 	Role        string                           `json:"role,omitempty" jsonschema:"title=Role,description=The user role used to perform actions." jsonschema_extras:"order=3"`
 	Credentials *snowflake_auth.CredentialConfig `json:"credentials" jsonschema:"title=Authentication"`
-	Advanced    advancedConfig                   `json:"advanced,omitempty" jsonschema:"title=Advanced Options,description=Options for advanced users. You should not typically need to modify these." jsonschema_extra:"advanced=true"`
+	Advanced    advancedConfig                   `json:"advanced,omitempty" jsonschema:"title=Advanced Options,description=Options for advanced users. You should not typically need to modify these." jsonschema_extras:"advanced=true"`
 }
 
 type advancedConfig struct {

--- a/source-sqlserver-batch/.snapshots/TestSpec
+++ b/source-sqlserver-batch/.snapshots/TestSpec
@@ -67,7 +67,8 @@
         "additionalProperties": false,
         "type": "object",
         "title": "Advanced Options",
-        "description": "Options for advanced users. You should not typically need to modify these."
+        "description": "Options for advanced users. You should not typically need to modify these.",
+        "advanced": true
       },
       "networkTunnel": {
         "properties": {

--- a/source-sqlserver-batch/main.go
+++ b/source-sqlserver-batch/main.go
@@ -35,7 +35,7 @@ type Config struct {
 	User     string         `json:"user" jsonschema:"default=flow_capture,description=The database user to authenticate as." jsonschema_extras:"order=1"`
 	Password string         `json:"password" jsonschema:"description=Password for the specified database user." jsonschema_extras:"secret=true,order=2"`
 	Database string         `json:"database" jsonschema:"description=Logical database name to capture from." jsonschema_extras:"order=3"`
-	Advanced advancedConfig `json:"advanced,omitempty" jsonschema:"title=Advanced Options,description=Options for advanced users. You should not typically need to modify these." jsonschema_extra:"advanced=true"`
+	Advanced advancedConfig `json:"advanced,omitempty" jsonschema:"title=Advanced Options,description=Options for advanced users. You should not typically need to modify these." jsonschema_extras:"advanced=true"`
 
 	NetworkTunnel *networkTunnel.TunnelConfig `json:"networkTunnel,omitempty" jsonschema:"title=Network Tunnel,description=Connect to your system through an SSH server that acts as a bastion host for your network."`
 }

--- a/source-sqlserver/.snapshots/TestGeneric-SpecResponse
+++ b/source-sqlserver/.snapshots/TestGeneric-SpecResponse
@@ -106,7 +106,8 @@
         "additionalProperties": false,
         "type": "object",
         "title": "Advanced Options",
-        "description": "Options for advanced users. You should not typically need to modify these."
+        "description": "Options for advanced users. You should not typically need to modify these.",
+        "advanced": true
       },
       "networkTunnel": {
         "properties": {

--- a/source-sqlserver/main.go
+++ b/source-sqlserver/main.go
@@ -81,7 +81,7 @@ type Config struct {
 	Timezone    string `json:"timezone,omitempty" jsonschema:"title=Time Zone,default=UTC,description=The IANA timezone name in which datetime columns will be converted to RFC3339 timestamps. Defaults to UTC if left blank." jsonschema_extras:"order=4"`
 	HistoryMode bool   `json:"historyMode" jsonschema:"default=false,description=Capture change events without reducing them to a final state." jsonschema_extras:"order=5"`
 
-	Advanced advancedConfig `json:"advanced,omitempty" jsonschema:"title=Advanced Options,description=Options for advanced users. You should not typically need to modify these." jsonschema_extra:"advanced=true"`
+	Advanced advancedConfig `json:"advanced,omitempty" jsonschema:"title=Advanced Options,description=Options for advanced users. You should not typically need to modify these." jsonschema_extras:"advanced=true"`
 
 	NetworkTunnel *tunnelConfig `json:"networkTunnel,omitempty" jsonschema:"title=Network Tunnel,description=Connect to your system through an SSH server that acts as a bastion host for your network."`
 }


### PR DESCRIPTION
As far as I can tell, `jsonschema_extra` is not a valid annotation and is ignored by the JSON schema reflection package we use. This doesn't seem to make a difference in practice (connectors with it set correctly vs missing seem to render identically in the UI) but we probably ought to fix it just to keep things tidy.