### PR TITLE
source-mysql-batch: Fix `CHAR(n) COLLATE *_bin` handling

### DIFF
--- a/source-mysql-batch/.snapshots/TestCharCollations-Capture
+++ b/source-mysql-batch/.snapshots/TestCharCollations-Capture
@@ -1,0 +1,223 @@
+# ================================
+# Collection "acmeCo/test/test/charcollations_382659": 5 Documents
+# ================================
+{
+  "type": "object",
+  "required": [
+    "_meta",
+    "char_binary",
+    "char_default",
+    "char_utf8mb4_bin",
+    "id",
+    "text_default",
+    "text_utf8mb4_bin",
+    "varchar_default",
+    "varchar_utf8mb4_bin"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "_meta": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "$id": "https://github.com/estuary/connectors/source-mysql-batch/document-metadata",
+      "properties": {
+        "polled": {
+          "type": "string",
+          "format": "date-time",
+          "title": "Polled Timestamp",
+          "description": "The time at which the update query which produced this document as executed."
+        },
+        "index": {
+          "type": "integer",
+          "title": "Result Index",
+          "description": "The index of this document within the query execution which produced it."
+        },
+        "row_id": {
+          "type": "integer",
+          "title": "Row ID",
+          "description": "Row ID of the Document"
+        },
+        "op": {
+          "type": "string",
+          "enum": [
+            "c",
+            "u",
+            "d"
+          ],
+          "title": "Change Operation",
+          "description": "Operation type (c: Create / u: Update / d: Delete)",
+          "default": "u"
+        },
+        "source": {
+          "properties": {
+            "resource": {
+              "type": "string",
+              "description": "Resource name of the binding from which this document was captured."
+            },
+            "schema": {
+              "type": "string",
+              "description": "Database schema from which the document was read."
+            },
+            "table": {
+              "type": "string",
+              "description": "Database table from which the document was read."
+            },
+            "tag": {
+              "type": "string",
+              "description": "Optional 'Source Tag' property as defined in the endpoint configuration."
+            }
+          },
+          "additionalProperties": false,
+          "type": "object",
+          "required": [
+            "resource"
+          ]
+        }
+      },
+      "type": "object",
+      "required": [
+        "polled",
+        "index",
+        "row_id",
+        "source"
+      ],
+      "additionalProperties": false
+    },
+    "char_binary": {
+      "maxLength": 16,
+      "description": "(source type: binary)",
+      "type": [
+        "string"
+      ]
+    },
+    "char_default": {
+      "maxLength": 10,
+      "description": "(source type: char)",
+      "type": [
+        "string"
+      ]
+    },
+    "char_utf8mb4_bin": {
+      "maxLength": 10,
+      "description": "(source type: char)",
+      "type": [
+        "string"
+      ]
+    },
+    "id": {
+      "type": "integer",
+      "description": "(source type: non-nullable int)"
+    },
+    "text_default": {
+      "description": "(source type: text)",
+      "type": [
+        "string"
+      ]
+    },
+    "text_utf8mb4_bin": {
+      "description": "(source type: text)",
+      "type": [
+        "string"
+      ]
+    },
+    "varchar_default": {
+      "maxLength": 255,
+      "description": "(source type: varchar)",
+      "type": [
+        "string"
+      ]
+    },
+    "varchar_utf8mb4_bin": {
+      "maxLength": 255,
+      "description": "(source type: varchar)",
+      "type": [
+        "string"
+      ]
+    }
+  },
+  "x-infer-schema": true
+}
+{
+  "_meta": {
+    "polled": "<TIMESTAMP>",
+    "index": 0,
+    "row_id": 0,
+    "source": {
+      "resource": "test_charcollations_382659",
+      "schema": "test",
+      "table": "charcollations_382659"
+    }
+  },
+  "char_binary": "aGVsbG8AAAAAAA==",
+  "char_default": "hello",
+  "char_utf8mb4_bin": "hello",
+  "id": 0,
+  "text_default": "text_val",
+  "text_utf8mb4_bin": "text_val",
+  "varchar_default": "world",
+  "varchar_utf8mb4_bin": "world"
+}
+{
+  "_meta": {
+    "polled": "<TIMESTAMP>",
+    "index": 1,
+    "row_id": 1,
+    "source": {
+      "resource": "test_charcollations_382659",
+      "schema": "test",
+      "table": "charcollations_382659"
+    }
+  },
+  "char_binary": "c2hvcnQAAAAAAA==",
+  "char_default": "short",
+  "char_utf8mb4_bin": "short",
+  "id": 1,
+  "text_default": "short",
+  "text_utf8mb4_bin": "short",
+  "varchar_default": "short",
+  "varchar_utf8mb4_bin": "short"
+}
+{
+  "_meta": {
+    "polled": "<TIMESTAMP>",
+    "index": 2,
+    "row_id": 2,
+    "source": {
+      "resource": "test_charcollations_382659",
+      "schema": "test",
+      "table": "charcollations_382659"
+    }
+  },
+  "char_binary": "AAAAAAAAAAAAAA==",
+  "char_default": "",
+  "char_utf8mb4_bin": "",
+  "id": 2,
+  "text_default": "",
+  "text_utf8mb4_bin": "",
+  "varchar_default": "",
+  "varchar_utf8mb4_bin": ""
+}
+{
+  "_meta": {
+    "polled": "<TIMESTAMP>",
+    "index": 3,
+    "row_id": 3,
+    "source": {
+      "resource": "test_charcollations_382659",
+      "schema": "test",
+      "table": "charcollations_382659"
+    }
+  },
+  "char_binary": null,
+  "char_default": null,
+  "char_utf8mb4_bin": null,
+  "id": 3,
+  "text_default": null,
+  "text_utf8mb4_bin": null,
+  "varchar_default": null,
+  "varchar_utf8mb4_bin": null
+}
+# ================================
+# Final State Checkpoint
+# ================================
+{"bindingStateV1":{"test_charcollations_382659":{"CursorNames":["id"],"CursorValues":[3],"DocumentCount":4,"LastPolled":"<TIMESTAMP>"}}}
+

