### PR TITLE
materialize-snowflake: only log clustering info on startup

### DIFF
--- a/materialize-snowflake/snowflake.go
+++ b/materialize-snowflake/snowflake.go
@@ -921,8 +921,6 @@ func (d *transactor) Acknowledge(ctx context.Context) (*pf.ConnectorState, error
 		return nil, fmt.Errorf("executing concurrent store query: %w", err)
 	}
 
-	d.logAllClusteringInfo(ctx)
-
 	// Keep asking for a report on the files that have been submitted for processing
 	// until they have all been successful, or an error has been thrown
 


### PR DESCRIPTION
**Description:**

- we were logging this after every transaction. turns out it takes a lot of time if you have a bunch of bindings (not even a crazy amount of bindings), adding significant overhead to every transaction. Removing it from per-transaction logs and only logging it on startup, it should still suffice for our use case.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

