### PR TITLE
sqlcapture: Raise diagnostics timeout slightly

### DIFF
--- a/sqlcapture/capture.go
+++ b/sqlcapture/capture.go
@@ -162,7 +162,7 @@ type Capture struct {
 }
 
 const (
-	automatedDiagnosticsTimeout = 60 * time.Second // How long to wait *after the point where the fence was requested* before triggering automated diagnostics.
+	automatedDiagnosticsTimeout = 5 * time.Minute  // How long to wait *after the point where the fence was requested* before triggering automated diagnostics.
 	streamIdleWarning           = 60 * time.Second // After `streamIdleWarning` has elapsed since the last replication event, we log a warning.
 	streamProgressInterval      = 60 * time.Second // After `streamProgressInterval` the replication streaming code may log a progress report.
 	rediscoverInterval          = 5 * time.Minute  // The capture will re-run discovery and reinitialize missing/pending tables this frequently.


### PR DESCRIPTION
**Description:**

Increases the threshold for the "automated replication diagnostics" triggering from one minute to five minutes. Generally if it takes less than 5 minutes there's still no cause for concern, we probably just had a bit of a replication backlog to work through. And in fact running diagnostics on too much of a hair-trigger just makes it harder to see what's actually going on with a capture.