### PR TITLE
estuary-cdk: add if/then/else schema block to support hard deletes

### DIFF
--- a/estuary-cdk/estuary_cdk/capture/common.py
+++ b/estuary-cdk/estuary_cdk/capture/common.py
@@ -503,8 +503,29 @@ def discovered(
         if resource.schema_inference:
             schema["x-infer-schema"] = True
 
+        # Materializations require this if/then/else conditional to support
+        # hard deletes. It tells Flow to use a top-level merge reduction
+        # strategy for deletions and mark them with `delete: True` so materializations
+        # know to issue DELETEs to destinations.
+        #
+        # `_meta` and `_meta.op` are both `required` in the `if` clause because
+        # JSON Schema's `properties` keyword passes when a key is absent.
+        # Without these `required` assertions, a document missing `_meta`
+        # or `_meta.op` would still match the `if` and get marked as a
+        # delete. The `required` clauses force the `if` to match only when
+        # `_meta.op` is present and equals `"d"`.
+        schema["if"] = {
+            "required": ["_meta"],
+            "properties": {
+                "_meta": {
+                    "required": ["op"],
+                    "properties": {"op": {"const": "d"}},
+                }
+            },
+        }
+        schema["then"] = {"reduce": {"strategy": "merge", "delete": True}}
         if resource.reduction_strategy:
-            schema["reduce"] = {"strategy": resource.reduction_strategy}
+            schema["else"] = {"reduce": {"strategy": resource.reduction_strategy}}
 
         bindings.append(
             response.DiscoveredBinding(

--- a/source-ada/tests/snapshots/snapshots__discover__capture.stdout.json
+++ b/source-ada/tests/snapshots/snapshots__discover__capture.stdout.json
@@ -39,7 +39,30 @@
       },
       "title": "BaseDocument",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/_meta/row_id"
@@ -93,7 +116,30 @@
       ],
       "title": "ExportResource",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/_id"
@@ -147,7 +193,30 @@
       ],
       "title": "ExportResource",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/_id"
@@ -193,7 +262,30 @@
       },
       "title": "BaseDocument",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/_meta/row_id"
@@ -239,7 +331,30 @@
       },
       "title": "BaseDocument",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/_meta/row_id"
@@ -285,7 +400,30 @@
       },
       "title": "BaseDocument",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/_meta/row_id"

--- a/source-airtable/tests/snapshots/snapshots__discover__capture.stdout.json
+++ b/source-airtable/tests/snapshots/snapshots__discover__capture.stdout.json
@@ -40,7 +40,30 @@
       "required": [
         "_airtable_id"
       ],
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/_airtable_id"
@@ -87,7 +110,30 @@
       "required": [
         "_airtable_id"
       ],
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/_airtable_id"

--- a/source-apple-app-store/tests/snapshots/snapshots__discover__stdout.json
+++ b/source-apple-app-store/tests/snapshots/snapshots__discover__stdout.json
@@ -60,7 +60,30 @@
       ],
       "title": "AppCrashesReportRow",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/filename",
@@ -128,7 +151,30 @@
       ],
       "title": "AppDownloadsDetailedReportRow",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/filename",
@@ -207,7 +253,30 @@
       ],
       "title": "AppReview",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/app_id",
@@ -275,7 +344,30 @@
       ],
       "title": "AppSessionsDetailedReportRow",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/filename",
@@ -343,7 +435,30 @@
       ],
       "title": "AppStoreDiscoveryAndEngagementDetailedReportRow",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/filename",
@@ -411,7 +526,30 @@
       ],
       "title": "AppStoreInstallsDetailedReportRow",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/filename",

--- a/source-appsflyer/tests/snapshots/snapshots__discover__stdout.json
+++ b/source-appsflyer/tests/snapshots/snapshots__discover__stdout.json
@@ -69,7 +69,30 @@
       ],
       "title": "AggGeoDailyReport",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/_meta/app_id",
@@ -220,7 +243,30 @@
       ],
       "title": "AppsFlyerWebhookDocument",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/_meta/estuary_id"
@@ -367,7 +413,30 @@
       ],
       "title": "AppsFlyerWebhookDocument",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/_meta/estuary_id"
@@ -514,7 +583,30 @@
       ],
       "title": "AppsFlyerWebhookDocument",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/_meta/estuary_id"
@@ -661,7 +753,30 @@
       ],
       "title": "AppsFlyerWebhookDocument",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/_meta/estuary_id"
@@ -808,7 +923,30 @@
       ],
       "title": "AppsFlyerWebhookDocument",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/_meta/estuary_id"
@@ -955,7 +1093,30 @@
       ],
       "title": "AppsFlyerWebhookDocument",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/_meta/estuary_id"
@@ -1102,7 +1263,30 @@
       ],
       "title": "AppsFlyerWebhookDocument",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/_meta/estuary_id"
@@ -1249,7 +1433,30 @@
       ],
       "title": "AppsFlyerWebhookDocument",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/_meta/estuary_id"
@@ -1396,7 +1603,30 @@
       ],
       "title": "AppsFlyerWebhookDocument",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/_meta/estuary_id"
@@ -1543,7 +1773,30 @@
       ],
       "title": "AppsFlyerWebhookDocument",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/_meta/estuary_id"
@@ -1690,7 +1943,30 @@
       ],
       "title": "AppsFlyerWebhookDocument",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/_meta/estuary_id"
@@ -1837,7 +2113,30 @@
       ],
       "title": "AppsFlyerWebhookDocument",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/_meta/estuary_id"
@@ -1984,7 +2283,30 @@
       ],
       "title": "AppsFlyerWebhookDocument",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/_meta/estuary_id"
@@ -2131,7 +2453,30 @@
       ],
       "title": "AppsFlyerWebhookDocument",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/_meta/estuary_id"

--- a/source-asana/tests/snapshots/snapshots__discover__capture.stdout.json
+++ b/source-asana/tests/snapshots/snapshots__discover__capture.stdout.json
@@ -46,7 +46,30 @@
           ]
         }
       },
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/gid"
@@ -194,7 +217,30 @@
           ]
         }
       },
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/gid"
@@ -427,7 +473,30 @@
           ]
         }
       },
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/gid"
@@ -627,7 +696,30 @@
           ]
         }
       },
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/created_at"
@@ -674,7 +766,30 @@
           ]
         }
       },
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/gid"
@@ -922,7 +1037,30 @@
           ]
         }
       },
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/gid"
@@ -1018,7 +1156,30 @@
           ]
         }
       },
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/gid"
@@ -1544,7 +1705,30 @@
           ]
         }
       },
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/gid"
@@ -1591,7 +1775,30 @@
           ]
         }
       },
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/gid"
@@ -1671,7 +1878,30 @@
           ]
         }
       },
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/gid"
@@ -1763,7 +1993,30 @@
           ]
         }
       },
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/gid"
@@ -1975,7 +2228,30 @@
           ]
         }
       },
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/gid"
@@ -2092,7 +2368,30 @@
           ]
         }
       },
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/gid"
@@ -2901,7 +3200,30 @@
           ]
         }
       },
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/gid"
@@ -2992,7 +3314,30 @@
           ]
         }
       },
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/gid"
@@ -3091,7 +3436,30 @@
           ]
         }
       },
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/gid"
@@ -3214,7 +3582,30 @@
           ]
         }
       },
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/gid"
@@ -3276,7 +3667,30 @@
           ]
         }
       },
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/gid"

--- a/source-ashby/tests/snapshots/snapshots__discover__stdout.json
+++ b/source-ashby/tests/snapshots/snapshots__discover__stdout.json
@@ -47,7 +47,30 @@
       ],
       "title": "Applications",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
@@ -101,7 +124,30 @@
       ],
       "title": "Approvals",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
@@ -155,7 +201,30 @@
       ],
       "title": "ArchiveReasons",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/_meta/row_id"
@@ -209,7 +278,30 @@
       ],
       "title": "CandidateTags",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
@@ -263,7 +355,30 @@
       ],
       "title": "Candidates",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
@@ -317,7 +432,30 @@
       ],
       "title": "CustomFields",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
@@ -371,7 +509,30 @@
       ],
       "title": "Departments",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
@@ -425,7 +586,30 @@
       ],
       "title": "FeedbackFormDefinitions",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
@@ -479,7 +663,30 @@
       ],
       "title": "InterviewEvents",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
@@ -533,7 +740,30 @@
       ],
       "title": "InterviewPlans",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
@@ -587,7 +817,30 @@
       ],
       "title": "InterviewSchedules",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
@@ -641,7 +894,30 @@
       ],
       "title": "InterviewStages",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/_meta/row_id"
@@ -695,7 +971,30 @@
       ],
       "title": "InterviewerPools",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
@@ -749,7 +1048,30 @@
       ],
       "title": "Interviews",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
@@ -803,7 +1125,30 @@
       ],
       "title": "JobPostings",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/_meta/row_id"
@@ -857,7 +1202,30 @@
       ],
       "title": "JobTemplates",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
@@ -911,7 +1279,30 @@
       ],
       "title": "Jobs",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
@@ -965,7 +1356,30 @@
       ],
       "title": "Locations",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
@@ -1019,7 +1433,30 @@
       ],
       "title": "Offers",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
@@ -1073,7 +1510,30 @@
       ],
       "title": "Openings",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
@@ -1127,7 +1587,30 @@
       ],
       "title": "Projects",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
@@ -1181,7 +1664,30 @@
       ],
       "title": "Sources",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/_meta/row_id"
@@ -1235,7 +1741,30 @@
       ],
       "title": "SurveyFormDefinitions",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
@@ -1289,7 +1818,30 @@
       ],
       "title": "Users",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"

--- a/source-braintree-native/tests/snapshots/snapshots__discover__capture.stdout.json
+++ b/source-braintree-native/tests/snapshots/snapshots__discover__capture.stdout.json
@@ -40,7 +40,30 @@
       },
       "title": "FullRefreshResource",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/_meta/row_id"
@@ -107,7 +130,30 @@
       ],
       "title": "IncrementalResource",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
@@ -174,7 +220,30 @@
       ],
       "title": "IncrementalResource",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
@@ -221,7 +290,30 @@
       },
       "title": "FullRefreshResource",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/_meta/row_id"
@@ -287,7 +379,30 @@
       ],
       "title": "IncrementalResource",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
@@ -334,7 +449,30 @@
       },
       "title": "FullRefreshResource",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/_meta/row_id"
@@ -381,7 +519,30 @@
       },
       "title": "FullRefreshResource",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/_meta/row_id"
@@ -448,7 +609,30 @@
       ],
       "title": "IncrementalResource",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
@@ -514,7 +698,30 @@
       ],
       "title": "IncrementalResource",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"

--- a/source-brevo/tests/snapshots/snapshots__discover__capture.stdout.json
+++ b/source-brevo/tests/snapshots/snapshots__discover__capture.stdout.json
@@ -22,7 +22,30 @@
           ]
         }
       },
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
@@ -55,7 +78,30 @@
         }
       },
       "additionalProperties": true,
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/name"
@@ -88,7 +134,30 @@
         }
       },
       "additionalProperties": true,
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"

--- a/source-calendly/tests/snapshots/snapshots__discover__stdout.json
+++ b/source-calendly/tests/snapshots/snapshots__discover__stdout.json
@@ -53,7 +53,30 @@
       ],
       "title": "EventInvitee",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/uri"
@@ -113,7 +136,30 @@
       ],
       "title": "EventType",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/uri"
@@ -173,7 +219,30 @@
       ],
       "title": "Group",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/_meta/row_id"
@@ -233,7 +302,30 @@
       ],
       "title": "OrganizationMembership",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/_meta/row_id"
@@ -293,7 +385,30 @@
       ],
       "title": "RoutingFormSubmission",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/_meta/row_id"
@@ -353,7 +468,30 @@
       ],
       "title": "RoutingForm",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/_meta/row_id"
@@ -413,7 +551,30 @@
       ],
       "title": "ScheduledEvent",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/uri"

--- a/source-datadog/tests/snapshots/snapshots__discover__stdout.json
+++ b/source-datadog/tests/snapshots/snapshots__discover__stdout.json
@@ -66,7 +66,30 @@
       ],
       "title": "LogResource",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
@@ -139,7 +162,30 @@
       ],
       "title": "RealUserMonitoringResource",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"

--- a/source-facebook-marketing-native/tests/e2e/snapshots/snapshots__discover__capture.stdout.json
+++ b/source-facebook-marketing-native/tests/e2e/snapshots/snapshots__discover__capture.stdout.json
@@ -68,7 +68,30 @@
       ],
       "title": "Activities",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/object_id",
@@ -118,7 +141,30 @@
       },
       "title": "BaseDocument",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/_meta/row_id"
@@ -164,7 +210,30 @@
       },
       "title": "BaseDocument",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/_meta/row_id"
@@ -219,7 +288,30 @@
       ],
       "title": "AdSets",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
@@ -274,7 +366,30 @@
       ],
       "title": "Ads",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
@@ -338,7 +453,30 @@
       ],
       "title": "AdsInsights",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/account_id",
@@ -404,7 +542,30 @@
       ],
       "title": "AdsInsightsActionType",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/account_id",
@@ -480,7 +641,30 @@
       ],
       "title": "AdsInsightsAgeAndGender",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/account_id",
@@ -553,7 +737,30 @@
       ],
       "title": "AdsInsightsCountry",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/account_id",
@@ -625,7 +832,30 @@
       ],
       "title": "AdsInsightsDma",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/account_id",
@@ -707,7 +937,30 @@
       ],
       "title": "AdsInsightsPlatformAndDevice",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/account_id",
@@ -781,7 +1034,30 @@
       ],
       "title": "AdsInsightsRegion",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/account_id",
@@ -838,7 +1114,30 @@
       ],
       "title": "Campaigns",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
@@ -884,7 +1183,30 @@
       },
       "title": "BaseDocument",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/_meta/row_id"
@@ -960,7 +1282,30 @@
       ],
       "title": "AdsInsightsPublisherPlatform",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/account_id",
@@ -1018,7 +1363,30 @@
       ],
       "title": "Images",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
@@ -1073,7 +1441,30 @@
       ],
       "title": "Videos",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"

--- a/source-front/tests/snapshots/snapshots__discover__capture.stdout.json
+++ b/source-front/tests/snapshots/snapshots__discover__capture.stdout.json
@@ -40,7 +40,30 @@
       },
       "title": "FrontResource",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/_meta/row_id"
@@ -87,7 +110,30 @@
       },
       "title": "FrontResource",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/_meta/row_id"
@@ -134,7 +180,30 @@
       },
       "title": "FrontResource",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/_meta/row_id"
@@ -181,7 +250,30 @@
       },
       "title": "FrontResource",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/_meta/row_id"
@@ -228,7 +320,30 @@
       },
       "title": "FrontResource",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/_meta/row_id"
@@ -287,7 +402,30 @@
       ],
       "title": "Event",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
@@ -346,7 +484,30 @@
       ],
       "title": "Contact",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
@@ -400,7 +561,30 @@
       ],
       "title": "Conversation",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"

--- a/source-genesys/tests/snapshots/snapshots__discover__capture.stdout.json
+++ b/source-genesys/tests/snapshots/snapshots__discover__capture.stdout.json
@@ -40,7 +40,30 @@
       },
       "title": "FullRefreshResource",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/_meta/row_id"
@@ -105,7 +128,30 @@
       ],
       "title": "Conversation",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/conversationId"
@@ -152,7 +198,30 @@
       },
       "title": "FullRefreshResource",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/_meta/row_id"
@@ -199,7 +268,30 @@
       },
       "title": "FullRefreshResource",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/_meta/row_id"
@@ -246,7 +338,30 @@
       },
       "title": "FullRefreshResource",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/_meta/row_id"
@@ -293,7 +408,30 @@
       },
       "title": "FullRefreshResource",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/_meta/row_id"
@@ -340,7 +478,30 @@
       },
       "title": "FullRefreshResource",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/_meta/row_id"

--- a/source-gladly/tests/snapshots/snapshots__discover__stdout.json
+++ b/source-gladly/tests/snapshots/snapshots__discover__stdout.json
@@ -91,7 +91,30 @@
       ],
       "title": "Event",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
@@ -189,7 +212,30 @@
       ],
       "title": "Event",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
@@ -287,7 +333,30 @@
       ],
       "title": "Event",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
@@ -385,7 +454,30 @@
       ],
       "title": "Event",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
@@ -483,7 +575,30 @@
       ],
       "title": "Event",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
@@ -581,7 +696,30 @@
       ],
       "title": "Event",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
@@ -679,7 +817,30 @@
       ],
       "title": "Event",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"

--- a/source-gong/tests/snapshots/snapshots__discover__stdout.json
+++ b/source-gong/tests/snapshots/snapshots__discover__stdout.json
@@ -48,7 +48,30 @@
       ],
       "title": "Call",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
@@ -96,7 +119,30 @@
       },
       "title": "ScorecardDefinition",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/_meta/row_id"
@@ -151,7 +197,30 @@
       ],
       "title": "Scorecard",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/scorecardId"
@@ -207,7 +276,30 @@
       ],
       "title": "User",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"

--- a/source-google-ads/tests/snapshots/snapshots__discover__capture.stdout.json
+++ b/source-google-ads/tests/snapshots/snapshots__discover__capture.stdout.json
@@ -936,7 +936,30 @@
           ]
         }
       },
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/ad_group_ad.ad.id",
@@ -991,7 +1014,30 @@
           ]
         }
       },
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/ad_group_ad_label.resource_name"
@@ -1205,7 +1251,30 @@
           ]
         }
       },
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/ad_group.id",
@@ -1260,7 +1329,30 @@
           ]
         }
       },
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/ad_group_label.resource_name"
@@ -1423,7 +1515,30 @@
           ]
         }
       },
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/customer.id",
@@ -1478,7 +1593,30 @@
           ]
         }
       },
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/campaign_label.resource_name"
@@ -1607,7 +1745,30 @@
           ]
         }
       },
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/click_view.gclid",
@@ -1674,7 +1835,30 @@
           ]
         }
       },
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/geo_target_constant.id"
@@ -2215,7 +2399,30 @@
           ]
         }
       },
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/campaign.id",
@@ -2511,7 +2718,30 @@
           ]
         }
       },
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/segments.ad_network_type",
@@ -2894,7 +3124,30 @@
           ]
         }
       },
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/segments.ad_network_type",
@@ -3407,7 +3660,30 @@
           ]
         }
       },
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/segments.ad_network_type",
@@ -3924,7 +4200,30 @@
           ]
         }
       },
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/segments.ad_network_type",
@@ -4306,7 +4605,30 @@
           ]
         }
       },
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/segments.ad_network_type",
@@ -5176,7 +5498,30 @@
           ]
         }
       },
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/segments.ad_network_type",
@@ -5245,7 +5590,30 @@
           ]
         }
       },
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/segments.date",
@@ -5406,7 +5774,30 @@
           ]
         }
       },
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/segments.date",
@@ -5519,7 +5910,30 @@
         "customer.id",
         "segments.date"
       ],
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/customer.id",

--- a/source-google-analytics-data-api-native/tests/snapshots/snapshots__discover__capture.stdout.json
+++ b/source-google-analytics-data-api-native/tests/snapshots/snapshots__discover__capture.stdout.json
@@ -57,7 +57,30 @@
       ],
       "title": "daily_active_users",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/property_id",
@@ -138,7 +161,30 @@
       ],
       "title": "devices",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/property_id",
@@ -207,7 +253,30 @@
       ],
       "title": "four_weekly_active_users",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/property_id",
@@ -288,7 +357,30 @@
       ],
       "title": "locations",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/property_id",
@@ -362,7 +454,30 @@
       ],
       "title": "my_custom_report_with_a_filter",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/property_id",
@@ -439,7 +554,30 @@
       ],
       "title": "pages",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/property_id",
@@ -517,7 +655,30 @@
       ],
       "title": "traffic_sources",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/property_id",
@@ -585,7 +746,30 @@
       ],
       "title": "website_overview",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/property_id",
@@ -651,7 +835,30 @@
       ],
       "title": "weekly_active_users",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/property_id",

--- a/source-google-play/tests/snapshots/snapshots__discover__capture.stdout.json
+++ b/source-google-play/tests/snapshots/snapshots__discover__capture.stdout.json
@@ -52,7 +52,30 @@
       ],
       "title": "Crashes",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/Date",
@@ -112,7 +135,30 @@
       ],
       "title": "Installs",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/Date",
@@ -188,7 +234,30 @@
       ],
       "title": "Reviews",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/Month",

--- a/source-google-sheets-native/tests/snapshots/snapshots__discover__stdout.json
+++ b/source-google-sheets-native/tests/snapshots/snapshots__discover__stdout.json
@@ -40,7 +40,30 @@
       },
       "title": "Row",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/_meta/row_id"
@@ -87,7 +110,30 @@
       },
       "title": "Row",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/_meta/row_id"

--- a/source-greenhouse-native/tests/snapshots/snapshots__discover__capture.stdout.json
+++ b/source-greenhouse-native/tests/snapshots/snapshots__discover__capture.stdout.json
@@ -59,7 +59,30 @@
       ],
       "title": "GreenhouseResource",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
@@ -125,7 +148,30 @@
       ],
       "title": "GreenhouseResource",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
@@ -191,7 +237,30 @@
       ],
       "title": "GreenhouseResource",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
@@ -257,7 +326,30 @@
       ],
       "title": "GreenhouseResource",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
@@ -323,7 +415,30 @@
       ],
       "title": "GreenhouseResource",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
@@ -389,7 +504,30 @@
       ],
       "title": "GreenhouseResource",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
@@ -455,7 +593,30 @@
       ],
       "title": "GreenhouseResource",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
@@ -521,7 +682,30 @@
       ],
       "title": "GreenhouseResource",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
@@ -587,7 +771,30 @@
       ],
       "title": "GreenhouseResource",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
@@ -653,7 +860,30 @@
       ],
       "title": "GreenhouseResource",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
@@ -719,7 +949,30 @@
       ],
       "title": "GreenhouseResource",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
@@ -785,7 +1038,30 @@
       ],
       "title": "GreenhouseResource",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
@@ -851,7 +1127,30 @@
       ],
       "title": "GreenhouseResource",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
@@ -917,7 +1216,30 @@
       ],
       "title": "GreenhouseResource",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
@@ -983,7 +1305,30 @@
       ],
       "title": "GreenhouseResource",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
@@ -1049,7 +1394,30 @@
       ],
       "title": "GreenhouseResource",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
@@ -1115,7 +1483,30 @@
       ],
       "title": "GreenhouseResource",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
@@ -1181,7 +1572,30 @@
       ],
       "title": "GreenhouseResource",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
@@ -1247,7 +1661,30 @@
       ],
       "title": "GreenhouseResource",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
@@ -1313,7 +1750,30 @@
       ],
       "title": "GreenhouseResource",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
@@ -1379,7 +1839,30 @@
       ],
       "title": "GreenhouseResource",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
@@ -1445,7 +1928,30 @@
       ],
       "title": "GreenhouseResource",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
@@ -1511,7 +2017,30 @@
       ],
       "title": "GreenhouseResource",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
@@ -1577,7 +2106,30 @@
       ],
       "title": "GreenhouseResource",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
@@ -1643,7 +2195,30 @@
       ],
       "title": "GreenhouseResource",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
@@ -1709,7 +2284,30 @@
       ],
       "title": "GreenhouseResource",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
@@ -1775,7 +2373,30 @@
       ],
       "title": "GreenhouseResource",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
@@ -1841,7 +2462,30 @@
       ],
       "title": "GreenhouseResource",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
@@ -1907,7 +2551,30 @@
       ],
       "title": "GreenhouseResource",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
@@ -1973,7 +2640,30 @@
       ],
       "title": "GreenhouseResource",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
@@ -2039,7 +2729,30 @@
       ],
       "title": "GreenhouseResource",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
@@ -2105,7 +2818,30 @@
       ],
       "title": "GreenhouseResource",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
@@ -2171,7 +2907,30 @@
       ],
       "title": "GreenhouseResource",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
@@ -2237,7 +2996,30 @@
       ],
       "title": "GreenhouseResource",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
@@ -2303,7 +3085,30 @@
       ],
       "title": "GreenhouseResource",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
@@ -2369,7 +3174,30 @@
       ],
       "title": "GreenhouseResource",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
@@ -2435,7 +3263,30 @@
       ],
       "title": "GreenhouseResource",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
@@ -2501,7 +3352,30 @@
       ],
       "title": "GreenhouseResource",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
@@ -2567,7 +3441,30 @@
       ],
       "title": "GreenhouseResource",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
@@ -2633,7 +3530,30 @@
       ],
       "title": "GreenhouseResource",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
@@ -2699,7 +3619,30 @@
       ],
       "title": "GreenhouseResource",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
@@ -2765,7 +3708,30 @@
       ],
       "title": "GreenhouseResource",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
@@ -2831,7 +3797,30 @@
       ],
       "title": "GreenhouseResource",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
@@ -2897,7 +3886,30 @@
       ],
       "title": "GreenhouseResource",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"

--- a/source-hubspot-native/tests/snapshots/snapshots__discover__stdout.json
+++ b/source-hubspot-native/tests/snapshots/snapshots__discover__stdout.json
@@ -192,8 +192,33 @@
       "title": "Company",
       "type": "object",
       "x-infer-schema": true,
-      "reduce": {
-        "strategy": "merge"
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      },
+      "else": {
+        "reduce": {
+          "strategy": "merge"
+        }
       }
     },
     "key": [
@@ -385,8 +410,33 @@
       "title": "Contact",
       "type": "object",
       "x-infer-schema": true,
-      "reduce": {
-        "strategy": "merge"
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      },
+      "else": {
+        "reduce": {
+          "strategy": "merge"
+        }
       }
     },
     "key": [
@@ -594,8 +644,33 @@
       "title": "Deal",
       "type": "object",
       "x-infer-schema": true,
-      "reduce": {
-        "strategy": "merge"
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      },
+      "else": {
+        "reduce": {
+          "strategy": "merge"
+        }
       }
     },
     "key": [
@@ -891,8 +966,33 @@
       "title": "Engagement",
       "type": "object",
       "x-infer-schema": true,
-      "reduce": {
-        "strategy": "merge"
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      },
+      "else": {
+        "reduce": {
+          "strategy": "merge"
+        }
       }
     },
     "key": [
@@ -1100,8 +1200,33 @@
       "title": "Ticket",
       "type": "object",
       "x-infer-schema": true,
-      "reduce": {
-        "strategy": "merge"
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      },
+      "else": {
+        "reduce": {
+          "strategy": "merge"
+        }
       }
     },
     "key": [
@@ -1285,8 +1410,33 @@
       "title": "Product",
       "type": "object",
       "x-infer-schema": true,
-      "reduce": {
-        "strategy": "merge"
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      },
+      "else": {
+        "reduce": {
+          "strategy": "merge"
+        }
       }
     },
     "key": [
@@ -1518,8 +1668,33 @@
       "title": "LineItem",
       "type": "object",
       "x-infer-schema": true,
-      "reduce": {
-        "strategy": "merge"
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      },
+      "else": {
+        "reduce": {
+          "strategy": "merge"
+        }
       }
     },
     "key": [
@@ -1589,7 +1764,30 @@
       ],
       "title": "Property",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/_meta/row_id"
@@ -1664,7 +1862,30 @@
       ],
       "title": "DealPipeline",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/_meta/row_id"
@@ -1739,7 +1960,30 @@
       ],
       "title": "Owner",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/_meta/row_id"
@@ -1819,7 +2063,30 @@
       ],
       "title": "EmailEvent",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
@@ -1899,7 +2166,30 @@
       ],
       "title": "Form",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/_meta/row_id"
@@ -1958,7 +2248,30 @@
       ],
       "title": "FormSubmission",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/formId",
@@ -2018,7 +2331,30 @@
       ],
       "title": "MarketingEmail",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
@@ -2090,7 +2426,30 @@
       ],
       "title": "ContactList",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/listId"
@@ -2155,7 +2514,30 @@
       ],
       "title": "ContactListMembership",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/listId",
@@ -2371,8 +2753,33 @@
       "title": "Order",
       "type": "object",
       "x-infer-schema": true,
