### PR TITLE
source-shopify-native: add some fields to `orders`

### DIFF
--- a/source-shopify-native/source_shopify_native/graphql/orders/orders.py
+++ b/source-shopify-native/source_shopify_native/graphql/orders/orders.py
@@ -15,6 +15,7 @@ class Orders(ShopifyGraphQLResource):
     QUERY = """
     app {
         id
+        name
     }
     billingAddress {
         id
@@ -146,7 +147,25 @@ class Orders(ShopifyGraphQLResource):
                 index
                 targetSelection
                 targetType
-                value
+                value {
+                    __typename
+                    ... on MoneyV2 {
+                        amount
+                        currencyCode
+                    }
+                    ... on PricingPercentageValue {
+                        percentage
+                    }
+                }
+                ... on AutomaticDiscountApplication {
+                    title
+                }
+                ... on ManualDiscountApplication {
+                    title
+                }
+                ... on ScriptDiscountApplication {
+                    title
+                }
             }
         }
     }

--- a/source-shopify-native/tests/snapshots/snapshots__capture__capture.stdout.json
+++ b/source-shopify-native/tests/snapshots/snapshots__capture__capture.stdout.json
@@ -444,7 +444,8 @@
         "uuid": "DocUUIDPlaceholder-329Bb50aa48EAa9ef"
       },
       "app": {
-        "id": "gid://shopify/App/1354745"
+        "id": "gid://shopify/App/1354745",
+        "name": "Draft Orders"
       },
       "billingAddress": null,
       "cancelReason": null,

--- a/source-shopify-native/tests/snapshots/snapshots__capture__capture.stdout.json
+++ b/source-shopify-native/tests/snapshots/snapshots__capture__capture.stdout.json
@@ -1124,9 +1124,9 @@
         "store": "estuary-alex-testing",
         "uuid": "DocUUIDPlaceholder-329Bb50aa48EAa9ef"
       },
-      "canDeactivate": false,
+      "canDeactivate": true,
       "createdAt": "2025-01-14T15:10:14Z",
-      "deactivationAlert": "Can't unstock from this location because it has committed inventory.",
+      "deactivationAlert": null,
       "id": "gid://shopify/InventoryLevel/108219858989?inventory_item_id=45258934976557",
       "item": {
         "id": "gid://shopify/InventoryItem/45258934976557",


### PR DESCRIPTION
**Description:**

- `app.name`
- `title` for the concrete types that have it and implement the `discountApplications` interface
- actually fill out the `value` object for `discountApplications`

**Notes for reviewers:**

These should all be free to add since they don't require any new scopes or additional connections beyond what we were already using.

