### PR TITLE
source-braintree-native: strip microseconds from cursors

### DIFF
--- a/source-braintree-native/source_braintree_native/api/__init__.py
+++ b/source-braintree-native/source_braintree_native/api/__init__.py
@@ -76,7 +76,7 @@ async def fetch_transactions(
         initial_end=min(
             log_cursor + timedelta(hours=window_size),
             datetime.now(tz=UTC) - LAG,
-        ),
+        ).replace(microsecond=0),
         log=log,
     )
 
@@ -144,7 +144,12 @@ async def backfill_transactions(
 
     start = _str_to_dt(page)
 
-    if start >= cutoff:
+    initial_end = min(
+        start + timedelta(hours=window_size),
+        cutoff,
+    ).replace(microsecond=0)
+
+    if start >= initial_end:
         return
 
     end = await determine_next_searchable_resource_window_end_by_field(
@@ -153,7 +158,7 @@ async def backfill_transactions(
         path=TRANSACTION_PATH_COMPONENT,
         field_name="created_at",
         start=start,
-        initial_end=min(start + timedelta(hours=window_size), cutoff),
+        initial_end=initial_end,
         log=log,
         search_limit=TRANSACTION_SEARCH_LIMIT,
     )
@@ -195,7 +200,7 @@ async def fetch_incremental_resources(
         initial_end=min(
             log_cursor + timedelta(hours=window_size),
             datetime.now(tz=UTC) - LAG,
-        ),
+        ).replace(microsecond=0),
         log=log,
     )
 
@@ -242,7 +247,12 @@ async def backfill_incremental_resources(
 
     start = _str_to_dt(page)
 
-    if start >= cutoff:
+    initial_end = min(
+        start + timedelta(hours=window_size),
+        cutoff,
+    ).replace(microsecond=0)
+
+    if start >= initial_end:
         return
 
     end = await determine_next_searchable_resource_window_end_by_field(
@@ -251,7 +261,7 @@ async def backfill_incremental_resources(
         path=path,
         field_name="created_at",
         start=start,
-        initial_end=min(start + timedelta(hours=window_size), cutoff),
+        initial_end=initial_end,
         log=log,
     )
 
@@ -316,11 +326,11 @@ async def backfill_disputes(
 
     start = _str_to_dt(page)
 
-    if start >= cutoff:
-        return
-
     window_end = start + timedelta(hours=max(window_size, MIN_DISPUTES_WINDOW_SIZE))
-    end = min(window_end, cutoff)
+    end = min(window_end, cutoff).replace(microsecond=0)
+
+    if start >= end:
+        return
 
     async for doc in fetch_disputes_between(
         http,

--- a/source-braintree-native/tests/snapshots/snapshots__capture__capture.stdout.json
+++ b/source-braintree-native/tests/snapshots/snapshots__capture__capture.stdout.json
@@ -105,6 +105,7 @@
           "card_types": [
             "AMERICAN_EXPRESS",
             "DISCOVER",
+            "JCB",
             "MASTERCARD",
             "VISA"
           ],


### PR DESCRIPTION
**Description:**

This PR is a follow-up to 0bc7c7b741. That commit fixed `disputes` but the other incremental streams (`subscriptions`, `customers`, `credit_card_verifications`, `transactions`) were still yielding cursors with microseconds via `datetime.now(tz=UTC) - LAG`. When a scheduled re-initialization fires, the CDK coordinates the new backfill cutoff with the current incremental cursor, so the microseconds leaked into `ResourceState.Backfill.cutoff` even though `resources.py` initializes it with `.replace(microsecond=0)`. This PR fixes this by preventing microseconds from making it into the incremental cursor in the first place.

Also, we're now stripping microseconds from the backfill window `end` so existing backfills with microsecond-laden cutoffs can complete instead of infinitely yielding the same page cursor on the final backfill iteration where `start < cutoff` but `floor(cutoff) == start`. The termination check is now `start >= end` instead of `start >= cutoff`.