### PR TITLE
Revert "source-dyanmics-365-finance-and-operations: increase CACHE_TTL to improve backfill performance

### DIFF
--- a/source-dynamics-365-finance-and-operations/source_dynamics_365_finance_and_operations/api.py
+++ b/source-dynamics-365-finance-and-operations/source_dynamics_365_finance_and_operations/api.py
@@ -26,7 +26,10 @@ from .shared import call_with_cache_logging, is_datetime_format, str_to_dt
 
 
 MINIMUM_AZURE_SYNAPSE_LINK_EXPORT_INTERVAL = 300             # 5 minutes
-CACHE_TTL = 3600 # 1 hour
+# CACHE_TTL is shorter than the minimum export interval allowed by Azure
+# in order to minimize how long stale data remains in the cache while
+# still picking up on any changes in Azure relatively quickly.
+CACHE_TTL = MINIMUM_AZURE_SYNAPSE_LINK_EXPORT_INTERVAL / 5   # 1 minute
 # FOLDER_PROCESSING_SEMAPHORE is used to bound how many timestamp
 # folders are processed concurrently. Processing an unbounded number
 # of folders can easily trigger the connector to exceed its memory


### PR DESCRIPTION
**Description:**

This reverts commit 67eac7073e40e1e131e0953ff13a1c903c23ab52. The larger `CACHE_TTL` didn't have a measurable impact on backfill speed since `fetch_changes` invocations only fetch a list of timestamp folders once and attempt to process _all_ more recent folders in a single invocation. The larger `CACHE_TTL` right now only serves to delay how soon the connector will pick up incremental changes, which isn't ideal. Setting it back to 1 minute will ensure the connector is able to pick up changes quickly if the user configures a small resource interval.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

