### PR TITLE
postgres: lower tcp_keepalive connection settings

### DIFF
--- a/materialize-postgres/.snapshots/TestConfigURI-Basic
+++ b/materialize-postgres/.snapshots/TestConfigURI-Basic
@@ -1,2 +1,2 @@
-postgres://will:secret1234@example.com:5432/somedb
+postgres://will:secret1234@example.com:5432/somedb?tcp_keepalives_count=6&tcp_keepalives_idle=120&tcp_keepalives_interval=30
 config valid

--- a/materialize-postgres/.snapshots/TestConfigURI-IncorrectSSL
+++ b/materialize-postgres/.snapshots/TestConfigURI-IncorrectSSL
@@ -1,2 +1,2 @@
-postgres://will:secret1234@example.com:5432/somedb?sslmode=whoops-this-isnt-right
+postgres://will:secret1234@example.com:5432/somedb?sslmode=whoops-this-isnt-right&tcp_keepalives_count=6&tcp_keepalives_idle=120&tcp_keepalives_interval=30
 invalid 'sslmode' configuration: unknown setting "whoops-this-isnt-right"

--- a/materialize-postgres/.snapshots/TestConfigURI-RequireSSL
+++ b/materialize-postgres/.snapshots/TestConfigURI-RequireSSL
@@ -1,2 +1,2 @@
-postgres://will:secret1234@example.com:5432/somedb?sslmode=verify-full
+postgres://will:secret1234@example.com:5432/somedb?sslmode=verify-full&tcp_keepalives_count=6&tcp_keepalives_idle=120&tcp_keepalives_interval=30
 config valid

--- a/materialize-postgres/.snapshots/TestValidateAndApplyMigrations
+++ b/materialize-postgres/.snapshots/TestValidateAndApplyMigrations
@@ -20,6 +20,8 @@ Base Initial Constraints:
 {"Field":"requiredNumeric","Type":2,"TypeString":"LOCATION_REQUIRED","Reason":"Required root-level properties must be present when flow_document is disabled"}
 {"Field":"scalarValue","Type":2,"TypeString":"LOCATION_REQUIRED","Reason":"Required root-level properties must be present when flow_document is disabled"}
 {"Field":"second_root","Type":5,"TypeString":"FIELD_FORBIDDEN","Reason":"Only a single root document projection can be materialized for standard updates"}
+{"Field":"stringAddMaxLength","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The projection has a single scalar type"}
+{"Field":"stringIncreaseMaxLength","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The projection has a single scalar type"}
 {"Field":"stringWidenedToJson","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The projection has a single scalar type"}
 {"Field":"timeValue","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The projection has a single scalar type"}
 
@@ -43,19 +45,23 @@ Migratable Changes Before Apply Schema:
 {"Name":"optional","Nullable":"YES","Type":"json"}
 {"Name":"requiredNumeric","Nullable":"NO","Type":"numeric"}
 {"Name":"scalarValue","Nullable":"NO","Type":"text"}
+{"Name":"stringAddMaxLength","Nullable":"YES","Type":"text"}
+{"Name":"stringIncreaseMaxLength","Nullable":"YES","Type":"text"}
 {"Name":"stringWidenedToJson","Nullable":"YES","Type":"text"}
 {"Name":"timeValue","Nullable":"YES","Type":"time without time zone"}
 
 
 Migratable Changes Before Apply Data:
