### PR TITLE
source-hubspot-native: increase semaphore value

### DIFF
--- a/source-hubspot-native/source_hubspot_native/api.py
+++ b/source-hubspot-native/source_hubspot_native/api.py
@@ -1774,7 +1774,9 @@ class ContactListMembershipControl:
 
     # We expect users to have tens of thousands of lists to fetch.
     # This semaphore limits the number of tasks we keep in memory at any given time
-    task_slots: asyncio.Semaphore = field(default_factory=lambda: asyncio.Semaphore(5))
+    task_slots: asyncio.Semaphore = field(
+        default_factory=lambda: asyncio.Semaphore(300)
+    )
     results: asyncio.Queue[ContactListMembership | None] = field(
         default_factory=lambda: asyncio.Queue(1)
     )


### PR DESCRIPTION

**Description:**

Contact list membership streams were taking several hours to complete due to our semaphore system. Concerned about memory limitations, we restricted our concurrent membership paginations to 5. However, recent testing indicates 60x that could be done while keeping memory under 20%.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

PR has been tested locally and profiled using `docker stats`. CPU usage stays at ~40% with spikes in the 90%-100% range and memory sits at less than 20%.