### PR TITLE
source-hubspot-native: fix contact list memberships deadlock

### DIFF
--- a/source-hubspot-native/source_hubspot_native/api.py
+++ b/source-hubspot-native/source_hubspot_native/api.py
@@ -1749,18 +1749,19 @@ async def _request_contact_list_memberships(
     url = f"{HUB}/crm/v3/lists/{contact_list.listId}/memberships"
     params = {"limit": 250}
 
-    response = ContactListMembershipResponse.model_validate_json(
-        await http.request(log, url, params=params),
-        context=contact_list,
-    )
+    while True:
+        response = ContactListMembershipResponse.model_validate_json(
+            await http.request(log, url, params=params),
+            context=contact_list,
+        )
 
-    for item in response.results:
-        if item.membershipTimestamp < start:
-            continue
-        if end and item.membershipTimestamp >= end:
-            continue
+        for item in response.results:
+            if item.membershipTimestamp < start:
+                continue
+            if end and item.membershipTimestamp >= end:
+                continue
 
-        yield item
+            yield item
 
         if (next_cursor := response.get_next_cursor()) is None:
             break


### PR DESCRIPTION
**Description:**

Contact list membership streams might get blocked waiting for nonexistent documents if no lists have been updated in a given time window. This PR fixes this deadlock by returning early if there are no lists to request data from.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

