### PR TITLE
source-zendesk-support-native: add calls and call_legs streams from Zendesk Talk

### DIFF
--- a/source-zendesk-support-native/acmeCo/call_legs.schema.yaml
+++ b/source-zendesk-support-native/acmeCo/call_legs.schema.yaml
@@ -1,0 +1,37 @@
+$defs:
+  Meta:
+    properties:
+      op:
+        default: u
+        description: 'Operation type (c: Create, u: Update, d: Delete)'
+        enum:
+        - c
+        - u
+        - d
+        title: Op
+        type: string
+      row_id:
+        default: -1
+        description: Row ID of the Document, counting up from zero, or -1 if not known
+        title: Row Id
+        type: integer
+    title: Meta
+    type: object
+additionalProperties: true
+properties:
+  _meta:
+    $ref: '#/$defs/Meta'
+    description: Document metadata
+  id:
+    title: Id
+    type: integer
+  updated_at:
+    format: date-time
+    title: Updated At
+    type: string
+required:
+- id
+- updated_at
+title: TimestampedResource
+type: object
+x-infer-schema: true

--- a/source-zendesk-support-native/acmeCo/calls.schema.yaml
+++ b/source-zendesk-support-native/acmeCo/calls.schema.yaml
@@ -1,0 +1,37 @@
+$defs:
+  Meta:
+    properties:
+      op:
+        default: u
+        description: 'Operation type (c: Create, u: Update, d: Delete)'
+        enum:
+        - c
+        - u
+        - d
+        title: Op
+        type: string
+      row_id:
+        default: -1
+        description: Row ID of the Document, counting up from zero, or -1 if not known
+        title: Row Id
+        type: integer
+    title: Meta
+    type: object
+additionalProperties: true
+properties:
+  _meta:
+    $ref: '#/$defs/Meta'
+    description: Document metadata
+  id:
+    title: Id
+    type: integer
+  updated_at:
+    format: date-time
+    title: Updated At
+    type: string
+required:
+- id
+- updated_at
+title: TimestampedResource
+type: object
+x-infer-schema: true

--- a/source-zendesk-support-native/acmeCo/flow.yaml
+++ b/source-zendesk-support-native/acmeCo/flow.yaml
@@ -19,6 +19,14 @@ collections:
     schema: brands.schema.yaml
     key:
     - /id
+  acmeCo/call_legs:
+    schema: call_legs.schema.yaml
+    key:
+    - /id
+  acmeCo/calls:
+    schema: calls.schema.yaml
+    key:
+    - /id
   acmeCo/categories:
     schema: categories.schema.yaml
     key:

--- a/source-zendesk-support-native/source_zendesk_support_native/models.py
+++ b/source-zendesk-support-native/source_zendesk_support_native/models.py
@@ -193,6 +193,29 @@ INCREMENTAL_TIME_EXPORT_RESOURCES: list[tuple[str, str, type[IncrementalTimeExpo
 ]
 
 
+class TalkIncrementalExportResponse(BaseModel, extra="allow"):
+    next_page: str | None
+    count: int
+    end_time: int | None
+    resources: list[TimestampedResource]
+
+
+class CallsResponse(TalkIncrementalExportResponse):
+    resources: list[TimestampedResource] = Field(alias="calls")
+
+
+class CallLegsResponse(TalkIncrementalExportResponse):
+    resources: list[TimestampedResource] = Field(alias="legs")
+
+
+# Talk API incremental export resources.
+# Tuples contain the name, path, and response model for each resource.
+TALK_INCREMENTAL_EXPORT_RESOURCES: list[tuple[str, str, type[TalkIncrementalExportResponse]]] = [
+    ("calls", "calls", CallsResponse),
+    ("call_legs", "legs", CallLegsResponse),
+]
+
+
 class IncrementalCursorExportResponse(BaseModel, extra="allow"):
     after_cursor: str | None
     end_of_stream: bool

--- a/source-zendesk-support-native/test.flow.yaml
+++ b/source-zendesk-support-native/test.flow.yaml
@@ -19,6 +19,10 @@ captures:
         interval: PT5M
       target: acmeCo/ticket_metrics
     - resource:
+        name: custom_ticket_statuses
+        interval: PT1H
+      target: acmeCo/custom_ticket_statuses
+    - resource:
         name: schedules
         interval: PT1H
       target: acmeCo/schedules
@@ -34,10 +38,6 @@ captures:
         name: tags
         interval: PT1H
       target: acmeCo/tags
-    - resource:
-        name: custom_ticket_statuses
-        interval: PT1H
-      target: acmeCo/custom_ticket_statuses
     - resource:
         name: custom_roles
         interval: PT30M
@@ -110,6 +110,14 @@ captures:
         name: organizations
         interval: PT5M
       target: acmeCo/organizations
+    - resource:
+        name: calls
+        interval: PT5M
+      target: acmeCo/calls
+    - resource:
+        name: call_legs
+        interval: PT5M
+      target: acmeCo/call_legs
     - resource:
         name: tickets
         interval: PT5M

--- a/source-zendesk-support-native/tests/snapshots/snapshots__capture__capture.stdout.json
+++ b/source-zendesk-support-native/tests/snapshots/snapshots__capture__capture.stdout.json
@@ -116,6 +116,100 @@
     }
   ],
   [
+    "acmeCo/call_legs",
+    {
+      "_meta": {
+        "uuid": "DocUUIDPlaceholder-329Bb50aa48EAa9ef",
+        "row_id": 0
+      },
+      "agent_id": 0,
+      "available_via": null,
+      "call_charge": "0.059",
+      "call_id": 32274723903636,
+      "completion_status": "completed",
+      "conference_from": null,
+      "conference_time": null,
+      "conference_to": null,
+      "consultation_from": null,
+      "consultation_time": null,
+      "consultation_to": null,
+      "created_at": "2024-11-19T16:56:46Z",
+      "duration": 14,
+      "forwarded_to": null,
+      "hold_time": 0,
+      "id": 32274695343252,
+      "minutes_billed": 1,
+      "quality_issues": [
+        "none"
+      ],
+      "talk_time": 0,
+      "transferred_from": null,
+      "transferred_to": null,
+      "type": "customer",
+      "updated_at": "redacted",
+      "user_id": 32274730131988,
+      "wrap_up_time": null
+    }
+  ],
+  [
+    "acmeCo/calls",
+    {
+      "_meta": {
+        "uuid": "DocUUIDPlaceholder-329Bb50aa48EAa9ef",
+        "row_id": 0
+      },
+      "agent_id": null,
+      "call_channel": "phone",
+      "call_charge": "0.062",
+      "call_group_id": null,
+      "call_recording_consent": "always",
+      "call_recording_consent_action": null,
+      "call_recording_consent_keypress": null,
+      "callback": false,
+      "callback_source": null,
+      "completion_status": "completed",
+      "consultation_time": 0,
+      "created_at": "2024-11-19T16:57:27Z",
+      "customer_id": 32274730131988,
+      "customer_requested_voicemail": false,
+      "default_group": false,
+      "direction": "inbound",
+      "duration": 29,
+      "exceeded_queue_wait_time": false,
+      "hold_time": 0,
+      "id": 32274699328148,
+      "ivr_action": null,
+      "ivr_destination_group_name": null,
+      "ivr_hops": null,
+      "ivr_routed_to": null,
+      "ivr_time_spent": null,
+      "line": "+16194574051",
+      "line_id": 28835744176276,
+      "line_type": "phone",
+      "minutes_billed": 1,
+      "not_recording_time": 0,
+      "outside_business_hours": false,
+      "overflowed": false,
+      "overflowed_to": null,
+      "phone_number": "+16194574051",
+      "phone_number_id": 28835744176276,
+      "post_call_summary_created": null,
+      "post_call_transcription_created": null,
+      "quality_issues": [
+        "none"
+      ],
+      "recording_control_interactions": 0,
+      "recording_time": 0,
+      "talk_time": 0,
+      "ticket_id": 32,
+      "time_to_answer": null,
+      "updated_at": "redacted",
+      "voicemail": true,
+      "wait_time": 0,
+      "wrap_up_time": 0
+    }
+  ],
+  [
     "acmeCo/categories",
     {
       "_meta": {

--- a/source-zendesk-support-native/tests/snapshots/snapshots__discover__capture.stdout.json
+++ b/source-zendesk-support-native/tests/snapshots/snapshots__discover__capture.stdout.json
@@ -287,6 +287,126 @@
     ]
   },
   {
+    "recommendedName": "call_legs",
+    "resourceConfig": {
+      "name": "call_legs",
+      "interval": "PT5M"
+    },
+    "documentSchema": {
+      "$defs": {
+        "Meta": {
+          "properties": {
+            "op": {
+              "default": "u",
+              "description": "Operation type (c: Create, u: Update, d: Delete)",
+              "enum": [
+                "c",
+                "u",
+                "d"
+              ],
+              "title": "Op",
+              "type": "string"
+            },
+            "row_id": {
+              "default": -1,
+              "description": "Row ID of the Document, counting up from zero, or -1 if not known",
+              "title": "Row Id",
+              "type": "integer"
+            }
+          },
+          "title": "Meta",
+          "type": "object"
+        }
+      },
+      "additionalProperties": true,
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/Meta",
+          "description": "Document metadata"
+        },
+        "id": {
+          "title": "Id",
+          "type": "integer"
+        },
+        "updated_at": {
+          "format": "date-time",
+          "title": "Updated At",
+          "type": "string"
+        }
+      },
+      "required": [
+        "id",
+        "updated_at"
+      ],
+      "title": "TimestampedResource",
+      "type": "object",
+      "x-infer-schema": true
+    },
+    "key": [
+      "/id"
+    ]
+  },
+  {
+    "recommendedName": "calls",
+    "resourceConfig": {
+      "name": "calls",
+      "interval": "PT5M"
+    },
+    "documentSchema": {
+      "$defs": {
+        "Meta": {
+          "properties": {
+            "op": {
+              "default": "u",
+              "description": "Operation type (c: Create, u: Update, d: Delete)",
+              "enum": [
+                "c",
+                "u",
+                "d"
+              ],
+              "title": "Op",
+              "type": "string"
+            },
+            "row_id": {
+              "default": -1,
+              "description": "Row ID of the Document, counting up from zero, or -1 if not known",
+              "title": "Row Id",
+              "type": "integer"
+            }
+          },
+          "title": "Meta",
+          "type": "object"
+        }
+      },
+      "additionalProperties": true,
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/Meta",
+          "description": "Document metadata"
+        },
+        "id": {
+          "title": "Id",
+          "type": "integer"
+        },
+        "updated_at": {
+          "format": "date-time",
+          "title": "Updated At",
+          "type": "string"
+        }
+      },
+      "required": [
+        "id",
+        "updated_at"
+      ],
+      "title": "TimestampedResource",
+      "type": "object",
+      "x-infer-schema": true
+    },
+    "key": [
+      "/id"
+    ]
+  },
+  {
     "recommendedName": "categories",
     "resourceConfig": {
       "name": "categories",


### PR DESCRIPTION
**Description:**

Add two new streams for Zendesk Talk data using the Talk API's incremental exports endpoint. This required a separate implementation from the standard incremental time exports because the Talk API has different pagination semantics: it lacks an `end_of_stream` field and instead signals completion when `end_time` equals `start_time` (i.e. we'd end up requesting the same page if we continue paginating).

Includes a check to conditionally discover `calls` and `call_legs` depending on whether Zendesk Talk is enabled for the account.

Discover and capture snapshot changes are expected due to the addition of the new streams.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

The connector's documentation should be updated to reflect the new streams.

**Notes for reviewers:**

Tested with `flowctl preview`. Confirmed documents are captured for both new streams.