-      "reduce": {
-        "strategy": "merge"
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      },
+      "else": {
+        "reduce": {
+          "strategy": "merge"
+        }
       }
     },
     "key": [

--- a/source-hubspot/tests/snapshots/snapshots__discover__capture.stdout.json
+++ b/source-hubspot/tests/snapshots/snapshots__discover__capture.stdout.json
@@ -2,6 +2,23 @@
   {
     "documentSchema": {
       "$schema": "http://json-schema.org/draft-07/schema#",
+      "if": {
+        "properties": {
+          "_meta": {
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            },
+            "required": [
+              "op"
+            ]
+          }
+        },
+        "required": [
+          "_meta"
+        ]
+      },
       "properties": {
         "_meta": {
           "properties": {
@@ -185,6 +202,12 @@
       "required": [
         "id"
       ],
+      "then": {
+        "reduce": {
+          "delete": true,
+          "strategy": "merge"
+        }
+      },
       "type": [
         "object"
       ]
@@ -204,6 +227,23 @@
   {
     "documentSchema": {
       "$schema": "http://json-schema.org/draft-07/schema#",
+      "if": {
+        "properties": {
+          "_meta": {
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            },
+            "required": [
+              "op"
+            ]
+          }
+        },
+        "required": [
+          "_meta"
+        ]
+      },
       "properties": {
         "_meta": {
           "properties": {
@@ -1494,6 +1534,12 @@
       "required": [
         "id"
       ],
+      "then": {
+        "reduce": {
+          "delete": true,
+          "strategy": "merge"
+        }
+      },
       "type": [
         "object"
       ]
@@ -1513,6 +1559,23 @@
   {
     "documentSchema": {
       "$schema": "http://json-schema.org/draft-07/schema#",
+      "if": {
+        "properties": {
+          "_meta": {
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            },
+            "required": [
+              "op"
+            ]
+          }
+        },
+        "required": [
+          "_meta"
+        ]
+      },
       "properties": {
         "_meta": {
           "properties": {
@@ -1698,6 +1761,12 @@
       "required": [
         "listId"
       ],
+      "then": {
+        "reduce": {
+          "delete": true,
+          "strategy": "merge"
+        }
+      },
       "type": "object"
     },
     "key": [
@@ -1715,6 +1784,23 @@
   {
     "documentSchema": {
       "$schema": "http://json-schema.org/draft-07/schema#",
+      "if": {
+        "properties": {
+          "_meta": {
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            },
+            "required": [
+              "op"
+            ]
+          }
+        },
+        "required": [
+          "_meta"
+        ]
+      },
       "properties": {
         "_meta": {
           "properties": {
@@ -3613,6 +3699,12 @@
       "required": [
         "id"
       ],
+      "then": {
+        "reduce": {
+          "delete": true,
+          "strategy": "merge"
+        }
+      },
       "type": [
         "object"
       ]
@@ -3632,6 +3724,23 @@
   {
     "documentSchema": {
       "$schema": "http://json-schema.org/draft-07/schema#",
+      "if": {
+        "properties": {
+          "_meta": {
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            },
+            "required": [
+              "op"
+            ]
+          }
+        },
+        "required": [
+          "_meta"
+        ]
+      },
       "properties": {
         "_meta": {
           "properties": {
@@ -3681,6 +3790,12 @@
       "required": [
         "canonical-vid"
       ],
+      "then": {
+        "reduce": {
+          "delete": true,
+          "strategy": "merge"
+        }
+      },
       "type": "object"
     },
     "key": [
@@ -3695,6 +3810,23 @@
   {
     "documentSchema": {
       "$schema": "http://json-schema.org/draft-07/schema#",
+      "if": {
+        "properties": {
+          "_meta": {
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            },
+            "required": [
+              "op"
+            ]
+          }
+        },
+        "required": [
+          "_meta"
+        ]
+      },
       "properties": {
         "_meta": {
           "properties": {
@@ -3832,6 +3964,12 @@
       "required": [
         "pipelineId"
       ],
+      "then": {
+        "reduce": {
+          "delete": true,
+          "strategy": "merge"
+        }
+      },
       "type": [
         "object"
       ]
@@ -3851,6 +3989,23 @@
   {
     "documentSchema": {
       "$schema": "http://json-schema.org/draft-07/schema#",
+      "if": {
+        "properties": {
+          "_meta": {
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            },
+            "required": [
+              "op"
+            ]
+          }
+        },
+        "required": [
+          "_meta"
+        ]
+      },
       "properties": {
         "_meta": {
           "properties": {
@@ -4846,6 +5001,12 @@
       "required": [
         "id"
       ],
+      "then": {
+        "reduce": {
+          "delete": true,
+          "strategy": "merge"
+        }
+      },
       "type": [
         "object"
       ]
@@ -4865,6 +5026,23 @@
   {
     "documentSchema": {
       "$schema": "http://json-schema.org/draft-07/schema#",
+      "if": {
+        "properties": {
+          "_meta": {
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            },
+            "required": [
+              "op"
+            ]
+          }
+        },
+        "required": [
+          "_meta"
+        ]
+      },
       "properties": {
         "_meta": {
           "properties": {
@@ -5861,6 +6039,12 @@
       "required": [
         "id"
       ],
+      "then": {
+        "reduce": {
+          "delete": true,
+          "strategy": "merge"
+        }
+      },
       "type": [
         "object"
       ]
@@ -5880,6 +6064,23 @@
   {
     "documentSchema": {
       "$schema": "http://json-schema.org/draft-07/schema#",
+      "if": {
+        "properties": {
+          "_meta": {
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            },
+            "required": [
+              "op"
+            ]
+          }
+        },
+        "required": [
+          "_meta"
+        ]
+      },
       "properties": {
         "_meta": {
           "properties": {
@@ -6258,6 +6459,12 @@
       "required": [
         "id"
       ],
+      "then": {
+        "reduce": {
+          "delete": true,
+          "strategy": "merge"
+        }
+      },
       "type": [
         "object"
       ]
@@ -6278,6 +6485,23 @@
     "documentSchema": {
       "$schema": "http://json-schema.org/draft-07/schema#",
       "additionalProperties": true,
+      "if": {
+        "properties": {
+          "_meta": {
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            },
+            "required": [
+              "op"
+            ]
+          }
+        },
+        "required": [
+          "_meta"
+        ]
+      },
       "properties": {
         "_meta": {
           "properties": {
@@ -6321,6 +6545,12 @@
       "required": [
         "id"
       ],
+      "then": {
+        "reduce": {
+          "delete": true,
+          "strategy": "merge"
+        }
+      },
       "type": [
         "object"
       ]
@@ -6337,6 +6567,23 @@
   {
     "documentSchema": {
       "$schema": "http://json-schema.org/draft-07/schema#",
+      "if": {
+        "properties": {
+          "_meta": {
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            },
+            "required": [
+              "op"
+            ]
+          }
+        },
+        "required": [
+          "_meta"
+        ]
+      },
       "properties": {
         "_meta": {
           "properties": {
@@ -6979,6 +7226,12 @@
       "required": [
         "id"
       ],
+      "then": {
+        "reduce": {
+          "delete": true,
+          "strategy": "merge"
+        }
+      },
       "type": [
         "object"
       ]
@@ -6998,6 +7251,23 @@
   {
     "documentSchema": {
       "$schema": "http://json-schema.org/draft-07/schema#",
+      "if": {
+        "properties": {
+          "_meta": {
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            },
+            "required": [
+              "op"
+            ]
+          }
+        },
+        "required": [
+          "_meta"
+        ]
+      },
       "properties": {
         "_meta": {
           "properties": {
@@ -7651,6 +7921,12 @@
       "required": [
         "id"
       ],
+      "then": {
+        "reduce": {
+          "delete": true,
+          "strategy": "merge"
+        }
+      },
       "type": [
         "object"
       ]
@@ -7670,6 +7946,23 @@
   {
     "documentSchema": {
       "$schema": "http://json-schema.org/draft-07/schema#",
+      "if": {
+        "properties": {
+          "_meta": {
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            },
+            "required": [
+              "op"
+            ]
+          }
+        },
+        "required": [
+          "_meta"
+        ]
+      },
       "properties": {
         "_meta": {
           "properties": {
@@ -8477,6 +8770,12 @@
       "required": [
         "id"
       ],
+      "then": {
+        "reduce": {
+          "delete": true,
+          "strategy": "merge"
+        }
+      },
       "type": [
         "object"
       ]
@@ -8496,6 +8795,23 @@
   {
     "documentSchema": {
       "$schema": "http://json-schema.org/draft-07/schema#",
+      "if": {
+        "properties": {
+          "_meta": {
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            },
+            "required": [
+              "op"
+            ]
+          }
+        },
+        "required": [
+          "_meta"
+        ]
+      },
       "properties": {
         "_meta": {
           "properties": {
@@ -9156,6 +9472,12 @@
       "required": [
         "id"
       ],
+      "then": {
+        "reduce": {
+          "delete": true,
+          "strategy": "merge"
+        }
+      },
       "type": [
         "object"
       ]
@@ -9175,6 +9497,23 @@
   {
     "documentSchema": {
       "$schema": "http://json-schema.org/draft-07/schema#",
+      "if": {
+        "properties": {
+          "_meta": {
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            },
+            "required": [
+              "op"
+            ]
+          }
+        },
+        "required": [
+          "_meta"
+        ]
+      },
       "properties": {
         "_meta": {
           "properties": {
@@ -9563,6 +9902,12 @@
       "required": [
         "id"
       ],
+      "then": {
+        "reduce": {
+          "delete": true,
+          "strategy": "merge"
+        }
+      },
       "type": [
         "object"
       ]
@@ -9582,6 +9927,23 @@
   {
     "documentSchema": {
       "$schema": "http://json-schema.org/draft-07/schema#",
+      "if": {
+        "properties": {
+          "_meta": {
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            },
+            "required": [
+              "op"
+            ]
+          }
+        },
+        "required": [
+          "_meta"
+        ]
+      },
       "properties": {
         "_meta": {
           "properties": {
@@ -10405,6 +10767,12 @@
       "required": [
         "id"
       ],
+      "then": {
+        "reduce": {
+          "delete": true,
+          "strategy": "merge"
+        }
+      },
       "type": [
         "object"
       ]
@@ -10424,6 +10792,23 @@
   {
     "documentSchema": {
       "$schema": "http://json-schema.org/draft-07/schema#",
+      "if": {
+        "properties": {
+          "_meta": {
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            },
+            "required": [
+              "op"
+            ]
+          }
+        },
+        "required": [
+          "_meta"
+        ]
+      },
       "properties": {
         "_meta": {
           "properties": {
@@ -11073,6 +11458,12 @@
       "required": [
         "id"
       ],
+      "then": {
+        "reduce": {
+          "delete": true,
+          "strategy": "merge"
+        }
+      },
       "type": [
         "object"
       ]
@@ -11092,6 +11483,23 @@
   {
     "documentSchema": {
       "$schema": "http://json-schema.org/draft-07/schema",
+      "if": {
+        "properties": {
+          "_meta": {
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            },
+            "required": [
+              "op"
+            ]
+          }
+        },
+        "required": [
+          "_meta"
+        ]
+      },
       "properties": {
         "_meta": {
           "properties": {
@@ -11156,6 +11564,12 @@
         "submittedAt",
         "formId"
       ],
+      "then": {
+        "reduce": {
+          "delete": true,
+          "strategy": "merge"
+        }
+      },
       "type": [
         "object"
       ]
@@ -11176,6 +11590,23 @@
   {
     "documentSchema": {
       "$schema": "http://json-schema.org/draft-07/schema#",
+      "if": {
+        "properties": {
+          "_meta": {
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            },
+            "required": [
+              "op"
+            ]
+          }
+        },
+        "required": [
+          "_meta"
+        ]
+      },
       "properties": {
         "_meta": {
           "properties": {
@@ -11798,6 +12229,12 @@
       "required": [
         "id"
       ],
+      "then": {
+        "reduce": {
+          "delete": true,
+          "strategy": "merge"
+        }
+      },
       "type": [
         "object"
       ]
@@ -11817,6 +12254,23 @@
   {
     "documentSchema": {
       "$schema": "http://json-schema.org/draft-07/schema#",
+      "if": {
+        "properties": {
+          "_meta": {
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            },
+            "required": [
+              "op"
+            ]
+          }
+        },
+        "required": [
+          "_meta"
+        ]
+      },
       "properties": {
         "_meta": {
           "properties": {
@@ -11909,6 +12363,12 @@
       "required": [
         "id"
       ],
+      "then": {
+        "reduce": {
+          "delete": true,
+          "strategy": "merge"
+        }
+      },
       "type": [
         "object"
       ]
@@ -11928,6 +12388,23 @@
   {
     "documentSchema": {
       "$schema": "http://json-schema.org/draft-07/schema#",
+      "if": {
+        "properties": {
+          "_meta": {
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            },
+            "required": [
+              "op"
+            ]
+          }
+        },
+        "required": [
+          "_meta"
+        ]
+      },
       "properties": {
         "_meta": {
           "properties": {
@@ -12301,6 +12778,12 @@
       "required": [
         "id"
       ],
+      "then": {
+        "reduce": {
+          "delete": true,
+          "strategy": "merge"
+        }
+      },
       "type": [
         "object"
       ]
@@ -12320,6 +12803,23 @@
   {
     "documentSchema": {
       "$schema": "http://json-schema.org/draft-07/schema",
+      "if": {
+        "properties": {
+          "_meta": {
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            },
+            "required": [
+              "op"
+            ]
+          }
+        },
+        "required": [
+          "_meta"
+        ]
+      },
       "properties": {
         "_meta": {
           "properties": {
@@ -14216,6 +14716,12 @@
         "property",
         "timestamp"
       ],
+      "then": {
+        "reduce": {
+          "delete": true,
+          "strategy": "merge"
+        }
+      },
       "type": [
         "object"
       ]
@@ -14233,6 +14739,23 @@
   {
     "documentSchema": {
       "$schema": "http://json-schema.org/draft-07/schema#",
+      "if": {
+        "properties": {
+          "_meta": {
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            },
+            "required": [
+              "op"
+            ]
+          }
+        },
+        "required": [
+          "_meta"
+        ]
+      },
       "properties": {
         "_meta": {
           "properties": {
@@ -14332,6 +14855,12 @@
         "timestamp",
         "recipient"
       ],
+      "then": {
+        "reduce": {
+          "delete": true,
+          "strategy": "merge"
+        }
+      },
       "type": [
         "object"
       ]
@@ -14352,6 +14881,23 @@
   {
     "documentSchema": {
       "$schema": "http://json-schema.org/draft-07/schema#",
+      "if": {
+        "properties": {
+          "_meta": {
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            },
+            "required": [
+              "op"
+            ]
+          }
+        },
+        "required": [
+          "_meta"
+        ]
+      },
       "properties": {
         "_meta": {
           "properties": {
@@ -15347,6 +15893,12 @@
       "required": [
         "id"
       ],
+      "then": {
+        "reduce": {
+          "delete": true,
+          "strategy": "merge"
+        }
+      },
       "type": [
         "object"
       ]
@@ -15366,6 +15918,23 @@
   {
     "documentSchema": {
       "$schema": "http://json-schema.org/draft-07/schema#",
+      "if": {
+        "properties": {
+          "_meta": {
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            },
+            "required": [
+              "op"
+            ]
+          }
+        },
+        "required": [
+          "_meta"
+        ]
+      },
       "properties": {
         "_meta": {
           "properties": {
@@ -15483,6 +16052,12 @@
       "required": [
         "id"
       ],
+      "then": {
+        "reduce": {
+          "delete": true,
+          "strategy": "merge"
+        }
+      },
       "type": [
         "object"
       ]
@@ -15502,6 +16077,23 @@
   {
     "documentSchema": {
       "$schema": "http://json-schema.org/draft-07/schema#",
+      "if": {
+        "properties": {
+          "_meta": {
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            },
+            "required": [
+              "op"
+            ]
+          }
+        },
+        "required": [
+          "_meta"
+        ]
+      },
       "properties": {
         "_meta": {
           "properties": {
@@ -15595,6 +16187,12 @@
       "required": [
         "id"
       ],
+      "then": {
+        "reduce": {
+          "delete": true,
+          "strategy": "merge"
+        }
+      },
       "type": [
         "object"
       ]

--- a/source-impact-native/tests/snapshots/snapshots__discover__stdout.json
+++ b/source-impact-native/tests/snapshots/snapshots__discover__stdout.json
@@ -51,7 +51,30 @@
       ],
       "title": "Actions",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/Id"
@@ -109,7 +132,30 @@
       ],
       "title": "ActionInquiries",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/Id"
@@ -167,7 +213,30 @@
       ],
       "title": "Invoices",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/Id"
@@ -225,7 +294,30 @@
       ],
       "title": "Jobs",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/Id"
@@ -283,7 +375,30 @@
       ],
       "title": "PromoCodes",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/Id"
@@ -341,7 +456,30 @@
       ],
       "title": "Deals",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/Id"
@@ -399,7 +537,30 @@
       ],
       "title": "ExceptionLists",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/Id"
@@ -457,7 +618,30 @@
       ],
       "title": "UniqueUrls",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/Id"
@@ -515,7 +699,30 @@
       ],
       "title": "TrackingValueRequests",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/Id"
@@ -566,7 +773,30 @@
       },
       "title": "Campaigns",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/_meta/row_id"
@@ -617,7 +847,30 @@
       },
       "title": "Ads",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/_meta/row_id"
@@ -668,7 +921,30 @@
       },
       "title": "Catalogs",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/_meta/row_id"
@@ -719,7 +995,30 @@
       },
       "title": "Reports",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/_meta/row_id"
@@ -770,7 +1069,30 @@
       },
       "title": "PhoneNumbers",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/_meta/row_id"
@@ -828,7 +1150,30 @@
       ],
       "title": "Contracts",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/Id"
@@ -886,7 +1231,30 @@
       ],
       "title": "Tasks",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/Id"
@@ -944,7 +1312,30 @@
       ],
       "title": "Notes",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/Id"
@@ -1002,7 +1393,30 @@
       ],
       "title": "BlockRedirectRules",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/Id"
@@ -1053,7 +1467,30 @@
       },
       "title": "MediaPartnerGroups",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/_meta/row_id"

--- a/source-incident-io/tests/snapshots/snapshots__discover__capture.stdout.json
+++ b/source-incident-io/tests/snapshots/snapshots__discover__capture.stdout.json
@@ -53,7 +53,30 @@
       ],
       "title": "IncrementalStream",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
@@ -99,7 +122,30 @@
       },
       "title": "BaseDocument",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/_meta/row_id"
@@ -159,7 +205,30 @@
       ],
       "title": "IncrementalStream",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
@@ -219,7 +288,30 @@
       ],
       "title": "IncrementalStream",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
@@ -265,7 +357,30 @@
       },
       "title": "BaseDocument",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/_meta/row_id"
@@ -325,7 +440,30 @@
       ],
       "title": "IncrementalStream",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
@@ -385,7 +523,30 @@
       ],
       "title": "IncrementalStream",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
@@ -431,7 +592,30 @@
       },
       "title": "BaseDocument",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/_meta/row_id"
@@ -491,7 +675,30 @@
       ],
       "title": "IncrementalStream",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
@@ -551,7 +758,30 @@
       ],
       "title": "IncrementalStream",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
@@ -611,7 +841,30 @@
       ],
       "title": "IncrementalStream",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
@@ -657,7 +910,30 @@
       },
       "title": "BaseDocument",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/_meta/row_id"

--- a/source-intercom-native/tests/snapshots/snapshots__discover__capture.stdout.json
+++ b/source-intercom-native/tests/snapshots/snapshots__discover__capture.stdout.json
@@ -39,7 +39,30 @@
       },
       "title": "BaseDocument",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/_meta/row_id"
@@ -85,7 +108,30 @@
       },
       "title": "BaseDocument",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/_meta/row_id"
@@ -131,7 +177,30 @@
       },
       "title": "BaseDocument",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/_meta/row_id"
@@ -177,7 +246,30 @@
       },
       "title": "BaseDocument",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/_meta/row_id"
@@ -223,7 +315,30 @@
       },
       "title": "BaseDocument",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/_meta/row_id"
@@ -269,7 +384,30 @@
       },
       "title": "BaseDocument",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/_meta/row_id"
@@ -328,7 +466,30 @@
       ],
       "title": "TimestampedResource",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
@@ -387,7 +548,30 @@
       ],
       "title": "TimestampedResource",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
@@ -446,7 +630,30 @@
       ],
       "title": "TimestampedResource",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
@@ -505,7 +712,30 @@
       ],
       "title": "TimestampedResource",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
@@ -564,7 +794,30 @@
       ],
       "title": "TimestampedResource",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
@@ -623,7 +876,30 @@
       ],
       "title": "TimestampedResource",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
@@ -682,7 +958,30 @@
       ],
       "title": "TimestampedResource",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"

--- a/source-iterable-native/tests/snapshots/snapshots__discover__capture.stdout.json
+++ b/source-iterable-native/tests/snapshots/snapshots__discover__capture.stdout.json
@@ -47,7 +47,30 @@
       ],
       "title": "CampaignMetrics",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
@@ -159,7 +182,30 @@
       ],
       "title": "Campaigns",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
@@ -205,7 +251,30 @@
       },
       "title": "BaseDocument",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/_meta/row_id"
@@ -286,7 +355,30 @@
       ],
       "title": "Events",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/_estuary_id",
@@ -347,7 +439,30 @@
       ],
       "title": "ListUsers",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/list_id",
@@ -395,7 +510,30 @@
       },
       "title": "BaseDocument",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/_meta/row_id"
@@ -441,7 +579,30 @@
       },
       "title": "BaseDocument",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/_meta/row_id"
@@ -487,7 +648,30 @@
       },
       "title": "BaseDocument",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/_meta/row_id"
@@ -533,7 +717,30 @@
       },
       "title": "BaseDocument",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/_meta/row_id"
@@ -593,7 +800,30 @@
       ],
       "title": "UsersWithEmails",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/email"

--- a/source-iterable/tests/snapshots/snapshots__discover__capture.stdout.json
+++ b/source-iterable/tests/snapshots/snapshots__discover__capture.stdout.json
@@ -131,7 +131,30 @@
         "id"
       ],
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
@@ -175,7 +198,30 @@
         "id"
       ],
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
@@ -226,7 +272,30 @@
         "id"
       ],
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
@@ -279,7 +348,30 @@
         "id"
       ],
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
@@ -324,7 +416,30 @@
         "id"
       ],
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
@@ -354,7 +469,30 @@
         }
       },
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/_meta/row_id"
@@ -433,7 +571,30 @@
         "templateId"
       ],
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/templateId"
@@ -1101,7 +1262,30 @@
         "email"
       ],
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/email"
@@ -1137,7 +1321,30 @@
         "listId"
       ],
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/listId"
@@ -1230,7 +1437,30 @@
         "messageId"
       ],
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/messageId",
@@ -1372,7 +1602,30 @@
         "messageId"
       ],
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/messageId",
@@ -1466,7 +1719,30 @@
         "messageId"
       ],
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/messageId",
@@ -1590,7 +1866,30 @@
         "messageId"
       ],
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/messageId",
@@ -1861,7 +2160,30 @@
         "messageId"
       ],
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/messageId",
@@ -2133,7 +2455,30 @@
         "messageId"
       ],
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/messageId",
@@ -2235,7 +2580,30 @@
         "email"
       ],
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/email",
@@ -2363,7 +2731,30 @@
         "email"
       ],
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/email"
@@ -2444,7 +2835,30 @@
         "email"
       ],
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/email",
@@ -2526,7 +2940,30 @@
         "email"
       ],
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/email",
@@ -2608,7 +3045,30 @@
         "email"
       ],
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/email",
@@ -2690,7 +3150,30 @@
         "email"
       ],
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/email",
@@ -2772,7 +3255,30 @@
         "email"
       ],
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/email",
@@ -2854,7 +3360,30 @@
         "email"
       ],
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/email",
@@ -2936,7 +3465,30 @@
         "email"
       ],
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/email",
@@ -3018,7 +3570,30 @@
         "email"
       ],
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/email",
@@ -3100,7 +3675,30 @@
         "email"
       ],
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/email",
@@ -3182,7 +3780,30 @@
         "email"
       ],
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/email",
@@ -3264,7 +3885,30 @@
         "email"
       ],
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/email",
@@ -3346,7 +3990,30 @@
         "email"
       ],
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/email",
@@ -3428,7 +4095,30 @@
         "email"
       ],
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/email",
@@ -3510,7 +4200,30 @@
         "email"
       ],
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/email",
@@ -3592,7 +4305,30 @@
         "email"
       ],
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/email",
@@ -3674,7 +4410,30 @@
         "email"
       ],
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/email",
@@ -3756,7 +4515,30 @@
         "email"
       ],
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/email",
@@ -3838,7 +4620,30 @@
         "email"
       ],
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/email",
@@ -3920,7 +4725,30 @@
         "email"
       ],
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/email",
@@ -4002,7 +4830,30 @@
         "email"
       ],
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/email",
@@ -4084,7 +4935,30 @@
         "email"
       ],
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/email",
@@ -4166,7 +5040,30 @@
         "email"
       ],
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/email",
@@ -4248,7 +5145,30 @@
         "email"
       ],
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/email",
@@ -4330,7 +5250,30 @@
         "email"
       ],
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/email",
@@ -4412,7 +5355,30 @@
         "email"
       ],
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/email",
@@ -4494,7 +5460,30 @@
         "email"
       ],
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/email",

--- a/source-iterate/tests/snapshots/snapshots__discover__capture.stdout.json
+++ b/source-iterate/tests/snapshots/snapshots__discover__capture.stdout.json
@@ -40,7 +40,30 @@
       },
       "title": "FullRefreshResource",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/_meta/row_id"
@@ -87,7 +110,30 @@
       },
       "title": "FullRefreshResource",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/_meta/row_id"

--- a/source-jira-legacy/tests/snapshots/snapshots__discover__capture.stdout.json
+++ b/source-jira-legacy/tests/snapshots/snapshots__discover__capture.stdout.json
@@ -1,48 +1,23 @@
 [
   {
-    "documentSchema": {
-      "$schema": "http://json-schema.org/draft-07/schema#",
-      "additionalProperties": true,
-      "description": "Details of an application role.",
-      "properties": {
-        "_meta": {
-          "properties": {
-            "row_id": {
-              "type": "integer"
-            }
-          },
-          "required": [
-            "row_id"
-          ],
-          "type": "object"
-        },
-        "key": {
-          "description": "The key identifier of the application role.",
-          "type": "string"
-        }
-      },
-      "required": [
-        "key"
-      ],
-      "type": "object",
-      "x-infer-schema": true
-    },
-    "key": [
-      "/key"
-    ],
     "recommendedName": "application_roles",
     "resourceConfig": {
       "stream": "application_roles",
       "syncMode": "full_refresh"
-    }
-  },
-  {
+    },
     "documentSchema": {
       "$schema": "http://json-schema.org/draft-07/schema#",
-      "additionalProperties": true,
-      "description": "List of system avatars.",
+      "type": "object",
+      "required": [
+        "key"
+      ],
       "properties": {
+        "key": {
+          "description": "The key identifier of the application role.",
+          "type": "string"
+        },
         "_meta": {
+          "type": "object",
           "properties": {
             "row_id": {
               "type": "integer"
@@ -50,35 +25,59 @@
           },
           "required": [
             "row_id"
-          ],
-          "type": "object"
-        },
-        "id": {
-          "description": "The ID of the avatar.",
-          "type": "string"
+          ]
         }
       },
-      "required": [
-        "id"
-      ],
-      "type": "object",
-      "x-infer-schema": true
+      "additionalProperties": true,
+      "description": "Details of an application role.",
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
-      "/id"
-    ],
+      "/key"
+    ]
+  },
+  {
     "recommendedName": "avatars",
     "resourceConfig": {
       "stream": "avatars",
       "syncMode": "full_refresh"
-    }
-  },
-  {
+    },
     "documentSchema": {
       "$schema": "http://json-schema.org/draft-07/schema#",
-      "additionalProperties": true,
+      "type": "object",
+      "required": [
+        "id"
+      ],
       "properties": {
+        "id": {
+          "description": "The ID of the avatar.",
+          "type": "string"
+        },
         "_meta": {
+          "type": "object",
           "properties": {
             "row_id": {
               "type": "integer"
@@ -86,35 +85,59 @@
           },
           "required": [
             "row_id"
-          ],
-          "type": "object"
-        },
-        "id": {
-          "description": "Unique identifier of the board.",
-          "type": "integer"
+          ]
         }
       },
-      "required": [
-        "id"
-      ],
-      "type": "object",
-      "x-infer-schema": true
+      "additionalProperties": true,
+      "description": "List of system avatars.",
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
-    ],
+    ]
+  },
+  {
     "recommendedName": "boards",
     "resourceConfig": {
       "stream": "boards",
       "syncMode": "full_refresh"
-    }
-  },
-  {
+    },
     "documentSchema": {
       "$schema": "http://json-schema.org/draft-07/schema#",
-      "additionalProperties": true,
+      "type": "object",
+      "required": [
+        "id"
+      ],
       "properties": {
+        "id": {
+          "description": "Unique identifier of the board.",
+          "type": "integer"
+        },
         "_meta": {
+          "type": "object",
           "properties": {
             "row_id": {
               "type": "integer"
@@ -122,39 +145,61 @@
           },
           "required": [
             "row_id"
-          ],
-          "type": "object"
-        },
+          ]
+        }
+      },
+      "additionalProperties": true,
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
+    },
+    "key": [
+      "/id"
+    ]
+  },
+  {
+    "recommendedName": "board_issues",
+    "resourceConfig": {
+      "stream": "board_issues",
+      "syncMode": "incremental",
+      "cursorField": [
+        "updated"
+      ]
+    },
+    "documentSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "required": [
+        "id"
+      ],
+      "properties": {
         "id": {
           "description": "The unique identifier of the issue",
           "type": "string"
-        }
-      },
-      "required": [
-        "id"
-      ],
-      "type": "object",
-      "x-infer-schema": true
-    },
-    "key": [
-      "/id"
-    ],
-    "recommendedName": "board_issues",
-    "resourceConfig": {
-      "cursorField": [
-        "updated"
-      ],
-      "stream": "board_issues",
-      "syncMode": "incremental"
-    }
-  },
-  {
-    "documentSchema": {
-      "$schema": "http://json-schema.org/draft-07/schema#",
-      "additionalProperties": true,
-      "description": "Details of a dashboard.",
-      "properties": {
+        },
         "_meta": {
+          "type": "object",
           "properties": {
             "row_id": {
               "type": "integer"
@@ -162,36 +207,58 @@
           },
           "required": [
             "row_id"
-          ],
-          "type": "object"
-        },
-        "id": {
-          "description": "The ID of the dashboard.",
-          "type": "string"
+          ]
         }
       },
-      "required": [
-        "id"
-      ],
-      "type": "object",
-      "x-infer-schema": true
+      "additionalProperties": true,
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
-    ],
+    ]
+  },
+  {
     "recommendedName": "dashboards",
     "resourceConfig": {
       "stream": "dashboards",
       "syncMode": "full_refresh"
-    }
-  },
-  {
+    },
     "documentSchema": {
       "$schema": "http://json-schema.org/draft-07/schema#",
-      "additionalProperties": true,
-      "description": "Details of a filter.",
+      "type": "object",
+      "required": [
+        "id"
+      ],
       "properties": {
+        "id": {
+          "description": "The ID of the dashboard.",
+          "type": "string"
+        },
         "_meta": {
+          "type": "object",
           "properties": {
             "row_id": {
               "type": "integer"
@@ -199,37 +266,60 @@
           },
           "required": [
             "row_id"
-          ],
-          "type": "object"
-        },
-        "id": {
-          "description": "The unique identifier for the filter.",
-          "readOnly": true,
-          "type": "string"
+          ]
         }
       },
-      "required": [
-        "id"
-      ],
-      "type": "object",
-      "x-infer-schema": true
+      "additionalProperties": true,
+      "description": "Details of a dashboard.",
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
-    ],
+    ]
+  },
+  {
     "recommendedName": "filters",
     "resourceConfig": {
       "stream": "filters",
       "syncMode": "full_refresh"
-    }
-  },
-  {
+    },
     "documentSchema": {
       "$schema": "http://json-schema.org/draft-07/schema#",
-      "additionalProperties": true,
-      "description": "Details of a share permission for the filter.",
+      "type": "object",
+      "required": [
+        "id"
+      ],
       "properties": {
+        "id": {
+          "type": "string",
+          "description": "The unique identifier for the filter.",
+          "readOnly": true
+        },
         "_meta": {
+          "type": "object",
           "properties": {
             "row_id": {
               "type": "integer"
@@ -237,37 +327,60 @@
           },
           "required": [
             "row_id"
-          ],
-          "type": "object"
-        },
-        "id": {
-          "description": "The unique identifier of the share permission.",
-          "readOnly": true,
-          "type": "integer"
+          ]
         }
       },
-      "required": [
-        "id"
-      ],
-      "type": "object",
-      "x-infer-schema": true
+      "additionalProperties": true,
+      "description": "Details of a filter.",
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
-    ],
+    ]
+  },
+  {
     "recommendedName": "filter_sharing",
     "resourceConfig": {
       "stream": "filter_sharing",
       "syncMode": "full_refresh"
-    }
-  },
-  {
+    },
     "documentSchema": {
       "$schema": "http://json-schema.org/draft-07/schema#",
-      "additionalProperties": true,
-      "description": "The list of groups found in a search, including header text (Showing X of Y matching groups) and total of matched groups.",
+      "type": "object",
+      "required": [
+        "id"
+      ],
       "properties": {
+        "id": {
+          "type": "integer",
+          "description": "The unique identifier of the share permission.",
+          "readOnly": true
+        },
         "_meta": {
+          "type": "object",
           "properties": {
             "row_id": {
               "type": "integer"
@@ -275,35 +388,59 @@
           },
           "required": [
             "row_id"
-          ],
-          "type": "object"
-        },
-        "groupId": {
-          "description": "The ID of the group, if available, which uniquely identifies the group across all Atlassian products. For example, *952d12c3-5b5b-4d04-bb32-44d383afc4b2*.",
-          "type": "string"
+          ]
         }
       },
-      "required": [
-        "groupId"
-      ],
-      "type": "object",
-      "x-infer-schema": true
+      "additionalProperties": true,
+      "description": "Details of a share permission for the filter.",
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
-      "/groupId"
-    ],
+      "/id"
+    ]
+  },
+  {
     "recommendedName": "groups",
     "resourceConfig": {
       "stream": "groups",
       "syncMode": "full_refresh"
-    }
-  },
-  {
+    },
     "documentSchema": {
       "$schema": "http://json-schema.org/draft-07/schema#",
-      "additionalProperties": true,
+      "type": "object",
+      "required": [
+        "groupId"
+      ],
       "properties": {
+        "groupId": {
+          "description": "The ID of the group, if available, which uniquely identifies the group across all Atlassian products. For example, *952d12c3-5b5b-4d04-bb32-44d383afc4b2*.",
+          "type": "string"
+        },
         "_meta": {
+          "type": "object",
           "properties": {
             "row_id": {
               "type": "integer"
@@ -311,39 +448,63 @@
           },
           "required": [
             "row_id"
-          ],
-          "type": "object"
-        },
-        "id": {
-          "description": "The unique ID of the issue.",
-          "readOnly": true,
-          "type": "string"
+          ]
         }
       },
-      "required": [
-        "id"
-      ],
-      "type": "object",
-      "x-infer-schema": true
+      "additionalProperties": true,
+      "description": "The list of groups found in a search, including header text (Showing X of Y matching groups) and total of matched groups.",
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
-      "/id"
-    ],
+      "/groupId"
+    ]
+  },
+  {
     "recommendedName": "issues",
     "resourceConfig": {
+      "stream": "issues",
+      "syncMode": "incremental",
       "cursorField": [
         "updated"
-      ],
-      "stream": "issues",
-      "syncMode": "incremental"
-    }
-  },
-  {
+      ]
+    },
     "documentSchema": {
       "$schema": "http://json-schema.org/draft-07/schema#",
-      "additionalProperties": true,
+      "type": "object",
+      "required": [
+        "id"
+      ],
       "properties": {
+        "id": {
+          "description": "The unique ID of the issue.",
+          "type": "string",
+          "readOnly": true
+        },
         "_meta": {
+          "type": "object",
           "properties": {
             "row_id": {
               "type": "integer"
@@ -351,40 +512,62 @@
           },
           "required": [
             "row_id"
-          ],
-          "type": "object"
-        },
-        "id": {
-          "description": "The ID of the comment.",
-          "readOnly": true,
-          "type": "string"
+          ]
         }
       },
-      "required": [
-        "id"
-      ],
-      "type": "object",
-      "x-infer-schema": true
+      "additionalProperties": true,
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
-    ],
+    ]
+  },
+  {
     "recommendedName": "issue_comments",
     "resourceConfig": {
+      "stream": "issue_comments",
+      "syncMode": "incremental",
       "cursorField": [
         "updated"
-      ],
-      "stream": "issue_comments",
-      "syncMode": "incremental"
-    }
-  },
-  {
+      ]
+    },
     "documentSchema": {
       "$schema": "http://json-schema.org/draft-07/schema#",
-      "additionalProperties": true,
-      "description": "Details about a field.",
+      "type": "object",
+      "required": [
+        "id"
+      ],
       "properties": {
+        "id": {
+          "description": "The ID of the comment.",
+          "type": "string",
+          "readOnly": true
+        },
         "_meta": {
+          "type": "object",
           "properties": {
             "row_id": {
               "type": "integer"
@@ -392,36 +575,58 @@
           },
           "required": [
             "row_id"
-          ],
-          "type": "object"
-        },
-        "id": {
-          "description": "The ID of the field.",
-          "type": "string"
+          ]
         }
       },
-      "required": [
-        "id"
-      ],
-      "type": "object",
-      "x-infer-schema": true
+      "additionalProperties": true,
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
-    ],
+    ]
+  },
+  {
     "recommendedName": "issue_fields",
     "resourceConfig": {
       "stream": "issue_fields",
       "syncMode": "full_refresh"
-    }
-  },
-  {
+    },
     "documentSchema": {
       "$schema": "http://json-schema.org/draft-07/schema#",
-      "additionalProperties": true,
-      "description": "Details of a field configuration.",
+      "type": "object",
+      "required": [
+        "id"
+      ],
       "properties": {
+        "id": {
+          "description": "The ID of the field.",
+          "type": "string"
+        },
         "_meta": {
+          "type": "object",
           "properties": {
             "row_id": {
               "type": "integer"
@@ -429,36 +634,59 @@
           },
           "required": [
             "row_id"
-          ],
-          "type": "object"
-        },
-        "id": {
-          "description": "The ID of the field configuration.",
-          "type": "integer"
+          ]
         }
       },
-      "required": [
-        "id"
-      ],
-      "type": "object",
-      "x-infer-schema": true
+      "additionalProperties": true,
+      "description": "Details about a field.",
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
-    ],
+    ]
+  },
+  {
     "recommendedName": "issue_field_configurations",
     "resourceConfig": {
       "stream": "issue_field_configurations",
       "syncMode": "full_refresh"
-    }
-  },
-  {
+    },
     "documentSchema": {
-      "$schema": "https://json-schema.org/draft-07/schema#",
-      "additionalProperties": true,
-      "description": "The details of a custom field context.",
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "required": [
+        "id"
+      ],
       "properties": {
+        "id": {
+          "description": "The ID of the field configuration.",
+          "type": "integer"
+        },
         "_meta": {
+          "type": "object",
           "properties": {
             "row_id": {
               "type": "integer"
@@ -466,36 +694,60 @@
           },
           "required": [
             "row_id"
-          ],
-          "type": "object"
-        },
-        "id": {
-          "description": "The ID of the context.",
-          "type": "string"
+          ]
         }
       },
-      "required": [
-        "id"
-      ],
-      "type": "object",
-      "x-infer-schema": true
+      "additionalProperties": true,
+      "description": "Details of a field configuration.",
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
-    ],
+    ]
+  },
+  {
     "recommendedName": "issue_custom_field_contexts",
     "resourceConfig": {
       "stream": "issue_custom_field_contexts",
       "syncMode": "full_refresh"
-    }
-  },
-  {
+    },
     "documentSchema": {
       "$schema": "https://json-schema.org/draft-07/schema#",
-      "additionalProperties": true,
-      "description": "Details of the custom field options for a context.",
+      "type": "object",
+      "description": "The details of a custom field context.",
+      "required": [
+        "id"
+      ],
       "properties": {
+        "id": {
+          "description": "The ID of the context.",
+          "type": "string"
+        },
         "_meta": {
+          "type": "object",
           "properties": {
             "row_id": {
               "type": "integer"
@@ -503,36 +755,59 @@
           },
           "required": [
             "row_id"
-          ],
-          "type": "object"
-        },
-        "id": {
-          "description": "The ID of the custom field option.",
-          "type": "string"
+          ]
         }
       },
-      "required": [
-        "id"
-      ],
-      "type": "object",
-      "x-infer-schema": true
+      "additionalProperties": true,
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
-    ],
+    ]
+  },
+  {
     "recommendedName": "issue_custom_field_options",
     "resourceConfig": {
       "stream": "issue_custom_field_options",
       "syncMode": "full_refresh"
-    }
-  },
-  {
+    },
     "documentSchema": {
-      "$schema": "http://json-schema.org/draft-07/schema#",
-      "additionalProperties": true,
-      "description": "A list of issue link type beans.",
+      "$schema": "https://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "description": "Details of the custom field options for a context.",
+      "required": [
+        "id"
+      ],
       "properties": {
+        "id": {
+          "description": "The ID of the custom field option.",
+          "type": "string"
+        },
         "_meta": {
+          "type": "object",
           "properties": {
             "row_id": {
               "type": "integer"
@@ -540,36 +815,58 @@
           },
           "required": [
             "row_id"
-          ],
-          "type": "object"
-        },
-        "id": {
-          "description": "The ID of the issue link type. Used as the type of issue link in `issueLink` resource. Required on create when `name` isn't provided. Otherwise, read only.",
-          "type": "string"
+          ]
         }
       },
-      "required": [
-        "id"
-      ],
-      "type": "object",
-      "x-infer-schema": true
+      "additionalProperties": true,
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
-    ],
+    ]
+  },
+  {
     "recommendedName": "issue_link_types",
     "resourceConfig": {
       "stream": "issue_link_types",
       "syncMode": "full_refresh"
-    }
-  },
-  {
+    },
     "documentSchema": {
       "$schema": "http://json-schema.org/draft-07/schema#",
-      "additionalProperties": true,
-      "description": "Details of an issue navigator column item.",
+      "type": "object",
+      "required": [
+        "id"
+      ],
       "properties": {
+        "id": {
+          "description": "The ID of the issue link type. Used as the type of issue link in `issueLink` resource. Required on create when `name` isn't provided. Otherwise, read only.",
+          "type": "string"
+        },
         "_meta": {
+          "type": "object",
           "properties": {
             "row_id": {
               "type": "integer"
@@ -577,36 +874,59 @@
           },
           "required": [
             "row_id"
-          ],
-          "type": "object"
-        },
-        "value": {
-          "description": "The actual value/data associated with the label in the issue navigator column.",
-          "type": "string"
+          ]
         }
       },
-      "required": [
-        "value"
-      ],
-      "type": "object",
-      "x-infer-schema": true
+      "additionalProperties": true,
+      "description": "A list of issue link type beans.",
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
-      "/value"
-    ],
+      "/id"
+    ]
+  },
+  {
     "recommendedName": "issue_navigator_settings",
     "resourceConfig": {
       "stream": "issue_navigator_settings",
       "syncMode": "full_refresh"
-    }
-  },
-  {
+    },
     "documentSchema": {
       "$schema": "http://json-schema.org/draft-07/schema#",
-      "additionalProperties": true,
-      "description": "Details about a notification scheme.",
+      "type": "object",
+      "required": [
+        "value"
+      ],
       "properties": {
+        "value": {
+          "description": "The actual value/data associated with the label in the issue navigator column.",
+          "type": "string"
+        },
         "_meta": {
+          "type": "object",
           "properties": {
             "row_id": {
               "type": "integer"
@@ -614,36 +934,59 @@
           },
           "required": [
             "row_id"
-          ],
-          "type": "object"
-        },
-        "id": {
-          "description": "The ID of the notification scheme.",
-          "type": "integer"
+          ]
         }
       },
-      "required": [
-        "id"
-      ],
-      "type": "object",
-      "x-infer-schema": true
+      "additionalProperties": true,
+      "description": "Details of an issue navigator column item.",
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
-      "/id"
-    ],
+      "/value"
+    ]
+  },
+  {
     "recommendedName": "issue_notification_schemes",
     "resourceConfig": {
       "stream": "issue_notification_schemes",
       "syncMode": "full_refresh"
-    }
-  },
-  {
+    },
     "documentSchema": {
       "$schema": "http://json-schema.org/draft-07/schema#",
-      "additionalProperties": true,
-      "description": "An issue priority.",
+      "type": "object",
+      "required": [
+        "id"
+      ],
       "properties": {
+        "id": {
+          "description": "The ID of the notification scheme.",
+          "type": "integer"
+        },
         "_meta": {
+          "type": "object",
           "properties": {
             "row_id": {
               "type": "integer"
@@ -651,36 +994,59 @@
           },
           "required": [
             "row_id"
-          ],
-          "type": "object"
-        },
-        "id": {
-          "description": "The ID of the issue priority.",
-          "type": "string"
+          ]
         }
       },
-      "required": [
-        "id"
-      ],
-      "type": "object",
-      "x-infer-schema": true
+      "additionalProperties": true,
+      "description": "Details about a notification scheme.",
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
-    ],
+    ]
+  },
+  {
     "recommendedName": "issue_priorities",
     "resourceConfig": {
       "stream": "issue_priorities",
       "syncMode": "full_refresh"
-    }
-  },
-  {
+    },
     "documentSchema": {
       "$schema": "http://json-schema.org/draft-07/schema#",
-      "additionalProperties": true,
-      "description": "An entity property, for more information see [Entity properties](https://developer.atlassian.com/cloud/jira/platform/jira-entity-properties/).",
+      "type": "object",
+      "required": [
+        "id"
+      ],
       "properties": {
+        "id": {
+          "description": "The ID of the issue priority.",
+          "type": "string"
+        },
         "_meta": {
+          "type": "object",
           "properties": {
             "row_id": {
               "type": "integer"
@@ -688,36 +1054,59 @@
           },
           "required": [
             "row_id"
-          ],
-          "type": "object"
-        },
-        "key": {
-          "description": "The key of the property. Required on create and update.",
-          "type": "string"
+          ]
         }
       },
-      "required": [
-        "key"
-      ],
-      "type": "object",
-      "x-infer-schema": true
+      "additionalProperties": true,
+      "description": "An issue priority.",
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
-      "/key"
-    ],
+      "/id"
+    ]
+  },
+  {
     "recommendedName": "issue_properties",
     "resourceConfig": {
       "stream": "issue_properties",
       "syncMode": "full_refresh"
-    }
-  },
-  {
+    },
     "documentSchema": {
       "$schema": "http://json-schema.org/draft-07/schema#",
-      "additionalProperties": true,
-      "description": "Details of an issue remote link.",
+      "type": "object",
+      "required": [
+        "key"
+      ],
       "properties": {
+        "key": {
+          "description": "The key of the property. Required on create and update.",
+          "type": "string"
+        },
         "_meta": {
+          "type": "object",
           "properties": {
             "row_id": {
               "type": "integer"
@@ -725,36 +1114,59 @@
           },
           "required": [
             "row_id"
-          ],
-          "type": "object"
-        },
-        "id": {
-          "description": "The ID of the link.",
-          "type": "integer"
+          ]
         }
       },
-      "required": [
-        "id"
-      ],
-      "type": "object",
-      "x-infer-schema": true
+      "additionalProperties": true,
+      "description": "An entity property, for more information see [Entity properties](https://developer.atlassian.com/cloud/jira/platform/jira-entity-properties/).",
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
-      "/id"
-    ],
+      "/key"
+    ]
+  },
+  {
     "recommendedName": "issue_remote_links",
     "resourceConfig": {
       "stream": "issue_remote_links",
       "syncMode": "full_refresh"
-    }
-  },
-  {
+    },
     "documentSchema": {
       "$schema": "http://json-schema.org/draft-07/schema#",
-      "additionalProperties": true,
-      "description": "Details of an issue resolution.",
+      "type": "object",
+      "required": [
+        "id"
+      ],
       "properties": {
+        "id": {
+          "description": "The ID of the link.",
+          "type": "integer"
+        },
         "_meta": {
+          "type": "object",
           "properties": {
             "row_id": {
               "type": "integer"
@@ -762,36 +1174,59 @@
           },
           "required": [
             "row_id"
-          ],
-          "type": "object"
-        },
-        "id": {
-          "description": "The ID of the issue resolution.",
-          "type": "string"
+          ]
         }
       },
-      "required": [
-        "id"
-      ],
-      "type": "object",
-      "x-infer-schema": true
+      "additionalProperties": true,
+      "description": "Details of an issue remote link.",
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
-    ],
+    ]
+  },
+  {
     "recommendedName": "issue_resolutions",
     "resourceConfig": {
       "stream": "issue_resolutions",
       "syncMode": "full_refresh"
-    }
-  },
-  {
+    },
     "documentSchema": {
       "$schema": "http://json-schema.org/draft-07/schema#",
-      "additionalProperties": true,
-      "description": "List of security schemes.",
+      "type": "object",
+      "required": [
+        "id"
+      ],
       "properties": {
+        "id": {
+          "description": "The ID of the issue resolution.",
+          "type": "string"
+        },
         "_meta": {
+          "type": "object",
           "properties": {
             "row_id": {
               "type": "integer"
@@ -799,36 +1234,60 @@
           },
           "required": [
             "row_id"
-          ],
-          "type": "object"
-        },
-        "id": {
-          "description": "The ID of the issue security scheme.",
-          "readOnly": true,
-          "type": "integer"
+          ]
         }
       },
-      "required": [
-        "id"
-      ],
-      "type": "object",
-      "x-infer-schema": true
+      "additionalProperties": true,
+      "description": "Details of an issue resolution.",
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
-    ],
+    ]
+  },
+  {
     "recommendedName": "issue_security_schemes",
     "resourceConfig": {
       "stream": "issue_security_schemes",
       "syncMode": "full_refresh"
-    }
-  },
-  {
+    },
     "documentSchema": {
-      "$schema": "https://json-schema.org/draft-07/schema#",
-      "additionalProperties": true,
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "required": [
+        "id"
+      ],
       "properties": {
+        "id": {
+          "description": "The ID of the issue security scheme.",
+          "type": "integer",
+          "readOnly": true
+        },
         "_meta": {
+          "type": "object",
           "properties": {
             "row_id": {
               "type": "integer"
@@ -836,9 +1295,55 @@
           },
           "required": [
             "row_id"
-          ],
-          "type": "object"
-        },
+          ]
+        }
+      },
+      "additionalProperties": true,
+      "description": "List of security schemes.",
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
+    },
+    "key": [
+      "/id"
+    ]
+  },
+  {
+    "recommendedName": "issue_transitions",
+    "resourceConfig": {
+      "stream": "issue_transitions",
+      "syncMode": "full_refresh"
+    },
+    "documentSchema": {
+      "$schema": "https://json-schema.org/draft-07/schema#",
+      "title": "Issue Transitions",
+      "type": "object",
+      "required": [
+        "id",
+        "issueId"
+      ],
+      "properties": {
         "id": {
           "description": "Unique identifier for the issue transition",
           "type": [
@@ -850,70 +1355,69 @@
           "type": [
             "string"
           ]
+        },
+        "_meta": {
+          "type": "object",
+          "properties": {
+            "row_id": {
+              "type": "integer"
+            }
+          },
+          "required": [
+            "row_id"
+          ]
         }
       },
-      "required": [
-        "id",
-        "issueId"
-      ],
-      "title": "Issue Transitions",
-      "type": "object",
-      "x-infer-schema": true
+      "additionalProperties": true,
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/issueId",
       "/id"
-    ],
-    "recommendedName": "issue_transitions",
-    "resourceConfig": {
-      "stream": "issue_transitions",
-      "syncMode": "full_refresh"
-    }
+    ]
   },
   {
-    "documentSchema": {
-      "$schema": "http://json-schema.org/draft-07/schema#",
-      "additionalProperties": true,
-      "description": "Details of an issue type scheme.",
-      "properties": {
-        "_meta": {
-          "properties": {
-            "row_id": {
-              "type": "integer"
-            }
-          },
-          "required": [
-            "row_id"
-          ],
-          "type": "object"
-        },
-        "id": {
-          "description": "The unique identifier for the issue type scheme.",
-          "type": "string"
-        }
-      },
-      "required": [
-        "id"
-      ],
-      "type": "object",
-      "x-infer-schema": true
-    },
-    "key": [
-      "/id"
-    ],
     "recommendedName": "issue_type_schemes",
     "resourceConfig": {
       "stream": "issue_type_schemes",
       "syncMode": "full_refresh"
-    }
-  },
-  {
+    },
     "documentSchema": {
-      "$schema": "https://json-schema.org/draft-07/schema#",
-      "additionalProperties": true,
-      "description": "Details about an issue type.",
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "required": [
+        "id"
+      ],
       "properties": {
+        "id": {
+          "description": "The unique identifier for the issue type scheme.",
+          "type": "string"
+        },
         "_meta": {
+          "type": "object",
           "properties": {
             "row_id": {
               "type": "integer"
@@ -921,37 +1425,61 @@
           },
           "required": [
             "row_id"
-          ],
-          "type": "object"
-        },
-        "id": {
-          "description": "The ID of the issue type.",
-          "readOnly": true,
-          "type": "string"
+          ]
         }
       },
-      "required": [
-        "id"
-      ],
-      "type": "object",
-      "x-infer-schema": true
+      "additionalProperties": true,
+      "description": "Details of an issue type scheme.",
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
-    ],
+    ]
+  },
+  {
     "recommendedName": "issue_types",
     "resourceConfig": {
       "stream": "issue_types",
       "syncMode": "full_refresh"
-    }
-  },
-  {
+    },
     "documentSchema": {
-      "$schema": "http://json-schema.org/draft-07/schema#",
-      "additionalProperties": true,
-      "description": "Details of an issue type screen scheme.",
+      "$schema": "https://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "description": "Details about an issue type.",
+      "required": [
+        "id"
+      ],
       "properties": {
+        "id": {
+          "description": "The ID of the issue type.",
+          "type": "string",
+          "readOnly": true
+        },
         "_meta": {
+          "type": "object",
           "properties": {
             "row_id": {
               "type": "integer"
@@ -959,36 +1487,58 @@
           },
           "required": [
             "row_id"
-          ],
-          "type": "object"
-        },
-        "id": {
-          "description": "The ID of the issue type screen scheme.",
-          "type": "string"
+          ]
         }
       },
-      "required": [
-        "id"
-      ],
-      "type": "object",
-      "x-infer-schema": true
+      "additionalProperties": true,
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
-    ],
+    ]
+  },
+  {
     "recommendedName": "issue_type_screen_schemes",
     "resourceConfig": {
       "stream": "issue_type_screen_schemes",
       "syncMode": "full_refresh"
-    }
-  },
-  {
+    },
     "documentSchema": {
       "$schema": "http://json-schema.org/draft-07/schema#",
-      "additionalProperties": true,
-      "description": "The details of votes on an issue.",
+      "type": "object",
+      "required": [
+        "id"
+      ],
       "properties": {
+        "id": {
+          "description": "The ID of the issue type screen scheme.",
+          "type": "string"
+        },
         "_meta": {
+          "type": "object",
           "properties": {
             "row_id": {
               "type": "integer"
@@ -996,37 +1546,60 @@
           },
           "required": [
             "row_id"
-          ],
-          "type": "object"
-        },
-        "self": {
-          "description": "The URL of these issue vote details.",
-          "readOnly": true,
-          "type": "string"
+          ]
         }
       },
-      "required": [
-        "self"
-      ],
-      "type": "object",
-      "x-infer-schema": true
+      "additionalProperties": true,
+      "description": "Details of an issue type screen scheme.",
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
-      "/self"
-    ],
+      "/id"
+    ]
+  },
+  {
     "recommendedName": "issue_votes",
     "resourceConfig": {
       "stream": "issue_votes",
       "syncMode": "full_refresh"
-    }
-  },
-  {
+    },
     "documentSchema": {
       "$schema": "http://json-schema.org/draft-07/schema#",
-      "additionalProperties": true,
-      "description": "The details of watchers on an issue.",
+      "type": "object",
+      "required": [
+        "self"
+      ],
       "properties": {
+        "self": {
+          "description": "The URL of these issue vote details.",
+          "type": "string",
+          "readOnly": true
+        },
         "_meta": {
+          "type": "object",
           "properties": {
             "row_id": {
               "type": "integer"
@@ -1034,37 +1607,60 @@
           },
           "required": [
             "row_id"
-          ],
-          "type": "object"
-        },
-        "self": {
-          "description": "The URL of these issue watcher details.",
-          "readOnly": true,
-          "type": "string"
+          ]
         }
       },
-      "required": [
-        "self"
-      ],
-      "type": "object",
-      "x-infer-schema": true
+      "additionalProperties": true,
+      "description": "The details of votes on an issue.",
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/self"
-    ],
+    ]
+  },
+  {
     "recommendedName": "issue_watchers",
     "resourceConfig": {
       "stream": "issue_watchers",
       "syncMode": "full_refresh"
-    }
-  },
-  {
+    },
     "documentSchema": {
       "$schema": "http://json-schema.org/draft-07/schema#",
-      "additionalProperties": true,
-      "description": "Details of a worklog.",
+      "type": "object",
+      "required": [
+        "self"
+      ],
       "properties": {
+        "self": {
+          "description": "The URL of these issue watcher details.",
+          "type": "string",
+          "readOnly": true
+        },
         "_meta": {
+          "type": "object",
           "properties": {
             "row_id": {
               "type": "integer"
@@ -1072,40 +1668,63 @@
           },
           "required": [
             "row_id"
-          ],
-          "type": "object"
-        },
-        "id": {
-          "description": "The ID of the worklog record.",
-          "readOnly": true,
-          "type": "string"
+          ]
         }
       },
-      "required": [
-        "id"
-      ],
-      "type": "object",
-      "x-infer-schema": true
+      "additionalProperties": true,
+      "description": "The details of watchers on an issue.",
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
-      "/id"
-    ],
+      "/self"
+    ]
+  },
+  {
     "recommendedName": "issue_worklogs",
     "resourceConfig": {
+      "stream": "issue_worklogs",
+      "syncMode": "incremental",
       "cursorField": [
         "updated"
-      ],
-      "stream": "issue_worklogs",
-      "syncMode": "incremental"
-    }
-  },
-  {
+      ]
+    },
     "documentSchema": {
       "$schema": "http://json-schema.org/draft-07/schema#",
-      "additionalProperties": true,
-      "description": "Details of an application property.",
+      "type": "object",
+      "required": [
+        "id"
+      ],
       "properties": {
+        "id": {
+          "description": "The ID of the worklog record.",
+          "type": "string",
+          "readOnly": true
+        },
         "_meta": {
+          "type": "object",
           "properties": {
             "row_id": {
               "type": "integer"
@@ -1113,35 +1732,59 @@
           },
           "required": [
             "row_id"
-          ],
-          "type": "object"
-        },
-        "id": {
-          "description": "The unique ID of the application property. The ID is the same as the key.",
-          "type": "string"
+          ]
         }
       },
-      "required": [
-        "id"
-      ],
-      "type": "object",
-      "x-infer-schema": true
+      "additionalProperties": true,
+      "description": "Details of a worklog.",
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
-    ],
+    ]
+  },
+  {
     "recommendedName": "jira_settings",
     "resourceConfig": {
       "stream": "jira_settings",
       "syncMode": "full_refresh"
-    }
-  },
-  {
+    },
     "documentSchema": {
       "$schema": "http://json-schema.org/draft-07/schema#",
-      "additionalProperties": true,
+      "type": "object",
+      "required": [
+        "id"
+      ],
       "properties": {
+        "id": {
+          "description": "The unique ID of the application property. The ID is the same as the key.",
+          "type": "string"
+        },
         "_meta": {
+          "type": "object",
           "properties": {
             "row_id": {
               "type": "integer"
@@ -1149,36 +1792,59 @@
           },
           "required": [
             "row_id"
-          ],
-          "type": "object"
-        },
-        "label": {
-          "description": "The label associated with the issue in Jira.",
-          "type": "string"
+          ]
         }
       },
-      "required": [
-        "label"
-      ],
-      "type": "object",
-      "x-infer-schema": true
+      "additionalProperties": true,
+      "description": "Details of an application property.",
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
-      "/label"
-    ],
+      "/id"
+    ]
+  },
+  {
     "recommendedName": "labels",
     "resourceConfig": {
       "stream": "labels",
       "syncMode": "full_refresh"
-    }
-  },
-  {
+    },
     "documentSchema": {
       "$schema": "http://json-schema.org/draft-07/schema#",
-      "additionalProperties": true,
-      "description": "Details about permissions.",
+      "type": "object",
+      "required": [
+        "label"
+      ],
       "properties": {
+        "label": {
+          "description": "The label associated with the issue in Jira.",
+          "type": "string"
+        },
         "_meta": {
+          "type": "object",
           "properties": {
             "row_id": {
               "type": "integer"
@@ -1186,36 +1852,58 @@
           },
           "required": [
             "row_id"
-          ],
-          "type": "object"
-        },
-        "key": {
-          "description": "Unique key identifier for the permission",
-          "type": "string"
+          ]
         }
       },
-      "required": [
-        "key"
-      ],
-      "type": "object",
-      "x-infer-schema": true
+      "additionalProperties": true,
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
-      "/key"
-    ],
+      "/label"
+    ]
+  },
+  {
     "recommendedName": "permissions",
     "resourceConfig": {
       "stream": "permissions",
       "syncMode": "full_refresh"
-    }
-  },
-  {
+    },
     "documentSchema": {
       "$schema": "http://json-schema.org/draft-07/schema#",
-      "additionalProperties": true,
-      "description": "List of all permission schemes.",
+      "type": "object",
+      "required": [
+        "key"
+      ],
       "properties": {
+        "key": {
+          "description": "Unique key identifier for the permission",
+          "type": "string"
+        },
         "_meta": {
+          "type": "object",
           "properties": {
             "row_id": {
               "type": "integer"
@@ -1223,37 +1911,60 @@
           },
           "required": [
             "row_id"
-          ],
-          "type": "object"
-        },
-        "id": {
-          "description": "The ID of the permission scheme.",
-          "readOnly": true,
-          "type": "integer"
+          ]
         }
       },
-      "required": [
-        "id"
-      ],
-      "type": "object",
-      "x-infer-schema": true
+      "additionalProperties": true,
+      "description": "Details about permissions.",
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
-      "/id"
-    ],
+      "/key"
+    ]
+  },
+  {
     "recommendedName": "permission_schemes",
     "resourceConfig": {
       "stream": "permission_schemes",
       "syncMode": "full_refresh"
-    }
-  },
-  {
+    },
     "documentSchema": {
       "$schema": "http://json-schema.org/draft-07/schema#",
-      "additionalProperties": true,
-      "description": "Details about a project.",
+      "type": "object",
+      "required": [
+        "id"
+      ],
       "properties": {
+        "id": {
+          "description": "The ID of the permission scheme.",
+          "type": "integer",
+          "readOnly": true
+        },
         "_meta": {
+          "type": "object",
           "properties": {
             "row_id": {
               "type": "integer"
@@ -1261,36 +1972,59 @@
           },
           "required": [
             "row_id"
-          ],
-          "type": "object"
-        },
-        "id": {
-          "description": "The ID of the project.",
-          "type": "string"
+          ]
         }
       },
-      "required": [
-        "id"
-      ],
-      "type": "object",
-      "x-infer-schema": true
+      "additionalProperties": true,
+      "description": "List of all permission schemes.",
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
-    ],
+    ]
+  },
+  {
     "recommendedName": "projects",
     "resourceConfig": {
       "stream": "projects",
       "syncMode": "full_refresh"
-    }
-  },
-  {
+    },
     "documentSchema": {
-      "$schema": "https://json-schema.org/draft-07/schema#",
-      "additionalProperties": true,
-      "description": "Project Roles",
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "required": [
+        "id"
+      ],
       "properties": {
+        "id": {
+          "description": "The ID of the project.",
+          "type": "string"
+        },
         "_meta": {
+          "type": "object",
           "properties": {
             "row_id": {
               "type": "integer"
@@ -1298,36 +2032,60 @@
           },
           "required": [
             "row_id"
-          ],
-          "type": "object"
-        },
-        "id": {
-          "description": "The ID of the project role.",
-          "type": "integer"
+          ]
         }
       },
-      "required": [
-        "id"
-      ],
-      "type": "object",
-      "x-infer-schema": true
+      "additionalProperties": true,
+      "description": "Details about a project.",
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
-    ],
+    ]
+  },
+  {
     "recommendedName": "project_roles",
     "resourceConfig": {
       "stream": "project_roles",
       "syncMode": "full_refresh"
-    }
-  },
-  {
+    },
     "documentSchema": {
-      "$schema": "http://json-schema.org/draft-07/schema#",
-      "additionalProperties": true,
-      "description": "List of project avatars.",
+      "$schema": "https://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "required": [
+        "id"
+      ],
+      "description": "Project Roles",
       "properties": {
+        "id": {
+          "description": "The ID of the project role.",
+          "type": "integer"
+        },
         "_meta": {
+          "type": "object",
           "properties": {
             "row_id": {
               "type": "integer"
@@ -1335,36 +2093,58 @@
           },
           "required": [
             "row_id"
-          ],
-          "type": "object"
-        },
-        "id": {
-          "description": "The ID of the avatar.",
-          "type": "string"
+          ]
         }
       },
