### PR TITLE
materialize-sql: do conditional rollbacks on panic

### DIFF
--- a/materialize-cratedb/driver.go
+++ b/materialize-cratedb/driver.go
@@ -445,17 +445,42 @@ func (d *transactor) Load(it *m.LoadIterator, loaded func(int, json.RawMessage) 
 	return nil
 }
 
+// TxDefuser.MaybeRollback calls Rollback on a Tx, unless Defuse has previously
+// been called.
+type TxDefuser struct {
+	defused bool
+	txn     pgx.Tx
+}
+
+func NewTxDefuser(txn pgx.Tx) *TxDefuser {
+	return &TxDefuser{
+		defused: false,
+		txn:     txn,
+	}
+}
+
+func (t *TxDefuser) MaybeRollback() {
+	if t.defused {
+		return
+	}
+	t.txn.Rollback(context.Background())
+}
+
+func (t *TxDefuser) Defuse() {
+	t.defused = true
+}
+
 func (d *transactor) Store(it *m.StoreIterator) (_ m.StartCommitFunc, err error) {
 	ctx := it.Context()
 	txn, err := d.store.conn.BeginTx(ctx, pgx.TxOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("DB.BeginTx: %w", err)
 	}
-	defer func() {
-		if err != nil {
-			txn.Rollback(ctx)
-		}
-	}()
+
+	// All transactions must be complete before closing the database.  This
+	// handles the case of both an error or a panic occurring.
+	defuser := NewTxDefuser(txn)
+	defer defuser.MaybeRollback()
 
 	var batch pgx.Batch
 	batchBytes := 0
@@ -497,6 +522,7 @@ func (d *transactor) Store(it *m.StoreIterator) (_ m.StartCommitFunc, err error)
 		}
 	}
 
+	defuser.Defuse()
 	return func(ctx context.Context, runtimeCheckpoint *protocol.Checkpoint) (*pf.ConnectorState, m.OpFuture) {
 		return nil, m.RunAsyncOperation(func() error {
 			defer txn.Rollback(ctx)

--- a/materialize-postgres/driver.go
+++ b/materialize-postgres/driver.go
@@ -50,7 +50,7 @@ const (
 )
 
 var featureFlagDefaults = map[string]bool{
-	"datetime_keys_as_string": true,
+	"datetime_keys_as_string":          true,
 	"retain_existing_data_on_backfill": false,
 }
 
@@ -564,17 +564,41 @@ func (d *transactor) Load(it *m.LoadIterator, loaded func(int, json.RawMessage) 
 	return nil
 }
 
+// TxDefuser.MaybeRollback calls Rollback on a Tx, unless Defuse has previously
+// been called.
+type TxDefuser struct {
+	defused bool
+	txn     pgx.Tx
+}
+
+func NewTxDefuser(txn pgx.Tx) *TxDefuser {
+	return &TxDefuser{
+		defused: false,
+		txn:     txn,
+	}
+}
+
+func (t *TxDefuser) MaybeRollback() {
+	if t.defused {
+		return
+	}
+	t.txn.Rollback(context.Background())
+}
+
+func (t *TxDefuser) Defuse() {
+	t.defused = true
+}
+
 func (d *transactor) Store(it *m.StoreIterator) (_ m.StartCommitFunc, err error) {
 	ctx := it.Context()
 	txn, err := d.store.conn.BeginTx(ctx, pgx.TxOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("DB.BeginTx: %w", err)
 	}
-	defer func() {
-		if err != nil {
-			txn.Rollback(ctx)
-		}
-	}()
+	// All transactions must be complete before closing the database.  This
+	// handles the case of both an error or a panic occurring.
+	defuser := NewTxDefuser(txn)
+	defer defuser.MaybeRollback()
 
 	var batch pgx.Batch
 	batchBytes := 0
@@ -616,6 +640,7 @@ func (d *transactor) Store(it *m.StoreIterator) (_ m.StartCommitFunc, err error)
 		}
 	}
 
+	defuser.Defuse()
 	return func(ctx context.Context, runtimeCheckpoint *protocol.Checkpoint) (*pf.ConnectorState, m.OpFuture) {
 		return nil, m.RunAsyncOperation(func() error {
 			defer txn.Rollback(ctx)

--- a/materialize-sqlserver/driver.go
+++ b/materialize-sqlserver/driver.go
@@ -468,31 +468,6 @@ func (d *transactor) Load(it *m.LoadIterator, loaded func(int, json.RawMessage) 
 	return nil
 }
 
-// TxDefuser.MaybeRollback calls Rollback on a Tx, unless Defuse has previously
-// been called.
-type TxDefuser struct {
-	defused bool
-	txn     *stdsql.Tx
-}
-
-func NewTxDefuser(txn *stdsql.Tx) *TxDefuser {
-	return &TxDefuser{
-		defused: false,
-		txn:     txn,
-	}
-}
-
-func (t *TxDefuser) MaybeRollback() {
-	if t.defused {
-		return
-	}
-	t.txn.Rollback()
-}
-
-func (t *TxDefuser) Defuse() {
-	t.defused = true
-}
-
 func (d *transactor) Store(it *m.StoreIterator) (m.StartCommitFunc, error) {
 	ctx := it.Context()
 	txn, err := d.store.conn.BeginTx(ctx, &stdsql.TxOptions{})
@@ -502,7 +477,7 @@ func (d *transactor) Store(it *m.StoreIterator) (m.StartCommitFunc, error) {
 
 	// If a Tx is open and you attempt to close the connection, msqldb will
 	// deadlock.  This handles the case of both an error or a panic occurring.
-	defuser := NewTxDefuser(txn)
+	defuser := sql.NewTxDefuser(txn)
 	defer defuser.MaybeRollback()
 
 	// The mssql driver uses prepared statements to drive bulk inserts. A bulk


### PR DESCRIPTION
**Description:**

If a panic occurs, any conditional rollbacks must be performed and it is unlikely that err will be set.

This is a similar fix to 5d9d092.

**Notes for reviewers:**

This PR doesn't address the cause of the panic, but hopefully makes it easier to debug the error since it will no longer result in a deadlock.

