### PR TITLE
chore: use action for docker-login

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,9 +27,11 @@ jobs:
           echo ::set-output name=version::${VERSION}
 
       - name: Login to GitHub package docker registry
-        run: |
-          echo "${{ secrets.GITHUB_TOKEN }}" | \
-            docker login --username ${{ github.actor }} --password-stdin ghcr.io
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
@@ -167,9 +169,11 @@ jobs:
           export_default_credentials: true
 
       - name: Login to GitHub package docker registry
-        run: |
-          echo "${{ secrets.GITHUB_TOKEN }}" | \
-            docker login --username ${{ github.actor }} --password-stdin ghcr.io
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1


### PR DESCRIPTION
**Description:**

Use `docker/login-action` instead of a manual `docker login` command for ghcr.io authentication. This may help some CI tests be less flakey by automatically retrying transient authentication failures.