### PR TITLE
source-outreach: use date windows for incremental replication

### DIFF
--- a/source-outreach/source_outreach/api.py
+++ b/source-outreach/source_outreach/api.py
@@ -23,6 +23,12 @@ MAX_PAGE_SIZE = 1000
 MIN_PAGE_SIZE = 1
 NEXT_PAGE_QUERY_PARAMETER = "page[after]"
 
+# MAX_WINDOW_SIZE bounds how far forward a single fetch_resources invocation
+# will advance. The Outreach API sometimes returns results unsorted within a
+# query, so we process records in explicit [lower, upper] date windows and
+# trust the set of records returned for that window rather than their order.
+MAX_WINDOW_SIZE = timedelta(days=1)
+
 def _dt_to_str(dt: datetime) -> str:
     return dt.strftime(DATETIME_STRING_FORMAT)
 
@@ -83,17 +89,6 @@ def _extract_resource_cursor(
     return _str_to_dt(getattr(resource, 'attributes')[cursor_field])
 
 
-# _raise_if_unordered performs a sanity check to confirm
-# the Outreach API returned sorted records.
-def _raise_if_unordered(
-    resource_id: int,
-    previous_dt: datetime | None,
-    resource_dt: datetime,
-) -> None:
-    if previous_dt and resource_dt < previous_dt:
-        raise RuntimeError(f"Outreach API returned records out of order for {resource_id} with {resource_dt} < {previous_dt}.")
-
-
 async def _do_request(
     http: HTTPSession,
     url: str,
@@ -137,7 +132,7 @@ async def backfill_resources(
 
     url = f"{API}/{path}"
 
-    params = _build_query_params(cursor_field, start_date, None, extra_params)
+    params = _build_query_params(cursor_field, start_date, cutoff, extra_params)
 
     if page is not None:
         assert isinstance(page, str)
@@ -145,17 +140,12 @@ async def backfill_resources(
 
     response = await _do_request(http, url, params, log)
 
-    previous_dt: datetime | None = None
-
     for resource in response.data:
         resource_dt = _extract_resource_cursor(resource, cursor_field)
 
-        _raise_if_unordered(resource.id, previous_dt, resource_dt)
-
         if resource_dt >= cutoff:
-            return
+            continue
 
-        previous_dt = resource_dt
         yield resource
 
     next_page_cursor = _extract_page_cursor(response.links)
@@ -175,38 +165,35 @@ async def fetch_resources(
 ) -> AsyncGenerator[OutreachResource | LogCursor, None]:
     assert isinstance(log_cursor, datetime)
 
-    upper_bound = now() - horizon if horizon else now()
+    horizon_cutoff = now() - horizon if horizon else now()
 
-    if log_cursor >= upper_bound:
+    if log_cursor >= horizon_cutoff:
         return
 
-    url = f"{API}/{path}"
+    max_upper_bound = log_cursor + MAX_WINDOW_SIZE
+    upper_bound = min(max_upper_bound, horizon_cutoff)
 
+    url = f"{API}/{path}"
     params = _build_query_params(cursor_field, log_cursor, upper_bound, extra_params)
 
-    last_seen_dt = log_cursor
+    max_seen_dt = log_cursor
 
     while True:
         response = await _do_request(http, url, params, log)
 
-        if (
-            last_seen_dt > log_cursor
-            and response.data
-            and _extract_resource_cursor(response.data[0], cursor_field) > last_seen_dt
-        ):
-            yield last_seen_dt
-
         for resource in response.data:
             resource_dt = _extract_resource_cursor(resource, cursor_field)
 
-            _raise_if_unordered(resource.id, last_seen_dt, resource_dt)
-
+            # The API sometimes ignores the server-side upper-bound filter.
+            # Skip such records so they don't advance max_seen_dt past the
+            # queried window; the next invocation will fetch them in its
+            # own window.
             if resource_dt > upper_bound:
                 log.info(f"Outreach API returned record {resource.id} with {cursor_field}={resource_dt} beyond the requested upper bound {upper_bound}.")
                 continue
 
-            if resource_dt > last_seen_dt:
-                last_seen_dt = resource_dt
+            if resource_dt > max_seen_dt:
+                max_seen_dt = resource_dt
 
             if resource_dt > log_cursor and cache.should_yield(path, resource.id, resource_dt):
                 yield resource
@@ -214,8 +201,16 @@ async def fetch_resources(
         next_page_cursor = _extract_page_cursor(response.links)
 
         if not next_page_cursor:
-            if last_seen_dt > log_cursor:
-                yield last_seen_dt
             break
-        else:
-            params[NEXT_PAGE_QUERY_PARAMETER] = next_page_cursor
+
+        params[NEXT_PAGE_QUERY_PARAMETER] = next_page_cursor
+
+    # Were there any records within the date window? If so, yield the
+    # most recent datetime cursor from them.
+    if max_seen_dt > log_cursor:
+        yield max_seen_dt
+    # Otherwise, did we check a max-sized date window? If so, yield
+    # the upper bound to use as the lower bound next iteration to avoid
+    # repeatedly checking an empty, max-sized date window.
+    elif upper_bound >= max_upper_bound:
+        yield upper_bound

--- a/source-outreach/source_outreach/api.py
+++ b/source-outreach/source_outreach/api.py
@@ -143,7 +143,7 @@ async def backfill_resources(
     for resource in response.data:
         resource_dt = _extract_resource_cursor(resource, cursor_field)
 
-        if resource_dt >= cutoff:
+        if resource_dt > cutoff:
             continue
 
         yield resource

--- a/source-outreach/source_outreach/api.py
+++ b/source-outreach/source_outreach/api.py
@@ -23,11 +23,6 @@ MAX_PAGE_SIZE = 1000
 MIN_PAGE_SIZE = 1
 NEXT_PAGE_QUERY_PARAMETER = "page[after]"
 
-# MAX_WINDOW_SIZE bounds how far forward a single fetch_resources invocation
-# will advance. The Outreach API sometimes returns results unsorted within a
-# query, so we process records in explicit [lower, upper] date windows and
-# trust the set of records returned for that window rather than their order.
-MAX_WINDOW_SIZE = timedelta(days=1)
 
 def _dt_to_str(dt: datetime) -> str:
     return dt.strftime(DATETIME_STRING_FORMAT)
@@ -160,6 +155,7 @@ async def fetch_resources(
     extra_params: dict[str, str | int | bool] | None,
     cursor_field: CursorField,
     horizon: timedelta | None,
+    window_size: timedelta,
     log: Logger,
     log_cursor: LogCursor,
 ) -> AsyncGenerator[OutreachResource | LogCursor, None]:
@@ -170,7 +166,11 @@ async def fetch_resources(
     if log_cursor >= horizon_cutoff:
         return
 
-    max_upper_bound = log_cursor + MAX_WINDOW_SIZE
+    # window_size bounds how far forward a single invocation will advance.
+    # The Outreach API sometimes returns results unsorted within a query, so
+    # we process records in explicit [lower, upper] date windows and trust
+    # the set of records returned for that window rather than their order.
+    max_upper_bound = log_cursor + window_size
     upper_bound = min(max_upper_bound, horizon_cutoff)
 
     url = f"{API}/{path}"

--- a/source-outreach/source_outreach/models.py
+++ b/source-outreach/source_outreach/models.py
@@ -1,7 +1,7 @@
 from datetime import datetime, UTC, timedelta
 from enum import StrEnum
 import json
-from typing import TYPE_CHECKING
+from typing import Annotated, TYPE_CHECKING
 from urllib import parse
 
 from estuary_cdk.capture.common import (
@@ -135,6 +135,21 @@ class EndpointConfig(BaseModel):
     credentials: OAuth2Credentials = Field(
         discriminator="credentials_title",
         title="Authentication",
+    )
+    class Advanced(BaseModel):
+        window_size: Annotated[timedelta, Field(
+            description="Date window size for incremental syncs in ISO 8601 format. ex: P1D means 1 day, PT6H means 6 hours.",
+            title="Window size",
+            default=timedelta(days=1),
+            ge=timedelta(seconds=5),
+            le=timedelta(days=365),
+        )]
+
+    advanced: Advanced = Field(
+        default_factory=Advanced, #type: ignore
+        title="Advanced Config",
+        description="Advanced settings for the connector.",
+        json_schema_extra={"advanced": True},
     )
 
 

--- a/source-outreach/source_outreach/resources.py
+++ b/source-outreach/source_outreach/resources.py
@@ -76,6 +76,7 @@ def incremental_resources(
                     params,
                     cursor_field,
                     None,
+                    config.advanced.window_size,
                 ),
                 LOOKBACK: functools.partial(
                     fetch_resources,
@@ -84,6 +85,7 @@ def incremental_resources(
                     params,
                     cursor_field,
                     LOOKBACK_LAG,
+                    config.advanced.window_size,
                 ),
             },
             fetch_page=functools.partial(

--- a/source-outreach/tests/snapshots/snapshots__spec__capture.stdout.json
+++ b/source-outreach/tests/snapshots/snapshots__spec__capture.stdout.json
@@ -3,6 +3,19 @@
     "protocol": 3032023,
     "configSchema": {
       "$defs": {
+        "Advanced": {
+          "properties": {
+            "window_size": {
+              "default": "P1D",
+              "description": "Date window size for incremental syncs in ISO 8601 format. ex: P1D means 1 day, PT6H means 6 hours.",
+              "format": "duration",
+              "title": "Window size",
+              "type": "string"
+            }
+          },
+          "title": "Advanced",
+          "type": "object"
+        },
         "RotatingOAuth2Credentials": {
           "properties": {
             "credentials_title": {
@@ -69,6 +82,12 @@
             }
           ],
           "title": "Authentication"
+        },
+        "advanced": {
+          "$ref": "#/$defs/Advanced",
+          "advanced": true,
+          "description": "Advanced settings for the connector.",
+          "title": "Advanced Config"
         }
       },
       "required": [


### PR DESCRIPTION
**Description:**

Despite returning results in mostly sorted order per the `sort` query parameter, Outreach can still return slightly unsorted results. The connector's current replication strategies rely on the API returning results in non-decreasing order of a given cursor field, and we've seen both real-time and lookback subtasks for incremental streams consistently fail since that assumption doesn't hold. This PR makes `source-outreach` use an alternative replication strategy that uses date windows & doesn't rely on a specific ordering of results.

This PR's scope includes:
- revising `backfill_resources` and `fetch_resources` to not assume the API returns results in any particular order
- ensuring the `backfill_resources` function captures records at the `cutoff`
- allowing users to configure the window size used by `fetch_resources` via a new endpoint config setting

The spec snapshot change is expected due to the addition of the `advanced.window_size` endpoint config setting.

**Documentation links affected:**

The connector's documentation should be updated to reflect the new config setting.

**Notes for reviewers:**

The changes are best reviewed commit-by-commit.

