### PR TITLE
source-postgres: Advanced statement_timeout option

### DIFF
--- a/source-postgres/.snapshots/TestGeneric-SpecResponse
+++ b/source-postgres/.snapshots/TestGeneric-SpecResponse
@@ -230,6 +230,19 @@
             "title": "Feature Flags",
             "description": "This property is intended for Estuary internal use. You should only modify this field as directed by Estuary support."
           },
+          "statement_timeout": {
+            "type": "string",
+            "enum": [
+              "",
+              "30s",
+              "1m",
+              "5m",
+              "30m"
+            ],
+            "title": "Statement Timeout",
+            "description": "Overrides the default statement timeout used by the connector. The default of zero disables statement timeouts entirely.",
+            "default": ""
+          },
           "discover_only_published": {
             "type": "boolean",
             "x-hidden-field": true


### PR DESCRIPTION
**Description:**

We already have this option in source-postgres-batch so it seems reasonable to add it for symmetry here. It also _might_ help with a current issue a production capture is seeing, but that's uncertain and I think feature parity is the stronger justification here.

**Workflow steps:**

Nothing should change by default. Users will now be able to specify a statement timeout value in the advanced endpoint config.
