### PR TITLE
materialize-s3-iceberg: add scope option for rest catalogs

### DIFF
--- a/materialize-s3-iceberg/Dockerfile
+++ b/materialize-s3-iceberg/Dockerfile
@@ -15,8 +15,10 @@ ENV VIRTUAL_ENV=/opt/venv
 
 WORKDIR /opt/iceberg-ctl
 
-COPY materialize-s3-iceberg/iceberg-ctl /opt/iceberg-ctl
-
+COPY materialize-s3-iceberg/iceberg-ctl/poetry.lock /opt/iceberg-ctl/poetry.lock
+COPY materialize-s3-iceberg/iceberg-ctl/pyproject.toml /opt/iceberg-ctl/pyproject.toml
+RUN poetry install --no-root
+COPY materialize-s3-iceberg/iceberg-ctl/iceberg_ctl /opt/iceberg-ctl/iceberg_ctl
 RUN poetry install
 
 # Go build stage
@@ -26,6 +28,8 @@ FROM --platform=linux/amd64 golang:1.25-bookworm AS gobuilder
 WORKDIR /builder
 
 COPY go.*                       ./
+RUN go mod download
+
 COPY go                         ./go
 COPY filesink                   ./filesink
 COPY materialize-boilerplate    ./materialize-boilerplate

--- a/materialize-s3-iceberg/driver.go
+++ b/materialize-s3-iceberg/driver.go
@@ -62,6 +62,7 @@ type catalogConfig struct {
 	Credential string `json:"credential,omitempty"`
 	Token      string `json:"token,omitempty"`
 	Warehouse  string `json:"warehouse,omitempty"`
+	Scope      string `json:"scope,omitempty"`
 }
 
 type advancedConfig struct {

--- a/materialize-s3-iceberg/iceberg-ctl/iceberg_ctl/__main__.py
+++ b/materialize-s3-iceberg/iceberg-ctl/iceberg_ctl/__main__.py
@@ -76,15 +76,17 @@ def run(
 
         match cfg.catalog:
             case RestCatalogConfig():
+                properties = {
+                    "uri": cfg.catalog.uri,
+                    "credential": cfg.catalog.credential,
+                    "token": cfg.catalog.token,
+                    "warehouse": cfg.catalog.warehouse,
+                    "scope": cfg.catalog.scope,
+                    PY_IO_IMPL: "pyiceberg.io.fsspec.FsspecFileIO",  # use S3 file IO instead of Arrow
+                }
                 ctx.obj["catalog"] = RestCatalog(
                     "default",
-                    **{
-                        "uri": cfg.catalog.uri,
-                        "credential": cfg.catalog.credential,
-                        "token": cfg.catalog.token,
-                        "warehouse": cfg.catalog.warehouse,
-                        PY_IO_IMPL: "pyiceberg.io.fsspec.FsspecFileIO",  # use S3 file IO instead of Arrow
-                    },
+                    **{k:v for k, v in properties.items() if v is not None},
                 )
 
             case GlueCatalogConfig():

--- a/materialize-s3-iceberg/iceberg-ctl/iceberg_ctl/models.py
+++ b/materialize-s3-iceberg/iceberg-ctl/iceberg_ctl/models.py
@@ -107,6 +107,12 @@ class RestCatalogConfig(BaseModel):
         description="Warehouse to connect to.",
         json_schema_extra={"order": 4},
     )
+    scope: str | None = Field(
+        default=None,
+        title="Scope",
+        description="Desired scope of the requested security token.",
+        json_schema_extra={"order": 5},
+    )
 
 
 class GlueCatalogConfig(BaseModel):


### PR DESCRIPTION
**Description:**

Passthrough the scope to PyIceberg in case the REST catalog requires special OAuth2 scopes.

**Workflow steps:**

Optionally add scopes

**Documentation links affected:**

TODO: add new config option to https://docs.estuary.dev/reference/Connectors/materialization-connectors/amazon-s3-iceberg/

**Notes for reviewers:**

Changes to Dockerfile for better layer caching.

Filtered properties to avoid type error, values must be a str according to annotations.

