### PR TITLE
estuary-cdk: make `Task.checkpoint` async to improve capture concurrency

### DIFF
--- a/estuary-cdk/estuary_cdk/capture/_emit.py
+++ b/estuary-cdk/estuary_cdk/capture/_emit.py
@@ -1,0 +1,26 @@
+import asyncio
+import shutil
+from typing import BinaryIO
+
+# Global lock for serializing all emissions to stdout and prevent interleaving output.
+_emit_lock = asyncio.Lock()
+
+
+async def emit_bytes(data: bytes, output: BinaryIO) -> None:
+    async with _emit_lock:
+        await asyncio.to_thread(_write_bytes, data, output)
+
+
+async def emit_from_buffer(buffer: BinaryIO, output: BinaryIO) -> None:
+    async with _emit_lock:
+        await asyncio.to_thread(_copy_buffer, buffer, output)
+
+
+def _write_bytes(data: bytes, output: BinaryIO) -> None:
+    output.write(data)
+    output.flush()
+
+
+def _copy_buffer(buffer: BinaryIO, output: BinaryIO) -> None:
+    shutil.copyfileobj(buffer, output)
+    output.flush()

--- a/estuary-cdk/estuary_cdk/shim_airbyte_cdk.py
+++ b/estuary-cdk/estuary_cdk/shim_airbyte_cdk.py
@@ -375,7 +375,7 @@ class CaptureShim(BaseCaptureConnector):
                     binding_index=binding_idx,
                     schema=schema,
                 )
-                task.checkpoint(state=ConnectorState())
+                await task.checkpoint(state=ConnectorState())
 
         airbyte_catalog = ConfiguredAirbyteCatalog(streams=airbyte_streams)
 
@@ -462,7 +462,7 @@ class CaptureShim(BaseCaptureConnector):
 
                 entry[1].state = state_msg.dict()
 
-                task.checkpoint(connector_state, merge_patch=False)
+                await task.checkpoint(connector_state, merge_patch=False)
 
             elif trace := message.trace:
                 if error := trace.error:
@@ -517,5 +517,5 @@ class CaptureShim(BaseCaptureConnector):
 
         # Emit a final checkpoint before exiting.
         task.log.info("Emitting final checkpoint for sweep.")
-        task.checkpoint(connector_state, merge_patch=False)
+        await task.checkpoint(connector_state, merge_patch=False)
         return None

--- a/source-apple-app-store/source_apple_app_store/resources.py
+++ b/source-apple-app-store/source_apple_app_store/resources.py
@@ -76,7 +76,7 @@ def _create_initial_state(app_ids: list[str]) -> ResourceState:
     return initial_state
 
 
