### PR TITLE
materialize-*: check `rows.Err()` after all `rows.Next()` loops

### DIFF
--- a/materialize-azure-fabric-warehouse/client.go
+++ b/materialize-azure-fabric-warehouse/client.go
@@ -266,6 +266,9 @@ func (c *client) ListSchemas(ctx context.Context) ([]string, error) {
 		}
 		out = append(out, schema)
 	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterating rows: %w", err)
+	}
 
 	return out, nil
 }

--- a/materialize-motherduck/client.go
+++ b/materialize-motherduck/client.go
@@ -122,6 +122,9 @@ func (c *client) ListSchemas(ctx context.Context) ([]string, error) {
 		}
 		out = append(out, schema)
 	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterating rows: %w", err)
+	}
 
 	return out, nil
 }

--- a/materialize-motherduck/config.go
+++ b/materialize-motherduck/config.go
@@ -325,6 +325,9 @@ func (c *config) db(ctx context.Context) (*stdsql.DB, error) {
 			log.WithField("name", name).Warn("unexpected secret selected")
 		}
 	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterating selected secrets: %w", err)
+	}
 
 	return db, err
 }

--- a/materialize-redshift/client.go
+++ b/materialize-redshift/client.go
@@ -142,6 +142,9 @@ func (c *client) ListSchemas(ctx context.Context) ([]string, error) {
 		}
 		out = append(out, schema)
 	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterating rows: %w", err)
+	}
 
 	return out, nil
 }

--- a/materialize-sql/std_sql.go
+++ b/materialize-sql/std_sql.go
@@ -223,6 +223,9 @@ func StdDumpTable(ctx context.Context, db *sql.DB, table Table) (string, error) 
 			b.WriteString(val.String())
 		}
 	}
+	if err := rows.Err(); err != nil {
+		return "", err
+	}
 	return b.String(), nil
 }
 
@@ -438,6 +441,9 @@ func StdListSchemas(ctx context.Context, db *sql.DB) ([]string, error) {
 			return nil, fmt.Errorf("scanning row: %w", err)
 		}
 		out = append(out, schema)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterating rows: %w", err)
 	}
 
 	return out, nil

--- a/materialize-sql/test_support.go
+++ b/materialize-sql/test_support.go
@@ -429,5 +429,8 @@ func DumpTestTable(t *testing.T, db *stdsql.DB, qualifiedTableName string) (stri
 			b.WriteString(val.String())
 		}
 	}
+	if err := rows.Err(); err != nil {
+		return "", err
+	}
 	return b.String(), nil
 }

--- a/materialize-sqlserver/collation.go
+++ b/materialize-sqlserver/collation.go
@@ -45,6 +45,9 @@ func getCollation(ctx context.Context, db *stdsql.DB) (string, error) {
 
 		collations = append(collations, c)
 	}
+	if err := rows.Err(); err != nil {
+		return "", fmt.Errorf("iterating collations: %w", err)
+	}
 
 	sortCollations(collations)
 

--- a/materialize-sqlserver/collation.go
+++ b/materialize-sqlserver/collation.go
@@ -35,6 +35,7 @@ func getCollation(ctx context.Context, db *stdsql.DB) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("querying available collations: %w", err)
 	}
+	defer rows.Close()
 
 	var collations []string
 	for rows.Next() {

--- a/materialize-starburst/starburst.go
+++ b/materialize-starburst/starburst.go
@@ -329,6 +329,9 @@ func (t *transactor) Load(it *m.LoadIterator, loaded func(int, json.RawMessage) 
 				return err
 			}
 		}
+		if err := rows.Err(); err != nil {
+			return fmt.Errorf("iterating Load documents: %w", err)
+		}
 
 		if err := rows.Close(); err != nil {
 			return fmt.Errorf("closing rows: %w", err)


### PR DESCRIPTION
**Description:**

This is the materialization counterpart of https://github.com/estuary/connectors/pull/4233.

Per Go's [database/sql docs](https://pkg.go.dev/database/sql#Rows.Next), `rows.Next()` returns `false` both when the result set is exhausted and when an error is encountered. `rows.Err()` must be checked afterward to distinguish the two cases. Without this check, a mid-iteration error causes the function to return success with a partial result set.

I also added a `defer rows.Close()` in a spot in `materailize-sqlserver` that was missing it.

**Notes for reviewers:**

When investigating an escalation for `source-sqlserver`, we found that it wasn't checking `rows.Err()` after iterating through `rows.Next()` and could have missed changes as a result of that bug. I'm going through and updating all connectors to make sure they check `rows.Err()` so we don't encounter the same bug elsewhere, and this PR is a part of that effort. I'm not as familiar with materializations, so feel free to tell me to do things differently if these changes aren't applicable for whatever reason. 😁 

