### PR TITLE
materialize-sqlserver: add aws iam auth

### DIFF
--- a/materialize-sqlserver/.snapshots/TestSpecification
+++ b/materialize-sqlserver/.snapshots/TestSpecification
@@ -15,13 +15,6 @@
         "description": "Database user to connect as.",
         "order": 1
       },
-      "password": {
-        "type": "string",
-        "title": "Password",
-        "description": "Password for the specified database user.",
-        "order": 2,
-        "secret": true
-      },
       "database": {
         "type": "string",
         "title": "Database",
@@ -40,6 +33,72 @@
         "description": "If this option is enabled items deleted in the source will also be deleted from the destination. By default is disabled and _meta/op in the destination will signify whether rows have been deleted (soft-delete).",
         "default": false,
         "order": 5
+      },
+      "credentials": {
+        "oneOf": [
+          {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$id": "https://github.com/estuary/connectors/materialize-sqlserver/user-password-config",
+            "properties": {
+              "auth_type": {
+                "type": "string",
+                "const": "UserPassword",
+                "default": "UserPassword",
+                "order": 0
+              },
+              "password": {
+                "type": "string",
+                "title": "Password",
+                "description": "Password for the specified database user.",
+                "order": 1,
+                "secret": true
+              }
+            },
+            "type": "object",
+            "required": [
+              "password"
+            ],
+            "title": "Password"
+          },
+          {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$id": "https://github.com/estuary/connectors/go/auth/iam/aws-config",
+            "properties": {
+              "auth_type": {
+                "type": "string",
+                "const": "AWSIAM",
+                "default": "AWSIAM",
+                "order": 0
+              },
+              "aws_region": {
+                "type": "string",
+                "title": "AWS Region",
+                "description": "AWS Region of your resource"
+              },
+              "aws_role_arn": {
+                "type": "string",
+                "title": "AWS Role ARN",
+                "description": "AWS Role which has access to the resource which will be assumed by Flow"
+              }
+            },
+            "type": "object",
+            "required": [
+              "aws_region",
+              "aws_role_arn"
+            ],
+            "title": "AWS IAM"
+          }
+        ],
+        "type": "object",
+        "title": "Authentication",
+        "default": {
+          "auth_type": "UserPassword"
+        },
+        "discriminator": {
+          "propertyName": "auth_type"
+        },
+        "order": 6,
+        "x-iam-auth": true
       },
       "dbt_job_trigger": {
         "properties": {
@@ -155,8 +214,8 @@
     "required": [
       "address",
       "user",
-      "password",
-      "database"
+      "database",
+      "credentials"
     ],
     "title": "SQL Connection"
   },

--- a/materialize-sqlserver/client.go
+++ b/materialize-sqlserver/client.go
@@ -28,10 +28,12 @@ type client struct {
 }
 
 func newClient(ctx context.Context, ep *sql.Endpoint[config]) (sql.Client, error) {
-	db, err := stdsql.Open("sqlserver", ep.Config.ToURI())
+	connector, err := ep.Config.ToSQLConnector(ctx)
 	if err != nil {
 		return nil, err
 	}
+
+	db := stdsql.OpenDB(connector)
 
 	return &client{
 		db: db,
@@ -42,11 +44,13 @@ func newClient(ctx context.Context, ep *sql.Endpoint[config]) (sql.Client, error
 func preReqs(ctx context.Context, cfg config) *cerrors.PrereqErr {
 	errs := &cerrors.PrereqErr{}
 
-	db, err := stdsql.Open("sqlserver", cfg.ToURI())
+	connector, err := cfg.ToSQLConnector(ctx)
 	if err != nil {
 		errs.Err(err)
 		return errs
 	}
+
+	db := stdsql.OpenDB(connector)
 
 	// Use a reasonable timeout for this connection test. It is not uncommon for a misconfigured
 	// connection (wrong host, wrong port, etc.) to hang for several minutes on Ping and we want to

--- a/materialize-sqlserver/config_test.go
+++ b/materialize-sqlserver/config_test.go
@@ -19,13 +19,13 @@ func TestConfig(t *testing.T) {
 		Database: "namegame",
 	}
 	require.NoError(t, validConfig.Validate())
-	var uri = validConfig.ToURI()
+	var uri = validConfig.ToURI().String()
 	require.Equal(t, "sqlserver://youser:shmassword@post.toast:1234?TrustServerCertificate=true&app+name=Flow+Materialization+Connector&database=namegame&encrypt=true", uri)
 
 	var noPort = validConfig
 	noPort.Address = "post.toast"
 	require.NoError(t, noPort.Validate())
-	uri = noPort.ToURI()
+	uri = noPort.ToURI().String()
 	require.Equal(t, "sqlserver://youser:shmassword@post.toast:1433?TrustServerCertificate=true&app+name=Flow+Materialization+Connector&database=namegame&encrypt=true", uri)
 
 	var noAddress = validConfig
@@ -70,7 +70,7 @@ func TestConfigURI(t *testing.T) {
 			if err := cfg.Validate(); err != nil {
 				valid = err.Error()
 			}
-			var uri = cfg.ToURI()
+			var uri = cfg.ToURI().String()
 			cupaloy.SnapshotT(t, fmt.Sprintf("%s\n%s", uri, valid))
 		})
 	}

--- a/materialize-sqlserver/driver.go
+++ b/materialize-sqlserver/driver.go
@@ -3,20 +3,26 @@ package main
 import (
 	"context"
 	stdsql "database/sql"
+	"database/sql/driver"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net"
 	"net/url"
 	"strings"
 	"text/template"
 
+	"github.com/aws/aws-sdk-go-v2/feature/rds/auth"
+	"github.com/estuary/connectors/go/auth/iam"
 	"github.com/estuary/connectors/go/dbt"
 	m "github.com/estuary/connectors/go/materialize"
 	networkTunnel "github.com/estuary/connectors/go/network-tunnel"
+	schemagen "github.com/estuary/connectors/go/schema-gen"
 	boilerplate "github.com/estuary/connectors/materialize-boilerplate"
 	sql "github.com/estuary/connectors/materialize-sql"
 	pf "github.com/estuary/flow/go/protocols/flow"
 	pm "github.com/estuary/flow/go/protocols/materialize"
+	"github.com/invopop/jsonschema"
 	mssqldb "github.com/microsoft/go-mssqldb"
 	log "github.com/sirupsen/logrus"
 	"go.gazette.dev/core/consumer/protocol"
@@ -25,6 +31,51 @@ import (
 var featureFlagDefaults = map[string]bool{
 	"datetime_keys_as_string":          true,
 	"retain_existing_data_on_backfill": false,
+}
+
+type AuthType string
+
+const (
+	UserPassword AuthType = "UserPassword"
+	AWSIAM       AuthType = "AWSIAM"
+)
+
+type UserPasswordConfig struct {
+	Password string `json:"password" jsonschema:"title=Password,description=Password for the specified database user." jsonschema_extras:"secret=true,order=1"`
+}
+
+type CredentialsConfig struct {
+	AuthType AuthType `json:"auth_type"`
+
+	UserPasswordConfig
+	iam.IAMConfig
+}
+
+func (CredentialsConfig) JSONSchema() *jsonschema.Schema {
+	subSchemas := []schemagen.OneOfSubSchemaT{
+		schemagen.OneOfSubSchema("Password", UserPasswordConfig{}, string(UserPassword)),
+	}
+	subSchemas = append(subSchemas,
+		schemagen.OneOfSubSchema("AWS IAM", iam.AWSConfig{}, string(AWSIAM)))
+
+	schema := schemagen.OneOfSchema("Authentication", "", "auth_type", string(UserPassword), subSchemas...)
+	return schema
+}
+
+func (c *CredentialsConfig) Validate() error {
+	switch c.AuthType {
+	case UserPassword:
+		if c.Password == "" {
+			return errors.New("missing 'password'")
+		}
+		return nil
+	case AWSIAM:
+		if err := c.ValidateIAM(); err != nil {
+			return err
+		}
+		return nil
+	}
+	return fmt.Errorf("unknown 'auth_type'")
 }
 
 type sshForwarding struct {
@@ -43,12 +94,13 @@ type advancedConfig struct {
 
 // config represents the endpoint configuration for sql server.
 type config struct {
-	Address    string `json:"address" jsonschema:"title=Address,description=Host and port of the database (in the form of host[:port]). Port 1433 is used as the default if no specific port is provided." jsonschema_extras:"order=0"`
-	User       string `json:"user" jsonschema:"title=User,description=Database user to connect as." jsonschema_extras:"order=1"`
-	Password   string `json:"password" jsonschema:"title=Password,description=Password for the specified database user." jsonschema_extras:"secret=true,order=2"`
-	Database   string `json:"database" jsonschema:"title=Database,description=Name of the logical database to materialize to." jsonschema_extras:"order=3"`
-	Schema     string `json:"schema,omitempty" jsonschema:"title=Database Schema,description=Database schema for bound collection tables (unless overridden within the binding resource configuration) as well as associated materialization metadata tables" jsonschema_extras:"order=4"`
-	HardDelete bool   `json:"hardDelete,omitempty" jsonschema:"title=Hard Delete,description=If this option is enabled items deleted in the source will also be deleted from the destination. By default is disabled and _meta/op in the destination will signify whether rows have been deleted (soft-delete).,default=false" jsonschema_extras:"order=5"`
+	Address     string             `json:"address" jsonschema:"title=Address,description=Host and port of the database (in the form of host[:port]). Port 1433 is used as the default if no specific port is provided." jsonschema_extras:"order=0"`
+	User        string             `json:"user" jsonschema:"title=User,description=Database user to connect as." jsonschema_extras:"order=1"`
+	Password    string             `json:"password" jsonschema:"-" jsonschema_extras:"secret=true,order=2"`
+	Database    string             `json:"database" jsonschema:"title=Database,description=Name of the logical database to materialize to." jsonschema_extras:"order=3"`
+	Schema      string             `json:"schema,omitempty" jsonschema:"title=Database Schema,description=Database schema for bound collection tables (unless overridden within the binding resource configuration) as well as associated materialization metadata tables" jsonschema_extras:"order=4"`
+	HardDelete  bool               `json:"hardDelete,omitempty" jsonschema:"title=Hard Delete,description=If this option is enabled items deleted in the source will also be deleted from the destination. By default is disabled and _meta/op in the destination will signify whether rows have been deleted (soft-delete).,default=false" jsonschema_extras:"order=5"`
+	Credentials *CredentialsConfig `json:"credentials" jsonschema:"title=Authentication" jsonschema_extras:"x-iam-auth=true,order=6"`
 
 	DBTJobTrigger dbt.JobConfig `json:"dbt_job_trigger,omitempty" jsonschema:"title=dbt Cloud Job Trigger,description=Trigger a dbt Job when new data is available"`
 
@@ -62,13 +114,20 @@ func (c config) Validate() error {
 	var requiredProperties = [][]string{
 		{"address", c.Address},
 		{"user", c.User},
-		{"password", c.Password},
 		{"database", c.Database},
 	}
 	for _, req := range requiredProperties {
 		if req[1] == "" {
 			return fmt.Errorf("missing '%s'", req[0])
 		}
+	}
+
+	if c.Credentials == nil {
+		if c.Password == "" {
+			return errors.New("missing 'password'")
+		}
+	} else if err := c.Credentials.Validate(); err != nil {
+		return err
 	}
 
 	if err := c.DBTJobTrigger.Validate(); err != nil {
@@ -89,7 +148,7 @@ func (c config) FeatureFlags() (string, map[string]bool) {
 const defaultPort = "1433"
 
 // ToURI converts the Config to a DSN string.
-func (c *config) ToURI() string {
+func (c *config) ToURI() *url.URL {
 	var address = c.Address
 	// If SSH Tunnel is configured, we are going to create a tunnel from localhost:1433
 	// to address through the bastion server, so we use the tunnel's address
@@ -109,14 +168,61 @@ func (c *config) ToURI() string {
 	params.Add("TrustServerCertificate", "true")
 	params.Add("database", c.Database)
 
-	var uri = url.URL{
+	userInfo := url.UserPassword(c.User, c.Password)
+	if c.Credentials != nil {
+		switch c.Credentials.AuthType {
+		case UserPassword:
+			pass := c.Credentials.Password
+			userInfo = url.UserPassword(c.User, pass)
+		case AWSIAM:
+			userInfo = url.User(c.User)
+		}
+	}
+
+	var uri = &url.URL{
 		Scheme:   "sqlserver",
 		Host:     address,
-		User:     url.UserPassword(c.User, c.Password),
+		User:     userInfo,
 		RawQuery: params.Encode(),
 	}
 
-	return uri.String()
+	return uri
+}
+
+// ToSQLConnector converts the Config to a sql Connector for use with OpenDB.
+func (c *config) ToSQLConnector(ctx context.Context) (driver.Connector, error) {
+	uri := c.ToURI()
+
+	if c.Credentials != nil {
+		switch c.Credentials.AuthType {
+		case AWSIAM:
+			credProvider, err := c.Credentials.AWSCredentialsProvider()
+			if err != nil {
+				return nil, err
+			}
+
+			// In the case of a network tunnel, we want to use the RDS Proxy
+			// endpoint when building the token.
+			endpoint := c.Address
+			if !strings.Contains(endpoint, ":") {
+				endpoint = endpoint + ":" + defaultPort
+			}
+
+			tokenProvider := func(ctx context.Context) (string, error) {
+				token, err := auth.BuildAuthToken(
+					ctx,
+					endpoint,
+					c.Credentials.AWSRegion,
+					c.User,
+					credProvider)
+				return token, err
+			}
+
+			return mssqldb.NewConnectorWithAccessTokenProvider(uri.String(), tokenProvider)
+		}
+	}
+
+	return mssqldb.NewConnector(uri.String())
 }
 
 type tableConfig struct {
@@ -191,10 +297,13 @@ func newSqlServerDriver() *sql.Driver[config, tableConfig] {
 			if cfg.Schema != "" {
 				metaBase = append(metaBase, cfg.Schema)
 			}
-			db, err := stdsql.Open("sqlserver", cfg.ToURI())
+
+			connector, err := cfg.ToSQLConnector(ctx)
 			if err != nil {
-				return nil, fmt.Errorf("opening db: %w", err)
+				return nil, err
 			}
+
+			db := stdsql.OpenDB(connector)
 			defer db.Close()
 
 			collation, err := getCollation(ctx, db)
@@ -266,15 +375,18 @@ func prepareNewTransactor(
 		var d = &transactor{templates: templates, cfg: cfg, be: be}
 		d.store.fence = fence
 
+		connector, err := ep.Config.ToSQLConnector(ctx)
+		if err != nil {
+			return nil, err
+		}
+
 		// Establish connections.
-		if db, err := stdsql.Open("sqlserver", cfg.ToURI()); err != nil {
-			return nil, fmt.Errorf("load sql.Open: %w", err)
-		} else if d.load.conn, err = db.Conn(ctx); err != nil {
+		db := stdsql.OpenDB(connector)
+		if d.load.conn, err = db.Conn(ctx); err != nil {
 			return nil, fmt.Errorf("load db.Conn: %w", err)
 		}
-		if db, err := stdsql.Open("sqlserver", cfg.ToURI()); err != nil {
-			return nil, fmt.Errorf("store sql.Open: %w", err)
-		} else if d.store.conn, err = db.Conn(ctx); err != nil {
+
+		if d.store.conn, err = db.Conn(ctx); err != nil {
 			return nil, fmt.Errorf("store db.Conn: %w", err)
 		}
 

--- a/materialize-sqlserver/driver_test.go
+++ b/materialize-sqlserver/driver_test.go
@@ -46,7 +46,9 @@ func TestValidateAndApply(t *testing.T) {
 		Table: "target",
 	}
 
-	db, err := stdsql.Open("sqlserver", cfg.ToURI())
+	uri := cfg.ToURI().String()
+
+	db, err := stdsql.Open("sqlserver", uri)
 	require.NoError(t, err)
 	defer db.Close()
 
@@ -79,7 +81,9 @@ func TestValidateAndApplyMigrations(t *testing.T) {
 		Table: "target",
 	}
 
-	db, err := stdsql.Open("sqlserver", cfg.ToURI())
+	uri := cfg.ToURI().String()
+
+	db, err := stdsql.Open("sqlserver", uri)
 	require.NoError(t, err)
 	defer db.Close()
 
@@ -151,7 +155,9 @@ func TestApplyChanges(t *testing.T) {
 	resourceConfigJson, err := json.Marshal(resourceConfig)
 	require.NoError(t, err)
 
-	db, err := stdsql.Open("sqlserver", cfg.ToURI())
+	uri := cfg.ToURI().String()
+
+	db, err := stdsql.Open("sqlserver", uri)
 	require.NoError(t, err)
 	defer db.Close()
 


### PR DESCRIPTION
**Description:**

Adds support for authenticating to SQL Server on AWS using IAM authentication.

related: #3736

**Workflow steps:**

See linked documentation.

**Documentation links affected:**

https://github.com/estuary/flow/pull/2630

**Notes for reviewers:**

No support for IAM on [GCP is planned](https://github.com/estuary/connectors/issues/3736#issuecomment-3752228052).  Azure support will be done in a separate PR once required changes to the runtime are complete.