-      "required": [
-        "id"
-      ],
-      "type": "object",
-      "x-infer-schema": true
+      "additionalProperties": true,
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
-    ],
+    ]
+  },
+  {
     "recommendedName": "project_avatars",
     "resourceConfig": {
       "stream": "project_avatars",
       "syncMode": "full_refresh"
-    }
-  },
-  {
+    },
     "documentSchema": {
       "$schema": "http://json-schema.org/draft-07/schema#",
-      "additionalProperties": true,
-      "description": "A project category.",
+      "type": "object",
+      "required": [
+        "id"
+      ],
       "properties": {
+        "id": {
+          "description": "The ID of the avatar.",
+          "type": "string"
+        },
         "_meta": {
+          "type": "object",
           "properties": {
             "row_id": {
               "type": "integer"
@@ -1372,37 +2152,60 @@
           },
           "required": [
             "row_id"
-          ],
-          "type": "object"
-        },
-        "id": {
-          "description": "The ID of the project category.",
-          "readOnly": true,
-          "type": "string"
+          ]
         }
       },
-      "required": [
-        "id"
-      ],
-      "type": "object",
-      "x-infer-schema": true
+      "additionalProperties": true,
+      "description": "List of project avatars.",
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
-    ],
+    ]
+  },
+  {
     "recommendedName": "project_categories",
     "resourceConfig": {
       "stream": "project_categories",
       "syncMode": "full_refresh"
-    }
-  },
-  {
+    },
     "documentSchema": {
       "$schema": "http://json-schema.org/draft-07/schema#",
-      "additionalProperties": true,
-      "description": "Details about a project component.",
+      "type": "object",
+      "required": [
+        "id"
+      ],
       "properties": {
+        "id": {
+          "description": "The ID of the project category.",
+          "type": "string",
+          "readOnly": true
+        },
         "_meta": {
+          "type": "object",
           "properties": {
             "row_id": {
               "type": "integer"
@@ -1410,37 +2213,60 @@
           },
           "required": [
             "row_id"
-          ],
-          "type": "object"
-        },
-        "id": {
-          "description": "The unique identifier for the component.",
-          "readOnly": true,
-          "type": "string"
+          ]
         }
       },
-      "required": [
-        "id"
-      ],
-      "type": "object",
-      "x-infer-schema": true
+      "additionalProperties": true,
+      "description": "A project category.",
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
-    ],
+    ]
+  },
+  {
     "recommendedName": "project_components",
     "resourceConfig": {
       "stream": "project_components",
       "syncMode": "full_refresh"
-    }
-  },
-  {
+    },
     "documentSchema": {
       "$schema": "http://json-schema.org/draft-07/schema#",
-      "additionalProperties": true,
-      "description": "A project's sender email address.",
+      "type": "object",
+      "required": [
+        "id"
+      ],
       "properties": {
+        "id": {
+          "description": "The unique identifier for the component.",
+          "type": "string",
+          "readOnly": true
+        },
         "_meta": {
+          "type": "object",
           "properties": {
             "row_id": {
               "type": "integer"
@@ -1448,36 +2274,59 @@
           },
           "required": [
             "row_id"
-          ],
-          "type": "object"
-        },
-        "projectId": {
-          "description": "The unique identifier for the project.",
-          "type": "string"
+          ]
         }
       },
-      "required": [
-        "projectId"
-      ],
-      "type": "object",
-      "x-infer-schema": true
+      "additionalProperties": true,
+      "description": "Details about a project component.",
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
-      "/projectId"
-    ],
+      "/id"
+    ]
+  },
+  {
     "recommendedName": "project_email",
     "resourceConfig": {
       "stream": "project_email",
       "syncMode": "full_refresh"
-    }
-  },
-  {
+    },
     "documentSchema": {
       "$schema": "http://json-schema.org/draft-07/schema#",
-      "additionalProperties": true,
-      "description": "Details about a security scheme.",
+      "type": "object",
+      "required": [
+        "projectId"
+      ],
       "properties": {
+        "projectId": {
+          "description": "The unique identifier for the project.",
+          "type": "string"
+        },
         "_meta": {
+          "type": "object",
           "properties": {
             "row_id": {
               "type": "integer"
@@ -1485,36 +2334,59 @@
           },
           "required": [
             "row_id"
-          ],
-          "type": "object"
-        },
-        "id": {
-          "description": "The ID of the issue level security item.",
-          "type": "string"
+          ]
         }
       },
-      "required": [
-        "id"
-      ],
-      "type": "object",
-      "x-infer-schema": true
+      "additionalProperties": true,
+      "description": "A project's sender email address.",
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
-      "/id"
-    ],
+      "/projectId"
+    ]
+  },
+  {
     "recommendedName": "project_permission_schemes",
     "resourceConfig": {
       "stream": "project_permission_schemes",
       "syncMode": "full_refresh"
-    }
-  },
-  {
+    },
     "documentSchema": {
       "$schema": "http://json-schema.org/draft-07/schema#",
-      "additionalProperties": true,
-      "description": "Details about a project type.",
+      "type": "object",
+      "required": [
+        "id"
+      ],
       "properties": {
+        "id": {
+          "description": "The ID of the issue level security item.",
+          "type": "string"
+        },
         "_meta": {
+          "type": "object",
           "properties": {
             "row_id": {
               "type": "integer"
@@ -1522,36 +2394,60 @@
           },
           "required": [
             "row_id"
-          ],
-          "type": "object"
-        },
-        "key": {
-          "description": "The key of the project type.",
-          "readOnly": true,
-          "type": "string"
+          ]
         }
       },
-      "required": [
-        "key"
-      ],
-      "type": "object",
-      "x-infer-schema": true
+      "additionalProperties": true,
+      "description": "Details about a security scheme.",
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
-      "/key"
-    ],
+      "/id"
+    ]
+  },
+  {
     "recommendedName": "project_types",
     "resourceConfig": {
       "stream": "project_types",
       "syncMode": "full_refresh"
-    }
-  },
-  {
+    },
     "documentSchema": {
       "$schema": "http://json-schema.org/draft-07/schema#",
-      "additionalProperties": true,
+      "type": "object",
+      "required": [
+        "key"
+      ],
       "properties": {
+        "key": {
+          "description": "The key of the project type.",
+          "type": "string",
+          "readOnly": true
+        },
         "_meta": {
+          "type": "object",
           "properties": {
             "row_id": {
               "type": "integer"
@@ -1559,37 +2455,60 @@
           },
           "required": [
             "row_id"
-          ],
-          "type": "object"
-        },
-        "id": {
-          "description": "The unique ID of the version.",
-          "readOnly": true,
-          "type": "string"
+          ]
         }
       },
-      "readOnly": true,
-      "required": [
-        "id"
-      ],
-      "type": "object",
-      "x-infer-schema": true
+      "additionalProperties": true,
+      "description": "Details about a project type.",
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
-      "/id"
-    ],
+      "/key"
+    ]
+  },
+  {
     "recommendedName": "project_versions",
     "resourceConfig": {
       "stream": "project_versions",
       "syncMode": "full_refresh"
-    }
-  },
-  {
+    },
     "documentSchema": {
       "$schema": "http://json-schema.org/draft-07/schema#",
-      "additionalProperties": true,
+      "type": "object",
+      "required": [
+        "id"
+      ],
       "properties": {
+        "id": {
+          "description": "The unique ID of the version.",
+          "type": "string",
+          "readOnly": true
+        },
         "_meta": {
+          "type": "object",
           "properties": {
             "row_id": {
               "type": "integer"
@@ -1597,37 +2516,60 @@
           },
           "required": [
             "row_id"
-          ],
-          "type": "object"
-        },
-        "id": {
-          "description": "The ID of the screen.",
-          "readOnly": true,
-          "type": "integer"
+          ]
         }
       },
-      "required": [
-        "id"
-      ],
-      "type": "object",
-      "x-infer-schema": true
+      "additionalProperties": true,
+      "readOnly": true,
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
-    ],
+    ]
+  },
+  {
     "recommendedName": "screens",
     "resourceConfig": {
       "stream": "screens",
       "syncMode": "full_refresh"
-    }
-  },
-  {
+    },
     "documentSchema": {
       "$schema": "http://json-schema.org/draft-07/schema#",
-      "additionalProperties": true,
-      "description": "A screen tab.",
+      "type": "object",
+      "required": [
+        "id"
+      ],
       "properties": {
+        "id": {
+          "description": "The ID of the screen.",
+          "type": "integer",
+          "readOnly": true
+        },
         "_meta": {
+          "type": "object",
           "properties": {
             "row_id": {
               "type": "integer"
@@ -1635,37 +2577,59 @@
           },
           "required": [
             "row_id"
-          ],
-          "type": "object"
-        },
-        "id": {
-          "description": "The ID of the screen tab.",
-          "readOnly": true,
-          "type": "integer"
+          ]
         }
       },
-      "required": [
-        "id"
-      ],
-      "type": "object",
-      "x-infer-schema": true
+      "additionalProperties": true,
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
-    ],
+    ]
+  },
+  {
     "recommendedName": "screen_tabs",
     "resourceConfig": {
       "stream": "screen_tabs",
       "syncMode": "full_refresh"
-    }
-  },
-  {
+    },
     "documentSchema": {
       "$schema": "http://json-schema.org/draft-07/schema#",
-      "additionalProperties": true,
-      "description": "A screen tab field.",
+      "required": [
+        "id"
+      ],
+      "type": "object",
       "properties": {
+        "id": {
+          "description": "The ID of the screen tab.",
+          "type": "integer",
+          "readOnly": true
+        },
         "_meta": {
+          "type": "object",
           "properties": {
             "row_id": {
               "type": "integer"
@@ -1673,37 +2637,60 @@
           },
           "required": [
             "row_id"
-          ],
-          "type": "object"
-        },
-        "id": {
-          "description": "The ID of the screen tab field.",
-          "readOnly": true,
-          "type": "string"
+          ]
         }
       },
-      "required": [
-        "id"
-      ],
-      "type": "object",
-      "x-infer-schema": true
+      "additionalProperties": true,
+      "description": "A screen tab.",
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
-    ],
+    ]
+  },
+  {
     "recommendedName": "screen_tab_fields",
     "resourceConfig": {
       "stream": "screen_tab_fields",
       "syncMode": "full_refresh"
-    }
-  },
-  {
+    },
     "documentSchema": {
       "$schema": "http://json-schema.org/draft-07/schema#",
-      "additionalProperties": true,
-      "description": "A screen scheme.",
+      "type": "object",
+      "required": [
+        "id"
+      ],
       "properties": {
+        "id": {
+          "description": "The ID of the screen tab field.",
+          "type": "string",
+          "readOnly": true
+        },
         "_meta": {
+          "type": "object",
           "properties": {
             "row_id": {
               "type": "integer"
@@ -1711,35 +2698,59 @@
           },
           "required": [
             "row_id"
-          ],
-          "type": "object"
-        },
-        "id": {
-          "description": "The ID of the screen scheme.",
-          "type": "integer"
+          ]
         }
       },
-      "required": [
-        "id"
-      ],
-      "type": "object",
-      "x-infer-schema": true
+      "additionalProperties": true,
+      "description": "A screen tab field.",
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
-    ],
+    ]
+  },
+  {
     "recommendedName": "screen_schemes",
     "resourceConfig": {
       "stream": "screen_schemes",
       "syncMode": "full_refresh"
-    }
-  },
-  {
+    },
     "documentSchema": {
       "$schema": "http://json-schema.org/draft-07/schema#",
-      "additionalProperties": true,
+      "type": "object",
+      "required": [
+        "id"
+      ],
       "properties": {
+        "id": {
+          "description": "The ID of the screen scheme.",
+          "type": "integer"
+        },
         "_meta": {
+          "type": "object",
           "properties": {
             "row_id": {
               "type": "integer"
@@ -1747,75 +2758,59 @@
           },
           "required": [
             "row_id"
-          ],
-          "type": "object"
-        },
-        "id": {
-          "description": "The unique identifier for the sprint.",
-          "type": "integer"
+          ]
         }
       },
-      "required": [
-        "id"
-      ],
-      "type": "object",
-      "x-infer-schema": true
+      "additionalProperties": true,
+      "description": "A screen scheme.",
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
-    ],
+    ]
+  },
+  {
     "recommendedName": "sprints",
     "resourceConfig": {
       "stream": "sprints",
       "syncMode": "full_refresh"
-    }
-  },
-  {
+    },
     "documentSchema": {
       "$schema": "http://json-schema.org/draft-07/schema#",
-      "additionalProperties": true,
-      "properties": {
-        "_meta": {
-          "properties": {
-            "row_id": {
-              "type": "integer"
-            }
-          },
-          "required": [
-            "row_id"
-          ],
-          "type": "object"
-        },
-        "id": {
-          "description": "ID of the issue",
-          "type": "string"
-        }
-      },
+      "type": "object",
       "required": [
         "id"
       ],
-      "type": "object",
-      "x-infer-schema": true
-    },
-    "key": [
-      "/id"
-    ],
-    "recommendedName": "sprint_issues",
-    "resourceConfig": {
-      "cursorField": [
-        "updated"
-      ],
-      "stream": "sprint_issues",
-      "syncMode": "incremental"
-    }
-  },
-  {
-    "documentSchema": {
-      "$schema": "http://json-schema.org/draft-07/schema#",
-      "additionalProperties": true,
-      "description": "Details about the time tracking provider.",
       "properties": {
+        "id": {
+          "description": "The unique identifier for the sprint.",
+          "type": "integer"
+        },
         "_meta": {
+          "type": "object",
           "properties": {
             "row_id": {
               "type": "integer"
@@ -1823,36 +2818,120 @@
           },
           "required": [
             "row_id"
-          ],
-          "type": "object"
-        },
-        "key": {
-          "description": "The key associated with the time tracking provider.",
-          "type": "string"
+          ]
         }
       },
-      "required": [
-        "key"
-      ],
-      "type": "object",
-      "x-infer-schema": true
+      "additionalProperties": true,
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
-      "/key"
-    ],
+      "/id"
+    ]
+  },
+  {
+    "recommendedName": "sprint_issues",
+    "resourceConfig": {
+      "stream": "sprint_issues",
+      "syncMode": "incremental",
+      "cursorField": [
+        "updated"
+      ]
+    },
+    "documentSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "required": [
+        "id"
+      ],
+      "properties": {
+        "id": {
+          "description": "ID of the issue",
+          "type": "string"
+        },
+        "_meta": {
+          "type": "object",
+          "properties": {
+            "row_id": {
+              "type": "integer"
+            }
+          },
+          "required": [
+            "row_id"
+          ]
+        }
+      },
+      "additionalProperties": true,
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
+    },
+    "key": [
+      "/id"
+    ]
+  },
+  {
     "recommendedName": "time_tracking",
     "resourceConfig": {
       "stream": "time_tracking",
       "syncMode": "full_refresh"
-    }
-  },
-  {
+    },
     "documentSchema": {
       "$schema": "http://json-schema.org/draft-07/schema#",
-      "additionalProperties": true,
-      "description": "A user with details as permitted by the user's Atlassian Account privacy settings. However, be aware of these exceptions:\n\n *  User record deleted from Atlassian: This occurs as the result of a right to be forgotten request. In this case, `displayName` provides an indication and other parameters have default values or are blank (for example, email is blank).\n *  User record corrupted: This occurs as a results of events such as a server import and can only happen to deleted users. In this case, `accountId` returns *unknown* and all other parameters have fallback values.\n *  User record unavailable: This usually occurs due to an internal service outage. In this case, all parameters have fallback values.",
+      "required": [
+        "key"
+      ],
+      "type": "object",
       "properties": {
+        "key": {
+          "description": "The key associated with the time tracking provider.",
+          "type": "string"
+        },
         "_meta": {
+          "type": "object",
           "properties": {
             "row_id": {
               "type": "integer"
@@ -1860,36 +2939,59 @@
           },
           "required": [
             "row_id"
-          ],
-          "type": "object"
-        },
-        "accountId": {
-          "description": "The account ID of the user, uniquely identifying the user across all Atlassian products. Required in requests.",
-          "type": "string"
+          ]
         }
       },
-      "required": [
-        "accountId"
-      ],
-      "type": "object",
-      "x-infer-schema": true
+      "additionalProperties": true,
+      "description": "Details about the time tracking provider.",
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
-      "/accountId"
-    ],
+      "/key"
+    ]
+  },
+  {
     "recommendedName": "users",
     "resourceConfig": {
       "stream": "users",
       "syncMode": "full_refresh"
-    }
-  },
-  {
+    },
     "documentSchema": {
       "$schema": "http://json-schema.org/draft-07/schema#",
-      "additionalProperties": true,
-      "description": "A user with details as permitted by the user's Atlassian Account privacy settings. However, be aware of these exceptions:\n\n *  User record deleted from Atlassian: This occurs as the result of a right to be forgotten request. In this case, `displayName` provides an indication and other parameters have default values or are blank (for example, email is blank).\n *  User record corrupted: This occurs as a results of events such as a server import and can only happen to deleted users. In this case, `accountId` returns *unknown* and all other parameters have fallback values.\n *  User record unavailable: This usually occurs due to an internal service outage. In this case, all parameters have fallback values.",
+      "type": "object",
+      "required": [
+        "accountId"
+      ],
       "properties": {
+        "accountId": {
+          "description": "The account ID of the user, uniquely identifying the user across all Atlassian products. Required in requests.",
+          "type": "string"
+        },
         "_meta": {
+          "type": "object",
           "properties": {
             "row_id": {
               "type": "integer"
@@ -1897,35 +2999,59 @@
           },
           "required": [
             "row_id"
-          ],
-          "type": "object"
-        },
-        "accountId": {
-          "description": "The account ID of the user, uniquely identifying the user across all Atlassian products. Required in requests.",
-          "type": "string"
+          ]
         }
       },
-      "required": [
-        "accountId"
-      ],
-      "type": "object",
-      "x-infer-schema": true
+      "additionalProperties": true,
+      "description": "A user with details as permitted by the user's Atlassian Account privacy settings. However, be aware of these exceptions:\n\n *  User record deleted from Atlassian: This occurs as the result of a right to be forgotten request. In this case, `displayName` provides an indication and other parameters have default values or are blank (for example, email is blank).\n *  User record corrupted: This occurs as a results of events such as a server import and can only happen to deleted users. In this case, `accountId` returns *unknown* and all other parameters have fallback values.\n *  User record unavailable: This usually occurs due to an internal service outage. In this case, all parameters have fallback values.",
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/accountId"
-    ],
+    ]
+  },
+  {
     "recommendedName": "users_groups_detailed",
     "resourceConfig": {
       "stream": "users_groups_detailed",
       "syncMode": "full_refresh"
-    }
-  },
-  {
+    },
     "documentSchema": {
       "$schema": "http://json-schema.org/draft-07/schema#",
-      "additionalProperties": true,
+      "type": "object",
+      "required": [
+        "accountId"
+      ],
       "properties": {
+        "accountId": {
+          "description": "The account ID of the user, uniquely identifying the user across all Atlassian products. Required in requests.",
+          "type": "string"
+        },
         "_meta": {
+          "type": "object",
           "properties": {
             "row_id": {
               "type": "integer"
@@ -1933,35 +3059,58 @@
           },
           "required": [
             "row_id"
-          ],
-          "type": "object"
-        },
-        "entity_id": {
-          "type": "string"
+          ]
         }
       },
-      "readOnly": true,
-      "required": [
-        "entity_id"
-      ],
-      "type": "object",
-      "x-infer-schema": true
+      "additionalProperties": true,
+      "description": "A user with details as permitted by the user's Atlassian Account privacy settings. However, be aware of these exceptions:\n\n *  User record deleted from Atlassian: This occurs as the result of a right to be forgotten request. In this case, `displayName` provides an indication and other parameters have default values or are blank (for example, email is blank).\n *  User record corrupted: This occurs as a results of events such as a server import and can only happen to deleted users. In this case, `accountId` returns *unknown* and all other parameters have fallback values.\n *  User record unavailable: This usually occurs due to an internal service outage. In this case, all parameters have fallback values.",
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
-      "/entity_id"
-    ],
+      "/accountId"
+    ]
+  },
+  {
     "recommendedName": "workflows",
     "resourceConfig": {
       "stream": "workflows",
       "syncMode": "full_refresh"
-    }
-  },
-  {
+    },
     "documentSchema": {
       "$schema": "http://json-schema.org/draft-07/schema#",
-      "additionalProperties": true,
+      "type": "object",
+      "required": [
+        "entity_id"
+      ],
       "properties": {
+        "entity_id": {
+          "type": "string"
+        },
         "_meta": {
+          "type": "object",
           "properties": {
             "row_id": {
               "type": "integer"
@@ -1969,38 +3118,60 @@
           },
           "required": [
             "row_id"
-          ],
-          "type": "object"
-        },
-        "id": {
-          "description": "The ID of the workflow scheme.",
-          "readOnly": true,
-          "type": "integer"
+          ]
         }
       },
       "readOnly": true,
-      "required": [
-        "id"
-      ],
-      "type": "object",
-      "x-infer-schema": true
+      "additionalProperties": true,
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
-      "/id"
-    ],
+      "/entity_id"
+    ]
+  },
+  {
     "recommendedName": "workflow_schemes",
     "resourceConfig": {
       "stream": "workflow_schemes",
       "syncMode": "full_refresh"
-    }
-  },
-  {
+    },
     "documentSchema": {
       "$schema": "http://json-schema.org/draft-07/schema#",
-      "additionalProperties": true,
-      "description": "A status.",
+      "type": "object",
+      "required": [
+        "id"
+      ],
       "properties": {
+        "id": {
+          "description": "The ID of the workflow scheme.",
+          "type": "integer",
+          "readOnly": true
+        },
         "_meta": {
+          "type": "object",
           "properties": {
             "row_id": {
               "type": "integer"
@@ -2008,37 +3179,60 @@
           },
           "required": [
             "row_id"
-          ],
-          "type": "object"
-        },
-        "id": {
-          "description": "The ID of the status.",
-          "readOnly": true,
-          "type": "string"
+          ]
         }
       },
-      "required": [
-        "id"
-      ],
-      "type": "object",
-      "x-infer-schema": true
+      "readOnly": true,
+      "additionalProperties": true,
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
-    ],
+    ]
+  },
+  {
     "recommendedName": "workflow_statuses",
     "resourceConfig": {
       "stream": "workflow_statuses",
       "syncMode": "full_refresh"
-    }
-  },
-  {
+    },
     "documentSchema": {
       "$schema": "http://json-schema.org/draft-07/schema#",
-      "additionalProperties": true,
-      "description": "A status category.",
+      "type": "object",
+      "required": [
+        "id"
+      ],
       "properties": {
+        "id": {
+          "description": "The ID of the status.",
+          "type": "string",
+          "readOnly": true
+        },
         "_meta": {
+          "type": "object",
           "properties": {
             "row_id": {
               "type": "integer"
@@ -2046,28 +3240,99 @@
           },
           "required": [
             "row_id"
-          ],
-          "type": "object"
-        },
-        "id": {
-          "description": "The ID of the status category.",
-          "readOnly": true,
-          "type": "integer"
+          ]
         }
       },
-      "required": [
-        "id"
-      ],
-      "type": "object",
-      "x-infer-schema": true
+      "additionalProperties": true,
+      "description": "A status.",
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
-    ],
+    ]
+  },
+  {
     "recommendedName": "workflow_status_categories",
     "resourceConfig": {
       "stream": "workflow_status_categories",
       "syncMode": "full_refresh"
-    }
+    },
+    "documentSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "required": [
+        "id"
+      ],
+      "properties": {
+        "id": {
+          "description": "The ID of the status category.",
+          "type": "integer",
+          "readOnly": true
+        },
+        "_meta": {
+          "type": "object",
+          "properties": {
+            "row_id": {
+              "type": "integer"
+            }
+          },
+          "required": [
+            "row_id"
+          ]
+        }
+      },
+      "additionalProperties": true,
+      "description": "A status category.",
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
+    },
+    "key": [
+      "/id"
+    ]
   }
 ]

