### PR TITLE
source-outreach: add REALTIME/LOOKBACK subtasks for eventual consistency

### DIFF
--- a/source-outreach/source_outreach/shared.py
+++ b/source-outreach/source_outreach/shared.py
@@ -1,0 +1,8 @@
+from datetime import datetime, UTC
+
+
+def now() -> datetime:
+    """
+    Returns the current time with microseconds removed.
+    """
+    return datetime.now(tz=UTC).replace(microsecond=0)


### PR DESCRIPTION
**Description:**

We suspect the Outreach API is eventually consistent. This commit adds a LOOKBACK incremental subtask to catch records that are not returned by the API immediately after creation/update. This is the same strategy we've implemented in other connectors that capture from eventually consistent APIs.

In the past, migrating the state of existing captures to the subtask format hasn't been wildly successful. However for this migration, I realized I could remove the prior state _and_ add the new subtask state in the same merge patch checkpoint; the piece I had missed previously was specifying `null` for the previous `cursor` key in the same checkpoint would remove the old, single cursor format state while still adding the new REALTIME and LOOKBACK subtask states.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

Tested on a development stack. Confirmed the old single cursor state is successfully migrated to the REALTIME / LOOKBACK subtask state, and the old single cursor state is removed from the persisted `ResourceState`.

6 hours was chosen as the `LOOKBACK_LAG` as an ultra-safe option to avoid missing records due to eventual consistency. We've been told another tool has ingested a record 6 hours after it's `updatedAt` value. The frequency at which that tool polls for updates affects when it would observe the record, but without more information or rigorous testing, we should the API is eventually consistent up to 6 hours.

Since `source-outreach` uses `RotatingOAuth2Credentials` and access tokens expire after 2 hours, the connector exits, restarts, and gets republished with rotated tokens every 2 hours. On each restart, the `emitted_changes_cache` is cleared. For meaningful deduplication between the realtime and lookback subtasks, their fetched time windows need to overlap within a single connector run, which requires `LOOKBACK_LAG` to be under 2 hours. However, as noted above, eventual consistency may extend up to 6 hours, so a `LOOKBACK_LAG` under 2 hours may not catch all delayed records. Resolving this tension would require a mechanism to rotate refresh tokens without restarting the connector, ensuring the `emitted_changes_cache` persists across token rotations. That would require more investigation, design effort, and likely significant CDK changes, which I'm opting to defer for now.