### PR TITLE
source-dynamics-365-finance-and-operations: fix deletion emission order

### DIFF
--- a/source-dynamics-365-finance-and-operations/source_dynamics_365_finance_and_operations/api.py
+++ b/source-dynamics-365-finance-and-operations/source_dynamics_365_finance_and_operations/api.py
@@ -211,10 +211,10 @@ async def read_csvs_in_folder(
 
         for csv in csvs:
             async for row in client.stream_csv(csv.name, table_metadata.field_names):
-                yield transform_row(row, table_metadata.boolean_fields)
+                yield transform_row(row, table_metadata.boolean_fields, csv.name)
 
 
-def transform_row(row: dict[str, str], boolean_fields: frozenset[str]) -> dict[str, str | bool | dict[str, str]]:
+def transform_row(row: dict[str, str], boolean_fields: frozenset[str], csv_name: str) -> dict[str, str | bool | dict[str, str]]:
     """
     Apply Dynamics 365-specific transformations to a CSV row.
 
@@ -229,7 +229,10 @@ def transform_row(row: dict[str, str], boolean_fields: frozenset[str]) -> dict[s
         value = row.get(field_name)
         result[field_name] = value.lower() == "true" if value else False
 
-    result["_meta"] = {"op": "d" if result.get("IsDelete") else "u"}
+    result["_meta"] = {
+        "op": "d" if result.get("IsDelete") else "u",
+        "source_file": csv_name,
+    }
 
     return result
 

--- a/source-dynamics-365-finance-and-operations/source_dynamics_365_finance_and_operations/api.py
+++ b/source-dynamics-365-finance-and-operations/source_dynamics_365_finance_and_operations/api.py
@@ -38,6 +38,13 @@ CACHE_TTL = MINIMUM_AZURE_SYNAPSE_LINK_EXPORT_INTERVAL / 5   # 1 minute
 # other streams for CPU time and can finish processing the contents
 # of a timestamp folder in a reasonable amount of time.
 FOLDER_PROCESSING_SEMAPHORE = asyncio.Semaphore(5)
+# A transformed CSV row. Keys are the standard Synapse Link metadata
+# columns (Id, IsDelete, versionnumber, SinkModifiedOn, _meta) plus
+# arbitrary table-specific columns.
+TransformedRow = dict[str, str | bool | None | dict[str, str]]
+# SinkModifiedOn arrives as a US-locale string like "4/29/2026 9:01:26 PM".
+# We parse it only internally as a tiebreaker for order_key.
+_SINK_MODIFIED_ON_FORMAT = "%m/%d/%Y %I:%M:%S %p"
 
 
 class ModelFormat(StrEnum):
@@ -181,12 +188,101 @@ async def get_folder_contents_for_table(
     return metadata
 
 
+def order_key(row: TransformedRow) -> tuple[int, datetime]:
+    """
+    Build the comparison key used by the per-folder ordering state machine.
+
+    versionnumber is the source-of-truth ordering primitive. SinkModifiedOn
+    is a defensive tiebreaker for the unexpected case where two rows for
+    the same Id share a versionnumber.
+
+    Both fields are required on every Synapse Link CSV row.
+    """
+    # versionnumber and SinkModifiedOn pass straight through transform_row,
+    # so values here are guaranteed to be str | None from client.stream_csv.
+    version = cast(str | None, row["versionnumber"])
+    sink_modified_on = cast(str | None, row["SinkModifiedOn"])
+    if version is None or sink_modified_on is None:
+        raise ValueError(
+            f"Row is missing required ordering fields "
+            f"(versionnumber={version!r}, SinkModifiedOn={sink_modified_on!r}). "
+        )
+    return (int(version), datetime.strptime(sink_modified_on, _SINK_MODIFIED_ON_FORMAT))
+
+
+async def defer_deletes(rows: AsyncGenerator[TransformedRow, None]) -> AsyncGenerator[TransformedRow, None]:
+    """
+    Buffer deletes from a single (folder, table) pair and emit them after
+    all upserts, so the destination ends up with the correct latest state
+    for each Id.
+
+    Rows in a folder don't arrive in versionnumber order. CSVs are sorted
+    by file modification time, which only loosely tracks the source commit
+    sequence. A delete might appear in an earlier-modified file than the
+    upsert that should follow it. So we can't just emit rows as they come.
+
+    For each Id we track two things:
+
+      - The highest versionnumber of any upsert we've already emitted for
+        this Id in this folder.
+      - The highest-versionnumber delete we've seen for this Id, held
+        until the end of the folder.
+
+    Upserts emit immediately, unless an upsert with a higher versionnumber
+    for the same Id has already gone out (in which case the incoming one
+    is stale). Deletes are buffered. At end-of-folder, a buffered delete
+    emits only if no upsert with a higher versionnumber for that Id was
+    seen during streaming.
+
+    State is reset per call. A delete in folder N+1 against an upsert from
+    folder N must still emit, and starting each call with empty maps
+    ensures it does. (Synapse Link gives us monotonically-increasing
+    versionnumbers across folders, so this is safe.)
+
+    Tradeoff: if a delete and a later recreate for the same Id appear in
+    the same folder, the delete is coalesced away. The destination ends
+    up in the right state, but the connector does not produce a faithful
+    event log.
+    """
+    # latest_upsert_key tracks the highest order_key for non-deletion events.
+    latest_upsert_key: dict[str, tuple[int, datetime]] = {}
+    # pending_deletes buffers all deletions. It gets drained after yielding
+    # all non-deletions.
+    pending_deletes: dict[str, TransformedRow] = {}
+
+    # Yield all non-deletions as they're read.
+    async for row in rows:
+        row_id = cast(str, row["Id"])
+        row_key = order_key(row)
+
+        # Defer yielding deletions until all non-deletions have been yielded.
+        if row["IsDelete"] is True:
+            prior_delete = pending_deletes.get(row_id)
+            if prior_delete is None or row_key > order_key(prior_delete):
+                pending_deletes[row_id] = row
+            continue
+
+        prior_key = latest_upsert_key.get(row_id)
+        if prior_key is not None and prior_key >= row_key:
+            # Drop stale upserts so the cache stays an accurate high-water mark.
+            continue
+
+        yield row
+        latest_upsert_key[row_id] = row_key
+
+    for row_id, delete_row in pending_deletes.items():
+        prior_key = latest_upsert_key.get(row_id)
+        if prior_key is not None and prior_key >= order_key(delete_row):
+            continue
+        yield delete_row
+
+
 async def read_csvs_in_folder(
     folder: str,
     table_name: str,
     client: ADLSGen2Client,
     log: Logger,
-) -> AsyncGenerator[dict, None]:
+) -> AsyncGenerator[TransformedRow, None]:
     folder_contents = await get_folder_contents_for_table(folder, table_name, client)
 
     csvs: list[ADLSPathMetadata] = []
@@ -199,22 +295,33 @@ async def read_csvs_in_folder(
         ):
             csvs.append(metadata)
 
-    if csvs:
-        table_metadata = await get_table_metadata(
-            timestamp=folder,
-            table_name=table_name,
-            client=client,
-            log=log,
-        )
+    if not csvs:
+        return
 
-        csvs.sort(key=lambda c: c.last_modified_datetime)
+    table_metadata = await get_table_metadata(
+        timestamp=folder,
+        table_name=table_name,
+        client=client,
+        log=log,
+    )
 
+    # Sorting by last_modified_datetime should ensure that all create/update events
+    # are sorted in modification order. But deletions live in separate files whose last_modified_datetime can
+    # precede the files containing creates/updates, so a delete might come up before
+    # the upsert it should follow. defer_deletes defers emitting deletions until
+    # we've processed all non-deletions in this folder.
+    csvs.sort(key=lambda c: c.last_modified_datetime)
+
+    async def transformed_rows() -> AsyncGenerator[TransformedRow, None]:
         for csv in csvs:
-            async for row in client.stream_csv(csv.name, table_metadata.field_names):
-                yield transform_row(row, table_metadata.boolean_fields, csv.name)
+            async for raw_row in client.stream_csv(csv.name, table_metadata.field_names):
+                yield transform_row(raw_row, table_metadata.boolean_fields, csv.name)
+
+    async for row in defer_deletes(transformed_rows()):
+        yield row
 
 
-def transform_row(row: dict[str, str], boolean_fields: frozenset[str], csv_name: str) -> dict[str, str | bool | dict[str, str]]:
+def transform_row(row: dict[str, str | None], boolean_fields: frozenset[str], csv_name: str) -> TransformedRow:
     """
     Apply Dynamics 365-specific transformations to a CSV row.
 
@@ -223,7 +330,7 @@ def transform_row(row: dict[str, str], boolean_fields: frozenset[str], csv_name:
     - Add _meta field with operation type based on IsDelete field
       (IsDelete is "True" for deletions, "" otherwise)
     """
-    result = cast(dict[str, str | bool | dict[str, str]], row)
+    result = cast(TransformedRow, row)
 
     for field_name in boolean_fields:
         value = row.get(field_name)

--- a/source-dynamics-365-finance-and-operations/source_dynamics_365_finance_and_operations/models.py
+++ b/source-dynamics-365-finance-and-operations/source_dynamics_365_finance_and_operations/models.py
@@ -70,6 +70,13 @@ class BaseTable(BaseCSVRow, extra="allow"):
 
     Id: str
     IsDelete: bool | None
+    # Monotonically increasing commit sequence number from the source system.
+    # Authoritative ordering primitive for changes within a folder.
+    versionnumber: str
+    # Timestamp at which the change was committed to the data lake. Used
+    # only as a defensive tiebreaker when two rows for the same Id share
+    # a versionnumber.
+    SinkModifiedOn: str
 
 
 def model_from_entity(entity: ModelDotJson.Entity) -> type[BaseTable]:

--- a/source-dynamics-365-finance-and-operations/tests/test_api.py
+++ b/source-dynamics-365-finance-and-operations/tests/test_api.py
@@ -1,7 +1,42 @@
-from source_dynamics_365_finance_and_operations.api import transform_row
+from typing import AsyncGenerator
+
+import pytest
+
+from source_dynamics_365_finance_and_operations.api import (
+    order_key,
+    defer_deletes,
+    transform_row,
+)
 
 
 CSV_NAME = "2026-01-01T00:00:00.000Z/Table/data.csv"
+
+
+def make_row(
+    row_id: str,
+    versionnumber: str,
+    is_delete: bool = False,
+    sink_modified_on: str = "1/1/2026 12:00:00 AM",
+    **extra,
+) -> dict:
+    """Build a row in the shape produced by transform_row."""
+    return {
+        "Id": row_id,
+        "IsDelete": is_delete,
+        "versionnumber": versionnumber,
+        "SinkModifiedOn": sink_modified_on,
+        "_meta": {"op": "d" if is_delete else "u", "source_file": CSV_NAME},
+        **extra,
+    }
+
+
+async def as_async_gen(items: list[dict]) -> AsyncGenerator[dict, None]:
+    for item in items:
+        yield item
+
+
+async def collect(gen: AsyncGenerator[dict, None]) -> list[dict]:
+    return [row async for row in gen]
 
 
 class TestTransformRow:
@@ -9,7 +44,7 @@ class TestTransformRow:
 
     def test_converts_boolean_field_true(self):
         """Boolean field with 'true' string should become True."""
-        row = {"IsActive": "true", "Name": "Test"}
+        row: dict[str, str | None] = {"IsActive": "true", "Name": "Test"}
         boolean_fields = frozenset({"IsActive"})
 
         result = transform_row(row, boolean_fields, CSV_NAME)
@@ -19,7 +54,7 @@ class TestTransformRow:
 
     def test_converts_boolean_field_false(self):
         """Boolean field with 'false' string should become False."""
-        row = {"IsActive": "false", "Name": "Test"}
+        row: dict[str, str | None] = {"IsActive": "false", "Name": "Test"}
         boolean_fields = frozenset({"IsActive"})
 
         result = transform_row(row, boolean_fields, CSV_NAME)
@@ -28,7 +63,7 @@ class TestTransformRow:
 
     def test_converts_boolean_field_case_insensitive(self):
         """Boolean conversion should be case-insensitive."""
-        row = {"IsActive": "TRUE", "IsEnabled": "False", "IsValid": "TrUe"}
+        row: dict[str, str | None] = {"IsActive": "TRUE", "IsEnabled": "False", "IsValid": "TrUe"}
         boolean_fields = frozenset({"IsActive", "IsEnabled", "IsValid"})
 
         result = transform_row(row, boolean_fields, CSV_NAME)
@@ -39,7 +74,7 @@ class TestTransformRow:
 
     def test_boolean_field_none_becomes_false(self):
         """Boolean field with None value should become False."""
-        row = {"IsActive": None, "Name": "Test"}
+        row: dict[str, str | None] = {"IsActive": None, "Name": "Test"}
         boolean_fields = frozenset({"IsActive"})
 
         result = transform_row(row, boolean_fields, CSV_NAME)
@@ -48,7 +83,7 @@ class TestTransformRow:
 
     def test_multiple_boolean_fields(self):
         """Multiple boolean fields should all be converted."""
-        row = {"IsActive": "true", "IsDeleted": "false", "IsEnabled": "true"}
+        row: dict[str, str | None] = {"IsActive": "true", "IsDeleted": "false", "IsEnabled": "true"}
         boolean_fields = frozenset({"IsActive", "IsDeleted", "IsEnabled"})
 
         result = transform_row(row, boolean_fields, CSV_NAME)
@@ -59,7 +94,7 @@ class TestTransformRow:
 
     def test_meta_op_delete_when_isdelete_true(self):
         """_meta.op should be 'd' when IsDelete is True."""
-        row = {"IsDelete": "True", "Name": "Test"}
+        row: dict[str, str | None] = {"IsDelete": "True", "Name": "Test"}
         boolean_fields = frozenset()
 
         result = transform_row(row, boolean_fields, CSV_NAME)
@@ -68,7 +103,7 @@ class TestTransformRow:
 
     def test_meta_op_update_when_isdelete_empty(self):
         """_meta.op should be 'u' when IsDelete is empty string."""
-        row = {"IsDelete": "", "Name": "Test"}
+        row: dict[str, str | None] = {"IsDelete": "", "Name": "Test"}
         boolean_fields = frozenset()
 
         result = transform_row(row, boolean_fields, CSV_NAME)
@@ -77,7 +112,7 @@ class TestTransformRow:
 
     def test_meta_op_update_when_isdelete_false(self):
         """_meta.op should be 'u' when IsDelete is 'False' and converted to bool."""
-        row = {"IsDelete": "False", "Name": "Test"}
+        row: dict[str, str | None] = {"IsDelete": "False", "Name": "Test"}
         boolean_fields = frozenset({"IsDelete"})
 
         result = transform_row(row, boolean_fields, CSV_NAME)
@@ -87,7 +122,7 @@ class TestTransformRow:
 
     def test_mutates_row_in_place(self):
         """transform_row should mutate the row in place and return it."""
-        row = {"IsActive": "true"}
+        row: dict[str, str | None] = {"IsActive": "true"}
         boolean_fields = frozenset({"IsActive"})
 
         result = transform_row(row, boolean_fields, CSV_NAME)
@@ -95,3 +130,154 @@ class TestTransformRow:
         assert result is row
         assert row["IsActive"] is True
         assert "_meta" in row
+
+
+class TestOrderKey:
+    def test_versionnumber_drives_comparison(self):
+        a = make_row("X", "10")
+        b = make_row("X", "20")
+        assert order_key(a) < order_key(b)
+
+    def test_sink_modified_on_breaks_ties(self):
+        a = make_row("X", "10", sink_modified_on="4/29/2026 9:01:26 PM")
+        b = make_row("X", "10", sink_modified_on="4/29/2026 9:01:27 PM")
+        assert order_key(a) < order_key(b)
+
+    @pytest.mark.parametrize("missing_field", ["versionnumber", "SinkModifiedOn"])
+    def test_missing_required_field_raises(self, missing_field: str):
+        row = make_row("X", "10")
+        row[missing_field] = None
+        with pytest.raises(ValueError, match="missing required ordering fields"):
+            order_key(row)
+
+
+class TestDeferDeletes:
+    """Tests for the per-folder delete-deferral state machine."""
+
+    @pytest.mark.asyncio
+    async def test_in_order_passthrough(self):
+        rows = [
+            make_row("A", "10"),
+            make_row("B", "20"),
+            make_row("A", "30"),
+        ]
+        result = await collect(defer_deletes(as_async_gen(rows)))
+        assert [(r["Id"], r["versionnumber"]) for r in result] == [
+            ("A", "10"),
+            ("B", "20"),
+            ("A", "30"),
+        ]
+
+    @pytest.mark.asyncio
+    async def test_delete_emitted_at_end(self):
+        """A delete is buffered and only emitted after all upserts."""
+        rows = [
+            make_row("A", "10"),
+            make_row("A", "20", is_delete=True),
+            make_row("B", "30"),
+        ]
+        result = await collect(defer_deletes(as_async_gen(rows)))
+        assert [(r["Id"], r["versionnumber"], r["IsDelete"]) for r in result] == [
+            ("A", "10", False),
+            ("B", "30", False),
+            ("A", "20", True),
+        ]
+
+    @pytest.mark.asyncio
+    async def test_delete_then_recreate_coalesces_delete(self):
+        rows = [
+            make_row("A", "10", is_delete=True),
+            make_row("A", "20"),
+        ]
+        result = await collect(defer_deletes(as_async_gen(rows)))
+        assert [(r["Id"], r["versionnumber"], r["IsDelete"]) for r in result] == [
+            ("A", "20", False),
+        ]
+
+    @pytest.mark.asyncio
+    async def test_recreate_then_stale_delete_arrives_first(self):
+        rows = [
+            make_row("A", "20"),
+            make_row("A", "10", is_delete=True),
+        ]
+        result = await collect(defer_deletes(as_async_gen(rows)))
+        assert [(r["Id"], r["versionnumber"], r["IsDelete"]) for r in result] == [
+            ("A", "20", False),
+        ]
+
+    @pytest.mark.asyncio
+    async def test_insert_delete_recreate_same_id(self):
+        """insert@10, delete@20, recreate@30 — recreate wins, delete dropped."""
+        rows = [
+            make_row("A", "10"),
+            make_row("A", "20", is_delete=True),
+            make_row("A", "30"),
+        ]
+        result = await collect(defer_deletes(as_async_gen(rows)))
+        assert [(r["Id"], r["versionnumber"], r["IsDelete"]) for r in result] == [
+            ("A", "10", False),
+            ("A", "30", False),
+        ]
+
+    @pytest.mark.asyncio
+    async def test_multiple_deletes_keep_highest(self):
+        """When multiple deletes for one Id arrive, only the highest survives."""
+        rows = [
+            make_row("A", "10", is_delete=True),
+            make_row("A", "30", is_delete=True),
+            make_row("A", "20", is_delete=True),
+        ]
+        result = await collect(defer_deletes(as_async_gen(rows)))
+        assert [(r["Id"], r["versionnumber"], r["IsDelete"]) for r in result] == [
+            ("A", "30", True),
+        ]
+
+    @pytest.mark.asyncio
+    async def test_state_resets_between_folders(self):
+        """A new call has fresh state; deletes are not silently suppressed."""
+        # First call: emit insert@10
+        first = await collect(defer_deletes(
+            as_async_gen([make_row("A", "10")]),
+        ))
+        assert len(first) == 1
+
+        # Second call (next folder): delete@20 should emit since state is
+        # not carried across calls.
+        second = await collect(defer_deletes(
+            as_async_gen([make_row("A", "20", is_delete=True)]),
+        ))
+        assert [(r["Id"], r["IsDelete"]) for r in second] == [("A", True)]
+
+    @pytest.mark.asyncio
+    async def test_equal_versionnumber_tiebreaker(self):
+        """Equal versionnumber falls back to SinkModifiedOn."""
+        rows = [
+            make_row("A", "10", sink_modified_on="4/29/2026 9:01:26 PM"),
+            make_row(
+                "A", "10",
+                is_delete=True,
+                sink_modified_on="4/29/2026 9:01:27 PM",
+            ),
+        ]
+        result = await collect(defer_deletes(as_async_gen(rows)))
+        # Delete has higher SinkModifiedOn, so it wins.
+        assert [(r["Id"], r["IsDelete"]) for r in result] == [
+            ("A", False),
+            ("A", True),
+        ]
+
+    @pytest.mark.asyncio
+    async def test_stale_upsert_dropped(self):
+        """
+        An upsert with a lower versionnumber than one already
+        emitted for the same Id should be dropped.
+        """
+        rows = [
+            make_row("A", "30"),
+            make_row("A", "10"),
+        ]
+        result = await collect(defer_deletes(as_async_gen(rows)))
+        assert [(r["Id"], r["versionnumber"]) for r in result] == [
+            ("A", "30"),
+        ]
+

--- a/source-dynamics-365-finance-and-operations/tests/test_api.py
+++ b/source-dynamics-365-finance-and-operations/tests/test_api.py
@@ -1,6 +1,9 @@
 from source_dynamics_365_finance_and_operations.api import transform_row
 
 
+CSV_NAME = "2026-01-01T00:00:00.000Z/Table/data.csv"
+
+
 class TestTransformRow:
     """Tests for the transform_row helper function."""
 
@@ -9,7 +12,7 @@ class TestTransformRow:
         row = {"IsActive": "true", "Name": "Test"}
         boolean_fields = frozenset({"IsActive"})
 
-        result = transform_row(row, boolean_fields)
+        result = transform_row(row, boolean_fields, CSV_NAME)
 
         assert result["IsActive"] is True
         assert result["Name"] == "Test"
@@ -19,7 +22,7 @@ class TestTransformRow:
         row = {"IsActive": "false", "Name": "Test"}
         boolean_fields = frozenset({"IsActive"})
 
-        result = transform_row(row, boolean_fields)
+        result = transform_row(row, boolean_fields, CSV_NAME)
 
         assert result["IsActive"] is False
 
@@ -28,7 +31,7 @@ class TestTransformRow:
         row = {"IsActive": "TRUE", "IsEnabled": "False", "IsValid": "TrUe"}
         boolean_fields = frozenset({"IsActive", "IsEnabled", "IsValid"})
 
-        result = transform_row(row, boolean_fields)
+        result = transform_row(row, boolean_fields, CSV_NAME)
 
         assert result["IsActive"] is True
         assert result["IsEnabled"] is False
@@ -39,7 +42,7 @@ class TestTransformRow:
         row = {"IsActive": None, "Name": "Test"}
         boolean_fields = frozenset({"IsActive"})
 
-        result = transform_row(row, boolean_fields)
+        result = transform_row(row, boolean_fields, CSV_NAME)
 
         assert result["IsActive"] is False
 
@@ -48,7 +51,7 @@ class TestTransformRow:
         row = {"IsActive": "true", "IsDeleted": "false", "IsEnabled": "true"}
         boolean_fields = frozenset({"IsActive", "IsDeleted", "IsEnabled"})
 
-        result = transform_row(row, boolean_fields)
+        result = transform_row(row, boolean_fields, CSV_NAME)
 
         assert result["IsActive"] is True
         assert result["IsDeleted"] is False
@@ -59,35 +62,35 @@ class TestTransformRow:
         row = {"IsDelete": "True", "Name": "Test"}
         boolean_fields = frozenset()
 
-        result = transform_row(row, boolean_fields)
+        result = transform_row(row, boolean_fields, CSV_NAME)
 
-        assert result["_meta"] == {"op": "d"}
+        assert result["_meta"] == {"op": "d", "source_file": CSV_NAME}
 
     def test_meta_op_update_when_isdelete_empty(self):
         """_meta.op should be 'u' when IsDelete is empty string."""
         row = {"IsDelete": "", "Name": "Test"}
         boolean_fields = frozenset()
 
-        result = transform_row(row, boolean_fields)
+        result = transform_row(row, boolean_fields, CSV_NAME)
 
-        assert result["_meta"] == {"op": "u"}
+        assert result["_meta"] == {"op": "u", "source_file": CSV_NAME}
 
     def test_meta_op_update_when_isdelete_false(self):
         """_meta.op should be 'u' when IsDelete is 'False' and converted to bool."""
         row = {"IsDelete": "False", "Name": "Test"}
         boolean_fields = frozenset({"IsDelete"})
 
-        result = transform_row(row, boolean_fields)
+        result = transform_row(row, boolean_fields, CSV_NAME)
 
         assert result["IsDelete"] is False
-        assert result["_meta"] == {"op": "u"}
+        assert result["_meta"] == {"op": "u", "source_file": CSV_NAME}
 
     def test_mutates_row_in_place(self):
         """transform_row should mutate the row in place and return it."""
         row = {"IsActive": "true"}
         boolean_fields = frozenset({"IsActive"})
 
-        result = transform_row(row, boolean_fields)
+        result = transform_row(row, boolean_fields, CSV_NAME)
 
         assert result is row
         assert row["IsActive"] is True


### PR DESCRIPTION
**Description:**

Within a single timestamp folder, the connector previously emitted rows in the order they appeared across CSV files. CSVs are sorted by `last_modified_datetime`, which doesn't necessarily track the actual source commit order: deletions can live in a file last modified before the file containing the corresponding upsert, so a delete could land at the destination before the upsert it logically follows. This causes rows to be materialized when they should be soft/hard deleted instead.

This PR introduces `defer_deletes`, an async generator that wraps the per-folder row stream with a small state machine:
- Upserts are yielded immediately, unless an upsert with a higher `versionnumber` for the same `Id` has already gone out.
- Deletes are buffered, keyed by `Id`, keeping only the highest `versionnumber` delete per `Id`.
- At the end of the folder, each buffered delete is yielded only if no upsert with a higher `versionnumber` for that Id was yielded while streaming rows.

`versionnumber` is the source-of-truth ordering primitive; `SinkModifiedOn` serves as a defensive tiebreaker for the unexpected case of two rows sharing a `versionnumber`. This aligns with guidance provided in the official [Microsoft documentation](https://learn.microsoft.com/en-us/power-apps/maker/data-platform/export-data-lake-faq#how-do-i-retrieve-the-most-up-to-date-row-of-each-record-and-exclude-deleted-rows-when-i-export-data-in-append-only-mode) for retrieving the most up to date version of a row.

One tradeoff of this approach is that a delete superseded by a later recreate for the same `Id` within one folder is coalesced away. In order to preserve every event in the correct order, all files' rows within a single timestamp folder would need buffered in memory and sorted before yielding any of them. I have concerns that would undo some of the hard-won memory and CPU efficiency gains we've made on this connector, so I'm opting to go with this more efficient "buffer deletions in memory and emit them at the end" approach instead.

Also, I added a `_meta/source_file` field to each document to tie each emitted document back to the file it was read from. This probably won't be super helpful for end users, but it'll save us time debugging in the future figuring out where a certain document came from.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

