### PR TITLE
source-recharge: remove date-time format from onetimes.next_charge_scheduled_at

### DIFF
--- a/source-recharge/source_recharge/schemas/onetimes.json
+++ b/source-recharge/source_recharge/schemas/onetimes.json
@@ -17,8 +17,7 @@
       "type": ["null", "string"]
     },
     "next_charge_scheduled_at": {
-      "type": ["null", "string"],
-      "format": "date-time"
+      "type": ["null", "string"]
     },
     "price": {
       "type": ["null", "string"]

--- a/source-recharge/tests/snapshots/snapshot__discover__capture.stdout.json
+++ b/source-recharge/tests/snapshots/snapshot__discover__capture.stdout.json
@@ -1272,7 +1272,6 @@
           ]
         },
         "next_charge_scheduled_at": {
-          "format": "date-time",
           "type": [
             "null",
             "string"


### PR DESCRIPTION
**Description:**

We've observed the `next_charge_scheduled_at` field in the [`onetime` object](https://developer.rechargepayments.com/2021-11/onetimes/onetimes_object) to be a date like `2026-03-23` _and_ an actual ISO 8601 datetime, and production captures have been hitting schema violations since the schema thinks this field is always formatted as a datetime.

We can't reconcile a `date` and a `datetime` format, so we have to simply remove the format entirely to address the schema violations.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

