### PR TITLE
materialize-snowflake: additional snowpipe streaming logging

### DIFF
--- a/materialize-snowflake/stream_http.go
+++ b/materialize-snowflake/stream_http.go
@@ -284,6 +284,7 @@ func (s *streamClient) write(ctx context.Context, blob *blobMetadata) error {
 		"rows":               blob.Chunks[0].EPS.Rows,
 		"length":             blob.Chunks[0].ChunkLength,
 		"lengthUncompressed": blob.Chunks[0].ChunkLengthUncompressed,
+		"blobToken":          blob.Chunks[0].Channels[0].OffsetToken,
 	}).Info("registered bdec file")
 
 	return nil
@@ -363,7 +364,7 @@ func (s *streamClient) waitForTokenPersisted(ctx context.Context, token string, 
 		"table":  table,
 		"token":  token,
 		"took":   time.Since(ts).String(),
-	}).Debug("channel offset token persisted")
+	}).Info("channel offset token persisted")
 
 	return nil
 }


### PR DESCRIPTION
**Description:**

Adds some additional logging to snowpipe streaming to help with troubleshooting duplicate bdec file registrations.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

