### PR TITLE
materialize-{postgres,cratedb.redshift}: always 2-part resource path

### DIFF
--- a/materialize-cratedb/driver.go
+++ b/materialize-cratedb/driver.go
@@ -178,13 +178,7 @@ func (c tableConfig) WithDefaults(cfg config) tableConfig {
 }
 
 func (c tableConfig) Parameters() ([]string, bool, error) {
-	var path []string
-	if c.Schema != "" {
-		path = []string{c.Schema, normalizeColumn(c.Table)}
-	} else {
-		path = []string{normalizeColumn(c.Table)}
-	}
-	return path, c.Delta, nil
+	return []string{c.Schema, normalizeColumn(c.Table)}, c.Delta, nil
 }
 
 func newPostgresDriver() *sql.Driver[config, tableConfig] {

--- a/materialize-postgres/driver.go
+++ b/materialize-postgres/driver.go
@@ -278,13 +278,7 @@ func (r tableConfig) Validate() error {
 }
 
 func (c tableConfig) Parameters() ([]string, bool, error) {
-	var path []string
-	if c.Schema != "" {
-		path = []string{c.Schema, c.Table}
-	} else {
-		path = []string{c.Table}
-	}
-	return path, c.Delta, nil
+	return []string{c.Schema, c.Table}, c.Delta, nil
 }
 
 func newPostgresDriver() *sql.Driver[config, tableConfig] {
@@ -426,13 +420,13 @@ func newTransactor(
 }
 
 type binding struct {
-	target             sql.Table
-	nullFieldsToStrip  []string
-	loadInsertSQL      string
-	storeUpdateSQL     string
-	storeInsertSQL     string
-	deleteQuerySQL     string
-	loadQuerySQL       string
+	target            sql.Table
+	nullFieldsToStrip []string
+	loadInsertSQL     string
+	storeUpdateSQL    string
+	storeInsertSQL    string
+	deleteQuerySQL    string
+	loadQuerySQL      string
 }
 
 func (t *transactor) addBinding(ctx context.Context, target sql.Table, is *boilerplate.InfoSchema) error {

--- a/materialize-redshift/driver.go
+++ b/materialize-redshift/driver.go
@@ -203,13 +203,7 @@ func (r tableConfig) Validate() error {
 }
 
 func (c tableConfig) Parameters() ([]string, bool, error) {
-	var path []string
-	if c.Schema != "" {
-		path = []string{c.Schema, c.Table}
-	} else {
-		path = []string{c.Table}
-	}
-	return path, c.Delta, nil
+	return []string{c.Schema, c.Table}, c.Delta, nil
 }
 
 func newRedshiftDriver() *sql.Driver[config, tableConfig] {


### PR DESCRIPTION
**Description:**

(Describe the high level scope of new or changed features)

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

