### PR TITLE
source-iterable-native: expand `list_users` handling for skipping lists when there are consistent transport-level errors

### DIFF
--- a/source-iterable-native/source_iterable_native/api.py
+++ b/source-iterable-native/source_iterable_native/api.py
@@ -168,11 +168,34 @@ async def _fetch_users_in_list(
                     {
                         "list_id": list_id,
                         "attempt": attempt,
-                        "error": str(e),
+                        "error_type": type(e).__name__,
+                        "error_message": str(e),
                     },
                 )
             else:
-                raise
+                # Iterable's /lists/getUsers endpoint can be persistently unable
+                # to deliver a complete response for a specific list, surfacing
+                # as transport-layer failures rather than HTTP errors. We skip
+                # the list after exhausting retries so one bad list can't block the
+                # entire backfill. The `list_users` binding defaults to re-backfilling
+                # per a configurable schedule, so the next backfill cycle will retry fetching
+                # users for any lists that we skip here.
+                #
+                # NOTE: Any documents that were already captured before reaching this else branch
+                # will be emitted and checkpointed into the associated collection. This means we'll
+                # have captured only partial data for the set of list users, which usually isn't ideal,
+                # but given the fickleness of the /lists/getUsers endpoint, partial data seems better than
+                # the alternative of no data if we were to not emit already captured docs or blocking
+                # the backfill on a specific list.
+                log.info(
+                    f"Iterable API consistently failed to stream users of list {list_id}. Checkpointing data captured for this list so far and moving on to the next list.",
+                    {
+                        "list_id": list_id,
+                        "error_type": type(e).__name__,
+                        "error_message": str(e),
+                    },
+                )
+                return
         except HTTPError as e:
             if (
                 e.code == 500 and

--- a/source-iterable-native/source_iterable_native/models.py
+++ b/source-iterable-native/source_iterable_native/models.py
@@ -66,7 +66,6 @@ class EndpointConfig(BaseModel):
             title="list_users Request Timeout",
             default_factory=lambda: timedelta(minutes=30),
             ge=timedelta(minutes=5),
-            le=timedelta(hours=4),
         )]
 
     advanced: Advanced = Field(


### PR DESCRIPTION
**Description:**

This PR's scope includes:
- removing the 4 hour max limit for the configurable `list_users_timeout` setting
- skipping lists that have consistent transport-level errors when backfilling `list_users`. The `list_users` binding defaults to constantly backfilling anyway, so any lists that are skipped in the current backfill will be retried on future backfills.

See individual commits for more details.

**Documentation links affected:**

The connector's documentation should be updated to reflect that there's no longer a 4 hour maximum limit on the `list_users_timeout` setting.

