### PR TITLE
estuary-cdk: include status code in 5xx retry logs

### DIFF
--- a/estuary-cdk/estuary_cdk/http.py
+++ b/estuary-cdk/estuary_cdk/http.py
@@ -636,7 +636,10 @@ class HTTPMixin(Mixin, HTTPSession):
                     ):
                         log.warning(
                             "server internal error (will retry)",
-                            {"body": body.decode("utf-8")},
+                            {
+                                "status_code": resp.status,
+                                "body": body.decode("utf-8"),
+                            },
                         )
                     else:
                         raise HTTPError(


### PR DESCRIPTION
**Description:**

This PR adds the status code to the log emitted by the CDK when it automatically retries after receiving a 5xx response. This can be useful when troubleshooting APIs that consistently return 5xx errors for reasons we don't yet fully understand.