### PR TITLE
materialize-spanner: flow_checkpoints_v1 does not need flow_key_hash

### DIFF
--- a/tests/materialize/materialize-spanner/cleanup.sh
+++ b/tests/materialize/materialize-spanner/cleanup.sh
@@ -43,6 +43,7 @@ dropTable "many_columns"
 dropTable "timezone_datetimes_standard"
 dropTable "perf_simple"
 dropTable "perf_uuid_key"
+dropTable "flow_checkpoints_v1"
 
 echo "dropping all tables in Spanner database '$SPANNER_DATABASE'..."
 gcloud spanner databases ddl update "$SPANNER_DATABASE" \

--- a/tests/materialize/materialize-spanner/snapshot.json
+++ b/tests/materialize/materialize-spanner/snapshot.json
@@ -1,6 +1,10 @@
 [
   "applied.actionDescription",
-  "\nCREATE TABLE IF NOT EXISTS simple (\n\tflow_key_hash INT64 NOT NULL,\n\t\tid INT64 NOT NULL,\n\t\tcanary STRING(MAX) NOT NULL,\n\t\tflow_published_at TIMESTAMP NOT NULL,\n\n\t\tPRIMARY KEY (flow_key_hash,id)\n)\n\n\nCREATE TABLE IF NOT EXISTS duplicate_keys_standard (\n\tflow_key_hash INT64 NOT NULL,\n\t\tid INT64 NOT NULL,\n\t\tflow_published_at TIMESTAMP NOT NULL,\n\t\tint INT64,\n\t\tstr STRING(MAX) NOT NULL,\n\n\t\tPRIMARY KEY (flow_key_hash,id)\n)\n\n\nCREATE TABLE IF NOT EXISTS multiple_types (\n\tflow_key_hash INT64 NOT NULL,\n\t\tid INT64 NOT NULL,\n\t\tarray_int JSON,\n\t\tbinary_field BYTES(MAX),\n\t\tbool_field BOOL,\n\t\tfloat_field FLOAT64,\n\t\tflow_published_at TIMESTAMP NOT NULL,\n\t\tmultiple JSON,\n\t\tnested JSON,\n\t\tnullable_int INT64,\n\t\tstr_field STRING(MAX) NOT NULL,\n\n\t\tPRIMARY KEY (flow_key_hash,id)\n)\n\n\nCREATE TABLE IF NOT EXISTS formatted_strings (\n\tflow_key_hash INT64 NOT NULL,\n\t\tid INT64 NOT NULL,\n\t\tdate DATE,\n\t\tdatetime TIMESTAMP,\n\t\tflow_published_at TIMESTAMP NOT NULL,\n\t\tint_and_str NUMERIC,\n\t\tint_str NUMERIC,\n\t\tnum_and_str FLOAT64,\n\t\tnum_str FLOAT64,\n\t\ttime STRING(MAX),\n\n\t\tPRIMARY KEY (flow_key_hash,id)\n)\n\n\nCREATE TABLE IF NOT EXISTS symbols (\n\tflow_key_hash INT64 NOT NULL,\n\t\ttesting___s_ STRING(MAX) NOT NULL,\n\t\tflow_published_at TIMESTAMP NOT NULL,\n\t\tid STRING(MAX),\n\n\t\tPRIMARY KEY (flow_key_hash,testing___s_)\n)\n\n\nCREATE TABLE IF NOT EXISTS unsigned_bigint (\n\tflow_key_hash INT64 NOT NULL,\n\t\tid INT64 NOT NULL,\n\t\tflow_published_at TIMESTAMP NOT NULL,\n\t\tunsigned_bigint NUMERIC,\n\n\t\tPRIMARY KEY (flow_key_hash,id)\n)\n\n\nCREATE TABLE IF NOT EXISTS deletions (\n\tflow_key_hash INT64 NOT NULL,\n\t\tid INT64 NOT NULL,\n\t\tc__meta_op STRING(MAX),\n\t\tflow_published_at TIMESTAMP NOT NULL,\n\n\t\tPRIMARY KEY (flow_key_hash,id)\n)\n\n\nCREATE TABLE IF NOT EXISTS string_escaped_key (\n\tflow_key_hash INT64 NOT NULL,\n\t\tid STRING(MAX) NOT NULL,\n\t\tcounter INT64,\n\t\tflow_published_at TIMESTAMP NOT NULL,\n\n\t\tPRIMARY KEY (flow_key_hash,id)\n)\n\n\nCREATE TABLE IF NOT EXISTS all_key_types_part_one (\n\tflow_key_hash INT64 NOT NULL,\n\t\tid INT64 NOT NULL,\n\t\tstrintkey STRING(MAX) NOT NULL,\n\t\tstrnumkey STRING(MAX) NOT NULL,\n\t\tcounter INT64,\n\t\tflow_published_at TIMESTAMP NOT NULL,\n\t\tstrint NUMERIC,\n\t\tstrnum FLOAT64,\n\n\t\tPRIMARY KEY (flow_key_hash,id, strintkey, strnumkey)\n)\n\n\nCREATE TABLE IF NOT EXISTS all_key_types_part_two (\n\tflow_key_hash INT64 NOT NULL,\n\t\tid INT64 NOT NULL,\n\t\tdatekey STRING(MAX) NOT NULL,\n\t\ttimekey STRING(MAX) NOT NULL,\n\t\tcounter INT64,\n\t\tdate DATE,\n\t\tflow_published_at TIMESTAMP NOT NULL,\n\t\ttime STRING(MAX),\n\n\t\tPRIMARY KEY (flow_key_hash,id, datekey, timekey)\n)\n\n\nCREATE TABLE IF NOT EXISTS all_key_types_part_three (\n\tflow_key_hash INT64 NOT NULL,\n\t\tid INT64 NOT NULL,\n\t\tdatetimekey STRING(MAX) NOT NULL,\n\t\tuuidkey STRING(36) NOT NULL,\n\t\tcounter INT64,\n\t\tdatetime TIMESTAMP,\n\t\tflow_published_at TIMESTAMP NOT NULL,\n\t\tuuid STRING(36),\n\n\t\tPRIMARY KEY (flow_key_hash,id, datetimekey, uuidkey)\n)\n\n\nCREATE TABLE IF NOT EXISTS fields_with_projections (\n\tflow_key_hash INT64 NOT NULL,\n\t\tid INT64 NOT NULL,\n\t\tanother_field STRING(MAX),\n\t\tflow_published_at TIMESTAMP NOT NULL,\n\t\tprojected_another STRING(MAX),\n\t\tprojected_field STRING(MAX),\n\n\t\tPRIMARY KEY (flow_key_hash,id)\n)\n\n\nCREATE TABLE IF NOT EXISTS many_columns (\n\tflow_key_hash INT64 NOT NULL,\n\t\tid INT64 NOT NULL,\n\t\ta0 INT64,\n\t\ta1 INT64,\n\t\ta10 INT64,\n\t\ta11 INT64,\n\t\ta12 INT64,\n\t\ta13 INT64,\n\t\ta14 INT64,\n\t\ta15 INT64,\n\t\ta16 INT64,\n\t\ta17 INT64,\n\t\ta18 INT64,\n\t\ta19 INT64,\n\t\ta2 INT64,\n\t\ta20 INT64,\n\t\ta21 INT64,\n\t\ta22 INT64,\n\t\ta23 INT64,\n\t\ta24 INT64,\n\t\ta25 INT64,\n\t\ta26 INT64,\n\t\ta27 INT64,\n\t\ta28 INT64,\n\t\ta29 INT64,\n\t\ta3 INT64,\n\t\ta30 INT64,\n\t\ta31 INT64,\n\t\ta32 INT64,\n\t\ta33 INT64,\n\t\ta34 INT64,\n\t\ta35 INT64,\n\t\ta36 INT64,\n\t\ta37 INT64,\n\t\ta38 INT64,\n\t\ta39 INT64,\n\t\ta4 INT64,\n\t\ta40 INT64,\n\t\ta41 INT64,\n\t\ta42 INT64,\n\t\ta43 INT64,\n\t\ta44 INT64,\n\t\ta45 INT64,\n\t\ta46 INT64,\n\t\ta47 INT64,\n\t\ta48 INT64,\n\t\ta49 INT64,\n\t\ta5 INT64,\n\t\ta50 INT64,\n\t\ta51 INT64,\n\t\ta52 INT64,\n\t\ta53 INT64,\n\t\ta54 INT64,\n\t\ta55 INT64,\n\t\ta56 INT64,\n\t\ta57 INT64,\n\t\ta58 INT64,\n\t\ta59 INT64,\n\t\ta6 INT64,\n\t\ta60 INT64,\n\t\ta61 INT64,\n\t\ta62 INT64,\n\t\ta63 INT64,\n\t\ta64 INT64,\n\t\ta65 INT64,\n\t\ta66 INT64,\n\t\ta67 INT64,\n\t\ta68 INT64,\n\t\ta69 INT64,\n\t\ta7 INT64,\n\t\ta70 INT64,\n\t\ta71 INT64,\n\t\ta72 INT64,\n\t\ta73 INT64,\n\t\ta74 INT64,\n\t\ta75 INT64,\n\t\ta76 INT64,\n\t\ta77 INT64,\n\t\ta78 INT64,\n\t\ta79 INT64,\n\t\ta8 INT64,\n\t\ta80 INT64,\n\t\ta81 INT64,\n\t\ta82 INT64,\n\t\ta83 INT64,\n\t\ta84 INT64,\n\t\ta85 INT64,\n\t\ta86 INT64,\n\t\ta87 INT64,\n\t\ta88 INT64,\n\t\ta89 INT64,\n\t\ta9 INT64,\n\t\ta90 INT64,\n\t\ta91 INT64,\n\t\ta92 INT64,\n\t\ta93 INT64,\n\t\ta94 INT64,\n\t\ta95 INT64,\n\t\ta96 INT64,\n\t\ta97 INT64,\n\t\ta98 INT64,\n\t\ta99 INT64,\n\t\tflow_published_at TIMESTAMP NOT NULL,\n\n\t\tPRIMARY KEY (flow_key_hash,id)\n)\n\n\nCREATE TABLE IF NOT EXISTS timezone_datetimes_standard (\n\tflow_key_hash INT64 NOT NULL,\n\t\tid INT64 NOT NULL,\n\t\tflow_published_at TIMESTAMP NOT NULL,\n\t\toffset_datetime TIMESTAMP NOT NULL,\n\t\tutc_datetime TIMESTAMP NOT NULL,\n\n\t\tPRIMARY KEY (flow_key_hash,id)\n)\n"
+  "\nCREATE TABLE IF NOT EXISTS flow_checkpoints_v1 (\n\t\n\t\tmaterialization STRING(MAX) NOT NULL,\n\t\tkey_begin INT64 NOT NULL,\n\t\tkey_end INT64 NOT NULL,\n\t\tfence INT64 NOT NULL,\n\t\tcheckpoint STRING(MAX) NOT NULL,\n\n\t\tPRIMARY KEY (materialization, key_begin, key_end)\n)\n\n\nCREATE TABLE IF NOT EXISTS simple (\n\tflow_key_hash INT64 NOT NULL,\n\t\tid INT64 NOT NULL,\n\t\tcanary STRING(MAX) NOT NULL,\n\t\tflow_published_at TIMESTAMP NOT NULL,\n\n\t\tPRIMARY KEY (flow_key_hash, id)\n)\n\n\nCREATE TABLE IF NOT EXISTS duplicate_keys_standard (\n\tflow_key_hash INT64 NOT NULL,\n\t\tid INT64 NOT NULL,\n\t\tflow_published_at TIMESTAMP NOT NULL,\n\t\tint INT64,\n\t\tstr STRING(MAX) NOT NULL,\n\n\t\tPRIMARY KEY (flow_key_hash, id)\n)\n\n\nCREATE TABLE IF NOT EXISTS multiple_types (\n\tflow_key_hash INT64 NOT NULL,\n\t\tid INT64 NOT NULL,\n\t\tarray_int JSON,\n\t\tbinary_field BYTES(MAX),\n\t\tbool_field BOOL,\n\t\tfloat_field FLOAT64,\n\t\tflow_published_at TIMESTAMP NOT NULL,\n\t\tmultiple JSON,\n\t\tnested JSON,\n\t\tnullable_int INT64,\n\t\tstr_field STRING(MAX) NOT NULL,\n\n\t\tPRIMARY KEY (flow_key_hash, id)\n)\n\n\nCREATE TABLE IF NOT EXISTS formatted_strings (\n\tflow_key_hash INT64 NOT NULL,\n\t\tid INT64 NOT NULL,\n\t\tdate DATE,\n\t\tdatetime TIMESTAMP,\n\t\tflow_published_at TIMESTAMP NOT NULL,\n\t\tint_and_str NUMERIC,\n\t\tint_str NUMERIC,\n\t\tnum_and_str FLOAT64,\n\t\tnum_str FLOAT64,\n\t\ttime STRING(MAX),\n\n\t\tPRIMARY KEY (flow_key_hash, id)\n)\n\n\nCREATE TABLE IF NOT EXISTS symbols (\n\tflow_key_hash INT64 NOT NULL,\n\t\ttesting___s_ STRING(MAX) NOT NULL,\n\t\tflow_published_at TIMESTAMP NOT NULL,\n\t\tid STRING(MAX),\n\n\t\tPRIMARY KEY (flow_key_hash, testing___s_)\n)\n\n\nCREATE TABLE IF NOT EXISTS unsigned_bigint (\n\tflow_key_hash INT64 NOT NULL,\n\t\tid INT64 NOT NULL,\n\t\tflow_published_at TIMESTAMP NOT NULL,\n\t\tunsigned_bigint NUMERIC,\n\n\t\tPRIMARY KEY (flow_key_hash, id)\n)\n\n\nCREATE TABLE IF NOT EXISTS deletions (\n\tflow_key_hash INT64 NOT NULL,\n\t\tid INT64 NOT NULL,\n\t\tc__meta_op STRING(MAX),\n\t\tflow_published_at TIMESTAMP NOT NULL,\n\n\t\tPRIMARY KEY (flow_key_hash, id)\n)\n\n\nCREATE TABLE IF NOT EXISTS string_escaped_key (\n\tflow_key_hash INT64 NOT NULL,\n\t\tid STRING(MAX) NOT NULL,\n\t\tcounter INT64,\n\t\tflow_published_at TIMESTAMP NOT NULL,\n\n\t\tPRIMARY KEY (flow_key_hash, id)\n)\n\n\nCREATE TABLE IF NOT EXISTS all_key_types_part_one (\n\tflow_key_hash INT64 NOT NULL,\n\t\tid INT64 NOT NULL,\n\t\tstrintkey STRING(MAX) NOT NULL,\n\t\tstrnumkey STRING(MAX) NOT NULL,\n\t\tcounter INT64,\n\t\tflow_published_at TIMESTAMP NOT NULL,\n\t\tstrint NUMERIC,\n\t\tstrnum FLOAT64,\n\n\t\tPRIMARY KEY (flow_key_hash, id, strintkey, strnumkey)\n)\n\n\nCREATE TABLE IF NOT EXISTS all_key_types_part_two (\n\tflow_key_hash INT64 NOT NULL,\n\t\tid INT64 NOT NULL,\n\t\tdatekey STRING(MAX) NOT NULL,\n\t\ttimekey STRING(MAX) NOT NULL,\n\t\tcounter INT64,\n\t\tdate DATE,\n\t\tflow_published_at TIMESTAMP NOT NULL,\n\t\ttime STRING(MAX),\n\n\t\tPRIMARY KEY (flow_key_hash, id, datekey, timekey)\n)\n\n\nCREATE TABLE IF NOT EXISTS all_key_types_part_three (\n\tflow_key_hash INT64 NOT NULL,\n\t\tid INT64 NOT NULL,\n\t\tdatetimekey STRING(MAX) NOT NULL,\n\t\tuuidkey STRING(36) NOT NULL,\n\t\tcounter INT64,\n\t\tdatetime TIMESTAMP,\n\t\tflow_published_at TIMESTAMP NOT NULL,\n\t\tuuid STRING(36),\n\n\t\tPRIMARY KEY (flow_key_hash, id, datetimekey, uuidkey)\n)\n\n\nCREATE TABLE IF NOT EXISTS fields_with_projections (\n\tflow_key_hash INT64 NOT NULL,\n\t\tid INT64 NOT NULL,\n\t\tanother_field STRING(MAX),\n\t\tflow_published_at TIMESTAMP NOT NULL,\n\t\tprojected_another STRING(MAX),\n\t\tprojected_field STRING(MAX),\n\n\t\tPRIMARY KEY (flow_key_hash, id)\n)\n\n\nCREATE TABLE IF NOT EXISTS many_columns (\n\tflow_key_hash INT64 NOT NULL,\n\t\tid INT64 NOT NULL,\n\t\ta0 INT64,\n\t\ta1 INT64,\n\t\ta10 INT64,\n\t\ta11 INT64,\n\t\ta12 INT64,\n\t\ta13 INT64,\n\t\ta14 INT64,\n\t\ta15 INT64,\n\t\ta16 INT64,\n\t\ta17 INT64,\n\t\ta18 INT64,\n\t\ta19 INT64,\n\t\ta2 INT64,\n\t\ta20 INT64,\n\t\ta21 INT64,\n\t\ta22 INT64,\n\t\ta23 INT64,\n\t\ta24 INT64,\n\t\ta25 INT64,\n\t\ta26 INT64,\n\t\ta27 INT64,\n\t\ta28 INT64,\n\t\ta29 INT64,\n\t\ta3 INT64,\n\t\ta30 INT64,\n\t\ta31 INT64,\n\t\ta32 INT64,\n\t\ta33 INT64,\n\t\ta34 INT64,\n\t\ta35 INT64,\n\t\ta36 INT64,\n\t\ta37 INT64,\n\t\ta38 INT64,\n\t\ta39 INT64,\n\t\ta4 INT64,\n\t\ta40 INT64,\n\t\ta41 INT64,\n\t\ta42 INT64,\n\t\ta43 INT64,\n\t\ta44 INT64,\n\t\ta45 INT64,\n\t\ta46 INT64,\n\t\ta47 INT64,\n\t\ta48 INT64,\n\t\ta49 INT64,\n\t\ta5 INT64,\n\t\ta50 INT64,\n\t\ta51 INT64,\n\t\ta52 INT64,\n\t\ta53 INT64,\n\t\ta54 INT64,\n\t\ta55 INT64,\n\t\ta56 INT64,\n\t\ta57 INT64,\n\t\ta58 INT64,\n\t\ta59 INT64,\n\t\ta6 INT64,\n\t\ta60 INT64,\n\t\ta61 INT64,\n\t\ta62 INT64,\n\t\ta63 INT64,\n\t\ta64 INT64,\n\t\ta65 INT64,\n\t\ta66 INT64,\n\t\ta67 INT64,\n\t\ta68 INT64,\n\t\ta69 INT64,\n\t\ta7 INT64,\n\t\ta70 INT64,\n\t\ta71 INT64,\n\t\ta72 INT64,\n\t\ta73 INT64,\n\t\ta74 INT64,\n\t\ta75 INT64,\n\t\ta76 INT64,\n\t\ta77 INT64,\n\t\ta78 INT64,\n\t\ta79 INT64,\n\t\ta8 INT64,\n\t\ta80 INT64,\n\t\ta81 INT64,\n\t\ta82 INT64,\n\t\ta83 INT64,\n\t\ta84 INT64,\n\t\ta85 INT64,\n\t\ta86 INT64,\n\t\ta87 INT64,\n\t\ta88 INT64,\n\t\ta89 INT64,\n\t\ta9 INT64,\n\t\ta90 INT64,\n\t\ta91 INT64,\n\t\ta92 INT64,\n\t\ta93 INT64,\n\t\ta94 INT64,\n\t\ta95 INT64,\n\t\ta96 INT64,\n\t\ta97 INT64,\n\t\ta98 INT64,\n\t\ta99 INT64,\n\t\tflow_published_at TIMESTAMP NOT NULL,\n\n\t\tPRIMARY KEY (flow_key_hash, id)\n)\n\n\nCREATE TABLE IF NOT EXISTS timezone_datetimes_standard (\n\tflow_key_hash INT64 NOT NULL,\n\t\tid INT64 NOT NULL,\n\t\tflow_published_at TIMESTAMP NOT NULL,\n\t\toffset_datetime TIMESTAMP NOT NULL,\n\t\tutc_datetime TIMESTAMP NOT NULL,\n\n\t\tPRIMARY KEY (flow_key_hash, id)\n)\n"
+]
+[
+  "connectorState",
+  {}
 ]
 [
   "connectorState",
@@ -26,61 +30,61 @@
     {
       "canary": "amputation's",
       "flow_key_hash": "-8517097267634966620",
-      "flow_published_at": "1970-01-01T00:00:00Z",
+      "flow_published_at": "1970-01-01T01:00:00Z",
       "id": "1"
     },
     {
       "canary": "armament's",
       "flow_key_hash": "-1820151046732198393",
-      "flow_published_at": "1970-01-01T00:00:01Z",
+      "flow_published_at": "1970-01-01T01:00:01Z",
       "id": "2"
     },
     {
       "canary": "splatters",
       "flow_key_hash": "-4052466453699787802",
-      "flow_published_at": "1970-01-01T00:00:02Z",
+      "flow_published_at": "1970-01-01T01:00:02Z",
       "id": "3"
     },
     {
       "canary": "strengthen",
       "flow_key_hash": "3232700585171816769",
-      "flow_published_at": "1970-01-01T00:00:03Z",
+      "flow_published_at": "1970-01-01T01:00:03Z",
       "id": "4"
     },
     {
       "canary": "Kringle's",
       "flow_key_hash": "1000385178204227360",
-      "flow_published_at": "1970-01-01T00:00:04Z",
+      "flow_published_at": "1970-01-01T01:00:04Z",
       "id": "5"
     },
     {
       "canary": "grosbeak's",
       "flow_key_hash": "7697331399106995587",
-      "flow_published_at": "1970-01-01T00:00:05Z",
+      "flow_published_at": "1970-01-01T01:00:05Z",
       "id": "6"
     },
     {
       "canary": "pieced",
       "flow_key_hash": "5465015992139406178",
-      "flow_published_at": "1970-01-01T01:00:00Z",
+      "flow_published_at": "1970-01-01T02:00:00Z",
       "id": "7"
     },
     {
       "canary": "roaches",
       "flow_key_hash": "-6873002678636213555",
-      "flow_published_at": "1970-01-01T01:00:01Z",
+      "flow_published_at": "1970-01-01T02:00:01Z",
       "id": "8"
     },
     {
       "canary": "devilish",
       "flow_key_hash": "-9105318085603802964",
-      "flow_published_at": "1970-01-01T01:00:02Z",
+      "flow_published_at": "1970-01-01T02:00:02Z",
       "id": "9"
     },
     {
       "canary": "glucose's",
       "flow_key_hash": "-2408371864701034737",
-      "flow_published_at": "1970-01-01T01:00:03Z",
+      "flow_published_at": "1970-01-01T02:00:03Z",
       "id": "10"
     }
   ]