--- a/source-jira-native/tests/snapshots/snapshots__discover__capture.stdout.json
+++ b/source-jira-native/tests/snapshots/snapshots__discover__capture.stdout.json
@@ -40,7 +40,30 @@
       },
       "title": "FullRefreshResource",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/_meta/row_id"
@@ -88,7 +111,30 @@
       },
       "title": "FullRefreshResource",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/_meta/row_id"
@@ -135,7 +181,30 @@
       },
       "title": "FullRefreshResource",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/_meta/row_id"
@@ -182,7 +251,30 @@
       },
       "title": "FullRefreshResource",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/_meta/row_id"
@@ -230,7 +322,30 @@
       },
       "title": "FullRefreshResource",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/_meta/row_id"
@@ -278,7 +393,30 @@
       },
       "title": "FullRefreshResource",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/_meta/row_id"
@@ -326,7 +464,30 @@
       },
       "title": "FullRefreshResource",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/_meta/row_id"
@@ -386,7 +547,30 @@
       ],
       "title": "IssueChildResource",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id",
@@ -447,7 +631,30 @@
       ],
       "title": "IssueChildResource",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id",
@@ -496,7 +703,30 @@
       },
       "title": "FullRefreshResource",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/_meta/row_id"
@@ -544,7 +774,30 @@
       },
       "title": "FullRefreshResource",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/_meta/row_id"
@@ -592,7 +845,30 @@
       },
       "title": "FullRefreshResource",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/_meta/row_id"
@@ -640,7 +916,30 @@
       },
       "title": "FullRefreshResource",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/_meta/row_id"
@@ -687,7 +986,30 @@
       },
       "title": "FullRefreshResource",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/_meta/row_id"
@@ -735,7 +1057,30 @@
       },
       "title": "FullRefreshResource",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/_meta/row_id"
@@ -783,7 +1128,30 @@
       },
       "title": "FullRefreshResource",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/_meta/row_id"
@@ -831,7 +1199,30 @@
       },
       "title": "FullRefreshResource",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/_meta/row_id"
@@ -879,7 +1270,30 @@
       },
       "title": "FullRefreshResource",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/_meta/row_id"
@@ -939,7 +1353,30 @@
       ],
       "title": "IssueChildResource",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id",
@@ -988,7 +1425,30 @@
       },
       "title": "FullRefreshResource",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/_meta/row_id"
@@ -1036,7 +1496,30 @@
       },
       "title": "FullRefreshResource",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/_meta/row_id"
@@ -1084,7 +1567,30 @@
       },
       "title": "FullRefreshResource",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/_meta/row_id"
@@ -1143,7 +1649,30 @@
       ],
       "title": "IssueChildResource",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id",
@@ -1199,7 +1728,30 @@
       ],
       "title": "JiraResource",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
@@ -1246,7 +1798,30 @@
       },
       "title": "FullRefreshResource",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/_meta/row_id"
@@ -1294,7 +1869,30 @@
       },
       "title": "FullRefreshResource",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/_meta/row_id"
@@ -1342,7 +1940,30 @@
       },
       "title": "FullRefreshResource",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/_meta/row_id"
@@ -1390,7 +2011,30 @@
       },
       "title": "FullRefreshResource",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/_meta/row_id"
@@ -1438,7 +2082,30 @@
       },
       "title": "FullRefreshResource",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/_meta/row_id"
@@ -1486,7 +2153,30 @@
       },
       "title": "FullRefreshResource",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/_meta/row_id"
@@ -1534,7 +2224,30 @@
       },
       "title": "FullRefreshResource",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/_meta/row_id"
@@ -1582,7 +2295,30 @@
       },
       "title": "FullRefreshResource",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/_meta/row_id"
@@ -1630,7 +2366,30 @@
       },
       "title": "FullRefreshResource",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/_meta/row_id"
@@ -1678,7 +2437,30 @@
       },
       "title": "FullRefreshResource",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/_meta/row_id"
@@ -1726,7 +2508,30 @@
       },
       "title": "FullRefreshResource",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/_meta/row_id"
@@ -1773,7 +2578,30 @@
       },
       "title": "FullRefreshResource",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/_meta/row_id"
@@ -1821,7 +2649,30 @@
       },
       "title": "FullRefreshResource",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/_meta/row_id"
@@ -1869,7 +2720,30 @@
       },
       "title": "FullRefreshResource",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/_meta/row_id"
@@ -1917,7 +2791,30 @@
       },
       "title": "FullRefreshResource",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/_meta/row_id"
@@ -1965,7 +2862,30 @@
       },
       "title": "FullRefreshResource",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/_meta/row_id"
@@ -2013,7 +2933,30 @@
       },
       "title": "FullRefreshResource",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/_meta/row_id"
@@ -2061,7 +3004,30 @@
       },
       "title": "FullRefreshResource",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/_meta/row_id"
@@ -2109,7 +3075,30 @@
       },
       "title": "FullRefreshResource",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/_meta/row_id"
@@ -2156,7 +3145,30 @@
       },
       "title": "FullRefreshResource",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/_meta/row_id"
@@ -2204,7 +3216,30 @@
       },
       "title": "FullRefreshResource",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/_meta/row_id"
@@ -2252,7 +3287,30 @@
       },
       "title": "FullRefreshResource",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/_meta/row_id"
@@ -2299,7 +3357,30 @@
       },
       "title": "FullRefreshResource",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/_meta/row_id"
@@ -2347,7 +3428,30 @@
       },
       "title": "FullRefreshResource",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/_meta/row_id"
@@ -2395,7 +3499,30 @@
       },
       "title": "FullRefreshResource",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/_meta/row_id"
@@ -2443,7 +3570,30 @@
       },
       "title": "FullRefreshResource",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/_meta/row_id"

--- a/source-klaviyo-native/tests/snapshots/snapshots__discover__capture.stdout.json
+++ b/source-klaviyo-native/tests/snapshots/snapshots__discover__capture.stdout.json
@@ -57,7 +57,30 @@
       ],
       "title": "IncrementalStream",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
@@ -103,7 +126,30 @@
       },
       "title": "BaseDocument",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/_meta/row_id"
@@ -149,7 +195,30 @@
       },
       "title": "BaseDocument",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/_meta/row_id"
@@ -213,7 +282,30 @@
       ],
       "title": "IncrementalStream",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
@@ -277,7 +369,30 @@
       ],
       "title": "IncrementalStream",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
@@ -341,7 +456,30 @@
       ],
       "title": "IncrementalStream",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
@@ -405,7 +543,30 @@
       ],
       "title": "IncrementalStream",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
@@ -469,7 +630,30 @@
       ],
       "title": "IncrementalStream",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
@@ -515,7 +699,30 @@
       },
       "title": "BaseDocument",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/_meta/row_id"
@@ -579,7 +786,30 @@
       ],
       "title": "IncrementalStream",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
@@ -625,7 +855,30 @@
       },
       "title": "BaseDocument",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/_meta/row_id"
@@ -689,7 +942,30 @@
       ],
       "title": "IncrementalStream",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
@@ -735,7 +1011,30 @@
       },
       "title": "BaseDocument",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/_meta/row_id"
@@ -781,7 +1080,30 @@
       },
       "title": "BaseDocument",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/_meta/row_id"
@@ -845,7 +1167,30 @@
       ],
       "title": "IncrementalStream",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"

--- a/source-klaviyo/tests/snapshots/snapshots__discover__capture.stdout.json
+++ b/source-klaviyo/tests/snapshots/snapshots__discover__capture.stdout.json
@@ -1,307 +1,490 @@
 [
-    {
-      "documentSchema": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
-        "additionalProperties": true,
+  {
+    "documentSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "additionalProperties": true,
+      "if": {
         "properties": {
           "_meta": {
             "properties": {
-              "row_id": {
-                "type": "integer"
+              "op": {
+                "const": "d"
               }
             },
             "required": [
-              "row_id"
-            ],
-            "type": "object"
-          },
-          "id": {
-            "type": "string"
+              "op"
+            ]
           }
         },
         "required": [
-          "id"
-        ],
-        "type": "object",
-        "x-infer-schema": true
+          "_meta"
+        ]
       },
-      "key": [
-        "/id"
+      "properties": {
+        "_meta": {
+          "properties": {
+            "row_id": {
+              "type": "integer"
+            }
+          },
+          "required": [
+            "row_id"
+          ],
+          "type": "object"
+        },
+        "id": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "id"
       ],
-      "recommendedName": "campaigns",
-      "resourceConfig": {
-        "cursorField": [
-          "updated_at"
-        ],
-        "stream": "campaigns",
-        "syncMode": "incremental"
-      }
+      "then": {
+        "reduce": {
+          "delete": true,
+          "strategy": "merge"
+        }
+      },
+      "type": "object",
+      "x-infer-schema": true
     },
-    {
-      "documentSchema": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
-        "additionalProperties": true,
-        "properties": {
-          "_meta": {
-            "properties": {
-              "row_id": {
-                "type": "integer"
-              }
-            },
-            "required": [
-              "row_id"
-            ],
-            "type": "object"
-          },
-          "id": {
-            "type": "string"
-          }
-        },
-        "required": [
-          "id"
-        ],
-        "type": "object",
-        "x-infer-schema": true
-      },
-      "key": [
-        "/id"
+    "key": [
+      "/id"
+    ],
+    "recommendedName": "campaigns",
+    "resourceConfig": {
+      "cursorField": [
+        "updated_at"
       ],
-      "recommendedName": "events",
-      "resourceConfig": {
-        "cursorField": [
-          "datetime"
-        ],
-        "stream": "events",
-        "syncMode": "incremental"
-      }
-    },
-    {
-      "documentSchema": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
-        "additionalProperties": true,
-        "properties": {
-          "_meta": {
-            "properties": {
-              "row_id": {
-                "type": "integer"
-              }
-            },
-            "required": [
-              "row_id"
-            ],
-            "type": "object"
-          },
-          "id": {
-            "type": "string"
-          }
-        },
-        "required": [
-          "id"
-        ],
-        "type": "object",
-        "x-infer-schema": true
-      },
-      "key": [
-        "/id"
-      ],
-      "recommendedName": "global_exclusions",
-      "resourceConfig": {
-        "cursorField": [
-          "updated"
-        ],
-        "stream": "global_exclusions",
-        "syncMode": "incremental"
-      }
-    },
-    {
-      "documentSchema": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
-        "additionalProperties": true,
-        "properties": {
-          "_meta": {
-            "properties": {
-              "row_id": {
-                "type": "integer"
-              }
-            },
-            "required": [
-              "row_id"
-            ],
-            "type": "object"
-          },
-          "id": {
-            "type": "string"
-          }
-        },
-        "required": [
-          "id"
-        ],
-        "type": "object",
-        "x-infer-schema": true
-      },
-      "key": [
-        "/id"
-      ],
-      "recommendedName": "lists",
-      "resourceConfig": {
-        "cursorField": [
-          "updated"
-        ],
-        "stream": "lists",
-        "syncMode": "incremental"
-      }
-    },
-    {
-      "documentSchema": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
-        "additionalProperties": true,
-        "properties": {
-          "_meta": {
-            "properties": {
-              "row_id": {
-                "type": "integer"
-              }
-            },
-            "required": [
-              "row_id"
-            ],
-            "type": "object"
-          },
-          "id": {
-            "type": "string"
-          }
-        },
-        "required": [
-          "id"
-        ],
-        "type": "object",
-        "x-infer-schema": true
-      },
-      "key": [
-        "/id"
-      ],
-      "recommendedName": "metrics",
-      "resourceConfig": {
-        "cursorField": [
-          "updated"
-        ],
-        "stream": "metrics",
-        "syncMode": "incremental"
-      }
-    },
-    {
-      "documentSchema": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
-        "additionalProperties": true,
-        "properties": {
-          "_meta": {
-            "properties": {
-              "row_id": {
-                "type": "integer"
-              }
-            },
-            "required": [
-              "row_id"
-            ],
-            "type": "object"
-          },
-          "id": {
-            "type": "string"
-          }
-        },
-        "required": [
-          "id"
-        ],
-        "type": "object",
-        "x-infer-schema": true
-      },
-      "key": [
-        "/id"
-      ],
-      "recommendedName": "flows",
-      "resourceConfig": {
-        "cursorField": [
-          "updated"
-        ],
-        "stream": "flows",
-        "syncMode": "incremental"
-      }
-    },
-    {
-      "documentSchema": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
-        "additionalProperties": true,
-        "properties": {
-          "_meta": {
-            "properties": {
-              "row_id": {
-                "type": "integer"
-              }
-            },
-            "required": [
-              "row_id"
-            ],
-            "type": "object"
-          },
-          "id": {
-            "type": "string"
-          }
-        },
-        "required": [
-          "id"
-        ],
-        "type": "object",
-        "x-infer-schema": true
-      },
-      "key": [
-        "/id"
-      ],
-      "recommendedName": "email_templates",
-      "resourceConfig": {
-        "cursorField": [
-          "updated"
-        ],
-        "stream": "email_templates",
-        "syncMode": "incremental"
-      }
-    },
-    {
-      "documentSchema": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
-        "additionalProperties": true,
-        "properties": {
-          "_meta": {
-            "properties": {
-              "row_id": {
-                "type": "integer"
-              }
-            },
-            "required": [
-              "row_id"
-            ],
-            "type": "object"
-          },
-          "id": {
-            "type": "string"
-          }
-        },
-        "required": [
-          "id"
-        ],
-        "type": "object",
-        "x-infer-schema": true
-      },
-      "key": [
-        "/id"
-      ],
-      "recommendedName": "profiles",
-      "resourceConfig": {
-        "cursorField": [
-          "updated"
-        ],
-        "stream": "profiles",
-        "syncMode": "incremental"
-      }
+      "stream": "campaigns",
+      "syncMode": "incremental"
     }
-  ]
-  
+  },
+  {
+    "documentSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "additionalProperties": true,
+      "if": {
+        "properties": {
+          "_meta": {
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            },
+            "required": [
+              "op"
+            ]
+          }
+        },
+        "required": [
+          "_meta"
+        ]
+      },
+      "properties": {
+        "_meta": {
+          "properties": {
+            "row_id": {
+              "type": "integer"
+            }
+          },
+          "required": [
+            "row_id"
+          ],
+          "type": "object"
+        },
+        "id": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "id"
+      ],
+      "then": {
+        "reduce": {
+          "delete": true,
+          "strategy": "merge"
+        }
+      },
+      "type": "object",
+      "x-infer-schema": true
+    },
+    "key": [
+      "/id"
+    ],
+    "recommendedName": "events",
+    "resourceConfig": {
+      "cursorField": [
+        "datetime"
+      ],
+      "stream": "events",
+      "syncMode": "incremental"
+    }
+  },
+  {
+    "documentSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "additionalProperties": true,
+      "if": {
+        "properties": {
+          "_meta": {
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            },
+            "required": [
+              "op"
+            ]
+          }
+        },
+        "required": [
+          "_meta"
+        ]
+      },
+      "properties": {
+        "_meta": {
+          "properties": {
+            "row_id": {
+              "type": "integer"
+            }
+          },
+          "required": [
+            "row_id"
+          ],
+          "type": "object"
+        },
+        "id": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "id"
+      ],
+      "then": {
+        "reduce": {
+          "delete": true,
+          "strategy": "merge"
+        }
+      },
+      "type": "object",
+      "x-infer-schema": true
+    },
+    "key": [
+      "/id"
+    ],
+    "recommendedName": "global_exclusions",
+    "resourceConfig": {
+      "cursorField": [
+        "updated"
+      ],
+      "stream": "global_exclusions",
+      "syncMode": "incremental"
+    }
+  },
+  {
+    "documentSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "additionalProperties": true,
+      "if": {
+        "properties": {
+          "_meta": {
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            },
+            "required": [
+              "op"
+            ]
+          }
+        },
+        "required": [
+          "_meta"
+        ]
+      },
+      "properties": {
+        "_meta": {
+          "properties": {
+            "row_id": {
+              "type": "integer"
+            }
+          },
+          "required": [
+            "row_id"
+          ],
+          "type": "object"
+        },
+        "id": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "id"
+      ],
+      "then": {
+        "reduce": {
+          "delete": true,
+          "strategy": "merge"
+        }
+      },
+      "type": "object",
+      "x-infer-schema": true
+    },
+    "key": [
+      "/id"
+    ],
+    "recommendedName": "lists",
+    "resourceConfig": {
+      "cursorField": [
+        "updated"
+      ],
+      "stream": "lists",
+      "syncMode": "incremental"
+    }
+  },
+  {
+    "documentSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "additionalProperties": true,
+      "if": {
+        "properties": {
+          "_meta": {
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            },
+            "required": [
+              "op"
+            ]
+          }
+        },
+        "required": [
+          "_meta"
+        ]
+      },
+      "properties": {
+        "_meta": {
+          "properties": {
+            "row_id": {
+              "type": "integer"
+            }
+          },
+          "required": [
+            "row_id"
+          ],
+          "type": "object"
+        },
+        "id": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "id"
+      ],
+      "then": {
+        "reduce": {
+          "delete": true,
+          "strategy": "merge"
+        }
+      },
+      "type": "object",
+      "x-infer-schema": true
+    },
+    "key": [
+      "/id"
+    ],
+    "recommendedName": "metrics",
+    "resourceConfig": {
+      "cursorField": [
+        "updated"
+      ],
+      "stream": "metrics",
+      "syncMode": "incremental"
+    }
+  },
+  {
+    "documentSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "additionalProperties": true,
+      "if": {
+        "properties": {
+          "_meta": {
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            },
+            "required": [
+              "op"
+            ]
+          }
+        },
+        "required": [
+          "_meta"
+        ]
+      },
+      "properties": {
+        "_meta": {
+          "properties": {
+            "row_id": {
+              "type": "integer"
+            }
+          },
+          "required": [
+            "row_id"
+          ],
+          "type": "object"
+        },
+        "id": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "id"
+      ],
+      "then": {
+        "reduce": {
+          "delete": true,
+          "strategy": "merge"
+        }
+      },
+      "type": "object",
+      "x-infer-schema": true
+    },
+    "key": [
+      "/id"
+    ],
+    "recommendedName": "flows",
+    "resourceConfig": {
+      "cursorField": [
+        "updated"
+      ],
+      "stream": "flows",
+      "syncMode": "incremental"
+    }
+  },
+  {
+    "documentSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "additionalProperties": true,
+      "if": {
+        "properties": {
+          "_meta": {
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            },
+            "required": [
+              "op"
+            ]
+          }
+        },
+        "required": [
+          "_meta"
+        ]
+      },
+      "properties": {
+        "_meta": {
+          "properties": {
+            "row_id": {
+              "type": "integer"
+            }
+          },
+          "required": [
+            "row_id"
+          ],
+          "type": "object"
+        },
+        "id": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "id"
+      ],
+      "then": {
+        "reduce": {
+          "delete": true,
+          "strategy": "merge"
+        }
+      },
+      "type": "object",
+      "x-infer-schema": true
+    },
+    "key": [
+      "/id"
+    ],
+    "recommendedName": "email_templates",
+    "resourceConfig": {
+      "cursorField": [
+        "updated"
+      ],
+      "stream": "email_templates",
+      "syncMode": "incremental"
+    }
+  },
+  {
+    "documentSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "additionalProperties": true,
+      "if": {
+        "properties": {
+          "_meta": {
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            },
+            "required": [
+              "op"
+            ]
+          }
+        },
+        "required": [
+          "_meta"
+        ]
+      },
+      "properties": {
+        "_meta": {
+          "properties": {
+            "row_id": {
+              "type": "integer"
+            }
+          },
+          "required": [
+            "row_id"
+          ],
+          "type": "object"
+        },
+        "id": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "id"
+      ],
+      "then": {
+        "reduce": {
+          "delete": true,
+          "strategy": "merge"
+        }
+      },
+      "type": "object",
+      "x-infer-schema": true
+    },
+    "key": [
+      "/id"
+    ],
+    "recommendedName": "profiles",
+    "resourceConfig": {
+      "cursorField": [
+        "updated"
+      ],
+      "stream": "profiles",
+      "syncMode": "incremental"
+    }
+  }
+]

