### PR TITLE
source-pendo: add configurable host to support regional Pendo instances

### DIFF
--- a/source-pendo/source_pendo/api.py
+++ b/source-pendo/source_pendo/api.py
@@ -14,9 +14,10 @@ from .models import (
     Metadata,
     FullRefreshResource,
     IncrementalResource,
+    PendoHost,
 )
 
-API = "https://app.pendo.io/api/v1"
+
 RESPONSE_LIMIT = 50000
 # Event data for a given hour isn't available via the API until ~4-6 hours afterwards.
 # This isn't mentioned in Pendo's docs but has been observed empirically. We shift the
@@ -35,6 +36,9 @@ def _dt_to_ms(dt: datetime) -> int:
 
 def _ms_to_dt(ms: int) -> datetime:
     return datetime.fromtimestamp(ms / 1000.0, tz=UTC)
+
+def base_url(host: PendoHost) -> str:
+    return f"https://{host}/api/v1"
 
 def generate_events_body(
         entity: str,
@@ -247,10 +251,11 @@ def generate_resources_body(
 
 async def snapshot_resources(
         http: HTTPSession,
+        host: PendoHost,
         entity: str,
         log: Logger,
 ) -> AsyncGenerator[FullRefreshResource, None]:
-    url = f"{API}/{entity}"
+    url = f"{base_url(host)}/{entity}"
 
     params = {
         # The expand query parameter tells Pendo to return data for all
@@ -266,10 +271,11 @@ async def snapshot_resources(
 
 async def snapshot_metadata(
         http: HTTPSession,
+        host: PendoHost,
         entity: str,
         log: Logger,
 ) -> AsyncGenerator[Metadata, None]:
-    url = f"{API}/metadata/schema/{entity}"
+    url = f"{base_url(host)}/metadata/schema/{entity}"
 
     metadata = Metadata.model_validate_json(
         await http.request(log, url)
@@ -280,6 +286,7 @@ async def snapshot_metadata(
 
 async def _fetch_events_between(
     http: HTTPSession,
+    host: PendoHost,
     entity: str,
     model: type[Event],
     identifying_field: str,
@@ -287,7 +294,7 @@ async def _fetch_events_between(
     upper_bound: datetime,
     log: Logger,
 ) -> AsyncGenerator[Event, None]:
-    url = f"{API}/aggregation"
+    url = f"{base_url(host)}/aggregation"
     last_dt = lower_bound
     lower_bound_ts = _dt_to_ms(lower_bound)
     upper_bound_ts = _dt_to_ms(upper_bound)
@@ -355,6 +362,7 @@ async def _fetch_events_between(
 
 async def fetch_events(
         http: HTTPSession,
+        host: PendoHost,
         entity: str,
         model: type[Event],
         identifying_field: str,
@@ -375,6 +383,7 @@ async def fetch_events(
     count = 0
     async for event in _fetch_events_between(
         http=http,
+        host=host,
         entity=entity,
         model=model,
         identifying_field=identifying_field,
@@ -401,6 +410,7 @@ async def fetch_events(
 
 async def backfill_events(
         http: HTTPSession,
+        host: PendoHost,
         entity: str,
         model: type[Event],
         identifying_field: str,
@@ -420,6 +430,7 @@ async def backfill_events(
     count = 0
     async for event in _fetch_events_between(
         http=http,
+        host=host,
         entity=entity,
         model=model,
         identifying_field=identifying_field,
@@ -446,6 +457,7 @@ async def backfill_events(
 
 async def _fetch_aggregated_events_between(
     http: HTTPSession,
+    host: PendoHost,
     entity: str,
     model: type[EventAggregate],
     identifying_field: str,
@@ -453,7 +465,7 @@ async def _fetch_aggregated_events_between(
     upper_bound: datetime,
     log: Logger,
 ) -> AsyncGenerator[EventAggregate, None]:
-    url = f"{API}/aggregation"
+    url = f"{base_url(host)}/aggregation"
     last_dt = lower_bound
     lower_bound_ts = _dt_to_ms(lower_bound)
     upper_bound_ts = _dt_to_ms(upper_bound)
@@ -521,6 +533,7 @@ async def _fetch_aggregated_events_between(
 
 async def fetch_aggregated_events(
         http: HTTPSession,
+        host: PendoHost,
         entity: str,
         model: type[EventAggregate],
         identifying_field: str,
@@ -541,6 +554,7 @@ async def fetch_aggregated_events(
     count = 0
     async for aggregate in _fetch_aggregated_events_between(
         http=http,
+        host=host,
         entity=entity,
         model=model,
         identifying_field=identifying_field,
@@ -567,6 +581,7 @@ async def fetch_aggregated_events(
 
 async def backfill_aggregated_events(
         http: HTTPSession,
+        host: PendoHost,
         entity: str,
         model: type[EventAggregate],
         identifying_field: str,
@@ -586,6 +601,7 @@ async def backfill_aggregated_events(
     count = 0
     async for aggregate in _fetch_aggregated_events_between(
         http=http,
+        host=host,
         entity=entity,
         model=model,
         identifying_field=identifying_field,
@@ -631,6 +647,7 @@ def _extract_updated_at(doc: BaseDocument, updated_at_field: str, log: Logger) -
 
 async def _fetch_resources_between(
     http: HTTPSession,
+    host: PendoHost,
     entity: str,
     model: type[IncrementalResource],
     updated_at_field: str,
@@ -639,7 +656,7 @@ async def _fetch_resources_between(
     upper_bound: datetime,
     log: Logger,
 ) -> AsyncGenerator[IncrementalResource, None]:
-    url = f"{API}/aggregation"
+    url = f"{base_url(host)}/aggregation"
     last_dt = lower_bound
     lower_bound_ts = _dt_to_ms(lower_bound)
     upper_bound_ts = _dt_to_ms(upper_bound)
@@ -707,6 +724,7 @@ async def _fetch_resources_between(
 
 async def fetch_resources(
         http: HTTPSession,
+        host: PendoHost,
         entity: str,
         model: type[IncrementalResource],
         updated_at_field: str,
@@ -721,6 +739,7 @@ async def fetch_resources(
     count = 0
     async for resource in _fetch_resources_between(
         http=http,
+        host=host,
         entity=entity,
         model=model,
         updated_at_field=updated_at_field,
@@ -750,6 +769,7 @@ async def fetch_resources(
 
 async def backfill_resources(
         http: HTTPSession,
+        host: PendoHost,
         entity: str,
         model: type[IncrementalResource],
         updated_at_field: str,
@@ -770,6 +790,7 @@ async def backfill_resources(
     count = 0
     async for resource in _fetch_resources_between(
         http=http,
+        host=host,
         entity=entity,
         model=model,
         updated_at_field=updated_at_field,

--- a/source-pendo/source_pendo/models.py
+++ b/source-pendo/source_pendo/models.py
@@ -1,3 +1,4 @@
+from enum import StrEnum
 from typing import ClassVar, Generic, TypeVar
 import pendulum
 from pydantic import AwareDatetime, BaseModel, Field
@@ -13,11 +14,24 @@ from estuary_cdk.capture.common import (
 from estuary_cdk.flow import AccessToken
 
 
+class PendoHost(StrEnum):
+    US = "app.pendo.io"
+    US1 = "us1.app.pendo.io"
+    EU = "app.eu.pendo.io"
+    JPN = "app.jpn.pendo.io"
+    AU = "app.au.pendo.io"
+
+
 def default_start_date():
     return pendulum.now().subtract(hours=1).in_timezone("UTC").format("YYYY-MM-DDTHH:mm:ssZ")
 
 
 class EndpointConfig(BaseModel):
+    host: PendoHost = Field(
+        description="The Pendo host to connect to. Select the host that matches the region of your Pendo subscription.",
+        title="Pendo Host",
+        default=PendoHost.US,
+    )
     startDate: str = Field(
         description="UTC date and time in the format YYYY-MM-DDTHH:MM:SSZ. Any event data generated before this date will not be replicated. If left blank, the start date will be set to one hour before the present date.",
         title="Start Date",

--- a/source-pendo/source_pendo/resources.py
+++ b/source-pendo/source_pendo/resources.py
@@ -32,7 +32,7 @@ from .api import (
     fetch_aggregated_events,
     snapshot_metadata,
     _dt_to_ms,
-    API,
+    base_url,
     API_EVENT_LAG,
 )
 
@@ -44,7 +44,7 @@ async def validate_api_key(
         log: Logger, http: HTTPMixin, config: EndpointConfig
 ):
     http.token_source = TokenSource(oauth_spec=None, credentials=config.credentials, authorization_header=AUTHORIZATION_HEADER)
-    url = f"{API}/metadata/schema/AccountMetadata"
+    url = f"{base_url(config.host)}/metadata/schema/AccountMetadata"
 
     try:
         await http.request(log, url)
@@ -76,6 +76,7 @@ def full_refresh_resources(
             fetch_snapshot=functools.partial(
                 snapshot_resources,
                 http,
+                config.host,
                 entity,
             ),
             tombstone=FullRefreshResource(_meta=FullRefreshResource.Meta(op="d"))
@@ -121,6 +122,7 @@ def incremental_resources(
             fetch_changes=functools.partial(
                 fetch_resources,
                 http,
+                config.host,
                 entity,
                 model,
                 updated_at_field,
@@ -129,6 +131,7 @@ def incremental_resources(
             fetch_page=functools.partial(
                 backfill_resources,
                 http,
+                config.host,
                 entity,
                 model,
                 updated_at_field,
@@ -180,6 +183,7 @@ def metadata(
             fetch_snapshot=functools.partial(
                 snapshot_metadata,
                 http,
+                config.host,
                 entity,
             ),
             tombstone=Metadata(_meta=Metadata.Meta(op="d"))
@@ -224,6 +228,7 @@ def events(
             fetch_changes=functools.partial(
                 fetch_events,
                 http,
+                config.host,
                 entity,
                 model,
                 identifying_field,
@@ -231,6 +236,7 @@ def events(
             fetch_page=functools.partial(
                 backfill_events,
                 http,
+                config.host,
                 entity,
                 model,
                 identifying_field,
@@ -292,6 +298,7 @@ def aggregated_events(
             fetch_changes=functools.partial(
                 fetch_aggregated_events,
                 http,
+                config.host,
                 entity,
                 model,
                 identifying_field,
@@ -299,6 +306,7 @@ def aggregated_events(
             fetch_page=functools.partial(
                 backfill_aggregated_events,
                 http,
+                config.host,
                 entity,
                 model,
                 identifying_field,

--- a/source-pendo/tests/snapshots/snapshots__spec__capture.stdout.json
+++ b/source-pendo/tests/snapshots/snapshots__spec__capture.stdout.json
@@ -22,9 +22,26 @@
           ],
           "title": "AccessToken",
           "type": "object"
+        },
+        "PendoHost": {
+          "enum": [
+            "app.pendo.io",
+            "us1.app.pendo.io",
+            "app.eu.pendo.io",
+            "app.jpn.pendo.io",
+            "app.au.pendo.io"
+          ],
+          "title": "PendoHost",
+          "type": "string"
         }
       },
       "properties": {
+        "host": {
+          "$ref": "#/$defs/PendoHost",
+          "default": "app.pendo.io",
+          "description": "The Pendo host to connect to. Select the host that matches the region of your Pendo subscription.",
+          "title": "Pendo Host"
+        },
         "startDate": {
           "description": "UTC date and time in the format YYYY-MM-DDTHH:MM:SSZ. Any event data generated before this date will not be replicated. If left blank, the start date will be set to one hour before the present date.",
           "examples": [


### PR DESCRIPTION
**Description:**

Pendo has multiple regional data centers (US, US1, EU, Japan, Australia) each with a different API host. Previously the connector hardcoded `app.pendo.io`, causing 400 errors for users on non-default instances. Adds a `PendoHost` enum and endpoint config field so users can select their region. Defaults to US (`app.pendo.io`) for backward compatibility.

Spec snapshot changes are expected due to the addition of the new `host` field in the config.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

The connector's documentation should be updated to reflect the new config option.

**Notes for reviewers:**

(anything that might help someone review this PR)

