### PR TITLE
source-salesforce-native: capitalization typo fix

### DIFF
--- a/source-salesforce-native/source_salesforce_native/supported_standard_objects.py
+++ b/source-salesforce-native/source_salesforce_native/supported_standard_objects.py
@@ -2744,7 +2744,7 @@ SUPPORTED_STANDARD_OBJECTS: dict[str, ObjectDetails] = {
     "LiveChatButton": {
         "cursor_field": CursorFields.SYSTEM_MODSTAMP
     },
-    "LiveChatdeployment": {
+    "LiveChatDeployment": {
         "cursor_field": CursorFields.SYSTEM_MODSTAMP
     },
     "LiveChatSensitiveDataRule": {


### PR DESCRIPTION
**Description:**

Fixing a capitalization typo made in ecf12bb5c3003e7092605e844a644dcff878388b. I'm looking into ways to make the `SUPPORTED_STANDARD_OBJECTS` lookup case insensitive too so these types of typos would be ok.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

