### PR TITLE
source-salesforce-native: add retry cap for 500 errors to reduce API credit usage

### DIFF
--- a/source-salesforce-native/source_salesforce_native/api.py
+++ b/source-salesforce-native/source_salesforce_native/api.py
@@ -15,7 +15,7 @@ from .bulk_job_manager import (
     MAX_BULK_QUERY_SET_SIZE,
 )
 from .rest_query_manager import RestQueryManager
-from .shared import dt_to_str, str_to_dt, now, VERSION
+from .shared import dt_to_str, str_to_dt, now, should_retry, VERSION
 from .models import (
     FieldDetails,
     FieldDetailsDict,
@@ -64,7 +64,7 @@ async def fetch_object_fields(
     url = f"{instance_url}/services/data/v{VERSION}/sobjects/{name}/describe"
 
     response = SObject.model_validate_json(
-        await http.request(log, url)
+        await http.request(log, url, should_retry=should_retry)
     )
 
     fields = {}

--- a/source-salesforce-native/source_salesforce_native/rest_query_manager.py
+++ b/source-salesforce-native/source_salesforce_native/rest_query_manager.py
@@ -3,7 +3,7 @@ from logging import Logger
 from typing import Any, AsyncGenerator, TypedDict
 
 from estuary_cdk.http import HTTPSession
-from .shared import build_query, str_to_dt, VERSION
+from .shared import build_query, should_retry, str_to_dt, VERSION
 from .models import (
     CursorFields,
     FieldDetailsDict,
@@ -61,7 +61,7 @@ class Query:
         })
 
         response = QueryResponse.model_validate_json(
-            await self.http.request(self.log, url, params=params)
+            await self.http.request(self.log, url, params=params, should_retry=should_retry)
         )
 
         count = 0

--- a/source-salesforce-native/source_salesforce_native/shared.py
+++ b/source-salesforce-native/source_salesforce_native/shared.py
@@ -1,7 +1,17 @@
 from datetime import datetime, UTC
 
+from estuary_cdk.http import Headers
+
 VERSION = "62.0"
 DATETIME_STRING_FORMAT = "%Y-%m-%dT%H:%M:%S"
+
+# Salesforce recommends retrying transient 500 errors with exponential backoff,
+# but limiting retry attempts to avoid burning API credits indefinitely.
+MAX_SERVER_ERROR_RETRY_ATTEMPTS = 5
+
+
+def should_retry(status: int, headers: Headers, body: bytes, attempt: int) -> bool:
+    return attempt < MAX_SERVER_ERROR_RETRY_ATTEMPTS
 
 
 def dt_to_str(dt: datetime) -> str:
@@ -20,7 +30,7 @@ def now() -> datetime:
 
 
 def build_query(
-        object_name: str, 
+        object_name: str,
         fields: list[str],
         cursor_field: str | None = None,
         start: datetime | None = None,


### PR DESCRIPTION
**Description:**

We may have scenarios where the connecter is consuming many API credits from continuous 5xx errors thus causing a death spiral. This limits the number of times we retry before failing.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

