### PR TITLE
source-braintree-native: fix disbursed/disputed transactions lookback search

### DIFF
--- a/source-braintree-native/source_braintree_native/api/common.py
+++ b/source-braintree-native/source_braintree_native/api/common.py
@@ -169,10 +169,13 @@ def braintree_object_to_dict(braintree_object):
     return data
 
 
-def reduce_window_end(
+def bisect_window(
     start: datetime,
     end: datetime,
 ) -> datetime:
+    """
+    Returns the datetime at the midpoint between start and end.
+    """
     window_size = (end - start) / 2
 
     # Braintree's datetimes have a resolution of seconds, so we remove microseconds from the window size.

--- a/source-braintree-native/source_braintree_native/api/searchable_incremental_resource.py
+++ b/source-braintree-native/source_braintree_native/api/searchable_incremental_resource.py
@@ -17,7 +17,7 @@ from .common import (
     braintree_xml_to_dict,
     process_completed_fetches,
     search_limit_error_message,
-    reduce_window_end,
+    bisect_window,
 )
 from ..models import (
     IncrementalResource,
@@ -99,7 +99,7 @@ async def determine_next_searchable_resource_window_end_by_field(
         if len(ids) < search_limit:
             break
 
-        end = reduce_window_end(start, end)
+        end = bisect_window(start, end)
 
     return end
 

--- a/source-braintree-native/source_braintree_native/api/transactions.py
+++ b/source-braintree-native/source_braintree_native/api/transactions.py
@@ -12,7 +12,7 @@ from .common import (
     HEADERS,
     TRANSACTION_SEARCH_LIMIT,
     braintree_xml_to_dict,
-    reduce_window_end,
+    bisect_window,
 )
 from ..models import (
     IncrementalResource,
@@ -205,7 +205,7 @@ async def _fetch_transaction_ids_with_created_at_windowing(
             if min_created_at is None:
                 min_created_at = max_created_at - timedelta(days=1)
             else:
-                min_created_at = reduce_window_end(min_created_at, max_created_at)
+                min_created_at = bisect_window(min_created_at, max_created_at)
 
         yield (ids, min_created_at, max_created_at)
 


### PR DESCRIPTION
**Description:**

We've observed that when a transaction search hits/exceeds the 50,000 result limit, the returned results are not guaranteed to be complete across the returned `created_at` range. That breaks an assumption the connector relied on when "paging" through disbursed and disputed transactions; it used the `created_at` of the last result of a truncated search as the max `created_at` filter for the next search. This caused the connector to miss updates to disbursed/disputed transactions since the result set itself was inconsistent. We fundamentally can't "page" through a search, so we have to restrict the search criteria until fewer than 50,000 transactions are returned & the results are consistent.

The new disbursed/disputed transaction lookback algorithm narrows the window until results aren't truncated. The algorithm is:
1. Start with the full `created_at` range for a disbursed/disputed transaction date window
2. If results hit the 50k cap, halve the `created_at` window until below the 50k cap.
3. Once uncapped, yield results and shift window to cover older transactions.
4. Repeat until `min_created_at` is `None`, meaning all transactions have been captured.

This refactors both `fetch_transactions_disbursed_between` and `fetch_transactions_disputed_between` to use a shared `_fetch_transaction_ids_with_created_at_windowing` helper since the assumptions .

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

