### PR TITLE
materialize-iceberg: add alternative naming feature flag

### DIFF
--- a/materialize-iceberg/config_test.go
+++ b/materialize-iceberg/config_test.go
@@ -1,0 +1,38 @@
+package connector
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestLocationSuffix(t *testing.T) {
+	tests := []struct {
+		name      string
+		namespace string
+		table     string
+		style     LocationStyle
+		expected  string
+	}{
+		{
+			name:      "flat style",
+			namespace: "flow",
+			table:     "mytable",
+			style:     FlatLocationStyle,
+			expected:  "flow_mytable_15EEAE2C604ABEC4",
+		},
+		{
+			name:      "nested dot hash style",
+			namespace: "flow",
+			table:     "mytable",
+			style:     NestedDotHashLocationStyle,
+			expected:  "flow/mytable.D7D053D01D253AEB",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual := createLocationSuffix(tt.namespace, tt.table, tt.style)
+			require.Equal(t, tt.expected, actual)
+		})
+	}
+}


### PR DESCRIPTION
**Description:**

Currently the materialization write Iceberg tables as:
  `<base_location>/<namespace>_<table>_<hash>`

This PR adds another style which can be activated by settings the `nested_dot_hash_location_style` feature flag and write tables as:
  `<base_location>/<namespace>/<table>.<hash>`

If this flag is enabled you will need to backfill the materialization.

**Workflow steps:**

To use set `nested_dot_hash_location_style`, if not set on a new materialization you will need to backfill.

**Documentation links affected:**

None

**Notes for reviewers:**

(anything that might help someone review this PR)