--- a/source-mysql-batch/.snapshots/TestCharCollations-Discovery
+++ b/source-mysql-batch/.snapshots/TestCharCollations-Discovery
@@ -1,0 +1,155 @@
+Binding 0:
+{
+    "resource_config_json": {
+      "name": "test_charcollations_382659",
+      "schema": "test",
+      "table": "charcollations_382659",
+      "cursor": [
+        "id"
+      ]
+    },
+    "resource_path": [
+      "test_charcollations_382659"
+    ],
+    "collection": {
+      "name": "acmeCo/test/test/charcollations_382659",
+      "read_schema_json": {
+        "type": "object",
+        "required": [
+          "_meta",
+          "id"
+        ],
+        "properties": {
+          "_meta": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$id": "https://github.com/estuary/connectors/source-mysql-batch/document-metadata",
+            "properties": {
+              "polled": {
+                "type": "string",
+                "format": "date-time",
+                "title": "Polled Timestamp",
+                "description": "The time at which the update query which produced this document as executed."
+              },
+              "index": {
+                "type": "integer",
+                "title": "Result Index",
+                "description": "The index of this document within the query execution which produced it."
+              },
+              "row_id": {
+                "type": "integer",
+                "title": "Row ID",
+                "description": "Row ID of the Document"
+              },
+              "op": {
+                "type": "string",
+                "enum": [
+                  "c",
+                  "u",
+                  "d"
+                ],
+                "title": "Change Operation",
+                "description": "Operation type (c: Create / u: Update / d: Delete)",
+                "default": "u"
+              },
+              "source": {
+                "properties": {
+                  "resource": {
+                    "type": "string",
+                    "description": "Resource name of the binding from which this document was captured."
+                  },
+                  "schema": {
+                    "type": "string",
+                    "description": "Database schema from which the document was read."
+                  },
+                  "table": {
+                    "type": "string",
+                    "description": "Database table from which the document was read."
+                  },
+                  "tag": {
+                    "type": "string",
+                    "description": "Optional 'Source Tag' property as defined in the endpoint configuration."
+                  }
+                },
+                "type": "object",
+                "required": [
+                  "resource"
+                ]
+              }
+            },
+            "type": "object",
+            "required": [
+              "polled",
+              "index",
+              "row_id",
+              "source"
+            ]
+          },
+          "char_binary": {
+            "maxLength": 16,
+            "description": "(source type: binary)",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "char_default": {
+            "maxLength": 10,
+            "description": "(source type: char)",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "char_utf8mb4_bin": {
+            "maxLength": 10,
+            "description": "(source type: char)",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "id": {
+            "type": "integer",
+            "description": "(source type: non-nullable int)"
+          },
+          "text_default": {
+            "description": "(source type: text)",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "text_utf8mb4_bin": {
+            "description": "(source type: text)",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "varchar_default": {
+            "maxLength": 255,
+            "description": "(source type: varchar)",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "varchar_utf8mb4_bin": {
+            "maxLength": 255,
+            "description": "(source type: varchar)",
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "x-infer-schema": true
+      },
+      "key": [
+        "/id"
+      ],
+      "projections": null
+    },
+    "state_key": "test_charcollations_382659"
+  }
+

--- a/source-mysql-batch/driver.go
+++ b/source-mysql-batch/driver.go
@@ -630,7 +630,7 @@ func (c *capture) poll(ctx context.Context, binding *bindingInfo) error {
 		rowValues[0] = metadata
 		for idx, val := range row {
 			var field = result.Fields[idx]
-			var translatedValue, err = translateMySQLValue(val.Value(), field.Type, field.Flag)
+			var translatedValue, err = translateMySQLValue(val.Value(), field.Type, field.Charset)
 			if err != nil {
 				return fmt.Errorf("error translating column %q value: %w", string(field.Name), err)
 			}


### PR DESCRIPTION
**Description:**

Previously we added logic to serialize string/blob result types differently depending on the value of the `BINARY_FLAG` flat bit on the result. This was incorrect, because that flag actually means that a binary collation order is used for a given column.

The correct way to check whether a column contains binary data vs text data is by looking for character set number 63. See https://dev.mysql.com/doc/c-api/8.0/en/c-api-data-structures.html which explicitly says that:

> To distinguish between binary and nonbinary data for string data
> types, check whether the charsetnr value is 63. If so, the character
> set is binary, which indicates binary rather than nonbinary data.
> This enables you to distinguish BINARY from CHAR, VARBINARY from
> VARCHAR, and the BLOB types from the TEXT types.