### PR TITLE
source-hubspot-native: fix `UnboundLocalVariable` error

### DIFF
--- a/source-hubspot-native/source_hubspot_native/api.py
+++ b/source-hubspot-native/source_hubspot_native/api.py
@@ -240,10 +240,13 @@ async def fetch_page_with_associations(
     # On connector initiated backfills, only capture calculated properties and rely
     # on the merge reduction strategies to merge in partial documents containing
     # updated calculated properties.
-    property_names: list[str] = [
+    properties_to_fetch: list[str] = [
         p.name for p in properties.results
         if not is_connector_initiated or p.calculated
     ]
+
+    if not properties_to_fetch:
+        return
 
     # There is a limit on how large a URL can be when making a GET request to HubSpot. Exactly what
     # this limit is is a bit mysterious to me. Empirical testing indicates that a single property
@@ -257,7 +260,7 @@ async def fetch_page_with_associations(
     # cumulative byte lengths, we will issue multiple requests for different sets of properties and
     # combine the results together in the output documents.
     chunked_properties = _chunk_props(
-        property_names,
+        properties_to_fetch,
         5 * 1024,
     )
 


### PR DESCRIPTION
**Description:**

After rolling out https://github.com/estuary/connectors/pull/3528 to only capture calculated properties during connector initiated backfills, we began seeing the following error:

```
Traceback (most recent call last):
  File "/opt/estuary-cdk/estuary_cdk/capture/task.py", line 201, in run_task
    await child(t)
  File "/opt/estuary-cdk/estuary_cdk/capture/common.py", line 751, in backfill_closure
    await _binding_backfill_task(
  File "/opt/estuary-cdk/estuary_cdk/capture/common.py", line 943, in _binding_backfill_task
    async for item in pages:
  File "/opt/source-hubspot-native/source_hubspot_native/api.py", line 313, in fetch_page_with_associations
    if result.paging:
       ^^^^^^
UnboundLocalError: cannot access local variable 'result' where it is not associated with a value

```

This was happening in the `fetch_page_with_associations` function. When an object has no calculated properties, the `result` variable was never initialized in the loop to fetch properties, and the connector crashed when trying to access `result` at the end of the function.

Returning early if there are no properties to fetch stops the connector from attempting to access `result` without first assigning it while fetching properties.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

