### PR TITLE
source-hubspot-native: improve memory usage & other misc. improvements

### DIFF
--- a/source-hubspot-native/source_hubspot_native/api/companies.py
+++ b/source-hubspot-native/source_hubspot_native/api/companies.py
@@ -42,7 +42,13 @@ def fetch_recent_companies(
                 await http.request(log, url, params=params)
             )
             for r in result.results:
-                yield (ms_to_dt(r.properties.hs_lastmodifieddate.timestamp), str(r.companyId))
+                ts = ms_to_dt(r.properties.hs_lastmodifieddate.timestamp)
+                # This API returns results newest-first, so once we
+                # see a record at or before `since` there's nothing
+                # left worth fetching.
+                if ts <= since:
+                    return
+                yield (ts, str(r.companyId))
                 count += 1
 
             if not (result.hasMore and result.offset):

--- a/source-hubspot-native/source_hubspot_native/api/companies.py
+++ b/source-hubspot-native/source_hubspot_native/api/companies.py
@@ -2,10 +2,8 @@ from datetime import datetime
 from logging import Logger
 from typing import (
     AsyncGenerator,
-    Iterable,
 )
 
-from estuary_cdk.capture.common import PageCursor
 from estuary_cdk.http import HTTPSession
 
 from ..models import (
@@ -29,26 +27,30 @@ def fetch_recent_companies(
     until: datetime | None,
 ) -> AsyncGenerator[tuple[datetime, str, Company], None]:
 
-    async def do_fetch(
-        page: PageCursor, count: int
-    ) -> tuple[Iterable[tuple[datetime, str]], PageCursor]:
-        if count >= 9_900:
-            log.warn("limit of 9,900 recent companies reached")
-            return [], None
+    async def fetch_ids():
+        count = 0
+        page = None
+        while True:
+            if count >= 9_900:
+                log.warn("limit of 9,900 recent companies reached")
+                return
 
-        url = f"{HUB}/companies/v2/companies/recent/modified"
-        params = {"count": 100, "offset": page} if page else {"count": 1}
+            url = f"{HUB}/companies/v2/companies/recent/modified"
+            params = {"count": 100, "offset": page} if page else {"count": 1}
 
-        result = OldRecentCompanies.model_validate_json(
-            await http.request(log, url, params=params)
-        )
-        return (
-            (ms_to_dt(r.properties.hs_lastmodifieddate.timestamp), str(r.companyId))
-            for r in result.results
-        ), result.hasMore and result.offset
+            result = OldRecentCompanies.model_validate_json(
+                await http.request(log, url, params=params)
+            )
+            for r in result.results:
+                yield (ms_to_dt(r.properties.hs_lastmodifieddate.timestamp), str(r.companyId))
+                count += 1
+
+            if not (result.hasMore and result.offset):
+                return
+            page = result.offset
 
     return fetch_changes_with_associations(
-        Names.companies, Company, do_fetch, log, http, with_history, since, until
+        Names.companies, Company, fetch_ids(), log, http, with_history, since, until
     )
 
 
@@ -56,13 +58,8 @@ def fetch_delayed_companies(
     log: Logger, http: HTTPSession, with_history: bool, since: datetime, until: datetime
 ) -> AsyncGenerator[tuple[datetime, str, Company], None]:
 
-    async def do_fetch(
-        page: PageCursor, count: int
-    ) -> tuple[Iterable[tuple[datetime, str]], PageCursor]:
-        return await fetch_search_objects(
-            Names.companies, log, http, since, until, page
-        )
-
     return fetch_changes_with_associations(
-        Names.companies, Company, do_fetch, log, http, with_history, since, until
+        Names.companies, Company,
+        fetch_search_objects(Names.companies, log, http, since, until),
+        log, http, with_history, since, until,
     )

--- a/source-hubspot-native/source_hubspot_native/api/contacts.py
+++ b/source-hubspot-native/source_hubspot_native/api/contacts.py
@@ -48,7 +48,13 @@ def fetch_recent_contacts(
                 await http.request(log, url, params=params)
             )
             for r in result.contacts:
-                yield (ms_to_dt(int(r.properties.lastmodifieddate.value)), str(r.vid))
+                ts = ms_to_dt(int(r.properties.lastmodifieddate.value))
+                # This API returns results newest-first, so once we
+                # see a record at or before `since` there's nothing
+                # left worth fetching.
+                if ts <= since:
+                    return
+                yield (ts, str(r.vid))
                 count += 1
 
             if not (result.has_more and result.time_offset):

--- a/source-hubspot-native/source_hubspot_native/api/contacts.py
+++ b/source-hubspot-native/source_hubspot_native/api/contacts.py
@@ -2,10 +2,8 @@ from datetime import datetime
 from logging import Logger
 from typing import (
     AsyncGenerator,
-    Iterable,
 )
 
-from estuary_cdk.capture.common import PageCursor
 from estuary_cdk.http import HTTPSession
 
 from ..models import (
@@ -27,33 +25,38 @@ def fetch_recent_contacts(
     since: datetime,
     until: datetime | None,
 ) -> AsyncGenerator[tuple[datetime, str, Contact], None]:
-    async def do_fetch(
-        page: PageCursor, count: int
-    ) -> tuple[Iterable[tuple[datetime, str]], PageCursor]:
-        if count >= 9_900:
-            # There is actually no documented limit on the number of contacts
-            # that can be returned by this API, other than that it goes back a
-            # maximum of 30 days. But since there is no way to filter the
-            # response by `until`, we impose the same limit on the number of
-            # recent IDs that will be fetched here as other ID fetchers to
-            # prevent cases of trying to cycle through huge numbers of results
-            # if the LogCursor hasn't been updated in a long time.
-            log.warn("limit of 9,900 recent contacts reached")
-            return [], None
 
-        url = f"{HUB}/contacts/v1/lists/recently_updated/contacts/recent"
-        params = {"count": 100, "timeOffset": page} if page else {"count": 1}
+    async def fetch_ids():
+        count = 0
+        page = None
+        while True:
+            if count >= 9_900:
+                # There is actually no documented limit on the number of contacts
+                # that can be returned by this API, other than that it goes back a
+                # maximum of 30 days. But since there is no way to filter the
+                # response by `until`, we impose the same limit on the number of
+                # recent IDs that will be fetched here as other ID fetchers to
+                # prevent cases of trying to cycle through huge numbers of results
+                # if the LogCursor hasn't been updated in a long time.
+                log.warn("limit of 9,900 recent contacts reached")
+                return
 
-        result = OldRecentContacts.model_validate_json(
-            await http.request(log, url, params=params)
-        )
-        return (
-            (ms_to_dt(int(r.properties.lastmodifieddate.value)), str(r.vid))
-            for r in result.contacts
-        ), result.has_more and result.time_offset
+            url = f"{HUB}/contacts/v1/lists/recently_updated/contacts/recent"
+            params = {"count": 100, "timeOffset": page} if page else {"count": 1}
+
+            result = OldRecentContacts.model_validate_json(
+                await http.request(log, url, params=params)
+            )
+            for r in result.contacts:
+                yield (ms_to_dt(int(r.properties.lastmodifieddate.value)), str(r.vid))
+                count += 1
+
+            if not (result.has_more and result.time_offset):
+                return
+            page = result.time_offset
 
     return fetch_changes_with_associations(
-        Names.contacts, Contact, do_fetch, log, http, with_history, since, until
+        Names.contacts, Contact, fetch_ids(), log, http, with_history, since, until
     )
 
 
@@ -61,13 +64,8 @@ def fetch_delayed_contacts(
     log: Logger, http: HTTPSession, with_history: bool, since: datetime, until: datetime
 ) -> AsyncGenerator[tuple[datetime, str, Contact], None]:
 
-    async def do_fetch(
-        page: PageCursor, count: int
-    ) -> tuple[Iterable[tuple[datetime, str]], PageCursor]:
-        return await fetch_search_objects(
-            Names.contacts, log, http, since, until, page, "lastmodifieddate"
-        )
-
     return fetch_changes_with_associations(
-        Names.contacts, Contact, do_fetch, log, http, with_history, since, until
+        Names.contacts, Contact,
+        fetch_search_objects(Names.contacts, log, http, since, until, "lastmodifieddate"),
+        log, http, with_history, since, until,
     )

--- a/source-hubspot-native/source_hubspot_native/api/custom_objects.py
+++ b/source-hubspot-native/source_hubspot_native/api/custom_objects.py
@@ -2,10 +2,8 @@ from datetime import datetime
 from logging import Logger
 from typing import (
     AsyncGenerator,
-    Iterable,
 )
 
-from estuary_cdk.capture.common import PageCursor
 from estuary_cdk.http import HTTPSession
 
 from ..models import (
@@ -27,13 +25,10 @@ def fetch_recent_custom_objects(
     until: datetime | None,
 ) -> AsyncGenerator[tuple[datetime, str, CustomObject], None]:
 
-    async def do_fetch(
-        page: PageCursor, count: int
-    ) -> tuple[Iterable[tuple[datetime, str]], PageCursor]:
-        return await fetch_search_objects(object_name, log, http, since, until, page)
-
     return fetch_changes_with_associations(
-        object_name, CustomObject, do_fetch, log, http, with_history, since, until
+        object_name, CustomObject,
+        fetch_search_objects(object_name, log, http, since, until),
+        log, http, with_history, since, until,
     )
 
 
@@ -46,13 +41,10 @@ def fetch_delayed_custom_objects(
     until: datetime,
 ) -> AsyncGenerator[tuple[datetime, str, CustomObject], None]:
 
-    async def do_fetch(
-        page: PageCursor, count: int
-    ) -> tuple[Iterable[tuple[datetime, str]], PageCursor]:
-        return await fetch_search_objects(object_name, log, http, since, until, page)
-
     return fetch_changes_with_associations(
-        object_name, CustomObject, do_fetch, log, http, with_history, since, until
+        object_name, CustomObject,
+        fetch_search_objects(object_name, log, http, since, until),
+        log, http, with_history, since, until,
     )
 
 async def list_custom_objects(

--- a/source-hubspot-native/source_hubspot_native/api/custom_objects.py
+++ b/source-hubspot-native/source_hubspot_native/api/custom_objects.py
@@ -27,7 +27,7 @@ def fetch_recent_custom_objects(
 
     return fetch_changes_with_associations(
         object_name, CustomObject,
-        fetch_search_objects(object_name, log, http, since, until),
+        fetch_search_objects(object_name, log, http, since, until, ignore_out_of_order_results=True),
         log, http, with_history, since, until,
     )
 

--- a/source-hubspot-native/source_hubspot_native/api/deals.py
+++ b/source-hubspot-native/source_hubspot_native/api/deals.py
@@ -2,10 +2,8 @@ from datetime import datetime
 from logging import Logger
 from typing import (
     AsyncGenerator,
-    Iterable,
 )
 
-from estuary_cdk.capture.common import PageCursor
 from estuary_cdk.http import HTTPSession
 
 from ..models import (
@@ -29,27 +27,30 @@ def fetch_recent_deals(
     until: datetime | None,
 ) -> AsyncGenerator[tuple[datetime, str, Deal], None]:
 
-    async def do_fetch(
-        page: PageCursor, count: int
-    ) -> tuple[Iterable[tuple[datetime, str]], PageCursor]:
-        if count >= 9_900:
-            log.warn("limit of 9,900 recent deals reached")
-            return [], None
+    async def fetch_ids():
+        count = 0
+        page = None
+        while True:
+            if count >= 9_900:
+                log.warn("limit of 9,900 recent deals reached")
+                return
 
-        url = f"{HUB}/deals/v1/deal/recent/modified"
-        params = {"count": 100, "offset": page} if page else {"count": 1}
+            url = f"{HUB}/deals/v1/deal/recent/modified"
+            params = {"count": 100, "offset": page} if page else {"count": 1}
 
-        result = OldRecentDeals.model_validate_json(
-            await http.request(log, url, params=params)
-        )
+            result = OldRecentDeals.model_validate_json(
+                await http.request(log, url, params=params)
+            )
+            for r in result.results:
+                yield (ms_to_dt(r.properties.hs_lastmodifieddate.timestamp), str(r.dealId))
+                count += 1
 
-        return (
-            (ms_to_dt(r.properties.hs_lastmodifieddate.timestamp), str(r.dealId))
-            for r in result.results
-        ), result.hasMore and result.offset
+            if not (result.hasMore and result.offset):
+                return
+            page = result.offset
 
     return fetch_changes_with_associations(
-        Names.deals, Deal, do_fetch, log, http, with_history, since, until
+        Names.deals, Deal, fetch_ids(), log, http, with_history, since, until
     )
 
 
@@ -57,11 +58,8 @@ def fetch_delayed_deals(
     log: Logger, http: HTTPSession, with_history: bool, since: datetime, until: datetime
 ) -> AsyncGenerator[tuple[datetime, str, Deal], None]:
 
-    async def do_fetch(
-        page: PageCursor, count: int
-    ) -> tuple[Iterable[tuple[datetime, str]], PageCursor]:
-        return await fetch_search_objects(Names.deals, log, http, since, until, page)
-
     return fetch_changes_with_associations(
-        Names.deals, Deal, do_fetch, log, http, with_history, since, until
+        Names.deals, Deal,
+        fetch_search_objects(Names.deals, log, http, since, until),
+        log, http, with_history, since, until,
     )

--- a/source-hubspot-native/source_hubspot_native/api/deals.py
+++ b/source-hubspot-native/source_hubspot_native/api/deals.py
@@ -42,7 +42,13 @@ def fetch_recent_deals(
                 await http.request(log, url, params=params)
             )
             for r in result.results:
-                yield (ms_to_dt(r.properties.hs_lastmodifieddate.timestamp), str(r.dealId))
+                ts = ms_to_dt(r.properties.hs_lastmodifieddate.timestamp)
+                # This API returns results newest-first, so once we
+                # see a record at or before `since` there's nothing
+                # left worth fetching.
+                if ts <= since:
+                    return
+                yield (ts, str(r.dealId))
                 count += 1
 
             if not (result.hasMore and result.offset):

--- a/source-hubspot-native/source_hubspot_native/api/engagements.py
+++ b/source-hubspot-native/source_hubspot_native/api/engagements.py
@@ -20,7 +20,7 @@ from .shared import (
 
 
 async def _fetch_engagement_ids(
-    log: Logger, http: HTTPSession,
+    log: Logger, http: HTTPSession, since: datetime,
 ):
     count = 0
     page = None
@@ -40,7 +40,13 @@ async def _fetch_engagement_ids(
             await http.request(log, url, params=params)
         )
         for r in result.results:
-            yield (ms_to_dt(r.engagement.lastUpdated), str(r.engagement.id))
+            ts = ms_to_dt(r.engagement.lastUpdated)
+            # This API returns results newest-first, so once we
+            # see a record at or before `since` there's nothing
+            # left worth fetching.
+            if ts <= since:
+                return
+            yield (ts, str(r.engagement.id))
             count += 1
 
         if not (result.hasMore and result.offset):
@@ -58,7 +64,7 @@ def fetch_recent_engagements(
     return fetch_changes_with_associations(
         Names.engagements,
         Engagement,
-        _fetch_engagement_ids(log, http),
+        _fetch_engagement_ids(log, http, since),
         log,
         http,
         with_history,
@@ -77,7 +83,7 @@ def fetch_delayed_engagements(
     return fetch_changes_with_associations(
         Names.engagements,
         Engagement,
-        _fetch_engagement_ids(log, http),
+        _fetch_engagement_ids(log, http, since),
         log,
         http,
         with_history,

--- a/source-hubspot-native/source_hubspot_native/api/engagements.py
+++ b/source-hubspot-native/source_hubspot_native/api/engagements.py
@@ -1,12 +1,9 @@
-import functools
 from datetime import datetime
 from logging import Logger
 from typing import (
     AsyncGenerator,
-    Iterable,
 )
 
-from estuary_cdk.capture.common import PageCursor
 from estuary_cdk.http import HTTPSession
 
 from ..models import (
@@ -22,27 +19,33 @@ from .shared import (
 )
 
 
-async def _fetch_engagements(
-    log: Logger, http: HTTPSession, page: PageCursor, count: int
-) -> tuple[Iterable[tuple[datetime, str]], PageCursor]:
-    if count >= 9_900:
-        # "Engagements" as we are capturing them has a 10k limit on how many
-        # items the API can return, and there is no other API that can be used
-        # to get them within a certain time window. The only option here is to
-        # re-backfill.
-        log.warn("limit of 9,900 recent engagements reached")
-        raise MustBackfillBinding
+async def _fetch_engagement_ids(
+    log: Logger, http: HTTPSession,
+):
+    count = 0
+    page = None
+    while True:
+        if count >= 9_900:
+            # "Engagements" as we are capturing them has a 10k limit on how many
+            # items the API can return, and there is no other API that can be used
+            # to get them within a certain time window. The only option here is to
+            # re-backfill.
+            log.warn("limit of 9,900 recent engagements reached")
+            raise MustBackfillBinding
 
-    url = f"{HUB}/engagements/v1/engagements/recent/modified"
-    params = {"count": 100, "offset": page} if page else {"count": 1}
+        url = f"{HUB}/engagements/v1/engagements/recent/modified"
+        params = {"count": 100, "offset": page} if page else {"count": 1}
 
-    result = OldRecentEngagements.model_validate_json(
-        await http.request(log, url, params=params)
-    )
-    return (
-        (ms_to_dt(r.engagement.lastUpdated), str(r.engagement.id))
-        for r in result.results
-    ), result.hasMore and result.offset
+        result = OldRecentEngagements.model_validate_json(
+            await http.request(log, url, params=params)
+        )
+        for r in result.results:
+            yield (ms_to_dt(r.engagement.lastUpdated), str(r.engagement.id))
+            count += 1
+
+        if not (result.hasMore and result.offset):
+            return
+        page = result.offset
 
 
 def fetch_recent_engagements(
@@ -55,7 +58,7 @@ def fetch_recent_engagements(
     return fetch_changes_with_associations(
         Names.engagements,
         Engagement,
-        functools.partial(_fetch_engagements, log, http),
+        _fetch_engagement_ids(log, http),
         log,
         http,
         with_history,
@@ -74,7 +77,7 @@ def fetch_delayed_engagements(
     return fetch_changes_with_associations(
         Names.engagements,
         Engagement,
-        functools.partial(_fetch_engagements, log, http),
+        _fetch_engagement_ids(log, http),
         log,
         http,
         with_history,

--- a/source-hubspot-native/source_hubspot_native/api/feedback_submissions.py
+++ b/source-hubspot-native/source_hubspot_native/api/feedback_submissions.py
@@ -2,10 +2,8 @@ from datetime import datetime
 from logging import Logger
 from typing import (
     AsyncGenerator,
-    Iterable,
 )
 
-from estuary_cdk.capture.common import PageCursor
 from estuary_cdk.http import HTTPSession
 
 from ..models import (
@@ -24,17 +22,10 @@ def fetch_recent_feedback_submissions(
     until: datetime | None,
 ) -> AsyncGenerator[tuple[datetime, str, FeedbackSubmission], None]:
 
-    async def do_fetch(
-        page: PageCursor, count: int
-    ) -> tuple[Iterable[tuple[datetime, str]], PageCursor]:
-        return await fetch_search_objects(
-            Names.feedback_submissions, log, http, since, until, page
-        )
-
     return fetch_changes_with_associations(
         Names.feedback_submissions,
         FeedbackSubmission,
-        do_fetch,
+        fetch_search_objects(Names.feedback_submissions, log, http, since, until),
         log,
         http,
         with_history,

--- a/source-hubspot-native/source_hubspot_native/api/feedback_submissions.py
+++ b/source-hubspot-native/source_hubspot_native/api/feedback_submissions.py
@@ -25,7 +25,7 @@ def fetch_recent_feedback_submissions(
     return fetch_changes_with_associations(
         Names.feedback_submissions,
         FeedbackSubmission,
-        fetch_search_objects(Names.feedback_submissions, log, http, since, until),
+        fetch_search_objects(Names.feedback_submissions, log, http, since, until, ignore_out_of_order_results=True),
         log,
         http,
         with_history,
@@ -37,4 +37,14 @@ def fetch_recent_feedback_submissions(
 def fetch_delayed_feedback_submissions(
     log: Logger, http: HTTPSession, with_history: bool, since: datetime, until: datetime
 ) -> AsyncGenerator[tuple[datetime, str, FeedbackSubmission], None]:
-    return fetch_recent_feedback_submissions(log, http, with_history, since, until)
+
+    return fetch_changes_with_associations(
+        Names.feedback_submissions,
+        FeedbackSubmission,
+        fetch_search_objects(Names.feedback_submissions, log, http, since, until),
+        log,
+        http,
+        with_history,
+        since,
+        until,
+    )

--- a/source-hubspot-native/source_hubspot_native/api/goals.py
+++ b/source-hubspot-native/source_hubspot_native/api/goals.py
@@ -2,10 +2,8 @@ from datetime import datetime
 from logging import Logger
 from typing import (
     AsyncGenerator,
-    Iterable,
 )
 
-from estuary_cdk.capture.common import PageCursor
 from estuary_cdk.http import HTTPSession
 
 from ..models import (
@@ -24,13 +22,10 @@ def fetch_recent_goals(
     until: datetime | None,
 ) -> AsyncGenerator[tuple[datetime, str, Goals], None]:
 
-    async def do_fetch(
-        page: PageCursor, count: int
-    ) -> tuple[Iterable[tuple[datetime, str]], PageCursor]:
-        return await fetch_search_objects(Names.goals, log, http, since, until, page)
-
     return fetch_changes_with_associations(
-        Names.goals, Goals, do_fetch, log, http, with_history, since, until
+        Names.goals, Goals,
+        fetch_search_objects(Names.goals, log, http, since, until),
+        log, http, with_history, since, until,
     )
 
 
@@ -38,11 +33,8 @@ def fetch_delayed_goals(
     log: Logger, http: HTTPSession, with_history: bool, since: datetime, until: datetime
 ) -> AsyncGenerator[tuple[datetime, str, Goals], None]:
 
-    async def do_fetch(
-        page: PageCursor, count: int
-    ) -> tuple[Iterable[tuple[datetime, str]], PageCursor]:
-        return await fetch_search_objects(Names.goals, log, http, since, until, page)
-
     return fetch_changes_with_associations(
-        Names.goals, Goals, do_fetch, log, http, with_history, since, until
+        Names.goals, Goals,
+        fetch_search_objects(Names.goals, log, http, since, until),
+        log, http, with_history, since, until,
     )

--- a/source-hubspot-native/source_hubspot_native/api/goals.py
+++ b/source-hubspot-native/source_hubspot_native/api/goals.py
@@ -24,7 +24,7 @@ def fetch_recent_goals(
 
     return fetch_changes_with_associations(
         Names.goals, Goals,
-        fetch_search_objects(Names.goals, log, http, since, until),
+        fetch_search_objects(Names.goals, log, http, since, until, ignore_out_of_order_results=True),
         log, http, with_history, since, until,
     )
 

--- a/source-hubspot-native/source_hubspot_native/api/line_items.py
+++ b/source-hubspot-native/source_hubspot_native/api/line_items.py
@@ -2,10 +2,8 @@ from datetime import datetime
 from logging import Logger
 from typing import (
     AsyncGenerator,
-    Iterable,
 )
 
-from estuary_cdk.capture.common import PageCursor
 from estuary_cdk.http import HTTPSession
 
 from ..models import (
@@ -24,15 +22,10 @@ def fetch_recent_line_items(
     until: datetime | None,
 ) -> AsyncGenerator[tuple[datetime, str, LineItem], None]:
 
-    async def do_fetch(
-        page: PageCursor, count: int
-    ) -> tuple[Iterable[tuple[datetime, str]], PageCursor]:
-        return await fetch_search_objects(
-            Names.line_items, log, http, since, until, page
-        )
-
     return fetch_changes_with_associations(
-        Names.line_items, LineItem, do_fetch, log, http, with_history, since, until
+        Names.line_items, LineItem,
+        fetch_search_objects(Names.line_items, log, http, since, until),
+        log, http, with_history, since, until,
     )
 
 
@@ -40,13 +33,8 @@ def fetch_delayed_line_items(
     log: Logger, http: HTTPSession, with_history: bool, since: datetime, until: datetime
 ) -> AsyncGenerator[tuple[datetime, str, LineItem], None]:
 
-    async def do_fetch(
-        page: PageCursor, count: int
-    ) -> tuple[Iterable[tuple[datetime, str]], PageCursor]:
-        return await fetch_search_objects(
-            Names.line_items, log, http, since, until, page
-        )
-
     return fetch_changes_with_associations(
-        Names.line_items, LineItem, do_fetch, log, http, with_history, since, until
+        Names.line_items, LineItem,
+        fetch_search_objects(Names.line_items, log, http, since, until),
+        log, http, with_history, since, until,
     )

--- a/source-hubspot-native/source_hubspot_native/api/line_items.py
+++ b/source-hubspot-native/source_hubspot_native/api/line_items.py
@@ -24,7 +24,7 @@ def fetch_recent_line_items(
 
     return fetch_changes_with_associations(
         Names.line_items, LineItem,
-        fetch_search_objects(Names.line_items, log, http, since, until),
+        fetch_search_objects(Names.line_items, log, http, since, until, ignore_out_of_order_results=True),
         log, http, with_history, since, until,
     )
 

--- a/source-hubspot-native/source_hubspot_native/api/object_with_associations.py
+++ b/source-hubspot-native/source_hubspot_native/api/object_with_associations.py
@@ -6,7 +6,6 @@ from typing import (
     Any,
     AsyncGenerator,
     Awaitable,
-    Callable,
     Iterable,
 )
 
@@ -30,17 +29,14 @@ from .shared import (
 )
 
 
-_FetchIdsFn = Callable[
-    [PageCursor, int],
-    Awaitable[tuple[Iterable[tuple[datetime, str]], PageCursor]],
-]
+FetchIdsFn = AsyncGenerator[tuple[datetime, str], None]
 """
-Returns a stream of object IDs that can be used to fetch the full object details
-along with its associations. Used in `fetch_changes_with_associations`.
+An async generator that yields (datetime, id) tuples for fetching the full
+object details along with associations. Used in `fetch_changes_with_associations`.
 
-IDs may be returned in any order, but iteration will be stopped upon seeing an
-entry that's as-old or older than the datetime cursor. Entries newer than the
-until datetime will be discarded.
+IDs may be yielded in any order. Entries as-old or older than the `since` cursor
+will be filtered out by `fetch_changes_with_associations`. Entries newer than the
+`until` datetime will be discarded.
 """
 
 
@@ -220,7 +216,7 @@ async def fetch_batch_with_associations(
 async def fetch_changes_with_associations(
     object_name: str,
     cls: type[CRMObject],
-    fetcher: _FetchIdsFn,
+    fetch_ids: FetchIdsFn,
     log: Logger,
     http: HTTPSession,
     with_history: bool,
@@ -228,35 +224,13 @@ async def fetch_changes_with_associations(
     until: datetime | None,
 ) -> AsyncGenerator[tuple[datetime, str, CRMObject], None]:
 
-    # Walk pages of recent IDs until we see one which is as-old
-    # as `since`, or no pages remain.
-    recent: list[tuple[datetime, str]] = []
-    next_page: PageCursor = None
-    count = 0
-
-    while True:
-        iter, next_page = await fetcher(next_page, count)
-
-        for ts, id in iter:
-            count += 1
-            if until and ts > until:
-                continue
-            elif ts > since:
-                # TODO(whb): It may be worth consulting the emitted changes
-                # cache here to see if we have already emitted a more recent
-                # change event before we do all the associations fetching work.
-                # Before implementing that I'd like to make sure that the
-                # top-level filtering works in production. Since the delayed
-                # changes stream only runs every 5 minutes or so it shouldn't be
-                # a huge load on the connector.
-                recent.append((ts, id))
-            else:
-                next_page = None
-
-        if not next_page:
-            break
-
-    recent.sort()  # Oldest updates first.
+    batch_size = 50 if with_history else 100
+    # Collect enough IDs for several concurrent batch fetches before
+    # processing, keeping the buffer_ordered pipeline saturated while
+    # limiting peak memory to a small multiple of the batch size.
+    concurrent_batches = 3
+    batches_per_chunk = 3
+    chunk_size = batch_size * concurrent_batches * batches_per_chunk
 
     async def _do_batch_fetch(
         batch: list[tuple[datetime, str]],
@@ -283,25 +257,46 @@ async def fetch_changes_with_associations(
 
         return ((dts[str(doc.id)], str(doc.id), doc) for doc in documents.results)
 
-    async def _batches_gen() -> (
-        AsyncGenerator[Awaitable[Iterable[tuple[datetime, str, CRMObject]]], None]
-    ):
-        for batch_it in itertools.batched(recent, 50 if with_history else 100):
-            yield _do_batch_fetch(list(batch_it))
+    async def _process_chunk(
+        chunk: list[tuple[datetime, str]],
+    ) -> AsyncGenerator[tuple[datetime, str, CRMObject], None]:
+        async def _batches_gen() -> (
+            AsyncGenerator[Awaitable[Iterable[tuple[datetime, str, CRMObject]]], None]
+        ):
+            for batch_it in itertools.batched(chunk, batch_size):
+                yield _do_batch_fetch(list(batch_it))
 
-    total = len(recent)
-    if total >= 10_000:
-        log.info(
-            "will process large batch of changes with associations", {"total": total}
-        )
+        async for res in buffer_ordered(_batches_gen(), concurrent_batches):
+            for item in res:
+                yield item
 
-    count = 0
-    async for res in buffer_ordered(_batches_gen(), 3):
-        for ts, id, doc in res:
-            count += 1
-            if count > 0 and count % 10_000 == 0:
+    # Consume IDs from the generator incrementally, processing each chunk of
+    # IDs as it fills up rather than buffering all IDs in memory.
+    chunk: list[tuple[datetime, str]] = []
+    emitted = 0
+
+    async for ts, id in fetch_ids:
+        if until and ts > until:
+            continue
+        elif ts > since:
+            chunk.append((ts, id))
+            if len(chunk) >= chunk_size:
+                async for item in _process_chunk(chunk):
+                    emitted += 1
+                    if emitted % 10_000 == 0:
+                        log.info(
+                            "fetching changes with associations",
+                            {"count": emitted},
+                        )
+                    yield item
+                chunk = []
+
+    if chunk:
+        async for item in _process_chunk(chunk):
+            emitted += 1
+            if emitted % 10_000 == 0:
                 log.info(
                     "fetching changes with associations",
-                    {"count": count, "total": total},
+                    {"count": emitted},
                 )
-            yield ts, id, doc
+            yield item

--- a/source-hubspot-native/source_hubspot_native/api/orders.py
+++ b/source-hubspot-native/source_hubspot_native/api/orders.py
@@ -2,10 +2,8 @@ from datetime import datetime
 from logging import Logger
 from typing import (
     AsyncGenerator,
-    Iterable,
 )
 
-from estuary_cdk.capture.common import PageCursor
 from estuary_cdk.http import HTTPSession
 
 from ..models import (
@@ -24,13 +22,10 @@ def fetch_recent_orders(
     until: datetime | None,
 ) -> AsyncGenerator[tuple[datetime, str, Order], None]:
 
-    async def do_fetch(
-        page: PageCursor, count: int
-    ) -> tuple[Iterable[tuple[datetime, str]], PageCursor]:
-        return await fetch_search_objects(Names.orders, log, http, since, until, page)
-
     return fetch_changes_with_associations(
-        Names.orders, Order, do_fetch, log, http, with_history, since, until
+        Names.orders, Order,
+        fetch_search_objects(Names.orders, log, http, since, until),
+        log, http, with_history, since, until,
     )
 
 
@@ -38,11 +33,8 @@ def fetch_delayed_orders(
     log: Logger, http: HTTPSession, with_history: bool, since: datetime, until: datetime
 ) -> AsyncGenerator[tuple[datetime, str, Order], None]:
 
-    async def do_fetch(
-        page: PageCursor, count: int
-    ) -> tuple[Iterable[tuple[datetime, str]], PageCursor]:
-        return await fetch_search_objects(Names.orders, log, http, since, until, page)
-
     return fetch_changes_with_associations(
-        Names.orders, Order, do_fetch, log, http, with_history, since, until
+        Names.orders, Order,
+        fetch_search_objects(Names.orders, log, http, since, until),
+        log, http, with_history, since, until,
     )

--- a/source-hubspot-native/source_hubspot_native/api/orders.py
+++ b/source-hubspot-native/source_hubspot_native/api/orders.py
@@ -24,7 +24,7 @@ def fetch_recent_orders(
 
     return fetch_changes_with_associations(
         Names.orders, Order,
-        fetch_search_objects(Names.orders, log, http, since, until),
+        fetch_search_objects(Names.orders, log, http, since, until, ignore_out_of_order_results=True),
         log, http, with_history, since, until,
     )
 

--- a/source-hubspot-native/source_hubspot_native/api/products.py
+++ b/source-hubspot-native/source_hubspot_native/api/products.py
@@ -2,10 +2,8 @@ from datetime import datetime
 from logging import Logger
 from typing import (
     AsyncGenerator,
-    Iterable,
 )
 
-from estuary_cdk.capture.common import PageCursor
 from estuary_cdk.http import HTTPSession
 
 from ..models import (
@@ -24,13 +22,10 @@ def fetch_recent_products(
     until: datetime | None,
 ) -> AsyncGenerator[tuple[datetime, str, Product], None]:
 
-    async def do_fetch(
-        page: PageCursor, count: int
-    ) -> tuple[Iterable[tuple[datetime, str]], PageCursor]:
-        return await fetch_search_objects(Names.products, log, http, since, until, page)
-
     return fetch_changes_with_associations(
-        Names.products, Product, do_fetch, log, http, with_history, since, until
+        Names.products, Product,
+        fetch_search_objects(Names.products, log, http, since, until),
+        log, http, with_history, since, until,
     )
 
 
@@ -38,11 +33,8 @@ def fetch_delayed_products(
     log: Logger, http: HTTPSession, with_history: bool, since: datetime, until: datetime
 ) -> AsyncGenerator[tuple[datetime, str, Product], None]:
 
-    async def do_fetch(
-        page: PageCursor, count: int
-    ) -> tuple[Iterable[tuple[datetime, str]], PageCursor]:
-        return await fetch_search_objects(Names.products, log, http, since, until, page)
-
     return fetch_changes_with_associations(
-        Names.products, Product, do_fetch, log, http, with_history, since, until
+        Names.products, Product,
+        fetch_search_objects(Names.products, log, http, since, until),
+        log, http, with_history, since, until,
     )

--- a/source-hubspot-native/source_hubspot_native/api/products.py
+++ b/source-hubspot-native/source_hubspot_native/api/products.py
@@ -24,7 +24,7 @@ def fetch_recent_products(
 
     return fetch_changes_with_associations(
         Names.products, Product,
-        fetch_search_objects(Names.products, log, http, since, until),
+        fetch_search_objects(Names.products, log, http, since, until, ignore_out_of_order_results=True),
         log, http, with_history, since, until,
     )
 

--- a/source-hubspot-native/source_hubspot_native/api/search_objects.py
+++ b/source-hubspot-native/source_hubspot_native/api/search_objects.py
@@ -24,6 +24,7 @@ async def fetch_search_objects(
     since: datetime,
     until: datetime | None,
     last_modified_property_name: str = "hs_lastmodifieddate",
+    ignore_out_of_order_results: bool = False,
 ) -> AsyncGenerator[tuple[datetime, str], None]:
     """
     Yields (modified_time, id) tuples for records between 'since' and 'until'.
@@ -108,6 +109,12 @@ async def fetch_search_objects(
                 continue
 
             if this_mod_time < max_updated:
+                if ignore_out_of_order_results:
+                    log.warning(
+                        "ignoring out-of-order search result",
+                        {"id": r.id, "this_mod_time": this_mod_time, "max_updated": max_updated},
+                    )
+                    continue
                 log.error("search query input", input)
                 raise Exception(
                     f"search query returned records out of order for {r.id} with {this_mod_time} < {max_updated}"

--- a/source-hubspot-native/source_hubspot_native/api/search_objects.py
+++ b/source-hubspot-native/source_hubspot_native/api/search_objects.py
@@ -36,8 +36,7 @@ async def fetch_search_objects(
 
     Multiple records can have the same "last modified" property value, and
     indeed large runs of these may have the same value. When a new search is
-    initiated at the 10k boundary, some records may be yielded again. Callers
-    are expected to handle deduplication (e.g. via the emitted changes cache).
+    initiated at the 10k boundary, duplicates are filtered out locally.
     """
 
     url = f"{HUB}/crm/v3/objects/{object_name}/search"
@@ -45,6 +44,7 @@ async def fetch_search_objects(
     count = 0
     cursor: int | None = None
     max_updated: datetime = since
+    ids_at_max: set[str] = set()
     original_since = since
     original_total: int | None = None
 
@@ -120,7 +120,10 @@ async def fetch_search_objects(
                     f"search query returned records out of order for {r.id} with {this_mod_time} < {max_updated}"
                 )
 
-            max_updated = this_mod_time
+            if this_mod_time > max_updated:
+                max_updated = this_mod_time
+                ids_at_max = set()
+            ids_at_max.add(str(r.id))
             count += 1
             yield (this_mod_time, str(r.id))
 
@@ -150,8 +153,9 @@ async def fetch_search_objects(
                 for item in await fetch_search_objects_modified_at(
                     object_name, log, http, max_updated, last_modified_property_name
                 ):
-                    count += 1
-                    yield item
+                    if item[1] not in ids_at_max:
+                        count += 1
+                        yield item
 
                 # HubSpot APIs use millisecond resolution, so move the time
                 # cursor forward by that minimum amount now that we know we have

--- a/source-hubspot-native/source_hubspot_native/api/search_objects.py
+++ b/source-hubspot-native/source_hubspot_native/api/search_objects.py
@@ -2,10 +2,9 @@ from datetime import datetime, timedelta
 from logging import Logger
 from typing import (
     Any,
-    Iterable,
+    AsyncGenerator,
 )
 
-from estuary_cdk.capture.common import PageCursor
 from estuary_cdk.http import HTTPSession
 
 from ..models import (
@@ -24,26 +23,25 @@ async def fetch_search_objects(
     http: HTTPSession,
     since: datetime,
     until: datetime | None,
-    _: PageCursor,
     last_modified_property_name: str = "hs_lastmodifieddate",
-) -> tuple[Iterable[tuple[datetime, str]], PageCursor]:
+) -> AsyncGenerator[tuple[datetime, str], None]:
     """
-    Retrieve all records between 'since' and 'until' (or the present time).
+    Yields (modified_time, id) tuples for records between 'since' and 'until'.
 
-    The HubSpot Search API has an undocumented maximum offset of 10,000 items,
-    so the logic here will completely enumerate all available records, kicking
-    off new searches if needed to work around that limit. The returned
-    PageCursor is always None.
+    Results are yielded incrementally as each search API page is received,
+    rather than buffered in memory. The HubSpot Search API has an undocumented
+    maximum offset of 10,000 items, so the logic here will kick off new
+    searches if needed to work around that limit.
 
     Multiple records can have the same "last modified" property value, and
-    indeed large runs of these may have the same value. So a "new" search will
-    inevitably grab some records again, and deduplication is handled here via
-    the set.
+    indeed large runs of these may have the same value. When a new search is
+    initiated at the 10k boundary, some records may be yielded again. Callers
+    are expected to handle deduplication (e.g. via the emitted changes cache).
     """
 
     url = f"{HUB}/crm/v3/objects/{object_name}/search"
     limit = 200
-    output_items: set[tuple[datetime, str]] = set()
+    count = 0
     cursor: int | None = None
     max_updated: datetime = since
     original_since = since
@@ -116,14 +114,15 @@ async def fetch_search_objects(
                 )
 
             max_updated = this_mod_time
-            output_items.add((this_mod_time, str(r.id)))
+            count += 1
+            yield (this_mod_time, str(r.id))
 
         if not result.paging:
             if since is not original_since:
                 log.info(
                     "finished multi-request fetch",
                     {
-                        "final_count": len(output_items),
+                        "final_count": count,
                         "total": original_total,
                     },
                 )
@@ -141,11 +140,11 @@ async def fetch_search_objects(
                     "cycle detected for lastmodifieddate, fetching all ids for records modified at that instant",
                     {"object_name": object_name, "instant": since},
                 )
-                output_items.update(
-                    await fetch_search_objects_modified_at(
-                        object_name, log, http, max_updated, last_modified_property_name
-                    )
-                )
+                for item in await fetch_search_objects_modified_at(
+                    object_name, log, http, max_updated, last_modified_property_name
+                ):
+                    count += 1
+                    yield item
 
                 # HubSpot APIs use millisecond resolution, so move the time
                 # cursor forward by that minimum amount now that we know we have
@@ -165,14 +164,10 @@ async def fetch_search_objects(
                     "since": since,
                     "until": until,
                     "original_since": original_since,
-                    "count": len(output_items),
+                    "count": count,
                     "total": original_total,
                 },
             )
-
-    # Sort newest to oldest to match the convention of most of "fetch ID"
-    # functions.
-    return sorted(list(output_items), reverse=True), None
 
 
 async def fetch_search_objects_modified_at(

--- a/source-hubspot-native/source_hubspot_native/api/shared.py
+++ b/source-hubspot-native/source_hubspot_native/api/shared.py
@@ -209,7 +209,7 @@ async def fetch_delayed_changes(
                 continue
             elif ts > lower_bound:
                 max_ts = max(max_ts, ts)
-                if cache.should_yield(object_name, key, ts):
+                if not cache.has_as_recent_as(object_name, key, ts):
                     emitted += 1
                     yield obj
                 else:

--- a/source-hubspot-native/source_hubspot_native/api/tickets.py
+++ b/source-hubspot-native/source_hubspot_native/api/tickets.py
@@ -2,10 +2,8 @@ from datetime import datetime
 from logging import Logger
 from typing import (
     AsyncGenerator,
-    Iterable,
 )
 
-from estuary_cdk.capture.common import PageCursor
 from estuary_cdk.http import HTTPSession
 from pydantic import TypeAdapter
 
@@ -30,9 +28,7 @@ def fetch_recent_tickets(
     until: datetime | None,
 ) -> AsyncGenerator[tuple[datetime, str, Ticket], None]:
 
-    async def do_fetch(
-        page: PageCursor, count: int
-    ) -> tuple[Iterable[tuple[datetime, str]], PageCursor]:
+    async def fetch_ids():
         # This API will return a maximum of 1000 tickets, and does not appear to
         # ever return an error. It just ends at the 1000 most recently modified
         # tickets.
@@ -42,10 +38,11 @@ def fetch_recent_tickets(
         result = TypeAdapter(list[OldRecentTicket]).validate_json(
             await http.request(log, url, params=params)
         )
-        return ((ms_to_dt(r.timestamp), str(r.objectId)) for r in result), None
+        for r in result:
+            yield (ms_to_dt(r.timestamp), str(r.objectId))
 
     return fetch_changes_with_associations(
-        Names.tickets, Ticket, do_fetch, log, http, with_history, since, until
+        Names.tickets, Ticket, fetch_ids(), log, http, with_history, since, until
     )
 
 
@@ -53,11 +50,8 @@ def fetch_delayed_tickets(
     log: Logger, http: HTTPSession, with_history: bool, since: datetime, until: datetime
 ) -> AsyncGenerator[tuple[datetime, str, Ticket], None]:
 
-    async def do_fetch(
-        page: PageCursor, count: int
-    ) -> tuple[Iterable[tuple[datetime, str]], PageCursor]:
-        return await fetch_search_objects(Names.tickets, log, http, since, until, page)
-
     return fetch_changes_with_associations(
-        Names.tickets, Ticket, do_fetch, log, http, with_history, since, until
+        Names.tickets, Ticket,
+        fetch_search_objects(Names.tickets, log, http, since, until),
+        log, http, with_history, since, until,
     )


### PR DESCRIPTION
**Description:**

We've observed `source-hubspot-native` consistently OOM when there are millions of delayed changes to catch up on in a single `fetch_delayed_changes` invocation. This PR attempts to avoid those OOMs by:
 - Refactoring ID fetching from a callback-based pagination pattern to async generators, allowing `fetch_changes_with_associations` to process IDs in bounded chunks instead of buffering all records in memory.
  - Stopping legacy API pagination once results are at or before the since cursor, since these APIs return results newest-first.                                                     
  - Replacing the global deduplication set in `fetch_search_objects` with a small set tracking only IDs at the current `max_updated` timestamp, used for deduplication at the 10k search boundary.       
  - Switching delayed streams from `should_yield` (which inserted into the emitted changes cache as a side effect) to a pure `has_as_recent_as` check, limiting cache growth.

Additionally, realtime streams now tolerate out-of-order search results by logging a warning and skipping the record instead of raising an exception.   

There are quite a few changes here, and a lot of the diff is a result of changing from callbacks to async generators & the resulting interface changes. I recommend reading commit-by-commit

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

