### PR TITLE
source-facebook-marketing-native: remove special handling for `business_management` permission in filtered fields

### DIFF
--- a/source-facebook-marketing-native/source_facebook_marketing_native/permissions.py
+++ b/source-facebook-marketing-native/source_facebook_marketing_native/permissions.py
@@ -137,12 +137,6 @@ class PermissionManager:
                 )
 
                 match field_requirements:
-                    case ResourcePermissionRequirement() if (
-                        "business_management" in field_requirements.required_permissions
-                    ):
-                        # For business_management, we'll handle this in the API client with error handling
-                        # Include the field for now and let the API client handle the error
-                        filtered_fields.append(field)
                     case ResourcePermissionRequirement():
                         has_required_permissions = any(
                             perm in user_permissions


### PR DESCRIPTION
**Description:**

Removes special handling for `business_management` permission in filtered fields. Was incorrectly adding `owner` to fields for requested in `ad_account` stream even though the permissions clearly would prevent that.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

