### PR TITLE
source-oracle: fix oracle 11g compatibility issues

### DIFF
--- a/source-oracle/backfill.go
+++ b/source-oracle/backfill.go
@@ -324,15 +324,16 @@ func (db *oracleDatabase) fetchBackfillRowIDRange(ctx context.Context, schemaNam
 	return nil
 }
 
-// The set of column types for which we need to specify `COLLATE BINARY` to get
+// The set of column types for which we need to use `NLSSORT` with binary sorting to get
 // proper ordering and comparison. Represented as a map[string]bool so that it can be
 // combined with the "is the column typename a string" check into one if statement.
-// See https://docs.oracle.com/en/database/oracle/oracle-database/19/sqlrf/COLLATE-Operator.html
+// See https://docs.oracle.com/en/database/oracle/oracle-database/19/sqlrf/NLSSORT.html
 var columnBinaryKeyComparison = map[string]bool{
-	"varchar2": true,
 	"char":     true,
-	"nvarchar": true,
 	"nchar":    true,
+	"nvarchar2": true,
+	"varchar": true,
+	"varchar2": true,
 }
 
 // render a "cast" expression for a column so that we can cast it to the
@@ -438,24 +439,31 @@ func (db *oracleDatabase) buildScanQuery(start bool, info *sqlcapture.DiscoveryI
 	var pkey []string
 	var args []string
 	for idx, colName := range keyColumns {
-		var quotedName = quoteColumnName(colName)
+		quotedName := quoteColumnName(colName)
+		arg := fmt.Sprintf(":p%d", idx+1)
 		// If a precise backfill is requested *and* the column type requires binary ordering for precise
-		// backfill comparisons to work, add the 'COLLATE BINARY' qualifier to the column name.
-		if columnTypes[colName].JsonType == "string" && columnBinaryKeyComparison[colName] {
-			pkey = append(pkey, quotedName+" COLLATE BINARY")
+		// backfill comparisons to work, use NLSSORT with binary sorting so that comparisons
+		// and ordering are consistent regardless of database NLS settings. NLSSORT is used
+		// instead of the COLLATE operator for compatibility with Oracle 11g.
+		colType := strings.ToLower(columnTypes[colName].Original)
+		if columnTypes[colName].JsonType == "string" && columnBinaryKeyComparison[colType] {
+			pkey = append(pkey, fmt.Sprintf("NLSSORT(%s, 'NLS_SORT=BINARY')", quotedName))
+			arg = fmt.Sprintf("NLSSORT(%s, 'NLS_SORT=BINARY')", arg)
 		} else {
 			pkey = append(pkey, quotedName)
 		}
-		args = append(args, fmt.Sprintf(":p%d", idx+1))
+		args = append(args, arg)
 	}
 
-	// Construct the query itself
-	var query = new(strings.Builder)
+	// Construct the query itself. A ROWNUM wrapper is used instead of FETCH NEXT
+	// for compatibility with Oracle 11g. The subquery is important: ROWNUM is applied
+	// on the outer query so that the inner query's ORDER BY executes first.
+	query := new(strings.Builder)
 	var columnSelect []string
 	for _, col := range info.Columns {
 		columnSelect = append(columnSelect, castColumn(col))
 	}
-	fmt.Fprintf(query, `SELECT ROWID, %s FROM "%s"."%s"`, strings.Join(columnSelect, ","), schemaName, tableName)
+	fmt.Fprintf(query, `SELECT * FROM (SELECT ROWID, %s FROM "%s"."%s"`, strings.Join(columnSelect, ","), schemaName, tableName)
 	if !start {
 		for i := 0; i != len(pkey); i++ {
 			if i == 0 {
@@ -472,7 +480,7 @@ func (db *oracleDatabase) buildScanQuery(start bool, info *sqlcapture.DiscoveryI
 		fmt.Fprintf(query, ")")
 	}
 	fmt.Fprintf(query, " ORDER BY %s ASC", strings.Join(pkey, ", "))
-	fmt.Fprintf(query, ` FETCH NEXT %d ROWS ONLY`, db.config.Advanced.BackfillChunkSize)
+	fmt.Fprintf(query, `) WHERE ROWNUM <= %d`, db.config.Advanced.BackfillChunkSize)
 	return query.String()
 }
 

--- a/source-oracle/main.go
+++ b/source-oracle/main.go
@@ -111,20 +111,40 @@ func connectOracle(ctx context.Context, name string, cfg json.RawMessage) (sqlca
 		return nil, err
 	}
 
-	var isContainerDatabase string
-	var row = db.conn.QueryRowContext(ctx, "SELECT CDB FROM V$DATABASE")
-	if err := row.Scan(&isContainerDatabase); err != nil {
-		return nil, fmt.Errorf("querying CDB status: %w", err)
+	var version string
+	var row = db.conn.QueryRowContext(ctx, "SELECT VERSION FROM V$INSTANCE")
+	if err := row.Scan(&version); err != nil {
+		return nil, fmt.Errorf("querying database version: %w", err)
+	}
+	log.WithField("version", version).Info("detected Oracle database version")
+
+	parts := strings.SplitN(version, ".", 2)
+	if len(parts) == 0 || parts[0] == "" {
+		return nil, fmt.Errorf("unexpected empty version string from V$INSTANCE")
+	}
+	majorVersion, err := strconv.Atoi(parts[0])
+	if err != nil {
+		return nil, fmt.Errorf("parsing major version from %q: %w", version, err)
 	}
 
-	if isContainerDatabase == "YES" {
-		var containerName string
-		var row = db.conn.QueryRowContext(ctx, "SELECT SYS_CONTEXT('USERENV', 'CON_NAME') AS CONTAINER_NAME FROM DUAL")
+	// Container Database (CDB) architecture was introduced in Oracle 12c.
+	// The CDB column in V$DATABASE does not exist in earlier versions.
+	if majorVersion >= 12 {
+		var isContainerDatabase string
+		var row = db.conn.QueryRowContext(ctx, "SELECT CDB FROM V$DATABASE")
+		if err := row.Scan(&isContainerDatabase); err != nil {
+			return nil, fmt.Errorf("querying CDB status: %w", err)
+		}
 
-		if err := row.Scan(&containerName); err != nil {
-			return nil, fmt.Errorf("querying current container name: %w", err)
-		} else if containerName != "CDB$ROOT" && containerName != "DATABASE" {
-			db.pdbName = containerName
+		if isContainerDatabase == "YES" {
+			var containerName string
+			var row = db.conn.QueryRowContext(ctx, "SELECT SYS_CONTEXT('USERENV', 'CON_NAME') AS CONTAINER_NAME FROM DUAL")
+
+			if err := row.Scan(&containerName); err != nil {
+				return nil, fmt.Errorf("querying current container name: %w", err)
+			} else if containerName != "CDB$ROOT" && containerName != "DATABASE" {
+				db.pdbName = containerName
+			}
 		}
 	}
 


### PR DESCRIPTION
**Description:**

This PR replaces the three features implemented in Oracle 12+ with 11g-friendly alternatives:

- CDB checks are only queried if the source's major version >= 12
- `FETCH NEXT` clauses are replaced with `ROWNUM` subqueries
- Uses `NLSSORT` in place of `COLLATE BINARY` for sorting string-like columns

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

The docker image has been replaced with an 11g alternative locally to reproduce the reported exceptions. After tests passed, the original test suite was restored to ensure no regressions were present.

