### PR TITLE
materialize-bigquery: add skip_cleanup feature flag

### DIFF
--- a/materialize-bigquery/bigquery.go
+++ b/materialize-bigquery/bigquery.go
@@ -27,6 +27,7 @@ var featureFlagDefaults = map[string]bool{
 	"objects_and_arrays_as_json":       true,
 	"datetime_keys_as_string":          true,
 	"retain_existing_data_on_backfill": false,
+	"skip_cleanup":                     false,
 }
 
 type AuthType string


### PR DESCRIPTION
**Description:**

When this flag is enabled, skip removal of staged files for later debugging.  Also added debug logging of the queries with their external data mappings, while the stage files are already logged it was difficult to determine how they were used in the query.

**Workflow steps:**

Add `skip_cleanup` to the feature flags to disable cleanup.  Use `logLevel: debug` for query logging.

**Documentation links affected:**

None

**Notes for reviewers:**

(anything that might help someone review this PR)

