### PR TITLE
source-iterable-native: convert `list_users` from a snapshot to a backfill only stream

### DIFF
--- a/source-iterable-native/source_iterable_native/__init__.py
+++ b/source-iterable-native/source_iterable_native/__init__.py
@@ -11,35 +11,35 @@ from estuary_cdk.capture import (
 )
 from estuary_cdk.flow import ConnectorSpec
 
-from .models import ConnectorState, EndpointConfig, ResourceConfig
+from .models import ConnectorState, EndpointConfig, ResourceConfigWithSchedule
 from .resources import all_resources, validate_credentials
 
 
 class Connector(
-    BaseCaptureConnector[EndpointConfig, ResourceConfig, ConnectorState],
+    BaseCaptureConnector[EndpointConfig, ResourceConfigWithSchedule, ConnectorState],
 ):
     def request_class(self):
-        return Request[EndpointConfig, ResourceConfig, ConnectorState]
+        return Request[EndpointConfig, ResourceConfigWithSchedule, ConnectorState]
 
     async def spec(self, log: Logger, _: request.Spec) -> ConnectorSpec:
         return ConnectorSpec(
             configSchema=EndpointConfig.model_json_schema(),
             oauth2=None,
             documentationUrl="https://go.estuary.dev/source-iterable-native",
-            resourceConfigSchema=ResourceConfig.model_json_schema(),
-            resourcePathPointers=ResourceConfig.PATH_POINTERS,
+            resourceConfigSchema=ResourceConfigWithSchedule.model_json_schema(),
+            resourcePathPointers=ResourceConfigWithSchedule.PATH_POINTERS,
         )
 
     async def discover(
         self, log: Logger, discover: request.Discover[EndpointConfig]
-    ) -> response.Discovered[ResourceConfig]:
+    ) -> response.Discovered[ResourceConfigWithSchedule]:
         resources = await all_resources(log, self, discover.config)
         return common.discovered(resources)
 
     async def validate(
         self,
         log: Logger,
-        validate: request.Validate[EndpointConfig, ResourceConfig],
+        validate: request.Validate[EndpointConfig, ResourceConfigWithSchedule],
     ) -> response.Validated:
         await validate_credentials(log, self, validate.config)
         resources = await all_resources(log, self, validate.config)
@@ -49,7 +49,7 @@ class Connector(
     async def open(
         self,
         log: Logger,
-        open: request.Open[EndpointConfig, ResourceConfig, ConnectorState],
+        open: request.Open[EndpointConfig, ResourceConfigWithSchedule, ConnectorState],
     ) -> tuple[response.Opened, Callable[[Task], Awaitable[None]]]:
         resources = await all_resources(log, self, open.capture.config, should_cancel_running_jobs=True)
         resolved = common.resolve_bindings(open.capture.bindings, resources)

--- a/source-iterable-native/source_iterable_native/models.py
+++ b/source-iterable-native/source_iterable_native/models.py
@@ -12,7 +12,7 @@ from estuary_cdk.capture.common import (
     ConnectorState as GenericConnectorState,
     LogCursor,
     Logger,
-    ResourceConfig,
+    ResourceConfigWithSchedule,
     ResourceState,
 )
 from estuary_cdk.http import AccessToken
@@ -190,12 +190,11 @@ class Templates(IterableResource):
 class ListUsers(IterableResource):
     name: ClassVar[str] = "list_users"
     path: ClassVar[str] = "lists/getUsers"
-    # The lists/getUsers endpoint has pretty strict rate limits, and
-    # we need to make as many requests as there are lists to complete
-    # a snapshot. This can take hours, so to make the garden path
-    # easier for most users, we disable this stream and use a larger
-    # interval by default.
-    interval: ClassVar[timedelta] = timedelta(hours=4)
+    # Since list_users has a backfill task but not an incremental task,
+    # the interval has no effect. Instead, the schedule
+    # dictates how frequently the stream re-backfills all records.
+    interval: ClassVar[timedelta] = timedelta(hours=24)
+    schedule: ClassVar[str] = "55 23 * * *"
     disable: ClassVar[bool] = True
 
     list_id: int

--- a/source-iterable-native/tests/snapshots/snapshots__discover__capture.stdout.json
+++ b/source-iterable-native/tests/snapshots/snapshots__discover__capture.stdout.json
@@ -297,7 +297,8 @@
     "recommendedName": "list_users",
     "resourceConfig": {
       "name": "list_users",
-      "interval": "PT4H"
+      "interval": "P1D",
+      "schedule": "55 23 * * *"
     },
     "documentSchema": {
       "$defs": {
@@ -325,18 +326,32 @@
           "type": "object"
         }
       },
+      "additionalProperties": true,
       "properties": {
         "_meta": {
           "$ref": "#/$defs/Meta",
           "description": "Document metadata"
+        },
+        "list_id": {
+          "title": "List Id",
+          "type": "integer"
+        },
+        "user_id": {
+          "title": "User Id",
+          "type": "string"
         }
       },
-      "title": "BaseDocument",
+      "required": [
+        "list_id",
+        "user_id"
+      ],
+      "title": "ListUsers",
       "type": "object",
       "x-infer-schema": true
     },
     "key": [
-      "/_meta/row_id"
+      "/list_id",
+      "/user_id"
     ],
     "disable": true
   },

