### PR TITLE
materialize-s3-iceberg: add alternative naming feature flag

### DIFF
--- a/materialize-iceberg/config.go
+++ b/materialize-iceberg/config.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
-	"regexp"
 	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -14,7 +13,6 @@ import (
 	emr "github.com/aws/aws-sdk-go-v2/service/emrserverless"
 	"github.com/aws/aws-sdk-go-v2/service/glue"
 	"github.com/aws/aws-sdk-go-v2/service/ssm"
-	"github.com/cespare/xxhash/v2"
 	"github.com/estuary/connectors/go/auth/iam"
 	"github.com/estuary/connectors/go/blob"
 	"github.com/estuary/connectors/go/dbt"
@@ -26,8 +24,11 @@ import (
 )
 
 var featureFlagDefaults = map[string]bool{
-	// An alternate naming style for the Iceberg tables:
-	//   <base_location>/<namespace>/<table>_<hash>
+	// An alternate naming style for the Iceberg table data.  By default (when
+	// false), the naming is:
+	//   <base_location>/<namespace>_<table>_<hash>
+	// When this flag is enabled:
+	//   <base_location>/<namespace>/<table>.<hash>
 	"nested_dot_hash_location_style": false,
 }
 
@@ -624,63 +625,4 @@ func (r resource) WithDefaults(cfg config) resource {
 
 func (r resource) Parameters() (path []string, deltaUpdates bool, err error) {
 	return sanitizePath(r.Namespace, r.Table), false, nil
-}
-
-type LocationStyle int
-
-const (
-	FlatLocationStyle LocationStyle = iota
-	NestedDotHashLocationStyle
-)
-
-// Iceberg catalogs are generally case-insensitive and do not allow dots in
-// namespace or table names. AWS Glue is also very picky about anything other
-// than alphanumerics or underscores in namespace or table names.
-var pathSanitizeRegex = regexp.MustCompile("(?i)[^a-z0-9_]")
-
-func sanitizePath(path ...string) []string {
-	out := []string{}
-	for _, p := range path {
-		out = append(out, strings.ToLower(pathSanitizeRegex.ReplaceAllString(p, "_")))
-	}
-
-	return out
-}
-
-// sanitizeAndAppendHash adapts an input into a reasonably human-readable
-// representation, sanitizing problematic characters and including a hash of the
-// "original" value to guarantee a unique (with respect to the input) and
-// deterministic output.
-func sanitizeAndAppendHash(in ...any) string {
-	strs := make([]string, 0, len(in))
-	for _, i := range in {
-		strs = append(strs, fmt.Sprintf("%v", i))
-	}
-
-	joined := strings.Join(strs, "_")
-	sanitized := pathSanitizeRegex.ReplaceAllString(joined, "_")
-	if len(sanitized) > 64 {
-		// Limit the length of the "human readable" part of the table name to
-		// something reasonable.
-		sanitized = sanitized[:64]
-	}
-
-	return fmt.Sprintf("%s_%016X", sanitized, xxhash.Sum64String(joined))
-}
-
-func createNestedDotHashLocation(namespace, table string) string {
-	sanitized := pathSanitizeRegex.ReplaceAllString(namespace, "_") +
-		"/" + pathSanitizeRegex.ReplaceAllString(table, "_")
-	return fmt.Sprintf("%s.%016X", sanitized, xxhash.Sum64String(sanitized))
-}
-
-func createLocationSuffix(namespace, table string, style LocationStyle) string {
-	switch style {
-	case FlatLocationStyle:
-		return sanitizeAndAppendHash(namespace + "_" + table)
-	case NestedDotHashLocationStyle:
-		return createNestedDotHashLocation(namespace, table)
-	default:
-		panic("unknown location style")
-	}
 }

--- a/materialize-iceberg/locations.go
+++ b/materialize-iceberg/locations.go
@@ -1,0 +1,75 @@
+package connector
+
+import (
+	"fmt"
+	"path"
+	"regexp"
+	"strings"
+
+	"github.com/cespare/xxhash/v2"
+)
+
+// LocationStyle determines the location of the Iceberg table data.
+type LocationStyle int
+
+const (
+	FlatLocationStyle LocationStyle = iota
+	NestedDotHashLocationStyle
+)
+
+// Iceberg catalogs are generally case-insensitive and do not allow dots in
+// namespace or table names. AWS Glue is also very picky about anything other
+// than alphanumerics or underscores in namespace or table names.
+var pathSanitizeRegex = regexp.MustCompile("(?i)[^a-z0-9_]")
+
+func sanitize(name string) string {
+	return pathSanitizeRegex.ReplaceAllString(name, "_")
+}
+
+func sanitizePath(path ...string) []string {
+	out := []string{}
+	for _, p := range path {
+		out = append(out, strings.ToLower(sanitize(p)))
+	}
+
+	return out
+}
+
+// sanitizeAndAppendHash adapts an input into a reasonably human-readable
+// representation, sanitizing problematic characters and including a hash of the
+// "original" value to guarantee a unique (with respect to the input) and
+// deterministic output.
+func sanitizeAndAppendHash(in ...any) string {
+	strs := make([]string, 0, len(in))
+	for _, i := range in {
+		strs = append(strs, fmt.Sprintf("%v", i))
+	}
+
+	joined := strings.Join(strs, "_")
+	sanitized := sanitize(joined)
+	if len(sanitized) > 64 {
+		// Limit the length of the "human readable" part of the table name to
+		// something reasonable.
+		sanitized = sanitized[:64]
+	}
+
+	return fmt.Sprintf("%s_%016X", sanitized, xxhash.Sum64String(joined))
+}
+
+func createNestedDotHashLocation(namespace, table string) string {
+	sanitized := path.Join(sanitize(namespace), sanitize(table))
+	return fmt.Sprintf("%s.%016X", sanitized, xxhash.Sum64String(sanitized))
+}
+
+// CreateLocationSuffix returns a path suffix for the namespace and table in
+// the selected style.
+func createLocationSuffix(namespace, table string, style LocationStyle) string {
+	switch style {
+	case FlatLocationStyle:
+		return sanitizeAndAppendHash(namespace + "_" + table)
+	case NestedDotHashLocationStyle:
+		return createNestedDotHashLocation(namespace, table)
+	default:
+		panic("unknown location style")
+	}
+}

--- a/materialize-iceberg/locations_test.go
+++ b/materialize-iceberg/locations_test.go
@@ -22,11 +22,39 @@ func TestLocationSuffix(t *testing.T) {
 			expected:  "flow_mytable_15EEAE2C604ABEC4",
 		},
 		{
+			name:      "flat style needs sanitize",
+			namespace: "flow",
+			table:     "my.table",
+			style:     FlatLocationStyle,
+			expected:  "flow_my_table_D5723292493D5622",
+		},
+		{
+			name:      "flat style hyphen sanitize",
+			namespace: "flow",
+			table:     "my-table",
+			style:     FlatLocationStyle,
+			expected:  "flow_my_table_839FE986CB099DF4",
+		},
+		{
 			name:      "nested dot hash style",
 			namespace: "flow",
 			table:     "mytable",
 			style:     NestedDotHashLocationStyle,
 			expected:  "flow/mytable.D7D053D01D253AEB",
+		},
+		{
+			name:      "nested dot hash style needs sanitize",
+			namespace: "flow",
+			table:     "my.table",
+			style:     NestedDotHashLocationStyle,
+			expected:  "flow/my_table.25FBA56C761DB31B",
+		},
+		{
+			name:      "nested dot hash style hyphen no sanitize",
+			namespace: "flow",
+			table:     "my-table",
+			style:     NestedDotHashLocationStyle,
+			expected:  "flow/my_table.25FBA56C761DB31B",
 		},
 	}
 	for _, tt := range tests {

--- a/materialize-s3-iceberg/catalog.go
+++ b/materialize-s3-iceberg/catalog.go
@@ -12,11 +12,15 @@ import (
 )
 
 type catalog struct {
-	cfg *config
+	cfg           *config
+	locationStyle LocationStyle
 }
 
-func newCatalog(cfg config) *catalog {
-	return &catalog{cfg: &cfg}
+func newCatalog(cfg config, locationStyle LocationStyle) *catalog {
+	return &catalog{
+		cfg:           &cfg,
+		locationStyle: locationStyle,
+	}
 }
 
 func (c *catalog) populateInfoSchema(ctx context.Context, is *boilerplate.InfoSchema, resourcePaths [][]string) error {
@@ -106,7 +110,7 @@ func (c *catalog) createNamespace(ctx context.Context, namespace string) error {
 }
 
 func (c *catalog) CreateResource(ctx context.Context, b *pf.MaterializationSpec_Binding) (string, boilerplate.ActionApplyFn, error) {
-	tc := tableCreate{Location: tablePath(c.cfg.Bucket, c.cfg.Prefix, b.ResourcePath[0], b.ResourcePath[1])}
+	tc := tableCreate{Location: tablePath(c.cfg.Bucket, c.cfg.Prefix, b.ResourcePath[0], b.ResourcePath[1], c.locationStyle)}
 
 	parquetSchema, err := parquetSchema(b.FieldSelection.AllFields(), b.Collection, b.FieldSelection.FieldConfigJsonMap)
 	if err != nil {

--- a/materialize-s3-iceberg/driver.go
+++ b/materialize-s3-iceberg/driver.go
@@ -31,6 +31,13 @@ import (
 
 var featureFlagDefaults = map[string]bool{
 	"retain_existing_data_on_backfill": false,
+
+	// An alternate naming style for the Iceberg table data.  By default (when
+	// false), the naming is:
+	//   <base_location>/<namespace>/<table>_<hash>
+	// When this flag is enabled:
+	//   <base_location>/<namespace>/<table>.<hash>
+	"nested_dot_hash_location_style": false,
 }
 
 type catalogType string
@@ -264,7 +271,12 @@ func newMaterialization(ctx context.Context, materializationName string, cfg con
 			cfg.Prefix = "__r2_data_catalog/" + cfg.Prefix
 		}
 	}
-	catalog := newCatalog(cfg)
+	locationStyle := NestedLocationStyle
+	if featureFlags["nested_dot_hash_location_style"] {
+		locationStyle = NestedDotHashLocationStyle
+	}
+
+	catalog := newCatalog(cfg, locationStyle)
 
 	return &materialization{
 		cfg:     cfg,

--- a/materialize-s3-iceberg/locations.go
+++ b/materialize-s3-iceberg/locations.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"fmt"
+	"path"
+	"regexp"
+
+	"github.com/cespare/xxhash/v2"
+)
+
+// LocationStyle determines the location of the Iceberg table data in object
+// storage.
+//
+// In contrast to materialize-iceberg, this connector uses a nested directory
+// structure.
+type LocationStyle int
+
+const (
+	NestedLocationStyle LocationStyle = iota
+	NestedDotHashLocationStyle
+)
+
+// Iceberg catalogs are generally case-insensitive and do not allow dots in
+// namespace or table names.
+//
+// Note: Unlike materialize-snowflake, this regex allows hyphens.
+var identifierSanitizerRegexp = regexp.MustCompile(`[^\-_0-9a-zA-Z]`)
+
+func sanitize(name string) string {
+	return identifierSanitizerRegexp.ReplaceAllString(name, "_")
+}
+
+// sanitizeTable adapts a table name into a reasonably human-readable
+// representation, sanitizing problematic characters from the table name and
+// including a hash of the "original" value to guarantee uniqueness.
+// Alphanumerics, hyphens, and underscores are left as-is and others are
+// converted to underscores. S3 object names are actually very flexible in the
+// characters they allow but generally characters outside of these common ones
+// can cause issues with clients trying to read the named objects.
+func sanitizeTable(table string) string {
+	sanitized := sanitize(table)
+	if len(sanitized) > 64 {
+		// Limit the length of the "human readable" part of the table name to
+		// something reasonable.
+		sanitized = sanitized[:64]
+	}
+
+	hash := xxhash.Sum64String(table)
+	return fmt.Sprintf("%s_%016X", sanitized, hash)
+}
+
+func createNestedLocation(namespace, table string) string {
+	return path.Join(sanitize(namespace), sanitizeTable(table))
+}
+
+func createNestedDotHashLocation(namespace, table string) string {
+	sanitized := path.Join(sanitize(namespace), sanitize(table))
+	return fmt.Sprintf("%s.%016X", sanitized, xxhash.Sum64String(sanitized))
+}
+
+// CreateLocationSuffix returns a path suffix for the namespace and table in
+// the selected style.
+func createLocationSuffix(namespace, table string, style LocationStyle) string {
+	switch style {
+	case NestedLocationStyle:
+		return createNestedLocation(namespace, table)
+	case NestedDotHashLocationStyle:
+		return createNestedDotHashLocation(namespace, table)
+	default:
+		panic("unknown location style")
+	}
+}

--- a/materialize-s3-iceberg/locations_test.go
+++ b/materialize-s3-iceberg/locations_test.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestLocationSuffix(t *testing.T) {
+	tests := []struct {
+		name      string
+		namespace string
+		table     string
+		style     LocationStyle
+		expected  string
+	}{
+		{
+			name:      "nested style",
+			namespace: "flow",
+			table:     "mytable",
+			style:     NestedLocationStyle,
+			expected:  "flow/mytable_3A6FA27EC5D2E5B2",
+		},
+		{
+			name:      "nested style needs sanitize",
+			namespace: "flow",
+			table:     "my.table",
+			style:     NestedLocationStyle,
+			expected:  "flow/my_table_1224DB2BF670A673",
+		},
+		{
+			name:      "nested style hyphen no sanitize",
+			namespace: "flow",
+			table:     "my-table",
+			style:     NestedLocationStyle,
+			expected:  "flow/my-table_8B5C97BB6111DDEE",
+		},
+		{
+			name:      "nested dot hash style",
+			namespace: "flow",
+			table:     "mytable",
+			style:     NestedDotHashLocationStyle,
+			expected:  "flow/mytable.D7D053D01D253AEB",
+		},
+		{
+			name:      "nested dot hash style needs sanitize",
+			namespace: "flow",
+			table:     "my.table",
+			style:     NestedDotHashLocationStyle,
+			expected:  "flow/my_table.25FBA56C761DB31B",
+		},
+		{
+			name:      "nested dot hash style hyphen no sanitize",
+			namespace: "flow",
+			table:     "my-table",
+			style:     NestedDotHashLocationStyle,
+			expected:  "flow/my-table.47E2A0063A659F99",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual := createLocationSuffix(tt.namespace, tt.table, tt.style)
+			require.Equal(t, tt.expected, actual)
+		})
+	}
+}

--- a/materialize-s3-iceberg/transactor.go
+++ b/materialize-s3-iceberg/transactor.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 	"path"
-	"regexp"
 	"strings"
 	"time"
 
@@ -29,29 +28,8 @@ const (
 	fileSizeLimit = 512 * 1024 * 1024
 )
 
-var identifierSanitizerRegexp = regexp.MustCompile(`[^\-_0-9a-zA-Z]`)
-
-// sanitizeTable adapts a table name into a reasonably human-readable
-// representation, sanitizing problematic characters from the table name and
-// including a hash of the "original" value to guarantee uniqueness.
-// Alphanumerics, hyphens, and underscores are left as-is and others are
-// converted to underscores. S3 object names are actually very flexible in the
-// characters they allow but generally characters outside of these common ones
-// can cause issues with clients trying to read the named objects.
-func sanitizeTable(table string) string {
-	sanitized := identifierSanitizerRegexp.ReplaceAllString(table, "_")
-	if len(sanitized) > 64 {
-		// Limit the length of the "human readable" part of the table name to
-		// something reasonable.
-		sanitized = sanitized[:64]
-	}
-
-	hash := xxhash.Sum64String(table)
-	return fmt.Sprintf("%s_%016X", sanitized, hash)
-}
-
-func tablePath(bucket, prefix, namespace, table string) string {
-	return fmt.Sprintf("s3://%s/", path.Join(bucket, prefix, namespace, sanitizeTable(table)))
+func tablePath(bucket, prefix, namespace, table string, style LocationStyle) string {
+	return fmt.Sprintf("s3://%s/", path.Join(bucket, prefix, createLocationSuffix(namespace, table, style)))
 }
 
 // filePath returns path information for a new file, including both the object


### PR DESCRIPTION
Similar to the flag added to the materialize-iceberg connector, this flag changes the table data paths in object storage to:
```
  <base_location>/<namespace>/<table>.<hash>
```

I brought the logic for table location naming into its own file for both iceberg connectors to better be able to compare them.

There are some notable differences between them, unlike materialize-iceberg this connector allows hyphens in namespace and table names and it always uses a nested layout with a directory for the namespace.

closes: #4136

**Workflow steps:**

To enable set the `nested_dot_hash_location_style` feature flag.

**Documentation links affected:**

None planned

**Notes for reviewers:**


