### PR TITLE
CDK: Support configuring config-encryption `URL` at build time for local dev

### DIFF
--- a/estuary-cdk/common.Dockerfile
+++ b/estuary-cdk/common.Dockerfile
@@ -26,6 +26,7 @@ FROM base AS runner
 ARG CONNECTOR_NAME
 ARG CONNECTOR_TYPE
 ARG DOCS_URL
+ARG ENCRYPTION_URL="https://config-encryption.estuary.dev/v1/encrypt-config"
 # The USAGE_RATE arg is required, because GH actions doesn't seem to have a way to conditionally
 # pass it only for the connectors that should have a 0 rate. Comes from `usage_rate` in the
 # `python.yaml` workflow matrix.
@@ -47,6 +48,7 @@ COPY --from=builder /opt/venv /opt/venv
 COPY --from=ghcr.io/estuary/network-tunnel:dev /flow-network-tunnel /usr/bin/flow-network-tunnel
 
 ENV DOCS_URL=${DOCS_URL}
+ENV ENCRYPTION_URL=${ENCRYPTION_URL}
 ENV CONNECTOR_NAME=${CONNECTOR_NAME}
 
 CMD ["/bin/sh", "-c", "/opt/venv/bin/python -m $(echo \"$CONNECTOR_NAME\" | tr '-' '_')"]

--- a/estuary-cdk/estuary_cdk/capture/base_capture_connector.py
+++ b/estuary-cdk/estuary_cdk/capture/base_capture_connector.py
@@ -1,6 +1,7 @@
 import abc
 import asyncio
 import json
+import os
 import sys
 from datetime import UTC, datetime, timedelta
 from typing import Any, Awaitable, BinaryIO, Callable, Generic
@@ -26,6 +27,10 @@ from ..utils import format_error_message, sort_dict
 from . import Request, Response, Task, request, response
 from ._emit import emit_bytes
 from .common import _ConnectorState
+
+# Default encryption service URL, can be overridden via ENCRYPTION_URL environment variable
+# for local testing with docker gateway addresses like http://172.18.0.1:port
+ENCRYPTION_URL = os.getenv("ENCRYPTION_URL") or "https://config-encryption.estuary.dev/v1/encrypt-config"
 
 
 class BaseCaptureConnector(
@@ -162,7 +167,6 @@ class BaseCaptureConnector(
         config: EndpointConfig,
     ) -> dict[str, Any]:
         assert isinstance(config, BaseModel)
-        ENCRYPTION_URL = "https://config-encryption.estuary.dev/v1/encrypt-config"
 
         # mode="json" converts Python-specific concepts (like datetimes) to valid JSON.
         # include=config.model_fields_set ensures only the fields that are explicitly set on the


### PR DESCRIPTION
**Description:**

This adds an `ARG` and `ENV` variable to the CDK common.Dockerfile and consumes that as an optional value in the `BaseCaptureConnector` once at the module level. This provides the option to set this variable when testing on a local stack, which will not have access to the production KMS keys for encryption/decryption.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

Tested along with #3626 in a GCP VM (`mise` local stack)

