### PR TITLE
source-iterable-native: add Starting campaign state

### DIFF
--- a/source-iterable-native/source_iterable_native/models.py
+++ b/source-iterable-native/source_iterable_native/models.py
@@ -206,6 +206,7 @@ class CampaignPreLaunchStates(StrEnum):
     DRAFT = "Draft"
     RECURRING = "Recurring"
     SCHEDULED = "Scheduled"
+    STARTING = "Starting"
 
 
 class CampaignInProgressStates(StrEnum):

--- a/source-iterable-native/tests/snapshots/snapshots__discover__capture.stdout.json
+++ b/source-iterable-native/tests/snapshots/snapshots__discover__capture.stdout.json
@@ -84,7 +84,8 @@
           "enum": [
             "Draft",
             "Recurring",
-            "Scheduled"
+            "Scheduled",
+            "Starting"
           ],
           "title": "CampaignPreLaunchStates",
           "type": "string"


### PR DESCRIPTION
**Description:**

We've observed campaigns can be in the "Starting" transitional state before they actually start running. Capture have choked on this since "Starting" isn't accepted as a valid `CampaignState`:

```
Task capture.campaigns.incremental: 3 validation errors for Campaigns
campaignState.str-enum[CampaignPreLaunchStates]
  Input should be 'Draft', 'Recurring' or 'Scheduled' [type=enum, input_value='Starting', input_type=str]
    For further information visit https://errors.pydantic.dev/2.12/v/enum
campaignState.str-enum[CampaignInProgressStates]
  Input should be 'Ready', 'Running' or 'Recalling' [type=enum, input_value='Starting', input_type=str]
    For further information visit https://errors.pydantic.dev/2.12/v/enum
campaignState.str-enum[CampaignFinalStates]
  Input should be 'Aborted', 'Archived', 'Finished' or 'Recalled' [type=enum, input_value='Starting', input_type=str]
    For further information visit https://errors.pydantic.dev/2.12/v/enum
```

This commit fixes that by adding "Starting" as a `CampaignPreLaunchStates` member.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

