### PR TITLE
materialize-*: handle null valued keys in MergeBounds

### DIFF
--- a/materialize-azure-fabric-warehouse/.snapshots/TestSQLGeneration
+++ b/materialize-azure-fabric-warehouse/.snapshots/TestSQLGeneration
@@ -166,9 +166,9 @@ WITH (
 SELECT 0, r.flow_document
 FROM flow_temp_table_load_0 AS l
 JOIN "a-warehouse"."a-schema".key_value AS r
-	 ON  l.key1 = r.key1 AND r.key1 >= 10 AND r.key1 <= 100
-	 AND l.key2 = r.key2
-	 AND BASE64_DECODE(l."key!binary") = r."key!binary"
+	 ON  (l.key1 = r.key1 AND r.key1 >= 10 AND r.key1 <= 100)
+	 AND (l.key2 = r.key2)
+	 AND (BASE64_DECODE(l."key!binary") = r."key!binary")
 --- End "a-warehouse"."a-schema".key_value loadQuery ---
 
 --- Begin "a-warehouse"."a-schema".key_value loadQueryNoFlowDocument ---
@@ -197,9 +197,9 @@ SELECT 0,
 	) as flow_document
 FROM flow_temp_table_load_0 AS l
 JOIN "a-warehouse"."a-schema".key_value AS r
-	 ON  l.key1 = r.key1 AND r.key1 >= 10 AND r.key1 <= 100
-	 AND l.key2 = r.key2
-	 AND BASE64_DECODE(l."key!binary") = r."key!binary"
+	 ON  (l.key1 = r.key1 AND r.key1 >= 10 AND r.key1 <= 100)
+	 AND (l.key2 = r.key2)
+	 AND (BASE64_DECODE(l."key!binary") = r."key!binary")
 --- End "a-warehouse"."a-schema".key_value loadQueryNoFlowDocument ---
 
 --- Begin "a-warehouse"."a-schema".key_value dropLoadTable ---
