### PR TITLE
source-shopify-native: support multiple Shopify stores

### DIFF
--- a/source-shopify-native/acmeCo/abandoned_checkouts.schema.yaml
+++ b/source-shopify-native/acmeCo/abandoned_checkouts.schema.yaml
@@ -1,36 +1,37 @@
----
 $defs:
   Meta:
     properties:
       op:
         default: u
-        description: "Operation type (c: Create, u: Update, d: Delete)"
+        description: 'Operation type (c: Create, u: Update, d: Delete)'
         enum:
-          - c
-          - u
-          - d
+        - c
+        - u
+        - d
         title: Op
         type: string
       row_id:
         default: -1
-        description: "Row ID of the Document, counting up from zero, or -1 if not known"
+        description: Row ID of the Document, counting up from zero, or -1 if not known
         title: Row Id
         type: integer
+      store:
+        default: ''
+        description: The Shopify store this document belongs to
+        title: Store
+        type: string
     title: Meta
     type: object
 additionalProperties: true
 properties:
   _meta:
-    $ref: "#/$defs/Meta"
-    default:
-      op: u
-      row_id: -1
+    $ref: '#/$defs/Meta'
     description: Document metadata
   id:
     title: Id
     type: string
 required:
-  - id
+- id
 title: ShopifyGraphQLResource
 type: object
 x-infer-schema: true

--- a/source-shopify-native/acmeCo/custom_collection_metafields.schema.yaml
+++ b/source-shopify-native/acmeCo/custom_collection_metafields.schema.yaml
@@ -1,36 +1,37 @@
----
 $defs:
   Meta:
     properties:
       op:
         default: u
-        description: "Operation type (c: Create, u: Update, d: Delete)"
+        description: 'Operation type (c: Create, u: Update, d: Delete)'
         enum:
-          - c
-          - u
-          - d
+        - c
+        - u
+        - d
         title: Op
         type: string
       row_id:
         default: -1
-        description: "Row ID of the Document, counting up from zero, or -1 if not known"
+        description: Row ID of the Document, counting up from zero, or -1 if not known
         title: Row Id
         type: integer
+      store:
+        default: ''
+        description: The Shopify store this document belongs to
+        title: Store
+        type: string
     title: Meta
     type: object
 additionalProperties: true
 properties:
   _meta:
-    $ref: "#/$defs/Meta"
-    default:
-      op: u
-      row_id: -1
+    $ref: '#/$defs/Meta'
     description: Document metadata
   id:
     title: Id
     type: string
 required:
-  - id
+- id
 title: ShopifyGraphQLResource
 type: object
 x-infer-schema: true

--- a/source-shopify-native/acmeCo/custom_collections.schema.yaml
+++ b/source-shopify-native/acmeCo/custom_collections.schema.yaml
@@ -1,36 +1,37 @@
----
 $defs:
   Meta:
     properties:
       op:
         default: u
-        description: "Operation type (c: Create, u: Update, d: Delete)"
+        description: 'Operation type (c: Create, u: Update, d: Delete)'
         enum:
-          - c
-          - u
-          - d
+        - c
+        - u
+        - d
         title: Op
         type: string
       row_id:
         default: -1
-        description: "Row ID of the Document, counting up from zero, or -1 if not known"
+        description: Row ID of the Document, counting up from zero, or -1 if not known
         title: Row Id
         type: integer
+      store:
+        default: ''
+        description: The Shopify store this document belongs to
+        title: Store
+        type: string
     title: Meta
     type: object
 additionalProperties: true
 properties:
   _meta:
-    $ref: "#/$defs/Meta"
-    default:
-      op: u
-      row_id: -1
+    $ref: '#/$defs/Meta'
     description: Document metadata
   id:
     title: Id
     type: string
 required:
-  - id
+- id
 title: ShopifyGraphQLResource
 type: object
 x-infer-schema: true

--- a/source-shopify-native/acmeCo/customer_metafields.schema.yaml
+++ b/source-shopify-native/acmeCo/customer_metafields.schema.yaml
@@ -1,36 +1,37 @@
----
 $defs:
   Meta:
     properties:
       op:
         default: u
-        description: "Operation type (c: Create, u: Update, d: Delete)"
+        description: 'Operation type (c: Create, u: Update, d: Delete)'
         enum:
-          - c
-          - u
-          - d
+        - c
+        - u
+        - d
         title: Op
         type: string
       row_id:
         default: -1
-        description: "Row ID of the Document, counting up from zero, or -1 if not known"
+        description: Row ID of the Document, counting up from zero, or -1 if not known
         title: Row Id
         type: integer
+      store:
+        default: ''
+        description: The Shopify store this document belongs to
+        title: Store
+        type: string
     title: Meta
     type: object
 additionalProperties: true
 properties:
   _meta:
-    $ref: "#/$defs/Meta"
-    default:
-      op: u
-      row_id: -1
+    $ref: '#/$defs/Meta'
     description: Document metadata
   id:
     title: Id
     type: string
 required:
-  - id
+- id
 title: ShopifyGraphQLResource
 type: object
 x-infer-schema: true

--- a/source-shopify-native/acmeCo/customers.schema.yaml
+++ b/source-shopify-native/acmeCo/customers.schema.yaml
@@ -1,36 +1,37 @@
----
 $defs:
   Meta:
     properties:
       op:
         default: u
-        description: "Operation type (c: Create, u: Update, d: Delete)"
+        description: 'Operation type (c: Create, u: Update, d: Delete)'
         enum:
-          - c
-          - u
-          - d
+        - c
+        - u
+        - d
         title: Op
         type: string
       row_id:
         default: -1
-        description: "Row ID of the Document, counting up from zero, or -1 if not known"
+        description: Row ID of the Document, counting up from zero, or -1 if not known
         title: Row Id
         type: integer
+      store:
+        default: ''
+        description: The Shopify store this document belongs to
+        title: Store
+        type: string
     title: Meta
     type: object
 additionalProperties: true
 properties:
   _meta:
-    $ref: "#/$defs/Meta"
-    default:
-      op: u
-      row_id: -1
+    $ref: '#/$defs/Meta'
     description: Document metadata
   id:
     title: Id
     type: string
 required:
-  - id
+- id
 title: ShopifyGraphQLResource
 type: object
 x-infer-schema: true

--- a/source-shopify-native/acmeCo/flow.yaml
+++ b/source-shopify-native/acmeCo/flow.yaml
@@ -1,98 +1,97 @@
----
 collections:
   acmeCo/abandoned_checkouts:
     schema: abandoned_checkouts.schema.yaml
     key:
-      - /id
+    - /id
   acmeCo/custom_collection_metafields:
     schema: custom_collection_metafields.schema.yaml
     key:
-      - /id
+    - /id
   acmeCo/custom_collections:
     schema: custom_collections.schema.yaml
     key:
-      - /id
+    - /id
   acmeCo/customer_metafields:
     schema: customer_metafields.schema.yaml
     key:
-      - /id
+    - /id
   acmeCo/customers:
     schema: customers.schema.yaml
     key:
-      - /id
+    - /id
   acmeCo/fulfillment_orders:
     schema: fulfillment_orders.schema.yaml
     key:
-      - /id
+    - /id
   acmeCo/fulfillments:
     schema: fulfillments.schema.yaml
     key:
-      - /id
+    - /id
   acmeCo/inventory_items:
     schema: inventory_items.schema.yaml
     key:
-      - /id
+    - /id
   acmeCo/inventory_levels:
     schema: inventory_levels.schema.yaml
     key:
-      - /id
+    - /id
   acmeCo/location_metafields:
     schema: location_metafields.schema.yaml
     key:
-      - /id
+    - /id
   acmeCo/locations:
     schema: locations.schema.yaml
     key:
-      - /id
+    - /id
   acmeCo/order_agreements:
     schema: order_agreements.schema.yaml
     key:
-      - /id
+    - /id
   acmeCo/order_metafields:
     schema: order_metafields.schema.yaml
     key:
-      - /id
+    - /id
   acmeCo/order_refunds:
     schema: order_refunds.schema.yaml
     key:
-      - /id
+    - /id
   acmeCo/order_risks:
     schema: order_risks.schema.yaml
     key:
-      - /id
+    - /id
   acmeCo/order_transactions:
     schema: order_transactions.schema.yaml
     key:
-      - /id
+    - /id
   acmeCo/orders:
     schema: orders.schema.yaml
     key:
-      - /id
+    - /id
   acmeCo/product_media:
     schema: product_media.schema.yaml
     key:
-      - /id
+    - /id
   acmeCo/product_metafields:
     schema: product_metafields.schema.yaml
     key:
-      - /id
+    - /id
   acmeCo/product_variant_metafields:
     schema: product_variant_metafields.schema.yaml
     key:
-      - /id
+    - /id
   acmeCo/product_variants:
     schema: product_variants.schema.yaml
     key:
-      - /id
+    - /id
   acmeCo/products:
     schema: products.schema.yaml
     key:
-      - /id
+    - /id
   acmeCo/smart_collection_metafields:
     schema: smart_collection_metafields.schema.yaml
     key:
-      - /id
+    - /id
   acmeCo/smart_collections:
     schema: smart_collections.schema.yaml
     key:
-      - /id
+    - /id

--- a/source-shopify-native/acmeCo/fulfillment_orders.schema.yaml
+++ b/source-shopify-native/acmeCo/fulfillment_orders.schema.yaml
@@ -1,36 +1,37 @@
----
 $defs:
   Meta:
     properties:
       op:
         default: u
-        description: "Operation type (c: Create, u: Update, d: Delete)"
+        description: 'Operation type (c: Create, u: Update, d: Delete)'
         enum:
-          - c
-          - u
-          - d
+        - c
+        - u
+        - d
         title: Op
         type: string
       row_id:
         default: -1
-        description: "Row ID of the Document, counting up from zero, or -1 if not known"
+        description: Row ID of the Document, counting up from zero, or -1 if not known
         title: Row Id
         type: integer
+      store:
+        default: ''
+        description: The Shopify store this document belongs to
+        title: Store
+        type: string
     title: Meta
     type: object
 additionalProperties: true
 properties:
   _meta:
-    $ref: "#/$defs/Meta"
-    default:
-      op: u
-      row_id: -1
+    $ref: '#/$defs/Meta'
     description: Document metadata
   id:
     title: Id
     type: string
 required:
-  - id
+- id
 title: ShopifyGraphQLResource
 type: object
 x-infer-schema: true

--- a/source-shopify-native/acmeCo/fulfillments.schema.yaml
+++ b/source-shopify-native/acmeCo/fulfillments.schema.yaml
@@ -1,36 +1,37 @@
----
 $defs:
   Meta:
     properties:
       op:
         default: u
-        description: "Operation type (c: Create, u: Update, d: Delete)"
+        description: 'Operation type (c: Create, u: Update, d: Delete)'
         enum:
-          - c
-          - u
-          - d
+        - c
+        - u
+        - d
         title: Op
         type: string
       row_id:
         default: -1
-        description: "Row ID of the Document, counting up from zero, or -1 if not known"
+        description: Row ID of the Document, counting up from zero, or -1 if not known
         title: Row Id
         type: integer
+      store:
+        default: ''
+        description: The Shopify store this document belongs to
+        title: Store
+        type: string
     title: Meta
     type: object
 additionalProperties: true
 properties:
   _meta:
-    $ref: "#/$defs/Meta"
-    default:
-      op: u
-      row_id: -1
+    $ref: '#/$defs/Meta'
     description: Document metadata
   id:
     title: Id
     type: string
 required:
-  - id
+- id
 title: ShopifyGraphQLResource
 type: object
 x-infer-schema: true

--- a/source-shopify-native/acmeCo/inventory_items.schema.yaml
+++ b/source-shopify-native/acmeCo/inventory_items.schema.yaml
@@ -1,36 +1,37 @@
----
 $defs:
   Meta:
     properties:
       op:
         default: u
-        description: "Operation type (c: Create, u: Update, d: Delete)"
+        description: 'Operation type (c: Create, u: Update, d: Delete)'
         enum:
-          - c
-          - u
-          - d
+        - c
+        - u
+        - d
         title: Op
         type: string
       row_id:
         default: -1
-        description: "Row ID of the Document, counting up from zero, or -1 if not known"
+        description: Row ID of the Document, counting up from zero, or -1 if not known
         title: Row Id
         type: integer
+      store:
+        default: ''
+        description: The Shopify store this document belongs to
+        title: Store
+        type: string
     title: Meta
     type: object
 additionalProperties: true
 properties:
   _meta:
-    $ref: "#/$defs/Meta"
-    default:
-      op: u
-      row_id: -1
+    $ref: '#/$defs/Meta'
     description: Document metadata
   id:
     title: Id
     type: string
 required:
-  - id
+- id
 title: ShopifyGraphQLResource
 type: object
 x-infer-schema: true

--- a/source-shopify-native/acmeCo/inventory_levels.schema.yaml
+++ b/source-shopify-native/acmeCo/inventory_levels.schema.yaml
@@ -1,36 +1,37 @@
----
 $defs:
   Meta:
     properties:
       op:
         default: u
-        description: "Operation type (c: Create, u: Update, d: Delete)"
+        description: 'Operation type (c: Create, u: Update, d: Delete)'
         enum:
-          - c
-          - u
-          - d
+        - c
+        - u
+        - d
         title: Op
         type: string
       row_id:
         default: -1
-        description: "Row ID of the Document, counting up from zero, or -1 if not known"
+        description: Row ID of the Document, counting up from zero, or -1 if not known
         title: Row Id
         type: integer
+      store:
+        default: ''
+        description: The Shopify store this document belongs to
+        title: Store
+        type: string
     title: Meta
     type: object
 additionalProperties: true
 properties:
   _meta:
-    $ref: "#/$defs/Meta"
-    default:
-      op: u
-      row_id: -1
+    $ref: '#/$defs/Meta'
     description: Document metadata
   id:
     title: Id
     type: string
 required:
-  - id
+- id
 title: ShopifyGraphQLResource
 type: object
 x-infer-schema: true

--- a/source-shopify-native/acmeCo/location_metafields.schema.yaml
+++ b/source-shopify-native/acmeCo/location_metafields.schema.yaml
@@ -1,36 +1,37 @@
----
 $defs:
   Meta:
     properties:
       op:
         default: u
-        description: "Operation type (c: Create, u: Update, d: Delete)"
+        description: 'Operation type (c: Create, u: Update, d: Delete)'
         enum:
-          - c
-          - u
-          - d
+        - c
+        - u
+        - d
         title: Op
         type: string
       row_id:
         default: -1
-        description: "Row ID of the Document, counting up from zero, or -1 if not known"
+        description: Row ID of the Document, counting up from zero, or -1 if not known
         title: Row Id
         type: integer
+      store:
+        default: ''
+        description: The Shopify store this document belongs to
+        title: Store
+        type: string
     title: Meta
     type: object
 additionalProperties: true
 properties:
   _meta:
-    $ref: "#/$defs/Meta"
-    default:
-      op: u
-      row_id: -1
+    $ref: '#/$defs/Meta'
     description: Document metadata
   id:
     title: Id
     type: string
 required:
-  - id
+- id
 title: ShopifyGraphQLResource
 type: object
 x-infer-schema: true

--- a/source-shopify-native/acmeCo/locations.schema.yaml
+++ b/source-shopify-native/acmeCo/locations.schema.yaml
@@ -1,36 +1,37 @@
----
 $defs:
   Meta:
     properties:
       op:
         default: u
-        description: "Operation type (c: Create, u: Update, d: Delete)"
+        description: 'Operation type (c: Create, u: Update, d: Delete)'
         enum:
-          - c
-          - u
-          - d
+        - c
+        - u
+        - d
         title: Op
         type: string
       row_id:
         default: -1
-        description: "Row ID of the Document, counting up from zero, or -1 if not known"
+        description: Row ID of the Document, counting up from zero, or -1 if not known
         title: Row Id
         type: integer
+      store:
+        default: ''
+        description: The Shopify store this document belongs to
+        title: Store
+        type: string
     title: Meta
     type: object
 additionalProperties: true
 properties:
   _meta:
-    $ref: "#/$defs/Meta"
-    default:
-      op: u
-      row_id: -1
+    $ref: '#/$defs/Meta'
     description: Document metadata
   id:
     title: Id
     type: string
 required:
-  - id
+- id
 title: ShopifyGraphQLResource
 type: object
 x-infer-schema: true

--- a/source-shopify-native/acmeCo/order_agreements.schema.yaml
+++ b/source-shopify-native/acmeCo/order_agreements.schema.yaml
@@ -1,36 +1,37 @@
----
 $defs:
   Meta:
     properties:
       op:
         default: u
-        description: "Operation type (c: Create, u: Update, d: Delete)"
+        description: 'Operation type (c: Create, u: Update, d: Delete)'
         enum:
-          - c
-          - u
-          - d
+        - c
+        - u
+        - d
         title: Op
         type: string
       row_id:
         default: -1
-        description: "Row ID of the Document, counting up from zero, or -1 if not known"
+        description: Row ID of the Document, counting up from zero, or -1 if not known
         title: Row Id
         type: integer
+      store:
+        default: ''
+        description: The Shopify store this document belongs to
+        title: Store
+        type: string
     title: Meta
     type: object
 additionalProperties: true
 properties:
   _meta:
