### PR TITLE
source-dynamics-365-finance-and-operations: emit sourced schemas

### DIFF
--- a/source-dynamics-365-finance-and-operations/source_dynamics_365_finance_and_operations/models.py
+++ b/source-dynamics-365-finance-and-operations/source_dynamics_365_finance_and_operations/models.py
@@ -1,5 +1,7 @@
 from dataclasses import dataclass
-from typing import ClassVar, Literal, Annotated
+from enum import StrEnum
+from logging import Logger
+from typing import Any, ClassVar, Literal, Annotated
 
 from estuary_cdk.capture.common import (
     ConnectorState as GenericConnectorState,
@@ -42,11 +44,24 @@ class EndpointConfig(BaseModel):
 ConnectorState = GenericConnectorState[ResourceState]
 
 
+class AttributeDataType(StrEnum):
+    STRING = "string"
+    INT64 = "int64"
+    DECIMAL = "decimal"
+    DATE_TIME = "dateTime"
+    DATE_TIME_OFFSET = "dateTimeOffset"
+    GUID = "guid"
+    BOOLEAN = "boolean"
+
+
 class ModelDotJson(BaseModel, extra="allow"):
     class Entity(BaseModel, extra="allow"):
         class Attribute(BaseModel, extra="allow"):
             name: str
-            dataType: str
+            dataType: AttributeDataType | str
+            # maxLength is only set to a non -1 value for string dataTypes. For
+            # other dataTypes, it's either absent or set to -1.
+            maxLength: int = -1
 
         type_: str = Field(alias="$type")
         name: str
@@ -67,13 +82,113 @@ class BaseTable(BaseCSVRow, extra="allow"):
     that's not necessary in this connector.
     """
     name: ClassVar[str]
+    attributes: ClassVar[list[ModelDotJson.Entity.Attribute]]
 
     Id: str
     IsDelete: bool | None
 
+    @classmethod
+    def sourced_schema(cls, log: Logger) -> dict[str, Any]:
+        """Build a sourced schema from entity attribute metadata.
+
+        The sourced schema tells the Flow runtime what each field's type is,
+        causing materialization columns to be created even before data is seen.
+        Length constraints start tight and schema inference widens them as
+        actual data arrives.
+
+        All values except booleans arrive as CSV strings, so most types are
+        schematized as {"type": "string"} with a format hint.
+        """
+        schema: dict[str, Any] = {
+            "additionalProperties": False,
+            "type": "object",
+            "properties": {},
+            "required": [],
+        }
+
+        for attr in cls.attributes:
+            match attr.dataType:
+                case AttributeDataType.STRING:
+                    # model.json provides an authoritative maxLength for every
+                    # string field. Set minLength=maxLength so inference widens
+                    # minLength down as shorter values are seen. Fall back to 1
+                    # if maxLength is absent.
+                    if attr.maxLength > 0:
+                        field_schema: dict[str, Any] = {
+                            "type": "string",
+                            "minLength": attr.maxLength,
+                            "maxLength": attr.maxLength
+                        }
+                    else:
+                        field_schema = {
+                            "type": "string",
+                            "minLength": 1,
+                            "maxLength": 1
+                        }
+                case AttributeDataType.INT64 | AttributeDataType.DECIMAL:
+                    # Actual string lengths vary widely across fields, so start
+                    # at 1 and let schema inference discover real bounds.
+                    fmt = "integer" if attr.dataType == AttributeDataType.INT64 else "number"
+                    field_schema = {
+                        "type": "string",
+                        "format": fmt,
+                        "minLength": 1,
+                        "maxLength": 1
+                    }
+                case AttributeDataType.DATE_TIME:
+                    # SinkCreatedOn/SinkModifiedOn are Azure Synapse Link
+                    # metadata fields that use a non-ISO format like
+                    # "4/14/2026 8:21:50 PM". Lengths range from 19
+                    # ("1/1/2026 1:00:00 PM") to 22 ("12/31/2026 12:59:59 PM").
+                    # All other dateTime fields are ISO 8601 with 7 fractional
+                    # digits: "1900-01-01T00:00:00.0000000Z" (28 chars).
+                    if attr.name in ("SinkCreatedOn", "SinkModifiedOn"):
+                        field_schema = {
+                            "type": "string",
+                            "minLength": 19,
+                            "maxLength": 22
+                        }
+                    else:
+                        field_schema = {
+                            "type": "string",
+                            "format": "date-time",
+                            "minLength": 28, "maxLength": 28
+                        }
+                case AttributeDataType.DATE_TIME_OFFSET:
+                    # ISO 8601 with offset: "1900-01-01T00:00:00.0000000+00:00" (33 chars).
+                    field_schema = {
+                        "type": "string",
+                        "format": "date-time",
+                        "minLength": 33, "maxLength": 33
+                    }
+                case AttributeDataType.GUID:
+                    # Standard UUID with hyphens: "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" (36 chars).
+                    field_schema = {
+                        "type": "string",
+                        "format": "uuid",
+                        "minLength": 36,
+                        "maxLength": 36
+                    }
+                case AttributeDataType.BOOLEAN:
+                    field_schema = {"type": "boolean"}
+                case _:
+                    log.warning(f"Omitting attribute '{attr.name}' from sourced schema for entity '{cls.name}' due to unknown dataType '{attr.dataType}'.")
+                    continue
+
+            schema["properties"][attr.name] = field_schema
+            # Mark every field as required so the sourced schema starts as
+            # tight as possible. Schema inference will widen to permit nulls
+            # as actual data arrives.
+            schema["required"].append(attr.name)
+
+        # Sort to keep a stable ordering.
+        schema["required"].sort()
+
+        return schema
+
 
 def model_from_entity(entity: ModelDotJson.Entity) -> type[BaseTable]:
-    return type(entity.name, (BaseTable,), {'name': entity.name})
+    return type(entity.name, (BaseTable,), {'name': entity.name, 'attributes': entity.attributes})
 
 
 def tables_from_model_dot_json(model_dot_json: ModelDotJson) -> list[type[BaseTable]]:

--- a/source-dynamics-365-finance-and-operations/source_dynamics_365_finance_and_operations/resources.py
+++ b/source-dynamics-365-finance-and-operations/source_dynamics_365_finance_and_operations/resources.py
@@ -8,6 +8,7 @@ from estuary_cdk.http import HTTPMixin
 
 from .models import (
     BaseTable,
+    ConnectorState,
     EndpointConfig,
     ResourceConfig,
     ResourceState,
@@ -44,7 +45,7 @@ def resources(
         log: Logger, config: EndpointConfig, adls_client: ADLSGen2Client, tables: list[type[BaseTable]],
 ) -> list[common.Resource]:
 
-    def open(
+    async def open(
         model: type[BaseTable],
         binding: CaptureBinding[ResourceConfig],
         binding_index: int,
@@ -52,6 +53,9 @@ def resources(
         task: Task,
         all_bindings,
     ):
+        task.sourced_schema(binding_index, model.sourced_schema(log))
+        await task.checkpoint(state=ConnectorState())
+
         common.open_binding(
             binding,
             binding_index,

--- a/source-dynamics-365-finance-and-operations/tests/test_sourced_schemas.py
+++ b/source-dynamics-365-finance-and-operations/tests/test_sourced_schemas.py
@@ -1,0 +1,151 @@
+import logging
+
+from source_dynamics_365_finance_and_operations.models import (
+    ModelDotJson,
+    model_from_entity,
+)
+
+
+log = logging.getLogger("test")
+
+
+def make_attribute(name: str, dataType: str, maxLength: int = -1) -> ModelDotJson.Entity.Attribute:
+    return ModelDotJson.Entity.Attribute(name=name, dataType=dataType, maxLength=maxLength)
+
+
+def make_entity(name: str, attributes: list[ModelDotJson.Entity.Attribute]) -> ModelDotJson.Entity:
+    return ModelDotJson.Entity(**{"$type": "LocalEntity", "name": name, "description": name, "attributes": attributes})
+
+
+class TestSourcedSchema:
+    def test_string_with_max_length(self):
+        entity = make_entity("test", [make_attribute("Name", "string", maxLength=50)])
+        model = model_from_entity(entity)
+
+        schema = model.sourced_schema(log)
+
+        assert schema["properties"]["Name"] == {"type": "string", "minLength": 50, "maxLength": 50}
+
+    def test_string_without_max_length(self):
+        entity = make_entity("test", [make_attribute("Name", "string", maxLength=-1)])
+        model = model_from_entity(entity)
+
+        schema = model.sourced_schema(log)
+
+        assert schema["properties"]["Name"] == {"type": "string", "minLength": 1, "maxLength": 1}
+
+    def test_int64(self):
+        entity = make_entity("test", [make_attribute("Count", "int64")])
+        model = model_from_entity(entity)
+
+        schema = model.sourced_schema(log)
+
+        assert schema["properties"]["Count"] == {"type": "string", "format": "integer", "minLength": 1, "maxLength": 1}
+
+    def test_decimal(self):
+        entity = make_entity("test", [make_attribute("Amount", "decimal")])
+        model = model_from_entity(entity)
+
+        schema = model.sourced_schema(log)
+
+        assert schema["properties"]["Amount"] == {"type": "string", "format": "number", "minLength": 1, "maxLength": 1}
+
+    def test_datetime(self):
+        entity = make_entity("test", [make_attribute("CreatedDate", "dateTime")])
+        model = model_from_entity(entity)
+
+        schema = model.sourced_schema(log)
+
+        assert schema["properties"]["CreatedDate"] == {"type": "string", "format": "date-time", "minLength": 28, "maxLength": 28}
+
+    def test_datetime_sink_fields(self):
+        entity = make_entity("test", [
+            make_attribute("SinkCreatedOn", "dateTime"),
+            make_attribute("SinkModifiedOn", "dateTime"),
+        ])
+        model = model_from_entity(entity)
+
+        schema = model.sourced_schema(log)
+
+        expected = {"type": "string", "minLength": 19, "maxLength": 22}
+        assert schema["properties"]["SinkCreatedOn"] == expected
+        assert schema["properties"]["SinkModifiedOn"] == expected
+
+    def test_datetime_offset(self):
+        entity = make_entity("test", [make_attribute("CreatedOn", "dateTimeOffset")])
+        model = model_from_entity(entity)
+
+        schema = model.sourced_schema(log)
+
+        assert schema["properties"]["CreatedOn"] == {"type": "string", "format": "date-time", "minLength": 33, "maxLength": 33}
+
+    def test_guid(self):
+        entity = make_entity("test", [make_attribute("Id", "guid")])
+        model = model_from_entity(entity)
+
+        schema = model.sourced_schema(log)
+
+        assert schema["properties"]["Id"] == {"type": "string", "format": "uuid", "minLength": 36, "maxLength": 36}
+
+    def test_boolean(self):
+        entity = make_entity("test", [make_attribute("IsDelete", "boolean")])
+        model = model_from_entity(entity)
+
+        schema = model.sourced_schema(log)
+
+        assert schema["properties"]["IsDelete"] == {"type": "boolean"}
+
+    def test_unknown_type_skipped(self, caplog):
+        entity = make_entity("test", [
+            make_attribute("Name", "string", maxLength=10),
+            make_attribute("Unknown", "complexType"),
+        ])
+        model = model_from_entity(entity)
+
+        with caplog.at_level(logging.WARNING):
+            schema = model.sourced_schema(log)
+
+        assert "Unknown" not in schema["properties"]
+        assert "Unknown" not in schema["required"]
+        assert "Name" in schema["properties"]
+        assert "Name" in schema["required"]
+        assert "Omitting attribute 'Unknown' from sourced schema for entity 'test' due to unknown dataType 'complexType'" in caplog.text
+
+    def test_schema_structure(self):
+        entity = make_entity("test", [make_attribute("Name", "string", maxLength=10)])
+        model = model_from_entity(entity)
+
+        schema = model.sourced_schema(log)
+
+        assert schema["additionalProperties"] is False
+        assert schema["type"] == "object"
+        assert "properties" in schema
+        assert schema["required"] == ["Name"]
+
+    def test_all_types_together(self):
+        entity = make_entity("test", [
+            make_attribute("Id", "guid"),
+            make_attribute("SinkCreatedOn", "dateTime"),
+            make_attribute("SinkModifiedOn", "dateTime"),
+            make_attribute("Name", "string", maxLength=20),
+            make_attribute("Count", "int64"),
+            make_attribute("Amount", "decimal"),
+            make_attribute("CreatedDate", "dateTime"),
+            make_attribute("CreatedOn", "dateTimeOffset"),
+            make_attribute("IsActive", "boolean"),
+        ])
+        model = model_from_entity(entity)
+
+        schema = model.sourced_schema(log)
+
+        assert len(schema["properties"]) == 9
+        assert len(schema["required"]) == 9
+        assert schema["properties"]["Id"]["format"] == "uuid"
+        assert schema["properties"]["SinkCreatedOn"] == {"type": "string", "minLength": 19, "maxLength": 22}
+        assert schema["properties"]["SinkModifiedOn"] == {"type": "string", "minLength": 19, "maxLength": 22}
+        assert schema["properties"]["Name"] == {"type": "string", "minLength": 20, "maxLength": 20}
+        assert schema["properties"]["Count"]["format"] == "integer"
+        assert schema["properties"]["Amount"]["format"] == "number"
+        assert schema["properties"]["CreatedDate"]["format"] == "date-time"
+        assert schema["properties"]["CreatedOn"]["format"] == "date-time"
+        assert schema["properties"]["IsActive"] == {"type": "boolean"}


### PR DESCRIPTION
**Description:**

When a connector relies solely on schema inference, the runtime can only learn a field's type from non-null values observed in captured documents. If a field has only ever been null in captured documents, the runtime has no type information for it, and materializations cannot create the corresponding column in the destination. This is especially problematic for sparse D365 entities where many fields may remain null for long periods. We've solved this problem before in other captures by emitting sourced schema messages - messages that inform the runtime about the source system's understanding of the schema, usually derived from source system provided metadata.

This PR crafts sourced schema messages from the table attribute metadata present in the top level `model.json`. This gives the Flow runtime upfront knowledge of all field types and constraints, so materialization columns can be created before any data arrives.

**Notes for reviewers:**

See this [PR](https://github.com/estuary/connectors/pull/2732) for some more context around how sourced schema messages are used by capture connectors to pre-widen inferred schemas. The use case described in that PR for `source-salesforce-native` is the same use case here for `source-dynamics-365-finance-and-operations`; pre-populating columns in destinations before any non-null values have been captured for those columns.

Additional source: [official docs](https://learn.microsoft.com/en-us/power-apps/maker/data-platform/export-data-lake-faq#what-date-and-time-formats-can-be-expected-in-exported-dataverse-tables) describing the format for different `datetime` and `datetimeOffset` fields

