### PR TITLE
source-iterable: add project_type config setting to fix `users` primary key

### DIFF
--- a/source-iterable/source_iterable/models.py
+++ b/source-iterable/source_iterable/models.py
@@ -1,0 +1,6 @@
+from enum import StrEnum
+
+class ProjectType(StrEnum):
+    EMAIL_BASED = "Email-based"
+    USER_ID_BASED = "UserID-based"
+    HYBRID = "Hybrid"

--- a/source-iterable/source_iterable/schemas/users.json
+++ b/source-iterable/source_iterable/schemas/users.json
@@ -310,6 +310,9 @@
     "userId": {
       "type": ["null", "string"]
     },
+    "itblUserId": {
+      "type": ["null", "string"]
+    },
     "shopify_created_at": {
       "type": ["null", "string"],
       "format": "date-time"

--- a/source-iterable/source_iterable/source.py
+++ b/source-iterable/source_iterable/source.py
@@ -11,6 +11,7 @@ from airbyte_cdk.sources.streams import Stream
 from airbyte_cdk.sources.streams.http.requests_native_auth import TokenAuthenticator
 from source_iterable.utils import read_full_refresh
 
+from .models import ProjectType
 from .streams import (
     AccessCheck,
     Campaigns,
@@ -81,6 +82,8 @@ class SourceIterable(AbstractSource):
 
     def streams(self, config: Mapping[str, Any]) -> List[Stream]:
         start_date, end_date = config["start_date"], config.get("end_date")
+        # If project_type is absent from the config, preserve the previous behavior of assuming this is an Email-based project.
+        project_type = config.get("project_type", ProjectType.EMAIL_BASED)
         date_range = {"start_date": start_date, "end_date": end_date}
 
         def all_streams_accessible():
@@ -116,7 +119,7 @@ class SourceIterable(AbstractSource):
         if all_streams_accessible():
             streams.extend(
                 [
-                    Users(authenticator=authenticator, **date_range),
+                    Users(authenticator=authenticator, project_type=project_type, **date_range),
                     ListUsers(authenticator=authenticator),
                     EmailBounce(authenticator=authenticator, **date_range),
                     EmailClick(authenticator=authenticator, **date_range),

--- a/source-iterable/source_iterable/spec.json
+++ b/source-iterable/source_iterable/spec.json
@@ -22,6 +22,14 @@
         "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$",
         "order": 1,
         "format": "date-time"
+      },
+      "project_type": {
+        "type": "string",
+        "title": "Project Type",
+        "description": "The type of Iterable project, which determines how users are uniquely identified. See https://support.iterable.com/hc/en-us/articles/9216719179796-Project-Types-and-Unique-Identifiers for more information.",
+        "enum": ["Email-based", "UserID-based", "Hybrid"],
+        "default": "UserID-based",
+        "order": 2
       }
     }
   }

--- a/source-iterable/tests/snapshots/snapshots__discover__capture.stdout.json
+++ b/source-iterable/tests/snapshots/snapshots__discover__capture.stdout.json
@@ -1039,6 +1039,12 @@
             "string"
           ]
         },
