### PR TITLE
source-appsflyer: improve logging for failed webhook matches

### DIFF
--- a/estuary-cdk/estuary_cdk/capture/webhook/match.py
+++ b/estuary-cdk/estuary_cdk/capture/webhook/match.py
@@ -4,6 +4,7 @@ import abc
 import re
 from abc import abstractmethod
 from collections.abc import Sequence
+from logging import Logger
 from typing import Any, Literal, override
 
 from aiohttp import web
@@ -38,7 +39,10 @@ class MatchRule(abc.ABC, BaseModel, frozen=True):
 
     @abstractmethod
     async def matches(
-        self, req: web.Request, raw_doc: dict[str, Any] | None = None
+        self,
+        req: web.Request,
+        failure_log: Logger,
+        raw_doc: dict[str, Any] | None = None,
     ) -> bool: ...
 
     @property
@@ -119,17 +123,28 @@ class UrlMatch(MatchRule, frozen=True):
 
     @override
     async def matches(
-        self, req: web.Request, raw_doc: dict[str, Any] | None = None
+        self,
+        req: web.Request,
+        failure_log: Logger,
+        raw_doc: dict[str, Any] | None = None,
     ) -> bool:
         if self.value == "*":
             return True
 
-        return (
+        is_match = (
             DynamicResource(self.value)._match(  # pyright: ignore[reportPrivateUsage]
                 req.path
             )
             is not None
         )
+
+        if not is_match:
+            failure_log.debug(
+                "URL path did not match",
+                extra={"path": req.path, "match_value": self.value},
+            )
+
+        return is_match
 
     @property
     @override
@@ -167,12 +182,29 @@ class HeaderMatch(_KeyValueMatch, frozen=True):
 
     @override
     async def matches(
-        self, req: web.Request, raw_doc: dict[str, Any] | None = None
+        self,
+        req: web.Request,
+        failure_log: Logger,
+        raw_doc: dict[str, Any] | None = None,
     ) -> bool:
         header_value = req.headers.get(self.key)
         if header_value is None:
+            failure_log.debug(
+                "Header not present on request",
+                extra={"header": self.key},
+            )
             return False
-        return header_value == self.value
+        if header_value != self.value:
+            failure_log.debug(
+                "Header value did not match",
+                extra={
+                    "header": self.key,
+                    "actual": header_value,
+                    "match_value": self.value,
+                },
+            )
+            return False
+        return True
 
     @property
     @override
@@ -186,7 +218,10 @@ class BodyMatch(_KeyValueMatch, frozen=True):
 
     @override
     async def matches(
-        self, req: web.Request, raw_doc: dict[str, Any] | None = None
+        self,
+        req: web.Request,
+        failure_log: Logger,
+        raw_doc: dict[str, Any] | None = None,
     ) -> bool:
         if raw_doc is None:
             parsed = await req.json()
@@ -206,12 +241,32 @@ class BodyMatch(_KeyValueMatch, frozen=True):
         for segment in segments[:-1]:
             nested = cursor.get(segment)
             if not isinstance(nested, dict):
+                failure_log.debug(
+                    "Body path segment missing or not an object",
+                    extra={"key": self.key, "segment": segment},
+                )
                 return False
 
             cursor = nested
 
         value = cursor.get(segments[-1])
-        return value is not None and str(value) == self.value
+        if value is None:
+            failure_log.debug(
+                "Body key not present",
+                extra={"key": self.key},
+            )
+            return False
+        if str(value) != self.value:
+            failure_log.debug(
+                "Body value did not match",
+                extra={
+                    "key": self.key,
+                    "actual": str(value),
+                    "match_value": self.value,
+                },
+            )
+            return False
+        return True
 
     @property
     @override

--- a/estuary-cdk/estuary_cdk/capture/webhook/server.py
+++ b/estuary-cdk/estuary_cdk/capture/webhook/server.py
@@ -60,7 +60,9 @@ def build_webhook_app(
                 (
                     (idx, rsc.model)
                     for idx, rsc in sorted_mapping.items()
-                    if await rsc.initial_config.match_rule.matches(req, raw_doc)
+                    if await rsc.initial_config.match_rule.matches(
+                        req, task.log, raw_doc
+                    )
                 ),
             )
             assert not isinstance(

--- a/estuary-cdk/tests/test_webhook_match.py
+++ b/estuary-cdk/tests/test_webhook_match.py
@@ -1,3 +1,4 @@
+import logging
 from typing import Any
 
 import pytest
@@ -13,6 +14,8 @@ from estuary_cdk.capture.webhook.match import (
     UrlMatch,
 )
 from estuary_cdk.capture.webhook.resources import CATCH_ALL_DISCRIMINATOR
+
+_log = logging.getLogger(__name__)
 
 
 def _make_request(
@@ -90,7 +93,7 @@ class TestUrlMatch:
     @pytest.mark.asyncio
     async def test_matches(self, value: str, path: str, expected: str):
         req = _make_request(path=path)
-        assert await UrlMatch(value=value).matches(req) == expected
+        assert await UrlMatch(value=value).matches(req, _log) == expected
 
     @pytest.mark.parametrize(
         "a, b, has_error",
@@ -143,7 +146,7 @@ class TestHeaderMatch:
         self, key: str, value: str, headers: dict[str, str], expected: bool
     ):
         req = _make_request(headers=headers)
-        assert await HeaderMatch(key=key, value=value).matches(req) == expected
+        assert await HeaderMatch(key=key, value=value).matches(req, _log) == expected
 
     @pytest.mark.parametrize(
         "a_key, a_val, b_key, b_val, has_error",
@@ -225,7 +228,7 @@ class TestBodyMatch:
         expected: bool,
     ):
         req = _make_request()
-        assert await BodyMatch(key=dot_path, value=value).matches(req, body) == expected
+        assert await BodyMatch(key=dot_path, value=value).matches(req, _log, body) == expected
 
     @pytest.mark.parametrize(
         "a_key, a_val, b_key, b_val, has_error",
@@ -316,4 +319,4 @@ class TestDiscriminators:
     async def test_catch_all_matches_any_request(self):
         rule = CATCH_ALL_DISCRIMINATOR.create_match_rules()[0]
         req = _make_request(path="/anything/at/all")
-        assert await rule.matches(req) is True
+        assert await rule.matches(req, _log) is True

--- a/source-appsflyer/source_appsflyer/models.py
+++ b/source-appsflyer/source_appsflyer/models.py
@@ -1,7 +1,7 @@
 from abc import ABCMeta
 from datetime import datetime, timedelta
 from functools import reduce
-from typing import Any, ClassVar, Self
+from typing import Any, ClassVar, Self, override
 from urllib.parse import urljoin
 
 import xxhash
@@ -93,26 +93,47 @@ class AppsFlyerWebhookDocument(WebhookDocument):
         description="Document metadata",
     )
 
+    pk_fields: ClassVar[list[str]] = [
+        "app_id",
+        "app_type",
+        "appsflyer_id",
+        "campaign_type",
+        "conversion_type",
+        "event_name",
+        "event_time",
+        "event_value",
+    ]
+
     app_id: str
+    app_type: str
     appsflyer_id: str
+    campaign_type: str
+    conversion_type: str
     event_name: str
     event_time: str
     event_value: str
-    api_version: str
 
-    @model_validator(mode="after")
-    def inject_estuary_id(self) -> Self:
-        parts = [
-            self.app_id,
-            self.appsflyer_id,
-            self.event_name,
-            self.event_time,
-            self.event_value,
-            self.api_version,
-        ]
+    @model_validator(mode="before")
+    def ensure_pk_fields_present(cls, data: dict[str, str]):
+        assert isinstance(data, dict)
+
+        missing_keys = [key for key in cls.pk_fields if key not in data]
+        if missing_keys:
+            raise ValueError(
+                (
+                    "Received a push API document that did not contain the following"
+                    f" required field(s): {missing_keys}."
+                    " Please update your API export to include them"
+                )
+            )
+
+        return data
+
+    @override
+    def model_post_init(self, _: Any):  # pyright: ignore[reportExplicitAny]
+        parts = [getattr(self, key) for key in self.pk_fields]
+
         self.meta_.estuary_id = xxhash.xxh128("|".join(parts).encode()).hexdigest()
-
-        return self
 
 
 class PullApiDocument(BaseDocument, metaclass=ABCMeta):

--- a/source-appsflyer/source_appsflyer/resources.py
+++ b/source-appsflyer/source_appsflyer/resources.py
@@ -157,7 +157,7 @@ async def all_resources(
         if ok:
             supported.setdefault(doc_type, []).append(app_id)
 
-    discriminator = BodyDiscriminator(key="event_name", known_values=event_types)
+    discriminator = BodyDiscriminator(key="event_type", known_values=event_types)
     webhook_resources = [
         Resource(
             name=f"{rule.display_name}",

--- a/source-appsflyer/tests/snapshots/snapshots__discover__stdout.json
+++ b/source-appsflyer/tests/snapshots/snapshots__discover__stdout.json
@@ -85,7 +85,7 @@
       "name": "in-app-event",
       "match_rule": {
         "value": "in-app-event",
-        "key": "event_name",
+        "key": "event_type",
         "type": "body"
       },
       "type": "webhook"
@@ -237,7 +237,7 @@
       "name": "install",
       "match_rule": {
         "value": "install",
-        "key": "event_name",
+        "key": "event_type",
         "type": "body"
       },
       "type": "webhook"
@@ -389,7 +389,7 @@
       "name": "install-in-app-event",
       "match_rule": {
         "value": "install-in-app-event",
-        "key": "event_name",
+        "key": "event_type",
         "type": "body"
       },
       "type": "webhook"
@@ -541,7 +541,7 @@
       "name": "organic-install",
       "match_rule": {
         "value": "organic-install",
-        "key": "event_name",
+        "key": "event_type",
         "type": "body"
       },
       "type": "webhook"
@@ -693,7 +693,7 @@
       "name": "organic-install-in-app-event",
       "match_rule": {
         "value": "organic-install-in-app-event",
-        "key": "event_name",
+        "key": "event_type",
         "type": "body"
       },
       "type": "webhook"
@@ -845,7 +845,7 @@
       "name": "organic-reinstall",
       "match_rule": {
         "value": "organic-reinstall",
-        "key": "event_name",
+        "key": "event_type",
         "type": "body"
       },
       "type": "webhook"
@@ -997,7 +997,7 @@
       "name": "postback",
       "match_rule": {
         "value": "postback",
-        "key": "event_name",
+        "key": "event_type",
         "type": "body"
       },
       "type": "webhook"
@@ -1149,7 +1149,7 @@
       "name": "postbacks-copy",
       "match_rule": {
         "value": "postbacks-copy",
-        "key": "event_name",
+        "key": "event_type",
         "type": "body"
       },
       "type": "webhook"
@@ -1301,7 +1301,7 @@
       "name": "re-attribution",
       "match_rule": {
         "value": "re-attribution",
-        "key": "event_name",
+        "key": "event_type",
         "type": "body"
       },
       "type": "webhook"
@@ -1453,7 +1453,7 @@
       "name": "re-attribution-in-app-event",
       "match_rule": {
         "value": "re-attribution-in-app-event",
-        "key": "event_name",
+        "key": "event_type",
         "type": "body"
       },
       "type": "webhook"
@@ -1605,7 +1605,7 @@
       "name": "re-download",
       "match_rule": {
         "value": "re-download",
-        "key": "event_name",
+        "key": "event_type",
         "type": "body"
       },
       "type": "webhook"
@@ -1757,7 +1757,7 @@
       "name": "re-engagement",
       "match_rule": {
         "value": "re-engagement",
-        "key": "event_name",
+        "key": "event_type",
         "type": "body"
       },
       "type": "webhook"
@@ -1909,7 +1909,7 @@
       "name": "re-engagement-in-app-event",
       "match_rule": {
         "value": "re-engagement-in-app-event",
-        "key": "event_name",
+        "key": "event_type",
         "type": "body"
       },
       "type": "webhook"
@@ -2061,7 +2061,7 @@
       "name": "reinstall",
       "match_rule": {
         "value": "reinstall",
-        "key": "event_name",
+        "key": "event_type",
         "type": "body"
       },
       "type": "webhook"

--- a/source-appsflyer/tests/snapshots/snapshots__discover__stdout.json
+++ b/source-appsflyer/tests/snapshots/snapshots__discover__stdout.json
@@ -82,13 +82,13 @@
   {
     "recommendedName": "in-app-event",
     "resourceConfig": {
-      "type": "webhook",
       "name": "in-app-event",
       "match_rule": {
         "value": "in-app-event",
         "key": "event_name",
         "type": "body"
-      }
+      },
+      "type": "webhook"
     },
     "documentSchema": {
       "$defs": {
@@ -184,8 +184,20 @@
           "title": "App Id",
           "type": "string"
         },
+        "app_type": {
+          "title": "App Type",
+          "type": "string"
+        },
         "appsflyer_id": {
           "title": "Appsflyer Id",
+          "type": "string"
+        },
+        "campaign_type": {
+          "title": "Campaign Type",
+          "type": "string"
+        },
+        "conversion_type": {
+          "title": "Conversion Type",
           "type": "string"
         },
         "event_name": {
@@ -199,19 +211,17 @@
         "event_value": {
           "title": "Event Value",
           "type": "string"
-        },
-        "api_version": {
-          "title": "Api Version",
-          "type": "string"
         }
       },
       "required": [
         "app_id",
+        "app_type",
         "appsflyer_id",
+        "campaign_type",
+        "conversion_type",
         "event_name",
         "event_time",
-        "event_value",
-        "api_version"
+        "event_value"
       ],
       "title": "AppsFlyerWebhookDocument",
       "type": "object",
@@ -224,13 +234,13 @@
   {
     "recommendedName": "install",
     "resourceConfig": {
-      "type": "webhook",
       "name": "install",
       "match_rule": {
         "value": "install",
         "key": "event_name",
         "type": "body"
-      }
+      },
+      "type": "webhook"
     },
     "documentSchema": {
       "$defs": {
@@ -326,8 +336,20 @@
           "title": "App Id",
           "type": "string"
         },
+        "app_type": {
+          "title": "App Type",
+          "type": "string"
+        },
         "appsflyer_id": {
           "title": "Appsflyer Id",
+          "type": "string"
+        },
+        "campaign_type": {
+          "title": "Campaign Type",
+          "type": "string"
+        },
+        "conversion_type": {
+          "title": "Conversion Type",
           "type": "string"
         },
         "event_name": {
@@ -341,19 +363,17 @@
         "event_value": {
           "title": "Event Value",
           "type": "string"
-        },
-        "api_version": {
-          "title": "Api Version",
-          "type": "string"
         }
       },
       "required": [
         "app_id",
+        "app_type",
         "appsflyer_id",
+        "campaign_type",
+        "conversion_type",
         "event_name",
         "event_time",
-        "event_value",
-        "api_version"
+        "event_value"
       ],
       "title": "AppsFlyerWebhookDocument",
       "type": "object",
@@ -366,13 +386,13 @@
   {
     "recommendedName": "install-in-app-event",
     "resourceConfig": {
-      "type": "webhook",
       "name": "install-in-app-event",
       "match_rule": {
         "value": "install-in-app-event",
         "key": "event_name",
         "type": "body"
-      }
+      },
+      "type": "webhook"
     },
     "documentSchema": {
       "$defs": {
@@ -468,8 +488,20 @@
           "title": "App Id",
           "type": "string"
         },
+        "app_type": {
+          "title": "App Type",
+          "type": "string"
+        },
         "appsflyer_id": {
           "title": "Appsflyer Id",
+          "type": "string"
+        },
+        "campaign_type": {
+          "title": "Campaign Type",
+          "type": "string"
+        },
+        "conversion_type": {
+          "title": "Conversion Type",
           "type": "string"
         },
         "event_name": {
@@ -483,19 +515,17 @@
         "event_value": {
           "title": "Event Value",
           "type": "string"
-        },
-        "api_version": {
-          "title": "Api Version",
-          "type": "string"
         }
       },
       "required": [
         "app_id",
+        "app_type",
         "appsflyer_id",
+        "campaign_type",
+        "conversion_type",
         "event_name",
         "event_time",
-        "event_value",
-        "api_version"
+        "event_value"
       ],
       "title": "AppsFlyerWebhookDocument",
       "type": "object",
@@ -508,13 +538,13 @@
   {
     "recommendedName": "organic-install",
     "resourceConfig": {
-      "type": "webhook",
       "name": "organic-install",
       "match_rule": {
         "value": "organic-install",
         "key": "event_name",
         "type": "body"
-      }
+      },
+      "type": "webhook"
     },
     "documentSchema": {
       "$defs": {
@@ -610,8 +640,20 @@
           "title": "App Id",
           "type": "string"
         },
+        "app_type": {
+          "title": "App Type",
+          "type": "string"
+        },
         "appsflyer_id": {
           "title": "Appsflyer Id",
+          "type": "string"
+        },
+        "campaign_type": {
+          "title": "Campaign Type",
+          "type": "string"
+        },
+        "conversion_type": {
+          "title": "Conversion Type",
           "type": "string"
         },
         "event_name": {
@@ -625,19 +667,17 @@
         "event_value": {
           "title": "Event Value",
           "type": "string"
-        },
-        "api_version": {
-          "title": "Api Version",
-          "type": "string"
         }
       },
       "required": [
         "app_id",
+        "app_type",
         "appsflyer_id",
+        "campaign_type",
+        "conversion_type",
         "event_name",
         "event_time",
-        "event_value",
-        "api_version"
+        "event_value"
       ],
       "title": "AppsFlyerWebhookDocument",
       "type": "object",
@@ -650,13 +690,13 @@
   {
     "recommendedName": "organic-install-in-app-event",
     "resourceConfig": {
-      "type": "webhook",
       "name": "organic-install-in-app-event",
       "match_rule": {
         "value": "organic-install-in-app-event",
         "key": "event_name",
         "type": "body"
-      }
+      },
+      "type": "webhook"
     },
     "documentSchema": {
       "$defs": {
@@ -752,8 +792,20 @@
           "title": "App Id",
           "type": "string"
         },
+        "app_type": {
+          "title": "App Type",
+          "type": "string"
+        },
         "appsflyer_id": {
           "title": "Appsflyer Id",
+          "type": "string"
+        },
+        "campaign_type": {
+          "title": "Campaign Type",
+          "type": "string"
+        },
+        "conversion_type": {
+          "title": "Conversion Type",
           "type": "string"
         },
         "event_name": {
@@ -767,19 +819,17 @@
         "event_value": {
           "title": "Event Value",
           "type": "string"
-        },
-        "api_version": {
-          "title": "Api Version",
-          "type": "string"
         }
       },
       "required": [
         "app_id",
+        "app_type",
         "appsflyer_id",
+        "campaign_type",
+        "conversion_type",
         "event_name",
         "event_time",
-        "event_value",
-        "api_version"
+        "event_value"
       ],
       "title": "AppsFlyerWebhookDocument",
       "type": "object",
@@ -792,13 +842,13 @@
   {
     "recommendedName": "organic-reinstall",
     "resourceConfig": {
-      "type": "webhook",
       "name": "organic-reinstall",
       "match_rule": {
         "value": "organic-reinstall",
         "key": "event_name",
         "type": "body"
-      }
+      },
+      "type": "webhook"
     },
     "documentSchema": {
       "$defs": {
@@ -894,8 +944,20 @@
           "title": "App Id",
           "type": "string"
         },
+        "app_type": {
+          "title": "App Type",
+          "type": "string"
+        },
         "appsflyer_id": {
           "title": "Appsflyer Id",
+          "type": "string"
+        },
+        "campaign_type": {
+          "title": "Campaign Type",
+          "type": "string"
+        },
+        "conversion_type": {
+          "title": "Conversion Type",
           "type": "string"
         },
         "event_name": {
@@ -909,19 +971,17 @@
         "event_value": {
           "title": "Event Value",
           "type": "string"
-        },
-        "api_version": {
-          "title": "Api Version",
-          "type": "string"
         }
       },
       "required": [
         "app_id",
+        "app_type",
         "appsflyer_id",
+        "campaign_type",
+        "conversion_type",
         "event_name",
         "event_time",
-        "event_value",
-        "api_version"
+        "event_value"
       ],
       "title": "AppsFlyerWebhookDocument",
       "type": "object",
@@ -934,13 +994,13 @@
   {
     "recommendedName": "postback",
     "resourceConfig": {
-      "type": "webhook",
       "name": "postback",
       "match_rule": {
         "value": "postback",
         "key": "event_name",
         "type": "body"
-      }
+      },
+      "type": "webhook"
     },
     "documentSchema": {
       "$defs": {
@@ -1036,8 +1096,20 @@
           "title": "App Id",
           "type": "string"
         },
+        "app_type": {
+          "title": "App Type",
+          "type": "string"
+        },
         "appsflyer_id": {
           "title": "Appsflyer Id",
+          "type": "string"
+        },
+        "campaign_type": {
+          "title": "Campaign Type",
+          "type": "string"
+        },
+        "conversion_type": {
+          "title": "Conversion Type",
           "type": "string"
         },
         "event_name": {
@@ -1051,19 +1123,17 @@
         "event_value": {
           "title": "Event Value",
           "type": "string"
-        },
-        "api_version": {
-          "title": "Api Version",
-          "type": "string"
         }
       },
       "required": [
         "app_id",
+        "app_type",
         "appsflyer_id",
+        "campaign_type",
+        "conversion_type",
         "event_name",
         "event_time",
-        "event_value",
-        "api_version"
+        "event_value"
       ],
       "title": "AppsFlyerWebhookDocument",
       "type": "object",
@@ -1076,13 +1146,13 @@
   {
     "recommendedName": "postbacks-copy",
     "resourceConfig": {
-      "type": "webhook",
       "name": "postbacks-copy",
       "match_rule": {
         "value": "postbacks-copy",
         "key": "event_name",
         "type": "body"
-      }
+      },
+      "type": "webhook"
     },
     "documentSchema": {
       "$defs": {
@@ -1178,8 +1248,20 @@
           "title": "App Id",
           "type": "string"
         },
+        "app_type": {
+          "title": "App Type",
+          "type": "string"
+        },
         "appsflyer_id": {
           "title": "Appsflyer Id",
+          "type": "string"
+        },
+        "campaign_type": {
+          "title": "Campaign Type",
+          "type": "string"
+        },
+        "conversion_type": {
+          "title": "Conversion Type",
           "type": "string"
         },
         "event_name": {
@@ -1193,19 +1275,17 @@
         "event_value": {
           "title": "Event Value",
           "type": "string"
-        },
-        "api_version": {
-          "title": "Api Version",
-          "type": "string"
         }
       },
       "required": [
         "app_id",
+        "app_type",
         "appsflyer_id",
+        "campaign_type",
+        "conversion_type",
         "event_name",
         "event_time",
-        "event_value",
-        "api_version"
+        "event_value"
       ],
       "title": "AppsFlyerWebhookDocument",
       "type": "object",
@@ -1218,13 +1298,13 @@
   {
     "recommendedName": "re-attribution",
     "resourceConfig": {
-      "type": "webhook",
       "name": "re-attribution",
       "match_rule": {
         "value": "re-attribution",
         "key": "event_name",
         "type": "body"
-      }
+      },
+      "type": "webhook"
     },
     "documentSchema": {
       "$defs": {
@@ -1320,8 +1400,20 @@
           "title": "App Id",
           "type": "string"
         },
+        "app_type": {
+          "title": "App Type",
+          "type": "string"
+        },
         "appsflyer_id": {
           "title": "Appsflyer Id",
+          "type": "string"
+        },
+        "campaign_type": {
+          "title": "Campaign Type",
+          "type": "string"
+        },
+        "conversion_type": {
+          "title": "Conversion Type",
           "type": "string"
         },
         "event_name": {
@@ -1335,19 +1427,17 @@
         "event_value": {
           "title": "Event Value",
           "type": "string"
-        },
-        "api_version": {
-          "title": "Api Version",
-          "type": "string"
         }
       },
       "required": [
         "app_id",
+        "app_type",
         "appsflyer_id",
+        "campaign_type",
+        "conversion_type",
         "event_name",
         "event_time",
-        "event_value",
-        "api_version"
+        "event_value"
       ],
       "title": "AppsFlyerWebhookDocument",
       "type": "object",
@@ -1360,13 +1450,13 @@
   {
     "recommendedName": "re-attribution-in-app-event",
     "resourceConfig": {
-      "type": "webhook",
       "name": "re-attribution-in-app-event",
       "match_rule": {
         "value": "re-attribution-in-app-event",
         "key": "event_name",
         "type": "body"
-      }
+      },
+      "type": "webhook"
     },
     "documentSchema": {
       "$defs": {
@@ -1462,8 +1552,20 @@
           "title": "App Id",
           "type": "string"
         },
+        "app_type": {
+          "title": "App Type",
+          "type": "string"
+        },
         "appsflyer_id": {
           "title": "Appsflyer Id",
+          "type": "string"
+        },
+        "campaign_type": {
+          "title": "Campaign Type",
+          "type": "string"
+        },
+        "conversion_type": {
+          "title": "Conversion Type",
           "type": "string"
         },
         "event_name": {
@@ -1477,19 +1579,17 @@
         "event_value": {
           "title": "Event Value",
           "type": "string"
-        },
-        "api_version": {
-          "title": "Api Version",
-          "type": "string"
         }
       },
       "required": [
         "app_id",
+        "app_type",
         "appsflyer_id",
+        "campaign_type",
+        "conversion_type",
         "event_name",
         "event_time",
-        "event_value",
-        "api_version"
+        "event_value"
       ],
       "title": "AppsFlyerWebhookDocument",
       "type": "object",
@@ -1502,13 +1602,13 @@
   {
     "recommendedName": "re-download",
     "resourceConfig": {
-      "type": "webhook",
       "name": "re-download",
       "match_rule": {
         "value": "re-download",
         "key": "event_name",
         "type": "body"
-      }
+      },
+      "type": "webhook"
     },
     "documentSchema": {
       "$defs": {
@@ -1604,8 +1704,20 @@
           "title": "App Id",
           "type": "string"
         },
+        "app_type": {
+          "title": "App Type",
+          "type": "string"
+        },
         "appsflyer_id": {
           "title": "Appsflyer Id",
+          "type": "string"
+        },
+        "campaign_type": {
+          "title": "Campaign Type",
+          "type": "string"
+        },
+        "conversion_type": {
+          "title": "Conversion Type",
           "type": "string"
         },
         "event_name": {
@@ -1619,19 +1731,17 @@
         "event_value": {
           "title": "Event Value",
           "type": "string"
-        },
-        "api_version": {
-          "title": "Api Version",
-          "type": "string"
         }
       },
       "required": [
         "app_id",
+        "app_type",
         "appsflyer_id",
+        "campaign_type",
+        "conversion_type",
         "event_name",
         "event_time",
-        "event_value",
-        "api_version"
+        "event_value"
       ],
       "title": "AppsFlyerWebhookDocument",
       "type": "object",
@@ -1644,13 +1754,13 @@
   {
     "recommendedName": "re-engagement",
     "resourceConfig": {
-      "type": "webhook",
       "name": "re-engagement",
       "match_rule": {
         "value": "re-engagement",
         "key": "event_name",
         "type": "body"
-      }
+      },
+      "type": "webhook"
     },
     "documentSchema": {
       "$defs": {
@@ -1746,8 +1856,20 @@
           "title": "App Id",
           "type": "string"
         },
+        "app_type": {
+          "title": "App Type",
+          "type": "string"
+        },
         "appsflyer_id": {
           "title": "Appsflyer Id",
+          "type": "string"
+        },
+        "campaign_type": {
+          "title": "Campaign Type",
+          "type": "string"
+        },
+        "conversion_type": {
+          "title": "Conversion Type",
           "type": "string"
         },
         "event_name": {
@@ -1761,19 +1883,17 @@
         "event_value": {
           "title": "Event Value",
           "type": "string"
-        },
-        "api_version": {
-          "title": "Api Version",
-          "type": "string"
         }
       },
       "required": [
         "app_id",
+        "app_type",
         "appsflyer_id",
+        "campaign_type",
+        "conversion_type",
         "event_name",
         "event_time",
-        "event_value",
-        "api_version"
+        "event_value"
       ],
       "title": "AppsFlyerWebhookDocument",
       "type": "object",
@@ -1786,13 +1906,13 @@
   {
     "recommendedName": "re-engagement-in-app-event",
     "resourceConfig": {
-      "type": "webhook",
       "name": "re-engagement-in-app-event",
       "match_rule": {
         "value": "re-engagement-in-app-event",
         "key": "event_name",
         "type": "body"
-      }
+      },
+      "type": "webhook"
     },
     "documentSchema": {
       "$defs": {
@@ -1888,8 +2008,20 @@
           "title": "App Id",
           "type": "string"
         },
+        "app_type": {
+          "title": "App Type",
+          "type": "string"
+        },
         "appsflyer_id": {
           "title": "Appsflyer Id",
+          "type": "string"
+        },
+        "campaign_type": {
+          "title": "Campaign Type",
+          "type": "string"
+        },
+        "conversion_type": {
+          "title": "Conversion Type",
           "type": "string"
         },
         "event_name": {
@@ -1903,19 +2035,17 @@
         "event_value": {
           "title": "Event Value",
           "type": "string"
-        },
-        "api_version": {
-          "title": "Api Version",
-          "type": "string"
         }
       },
       "required": [
         "app_id",
+        "app_type",
         "appsflyer_id",
+        "campaign_type",
+        "conversion_type",
         "event_name",
         "event_time",
-        "event_value",
-        "api_version"
+        "event_value"
       ],
       "title": "AppsFlyerWebhookDocument",
       "type": "object",
@@ -1928,13 +2058,13 @@
   {
     "recommendedName": "reinstall",
     "resourceConfig": {
-      "type": "webhook",
       "name": "reinstall",
       "match_rule": {
         "value": "reinstall",
         "key": "event_name",
         "type": "body"
-      }
+      },
+      "type": "webhook"
     },
     "documentSchema": {
       "$defs": {
@@ -2030,8 +2160,20 @@
           "title": "App Id",
           "type": "string"
         },
+        "app_type": {
+          "title": "App Type",
+          "type": "string"
+        },
         "appsflyer_id": {
           "title": "Appsflyer Id",
+          "type": "string"
+        },
+        "campaign_type": {
+          "title": "Campaign Type",
+          "type": "string"
+        },
+        "conversion_type": {
+          "title": "Conversion Type",
           "type": "string"
         },
         "event_name": {
@@ -2045,19 +2187,17 @@
         "event_value": {
           "title": "Event Value",
           "type": "string"
-        },
-        "api_version": {
-          "title": "Api Version",
-          "type": "string"
         }
       },
       "required": [
         "app_id",
+        "app_type",
         "appsflyer_id",
+        "campaign_type",
+        "conversion_type",
         "event_name",
         "event_time",
-        "event_value",
-        "api_version"
+        "event_value"
       ],
       "title": "AppsFlyerWebhookDocument",
       "type": "object",


### PR DESCRIPTION
**Description:**

Existing `source-appsflyer` captures are failing to capture webhook messages. This PR addresses three issues:

- Updates the set of required fields to guarantee document identity
- Prints a detailed error if any of these are missing
- Adds debug lines for every failed rule matching attempt

These new logs are noisy but should only affect webhook captures where the `debug` log level is used. Do not enable them unless strictly necessary.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

