### PR TITLE
source-appsflyer: relax restrictions on event_value field

### DIFF
--- a/source-appsflyer/source_appsflyer/models.py
+++ b/source-appsflyer/source_appsflyer/models.py
@@ -77,6 +77,13 @@ class EventTypesResponse(BaseModel):
     event_types: list[str]
 
 
+KNOWN_STREAMS_WITH_EVENT_VALUE_FIELD = frozenset({
+    "organic-install-in-app-event",
+    "re-attribution-in-app-event",
+    "re-engagement-in-app-event",
+})
+
+
 class AppsFlyerWebhookDocument(WebhookDocument):
     class Meta(WebhookDocument.Meta):
         model_config = ConfigDict(  # pyright: ignore[reportUnannotatedClassAttribute]
@@ -100,7 +107,7 @@ class AppsFlyerWebhookDocument(WebhookDocument):
         "conversion_type",
         "event_name",
         "event_time",
-        "event_value",
+        "event_type",
     ]
 
     app_id: str
@@ -109,13 +116,26 @@ class AppsFlyerWebhookDocument(WebhookDocument):
     conversion_type: str
     event_name: str
     event_time: str
-    event_value: str
+    event_type: str
 
     @model_validator(mode="before")
     def ensure_pk_fields_present(cls, data: dict[str, str]):
         assert isinstance(data, dict)
 
-        missing_keys = [key for key in cls.required_pk_fields if key not in data]
+        required = list(cls.required_pk_fields)
+        # Event values have been observed in all Android streams but only a
+        # handful of iOS ones (AppsFlyer prefixes iOS unified app IDs with
+        # "id"). We tolerate their absence only when the app_id signals iOS
+        # AND the stream isn't one of the few that always carry the field
+        # across every platform.
+        is_ios_app = data.get("app_id", "").startswith("id")
+        always_carries_event_value = (
+            data.get("event_type", "") in KNOWN_STREAMS_WITH_EVENT_VALUE_FIELD
+        )
+        if not is_ios_app or always_carries_event_value:
+            required.append("event_value")
+
+        missing_keys = [key for key in required if key not in data]
         if missing_keys:
             raise ValueError(
                 (
@@ -135,6 +155,9 @@ class AppsFlyerWebhookDocument(WebhookDocument):
         # It is included in all document PKs as a future proofing measure
         # in case a different platform adopts it.
         parts.append(getattr(self, "app_type", "estuary_missing_app_type"))
+
+        # Event values have been observed in all Android streams but only a handful in iOS
+        parts.append(getattr(self, "event_value", "estuary_missing_event_value"))
 
         self.meta_.estuary_id = xxhash.xxh128("|".join(parts).encode()).hexdigest()
 

--- a/source-appsflyer/tests/snapshots/snapshots__discover__stdout.json
+++ b/source-appsflyer/tests/snapshots/snapshots__discover__stdout.json
@@ -204,8 +204,8 @@
           "title": "Event Time",
           "type": "string"
         },
-        "event_value": {
-          "title": "Event Value",
+        "event_type": {
+          "title": "Event Type",
           "type": "string"
         }
       },
@@ -216,7 +216,7 @@
         "conversion_type",
         "event_name",
         "event_time",
-        "event_value"
+        "event_type"
       ],
       "title": "AppsFlyerWebhookDocument",
       "type": "object",
@@ -351,8 +351,8 @@
           "title": "Event Time",
           "type": "string"
         },
-        "event_value": {
-          "title": "Event Value",
+        "event_type": {
+          "title": "Event Type",
           "type": "string"
         }
       },
@@ -363,7 +363,7 @@
         "conversion_type",
         "event_name",
         "event_time",
-        "event_value"
+        "event_type"
       ],
       "title": "AppsFlyerWebhookDocument",
       "type": "object",
@@ -498,8 +498,8 @@
           "title": "Event Time",
           "type": "string"
         },
-        "event_value": {
-          "title": "Event Value",
+        "event_type": {
+          "title": "Event Type",
           "type": "string"
         }
       },
@@ -510,7 +510,7 @@
         "conversion_type",
         "event_name",
         "event_time",
-        "event_value"
+        "event_type"
       ],
       "title": "AppsFlyerWebhookDocument",
       "type": "object",
@@ -645,8 +645,8 @@
           "title": "Event Time",
           "type": "string"
         },
-        "event_value": {
-          "title": "Event Value",
+        "event_type": {
+          "title": "Event Type",
           "type": "string"
         }
       },
@@ -657,7 +657,7 @@
         "conversion_type",
         "event_name",
         "event_time",
-        "event_value"
+        "event_type"
       ],
       "title": "AppsFlyerWebhookDocument",
       "type": "object",
@@ -792,8 +792,8 @@
           "title": "Event Time",
           "type": "string"
         },
-        "event_value": {
-          "title": "Event Value",
+        "event_type": {
+          "title": "Event Type",
           "type": "string"
         }
       },
