### PR TITLE
materialize-sql: dialect nullability more flexible

### DIFF
--- a/materialize-bigquery/sqlgen.go
+++ b/materialize-bigquery/sqlgen.go
@@ -115,7 +115,7 @@ func bqDialect(featureFlags map[string]bool) sql.Dialect {
 				},
 			}),
 		},
-		sql.WithNotNullText("NOT NULL"),
+		sql.WithNotNullSuffix("NOT NULL"),
 	)
 
 	return sql.Dialect{

--- a/materialize-cratedb/sqlgen.go
+++ b/materialize-cratedb/sqlgen.go
@@ -63,7 +63,7 @@ var crateDialect = func() sql.Dialect {
 				},
 			}),
 		},
-		//sql.WithNotNullText("NOT NULL"), CrateDB does not support dropping NOT NULL columns.
+		//sql.WithNotNullSuffix("NOT NULL"), CrateDB does not support dropping NOT NULL columns.
 	)
 
 	return sql.Dialect{

--- a/materialize-databricks/sqlgen.go
+++ b/materialize-databricks/sqlgen.go
@@ -67,7 +67,7 @@ func createDatabricksDialect(featureFlags map[string]bool) sql.Dialect {
 				},
 			}),
 		},
-		sql.WithNotNullText("NOT NULL"),
+		sql.WithNotNullSuffix("NOT NULL"),
 	)
 
 	return sql.Dialect{

--- a/materialize-motherduck/sqlgen.go
+++ b/materialize-motherduck/sqlgen.go
@@ -65,7 +65,7 @@ func createDuckDialect(featureFlags map[string]bool) sql.Dialect {
 				},
 			}),
 		},
-		sql.WithNotNullText("NOT NULL"),
+		sql.WithNotNullSuffix("NOT NULL"),
 	)
 
 	return sql.Dialect{

--- a/materialize-mysql/sqlgen.go
+++ b/materialize-mysql/sqlgen.go
@@ -140,7 +140,7 @@ var mysqlDialect = func(tzLocation *time.Location, database string, product stri
 				},
 			}),
 		},
-		sql.WithNotNullText("NOT NULL"),
+		sql.WithNotNullSuffix("NOT NULL"),
 	)
 
 	var nocast = sql.WithCastSQL(migrationIdentifier)

--- a/materialize-postgres/sqlgen.go
+++ b/materialize-postgres/sqlgen.go
@@ -61,7 +61,7 @@ func createPgDialect(featureFlags map[string]bool) sql.Dialect {
 				},
 			}),
 		},
-		sql.WithNotNullText("NOT NULL"),
+		sql.WithNotNullSuffix("NOT NULL"),
 	)
 
 	return sql.Dialect{

--- a/materialize-snowflake/sqlgen.go
+++ b/materialize-snowflake/sqlgen.go
@@ -111,7 +111,7 @@ var snowflakeDialect = func(configSchema string, timestampType snowflakeTimestam
 				},
 			}),
 		},
-		sql.WithNotNullText("NOT NULL"),
+		sql.WithNotNullSuffix("NOT NULL"),
 	)
 
 	translateIdentifier := func(in string) string {

--- a/materialize-spanner/sqlgen.go
+++ b/materialize-spanner/sqlgen.go
@@ -81,7 +81,7 @@ func createSpannerDialect(featureFlags map[string]bool) sql.Dialect {
 				},
 			}),
 		},
-		sql.WithNotNullText("NOT NULL"),
+		sql.WithNotNullSuffix("NOT NULL"),
 	)
 
 	return sql.Dialect{

--- a/materialize-sql/templating_test.go
+++ b/materialize-sql/templating_test.go
@@ -30,7 +30,7 @@ func newTestDialect() Dialect {
 				},
 			}),
 		},
