### PR TITLE
materialize-iceberg: use uri from catalog config

### DIFF
--- a/materialize-iceberg/catalog/catalog.go
+++ b/materialize-iceberg/catalog/catalog.go
@@ -278,16 +278,29 @@ func New(ctx context.Context, catalogUrl string, warehouse string, opts ...Catal
 		if p, ok := catalogCfg.Defaults["prefix"]; ok {
 			prefix = p
 		}
+		if u, ok := catalogCfg.Overrides["uri"]; ok {
+			uri, err := url.Parse(u)
+			if err != nil {
+				return nil, fmt.Errorf("unable to parse defaults.uri %q: %w", uri, err)
+			}
+			baseURL = uri.JoinPath("v1")
+		}
 	}
 	if catalogCfg.Overrides != nil {
 		if p, ok := catalogCfg.Overrides["prefix"]; ok {
 			prefix = p
-
+		}
+		if u, ok := catalogCfg.Overrides["uri"]; ok {
+			uri, err := url.Parse(u)
+			if err != nil {
+				return nil, fmt.Errorf("unable to parse overrides.uri %q: %w", uri, err)
+			}
+			baseURL = uri.JoinPath("v1")
 		}
 	}
-	if prefix != "" {
-		rc.rHttp = rc.rHttp.SetBaseURL(baseURL.JoinPath(prefix).String())
-	}
+
+	// Update the baseURL based on the CatalogConfig.
+	rc.rHttp = rc.rHttp.SetBaseURL(baseURL.JoinPath(prefix).String())
 
 	return rc, nil
 }

--- a/materialize-iceberg/catalog/catalog.go
+++ b/materialize-iceberg/catalog/catalog.go
@@ -278,7 +278,7 @@ func New(ctx context.Context, catalogUrl string, warehouse string, opts ...Catal
 		if p, ok := catalogCfg.Defaults["prefix"]; ok {
 			prefix = p
 		}
-		if u, ok := catalogCfg.Overrides["uri"]; ok {
+		if u, ok := catalogCfg.Defaults["uri"]; ok {
 			uri, err := url.Parse(u)
 			if err != nil {
 				return nil, fmt.Errorf("unable to parse defaults.uri %q: %w", uri, err)

--- a/materialize-iceberg/catalog/catalog_test.go
+++ b/materialize-iceberg/catalog/catalog_test.go
@@ -1,0 +1,117 @@
+package catalog
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestBaseURL(t *testing.T) {
+	tests := []struct {
+		name    string
+		handler http.HandlerFunc
+		check   func(catalogURL, baseURL *url.URL)
+	}{
+		{
+			name: "no prefix or uri",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusOK)
+				respBody, err := json.Marshal(map[string]any{
+					"defaults":  map[string]string{},
+					"overrides": map[string]string{},
+				})
+				require.NoError(t, err)
+				w.Write(respBody)
+			},
+			check: func(catalogURL, baseURL *url.URL) {
+				require.Equal(t, baseURL.Path, "/iceberg/v1")
+				require.Equal(t, catalogURL.Host, baseURL.Host)
+			},
+		},
+		{
+			name: "with prefix",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusOK)
+				respBody, err := json.Marshal(map[string]any{
+					"defaults": map[string]string{
+						"prefix": "main",
+					},
+					"overrides": map[string]string{},
+				})
+				require.NoError(t, err)
+				w.Write(respBody)
+			},
+			check: func(catalogURL, baseURL *url.URL) {
+				require.Equal(t, baseURL.Path, "/iceberg/v1/main")
+				require.Equal(t, catalogURL.Host, baseURL.Host)
+			},
+		},
+		{
+			name: "with uri",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusOK)
+				respBody, err := json.Marshal(map[string]any{
+					"defaults": map[string]string{},
+					"overrides": map[string]string{
+						"uri": "http://example.org/iceberg/",
+					},
+				})
+				require.NoError(t, err)
+				w.Write(respBody)
+			},
+			check: func(catalogURL, baseURL *url.URL) {
+				require.Equal(t, baseURL.String(), "http://example.org/iceberg/v1")
+			},
+		},
+		{
+			name: "with prefix and uri",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusOK)
+				respBody, err := json.Marshal(map[string]any{
+					"defaults": map[string]string{
+						"prefix": "main",
+					},
+					"overrides": map[string]string{
+						"uri": "http://example.org/iceberg/",
+					},
+				})
+				require.NoError(t, err)
+				w.Write(respBody)
+			},
+			check: func(catalogURL, baseURL *url.URL) {
+				require.Equal(t, baseURL.String(), "http://example.org/iceberg/v1/main")
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mux := http.NewServeMux()
+			mux.HandleFunc("GET /iceberg/v1/config", tt.handler)
+
+			ts := httptest.NewServer(mux)
+			defer ts.Close()
+
+			testURL, err := url.Parse(ts.URL)
+			require.NoError(t, err)
+
+			catalogURL := testURL.JoinPath("iceberg")
+			scope := "my-scope"
+			options := WithClientCredential("my-creds", "my-uri", &scope)
+			catalog, err := New(t.Context(), catalogURL.String(), "my-warehouse", options)
+			require.NoError(t, err)
+
+			baseURL, err := url.Parse(catalog.rHttp.BaseURL())
+			require.NoError(t, err)
+
+			tt.check(catalogURL, baseURL)
+		})
+	}
+}

