### PR TITLE
source-*: Dynamic memory limits for Go connectors

### DIFF
--- a/base-image/Dockerfile
+++ b/base-image/Dockerfile
@@ -12,8 +12,11 @@ RUN mkdir /home/nonroot/.ssh
 RUN chmod 700 /home/nonroot/.ssh
 RUN chmod 755 /home/nonroot
 
-# Ask the Go runtime to keep heap size below 900MiB. Our real memory limit is
-# 1GiB so this is 10% headroom as recommended in https://go.dev/doc/gc-guide
+# Fallback Go GC memory limit, 90% of the default 1GiB container allocation,
+# per the recommendations in https://go.dev/doc/gc-guide.
+#
+# Overridden dynamically via `common.ConfigureMemoryLimit()` which reads the
+# actual cgroup `memory.max` and uses 90% of that instead.
 ENV GOMEMLIMIT=900MiB
 
 USER root

--- a/go/common/memory.go
+++ b/go/common/memory.go
@@ -1,0 +1,61 @@
+package common
+
+import (
+	"fmt"
+	"os"
+	"runtime/debug"
+	"strconv"
+	"strings"
+
+	log "github.com/sirupsen/logrus"
+)
+
+// defaultMemoryLimit is the assumed container memory limit when the cgroup
+// limit cannot be determined. This matches the standard 1GiB reactor allocation.
+const defaultMemoryLimit int64 = 1 << 30 // 1 GiB
+
+// memoryLimit holds the actual container memory limit in bytes, as determined
+// by ConfigureMemoryLimit. It defaults to 1 GiB and is updated if the cgroup
+// limit is successfully read.
+var memoryLimit = defaultMemoryLimit
+
+// ConfigureMemoryLimit reads the container memory limit from cgroup and
+// configures the Go runtime's GC memory limit to 90% of that value. If the
+// cgroup limit is unavailable, the GOMEMLIMIT environment variable (set in
+// the base Docker image) applies as-is.
+//
+// This should be called once, early in process startup.
+func ConfigureMemoryLimit() {
+	data, err := os.ReadFile("/sys/fs/cgroup/memory.max")
+	if err != nil {
+		log.WithField("err", err).Debug("unable to read cgroup memory limit, using default")
+		return
+	}
+
+	var text = strings.TrimSpace(string(data))
+	if text == "max" {
+		log.Debug("cgroup memory limit is 'max' (unlimited), using default")
+		return
+	}
+
+	limit, err := strconv.ParseInt(text, 10, 64)
+	if err != nil || limit <= 0 {
+		log.WithFields(log.Fields{"err": err, "value": text}).Debug("unable to parse cgroup memory limit, using default")
+		return
+	}
+
+	memoryLimit = limit
+	var goMemLimit = limit * 9 / 10
+	debug.SetMemoryLimit(goMemLimit)
+
+	log.WithFields(log.Fields{
+		"cgroup_limit": fmt.Sprintf("%.0fMiB", float64(limit)/(1024*1024)),
+		"go_mem_limit": fmt.Sprintf("%.0fMiB", float64(goMemLimit)/(1024*1024)),
+	}).Debug("configured memory limit from cgroup")
+}
+
+// MemoryLimit returns the container memory limit in bytes. If ConfigureMemoryLimit
+// was not called or could not determine the cgroup limit, this returns 1 GiB.
+func MemoryLimit() int64 {
+	return memoryLimit
+}

--- a/materialize-boilerplate/boilerplate.go
+++ b/materialize-boilerplate/boilerplate.go
@@ -16,6 +16,7 @@ import (
 	"net/http"
 	_ "net/http/pprof"
 
+	"github.com/estuary/connectors/go/common"
 	cerrors "github.com/estuary/connectors/go/connector-errors"
 	m "github.com/estuary/connectors/go/materialize"
 	pm "github.com/estuary/flow/go/protocols/materialize"
@@ -51,6 +52,8 @@ func RunMain(connector Connector) {
 	} else {
 		log.SetLevel(lvl)
 	}
+
+	common.ConfigureMemoryLimit()
 
 	var ctx, _ = signal.NotifyContext(context.Background(), syscall.SIGTERM, syscall.SIGINT)
 	var stream m.Stream

--- a/source-boilerplate/boilerplate.go
+++ b/source-boilerplate/boilerplate.go
@@ -19,6 +19,7 @@ import (
 	"net/http"
 	_ "net/http/pprof"
 
+	"github.com/estuary/connectors/go/common"
 	cerrors "github.com/estuary/connectors/go/connector-errors"
 	pc "github.com/estuary/flow/go/protocols/capture"
 	pf "github.com/estuary/flow/go/protocols/flow"
@@ -68,6 +69,8 @@ func RunMain(connector Connector) {
 	} else {
 		log.SetLevel(lvl)
 	}
+
+	common.ConfigureMemoryLimit()
 
 	var ctx, _ = signal.NotifyContext(context.Background(), syscall.SIGTERM, syscall.SIGINT)
 

--- a/source-postgres/replication.go
+++ b/source-postgres/replication.go
@@ -14,6 +14,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/estuary/connectors/go/common"
 	"github.com/estuary/connectors/go/encrow"
 	"github.com/estuary/connectors/sqlcapture"
 	"github.com/google/uuid"
@@ -58,8 +59,10 @@ var (
 	// rxBufferInitialSize is the initial size of the receive buffer into which replication messages are read.
 	rxBufferInitialSize = 1 * 1024 * 1024
 
-	// rxBufferMaximumSize is the maximum size to which the receive buffer may grow, and thus also the maximum size of a single message we can handle.
-	rxBufferMaximumSize = 512 * 1024 * 1024
+	// rxBufferMaximumSize is the maximum size to which the receive buffer may grow, and thus also the
+	// maximum size of a single message we can handle. Set to 50% of the container memory limit, which
+	// is determined at startup by common.ConfigureMemoryLimit reading the cgroup limit.
+	rxBufferMaximumSize = int(common.MemoryLimit() / 2)
 )
 
 // A replicationStream represents the process of receiving PostgreSQL


### PR DESCRIPTION
**Description:**

Previously all Go connectors hard-coded an assumption that they're running with a 1GiB memory allocation and so we should attempt to keep Go heap size below 90% of that 1GiB to avoid OOMing.

After this change we instead read `/sys/fs/cgroup/memory.max` at runtime to see how much memory we're working with and set the Go heap limit to 90% of that.

In addition `source-postgres` has been updated to use half of that value as the maximum CDC event receive buffer size, in keeping with the previous hard-coded 512MiB.

**Workflow steps:**

No user action required. No behavior change expected on data planes with the default 1GiB connector memory allocation. Data planes with >1GB of connector RAM available should be able to make better use of that extra memory where necessary.

**Notes for reviewers:**

This should obviously have no effect in data planes with the default 1GB limits because the dynamic value will still be based on that 1GB limit. In data planes with >1GB available I _think_ that this should still not increase steady-state memory usage, and if it _does_ that suggests that the current 1GiB assumption is probably also doing the same thing and we should think about how to encourage connectors to release memory more proactively when they can get by with less.