@@ -245,9 +245,9 @@ WITH (
 DELETE r
 FROM "a-warehouse"."a-schema".key_value AS r
 INNER JOIN flow_temp_table_store_0 AS l
-	 ON  l.key1 = r.key1 AND r.key1 >= 10 AND r.key1 <= 100
-	 AND l.key2 = r.key2
-	 AND BASE64_DECODE(l."key!binary") = r."key!binary";
+	 ON  (l.key1 = r.key1 AND r.key1 >= 10 AND r.key1 <= 100)
+	 AND (l.key2 = r.key2)
+	 AND (BASE64_DECODE(l."key!binary") = r."key!binary");
 
 INSERT INTO "a-warehouse"."a-schema".key_value (key1, key2, "key!binary", "array", "binary", "boolean", field_with_projection, flow_published_at, "integer", "integerGt64Bit", "integerWithUserDDL", multiple, "nonAsciiκόσμε", number, "numberCastToString", "object", string, "stringInteger", "stringInteger39Chars", "stringInteger66Chars", "stringNumber", flow_document)
 SELECT key1, key2, BASE64_DECODE("key!binary"), "array", BASE64_DECODE("binary"), "boolean", field_with_projection, flow_published_at, "integer", "integerGt64Bit", "integerWithUserDDL", multiple, "nonAsciiκόσμε", number, "numberCastToString", "object", string, "stringInteger", "stringInteger39Chars", "stringInteger66Chars", "stringNumber", flow_document
@@ -256,6 +256,98 @@ WHERE _flow_delete = 0;
 
 DROP TABLE flow_temp_table_store_0;
 --- End "a-warehouse"."a-schema".key_value storeMergeQuery ---
+
+--- Begin "a-warehouse"."a-schema".key_value loadQuery (with null bounds) ---
+SELECT 0, r.flow_document
+FROM flow_temp_table_load_0 AS l
+JOIN "a-warehouse"."a-schema".key_value AS r
+	 ON  (l.key1 = r.key1 AND r.key1 >= 10 AND r.key1 <= 100 OR r.key1 IS NULL)
+	 AND (l.key2 = r.key2)
+	 AND (BASE64_DECODE(l."key!binary") = r."key!binary")
+--- End "a-warehouse"."a-schema".key_value loadQuery (with null bounds) ---
+
+--- Begin "a-warehouse"."a-schema".key_value loadQueryNoFlowDocument (with null bounds) ---
+SELECT 0, 
+	JSON_OBJECT(
+		'key1': r.key1,
+		'key2': r.key2,
+		'key!binary': r."key!binary",
+		'array': r."array",
+		'binary': r."binary",
+		'boolean': r."boolean",
+		'field_with_projection': r.field_with_projection,
+		'integer': r."integer",
+		'integerGt64Bit': r."integerGt64Bit",
+		'integerWithUserDDL': r."integerWithUserDDL",
+		'multiple': r.multiple,
+		'nonAsciiκόσμε': r."nonAsciiκόσμε",
+		'number': r.number,
+		'numberCastToString': CAST(r."numberCastToString" AS VARCHAR(MAX)),
+		'object': r."object",
+		'string': r.string,
+		'stringInteger': CAST(r."stringInteger" AS VARCHAR(MAX)),
+		'stringInteger39Chars': CAST(r."stringInteger39Chars" AS VARCHAR(MAX)),
+		'stringInteger66Chars': CAST(r."stringInteger66Chars" AS VARCHAR(MAX)),
+		'stringNumber': CAST(r."stringNumber" AS VARCHAR(MAX))
+	) as flow_document
+FROM flow_temp_table_load_0 AS l
+JOIN "a-warehouse"."a-schema".key_value AS r
+	 ON  (l.key1 = r.key1 AND r.key1 >= 10 AND r.key1 <= 100 OR r.key1 IS NULL)
+	 AND (l.key2 = r.key2)
+	 AND (BASE64_DECODE(l."key!binary") = r."key!binary")
+--- End "a-warehouse"."a-schema".key_value loadQueryNoFlowDocument (with null bounds) ---
+
+--- Begin "a-warehouse"."a-schema".key_value storeMergeQuery (with null bounds) ---
+CREATE TABLE flow_temp_table_store_0 (
+	key1 BIGINT,
+	key2 BIT,
+	"key!binary" VARCHAR(MAX),
+	"array" VARCHAR(MAX),
+	"binary" VARCHAR(MAX),
+	"boolean" BIT,
+	field_with_projection VARCHAR(MAX),
+	flow_published_at DATETIME2(6),
+	"integer" BIGINT,
+	"integerGt64Bit" DECIMAL(38,0),
+	"integerWithUserDDL" DECIMAL(20),
+	multiple VARCHAR(MAX),
+	"nonAsciiκόσμε" VARCHAR(MAX),
+	number FLOAT,
+	"numberCastToString" VARCHAR(MAX),
+	"object" VARCHAR(MAX),
+	string VARCHAR(MAX),
+	"stringInteger" DECIMAL(38,0),
+	"stringInteger39Chars" VARCHAR(MAX),
+	"stringInteger66Chars" VARCHAR(MAX),
+	"stringNumber" FLOAT,
+	flow_document VARCHAR(MAX),
+	_flow_delete BIT
+);
+
+COPY INTO flow_temp_table_store_0
+(key1, key2, "key!binary", "array", "binary", "boolean", field_with_projection, flow_published_at, "integer", "integerGt64Bit", "integerWithUserDDL", multiple, "nonAsciiκόσμε", number, "numberCastToString", "object", string, "stringInteger", "stringInteger39Chars", "stringInteger66Chars", "stringNumber", flow_document, _flow_delete)
+FROM 'https://some/file1', 'https://some/file2'
+WITH (
+	FILE_TYPE = 'CSV',
+	COMPRESSION = 'Gzip',
+	FIELDQUOTE = '`',
+	CREDENTIAL = (IDENTITY='Storage Account Key', SECRET='some-storage-account-key')
+);
+
+DELETE r
+FROM "a-warehouse"."a-schema".key_value AS r
+INNER JOIN flow_temp_table_store_0 AS l
+	 ON  (l.key1 = r.key1 AND r.key1 >= 10 AND r.key1 <= 100 OR r.key1 IS NULL)
+	 AND (l.key2 = r.key2)
+	 AND (BASE64_DECODE(l."key!binary") = r."key!binary");
+
+INSERT INTO "a-warehouse"."a-schema".key_value (key1, key2, "key!binary", "array", "binary", "boolean", field_with_projection, flow_published_at, "integer", "integerGt64Bit", "integerWithUserDDL", multiple, "nonAsciiκόσμε", number, "numberCastToString", "object", string, "stringInteger", "stringInteger39Chars", "stringInteger66Chars", "stringNumber", flow_document)
+SELECT key1, key2, BASE64_DECODE("key!binary"), "array", BASE64_DECODE("binary"), "boolean", field_with_projection, flow_published_at, "integer", "integerGt64Bit", "integerWithUserDDL", multiple, "nonAsciiκόσμε", number, "numberCastToString", "object", string, "stringInteger", "stringInteger39Chars", "stringInteger66Chars", "stringNumber", flow_document
+FROM flow_temp_table_store_0
+WHERE _flow_delete = 0;
+
+DROP TABLE flow_temp_table_store_0;
+--- End "a-warehouse"."a-schema".key_value storeMergeQuery (with null bounds) ---
 
 --- Begin createMigrationTable
 CREATE TABLE some_table_tmp AS SELECT

--- a/materialize-azure-fabric-warehouse/sqlgen.go
+++ b/materialize-azure-fabric-warehouse/sqlgen.go
@@ -248,8 +248,9 @@ FROM {{ template "temp_name_load" . }} AS l
 JOIN {{ $.Identifier}} AS r
 {{- range $ind, $bound := $.Bounds }}
 	{{ if $ind }} AND {{ else }} ON  {{ end -}}
-	{{ template "maybe_unbase64_lhs" $bound }} = r.{{ $bound.Identifier }}
+	({{ template "maybe_unbase64_lhs" $bound }} = r.{{ $bound.Identifier }}
 	{{- if $bound.LiteralLower }} AND r.{{ $bound.Identifier }} >= {{ $bound.LiteralLower }} AND r.{{ $bound.Identifier }} <= {{ $bound.LiteralUpper }}{{ end }}
+	{{- if $bound.IsNull }} OR r.{{ $bound.Identifier }} IS NULL{{ end }})
 {{- end }}
 {{ end }}
 
@@ -284,8 +285,9 @@ FROM {{ template "temp_name_load" . }} AS l
 JOIN {{ $.Identifier}} AS r
 {{- range $ind, $bound := $.Bounds }}
 	{{ if $ind }} AND {{ else }} ON  {{ end -}}
-	{{ template "maybe_unbase64_lhs" $bound }} = r.{{ $bound.Identifier }}
+	({{ template "maybe_unbase64_lhs" $bound }} = r.{{ $bound.Identifier }}
 	{{- if $bound.LiteralLower }} AND r.{{ $bound.Identifier }} >= {{ $bound.LiteralLower }} AND r.{{ $bound.Identifier }} <= {{ $bound.LiteralUpper }}{{ end }}
+	{{- if $bound.IsNull }} OR r.{{ $bound.Identifier }} IS NULL{{ end }})
 {{- end }}
 {{ end }}
 
@@ -326,8 +328,9 @@ FROM {{$.Identifier}} AS r
 INNER JOIN {{ template "temp_name_store" $ }} AS l
 {{- range $ind, $bound := $.Bounds }}
 	{{ if $ind }} AND {{ else }} ON  {{ end -}}
-	{{ template "maybe_unbase64_lhs" $bound }} = r.{{ $bound.Identifier }}
+	({{ template "maybe_unbase64_lhs" $bound }} = r.{{ $bound.Identifier }}
 	{{- if $bound.LiteralLower }} AND r.{{ $bound.Identifier }} >= {{ $bound.LiteralLower }} AND r.{{ $bound.Identifier }} <= {{ $bound.LiteralUpper }}{{ end }}
+	{{- if $bound.IsNull }} OR r.{{ $bound.Identifier }} IS NULL{{ end }})
 {{- end }};
 
 INSERT INTO {{$.Identifier}} ({{- range $ind, $col := $.Columns }}{{- if $ind }}, {{ end }}{{$col.Identifier}}{{- end }})

--- a/materialize-azure-fabric-warehouse/sqlgen_test.go
+++ b/materialize-azure-fabric-warehouse/sqlgen_test.go
@@ -79,6 +79,37 @@ func TestSQLGeneration(t *testing.T) {
 		snap.WriteString("--- End " + testcase + " ---\n\n")
 	}
 
+	// Re-run the bound-aware templates with bounds that include observed null
+	// keys, to cover the IsNull paths in the templates. Only Keys[0]
+	// (integer) realistically produces an IsNull bound — booleans and
+	// binaries are filtered out by the materialize-sql builder regardless.
+	for _, tpl := range []*template.Template{
+		testTemplates.loadQuery,
+		testTemplates.loadQueryNoFlowDocument,
+		testTemplates.storeMergeQuery,
+	} {
+		tbl := tables[0]
+		var testcase = tbl.Identifier + " " + tpl.Name() + " (with null bounds)"
+
+		snap.WriteString("--- Begin " + testcase + " ---")
+		require.NoError(t, tpl.Execute(snap, &queryParams{
+			Table:             tbl,
+			URIs:              []string{"https://some/file1", "https://some/file2"},
+			StorageAccountKey: "some-storage-account-key",
+			Bounds: []sql.MergeBound{
+				{
+					Column:       tbl.Keys[0],
+					LiteralLower: testDialect.Literal(int64(10)),
+					LiteralUpper: testDialect.Literal(int64(100)),
+					IsNull:       true,
+				},
+				{Column: tbl.Keys[1]}, // boolean key
+				{Column: tbl.Keys[2]}, // binary key
+			},
+		}))
+		snap.WriteString("--- End " + testcase + " ---\n\n")
+	}
+
 	{
 		params := migrateParams{
 			SourceTable: "some_table",

--- a/materialize-bigquery/.snapshots/TestSQLGeneration
+++ b/materialize-bigquery/.snapshots/TestSQLGeneration
@@ -142,9 +142,9 @@ UPDATE path.`to`.checkpoints
 MERGE INTO projectID.dataset.key_value AS l
 USING flow_temp_table_0 AS r
 ON 
-	l.key1 = r.c0 AND l.key1 >= 10 AND l.key1 <= 100
-	AND l.key2 = r.c1
-	AND l.key_binary = r.c2 AND l.key_binary >= 'aGVsbG8K' AND l.key_binary <= 'Z29vZGJ5ZQo='
+	(l.key1 = r.c0 AND l.key1 >= 10 AND l.key1 <= 100)
+	AND (l.key2 = r.c1)
+	AND (l.key_binary = r.c2 AND l.key_binary >= 'aGVsbG8K' AND l.key_binary <= 'Z29vZGJ5ZQo=')
 WHEN MATCHED AND r._flow_delete THEN
 	DELETE
 WHEN MATCHED THEN
@@ -158,9 +158,9 @@ WHEN NOT MATCHED AND NOT r._flow_delete THEN
 SELECT 0, l.flow_document
 	FROM projectID.dataset.key_value AS l
 	JOIN flow_temp_table_0 AS r
-		 ON l.key1 = r.c0 AND l.key1 >= 10 AND l.key1 <= 100
-		 AND l.key2 = r.c1
-		 AND l.key_binary = r.c2 AND l.key_binary >= 'aGVsbG8K' AND l.key_binary <= 'Z29vZGJ5ZQo='
+		 ON (l.key1 = r.c0 AND l.key1 >= 10 AND l.key1 <= 100)
+		 AND (l.key2 = r.c1)
+		 AND (l.key_binary = r.c2 AND l.key_binary >= 'aGVsbG8K' AND l.key_binary <= 'Z29vZGJ5ZQo=')
 --- End projectID.dataset.key_value loadQuery ---
 
 --- Begin projectID.dataset.key_value loadQueryNoFlowDocument ---
@@ -193,5 +193,61 @@ JOIN flow_temp_table_0 AS r
 	 AND l.key2 = r.c1
 	 AND l.key_binary = r.c2 AND l.key_binary >= 'aGVsbG8K' AND l.key_binary <= 'Z29vZGJ5ZQo='
 --- End projectID.dataset.key_value loadQueryNoFlowDocument ---
+
+--- Begin projectID.dataset.key_value storeUpdate (with null bounds) ---
+MERGE INTO projectID.dataset.key_value AS l
+USING flow_temp_table_0 AS r
+ON 
+	(l.key1 = r.c0 AND l.key1 >= 10 AND l.key1 <= 100 OR l.key1 IS NULL)
+	AND (l.key2 = r.c1)
+	AND (l.key_binary = r.c2 OR l.key_binary IS NULL)
+WHEN MATCHED AND r._flow_delete THEN
+	DELETE
+WHEN MATCHED THEN
+	UPDATE SET l.`array` = r.c3, l.binary = r.c4, l.boolean = r.c5, l.field_with_projection = r.c6, l.flow_published_at = r.c7, l.integer = r.c8, l.integerGt64Bit = r.c9, l.integerWithUserDDL = r.c10, l.multiple = r.c11, l.nonAscii_____ = r.c12, l.number = r.c13, l.numberCastToString = r.c14, l.object = r.c15, l.string = r.c16, l.stringInteger = r.c17, l.stringInteger39Chars = r.c18, l.stringInteger66Chars = r.c19, l.stringNumber = r.c20, l.flow_document = r.c21
+WHEN NOT MATCHED AND NOT r._flow_delete THEN
+	INSERT (key1, key2, key_binary, `array`, binary, boolean, field_with_projection, flow_published_at, integer, integerGt64Bit, integerWithUserDDL, multiple, nonAscii_____, number, numberCastToString, object, string, stringInteger, stringInteger39Chars, stringInteger66Chars, stringNumber, flow_document)
+	VALUES (r.c0, r.c1, r.c2, r.c3, r.c4, r.c5, r.c6, r.c7, r.c8, r.c9, r.c10, r.c11, r.c12, r.c13, r.c14, r.c15, r.c16, r.c17, r.c18, r.c19, r.c20, r.c21);
+--- End projectID.dataset.key_value storeUpdate (with null bounds) ---
+
+--- Begin projectID.dataset.key_value loadQuery (with null bounds) ---
+SELECT 0, l.flow_document
+	FROM projectID.dataset.key_value AS l
+	JOIN flow_temp_table_0 AS r
+		 ON (l.key1 = r.c0 AND l.key1 >= 10 AND l.key1 <= 100 OR l.key1 IS NULL)
+		 AND (l.key2 = r.c1)
+		 AND (l.key_binary = r.c2 OR l.key_binary IS NULL)
+--- End projectID.dataset.key_value loadQuery (with null bounds) ---
+
+--- Begin projectID.dataset.key_value loadQueryNoFlowDocument (with null bounds) ---
+SELECT 0,
+TO_JSON(STRUCT(
+	l.key1 AS key1, 
+	l.key2 AS key2, 
+	l.key_binary AS key!binary, 
+	l.`array` AS array, 
+	l.binary AS binary, 
+	l.boolean AS boolean, 
+	l.field_with_projection AS field_with_projection, 
+	l.integer AS integer, 
+	l.integerGt64Bit AS integerGt64Bit, 
+	l.integerWithUserDDL AS integerWithUserDDL, 
+	l.multiple AS multiple, 
+	l.nonAscii_____ AS nonAsciiκόσμε, 
+	l.number AS number, 
+	CAST(l.numberCastToString AS STRING) AS numberCastToString, 
+	l.object AS object, 
+	l.string AS string, 
+	CAST(l.stringInteger AS STRING) AS stringInteger, 
+	CAST(l.stringInteger39Chars AS STRING) AS stringInteger39Chars, 
+	CAST(l.stringInteger66Chars AS STRING) AS stringInteger66Chars, 
+	CAST(l.stringNumber AS STRING) AS stringNumber
+)) as flow_document
+FROM projectID.dataset.key_value AS l
+JOIN flow_temp_table_0 AS r
+	 ON l.key1 = r.c0 AND (l.key1 >= 10 AND l.key1 <= 100 OR l.key1 IS NULL)
+	 AND l.key2 = r.c1
+	 AND l.key_binary = r.c2 AND l.key_binary IS NULL
+--- End projectID.dataset.key_value loadQueryNoFlowDocument (with null bounds) ---
 
 

--- a/materialize-bigquery/sqlgen.go
+++ b/materialize-bigquery/sqlgen.go
@@ -242,8 +242,9 @@ SELECT {{ $.Binding }}, l.{{$.Document.Identifier}}
 	JOIN {{ template "tempTableName" . }} AS r
 	{{- range $ind, $bound := $.Bounds }}
 		{{ if $ind }} AND {{ else }} ON {{ end -}}
-		l.{{ $bound.Identifier }} = r.c{{$ind}}
+		(l.{{ $bound.Identifier }} = r.c{{$ind}}
 		{{- if $bound.LiteralLower }} AND l.{{ $bound.Identifier }} >= {{ $bound.LiteralLower }} AND l.{{ $bound.Identifier }} <= {{ $bound.LiteralUpper }}{{ end }}
+		{{- if $bound.IsNull }} OR l.{{ $bound.Identifier }} IS NULL{{ end }})
 	{{- end }}
 {{- else -}}
 (SELECT -1, CAST(NULL AS {{ $.ObjectType }}) LIMIT 0) as nodoc
@@ -280,7 +281,7 @@ JOIN {{ template "tempTableName" . }} AS r
 {{- range $ind, $bound := $.Bounds }}
 	{{ if $ind }} AND {{ else }} ON {{ end -}}
 	l.{{ $bound.Identifier }} = r.c{{$ind}}
-	{{- if $bound.LiteralLower }} AND l.{{ $bound.Identifier }} >= {{ $bound.LiteralLower }} AND l.{{ $bound.Identifier }} <= {{ $bound.LiteralUpper }}{{ end }}
+	{{- if and $bound.LiteralLower $bound.IsNull }} AND (l.{{ $bound.Identifier }} >= {{ $bound.LiteralLower }} AND l.{{ $bound.Identifier }} <= {{ $bound.LiteralUpper }} OR l.{{ $bound.Identifier }} IS NULL){{ else if $bound.LiteralLower }} AND l.{{ $bound.Identifier }} >= {{ $bound.LiteralLower }} AND l.{{ $bound.Identifier }} <= {{ $bound.LiteralUpper }}{{ else if $bound.IsNull }} AND l.{{ $bound.Identifier }} IS NULL{{ end }}
 {{- end }}
 {{ end }}
 
@@ -306,8 +307,9 @@ MERGE INTO {{ $.Identifier }} AS l
 USING {{ template "tempTableName" . }} AS r
 ON {{ range $ind, $bound := $.Bounds }}
 	{{ if $ind -}} AND {{end -}}
-	l.{{$bound.Identifier}} = r.c{{$ind}}
+	(l.{{$bound.Identifier}} = r.c{{$ind}}
 	{{- if $bound.LiteralLower }} AND l.{{ $bound.Identifier }} >= {{ $bound.LiteralLower }} AND l.{{ $bound.Identifier }} <= {{ $bound.LiteralUpper }}{{ end }}
+	{{- if $bound.IsNull }} OR l.{{ $bound.Identifier }} IS NULL{{ end }})
 {{- end}}
 WHEN MATCHED AND r._flow_delete THEN
 	DELETE

--- a/materialize-bigquery/sqlgen_test.go
+++ b/materialize-bigquery/sqlgen_test.go
@@ -67,5 +67,46 @@ func TestSQLGeneration(t *testing.T) {
 		snap.WriteString("--- End " + testcase + " ---\n\n")
 	}
 
+	// Re-run the bound-aware templates with bounds that include observed null
+	// keys, to cover the IsNull paths in the templates.
+	for _, tpl := range []*template.Template{
+		testTemplates.storeUpdate,
+		testTemplates.loadQuery,
+		testTemplates.loadQueryNoFlowDocument,
+	} {
+		tbl := tables[0]
+		var testcase = tbl.Identifier + " " + tpl.Name() + " (with null bounds)"
+
+		bounds := []sql.MergeBound{
+			{
+				// Range bound and null observed: must produce the
+				// parenthesized "(range OR IS NULL)" predicate.
+				Column:       tbl.Keys[0],
+				LiteralLower: testDialect.Literal(int64(10)),
+				LiteralUpper: testDialect.Literal(int64(100)),
+				IsNull:       true,
+			},
+			{
+				// Boolean key: builder always emits an empty MergeBound for
+				// booleans, regardless of observed values.
+				Column: tbl.Keys[1],
+			},
+			{
+				// Null observed but no literal bounds: emit a bare IS NULL.
+				Column: tbl.Keys[2],
+				IsNull: true,
+			},
+		}
+
+		tf := queryParams{
+			Table:  tbl,
+			Bounds: bounds,
+		}
+
+		snap.WriteString("--- Begin " + testcase + " ---\n")
+		require.NoError(t, tpl.Execute(snap, &tf))
+		snap.WriteString("--- End " + testcase + " ---\n\n")
+	}
+
 	cupaloy.SnapshotT(t, snap.String())
 }

--- a/materialize-databricks/.snapshots/TestSQLGeneration
+++ b/materialize-databricks/.snapshots/TestSQLGeneration
@@ -62,9 +62,9 @@ SELECT 0, `a-schema`.key_value.flow_document
 			FROM json.`file2`
 		)
 	) AS r