@@ -804,7 +804,7 @@
         "conversion_type",
         "event_name",
         "event_time",
-        "event_value"
+        "event_type"
       ],
       "title": "AppsFlyerWebhookDocument",
       "type": "object",
@@ -939,8 +939,8 @@
           "title": "Event Time",
           "type": "string"
         },
-        "event_value": {
-          "title": "Event Value",
+        "event_type": {
+          "title": "Event Type",
           "type": "string"
         }
       },
@@ -951,7 +951,7 @@
         "conversion_type",
         "event_name",
         "event_time",
-        "event_value"
+        "event_type"
       ],
       "title": "AppsFlyerWebhookDocument",
       "type": "object",
@@ -1086,8 +1086,8 @@
           "title": "Event Time",
           "type": "string"
         },
-        "event_value": {
-          "title": "Event Value",
+        "event_type": {
+          "title": "Event Type",
           "type": "string"
         }
       },
@@ -1098,7 +1098,7 @@
         "conversion_type",
         "event_name",
         "event_time",
-        "event_value"
+        "event_type"
       ],
       "title": "AppsFlyerWebhookDocument",
       "type": "object",
@@ -1233,8 +1233,8 @@
           "title": "Event Time",
           "type": "string"
         },
-        "event_value": {
-          "title": "Event Value",
+        "event_type": {
+          "title": "Event Type",
           "type": "string"
         }
       },
@@ -1245,7 +1245,7 @@
         "conversion_type",
         "event_name",
         "event_time",
-        "event_value"
+        "event_type"
       ],
       "title": "AppsFlyerWebhookDocument",
       "type": "object",
@@ -1380,8 +1380,8 @@
           "title": "Event Time",
           "type": "string"
         },
-        "event_value": {
-          "title": "Event Value",
+        "event_type": {
+          "title": "Event Type",
           "type": "string"
         }
       },
@@ -1392,7 +1392,7 @@
         "conversion_type",
         "event_name",
         "event_time",
-        "event_value"
+        "event_type"
       ],
       "title": "AppsFlyerWebhookDocument",
       "type": "object",
@@ -1527,8 +1527,8 @@
           "title": "Event Time",
           "type": "string"
         },
-        "event_value": {
-          "title": "Event Value",
+        "event_type": {
+          "title": "Event Type",
           "type": "string"
         }
       },
@@ -1539,7 +1539,7 @@
         "conversion_type",
         "event_name",
         "event_time",
-        "event_value"
+        "event_type"
       ],
       "title": "AppsFlyerWebhookDocument",
       "type": "object",
@@ -1674,8 +1674,8 @@
           "title": "Event Time",
           "type": "string"
         },
-        "event_value": {
-          "title": "Event Value",
+        "event_type": {
+          "title": "Event Type",
           "type": "string"
         }
       },
@@ -1686,7 +1686,7 @@
         "conversion_type",
         "event_name",
         "event_time",
-        "event_value"
+        "event_type"
       ],
       "title": "AppsFlyerWebhookDocument",
       "type": "object",
@@ -1821,8 +1821,8 @@
           "title": "Event Time",
           "type": "string"
         },
-        "event_value": {
-          "title": "Event Value",
+        "event_type": {
+          "title": "Event Type",
           "type": "string"
         }
       },
@@ -1833,7 +1833,7 @@
         "conversion_type",
         "event_name",
         "event_time",
-        "event_value"
+        "event_type"
       ],
       "title": "AppsFlyerWebhookDocument",
       "type": "object",
@@ -1968,8 +1968,8 @@
           "title": "Event Time",
           "type": "string"
         },
-        "event_value": {
-          "title": "Event Value",
+        "event_type": {
+          "title": "Event Type",
           "type": "string"
         }
       },
@@ -1980,7 +1980,7 @@
         "conversion_type",
         "event_name",
         "event_time",
-        "event_value"
+        "event_type"
       ],
       "title": "AppsFlyerWebhookDocument",
       "type": "object",
@@ -2115,8 +2115,8 @@
           "title": "Event Time",
           "type": "string"
         },
-        "event_value": {
-          "title": "Event Value",
+        "event_type": {
+          "title": "Event Type",
           "type": "string"
         }
       },
@@ -2127,7 +2127,7 @@
         "conversion_type",
         "event_name",
         "event_time",
-        "event_value"
+        "event_type"
       ],
       "title": "AppsFlyerWebhookDocument",
       "type": "object",


### PR DESCRIPTION
It has been observed that the `event_value` field being used for the construction of document surrogate keys is not present in some streams. To summarise:

1. All Android apps report `event_value` in all event types
2. The following event types include `event_value` on iOS apps:
    a. organic-install-in-app-event
    b. re-attribution-in-app-event
    c. re-engagement-in-app-event
3. All other iOS streams never include it

This change relaxes the field requirement only where it's strictly necessary, while enforcing our capture setup requirements as much as we can.

**Description:**

(Describe the high level scope of new or changed features)

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

