### PR TITLE
source-klaviyo-native: support custom event streams with user-defined filters

### DIFF
--- a/source-klaviyo-native/config.yaml
+++ b/source-klaviyo-native/config.yaml
@@ -2,6 +2,14 @@ credentials:
     credentials_title: API Key
     access_token_sops: ENC[AES256_GCM,data:ahq3zFIiztn/QIx/UB10KRRPJdBzvQM3CjgiVa/4977qtYIaug==,iv:urvMFErNkLbL3/ZOaw1e0sCz1Jxbkj30QCyxOtzDon8=,tag:JCn2QwJIaa4qYOlv6cysmw==,type:str]
 start_date: "2025-08-12T00:00:00Z"
+advanced:
+    custom_event_streams:
+        - name: profile_id_abc_events
+          profile_id: abc
+        - name: metric_id_123_events
+          metric_id: "123"
+        - name: profile_zyw_events
+          profile: zyw
 sops:
     kms: []
     gcp_kms:
@@ -11,8 +19,8 @@ sops:
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2025-08-12T16:43:43Z"
-    mac: ENC[AES256_GCM,data:RA9K1tI9OntWwRJWY1mct5LAiC/miIuSqX/jItBRbBbZAIt4KhnWNOdC1GJ5rCJceQNCdEI5992kJbCf/6Ki/cNbR6YjdvVdyXUQ4Zby4D80IKVOlCfGcbaXTPBCUT6wNLEitIayRF8KVo3PqVowe6siQs16Uy34C4jv7pF4c7s=,iv:W9pLf2w6EgRvjQQrox2CGNomb45VZPH0YaId4TRWiMk=,tag:9yN0sszqflbobU3uLUSdbQ==,type:str]
+    lastmodified: "2026-01-19T03:38:17Z"
+    mac: ENC[AES256_GCM,data:8r8qrCti8UnrvdG4oNUnEhtxPJw1sE6NZTdaKFYM9darlYJPJT/ssl2Z5460dh9+uzcDblzKCIwpm9+rH1YNN6xTz1TSo78K3uiiWCqdTl0eOeDWuGb3xni6LYBa8ADW65Ev9DDyaOv7B0DVNH7N/6TtC76V+kHjdkIPEsTBs0o=,iv:HEMZHibqDz2HvpuLWl+ATdgfIovjQ91KcfoIdZTQRoI=,tag:iSdvQha1+f6pVPc862dzaw==,type:str]
     pgp: []
     encrypted_suffix: _sops
     version: 3.9.0

