### PR TITLE
source-google-ads: Add primary keys to custom query schemas' required array

### DIFF
--- a/source-google-ads/source_google_ads/custom_query_stream.py
+++ b/source-google-ads/source_google_ads/custom_query_stream.py
@@ -45,6 +45,7 @@ class CustomQueryMixin:
             "type": "object",
             "properties": {},
             "additionalProperties": True,
+            "required": [],
         }
         # full list {'ENUM', 'STRING', 'DATE', 'DOUBLE', 'RESOURCE_NAME', 'INT32', 'INT64', 'BOOLEAN', 'MESSAGE'}
 
@@ -95,7 +96,7 @@ class CustomQueryMixin:
 
             local_json_schema["properties"][field] = field_value
 
-        # Primary key fields should not be nullable
+        # Primary key fields should not be nullable and must be required
         for pk in self.primary_key:
             if pk in local_json_schema["properties"]:
                 prop = local_json_schema["properties"][pk]
@@ -103,6 +104,7 @@ class CustomQueryMixin:
                 if isinstance(field_type, list) and "null" in field_type:
                     non_null_types = [t for t in field_type if t != "null"]
                     prop["type"] = non_null_types[0] if len(non_null_types) == 1 else non_null_types
+                local_json_schema["required"].append(pk)
 
         return local_json_schema
 

--- a/source-google-ads/tests/snapshots/snapshots__discover__capture.stdout.json
+++ b/source-google-ads/tests/snapshots/snapshots__discover__capture.stdout.json
@@ -5515,6 +5515,10 @@
         }
       },
       "additionalProperties": true,
+      "required": [
+        "customer.id",
+        "segments.date"
+      ],
       "x-infer-schema": true
     },
     "key": [

--- a/source-google-ads/tests/test_custom_query.py
+++ b/source-google-ads/tests/test_custom_query.py
@@ -41,7 +41,7 @@ def test_get_json_schema():
     })
     instance = CustomQueryMixin(config={
         'query': Obj(fields=['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j']),
-        'primary_key': '',
+        'primary_key': 'a',
     })
     instance.cursor_field = None
     instance.google_ads_client = Obj(get_fields_metadata=query_object)
@@ -62,12 +62,13 @@ def test_get_json_schema():
             'h': {'type': ['null', 'array'], 'items': {'type': 'integer'}},
             'i': {'type': ['null', 'array'], 'items': {'type': 'number'}},
             'j': {'type': ['null', 'array'], 'items': {'type': 'boolean'}},
-        }
+        },
+        'required': ['a'],
     }
 
 
 def test_get_json_schema_primary_keys_not_nullable():
-    """Primary key fields should not have null in their type."""
+    """Primary key fields should not have null in their type and must be required."""
     query_object = MagicMock(return_value={
         'a': Obj(data_type=Obj(name='ENUM'), is_repeated=False, enum_values=['a', 'aa']),
         'b': Obj(data_type=Obj(name='ENUM'), is_repeated=True,  enum_values=['b', 'bb']),
@@ -103,5 +104,6 @@ def test_get_json_schema_primary_keys_not_nullable():
             'h': {'type': 'array', 'items': {'type': 'integer'}},
             'i': {'type': 'array', 'items': {'type': 'number'}},
             'j': {'type': 'array', 'items': {'type': 'boolean'}},
-        }
+        },
+        'required': ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j'],
     }


### PR DESCRIPTION
**Description:**

Custom query schemas were missing key fields in the `required` array. During a data flow reset, when no inferred schema exists yet, this caused key fields to have `exists: MAY` instead of `MUST`, failing materialization validation with "nullable key field" errors.

To allow data flow resets to work correctly, we need to include the primary keys in the schemas' `required` array.

This PR follows up and completes the intention of https://github.com/estuary/connectors/pull/3810.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

