### PR TITLE
source-s3: fix deprecated syntax for anon buckets

### DIFF
--- a/source-s3/main.go
+++ b/source-s3/main.go
@@ -127,15 +127,10 @@ func (c config) Validate() error {
 		return fmt.Errorf("missing region")
 	}
 
-	if c.Credentials == nil {
-		if c.AWSAccessKeyID == "" {
-			return errors.New("missing 'awsAccessKeyId'")
+	if c.Credentials != nil {
+		if err := c.Credentials.Validate(); err != nil {
+			return err
 		}
-		if c.AWSSecretAccessKey == "" {
-			return errors.New("missing 'awsSecretAccessKey'")
-		}
-	} else if err := c.Credentials.Validate(); err != nil {
-		return err
 	}
 
 	return nil


### PR DESCRIPTION
**Description:**

In a4f91564a backwards compatibility with the old anonymous credentials format was broken.  Unlike other IAM connectors having no credentials is allowed.

**Workflow steps:**

No changes

**Documentation links affected:**

None

**Notes for reviewers:**

(anything that might help someone review this PR)

