### PR TITLE
materialize-s3-iceberg: use 1 based indexing for field-id

### DIFF
--- a/materialize-s3-iceberg/iceberg-ctl/iceberg_ctl/__main__.py
+++ b/materialize-s3-iceberg/iceberg-ctl/iceberg_ctl/__main__.py
@@ -244,7 +244,7 @@ def create_table(
             field_type=_field_to_type(f.type),
             required=not f.nullable,
         )
-        for idx, f in enumerate(table_create.fields)
+        for idx, f in enumerate(table_create.fields, 1)
     ]
 
     schema = Schema(*columns)


### PR DESCRIPTION
Iceberg generally uses 1-based indexing for field-ids, and adjusts this value forward automatically when writing the schema.  However, this adjustment does not apply to the schema.name_mapping which is now attached when creating the initial table.  This could cause a discrepancy between the field-id making preventing the table from being loaded.

