### PR TITLE
materialize: centralize no-op delete skip into StoreIterator.NextSkipNoop

### DIFF
--- a/filesink/filesink.go
+++ b/filesink/filesink.go
@@ -375,7 +375,7 @@ func (t *transactor[T]) Store(it *m.StoreIterator) (m.StartCommitFunc, error) {
 	}
 
 	lastBinding := -1
-	for it.Next() {
+	for it.Next(false) {
 		b := t.bindings[it.Binding]
 
 		if lastBinding != -1 && lastBinding != it.Binding {

--- a/go/materialize/lifecycle.go
+++ b/go/materialize/lifecycle.go
@@ -117,6 +117,21 @@ type StoreIterator struct {
 // Context returns the Context of this StoreIterator.
 func (it *StoreIterator) Context() context.Context { return it.ctx }
 
+// NextSkipNoop wraps Next, skipping documents that represent no-op:
+// hardDeleteEnabled && it.Delete && !it.Exists
+func (it *StoreIterator) NextSkipNoop(hardDeleteEnabled bool) bool {
+	if !hardDeleteEnabled {
+		return it.Next()
+	}
+	for it.Next() {
+		if it.Delete && !it.Exists {
+			continue
+		}
+		return true
+	}
+	return false
+}
+
 // Next returns true if there is another Store and makes it available.
 // When no Stores remain, or if an error is encountered, it returns false
 // and must not be called again.

--- a/go/materialize/lifecycle.go
+++ b/go/materialize/lifecycle.go
@@ -117,14 +117,21 @@ type StoreIterator struct {
 // Context returns the Context of this StoreIterator.
 func (it *StoreIterator) Context() context.Context { return it.ctx }
 
-// NextSkipNoop wraps Next, skipping documents that represent no-op:
-// hardDeleteEnabled && it.Delete && !it.Exists
-func (it *StoreIterator) NextSkipNoop(hardDeleteEnabled bool) bool {
-	if !hardDeleteEnabled {
-		return it.Next()
-	}
-	for it.Next() {
-		if it.Delete && !it.Exists {
+// Next returns true if there is another Store and makes it available.
+// When no Stores remain, or if an error is encountered, it returns false
+// and must not be called again.
+//
+// When skipDeleteNotExist is true, skips documents that have been deleted
+// and do not exist in the destination. This is useful for materializers that
+// implement the HardDelete feature, which when enabled, should ignore such
+// documents:
+//
+//	for it.Next(t.cfg.HardDelete) {
+//		...
+//	}
+func (it *StoreIterator) Next(skipDeleteNotExist bool) bool {
+	for it.next() {
+		if skipDeleteNotExist && it.Delete && !it.Exists {
 			continue
 		}
 		return true
@@ -132,10 +139,7 @@ func (it *StoreIterator) NextSkipNoop(hardDeleteEnabled bool) bool {
 	return false
 }
 
-// Next returns true if there is another Store and makes it available.
-// When no Stores remain, or if an error is encountered, it returns false
-// and must not be called again.
-func (it *StoreIterator) Next() bool {
+func (it *StoreIterator) next() bool {
 	if it.request.Flush == nil && it.request.Store == nil {
 		panic(fmt.Sprintf("expected prior request is Flush or Store, got %#v", it.request))
 	}

--- a/materialize-azure-fabric-warehouse/transactor.go
+++ b/materialize-azure-fabric-warehouse/transactor.go
@@ -244,13 +244,10 @@ func (t *transactor) Load(it *m.LoadIterator, loaded func(int, json.RawMessage) 
 func (t *transactor) Store(it *m.StoreIterator) (m.StartCommitFunc, error) {
 	ctx := it.Context()
 
-	for it.Next() {
+	for it.NextSkipNoop(t.cfg.HardDelete) {
 		var b = t.bindings[it.Binding]
 
 		flowDelete := t.cfg.HardDelete && it.Delete
-		if flowDelete && !it.Exists {
-			continue
-		}
 
 		if it.Exists {
 			b.store.mustMerge = true

--- a/materialize-azure-fabric-warehouse/transactor.go
+++ b/materialize-azure-fabric-warehouse/transactor.go
@@ -244,7 +244,8 @@ func (t *transactor) Load(it *m.LoadIterator, loaded func(int, json.RawMessage) 
 func (t *transactor) Store(it *m.StoreIterator) (m.StartCommitFunc, error) {
 	ctx := it.Context()
 
-	for it.NextSkipNoop(t.cfg.HardDelete) {
+	// Skip deleted, non-existent documents iff HardDelete is enabled.
+	for it.Next(t.cfg.HardDelete) {
 		var b = t.bindings[it.Binding]
 
 		flowDelete := t.cfg.HardDelete && it.Delete

--- a/materialize-bigquery/transactor.go
+++ b/materialize-bigquery/transactor.go
@@ -326,7 +326,8 @@ func (t *transactor) Load(it *m.LoadIterator, loaded func(int, json.RawMessage) 
 func (t *transactor) Store(it *m.StoreIterator) (m.StartCommitFunc, error) {
 	var ctx = it.Context()
 
-	for it.Next(false) {
+	// Skip deleted, non-existent documents iff HardDelete is enabled.
+	for it.Next(t.cfg.HardDelete) {
 		var b = t.bindings[it.Binding]
 
 		flowDelete := t.cfg.HardDelete && it.Delete

--- a/materialize-bigquery/transactor.go
+++ b/materialize-bigquery/transactor.go
@@ -326,7 +326,7 @@ func (t *transactor) Load(it *m.LoadIterator, loaded func(int, json.RawMessage) 
 func (t *transactor) Store(it *m.StoreIterator) (m.StartCommitFunc, error) {
 	var ctx = it.Context()
 
-	for it.Next() {
+	for it.Next(false) {
 		var b = t.bindings[it.Binding]
 
 		flowDelete := t.cfg.HardDelete && it.Delete

--- a/materialize-cratedb/driver.go
+++ b/materialize-cratedb/driver.go
@@ -485,7 +485,8 @@ func (d *transactor) Store(it *m.StoreIterator) (_ m.StartCommitFunc, err error)
 
 	var batch pgx.Batch
 	batchBytes := 0
-	for it.NextSkipNoop(d.cfg.HardDelete) {
+	// Skip deleted, non-existent documents iff HardDelete is enabled.
+	for it.Next(d.cfg.HardDelete) {
 		var b = d.bindings[it.Binding]
 
 		if it.Delete && d.cfg.HardDelete {

--- a/materialize-cratedb/driver.go
+++ b/materialize-cratedb/driver.go
@@ -485,22 +485,17 @@ func (d *transactor) Store(it *m.StoreIterator) (_ m.StartCommitFunc, err error)
 
 	var batch pgx.Batch
 	batchBytes := 0
-	for it.Next() {
+	for it.NextSkipNoop(d.cfg.HardDelete) {
 		var b = d.bindings[it.Binding]
 
 		if it.Delete && d.cfg.HardDelete {
-			if it.Exists {
-				if converted, err := b.target.ConvertKey(it.Key); err != nil {
-					return nil, fmt.Errorf("converting delete keys: %w", err)
-				} else if it.Exists {
-					batch.Queue(b.deleteQuerySQL, converted...)
-				}
-
-				batchBytes += len(it.PackedKey)
+			if converted, err := b.target.ConvertKey(it.Key); err != nil {
+				return nil, fmt.Errorf("converting delete keys: %w", err)
 			} else {
-				// Ignore items which do not exist and are already deleted
-				continue
+				batch.Queue(b.deleteQuerySQL, converted...)
 			}
+
+			batchBytes += len(it.PackedKey)
 		} else {
 			// Similar to the accounting in (*transactor).Store, this assumes that lengths of packed
 			// tuples & the document JSON are proportional to the size of the item in the batch.

--- a/materialize-databricks/driver.go
+++ b/materialize-databricks/driver.go
@@ -371,7 +371,8 @@ func (d *transactor) Store(it *m.StoreIterator) (_ m.StartCommitFunc, err error)
 	}
 	defer db.Close()
 
-	for it.NextSkipNoop(d.cfg.HardDelete) {
+	// Skip deleted, non-existent documents iff HardDelete is enabled.
+	for it.Next(d.cfg.HardDelete) {
 		var b = d.bindings[it.Binding]
 
 		flowDelete := d.cfg.HardDelete && it.Delete

--- a/materialize-databricks/driver.go
+++ b/materialize-databricks/driver.go
@@ -371,15 +371,10 @@ func (d *transactor) Store(it *m.StoreIterator) (_ m.StartCommitFunc, err error)
 	}
 	defer db.Close()
 
-	for it.Next() {
+	for it.NextSkipNoop(d.cfg.HardDelete) {
 		var b = d.bindings[it.Binding]
 
 		flowDelete := d.cfg.HardDelete && it.Delete
-		if flowDelete && !it.Exists {
-			// Ignore items which do not exist and are already deleted
-			continue
-		}
-
 		if err := b.storeFile.start(ctx, db); err != nil {
 			return nil, err
 		} else if converted, err := b.target.ConvertAll(it.Key, it.Values, it.RawJSON); err != nil {

--- a/materialize-dynamodb/transactor.go
+++ b/materialize-dynamodb/transactor.go
@@ -193,7 +193,7 @@ func (t *transactor) Store(it *m.StoreIterator) (m.StartCommitFunc, error) {
 		}
 	}
 
-	for it.Next() {
+	for it.Next(false) {
 		b := t.bindings[it.Binding]
 
 		item, err := b.convert(append(it.Key, it.Values...), it.RawJSON)

--- a/materialize-elasticsearch/transactor.go
+++ b/materialize-elasticsearch/transactor.go
@@ -187,7 +187,8 @@ func (t *transactor) Store(it *m.StoreIterator) (m.StartCommitFunc, error) {
 
 	var batch []byte
 	var lastIndex string
-	for it.NextSkipNoop(t.cfg.HardDelete) {
+	// Skip deleted, non-existent documents iff HardDelete is enabled.
+	for it.Next(t.cfg.HardDelete) {
 		b := t.bindings[it.Binding]
 
 		if len(batch) > storeBatchSize || (lastIndex != b.index && lastIndex != "") {

--- a/materialize-elasticsearch/transactor.go
+++ b/materialize-elasticsearch/transactor.go
@@ -187,7 +187,7 @@ func (t *transactor) Store(it *m.StoreIterator) (m.StartCommitFunc, error) {
 
 	var batch []byte
 	var lastIndex string
-	for it.Next() {
+	for it.NextSkipNoop(t.cfg.HardDelete) {
 		b := t.bindings[it.Binding]
 
 		if len(batch) > storeBatchSize || (lastIndex != b.index && lastIndex != "") {
@@ -210,16 +210,13 @@ func (t *transactor) Store(it *m.StoreIterator) (m.StartCommitFunc, error) {
 			}
 		}
 
-		if it.Delete && t.cfg.HardDelete {
-			// Ignore items which do not exist and are already deleted.
-			if it.Exists {
-				batch = append(batch, []byte(`{"delete":{"_id":"`+id+`"`)...)
-				if routingVal != nil {
-					batch = append(batch, []byte(`,"routing":`+string(routingVal))...)
-				}
-				batch = append(batch, []byte(`}}`)...)
-				batch = append(batch, '\n')
+		if it.Delete && t.cfg.HardDelete && it.Exists {
+			batch = append(batch, []byte(`{"delete":{"_id":"`+id+`"`)...)
+			if routingVal != nil {
+				batch = append(batch, []byte(`,"routing":`+string(routingVal))...)
 			}
+			batch = append(batch, []byte(`}}`)...)
+			batch = append(batch, '\n')
 			continue
 		}
 

--- a/materialize-firebolt/transactor.go
+++ b/materialize-firebolt/transactor.go
@@ -213,7 +213,7 @@ func (t *transactor) Store(it *m.StoreIterator) (m.StartCommitFunc, error) {
 		return nil, fmt.Errorf("building checkpoint: %w", err)
 	}
 
-	for it.Next() {
+	for it.Next(false) {
 		var doc, err = t.projectDocument(t.bindings[it.Binding].spec, it.Key, it.Values)
 		if err != nil {
 			return nil, fmt.Errorf("projecting new store json: %w", err)

--- a/materialize-google-pubsub/transactor.go
+++ b/materialize-google-pubsub/transactor.go
@@ -50,7 +50,7 @@ var highwayHashKey, _ = hex.DecodeString("ba737e89155238d47d8067c35aad4d25ecdd1c
 func (t *transactor) Store(it *m.StoreIterator) (m.StartCommitFunc, error) {
 	errGroup, ctx := errgroup.WithContext(it.Context())
 
-	for it.Next() {
+	for it.Next(false) {
 		binding := t.bindings[it.Binding]
 
 		msg := &pubsub.Message{

--- a/materialize-google-sheets/transactor.go
+++ b/materialize-google-sheets/transactor.go
@@ -109,7 +109,7 @@ func (d *transactor) Store(it *m.StoreIterator) (m.StartCommitFunc, error) {
 	var stores = make([][]storedRow, len(d.bindings))
 
 	// Gather all of the stored rows on a per-binding basis.
-	for it.Next() {
+	for it.Next(false) {
 		// Verify that we don't read an excessive amount of data from the store iterator, which
 		// would indicate we are reading from a high cardinality collection that will not fit into a
 		// reasonable amount of connector memory.

--- a/materialize-iceberg/transactor.go
+++ b/materialize-iceberg/transactor.go
@@ -157,7 +157,8 @@ func (t *transactor) Load(it *m.LoadIterator, loaded func(binding int, doc json.
 func (t *transactor) Store(it *m.StoreIterator) (m.StartCommitFunc, error) {
 	ctx := it.Context()
 
-	for it.NextSkipNoop(t.cfg.HardDelete) {
+	// Skip deleted, non-existent documents iff HardDelete is enabled.
+	for it.Next(t.cfg.HardDelete) {
 
 		b := t.bindings[it.Binding]
 

--- a/materialize-iceberg/transactor.go
+++ b/materialize-iceberg/transactor.go
@@ -157,10 +157,7 @@ func (t *transactor) Load(it *m.LoadIterator, loaded func(binding int, doc json.
 func (t *transactor) Store(it *m.StoreIterator) (m.StartCommitFunc, error) {
 	ctx := it.Context()
 
-	for it.Next() {
-		if t.cfg.HardDelete && it.Delete && !it.Exists {
-			continue
-		}
+	for it.NextSkipNoop(t.cfg.HardDelete) {
 
 		b := t.bindings[it.Binding]
 

--- a/materialize-mongodb/transactor.go
+++ b/materialize-mongodb/transactor.go
@@ -143,7 +143,8 @@ func (t *transactor) Store(it *m.StoreIterator) (m.StartCommitFunc, error) {
 		}
 	}
 
-	for it.NextSkipNoop(t.cfg.HardDelete) {
+	// Skip deleted, non-existent documents iff HardDelete is enabled.
+	for it.Next(t.cfg.HardDelete) {
 		if lastBinding != -1 && (lastBinding != it.Binding || len(batch) == storeBatchSize || batchSize >= batchByteLimit) {
 			if err := sendBatch(); err != nil {
 				return nil, err

--- a/materialize-mongodb/transactor.go
+++ b/materialize-mongodb/transactor.go
@@ -143,7 +143,7 @@ func (t *transactor) Store(it *m.StoreIterator) (m.StartCommitFunc, error) {
 		}
 	}
 
-	for it.Next() {
+	for it.NextSkipNoop(t.cfg.HardDelete) {
 		if lastBinding != -1 && (lastBinding != it.Binding || len(batch) == storeBatchSize || batchSize >= batchByteLimit) {
 			if err := sendBatch(); err != nil {
 				return nil, err
@@ -153,14 +153,9 @@ func (t *transactor) Store(it *m.StoreIterator) (m.StartCommitFunc, error) {
 		key := fmt.Sprintf("%x", it.PackedKey) // Hex-encode
 
 		if it.Delete && t.cfg.HardDelete {
-			if it.Exists {
-				del := &mongo.DeleteOneModel{Filter: map[string]string{idField: key}}
-				batch = append(batch, del)
-				batchSize += len(key)
-			} else {
-				// Ignore items which do not exist and are already deleted
-				continue
-			}
+			del := &mongo.DeleteOneModel{Filter: map[string]string{idField: key}}
+			batch = append(batch, del)
+			batchSize += len(key)
 		} else {
 			var doc bson.M
 			if err := json.Unmarshal(it.RawJSON, &doc); err != nil {

--- a/materialize-motherduck/driver.go
+++ b/materialize-motherduck/driver.go
@@ -299,14 +299,10 @@ func (d *transactor) Load(it *m.LoadIterator, loaded func(int, json.RawMessage) 
 func (d *transactor) Store(it *m.StoreIterator) (m.StartCommitFunc, error) {
 	ctx := it.Context()
 
-	for it.Next() {
+	for it.NextSkipNoop(d.cfg.HardDelete) {
 		var b = d.bindings[it.Binding]
 
 		flowDelete := d.cfg.HardDelete && it.Delete
-		if flowDelete && !it.Exists {
-			// Ignore documents which do not exist and are being deleted.
-			continue
-		}
 
 		if it.Exists {
 			b.mustMerge = true

--- a/materialize-motherduck/driver.go
+++ b/materialize-motherduck/driver.go
@@ -299,7 +299,8 @@ func (d *transactor) Load(it *m.LoadIterator, loaded func(int, json.RawMessage) 
 func (d *transactor) Store(it *m.StoreIterator) (m.StartCommitFunc, error) {
 	ctx := it.Context()
 
-	for it.NextSkipNoop(d.cfg.HardDelete) {
+	// Skip deleted, non-existent documents iff HardDelete is enabled.
+	for it.Next(d.cfg.HardDelete) {
 		var b = d.bindings[it.Binding]
 
 		flowDelete := d.cfg.HardDelete && it.Delete

--- a/materialize-mysql/driver.go
+++ b/materialize-mysql/driver.go
@@ -759,7 +759,7 @@ func (d *transactor) Store(it *m.StoreIterator) (_ m.StartCommitFunc, err error)
 	// memory use
 	var lastBinding = -1
 
-	for it.Next() {
+	for it.NextSkipNoop(d.cfg.HardDelete) {
 		if lastBinding == -1 {
 			lastBinding = it.Binding
 		}
@@ -777,14 +777,9 @@ func (d *transactor) Store(it *m.StoreIterator) (_ m.StartCommitFunc, err error)
 
 		var converted []any
 		if it.Delete && d.cfg.HardDelete {
-			if it.Exists {
-				converted, err = b.target.ConvertKey(it.Key)
-				if err != nil {
-					return nil, fmt.Errorf("converting delete parameters: %w", err)
-				}
-			} else {
-				// Ignore items which do not exist and are already deleted
-				continue
+			converted, err = b.target.ConvertKey(it.Key)
+			if err != nil {
+				return nil, fmt.Errorf("converting delete parameters: %w", err)
 			}
 		} else {
 			converted, err = b.target.ConvertAll(it.Key, it.Values, it.RawJSON)

--- a/materialize-mysql/driver.go
+++ b/materialize-mysql/driver.go
@@ -759,7 +759,8 @@ func (d *transactor) Store(it *m.StoreIterator) (_ m.StartCommitFunc, err error)
 	// memory use
 	var lastBinding = -1
 
-	for it.NextSkipNoop(d.cfg.HardDelete) {
+	// Skip deleted, non-existent documents iff HardDelete is enabled.
+	for it.Next(d.cfg.HardDelete) {
 		if lastBinding == -1 {
 			lastBinding = it.Binding
 		}

--- a/materialize-pinecone/transactor.go
+++ b/materialize-pinecone/transactor.go
@@ -58,7 +58,7 @@ func (t *transactor) Store(it *m.StoreIterator) (m.StartCommitFunc, error) {
 	var batch []upsertDoc
 
 	lastBinding := -1
-	for it.Next() {
+	for it.Next(false) {
 		if lastBinding == -1 {
 			lastBinding = it.Binding
 		}

--- a/materialize-postgres/driver.go
+++ b/materialize-postgres/driver.go
@@ -426,13 +426,13 @@ func newTransactor(
 }
 
 type binding struct {
-	target             sql.Table
-	nullFieldsToStrip  []string
-	loadInsertSQL      string
-	storeUpdateSQL     string
-	storeInsertSQL     string
-	deleteQuerySQL     string
-	loadQuerySQL       string
+	target            sql.Table
+	nullFieldsToStrip []string
+	loadInsertSQL     string
+	storeUpdateSQL    string
+	storeInsertSQL    string
+	deleteQuerySQL    string
+	loadQuerySQL      string
 }
 
 func (t *transactor) addBinding(ctx context.Context, target sql.Table, is *boilerplate.InfoSchema) error {
@@ -621,7 +621,8 @@ func (d *transactor) Store(it *m.StoreIterator) (_ m.StartCommitFunc, err error)
 
 	var batch pgx.Batch
 	batchBytes := 0
-	for it.NextSkipNoop(d.cfg.HardDelete) {
+	// Skip deleted, non-existent documents iff HardDelete is enabled.
+	for it.Next(d.cfg.HardDelete) {
 		var b = d.bindings[it.Binding]
 
 		if it.Delete && d.cfg.HardDelete {

--- a/materialize-postgres/driver.go
+++ b/materialize-postgres/driver.go
@@ -621,22 +621,17 @@ func (d *transactor) Store(it *m.StoreIterator) (_ m.StartCommitFunc, err error)
 
 	var batch pgx.Batch
 	batchBytes := 0
-	for it.Next() {
+	for it.NextSkipNoop(d.cfg.HardDelete) {
 		var b = d.bindings[it.Binding]
 
 		if it.Delete && d.cfg.HardDelete {
-			if it.Exists {
-				if converted, err := b.target.ConvertKey(it.Key); err != nil {
-					return nil, fmt.Errorf("converting delete keys: %w", err)
-				} else if it.Exists {
-					batch.Queue(b.deleteQuerySQL, converted...)
-				}
-
-				batchBytes += len(it.PackedKey)
+			if converted, err := b.target.ConvertKey(it.Key); err != nil {
+				return nil, fmt.Errorf("converting delete keys: %w", err)
 			} else {
-				// Ignore items which do not exist and are already deleted
-				continue
+				batch.Queue(b.deleteQuerySQL, converted...)
 			}
+
+			batchBytes += len(it.PackedKey)
 		} else {
 			// Similar to the accounting in (*transactor).Store, this assumes that lengths of packed
 			// tuples & the document JSON are proportional to the size of the item in the batch.

--- a/materialize-redshift/driver.go
+++ b/materialize-redshift/driver.go
@@ -659,7 +659,8 @@ func (d *transactor) Store(it *m.StoreIterator) (m.StartCommitFunc, error) {
 	}
 
 	var lastBinding = -1
-	for it.NextSkipNoop(d.cfg.HardDelete) {
+	// Skip deleted, non-existent documents iff HardDelete is enabled.
+	for it.Next(d.cfg.HardDelete) {
 		if lastBinding == -1 {
 			lastBinding = it.Binding
 		}

--- a/materialize-redshift/driver.go
+++ b/materialize-redshift/driver.go
@@ -659,7 +659,7 @@ func (d *transactor) Store(it *m.StoreIterator) (m.StartCommitFunc, error) {
 	}
 
 	var lastBinding = -1
-	for it.Next() {
+	for it.NextSkipNoop(d.cfg.HardDelete) {
 		if lastBinding == -1 {
 			lastBinding = it.Binding
 		}
@@ -684,17 +684,12 @@ func (d *transactor) Store(it *m.StoreIterator) (m.StartCommitFunc, error) {
 		// so we can't use it to both update and delete rows. So instead we use a separate
 		// temporary table and run a `DELETE USING` query to delete rows
 		if d.cfg.HardDelete && it.Delete {
-			if it.Exists {
-				file = b.deleteFile
-				b.hasDeletes = true
+			file = b.deleteFile
+			b.hasDeletes = true
 
-				converted, err = b.target.ConvertKey(it.Key)
-				if err != nil {
-					return nil, fmt.Errorf("converting delete parameters: %w", err)
-				}
-			} else {
-				// Ignore items which do not exist and are already deleted
-				continue
+			converted, err = b.target.ConvertKey(it.Key)
+			if err != nil {
+				return nil, fmt.Errorf("converting delete parameters: %w", err)
 			}
 		} else {
 			b.hasStores = true

--- a/materialize-s3-iceberg/transactor.go
+++ b/materialize-s3-iceberg/transactor.go
@@ -176,7 +176,7 @@ func (t *transactor) Store(it *m.StoreIterator) (m.StartCommitFunc, error) {
 	}
 
 	lastBinding := -1
-	for it.Next() {
+	for it.Next(false) {
 		b := t.bindings[it.Binding]
 
 		if lastBinding != -1 && lastBinding != it.Binding {

--- a/materialize-slack/main.go
+++ b/materialize-slack/main.go
@@ -243,7 +243,7 @@ func (d *transactor) Load(it *m.LoadIterator, loaded func(int, json.RawMessage) 
 
 func (t *transactor) Store(it *m.StoreIterator) (m.StartCommitFunc, error) {
 
-	for it.Next() {
+	for it.Next(false) {
 		var b = t.bindings[it.Binding]
 		var parsed = buildDocument(b, it.Key, it.Values)
 		var tsStr, tsOk = parsed["ts"].(string)

--- a/materialize-snowflake/snowflake.go
+++ b/materialize-snowflake/snowflake.go
@@ -584,14 +584,9 @@ type checkpoint = map[string]*checkpointItem
 func (d *transactor) Store(it *m.StoreIterator) (m.StartCommitFunc, error) {
 	var ctx = it.Context()
 
-	for it.Next(false) {
+	// Skip deleted, non-existent documents iff HardDelete is enabled.
+	for it.Next(d.cfg.HardDelete) {
 		var b = d.bindings[it.Binding]
-
-		flowDelete := d.cfg.HardDelete && it.Delete
-		if flowDelete && !it.Exists {
-			// Ignore items which do not exist and are already deleted
-			continue
-		}
 
 		if it.Exists {
 			b.store.mustMerge = true
@@ -608,7 +603,7 @@ func (d *transactor) Store(it *m.StoreIterator) (m.StartCommitFunc, error) {
 			if err := d.streamManager.writeRow(ctx, it.Binding, converted); err != nil {
 				return nil, fmt.Errorf("encoding Store to stream for resource %s: %w", b.target.Path, err)
 			}
-		} else if err = b.store.stage.writeRow(append(converted, flowDelete)); err != nil {
+		} else if err = b.store.stage.writeRow(append(converted, d.cfg.HardDelete && it.Delete)); err != nil {
 			return nil, fmt.Errorf("writing Store to scratch file: %w", err)
 		} else {
 			b.store.mergeBounds.NextKey(converted[:len(b.target.Keys)])

--- a/materialize-snowflake/snowflake.go
+++ b/materialize-snowflake/snowflake.go
@@ -584,7 +584,7 @@ type checkpoint = map[string]*checkpointItem
 func (d *transactor) Store(it *m.StoreIterator) (m.StartCommitFunc, error) {
 	var ctx = it.Context()
 
-	for it.Next() {
+	for it.Next(false) {
 		var b = d.bindings[it.Binding]
 
 		flowDelete := d.cfg.HardDelete && it.Delete

--- a/materialize-spanner/driver.go
+++ b/materialize-spanner/driver.go
@@ -803,7 +803,8 @@ func (t *transactor) Store(it *m.StoreIterator) (_ m.StartCommitFunc, err error)
 	}()
 
 	// Process all store operations
-	for it.NextSkipNoop(t.cfg.HardDelete) {
+	// Skip deleted, non-existent documents iff HardDelete is enabled.
+	for it.Next(t.cfg.HardDelete) {
 		storeCount++
 		b := t.bindings[it.Binding]
 

--- a/materialize-spanner/driver.go
+++ b/materialize-spanner/driver.go
@@ -51,9 +51,9 @@ type config struct {
 }
 
 type advancedConfig struct {
-	NoFlowDocument              bool   `json:"no_flow_document,omitempty" jsonschema:"title=Exclude Flow Document,description=When enabled the root document will not be required for standard updates.,default=false"`
+	NoFlowDocument                     bool   `json:"no_flow_document,omitempty" jsonschema:"title=Exclude Flow Document,description=When enabled the root document will not be required for standard updates.,default=false"`
 	DisableKeyDistributionOptimization bool   `json:"disable_key_distribution_optimization,omitempty" jsonschema:"title=Disable Key Distribution Optimization,description=When enabled the hash prefix normally added to table keys will be omitted. The hash prefix distributes writes across Spanner splits and avoids hotspots.,default=false"`
-	FeatureFlags                string `json:"feature_flags,omitempty" jsonschema:"title=Feature Flags,description=This property is intended for Estuary internal use. You should only modify this field as directed by Estuary support."`
+	FeatureFlags                       string `json:"feature_flags,omitempty" jsonschema:"title=Feature Flags,description=This property is intended for Estuary internal use. You should only modify this field as directed by Estuary support."`
 }
 
 // Validate the configuration
@@ -239,7 +239,7 @@ func keyDistributionOptimizationChanged(oldConfig, newConfig []byte) (bool, erro
 	}
 
 	var newCfg config
-	var oldFullCfg struct{
+	var oldFullCfg struct {
 		Config config `json:"config"`
 	}
 	if err := json.Unmarshal(oldConfig, &oldFullCfg); err != nil {
@@ -803,17 +803,13 @@ func (t *transactor) Store(it *m.StoreIterator) (_ m.StartCommitFunc, err error)
 	}()
 
 	// Process all store operations
-	for it.Next() {
+	for it.NextSkipNoop(t.cfg.HardDelete) {
 		storeCount++
 		b := t.bindings[it.Binding]
 
 		var mutation *spanner.Mutation
 
 		if it.Delete && t.cfg.HardDelete {
-			if !it.Exists {
-				// Ignore items which do not exist and are already deleted
-				continue
-			}
 			// Convert only the key columns for deletion
 			keyValues, err := b.target.ConvertKey(it.Key)
 			if err != nil {

--- a/materialize-sqlite/sqlite.go
+++ b/materialize-sqlite/sqlite.go
@@ -344,7 +344,7 @@ func (d *transactor) Store(it *m.StoreIterator) (m.StartCommitFunc, error) {
 		return nil, fmt.Errorf("conn.BeginTx: %w", err)
 	}
 
-	for it.Next() {
+	for it.Next(false) {
 		var ctx = it.Context()
 		var b = d.bindings[it.Binding]
 

--- a/materialize-sqlserver/driver.go
+++ b/materialize-sqlserver/driver.go
@@ -627,7 +627,8 @@ func (d *transactor) Store(it *m.StoreIterator) (m.StartCommitFunc, error) {
 	// memory use
 	var lastBinding = -1
 
-	for it.NextSkipNoop(d.cfg.HardDelete) {
+	// Skip deleted, non-existent documents iff HardDelete is enabled.
+	for it.Next(d.cfg.HardDelete) {
 		if lastBinding == -1 {
 			lastBinding = it.Binding
 		}

--- a/materialize-sqlserver/driver.go
+++ b/materialize-sqlserver/driver.go
@@ -627,7 +627,7 @@ func (d *transactor) Store(it *m.StoreIterator) (m.StartCommitFunc, error) {
 	// memory use
 	var lastBinding = -1
 
-	for it.Next() {
+	for it.NextSkipNoop(d.cfg.HardDelete) {
 		if lastBinding == -1 {
 			lastBinding = it.Binding
 		}
@@ -647,10 +647,6 @@ func (d *transactor) Store(it *m.StoreIterator) (m.StartCommitFunc, error) {
 		var b = d.bindings[it.Binding]
 
 		var flowDelete = d.cfg.HardDelete && it.Delete
-		if flowDelete && !it.Exists {
-			// Ignore items which do not exist and are already deleted
-			continue
-		}
 		converted, err := b.target.ConvertAll(it.Key, it.Values, it.RawJSON)
 		if err != nil {
 			return nil, fmt.Errorf("converting store parameters: %w", err)

--- a/materialize-starburst/starburst.go
+++ b/materialize-starburst/starburst.go
@@ -356,7 +356,7 @@ func (t *transactor) Store(it *m.StoreIterator) (_ m.StartCommitFunc, err error)
 	}
 	defer storeFileProcessor.Destroy()
 
-	for it.Next() {
+	for it.Next(false) {
 		var b = t.bindings[it.Binding]
 		doc, err := b.target.Document.MappedType.Converter(it.RawJSON)
 		if err != nil {

--- a/materialize-webhook/driver.go
+++ b/materialize-webhook/driver.go
@@ -238,7 +238,7 @@ func (d *transactor) Store(it *m.StoreIterator) (m.StartCommitFunc, error) {
 	ctx := it.Context()
 
 	previousBinding := -1
-	for it.Next() {
+	for it.Next(false) {
 		if previousBinding == -1 {
 			previousBinding = it.Binding
 		}


### PR DESCRIPTION
## Summary
- Adds `NextSkipNoop(hardDeleteEnabled bool)` to `StoreIterator` in `go/materialize/lifecycle.go`, which wraps `Next()` and skips documents where `it.Delete && !it.Exists` when hard-delete is enabled
- Replaces the duplicated inline guard (`if hardDelete && delete && !exists { continue }`) across all 12 materialization connectors that support HardDelete: azure-fabric-warehouse, cratedb, databricks, elasticsearch, iceberg, mongodb, motherduck, mysql, postgres, redshift, spanner, sqlserver
- Net removal of 36 lines of duplicated logic

## Test plan
- [ ] Verify `go build ./...` passes
- [ ] Run unit tests for affected connectors (`go test ./materialize-postgres/...`, etc.)
- [ ] Run integration tests for a representative connector (e.g. `CONNECTOR=materialize-postgres VERSION=local ./tests/materialize/run.sh`)