### PR TITLE
estuary-cdk: fix timeout=None disabling requests timeouts

### DIFF
--- a/estuary-cdk/estuary_cdk/http.py
+++ b/estuary-cdk/estuary_cdk/http.py
@@ -98,7 +98,7 @@ class HTTPSession(abc.ABC):
      * `json` is a JSON-encoded request body (if set, `form` cannot be)
      * `form` is a form URL-encoded request body (if set, `json` cannot be)
      * `should_retry` determines whether 5xx errors are retried or bubbled up. If not provided, all 5xx errors are retried.
-     * `timeout` is an aiohttp.ClientTimeout for the request. If not provided, the default aiohttp timeout is used.
+     * `timeout` is an aiohttp.ClientTimeout for the request. If not provided, the default aiohttp session timeout is used.
     """
 
     async def request(
@@ -509,6 +509,10 @@ class HTTPMixin(Mixin, HTTPSession):
             )
             headers[self.token_source.authorization_header] = header_value
 
+        # Only pass timeout if explicitly provided. Otherwise, omit the
+        # timeout argument and rely on the session's default timeout.
+        optional_kwargs: dict[str, Any] = {"timeout": timeout} if timeout is not None else {}
+
         resp = await self.inner.request(
             headers=headers,
             json=json,
@@ -516,7 +520,7 @@ class HTTPMixin(Mixin, HTTPSession):
             method=method,
             params=params,
             url=url,
-            timeout=timeout,
+            **optional_kwargs,
         )
 
         return resp


### PR DESCRIPTION
**Description:**

Fixes a bug introduced in 3c0d554f180d90659f78601b9da5754aaafd98a7. Passing `timeout=None` to `aiohttp.ClientSession.request()` disables timeouts entirely rather than using the session default. We should only pass the timeout parameter when it's explicitly provided so `aiohttp` falls back to the session's default timeout.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

