### PR TITLE
source-sqlserver: Lowercase sys.partitions in backfill stats

### DIFF
--- a/source-sqlserver/backfill.go
+++ b/source-sqlserver/backfill.go
@@ -317,12 +317,12 @@ func (db *sqlserverDatabase) queryTableStatistics(ctx context.Context, schema, t
 
 	// Query sys.partitions for row count estimate
 	var query = `
-		SELECT SUM(P.ROWS)
-		FROM SYS.PARTITIONS P
-		JOIN SYS.TABLES T ON P.OBJECT_ID = T.OBJECT_ID
-		JOIN SYS.SCHEMAS S ON T.SCHEMA_ID = S.SCHEMA_ID
-		WHERE S.NAME = @p1 AND T.NAME = @p2
-		  AND P.INDEX_ID IN (0, 1)`
+		SELECT SUM(p.rows)
+		FROM sys.partitions p
+		JOIN sys.tables t ON p.object_id = t.object_id
+		JOIN sys.schemas s ON t.schema_id = s.schema_id
+		WHERE s.name = @p1 AND t.name = @p2
+		  AND p.index_id IN (0, 1)`
 	var rowCount sql.NullInt64
 	if err := db.conn.QueryRowContext(ctx, query, schema, table).Scan(&rowCount); err != nil {
 		var stats = &sqlserverTableStatistics{Err: fmt.Errorf("error querying table statistics for %q: %w", streamID, err)}


### PR DESCRIPTION
**Description:**

This is kind of the inverse of the usual `information_schema` vs `INFORMATION_SCHEMA` capitalization issue we see with discovery queries. The canonical names of the `sys.foo` tables are lower- case and if we capitalize them then things will work fine in the default collation but in some locales with tricky case folding rules (like Turkish 'i') `'SYS.PARTITIONS' != 'sys.partitions'` and the query will fail.

Using lowercase identifiers is always more correct, AFAIK.