-key (TEXT), _meta/flow_truncated (BOOL), boolWidenedToJson (BOOL), dateValue (DATE), datetimeValue (TIMESTAMPTZ), fieldWithProjection (TEXT), field_with_projection (TEXT), flow_published_at (TIMESTAMPTZ), int64 (INT8), int64ToNumber (NUMERIC), intToNumber (INT8), intWidenedToJson (INT8), multiple (JSON), nonScalarValue (JSON), numericString (NUMERIC), optional (JSON), requiredNumeric (NUMERIC), scalarValue (TEXT), stringWidenedToJson (TEXT), timeValue (TIME), flow_document (JSON)
-1, false, true, 2024-01-01T00:00:00Z, 2024-01-01T01:01:01.111111Z, <nil>, <nil>, 2024-09-13T01:01:01Z, 1, 10000000000000000000, 9223372036854775807, 999, <nil>, <nil>, 123, <nil>, 456, test, hello, 01:01:01, {}
+key (TEXT), _meta/flow_truncated (BOOL), boolWidenedToJson (BOOL), dateValue (DATE), datetimeValue (TIMESTAMPTZ), fieldWithProjection (TEXT), field_with_projection (TEXT), flow_published_at (TIMESTAMPTZ), int64 (INT8), int64ToNumber (NUMERIC), intToNumber (INT8), intWidenedToJson (INT8), multiple (JSON), nonScalarValue (JSON), numericString (NUMERIC), optional (JSON), requiredNumeric (NUMERIC), scalarValue (TEXT), stringAddMaxLength (TEXT), stringIncreaseMaxLength (TEXT), stringWidenedToJson (TEXT), timeValue (TIME), flow_document (JSON)
+1, false, true, 2024-01-01T00:00:00Z, 2024-01-01T01:01:01.111111Z, <nil>, <nil>, 2024-09-13T01:01:01Z, 1, 10000000000000000000, 9223372036854775807, 999, <nil>, <nil>, 123, <nil>, 456, test, <nil>, <nil>, hello, 01:01:01, {}
 
 Migratable Changes Constraints:
 {"Field":"_meta/flow_truncated","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
 {"Field":"boolWidenedToJson","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
 {"Field":"dateValue","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
 {"Field":"datetimeValue","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"fieldWithProjection","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"field_with_projection","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
 {"Field":"flow_document","Type":1,"TypeString":"FIELD_REQUIRED","Reason":"This field is the document in the current materialization"}
 {"Field":"flow_published_at","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
 {"Field":"int64","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
@@ -71,6 +77,8 @@ Migratable Changes Constraints:
 {"Field":"requiredNumeric","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
 {"Field":"scalarValue","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
 {"Field":"second_root","Type":5,"TypeString":"FIELD_FORBIDDEN","Reason":"Cannot materialize root document projection 'second_root' because field 'flow_document' is already being materialized as the document"}
+{"Field":"stringAddMaxLength","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"stringIncreaseMaxLength","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
 {"Field":"stringWidenedToJson","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
 {"Field":"timeValue","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
 
@@ -94,11 +102,13 @@ Migratable Changes Applied Schema:
 {"Name":"optional","Nullable":"YES","Type":"json"}
 {"Name":"requiredNumeric","Nullable":"NO","Type":"text"}
 {"Name":"scalarValue","Nullable":"NO","Type":"text"}
+{"Name":"stringAddMaxLength","Nullable":"YES","Type":"text"}
+{"Name":"stringIncreaseMaxLength","Nullable":"YES","Type":"text"}
 {"Name":"stringWidenedToJson","Nullable":"YES","Type":"json"}
 {"Name":"timeValue","Nullable":"YES","Type":"text"}
 
 
 Migratable Changes Applied Data:
-key (TEXT), _meta/flow_truncated (BOOL), fieldWithProjection (TEXT), field_with_projection (TEXT), flow_published_at (TIMESTAMPTZ), multiple (JSON), nonScalarValue (JSON), optional (JSON), scalarValue (TEXT), flow_document (JSON), boolWidenedToJson (JSON), dateValue (TEXT), datetimeValue (TEXT), int64 (NUMERIC), int64ToNumber (FLOAT8), intToNumber (FLOAT8), intWidenedToJson (JSON), numericString (TEXT), requiredNumeric (TEXT), stringWidenedToJson (JSON), timeValue (TEXT)
-1, false, <nil>, <nil>, 2024-09-13T01:01:01Z, <nil>, <nil>, <nil>, test, {}, true, 2024-01-01, 2024-01-01T01:01:01.111111Z, 1, 1e+19, 9.223372036854776e+18, 999, 123, 456, "hello", 01:01:01
+key (TEXT), _meta/flow_truncated (BOOL), fieldWithProjection (TEXT), field_with_projection (TEXT), flow_published_at (TIMESTAMPTZ), multiple (JSON), nonScalarValue (JSON), optional (JSON), scalarValue (TEXT), stringAddMaxLength (TEXT), stringIncreaseMaxLength (TEXT), flow_document (JSON), boolWidenedToJson (JSON), dateValue (TEXT), datetimeValue (TEXT), int64 (NUMERIC), int64ToNumber (FLOAT8), intToNumber (FLOAT8), intWidenedToJson (JSON), numericString (TEXT), requiredNumeric (TEXT), stringWidenedToJson (JSON), timeValue (TEXT)
+1, false, <nil>, <nil>, 2024-09-13T01:01:01Z, <nil>, <nil>, <nil>, test, <nil>, <nil>, {}, true, 2024-01-01, 2024-01-01T01:01:01.111111Z, 1, 1e+19, 9.223372036854776e+18, 999, 123, 456, "hello", 01:01:01
 

--- a/materialize-postgres/config_test.go
+++ b/materialize-postgres/config_test.go
@@ -21,21 +21,21 @@ func TestPostgresConfig(t *testing.T) {
 	require.NoError(t, validConfig.Validate())
 	uri, err := validConfig.ToURI(context.Background())
 	require.NoError(t, err)
-	require.Equal(t, "postgres://youser:shmassword@post.toast:1234/namegame", uri)
+	require.Equal(t, "postgres://youser:shmassword@post.toast:1234/namegame?tcp_keepalives_count=6&tcp_keepalives_idle=120&tcp_keepalives_interval=30", uri)
 
 	var minimal = validConfig
 	minimal.Database = ""
 	require.NoError(t, minimal.Validate())
 	uri, err = minimal.ToURI(context.Background())
 	require.NoError(t, err)
-	require.Equal(t, "postgres://youser:shmassword@post.toast:1234", uri)
+	require.Equal(t, "postgres://youser:shmassword@post.toast:1234?tcp_keepalives_count=6&tcp_keepalives_idle=120&tcp_keepalives_interval=30", uri)
 
 	var noPort = validConfig
 	noPort.Address = "post.toast"
 	require.NoError(t, noPort.Validate())
 	uri, err = noPort.ToURI(context.Background())
 	require.NoError(t, err)
-	require.Equal(t, "postgres://youser:shmassword@post.toast:5432/namegame", uri)
+	require.Equal(t, "postgres://youser:shmassword@post.toast:5432/namegame?tcp_keepalives_count=6&tcp_keepalives_idle=120&tcp_keepalives_interval=30", uri)
 
 	var noAddress = validConfig
 	noAddress.Address = ""

--- a/materialize-postgres/driver.go
+++ b/materialize-postgres/driver.go
@@ -232,9 +232,14 @@ func (c config) ToURI(ctx context.Context) (string, error) {
 		// Enable SSL for cloud provider IAM connections by default when not explicitly set
 		params.Set("sslmode", "require")
 	}
-	if len(params) > 0 {
-		uri.RawQuery = params.Encode()
-	}
+
+	// Set a short keepalive interval to detect half-open connections more
+	// quickly.  The default is OS specific, but is over 2 hours on many
+	// systems.  This will detect within 120 + (30 * 6) = 5 minutes
+	params.Set("tcp_keepalives_idle", "120")
+	params.Set("tcp_keepalives_interval", "30")
+	params.Set("tcp_keepalives_count", "6")
+	uri.RawQuery = params.Encode()
 
 	return uri.String(), nil
 }

--- a/materialize-postgres/driver_test.go
+++ b/materialize-postgres/driver_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	stdsql "database/sql"
 	"fmt"
+	"net/url"
 	"strings"
 	"testing"
 
@@ -18,7 +19,7 @@ import (
 
 func testConfig() config {
 	return config{
-		Address:  "localhost:5432",
+		Address:  *dbAddress,
 		User:     "flow",
 		Password: "flow",
 		Database: "flow",
@@ -78,7 +79,14 @@ func TestValidateAndApplyMigrations(t *testing.T) {
 
 	uri, err := cfg.ToURI(ctx)
 	require.NoError(t, err)
-	db, err := stdsql.Open("pgx", uri+"?default_query_exec_mode=exec")
+
+	u, err := url.Parse(uri)
+	require.NoError(t, err)
+	params := u.Query()
+	params.Set("default_query_exec_mode", "exec")
+	u.RawQuery = params.Encode()
+
+	db, err := stdsql.Open("pgx", u.String())
 	require.NoError(t, err)
 	defer db.Close()
 
@@ -132,7 +140,7 @@ func TestValidateAndApplyMigrations(t *testing.T) {
 func TestFencingCases(t *testing.T) {
 	var ctx = context.Background()
 
-	c, err := newClient(ctx, "", &sql.Endpoint[config]{Config: testConfig()})
+	c, err := newClient(ctx, "", &sql.Endpoint[config]{Config: testConfig(), Dialect: testDialect})
 	require.NoError(t, err)
 	defer c.Close()
 

--- a/materialize-postgres/main_test.go
+++ b/materialize-postgres/main_test.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"flag"
+	"os"
+	"runtime/debug"
+	"testing"
+
+	log "github.com/sirupsen/logrus"
+)
+
+var (
+	dbAddress = flag.String("db_address", "localhost:5432", "The database server address")
+)
+
+func TestMain(m *testing.M) {
+	flag.Parse()
+
+	if logLevel := os.Getenv("LOG_LEVEL"); logLevel != "" {
+		level, err := log.ParseLevel(logLevel)
+		if err != nil {
+			log.WithField("level", logLevel).Fatal("invalid log level")
+		}
+		log.SetLevel(level)
+	}
+
+	// Set a 900MiB memory limit, same as we use in production.
+	debug.SetMemoryLimit(900 * 1024 * 1024)
+
+	os.Exit(m.Run())
+}

--- a/source-postgres-batch/main.go
+++ b/source-postgres-batch/main.go
@@ -126,9 +126,14 @@ func (c *Config) ToURI() string {
 			params.Set("options", fmt.Sprintf("-c statement_timeout=%d", timeout.Milliseconds()))
 		}
 	}
-	if len(params) > 0 {
-		uri.RawQuery = params.Encode()
-	}
+
+	// Set a short keepalive interval to detect half-open connections more
+	// quickly.  The default is OS specific, but is over 2 hours on many
+	// systems.  This will detect within 120 + (30 * 6) = 5 minutes
+	params.Set("tcp_keepalives_idle", "120")
+	params.Set("tcp_keepalives_interval", "30")
+	params.Set("tcp_keepalives_count", "6")
+	uri.RawQuery = params.Encode()
 	return uri.String()
 }
 


### PR DESCRIPTION
**Description:**

In some situations a half-open connections cannot be timed out using the idle_timeout, idle_in_transaction_session_timeout settings.  In these cases, it is useful to have tcp_keepalive reduced to detect the error more quickly since the default is longer than 2 hours on most systems.

Changes to `TestFencingCases` to fix preexisting failure that is normally excluded by `-tags nodb`.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

I was not able to duplicate this issue, but it has been reported in the wild on the server side.  This doesn't add an new timeouts, so it ought to be safe.  I didn't attempt to add this to source-postgres, because it didn't look like `pgconn.ParseConfig` supported these connection parameters, so perhaps we need another method there.