-def _reconcile_connector_state(
+async def _reconcile_connector_state(
     app_ids: list[str],
     binding: CaptureBinding[ResourceConfig],
     state: ResourceState,
@@ -109,7 +109,7 @@ def _reconcile_connector_state(
             task.log.info(
                 f"Checkpointing state to ensure any new state is persisted for {binding.stateKey}."
             )
-            task.checkpoint(
+            await task.checkpoint(
                 ConnectorState(
                     bindingStateV1={binding.stateKey: state},
                 )
@@ -130,7 +130,7 @@ async def analytics_resources(
 
     initial_state = _create_initial_state(app_ids)
 
-    def open(
+    async def open(
         model: type[AppleAnalyticsRow],
         binding: CaptureBinding[ResourceConfig],
         binding_index: int,
@@ -155,7 +155,7 @@ async def analytics_resources(
                 model,
             )
 
-        _reconcile_connector_state(app_ids, binding, state, initial_state, task)
+        await _reconcile_connector_state(app_ids, binding, state, initial_state, task)
 
         open_binding(
             binding,
@@ -194,7 +194,7 @@ async def api_resources(
 
     initial_state = _create_initial_state(app_ids)
 
-    def open(
+    async def open(
         app_ids: list[str],
         fetch_changes_fn: ApiFetchChangesFn,
         fetch_page_fn: ApiFetchPageFn,
@@ -219,7 +219,7 @@ async def api_resources(
                 app_id,
             )
 
-        _reconcile_connector_state(app_ids, binding, state, initial_state, task)
+        await _reconcile_connector_state(app_ids, binding, state, initial_state, task)
 
         open_binding(
             binding,

--- a/source-jira-native/source_jira_native/resources.py
+++ b/source-jira-native/source_jira_native/resources.py
@@ -338,7 +338,7 @@ def issues(
         log: Logger, http: HTTPMixin, config: EndpointConfig, timezone: ZoneInfo
 ) -> common.Resource:
 
-    def open(
+    async def open(
         binding: CaptureBinding[ResourceConfig],
         binding_index: int,
         state: ResourceState,
@@ -355,7 +355,7 @@ def issues(
             }
             state.inc = migrated_inc_state
 
-            task.checkpoint(
+            await task.checkpoint(
                 ConnectorState(
                     bindingStateV1={binding.stateKey: state}
                 ),
@@ -421,7 +421,7 @@ def issue_child_resources(
         log: Logger, http: HTTPMixin, config: EndpointConfig, timezone: ZoneInfo
 ) -> list[common.Resource]:
 
-    def open(
+    async def open(
         stream: type[IssueChildStream],
         binding: CaptureBinding[ResourceConfig],
         binding_index: int,
@@ -439,7 +439,7 @@ def issue_child_resources(
             }
             state.inc = migrated_inc_state
 
-            task.checkpoint(
+            await task.checkpoint(
                 ConnectorState(
                     bindingStateV1={binding.stateKey: state}
                 ),

--- a/source-sage-intacct/source_sage_intacct/resources.py
+++ b/source-sage-intacct/source_sage_intacct/resources.py
@@ -55,7 +55,7 @@ async def incremental_resource(
 ) -> common.Resource:
     model = await sage.get_model(obj)
 
-    def open(
+    async def open(
         binding: CaptureBinding[ResourceConfig],
         binding_index: int,
         state: ResourceState,
@@ -63,7 +63,7 @@ async def incremental_resource(
         all_bindings,
     ):
         task.sourced_schema(binding_index, model.sourced_schema())
-        task.checkpoint(state=ConnectorState())
+        await task.checkpoint(state=ConnectorState())
 
         common.open_binding(
             binding,
@@ -125,7 +125,7 @@ async def incremental_resource(
 async def snapshot_resource(sage: Sage, obj: str) -> common.Resource:
     model = await sage.get_model(obj)
 
-    def open(
+    async def open(
         obj: str,
         binding: CaptureBinding[ResourceConfig],
         binding_index: int,
@@ -134,7 +134,7 @@ async def snapshot_resource(sage: Sage, obj: str) -> common.Resource:
         all_bindings,
     ):
         task.sourced_schema(binding_index, model.sourced_schema())
-        task.checkpoint(state=ConnectorState())
+        await task.checkpoint(state=ConnectorState())
 
         common.open_binding(
             binding,

--- a/source-salesforce-native/source_salesforce_native/resources.py
+++ b/source-salesforce-native/source_salesforce_native/resources.py
@@ -74,7 +74,7 @@ def full_refresh_resource(
     enable: bool,
 ) -> common.Resource:
 
-    def open(
+    async def open(
         binding: CaptureBinding[SalesforceResourceConfigWithSchedule],
         binding_index: int,
         state: ResourceState,
@@ -89,7 +89,7 @@ def full_refresh_resource(
         model_cls = create_salesforce_model(name, fields)
 
         task.sourced_schema(binding_index, model_cls.sourced_schema())
-        task.checkpoint(state=ConnectorState())
+        await task.checkpoint(state=ConnectorState())
 
         common.open_binding(
             binding,
@@ -137,7 +137,7 @@ def incremental_resource(
     enable: bool,
 ) -> common.Resource:
 
-    def open(
+    async def open(
         binding: CaptureBinding[SalesforceResourceConfigWithSchedule],
         binding_index: int,
         state: ResourceState,
@@ -152,7 +152,7 @@ def incremental_resource(
         model_cls = create_salesforce_model(name, fields)
 
         task.sourced_schema(binding_index, model_cls.sourced_schema())
-        task.checkpoint(state=ConnectorState())
+        await task.checkpoint(state=ConnectorState())
 
         common.open_binding(
             binding,

--- a/source-stripe-native/source_stripe_native/priority_capture.py
+++ b/source-stripe-native/source_stripe_native/priority_capture.py
@@ -564,7 +564,7 @@ async def _binding_incremental_task_with_work_item(
                     "incremental task triggered backfill", {"subtask_id": work_item.account_id}
                 )
                 task.stopping.event.set()
-                task.checkpoint(
+                await task.checkpoint(
                     ConnectorState(backfillRequests={binding.stateKey: True})
                 )
                 return
@@ -593,7 +593,7 @@ async def _binding_incremental_task_with_work_item(
                     )
 
                 state.cursor = item
-                task.checkpoint(connector_state)
+                await task.checkpoint(connector_state)
                 checkpoints += 1
                 pending = False
 
@@ -684,13 +684,13 @@ async def _binding_backfill_task_with_work_item(
                 )
             else:
                 state.next_page = item
-                task.checkpoint(connector_state)
+                await task.checkpoint(connector_state)
                 done = False
 
         if done:
             break
 
-    task.checkpoint(
+    await task.checkpoint(
         ConnectorState(
             bindingStateV1={
                 binding.stateKey: ResourceState(backfill={work_item.account_id: None})

--- a/source-stripe-native/source_stripe_native/resources.py
+++ b/source-stripe-native/source_stripe_native/resources.py
@@ -105,7 +105,7 @@ async def _fetch_platform_account_id(
     return platform_account.id
 
 
-def _reconcile_connector_state(
+async def _reconcile_connector_state(
     account_ids: list[str],
     binding: CaptureBinding[ResourceConfig],
     state: ResourceState,
@@ -146,7 +146,7 @@ def _reconcile_connector_state(
             task.log.info(
                 f"Checkpointing state to ensure any new state is persisted for {binding.stateKey}."
             )
-            task.checkpoint(
+            await task.checkpoint(
                 ConnectorState(
                     bindingStateV1={binding.stateKey: state},
                 )
@@ -325,7 +325,7 @@ def base_object(
     It requires a single, parent stream with a valid Event API Type
     """
 
-    def open(
+    async def open(
         binding: CaptureBinding[ResourceConfig],
         binding_index: int,
         state: ResourceState,
@@ -357,7 +357,7 @@ def base_object(
                 fetch_page=fetch_page_fns,
             )
         else:
-            _reconcile_connector_state(
+            await _reconcile_connector_state(
                 all_account_ids, binding, state, initial_state, task
             )
 
@@ -416,7 +416,7 @@ def child_object(
     a valid Event API Type
     """
 
-    def open(
+    async def open(
         binding: CaptureBinding[ResourceConfig],
         binding_index: int,
         state: ResourceState,
@@ -450,7 +450,7 @@ def child_object(
                 fetch_page=fetch_page_fns,
             )
         else:
-            _reconcile_connector_state(
+            await _reconcile_connector_state(
                 all_account_ids, binding, state, initial_state, task
             )
 
@@ -515,7 +515,7 @@ def split_child_object(
     in the API response. Meaning, the stream behaves like a non-chid stream incrementally.
     """
 
-    def open(
+    async def open(
         binding: CaptureBinding[ResourceConfig],
         binding_index: int,
         state: ResourceState,
@@ -548,7 +548,7 @@ def split_child_object(
                 fetch_page=fetch_page_fns,
             )
         else:
-            _reconcile_connector_state(
+            await _reconcile_connector_state(
                 all_account_ids, binding, state, initial_state, task
             )
 
@@ -611,7 +611,7 @@ def usage_records(
     and requires special processing.
     """
 
-    def open(
+    async def open(
         binding: CaptureBinding[ResourceConfig],
         binding_index: int,
         state: ResourceState,
@@ -645,7 +645,7 @@ def usage_records(
                 fetch_page=fetch_page_fns,
             )
         else:
-            _reconcile_connector_state(
+            await _reconcile_connector_state(
                 all_account_ids, binding, state, initial_state, task
             )
 
@@ -708,7 +708,7 @@ def no_events_object(
     It works very similar to the base object, but without the use of the Events APi.
     """
 
-    def open(
+    async def open(
         binding: CaptureBinding[ResourceConfig],
         binding_index: int,
         state: ResourceState,
@@ -740,7 +740,7 @@ def no_events_object(
                 fetch_page=fetch_page_fns,
             )
         else:
-            _reconcile_connector_state(
+            await _reconcile_connector_state(
                 all_account_ids, binding, state, initial_state, task
             )
 


### PR DESCRIPTION
**Description:**

When multiple tasks run concurrently in a CDK-based capture, the synchronous `Task.checkpoint()` method blocks the entire `asyncio` event loop while writing buffered documents to stdout. This means when one task flushes a large buffer, all other tasks are blocked from fetching data, processing rows, or building up their own document buffers.

We can make `Task.checkpoint` async in order to improve concurrency. Blocking I/O when flushing a buffer is run with `asyncio.to_thread`, freeing the main event loop to run other coroutines while a buffer is being flushed. A module-level `asyncio.Lock` is used to serialize emissions to stdout. This prevents documents and checkpoints from being interleaved or corrupted between tasks trying to flush their buffers.

With this change, while one task holds the lock and emits its buffer, other tasks can continue fetching data from the API, process/parse responses, and capture documents to build up their own buffers. When the emitting task releases the lock, another waiting task can begin flushing its buffer.

This commit makes `Task.checkpoint()` async, which is a breaking change. All connectors calling `Task.checkpoint` must now await it. The connectors in the `connectors` repo affected by this are updated in this commit as well.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

Tested on a local stack. Confirmed `Task.checkpoint` no longer blocks the `asyncio` event loop.

Note: I also made `BaseCaptureConnector.checkpoint` and `BaseCaptureConnector._emit` async as well and made them use the same `asyncio.Lock` to ensure they don't emit to `stdout` at the same time as any `Task`s. Right now, that won't ever happen because `BaseCaptureConnector._emit` is only called before `Task` creation, but it's a good future-proofing idea to ensure `stdout` is behind a lock no matter who's writing to it.

