### PR TITLE
fix(clickhouse): keep store table schema in sync with target

### DIFF
--- a/materialize-clickhouse/.snapshots/TestSQLGeneration
+++ b/materialize-clickhouse/.snapshots/TestSQLGeneration
@@ -46,6 +46,22 @@ ORDER BY (theKey)
 ;
 --- End delta_updates createTargetTable ---
 
+--- Begin key_value queryStoreTablesAllRangeKeys ---
+
+SELECT name FROM system.tables
+WHERE database = currentDatabase()
+  AND name LIKE 'flow_temp_store_%_key_value'
+  AND match(name, '^flow_temp_store_[0-9a-f]+_key_value$')
+--- End key_value queryStoreTablesAllRangeKeys ---
+
+--- Begin delta_updates queryStoreTablesAllRangeKeys ---
+
+SELECT name FROM system.tables
+WHERE database = currentDatabase()
+  AND name LIKE 'flow_temp_store_%_delta_updates'
+  AND match(name, '^flow_temp_store_[0-9a-f]+_delta_updates$')
+--- End delta_updates queryStoreTablesAllRangeKeys ---
+
 --- Begin alter table add columns and drop not nulls ---
 
 ALTER TABLE key_value ADD COLUMN IF NOT EXISTS first_new_column Nullable(STRING);

--- a/materialize-clickhouse/.snapshots/TestSQLGenerationQuotedTableNames
+++ b/materialize-clickhouse/.snapshots/TestSQLGenerationQuotedTableNames
@@ -46,6 +46,22 @@ ORDER BY (theKey)
 ;
 --- End `delta_updates-@你好-``-"especiál` createTargetTable ---
 
+--- Begin `key_value-@你好-``-"especiál` queryStoreTablesAllRangeKeys ---
+
+SELECT name FROM system.tables
+WHERE database = currentDatabase()
+  AND name LIKE 'flow_temp_store_%_key_value-@你好-`-"especiál'
+  AND match(name, '^flow_temp_store_[0-9a-f]+_key_value-@你好-`-"especiál$')
+--- End `key_value-@你好-``-"especiál` queryStoreTablesAllRangeKeys ---
+
+--- Begin `delta_updates-@你好-``-"especiál` queryStoreTablesAllRangeKeys ---
+
+SELECT name FROM system.tables
+WHERE database = currentDatabase()
+  AND name LIKE 'flow_temp_store_%_delta_updates-@你好-`-"especiál'
+  AND match(name, '^flow_temp_store_[0-9a-f]+_delta_updates-@你好-`-"especiál$')
+--- End `delta_updates-@你好-``-"especiál` queryStoreTablesAllRangeKeys ---
+
 --- Begin alter table add columns and drop not nulls ---
 
 ALTER TABLE `key_value-@你好-``-"especiál` ADD COLUMN IF NOT EXISTS first_new_column Nullable(STRING);

--- a/materialize-clickhouse/client.go
+++ b/materialize-clickhouse/client.go
@@ -120,45 +120,80 @@ func (c *client) CreateTable(ctx context.Context, tc sql.TableCreate) error {
 	return nil
 }
 
