### PR TITLE
materialize-snowflake: revert reencrypt files on recovery

### DIFF
--- a/materialize-snowflake/bdec.go
+++ b/materialize-snowflake/bdec.go
@@ -416,24 +416,22 @@ func getCipherStream(encryptionKey string, fileName blobFileName) (cipher.Stream
 	return cipher.NewCTR(block, make([]byte, aes.BlockSize)), nil
 }
 
-// reencrypt reads encrypted blob data from r, decrypts it using the
-// decryptKey and original file name, and then re-encrypts it using the
-// new file name and writes the output to w. The blob metadata is updated in
-// place.
+// reencrypt reads encrypted blob data from r, decrypts it using the encryption
+// key and original file name, and then re-encrypts it using the new file name
+// and writes the output to w. The blob metadata is updated in place.
 func reencrypt(
 	r io.Reader,
 	w io.Writer,
 	blob *blobMetadata,
-	decryptKey string,
-	channel *channel,
+	encryptionKey string,
 	newFileName blobFileName,
 ) error {
-	decryptStream, err := getCipherStream(decryptKey, blobFileName(blob.Path))
+	decryptStream, err := getCipherStream(encryptionKey, blobFileName(blob.Path))
 	if err != nil {
 		return fmt.Errorf("getting decryptStream: %w", err)
 	}
 
-	encryptStream, err := getCipherStream(channel.EncryptionKey, newFileName)
+	encryptStream, err := getCipherStream(encryptionKey, newFileName)
 	if err != nil {
 		return fmt.Errorf("getting encryptStream: %w", err)
 	}
@@ -481,6 +479,7 @@ func reencrypt(
 		if err != nil && !errors.Is(err, io.EOF) {
 			return fmt.Errorf("reading from r: %w", err)
 		}
+		fmt.Println(n, err)
 	}
 
 	downHash := hex.EncodeToString(downMd5.Sum(nil))
@@ -492,7 +491,6 @@ func reencrypt(
 	blob.Path = string(newFileName)
 	blob.MD5 = upHash
 	blob.Chunks[0].ChunkMD5 = upHash
-	blob.Chunks[0].EncryptionKeyID = channel.EncryptionKeyId
 
 	return nil
 }

--- a/materialize-snowflake/bdec.go
+++ b/materialize-snowflake/bdec.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"bytes"
 	"crypto/aes"
 	"crypto/cipher"
 	"crypto/md5"
@@ -440,14 +439,14 @@ func reencrypt(
 	upMd5 := md5.New()
 
 	buf := make([]byte, 64*1024)
+	for {
+		n, err := r.Read(buf)
+		if err != nil && !errors.Is(err, io.EOF) {
+			return fmt.Errorf("reading from r: %w", err)
+		} else if n == 0 {
+			break
+		}
 
-	firstRead := true
-	n, err := io.ReadAtLeast(r, buf, 4)
-	if err != nil {
-		return fmt.Errorf("reading from r: %w", err)
-	}
-
-	for n != 0 {
 		if m, err := downMd5.Write(buf[:n]); err != nil {
 			return fmt.Errorf("writing to downMd5: %w", err)
 		} else if m != n {
@@ -455,13 +454,6 @@ func reencrypt(
 		}
 
 		decryptStream.XORKeyStream(buf[:n], buf[:n])
-
-		// The stream must be a valid parquet file, if the magic is incorrect
-		// is is very likely we have the wrong decryption key.
-		if firstRead && !bytes.Equal(buf[:4], []byte("PAR1")) {
-			return fmt.Errorf("unexpected magic: %v", buf[:4])
-		}
-
 		encryptStream.XORKeyStream(buf[:n], buf[:n])
 
 		if m, err := upMd5.Write(buf[:n]); err != nil {
@@ -473,13 +465,6 @@ func reencrypt(
 		} else if written != n {
 			return fmt.Errorf("written bytes %d != expected bytes %d", written, n)
 		}
-
-		firstRead = false
-		n, err = r.Read(buf)
-		if err != nil && !errors.Is(err, io.EOF) {
-			return fmt.Errorf("reading from r: %w", err)
-		}
-		fmt.Println(n, err)
 	}
 
 	downHash := hex.EncodeToString(downMd5.Sum(nil))

--- a/materialize-snowflake/bdec_test.go
+++ b/materialize-snowflake/bdec_test.go
@@ -133,11 +133,6 @@ func TestReencrypt(t *testing.T) {
 	sum := md5.Sum(encrypted)
 	hsh := hex.EncodeToString(sum[:])
 
-	channel := &channel{
-		EncryptionKey:   encryptionKey,
-		EncryptionKeyId: 12345,
-	}
-
 	blob := &blobMetadata{
 		Path:   string(oldFileName),
 		MD5:    hsh,
@@ -147,7 +142,7 @@ func TestReencrypt(t *testing.T) {
 	var in = bytes.NewReader(encrypted)
 	var out bytes.Buffer
 
-	err = reencrypt(in, &out, blob, encryptionKey, channel, newFileName)
+	err = reencrypt(in, &out, blob, encryptionKey, newFileName)
 	require.NoError(t, err)
 
 	// The re-encrypted file matches the original input.

--- a/materialize-snowflake/bdec_test.go
+++ b/materialize-snowflake/bdec_test.go
@@ -115,8 +115,6 @@ func TestReencrypt(t *testing.T) {
 	input := make([]byte, 1024*1024+3)
 	_, err := rand.Read(input)
 	require.NoError(t, err)
-	copy(input, "PAR1")
-
 	encryptionKey := "aGVsbG8K"
 	oldFileName := blobFileName("old")
 	newFileName := blobFileName("new")
@@ -142,8 +140,7 @@ func TestReencrypt(t *testing.T) {
 	var in = bytes.NewReader(encrypted)
 	var out bytes.Buffer
 
-	err = reencrypt(in, &out, blob, encryptionKey, newFileName)
-	require.NoError(t, err)
+	require.NoError(t, reencrypt(in, &out, blob, encryptionKey, newFileName))
 
 	// The re-encrypted file matches the original input.
 	newKey, err := deriveKey(encryptionKey, newFileName)

--- a/materialize-snowflake/snowflake.go
+++ b/materialize-snowflake/snowflake.go
@@ -582,14 +582,13 @@ func (d *transactor) pipeExists(ctx context.Context, pipeName string) (bool, err
 }
 
 type checkpointItem struct {
-	Table         string
-	Query         string
-	StagedDir     string
-	StreamBlobs   []*blobMetadata
-	PipeName      string
-	PipeFiles     []fileRecord
-	Version       string
-	EncryptionKey string
+	Table       string
+	Query       string
+	StagedDir   string
+	StreamBlobs []*blobMetadata
+	PipeName    string
+	PipeFiles   []fileRecord
+	Version     string
 }
 
 type checkpoint = map[string]*checkpointItem
@@ -638,7 +637,6 @@ func (d *transactor) Store(it *m.StoreIterator) (m.StartCommitFunc, error) {
 
 func (d *transactor) buildDriverCheckpoint(ctx context.Context, runtimeCheckpoint *protocol.Checkpoint) (json.RawMessage, error) {
 	streamBlobs := make(map[int][]*blobMetadata)
-	keys := make(map[int]string)
 	if d.streamManager != nil {
 		// The "base token" only really needs to be sufficiently random that it
 		// doesn't collide with the prior or next transaction's value. Deriving
@@ -646,7 +644,7 @@ func (d *transactor) buildDriverCheckpoint(ctx context.Context, runtimeCheckpoin
 		// convenient to make testing outputs consistent.
 		if mcp, err := runtimeCheckpoint.Marshal(); err != nil {
 			return nil, fmt.Errorf("marshalling checkpoint: %w", err)
-		} else if streamBlobs, keys, err = d.streamManager.flush(fmt.Sprintf("%016x", xxhash.Sum64(mcp))); err != nil {
+		} else if streamBlobs, err = d.streamManager.flush(fmt.Sprintf("%016x", xxhash.Sum64(mcp))); err != nil {
 			return nil, fmt.Errorf("flushing stream manager: %w", err)
 		}
 	}
@@ -655,8 +653,7 @@ func (d *transactor) buildDriverCheckpoint(ctx context.Context, runtimeCheckpoin
 		if b.streaming {
 			if blobs, ok := streamBlobs[idx]; ok {
 				d.cp[b.target.StateKey] = &checkpointItem{
-					StreamBlobs:   blobs,
-					EncryptionKey: keys[idx],
+					StreamBlobs: blobs,
 				}
 			}
 			continue
@@ -885,7 +882,7 @@ func (d *transactor) Acknowledge(ctx context.Context) (*pf.ConnectorState, error
 		} else if len(item.StreamBlobs) > 0 {
 			group.Go(func() error {
 				d.be.StartedResourceCommit(path)
-				if err := d.streamManager.write(groupCtx, item.StreamBlobs, item.EncryptionKey, !d.didRecovery); err != nil {
+				if err := d.streamManager.write(groupCtx, item.StreamBlobs, !d.didRecovery); err != nil {
 					return fmt.Errorf("writing streaming blobs for %s: %w", path, err)
 				}
 				d.be.FinishedResourceCommit(path)

--- a/materialize-snowflake/snowflake.go
+++ b/materialize-snowflake/snowflake.go
@@ -232,10 +232,6 @@ type transactor struct {
 	// this shard's range spec and version, used to key pipes so they don't collide
 	_range  *pf.RangeSpec
 	version string
-
-	// If this is still the recovery (first after startup) commit, where special
-	// handling may be needed for registering streaming files.
-	didRecovery bool
 }
 
 func (d *transactor) RecoverCheckpoint(_ context.Context, _ pf.MaterializationSpec, _ pf.RangeSpec) (m.RuntimeCheckpoint, error) {
@@ -816,10 +812,6 @@ func (d *transactor) copyHistory(ctx context.Context, tableName string, fileName
 
 // Acknowledge merges data from temporary table to main table
 func (d *transactor) Acknowledge(ctx context.Context) (*pf.ConnectorState, error) {
-	defer func() {
-		d.didRecovery = true
-	}()
-
 	// Run store queries concurrently, as each independently operates on a separate table.
 	group, groupCtx := errgroup.WithContext(ctx)
 	group.SetLimit(MaxConcurrentQueries)
@@ -882,7 +874,7 @@ func (d *transactor) Acknowledge(ctx context.Context) (*pf.ConnectorState, error
 		} else if len(item.StreamBlobs) > 0 {
 			group.Go(func() error {
 				d.be.StartedResourceCommit(path)
-				if err := d.streamManager.write(groupCtx, item.StreamBlobs, !d.didRecovery); err != nil {
+				if err := d.streamManager.write(groupCtx, item.StreamBlobs); err != nil {
 					return fmt.Errorf("writing streaming blobs for %s: %w", path, err)
 				}
 				d.be.FinishedResourceCommit(path)

--- a/materialize-snowflake/stream.go
+++ b/materialize-snowflake/stream.go
@@ -208,7 +208,7 @@ func (sm *streamManager) flush(baseToken string) (map[int][]*blobMetadata, error
 // channel itself persists the last registered token, and this allows us to
 // filter out blobs that had previously been registered and don't need
 // registered again on a re-attempt of an Acknowledge.
-func (sm *streamManager) write(ctx context.Context, blobs []*blobMetadata, recovery bool) error {
+func (sm *streamManager) write(ctx context.Context, blobs []*blobMetadata) error {
 	if err := validWriteBlobs(blobs); err != nil {
 		return fmt.Errorf("validWriteBlobs: %w", err)
 	}
@@ -247,19 +247,7 @@ func (sm *streamManager) write(ctx context.Context, blobs []*blobMetadata, recov
 		blob.Chunks[0].Channels[0].ClientSequencer = thisChannel.ClientSequencer
 		blob.Chunks[0].Channels[0].RowSequencer = thisChannel.RowSequencer + 1
 
-		if recovery {
-			// Always use the rename and re-upload strategy during recovery
-			// commits. This prevents issues where blobs could be re-registered
-			// if the underlying channel has changed somehow, perhaps by being
-			// dropped out-of-band, or its last persisted token changed in some
-			// other way.
-			//
-			// This should be a relatively infrequent occurrence, so the
-			// performance impact + increased data transfer should be tolerable.
-			if err := sm.writeRenamed(ctx, thisChannel, blob); err != nil {
-				return fmt.Errorf("writeRenamed: %w", err)
-			}
-		} else if err := sm.c.write(ctx, blob); err != nil {
+		if err := sm.c.write(ctx, blob); err != nil {
 			var apiError *streamingApiError
 			if errors.As(err, &apiError) && apiError.Code == 38 {
 				// The "blob has wrong format or extension" error occurs if the
@@ -277,16 +265,27 @@ func (sm *streamManager) write(ctx context.Context, blobs []*blobMetadata, recov
 				// rather than exclusively managed by our Acknowledge
 				// checkpoints. But it is still technically possible and so it
 				// is handled with this.
-				log.WithFields(log.Fields{
-					"name":   blob.Path,
-					"token":  blobToken,
-					"schema": blob.Chunks[0].Schema,
-					"table":  blob.Chunks[0].Table,
-				}).Warn("blob rejected for malformed name; will attempt to register by renaming")
-
-				if err := sm.writeRenamed(ctx, thisChannel, blob); err != nil {
-					return fmt.Errorf("writeRenamed: %w", err)
+				if err := sm.maybeInitializeBucket(ctx); err != nil {
+					return fmt.Errorf("initializing bucket to rename: %w", err)
 				}
+				nextName := sm.getNextFileName(time.Now(), fmt.Sprintf("%s_%d", sm.prefix, sm.deploymentId))
+
+				ll := log.WithFields(log.Fields{
+					"oldName": blob.Path,
+					"newName": nextName,
+					"token":   blobToken,
+				})
+				ll.Info("attempting to register blob with malformed name by renaming")
+
+				if err := sm.renameBlob(ctx, blob, thisChannel.EncryptionKey, nextName); err != nil {
+					return fmt.Errorf("renameBlob: %w", err)
+				}
+
+				if err := sm.c.write(ctx, blob); err != nil {
+					log.WithField("blob", blob).Warn("blob metadata")
+					return fmt.Errorf("failed to write renamed blob: %w", err)
+				}
+				ll.Info("successfully registered renamed blob")
 			} else {
 				return fmt.Errorf("write: %w", err)
 			}
@@ -309,34 +308,6 @@ func (sm *streamManager) write(ctx context.Context, blobs []*blobMetadata, recov
 	); err != nil {
 		return fmt.Errorf("waitForTokenPersisted: %w", err)
 	}
-
-	return nil
-}
-
-func (sm *streamManager) writeRenamed(ctx context.Context, channel *channel, blob *blobMetadata) error {
-	if err := sm.maybeInitializeBucket(ctx); err != nil {
-		return fmt.Errorf("initializing bucket to rename: %w", err)
-	}
-	nextName := sm.getNextFileName(time.Now(), fmt.Sprintf("%s_%d", sm.prefix, sm.deploymentId))
-
-	ll := log.WithFields(log.Fields{
-		"oldName": blob.Path,
-		"newName": nextName,
-		"token":   blob.Chunks[0].Channels[0].OffsetToken,
-		"schema":  blob.Chunks[0].Schema,
-		"table":   blob.Chunks[0].Table,
-	})
-	ll.Info("attempting to register blob by renaming")
-
-	if err := sm.renameBlob(ctx, blob, channel.EncryptionKey, nextName); err != nil {
-		return fmt.Errorf("renameBlob: %w", err)
-	}
-
-	if err := sm.c.write(ctx, blob); err != nil {
-		ll.WithField("blob", blob).Warn("blob metadata")
-		return fmt.Errorf("failed to write renamed blob: %w", err)
-	}
-	ll.Info("successfully registered renamed blob")
 
 	return nil
 }

--- a/materialize-snowflake/stream.go
+++ b/materialize-snowflake/stream.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"path"
 	"strconv"
@@ -169,15 +170,14 @@ func (sm *streamManager) objMetadata() blob.WriterOption {
 	})
 }
 
-func (sm *streamManager) flush(baseToken string) (map[int][]*blobMetadata, map[int]string, error) {
+func (sm *streamManager) flush(baseToken string) (map[int][]*blobMetadata, error) {
 	if sm.bdecWriter != nil {
 		if err := sm.finishBlob(); err != nil {
-			return nil, nil, fmt.Errorf("finishBlob: %w", err)
+			return nil, fmt.Errorf("finishBlob: %w", err)
 		}
 	}
 
 	out := make(map[int][]*blobMetadata)
-	keys := make(map[int]string)
 	for binding, trackedBlobs := range sm.blobStats {
 		for idx, trackedBlob := range trackedBlobs {
 			out[binding] = append(out[binding], generateBlobMetadata(
@@ -185,12 +185,11 @@ func (sm *streamManager) flush(baseToken string) (map[int][]*blobMetadata, map[i
 				sm.tableStreams[binding].channel,
 				blobToken(baseToken, idx)),
 			)
-			keys[binding] = sm.tableStreams[binding].channel.EncryptionKey
 		}
 	}
 	maps.Clear(sm.blobStats)
 
-	return out, keys, nil
+	return out, nil
 }
 
 // write registers a series of blobs to the table. All the blobs must be for the
@@ -209,7 +208,7 @@ func (sm *streamManager) flush(baseToken string) (map[int][]*blobMetadata, map[i
 // channel itself persists the last registered token, and this allows us to
 // filter out blobs that had previously been registered and don't need
 // registered again on a re-attempt of an Acknowledge.
-func (sm *streamManager) write(ctx context.Context, blobs []*blobMetadata, decryptKey string, recovery bool) error {
+func (sm *streamManager) write(ctx context.Context, blobs []*blobMetadata, recovery bool) error {
 	if err := validWriteBlobs(blobs); err != nil {
 		return fmt.Errorf("validWriteBlobs: %w", err)
 	}
@@ -249,41 +248,48 @@ func (sm *streamManager) write(ctx context.Context, blobs []*blobMetadata, decry
 		blob.Chunks[0].Channels[0].RowSequencer = thisChannel.RowSequencer + 1
 
 		if recovery {
-			// Handle the case where decryptKey was not in the checkpoint because
-			// the checkpoint was created before it was added.  We will guess that
-			// its the same as the current key, if its not then the decrypted
-			// data will not have the parquet magic header.
-			//
-			// This check can be removed once all tasks have written a checkpoint.
-			if decryptKey == "" {
-				decryptKey = thisChannel.EncryptionKey
-			}
-
 			// Always use the rename and re-upload strategy during recovery
 			// commits. This prevents issues where blobs could be re-registered
 			// if the underlying channel has changed somehow, perhaps by being
 			// dropped out-of-band, or its last persisted token changed in some
 			// other way.
 			//
-			// It is also possible the channel encryption key has changed and
-			// the blob will need to be rewritten with the new encryption key.
-			//
-			// This also address the "blob has wrong format or extension" error
-			// which occurs if the blob was written not-so-recently; apparently
-			// anything older than an hour or so is rejected by what seems to
-			// be a server-side check the examines the name of the file, which
-			// contains the timestamp it was written.  In this case, which
-			// may arise from re-enabling a disabled binding / materialization,
-			// or extended outages, we have to download the file and re-upload
-			// it with an up-to-date name.
-			//
 			// This should be a relatively infrequent occurrence, so the
 			// performance impact + increased data transfer should be tolerable.
-			if err := sm.writeRenamed(ctx, decryptKey, thisChannel, blob); err != nil {
+			if err := sm.writeRenamed(ctx, thisChannel, blob); err != nil {
 				return fmt.Errorf("writeRenamed: %w", err)
 			}
 		} else if err := sm.c.write(ctx, blob); err != nil {
-			return fmt.Errorf("write: %w", err)
+			var apiError *streamingApiError
+			if errors.As(err, &apiError) && apiError.Code == 38 {
+				// The "blob has wrong format or extension" error occurs if the
+				// blob was written not-so-recently; apparently anything older
+				// than an hour or so is rejected by what seems to be a
+				// server-side check the examines the name of the file, which
+				// contains the timestamp it was written.
+				//
+				// In these cases, which may arise from re-enabling a disabled
+				// binding / materialization, or extended outages, we have to
+				// download the file and re-upload it with an up-to-date name.
+				//
+				// This should be quite rare, even more rare than one may think,
+				// since blob registration tokens are persisted in Snowflake
+				// rather than exclusively managed by our Acknowledge
+				// checkpoints. But it is still technically possible and so it
+				// is handled with this.
+				log.WithFields(log.Fields{
+					"name":   blob.Path,
+					"token":  blobToken,
+					"schema": blob.Chunks[0].Schema,
+					"table":  blob.Chunks[0].Table,
+				}).Warn("blob rejected for malformed name; will attempt to register by renaming")
+
+				if err := sm.writeRenamed(ctx, thisChannel, blob); err != nil {
+					return fmt.Errorf("writeRenamed: %w", err)
+				}
+			} else {
+				return fmt.Errorf("write: %w", err)
+			}
 		}
 
 		thisChannel.RowSequencer++
@@ -307,7 +313,7 @@ func (sm *streamManager) write(ctx context.Context, blobs []*blobMetadata, decry
 	return nil
 }
 
-func (sm *streamManager) writeRenamed(ctx context.Context, decryptKey string, channel *channel, blob *blobMetadata) error {
+func (sm *streamManager) writeRenamed(ctx context.Context, channel *channel, blob *blobMetadata) error {
 	if err := sm.maybeInitializeBucket(ctx); err != nil {
 		return fmt.Errorf("initializing bucket to rename: %w", err)
 	}
@@ -322,7 +328,7 @@ func (sm *streamManager) writeRenamed(ctx context.Context, decryptKey string, ch
 	})
 	ll.Info("attempting to register blob by renaming")
 
-	if err := sm.renameBlob(ctx, blob, decryptKey, channel, nextName); err != nil {
+	if err := sm.renameBlob(ctx, blob, channel.EncryptionKey, nextName); err != nil {
 		return fmt.Errorf("renameBlob: %w", err)
 	}
 
@@ -335,20 +341,14 @@ func (sm *streamManager) writeRenamed(ctx context.Context, decryptKey string, ch
 	return nil
 }
 
-func (sm *streamManager) renameBlob(
-	ctx context.Context,
-	blob *blobMetadata,
-	decryptKey string,
-	channel *channel,
-	newName blobFileName,
-) error {
+func (sm *streamManager) renameBlob(ctx context.Context, blob *blobMetadata, encryptionKey string, newName blobFileName) error {
 	r, err := sm.bucket.NewReader(ctx, path.Join(sm.bucketPath, blob.Path))
 	if err != nil {
 		return fmt.Errorf("NewReader: %w", err)
 	}
 	w := sm.bucket.NewWriter(ctx, path.Join(sm.bucketPath, string(newName)), sm.objMetadata())
 
-	if err := reencrypt(r, w, blob, decryptKey, channel, newName); err != nil {
+	if err := reencrypt(r, w, blob, encryptionKey, newName); err != nil {
 		return fmt.Errorf("reencrypt: %w", err)
 	} else if err := r.Close(); err != nil {
 		return fmt.Errorf("closing r: %w", err)

--- a/materialize-snowflake/stream.go
+++ b/materialize-snowflake/stream.go
@@ -256,10 +256,6 @@ func (sm *streamManager) write(ctx context.Context, blobs []*blobMetadata, decry
 			//
 			// This check can be removed once all tasks have written a checkpoint.
 			if decryptKey == "" {
-				log.WithFields(log.Fields{
-					"schema": schema,
-					"table":  table,
-				}).Warn("unknown encryption key for rewrite; using current")
 				decryptKey = thisChannel.EncryptionKey
 			}
 

--- a/materialize-snowflake/stream_test.go
+++ b/materialize-snowflake/stream_test.go
@@ -91,12 +91,12 @@ func TestStreamManager(t *testing.T) {
 		require.NoError(t, sm.writeRow(ctx, 0, []any{"key1", "hello1", "world1"}))
 		require.NoError(t, sm.writeRow(ctx, 0, []any{"key2", "hello2", "world2"}))
 		require.NoError(t, sm.writeRow(ctx, 0, []any{"key3", "hello3", "world3"}))
-		blobs, encKeys, err := sm.flush("the-token-1")
+		blobs, err := sm.flush("the-token-1")
 		require.NoError(t, err)
 		require.Equal(t, 1, len(blobs))
 		require.Equal(t, 1, len(blobs[0]))
 
-		require.NoError(t, sm.write(ctx, blobs[0], encKeys[0], false))
+		require.NoError(t, sm.write(ctx, blobs[0], false))
 
 		verify(t, "SELECT * FROM STREAM_TEST ORDER BY key", [][]any{
 			{"key1", "hello1", "world1"},
@@ -105,7 +105,7 @@ func TestStreamManager(t *testing.T) {
 		})
 
 		// Write the same token again, it is not added to the table.
-		require.NoError(t, sm.write(ctx, blobs[0], encKeys[0], false))
+		require.NoError(t, sm.write(ctx, blobs[0], false))
 
 		verify(t, "SELECT * FROM STREAM_TEST ORDER BY key", [][]any{
 			{"key1", "hello1", "world1"},
@@ -121,13 +121,13 @@ func TestStreamManager(t *testing.T) {
 		require.NoError(t, sm.writeRow(ctx, 0, []any{"key4", "hello4", "world4"}))
 		require.NoError(t, sm.writeRow(ctx, 0, []any{"key5", "hello5", "world5"}))
 		require.NoError(t, sm.writeRow(ctx, 0, []any{"key6", "hello6", "world6"}))
-		blobs, encKeys, err = sm.flush("the-token-2")
+		blobs, err = sm.flush("the-token-2")
 		require.NoError(t, err)
 		require.Equal(t, 1, len(blobs))
 		require.Equal(t, 1, len(blobs[0]))
 
 		// The original invocation will error and not write any data.
-		require.Error(t, sm.write(ctx, blobs[0], encKeys[0], false))
+		require.Error(t, sm.write(ctx, blobs[0], false))
 		verify(t, "SELECT * FROM STREAM_TEST ORDER BY key", [][]any{
 			{"key1", "hello1", "world1"},
 			{"key2", "hello2", "world2"},
@@ -138,12 +138,12 @@ func TestStreamManager(t *testing.T) {
 		require.NoError(t, sm.writeRow(ctx, 0, []any{"key4", "hello4", "world4"}))
 		require.NoError(t, sm.writeRow(ctx, 0, []any{"key5", "hello5", "world5"}))
 		require.NoError(t, sm.writeRow(ctx, 0, []any{"key6", "hello6", "world6"}))
-		blobs, encKeys, err = sm.flush("the-token-2")
+		blobs, err = sm.flush("the-token-2")
 		require.NoError(t, err)
 		require.Equal(t, 1, len(blobs))
 		require.Equal(t, 1, len(blobs[0]))
 
-		require.NoError(t, ssm.write(ctx, blobs[0], encKeys[0], false))
+		require.NoError(t, ssm.write(ctx, blobs[0], false))
 
 		verify(t, "SELECT * FROM STREAM_TEST ORDER BY key", [][]any{
 			{"key1", "hello1", "world1"},
@@ -184,13 +184,13 @@ func TestStreamManager(t *testing.T) {
 		require.NoError(t, sm.writeRow(ctx, 0, []any{"key1", "hello1", "world1"}))
 		require.NoError(t, sm.writeRow(ctx, 0, []any{"key2", "hello2", "world2"}))
 		require.NoError(t, sm.writeRow(ctx, 0, []any{"key3", "hello3", "world3"}))
-		blobs, encKeys, err := sm.flush("the-token-1")
+		blobs, err := sm.flush("the-token-1")
 		require.NoError(t, err)
 		require.Equal(t, 1, len(blobs))
 		require.Equal(t, 1, len(blobs[0]))
 
 		// Write blob normally.
-		require.NoError(t, sm.write(ctx, blobs[0], encKeys[0], false))
+		require.NoError(t, sm.write(ctx, blobs[0], false))
 
 		verify(t, "SELECT * FROM STREAM_TEST ORDER BY key", [][]any{
 			{"key1", "hello1", "world1"},
@@ -205,7 +205,7 @@ func TestStreamManager(t *testing.T) {
 		// cause a Snowflake error / table corruption), this will re-name the
 		// blob and register it with the exact same data.
 		blobs[0][0].Chunks[0].Channels[0].OffsetToken = "a-new-token:0"
-		require.NoError(t, sm.write(ctx, blobs[0], encKeys[0], true))
+		require.NoError(t, sm.write(ctx, blobs[0], true))
 
 		verify(t, "SELECT * FROM STREAM_TEST ORDER BY key", [][]any{
 			{"key1", "hello1", "world1"},
@@ -250,12 +250,12 @@ func TestStreamManager(t *testing.T) {
 		require.NoError(t, sm.writeRow(ctx, 0, []any{"key4", "hello4", "world4"}))
 		require.NoError(t, sm.writeRow(ctx, 0, []any{"key5", "hello5", "world5"}))
 		require.NoError(t, sm.writeRow(ctx, 0, []any{"key6", "hello6", "world6"}))
-		blobs, encKeys, err := sm.flush("the-token-1")
+		blobs, err := sm.flush("the-token-1")
 		require.NoError(t, err)
 		require.Equal(t, 1, len(blobs))
 		require.Equal(t, 2, len(blobs[0]))
 
-		require.NoError(t, sm.write(ctx, blobs[0], encKeys[0], false))
+		require.NoError(t, sm.write(ctx, blobs[0], false))
 
 		verify(t, "SELECT * FROM STREAM_TEST ORDER BY key", [][]any{
 			{"key1", "hello1", "world1"},
@@ -319,11 +319,11 @@ func TestStreamManager(t *testing.T) {
 		require.NoError(t, sm.writeRow(ctx, 0, []any{"key1", "hello1", "world1"}))
 		require.NoError(t, sm.writeRow(ctx, 0, []any{"key2", "hello2", "world2"}))
 		require.NoError(t, sm.writeRow(ctx, 0, []any{"key3", "hello3", "world3"}))
-		blobs, encKeys, err := sm.flush("the-token-1")
+		blobs, err := sm.flush("the-token-1")
 		require.NoError(t, err)
 		require.Equal(t, 1, len(blobs))
 		require.Equal(t, 1, len(blobs[0]))
-		require.NoError(t, sm.write(ctx, blobs[0], encKeys[0], false))
+		require.NoError(t, sm.write(ctx, blobs[0], false))
 
 		require.NoError(t, sm.writeRow(ctx, 0, []any{"key4", "hello4", "world4"}))
 		require.NoError(t, sm.writeRow(ctx, 0, []any{"key5", "hello5", "world5"}))
@@ -334,16 +334,16 @@ func TestStreamManager(t *testing.T) {
 		require.NoError(t, sm.writeRow(ctx, 2, []any{"key4", "hello4", "world4"}))
 		require.NoError(t, sm.writeRow(ctx, 2, []any{"key5", "hello5", "world5"}))
 		require.NoError(t, sm.writeRow(ctx, 2, []any{"key6", "hello6", "world6"}))
-		blobs, encKeys, err = sm.flush("the-token-2")
+		blobs, err = sm.flush("the-token-2")
 		require.NoError(t, err)
 		require.Equal(t, 3, len(blobs))
-		for idx, blob := range blobs {
+		for _, blob := range blobs {
 			require.Equal(t, 1, len(blob))
-			require.NoError(t, sm.write(ctx, blob, encKeys[idx], false))
+			require.NoError(t, sm.write(ctx, blob, false))
 		}
 
 		// Noop commit.
-		blobs, encKeys, err = sm.flush("the-token-3")
+		blobs, err = sm.flush("the-token-3")
 		require.NoError(t, err)
 		require.Equal(t, 0, len(blobs))
 
@@ -353,12 +353,12 @@ func TestStreamManager(t *testing.T) {
 		require.NoError(t, sm.writeRow(ctx, 2, []any{"key7", "hello7", "world7"}))
 		require.NoError(t, sm.writeRow(ctx, 2, []any{"key8", "hello8", "world8"}))
 		require.NoError(t, sm.writeRow(ctx, 2, []any{"key9", "hello9", "world9"}))
-		blobs, encKeys, err = sm.flush("the-token-3")
+		blobs, err = sm.flush("the-token-3")
 		require.NoError(t, err)
 		require.Equal(t, 2, len(blobs))
-		for idx, blob := range blobs {
+		for _, blob := range blobs {
 			require.Equal(t, 1, len(blob))
-			require.NoError(t, sm.write(ctx, blob, encKeys[idx], false))
+			require.NoError(t, sm.write(ctx, blob, false))
 		}
 
 		verify(t, "SELECT * FROM "+tables[0].Identifier+" ORDER BY key", [][]any{
@@ -435,11 +435,11 @@ func TestStreamManager(t *testing.T) {
 		require.NoError(t, sm.writeRow(ctx, 0, []any{"key1", "hello1", "goodbye1", "aloha1"}))
 		require.NoError(t, sm.writeRow(ctx, 0, []any{"key2", "hello2", "goodbye2", "aloha2"}))
 		require.NoError(t, sm.writeRow(ctx, 0, []any{"key3", "hello3", "goodbye3", "aloha3"}))
-		blobs, encKeys, err := sm.flush("token")
+		blobs, err := sm.flush("token")
 		require.NoError(t, err)
 		require.Equal(t, 1, len(blobs))
 		require.Equal(t, 1, len(blobs[0]))
-		require.NoError(t, sm.write(ctx, blobs[0], encKeys[0], false))
+		require.NoError(t, sm.write(ctx, blobs[0], false))
 
 		verify(t, "SELECT * FROM "+tbl.Identifier+" ORDER BY key", [][]any{
 			{nil, "key1", "hello1", nil, "goodbye1", "aloha1", nil},
@@ -482,12 +482,12 @@ func TestStreamManager(t *testing.T) {
 		require.NoError(t, err)
 		require.NoError(t, sm.addBinding(ctx, cfg.Schema, table.Identifier, table))
 		require.NoError(t, sm.writeRow(ctx, 0, []any{"key1", json.RawMessage(data)}))
-		blobs, encKeys, err := sm.flush("the-token-1")
+		blobs, err := sm.flush("the-token-1")
 		require.NoError(t, err)
 		require.Equal(t, 1, len(blobs))
 		require.Equal(t, 1, len(blobs[0]))
 
-		require.NoError(t, sm.write(ctx, blobs[0], encKeys[0], false))
+		require.NoError(t, sm.write(ctx, blobs[0], false))
 
 		var gotData string
 		require.NoError(t, db.QueryRowContext(ctx, "SELECT firstcol FROM STREAM_TEST").Scan(&gotData))
@@ -603,11 +603,11 @@ func TestStreamDatatypes(t *testing.T) {
 				require.NoError(t, sm.writeRow(ctx, 0, []any{i, val}))
 			}
 
-			blobs, encKeys, err := sm.flush("token")
+			blobs, err := sm.flush("token")
 			require.NoError(t, err)
 			require.Equal(t, 1, len(blobs))
 			require.Equal(t, 1, len(blobs[0]))
-			require.NoError(t, sm.write(ctx, blobs[0], encKeys[0], false))
+			require.NoError(t, sm.write(ctx, blobs[0], false))
 
 			var snap strings.Builder
 			eps, err := json.Marshal(blobs[0][0].Chunks[0].EPS)

--- a/materialize-snowflake/stream_test.go
+++ b/materialize-snowflake/stream_test.go
@@ -96,7 +96,7 @@ func TestStreamManager(t *testing.T) {
 		require.Equal(t, 1, len(blobs))
 		require.Equal(t, 1, len(blobs[0]))
 
-		require.NoError(t, sm.write(ctx, blobs[0], false))
+		require.NoError(t, sm.write(ctx, blobs[0]))
 
 		verify(t, "SELECT * FROM STREAM_TEST ORDER BY key", [][]any{
 			{"key1", "hello1", "world1"},
@@ -105,7 +105,7 @@ func TestStreamManager(t *testing.T) {
 		})
 
 		// Write the same token again, it is not added to the table.
-		require.NoError(t, sm.write(ctx, blobs[0], false))
+		require.NoError(t, sm.write(ctx, blobs[0]))
 
 		verify(t, "SELECT * FROM STREAM_TEST ORDER BY key", [][]any{
 			{"key1", "hello1", "world1"},
@@ -127,7 +127,7 @@ func TestStreamManager(t *testing.T) {
 		require.Equal(t, 1, len(blobs[0]))
 
 		// The original invocation will error and not write any data.
-		require.Error(t, sm.write(ctx, blobs[0], false))
+		require.Error(t, sm.write(ctx, blobs[0]))
 		verify(t, "SELECT * FROM STREAM_TEST ORDER BY key", [][]any{
 			{"key1", "hello1", "world1"},
 			{"key2", "hello2", "world2"},
@@ -143,7 +143,7 @@ func TestStreamManager(t *testing.T) {
 		require.Equal(t, 1, len(blobs))
 		require.Equal(t, 1, len(blobs[0]))
 
-		require.NoError(t, ssm.write(ctx, blobs[0], false))
+		require.NoError(t, ssm.write(ctx, blobs[0]))
 
 		verify(t, "SELECT * FROM STREAM_TEST ORDER BY key", [][]any{
 			{"key1", "hello1", "world1"},
@@ -152,68 +152,6 @@ func TestStreamManager(t *testing.T) {
 			{"key4", "hello4", "world4"},
 			{"key5", "hello5", "world5"},
 			{"key6", "hello6", "world6"},
-		})
-	})
-
-	t.Run("upload with rename", func(t *testing.T) {
-		table := sql.Table{
-			TableShape: sql.TableShape{
-				Binding: 0,
-			},
-			Identifier: `STREAM_TEST`,
-			Keys:       []sql.Column{{Identifier: `key`}},
-			Values:     []sql.Column{{Identifier: `firstcol`}, {Identifier: `secondcol`}},
-			Document:   nil,
-		}
-
-		cleanup := func(t *testing.T) {
-			t.Helper()
-			_, err = db.ExecContext(ctx, "DROP TABLE IF EXISTS STREAM_TEST;")
-		}
-		defer cleanup(t)
-
-		cleanup(t)
-		_, err = db.ExecContext(ctx, `CREATE TABLE STREAM_TEST (key TEXT, firstcol TEXT, secondcol TEXT);`)
-		require.NoError(t, err)
-
-		sm, err := newStreamManager(&cfg, "testing", accountName, 0)
-		require.NoError(t, err)
-
-		require.NoError(t, sm.addBinding(ctx, cfg.Schema, table.Identifier, table))
-
-		require.NoError(t, sm.writeRow(ctx, 0, []any{"key1", "hello1", "world1"}))
-		require.NoError(t, sm.writeRow(ctx, 0, []any{"key2", "hello2", "world2"}))
-		require.NoError(t, sm.writeRow(ctx, 0, []any{"key3", "hello3", "world3"}))
-		blobs, err := sm.flush("the-token-1")
-		require.NoError(t, err)
-		require.Equal(t, 1, len(blobs))
-		require.Equal(t, 1, len(blobs[0]))
-
-		// Write blob normally.
-		require.NoError(t, sm.write(ctx, blobs[0], false))
-
-		verify(t, "SELECT * FROM STREAM_TEST ORDER BY key", [][]any{
-			{"key1", "hello1", "world1"},
-			{"key2", "hello2", "world2"},
-			{"key3", "hello3", "world3"},
-		})
-
-		// Attempt to register the same blob again, with the persisted channel
-		// token having been changed. This is simulated not by actually changing
-		// the channel token, but swapping out our desired offset token. Rather
-		// than registering the blob with the exact same file name (which will
-		// cause a Snowflake error / table corruption), this will re-name the
-		// blob and register it with the exact same data.
-		blobs[0][0].Chunks[0].Channels[0].OffsetToken = "a-new-token:0"
-		require.NoError(t, sm.write(ctx, blobs[0], true))
-
-		verify(t, "SELECT * FROM STREAM_TEST ORDER BY key", [][]any{
-			{"key1", "hello1", "world1"},
-			{"key1", "hello1", "world1"},
-			{"key2", "hello2", "world2"},
-			{"key2", "hello2", "world2"},
-			{"key3", "hello3", "world3"},
-			{"key3", "hello3", "world3"},
 		})
 	})
 
@@ -255,7 +193,7 @@ func TestStreamManager(t *testing.T) {
 		require.Equal(t, 1, len(blobs))
 		require.Equal(t, 2, len(blobs[0]))
 
-		require.NoError(t, sm.write(ctx, blobs[0], false))
+		require.NoError(t, sm.write(ctx, blobs[0]))
 
 		verify(t, "SELECT * FROM STREAM_TEST ORDER BY key", [][]any{
 			{"key1", "hello1", "world1"},
@@ -323,7 +261,7 @@ func TestStreamManager(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, 1, len(blobs))
 		require.Equal(t, 1, len(blobs[0]))
-		require.NoError(t, sm.write(ctx, blobs[0], false))
+		require.NoError(t, sm.write(ctx, blobs[0]))
 
 		require.NoError(t, sm.writeRow(ctx, 0, []any{"key4", "hello4", "world4"}))
 		require.NoError(t, sm.writeRow(ctx, 0, []any{"key5", "hello5", "world5"}))
@@ -339,7 +277,7 @@ func TestStreamManager(t *testing.T) {
 		require.Equal(t, 3, len(blobs))
 		for _, blob := range blobs {
 			require.Equal(t, 1, len(blob))
-			require.NoError(t, sm.write(ctx, blob, false))
+			require.NoError(t, sm.write(ctx, blob))
 		}
 
 		// Noop commit.
@@ -358,7 +296,7 @@ func TestStreamManager(t *testing.T) {
 		require.Equal(t, 2, len(blobs))
 		for _, blob := range blobs {
 			require.Equal(t, 1, len(blob))
-			require.NoError(t, sm.write(ctx, blob, false))
+			require.NoError(t, sm.write(ctx, blob))
 		}
 
 		verify(t, "SELECT * FROM "+tables[0].Identifier+" ORDER BY key", [][]any{
@@ -439,7 +377,7 @@ func TestStreamManager(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, 1, len(blobs))
 		require.Equal(t, 1, len(blobs[0]))
-		require.NoError(t, sm.write(ctx, blobs[0], false))
+		require.NoError(t, sm.write(ctx, blobs[0]))
 
 		verify(t, "SELECT * FROM "+tbl.Identifier+" ORDER BY key", [][]any{
 			{nil, "key1", "hello1", nil, "goodbye1", "aloha1", nil},
@@ -487,7 +425,7 @@ func TestStreamManager(t *testing.T) {
 		require.Equal(t, 1, len(blobs))
 		require.Equal(t, 1, len(blobs[0]))
 
-		require.NoError(t, sm.write(ctx, blobs[0], false))
+		require.NoError(t, sm.write(ctx, blobs[0]))
 
 		var gotData string
 		require.NoError(t, db.QueryRowContext(ctx, "SELECT firstcol FROM STREAM_TEST").Scan(&gotData))
@@ -607,7 +545,7 @@ func TestStreamDatatypes(t *testing.T) {
 			require.NoError(t, err)
 			require.Equal(t, 1, len(blobs))
 			require.Equal(t, 1, len(blobs[0]))
-			require.NoError(t, sm.write(ctx, blobs[0], false))
+			require.NoError(t, sm.write(ctx, blobs[0]))
 
 			var snap strings.Builder
 			eps, err := json.Marshal(blobs[0][0].Chunks[0].EPS)

--- a/tests/materialize/materialize-snowflake/checks.sh
+++ b/tests/materialize/materialize-snowflake/checks.sh
@@ -6,7 +6,6 @@ fi
 $SED_CMD -i'' 's/@flow_v1\/.\{36\}/<uuid>/g' ${SNAPSHOT}
 $SED_CMD -i'' 's/"Path": ".*"/"Path": "<uuid>"/g' ${SNAPSHOT}
 $SED_CMD -i'' 's/"PipeStartTime": ".\{1,\}"/"PipeStartTime": "<timestamp>"/g' ${SNAPSHOT}
-$SED_CMD -i'' 's/"EncryptionKey": ".*"/"EncryptionKey": "<encryption_key>"/g' ${SNAPSHOT}
 $SED_CMD -i'' 's/"path": ".*"/"path": "<path>"/g' ${SNAPSHOT}
 $SED_CMD -i'' 's/"md5": ".*"/"md5": "<md5>"/g' ${SNAPSHOT}
 $SED_CMD -i'' 's/"chunk_length": [0-9]\+/"chunk_length": "<chunk_length>"/g' ${SNAPSHOT}

--- a/tests/materialize/materialize-snowflake/snapshot.json
+++ b/tests/materialize/materialize-snowflake/snapshot.json
@@ -20,8 +20,7 @@
         "StreamBlobs": null,
         "PipeName": "",
         "PipeFiles": null,
-        "Version": "",
-        "EncryptionKey": "<encryption_key>"
+        "Version": ""
       },
       "all_key_types_part_three": {
         "Table": "all_key_types_part_three",
@@ -30,8 +29,7 @@
         "StreamBlobs": null,
         "PipeName": "",
         "PipeFiles": null,
-        "Version": "",
-        "EncryptionKey": "<encryption_key>"
+        "Version": ""
       },
       "all_key_types_part_two": {
         "Table": "all_key_types_part_two",
@@ -40,8 +38,7 @@
         "StreamBlobs": null,
         "PipeName": "",
         "PipeFiles": null,
-        "Version": "",
-        "EncryptionKey": "<encryption_key>"
+        "Version": ""
       },
       "deletions": {
         "Table": "deletions",
@@ -50,8 +47,7 @@
         "StreamBlobs": null,
         "PipeName": "",
         "PipeFiles": null,
-        "Version": "",
-        "EncryptionKey": "<encryption_key>"
+        "Version": ""
       },
       "duplicate%20keys%20%40%20with%20spaces": {
         "Table": "",
@@ -158,8 +154,7 @@
         ],
         "PipeName": "",
         "PipeFiles": null,
-        "Version": "",
-        "EncryptionKey": "<encryption_key>"
+        "Version": ""
       },
       "duplicate_keys_delta": {
         "Table": "",
@@ -266,8 +261,7 @@
         ],
         "PipeName": "",
         "PipeFiles": null,
-        "Version": "",
-        "EncryptionKey": "<encryption_key>"
+        "Version": ""
       },
       "duplicate_keys_delta_exclude_flow_doc": {
         "Table": "",
@@ -374,8 +368,7 @@
         ],
         "PipeName": "",
         "PipeFiles": null,
-        "Version": "",
-        "EncryptionKey": "<encryption_key>"
+        "Version": ""
       },
       "duplicate_keys_standard": {
         "Table": "duplicate_keys_standard",
@@ -384,8 +377,7 @@
         "StreamBlobs": null,
         "PipeName": "",
         "PipeFiles": null,
-        "Version": "",
-        "EncryptionKey": "<encryption_key>"
+        "Version": ""
       },
       "fields_with_projections": {
         "Table": "fields_with_projections",
@@ -394,8 +386,7 @@
         "StreamBlobs": null,
         "PipeName": "",
         "PipeFiles": null,
-        "Version": "",
-        "EncryptionKey": "<encryption_key>"
+        "Version": ""
       },
       "formatted_strings": {
         "Table": "formatted_strings",
@@ -404,8 +395,7 @@
         "StreamBlobs": null,
         "PipeName": "",
         "PipeFiles": null,
-        "Version": "",
-        "EncryptionKey": "<encryption_key>"
+        "Version": ""
       },
       "many_columns": {
         "Table": "many_columns",
@@ -414,8 +404,7 @@
         "StreamBlobs": null,
         "PipeName": "",
         "PipeFiles": null,
-        "Version": "",
-        "EncryptionKey": "<encryption_key>"
+        "Version": ""
       },
       "multiple_types": {
         "Table": "multiple_types",
@@ -424,8 +413,7 @@
         "StreamBlobs": null,
         "PipeName": "",
         "PipeFiles": null,
-        "Version": "",
-        "EncryptionKey": "<encryption_key>"
+        "Version": ""
       },
       "optional_non_nullable": {
         "Table": "optional_non_nullable",
@@ -434,8 +422,7 @@
         "StreamBlobs": null,
         "PipeName": "",
         "PipeFiles": null,
-        "Version": "",
-        "EncryptionKey": "<encryption_key>"
+        "Version": ""
       },
       "simple": {
         "Table": "simple",
@@ -444,8 +431,7 @@
         "StreamBlobs": null,
         "PipeName": "",
         "PipeFiles": null,
-        "Version": "",
-        "EncryptionKey": "<encryption_key>"
+        "Version": ""
       },
       "string_escaped_key": {
         "Table": "string_escaped_key",
@@ -454,8 +440,7 @@
         "StreamBlobs": null,
         "PipeName": "",
         "PipeFiles": null,
-        "Version": "",
-        "EncryptionKey": "<encryption_key>"
+        "Version": ""
       },
       "symbols": {
         "Table": "symbols",
@@ -464,8 +449,7 @@
         "StreamBlobs": null,
         "PipeName": "",
         "PipeFiles": null,
-        "Version": "",
-        "EncryptionKey": "<encryption_key>"
+        "Version": ""
       },
       "timezone_datetimes_delta": {
         "Table": "",
@@ -572,8 +556,7 @@
         ],
         "PipeName": "",
         "PipeFiles": null,
-        "Version": "",
-        "EncryptionKey": "<encryption_key>"
+        "Version": ""
       },
       "timezone_datetimes_standard": {
         "Table": "timezone_datetimes_standard",
@@ -582,8 +565,7 @@
         "StreamBlobs": null,
         "PipeName": "",
         "PipeFiles": null,
-        "Version": "",
-        "EncryptionKey": "<encryption_key>"
+        "Version": ""
       },
       "unsigned_bigint": {
         "Table": "unsigned_bigint",
@@ -592,8 +574,7 @@
         "StreamBlobs": null,
         "PipeName": "",
         "PipeFiles": null,
-        "Version": "",
-        "EncryptionKey": "<encryption_key>"
+        "Version": ""
       }
     },
     "mergePatch": true
@@ -610,8 +591,7 @@
         "StreamBlobs": null,
         "PipeName": "",
         "PipeFiles": null,
-        "Version": "ffffffffffffffff",
-        "EncryptionKey": "<encryption_key>"
+        "Version": "ffffffffffffffff"
       },
       "all_key_types_part_three": {
         "Table": "all_key_types_part_three",
@@ -620,8 +600,7 @@
         "StreamBlobs": null,
         "PipeName": "",
         "PipeFiles": null,
-        "Version": "ffffffffffffffff",
-        "EncryptionKey": "<encryption_key>"
+        "Version": "ffffffffffffffff"
       },
       "all_key_types_part_two": {
         "Table": "all_key_types_part_two",
@@ -630,8 +609,7 @@
         "StreamBlobs": null,
         "PipeName": "",
         "PipeFiles": null,
-        "Version": "ffffffffffffffff",
-        "EncryptionKey": "<encryption_key>"
+        "Version": "ffffffffffffffff"
       },
       "deletions": {
         "Table": "deletions",
@@ -640,8 +618,7 @@
         "StreamBlobs": null,
         "PipeName": "",
         "PipeFiles": null,
-        "Version": "ffffffffffffffff",
-        "EncryptionKey": "<encryption_key>"
+        "Version": "ffffffffffffffff"
       },
       "duplicate%20keys%20%40%20with%20spaces": {
         "Table": "",
@@ -748,8 +725,7 @@
         ],
         "PipeName": "",
         "PipeFiles": null,
-        "Version": "",
-        "EncryptionKey": "<encryption_key>"
+        "Version": ""
       },
       "duplicate_keys_delta": {
         "Table": "",
@@ -856,8 +832,7 @@
         ],
         "PipeName": "",
         "PipeFiles": null,
-        "Version": "",
-        "EncryptionKey": "<encryption_key>"
+        "Version": ""
       },
       "duplicate_keys_delta_exclude_flow_doc": {
         "Table": "",
@@ -964,8 +939,7 @@
         ],
         "PipeName": "",
         "PipeFiles": null,
-        "Version": "",
-        "EncryptionKey": "<encryption_key>"
+        "Version": ""
       },
       "duplicate_keys_standard": {
         "Table": "duplicate_keys_standard",
@@ -974,8 +948,7 @@
         "StreamBlobs": null,
         "PipeName": "",
         "PipeFiles": null,
-        "Version": "ffffffffffffffff",
-        "EncryptionKey": "<encryption_key>"
+        "Version": "ffffffffffffffff"
       },
       "fields_with_projections": {
         "Table": "fields_with_projections",
@@ -984,8 +957,7 @@
         "StreamBlobs": null,
         "PipeName": "",
         "PipeFiles": null,
-        "Version": "ffffffffffffffff",
-        "EncryptionKey": "<encryption_key>"
+        "Version": "ffffffffffffffff"
       },
       "formatted_strings": {
         "Table": "formatted_strings",
@@ -994,8 +966,7 @@
         "StreamBlobs": null,
         "PipeName": "",
         "PipeFiles": null,
-        "Version": "",
-        "EncryptionKey": "<encryption_key>"
+        "Version": ""
       },
       "many_columns": {
         "Table": "many_columns",
@@ -1004,8 +975,7 @@
         "StreamBlobs": null,
         "PipeName": "",
         "PipeFiles": null,
-        "Version": "ffffffffffffffff",
-        "EncryptionKey": "<encryption_key>"
+        "Version": "ffffffffffffffff"
       },
       "multiple_types": {
         "Table": "multiple_types",
@@ -1014,8 +984,7 @@
         "StreamBlobs": null,
         "PipeName": "",
         "PipeFiles": null,
-        "Version": "ffffffffffffffff",
-        "EncryptionKey": "<encryption_key>"
+        "Version": "ffffffffffffffff"
       },
       "optional_non_nullable": {
         "Table": "optional_non_nullable",
@@ -1024,8 +993,7 @@
         "StreamBlobs": null,
         "PipeName": "",
         "PipeFiles": null,
-        "Version": "ffffffffffffffff",
-        "EncryptionKey": "<encryption_key>"
+        "Version": "ffffffffffffffff"
       },
       "simple": {
         "Table": "simple",
@@ -1034,8 +1002,7 @@
         "StreamBlobs": null,
         "PipeName": "",
         "PipeFiles": null,
-        "Version": "",
-        "EncryptionKey": "<encryption_key>"
+        "Version": ""
       },
       "string_escaped_key": {
         "Table": "string_escaped_key",
@@ -1044,8 +1011,7 @@
         "StreamBlobs": null,
         "PipeName": "",
         "PipeFiles": null,
-        "Version": "ffffffffffffffff",
-        "EncryptionKey": "<encryption_key>"
+        "Version": "ffffffffffffffff"
       }
     },
     "mergePatch": true
@@ -1160,8 +1126,7 @@
         ],
         "PipeName": "",
         "PipeFiles": null,
-        "Version": "",
-        "EncryptionKey": "<encryption_key>"
+        "Version": ""
       },
       "duplicate_keys_delta": {
         "Table": "",
@@ -1268,8 +1233,7 @@
         ],
         "PipeName": "",
         "PipeFiles": null,
-        "Version": "",
-        "EncryptionKey": "<encryption_key>"
+        "Version": ""
       },
       "duplicate_keys_delta_exclude_flow_doc": {
         "Table": "",
@@ -1376,8 +1340,7 @@
         ],
         "PipeName": "",
         "PipeFiles": null,
-        "Version": "",
-        "EncryptionKey": "<encryption_key>"
+        "Version": ""
       },
       "duplicate_keys_standard": {
         "Table": "duplicate_keys_standard",
@@ -1386,8 +1349,7 @@
         "StreamBlobs": null,
         "PipeName": "",
         "PipeFiles": null,
-        "Version": "",
-        "EncryptionKey": "<encryption_key>"
+        "Version": ""
       }
     },
     "mergePatch": true
@@ -1398,7 +1360,6 @@
   {
     "updated": {
       "duplicate%20keys%20%40%20with%20spaces": {
-        "EncryptionKey": "<encryption_key>",
         "PipeName": "",
         "Query": "",
         "StagedDir": "",
@@ -1505,7 +1466,6 @@
         "Version": ""
       },
       "duplicate_keys_delta": {
-        "EncryptionKey": "<encryption_key>",
         "PipeName": "",
         "Query": "",
         "StagedDir": "",
@@ -1612,7 +1572,6 @@
         "Version": ""
       },
       "duplicate_keys_delta_exclude_flow_doc": {
-        "EncryptionKey": "<encryption_key>",
         "PipeName": "",
         "Query": "",
         "StagedDir": "",
@@ -1719,7 +1678,6 @@
         "Version": ""
       },
       "duplicate_keys_standard": {
-        "EncryptionKey": "<encryption_key>",
         "PipeName": "",
         "Query": "\nCOPY INTO duplicate_keys_standard (\n\tid, flow_published_at, int, str\n) FROM (\n\tSELECT $1[0] AS id, $1[1] AS flow_published_at, $1[2] AS int, $1[3] AS str\n\tFROM <uuid>\n);\n",
         "StagedDir": "<uuid>",


### PR DESCRIPTION
**Description:**

If the first time the connector uses the new checkpoint is during recovery, the key will not be set.  In this case we guessed that the channel key is the same but if this is incorrect then we can't rename the blob.  This situation came up much faster than expected, so we think it may be more common than expected.

**Workflow steps:**

No changes

**Documentation links affected:**

None.

**Notes for reviewers:**

(anything that might help someone review this PR)

