### PR TITLE
integrate feedback in PR #3990

### DIFF
--- a/materialize-snowflake/.snapshots/TestConfigURI-Optional_Parameters
+++ b/materialize-snowflake/.snapshots/TestConfigURI-Optional_Parameters
@@ -1,1 +1,1 @@
-alex:mysecret@orgname-accountname.snowflakecomputing.com:443?GO_QUERY_RESULT_FORMAT=json&MULTI_STATEMENT_COUNT=0&account=myaccount&application=EstuaryFlow&client_session_keep_alive=true&database=mydb&maxRetryCount=35&query_tag=materialization_name%3An%2Fa&role=myrole&schema=myschema&warehouse=mywarehouse
+alex:mysecret@orgname-accountname.snowflakecomputing.com:443?GO_QUERY_RESULT_FORMAT=json&MULTI_STATEMENT_COUNT=0&account=myaccount&application=EstuaryFlow&client_session_keep_alive=true&database=mydb&maxRetryCount=35&role=myrole&schema=myschema&warehouse=mywarehouse

--- a/materialize-snowflake/.snapshots/TestConfigURI-User_&_Password_Authentication
+++ b/materialize-snowflake/.snapshots/TestConfigURI-User_&_Password_Authentication
@@ -1,1 +1,1 @@
-will:some%2Bcomplex%2Fpassword@orgname-accountname.snowflakecomputing.com:443?GO_QUERY_RESULT_FORMAT=json&MULTI_STATEMENT_COUNT=0&application=EstuaryFlow&client_session_keep_alive=true&database=mydb&maxRetryCount=35&query_tag=materialization_name%3An%2Fa&schema=myschema
+will:some%2Bcomplex%2Fpassword@orgname-accountname.snowflakecomputing.com:443?GO_QUERY_RESULT_FORMAT=json&MULTI_STATEMENT_COUNT=0&application=EstuaryFlow&client_session_keep_alive=true&database=mydb&maxRetryCount=35&schema=myschema

--- a/materialize-snowflake/client.go
+++ b/materialize-snowflake/client.go
@@ -260,7 +260,7 @@ func (c *client) CreateSchema(ctx context.Context, schemaName string) (string, e
 func preReqs(ctx context.Context, cfg config) *cerrors.PrereqErr {
 	errs := &cerrors.PrereqErr{}
 
-	dsn, err := cfg.toURI(false, "n/a")
+	dsn, err := cfg.toURI(false, "")
 	if err != nil {
 		errs.Err(err)
 		return errs

--- a/materialize-snowflake/config_test.go
+++ b/materialize-snowflake/config_test.go
@@ -39,7 +39,7 @@ func TestConfigURI(t *testing.T) {
 	} {
 		t.Run(name, func(t *testing.T) {
 			require.NoError(t, cfg.Validate())
-			uri, err := cfg.toURI(true, "n/a")
+			uri, err := cfg.toURI(true, "")
 			require.NoError(t, err)
 			cupaloy.SnapshotT(t, uri)
 		})

--- a/materialize-snowflake/snowflake.go
+++ b/materialize-snowflake/snowflake.go
@@ -91,7 +91,7 @@ func newSnowflakeDriver() *sql.Driver[config, tableConfig] {
 				"schema":   cfg.Schema,
 			}).Info("opening Snowflake")
 
-			dsn, err := cfg.toURI(false, "n/a")
+			dsn, err := cfg.toURI(false, "")
 			if err != nil {
 				return nil, fmt.Errorf("building snowflake dsn: %w", err)
 			}

--- a/materialize-snowflake/snowflake_test.go
+++ b/materialize-snowflake/snowflake_test.go
@@ -72,7 +72,7 @@ func TestValidateAndApply(t *testing.T) {
 		Schema: "PUBLIC",
 	}
 
-	dsn, err := cfg.toURI(true, "n/a")
+	dsn, err := cfg.toURI(true, "")
 	require.NoError(t, err)
 
 	db, err := stdsql.Open("snowflake", dsn)
@@ -109,7 +109,7 @@ func TestValidateAndApplyMigrations(t *testing.T) {
 		Schema: "PUBLIC",
 	}
 
-	dsn, err := cfg.toURI(true, "n/a")
+	dsn, err := cfg.toURI(true, "")
 	require.NoError(t, err)
 
 	db, err := stdsql.Open("snowflake", dsn)

--- a/materialize-snowflake/stream_test.go
+++ b/materialize-snowflake/stream_test.go
@@ -28,7 +28,7 @@ func TestStreamManager(t *testing.T) {
 
 	cfg := mustGetCfg(t)
 
-	dsn, err := cfg.toURI(true, "n/a")
+	dsn, err := cfg.toURI(true, "")
 	require.NoError(t, err)
 
 	db, err := stdsql.Open("snowflake", dsn)
@@ -441,7 +441,7 @@ func TestStreamDatatypes(t *testing.T) {
 
 	cfg := mustGetCfg(t)
 
-	dsn, err := cfg.toURI(true, "n/a")
+	dsn, err := cfg.toURI(true, "")
 	require.NoError(t, err)
 
 	db, err := stdsql.Open("snowflake", dsn)


### PR DESCRIPTION
**Description:**

Following up from #3990

**Notes for reviewers:**

@danielnelson asked that materialization name `n/a` be removed. I merged the PR with the fix applied to `materialization-databricks`, but not to `materialization-snowflake`.
