### PR TITLE
source-iterable: handle `ChunkedEncodingError` for `users` stream

### DIFF
--- a/source-iterable/source_iterable/streams.py
+++ b/source-iterable/source_iterable/streams.py
@@ -813,7 +813,7 @@ class Templates(IterableExportStreamRanged):
             yield record
 
 
-class Users(IterableExportStreamRanged):
+class Users(IterableExportStreamAdjustableRange):
     data_field = "user"
     cursor_field = "profileUpdatedAt"
 


### PR DESCRIPTION
**Description:**

The `users` stream was failing with `ChunkedEncodingError: Response ended prematurely`. `users` didn't have any handling for this error, so it ended up crashing.

We could have `users` inherit from `IterableExportStreamAdjustableRange` instead of `InterableExportStreamRanged` & automatically get some handling for `ChunkedEncodingError`s that reduces the date range we request whenever we get those errors. This PR does just that.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