-func (c *client) DeleteTable(_ context.Context, path []string) (string, boilerplate.ActionApplyFn, error) {
-	var stmt = fmt.Sprintf("DROP TABLE IF EXISTS %s;", c.ep.Dialect.Identifier(path...))
-	return stmt, func(ctx context.Context) error {
-		if _, err := c.db.ExecContext(ctx, stmt); err != nil {
-			return fmt.Errorf("executing delete table: %w", err)
+func (c *client) DeleteTable(ctx context.Context, path []string) (string, boilerplate.ActionApplyFn, error) {
+	storeNames, err := c.findStoreTableNames(ctx, path)
+	if err != nil {
+		return "", nil, err
+	}
+
+	var stmts []string
+	for _, name := range storeNames {
+		stmts = append(stmts, fmt.Sprintf("DROP TABLE IF EXISTS %s;", c.ep.Dialect.Identifier(name)))
+	}
+	stmts = append(stmts, fmt.Sprintf("DROP TABLE IF EXISTS %s;", c.ep.Dialect.Identifier(path...)))
+
+	return strings.Join(stmts, "\n"), func(ctx context.Context) error {
+		for _, stmt := range stmts {
+			if _, err := c.db.ExecContext(ctx, stmt); err != nil {
+				return fmt.Errorf("executing %q: %w", stmt, err)
+			}
 		}
 		return nil
 	}, nil
 }
 
 func (c *client) AlterTable(ctx context.Context, ta sql.TableAlter) (string, boilerplate.ActionApplyFn, error) {
+	var tpls = renderTemplates(c.ep.Dialect, c.ep.Config.HardDelete)
+
+	storeNames, err := c.findStoreTableNames(ctx, ta.Table.Path)
+	if err != nil {
+		return "", nil, err
+	}
+
+	var tables = []sql.Table{ta.Table}
+	for _, storeName := range storeNames {
+		var storeTable = ta.Table
+		storeTable.Identifier = c.ep.Dialect.Identifier(storeName)
+		storeTable.Path = sql.TablePath{storeName}
+		storeTable.InfoLocation = c.ep.Dialect.TableLocator(storeTable.Path)
+		tables = append(tables, storeTable)
+	}
+
 	var stmts []string
 
 	if len(ta.AddColumns) > 0 || len(ta.DropNotNulls) > 0 {
-		var alterStmtBuilder strings.Builder
-		if err := renderTemplates(c.ep.Dialect, c.ep.Config.HardDelete).alterTargetColumns.Execute(&alterStmtBuilder, ta); err != nil {
-			return "", nil, fmt.Errorf("rendering alter table statement: %w", err)
-		}
-		var alterStmt = alterStmtBuilder.String()
-		// The template generates separate ALTER statements per column.
-		for _, s := range strings.Split(alterStmt, ";") {
-			s = strings.TrimSpace(s)
-			if s != "" {
-				stmts = append(stmts, s+";")
+		for _, table := range tables {
+			var b strings.Builder
+			if err = tpls.alterTargetColumns.Execute(&b, sql.TableAlter{
+				Table:        table,
+				AddColumns:   ta.AddColumns,
+				DropNotNulls: ta.DropNotNulls,
+			}); err != nil {
+				return "", nil, fmt.Errorf("rendering alter table statement for %s: %w", table.Identifier, err)
+			}
+			// The template generates separate ALTER statements per column.
+			for _, s := range strings.Split(b.String(), ";") {
+				s = strings.TrimSpace(s)
+				if s != "" {
+					stmts = append(stmts, s+";")
+				}
 			}
 		}
 	}
 
 	if len(ta.ColumnTypeChanges) > 0 {
-		var steps, err = sql.StdColumnTypeMigrations(ctx, c.ep.Dialect, ta.Table, ta.ColumnTypeChanges)
-		if err != nil {
-			return "", nil, fmt.Errorf("rendering column migration steps: %w", err)
+		for _, table := range tables {
+			var steps, err = sql.StdColumnTypeMigrations(ctx, c.ep.Dialect, table, ta.ColumnTypeChanges)
+			if err != nil {
+				return "", nil, fmt.Errorf("rendering column migration steps for %s: %w", table.Identifier, err)
+			}
+			stmts = append(stmts, steps...)
 		}
-		stmts = append(stmts, steps...)
 	}
 
 	return strings.Join(stmts, "\n"), func(ctx context.Context) error {
 		for _, stmt := range stmts {
-			if _, err := c.db.ExecContext(ctx, stmt); err != nil {
+			if _, err = c.db.ExecContext(ctx, stmt); err != nil {
 				return fmt.Errorf("executing %q: %w", stmt, err)
 			}
 		}
@@ -174,6 +209,39 @@ func (c *client) TruncateTable(_ context.Context, path []string) (string, boiler
 		}
 		return nil
 	}, nil
+}
+
+// findStoreTableNames returns the names of any store tables that exist for the
+// given target table path. Store tables follow the naming convention
+// flow_temp_store_{hex_rangekey}_{tablename}.
+func (c *client) findStoreTableNames(ctx context.Context, path []string) ([]string, error) {
+	var tpls = renderTemplates(c.ep.Dialect, c.ep.Config.HardDelete)
+	var table = sql.Table{TableShape: sql.TableShape{Path: path}}
+
+	findSQL, err := sql.RenderTableTemplate(table, tpls.queryStoreTablesAllRangeKeys)
+	if err != nil {
+		return nil, fmt.Errorf("rendering queryStoreTablesAllRangeKeys: %w", err)
+	}
+
+	rows, err := c.db.QueryContext(ctx, findSQL)
+	if err != nil {
+		return nil, fmt.Errorf("querying for store tables: %w", err)
+	}
+	defer rows.Close()
+
+	var names []string
+	for rows.Next() {
+		var name string
+		if err = rows.Scan(&name); err != nil {
+			return nil, fmt.Errorf("scanning store table name: %w", err)
+		}
+		names = append(names, name)
+	}
+	if err = rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterating store table rows: %w", err)
+	}
+
+	return names, nil
 }
 
 func (c *client) InstallFence(_ context.Context, _ sql.Table, _ sql.Fence) (sql.Fence, error) {

--- a/materialize-clickhouse/driver_test.go
+++ b/materialize-clickhouse/driver_test.go
@@ -365,6 +365,53 @@ func TestTruncateTable(t *testing.T) {
 	require.Equal(t, 0, count)
 }
 
+func TestDeleteTableDropsStoreTable(t *testing.T) {
+	var cfg = testConfig()
+	var ctx = t.Context()
+	var dialect = clickHouseDialect(cfg.Database)
+	var ep = &sql.Endpoint[config]{Config: cfg, Dialect: dialect}
+	var tableName = "test_delete_store"
+	var storeTableName = "flow_temp_store_0_" + tableName
+
+	db := clickhouse.OpenDB(cfg.newClickhouseOptions())
+	defer db.Close()
+
+	// Create target and store tables.
+	_, _ = db.ExecContext(ctx, fmt.Sprintf("DROP TABLE IF EXISTS %s", dialect.Identifier(tableName)))
+	_, _ = db.ExecContext(ctx, fmt.Sprintf("DROP TABLE IF EXISTS %s", dialect.Identifier(storeTableName)))
+	_, err := db.ExecContext(ctx, fmt.Sprintf(
+		"CREATE TABLE IF NOT EXISTS %s (id String, flow_published_at DateTime64(6, 'UTC')) ENGINE = ReplacingMergeTree(flow_published_at) ORDER BY (id)",
+		dialect.Identifier(tableName),
+	))
+	require.NoError(t, err)
+	_, err = db.ExecContext(ctx, fmt.Sprintf(
+		"CREATE TABLE IF NOT EXISTS %s AS %s",
+		dialect.Identifier(storeTableName), dialect.Identifier(tableName),
+	))
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_, _ = db.ExecContext(context.Background(), fmt.Sprintf("DROP TABLE IF EXISTS %s", dialect.Identifier(tableName)))
+		_, _ = db.ExecContext(context.Background(), fmt.Sprintf("DROP TABLE IF EXISTS %s", dialect.Identifier(storeTableName)))
+	})
+
+	c, err := newClient(ctx, "test", ep)
+	require.NoError(t, err)
+	defer c.Close()
+
+	desc, applyFn, err := c.DeleteTable(ctx, []string{tableName})
+	require.NoError(t, err)
+	require.Contains(t, desc, storeTableName)
+	require.NoError(t, applyFn(ctx))
+
+	// Both target and store tables should be gone.
+	var count int
+	require.NoError(t, db.QueryRowContext(ctx, fmt.Sprintf(
+		"SELECT count() FROM system.tables WHERE database = currentDatabase() AND name IN ('%s', '%s')",
+		tableName, storeTableName,
+	)).Scan(&count))
+	require.Equal(t, 0, count, "both tables should be dropped")
+}
+
 func TestOpenNativeConn(t *testing.T) {
 	var cfg = testConfig()
 	conn, err := clickhouse.Open(cfg.newClickhouseOptions())
@@ -1283,4 +1330,158 @@ func TestNoFlowDocumentNullValues(t *testing.T) {
 	// Non-nullable columns are still present.
 	require.JSONEq(t, `{"op":"c"}`, string(parsed["_meta"]))
 	require.Equal(t, `"1"`, string(parsed["score"]))
+}
+
+// TestAlterTableUpdatesStoreTable verifies that AlterTable applies schema
+// changes to both the target table and any existing store table.
+func TestAlterTableUpdatesStoreTable(t *testing.T) {
+	var cfg = testConfig()
+	var ctx = t.Context()
+	var dialect = clickHouseDialect(cfg.Database)
+	var tableName = "test_alter_store"
+	var storeTableName = "flow_temp_store_0_" + tableName
+
+	db := clickhouse.OpenDB(cfg.newClickhouseOptions())
+	defer db.Close()
+
+	// Helper to check if a column exists on a table and return its type.
+	columnType := func(table, col string) (string, bool) {
+		var colType string
+		err := db.QueryRowContext(ctx, fmt.Sprintf(
+			"SELECT type FROM system.columns WHERE database = '%s' AND table = '%s' AND name = '%s'",
+			cfg.Database, table, col,
+		)).Scan(&colType)
+		if err != nil {
+			return "", false
+		}
+		return colType, true
+	}
+
+	setup := func(t *testing.T) {
+		t.Helper()
+		_, _ = db.ExecContext(ctx, fmt.Sprintf("DROP TABLE IF EXISTS %s", dialect.Identifier(tableName)))
+		_, _ = db.ExecContext(ctx, fmt.Sprintf("DROP TABLE IF EXISTS %s", dialect.Identifier(storeTableName)))
+
+		// Create target with a non-nullable required_val column.
+		_, err := db.ExecContext(ctx, fmt.Sprintf(
+			"CREATE TABLE IF NOT EXISTS %s (id String, required_val String, flow_published_at DateTime64(6, 'UTC')) ENGINE = ReplacingMergeTree(flow_published_at) ORDER BY (id)",
+			dialect.Identifier(tableName),
+		))
+		require.NoError(t, err)
+
+		// Clone into store table.
+		_, err = db.ExecContext(ctx, fmt.Sprintf(
+			"CREATE TABLE IF NOT EXISTS %s AS %s",
+			dialect.Identifier(storeTableName), dialect.Identifier(tableName),
+		))
+		require.NoError(t, err)
+
+		t.Cleanup(func() {
+			_, _ = db.ExecContext(context.Background(), fmt.Sprintf("DROP TABLE IF EXISTS %s", dialect.Identifier(tableName)))
+			_, _ = db.ExecContext(context.Background(), fmt.Sprintf("DROP TABLE IF EXISTS %s", dialect.Identifier(storeTableName)))
+		})
+	}
+
+	var table = buildTestTable(t, dialect, tableName)
+	var ep = &sql.Endpoint[config]{Config: cfg, Dialect: dialect}
+
+	t.Run("add columns", func(t *testing.T) {
+		setup(t)
+		c, err := newClient(ctx, "test", ep)
+		require.NoError(t, err)
+		defer c.Close()
+
+		desc, applyFn, err := c.AlterTable(ctx, sql.TableAlter{
+			Table: table,
+			AddColumns: []sql.Column{
+				{Identifier: "new_col", MappedType: sql.MappedType{NullableDDL: "String"}},
+			},
+		})
+		require.NoError(t, err)
+		require.Contains(t, desc, storeTableName)
+		require.NoError(t, applyFn(ctx))
+
+		// Column must exist on both target and store table.
+		_, ok := columnType(tableName, "new_col")
+		require.True(t, ok, "new_col should exist on target")
+		_, ok = columnType(storeTableName, "new_col")
+		require.True(t, ok, "new_col should exist on store table")
+	})
+
+	t.Run("drop not nulls", func(t *testing.T) {
+		setup(t)
+		c, err := newClient(ctx, "test", ep)
+		require.NoError(t, err)
+		defer c.Close()
+
+		// Verify required_val starts as non-nullable.
+		typ, ok := columnType(storeTableName, "required_val")
+		require.True(t, ok)
+		require.Equal(t, "String", typ, "should start non-nullable")
+
+		desc, applyFn, err := c.AlterTable(ctx, sql.TableAlter{
+			Table: table,
+			DropNotNulls: []boilerplate.ExistingField{
+				{Name: "required_val", Type: "String"},
+			},
+		})
+		require.NoError(t, err)
+		require.Contains(t, desc, storeTableName)
+		require.NoError(t, applyFn(ctx))
+
+		// Column must be nullable on both.
+		typ, ok = columnType(tableName, "required_val")
+		require.True(t, ok)
+		require.Equal(t, "Nullable(String)", typ, "target should be nullable")
+		typ, ok = columnType(storeTableName, "required_val")
+		require.True(t, ok)
+		require.Equal(t, "Nullable(String)", typ, "store table should be nullable")
+	})
+}
+
+// TestAlterTableNoStoreTable verifies that AlterTable works correctly when no
+// store table exists (the common case outside of active transactions).
+func TestAlterTableNoStoreTable(t *testing.T) {
+	var cfg = testConfig()
+	var ctx = t.Context()
+	var dialect = clickHouseDialect(cfg.Database)
+	var tableName = "test_alter_no_store"
+
+	db := clickhouse.OpenDB(cfg.newClickhouseOptions())
+	defer db.Close()
+
+	_, _ = db.ExecContext(ctx, fmt.Sprintf("DROP TABLE IF EXISTS %s", dialect.Identifier(tableName)))
+	_, err := db.ExecContext(ctx, fmt.Sprintf(
+		"CREATE TABLE IF NOT EXISTS %s (id String, flow_published_at DateTime64(6, 'UTC')) ENGINE = ReplacingMergeTree(flow_published_at) ORDER BY (id)",
+		dialect.Identifier(tableName),
+	))
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_, _ = db.ExecContext(context.Background(), fmt.Sprintf("DROP TABLE IF EXISTS %s", dialect.Identifier(tableName)))
+	})
+
+	var table = buildTestTable(t, dialect, tableName)
+	var ep = &sql.Endpoint[config]{Config: cfg, Dialect: dialect}
+	c, err := newClient(ctx, "test", ep)
+	require.NoError(t, err)
+	defer c.Close()
+
+	var ta = sql.TableAlter{
+		Table: table,
+		AddColumns: []sql.Column{
+			{Identifier: "new_col", MappedType: sql.MappedType{NullableDDL: "String"}},
+		},
+	}
+	desc, applyFn, err := c.AlterTable(ctx, ta)
+	require.NoError(t, err)
+	require.NotContains(t, desc, "flow_temp_store")
+	require.NoError(t, applyFn(ctx))
+
+	// Verify the new column exists on the target.
+	var count int
+	require.NoError(t, db.QueryRowContext(ctx, fmt.Sprintf(
+		"SELECT count() FROM system.columns WHERE database = '%s' AND table = '%s' AND name = 'new_col'",
+		cfg.Database, tableName,
+	)).Scan(&count))
+	require.Equal(t, 1, count)
 }

--- a/materialize-clickhouse/sqlgen.go
+++ b/materialize-clickhouse/sqlgen.go
@@ -119,6 +119,7 @@ type templates struct {
 	queryStoreParts              *template.Template
 	moveStorePartition           *template.Template
 	existsStoreTable             *template.Template
+	queryStoreTablesAllRangeKeys *template.Template
 	dropStoreTable               *template.Template
 }
 
@@ -338,6 +339,14 @@ DROP TABLE IF EXISTS {{ template "loadTableName" . }};
 {{ printf "flow_temp_store_%s_%s" $.RangeKey (index $.Path 0) | Literal }}
 {{- end }}
 
+{{ define "storeTableAllRangeKeysPatternLike" -}}
+{{ printf "flow_temp_store_%%_%s" (index $.Path 0) | Literal }}
+{{- end }}
+
+{{ define "storeTableAllRangeKeysPatternRegexp" -}}
+{{ printf "^flow_temp_store_[0-9a-f]+_%s$" (index $.Path 0) | Literal }}
+{{- end }}
+
 {{ define "createStoreTable" }}
 CREATE OR REPLACE TABLE {{ template "storeTableNameIdentifier" . }}
 AS {{$.Identifier}};
@@ -371,6 +380,13 @@ WHERE database = currentDatabase()
   AND name = {{ template "storeTableNameString" . }};
 {{ end }}
 
+{{ define "queryStoreTablesAllRangeKeys" }}
+SELECT name FROM system.tables
+WHERE database = currentDatabase()
+  AND name LIKE {{ template "storeTableAllRangeKeysPatternLike" . }}
+  AND match(name, {{ template "storeTableAllRangeKeysPatternRegexp" . }})
+{{ end }}
+
 {{ define "dropStoreTable" }}
 DROP TABLE IF EXISTS {{ template "storeTableNameIdentifier" . }};
 {{ end }}
@@ -389,6 +405,7 @@ DROP TABLE IF EXISTS {{ template "storeTableNameIdentifier" . }};
 		queryStoreParts:              tplAll.Lookup("queryStoreParts"),
 		moveStorePartition:           tplAll.Lookup("moveStorePartition"),
 		existsStoreTable:             tplAll.Lookup("existsStoreTable"),
+		queryStoreTablesAllRangeKeys: tplAll.Lookup("queryStoreTablesAllRangeKeys"),
 		dropStoreTable:               tplAll.Lookup("dropStoreTable"),
 	}
 }

--- a/materialize-clickhouse/sqlgen_test.go
+++ b/materialize-clickhouse/sqlgen_test.go
@@ -41,6 +41,7 @@ func TestSQLGeneration(t *testing.T) {
 		sql.TestTemplates{
 			TableTemplates: []*template.Template{
 				testTemplates.createTargetTable,
+				testTemplates.queryStoreTablesAllRangeKeys,
 			},
 			TplAddColumns:    testTemplates.alterTargetColumns,
 			TplDropNotNulls:  testTemplates.alterTargetColumns,
@@ -131,6 +132,7 @@ func TestSQLGenerationQuotedTableNames(t *testing.T) {
 		sql.TestTemplates{
 			TableTemplates: []*template.Template{
 				testTemplates.createTargetTable,
+				testTemplates.queryStoreTablesAllRangeKeys,
 			},
 			TplAddColumns:    testTemplates.alterTargetColumns,
 			TplDropNotNulls:  testTemplates.alterTargetColumns,


### PR DESCRIPTION
**Description:**

When the runtime changes the destination schema by calling `Apply()`, and store tables exist for the target table, then the next call to `Acknowledge()` fails because it implements the store-commit operation with `ALTER TABLE ... MOVE PARTITION ...`, which requires that the tables have a common schema.

This fixes the bug by applying every schema change to both the target and store tables.

**Workflow steps:**

This is a bug fix that requires no change to customer workflows.

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

