### PR TITLE
materialize-snowflake: run logAllClusteringInfo in background

### DIFF
--- a/materialize-snowflake/snowflake.go
+++ b/materialize-snowflake/snowflake.go
@@ -311,7 +311,9 @@ func newTransactor(
 		}
 	}
 
-	d.logAllClusteringInfo(ctx)
+	go func() {
+		d.logAllClusteringInfo(ctx)
+	}()
 
 	return d, nil
 }


### PR DESCRIPTION
**Description:**

- this can take up to 20-30 minutes in some cases

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

