### PR TITLE
materialize-s3-iceberg: add `glue_id` config setting

### DIFF
--- a/materialize-s3-iceberg/.snapshots/TestSpec
+++ b/materialize-s3-iceberg/.snapshots/TestSpec
@@ -30,6 +30,20 @@
             ],
             "title": "Catalog Type",
             "type": "string"
+          },
+          "glue_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Glue Catalog ID to use. If not specified, defaults to the account ID of the configured credentials.",
+            "order": 1,
+            "title": "Glue Catalog ID"
           }
         },
         "title": "AWS Glue",

--- a/materialize-s3-iceberg/driver.go
+++ b/materialize-s3-iceberg/driver.go
@@ -53,6 +53,9 @@ type config struct {
 type catalogConfig struct {
 	CatalogType catalogType `json:"catalog_type"`
 
+	// Glue catalog configuration.
+	GlueID string `json:"glue_id,omitempty"`
+
 	// Rest catalog configuration.
 	URI        string `json:"uri,omitempty"`
 	Credential string `json:"credential,omitempty"`

--- a/materialize-s3-iceberg/iceberg-ctl/iceberg_ctl/__main__.py
+++ b/materialize-s3-iceberg/iceberg-ctl/iceberg_ctl/__main__.py
@@ -85,15 +85,16 @@ def run(
                 )
 
             case GlueCatalogConfig():
-                ctx.obj["catalog"] = GlueCatalog(
-                    "default",
-                    **{
-                        "client.region": cfg.region,
-                        "client.access-key-id": cfg.aws_access_key_id,
-                        "client.secret-access-key": cfg.aws_secret_access_key,
-                        PY_IO_IMPL: "pyiceberg.io.fsspec.FsspecFileIO",  # use S3 file IO instead of Arrow
-                    },
-                )
+                glue_props = {
+                    "client.region": cfg.region,
+                    "client.access-key-id": cfg.aws_access_key_id,
+                    "client.secret-access-key": cfg.aws_secret_access_key,
+                    PY_IO_IMPL: "pyiceberg.io.fsspec.FsspecFileIO",  # use S3 file IO instead of Arrow
+                }
+                if cfg.catalog.glue_id:
+                    glue_props["glue.id"] = cfg.catalog.glue_id
+
+                ctx.obj["catalog"] = GlueCatalog("default", **glue_props)
 
             case _:
                 raise Exception(f"unhandled catalog type: {cfg.catalog.catalog_type}")

--- a/materialize-s3-iceberg/iceberg-ctl/iceberg_ctl/models.py
+++ b/materialize-s3-iceberg/iceberg-ctl/iceberg_ctl/models.py
@@ -47,6 +47,12 @@ class GlueCatalogConfig(BaseModel):
         default="AWS Glue",
         json_schema_extra={"type": "string"}
     )
+    glue_id: Optional[str] = Field(
+        default=None,
+        title="Glue Catalog ID",
+        description="Glue Catalog ID to use. If not specified, defaults to the account ID of the configured credentials.",
+        json_schema_extra={"order": 1},
+    )
 
 class AdvancedConfig(BaseModel):
     feature_flags: Optional[str] = Field(


### PR DESCRIPTION
**Description:**

Enables cross-account Glue catalog access. This supports the use case of writing Iceberg data to a partner's S3 bucket and registering tables in their Glue catalog.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

The connector's documentation should be updated to include the new `glue_id` config option.

**Notes for reviewers:**

Tested on a development stack. Confirmed the Glue catalog identified by the configured `glue_id` is used by the connector, and that leaving the `glue_id` empty defaults to the existing behavior of using the configured credential's own account id as the `glue_id`.