### PR TITLE
source-facebook-marketing-native: Remove ID field from full refresh models

### DIFF
--- a/source-facebook-marketing-native/source_facebook_marketing_native/models.py
+++ b/source-facebook-marketing-native/source_facebook_marketing_native/models.py
@@ -701,7 +701,6 @@ InsightsFetchChangesFn = Callable[
 
 class AdAccount(FacebookResource):
     name: ClassVar[str] = ResourceName.AD_ACCOUNT
-    primary_keys: ClassVar[list[str]] = ["/id"]
     endpoint: ClassVar[str] = ""
     fields: ClassVar[list[str]] = [
         F.ID,
@@ -759,8 +758,6 @@ class AdAccount(FacebookResource):
         F.USER_TOS_ACCEPTED,
     ]
 
-    id: str
-
     @classmethod
     def sourced_schema(cls) -> dict[str, Any]:
         """Return explicit sourced schema matching legacy connector format."""
@@ -769,7 +766,6 @@ class AdAccount(FacebookResource):
 
 class AdCreative(FacebookResource):
     name: ClassVar[str] = ResourceName.AD_CREATIVES
-    primary_keys: ClassVar[list[str]] = ["/id"]
     endpoint: ClassVar[str] = "adcreatives"
     fields: ClassVar[list[str]] = [
         F.ID,
@@ -807,8 +803,6 @@ class AdCreative(FacebookResource):
         F.VIDEO_ID,
     ]
 
-    id: str
-
     @classmethod
     def sourced_schema(cls) -> dict[str, Any]:
         """Return explicit sourced schema matching legacy connector format."""
@@ -817,7 +811,6 @@ class AdCreative(FacebookResource):
 
 class CustomConversions(FacebookResource):
     name: ClassVar[str] = ResourceName.CUSTOM_CONVERSIONS
-    primary_keys: ClassVar[list[str]] = ["/id"]
     endpoint: ClassVar[str] = "customconversions"
     fields: ClassVar[list[str]] = [
         F.ID,
@@ -838,8 +831,6 @@ class CustomConversions(FacebookResource):
         F.RETENTION_DAYS,
         F.RULE,
     ]
-
-    id: str
 
 
 class Campaigns(FacebookResource):

--- a/source-facebook-marketing-native/source_facebook_marketing_native/resources.py
+++ b/source-facebook-marketing-native/source_facebook_marketing_native/resources.py
@@ -5,6 +5,7 @@ from copy import deepcopy
 from typing import Callable
 
 from estuary_cdk.capture.common import (
+    BaseDocument,
     Resource,
     ResourceState,
     open_binding,
@@ -298,13 +299,13 @@ def full_refresh_resource(
             state,
             task,
             fetch_snapshot=snapshot_fn,
-            tombstone=FacebookResource(_meta=FacebookResource.Meta(op="d")),
+            tombstone=BaseDocument(_meta=BaseDocument.Meta(op="d")),
         )
 
     return Resource(
         name=model.name,
         key=["/_meta/row_id"],
-        model=model,
+        model=BaseDocument,
         open=functools.partial(
             open,
             snapshot_fn=functools.partial(

--- a/source-facebook-marketing-native/tests/e2e/snapshots/snapshots__discover__capture.stdout.json
+++ b/source-facebook-marketing-native/tests/e2e/snapshots/snapshots__discover__capture.stdout.json
@@ -110,21 +110,13 @@
           "type": "object"
         }
       },
-      "additionalProperties": true,
       "properties": {
         "_meta": {
           "$ref": "#/$defs/Meta",
           "description": "Document metadata"
-        },
-        "id": {
-          "title": "Id",
-          "type": "string"
         }
       },
-      "required": [
-        "id"
-      ],
-      "title": "AdAccount",
+      "title": "BaseDocument",
       "type": "object",
       "x-infer-schema": true
     },
@@ -164,21 +156,13 @@
           "type": "object"
         }
       },
-      "additionalProperties": true,
       "properties": {
         "_meta": {
           "$ref": "#/$defs/Meta",
           "description": "Document metadata"
-        },
-        "id": {
-          "title": "Id",
-          "type": "string"
         }
       },
-      "required": [
-        "id"
-      ],
-      "title": "AdCreative",
+      "title": "BaseDocument",
       "type": "object",
       "x-infer-schema": true
     },
@@ -892,21 +876,13 @@
           "type": "object"
         }
       },
-      "additionalProperties": true,
       "properties": {
         "_meta": {
           "$ref": "#/$defs/Meta",
           "description": "Document metadata"
-        },
-        "id": {
-          "title": "Id",
-          "type": "string"
         }
       },
-      "required": [
-        "id"
-      ],
-      "title": "CustomConversions",
+      "title": "BaseDocument",
       "type": "object",
       "x-infer-schema": true
     },


### PR DESCRIPTION
**Description:**

This PR addresses a validation issue that pops up in full refresh streams due to the `id` field being required on these collections. The CDK infers deletions and only includes `_meta` in deleted documents, `id` isn't always present & triggers a schema violation error.

The `id` is not used anywhere in the code and was an artifact of copying Primary Keys from the imported Airbyte connector when developing this Native version.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

