### PR TITLE
source-*: check `rows.Err()` after all `rows.Next()` loops

### DIFF
--- a/source-oracle-batch/discovery.go
+++ b/source-oracle-batch/discovery.go
@@ -239,6 +239,9 @@ func discoverTables(ctx context.Context, db *sql.DB, discoverSchemas []string) (
 			Name:  tableName,
 		})
 	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("error iterating discovered tables: %w", err)
+	}
 	return tables, nil
 }
 
@@ -336,6 +339,9 @@ func discoverColumns(ctx context.Context, db *sql.DB, discoverSchemas []string) 
 			DataType: dataType,
 		}
 		columns = append(columns, column)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("error iterating discovered columns: %w", err)
 	}
 	return columns, nil
 }

--- a/source-oracle/backfill.go
+++ b/source-oracle/backfill.go
@@ -297,6 +297,9 @@ func (db *oracleDatabase) fetchBackfillRowIDRange(ctx context.Context, schemaNam
 
 		db.backfillRowIDRanges[streamID] = append(db.backfillRowIDRanges[streamID], rowidStart)
 	}
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("iterating rowid ranges: %w", err)
+	}
 
 	var row = db.conn.QueryRowContext(ctx, fmt.Sprintf(`SELECT MAX(ROWID) FROM "%s"."%s"`, schemaName, tableName))
 	if err != nil {
@@ -515,6 +518,10 @@ func (db *oracleDatabase) explainQuery(ctx context.Context, streamID sqlcapture.
 		}
 
 		outputLines = append(outputLines, outputLine)
+	}
+	if err := rows.Err(); err != nil {
+		logrus.WithFields(logrus.Fields{"id": streamID, "err": err}).Error("error iterating explain output")
+		return
 	}
 
 	logrus.WithFields(logrus.Fields{

--- a/source-oracle/prerequisites.go
+++ b/source-oracle/prerequisites.go
@@ -145,6 +145,9 @@ func (db *oracleDatabase) prerequisiteTableAndColumnNameLengths(ctx context.Cont
 				}).Warn("column names longer than 30 characters are not supported for capturing, column will be ignored.")
 			}
 		}
+		if err := rows.Err(); err != nil {
+			return fmt.Errorf("iterating columns for table %q.%q: %w", owner, tableName, err)
+		}
 	}
 
 	return nil

--- a/source-postgres-batch/discovery.go
+++ b/source-postgres-batch/discovery.go
@@ -264,6 +264,9 @@ func discoverTables(ctx context.Context, db *sql.DB, discoverSchemas []string) (
 			Type:   tableType,
 		})
 	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("error iterating discovered tables: %w", err)
+	}
 	return tables, nil
 }
 
@@ -419,6 +422,9 @@ func discoverColumns(ctx context.Context, db *sql.DB, discoverSchemas []string) 
 			DataType:   &dataType,
 		})
 	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("error iterating discovered columns: %w", err)
+	}
 	return columns, nil
 }
 
@@ -481,6 +487,9 @@ func discoverPrimaryKeys(ctx context.Context, db *sql.DB, discoverSchemas []stri
 		if ordinalPosition != len(keyInfo.Columns) {
 			return nil, fmt.Errorf("primary key column %q (of table %q) appears out of order", columnName, tableID)
 		}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("error iterating discovered primary keys: %w", err)
 	}
 
 	var keys []*discoveredPrimaryKey

--- a/source-postgres/database.go
+++ b/source-postgres/database.go
@@ -59,6 +59,9 @@ func listPublishedTables(ctx context.Context, conn *pgxpool.Pool, publicationNam
 		}
 		publicationStatus[sqlcapture.JoinStreamID(schema, table)] = true
 	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("error listing tables in publication %q: %w", publicationName, err)
+	}
 	return publicationStatus, nil
 }
 

--- a/source-postgres/discovery.go
+++ b/source-postgres/discovery.go
@@ -798,6 +798,9 @@ func getGeneratedColumns(ctx context.Context, conn *pgxpool.Pool) (map[sqlcaptur
 		var streamID = sqlcapture.JoinStreamID(tableSchema, tableName)
 		generatedColumns[streamID] = append(generatedColumns[streamID], columnName)
 	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("error iterating generated columns: %w", err)
+	}
 	return generatedColumns, nil
 }
 

--- a/source-redshift-batch/discovery.go
+++ b/source-redshift-batch/discovery.go
@@ -304,6 +304,9 @@ func discoverTables(ctx context.Context, db *sql.DB, discoverSchemas []string) (
 			Type:   tableType,
 		})
 	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("error iterating discovered tables: %w", err)
+	}
 	return tables, nil
 }
 
@@ -464,6 +467,9 @@ func discoverColumns(ctx context.Context, db *sql.DB, discoverSchemas []string) 
 			DataType:   &dataType,
 		})
 	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("error iterating discovered columns: %w", err)
+	}
 	return columns, nil
 }
 
@@ -522,6 +528,9 @@ func discoverPrimaryKeys(ctx context.Context, db *sql.DB, discoverSchemas []stri
 			Column: columnName,
 			Index:  ordinalPosition,
 		})
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("error iterating discovered primary keys: %w", err)
 	}
 	return keys, nil
 }

--- a/source-sqlserver-batch/discovery.go
+++ b/source-sqlserver-batch/discovery.go
@@ -253,6 +253,9 @@ func discoverTables(ctx context.Context, db *sql.DB, discoverSchemas []string) (
 			Type:   tableType,
 		})
 	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("error iterating discovered tables: %w", err)
