### PR TITLE
source-http-ingest: implement ECDSA validation

### DIFF
--- a/source-http-ingest/Cargo.lock
+++ b/source-http-ingest/Cargo.lock
@@ -153,6 +153,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "base16ct"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
+
+[[package]]
 name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -163,6 +169,12 @@ name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "base64ct"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bigdecimal"
@@ -295,9 +307,9 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "chrono"
-version = "0.4.42"
+version = "0.4.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "145052bdd345b87320e369255277e3fb5152762ad123a901ef5c262dd38fe8d2"
+checksum = "fac4744fb15ae8337dc853fee7fb3f4e48c0fbaa23d0afe49c447b4fab126118"
 dependencies = [
  "iana-time-zone",
  "js-sys",
@@ -340,6 +352,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-oid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -371,6 +389,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "crypto-bigint"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
+dependencies = [
+ "generic-array",
+ "rand_core",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -419,6 +449,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "der"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
+dependencies = [
+ "const-oid",
+ "pem-rfc7468",
+ "zeroize",
+]
+
+[[package]]
 name = "deranged"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -446,7 +487,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
+ "const-oid",
  "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -475,7 +518,7 @@ dependencies = [
  "proto-gazette",
  "regex",
  "rkyv",
- "schemars 1.1.0",
+ "schemars",
  "serde",
  "serde_json",
  "sha2",
@@ -495,10 +538,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
+name = "ecdsa"
+version = "0.16.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
+dependencies = [
+ "der",
+ "digest",
+ "elliptic-curve",
+ "rfc6979",
+ "signature",
+ "spki",
+]
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
+name = "elliptic-curve"
+version = "0.13.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
+dependencies = [
+ "base16ct",
+ "crypto-bigint",
+ "digest",
+ "ff",
+ "generic-array",
+ "group",
+ "pem-rfc7468",
+ "pkcs8",
+ "rand_core",
+ "sec1",
+ "subtle",
+ "zeroize",
+]
 
 [[package]]
 name = "encode_unicode"
@@ -536,6 +613,16 @@ name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "ff"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
+dependencies = [
+ "rand_core",
+ "subtle",
+]
 
 [[package]]
 name = "find-msvc-tools"
@@ -678,6 +765,18 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+ "zeroize",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
 ]
 
 [[package]]
@@ -690,6 +789,17 @@ dependencies = [
  "libc",
  "r-efi",
  "wasip2",
+]
+
+[[package]]
+name = "group"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
+dependencies = [
+ "ff",
+ "rand_core",
+ "subtle",
 ]
 
 [[package]]
@@ -728,6 +838,15 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
 
 [[package]]
 name = "http"
@@ -1106,7 +1225,7 @@ version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
 dependencies = [
- "getrandom",
+ "getrandom 0.3.4",
  "libc",
 ]
 
@@ -1267,7 +1386,7 @@ dependencies = [
  "itertools 0.14.0",
  "lazy_static",
  "regex",
- "schemars 1.1.0",
+ "schemars",
  "serde",
  "serde_json",
  "superslice",
@@ -1354,6 +1473,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
+name = "p256"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2",
+]
+
+[[package]]
 name = "parking_lot"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1420,6 +1551,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "pem-rfc7468"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+dependencies = [
+ "base64ct",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1446,6 +1586,16 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der",
+ "spki",
+]
 
 [[package]]
 name = "pkg-config"
@@ -1476,6 +1626,15 @@ checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
  "syn",
+]
+
+[[package]]
+name = "primeorder"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
+dependencies = [
+ "elliptic-curve",
 ]
 
 [[package]]
