### PR TITLE
source-greenhouse-native: add four additional streams

### DIFF
--- a/source-greenhouse-native/source_greenhouse_native/models.py
+++ b/source-greenhouse-native/source_greenhouse_native/models.py
@@ -207,6 +207,16 @@ class Interviewers(GreenhouseResource):
     path: ClassVar[str] = "interviewers"
 
 
+class InterviewerTags(GreenhouseResource):
+    name: ClassVar[str] = "interviewer_tags"
+    path: ClassVar[str] = "interviewer_tags"
+
+
+class JobHiringManagers(GreenhouseResource):
+    name: ClassVar[str] = "job_hiring_managers"
+    path: ClassVar[str] = "job_hiring_managers"
+
+
 class JobNotes(GreenhouseResource):
     name: ClassVar[str] = "job_notes"
     path: ClassVar[str] = "job_notes"
@@ -250,6 +260,16 @@ class ProspectPools(GreenhouseResource):
 class ProspectPoolStages(GreenhouseResource):
     name: ClassVar[str] = "prospect_pool_stages"
     path: ClassVar[str] = "prospect_pool_stages"
+
+
+class Referrers(GreenhouseResource):
+    name: ClassVar[str] = "referrers"
+    path: ClassVar[str] = "referrers"
+
+
+class RejectionDetails(GreenhouseResource):
+    name: ClassVar[str] = "rejection_details"
+    path: ClassVar[str] = "rejection_details"
 
 
 class RejectionReasons(GreenhouseResource):
