### PR TITLE
materialize-snowflake: per-binding clustering option

### DIFF
--- a/materialize-snowflake/.snapshots/TestSpecification
+++ b/materialize-snowflake/.snapshots/TestSpecification
@@ -290,6 +290,12 @@
         "title": "Delta Updates",
         "description": "Use Private Key authentication to enable Snowpipe Streaming for Delta Update bindings",
         "x-delta-updates": true
+      },
+      "clustering": {
+        "type": "boolean",
+        "title": "Automatic Clustering",
+        "description": "Enable Snowflake Automatic Clustering on this table using the collection key columns as the clustering key. Recommended only for large tables queried with selective filters on key columns. Consumes additional Snowflake credits.",
+        "advanced": true
       }
     },
     "type": "object",

--- a/materialize-snowflake/.snapshots/TestSpecification
+++ b/materialize-snowflake/.snapshots/TestSpecification
@@ -292,9 +292,12 @@
         "x-delta-updates": true
       },
       "clustering": {
-        "type": "boolean",
-        "title": "Automatic Clustering",
-        "description": "Enable Snowflake Automatic Clustering on this table using the collection key columns as the clustering key. Recommended only for large tables queried with selective filters on key columns. Consumes additional Snowflake credits.",
+        "items": {
+          "type": "string"
+        },
+        "type": "array",
+        "title": "Clustering Key Columns",
+        "description": "Enable Snowflake Automatic Clustering on this table using the listed fields as the clustering key. Fields must match column names on the materialized table. Leave empty to disable clustering. Recommended only for large tables queried with selective filters on these columns. Consumes additional Snowflake credits.",
         "advanced": true
       }
     },

--- a/materialize-snowflake/.snapshots/TestSpecification
+++ b/materialize-snowflake/.snapshots/TestSpecification
@@ -292,12 +292,9 @@
         "x-delta-updates": true
       },
       "clustering": {
-        "items": {
-          "type": "string"
-        },
-        "type": "array",
-        "title": "Clustering Key Columns",
-        "description": "Enable Snowflake Automatic Clustering on this table using the listed fields as the clustering key. Fields must match column names on the materialized table. Leave empty to disable clustering. Recommended only for large tables queried with selective filters on these columns. Consumes additional Snowflake credits.",
+        "type": "boolean",
+        "title": "Automatic Clustering",
+        "description": "Enable Snowflake Automatic Clustering on this table using the collection key columns as the clustering key. Recommended only for large tables queried with selective filters on key columns. Consumes additional Snowflake credits.",
         "advanced": true
       }
     },

--- a/materialize-snowflake/.snapshots/TestSpecification
+++ b/materialize-snowflake/.snapshots/TestSpecification
@@ -292,9 +292,9 @@
         "x-delta-updates": true
       },
       "clustering": {
-        "type": "boolean",
-        "title": "Automatic Clustering",
-        "description": "Enable Snowflake Automatic Clustering on this table using the collection key columns as the clustering key. Recommended only for large tables queried with selective filters on key columns. Consumes additional Snowflake credits.",
+        "type": "string",
+        "title": "Clustering Keys",
+        "description": "Comma-separated list of column names to use as the clustering key for Snowflake Automatic Clustering. Leave empty to disable clustering. Recommended only for large tables queried with selective filters on the chosen columns. Consumes additional Snowflake credits.",
         "advanced": true
       }
     },

--- a/materialize-snowflake/client.go
+++ b/materialize-snowflake/client.go
@@ -195,11 +195,16 @@ func (c *client) CreateTable(ctx context.Context, tc sql.TableCreate) error {
 		return err
 	}
 
