### PR TITLE
source-intercom-native: add configurable API version setting

### DIFF
--- a/source-intercom-native/source_intercom_native/api.py
+++ b/source-intercom-native/source_intercom_native/api.py
@@ -27,6 +27,7 @@ from .models import (
 
 
 API = "https://api.intercom.io"
+API_VERSION_HEADER = "Intercom-Version"
 COMPANIES_LIST_LIMIT = 10_000
 
 COMPANIES_LIST_LIMIT_REACHED_REGEX = r"page limit reached, please use scroll API"
@@ -49,13 +50,14 @@ async def snapshot_resources(
         path: str,
         response_field: str,
         query_param: str | None,
+        api_version: str,
         log: Logger,
 ) -> AsyncGenerator[IntercomResource, None]:
     url = f"{API}/{path}"
     params = None if query_param is None else {"model": query_param}
 
     response = json.loads(
-        await http.request(log, url, params=params)
+        await http.request(log, url, params=params, headers={API_VERSION_HEADER: api_version})
     )
 
     resources = TypeAdapter(list[IntercomResource]).validate_python(response[f'{response_field}'])
@@ -193,12 +195,13 @@ def _is_large_date_window(start: int, end: int) -> bool:
 async def _hydrate_contact(
     http: HTTPSession,
     contact: Contact,
+    api_version: str,
     log: Logger,
 ) -> Contact:
     if contact.tags.has_more:
         url = f"{API}/contacts/{contact.id}/tags"
         response = ContactTagsResponse.model_validate_json(
-            await http.request(log, url)
+            await http.request(log, url, headers={API_VERSION_HEADER: api_version})
         )
 
         # Tags and nested tags have different shapes. We have to transform tags into nested tags
@@ -221,6 +224,7 @@ async def fetch_contacts(
     http: HTTPSession,
     window_size: int,
     page_size: int,
+    api_version: str,
     log: Logger,
     log_cursor: LogCursor,
 ) -> AsyncGenerator[TimestampedResource | LogCursor, None]:
@@ -239,7 +243,7 @@ async def fetch_contacts(
     pagination_ended_early = False
     while True:
         response = ContactsSearchResponse.model_validate_json(
-                await http.request(log, url, "POST", json=body)
+                await http.request(log, url, "POST", json=body, headers={API_VERSION_HEADER: api_version})
         )
 
         page_num = response.pages.page
@@ -270,7 +274,7 @@ async def fetch_contacts(
             if updated_at > start:
                 # Nested subresources within a contact are capped at 10 elements, even if more exist.
                 # We hydrate the contact with the additional subresources if they aren't all present.
-                yield await _hydrate_contact(http, contact, log)
+                yield await _hydrate_contact(http, contact, api_version, log)
 
         if pagination_ended_early or response.pages.next is None:
             break
@@ -287,6 +291,7 @@ async def fetch_contacts(
 async def fetch_tickets(
     http: HTTPSession,
     page_size: int,
+    api_version: str,
     log: Logger,
     log_cursor: LogCursor,
 ) -> AsyncGenerator[TimestampedResource | LogCursor, None]:
@@ -302,7 +307,7 @@ async def fetch_tickets(
 
     while True:
         response = TicketsSearchResponse.model_validate_json(
-                await http.request(log, url, "POST", json=body)
+                await http.request(log, url, "POST", json=body, headers={API_VERSION_HEADER: api_version})
         )
 
         page_num = response.pages.page
@@ -340,6 +345,7 @@ async def fetch_tickets(
 async def fetch_conversations(
     http: HTTPSession,
     page_size: int,
+    api_version: str,
     log: Logger,
     log_cursor: LogCursor,
 ) -> AsyncGenerator[TimestampedResource | LogCursor, None]:
@@ -357,7 +363,7 @@ async def fetch_conversations(
 
     while True:
         response = ConversationsSearchResponse.model_validate_json(
-                await http.request(log, url, "POST", json=body)
+                await http.request(log, url, "POST", json=body, headers={API_VERSION_HEADER: api_version})
         )
 
         page_num = response.pages.page
@@ -396,18 +402,19 @@ async def fetch_conversations(
 async def fetch_conversations_parts(
     http: HTTPSession,
     page_size: int,
+    api_version: str,
     log: Logger,
     log_cursor: LogCursor,
 ) -> AsyncGenerator[TimestampedResource | LogCursor, None]:
     conversation_ids: list[str] = []
 
-    async for conversation_or_dt in fetch_conversations(http, page_size, log, log_cursor):
+    async for conversation_or_dt in fetch_conversations(http, page_size, api_version, log, log_cursor):
         if isinstance(conversation_or_dt, TimestampedResource):
             conversation_ids.append(conversation_or_dt.id)
         else:
             for coro in asyncio.as_completed(
                 [
-                    _fetch_parts(http, log, conversation_id)
+                    _fetch_parts(http, conversation_id, api_version, log)
                     for conversation_id in conversation_ids
                 ]
             ):
@@ -422,14 +429,15 @@ async def fetch_conversations_parts(
 
 async def _fetch_parts(
         http: HTTPSession,
+        conversation_id: str,
+        api_version: str,
         log: Logger,
-        conversation_id: str
 ) -> list[TimestampedResource]:
     async with parts_semaphore:
         url = f"{API}/conversations/{conversation_id}"
 
         response = ConversationResponse.model_validate_json(
-            await http.request(log, url)
+            await http.request(log, url, headers={API_VERSION_HEADER: api_version})
         )
 
         for part in response.conversation_parts.conversation_parts:
@@ -441,6 +449,7 @@ async def _fetch_parts(
 
 async def fetch_segments(
     http: HTTPSession,
+    api_version: str,
     log: Logger,
     log_cursor: LogCursor,
 ) -> AsyncGenerator[TimestampedResource | LogCursor, None]:
@@ -453,7 +462,7 @@ async def fetch_segments(
     params={"include_count": 'true'}
 
     response = SegmentsResponse.model_validate_json(
-        await http.request(log, url, params=params)
+        await http.request(log, url, params=params, headers={API_VERSION_HEADER: api_version})
     )
 
     for result in response.data:
@@ -470,6 +479,7 @@ async def fetch_segments(
 
 async def _list_companies(
         http: HTTPSession,
+        api_version: str,
         log: Logger,
 ) -> AsyncGenerator[TimestampedResource, None]:
     url = f"{API}/companies/list"
@@ -484,7 +494,7 @@ async def _list_companies(
     while True:
         try:
             response = CompanyListResponse.model_validate_json(
-                await http.request(log, url, method="POST", params=params)
+                await http.request(log, url, method="POST", params=params, headers={API_VERSION_HEADER: api_version})
             )
         except HTTPError as err:
             # End pagination and checkpoint any documents if we hit the limit for the /companies/list endpoint.
@@ -511,6 +521,7 @@ async def _list_companies(
 
 async def _scroll_companies(
         http: HTTPSession,
+        api_version: str,
         log: Logger,
 ) -> AsyncGenerator[TimestampedResource, None]:
     url = f"{API}/companies/scroll"
@@ -522,7 +533,7 @@ async def _scroll_companies(
         while True:
             try:
                 response = CompanyScrollResponse.model_validate_json(
-                    await http.request(log, url, method="GET", params=params)
+                    await http.request(log, url, method="GET", params=params, headers={API_VERSION_HEADER: api_version})
                 )
             except HTTPError as err:
                 if err.code == 400 and bool(re.search(COMPANIES_SCROLL_IN_USE_BY_OTHER_APPLICATION_REGEX, err.message, re.DOTALL)):
@@ -545,6 +556,7 @@ async def _scroll_companies(
 async def fetch_companies(
         http: HTTPSession,
         use_list_endpoint: bool,
+        api_version: str,
         log: Logger,
         log_cursor: LogCursor,
 ) -> AsyncGenerator[TimestampedResource | LogCursor, None]:
@@ -555,7 +567,7 @@ async def fetch_companies(
 
     companies_func = _list_companies if use_list_endpoint else _scroll_companies
 
-    async for company in companies_func(http, log):
+    async for company in companies_func(http, api_version, log):
         if company.updated_at > last_seen_ts:
             last_seen_ts = company.updated_at
         if company.updated_at > log_cursor_ts:
@@ -570,6 +582,7 @@ async def fetch_companies(
 async def fetch_company_segments(
         http: HTTPSession,
         use_list_endpoint: bool,
+        api_version: str,
         log: Logger,
         log_cursor: LogCursor,
 ) -> AsyncGenerator[TimestampedResource | LogCursor, None]:
@@ -584,7 +597,7 @@ async def fetch_company_segments(
 
     # Fetch & buffer company ids to avoid using the /companies/scroll endpoint for longer than necessary and
     # avoid exceeding the one minute timeout for a single "scroll" if we were to fetch segments while scrolling.
-    async for company in companies_func(http, log):
+    async for company in companies_func(http, api_version, log):
         company_ids.append(company.id)
 
     for id in company_ids:
@@ -592,7 +605,7 @@ async def fetch_company_segments(
 
         try:
             company_segments = CompanySegmentsResponse.model_validate_json(
-                await http.request(log, segments_url)
+                await http.request(log, segments_url, headers={API_VERSION_HEADER: api_version})
             )
         except HTTPError as err:
             if err.code == 404 and 'Company Not Found' in err.message:

--- a/source-intercom-native/source_intercom_native/models.py
+++ b/source-intercom-native/source_intercom_native/models.py
@@ -53,6 +53,7 @@ else:
     OAuth2Credentials = LongLivedClientCredentialsOAuth2Credentials.for_provider(OAUTH2_SPEC.provider)
 
 MAX_SEARCH_PAGE_SIZE = 150
+DEFAULT_API_VERSION = "2.11"
 
 
 def default_start_date():
@@ -89,6 +90,12 @@ class EndpointConfig(BaseModel):
             gt=0,
             le=MAX_SEARCH_PAGE_SIZE,
         )]
+        api_version: str = Field(
+            description=f"The Intercom API version used for requests. Defaults to '{DEFAULT_API_VERSION}'.",
+            title="API Version",
+            default_factory=lambda: DEFAULT_API_VERSION,
+            pattern=r"^\d+\.\d+$",
+        )
 
     advanced: Advanced = Field(
         default_factory=Advanced, #type: ignore
@@ -222,21 +229,21 @@ class CompanyScrollResponse(BaseModel, extra="allow"):
 
 
 ClientSideFilteringResourceFetchChangesFn = Callable[
-    [HTTPSession, Logger, LogCursor],
+    [HTTPSession, str, Logger, LogCursor],
     AsyncGenerator[TimestampedResource | LogCursor, None],
 ]
 
 IncrementalResourceFetchChangesFn = Callable[
-    [HTTPSession, int, Logger, LogCursor],
+    [HTTPSession, int, str, Logger, LogCursor],
     AsyncGenerator[TimestampedResource | LogCursor, None],
 ]
 
 CompanyResourceFetchChangesFn = Callable[
-    [HTTPSession, bool, Logger, LogCursor],
+    [HTTPSession, bool, str, Logger, LogCursor],
     AsyncGenerator[TimestampedResource | LogCursor, None],
 ]
 
 IncrementalDateWindowResourceFetchChangesFn = Callable[
-    [HTTPSession, int, int, Logger, LogCursor],
+    [HTTPSession, int, int, str, Logger, LogCursor],
     AsyncGenerator[TimestampedResource | LogCursor, None],
 ]

--- a/source-intercom-native/source_intercom_native/resources.py
+++ b/source-intercom-native/source_intercom_native/resources.py
@@ -28,6 +28,7 @@ from .api import (
     fetch_companies,
     fetch_company_segments,
     API,
+    API_VERSION_HEADER,
 )
 
 
@@ -77,9 +78,10 @@ async def validate_credentials(
     http.token_source = TokenSource(oauth_spec=OAUTH2_SPEC, credentials=config.credentials)
     url = f"{API}/data_attributes"
     params = {"model": "contact"}
+    headers = {API_VERSION_HEADER: config.advanced.api_version}
 
     try:
-        await http.request(log, url, params=params)
+        await http.request(log, url, params=params, headers=headers)
     except HTTPError as err:
         msg = 'Unknown error occurred.'
         if err.code == 401:
@@ -115,6 +117,7 @@ def full_refresh_resources(
                 path,
                 response_field,
                 query_param,
+                config.advanced.api_version,
             ),
             tombstone=IntercomResource(_meta=IntercomResource.Meta(op="d"))
         )
@@ -158,6 +161,7 @@ def incremental_resources(
                 fetch_fn,
                 http,
                 config.advanced.search_page_size,
+                config.advanced.api_version,
             )
         )
 
@@ -203,6 +207,7 @@ def incremental_date_window_resources(
                 http,
                 config.advanced.window_size,
                 config.advanced.search_page_size,
+                config.advanced.api_version,
             )
         )
 
@@ -246,6 +251,7 @@ def client_side_filtered_resources(
             fetch_changes=functools.partial(
                 fetch_fn,
                 http,
+                config.advanced.api_version,
             )
         )
 
@@ -290,6 +296,7 @@ def company_resources(
                 fetch_fn,
                 http,
                 config.advanced.use_companies_list_endpoint,
+                config.advanced.api_version,
             )
         )
 

--- a/source-intercom-native/tests/snapshots/snapshots__capture__capture.stdout.json
+++ b/source-intercom-native/tests/snapshots/snapshots__capture__capture.stdout.json
@@ -152,7 +152,6 @@
       "created_at": 1733757892,
       "custom_attributes": {},
       "email": "alexb@estuary.dev",
-      "enabled_push_messaging": null,
       "external_id": null,
       "has_hard_bounced": false,
       "id": "67570bc4f8bbaf49f9287fc9",
@@ -291,30 +290,22 @@
       "_meta": {
         "uuid": "DocUUIDPlaceholder-329Bb50aa48EAa9ef"
       },
-      "app_package_code": null,
       "assigned_to": null,
       "attachments": [],
       "author": {
         "email": "alexb@estuary.dev",
-        "from_ai_agent": false,
         "id": "7939621",
-        "is_ai_answer": false,
         "name": "Alex Bair",
         "type": "admin"
       },
       "body": "<p class=\"no-margin\">Hello</p>",
       "conversation_id": "1",
       "created_at": 1734097565,
-      "email_message_metadata": null,
-      "event_details": {},
       "external_id": null,
       "id": "1",
-      "metadata": {},
       "notified_at": 1734097565,
       "part_type": "comment",
       "redacted": false,
-      "state": "open",
-      "tags": [],
       "type": "conversation_part",
       "updated_at": 1734097565
     }
@@ -327,7 +318,6 @@
       },
       "admin_assignee_id": "7939621",
       "category": "Tracker",
-      "channel": "messenger",
       "contacts": {
         "contacts": [],
         "type": "contact.list"
@@ -411,13 +401,9 @@
         "total_count": 3,
         "type": "ticket_part.list"
       },
-      "ticket_state": {
-        "category": "in_progress",
-        "external_label": "In progress",
-        "id": "2",
-        "internal_label": "In progress",
-        "type": "ticket_state"
-      },
+      "ticket_state": "in_progress",
+      "ticket_state_external_label": "In progress",
+      "ticket_state_internal_label": "In progress",
       "ticket_type": {
         "archived": false,
         "category": "Tracker",
@@ -573,7 +559,6 @@
       "admin_assignee_id": null,
       "ai_agent": null,
       "ai_agent_participated": false,
-      "company": null,
       "contacts": {
         "contacts": [
           {
@@ -613,7 +598,6 @@
         "body": "",
         "delivered_as": "admin_initiated",
         "id": "1",
-        "recipients": null,
         "redacted": false,
         "subject": "",
         "type": null,
@@ -621,8 +605,6 @@
       },
       "state": "open",
       "statistics": {
-        "assigned_team_first_response_time": [],
-        "assigned_team_first_response_time_in_office_hours": [],
         "count_assignments": 0,
         "count_conversation_parts": 11,
         "count_reopens": 0,
@@ -630,7 +612,6 @@
         "first_assignment_at": null,
         "first_close_at": null,
         "first_contact_reply_at": null,
-        "handling_time": null,
         "last_admin_reply_at": null,
         "last_assignment_admin_reply_at": null,
         "last_assignment_at": null,

--- a/source-intercom-native/tests/snapshots/snapshots__spec__capture.stdout.json
+++ b/source-intercom-native/tests/snapshots/snapshots__spec__capture.stdout.json
@@ -45,6 +45,12 @@
               "maximum": 150,
               "title": "Search Streams' Page Size",
               "type": "integer"
+            },
+            "api_version": {
+              "description": "The Intercom API version used for requests. Defaults to '2.11'.",
+              "pattern": "^\\d+\\.\\d+$",
+              "title": "API Version",
+              "type": "string"
             }
           },
           "title": "Advanced",


### PR DESCRIPTION
**Description:**

This PR adds an `advanced.api_version` field to the endpoint config that sets the `Intercom-Version` header on all API requests. This decouples the API version used by capture tasks from the version pinned by our production Intercom OAuth app, and it will allow users to pin a specific Intercom API version for their capture. The default is "2.11", which is the API version our production Intercom OAuth app is currently pinned on.

The snapshot changes are expected:
- The capture snapshot was previously generated with API version 2.15 (set by the OAuth app for our test credentials) but now it's generated with API version 2.11 (set by the version specified in the connector code) that returns fewer fields. Production captures are not impacted by this change - they've been using our production OAuth app that's pinned on version 2.11.
- The spec snapshot change is expected because of the addition of the `advanced.api_version` config setting.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

The connector's documentation should be updated to reflect the new config setting.

**Notes for reviewers:**

(anything that might help someone review this PR)

