### PR TITLE
materialize-snowflake: retry load queries

### DIFF
--- a/materialize-snowflake/.snapshots/TestSQLGeneration
+++ b/materialize-snowflake/.snapshots/TestSQLGeneration
@@ -97,7 +97,9 @@ ALTER TABLE "a-schema".key_value ALTER COLUMN
 --- End alter table drop not nulls ---
 
 --- Begin "a-schema".key_value loadQuery ---
-SELECT 0, TO_JSON("a-schema".key_value.flow_document)
+SELECT 0,
+	ROW_NUMBER() OVER (ORDER BY "a-schema".key_value.key1, "a-schema".key_value.key2, "a-schema".key_value."key!binary") AS row_number,
+	TO_JSON("a-schema".key_value.flow_document)
 	FROM "a-schema".key_value
 	JOIN (
 		SELECT $1[0] AS key1, $1[1] AS key2, $1[2] AS "key!binary"
@@ -106,10 +108,12 @@ SELECT 0, TO_JSON("a-schema".key_value.flow_document)
 	ON "a-schema".key_value.key1 = r.key1 AND "a-schema".key_value.key1 >= 10 AND "a-schema".key_value.key1 <= 100
 	AND "a-schema".key_value.key2 = r.key2
 	AND "a-schema".key_value."key!binary" = r."key!binary" AND "a-schema".key_value."key!binary" >= 'aGVsbG8K' AND "a-schema".key_value."key!binary" <= 'Z29vZGJ5ZQo='
+	ORDER BY "a-schema".key_value.key1, "a-schema".key_value.key2, "a-schema".key_value."key!binary"
 --- End "a-schema".key_value loadQuery ---
 
 --- Begin "a-schema".key_value loadQueryNoFlowDocument ---
-SELECT 0, 
+SELECT 0,
+ROW_NUMBER() OVER (ORDER BY "a-schema".key_value.key1, "a-schema".key_value.key2, "a-schema".key_value."key!binary") AS row_number,
 OBJECT_CONSTRUCT(
 	'key1', "a-schema".key_value.key1,
 	'key2', "a-schema".key_value.key2,
@@ -139,6 +143,7 @@ JOIN (
 ON "a-schema".key_value.key1 = r.key1 AND "a-schema".key_value.key1 >= 10 AND "a-schema".key_value.key1 <= 100
 AND "a-schema".key_value.key2 = r.key2
 AND "a-schema".key_value."key!binary" = r."key!binary" AND "a-schema".key_value."key!binary" >= 'aGVsbG8K' AND "a-schema".key_value."key!binary" <= 'Z29vZGJ5ZQo='
+ORDER BY "a-schema".key_value.key1, "a-schema".key_value.key2, "a-schema".key_value."key!binary"
 --- End "a-schema".key_value loadQueryNoFlowDocument ---
 
 --- Begin "a-schema".key_value mergeInto ---


### PR DESCRIPTION
**Description:**

If an error occurs while running a load query, we would return an error and start over on the next run.  This can be a problem as you scale up the size of the transaction, as it becomes more likely for an error to occur and more expensive to rerun the transaction from the start.

In order to retry a query after it fails, we need to resume at the same position without loading documents multiple times.  I added an ORDER BY clause to ensure the results have the same ordering, and a row number so we can skip over results we already processed.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

None

**Notes for reviewers:**

(anything that might help someone review this PR)

