### PR TITLE
source-azure-blob-storage: add title to advanced config schema

### DIFF
--- a/source-azure-blob-storage/.snapshots/TestAzureBlobStore_getConfigSchema
+++ b/source-azure-blob-storage/.snapshots/TestAzureBlobStore_getConfigSchema
@@ -1,110 +1,117 @@
 {
-		"$schema": "http://json-schema.org/draft-07/schema#",
-		"title": "Azure Blob Storage Source",
-		"type": "object",
-		"properties": {
-			"credentials": {
-				"type": "object",
-				"title": "Credentials",
-				"description": "Azure credentials used to authenticate with Azure Blob Storage.",
-				"order": 0,
-				"oneOf": [
-					{
-						"title": "OAuth2 Credentials",
-						"required": [
-							"azureClientID",
-							"azureClientSecret",
-							"azureTenantID",
-							"azureSubscriptionID",
-							"storageAccountName"
-						],
-						"properties": {
-							"azureClientID": {
-								"type": "string",
-								"title": "Azure Client ID",
-								"description": "The client ID used to authenticate with Azure Blob Storage.",
-								"order": 0
-							},
-							"azureClientSecret": {
-								"type": "string",
-								"title": "Azure Client Secret",
-								"description": "The client secret used to authenticate with Azure Blob Storage.",
-								"secret": true,
-								"order": 1
-							},
-							"azureTenantID": {
-								"type": "string",
-								"title": "Azure Tenant ID",
-								"description": "The ID of the Azure tenant where the Azure Blob Storage account is located.",
-								"order": 2
-							},
-							"azureSubscriptionID": {
-								"type": "string",
-								"title": "Azure Subscription ID",
-								"description": "The ID of the Azure subscription that contains the Azure Blob Storage account.",
-								"order": 3
-							},
-							"storageAccountName": {
-								"type": "string",
-								"title": "Storage Account Name",
-								"description": "The name of the Azure Blob Storage account.",
-								"order": 1
-							}
-						}
-					},
-					{
-						"title": "Connection String",
-						"required": [
-							"ConnectionString",
-							"storageAccountName"
-						],
-						"properties": {
-							"ConnectionString": {
-								"type": "string",
-								"title": "Connection String",
-								"description": "The connection string used to authenticate with Azure Blob Storage.",
-								"order": 0
-							},
-							"storageAccountName": {
-								"type": "string",
-								"title": "Storage Account Name",
-								"description": "The name of the Azure Blob Storage account.",
-								"order": 1
-							}
-						}
-					}
-				],
-				"title": "Credentials",
-				"description": "Azure credentials used to authenticate with Azure Blob Storage."
-			},
-			"containerName": {
-				"type": "string",
-				"title": "Container Name",
-				"description": "The name of the Azure Blob Storage container to read from.",
-				"order": 1
-			},
-			"matchKeys": {
-				"type": "string",
-				"title": "Match Keys",
-				"format": "regex",
-				"description": "Filter applied to all object keys under the prefix. If provided, only objects whose absolute path matches this regex will be read. For example, you can use \".*\\.json\" to only capture json files.",
-				"order": 2
-			},
-			"advanced": {
-				"properties": {
-				  "ascendingKeys": {
-					"type":        "boolean",
-					"title":       "Ascending Keys",
-					"description": "Improve sync speeds by listing files from the end of the last sync, rather than listing the entire bucket prefix. This requires that you write objects in ascending lexicographic order, such as an RFC-3339 timestamp, so that key ordering matches modification time ordering.",
-					"default":     false
-				  }
-				},
-				"additionalProperties": false,
-				"type": "object",
-				"description": "Options for advanced users. You should not typically need to modify these.",
-				"advanced": true,
-				"order": 3
-			},
-			"parser": {"type": "object", "properties": {"name": {"type": "string"}}}
-		}
-	}
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "properties": {
+    "advanced": {
+      "additionalProperties": false,
+      "advanced": true,
+      "description": "Options for advanced users. You should not typically need to modify these.",
+      "order": 5,
+      "properties": {
+        "ascendingKeys": {
+          "default": false,
+          "description": "Improve sync speeds by listing files from the end of the last sync, rather than listing the entire bucket prefix. This requires that you write objects in ascending lexicographic order, such as an RFC-3339 timestamp, so that key ordering matches modification time ordering.",
+          "title": "Ascending Keys",
+          "type": "boolean"
+        }
+      },
+      "title": "Advanced",
+      "type": "object"
+    },
+    "containerName": {
+      "description": "The name of the Azure Blob Storage container to read from.",
+      "order": 1,
+      "title": "Container Name",
+      "type": "string"
+    },
+    "credentials": {
+      "description": "Azure credentials used to authenticate with Azure Blob Storage.",
+      "oneOf": [
+        {
+          "properties": {
+            "azureClientID": {
+              "description": "The client ID used to authenticate with Azure Blob Storage.",
+              "order": 0,
+              "title": "Azure Client ID",
+              "type": "string"
+            },
+            "azureClientSecret": {
+              "description": "The client secret used to authenticate with Azure Blob Storage.",
+              "order": 1,
+              "secret": true,
+              "title": "Azure Client Secret",
+              "type": "string"
+            },
+            "azureSubscriptionID": {
+              "description": "The ID of the Azure subscription that contains the Azure Blob Storage account.",
+              "order": 3,
+              "title": "Azure Subscription ID",
+              "type": "string"
+            },
+            "azureTenantID": {
+              "description": "The ID of the Azure tenant where the Azure Blob Storage account is located.",
+              "order": 2,
+              "title": "Azure Tenant ID",
+              "type": "string"
+            },
+            "storageAccountName": {
+              "description": "The name of the Azure Blob Storage account.",
+              "order": 4,
+              "title": "Storage Account Name",
+              "type": "string"
+            }
+          },
+          "required": [
+            "azureClientID",
+            "azureClientSecret",
+            "azureTenantID",
+            "azureSubscriptionID",
+            "storageAccountName"
+          ],
+          "title": "OAuth2 Credentials"
+        },
+        {
+          "properties": {
+            "ConnectionString": {
+              "description": "The connection string used to authenticate with Azure Blob Storage.",
+              "order": 0,
+              "title": "Connection String",
+              "type": "string"
+            },
+            "storageAccountName": {
+              "description": "The name of the Azure Blob Storage account.",
+              "order": 1,
+              "title": "Storage Account Name",
+              "type": "string"
+            }
+          },
+          "required": [
+            "ConnectionString",
+            "storageAccountName"
+          ],
+          "title": "Connection String"
+        }
+      ],
+      "order": 3,
+      "title": "Credentials",
+      "type": "object"
+    },
+    "matchKeys": {
+      "description": "Filter applied to all object keys under the prefix. If provided, only objects whose absolute path matches this regex will be read. For example, you can use \".*\\.json\" to only capture json files.",
+      "format": "regex",
+      "order": 2,
+      "title": "Match Keys",
+      "type": "string"
+    },
+    "parser": {
+      "order": 4,
+      "properties": {
+        "name": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    }
+  },
+  "title": "Azure Blob Storage Source",
+  "type": "object"
+}

