### PR TITLE
source-firestore: fix semaphore panic & sleep after clearing backfill state

### DIFF
--- a/source-firestore/pull.go
+++ b/source-firestore/pull.go
@@ -555,6 +555,7 @@ func (c *capture) BackfillAsync(ctx context.Context, client *firestore.Client, b
 	}
 
 	var cursor *firestore.DocumentSnapshot
+	var prevCursor = resumeState.Cursor
 	if resumeState.Cursor == "" {
 		// If the cursor path is empty then we just leave the cursor document pointer nil
 		logEntry.Info("starting async backfill")
@@ -568,7 +569,12 @@ func (c *capture) BackfillAsync(ctx context.Context, client *firestore.Client, b
 		} else if err := c.Output.Checkpoint(checkpointJSON, true); err != nil {
 			return err
 		}
-		return fmt.Errorf("restarting backfill %q: error fetching resume document %q", backfill.CollectionID, resumeState.Cursor)
+		// Sleep briefly to give the runtime a chance to commit the checkpoint clearing
+		// the cursor before we return an error. Without this, the error may kill the
+		// connector before the checkpoint is committed, causing an infinite restart loop
+		// where the same stale cursor is retried on every startup.
+		time.Sleep(10 * time.Second)
+		return fmt.Errorf("restarting backfill %q: error fetching resume document %q", backfill.CollectionID, prevCursor)
 	} else if !resumeDocument.UpdateTime.Equal(resumeState.MTime) {
 		// Just like if the resume document fetch fails, mtime mismatches cause us to error out, so
 		// we'll restart from the beginning when the connector gets restarted and in the meantime
@@ -579,7 +585,9 @@ func (c *capture) BackfillAsync(ctx context.Context, client *firestore.Client, b
 		} else if err := c.Output.Checkpoint(checkpointJSON, true); err != nil {
 			return err
 		}
-		return fmt.Errorf("restarting backfill %q: resume document %q modified during backfill", backfill.CollectionID, resumeState.Cursor)
+		// See comment above for why we sleep here.
+		time.Sleep(10 * time.Second)
+		return fmt.Errorf("restarting backfill %q: resume document %q modified during backfill", backfill.CollectionID, prevCursor)
 	} else {
 		cursor = resumeDocument
 	}


### PR DESCRIPTION
**Description:**

This PR's scope includes:
- preventing backfills from releasing semaphores in the deferred `Release` if they don't currently hold the semaphore.
- sleeping 10 seconds after checkpointing cleared backfill state. I'm hoping this will avoid a suspected race condition where the connector was checkpointing & erroring out immediately after starting up, and the runtime wasn't able to commit the cleared backfill state before the connector crashed.

See individual commits for more details.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

