### PR TITLE
estuary-cdk: label port 8080 as public for webhook capture connectors

### DIFF
--- a/estuary-cdk/webhook-capture.Dockerfile
+++ b/estuary-cdk/webhook-capture.Dockerfile
@@ -52,5 +52,6 @@ ENV ENCRYPTION_URL=${ENCRYPTION_URL}
 ENV CONNECTOR_NAME=${CONNECTOR_NAME}
 
 EXPOSE 8080
+LABEL dev.estuary.port-public.8080=true
 
 CMD ["/bin/sh", "-c", "/opt/venv/bin/python -m $(echo \"$CONNECTOR_NAME\" | tr '-' '_')"]


### PR DESCRIPTION
**Description:**

This change follows the pattern seen in [`source-http-ingest`](https://github.com/estuary/connectors/blob/nlazo/fix-webhook-capture-dockerfile-public-port/source-http-ingest/Dockerfile), where port 8080 is marked as public in addition to being exposed through the Dockerfile.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

