### PR TITLE
materialize-snowflake: reencrypt blob if needed

### DIFF
--- a/materialize-snowflake/bdec_test.go
+++ b/materialize-snowflake/bdec_test.go
@@ -131,6 +131,11 @@ func TestReencrypt(t *testing.T) {
 	sum := md5.Sum(encrypted)
 	hsh := hex.EncodeToString(sum[:])
 
+	channel := &channel{
+		EncryptionKey:   encryptionKey,
+		EncryptionKeyId: 12345,
+	}
+
 	blob := &blobMetadata{
 		Path:   string(oldFileName),
 		MD5:    hsh,
@@ -140,7 +145,7 @@ func TestReencrypt(t *testing.T) {
 	var in = bytes.NewReader(encrypted)
 	var out bytes.Buffer
 
-	require.NoError(t, reencrypt(in, &out, blob, encryptionKey, newFileName))
+	require.NoError(t, reencrypt(in, &out, blob, encryptionKey, channel, newFileName))
 
 	// The re-encrypted file matches the original input.
 	newKey, err := deriveKey(encryptionKey, newFileName)

--- a/materialize-snowflake/snowflake.go
+++ b/materialize-snowflake/snowflake.go
@@ -560,13 +560,14 @@ func (d *transactor) pipeExists(ctx context.Context, pipeName string) (bool, err
 }
 
 type checkpointItem struct {
-	Table       string
-	Query       string
-	StagedDir   string
-	StreamBlobs []*blobMetadata
-	PipeName    string
-	PipeFiles   []fileRecord
-	Version     string
+	Table         string
+	Query         string
+	StagedDir     string
+	StreamBlobs   []*blobMetadata
+	PipeName      string
+	PipeFiles     []fileRecord
+	Version       string
+	EncryptionKey string
 }
 
 type checkpoint = map[string]*checkpointItem
@@ -620,6 +621,7 @@ func (d *transactor) Store(it *m.StoreIterator) (m.StartCommitFunc, error) {
 
 func (d *transactor) buildDriverCheckpoint(ctx context.Context, runtimeCheckpoint *protocol.Checkpoint) (json.RawMessage, error) {
 	streamBlobs := make(map[int][]*blobMetadata)
+	keys := make(map[int]string)
 	if d.streamManager != nil {
 		// The "base token" only really needs to be sufficiently random that it
 		// doesn't collide with the prior or next transaction's value. Deriving
@@ -627,7 +629,7 @@ func (d *transactor) buildDriverCheckpoint(ctx context.Context, runtimeCheckpoin
 		// convenient to make testing outputs consistent.
 		if mcp, err := runtimeCheckpoint.Marshal(); err != nil {
 			return nil, fmt.Errorf("marshalling checkpoint: %w", err)
-		} else if streamBlobs, err = d.streamManager.flush(fmt.Sprintf("%016x", xxhash.Sum64(mcp))); err != nil {
+		} else if streamBlobs, keys, err = d.streamManager.flush(fmt.Sprintf("%016x", xxhash.Sum64(mcp))); err != nil {
 			return nil, fmt.Errorf("flushing stream manager: %w", err)
 		}
 	}
@@ -636,7 +638,8 @@ func (d *transactor) buildDriverCheckpoint(ctx context.Context, runtimeCheckpoin
 		if b.streaming {
 			if blobs, ok := streamBlobs[idx]; ok {
 				d.cp[b.target.StateKey] = &checkpointItem{
-					StreamBlobs: blobs,
+					StreamBlobs:   blobs,
+					EncryptionKey: keys[idx],
 				}
 			}
 			continue
@@ -837,7 +840,7 @@ func (d *transactor) Acknowledge(ctx context.Context) (*pf.ConnectorState, error
 		} else if len(item.StreamBlobs) > 0 {
 			group.Go(func() error {
 				d.be.StartedResourceCommit(path)
-				if err := d.streamManager.write(groupCtx, item.StreamBlobs, !d.didRecovery); err != nil {
+				if err := d.streamManager.write(groupCtx, item.StreamBlobs, item.EncryptionKey, !d.didRecovery); err != nil {
 					return fmt.Errorf("writing streaming blobs for %s: %w", path, err)
 				}
 				d.be.FinishedResourceCommit(path)

--- a/materialize-snowflake/stream.go
+++ b/materialize-snowflake/stream.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"path"
 	"strconv"
@@ -170,14 +169,15 @@ func (sm *streamManager) objMetadata() blob.WriterOption {
 	})
 }
 
-func (sm *streamManager) flush(baseToken string) (map[int][]*blobMetadata, error) {
+func (sm *streamManager) flush(baseToken string) (map[int][]*blobMetadata, map[int]string, error) {
 	if sm.bdecWriter != nil {
 		if err := sm.finishBlob(); err != nil {
-			return nil, fmt.Errorf("finishBlob: %w", err)
+			return nil, nil, fmt.Errorf("finishBlob: %w", err)
 		}
 	}
 
 	out := make(map[int][]*blobMetadata)
+	keys := make(map[int]string)
 	for binding, trackedBlobs := range sm.blobStats {
 		for idx, trackedBlob := range trackedBlobs {
 			out[binding] = append(out[binding], generateBlobMetadata(
@@ -185,11 +185,12 @@ func (sm *streamManager) flush(baseToken string) (map[int][]*blobMetadata, error
 				sm.tableStreams[binding].channel,
 				blobToken(baseToken, idx)),
 			)
+			keys[binding] = sm.tableStreams[binding].channel.EncryptionKey
 		}
 	}
 	maps.Clear(sm.blobStats)
 
-	return out, nil
+	return out, keys, nil
 }
 
 // write registers a series of blobs to the table. All the blobs must be for the
@@ -208,7 +209,7 @@ func (sm *streamManager) flush(baseToken string) (map[int][]*blobMetadata, error
 // channel itself persists the last registered token, and this allows us to
 // filter out blobs that had previously been registered and don't need
 // registered again on a re-attempt of an Acknowledge.
-func (sm *streamManager) write(ctx context.Context, blobs []*blobMetadata, recovery bool) error {
+func (sm *streamManager) write(ctx context.Context, blobs []*blobMetadata, decryptKey string, recovery bool) error {
 	if err := validWriteBlobs(blobs); err != nil {
 		return fmt.Errorf("validWriteBlobs: %w", err)
 	}
@@ -229,12 +230,6 @@ func (sm *streamManager) write(ctx context.Context, blobs []*blobMetadata, recov
 		return fmt.Errorf("unknown channel %s", channelName)
 	}
 
-	// This can happen if a table is dropped after blobs have already been
-	// written.
-	if blobs[0].Chunks[0].EncryptionKeyID != thisChannel.EncryptionKeyId {
-		return fmt.Errorf("channel encryption key has changed; backfill required")
-	}
-
 	for _, blob := range blobs {
 		blobToken := blob.Chunks[0].Channels[0].OffsetToken
 		currentChannelToken := thisChannel.OffsetToken
@@ -253,6 +248,16 @@ func (sm *streamManager) write(ctx context.Context, blobs []*blobMetadata, recov
 		blob.Chunks[0].Channels[0].ClientSequencer = thisChannel.ClientSequencer
 		blob.Chunks[0].Channels[0].RowSequencer = thisChannel.RowSequencer + 1
 
+		// Handle the case where decryptKey was not in the checkpoint because
+		// the checkpoint was created before it was added.  We will guess that
+		// its the same as the current key, if its not then there will be a
+		// code 89 and the task will need backfilled.
+		//
+		// This check can be removed once all tasks have written a checkpoint.
+		if decryptKey != "" {
+			decryptKey = thisChannel.EncryptionKey
+		}
+
 		if recovery {
 			// Always use the rename and re-upload strategy during recovery
 			// commits. This prevents issues where blobs could be re-registered
@@ -260,42 +265,25 @@ func (sm *streamManager) write(ctx context.Context, blobs []*blobMetadata, recov
 			// dropped out-of-band, or its last persisted token changed in some
 			// other way.
 			//
+			// It is also possible the channel encryption key has changed and
+			// the blob will need to be rewritten with the new encryption key.
+			//
+			// This also address the "blob has wrong format or extension" error
+			// which occurs if the blob was written not-so-recently; apparently
+			// anything older than an hour or so is rejected by what seems to
+			// be a server-side check the examines the name of the file, which
+			// contains the timestamp it was written.  In this case, which
+			// may arise from re-enabling a disabled binding / materialization,
+			// or extended outages, we have to download the file and re-upload
+			// it with an up-to-date name.
+			//
 			// This should be a relatively infrequent occurrence, so the
 			// performance impact + increased data transfer should be tolerable.
-			if err := sm.writeRenamed(ctx, thisChannel, blob); err != nil {
+			if err := sm.writeRenamed(ctx, decryptKey, thisChannel, blob); err != nil {
 				return fmt.Errorf("writeRenamed: %w", err)
 			}
 		} else if err := sm.c.write(ctx, blob); err != nil {
-			var apiError *streamingApiError
-			if errors.As(err, &apiError) && apiError.Code == 38 {
-				// The "blob has wrong format or extension" error occurs if the
-				// blob was written not-so-recently; apparently anything older
-				// than an hour or so is rejected by what seems to be a
-				// server-side check the examines the name of the file, which
-				// contains the timestamp it was written.
-				//
-				// In these cases, which may arise from re-enabling a disabled
-				// binding / materialization, or extended outages, we have to
-				// download the file and re-upload it with an up-to-date name.
-				//
-				// This should be quite rare, even more rare than one may think,
-				// since blob registration tokens are persisted in Snowflake
-				// rather than exclusively managed by our Acknowledge
-				// checkpoints. But it is still technically possible and so it
-				// is handled with this.
-				log.WithFields(log.Fields{
-					"name":   blob.Path,
-					"token":  blobToken,
-					"schema": blob.Chunks[0].Schema,
-					"table":  blob.Chunks[0].Table,
-				}).Warn("blob rejected for malformed name; will attempt to register by renaming")
-
-				if err := sm.writeRenamed(ctx, thisChannel, blob); err != nil {
-					return fmt.Errorf("writeRenamed: %w", err)
-				}
-			} else {
-				return fmt.Errorf("write: %w", err)
-			}
+			return fmt.Errorf("write: %w", err)
 		}
 
 		thisChannel.RowSequencer++
@@ -319,7 +307,7 @@ func (sm *streamManager) write(ctx context.Context, blobs []*blobMetadata, recov
 	return nil
 }
 
-func (sm *streamManager) writeRenamed(ctx context.Context, channel *channel, blob *blobMetadata) error {
+func (sm *streamManager) writeRenamed(ctx context.Context, decryptKey string, channel *channel, blob *blobMetadata) error {
 	if err := sm.maybeInitializeBucket(ctx); err != nil {
 		return fmt.Errorf("initializing bucket to rename: %w", err)
 	}
@@ -334,7 +322,7 @@ func (sm *streamManager) writeRenamed(ctx context.Context, channel *channel, blo
 	})
 	ll.Info("attempting to register blob by renaming")
 
-	if err := sm.renameBlob(ctx, blob, channel.EncryptionKey, nextName); err != nil {
+	if err := sm.renameBlob(ctx, blob, decryptKey, channel, nextName); err != nil {
 		return fmt.Errorf("renameBlob: %w", err)
 	}
 
@@ -347,14 +335,20 @@ func (sm *streamManager) writeRenamed(ctx context.Context, channel *channel, blo
 	return nil
 }
 
-func (sm *streamManager) renameBlob(ctx context.Context, blob *blobMetadata, encryptionKey string, newName blobFileName) error {
+func (sm *streamManager) renameBlob(
+	ctx context.Context,
+	blob *blobMetadata,
+	decryptKey string,
+	channel *channel,
+	newName blobFileName,
+) error {
 	r, err := sm.bucket.NewReader(ctx, path.Join(sm.bucketPath, blob.Path))
 	if err != nil {
 		return fmt.Errorf("NewReader: %w", err)
 	}
 	w := sm.bucket.NewWriter(ctx, path.Join(sm.bucketPath, string(newName)), sm.objMetadata())
 
-	if err := reencrypt(r, w, blob, encryptionKey, newName); err != nil {
+	if err := reencrypt(r, w, blob, decryptKey, channel, newName); err != nil {
 		return fmt.Errorf("reencrypt: %w", err)
 	} else if err := r.Close(); err != nil {
 		return fmt.Errorf("closing r: %w", err)

--- a/tests/materialize/materialize-snowflake/checks.sh
+++ b/tests/materialize/materialize-snowflake/checks.sh
@@ -6,6 +6,7 @@ fi
 $SED_CMD -i'' 's/@flow_v1\/.\{36\}/<uuid>/g' ${SNAPSHOT}
 $SED_CMD -i'' 's/"Path": ".*"/"Path": "<uuid>"/g' ${SNAPSHOT}
 $SED_CMD -i'' 's/"PipeStartTime": ".\{1,\}"/"PipeStartTime": "<timestamp>"/g' ${SNAPSHOT}
+$SED_CMD -i'' 's/"EncryptionKey": ".*"/"EncryptionKey": "<encryption_key>"/g' ${SNAPSHOT}
 $SED_CMD -i'' 's/"path": ".*"/"path": "<path>"/g' ${SNAPSHOT}
 $SED_CMD -i'' 's/"md5": ".*"/"md5": "<md5>"/g' ${SNAPSHOT}
 $SED_CMD -i'' 's/"chunk_length": [0-9]\+/"chunk_length": "<chunk_length>"/g' ${SNAPSHOT}

--- a/tests/materialize/materialize-snowflake/snapshot.json
+++ b/tests/materialize/materialize-snowflake/snapshot.json
@@ -20,7 +20,8 @@
         "StreamBlobs": null,
         "PipeName": "",
         "PipeFiles": null,
-        "Version": ""
+        "Version": "",
+        "EncryptionKey": "<encryption_key>"
       },
       "all_key_types_part_three": {
         "Table": "all_key_types_part_three",
@@ -29,7 +30,8 @@
         "StreamBlobs": null,
         "PipeName": "",
         "PipeFiles": null,
-        "Version": ""
+        "Version": "",
+        "EncryptionKey": "<encryption_key>"
       },
       "all_key_types_part_two": {
         "Table": "all_key_types_part_two",
@@ -38,7 +40,8 @@
         "StreamBlobs": null,
         "PipeName": "",
         "PipeFiles": null,
-        "Version": ""
+        "Version": "",
+        "EncryptionKey": "<encryption_key>"
       },
       "deletions": {
         "Table": "deletions",
@@ -47,7 +50,8 @@
         "StreamBlobs": null,
         "PipeName": "",
         "PipeFiles": null,
-        "Version": ""
+        "Version": "",
+        "EncryptionKey": "<encryption_key>"
       },
       "duplicate%20keys%20%40%20with%20spaces": {
         "Table": "",
@@ -154,7 +158,8 @@
         ],
         "PipeName": "",
         "PipeFiles": null,
-        "Version": ""
+        "Version": "",
+        "EncryptionKey": "<encryption_key>"
       },
       "duplicate_keys_delta": {
         "Table": "",
@@ -261,7 +266,8 @@
         ],
         "PipeName": "",
         "PipeFiles": null,
-        "Version": ""
+        "Version": "",
+        "EncryptionKey": "<encryption_key>"
       },
       "duplicate_keys_delta_exclude_flow_doc": {
         "Table": "",
@@ -368,7 +374,8 @@
         ],
         "PipeName": "",
         "PipeFiles": null,
-        "Version": ""
+        "Version": "",
+        "EncryptionKey": "<encryption_key>"
       },
       "duplicate_keys_standard": {
         "Table": "duplicate_keys_standard",
@@ -377,7 +384,8 @@
         "StreamBlobs": null,
         "PipeName": "",
         "PipeFiles": null,
-        "Version": ""
+        "Version": "",
+        "EncryptionKey": "<encryption_key>"
       },
       "fields_with_projections": {
         "Table": "fields_with_projections",
@@ -386,7 +394,8 @@
         "StreamBlobs": null,
         "PipeName": "",
         "PipeFiles": null,
-        "Version": ""
+        "Version": "",
+        "EncryptionKey": "<encryption_key>"
       },
       "formatted_strings": {
         "Table": "formatted_strings",
@@ -395,7 +404,8 @@
         "StreamBlobs": null,
         "PipeName": "",
         "PipeFiles": null,
-        "Version": ""
+        "Version": "",
+        "EncryptionKey": "<encryption_key>"
       },
       "many_columns": {
         "Table": "many_columns",
@@ -404,7 +414,8 @@
         "StreamBlobs": null,
         "PipeName": "",
         "PipeFiles": null,
-        "Version": ""
+        "Version": "",
+        "EncryptionKey": "<encryption_key>"
       },
       "multiple_types": {
         "Table": "multiple_types",
@@ -413,7 +424,8 @@
         "StreamBlobs": null,
         "PipeName": "",
         "PipeFiles": null,
-        "Version": ""
+        "Version": "",
+        "EncryptionKey": "<encryption_key>"
       },
       "simple": {
         "Table": "simple",
@@ -422,7 +434,8 @@
         "StreamBlobs": null,
         "PipeName": "",
         "PipeFiles": null,
-        "Version": ""
+        "Version": "",
+        "EncryptionKey": "<encryption_key>"
       },
       "string_escaped_key": {
         "Table": "string_escaped_key",
@@ -431,7 +444,8 @@
         "StreamBlobs": null,
         "PipeName": "",
         "PipeFiles": null,
-        "Version": ""
+        "Version": "",
+        "EncryptionKey": "<encryption_key>"
       },
       "symbols": {
         "Table": "symbols",
@@ -440,7 +454,8 @@
         "StreamBlobs": null,
         "PipeName": "",
         "PipeFiles": null,
-        "Version": ""
+        "Version": "",
+        "EncryptionKey": "<encryption_key>"
       },
       "timezone_datetimes_delta": {
         "Table": "",
@@ -547,7 +562,8 @@
         ],
         "PipeName": "",
         "PipeFiles": null,
-        "Version": ""
+        "Version": "",
+        "EncryptionKey": "<encryption_key>"
       },
       "timezone_datetimes_standard": {
         "Table": "timezone_datetimes_standard",
@@ -556,7 +572,8 @@
         "StreamBlobs": null,
         "PipeName": "",
         "PipeFiles": null,
-        "Version": ""
+        "Version": "",
+        "EncryptionKey": "<encryption_key>"
       },
       "unsigned_bigint": {
         "Table": "unsigned_bigint",
@@ -565,7 +582,8 @@
         "StreamBlobs": null,
         "PipeName": "",
         "PipeFiles": null,
-        "Version": ""
+        "Version": "",
+        "EncryptionKey": "<encryption_key>"
       }
     },
     "mergePatch": true
@@ -582,7 +600,8 @@
         "StreamBlobs": null,
         "PipeName": "",
         "PipeFiles": null,
-        "Version": "ffffffffffffffff"
+        "Version": "ffffffffffffffff",
+        "EncryptionKey": "<encryption_key>"
       },
       "all_key_types_part_three": {
         "Table": "all_key_types_part_three",
@@ -591,7 +610,8 @@
         "StreamBlobs": null,
         "PipeName": "",
         "PipeFiles": null,
-        "Version": "ffffffffffffffff"
+        "Version": "ffffffffffffffff",
+        "EncryptionKey": "<encryption_key>"
       },
       "all_key_types_part_two": {
         "Table": "all_key_types_part_two",
@@ -600,7 +620,8 @@
         "StreamBlobs": null,
         "PipeName": "",
         "PipeFiles": null,
-        "Version": "ffffffffffffffff"
+        "Version": "ffffffffffffffff",
+        "EncryptionKey": "<encryption_key>"
       },
       "deletions": {
         "Table": "deletions",
@@ -609,7 +630,8 @@
         "StreamBlobs": null,
         "PipeName": "",
         "PipeFiles": null,
-        "Version": "ffffffffffffffff"
+        "Version": "ffffffffffffffff",
+        "EncryptionKey": "<encryption_key>"
       },
       "duplicate%20keys%20%40%20with%20spaces": {
         "Table": "",
@@ -716,7 +738,8 @@
         ],
         "PipeName": "",
         "PipeFiles": null,
-        "Version": ""
+        "Version": "",
+        "EncryptionKey": "<encryption_key>"
       },
       "duplicate_keys_delta": {
         "Table": "",
@@ -823,7 +846,8 @@
         ],
         "PipeName": "",
         "PipeFiles": null,
-        "Version": ""
+        "Version": "",
+        "EncryptionKey": "<encryption_key>"
       },
       "duplicate_keys_delta_exclude_flow_doc": {
         "Table": "",
@@ -930,7 +954,8 @@
         ],
         "PipeName": "",
         "PipeFiles": null,
-        "Version": ""
+        "Version": "",
+        "EncryptionKey": "<encryption_key>"
       },
       "duplicate_keys_standard": {
         "Table": "duplicate_keys_standard",
@@ -939,7 +964,8 @@
         "StreamBlobs": null,
         "PipeName": "",
         "PipeFiles": null,
-        "Version": "ffffffffffffffff"
+        "Version": "ffffffffffffffff",
+        "EncryptionKey": "<encryption_key>"
       },
       "fields_with_projections": {
         "Table": "fields_with_projections",
@@ -948,7 +974,8 @@
         "StreamBlobs": null,
         "PipeName": "",
         "PipeFiles": null,
-        "Version": "ffffffffffffffff"
+        "Version": "ffffffffffffffff",
+        "EncryptionKey": "<encryption_key>"
       },
       "formatted_strings": {
         "Table": "formatted_strings",
@@ -957,7 +984,8 @@
         "StreamBlobs": null,
         "PipeName": "",
         "PipeFiles": null,
-        "Version": ""
+        "Version": "",
+        "EncryptionKey": "<encryption_key>"
       },
       "many_columns": {
         "Table": "many_columns",
@@ -966,7 +994,8 @@
         "StreamBlobs": null,
         "PipeName": "",
         "PipeFiles": null,
-        "Version": "ffffffffffffffff"
+        "Version": "ffffffffffffffff",
+        "EncryptionKey": "<encryption_key>"
       },
       "multiple_types": {
         "Table": "multiple_types",
@@ -975,7 +1004,8 @@
         "StreamBlobs": null,
         "PipeName": "",
         "PipeFiles": null,
-        "Version": "ffffffffffffffff"
+        "Version": "ffffffffffffffff",
+        "EncryptionKey": "<encryption_key>"
       },
       "simple": {
         "Table": "simple",
@@ -984,7 +1014,8 @@
         "StreamBlobs": null,
         "PipeName": "",
         "PipeFiles": null,
-        "Version": ""
+        "Version": "",
+        "EncryptionKey": "<encryption_key>"
       },
       "string_escaped_key": {
         "Table": "string_escaped_key",
@@ -993,7 +1024,8 @@
         "StreamBlobs": null,
         "PipeName": "",
         "PipeFiles": null,
-        "Version": "ffffffffffffffff"
+        "Version": "ffffffffffffffff",
+        "EncryptionKey": "<encryption_key>"
       }
     },
     "mergePatch": true
@@ -1108,7 +1140,8 @@
         ],
         "PipeName": "",
         "PipeFiles": null,
-        "Version": ""
+        "Version": "",
+        "EncryptionKey": "<encryption_key>"
       },
       "duplicate_keys_delta": {
         "Table": "",
@@ -1215,7 +1248,8 @@
         ],
         "PipeName": "",
         "PipeFiles": null,
-        "Version": ""
+        "Version": "",
+        "EncryptionKey": "<encryption_key>"
       },
       "duplicate_keys_delta_exclude_flow_doc": {
         "Table": "",
@@ -1322,7 +1356,8 @@
         ],
         "PipeName": "",
         "PipeFiles": null,
-        "Version": ""
+        "Version": "",
+        "EncryptionKey": "<encryption_key>"
       },
       "duplicate_keys_standard": {
         "Table": "duplicate_keys_standard",
@@ -1331,7 +1366,8 @@
         "StreamBlobs": null,
         "PipeName": "",
         "PipeFiles": null,
-        "Version": ""
+        "Version": "",
+        "EncryptionKey": "<encryption_key>"
       }
     },
     "mergePatch": true
@@ -1342,6 +1378,7 @@
   {
     "updated": {
       "duplicate%20keys%20%40%20with%20spaces": {
+        "EncryptionKey": "<encryption_key>",
         "PipeName": "",
         "Query": "",
         "StagedDir": "",
@@ -1448,6 +1485,7 @@
         "Version": ""
       },
       "duplicate_keys_delta": {
+        "EncryptionKey": "<encryption_key>",
         "PipeName": "",
         "Query": "",
         "StagedDir": "",
@@ -1554,6 +1592,7 @@
         "Version": ""
       },
       "duplicate_keys_delta_exclude_flow_doc": {
+        "EncryptionKey": "<encryption_key>",
         "PipeName": "",
         "Query": "",
         "StagedDir": "",
@@ -1660,6 +1699,7 @@
         "Version": ""
       },
       "duplicate_keys_standard": {
+        "EncryptionKey": "<encryption_key>",
         "PipeName": "",
         "Query": "\nCOPY INTO duplicate_keys_standard (\n\tid, flow_published_at, int, str\n) FROM (\n\tSELECT $1[0] AS id, $1[1] AS flow_published_at, $1[2] AS int, $1[3] AS str\n\tFROM <uuid>\n);\n",
         "StagedDir": "<uuid>",


### PR DESCRIPTION
**Description:**

Adds the channel encryption key to the checkpoint.  If the channel encryption key has changed, recreate the blob with the new encryption key decrypting it with the key from the checkpoint.

Consolidate the handling of "blob has wrong format or extension" into the recovery logic.

**Workflow steps:**

No changes

**Documentation links affected:**

None

**Notes for reviewers:**

(anything that might help someone review this PR)

