### PR TITLE
materialize-snowflake: log if encryption key is missing

### DIFF
--- a/materialize-snowflake/stream.go
+++ b/materialize-snowflake/stream.go
@@ -256,6 +256,10 @@ func (sm *streamManager) write(ctx context.Context, blobs []*blobMetadata, decry
 			//
 			// This check can be removed once all tasks have written a checkpoint.
 			if decryptKey == "" {
+				log.WithFields(log.Fields{
+					"schema": schema,
+					"table":  table,
+				}).Warn("unknown encryption key for rewrite; using current")
 				decryptKey = thisChannel.EncryptionKey
 			}
 


### PR DESCRIPTION
**Description:**

This should essentially never happen, since we track the key in the checkpoint.

**Workflow steps:**

No changes

**Documentation links affected:**

None

**Notes for reviewers:**

(anything that might help someone review this PR)