--- a/materialize-iceberg/catalog/catalog_test.go
+++ b/materialize-iceberg/catalog/catalog_test.go
@@ -34,7 +34,7 @@ func TestBaseURL(t *testing.T) {
 			},
 		},
 		{
-			name: "with prefix",
+			name: "with defaults prefix",
 			handler: func(w http.ResponseWriter, r *http.Request) {
 				w.Header().Set("Content-Type", "application/json")
 				w.WriteHeader(http.StatusOK)
@@ -53,7 +53,25 @@ func TestBaseURL(t *testing.T) {
 			},
 		},
 		{
-			name: "with uri",
+			name: "with defaults uri",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusOK)
+				respBody, err := json.Marshal(map[string]any{
+					"defaults": map[string]string{
+						"uri": "http://example.org/iceberg/",
+					},
+					"overrides": map[string]string{},
+				})
+				require.NoError(t, err)
+				w.Write(respBody)
+			},
+			check: func(catalogURL, baseURL *url.URL) {
+				require.Equal(t, baseURL.String(), "http://example.org/iceberg/v1")
+			},
+		},
+		{
+			name: "with overrides uri",
 			handler: func(w http.ResponseWriter, r *http.Request) {
 				w.Header().Set("Content-Type", "application/json")
 				w.WriteHeader(http.StatusOK)
@@ -71,7 +89,8 @@ func TestBaseURL(t *testing.T) {
 			},
 		},
 		{
-			name: "with prefix and uri",
+			// This case matches how Nessie reports a branch.
+			name: "with defaults prefix and overrides uri",
 			handler: func(w http.ResponseWriter, r *http.Request) {
 				w.Header().Set("Content-Type", "application/json")
 				w.WriteHeader(http.StatusOK)

--- a/materialize-iceberg/driver_test.go
+++ b/materialize-iceberg/driver_test.go
@@ -19,7 +19,7 @@ var testAll = flag.Bool("iceberg.test-all", false, "run integration tests agains
 
 func TestIntegration(t *testing.T) {
 	if testing.Short() {
-		t.Skip()
+		t.Skip("skipping test in short mode.")
 	}
 
 	makeResourceFn := func(table string, delta bool) resource {


### PR DESCRIPTION
If the catalog config from /config specifies a uri, it should be used for future requests instead of the catalog url provided by the user.

One example of a catalog using this is Nessie.  With this catalog you connect to a branch specific catalog URL such as /iceberg/my-branch, the catalog config it will return a branch prefix and a new catalog URI. When the uri and prefix are combined it will be the correct URL for future requests to this branch.

**Workflow steps:**

No changes

**Documentation links affected:**

None

**Notes for reviewers:**

Nessie example:

To use a branch, the initial catalog url might be:
```
https://example.org/iceberg/my-branch
```

The connector checks the iceberg catalog for the catalog config at:
```
https://example.org/iceberg/my-branch/v1/config
```

Nessie replies with:
```
{
    "defaults": {
        "prefix": "my-branch",
    },
    "overrides": {
        "uri": "https://example.org/iceberg/"
    }
}
```

In this case for future requests, such as listing namespaces, we should use:
```
https://example.org/iceberg/v1/my-branch/namespaces
```

