### PR TITLE
source-hubspot-native: fix properties fetch for custom objects

### DIFF
--- a/source-hubspot-native/source_hubspot_native/resources.py
+++ b/source-hubspot-native/source_hubspot_native/resources.py
@@ -361,7 +361,7 @@ def crm_object_with_associations(
         all_bindings,
     ):
         # Emit a sourced schema to increase the inferred schema's complexity limit.
-        properties = await fetch_properties(task.log, http, object_name)
+        properties = await fetch_properties(task.log, http, path_component)
         task.sourced_schema(binding_index, cls.sourced_schema(properties.results))
         await task.checkpoint(state=ConnectorState())
 


### PR DESCRIPTION
**Description:**

The `fetch_properties` call was using `object_name` (the resource name) instead of `path_component` (the API identifier). For custom objects, these differ: the resource name is like "custom_portfolio" while the API requires "p_portfolio". This caused 400 errors from HubSpot's properties endpoint for custom objects.

For standard objects, both values are identical, so this change has no effect on them.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

