### PR TITLE
source-postgres: improve error message for missing key column during backfill

### DIFF
--- a/source-postgres/backfill.go
+++ b/source-postgres/backfill.go
@@ -162,7 +162,14 @@ func (db *postgresDatabase) ScanTableChunk(ctx context.Context, info *sqlcapture
 		for idx, colName := range keyColumns {
 			var resultIndex = slices.Index(resultColumnNames, colName)
 			if resultIndex < 0 {
-				return false, nil, fmt.Errorf("key column %q not found in result columns for %q", colName, streamID)
+				return false, nil, fmt.Errorf(
+				"key column %q not found in result columns for %q (got columns: [%s]):"+
+					" the backfill query uses SELECT * which must return all key columns."+
+					" Common causes: (1) the capture user lacks table-level SELECT and only has"+
+					" column-level grants that don't include this column,"+
+					" (2) row-level security (RLS) policies are restricting query results",
+				colName, streamID, strings.Join(resultColumnNames, ", "),
+			)
 			}
 			keyIndices[idx] = resultIndex
 		}


### PR DESCRIPTION
## Summary
- When a key column is not found in the `SELECT *` result set during backfill, the error message now includes the columns that were actually returned and suggests common causes
- Previously the error was just `key column "id" not found in result columns for "public.tablename"` with no guidance

The improved message covers the two known causes for this during backfill:
1. Missing table-level SELECT (only column-level grants that don't include the key column)
2. Row-level security (RLS) policies restricting query results

## Context
We've seen this error with multiple customers and it's consistently hard for them to debug. Recent case: customer on PostgreSQL 17.5 with RLS enabled — fix was `ALTER ROLE flow_capture BYPASSRLS`.

## Test plan
- [ ] String-only change, no logic affected
- [ ] Verified syntax compiles

🤖 Generated with [Claude Code](https://claude.com/claude-code)