### PR TITLE
source-sharepoint: fix expected site id schema format

### DIFF
--- a/source-sharepoint/.snapshots/TestSpec
+++ b/source-sharepoint/.snapshots/TestSpec
@@ -90,7 +90,7 @@
             "site_id": {
               "type": "string",
               "title": "Site ID",
-              "description": "The SharePoint site ID (GUID).",
+              "description": "The SharePoint site identifier. Accepts: (1) Full ID from Microsoft Graph API (e.g., \"contoso.sharepoint.com,2C712604-1370-44E7-A1F5-426573FDA80A,2D2244C3-251A-49EA-93A8-39E1C3A060FE\") or (2) Hostname with path (e.g., \"contoso.sharepoint.com:/sites/Marketing\").",
               "order": 1
             },
             "drive_id": {

--- a/source-sharepoint/main.go
+++ b/source-sharepoint/main.go
@@ -636,7 +636,7 @@ func configSchema(parserSchema json.RawMessage) json.RawMessage {
 							"site_id": {
 								"type": "string",
 								"title": "Site ID",
-								"description": "The SharePoint site ID (GUID).",
+								"description": "The SharePoint site identifier. Accepts: (1) Full ID from Microsoft Graph API (e.g., \"contoso.sharepoint.com,2C712604-1370-44E7-A1F5-426573FDA80A,2D2244C3-251A-49EA-93A8-39E1C3A060FE\") or (2) Hostname with path (e.g., \"contoso.sharepoint.com:/sites/Marketing\").",
 								"order": 1
 							},
 							"drive_id": {


### PR DESCRIPTION
**Description:**

Updates `source-sharepoint`'s JSON schema to correctly specify the expected site id format. These identifiers will then be internally converted into a GUID.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