--- a/source-iterable-native/tests/snapshots/snapshots__spec__capture.stdout.json
+++ b/source-iterable-native/tests/snapshots/snapshots__spec__capture.stdout.json
@@ -93,7 +93,6 @@
     },
     "resourceConfigSchema": {
       "additionalProperties": false,
-      "description": "ResourceConfig is a common resource configuration shape.",
       "properties": {
         "_meta": {
           "anyOf": [
@@ -119,12 +118,19 @@
           "format": "duration",
           "title": "Interval",
           "type": "string"
+        },
+        "schedule": {
+          "default": "",
+          "description": "Schedule to automatically rebackfill this binding. Accepts a cron expression.",
+          "pattern": "^((?:[0-5]?\\d(?:-[0-5]?\\d)?|\\*(?:/[0-5]?\\d)?)(?:,(?:[0-5]?\\d(?:-[0-5]?\\d)?|\\*(?:/[0-5]?\\d)?))*)\\s+((?:[01]?\\d|2[0-3]|(?:[01]?\\d|2[0-3])-(?:[01]?\\d|2[0-3])|\\*(?:/[01]?\\d|/2[0-3])?)(?:,(?:[01]?\\d|2[0-3]|(?:[01]?\\d|2[0-3])-(?:[01]?\\d|2[0-3])|\\*(?:/[01]?\\d|/2[0-3])?))*)\\s+((?:0?[1-9]|[12]\\d|3[01]|(?:0?[1-9]|[12]\\d|3[01])-(?:0?[1-9]|[12]\\d|3[01])|\\*(?:/[0-9]|/1[0-9]|/2[0-9]|/3[01])?)(?:,(?:0?[1-9]|[12]\\d|3[01]|(?:0?[1-9]|[12]\\d|3[01])-(?:0?[1-9]|[12]\\d|3[01])|\\*(?:/[0-9]|/1[0-9]|/2[0-9]|/3[01])?))*)\\s+((?:[1-9]|1[0-2]|(?:[1-9]|1[0-2])-(?:[1-9]|1[0-2])|\\*(?:/[1-9]|/1[0-2])?)(?:,(?:[1-9]|1[0-2]|(?:[1-9]|1[0-2])-(?:[1-9]|1[0-2])|\\*(?:/[1-9]|/1[0-2])?))*)\\s+((?:[0-6]|(?:[0-6])-(?:[0-6])|\\*(?:/[0-6])?)(?:,(?:[0-6]|(?:[0-6])-(?:[0-6])|\\*(?:/[0-6])?))*)$|^$",
+          "title": "Schedule",
+          "type": "string"
         }
       },
       "required": [
         "name"
       ],
-      "title": "ResourceConfig",
+      "title": "ResourceConfigWithSchedule",
       "type": "object"
     },
     "documentationUrl": "https://go.estuary.dev/source-iterable-native",


### PR DESCRIPTION
**Description:**

The `list_users` stream was causing OOMs and blocking graceful shutdowns because snapshotting all lists' users could take hours due to API limitations (5 req/min rate limit, responses taking 80+ minutes for large lists, no pagination).

This PR converts `list_users` to use periodic backfill, fetching a single list's users per `fetch_page` invocation. This makes the connector more responsive during graceful shutdowns, and the connector can make incremental progress while backfilling `list_users`. In order to capture new and updated `list_users`, a backfill schedule is used; by default, a backfill will be kicked off at most once a day.

The discover snapshot change is expected - the primary key for `list_users` is changing. All production captures will have to perform data flow resets for `list_users` due to the key change. This only applies to one capture, so I'll do that myself after merging this change.

The spec snapshot change is also expected due to the addition of the `schedule` field to the resource config.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

The connector's documentation should be updated to reflect the new `schedule` resource config field and explain how it's used to capture new and updated `list_users`.

**Notes for reviewers:**

Tested on a local stack. I confirmed a single list's users is captured per `fetch_page` invocation, and the connector is able to make progress on a sweep of all lists' users across capture restarts.