### PR TITLE
materialize-s3-parquet: use RustFS instead of MinIO

### DIFF
--- a/materialize-s3-parquet/docker-compose.yaml
+++ b/materialize-s3-parquet/docker-compose.yaml
@@ -1,19 +1,21 @@
 services:
   storage:
-    image: minio/minio:latest
-    command: server /data
+    image: rustfs/rustfs:latest
+    # Both env vars and CLI flags are set because RUSTFS_ACCESS_KEY / RUSTFS_SECRET_KEY
+    # have been reported to be ignored in some releases (rustfs/rustfs#375, #1058).
+    command: ["--access-key", "test_key", "--secret-key", "test_secret", "/data"]
     ports:
       - "9099:9000"
     environment:
-      MINIO_ROOT_USER: test_key
-      MINIO_ROOT_PASSWORD: test_secret
+      RUSTFS_ACCESS_KEY: test_key
+      RUSTFS_SECRET_KEY: test_secret
     networks:
       flow-test:
     healthcheck:
       test:
         [
           "CMD-SHELL",
-          "curl -f http://127.0.0.1:9000/minio/health/live"
+          "curl -f http://127.0.0.1:9000/health"
         ]
       interval: 2s
       timeout: 5s


### PR DESCRIPTION
**Description:**

- since MinIO is no longer maintained
- originally done by Daniel in #4066 

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