@@ -90,70 +94,70 @@
   "rows": [
     {
       "flow_key_hash": "-8517097267634966620",
-      "flow_published_at": "1970-01-01T01:00:04Z",
+      "flow_published_at": "1970-01-01T02:00:04Z",
       "id": "1",
       "int": "7",
       "str": "str 6"
     },
     {
       "flow_key_hash": "-1820151046732198393",
-      "flow_published_at": "1970-01-01T01:00:05Z",
+      "flow_published_at": "1970-01-01T02:00:05Z",
       "id": "2",
       "int": "9",
       "str": "str 7"
     },
     {
       "flow_key_hash": "-4052466453699787802",
-      "flow_published_at": "1970-01-01T01:00:06Z",
+      "flow_published_at": "1970-01-01T02:00:06Z",
       "id": "3",
       "int": "11",
       "str": "str 8"
     },
     {
       "flow_key_hash": "3232700585171816769",
-      "flow_published_at": "1970-01-01T01:00:07Z",
+      "flow_published_at": "1970-01-01T02:00:07Z",
       "id": "4",
       "int": "13",
       "str": "str 9"
     },
     {
       "flow_key_hash": "1000385178204227360",
-      "flow_published_at": "1970-01-01T01:00:08Z",
+      "flow_published_at": "1970-01-01T02:00:08Z",
       "id": "5",
       "int": "15",
       "str": "str 10"
     },
     {
       "flow_key_hash": "7697331399106995587",
-      "flow_published_at": "1970-01-01T02:00:00Z",
+      "flow_published_at": "1970-01-01T03:00:00Z",
       "id": "6",
       "int": "11",
       "str": "str 11"
     },
     {
       "flow_key_hash": "5465015992139406178",
-      "flow_published_at": "1970-01-01T02:00:01Z",
+      "flow_published_at": "1970-01-01T03:00:01Z",
       "id": "7",
       "int": "12",
       "str": "str 12"
     },
     {
       "flow_key_hash": "-6873002678636213555",
-      "flow_published_at": "1970-01-01T02:00:02Z",
+      "flow_published_at": "1970-01-01T03:00:02Z",
       "id": "8",
       "int": "13",
       "str": "str 13"
     },
     {
       "flow_key_hash": "-9105318085603802964",
-      "flow_published_at": "1970-01-01T02:00:03Z",
+      "flow_published_at": "1970-01-01T03:00:03Z",
       "id": "9",
       "int": "14",
       "str": "str 14"
     },
     {
       "flow_key_hash": "-2408371864701034737",
-      "flow_published_at": "1970-01-01T02:00:04Z",
+      "flow_published_at": "1970-01-01T03:00:04Z",
       "id": "10",
       "int": "15",
       "str": "str 15"
@@ -169,7 +173,7 @@
       "bool_field": false,
       "float_field": 1.1,
       "flow_key_hash": "-8517097267634966620",
-      "flow_published_at": "1970-01-01T00:00:13Z",
+      "flow_published_at": "1970-01-01T01:00:13Z",
       "id": "1",
       "multiple": "1",
       "nested": "{\"id\":\"i1\"}",
@@ -182,7 +186,7 @@
       "bool_field": true,
       "float_field": 2.2,
       "flow_key_hash": "-1820151046732198393",
-      "flow_published_at": "1970-01-01T00:00:14Z",
+      "flow_published_at": "1970-01-01T01:00:14Z",
       "id": "2",
       "multiple": "2.2",
       "nested": "{\"id\":\"i2\"}",
@@ -195,7 +199,7 @@
       "bool_field": false,
       "float_field": 3.3,
       "flow_key_hash": "-4052466453699787802",
-      "flow_published_at": "1970-01-01T00:00:15Z",
+      "flow_published_at": "1970-01-01T01:00:15Z",
       "id": "3",
       "multiple": "true",
       "nested": "{\"id\":\"i3\"}",
@@ -208,7 +212,7 @@
       "bool_field": true,
       "float_field": 4.4,
       "flow_key_hash": "3232700585171816769",
-      "flow_published_at": "1970-01-01T00:00:16Z",
+      "flow_published_at": "1970-01-01T01:00:16Z",
       "id": "4",
       "multiple": "false",
       "nested": "{\"id\":\"i4\"}",
@@ -221,7 +225,7 @@
       "bool_field": false,
       "float_field": 5.5,
       "flow_key_hash": "1000385178204227360",
-      "flow_published_at": "1970-01-01T00:00:17Z",
+      "flow_published_at": "1970-01-01T01:00:17Z",
       "id": "5",
       "multiple": "\"string five\"",
       "nested": "{\"id\":\"i5\"}",
@@ -234,7 +238,7 @@
       "bool_field": true,
       "float_field": 66.66,
       "flow_key_hash": "7697331399106995587",
-      "flow_published_at": "1970-01-01T01:00:19Z",
+      "flow_published_at": "1970-01-01T02:00:19Z",
       "id": "6",
       "multiple": "[\"one\",2,true]",
       "nested": "{\"id\":\"i6\"}",
@@ -247,7 +251,7 @@
       "bool_field": false,
       "float_field": 77.77,
       "flow_key_hash": "5465015992139406178",
-      "flow_published_at": "1970-01-01T01:00:20Z",
+      "flow_published_at": "1970-01-01T02:00:20Z",
       "id": "7",
       "multiple": "{\"object\":\"seven\"}",
       "nested": "{\"id\":\"i7\"}",
@@ -260,7 +264,7 @@
       "bool_field": true,
       "float_field": 88.88,
       "flow_key_hash": "-6873002678636213555",
-      "flow_published_at": "1970-01-01T01:00:21Z",
+      "flow_published_at": "1970-01-01T02:00:21Z",
       "id": "8",
       "multiple": null,
       "nested": "{\"id\":\"i8\"}",
@@ -273,7 +277,7 @@
       "bool_field": false,
       "float_field": 99.99,
       "flow_key_hash": "-9105318085603802964",
-      "flow_published_at": "1970-01-01T01:00:22Z",
+      "flow_published_at": "1970-01-01T02:00:22Z",
       "id": "9",
       "multiple": null,
       "nested": "{\"id\":\"i9\"}",
@@ -286,7 +290,7 @@
       "bool_field": true,
       "float_field": 1010.101,
       "flow_key_hash": "-2408371864701034737",
-      "flow_published_at": "1970-01-01T01:00:23Z",
+      "flow_published_at": "1970-01-01T02:00:23Z",
       "id": "10",
       "multiple": null,
       "nested": "{\"id\":\"i10\"}",
@@ -302,7 +306,7 @@
       "date": "0001-01-01",
       "datetime": "0001-01-01T00:00:00Z",
       "flow_key_hash": "-8517097267634966620",
-      "flow_published_at": "1970-01-01T01:00:13Z",
+      "flow_published_at": "1970-01-01T02:00:13Z",
       "id": "1",
       "int_and_str": "1",
       "int_str": "10",
@@ -314,7 +318,7 @@
       "date": "1999-02-02",
       "datetime": "1999-02-02T14:20:12.33Z",
       "flow_key_hash": "-1820151046732198393",
-      "flow_published_at": "1970-01-01T01:00:14Z",
+      "flow_published_at": "1970-01-01T02:00:14Z",
       "id": "2",
       "int_and_str": "2",
       "int_str": "20",
@@ -326,7 +330,7 @@
       "date": "1000-03-03",
       "datetime": "1000-03-03T23:59:38.1Z",
       "flow_key_hash": "-4052466453699787802",
-      "flow_published_at": "1970-01-01T00:00:11Z",
+      "flow_published_at": "1970-01-01T01:00:11Z",
       "id": "3",
       "int_and_str": "3",
       "int_str": "30",
@@ -338,7 +342,7 @@
       "date": "2023-08-29",
       "datetime": "2023-08-29T23:59:38Z",
       "flow_key_hash": "3232700585171816769",
-      "flow_published_at": "1970-01-01T00:00:12Z",
+      "flow_published_at": "1970-01-01T01:00:12Z",
       "id": "4",
       "int_and_str": "4",
       "int_str": "40",
@@ -350,7 +354,7 @@
       "date": "9999-12-31",
       "datetime": "9999-12-31T23:59:59Z",
       "flow_key_hash": "1000385178204227360",
-      "flow_published_at": "1970-01-01T01:00:15Z",
+      "flow_published_at": "1970-01-01T02:00:15Z",
       "id": "5",
       "int_and_str": "5",
       "int_str": "50",
@@ -362,7 +366,7 @@
       "date": null,
       "datetime": null,
       "flow_key_hash": "-6873002678636213555",
-      "flow_published_at": "1970-01-01T01:00:16Z",
+      "flow_published_at": "1970-01-01T02:00:16Z",
       "id": "8",
       "int_and_str": null,
       "int_str": null,
@@ -373,7 +377,7 @@
       "date": null,
       "datetime": null,
       "flow_key_hash": "-9105318085603802964",
-      "flow_published_at": "1970-01-01T01:00:17Z",
+      "flow_published_at": "1970-01-01T02:00:17Z",
       "id": "9",
       "int_and_str": null,
       "int_str": null,
@@ -384,7 +388,7 @@
       "date": null,
       "datetime": null,
       "flow_key_hash": "-2408371864701034737",
-      "flow_published_at": "1970-01-01T01:00:18Z",
+      "flow_published_at": "1970-01-01T02:00:18Z",
       "id": "10",
       "int_and_str": null,
       "int_str": null,
@@ -398,7 +402,7 @@
   "rows": [
     {
       "flow_key_hash": "-439409999022904539",
-      "flow_published_at": "1970-01-01T00:00:27Z",
+      "flow_published_at": "1970-01-01T01:00:27Z",
       "id": "test",
       "testing___s_": "test"
     }
@@ -409,7 +413,7 @@
   "rows": [
     {
       "flow_key_hash": "-8517097267634966620",
-      "flow_published_at": "1970-01-01T00:00:28Z",
+      "flow_published_at": "1970-01-01T01:00:28Z",
       "id": "1",
       "unsigned_bigint": "18446744073709551615"
     }
@@ -421,13 +425,13 @@
     {
       "c__meta_op": "u",
       "flow_key_hash": "-1820151046732198393",
-      "flow_published_at": "1970-01-01T01:00:26Z",
+      "flow_published_at": "1970-01-01T02:00:26Z",
       "id": "2"
     },
     {
       "c__meta_op": "c",
       "flow_key_hash": "-4052466453699787802",
-      "flow_published_at": "1970-01-01T01:00:27Z",
+      "flow_published_at": "1970-01-01T02:00:27Z",
       "id": "3"
     }
   ]
@@ -438,7 +442,7 @@
     {
       "counter": "3",
       "flow_key_hash": "-7079300731140785184",
-      "flow_published_at": "1970-01-01T01:00:31Z",
+      "flow_published_at": "1970-01-01T02:00:31Z",
       "id": "\\he \\ ' \" `llo`"
     }
   ]
@@ -449,7 +453,7 @@
     {
       "counter": "2",
       "flow_key_hash": "-1271019940749315661",
-      "flow_published_at": "1970-01-01T01:00:32Z",
+      "flow_published_at": "1970-01-01T02:00:32Z",
       "id": "1",
       "strint": "1",
       "strintkey": "1",
@@ -466,7 +470,7 @@
       "date": "0001-01-01",
       "datekey": "0000-01-01",
       "flow_key_hash": "-1615006715128879075",
-      "flow_published_at": "1970-01-01T01:00:33Z",
+      "flow_published_at": "1970-01-01T02:00:33Z",
       "id": "1",
       "time": "12:34:56Z",
       "timekey": "12:34:56Z"
@@ -481,7 +485,7 @@
       "datetime": "0001-01-01T00:00:00Z",
       "datetimekey": "0000-01-01T12:34:56Z",
       "flow_key_hash": "7329698761904902652",
-      "flow_published_at": "1970-01-01T01:00:34Z",
+      "flow_published_at": "1970-01-01T02:00:34Z",
       "id": "1",
       "uuid": "550e8400-e29b-41d4-a716-446655440000",
       "uuidkey": "550e8400-e29b-41d4-a716-446655440000"
@@ -494,7 +498,7 @@
     {
       "another_field": "another_updated",
       "flow_key_hash": "-8517097267634966620",
-      "flow_published_at": "1970-01-01T01:00:35Z",
+      "flow_published_at": "1970-01-01T02:00:35Z",
       "id": "1",
       "projected_another": "another_updated",
       "projected_field": "updated_value"
@@ -606,7 +610,7 @@
       "a98": null,
       "a99": "199",
       "flow_key_hash": "-8517097267634966620",
-      "flow_published_at": "1970-01-01T01:00:36Z",
+      "flow_published_at": "1970-01-01T02:00:36Z",
       "id": "1"
     }
   ]
@@ -616,21 +620,21 @@
   "rows": [
     {
       "flow_key_hash": "-8517097267634966620",
-      "flow_published_at": "1970-01-01T00:00:36Z",
+      "flow_published_at": "1970-01-01T01:00:36Z",
       "id": "1",
       "offset_datetime": "2024-01-15T15:30:00Z",
       "utc_datetime": "2024-01-15T15:30:00Z"
     },
     {
       "flow_key_hash": "-1820151046732198393",
-      "flow_published_at": "1970-01-01T00:00:37Z",
+      "flow_published_at": "1970-01-01T01:00:37Z",
       "id": "2",
       "offset_datetime": "0001-01-01T00:00:00Z",
       "utc_datetime": "0001-01-01T00:00:00Z"
     },
     {
       "flow_key_hash": "-4052466453699787802",
-      "flow_published_at": "1970-01-01T00:00:38Z",
+      "flow_published_at": "1970-01-01T01:00:38Z",
       "id": "3",
       "offset_datetime": "2025-01-01T00:00:00.123456789Z",
       "utc_datetime": "2025-01-01T00:00:00.123456789Z"


### PR DESCRIPTION
**Description:**

- We were mistakenly creating flow_checkpoints_v1 with `flow_key_hash` while it doesn't need it
- This was not noticed because our integration tests were not cleaning up `flow_checkpoints_v1` and we have `CREATE TABLE IF NOT EXISTS`
- Update test cleanup to make sure we clean up old tables
- Fix creation of `flow_checkpoints_v1` to remove `flow_key_hash`

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

