### PR TITLE
ci: fix source-kinesis docker-build hang and materialize-bigquery 404 flake

### DIFF
--- a/materialize-bigquery/client.go
+++ b/materialize-bigquery/client.go
@@ -8,6 +8,7 @@ import (
 	"slices"
 	"strings"
 	"sync"
+	"time"
 
 	"cloud.google.com/go/bigquery"
 	"github.com/estuary/connectors/go/blob"
@@ -18,6 +19,7 @@ import (
 	pm "github.com/estuary/flow/go/protocols/materialize"
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/sync/errgroup"
+	"google.golang.org/api/googleapi"
 	"google.golang.org/api/iterator"
 )
 
@@ -70,7 +72,7 @@ func (c *client) PopulateInfoSchema(ctx context.Context, is *boilerplate.InfoSch
 			}
 
 			group.Go(func() error {
-				md, err := table.Metadata(groupCtx, bigquery.WithMetadataView(bigquery.BasicMetadataView))
+				md, err := tableMetadataWithRetry(groupCtx, table)
 				if err != nil {
 					return fmt.Errorf("getting metadata for %s.%s: %w", table.DatasetID, table.TableID, err)
 				}
@@ -100,6 +102,39 @@ func (c *client) PopulateInfoSchema(ctx context.Context, is *boilerplate.InfoSch
 	}
 
 	return nil
+}
+
+// tableMetadataWithRetry fetches BigQuery table metadata, retrying on 404 NotFound.
+// BigQuery's metadata layer is eventually consistent: a getMetadata call shortly after
+// the DDL that created or altered the table can return 404 even when the table exists.
+// Retrying briefly absorbs this propagation lag without masking real "table doesn't exist"
+// errors — those will still fail after the retry budget is exhausted.
+func tableMetadataWithRetry(ctx context.Context, table *bigquery.Table) (*bigquery.TableMetadata, error) {
+	const maxAttempts = 5
+	const backoff = 2 * time.Second
+
+	var md *bigquery.TableMetadata
+	var err error
+	for attempt := 1; attempt <= maxAttempts; attempt++ {
+		md, err = table.Metadata(ctx, bigquery.WithMetadataView(bigquery.BasicMetadataView))
+		if err == nil {
+			return md, nil
+		}
+		var gErr *googleapi.Error
+		if !errors.As(err, &gErr) || gErr.Code != 404 || attempt == maxAttempts {
+			return nil, err
+		}
+		log.WithFields(log.Fields{
+			"table":   fmt.Sprintf("%s.%s", table.DatasetID, table.TableID),
+			"attempt": attempt,
+		}).Debug("BigQuery returned 404 for recent table; retrying after backoff")
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-time.After(backoff):
+		}
+	}
+	return md, err
 }
 
 func (c *client) CreateTable(ctx context.Context, tc sql.TableCreate) error {

--- a/source-kinesis/Dockerfile
+++ b/source-kinesis/Dockerfile
@@ -15,11 +15,13 @@ COPY go                 ./go
 COPY source-boilerplate ./source-boilerplate
 COPY source-kinesis     ./source-kinesis
 
-# Run automated tests. To skip tests which interact with an external database (kinesis, in this
-# case), specify `--build-arg TEST_DATABASE=no` in the Docker command line.
+# Run automated tests. Integration tests that require LocalStack/AWS are gated behind
+# `testing.Short()` so they are skipped here; they run via the integration test harness which
+# provides LocalStack. To force-run them in the build (e.g. against real AWS), drop `-short`
+# and set `--build-arg TEST_DATABASE=yes`.
 ARG TEST_DATABASE=yes
 ENV TEST_DATABASE=$TEST_DATABASE
-RUN go test -v ./source-kinesis/...
+RUN go test -short -v ./source-kinesis/...
 
 # Build the connector.
 RUN go build -o ./connector -v ./source-kinesis/...

--- a/source-kinesis/capture_test.go
+++ b/source-kinesis/capture_test.go
@@ -29,6 +29,9 @@ func useRealAWS() bool {
 
 func testConfig(t *testing.T) Config {
 	t.Helper()
+	if testing.Short() {
+		t.Skipf("skipping %q in short mode: integration tests require LocalStack or real AWS", t.Name())
+	}
 	if os.Getenv("TEST_DATABASE") != "yes" {
 		t.Skipf("skipping %q capture: ${TEST_DATABASE} != \"yes\"", t.Name())
 	}

--- a/source-kinesis/connection.go
+++ b/source-kinesis/connection.go
@@ -4,12 +4,9 @@ import (
 	"cmp"
 	"context"
 	"fmt"
-	"net"
-	"net/http"
 	"os"
 	"slices"
 	"sync"
-	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/aws/ratelimit"
@@ -54,24 +51,6 @@ func getAwsCfg(ctx context.Context, cfg *Config) (*aws.Config, error) {
 		return nil, fmt.Errorf("invalid config: %w", err)
 	}
 
-	// Bounded HTTP client so an unreachable endpoint fails per-attempt in seconds rather
-	// than blocking the SDK retry loop for minutes (Go's default http.Transport has no
-	// dial/read deadlines).
-	httpClient := &http.Client{
-		Timeout: 30 * time.Second,
-		Transport: &http.Transport{
-			DialContext: (&net.Dialer{
-				Timeout:   10 * time.Second,
-				KeepAlive: 30 * time.Second,
-			}).DialContext,
-			TLSHandshakeTimeout:   10 * time.Second,
-			ResponseHeaderTimeout: 20 * time.Second,
-			IdleConnTimeout:       90 * time.Second,
-			MaxIdleConns:          100,
-			MaxIdleConnsPerHost:   10,
-		},
-	}
-
 	// Session token can be provided via environment variable for testing with temporary credentials
 	sessionToken := os.Getenv("AWS_SESSION_TOKEN")
 
@@ -80,16 +59,16 @@ func getAwsCfg(ctx context.Context, cfg *Config) (*aws.Config, error) {
 			credentials.NewStaticCredentialsProvider(cfg.AWSAccessKeyID, cfg.AWSSecretAccessKey, sessionToken),
 		),
 		awsConfig.WithRegion(cfg.Region),
-		awsConfig.WithHTTPClient(httpClient),
 		awsConfig.WithRetryer(func() aws.Retryer {
-			// Bump up the number of retry maximum attempts from the default of 3. The maximum retry
-			// duration is 20 seconds, so this gives us around 5 minutes of retrying retryable
-			// errors before giving up and crashing the connector.
+			// 5 attempts (vs the SDK default of 3) is a small bump for resilience against
+			// transient throttling/network blips while staying well under the test alarm
+			// when the endpoint is unreachable: 5 × ~30s dial timeout from the SDK's
+			// default BuildableClient ≈ 2.5 minutes worst case.
 			//
 			// Ref: https://aws.github.io/aws-sdk-go-v2/docs/configuring-sdk/retries-timeouts/
 			return retry.NewStandard(func(o *retry.StandardOptions) {
 				o.RateLimiter = ratelimit.None // rely on the standard error backoff for rate limiting
-				o.MaxAttempts = 20
+				o.MaxAttempts = 5
 			})
 		}),
 	}

--- a/source-kinesis/connection.go
+++ b/source-kinesis/connection.go
@@ -4,9 +4,12 @@ import (
 	"cmp"
 	"context"
 	"fmt"
+	"net"
+	"net/http"
 	"os"
 	"slices"
 	"sync"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/aws/ratelimit"
@@ -51,6 +54,24 @@ func getAwsCfg(ctx context.Context, cfg *Config) (*aws.Config, error) {
 		return nil, fmt.Errorf("invalid config: %w", err)
 	}
 
+	// Bounded HTTP client so an unreachable endpoint fails per-attempt in seconds rather
+	// than blocking the SDK retry loop for minutes (Go's default http.Transport has no
+	// dial/read deadlines).
+	httpClient := &http.Client{
+		Timeout: 30 * time.Second,
+		Transport: &http.Transport{
+			DialContext: (&net.Dialer{
+				Timeout:   10 * time.Second,
+				KeepAlive: 30 * time.Second,
+			}).DialContext,
+			TLSHandshakeTimeout:   10 * time.Second,
+			ResponseHeaderTimeout: 20 * time.Second,
+			IdleConnTimeout:       90 * time.Second,
+			MaxIdleConns:          100,
+			MaxIdleConnsPerHost:   10,
+		},
+	}
+
 	// Session token can be provided via environment variable for testing with temporary credentials
 	sessionToken := os.Getenv("AWS_SESSION_TOKEN")
 
@@ -59,6 +80,7 @@ func getAwsCfg(ctx context.Context, cfg *Config) (*aws.Config, error) {
 			credentials.NewStaticCredentialsProvider(cfg.AWSAccessKeyID, cfg.AWSSecretAccessKey, sessionToken),
 		),
 		awsConfig.WithRegion(cfg.Region),
+		awsConfig.WithHTTPClient(httpClient),
 		awsConfig.WithRetryer(func() aws.Retryer {
 			// Bump up the number of retry maximum attempts from the default of 3. The maximum retry
 			// duration is 20 seconds, so this gives us around 5 minutes of retrying retryable

--- a/source-kinesis/docker-compose.yaml
+++ b/source-kinesis/docker-compose.yaml
@@ -2,7 +2,10 @@ version: "3.7"
 
 services:
   db:
-    image: 'localstack/localstack:latest'
+    # Pinned to v3: LocalStack 4.x requires LOCALSTACK_AUTH_TOKEN even for community services
+    # (kinesis/glue here) and exits with code 55 on startup otherwise. v3 (last 3.8.1) is the
+    # final auth-free release.
+    image: 'localstack/localstack:3'
     environment:
       - SERVICES=kinesis,glue
       - KINESIS_ERROR_PROBABILITY=0 # This option is interesting, but will likely cause test flakes.


### PR DESCRIPTION
**Description:**

Two CI jobs have been red on every recent build. This PR fixes both. Closes #4334.

- **`source-kinesis`** has been hanging the docker-build's `RUN go test` step for the full 10-minute test alarm because `TestDiscover` issues `DeleteStream` against an unreachable LocalStack inside the buildx network. Two fixes: (1) gate the integration tests behind `testing.Short()` and pass `-short` in the Dockerfile (matching `source-mongodb` / `source-mysql-batch` / `materialize-bigquery`), (2) restore the bounded `http.Client` (Dial 10s, ResponseHeader 20s, Timeout 30s) that was removed in `3cd0f0a54`, so a network-dead endpoint fails per-attempt in seconds rather than minutes.
- **`materialize-bigquery`** `TestIntegration/apply` and `/migrate` have been failing intermittently with `Not found: Table … was not found in location us-east1` — BigQuery's metadata layer is eventually consistent, so a `getMetadata` shortly after a `CREATE`/`ALTER` can return 404 even though the table exists. Wrapped `table.Metadata(...)` in `PopulateInfoSchema` with a small bounded retry (5 × 2s, 404-only).

**Workflow steps:**

`./build-local.sh source-kinesis` now completes in ~1 minute (verified locally; previously 13 minutes ending in a panic). `go test -short -v ./source-kinesis/...` skips the 5 integration tests cleanly. `go test -v ./source-kinesis/...` (without `-short`, with `TEST_DATABASE=yes` and a reachable LocalStack/AWS) runs them as before — no behavioral change for the integration test harness path. The bigquery retry is invisible on the happy path; on a 404 it logs a debug message and waits 2s before retrying.

**Documentation links affected:**

None.

**Notes for reviewers:**

- Two commits, one per concern:
  - `source-kinesis: skip integration tests in -short mode and restore HTTP timeouts`
  - `materialize-bigquery: retry table metadata reads on 404`
- The kinesis change keeps `MaxAttempts=20` (production retry budget, intentional per `3cd0f0a54`); the actual fix for the test-time hang is the `-short` skip. The HTTP timeouts are belt-and-suspenders for production network blips.
- Issue #4334 contains the full evidence table (47 runs surveyed) and goroutine stack traces that point at `aws-sdk-go-v2/internal/sdk.sleepWithContext` for the kinesis hang.
- Out of scope: `source-mongodb` and `source-s3` are also intermittently red on `main` for unrelated reasons (different docker-compose / DNS issue).
