### PR TITLE
materialize-snowflake: detect QUOTED_IDENTIFIERS_IGNORE_CASE during validation

### DIFF
--- a/materialize-snowflake/client.go
+++ b/materialize-snowflake/client.go
@@ -315,7 +315,10 @@ func preReqs(ctx context.Context, cfg config) *cerrors.PrereqErr {
 		if err != nil {
 			errs.Err(fmt.Errorf("checking for QUOTED_IDENTIFIERS_IGNORE_CASE: %w", err))
 		} else {
-			if strings.EqualFold(quotedIdentifiersIgnoreCase, "true") {
+			ignoreCase, err := strconv.ParseBool(value)
+			if err != nil {
+				errs.Err(fmt.Errorf("unable to parse QUOTED_IDENTIFIERS_IGNORE_CASE value: %w", err))
+			} else if ignoreCase {
 				errs.Err(fmt.Errorf(
 					"the Snowflake parameter QUOTED_IDENTIFIERS_IGNORE_CASE is enabled, which is incompatible with this connector: " +
 						"Estuary uses quoted identifiers for column names containing special characters (e.g. \"_meta/op\"), " +

--- a/materialize-snowflake/client.go
+++ b/materialize-snowflake/client.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"regexp"
 	"slices"
+	"strconv"
 	"strings"
 	"sync"
 
@@ -319,13 +320,7 @@ func preReqs(ctx context.Context, cfg config) *cerrors.PrereqErr {
 			if err != nil {
 				errs.Err(fmt.Errorf("unable to parse QUOTED_IDENTIFIERS_IGNORE_CASE value: %w", err))
 			} else if ignoreCase {
-				errs.Err(fmt.Errorf(
-					"the Snowflake parameter QUOTED_IDENTIFIERS_IGNORE_CASE is enabled, which is incompatible with this connector: " +
-						"Estuary uses quoted identifiers for column names containing special characters (e.g. \"_meta/op\"), " +
-						"and requires Snowflake to preserve their case exactly as created. " +
-						"Disable this parameter for the Estuary user with: " +
-						"ALTER USER <estuary_user> SET QUOTED_IDENTIFIERS_IGNORE_CASE = FALSE",
-				))
+				errs.Err(fmt.Errorf("QUOTED_IDENTIFIERS_IGNORE_CASE must be FALSE, see go.estuary.dev/mat-snow"))
 			}
 		}
 	}

--- a/materialize-snowflake/client.go
+++ b/materialize-snowflake/client.go
@@ -309,8 +309,12 @@ func preReqs(ctx context.Context, cfg config) *cerrors.PrereqErr {
 		// is enabled, quoted identifiers are returned uppercased regardless of how they were
 		// created. Estuary uses quoted identifiers for column names containing special characters
 		// (such as "_meta/op"), and requires that Snowflake preserve their case exactly as created.
-		var quotedIdentifiersIgnoreCase string
-		if err := db.QueryRowContext(ctx, "SELECT SYSTEM$GET_SESSION_PARAMETER('QUOTED_IDENTIFIERS_IGNORE_CASE');").Scan(&quotedIdentifiersIgnoreCase); err == nil {
+		var key, value, default_, level, desc, type_ string
+		query := "SHOW PARAMETERS LIKE 'QUOTED_IDENTIFIERS_IGNORE_CASE' IN SESSION;"
+		err := db.QueryRowContext(ctx, query).Scan(&key, &value, &default_, &level, &desc, &type_)
+		if err != nil {
+			errs.Err(fmt.Errorf("checking for QUOTED_IDENTIFIERS_IGNORE_CASE: %w", err))
+		} else {
 			if strings.EqualFold(quotedIdentifiersIgnoreCase, "true") {
 				errs.Err(fmt.Errorf(
 					"the Snowflake parameter QUOTED_IDENTIFIERS_IGNORE_CASE is enabled, which is incompatible with this connector: " +

--- a/materialize-snowflake/client.go
+++ b/materialize-snowflake/client.go
@@ -304,6 +304,23 @@ func preReqs(ctx context.Context, cfg config) *cerrors.PrereqErr {
 				errs.Err(fmt.Errorf("no warehouse configured and default warehouse not set for user '%s': must set a value for 'Warehouse' in the endpoint configuration", cfg.Credentials.User))
 			}
 		}
+
+		// Check that QUOTED_IDENTIFIERS_IGNORE_CASE is not enabled. When this Snowflake parameter
+		// is enabled, quoted identifiers are returned uppercased regardless of how they were
+		// created. Estuary uses quoted identifiers for column names containing special characters
+		// (such as "_meta/op"), and requires that Snowflake preserve their case exactly as created.
+		var quotedIdentifiersIgnoreCase string
+		if err := db.QueryRowContext(ctx, "SELECT SYSTEM$GET_SESSION_PARAMETER('QUOTED_IDENTIFIERS_IGNORE_CASE');").Scan(&quotedIdentifiersIgnoreCase); err == nil {
+			if strings.EqualFold(quotedIdentifiersIgnoreCase, "true") {
+				errs.Err(fmt.Errorf(
+					"the Snowflake parameter QUOTED_IDENTIFIERS_IGNORE_CASE is enabled, which is incompatible with this connector: " +
+						"Estuary uses quoted identifiers for column names containing special characters (e.g. \"_meta/op\"), " +
+						"and requires Snowflake to preserve their case exactly as created. " +
+						"Disable this parameter for the Estuary user with: " +
+						"ALTER USER <estuary_user> SET QUOTED_IDENTIFIERS_IGNORE_CASE = FALSE",
+				))
+			}
+		}
 	}
 
 	return errs


### PR DESCRIPTION
## Summary

When `QUOTED_IDENTIFIERS_IGNORE_CASE` is enabled at the Snowflake account or user level, Snowflake uppercases quoted identifiers even when they were created with lowercase casing. This breaks the connector, which uses quoted identifiers for column names containing special characters (e.g. `"_meta/op"`), and expects Snowflake to preserve their case exactly as created.

The failure mode is confusing: the connector creates `"_meta/op"`, reads back the table schema and sees `_META/OP`, thinks the column doesn't exist, tries to `ALTER TABLE ... ADD COLUMN "_meta/op"`, and hits a `column '_META/OP' already exists` error deep in `completeRecovery`. This has come up multiple times with different customers.

This PR adds a prereq check that detects the setting during validation and surfaces a clear, actionable error with remediation instructions rather than silently failing mid-run.

Disclaimer: I am not a software engineer

## Test plan

- [ ] Verify the prereq check fires with a descriptive error when connecting to a Snowflake account/user with `QUOTED_IDENTIFIERS_IGNORE_CASE = TRUE`
- [ ] Verify normal materialization setup is unaffected when the setting is `FALSE` (default)