### PR TITLE
source-ashby: implement snapshot and child streams

### DIFF
--- a/.claude/skills/child-entities/SKILL.md
+++ b/.claude/skills/child-entities/SKILL.md
@@ -1,0 +1,121 @@
+# Child Entity Pattern for estuary-cdk Connectors
+
+Use this when an API endpoint requires a parent ID to list child records, AND those children need independent incremental sync per parent (separate cursor, composite key including the parent ID). The canonical reference is `source-posthog`.
+
+If the children can instead be re-snapshotted in full on every interval, use the much simpler snapshot-child approach in `source-ashby` (`snapshot_child_entity` in `source-ashby/source_ashby/api.py`) and ignore the rest of this file.
+
+## Before You Start
+
+Check whether the parent ID is already in the child's response body. If it is, you don't need context-injection machinery. This pattern is specifically for when the parent ID is absent from the response and must be stamped onto each child document during validation.
+
+## Drain parents first, with the minimum data possible
+
+Before iterating to fetch children, drain the parent stream into a list of **only** the fields you actually need downstream — typically just `id`, plus any filter fields like `updated_at`. Do **not** interleave streaming a parent response with per-parent child requests. Holding a parent HTTP response open while fetching children for each parent leaves the parent connection idle long enough to trigger timeout errors. Don't buffer the full parent records — define a small dataclass or extract just `parent.id` (and the filter fields you need) to save on memory.
+
+## Pattern
+
+### 1. Validation-context dataclass (`models.py`)
+
+A frozen dataclass carries the parent ID through Pydantic's validation context. See `source-posthog/source_posthog/models.py:39-43`:
+
+```python
+@dataclass(frozen=True, slots=True)
+class ProjectIdValidationContext:
+    """Validation context carrying the project_id for document construction."""
+    project_id: int
+```
+
+### 2. Mixin that extends `_meta` and injects from context (`models.py`)
+
+Extend `BaseDocument.Meta` with the parent-id field, then use `@model_validator(mode="before")` to copy it from the context into `_meta` before field validation runs. See `source-posthog/source_posthog/models.py`:
+
+```python
+class ProjectScopedMixin(BaseDocument):
+    class Meta(BaseDocument.Meta):
+        model_config = ConfigDict(validate_assignment=True)
+        project_id: int = Field(default=-1, description="...")
+
+    meta_: Meta = Field(default_factory=Meta, alias="_meta", description="Document metadata")
+
+    @model_validator(mode="before")
+    @classmethod
+    def _inject_project_id_from_context(cls, data: Any, info: ValidationInfo) -> Any:
+        if not isinstance(data, dict):
+            return data
+        if info.context and isinstance(info.context, ProjectIdValidationContext):
+            meta = data.get("_meta") or {}
+            meta["project_id"] = info.context.project_id
+            data["_meta"] = meta
+        return data
+```
+
+Child entities inherit from this mixin (`HogQLEntity(ProjectScopedMixin, BasePostHogEntity[T])`, `models.py`).
+
+### 3. Fetch functions pass the context through (`api.py`)
+
+Two call shapes appear in source-posthog:
+
+**Direct `model_validate` with context** (when you already have a dict, e.g. HogQL columns → values), see `api.py:219-223`:
+
+```python
+async for row in processor:
+    yield model.model_validate(
+        dict(zip(column_names, row.root, strict=True)),
+        context=ProjectIdValidationContext(project_id),
+    )
+```
+
+**Streaming through `IncrementalJsonProcessor(..., validation_context=ctx)`**, see `api.py:79-91` and `api.py:244-250`:
+
+```python
+ctx = ProjectIdValidationContext(project_id=project_id)
+async for item in _fetch_from_url(url, FeatureFlag, http, log, validation_context=ctx):
+    ...
+```
+
+`IncrementalJsonProcessor` accepts a `validation_context` kwarg that it forwards into each item's Pydantic validation, so the injector fires as documents stream in.
+
+### 4. Resource with per-parent cursors and composite key (`resources.py`)
+
+One cursor per parent: build a dict of `f"{parent_id}"` → `functools.partial(fetcher, ..., parent_id)`, and pass the whole dict as `fetch_changes` to `open_binding`. See `resources.py:372-424`:
+
+```python
+incremental_fetchers = {
+    f"{project_id}": functools.partial(fetch_feature_flags, http, config, project_id)
+    for project_id in project_ids
+}
+backfill_fetchers = {
+    f"{project_id}": functools.partial(backfill_feature_flags, http, config, project_id)
+    for project_id in project_ids
+}
+
+async def open(binding, binding_index, state, task, all_bindings):
+    await _patch_missing_project_states(binding, state, task, project_ids, cutoff)
+    open_binding(binding, binding_index, state, task,
+                 fetch_changes=incremental_fetchers, fetch_page=backfill_fetchers)
+
+return PostHogResource(
+    name=FeatureFlag.resource_name,
+    key=["/_meta/project_id", "/id"],
+    model=FeatureFlag,
+    open=open,
+    initial_state=_generate_resource_state(project_ids, cutoff),
+    initial_config=ResourceConfig(name=FeatureFlag.resource_name, interval=timedelta(minutes=5)),
+    schema_inference=True,
+)
+```
+
+Two things to notice:
+
+- **Key is composite**: `["/_meta/project_id", "/id"]`.
+- **Newly-added parents between runs**: `_patch_missing_project_states` adds cursor state entries for projects that appear after the capture first opened. Without this, a new project would have no cursor slot and be silently skipped. Mirror this if parents can be added after initial sync.
+
+## When to pick this vs. the snapshot-child shortcut
+
+|                       | Incremental (source-posthog)                                                  | Snapshot (source-ashby)                                      |
+| --------------------- | ----------------------------------------------------------------------------- | ------------------------------------------------------------ |
+| Cursor                | One per parent, persisted in `ResourceState`                                  | None — re-fetch everything on each interval                  |
+| Parent ID on doc      | Yes, injected into `_meta` via context + `@model_validator`                   | No — only sent in request body                               |
+| Key                   | `["/_meta/<parent_id_field>", "/id"]`                                         | `["/_meta/row_id"]`                                          |
+| Good for              | Large/mutable child sets, deletions not important, per-parent backfill wanted | Small stable child sets where periodic full-refresh is cheap |
+| New parents appearing | Needs `_patch_missing_project_states`-style handling                          | Handled automatically — parent iteration picks them up       |

