### PR TITLE
source-postgres: Add skip_prerequisites and skip_table_prerequisites

### DIFF
--- a/source-postgres/main.go
+++ b/source-postgres/main.go
@@ -225,6 +225,13 @@ var featureFlagDefaults = map[string]bool{
 	// This is the default, but advanced users could set `no_create_replication_slot` if they want
 	// to manage their replication slots manually instead.
 	"create_replication_slot": true,
+
+	// When true, all prerequisite checks (both global and per-table) are skipped. This is intended
+	// as an escape hatch for situations where the checks themselves are buggy or do not apply.
+	"skip_prerequisites": false,
+
+	// When true, per-table prerequisite checks are skipped. Implied by `skip_prerequisites`.
+	"skip_table_prerequisites": false,
 }
 
 // Validate checks that the configuration possesses all required properties.

--- a/source-postgres/prerequisites.go
+++ b/source-postgres/prerequisites.go
@@ -14,6 +14,11 @@ import (
 func (db *postgresDatabase) SetupPrerequisites(ctx context.Context) []error {
 	var errs []error
 
+	if db.featureFlags["skip_prerequisites"] {
+		logrus.Warn("skipping all prerequisite checks because the 'skip_prerequisites' feature flag is set")
+		return nil
+	}
+
 	if err := db.prerequisiteVersion(ctx); err != nil {
 		// Return early if the database version is incompatible with the connector since additional
 		// errors will be of minimal use.
@@ -220,6 +225,10 @@ func (db *postgresDatabase) prerequisiteWatermarksInPublication(ctx context.Cont
 
 func (db *postgresDatabase) SetupTablePrerequisites(ctx context.Context, tables []sqlcapture.TableID) map[sqlcapture.TableID]error {
 	var errs = make(map[sqlcapture.TableID]error)
+	if db.featureFlags["skip_prerequisites"] || db.featureFlags["skip_table_prerequisites"] {
+		logrus.Warn("skipping per-table prerequisite checks because the 'skip_prerequisites' or 'skip_table_prerequisites' feature flag is set")
+		return errs
+	}
 	for _, table := range tables {
 		if err := db.setupTablePrerequisite(ctx, table.Schema, table.Table); err != nil {
 			errs[table] = err


### PR DESCRIPTION
**Description:**

Adds two feature flags as escape hatches for cases where the connector's prerequisite checks should be skipped.

The immediate motivation here is a production capture where the prerequisite checks appear to be taking approximately an hour and a half to run. This is anonymously slow, and we should figure out why it is so slow, but it would be very useful to be able to just say "skip the checks" for now.