### PR TITLE
source-google-ads: allow users to force snapsho...

### DIFF
--- a/source-google-ads/acmeCo/flow.yaml
+++ b/source-google-ads/acmeCo/flow.yaml
@@ -179,6 +179,7 @@ collections:
     schema: my_custom_query.schema.yaml
     key:
     - /customer.id
+    - /segments.date
   acmeCo/shopping_performance_report:
     schema: shopping_performance_report.schema.yaml
     key:

--- a/source-google-ads/connector_config.yaml
+++ b/source-google-ads/connector_config.yaml
@@ -8,19 +8,14 @@ customer_id: "6458773721"
 start_date: "2022-01-01"
 custom_queries:
     - query: SELECT segments.ad_destination_type, segments.ad_network_type, segments.day_of_week, customer.auto_tagging_enabled, customer.id, metrics.conversions, campaign.start_date FROM campaign
-      primary_key: customer.id
+      primary_key: customer.id, segments.date
       table_name: my_custom_query
 sops:
-    kms: []
     gcp_kms:
         - resource_id: projects/estuary-theatre/locations/us-central1/keyRings/connector-keyring/cryptoKeys/connector-repository
           created_at: "2024-02-01T15:11:34Z"
           enc: CiQAdmEdwpewZLDvu80ySB31XOaRpBuQ5twOS4zpydRmn3imRsQSSQCVvC1zm2KgUypWm0F//eD1yeScHf7y/TMYBC5tqXHiK6Qy4eb7deyHVe5dO5rYenWveJzy7enCAhxAxk9N7RHXUjK89lsgn6E=
-    azure_kv: []
-    hc_vault: []
-    age: []
-    lastmodified: "2025-06-11T20:26:18Z"
-    mac: ENC[AES256_GCM,data:ib9b0KKu+2DAQNWCkMo9PbKvy7Rb96nQptk/TvGNAK9RzXuC77zZoAaZtmz9w68M33f128e+6o8XQYXo5K3uA69YUPhU2LpdncQprKjklZIpuKVt5DoUPAoFRAFXqrXu/g53OqCnqOYce3BPAmpDQ55DViRzcH9Vds7/qzvVxqM=,iv:8qMqKbPhk2tmnwlrubW32WAb5eLmHWKjENcnfA7XtlI=,tag:yEVCxLdJ8Ar304phxFsyoA==,type:str]
-    pgp: []
+    lastmodified: "2026-01-14T13:58:33Z"
+    mac: ENC[AES256_GCM,data:GiT6SFgCK/IW110/M/AUcDW5VQLW6Q09EaBbsDby5Jj4NHPMt7YdWxl/0MpqwVkS7BZxPUIO/y2GUcV/TmqIY7rFqa4Ej8FPyo+l/pn3PaRJULY3hgkrHOYjlPr63dR32uc/s51NcNY5W2JTSkihXpx22xBWrmIu9a5K+Nbh6cs=,iv:CHXNv1niaix6YYdNfFMP3VGFV+0uOKMeAsQlifOQ3ao=,tag:u6vD+lxBiXH7D4kk8/IKSQ==,type:str]
     encrypted_suffix: _sops
-    version: 3.9.0
+    version: 3.10.2

--- a/source-google-ads/tests/conftest.py
+++ b/source-google-ads/tests/conftest.py
@@ -21,7 +21,7 @@ def test_config():
         "custom_queries": [
             {
                 "query": "SELECT campaign.accessible_bidding_strategy, segments.ad_destination_type, campaign.start_date, campaign.end_date FROM campaign",
-                "primary_key": None,
+                "primary_key": "customer.id",
                 "cursor_field": "campaign.start_date",
                 "table_name": "happytable",
             },

--- a/source-google-ads/tests/snapshots/snapshots__discover__capture.stdout.json
+++ b/source-google-ads/tests/snapshots/snapshots__discover__capture.stdout.json
@@ -5521,7 +5521,8 @@
       "x-infer-schema": true
     },
     "key": [
-      "/customer.id"
+      "/customer.id",
+      "/segments.date"
     ]
   }
 ]


### PR DESCRIPTION
t streams on custom queries

**Description:**

This PR determines whether to turn a custom query into an incremental or snapshot stream by inspecting the granularity of the primary key. If `segments.date` is not present in the PK, it is assumed that it is meant to be a full refresh stream and aggregated data will be collected.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

Two custom queries were created:

```yaml
  custom_queries:
      - query: SELECT segments.ad_destination_type, segments.ad_network_type, segments.day_of_week, customer.auto_tagging_enabled, customer.id, metrics.conversions, campaign.start_date FROM campaign
        primary_key: customer.id,segments.date
        table_name: my_custom_query
      - query: SELECT segments.ad_destination_type, segments.ad_network_type, segments.day_of_week, customer.auto_tagging_enabled, customer.id, metrics.conversions, campaign.start_date FROM campaign
        primary_key: customer.id
        table_name: my_custom_query_snapshot
```

The former showed the usual incremental stream output, while the latter didn't feature `segments.date` references and kept a different entry for every permutation of all other segments.

**Backwards compatibility considerations:**

This PR would change the behaviour of any custom queries for tables whose schema contain `segments.date` but the field isn't referenced in the primary key. Only one such instance has been found in production and the case has been raised to @Alex-Bair 's attention.