### PR TITLE
materialize-snowflake: always rename bdec files when registering on recovery commits

### DIFF
--- a/materialize-snowflake/snowflake.go
+++ b/materialize-snowflake/snowflake.go
@@ -229,6 +229,10 @@ type transactor struct {
 	// this shard's range spec and version, used to key pipes so they don't collide
 	_range  *pf.RangeSpec
 	version string
+
+	// If this is still the recovery (first after startup) commit, where special
+	// handling may be needed for registering streaming files.
+	didRecovery bool
 }
 
 func (d *transactor) UnmarshalState(state json.RawMessage) error {
@@ -795,6 +799,10 @@ func (d *transactor) copyHistory(ctx context.Context, tableName string, fileName
 
 // Acknowledge merges data from temporary table to main table
 func (d *transactor) Acknowledge(ctx context.Context) (*pf.ConnectorState, error) {
+	defer func() {
+		d.didRecovery = true
+	}()
+
 	// Run store queries concurrently, as each independently operates on a separate table.
 	group, groupCtx := errgroup.WithContext(ctx)
 	group.SetLimit(MaxConcurrentQueries)
@@ -829,7 +837,7 @@ func (d *transactor) Acknowledge(ctx context.Context) (*pf.ConnectorState, error
 		} else if len(item.StreamBlobs) > 0 {
 			group.Go(func() error {
 				d.be.StartedResourceCommit(path)
-				if err := d.streamManager.write(groupCtx, item.StreamBlobs); err != nil {
+				if err := d.streamManager.write(groupCtx, item.StreamBlobs, !d.didRecovery); err != nil {
 					return fmt.Errorf("writing streaming blobs for %s: %w", path, err)
 				}
 				d.be.FinishedResourceCommit(path)


### PR DESCRIPTION
**Description:**

There are conceivable scenarios where the persisted offset token may have been changed out-of-bounds between restarts of the connector, and this could result in the same file be registered twice. The outcome of this is quite severe, resulting in a corrupted table that requires re-backfilling. It's safer to always download & re-upload files in this scenario with new names, which will result in duplicate table data, but at least the tables will still be usable.

It is worth noting that this strategy incurs a performance penalty and extra data transfer. This shouldn't be too big of a deal, since it's only for the recovery commit, and only when a driver checkpoint was committed to the to the runtime but the files weren't actually registered. So this should not happen very often.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

