### PR TITLE
source-google-ads: fix vague query parsing error

### DIFF
--- a/source-google-ads/source_google_ads/source.py
+++ b/source-google-ads/source_google_ads/source.py
@@ -54,7 +54,9 @@ class SourceGoogleAds(AbstractSource):
             except ValueError:
                 message = f"The custom GAQL query {query['table_name']} failed. Validate your GAQL query with the Google Ads query validator. https://developers.google.com/google-ads/api/fields/v21/query_validator"
                 raise AirbyteTracedException(
-                    message=message, failure_type=FailureType.config_error
+                    message=message,
+                    internal_message=message,
+                    failure_type=FailureType.config_error,
                 )
         return config
 


### PR DESCRIPTION
**Description:**

This PR fixes an oversight where the custom GAQL query parsing error message isn't being properly shown to users.

Example:

```
  File "/home/redacted/connectors/source-google-ads/source_google_ads/source.py", line 53, in _validate_and_transform
    query["query"] = GAQL.parse(str(query["query"]))
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/redacted/connectors/source-google-ads/source_google_ads/utils.py", line 45, in parse
    raise ValueError
ValueError

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/redacted/google-ads-worktree/estuary-cdk/estuary_cdk/capture/base_capture_connector.py", line 96, in handle
    await self._emit(Response(validated=await self.validate(log, validate)))
                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/redacted/google-ads-worktree/estuary-cdk/estuary_cdk/shim_airbyte_cdk.py", line 310, in validate
    result = self.delegate.check(log, validate.config)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/self/.cache/pypoetry/virtualenvs/source-google-ads-ngvmshp5-py3.12/lib/python3.12/site-packages/airbyte_cdk/sources/abstract_source.py", line 82, in check
    check_succeeded, error = self.check_connection(logger, config)
                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/redacted/connectors/source-google-ads/source_google_ads/source.py", line 121, in check_connection
    config = self._validate_and_transform(config)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/redacted/connectors/source-google-ads/source_google_ads/source.py", line 56, in _validate_and_transform
    raise AirbyteTracedException(
airbyte_cdk.utils.traced_exception.AirbyteTracedException: None
```

The intended error message is `The custom GAQL query {query['table_name']} failed. Validate your GAQL query with the Google Ads query validator. https://developers.google.com/google-ads/api/fields/v21/query_validator`.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

PR has been tested by removing the FROM clause from the custom query in `test.flow.yaml`. The error now displays the more expressive error message.