@@ -1656,6 +1815,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1759,6 +1927,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rfc6979"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
+dependencies = [
+ "hmac",
+ "subtle",
+]
+
+[[package]]
 name = "rkyv"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1858,39 +2036,15 @@ dependencies = [
 
 [[package]]
 name = "schemars"
-version = "0.8.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fbf2ae1b8bc8e02df939598064d22402220cd5bbcca1c76f7d6a310974d5615"
-dependencies = [
- "dyn-clone",
- "schemars_derive 0.8.22",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "schemars"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9558e172d4e8533736ba97870c4b2cd63f84b382a3d6eb063da41b91cce17289"
 dependencies = [
  "dyn-clone",
  "ref-cast",
- "schemars_derive 1.1.0",
+ "schemars_derive",
  "serde",
  "serde_json",
-]
-
-[[package]]
-name = "schemars_derive"
-version = "0.8.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32e265784ad618884abaea0600a9adf15393368d840e0222d101a072f3f7534d"
-dependencies = [
- "proc-macro2",
- "quote",
- "serde_derive_internals",
- "syn",
 ]
 
 [[package]]
@@ -1910,6 +2064,20 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "sec1"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
+dependencies = [
+ "base16ct",
+ "der",
+ "generic-array",
+ "pkcs8",
+ "subtle",
+ "zeroize",
+]
 
 [[package]]
 name = "serde"
@@ -2024,6 +2192,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "digest",
+ "rand_core",
+]
+
+[[package]]
 name = "simd-adler32"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2080,7 +2258,9 @@ dependencies = [
  "allocator",
  "anyhow",
  "axum",
+ "base64 0.22.1",
  "bytes",
+ "chrono",
  "doc",
  "futures",
  "http 1.4.0",
@@ -2089,9 +2269,10 @@ dependencies = [
  "json",
  "lazy_static",
  "models",
+ "p256",
  "proto-flow",
  "reqwest",
- "schemars 0.8.22",
+ "schemars",
  "serde",
  "serde_json",
  "time",
@@ -2107,6 +2288,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "spki"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+dependencies = [
+ "base64ct",
+ "der",
+]
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2117,6 +2308,12 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "superslice"
@@ -2192,7 +2389,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d31c77bdf42a745371d260a26ca7163f1e0924b64afa0b688e61b5a9fa02f16"
 dependencies = [
  "fastrand",
- "getrandom",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -2568,7 +2765,7 @@ version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2e054861b4bd027cd373e18e8d8d8e6548085000e41290d95ce0c373a654b4a"
 dependencies = [
- "getrandom",
+ "getrandom 0.3.4",
  "js-sys",
  "serde_core",
  "wasm-bindgen",

--- a/source-http-ingest/Cargo.toml
+++ b/source-http-ingest/Cargo.toml
@@ -20,7 +20,7 @@ bytes = "1"
 futures = "0.3"
 http = "1.0"
 itertools = "0.13"
-schemars = "0.8"
+schemars = "1.1"
 serde = "1.0"
 serde_json = { version = "1.0", features = ["raw_value", "float_roundtrip"] }
 tokio = { version = "1", features = ["full"] }
@@ -42,6 +42,9 @@ tower-http = { version = "0.5", features = [
     "cors",
 ] }
 tower = "0.4"
+p256 = { version = "0.13.2", features = ["pem"] }
+base64 = "0.22.1"
+chrono = "0.4.43"
 
 [dev-dependencies]
 insta = { version = "1.28", features = ["json", "serde"] }

--- a/source-http-ingest/VARIANTS
+++ b/source-http-ingest/VARIANTS
@@ -1,3 +1,4 @@
 source-datadog-ingest
 source-intercom-ingest
 source-jira-ingest
+source-twilio-ingest

--- a/source-http-ingest/src/signature.rs
+++ b/source-http-ingest/src/signature.rs
@@ -1,0 +1,595 @@
+use std::str;
+
+use anyhow::{bail, Context, Result};
+use axum::http::HeaderMap;
+use base64::prelude::*;
+use bytes::Bytes;
+use chrono::{DateTime, TimeDelta, Utc};
+use p256::ecdsa::{signature::Verifier, Signature, VerifyingKey};
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize, Clone, Copy, Debug, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub enum SignatureAlgorithm {
+    #[serde(rename = "ecdsa")]
+    Ecdsa,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct EcdsaProviderSettings<'a> {
+    pub signature_header: &'a str,
+    pub timestamp_header: Option<&'a str>,
+}
+
+const TWILIO_SETTINGS: EcdsaProviderSettings = EcdsaProviderSettings {
+    signature_header: "X-Twilio-Email-Event-Webhook-Signature",
+    timestamp_header: Some("X-Twilio-Email-Event-Webhook-Timestamp"),
+};
+
+fn default_max_signature_age() -> u64 {
+    300
+}
+
+#[derive(Serialize, Deserialize, Clone)]
+#[serde(tag = "provider", deny_unknown_fields)]
+pub enum WebhookSignatureConfig {
+    #[serde(rename = "none")]
+    None {},
+
+    #[serde(rename = "twilio")]
+    Twilio {
+        #[serde(rename = "publicKey")]
+        public_key: String,
+        #[serde(default = "default_max_signature_age", rename = "maxSignatureAge")]
+        max_signature_age: u64,
+    },
+
+    #[serde(rename = "custom")]
+    Custom {
+        algorithm: SignatureAlgorithm,
+        #[serde(rename = "publicKey")]
+        public_key: String,
+        #[serde(rename = "signatureHeader")]
+        signature_header: String,
+        #[serde(default, rename = "timestampHeader")]
+        timestamp_header: Option<String>,
+        #[serde(default = "default_max_signature_age", rename = "maxSignatureAge")]
+        max_signature_age: u64,
+    },
+}
+
+impl Default for WebhookSignatureConfig {
+    fn default() -> Self {
+        Self::None {}
+    }
+}
+
+pub trait WebhookSignatureVerifier: Send + Sync {
+    fn verify(&self, headers: &HeaderMap, body: Bytes) -> Result<Bytes>;
+}
+
+struct NoopVerifier;
+
+impl WebhookSignatureVerifier for NoopVerifier {
+    fn verify(&self, _: &HeaderMap, body: Bytes) -> Result<Bytes> {
+        Ok(body)
+    }
+}
+
+struct TimestampParser {
+    header: String,
+    max_age: TimeDelta,
+}
+
+impl TimestampParser {
+    fn new(header: String, max_age_seconds: u64) -> Result<Self> {
+        if header.trim().is_empty() {
+            anyhow::bail!("Timestamp header name was provided but was empty");
+        }
+        Ok(Self {
+            header,
+            max_age: TimeDelta::seconds(max_age_seconds as i64),
+        })
+    }
+
+    fn as_bytes<'a>(&self, header_map: &'a HeaderMap) -> Result<&'a [u8]> {
+        let val = header_map
+            .get(&self.header)
+            .with_context(|| {
+                format!(
+                    "A timestamp was expected at header {} but was not found",
+                    &self.header
+                )
+            })?
+            .as_bytes();
+
+        Ok(val)
+    }
+
+    fn verify(&self, header_map: &HeaderMap) -> Result<()> {
+        let ts_bytes = self.as_bytes(header_map)?;
+        let ts_str = str::from_utf8(ts_bytes).context("Timestamp header is not valid UTF-8")?;
+        let ts_unix: i64 = ts_str.parse().with_context(|| {
+            format!(
+                "Failed to parse timestamp header as integer: \"{}\"",
+                ts_str
+            )
+        })?;
+        let ts = DateTime::from_timestamp(ts_unix, 0)
+            .with_context(|| format!("Invalid Unix timestamp: \"{}\"", ts_unix))?;
+        let age = Utc::now().signed_duration_since(ts);
+
+        if age > self.max_age {
+            bail!("Signature expired. Signed at: {}", ts)
+        }
+        if age < -TimeDelta::seconds(15) {
+            bail!("Signature is in the future. Signed at: {}", ts)
+        }
+
+        Ok(())
+    }
+}
+
+struct EcdsaVerifier {
+    verifying_key: VerifyingKey,
+    signature_header: String,
+    timestamp_parser: Option<TimestampParser>,
+}
+
+impl EcdsaVerifier {
+    pub fn new(
+        public_key: &str,
+        signature_header: String,
+        timestamp_parser: Option<TimestampParser>,
+    ) -> anyhow::Result<Self> {
+        if signature_header.trim().is_empty() {
+            anyhow::bail!("Signature header name is required but was empty");
+        }
+
+        let verifying_key = public_key
+            .parse::<VerifyingKey>()
+            .context("parsing ECDSA public key from PEM")?;
+
+        Ok(Self {
+            verifying_key,
+            signature_header,
+            timestamp_parser,
+        })
+    }
+}
+
+impl WebhookSignatureVerifier for EcdsaVerifier {
+    fn verify(&self, headers: &HeaderMap, body: Bytes) -> Result<Bytes> {
+        let signature = {
+            let b64 = headers.get(&self.signature_header).with_context(|| {
+                format!(
+                    "A signature value was expected at header {} but was not found",
+                    self.signature_header,
+                )
+            })?;
+            let bytes = BASE64_STANDARD.decode(b64).with_context(|| {
+                format!(
+                    "Failed to decode base64 signature from header '{}'",
+                    self.signature_header
+                )
+            })?;
+            Signature::from_der(&bytes).with_context(|| {
+                format!(
+                    "Failed to parse DER-encoded ECDSA signature from header '{}'",
+                    self.signature_header
+                )
+            })?
+        };
+
+        let payload = {
+            let mut value = Vec::new();
+
+            if let Some(v) = &self.timestamp_parser {
+                value.extend(v.as_bytes(headers)?);
+            }
+            value.extend(&body);
+
+            value
+        };
+
+        self.verifying_key.verify(&payload, &signature).context(
+            "Signature verification failed. Check that the public key matches your webhook provider's key",
+        )?;
+
+        // Verify timestamp freshness after the cryptographic signature check.
+        // This prevents unauthenticated callers from probing the server's
+        // max-age window via crafted timestamp headers.
+        if let Some(v) = &self.timestamp_parser {
+            v.verify(headers)?;
+        }
+
+        Ok(body)
+    }
+}
+
+impl TryFrom<WebhookSignatureConfig> for Box<dyn WebhookSignatureVerifier> {
+    type Error = anyhow::Error;
+
+    fn try_from(config: WebhookSignatureConfig) -> Result<Self> {
+        match config {
+            WebhookSignatureConfig::None {} => Ok(Box::new(NoopVerifier {})),
+
+            WebhookSignatureConfig::Twilio {
+                public_key,
+                max_signature_age,
+            } => {
+                let timestamp_parser = TimestampParser::new(
+                    // .unwrap() call is operating on a constant
+                    TWILIO_SETTINGS.timestamp_header.unwrap().to_string(),
+                    max_signature_age,
+                )?;
+
+                Ok(Box::new(EcdsaVerifier::new(
+                    &public_key,
+                    TWILIO_SETTINGS.signature_header.to_string(),
+                    Some(timestamp_parser),
+                )?))
+            }
+
+            WebhookSignatureConfig::Custom {
+                algorithm,
+                public_key,
+                signature_header,
+                timestamp_header,
+                max_signature_age,
+            } => match algorithm {
+                SignatureAlgorithm::Ecdsa => {
+                    let tv = timestamp_header
+                        .map(|h| TimestampParser::new(h, max_signature_age))
+                        .transpose()?;
+                    Ok(Box::new(EcdsaVerifier::new(
+                        &public_key,
+                        signature_header,
+                        tv,
+                    )?))
+                }
+            },
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use chrono::TimeZone;
+    use insta::assert_snapshot;
+    use p256::pkcs8::EncodePublicKey;
+
+    const TEST_PRIVATE_KEY_B64: &str = "eis1jT5PECEyQ1RldoeYqa7L3O3+DxEiM0RVZneImao=";
+
+    fn test_signing_key() -> p256::ecdsa::SigningKey {
+        let bytes = BASE64_STANDARD
+            .decode(TEST_PRIVATE_KEY_B64)
+            .expect("invalid test key base64");
+        p256::ecdsa::SigningKey::from_slice(&bytes).expect("failed to create signing key")
+    }
+
+    fn test_verifying_key() -> VerifyingKey {
+        *test_signing_key().verifying_key()
+    }
+
+    /// Helper to create a signed payload for testing
+    fn sign_payload(payload: &[u8]) -> String {
+        use p256::ecdsa::signature::Signer;
+
+        let signature: Signature = test_signing_key().sign(payload);
+        BASE64_STANDARD.encode(signature.to_der())
+    }
+
+    fn test_verifying_key_pem() -> String {
+        use p256::pkcs8::LineEnding;
+        test_verifying_key()
+            .to_public_key_pem(LineEnding::LF)
+            .expect("failed to encode public key as PEM")
+    }
+
+    fn make_ecdsa_verifier(with_timestamp: bool) -> Box<dyn WebhookSignatureVerifier> {
+        let tv = if with_timestamp {
+            Some(TimestampParser::new("X-Timestamp".into(), default_max_signature_age()).unwrap())
+        } else {
+            None
+        };
+        Box::new(
+            EcdsaVerifier::new(&test_verifying_key_pem(), "X-Signature".to_string(), tv).unwrap(),
+        )
+    }
+
+    fn make_ecdsa_verifier_with_age(
+        max_age_seconds: Option<u64>,
+    ) -> Box<dyn WebhookSignatureVerifier> {
+        let tv =
+            max_age_seconds.map(|age| TimestampParser::new("X-Timestamp".into(), age).unwrap());
+        Box::new(
+            EcdsaVerifier::new(&test_verifying_key_pem(), "X-Signature".to_string(), tv).unwrap(),
+        )
+    }
+
+    #[test]
+    fn test_ecdsa_signature_valid() {
+        let now = Utc::now().timestamp().to_string();
+        let body = b"test body content";
+
+        let signature = {
+            let mut payload = Vec::new();
+            payload.extend(now.as_bytes());
+            payload.extend(body);
+            sign_payload(&payload)
+        };
+
+        let headers = {
+            let mut val = axum::http::HeaderMap::new();
+            val.insert("X-Signature", signature.parse().unwrap());
+            val.insert("X-Timestamp", now.parse().unwrap());
+            val
+        };
+
+        let verifier = make_ecdsa_verifier(true);
+        let result = verifier.verify(&headers, Bytes::from_static(body));
+
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap().as_ref(), body);
+    }
+
+    #[test]
+    fn test_ecdsa_signature_valid_no_timestamp() {
+        let body = b"test body content";
+        let signature = sign_payload(body);
+
+        let headers = {
+            let mut val = axum::http::HeaderMap::new();
+            val.insert("X-Signature", signature.parse().unwrap());
+
+            val
+        };
+
+        let verifier = make_ecdsa_verifier(false);
+        let result = verifier.verify(&headers, Bytes::from_static(body));
+
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap().as_ref(), body);
+    }
+
+    #[test]
+    fn test_ecdsa_signature_invalid() {
+        let body = b"test body content";
+        let wrong_body = b"different content";
+
+        let signature = sign_payload(wrong_body);
+
+        let headers = {
+            let mut val = axum::http::HeaderMap::new();
+            val.insert("X-Signature", signature.parse().unwrap());
+
+            val
+        };
+
+        let verifier = make_ecdsa_verifier(false);
+        let result = verifier.verify(&headers, Bytes::from_static(body));
+
+        assert!(result.is_err());
+        assert_snapshot!(
+            result.unwrap_err(),
+            @"Signature verification failed. Check that the public key matches your webhook provider's key"
+        )
+    }
+
+    #[test]
+    fn test_ecdsa_signature_missing_header() {
+        let body = b"test body content";
+        let headers = axum::http::HeaderMap::new();
+
+        let verifier = make_ecdsa_verifier(false);
+        let result = verifier.verify(&headers, Bytes::from_static(body));
+
+        assert!(result.is_err());
+        assert_snapshot!(
+            result.unwrap_err(),
+            @"A signature value was expected at header X-Signature but was not found"
+        )
+    }
+
+    #[test]
+    fn test_ecdsa_signature_missing_timestamp() {
+        let body = b"test body content";
+        let signature = sign_payload(body);
+
+        let headers = {
+            let mut val = axum::http::HeaderMap::new();
+            val.insert("X-Signature", signature.parse().unwrap());
+
+            val
+        };
+
+        let verifier = make_ecdsa_verifier(true);
+        let result = verifier.verify(&headers, Bytes::from_static(body));
+
+        assert!(result.is_err());
+        assert_snapshot!(
+            result.unwrap_err().to_string(),
+            @"A timestamp was expected at header X-Timestamp but was not found"
+        )
+    }
+
+    #[test]
+    fn test_ecdsa_signature_invalid_base64() {
+        let body = b"test body content";
+
+        let headers = {
+            let mut val = axum::http::HeaderMap::new();
+            val.insert("X-Signature", "not-valid-base64!!!".parse().unwrap());
+
+            val
+        };
+
+        let verifier = make_ecdsa_verifier(false);
+        let result = verifier.verify(&headers, Bytes::from_static(body));
+
+        assert!(result.is_err());
+        assert_snapshot!(
+            result.unwrap_err(),
+            @"Failed to decode base64 signature from header 'X-Signature'"
+        )
+    }
+
+    #[test]
+    fn test_ecdsa_signature_invalid_der() {
+        let body = b"test body content";
+
+        let headers = {
+            let invalid_der =
+                BASE64_STANDARD.encode([0x30, 0x06, 0x02, 0x01, 0x01, 0x02, 0x01, 0x01]);
+
+            let mut val = axum::http::HeaderMap::new();
+            val.insert("X-Signature", invalid_der.parse().unwrap());
+
+            val
+        };
+
+        let verifier = make_ecdsa_verifier(false);
+        let result = verifier.verify(&headers, Bytes::from_static(body));
+
+        assert!(result.is_err());
+        assert_snapshot!(
+            result.unwrap_err(),
+            @"Signature verification failed. Check that the public key matches your webhook provider's key"
+        )
+    }
+
+    #[test]
+    fn test_twilio_config_conversion() {
+        let pem_key = test_verifying_key_pem();
+        let config = WebhookSignatureConfig::Twilio {
+            public_key: pem_key,
+            max_signature_age: default_max_signature_age(),
+        };
+        let verifier: Result<Box<dyn WebhookSignatureVerifier>, _> = config.try_into();
+        assert!(verifier.is_ok());
+    }
+
+    #[test]
+    fn test_custom_config_conversion() {
+        let pem_key = test_verifying_key_pem();
+        let config = WebhookSignatureConfig::Custom {
+            algorithm: SignatureAlgorithm::Ecdsa,
+            public_key: pem_key,
+            signature_header: "X-Custom-Sig".to_string(),
+            timestamp_header: Some("X-Custom-Ts".to_string()),
+            max_signature_age: default_max_signature_age(),
+        };
+        let verifier: Result<Box<dyn WebhookSignatureVerifier>, _> = config.try_into();
+        assert!(verifier.is_ok());
+    }
+
+    #[test]
+    fn test_twilio_config_json_deserialization() {
+        let pem_key = test_verifying_key_pem();
+        let json = format!(
+            r#"{{"provider": "twilio", "publicKey": {}}}"#,
+            serde_json::to_string(&pem_key).unwrap()
+        );
+        let config: WebhookSignatureConfig = serde_json::from_str(&json).unwrap();
+        assert!(matches!(config, WebhookSignatureConfig::Twilio { .. }));
+    }
+
+    #[test]
+    fn test_custom_config_json_deserialization() {
+        let pem_key = test_verifying_key_pem();
+        let json = format!(
+            r#"{{
+                "provider": "custom",
+                "algorithm": "ecdsa",
+                "publicKey": {},
+                "signatureHeader": "X-Sig",
+                "timestampHeader": "X-Ts"
+            }}"#,
+            serde_json::to_string(&pem_key).unwrap()
+        );
+        let config: WebhookSignatureConfig = serde_json::from_str(&json).unwrap();
+        assert!(matches!(config, WebhookSignatureConfig::Custom { .. }));
+    }
+
+    #[test]
+    fn test_ecdsa_signature_custom_max_age_accepts_recent() {
+        let now = Utc::now().timestamp().to_string();
+        let body = b"test body content";
+
+        let signature = {
+            let mut payload = Vec::new();
+            payload.extend(now.as_bytes());
+            payload.extend(body);
+            sign_payload(&payload)
+        };
+
+        let headers = {
+            let mut val = axum::http::HeaderMap::new();
+            val.insert("X-Signature", signature.parse().unwrap());
+            val.insert("X-Timestamp", now.parse().unwrap());
+            val
+        };
+
+        let verifier = make_ecdsa_verifier_with_age(Some(3600));
+        let result = verifier.verify(&headers, Bytes::from_static(body));
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_ecdsa_signature_custom_max_age_rejects_old() {
+        let old_timestamp = Utc
+            .with_ymd_and_hms(2000, 1, 1, 0, 0, 0)
+            .unwrap()
+            .timestamp()
+            .to_string();
+        let body = b"test body content";
+
+        let signature = {
+            let mut payload = Vec::new();
+            payload.extend(old_timestamp.as_bytes());
+            payload.extend(body);
+            sign_payload(&payload)
+        };
+
+        let headers = {
+            let mut val = axum::http::HeaderMap::new();
+            val.insert("X-Signature", signature.parse().unwrap());
+            val.insert("X-Timestamp", old_timestamp.parse().unwrap());
+            val
+        };
+
+        let verifier = make_ecdsa_verifier_with_age(Some(1));
+        let result = verifier.verify(&headers, Bytes::from_static(body));
+        assert!(result.is_err());
+        assert_snapshot!(
+            result.unwrap_err(),
+            @"Signature expired. Signed at: 2000-01-01 00:00:00 UTC"
+        )
+    }
+
+    #[test]
+    fn test_custom_config_json_deserialization_with_max_age() {
+        let pem_key = test_verifying_key_pem();
+        let json = format!(
+            r#"{{
+                "provider": "custom",
+                "algorithm": "ecdsa",
+                "publicKey": {},
+                "signatureHeader": "X-Sig",
+                "maxSignatureAge": 3600
+            }}"#,
+            serde_json::to_string(&pem_key).unwrap()
+        );
+        let config: WebhookSignatureConfig = serde_json::from_str(&json).unwrap();
+        match config {
+            WebhookSignatureConfig::Custom {
+                max_signature_age, ..
+            } => {
+                assert_eq!(max_signature_age, 3600);
+            }
+            _ => panic!("expected Custom variant"),
+        }
+    }
+}

