### PR TITLE
source-dynamics-365-finance-and-operations: add _meta to sourced schemas

### DIFF
--- a/source-dynamics-365-finance-and-operations/source_dynamics_365_finance_and_operations/models.py
+++ b/source-dynamics-365-finance-and-operations/source_dynamics_365_finance_and_operations/models.py
@@ -113,6 +113,37 @@ class BaseTable(BaseCSVRow, extra="allow"):
             "required": [],
         }
 
+        # Add the _meta field.
+        meta_schema = {
+            "additionalProperties": False,
+            "type": "object",
+            "properties": {
+                "op": {
+                    "type": "string",
+                    "maxLength": 1,
+                },
+                "uuid": {
+                    "type": "string",
+                    "format": "uuid",
+                    "minLength": 36,
+                    "maxLength": 36,
+                },
+                "source_file": {
+                    "type": "string",
+                    "maxLength": 1,
+                }
+            },
+            "required": [
+                "op",
+                "source_file",
+                "uuid",
+            ]
+        }
+
+        schema["properties"]["_meta"] = meta_schema
+        schema["required"].append("_meta")
+
+        # Add fields defined in model.json.
         for attr in cls.attributes:
             match attr.dataType:
                 case AttributeDataType.STRING:

--- a/source-dynamics-365-finance-and-operations/tests/test_sourced_schemas.py
+++ b/source-dynamics-365-finance-and-operations/tests/test_sourced_schemas.py
@@ -120,7 +120,32 @@ class TestSourcedSchema:
         assert schema["additionalProperties"] is False
         assert schema["type"] == "object"
         assert "properties" in schema
-        assert schema["required"] == ["Name"]
+        assert schema["required"] == ["Name", "_meta"]
+        assert schema["properties"]["_meta"] == {
+            "additionalProperties": False,
+            "type": "object",
+            "properties": {
+                "op": {
+                    "type": "string",
+                    "maxLength": 1,
+                },
+                "uuid": {
+                    "type": "string",
+                    "format": "uuid",
+                    "minLength": 36,
+                    "maxLength": 36,
+                },
+                "source_file": {
+                    "type": "string",
+                    "maxLength": 1,
+                }
+            },
+            "required": [
+                "op",
+                "source_file",
+                "uuid",
+            ]
+        }
 
     def test_all_types_together(self):
         entity = make_entity("test", [
@@ -138,8 +163,8 @@ class TestSourcedSchema:
 
         schema = model.sourced_schema(log)
 
-        assert len(schema["properties"]) == 9
-        assert len(schema["required"]) == 9
+        assert len(schema["properties"]) == 10
+        assert len(schema["required"]) == 10
         assert schema["properties"]["Id"]["format"] == "uuid"
         assert schema["properties"]["SinkCreatedOn"] == {"type": "string", "minLength": 19, "maxLength": 22}
         assert schema["properties"]["SinkModifiedOn"] == {"type": "string", "minLength": 19, "maxLength": 22}


### PR DESCRIPTION


**Description:**

In PR https://github.com/estuary/connectors/pull/4247, I missed adding the `_meta` field to sourced schemas. This PR fixes that oversight.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

