### PR TITLE
source-stripe-native: speed up fetching connected account ids with concurrent worker system

### DIFF
--- a/source-stripe-native/source_stripe_native/account_fetcher.py
+++ b/source-stripe-native/source_stripe_native/account_fetcher.py
@@ -1,0 +1,314 @@
+import asyncio
+import time
+import traceback
+from asyncio import CancelledError
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from logging import Logger
+
+from estuary_cdk.http import HTTPSession
+from estuary_cdk.utils import format_error_message
+
+from .api import API
+from .models import Accounts, ListResult
+
+
+# Stripe launched in 2011. No connected accounts can exist before this date.
+STRIPE_EPOCH = int(datetime(2011, 2, 1, tzinfo=UTC).timestamp())
+
+
+@dataclass
+class TimestampChunk:
+    start: int
+    end: int
+
+
+@dataclass
+class AccountFetchConfig:
+    initial_chunks: int = 50
+    num_workers: int = 10
+
+    # How many seconds a worker processes a chunk before it is considered
+    # a dense time window and should be divided into smaller chunks.
+    dense_chunk_threshold_seconds: int = 30
+
+    # Minimum chunk size in seconds (1 minute) to prevent over-subdivision.
+    minimum_chunk_seconds: int = 60
+
+    work_queue_size: int = 100
+
+    page_limit: int = 100
+
+
+DEFAULT_CONFIG = AccountFetchConfig()
+
+
+def split_timestamp_range(
+    start: int,
+    end: int,
+    num_chunks: int,
+    minimum_chunk_seconds: int,
+) -> list[TimestampChunk]:
+    """Split a unix timestamp range into roughly equal-sized chunks.
+
+    If minimum_chunk_seconds would be violated, fewer chunks are produced.
+    Returns a list of TimestampChunks covering the full range.
+    """
+    if num_chunks <= 0:
+        raise ValueError("num_chunks must be positive")
+
+    if start >= end:
+        raise ValueError("start must be before end")
+
+    total_duration = end - start
+    num_chunks = max(
+        1,
+        min(
+            num_chunks,
+            total_duration // minimum_chunk_seconds,
+        ),
+    )
+    chunk_duration = total_duration / num_chunks
+
+    chunks: list[TimestampChunk] = []
+    current_start = start
+
+    for i in range(num_chunks):
+        if i == num_chunks - 1:
+            chunk_end = end
+        else:
+            chunk_end = int(current_start + chunk_duration)
+
+        chunks.append(TimestampChunk(start=current_start, end=chunk_end))
+        current_start = chunk_end
+
+    return chunks
+
+
+class AccountWorkManager:
+    def __init__(
+        self,
+        http: HTTPSession,
+        log: Logger,
+        config: AccountFetchConfig = DEFAULT_CONFIG,
+    ):
+        self.http = http
+        self.log = log
+        self.config = config
+
+        self.work_queue: asyncio.Queue[TimestampChunk | None] = asyncio.Queue(maxsize=config.work_queue_size)
+
+        self._active_worker_count = 0
+        self.first_worker_error: str | None = None
+
+        self.account_ids: set[str] = set()
+
+    def mark_worker_active(self) -> None:
+        if self._active_worker_count >= self.config.num_workers:
+            raise Exception(f"A worker attempted to mark itself active when the active worker count is {self._active_worker_count}.")
+        self._active_worker_count += 1
+
+    def mark_worker_inactive(self) -> None:
+        if self._active_worker_count <= 0:
+            raise Exception(f"A worker attempted to mark itself inactive when the active worker count is {self._active_worker_count}.")
+        self._active_worker_count -= 1
+
+    def are_active_workers(self) -> bool:
+        return self._active_worker_count > 0
+
+    def has_idle_workers(self) -> bool:
+        return self._active_worker_count < self.config.num_workers
+
+    async def fetch_account_ids(self, start: int, end: int) -> set[str]:
+        initial_chunks = self._create_initial_chunks(start, end)
+        for chunk in initial_chunks:
+            self.work_queue.put_nowait(chunk)
+
+        # Purely diagnostic: logs task outcomes to aid debugging when a task
+        # fails or is cancelled unexpectedly. Not used for control flow —
+        # the TaskGroup handles exception propagation and cancellation.
+        def callback(task: asyncio.Task):
+            task_name = task.get_name()
+            status: str = ""
+            stack_trace: str | None = None
+
+            if task.cancelled():
+                status = "cancelled"
+            elif exc := task.exception():
+                status = f"failed with exception {format_error_message(exc)}"
+                if exc.__traceback__:
+                    stack_trace = "\nStack trace:\n" + "".join(traceback.format_list(traceback.extract_tb(exc.__traceback__)))
+            else:
+                status = "completed"
+
+            self.log.debug(f"Task {task_name} {status}.", {
+                "first_worker_error": self.first_worker_error,
+                "active_worker_count": self._active_worker_count,
+                "stack_trace": stack_trace,
+            })
+
+        self.log.debug("Starting concurrent account fetch workers.")
+        async with asyncio.TaskGroup() as tg:
+            for i in range(self.config.num_workers):
+                worker_id = i + 1
+                task = tg.create_task(
+                    account_chunk_worker(
+                        worker_id=worker_id,
+                        work_queue=self.work_queue,
+                        work_manager=self,
+                        http=self.http,
+                        log=self.log,
+                        config=self.config,
+                    ),
+                    name=f"account_chunk_worker_{worker_id}"
+                )
+                task.add_done_callback(callback)
+
+            task = tg.create_task(
+                self._shutdown_coordinator(),
+                name="account_shutdown_coordinator"
+            )
+            task.add_done_callback(callback)
+
+        self.log.debug(f"Concurrent account fetch complete. Found {len(self.account_ids)} account IDs.")
+        return self.account_ids
+
+    def _create_initial_chunks(self, start: int, end: int) -> list[TimestampChunk]:
+        return split_timestamp_range(
+            start=start,
+            end=end,
+            num_chunks=self.config.initial_chunks,
+            minimum_chunk_seconds=self.config.minimum_chunk_seconds,
+        )
+
+    async def _shutdown_coordinator(self) -> None:
+        """Wait for all work items to be processed, then signal workers to exit."""
+        await self.work_queue.join()
+        for _ in range(self.config.num_workers):
+            self.work_queue.put_nowait(None)
+
+
+async def account_chunk_worker(
+    worker_id: int,
+    work_queue: asyncio.Queue[TimestampChunk | None],
+    work_manager: AccountWorkManager,
+    http: HTTPSession,
+    log: Logger,
+    config: AccountFetchConfig,
+) -> None:
+    try:
+        log.debug(f"Account worker {worker_id} started.")
+
+        while True:
+            chunk = await work_queue.get()
+            if chunk is None:
+                work_queue.task_done()
+                break
+
+            log.debug(f"Account worker {worker_id} working on chunk [{chunk.start}, {chunk.end}]")
+
+            work_manager.mark_worker_active()
+
+            try:
+                url = f"{API}/accounts"
+                params: dict[str, str | int] = {
+                    "limit": config.page_limit,
+                    "created[gte]": chunk.start,
+                    "created[lte]": chunk.end,
+                }
+                start_time = time.time()
+                page_count = 0
+                last_created: int | None = None
+                # Only consider subdividing if the chunk is large enough that the resulting
+                # sub-chunks would each still be meaningfully sized (above minimum_chunk_seconds).
+                is_divisible = (chunk.end - chunk.start) >= (config.minimum_chunk_seconds * 3)
+                is_dense_chunk = False
+
+                while True:
+                    response = ListResult[Accounts].model_validate_json(
+                        await http.request(log, url, params=params)
+                    )
+
+                    for account in response.data:
+                        work_manager.account_ids.add(account.id)
+                        last_created = account.created
+
+                    page_count += 1
+
+                    if not response.has_more:
+                        break
+
+                    # Stripe returns results in descending created order. After paginating
+                    # partway through chunk [S, E], the worker has processed accounts from E
+                    # down to last_created. The unprocessed range is [S, last_created].
+                    if (
+                        is_dense_chunk
+                        and last_created is not None
+                        and last_created > chunk.start
+                        and work_manager.has_idle_workers()
+                    ):
+                        sub_chunks = split_timestamp_range(
+                            start=chunk.start,
+                            end=last_created,
+                            num_chunks=config.num_workers,
+                            minimum_chunk_seconds=config.minimum_chunk_seconds,
+                        )
+                        for sub_chunk in sub_chunks:
+                            work_queue.put_nowait(sub_chunk)
+                        break
+
+                    # Check if this chunk is dense after each page.
+                    if (
+                        is_divisible
+                        and not is_dense_chunk
+                    ):
+                        elapsed = time.time() - start_time
+                        if elapsed > config.dense_chunk_threshold_seconds:
+                            is_dense_chunk = True
+
+                    params["starting_after"] = response.data[-1].id
+
+                log.debug(f"Account worker {worker_id} finished chunk. Pages: {page_count}, dense: {is_dense_chunk}")
+
+                # task_done() is called after any sub-chunks are enqueued to prevent
+                # join() from returning before the sub-chunks are processed.
+                work_queue.task_done()
+            finally:
+                work_manager.mark_worker_inactive()
+
+        log.debug(f"Account worker {worker_id} exited.")
+    except CancelledError as e:
+        if not work_manager.first_worker_error:
+            msg = format_error_message(e)
+            work_manager.first_worker_error = msg
+            raise Exception(f"Account worker {worker_id} was unexpectedly cancelled: {msg}")
+        else:
+            raise e
+    except BaseException as e:
+        msg = format_error_message(e)
+        if not work_manager.first_worker_error:
+            work_manager.first_worker_error = msg
+
+        log.error(f"Account worker {worker_id} encountered an error.", {
+            "exception": msg,
+        })
+        raise e
+
+
+async def fetch_connected_account_ids(
+    http: HTTPSession,
+    log: Logger,
+    config: AccountFetchConfig = DEFAULT_CONFIG,
+) -> list[str]:
+    """Fetch all connected account IDs using concurrent workers.
+
+    Uses time-range partitioning with created[gte]/created[lte] to parallelize
+    paginating through the accounts list endpoint.
+    """
+    start = STRIPE_EPOCH
+    end = int(time.time())
+
+    work_manager = AccountWorkManager(http=http, log=log, config=config)
+    await work_manager.fetch_account_ids(start, end)
+
+    return list(work_manager.account_ids)