--- a/source-http-ingest/src/snapshots/source_http_ingest__test__endpoint_config_schema.snap
+++ b/source-http-ingest/src/snapshots/source_http_ingest__test__endpoint_config_schema.snap
@@ -9,9 +9,9 @@ expression: schema
   "properties": {
     "allowedCorsOrigins": {
       "title": "CORS Allowed Origins",
-      "description": "List of allowed CORS origins. If empty, then CORS will be disabled. Otherwise, each item in the list will be interpreted as a specific request origin that will be permitted by the `Access-Control-Allow-Origin` header for preflight requests coming from that origin. As a special case, the value `*` is permitted in order to allow all origins. The `*` should be used with extreme caution, however. See: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Origin",
-      "default": [],
+      "description": "List of allowed CORS origins. If empty, then CORS will be disabled. Otherwise, each item\nin the list will be interpreted as a specific request origin that will be permitted by the\n`Access-Control-Allow-Origin` header for preflight requests coming from that origin. As a special\ncase, the value `*` is permitted in order to allow all origins. The `*` should be used with extreme\ncaution, however. See: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Origin",
       "type": "array",
+      "default": [],
       "items": {
         "type": "string"
       },
@@ -19,11 +19,11 @@ expression: schema
     },
     "paths": {
       "title": "URL paths",
-      "description": "List of URL paths to accept requests at.\n\nDiscovery will return a separate collection for each given path. Paths must be provided without any percent encoding, and should not include any query parameters or fragment.\n\nPaths can include path parameters, following the syntax of OpenAPI path templating. For example, `/vendors/{vendorId}/products/{productId}`, which would accept a request to `/vendors/abc/products/123`. This would result in captured data with `\"_meta\": { \"pathParams\": { \"vendorId\": \"abc\", \"productId\": \"123\"}, ...}`",
+      "description": "List of URL paths to accept requests at.\n\nDiscovery will return a separate collection for each given path. Paths\nmust be provided without any percent encoding, and should not include\nany query parameters or fragment.\n\nPaths can include path parameters, following the syntax of OpenAPI path\ntemplating. For example, `/vendors/{vendorId}/products/{productId}`,\nwhich would accept a request to `/vendors/abc/products/123`. This would\nresult in captured data with\n`\"_meta\": { \"pathParams\": { \"vendorId\": \"abc\", \"productId\": \"123\"}, ...}`",
+      "type": "array",
       "default": [
         "/webhook-data"
       ],
-      "type": "array",
       "items": {
         "type": "string",
         "pattern": "/.+"
@@ -32,14 +32,129 @@ expression: schema
     },
     "requireAuthToken": {
       "title": "Authentication token",
-      "description": "Optional bearer token to authenticate webhook requests.\n\nWARNING: If this is empty or unset, then anyone who knows the URL of the connector will be able to write data to your collections.",
-      "default": null,
+      "description": "Optional bearer token to authenticate webhook requests.\n\nWARNING: If this is empty or unset, then anyone who knows the URL of the connector\nwill be able to write data to your collections.",
       "type": [
         "string",
         "null"
       ],
+      "default": null,
       "order": 2,
       "secret": true
+    },
+    "signatureConfig": {
+      "title": "Signature Verification",
+      "description": "Configuration for verifying webhook signatures.\nIf set, incoming requests must include valid signature headers.",
+      "type": "object",
+      "default": {
+        "provider": "none"
+      },
+      "discriminator": {
+        "propertyName": "provider"
+      },
+      "oneOf": [
+        {
+          "title": "None",
+          "properties": {
+            "provider": {
+              "type": "string",
+              "const": "none",
+              "default": "none",
+              "order": 0
+            }
+          },
+          "required": [
+            "provider"
+          ]
+        },
+        {
+          "title": "Twilio SendGrid",
+          "properties": {
+            "maxSignatureAge": {
+              "title": "Max Signature Age",
+              "description": "Maximum age of a signed request in seconds before it is rejected. Defaults to 300 (5 minutes).",
+              "type": "integer",
+              "default": 300,
+              "maximum": 259200,
+              "minimum": 1,
+              "order": 2
+            },
+            "provider": {
+              "type": "string",
+              "const": "twilio",
+              "default": "twilio",
+              "order": 0
+            },
+            "publicKey": {
+              "title": "Public Key",
+              "description": "PEM-encoded ECDSA public key from Twilio SendGrid Event Webhook settings.",
+              "type": "string",
+              "multiline": true,
+              "order": 1,
+              "secret": true
+            }
+          },
+          "required": [
+            "provider",
+            "publicKey"
+          ]
+        },
+        {
+          "title": "Custom",
+          "properties": {
+            "algorithm": {
+              "title": "Algorithm",
+              "type": "string",
+              "default": "ecdsa",
+              "enum": [
+                "ecdsa"
+              ],
+              "order": 1
+            },
+            "maxSignatureAge": {
+              "title": "Max Signature Age",
+              "description": "Maximum age of a signed request in seconds before it is rejected. Only applies when a Timestamp Header is configured. Defaults to 300 (5 minutes).",
+              "type": "integer",
+              "default": 300,
+              "maximum": 259200,
+              "minimum": 1,
+              "order": 5
+            },
+            "provider": {
+              "type": "string",
+              "const": "custom",
+              "default": "custom",
+              "order": 0
+            },
+            "publicKey": {
+              "title": "Public Key",
+              "description": "PEM-encoded public key.",
+              "type": "string",
+              "multiline": true,
+              "order": 2,
+              "secret": true
+            },
+            "signatureHeader": {
+              "title": "Signature Header",
+              "description": "HTTP header containing the base64-encoded signature.",
+              "type": "string",
+              "order": 3
+            },
+            "timestampHeader": {
+              "title": "Timestamp Header",
+              "description": "Optional HTTP header containing the timestamp.",
+              "type": "string",
+              "order": 4
+            }
+          },
+          "required": [
+            "provider",
+            "algorithm",
+            "publicKey",
+            "signatureHeader"
+          ]
+        }
+      ],
+      "order": 4
     }
   }
 }

