### PR TITLE
source-postgres: Set TCP keepalive params

### DIFF
--- a/source-postgres/.snapshots/TestConfigURI-Basic
+++ b/source-postgres/.snapshots/TestConfigURI-Basic
@@ -1,2 +1,2 @@
-postgres://will:secret1234@example.com:5432/somedb?application_name=estuary_flow
+postgres://will:secret1234@example.com:5432/somedb?application_name=estuary_flow&tcp_keepalives_count=6&tcp_keepalives_idle=120&tcp_keepalives_interval=30
 config valid

--- a/source-postgres/.snapshots/TestConfigURI-IncorrectSSL
+++ b/source-postgres/.snapshots/TestConfigURI-IncorrectSSL
@@ -1,2 +1,2 @@
-postgres://will:secret1234@example.com:5432/somedb?application_name=estuary_flow&sslmode=whoops-this-isnt-right
+postgres://will:secret1234@example.com:5432/somedb?application_name=estuary_flow&sslmode=whoops-this-isnt-right&tcp_keepalives_count=6&tcp_keepalives_idle=120&tcp_keepalives_interval=30
 invalid 'sslmode' configuration: unknown setting "whoops-this-isnt-right"

--- a/source-postgres/.snapshots/TestConfigURI-RequireSSL
+++ b/source-postgres/.snapshots/TestConfigURI-RequireSSL
@@ -1,2 +1,2 @@
-postgres://will:secret1234@example.com:5432/somedb?application_name=estuary_flow&sslmode=verify-full
+postgres://will:secret1234@example.com:5432/somedb?application_name=estuary_flow&sslmode=verify-full&tcp_keepalives_count=6&tcp_keepalives_idle=120&tcp_keepalives_interval=30
 config valid

--- a/source-postgres/main.go
+++ b/source-postgres/main.go
@@ -365,6 +365,13 @@ func (c *Config) ToURI(ctx context.Context) (string, error) {
 	var params = make(url.Values)
 	params.Set("application_name", "estuary_flow")
 
+	// Lower TCP keepalive settings so that half-open connections are detected more
+	// quickly. With these settings a dead connection will be noticed within ~5 minutes
+	// rather than the OS default of 2+ hours.
+	params.Set("tcp_keepalives_idle", "120")
+	params.Set("tcp_keepalives_interval", "30")
+	params.Set("tcp_keepalives_count", "6")
+
 	// Set SSL mode - user configuration takes precedence, then cloud IAM defaults
 	if c.Advanced.SSLMode != "" {
 		params.Set("sslmode", c.Advanced.SSLMode)


### PR DESCRIPTION
**Description:**

Copies https://github.com/estuary/connectors/pull/4027 and adds keepalives to `source-postgres`. Seems to work fine.

**Workflow steps:**

No user action required, TCP connection failures should be detected more readily in some cases.