-	ON `a-schema`.key_value.key1 = r.key1 AND `a-schema`.key_value.key1 >= 10 AND `a-schema`.key_value.key1 <= 100
-	AND `a-schema`.key_value.key2 = r.key2
-	AND `a-schema`.key_value.`key!binary` = r.`key!binary` AND `a-schema`.key_value.`key!binary` >= 'aGVsbG8K' AND `a-schema`.key_value.`key!binary` <= 'Z29vZGJ5ZQo='
+	ON (`a-schema`.key_value.key1 = r.key1 AND `a-schema`.key_value.key1 >= 10 AND `a-schema`.key_value.key1 <= 100)
+	AND (`a-schema`.key_value.key2 = r.key2)
+	AND (`a-schema`.key_value.`key!binary` = r.`key!binary` AND `a-schema`.key_value.`key!binary` >= 'aGVsbG8K' AND `a-schema`.key_value.`key!binary` <= 'Z29vZGJ5ZQo=')
 --- End `a-schema`.key_value loadQuery ---
 
 --- Begin `a-schema`.key_value loadQueryNoFlowDocument ---
@@ -104,9 +104,9 @@ JOIN (
 		FROM json.`file2`
 	)
 ) AS r
-ON `a-schema`.key_value.key1 = r.key1 AND `a-schema`.key_value.key1 >= 10 AND `a-schema`.key_value.key1 <= 100
-AND `a-schema`.key_value.key2 = r.key2
-AND `a-schema`.key_value.`key!binary` = r.`key!binary` AND `a-schema`.key_value.`key!binary` >= 'aGVsbG8K' AND `a-schema`.key_value.`key!binary` <= 'Z29vZGJ5ZQo='
+ON (`a-schema`.key_value.key1 = r.key1 AND `a-schema`.key_value.key1 >= 10 AND `a-schema`.key_value.key1 <= 100)
+AND (`a-schema`.key_value.key2 = r.key2)
+AND (`a-schema`.key_value.`key!binary` = r.`key!binary` AND `a-schema`.key_value.`key!binary` >= 'aGVsbG8K' AND `a-schema`.key_value.`key!binary` <= 'Z29vZGJ5ZQo=')
 --- End `a-schema`.key_value loadQueryNoFlowDocument ---
 
 --- Begin `a-schema`.key_value mergeInto ---
@@ -124,9 +124,9 @@ AND `a-schema`.key_value.`key!binary` = r.`key!binary` AND `a-schema`.key_value.
 		)
 	) AS r
   ON 
-    l.key1 = r.key1 AND l.key1 >= 10 AND l.key1 <= 100
-    AND l.key2 = r.key2
-    AND l.`key!binary` = r.`key!binary` AND l.`key!binary` >= 'aGVsbG8K' AND l.`key!binary` <= 'Z29vZGJ5ZQo='
+    (l.key1 = r.key1 AND l.key1 >= 10 AND l.key1 <= 100)
+    AND (l.key2 = r.key2)
+    AND (l.`key!binary` = r.`key!binary` AND l.`key!binary` >= 'aGVsbG8K' AND l.`key!binary` <= 'Z29vZGJ5ZQo=')
 	WHEN MATCHED AND r._flow_delete THEN
 		DELETE
 	WHEN MATCHED THEN
@@ -135,6 +135,95 @@ AND `a-schema`.key_value.`key!binary` = r.`key!binary` AND `a-schema`.key_value.
 		INSERT (key1, key2, `key!binary`, array, binary, boolean, field_with_projection, flow_published_at, integer, `integerGt64Bit`, `integerWithUserDDL`, multiple, `nonAsciiκόσμε`, number, `numberCastToString`, object, string, `stringInteger`, `stringInteger39Chars`, `stringInteger66Chars`, `stringNumber`, flow_document)
 		VALUES (r.key1, r.key2, r.`key!binary`, r.array, r.binary, r.boolean, r.field_with_projection, r.flow_published_at, r.integer, r.`integerGt64Bit`, r.`integerWithUserDDL`, r.multiple, r.`nonAsciiκόσμε`, r.number, r.`numberCastToString`, r.object, r.string, r.`stringInteger`, r.`stringInteger39Chars`, r.`stringInteger66Chars`, r.`stringNumber`, r.flow_document);
 --- End `a-schema`.key_value mergeInto ---
