### PR TITLE
estuary-cdk: implement transactor for ACK management

### DIFF
--- a/estuary-cdk/estuary_cdk/capture/base_capture_connector.py
+++ b/estuary-cdk/estuary_cdk/capture/base_capture_connector.py
@@ -28,6 +28,7 @@ from ..utils import format_error_message, get_running_tasks_info, sort_dict
 from . import Request, Response, Task, request, response
 from ._emit import emit_bytes
 from .common import _ConnectorState
+from .transactor import Transactor
 
 # Default encryption service URL, can be overridden via ENCRYPTION_URL environment variable
 # for local testing with docker gateway addresses like http://172.18.0.1:port
@@ -57,6 +58,12 @@ class BaseCaptureConnector(
     metaclass=abc.ABCMeta,
 ):
     output: BinaryIO = sys.stdout.buffer
+
+    _transactor: Transactor
+    """Constructed during `open`. Coordinates stdout writes for every Task and,
+    when the capture has at least one binding requiring Flow's explicit
+    Acknowledge protocol, lets ACK-requiring Tasks block their checkpoints
+    until Flow confirms persistence."""
 
     @abc.abstractmethod
     async def spec(self, log: FlowLogger, _: request.Spec) -> ConnectorSpec:
@@ -108,7 +115,7 @@ class BaseCaptureConnector(
         return None # No-op by default.
 
     async def acknowledge(self, acknowledge: request.Acknowledge) -> None:
-        return None  # No-op.
+        self._transactor.deliver_ack(acknowledge.checkpoints)
 
     async def handle(
         self,
@@ -140,6 +147,11 @@ class BaseCaptureConnector(
 
             opened, capture = await self.open(log, open)
             await self._emit(Response(opened=opened))
+
+            self._transactor = Transactor(
+                self.output,
+                requires_explicit_acks=opened.explicitAcknowledgements,
+            )
 
             stopping = Task.Stopping()
 
@@ -233,6 +245,7 @@ class BaseCaptureConnector(
                         self.output,
                         stopping,
                         tg,
+                        self._transactor,
                     )
                     log.event.status("Capture started")
                     await capture(task)

--- a/estuary-cdk/estuary_cdk/capture/common.py
+++ b/estuary-cdk/estuary_cdk/capture/common.py
@@ -17,6 +17,7 @@ from typing import (
     TypeVar,
     cast,
 )
+from typing_extensions import override
 
 from pydantic import AwareDatetime, BaseModel, Field, NonNegativeInt
 
@@ -38,6 +39,7 @@ from ..flow import (
 from ..pydantic_polyfill import GenericModel
 from ..utils import json_merge_patch
 from . import Task, request, response
+from .webhook.match import CollectionMatchingSpec, UrlMatch
 
 LogCursor = tuple[str | int] | AwareDatetime | NonNegativeInt
 """LogCursor is a cursor into a logical log of changes.
@@ -189,6 +191,21 @@ class ResourceConfig(BaseResourceConfig):
 
 
 _ResourceConfig = TypeVar("_ResourceConfig", bound=ResourceConfig)
+
+
+class WebhookResourceConfig(BaseResourceConfig):
+    PATH_POINTERS: ClassVar[list[str]] = ["/name"]
+
+    name: str = Field(description="Name of this resource")
+    match_rule: CollectionMatchingSpec = Field(
+        default_factory=lambda: UrlMatch(value="*"),
+        description="Matching spec for routing incoming webhooks to this collection",
+        discriminator="type",
+    )
+
+    @override
+    def path(self) -> list[str]:
+        return [self.name]
 
 
 CRON_REGEX = (
@@ -473,6 +490,7 @@ class Resource(Generic[_BaseDocument, _BaseResourceConfig, _BaseResourceState]):
     schema_inference: bool
     reduction_strategy: ReductionStrategy | None = None
     disable: bool = False
+    requires_explicit_acks: bool = False
 
 
 @dataclass(kw_only=True)
@@ -558,8 +576,6 @@ def resolve_bindings(
     errors: list[str] = []
 
     # Check for routing conflicts between webhook match rules.
-    from .webhook.resources import WebhookResourceConfig
-
     webhook_match_rules = [
         resource.initial_config.match_rule
         for resource in resources
@@ -751,7 +767,11 @@ def open(
             # TaskGroup stays alive until graceful shutdown begins.
             await task.stopping.event.wait()
 
-    return (response.Opened(explicitAcknowledgements=False), _run)
+    requires_explicit_acks = any(
+        rsc.requires_explicit_acks for _, rsc in resolved_bindings
+    )
+
+    return (response.Opened(explicitAcknowledgements=requires_explicit_acks), _run)
 
 
 def open_binding(

--- a/estuary-cdk/estuary_cdk/capture/task.py
+++ b/estuary-cdk/estuary_cdk/capture/task.py
@@ -23,7 +23,7 @@ from ..flow import (
 )
 from ..pydantic_polyfill import GenericModel
 from . import request, response
-from ._emit import emit_from_buffer
+from .transactor import Transactor
 
 
 class Request(GenericModel, Generic[EndpointConfig, ResourceConfig, ConnectorState]):
@@ -102,6 +102,13 @@ class Task:
 
     stopping: Stopping
 
+    transactor: Transactor
+    """Shared Transactor that coordinates stdout writes and Acknowledge pairing."""
+
+    requires_ack: bool
+    """When True, checkpoint() blocks until Flow ACKs the emitted checkpoint.
+    Inherited by children via spawn_child."""
+
     _buffer: tempfile.SpooledTemporaryFile
     _hasher: xxhash.xxh3_128
     _name: str
@@ -120,6 +127,8 @@ class Task:
         output: BinaryIO,
         stopping: Stopping,
         tg: asyncio.TaskGroup,
+        transactor: Transactor,
+        requires_ack: bool = False,
     ):
         self._buffer = tempfile.SpooledTemporaryFile(max_size=self.MAX_BUFFER_MEM)
         self._hasher = xxhash.xxh3_128()
@@ -129,6 +138,8 @@ class Task:
         self.log = log
         self.connector_status = connector_status
         self.stopping = stopping
+        self.transactor = transactor
+        self.requires_ack = requires_ack
 
     def captured(self, binding: int, document: Any):
         """Enqueue the document to be captured under the given binding.
@@ -168,15 +179,53 @@ class Task:
         self._buffer.write(b)
         self._buffer.write(b"\n")
 
-    async def checkpoint(self, state: ConnectorState, merge_patch: bool = True):
-        """Emit previously-queued, captured documents followed by a checkpoint."""
-        await self._emit(
-            Response[Any, Any, ConnectorState](
-                checkpoint=response.Checkpoint(
-                    state=ConnectorStateUpdate(updated=state, mergePatch=merge_patch)
-                )
+    async def _emit_checkpoint(
+        self, state: ConnectorState, merge_patch: bool = True
+    ) -> asyncio.Future[None] | None:
+        checkpoint = Response[Any, Any, ConnectorState](
+            checkpoint=response.Checkpoint(
+                state=ConnectorStateUpdate(updated=state, mergePatch=merge_patch)
             )
         )
+        self._buffer.write(
+            checkpoint.model_dump_json(by_alias=True, exclude_unset=True).encode()
+        )
+        self._buffer.write(b"\n")
+
+        completion = await self.transactor.commit(
+            self._buffer, wait_for_ack=self.requires_ack
+        )
+        self.reset()
+
+        return completion
+
+    async def checkpoint(self, state: ConnectorState, merge_patch: bool = True):
+        """Emit previously-queued, captured documents followed by a checkpoint.
+
+        When this Task's `requires_ack` is True, the call blocks on Flow's
+        Acknowledge for the emitted checkpoint before returning.
+
+        Captures are at-least-once: once the buffer has been written to stdout
+        the documents may be durable, regardless of whether this coroutine
+        returns. Cancellation between the write and the ACK can therefore
+        produce a duplicate when the sender retries on the resulting failure."""
+
+        completion = await self._emit_checkpoint(state, merge_patch)
+
+        if completion is None:
+            return
+
+        try:
+            await completion
+        except asyncio.CancelledError:
+            self.log.warning(
+                (
+                    "checkpoint cancelled while awaiting ACK;"
+                    " documents may be durable but caller will see failure"
+                ),
+                {"task": self._name},
+            )
+            raise
 
     def reset(self):
         """Discard any captured documents, resetting to an empty state."""
@@ -205,6 +254,8 @@ class Task:
                         parent._output,
                         parent.stopping,
                         child_tg,
+                        parent.transactor,
+                        parent.requires_ack,
                     )
                     await child(t)
                 except Exception as exc:
@@ -219,12 +270,3 @@ class Task:
         task = self._tg.create_task(run_task(self))
         task.set_name(child_name)
         return task
-
-    async def _emit(self, response: Response[EndpointConfig, ResourceConfig, ConnectorState]):
-        self._buffer.write(
-            response.model_dump_json(by_alias=True, exclude_unset=True).encode()
-        )
-        self._buffer.write(b"\n")
-        self._buffer.seek(0)
-        await emit_from_buffer(self._buffer, self._output)
-        self.reset()

--- a/estuary-cdk/estuary_cdk/capture/transactor.py
+++ b/estuary-cdk/estuary_cdk/capture/transactor.py
@@ -1,0 +1,77 @@
+import asyncio
+from collections import deque
+from typing import BinaryIO
+
+from ._emit import emit_from_buffer
+
+
+class Transactor:
+    """
+    Coordinates stdout writes and pairs each emitted checkpoint with the
+    Acknowledge message that Flow returns once the checkpoint is durably
+    persisted.
+
+    When `requires_explicit_acks` is True, every commit registers a slot in
+    the pending FIFO so its ordering matches the ACK stream. A commit only
+    blocks on the slot when its caller passes `wait_for_ack=True`; otherwise
+    the slot is drained on ACK without anyone awaiting it. When False, no
+    FIFO bookkeeping happens and stray ACKs are ignored.
+    """
+
+    def __init__(self, output: BinaryIO, requires_explicit_acks: bool = False):
+        self._output: BinaryIO = output
+        self._emit_lock: asyncio.Lock = asyncio.Lock()
+        self._pending: deque[asyncio.Future[None] | None] = deque()
+        self._tracks_acks: bool = requires_explicit_acks
+
+    async def commit(
+        self,
+        buffer: BinaryIO,
+        wait_for_ack: bool = False,
+    ) -> asyncio.Future[None] | None:
+        """Emit `buffer` (already containing captured + checkpoint bytes) to
+        stdout in commit order. Returns a future the caller awaits to block
+        until Flow ACKs this checkpoint when `wait_for_ack` is True; otherwise
+        returns None."""
+        _ = buffer.seek(0)
+
+        if not self._tracks_acks:
+            if wait_for_ack:
+                raise RuntimeError(
+                    (
+                        "wait_for_ack=True requires a Transactor constructed with "
+                        "requires_explicit_acks=True"
+                    )
+                )
+            await emit_from_buffer(buffer, self._output)
+            return None
+
+        async with self._emit_lock:
+            completion = (
+                asyncio.get_running_loop().create_future() if wait_for_ack else None
+            )
+            self._pending.append(completion)
+
+            await emit_from_buffer(buffer, self._output)
+
+        return completion
+
+    def deliver_ack(self, count: int) -> None:
+        """Forward an Acknowledge.checkpoints count from Flow, draining the
+        first `count` pending slots and resolving their completion futures."""
+        if not self._tracks_acks:
+            return
+        if count == 0:
+            return
+
+        if count > len(self._pending):
+            raise RuntimeError(
+                f"received ACK for {count} checkpoint(s) but only {len(self._pending)} are pending"
+            )
+
+        for _ in range(count):
+            slot = self._pending.popleft()
+            if slot is None:
+                continue
+            if not slot.done():
+                slot.set_result(None)

--- a/estuary-cdk/estuary_cdk/capture/webhook/resources.py
+++ b/estuary-cdk/estuary_cdk/capture/webhook/resources.py
@@ -1,7 +1,7 @@
 from collections.abc import Sequence
+from dataclasses import dataclass, field
 from datetime import UTC, datetime
-from typing import ClassVar, Generic, TypeVar
-from typing_extensions import override
+from typing import Generic, TypeVar
 from uuid import uuid4
 from pydantic import BaseModel, Field
 from estuary_cdk.capture.common import (
@@ -9,14 +9,13 @@ from estuary_cdk.capture.common import (
     BaseResourceConfig,
     Resource,
     ResourceState,
+    WebhookResourceConfig,
     open_binding,
 )
 from estuary_cdk.capture.task import Task
 from estuary_cdk.capture.webhook.match import (
     CollectionDiscriminatorSpec,
-    CollectionMatchingSpec,
     UrlDiscriminator,
-    UrlMatch,
 )
 from estuary_cdk.flow import CaptureBinding
 
@@ -40,21 +39,21 @@ class WebhookDocument(BaseDocument):
 
 
 _WebhookDocument = TypeVar("_WebhookDocument", bound=WebhookDocument)
+_WebhookResourceConfig = TypeVar("_WebhookResourceConfig", bound=BaseResourceConfig)
 
 
-class WebhookResourceConfig(BaseResourceConfig):
-    PATH_POINTERS: ClassVar[list[str]] = ["/name"]
+@dataclass(kw_only=True)
+class WebhookResource(
+    Resource[_WebhookDocument, _WebhookResourceConfig, ResourceState]
+):
+    """A Resource for webhook bindings with standard defaults."""
 
-    name: str = Field(description="Name of this resource")
-    match_rule: CollectionMatchingSpec = Field(
-        default_factory=lambda: UrlMatch(value="*"),
-        description="Matching spec for routing incoming webhooks to this collection",
-        discriminator="type",
+    key: list[str] = field(default_factory=lambda: ["/_meta/webhookId"])
+    model: type[_WebhookDocument] | Resource.FixedSchema = field(
+        default=WebhookDocument  # pyright: ignore[reportAssignmentType]
     )
-
-    @override
-    def path(self) -> list[str]:
-        return [self.name]
+    initial_state: ResourceState = field(default_factory=ResourceState)
+    requires_explicit_acks: bool = True
 
 
 def open_webhook_binding(
@@ -65,7 +64,7 @@ def open_webhook_binding(
     all_bindings: Sequence[
         tuple[
             CaptureBinding[BaseResourceConfig],
-            Resource[_WebhookDocument, BaseResourceConfig, ResourceState],
+            Resource[BaseDocument, BaseResourceConfig, ResourceState],
         ]
     ],
 ):
@@ -82,10 +81,12 @@ def open_webhook_binding(
     if task.stopping.webhook_task is None:
         from estuary_cdk.capture.webhook.server import start_webhook_server
 
-        webhook_bindings = {
+        webhook_bindings: dict[
+            int, WebhookResource[WebhookDocument, WebhookResourceConfig]
+        ] = {
             idx: rsc
             for idx, (_, rsc) in enumerate(all_bindings)
-            if isinstance(rsc.initial_config, WebhookResourceConfig)
+            if isinstance(rsc, WebhookResource)
         }
         start_webhook_server(webhook_bindings, task)
 
@@ -113,15 +114,14 @@ class WebhookCaptureSpec(BaseModel, Generic[_WebhookDocument]):
 
     def create_resources(
         self,
-    ) -> list[Resource[_WebhookDocument, WebhookResourceConfig, ResourceState]]:
+    ) -> list[WebhookResource[_WebhookDocument, WebhookResourceConfig]]:
         if self.discriminator == CATCH_ALL_DISCRIMINATOR:
             return [
-                Resource(
+                WebhookResource(
                     name=self.name,
                     key=self.key,
                     model=self.document_model,
                     open=open_webhook_binding,  # pyright: ignore[reportArgumentType]
-                    initial_state=ResourceState(),
                     initial_config=WebhookResourceConfig(
                         name=self.name,
                         match_rule=CATCH_ALL_DISCRIMINATOR.for_value("*"),
@@ -131,12 +131,10 @@ class WebhookCaptureSpec(BaseModel, Generic[_WebhookDocument]):
             ]
 
         return [
-            Resource(
+            WebhookResource(
                 name=f"{self.name}_{rule.display_name}",
-                key=["/_meta/webhookId"],
                 model=self.document_model,
                 open=open_webhook_binding,  # pyright: ignore[reportArgumentType]
-                initial_state=ResourceState(),
                 initial_config=WebhookResourceConfig(
                     name=f"{self.name}_{rule.display_name}",
                     match_rule=rule,

--- a/estuary-cdk/estuary_cdk/capture/webhook/server.py
+++ b/estuary-cdk/estuary_cdk/capture/webhook/server.py
@@ -14,8 +14,9 @@ from estuary_cdk.capture.common import (
     Resource,
     ResourceState,
     Task,
+    WebhookResourceConfig,
 )
-from estuary_cdk.capture.webhook.resources import WebhookDocument, WebhookResourceConfig
+from estuary_cdk.capture.webhook.resources import WebhookDocument, WebhookResource
 
 _rejecting_key = web.AppKey("rejecting", bool)
 
@@ -155,9 +156,7 @@ def build_webhook_app(
             for doc in enriched_docs:
                 task.captured(doc.binding, doc.doc)
 
-            await task.checkpoint(
-                state=ConnectorState()  # pyright: ignore[reportUnknownArgumentType]
-            )
+            await task.checkpoint(state=ConnectorState())
 
         return web.json_response({"published": len(enriched_docs)})
 
@@ -168,7 +167,7 @@ def build_webhook_app(
 
 def start_webhook_server(
     binding_index_mapping: Mapping[
-        int, Resource[WebhookDocument, WebhookResourceConfig, ResourceState]
+        int, WebhookResource[WebhookDocument, WebhookResourceConfig]
     ],
     task: Task,
 ):
@@ -199,6 +198,8 @@ def start_webhook_server(
                 task._output,  # pyright: ignore[reportPrivateUsage]
                 task.stopping,
                 webhook_tg,
+                task.transactor,
+                requires_ack=True,
             )
 
             app = build_webhook_app(binding_index_mapping, webhook_task)

--- a/estuary-cdk/tests/test_transactor.py
+++ b/estuary-cdk/tests/test_transactor.py
@@ -1,0 +1,202 @@
+import asyncio
+import io
+
+import pytest
+
+from estuary_cdk.capture.transactor import Transactor
+
+
+def _buffer(payload: bytes = b"hello\n") -> io.BytesIO:
+    """Build a buffer positioned at 0 for emit_from_buffer to drain."""
+    buf = io.BytesIO()
+    _ = buf.write(payload)
+    _ = buf.seek(0)
+    return buf
+
+
+async def _yield_until_pending(transactor: Transactor, expected: int) -> None:
+    """Spin the event loop until `expected` slots are pending, or fail."""
+
+    async def wait() -> None:
+        while (
+            len(transactor._pending) < expected  # pyright: ignore[reportPrivateUsage]
+        ):
+            await asyncio.sleep(0)
+
+    await asyncio.wait_for(wait(), timeout=1.0)
+
+
+async def _commit_then_wait(transactor: Transactor, buf: io.BytesIO) -> None:
+    """Drive a full waiting commit: emit, then block on the ACK future."""
+    completion = await transactor.commit(buf, wait_for_ack=True)
+    assert completion is not None
+    await completion
+
+
+class TestTransactor:
+    @pytest.mark.asyncio
+    async def test_commit_without_ack_tracking_emits_and_returns_no_future(self):
+        output = io.BytesIO()
+        transactor = Transactor(output)
+
+        completion = await transactor.commit(_buffer(b"line\n"), wait_for_ack=False)
+
+        assert completion is None
+        assert output.getvalue() == b"line\n"
+        assert len(transactor._pending) == 0  # pyright: ignore[reportPrivateUsage]
+
+    @pytest.mark.asyncio
+    async def test_wait_for_ack_on_untracked_transactor_raises(self):
+        output = io.BytesIO()
+        transactor = Transactor(output)
+
+        with pytest.raises(RuntimeError, match="requires_explicit_acks=True"):
+            await transactor.commit(_buffer(b"line\n"), wait_for_ack=True)
+
+    @pytest.mark.asyncio
+    async def test_commit_blocks_until_ack(self):
+        output = io.BytesIO()
+        transactor = Transactor(output, requires_explicit_acks=True)
+
+        commit_task = asyncio.create_task(
+            _commit_then_wait(transactor, _buffer(b"line\n"))
+        )
+        await _yield_until_pending(transactor, 1)
+        assert not commit_task.done()
+        assert (
+            output.getvalue() == b"line\n"
+        ), "buffer is emitted before the ACK arrives"
+
+        transactor.deliver_ack(1)
+        await asyncio.wait_for(commit_task, timeout=1.0)
+
+    @pytest.mark.asyncio
+    async def test_fire_and_forget_returns_before_ack(self):
+        """When ACK tracking is on but the caller doesn't need to wait (a
+        pull-API checkpoint in a mixed connector), commit() returns as soon
+        as the buffer is on stdout. The slot still sits in the FIFO until
+        Flow's ACK drains it."""
+        output = io.BytesIO()
+        transactor = Transactor(output, requires_explicit_acks=True)
+
+        await transactor.commit(_buffer(b"line\n"), wait_for_ack=False)
+
+        assert output.getvalue() == b"line\n"
+        assert len(transactor._pending) == 1  # pyright: ignore[reportPrivateUsage]
+
+        transactor.deliver_ack(1)
+        assert len(transactor._pending) == 0  # pyright: ignore[reportPrivateUsage]
+
+    @pytest.mark.asyncio
+    async def test_mixed_waiting_and_fire_and_forget_drain_in_order(self):
+        """A pull-API commit's slot drains correctly even when interleaved
+        with a webhook commit that is awaiting its own ACK."""
+        output = io.BytesIO()
+        transactor = Transactor(output, requires_explicit_acks=True)
+
+        await transactor.commit(_buffer(b"a\n"), wait_for_ack=False)
+        webhook = asyncio.create_task(
+            _commit_then_wait(transactor, _buffer(b"b\n"))
+        )
+        await _yield_until_pending(transactor, 2)
+
+        transactor.deliver_ack(1)  # drains the fire-and-forget slot
+        assert not webhook.done(), "webhook commit must wait for its own ACK"
+
+        transactor.deliver_ack(1)
+        await asyncio.wait_for(webhook, timeout=1.0)
+        assert output.getvalue() == b"a\nb\n"
+
+    @pytest.mark.asyncio
+    async def test_concurrent_waiting_commits_resolve_in_arrival_order(self):
+        output = io.BytesIO()
+        transactor = Transactor(output, requires_explicit_acks=True)
+
+        first = asyncio.create_task(_commit_then_wait(transactor, _buffer(b"a\n")))
+        second = asyncio.create_task(_commit_then_wait(transactor, _buffer(b"b\n")))
+        await _yield_until_pending(transactor, 2)
+
+        assert not first.done() and not second.done()
+
+        transactor.deliver_ack(1)
+        await asyncio.wait_for(first, timeout=1.0)
+        assert not second.done(), "second commit must wait for its own ACK"
+
+        transactor.deliver_ack(1)
+        await asyncio.wait_for(second, timeout=1.0)
+        assert output.getvalue() == b"a\nb\n"
+
+    @pytest.mark.asyncio
+    async def test_batched_ack_resolves_multiple_commits(self):
+        output = io.BytesIO()
+        transactor = Transactor(output, requires_explicit_acks=True)
+
+        first = asyncio.create_task(_commit_then_wait(transactor, _buffer(b"a\n")))
+        second = asyncio.create_task(_commit_then_wait(transactor, _buffer(b"b\n")))
+        await _yield_until_pending(transactor, 2)
+
+        transactor.deliver_ack(2)
+        await asyncio.wait_for(first, timeout=1.0)
+        await asyncio.wait_for(second, timeout=1.0)
+
+    @pytest.mark.asyncio
+    async def test_ack_without_pending_checkpoint_raises(self):
+        output = io.BytesIO()
+        transactor = Transactor(output, requires_explicit_acks=True)
+
+        with pytest.raises(RuntimeError, match="only 0 are pending"):
+            transactor.deliver_ack(1)
+
+    @pytest.mark.asyncio
+    async def test_ack_exceeding_pending_count_raises(self):
+        output = io.BytesIO()
+        transactor = Transactor(output, requires_explicit_acks=True)
+
+        commit_task = asyncio.create_task(_commit_then_wait(transactor, _buffer()))
+        await _yield_until_pending(transactor, 1)
+
+        with pytest.raises(RuntimeError, match="only 1 are pending"):
+            transactor.deliver_ack(2)
+
+        transactor.deliver_ack(1)
+        await asyncio.wait_for(commit_task, timeout=1.0)
+
+    @pytest.mark.asyncio
+    async def test_deliver_zero_is_noop(self):
+        output = io.BytesIO()
+        transactor = Transactor(output, requires_explicit_acks=True)
+
+        commit_task = asyncio.create_task(_commit_then_wait(transactor, _buffer()))
+        await _yield_until_pending(transactor, 1)
+
+        transactor.deliver_ack(0)
+        assert not commit_task.done()
+
+        transactor.deliver_ack(1)
+        await asyncio.wait_for(commit_task, timeout=1.0)
+
+    @pytest.mark.asyncio
+    async def test_untracked_acks_are_ignored(self):
+        """When ACK tracking is disabled, deliver_ack is a no-op even with a
+        non-zero count, so pull-only connectors can ignore stray ACKs."""
+        output = io.BytesIO()
+        transactor = Transactor(output)
+
+        transactor.deliver_ack(5)
+
+    @pytest.mark.asyncio
+    async def test_reusable_after_full_drain(self):
+        """After a full commit/ack/drain cycle, the Transactor accepts new
+        commits and drains them correctly."""
+        output = io.BytesIO()
+        transactor = Transactor(output, requires_explicit_acks=True)
+
+        first = asyncio.create_task(_commit_then_wait(transactor, _buffer(b"a\n")))
+        await _yield_until_pending(transactor, 1)
+        transactor.deliver_ack(1)
+        await asyncio.wait_for(first, timeout=1.0)
+
+        second = asyncio.create_task(_commit_then_wait(transactor, _buffer(b"b\n")))
+        await _yield_until_pending(transactor, 1)
+        transactor.deliver_ack(1)
+        await asyncio.wait_for(second, timeout=1.0)

--- a/estuary-cdk/tests/test_webhook_resources.py
+++ b/estuary-cdk/tests/test_webhook_resources.py
@@ -1,12 +1,14 @@
+from unittest.mock import MagicMock
+
+from estuary_cdk.capture import common
+from estuary_cdk.capture.common import WebhookResourceConfig
 from estuary_cdk.capture.webhook.match import (
     HeaderDiscriminator,
     HeaderMatch,
     UrlMatch,
 )
-from estuary_cdk.capture.webhook.resources import (
-    WebhookCaptureSpec,
-    WebhookResourceConfig,
-)
+from estuary_cdk.capture.webhook.resources import WebhookCaptureSpec
+from tests.utils import make_pull_resource, make_webhook_resource
 
 
 class TestWebhookResourceConfig:
@@ -47,3 +49,26 @@ class TestWebhookCaptureSpec:
             assert r.schema_inference is True
             assert isinstance(r.initial_config.match_rule, HeaderMatch)
             assert r.initial_config.match_rule.key == "X-Event"
+
+
+class TestExplicitAcknowledgements:
+    def test_no_webhook_bindings_disables_explicit_acks(self):
+        opened, _ = common.open(
+            MagicMock(),
+            [(MagicMock(), make_pull_resource())],
+        )
+        assert opened.explicitAcknowledgements is False
+
+    def test_at_least_one_webhook_binding_enables_explicit_acks(self):
+        opened, _ = common.open(
+            MagicMock(),
+            [
+                (MagicMock(), make_pull_resource()),
+                (MagicMock(), make_webhook_resource("hook")),
+            ],
+        )
+        assert opened.explicitAcknowledgements is True
+
+    def test_empty_bindings_disables_explicit_acks(self):
+        opened, _ = common.open(MagicMock(), [])
+        assert opened.explicitAcknowledgements is False

--- a/estuary-cdk/tests/test_webhook_server.py
+++ b/estuary-cdk/tests/test_webhook_server.py
@@ -4,7 +4,7 @@ import json
 import logging
 from collections.abc import AsyncGenerator, Mapping
 from contextlib import asynccontextmanager
-from typing import Any, NamedTuple
+from typing import Any, BinaryIO, NamedTuple
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -15,17 +15,17 @@ from pydantic import model_validator
 from estuary_cdk.capture.common import (
     Resource,
     ResourceState,
+    WebhookResourceConfig,
 )
 from estuary_cdk.capture.task import Task
+from estuary_cdk.capture.transactor import Transactor
 from estuary_cdk.capture.webhook.match import (
     BodyMatch,
-    CollectionMatchingSpec,
     HeaderMatch,
     UrlMatch,
 )
 from estuary_cdk.capture.webhook.resources import (
     WebhookDocument,
-    WebhookResourceConfig,
     open_webhook_binding,
 )
 from estuary_cdk.capture.webhook.server import (
@@ -33,26 +33,7 @@ from estuary_cdk.capture.webhook.server import (
     build_webhook_app,
     start_webhook_server,
 )
-
-
-def _make_resource(
-    name: str,
-    match_rule: CollectionMatchingSpec | None = None,
-) -> Resource[WebhookDocument, WebhookResourceConfig, ResourceState]:
-    if match_rule is None:
-        match_rule = UrlMatch(value="*")
-    return Resource(
-        name=name,
-        key=["/_meta/webhookId"],
-        model=WebhookDocument,
-        open=open_webhook_binding,  # pyright: ignore[reportArgumentType]
-        initial_state=ResourceState(),
-        initial_config=WebhookResourceConfig(
-            name=name,
-            match_rule=match_rule,
-        ),
-        schema_inference=True,
-    )
+from tests.utils import make_webhook_resource
 
 
 class ServerContext(NamedTuple):
@@ -69,6 +50,7 @@ async def run_server(
 ) -> AsyncGenerator[ServerContext, None]:
     output = io.BytesIO()
     stopping = Task.Stopping()
+    transactor = Transactor(output, requires_explicit_acks=True)
 
     task = Task(
         log=logging.getLogger("test-webhook"),
@@ -77,28 +59,43 @@ async def run_server(
         output=output,
         stopping=stopping,
         tg=MagicMock(),
+        transactor=transactor,
+        requires_ack=True,
     )
 
-    app = build_webhook_app(binding_index_mapping, task)
-    async with TestClient(TestServer(app)) as client:
-        yield ServerContext(task, client, app)
+    async def auto_ack() -> None:
+        """Drain pending checkpoints continuously so handlers awaiting ACK
+        unblock without a real Flow runtime."""
+        while True:
+            if transactor._pending:  # pyright: ignore[reportPrivateUsage]
+                transactor.deliver_ack(
+                    len(transactor._pending)  # pyright: ignore[reportPrivateUsage]
+                )
+            await asyncio.sleep(0)
+
+    ack_task = asyncio.create_task(auto_ack())
+    try:
+        app = build_webhook_app(binding_index_mapping, task)
+        async with TestClient(TestServer(app)) as client:
+            yield ServerContext(task, client, app)
+    finally:
+        _ = ack_task.cancel()
+        try:
+            await ack_task
+        except asyncio.CancelledError:
+            pass
 
 
-def _read_output(task: Task) -> list[dict[str, Any]]:
-    _ = task._output.seek(0)  # pyright: ignore[reportPrivateUsage]
-    lines = (
-        task._output.read()  # pyright: ignore[reportPrivateUsage]
-        .decode()
-        .strip()
-        .splitlines()
-    )
-    return [json.loads(line) for line in lines if line]
+def read_emitted_records(output: BinaryIO) -> list[dict[str, Any]]:
+    """Rewind `output` and parse the JSON-lines a Task has emitted to it."""
+    _ = output.seek(0)
+    return [json.loads(line) for line in output.read().decode().splitlines() if line]
 
 
 class TestWebhookHandler:
     @pytest.mark.asyncio
     async def test_successful_post(self):
-        resource = _make_resource("catch-all")
+        resource = make_webhook_resource("catch-all")
         async with run_server({0: resource}) as ctx:
             resp = await ctx.client.post("/hook", json={"foo": "bar"})
             assert resp.status == 200
@@ -106,12 +103,14 @@ class TestWebhookHandler:
 
     @pytest.mark.asyncio
     async def test_meta_enrichment(self):
-        resource = _make_resource("catch-all")
+        resource = make_webhook_resource("catch-all")
         async with run_server({0: resource}) as ctx:
             resp = await ctx.client.post("/hook", json={"data": 1})
             assert resp.status == 200
 
-            output = _read_output(ctx.task)
+            output = read_emitted_records(
+                ctx.task._output  # pyright: ignore[reportPrivateUsage]
+            )
             assert len(output) >= 1
 
             captured = output[0]["captured"]
@@ -130,20 +129,24 @@ class TestWebhookHandler:
 
     @pytest.mark.asyncio
     async def test_multiple_posts_capture_separately(self):
-        resource = _make_resource("catch-all")
+        resource = make_webhook_resource("catch-all")
         async with run_server({0: resource}) as ctx:
             resp1 = await ctx.client.post("/hook", json={"n": 1})
             resp2 = await ctx.client.post("/hook", json={"n": 2})
             assert resp1.status == 200
             assert resp2.status == 200
 
-            output = _read_output(ctx.task)
+            output = read_emitted_records(
+                ctx.task._output  # pyright: ignore[reportPrivateUsage]
+            )
             captured_lines = [line for line in output if "captured" in line]
             assert len(captured_lines) >= 2
 
     @pytest.mark.asyncio
     async def test_404_no_matching_binding(self):
-        resource = _make_resource("specific", match_rule=UrlMatch(value="/specific"))
+        resource = make_webhook_resource(
+            "specific", match_rule=UrlMatch(value="/specific")
+        )
         async with run_server({0: resource}) as ctx:
             resp = await ctx.client.post("/other", json={"x": 1})
             assert resp.status == 404
@@ -151,7 +154,7 @@ class TestWebhookHandler:
 
     @pytest.mark.asyncio
     async def test_503_when_rejecting(self):
-        resource = _make_resource("catch-all")
+        resource = make_webhook_resource("catch-all")
         async with run_server({0: resource}) as ctx:
             ctx.app[_rejecting_key] = True
             resp = await ctx.client.post("/hook", json={"x": 1})
@@ -160,7 +163,7 @@ class TestWebhookHandler:
 
     @pytest.mark.asyncio
     async def test_non_json_body(self):
-        resource = _make_resource("catch-all")
+        resource = make_webhook_resource("catch-all")
         async with run_server({0: resource}) as ctx:
             resp = await ctx.client.post(
                 "/hook",
@@ -171,19 +174,21 @@ class TestWebhookHandler:
 
     @pytest.mark.asyncio
     async def test_array_body_publishes_all(self):
-        resource = _make_resource("catch-all")
+        resource = make_webhook_resource("catch-all")
         async with run_server({0: resource}) as ctx:
             resp = await ctx.client.post("/hook", json=[{"a": 1}, {"b": 2}, {"c": 3}])
             assert resp.status == 200
             assert await resp.json() == {"published": 3}
 
-            output = _read_output(ctx.task)
+            output = read_emitted_records(
+                ctx.task._output  # pyright: ignore[reportPrivateUsage]
+            )
             captured_lines = [line for line in output if "captured" in line]
             assert len(captured_lines) == 3
 
     @pytest.mark.asyncio
     async def test_array_body_single_element(self):
-        resource = _make_resource("catch-all")
+        resource = make_webhook_resource("catch-all")
         async with run_server({0: resource}) as ctx:
             resp = await ctx.client.post("/hook", json=[{"x": 1}])
             assert resp.status == 200
@@ -191,7 +196,7 @@ class TestWebhookHandler:
 
     @pytest.mark.asyncio
     async def test_non_dict_in_array_rejected(self):
-        resource = _make_resource("catch-all")
+        resource = make_webhook_resource("catch-all")
         async with run_server({0: resource}) as ctx:
             resp = await ctx.client.post("/hook", json=[{"ok": 1}, "bad"])
             assert resp.status == 400
@@ -222,13 +227,15 @@ class TestWebhookHandler:
             resp = await ctx.client.post("/hook", json={"name": "hello"})
             assert resp.status == 200
 
-            output = _read_output(ctx.task)
+            output = read_emitted_records(
+                ctx.task._output  # pyright: ignore[reportPrivateUsage]
+            )
             doc = output[0]["captured"]["doc"]
             assert doc["name"] == "HELLO"
 
     @pytest.mark.asyncio
     async def test_non_dict_scalar_body_rejected(self):
-        resource = _make_resource("catch-all")
+        resource = make_webhook_resource("catch-all")
         async with run_server({0: resource}) as ctx:
             resp = await ctx.client.post(
                 "/hook",
@@ -241,10 +248,12 @@ class TestWebhookHandler:
 class TestRequestRouting:
     @pytest.mark.asyncio
     async def test_header_match_priority_over_url(self):
-        header_resource = _make_resource(
+        header_resource = make_webhook_resource(
             "header", match_rule=HeaderMatch(key="X-Event", value="push")
         )
-        url_resource = _make_resource("catch-all", match_rule=UrlMatch(value="*"))
+        url_resource = make_webhook_resource(
+            "catch-all", match_rule=UrlMatch(value="*")
+        )
         async with run_server({0: header_resource, 1: url_resource}) as ctx:
             resp = await ctx.client.post(
                 "/hook",
@@ -253,7 +262,9 @@ class TestRequestRouting:
             )
             assert resp.status == 200
 
-            output = _read_output(ctx.task)
+            output = read_emitted_records(
+                ctx.task._output  # pyright: ignore[reportPrivateUsage]
+            )
 
             first_line = output[0]
             assert isinstance(first_line, dict)
@@ -264,15 +275,19 @@ class TestRequestRouting:
 
     @pytest.mark.asyncio
     async def test_body_match_priority_over_url(self):
-        body_resource = _make_resource(
+        body_resource = make_webhook_resource(
             "body", match_rule=BodyMatch(key="event", value="push")
         )
-        url_resource = _make_resource("catch-all", match_rule=UrlMatch(value="*"))
+        url_resource = make_webhook_resource(
+            "catch-all", match_rule=UrlMatch(value="*")
+        )
         async with run_server({0: body_resource, 1: url_resource}) as ctx:
             resp = await ctx.client.post("/hook", json={"event": "push"})
             assert resp.status == 200
 
-            output = _read_output(ctx.task)
+            output = read_emitted_records(
+                ctx.task._output  # pyright: ignore[reportPrivateUsage]
+            )
 
             first_line = output[0]
             assert isinstance(first_line, dict)
@@ -283,15 +298,21 @@ class TestRequestRouting:
 
     @pytest.mark.asyncio
     async def test_more_specific_url_first(self):
-        specific = _make_resource("specific", match_rule=UrlMatch(value="/foo/bar"))
-        parametric = _make_resource("parametric", match_rule=UrlMatch(value="/foo/{x}"))
-        wildcard = _make_resource("wildcard", match_rule=UrlMatch(value="*"))
+        specific = make_webhook_resource(
+            "specific", match_rule=UrlMatch(value="/foo/bar")
+        )
+        parametric = make_webhook_resource(
+            "parametric", match_rule=UrlMatch(value="/foo/{x}")
+        )
+        wildcard = make_webhook_resource("wildcard", match_rule=UrlMatch(value="*"))
 
         async with run_server({0: specific, 1: parametric, 2: wildcard}) as ctx:
             resp = await ctx.client.post("/foo/bar", json={"x": 1})
             assert resp.status == 200
 
-            output = _read_output(ctx.task)
+            output = read_emitted_records(
+                ctx.task._output  # pyright: ignore[reportPrivateUsage]
+            )
 
             first_line = output[0]
             assert isinstance(first_line, dict)
@@ -302,13 +323,17 @@ class TestRequestRouting:
 
     @pytest.mark.asyncio
     async def test_wildcard_catches_unmatched(self):
-        specific = _make_resource("specific", match_rule=UrlMatch(value="/specific"))
-        wildcard = _make_resource("wildcard", match_rule=UrlMatch(value="*"))
+        specific = make_webhook_resource(
+            "specific", match_rule=UrlMatch(value="/specific")
+        )
+        wildcard = make_webhook_resource("wildcard", match_rule=UrlMatch(value="*"))
         async with run_server({0: specific, 1: wildcard}) as ctx:
             resp = await ctx.client.post("/something-else", json={"x": 1})
             assert resp.status == 200
 
-            output = _read_output(ctx.task)
+            output = read_emitted_records(
+                ctx.task._output  # pyright: ignore[reportPrivateUsage]
+            )
 
             first_line = output[0]
             assert isinstance(first_line, dict)
@@ -319,14 +344,55 @@ class TestRequestRouting:
 
 
 def _make_task() -> Task:
+    output = io.BytesIO()
     return Task(
         log=logging.getLogger("test-webhook"),
         connector_status=MagicMock(),
         name="test-webhook",
-        output=io.BytesIO(),
+        output=output,
         stopping=Task.Stopping(),
         tg=MagicMock(),
+        transactor=Transactor(output, requires_explicit_acks=True),
+        requires_ack=True,
     )
+
+
+class TestWebhookAckBlocking:
+    @pytest.mark.asyncio
+    async def test_handler_blocks_until_ack(self):
+        output = io.BytesIO()
+        stopping = Task.Stopping()
+        transactor = Transactor(output, requires_explicit_acks=True)
+
+        task = Task(
+            log=logging.getLogger("test-webhook-ack"),
+            connector_status=MagicMock(),
+            name="test-webhook-ack",
+            output=output,
+            stopping=stopping,
+            tg=MagicMock(),
+            transactor=transactor,
+            requires_ack=True,
+        )
+
+        app = build_webhook_app({0: make_webhook_resource("catch-all")}, task)
+        async with TestClient(TestServer(app)) as client:
+            request_task = asyncio.create_task(client.post("/hook", json={"x": 1}))
+
+            # Give the handler time to enter checkpoint() and start awaiting the ACK.
+            await asyncio.sleep(0.1)
+            assert (
+                len(transactor._pending) == 1  # pyright: ignore[reportPrivateUsage]
+            ), "Handler did not register a pending checkpoint slot"
+            assert (
+                not request_task.done()
+            ), "Webhook handler returned before ACK was delivered"
+
+            transactor.deliver_ack(1)
+
+            resp = await asyncio.wait_for(request_task, timeout=1.0)
+            assert resp.status == 200
+            assert await resp.json() == {"published": 1}
 
 
 class TestWebhookServerLifecycle:
@@ -334,7 +400,7 @@ class TestWebhookServerLifecycle:
     async def test_start_sets_webhook_task(self):
         task = _make_task()
 
-        resource = _make_resource("catch-all")
+        resource = make_webhook_resource("catch-all")
         start_webhook_server({0: resource}, task)
 
         webhook_task = task.stopping.webhook_task
@@ -346,7 +412,7 @@ class TestWebhookServerLifecycle:
     @pytest.mark.asyncio
     async def test_webhook_event_triggers_shutdown(self):
         task = _make_task()
-        resource = _make_resource("catch-all")
+        resource = make_webhook_resource("catch-all")
         start_webhook_server({0: resource}, task)
 
         # Give server time to bind
@@ -362,7 +428,7 @@ class TestWebhookServerLifecycle:
     @pytest.mark.asyncio
     async def test_startup_failure_propagates_error(self):
         task = _make_task()
-        resource = _make_resource("catch-all")
+        resource = make_webhook_resource("catch-all")
 
         with patch(
             "aiohttp.web.TCPSite.start", side_effect=OSError("Address already in use")

--- a/estuary-cdk/tests/utils.py
+++ b/estuary-cdk/tests/utils.py
@@ -1,0 +1,43 @@
+from estuary_cdk.capture.common import (
+    Resource,
+    ResourceConfig,
+    ResourceState,
+    WebhookResourceConfig,
+)
+from estuary_cdk.capture.webhook.match import CollectionMatchingSpec, UrlMatch
+from estuary_cdk.capture.webhook.resources import (
+    WebhookDocument,
+    WebhookResource,
+    open_webhook_binding,
+)
+
+
+def make_webhook_resource(
+    name: str,
+    match_rule: CollectionMatchingSpec | None = None,
+) -> Resource[WebhookDocument, WebhookResourceConfig, ResourceState]:
+    if match_rule is None:
+        match_rule = UrlMatch(value="*")
+    return WebhookResource(
+        name=name,
+        open=open_webhook_binding,  # pyright: ignore[reportArgumentType]
+        initial_config=WebhookResourceConfig(
+            name=name,
+            match_rule=match_rule,
+        ),
+        schema_inference=True,
+    )
+
+
+def make_pull_resource(
+    name: str = "pull",
+) -> Resource[WebhookDocument, ResourceConfig, ResourceState]:
+    return Resource(
+        name=name,
+        key=["/id"],
+        model=WebhookDocument,
+        open=lambda *args, **kwargs: None,
+        initial_state=ResourceState(),
+        initial_config=ResourceConfig(name=name),
+        schema_inference=True,
+    )

--- a/source-appsflyer/source_appsflyer/resources.py
+++ b/source-appsflyer/source_appsflyer/resources.py
@@ -9,12 +9,10 @@ from estuary_cdk.capture.common import (
     Resource,
     ResourceConfig,
     ResourceState,
+    WebhookResourceConfig,
 )
 from estuary_cdk.capture.webhook.match import BodyDiscriminator
-from estuary_cdk.capture.webhook.resources import (
-    WebhookResourceConfig,
-    open_webhook_binding,
-)
+from estuary_cdk.capture.webhook.resources import WebhookResource, open_webhook_binding
 from estuary_cdk.flow import CaptureBinding
 from estuary_cdk.http import HTTPMixin, TokenSource
 from pydantic import Field, TypeAdapter
@@ -159,12 +157,11 @@ async def all_resources(
 
     discriminator = BodyDiscriminator(key="event_type", known_values=event_types)
     webhook_resources = [
-        Resource(
+        WebhookResource(
             name=f"{rule.display_name}",
             key=["/_meta/estuary_id"],
             model=AppsFlyerWebhookDocument,
             open=open_webhook_binding,  # pyright: ignore[reportArgumentType]
-            initial_state=ResourceState(),
             initial_config=AppsFlyerWebhookResourceConfig(
                 name=f"{rule.display_name}",
                 type="webhook",


### PR DESCRIPTION
**Description:**

Webhook servers were responding with 200s to incoming requests without waiting for the Flow runtime to confirm they have been persisted; this change makes `checkpoint()` calls block on ACKs for webhook tasks.

The Flow runtime responds with `{checkpoints: N}` to signal that the first N pending checkpoints have been processed, so a deque was implemented to track the order in which they've been made.

The transactor is designed to keep pull API checkpoints fire-and-forget to not harm performance.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

Recommended file reading order:

1. `base_capture_connector.py`
2. `transactor.py`
3. `common.py`
4. Tests
5. `source-appsflyer/resources.py`