-    $ref: "#/$defs/Meta"
-    default:
-      op: u
-      row_id: -1
+    $ref: '#/$defs/Meta'
     description: Document metadata
   id:
     title: Id
     type: string
 required:
-  - id
+- id
 title: ShopifyGraphQLResource
 type: object
 x-infer-schema: true

--- a/source-shopify-native/acmeCo/order_metafields.schema.yaml
+++ b/source-shopify-native/acmeCo/order_metafields.schema.yaml
@@ -1,36 +1,37 @@
----
 $defs:
   Meta:
     properties:
       op:
         default: u
-        description: "Operation type (c: Create, u: Update, d: Delete)"
+        description: 'Operation type (c: Create, u: Update, d: Delete)'
         enum:
-          - c
-          - u
-          - d
+        - c
+        - u
+        - d
         title: Op
         type: string
       row_id:
         default: -1
-        description: "Row ID of the Document, counting up from zero, or -1 if not known"
+        description: Row ID of the Document, counting up from zero, or -1 if not known
         title: Row Id
         type: integer
+      store:
+        default: ''
+        description: The Shopify store this document belongs to
+        title: Store
+        type: string
     title: Meta
     type: object
 additionalProperties: true
 properties:
   _meta:
-    $ref: "#/$defs/Meta"
-    default:
-      op: u
-      row_id: -1
+    $ref: '#/$defs/Meta'
     description: Document metadata
   id:
     title: Id
     type: string
 required:
-  - id
+- id
 title: ShopifyGraphQLResource
 type: object
 x-infer-schema: true

--- a/source-shopify-native/acmeCo/order_refunds.schema.yaml
+++ b/source-shopify-native/acmeCo/order_refunds.schema.yaml
@@ -1,36 +1,37 @@
----
 $defs:
   Meta:
     properties:
       op:
         default: u
-        description: "Operation type (c: Create, u: Update, d: Delete)"
+        description: 'Operation type (c: Create, u: Update, d: Delete)'
         enum:
-          - c
-          - u
-          - d
+        - c
+        - u
+        - d
         title: Op
         type: string
       row_id:
         default: -1
-        description: "Row ID of the Document, counting up from zero, or -1 if not known"
+        description: Row ID of the Document, counting up from zero, or -1 if not known
         title: Row Id
         type: integer
+      store:
+        default: ''
+        description: The Shopify store this document belongs to
+        title: Store
+        type: string
     title: Meta
     type: object
 additionalProperties: true
 properties:
   _meta:
-    $ref: "#/$defs/Meta"
-    default:
-      op: u
-      row_id: -1
+    $ref: '#/$defs/Meta'
     description: Document metadata
   id:
     title: Id
     type: string
 required:
-  - id
+- id
 title: ShopifyGraphQLResource
 type: object
 x-infer-schema: true

--- a/source-shopify-native/acmeCo/order_risks.schema.yaml
+++ b/source-shopify-native/acmeCo/order_risks.schema.yaml
@@ -1,36 +1,37 @@
----
 $defs:
   Meta:
     properties:
       op:
         default: u
-        description: "Operation type (c: Create, u: Update, d: Delete)"
+        description: 'Operation type (c: Create, u: Update, d: Delete)'
         enum:
-          - c
-          - u
-          - d
+        - c
+        - u
+        - d
         title: Op
         type: string
       row_id:
         default: -1
-        description: "Row ID of the Document, counting up from zero, or -1 if not known"
+        description: Row ID of the Document, counting up from zero, or -1 if not known
         title: Row Id
         type: integer
+      store:
+        default: ''
+        description: The Shopify store this document belongs to
+        title: Store
+        type: string
     title: Meta
     type: object
 additionalProperties: true
 properties:
   _meta:
-    $ref: "#/$defs/Meta"
-    default:
-      op: u
-      row_id: -1
+    $ref: '#/$defs/Meta'
     description: Document metadata
   id:
     title: Id
     type: string
 required:
-  - id
+- id
 title: ShopifyGraphQLResource
 type: object
 x-infer-schema: true

--- a/source-shopify-native/acmeCo/order_transactions.schema.yaml
+++ b/source-shopify-native/acmeCo/order_transactions.schema.yaml
@@ -1,36 +1,37 @@
----
 $defs:
   Meta:
     properties:
       op:
         default: u
-        description: "Operation type (c: Create, u: Update, d: Delete)"
+        description: 'Operation type (c: Create, u: Update, d: Delete)'
         enum:
-          - c
-          - u
-          - d
+        - c
+        - u
+        - d
         title: Op
         type: string
       row_id:
         default: -1
-        description: "Row ID of the Document, counting up from zero, or -1 if not known"
+        description: Row ID of the Document, counting up from zero, or -1 if not known
         title: Row Id
         type: integer
+      store:
+        default: ''
+        description: The Shopify store this document belongs to
+        title: Store
+        type: string
     title: Meta
     type: object
 additionalProperties: true
 properties:
   _meta:
-    $ref: "#/$defs/Meta"
-    default:
-      op: u
-      row_id: -1
+    $ref: '#/$defs/Meta'
     description: Document metadata
   id:
     title: Id
     type: string
 required:
-  - id
+- id
 title: ShopifyGraphQLResource
 type: object
 x-infer-schema: true

--- a/source-shopify-native/acmeCo/orders.schema.yaml
+++ b/source-shopify-native/acmeCo/orders.schema.yaml
@@ -1,36 +1,37 @@
----
 $defs:
   Meta:
     properties:
       op:
         default: u
-        description: "Operation type (c: Create, u: Update, d: Delete)"
+        description: 'Operation type (c: Create, u: Update, d: Delete)'
         enum:
-          - c
-          - u
-          - d
+        - c
+        - u
+        - d
         title: Op
         type: string
       row_id:
         default: -1
-        description: "Row ID of the Document, counting up from zero, or -1 if not known"
+        description: Row ID of the Document, counting up from zero, or -1 if not known
         title: Row Id
         type: integer
+      store:
+        default: ''
+        description: The Shopify store this document belongs to
+        title: Store
+        type: string
     title: Meta
     type: object
 additionalProperties: true
 properties:
   _meta:
-    $ref: "#/$defs/Meta"
-    default:
-      op: u
-      row_id: -1
+    $ref: '#/$defs/Meta'
     description: Document metadata
   id:
     title: Id
     type: string
 required:
-  - id
+- id
 title: ShopifyGraphQLResource
 type: object
 x-infer-schema: true

--- a/source-shopify-native/acmeCo/product_media.schema.yaml
+++ b/source-shopify-native/acmeCo/product_media.schema.yaml
@@ -1,36 +1,37 @@
----
 $defs:
   Meta:
     properties:
       op:
         default: u
-        description: "Operation type (c: Create, u: Update, d: Delete)"
+        description: 'Operation type (c: Create, u: Update, d: Delete)'
         enum:
-          - c
-          - u
-          - d
+        - c
+        - u
+        - d
         title: Op
         type: string
       row_id:
         default: -1
-        description: "Row ID of the Document, counting up from zero, or -1 if not known"
+        description: Row ID of the Document, counting up from zero, or -1 if not known
         title: Row Id
         type: integer
+      store:
+        default: ''
+        description: The Shopify store this document belongs to
+        title: Store
+        type: string
     title: Meta
     type: object
 additionalProperties: true
 properties:
   _meta:
-    $ref: "#/$defs/Meta"
-    default:
-      op: u
-      row_id: -1
+    $ref: '#/$defs/Meta'
     description: Document metadata
   id:
     title: Id
     type: string
 required:
-  - id
+- id
 title: ShopifyGraphQLResource
 type: object
 x-infer-schema: true

--- a/source-shopify-native/acmeCo/product_metafields.schema.yaml
+++ b/source-shopify-native/acmeCo/product_metafields.schema.yaml
@@ -1,36 +1,37 @@
----
 $defs:
   Meta:
     properties:
       op:
         default: u
-        description: "Operation type (c: Create, u: Update, d: Delete)"
+        description: 'Operation type (c: Create, u: Update, d: Delete)'
         enum:
-          - c
-          - u
-          - d
+        - c
+        - u
+        - d
         title: Op
         type: string
       row_id:
         default: -1
-        description: "Row ID of the Document, counting up from zero, or -1 if not known"
+        description: Row ID of the Document, counting up from zero, or -1 if not known
         title: Row Id
         type: integer
+      store:
+        default: ''
+        description: The Shopify store this document belongs to
+        title: Store
+        type: string
     title: Meta
     type: object
 additionalProperties: true
 properties:
   _meta:
-    $ref: "#/$defs/Meta"
-    default:
-      op: u
-      row_id: -1
+    $ref: '#/$defs/Meta'
     description: Document metadata
   id:
     title: Id
     type: string
 required:
-  - id
+- id
 title: ShopifyGraphQLResource
 type: object
 x-infer-schema: true

--- a/source-shopify-native/acmeCo/product_variant_metafields.schema.yaml
+++ b/source-shopify-native/acmeCo/product_variant_metafields.schema.yaml
@@ -1,33 +1,37 @@
----
 $defs:
   Meta:
     properties:
       op:
         default: u
-        description: "Operation type (c: Create, u: Update, d: Delete)"
+        description: 'Operation type (c: Create, u: Update, d: Delete)'
         enum:
-          - c
-          - u
-          - d
+        - c
+        - u
+        - d
         title: Op
         type: string
       row_id:
         default: -1
-        description: "Row ID of the Document, counting up from zero, or -1 if not known"
+        description: Row ID of the Document, counting up from zero, or -1 if not known
         title: Row Id
         type: integer
+      store:
+        default: ''
+        description: The Shopify store this document belongs to
+        title: Store
+        type: string
     title: Meta
     type: object
 additionalProperties: true
 properties:
   _meta:
-    $ref: "#/$defs/Meta"
+    $ref: '#/$defs/Meta'
     description: Document metadata
   id:
     title: Id
     type: string
 required:
-  - id
+- id
 title: ShopifyGraphQLResource
 type: object
 x-infer-schema: true

--- a/source-shopify-native/acmeCo/product_variants.schema.yaml
+++ b/source-shopify-native/acmeCo/product_variants.schema.yaml
@@ -1,36 +1,37 @@
----
 $defs:
   Meta:
     properties:
       op:
         default: u
-        description: "Operation type (c: Create, u: Update, d: Delete)"
+        description: 'Operation type (c: Create, u: Update, d: Delete)'
         enum:
-          - c
-          - u
-          - d
+        - c
+        - u
+        - d
         title: Op
         type: string
       row_id:
         default: -1
-        description: "Row ID of the Document, counting up from zero, or -1 if not known"
+        description: Row ID of the Document, counting up from zero, or -1 if not known
         title: Row Id
         type: integer
+      store:
+        default: ''
+        description: The Shopify store this document belongs to
+        title: Store
+        type: string
     title: Meta
     type: object
 additionalProperties: true
 properties:
   _meta:
-    $ref: "#/$defs/Meta"
-    default:
-      op: u
-      row_id: -1
+    $ref: '#/$defs/Meta'
     description: Document metadata
   id:
     title: Id
     type: string
 required:
-  - id
+- id
 title: ShopifyGraphQLResource
 type: object
 x-infer-schema: true

--- a/source-shopify-native/acmeCo/products.schema.yaml
+++ b/source-shopify-native/acmeCo/products.schema.yaml
@@ -1,36 +1,37 @@
----
 $defs:
   Meta:
     properties:
       op:
         default: u
-        description: "Operation type (c: Create, u: Update, d: Delete)"
+        description: 'Operation type (c: Create, u: Update, d: Delete)'
         enum:
-          - c
-          - u
-          - d
+        - c
+        - u
+        - d
         title: Op
         type: string
       row_id:
         default: -1
-        description: "Row ID of the Document, counting up from zero, or -1 if not known"
+        description: Row ID of the Document, counting up from zero, or -1 if not known
         title: Row Id
         type: integer
+      store:
+        default: ''
+        description: The Shopify store this document belongs to
+        title: Store
+        type: string
     title: Meta
     type: object
 additionalProperties: true
 properties:
   _meta:
-    $ref: "#/$defs/Meta"
-    default:
-      op: u
-      row_id: -1
+    $ref: '#/$defs/Meta'
     description: Document metadata
   id:
     title: Id
     type: string
 required:
-  - id
+- id
 title: ShopifyGraphQLResource
 type: object
 x-infer-schema: true

--- a/source-shopify-native/acmeCo/smart_collection_metafields.schema.yaml
+++ b/source-shopify-native/acmeCo/smart_collection_metafields.schema.yaml
@@ -1,36 +1,37 @@
----
 $defs:
   Meta:
     properties:
       op:
         default: u
-        description: "Operation type (c: Create, u: Update, d: Delete)"
+        description: 'Operation type (c: Create, u: Update, d: Delete)'
         enum:
-          - c
-          - u
-          - d
+        - c
+        - u
+        - d
         title: Op
         type: string
       row_id:
         default: -1
-        description: "Row ID of the Document, counting up from zero, or -1 if not known"
+        description: Row ID of the Document, counting up from zero, or -1 if not known
         title: Row Id
         type: integer
+      store:
+        default: ''
+        description: The Shopify store this document belongs to
+        title: Store
+        type: string
     title: Meta
     type: object
 additionalProperties: true
 properties:
   _meta:
-    $ref: "#/$defs/Meta"
-    default:
-      op: u
-      row_id: -1
+    $ref: '#/$defs/Meta'
     description: Document metadata
   id:
     title: Id
     type: string
 required:
-  - id
+- id
 title: ShopifyGraphQLResource
 type: object
 x-infer-schema: true

--- a/source-shopify-native/acmeCo/smart_collections.schema.yaml
+++ b/source-shopify-native/acmeCo/smart_collections.schema.yaml
@@ -1,36 +1,37 @@
----
 $defs:
   Meta:
     properties:
       op:
         default: u
-        description: "Operation type (c: Create, u: Update, d: Delete)"
+        description: 'Operation type (c: Create, u: Update, d: Delete)'
         enum:
-          - c
-          - u
-          - d
+        - c
+        - u
+        - d
         title: Op
         type: string
       row_id:
         default: -1
-        description: "Row ID of the Document, counting up from zero, or -1 if not known"
+        description: Row ID of the Document, counting up from zero, or -1 if not known
         title: Row Id
         type: integer
+      store:
+        default: ''
+        description: The Shopify store this document belongs to
+        title: Store
+        type: string
     title: Meta
     type: object
 additionalProperties: true
 properties:
   _meta:
-    $ref: "#/$defs/Meta"
-    default:
-      op: u
-      row_id: -1
+    $ref: '#/$defs/Meta'
     description: Document metadata
   id:
     title: Id
     type: string
 required:
-  - id
+- id
 title: ShopifyGraphQLResource
 type: object
 x-infer-schema: true

--- a/source-shopify-native/config.yaml
+++ b/source-shopify-native/config.yaml
@@ -1,21 +1,17 @@
-credentials:
-    credentials_title: Private App Credentials
-    access_token_sops: ENC[AES256_GCM,data:Mcq58scGHGj8jW7Lsv9gI7GQ+kbnnGe40nwOY+60W173vqNklHo=,iv:9XLi7MOmucqmyesaSxEhj4GQKd74JbyR1w20TdG7YcM=,tag:U2M6LgJeHn3Xj4ysnQYLag==,type:str]
-store: estuary-alex-testing
+stores:
+    - store: estuary-alex-testing
+      credentials:
+        credentials_title: Private App Credentials
+        access_token_sops: ENC[AES256_GCM,data:U4H9/+mC+YbmCzSeQOs77ikDHAFAl8flLkohlfLvIG4oR6O444s=,iv:RpboQbPOJnctlQeH2EEnns+xtBydFpD6TecqLiilFD4=,tag:zWOk5wMGZObyaLemX0bZ7w==,type:str]
 start_date: "2025-01-10T00:00:00Z"
 advanced:
     window_size: P50000D
 sops:
-    kms: []
     gcp_kms:
         - resource_id: projects/estuary-theatre/locations/us-central1/keyRings/connector-keyring/cryptoKeys/connector-repository
-          created_at: "2023-12-19T13:25:05Z"
-          enc: CiQAdmEdwmjDSn1NNdMUXMUGzrNlxb+PmRnwO3SlDl7ECE2TEj8SSQCVvC1zgeSluXBB2sK8SHPxU5VLUcCcAoMUAYjww/YYhqowBhINH4xi+cC9zJaOZxU8Oq/jrGCzO0o1Kxr1HMKv4C3tyc6/4ck=
-    azure_kv: []
-    hc_vault: []
-    age: []
-    lastmodified: "2025-09-05T13:06:45Z"
-    mac: ENC[AES256_GCM,data:I4FWGsOWyKxrI4ud+Ul5b8MR2qCOGeK0HyOtRnxpdC6cc2g7qa9o0ZNi70Uz+1LtigCfFgRKyJkU1lry7AFyPJsT9IEDo4mt/4+taSkoo7T1aFakwnN5GLDeD3j0ktKvlFXPt5/RoWGczTfgZ0U+q8IsjBF1gPPA2BgJ5+kP1S4=,iv:flzhyYQLxi/5vFPXywtE0ENHM67oWehJglMWHnvIclE=,tag:JXkLiXB8p/NHbj/UBqW69A==,type:str]
-    pgp: []
+          created_at: "2026-02-10T14:31:14Z"
+          enc: CiQAdmEdwsIlJneQ2fXL155ChSwlJWjSsbXJPov0rLvZ67BYKaISSQDNZIk6KsWXDUNAXjyc2C/5rNbt67SyOZRv+8m0bkmtWcHAkq7Qe2CdsqquG2FG5Mc0XPVvt7wmhb1N51XpxaGykrD79QbhWR4=
+    lastmodified: "2026-02-10T14:31:14Z"
+    mac: ENC[AES256_GCM,data:/pYcG5z75ME8I68UVj1whiJAHRTp/VOAoAa0elRQiPJCP93LvAFeNhekN4T23pdyiscL88prwVNjzS8dMvAPSTSxF0T/H2di7BYqDawAEKV4C42cup74wB1Gxl8QeUpTwmYIlOSq/13kuSF+mEruPrTvvnSddiwkYrGyUciEPJo=,iv:R2u0T3Nrsqbuin5HE9xkk9mlOXCOJEo6NVmvuftv2o0=,tag:IeX6GSZ+hF7n36fEilmFfw==,type:str]
     encrypted_suffix: _sops
