### PR TITLE
source-mongodb: use fullDocument: WhenAvailable, check presence

### DIFF
--- a/bson-transcoder/src/main.rs
+++ b/bson-transcoder/src/main.rs
@@ -11,7 +11,7 @@ use event::{
     get_split_info, is_document_operation, process_change_event, process_raw_document,
     ChangeEvent, FragmentAccumulator,
 };
-use protocol::{read_input_message, write_document_bytes, write_skip, ReadResult};
+use protocol::{read_input_message, write_document_bytes, write_skip, write_skip_no_full_document, ReadResult};
 
 // Thread-local reusable buffers for JSON serialization and payload building
 thread_local! {
@@ -117,8 +117,10 @@ fn main() -> Result<()> {
                             // events where FullDocument is null. Another change event of type
                             // delete will eventually come and delete the document.
                             if event.operation_type != "delete" && event.full_document.is_none() {
+                                let db = event.database.to_owned();
+                                let coll = event.collection.to_owned();
                                 accumulator = None;
-                                write_skip(&mut stdout)?;
+                                write_skip_no_full_document(&mut stdout, &db, &coll)?;
                                 continue;
                             }
 
@@ -165,7 +167,10 @@ fn main() -> Result<()> {
                     // events where FullDocument is null. Another change event of type
                     // delete will eventually come and delete the document.
                     if op_type != "delete" && raw_doc.get_document("fullDocument").is_err() {
-                        write_skip(&mut stdout)?;
+                        let ns = raw_doc.get_document("ns").map_err(|_| Error::MissingField("ns"))?;
+                        let db = ns.get_str("db").map_err(|_| Error::MissingField("ns.db"))?;
+                        let coll = ns.get_str("coll").map_err(|_| Error::MissingField("ns.coll"))?;
+                        write_skip_no_full_document(&mut stdout, db, coll)?;
                         continue;
                     }
 

--- a/bson-transcoder/src/protocol.rs
+++ b/bson-transcoder/src/protocol.rs
@@ -10,6 +10,7 @@ use crate::{Error, Result, PAYLOAD_BUFFER};
 // Binary protocol output message type discriminators
 const MSG_TYPE_SKIP: u8 = 0x01;
 const MSG_TYPE_DOCUMENT: u8 = 0x02;
+const MSG_TYPE_SKIP_NO_FULL_DOCUMENT: u8 = 0x03;
 
 // Binary protocol input message type discriminators
 const INPUT_TYPE_CHANGE_EVENT: u8 = 0x01;
@@ -126,6 +127,23 @@ fn write_frame(writer: &mut impl Write, payload: &[u8]) -> io::Result<()> {
 /// Write a skip message (1 byte: type only)
 pub fn write_skip(writer: &mut impl Write) -> io::Result<()> {
     write_frame(writer, &[MSG_TYPE_SKIP])
+}
+
+/// Write a skip message indicating fullDocument was missing for a non-delete event.
+/// Format: [type: 0x03][db_len: u8][db][coll_len: u8][coll]
+pub fn write_skip_no_full_document(
+    writer: &mut impl Write,
+    database: &str,
+    collection: &str,
+) -> io::Result<()> {
+    let payload_size = 1 + 1 + database.len() + 1 + collection.len();
+    let mut payload = Vec::with_capacity(payload_size);
+    payload.push(MSG_TYPE_SKIP_NO_FULL_DOCUMENT);
+    payload.push(database.len() as u8);
+    payload.extend_from_slice(database.as_bytes());
+    payload.push(collection.len() as u8);
+    payload.extend_from_slice(collection.as_bytes());
+    write_frame(writer, &payload)
 }
 
 /// Build a document message payload into the provided buffer.
@@ -387,5 +405,21 @@ mod tests {
         let parsed: serde_json::Value = serde_json::from_slice(json_bytes).unwrap();
         assert_eq!(parsed["_id"], "abc123");
         assert_eq!(parsed["name"], "John Doe");
+    }
+
+    #[test]
+    fn test_write_skip_no_full_document() {
+        let mut buf = Vec::new();
+        write_skip_no_full_document(&mut buf, "mydb", "mycoll").unwrap();
+
+        // Parse frame
+        let frame_len = u32::from_le_bytes([buf[0], buf[1], buf[2], buf[3]]) as usize;
+        let payload = &buf[4..4 + frame_len];
+
+        assert_eq!(payload[0], MSG_TYPE_SKIP_NO_FULL_DOCUMENT);
+        assert_eq!(payload[1], 4); // db length
+        assert_eq!(&payload[2..6], b"mydb");
+        assert_eq!(payload[6], 6); // coll length
+        assert_eq!(&payload[7..13], b"mycoll");
     }
 }

--- a/source-mongodb/change_stream.go
+++ b/source-mongodb/change_stream.go
@@ -108,8 +108,8 @@ func (c *capture) initializeStreams(
 
 		fullDocOpt := options.UpdateLookup
 		if fullDocRequired[db] {
-			logEntry.Info("using fullDocument 'required' mode (changeStreamPreAndPostImages enabled on all collections)")
-			fullDocOpt = options.Required
+			logEntry.Info("using fullDocument 'whenAvailable' mode (changeStreamPreAndPostImages enabled on all collections)")
+			fullDocOpt = options.WhenAvailable
 		}
 		opts := options.ChangeStream().SetFullDocument(fullDocOpt)
 		if maxAwaitTime != nil {
@@ -430,6 +430,19 @@ func (c *capture) processBatch(
 			return primitive.Timestamp{}, fmt.Errorf("extracting timestamp from resume token: %w", err)
 		} else {
 			lastOpTime = opTime
+		}
+
+		if resp.IsSkip && resp.FullDocumentMissing {
+			rid := resourceId(resp.Database, resp.Collection)
+			if _, tracked := c.trackedChangeStreamBindings[rid]; tracked && c.fullDocRequired[resp.Database] {
+				return primitive.Timestamp{}, fmt.Errorf(
+					"fullDocument was missing for a change event on %s.%s: the collection must have changeStreamPreAndPostImages enabled",
+					resp.Database, resp.Collection,
+				)
+			}
+			// Untracked binding or UpdateLookup database: null fullDocument is a
+			// known race condition (doc deleted between update and lookup).
+			continue
 		}
 
 		if resp.IsSkip {

--- a/source-mongodb/change_stream_test.go
+++ b/source-mongodb/change_stream_test.go
@@ -59,6 +59,7 @@ func TestPullStream(t *testing.T) {
 		pullTimes       int
 		wantSent        []string
 		wantEventCount  int
+		wantErr         string // if non-empty, expect processBatch to return an error containing this string
 	}{
 		{
 			name: "one document",
@@ -112,6 +113,43 @@ func TestPullStream(t *testing.T) {
 			wantEventCount:  2,
 		},
 		{
+			name: "fullDocument missing on tracked binding with fullDocRequired errors",
+			setup: func(t *testing.T) {
+				// Collection WITHOUT changeStreamPreAndPostImages but fullDocRequired is set.
+				// With whenAvailable, update events on collections without the flag will have
+				// null fullDocument since there is no stored post-image to return.
+				insertDoc(t, testColl1, 1)
+				_, err := client.Database(testDb).Collection(testColl1).UpdateOne(ctx,
+					bson.D{{Key: "_id", Value: 1}},
+					bson.D{{Key: "$set", Value: bson.D{{Key: "v", Value: true}}}})
+				require.NoError(t, err)
+			},
+			fullDocRequired: map[string]bool{testDb: true},
+			pullTimes:       5,
+			wantErr:         "changeStreamPreAndPostImages",
+		},
+		{
+			name: "fullDocument missing on untracked collection is silently ignored",
+			setup: func(t *testing.T) {
+				// testColl1 is tracked and has changeStreamPreAndPostImages enabled.
+				// testColl3 is NOT tracked and does NOT have the flag. With whenAvailable,
+				// an update on testColl3 produces a null fullDocument event in the
+				// database-level change stream. This should be silently ignored since
+				// testColl3 is not a tracked binding.
+				require.NoError(t, client.Database(testDb).CreateCollection(ctx, testColl1, &options.CreateCollectionOptions{ChangeStreamPreAndPostImages: bson.D{{Key: "enabled", Value: true}}}))
+				insertDoc(t, testColl3, 1)
+				_, err := client.Database(testDb).Collection(testColl3).UpdateOne(ctx,
+					bson.D{{Key: "_id", Value: 1}},
+					bson.D{{Key: "$set", Value: bson.D{{Key: "v", Value: true}}}})
+				require.NoError(t, err)
+				insertDoc(t, testColl1, 1)
+			},
+			fullDocRequired: map[string]bool{testDb: true},
+			pullTimes:       3,
+			wantSent:        []string{cp, "1", cp},
+			wantEventCount:  3, // insert on coll3 (skipped: untracked) + update on coll3 (skipped: untracked, no fullDoc) + insert on coll1 (emitted)
+		},
+		{
 			name: "split fragments",
 			setup: func(t *testing.T) {
 				require.NoError(t, client.Database(testDb).CreateCollection(ctx, testColl1, &options.CreateCollectionOptions{ChangeStreamPreAndPostImages: bson.D{{Key: "enabled", Value: true}}}))
@@ -155,6 +193,12 @@ func TestPullStream(t *testing.T) {
 			t.Cleanup(func() { transcoder.Stop() })
 
 			srv := &testServer{}
+
+			fullDocRequired := tt.fullDocRequired
+			if fullDocRequired == nil {
+				fullDocRequired = map[string]bool{}
+			}
+
 			c := capture{
 				client:     client,
 				output:     &boilerplate.PullOutput{Connector_CaptureServer: srv},
@@ -163,13 +207,9 @@ func TestPullStream(t *testing.T) {
 					resourceId(testDb, testColl1): bindings[0],
 					resourceId(testDb, testColl2): bindings[1],
 				},
+				fullDocRequired:      fullDocRequired,
 				state:                captureState{DatabaseResumeTokens: map[string]bson.Raw{}},
 				lastEventClusterTime: map[string]primitive.Timestamp{},
-			}
-
-			fullDocRequired := tt.fullDocRequired
-			if fullDocRequired == nil {
-				fullDocRequired = map[string]bool{}
 			}
 			streams, err := c.initializeStreams(ctx, bindings, nil, true, true, false, map[string][]string{}, fullDocRequired)
 			require.NoError(t, err)
@@ -206,12 +246,16 @@ func TestPullStream(t *testing.T) {
 			tt.setup(t)
 
 			// Pull and process batches until we've seen pullTimes batch completions.
+			var processErr error
 			batchesCompleted := 0
 			for batch := range batches {
 				require.NoError(t, batch.err)
 
 				_, err := c.processBatch(ctx, stream, batch)
-				require.NoError(t, err)
+				if err != nil {
+					processErr = err
+					break
+				}
 
 				batchesCompleted++
 				if batchesCompleted >= tt.pullTimes {
@@ -222,6 +266,13 @@ func TestPullStream(t *testing.T) {
 			// Stop producer
 			cancelProducer()
 			<-producerDone
+
+			if tt.wantErr != "" {
+				require.Error(t, processErr)
+				require.Contains(t, processErr.Error(), tt.wantErr)
+				return
+			}
+			require.NoError(t, processErr)
 
 			// MongoDB may non-deterministically batch change events together or
 			// separately, and map iteration order in processBatch can vary the

--- a/source-mongodb/pull.go
+++ b/source-mongodb/pull.go
@@ -170,6 +170,7 @@ func (d *driver) Pull(open *pc.Request_Open, stream *boilerplate.PullOutput) err
 		output:                      stream,
 		state:                       prevState,
 		trackedChangeStreamBindings: trackedChangeStreamBindings,
+		fullDocRequired:             fullDocRequired,
 		lastEventClusterTime:        make(map[string]primitive.Timestamp),
 	}
 
@@ -290,6 +291,7 @@ type capture struct {
 	client                      *mongo.Client
 	output                      *boilerplate.PullOutput
 	trackedChangeStreamBindings map[string]bindingInfo
+	fullDocRequired             map[string]bool
 	transcoder                  *Transcoder
 
 	// mu provides synchronization for values that are accessed by concurrent backfill and change

--- a/source-mongodb/transcoder.go
+++ b/source-mongodb/transcoder.go
@@ -18,8 +18,9 @@ import (
 
 // Binary protocol output message type discriminators
 const (
-	msgTypeSkip     uint8 = 0x01
-	msgTypeDocument uint8 = 0x02
+	msgTypeSkip               uint8 = 0x01
+	msgTypeDocument           uint8 = 0x02
+	msgTypeSkipNoFullDocument uint8 = 0x03
 )
 
 // Binary protocol input message type discriminators
@@ -251,6 +252,8 @@ func (t *Transcoder) TranscodeRawDocuments(docs []RawDocumentInput) ([]*Transcod
 type TranscoderResponse struct {
 	// IsSkip is true if the event was skipped (not a document event).
 	IsSkip bool
+	// FullDocumentMissing is true when the skip was due to a missing fullDocument on a non-delete event.
+	FullDocumentMissing bool
 	// Document is the JSON document (only set if IsSkip is false).
 	Document json.RawMessage
 	// CompletedSplitEvent is true if this document completed a split event (multiple fragments merged).
@@ -364,6 +367,36 @@ func (t *Transcoder) readResponse() (*TranscoderResponse, error) {
 		// Skip message - just 1 byte, no additional data
 		return &TranscoderResponse{
 			IsSkip: true,
+		}, nil
+
+	case msgTypeSkipNoFullDocument:
+		// Skip due to missing fullDocument on a non-delete event.
+		// Payload format: [type: u8][db_len: u8][db][coll_len: u8][coll]
+		offset := 1 // skip type byte
+		if offset >= len(payload) {
+			return nil, fmt.Errorf("skipNoFullDocument message too short for db_len")
+		}
+		dbLen := int(payload[offset])
+		offset++
+		if offset+dbLen > len(payload) {
+			return nil, fmt.Errorf("skipNoFullDocument db length exceeds payload")
+		}
+		database := string(payload[offset : offset+dbLen])
+		offset += dbLen
+		if offset >= len(payload) {
+			return nil, fmt.Errorf("skipNoFullDocument message too short for coll_len")
+		}
+		collLen := int(payload[offset])
+		offset++
+		if offset+collLen > len(payload) {
+			return nil, fmt.Errorf("skipNoFullDocument collection length exceeds payload")
+		}
+		collection := string(payload[offset : offset+collLen])
+		return &TranscoderResponse{
+			IsSkip:              true,
+			FullDocumentMissing: true,
+			Database:            database,
+			Collection:          collection,
 		}, nil
 
 	case msgTypeDocument:


### PR DESCRIPTION
**Description:**

- If one collection, even for non-enabled bindings does not have `changeStreamPreAndPostImages` enabled, we would error out, unless `exclusiveCollectionFilter` is also enabled.
- With this pull-request, we will ask for `FullDocument: WhenAvailable`, so that if the document belongs to a disabled binding, we do not error out, and if it belongs to an enabled binding, we programmatically check for the presence of FullDocument and verify it on our side.
- Added test for both cases

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

