### PR TITLE
source-shopify-native: set composite key config default to True

### DIFF
--- a/source-shopify-native/source_shopify_native/models.py
+++ b/source-shopify-native/source_shopify_native/models.py
@@ -128,7 +128,7 @@ class EndpointConfig(BaseModel):
             ),
         ]
         should_use_composite_key: bool = Field(
-            default=False,
+            default=True,
             title="Use Composite Key",
             description=(
                 "Controls whether collection keys include the store identifier (/_meta/store). "

--- a/source-shopify-native/tests/snapshots/snapshots__discover__capture.stdout.json
+++ b/source-shopify-native/tests/snapshots/snapshots__discover__capture.stdout.json
@@ -56,6 +56,7 @@
       "x-infer-schema": true
     },
     "key": [
+      "/_meta/store",
       "/id"
     ]
   },
@@ -116,6 +117,7 @@
       "x-infer-schema": true
     },
     "key": [
+      "/_meta/store",
       "/id"
     ]
   },
@@ -176,6 +178,7 @@
       "x-infer-schema": true
     },
     "key": [
+      "/_meta/store",
       "/id"
     ]
   },
@@ -236,6 +239,7 @@
       "x-infer-schema": true
     },
     "key": [
+      "/_meta/store",
       "/id"
     ]
   },
@@ -296,6 +300,7 @@
       "x-infer-schema": true
     },
     "key": [
+      "/_meta/store",
       "/id"
     ]
   },
@@ -356,6 +361,7 @@
       "x-infer-schema": true
     },
     "key": [
+      "/_meta/store",
       "/id"
     ]
   },
@@ -416,6 +422,7 @@
       "x-infer-schema": true
     },
     "key": [
+      "/_meta/store",
       "/id"
     ]
   },
@@ -476,6 +483,7 @@
       "x-infer-schema": true
     },
     "key": [
+      "/_meta/store",
       "/id"
     ]
   },
@@ -536,6 +544,7 @@
       "x-infer-schema": true
     },
     "key": [
+      "/_meta/store",
       "/id"
     ]
   },
@@ -596,6 +605,7 @@
       "x-infer-schema": true
     },
     "key": [
+      "/_meta/store",
       "/id"
     ]
   },
@@ -656,6 +666,7 @@
       "x-infer-schema": true
     },
     "key": [
+      "/_meta/store",
       "/id"
     ]
   },
@@ -716,6 +727,7 @@
       "x-infer-schema": true
     },
     "key": [
+      "/_meta/store",
       "/id"
     ]
   },
@@ -776,6 +788,7 @@
       "x-infer-schema": true
     },
     "key": [
+      "/_meta/store",
       "/id"
     ]
   },
@@ -836,6 +849,7 @@
       "x-infer-schema": true
     },
     "key": [
+      "/_meta/store",
       "/id"
     ]
   },
@@ -896,6 +910,7 @@
       "x-infer-schema": true
     },
     "key": [
+      "/_meta/store",
       "/id"
     ]
   },
@@ -956,6 +971,7 @@
       "x-infer-schema": true
     },
     "key": [
+      "/_meta/store",
       "/id"
     ]
   },
@@ -1016,6 +1032,7 @@
       "x-infer-schema": true
     },
     "key": [
+      "/_meta/store",
       "/id"
     ]
   },
@@ -1076,6 +1093,7 @@
       "x-infer-schema": true
     },
     "key": [
+      "/_meta/store",
       "/id"
     ]
   },
@@ -1136,6 +1154,7 @@
       "x-infer-schema": true
     },
     "key": [
+      "/_meta/store",
       "/id"
     ]
   },
@@ -1196,6 +1215,7 @@
       "x-infer-schema": true
     },
     "key": [
+      "/_meta/store",
       "/id"
     ]
   },
@@ -1256,6 +1276,7 @@
       "x-infer-schema": true
     },
     "key": [
+      "/_meta/store",
       "/id"
     ]
   },
@@ -1316,6 +1337,7 @@
       "x-infer-schema": true
     },
     "key": [
+      "/_meta/store",
       "/id"
     ]
   },
@@ -1376,6 +1398,7 @@
       "x-infer-schema": true
     },
     "key": [
+      "/_meta/store",
       "/id"
     ]
   },
@@ -1436,6 +1459,7 @@
       "x-infer-schema": true
     },
     "key": [
+      "/_meta/store",
       "/id"
     ]
   }

--- a/source-shopify-native/tests/snapshots/snapshots__spec__capture.stdout.json
+++ b/source-shopify-native/tests/snapshots/snapshots__spec__capture.stdout.json
@@ -33,7 +33,7 @@
               "type": "string"
             },
             "should_use_composite_key": {
-              "default": false,
+              "default": true,
               "description": "Controls whether collection keys include the store identifier (/_meta/store). Enabled by default for new captures. Automatically set to false for legacy single-store captures during migration. Must be set to true (with a full backfill / dataflow reset of all bindings) before adding additional stores to a legacy capture.",
               "title": "Use Composite Key",
               "type": "boolean"

--- a/source-shopify-native/tests/test_state_migration.py
+++ b/source-shopify-native/tests/test_state_migration.py
@@ -511,7 +511,7 @@ class TestEndpointConfigMigration:
         })
         assert config._was_migrated is False
         assert config._legacy_store is None
-        assert config.advanced.should_use_composite_key is False
+        assert config.advanced.should_use_composite_key is True
 
     def test_duplicate_stores_rejected(self):
         with pytest.raises(ValueError, match="Duplicate store names"):


### PR DESCRIPTION
**Description:**

Sets the default value of `advanced.should_use_composite_key` to `True`. This was originally `False` to prevent existing captures from having issues during online migration.

This will be merged once all production captures are verified to be migrated.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