--- a/source-azure-blob-storage/main.go
+++ b/source-azure-blob-storage/main.go
@@ -279,117 +279,127 @@ func (l *azureBlobListing) getPage() (*azblob.ListBlobsFlatResponse, error) {
 }
 
 func getConfigSchema(parserSchema json.RawMessage) json.RawMessage {
+	var parserOrderSchema map[string]any
+	err := json.Unmarshal(parserSchema, &parserOrderSchema)
+	if err != nil {
+		panic(fmt.Errorf("unable to parse parser schema: %w", err))
+	}
+	parserOrderSchema["order"] = 4
 
-	return json.RawMessage(`{
+	schema := map[string]any{
 		"$schema": "http://json-schema.org/draft-07/schema#",
-		"title": "Azure Blob Storage Source",
-		"type": "object",
-		"properties": {
-			"credentials": {
-				"type": "object",
-				"title": "Credentials",
+		"title":   "Azure Blob Storage Source",
+		"type":    "object",
+		"properties": map[string]any{
+			"containerName": map[string]any{
+				"type":        "string",
+				"title":       "Container Name",
+				"description": "The name of the Azure Blob Storage container to read from.",
+				"order":       1,
+			},
+			"matchKeys": map[string]any{
+				"type":        "string",
+				"title":       "Match Keys",
+				"format":      "regex",
+				"description": "Filter applied to all object keys under the prefix. If provided, only objects whose absolute path matches this regex will be read. For example, you can use \".*\\.json\" to only capture json files.",
+				"order":       2,
+			},
+			"credentials": map[string]any{
+				"type":        "object",
+				"title":       "Credentials",
 				"description": "Azure credentials used to authenticate with Azure Blob Storage.",
-				"order": 0,
-				"oneOf": [
-					{
+				"order":       3,
+				"oneOf": []any{
+					map[string]any{
 						"title": "OAuth2 Credentials",
-						"required": [
+						"required": []string{
 							"azureClientID",
 							"azureClientSecret",
 							"azureTenantID",
 							"azureSubscriptionID",
-							"storageAccountName"
-						],
-						"properties": {
-							"azureClientID": {
-								"type": "string",
-								"title": "Azure Client ID",
+							"storageAccountName",
+						},
+						"properties": map[string]any{
+							"azureClientID": map[string]any{
+								"type":        "string",
+								"title":       "Azure Client ID",
 								"description": "The client ID used to authenticate with Azure Blob Storage.",
-								"order": 0
+								"order":       0,
 							},
-							"azureClientSecret": {
-								"type": "string",
-								"title": "Azure Client Secret",
+							"azureClientSecret": map[string]any{
+								"type":        "string",
+								"title":       "Azure Client Secret",
 								"description": "The client secret used to authenticate with Azure Blob Storage.",
-								"secret": true,
-								"order": 1
+								"secret":      true,
+								"order":       1,
 							},
-							"azureTenantID": {
-								"type": "string",
-								"title": "Azure Tenant ID",
+							"azureTenantID": map[string]any{
+								"type":        "string",
+								"title":       "Azure Tenant ID",
 								"description": "The ID of the Azure tenant where the Azure Blob Storage account is located.",
-								"order": 2
+								"order":       2,
 							},
-							"azureSubscriptionID": {
-								"type": "string",
-								"title": "Azure Subscription ID",
+							"azureSubscriptionID": map[string]any{
+								"type":        "string",
+								"title":       "Azure Subscription ID",
 								"description": "The ID of the Azure subscription that contains the Azure Blob Storage account.",
-								"order": 3
+								"order":       3,
 							},
-							"storageAccountName": {
-								"type": "string",
-								"title": "Storage Account Name",
+							"storageAccountName": map[string]any{
+								"type":        "string",
+								"title":       "Storage Account Name",
 								"description": "The name of the Azure Blob Storage account.",
-								"order": 1
-							}
-						}
+								"order":       4,
+							},
+						},
 					},
-					{
+					map[string]any{
 						"title": "Connection String",
-						"required": [
+						"required": []string{
 							"ConnectionString",
-							"storageAccountName"
-						],
-						"properties": {
-							"ConnectionString": {
-								"type": "string",
-								"title": "Connection String",
+							"storageAccountName",
+						},
+						"properties": map[string]any{
+							"ConnectionString": map[string]any{
+								"type":        "string",
+								"title":       "Connection String",
 								"description": "The connection string used to authenticate with Azure Blob Storage.",
-								"order": 0
+								"order":       0,
 							},
-							"storageAccountName": {
-								"type": "string",
-								"title": "Storage Account Name",
+							"storageAccountName": map[string]any{
+								"type":        "string",
+								"title":       "Storage Account Name",
 								"description": "The name of the Azure Blob Storage account.",
-								"order": 1
-							}
-						}
-					}
-				],
-				"title": "Credentials",
-				"description": "Azure credentials used to authenticate with Azure Blob Storage."
+								"order":       1,
+							},
+						},
+					},
+				},
 			},
-			"containerName": {
-				"type": "string",
-				"title": "Container Name",
-				"description": "The name of the Azure Blob Storage container to read from.",
-				"order": 1
-			},
-			"matchKeys": {
-				"type": "string",
-				"title": "Match Keys",
-				"format": "regex",
-				"description": "Filter applied to all object keys under the prefix. If provided, only objects whose absolute path matches this regex will be read. For example, you can use \".*\\.json\" to only capture json files.",
-				"order": 2
-			},
-			"advanced": {
-				"properties": {
-				  "ascendingKeys": {
-					"type":        "boolean",
-					"title":       "Ascending Keys",
-					"description": "Improve sync speeds by listing files from the end of the last sync, rather than listing the entire bucket prefix. This requires that you write objects in ascending lexicographic order, such as an RFC-3339 timestamp, so that key ordering matches modification time ordering.",
-					"default":     false
-				  }
+			"parser": parserOrderSchema,
+			"advanced": map[string]any{
+				"properties": map[string]any{
+					"ascendingKeys": map[string]any{
+						"type":        "boolean",
+						"title":       "Ascending Keys",
+						"description": "Improve sync speeds by listing files from the end of the last sync, rather than listing the entire bucket prefix. This requires that you write objects in ascending lexicographic order, such as an RFC-3339 timestamp, so that key ordering matches modification time ordering.",
+						"default":     false,
+					},
 				},
 				"additionalProperties": false,
-				"type": "object",
-				"description": "Options for advanced users. You should not typically need to modify these.",
-				"advanced": true,
-				"order": 3
+				"type":                 "object",
+				"title":                "Advanced",
+				"description":          "Options for advanced users. You should not typically need to modify these.",
+				"advanced":             true,
+				"order":                5,
 			},
-			"parser": ` + string(parserSchema) + `
-		}
-	}`)
+		},
+	}
+	schemaBytes, err := json.Marshal(schema)
+	if err != nil {
+		panic(fmt.Errorf("generating schema %w", err))
+	}
+	return json.RawMessage(schemaBytes)
 }
 
 func main() {

--- a/source-azure-blob-storage/main_test.go
+++ b/source-azure-blob-storage/main_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"os"
@@ -41,10 +42,12 @@ func TestAzureBlobStore_newAzureBlobStore(t *testing.T) {
 
 func TestAzureBlobStore_getConfigSchema(t *testing.T) {
 	parserJsonSchema := []byte(`{"type": "object", "properties": {"name": {"type": "string"}}}`)
+	data := getConfigSchema(parserJsonSchema)
 
-	result := getConfigSchema(parserJsonSchema)
+	formatted, err := json.MarshalIndent(data, "", "  ")
+	require.NoError(t, err)
 
-	cupaloy.SnapshotT(t, string(result))
+	cupaloy.SnapshotT(t, string(formatted))
 }
 
 func TestAzureBlobStore_List(t *testing.T) {


### PR DESCRIPTION
**Description:**

Adds a title to the advanced section of the config, so that it will be capitalized when rendered in the UI.  As part of this, I changed the way the config schema is generated, mostly because I expect the github security bot will complain about how we manipulate the json with string concatenation and it should ensure we don't emit invalid json.

fixes: https://github.com/estuary/connectors/issues/3764

**Workflow steps:**

No changes

**Documentation links affected:**

None

**Notes for reviewers:**

(anything that might help someone review this PR)