+	}
 	return tables, nil
 }
 
@@ -411,6 +414,9 @@ func discoverColumns(ctx context.Context, db *sql.DB, discoverSchemas []string) 
 		}
 		columns = append(columns, column)
 	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("error iterating discovered columns: %w", err)
+	}
 	return columns, nil
 }
 
@@ -477,6 +483,9 @@ func discoverPrimaryKeys(ctx context.Context, db *sql.DB, discoverSchemas []stri
 		if ordinalPosition != len(keyInfo.Columns) {
 			return nil, fmt.Errorf("primary key column %q (of table %q) appears out of order", columnName, tableID)
 		}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("error iterating discovered primary keys: %w", err)
 	}
 
 	var keys []*discoveredPrimaryKey

--- a/source-sqlserver-ct/diagnostics.go
+++ b/source-sqlserver-ct/diagnostics.go
@@ -42,6 +42,9 @@ func (db *sqlserverDatabase) ReplicationDiagnostics(ctx context.Context) error {
 			}
 			log.WithFields(logFields).Info("got diagnostic row")
 		}
+		if err := rows.Err(); err != nil {
+			logEntry.WithField("err", err).Error("error iterating diagnostic rows")
+		}
 		if numResults == 0 {
 			logEntry.Info("no results")
 		}

--- a/source-sqlserver-ct/discovery.go
+++ b/source-sqlserver-ct/discovery.go
@@ -173,6 +173,9 @@ func getTables(ctx context.Context, conn *sql.DB, opts discoveryOptions) ([]*sql
 			ExtraDetails: &sqlserverTableDiscoveryDetails{},
 		})
 	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("error iterating discovered tables: %w", err)
+	}
 	return tables, nil
 }
 
@@ -246,6 +249,9 @@ func getColumns(ctx context.Context, conn *sql.DB, opts discoveryOptions) ([]sql
 		}
 		columns = append(columns, ci)
 	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("error iterating discovered columns: %w", err)
+	}
 	return columns, nil
 }
 
@@ -305,6 +311,9 @@ func getPrimaryKeys(ctx context.Context, conn *sql.DB, opts discoveryOptions) (m
 			return nil, fmt.Errorf("primary key column %q (of table %q) appears out of order", columnName, streamID)
 		}
 	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("error iterating discovered primary keys: %w", err)
+	}
 	return keys, nil
 }
 
@@ -341,6 +350,9 @@ func getComputedColumns(ctx context.Context, conn *sql.DB, opts discoveryOptions
 		}
 		var streamID = sqlcapture.JoinStreamID(tableSchema, tableName)
 		computedColumns[streamID] = append(computedColumns[streamID], columnName)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("error iterating discovered computed columns: %w", err)
 	}
 	return computedColumns, nil
 }

--- a/source-sqlserver/discovery.go
+++ b/source-sqlserver/discovery.go
@@ -268,6 +268,9 @@ func getTables(ctx context.Context, conn *sql.DB, opts discoveryOptions) ([]*sql
 			ExtraDetails: &sqlserverTableDiscoveryDetails{},
 		})
 	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("error iterating discovered tables: %w", err)
+	}
 	return tables, nil
 }
 
@@ -347,6 +350,9 @@ func getColumns(ctx context.Context, conn *sql.DB, opts discoveryOptions) ([]sql
 		}
 		columns = append(columns, ci)
 	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("error iterating discovered columns: %w", err)
+	}
 	return columns, nil
 }
 
@@ -420,6 +426,9 @@ func getPrimaryKeys(ctx context.Context, conn *sql.DB, opts discoveryOptions) (m
 			return nil, fmt.Errorf("primary key column %q (of table %q) appears out of order", columnName, streamID)
 		}
 	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("error iterating discovered primary keys: %w", err)
+	}
 	return keys, nil
 }
 
@@ -472,7 +481,10 @@ func getSecondaryIndexes(ctx context.Context, conn *sql.DB, opts discoveryOption
 			return nil, fmt.Errorf("internal error: secondary index key ordering failure: index %q on stream %q: column %q appears out of order", indexName, streamID, columnName)
 		}
 	}
-	return streamIndexColumns, err
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("error iterating discovered secondary indexes: %w", err)
+	}
+	return streamIndexColumns, nil
 }
 
 func queryDiscoverComputedColumns(opts discoveryOptions) string {
@@ -508,6 +520,9 @@ func getComputedColumns(ctx context.Context, conn *sql.DB, opts discoveryOptions
 		}
 		var streamID = sqlcapture.JoinStreamID(tableSchema, tableName)
 		computedColumns[streamID] = append(computedColumns[streamID], columnName)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("error iterating discovered computed columns: %w", err)
 	}
 	return computedColumns, nil
 }


### PR DESCRIPTION
**Description:**

Per Go's [database/sql docs](https://pkg.go.dev/database/sql#Rows.Next), `rows.Next()` returns `false` both when the result set is exhausted and when an error is encountered. `rows.Err()` must be checked afterward to distinguish the two cases. Without this check, a mid-iteration error causes the function to return success with a partial result set.

**Notes for reviewers:**

There are also materializations that aren't checking `rows.Err()` after iterating through `rows.Next()`, but I'm going to split those off into a different PR for the materialization team to review.

