### PR TITLE
materialize-s3-iceberg: fix handling of legacy top level credentials

### DIFF
--- a/materialize-s3-iceberg/.snapshots/TestSpec
+++ b/materialize-s3-iceberg/.snapshots/TestSpec
@@ -188,29 +188,6 @@
       }
     },
     "properties": {
-      "aws_access_key_id": {
-        "default": null,
-        "description": "Access Key ID for accessing AWS services (legacy).",
-        "order": 0,
-        "title": "AWS Access Key ID",
-        "type": [
-          "string",
-          "null"
-        ],
-        "x-hidden-field": true
-      },
-      "aws_secret_access_key": {
-        "default": null,
-        "description": "Secret Access Key for accessing AWS services (legacy).",
-        "order": 1,
-        "secret": true,
-        "title": "AWS Secret Access Key",
-        "type": [
-          "string",
-          "null"
-        ],
-        "x-hidden-field": true
-      },
       "credentials": {
         "default": {
           "auth_type": "AWSAccessKey"
@@ -311,6 +288,7 @@
       }
     },
     "required": [
+      "credentials",
       "bucket",
       "region",
       "namespace",

--- a/materialize-s3-iceberg/driver.go
+++ b/materialize-s3-iceberg/driver.go
@@ -114,22 +114,19 @@ func (c config) Validate() error {
 		}
 	}
 
-	hasLegacy := c.AWSAccessKeyID != "" || c.AWSSecretAccessKey != ""
-	hasNew := c.Credentials != nil
-
-	if hasLegacy && hasNew {
-		return fmt.Errorf("cannot specify both top-level aws_access_key_id/aws_secret_access_key and credentials")
-	} else if !hasLegacy && !hasNew {
-		return fmt.Errorf("must provide either credentials or aws_access_key_id/aws_secret_access_key")
-	} else if hasLegacy {
+	if c.Credentials != nil {
+		if err := c.Credentials.Validate(); err != nil {
+			return err
+		}
+	} else if c.AWSAccessKeyID != "" || c.AWSSecretAccessKey != "" {
 		if c.AWSAccessKeyID == "" {
 			return fmt.Errorf("missing 'aws_access_key_id'")
 		}
 		if c.AWSSecretAccessKey == "" {
 			return fmt.Errorf("missing 'aws_secret_access_key'")
 		}
-	} else if err := c.Credentials.Validate(); err != nil {
-		return err
+	} else {
+		return fmt.Errorf("must provide credentials")
 	}
 
 	if c.Catalog.CatalogType == "" {

--- a/materialize-s3-iceberg/driver_test.go
+++ b/materialize-s3-iceberg/driver_test.go
@@ -183,7 +183,7 @@ func runTimestampOverflowRegression(t *testing.T, cfg config) {
 
 	s3client := s3.New(s3.Options{
 		Region:       cfg.Region,
-		Credentials:  credentials.NewStaticCredentialsProvider(cfg.AWSAccessKeyID, cfg.AWSSecretAccessKey, ""),
+		Credentials:  credentials.NewStaticCredentialsProvider(cfg.Credentials.AWSAccessKeyID, cfg.Credentials.AWSSecretAccessKey, ""),
 		BaseEndpoint: aws.String(cfg.S3Endpoint),
 		UsePathStyle: true,
 	})
@@ -257,7 +257,7 @@ func runDateOverflowRegression(t *testing.T, cfg config) {
 
 	s3client := s3.New(s3.Options{
 		Region:       cfg.Region,
-		Credentials:  credentials.NewStaticCredentialsProvider(cfg.AWSAccessKeyID, cfg.AWSSecretAccessKey, ""),
+		Credentials:  credentials.NewStaticCredentialsProvider(cfg.Credentials.AWSAccessKeyID, cfg.Credentials.AWSSecretAccessKey, ""),
 		BaseEndpoint: aws.String(cfg.S3Endpoint),
 		UsePathStyle: true,
 	})
@@ -298,7 +298,7 @@ func createTestBucket(t *testing.T, cfg config) {
 	ctx := context.Background()
 	client := s3.New(s3.Options{
 		Region:       cfg.Region,
-		Credentials:  credentials.NewStaticCredentialsProvider(cfg.AWSAccessKeyID, cfg.AWSSecretAccessKey, ""),
+		Credentials:  credentials.NewStaticCredentialsProvider(cfg.Credentials.AWSAccessKeyID, cfg.Credentials.AWSSecretAccessKey, ""),
 		BaseEndpoint: aws.String(cfg.S3Endpoint),
 		UsePathStyle: true,
 	})
@@ -379,8 +379,8 @@ func createTestWarehouse(t *testing.T, cfg config) {
 			"properties": map[string]any{
 				"default-base-location": baseLocation,
 				"s3.endpoint":           cfg.S3Endpoint,
-				"s3.access-key-id":      cfg.AWSAccessKeyID,
-				"s3.secret-access-key":  cfg.AWSSecretAccessKey,
+				"s3.access-key-id":      cfg.Credentials.AWSAccessKeyID,
+				"s3.secret-access-key":  cfg.Credentials.AWSSecretAccessKey,
 				"s3.region":             cfg.Region,
 				"s3.path-style-access":  "true",
 			},

--- a/materialize-s3-iceberg/iceberg-ctl/iceberg_ctl/__main__.py
+++ b/materialize-s3-iceberg/iceberg-ctl/iceberg_ctl/__main__.py
@@ -3,7 +3,7 @@ import json
 import sys
 import time
 import traceback
-from typing import Any, Literal, override
+from typing import Literal, override
 
 import click
 from click import Context
@@ -85,28 +85,28 @@ def run(
                     PY_IO_IMPL: "pyiceberg.io.fsspec.FsspecFileIO",  # use S3 file IO instead of Arrow
                 }
 
-                # When the (legacy) top-level S3 credentials are provided we
-                # use them directly with pyiceberg and disable catalog
-                # credential vending. This path is for local/S3-compatible
-                # setups where the catalog server cannot vend STS creds.
-                # Customers using the newer `credentials` field hit none of
-                # this and continue to receive vended credentials from the
-                # catalog as before.
+                # For local/S3-compatible setups the catalog server cannot vend STS creds,
+                # so we pass the user's access keys directly to pyiceberg and disable
+                # catalog credential vending. We key off `s3_endpoint` —
+                # production AWS users leave it blank and continue to receive
+                # vended credentials from the catalog as before.
                 direct_s3_creds = (
-                    cfg.aws_access_key_id
-                    and cfg.aws_secret_access_key
+                    cfg.s3_endpoint
+                    and cfg.credentials is not None
+                    and cfg.credentials.auth_type == "AWSAccessKey"
                     and cfg.region
                 )
 
                 if direct_s3_creds:
-                    properties["s3.access-key-id"] = cfg.aws_access_key_id
-                    properties["s3.secret-access-key"] = cfg.aws_secret_access_key
+                    properties["s3.access-key-id"] = cfg.credentials.aws_access_key_id
+                    properties["s3.secret-access-key"] = (
+                        cfg.credentials.aws_secret_access_key
+                    )
                     properties["s3.region"] = cfg.region
-                    if cfg.s3_endpoint:
-                        properties["s3.endpoint"] = cfg.s3_endpoint
+                    properties["s3.endpoint"] = cfg.s3_endpoint
                 catalog = RestCatalog(
                     "default",
-                    **{k:v for k, v in properties.items() if v is not None},
+                    **{k: v for k, v in properties.items() if v is not None},
                 )
 
                 if direct_s3_creds and hasattr(catalog, "_session"):
@@ -126,20 +126,12 @@ def run(
                     glue_props["glue.id"] = cfg.catalog.glue_id
 
                 if (
-                    cfg.aws_access_key_id is not None
-                    and cfg.aws_secret_access_key is not None
-                ):  # Legacy creds
-                    creds = {
-                        "client.access-key-id": cfg.aws_access_key_id,
-                        "client.secret-access-key": cfg.aws_secret_access_key,
-                    }
-                elif (
                     cfg.credentials is not None
                     and cfg.credentials.auth_type == "AWSAccessKey"
                 ):
                     creds = {
-                        "client.access-key-id": cfg.credentials.awsAccessKeyId,
-                        "client.secret-access-key": cfg.credentials.awsSecretAccessKey,
+                        "client.access-key-id": cfg.credentials.aws_access_key_id,
+                        "client.secret-access-key": cfg.credentials.aws_secret_access_key,
                     }
                 elif (
                     cfg.credentials is not None

--- a/materialize-s3-iceberg/iceberg-ctl/iceberg_ctl/models.py
+++ b/materialize-s3-iceberg/iceberg-ctl/iceberg_ctl/models.py
@@ -1,5 +1,6 @@
+import sys
 from datetime import timedelta
-from typing import Annotated, Literal
+from typing import Annotated, Any, Literal
 
 from pydantic import (
     BaseModel,
@@ -21,17 +22,19 @@ class AccessKeyCredentials(BaseModel):
     auth_type: AuthTypeAccessKey = Field(
         default="AWSAccessKey", json_schema_extra={"order": 0, "type": "string"}
     )
-    awsAccessKeyId: str = Field(
+    aws_access_key_id: str = Field(
         min_length=1,
         title="AWS Access Key ID",
         description="Access Key ID for accessing AWS services.",
         json_schema_extra={"order": 1},
+        alias="awsAccessKeyId",
     )
-    awsSecretAccessKey: str = Field(
+    aws_secret_access_key: str = Field(
         min_length=1,
         title="AWS Secret Access Key",
         description="Secret Access Key for accessing AWS services.",
         json_schema_extra={"order": 2, "secret": True},
+        alias="awsSecretAccessKey",
     )
 
 
@@ -139,24 +142,9 @@ class AdvancedConfig(BaseModel):
 
 
 class EndpointConfig(BaseModel):
-    # Kept for backwards compatibility
-    aws_access_key_id: str | None = Field(
-        title="AWS Access Key ID",
-        description="Access Key ID for accessing AWS services (legacy).",
-        default=None,
-        json_schema_extra={"order": 0, "x-hidden-field": True},
-    )
-    # Kept for backwards compatibility
-    aws_secret_access_key: str | None = Field(
-        title="AWS Secret Access Key",
-        description="Secret Access Key for accessing AWS services (legacy).",
-        default=None,
-        json_schema_extra={"order": 1, "secret": True, "x-hidden-field": True},
-    )
-    credentials: AccessKeyCredentials | IAMCredentials | None = Field(
+    credentials: AccessKeyCredentials | IAMCredentials = Field(
         discriminator="auth_type",
         title="Authentication",
-        default=None,
         json_schema_extra={
             "order": 2,
             "x-iam-auth": True,
@@ -202,25 +190,38 @@ class EndpointConfig(BaseModel):
         json_schema_extra={"order": 10, "advanced": True},
     )
 
-    @model_validator(mode="after")
-    def validate_credentials(self):
-        has_legacy = (
-            self.aws_access_key_id is not None or self.aws_secret_access_key is not None
-        )
-        has_new = self.credentials is not None
+    @model_validator(mode="before")
+    @classmethod
+    def transform_legacy_credentials(cls, data: Any):
+        if not isinstance(data, dict):
+            return data
+
+        legacy_id = data.get("aws_access_key_id")
+        legacy_secret = data.get("aws_secret_access_key")
+        has_legacy = legacy_id is not None or legacy_secret is not None
+        has_new = data.get("credentials") is not None
 
         if has_legacy and has_new:
-            raise ValueError(
-                "cannot specify both top-level aws_access_key_id/aws_secret_access_key and credentials"
+            print(
+                (
+                    "Credentials have been found in both the legacy"
+                    " (top-level aws_access_key_id/aws_secret_access_key keys)"
+                    " and new formats (credentials object)."
+                    " The former will be ignored in favour of the latter"
+                ),
+                file=sys.stderr,
+                flush=True,
             )
-        if not has_legacy and not has_new:
-            raise ValueError(
-                "must provide either credentials or aws_access_key_id/aws_secret_access_key"
-            )
-        if has_legacy:
-            if not self.aws_access_key_id:
-                raise ValueError("missing aws_access_key_id")
-            if not self.aws_secret_access_key:
-                raise ValueError("missing aws_secret_access_key")
+        elif has_legacy:
+            data["credentials"] = {
+                "auth_type": "AWSAccessKey",
+                "awsAccessKeyId": legacy_id,
+                "awsSecretAccessKey": legacy_secret,
+            }
+        elif not has_new:
+            raise ValueError("must provide credentials")
 
-        return self
+        data.pop("aws_access_key_id", None)
+        data.pop("aws_secret_access_key", None)
+
+        return data

--- a/materialize-s3-iceberg/testdata/config.yaml
+++ b/materialize-s3-iceberg/testdata/config.yaml
@@ -1,11 +1,13 @@
-aws_access_key_id: flow
-aws_secret_access_key: flow
 bucket: test-warehouse
 region: us-east-1
 prefix: warehouse
 namespace: tests
 upload_interval: PT1S
 s3_endpoint: http://localhost:9702
+credentials:
+    auth_type: AWSAccessKey
+    awsAccessKeyId: flow
+    awsSecretAccessKey: flow
 catalog:
     catalog_type: Iceberg REST Server
     uri: http://localhost:9700/api/catalog


### PR DESCRIPTION
**Description:**

Removes `aws_access_key_id` and `aws_secret_access_key_sops` from specresponses so they'll get ignored in materialization edits. This means old credential setups will get migrated to the new format during republishes.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