--- a/source-linkedin-ads-v2/tests/snapshots/snapshots__discover__capture.stdout.json
+++ b/source-linkedin-ads-v2/tests/snapshots/snapshots__discover__capture.stdout.json
@@ -3,6 +3,23 @@
     "documentSchema": {
       "$schema": "http://json-schema.org/draft-07/schema#",
       "additionalProperties": true,
+      "if": {
+        "properties": {
+          "_meta": {
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            },
+            "required": [
+              "op"
+            ]
+          }
+        },
+        "required": [
+          "_meta"
+        ]
+      },
       "properties": {
         "_meta": {
           "properties": {
@@ -23,6 +40,12 @@
       "required": [
         "id"
       ],
+      "then": {
+        "reduce": {
+          "delete": true,
+          "strategy": "merge"
+        }
+      },
       "title": "Accounts",
       "type": "object",
       "x-infer-schema": true
@@ -40,6 +63,23 @@
     "documentSchema": {
       "$schema": "http://json-schema.org/draft-07/schema#",
       "additionalProperties": true,
+      "if": {
+        "properties": {
+          "_meta": {
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            },
+            "required": [
+              "op"
+            ]
+          }
+        },
+        "required": [
+          "_meta"
+        ]
+      },
       "properties": {
         "_meta": {
           "properties": {
@@ -60,6 +100,12 @@
       "required": [
         "account"
       ],
+      "then": {
+        "reduce": {
+          "delete": true,
+          "strategy": "merge"
+        }
+      },
       "title": "AccountUsers",
       "type": "object",
       "x-infer-schema": true
@@ -80,6 +126,23 @@
     "documentSchema": {
       "$schema": "http://json-schema.org/draft-07/schema#",
       "additionalProperties": true,
+      "if": {
+        "properties": {
+          "_meta": {
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            },
+            "required": [
+              "op"
+            ]
+          }
+        },
+        "required": [
+          "_meta"
+        ]
+      },
       "properties": {
         "_meta": {
           "properties": {
@@ -105,6 +168,12 @@
         "string_of_pivot_values",
         "end_date"
       ],
+      "then": {
+        "reduce": {
+          "delete": true,
+          "strategy": "merge"
+        }
+      },
       "title": "Ad Creative Analytics",
       "type": "object",
       "x-infer-schema": true
@@ -126,6 +195,23 @@
     "documentSchema": {
       "$schema": "http://json-schema.org/draft-07/schema#",
       "additionalProperties": true,
+      "if": {
+        "properties": {
+          "_meta": {
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            },
+            "required": [
+              "op"
+            ]
+          }
+        },
+        "required": [
+          "_meta"
+        ]
+      },
       "properties": {
         "_meta": {
           "properties": {
@@ -151,6 +237,12 @@
         "string_of_pivot_values",
         "end_date"
       ],
+      "then": {
+        "reduce": {
+          "delete": true,
+          "strategy": "merge"
+        }
+      },
       "title": "Ad Creative Analytics",
       "type": "object",
       "x-infer-schema": true
@@ -172,6 +264,23 @@
     "documentSchema": {
       "$schema": "http://json-schema.org/draft-07/schema#",
       "additionalProperties": true,
+      "if": {
+        "properties": {
+          "_meta": {
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            },
+            "required": [
+              "op"
+            ]
+          }
+        },
+        "required": [
+          "_meta"
+        ]
+      },
       "properties": {
         "_meta": {
           "properties": {
@@ -197,6 +306,12 @@
         "string_of_pivot_values",
         "end_date"
       ],
+      "then": {
+        "reduce": {
+          "delete": true,
+          "strategy": "merge"
+        }
+      },
       "title": "Ad Creative Analytics",
       "type": "object",
       "x-infer-schema": true
@@ -218,6 +333,23 @@
     "documentSchema": {
       "$schema": "http://json-schema.org/draft-07/schema#",
       "additionalProperties": true,
+      "if": {
+        "properties": {
+          "_meta": {
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            },
+            "required": [
+              "op"
+            ]
+          }
+        },
+        "required": [
+          "_meta"
+        ]
+      },
       "properties": {
         "_meta": {
           "properties": {
@@ -243,6 +375,12 @@
         "string_of_pivot_values",
         "end_date"
       ],
+      "then": {
+        "reduce": {
+          "delete": true,
+          "strategy": "merge"
+        }
+      },
       "title": "Ad Creative Analytics",
       "type": "object",
       "x-infer-schema": true
@@ -264,6 +402,23 @@
     "documentSchema": {
       "$schema": "http://json-schema.org/draft-07/schema#",
       "additionalProperties": true,
+      "if": {
+        "properties": {
+          "_meta": {
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            },
+            "required": [
+              "op"
+            ]
+          }
+        },
+        "required": [
+          "_meta"
+        ]
+      },
       "properties": {
         "_meta": {
           "properties": {
@@ -289,6 +444,12 @@
         "string_of_pivot_values",
         "end_date"
       ],
+      "then": {
+        "reduce": {
+          "delete": true,
+          "strategy": "merge"
+        }
+      },
       "title": "Ad Creative Analytics",
       "type": "object",
       "x-infer-schema": true
@@ -310,6 +471,23 @@
     "documentSchema": {
       "$schema": "http://json-schema.org/draft-07/schema#",
       "additionalProperties": true,
+      "if": {
+        "properties": {
+          "_meta": {
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            },
+            "required": [
+              "op"
+            ]
+          }
+        },
+        "required": [
+          "_meta"
+        ]
+      },
       "properties": {
         "_meta": {
           "properties": {
@@ -335,6 +513,12 @@
         "string_of_pivot_values",
         "end_date"
       ],
+      "then": {
+        "reduce": {
+          "delete": true,
+          "strategy": "merge"
+        }
+      },
       "title": "Ad Creative Analytics",
       "type": "object",
       "x-infer-schema": true
@@ -356,6 +540,23 @@
     "documentSchema": {
       "$schema": "http://json-schema.org/draft-07/schema#",
       "additionalProperties": true,
+      "if": {
+        "properties": {
+          "_meta": {
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            },
+            "required": [
+              "op"
+            ]
+          }
+        },
+        "required": [
+          "_meta"
+        ]
+      },
       "properties": {
         "_meta": {
           "properties": {
@@ -381,6 +582,12 @@
         "string_of_pivot_values",
         "end_date"
       ],
+      "then": {
+        "reduce": {
+          "delete": true,
+          "strategy": "merge"
+        }
+      },
       "title": "Ad Creative Analytics",
       "type": "object",
       "x-infer-schema": true
@@ -402,6 +609,23 @@
     "documentSchema": {
       "$schema": "http://json-schema.org/draft-07/schema#",
       "additionalProperties": true,
+      "if": {
+        "properties": {
+          "_meta": {
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            },
+            "required": [
+              "op"
+            ]
+          }
+        },
+        "required": [
+          "_meta"
+        ]
+      },
       "properties": {
         "_meta": {
           "properties": {
@@ -427,6 +651,12 @@
         "string_of_pivot_values",
         "end_date"
       ],
+      "then": {
+        "reduce": {
+          "delete": true,
+          "strategy": "merge"
+        }
+      },
       "title": "Ad Creative Analytics",
       "type": "object",
       "x-infer-schema": true
@@ -448,6 +678,23 @@
     "documentSchema": {
       "$schema": "http://json-schema.org/draft-07/schema#",
       "additionalProperties": true,
+      "if": {
+        "properties": {
+          "_meta": {
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            },
+            "required": [
+              "op"
+            ]
+          }
+        },
+        "required": [
+          "_meta"
+        ]
+      },
       "properties": {
         "_meta": {
           "properties": {
@@ -473,6 +720,12 @@
         "string_of_pivot_values",
         "end_date"
       ],
+      "then": {
+        "reduce": {
+          "delete": true,
+          "strategy": "merge"
+        }
+      },
       "title": "Ad Creative Analytics",
       "type": "object",
       "x-infer-schema": true
@@ -494,6 +747,23 @@
     "documentSchema": {
       "$schema": "http://json-schema.org/draft-07/schema#",
       "additionalProperties": true,
+      "if": {
+        "properties": {
+          "_meta": {
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            },
+            "required": [
+              "op"
+            ]
+          }
+        },
+        "required": [
+          "_meta"
+        ]
+      },
       "properties": {
         "_meta": {
           "properties": {
@@ -519,6 +789,12 @@
         "string_of_pivot_values",
         "end_date"
       ],
+      "then": {
+        "reduce": {
+          "delete": true,
+          "strategy": "merge"
+        }
+      },
       "title": "Ad Creative Analytics",
       "type": "object",
       "x-infer-schema": true
@@ -540,6 +816,23 @@
     "documentSchema": {
       "$schema": "http://json-schema.org/draft-07/schema#",
       "additionalProperties": true,
+      "if": {
+        "properties": {
+          "_meta": {
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            },
+            "required": [
+              "op"
+            ]
+          }
+        },
+        "required": [
+          "_meta"
+        ]
+      },
       "properties": {
         "_meta": {
           "properties": {
@@ -565,6 +858,12 @@
         "string_of_pivot_values",
         "end_date"
       ],
+      "then": {
+        "reduce": {
+          "delete": true,
+          "strategy": "merge"
+        }
+      },
       "title": "Ad Creative Analytics",
       "type": "object",
       "x-infer-schema": true
@@ -586,6 +885,23 @@
     "documentSchema": {
       "$schema": "http://json-schema.org/draft-07/schema#",
       "additionalProperties": true,
+      "if": {
+        "properties": {
+          "_meta": {
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            },
+            "required": [
+              "op"
+            ]
+          }
+        },
+        "required": [
+          "_meta"
+        ]
+      },
       "properties": {
         "_meta": {
           "properties": {
@@ -606,6 +922,12 @@
       "required": [
         "id"
       ],
+      "then": {
+        "reduce": {
+          "delete": true,
+          "strategy": "merge"
+        }
+      },
       "title": "Campaign Groups",
       "type": "object",
       "x-infer-schema": true
@@ -626,6 +948,23 @@
     "documentSchema": {
       "$schema": "http://json-schema.org/draft-07/schema#",
       "additionalProperties": true,
+      "if": {
+        "properties": {
+          "_meta": {
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            },
+            "required": [
+              "op"
+            ]
+          }
+        },
+        "required": [
+          "_meta"
+        ]
+      },
       "properties": {
         "_meta": {
           "properties": {
@@ -654,6 +993,12 @@
       "required": [
         "id"
       ],
+      "then": {
+        "reduce": {
+          "delete": true,
+          "strategy": "merge"
+        }
+      },
       "title": "Campaigns",
       "type": "object",
       "x-infer-schema": true
@@ -674,6 +1019,23 @@
     "documentSchema": {
       "$schema": "http://json-schema.org/draft-07/schema#",
       "additionalProperties": true,
+      "if": {
+        "properties": {
+          "_meta": {
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            },
+            "required": [
+              "op"
+            ]
+          }
+        },
+        "required": [
+          "_meta"
+        ]
+      },
       "properties": {
         "_meta": {
           "properties": {
@@ -694,6 +1056,12 @@
       "required": [
         "id"
       ],
+      "then": {
+        "reduce": {
+          "delete": true,
+          "strategy": "merge"
+        }
+      },
       "title": "Creatives",
       "type": "object",
       "x-infer-schema": true
@@ -713,6 +1081,23 @@
   {
     "documentSchema": {
       "$schema": "https://json-schema.org/draft-07/schema#",
+      "if": {
+        "properties": {
+          "_meta": {
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            },
+            "required": [
+              "op"
+            ]
+          }
+        },
+        "required": [
+          "_meta"
+        ]
+      },
       "properties": {
         "_meta": {
           "properties": {
@@ -733,6 +1118,12 @@
       "required": [
         "id"
       ],
+      "then": {
+        "reduce": {
+          "delete": true,
+          "strategy": "merge"
+        }
+      },
       "title": "Conversions",
       "type": "object",
       "x-infer-schema": true

--- a/source-linkedin-pages/tests/snapshots/discover.stdout.json
+++ b/source-linkedin-pages/tests/snapshots/discover.stdout.json
@@ -516,7 +516,30 @@
           }
         }
       },
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/_meta/row_id"
@@ -645,7 +668,30 @@
           }
         }
       },
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/_meta/row_id"
@@ -745,7 +791,30 @@
           ]
         }
       },
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/_meta/row_id"
@@ -783,7 +852,30 @@
           ]
         }
       },
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/_meta/row_id"

--- a/source-mixpanel-native/tests/snapshots/snapshots__discover__capture.stdout.json
+++ b/source-mixpanel-native/tests/snapshots/snapshots__discover__capture.stdout.json
@@ -32,7 +32,30 @@
           ]
         }
       },
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
@@ -78,7 +101,30 @@
           ]
         }
       },
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/distinct_id"
@@ -121,7 +167,30 @@
           ]
         }
       },
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/funnel_id",
@@ -169,7 +238,30 @@
           ]
         }
       },
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/insert_id"
@@ -218,7 +310,30 @@
           ]
         }
       },
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
@@ -260,7 +375,30 @@
           ]
         }
       },
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/distinct_id"

--- a/source-monday/tests/snapshots/snapshots__discover__stdout.json
+++ b/source-monday/tests/snapshots/snapshots__discover__stdout.json
@@ -40,7 +40,30 @@
       },
       "title": "FullRefreshResource",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/_meta/row_id"
@@ -87,7 +110,30 @@
       },
       "title": "FullRefreshResource",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/_meta/row_id"
@@ -134,7 +180,30 @@
       },
       "title": "FullRefreshResource",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/_meta/row_id"
@@ -194,7 +263,30 @@
       ],
       "title": "IncrementalResource",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
@@ -254,7 +346,30 @@
       ],
       "title": "IncrementalResource",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"

--- a/source-navan/tests/snapshots/snapshots__discover__stdout.json
+++ b/source-navan/tests/snapshots/snapshots__discover__stdout.json
@@ -53,7 +53,30 @@
       ],
       "title": "Booking",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/uuid"

--- a/source-notion/tests/snapshots/snapshots__discover__capture.stdout.json
+++ b/source-notion/tests/snapshots/snapshots__discover__capture.stdout.json
@@ -147,7 +147,30 @@
           ]
         }
       },
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
@@ -1253,7 +1276,30 @@
           ]
         }
       },
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
@@ -2039,7 +2085,30 @@
           ]
         }
       },
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
@@ -6213,7 +6282,30 @@
           ]
         }
       },
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
@@ -6473,7 +6565,30 @@
           ]
         }
       },
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"

--- a/source-outreach/tests/snapshots/snapshots__discover__capture.stdout.json
+++ b/source-outreach/tests/snapshots/snapshots__discover__capture.stdout.json
@@ -1,866 +1,1234 @@
 [
-    {
-      "recommendedName": "accounts",
-      "resourceConfig": {
-        "name": "accounts",
-        "interval": "PT5M"
-      },
-      "documentSchema": {
-        "$defs": {
-          "Meta": {
-            "properties": {
-              "op": {
-                "default": "u",
-                "description": "Operation type (c: Create, u: Update, d: Delete)",
-                "enum": [
-                  "c",
-                  "u",
-                  "d"
-                ],
-                "title": "Op",
-                "type": "string"
-              },
-              "row_id": {
-                "default": -1,
-                "description": "Row ID of the Document, counting up from zero, or -1 if not known",
-                "title": "Row Id",
-                "type": "integer"
-              }
-            },
-            "title": "Meta",
-            "type": "object"
-          }
-        },
-        "additionalProperties": true,
-        "properties": {
-          "_meta": {
-            "$ref": "#/$defs/Meta",
-            "description": "Document metadata"
-          },
-          "id": {
-            "title": "Id",
-            "type": "integer"
-          }
-        },
-        "required": [
-          "id"
-        ],
-        "title": "OutreachResource",
-        "type": "object",
-        "x-infer-schema": true
-      },
-      "key": [
-        "/id"
-      ]
+  {
+    "recommendedName": "accounts",
+    "resourceConfig": {
+      "name": "accounts",
+      "interval": "PT5M"
     },
-    {
-      "recommendedName": "call_dispositions",
-      "resourceConfig": {
-        "name": "call_dispositions",
-        "interval": "PT5M"
-      },
-      "documentSchema": {
-        "$defs": {
-          "Meta": {
-            "properties": {
-              "op": {
-                "default": "u",
-                "description": "Operation type (c: Create, u: Update, d: Delete)",
-                "enum": [
-                  "c",
-                  "u",
-                  "d"
-                ],
-                "title": "Op",
-                "type": "string"
-              },
-              "row_id": {
-                "default": -1,
-                "description": "Row ID of the Document, counting up from zero, or -1 if not known",
-                "title": "Row Id",
-                "type": "integer"
-              }
+    "documentSchema": {
+      "$defs": {
+        "Meta": {
+          "properties": {
+            "op": {
+              "default": "u",
+              "description": "Operation type (c: Create, u: Update, d: Delete)",
+              "enum": [
+                "c",
+                "u",
+                "d"
+              ],
+              "title": "Op",
+              "type": "string"
             },
-            "title": "Meta",
-            "type": "object"
-          }
+            "row_id": {
+              "default": -1,
+              "description": "Row ID of the Document, counting up from zero, or -1 if not known",
+              "title": "Row Id",
+              "type": "integer"
+            }
+          },
+          "title": "Meta",
+          "type": "object"
+        }
+      },
+      "additionalProperties": true,
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/Meta",
+          "description": "Document metadata"
         },
-        "additionalProperties": true,
+        "id": {
+          "title": "Id",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "id"
+      ],
+      "title": "OutreachResource",
+      "type": "object",
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
         "properties": {
           "_meta": {
-            "$ref": "#/$defs/Meta",
-            "description": "Document metadata"
-          },
-          "id": {
-            "title": "Id",
-            "type": "integer"
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
           }
-        },
-        "required": [
-          "id"
-        ],
-        "title": "OutreachResource",
-        "type": "object",
-        "x-infer-schema": true
+        }
       },
-      "key": [
-        "/id"
-      ]
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
-    {
-      "recommendedName": "call_purposes",
-      "resourceConfig": {
-        "name": "call_purposes",
-        "interval": "PT5M"
-      },
-      "documentSchema": {
-        "$defs": {
-          "Meta": {
-            "properties": {
-              "op": {
-                "default": "u",
-                "description": "Operation type (c: Create, u: Update, d: Delete)",
-                "enum": [
-                  "c",
-                  "u",
-                  "d"
-                ],
-                "title": "Op",
-                "type": "string"
-              },
-              "row_id": {
-                "default": -1,
-                "description": "Row ID of the Document, counting up from zero, or -1 if not known",
-                "title": "Row Id",
-                "type": "integer"
-              }
-            },
-            "title": "Meta",
-            "type": "object"
-          }
-        },
-        "additionalProperties": true,
-        "properties": {
-          "_meta": {
-            "$ref": "#/$defs/Meta",
-            "description": "Document metadata"
-          },
-          "id": {
-            "title": "Id",
-            "type": "integer"
-          }
-        },
-        "required": [
-          "id"
-        ],
-        "title": "OutreachResource",
-        "type": "object",
-        "x-infer-schema": true
-      },
-      "key": [
-        "/id"
-      ]
+    "key": [
+      "/id"
+    ]
+  },
+  {
+    "recommendedName": "call_dispositions",
+    "resourceConfig": {
+      "name": "call_dispositions",
+      "interval": "PT5M"
     },
-    {
-      "recommendedName": "calls",
-      "resourceConfig": {
-        "name": "calls",
-        "interval": "PT5M"
-      },
-      "documentSchema": {
-        "$defs": {
-          "Meta": {
-            "properties": {
-              "op": {
-                "default": "u",
-                "description": "Operation type (c: Create, u: Update, d: Delete)",
-                "enum": [
-                  "c",
-                  "u",
-                  "d"
-                ],
-                "title": "Op",
-                "type": "string"
-              },
-              "row_id": {
-                "default": -1,
-                "description": "Row ID of the Document, counting up from zero, or -1 if not known",
-                "title": "Row Id",
-                "type": "integer"
-              }
+    "documentSchema": {
+      "$defs": {
+        "Meta": {
+          "properties": {
+            "op": {
+              "default": "u",
+              "description": "Operation type (c: Create, u: Update, d: Delete)",
+              "enum": [
+                "c",
+                "u",
+                "d"
+              ],
+              "title": "Op",
+              "type": "string"
             },
-            "title": "Meta",
-            "type": "object"
-          }
+            "row_id": {
+              "default": -1,
+              "description": "Row ID of the Document, counting up from zero, or -1 if not known",
+              "title": "Row Id",
+              "type": "integer"
+            }
+          },
+          "title": "Meta",
+          "type": "object"
+        }
+      },
+      "additionalProperties": true,
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/Meta",
+          "description": "Document metadata"
         },
-        "additionalProperties": true,
+        "id": {
+          "title": "Id",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "id"
+      ],
+      "title": "OutreachResource",
+      "type": "object",
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
         "properties": {
           "_meta": {
-            "$ref": "#/$defs/Meta",
-            "description": "Document metadata"
-          },
-          "id": {
-            "title": "Id",
-            "type": "integer"
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
           }
-        },
-        "required": [
-          "id"
-        ],
-        "title": "OutreachResource",
-        "type": "object",
-        "x-infer-schema": true
+        }
       },
-      "key": [
-        "/id"
-      ]
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
-    {
-      "recommendedName": "email_addresses",
-      "resourceConfig": {
-        "name": "email_addresses",
-        "interval": "PT5M"
-      },
-      "documentSchema": {
-        "$defs": {
-          "Meta": {
-            "properties": {
-              "op": {
-                "default": "u",
-                "description": "Operation type (c: Create, u: Update, d: Delete)",
-                "enum": [
-                  "c",
-                  "u",
-                  "d"
-                ],
-                "title": "Op",
-                "type": "string"
-              },
-              "row_id": {
-                "default": -1,
-                "description": "Row ID of the Document, counting up from zero, or -1 if not known",
-                "title": "Row Id",
-                "type": "integer"
-              }
-            },
-            "title": "Meta",
-            "type": "object"
-          }
-        },
-        "additionalProperties": true,
-        "properties": {
-          "_meta": {
-            "$ref": "#/$defs/Meta",
-            "description": "Document metadata"
-          },
-          "id": {
-            "title": "Id",
-            "type": "integer"
-          }
-        },
-        "required": [
-          "id"
-        ],
-        "title": "OutreachResource",
-        "type": "object",
-        "x-infer-schema": true
-      },
-      "key": [
-        "/id"
-      ]
+    "key": [
+      "/id"
+    ]
+  },
+  {
+    "recommendedName": "call_purposes",
+    "resourceConfig": {
+      "name": "call_purposes",
+      "interval": "PT5M"
     },
-    {
-      "recommendedName": "events",
-      "resourceConfig": {
-        "name": "events",
-        "interval": "PT5M"
-      },
-      "documentSchema": {
-        "$defs": {
-          "Meta": {
-            "properties": {
-              "op": {
-                "default": "u",
-                "description": "Operation type (c: Create, u: Update, d: Delete)",
-                "enum": [
-                  "c",
-                  "u",
-                  "d"
-                ],
-                "title": "Op",
-                "type": "string"
-              },
-              "row_id": {
-                "default": -1,
-                "description": "Row ID of the Document, counting up from zero, or -1 if not known",
-                "title": "Row Id",
-                "type": "integer"
-              }
+    "documentSchema": {
+      "$defs": {
+        "Meta": {
+          "properties": {
+            "op": {
+              "default": "u",
+              "description": "Operation type (c: Create, u: Update, d: Delete)",
+              "enum": [
+                "c",
+                "u",
+                "d"
+              ],
+              "title": "Op",
+              "type": "string"
             },
-            "title": "Meta",
-            "type": "object"
-          }
+            "row_id": {
+              "default": -1,
+              "description": "Row ID of the Document, counting up from zero, or -1 if not known",
+              "title": "Row Id",
+              "type": "integer"
+            }
+          },
+          "title": "Meta",
+          "type": "object"
+        }
+      },
+      "additionalProperties": true,
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/Meta",
+          "description": "Document metadata"
         },
-        "additionalProperties": true,
+        "id": {
+          "title": "Id",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "id"
+      ],
+      "title": "OutreachResource",
+      "type": "object",
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
         "properties": {
           "_meta": {
-            "$ref": "#/$defs/Meta",
-            "description": "Document metadata"
-          },
-          "id": {
-            "title": "Id",
-            "type": "integer"
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
           }
-        },
-        "required": [
-          "id"
-        ],
-        "title": "OutreachResource",
-        "type": "object",
-        "x-infer-schema": true
+        }
       },
-      "key": [
-        "/id"
-      ]
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
-    {
-      "recommendedName": "mailboxes",
-      "resourceConfig": {
-        "name": "mailboxes",
-        "interval": "PT5M"
-      },
-      "documentSchema": {
-        "$defs": {
-          "Meta": {
-            "properties": {
-              "op": {
-                "default": "u",
-                "description": "Operation type (c: Create, u: Update, d: Delete)",
-                "enum": [
-                  "c",
-                  "u",
-                  "d"
-                ],
-                "title": "Op",
-                "type": "string"
-              },
-              "row_id": {
-                "default": -1,
-                "description": "Row ID of the Document, counting up from zero, or -1 if not known",
-                "title": "Row Id",
-                "type": "integer"
-              }
-            },
-            "title": "Meta",
-            "type": "object"
-          }
-        },
-        "additionalProperties": true,
-        "properties": {
-          "_meta": {
-            "$ref": "#/$defs/Meta",
-            "description": "Document metadata"
-          },
-          "id": {
-            "title": "Id",
-            "type": "integer"
-          }
-        },
-        "required": [
-          "id"
-        ],
-        "title": "OutreachResource",
-        "type": "object",
-        "x-infer-schema": true
-      },
-      "key": [
-        "/id"
-      ]
+    "key": [
+      "/id"
+    ]
+  },
+  {
+    "recommendedName": "calls",
+    "resourceConfig": {
+      "name": "calls",
+      "interval": "PT5M"
     },
-    {
-      "recommendedName": "mailings",
-      "resourceConfig": {
-        "name": "mailings",
-        "interval": "PT5M"
-      },
-      "documentSchema": {
-        "$defs": {
-          "Meta": {
-            "properties": {
-              "op": {
-                "default": "u",
-                "description": "Operation type (c: Create, u: Update, d: Delete)",
-                "enum": [
-                  "c",
-                  "u",
-                  "d"
-                ],
-                "title": "Op",
-                "type": "string"
-              },
-              "row_id": {
-                "default": -1,
-                "description": "Row ID of the Document, counting up from zero, or -1 if not known",
-                "title": "Row Id",
-                "type": "integer"
-              }
+    "documentSchema": {
+      "$defs": {
+        "Meta": {
+          "properties": {
+            "op": {
+              "default": "u",
+              "description": "Operation type (c: Create, u: Update, d: Delete)",
+              "enum": [
+                "c",
+                "u",
+                "d"
+              ],
+              "title": "Op",
+              "type": "string"
             },
-            "title": "Meta",
-            "type": "object"
-          }
+            "row_id": {
+              "default": -1,
+              "description": "Row ID of the Document, counting up from zero, or -1 if not known",
+              "title": "Row Id",
+              "type": "integer"
+            }
+          },
+          "title": "Meta",
+          "type": "object"
+        }
+      },
+      "additionalProperties": true,
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/Meta",
+          "description": "Document metadata"
         },
-        "additionalProperties": true,
+        "id": {
+          "title": "Id",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "id"
+      ],
+      "title": "OutreachResource",
+      "type": "object",
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
         "properties": {
           "_meta": {
-            "$ref": "#/$defs/Meta",
-            "description": "Document metadata"
-          },
-          "id": {
-            "title": "Id",
-            "type": "integer"
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
           }
-        },
-        "required": [
-          "id"
-        ],
-        "title": "OutreachResource",
-        "type": "object",
-        "x-infer-schema": true
+        }
       },
-      "key": [
-        "/id"
-      ]
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
-    {
-      "recommendedName": "opportunities",
-      "resourceConfig": {
-        "name": "opportunities",
-        "interval": "PT5M"
-      },
-      "documentSchema": {
-        "$defs": {
-          "Meta": {
-            "properties": {
-              "op": {
-                "default": "u",
-                "description": "Operation type (c: Create, u: Update, d: Delete)",
-                "enum": [
-                  "c",
-                  "u",
-                  "d"
-                ],
-                "title": "Op",
-                "type": "string"
-              },
-              "row_id": {
-                "default": -1,
-                "description": "Row ID of the Document, counting up from zero, or -1 if not known",
-                "title": "Row Id",
-                "type": "integer"
-              }
-            },
-            "title": "Meta",
-            "type": "object"
-          }
-        },
-        "additionalProperties": true,
-        "properties": {
-          "_meta": {
-            "$ref": "#/$defs/Meta",
-            "description": "Document metadata"
-          },
-          "id": {
-            "title": "Id",
-            "type": "integer"
-          }
-        },
-        "required": [
-          "id"
-        ],
-        "title": "OutreachResource",
-        "type": "object",
-        "x-infer-schema": true
-      },
-      "key": [
-        "/id"
-      ]
+    "key": [
+      "/id"
+    ]
+  },
+  {
+    "recommendedName": "email_addresses",
+    "resourceConfig": {
+      "name": "email_addresses",
+      "interval": "PT5M"
     },
-    {
-      "recommendedName": "opportunity_stages",
-      "resourceConfig": {
-        "name": "opportunity_stages",
-        "interval": "PT5M"
-      },
-      "documentSchema": {
-        "$defs": {
-          "Meta": {
-            "properties": {
-              "op": {
-                "default": "u",
-                "description": "Operation type (c: Create, u: Update, d: Delete)",
-                "enum": [
-                  "c",
-                  "u",
-                  "d"
-                ],
-                "title": "Op",
-                "type": "string"
-              },
-              "row_id": {
-                "default": -1,
-                "description": "Row ID of the Document, counting up from zero, or -1 if not known",
-                "title": "Row Id",
-                "type": "integer"
-              }
+    "documentSchema": {
+      "$defs": {
+        "Meta": {
+          "properties": {
+            "op": {
+              "default": "u",
+              "description": "Operation type (c: Create, u: Update, d: Delete)",
+              "enum": [
+                "c",
+                "u",
+                "d"
+              ],
+              "title": "Op",
+              "type": "string"
             },
-            "title": "Meta",
-            "type": "object"
-          }
+            "row_id": {
+              "default": -1,
+              "description": "Row ID of the Document, counting up from zero, or -1 if not known",
+              "title": "Row Id",
+              "type": "integer"
+            }
+          },
+          "title": "Meta",
+          "type": "object"
+        }
+      },
+      "additionalProperties": true,
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/Meta",
+          "description": "Document metadata"
         },
-        "additionalProperties": true,
+        "id": {
+          "title": "Id",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "id"
+      ],
+      "title": "OutreachResource",
+      "type": "object",
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
         "properties": {
           "_meta": {
-            "$ref": "#/$defs/Meta",
-            "description": "Document metadata"
-          },
-          "id": {
-            "title": "Id",
-            "type": "integer"
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
           }
-        },
-        "required": [
-          "id"
-        ],
-        "title": "OutreachResource",
-        "type": "object",
-        "x-infer-schema": true
+        }
       },
-      "key": [
-        "/id"
-      ]
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
-    {
-      "recommendedName": "prospects",
-      "resourceConfig": {
-        "name": "prospects",
-        "interval": "PT5M"
-      },
-      "documentSchema": {
-        "$defs": {
-          "Meta": {
-            "properties": {
-              "op": {
-                "default": "u",
-                "description": "Operation type (c: Create, u: Update, d: Delete)",
-                "enum": [
-                  "c",
-                  "u",
-                  "d"
-                ],
-                "title": "Op",
-                "type": "string"
-              },
-              "row_id": {
-                "default": -1,
-                "description": "Row ID of the Document, counting up from zero, or -1 if not known",
-                "title": "Row Id",
-                "type": "integer"
-              }
-            },
-            "title": "Meta",
-            "type": "object"
-          }
-        },
-        "additionalProperties": true,
-        "properties": {
-          "_meta": {
-            "$ref": "#/$defs/Meta",
-            "description": "Document metadata"
-          },
-          "id": {
-            "title": "Id",
-            "type": "integer"
-          }
-        },
-        "required": [
-          "id"
-        ],
-        "title": "OutreachResource",
-        "type": "object",
-        "x-infer-schema": true
-      },
-      "key": [
-        "/id"
-      ]
+    "key": [
+      "/id"
+    ]
+  },
+  {
+    "recommendedName": "events",
+    "resourceConfig": {
+      "name": "events",
+      "interval": "PT5M"
     },
-    {
-      "recommendedName": "stages",
-      "resourceConfig": {
-        "name": "stages",
-        "interval": "PT5M"
-      },
-      "documentSchema": {
-        "$defs": {
-          "Meta": {
-            "properties": {
-              "op": {
-                "default": "u",
-                "description": "Operation type (c: Create, u: Update, d: Delete)",
-                "enum": [
-                  "c",
-                  "u",
-                  "d"
-                ],
-                "title": "Op",
-                "type": "string"
-              },
-              "row_id": {
-                "default": -1,
-                "description": "Row ID of the Document, counting up from zero, or -1 if not known",
-                "title": "Row Id",
-                "type": "integer"
-              }
+    "documentSchema": {
+      "$defs": {
+        "Meta": {
+          "properties": {
+            "op": {
+              "default": "u",
+              "description": "Operation type (c: Create, u: Update, d: Delete)",
+              "enum": [
+                "c",
+                "u",
+                "d"
+              ],
+              "title": "Op",
+              "type": "string"
             },
-            "title": "Meta",
-            "type": "object"
-          }
+            "row_id": {
+              "default": -1,
+              "description": "Row ID of the Document, counting up from zero, or -1 if not known",
+              "title": "Row Id",
+              "type": "integer"
+            }
+          },
+          "title": "Meta",
+          "type": "object"
+        }
+      },
+      "additionalProperties": true,
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/Meta",
+          "description": "Document metadata"
         },
-        "additionalProperties": true,
+        "id": {
+          "title": "Id",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "id"
+      ],
+      "title": "OutreachResource",
+      "type": "object",
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
         "properties": {
           "_meta": {
-            "$ref": "#/$defs/Meta",
-            "description": "Document metadata"
-          },
-          "id": {
-            "title": "Id",
-            "type": "integer"
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
           }
-        },
-        "required": [
-          "id"
-        ],
-        "title": "OutreachResource",
-        "type": "object",
-        "x-infer-schema": true
+        }
       },
-      "key": [
-        "/id"
-      ]
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
-    {
-      "recommendedName": "tasks",
-      "resourceConfig": {
-        "name": "tasks",
-        "interval": "PT5M"
-      },
-      "documentSchema": {
-        "$defs": {
-          "Meta": {
-            "properties": {
-              "op": {
-                "default": "u",
-                "description": "Operation type (c: Create, u: Update, d: Delete)",
-                "enum": [
-                  "c",
-                  "u",
-                  "d"
-                ],
-                "title": "Op",
-                "type": "string"
-              },
-              "row_id": {
-                "default": -1,
-                "description": "Row ID of the Document, counting up from zero, or -1 if not known",
-                "title": "Row Id",
-                "type": "integer"
-              }
-            },
-            "title": "Meta",
-            "type": "object"
-          }
-        },
-        "additionalProperties": true,
-        "properties": {
-          "_meta": {
-            "$ref": "#/$defs/Meta",
-            "description": "Document metadata"
-          },
-          "id": {
-            "title": "Id",
-            "type": "integer"
-          }
-        },
-        "required": [
-          "id"
-        ],
-        "title": "OutreachResource",
-        "type": "object",
-        "x-infer-schema": true
-      },
-      "key": [
-        "/id"
-      ]
+    "key": [
+      "/id"
+    ]
+  },
+  {
+    "recommendedName": "mailboxes",
+    "resourceConfig": {
+      "name": "mailboxes",
+      "interval": "PT5M"
     },
-    {
-      "recommendedName": "teams",
-      "resourceConfig": {
-        "name": "teams",
-        "interval": "PT5M"
-      },
-      "documentSchema": {
-        "$defs": {
-          "Meta": {
-            "properties": {
-              "op": {
-                "default": "u",
-                "description": "Operation type (c: Create, u: Update, d: Delete)",
-                "enum": [
-                  "c",
-                  "u",
-                  "d"
-                ],
-                "title": "Op",
-                "type": "string"
-              },
-              "row_id": {
-                "default": -1,
-                "description": "Row ID of the Document, counting up from zero, or -1 if not known",
-                "title": "Row Id",
-                "type": "integer"
-              }
+    "documentSchema": {
+      "$defs": {
+        "Meta": {
+          "properties": {
+            "op": {
+              "default": "u",
+              "description": "Operation type (c: Create, u: Update, d: Delete)",
+              "enum": [
+                "c",
+                "u",
+                "d"
+              ],
+              "title": "Op",
+              "type": "string"
             },
-            "title": "Meta",
-            "type": "object"
-          }
+            "row_id": {
+              "default": -1,
+              "description": "Row ID of the Document, counting up from zero, or -1 if not known",
+              "title": "Row Id",
+              "type": "integer"
+            }
+          },
+          "title": "Meta",
+          "type": "object"
+        }
+      },
+      "additionalProperties": true,
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/Meta",
+          "description": "Document metadata"
         },
-        "additionalProperties": true,
+        "id": {
+          "title": "Id",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "id"
+      ],
+      "title": "OutreachResource",
+      "type": "object",
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
         "properties": {
           "_meta": {
-            "$ref": "#/$defs/Meta",
-            "description": "Document metadata"
-          },
-          "id": {
-            "title": "Id",
-            "type": "integer"
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
           }
-        },
-        "required": [
-          "id"
-        ],
-        "title": "OutreachResource",
-        "type": "object",
-        "x-infer-schema": true
+        }
       },
-      "key": [
-        "/id"
-      ]
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
-    {
-      "recommendedName": "templates",
-      "resourceConfig": {
-        "name": "templates",
-        "interval": "PT5M"
-      },
-      "documentSchema": {
-        "$defs": {
-          "Meta": {
-            "properties": {
-              "op": {
-                "default": "u",
-                "description": "Operation type (c: Create, u: Update, d: Delete)",
-                "enum": [
-                  "c",
-                  "u",
-                  "d"
-                ],
-                "title": "Op",
-                "type": "string"
-              },
-              "row_id": {
-                "default": -1,
-                "description": "Row ID of the Document, counting up from zero, or -1 if not known",
-                "title": "Row Id",
-                "type": "integer"
-              }
-            },
-            "title": "Meta",
-            "type": "object"
-          }
-        },
-        "additionalProperties": true,
-        "properties": {
-          "_meta": {
-            "$ref": "#/$defs/Meta",
-            "description": "Document metadata"
-          },
-          "id": {
-            "title": "Id",
-            "type": "integer"
-          }
-        },
-        "required": [
-          "id"
-        ],
-        "title": "OutreachResource",
-        "type": "object",
-        "x-infer-schema": true
-      },
-      "key": [
-        "/id"
-      ]
+    "key": [
+      "/id"
+    ]
+  },
+  {
+    "recommendedName": "mailings",
+    "resourceConfig": {
+      "name": "mailings",
+      "interval": "PT5M"
     },
-    {
-      "recommendedName": "users",
-      "resourceConfig": {
-        "name": "users",
-        "interval": "PT5M"
-      },
-      "documentSchema": {
-        "$defs": {
-          "Meta": {
-            "properties": {
-              "op": {
-                "default": "u",
-                "description": "Operation type (c: Create, u: Update, d: Delete)",
-                "enum": [
-                  "c",
-                  "u",
-                  "d"
-                ],
-                "title": "Op",
-                "type": "string"
-              },
-              "row_id": {
-                "default": -1,
-                "description": "Row ID of the Document, counting up from zero, or -1 if not known",
-                "title": "Row Id",
-                "type": "integer"
-              }
+    "documentSchema": {
+      "$defs": {
+        "Meta": {
+          "properties": {
+            "op": {
+              "default": "u",
+              "description": "Operation type (c: Create, u: Update, d: Delete)",
+              "enum": [
+                "c",
+                "u",
+                "d"
+              ],
+              "title": "Op",
+              "type": "string"
             },
-            "title": "Meta",
-            "type": "object"
-          }
+            "row_id": {
+              "default": -1,
+              "description": "Row ID of the Document, counting up from zero, or -1 if not known",
+              "title": "Row Id",
+              "type": "integer"
+            }
+          },
+          "title": "Meta",
+          "type": "object"
+        }
+      },
+      "additionalProperties": true,
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/Meta",
+          "description": "Document metadata"
         },
-        "additionalProperties": true,
+        "id": {
+          "title": "Id",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "id"
+      ],
+      "title": "OutreachResource",
+      "type": "object",
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
         "properties": {
           "_meta": {
-            "$ref": "#/$defs/Meta",
-            "description": "Document metadata"
-          },
-          "id": {
-            "title": "Id",
-            "type": "integer"
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
           }
-        },
-        "required": [
-          "id"
-        ],
-        "title": "OutreachResource",
-        "type": "object",
-        "x-infer-schema": true
+        }
       },
-      "key": [
-        "/id"
-      ]
-    }
-  ]
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
+    },
+    "key": [
+      "/id"
+    ]
+  },
+  {
+    "recommendedName": "opportunities",
+    "resourceConfig": {
+      "name": "opportunities",
+      "interval": "PT5M"
+    },
+    "documentSchema": {
+      "$defs": {
+        "Meta": {
+          "properties": {
+            "op": {
+              "default": "u",
+              "description": "Operation type (c: Create, u: Update, d: Delete)",
+              "enum": [
+                "c",
+                "u",
+                "d"
+              ],
+              "title": "Op",
+              "type": "string"
+            },
+            "row_id": {
+              "default": -1,
+              "description": "Row ID of the Document, counting up from zero, or -1 if not known",
+              "title": "Row Id",
+              "type": "integer"
+            }
+          },
+          "title": "Meta",
+          "type": "object"
+        }
+      },
+      "additionalProperties": true,
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/Meta",
+          "description": "Document metadata"
+        },
+        "id": {
+          "title": "Id",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "id"
+      ],
+      "title": "OutreachResource",
+      "type": "object",
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
+    },
+    "key": [
+      "/id"
+    ]
+  },
+  {
+    "recommendedName": "opportunity_stages",
+    "resourceConfig": {
+      "name": "opportunity_stages",
+      "interval": "PT5M"
+    },
+    "documentSchema": {
+      "$defs": {
+        "Meta": {
+          "properties": {
+            "op": {
+              "default": "u",
+              "description": "Operation type (c: Create, u: Update, d: Delete)",
+              "enum": [
+                "c",
+                "u",
+                "d"
+              ],
+              "title": "Op",
+              "type": "string"
+            },
+            "row_id": {
+              "default": -1,
+              "description": "Row ID of the Document, counting up from zero, or -1 if not known",
+              "title": "Row Id",
+              "type": "integer"
+            }
+          },
+          "title": "Meta",
+          "type": "object"
+        }
+      },
+      "additionalProperties": true,
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/Meta",
+          "description": "Document metadata"
+        },
+        "id": {
+          "title": "Id",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "id"
+      ],
+      "title": "OutreachResource",
+      "type": "object",
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
+    },
+    "key": [
+      "/id"
+    ]
+  },
+  {
+    "recommendedName": "prospects",
+    "resourceConfig": {
+      "name": "prospects",
+      "interval": "PT5M"
+    },
+    "documentSchema": {
+      "$defs": {
+        "Meta": {
+          "properties": {
+            "op": {
+              "default": "u",
+              "description": "Operation type (c: Create, u: Update, d: Delete)",
+              "enum": [
+                "c",
+                "u",
+                "d"
+              ],
+              "title": "Op",
+              "type": "string"
+            },
+            "row_id": {
+              "default": -1,
+              "description": "Row ID of the Document, counting up from zero, or -1 if not known",
+              "title": "Row Id",
+              "type": "integer"
+            }
+          },
+          "title": "Meta",
+          "type": "object"
+        }
+      },
+      "additionalProperties": true,
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/Meta",
+          "description": "Document metadata"
+        },
+        "id": {
+          "title": "Id",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "id"
+      ],
+      "title": "OutreachResource",
+      "type": "object",
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
+    },
+    "key": [
+      "/id"
+    ]
+  },
+  {
+    "recommendedName": "stages",
+    "resourceConfig": {
+      "name": "stages",
+      "interval": "PT5M"
+    },
+    "documentSchema": {
+      "$defs": {
+        "Meta": {
+          "properties": {
+            "op": {
+              "default": "u",
+              "description": "Operation type (c: Create, u: Update, d: Delete)",
+              "enum": [
+                "c",
+                "u",
+                "d"
+              ],
+              "title": "Op",
+              "type": "string"
+            },
+            "row_id": {
+              "default": -1,
+              "description": "Row ID of the Document, counting up from zero, or -1 if not known",
+              "title": "Row Id",
+              "type": "integer"
+            }
+          },
+          "title": "Meta",
+          "type": "object"
+        }
+      },
+      "additionalProperties": true,
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/Meta",
+          "description": "Document metadata"
+        },
+        "id": {
+          "title": "Id",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "id"
+      ],
+      "title": "OutreachResource",
+      "type": "object",
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
+    },
+    "key": [
+      "/id"
+    ]
+  },
+  {
+    "recommendedName": "tasks",
+    "resourceConfig": {
+      "name": "tasks",
+      "interval": "PT5M"
+    },
+    "documentSchema": {
+      "$defs": {
+        "Meta": {
+          "properties": {
+            "op": {
+              "default": "u",
+              "description": "Operation type (c: Create, u: Update, d: Delete)",
+              "enum": [
+                "c",
+                "u",
+                "d"
+              ],
+              "title": "Op",
+              "type": "string"
+            },
+            "row_id": {
+              "default": -1,
+              "description": "Row ID of the Document, counting up from zero, or -1 if not known",
+              "title": "Row Id",
+              "type": "integer"
+            }
+          },
+          "title": "Meta",
+          "type": "object"
+        }
+      },
+      "additionalProperties": true,
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/Meta",
+          "description": "Document metadata"
+        },
+        "id": {
+          "title": "Id",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "id"
+      ],
+      "title": "OutreachResource",
+      "type": "object",
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
+    },
+    "key": [
+      "/id"
+    ]
+  },
+  {
+    "recommendedName": "teams",
+    "resourceConfig": {
+      "name": "teams",
+      "interval": "PT5M"
+    },
+    "documentSchema": {
+      "$defs": {
+        "Meta": {
+          "properties": {
+            "op": {
+              "default": "u",
+              "description": "Operation type (c: Create, u: Update, d: Delete)",
+              "enum": [
+                "c",
+                "u",
+                "d"
+              ],
+              "title": "Op",
+              "type": "string"
+            },
+            "row_id": {
+              "default": -1,
+              "description": "Row ID of the Document, counting up from zero, or -1 if not known",
+              "title": "Row Id",
+              "type": "integer"
+            }
+          },
+          "title": "Meta",
+          "type": "object"
+        }
+      },
+      "additionalProperties": true,
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/Meta",
+          "description": "Document metadata"
+        },
+        "id": {
+          "title": "Id",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "id"
+      ],
+      "title": "OutreachResource",
+      "type": "object",
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
+    },
+    "key": [
+      "/id"
+    ]
+  },
+  {
+    "recommendedName": "templates",
+    "resourceConfig": {
+      "name": "templates",
+      "interval": "PT5M"
+    },
+    "documentSchema": {
+      "$defs": {
+        "Meta": {
+          "properties": {
+            "op": {
+              "default": "u",
+              "description": "Operation type (c: Create, u: Update, d: Delete)",
+              "enum": [
+                "c",
+                "u",
+                "d"
+              ],
+              "title": "Op",
+              "type": "string"
+            },
+            "row_id": {
+              "default": -1,
+              "description": "Row ID of the Document, counting up from zero, or -1 if not known",
+              "title": "Row Id",
+              "type": "integer"
+            }
+          },
+          "title": "Meta",
+          "type": "object"
+        }
+      },
+      "additionalProperties": true,
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/Meta",
+          "description": "Document metadata"
+        },
+        "id": {
+          "title": "Id",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "id"
+      ],
+      "title": "OutreachResource",
+      "type": "object",
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
+    },
+    "key": [
+      "/id"
+    ]
+  },
+  {
+    "recommendedName": "users",
+    "resourceConfig": {
+      "name": "users",
+      "interval": "PT5M"
+    },
+    "documentSchema": {
+      "$defs": {
+        "Meta": {
+          "properties": {
+            "op": {
+              "default": "u",
+              "description": "Operation type (c: Create, u: Update, d: Delete)",
+              "enum": [
+                "c",
+                "u",
+                "d"
+              ],
+              "title": "Op",
+              "type": "string"
+            },
+            "row_id": {
+              "default": -1,
+              "description": "Row ID of the Document, counting up from zero, or -1 if not known",
+              "title": "Row Id",
+              "type": "integer"
+            }
+          },
+          "title": "Meta",
+          "type": "object"
+        }
+      },
+      "additionalProperties": true,
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/Meta",
+          "description": "Document metadata"
+        },
+        "id": {
+          "title": "Id",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "id"
+      ],
+      "title": "OutreachResource",
+      "type": "object",
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
+    },
+    "key": [
+      "/id"
+    ]
+  }
+]

--- a/source-pendo/tests/snapshots/snapshots__discover__capture.stdout.json
+++ b/source-pendo/tests/snapshots/snapshots__discover__capture.stdout.json
@@ -40,7 +40,30 @@
       },
       "title": "FullRefreshResource",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/_meta/row_id"
@@ -87,7 +110,30 @@
       },
       "title": "FullRefreshResource",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/_meta/row_id"
@@ -134,7 +180,30 @@
       },
       "title": "FullRefreshResource",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/_meta/row_id"
@@ -181,7 +250,30 @@
       },
       "title": "FullRefreshResource",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/_meta/row_id"
@@ -228,7 +320,30 @@
       },
       "title": "FullRefreshResource",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/_meta/row_id"
@@ -282,7 +397,30 @@
       ],
       "title": "Account",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/accountId"
@@ -336,7 +474,30 @@
       ],
       "title": "Visitor",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/visitorId"
@@ -390,7 +551,30 @@
       ],
       "title": "TrackType",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
@@ -437,7 +621,30 @@
       },
       "title": "Metadata",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/_meta/row_id"
@@ -484,7 +691,30 @@
       },
       "title": "Metadata",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/_meta/row_id"
@@ -574,7 +804,30 @@
       ],
       "title": "GuideEvent",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/accountId",
@@ -676,7 +929,30 @@
       ],
       "title": "PollEvent",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/accountId",
@@ -779,7 +1055,30 @@
       ],
       "title": "PageEvent",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/accountId",
