### PR TITLE
materialize-snowflake: CLIENT_RESULT_CHUNK_SIZE=80 to reduce memory use

### DIFF
--- a/materialize-snowflake/.snapshots/TestConfigURI-Optional_Parameters
+++ b/materialize-snowflake/.snapshots/TestConfigURI-Optional_Parameters
@@ -1,1 +1,1 @@
-alex:mysecret@orgname-accountname.snowflakecomputing.com:443?GO_QUERY_RESULT_FORMAT=json&MULTI_STATEMENT_COUNT=0&account=myaccount&application=EstuaryFlow&client_session_keep_alive=true&database=mydb&maxRetryCount=35&role=myrole&schema=myschema&warehouse=mywarehouse
+alex:mysecret@orgname-accountname.snowflakecomputing.com:443?CLIENT_RESULT_CHUNK_SIZE=80&GO_QUERY_RESULT_FORMAT=json&MULTI_STATEMENT_COUNT=0&account=myaccount&application=EstuaryFlow&client_session_keep_alive=true&database=mydb&maxRetryCount=35&role=myrole&schema=myschema&warehouse=mywarehouse

--- a/materialize-snowflake/.snapshots/TestConfigURI-User_&_Password_Authentication
+++ b/materialize-snowflake/.snapshots/TestConfigURI-User_&_Password_Authentication
@@ -1,1 +1,1 @@
-will:some%2Bcomplex%2Fpassword@orgname-accountname.snowflakecomputing.com:443?GO_QUERY_RESULT_FORMAT=json&MULTI_STATEMENT_COUNT=0&application=EstuaryFlow&client_session_keep_alive=true&database=mydb&maxRetryCount=35&schema=myschema
+will:some%2Bcomplex%2Fpassword@orgname-accountname.snowflakecomputing.com:443?CLIENT_RESULT_CHUNK_SIZE=80&GO_QUERY_RESULT_FORMAT=json&MULTI_STATEMENT_COUNT=0&application=EstuaryFlow&client_session_keep_alive=true&database=mydb&maxRetryCount=35&schema=myschema

--- a/materialize-snowflake/config.go
+++ b/materialize-snowflake/config.go
@@ -126,6 +126,11 @@ func (c config) toURI(includeSchema bool, materializationName string) (string, e
 	// bumps that up quite a bit, to continue attempting retryable errors for
 	// about 10 minutes before crashing.
 	queryParams.Add("maxRetryCount", "35")
+	// The default for CLIENT_RESULT_CHUNK_SIZE is 160. This specifies how many megabytes are in each
+	// arrow record batch we receive. This option, together with the MaxChunkDownloadWorkers option of
+	// gosnowflake which defaults to 10, determine how much memory can be used at once. With 80 megabytes per chunk
+	// we can go up to 800MB assuming 10 download workers.
+	queryParams.Add("CLIENT_RESULT_CHUNK_SIZE", "80")
 
 	// Optional params
 	if c.Warehouse != "" {


### PR DESCRIPTION
**Description:**

- To reduce memory usage

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