@@ -316,6 +336,8 @@ INCREMENTAL_RESOURCES: list[type[GreenhouseResource]] = [
     EmailTemplates,
     Interviews,
     Interviewers,
+    InterviewerTags,
+    JobHiringManagers,
     JobInterviewStages,
     JobNotes,
     JobPosts,
@@ -325,6 +347,8 @@ INCREMENTAL_RESOURCES: list[type[GreenhouseResource]] = [
     Openings,
     ProspectPools,
     ProspectPoolStages,
+    Referrers,
+    RejectionDetails,
     RejectionReasons,
     ScorecardQuestions,
     Scorecards,

--- a/source-greenhouse-native/tests/snapshots/snapshots__discover__capture.stdout.json
+++ b/source-greenhouse-native/tests/snapshots/snapshots__discover__capture.stdout.json
@@ -1386,6 +1386,72 @@
     ]
   },
   {
+    "recommendedName": "interviewer_tags",
+    "resourceConfig": {
+      "name": "interviewer_tags",
+      "interval": "PT5M"
+    },
+    "documentSchema": {
+      "$defs": {
+        "Meta": {
+          "properties": {
+            "op": {
+              "default": "u",
+              "description": "Operation type (c: Create, u: Update, d: Delete)",
+              "enum": [
+                "c",
+                "u",
+                "d"
+              ],
+              "title": "Op",
+              "type": "string"
+            },
+            "row_id": {
+              "default": -1,
+              "description": "Row ID of the Document, counting up from zero, or -1 if not known",
+              "title": "Row Id",
+              "type": "integer"
+            }
+          },
+          "title": "Meta",
+          "type": "object"
+        }
+      },
+      "additionalProperties": true,
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/Meta",
+          "description": "Document metadata"
+        },
+        "id": {
+          "title": "Id",
+          "type": "integer"
+        },
+        "created_at": {
+          "format": "date-time",
+          "title": "Created At",
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time",
+          "title": "Updated At",
+          "type": "string"
+        }
+      },
+      "required": [
+        "id",
+        "created_at",
+        "updated_at"
+      ],
+      "title": "GreenhouseResource",
+      "type": "object",
+      "x-infer-schema": true
+    },
+    "key": [
+      "/id"
+    ]
+  },
+  {
     "recommendedName": "interviewers",
     "resourceConfig": {
       "name": "interviewers",
@@ -1455,6 +1521,72 @@
     "recommendedName": "interviews",
     "resourceConfig": {
       "name": "interviews",
+      "interval": "PT5M"
+    },
+    "documentSchema": {
+      "$defs": {
+        "Meta": {
+          "properties": {
+            "op": {
+              "default": "u",
+              "description": "Operation type (c: Create, u: Update, d: Delete)",
+              "enum": [
+                "c",
+                "u",
+                "d"
+              ],
+              "title": "Op",
+              "type": "string"
+            },
+            "row_id": {
+              "default": -1,
+              "description": "Row ID of the Document, counting up from zero, or -1 if not known",
+              "title": "Row Id",
+              "type": "integer"
+            }
+          },
+          "title": "Meta",
+          "type": "object"
+        }
+      },
+      "additionalProperties": true,
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/Meta",
+          "description": "Document metadata"
+        },
+        "id": {
+          "title": "Id",
+          "type": "integer"
+        },
+        "created_at": {
+          "format": "date-time",
+          "title": "Created At",
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time",
+          "title": "Updated At",
+          "type": "string"
+        }
+      },
+      "required": [
+        "id",
+        "created_at",
+        "updated_at"
+      ],
+      "title": "GreenhouseResource",
+      "type": "object",
+      "x-infer-schema": true
+    },
+    "key": [
+      "/id"
+    ]
+  },
+  {
+    "recommendedName": "job_hiring_managers",
+    "resourceConfig": {
+      "name": "job_hiring_managers",
       "interval": "PT5M"
     },
     "documentSchema": {
@@ -2049,6 +2181,138 @@
     "recommendedName": "prospect_pools",
     "resourceConfig": {
       "name": "prospect_pools",
+      "interval": "PT5M"
+    },
+    "documentSchema": {
+      "$defs": {
+        "Meta": {
+          "properties": {
+            "op": {
+              "default": "u",
+              "description": "Operation type (c: Create, u: Update, d: Delete)",
+              "enum": [
+                "c",
+                "u",
+                "d"
+              ],
+              "title": "Op",
+              "type": "string"
+            },
+            "row_id": {
+              "default": -1,
+              "description": "Row ID of the Document, counting up from zero, or -1 if not known",
+              "title": "Row Id",
+              "type": "integer"
+            }
+          },
+          "title": "Meta",
+          "type": "object"
+        }
+      },
+      "additionalProperties": true,
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/Meta",
+          "description": "Document metadata"
+        },
+        "id": {
+          "title": "Id",
+          "type": "integer"
+        },
+        "created_at": {
+          "format": "date-time",
+          "title": "Created At",
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time",
+          "title": "Updated At",
+          "type": "string"
+        }
+      },
+      "required": [
+        "id",
+        "created_at",
+        "updated_at"
+      ],
+      "title": "GreenhouseResource",
+      "type": "object",
+      "x-infer-schema": true
+    },
+    "key": [
+      "/id"
+    ]
+  },
+  {
+    "recommendedName": "referrers",
+    "resourceConfig": {
+      "name": "referrers",
+      "interval": "PT5M"
+    },
+    "documentSchema": {
+      "$defs": {
+        "Meta": {
+          "properties": {
+            "op": {
+              "default": "u",
+              "description": "Operation type (c: Create, u: Update, d: Delete)",
+              "enum": [
+                "c",
+                "u",
+                "d"
+              ],
+              "title": "Op",
+              "type": "string"
+            },
+            "row_id": {
+              "default": -1,
+              "description": "Row ID of the Document, counting up from zero, or -1 if not known",
+              "title": "Row Id",
+              "type": "integer"
+            }
+          },
+          "title": "Meta",
+          "type": "object"
+        }
+      },
+      "additionalProperties": true,
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/Meta",
+          "description": "Document metadata"
+        },
+        "id": {
+          "title": "Id",
+          "type": "integer"
+        },
+        "created_at": {
+          "format": "date-time",
+          "title": "Created At",
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time",
+          "title": "Updated At",
+          "type": "string"
+        }
+      },
+      "required": [
+        "id",
+        "created_at",
+        "updated_at"
+      ],
+      "title": "GreenhouseResource",
+      "type": "object",
+      "x-infer-schema": true
+    },
+    "key": [
+      "/id"
+    ]
+  },
+  {
+    "recommendedName": "rejection_details",
+    "resourceConfig": {
+      "name": "rejection_details",
       "interval": "PT5M"
     },
     "documentSchema": {


### PR DESCRIPTION
**Description:**

Adds `interviewer_tags`, `job_hiring_managers`, `referrers`, and `rejection_details`. All four fit the existing incremental pattern of `updated_at` filtering with `id`/`created_at`/`updated_at` fields, so no changes are required beyond registering the resources.

Closes #4253.

Connector documentation will need updated to include the four new streams.