### PR TITLE
source-appsflyer: honor user-configured window_size

### DIFF
--- a/source-appsflyer/source_appsflyer/api.py
+++ b/source-appsflyer/source_appsflyer/api.py
@@ -234,7 +234,9 @@ async def _fetch_adaptive_window(
 
     Yields validated documents, then the actual window_end datetime as the final item.
     """
-    window_size = min(window_size, timedelta(days=1))
+    # TODO: Ideally, we'd detect when we hit the daily limit of requests
+    # asking for 3+ days of data then automatically resize the window to 2
+    # or fewer days as appropriate.
     while True:
         window_end = min(start_time + window_size, end_time)
 

--- a/source-appsflyer/source_appsflyer/models.py
+++ b/source-appsflyer/source_appsflyer/models.py
@@ -52,9 +52,8 @@ class EndpointConfig(BaseModel):
                 "Window size for incremental streams in ISO 8601 format. "
                 "ex: P30D means 30 days, PT6H means 6 hours."
             ),
-            default=timedelta(days=7),
+            default=timedelta(days=2),
             ge=timedelta(days=1),
-            le=timedelta(days=90),
         )
 
     advanced: Advanced = Field(

--- a/source-appsflyer/tests/snapshots/snapshots__capture__stdout.json
+++ b/source-appsflyer/tests/snapshots/snapshots__capture__stdout.json
@@ -1,1 +1,35 @@
-[]
+[
+  [
+    "acmeCo/daily_geo_aggregate_report",
+    {
+      "ARPU": "61.9500",
+      "Agency/PMD (af_prt)": "None",
+      "Average eCPI": "N/A",
+      "CTR": "N/A",
+      "Campaign (c)": "None",
+      "Clicks": "N/A",
+      "Conversion Rate": "N/A",
+      "Country": "None",
+      "Date": "2026-04-07",
+      "Impressions": "N/A",
+      "Installs": "1",
+      "Loyal Users": "0",
+      "Loyal Users/Installs": "0.0000",
+      "Media Source (pid)": "Organic",
+      "ROI": "N/A",
+      "Sessions": "0",
+      "Total Cost": "N/A",
+      "Total Revenue": "61.9500",
+      "_meta": {
+        "app_id": "nativepc-1313456",
+        "uuid": "DocUUIDPlaceholder-329Bb50aa48EAa9ef"
+      },
+      "af_purchase (Event counter)": "4",
+      "af_purchase (Sales in USD)": "51.96",
+      "af_purchase (Unique users)": "1",
+      "af_subscribe (Event counter)": "1",
+      "af_subscribe (Sales in USD)": "9.99",
+      "af_subscribe (Unique users)": "1"
+    }
+  ]
+]

--- a/source-appsflyer/tests/snapshots/snapshots__spec__stdout.json
+++ b/source-appsflyer/tests/snapshots/snapshots__spec__stdout.json
@@ -26,7 +26,7 @@
         "Advanced": {
           "properties": {
             "window_size": {
-              "default": "P7D",
+              "default": "P2D",
               "description": "Window size for incremental streams in ISO 8601 format. ex: P30D means 30 days, PT6H means 6 hours.",
               "format": "duration",
               "title": "Window Size",


### PR DESCRIPTION
**Description:**

Previously the incremental fetch loop unconditionally clamped every request window to at most 1 day, so the configurable window_size had no practical effect — a user setting 7 days or 30 days still got 1-day requests. The config also rejected values above 90 days.

Remove both the 90-day validation cap and the 1-day runtime clamp so the configured value actually drives the fetch window. Lower the default from 7 to 2 days: 2 days should not trigger AppsFlyer's "request window too large" error for any known endpoint, keeps the default modestly larger than before while still being safe, and lets users opt into larger values deliberately. A TODO marks the follow-up to detect that error and shrink the window reactively (I didn't implement that yet cause we don't know what that specific error looks like).

The capture snapshot change is expected - increasing the default window size allowed `flowctl preview` to actually capture a document.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

The connector's documentation should be updated to reflect the new default & removal of a maximum limit for the `advanced.window_size` setting.

**Notes for reviewers:**

(anything that might help someone review this PR)

