### PR TITLE
materialize-iceberg: set oauth2-server-ui in spark

### DIFF
--- a/materialize-iceberg/driver.go
+++ b/materialize-iceberg/driver.go
@@ -129,6 +129,7 @@ func newMaterialization(ctx context.Context, materializationName string, cfg con
 			c:                   emr,
 			bucket:              bucket,
 			ssmClient:           ssmClient,
+			tokenURL:            catalog.TokenURL(),
 		},
 		ssmClient: ssmClient,
 		templates: parseTemplates(),

--- a/materialize-iceberg/emr.go
+++ b/materialize-iceberg/emr.go
@@ -30,6 +30,7 @@ type emrClient struct {
 	c                   *emr.Client
 	bucket              blob.Bucket
 	ssmClient           *ssm.Client
+	tokenURL            string
 }
 
 func (e *emrClient) checkPrereqs(ctx context.Context, errs *cerrors.PrereqErr) {
@@ -101,6 +102,7 @@ func (e *emrClient) runJob(ctx context.Context, input any, entryPointUri, pyFile
 	| --credential-secret-name | Name of the secret in Systems Manager if using client credentials auth               | Optional |
 	| --scope                  | Scope if using client credentials auth                                               | Optional |
 	| --signing-name           | Signing name to use when authenticating with AWS SigV4. Either 'glue' or 's3tables'. | Optional |
+	| --oauth2-server-uri      | OAuth2 token endpoint URI.                                                           | Optional |
 	***/
 	getStatus := func() (*python.StatusOutput, error) {
 		var status python.StatusOutput
@@ -128,6 +130,10 @@ func (e *emrClient) runJob(ctx context.Context, input any, entryPointUri, pyFile
 		"--catalog-url", e.catalogURL,
 		"--warehouse", e.warehouse,
 		"--region", e.cfg.Region,
+	}
+
+	if e.tokenURL != "" {
+		args = append(args, "--oauth2-server-uri", e.tokenURL)
 	}
 
 	if e.catalogAuth.AuthType == catalogAuthTypeClientCredential {

--- a/materialize-iceberg/python/common.py
+++ b/materialize-iceberg/python/common.py
@@ -1,5 +1,6 @@
 import argparse
 import json
+import sys
 from dataclasses import dataclass
 from typing import Optional
 from urllib.parse import urlparse
@@ -109,6 +110,11 @@ def common_args() -> argparse.Namespace:
         required=False,
         help="Signing name to use when authenticating with AWS SigV4. Either 'glue' or 's3tables'.",
     )
+    parser.add_argument(
+        "--oauth2-server-uri",
+        required=False,
+        help="OAuth2 token endpoint URI.",
+    )
     return parser.parse_args()
 
 
@@ -134,6 +140,12 @@ def get_spark_session(args: argparse.Namespace) -> SparkSession:
         .config("spark.sql.catalog.estuary.uri", args.catalog_url)
         .config("spark.sql.catalog.estuary.warehouse", args.warehouse)
     )
+
+    if args.oauth2_server_uri is not None:
+        builder = builder.config(
+            "spark.sql.catalog.estuary.oauth2-server-uri",
+            args.oauth2_server_uri
+        )
 
     if args.credential_secret_name:
         credential = (


### PR DESCRIPTION
**Description:**

This option is required when using OAuth2 client credentials with a non-default location and tells spark where the token endpoint is for the catalog.

**Workflow steps:**

Applied automatically

**Documentation links affected:**

None

**Notes for reviewers:**

(anything that might help someone review this PR)

