### PR TITLE
source-stripe-native: add warning log for invalid resource cursor

### DIFF
--- a/source-stripe-native/source_stripe_native/api.py
+++ b/source-stripe-native/source_stripe_native/api.py
@@ -98,7 +98,7 @@ async def fetch_incremental(
     url = f"{API}/events"
     parameters: dict[str, str | int] = {"limit": MAX_PAGE_LIMIT}
     parameters = add_event_types(parameters, cls.EVENT_TYPES)
-    
+
     end = min(
         datetime.now(tz=UTC) - LAG,
         # Bound the window to avoid processing too many events at once when catching up.
@@ -659,6 +659,8 @@ async def fetch_incremental_no_events(
         last_resource: StripeObjectNoEvents | None = None
         async for resource in processor:
             last_resource = resource
+            if not resource.created or not isinstance(resource.created, int):
+                log.warning("Resource has invalid 'created' field", resource)
             resource_ts = _s_to_dt(resource.created)
 
             # Update the most recent timestamp seen.


### PR DESCRIPTION
**Description:**

Adds a warning log to allow debugging issue where `resource.created` is `None`.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

