### PR TITLE
source-google-ads: dynamically determine when c...

### DIFF
--- a/source-google-ads/source_google_ads/source.py
+++ b/source-google-ads/source_google_ads/source.py
@@ -33,23 +33,14 @@ from .streams import (
     ClickView,
     DisplayKeywordPerformanceReport,
     DisplayTopicsPerformanceReport,
-    GeoTargetConstant,
     GeographicReport,
+    GeoTargetConstant,
     KeywordReport,
     ServiceAccounts,
     ShoppingPerformanceReport,
     UserLocationReport,
 )
 from .utils import GAQL
-
-FULL_REFRESH_CUSTOM_TABLE = [
-    "ad_group_criterion",
-    "asset",
-    "asset_group_listing_group_filter",
-    "call_view",
-    "custom_audience",
-    "geo_target_constant",
-]
 
 
 class SourceGoogleAds(AbstractSource):
@@ -133,7 +124,7 @@ class SourceGoogleAds(AbstractSource):
                             f"Metrics are not available for manager account {customer.id}. "
                             f"Please remove metrics fields in your custom query: {query}."
                         )
-                    if query.resource_name not in FULL_REFRESH_CUSTOM_TABLE:
+                    if not google_api.is_full_refresh_resource(query.resource_name):
                         query = IncrementalCustomQuery.insert_segments_date_expr(
                             query, "1980-01-01", "1980-01-01"
                         )
@@ -205,7 +196,7 @@ class SourceGoogleAds(AbstractSource):
             query = single_query_config["query"]
             if self.is_metrics_in_custom_query(query):
                 if non_manager_accounts:
-                    if query.resource_name in FULL_REFRESH_CUSTOM_TABLE:
+                    if google_api.is_full_refresh_resource(query.resource_name):
                         streams.append(
                             CustomQuery(
                                 config=single_query_config,
@@ -221,7 +212,7 @@ class SourceGoogleAds(AbstractSource):
                             )
                         )
                 continue
-            if query.resource_name in FULL_REFRESH_CUSTOM_TABLE:
+            if google_api.is_full_refresh_resource(query.resource_name):
                 streams.append(
                     CustomQuery(
                         config=single_query_config, api=google_api, customers=customers

--- a/source-google-ads/tests/test_source.py
+++ b/source-google-ads/tests/test_source.py
@@ -33,6 +33,13 @@ from .common import (
 )
 
 
+@pytest.fixture(autouse=True)
+def mock_is_full_refresh_resource(mocker):
+    # Mock is_full_refresh_resource to avoid real API calls in tests
+    # Returns False by default (incremental), matching most resources
+    mocker.patch.object(GoogleAds, "is_full_refresh_resource", return_value=False)
+
+
 @pytest.fixture
 def mock_account_info(mocker):
     mocker.patch(


### PR DESCRIPTION
ustom queries require full refresh streams.

**Description:**

This PR solves the problem of having to maintain our hardcoded allowlist of custom full refresh streams (`FULL_REFRESH_CUSTOM_TABLE`) by replacing it with an automated discovery method. `GoogleAds.is_full_refresh_resource()` queries the API for the presence of `segments.date` to decide whether a resource referenced in a custom query should be incremental or full refresh. 

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