--- a/.claude/skills/classify-stream-types/SKILL.md
+++ b/.claude/skills/classify-stream-types/SKILL.md
@@ -69,16 +69,42 @@ initial_state = ResourceState(
 
 ### Snapshot
 
-Reference: `source-sentry/source_sentry/resources.py` — `open_full_refresh_bindings` function, and `source-front/source_front/resources.py` — `full_refresh_resources` function.
+**Use `SnapshotResource`, not the generic `Resource`.**
+Reference: `source-ashby/source_ashby/resources.py`
 
 ```python
-common.open_binding(
-    binding, binding_index, state, task,
-    fetch_snapshot=functools.partial(list_all, http, ...),
-    tombstone=MyDocument(_meta=MyDocument.Meta(op="d")),
+from estuary_cdk.capture.common import (
+    ResourceConfig,
+    ResourceState,
+    SnapshotResource,
+    Task,
+    open_binding,
 )
+from estuary_cdk.flow import CaptureBinding
 
-initial_state = ResourceState()  # No cursor needed
+def open(
+    binding: CaptureBinding[ResourceConfig],
+    binding_index: int,
+    state: ResourceState,
+    task: Task,
+    all_bindings,
+) -> None:
+    open_binding(
+        binding,
+        binding_index,
+        state,
+        task,
+        fetch_snapshot=functools.partial(list_all, http, ...),
+        tombstone=MyDocument(_meta=MyDocument.Meta(op="d")),
+    )
+
+resource = SnapshotResource(
+    name=MyDocument.name,
+    model=MyDocument,
+    open=open,
+    initial_config=ResourceConfig(name=MyDocument.name, interval=timedelta(minutes=5)),
+    schema_inference=True,
+)
 ```
 
 ### Webhook

--- a/source-ashby/source_ashby/api.py
+++ b/source-ashby/source_ashby/api.py
@@ -5,13 +5,14 @@ from estuary_cdk.capture.common import LogCursor
 from estuary_cdk.flow import ValidationError
 from estuary_cdk.http import HTTPSession
 from estuary_cdk.incremental_json_processor import IncrementalJsonProcessor
+from pydantic import JsonValue
 
 from .models import (
     ApiKeyInfoResponse,
     AshbyEntity,
+    ChildEntityMixin,
     ResponseMeta,
 )
-
 
 API_BASE_URL = "https://api.ashbyhq.com"
 
@@ -19,7 +20,9 @@ API_BASE_URL = "https://api.ashbyhq.com"
 async def fetch_api_key_scopes(http: HTTPSession, log: Logger) -> set[str]:
     # Ashby requires Content-Type: application/json on all POST requests.
     # Passing json={} ensures aiohttp sets the header automatically.
-    response = await http.request(log, f"{API_BASE_URL}/apiKey.info", method="POST", json={})
+    response = await http.request(
+        log, f"{API_BASE_URL}/apiKey.info", method="POST", json={}
+    )
     info = ApiKeyInfoResponse.model_validate_json(response)
 
     if info.errorInfo is not None:
@@ -38,6 +41,96 @@ async def fetch_api_key_scopes(http: HTTPSession, log: Logger) -> set[str]:
     return set(info.results.scopes)
 
 
+async def _stream_pages(
+    entity_cls: type[AshbyEntity],
+    base_body: dict[str, JsonValue],
+    http: HTTPSession,
+    log: Logger,
+    sync_token: str | None = None,
+) -> AsyncGenerator[AshbyEntity | ResponseMeta, None]:
+    url = f"{API_BASE_URL}/{entity_cls.path}"
+    next_page_cursor: str | None = None
+
+    while True:
+        body: dict[str, JsonValue] = {**base_body}
+        if sync_token and next_page_cursor is None:
+            body["syncToken"] = sync_token
+        if next_page_cursor:
+            body["cursor"] = next_page_cursor
+
+        _, response = await http.request_stream(log, url, method="POST", json=body)
+        processor = IncrementalJsonProcessor(
+            response(), "results.item", entity_cls, remainder_cls=ResponseMeta
+        )
+
+        async for item in processor:
+            yield item
+
+        meta = processor.get_remainder()
+
+        # Tokens expire after ~1 month of disuse. Recovery is a fresh listing —
+        # restrict the retry to the first response so a mid-pagination error
+        # never causes us to re-yield earlier pages.
+        if "sync_token_expired" in meta.errors and next_page_cursor is None:
+            log.warning(
+                f"sync token expired for {entity_cls.name}, yielding all documents"
+            )
+            sync_token = None
+            continue
+
+        if not meta.success:
+            raise RuntimeError(
+                (
+                    f"Ashby API error for {entity_cls.name}: {meta.errors} "
+                    f"(request body: {body})"
+                )
+            )
+
+        yield meta
+
+        if not meta.moreDataAvailable:
+            return
+
+        next_page_cursor = meta.nextCursor
+
+
+async def snapshot_entity(
+    entity_cls: type[AshbyEntity],
+    http: HTTPSession,
+    log: Logger,
+) -> AsyncGenerator[AshbyEntity, None]:
+    async for item in _stream_pages(
+        entity_cls, entity_cls.base_request_body, http, log
+    ):
+        if isinstance(item, ResponseMeta):
+            continue
+        yield item
+
+
+async def snapshot_child_entity(
+    entity_cls: type[AshbyEntity],
+    http: HTTPSession,
+    log: Logger,
+) -> AsyncGenerator[AshbyEntity, None]:
+    assert issubclass(entity_cls, ChildEntityMixin)
+
+    parent_ids = [
+        parent.id
+        async for parent in snapshot_entity(entity_cls.parent_entity, http, log)
+    ]
+
+    for parent_id in parent_ids:
+        body: dict[str, JsonValue] = {
+            **entity_cls.base_request_body,
+            entity_cls.parent_id_field: parent_id,
+        }
+
+        async for item in _stream_pages(entity_cls, body, http, log):
+            if isinstance(item, ResponseMeta):
+                continue
+            yield item
+
+
 async def fetch_entity(
     entity_cls: type[AshbyEntity],
     http: HTTPSession,
@@ -45,53 +138,82 @@ async def fetch_entity(
     log_cursor: LogCursor,
 ) -> AsyncGenerator[AshbyEntity | LogCursor, None]:
     assert isinstance(log_cursor, tuple)
-    sync_token = str(log_cursor[0])
+    sync_token = str(log_cursor[0]) or None
 
-    url = f"{API_BASE_URL}/{entity_cls.path}"
-    next_page_cursor: str | None = None
-    latest_sync_token: str | None = None
+    new_sync_token: str | None = None
     at_least_one_doc_yielded = False
 
-    while True:
-        body: dict[str, str] = {}
-        if sync_token:
-            body["syncToken"] = sync_token
-        if next_page_cursor:
-            body["cursor"] = next_page_cursor
+    async for item in _stream_pages(
+        entity_cls, entity_cls.base_request_body, http, log, sync_token=sync_token
+    ):
+        if isinstance(item, ResponseMeta):
+            if item.syncToken:
+                new_sync_token = item.syncToken
+            continue
+        yield item
+        at_least_one_doc_yielded = True
 
-        _, response = await http.request_stream(log, url, method="POST", json=body)
-
-        processor = IncrementalJsonProcessor(
-            response(), "results.item", entity_cls, remainder_cls=ResponseMeta
+    if at_least_one_doc_yielded and new_sync_token is None:
+        raise RuntimeError(
+            (
+                f"Ashby API did not return a syncToken for {entity_cls.name} "
+                f"after yielding documents; cannot checkpoint."
+            )
         )
 
-        async for item in processor:
-            yield item
-            at_least_one_doc_yielded = True
+    if at_least_one_doc_yielded and new_sync_token:
+        yield (new_sync_token,)
 
-        meta = processor.get_remainder()
 
-        if not meta.success:
-            if "sync_token_expired" in meta.errors:
-                # Tokens expire if they go unused for ~1 month. Since it's a rare
-                # occurrence, we'll default to performing a backfill.
-                log.warning(
-                    f"syncToken expired for {entity_cls.name}, yielding all documents"
-                )
+async def fetch_incremental_child_entity(
+    entity_cls: type[AshbyEntity],
+    http: HTTPSession,
+    log: Logger,
+    log_cursor: LogCursor,
+) -> AsyncGenerator[AshbyEntity | LogCursor, None]:
+    assert issubclass(entity_cls, ChildEntityMixin)
+    assert isinstance(log_cursor, tuple)
 
-                sync_token = ""
-                next_page_cursor = None
-                continue
+    parent_cls = entity_cls.parent_entity
+    parent_token: str | None = str(log_cursor[0]) or None
 
-            raise RuntimeError(f"Ashby API error for {entity_cls.name}: {meta.errors}")
+    # Drain updated parents into a list before issuing per-parent child requests —
+    # holding the parent stream open while fetching children risks timing the
+    # parent connection out.
+    updated_parent_ids: list[str] = []
+    new_parent_token: str | None = None
 
-        if meta.syncToken:
-            latest_sync_token = meta.syncToken
-
-        if not meta.moreDataAvailable:
+    async for item in _stream_pages(
+        parent_cls, parent_cls.base_request_body, http, log, sync_token=parent_token
+    ):
+        if isinstance(item, ResponseMeta):
+            if item.syncToken:
+                new_parent_token = item.syncToken
             break
+        updated_parent_ids.append(item.id)
 
-        next_page_cursor = meta.nextCursor
+    yielded_anything = False
 
-    if at_least_one_doc_yielded and latest_sync_token:
-        yield (latest_sync_token,)
+    for parent_id in updated_parent_ids:
+        body: dict[str, JsonValue] = {
+            **entity_cls.base_request_body,
+            entity_cls.parent_id_field: parent_id,
+        }
+
+        async for item in _stream_pages(entity_cls, body, http, log):
+            if isinstance(item, ResponseMeta):
+                continue
+            yield item
+            yielded_anything = True
+
+    if yielded_anything and new_parent_token is None:
+        raise RuntimeError(
+            (
+                f"Ashby API did not return a syncToken for {parent_cls.name} "
+                f"after yielding {entity_cls.name} documents; cannot checkpoint."
+            )
+        )
+
+    if updated_parent_ids and new_parent_token:
+        assert new_parent_token
+        yield (new_parent_token,)

--- a/source-ashby/source_ashby/models.py
+++ b/source-ashby/source_ashby/models.py
@@ -1,17 +1,17 @@
 from __future__ import annotations
 
+from abc import ABCMeta
 from typing import ClassVar
 
 from estuary_cdk.capture.common import (
     BaseDocument,
-    ResourceConfig,
     ResourceState,
 )
 from estuary_cdk.capture.common import (
     ConnectorState as GenericConnectorState,
 )
 from estuary_cdk.flow import AccessToken
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, JsonValue
 
 
 class EndpointConfig(BaseModel):
@@ -47,10 +47,11 @@ class ApiKeyInfoResponse(BaseModel, extra="allow"):
     errorInfo: ApiKeyInfoError | None = None
 
 
-class AshbyEntity(BaseDocument, extra="allow"):
+class AshbyEntity(BaseDocument, extra="allow", metaclass=ABCMeta):
     name: ClassVar[str]
     required_scope: ClassVar[str]
     path: ClassVar[str]
+    base_request_body: ClassVar[dict[str, JsonValue]] = {}
 
     id: str
 
@@ -67,16 +68,11 @@ class Approvals(AshbyEntity):
     path: ClassVar[str] = "approval.list"
 
 
-class ArchiveReasons(AshbyEntity):
-    name: ClassVar[str] = "archive_reasons"
-    required_scope: ClassVar[str] = "hiringProcessMetadata:read"
-    path: ClassVar[str] = "archiveReason.list"
-
-
 class CandidateTags(AshbyEntity):
     name: ClassVar[str] = "candidate_tags"
     required_scope: ClassVar[str] = "hiringProcessMetadata:read"
     path: ClassVar[str] = "candidateTag.list"
+    base_request_body: ClassVar[dict[str, JsonValue]] = {"includeArchived": True}
 
 
 class Candidates(AshbyEntity):
@@ -89,36 +85,28 @@ class CustomFields(AshbyEntity):
     name: ClassVar[str] = "custom_fields"
     required_scope: ClassVar[str] = "hiringProcessMetadata:read"
     path: ClassVar[str] = "customField.list"
+    base_request_body: ClassVar[dict[str, JsonValue]] = {"includeArchived": True}
 
 
 class Departments(AshbyEntity):
     name: ClassVar[str] = "departments"
     required_scope: ClassVar[str] = "organization:read"
     path: ClassVar[str] = "department.list"
+    base_request_body: ClassVar[dict[str, JsonValue]] = {"includeArchived": True}
 
 
 class FeedbackFormDefinitions(AshbyEntity):
     name: ClassVar[str] = "feedback_form_definitions"
     required_scope: ClassVar[str] = "hiringProcessMetadata:read"
     path: ClassVar[str] = "feedbackFormDefinition.list"
-
-
-class InterviewEvents(AshbyEntity):
-    name: ClassVar[str] = "interview_events"
-    required_scope: ClassVar[str] = "interviews:read"
-    path: ClassVar[str] = "interviewEvent.list"
-
-
-class InterviewerPools(AshbyEntity):
-    name: ClassVar[str] = "interviewer_pools"
-    required_scope: ClassVar[str] = "hiringProcessMetadata:read"
-    path: ClassVar[str] = "interviewerPool.list"
+    base_request_body: ClassVar[dict[str, JsonValue]] = {"includeArchived": True}
 
 
 class InterviewPlans(AshbyEntity):
     name: ClassVar[str] = "interview_plans"
     required_scope: ClassVar[str] = "interviews:read"
     path: ClassVar[str] = "interviewPlan.list"
+    base_request_body: ClassVar[dict[str, JsonValue]] = {"includeArchived": True}
 
 
 class InterviewSchedules(AshbyEntity):
@@ -127,28 +115,37 @@ class InterviewSchedules(AshbyEntity):
     path: ClassVar[str] = "interviewSchedule.list"
 
 
-class InterviewStages(AshbyEntity):
-    name: ClassVar[str] = "interview_stages"
+class ChildEntityMixin(metaclass=ABCMeta):
+    parent_entity: ClassVar[type[AshbyEntity]]
+    parent_id_field: ClassVar[str]
+
+
+class InterviewEvents(AshbyEntity, ChildEntityMixin):
+    name: ClassVar[str] = "interview_events"
     required_scope: ClassVar[str] = "interviews:read"
-    path: ClassVar[str] = "interviewStage.list"
+    path: ClassVar[str] = "interviewEvent.list"
+    parent_entity: ClassVar[type[AshbyEntity]] = InterviewSchedules
+    parent_id_field: ClassVar[str] = "interviewScheduleId"
+
+
+class InterviewerPools(AshbyEntity):
+    name: ClassVar[str] = "interviewer_pools"
+    required_scope: ClassVar[str] = "hiringProcessMetadata:read"
+    path: ClassVar[str] = "interviewerPool.list"
+    base_request_body: ClassVar[dict[str, JsonValue]] = {
+        "includeArchivedPools": True,
+        "includeArchivedTrainingStages": True,
+    }
 
 
 class Interviews(AshbyEntity):
     name: ClassVar[str] = "interviews"
     required_scope: ClassVar[str] = "interviews:read"
     path: ClassVar[str] = "interview.list"
-
-
-class JobPostings(AshbyEntity):
-    name: ClassVar[str] = "job_postings"
-    required_scope: ClassVar[str] = "jobs:read"
-    path: ClassVar[str] = "jobPosting.list"
-
-
-class Jobs(AshbyEntity):
-    name: ClassVar[str] = "jobs"
-    required_scope: ClassVar[str] = "jobs:read"
-    path: ClassVar[str] = "job.list"
+    base_request_body: ClassVar[dict[str, JsonValue]] = {
+        "includeArchived": True,
+        "includeNonSharedInterviews": True,
+    }
 
 
 class JobTemplates(AshbyEntity):
@@ -157,10 +154,23 @@ class JobTemplates(AshbyEntity):
     path: ClassVar[str] = "jobTemplate.list"
 
 
+class Jobs(AshbyEntity):
+    name: ClassVar[str] = "jobs"
+    required_scope: ClassVar[str] = "jobs:read"
+    path: ClassVar[str] = "job.list"
+    base_request_body: ClassVar[dict[str, JsonValue]] = {
+        "includeUnpublishedJobPostingsIds": True
+    }
+
+
 class Locations(AshbyEntity):
     name: ClassVar[str] = "locations"
     required_scope: ClassVar[str] = "organization:read"
     path: ClassVar[str] = "location.list"
+    base_request_body: ClassVar[dict[str, JsonValue]] = {
+        "includeArchived": True,
+        "includeLocationHierarchy": True,
+    }
 
 
 class Offers(AshbyEntity):
@@ -181,12 +191,6 @@ class Projects(AshbyEntity):
     path: ClassVar[str] = "project.list"
 
 
-class Sources(AshbyEntity):
-    name: ClassVar[str] = "sources"
-    required_scope: ClassVar[str] = "hiringProcessMetadata:read"
-    path: ClassVar[str] = "source.list"
-
-
 class SurveyFormDefinitions(AshbyEntity):
     name: ClassVar[str] = "survey_form_definitions"
     required_scope: ClassVar[str] = "hiringProcessMetadata:read"
@@ -197,31 +201,67 @@ class Users(AshbyEntity):
     name: ClassVar[str] = "users"
     required_scope: ClassVar[str] = "organization:read"
     path: ClassVar[str] = "user.list"
+    base_request_body: ClassVar[dict[str, JsonValue]] = {"includeDeactivated": True}
 
 
-ALL_STREAMS: list[type[AshbyEntity]] = [
+class AshbySnapshotEntity(AshbyEntity, metaclass=ABCMeta):
+    pass
+
+
+class ArchiveReasons(AshbySnapshotEntity):
+    name: ClassVar[str] = "archive_reasons"
+    required_scope: ClassVar[str] = "hiringProcessMetadata:read"
+    path: ClassVar[str] = "archiveReason.list"
+    base_request_body: ClassVar[dict[str, JsonValue]] = {"includeArchived": True}
+
+
+class JobPostings(AshbySnapshotEntity):
+    name: ClassVar[str] = "job_postings"
+    required_scope: ClassVar[str] = "jobs:read"
+    path: ClassVar[str] = "jobPosting.list"
+
+
+class Sources(AshbySnapshotEntity):
+    name: ClassVar[str] = "sources"
+    required_scope: ClassVar[str] = "hiringProcessMetadata:read"
+    path: ClassVar[str] = "source.list"
+    base_request_body: ClassVar[dict[str, JsonValue]] = {"includeArchived": True}
+
+
+class InterviewStages(AshbySnapshotEntity, ChildEntityMixin):
+    name: ClassVar[str] = "interview_stages"
+    required_scope: ClassVar[str] = "interviews:read"
+    path: ClassVar[str] = "interviewStage.list"
+    parent_entity: ClassVar[type[AshbyEntity]] = InterviewPlans
+    parent_id_field: ClassVar[str] = "interviewPlanId"
+
+
+INCREMENTAL_STREAMS: list[type[AshbyEntity]] = [
     Applications,
     Approvals,
-    ArchiveReasons,
     CandidateTags,
     Candidates,
     CustomFields,
     Departments,
     FeedbackFormDefinitions,
     InterviewEvents,
-    InterviewerPools,
     InterviewPlans,
     InterviewSchedules,
-    InterviewStages,
+    InterviewerPools,
     Interviews,
-    JobPostings,
-    Jobs,
     JobTemplates,
+    Jobs,
     Locations,
     Offers,
     Openings,
     Projects,
-    Sources,
     SurveyFormDefinitions,
     Users,
+]
+
+SNAPSHOT_STREAMS: list[type[AshbySnapshotEntity]] = [
+    ArchiveReasons,
+    InterviewStages,
+    JobPostings,
+    Sources,
 ]

--- a/source-ashby/source_ashby/resources.py
+++ b/source-ashby/source_ashby/resources.py
@@ -3,16 +3,32 @@ from datetime import timedelta
 from logging import Logger
 
 from estuary_cdk.capture.common import (
+    BaseDocument,
     Resource,
     ResourceConfig,
     ResourceState,
+    SnapshotResource,
+    Task,
     open_binding,
 )
-from estuary_cdk.flow import BasicAuth
+from estuary_cdk.flow import BasicAuth, CaptureBinding
 from estuary_cdk.http import HTTPMixin, TokenSource
 
-from .api import fetch_api_key_scopes, fetch_entity
-from .models import ALL_STREAMS, AshbyEntity, EndpointConfig
+from .api import (
+    fetch_api_key_scopes,
+    fetch_entity,
+    fetch_incremental_child_entity,
+    snapshot_child_entity,
+    snapshot_entity,
+)
+from .models import (
+    INCREMENTAL_STREAMS,
+    SNAPSHOT_STREAMS,
+    AshbyEntity,
+    AshbySnapshotEntity,
+    ChildEntityMixin,
+    EndpointConfig,
+)
 
 AshbyResource = Resource[AshbyEntity, ResourceConfig, ResourceState]
 
@@ -58,16 +74,30 @@ async def validate_credentials(
     _ = await fetch_api_key_scopes(http, log)
 
 
-def _create_resource(entity_cls: type[AshbyEntity], http: HTTPMixin) -> AshbyResource:
-    def open(binding, binding_index, state, task, all_bindings):
+def _create_incremental_resource(
+    entity_cls: type[AshbyEntity], http: HTTPMixin
+) -> AshbyResource:
+    fetch_fn = (
+        fetch_incremental_child_entity
+        if issubclass(entity_cls, ChildEntityMixin)
+        else fetch_entity
+    )
+
+    def open(
+        binding: CaptureBinding[ResourceConfig],
+        binding_index: int,
+        state: ResourceState,
+        task: Task,
+        all_bindings,
+    ):
         open_binding(
             binding,
             binding_index,
             state,
             task,
             # Since incremental fetches couldn't begin until a complete backfill was performed,
-            # it is impossible to define two discrete functions — `fetch_entity` will do both.
-            fetch_changes=functools.partial(fetch_entity, entity_cls, http),
+            # it is impossible to define two discrete functions — the fetch function does both.
+            fetch_changes=functools.partial(fetch_fn, entity_cls, http),
         )
 
     return Resource(
@@ -78,6 +108,43 @@ def _create_resource(entity_cls: type[AshbyEntity], http: HTTPMixin) -> AshbyRes
         initial_state=ResourceState(
             inc=ResourceState.Incremental(cursor=("",)),
         ),
+        initial_config=ResourceConfig(
+            name=entity_cls.name,
+            interval=timedelta(minutes=5),
+        ),
+        schema_inference=True,
+    )
+
+
+def _create_snapshot_resource(
+    entity_cls: type[AshbySnapshotEntity], http: HTTPMixin
+) -> AshbyResource:
+    snapshot_fn = (
+        snapshot_child_entity
+        if issubclass(entity_cls, ChildEntityMixin)
+        else snapshot_entity
+    )
+
+    def open(
+        binding: CaptureBinding[ResourceConfig],
+        binding_index: int,
+        state: ResourceState,
+        task: Task,
+        all_bindings,
+    ):
+        open_binding(
+            binding,
+            binding_index,
+            state,
+            task,
+            fetch_snapshot=functools.partial(snapshot_fn, entity_cls, http),
+            tombstone=BaseDocument(_meta=BaseDocument.Meta(op="d")),
+        )
+
+    return SnapshotResource(
+        name=entity_cls.name,
+        model=entity_cls,
+        open=open,
         initial_config=ResourceConfig(
             name=entity_cls.name,
             interval=timedelta(minutes=5),
@@ -100,6 +167,12 @@ async def all_resources(
             ),
         )
 
-    resources = [_create_resource(stream_cls, http) for stream_cls in ALL_STREAMS]
+    resources: list[AshbyResource] = [
+        _create_incremental_resource(stream_cls, http)
+        for stream_cls in INCREMENTAL_STREAMS
+    ]
+    resources.extend(
+        _create_snapshot_resource(stream_cls, http) for stream_cls in SNAPSHOT_STREAMS
+    )
 
     return await filter_resources_by_scopes(log, http, config, resources)

--- a/source-ashby/tests/snapshots/snapshots__discover__stdout.json
+++ b/source-ashby/tests/snapshots/snapshots__discover__stdout.json
@@ -158,7 +158,7 @@
       "x-infer-schema": true
     },
     "key": [
-      "/id"
+      "/_meta/row_id"
     ]
   },
   {
@@ -644,7 +644,7 @@
       "x-infer-schema": true
     },
     "key": [
-      "/id"
+      "/_meta/row_id"
     ]
   },
   {
@@ -806,7 +806,7 @@
       "x-infer-schema": true
     },
     "key": [
-      "/id"
+      "/_meta/row_id"
     ]
   },
   {
@@ -1184,7 +1184,7 @@
       "x-infer-schema": true
     },
     "key": [
-      "/id"
+      "/_meta/row_id"
     ]
   },
   {


### PR DESCRIPTION
**Description:**

All Ashby streams were treated as incremental and requiring no parent entity id parameters. This change

- Implements snapshot streams
- Sets flags to pull additional data when available
- Implements a guard for the scenario when docs are yielded but no sync token is provided by Ashby at the end of pagination

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

