### PR TITLE
source-intercom-native: allow extra fields in `ContactTagResponse.Tag`

### DIFF
--- a/source-intercom-native/source_intercom_native/models.py
+++ b/source-intercom-native/source_intercom_native/models.py
@@ -150,7 +150,12 @@ class Contact(TimestampedResource):
 
 
 class ContactTagsResponse(BaseModel, extra="allow"):
-    class Tag(BaseModel, extra="forbid"):
+    # ContactTagsResponse.Tag describes only the fields
+    # necessary to construct a NestedTag model instance.
+    # Extra fields from the API are allowed but discarded during
+    # hydration since the contacts returned by the /contacts/search
+    # endpoint do not contain those additional fields in nested tags.
+    class Tag(BaseModel, extra="allow"):
         id: str
         type: str
         name: str


### PR DESCRIPTION
**Description:**

The Intercom API now returns `applied_at` and `applied_by` fields in `ContactTagsResponse.Tag`. The /contacts/search endpoint does not include these extra fields in tags nested within contacts. So, this commit updates `ContactTagsResponse.Tag` to allow those additional, ignored fields.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

Tested via the capture snapshot test. Previously, it was failing with Pydantic validation errors due to the presence of `applied_at` and `applied_by` fields in the `/contacts/:contactId/tags` response. Now, the capture snapshot test doesn't fail.