-		WithNotNullText("NOT NULL"),
+		WithNotNullSuffix("NOT NULL"),
 	)
 
 	return Dialect{

--- a/materialize-sql/type_mapping.go
+++ b/materialize-sql/type_mapping.go
@@ -219,13 +219,14 @@ type MapProjectionFn func(p *Projection) (DDLer, CompatibleColumnTypes, ElementC
 
 var _ TypeMapper = DDLMapper{}
 
-// DDLMapper completes the column definition from the column DDL, by adding the
-// "not null" and "nullable" text (if applicable), the comment for the column,
-// and handling any field configuration options.
+// DDLMapper completes the column definition from the column DDL, by applying
+// the dialect's "not null" and "nullable" transformations (if configured) to
+// the base type, the comment for the column, and handling any field
+// configuration options.
 type DDLMapper struct {
-	notNullText  string
-	nullableText string
-	m            map[FlatType]MapProjectionFn
+	notNullFn  func(ddl string) string
+	nullableFn func(ddl string) string
+	m          map[FlatType]MapProjectionFn
 }
 
 type FlatTypeMappings map[FlatType]MapProjectionFn
@@ -246,23 +247,41 @@ func NewDDLMapper(mappings FlatTypeMappings, opts ...DDLMapperOption) DDLMapper 
 
 type DDLMapperOption func(*DDLMapper)
 
-// WithNotNullText sets the "not null" DDL that will be used for columns with
-// fields that can never be NULL.
-func WithNotNullText(notNullText string) DDLMapperOption {
+// WithNotNullFn sets a transformation applied to the base DDL for columns with
+// fields that can never be NULL. Use WithNotNullSuffix for the common case of
+// appending a suffix token (e.g. "NOT NULL").
+func WithNotNullFn(fn func(ddl string) string) DDLMapperOption {
 	return func(m *DDLMapper) {
-		m.notNullText = notNullText
+		m.notNullFn = fn
 	}
 }
 
-// WithNullableText sets the "nullable" DDL that will be used for columns with
-// fields that can be NULL. Most databases will assume that a column may contain
-// null as long as it isn't declared with a NOT NULL constraint, but some
-// databases (e.g. ms sql server) make that behavior configurable, requiring the
-// DDL to explicitly declare a column with NULL if it may contain null values.
-func WithNullableText(nullableText string) DDLMapperOption {
+// WithNotNullSuffix is a convenience form of WithNotNullFn for dialects that
+// express non-nullability by appending a token after the base DDL (e.g. "NOT
+// NULL").
+func WithNotNullSuffix(suffix string) DDLMapperOption {
+	return WithNotNullFn(func(ddl string) string { return ddl + " " + suffix })
+}
+
+// WithNullableFn sets a transformation applied to the base DDL for columns with
+// fields that can be NULL. Use WithNullableSuffix for the common case of
+// appending a suffix token (e.g. "NULL"). Use WithNullableFn for dialects that
+// express nullability by wrapping the type (e.g. ClickHouse's "Nullable(T)").
+//
+// Most databases assume that a column may contain null as long as it isn't
+// declared with a NOT NULL constraint, but some databases (e.g. ms sql server)
+// make that behavior configurable, requiring the DDL to explicitly declare a
+// column with NULL if it may contain null values.
+func WithNullableFn(fn func(ddl string) string) DDLMapperOption {
 	return func(m *DDLMapper) {
-		m.nullableText = nullableText
+		m.nullableFn = fn
 	}
+}
+
+// WithNullableSuffix is a convenience form of WithNullableFn for dialects that
+// express nullability by appending a token after the base DDL (e.g. "NULL").
+func WithNullableSuffix(suffix string) DDLMapperOption {
+	return WithNullableFn(func(ddl string) string { return ddl + " " + suffix })
 }
 
 type mapStaticConfig struct {
@@ -452,10 +471,10 @@ func (d DDLMapper) MapType(p *Projection, fc FieldConfig) MappedType {
 		TargetType:            ddl,
 	}
 
-	if mustExist && d.notNullText != "" {
-		out.DDL += " " + d.notNullText
-	} else if d.nullableText != "" {
-		out.DDL += " " + d.nullableText
+	if mustExist && d.notNullFn != nil {
+		out.DDL = d.notNullFn(out.DDL)
+	} else if d.nullableFn != nil {
+		out.DDL = d.nullableFn(out.DDL)
 		out.NullableDDL = out.DDL
 	}
 

--- a/materialize-sqlite/sqlgen.go
+++ b/materialize-sqlite/sqlgen.go
@@ -21,7 +21,7 @@ var sqliteDialect = func() sql.Dialect {
 			sql.STRING_NUMBER:  sql.MapStatic("REAL"),
 			sql.STRING:         sql.MapStatic("TEXT"),
 		},
-		sql.WithNotNullText("NOT NULL"),
+		sql.WithNotNullSuffix("NOT NULL"),
 	)
 
 	return sql.Dialect{

--- a/materialize-sqlserver/sqlgen.go
+++ b/materialize-sqlserver/sqlgen.go
@@ -97,7 +97,7 @@ func createSqlServerDialect(collation string, defaultSchema string, featureFlags
 				},
 			}),
 		},
-		sql.WithNotNullText("NOT NULL"),
+		sql.WithNotNullSuffix("NOT NULL"),
 	)
 
 	var nocast = sql.WithCastSQL(migrationIdentifier)


### PR DESCRIPTION
**Description:**

Helps https://github.com/estuary/connectors/issues/4246

This change allows SQL dialects to set nullability with a function, not just a string suffix. It is needed because ClickHouse syntax is `Nullable(DDL)` instead of `DDL NULLABLE` or similar.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

