### PR TITLE
build-local: update for Python CDK-based connectors

### DIFF
--- a/build-local.sh
+++ b/build-local.sh
@@ -1,33 +1,51 @@
 #!/bin/bash
-if [[ $# < 1 ]]; then
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+name="$1"
+
+if [[ -z "$name" ]]; then
     echo "This script builds \"<connector_name>:local\" images for testing."
-    echo "Usage: build-local.sh <connector_name> <Dockerfile>"
+    echo ""
+    echo "Usage: build-local.sh <connector-name> [Dockerfile]"
+    echo ""
+    echo "Example: build-local.sh source-salesforce-native"
     exit 1
 fi
 
-if [[ $1 == source-* ]]; 
-then
-  CONNECTOR_TYPE=capture
-elif [[ $1 == materialize-* ]];
-then
-  CONNECTOR_TYPE=materialization
+# Determine connector type from name prefix
+if [[ "$name" == source-* ]]; then
+    type="capture"
+elif [[ "$name" == materialize-* ]]; then
+    type="materialize"
+else
+    echo "Invalid argument. Must start with 'source-' or 'materialize-'."
+    exit 1
 fi
 
-if [ -z "$2" ]
-then
-  DOCKERFILE="$1"/Dockerfile
+# Detect Python vs Go/Rust connector and select Dockerfile
+if [[ -f "${SCRIPT_DIR}/${name}/pyproject.toml" ]]; then
+    # Python connector - use common Dockerfile
+    dockerfile="${SCRIPT_DIR}/estuary-cdk/common.Dockerfile"
 else
-  DOCKERFILE=$2
+    # Go connector - use connector-specific Dockerfile
+    if [[ -z "$2" ]]; then
+        dockerfile="${name}/Dockerfile"
+    else
+        dockerfile="$2"
+    fi
 fi
 
 docker buildx build \
-  --cache-to=type=local,dest=.docker-cache \
-  --cache-from=type=local,src=.docker-cache \
-  --platform linux/amd64 \
-  --build-arg CONNECTOR_NAME="$1" \
-  --build-arg CONNECTOR_TYPE="$CONNECTOR_TYPE" \
-  --build-arg="USAGE_RATE=1.0" \
-  --load \
-  -t ghcr.io/estuary/"$1":local \
-  -f "$DOCKERFILE" \
-  .
+    --cache-to=type=local,dest=.docker-cache \
+    --cache-from=type=local,src=.docker-cache \
+    --platform linux/amd64 \
+    --build-arg CONNECTOR_NAME="$name" \
+    --build-arg CONNECTOR_TYPE="$type" \
+    --build-arg="USAGE_RATE=1.0" \
+    --load \
+    -t "ghcr.io/estuary/${name}:local" \
+    -f "$dockerfile" \
+    .


### PR DESCRIPTION
**Description:**

We've been passing around a `build-local-python.sh` script in back alleys for building Python CDK-based connectors during development. That's not ideal; ~~it'd be better if the `build-local.sh` script worked for all connectors in the `connectors` repo, so I've updated the script to work for Go, Rust, and Python CDK-based connectors.~~

Edit: I was wrong, `build-local.sh` already worked for Python CDK-based connectors by specifying the `./estuary-cds/common.Dockerfile` as the second argument. It'd still be nice to not have to specify it when using `build-local.sh`, which will be the main improvement of this PR.

**Workflow steps:**

The way to use the `build-local.sh` script is the same as it was before: `./build-local.sh <connector-name> [Dockerfile]`

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

Confirmed the script works to build:
- `materialize-iceberg` (Go) and `source-kafka` (Rust) that have Dockerfiles located in the connector's directory
- `source-hubspot-native` (Python CDK-based) that uses the `estuary-cdk/common.Dockerfile` 

