### PR TITLE
source-ashby: fix missing Content-Type header on `apiKey.info` request

### DIFF
--- a/source-ashby/source_ashby/api.py
+++ b/source-ashby/source_ashby/api.py
@@ -17,7 +17,9 @@ API_BASE_URL = "https://api.ashbyhq.com"
 
 
 async def fetch_api_key_scopes(http: HTTPSession, log: Logger) -> set[str]:
-    response = await http.request(log, f"{API_BASE_URL}/apiKey.info", method="POST")
+    # Ashby requires Content-Type: application/json on all POST requests.
+    # Passing json={} ensures aiohttp sets the header automatically.
+    response = await http.request(log, f"{API_BASE_URL}/apiKey.info", method="POST", json={})
     info = ApiKeyInfoResponse.model_validate_json(response)
 
     if info.errorInfo is not None:


### PR DESCRIPTION
**Description:**

Ashby requires `Content-Type: application/json` on all `POST` requests. The `apiKey.info` call was missing this, causing a `400` error during discover:
```
ERROR: Traceback (most recent call last): File "/opt/estuary-cdk/estuary_cdk/capture/base_capture_connector.py", line 122, in handle await self._emit(Response(discovered=await self.discover(log, discover))) ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ File "/opt/source-ashby/source_ashby/__init__.py", line 47, in discover resources = await all_resources(log, self, discover.config) ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ File "/opt/source-ashby/source_ashby/resources.py", line 105, in all_resources return await filter_resources_by_scopes(log, http, config, resources) ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ File "/opt/source-ashby/source_ashby/resources.py", line 31, in filter_resources_by_scopes available_scopes = await fetch_api_key_scopes(http, log) ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ File "/opt/source-ashby/source_ashby/api.py", line 20, in fetch_api_key_scopes response = await http.request(log, f"{API_BASE_URL}/apiKey.info", method="POST") ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ File "/opt/estuary-cdk/estuary_cdk/http.py", line 125, in request _, body_generator = await self._request_stream( ^^^^^^^^^^^^^^^^^^^^^^^^^^^ File "/opt/estuary-cdk/estuary_cdk/http.py", line 638, in _request_stream raise HTTPError( estuary_cdk.http.HTTPError: Encountered HTTP error status 400 which cannot be retried. URL: https://api.ashbyhq.com/apiKey.info Response: Invalid Content-Type. Must be 'application/json'. file="/opt/estuary-cdk/estuary_cdk/__init__.py:152" source="flow"
```

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