--- a/source-http-ingest/src/snapshots/source_http_ingest__test__resource_config_schema.snap
+++ b/source-http-ingest/src/snapshots/source_http_ingest__test__resource_config_schema.snap
@@ -8,27 +8,27 @@ expression: schema
   "type": "object",
   "properties": {
     "idFromHeader": {
-      "description": "Set the /_meta/webhookId from the given HTTP header in each request.\n\nIf not set, then a random id will be generated automatically. If set, then each request will be required to have the header, and the header value will be used as the value of `/_meta/webhookId`.",
-      "default": null,
+      "description": "Set the /_meta/webhookId from the given HTTP header in each request.\n\nIf not set, then a random id will be generated automatically. If set, then each request will be required\nto have the header, and the header value will be used as the value of `/_meta/webhookId`.",
       "type": [
         "string",
         "null"
-      ]
+      ],
+      "default": null
     },
     "path": {
       "description": "The URL path to use for adding documents to this binding. Defaults to the name of the collection.",
-      "default": null,
       "type": [
         "string",
         "null"
-      ]
+      ],
+      "default": null
     },
     "stream": {
-      "default": null,
       "type": [
         "string",
         "null"
-      ]
+      ],
+      "default": null
     }
   }
 }


### PR DESCRIPTION
**Description:**

This PR adds the `WebhookSignatureVerifier` trait and implements ECDSA signature verifications to ascertain the authenticity of incoming messages for `source-http-ingest`. Twilio has been included as an explicitly supported provider and a new variant has been created to reflect that.

Closes #3547 .

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

The code structure has been set up in the expectation that new providers and different verification algorithms will be implemented in the near future.

