### PR TITLE
source-iterable: stream `events` response

### DIFF
--- a/source-iterable/source_iterable/streams.py
+++ b/source-iterable/source_iterable/streams.py
@@ -518,14 +518,18 @@ class Events(IterableStream):
         Put common event fields at the top level.
         Put the rest of the fields in the `data` subobject.
         """
-        jsonl_records = StringIO(response.text)
-        for record in jsonl_records:
+        for record in response.iter_lines():
             record_dict = json.loads(record)
             record_dict_common_fields = {}
             for field in self.common_fields:
                 record_dict_common_fields[field] = record_dict.pop(field, None)
 
             yield {**record_dict_common_fields, "data": record_dict}
+
+    def request_kwargs(
+        self, stream_state: Mapping[str, Any], stream_slice: Mapping[str, Any] = None, next_page_token: Mapping[str, Any] = None
+    ) -> Mapping[str, Any]:
+        return {"stream": True}
 
 
 class EmailBounce(IterableExportStreamAdjustableRange):


### PR DESCRIPTION
**Description:**

We've observed `source-iterable` captures OOMing when processing the `events` stream. I suspect this is happening when a single API response is too large to fit in memory. Switching the `events` stream to incrementally stream the API response instead of loading it all in memory should help avoid those OOMs.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

Tested on a local stack. Confirmed the connector OOMs ~ 4 minutes after beginning to process `events` before any changes. After updating `events` to incrementally stream API responses, memory usage has hovered around ~9% and I haven't observed any OOMs after letting it run for ~1.5 hours.

