### PR TITLE
fix: generate-fixture needs 'commit' not 'ack'

### DIFF
--- a/tests/materialize/generate-fixture.py
+++ b/tests/materialize/generate-fixture.py
@@ -110,8 +110,8 @@ def write_phase_documents(f, collection: str, schema: dict, properties: list[str
         f.write(json.dumps(entry, separators=(',', ':')) + '\n')
 
 def write_ack(f):
-    """Write an ack marker to indicate end of transaction."""
-    f.write('{"ack":true}\n')
+    """Write a commit marker to indicate end of transaction."""
+    f.write('{"commit":true}\n')
 
 def main():
     if len(sys.argv) != 3:


### PR DESCRIPTION
**Description:**

Running ClickHouse integration tests #4022 with `PERF_DOC_COUNT` yields an error suggesting the `ack` key was replaced with `commit`.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

