### PR TITLE
source-google-ads: make primary key fields non-nullable in custom query schemas

### DIFF
--- a/source-google-ads/acmeCo/my_custom_query.schema.yaml
+++ b/source-google-ads/acmeCo/my_custom_query.schema.yaml
@@ -46,9 +46,7 @@ properties:
     - boolean
     - 'null'
   customer.id:
-    type:
-    - integer
-    - 'null'
+    type: integer
   metrics.conversions:
     type:
     - number
@@ -59,9 +57,7 @@ properties:
     - 'null'
     format: date
   segments.date:
-    type:
-    - string
-    - 'null'
+    type: string
     format: date
   _meta:
     type: object

--- a/source-google-ads/source_google_ads/custom_query_stream.py
+++ b/source-google-ads/source_google_ads/custom_query_stream.py
@@ -96,6 +96,15 @@ class CustomQueryMixin:
 
             local_json_schema["properties"][field] = field_value
 
+        # Primary key fields should not be nullable
+        for pk in self.primary_key:
+            if pk in local_json_schema["properties"]:
+                prop = local_json_schema["properties"][pk]
+                field_type = prop.get("type")
+                if isinstance(field_type, list) and "null" in field_type:
+                    non_null_types = [t for t in field_type if t != "null"]
+                    prop["type"] = non_null_types[0] if len(non_null_types) == 1 else non_null_types
+
         return local_json_schema
 
 

--- a/source-google-ads/tests/snapshots/snapshots__discover__capture.stdout.json
+++ b/source-google-ads/tests/snapshots/snapshots__discover__capture.stdout.json
@@ -5480,10 +5480,7 @@
           ]
         },
         "customer.id": {
-          "type": [
-            "integer",
-            "null"
-          ]
+          "type": "integer"
         },
         "metrics.conversions": {
           "type": [
@@ -5499,10 +5496,7 @@
           "format": "date"
         },
         "segments.date": {
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": "string",
           "format": "date"
         },
         "_meta": {

--- a/source-google-ads/tests/test_source.py
+++ b/source-google-ads/tests/test_source.py
@@ -291,7 +291,7 @@ def stream_instance(query, api_mock, **kwargs):
         api=api_mock,
         conversion_window_days=conversion_window_days,
         start_date=start_date,
-        config={"query": GAQL.parse(query), "table_name": "whatever_table"},
+        config={"query": GAQL.parse(query), "table_name": "whatever_table", "primary_key": "some_primary_key"},
         **kwargs,
     )
     return instance


### PR DESCRIPTION
**Description:**

Custom query streams dynamically generate their JSON schemas by querying the Google Ads API for field metadata. Previously, all fields were marked as nullable (e.g., `["integer", "null"]`), including fields specified as primary keys by the user.

This change checks if each field is part of the user-specified primary key and, if so, generates a non-nullable type (e.g., `"integer"` instead of `["integer", "null"]`).

Discover snapshot changes are expected - collection key fields for the example custom stream are no longer discovered as nullable.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

Confirmed via `flowctl raw discover` that fields that are part of the collection key schema for custom streams are no longer nullable. You can see this in `acmeCo/my_custom_query.schema.yaml` with the `customer.id` and `segments.date` fields.

