### PR TITLE
source-appsflyer: inherit from the CDK's WebhookResourceConfig

### DIFF
--- a/estuary-cdk/estuary_cdk/capture/webhook/server.py
+++ b/estuary-cdk/estuary_cdk/capture/webhook/server.py
@@ -178,7 +178,15 @@ def start_webhook_server(
     Since non-webhook tasks can take minutes/hours to gracefully shut down,
     we want to wait until they are done to stop listening for webhooks.
     """
-    task.log.info("Starting webhook server")
+    task.log.info(
+        "Starting webhook server",
+        {
+            "bindings": [
+                {"index": idx, "name": rsc.initial_config.name}
+                for idx, rsc in binding_index_mapping.items()
+            ]
+        },
+    )
 
     async def run():
         async with asyncio.TaskGroup() as webhook_tg:

--- a/source-appsflyer/source_appsflyer/resources.py
+++ b/source-appsflyer/source_appsflyer/resources.py
@@ -2,21 +2,19 @@ import asyncio
 import functools
 from datetime import UTC, datetime, timedelta
 from logging import Logger
-from typing import Annotated, ClassVar, Literal, override
+from typing import Annotated, ClassVar, Literal
 
 from estuary_cdk.capture import common
 from estuary_cdk.capture.common import (
-    BaseResourceConfig,
     Resource,
     ResourceConfig,
     ResourceState,
 )
-from estuary_cdk.capture.webhook.match import (
-    BodyDiscriminator,
-    CollectionMatchingSpec,
-    UrlMatch,
+from estuary_cdk.capture.webhook.match import BodyDiscriminator
+from estuary_cdk.capture.webhook.resources import (
+    WebhookResourceConfig,
+    open_webhook_binding,
 )
-from estuary_cdk.capture.webhook.resources import open_webhook_binding
 from estuary_cdk.flow import CaptureBinding
 from estuary_cdk.http import HTTPMixin, TokenSource
 from pydantic import Field, TypeAdapter
@@ -41,23 +39,14 @@ class PullApiResourceConfig(ResourceConfig):
     type: Literal["pull"]
 
 
-class WebhookResourceConfig(BaseResourceConfig):
+class AppsFlyerWebhookResourceConfig(WebhookResourceConfig):
     PATH_POINTERS: ClassVar[list[str]] = ["/name"]
 
     type: Literal["webhook"]
-    name: str = Field(description="Name of this resource")
-    match_rule: CollectionMatchingSpec = Field(
-        default_factory=lambda: UrlMatch(value="*"),
-        description="Matching spec for routing incoming webhooks to this collection",
-    )
-
-    @override
-    def path(self) -> list[str]:
-        return [self.name]
 
 
 AnyResourceConfig = Annotated[
-    PullApiResourceConfig | WebhookResourceConfig,
+    PullApiResourceConfig | AppsFlyerWebhookResourceConfig,
     Field(discriminator="type"),
 ]
 
@@ -176,7 +165,7 @@ async def all_resources(
             model=AppsFlyerWebhookDocument,
             open=open_webhook_binding,  # pyright: ignore[reportArgumentType]
             initial_state=ResourceState(),
-            initial_config=WebhookResourceConfig(
+            initial_config=AppsFlyerWebhookResourceConfig(
                 name=f"{rule.display_name}",
                 type="webhook",
                 match_rule=rule,

--- a/source-appsflyer/tests/snapshots/snapshots__spec__stdout.json
+++ b/source-appsflyer/tests/snapshots/snapshots__spec__stdout.json
@@ -75,6 +75,63 @@
     },
     "resourceConfigSchema": {
       "$defs": {
+        "AppsFlyerWebhookResourceConfig": {
+          "additionalProperties": false,
+          "properties": {
+            "_meta": {
+              "anyOf": [
+                {
+                  "additionalProperties": true,
+                  "type": "object"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "title": "Meta"
+            },
+            "name": {
+              "description": "Name of this resource",
+              "title": "Name",
+              "type": "string"
+            },
+            "match_rule": {
+              "description": "Matching spec for routing incoming webhooks to this collection",
+              "discriminator": {
+                "mapping": {
+                  "body": "#/$defs/BodyMatch",
+                  "header": "#/$defs/HeaderMatch",
+                  "url": "#/$defs/UrlMatch"
+                },
+                "propertyName": "type"
+              },
+              "oneOf": [
+                {
+                  "$ref": "#/$defs/UrlMatch"
+                },
+                {
+                  "$ref": "#/$defs/HeaderMatch"
+                },
+                {
+                  "$ref": "#/$defs/BodyMatch"
+                }
+              ],
+              "title": "Match Rule"
+            },
+            "type": {
+              "const": "webhook",
+              "title": "Type",
+              "type": "string"
+            }
+          },
+          "required": [
+            "name",
+            "type"
+          ],
+          "title": "AppsFlyerWebhookResourceConfig",
+          "type": "object"
+        },
         "BodyMatch": {
           "properties": {
             "value": {
@@ -183,61 +240,12 @@
           ],
           "title": "UrlMatch",
           "type": "object"
-        },
-        "WebhookResourceConfig": {
-          "additionalProperties": false,
-          "properties": {
-            "_meta": {
-              "anyOf": [
-                {
-                  "additionalProperties": true,
-                  "type": "object"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "default": null,
-              "title": "Meta"
-            },
-            "type": {
-              "const": "webhook",
-              "title": "Type",
-              "type": "string"
-            },
-            "name": {
-              "description": "Name of this resource",
-              "title": "Name",
-              "type": "string"
-            },
-            "match_rule": {
-              "anyOf": [
-                {
-                  "$ref": "#/$defs/UrlMatch"
-                },
-                {
-                  "$ref": "#/$defs/HeaderMatch"
-                },
-                {
-                  "$ref": "#/$defs/BodyMatch"
-                }
-              ],
-              "description": "Matching spec for routing incoming webhooks to this collection",
-              "title": "Match Rule"
-            }
-          },
-          "required": [
-            "type",
-            "name"
-          ],
-          "title": "WebhookResourceConfig",
-          "type": "object"
         }
       },
       "discriminator": {
         "mapping": {
           "pull": "#/$defs/PullApiResourceConfig",
-          "webhook": "#/$defs/WebhookResourceConfig"
+          "webhook": "#/$defs/AppsFlyerWebhookResourceConfig"
         },
         "propertyName": "type"
       },
@@ -246,7 +254,7 @@
           "$ref": "#/$defs/PullApiResourceConfig"
         },
         {
-          "$ref": "#/$defs/WebhookResourceConfig"
+          "$ref": "#/$defs/AppsFlyerWebhookResourceConfig"
         }
       ]
     },


### PR DESCRIPTION
**Description:**

Fixes resource discovery by inheriting from the CDK's `WebhookResourceConfig` definition rather than redefining it locally in the connector.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

