### PR TITLE
source-linkedin-ads-v2: update API version to 202602

### DIFF
--- a/source-linkedin-ads-v2/source_linkedin_ads_v2/streams.py
+++ b/source-linkedin-ads-v2/source_linkedin_ads_v2/streams.py
@@ -19,7 +19,7 @@ from .utils import get_parent_stream_values, transform_data
 
 logger = logging.getLogger("airbyte")
 
-LINKEDIN_VERSION_API = "202502"
+LINKEDIN_VERSION_API = "202602"
 
 
 class LinkedinAdsStream(HttpStream, ABC):


### PR DESCRIPTION
**Description:**

The connector was using API version 202502, which was sunset on 16FEB2026 and caused all existing captures to break. This commit updates the connector to use API version 202602.

No notable breaking changes were seen in the [API changelog](https://learn.microsoft.com/en-us/linkedin/marketing/integrations/recent-changes?view=li-lms-2026-02#february-2026---version-202602-latest) for this API version bump.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

