### PR TITLE
source-dynamics-365-finance-and-operations: reduce default resource interval

### DIFF
--- a/source-dynamics-365-finance-and-operations/source_dynamics_365_finance_and_operations/resources.py
+++ b/source-dynamics-365-finance-and-operations/source_dynamics_365_finance_and_operations/resources.py
@@ -75,7 +75,7 @@ def resources(
                 inc=ResourceState.Incremental(cursor=EPOCH),
             ),
             initial_config=ResourceConfig(
-                name=table.name, interval=timedelta(minutes=15)
+                name=table.name, interval=timedelta(minutes=5)
             ),
             schema_inference=True,
         )


### PR DESCRIPTION
**Description:**

When users make a significant number of changes in their D365 F&O account within the timespan covered by a single timestamp folder, the connector may take a while to process all those changes. It could take long enough that if the user has an aggressive retention setting that deletes the CSVs containing the changes shortly after they're finalized, the connector ends up attempting to read a deleted CSV.

Reducing the resource interval to 5 minutes should help the connector detect when new CSVs exist sooner & hopefully avoid the connector attempting to read deleted files.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