@@ -882,7 +1181,30 @@
       ],
       "title": "FeatureEvent",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/accountId",
@@ -985,7 +1307,30 @@
       ],
       "title": "TrackEvent",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/accountId",

--- a/source-posthog/tests/snapshots/snapshots__discover__stdout.json
+++ b/source-posthog/tests/snapshots/snapshots__discover__stdout.json
@@ -48,7 +48,30 @@
       ],
       "title": "Annotation",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/_meta/row_id"
@@ -103,7 +126,30 @@
       ],
       "title": "Cohort",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/_meta/row_id"
@@ -170,7 +216,30 @@
       ],
       "title": "Event",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/_meta/project_id",
@@ -238,7 +307,30 @@
       ],
       "title": "FeatureFlag",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/_meta/project_id",
@@ -299,7 +391,30 @@
       ],
       "title": "Organization",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/_meta/row_id"
@@ -379,7 +494,30 @@
       ],
       "title": "Person",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/_meta/project_id",
@@ -435,7 +573,30 @@
       ],
       "title": "Project",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/_meta/row_id"

--- a/source-qualtrics/tests/snapshots/snapshots__discover__stdout.json
+++ b/source-qualtrics/tests/snapshots/snapshots__discover__stdout.json
@@ -47,7 +47,30 @@
       ],
       "title": "SurveyQuestion",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/_meta/row_id"
@@ -124,7 +147,30 @@
       ],
       "title": "SurveyResponse",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/surveyId",
@@ -179,7 +225,30 @@
       ],
       "title": "Survey",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/_meta/row_id"

--- a/source-quickbooks/tests/snapshots/snapshots__discover__stdout.json
+++ b/source-quickbooks/tests/snapshots/snapshots__discover__stdout.json
@@ -66,7 +66,30 @@
       ],
       "title": "Account",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/Id"
@@ -139,7 +162,30 @@
       ],
       "title": "BillPayment",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/Id"
@@ -212,7 +258,30 @@
       ],
       "title": "Bill",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/Id"
@@ -285,7 +354,30 @@
       ],
       "title": "Budget",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/Id"
@@ -358,7 +450,30 @@
       ],
       "title": "Class",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/Id"
@@ -431,7 +546,30 @@
       ],
       "title": "CreditMemo",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/Id"
@@ -504,7 +642,30 @@
       ],
       "title": "Customer",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/Id"
@@ -577,7 +738,30 @@
       ],
       "title": "Department",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/Id"
@@ -650,7 +834,30 @@
       ],
       "title": "Deposit",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/Id"
@@ -723,7 +930,30 @@
       ],
       "title": "Employee",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/Id"
@@ -796,7 +1026,30 @@
       ],
       "title": "Estimate",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/Id"
@@ -869,7 +1122,30 @@
       ],
       "title": "Invoice",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/Id"
@@ -942,7 +1218,30 @@
       ],
       "title": "Item",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/Id"
@@ -1015,7 +1314,30 @@
       ],
       "title": "JournalEntry",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/Id"
@@ -1088,7 +1410,30 @@
       ],
       "title": "PaymentMethod",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/Id"
@@ -1161,7 +1506,30 @@
       ],
       "title": "Payment",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/Id"
@@ -1234,7 +1602,30 @@
       ],
       "title": "PurchaseOrder",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/Id"
@@ -1307,7 +1698,30 @@
       ],
       "title": "Purchase",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/Id"
@@ -1380,7 +1794,30 @@
       ],
       "title": "RefundReceipt",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/Id"
@@ -1453,7 +1890,30 @@
       ],
       "title": "SalesReceipt",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/Id"
@@ -1526,7 +1986,30 @@
       ],
       "title": "TaxAgency",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/Id"
@@ -1599,7 +2082,30 @@
       ],
       "title": "TaxCode",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/Id"
@@ -1672,7 +2178,30 @@
       ],
       "title": "TaxRate",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/Id"
@@ -1745,7 +2274,30 @@
       ],
       "title": "Term",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/Id"
@@ -1818,7 +2370,30 @@
       ],
       "title": "TimeActivity",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/Id"
@@ -1891,7 +2466,30 @@
       ],
       "title": "Transfer",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/Id"
@@ -1964,7 +2562,30 @@
       ],
       "title": "VendorCredit",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/Id"
@@ -2037,7 +2658,30 @@
       ],
       "title": "Vendor",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/Id"

--- a/source-recharge/tests/snapshots/snapshot__discover__capture.stdout.json
+++ b/source-recharge/tests/snapshots/snapshot__discover__capture.stdout.json
@@ -1,18 +1,24 @@
 [
   {
+    "recommendedName": "addresses",
+    "resourceConfig": {
+      "stream": "addresses",
+      "syncMode": "incremental",
+      "cursorField": [
+        "updated_at"
+      ]
+    },
     "documentSchema": {
       "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "required": [
+        "id"
+      ],
       "properties": {
-        "_meta": {
-          "properties": {
-            "row_id": {
-              "type": "integer"
-            }
-          },
-          "required": [
-            "row_id"
-          ],
-          "type": "object"
+        "id": {
+          "type": [
+            "integer"
+          ]
         },
         "address1": {
           "type": [
@@ -50,18 +56,18 @@
             "string"
           ]
         },
-        "created_at": {
-          "format": "date-time",
-          "type": [
-            "null",
-            "string"
-          ]
-        },
         "customer_id": {
           "type": [
             "null",
             "integer"
           ]
+        },
+        "created_at": {
+          "type": [
+            "null",
+            "string"
+          ],
+          "format": "date-time"
         },
         "discount_id": {
           "type": [
@@ -73,11 +79,6 @@
           "type": [
             "null",
             "string"
-          ]
-        },
-        "id": {
-          "type": [
-            "integer"
           ]
         },
         "last_name": {
@@ -111,41 +112,20 @@
           ]
         },
         "updated_at": {
-          "format": "date-time",
           "type": [
             "null",
             "string"
-          ]
+          ],
+          "format": "date-time"
         },
         "zip": {
           "type": [
             "null",
             "string"
           ]
-        }
-      },
-      "required": [
-        "id"
-      ],
-      "type": "object"
-    },
-    "key": [
-      "/id"
-    ],
-    "recommendedName": "addresses",
-    "resourceConfig": {
-      "cursorField": [
-        "updated_at"
-      ],
-      "stream": "addresses",
-      "syncMode": "incremental"
-    }
-  },
-  {
-    "documentSchema": {
-      "$schema": "http://json-schema.org/draft-07/schema#",
-      "properties": {
+        },
         "_meta": {
+          "type": "object",
           "properties": {
             "row_id": {
               "type": "integer"
@@ -153,8 +133,57 @@
           },
           "required": [
             "row_id"
-          ],
-          "type": "object"
+          ]
+        }
+      },
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
+    },
+    "key": [
+      "/id"
+    ]
+  },
+  {
+    "recommendedName": "charges",
+    "resourceConfig": {
+      "stream": "charges",
+      "syncMode": "incremental",
+      "cursorField": [
+        "updated_at"
+      ]
+    },
+    "documentSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "required": [
+        "id"
+      ],
+      "properties": {
+        "id": {
+          "type": [
+            "integer"
+          ]
         },
         "address_id": {
           "type": [
@@ -169,7 +198,17 @@
           ]
         },
         "billing_address": {
+          "type": [
+            "null",
+            "object"
+          ],
           "properties": {
+            "id": {
+              "type": [
+                "null",
+                "integer"
+              ]
+            },
             "address1": {
               "type": [
                 "null",
@@ -206,18 +245,18 @@
                 "string"
               ]
             },
-            "created_at": {
-              "format": "date-time",
-              "type": [
-                "null",
-                "string"
-              ]
-            },
             "customer_id": {
               "type": [
                 "null",
                 "integer"
               ]
+            },
+            "created_at": {
+              "type": [
+                "null",
+                "string"
+              ],
+              "format": "date-time"
             },
             "discount_id": {
               "type": [
@@ -229,12 +268,6 @@
               "type": [
                 "null",
                 "string"
-              ]
-            },
-            "id": {
-              "type": [
-                "null",
-                "integer"
               ]
             },
             "last_name": {
@@ -268,11 +301,11 @@
               ]
             },
             "updated_at": {
-              "format": "date-time",
               "type": [
                 "null",
                 "string"
-              ]
+              ],
+              "format": "date-time"
             },
             "zip": {
               "type": [
@@ -280,11 +313,7 @@
                 "string"
               ]
             }
-          },
-          "type": [
-            "null",
-            "object"
-          ]
+          }
         },
         "client_details": {
           "type": [
@@ -293,11 +322,11 @@
           ]
         },
         "created_at": {
-          "format": "date-time",
           "type": [
             "null",
             "string"
-          ]
+          ],
+          "format": "date-time"
         },
         "customer_hash": {
           "type": [
@@ -312,16 +341,16 @@
           ]
         },
         "discount_codes": {
+          "type": [
+            "null",
+            "array"
+          ],
           "items": {
             "type": [
               "null",
               "object"
             ]
-          },
-          "type": [
-            "null",
-            "array"
-          ]
+          }
         },
         "email": {
           "type": [
@@ -347,34 +376,29 @@
             "string"
           ]
         },
-        "has_uncommited_changes": {
-          "type": [
-            "null",
-            "boolean"
-          ]
-        },
-        "id": {
-          "type": [
-            "integer"
-          ]
-        },
-        "last_charge_attempt_date": {
-          "format": "date-time",
-          "type": [
-            "null",
-            "string"
-          ]
-        },
         "last_name": {
           "type": [
             "null",
             "string"
           ]
         },
+        "last_charge_attempt_date": {
+          "type": [
+            "null",
+            "string"
+          ],
+          "format": "date-time"
+        },
         "line_items": {
           "type": [
             "null",
             "array"
+          ]
+        },
+        "has_uncommited_changes": {
+          "type": [
+            "null",
+            "boolean"
           ]
         },
         "note": {
@@ -396,11 +420,11 @@
           ]
         },
         "processed_at": {
-          "format": "date-time",
           "type": [
             "null",
             "string"
-          ]
+          ],
+          "format": "date-time"
         },
         "processor_name": {
           "type": [
@@ -409,11 +433,11 @@
           ]
         },
         "retry_date": {
-          "format": "date-time",
           "type": [
             "null",
             "string"
-          ]
+          ],
+          "format": "date-time"
         },
         "scheduled_at": {
           "type": [
@@ -428,7 +452,17 @@
           ]
         },
         "shipping_address": {
+          "type": [
+            "null",
+            "object"
+          ],
           "properties": {
+            "id": {
+              "type": [
+                "null",
+                "integer"
+              ]
+            },
             "address1": {
               "type": [
                 "null",
@@ -465,18 +499,18 @@
                 "string"
               ]
             },
-            "created_at": {
-              "format": "date-time",
-              "type": [
-                "null",
-                "string"
-              ]
-            },
             "customer_id": {
               "type": [
                 "null",
                 "integer"
               ]
+            },
+            "created_at": {
+              "type": [
+                "null",
+                "string"
+              ],
+              "format": "date-time"
             },
             "discount_id": {
               "type": [
@@ -488,12 +522,6 @@
               "type": [
                 "null",
                 "string"
-              ]
-            },
-            "id": {
-              "type": [
-                "null",
-                "integer"
               ]
             },
             "last_name": {
@@ -527,11 +555,11 @@
               ]
             },
             "updated_at": {
-              "format": "date-time",
               "type": [
                 "null",
                 "string"
-              ]
+              ],
+              "format": "date-time"
             },
             "zip": {
               "type": [
@@ -539,20 +567,16 @@
                 "string"
               ]
             }
-          },
-          "type": [
-            "null",
-            "object"
-          ]
+          }
         },
         "shipping_lines": {
-          "items": {
-            "type": "object"
-          },
           "type": [
             "null",
             "array"
-          ]
+          ],
+          "items": {
+            "type": "object"
+          }
         },
         "shopify_order_id": {
           "type": [
@@ -639,35 +663,14 @@
           ]
         },
         "updated_at": {
-          "format": "date-time",
           "type": [
             "null",
             "string"
-          ]
-        }
-      },
-      "required": [
-        "id"
-      ],
-      "type": "object"
-    },
-    "key": [
-      "/id"
-    ],
-    "recommendedName": "charges",
-    "resourceConfig": {
-      "cursorField": [
-        "updated_at"
-      ],
-      "stream": "charges",
-      "syncMode": "incremental"
-    }
-  },
-  {
-    "documentSchema": {
-      "$schema": "http://json-schema.org/draft-07/schema#",
-      "properties": {
+          ],
+          "format": "date-time"
+        },
         "_meta": {
+          "type": "object",
           "properties": {
             "row_id": {
               "type": "integer"
@@ -675,16 +678,50 @@
           },
           "required": [
             "row_id"
-          ],
-          "type": "object"
-        },
-        "created_at": {
-          "format": "date-time",
-          "type": [
-            "null",
-            "string"
           ]
-        },
+        }
+      },
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
+    },
+    "key": [
+      "/id"
+    ]
+  },
+  {
+    "recommendedName": "collections",
+    "resourceConfig": {
+      "stream": "collections",
+      "syncMode": "full_refresh"
+    },
+    "documentSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "required": [
+        "id"
+      ],
+      "properties": {
         "id": {
           "type": [
             "integer"
@@ -696,33 +733,22 @@
             "string"
           ]
         },
-        "updated_at": {
-          "format": "date-time",
+        "created_at": {
           "type": [
             "null",
             "string"
-          ]
-        }
-      },
-      "required": [
-        "id"
-      ],
-      "type": "object"
-    },
-    "key": [
-      "/id"
-    ],
-    "recommendedName": "collections",
-    "resourceConfig": {
-      "stream": "collections",
-      "syncMode": "full_refresh"
-    }
-  },
-  {
-    "documentSchema": {
-      "$schema": "http://json-schema.org/draft-07/schema#",
-      "properties": {
+          ],
+          "format": "date-time"
+        },
+        "updated_at": {
+          "type": [
+            "null",
+            "string"
+          ],
+          "format": "date-time"
+        },
         "_meta": {
+          "type": "object",
           "properties": {
             "row_id": {
               "type": "integer"
@@ -730,8 +756,57 @@
           },
           "required": [
             "row_id"
-          ],
-          "type": "object"
+          ]
+        }
+      },
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
+    },
+    "key": [
+      "/id"
+    ]
+  },
+  {
+    "recommendedName": "customers",
+    "resourceConfig": {
+      "stream": "customers",
+      "syncMode": "incremental",
+      "cursorField": [
+        "updated_at"
+      ]
+    },
+    "documentSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "required": [
+        "id"
+      ],
+      "properties": {
+        "id": {
+          "type": [
+            "integer"
+          ]
         },
         "accepts_marketing": {
           "type": [
@@ -743,12 +818,6 @@
           "type": [
             "null",
             "object"
-          ]
-        },
-        "apply_credit_to_next_recurring_charge": {
-          "type": [
-            "null",
-            "boolean"
           ]
         },
         "billing_address1": {
@@ -812,11 +881,11 @@
           ]
         },
         "created_at": {
-          "format": "date-time",
           "type": [
             "null",
             "string"
-          ]
+          ],
+          "format": "date-time"
         },
         "email": {
           "type": [
@@ -825,11 +894,11 @@
           ]
         },
         "first_charge_processed_at": {
-          "format": "date-time",
           "type": [
             "null",
             "string"
-          ]
+          ],
+          "format": "date-time"
         },
         "first_name": {
           "type": [
@@ -853,11 +922,6 @@
           "type": [
             "null",
             "string"
-          ]
-        },
-        "id": {
-          "type": [
-            "integer"
           ]
         },
         "last_name": {
@@ -909,35 +973,20 @@
           ]
         },
         "updated_at": {
-          "format": "date-time",
           "type": [
             "null",
             "string"
+          ],
+          "format": "date-time"
+        },
+        "apply_credit_to_next_recurring_charge": {
+          "type": [
+            "null",
+            "boolean"
           ]
-        }
-      },
-      "required": [
-        "id"
-      ],
-      "type": "object"
-    },
-    "key": [
-      "/id"
-    ],
-    "recommendedName": "customers",
-    "resourceConfig": {
-      "cursorField": [
-        "updated_at"
-      ],
-      "stream": "customers",
-      "syncMode": "incremental"
-    }
-  },
-  {
-    "documentSchema": {
-      "$schema": "http://json-schema.org/draft-07/schema#",
-      "properties": {
+        },
         "_meta": {
+          "type": "object",
           "properties": {
             "row_id": {
               "type": "integer"
@@ -945,8 +994,57 @@
           },
           "required": [
             "row_id"
-          ],
-          "type": "object"
+          ]
+        }
+      },
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
+    },
+    "key": [
+      "/id"
+    ]
+  },
+  {
+    "recommendedName": "discounts",
+    "resourceConfig": {
+      "stream": "discounts",
+      "syncMode": "incremental",
+      "cursorField": [
+        "updated_at"
+      ]
+    },
+    "documentSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "required": [
+        "id"
+      ],
+      "properties": {
+        "id": {
+          "type": [
+            "integer"
+          ]
         },
         "applies_to": {
           "type": [
@@ -973,44 +1071,44 @@
           ]
         },
         "channel_settings": {
-          "properties": {
-            "api": {
-              "properties": {
-                "can_apply": {
-                  "type": "boolean"
-                }
-              },
-              "type": "object"
-            },
-            "checkout_page": {
-              "properties": {
-                "can_apply": {
-                  "type": "boolean"
-                }
-              },
-              "type": "object"
-            },
-            "customer_portal": {
-              "properties": {
-                "can_apply": {
-                  "type": "boolean"
-                }
-              },
-              "type": "object"
-            },
-            "merchant_portal": {
-              "properties": {
-                "can_apply": {
-                  "type": "boolean"
-                }
-              },
-              "type": "object"
-            }
-          },
           "type": [
             "null",
             "object"
-          ]
+          ],
+          "properties": {
+            "api": {
+              "type": "object",
+              "properties": {
+                "can_apply": {
+                  "type": "boolean"
+                }
+              }
+            },
+            "checkout_page": {
+              "type": "object",
+              "properties": {
+                "can_apply": {
+                  "type": "boolean"
+                }
+              }
+            },
+            "customer_portal": {
+              "type": "object",
+              "properties": {
+                "can_apply": {
+                  "type": "boolean"
+                }
+              }
+            },
+            "merchant_portal": {
+              "type": "object",
+              "properties": {
+                "can_apply": {
+                  "type": "boolean"
+                }
+              }
+            }
+          }
         },
         "code": {
           "type": [
@@ -1019,11 +1117,11 @@
           ]
         },
         "created_at": {
-          "format": "date-time",
           "type": [
             "null",
             "string"
-          ]
+          ],
+          "format": "date-time"
         },
         "discount_type": {
           "type": [
@@ -1044,11 +1142,11 @@
           ]
         },
         "ends_at": {
-          "format": "date-time",
           "type": [
             "null",
             "string"
-          ]
+          ],
+          "format": "date-time"
         },
         "external_discount_id": {
           "type": [
@@ -1068,11 +1166,6 @@
             "string"
           ]
         },
