### PR TITLE
source-snowflake: CLIENT_RESULT_CHUNK_SIZE=40 to reduce memory use

### DIFF
--- a/source-snowflake/.snapshots/TestConfigURI-Optional_Parameters
+++ b/source-snowflake/.snapshots/TestConfigURI-Optional_Parameters
@@ -1,1 +1,1 @@
-alex:some%2Bcomplex%2Fpassword@orgname-accountname.snowflakecomputing.com:443?GO_QUERY_RESULT_FORMAT=json&application=EstuaryFlow&client_session_keep_alive=true&database=mydb&role=myrole&warehouse=mywarehouse
+alex:some%2Bcomplex%2Fpassword@orgname-accountname.snowflakecomputing.com:443?CLIENT_RESULT_CHUNK_SIZE=40&GO_QUERY_RESULT_FORMAT=json&application=EstuaryFlow&client_session_keep_alive=true&database=mydb&role=myrole&warehouse=mywarehouse

--- a/source-snowflake/.snapshots/TestConfigURI-User_&_Password_Authentication
+++ b/source-snowflake/.snapshots/TestConfigURI-User_&_Password_Authentication
@@ -1,1 +1,1 @@
-will:some%2Bcomplex%2Fpassword@orgname-accountname.snowflakecomputing.com:443?GO_QUERY_RESULT_FORMAT=json&application=EstuaryFlow&client_session_keep_alive=true&database=mydb
+will:some%2Bcomplex%2Fpassword@orgname-accountname.snowflakecomputing.com:443?CLIENT_RESULT_CHUNK_SIZE=40&GO_QUERY_RESULT_FORMAT=json&application=EstuaryFlow&client_session_keep_alive=true&database=mydb

--- a/source-snowflake/main.go
+++ b/source-snowflake/main.go
@@ -104,6 +104,11 @@ func (c *config) ToURI() (string, error) {
 	// GO_QUERY_RESULT_FORMAT returns query results as individual JSON documents
 	// representing rows rather than as *batches* of Arrow records.
 	queryParams.Add("GO_QUERY_RESULT_FORMAT", jsonString)
+	// The default for CLIENT_RESULT_CHUNK_SIZE is 160. This specifies how many megabytes are in each
+	// result chunk we receive. This option, together with the MaxChunkDownloadWorkers option of
+	// gosnowflake which defaults to 10, determine how much memory can be used at once. With 40
+	// megabytes per chunk we can go up to 400MB assuming 10 download workers.
+	queryParams.Add("CLIENT_RESULT_CHUNK_SIZE", "40")
 
 	// Optional params
 	if c.Warehouse != "" {


### PR DESCRIPTION
**Description:**

Apply the same fix as https://github.com/estuary/connectors/pull/4067 and https://github.com/estuary/connectors/pull/4075 to hopefully avoid OOMs due to a change in `gosnowflake`'s behavior after the version bump in https://github.com/estuary/connectors/pull/4054.

Slack thread for context: https://estuaryworkspace.slack.com/archives/C03Q2NRFKDL/p1774643425959339

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

