### PR TITLE
materialize-snowflake: log on encryption key change instead of error

### DIFF
--- a/materialize-snowflake/stream.go
+++ b/materialize-snowflake/stream.go
@@ -232,7 +232,10 @@ func (sm *streamManager) write(ctx context.Context, blobs []*blobMetadata, recov
 	// This can happen if a table is dropped after blobs have already been
 	// written.
 	if blobs[0].Chunks[0].EncryptionKeyID != thisChannel.EncryptionKeyId {
-		return fmt.Errorf("channel encryption key has changed; backfill required")
+		log.WithFields(log.Fields{
+			"schema": schema,
+			"table":  table,
+		}).Warn("channel encryption key has changed; backfill may be required")
 	}
 
 	for _, blob := range blobs {


### PR DESCRIPTION
**Description:**

It's may be possible that an encryption key change isn't always going to result in an error, it's possible that some number of previous keys can still be read, so reducing this error to a warning.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