-        "id": {
-          "type": [
-            "integer"
-          ]
-        },
         "once_per_customer": {
           "type": [
             "null",
@@ -1086,11 +1179,11 @@
           ]
         },
         "starts_at": {
-          "format": "date-time",
           "type": [
             "null",
             "string"
-          ]
+          ],
+          "format": "date-time"
         },
         "status": {
           "type": [
@@ -1105,11 +1198,11 @@
           ]
         },
         "updated_at": {
-          "format": "date-time",
           "type": [
             "null",
             "string"
-          ]
+          ],
+          "format": "date-time"
         },
         "usage_limit": {
           "type": [
@@ -1122,30 +1215,9 @@
             "null",
             "number"
           ]
-        }
-      },
-      "required": [
-        "id"
-      ],
-      "type": "object"
-    },
-    "key": [
-      "/id"
-    ],
-    "recommendedName": "discounts",
-    "resourceConfig": {
-      "cursorField": [
-        "updated_at"
-      ],
-      "stream": "discounts",
-      "syncMode": "incremental"
-    }
-  },
-  {
-    "documentSchema": {
-      "$schema": "http://json-schema.org/draft-07/schema#",
-      "properties": {
+        },
         "_meta": {
+          "type": "object",
           "properties": {
             "row_id": {
               "type": "integer"
@@ -1153,25 +1225,66 @@
           },
           "required": [
             "row_id"
-          ],
-          "type": "object"
+          ]
+        }
+      },
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
+    },
+    "key": [
+      "/id"
+    ]
+  },
+  {
+    "recommendedName": "metafields",
+    "resourceConfig": {
+      "stream": "metafields",
+      "syncMode": "full_refresh"
+    },
+    "documentSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "required": [
+        "id"
+      ],
+      "properties": {
+        "id": {
+          "type": [
+            "integer"
+          ]
         },
         "created_at": {
-          "format": "date-time",
           "type": [
             "null",
             "string"
-          ]
+          ],
+          "format": "date-time"
         },
         "description": {
           "type": [
             "null",
             "string"
-          ]
-        },
-        "id": {
-          "type": [
-            "integer"
           ]
         },
         "key": {
@@ -1199,11 +1312,11 @@
           ]
         },
         "updated_at": {
-          "format": "date-time",
           "type": [
             "null",
             "string"
-          ]
+          ],
+          "format": "date-time"
         },
         "value": {
           "type": [
@@ -1216,27 +1329,9 @@
             "null",
             "string"
           ]
-        }
-      },
-      "required": [
-        "id"
-      ],
-      "type": "object"
-    },
-    "key": [
-      "/id"
-    ],
-    "recommendedName": "metafields",
-    "resourceConfig": {
-      "stream": "metafields",
-      "syncMode": "full_refresh"
-    }
-  },
-  {
-    "documentSchema": {
-      "$schema": "http://json-schema.org/draft-07/schema#",
-      "properties": {
+        },
         "_meta": {
+          "type": "object",
           "properties": {
             "row_id": {
               "type": "integer"
@@ -1244,8 +1339,57 @@
           },
           "required": [
             "row_id"
-          ],
-          "type": "object"
+          ]
+        }
+      },
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
+    },
+    "key": [
+      "/id"
+    ]
+  },
+  {
+    "recommendedName": "onetimes",
+    "resourceConfig": {
+      "stream": "onetimes",
+      "syncMode": "incremental",
+      "cursorField": [
+        "updated_at"
+      ]
+    },
+    "documentSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "required": [
+        "id"
+      ],
+      "properties": {
+        "id": {
+          "type": [
+            "integer"
+          ]
         },
         "address_id": {
           "type": [
@@ -1254,21 +1398,16 @@
           ]
         },
         "created_at": {
-          "format": "date-time",
           "type": [
             "null",
             "string"
-          ]
+          ],
+          "format": "date-time"
         },
         "customer_id": {
           "type": [
             "null",
             "string"
-          ]
-        },
-        "id": {
-          "type": [
-            "integer"
           ]
         },
         "next_charge_scheduled_at": {
@@ -1332,41 +1471,20 @@
           ]
         },
         "updated_at": {
-          "format": "date-time",
           "type": [
             "null",
             "string"
-          ]
+          ],
+          "format": "date-time"
         },
         "variant_title": {
           "type": [
             "null",
             "string"
           ]
-        }
-      },
-      "required": [
-        "id"
-      ],
-      "type": "object"
-    },
-    "key": [
-      "/id"
-    ],
-    "recommendedName": "onetimes",
-    "resourceConfig": {
-      "cursorField": [
-        "updated_at"
-      ],
-      "stream": "onetimes",
-      "syncMode": "incremental"
-    }
-  },
-  {
-    "documentSchema": {
-      "$schema": "http://json-schema.org/draft-07/schema#",
-      "properties": {
+        },
         "_meta": {
+          "type": "object",
           "properties": {
             "row_id": {
               "type": "integer"
@@ -1374,8 +1492,57 @@
           },
           "required": [
             "row_id"
-          ],
-          "type": "object"
+          ]
+        }
+      },
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
+    },
+    "key": [
+      "/id"
+    ]
+  },
+  {
+    "recommendedName": "orders",
+    "resourceConfig": {
+      "stream": "orders",
+      "syncMode": "incremental",
+      "cursorField": [
+        "updated_at"
+      ]
+    },
+    "documentSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "required": [
+        "id"
+      ],
+      "properties": {
+        "id": {
+          "type": [
+            "integer"
+          ]
         },
         "address_id": {
           "type": [
@@ -1390,7 +1557,17 @@
           ]
         },
         "billing_address": {
+          "type": [
+            "null",
+            "object"
+          ],
           "properties": {
+            "id": {
+              "type": [
+                "null",
+                "integer"
+              ]
+            },
             "address1": {
               "type": [
                 "null",
@@ -1427,18 +1604,18 @@
                 "string"
               ]
             },
-            "created_at": {
-              "format": "date-time",
-              "type": [
-                "null",
-                "string"
-              ]
-            },
             "customer_id": {
               "type": [
                 "null",
                 "integer"
               ]
+            },
+            "created_at": {
+              "type": [
+                "null",
+                "string"
+              ],
+              "format": "date-time"
             },
             "discount_id": {
               "type": [
@@ -1450,12 +1627,6 @@
               "type": [
                 "null",
                 "string"
-              ]
-            },
-            "id": {
-              "type": [
-                "null",
-                "integer"
               ]
             },
             "last_name": {
@@ -1489,11 +1660,11 @@
               ]
             },
             "updated_at": {
-              "format": "date-time",
               "type": [
                 "null",
                 "string"
-              ]
+              ],
+              "format": "date-time"
             },
             "zip": {
               "type": [
@@ -1501,11 +1672,7 @@
                 "string"
               ]
             }
-          },
-          "type": [
-            "null",
-            "object"
-          ]
+          }
         },
         "browser_ip": {
           "type": [
@@ -1514,9 +1681,23 @@
           ]
         },
         "charge": {
+          "type": [
+            "null",
+            "object"
+          ],
           "additionalProperties": true,
           "properties": {
+            "id": {
+              "type": [
+                "null",
+                "integer"
+              ]
+            },
             "external_transaction_id": {
+              "type": [
+                "null",
+                "object"
+              ],
               "additionalProperties": true,
               "properties": {
                 "payment_processor": {
@@ -1525,17 +1706,7 @@
                     "string"
                   ]
                 }
-              },
-              "type": [
-                "null",
-                "object"
-              ]
-            },
-            "id": {
-              "type": [
-                "null",
-                "integer"
-              ]
+              }
             },
             "payment_processor_name": {
               "type": [
@@ -1549,25 +1720,13 @@
                 "string"
               ]
             }
-          },
+          }
+        },
+        "client_details": {
           "type": [
             "null",
             "object"
-          ]
-        },
-        "charge_id": {
-          "type": [
-            "null",
-            "integer"
-          ]
-        },
-        "charge_status": {
-          "type": [
-            "null",
-            "string"
-          ]
-        },
-        "client_details": {
+          ],
           "additionalProperties": true,
           "properties": {
             "browser_ip": {
@@ -1582,14 +1741,114 @@
                 "string"
               ]
             }
-          },
+          }
+        },
+        "discounts": {
+          "type": [
+            "null",
+            "array"
+          ],
+          "items": {
+            "type": [
+              "null",
+              "string"
+            ]
+          }
+        },
+        "error": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "external_cart_token": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "external_order_id": {
           "type": [
             "null",
             "object"
+          ],
+          "additionalProperties": true,
+          "properties": {
+            "ecommerce": {
+              "type": [
+                "null",
+                "string"
+              ]
+            }
+          }
+        },
+        "external_order_name": {
+          "type": [
+            "null",
+            "object"
+          ],
+          "additionalProperties": true,
+          "properties": {
+            "ecommerce": {
+              "type": [
+                "null",
+                "string"
+              ]
+            }
+          }
+        },
+        "external_order_number": {
+          "type": [
+            "null",
+            "object"
+          ],
+          "additionalProperties": true,
+          "properties": {
+            "ecommerce": {
+              "type": [
+                "null",
+                "string"
+              ]
+            }
+          }
+        },
+        "order_attributes": {
+          "type": [
+            "null",
+            "array"
+          ],
+          "items": {
+            "type": [
+              "null",
+              "string"
+            ]
+          }
+        },
+        "taxable": {
+          "type": [
+            "null",
+            "boolean"
           ]
         },
-        "created_at": {
-          "format": "date-time",
+        "total_duties": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "total_weight_grams": {
+          "type": [
+            "null",
+            "integer"
+          ]
+        },
+        "charge_id": {
+          "type": [
+            "null",
+            "integer"
+          ]
+        },
+        "charge_status": {
           "type": [
             "null",
             "string"
@@ -1601,8 +1860,25 @@
             "string"
           ]
         },
+        "created_at": {
+          "type": [
+            "null",
+            "string"
+          ],
+          "format": "date-time"
+        },
         "customer": {
+          "type": [
+            "null",
+            "object"
+          ],
           "properties": {
+            "id": {
+              "type": [
+                "null",
+                "integer"
+              ]
+            },
             "billing_address1": {
               "type": [
                 "null",
@@ -1664,11 +1940,11 @@
               ]
             },
             "created_at": {
-              "format": "date-time",
               "type": [
                 "null",
                 "string"
-              ]
+              ],
+              "format": "date-time"
             },
             "email": {
               "type": [
@@ -1677,11 +1953,11 @@
               ]
             },
             "first_charge_processed_at": {
-              "format": "date-time",
               "type": [
                 "null",
                 "string"
-              ]
+              ],
+              "format": "date-time"
             },
             "first_name": {
               "type": [
@@ -1705,12 +1981,6 @@
               "type": [
                 "null",
                 "string"
-              ]
-            },
-            "id": {
-              "type": [
-                "null",
-                "integer"
               ]
             },
             "last_name": {
@@ -1756,17 +2026,13 @@
               ]
             },
             "updated_at": {
-              "format": "date-time",
               "type": [
                 "null",
                 "string"
-              ]
+              ],
+              "format": "date-time"
             }
-          },
-          "type": [
-            "null",
-            "object"
-          ]
+          }
         },
         "customer_id": {
           "type": [
@@ -1780,79 +2046,10 @@
             "array"
           ]
         },
-        "discounts": {
-          "items": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "type": [
-            "null",
-            "array"
-          ]
-        },
         "email": {
           "type": [
             "null",
             "string"
-          ]
-        },
-        "error": {
-          "type": [
-            "null",
-            "string"
-          ]
-        },
-        "external_cart_token": {
-          "type": [
-            "null",
-            "string"
-          ]
-        },
-        "external_order_id": {
-          "additionalProperties": true,
-          "properties": {
-            "ecommerce": {
-              "type": [
-                "null",
-                "string"
-              ]
-            }
-          },
-          "type": [
-            "null",
-            "object"
-          ]
-        },
-        "external_order_name": {
-          "additionalProperties": true,
-          "properties": {
-            "ecommerce": {
-              "type": [
-                "null",
-                "string"
-              ]
-            }
-          },
-          "type": [
-            "null",
-            "object"
-          ]
-        },
-        "external_order_number": {
-          "additionalProperties": true,
-          "properties": {
-            "ecommerce": {
-              "type": [
-                "null",
-                "string"
-              ]
-            }
-          },
-          "type": [
-            "null",
-            "object"
           ]
         },
         "first_name": {
@@ -1865,11 +2062,6 @@
           "type": [
             "null",
             "string"
-          ]
-        },
-        "id": {
-          "type": [
-            "integer"
           ]
         },
         "is_prepaid": {
@@ -1885,7 +2077,12 @@
           ]
         },
         "line_items": {
+          "type": [
+            "null",
+            "array"
+          ],
           "items": {
+            "type": "object",
             "properties": {
               "external_inventory_policy": {
                 "type": [
@@ -1959,13 +2156,8 @@
                   "string"
                 ]
               }
-            },
-            "type": "object"
-          },
-          "type": [
-            "null",
-            "array"
-          ]
+            }
+          }
         },
         "note": {
           "type": [
@@ -1979,18 +2171,6 @@
             "array"
           ]
         },
-        "order_attributes": {
-          "items": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "type": [
-            "null",
-            "array"
-          ]
-        },
         "payment_processor": {
           "type": [
             "null",
@@ -1998,11 +2178,11 @@
           ]
         },
         "processed_at": {
-          "format": "date-time",
           "type": [
             "null",
             "string"
-          ]
+          ],
+          "format": "date-time"
         },
         "redacted": {
           "type": [
@@ -2011,21 +2191,31 @@
           ]
         },
         "scheduled_at": {
-          "format": "date-time",
           "type": [
             "null",
             "string"
-          ]
+          ],
+          "format": "date-time"
         },
         "shipped_date": {
-          "format": "date-time",
           "type": [
             "null",
             "string"
-          ]
+          ],
+          "format": "date-time"
         },
         "shipping_address": {
+          "type": [
+            "null",
+            "object"
+          ],
           "properties": {
+            "id": {
+              "type": [
+                "null",
+                "integer"
+              ]
+            },
             "address1": {
               "type": [
                 "null",
@@ -2062,18 +2252,18 @@
                 "string"
               ]
             },
-            "created_at": {
-              "format": "date-time",
-              "type": [
-                "null",
-                "string"
-              ]
-            },
             "customer_id": {
               "type": [
                 "null",
                 "integer"
               ]
+            },
+            "created_at": {
+              "type": [
+                "null",
+                "string"
+              ],
+              "format": "date-time"
             },
             "discount_id": {
               "type": [
@@ -2085,12 +2275,6 @@
               "type": [
                 "null",
                 "string"
-              ]
-            },
-            "id": {
-              "type": [
-                "null",
-                "integer"
               ]
             },
             "last_name": {
@@ -2124,11 +2308,11 @@
               ]
             },
             "updated_at": {
-              "format": "date-time",
               "type": [
                 "null",
                 "string"
-              ]
+              ],
+              "format": "date-time"
             },
             "zip": {
               "type": [
@@ -2136,11 +2320,7 @@
                 "string"
               ]
             }
-          },
-          "type": [
-            "null",
-            "object"
-          ]
+          }
         },
         "shipping_lines": {
           "type": [
@@ -2196,22 +2376,16 @@
             "array"
           ]
         },
-        "taxable": {
+        "transaction_id": {
           "type": [
             "null",
-            "boolean"
+            "string"
           ]
         },
         "total_discounts": {
           "type": [
             "null",
             "number"
-          ]
-        },
-        "total_duties": {
-          "type": [
-            "null",
-            "string"
           ]
         },
         "total_line_items_price": {
@@ -2244,18 +2418,6 @@
             "integer"
           ]
         },
-        "total_weight_grams": {
-          "type": [
-            "null",
-            "integer"
-          ]
-        },
-        "transaction_id": {
-          "type": [
-            "null",
-            "string"
-          ]
-        },
         "type": {
           "type": [
             "null",
@@ -2263,35 +2425,14 @@
           ]
         },
         "updated_at": {
-          "format": "date-time",
           "type": [
             "null",
             "string"
-          ]
-        }
-      },
-      "required": [
-        "id"
-      ],
-      "type": "object"
-    },
-    "key": [
-      "/id"
-    ],
-    "recommendedName": "orders",
-    "resourceConfig": {
-      "cursorField": [
-        "updated_at"
-      ],
-      "stream": "orders",
-      "syncMode": "incremental"
-    }
-  },
-  {
-    "documentSchema": {
-      "$schema": "http://json-schema.org/draft-07/schema#",
-      "properties": {
+          ],
+          "format": "date-time"
+        },
         "_meta": {
+          "type": "object",
           "properties": {
             "row_id": {
               "type": "integer"
@@ -2299,8 +2440,54 @@
           },
           "required": [
             "row_id"
-          ],
-          "type": "object"
+          ]
+        }
+      },
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
+    },
+    "key": [
+      "/id"
+    ]
+  },
+  {
+    "recommendedName": "products",
+    "resourceConfig": {
+      "stream": "products",
+      "syncMode": "full_refresh"
+    },
+    "documentSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "required": [
+        "id"
+      ],
+      "properties": {
+        "id": {
+          "type": [
+            "integer"
+          ]
         },
         "charge_interval_frequency": {
           "type": [
@@ -2315,11 +2502,11 @@
           ]
         },
         "created_at": {
-          "format": "date-time",
           "type": [
             "null",
             "string"
-          ]
+          ],
+          "format": "date-time"
         },
         "cutoff_day_of_month": {
           "type": [
@@ -2355,11 +2542,6 @@
           "type": [
             "null",
             "string"
-          ]
-        },
-        "id": {
-          "type": [
-            "integer"
           ]
         },
         "images": {
@@ -2423,32 +2605,14 @@
           ]
         },
         "updated_at": {
-          "format": "date-time",
           "type": [
             "null",
             "string"
-          ]
-        }
-      },
-      "required": [
-        "id"
-      ],
-      "type": "object"
-    },
-    "key": [
-      "/id"
-    ],
-    "recommendedName": "products",
-    "resourceConfig": {
-      "stream": "products",
-      "syncMode": "full_refresh"
-    }
-  },
-  {
-    "documentSchema": {
-      "$schema": "http://json-schema.org/draft-07/schema#",
-      "properties": {
+          ],
+          "format": "date-time"
+        },
         "_meta": {
+          "type": "object",
           "properties": {
             "row_id": {
               "type": "integer"
@@ -2456,8 +2620,52 @@
           },
           "required": [
             "row_id"
-          ],
-          "type": "object"
+          ]
+        }
+      },
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
+    },
+    "key": [
+      "/id"
+    ]
+  },
+  {
+    "recommendedName": "shop",
+    "resourceConfig": {
+      "stream": "shop",
+      "syncMode": "full_refresh"
+    },
+    "documentSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "required": [
+        "store_id"
+      ],
+      "properties": {
+        "store_id": {
+          "type": "integer"
         },
         "shop": {
           "type": [
@@ -2466,7 +2674,13 @@
           ]
         },
         "store": {
+          "type": [
+            "object"
+          ],
           "properties": {
+            "id": {
+              "type": "integer"
+            },
             "checkout_platform": {
               "type": [
                 "string",
@@ -2482,12 +2696,6 @@
             "currency": {
               "type": [
                 "string",
-                "null"
-              ]
-            },
-            "disabled_currencies_historical": {
-              "type": [
-                "array",
                 "null"
               ]
             },
@@ -2515,14 +2723,17 @@
                 "null"
               ]
             },
+            "disabled_currencies_historical": {
+              "type": [
+                "array",
+                "null"
+              ]
+            },
             "iana_timezone": {
               "type": [
                 "string",
                 "null"
               ]
-            },
-            "id": {
-              "type": "integer"
             },
             "my_shopify_domain": {
               "type": [
@@ -2560,34 +2771,10 @@
                 "null"
               ]
             }
-          },
-          "type": [
-            "object"
-          ]
+          }
         },
-        "store_id": {
-          "type": "integer"
-        }
-      },
-      "required": [
-        "store_id"
-      ],
-      "type": "object"
-    },
-    "key": [
-      "/store_id"
-    ],
-    "recommendedName": "shop",
-    "resourceConfig": {
-      "stream": "shop",
-      "syncMode": "full_refresh"
-    }
-  },
-  {
-    "documentSchema": {
-      "$schema": "http://json-schema.org/draft-07/schema#",
-      "properties": {
         "_meta": {
+          "type": "object",
           "properties": {
             "row_id": {
               "type": "integer"
@@ -2595,8 +2782,57 @@
           },
           "required": [
             "row_id"
-          ],
-          "type": "object"
+          ]
+        }
+      },
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
+    },
+    "key": [
+      "/store_id"
+    ]
+  },
+  {
+    "recommendedName": "subscriptions",
+    "resourceConfig": {
+      "stream": "subscriptions",
+      "syncMode": "incremental",
+      "cursorField": [
+        "updated_at"
+      ]
+    },
+    "documentSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "required": [
+        "id"
+      ],
+      "properties": {
+        "id": {
+          "type": [
+            "integer"
+          ]
         },
         "address_id": {
           "type": [
@@ -2623,11 +2859,11 @@
           ]
         },
         "cancelled_at": {
-          "format": "date-time",
           "type": [
             "null",
             "string"
-          ]
+          ],
+          "format": "date-time"
         },
         "charge_interval_frequency": {
           "type": [
@@ -2635,17 +2871,17 @@
             "string"
           ]
         },
+        "created_at": {
+          "type": [
+            "null",
+            "string"
+          ],
+          "format": "date-time"
+        },
         "commit_update": {
           "type": [
             "null",
             "boolean"
-          ]
-        },
-        "created_at": {
-          "format": "date-time",
-          "type": [
-            "null",
-            "string"
           ]
         },
         "customer_id": {
@@ -2669,11 +2905,6 @@
         "has_queued_charges": {
           "type": [
             "null",
-            "integer"
-          ]
-        },
-        "id": {
-          "type": [
             "integer"
           ]
         },
@@ -2744,7 +2975,12 @@
           ]
         },
         "properties": {
+          "type": [
+            "null",
+            "array"
+          ],
           "items": {
+            "type": "object",
             "properties": {
               "name": {
                 "type": "string"
@@ -2755,13 +2991,8 @@
                   "string"
                 ]
               }
-            },
-            "type": "object"
-          },
-          "type": [
-            "null",
-            "array"
-          ]
+            }
+          }
         },
         "quantity": {
           "type": [
@@ -2806,34 +3037,56 @@
           ]
         },
         "updated_at": {
-          "format": "date-time",
           "type": [
             "null",
             "string"
-          ]
+          ],
+          "format": "date-time"
         },
         "variant_title": {
           "type": [
             "null",
             "string"
           ]
+        },
+        "_meta": {
+          "type": "object",
+          "properties": {
+            "row_id": {
+              "type": "integer"
+            }
+          },
+          "required": [
+            "row_id"
+          ]
         }
       },
-      "required": [
-        "id"
-      ],
-      "type": "object"
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
-    ],
-    "recommendedName": "subscriptions",
-    "resourceConfig": {
-      "cursorField": [
-        "updated_at"
-      ],
-      "stream": "subscriptions",
-      "syncMode": "incremental"
-    }
+    ]
   }
 ]

--- a/source-salesforce-native/tests/snapshots/snapshots__discover__capture.stdout.json
+++ b/source-salesforce-native/tests/snapshots/snapshots__discover__capture.stdout.json
@@ -49,8 +49,33 @@
       "title": "SalesforceResource",
       "type": "object",
       "x-infer-schema": true,
-      "reduce": {
-        "strategy": "merge"
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      },
+      "else": {
+        "reduce": {
+          "strategy": "merge"
+        }
       }
     },
     "key": [
@@ -107,8 +132,33 @@
       "title": "SalesforceResource",
       "type": "object",
       "x-infer-schema": true,
-      "reduce": {
-        "strategy": "merge"
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      },
+      "else": {
+        "reduce": {
+          "strategy": "merge"
+        }
       }
     },
     "key": [
@@ -165,8 +215,33 @@
       "title": "SalesforceResource",
       "type": "object",
       "x-infer-schema": true,
-      "reduce": {
-        "strategy": "merge"
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      },
+      "else": {
+        "reduce": {
+          "strategy": "merge"
+        }
       }
     },
     "key": [
@@ -223,8 +298,33 @@
       "title": "SalesforceResource",
       "type": "object",
       "x-infer-schema": true,
-      "reduce": {
-        "strategy": "merge"
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      },
+      "else": {
+        "reduce": {
+          "strategy": "merge"
+        }
       }
     },
     "key": [
@@ -281,8 +381,33 @@
       "title": "SalesforceResource",
       "type": "object",
       "x-infer-schema": true,
-      "reduce": {
-        "strategy": "merge"
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      },
+      "else": {
+        "reduce": {
+          "strategy": "merge"
+        }
       }
     },
     "key": [
@@ -339,8 +464,33 @@
       "title": "SalesforceResource",
       "type": "object",
       "x-infer-schema": true,
-      "reduce": {
-        "strategy": "merge"
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      },
+      "else": {
+        "reduce": {
+          "strategy": "merge"
+        }
       }
     },
     "key": [
@@ -397,8 +547,33 @@
       "title": "SalesforceResource",
       "type": "object",
       "x-infer-schema": true,
-      "reduce": {
-        "strategy": "merge"
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      },
+      "else": {
+        "reduce": {
+          "strategy": "merge"
+        }
       }
     },
     "key": [
@@ -455,8 +630,33 @@
       "title": "SalesforceResource",
       "type": "object",
       "x-infer-schema": true,
-      "reduce": {
-        "strategy": "merge"
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      },
+      "else": {
+        "reduce": {
+          "strategy": "merge"
+        }
       }
     },
     "key": [
@@ -513,8 +713,33 @@
       "title": "SalesforceResource",
       "type": "object",
       "x-infer-schema": true,
-      "reduce": {
-        "strategy": "merge"
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      },
+      "else": {
+        "reduce": {
+          "strategy": "merge"
+        }
       }
     },
     "key": [
@@ -571,8 +796,33 @@
       "title": "SalesforceResource",
       "type": "object",
       "x-infer-schema": true,
-      "reduce": {
-        "strategy": "merge"
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      },
+      "else": {
+        "reduce": {
+          "strategy": "merge"
+        }
       }
     },
     "key": [
@@ -629,8 +879,33 @@
       "title": "SalesforceResource",
       "type": "object",
       "x-infer-schema": true,
-      "reduce": {
-        "strategy": "merge"
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      },
+      "else": {
+        "reduce": {
+          "strategy": "merge"
+        }
       }
     },
     "key": [
@@ -687,8 +962,33 @@
       "title": "SalesforceResource",
       "type": "object",
       "x-infer-schema": true,
-      "reduce": {
-        "strategy": "merge"
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      },
+      "else": {
+        "reduce": {
+          "strategy": "merge"
+        }
       }
     },
     "key": [
@@ -745,8 +1045,33 @@
       "title": "SalesforceResource",
       "type": "object",
       "x-infer-schema": true,
-      "reduce": {
-        "strategy": "merge"
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      },
+      "else": {
+        "reduce": {
+          "strategy": "merge"
+        }
       }
     },
     "key": [
@@ -803,8 +1128,33 @@
       "title": "SalesforceResource",
       "type": "object",
       "x-infer-schema": true,
-      "reduce": {
-        "strategy": "merge"
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      },
+      "else": {
+        "reduce": {
+          "strategy": "merge"
+        }
       }
     },
     "key": [
@@ -861,8 +1211,33 @@
       "title": "SalesforceResource",
       "type": "object",
       "x-infer-schema": true,
-      "reduce": {
-        "strategy": "merge"
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      },
+      "else": {
+        "reduce": {
+          "strategy": "merge"
+        }
       }
     },
     "key": [

--- a/source-sentry/tests/snapshots/snapshots__discover__stdout.json
+++ b/source-sentry/tests/snapshots/snapshots__discover__stdout.json
@@ -40,7 +40,30 @@
       },
       "title": "Environment",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/_meta/row_id"
@@ -100,7 +123,30 @@
       ],
       "title": "Issue",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
@@ -165,7 +211,30 @@
       ],
       "title": "Project",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/_meta/row_id"
@@ -212,7 +281,30 @@
       },
       "title": "Release",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/_meta/row_id"
@@ -269,7 +361,30 @@
       ],
       "title": "Team",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/_meta/row_id"

--- a/source-shopify-native/tests/snapshots/snapshots__discover__capture.stdout.json
+++ b/source-shopify-native/tests/snapshots/snapshots__discover__capture.stdout.json
@@ -53,7 +53,30 @@
       ],
       "title": "ShopifyGraphQLResource",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/_meta/store",
@@ -114,7 +137,30 @@
       ],
       "title": "ShopifyGraphQLResource",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/_meta/store",
@@ -175,7 +221,30 @@
       ],
       "title": "ShopifyGraphQLResource",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/_meta/store",
@@ -236,7 +305,30 @@
       ],
       "title": "ShopifyGraphQLResource",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/_meta/store",
@@ -297,7 +389,30 @@
       ],
       "title": "ShopifyGraphQLResource",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/_meta/store",
@@ -358,7 +473,30 @@
       ],
       "title": "ShopifyGraphQLResource",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/_meta/store",
@@ -419,7 +557,30 @@
       ],
       "title": "ShopifyGraphQLResource",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/_meta/store",
@@ -480,7 +641,30 @@
       ],
       "title": "ShopifyGraphQLResource",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/_meta/store",
@@ -541,7 +725,30 @@
       ],
       "title": "ShopifyGraphQLResource",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/_meta/store",
@@ -602,7 +809,30 @@
       ],
       "title": "ShopifyGraphQLResource",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/_meta/store",
@@ -663,7 +893,30 @@
       ],
       "title": "ShopifyGraphQLResource",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/_meta/store",
@@ -724,7 +977,30 @@
       ],
       "title": "ShopifyGraphQLResource",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/_meta/store",
@@ -785,7 +1061,30 @@
       ],
       "title": "ShopifyGraphQLResource",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/_meta/store",
@@ -846,7 +1145,30 @@
       ],
       "title": "ShopifyGraphQLResource",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/_meta/store",
@@ -907,7 +1229,30 @@
       ],
       "title": "ShopifyGraphQLResource",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/_meta/store",
@@ -968,7 +1313,30 @@
       ],
       "title": "ShopifyGraphQLResource",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/_meta/store",
@@ -1029,7 +1397,30 @@
       ],
       "title": "ShopifyGraphQLResource",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/_meta/store",
@@ -1090,7 +1481,30 @@
       ],
       "title": "ShopifyGraphQLResource",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/_meta/store",
@@ -1151,7 +1565,30 @@
       ],
       "title": "ShopifyGraphQLResource",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/_meta/store",
@@ -1212,7 +1649,30 @@
       ],
       "title": "ShopifyGraphQLResource",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/_meta/store",
@@ -1273,7 +1733,30 @@
       ],
       "title": "ShopifyGraphQLResource",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/_meta/store",
@@ -1334,7 +1817,30 @@
       ],
       "title": "ShopifyGraphQLResource",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/_meta/store",
@@ -1395,7 +1901,30 @@
       ],
       "title": "ShopifyGraphQLResource",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/_meta/store",
@@ -1456,7 +1985,30 @@
       ],
       "title": "ShopifyGraphQLResource",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/_meta/store",

--- a/source-stripe-native/tests/snapshots/snapshots__discover__stdout.json
+++ b/source-stripe-native/tests/snapshots/snapshots__discover__stdout.json
@@ -69,7 +69,30 @@
       ],
       "title": "Accounts",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
@@ -146,7 +169,30 @@
       ],
       "title": "ApplicationFees",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
@@ -219,7 +265,30 @@
       ],
       "title": "ApplicationFeesRefunds",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
@@ -297,7 +366,30 @@
       ],
       "title": "BalanceTransactions",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
@@ -370,7 +462,30 @@
       ],
       "title": "Bank_Accounts",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
@@ -443,7 +558,30 @@
       ],
       "title": "Cards",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
@@ -520,7 +658,30 @@
       ],
       "title": "Charges",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
@@ -597,7 +758,30 @@
       ],
       "title": "CheckoutSessions",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
@@ -670,7 +854,30 @@
       ],
       "title": "CheckoutSessionsLine",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
@@ -747,7 +954,30 @@
       ],
       "title": "Coupons",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
@@ -824,7 +1054,30 @@
       ],
       "title": "CreditNotes",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
@@ -897,7 +1150,30 @@
       ],
       "title": "CreditNotesLines",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
@@ -970,7 +1246,30 @@
       ],
       "title": "CustomerBalanceTransaction",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
