### PR TITLE
source-zendesk-support-native: add CustomTicketStatuses

### DIFF
--- a/source-zendesk-support-native/source_zendesk_support_native/models.py
+++ b/source-zendesk-support-native/source_zendesk_support_native/models.py
@@ -264,9 +264,15 @@ class FullRefreshCursorPaginatedResponse(FullRefreshResponse):
 class TagsResponse(FullRefreshCursorPaginatedResponse):
     resources: list[FullRefreshResource] = Field(alias="tags")
 
+
+class CustomTicketStatusesResponse(FullRefreshCursorPaginatedResponse):
+    resources: list[FullRefreshResource] = Field(alias="custom_statuses")
+
+
 # Full refresh resources that are paginated through with a cursor.
 # Tuples contain the name, path, and response model for each resource.
 FULL_REFRESH_CURSOR_PAGINATED_RESOURCES: list[tuple[str, str, type[FullRefreshCursorPaginatedResponse]]] = [
+    ("custom_ticket_statuses", "custom_statuses", CustomTicketStatusesResponse),
     ("tags", "tags", TagsResponse),
 ]
 

--- a/source-zendesk-support-native/tests/snapshots/snapshots__discover__capture.stdout.json
+++ b/source-zendesk-support-native/tests/snapshots/snapshots__discover__capture.stdout.json
@@ -407,6 +407,53 @@
     ]
   },
   {
+    "recommendedName": "custom_ticket_statuses",
+    "resourceConfig": {
+      "name": "custom_ticket_statuses",
+      "interval": "PT1H"
+    },
+    "documentSchema": {
+      "$defs": {
+        "Meta": {
+          "properties": {
+            "op": {
+              "default": "u",
+              "description": "Operation type (c: Create, u: Update, d: Delete)",
+              "enum": [
+                "c",
+                "u",
+                "d"
+              ],
+              "title": "Op",
+              "type": "string"
+            },
+            "row_id": {
+              "default": -1,
+              "description": "Row ID of the Document, counting up from zero, or -1 if not known",
+              "title": "Row Id",
+              "type": "integer"
+            }
+          },
+          "title": "Meta",
+          "type": "object"
+        }
+      },
+      "additionalProperties": true,
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/Meta",
+          "description": "Document metadata"
+        }
+      },
+      "title": "FullRefreshResource",
+      "type": "object",
+      "x-infer-schema": true
+    },
+    "key": [
+      "/_meta/row_id"
+    ]
+  },
+  {
     "recommendedName": "group_memberships",
     "resourceConfig": {
       "name": "group_memberships",


### PR DESCRIPTION
**Description:**

Added support for the Custom Ticket Statuses endpoint (`/api/v2/custom_statuses`) to the Zendesk Support Native connector.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

- Added `CustomTicketStatusesResponse` model to `models.py`
- Registered the new stream in `FULL_REFRESH_CURSOR_PAGINATED_RESOURCES` tuple

**Notes for reviewers:**

(anything that might help someone review this PR)

