### PR TITLE
materialize-bigquery: split ALTER TABLE script into per-statement queries

### DIFF
--- a/materialize-bigquery/client.go
+++ b/materialize-bigquery/client.go
@@ -153,8 +153,17 @@ func (c *client) AlterTable(ctx context.Context, ta sql.TableAlter) (string, boi
 		if err := renderTemplates(c.ep.Dialect).alterTableColumns.Execute(&alterColumnStmtBuilder, ta); err != nil {
 			return "", nil, fmt.Errorf("rendering alter table columns statement: %w", err)
 		}
-		alterColumnStmt := alterColumnStmtBuilder.String()
-		stmts = append(stmts, alterColumnStmt)
+		// The template can render both an ADD COLUMN and a DROP NOT NULL
+		// statement. Split them apart so each is submitted as its own query:
+		// running both in a single multi-statement script is not retry-safe,
+		// since the first statement may commit before the second's retry is
+		// issued.
+		for _, s := range strings.Split(alterColumnStmtBuilder.String(), ";") {
+			s = strings.TrimSpace(s)
+			if s != "" {
+				stmts = append(stmts, s+";\n")
+			}
+		}
 	}
 
 	if len(ta.ColumnTypeChanges) > 0 {


### PR DESCRIPTION
**Description:**

Splits rendered `ALTER TABLE ... ADD COLUMN ...; ALTER TABLE ... DROP NOT NULL ...;` output into individual queries and submits each as its own `c.query` call, rather than sending the whole multi-statement script as one job.

Rationale: BigQuery executes each DDL in a multi-statement script as an independent transaction. When the first statement commits and the second hits a transient error that `runQuery`/`maybeRetry` (materialize-bigquery/query.go) classifies as retryable — e.g. rate limits, `"encountered an error during execution"`, concurrent-update errors — the whole script gets re-submitted. The re-run then fails non-retryably with `"Column already exists"` on the first statement, masking the original transient error. Splitting makes each retry idempotent-or-already-succeeded.

Diagnosed from the `TestIntegration/apply` flake seen in https://github.com/estuary/connectors/actions/runs/24859764044/job/72782173507.

Follows the existing pattern in `materialize-spanner/client.go` and `materialize-clickhouse/client.go`, which render a combined alter template and then split on `;`.

**Workflow steps:**

No user-visible change. Generated SQL is identical; only transport changes (N separate queries instead of one N-statement script).

**Documentation links affected:**

None.

**Notes for reviewers:**

- `TestSQLGeneration` snapshot is unchanged — the template output is byte-identical to before; only the caller now splits it.
- Integration test fix can only be confirmed by re-running `TestIntegration/apply` in CI; the flake is transient so a single green run isn't conclusive, but the class of failure ("Column already exists" after a transient retry) is now structurally impossible.