### PR TITLE
source-ashby: handle missing `moreDataAvailable` field in error responses

### DIFF
--- a/source-ashby/source_ashby/models.py
+++ b/source-ashby/source_ashby/models.py
@@ -27,7 +27,7 @@ ConnectorState = GenericConnectorState[ResourceState]
 
 class ResponseMeta(BaseModel, extra="allow"):
     success: bool
-    moreDataAvailable: bool
+    moreDataAvailable: bool = False
     nextCursor: str | None = None
     syncToken: str | None = None
     errors: list[str] = []


### PR DESCRIPTION
**Description:**

Error responses from the Ashby API omit the `moreDataAvailable` field, causing Pydantic validation to fail before any error handling logic can run. Default the field to `False` so error responses can be parsed.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

