### PR TITLE
materialize-snowflake: log partitions statistics for merge queries

### DIFF
--- a/materialize-snowflake/snowflake.go
+++ b/materialize-snowflake/snowflake.go
@@ -815,11 +815,17 @@ func (d *transactor) Acknowledge(ctx context.Context) (*pf.ConnectorState, error
 				// NB: Not using groupTx here since the Go Snowflake driver
 				// retains contexts internally, and groupCtx is cancelled after
 				// group.Wait() returns.
-				if _, err := d.db.ExecContext(ctx, item.Query); err != nil {
+				result, err := d.db.ExecContext(ctx, item.Query)
+				if err != nil {
 					return fmt.Errorf("query %q failed: %w", item.Query, err)
 				}
 
 				d.be.FinishedResourceCommit(path)
+
+				// Log partition scan stats for merge observability.
+				if sfResult, ok := result.(sf.SnowflakeResult); ok {
+					logMergePartitionStats(ctx, d.db, sfResult.GetQueryID(), path)
+				}
 				if err := d.deleteFiles(groupCtx, []string{item.StagedDir}); err != nil {
 					return fmt.Errorf("cleaning up files: %w", err)
 				}
@@ -1134,6 +1140,26 @@ func (d *transactor) Destroy() {
 	d.load.conn.Close()
 	d.store.conn.Close()
 	d.db.Close()
+}
+
+func logMergePartitionStats(ctx context.Context, db *stdsql.DB, queryID string, path []string) {
+	var scanned, total stdsql.NullInt64
+	row := db.QueryRowContext(ctx,
+		`SELECT PARTITIONS_SCANNED, PARTITIONS_TOTAL
+         FROM TABLE(INFORMATION_SCHEMA.QUERY_HISTORY_BY_SESSION(RESULT_LIMIT => 20))
+         WHERE QUERY_ID = ?`,
+		queryID,
+	)
+	if err := row.Scan(&scanned, &total); err != nil {
+		log.WithField("query_id", queryID).WithError(err).Debug("could not fetch merge partition stats")
+		return
+	}
+	log.WithFields(log.Fields{
+		"table":              path,
+		"query_id":           queryID,
+		"partitions_scanned": scanned.Int64,
+		"partitions_total":   total.Int64,
+	}).Info("merge partition stats")
 }
 
 func main() {


### PR DESCRIPTION
**Description:**

- Log partition's scanned and total partitions statistics for MERGE queries we run. We can use these to diagnose our performance inefficiencies to see if it is related to partition pruning or not.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

