### PR TITLE
materialize-s3-iceberg: add additional_table_properties resource field

### DIFF
--- a/materialize-s3-iceberg/.snapshots/TestSpec
+++ b/materialize-s3-iceberg/.snapshots/TestSpec
@@ -339,6 +339,14 @@
         "title": "Delta Update",
         "description": "Should updates to this table be done via delta updates. Currently this connector only supports delta updates.",
         "default": true
+      },
+      "additional_table_properties": {
+        "additionalProperties": {
+          "type": "string"
+        },
+        "type": "object",
+        "title": "Additional Table Properties",
+        "description": "Additional Iceberg table properties to set when the table is created. These are set only at creation time and cannot be changed afterwards. Example: {'write.parquet.compression-codec': 'zstd'}"
       }
     },
     "type": "object",

--- a/materialize-s3-iceberg/catalog.go
+++ b/materialize-s3-iceberg/catalog.go
@@ -109,8 +109,11 @@ func (c *catalog) createNamespace(ctx context.Context, namespace string) error {
 	return err
 }
 
-func (c *catalog) CreateResource(ctx context.Context, b *pf.MaterializationSpec_Binding) (string, boilerplate.ActionApplyFn, error) {
-	tc := tableCreate{Location: tablePath(c.cfg.Bucket, c.cfg.Prefix, b.ResourcePath[0], b.ResourcePath[1], c.locationStyle)}
+func (c *catalog) CreateResource(ctx context.Context, b *pf.MaterializationSpec_Binding, res resource) (string, boilerplate.ActionApplyFn, error) {
+	tc := tableCreate{
+		Location:   tablePath(c.cfg.Bucket, c.cfg.Prefix, b.ResourcePath[0], b.ResourcePath[1], c.locationStyle),
+		Properties: res.AdditionalTableProperties,
+	}
 
 	parquetSchema, err := parquetSchema(b.FieldSelection.AllFields(), b.Collection, b.FieldSelection.FieldConfigJsonMap)
 	if err != nil {

--- a/materialize-s3-iceberg/driver.go
+++ b/materialize-s3-iceberg/driver.go
@@ -190,9 +190,10 @@ func parse8601(in string) (time.Duration, error) {
 }
 
 type resource struct {
-	Table     string `json:"table" jsonschema:"title=Table,description=Name of the database table." jsonschema_extras:"x-collection-name=true"`
-	Namespace string `json:"namespace,omitempty" jsonschema:"title=Alternative Namespace,description=Alternative namespace for this table (optional)."`
-	Delta     *bool  `json:"delta_updates,omitempty" jsonschema:"default=true,title=Delta Update,description=Should updates to this table be done via delta updates. Currently this connector only supports delta updates."`
+	Table                     string            `json:"table" jsonschema:"title=Table,description=Name of the database table." jsonschema_extras:"x-collection-name=true"`
+	Namespace                 string            `json:"namespace,omitempty" jsonschema:"title=Alternative Namespace,description=Alternative namespace for this table (optional)."`
+	Delta                     *bool             `json:"delta_updates,omitempty" jsonschema:"default=true,title=Delta Update,description=Should updates to this table be done via delta updates. Currently this connector only supports delta updates."`
+	AdditionalTableProperties map[string]string `json:"additional_table_properties,omitempty" jsonschema:"title=Additional Table Properties,description=Additional Iceberg table properties to set when the table is created. These are set only at creation time and cannot be changed afterwards. Example: {'write.parquet.compression-codec': 'zstd'}"`
 }
 
 func pathToFQN(p []string) string {
@@ -427,7 +428,7 @@ func (d *materialization) CreateNamespace(ctx context.Context, ns string) (strin
 }
 
 func (d *materialization) CreateResource(ctx context.Context, res boilerplate.MappedBinding[config, resource, mappedType]) (string, boilerplate.ActionApplyFn, error) {
-	return d.catalog.CreateResource(ctx, &res.MaterializationSpec_Binding)
+	return d.catalog.CreateResource(ctx, &res.MaterializationSpec_Binding, res.Config)
 }
 
 func (d *materialization) DeleteResource(ctx context.Context, resourcePath []string) (string, boilerplate.ActionApplyFn, error) {

--- a/materialize-s3-iceberg/iceberg-ctl/iceberg_ctl/__main__.py
+++ b/materialize-s3-iceberg/iceberg-ctl/iceberg_ctl/__main__.py
@@ -337,7 +337,12 @@ def create_table(
     schema = Schema(*columns)
     catalog.create_table(table, schema, table_create.location,
         properties={
-            TableProperties.DEFAULT_NAME_MAPPING: schema.name_mapping.model_dump_json()
+            TableProperties.DEFAULT_NAME_MAPPING: schema.name_mapping.model_dump_json(),
+            "write.metadata.compression-codec": "gzip",
+            "write.metadata.delete-after-commit.enabled": "true",
+            "write.metadata.previous-versions-max": "10",
+            "history.expire.min-snapshots-to-keep": "1",
+            "history.expire.max-snapshot-age-ms": str(24 * 60 * 60 * 1000),
         },
     )
     log(f"create_table: created table {table}")

--- a/materialize-s3-iceberg/iceberg-ctl/iceberg_ctl/__main__.py
+++ b/materialize-s3-iceberg/iceberg-ctl/iceberg_ctl/__main__.py
@@ -307,6 +307,7 @@ def list_namespaces(ctx: Context):
 class TableCreate(BaseModel, extra="forbid"):
     location: str
     fields: list[IcebergColumn]
+    properties: dict[str, str] | None = None
 
 
 @run.command()
@@ -335,16 +336,14 @@ def create_table(
     ]
 
     schema = Schema(*columns)
-    catalog.create_table(table, schema, table_create.location,
-        properties={
-            TableProperties.DEFAULT_NAME_MAPPING: schema.name_mapping.model_dump_json(),
-            "write.metadata.compression-codec": "gzip",
-            "write.metadata.delete-after-commit.enabled": "true",
-            "write.metadata.previous-versions-max": "10",
-            "history.expire.min-snapshots-to-keep": "1",
-            "history.expire.max-snapshot-age-ms": str(24 * 60 * 60 * 1000),
-        },
-    )
+    properties = {TableProperties.DEFAULT_NAME_MAPPING: schema.name_mapping.model_dump_json()}
+    if table_create.properties:
+        for k, v in table_create.properties.items():
+            # Never let a user-supplied key override the name mapping.
+            if k == TableProperties.DEFAULT_NAME_MAPPING:
+                continue
+            properties[k] = v
+    catalog.create_table(table, schema, table_create.location, properties=properties)
     log(f"create_table: created table {table}")
 
 

--- a/materialize-s3-iceberg/icebergctl.go
+++ b/materialize-s3-iceberg/icebergctl.go
@@ -30,8 +30,9 @@ type existingIcebergColumn struct {
 }
 
 type tableCreate struct {
-	Fields   []existingIcebergColumn `json:"fields"`
-	Location string                  `json:"location"`
+	Fields     []existingIcebergColumn `json:"fields"`
+	Location   string                  `json:"location"`
+	Properties map[string]string       `json:"properties,omitempty"`
 }
 
 type tableAlter struct {


### PR DESCRIPTION
Closes #3984

**Description:**

Adds an `additional_table_properties` field to the materialize-s3-iceberg resource config. The map is forwarded through `iceberg-ctl create-table` and merged into the property dict passed to `pyiceberg.catalog.create_table` at table-creation time. Properties are set only when the table is created and cannot be changed afterward.

`pyiceberg.table.TableProperties.DEFAULT_NAME_MAPPING` is filtered out of user input so a binding cannot clobber the name mapping that pyiceberg requires to read the table.

Example resource config:

```json
{
  "table": "my_table",
  "additional_table_properties": {
    "write.metadata.compression-codec": "gzip",
    "write.metadata.delete-after-commit.enabled": "true",
    "write.metadata.previous-versions-max": "10",
    "history.expire.min-snapshots-to-keep": "1",
    "history.expire.max-snapshot-age-ms": "86400000"
  }
}
```

**Workflow steps:**

Applies to newly-created tables. Existing tables are unaffected.

**Documentation links affected:**

None.

**Relationship to `materialize-iceberg`:**

`materialize-iceberg` already exposes an identical `additional_table_properties` resource field (same JSON tag, same title, same description, same "set only at creation" semantics). This PR brings the same user-facing config knob to `materialize-s3-iceberg` so the two connectors behave consistently from the catalog perspective.

Implementation differences are limited to how the property map reaches the catalog:

- `materialize-iceberg` passes the map directly to its Go REST-catalog client in the `createTableRequest.properties` field.
- `materialize-s3-iceberg` JSON-marshals the map into the `iceberg-ctl create-table` invocation; the Python side merges it into the dict handed to `pyiceberg.catalog.create_table` and filters out `DEFAULT_NAME_MAPPING` (which `materialize-iceberg` does not need to guard against because it constructs the catalog request directly).

**Notes for reviewers:**

The first commit on this branch hardcoded a fixed set of metadata-compaction and snapshot-expiration properties; the second commit replaces that with the user-configurable field. Net effect vs main is the new resource field only.