-    version: 3.9.0
+    version: 3.10.2

--- a/source-shopify-native/source_shopify_native/__init__.py
+++ b/source-shopify-native/source_shopify_native/__init__.py
@@ -1,9 +1,5 @@
-from logging import Logger
-from typing import Callable, Awaitable
+from typing import Awaitable, Callable
 
-from estuary_cdk.flow import (
-    ConnectorSpec,
-)
 from estuary_cdk.capture import (
     BaseCaptureConnector,
     Request,
@@ -13,13 +9,113 @@ from estuary_cdk.capture import (
     response,
 )
 from estuary_cdk.capture.common import ResourceConfig
+from estuary_cdk.flow import (
+    ConnectorSpec,
+    ValidationError,
+)
+from estuary_cdk.logger import FlowLogger
 
-from .resources import all_resources, validate_credentials
 from .models import (
     ConnectorState,
     EndpointConfig,
-    OAUTH2_SPEC,
 )
+from .resources import all_resources, validate_credentials
+
+
+def _validate_config(
+    validate_req: request.Validate[EndpointConfig, ResourceConfig],
+) -> None:
+    """Validate config constraints around composite keys and multi-store.
+
+    1. Block multi-store when composite keys are disabled (legacy captures).
+    2. Require re-discovery when the composite key flag is toggled so the
+       catalog reflects the new key structure.
+    3. When composite keys are being enabled, require dataflow reset for all
+       bindings that still have non-composite keys.
+    """
+    config = validate_req.config
+
+    # Legacy captures can't add stores without enabling composite keys.
+    if not config.advanced.should_use_composite_key and len(config.stores) > 1:
+        raise ValidationError(
+            [
+                "Adding multiple stores to a capture requires enabling composite keys. "
+                "Set advanced.should_use_composite_key to true and backfill all enabled "
+                "bindings with a dataflow reset to change collection keys to include "
+                "the store identifier (/_meta/store)."
+            ]
+        )
+
+    if validate_req.lastCapture is None:
+        return
+
+    # Extract the previous composite key flag directly from the raw config
+    # dict rather than parsing a full EndpointConfig. The previous config may
+    # contain SOPS-encrypted credential fields (e.g. client_id_sops) that
+    # would fail strict model validation.
+    prev_raw = validate_req.lastCapture.config.config
+    if isinstance(prev_raw, dict) and "stores" not in prev_raw and "store" in prev_raw:
+        # Legacy flat config predates composite keys.
+        prev_use_composite_key = False
+    else:
+        prev_advanced = prev_raw.get("advanced", {}) if isinstance(prev_raw, dict) else {}
+        prev_use_composite_key = prev_advanced.get("should_use_composite_key", True) if isinstance(prev_advanced, dict) else True
+
+    # Detect whether the composite key flag was toggled since the last capture.
+    flag_toggled = (
+        config.advanced.should_use_composite_key
+        != prev_use_composite_key
+    )
+
+    # Toggling the flag changes collection keys, so the user must re-discover
+    # to update the catalog before validation can proceed. Skip this check if
+    # the current bindings already reflect the expected key structure, meaning
+    # the user has already re-discovered after toggling.
+    if flag_toggled:
+        if config.advanced.should_use_composite_key:
+            already_discovered = all(
+                "/_meta/store" in b.collection.key for b in validate_req.bindings
+            )
+        else:
+            already_discovered = all(
+                "/_meta/store" not in b.collection.key for b in validate_req.bindings
+            )
+
+        if not already_discovered:
+            current = "enabled" if config.advanced.should_use_composite_key else "disabled"
+            raise ValidationError(
+                [
+                    f"Composite keys have been {current}. "
+                    "Please click 'Discover' to update the catalog with the new "
+                    "collection key structure before publishing."
+                ]
+            )
+
+    # When composite keys are enabled, verify existing non-composite bindings
+    # have been backfilled (dataflow reset) so the key transition is safe.
+    if config.advanced.should_use_composite_key:
+        prev_bindings = {
+            b.resourceConfig.name: b for b in validate_req.lastCapture.bindings
+        }
+        if any("/_meta/store" not in b.collection.key for b in prev_bindings.values()):
+            needs_backfill: list[str] = []
+            for binding in validate_req.bindings:
+                prev = prev_bindings.get(binding.resourceConfig.name)
+                if prev is None:
+                    continue
+                if "/_meta/store" in prev.collection.key:
+                    continue  # Already composite
+                if binding.backfill > prev.backfill:
+                    continue  # Backfill acknowledged
+                needs_backfill.append(binding.resourceConfig.name)
+            if needs_backfill:
+                raise ValidationError(
+                    [
+                        "Enabling composite keys requires a dataflow reset to change "
+                        "collection keys from [/id] to [/_meta/store, /id]. "
+                        f"Please increment the backfill counter for: {', '.join(needs_backfill)}"
+                    ]
+                )
 
 
 class Connector(
@@ -28,36 +124,49 @@ class Connector(
     def request_class(self):
         return Request[EndpointConfig, ResourceConfig, ConnectorState]
 
-    async def spec(self, log: Logger, _: request.Spec) -> ConnectorSpec:
+    async def spec(self, log: FlowLogger, _: request.Spec) -> ConnectorSpec:
         return ConnectorSpec(
             configSchema=EndpointConfig.model_json_schema(),
-            oauth2=OAUTH2_SPEC,
+            oauth2=None,
             documentationUrl="https://go.estuary.dev/source-shopify-native",
             resourceConfigSchema=ResourceConfig.model_json_schema(),
             resourcePathPointers=ResourceConfig.PATH_POINTERS,
         )
 
     async def discover(
-        self, log: Logger, discover: request.Discover[EndpointConfig]
+        self, log: FlowLogger, discover: request.Discover[EndpointConfig]
     ) -> response.Discovered[ResourceConfig]:
         resources = await all_resources(log, self, discover.config)
         return common.discovered(resources)
 
     async def validate(
         self,
-        log: Logger,
+        log: FlowLogger,
         validate: request.Validate[EndpointConfig, ResourceConfig],
     ) -> response.Validated:
         await validate_credentials(log, self, validate.config)
+        _validate_config(validate)
+
         resources = await all_resources(log, self, validate.config)
         resolved = common.resolve_bindings(validate.bindings, resources)
         return common.validated(resolved)
 
     async def open(
         self,
-        log: Logger,
+        log: FlowLogger,
         open: request.Open[EndpointConfig, ResourceConfig, ConnectorState],
     ) -> tuple[response.Opened, Callable[[Task], Awaitable[None]]]:
-        resources = await all_resources(log, self, open.capture.config, should_cancel_ongoing_job=True)
+        config = open.capture.config
+
+        if config._was_migrated:
+            encrypted_config = await self._encrypt_config(log, config)
+            log.event.config_update(
+                "Migrating legacy single-store config to multi-store format.",
+                encrypted_config,
+            )
+
+        resources = await all_resources(
+            log, self, config, should_cancel_ongoing_job=True
+        )
         resolved = common.resolve_bindings(open.capture.bindings, resources)
         return common.open(open, resolved)

--- a/source-shopify-native/source_shopify_native/graphql/__init__.py
+++ b/source-shopify-native/source_shopify_native/graphql/__init__.py
@@ -1,5 +1,3 @@
-from . import bulk_job_manager
-
 from .abandoned_checkouts import AbandonedCheckouts
 from .client import ShopifyGraphQLClient
 from .collections.collections import CustomCollections, SmartCollections
@@ -32,7 +30,6 @@ from .subscriptions.subscription_contracts import SubscriptionContracts
 __all__ = [
     "AbandonedCheckouts",
     "ShopifyGraphQLClient",
-    "bulk_job_manager",
     "CustomCollections",
     "SmartCollections",
     "CustomCollectionMetafields",

--- a/source-shopify-native/source_shopify_native/graphql/bulk_job_manager.py
+++ b/source-shopify-native/source_shopify_native/graphql/bulk_job_manager.py
@@ -1,4 +1,5 @@
 import asyncio
+import time
 from logging import Logger
 from typing import Any
 
@@ -23,6 +24,7 @@ BULK_QUERY_ALREADY_EXISTS_ERROR = (
 INITIAL_SLEEP = 1
 MAX_SLEEP = 2
 SIX_HOURS = 6 * 60 * 60
+CANCEL_TIMEOUT = 5 * 60  # 5 minutes
 MAX_CONCURRENT_BULK_OPS = 5
 
 
@@ -61,7 +63,10 @@ class BulkJobManager:
         self.log = log
         self.semaphore = asyncio.Semaphore(MAX_CONCURRENT_BULK_OPS)
 
-    # Cancel all running bulk query jobs
+    async def check_connectivity(self) -> None:
+        """Verify that the store's credentials are valid by issuing a lightweight API call."""
+        await self._get_running_jobs()
+
     async def cancel_current(self):
         running_jobs = await self._get_running_jobs()
 
@@ -72,19 +77,26 @@ class BulkJobManager:
         job_statuses: dict[str, BulkOperationStatuses] = {}
         for job_details in running_jobs:
             job_id = job_details.id
-            self.log.info(f"Cancelling bulk job {job_id}.")
+            self.log.info(f"[{self.client.store}] Cancelling bulk job {job_id}.")
             status = await self._cancel(job_id)
             job_statuses[job_id] = status
 
         # Then, wait for all jobs to finish cancelling
         for job_id, status in job_statuses.items():
+            deadline = time.monotonic() + CANCEL_TIMEOUT
             while True:
                 match status:
                     case BulkOperationStatuses.CANCELED | BulkOperationStatuses.COMPLETED:
-                        self.log.info(f"Bulk job {job_id} is {status}.")
+                        self.log.info(f"[{self.client.store}] Bulk job {job_id} is {status}.")
                         break
                     case BulkOperationStatuses.CANCELING:
-                        self.log.info(f"Waiting for bulk job {job_id} to be CANCELED.")
+                        if time.monotonic() >= deadline:
+                            self.log.warning(
+                                f"[{self.client.store}] Timed out waiting for bulk job {job_id} to cancel "
+                                f"after {CANCEL_TIMEOUT}s. Will retry on next startup."
+                            )
+                            break
+                        self.log.info(f"[{self.client.store}] Waiting for bulk job {job_id} to be CANCELED.")
                         await asyncio.sleep(5)
 
                         details = await self._get_job(job_id)
@@ -170,7 +182,7 @@ class BulkJobManager:
             }}
         """
 
-        self.log.debug(f"Trying to cancel job {job_id}.")
+        self.log.debug(f"[{self.client.store}] Trying to cancel job {job_id}.")
 
         data = await self.client.request(
             query,
@@ -182,12 +194,12 @@ class BulkJobManager:
 
         match status:
             case BulkOperationStatuses.CANCELED:
-                self.log.debug(f"Bulk job {job_id} has been cancelled.")
+                self.log.debug(f"[{self.client.store}] Bulk job {job_id} has been cancelled.")
             case BulkOperationStatuses.CANCELING:
-                self.log.debug(f"Bulk job {job_id} is being cancelled.")
+                self.log.debug(f"[{self.client.store}] Bulk job {job_id} is being cancelled.")
             case _:
                 self.log.debug(
-                    f"Could not cancel bulk job {job_id}.",
+                    f"[{self.client.store}] Could not cancel bulk job {job_id}.",
                     {
                         "status": status,
                         "errors": data.bulkOperationCancel.userErrors,
@@ -211,7 +223,7 @@ class BulkJobManager:
                 details = await self._get_job(job_id)
                 match details.status:
                     case BulkOperationStatuses.COMPLETED:
-                        self.log.info(f"Job {job_id} has completed.", {
+                        self.log.info(f"[{self.client.store}] Job {job_id} has completed.", {
                             "stream": model.NAME,
                             "details": details,
                         })
@@ -219,7 +231,7 @@ class BulkJobManager:
                     case BulkOperationStatuses.CREATED | BulkOperationStatuses.RUNNING:
                         if not is_running:
                             self.log.info(
-                                f"Job {job_id} is {details.status}. Sleeping to await job completion.", {
+                                f"[{self.client.store}] Job {job_id} is {details.status}. Sleeping to await job completion.", {
                                     "stream": model.NAME,
                                 }
                             )
@@ -230,7 +242,7 @@ class BulkJobManager:
 
                         if total_sleep > SIX_HOURS:
                             self.log.warning(
-                                f"Shopify has been working on job {job_id} for over {SIX_HOURS / (60 * 60)} hours. "
+                                f"[{self.client.store}] Shopify has been working on job {job_id} for over {SIX_HOURS / (60 * 60)} hours. "
                                 "This is likely due to a large amount of data being processed within the job. "
                                 "Consider reducing how much data is processed in a single job by reducing the advanced date window setting in the config.", {
                                     "stream": model.NAME,
@@ -309,7 +321,7 @@ class BulkJobManager:
             if is_ongoing_query_conflict:
                 msg = (
                     "Another application is submitting bulk query operations to Shopify's API, preventing"
-                    " this connector from extracting data. Please prevent prevent the other application from"
+                    " this connector from extracting data. Please prevent the other application from"
                     " submitting bulk query operations to Shopify."
                 )
                 raise BulkJobError(
@@ -319,7 +331,7 @@ class BulkJobManager:
             else:
                 errors = [error.message for error in errors]
                 for error in errors:
-                    self.log.warning(error)
+                    self.log.warning(f"[{self.client.store}] {error}")
 
                 raise BulkJobError(
                     message="Errors when submitting query.",

--- a/source-shopify-native/source_shopify_native/graphql/common.py
+++ b/source-shopify-native/source_shopify_native/graphql/common.py
@@ -1,15 +1,4 @@
-from datetime import datetime, timedelta
-
-DATETIME_STRING_FORMAT = "%Y-%m-%dT%H:%M:%SZ"
 VERSION = "2026-01"
-
-
-def dt_to_str(dt: datetime) -> str:
-    return dt.strftime(DATETIME_STRING_FORMAT)
-
-
-def str_to_dt(dt_str: str) -> datetime:
-    return datetime.fromisoformat(dt_str.replace('Z', '+00:00'))
 
 
 money_bag_fragment = """

--- a/source-shopify-native/source_shopify_native/models.py
+++ b/source-shopify-native/source_shopify_native/models.py
@@ -1,32 +1,39 @@
 import json
+from collections import Counter
+from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from enum import StrEnum
 from logging import Logger
 from typing import (
-    TYPE_CHECKING,
     Annotated,
     Any,
     AsyncGenerator,
     ClassVar,
     Generic,
-    TypeVar,
     Literal,
+    TypeVar,
 )
 
-from estuary_cdk.flow import (
-    AccessToken,
-    ClientCredentialsOAuth2Credentials,
-    LongLivedClientCredentialsOAuth2Credentials,
-    OAuth2Spec,
-)
 from estuary_cdk.capture.common import (
     BaseDocument,
     ResourceState,
+)
+from estuary_cdk.capture.common import (
     ConnectorState as GenericConnectorState,
 )
-from pydantic import AwareDatetime, BaseModel, Field, ConfigDict
+from estuary_cdk.flow import AccessToken, ClientCredentialsOAuth2Credentials
+from pydantic import (
+    AwareDatetime,
+    BaseModel,
+    ConfigDict,
+    Field,
+    PrivateAttr,
+    ValidationInfo,
+    ValidatorFunctionWrapHandler,
+    model_validator,
+)
 
-from .graphql.common import dt_to_str, str_to_dt
+from .utils import dt_to_str, str_to_dt
 
 # OAuth scopes requested during authorization.
 # These are verified against Shopify's GraphQL Admin API 2025-04 documentation.
@@ -47,40 +54,10 @@ scopes = [
     "read_marketplace_fulfillment_orders",
 ]
 
-OAUTH2_SPEC = OAuth2Spec(
-    provider="shopify",
-    authUrlTemplate=(
-        r"https://{{{ config.store }}}.myshopify.com/admin/oauth/authorize"
-        r"?client_id={{{#urlencode}}}{{{ client_id }}}{{{/urlencode}}}"
-        "&scope="
-        + ",".join(scopes)
-        + r"&state={{{#urlencode}}}{{{ state }}}{{{/urlencode}}}"
-        r"&redirect_uri={{{#urlencode}}}{{{ redirect_uri }}}{{{/urlencode}}}"
-    ),
-    accessTokenUrlTemplate=(
-        r"https://{{{ config.store }}}.myshopify.com/admin/oauth/access_token"
-        r"?client_id={{{#urlencode}}}{{{ client_id }}}{{{/urlencode}}}"
-        r"&client_secret={{{#urlencode}}}{{{ client_secret }}}{{{/urlencode}}}"
-        r"&code={{{#urlencode}}}{{{ code }}}{{{/urlencode}}}"
-    ),
-    accessTokenHeaders={"content-type": "application/x-www-form-urlencoded"},
-    accessTokenBody=(
-        r"client_id={{{#urlencode}}}{{{ client_id }}}{{{/urlencode}}}"
-        r"&client_secret={{{#urlencode}}}{{{ client_secret }}}{{{/urlencode}}}"
-        r"&code={{{#urlencode}}}{{{ code }}}{{{/urlencode}}}"
-    ),
-    accessTokenResponseMap={
-        "access_token": "/access_token",
-    },
-)
+# TODO(justin): OAuth support is temporarily removed for multi-store. Will revisit once the
+# OAuth app is approved and UI/runtime is ready to support OAuth inside array items with credentials.
+# See git history for the previous OAUTH2_SPEC implementation.
 
-
-if TYPE_CHECKING:
-    OAuth2Credentials = LongLivedClientCredentialsOAuth2Credentials
-else:
-    OAuth2Credentials = LongLivedClientCredentialsOAuth2Credentials.for_provider(
-        OAUTH2_SPEC.provider
-    )
 
 class ShopifyClientCredentials(ClientCredentialsOAuth2Credentials):
     """Credentials for the Shopify client_credentials grant flow.
@@ -96,6 +73,7 @@ class ShopifyClientCredentials(ClientCredentialsOAuth2Credentials):
     References:
         https://shopify.dev/docs/apps/build/authentication-authorization/access-tokens/client-credentials-grant
     """
+
     # This configuration provides a "title" annotation for the UI to display
     # instead of the class name.
     model_config = ConfigDict(
@@ -108,20 +86,31 @@ class ShopifyClientCredentials(ClientCredentialsOAuth2Credentials):
     )
 
 
-def default_start_date():
-    dt = datetime.now(tz=UTC) - timedelta(days=30)
-    return dt
+def default_start_date() -> datetime:
+    return datetime.now(tz=UTC) - timedelta(days=30)
 
 
-class EndpointConfig(BaseModel):
+class StoreConfig(BaseModel):
+    """Configuration for a single Shopify store."""
+
     store: str = Field(
-        title="Shopify Store",
-        description="Shopify store ID. Use the prefix of your admin URL e.g. https://{YOUR_STORE}.myshopify.com/admin",
+        title="Store Name",
+        description="Shopify store name (the prefix of your admin URL, e.g., 'mystore' for mystore.myshopify.com)",
+        min_length=1,
     )
-    credentials: ShopifyClientCredentials | AccessToken | OAuth2Credentials = Field(
+    credentials: ShopifyClientCredentials | AccessToken = Field(
         discriminator="credentials_title",
         title="Authentication",
     )
+
+
+class EndpointConfig(BaseModel):
+    stores: list[StoreConfig] = Field(
+        title="Shopify Stores",
+        description="One or more Shopify stores to capture. Each store requires its own credentials.",
+        min_length=1,
+    )
+
     start_date: AwareDatetime = Field(
         description="UTC date and time in the format YYYY-MM-DDTHH:MM:SSZ. Any data generated before this date will not be replicated. If left blank, the start date will be set to 30 days before the present.",
         title="Start Date",
@@ -138,6 +127,17 @@ class EndpointConfig(BaseModel):
                 ge=timedelta(minutes=1),
             ),
         ]
+        should_use_composite_key: bool = Field(
+            default=False,
+            title="Use Composite Key",
+            description=(
+                "Controls whether collection keys include the store identifier (/_meta/store). "
+                "Enabled by default for new captures. Automatically set to false for legacy "
+                "single-store captures during migration. Must be set to true (with a full "
+                "backfill / dataflow reset of all bindings) before adding additional stores "
+                "to a legacy capture."
+            ),
+        )
 
     advanced: Advanced = Field(
         default_factory=Advanced,  # type: ignore
@@ -145,6 +145,48 @@ class EndpointConfig(BaseModel):
         description="Advanced settings for the connector.",
         json_schema_extra={"advanced": True},
     )
+
+    _was_migrated: bool = PrivateAttr(default=False)
+    _legacy_store: str | None = PrivateAttr(default=None)
+
+    @model_validator(mode="wrap")
+    @classmethod
+    def transform_legacy_config(
+        cls,
+        data: Any,
+        handler: ValidatorFunctionWrapHandler,
+    ) -> "EndpointConfig":
+        was_migrated = False
+        legacy_store: str | None = None
+
+        if isinstance(data, dict):
+            # Migrate flat config to stores list
+            if "stores" not in data and "store" in data and "credentials" in data:
+                data = data.copy()
+                legacy_store = data.pop("store")
+                credentials = data.pop("credentials")
+                data["stores"] = [{"store": legacy_store, "credentials": credentials}]
+                advanced = data.get("advanced", {})
+                if isinstance(advanced, dict):
+                    advanced["should_use_composite_key"] = False
+                    data["advanced"] = advanced
+                was_migrated = True
+
+        instance = handler(data)
+        instance._was_migrated = was_migrated
+        instance._legacy_store = legacy_store
+
+        return instance
+
+    @model_validator(mode="after")
+    def validate_unique_store_names(self) -> "EndpointConfig":
+        counts = Counter(s.store for s in self.stores)
+        duplicates = [name for name, count in counts.items() if count > 1]
+        if duplicates:
+            raise ValueError(
+                f"Duplicate store names are not allowed: {', '.join(duplicates)}"
+            )
+        return self
 
 
 ConnectorState = GenericConnectorState[ResourceState]
@@ -359,7 +401,14 @@ class SortKey(StrEnum):
     UPDATED_AT = "UPDATED_AT"
 
 
-class ShopifyGraphQLResource(BaseDocument, extra="allow"):
+@dataclass(frozen=True, slots=True)
+class StoreValidationContext:
+    """Validation context carrying the store name for document construction."""
+
+    store: str
+
+
+class ShopifyGraphQLResource(BaseDocument):
     QUERY: ClassVar[str] = ""
     QUERY_ROOT: ClassVar[str] = ""
     FRAGMENTS: ClassVar[list[str]] = []
@@ -367,6 +416,39 @@ class ShopifyGraphQLResource(BaseDocument, extra="allow"):
     SORT_KEY: ClassVar[SortKey | None] = None
     SHOULD_USE_BULK_QUERIES: ClassVar[bool] = True
     QUALIFYING_SCOPES: ClassVar[set[str]] = set()
+
+    model_config = ConfigDict(extra="allow", validate_assignment=True)
+
+    class Meta(BaseDocument.Meta):
+        model_config = ConfigDict(validate_assignment=True)
+
+        store: str = Field(
+            default="",
+            description="The Shopify store this document belongs to",
+        )
+
+    meta_: Meta = Field(  # type: ignore[override]
+        default_factory=lambda: ShopifyGraphQLResource.Meta(op="u"),
+        alias="_meta",
+        description="Document metadata",
+    )
+
+    @model_validator(mode="before")
+    @classmethod
+    def _inject_store_from_context(cls, data: Any, info: ValidationInfo) -> Any:
+        """Inject store name from validation context into document metadata.
+
+        Uses mode="before" so the store is set on the raw dict before Pydantic constructs
+        the model. Combined with validate_assignment=True on Meta, this ensures the store
+        field is tracked in model_fields_set and survives model_dump(exclude_unset=True).
+        """
+        if not isinstance(data, dict):
+            return data
+        if info.context and isinstance(info.context, StoreValidationContext):
+            meta = data.get("_meta") or {}
+            meta["store"] = info.context.store
+            data["_meta"] = meta
+        return data
 
     id: str
 
@@ -441,10 +523,12 @@ class ShopifyGraphQLResource(BaseDocument, extra="allow"):
         query = f"""
         {{
             {cls.QUERY_ROOT}(
-                query: "updated_at:>='{lower_bound}' AND updated_at:<='{upper_bound}' {"AND " + query.strip() if query else ""}"
+                query: "updated_at:>='{lower_bound}' AND updated_at:<='{upper_bound}' {
+            "AND " + query.strip() if query else ""
+        }"
                 {f"sortKey: {cls.SORT_KEY}" if cls.SORT_KEY else ""}
                 {f"first: {first}" if first else ""}
-                {f"after: \"{after}\"" if after else ""}
+                {f'after: "{after}"' if after else ""}
             ) {{
                 edges {{
                     node {{
@@ -455,10 +539,14 @@ class ShopifyGraphQLResource(BaseDocument, extra="allow"):
                         {cls.QUERY}
                     }}
                 }}
-                {f"""pageInfo {{
+                {
+            f'''pageInfo {{
                     hasNextPage
                     endCursor
-                }}""" if first else ""}
+                }}'''
+            if first
+            else ""
+        }
             }}
         }}
         """
@@ -520,6 +608,8 @@ def create_response_data_model(
         "page_info": property(get_page_info),
     }
 
-    DataModel = type(f"{query_root.title()}Data", (BaseResponseData[resource_type],), class_dict)
+    DataModel = type(
+        f"{query_root.title()}Data", (BaseResponseData[resource_type],), class_dict
+    )
 
     return DataModel

--- a/source-shopify-native/source_shopify_native/resources.py
+++ b/source-shopify-native/source_shopify_native/resources.py
@@ -1,4 +1,7 @@
+import asyncio
 import functools
+from copy import deepcopy
+from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from logging import Logger
 
@@ -10,13 +13,16 @@ from estuary_cdk.capture.common import (
     open_binding,
 )
 from estuary_cdk.flow import (
+    AccessToken,
     CaptureBinding,
     OAuth2TokenFlowSpec,
     ValidationError,
 )
-from estuary_cdk.http import HTTPError, HTTPMixin, TokenSource
+from estuary_cdk.http import HTTPError, HTTPMixin, RateLimiter, TokenSource
+from pydantic import AwareDatetime
 
 import source_shopify_native.graphql as gql
+from .graphql.bulk_job_manager import BulkJobManager
 
 from .api import (
     backfill_incremental,
@@ -24,20 +30,104 @@ from .api import (
     fetch_incremental,
     fetch_incremental_unsorted,
 )
-from .graphql.common import dt_to_str
+from .utils import dt_to_str
 from .models import (
-    OAUTH2_SPEC,
     AccessScopes,
-    AccessToken,
+    ConnectorState,
     EndpointConfig,
     PlanName,
     ShopDetails,
     ShopifyClientCredentials,
     ShopifyGraphQLResource,
+    StoreConfig,
     create_response_data_model,
 )
 
+
+class StoreInitError(Exception):
+    """Raised when one or more stores fail to initialize.
+
+    Current behavior is fail-fast: any single store failure blocks the entire capture.
+    This surfaces configuration errors clearly rather than silently skipping a store.
+    TODO: Consider graceful degradation — continue with healthy stores and surface
+    errors for failed ones without blocking the entire capture.
+    """
+
+    def __init__(
+        self, failed_stores: dict[str, BaseException], initialized_stores: list[str]
+    ):
+        self.failed_stores = failed_stores
+        self.initialized_stores = initialized_stores
+        store_errors = "\n".join(
+            f"  - {store}: {error}" for store, error in failed_stores.items()
+        )
+        super().__init__(
+            f"Failed to initialize {len(failed_stores)} store(s):\n{store_errors}"
+        )
+
+
+class StoreHTTP(HTTPMixin):
+    """Per-store HTTP wrapper that shares a parent session with per-store auth and rate limiting.
+
+    Sets the three attributes that HTTPMixin's methods depend on:
+    - inner: shared aiohttp.ClientSession from the parent (for connection pooling)
+    - rate_limiter: independent per-store rate limiter
+    - token_source: per-store authentication credentials
+
+    All HTTP methods (request, request_lines, etc.) are inherited via the class hierarchy.
+    """
+
+    def __init__(self, http: HTTPMixin, token_source: TokenSource):
+        # super().__init__() is intentionally not called. HTTPMixin is a pure
+        # attribute-based mixin whose initialization happens via _mixin_enter()
+        # context manager hooks (estuary_cdk/http.py:481), not constructors.
+        # We directly set the three attributes that HTTPMixin's methods depend on.
+        self.inner = http.inner
+        self.rate_limiter = RateLimiter()
+        self.token_source = token_source
+
+
+@dataclass(frozen=True, slots=True)
+class StoreContext:
+    """Context for a single Shopify store containing HTTP client, GraphQL client, and available resources."""
+
+    http: StoreHTTP
+    client: gql.ShopifyGraphQLClient
+    bulk_job_manager: BulkJobManager
+    scopes: set[str]
+    available_resources: set[type[ShopifyGraphQLResource]]
+
+
 AUTHORIZATION_HEADER = "X-Shopify-Access-Token"
+
+
+def _build_token_source(store_config: StoreConfig) -> TokenSource:
+    """Construct the appropriate TokenSource based on the credential type.
+
+    Each store gets its own independent TokenSource to avoid race conditions.
+
+    - AccessToken (legacy shpat_* tokens): Static token, no OAuth flow needed.
+    - ShopifyClientCredentials: Uses the CDK's built-in client_credentials
+      OAuth2 flow with a store-specific token endpoint URL. The CDK handles
+      token exchange, caching, and refresh automatically.
+    """
+    if isinstance(store_config.credentials, ShopifyClientCredentials):
+        spec = OAuth2TokenFlowSpec(
+            accessTokenUrlTemplate=f"https://{store_config.store}.myshopify.com/admin/oauth/access_token",
+            accessTokenResponseMap={"access_token": "/access_token"},
+        )
+        return TokenSource(
+            oauth_spec=spec,
+            credentials=store_config.credentials,
+            authorization_header=AUTHORIZATION_HEADER,
+        )
+    else:  # AccessToken
+        return TokenSource(
+            oauth_spec=None,
+            credentials=store_config.credentials,
+            authorization_header=AUTHORIZATION_HEADER,
+        )
+
 
 INCREMENTAL_RESOURCES: list[type[ShopifyGraphQLResource]] = [
     gql.AbandonedCheckouts,
@@ -67,81 +157,211 @@ INCREMENTAL_RESOURCES: list[type[ShopifyGraphQLResource]] = [
     gql.SubscriptionContracts,
 ]
 
-
-PII_RESOURCES: list[type[ShopifyGraphQLResource]] = [
+PII_RESOURCES: set[type[ShopifyGraphQLResource]] = {
     gql.Customers,
     gql.Orders,
     gql.FulfillmentOrders,
-]
+}
 
 
-def _build_token_source(config: EndpointConfig) -> TokenSource:
-    """Construct the appropriate TokenSource based on the credential type.
-
-    - AccessToken (legacy shpat_* tokens): Uses the CDK's default TokenSource
-      with the static token and X-Shopify-Access-Token header.
-    - ShopifyClientCredentials: Uses the CDK's built-in client_credentials
-      OAuth2 flow with a store-specific token endpoint URL. The CDK handles
-      token exchange, caching, and refresh automatically.
-    - OAuth2Credentials: Uses the CDK's default TokenSource with the OAuth2 spec
-      and the long-lived access token obtained during the OAuth2 flow.
-    """
-    if isinstance(config.credentials, ShopifyClientCredentials):
-        # Build a store-specific OAuth2TokenFlowSpec at runtime since
-        # the token endpoint URL depends on the store name and the CDK
-        # uses this URL as a literal string (not a Mustache template).
-        spec = OAuth2TokenFlowSpec(
-            accessTokenUrlTemplate=f"https://{config.store}.myshopify.com/admin/oauth/access_token",
-            accessTokenResponseMap={"access_token": "/access_token"},
-        )
-        return TokenSource(
-            oauth_spec=spec,
-            credentials=config.credentials,
-            authorization_header=AUTHORIZATION_HEADER,
-        )
-    else:
-        return TokenSource(
-            oauth_spec=OAUTH2_SPEC,
-            credentials=config.credentials,
-            authorization_header=AUTHORIZATION_HEADER,
-        )
-
-
-async def _can_access_pii(
-    http: HTTPMixin,
-    url: str,
+async def _create_store_context(
     log: Logger,
-) -> bool:
-    response = ShopDetails.model_validate_json(
-        await http.request(
-            log, url, method="POST", json={"query": ShopDetails.query()}
-        )
+    http: HTTPMixin,
+    store_config: StoreConfig,
+    should_cancel_ongoing_job: bool,
+) -> StoreContext:
+    """Create context for a single store."""
+    token_source = _build_token_source(store_config)
+    store_http = StoreHTTP(http, token_source)
+    client = gql.ShopifyGraphQLClient(store_http, store_config.store)
+    bulk_job_manager = BulkJobManager(client, log)
+
+    if should_cancel_ongoing_job:
+        await bulk_job_manager.cancel_current()
+
+    granted_scopes = await _get_granted_scopes(store_http, client.url, log)
+
+    # Both AccessToken and ShopifyClientCredentials are custom app tokens
+    # subject to plan restrictions on PII access.
+    uses_custom_app_token = isinstance(
+        store_config.credentials, (AccessToken, ShopifyClientCredentials)
+    )
+    can_access_pii = True
+    if uses_custom_app_token:
+        can_access_pii = await _check_plan_allows_pii(store_http, client.url, log)
+
+    available_resources = _get_available_resources(
+        granted_scopes, uses_custom_app_token, can_access_pii
     )
 
+    store_context = StoreContext(
+        http=store_http,
+        client=client,
+        bulk_job_manager=bulk_job_manager,
+        scopes=granted_scopes,
+        available_resources=available_resources,
+    )
+
+    return store_context
+
+
+def _get_available_resources(
+    granted_scopes: set[str],
+    uses_custom_app_token: bool,
+    can_access_pii: bool,
+) -> set[type[ShopifyGraphQLResource]]:
+    """Determine which resources are available based on scopes and plan."""
+    available: set[type[ShopifyGraphQLResource]] = set()
+
+    for resource in INCREMENTAL_RESOURCES:
+        # Skip if none of the qualifying scopes are granted
+        if resource.QUALIFYING_SCOPES.isdisjoint(granted_scopes):
+            continue
+        # Skip PII resources for custom app tokens when plan doesn't allow PII
+        if uses_custom_app_token and resource in PII_RESOURCES and not can_access_pii:
+            continue
+        available.add(resource)
+
+    return available
+
+
+def _create_initial_state(
+    store_ids: list[str],
+    start_date: AwareDatetime,
+    use_backfill: bool,
+) -> ResourceState:
+    """Create initial state for a resource.
+
+    State format is always dictionary-based: {"inc": {"store_id": {"cursor": "..."}}}
+
+    This ensures consistency across all captures (new and legacy) and allows
+    seamless addition of stores without requiring backfill when only state format changes.
+
+    Args:
+        store_ids: List of store IDs to create state for.
+        start_date: The start date for data replication.
+        use_backfill: Whether to create backfill state (for non-bulk queries with SORT_KEY).
+    """
+    cutoff = datetime.now(tz=UTC)
+
+    if use_backfill:
+        return ResourceState(
+            inc={sid: ResourceState.Incremental(cursor=cutoff) for sid in store_ids},
+            backfill={
+                sid: ResourceState.Backfill(
+                    next_page=dt_to_str(start_date), cutoff=cutoff
+                )
+                for sid in store_ids
+            },
+        )
+    return ResourceState(
+        inc={sid: ResourceState.Incremental(cursor=start_date) for sid in store_ids},
+    )
+
+
+def _migrate_flat_to_dict_state(
+    state: ResourceState,
+    store_id: str,
+    log: Logger,
+) -> bool:
+    """Migrate legacy flat state format to dict-based format.
+
+    Converts:
+    - Flat: {"inc": {"cursor": "..."}, "backfill": {...}}
+    - Dict: {"inc": {"store_id": {"cursor": "..."}}, "backfill": {"store_id": {...}}}
+
+    Args:
+        state: The resource state to migrate (modified in place).
+        store_id: The store ID to use as the key for migrated state.
+        log: Logger for info messages.
+
+    Returns:
+        True if migration was performed, False if state was already dict-based.
+    """
+    if not isinstance(state.inc, ResourceState.Incremental):
+        return False  # Already dict-based or None
+
+    log.info(f"Migrating from flat to dict state using store: {store_id}")
+
+    # Convert incremental state to dict format
+    state.inc = {store_id: state.inc, "cursor": None}
+
+    # Convert backfill state
+    if isinstance(state.backfill, ResourceState.Backfill):
+        state.backfill = {store_id: state.backfill, "cutoff": None, "next_page": None}
+    elif state.backfill is None:
+        # Completed backfill in flat mode → represent as dict with None entry
+        state.backfill = {store_id: None}
+
+    return True
+
+
+async def _reconcile_connector_state(
+    store_ids: list[str],
+    binding: CaptureBinding[ResourceConfig],
+    state: ResourceState,
+    initial_state: ResourceState,
+    task: Task,
+    legacy_store_id: str,
+) -> None:
+    """Reconcile connector state: migrate format if needed and add missing stores.
+
+    This handles two scenarios:
+    1. Migration from flat to dict-based state (legacy single-store captures)
+    2. Adding missing store entries for newly configured stores
+    """
+    # Step 1: Migrate flat state to dict-based if needed.
+    migrated = _migrate_flat_to_dict_state(state, legacy_store_id, task.log)
+
+    # Step 2: Add missing store entries for newly configured stores.
+    # Not all resources use backfill (bulk query resources don't), so backfill
+    # may be None for both state and initial_state — only reconcile it when both are dicts.
+    should_checkpoint = migrated
+
+    if isinstance(state.inc, dict) and isinstance(initial_state.inc, dict):
+        for store_id in store_ids:
+            if store_id not in state.inc:
+                task.log.info(f"Initializing new subtask state for store {store_id}.")
+                state.inc[store_id] = deepcopy(initial_state.inc[store_id])
+                should_checkpoint = True
+
+    if isinstance(state.backfill, dict) and isinstance(initial_state.backfill, dict):
+        for store_id in store_ids:
+            if store_id not in state.backfill:
+                state.backfill[store_id] = deepcopy(initial_state.backfill[store_id])
+                should_checkpoint = True
+
+    if should_checkpoint:
+        task.log.info(
+            f"Checkpointing state to ensure any new state is persisted for {binding.stateKey}."
+        )
+        await task.checkpoint(ConnectorState(bindingStateV1={binding.stateKey: state}))
+
+
+async def _check_plan_allows_pii(http: HTTPMixin, url: str, log: Logger) -> bool:
+    """Check if the Shopify plan allows access to PII data."""
+    response = ShopDetails.model_validate_json(
+        await http.request(log, url, method="POST", json={"query": ShopDetails.query()})
+    )
     plan = response.data.shop.plan
 
     if plan.partnerDevelopment or plan.shopifyPlus:
         return True
 
-    match plan.displayName:
-        case PlanName.BASIC | PlanName.STARTER:
-            return False
-        case _:
-            if plan.displayName in PlanName:
-                return True
-            else:
-                log.warning(
-                    f"Shopify plan '{plan.displayName}' is not recognized. "
-                    f"Assuming access to PII is supported on the {plan.displayName} plan."
-                )
-                return True
+    if plan.displayName in (PlanName.BASIC, PlanName.STARTER):
+        return False
+
+    if plan.displayName in PlanName:
+        return True
+
+    log.warning(
+        f"Shopify plan '{plan.displayName}' is not recognized. "
+        f"Assuming PII access is supported."
+    )
+    return True
 
 
-async def _get_granted_scopes(
-    http: HTTPMixin,
-    url: str,
-    log: Logger,
-) -> set[str]:
+async def _get_granted_scopes(http: HTTPMixin, url: str, log: Logger) -> set[str]:
     """Query the currentAppInstallation to determine which scopes are granted."""
     response = AccessScopes.model_validate_json(
         await http.request(
@@ -153,136 +373,46 @@ async def _get_granted_scopes(
     return scopes
 
 
-def _incremental_resources(
+async def _validate_store(
+    log: Logger,
     http: HTTPMixin,
-    config: EndpointConfig,
-    client: gql.ShopifyGraphQLClient,
-    bulk_job_manager: gql.bulk_job_manager.BulkJobManager,
-    resource_models: list[type[ShopifyGraphQLResource]],
-    granted_scopes: set[str],
-) -> list[Resource]:
-    def open(
-        model: type[ShopifyGraphQLResource],
-        binding: CaptureBinding[ResourceConfig],
-        binding_index: int,
-        state: ResourceState,
-        task: Task,
-        _all_bindings=None,
-    ):
-        # Warn if FulfillmentOrders has partial scope coverage (data may be incomplete).
-        if model == gql.FulfillmentOrders:
-            fo_scopes = gql.FulfillmentOrders.QUALIFYING_SCOPES
-            has_partial_coverage = fo_scopes.intersection(
-                granted_scopes
-            ) and not fo_scopes.issubset(granted_scopes)
-            if has_partial_coverage:
-                missing = fo_scopes.difference(granted_scopes)
-                task.log.warning(
-                    f"FulfillmentOrders stream enabled with partial scopes. Missing: {missing}. "
-                    "Only fulfillment orders matching granted scope types will be captured."
-                )
+    store_config: StoreConfig,
+) -> str | None:
+    """Validate credentials for a single store. Returns an error message or None."""
+    token_source = _build_token_source(store_config)
+    store_http = StoreHTTP(http, token_source)
+    client = gql.ShopifyGraphQLClient(store_http, store_config.store)
+    bulk_job_manager = BulkJobManager(client, log)
 
-        data_model = create_response_data_model(model)
-
-        if model.SHOULD_USE_BULK_QUERIES:
-            open_binding(
-                binding,
-                binding_index,
-                state,
-                task,
-                fetch_changes=functools.partial(
-                    bulk_fetch_incremental,
-                    http,
-                    config.advanced.window_size,
-                    bulk_job_manager,
-                    model,
-                ),
+    try:
+        await bulk_job_manager.check_connectivity()
+    except HTTPError as err:
+        if err.code == 401:
+            return (
+                f"Store '{store_config.store}': Invalid credentials. "
+                f"Please confirm the provided credentials are correct.\n\n{err.message}"
             )
-        else:
-            # Non-bulk queries cannot be used for queries that have nested
-            # connections. Any query with "edges { node { blah } }" in it
-            # contains a nested connection.
-            if "edges" in model.QUERY.lower():
-                raise RuntimeError("Implementation error: Non-bulk queries cannot contain nested connections.")
+        return f"Store '{store_config.store}': Encountered error validating access token.\n\n{err.message}"
 
-            if model.SORT_KEY is None:
-                open_binding(
-                    binding,
-                    binding_index,
-                    state,
-                    task,
-                    fetch_changes=functools.partial(
-                        fetch_incremental_unsorted,
-                        client,
-                        model,
-                        data_model,
-                    ),
-                )
-            else:
-                open_binding(
-                    binding,
-                    binding_index,
-                    state,
-                    task,
-                    fetch_changes=functools.partial(
-                        fetch_incremental,
-                        client,
-                        model,
-                        data_model,
-                    ),
-                    fetch_page=functools.partial(
-                        backfill_incremental,
-                        client,
-                        model,
-                        data_model,
-                    ),
-                )
-
-    cutoff = datetime.now(tz=UTC)
-
-    resources: list[Resource] = []
-
-    for model in resource_models:
-        if model.SHOULD_USE_BULK_QUERIES or model.SORT_KEY is None:
-            initial_state = ResourceState(
-                inc=ResourceState.Incremental(cursor=config.start_date)
-            )
-        else:
-            initial_state = ResourceState(
-                inc=ResourceState.Incremental(cursor=cutoff),
-                backfill=ResourceState.Backfill(next_page=dt_to_str(config.start_date), cutoff=cutoff)
-            )
-
-        resources.append(
-            Resource(
-                name=model.NAME,
-                key=["/id"],
-                model=ShopifyGraphQLResource,
-                open=functools.partial(open, model),
-                initial_state=initial_state,
-                initial_config=ResourceConfig(name=model.NAME, interval=timedelta(minutes=5)),
-                schema_inference=True,
-            )
-        )
-
-    return resources
+    return None
 
 
 async def validate_credentials(log: Logger, http: HTTPMixin, config: EndpointConfig):
-    http.token_source = _build_token_source(config)
-    client = gql.ShopifyGraphQLClient(http, config.store)
-    bulk_job_manager = gql.bulk_job_manager.BulkJobManager(client, log)
+    """Validate credentials for all configured stores in parallel."""
+    results = await asyncio.gather(
+        *[_validate_store(log, http, store_config) for store_config in config.stores],
+        return_exceptions=True,
+    )
 
-    try:
-        await bulk_job_manager._get_running_jobs()
-    except HTTPError as err:
-        msg = "Unknown error occurred."
-        if err.code == 401:
-            msg = f"Invalid credentials. Please confirm the provided credentials are correct.\n\n{err.message}"
-        else:
-            msg = f"Encountered error validating access token.\n\n{err.message}"
+    errors: list[str] = []
+    for store_config, result in zip(config.stores, results):
+        if isinstance(result, BaseException):
+            raise RuntimeError(f"Store '{store_config.store}': {result}") from result
+        if result is not None:
+            errors.append(result)
 
-        raise ValidationError([msg])
+    if errors:
+        raise ValidationError(errors)
 
 
 async def all_resources(
@@ -291,46 +421,189 @@ async def all_resources(
     config: EndpointConfig,
     should_cancel_ongoing_job: bool = False,
 ) -> list[Resource]:
-    http.token_source = _build_token_source(config)
-    client = gql.ShopifyGraphQLClient(http, config.store)
-    bulk_job_manager = gql.bulk_job_manager.BulkJobManager(client, log)
+    """Discover all available resources across all configured stores.
 
-    # Before opening bindings, cancel any ongoing bulk query jobs before the
-    # connector starts submitting its own bulk query jobs.
-    if should_cancel_ongoing_job:
-        await bulk_job_manager.cancel_current()
+    State format is always dictionary-based: {"inc": {"store_id": {...}}}
 
-    # Query the access token's granted scopes to filter available streams.
-    granted_scopes = await _get_granted_scopes(http, client.url, log)
+    Collection key format depends on config.advanced.should_use_composite_key:
+    - True: ["/_meta/store", "/id"]
+    - False: ["/id"]
+    """
+    store_contexts: dict[str, StoreContext] = {}
 
-    # Filter streams to only those whose required scope is granted.
-    # Uses set intersection to check if ANY of the required scopes are granted (OR logic).
-    available_models: list[type[ShopifyGraphQLResource]] = []
-    excluded_streams: list[tuple[str, set[str]]] = []
-    for model in INCREMENTAL_RESOURCES:
-        if model.QUALIFYING_SCOPES & granted_scopes:
-            available_models.append(model)
+    # Initialize all store contexts in parallel
+    results = await asyncio.gather(
+        *[
+            _create_store_context(log, http, store_config, should_cancel_ongoing_job)
+            for store_config in config.stores
+        ],
+        return_exceptions=True,
+    )
+
+    failed_stores: dict[str, BaseException] = {}
+    for store_config, result in zip(config.stores, results):
+        if isinstance(result, BaseException):
+            log.error(f"Failed to initialize store '{store_config.store}': {result}")
+            failed_stores[store_config.store] = result
         else:
-            excluded_streams.append((model.NAME, model.QUALIFYING_SCOPES))
+            excluded = [
+                m.NAME
+                for m in INCREMENTAL_RESOURCES
+                if m not in result.available_resources
+            ]
+            if excluded:
+                log.info(
+                    f"Store '{store_config.store}' excluding {len(excluded)} stream(s) due to missing scopes or plan restrictions"
+                )
+            store_contexts[store_config.store] = result
 
-    if excluded_streams:
-        log.warning(
-            f"Excluding {len(excluded_streams)} stream(s) due to missing scopes: "
-            f"{', '.join(f'{name} (needs one of {scopes})' for name, scopes in excluded_streams)}"
+    if not store_contexts:
+        raise StoreInitError(failed_stores, [])
+
+    if failed_stores:
+        raise StoreInitError(failed_stores, list(store_contexts.keys()))
+
+    # Determine which resources are available across all stores (union)
+    all_available: set[type[ShopifyGraphQLResource]] = set()
+    for ctx in store_contexts.values():
+        all_available.update(ctx.available_resources)
+
+    log.info(
+        f"Discovered {len(all_available)} stream(s) across {len(store_contexts)} store(s)"
+    )
+
+    # Build resources
+    resources: list[Resource] = []
+    key = (
+        ["/_meta/store", "/id"]
+        if config.advanced.should_use_composite_key
+        else ["/id"]
+    )
+
+    for model in INCREMENTAL_RESOURCES:
+        stores_with_access = [
+            store_id
+            for store_id, ctx in store_contexts.items()
+            if model in ctx.available_resources
+        ]
+
+        if not stores_with_access:
+            continue
+
+        use_backfill = not model.SHOULD_USE_BULK_QUERIES and model.SORT_KEY is not None
+        initial_state = _create_initial_state(
+            stores_with_access, config.start_date, use_backfill
         )
+        legacy_store_id = config._legacy_store or config.stores[0].store
 
-    resources = [
-        *_incremental_resources(http, config, client, bulk_job_manager, available_models, granted_scopes),
-    ]
+        def create_open_fn(
+            model: type[ShopifyGraphQLResource],
+            stores_with_access: list[str],
+            initial_state: ResourceState,
+            legacy_store_id: str,
+        ):
+            async def open(
+                binding: CaptureBinding[ResourceConfig],
+                binding_index: int,
+                state: ResourceState,
+                task: Task,
+                _all_bindings,
+            ):
+                await _reconcile_connector_state(
+                    stores_with_access,
+                    binding,
+                    state,
+                    initial_state,
+                    task,
+                    legacy_store_id=legacy_store_id,
+                )
 
-    # If the user is authenticating with an access token from their custom Shopify app,
-    # they may not be able to access certain PII data.
-    # https://help.shopify.com/en/manual/apps/app-types/custom-apps
-    # https://community.shopify.com/c/shopify-discussions/no-more-customer-pii-in-custom-app-integrations-for-shopify/td-p/2496209
-    if isinstance(
-        config.credentials, (AccessToken, ShopifyClientCredentials)
-    ) and not await _can_access_pii(http, client.url, log):
-        for model in PII_RESOURCES:
-            resources = [r for r in resources if r.name != model.NAME]
+                # Warn if FulfillmentOrders has partial scope coverage
+                if model == gql.FulfillmentOrders:
+                    fo_scopes = gql.FulfillmentOrders.QUALIFYING_SCOPES
+                    for store_id in stores_with_access:
+                        granted = store_contexts[store_id].scopes
+                        if fo_scopes & granted and not fo_scopes <= granted:
+                            missing = fo_scopes - granted
+                            task.log.warning(
+                                f"Store '{store_id}': FulfillmentOrders has partial scopes. "
+                                f"Missing: {missing}. Only matching fulfillment orders will be captured."
+                            )
+
+                if not model.SHOULD_USE_BULK_QUERIES and "edges" in model.QUERY.lower():
+                    raise RuntimeError(
+                        "Non-bulk queries cannot contain nested connections."
+                    )
+
+                data_model = create_response_data_model(model)
+
+                # Subtask creation is driven by fetch_changes/fetch_page dict keys
+                # (from stores_with_access), NOT by state keys. Orphaned state for
+                # removed stores is inert and intentionally preserved.
+                fetch_changes: dict[str, functools.partial] = {}
+                fetch_page: dict[str, functools.partial] = {}
+
+                for store_id in stores_with_access:
+                    ctx = store_contexts[store_id]
+
+                    if model.SHOULD_USE_BULK_QUERIES:
+                        fetch_changes[store_id] = functools.partial(
+                            bulk_fetch_incremental,
+                            ctx.http,
+                            config.advanced.window_size,
+                            ctx.bulk_job_manager,
+                            model,
+                            store_id,
+                        )
+                    elif model.SORT_KEY is None:
+                        fetch_changes[store_id] = functools.partial(
+                            fetch_incremental_unsorted,
+                            ctx.client,
+                            model,
+                            data_model,
+                            store_id,
+                        )
+                    else:
+                        fetch_changes[store_id] = functools.partial(
+                            fetch_incremental,
+                            ctx.client,
+                            model,
+                            data_model,
+                            store_id,
+                        )
+                        fetch_page[store_id] = functools.partial(
+                            backfill_incremental,
+                            ctx.client,
+                            model,
+                            data_model,
+                            store_id,
+                        )
+
+                open_binding(
+                    binding,
+                    binding_index,
+                    state,
+                    task,
+                    fetch_changes=fetch_changes,
+                    fetch_page=fetch_page if fetch_page else None,
+                )
+
+            return open
+
+        resources.append(
+            Resource(
+                name=model.NAME,
+                key=key,
+                model=ShopifyGraphQLResource,
+                open=create_open_fn(
+                    model, stores_with_access, initial_state, legacy_store_id
+                ),
+                initial_state=initial_state,
+                schema_inference=True,
+                initial_config=ResourceConfig(
+                    name=model.NAME, interval=timedelta(minutes=5)
+                ),
+            )
+        )
 
     return resources

--- a/source-shopify-native/source_shopify_native/utils.py
+++ b/source-shopify-native/source_shopify_native/utils.py
@@ -1,0 +1,11 @@
+from datetime import datetime
+
+DATETIME_STRING_FORMAT = "%Y-%m-%dT%H:%M:%SZ"
+
+
+def dt_to_str(dt: datetime) -> str:
+    return dt.strftime(DATETIME_STRING_FORMAT)
+
+
+def str_to_dt(dt_str: str) -> datetime:
+    return datetime.fromisoformat(dt_str.replace("Z", "+00:00"))

--- a/source-shopify-native/tests/snapshots/snapshots__capture__capture.stdout.json
+++ b/source-shopify-native/tests/snapshots/snapshots__capture__capture.stdout.json
@@ -3,6 +3,7 @@
     "acmeCo/products",
     {
       "_meta": {
+        "store": "estuary-alex-testing",
         "uuid": "DocUUIDPlaceholder-329Bb50aa48EAa9ef"
       },
       "bodyHtml": "This is a gift card for the store",
@@ -105,6 +106,7 @@
     "acmeCo/product_media",
     {
       "_meta": {
+        "store": "estuary-alex-testing",
         "uuid": "DocUUIDPlaceholder-329Bb50aa48EAa9ef"
       },
       "createdAt": "2025-01-14T15:10:14Z",
@@ -129,6 +131,7 @@
     "acmeCo/product_metafields",
     {
       "_meta": {
+        "store": "estuary-alex-testing",
         "uuid": "DocUUIDPlaceholder-329Bb50aa48EAa9ef"
       },
       "createdAt": "2025-01-14T15:10:14Z",
@@ -142,6 +145,7 @@
     "acmeCo/product_variants",
     {
       "_meta": {
+        "store": "estuary-alex-testing",
         "uuid": "DocUUIDPlaceholder-329Bb50aa48EAa9ef"
       },
       "createdAt": "2025-01-14T15:10:14Z",
@@ -281,6 +285,7 @@
     {
       "__parentId": "gid://shopify/Product/8086707830829",
       "_meta": {
+        "store": "estuary-alex-testing",
         "uuid": "DocUUIDPlaceholder-329Bb50aa48EAa9ef"
       },
       "createdAt": "2025-01-14T15:10:14Z",
@@ -316,6 +321,7 @@
     "acmeCo/fulfillment_orders",
     {
       "_meta": {
+        "store": "estuary-alex-testing",
         "uuid": "DocUUIDPlaceholder-329Bb50aa48EAa9ef"
       },
       "createdAt": "2025-04-10T17:42:58Z",
@@ -420,6 +426,7 @@
     "acmeCo/fulfillments",
     {
       "_meta": {
+        "store": "estuary-alex-testing",
         "uuid": "DocUUIDPlaceholder-329Bb50aa48EAa9ef"
       },
       "createdAt": "2025-04-10T17:42:58Z",
@@ -433,6 +440,7 @@
     "acmeCo/orders",
     {
       "_meta": {
+        "store": "estuary-alex-testing",
         "uuid": "DocUUIDPlaceholder-329Bb50aa48EAa9ef"
       },
       "app": {
@@ -861,6 +869,7 @@
     "acmeCo/order_agreements",
     {
       "_meta": {
+        "store": "estuary-alex-testing",
         "uuid": "DocUUIDPlaceholder-329Bb50aa48EAa9ef"
       },
       "agreements": [
@@ -977,6 +986,7 @@
     "acmeCo/order_metafields",
     {
       "_meta": {
+        "store": "estuary-alex-testing",
         "uuid": "DocUUIDPlaceholder-329Bb50aa48EAa9ef"
       },
       "createdAt": "2025-04-10T17:42:58Z",
@@ -990,6 +1000,7 @@
     "acmeCo/order_transactions",
     {
       "_meta": {
+        "store": "estuary-alex-testing",
         "uuid": "DocUUIDPlaceholder-329Bb50aa48EAa9ef"
       },
       "createdAt": "2025-04-10T17:42:58Z",
@@ -1003,6 +1014,7 @@
     "acmeCo/order_refunds",
     {
       "_meta": {
+        "store": "estuary-alex-testing",
         "uuid": "DocUUIDPlaceholder-329Bb50aa48EAa9ef"
       },
       "createdAt": "2025-04-10T17:42:58Z",
@@ -1018,6 +1030,7 @@
     "acmeCo/order_risks",
     {
       "_meta": {
+        "store": "estuary-alex-testing",
         "uuid": "DocUUIDPlaceholder-329Bb50aa48EAa9ef"
       },
       "createdAt": "2025-04-10T17:42:58Z",
@@ -1077,6 +1090,7 @@
     "acmeCo/inventory_items",
     {
       "_meta": {
+        "store": "estuary-alex-testing",
         "uuid": "DocUUIDPlaceholder-329Bb50aa48EAa9ef"
       },
       "countryCodeOfOrigin": null,
@@ -1107,6 +1121,7 @@
     {
       "__parentId": "gid://shopify/InventoryItem/45258934976557",
       "_meta": {
+        "store": "estuary-alex-testing",
         "uuid": "DocUUIDPlaceholder-329Bb50aa48EAa9ef"
       },
       "canDeactivate": false,
@@ -1179,6 +1194,7 @@
     "acmeCo/custom_collections",
     {
       "_meta": {
+        "store": "estuary-alex-testing",
         "uuid": "DocUUIDPlaceholder-329Bb50aa48EAa9ef"
       },
       "description": "",
@@ -1233,6 +1249,7 @@
     "acmeCo/smart_collections",
     {
       "_meta": {
+        "store": "estuary-alex-testing",
         "uuid": "DocUUIDPlaceholder-329Bb50aa48EAa9ef"
       },
       "description": "",
@@ -1306,6 +1323,7 @@
     "acmeCo/custom_collection_metafields",
     {
       "_meta": {
+        "store": "estuary-alex-testing",
         "uuid": "DocUUIDPlaceholder-329Bb50aa48EAa9ef"
       },
       "id": "gid://shopify/Collection/295442513965",
@@ -1318,6 +1336,7 @@
     "acmeCo/smart_collection_metafields",
     {
       "_meta": {
+        "store": "estuary-alex-testing",
         "uuid": "DocUUIDPlaceholder-329Bb50aa48EAa9ef"
       },
       "id": "gid://shopify/Collection/295442612269",
@@ -1330,6 +1349,7 @@
     "acmeCo/locations",
     {
       "_meta": {
+        "store": "estuary-alex-testing",
         "uuid": "DocUUIDPlaceholder-329Bb50aa48EAa9ef"
       },
       "activatable": true,
@@ -1365,6 +1385,7 @@
     "acmeCo/location_metafields",
     {
       "_meta": {
+        "store": "estuary-alex-testing",
         "uuid": "DocUUIDPlaceholder-329Bb50aa48EAa9ef"
       },
       "createdAt": "2025-01-14T15:09:43Z",

--- a/source-shopify-native/tests/snapshots/snapshots__discover__capture.stdout.json
+++ b/source-shopify-native/tests/snapshots/snapshots__discover__capture.stdout.json
@@ -25,6 +25,12 @@
               "description": "Row ID of the Document, counting up from zero, or -1 if not known",
               "title": "Row Id",
               "type": "integer"
+            },
+            "store": {
+              "default": "",
+              "description": "The Shopify store this document belongs to",
+              "title": "Store",
+              "type": "string"
             }
           },
           "title": "Meta",
@@ -79,6 +85,12 @@
               "description": "Row ID of the Document, counting up from zero, or -1 if not known",
               "title": "Row Id",
               "type": "integer"
+            },
+            "store": {
+              "default": "",
+              "description": "The Shopify store this document belongs to",
+              "title": "Store",
+              "type": "string"
             }
           },
           "title": "Meta",
@@ -133,6 +145,12 @@
               "description": "Row ID of the Document, counting up from zero, or -1 if not known",
               "title": "Row Id",
               "type": "integer"
+            },
+            "store": {
+              "default": "",
+              "description": "The Shopify store this document belongs to",
+              "title": "Store",
+              "type": "string"
             }
           },
           "title": "Meta",
@@ -187,6 +205,12 @@
               "description": "Row ID of the Document, counting up from zero, or -1 if not known",
               "title": "Row Id",
               "type": "integer"
+            },
+            "store": {
+              "default": "",
+              "description": "The Shopify store this document belongs to",
+              "title": "Store",
+              "type": "string"
             }
           },
           "title": "Meta",
@@ -241,6 +265,12 @@
               "description": "Row ID of the Document, counting up from zero, or -1 if not known",
               "title": "Row Id",
               "type": "integer"
+            },
+            "store": {
+              "default": "",
+              "description": "The Shopify store this document belongs to",
+              "title": "Store",
+              "type": "string"
             }
           },
           "title": "Meta",
@@ -295,6 +325,12 @@
               "description": "Row ID of the Document, counting up from zero, or -1 if not known",
               "title": "Row Id",
               "type": "integer"
+            },
+            "store": {
+              "default": "",
+              "description": "The Shopify store this document belongs to",
+              "title": "Store",
+              "type": "string"
             }
           },
           "title": "Meta",
@@ -349,6 +385,12 @@
               "description": "Row ID of the Document, counting up from zero, or -1 if not known",
               "title": "Row Id",
               "type": "integer"
+            },
+            "store": {
+              "default": "",
+              "description": "The Shopify store this document belongs to",
+              "title": "Store",
+              "type": "string"
             }
           },
           "title": "Meta",
@@ -403,6 +445,12 @@
               "description": "Row ID of the Document, counting up from zero, or -1 if not known",
               "title": "Row Id",
               "type": "integer"
+            },
+            "store": {
+              "default": "",
+              "description": "The Shopify store this document belongs to",
+              "title": "Store",
+              "type": "string"
             }
           },
           "title": "Meta",
@@ -457,6 +505,12 @@
               "description": "Row ID of the Document, counting up from zero, or -1 if not known",
               "title": "Row Id",
               "type": "integer"
+            },
+            "store": {
+              "default": "",
+              "description": "The Shopify store this document belongs to",
+              "title": "Store",
+              "type": "string"
             }
           },
           "title": "Meta",
@@ -511,6 +565,12 @@
               "description": "Row ID of the Document, counting up from zero, or -1 if not known",
               "title": "Row Id",
               "type": "integer"
+            },
+            "store": {
+              "default": "",
+              "description": "The Shopify store this document belongs to",
+              "title": "Store",
+              "type": "string"
             }
           },
           "title": "Meta",
@@ -565,6 +625,12 @@
               "description": "Row ID of the Document, counting up from zero, or -1 if not known",
               "title": "Row Id",
               "type": "integer"
+            },
+            "store": {
+              "default": "",
+              "description": "The Shopify store this document belongs to",
+              "title": "Store",
+              "type": "string"
             }
           },
           "title": "Meta",
@@ -619,6 +685,12 @@
               "description": "Row ID of the Document, counting up from zero, or -1 if not known",
               "title": "Row Id",
               "type": "integer"
+            },
+            "store": {
+              "default": "",
+              "description": "The Shopify store this document belongs to",
+              "title": "Store",
+              "type": "string"
             }
           },
           "title": "Meta",
@@ -673,6 +745,12 @@
               "description": "Row ID of the Document, counting up from zero, or -1 if not known",
               "title": "Row Id",
               "type": "integer"
+            },
+            "store": {
+              "default": "",
+              "description": "The Shopify store this document belongs to",
+              "title": "Store",
+              "type": "string"
             }
           },
           "title": "Meta",
@@ -727,6 +805,12 @@
               "description": "Row ID of the Document, counting up from zero, or -1 if not known",
               "title": "Row Id",
               "type": "integer"
+            },
+            "store": {
+              "default": "",
+              "description": "The Shopify store this document belongs to",
+              "title": "Store",
+              "type": "string"
             }
           },
           "title": "Meta",
@@ -781,6 +865,12 @@
               "description": "Row ID of the Document, counting up from zero, or -1 if not known",
               "title": "Row Id",
               "type": "integer"
+            },
+            "store": {
+              "default": "",
+              "description": "The Shopify store this document belongs to",
+              "title": "Store",
+              "type": "string"
             }
           },
           "title": "Meta",
@@ -835,6 +925,12 @@
               "description": "Row ID of the Document, counting up from zero, or -1 if not known",
               "title": "Row Id",
               "type": "integer"
+            },
+            "store": {
+              "default": "",
+              "description": "The Shopify store this document belongs to",
+              "title": "Store",
+              "type": "string"
             }
           },
           "title": "Meta",
@@ -889,6 +985,12 @@
               "description": "Row ID of the Document, counting up from zero, or -1 if not known",
               "title": "Row Id",
               "type": "integer"
+            },
+            "store": {
+              "default": "",
+              "description": "The Shopify store this document belongs to",
+              "title": "Store",
+              "type": "string"
             }
           },
           "title": "Meta",
@@ -943,6 +1045,12 @@
               "description": "Row ID of the Document, counting up from zero, or -1 if not known",
               "title": "Row Id",
               "type": "integer"
+            },
+            "store": {
+              "default": "",
+              "description": "The Shopify store this document belongs to",
+              "title": "Store",
+              "type": "string"
             }
           },
           "title": "Meta",
@@ -997,6 +1105,12 @@
               "description": "Row ID of the Document, counting up from zero, or -1 if not known",
               "title": "Row Id",
               "type": "integer"
+            },
+            "store": {
+              "default": "",
+              "description": "The Shopify store this document belongs to",
+              "title": "Store",
+              "type": "string"
             }
           },
           "title": "Meta",
@@ -1051,6 +1165,12 @@
               "description": "Row ID of the Document, counting up from zero, or -1 if not known",
               "title": "Row Id",
               "type": "integer"
+            },
+            "store": {
+              "default": "",
+              "description": "The Shopify store this document belongs to",
+              "title": "Store",
+              "type": "string"
             }
           },
           "title": "Meta",
@@ -1105,6 +1225,12 @@
               "description": "Row ID of the Document, counting up from zero, or -1 if not known",
               "title": "Row Id",
               "type": "integer"
+            },
+            "store": {
+              "default": "",
+              "description": "The Shopify store this document belongs to",
+              "title": "Store",
+              "type": "string"
             }
           },
           "title": "Meta",
@@ -1159,6 +1285,12 @@
               "description": "Row ID of the Document, counting up from zero, or -1 if not known",
               "title": "Row Id",
               "type": "integer"
+            },
+            "store": {
+              "default": "",
+              "description": "The Shopify store this document belongs to",
+              "title": "Store",
+              "type": "string"
             }
           },
           "title": "Meta",
@@ -1213,6 +1345,12 @@
               "description": "Row ID of the Document, counting up from zero, or -1 if not known",
               "title": "Row Id",
               "type": "integer"
+            },
+            "store": {
+              "default": "",
+              "description": "The Shopify store this document belongs to",
+              "title": "Store",
+              "type": "string"
             }
           },
           "title": "Meta",
@@ -1267,6 +1405,12 @@
               "description": "Row ID of the Document, counting up from zero, or -1 if not known",
               "title": "Row Id",
               "type": "integer"
+            },
+            "store": {
+              "default": "",
+              "description": "The Shopify store this document belongs to",
+              "title": "Store",
+              "type": "string"
             }
           },
           "title": "Meta",

--- a/source-shopify-native/tests/snapshots/snapshots__spec__capture.stdout.json
+++ b/source-shopify-native/tests/snapshots/snapshots__spec__capture.stdout.json
@@ -31,43 +31,16 @@
               "format": "duration",
               "title": "Window Size",
               "type": "string"
+            },
+            "should_use_composite_key": {
+              "default": false,
+              "description": "Controls whether collection keys include the store identifier (/_meta/store). Enabled by default for new captures. Automatically set to false for legacy single-store captures during migration. Must be set to true (with a full backfill / dataflow reset of all bindings) before adding additional stores to a legacy capture.",
+              "title": "Use Composite Key",
+              "type": "boolean"
             }
           },
           "title": "Advanced",
           "type": "object"
-        },
-        "LongLivedClientCredentialsOAuth2Credentials": {
-          "properties": {
-            "credentials_title": {
-              "const": "OAuth Credentials",
-              "default": "OAuth Credentials",
-              "title": "Credentials Title",
-              "type": "string"
-            },
-            "client_id": {
-              "secret": true,
-              "title": "Client Id",
-              "type": "string"
-            },
-            "client_secret": {
-              "secret": true,
-              "title": "Client Secret",
-              "type": "string"
-            },
-            "access_token": {
-              "secret": true,
-              "title": "Access Token",
-              "type": "string"
-            }
-          },
-          "required": [
-            "client_id",
-            "client_secret",
-            "access_token"
-          ],
-          "title": "OAuth",
-          "type": "object",
-          "x-oauth2-provider": "shopify"
         },
         "ShopifyClientCredentials": {
           "description": "Credentials for the Shopify client_credentials grant flow.\n\nUsed by Dev Dashboard custom apps (post-Jan 2026) where the app developer\nand store owner are the same organization. The CDK's TokenSource exchanges\nclient_id + client_secret for a short-lived access token (~24 hours)\nat runtime, with automatic refresh at 75% of the token lifetime.\n\nInherits client_id, client_secret, and grant_type=\"client_credentials\"\nfrom ClientCredentialsOAuth2Credentials / _BaseOAuth2CredentialsData.\n\nReferences:\n    https://shopify.dev/docs/apps/build/authentication-authorization/access-tokens/client-credentials-grant",
@@ -95,35 +68,52 @@
           ],
           "title": "Client Credentials",
           "type": "object"
+        },
+        "StoreConfig": {
+          "description": "Configuration for a single Shopify store.",
+          "properties": {
+            "store": {
+              "description": "Shopify store name (the prefix of your admin URL, e.g., 'mystore' for mystore.myshopify.com)",
+              "minLength": 1,
+              "title": "Store Name",
+              "type": "string"
+            },
+            "credentials": {
+              "discriminator": {
+                "mapping": {
+                  "Client Credentials": "#/$defs/ShopifyClientCredentials",
+                  "Private App Credentials": "#/$defs/AccessToken"
+                },
+                "propertyName": "credentials_title"
+              },
+              "oneOf": [
+                {
+                  "$ref": "#/$defs/ShopifyClientCredentials"
+                },
+                {
+                  "$ref": "#/$defs/AccessToken"
+                }
+              ],
+              "title": "Authentication"
+            }
+          },
+          "required": [
+            "store",
+            "credentials"
+          ],
+          "title": "StoreConfig",
+          "type": "object"
         }
       },
       "properties": {
-        "store": {
-          "description": "Shopify store ID. Use the prefix of your admin URL e.g. https://{YOUR_STORE}.myshopify.com/admin",
-          "title": "Shopify Store",
-          "type": "string"
-        },
-        "credentials": {
-          "discriminator": {
-            "mapping": {
-              "Client Credentials": "#/$defs/ShopifyClientCredentials",
-              "OAuth Credentials": "#/$defs/LongLivedClientCredentialsOAuth2Credentials",
-              "Private App Credentials": "#/$defs/AccessToken"
-            },
-            "propertyName": "credentials_title"
+        "stores": {
+          "description": "One or more Shopify stores to capture. Each store requires its own credentials.",
+          "items": {
+            "$ref": "#/$defs/StoreConfig"
           },
-          "oneOf": [
-            {
-              "$ref": "#/$defs/ShopifyClientCredentials"
-            },
-            {
-              "$ref": "#/$defs/AccessToken"
-            },
-            {
-              "$ref": "#/$defs/LongLivedClientCredentialsOAuth2Credentials"
-            }
-          ],
-          "title": "Authentication"
+          "minItems": 1,
+          "title": "Shopify Stores",
+          "type": "array"
         },
         "start_date": {
           "description": "UTC date and time in the format YYYY-MM-DDTHH:MM:SSZ. Any data generated before this date will not be replicated. If left blank, the start date will be set to 30 days before the present.",
@@ -139,8 +129,7 @@
         }
       },
       "required": [
-        "store",
-        "credentials"
+        "stores"
       ],
       "title": "EndpointConfig",
       "type": "object"
@@ -182,18 +171,6 @@
       "type": "object"
     },
     "documentationUrl": "https://go.estuary.dev/source-shopify-native",
-    "oauth2": {
-      "provider": "shopify",
-      "authUrlTemplate": "https://{{{ config.store }}}.myshopify.com/admin/oauth/authorize?client_id={{{#urlencode}}}{{{ client_id }}}{{{/urlencode}}}&scope=read_locales,read_products,read_orders,read_locations,read_inventory,read_customers,read_own_subscription_contracts,read_assigned_fulfillment_orders,read_merchant_managed_fulfillment_orders,read_third_party_fulfillment_orders,read_marketplace_fulfillment_orders&state={{{#urlencode}}}{{{ state }}}{{{/urlencode}}}&redirect_uri={{{#urlencode}}}{{{ redirect_uri }}}{{{/urlencode}}}",
-      "accessTokenUrlTemplate": "https://{{{ config.store }}}.myshopify.com/admin/oauth/access_token?client_id={{{#urlencode}}}{{{ client_id }}}{{{/urlencode}}}&client_secret={{{#urlencode}}}{{{ client_secret }}}{{{/urlencode}}}&code={{{#urlencode}}}{{{ code }}}{{{/urlencode}}}",
-      "accessTokenBody": "client_id={{{#urlencode}}}{{{ client_id }}}{{{/urlencode}}}&client_secret={{{#urlencode}}}{{{ client_secret }}}{{{/urlencode}}}&code={{{#urlencode}}}{{{ code }}}{{{/urlencode}}}",
-      "accessTokenHeaders": {
-        "content-type": "application/x-www-form-urlencoded"
-      },
-      "accessTokenResponseMap": {
-        "access_token": "/access_token"
-      }
-    },
     "resourcePathPointers": [
       "/name"
     ]

--- a/source-shopify-native/tests/test_state_migration.py
+++ b/source-shopify-native/tests/test_state_migration.py
@@ -1,0 +1,564 @@
+"""
+Tests for multi-store support: state migration, key validation, config migration,
+and store context injection.
+"""
+
+import pytest
+from datetime import datetime, timedelta, UTC
+from logging import Logger
+from unittest.mock import MagicMock, AsyncMock
+
+from estuary_cdk.capture.common import ResourceState, ResourceConfig, CaptureBinding
+from estuary_cdk.capture import Task, request
+from estuary_cdk.flow import CollectionSpec, ValidationError
+
+from source_shopify_native.models import ConnectorState, EndpointConfig, ShopifyClientCredentials, ShopifyGraphQLResource, StoreValidationContext
+from source_shopify_native.resources import (
+    _reconcile_connector_state,
+    _migrate_flat_to_dict_state,
+)
+from source_shopify_native import _validate_config
+
+
+CURSOR = datetime(2024, 6, 15, tzinfo=UTC)
+CUTOFF = datetime(2024, 6, 1, tzinfo=UTC)
+
+
+@pytest.fixture
+def log():
+    return MagicMock(spec=Logger)
+
+
+def _make_binding(state_key: str = "orders") -> CaptureBinding[ResourceConfig]:
+    binding = MagicMock(spec=CaptureBinding)
+    binding.stateKey = state_key
+    return binding
+
+
+def _make_task() -> Task:
+    task = MagicMock(spec=Task)
+    task.log = MagicMock()
+    task.checkpoint = AsyncMock()
+    return task
+
+
+def _make_initial_state(store_ids: list[str], use_backfill: bool = False) -> ResourceState:
+    cutoff = datetime.now(tz=UTC)
+    start_date = cutoff - timedelta(days=30)
+    if use_backfill:
+        return ResourceState(
+            inc={sid: ResourceState.Incremental(cursor=cutoff) for sid in store_ids},
+            backfill={sid: ResourceState.Backfill(next_page=start_date.isoformat(), cutoff=cutoff) for sid in store_ids},
+        )
+    return ResourceState(
+        inc={sid: ResourceState.Incremental(cursor=start_date) for sid in store_ids},
+    )
+
+
+async def _reconcile(state, store_ids, initial_state, legacy_store_id, state_key="orders"):
+    binding = _make_binding(state_key)
+    task = _make_task()
+    await _reconcile_connector_state(store_ids, binding, state, initial_state, task, legacy_store_id=legacy_store_id)
+    return task
+
+
+class TestReconcileConnectorState:
+    pytestmark = pytest.mark.asyncio
+
+    async def test_migrate_flat_incremental(self):
+        state = ResourceState(inc=ResourceState.Incremental(cursor=CURSOR))
+        task = await _reconcile(state, ["my-store"], _make_initial_state(["my-store"]), "my-store")
+
+        assert isinstance(state.inc, dict)
+        assert state.inc["my-store"].cursor == CURSOR
+        task.checkpoint.assert_called_once()
+
+    async def test_migrate_flat_with_backfill(self):
+        state = ResourceState(
+            inc=ResourceState.Incremental(cursor=CURSOR),
+            backfill=ResourceState.Backfill(cutoff=CUTOFF, next_page="cursor_abc"),
+        )
+        task = await _reconcile(state, ["s1"], _make_initial_state(["s1"], use_backfill=True), "s1", state_key="products")
+
+        assert state.inc["s1"].cursor == CURSOR
+        assert state.backfill["s1"].cutoff == CUTOFF
+        assert state.backfill["s1"].next_page == "cursor_abc"
+
+    async def test_dict_state_unchanged(self):
+        state = ResourceState(inc={"my-store": ResourceState.Incremental(cursor=CURSOR)})
+        task = await _reconcile(state, ["my-store"], _make_initial_state(["my-store"]), "my-store")
+
+        assert state.inc["my-store"].cursor == CURSOR
+        task.checkpoint.assert_not_called()
+
+    async def test_uses_explicit_legacy_store_id(self):
+        state = ResourceState(inc=ResourceState.Incremental(cursor=CURSOR))
+        store_ids = ["new-primary", "legacy-store", "third-store"]
+
+        await _reconcile(state, store_ids, _make_initial_state(store_ids), "legacy-store")
+
+        assert state.inc["legacy-store"].cursor == CURSOR
+        assert "new-primary" in state.inc
+        assert "third-store" in state.inc
+
+    async def test_idempotent(self):
+        state = ResourceState(inc=ResourceState.Incremental(cursor=CURSOR))
+
+        task1 = await _reconcile(state, ["s1"], _make_initial_state(["s1"]), "s1")
+        assert task1.checkpoint.call_count == 1
+
+        task2 = await _reconcile(state, ["s1"], _make_initial_state(["s1"]), "s1")
+        task2.checkpoint.assert_not_called()
+        assert state.inc["s1"].cursor == CURSOR
+
+    async def test_completed_backfill_converted_to_dict(self):
+        state = ResourceState(inc=ResourceState.Incremental(cursor=CURSOR), backfill=None)
+
+        await _reconcile(state, ["s1"], _make_initial_state(["s1"]), "s1")
+
+        assert isinstance(state.backfill, dict)
+        assert state.backfill["s1"] is None
+
+    async def test_add_new_store(self):
+        state = ResourceState(inc={"existing": ResourceState.Incremental(cursor=CURSOR)})
+        store_ids = ["existing", "new-store"]
+
+        task = await _reconcile(state, store_ids, _make_initial_state(store_ids), "existing")
+
+        assert state.inc["existing"].cursor == CURSOR
+        assert "new-store" in state.inc
+        task.checkpoint.assert_called_once()
+
+    async def test_add_store_with_backfill(self):
+        state = ResourceState(
+            inc={"store-a": ResourceState.Incremental(cursor=CURSOR)},
+            backfill={"store-a": None},
+        )
+        store_ids = ["store-a", "store-b"]
+        task = await _reconcile(state, store_ids, _make_initial_state(store_ids, use_backfill=True), "store-a")
+
+        assert "store-b" in state.inc
+        assert state.backfill["store-b"] is not None
+        task.checkpoint.assert_called_once()
+
+    async def test_independent_backfill_addition(self):
+        """Backfill is added for a store even when its inc already exists."""
+        state = ResourceState(
+            inc={"a": ResourceState.Incremental(cursor=CURSOR), "b": ResourceState.Incremental(cursor=CURSOR)},
+            backfill={"a": ResourceState.Backfill(cutoff=CURSOR, next_page="p1")},
+        )
+
+        task = await _reconcile(state, ["a", "b"], _make_initial_state(["a", "b"], use_backfill=True), "a")
+
+        assert state.backfill["b"] is not None
+        assert state.backfill["a"].next_page == "p1"
+        task.checkpoint.assert_called_once()
+
+    async def test_removed_store_state_preserved(self):
+        cursor_b = datetime(2024, 7, 1, tzinfo=UTC)
+        state = ResourceState(inc={
+            "store-a": ResourceState.Incremental(cursor=CURSOR),
+            "store-b": ResourceState.Incremental(cursor=cursor_b),
+        })
+
+        task = await _reconcile(state, ["store-a"], _make_initial_state(["store-a"]), "store-a")
+
+        assert state.inc["store-b"].cursor == cursor_b
+        task.checkpoint.assert_not_called()
+
+    async def test_error_on_invalid_initial_state(self):
+        state = ResourceState(inc=ResourceState.Incremental(cursor=CURSOR))
+        invalid = ResourceState(inc=ResourceState.Incremental(cursor=CURSOR))
+
+        with pytest.raises(RuntimeError, match="Invalid initial_state.*orders"):
+            binding = _make_binding("orders")
+            task = _make_task()
+            await _reconcile_connector_state(["s1"], binding, state, invalid, task, legacy_store_id="s1")
+
+    async def test_error_on_none_inc_state(self):
+        state = ResourceState(inc=None)
+
+        with pytest.raises(RuntimeError, match="not dict-based"):
+            binding = _make_binding("orders")
+            task = _make_task()
+            await _reconcile_connector_state(["s1"], binding, state, _make_initial_state(["s1"]), task, legacy_store_id="s1")
+
+
+class TestMigrateFlatToDictState:
+    def test_migrates_incremental(self, log):
+        state = ResourceState(inc=ResourceState.Incremental(cursor=CURSOR))
+        assert _migrate_flat_to_dict_state(state, "s1", log) is True
+        assert state.inc["s1"].cursor == CURSOR
+
+    def test_migrates_backfill(self, log):
+        state = ResourceState(
+            inc=ResourceState.Incremental(cursor=CURSOR),
+            backfill=ResourceState.Backfill(cutoff=CUTOFF, next_page="p1"),
+        )
+        assert _migrate_flat_to_dict_state(state, "s1", log) is True
+        assert state.backfill["s1"].cutoff == CUTOFF
+
+    def test_migrates_completed_backfill(self, log):
+        state = ResourceState(inc=ResourceState.Incremental(cursor=CURSOR), backfill=None)
+        assert _migrate_flat_to_dict_state(state, "s1", log) is True
+        assert state.backfill["s1"] is None
+
+    @pytest.mark.parametrize("inc", [
+        {"s1": ResourceState.Incremental(cursor=CURSOR)},
+        None,
+    ], ids=["already_dict", "none"])
+    def test_skips_non_flat(self, inc, log):
+        state = ResourceState(inc=inc)
+        assert _migrate_flat_to_dict_state(state, "s1", log) is False
+
+
+class TestStoreValidationContext:
+    def test_store_survives_exclude_unset(self):
+        doc = ShopifyGraphQLResource.model_validate(
+            {"id": "gid://shopify/Order/123"}, context=StoreValidationContext(store="my-store"),
+        )
+        dumped = doc.model_dump(exclude_unset=True, by_alias=True)
+        assert dumped["_meta"]["store"] == "my-store"
+
+    def test_store_in_fields_set(self):
+        doc = ShopifyGraphQLResource.model_validate(
+            {"id": "gid://shopify/Product/456"}, context=StoreValidationContext(store="test-store"),
+        )
+        assert doc.meta_.store == "test-store"
+        assert "meta_" in doc.model_fields_set
+
+    def test_no_context_leaves_store_empty(self):
+        assert ShopifyGraphQLResource(id="gid://shopify/Order/789").meta_.store == ""
+
+    def test_works_with_model_validate_json(self):
+        doc = ShopifyGraphQLResource.model_validate_json(
+            '{"id": "gid://shopify/Order/100"}', context=StoreValidationContext(store="json-store"),
+        )
+        assert doc.meta_.store == "json-store"
+        assert doc.model_dump(exclude_unset=True, by_alias=True)["_meta"]["store"] == "json-store"
+
+    def test_existing_meta_preserved(self):
+        doc = ShopifyGraphQLResource.model_validate(
+            {"id": "gid://shopify/Order/123", "_meta": {"op": "c"}},
+            context=StoreValidationContext(store="my-store"),
+        )
+        assert doc.meta_.store == "my-store"
+        assert doc.meta_.op == "c"
+
+
+def _make_validate_binding(name: str, key: list[str], backfill: int = 0) -> request.ValidateBinding:
+    binding = MagicMock(spec=request.ValidateBinding)
+    binding.resourceConfig = MagicMock()
+    binding.resourceConfig.name = name
+    binding.collection = MagicMock(spec=CollectionSpec)
+    binding.collection.key = key
+    binding.backfill = backfill
+    return binding
+
+
+def _make_validate_request(
+    stores: list[str],
+    bindings: list[request.ValidateBinding],
+    last_bindings: list[request.ValidateBinding] | None = None,
+    should_use_composite_key: bool = True,
+    prev_should_use_composite_key: bool | None = None,
+) -> request.Validate:
+    config_data = {
+        "stores": [{"store": s, "credentials": {"credentials_title": "Private App Credentials", "access_token": "tok"}} for s in stores],
+        "advanced": {"should_use_composite_key": should_use_composite_key},
+    }
+    config = EndpointConfig.model_validate(config_data)
+
+    req = MagicMock(spec=request.Validate)
+    req.config = config
+    req.bindings = bindings
+
+    if last_bindings is not None:
+        # Default: previous flag matches current (no toggle) unless explicitly set.
+        prev_flag = prev_should_use_composite_key if prev_should_use_composite_key is not None else should_use_composite_key
+        prev_config_data = {
+            "stores": [{"store": s, "credentials": {"credentials_title": "Private App Credentials", "access_token": "tok"}} for s in stores],
+            "advanced": {"should_use_composite_key": prev_flag},
+        }
+        req.lastCapture = MagicMock()
+        req.lastCapture.bindings = last_bindings
+        req.lastCapture.config.config = prev_config_data
+    else:
+        req.lastCapture = None
+
+    return req
+
+
+class TestValidateConfig:
+    def test_single_store_flag_false_ok(self):
+        """Legacy capture with one store and composite keys disabled — no error."""
+        req = _make_validate_request(
+            ["store-a"],
+            [_make_validate_binding("orders", ["/id"])],
+            [_make_validate_binding("orders", ["/id"])],
+            should_use_composite_key=False,
+        )
+        _validate_config(req)  # should not raise
+
+    def test_multi_store_flag_true_ok(self):
+        """New capture with multiple stores and composite keys enabled — no error."""
+        req = _make_validate_request(
+            ["s1", "s2"],
+            [_make_validate_binding("orders", ["/_meta/store", "/id"])],
+        )
+        _validate_config(req)  # should not raise
+
+    def test_multi_store_flag_false_raises(self):
+        """Legacy capture trying to add stores without enabling composite keys — error."""
+        req = _make_validate_request(
+            ["s1", "s2"],
+            [_make_validate_binding("orders", ["/id"])],
+            should_use_composite_key=False,
+        )
+        with pytest.raises(ValidationError) as exc_info:
+            _validate_config(req)
+
+        assert "composite keys" in exc_info.value.errors[0].lower()
+
+    def test_single_store_flag_true_ok(self):
+        """Single store with composite keys enabled (new capture default) — no error."""
+        req = _make_validate_request(
+            ["store-a"],
+            [_make_validate_binding("orders", ["/_meta/store", "/id"])],
+        )
+        _validate_config(req)  # should not raise
+
+    def test_enabling_composite_keys_requires_backfill(self):
+        """Toggling composite keys on with legacy non-composite bindings requires dataflow reset."""
+        prev = [_make_validate_binding("orders", ["/id"]), _make_validate_binding("products", ["/id"])]
+        curr = [_make_validate_binding("orders", ["/id"]), _make_validate_binding("products", ["/id"])]
+        req = _make_validate_request(["s1"], curr, prev, should_use_composite_key=True)
+
+        with pytest.raises(ValidationError) as exc_info:
+            _validate_config(req)
+
+        assert "orders" in exc_info.value.errors[0]
+        assert "products" in exc_info.value.errors[0]
+
+    def test_enabling_composite_keys_with_backfill_ok(self):
+        """Toggling composite keys on with backfill incremented — no error."""
+        prev = [_make_validate_binding("orders", ["/id"], backfill=0)]
+        curr = [_make_validate_binding("orders", ["/id"], backfill=1)]
+        req = _make_validate_request(["s1"], curr, prev, should_use_composite_key=True)
+
+        _validate_config(req)  # should not raise
+
+    def test_new_binding_not_flagged_for_backfill(self):
+        """New bindings that weren't in lastCapture don't need backfill."""
+        prev = [_make_validate_binding("orders", ["/id"])]
+        curr = [
+            _make_validate_binding("orders", ["/id"]),
+            _make_validate_binding("new-resource", ["/_meta/store", "/id"]),
+        ]
+        req = _make_validate_request(["s1"], curr, prev, should_use_composite_key=True)
+
+        with pytest.raises(ValidationError) as exc_info:
+            _validate_config(req)
+
+        errors_text = exc_info.value.errors[0]
+        assert "orders" in errors_text
+        assert "new-resource" not in errors_text
+
+    def test_already_composite_bindings_no_backfill_needed(self):
+        """When all previous bindings already have composite keys, no backfill needed."""
+        prev = [_make_validate_binding("orders", ["/_meta/store", "/id"])]
+        curr = [_make_validate_binding("orders", ["/_meta/store", "/id"])]
+        req = _make_validate_request(["s1", "s2"], curr, prev, should_use_composite_key=True)
+
+        _validate_config(req)  # should not raise
+
+    def test_toggling_flag_requires_rediscovery(self):
+        """Toggling the composite key flag requires re-discovery before publishing."""
+        prev = [_make_validate_binding("orders", ["/id"])]
+        curr = [_make_validate_binding("orders", ["/id"])]
+        req = _make_validate_request(
+            ["s1"], curr, prev,
+            should_use_composite_key=True,
+            prev_should_use_composite_key=False,
+        )
+
+        with pytest.raises(ValidationError) as exc_info:
+            _validate_config(req)
+
+        assert "discover" in exc_info.value.errors[0].lower()
+
+    def test_toggling_flag_off_requires_rediscovery(self):
+        """Toggling composite keys off also requires re-discovery."""
+        prev = [_make_validate_binding("orders", ["/_meta/store", "/id"])]
+        curr = [_make_validate_binding("orders", ["/_meta/store", "/id"])]
+        req = _make_validate_request(
+            ["s1"], curr, prev,
+            should_use_composite_key=False,
+            prev_should_use_composite_key=True,
+        )
+
+        with pytest.raises(ValidationError) as exc_info:
+            _validate_config(req)
+
+        assert "discover" in exc_info.value.errors[0].lower()
+
+    def test_toggling_flag_on_after_rediscovery_requires_backfill(self):
+        """Flag toggled on and user already re-discovered, but backfill not incremented."""
+        prev = [_make_validate_binding("orders", ["/id"])]
+        curr = [_make_validate_binding("orders", ["/_meta/store", "/id"])]
+        req = _make_validate_request(
+            ["s1"], curr, prev,
+            should_use_composite_key=True,
+            prev_should_use_composite_key=False,
+        )
+
+        with pytest.raises(ValidationError) as exc_info:
+            _validate_config(req)
+
+        assert "backfill" in exc_info.value.errors[0].lower()
+        assert "orders" in exc_info.value.errors[0]
+
+    def test_toggling_flag_on_after_rediscovery_with_backfill_ok(self):
+        """Flag toggled on, user re-discovered, and backfill incremented — no error."""
+        prev = [_make_validate_binding("orders", ["/id"], backfill=0)]
+        curr = [_make_validate_binding("orders", ["/_meta/store", "/id"], backfill=1)]
+        req = _make_validate_request(
+            ["s1"], curr, prev,
+            should_use_composite_key=True,
+            prev_should_use_composite_key=False,
+        )
+
+        _validate_config(req)  # should not raise
+
+    def test_toggling_flag_off_after_rediscovery_ok(self):
+        """Flag toggled off and user already re-discovered — no error."""
+        prev = [_make_validate_binding("orders", ["/_meta/store", "/id"])]
+        curr = [_make_validate_binding("orders", ["/id"])]
+        req = _make_validate_request(
+            ["s1"], curr, prev,
+            should_use_composite_key=False,
+            prev_should_use_composite_key=True,
+        )
+
+        _validate_config(req)  # should not raise
+
+    def test_prev_config_with_sops_encrypted_credentials(self):
+        """Previous config may have SOPS-encrypted fields (client_id_sops instead of client_id).
+        _validate_config should not fail when parsing the previous config."""
+        req = MagicMock(spec=request.Validate)
+        req.config = EndpointConfig.model_validate({
+            "stores": [{"store": "s1", "credentials": {"credentials_title": "Private App Credentials", "access_token": "tok"}}],
+            "advanced": {"should_use_composite_key": True},
+        })
+        req.bindings = [_make_validate_binding("orders", ["/_meta/store", "/id"])]
+
+        req.lastCapture = MagicMock()
+        req.lastCapture.bindings = [_make_validate_binding("orders", ["/_meta/store", "/id"])]
+        # Simulate SOPS-encrypted previous config: client_id_sops instead of client_id.
+        req.lastCapture.config.config = {
+            "stores": [{
+                "store": "s1",
+                "credentials": {
+                    "credentials_title": "Client Credentials",
+                    "client_id_sops": "ENC[AES256_GCM,...]",
+                    "client_secret_sops": "ENC[AES256_GCM,...]",
+                },
+            }],
+            "advanced": {"should_use_composite_key": True},
+        }
+
+        _validate_config(req)  # should not raise
+
+    def test_prev_config_legacy_flat_with_sops(self):
+        """Legacy flat config with SOPS-encrypted credentials should be treated as composite=False."""
+        req = MagicMock(spec=request.Validate)
+        req.config = EndpointConfig.model_validate({
+            "stores": [{"store": "s1", "credentials": {"credentials_title": "Private App Credentials", "access_token": "tok"}}],
+            "advanced": {"should_use_composite_key": False},
+        })
+        req.bindings = [_make_validate_binding("orders", ["/id"])]
+
+        req.lastCapture = MagicMock()
+        req.lastCapture.bindings = [_make_validate_binding("orders", ["/id"])]
+        # Legacy flat config with SOPS fields — should infer composite=False.
+        req.lastCapture.config.config = {
+            "store": "s1",
+            "credentials": {
+                "credentials_title": "Client Credentials",
+                "client_id_sops": "ENC[AES256_GCM,...]",
+                "client_secret_sops": "ENC[AES256_GCM,...]",
+            },
+        }
+
+        _validate_config(req)  # should not raise (no toggle, both False)
+
+
+class TestEndpointConfigMigration:
+    def test_legacy_config_migrated(self):
+        config = EndpointConfig.model_validate({
+            "store": "my-shop",
+            "credentials": {"credentials_title": "Private App Credentials", "access_token": "tok"},
+        })
+        assert len(config.stores) == 1
+        assert config.stores[0].store == "my-shop"
+        assert config._was_migrated is True
+        assert config._legacy_store == "my-shop"
+        assert config.advanced.should_use_composite_key is False
+
+    def test_multi_store_config_not_flagged(self):
+        config = EndpointConfig.model_validate({
+            "stores": [{"store": "s1", "credentials": {"credentials_title": "Private App Credentials", "access_token": "t1"}}],
+        })
+        assert config._was_migrated is False
+        assert config._legacy_store is None
+        assert config.advanced.should_use_composite_key is False
+
+    def test_duplicate_stores_rejected(self):
+        with pytest.raises(ValueError, match="Duplicate store names"):
+            EndpointConfig.model_validate({
+                "stores": [
+                    {"store": "dup", "credentials": {"credentials_title": "Private App Credentials", "access_token": "t1"}},
+                    {"store": "dup", "credentials": {"credentials_title": "Private App Credentials", "access_token": "t2"}},
+                ],
+            })
+
+
+class TestClientCredentialsConfig:
+    def test_client_credentials_parsed(self):
+        config = EndpointConfig.model_validate({
+            "stores": [{
+                "store": "my-shop",
+                "credentials": {
+                    "credentials_title": "Client Credentials",
+                    "client_id": "app-id",
+                    "client_secret": "app-secret",
+                },
+            }],
+        })
+        assert isinstance(config.stores[0].credentials, ShopifyClientCredentials)
+        assert config.stores[0].credentials.client_id == "app-id"
+        assert config.stores[0].credentials.client_secret == "app-secret"
+
+    def test_access_token_still_works(self):
+        config = EndpointConfig.model_validate({
+            "stores": [{
+                "store": "my-shop",
+                "credentials": {"credentials_title": "Private App Credentials", "access_token": "shpat_xxx"},
+            }],
+        })
+        from estuary_cdk.flow import AccessToken
+        assert isinstance(config.stores[0].credentials, AccessToken)
+
+    def test_legacy_flat_config_with_client_credentials(self):
+        config = EndpointConfig.model_validate({
+            "store": "my-shop",
+            "credentials": {
+                "credentials_title": "Client Credentials",
+                "client_id": "app-id",
+                "client_secret": "app-secret",
+            },
+        })
+        assert len(config.stores) == 1
+        assert isinstance(config.stores[0].credentials, ShopifyClientCredentials)
+        assert config._was_migrated is True
+        assert config.advanced.should_use_composite_key is False


### PR DESCRIPTION
**Description:**

## Summary 

Adds multi-store support to `source-shopify-native`, allowing a single capture to replicate data from multiple Shopify stores. Each store authenticates independently via Access Token with its own rate limiter and HTTP session.

### Key changes

- **Multi-store config**: New `StoreConfig` model wrapping per-store `store` name and `credentials`. Legacy single-store configs (`{"store": "...", "credentials": {...}}`) are auto-migrated to the new `stores` list format via a Pydantic `mode="wrap"` validator, with the original config persisted on next `open` via `config_update` event.
- **Composite collection keys**: All collections now use `["/_meta/store", "/id"]` to ensure cross-store document uniqueness. Discover always proposes composite keys for forward compatibility. Legacy captures may have mixed keys — old bindings retain `["/id"]` while newly discovered bindings get `["/_meta/store", "/id"]` — reducing the number of bindings requiring backfill if a store is added later.
- **Backfill validation**: Adding multiple stores to an existing capture requires backfill acknowledgment for legacy `["/id"]` bindings so the key structure can change to include the store identifier.
- **Dict-based state**: Resource state is always keyed by store ID (`{"inc": {"store-id": {"cursor": "..."}}}`). Legacy flat state is automatically migrated during `open` and checkpointed.
- **Per-store isolation**: `StoreHTTP` wrapper shares the parent `aiohttp.ClientSession` for connection pooling while providing independent `RateLimiter` and `TokenSource` per store. Store initialization and credential validation run in parallel via `asyncio.gather`.
- **Store context injection**: `StoreValidationContext` dataclass is passed through Pydantic's validation context to inject the `_meta.store` field on every document. A `mode="before"` model validator combined with `validate_assignment=True` ensures the field survives `model_dump(exclude_unset=True)`.
- **OAuth temporarily removed**: Will revisit once the OAuth app is approved and UI/runtime supports OAuth inside array items with per-store credentials.
- **Circular import fix**: Extracted `dt_to_str`/`str_to_dt` into `utils.py` and removed the eager `bulk_job_manager` import from `graphql/__init__.py` to break the cycle: `models.py` → `graphql/__init__.py` → `bulk_job_manager` → `models.py`.
- `StoreInitError`: fail-fast behavior documented with TODO for graceful degradation.

### Other improvements

- `BulkJobManager`: public `check_connectivity()` method (replacing private `_get_running_jobs()` usage for validation), cancel timeout using `time.monotonic()`, store-prefixed log messages, typo fix.

Closes #3508

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

### TODO: Needs updated documentation PR.

**Notes for reviewers:**

## Test plan

- [x] `poetry run pytest tests/test_state_migration.py` — 41 tests covering:
  - State migration (flat-to-dict, backfill, idempotency, multi-store addition, removed store preservation, error cases)
  - Binding key validation (multi-store transition, backfill acknowledgment, new binding not flagged)
  - `_should_use_store_in_key` (all branches including key regression prevention)
  - `EndpointConfig` migration (legacy format, multi-store, duplicate rejection)
  - `StoreValidationContext` (serialization, `exclude_unset`, JSON parsing, existing meta preserved)
- [x] `poetry run pytest tests/test_snapshots.py --insta=update` — spec, discover, capture snapshots pass
- [ ] Manual test with multi-store config against live Shopify stores
- [ ] Verify legacy single-store capture continues working without backfill
- [ ] Verify adding a second store triggers backfill validation error