+
+--- Begin `a-schema`.key_value loadQuery (with null bounds) ---
+SELECT 0, `a-schema`.key_value.flow_document
+	FROM `a-schema`.key_value
+	JOIN (
+		(
+			SELECT
+			key1::LONG, key2::BOOLEAN, unbase64(`key!binary`)::BINARY as `key!binary`
+			FROM json.`file1`
+		)
+		 UNION ALL (
+			SELECT
+			key1::LONG, key2::BOOLEAN, unbase64(`key!binary`)::BINARY as `key!binary`
+			FROM json.`file2`
+		)
+	) AS r
+	ON (`a-schema`.key_value.key1 = r.key1 AND `a-schema`.key_value.key1 >= 10 AND `a-schema`.key_value.key1 <= 100 OR `a-schema`.key_value.key1 IS NULL)
+	AND (`a-schema`.key_value.key2 = r.key2)
+	AND (`a-schema`.key_value.`key!binary` = r.`key!binary` OR `a-schema`.key_value.`key!binary` IS NULL)
+--- End `a-schema`.key_value loadQuery (with null bounds) ---
+
+--- Begin `a-schema`.key_value loadQueryNoFlowDocument (with null bounds) ---
+SELECT 0, 
+to_json(struct(
+	`a-schema`.key_value.key1 AS key1,
+	`a-schema`.key_value.key2 AS key2,
+	`a-schema`.key_value.`key!binary` AS key!binary,
+	`a-schema`.key_value.array AS array,
+	`a-schema`.key_value.binary AS binary,
+	`a-schema`.key_value.boolean AS boolean,
+	`a-schema`.key_value.field_with_projection AS field_with_projection,
+	`a-schema`.key_value.integer AS integer,
+	`a-schema`.key_value.`integerGt64Bit` AS integerGt64Bit,
+	`a-schema`.key_value.`integerWithUserDDL` AS integerWithUserDDL,
+	`a-schema`.key_value.multiple AS multiple,
+	`a-schema`.key_value.`nonAsciiκόσμε` AS nonAsciiκόσμε,
+	`a-schema`.key_value.number AS number,
+	CAST(`a-schema`.key_value.`numberCastToString` AS STRING) AS numberCastToString,
+	`a-schema`.key_value.object AS object,
+	`a-schema`.key_value.string AS string,
+	CAST(`a-schema`.key_value.`stringInteger` AS STRING) AS stringInteger,
+	CAST(`a-schema`.key_value.`stringInteger39Chars` AS STRING) AS stringInteger39Chars,
+	CAST(`a-schema`.key_value.`stringInteger66Chars` AS STRING) AS stringInteger66Chars,
+	CAST(`a-schema`.key_value.`stringNumber` AS STRING) AS stringNumber
+)) as flow_document
+FROM `a-schema`.key_value
+JOIN (
+	(
+		SELECT
+		key1::LONG, key2::BOOLEAN, unbase64(`key!binary`)::BINARY as `key!binary`
+		FROM json.`file1`
+	)
+	 UNION ALL (
+		SELECT
+		key1::LONG, key2::BOOLEAN, unbase64(`key!binary`)::BINARY as `key!binary`
+		FROM json.`file2`
+	)
+) AS r
+ON (`a-schema`.key_value.key1 = r.key1 AND `a-schema`.key_value.key1 >= 10 AND `a-schema`.key_value.key1 <= 100 OR `a-schema`.key_value.key1 IS NULL)
+AND (`a-schema`.key_value.key2 = r.key2)
+AND (`a-schema`.key_value.`key!binary` = r.`key!binary` OR `a-schema`.key_value.`key!binary` IS NULL)
+--- End `a-schema`.key_value loadQueryNoFlowDocument (with null bounds) ---
+
+--- Begin `a-schema`.key_value mergeInto (with null bounds) ---
+	MERGE INTO `a-schema`.key_value AS l
+	USING (
+		(
+			SELECT
+			key1::LONG, key2::BOOLEAN, unbase64(`key!binary`)::BINARY as `key!binary`, array::STRING, unbase64(binary)::BINARY as binary, boolean::BOOLEAN, field_with_projection::STRING, flow_published_at::TIMESTAMP, integer::LONG, `integerGt64Bit`::NUMERIC(38,0), `integerWithUserDDL`::DECIMAL(20), multiple::STRING, `nonAsciiκόσμε`::STRING, number::DOUBLE, `numberCastToString`::STRING, object::STRING, string::STRING, `stringInteger`::NUMERIC(38,0), `stringInteger39Chars`::STRING, `stringInteger66Chars`::STRING, `stringNumber`::DOUBLE, flow_document::STRING, _flow_delete::BOOLEAN
+			FROM json.`file1`
+		)
+		 UNION ALL (
+			SELECT
+			key1::LONG, key2::BOOLEAN, unbase64(`key!binary`)::BINARY as `key!binary`, array::STRING, unbase64(binary)::BINARY as binary, boolean::BOOLEAN, field_with_projection::STRING, flow_published_at::TIMESTAMP, integer::LONG, `integerGt64Bit`::NUMERIC(38,0), `integerWithUserDDL`::DECIMAL(20), multiple::STRING, `nonAsciiκόσμε`::STRING, number::DOUBLE, `numberCastToString`::STRING, object::STRING, string::STRING, `stringInteger`::NUMERIC(38,0), `stringInteger39Chars`::STRING, `stringInteger66Chars`::STRING, `stringNumber`::DOUBLE, flow_document::STRING, _flow_delete::BOOLEAN
+			FROM json.`file2`
+		)
+	) AS r
+  ON 
+    (l.key1 = r.key1 AND l.key1 >= 10 AND l.key1 <= 100 OR l.key1 IS NULL)
+    AND (l.key2 = r.key2)
+    AND (l.`key!binary` = r.`key!binary` OR l.`key!binary` IS NULL)
+	WHEN MATCHED AND r._flow_delete THEN
+		DELETE
+	WHEN MATCHED THEN
+		UPDATE SET l.array = r.array, l.binary = r.binary, l.boolean = r.boolean, l.field_with_projection = r.field_with_projection, l.flow_published_at = r.flow_published_at, l.integer = r.integer, l.`integerGt64Bit` = r.`integerGt64Bit`, l.`integerWithUserDDL` = r.`integerWithUserDDL`, l.multiple = r.multiple, l.`nonAsciiκόσμε` = r.`nonAsciiκόσμε`, l.number = r.number, l.`numberCastToString` = r.`numberCastToString`, l.object = r.object, l.string = r.string, l.`stringInteger` = r.`stringInteger`, l.`stringInteger39Chars` = r.`stringInteger39Chars`, l.`stringInteger66Chars` = r.`stringInteger66Chars`, l.`stringNumber` = r.`stringNumber`, l.flow_document = r.flow_document
+	WHEN NOT MATCHED AND NOT r._flow_delete THEN
+		INSERT (key1, key2, `key!binary`, array, binary, boolean, field_with_projection, flow_published_at, integer, `integerGt64Bit`, `integerWithUserDDL`, multiple, `nonAsciiκόσμε`, number, `numberCastToString`, object, string, `stringInteger`, `stringInteger39Chars`, `stringInteger66Chars`, `stringNumber`, flow_document)
+		VALUES (r.key1, r.key2, r.`key!binary`, r.array, r.binary, r.boolean, r.field_with_projection, r.flow_published_at, r.integer, r.`integerGt64Bit`, r.`integerWithUserDDL`, r.multiple, r.`nonAsciiκόσμε`, r.number, r.`numberCastToString`, r.object, r.string, r.`stringInteger`, r.`stringInteger39Chars`, r.`stringInteger66Chars`, r.`stringNumber`, r.flow_document);
+--- End `a-schema`.key_value mergeInto (with null bounds) ---
 
 --- Begin `a-schema`.key_value copyIntoDirect ---
 	COPY INTO `a-schema`.key_value FROM (

--- a/materialize-databricks/sqlgen.go
+++ b/materialize-databricks/sqlgen.go
@@ -186,8 +186,9 @@ SELECT {{ $.Table.Binding }}, {{ $.Table.Identifier }}.{{ $.Table.Document.Ident
 	) AS r
 	{{- range $ind, $bound := $.Bounds }}
 	{{ if $ind }}AND {{ else }}ON {{ end -}}
-	{{ $.Table.Identifier }}.{{ $bound.Identifier }} = r.{{ $bound.Identifier }}
+	({{ $.Table.Identifier }}.{{ $bound.Identifier }} = r.{{ $bound.Identifier }}
 	{{- if $bound.LiteralLower }} AND {{ $.Table.Identifier }}.{{ $bound.Identifier }} >= {{ $bound.LiteralLower }} AND {{ $.Table.Identifier }}.{{ $bound.Identifier }} <= {{ $bound.LiteralUpper }}{{ end }}
+	{{- if $bound.IsNull }} OR {{ $.Table.Identifier }}.{{ $bound.Identifier }} IS NULL{{ end }})
 	{{- end }}
 {{ else -}}
 SELECT -1, ""
@@ -220,8 +221,9 @@ JOIN (
 ) AS r
 {{- range $ind, $bound := $.Bounds }}
 {{ if $ind }}AND {{ else }}ON {{ end -}}
-{{ $.Table.Identifier }}.{{ $bound.Identifier }} = r.{{ $bound.Identifier }}
+({{ $.Table.Identifier }}.{{ $bound.Identifier }} = r.{{ $bound.Identifier }}
 {{- if $bound.LiteralLower }} AND {{ $.Table.Identifier }}.{{ $bound.Identifier }} >= {{ $bound.LiteralLower }} AND {{ $.Table.Identifier }}.{{ $bound.Identifier }} <= {{ $bound.LiteralUpper }}{{ end }}
+{{- if $bound.IsNull }} OR {{ $.Table.Identifier }}.{{ $bound.Identifier }} IS NULL{{ end }})
 {{- end }}
 {{ end }}
 
@@ -286,8 +288,9 @@ JOIN (
 	) AS r
   ON {{ range $ind, $bound := $.Bounds }}
     {{ if $ind -}} AND {{ end -}}
-    l.{{ $bound.Identifier }} = r.{{ $bound.Identifier }}
+    (l.{{ $bound.Identifier }} = r.{{ $bound.Identifier }}
     {{- if $bound.LiteralLower }} AND l.{{ $bound.Identifier }} >= {{ $bound.LiteralLower }} AND l.{{ $bound.Identifier }} <= {{ $bound.LiteralUpper }}{{ end }}
+    {{- if $bound.IsNull }} OR l.{{ $bound.Identifier }} IS NULL{{ end }})
   {{- end }}
 	WHEN MATCHED AND r._flow_delete THEN
 		DELETE

--- a/materialize-databricks/sqlgen_test.go
+++ b/materialize-databricks/sqlgen_test.go
@@ -66,6 +66,44 @@ func TestSQLGeneration(t *testing.T) {
 		snap.WriteString("--- End " + testcase + " ---\n\n")
 	}
 
+	// Re-run the bound-aware templates with bounds that include observed null
+	// keys, to cover the IsNull paths in the templates.
+	for _, tpl := range []*template.Template{
+		testTemplates.loadQuery,
+		testTemplates.loadQueryNoFlowDocument,
+		testTemplates.mergeInto,
+	} {
+		tbl := tables[0]
+		var testcase = tbl.Identifier + " " + tpl.Name() + " (with null bounds)"
+
+		bounds := []sql.MergeBound{
+			{
+				Column:       tbl.Keys[0],
+				LiteralLower: testDialect.Literal(int64(10)),
+				LiteralUpper: testDialect.Literal(int64(100)),
+				IsNull:       true,
+			},
+			{
+				Column: tbl.Keys[1],
+			},
+			{
+				Column: tbl.Keys[2],
+				IsNull: true,
+			},
+		}
+
+		tf := tableWithFiles{
+			Table:       &tbl,
+			StagingPath: "test-staging-path",
+			Files:       []string{"file1", "file2"},
+			Bounds:      bounds,
+		}
+
+		snap.WriteString("--- Begin " + testcase + " ---")
+		require.NoError(t, tpl.Execute(snap, &tf))
+		snap.WriteString("--- End " + testcase + " ---\n\n")
+	}
+
 	for _, tpl := range []*template.Template{
 		testTemplates.copyIntoDirect,
 	} {

--- a/materialize-iceberg/.snapshots/TestTemplates
+++ b/materialize-iceberg/.snapshots/TestTemplates
@@ -2,22 +2,43 @@
 SELECT 0, l.`flow_document`
 FROM `estuary`.`foo`.`bar` AS l
 JOIN load_view_0 AS r
-	 ON  l.`first-key` = r.`first-key` AND l.`first-key` >= 1 AND l.`first-key` <= 10
-	 AND l.`second-key` = UNBASE64(r.`second-key`)
-	 AND l.`third-key` = r.`third-key` AND l.`third-key` >= 'aaaSomeString' AND l.`third-key` <= 'zzzSomeString'
+	 ON  (l.`first-key` = r.`first-key` AND l.`first-key` >= 1 AND l.`first-key` <= 10)
+	 AND (l.`second-key` = UNBASE64(r.`second-key`))
+	 AND (l.`third-key` = r.`third-key` AND l.`third-key` >= 'aaaSomeString' AND l.`third-key` <= 'zzzSomeString')
 --- End load query ---
 
 --- Begin merge query ---
 MERGE INTO `estuary`.`foo`.`bar` AS l
 USING merge_view_0 AS r
 ON 
-	l.`first-key` = r.`first-key` AND l.`first-key` >= 1 AND l.`first-key` <= 10
-	AND l.`second-key` = UNBASE64(r.`second-key`)
-	AND l.`third-key` = r.`third-key` AND l.`third-key` >= 'aaaSomeString' AND l.`third-key` <= 'zzzSomeString'
+	(l.`first-key` = r.`first-key` AND l.`first-key` >= 1 AND l.`first-key` <= 10)
+	AND (l.`second-key` = UNBASE64(r.`second-key`))
+	AND (l.`third-key` = r.`third-key` AND l.`third-key` >= 'aaaSomeString' AND l.`third-key` <= 'zzzSomeString')
 WHEN MATCHED AND r.`flow_document` = '"delete"' THEN DELETE
 WHEN MATCHED THEN UPDATE SET l.`first-key` = r.`first-key`, l.`second-key` = UNBASE64(r.`second-key`), l.`third-key` = r.`third-key`, l.`first-val` = r.`first-val`, l.`second-val` = r.`second-val`, l.`third-val` = UNBASE64(r.`third-val`), l.`fourth-val` = r.`fourth-val`, l.`flow_document` = r.`flow_document`
 WHEN NOT MATCHED AND r.`flow_document` != '"delete"' THEN INSERT (`first-key`, `second-key`, `third-key`, `first-val`, `second-val`, `third-val`, `fourth-val`, `flow_document`) VALUES (r.`first-key`, UNBASE64(r.`second-key`), r.`third-key`, r.`first-val`, r.`second-val`, UNBASE64(r.`third-val`), r.`fourth-val`, r.`flow_document`)
 --- End merge query ---
+
+--- Begin load query (with null bounds) ---
+SELECT 0, l.`flow_document`
+FROM `estuary`.`foo`.`bar` AS l
+JOIN load_view_0 AS r
+	 ON  (l.`first-key` = r.`first-key` AND l.`first-key` >= 1 AND l.`first-key` <= 10 OR l.`first-key` IS NULL)
+	 AND (l.`second-key` = UNBASE64(r.`second-key`))
+	 AND (l.`third-key` = r.`third-key` OR l.`third-key` IS NULL)
+--- End load query (with null bounds) ---
+
+--- Begin merge query (with null bounds) ---
+MERGE INTO `estuary`.`foo`.`bar` AS l
+USING merge_view_0 AS r
+ON 
+	(l.`first-key` = r.`first-key` AND l.`first-key` >= 1 AND l.`first-key` <= 10 OR l.`first-key` IS NULL)
+	AND (l.`second-key` = UNBASE64(r.`second-key`))
+	AND (l.`third-key` = r.`third-key` OR l.`third-key` IS NULL)
+WHEN MATCHED AND r.`flow_document` = '"delete"' THEN DELETE
+WHEN MATCHED THEN UPDATE SET l.`first-key` = r.`first-key`, l.`second-key` = UNBASE64(r.`second-key`), l.`third-key` = r.`third-key`, l.`first-val` = r.`first-val`, l.`second-val` = r.`second-val`, l.`third-val` = UNBASE64(r.`third-val`), l.`fourth-val` = r.`fourth-val`, l.`flow_document` = r.`flow_document`
+WHEN NOT MATCHED AND r.`flow_document` != '"delete"' THEN INSERT (`first-key`, `second-key`, `third-key`, `first-val`, `second-val`, `third-val`, `fourth-val`, `flow_document`) VALUES (r.`first-key`, UNBASE64(r.`second-key`), r.`third-key`, r.`first-val`, r.`second-val`, UNBASE64(r.`third-val`), r.`fourth-val`, r.`flow_document`)
+--- End merge query (with null bounds) ---
 
 --- Begin migrate query ---
 UPDATE `estuary`.`some`.`table`

--- a/materialize-iceberg/merge_bounds.go
+++ b/materialize-iceberg/merge_bounds.go
@@ -16,14 +16,19 @@ type mergeBound struct {
 	boilerplate.MappedProjection[mapped]
 	LiteralLower string
 	LiteralUpper string
+	// IsNull indicates that at least one observed key value for this column
+	// was nil during the transaction; the merge predicate must include the
+	// NULL key rows alongside any range bounds.
+	IsNull bool
 }
 
 type mergeBoundsBuilder struct {
 	keys      []boilerplate.MappedProjection[mapped]
 	literaler func(any) string
 
-	lower []any
-	upper []any
+	lower  []any
+	upper  []any
+	isNull []bool
 }
 
 func newMergeBoundsBuilder(keys []boilerplate.MappedProjection[mapped]) *mergeBoundsBuilder {
@@ -35,11 +40,21 @@ func newMergeBoundsBuilder(keys []boilerplate.MappedProjection[mapped]) *mergeBo
 
 func (b *mergeBoundsBuilder) nextKey(key []any) {
 	if b.lower == nil {
-		b.lower = append([]any(nil), key...)
-		b.upper = append([]any(nil), key...)
+		b.lower = make([]any, len(b.keys))
+		b.upper = make([]any, len(b.keys))
+		b.isNull = make([]bool, len(b.keys))
 	}
 
 	for idx, k := range key {
+		if k == nil {
+			b.isNull[idx] = true
+			continue
+		}
+		if b.lower[idx] == nil {
+			b.lower[idx] = k
+			b.upper[idx] = k
+			continue
+		}
 		b.lower[idx] = minKey(b.lower[idx], k)
 		b.upper[idx] = maxKey(b.upper[idx], k)
 	}
@@ -82,23 +97,29 @@ func maxKey(k1 any, k2 any) any {
 }
 
 func (b *mergeBoundsBuilder) build() []mergeBound {
-	conditions := make([]mergeBound, len(b.lower))
+	conditions := make([]mergeBound, len(b.keys))
 
 	for idx, p := range b.keys {
 		conditions[idx] = mergeBound{MappedProjection: p}
 
 		switch p.Mapped.type_.(type) {
 		case iceberg.BooleanType, iceberg.BinaryType:
+			// Type-based skip mirrors the upstream materialize-sql behavior:
+			// these key types are intentionally never bounded, even when null.
 			continue
 		}
 
-		conditions[idx].LiteralLower = b.literaler(b.lower[idx])
-		conditions[idx].LiteralUpper = b.literaler(b.upper[idx])
+		conditions[idx].IsNull = b.isNull[idx]
+		if b.lower[idx] != nil {
+			conditions[idx].LiteralLower = b.literaler(b.lower[idx])
+			conditions[idx].LiteralUpper = b.literaler(b.upper[idx])
+		}
 	}
 
 	// Reset for tracking the next transaction.
 	b.lower = nil
 	b.upper = nil
+	b.isNull = nil
 
 	return conditions
 }

--- a/materialize-iceberg/sqlgen.go
+++ b/materialize-iceberg/sqlgen.go
@@ -77,8 +77,9 @@ FROM {{ TableFQN $.Mapped.ResourcePath }} AS l
 JOIN load_view_{{ $.Idx }} AS r
 {{- range $ind, $bound := $.Bounds }}
 	{{ if $ind }} AND {{ else }} ON  {{ end -}}
-	l.{{ QuoteIdentifier $bound.Mapped.Name }} = {{ template "maybe_unbase64_rhs" $bound }}
+	(l.{{ QuoteIdentifier $bound.Mapped.Name }} = {{ template "maybe_unbase64_rhs" $bound }}
 	{{- if $bound.LiteralLower }} AND l.{{ QuoteIdentifier $bound.Mapped.Name }} >= {{ $bound.LiteralLower }} AND l.{{ QuoteIdentifier $bound.Mapped.Name }} <= {{ $bound.LiteralUpper }}{{ end }}
+	{{- if $bound.IsNull }} OR l.{{ QuoteIdentifier $bound.Mapped.Name }} IS NULL{{ end }})
 {{- end }}
 {{ end }}
 
@@ -87,8 +88,9 @@ MERGE INTO {{ TableFQN $.Mapped.ResourcePath }} AS l
 USING merge_view_{{ $.Idx }} AS r
 ON {{ range $ind, $bound := $.Bounds }}
 	{{ if $ind -}} AND {{end -}}
-	l.{{ QuoteIdentifier $bound.Mapped.Name }} = {{ template "maybe_unbase64_rhs" $bound }}
+	(l.{{ QuoteIdentifier $bound.Mapped.Name }} = {{ template "maybe_unbase64_rhs" $bound }}
 	{{- if $bound.LiteralLower }} AND l.{{ QuoteIdentifier $bound.Mapped.Name }} >= {{ $bound.LiteralLower }} AND l.{{ QuoteIdentifier $bound.Mapped.Name }} <= {{ $bound.LiteralUpper }}{{ end }}
+	{{- if $bound.IsNull }} OR l.{{ QuoteIdentifier $bound.Mapped.Name }} IS NULL{{ end }})
 {{- end}}
 WHEN MATCHED AND r.{{ QuoteIdentifier $.Mapped.Document.Mapped.Name }} = '"delete"' THEN DELETE
 WHEN MATCHED THEN UPDATE SET {{ range $ind, $proj := $.Mapped.SelectedProjections }}

--- a/materialize-iceberg/sqlgen_test.go
+++ b/materialize-iceberg/sqlgen_test.go
@@ -99,6 +99,40 @@ func TestTemplates(t *testing.T) {
 
 	snap.WriteString("\n\n")
 
+	// Re-run load and merge with bounds that include observed null keys, to
+	// cover the IsNull paths in the templates.
+	nullBoundsInput := input
+	nullBoundsInput.Bounds = []mergeBound{
+		{
+			// Range bound and null observed: parenthesized "(range OR IS NULL)".
+			MappedProjection: keys[0],
+			LiteralLower:     "1",
+			LiteralUpper:     "10",
+			IsNull:           true,
+		},
+		{
+			// Binary key: builder skips bounds for binary regardless.
+			MappedProjection: keys[1],
+		},
+		{
+			// Null observed but no literal bounds: bare IS NULL.
+			MappedProjection: keys[2],
+			IsNull:           true,
+		},
+	}
+
+	snap.WriteString("--- Begin load query (with null bounds) ---\n")
+	require.NoError(t, templates.loadQuery.Execute(&snap, nullBoundsInput))
+	snap.WriteString("--- End load query (with null bounds) ---")
+
+	snap.WriteString("\n\n")
+
+	snap.WriteString("--- Begin merge query (with null bounds) ---\n")
+	require.NoError(t, templates.mergeQuery.Execute(&snap, nullBoundsInput))
+	snap.WriteString("--- End merge query (with null bounds) ---")
+
+	snap.WriteString("\n\n")
+
 	snap.WriteString("--- Begin migrate query ---\n")
 	require.NoError(t, templates.migrateQuery.Execute(&snap, mInput))
 	snap.WriteString("--- End migrate query ---")

--- a/materialize-motherduck/.snapshots/TestSQLGeneration
+++ b/materialize-motherduck/.snapshots/TestSQLGeneration
@@ -57,9 +57,9 @@ JOIN read_json(
 		"key!binary": 'VARCHAR NOT NULL'
 	}
 ) AS r
-	 ON  l.key1 = r.key1 AND l.key1 >= 10 AND l.key1 <= 100
-	 AND l.key2 = r.key2
-	 AND l."key!binary" = r."key!binary" AND l."key!binary" >= 'aGVsbG8K' AND l."key!binary" <= 'Z29vZGJ5ZQo='
+	 ON  (l.key1 = r.key1 AND l.key1 >= 10 AND l.key1 <= 100)
+	 AND (l.key2 = r.key2)
+	 AND (l."key!binary" = r."key!binary" AND l."key!binary" >= 'aGVsbG8K' AND l."key!binary" <= 'Z29vZGJ5ZQo=')
 --- End db."a-schema".key_value loadQuery ---
 
 --- Begin db."a-schema".key_value loadQueryNoFlowDocument ---                                                                                                                             
@@ -97,9 +97,9 @@ JOIN read_json(
                "key!binary": 'VARCHAR NOT NULL'                                                                                                                                                  
        }                                                                                                                                                           
 ) AS r                                                                                                                              
-        ON  l.key1 = r.key1 AND l.key1 >= 10 AND l.key1 <= 100                                                                                                                              
-        AND l.key2 = r.key2                                                                                                                              
-        AND l."key!binary" = r."key!binary" AND l."key!binary" >= 'aGVsbG8K' AND l."key!binary" <= 'Z29vZGJ5ZQo='                                                                                                                                                         
+        ON  (l.key1 = r.key1 AND l.key1 >= 10 AND l.key1 <= 100)                                                                                                                              
+        AND (l.key2 = r.key2)                                                                                                                              
+        AND (l."key!binary" = r."key!binary" AND l."key!binary" >= 'aGVsbG8K' AND l."key!binary" <= 'Z29vZGJ5ZQo=')                                                                                                                                                         
 --- End db."a-schema".key_value loadQueryNoFlowDocument ---
 
 --- Begin db."a-schema".key_value storeDeleteQuery ---
@@ -134,9 +134,9 @@ USING read_json(
 		flow_document: 'JSON NOT NULL'
 	}
 ) AS r
-	 WHERE l.key1 = r.key1 AND l.key1 >= 10 AND l.key1 <= 100
-	 AND l.key2 = r.key2
-	 AND l."key!binary" = r."key!binary" AND l."key!binary" >= 'aGVsbG8K' AND l."key!binary" <= 'Z29vZGJ5ZQo=';
+	 WHERE (l.key1 = r.key1 AND l.key1 >= 10 AND l.key1 <= 100)
+	 AND (l.key2 = r.key2)
+	 AND (l."key!binary" = r."key!binary" AND l."key!binary" >= 'aGVsbG8K' AND l."key!binary" <= 'Z29vZGJ5ZQo=');
 --- End db."a-schema".key_value storeDeleteQuery ---
 
 --- Begin db."a-schema".key_value storeQuery ---
@@ -173,6 +173,101 @@ SELECT * EXCLUDE (_flow_delete) FROM read_json(
 	}
 ) WHERE NOT _flow_delete;
 --- End db."a-schema".key_value storeQuery ---
+
+--- Begin db."a-schema".key_value loadQuery (with null bounds) ---
+SELECT 0 AS binding, l.flow_document AS doc
+FROM db."a-schema".key_value AS l
+JOIN read_json(
+	['s3://bucket/file1', 's3://bucket/file2'],
+	format='newline_delimited',
+	compression='gzip',
+	columns={
+		key1: 'BIGINT NOT NULL',
+		key2: 'BOOLEAN NOT NULL',
+		"key!binary": 'VARCHAR NOT NULL'
+	}
+) AS r
+	 ON  (l.key1 = r.key1 AND l.key1 >= 10 AND l.key1 <= 100 OR l.key1 IS NULL)
+	 AND (l.key2 = r.key2)
+	 AND (l."key!binary" = r."key!binary" OR l."key!binary" IS NULL)
+--- End db."a-schema".key_value loadQuery (with null bounds) ---
+
+--- Begin db."a-schema".key_value loadQueryNoFlowDocument (with null bounds) ---                                                                                                                             
+SELECT 0 AS binding,                                                                                                                                 
+json_object(                                                                                                                                        
+       'key1', l.key1,                                                                                                                                         
+       'key2', l.key2,                                                                                                                                         
+       'key!binary', l."key!binary",                                                                                                                                         
+       'array', l."array",                                                                                                                                         
+       'binary', l."binary",                                                                                                                                         
+       'boolean', l."boolean",                                                                                                                                         
+       'field_with_projection', l.field_with_projection,                                                                                                                                         
+       'integer', l."integer",                                                                                                                                         
+       'integerGt64Bit', l."integerGt64Bit",                                                                                                                                         
+       'integerWithUserDDL', l."integerWithUserDDL",                                                                                                                                         
+       'multiple', l.multiple,                                                                                                                                         
+       'nonAsciiκόσμε', l."nonAsciiκόσμε",                                                                                                                                         
+       'number', l.number,                                                                                                                                         
+       'numberCastToString', CAST(l."numberCastToString" AS VARCHAR),                                                                                                                                         
+       'object', l."object",                                                                                                                                         
+       'string', l.string,                                                                                                                                         
+       'stringInteger', CAST(l."stringInteger" AS VARCHAR),                                                                                                                                         
+       'stringInteger39Chars', CAST(l."stringInteger39Chars" AS VARCHAR),                                                                                                                                         
+       'stringInteger66Chars', CAST(l."stringInteger66Chars" AS VARCHAR),                                                                                                                                         
+       'stringNumber', CAST(l."stringNumber" AS VARCHAR)                                                                                                                                                          
+) as doc                                                                                                                                                           
+FROM db."a-schema".key_value AS l                                                                                                                                       
+JOIN read_json(                                                                                                                                                    
+       ['s3://bucket/file1', 's3://bucket/file2'],                                                                                                                                                          
+       format='newline_delimited',                                                                                                                                 
+       compression='gzip',                                                                                                                                         
+       columns={                                                                                                                            
+               key1: 'BIGINT NOT NULL',                                                                                                                            
+               key2: 'BOOLEAN NOT NULL',                                                                                                                            
+               "key!binary": 'VARCHAR NOT NULL'                                                                                                                                                  
+       }                                                                                                                                                           
+) AS r                                                                                                                              
+        ON  (l.key1 = r.key1 AND l.key1 >= 10 AND l.key1 <= 100 OR l.key1 IS NULL)                                                                                                                              
+        AND (l.key2 = r.key2)                                                                                                                              
+        AND (l."key!binary" = r."key!binary" OR l."key!binary" IS NULL)                                                                                                                                                         
+--- End db."a-schema".key_value loadQueryNoFlowDocument (with null bounds) ---
+
+--- Begin db."a-schema".key_value storeDeleteQuery (with null bounds) ---
+DELETE FROM db."a-schema".key_value AS l
+USING read_json(
+	['s3://bucket/file1', 's3://bucket/file2'],
+	format='newline_delimited',
+	compression='gzip',
+	maximum_object_size=67108864,
+	columns={
+		key1: 'BIGINT NOT NULL',
+		key2: 'BOOLEAN NOT NULL',
+		"key!binary": 'VARCHAR NOT NULL',
+		"array": 'JSON',
+		"binary": 'VARCHAR',
+		"boolean": 'BOOLEAN',
+		field_with_projection: 'VARCHAR',
+		flow_published_at: 'TIMESTAMP WITH TIME ZONE NOT NULL',
+		"integer": 'BIGINT',
+		"integerGt64Bit": 'HUGEINT',
+		"integerWithUserDDL": 'DECIMAL(20)',
+		multiple: 'JSON',
+		"nonAsciiκόσμε": 'VARCHAR',
+		number: 'DOUBLE',
+		"numberCastToString": 'VARCHAR',
+		"object": 'JSON',
+		string: 'VARCHAR',
+		"stringInteger": 'HUGEINT',
+		"stringInteger39Chars": 'VARCHAR',
+		"stringInteger66Chars": 'VARCHAR',
+		"stringNumber": 'DOUBLE',
+		flow_document: 'JSON NOT NULL'
+	}
+) AS r
+	 WHERE (l.key1 = r.key1 AND l.key1 >= 10 AND l.key1 <= 100 OR l.key1 IS NULL)
+	 AND (l.key2 = r.key2)
+	 AND (l."key!binary" = r."key!binary" OR l."key!binary" IS NULL);
+--- End db."a-schema".key_value storeDeleteQuery (with null bounds) ---
 
 --- Begin db."a-schema".delta_updates storeQuery ---
 INSERT INTO db."a-schema".delta_updates BY NAME

--- a/materialize-motherduck/sqlgen.go
+++ b/materialize-motherduck/sqlgen.go
@@ -169,8 +169,9 @@ JOIN read_json(
 ) AS r
 {{- range $ind, $bound := $.Bounds }}
 	{{ if $ind }} AND {{ else }} ON  {{ end -}}
-	l.{{ $bound.Identifier }} = r.{{ $bound.Identifier }}
+	(l.{{ $bound.Identifier }} = r.{{ $bound.Identifier }}
 	{{- if $bound.LiteralLower }} AND l.{{ $bound.Identifier }} >= {{ $bound.LiteralLower }} AND l.{{ $bound.Identifier }} <= {{ $bound.LiteralUpper }}{{ end }}
+	{{- if $bound.IsNull }} OR l.{{ $bound.Identifier }} IS NULL{{ end }})
 {{- end -}}
 {{ else -}}
 SELECT * FROM (SELECT -1, CAST(NULL AS JSON) LIMIT 0) as nodoc
@@ -199,8 +200,9 @@ USING read_json(
 ) AS r
 {{- range $ind, $bound := $.Bounds }}
 	{{ if $ind }} AND {{ else }} WHERE {{ end -}}
-	l.{{ $bound.Identifier }} = r.{{ $bound.Identifier }}
+	(l.{{ $bound.Identifier }} = r.{{ $bound.Identifier }}
 	{{- if $bound.LiteralLower }} AND l.{{ $bound.Identifier }} >= {{ $bound.LiteralLower }} AND l.{{ $bound.Identifier }} <= {{ $bound.LiteralUpper }}{{ end }}
+	{{- if $bound.IsNull }} OR l.{{ $bound.Identifier }} IS NULL{{ end }})
 {{- end }};
 {{ end }}
 
@@ -271,8 +273,9 @@ JOIN read_json(
 ) AS r                                                                                                                                                             
 {{- range $ind, $bound := $.Bounds }}                                                                                                                              
        {{ if $ind }} AND {{ else }} ON  {{ end -}}                                                                                                                 
-       l.{{ $bound.Identifier }} = r.{{ $bound.Identifier }}                                                                                                       
+       (l.{{ $bound.Identifier }} = r.{{ $bound.Identifier }}
        {{- if $bound.LiteralLower }} AND l.{{ $bound.Identifier }} >= {{ $bound.LiteralLower }} AND l.{{ $bound.Identifier }} <= {{ $bound.LiteralUpper }}{{ end }}
+       {{- if $bound.IsNull }} OR l.{{ $bound.Identifier }} IS NULL{{ end }})
 {{- end -}}                                                                                                                                                        
 {{- end }}                                                                                                                                                         
 {{ end }} 

--- a/materialize-motherduck/sqlgen_test.go
+++ b/materialize-motherduck/sqlgen_test.go
@@ -66,6 +66,41 @@ func TestSQLGeneration(t *testing.T) {
 		snap.WriteString("--- End " + testcase + " ---\n\n")
 	}
 
+	// Re-run the bound-aware templates with bounds that include observed null
+	// keys, to cover the IsNull paths in the templates.
+	for _, tpl := range []*template.Template{
+		testTemplates.loadQuery,
+		testTemplates.loadQueryNoFlowDocument,
+		testTemplates.storeDeleteQuery,
+	} {
+		tbl := tables[0]
+		var testcase = tbl.Identifier + " " + tpl.Name() + " (with null bounds)"
+
+		bounds := []sql.MergeBound{
+			{
+				Column:       tbl.Keys[0],
+				LiteralLower: testDialect.Literal(int64(10)),
+				LiteralUpper: testDialect.Literal(int64(100)),
+				IsNull:       true,
+			},
+			{
+				Column: tbl.Keys[1],
+			},
+			{
+				Column: tbl.Keys[2],
+				IsNull: true,
+			},
+		}
+
+		snap.WriteString("--- Begin " + testcase + " ---")
+		require.NoError(t, tpl.Execute(snap, &queryParams{
+			Table:  tbl,
+			Bounds: bounds,
+			Files:  []string{"s3://bucket/file1", "s3://bucket/file2"},
+		}))
+		snap.WriteString("--- End " + testcase + " ---\n\n")
+	}
+
 	{
 		// Delta updates only run stores, never loads or merges.
 		tpl := testTemplates.storeQuery

--- a/materialize-snowflake/.snapshots/TestSQLGeneration
+++ b/materialize-snowflake/.snapshots/TestSQLGeneration
@@ -105,9 +105,9 @@ SELECT 0, TO_JSON("a-schema".key_value.flow_document)
 		SELECT $1[0] AS key1, $1[1] AS key2, $1[2] AS "key!binary"
 		FROM test-file
 	) AS r
-	ON "a-schema".key_value.key1 = r.key1 AND "a-schema".key_value.key1 >= 10 AND "a-schema".key_value.key1 <= 100
-	AND "a-schema".key_value.key2 = r.key2
-	AND "a-schema".key_value."key!binary" = r."key!binary" AND "a-schema".key_value."key!binary" >= 'aGVsbG8K' AND "a-schema".key_value."key!binary" <= 'Z29vZGJ5ZQo='
+	ON ("a-schema".key_value.key1 = r.key1 AND "a-schema".key_value.key1 >= 10 AND "a-schema".key_value.key1 <= 100)
+	AND ("a-schema".key_value.key2 = r.key2)
+	AND ("a-schema".key_value."key!binary" = r."key!binary" AND "a-schema".key_value."key!binary" >= 'aGVsbG8K' AND "a-schema".key_value."key!binary" <= 'Z29vZGJ5ZQo=')
 --- End "a-schema".key_value loadQuery ---
 
 --- Begin "a-schema".key_value loadQueryNoFlowDocument ---
@@ -139,9 +139,9 @@ JOIN (
 	SELECT $1[0] AS key1, $1[1] AS key2, $1[2] AS "key!binary"
 	FROM test-file
 ) AS r
-ON "a-schema".key_value.key1 = r.key1 AND "a-schema".key_value.key1 >= 10 AND "a-schema".key_value.key1 <= 100
-AND "a-schema".key_value.key2 = r.key2
-AND "a-schema".key_value."key!binary" = r."key!binary" AND "a-schema".key_value."key!binary" >= 'aGVsbG8K' AND "a-schema".key_value."key!binary" <= 'Z29vZGJ5ZQo='
+ON ("a-schema".key_value.key1 = r.key1 AND "a-schema".key_value.key1 >= 10 AND "a-schema".key_value.key1 <= 100)
+AND ("a-schema".key_value.key2 = r.key2)
+AND ("a-schema".key_value."key!binary" = r."key!binary" AND "a-schema".key_value."key!binary" >= 'aGVsbG8K' AND "a-schema".key_value."key!binary" <= 'Z29vZGJ5ZQo=')
 --- End "a-schema".key_value loadQueryNoFlowDocument ---
 
 --- Begin "a-schema".key_value mergeInto ---
@@ -151,9 +151,9 @@ USING (
 	FROM test-file
 ) AS r
 ON 
-	l.key1 = r.key1 AND l.key1 >= 10 AND l.key1 <= 100
-	AND l.key2 = r.key2
-	AND l."key!binary" = r."key!binary" AND l."key!binary" >= 'aGVsbG8K' AND l."key!binary" <= 'Z29vZGJ5ZQo='
+	(l.key1 = r.key1 AND l.key1 >= 10 AND l.key1 <= 100)
+	AND (l.key2 = r.key2)
+	AND (l."key!binary" = r."key!binary" AND l."key!binary" >= 'aGVsbG8K' AND l."key!binary" <= 'Z29vZGJ5ZQo=')
 WHEN MATCHED AND r._flow_delete=true THEN
 	DELETE
 WHEN MATCHED THEN
@@ -162,6 +162,71 @@ WHEN NOT MATCHED AND r._flow_delete=false THEN
 	INSERT (key1, key2, "key!binary", array, binary, boolean, field_with_projection, flow_published_at, integer, integerGt64Bit, integerWithUserDDL, multiple, "nonAsciiκόσμε", number, numberCastToString, object, string, stringInteger, stringInteger39Chars, stringInteger66Chars, stringNumber, flow_document)
 	VALUES (r.key1, r.key2, r."key!binary", r.array, r.binary, r.boolean, r.field_with_projection, r.flow_published_at, r.integer, r.integerGt64Bit, r.integerWithUserDDL, r.multiple, r."nonAsciiκόσμε", r.number, r.numberCastToString, r.object, r.string, r.stringInteger, r.stringInteger39Chars, r.stringInteger66Chars, r.stringNumber, r.flow_document);
 --- End "a-schema".key_value mergeInto ---
+
+--- Begin "a-schema".key_value loadQuery (with null bounds) ---
+SELECT 0, TO_JSON("a-schema".key_value.flow_document)
+	FROM "a-schema".key_value
+	JOIN (
+		SELECT $1[0] AS key1, $1[1] AS key2, $1[2] AS "key!binary"
+		FROM test-file
+	) AS r
+	ON ("a-schema".key_value.key1 = r.key1 AND "a-schema".key_value.key1 >= 10 AND "a-schema".key_value.key1 <= 100 OR "a-schema".key_value.key1 IS NULL)
+	AND ("a-schema".key_value.key2 = r.key2)
+	AND ("a-schema".key_value."key!binary" = r."key!binary" OR "a-schema".key_value."key!binary" IS NULL)
+--- End "a-schema".key_value loadQuery (with null bounds) ---
+
+--- Begin "a-schema".key_value loadQueryNoFlowDocument (with null bounds) ---
+SELECT 0, 
+OBJECT_CONSTRUCT_KEEP_NULL(
+	'key1', "a-schema".key_value.key1,
+	'key2', "a-schema".key_value.key2,
+	'key!binary', "a-schema".key_value."key!binary",
+	'array', "a-schema".key_value.array,
+	'binary', "a-schema".key_value.binary,
+	'boolean', "a-schema".key_value.boolean,
+	'field_with_projection', "a-schema".key_value.field_with_projection,
+	'integer', "a-schema".key_value.integer,
+	'integerGt64Bit', "a-schema".key_value.integerGt64Bit,
+	'integerWithUserDDL', "a-schema".key_value.integerWithUserDDL,
+	'multiple', "a-schema".key_value.multiple,
+	'nonAsciiκόσμε', "a-schema".key_value."nonAsciiκόσμε",
+	'number', "a-schema".key_value.number,
+	'numberCastToString', TO_VARCHAR("a-schema".key_value.numberCastToString),
+	'object', "a-schema".key_value.object,
+	'string', "a-schema".key_value.string,
+	'stringInteger', TO_VARCHAR("a-schema".key_value.stringInteger),
+	'stringInteger39Chars', TO_VARCHAR("a-schema".key_value.stringInteger39Chars),
+	'stringInteger66Chars', TO_VARCHAR("a-schema".key_value.stringInteger66Chars),
+	'stringNumber', TO_VARCHAR("a-schema".key_value.stringNumber)
+) as flow_document
+FROM "a-schema".key_value
+JOIN (
+	SELECT $1[0] AS key1, $1[1] AS key2, $1[2] AS "key!binary"
+	FROM test-file
+) AS r
+ON ("a-schema".key_value.key1 = r.key1 AND "a-schema".key_value.key1 >= 10 AND "a-schema".key_value.key1 <= 100 OR "a-schema".key_value.key1 IS NULL)
+AND ("a-schema".key_value.key2 = r.key2)
+AND ("a-schema".key_value."key!binary" = r."key!binary" OR "a-schema".key_value."key!binary" IS NULL)
+--- End "a-schema".key_value loadQueryNoFlowDocument (with null bounds) ---
+
+--- Begin "a-schema".key_value mergeInto (with null bounds) ---
+MERGE INTO "a-schema".key_value AS l
+USING (
+	SELECT $1[0] AS key1, $1[1] AS key2, $1[2] AS "key!binary", NULLIF($1[3], PARSE_JSON('null')) AS array, $1[4] AS binary, $1[5] AS boolean, $1[6] AS field_with_projection, $1[7] AS flow_published_at, $1[8] AS integer, $1[9] AS integerGt64Bit, $1[10] AS integerWithUserDDL, NULLIF($1[11], PARSE_JSON('null')) AS multiple, $1[12] AS "nonAsciiκόσμε", $1[13] AS number, $1[14] AS numberCastToString, NULLIF($1[15], PARSE_JSON('null')) AS object, $1[16] AS string, $1[17] AS stringInteger, $1[18] AS stringInteger39Chars, $1[19] AS stringInteger66Chars, $1[20] AS stringNumber, $1[21] AS flow_document, $1[22] AS _flow_delete
+	FROM test-file
+) AS r
+ON 
+	(l.key1 = r.key1 AND l.key1 >= 10 AND l.key1 <= 100 OR l.key1 IS NULL)
+	AND (l.key2 = r.key2)
+	AND (l."key!binary" = r."key!binary" OR l."key!binary" IS NULL)
+WHEN MATCHED AND r._flow_delete=true THEN
+	DELETE
+WHEN MATCHED THEN
+	UPDATE SET l.array = r.array, l.binary = r.binary, l.boolean = r.boolean, l.field_with_projection = r.field_with_projection, l.flow_published_at = r.flow_published_at, l.integer = r.integer, l.integerGt64Bit = r.integerGt64Bit, l.integerWithUserDDL = r.integerWithUserDDL, l.multiple = r.multiple, l."nonAsciiκόσμε" = r."nonAsciiκόσμε", l.number = r.number, l.numberCastToString = r.numberCastToString, l.object = r.object, l.string = r.string, l.stringInteger = r.stringInteger, l.stringInteger39Chars = r.stringInteger39Chars, l.stringInteger66Chars = r.stringInteger66Chars, l.stringNumber = r.stringNumber, l.flow_document = r.flow_document
+WHEN NOT MATCHED AND r._flow_delete=false THEN
+	INSERT (key1, key2, "key!binary", array, binary, boolean, field_with_projection, flow_published_at, integer, integerGt64Bit, integerWithUserDDL, multiple, "nonAsciiκόσμε", number, numberCastToString, object, string, stringInteger, stringInteger39Chars, stringInteger66Chars, stringNumber, flow_document)
+	VALUES (r.key1, r.key2, r."key!binary", r.array, r.binary, r.boolean, r.field_with_projection, r.flow_published_at, r.integer, r.integerGt64Bit, r.integerWithUserDDL, r.multiple, r."nonAsciiκόσμε", r.number, r.numberCastToString, r.object, r.string, r.stringInteger, r.stringInteger39Chars, r.stringInteger66Chars, r.stringNumber, r.flow_document);
+--- End "a-schema".key_value mergeInto (with null bounds) ---
 
 --- Begin "a-schema".key_value copyInto ---
 COPY INTO "a-schema".key_value (

--- a/materialize-snowflake/sqlgen.go
+++ b/materialize-snowflake/sqlgen.go
@@ -262,8 +262,9 @@ SELECT {{ $.Table.Binding }}, TO_JSON({{ $.Table.Identifier }}.{{ $.Table.Docume
 	) AS r
 	{{- range $ind, $bound := $.Bounds }}
 	{{ if $ind }}AND {{ else }}ON {{ end -}}
-	{{ $.Table.Identifier }}.{{ $bound.Identifier }} = r.{{ $bound.Identifier }}
+	({{ $.Table.Identifier }}.{{ $bound.Identifier }} = r.{{ $bound.Identifier }}
 	{{- if $bound.LiteralLower }} AND {{ $.Table.Identifier }}.{{ $bound.Identifier }} >= {{ $bound.LiteralLower }} AND {{ $.Table.Identifier }}.{{ $bound.Identifier }} <= {{ $bound.LiteralUpper }}{{ end }}
+	{{- if $bound.IsNull }} OR {{ $.Table.Identifier }}.{{ $bound.Identifier }} IS NULL{{ end }})
 	{{- end }}
 {{ else -}}
 SELECT * FROM (SELECT -1, CAST(NULL AS VARIANT) LIMIT 0) as nodoc
@@ -305,8 +306,9 @@ JOIN (
 ) AS r
 {{- range $ind, $bound := $.Bounds }}
 {{ if $ind }}AND {{ else }}ON {{ end -}}
-{{ $.Table.Identifier }}.{{ $bound.Identifier }} = r.{{ $bound.Identifier }}
+({{ $.Table.Identifier }}.{{ $bound.Identifier }} = r.{{ $bound.Identifier }}
 {{- if $bound.LiteralLower }} AND {{ $.Table.Identifier }}.{{ $bound.Identifier }} >= {{ $bound.LiteralLower }} AND {{ $.Table.Identifier }}.{{ $bound.Identifier }} <= {{ $bound.LiteralUpper }}{{ end }}
+{{- if $bound.IsNull }} OR {{ $.Table.Identifier }}.{{ $bound.Identifier }} IS NULL{{ end }})
 {{- end }}
 {{ end }}
 
@@ -354,8 +356,9 @@ USING (
 ) AS r
 ON {{ range $ind, $bound := $.Bounds }}
 	{{ if $ind -}} AND {{ end -}}
-	l.{{ $bound.Identifier }} = r.{{ $bound.Identifier }}
+	(l.{{ $bound.Identifier }} = r.{{ $bound.Identifier }}
 	{{- if $bound.LiteralLower }} AND l.{{ $bound.Identifier }} >= {{ $bound.LiteralLower }} AND l.{{ $bound.Identifier }} <= {{ $bound.LiteralUpper }}{{ end }}
+	{{- if $bound.IsNull }} OR l.{{ $bound.Identifier }} IS NULL{{ end }})
 {{- end }}
 WHEN MATCHED AND r._flow_delete=true THEN
 	DELETE

--- a/materialize-snowflake/sqlgen_test.go
+++ b/materialize-snowflake/sqlgen_test.go
@@ -65,6 +65,51 @@ func TestSQLGeneration(t *testing.T) {
 		snap.WriteString("--- End " + testcase + " ---\n\n")
 	}
 
+	// Re-run the bound-aware templates with bounds that include observed null
+	// keys, to cover the IsNull paths in the templates.
+	for _, tpl := range []*template.Template{
+		testTemplates.loadQuery,
+		testTemplates.loadQueryNoFlowDocument,
+		testTemplates.mergeInto,
+	} {
+		tbl := tables[0]
+		var testcase = tbl.Identifier + " " + tpl.Name() + " (with null bounds)"
+
+		bounds := []sql.MergeBound{
+			{
+				// Range bound and null observed: must produce the
+				// parenthesized "(range OR IS NULL)" predicate.
+				Column:       tbl.Keys[0],
+				LiteralLower: testDialect.Literal(int64(10)),
+				LiteralUpper: testDialect.Literal(int64(100)),
+				IsNull:       true,
+			},
+			{
+				// Boolean key: the builder always emits an empty MergeBound
+				// for booleans (no literals, IsNull never set), regardless
+				// of observed values. Mirrored here so the snapshot reflects
+				// production-realistic input.
+				Column: tbl.Keys[1],
+			},
+			{
+				// Null observed but no literal bounds (e.g. all observed
+				// values for the column were null): emit a bare IS NULL.
+				Column: tbl.Keys[2],
+				IsNull: true,
+			},
+		}
+
+		tf := boundedQueryInput{
+			Table:  tbl,
+			File:   "test-file",
+			Bounds: bounds,
+		}
+
+		snap.WriteString("--- Begin " + testcase + " ---")
+		require.NoError(t, tpl.Execute(snap, &tf))
+		snap.WriteString("--- End " + testcase + " ---\n\n")
+	}
+
 	for _, tpl := range []*template.Template{
 		testTemplates.copyInto,
 	} {

--- a/materialize-sql/templating.go
+++ b/materialize-sql/templating.go
@@ -88,6 +88,9 @@ type MergeBound struct {
 	// LiteralUpper will also be an empty string if no condition should be
 	// used.
 	LiteralUpper string
+	// IsNull indicates whether null values should be included in the merge bound
+	// conditions.
+	IsNull bool
 }
 
 // MergeBoundsBuilder tracks and generates a MergeBound for each of a binding's
@@ -96,8 +99,9 @@ type MergeBoundsBuilder struct {
 	keyColumns []Column
 	literaler  func(any) string
 
-	lower []any
-	upper []any
+	lower  []any
+	upper  []any
+	isNull []bool
 }
 
 func NewMergeBoundsBuilder(keyColumns []Column, literaler func(any) string) *MergeBoundsBuilder {
@@ -114,17 +118,27 @@ func (b *MergeBoundsBuilder) NextKey(key []any) {
 	}
 
 	if b.lower == nil {
-		// Initialize the tracked values if this is the first key observed for
-		// the transaction. A new array is allocated for both the tracked upper
-		// and lower values so that they can be updated separately based on the
-		// observed minimum and maximum keys for subsequent Stores. Note that
-		// b.lower and b.upper are set to `nil` on initialization of a
-		// MergeBoundsBuilder, and also after calls to `Build`.
-		b.lower = append([]any(nil), key...)
-		b.upper = append([]any(nil), key...)
+		b.lower = make([]any, len(b.keyColumns))
+		b.upper = make([]any, len(b.keyColumns))
+		b.isNull = make([]bool, len(b.keyColumns))
 	}
 
 	for idx, k := range key {
+		if k == nil {
+			b.isNull[idx] = true
+			continue
+		}
+		if b.lower[idx] == nil {
+			// Initialize the tracked values if this is the first non-null key observed for
+			// the transaction. A new array is allocated for both the tracked upper
+			// and lower values so that they can be updated separately based on the
+			// observed minimum and maximum keys for subsequent Stores. Note that
+			// b.lower and b.upper are set to `nil` on initialization of a
+			// MergeBoundsBuilder, and also after calls to `Build`.
+			b.lower[idx] = k
+			b.upper[idx] = k
+			continue
+		}
 		b.lower[idx] = minKey(b.lower[idx], k)
 		b.upper[idx] = maxKey(b.upper[idx], k)
 	}
@@ -192,8 +206,12 @@ func (b *MergeBoundsBuilder) Build() []MergeBound {
 			continue
 		}
 
-		conditions[idx].LiteralLower = b.literaler(b.lower[idx])
-		conditions[idx].LiteralUpper = b.literaler(b.upper[idx])
+		if b.lower[idx] != nil {
+			conditions[idx].LiteralLower = b.literaler(b.lower[idx])
+			conditions[idx].LiteralUpper = b.literaler(b.upper[idx])
+		}
+
+		conditions[idx].IsNull = b.isNull[idx]
 	}
 
 	// Reset for tracking the next transaction.
@@ -206,4 +224,5 @@ func (b *MergeBoundsBuilder) Build() []MergeBound {
 func (b *MergeBoundsBuilder) Reset() {
 	b.lower = nil
 	b.upper = nil
+	b.isNull = nil
 }

--- a/materialize-sql/templating_test.go
+++ b/materialize-sql/templating_test.go
@@ -114,7 +114,7 @@ func TestMergeBoundsBuilder(t *testing.T) {
 				{"c"},
 			},
 			want: []MergeBound{
-				{colA, literaler("a"), literaler("c")},
+				{Column: colA, LiteralLower: literaler("a"), LiteralUpper: literaler("c")},
 			},
 		},
 		{
@@ -126,9 +126,9 @@ func TestMergeBoundsBuilder(t *testing.T) {
 				{"c", true, int64(3)},
 			},
 			want: []MergeBound{
-				{colA, literaler("a"), literaler("c")},
-				{colB, "", ""},
-				{colC, literaler(int64(1)), literaler(int64(3))},
+				{Column: colA, LiteralLower: literaler("a"), LiteralUpper: literaler("c")},
+				{Column: colB},
+				{Column: colC, LiteralLower: literaler(int64(1)), LiteralUpper: literaler(int64(3))},
 			},
 		},
 		{
@@ -140,9 +140,86 @@ func TestMergeBoundsBuilder(t *testing.T) {
 				{"c", true, int64(2)},
 			},
 			want: []MergeBound{
-				{colA, literaler("a"), literaler("c")},
-				{colB, "", ""},
-				{colC, literaler(int64(1)), literaler(int64(3))},
+				{Column: colA, LiteralLower: literaler("a"), LiteralUpper: literaler("c")},
+				{Column: colB},
+				{Column: colC, LiteralLower: literaler(int64(1)), LiteralUpper: literaler(int64(3))},
+			},
+		},
+		{
+			name:       "single column all null",
+			keyColumns: []Column{colA},
+			keys: [][]any{
+				{nil},
+				{nil},
+			},
+			want: []MergeBound{
+				{Column: colA, IsNull: true},
+			},
+		},
+		{
+			name:       "single column mixed null and non-null",
+			keyColumns: []Column{colA},
+			keys: [][]any{
+				{"b"},
+				{nil},
+				{"a"},
+				{"c"},
+			},
+			want: []MergeBound{
+				{Column: colA, LiteralLower: literaler("a"), LiteralUpper: literaler("c"), IsNull: true},
+			},
+		},
+		{
+			name:       "null observed before any non-null for the same column",
+			keyColumns: []Column{colA},
+			keys: [][]any{
+				{nil},
+				{nil},
+				{"x"},
+				{"y"},
+			},
+			want: []MergeBound{
+				{Column: colA, LiteralLower: literaler("x"), LiteralUpper: literaler("y"), IsNull: true},
+			},
+		},
+		{
+			name:       "multi-column with independent null patterns",
+			keyColumns: []Column{colA, colC},
+			keys: [][]any{
+				{"a", nil},
+				{nil, int64(5)},
+				{"c", int64(2)},
+				{"b", nil},
+			},
+			want: []MergeBound{
+				{Column: colA, LiteralLower: literaler("a"), LiteralUpper: literaler("c"), IsNull: true},
+				{Column: colC, LiteralLower: literaler(int64(2)), LiteralUpper: literaler(int64(5)), IsNull: true},
+			},
+		},
+		{
+			name:       "every key entirely null across all columns",
+			keyColumns: []Column{colA, colC},
+			keys: [][]any{
+				{nil, nil},
+				{nil, nil},
+			},
+			want: []MergeBound{
+				{Column: colA, IsNull: true},
+				{Column: colC, IsNull: true},
+			},
+		},
+		{
+			name:       "boolean column is never bounded even when nulls are observed",
+			keyColumns: []Column{colB},
+			keys: [][]any{
+				{nil},
+				{true},
+				{false},
+			},
+			// colB is boolean: the type-based skip in Build leaves all fields
+			// zero — including IsNull — matching the pre-existing behavior.
+			want: []MergeBound{
+				{Column: colB},
 			},
 		},
 	} {
@@ -154,6 +231,25 @@ func TestMergeBoundsBuilder(t *testing.T) {
 			require.Equal(t, tt.want, b.Build())
 		})
 	}
+
+	// Verify that null-tracking state (b.isNull) does not leak across
+	// transactions: a transaction with null keys followed by one with only
+	// non-null keys must not report IsNull=true in the second Build.
+	t.Run("Build resets null state between transactions", func(t *testing.T) {
+		b := NewMergeBoundsBuilder([]Column{colA}, literaler)
+
+		b.NextKey([]any{nil})
+		b.NextKey([]any{"a"})
+		require.Equal(t, []MergeBound{
+			{Column: colA, LiteralLower: literaler("a"), LiteralUpper: literaler("a"), IsNull: true},
+		}, b.Build())
+
+		b.NextKey([]any{"x"})
+		b.NextKey([]any{"z"})
+		require.Equal(t, []MergeBound{
+			{Column: colA, LiteralLower: literaler("x"), LiteralUpper: literaler("z")},
+		}, b.Build())
+	})
 }
 
 func TestRootLevelColumns(t *testing.T) {


### PR DESCRIPTION
**Description:**

- Compound keys can have null values in one of their key parts. For merge bounds, what that means is we should include that in our merge bound. I have updated MergeBounds so that it detects existence of null values for a specific key, and if that's the case, we add `OR IS NULL` as a condition.
- Previously we would panic on seeing null values:
```
runTransactions: app.ConsumeMessage: panic: minKey unhandled key type <nil> (value: <nil>)
```

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

