### PR TITLE
estuary-cdk: support connector-specific dockerfiles

### DIFF
--- a/.claude/skills/create-webhook-connector/SKILL.md
+++ b/.claude/skills/create-webhook-connector/SKILL.md
@@ -108,3 +108,14 @@ async def all_resources(log, http, config):
 Ask the user which discriminator strategy fits their webhook provider and whether event types can be discovered via API or need to be statically defined.
 
 If the provider also has pull API endpoints (not just webhooks), use `/classify-stream-types` to determine the appropriate stream type for each endpoint.
+
+## Dockerfile setup
+
+Webhook connectors need a `Dockerfile` symlink in their connector directory pointing to the shared webhook Dockerfile:
+
+```bash
+cd source-<name>
+ln -s ../estuary-cdk/webhook-capture.Dockerfile Dockerfile
+```
+
+CI and `build-local.sh` automatically detect connector-specific Dockerfiles

--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -416,21 +416,20 @@ jobs:
           cd ..
           pytest ${{ matrix.connector.name }}
 
-      # Uncomment to allow each connector to have its own Dockerfile
-      #- name: Find Dockerfile for ${{ matrix.connector.name }}
-      #  id: dockerfile
-      #  run: |
-      #    DOCKERFILE_PATH="${PWD}/estuary-cdk/common.Dockerfile"
-      #    if [ -f "${{ matrix.connector.name }}/Dockerfile" ]; then
-      #      DOCKERFILE_PATH="${PWD}/${{ matrix.connector.name }}/Dockerfile"
-      #    fi
-      #    echo "path=${DOCKERFILE_PATH}" >> $GITHUB_OUTPUT
+      - name: Find Dockerfile for ${{ matrix.connector.name }}
+        id: dockerfile
+        run: |
+          DOCKERFILE_PATH="${PWD}/estuary-cdk/common.Dockerfile"
+          if [ -e "${{ matrix.connector.name }}/Dockerfile" ]; then
+            DOCKERFILE_PATH="$(readlink -f "${{ matrix.connector.name }}/Dockerfile")"
+          fi
+          echo "path=${DOCKERFILE_PATH}" >> $GITHUB_OUTPUT
 
       - name: Build ${{ matrix.connector.name }} Docker Image
         uses: docker/build-push-action@v6
         with:
           context: .
-          file: estuary-cdk/common.Dockerfile
+          file: ${{ steps.dockerfile.outputs.path }}
           load: true
           build-args: |
             CONNECTOR_NAME=${{ matrix.connector.name }}

--- a/build-local.sh
+++ b/build-local.sh
@@ -27,8 +27,12 @@ fi
 
 # Detect Python vs Go/Rust connector and select Dockerfile
 if [[ -f "${SCRIPT_DIR}/${name}/pyproject.toml" ]]; then
-    # Python connector - use common Dockerfile
-    dockerfile="${SCRIPT_DIR}/estuary-cdk/common.Dockerfile"
+    # Python connector - use connector-specific Dockerfile if present, else common
+    if [[ -e "${SCRIPT_DIR}/${name}/Dockerfile" ]]; then
+        dockerfile="$(readlink -f "${SCRIPT_DIR}/${name}/Dockerfile")"
+    else
+        dockerfile="${SCRIPT_DIR}/estuary-cdk/common.Dockerfile"
+    fi
 else
     # Go connector - use connector-specific Dockerfile
     if [[ -z "$2" ]]; then

--- a/estuary-cdk/webhook-capture.Dockerfile
+++ b/estuary-cdk/webhook-capture.Dockerfile
@@ -1,0 +1,56 @@
+# syntax=docker/dockerfile:1
+FROM python:3.12-slim AS base
+FROM base AS builder
+
+ARG CONNECTOR_NAME
+
+RUN apt-get update && \
+  apt install -y --no-install-recommends \
+  python3-poetry
+
+RUN python -m venv /opt/venv
+ENV VIRTUAL_ENV=/opt/venv
+
+WORKDIR /opt/${CONNECTOR_NAME}
+COPY ${CONNECTOR_NAME}/pyproject.toml ${CONNECTOR_NAME}/poetry.lock /opt/${CONNECTOR_NAME}
+COPY estuary-cdk /opt/estuary-cdk
+
+RUN poetry install --no-root
+
+COPY ${CONNECTOR_NAME} /opt/${CONNECTOR_NAME}
+
+RUN poetry install
+
+FROM base AS runner
+
+ARG CONNECTOR_NAME
+ARG CONNECTOR_TYPE
+ARG DOCS_URL
+ARG ENCRYPTION_URL="https://config-encryption.estuary.dev/v1/encrypt-config"
+# The USAGE_RATE arg is required, because GH actions doesn't seem to have a way to conditionally
+# pass it only for the connectors that should have a 0 rate. Comes from `usage_rate` in the
+# `python.yaml` workflow matrix.
+ARG USAGE_RATE
+
+RUN apt-get update && \
+  apt install -y --no-install-recommends \
+  openssh-client \
+  tzdata \
+  tzdata-legacy
+
+LABEL FLOW_RUNTIME_PROTOCOL=${CONNECTOR_TYPE}
+LABEL FLOW_RUNTIME_CODEC=json
+LABEL dev.estuary.usage-rate=${USAGE_RATE}
+
+COPY --from=builder /opt/$CONNECTOR_NAME /opt/$CONNECTOR_NAME
+COPY --from=builder /opt/estuary-cdk /opt/estuary-cdk
+COPY --from=builder /opt/venv /opt/venv
+COPY --from=ghcr.io/estuary/network-tunnel:dev /flow-network-tunnel /usr/bin/flow-network-tunnel
+
+ENV DOCS_URL=${DOCS_URL}
+ENV ENCRYPTION_URL=${ENCRYPTION_URL}
+ENV CONNECTOR_NAME=${CONNECTOR_NAME}
+
+EXPOSE 8080
+
+CMD ["/bin/sh", "-c", "/opt/venv/bin/python -m $(echo \"$CONNECTOR_NAME\" | tr '-' '_')"]


### PR DESCRIPTION
**Description:**

Builders will first search for a dockerfile at each connector's project root before defaulting to `common.Dockerfile`. Developers wishing to add support for webhook captures may symlink to the included `webhook-capture.Dockerfile` file to expose port 8080.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