@@ -1047,7 +1346,30 @@
       ],
       "title": "Customers",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
@@ -1124,7 +1446,30 @@
       ],
       "title": "Disputes",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
@@ -1201,7 +1546,30 @@
       ],
       "title": "EarlyFraudWarning",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
@@ -1278,7 +1646,30 @@
       ],
       "title": "Events",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
@@ -1351,7 +1742,30 @@
       ],
       "title": "ExternalAccountCards",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
@@ -1424,7 +1838,30 @@
       ],
       "title": "ExternalBankAccount",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
@@ -1502,7 +1939,30 @@
       ],
       "title": "Files",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
@@ -1580,7 +2040,30 @@
       ],
       "title": "FilesLink",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
@@ -1657,7 +2140,30 @@
       ],
       "title": "InvoiceItems",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
@@ -1730,7 +2236,30 @@
       ],
       "title": "InvoiceLineItems",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
@@ -1807,7 +2336,30 @@
       ],
       "title": "Invoices",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
@@ -1884,7 +2436,30 @@
       ],
       "title": "PaymentIntent",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
@@ -1957,7 +2532,30 @@
       ],
       "title": "PaymentMethods",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
@@ -2034,7 +2632,30 @@
       ],
       "title": "Payouts",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
@@ -2107,7 +2728,30 @@
       ],
       "title": "Persons",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
@@ -2184,7 +2828,30 @@
       ],
       "title": "Plans",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
@@ -2261,7 +2928,30 @@
       ],
       "title": "Products",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
@@ -2338,7 +3028,30 @@
       ],
       "title": "PromotionCode",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
@@ -2415,7 +3128,30 @@
       ],
       "title": "Refunds",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
@@ -2492,7 +3228,30 @@
       ],
       "title": "Reviews",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
@@ -2565,7 +3324,30 @@
       ],
       "title": "SetupAttempts",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
@@ -2642,7 +3424,30 @@
       ],
       "title": "SetupIntents",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
@@ -2754,7 +3559,30 @@
       ],
       "title": "SubscriptionItems",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
@@ -2831,7 +3659,30 @@
       ],
       "title": "SubscriptionsSchedule",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
@@ -2908,7 +3759,30 @@
       ],
       "title": "Subscriptions",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
@@ -2985,7 +3859,30 @@
       ],
       "title": "TopUps",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
@@ -3058,7 +3955,30 @@
       ],
       "title": "TransferReversals",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
@@ -3135,7 +4055,30 @@
       ],
       "title": "Transfers",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
@@ -3213,7 +4156,30 @@
       ],
       "title": "UsageRecords",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/subscription_item"

--- a/source-twilio/tests/snapshots/snapshots__discover__capture.stdout.json
+++ b/source-twilio/tests/snapshots/snapshots__discover__capture.stdout.json
@@ -2,6 +2,23 @@
   {
     "documentSchema": {
       "additionalProperties": true,
+      "if": {
+        "properties": {
+          "_meta": {
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            },
+            "required": [
+              "op"
+            ]
+          }
+        },
+        "required": [
+          "_meta"
+        ]
+      },
       "properties": {
         "_meta": {
           "properties": {
@@ -200,6 +217,12 @@
       "required": [
         "sid"
       ],
+      "then": {
+        "reduce": {
+          "delete": true,
+          "strategy": "merge"
+        }
+      },
       "type": "object"
     },
     "key": [
@@ -214,6 +237,23 @@
   {
     "documentSchema": {
       "additionalProperties": true,
+      "if": {
+        "properties": {
+          "_meta": {
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            },
+            "required": [
+              "op"
+            ]
+          }
+        },
+        "required": [
+          "_meta"
+        ]
+      },
       "properties": {
         "_meta": {
           "properties": {
@@ -325,6 +365,12 @@
       "required": [
         "sid"
       ],
+      "then": {
+        "reduce": {
+          "delete": true,
+          "strategy": "merge"
+        }
+      },
       "type": "object"
     },
     "key": [
@@ -339,6 +385,23 @@
   {
     "documentSchema": {
       "additionalProperties": true,
+      "if": {
+        "properties": {
+          "_meta": {
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            },
+            "required": [
+              "op"
+            ]
+          }
+        },
+        "required": [
+          "_meta"
+        ]
+      },
       "properties": {
         "_meta": {
           "properties": {
@@ -445,6 +508,12 @@
       "required": [
         "sid"
       ],
+      "then": {
+        "reduce": {
+          "delete": true,
+          "strategy": "merge"
+        }
+      },
       "type": "object"
     },
     "key": [
@@ -462,6 +531,23 @@
   {
     "documentSchema": {
       "additionalProperties": true,
+      "if": {
+        "properties": {
+          "_meta": {
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            },
+            "required": [
+              "op"
+            ]
+          }
+        },
+        "required": [
+          "_meta"
+        ]
+      },
       "properties": {
         "_meta": {
           "properties": {
@@ -603,6 +689,12 @@
       "required": [
         "sid"
       ],
+      "then": {
+        "reduce": {
+          "delete": true,
+          "strategy": "merge"
+        }
+      },
       "type": "object"
     },
     "key": [
@@ -617,6 +709,23 @@
   {
     "documentSchema": {
       "additionalProperties": true,
+      "if": {
+        "properties": {
+          "_meta": {
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            },
+            "required": [
+              "op"
+            ]
+          }
+        },
+        "required": [
+          "_meta"
+        ]
+      },
       "properties": {
         "_meta": {
           "properties": {
@@ -681,6 +790,12 @@
       "required": [
         "country"
       ],
+      "then": {
+        "reduce": {
+          "delete": true,
+          "strategy": "merge"
+        }
+      },
       "type": "object"
     },
     "key": [
@@ -695,6 +810,23 @@
   {
     "documentSchema": {
       "additionalProperties": true,
+      "if": {
+        "properties": {
+          "_meta": {
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            },
+            "required": [
+              "op"
+            ]
+          }
+        },
+        "required": [
+          "_meta"
+        ]
+      },
       "properties": {
         "_meta": {
           "properties": {
@@ -813,6 +945,12 @@
       "required": [
         "phone_number"
       ],
+      "then": {
+        "reduce": {
+          "delete": true,
+          "strategy": "merge"
+        }
+      },
       "type": "object"
     },
     "key": [
@@ -827,6 +965,23 @@
   {
     "documentSchema": {
       "additionalProperties": true,
+      "if": {
+        "properties": {
+          "_meta": {
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            },
+            "required": [
+              "op"
+            ]
+          }
+        },
+        "required": [
+          "_meta"
+        ]
+      },
       "properties": {
         "_meta": {
           "properties": {
@@ -945,6 +1100,12 @@
       "required": [
         "phone_number"
       ],
+      "then": {
+        "reduce": {
+          "delete": true,
+          "strategy": "merge"
+        }
+      },
       "type": "object"
     },
     "key": [
@@ -959,6 +1120,23 @@
   {
     "documentSchema": {
       "additionalProperties": true,
+      "if": {
+        "properties": {
+          "_meta": {
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            },
+            "required": [
+              "op"
+            ]
+          }
+        },
+        "required": [
+          "_meta"
+        ]
+      },
       "properties": {
         "_meta": {
           "properties": {
@@ -1077,6 +1255,12 @@
       "required": [
         "phone_number"
       ],
+      "then": {
+        "reduce": {
+          "delete": true,
+          "strategy": "merge"
+        }
+      },
       "type": "object"
     },
     "key": [
@@ -1091,6 +1275,23 @@
   {
     "documentSchema": {
       "additionalProperties": true,
+      "if": {
+        "properties": {
+          "_meta": {
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            },
+            "required": [
+              "op"
+            ]
+          }
+        },
+        "required": [
+          "_meta"
+        ]
+      },
       "properties": {
         "_meta": {
           "properties": {
@@ -1333,6 +1534,12 @@
       "required": [
         "sid"
       ],
+      "then": {
+        "reduce": {
+          "delete": true,
+          "strategy": "merge"
+        }
+      },
       "type": "object"
     },
     "key": [
@@ -1350,6 +1557,23 @@
   {
     "documentSchema": {
       "additionalProperties": true,
+      "if": {
+        "properties": {
+          "_meta": {
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            },
+            "required": [
+              "op"
+            ]
+          }
+        },
+        "required": [
+          "_meta"
+        ]
+      },
       "properties": {
         "_meta": {
           "properties": {
@@ -1447,6 +1671,12 @@
         "account_sid",
         "conference_sid"
       ],
+      "then": {
+        "reduce": {
+          "delete": true,
+          "strategy": "merge"
+        }
+      },
       "type": "object"
     },
     "key": [
@@ -1462,6 +1692,23 @@
   {
     "documentSchema": {
       "additionalProperties": true,
+      "if": {
+        "properties": {
+          "_meta": {
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            },
+            "required": [
+              "op"
+            ]
+          }
+        },
+        "required": [
+          "_meta"
+        ]
+      },
       "properties": {
         "_meta": {
           "properties": {
@@ -1564,6 +1811,12 @@
       "required": [
         "sid"
       ],
+      "then": {
+        "reduce": {
+          "delete": true,
+          "strategy": "merge"
+        }
+      },
       "type": "object"
     },
     "key": [
@@ -1581,6 +1834,23 @@
   {
     "documentSchema": {
       "additionalProperties": true,
+      "if": {
+        "properties": {
+          "_meta": {
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            },
+            "required": [
+              "op"
+            ]
+          }
+        },
+        "required": [
+          "_meta"
+        ]
+      },
       "properties": {
         "_meta": {
           "properties": {
@@ -1674,6 +1944,12 @@
       "required": [
         "sid"
       ],
+      "then": {
+        "reduce": {
+          "delete": true,
+          "strategy": "merge"
+        }
+      },
       "type": "object"
     },
     "key": [
@@ -1689,6 +1965,23 @@
     "documentSchema": {
       "$schema": "http://json-schema.org/draft-07/schema#",
       "additionalProperties": true,
+      "if": {
+        "properties": {
+          "_meta": {
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            },
+            "required": [
+              "op"
+            ]
+          }
+        },
+        "required": [
+          "_meta"
+        ]
+      },
       "properties": {
         "_meta": {
           "properties": {
@@ -1878,6 +2171,12 @@
       "required": [
         "sid"
       ],
+      "then": {
+        "reduce": {
+          "delete": true,
+          "strategy": "merge"
+        }
+      },
       "type": "object"
     },
     "key": [
@@ -1893,6 +2192,23 @@
     "documentSchema": {
       "$schema": "http://json-schema.org/draft-07/schema#",
       "additionalProperties": true,
+      "if": {
+        "properties": {
+          "_meta": {
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            },
+            "required": [
+              "op"
+            ]
+          }
+        },
+        "required": [
+          "_meta"
+        ]
+      },
       "properties": {
         "_meta": {
           "properties": {
@@ -2000,6 +2316,12 @@
       "required": [
         "sid"
       ],
+      "then": {
+        "reduce": {
+          "delete": true,
+          "strategy": "merge"
+        }
+      },
       "type": "object"
     },
     "key": [
@@ -2014,6 +2336,23 @@
   {
     "documentSchema": {
       "additionalProperties": true,
+      "if": {
+        "properties": {
+          "_meta": {
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            },
+            "required": [
+              "op"
+            ]
+          }
+        },
+        "required": [
+          "_meta"
+        ]
+      },
       "properties": {
         "_meta": {
           "properties": {
@@ -2206,6 +2545,12 @@
       "required": [
         "sid"
       ],
+      "then": {
+        "reduce": {
+          "delete": true,
+          "strategy": "merge"
+        }
+      },
       "type": "object"
     },
     "key": [
@@ -2221,6 +2566,23 @@
     "documentSchema": {
       "$schema": "http://json-schema.org/draft-07/schema#",
       "additionalProperties": true,
+      "if": {
+        "properties": {
+          "_meta": {
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            },
+            "required": [
+              "op"
+            ]
+          }
+        },
+        "required": [
+          "_meta"
+        ]
+      },
       "properties": {
         "_meta": {
           "properties": {
@@ -2303,6 +2665,12 @@
       "required": [
         "sid"
       ],
+      "then": {
+        "reduce": {
+          "delete": true,
+          "strategy": "merge"
+        }
+      },
       "type": "object"
     },
     "key": [
@@ -2318,6 +2686,23 @@
     "documentSchema": {
       "$schema": "http://json-schema.org/draft-07/schema#",
       "additionalProperties": true,
+      "if": {
+        "properties": {
+          "_meta": {
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            },
+            "required": [
+              "op"
+            ]
+          }
+        },
+        "required": [
+          "_meta"
+        ]
+      },
       "properties": {
         "_meta": {
           "properties": {
@@ -2415,6 +2800,12 @@
       "required": [
         "sid"
       ],
+      "then": {
+        "reduce": {
+          "delete": true,
+          "strategy": "merge"
+        }
+      },
       "title": "Executions",
       "type": "object"
     },
@@ -2430,6 +2821,23 @@
   {
     "documentSchema": {
       "additionalProperties": true,
+      "if": {
+        "properties": {
+          "_meta": {
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            },
+            "required": [
+              "op"
+            ]
+          }
+        },
+        "required": [
+          "_meta"
+        ]
+      },
       "properties": {
         "_meta": {
           "properties": {
@@ -2691,6 +3099,12 @@
       "required": [
         "sid"
       ],
+      "then": {
+        "reduce": {
+          "delete": true,
+          "strategy": "merge"
+        }
+      },
       "type": "object"
     },
     "key": [
@@ -2705,6 +3119,23 @@
   {
     "documentSchema": {
       "additionalProperties": true,
+      "if": {
+        "properties": {
+          "_meta": {
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            },
+            "required": [
+              "op"
+            ]
+          }
+        },
+        "required": [
+          "_meta"
+        ]
+      },
       "properties": {
         "_meta": {
           "properties": {
@@ -2744,6 +3175,12 @@
       "required": [
         "sid"
       ],
+      "then": {
+        "reduce": {
+          "delete": true,
+          "strategy": "merge"
+        }
+      },
       "type": "object"
     },
     "key": [
@@ -2758,6 +3195,23 @@
   {
     "documentSchema": {
       "additionalProperties": true,
+      "if": {
+        "properties": {
+          "_meta": {
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            },
+            "required": [
+              "op"
+            ]
+          }
+        },
+        "required": [
+          "_meta"
+        ]
+      },
       "properties": {
         "_meta": {
           "properties": {
@@ -2815,6 +3269,12 @@
       "required": [
         "sid"
       ],
+      "then": {
+        "reduce": {
+          "delete": true,
+          "strategy": "merge"
+        }
+      },
       "type": "object"
     },
     "key": [
@@ -2832,6 +3292,23 @@
   {
     "documentSchema": {
       "additionalProperties": true,
+      "if": {
+        "properties": {
+          "_meta": {
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            },
+            "required": [
+              "op"
+            ]
+          }
+        },
+        "required": [
+          "_meta"
+        ]
+      },
       "properties": {
         "_meta": {
           "properties": {
@@ -2983,6 +3460,12 @@
       "required": [
         "sid"
       ],
+      "then": {
+        "reduce": {
+          "delete": true,
+          "strategy": "merge"
+        }
+      },
       "type": "object"
     },
     "key": [
@@ -3000,6 +3483,23 @@
   {
     "documentSchema": {
       "additionalProperties": true,
+      "if": {
+        "properties": {
+          "_meta": {
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            },
+            "required": [
+              "op"
+            ]
+          }
+        },
+        "required": [
+          "_meta"
+        ]
+      },
       "properties": {
         "_meta": {
           "properties": {
@@ -3057,6 +3557,12 @@
       "required": [
         "sid"
       ],
+      "then": {
+        "reduce": {
+          "delete": true,
+          "strategy": "merge"
+        }
+      },
       "type": "object"
     },
     "key": [
@@ -3071,6 +3577,23 @@
   {
     "documentSchema": {
       "additionalProperties": true,
+      "if": {
+        "properties": {
+          "_meta": {
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            },
+            "required": [
+              "op"
+            ]
+          }
+        },
+        "required": [
+          "_meta"
+        ]
+      },
       "properties": {
         "_meta": {
           "properties": {
@@ -3155,6 +3678,12 @@
       "required": [
         "sid"
       ],
+      "then": {
+        "reduce": {
+          "delete": true,
+          "strategy": "merge"
+        }
+      },
       "type": "object"
     },
     "key": [
@@ -3169,6 +3698,23 @@
   {
     "documentSchema": {
       "additionalProperties": true,
+      "if": {
+        "properties": {
+          "_meta": {
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            },
+            "required": [
+              "op"
+            ]
+          }
+        },
+        "required": [
+          "_meta"
+        ]
+      },
       "properties": {
         "_meta": {
           "properties": {
@@ -3338,6 +3884,12 @@
       "required": [
         "sid"
       ],
+      "then": {
+        "reduce": {
+          "delete": true,
+          "strategy": "merge"
+        }
+      },
       "type": "object"
     },
     "key": [
@@ -3356,6 +3908,23 @@
     "documentSchema": {
       "$schema": "http://json-schema.org/draft-07/schema#",
       "additionalProperties": true,
+      "if": {
+        "properties": {
+          "_meta": {
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            },
+            "required": [
+              "op"
+            ]
+          }
+        },
+        "required": [
+          "_meta"
+        ]
+      },
       "properties": {
         "_meta": {
           "properties": {
@@ -3431,6 +4000,12 @@
       "required": [
         "sid"
       ],
+      "then": {
+        "reduce": {
+          "delete": true,
+          "strategy": "merge"
+        }
+      },
       "title": "Roles Schema",
       "type": "object"
     },
@@ -3447,6 +4022,23 @@
     "documentSchema": {
       "$schema": "http://json-schema.org/draft-07/schema#",
       "additionalProperties": true,
+      "if": {
+        "properties": {
+          "_meta": {
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            },
+            "required": [
+              "op"
+            ]
+          }
+        },
+        "required": [
+          "_meta"
+        ]
+      },
       "properties": {
         "_meta": {
           "properties": {
@@ -3668,6 +4260,12 @@
       "required": [
         "sid"
       ],
+      "then": {
+        "reduce": {
+          "delete": true,
+          "strategy": "merge"
+        }
+      },
       "title": "Services Schema",
       "type": "object"
     },
@@ -3684,6 +4282,23 @@
     "documentSchema": {
       "$schema": "http://json-schema.org/draft-07/schema#",
       "additionalProperties": true,
+      "if": {
+        "properties": {
+          "_meta": {
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            },
+            "required": [
+              "op"
+            ]
+          }
+        },
+        "required": [
+          "_meta"
+        ]
+      },
       "properties": {
         "_meta": {
           "properties": {
@@ -3783,6 +4398,12 @@
       "required": [
         "sid"
       ],
+      "then": {
+        "reduce": {
+          "delete": true,
+          "strategy": "merge"
+        }
+      },
       "title": "Step Schema",
       "type": "object"
     },
@@ -3798,6 +4419,23 @@
   {
     "documentSchema": {
       "additionalProperties": true,
+      "if": {
+        "properties": {
+          "_meta": {
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            },
+            "required": [
+              "op"
+            ]
+          }
+        },
+        "required": [
+          "_meta"
+        ]
+      },
       "properties": {
         "_meta": {
           "properties": {
@@ -3891,6 +4529,12 @@
       "required": [
         "sid"
       ],
+      "then": {
+        "reduce": {
+          "delete": true,
+          "strategy": "merge"
+        }
+      },
       "type": "object"
     },
     "key": [
@@ -3906,6 +4550,23 @@
     "documentSchema": {
       "$schema": "http://json-schema.org/draft-07/schema#",
       "additionalProperties": true,
+      "if": {
+        "properties": {
+          "_meta": {
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            },
+            "required": [
+              "op"
+            ]
+          }
+        },
+        "required": [
+          "_meta"
+        ]
+      },
       "properties": {
         "_meta": {
           "properties": {
@@ -4078,6 +4739,12 @@
       "required": [
         "sid"
       ],
+      "then": {
+        "reduce": {
+          "delete": true,
+          "strategy": "merge"
+        }
+      },
       "title": "Trunks Schema",
       "type": "object"
     },
@@ -4093,6 +4760,23 @@
   {
     "documentSchema": {
       "additionalProperties": true,
+      "if": {
+        "properties": {
+          "_meta": {
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            },
+            "required": [
+              "op"
+            ]
+          }
+        },
+        "required": [
+          "_meta"
+        ]
+      },
       "properties": {
         "_meta": {
           "properties": {
@@ -4247,6 +4931,12 @@
         "account_sid",
         "category"
       ],
+      "then": {
+        "reduce": {
+          "delete": true,
+          "strategy": "merge"
+        }
+      },
       "type": "object"
     },
     "key": [
@@ -4265,6 +4955,23 @@
   {
     "documentSchema": {
       "additionalProperties": true,
+      "if": {
+        "properties": {
+          "_meta": {
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            },
+            "required": [
+              "op"
+            ]
+          }
+        },
+        "required": [
+          "_meta"
+        ]
+      },
       "properties": {
         "_meta": {
           "properties": {
@@ -4377,6 +5084,12 @@
       "required": [
         "sid"
       ],
+      "then": {
+        "reduce": {
+          "delete": true,
+          "strategy": "merge"
+        }
+      },
       "type": "object"
     },
     "key": [
@@ -4392,6 +5105,23 @@
     "documentSchema": {
       "$schema": "http://json-schema.org/draft-07/schema#",
       "additionalProperties": true,
+      "if": {
+        "properties": {
+          "_meta": {
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            },
+            "required": [
+              "op"
+            ]
+          }
+        },
+        "required": [
+          "_meta"
+        ]
+      },
       "properties": {
         "_meta": {
           "properties": {
@@ -4491,6 +5221,12 @@
       "required": [
         "sid"
       ],
+      "then": {
+        "reduce": {
+          "delete": true,
+          "strategy": "merge"
+        }
+      },
       "title": "Users Schema",
       "type": "object"
     },
@@ -4507,6 +5243,23 @@
     "documentSchema": {
       "$schema": "http://json-schema.org/draft-07/schema#",
       "additionalProperties": true,
+      "if": {
+        "properties": {
+          "_meta": {
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            },
+            "required": [
+              "op"
+            ]
+          }
+        },
+        "required": [
+          "_meta"
+        ]
+      },
       "properties": {
         "_meta": {
           "properties": {
@@ -4650,6 +5403,12 @@
       "required": [
         "account_sid"
       ],
+      "then": {
+        "reduce": {
+          "delete": true,
+          "strategy": "merge"
+        }
+      },
       "title": "User Conversation Schema",
       "type": "object"
     },
@@ -4666,6 +5425,23 @@
     "documentSchema": {
       "$schema": "http://json-schema.org/draft-07/schema#",
       "additionalProperties": true,
+      "if": {
+        "properties": {
+          "_meta": {
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            },
+            "required": [
+              "op"
+            ]
+          }
+        },
+        "required": [
+          "_meta"
+        ]
+      },
       "properties": {
         "_meta": {
           "properties": {
@@ -4883,6 +5659,12 @@
       "required": [
         "sid"
       ],
+      "then": {
+        "reduce": {
+          "delete": true,
+          "strategy": "merge"
+        }
+      },
       "title": "Verify - Services Schema",
       "type": "object"
     },

--- a/source-zendesk-support-native/tests/snapshots/snapshots__discover__capture.stdout.json
+++ b/source-zendesk-support-native/tests/snapshots/snapshots__discover__capture.stdout.json
@@ -40,7 +40,30 @@
       },
       "title": "FullRefreshResource",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/_meta/row_id"
@@ -100,7 +123,30 @@
       ],
       "title": "TimestampedResource",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
@@ -160,7 +206,30 @@
       ],
       "title": "AuditLog",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
@@ -220,7 +289,30 @@
       ],
       "title": "TimestampedResource",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
@@ -280,7 +372,30 @@
       ],
       "title": "TimestampedResource",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
@@ -340,7 +455,30 @@
       ],
       "title": "TimestampedResource",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
@@ -400,7 +538,30 @@
       ],
       "title": "TimestampedResource",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
@@ -460,7 +621,30 @@
       ],
       "title": "TimestampedResource",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
@@ -520,7 +704,30 @@
       ],
       "title": "TimestampedResource",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
@@ -567,7 +774,30 @@
       },
       "title": "FullRefreshResource",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/_meta/row_id"
@@ -627,7 +857,30 @@
       ],
       "title": "TimestampedResource",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
@@ -687,7 +940,30 @@
       ],
       "title": "TimestampedResource",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
@@ -747,7 +1023,30 @@
       ],
       "title": "TimestampedResource",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
@@ -807,7 +1106,30 @@
       ],
       "title": "TimestampedResource",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
@@ -867,7 +1189,30 @@
       ],
       "title": "TimestampedResource",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
@@ -921,7 +1266,30 @@
       ],
       "title": "ZendeskResource",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
@@ -975,7 +1343,30 @@
       ],
       "title": "ZendeskResource",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
@@ -1029,7 +1420,30 @@
       ],
       "title": "ZendeskResource",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
@@ -1089,7 +1503,30 @@
       ],
       "title": "TimestampedResource",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
@@ -1143,7 +1580,30 @@
       ],
       "title": "ZendeskResource",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
@@ -1190,7 +1650,30 @@
       },
       "title": "FullRefreshResource",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/_meta/row_id"
@@ -1237,7 +1720,30 @@
       },
       "title": "FullRefreshResource",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/_meta/row_id"
@@ -1284,7 +1790,30 @@
       },
       "title": "FullRefreshResource",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/_meta/row_id"
@@ -1338,7 +1867,30 @@
       ],
       "title": "ZendeskResource",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
@@ -1392,7 +1944,30 @@
       ],
       "title": "ZendeskResource",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
@@ -1446,7 +2021,30 @@
       ],
       "title": "ZendeskResource",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
@@ -1506,7 +2104,30 @@
       ],
       "title": "TimestampedResource",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
@@ -1566,7 +2187,30 @@
       ],
       "title": "TimestampedResource",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
@@ -1620,7 +2264,30 @@
       ],
       "title": "ZendeskResource",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
@@ -1674,7 +2341,30 @@
       ],
       "title": "ZendeskResource",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
@@ -1728,7 +2418,30 @@
       ],
       "title": "ZendeskResource",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
@@ -1788,7 +2501,30 @@
       ],
       "title": "TimestampedResource",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
@@ -1848,7 +2584,30 @@
       ],
       "title": "TimestampedResource",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
@@ -1908,7 +2667,30 @@
       ],
       "title": "TimestampedResource",
       "type": "object",
-      "x-infer-schema": true
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"

--- a/source-zendesk-support/tests/snapshots/snapshots__discover__capture.stdout.json
+++ b/source-zendesk-support/tests/snapshots/snapshots__discover__capture.stdout.json
@@ -94,6 +94,29 @@
             "row_id"
           ]
         }
+      },
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
       }
     },
     "key": [
@@ -169,7 +192,30 @@
       ],
       "required": [
         "id"
-      ]
+      ],
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
@@ -237,6 +283,29 @@
           "required": [
             "row_id"
           ]
+        }
+      },
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
         }
       }
     },
@@ -377,7 +446,30 @@
       ],
       "required": [
         "id"
-      ]
+      ],
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
@@ -515,6 +607,29 @@
             "row_id"
           ]
         }
+      },
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
       }
     },
     "key": [
@@ -602,7 +717,30 @@
       ],
       "required": [
         "id"
-      ]
+      ],
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
@@ -698,6 +836,29 @@
           "required": [
             "row_id"
           ]
+        }
+      },
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
         }
       }
     },
@@ -810,6 +971,29 @@
             "row_id"
           ]
         }
+      },
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
       }
     },
     "key": [
@@ -890,6 +1074,29 @@
             "row_id"
           ]
         }
+      },
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
       }
     },
     "key": [
@@ -969,6 +1176,29 @@
           "required": [
             "row_id"
           ]
+        }
+      },
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
         }
       }
     },
@@ -1072,6 +1302,29 @@
           "required": [
             "row_id"
           ]
+        }
+      },
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
         }
       }
     },
@@ -1256,7 +1509,30 @@
       ],
       "required": [
         "id"
-      ]
+      ],
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
@@ -1295,6 +1571,29 @@
           "required": [
             "row_id"
           ]
+        }
+      },
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
         }
       }
     },
@@ -2302,6 +2601,29 @@
             "row_id"
           ]
         }
+      },
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
       }
     },
     "key": [
@@ -2828,7 +3150,30 @@
       ],
       "required": [
         "id"
-      ]
+      ],
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
@@ -3049,7 +3394,30 @@
       ],
       "required": [
         "id"
-      ]
+      ],
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
@@ -3370,7 +3738,30 @@
       ],
       "required": [
         "id"
-      ]
+      ],
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
@@ -3437,7 +3828,30 @@
       ],
       "required": [
         "id"
-      ]
+      ],
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
@@ -4073,7 +4487,30 @@
       ],
       "required": [
         "id"
-      ]
+      ],
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
@@ -4656,7 +5093,30 @@
       ],
       "required": [
         "id"
-      ]
+      ],
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
@@ -5062,6 +5522,29 @@
             "row_id"
           ]
         }
+      },
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
       }
     },
     "key": [
@@ -5187,6 +5670,29 @@
           "required": [
             "row_id"
           ]
+        }
+      },
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
         }
       }
     },
@@ -5490,6 +5996,29 @@
             "row_id"
           ]
         }
+      },
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
       }
     },
     "key": [
@@ -5575,6 +6104,29 @@
           "required": [
             "row_id"
           ]
+        }
+      },
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
         }
       }
     },
@@ -5711,7 +6263,30 @@
       ],
       "required": [
         "id"
-      ]
+      ],
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
     },
     "key": [
       "/id"
@@ -5770,6 +6345,29 @@
           "required": [
             "row_id"
           ]
+        }
+      },
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
         }
       }
     },
@@ -5902,6 +6500,29 @@
           "required": [
             "row_id"
           ]
+        }
+      },
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
         }
       }
     },

--- a/source-zoho/tests/snapshots/snapshots__discover__stdout.json
+++ b/source-zoho/tests/snapshots/snapshots__discover__stdout.json
@@ -55,8 +55,33 @@
       "title": "Accounts",
       "type": "object",
       "x-infer-schema": true,
-      "reduce": {
-        "strategy": "merge"
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      },
+      "else": {
+        "reduce": {
+          "strategy": "merge"
+        }
       }
     },
     "key": [
@@ -119,8 +144,33 @@
       "title": "Calls",
       "type": "object",
       "x-infer-schema": true,
-      "reduce": {
-        "strategy": "merge"
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      },
+      "else": {
+        "reduce": {
+          "strategy": "merge"
+        }
       }
     },
     "key": [
@@ -183,8 +233,33 @@
       "title": "Campaigns",
       "type": "object",
       "x-infer-schema": true,
-      "reduce": {
-        "strategy": "merge"
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      },
+      "else": {
+        "reduce": {
+          "strategy": "merge"
+        }
       }
     },
     "key": [
@@ -247,8 +322,33 @@
       "title": "Contacts",
       "type": "object",
       "x-infer-schema": true,
-      "reduce": {
-        "strategy": "merge"
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      },
+      "else": {
+        "reduce": {
+          "strategy": "merge"
+        }
       }
     },
     "key": [
@@ -311,8 +411,33 @@
       "title": "DealHistory",
       "type": "object",
       "x-infer-schema": true,
-      "reduce": {
-        "strategy": "merge"
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      },
+      "else": {
+        "reduce": {
+          "strategy": "merge"
+        }
       }
     },
     "key": [
@@ -375,8 +500,33 @@
       "title": "Deals",
       "type": "object",
       "x-infer-schema": true,
-      "reduce": {
-        "strategy": "merge"
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      },
+      "else": {
+        "reduce": {
+          "strategy": "merge"
+        }
       }
     },
     "key": [
@@ -439,8 +589,33 @@
       "title": "Events",
       "type": "object",
       "x-infer-schema": true,
-      "reduce": {
-        "strategy": "merge"
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      },
+      "else": {
+        "reduce": {
+          "strategy": "merge"
+        }
       }
     },
     "key": [
@@ -503,8 +678,33 @@
       "title": "File_Upload_1__s",
       "type": "object",
       "x-infer-schema": true,
-      "reduce": {
-        "strategy": "merge"
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      },
+      "else": {
+        "reduce": {
+          "strategy": "merge"
+        }
       }
     },
     "key": [
@@ -567,8 +767,33 @@
       "title": "Leads",
       "type": "object",
       "x-infer-schema": true,
-      "reduce": {
-        "strategy": "merge"
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      },
+      "else": {
+        "reduce": {
+          "strategy": "merge"
+        }
       }
     },
     "key": [
@@ -631,8 +856,33 @@
       "title": "Tasks",
       "type": "object",
       "x-infer-schema": true,
-      "reduce": {
-        "strategy": "merge"
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      },
+      "else": {
+        "reduce": {
+          "strategy": "merge"
+        }
       }
     },
     "key": [


### PR DESCRIPTION
**Description:**

Standard-mode materializations issue real `DELETE`s only when the collection schema marks `op="d"` docs to reduce as `merge + delete: true`, producing a tombstone the materialization translates to a `DELETE`, while letting other docs reduce normally. JSON Schema's if/then/else is how Flow expresses that per-document reduction switch on a single schema; the Go SQL framework already injects this block during discovery, but the Python CDK did not, so connectors emitting `_meta/op="d"` produced soft-delete markers instead of hard deletes.

This PR adds that if/then/else block to all discovered resources' schemas.

The changes to connectors' discover snapshots are expected due to the addition of the if/then/else to support hard deletes.

**Workflow steps:**

Dataflows that have a CDK-based capture that was previously emitting deletions (`_meta/op = "d"`) and a materialization with `hardDelete` set to `true` will begin using hard deletes instead of soft deletes.

Note: This change only affects dataflows that emit deletions, like many native connector's full refresh streams that take a snapshot of the entire data set in the source system. Dataflows where the capture side does not emit deletions are not affected.

**Notes for reviewers**

After this PR is merged into `main`, I'll open a PR for `source-netsuite-v2` that pulls in the latest CDK changes, including the if/then/else bit in discovered resource schemas added in this PR.

I confirmed via `flowctl raw combine` that the new if/then/else schema block correctly routes documents with `_meta.op == "d"` to the then branch and all other documents, including those missing `_meta` or `_meta/op`, to the else branch, with reductions applied as specified on each side.

