### PR TITLE
materialize-boilerplate: improve document field error

### DIFF
--- a/materialize-boilerplate/.snapshots/TestValidate
+++ b/materialize-boilerplate/.snapshots/TestValidate
@@ -178,7 +178,7 @@ cannot add or remove selected key fields for standard updates:
 {"Field":"flow_published_at","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The projection has a single scalar type"}
 {"Field":"keyA","Type":1,"TypeString":"FIELD_REQUIRED","Reason":"This field is a key in the current materialization"}
 {"Field":"keyB","Type":1,"TypeString":"FIELD_REQUIRED","Reason":"This field is a key in the current materialization"}
-{"Field":"keyC","Type":5,"TypeString":"FIELD_FORBIDDEN","Reason":"Cannot add a new key location to the field selection of an existing non-delta-updates materialization witout backfilling"}
+{"Field":"keyC","Type":5,"TypeString":"FIELD_FORBIDDEN","Reason":"Cannot add a new key location to the field selection of an existing non-delta-updates materialization without backfilling"}
 {"Field":"multiple","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This field is able to be materialized"}
 {"Field":"nonScalarValue","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This field is able to be materialized"}
 {"Field":"nullValue","Type":5,"TypeString":"FIELD_FORBIDDEN","Reason":"Cannot materialize this field"}


### PR DESCRIPTION
**Description:**

Previously, the constraint would refer to the empty string document field in error messages when coming from no document field:
```
"reason": "The root document must be materialized as field ''"
```

I kept the field as incompatible because this case shouldn't come up often and if it does we aren't fully sure that the destination contains the correct data.

related: https://github.com/estuary/flow/pull/2705
related: https://github.com/estuary/connectors/pull/3925

**Workflow steps:**

No changes

**Documentation links affected:**

None

**Notes for reviewers:**

(anything that might help someone review this PR)