--- a/source-stripe-native/source_stripe_native/resources.py
+++ b/source-stripe-native/source_stripe_native/resources.py
@@ -20,6 +20,7 @@ DEFAULT_SCHEDULE = "0 0 * * *"
 
 from estuary_cdk.http import HTTPError, HTTPMixin, HTTPSession, TokenSource
 
+from .account_fetcher import fetch_connected_account_ids
 from .api import (
     API,
     fetch_backfill,
@@ -39,7 +40,6 @@ from .models import (
     Accounts,
     ConnectorState,
     EndpointConfig,
-    ListResult,
 )
 from .priority_capture import (
     open_binding_with_priority_queue,
@@ -75,31 +75,6 @@ async def check_accessibility(
         is_accessible = not is_permission_blocked and not is_disabled
 
     return is_accessible
-
-
-async def _fetch_connected_account_ids(
-    http: HTTPSession,
-    log: Logger,
-) -> list[str]:
-    account_ids: set[str] = set()
-
-    url = f"{API}/accounts"
-    params: dict[str, str | int] = {"limit": 100}
-
-    while True:
-        response = ListResult[Accounts].model_validate_json(
-            await http.request(log, url, params=params)
-        )
-
-        for account in response.data:
-            account_ids.add(account.id)
-
-        if not response.has_more:
-            break
-
-        params["starting_after"] = response.data[-1].id
-
-    return list(account_ids)
 
 
 async def _fetch_platform_account_id(
@@ -189,7 +164,7 @@ async def all_resources(
         log.info(
             "Fetching connected account IDs. This may take multiple minutes if there are many connected accounts."
         )
-        connected_account_ids = await _fetch_connected_account_ids(http, log)
+        connected_account_ids = await fetch_connected_account_ids(http, log)
         log.info(
             f"Found {len(connected_account_ids)} connected account IDs.",
             {

--- a/source-stripe-native/tests/test_account_fetcher_unit.py
+++ b/source-stripe-native/tests/test_account_fetcher_unit.py
@@ -1,0 +1,337 @@
+import asyncio
+import json
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from source_stripe_native.account_fetcher import (
+    AccountFetchConfig,
+    AccountWorkManager,
+    TimestampChunk,
+    account_chunk_worker,
+    fetch_connected_account_ids,
+    split_timestamp_range,
+)
+
+
+class TestSplitTimestampRange:
+    def test_basic_split(self):
+        chunks = split_timestamp_range(0, 100, num_chunks=5, minimum_chunk_seconds=1)
+        assert len(chunks) == 5
+        # First chunk starts at 0, last chunk ends at 100
+        assert chunks[0].start == 0
+        assert chunks[-1].end == 100
+        # Chunks are contiguous
+        for i in range(len(chunks) - 1):
+            assert chunks[i].end == chunks[i + 1].start
+
+    def test_single_chunk(self):
+        chunks = split_timestamp_range(0, 100, num_chunks=1, minimum_chunk_seconds=1)
+        assert len(chunks) == 1
+        assert chunks[0] == TimestampChunk(0, 100)
+
+    def test_minimum_chunk_size_reduces_count(self):
+        # 100 seconds total, 50 chunks requested, but minimum is 25 seconds
+        # Should produce 4 chunks (100 / 25 = 4)
+        chunks = split_timestamp_range(0, 100, num_chunks=50, minimum_chunk_seconds=25)
+        assert len(chunks) == 4
+        assert chunks[0].start == 0
+        assert chunks[-1].end == 100
+
+    def test_minimum_chunk_size_larger_than_range(self):
+        # Range is 50 seconds but minimum chunk is 100 seconds -> 1 chunk
+        chunks = split_timestamp_range(0, 50, num_chunks=10, minimum_chunk_seconds=100)
+        assert len(chunks) == 1
+        assert chunks[0] == TimestampChunk(0, 50)
+
+    def test_invalid_num_chunks(self):
+        with pytest.raises(ValueError, match="num_chunks must be positive"):
+            split_timestamp_range(0, 100, num_chunks=0, minimum_chunk_seconds=1)
+
+    def test_invalid_range(self):
+        with pytest.raises(ValueError, match="start must be before end"):
+            split_timestamp_range(100, 50, num_chunks=5, minimum_chunk_seconds=1)
+
+    def test_equal_start_end(self):
+        with pytest.raises(ValueError, match="start must be before end"):
+            split_timestamp_range(100, 100, num_chunks=5, minimum_chunk_seconds=1)
+
+    def test_large_range(self):
+        # ~15 years in seconds (similar to STRIPE_EPOCH -> now)
+        start = 1296518400
+        end = start + (15 * 365 * 24 * 3600)
+        chunks = split_timestamp_range(start, end, num_chunks=50, minimum_chunk_seconds=60)
+        assert len(chunks) == 50
+        assert chunks[0].start == start
+        assert chunks[-1].end == end
+        for i in range(len(chunks) - 1):
+            assert chunks[i].end == chunks[i + 1].start
+
+
+class TestAccountWorkManager:
+    def test_mark_worker_active_inactive(self):
+        wm = AccountWorkManager(http=MagicMock(), log=MagicMock())
+        assert not wm.are_active_workers()
+
+        wm.mark_worker_active()
+        assert wm.are_active_workers()
+
+        wm.mark_worker_inactive()
+        assert not wm.are_active_workers()
+
+    def test_mark_worker_active_overflow(self):
+        config = AccountFetchConfig(num_workers=1)
+        wm = AccountWorkManager(http=MagicMock(), log=MagicMock(), config=config)
+        wm.mark_worker_active()
+        with pytest.raises(Exception, match="active worker count"):
+            wm.mark_worker_active()
+
+    def test_mark_worker_inactive_underflow(self):
+        wm = AccountWorkManager(http=MagicMock(), log=MagicMock())
+        with pytest.raises(Exception, match="active worker count"):
+            wm.mark_worker_inactive()
+
+
+def _make_accounts_response(account_ids: list[str], created_timestamps: list[int], has_more: bool = False) -> bytes:
+    """Build a JSON response matching ListResult[Accounts] shape."""
+    data = []
+    for aid, created in zip(account_ids, created_timestamps):
+        data.append({
+            "id": aid,
+            "object": "account",
+            "created": created,
+        })
+    return json.dumps({
+        "object": "list",
+        "url": "/v1/accounts",
+        "has_more": has_more,
+        "data": data,
+    }).encode()
+
+
+class TestFetchConnectedAccountIdsConcurrent:
+    @pytest.mark.asyncio
+    async def test_concurrent_fetch_collects_all_ids(self):
+        """Workers should find all accounts across time-range chunks."""
+        http = MagicMock()
+        log = MagicMock()
+
+        # Generate accounts across different time ranges
+        all_accounts: dict[str, int] = {}
+        for i in range(250):
+            aid = f"acct_{i:04d}"
+            created = 1296518400 + (i * 100000)
+            all_accounts[aid] = created
+
+        async def mock_request(_log, url, params: dict[str, str | int]):
+            gte = int(params["created[gte]"])
+            lte = int(params["created[lte]"])
+            starting_after = params.get("starting_after")
+
+            matching = [
+                (a, c) for a, c in all_accounts.items()
+                if gte <= c <= lte
+            ]
+            matching.sort(key=lambda x: x[1], reverse=True)
+
+            if starting_after:
+                idx = next(
+                    (j for j, (a, _) in enumerate(matching) if a == starting_after),
+                    None,
+                )
+                if idx is not None:
+                    matching = matching[idx + 1:]
+
+            page_size = int(params.get("limit", 100))
+            page = matching[:page_size]
+            has_more = len(matching) > page_size
+
+            return _make_accounts_response(
+                [a for a, _ in page],
+                [c for _, c in page],
+                has_more=has_more,
+            )
+
+        http.request = mock_request
+
+        config = AccountFetchConfig(
+            initial_chunks=10,
+            num_workers=3,
+            minimum_chunk_seconds=1,
+        )
+        result = await fetch_connected_account_ids(http, log, config=config)
+
+        assert set(result) == set(all_accounts.keys())
+
+    @pytest.mark.asyncio
+    async def test_deduplication(self):
+        """Accounts appearing in multiple chunks (edge boundary) are deduplicated."""
+        http = MagicMock()
+        log = MagicMock()
+
+        async def mock_request(_log, url, params: dict[str, str | int]):
+            gte = int(params["created[gte]"])
+
+            return _make_accounts_response(
+                ["acct_boundary", f"acct_unique_{gte}"],
+                [1500000000, 1500000000 + gte],
+                has_more=False,
+            )
+
+        http.request = mock_request
+
+        config = AccountFetchConfig(
+            initial_chunks=5,
+            num_workers=2,
+            minimum_chunk_seconds=1,
+        )
+        result = await fetch_connected_account_ids(http, log, config=config)
+
+        # acct_boundary should appear exactly once despite being in multiple chunks
+        assert result.count("acct_boundary") == 1
+
+
+class TestAccountChunkWorker:
+    @pytest.mark.asyncio
+    async def test_worker_processes_chunk_and_collects_ids(self):
+        """A single worker should paginate through its chunk and collect IDs."""
+        http = MagicMock()
+        log = MagicMock()
+        config = AccountFetchConfig(num_workers=1)
+        work_manager = AccountWorkManager(http=http, log=log, config=config)
+        work_queue = work_manager.work_queue
+
+        response = _make_accounts_response(
+            ["acct_1", "acct_2"],
+            [1700000200, 1700000100],
+            has_more=False,
+        )
+        http.request = AsyncMock(return_value=response)
+
+        work_queue.put_nowait(TimestampChunk(1700000000, 1700000300))
+        work_queue.put_nowait(None)  # Sentinel to shut down the worker.
+
+        await account_chunk_worker(
+            worker_id=1,
+            work_queue=work_queue,
+            work_manager=work_manager,
+            http=http,
+            log=log,
+            config=config,
+        )
+
+        assert work_manager.account_ids == {"acct_1", "acct_2"}
+
+    @pytest.mark.asyncio
+    async def test_worker_paginates_multiple_pages(self):
+        """Worker should follow pagination within its time chunk."""
+        http = MagicMock()
+        log = MagicMock()
+        config = AccountFetchConfig(num_workers=1, page_limit=2)
+        work_manager = AccountWorkManager(http=http, log=log, config=config)
+        work_queue = work_manager.work_queue
+
+        page1 = _make_accounts_response(
+            ["acct_1", "acct_2"],
+            [1700000300, 1700000200],
+            has_more=True,
+        )
+        page2 = _make_accounts_response(
+            ["acct_3"],
+            [1700000100],
+            has_more=False,
+        )
+        http.request = AsyncMock(side_effect=[page1, page2])
+
+        work_queue.put_nowait(TimestampChunk(1700000000, 1700000400))
+        work_queue.put_nowait(None)  # Sentinel to shut down the worker.
+
+        await account_chunk_worker(
+            worker_id=1,
+            work_queue=work_queue,
+            work_manager=work_manager,
+            http=http,
+            log=log,
+            config=config,
+        )
+
+        assert work_manager.account_ids == {"acct_1", "acct_2", "acct_3"}
+        assert http.request.call_count == 2
+
+
+class TestDenseChunkDetection:
+    @pytest.mark.asyncio
+    async def test_dense_chunk_triggers_subdivision(self):
+        """When a chunk takes too long and idle workers exist, subdivision should be triggered.
+
+        The worker flow is:
+          Page 1: fetch -> density check sets is_dense_chunk=True -> continue
+          Page 2: fetch -> has_more=True -> subdivision check triggers -> break
+
+        So we need at least 2 pages with has_more=True for subdivision to fire.
+        """
+        http = MagicMock()
+        log = MagicMock()
+        config = AccountFetchConfig(
+            num_workers=2,
+            dense_chunk_threshold_seconds=0,  # Immediately mark as dense
+            minimum_chunk_seconds=1,
+        )
+        work_manager = AccountWorkManager(http=http, log=log, config=config)
+        work_queue = work_manager.work_queue
+
+        # Page 1: has_more=True, triggers density detection
+        page1 = _make_accounts_response(
+            ["acct_1", "acct_2"],
+            [1700000200, 1700000150],
+            has_more=True,
+        )
+        # Page 2: has_more=True, now is_dense_chunk is True so subdivision triggers
+        page2 = _make_accounts_response(
+            ["acct_3", "acct_4"],
+            [1700000100, 1700000050],
+            has_more=True,
+        )
+        # Page 3 should not be reached because worker breaks after subdivision
+        page3 = _make_accounts_response(
+            ["acct_5"],
+            [1700000025],
+            has_more=False,
+        )
+        http.request = AsyncMock(side_effect=[page1, page2, page3])
+
+        chunk = TimestampChunk(start=1700000000, end=1700000300)
+        work_queue.put_nowait(chunk)
+        work_queue.put_nowait(None)  # Sentinel to shut down the worker.
+
+        await account_chunk_worker(
+            worker_id=1,
+            work_queue=work_queue,
+            work_manager=work_manager,
+            http=http,
+            log=log,
+            config=config,
+        )
+
+        # Worker should have collected accounts from pages 1 and 2
+        assert work_manager.account_ids >= {"acct_1", "acct_2", "acct_3", "acct_4"}
+        # Page 3 should not have been fetched
+        assert "acct_5" not in work_manager.account_ids
+
+        # The remaining range [chunk.start, last_created] should have been split into
+        # sub-chunks on the work queue. last_created after page 2 is 1700000050.
+        # With num_workers=2, we get 2 sub-chunks plus the sentinel we already consumed.
+        sub_chunks = []
+        while not work_queue.empty():
+            item = work_queue.get_nowait()
+            if item is not None:
+                sub_chunks.append(item)
+
+        assert len(sub_chunks) == 2
+        assert sub_chunks[0].start == chunk.start
+        assert sub_chunks[-1].end == 1700000050
+        for i in range(len(sub_chunks) - 1):
+            assert sub_chunks[i].end == sub_chunks[i + 1].start
+
+        # Only two API calls: page 1 (density detected) and page 2 (subdivision triggered)
+        assert http.request.call_count == 2


### PR DESCRIPTION
**Description:**

The previous `_fetch_connected_account_ids` implementation was a single sequential paginator through GET `/v1/accounts`. For platforms with 36k+ connected accounts, this was taking over an hour. That's too slow since all connected account ids are fetched each time the capture starts up; we'd rather not spend an hour fetching connected account ids before capturing any data.

This commit replaces that sequential paginator with a concurrent worker system modeled after `source-klaviyo-native`'s [events backfill](https://github.com/estuary/connectors/blob/main/source-klaviyo-native/source_klaviyo_native/api/events.py). The concurrent worker system partitions the time range into chunks using Stripe's `created[gte]`/`created[lte]` query parameters and has multiple workers paginate through their respective chunks in parallel.

Workers detect dense time windows (chunks that take >30s to paginate) and, when idle workers are available, they subdivide the remaining unprocessed range into smaller chunks for other workers to pick up.

**Notes for reviewers:**

This is an isolated change that's a drop in replacement for how the connector fetches connected account ids. The very similar concurrent worker system in `source-klaviyo-native` has been working well for multiple months, and I anticipate it'll work well in `source-stripe-native` too to speed up fetching all connected account ids by at least 5x, likely more.

