### PR TITLE
source-google-ads: fix protobuf MESSAGE type schematization and serialization

### DIFF
--- a/source-google-ads/source_google_ads/custom_query_stream.py
+++ b/source-google-ads/source_google_ads/custom_query_stream.py
@@ -70,15 +70,14 @@ class CustomQueryMixin:
                 if node.is_repeated:
                     field_value = {"type": ["null", "array"], "items": field_value}
             elif google_data_type == "MESSAGE":
-                # Represents protobuf message and could be anything, set custom
-                # attribute "protobuf_message" to convert it to a string (or
-                # array of strings) later.
+                # Represents protobuf message and could be anything, will be
+                # serialized to JSON string by GoogleAds._protobuf_to_json().
                 # https://developers.google.com/google-ads/api/reference/rpc/v11/GoogleAdsFieldDataTypeEnum.GoogleAdsFieldDataType?hl=en#message
                 if node.is_repeated:
                     output_type = ["array", "null"]
                 else:
                     output_type = ["string", "null"]
-                field_value = {"type": output_type, "protobuf_message": True}
+                field_value = {"type": output_type}
             else:
                 base_type = google_datatype_mapping.get(google_data_type, "string")
                 if node.is_repeated:

--- a/source-google-ads/tests/test_custom_query.py
+++ b/source-google-ads/tests/test_custom_query.py
@@ -54,8 +54,8 @@ def test_get_json_schema():
         'properties': {
             'a': {'type': 'string', 'enum': ['a', 'aa']},
             'b': {'type': ['null', 'array'], 'items': {'type': 'string', 'enum': ['b', 'bb']}},
-            'c': {'type': ['string', 'null'], 'protobuf_message': True},
-            'd': {'type': ['array', 'null'], 'protobuf_message': True},
+            'c': {'type': ['string', 'null']},
+            'd': {'type': ['array', 'null']},
             'e': {'type': ['string', 'null']},
             'f': {'type': ['string', 'null'], 'format': 'date'},
             'g': {'type': ['null', 'array'], 'items': {'type': 'string'}},
@@ -95,8 +95,8 @@ def test_get_json_schema_primary_keys_not_nullable():
         'properties': {
             'a': {'type': 'string', 'enum': ['a', 'aa']},
             'b': {'type': 'array', 'items': {'type': 'string', 'enum': ['b', 'bb']}},
-            'c': {'type': 'string', 'protobuf_message': True},
-            'd': {'type': 'array', 'protobuf_message': True},
+            'c': {'type': 'string'},
+            'd': {'type': 'array'},
             'e': {'type': 'string'},
             'f': {'type': 'string', 'format': 'date'},
             'g': {'type': 'array', 'items': {'type': 'string'}},


### PR DESCRIPTION
**Description:**

Custom queries with MESSAGE-type fields were failing schema validation because the connector added a non-standard "protobuf_message" attribute to the JSON schema. This attribute was used to pass metadata from schema generation to the connector's serialization process, but that's not a great idea since it leaked internal implementation details into the externally published schema.

This PR removes the "protobuf_message" attribute from generated schemas. The connector now uses `isinstance()` checks to detect when a protobuf MESSAGE needs to be serialized. The serialization behavior for protobuf MESSAGE types now also uses proto-plus's `to_json()` method for proper JSON serialization instead of using the generic `str()` function to create human readable strings.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

Tested with `flowctl raw discover` and `flowctl preview`. Confirmed custom streams specifying MESSAGE-type fields no longer have a "protobuf_message" attribute, and those fields are now serialized as valid JSON strings.

No MESSAGE-type fields have been successfully used in custom query streams yet, so the change in serialization behavior should be alright; no MESSAGE-type fields have been captured with the previous `str()` serialization.