### PR TITLE
materialize-snowflake: rename and reencrypt files on recovery

### DIFF
--- a/materialize-snowflake/bdec.go
+++ b/materialize-snowflake/bdec.go
@@ -416,22 +416,24 @@ func getCipherStream(encryptionKey string, fileName blobFileName) (cipher.Stream
 	return cipher.NewCTR(block, make([]byte, aes.BlockSize)), nil
 }
 
-// reencrypt reads encrypted blob data from r, decrypts it using the encryption
-// key and original file name, and then re-encrypts it using the new file name
-// and writes the output to w. The blob metadata is updated in place.
+// reencrypt reads encrypted blob data from r, decrypts it using the
+// decryptKey and original file name, and then re-encrypts it using the
+// new file name and writes the output to w. The blob metadata is updated in
+// place.
 func reencrypt(
 	r io.Reader,
 	w io.Writer,
 	blob *blobMetadata,
-	encryptionKey string,
+	decryptKey string,
+	channel *channel,
 	newFileName blobFileName,
 ) error {
-	decryptStream, err := getCipherStream(encryptionKey, blobFileName(blob.Path))
+	decryptStream, err := getCipherStream(decryptKey, blobFileName(blob.Path))
 	if err != nil {
 		return fmt.Errorf("getting decryptStream: %w", err)
 	}
 
-	encryptStream, err := getCipherStream(encryptionKey, newFileName)
+	encryptStream, err := getCipherStream(channel.EncryptionKey, newFileName)
 	if err != nil {
 		return fmt.Errorf("getting encryptStream: %w", err)
 	}
@@ -479,7 +481,6 @@ func reencrypt(
 		if err != nil && !errors.Is(err, io.EOF) {
 			return fmt.Errorf("reading from r: %w", err)
 		}
-		fmt.Println(n, err)
 	}
 
 	downHash := hex.EncodeToString(downMd5.Sum(nil))
@@ -491,6 +492,7 @@ func reencrypt(
 	blob.Path = string(newFileName)
 	blob.MD5 = upHash
 	blob.Chunks[0].ChunkMD5 = upHash
+	blob.Chunks[0].EncryptionKeyID = channel.EncryptionKeyId
 
 	return nil
 }

--- a/materialize-snowflake/bdec_test.go
+++ b/materialize-snowflake/bdec_test.go
@@ -133,6 +133,11 @@ func TestReencrypt(t *testing.T) {
 	sum := md5.Sum(encrypted)
 	hsh := hex.EncodeToString(sum[:])
 
+	channel := &channel{
+		EncryptionKey:   encryptionKey,
+		EncryptionKeyId: 12345,
+	}
+
 	blob := &blobMetadata{
 		Path:   string(oldFileName),
 		MD5:    hsh,
@@ -142,7 +147,7 @@ func TestReencrypt(t *testing.T) {
 	var in = bytes.NewReader(encrypted)
 	var out bytes.Buffer
 
-	err = reencrypt(in, &out, blob, encryptionKey, newFileName)
+	err = reencrypt(in, &out, blob, encryptionKey, channel, newFileName)
 	require.NoError(t, err)
 
 	// The re-encrypted file matches the original input.

--- a/materialize-snowflake/snowflake.go
+++ b/materialize-snowflake/snowflake.go
@@ -582,13 +582,14 @@ func (d *transactor) pipeExists(ctx context.Context, pipeName string) (bool, err
 }
 
 type checkpointItem struct {
-	Table       string
-	Query       string
-	StagedDir   string
-	StreamBlobs []*blobMetadata
-	PipeName    string
-	PipeFiles   []fileRecord
-	Version     string
+	Table         string
+	Query         string
+	StagedDir     string
+	StreamBlobs   []*blobMetadata
+	PipeName      string
+	PipeFiles     []fileRecord
+	Version       string
+	EncryptionKey string
 }
 
 type checkpoint = map[string]*checkpointItem
@@ -637,6 +638,7 @@ func (d *transactor) Store(it *m.StoreIterator) (m.StartCommitFunc, error) {
 
 func (d *transactor) buildDriverCheckpoint(ctx context.Context, runtimeCheckpoint *protocol.Checkpoint) (json.RawMessage, error) {
 	streamBlobs := make(map[int][]*blobMetadata)
+	keys := make(map[int]string)
 	if d.streamManager != nil {
 		// The "base token" only really needs to be sufficiently random that it
 		// doesn't collide with the prior or next transaction's value. Deriving
@@ -644,7 +646,7 @@ func (d *transactor) buildDriverCheckpoint(ctx context.Context, runtimeCheckpoin
 		// convenient to make testing outputs consistent.
 		if mcp, err := runtimeCheckpoint.Marshal(); err != nil {
 			return nil, fmt.Errorf("marshalling checkpoint: %w", err)
-		} else if streamBlobs, err = d.streamManager.flush(fmt.Sprintf("%016x", xxhash.Sum64(mcp))); err != nil {
+		} else if streamBlobs, keys, err = d.streamManager.flush(fmt.Sprintf("%016x", xxhash.Sum64(mcp))); err != nil {
 			return nil, fmt.Errorf("flushing stream manager: %w", err)
 		}
 	}
@@ -653,7 +655,8 @@ func (d *transactor) buildDriverCheckpoint(ctx context.Context, runtimeCheckpoin
 		if b.streaming {
 			if blobs, ok := streamBlobs[idx]; ok {
 				d.cp[b.target.StateKey] = &checkpointItem{
-					StreamBlobs: blobs,
+					StreamBlobs:   blobs,
+					EncryptionKey: keys[idx],
 				}
 			}
 			continue
@@ -882,7 +885,7 @@ func (d *transactor) Acknowledge(ctx context.Context) (*pf.ConnectorState, error
 		} else if len(item.StreamBlobs) > 0 {
 			group.Go(func() error {
 				d.be.StartedResourceCommit(path)
-				if err := d.streamManager.write(groupCtx, item.StreamBlobs, !d.didRecovery); err != nil {
+				if err := d.streamManager.write(groupCtx, item.StreamBlobs, item.EncryptionKey, !d.didRecovery); err != nil {
 					return fmt.Errorf("writing streaming blobs for %s: %w", path, err)
 				}
 				d.be.FinishedResourceCommit(path)

--- a/materialize-snowflake/stream.go
+++ b/materialize-snowflake/stream.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"path"
 	"strconv"
@@ -170,14 +169,15 @@ func (sm *streamManager) objMetadata() blob.WriterOption {
 	})
 }
 
-func (sm *streamManager) flush(baseToken string) (map[int][]*blobMetadata, error) {
+func (sm *streamManager) flush(baseToken string) (map[int][]*blobMetadata, map[int]string, error) {
 	if sm.bdecWriter != nil {
 		if err := sm.finishBlob(); err != nil {
-			return nil, fmt.Errorf("finishBlob: %w", err)
+			return nil, nil, fmt.Errorf("finishBlob: %w", err)
 		}
 	}
 
 	out := make(map[int][]*blobMetadata)
+	keys := make(map[int]string)
 	for binding, trackedBlobs := range sm.blobStats {
 		for idx, trackedBlob := range trackedBlobs {
 			out[binding] = append(out[binding], generateBlobMetadata(
@@ -185,11 +185,12 @@ func (sm *streamManager) flush(baseToken string) (map[int][]*blobMetadata, error
 				sm.tableStreams[binding].channel,
 				blobToken(baseToken, idx)),
 			)
+			keys[binding] = sm.tableStreams[binding].channel.EncryptionKey
 		}
 	}
 	maps.Clear(sm.blobStats)
 
-	return out, nil
+	return out, keys, nil
 }
 
 // write registers a series of blobs to the table. All the blobs must be for the
@@ -208,7 +209,7 @@ func (sm *streamManager) flush(baseToken string) (map[int][]*blobMetadata, error
 // channel itself persists the last registered token, and this allows us to
 // filter out blobs that had previously been registered and don't need
 // registered again on a re-attempt of an Acknowledge.
-func (sm *streamManager) write(ctx context.Context, blobs []*blobMetadata, recovery bool) error {
+func (sm *streamManager) write(ctx context.Context, blobs []*blobMetadata, decryptKey string, recovery bool) error {
 	if err := validWriteBlobs(blobs); err != nil {
 		return fmt.Errorf("validWriteBlobs: %w", err)
 	}
@@ -248,48 +249,41 @@ func (sm *streamManager) write(ctx context.Context, blobs []*blobMetadata, recov
 		blob.Chunks[0].Channels[0].RowSequencer = thisChannel.RowSequencer + 1
 
 		if recovery {
+			// Handle the case where decryptKey was not in the checkpoint because
+			// the checkpoint was created before it was added.  We will guess that
+			// its the same as the current key, if its not then the decrypted
+			// data will not have the parquet magic header.
+			//
+			// This check can be removed once all tasks have written a checkpoint.
+			if decryptKey == "" {
+				decryptKey = thisChannel.EncryptionKey
+			}
+
 			// Always use the rename and re-upload strategy during recovery
 			// commits. This prevents issues where blobs could be re-registered
 			// if the underlying channel has changed somehow, perhaps by being
 			// dropped out-of-band, or its last persisted token changed in some
 			// other way.
 			//
+			// It is also possible the channel encryption key has changed and
+			// the blob will need to be rewritten with the new encryption key.
+			//
+			// This also address the "blob has wrong format or extension" error
+			// which occurs if the blob was written not-so-recently; apparently
+			// anything older than an hour or so is rejected by what seems to
+			// be a server-side check the examines the name of the file, which
+			// contains the timestamp it was written.  In this case, which
+			// may arise from re-enabling a disabled binding / materialization,
+			// or extended outages, we have to download the file and re-upload
+			// it with an up-to-date name.
+			//
 			// This should be a relatively infrequent occurrence, so the
 			// performance impact + increased data transfer should be tolerable.
-			if err := sm.writeRenamed(ctx, thisChannel, blob); err != nil {
+			if err := sm.writeRenamed(ctx, decryptKey, thisChannel, blob); err != nil {
 				return fmt.Errorf("writeRenamed: %w", err)
 			}
 		} else if err := sm.c.write(ctx, blob); err != nil {
-			var apiError *streamingApiError
-			if errors.As(err, &apiError) && apiError.Code == 38 {
-				// The "blob has wrong format or extension" error occurs if the
-				// blob was written not-so-recently; apparently anything older
-				// than an hour or so is rejected by what seems to be a
-				// server-side check the examines the name of the file, which
-				// contains the timestamp it was written.
-				//
-				// In these cases, which may arise from re-enabling a disabled
-				// binding / materialization, or extended outages, we have to
-				// download the file and re-upload it with an up-to-date name.
-				//
-				// This should be quite rare, even more rare than one may think,
-				// since blob registration tokens are persisted in Snowflake
-				// rather than exclusively managed by our Acknowledge
-				// checkpoints. But it is still technically possible and so it
-				// is handled with this.
-				log.WithFields(log.Fields{
-					"name":   blob.Path,
-					"token":  blobToken,
-					"schema": blob.Chunks[0].Schema,
-					"table":  blob.Chunks[0].Table,
-				}).Warn("blob rejected for malformed name; will attempt to register by renaming")
-
-				if err := sm.writeRenamed(ctx, thisChannel, blob); err != nil {
-					return fmt.Errorf("writeRenamed: %w", err)
-				}
-			} else {
-				return fmt.Errorf("write: %w", err)
-			}
+			return fmt.Errorf("write: %w", err)
 		}
 
 		thisChannel.RowSequencer++
@@ -313,7 +307,7 @@ func (sm *streamManager) write(ctx context.Context, blobs []*blobMetadata, recov
 	return nil
 }
 
-func (sm *streamManager) writeRenamed(ctx context.Context, channel *channel, blob *blobMetadata) error {
+func (sm *streamManager) writeRenamed(ctx context.Context, decryptKey string, channel *channel, blob *blobMetadata) error {
 	if err := sm.maybeInitializeBucket(ctx); err != nil {
 		return fmt.Errorf("initializing bucket to rename: %w", err)
 	}
@@ -328,7 +322,7 @@ func (sm *streamManager) writeRenamed(ctx context.Context, channel *channel, blo
 	})
 	ll.Info("attempting to register blob by renaming")
 
-	if err := sm.renameBlob(ctx, blob, channel.EncryptionKey, nextName); err != nil {
+	if err := sm.renameBlob(ctx, blob, decryptKey, channel, nextName); err != nil {
 		return fmt.Errorf("renameBlob: %w", err)
 	}
 
@@ -341,14 +335,20 @@ func (sm *streamManager) writeRenamed(ctx context.Context, channel *channel, blo
 	return nil
 }
 
-func (sm *streamManager) renameBlob(ctx context.Context, blob *blobMetadata, encryptionKey string, newName blobFileName) error {
+func (sm *streamManager) renameBlob(
+	ctx context.Context,
+	blob *blobMetadata,
+	decryptKey string,
+	channel *channel,
+	newName blobFileName,
+) error {
 	r, err := sm.bucket.NewReader(ctx, path.Join(sm.bucketPath, blob.Path))
 	if err != nil {
 		return fmt.Errorf("NewReader: %w", err)
 	}
 	w := sm.bucket.NewWriter(ctx, path.Join(sm.bucketPath, string(newName)), sm.objMetadata())
 
-	if err := reencrypt(r, w, blob, encryptionKey, newName); err != nil {
+	if err := reencrypt(r, w, blob, decryptKey, channel, newName); err != nil {
 		return fmt.Errorf("reencrypt: %w", err)
 	} else if err := r.Close(); err != nil {
 		return fmt.Errorf("closing r: %w", err)

--- a/tests/materialize/materialize-snowflake/checks.sh
+++ b/tests/materialize/materialize-snowflake/checks.sh
@@ -6,6 +6,7 @@ fi
 $SED_CMD -i'' 's/@flow_v1\/.\{36\}/<uuid>/g' ${SNAPSHOT}
 $SED_CMD -i'' 's/"Path": ".*"/"Path": "<uuid>"/g' ${SNAPSHOT}
 $SED_CMD -i'' 's/"PipeStartTime": ".\{1,\}"/"PipeStartTime": "<timestamp>"/g' ${SNAPSHOT}
+$SED_CMD -i'' 's/"EncryptionKey": ".*"/"EncryptionKey": "<encryption_key>"/g' ${SNAPSHOT}
 $SED_CMD -i'' 's/"path": ".*"/"path": "<path>"/g' ${SNAPSHOT}
 $SED_CMD -i'' 's/"md5": ".*"/"md5": "<md5>"/g' ${SNAPSHOT}
 $SED_CMD -i'' 's/"chunk_length": [0-9]\+/"chunk_length": "<chunk_length>"/g' ${SNAPSHOT}

--- a/tests/materialize/materialize-snowflake/snapshot.json
+++ b/tests/materialize/materialize-snowflake/snapshot.json
@@ -20,7 +20,8 @@
         "StreamBlobs": null,
         "PipeName": "",
         "PipeFiles": null,
-        "Version": ""
+        "Version": "",
+        "EncryptionKey": "<encryption_key>"
       },
       "all_key_types_part_three": {
         "Table": "all_key_types_part_three",
@@ -29,7 +30,8 @@
         "StreamBlobs": null,
         "PipeName": "",
         "PipeFiles": null,
-        "Version": ""
+        "Version": "",
+        "EncryptionKey": "<encryption_key>"
       },
       "all_key_types_part_two": {
         "Table": "all_key_types_part_two",
@@ -38,7 +40,8 @@
         "StreamBlobs": null,
         "PipeName": "",
         "PipeFiles": null,
-        "Version": ""
+        "Version": "",
+        "EncryptionKey": "<encryption_key>"
       },
       "deletions": {
         "Table": "deletions",
@@ -47,7 +50,8 @@
         "StreamBlobs": null,
         "PipeName": "",
         "PipeFiles": null,
-        "Version": ""
+        "Version": "",
+        "EncryptionKey": "<encryption_key>"
       },
       "duplicate%20keys%20%40%20with%20spaces": {
         "Table": "",
@@ -154,7 +158,8 @@
         ],
         "PipeName": "",
         "PipeFiles": null,
-        "Version": ""
+        "Version": "",
+        "EncryptionKey": "<encryption_key>"
       },
       "duplicate_keys_delta": {
         "Table": "",
@@ -261,7 +266,8 @@
         ],
         "PipeName": "",
         "PipeFiles": null,
-        "Version": ""
+        "Version": "",
+        "EncryptionKey": "<encryption_key>"
       },
       "duplicate_keys_delta_exclude_flow_doc": {
         "Table": "",
@@ -368,7 +374,8 @@
         ],
         "PipeName": "",
         "PipeFiles": null,
-        "Version": ""
+        "Version": "",
+        "EncryptionKey": "<encryption_key>"
       },
       "duplicate_keys_standard": {
         "Table": "duplicate_keys_standard",
@@ -377,7 +384,8 @@
         "StreamBlobs": null,
         "PipeName": "",
         "PipeFiles": null,
-        "Version": ""
+        "Version": "",
+        "EncryptionKey": "<encryption_key>"
       },
       "fields_with_projections": {
         "Table": "fields_with_projections",
@@ -386,7 +394,8 @@
         "StreamBlobs": null,
         "PipeName": "",
         "PipeFiles": null,
-        "Version": ""
+        "Version": "",
+        "EncryptionKey": "<encryption_key>"
       },
       "formatted_strings": {
         "Table": "formatted_strings",
@@ -395,7 +404,8 @@
         "StreamBlobs": null,
         "PipeName": "",
         "PipeFiles": null,
-        "Version": ""
+        "Version": "",
+        "EncryptionKey": "<encryption_key>"
       },
       "many_columns": {
         "Table": "many_columns",
@@ -404,7 +414,8 @@
         "StreamBlobs": null,
         "PipeName": "",
         "PipeFiles": null,
-        "Version": ""
+        "Version": "",
+        "EncryptionKey": "<encryption_key>"
       },
       "multiple_types": {
         "Table": "multiple_types",
@@ -413,7 +424,8 @@
         "StreamBlobs": null,
         "PipeName": "",
         "PipeFiles": null,
-        "Version": ""
+        "Version": "",
+        "EncryptionKey": "<encryption_key>"
       },
       "optional_non_nullable": {
         "Table": "optional_non_nullable",
@@ -422,7 +434,8 @@
         "StreamBlobs": null,
         "PipeName": "",
         "PipeFiles": null,
-        "Version": ""
+        "Version": "",
+        "EncryptionKey": "<encryption_key>"
       },
       "simple": {
         "Table": "simple",
@@ -431,7 +444,8 @@
         "StreamBlobs": null,
         "PipeName": "",
         "PipeFiles": null,
-        "Version": ""
+        "Version": "",
+        "EncryptionKey": "<encryption_key>"
       },
       "string_escaped_key": {
         "Table": "string_escaped_key",
@@ -440,7 +454,8 @@
         "StreamBlobs": null,
         "PipeName": "",
         "PipeFiles": null,
-        "Version": ""
+        "Version": "",
+        "EncryptionKey": "<encryption_key>"
       },
       "symbols": {
         "Table": "symbols",
@@ -449,7 +464,8 @@
         "StreamBlobs": null,
         "PipeName": "",
         "PipeFiles": null,
-        "Version": ""
+        "Version": "",
+        "EncryptionKey": "<encryption_key>"
       },
       "timezone_datetimes_delta": {
         "Table": "",
@@ -556,7 +572,8 @@
         ],
         "PipeName": "",
         "PipeFiles": null,
-        "Version": ""
+        "Version": "",
+        "EncryptionKey": "<encryption_key>"
       },
       "timezone_datetimes_standard": {
         "Table": "timezone_datetimes_standard",
@@ -565,7 +582,8 @@
         "StreamBlobs": null,
         "PipeName": "",
         "PipeFiles": null,
-        "Version": ""
+        "Version": "",
+        "EncryptionKey": "<encryption_key>"
       },
       "unsigned_bigint": {
         "Table": "unsigned_bigint",
@@ -574,7 +592,8 @@
         "StreamBlobs": null,
         "PipeName": "",
         "PipeFiles": null,
-        "Version": ""
+        "Version": "",
+        "EncryptionKey": "<encryption_key>"
       }
     },
     "mergePatch": true
@@ -591,7 +610,8 @@
         "StreamBlobs": null,
         "PipeName": "",
         "PipeFiles": null,
-        "Version": "ffffffffffffffff"
+        "Version": "ffffffffffffffff",
+        "EncryptionKey": "<encryption_key>"
       },
       "all_key_types_part_three": {
         "Table": "all_key_types_part_three",
@@ -600,7 +620,8 @@
         "StreamBlobs": null,
         "PipeName": "",
         "PipeFiles": null,
-        "Version": "ffffffffffffffff"
+        "Version": "ffffffffffffffff",
+        "EncryptionKey": "<encryption_key>"
       },
       "all_key_types_part_two": {
         "Table": "all_key_types_part_two",
@@ -609,7 +630,8 @@
         "StreamBlobs": null,
         "PipeName": "",
         "PipeFiles": null,
-        "Version": "ffffffffffffffff"
+        "Version": "ffffffffffffffff",
+        "EncryptionKey": "<encryption_key>"
       },
       "deletions": {
         "Table": "deletions",
@@ -618,7 +640,8 @@
         "StreamBlobs": null,
         "PipeName": "",
         "PipeFiles": null,
-        "Version": "ffffffffffffffff"
+        "Version": "ffffffffffffffff",
+        "EncryptionKey": "<encryption_key>"
       },
       "duplicate%20keys%20%40%20with%20spaces": {
         "Table": "",
@@ -725,7 +748,8 @@
         ],
         "PipeName": "",
         "PipeFiles": null,
-        "Version": ""
+        "Version": "",
+        "EncryptionKey": "<encryption_key>"
       },
       "duplicate_keys_delta": {
         "Table": "",
@@ -832,7 +856,8 @@
         ],
         "PipeName": "",
         "PipeFiles": null,
-        "Version": ""
+        "Version": "",
+        "EncryptionKey": "<encryption_key>"
       },
       "duplicate_keys_delta_exclude_flow_doc": {
         "Table": "",
@@ -939,7 +964,8 @@
         ],
         "PipeName": "",
         "PipeFiles": null,
-        "Version": ""
+        "Version": "",
+        "EncryptionKey": "<encryption_key>"
       },
       "duplicate_keys_standard": {
         "Table": "duplicate_keys_standard",
@@ -948,7 +974,8 @@
         "StreamBlobs": null,
         "PipeName": "",
         "PipeFiles": null,
-        "Version": "ffffffffffffffff"
+        "Version": "ffffffffffffffff",
+        "EncryptionKey": "<encryption_key>"
       },
       "fields_with_projections": {
         "Table": "fields_with_projections",
@@ -957,7 +984,8 @@
         "StreamBlobs": null,
         "PipeName": "",
         "PipeFiles": null,
-        "Version": "ffffffffffffffff"
+        "Version": "ffffffffffffffff",
+        "EncryptionKey": "<encryption_key>"
       },
       "formatted_strings": {
         "Table": "formatted_strings",
@@ -966,7 +994,8 @@
         "StreamBlobs": null,
         "PipeName": "",
         "PipeFiles": null,
-        "Version": ""
+        "Version": "",
+        "EncryptionKey": "<encryption_key>"
       },
       "many_columns": {
         "Table": "many_columns",
@@ -975,7 +1004,8 @@
         "StreamBlobs": null,
         "PipeName": "",
         "PipeFiles": null,
-        "Version": "ffffffffffffffff"
+        "Version": "ffffffffffffffff",
+        "EncryptionKey": "<encryption_key>"
       },
       "multiple_types": {
         "Table": "multiple_types",
@@ -984,7 +1014,8 @@
         "StreamBlobs": null,
         "PipeName": "",
         "PipeFiles": null,
-        "Version": "ffffffffffffffff"
+        "Version": "ffffffffffffffff",
+        "EncryptionKey": "<encryption_key>"
       },
       "optional_non_nullable": {
         "Table": "optional_non_nullable",
@@ -993,7 +1024,8 @@
         "StreamBlobs": null,
         "PipeName": "",
         "PipeFiles": null,
-        "Version": "ffffffffffffffff"
+        "Version": "ffffffffffffffff",
+        "EncryptionKey": "<encryption_key>"
       },
       "simple": {
         "Table": "simple",
@@ -1002,7 +1034,8 @@
         "StreamBlobs": null,
         "PipeName": "",
         "PipeFiles": null,
-        "Version": ""
+        "Version": "",
+        "EncryptionKey": "<encryption_key>"
       },
       "string_escaped_key": {
         "Table": "string_escaped_key",
@@ -1011,7 +1044,8 @@
         "StreamBlobs": null,
         "PipeName": "",
         "PipeFiles": null,
-        "Version": "ffffffffffffffff"
+        "Version": "ffffffffffffffff",
+        "EncryptionKey": "<encryption_key>"
       }
     },
     "mergePatch": true
@@ -1126,7 +1160,8 @@
         ],
         "PipeName": "",
         "PipeFiles": null,
-        "Version": ""
+        "Version": "",
+        "EncryptionKey": "<encryption_key>"
       },
       "duplicate_keys_delta": {
         "Table": "",
@@ -1233,7 +1268,8 @@
         ],
         "PipeName": "",
         "PipeFiles": null,
-        "Version": ""
+        "Version": "",
+        "EncryptionKey": "<encryption_key>"
       },
       "duplicate_keys_delta_exclude_flow_doc": {
         "Table": "",
@@ -1340,7 +1376,8 @@
         ],
         "PipeName": "",
         "PipeFiles": null,
-        "Version": ""
+        "Version": "",
+        "EncryptionKey": "<encryption_key>"
       },
       "duplicate_keys_standard": {
         "Table": "duplicate_keys_standard",
@@ -1349,7 +1386,8 @@
         "StreamBlobs": null,
         "PipeName": "",
         "PipeFiles": null,
-        "Version": ""
+        "Version": "",
+        "EncryptionKey": "<encryption_key>"
       }
     },
     "mergePatch": true
@@ -1360,6 +1398,7 @@
   {
     "updated": {
       "duplicate%20keys%20%40%20with%20spaces": {
+        "EncryptionKey": "<encryption_key>",
         "PipeName": "",
         "Query": "",
         "StagedDir": "",
@@ -1466,6 +1505,7 @@
         "Version": ""
       },
       "duplicate_keys_delta": {
+        "EncryptionKey": "<encryption_key>",
         "PipeName": "",
         "Query": "",
         "StagedDir": "",
@@ -1572,6 +1612,7 @@
         "Version": ""
       },
       "duplicate_keys_delta_exclude_flow_doc": {
+        "EncryptionKey": "<encryption_key>",
         "PipeName": "",
         "Query": "",
         "StagedDir": "",
@@ -1678,6 +1719,7 @@
         "Version": ""
       },
       "duplicate_keys_standard": {
+        "EncryptionKey": "<encryption_key>",
         "PipeName": "",
         "Query": "\nCOPY INTO duplicate_keys_standard (\n\tid, flow_published_at, int, str\n) FROM (\n\tSELECT $1[0] AS id, $1[1] AS flow_published_at, $1[2] AS int, $1[3] AS str\n\tFROM <uuid>\n);\n",
         "StagedDir": "<uuid>",


### PR DESCRIPTION
**Description:**

This PR revives the commits reverted in #3906, correcting the conditional bug in #3899 and adding an additional new check to ensure decrypted blobs have valid parquet magic bytes.  If the blobs are not valid, probably we have the wrong key and unfortunately the user will need to backfill.

**Workflow steps:**

NA

**Documentation links affected:**

None

**Notes for reviewers:**

I tested this manually by adding delays and deleting tables while in the Acknowledge step.  This forces the channel to change its encryption key and clears the persisted checkpoint.