-	if rc, ok := tc.Resource.(tableConfig); ok && rc.Clustering && len(tc.Keys) > 0 {
-		keyExpr := clusteringKeyExpr(tc.Keys)
-		stmt := fmt.Sprintf("ALTER TABLE %s CLUSTER BY %s;", tc.Identifier, keyExpr)
-		if _, err := c.db.ExecContext(ctx, stmt); err != nil {
-			return fmt.Errorf("enabling clustering on new table %s: %w", tc.Identifier, err)
+	if rc, ok := tc.Resource.(tableConfig); ok {
+		if fields := rc.ClusteringColumns(); len(fields) > 0 {
+			keyExpr, err := clusteringKeyExpr(tc.Table, fields)
+			if err != nil {
+				return err
+			}
+			stmt := fmt.Sprintf("ALTER TABLE %s CLUSTER BY %s;", tc.Identifier, keyExpr)
+			if _, err := c.db.ExecContext(ctx, stmt); err != nil {
+				return fmt.Errorf("enabling clustering on new table %s: %w", tc.Identifier, err)
+			}
 		}
 	}
 

--- a/materialize-snowflake/client.go
+++ b/materialize-snowflake/client.go
@@ -195,11 +195,8 @@ func (c *client) CreateTable(ctx context.Context, tc sql.TableCreate) error {
 		return err
 	}
 
-	if rc, ok := tc.Resource.(tableConfig); ok && len(rc.Clustering) > 0 {
-		keyExpr, err := clusteringKeyExpr(rc.Clustering, tc.Table)
-		if err != nil {
-			return fmt.Errorf("resolving clustering key for new table %s: %w", tc.Identifier, err)
-		}
+	if rc, ok := tc.Resource.(tableConfig); ok && rc.Clustering && len(tc.Keys) > 0 {
+		keyExpr := clusteringKeyExpr(tc.Keys)
 		stmt := fmt.Sprintf("ALTER TABLE %s CLUSTER BY %s;", tc.Identifier, keyExpr)
 		if _, err := c.db.ExecContext(ctx, stmt); err != nil {
 			return fmt.Errorf("enabling clustering on new table %s: %w", tc.Identifier, err)

--- a/materialize-snowflake/client.go
+++ b/materialize-snowflake/client.go
@@ -195,8 +195,11 @@ func (c *client) CreateTable(ctx context.Context, tc sql.TableCreate) error {
 		return err
 	}
 
-	if rc, ok := tc.Resource.(tableConfig); ok && rc.Clustering && len(tc.Keys) > 0 {
-		keyExpr := clusteringKeyExpr(tc.Keys)
+	if rc, ok := tc.Resource.(tableConfig); ok && len(rc.Clustering) > 0 {
+		keyExpr, err := clusteringKeyExpr(rc.Clustering, tc.Table)
+		if err != nil {
+			return fmt.Errorf("resolving clustering key for new table %s: %w", tc.Identifier, err)
+		}
 		stmt := fmt.Sprintf("ALTER TABLE %s CLUSTER BY %s;", tc.Identifier, keyExpr)
 		if _, err := c.db.ExecContext(ctx, stmt); err != nil {
 			return fmt.Errorf("enabling clustering on new table %s: %w", tc.Identifier, err)

--- a/materialize-snowflake/client.go
+++ b/materialize-snowflake/client.go
@@ -194,6 +194,15 @@ func (c *client) CreateTable(ctx context.Context, tc sql.TableCreate) error {
 		}
 		return err
 	}
+
+	if rc, ok := tc.Resource.(tableConfig); ok && rc.Clustering && len(tc.Keys) > 0 {
+		keyExpr := clusteringKeyExpr(tc.Keys)
+		stmt := fmt.Sprintf("ALTER TABLE %s CLUSTER BY %s;", tc.Identifier, keyExpr)
+		if _, err := c.db.ExecContext(ctx, stmt); err != nil {
+			return fmt.Errorf("enabling clustering on new table %s: %w", tc.Identifier, err)
+		}
+	}
+
 	return nil
 }
 

--- a/materialize-snowflake/snowflake.go
+++ b/materialize-snowflake/snowflake.go
@@ -27,9 +27,10 @@ import (
 )
 
 type tableConfig struct {
-	Table  string `json:"table" jsonschema_extras:"x-collection-name=true"`
-	Schema string `json:"schema,omitempty" jsonschema:"title=Alternative Schema,description=Alternative schema for this table (optional)" jsonschema_extras:"x-schema-name=true"`
-	Delta  bool   `json:"delta_updates,omitempty" jsonschema:"title=Delta Updates,description=Use Private Key authentication to enable Snowpipe Streaming for Delta Update bindings" jsonschema_extras:"x-delta-updates=true"`
+	Table      string `json:"table" jsonschema_extras:"x-collection-name=true"`
+	Schema     string `json:"schema,omitempty" jsonschema:"title=Alternative Schema,description=Alternative schema for this table (optional)" jsonschema_extras:"x-schema-name=true"`
+	Delta      bool   `json:"delta_updates,omitempty" jsonschema:"title=Delta Updates,description=Use Private Key authentication to enable Snowpipe Streaming for Delta Update bindings" jsonschema_extras:"x-delta-updates=true"`
+	Clustering bool   `json:"clustering,omitempty" jsonschema:"title=Automatic Clustering,description=Enable Snowflake Automatic Clustering on this table using the collection key columns as the clustering key. Recommended only for large tables queried with selective filters on key columns. Consumes additional Snowflake credits." jsonschema_extras:"advanced=true"`
 
 	// If the endpoint schema is the same as the resource schema, the resource path will be only the
 	// table name. This is to provide compatibility for materializations that were created prior to
@@ -321,6 +322,10 @@ func newTransactor(
 		if err = d.addBinding(ctx, binding, featureFlags["snowpipe_streaming"]); err != nil {
 			return nil, fmt.Errorf("adding binding for %s: %w", binding.Path, err)
 		}
+	}
+
+	if err := d.syncClustering(ctx, bindings, open); err != nil {
+		return nil, fmt.Errorf("syncing clustering keys: %w", err)
 	}
 
 	go func() {
@@ -1267,6 +1272,96 @@ func clusteringKeyExpr(keys []sql.Column) string {
 		parts[i] = k.Identifier
 	}
 	return "(" + strings.Join(parts, ", ") + ")"
+}
+
+// queryCurrentClusterBy returns the current CLUSTER BY expression for a table,
+// or an empty string if the table has no clustering key.
+func queryCurrentClusterBy(ctx context.Context, db *stdsql.DB, schema, table string) (string, error) {
+	// SHOW TABLES LIKE returns a row with a "cluster_by" column.
+	rows, err := db.QueryContext(ctx, fmt.Sprintf("SHOW TABLES LIKE '%s' IN SCHEMA %q;", table, schema))
+	if err != nil {
+		return "", fmt.Errorf("querying table clustering state: %w", err)
+	}
+	defer rows.Close()
+
+	cols, err := rows.Columns()
+	if err != nil {
+		return "", fmt.Errorf("getting columns: %w", err)
+	}
+
+	clusterByIdx := -1
+	for i, col := range cols {
+		if strings.EqualFold(col, "cluster_by") {
+			clusterByIdx = i
+			break
+		}
+	}
+	if clusterByIdx == -1 {
+		return "", nil
+	}
+
+	if !rows.Next() {
+		return "", nil
+	}
+
+	vals := make([]any, len(cols))
+	ptrs := make([]any, len(cols))
+	for i := range vals {
+		ptrs[i] = &vals[i]
+	}
+	if err := rows.Scan(ptrs...); err != nil {
+		return "", fmt.Errorf("scanning table row: %w", err)
+	}
+
+	if v, ok := vals[clusterByIdx].(string); ok {
+		return v, nil
+	}
+	return "", nil
+}
+
+func (d *transactor) syncClustering(ctx context.Context, bindings []sql.Table, open pm.Request_Open) error {
+	for i, table := range bindings {
+		var rc tableConfig
+		if err := json.Unmarshal(open.Materialization.Bindings[i].ResourceConfigJson, &rc); err != nil {
+			return fmt.Errorf("parsing resource config for %s: %w", table.Identifier, err)
+		}
+
+		if rc.Clustering && len(table.Keys) > 0 {
+			keyExpr := clusteringKeyExpr(table.Keys)
+			stmt := fmt.Sprintf("ALTER TABLE %s CLUSTER BY %s;", table.Identifier, keyExpr)
+			if _, err := d.db.ExecContext(ctx, stmt); err != nil {
+				return fmt.Errorf("enabling clustering on %s: %w", table.Identifier, err)
+			}
+			log.WithFields(log.Fields{
+				"table":          table.Identifier,
+				"clustering_key": keyExpr,
+			}).Info("enabled automatic clustering")
+		} else if rc.Clustering && len(table.Keys) == 0 {
+			log.WithFields(log.Fields{
+				"table": table.Identifier,
+			}).Warn("clustering requested but table has no key columns; skipping")
+		} else if !rc.Clustering {
+			loc := d.ep.Dialect.TableLocator(table.Path)
+			currentClusterBy, err := queryCurrentClusterBy(ctx, d.db, loc.TableSchema, loc.TableName)
+			if err != nil {
+				log.WithFields(log.Fields{
+					"table": table.Identifier,
+				}).WithError(err).Warn("could not check current clustering state")
+				continue
+			}
+			if currentClusterBy != "" {
+				stmt := fmt.Sprintf("ALTER TABLE %s DROP CLUSTERING KEY;", table.Identifier)
+				if _, err := d.db.ExecContext(ctx, stmt); err != nil {
+					return fmt.Errorf("dropping clustering key on %s: %w", table.Identifier, err)
+				}
+				log.WithFields(log.Fields{
+					"table":              table.Identifier,
+					"previous_cluster_by": currentClusterBy,
+				}).Info("dropped clustering key")
+			}
+		}
+	}
+	return nil
 }
 
 func (d *transactor) logAllClusteringInfo(ctx context.Context) {

--- a/materialize-snowflake/snowflake.go
+++ b/materialize-snowflake/snowflake.go
@@ -30,7 +30,7 @@ type tableConfig struct {
 	Table      string `json:"table" jsonschema_extras:"x-collection-name=true"`
 	Schema     string `json:"schema,omitempty" jsonschema:"title=Alternative Schema,description=Alternative schema for this table (optional)" jsonschema_extras:"x-schema-name=true"`
 	Delta      bool   `json:"delta_updates,omitempty" jsonschema:"title=Delta Updates,description=Use Private Key authentication to enable Snowpipe Streaming for Delta Update bindings" jsonschema_extras:"x-delta-updates=true"`
-	Clustering bool   `json:"clustering,omitempty" jsonschema:"title=Automatic Clustering,description=Enable Snowflake Automatic Clustering on this table using the collection key columns as the clustering key. Recommended only for large tables queried with selective filters on key columns. Consumes additional Snowflake credits." jsonschema_extras:"advanced=true"`
+	Clustering string `json:"clustering,omitempty" jsonschema:"title=Clustering Keys,description=Comma-separated list of column names to use as the clustering key for Snowflake Automatic Clustering. Leave empty to disable clustering. Recommended only for large tables queried with selective filters on the chosen columns. Consumes additional Snowflake credits." jsonschema_extras:"advanced=true"`
 
 	// If the endpoint schema is the same as the resource schema, the resource path will be only the
 	// table name. This is to provide compatibility for materializations that were created prior to
@@ -53,6 +53,22 @@ func (c tableConfig) Validate() error {
 		return fmt.Errorf("expected table")
 	}
 	return nil
+}
+
+// ClusteringColumns parses the comma-separated clustering column list, trimming
+// whitespace and ignoring empty entries.
+func (c tableConfig) ClusteringColumns() []string {
+	if c.Clustering == "" {
+		return nil
+	}
+	parts := strings.Split(c.Clustering, ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if p = strings.TrimSpace(p); p != "" {
+			out = append(out, p)
+		}
+	}
+	return out
 }
 
 func schemasEqual(s1 string, s2 string) bool {
@@ -340,6 +356,9 @@ type binding struct {
 
 	streaming bool
 	pipeName  string
+	// clusteringExpr is the parenthesized CLUSTER BY expression for this
+	// binding, or empty if clustering is not configured.
+	clusteringExpr string
 	// Variables exclusively used by Load.
 	load struct {
 		loadQuery   string
@@ -1266,12 +1285,25 @@ func logClusteringInfo(ctx context.Context, db *stdsql.DB, table string, keyExpr
 	}).Info("clustering information")
 }
 
-func clusteringKeyExpr(keys []sql.Column) string {
-	parts := make([]string, len(keys))
-	for i, k := range keys {
-		parts[i] = k.Identifier
+// clusteringKeyExpr builds a Snowflake CLUSTER BY expression from the given
+// collection field names by resolving each one to its quoted column identifier
+// in the table.
+func clusteringKeyExpr(table sql.Table, fieldNames []string) (string, error) {
+	parts := make([]string, len(fieldNames))
+	for i, name := range fieldNames {
+		var ident string
+		for _, col := range table.Columns() {
+			if col.Field == name {
+				ident = col.Identifier
+				break
+			}
+		}
+		if ident == "" {
+			return "", fmt.Errorf("clustering column %q not found in materialized fields of %s", name, table.Identifier)
+		}
+		parts[i] = ident
 	}
-	return "(" + strings.Join(parts, ", ") + ")"
+	return "(" + strings.Join(parts, ", ") + ")", nil
 }
 
 // queryCurrentClusterBy returns the current CLUSTER BY expression for a table,
@@ -1326,8 +1358,12 @@ func (d *transactor) syncClustering(ctx context.Context, bindings []sql.Table, o
 			return fmt.Errorf("parsing resource config for %s: %w", table.Identifier, err)
 		}
 
-		if rc.Clustering && len(table.Keys) > 0 {
-			keyExpr := clusteringKeyExpr(table.Keys)
+		fields := rc.ClusteringColumns()
+		if len(fields) > 0 {
+			keyExpr, err := clusteringKeyExpr(table, fields)
+			if err != nil {
+				return err
+			}
 			stmt := fmt.Sprintf("ALTER TABLE %s CLUSTER BY %s;", table.Identifier, keyExpr)
 			if _, err := d.db.ExecContext(ctx, stmt); err != nil {
 				return fmt.Errorf("enabling clustering on %s: %w", table.Identifier, err)
@@ -1336,11 +1372,8 @@ func (d *transactor) syncClustering(ctx context.Context, bindings []sql.Table, o
 				"table":          table.Identifier,
 				"clustering_key": keyExpr,
 			}).Info("enabled automatic clustering")
-		} else if rc.Clustering && len(table.Keys) == 0 {
-			log.WithFields(log.Fields{
-				"table": table.Identifier,
-			}).Warn("clustering requested but table has no key columns; skipping")
-		} else if !rc.Clustering {
+			d.bindings[i].clusteringExpr = keyExpr
+		} else {
 			loc := d.ep.Dialect.TableLocator(table.Path)
 			currentClusterBy, err := queryCurrentClusterBy(ctx, d.db, loc.TableSchema, loc.TableName)
 			if err != nil {
@@ -1355,7 +1388,7 @@ func (d *transactor) syncClustering(ctx context.Context, bindings []sql.Table, o
 					return fmt.Errorf("dropping clustering key on %s: %w", table.Identifier, err)
 				}
 				log.WithFields(log.Fields{
-					"table":              table.Identifier,
+					"table":               table.Identifier,
 					"previous_cluster_by": currentClusterBy,
 				}).Info("dropped clustering key")
 			}
@@ -1366,10 +1399,10 @@ func (d *transactor) syncClustering(ctx context.Context, bindings []sql.Table, o
 
 func (d *transactor) logAllClusteringInfo(ctx context.Context) {
 	for _, b := range d.bindings {
-		if len(b.target.Keys) == 0 {
+		if b.clusteringExpr == "" {
 			continue
 		}
-		logClusteringInfo(ctx, d.db, b.target.Identifier, clusteringKeyExpr(b.target.Keys))
+		logClusteringInfo(ctx, d.db, b.target.Identifier, b.clusteringExpr)
 	}
 }
 

--- a/materialize-snowflake/snowflake.go
+++ b/materialize-snowflake/snowflake.go
@@ -30,7 +30,7 @@ type tableConfig struct {
 	Table      string `json:"table" jsonschema_extras:"x-collection-name=true"`
 	Schema     string `json:"schema,omitempty" jsonschema:"title=Alternative Schema,description=Alternative schema for this table (optional)" jsonschema_extras:"x-schema-name=true"`
 	Delta      bool   `json:"delta_updates,omitempty" jsonschema:"title=Delta Updates,description=Use Private Key authentication to enable Snowpipe Streaming for Delta Update bindings" jsonschema_extras:"x-delta-updates=true"`
-	Clustering []string `json:"clustering,omitempty" jsonschema:"title=Clustering Key Columns,description=Enable Snowflake Automatic Clustering on this table using the listed fields as the clustering key. Fields must match column names on the materialized table. Leave empty to disable clustering. Recommended only for large tables queried with selective filters on these columns. Consumes additional Snowflake credits." jsonschema_extras:"advanced=true"`
+	Clustering bool   `json:"clustering,omitempty" jsonschema:"title=Automatic Clustering,description=Enable Snowflake Automatic Clustering on this table using the collection key columns as the clustering key. Recommended only for large tables queried with selective filters on key columns. Consumes additional Snowflake credits." jsonschema_extras:"advanced=true"`
 
 	// If the endpoint schema is the same as the resource schema, the resource path will be only the
 	// table name. This is to provide compatibility for materializations that were created prior to
@@ -337,10 +337,6 @@ func newTransactor(
 
 type binding struct {
 	target sql.Table
-
-	// Parenthesised CLUSTER BY expression (e.g. "(col1, col2)") when
-	// clustering is enabled on this binding; empty otherwise.
-	clusteringKeyExpr string
 
 	streaming bool
 	pipeName  string
@@ -1270,35 +1266,12 @@ func logClusteringInfo(ctx context.Context, db *stdsql.DB, table string, keyExpr
 	}).Info("clustering information")
 }
 
-// clusteringKeyExpr resolves field names to SQL column identifiers and
-// returns a parenthesised CLUSTER BY expression. Field names are looked
-// up against the table's Keys first, then Values — Snowflake allows
-// clustering on any column, not just primary keys. It returns an error
-// if any field name is not a column on the table.
-func clusteringKeyExpr(fields []string, table sql.Table) (string, error) {
-	parts := make([]string, 0, len(fields))
-	for _, f := range fields {
-		var ident string
-		for _, k := range table.Keys {
-			if k.Field == f {
-				ident = k.Identifier
-				break
-			}
-		}
-		if ident == "" {
-			for _, v := range table.Values {
-				if v.Field == f {
-					ident = v.Identifier
-					break
-				}
-			}
-		}
-		if ident == "" {
-			return "", fmt.Errorf("clustering field %q is not a column on table %s", f, table.Identifier)
-		}
-		parts = append(parts, ident)
+func clusteringKeyExpr(keys []sql.Column) string {
+	parts := make([]string, len(keys))
+	for i, k := range keys {
+		parts[i] = k.Identifier
 	}
-	return "(" + strings.Join(parts, ", ") + ")", nil
+	return "(" + strings.Join(parts, ", ") + ")"
 }
 
 // queryCurrentClusterBy returns the current CLUSTER BY expression for a table,
@@ -1353,21 +1326,21 @@ func (d *transactor) syncClustering(ctx context.Context, bindings []sql.Table, o
 			return fmt.Errorf("parsing resource config for %s: %w", table.Identifier, err)
 		}
 
-		if len(rc.Clustering) > 0 {
-			keyExpr, err := clusteringKeyExpr(rc.Clustering, table)
-			if err != nil {
-				return fmt.Errorf("resolving clustering key for %s: %w", table.Identifier, err)
-			}
+		if rc.Clustering && len(table.Keys) > 0 {
+			keyExpr := clusteringKeyExpr(table.Keys)
 			stmt := fmt.Sprintf("ALTER TABLE %s CLUSTER BY %s;", table.Identifier, keyExpr)
 			if _, err := d.db.ExecContext(ctx, stmt); err != nil {
 				return fmt.Errorf("enabling clustering on %s: %w", table.Identifier, err)
 			}
-			d.bindings[i].clusteringKeyExpr = keyExpr
 			log.WithFields(log.Fields{
 				"table":          table.Identifier,
 				"clustering_key": keyExpr,
 			}).Info("enabled automatic clustering")
-		} else {
+		} else if rc.Clustering && len(table.Keys) == 0 {
+			log.WithFields(log.Fields{
+				"table": table.Identifier,
+			}).Warn("clustering requested but table has no key columns; skipping")
+		} else if !rc.Clustering {
 			loc := d.ep.Dialect.TableLocator(table.Path)
 			currentClusterBy, err := queryCurrentClusterBy(ctx, d.db, loc.TableSchema, loc.TableName)
 			if err != nil {
@@ -1393,10 +1366,10 @@ func (d *transactor) syncClustering(ctx context.Context, bindings []sql.Table, o
 
 func (d *transactor) logAllClusteringInfo(ctx context.Context) {
 	for _, b := range d.bindings {
-		if b.clusteringKeyExpr == "" {
+		if len(b.target.Keys) == 0 {
 			continue
 		}
-		logClusteringInfo(ctx, d.db, b.target.Identifier, b.clusteringKeyExpr)
+		logClusteringInfo(ctx, d.db, b.target.Identifier, clusteringKeyExpr(b.target.Keys))
 	}
 }
 

--- a/materialize-snowflake/snowflake.go
+++ b/materialize-snowflake/snowflake.go
@@ -30,7 +30,7 @@ type tableConfig struct {
 	Table      string `json:"table" jsonschema_extras:"x-collection-name=true"`
 	Schema     string `json:"schema,omitempty" jsonschema:"title=Alternative Schema,description=Alternative schema for this table (optional)" jsonschema_extras:"x-schema-name=true"`
 	Delta      bool   `json:"delta_updates,omitempty" jsonschema:"title=Delta Updates,description=Use Private Key authentication to enable Snowpipe Streaming for Delta Update bindings" jsonschema_extras:"x-delta-updates=true"`
-	Clustering bool   `json:"clustering,omitempty" jsonschema:"title=Automatic Clustering,description=Enable Snowflake Automatic Clustering on this table using the collection key columns as the clustering key. Recommended only for large tables queried with selective filters on key columns. Consumes additional Snowflake credits." jsonschema_extras:"advanced=true"`
+	Clustering []string `json:"clustering,omitempty" jsonschema:"title=Clustering Key Columns,description=Enable Snowflake Automatic Clustering on this table using the listed fields as the clustering key. Fields must match column names on the materialized table. Leave empty to disable clustering. Recommended only for large tables queried with selective filters on these columns. Consumes additional Snowflake credits." jsonschema_extras:"advanced=true"`
 
 	// If the endpoint schema is the same as the resource schema, the resource path will be only the
 	// table name. This is to provide compatibility for materializations that were created prior to
@@ -337,6 +337,10 @@ func newTransactor(
 
 type binding struct {
 	target sql.Table
+
+	// Parenthesised CLUSTER BY expression (e.g. "(col1, col2)") when
+	// clustering is enabled on this binding; empty otherwise.
+	clusteringKeyExpr string
 
 	streaming bool
 	pipeName  string
@@ -1266,12 +1270,35 @@ func logClusteringInfo(ctx context.Context, db *stdsql.DB, table string, keyExpr
 	}).Info("clustering information")
 }
 
-func clusteringKeyExpr(keys []sql.Column) string {
-	parts := make([]string, len(keys))
-	for i, k := range keys {
-		parts[i] = k.Identifier
+// clusteringKeyExpr resolves field names to SQL column identifiers and
+// returns a parenthesised CLUSTER BY expression. Field names are looked
+// up against the table's Keys first, then Values — Snowflake allows
+// clustering on any column, not just primary keys. It returns an error
+// if any field name is not a column on the table.
+func clusteringKeyExpr(fields []string, table sql.Table) (string, error) {
+	parts := make([]string, 0, len(fields))
+	for _, f := range fields {
+		var ident string
+		for _, k := range table.Keys {
+			if k.Field == f {
+				ident = k.Identifier
+				break
+			}
+		}
+		if ident == "" {
+			for _, v := range table.Values {
+				if v.Field == f {
+					ident = v.Identifier
+					break
+				}
+			}
+		}
+		if ident == "" {
+			return "", fmt.Errorf("clustering field %q is not a column on table %s", f, table.Identifier)
+		}
+		parts = append(parts, ident)
 	}
-	return "(" + strings.Join(parts, ", ") + ")"
+	return "(" + strings.Join(parts, ", ") + ")", nil
 }
 
 // queryCurrentClusterBy returns the current CLUSTER BY expression for a table,
@@ -1326,21 +1353,21 @@ func (d *transactor) syncClustering(ctx context.Context, bindings []sql.Table, o
 			return fmt.Errorf("parsing resource config for %s: %w", table.Identifier, err)
 		}
 
-		if rc.Clustering && len(table.Keys) > 0 {
-			keyExpr := clusteringKeyExpr(table.Keys)
+		if len(rc.Clustering) > 0 {
+			keyExpr, err := clusteringKeyExpr(rc.Clustering, table)
+			if err != nil {
+				return fmt.Errorf("resolving clustering key for %s: %w", table.Identifier, err)
+			}
 			stmt := fmt.Sprintf("ALTER TABLE %s CLUSTER BY %s;", table.Identifier, keyExpr)
 			if _, err := d.db.ExecContext(ctx, stmt); err != nil {
 				return fmt.Errorf("enabling clustering on %s: %w", table.Identifier, err)
 			}
+			d.bindings[i].clusteringKeyExpr = keyExpr
 			log.WithFields(log.Fields{
 				"table":          table.Identifier,
 				"clustering_key": keyExpr,
 			}).Info("enabled automatic clustering")
-		} else if rc.Clustering && len(table.Keys) == 0 {
-			log.WithFields(log.Fields{
-				"table": table.Identifier,
-			}).Warn("clustering requested but table has no key columns; skipping")
-		} else if !rc.Clustering {
+		} else {
 			loc := d.ep.Dialect.TableLocator(table.Path)
 			currentClusterBy, err := queryCurrentClusterBy(ctx, d.db, loc.TableSchema, loc.TableName)
 			if err != nil {
@@ -1366,10 +1393,10 @@ func (d *transactor) syncClustering(ctx context.Context, bindings []sql.Table, o
 
 func (d *transactor) logAllClusteringInfo(ctx context.Context) {
 	for _, b := range d.bindings {
-		if len(b.target.Keys) == 0 {
+		if b.clusteringKeyExpr == "" {
 			continue
 		}
-		logClusteringInfo(ctx, d.db, b.target.Identifier, clusteringKeyExpr(b.target.Keys))
+		logClusteringInfo(ctx, d.db, b.target.Identifier, b.clusteringKeyExpr)
 	}
 }
 

--- a/tests/benchmark/materialize/README.md
+++ b/tests/benchmark/materialize/README.md
@@ -63,6 +63,10 @@ transactions:
       - with: 0                # referenced earlier transaction's key range.
         fraction: 0.20         # 20% of this tx updates keys from tx 0.
         op: u
+        range: [0.6, 1.0]      # (optional) restrict sampling to the last 40%
+                               # of tx 0's keys. Models recency-biased updates
+                               # (newer records get updated more than old).
+                               # Defaults to [0.0, 1.0] (full range).
       - with: 0
         fraction: 0.10
         op: d                  # 10% of this tx deletes keys from tx 0.
@@ -86,6 +90,13 @@ Overlap rules:
   the remainder are fresh creates with new keys.
 * Within a single transaction, overlap key sets are pairwise disjoint
   (a key is never both updated and deleted in the same tx).
+* `overlap.range` (optional) is a `[lo, hi]` pair of fractions in `[0, 1]`
+  with `lo < hi`. Restricts sampling to a sub-range of the source tx's
+  keys: e.g. `[0.6, 1.0]` for the last 40% (recency-biased updates),
+  `[0.0, 0.1]` for the first 10% (cold-data updates). Each transaction
+  emits `fresh` keys sequentially, so a sub-range maps to a contiguous
+  slice of the id space — useful for exercising partition pruning on
+  destinations that cluster on the key column.
 
 ## CLI flags
 

--- a/tests/benchmark/materialize/README.md
+++ b/tests/benchmark/materialize/README.md
@@ -67,6 +67,18 @@ transactions:
                                # of tx 0's keys. Models recency-biased updates
                                # (newer records get updated more than old).
                                # Defaults to [0.0, 1.0] (full range).
+        distribution: zipfian  # (optional) sampling distribution within the
+                               # (sub-)range. "uniform" (default) or "zipfian".
+                               # Zipfian concentrates picks on a few keys near
+                               # zipf_bias's end with a long tail decaying
+                               # across the rest -- a closer match to many
+                               # real workloads (a hot recent set + occasional
+                               # touches of older rows) than pure uniform.
+        zipf_s: 1.0            # (optional) Zipfian skew exponent; default 1.0.
+                               # Larger s = more concentrated. s ~ 0 ≈ uniform.
+        zipf_bias: tail        # (optional) "tail" (default) or "head" --
+                               # which end of the (sub-)range gets rank 1
+                               # (the highest-weight key).
       - with: 0
         fraction: 0.10
         op: d                  # 10% of this tx deletes keys from tx 0.
@@ -97,6 +109,18 @@ Overlap rules:
   emits `fresh` keys sequentially, so a sub-range maps to a contiguous
   slice of the id space — useful for exercising partition pruning on
   destinations that cluster on the key column.
+* `overlap.distribution` (optional) is `uniform` (default) or `zipfian`.
+  `zipfian` weights each key in the (sub-)range by `1/rank^s` so a small
+  set of keys near `zipf_bias` (default `tail`) gets the bulk of the
+  picks, with a long tail trailing across the rest. This is closer to
+  many production workloads than pure uniform: most updates land on the
+  newest rows, but a few reach back into older history. Composes with
+  `range` — e.g. `range: [0.0, 1.0]` + `distribution: zipfian` says
+  "pull from anywhere in the prior tx, but mostly from the tail",
+  whereas `range: [0.6, 1.0]` + `distribution: zipfian` further
+  restricts the candidate window. Tunables: `zipf_s` (skew exponent,
+  default `1.0`; larger = more concentrated; `~0` ≈ uniform) and
+  `zipf_bias` (`tail` or `head`).
 
 ## CLI flags
 

--- a/tests/benchmark/materialize/generate.py
+++ b/tests/benchmark/materialize/generate.py
@@ -81,6 +81,12 @@ class OverlapSpec:
     with_tx: int
     fraction: float
     op: Literal["u", "d"]
+    # Sub-range of the source tx's key space to sample from, expressed as
+    # fractions in [0, 1]. Defaults to the full range. For example,
+    # (0.6, 1.0) restricts sampling to the last 40% of the source tx's keys
+    # — useful for modelling recency-biased update patterns.
+    range_lo: float = 0.0
+    range_hi: float = 1.0
 
 
 @dataclass
@@ -178,10 +184,32 @@ def load_scenario(path: str) -> tuple[dict[str, CollectionSpec], list[TxSpec]]:
     transactions: list[TxSpec] = []
     for i, t in enumerate(raw.get("transactions", [])):
         doc_count, doc_size = _resolve_sizing(t, i)
-        overlaps = [
-            OverlapSpec(with_tx=int(o["with"]), fraction=float(o["fraction"]), op=o["op"])
-            for o in t.get("overlaps", [])
-        ]
+        overlaps = []
+        for o in t.get("overlaps", []):
+            range_spec = o.get("range")
+            if range_spec is None:
+                rlo, rhi = 0.0, 1.0
+            else:
+                if not isinstance(range_spec, list) or len(range_spec) != 2:
+                    raise ValueError(
+                        f"transaction[{i}]: overlap.range must be a [lo, hi] list "
+                        f"(got {range_spec!r})"
+                    )
+                rlo, rhi = float(range_spec[0]), float(range_spec[1])
+                if not (0.0 <= rlo < rhi <= 1.0):
+                    raise ValueError(
+                        f"transaction[{i}]: overlap.range must satisfy "
+                        f"0 <= lo < hi <= 1 (got [{rlo}, {rhi}])"
+                    )
+            overlaps.append(
+                OverlapSpec(
+                    with_tx=int(o["with"]),
+                    fraction=float(o["fraction"]),
+                    op=o["op"],
+                    range_lo=rlo,
+                    range_hi=rhi,
+                )
+            )
         for o in overlaps:
             if o.op not in ("u", "d"):
                 raise ValueError(f"transaction[{i}]: overlap op must be 'u' or 'd' (got {o.op!r})")
@@ -412,27 +440,42 @@ class CollectionState:
         self.tx_ranges[tx_idx] = (start, count)
 
     def sample_from_tx(
-        self, tx_idx: int, n: int, exclude: set[int], rng: random.Random
+        self,
+        tx_idx: int,
+        n: int,
+        exclude: set[int],
+        rng: random.Random,
+        range_lo: float = 0.0,
+        range_hi: float = 1.0,
     ) -> list[int]:
-        """Sample n keys from tx_idx's key range, excluding `exclude`."""
+        """Sample n keys from tx_idx's key range, excluding `exclude`.
+
+        range_lo/range_hi restrict sampling to a sub-range of the source tx's
+        keys, expressed as fractions in [0, 1]. The defaults sample from the
+        full range (preserves prior behaviour).
+        """
         start, count = self.tx_ranges[tx_idx]
         if count == 0:
             raise ValueError(f"cannot overlap with tx {tx_idx}: it allocated no keys")
+        sub_start = start + int(count * range_lo)
+        sub_end = start + int(count * range_hi)
+        sub_count = sub_end - sub_start
         # Fast path: when exclude is empty we can sample directly from range().
         if not exclude:
-            if n > count:
+            if n > sub_count:
                 raise ValueError(
-                    f"overlap requests {n} keys from tx {tx_idx} which only has {count}"
+                    f"overlap requests {n} keys from tx {tx_idx} sub-range "
+                    f"[{range_lo}, {range_hi}) which only has {sub_count}"
                 )
-            return rng.sample(range(start, start + count), n)
+            return rng.sample(range(sub_start, sub_end), n)
         # With exclusions, fall back to building the candidate list. This
         # is acceptable because cross-overlap exclusions within one tx are
         # bounded by the tx's overlap size (not by total doc count).
-        candidates = [k for k in range(start, start + count) if k not in exclude]
+        candidates = [k for k in range(sub_start, sub_end) if k not in exclude]
         if n > len(candidates):
             raise ValueError(
-                f"overlap requests {n} keys from tx {tx_idx} after exclusions, "
-                f"only {len(candidates)} available"
+                f"overlap requests {n} keys from tx {tx_idx} sub-range "
+                f"[{range_lo}, {range_hi}) after exclusions, only {len(candidates)} available"
             )
         return rng.sample(candidates, n)
 
@@ -474,7 +517,9 @@ def _resolve_op_plan(
             plans.append(OverlapPlan(op=o.op, src_tx=o.with_tx, keys=[]))
             continue
         used = used_per_tx.setdefault(o.with_tx, set())
-        keys = state.sample_from_tx(o.with_tx, n, used, rng)
+        keys = state.sample_from_tx(
+            o.with_tx, n, used, rng, range_lo=o.range_lo, range_hi=o.range_hi
+        )
         used.update(keys)
         plans.append(OverlapPlan(op=o.op, src_tx=o.with_tx, keys=keys))
 

--- a/tests/benchmark/materialize/generate.py
+++ b/tests/benchmark/materialize/generate.py
@@ -20,6 +20,7 @@ Usage:
 """
 
 import argparse
+import itertools
 import json
 import random
 import string
@@ -150,6 +151,23 @@ def load_scenario(path: str) -> tuple[dict[str, CollectionSpec], list[TxSpec]]:
             raise ValueError(
                 f"collection {spec.name}: payload_field '{spec.payload_field}' not in schema.properties"
             )
+        for prop_name, prop_schema in spec.schema.get("properties", {}).items():
+            if not isinstance(prop_schema, dict) or "enum" not in prop_schema:
+                continue
+            if prop_name in (spec.key_field, spec.payload_field):
+                raise ValueError(
+                    f"collection {spec.name}: enum not supported on key or payload field {prop_name!r}"
+                )
+            values = prop_schema["enum"]
+            if not isinstance(values, list) or not values:
+                raise ValueError(
+                    f"collection {spec.name}: property {prop_name!r} enum must be a non-empty list"
+                )
+            for v in values:
+                if v is not None and not isinstance(v, (str, int, float, bool)):
+                    raise ValueError(
+                        f"collection {spec.name}: property {prop_name!r} enum value {v!r} is not a JSON scalar"
+                    )
         collections[spec.name] = spec
 
     if not collections:
@@ -264,14 +282,21 @@ def _make_pool(seed: int, size: int) -> str:
 
 def _build_emit_template(
     col: CollectionSpec, op: str
-) -> tuple[str, str, str, int]:
-    """Return (prefix, middle, suffix, fixed_overhead) for one (collection, op).
+) -> list[tuple[str, str, str, int]]:
+    """Return a list of (prefix, middle, suffix, fixed_overhead) variants
+    for one (collection, op).
 
     Emitted line: prefix + str(key) + middle + payload_slice + suffix
     (suffix already includes the trailing newline).
 
     fixed_overhead = len(prefix) + len(middle) + len(suffix), so
-    payload_len = doc_size - fixed_overhead - len(str(key))."""
+    payload_len = doc_size - fixed_overhead - len(str(key)).
+
+    When a property has a JSON Schema `enum`, each enum value produces a
+    distinct variant. Variants span the cross-product of all enum fields,
+    so selecting by `key % len(variants)` at emit time spreads enum values
+    evenly across docs without per-doc RNG. When no field has an enum,
+    the returned list has exactly one tuple."""
     props = col.schema.get("properties", {})
     if col.key_field not in props:
         raise ValueError(f"collection {col.name}: key_field {col.key_field!r} not in schema.properties")
@@ -291,6 +316,8 @@ def _build_emit_template(
     doc_parts: list[str] = ["{"]
     key_slot: int = -1
     payload_slot: int = -1
+    # (values, slot_index) per enum field, in property order.
+    enum_slots: list[tuple[list[Any], int]] = []
     first = True
 
     key_is_string = col.key_type == "uuid"
@@ -313,6 +340,10 @@ def _build_emit_template(
             payload_slot = len(doc_parts)
             doc_parts.append("")  # filled with pool_slice at emit time
             doc_parts.append('"')
+        elif "enum" in props[name]:
+            doc_parts.append(f'{sep}"{name}":')
+            enum_slots.append((props[name]["enum"], len(doc_parts)))
+            doc_parts.append("")  # filled per variant below
         else:
             val = _fixed_scalar(name, props[name])
             doc_parts.append(f'{sep}"{name}":{json.dumps(val, separators=(",", ":"))}')
@@ -323,21 +354,38 @@ def _build_emit_template(
     doc_parts.append(f'{meta_sep}"_meta":{{"op":"{op}"}}')
     doc_parts.append("}")
 
-    doc_prefix = "".join(doc_parts[:key_slot])
-    doc_middle = "".join(doc_parts[key_slot + 1 : payload_slot])
-    doc_suffix = "".join(doc_parts[payload_slot + 1 :])
-    # `overhead` measures the doc's static bytes only -- so that
-    # payload_len = doc_size - overhead - len(str(key)) makes each
-    # emitted DOC exactly doc_size bytes (the fixture envelope is extra).
-    overhead = len(doc_prefix) + len(doc_middle) + len(doc_suffix)
-
     # Wrap the doc in the fixture envelope: ["<collection>",<doc>]\n.
     envelope_prefix = f'["{col.name}",'
     envelope_suffix = "]\n"
-    prefix = envelope_prefix + doc_prefix
-    middle = doc_middle
-    suffix = doc_suffix + envelope_suffix
-    return prefix, middle, suffix, overhead
+
+    # Expand the cross-product of enum values into a list of concrete
+    # variants. itertools.product() with no iterables yields a single
+    # empty tuple, which produces one variant (today's behavior).
+    value_lists = [values for values, _ in enum_slots]
+    slot_indices = [idx for _, idx in enum_slots]
+
+    variants: list[tuple[str, str, str, int]] = []
+    for combo in itertools.product(*value_lists):
+        parts = list(doc_parts)
+        for slot_idx, value in zip(slot_indices, combo):
+            parts[slot_idx] = json.dumps(value, separators=(",", ":"))
+
+        doc_prefix = "".join(parts[:key_slot])
+        doc_middle = "".join(parts[key_slot + 1 : payload_slot])
+        doc_suffix = "".join(parts[payload_slot + 1 :])
+        # `overhead` measures the doc's static bytes only -- so that
+        # payload_len = doc_size - overhead - len(str(key)) makes each
+        # emitted DOC exactly doc_size bytes (the fixture envelope is extra).
+        overhead = len(doc_prefix) + len(doc_middle) + len(doc_suffix)
+        variants.append(
+            (
+                envelope_prefix + doc_prefix,
+                doc_middle,
+                doc_suffix + envelope_suffix,
+                overhead,
+            )
+        )
+    return variants
 
 
 # ---------------------------------------------------------------------------
@@ -456,8 +504,10 @@ def emit(
     pool = _make_pool(seed, pool_size)
 
     # Precompute per-(collection, op) line templates. Computed once up front,
-    # then the emit loop just does string concatenation + writes.
-    templates: dict[tuple[str, str], tuple[str, str, str, int]] = {}
+    # then the emit loop just does string concatenation + writes. Each entry
+    # is a list of variants when the schema has enum fields (one per value
+    # combination), otherwise a single-element list.
+    templates: dict[tuple[str, str], list[tuple[str, str, str, int]]] = {}
     for tx in transactions:
         col = collections[tx.collection]
         for op in {tx.op} | {o.op for o in tx.overlaps}:
@@ -495,8 +545,10 @@ def emit(
         format_key = _int_key_to_uuid if col.key_type == "uuid" else str
 
         def _emit_run(keys, op: str) -> None:
-            prefix, middle, suffix, overhead = templates[(col.name, op)]
+            variants = templates[(col.name, op)]
+            n_variants = len(variants)
             for key in keys:
+                prefix, middle, suffix, overhead = variants[key % n_variants]
                 key_s = format_key(key)
                 pad = doc_size - overhead - len(key_s)
                 if pad < 0:

--- a/tests/benchmark/materialize/generate.py
+++ b/tests/benchmark/materialize/generate.py
@@ -20,8 +20,10 @@ Usage:
 """
 
 import argparse
+import heapq
 import itertools
 import json
+import math
 import random
 import string
 import sys
@@ -87,6 +89,17 @@ class OverlapSpec:
     # — useful for modelling recency-biased update patterns.
     range_lo: float = 0.0
     range_hi: float = 1.0
+    # Sampling distribution within the (sub-)range:
+    # - "uniform" (default): each key equally likely.
+    # - "zipfian": each key drawn with probability ∝ 1/rank^s with rank=1
+    #   sitting at the biased end (zipf_bias). Models hot-spot workloads
+    #   where a small set of keys near one end of the range gets the bulk
+    #   of activity, with a long tail across the rest. Real-world updates
+    #   often concentrate on the most recent rows but occasionally reach
+    #   back into older ones — that's the shape this captures.
+    distribution: Literal["uniform", "zipfian"] = "uniform"
+    zipf_s: float = 1.0
+    zipf_bias: Literal["tail", "head"] = "tail"
 
 
 @dataclass
@@ -201,6 +214,23 @@ def load_scenario(path: str) -> tuple[dict[str, CollectionSpec], list[TxSpec]]:
                         f"transaction[{i}]: overlap.range must satisfy "
                         f"0 <= lo < hi <= 1 (got [{rlo}, {rhi}])"
                     )
+            distribution = o.get("distribution", "uniform")
+            if distribution not in ("uniform", "zipfian"):
+                raise ValueError(
+                    f"transaction[{i}]: overlap.distribution must be "
+                    f"'uniform' or 'zipfian' (got {distribution!r})"
+                )
+            zipf_s = float(o.get("zipf_s", 1.0))
+            if zipf_s <= 0:
+                raise ValueError(
+                    f"transaction[{i}]: overlap.zipf_s must be > 0 (got {zipf_s})"
+                )
+            zipf_bias = o.get("zipf_bias", "tail")
+            if zipf_bias not in ("tail", "head"):
+                raise ValueError(
+                    f"transaction[{i}]: overlap.zipf_bias must be "
+                    f"'tail' or 'head' (got {zipf_bias!r})"
+                )
             overlaps.append(
                 OverlapSpec(
                     with_tx=int(o["with"]),
@@ -208,6 +238,9 @@ def load_scenario(path: str) -> tuple[dict[str, CollectionSpec], list[TxSpec]]:
                     op=o["op"],
                     range_lo=rlo,
                     range_hi=rhi,
+                    distribution=distribution,
+                    zipf_s=zipf_s,
+                    zipf_bias=zipf_bias,
                 )
             )
         for o in overlaps:
@@ -447,12 +480,19 @@ class CollectionState:
         rng: random.Random,
         range_lo: float = 0.0,
         range_hi: float = 1.0,
+        distribution: str = "uniform",
+        zipf_s: float = 1.0,
+        zipf_bias: str = "tail",
     ) -> list[int]:
         """Sample n keys from tx_idx's key range, excluding `exclude`.
 
         range_lo/range_hi restrict sampling to a sub-range of the source tx's
         keys, expressed as fractions in [0, 1]. The defaults sample from the
         full range (preserves prior behaviour).
+
+        distribution selects the sampling distribution within the sub-range:
+        "uniform" (each key equally likely) or "zipfian" (probability
+        ∝ 1/rank^s with rank=1 at zipf_bias's end of the sub-range).
         """
         start, count = self.tx_ranges[tx_idx]
         if count == 0:
@@ -460,6 +500,20 @@ class CollectionState:
         sub_start = start + int(count * range_lo)
         sub_end = start + int(count * range_hi)
         sub_count = sub_end - sub_start
+
+        if distribution == "zipfian":
+            available = sub_count - (
+                sum(1 for k in exclude if sub_start <= k < sub_end) if exclude else 0
+            )
+            if n > available:
+                raise ValueError(
+                    f"overlap requests {n} keys from tx {tx_idx} sub-range "
+                    f"[{range_lo}, {range_hi}) after exclusions, only {available} available"
+                )
+            return _sample_zipfian(
+                sub_start, sub_end, n, exclude, rng, zipf_s, zipf_bias
+            )
+
         # Fast path: when exclude is empty we can sample directly from range().
         if not exclude:
             if n > sub_count:
@@ -478,6 +532,42 @@ class CollectionState:
                 f"[{range_lo}, {range_hi}) after exclusions, only {len(candidates)} available"
             )
         return rng.sample(candidates, n)
+
+
+def _sample_zipfian(
+    sub_start: int,
+    sub_end: int,
+    n: int,
+    exclude: set[int],
+    rng: random.Random,
+    s: float,
+    bias: str,
+) -> list[int]:
+    """Weighted sample without replacement using the Efraimidis-Spirakis
+    A-Res reservoir trick. Each key i gets weight 1/rank(i)^s with rank=1
+    at the biased end of [sub_start, sub_end); we assign each key a
+    priority log(u)/weight = log(u) * rank^s and keep the top-n priorities
+    (closest to zero, since both factors push priority negative).
+
+    Heavy mass on a few keys near the bias end, with a long tail decaying
+    over the rest of the sub-range. O(N log n) time, O(n) heap space —
+    fine at fixture-generation sizes.
+    """
+    heap: list[tuple[float, int]] = []
+    for i in range(sub_start, sub_end):
+        if i in exclude:
+            continue
+        if bias == "tail":
+            rank = sub_end - i  # rank 1 at sub_end - 1 (the tail).
+        else:
+            rank = i - sub_start + 1  # rank 1 at sub_start (the head).
+        u = rng.random() or 1e-300  # guard against log(0).
+        priority = math.log(u) * (rank ** s)
+        if len(heap) < n:
+            heapq.heappush(heap, (priority, i))
+        elif priority > heap[0][0]:
+            heapq.heapreplace(heap, (priority, i))
+    return [i for _, i in heap]
 
 
 # ---------------------------------------------------------------------------
@@ -518,7 +608,15 @@ def _resolve_op_plan(
             continue
         used = used_per_tx.setdefault(o.with_tx, set())
         keys = state.sample_from_tx(
-            o.with_tx, n, used, rng, range_lo=o.range_lo, range_hi=o.range_hi
+            o.with_tx,
+            n,
+            used,
+            rng,
+            range_lo=o.range_lo,
+            range_hi=o.range_hi,
+            distribution=o.distribution,
+            zipf_s=o.zipf_s,
+            zipf_bias=o.zipf_bias,
         )
         used.update(keys)
         plans.append(OverlapPlan(op=o.op, src_tx=o.with_tx, keys=keys))

--- a/tests/benchmark/materialize/run.sh
+++ b/tests/benchmark/materialize/run.sh
@@ -79,19 +79,14 @@ fi
   exit 2
 }
 
-# Ensure the connector is available in the selected mode.
+# Always rebuild the connector so each run picks up the latest code.
 if (( DOCKER )); then
-  IMAGE="ghcr.io/estuary/${CONNECTOR}:local"
-  if ! docker image inspect "$IMAGE" >/dev/null 2>&1; then
-    echo "image $IMAGE not found; building with build-local.sh"
-    (cd "$ROOT_DIR" && ./build-local.sh "$CONNECTOR")
-  fi
+  echo "building docker image for $CONNECTOR"
+  (cd "$ROOT_DIR" && ./build-local.sh "$CONNECTOR")
 else
   CONNECTOR_BIN="$ROOT_DIR/$CONNECTOR/connector"
-  if [[ ! -x "$CONNECTOR_BIN" ]]; then
-    echo "building connector binary: $CONNECTOR_BIN"
-    (cd "$ROOT_DIR" && go build -v -tags nozstd -o "$CONNECTOR_BIN" ./$CONNECTOR/...)
-  fi
+  echo "building connector binary: $CONNECTOR_BIN"
+  (cd "$ROOT_DIR" && go build -v -tags nozstd -o "$CONNECTOR_BIN" ./$CONNECTOR/...)
 fi
 
 # Output directory.

--- a/tests/benchmark/materialize/runs/baselines/materialize-snowflake/clustering/recency-biased/clustered-step1.json
+++ b/tests/benchmark/materialize/runs/baselines/materialize-snowflake/clustering/recency-biased/clustered-step1.json
@@ -1,0 +1,74 @@
+{
+  "connector": "materialize-snowflake",
+  "scenario": "100gb-3tx-overlap-clustered.yaml",
+  "seed": 0,
+  "preview_exit_code": 0,
+  "apply_seconds": 9.006561691,
+  "wall_seconds": 4717.682596297,
+  "total_docs": 104857600,
+  "total_bytes": 107374182400,
+  "docs_per_sec": 22226.505887086332,
+  "mb_per_sec": 21.705572155357746,
+  "transactions": [
+    {
+      "index": 0,
+      "collection": "bench/wide",
+      "doc_count": 34603008,
+      "doc_size": 1024,
+      "bytes": 35433480192,
+      "fresh": {
+        "start": 0,
+        "count": 34603008,
+        "op": "c"
+      },
+      "overlaps": [],
+      "wall_seconds": 968.325406715,
+      "mb_per_sec": 34.897359674407205,
+      "docs_per_sec": 35734.89630659298
+    },
+    {
+      "index": 1,
+      "collection": "bench/wide",
+      "doc_count": 34603008,
+      "doc_size": 1024,
+      "bytes": 35433480192,
+      "fresh": {
+        "start": 34603008,
+        "count": 25952256,
+        "op": "c"
+      },
+      "overlaps": [
+        {
+          "op": "u",
+          "with": 0,
+          "count": 8650752
+        }
+      ],
+      "wall_seconds": 1302.71064051,
+      "mb_per_sec": 25.939758952740817,
+      "docs_per_sec": 26562.313167606597
+    },
+    {
+      "index": 2,
+      "collection": "bench/wide",
+      "doc_count": 35651584,
+      "doc_size": 1024,
+      "bytes": 36507222016,
+      "fresh": {
+        "start": 60555264,
+        "count": 17825792,
+        "op": "c"
+      },
+      "overlaps": [
+        {
+          "op": "u",
+          "with": 1,
+          "count": 17825792
+        }
+      ],
+      "wall_seconds": 1829.796952038,
+      "mb_per_sec": 19.02724778354367,
+      "docs_per_sec": 19483.90173034872
+    }
+  ]
+}

--- a/tests/benchmark/materialize/runs/baselines/materialize-snowflake/clustering/recency-biased/clustered-step2-run1.json
+++ b/tests/benchmark/materialize/runs/baselines/materialize-snowflake/clustering/recency-biased/clustered-step2-run1.json
@@ -1,0 +1,74 @@
+{
+  "connector": "materialize-snowflake",
+  "scenario": "100gb-3tx-recency-biased-clustered.yaml",
+  "seed": 0,
+  "preview_exit_code": 0,
+  "apply_seconds": 4.059000064,
+  "wall_seconds": 7314.605512496,
+  "total_docs": 104857600,
+  "total_bytes": 107374182400,
+  "docs_per_sec": 14335.373222912045,
+  "mb_per_sec": 13.999387913000044,
+  "transactions": [
+    {
+      "index": 0,
+      "collection": "bench/wide",
+      "doc_count": 34603008,
+      "doc_size": 1024,
+      "bytes": 35433480192,
+      "fresh": {
+        "start": 0,
+        "count": 34603008,
+        "op": "c"
+      },
+      "overlaps": [],
+      "wall_seconds": 2171.583428437,
+      "mb_per_sec": 15.560995519440779,
+      "docs_per_sec": 15934.459411907357
+    },
+    {
+      "index": 1,
+      "collection": "bench/wide",
+      "doc_count": 34603008,
+      "doc_size": 1024,
+      "bytes": 35433480192,
+      "fresh": {
+        "start": 34603008,
+        "count": 27682406,
+        "op": "c"
+      },
+      "overlaps": [
+        {
+          "op": "u",
+          "with": 0,
+          "count": 6920602
+        }
+      ],
+      "wall_seconds": 2403.436592723,
+      "mb_per_sec": 14.059867484049155,
+      "docs_per_sec": 14397.304303666335
+    },
+    {
+      "index": 2,
+      "collection": "bench/wide",
+      "doc_count": 35651584,
+      "doc_size": 1024,
+      "bytes": 36507222016,
+      "fresh": {
+        "start": 62285414,
+        "count": 28521267,
+        "op": "c"
+      },
+      "overlaps": [
+        {
+          "op": "u",
+          "with": 1,
+          "count": 7130317
+        }
+      ],
+      "wall_seconds": 2016.272587371,
+      "mb_per_sec": 17.26750649593281,
+      "docs_per_sec": 17681.926651835198
+    }
+  ]
+}

--- a/tests/benchmark/materialize/runs/baselines/materialize-snowflake/clustering/recency-biased/clustered-step2-run2.json
+++ b/tests/benchmark/materialize/runs/baselines/materialize-snowflake/clustering/recency-biased/clustered-step2-run2.json
@@ -1,0 +1,74 @@
+{
+  "connector": "materialize-snowflake",
+  "scenario": "100gb-3tx-recency-biased-clustered.yaml",
+  "seed": 0,
+  "preview_exit_code": 0,
+  "apply_seconds": 5.728447075,
+  "wall_seconds": 7828.220148298,
+  "total_docs": 104857600,
+  "total_bytes": 107374182400,
+  "docs_per_sec": 13394.820024676745,
+  "mb_per_sec": 13.080878930348383,
+  "transactions": [
+    {
+      "index": 0,
+      "collection": "bench/wide",
+      "doc_count": 34603008,
+      "doc_size": 1024,
+      "bytes": 35433480192,
+      "fresh": {
+        "start": 0,
+        "count": 34603008,
+        "op": "c"
+      },
+      "overlaps": [],
+      "wall_seconds": 2178.583892034,
+      "mb_per_sec": 15.510993229850165,
+      "docs_per_sec": 15883.257067366569
+    },
+    {
+      "index": 1,
+      "collection": "bench/wide",
+      "doc_count": 34603008,
+      "doc_size": 1024,
+      "bytes": 35433480192,
+      "fresh": {
+        "start": 34603008,
+        "count": 27682406,
+        "op": "c"
+      },
+      "overlaps": [
+        {
+          "op": "u",
+          "with": 0,
+          "count": 6920602
+        }
+      ],
+      "wall_seconds": 2334.333542324,
+      "mb_per_sec": 14.476080383250453,
+      "docs_per_sec": 14823.506312448464
+    },
+    {
+      "index": 2,
+      "collection": "bench/wide",
+      "doc_count": 35651584,
+      "doc_size": 1024,
+      "bytes": 36507222016,
+      "fresh": {
+        "start": 62285414,
+        "count": 28521267,
+        "op": "c"
+      },
+      "overlaps": [
+        {
+          "op": "u",
+          "with": 1,
+          "count": 7130317
+        }
+      ],
+      "wall_seconds": 2474.257150519,
+      "mb_per_sec": 14.07129408222464,
+      "docs_per_sec": 14409.00514019803
+    }
+  ]
+}

--- a/tests/benchmark/materialize/runs/baselines/materialize-snowflake/clustering/recency-biased/clustered-step2-run3.json
+++ b/tests/benchmark/materialize/runs/baselines/materialize-snowflake/clustering/recency-biased/clustered-step2-run3.json
@@ -1,0 +1,74 @@
+{
+  "connector": "materialize-snowflake",
+  "scenario": "100gb-3tx-recency-biased-clustered.yaml",
+  "seed": 0,
+  "preview_exit_code": 0,
+  "apply_seconds": 7.360095846,
+  "wall_seconds": 7884.546229988,
+  "total_docs": 104857600,
+  "total_bytes": 107374182400,
+  "docs_per_sec": 13299.129327339817,
+  "mb_per_sec": 12.98743098373029,
+  "transactions": [
+    {
+      "index": 0,
+      "collection": "bench/wide",
+      "doc_count": 34603008,
+      "doc_size": 1024,
+      "bytes": 35433480192,
+      "fresh": {
+        "start": 0,
+        "count": 34603008,
+        "op": "c"
+      },
+      "overlaps": [],
+      "wall_seconds": 2173.86754895,
+      "mb_per_sec": 15.54464531030047,
+      "docs_per_sec": 15917.716797747682
+    },
+    {
+      "index": 1,
+      "collection": "bench/wide",
+      "doc_count": 34603008,
+      "doc_size": 1024,
+      "bytes": 35433480192,
+      "fresh": {
+        "start": 34603008,
+        "count": 27682406,
+        "op": "c"
+      },
+      "overlaps": [
+        {
+          "op": "u",
+          "with": 0,
+          "count": 6920602
+        }
+      ],
+      "wall_seconds": 2349.933629979,
+      "mb_per_sec": 14.37998059558047,
+      "docs_per_sec": 14725.100129874401
+    },
+    {
+      "index": 2,
+      "collection": "bench/wide",
+      "doc_count": 35651584,
+      "doc_size": 1024,
+      "bytes": 36507222016,
+      "fresh": {
+        "start": 62285414,
+        "count": 28521267,
+        "op": "c"
+      },
+      "overlaps": [
+        {
+          "op": "u",
+          "with": 1,
+          "count": 7130317
+        }
+      ],
+      "wall_seconds": 2496.696438691,
+      "mb_per_sec": 13.944827036423291,
+      "docs_per_sec": 14279.50288529745
+    }
+  ]
+}

--- a/tests/benchmark/materialize/runs/baselines/materialize-snowflake/clustering/recency-biased/clustered-step2-run4.json
+++ b/tests/benchmark/materialize/runs/baselines/materialize-snowflake/clustering/recency-biased/clustered-step2-run4.json
@@ -1,0 +1,74 @@
+{
+  "connector": "materialize-snowflake",
+  "scenario": "100gb-3tx-recency-biased-clustered.yaml",
+  "seed": 0,
+  "preview_exit_code": 0,
+  "apply_seconds": 7.440490229,
+  "wall_seconds": 7936.427977481,
+  "total_docs": 104857600,
+  "total_bytes": 107374182400,
+  "docs_per_sec": 13212.190710673029,
+  "mb_per_sec": 12.90252999089163,
+  "transactions": [
+    {
+      "index": 0,
+      "collection": "bench/wide",
+      "doc_count": 34603008,
+      "doc_size": 1024,
+      "bytes": 35433480192,
+      "fresh": {
+        "start": 0,
+        "count": 34603008,
+        "op": "c"
+      },
+      "overlaps": [],
+      "wall_seconds": 2209.984717042,
+      "mb_per_sec": 15.290603477670022,
+      "docs_per_sec": 15657.577961134102
+    },
+    {
+      "index": 1,
+      "collection": "bench/wide",
+      "doc_count": 34603008,
+      "doc_size": 1024,
+      "bytes": 35433480192,
+      "fresh": {
+        "start": 34603008,
+        "count": 27682406,
+        "op": "c"
+      },
+      "overlaps": [
+        {
+          "op": "u",
+          "with": 0,
+          "count": 6920602
+        }
+      ],
+      "wall_seconds": 2386.20261965,
+      "mb_per_sec": 14.161412665348802,
+      "docs_per_sec": 14501.286569317173
+    },
+    {
+      "index": 2,
+      "collection": "bench/wide",
+      "doc_count": 35651584,
+      "doc_size": 1024,
+      "bytes": 36507222016,
+      "fresh": {
+        "start": 62285414,
+        "count": 28521267,
+        "op": "c"
+      },
+      "overlaps": [
+        {
+          "op": "u",
+          "with": 1,
+          "count": 7130317
+        }
+      ],
+      "wall_seconds": 2477.857960323,
+      "mb_per_sec": 14.050845753669261,
+      "docs_per_sec": 14388.066051757323
+    }
+  ]
+}

--- a/tests/benchmark/materialize/runs/baselines/materialize-snowflake/clustering/recency-biased/no-cluster-step1.json
+++ b/tests/benchmark/materialize/runs/baselines/materialize-snowflake/clustering/recency-biased/no-cluster-step1.json
@@ -1,0 +1,74 @@
+{
+  "connector": "materialize-snowflake",
+  "scenario": "100gb-3tx-overlap.yaml",
+  "seed": 0,
+  "preview_exit_code": 0,
+  "apply_seconds": 7.489980922,
+  "wall_seconds": 4978.783477892,
+  "total_docs": 104857600,
+  "total_bytes": 107374182400,
+  "docs_per_sec": 21060.887758146968,
+  "mb_per_sec": 20.5672732013154,
+  "transactions": [
+    {
+      "index": 0,
+      "collection": "bench/wide",
+      "doc_count": 34603008,
+      "doc_size": 1024,
+      "bytes": 35433480192,
+      "fresh": {
+        "start": 0,
+        "count": 34603008,
+        "op": "c"
+      },
+      "overlaps": [],
+      "wall_seconds": 1029.802335948,
+      "mb_per_sec": 32.814064233882576,
+      "docs_per_sec": 33601.60177549576
+    },
+    {
+      "index": 1,
+      "collection": "bench/wide",
+      "doc_count": 34603008,
+      "doc_size": 1024,
+      "bytes": 35433480192,
+      "fresh": {
+        "start": 34603008,
+        "count": 25952256,
+        "op": "c"
+      },
+      "overlaps": [
+        {
+          "op": "u",
+          "with": 0,
+          "count": 8650752
+        }
+      ],
+      "wall_seconds": 1365.747376475,
+      "mb_per_sec": 24.742496732607535,
+      "docs_per_sec": 25336.316654190116
+    },
+    {
+      "index": 2,
+      "collection": "bench/wide",
+      "doc_count": 35651584,
+      "doc_size": 1024,
+      "bytes": 36507222016,
+      "fresh": {
+        "start": 60555264,
+        "count": 17825792,
+        "op": "c"
+      },
+      "overlaps": [
+        {
+          "op": "u",
+          "with": 1,
+          "count": 17825792
+        }
+      ],
+      "wall_seconds": 1849.833952434,
+      "mb_per_sec": 18.821148759968064,
+      "docs_per_sec": 19272.856330207298
+    }
+  ]
+}

--- a/tests/benchmark/materialize/runs/baselines/materialize-snowflake/clustering/recency-biased/no-cluster-step2-run1.json
+++ b/tests/benchmark/materialize/runs/baselines/materialize-snowflake/clustering/recency-biased/no-cluster-step2-run1.json
@@ -1,0 +1,74 @@
+{
+  "connector": "materialize-snowflake",
+  "scenario": "100gb-3tx-recency-biased.yaml",
+  "seed": 0,
+  "preview_exit_code": 0,
+  "apply_seconds": 7.084575627,
+  "wall_seconds": 7838.759300297,
+  "total_docs": 104857600,
+  "total_bytes": 107374182400,
+  "docs_per_sec": 13376.81079147654,
+  "mb_per_sec": 13.06329178855131,
+  "transactions": [
+    {
+      "index": 0,
+      "collection": "bench/wide",
+      "doc_count": 34603008,
+      "doc_size": 1024,
+      "bytes": 35433480192,
+      "fresh": {
+        "start": 0,
+        "count": 34603008,
+        "op": "c"
+      },
+      "overlaps": [],
+      "wall_seconds": 2180.923852494,
+      "mb_per_sec": 15.494351149104581,
+      "docs_per_sec": 15866.215576683091
+    },
+    {
+      "index": 1,
+      "collection": "bench/wide",
+      "doc_count": 34603008,
+      "doc_size": 1024,
+      "bytes": 35433480192,
+      "fresh": {
+        "start": 34603008,
+        "count": 27682406,
+        "op": "c"
+      },
+      "overlaps": [
+        {
+          "op": "u",
+          "with": 0,
+          "count": 6920602
+        }
+      ],
+      "wall_seconds": 2464.994557937,
+      "mb_per_sec": 13.708752374804899,
+      "docs_per_sec": 14037.762431800216
+    },
+    {
+      "index": 2,
+      "collection": "bench/wide",
+      "doc_count": 35651584,
+      "doc_size": 1024,
+      "bytes": 36507222016,
+      "fresh": {
+        "start": 62285414,
+        "count": 28521267,
+        "op": "c"
+      },
+      "overlaps": [
+        {
+          "op": "u",
+          "with": 1,
+          "count": 7130317
+        }
+      ],
+      "wall_seconds": 2208.690623813,
+      "mb_per_sec": 15.763185493084121,
+      "docs_per_sec": 16141.50194491814
+    }
+  ]
+}

--- a/tests/benchmark/materialize/runs/baselines/materialize-snowflake/clustering/recency-biased/no-cluster-step2-run2.json
+++ b/tests/benchmark/materialize/runs/baselines/materialize-snowflake/clustering/recency-biased/no-cluster-step2-run2.json
@@ -1,0 +1,74 @@
+{
+  "connector": "materialize-snowflake",
+  "scenario": "100gb-3tx-recency-biased.yaml",
+  "seed": 0,
+  "preview_exit_code": 0,
+  "apply_seconds": 7.830166717,
+  "wall_seconds": 8583.068812354,
+  "total_docs": 104857600,
+  "total_bytes": 107374182400,
+  "docs_per_sec": 12216.795914425584,
+  "mb_per_sec": 11.930464760181234,
+  "transactions": [
+    {
+      "index": 0,
+      "collection": "bench/wide",
+      "doc_count": 34603008,
+      "doc_size": 1024,
+      "bytes": 35433480192,
+      "fresh": {
+        "start": 0,
+        "count": 34603008,
+        "op": "c"
+      },
+      "overlaps": [],
+      "wall_seconds": 2199.164731328,
+      "mb_per_sec": 15.365833908946954,
+      "docs_per_sec": 15734.61392276168
+    },
+    {
+      "index": 1,
+      "collection": "bench/wide",
+      "doc_count": 34603008,
+      "doc_size": 1024,
+      "bytes": 35433480192,
+      "fresh": {
+        "start": 34603008,
+        "count": 27682406,
+        "op": "c"
+      },
+      "overlaps": [
+        {
+          "op": "u",
+          "with": 0,
+          "count": 6920602
+        }
+      ],
+      "wall_seconds": 2524.616443677,
+      "mb_per_sec": 13.385003525835925,
+      "docs_per_sec": 13706.243610455987
+    },
+    {
+      "index": 2,
+      "collection": "bench/wide",
+      "doc_count": 35651584,
+      "doc_size": 1024,
+      "bytes": 36507222016,
+      "fresh": {
+        "start": 62285414,
+        "count": 28521267,
+        "op": "c"
+      },
+      "overlaps": [
+        {
+          "op": "u",
+          "with": 1,
+          "count": 7130317
+        }
+      ],
+      "wall_seconds": 2709.456417394,
+      "mb_per_sec": 12.8498099384402,
+      "docs_per_sec": 13158.205376962766
+    }
+  ]
+}

--- a/tests/benchmark/materialize/runs/baselines/materialize-snowflake/clustering/recency-biased/no-cluster-step2-run3.json
+++ b/tests/benchmark/materialize/runs/baselines/materialize-snowflake/clustering/recency-biased/no-cluster-step2-run3.json
@@ -1,0 +1,74 @@
+{
+  "connector": "materialize-snowflake",
+  "scenario": "100gb-3tx-recency-biased.yaml",
+  "seed": 0,
+  "preview_exit_code": 0,
+  "apply_seconds": 7.624635786,
+  "wall_seconds": 8734.076029368,
+  "total_docs": 104857600,
+  "total_bytes": 107374182400,
+  "docs_per_sec": 12005.574447419544,
+  "mb_per_sec": 11.724193796308148,
+  "transactions": [
+    {
+      "index": 0,
+      "collection": "bench/wide",
+      "doc_count": 34603008,
+      "doc_size": 1024,
+      "bytes": 35433480192,
+      "fresh": {
+        "start": 0,
+        "count": 34603008,
+        "op": "c"
+      },
+      "overlaps": [],
+      "wall_seconds": 2206.885077796,
+      "mb_per_sec": 15.312079609395802,
+      "docs_per_sec": 15679.569520021301
+    },
+    {
+      "index": 1,
+      "collection": "bench/wide",
+      "doc_count": 34603008,
+      "doc_size": 1024,
+      "bytes": 35433480192,
+      "fresh": {
+        "start": 34603008,
+        "count": 27682406,
+        "op": "c"
+      },
+      "overlaps": [
+        {
+          "op": "u",
+          "with": 0,
+          "count": 6920602
+        }
+      ],
+      "wall_seconds": 2631.212038701,
+      "mb_per_sec": 12.84275060427389,
+      "docs_per_sec": 13150.976618776464
+    },
+    {
+      "index": 2,
+      "collection": "bench/wide",
+      "doc_count": 35651584,
+      "doc_size": 1024,
+      "bytes": 36507222016,
+      "fresh": {
+        "start": 62285414,
+        "count": 28521267,
+        "op": "c"
+      },
+      "overlaps": [
+        {
+          "op": "u",
+          "with": 1,
+          "count": 7130317
+        }
+      ],
+      "wall_seconds": 2860.065748428,
+      "mb_per_sec": 12.173146725433213,
+      "docs_per_sec": 12465.30224684361
+    }
+  ]
+}

--- a/tests/benchmark/materialize/runs/baselines/materialize-snowflake/clustering/recency-biased/no-cluster-step2-run4.json
+++ b/tests/benchmark/materialize/runs/baselines/materialize-snowflake/clustering/recency-biased/no-cluster-step2-run4.json
@@ -1,0 +1,74 @@
+{
+  "connector": "materialize-snowflake",
+  "scenario": "100gb-3tx-recency-biased.yaml",
+  "seed": 0,
+  "preview_exit_code": 0,
+  "apply_seconds": 7.863918543,
+  "wall_seconds": 8911.90418662,
+  "total_docs": 104857600,
+  "total_bytes": 107374182400,
+  "docs_per_sec": 11766.015186454684,
+  "mb_per_sec": 11.490249205522153,
+  "transactions": [
+    {
+      "index": 0,
+      "collection": "bench/wide",
+      "doc_count": 34603008,
+      "doc_size": 1024,
+      "bytes": 35433480192,
+      "fresh": {
+        "start": 0,
+        "count": 34603008,
+        "op": "c"
+      },
+      "overlaps": [],
+      "wall_seconds": 2188.471083813,
+      "mb_per_sec": 15.440916834561865,
+      "docs_per_sec": 15811.49883859135
+    },
+    {
+      "index": 1,
+      "collection": "bench/wide",
+      "doc_count": 34603008,
+      "doc_size": 1024,
+      "bytes": 35433480192,
+      "fresh": {
+        "start": 34603008,
+        "count": 27682406,
+        "op": "c"
+      },
+      "overlaps": [
+        {
+          "op": "u",
+          "with": 0,
+          "count": 6920602
+        }
+      ],
+      "wall_seconds": 2705.082310263,
+      "mb_per_sec": 12.492041322289595,
+      "docs_per_sec": 12791.850314024545
+    },
+    {
+      "index": 2,
+      "collection": "bench/wide",
+      "doc_count": 35651584,
+      "doc_size": 1024,
+      "bytes": 36507222016,
+      "fresh": {
+        "start": 62285414,
+        "count": 28521267,
+        "op": "c"
+      },
+      "overlaps": [
+        {
+          "op": "u",
+          "with": 1,
+          "count": 7130317
+        }
+      ],
+      "wall_seconds": 2802.412554908,
+      "mb_per_sec": 12.423581224336532,
+      "docs_per_sec": 12721.747173720609
+    }
+  ]
+}

--- a/tests/benchmark/materialize/runs/baselines/materialize-snowflake/clustering/zipfian/clustered-step1.json
+++ b/tests/benchmark/materialize/runs/baselines/materialize-snowflake/clustering/zipfian/clustered-step1.json
@@ -1,0 +1,74 @@
+{
+  "connector": "materialize-snowflake",
+  "scenario": "100gb-3tx-zipfian-clustered.yaml",
+  "seed": 0,
+  "preview_exit_code": 0,
+  "apply_seconds": 9.378120462,
+  "wall_seconds": 4501.226124692,
+  "total_docs": 104857600,
+  "total_bytes": 107374182400,
+  "docs_per_sec": 23295.341557001866,
+  "mb_per_sec": 22.749356989259635,
+  "transactions": [
+    {
+      "index": 0,
+      "collection": "bench/wide",
+      "doc_count": 34603008,
+      "doc_size": 1024,
+      "bytes": 35433480192,
+      "fresh": {
+        "start": 0,
+        "count": 34603008,
+        "op": "c"
+      },
+      "overlaps": [],
+      "wall_seconds": 997.874876833,
+      "mb_per_sec": 33.86396509675359,
+      "docs_per_sec": 34676.700259075675
+    },
+    {
+      "index": 1,
+      "collection": "bench/wide",
+      "doc_count": 34603008,
+      "doc_size": 1024,
+      "bytes": 35433480192,
+      "fresh": {
+        "start": 34603008,
+        "count": 27682406,
+        "op": "c"
+      },
+      "overlaps": [
+        {
+          "op": "u",
+          "with": 0,
+          "count": 6920602
+        }
+      ],
+      "wall_seconds": 1271.138744845,
+      "mb_per_sec": 26.584037452277112,
+      "docs_per_sec": 27222.054351131763
+    },
+    {
+      "index": 2,
+      "collection": "bench/wide",
+      "doc_count": 35651584,
+      "doc_size": 1024,
+      "bytes": 36507222016,
+      "fresh": {
+        "start": 62285414,
+        "count": 28521267,
+        "op": "c"
+      },
+      "overlaps": [
+        {
+          "op": "u",
+          "with": 1,
+          "count": 7130317
+        }
+      ],
+      "wall_seconds": 1445.42938924,
+      "mb_per_sec": 24.08696008201832,
+      "docs_per_sec": 24665.04712398676
+    }
+  ]
+}

--- a/tests/benchmark/materialize/runs/baselines/materialize-snowflake/clustering/zipfian/clustered-step2-run1.json
+++ b/tests/benchmark/materialize/runs/baselines/materialize-snowflake/clustering/zipfian/clustered-step2-run1.json
@@ -1,0 +1,74 @@
+{
+  "connector": "materialize-snowflake",
+  "scenario": "100gb-3tx-zipfian-clustered.yaml",
+  "seed": 0,
+  "preview_exit_code": 0,
+  "apply_seconds": 6.517830624,
+  "wall_seconds": 8136.432655992,
+  "total_docs": 104857600,
+  "total_bytes": 107374182400,
+  "docs_per_sec": 12887.416934837973,
+  "mb_per_sec": 12.585368100427708,
+  "transactions": [
+    {
+      "index": 0,
+      "collection": "bench/wide",
+      "doc_count": 34603008,
+      "doc_size": 1024,
+      "bytes": 35433480192,
+      "fresh": {
+        "start": 0,
+        "count": 34603008,
+        "op": "c"
+      },
+      "overlaps": [],
+      "wall_seconds": 2162.831746727,
+      "mb_per_sec": 15.623961526890488,
+      "docs_per_sec": 15998.93660353586
+    },
+    {
+      "index": 1,
+      "collection": "bench/wide",
+      "doc_count": 34603008,
+      "doc_size": 1024,
+      "bytes": 35433480192,
+      "fresh": {
+        "start": 34603008,
+        "count": 27682406,
+        "op": "c"
+      },
+      "overlaps": [
+        {
+          "op": "u",
+          "with": 0,
+          "count": 6920602
+        }
+      ],
+      "wall_seconds": 2378.027375341,
+      "mb_per_sec": 14.210097137823889,
+      "docs_per_sec": 14551.139469131662
+    },
+    {
+      "index": 2,
+      "collection": "bench/wide",
+      "doc_count": 35651584,
+      "doc_size": 1024,
+      "bytes": 36507222016,
+      "fresh": {
+        "start": 62285414,
+        "count": 28521267,
+        "op": "c"
+      },
+      "overlaps": [
+        {
+          "op": "u",
+          "with": 1,
+          "count": 7130317
+        }
+      ],
+      "wall_seconds": 2623.504913545,
+      "mb_per_sec": 13.270796566931155,
+      "docs_per_sec": 13589.295684537503
+    }
+  ]
+}

--- a/tests/benchmark/materialize/runs/baselines/materialize-snowflake/clustering/zipfian/clustered-step2-run2.json
+++ b/tests/benchmark/materialize/runs/baselines/materialize-snowflake/clustering/zipfian/clustered-step2-run2.json
@@ -1,0 +1,74 @@
+{
+  "connector": "materialize-snowflake",
+  "scenario": "100gb-3tx-zipfian-clustered.yaml",
+  "seed": 0,
+  "preview_exit_code": 0,
+  "apply_seconds": 7.542854906,
+  "wall_seconds": 7792.756921696,
+  "total_docs": 104857600,
+  "total_bytes": 107374182400,
+  "docs_per_sec": 13455.777082955514,
+  "mb_per_sec": 13.140407307573744,
+  "transactions": [
+    {
+      "index": 0,
+      "collection": "bench/wide",
+      "doc_count": 34603008,
+      "doc_size": 1024,
+      "bytes": 35433480192,
+      "fresh": {
+        "start": 0,
+        "count": 34603008,
+        "op": "c"
+      },
+      "overlaps": [],
+      "wall_seconds": 2223.964632853,
+      "mb_per_sec": 15.194486234545076,
+      "docs_per_sec": 15559.153904174158
+    },
+    {
+      "index": 1,
+      "collection": "bench/wide",
+      "doc_count": 34603008,
+      "doc_size": 1024,
+      "bytes": 35433480192,
+      "fresh": {
+        "start": 34603008,
+        "count": 27682406,
+        "op": "c"
+      },
+      "overlaps": [
+        {
+          "op": "u",
+          "with": 0,
+          "count": 6920602
+        }
+      ],
+      "wall_seconds": 2171.023686009,
+      "mb_per_sec": 15.565007520539744,
+      "docs_per_sec": 15938.567701032698
+    },
+    {
+      "index": 2,
+      "collection": "bench/wide",
+      "doc_count": 35651584,
+      "doc_size": 1024,
+      "bytes": 36507222016,
+      "fresh": {
+        "start": 62285414,
+        "count": 28521267,
+        "op": "c"
+      },
+      "overlaps": [
+        {
+          "op": "u",
+          "with": 1,
+          "count": 7130317
+        }
+      ],
+      "wall_seconds": 2426.528702132,
+      "mb_per_sec": 14.348068485408772,
+      "docs_per_sec": 14692.422129058583
+    }
+  ]
+}

--- a/tests/benchmark/materialize/runs/baselines/materialize-snowflake/clustering/zipfian/clustered-step2-run3.json
+++ b/tests/benchmark/materialize/runs/baselines/materialize-snowflake/clustering/zipfian/clustered-step2-run3.json
@@ -1,0 +1,74 @@
+{
+  "connector": "materialize-snowflake",
+  "scenario": "100gb-3tx-zipfian-clustered.yaml",
+  "seed": 0,
+  "preview_exit_code": 0,
+  "apply_seconds": 12.810233532,
+  "wall_seconds": 7873.501729674,
+  "total_docs": 104857600,
+  "total_bytes": 107374182400,
+  "docs_per_sec": 13317.784589391536,
+  "mb_per_sec": 13.005649013077672,
+  "transactions": [
+    {
+      "index": 0,
+      "collection": "bench/wide",
+      "doc_count": 34603008,
+      "doc_size": 1024,
+      "bytes": 35433480192,
+      "fresh": {
+        "start": 0,
+        "count": 34603008,
+        "op": "c"
+      },
+      "overlaps": [],
+      "wall_seconds": 2118.761523,
+      "mb_per_sec": 15.948939809022574,
+      "docs_per_sec": 16331.714364439116
+    },
+    {
+      "index": 1,
+      "collection": "bench/wide",
+      "doc_count": 34603008,
+      "doc_size": 1024,
+      "bytes": 35433480192,
+      "fresh": {
+        "start": 34603008,
+        "count": 27682406,
+        "op": "c"
+      },
+      "overlaps": [
+        {
+          "op": "u",
+          "with": 0,
+          "count": 6920602
+        }
+      ],
+      "wall_seconds": 2360.959158683,
+      "mb_per_sec": 14.312827003263365,
+      "docs_per_sec": 14656.334851341686
+    },
+    {
+      "index": 2,
+      "collection": "bench/wide",
+      "doc_count": 35651584,
+      "doc_size": 1024,
+      "bytes": 36507222016,
+      "fresh": {
+        "start": 62285414,
+        "count": 28521267,
+        "op": "c"
+      },
+      "overlaps": [
+        {
+          "op": "u",
+          "with": 1,
+          "count": 7130317
+        }
+      ],
+      "wall_seconds": 2423.280809652,
+      "mb_per_sec": 14.367299019299304,
+      "docs_per_sec": 14712.114195762488
+    }
+  ]
+}

--- a/tests/benchmark/materialize/runs/baselines/materialize-snowflake/clustering/zipfian/clustered-step2-run4.json
+++ b/tests/benchmark/materialize/runs/baselines/materialize-snowflake/clustering/zipfian/clustered-step2-run4.json
@@ -1,0 +1,74 @@
+{
+  "connector": "materialize-snowflake",
+  "scenario": "100gb-3tx-zipfian-clustered.yaml",
+  "seed": 0,
+  "preview_exit_code": 0,
+  "apply_seconds": 8.727334416,
+  "wall_seconds": 8003.514642868,
+  "total_docs": 104857600,
+  "total_bytes": 107374182400,
+  "docs_per_sec": 13101.44413785005,
+  "mb_per_sec": 12.79437904086919,
+  "transactions": [
+    {
+      "index": 0,
+      "collection": "bench/wide",
+      "doc_count": 34603008,
+      "doc_size": 1024,
+      "bytes": 35433480192,
+      "fresh": {
+        "start": 0,
+        "count": 34603008,
+        "op": "c"
+      },
+      "overlaps": [],
+      "wall_seconds": 2133.887304067,
+      "mb_per_sec": 15.835887835123927,
+      "docs_per_sec": 16215.949143166901
+    },
+    {
+      "index": 1,
+      "collection": "bench/wide",
+      "doc_count": 34603008,
+      "doc_size": 1024,
+      "bytes": 35433480192,
+      "fresh": {
+        "start": 34603008,
+        "count": 27682406,
+        "op": "c"
+      },
+      "overlaps": [
+        {
+          "op": "u",
+          "with": 0,
+          "count": 6920602
+        }
+      ],
+      "wall_seconds": 2374.865032371,
+      "mb_per_sec": 14.229019139779492,
+      "docs_per_sec": 14570.5155991342
+    },
+    {
+      "index": 2,
+      "collection": "bench/wide",
+      "doc_count": 35651584,
+      "doc_size": 1024,
+      "bytes": 36507222016,
+      "fresh": {
+        "start": 62285414,
+        "count": 28521267,
+        "op": "c"
+      },
+      "overlaps": [
+        {
+          "op": "u",
+          "with": 1,
+          "count": 7130317
+        }
+      ],
+      "wall_seconds": 2638.758865485,
+      "mb_per_sec": 13.194081678092578,
+      "docs_per_sec": 13510.7396383668
+    }
+  ]
+}

--- a/tests/benchmark/materialize/runs/baselines/materialize-snowflake/clustering/zipfian/no-cluster-step1.json
+++ b/tests/benchmark/materialize/runs/baselines/materialize-snowflake/clustering/zipfian/no-cluster-step1.json
@@ -1,0 +1,74 @@
+{
+  "connector": "materialize-snowflake",
+  "scenario": "100gb-3tx-zipfian.yaml",
+  "seed": 0,
+  "preview_exit_code": 0,
+  "apply_seconds": 8.324938843,
+  "wall_seconds": 4491.15582816,
+  "total_docs": 104857600,
+  "total_bytes": 107374182400,
+  "docs_per_sec": 23347.57554893381,
+  "mb_per_sec": 22.800366747005675,
+  "transactions": [
+    {
+      "index": 0,
+      "collection": "bench/wide",
+      "doc_count": 34603008,
+      "doc_size": 1024,
+      "bytes": 35433480192,
+      "fresh": {
+        "start": 0,
+        "count": 34603008,
+        "op": "c"
+      },
+      "overlaps": [],
+      "wall_seconds": 1016.86047605,
+      "mb_per_sec": 33.231697755886046,
+      "docs_per_sec": 34029.25850202731
+    },
+    {
+      "index": 1,
+      "collection": "bench/wide",
+      "doc_count": 34603008,
+      "doc_size": 1024,
+      "bytes": 35433480192,
+      "fresh": {
+        "start": 34603008,
+        "count": 27682406,
+        "op": "c"
+      },
+      "overlaps": [
+        {
+          "op": "u",
+          "with": 0,
+          "count": 6920602
+        }
+      ],
+      "wall_seconds": 1258.853353362,
+      "mb_per_sec": 26.84347617595984,
+      "docs_per_sec": 27487.719604182876
+    },
+    {
+      "index": 2,
+      "collection": "bench/wide",
+      "doc_count": 35651584,
+      "doc_size": 1024,
+      "bytes": 36507222016,
+      "fresh": {
+        "start": 62285414,
+        "count": 28521267,
+        "op": "c"
+      },
+      "overlaps": [
+        {
+          "op": "u",
+          "with": 1,
+          "count": 7130317
+        }
+      ],
+      "wall_seconds": 1461.003423368,
+      "mb_per_sec": 23.830197413049103,
+      "docs_per_sec": 24402.12215096228
+    }
+  ]
+}

--- a/tests/benchmark/materialize/runs/baselines/materialize-snowflake/clustering/zipfian/no-cluster-step2-run1.json
+++ b/tests/benchmark/materialize/runs/baselines/materialize-snowflake/clustering/zipfian/no-cluster-step2-run1.json
@@ -1,0 +1,74 @@
+{
+  "connector": "materialize-snowflake",
+  "scenario": "100gb-3tx-zipfian.yaml",
+  "seed": 0,
+  "preview_exit_code": 0,
+  "apply_seconds": 6.458223742,
+  "wall_seconds": 8195.777315963,
+  "total_docs": 104857600,
+  "total_bytes": 107374182400,
+  "docs_per_sec": 12794.100663980678,
+  "mb_per_sec": 12.494238929668631,
+  "transactions": [
+    {
+      "index": 0,
+      "collection": "bench/wide",
+      "doc_count": 34603008,
+      "doc_size": 1024,
+      "bytes": 35433480192,
+      "fresh": {
+        "start": 0,
+        "count": 34603008,
+        "op": "c"
+      },
+      "overlaps": [],
+      "wall_seconds": 2123.053581384,
+      "mb_per_sec": 15.916696731681775,
+      "docs_per_sec": 16298.697453242137
+    },
+    {
+      "index": 1,
+      "collection": "bench/wide",
+      "doc_count": 34603008,
+      "doc_size": 1024,
+      "bytes": 35433480192,
+      "fresh": {
+        "start": 34603008,
+        "count": 27682406,
+        "op": "c"
+      },
+      "overlaps": [
+        {
+          "op": "u",
+          "with": 0,
+          "count": 6920602
+        }
+      ],
+      "wall_seconds": 2385.292395385,
+      "mb_per_sec": 14.166816640752245,
+      "docs_per_sec": 14506.820240130299
+    },
+    {
+      "index": 2,
+      "collection": "bench/wide",
+      "doc_count": 35651584,
+      "doc_size": 1024,
+      "bytes": 36507222016,
+      "fresh": {
+        "start": 62285414,
+        "count": 28521267,
+        "op": "c"
+      },
+      "overlaps": [
+        {
+          "op": "u",
+          "with": 1,
+          "count": 7130317
+        }
+      ],
+      "wall_seconds": 2656.769834289,
+      "mb_per_sec": 13.104635392443544,
+      "docs_per_sec": 13419.14664186219
+    }
+  ]
+}

--- a/tests/benchmark/materialize/runs/baselines/materialize-snowflake/clustering/zipfian/no-cluster-step2-run2.json
+++ b/tests/benchmark/materialize/runs/baselines/materialize-snowflake/clustering/zipfian/no-cluster-step2-run2.json
@@ -1,0 +1,74 @@
+{
+  "connector": "materialize-snowflake",
+  "scenario": "100gb-3tx-zipfian.yaml",
+  "seed": 0,
+  "preview_exit_code": 0,
+  "apply_seconds": 6.571416564,
+  "wall_seconds": 8274.617860694,
+  "total_docs": 104857600,
+  "total_bytes": 107374182400,
+  "docs_per_sec": 12672.198494880766,
+  "mb_per_sec": 12.375193842656998,
+  "transactions": [
+    {
+      "index": 0,
+      "collection": "bench/wide",
+      "doc_count": 34603008,
+      "doc_size": 1024,
+      "bytes": 35433480192,
+      "fresh": {
+        "start": 0,
+        "count": 34603008,
+        "op": "c"
+      },
+      "overlaps": [],
+      "wall_seconds": 2124.148456243,
+      "mb_per_sec": 15.908492601203687,
+      "docs_per_sec": 16290.296423632575
+    },
+    {
+      "index": 1,
+      "collection": "bench/wide",
+      "doc_count": 34603008,
+      "doc_size": 1024,
+      "bytes": 35433480192,
+      "fresh": {
+        "start": 34603008,
+        "count": 27682406,
+        "op": "c"
+      },
+      "overlaps": [
+        {
+          "op": "u",
+          "with": 0,
+          "count": 6920602
+        }
+      ],
+      "wall_seconds": 2468.484715731,
+      "mb_per_sec": 13.689369751674995,
+      "docs_per_sec": 14017.914625715195
+    },
+    {
+      "index": 2,
+      "collection": "bench/wide",
+      "doc_count": 35651584,
+      "doc_size": 1024,
+      "bytes": 36507222016,
+      "fresh": {
+        "start": 62285414,
+        "count": 28521267,
+        "op": "c"
+      },
+      "overlaps": [
+        {
+          "op": "u",
+          "with": 1,
+          "count": 7130317
+        }
+      ],
+      "wall_seconds": 2716.666803736,
+      "mb_per_sec": 12.815704874856396,
+      "docs_per_sec": 13123.281791852949
+    }
+  ]
+}

--- a/tests/benchmark/materialize/runs/baselines/materialize-snowflake/clustering/zipfian/no-cluster-step2-run3.json
+++ b/tests/benchmark/materialize/runs/baselines/materialize-snowflake/clustering/zipfian/no-cluster-step2-run3.json
@@ -1,0 +1,74 @@
+{
+  "connector": "materialize-snowflake",
+  "scenario": "100gb-3tx-zipfian.yaml",
+  "seed": 0,
+  "preview_exit_code": 0,
+  "apply_seconds": 5.985304686,
+  "wall_seconds": 8538.595984182,
+  "total_docs": 104857600,
+  "total_bytes": 107374182400,
+  "docs_per_sec": 12280.426453512004,
+  "mb_per_sec": 11.992603958507816,
+  "transactions": [
+    {
+      "index": 0,
+      "collection": "bench/wide",
+      "doc_count": 34603008,
+      "doc_size": 1024,
+      "bytes": 35433480192,
+      "fresh": {
+        "start": 0,
+        "count": 34603008,
+        "op": "c"
+      },
+      "overlaps": [],
+      "wall_seconds": 2186.993963191,
+      "mb_per_sec": 15.451345805589126,
+      "docs_per_sec": 15822.178104923265
+    },
+    {
+      "index": 1,
+      "collection": "bench/wide",
+      "doc_count": 34603008,
+      "doc_size": 1024,
+      "bytes": 35433480192,
+      "fresh": {
+        "start": 34603008,
+        "count": 27682406,
+        "op": "c"
+      },
+      "overlaps": [
+        {
+          "op": "u",
+          "with": 0,
+          "count": 6920602
+        }
+      ],
+      "wall_seconds": 2617.18001315,
+      "mb_per_sec": 12.911607084805924,
+      "docs_per_sec": 13221.485654841266
+    },
+    {
+      "index": 2,
+      "collection": "bench/wide",
+      "doc_count": 35651584,
+      "doc_size": 1024,
+      "bytes": 36507222016,
+      "fresh": {
+        "start": 62285414,
+        "count": 28521267,
+        "op": "c"
+      },
+      "overlaps": [
+        {
+          "op": "u",
+          "with": 1,
+          "count": 7130317
+        }
+      ],
+      "wall_seconds": 2569.701993372,
+      "mb_per_sec": 13.548652758102095,
+      "docs_per_sec": 13873.820424296546
+    }
+  ]
+}

--- a/tests/benchmark/materialize/runs/baselines/materialize-snowflake/clustering/zipfian/no-cluster-step2-run4.json
+++ b/tests/benchmark/materialize/runs/baselines/materialize-snowflake/clustering/zipfian/no-cluster-step2-run4.json
@@ -1,0 +1,74 @@
+{
+  "connector": "materialize-snowflake",
+  "scenario": "100gb-3tx-zipfian.yaml",
+  "seed": 0,
+  "preview_exit_code": 0,
+  "apply_seconds": 6.880587619,
+  "wall_seconds": 8896.278043635,
+  "total_docs": 104857600,
+  "total_bytes": 107374182400,
+  "docs_per_sec": 11786.681968086892,
+  "mb_per_sec": 11.510431609459856,
+  "transactions": [
+    {
+      "index": 0,
+      "collection": "bench/wide",
+      "doc_count": 34603008,
+      "doc_size": 1024,
+      "bytes": 35433480192,
+      "fresh": {
+        "start": 0,
+        "count": 34603008,
+        "op": "c"
+      },
+      "overlaps": [],
+      "wall_seconds": 2148.536435138,
+      "mb_per_sec": 15.727915732473743,
+      "docs_per_sec": 16105.385710053113
+    },
+    {
+      "index": 1,
+      "collection": "bench/wide",
+      "doc_count": 34603008,
+      "doc_size": 1024,
+      "bytes": 35433480192,
+      "fresh": {
+        "start": 34603008,
+        "count": 27682406,
+        "op": "c"
+      },
+      "overlaps": [
+        {
+          "op": "u",
+          "with": 0,
+          "count": 6920602
+        }
+      ],
+      "wall_seconds": 2703.594672475,
+      "mb_per_sec": 12.498914997885088,
+      "docs_per_sec": 12798.88895783433
+    },
+    {
+      "index": 2,
+      "collection": "bench/wide",
+      "doc_count": 35651584,
+      "doc_size": 1024,
+      "bytes": 36507222016,
+      "fresh": {
+        "start": 62285414,
+        "count": 28521267,
+        "op": "c"
+      },
+      "overlaps": [
+        {
+          "op": "u",
+          "with": 1,
+          "count": 7130317
+        }
+      ],
+      "wall_seconds": 2824.840817454,
+      "mb_per_sec": 12.32494227104071,
+      "docs_per_sec": 12620.740885545687
+    }
+  ]
+}

--- a/tests/benchmark/materialize/scenarios/100gb-3tx-overlap-clustered.yaml
+++ b/tests/benchmark/materialize/scenarios/100gb-3tx-overlap-clustered.yaml
@@ -1,4 +1,6 @@
-# Same workload as 100gb-3tx-overlap, but with automatic clustering enabled.
+# Same workload as 100gb-3tx-overlap, but with automatic clustering enabled
+# and materialized to a separate table (wide_clustered) so both variants can
+# coexist in the same Snowflake schema for side-by-side comparison.
 collections:
   - name: bench/wide
     schema:
@@ -20,7 +22,7 @@ collections:
       required: [id, _meta]
     key: [/id]
     resource:
-      table: wide
+      table: wide_clustered
       clustering: true
 
 transactions:

--- a/tests/benchmark/materialize/scenarios/100gb-3tx-overlap-clustered.yaml
+++ b/tests/benchmark/materialize/scenarios/100gb-3tx-overlap-clustered.yaml
@@ -10,10 +10,9 @@ collections:
       then:
         reduce: { delete: true, strategy: lastWriteWins }
       properties:
-        id:          { type: integer }
-        val:         { type: integer }
-        cluster_key: { type: string, enum: [ck0, ck1, ck2, ck3, ck4, ck5, ck6, ck7, ck8, ck9] }
-        payload:     { type: string }
+        id:      { type: integer }
+        val:     { type: integer }
+        payload: { type: string }
         _meta:
           type: object
           properties: { op: { type: string } }
@@ -22,7 +21,7 @@ collections:
     key: [/id]
     resource:
       table: wide
-      clustering: [cluster_key]
+      clustering: true
 
 transactions:
   - total_size: 33GB

--- a/tests/benchmark/materialize/scenarios/100gb-3tx-overlap-clustered.yaml
+++ b/tests/benchmark/materialize/scenarios/100gb-3tx-overlap-clustered.yaml
@@ -23,7 +23,7 @@ collections:
     key: [/id]
     resource:
       table: wide_clustered
-      clustering: true
+      clustering: id
 
 transactions:
   - total_size: 33GB

--- a/tests/benchmark/materialize/scenarios/100gb-3tx-overlap-clustered.yaml
+++ b/tests/benchmark/materialize/scenarios/100gb-3tx-overlap-clustered.yaml
@@ -1,0 +1,39 @@
+# Same workload as 100gb-3tx-overlap, but with automatic clustering enabled.
+collections:
+  - name: bench/wide
+    schema:
+      type: object
+      if:
+        properties:
+          _meta:
+            properties: { op: { const: d } }
+      then:
+        reduce: { delete: true, strategy: lastWriteWins }
+      properties:
+        id:      { type: integer }
+        val:     { type: integer }
+        payload: { type: string }
+        _meta:
+          type: object
+          properties: { op: { type: string } }
+          required: [op]
+      required: [id, _meta]
+    key: [/id]
+    resource:
+      table: wide
+      clustering: true
+
+transactions:
+  - total_size: 33GB
+    doc_size:   1KB
+    op: c
+
+  - total_size: 33GB
+    doc_size:   1KB
+    overlaps:
+      - { with: 0, fraction: 0.25, op: u }
+
+  - total_size: 34GB
+    doc_size:   1KB
+    overlaps:
+      - { with: 1, fraction: 0.50, op: u }

--- a/tests/benchmark/materialize/scenarios/100gb-3tx-overlap-clustered.yaml
+++ b/tests/benchmark/materialize/scenarios/100gb-3tx-overlap-clustered.yaml
@@ -10,9 +10,10 @@ collections:
       then:
         reduce: { delete: true, strategy: lastWriteWins }
       properties:
-        id:      { type: integer }
-        val:     { type: integer }
-        payload: { type: string }
+        id:          { type: integer }
+        val:         { type: integer }
+        cluster_key: { type: string, enum: [ck0, ck1, ck2, ck3, ck4, ck5, ck6, ck7, ck8, ck9] }
+        payload:     { type: string }
         _meta:
           type: object
           properties: { op: { type: string } }
@@ -21,7 +22,7 @@ collections:
     key: [/id]
     resource:
       table: wide
-      clustering: true
+      clustering: [cluster_key]
 
 transactions:
   - total_size: 33GB

--- a/tests/benchmark/materialize/scenarios/100gb-3tx-overlap.yaml
+++ b/tests/benchmark/materialize/scenarios/100gb-3tx-overlap.yaml
@@ -12,9 +12,10 @@ collections:
       then:
         reduce: { delete: true, strategy: lastWriteWins }
       properties:
-        id:      { type: integer }
-        val:     { type: integer }
-        payload: { type: string }
+        id:          { type: integer }
+        val:         { type: integer }
+        cluster_key: { type: string, enum: [ck0, ck1, ck2, ck3, ck4, ck5, ck6, ck7, ck8, ck9] }
+        payload:     { type: string }
         _meta:
           type: object
           properties: { op: { type: string } }

--- a/tests/benchmark/materialize/scenarios/100gb-3tx-recency-biased-clustered.yaml
+++ b/tests/benchmark/materialize/scenarios/100gb-3tx-recency-biased-clustered.yaml
@@ -36,7 +36,7 @@ collections:
     key: [/id]
     resource:
       table: wide_clustered
-      clustering: true
+      clustering: id
 
 transactions:
   - total_size: 33GB

--- a/tests/benchmark/materialize/scenarios/100gb-3tx-recency-biased-clustered.yaml
+++ b/tests/benchmark/materialize/scenarios/100gb-3tx-recency-biased-clustered.yaml
@@ -3,9 +3,11 @@
 # previous tx's fresh range. Models a real-world workload where newer records
 # get updated more than old ones.
 #
-# This is the baseline (no clustering). Pair with
-# 100gb-3tx-recency-biased-clustered.yaml to compare against the variant with
-# automatic clustering enabled on the primary key.
+# This variant enables Snowflake automatic clustering on the primary key.
+# Pair with 100gb-3tx-recency-biased.yaml (same workload, no clustering) to
+# measure the impact of clustering on MERGE performance — recency-biased
+# updates produce contiguous source key ranges that allow Snowflake's
+# join-filter pushdown to prune old target partitions.
 #
 # Overlap math (1KB docs, ~34.6M docs per 33GB):
 #   tx1: 20% overlap of 34.6M = 6.9M keys, drawn from last 40% of tx0
@@ -32,6 +34,9 @@ collections:
           required: [op]
       required: [id, _meta]
     key: [/id]
+    resource:
+      table: wide_clustered
+      clustering: true
 
 transactions:
   - total_size: 33GB

--- a/tests/benchmark/materialize/scenarios/100gb-3tx-recency-biased.yaml
+++ b/tests/benchmark/materialize/scenarios/100gb-3tx-recency-biased.yaml
@@ -1,0 +1,49 @@
+# 100 GB across three equal transactions (~33.3 GB each) with recency-biased
+# updates: each tx updates keys concentrated in the most recent slice of the
+# previous tx's fresh range. Models a real-world workload where newer records
+# get updated more than old ones — and exercises partition-pruning paths in
+# destinations that cluster on the key column.
+#
+# Overlap math (1KB docs, ~34.6M docs per 33GB):
+#   tx1: 20% overlap of 34.6M = 6.9M keys, drawn from last 40% of tx0
+#        (13.8M candidates). 26.7M fresh allocated.
+#   tx2: 20% overlap of 35.6M = 7.1M keys, drawn from last 40% of tx1's fresh
+#        (11.1M candidates). 28.5M fresh allocated.
+collections:
+  - name: bench/wide
+    schema:
+      type: object
+      if:
+        properties:
+          _meta:
+            properties: { op: { const: d } }
+      then:
+        reduce: { delete: true, strategy: lastWriteWins }
+      properties:
+        id:      { type: integer }
+        val:     { type: integer }
+        payload: { type: string }
+        _meta:
+          type: object
+          properties: { op: { type: string } }
+          required: [op]
+      required: [id, _meta]
+    key: [/id]
+    resource:
+      table: wide
+      clustering: true
+
+transactions:
+  - total_size: 33GB
+    doc_size:   1KB
+    op: c
+
+  - total_size: 33GB
+    doc_size:   1KB
+    overlaps:
+      - { with: 0, fraction: 0.20, op: u, range: [0.6, 1.0] }
+
+  - total_size: 34GB
+    doc_size:   1KB
+    overlaps:
+      - { with: 1, fraction: 0.20, op: u, range: [0.6, 1.0] }

--- a/tests/benchmark/materialize/scenarios/100gb-3tx-zipfian-clustered.yaml
+++ b/tests/benchmark/materialize/scenarios/100gb-3tx-zipfian-clustered.yaml
@@ -40,7 +40,7 @@ collections:
     key: [/id]
     resource:
       table: wide_zipfian_clustered
-      clustering: true
+      clustering: id
 
 transactions:
   - total_size: 33GB

--- a/tests/benchmark/materialize/scenarios/100gb-3tx-zipfian-clustered.yaml
+++ b/tests/benchmark/materialize/scenarios/100gb-3tx-zipfian-clustered.yaml
@@ -1,0 +1,58 @@
+# 100 GB across three equal transactions (~33.3 GB each) with zipfian-
+# distributed updates: each tx updates keys drawn from the entire previous
+# tx's fresh range, but with probability ∝ 1/rank^s where rank=1 sits at
+# the tail (newest) end. The most recent rows get hammered while a long
+# tail of older rows still receives occasional touches — a closer match
+# to real workloads than either pure uniform overlap or the hard
+# `range: [0.6, 1.0]` cutoff used in the recency-biased scenarios.
+#
+# This variant enables Snowflake automatic clustering on the primary key
+# and materializes to a separate table (wide_zipfian_clustered) so it can
+# coexist with 100gb-3tx-zipfian.yaml for side-by-side comparison.
+# Compared to 100gb-3tx-recency-biased-clustered.yaml, this exercises a
+# more realistic update shape: heavy mass on recent keys (where pruning
+# is easy) plus a long tail of older keys (where pruning is harder).
+#
+# Overlap math (1KB docs, ~34.6M docs per 33GB):
+#   tx1: 20% overlap of 34.6M = 6.9M keys, drawn zipfian-tail (s=1.0)
+#        from the full 34.6M of tx0's keys. 26.7M fresh allocated.
+#   tx2: 20% overlap of 35.6M = 7.1M keys, drawn zipfian-tail (s=1.0)
+#        from the full ~28.5M of tx1's fresh range. 28.5M fresh allocated.
+collections:
+  - name: bench/wide
+    schema:
+      type: object
+      if:
+        properties:
+          _meta:
+            properties: { op: { const: d } }
+      then:
+        reduce: { delete: true, strategy: lastWriteWins }
+      properties:
+        id:      { type: integer }
+        val:     { type: integer }
+        payload: { type: string }
+        _meta:
+          type: object
+          properties: { op: { type: string } }
+          required: [op]
+      required: [id, _meta]
+    key: [/id]
+    resource:
+      table: wide_zipfian_clustered
+      clustering: true
+
+transactions:
+  - total_size: 33GB
+    doc_size:   1KB
+    op: c
+
+  - total_size: 33GB
+    doc_size:   1KB
+    overlaps:
+      - { with: 0, fraction: 0.20, op: u, distribution: zipfian, zipf_s: 1.0, zipf_bias: tail }
+
+  - total_size: 34GB
+    doc_size:   1KB
+    overlaps:
+      - { with: 1, fraction: 0.20, op: u, distribution: zipfian, zipf_s: 1.0, zipf_bias: tail }

--- a/tests/benchmark/materialize/scenarios/100gb-3tx-zipfian.yaml
+++ b/tests/benchmark/materialize/scenarios/100gb-3tx-zipfian.yaml
@@ -1,0 +1,58 @@
+# 100 GB across three equal transactions (~33.3 GB each) with zipfian-
+# distributed updates: each tx updates keys drawn from the entire previous
+# tx's fresh range, but with probability ∝ 1/rank^s where rank=1 sits at
+# the tail (newest) end. The most recent rows get hammered while a long
+# tail of older rows still receives occasional touches — a closer match
+# to real workloads than either pure uniform overlap or the hard
+# `range: [0.6, 1.0]` cutoff used in the recency-biased scenarios.
+#
+# This is the baseline (no clustering). Pair with
+# 100gb-3tx-zipfian-clustered.yaml to measure the impact of automatic
+# clustering on MERGE performance under a heavy-tailed update workload.
+# Compared to 100gb-3tx-recency-biased*.yaml, the zipfian variants
+# stress how well clustering's join-filter pushdown handles updates that
+# concentrate on a hot recent set but still occasionally reach into old
+# partitions.
+#
+# Overlap math (1KB docs, ~34.6M docs per 33GB):
+#   tx1: 20% overlap of 34.6M = 6.9M keys, drawn zipfian-tail (s=1.0)
+#        from the full 34.6M of tx0's keys. 26.7M fresh allocated.
+#   tx2: 20% overlap of 35.6M = 7.1M keys, drawn zipfian-tail (s=1.0)
+#        from the full ~28.5M of tx1's fresh range. 28.5M fresh allocated.
+collections:
+  - name: bench/wide
+    schema:
+      type: object
+      if:
+        properties:
+          _meta:
+            properties: { op: { const: d } }
+      then:
+        reduce: { delete: true, strategy: lastWriteWins }
+      properties:
+        id:      { type: integer }
+        val:     { type: integer }
+        payload: { type: string }
+        _meta:
+          type: object
+          properties: { op: { type: string } }
+          required: [op]
+      required: [id, _meta]
+    key: [/id]
+    resource:
+      table: wide_zipfian
+
+transactions:
+  - total_size: 33GB
+    doc_size:   1KB
+    op: c
+
+  - total_size: 33GB
+    doc_size:   1KB
+    overlaps:
+      - { with: 0, fraction: 0.20, op: u, distribution: zipfian, zipf_s: 1.0, zipf_bias: tail }
+
+  - total_size: 34GB
+    doc_size:   1KB
+    overlaps:
+      - { with: 1, fraction: 0.20, op: u, distribution: zipfian, zipf_s: 1.0, zipf_bias: tail }

--- a/tests/benchmark/materialize/test_generate.py
+++ b/tests/benchmark/materialize/test_generate.py
@@ -284,6 +284,179 @@ class TestOverlap(unittest.TestCase):
             )
 
 
+class TestZipfianDistribution(unittest.TestCase):
+    """Zipfian-weighted overlap sampling: biases overlap keys towards one
+    end of the source tx's (sub-)range with a long-tail decay. Useful for
+    modelling real-world hot-spot updates."""
+
+    def _zipf_update_keys(self, distribution_kwargs: dict, seed: int = 0):
+        lines, _ = _run(
+            [
+                {"doc_count": 1000, "doc_size": 256},
+                {
+                    "doc_count": 1000,
+                    "doc_size": 256,
+                    "overlaps": [
+                        {"with": 0, "fraction": 0.20, "op": "u", **distribution_kwargs},
+                    ],
+                },
+            ],
+            seed=seed,
+        )
+        docs = [json.loads(l) for l in lines if not l.startswith("{")]
+        return [d["id"] for _, d in docs[1000:] if d["_meta"]["op"] == "u"]
+
+    def test_zipfian_biases_to_tail(self):
+        keys = self._zipf_update_keys({"distribution": "zipfian", "zipf_s": 1.5})
+        self.assertEqual(len(keys), 200)
+        # Tx 0 spans [0, 1000). With heavy tail bias, mass should sit
+        # well above the midpoint. Median > 700 is a stable threshold for
+        # s=1.5: empirically the median floats around 850.
+        median = sorted(keys)[len(keys) // 2]
+        self.assertGreater(median, 700, f"expected median key > 700, got {median}")
+        # And the top decile should contain a disproportionate share of picks.
+        top_decile_share = sum(1 for k in keys if k >= 900) / len(keys)
+        self.assertGreater(top_decile_share, 0.30,
+                           f"top 10% of range should hold >30% of picks, got {top_decile_share:.2%}")
+
+    def test_zipfian_biases_to_head(self):
+        keys = self._zipf_update_keys(
+            {"distribution": "zipfian", "zipf_s": 1.5, "zipf_bias": "head"}
+        )
+        median = sorted(keys)[len(keys) // 2]
+        self.assertLess(median, 300, f"expected median key < 300, got {median}")
+
+    def test_zipfian_no_replacement(self):
+        keys = self._zipf_update_keys({"distribution": "zipfian", "zipf_s": 1.5})
+        self.assertEqual(len(keys), len(set(keys)),
+                         "zipfian sampling must not produce duplicate keys")
+
+    def test_zipfian_deterministic(self):
+        a = self._zipf_update_keys({"distribution": "zipfian", "zipf_s": 1.2}, seed=11)
+        b = self._zipf_update_keys({"distribution": "zipfian", "zipf_s": 1.2}, seed=11)
+        self.assertEqual(a, b)
+        c = self._zipf_update_keys({"distribution": "zipfian", "zipf_s": 1.2}, seed=12)
+        self.assertNotEqual(sorted(a), sorted(c))
+
+    def test_zipfian_with_subrange(self):
+        # Combine zipfian-tail with a [0.6, 1.0] sub-range: keys must lie in
+        # the last 40% of tx 0, AND skew towards the upper edge of THAT.
+        lines, _ = _run(
+            [
+                {"doc_count": 1000, "doc_size": 256},
+                {
+                    "doc_count": 1000,
+                    "doc_size": 256,
+                    "overlaps": [
+                        {
+                            "with": 0,
+                            "fraction": 0.10,
+                            "op": "u",
+                            "range": [0.6, 1.0],
+                            "distribution": "zipfian",
+                            "zipf_s": 1.5,
+                        },
+                    ],
+                },
+            ]
+        )
+        docs = [json.loads(l) for l in lines if not l.startswith("{")]
+        keys = [d["id"] for _, d in docs[1000:] if d["_meta"]["op"] == "u"]
+        self.assertEqual(len(keys), 100)
+        # All keys in the [0.6, 1.0] sub-range = [600, 1000).
+        self.assertTrue(all(600 <= k < 1000 for k in keys),
+                        f"expected all keys in [600, 1000), got min={min(keys)} max={max(keys)}")
+        # Tail bias: median should still skew above the sub-range midpoint (800).
+        median = sorted(keys)[len(keys) // 2]
+        self.assertGreater(median, 800, f"expected median > 800, got {median}")
+
+    def test_zipfian_disjoint_with_exclusions(self):
+        # Two overlap entries against the same source tx must produce
+        # disjoint key sets (existing invariant) under zipfian too.
+        lines, _ = _run(
+            [
+                {"doc_count": 1000, "doc_size": 256},
+                {
+                    "doc_count": 1000,
+                    "doc_size": 256,
+                    "overlaps": [
+                        {"with": 0, "fraction": 0.20, "op": "u",
+                         "distribution": "zipfian", "zipf_s": 1.5},
+                        {"with": 0, "fraction": 0.10, "op": "d",
+                         "distribution": "zipfian", "zipf_s": 1.5},
+                    ],
+                },
+            ]
+        )
+        docs = [json.loads(l) for l in lines if not l.startswith("{")]
+        tx1_docs = docs[1000:]
+        update_keys = {d["id"] for _, d in tx1_docs if d["_meta"]["op"] == "u"}
+        delete_keys = {d["id"] for _, d in tx1_docs if d["_meta"]["op"] == "d"}
+        self.assertEqual(len(update_keys), 200)
+        self.assertEqual(len(delete_keys), 100)
+        self.assertTrue(update_keys.isdisjoint(delete_keys))
+
+    def test_zipfian_sub_s_approaches_uniform(self):
+        # s=0.01 (almost flat) should look roughly uniform over the range.
+        keys = self._zipf_update_keys(
+            {"distribution": "zipfian", "zipf_s": 0.01}, seed=3,
+        )
+        # Mean within a generous band around the uniform mean of 499.5.
+        mean = sum(keys) / len(keys)
+        self.assertGreater(mean, 350)
+        self.assertLess(mean, 650)
+
+    def test_invalid_distribution_rejected(self):
+        with self.assertRaises(ValueError):
+            _run(
+                [
+                    {"doc_count": 100, "doc_size": 256},
+                    {
+                        "doc_count": 100,
+                        "doc_size": 256,
+                        "overlaps": [
+                            {"with": 0, "fraction": 0.2, "op": "u",
+                             "distribution": "lognormal"},
+                        ],
+                    },
+                ]
+            )
+
+    def test_invalid_zipf_s_rejected(self):
+        for bad in (0, -1.0):
+            with self.subTest(s=bad):
+                with self.assertRaises(ValueError):
+                    _run(
+                        [
+                            {"doc_count": 100, "doc_size": 256},
+                            {
+                                "doc_count": 100,
+                                "doc_size": 256,
+                                "overlaps": [
+                                    {"with": 0, "fraction": 0.2, "op": "u",
+                                     "distribution": "zipfian", "zipf_s": bad},
+                                ],
+                            },
+                        ]
+                    )
+
+    def test_invalid_zipf_bias_rejected(self):
+        with self.assertRaises(ValueError):
+            _run(
+                [
+                    {"doc_count": 100, "doc_size": 256},
+                    {
+                        "doc_count": 100,
+                        "doc_size": 256,
+                        "overlaps": [
+                            {"with": 0, "fraction": 0.2, "op": "u",
+                             "distribution": "zipfian", "zipf_bias": "middle"},
+                        ],
+                    },
+                ]
+            )
+
+
 class TestManualLineAssembly(unittest.TestCase):
     """The fast path assembles the fixture line by string fragments rather
     than calling json.dumps per doc. These tests verify that the output

--- a/tests/benchmark/materialize/test_generate.py
+++ b/tests/benchmark/materialize/test_generate.py
@@ -207,6 +207,82 @@ class TestOverlap(unittest.TestCase):
                 ]
             )
 
+    def test_overlap_range_restricts_to_tail(self):
+        """range: [0.6, 1.0] should sample only from the last 40% of the source tx."""
+        lines, state = _run(
+            [
+                {"doc_count": 100, "doc_size": 256},
+                {
+                    "doc_count": 100,
+                    "doc_size": 256,
+                    "overlaps": [
+                        {"with": 0, "fraction": 0.20, "op": "u", "range": [0.6, 1.0]},
+                    ],
+                },
+            ]
+        )
+        docs = [json.loads(l) for l in lines if not l.startswith("{")]
+        tx1_docs = docs[100:]
+        update_keys = [d["id"] for c, d in tx1_docs if d["_meta"]["op"] == "u"]
+        self.assertEqual(len(update_keys), 20)
+        # Tx 0 used keys [0, 100); the last 40% is [60, 100).
+        self.assertTrue(all(60 <= k < 100 for k in update_keys),
+                        f"expected all keys in [60, 100), got {sorted(update_keys)}")
+
+    def test_overlap_range_restricts_to_head(self):
+        lines, _ = _run(
+            [
+                {"doc_count": 100, "doc_size": 256},
+                {
+                    "doc_count": 100,
+                    "doc_size": 256,
+                    "overlaps": [
+                        {"with": 0, "fraction": 0.10, "op": "u", "range": [0.0, 0.25]},
+                    ],
+                },
+            ]
+        )
+        docs = [json.loads(l) for l in lines if not l.startswith("{")]
+        tx1_docs = docs[100:]
+        update_keys = [d["id"] for c, d in tx1_docs if d["_meta"]["op"] == "u"]
+        self.assertEqual(len(update_keys), 10)
+        # First 25% of tx 0 is [0, 25).
+        self.assertTrue(all(0 <= k < 25 for k in update_keys),
+                        f"expected all keys in [0, 25), got {sorted(update_keys)}")
+
+    def test_overlap_range_invalid_bounds(self):
+        for bad in ([0.5, 0.5], [0.7, 0.3], [-0.1, 0.5], [0.5, 1.1], [0.5]):
+            with self.subTest(bad=bad):
+                with self.assertRaises(ValueError):
+                    _run(
+                        [
+                            {"doc_count": 10, "doc_size": 256},
+                            {
+                                "doc_count": 10,
+                                "doc_size": 256,
+                                "overlaps": [
+                                    {"with": 0, "fraction": 0.5, "op": "u", "range": bad},
+                                ],
+                            },
+                        ]
+                    )
+
+    def test_overlap_range_too_narrow_for_fraction(self):
+        # 50% of 10 docs = 5 keys, but range covers only 2 keys of source.
+        with self.assertRaises(ValueError):
+            _run(
+                [
+                    {"doc_count": 10, "doc_size": 256},
+                    {
+                        "doc_count": 10,
+                        "doc_size": 256,
+                        "overlaps": [
+                            {"with": 0, "fraction": 0.5, "op": "u", "range": [0.0, 0.2]},
+                        ],
+                    },
+                ]
+            )
+
 
 class TestManualLineAssembly(unittest.TestCase):
     """The fast path assembles the fixture line by string fragments rather

--- a/tests/benchmark/materialize/test_generate.py
+++ b/tests/benchmark/materialize/test_generate.py
@@ -45,6 +45,24 @@ UUID_COLLECTION = {
     "key_type": "uuid",
 }
 
+# Uses enum values of *different* byte-lengths on purpose, so the exact
+# byte-size tests exercise the per-variant overhead bookkeeping.
+ENUM_VALUES = ["ck0", "ck1", "ck2", "ck3", "ck4", "ck5", "ck6", "ck7", "ck8", "ck9"]
+ENUM_COLLECTION = {
+    "name": "bench/enum",
+    "schema": {
+        "type": "object",
+        "properties": {
+            "id": {"type": "integer"},
+            "val": {"type": "integer"},
+            "cluster_key": {"type": "string", "enum": ENUM_VALUES},
+            "payload": {"type": "string"},
+        },
+        "required": ["id"],
+    },
+    "key": ["/id"],
+}
+
 
 def _scenario(transactions: list[dict], collection: dict | None = None) -> dict:
     return {"collections": [collection or SIMPLE_COLLECTION], "transactions": transactions}
@@ -300,6 +318,81 @@ class TestUUIDKeys(unittest.TestCase):
         bad_collection = dict(UUID_COLLECTION, key_type="sha256")
         with self.assertRaises(ValueError):
             _run([{"doc_count": 1, "doc_size": 256}], collection=bad_collection)
+
+
+class TestEnumFields(unittest.TestCase):
+    def test_values_from_enum_set(self):
+        lines, _ = _run(
+            [{"doc_count": 200, "doc_size": 256}], collection=ENUM_COLLECTION
+        )
+        docs = [json.loads(l) for l in lines if not l.startswith("{")]
+        self.assertEqual(len(docs), 200)
+        for _, doc in docs:
+            self.assertIn(doc["cluster_key"], ENUM_VALUES)
+
+    def test_exact_byte_size_with_enum(self):
+        # With variable-length enum values, per-variant overhead must drive
+        # payload padding correctly so each doc still hits doc_size exactly.
+        lines, _ = _run(
+            [{"doc_count": 200, "doc_size": 256}], collection=ENUM_COLLECTION
+        )
+        docs = [json.loads(l) for l in lines if not l.startswith("{")]
+        for _, doc in docs:
+            encoded = json.dumps(doc, separators=(",", ":"))
+            self.assertEqual(len(encoded.encode("utf-8")), 256)
+
+    def test_distribution_covers_all_enum_values(self):
+        # Keys are allocated as [0, N), and variant selection is
+        # key % len(enum), so all values must appear when N >> len(enum).
+        lines, _ = _run(
+            [{"doc_count": 500, "doc_size": 256}], collection=ENUM_COLLECTION
+        )
+        docs = [json.loads(l) for l in lines if not l.startswith("{")]
+        seen = {d["cluster_key"] for _, d in docs}
+        self.assertEqual(seen, set(ENUM_VALUES))
+
+    def test_enum_deterministic(self):
+        a, _ = _run(
+            [{"doc_count": 100, "doc_size": 256}], seed=7, collection=ENUM_COLLECTION
+        )
+        b, _ = _run(
+            [{"doc_count": 100, "doc_size": 256}], seed=7, collection=ENUM_COLLECTION
+        )
+        self.assertEqual(a, b)
+
+    def test_empty_enum_rejected(self):
+        bad = {
+            "name": "bench/bad-enum",
+            "schema": {
+                "type": "object",
+                "properties": {
+                    "id": {"type": "integer"},
+                    "cluster_key": {"type": "string", "enum": []},
+                    "payload": {"type": "string"},
+                },
+                "required": ["id"],
+            },
+            "key": ["/id"],
+        }
+        with self.assertRaises(ValueError):
+            _run([{"doc_count": 1, "doc_size": 256}], collection=bad)
+
+    def test_non_scalar_enum_rejected(self):
+        bad = {
+            "name": "bench/bad-enum",
+            "schema": {
+                "type": "object",
+                "properties": {
+                    "id": {"type": "integer"},
+                    "cluster_key": {"enum": [{"nested": "object"}]},
+                    "payload": {"type": "string"},
+                },
+                "required": ["id"],
+            },
+            "key": ["/id"],
+        }
+        with self.assertRaises(ValueError):
+            _run([{"doc_count": 1, "doc_size": 256}], collection=bad)
 
 
 class TestDeterminism(unittest.TestCase):


### PR DESCRIPTION
**Description:**

- Add a per-binding resource config option to enable Automatic Clustering with specified fields as clustering keys. For MERGE INTO performance improvement these should be identical to primary keys of the table, but otherwise it may be useful for customers who specifically want to query their data using certain fields, and they want to cluster on those fields
- Added two new features to benchmark suite: the ability to specify a range of keys for overlaps so that we can for example draw the overlapping keys from a specific tail range, and the ability to draw the keys from a Zipfian distribution which often can be useful for describing close-to-real-world pattern of updates on existing records: the tail end of recent events get majority of updates, with some updates to older records.
- Added the benchmark results as a baseline to the repository

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

