### PR TITLE
source-mysql: Statement timeout advanced option

### DIFF
--- a/source-mysql/.snapshots/TestGeneric-SpecResponse
+++ b/source-mysql/.snapshots/TestGeneric-SpecResponse
@@ -84,6 +84,19 @@
             "title": "Feature Flags",
             "description": "This property is intended for Estuary internal use. You should only modify this field as directed by Estuary support."
           },
+          "statement_timeout": {
+            "type": "string",
+            "enum": [
+              "",
+              "30s",
+              "1m",
+              "5m",
+              "30m"
+            ],
+            "title": "Statement Timeout",
+            "description": "Overrides the default statement timeout used by the connector. The default of zero disables statement timeouts entirely.",
+            "default": ""
+          },
           "watermarks_table": {
             "type": "string",
             "title": "Watermarks Table Name",


### PR DESCRIPTION
**Description:**

Mostly implemented for feature parity with source-postgres, and also because Dave thinks it might help with a production MySQL capture issue and it seems worth a shot