### PR TITLE
source-hubspot-native: flip useLegacyNamingForCustomObjects default to false

### DIFF
--- a/source-hubspot-native/source_hubspot_native/models.py
+++ b/source-hubspot-native/source_hubspot_native/models.py
@@ -98,7 +98,7 @@ class EndpointConfig(BaseModel):
     useLegacyNamingForCustomObjects: bool = Field(
         title="Use Legacy Naming for Custom Objects",
         description="If selected, the legacy naming convention for custom objects is used. Otherwise, all discovered bindings for custom objects will have 'custom_' prepended to their names.",
-        default=True,
+        default=False,
         json_schema_extra={"x-hidden-field": True},
     )
 

--- a/source-hubspot-native/tests/snapshots/snapshots__spec__stdout.json
+++ b/source-hubspot-native/tests/snapshots/snapshots__spec__stdout.json
@@ -80,7 +80,7 @@
           "type": "boolean"
         },
         "useLegacyNamingForCustomObjects": {
-          "default": true,
+          "default": false,
           "description": "If selected, the legacy naming convention for custom objects is used. Otherwise, all discovered bindings for custom objects will have 'custom_' prepended to their names.",
           "title": "Use Legacy Naming for Custom Objects",
           "type": "boolean",


### PR DESCRIPTION
**Description:**

This PR is a follow up to https://github.com/estuary/connectors/pull/3555. All existing captures have had the `useLegacyNamingForCustomObjects` flag explicitly set to `true`, so it is safe to flip the connector's default to `False` so all new captures will use the new naming convention for custom objects.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

The connector's documentation should be updated to mention what the `useLegacyNamingForCustomObjects` flag does.

**Notes for reviewers:**

(anything that might help someone review this PR)

