### PR TITLE
estuary-cdk: remove EXPOSE 8080 from Dockerfile.common

### DIFF
--- a/estuary-cdk/common.Dockerfile
+++ b/estuary-cdk/common.Dockerfile
@@ -51,6 +51,4 @@ ENV DOCS_URL=${DOCS_URL}
 ENV ENCRYPTION_URL=${ENCRYPTION_URL}
 ENV CONNECTOR_NAME=${CONNECTOR_NAME}
 
-EXPOSE 8080
-
 CMD ["/bin/sh", "-c", "/opt/venv/bin/python -m $(echo \"$CONNECTOR_NAME\" | tr '-' '_')"]


### PR DESCRIPTION
**Description:**

We are currently exposing an endpoint for every capture, regardless of whether they require it. This PR temporarily reverts that until we find how to conditionally do it only when it's needed.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

