### PR TITLE
source-asana: add target field to stories stream

### DIFF
--- a/source-asana/source_asana/schemas/stories.json
+++ b/source-asana/source_asana/schemas/stories.json
@@ -39,6 +39,15 @@
         }
       }
     },
-    "num_likes": { "type": ["null", "integer"] }
+    "num_likes": { "type": ["null", "integer"] },
+    "target": {
+      "type": ["null", "object"],
+      "properties": {
+        "gid": { "type": ["null", "string"] },
+        "resource_type": { "type": ["null", "string"] },
+        "resource_subtype": { "type": ["null", "string"] },
+        "name": { "type": ["null", "string"] }
+      }
+    }
   }
 }

--- a/source-asana/source_asana/streams.py
+++ b/source-asana/source_asana/streams.py
@@ -453,6 +453,12 @@ class Stories(AsanaStream):
         story_gid = stream_slice["story_gid"]
         return f"stories/{story_gid}"
 
+    def _handle_object_type(self, prop: str, value: MutableMapping[str, Any]) -> str:
+        if prop == "target":
+            # Nested object fields must be explicitly requested via opt_fields.
+            return "target.gid,target.name,target.resource_type,target.resource_subtype"
+        return super()._handle_object_type(prop, value)
+
     def stream_slices(self, **kwargs) -> Iterable[Optional[Mapping[str, Any]]]:
         # This streams causes tests to timeout (> 2hrs), so we limit stream slices to 100 to make tests less noisy
         if self.test_mode:

--- a/source-asana/tests/snapshots/snapshots__capture__capture.stdout.json
+++ b/source-asana/tests/snapshots/snapshots__capture__capture.stdout.json
@@ -92,6 +92,12 @@
       "is_editable": false,
       "resource_subtype": "assigned",
       "resource_type": "story",
+      "target": {
+        "gid": "1205846055668625",
+        "name": "Draft project brief",
+        "resource_subtype": "default_task",
+        "resource_type": "task"
+      },
       "text": "redacted",
       "type": "system"
     }

--- a/source-asana/tests/snapshots/snapshots__discover__capture.stdout.json
+++ b/source-asana/tests/snapshots/snapshots__discover__capture.stdout.json
@@ -1931,6 +1931,38 @@
             "integer"
           ]
         },
+        "target": {
+          "type": [
+            "null",
+            "object"
+          ],
+          "properties": {
+            "gid": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "resource_type": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "resource_subtype": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "name": {
+              "type": [
+                "null",
+                "string"
+              ]
+            }
+          }
+        },
         "_meta": {
           "type": "object",
           "properties": {


### PR DESCRIPTION
**Description:**

This PR adds the `target` field to the `stories` stream. The `target` field references the object (typically a task) that the story is about. Nested object fields in `target` must be explicitly requested via the `opt_fields` query parameter.

Capture and discover snapshot changes are expected due to the addition of the new `target` field.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

