### PR TITLE
source-google-ads: bump API version to v21

### DIFF
--- a/source-google-ads/acmeCo/my_custom_query.schema.yaml
+++ b/source-google-ads/acmeCo/my_custom_query.schema.yaml
@@ -21,8 +21,11 @@ properties:
     type: string
     enum:
     - CONTENT
+    - DISCOVER
+    - GMAIL
     - GOOGLE_OWNED_CHANNELS
     - GOOGLE_TV
+    - MAPS
     - MIXED
     - SEARCH
     - SEARCH_PARTNERS

--- a/source-google-ads/poetry.lock
+++ b/source-google-ads/poetry.lock
@@ -726,14 +726,14 @@ files = [
 
 [[package]]
 name = "google-ads"
-version = "26.1.0"
+version = "28.4.1"
 description = "Client library for the Google Ads API"
 optional = false
-python-versions = "<3.14,>=3.9"
+python-versions = "<3.15,>=3.9"
 groups = ["main"]
 files = [
-    {file = "google_ads-26.1.0-py3-none-any.whl", hash = "sha256:5fd2a7ac7216d45c6f7b8cadd765ea2670fda4a05aa280ea849ecc28f1aa7fd0"},
-    {file = "google_ads-26.1.0.tar.gz", hash = "sha256:3ec4cc8ad07f71c923433bd2a783afc59acd5d428ed75bcc64f8ecaa5b3d8691"},
+    {file = "google_ads-28.4.1-py3-none-any.whl", hash = "sha256:841e9a458bc4b3be9dc4ac3e8268cd781a8dc120607853b0ddddc6488cc3b142"},
+    {file = "google_ads-28.4.1.tar.gz", hash = "sha256:ecb9d651ac7728bfbf56c7dd20130cc1d093abce69df336d6b844d2ca8a1def3"},
 ]
 
 [package.dependencies]
@@ -747,7 +747,7 @@ protobuf = ">=4.25.0,<7.0.0"
 PyYAML = ">=5.1,<7.0"
 
 [package.extras]
-tests = ["nox (>=2020.12.31,<2022.6)"]
+tests = ["nox (>=2025.02.09)"]
 
 [[package]]
 name = "google-api-core"
@@ -2790,4 +2790,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11,<3.13"
-content-hash = "2cd3208967c379fef072f840aee00515f1e7f0989d8c0ba38ee75f35a0e0ae81"
+content-hash = "f50f2c0e63f9d1d9eda40bf5214549de5e5689a6dfcf9950edf0ce37d6fd157e"

--- a/source-google-ads/pyproject.toml
+++ b/source-google-ads/pyproject.toml
@@ -8,7 +8,7 @@ authors = ["Jonathan Wihl <jonathan@estuary.dev>"]
 airbyte-cdk = "^0.52"
 estuary-cdk = {path="../estuary-cdk", develop = true}
 freezegun = "^1.4.0"
-google-ads = "^26.1.0"
+google-ads = "^28.0.0"
 protobuf = ">=5.29.5"
 pydantic = "==1.10.14"
 python = ">=3.11,<3.13"

--- a/source-google-ads/source_google_ads/google_ads.py
+++ b/source-google-ads/source_google_ads/google_ads.py
@@ -14,7 +14,7 @@ import pendulum
 from airbyte_cdk.models import FailureType
 from airbyte_cdk.utils import AirbyteTracedException
 from google.ads.googleads.client import GoogleAdsClient
-from google.ads.googleads.v19.services.types.google_ads_service import (
+from google.ads.googleads.v21.services.types.google_ads_service import (
     GoogleAdsRow,
     SearchGoogleAdsResponse,
 )
@@ -43,7 +43,7 @@ REPORT_MAPPING = {
     "keyword_report": "keyword_view",
     "geo_target_constant": "geo_target_constant",
 }
-API_VERSION = "v19"
+API_VERSION = "v21"
 GRPC_TIMEOUT = 300.0
 REQUEST_TIMEOUT = 420.0
 logger = logging.getLogger("airbyte")

--- a/source-google-ads/source_google_ads/source.py
+++ b/source-google-ads/source_google_ads/source.py
@@ -12,7 +12,7 @@ from airbyte_cdk.sources import AbstractSource
 from airbyte_cdk.sources.streams import Stream
 from airbyte_cdk.utils import AirbyteTracedException
 from google.ads.googleads.errors import GoogleAdsException
-from google.ads.googleads.v19.errors.types.authorization_error import (
+from google.ads.googleads.v21.errors.types.authorization_error import (
     AuthorizationErrorEnum,
 )
 from pendulum import parse, today
@@ -52,7 +52,7 @@ class SourceGoogleAds(AbstractSource):
             try:
                 query["query"] = GAQL.parse(str(query["query"]))
             except ValueError:
-                message = f"The custom GAQL query {query['table_name']} failed. Validate your GAQL query with the Google Ads query validator. https://developers.google.com/google-ads/api/fields/v19/query_validator"
+                message = f"The custom GAQL query {query['table_name']} failed. Validate your GAQL query with the Google Ads query validator. https://developers.google.com/google-ads/api/fields/v21/query_validator"
                 raise AirbyteTracedException(
                     message=message, failure_type=FailureType.config_error
                 )

--- a/source-google-ads/source_google_ads/streams.py
+++ b/source-google-ads/source_google_ads/streams.py
@@ -11,11 +11,11 @@ from airbyte_cdk.models import SyncMode
 from airbyte_cdk.sources.streams import IncrementalMixin, Stream
 from airbyte_cdk.sources.utils.transform import TransformConfig, TypeTransformer
 from google.ads.googleads.errors import GoogleAdsException
-from google.ads.googleads.v19.errors.types.authorization_error import (
+from google.ads.googleads.v21.errors.types.authorization_error import (
     AuthorizationErrorEnum,
 )
-from google.ads.googleads.v19.errors.types.request_error import RequestErrorEnum
-from google.ads.googleads.v19.services.services.google_ads_service.pagers import (
+from google.ads.googleads.v21.errors.types.request_error import RequestErrorEnum
+from google.ads.googleads.v21.services.services.google_ads_service.pagers import (
     SearchPager,
 )
 
@@ -398,7 +398,7 @@ class IncrementalGoogleAdsStream(GoogleAdsStream, IncrementalMixin, ABC):
 
 class Accounts(IncrementalGoogleAdsStream):
     """
-    Accounts stream: https://developers.google.com/google-ads/api/fields/v19/customer
+    Accounts stream: https://developers.google.com/google-ads/api/fields/v21/customer
     """
 
     primary_key = ["customer.id", "segments.date"]
@@ -415,7 +415,7 @@ class ServiceAccounts(GoogleAdsStream):
 
 class Campaigns(IncrementalGoogleAdsStream):
     """
-    Campaigns stream: https://developers.google.com/google-ads/api/fields/v19/campaign
+    Campaigns stream: https://developers.google.com/google-ads/api/fields/v21/campaign
     """
 
     transformer = TypeTransformer(TransformConfig.DefaultSchemaNormalization)
@@ -424,7 +424,7 @@ class Campaigns(IncrementalGoogleAdsStream):
 
 class CampaignLabels(GoogleAdsStream):
     """
-    Campaign labels stream: https://developers.google.com/google-ads/api/fields/v19/campaign_label
+    Campaign labels stream: https://developers.google.com/google-ads/api/fields/v21/campaign_label
     """
 
     # Note that this is a string type. Google doesn't return a more convenient identifier.
@@ -433,7 +433,7 @@ class CampaignLabels(GoogleAdsStream):
 
 class AdGroups(IncrementalGoogleAdsStream):
     """
-    AdGroups stream: https://developers.google.com/google-ads/api/fields/v19/ad_group
+    AdGroups stream: https://developers.google.com/google-ads/api/fields/v21/ad_group
     """
 
     primary_key = ["ad_group.id", "segments.date"]
@@ -441,7 +441,7 @@ class AdGroups(IncrementalGoogleAdsStream):
 
 class AdGroupLabels(GoogleAdsStream):
     """
-    Ad Group Labels stream: https://developers.google.com/google-ads/api/fields/v19/ad_group_label
+    Ad Group Labels stream: https://developers.google.com/google-ads/api/fields/v21/ad_group_label
     """
 
     # Note that this is a string type. Google doesn't return a more convenient identifier.
@@ -450,7 +450,7 @@ class AdGroupLabels(GoogleAdsStream):
 
 class AdGroupAds(IncrementalGoogleAdsStream):
     """
-    AdGroups stream: https://developers.google.com/google-ads/api/fields/v19/ad_group_ad
+    AdGroups stream: https://developers.google.com/google-ads/api/fields/v21/ad_group_ad
     """
 
     primary_key = ["ad_group_ad.ad.id", "segments.date"]
@@ -458,7 +458,7 @@ class AdGroupAds(IncrementalGoogleAdsStream):
 
 class AdGroupAdLabels(GoogleAdsStream):
     """
-    Ad Group Ad Labels stream: https://developers.google.com/google-ads/api/fields/v19/ad_group_ad_label
+    Ad Group Ad Labels stream: https://developers.google.com/google-ads/api/fields/v21/ad_group_ad_label
     """
 
     # Note that this is a string type. Google doesn't return a more convenient identifier.
@@ -467,7 +467,7 @@ class AdGroupAdLabels(GoogleAdsStream):
 
 class AccountPerformanceReport(IncrementalGoogleAdsStream):
     """
-    AccountPerformanceReport stream: https://developers.google.com/google-ads/api/fields/v19/customer
+    AccountPerformanceReport stream: https://developers.google.com/google-ads/api/fields/v21/customer
     Google Ads API field mapping: https://developers.google.com/google-ads/api/docs/migration/mapping#account_performance
     """
 
@@ -481,7 +481,7 @@ class AccountPerformanceReport(IncrementalGoogleAdsStream):
 
 class AdGroupAdReport(IncrementalGoogleAdsStream):
     """
-    AdGroupAdReport stream: https://developers.google.com/google-ads/api/fields/v19/ad_group_ad
+    AdGroupAdReport stream: https://developers.google.com/google-ads/api/fields/v21/ad_group_ad
     Google Ads API field mapping: https://developers.google.com/google-ads/api/docs/migration/mapping#ad_performance
     """
 
@@ -497,7 +497,7 @@ class AdGroupAdReport(IncrementalGoogleAdsStream):
 
 class DisplayKeywordPerformanceReport(IncrementalGoogleAdsStream):
     """
-    DisplayKeywordPerformanceReport stream: https://developers.google.com/google-ads/api/fields/v19/display_keyword_view
+    DisplayKeywordPerformanceReport stream: https://developers.google.com/google-ads/api/fields/v21/display_keyword_view
     Google Ads API field mapping: https://developers.google.com/google-ads/api/docs/migration/mapping#display_keyword_performance
     """
 
@@ -514,7 +514,7 @@ class DisplayKeywordPerformanceReport(IncrementalGoogleAdsStream):
 
 class DisplayTopicsPerformanceReport(IncrementalGoogleAdsStream):
     """
-    DisplayTopicsPerformanceReport stream: https://developers.google.com/google-ads/api/fields/v19/topic_view
+    DisplayTopicsPerformanceReport stream: https://developers.google.com/google-ads/api/fields/v21/topic_view
     Google Ads API field mapping: https://developers.google.com/google-ads/api/docs/migration/mapping#display_topics_performance
     """
 
@@ -531,7 +531,7 @@ class DisplayTopicsPerformanceReport(IncrementalGoogleAdsStream):
 
 class ShoppingPerformanceReport(IncrementalGoogleAdsStream):
     """
-    ShoppingPerformanceReport stream: https://developers.google.com/google-ads/api/fields/v19/shopping_performance_view
+    ShoppingPerformanceReport stream: https://developers.google.com/google-ads/api/fields/v21/shopping_performance_view
     Google Ads API field mapping: https://developers.google.com/google-ads/api/docs/migration/mapping#shopping_performance
     """
 
@@ -548,7 +548,7 @@ class ShoppingPerformanceReport(IncrementalGoogleAdsStream):
 
 class UserLocationReport(IncrementalGoogleAdsStream):
     """
-    UserLocationReport stream: https://developers.google.com/google-ads/api/fields/v19/user_location_view
+    UserLocationReport stream: https://developers.google.com/google-ads/api/fields/v21/user_location_view
     Google Ads API field mapping: https://developers.google.com/google-ads/api/docs/migration/mapping#geo_performance
     """
 
@@ -563,7 +563,7 @@ class UserLocationReport(IncrementalGoogleAdsStream):
 
 class GeographicReport(IncrementalGoogleAdsStream):
     """
-    UserLocationReport stream: https://developers.google.com/google-ads/api/fields/v19/geographic_view
+    UserLocationReport stream: https://developers.google.com/google-ads/api/fields/v21/geographic_view
     """
 
     primary_key = [
@@ -576,7 +576,7 @@ class GeographicReport(IncrementalGoogleAdsStream):
 
 class KeywordReport(IncrementalGoogleAdsStream):
     """
-    UserLocationReport stream: https://developers.google.com/google-ads/api/fields/v19/keyword_view
+    UserLocationReport stream: https://developers.google.com/google-ads/api/fields/v21/keyword_view
     """
 
     primary_key = ["segments.date", "ad_group.id", "ad_group_criterion.criterion_id"]
@@ -584,7 +584,7 @@ class KeywordReport(IncrementalGoogleAdsStream):
 
 class ClickView(IncrementalGoogleAdsStream):
     """
-    ClickView stream: https://developers.google.com/google-ads/api/reference/rpc/v19/ClickView
+    ClickView stream: https://developers.google.com/google-ads/api/reference/rpc/v21/ClickView
     """
 
     primary_key = ["click_view.gclid", "segments.date", "segments.ad_network_type"]
@@ -594,7 +594,7 @@ class ClickView(IncrementalGoogleAdsStream):
 
 class GeoTargetConstant(GoogleAdsStream):
     """
-    GeoTargetConstant stream: https://developers.google.com/google-ads/api/fields/v19/geo_target_constant
+    GeoTargetConstant stream: https://developers.google.com/google-ads/api/fields/v21/geo_target_constant
     """
 
     primary_key = ["geo_target_constant.id"]

--- a/source-google-ads/tests/common.py
+++ b/source-google-ads/tests/common.py
@@ -5,7 +5,7 @@
 import json
 
 from google.ads.googleads.errors import GoogleAdsException
-from google.ads.googleads.v19.errors.types.errors import GoogleAdsFailure
+from google.ads.googleads.v21.errors.types.errors import GoogleAdsFailure
 from source_google_ads.google_ads import GRPC_TIMEOUT
 
 class MockSearchRequest:

--- a/source-google-ads/tests/snapshots/snapshots__discover__capture.stdout.json
+++ b/source-google-ads/tests/snapshots/snapshots__discover__capture.stdout.json
@@ -5449,8 +5449,11 @@
           "type": "string",
           "enum": [
             "CONTENT",
+            "DISCOVER",
+            "GMAIL",
             "GOOGLE_OWNED_CHANNELS",
             "GOOGLE_TV",
+            "MAPS",
             "MIXED",
             "SEARCH",
             "SEARCH_PARTNERS",

--- a/source-google-ads/tests/test_google_ads.py
+++ b/source-google-ads/tests/test_google_ads.py
@@ -10,7 +10,7 @@ import pendulum
 import pytest
 from airbyte_cdk.utils import AirbyteTracedException
 from freezegun import freeze_time
-from google.ads.googleads.v19.common.types.ad_asset import AdTextAsset
+from google.ads.googleads.v21.common.types.ad_asset import AdTextAsset
 from google.auth import exceptions
 from pendulum.tz.timezone import Timezone
 from proto import Message

--- a/source-google-ads/tests/test_source.py
+++ b/source-google-ads/tests/test_source.py
@@ -11,7 +11,7 @@ import pytest
 from airbyte_cdk import AirbyteLogger
 from freezegun import freeze_time
 from google.ads.googleads.errors import GoogleAdsException
-from google.ads.googleads.v19.errors.types.authorization_error import (
+from google.ads.googleads.v21.errors.types.authorization_error import (
     AuthorizationErrorEnum,
 )
 from pendulum import today

--- a/source-google-ads/tests/test_streams.py
+++ b/source-google-ads/tests/test_streams.py
@@ -8,8 +8,8 @@ from unittest.mock import Mock
 import pytest
 from airbyte_cdk.models import SyncMode
 from google.ads.googleads.errors import GoogleAdsException
-from google.ads.googleads.v19.errors.types.errors import ErrorCode, GoogleAdsError, GoogleAdsFailure
-from google.ads.googleads.v19.errors.types.request_error import RequestErrorEnum
+from google.ads.googleads.v21.errors.types.errors import ErrorCode, GoogleAdsError, GoogleAdsFailure
+from google.ads.googleads.v21.errors.types.request_error import RequestErrorEnum
 from google.api_core.exceptions import DataLoss, InternalServerError, ResourceExhausted, TooManyRequests
 from grpc import RpcError
 from source_google_ads.google_ads import GoogleAds

--- a/source-google-ads/tests/test_utils.py
+++ b/source-google-ads/tests/test_utils.py
@@ -107,7 +107,7 @@ def test_parse_GAQL_ok():
 def test_parse_GAQL_fail(config):
     with pytest.raises(AirbyteTracedException) as e:
         SourceGoogleAds._validate_and_transform(config)
-    expected_message = "The custom GAQL query test_table failed. Validate your GAQL query with the Google Ads query validator. https://developers.google.com/google-ads/api/fields/v19/query_validator"
+    expected_message = "The custom GAQL query test_table failed. Validate your GAQL query with the Google Ads query validator. https://developers.google.com/google-ads/api/fields/v21/query_validator"
     assert e.value.message == expected_message
 
 


### PR DESCRIPTION
**Description:**

Updates the connector's soon to be deprecated v19 to v21.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

The following v19 -> v21 breaking changes have been observed:

- `campaign.url_expansion_opt_out` removed
- `debug_enabled` mode in `ConversionUploadService` removed

Neither of these are used in production custom queries.

Changes have been tested through `flowctl preview` and a partial web UI test.

