### PR TITLE
materialize-snowflake: add retry limit for token persistance

### DIFF
--- a/materialize-snowflake/stream_http.go
+++ b/materialize-snowflake/stream_http.go
@@ -358,6 +358,10 @@ func (s *streamClient) waitForTokenPersisted(ctx context.Context, token string, 
 			}).Info("channel offset token not yet persisted")
 		}
 
+		if time.Since(ts) > 5*time.Minute {
+			return fmt.Errorf("channel offset token not persisted: max retries reached")
+		}
+
 		time.Sleep(backoff)
 		backoff = min(backoff*2, maxBackoff)
 	}

--- a/materialize-snowflake/stream_http.go
+++ b/materialize-snowflake/stream_http.go
@@ -337,7 +337,7 @@ func (s *streamClient) channelStatus(ctx context.Context, clientSeq int, schema,
 
 func (s *streamClient) waitForTokenPersisted(ctx context.Context, token string, clientSeq int, schema, table, name string) error {
 	logger := Logger(ctx)
-	maxBackoff := 1 * time.Second
+	maxBackoff := 2 * time.Second
 	backoff := 100 * time.Millisecond
 	ts := time.Now()
 	for n := 1; ; n++ {
@@ -345,6 +345,7 @@ func (s *streamClient) waitForTokenPersisted(ctx context.Context, token string, 
 			if !errors.Is(err, ErrTemporary) {
 				return err
 			}
+			logger.WithField("attempt", n).WithError(err).Info("temporary error getting channel status")
 		} else if len(status.Channels) != 1 {
 			return fmt.Errorf("expected 1 channel but got %d", len(status.Channels))
 		} else if status.Channels[0].PersistedOffsetToken == token {


### PR DESCRIPTION
Currently we wait forever for the token to be persisted potentially causing the connector to be stuck.  With this change after 5m we exit with an error, when the connector restarts it will reopen the channel which will fence any ongoing changes from other clients.

Additionally, when a temporary error occurred we would retry it but there was no logging that it occurred, which made it impossible to know if errors were the cause of retries or if the token was not updated.  related: https://github.com/estuary/connectors/pull/3959

Increased the max retry backoff to 2s, in case we are polling to quickly.

**Workflow steps:**

No changes

**Documentation links affected:**

None

**Notes for reviewers:**

