### PR TITLE
materialize-motherduck: add max object size to store delete query

### DIFF
--- a/materialize-motherduck/.snapshots/TestSQLGeneration
+++ b/materialize-motherduck/.snapshots/TestSQLGeneration
@@ -106,6 +106,7 @@ USING read_json(
 	['s3://bucket/file1', 's3://bucket/file2'],
 	format='newline_delimited',
 	compression='gzip',
+	maximum_object_size=67108864,
 	columns={
 		key1: 'BIGINT NOT NULL',
 		key2: 'BOOLEAN NOT NULL',

--- a/materialize-motherduck/sqlgen.go
+++ b/materialize-motherduck/sqlgen.go
@@ -189,6 +189,7 @@ USING read_json(
 	],
 	format='newline_delimited',
 	compression='gzip',
+	maximum_object_size=` + strconv.FormatUint(MAX_OBJECT_BYTES, 10) + `,
 	columns={
 	{{- range $ind, $col := $.Columns }}
 		{{- if $ind }},{{ end }}


### PR DESCRIPTION
**Description:**

If this value is too small then motherduck may produce an error, the current default size is 16MiB.  Since our documents can be up to 64MiB we increase this value to make sure all objects can be read.

**Workflow steps:**

No changes

**Documentation links affected:**

None

**Notes for reviewers:**
