### PR TITLE
materialize-snowflake: add error if encryption key changes

### DIFF
--- a/materialize-snowflake/stream.go
+++ b/materialize-snowflake/stream.go
@@ -229,6 +229,12 @@ func (sm *streamManager) write(ctx context.Context, blobs []*blobMetadata, recov
 		return fmt.Errorf("unknown channel %s", channelName)
 	}
 
+	// This can happen if a table is dropped after blobs have already been
+	// written.
+	if blobs[0].Chunks[0].EncryptionKeyID != thisChannel.EncryptionKeyId {
+		return fmt.Errorf("channel encryption key has changed; backfill required")
+	}
+
 	for _, blob := range blobs {
 		blobToken := blob.Chunks[0].Channels[0].OffsetToken
 		currentChannelToken := thisChannel.OffsetToken


### PR DESCRIPTION
**Description:**

When a table is dropped, the channels encryption key for the recreated table are changed.  If there are blobs that have already been encrypted for the old channel we won't be able to decrypt them and a backfill is required to avoid missing documents.

**Workflow steps:**

No changes.

**Documentation links affected:**

None

**Notes for reviewers:**

If we still had the encryption key we might be able to decrypt with the old key and upload with the new key, but this would require saving the encryption key in the checkpoint.

