### PR TITLE
source-monday: handle new `set_entity_board_role` activity log event

### DIFF
--- a/source-monday/source_monday/models.py
+++ b/source-monday/source_monday/models.py
@@ -208,6 +208,7 @@ class ActivityLogEvents(StrEnum):
     RESTORE_COLUMN = "restore_column"
     RESTORE_GROUP = "restore_group"
     RESTORE_PULSE = "restore_pulse"
+    SET_ENTITY_BOARD_ROLE = "set_entity_board_role"
     SUBSCRIBE = "subscribe"
     UPDATE_BOARD_NAME = "update_board_name"
     UPDATE_BOARD_NICKNAME = "update_board_nickname"
@@ -296,6 +297,7 @@ class ActivityLog(BaseModel, extra="allow"):
                 | ActivityLogEvents.UPDATE_BOARD_GRANULAR_PERMISSIONS
                 | ActivityLogEvents.UPDATE_BOARD_PERMISSIONS
                 | ActivityLogEvents.RESTORE_GROUP
+                | ActivityLogEvents.SET_ENTITY_BOARD_ROLE
             ):
                 log.debug(f"Board change event: {self.event}")
                 ids = []


### PR DESCRIPTION
**Description:**

New Monday.com Activity Log event type: `set_entity_board_role`.

Noticed this new Activity Log in a production capture that we warned about. No data loss, since we treat all new/unknown activity log event types as board+item update events and fetch that board+items again. However, this one is a board level event. This new event type should be classified as a board level change, similar to `update_board_granular_permissions` and `update_board_permissions`.

Example of this event's information:

```
Unknown activity log event 'set_entity_board_role' - defaulting to full board refresh. This event should be documented and handled explicitly. 

fields: {
    args: {
        event: "set_entity_board_role"
        stream: "boards"
        data: {
            board_id:<some_board_id>
            item_id:NULL
            pulse_id:NULL
            pulse_ids:NULL
            duplicated_pulse_ids:NULL
            subitem:NULL
            board_name: "Some board name"
            entity_id:<some_entity_id>
            entity_type: "user"
            role_id: 1
        }
    }
    file: "/opt/source-monday/source_monday/models.py:454"
    source: "flow.capture.boards.incremental"
}
```

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

