### PR TITLE
source-shopify-native: Support up to 5 concurrent bulk jobs versus 1

### DIFF
--- a/source-shopify-native/source_shopify_native/graphql/common.py
+++ b/source-shopify-native/source_shopify_native/graphql/common.py
@@ -1,7 +1,7 @@
 from datetime import datetime, timedelta
 
 DATETIME_STRING_FORMAT = "%Y-%m-%dT%H:%M:%SZ"
-VERSION = "2025-04"
+VERSION = "2026-01"
 
 
 def dt_to_str(dt: datetime) -> str:

--- a/source-shopify-native/source_shopify_native/models.py
+++ b/source-shopify-native/source_shopify_native/models.py
@@ -124,8 +124,10 @@ class EndpointConfig(BaseModel):
 ConnectorState = GenericConnectorState[ResourceState]
 
 
-T = TypeVar('T')
-TShopifyGraphQLResource = TypeVar('TShopifyGraphQLResource', bound='ShopifyGraphQLResource')
+T = TypeVar("T")
+TShopifyGraphQLResource = TypeVar(
+    "TShopifyGraphQLResource", bound="ShopifyGraphQLResource"
+)
 
 
 class GraphQLErrorCode(StrEnum):
@@ -235,14 +237,22 @@ class BulkSpecificData(BaseModel, extra="forbid"):
     node: BulkOperationDetails
 
 
+class BulkOperationEdge(BaseModel, extra="forbid"):
+    node: BulkOperationDetails
+
+
+class BulkOperationsConnection(BaseModel, extra="forbid"):
+    edges: list[BulkOperationEdge]
+
+
+class BulkOperationsData(BaseModel, extra="forbid"):
+    """Response model for the bulkOperations query (API 2026-01+)."""
+
+    bulkOperations: BulkOperationsConnection
+
+
 class BulkSubmitData(BaseModel, extra="forbid"):
     bulkOperationRunQuery: BulkOperationRunQuery
-
-
-BulkJobCancelResponse = GraphQLResponse[BulkCancelData]
-BulkCurrentJobResponse = GraphQLResponse[BulkCurrentData]  
-BulkSpecificJobResponse = GraphQLResponse[BulkSpecificData]
-BulkJobSubmitResponse = GraphQLResponse[BulkSubmitData]
 
 
 # Names of Shopify plan types. Some plan types do not have access

--- a/source-shopify-native/source_shopify_native/resources.py
+++ b/source-shopify-native/source_shopify_native/resources.py
@@ -240,7 +240,7 @@ async def validate_credentials(log: Logger, http: HTTPMixin, config: EndpointCon
     bulk_job_manager = gql.bulk_job_manager.BulkJobManager(client, log)
 
     try:
-        await bulk_job_manager._get_currently_running_job()
+        await bulk_job_manager._get_running_jobs()
     except HTTPError as err:
         msg = "Unknown error occurred."
         if err.code == 401:


### PR DESCRIPTION
**Description:**

Shopify API now supports 5 concurrent bulk jobs per Shopify store in their latest API versions. This commit bumps the API version to `2026-01` and updates the bulk job manager to handle the query changes, submission, tracking, and cancellation of up to 5 concurrent jobs.

Notes:
- On startup the connector will query for all running jobs and cancel all of them before continuing.
- The `groupObjects` in the `bulkOperationRunQuery` was changed to have a default of `false` instead of `true`. This controls whether nested objects are grouped with their parent.
  - I tested setting this to `true` and `false` and setting to `true` keeps the emitted documents the same as they were. Setting to `false` did not - there were some small differences.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

Documentation updated here: https://github.com/estuary/flow/pull/2611

**Notes for reviewers:**

Tested on a local stack and verified that the documents captured in our test account match exactly what we received before this update.
- Performance seems to be quite a bit better - so I expect backfills and likely incremental tasks to move much quicker than before for large accounts. Not sure that will be an actual `5x` improvement or not, but should be a significant improvement for some.