+        "itblUserId": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
         "shopify_created_at": {
           "type": [
             "null",

--- a/source-iterable/tests/snapshots/snapshots__spec__capture.stdout.json
+++ b/source-iterable/tests/snapshots/snapshots__spec__capture.stdout.json
@@ -1,79 +1,91 @@
 [
   {
+    "protocol": 3032023,
     "configSchema": {
       "$schema": "http://json-schema.org/draft-07/schema#",
-      "additionalProperties": true,
-      "properties": {
-        "api_key": {
-          "airbyte_secret": true,
-          "description": "Iterable API Key. See the docs for more information on how to obtain this key: https://go.estuary.dev/FRCv4k",
-          "order": 0,
-          "title": "API Key",
-          "type": "string"
-        },
-        "start_date": {
-          "description": "The date from which you'd like to replicate data for Iterable, in the format YYYY-MM-DDT00:00:00Z. All data generated after this date will be replicated.",
-          "examples": [
-            "2021-04-01T00:00:00Z"
-          ],
-          "format": "date-time",
-          "order": 1,
-          "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$",
-          "title": "Start Date",
-          "type": "string"
-        }
-      },
+      "title": "Iterable Spec",
+      "type": "object",
       "required": [
         "start_date",
         "api_key"
       ],
-      "title": "Iterable Spec",
-      "type": "object"
+      "additionalProperties": true,
+      "properties": {
+        "api_key": {
+          "type": "string",
+          "title": "API Key",
+          "description": "Iterable API Key. See the docs for more information on how to obtain this key: https://go.estuary.dev/FRCv4k",
+          "airbyte_secret": true,
+          "order": 0
+        },
+        "start_date": {
+          "type": "string",
+          "title": "Start Date",
+          "description": "The date from which you'd like to replicate data for Iterable, in the format YYYY-MM-DDT00:00:00Z. All data generated after this date will be replicated.",
+          "examples": [
+            "2021-04-01T00:00:00Z"
+          ],
+          "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$",
+          "order": 1,
+          "format": "date-time"
+        },
+        "project_type": {
+          "type": "string",
+          "title": "Project Type",
+          "description": "The type of Iterable project, which determines how users are uniquely identified. See https://support.iterable.com/hc/en-us/articles/9216719179796-Project-Types-and-Unique-Identifiers for more information.",
+          "enum": [
+            "Email-based",
+            "UserID-based",
+            "Hybrid"
+          ],
+          "default": "UserID-based",
+          "order": 2
+        }
+      }
     },
-    "documentationUrl": "https://go.estuary.dev/FRCv4k",
-    "protocol": 3032023,
     "resourceConfigSchema": {
-      "additionalProperties": false,
+      "title": "ResourceConfig",
       "description": "ResourceConfig encodes a configured resource stream",
+      "type": "object",
       "properties": {
         "_meta": {
           "title": "Meta",
           "type": "object"
         },
-        "cursorField": {
-          "items": {
-            "type": "string"
-          },
-          "title": "Cursor Field",
-          "type": "array"
-        },
-        "namespace": {
-          "description": "Enclosing schema namespace of this resource",
-          "title": "Namespace",
-          "type": "string"
-        },
         "stream": {
-          "description": "Name of this stream",
           "title": "Stream",
+          "description": "Name of this stream",
           "type": "string"
         },
         "syncMode": {
+          "title": "Sync Mode",
           "description": "Sync this resource incrementally, or fully refresh it every run",
           "enum": [
             "full_refresh",
             "incremental"
           ],
-          "title": "Sync Mode",
           "type": "string"
+        },
+        "namespace": {
+          "title": "Namespace",
+          "description": "Enclosing schema namespace of this resource",
+          "type": "string"
+        },
+        "cursorField": {
+          "title": "Cursor Field",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         }
       },
       "required": [
         "stream",
         "syncMode"
       ],
-      "title": "ResourceConfig",
-      "type": "object"
+      "additionalProperties": false
     },
+    "documentationUrl": "https://go.estuary.dev/FRCv4k",
     "resourcePathPointers": [
       "/namespace",
       "/stream"


### PR DESCRIPTION
**Description:**

Iterable supports three project types that determine how users are uniquely identified. See https://support.iterable.com/hc/en-us/articles/9216719179796:

- Email-based: `email` is the unique identifier
- UserID-based: `itblUserId` is the unique identifier
- Hybrid: `itblUserId` is the unique identifier

Previously, the `users` stream hardcoded `email` as the primary key, which is incorrect for UserID-based and Hybrid projects where users do not have to have an email address. Pre-existing captures won't have a `project_type` in their config, and the connector will maintain the current behavior for these captures by assuming an absent `project_type` means to use `email` as `users`' primary key.

Note: We use `itblUserId` (Iterable's internal identifier) instead of `userId` because `itblUserId` is always present on all user records for both Hybrid and UserId-based projects.
See https://support.iterable.com/hc/en-us/articles/217744303-User-Profile-Fields-Used-by-Iterable#itbluserid.

The spec snapshot change is expected due to the addition of the new `project_type` setting. See this [jsondiff](https://jsondiff.com/?left=https://raw.githubusercontent.com/estuary/connectors/e84b9a738bdb960cbfa111c93656d9e9e3e0094d/source-iterable/tests/snapshots/snapshots__spec__capture.stdout.json&right=https://raw.githubusercontent.com/estuary/connectors/4ef1aca2e9313671d11143281e5dcd4fb7a5f6e0/source-iterable/tests/snapshots/snapshots__spec__capture.stdout.json) for a cleaner diff than what GitHub's showing.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

Connector documentation should be updated to mention the new `project_type` config option.

**Notes for reviewers:**

Confirmed via `flowctl raw discover` that the primary key for the `users` resource changes depending on the configured `project_type` according to the bullet points in the above description.

