### PR TITLE
materialize-snowflake: retry temporary error in channel status

### DIFF
--- a/materialize-snowflake/stream_http.go
+++ b/materialize-snowflake/stream_http.go
@@ -5,6 +5,7 @@ import (
 	"crypto/rsa"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"math"
 	"path"
@@ -321,7 +322,7 @@ func (s *streamClient) channelStatus(ctx context.Context, clientSeq int, schema,
 	} else if err := getErrorByCode(res.StatusCode); err != nil {
 		return nil, fmt.Errorf("request was not successful: %w", err)
 	} else if res.Message != "Success" {
-		return nil, fmt.Errorf("unexpected response message: %s", res.Message)
+		return nil, fmt.Errorf("unexpected response message: %q", res.Message)
 	}
 
 	for _, channel := range res.Channels {
@@ -339,7 +340,9 @@ func (s *streamClient) waitForTokenPersisted(ctx context.Context, token string, 
 	ts := time.Now()
 	for n := 1; ; n++ {
 		if status, err := s.channelStatus(ctx, clientSeq, schema, table, name); err != nil {
-			return err
+			if !errors.Is(err, ErrTemporary) {
+				return err
+			}
 		} else if len(status.Channels) != 1 {
 			return fmt.Errorf("expected 1 channel but got %d", len(status.Channels))
 		} else if status.Channels[0].PersistedOffsetToken == token {
@@ -461,13 +464,28 @@ var streamingIngestResponseCodes = map[int]string{
 	55: "Snowpipe Streaming does not support columns of type AUTOINCREMENT, IDENTITY, GEO, or columns with a default value or collation",
 }
 
+var ErrTemporary = errors.New("temporary error")
+var ErrPermanent = errors.New("permanent error")
+
+func errorCategory(code int) error {
+	if code == 10 {
+		return ErrTemporary
+	}
+	return ErrPermanent
+}
+
 type streamingApiError struct {
-	Code    int    `json:"status_code"`
-	Message string `json:"message"`
+	Code        int    `json:"status_code"`
+	Message     string `json:"message"`
+	ErrCategory error
 }
 
 func (e *streamingApiError) Error() string {
 	return fmt.Sprintf("%s (code %d)", e.Message, e.Code)
+}
+
+func (e *streamingApiError) Unwrap() error {
+	return e.ErrCategory
 }
 
 func getErrorByCode(code int) error {
@@ -476,7 +494,11 @@ func getErrorByCode(code int) error {
 	}
 
 	if msg, ok := streamingIngestResponseCodes[code]; ok {
-		return &streamingApiError{Code: code, Message: msg}
+		return &streamingApiError{
+			Code:        code,
+			Message:     msg,
+			ErrCategory: errorCategory(code),
+		}
 	}
 
 	return fmt.Errorf("unknown status message for code %d", code)

--- a/materialize-snowflake/stream_http_test.go
+++ b/materialize-snowflake/stream_http_test.go
@@ -1,0 +1,222 @@
+package main
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"resty.dev/v3"
+)
+
+func TestWaitForTokenPersisted(t *testing.T) {
+	tests := []struct {
+		name    string
+		handler http.HandlerFunc
+		check   func(err error)
+	}{
+		{
+			name: "success",
+			handler: func() http.HandlerFunc {
+				return func(w http.ResponseWriter, r *http.Request) {
+					_, err := io.ReadAll(r.Body)
+					require.NoError(t, err)
+
+					w.Header().Set("Content-Type", "application/json")
+					w.WriteHeader(http.StatusOK)
+					respBody, err := json.Marshal(map[string]any{
+						"status_code": 0,
+						"message":     "Success",
+						"channels": []any{
+							map[string]any{
+								"status_code":                0,
+								"persisted_offset_token":     nil,
+								"persisted_client_sequencer": 0,
+								"persisted_row_sequencer":    0,
+							},
+						},
+					})
+					require.NoError(t, err)
+					w.Write(respBody)
+				}
+			}(),
+			check: func(err error) {
+				require.NoError(t, err)
+			},
+		},
+		{
+			name: "top status code",
+			handler: func() http.HandlerFunc {
+				return func(w http.ResponseWriter, r *http.Request) {
+					_, err := io.ReadAll(r.Body)
+					require.NoError(t, err)
+
+					w.Header().Set("Content-Type", "application/json")
+					w.WriteHeader(http.StatusOK)
+					respBody, err := json.Marshal(map[string]any{
+						"status_code": 4,
+						"message":     "the supplied table does not exist or is not authorized",
+					})
+					require.NoError(t, err)
+					w.Write(respBody)
+				}
+			}(),
+			check: func(err error) {
+				require.ErrorContains(t, err, "request was not successful")
+			},
+		},
+		{
+			name: "retry top status code",
+			handler: func() http.HandlerFunc {
+				count := 0
+				return func(w http.ResponseWriter, r *http.Request) {
+					_, err := io.ReadAll(r.Body)
+					require.NoError(t, err)
+
+					if count == 0 {
+						count++
+						w.Header().Set("Content-Type", "application/json")
+						w.WriteHeader(http.StatusOK)
+						respBody, err := json.Marshal(map[string]any{
+							"status_code": 10,
+							"message":     "Snowflake experienced a transient exception, please retry the request",
+						})
+						require.NoError(t, err)
+						w.Write(respBody)
+					} else {
+						w.Header().Set("Content-Type", "application/json")
+						w.WriteHeader(http.StatusOK)
+						respBody, err := json.Marshal(map[string]any{
+							"status_code": 0,
+							"message":     "Success",
+							"channels": []any{
+								map[string]any{
+									"status_code":                0,
+									"persisted_offset_token":     nil,
+									"persisted_client_sequencer": 0,
+									"persisted_row_sequencer":    0,
+								},
+							},
+						})
+						require.NoError(t, err)
+						w.Write(respBody)
+					}
+				}
+			}(),
+			check: func(err error) {
+				require.NoError(t, err)
+			},
+		},
+		{
+			name: "channel error status code",
+			handler: func() http.HandlerFunc {
+				return func(w http.ResponseWriter, r *http.Request) {
+					_, err := io.ReadAll(r.Body)
+					require.NoError(t, err)
+
+					w.Header().Set("Content-Type", "application/json")
+					w.WriteHeader(http.StatusOK)
+					respBody, err := json.Marshal(map[string]any{
+						"status_code": 0,
+						"message":     "Success",
+						"channels": []any{
+							map[string]any{
+								"status_code":                5,
+								"persisted_offset_token":     nil,
+								"persisted_client_sequencer": 0,
+								"persisted_row_sequencer":    0,
+							},
+						},
+					})
+					require.NoError(t, err)
+					w.Write(respBody)
+				}
+			}(),
+			check: func(err error) {
+				require.ErrorContains(t, err, "failed to get channel status")
+			},
+		},
+		{
+			name: "retry temporary channel status code",
+			handler: func() http.HandlerFunc {
+				count := 0
+				return func(w http.ResponseWriter, r *http.Request) {
+					_, err := io.ReadAll(r.Body)
+					require.NoError(t, err)
+
+					if count == 0 {
+						count++
+						w.Header().Set("Content-Type", "application/json")
+						w.WriteHeader(http.StatusOK)
+						respBody, err := json.Marshal(map[string]any{
+							"status_code": 0,
+							"message":     "Success",
+							"channels": []any{
+								map[string]any{
+									"status_code":                10,
+									"persisted_offset_token":     nil,
+									"persisted_client_sequencer": 0,
+									"persisted_row_sequencer":    0,
+								},
+							},
+						})
+						require.NoError(t, err)
+						w.Write(respBody)
+					} else {
+						w.Header().Set("Content-Type", "application/json")
+						w.WriteHeader(http.StatusOK)
+						respBody, err := json.Marshal(map[string]any{
+							"status_code": 0,
+							"message":     "Success",
+							"channels": []any{
+								map[string]any{
+									"status_code":                0,
+									"persisted_offset_token":     nil,
+									"persisted_client_sequencer": 0,
+									"persisted_row_sequencer":    0,
+								},
+							},
+						})
+						require.NoError(t, err)
+						w.Write(respBody)
+					}
+				}
+			}(),
+			check: func(err error) {
+				require.NoError(t, err)
+			},
+		},
+	}
+
+	pkey, err := rsa.GenerateKey(rand.Reader, 1024)
+	require.NoError(t, err)
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mux := http.NewServeMux()
+			mux.HandleFunc("POST /v1/streaming/channels/status", tt.handler)
+
+			ts := httptest.NewServer(mux)
+			defer ts.Close()
+
+			ctx := context.Background()
+
+			role := "TEST_ROLE"
+			streamClient := &streamClient{
+				r:        resty.New().SetBaseURL(ts.URL + "/v1/streaming").SetDisableWarn(true),
+				key:      pkey,
+				user:     "TEST_USER",
+				database: "TEST_DB",
+				account:  "TEST_ACCOUNT",
+				role:     &role,
+			}
+			err := streamClient.waitForTokenPersisted(ctx, "", 0, "TEST_SCHEMA", "TEST_TABLE", "TEST_CHANNEL")
+			tt.check(err)
+		})
+	}
+}


### PR DESCRIPTION
**Description:**

Code 10 is an "transient exception" in the Snowpipe Streaming API and should be retried.  When checking status this error can occur at the top level or it can apply to just one of the channels.

In either case, this changes it so the error code is retried as part of the standard polling of the status.  This provides a fast and interrupt free retry path for this particular case.

**Workflow steps:**

No changes

**Documentation links affected:**

None

**Notes for reviewers:**

(anything that might help someone review this PR)

