### PR TITLE
source-jira-native: fix filter_sharing snapshot path

### DIFF
--- a/source-jira-native/source_jira_native/api.py
+++ b/source-jira-native/source_jira_native/api.py
@@ -377,7 +377,7 @@ async def snapshot_filter_sharing(
             filter_ids.append(filter_id)
 
     for id in filter_ids:
-        path = f"{Filters.path}/{id}/{stream.path}"
+        path = f"filter/{id}/{stream.path}"
         try:
             async for record in _fetch_non_paginated_arrayed_resources(http, domain, stream.api, path, stream.extra_headers, stream.extra_params, log):
                 record["filterId"] = id


### PR DESCRIPTION
**Description:**

The `filter_sharing` snapshot was constructing child paths from `Filters.path` ("filter/search"), producing URLs like `/rest/api/3/filter/search/{id}/permission` and 404ing. [Jira's documented endpoint](https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-filter-sharing/#api-group-filter-sharing) for a filter's share permissions is `/rest/api/3/filter/{id}/permission`, so build the path from "filter" directly.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