--- a/source-klaviyo-native/tests/snapshots/snapshots__discover__capture.stdout.json
+++ b/source-klaviyo-native/tests/snapshots/snapshots__discover__capture.stdout.json
@@ -156,6 +156,198 @@
     ]
   },
   {
+    "recommendedName": "custom_metric_id_123_events",
+    "resourceConfig": {
+      "name": "custom_metric_id_123_events",
+      "interval": "PT5M"
+    },
+    "documentSchema": {
+      "$defs": {
+        "Attributes": {
+          "additionalProperties": true,
+          "properties": {},
+          "title": "Attributes",
+          "type": "object"
+        },
+        "Meta": {
+          "properties": {
+            "op": {
+              "default": "u",
+              "description": "Operation type (c: Create, u: Update, d: Delete)",
+              "enum": [
+                "c",
+                "u",
+                "d"
+              ],
+              "title": "Op",
+              "type": "string"
+            },
+            "row_id": {
+              "default": -1,
+              "description": "Row ID of the Document, counting up from zero, or -1 if not known",
+              "title": "Row Id",
+              "type": "integer"
+            }
+          },
+          "title": "Meta",
+          "type": "object"
+        }
+      },
+      "additionalProperties": true,
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/Meta",
+          "description": "Document metadata"
+        },
+        "id": {
+          "title": "Id",
+          "type": "string"
+        },
+        "attributes": {
+          "$ref": "#/$defs/Attributes"
+        }
+      },
+      "required": [
+        "id",
+        "attributes"
+      ],
+      "title": "IncrementalStream",
+      "type": "object",
+      "x-infer-schema": true
+    },
+    "key": [
+      "/id"
+    ]
+  },
+  {
+    "recommendedName": "custom_profile_id_abc_events",
+    "resourceConfig": {
+      "name": "custom_profile_id_abc_events",
+      "interval": "PT5M"
+    },
+    "documentSchema": {
+      "$defs": {
+        "Attributes": {
+          "additionalProperties": true,
+          "properties": {},
+          "title": "Attributes",
+          "type": "object"
+        },
+        "Meta": {
+          "properties": {
+            "op": {
+              "default": "u",
+              "description": "Operation type (c: Create, u: Update, d: Delete)",
+              "enum": [
+                "c",
+                "u",
+                "d"
+              ],
+              "title": "Op",
+              "type": "string"
+            },
+            "row_id": {
+              "default": -1,
+              "description": "Row ID of the Document, counting up from zero, or -1 if not known",
+              "title": "Row Id",
+              "type": "integer"
+            }
+          },
+          "title": "Meta",
+          "type": "object"
+        }
+      },
+      "additionalProperties": true,
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/Meta",
+          "description": "Document metadata"
+        },
+        "id": {
+          "title": "Id",
+          "type": "string"
+        },
+        "attributes": {
+          "$ref": "#/$defs/Attributes"
+        }
+      },
+      "required": [
+        "id",
+        "attributes"
+      ],
+      "title": "IncrementalStream",
+      "type": "object",
+      "x-infer-schema": true
+    },
+    "key": [
+      "/id"
+    ]
+  },
+  {
+    "recommendedName": "custom_profile_zyw_events",
+    "resourceConfig": {
+      "name": "custom_profile_zyw_events",
+      "interval": "PT5M"
+    },
+    "documentSchema": {
+      "$defs": {
+        "Attributes": {
+          "additionalProperties": true,
+          "properties": {},
+          "title": "Attributes",
+          "type": "object"
+        },
+        "Meta": {
+          "properties": {
+            "op": {
+              "default": "u",
+              "description": "Operation type (c: Create, u: Update, d: Delete)",
+              "enum": [
+                "c",
+                "u",
+                "d"
+              ],
+              "title": "Op",
+              "type": "string"
+            },
+            "row_id": {
+              "default": -1,
+              "description": "Row ID of the Document, counting up from zero, or -1 if not known",
+              "title": "Row Id",
+              "type": "integer"
+            }
+          },
+          "title": "Meta",
+          "type": "object"
+        }
+      },
+      "additionalProperties": true,
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/Meta",
+          "description": "Document metadata"
+        },
+        "id": {
+          "title": "Id",
+          "type": "string"
+        },
+        "attributes": {
+          "$ref": "#/$defs/Attributes"
+        }
+      },
+      "required": [
+        "id",
+        "attributes"
+      ],
+      "title": "IncrementalStream",
+      "type": "object",
+      "x-infer-schema": true
+    },
+    "key": [
+      "/id"
+    ]
+  },
+  {
     "recommendedName": "events",
     "resourceConfig": {
       "name": "events",

--- a/source-klaviyo-native/tests/snapshots/snapshots__spec__capture.stdout.json
+++ b/source-klaviyo-native/tests/snapshots/snapshots__spec__capture.stdout.json
@@ -11,6 +11,14 @@
               "format": "duration",
               "title": "Window size",
               "type": "string"
+            },
+            "custom_event_streams": {
+              "description": "Define additional event streams with custom filters. Each stream captures events matching the specified filters.",
+              "items": {
+                "$ref": "#/$defs/CustomEventStream"
+              },
+              "title": "Custom Event Streams",
+              "type": "array"
             }
           },
           "title": "Advanced",
@@ -36,6 +44,59 @@
             "access_token"
           ],
           "title": "ApiKey",
+          "type": "object"
+        },
+        "CustomEventStream": {
+          "properties": {
+            "name": {
+              "description": "A unique name for this custom event binding. The binding will be named 'custom_<name>'.",
+              "title": "Stream Name",
+              "type": "string"
+            },
+            "metric_id": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "Filter events by metric ID. Adds 'equals(metric_id,\"<value>\")' to the API request's query filter.",
+              "title": "Metric ID"
+            },
+            "profile_id": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "Filter events by profile ID. Adds 'equals(profile_id,\"<value>\")' to the API request's query filter.",
+              "title": "Profile ID"
+            },
+            "profile": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "Filter events by profile. Adds 'has(profile,\"<value>\")' to the API request's query filter.",
+              "title": "Profile"
+            }
+          },
+          "required": [
+            "name"
+          ],
+          "title": "CustomEventStream",
           "type": "object"
         }
       },


### PR DESCRIPTION
**Description:**

Allow users to create additional event streams with custom filters. Each custom stream captures events matching the specified filters and is named with a 'custom_' prefix to prevent naming collisions with connector defined streams.

Supported filters:
- metric_id: `equals(metric_id,"<value>")`
- profile_id: `equals(profile_id,"<value>")`
- profile: `has(profile,"<value>")`

At least one filter must be provided per custom stream. Custom streams use dynamically created Events subclasses with the filters set via the model's `additional_filters` class variable.

Snapshot changes are expected due to the custom event stream related fields added to the spec and the example custom event streams I added to `config.yaml` to exercise the discovery logic.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

The connector's documentation should be updated to reflect the new functionality for specifying custom event streams.

**Notes for reviewers:**

Confirmed custom event streams are discovered as expected - with a `custom_` prefix in their names. Confirmed custom event streams go through the same code path as the existing `events` streams.

