### PR TITLE
DO NOT MERGE: materialize-snowflake: allow progress on recovery commit error code 35

### DIFF
--- a/materialize-snowflake/stream_http.go
+++ b/materialize-snowflake/stream_http.go
@@ -442,6 +442,7 @@ var streamingIngestResponseCodes = map[int]string{
 	32: "malformed request: invalid column in ep_info",
 	33: "malformed request: invalid ep_info (generic)",
 	34: "malformed request: invalid blob name",
+	35: "the channel must be reopened", // Not documented, but we've been told it means the same as 36.
 	36: "the channel must be reopened",
 	37: "malformed request: missing role in request",
 	38: "malformed request: blob has wrong format or extension",


### PR DESCRIPTION
**Description:**

For limited deployment: Allow the connector to progress when Snowpipe streaming blob registration encounters error code 35 during a recovery commit.

This branch is not intended to be merged, but its built image may be temporarily deployed to impacted tasks to get the unstuck.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

