### PR TITLE
source-zendesk-support-native: overwrite `None` ticket ids for child resources

### DIFF
--- a/source-zendesk-support-native/source_zendesk_support_native/models.py
+++ b/source-zendesk-support-native/source_zendesk_support_native/models.py
@@ -321,7 +321,7 @@ class TicketChildResource(ZendeskResource):
     @classmethod
     def _add_ticket_id(cls, values: dict[str, Any], info: ValidationInfo) -> dict[str, Any]:
         if info.context and isinstance(info.context, TicketChildResourceValidationContext):
-            if 'ticket_id' not in values:
+            if values.get("ticket_id") is None:
                 values['ticket_id'] = info.context.ticket_id
         else:
             raise RuntimeError("TicketChildResource requires either a TicketChildResourceValidationContext containing the ticket_id.")


### PR DESCRIPTION
**Description:**

We've observed a `TicketChildResource` document get emitted with a `null` `ticket_id` field. The only way I see this could happen is if Zendesk included the `ticket_id` field but left it as `null` in the API response. The connector never writes over a `ticket_id` provided by Zendesk, so the `null` would have passed through unchanged.

That's not the behavior users expect, and we should insert the actual ticket id when Zendesk decides to leave it as an explicit `null`. This PR does just that.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

I haven't tested this change, but it's a very small, contained change I feel pretty confident will perform as expected - inserting/mutating the `ticket_id` field when it's absent or `None`.

