### PR TITLE
materialize-bigquery: fix error return on success

### DIFF
--- a/materialize-bigquery/query.go
+++ b/materialize-bigquery/query.go
@@ -93,6 +93,7 @@ func (c client) queryIdempotent(
 				log.WithFields(log.Fields{
 					"jobID": jobID,
 				}).Info("previously submitted job finished successfully after waiting")
+				return nil
 			}
 
 			// Other errors will crash the connector and automatically be


### PR DESCRIPTION
**Description:**

If we reach this point, the query has completed successfully.  Return nil instead of leaving the conditional and returning the previous conflict error.

**Workflow steps:**

No changes

**Documentation links affected:**

None

**Notes for reviewers:**

This wasn't causing issues because on recovery the duplicate query would already be completed and it would return on L78.

