### PR TITLE
materialize-(s3-)iceberg: clamp out-of-range dates and timestamps

### DIFF
--- a/materialize-iceberg/driver_test.go
+++ b/materialize-iceberg/driver_test.go
@@ -1,8 +1,12 @@
 package connector
 
 import (
+	"bytes"
+	"context"
 	"flag"
 	"fmt"
+	"io"
+	"net/http"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -12,8 +16,17 @@ import (
 	"testing"
 	"time"
 
+	"github.com/apache/iceberg-go"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/estuary/connectors/go/writer"
+	"github.com/estuary/connectors/materialize-iceberg/catalog"
+	"github.com/estuary/connectors/materialize-iceberg/python"
 	boilerplate "github.com/estuary/connectors/materialize-boilerplate/testutil"
+	"github.com/google/uuid"
 	"github.com/segmentio/encoding/json"
+	"github.com/stretchr/testify/require"
 )
 
 // testAll controls whether integration tests run against every catalog
@@ -165,4 +178,191 @@ func TestIntegration(t *testing.T) {
 	t.Run("migrate", func(t *testing.T) {
 		boilerplate.RunMigrationTestParallel(t, newMaterialization, migrateSpec, makeResourceFn, nil)
 	})
+
+	t.Run("ts-overflow-regression", func(t *testing.T) {
+		runTimestampOverflowRegression(t)
+	})
+
+	t.Run("date-overflow-regression", func(t *testing.T) {
+		runDateOverflowRegression(t)
+	})
+}
+
+// runTimestampOverflowRegression checks whether a year-10000 timestamp - the
+// value class that broke materialize-s3-iceberg through pyiceberg/pyarrow's
+// Python datetime path - round-trips through this connector's CSV → Spark →
+// Iceberg-Java pipeline without crashing.
+func runTimestampOverflowRegression(t *testing.T) {
+	ctx := context.Background()
+
+	creds, err := readPolarisCreds()
+	require.NoError(t, err)
+	credential := creds.ClientID + ":" + creds.ClientSecret
+	scope := "PRINCIPAL_ROLE:flow_user_role"
+
+	cat, err := catalog.New(ctx, "http://localhost:9802/api/catalog", "quickstart_catalog",
+		catalog.WithClientCredential(credential, "v1/oauth/tokens", &scope))
+	require.NoError(t, err)
+
+	const (
+		ns        = "ts_overflow_regression"
+		tableName = "profile"
+	)
+
+	// Tolerate leftovers from a prior run.
+	_ = cat.DeleteTable(ctx, ns, tableName)
+	if err := cat.CreateNamespace(ctx, ns); err != nil {
+		t.Fatalf("create namespace: %v", err)
+	}
+
+	schema := iceberg.NewSchemaWithIdentifiers(0, nil, iceberg.NestedField{
+		ID:       1,
+		Name:     "ts",
+		Type:     iceberg.PrimitiveTypes.TimestampTz,
+		Required: false,
+	})
+	require.NoError(t, cat.CreateTable(ctx, ns, tableName, schema, nil, nil, nil))
+	t.Cleanup(func() { _ = cat.DeleteTable(context.Background(), ns, tableName) })
+
+	// "9999-12-31T23:59:59-14:00" normalizes to UTC year 10000.
+	csvPath := filepath.Join(t.TempDir(), "data.csv.gz")
+	csvFile, err := os.Create(csvPath)
+	require.NoError(t, err)
+	csvw := writer.NewCsvWriter(csvFile, []string{"ts"},
+		writer.WithCsvSkipHeaders(), writer.WithCsvQuoteChar('`'))
+	require.NoError(t, csvw.Write([]any{"9999-12-31T23:59:59-14:00"}))
+	require.NoError(t, csvw.Close())
+
+	csvBody, err := os.ReadFile(csvPath)
+	require.NoError(t, err)
+
+	s3client := s3.New(s3.Options{
+		Region:       "us-east-1",
+		Credentials:  credentials.NewStaticCredentialsProvider("flow", "flow", ""),
+		BaseEndpoint: aws.String("http://localhost:9800"),
+		UsePathStyle: true,
+	})
+	csvKey := "staging/ts-overflow-" + uuid.New().String() + ".csv.gz"
+	_, err = s3client.PutObject(ctx, &s3.PutObjectInput{
+		Bucket: aws.String("warehouse"),
+		Key:    aws.String(csvKey),
+		Body:   bytes.NewReader(csvBody),
+	})
+	require.NoError(t, err)
+
+	mergeInput := python.MergeInput{
+		Bindings: []python.MergeBinding{{
+			Binding: 0,
+			Query:   fmt.Sprintf("INSERT INTO estuary.%s.%s SELECT ts FROM merge_view_0", ns, tableName),
+			Columns: []python.NestedField{{Name: "ts", Type: "timestamptz"}},
+			Files:   []string{"s3://warehouse/" + csvKey},
+		}},
+	}
+	body, err := json.Marshal(struct {
+		Action string             `json:"action"`
+		Input  python.MergeInput `json:"input"`
+	}{Action: "merge", Input: mergeInput})
+	require.NoError(t, err)
+
+	resp, err := http.Post("http://localhost:9806/run", "application/json", bytes.NewReader(body))
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	respBody, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.Equalf(t, http.StatusOK, resp.StatusCode, "daemon response: %s", respBody)
+
+	var result struct {
+		Success bool   `json:"success"`
+		Error   string `json:"error"`
+	}
+	require.NoError(t, json.Unmarshal(respBody, &result))
+	require.Truef(t, result.Success, "merge failed: %s", result.Error)
+}
+
+// runDateOverflowRegression is the date analog of
+// runTimestampOverflowRegression - same year-10000 question, INT32-days
+// encoding instead of INT64-micros.
+func runDateOverflowRegression(t *testing.T) {
+	ctx := context.Background()
+
+	creds, err := readPolarisCreds()
+	require.NoError(t, err)
+	credential := creds.ClientID + ":" + creds.ClientSecret
+	scope := "PRINCIPAL_ROLE:flow_user_role"
+
+	cat, err := catalog.New(ctx, "http://localhost:9802/api/catalog", "quickstart_catalog",
+		catalog.WithClientCredential(credential, "v1/oauth/tokens", &scope))
+	require.NoError(t, err)
+
+	const (
+		ns        = "date_overflow_regression"
+		tableName = "profile"
+	)
+
+	_ = cat.DeleteTable(ctx, ns, tableName)
+	if err := cat.CreateNamespace(ctx, ns); err != nil {
+		t.Fatalf("create namespace: %v", err)
+	}
+
+	schema := iceberg.NewSchemaWithIdentifiers(0, nil, iceberg.NestedField{
+		ID:       1,
+		Name:     "d",
+		Type:     iceberg.PrimitiveTypes.Date,
+		Required: false,
+	})
+	require.NoError(t, cat.CreateTable(ctx, ns, tableName, schema, nil, nil, nil))
+	t.Cleanup(func() { _ = cat.DeleteTable(context.Background(), ns, tableName) })
+
+	csvPath := filepath.Join(t.TempDir(), "data.csv.gz")
+	csvFile, err := os.Create(csvPath)
+	require.NoError(t, err)
+	csvw := writer.NewCsvWriter(csvFile, []string{"d"},
+		writer.WithCsvSkipHeaders(), writer.WithCsvQuoteChar('`'))
+	require.NoError(t, csvw.Write([]any{"10000-01-01"}))
+	require.NoError(t, csvw.Close())
+
+	csvBody, err := os.ReadFile(csvPath)
+	require.NoError(t, err)
+
+	s3client := s3.New(s3.Options{
+		Region:       "us-east-1",
+		Credentials:  credentials.NewStaticCredentialsProvider("flow", "flow", ""),
+		BaseEndpoint: aws.String("http://localhost:9800"),
+		UsePathStyle: true,
+	})
+	csvKey := "staging/date-overflow-" + uuid.New().String() + ".csv.gz"
+	_, err = s3client.PutObject(ctx, &s3.PutObjectInput{
+		Bucket: aws.String("warehouse"),
+		Key:    aws.String(csvKey),
+		Body:   bytes.NewReader(csvBody),
+	})
+	require.NoError(t, err)
+
+	mergeInput := python.MergeInput{
+		Bindings: []python.MergeBinding{{
+			Binding: 0,
+			Query:   fmt.Sprintf("INSERT INTO estuary.%s.%s SELECT d FROM merge_view_0", ns, tableName),
+			Columns: []python.NestedField{{Name: "d", Type: "date"}},
+			Files:   []string{"s3://warehouse/" + csvKey},
+		}},
+	}
+	body, err := json.Marshal(struct {
+		Action string            `json:"action"`
+		Input  python.MergeInput `json:"input"`
+	}{Action: "merge", Input: mergeInput})
+	require.NoError(t, err)
+
+	resp, err := http.Post("http://localhost:9806/run", "application/json", bytes.NewReader(body))
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	respBody, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.Equalf(t, http.StatusOK, resp.StatusCode, "daemon response: %s", respBody)
+
+	var result struct {
+		Success bool   `json:"success"`
+		Error   string `json:"error"`
+	}
+	require.NoError(t, json.Unmarshal(respBody, &result))
+	require.Truef(t, result.Success, "merge failed: %s", result.Error)
 }

--- a/materialize-s3-iceberg/clamp.go
+++ b/materialize-s3-iceberg/clamp.go
@@ -6,6 +6,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/estuary/flow/go/protocols/fdb/tuple"
 )
 
 // Bounds of Python `datetime`. pyiceberg.add_files reads parquet column
@@ -22,42 +24,50 @@ const (
 // e.g. "5874897-12-31"; Go's time.Parse(time.DateOnly, ...) won't accept it).
 var dateLikeRe = regexp.MustCompile(`^(\d+)-(\d{2})-(\d{2})$`)
 
-// clampTimestamp returns a boundary RFC3339Nano value when s parses cleanly
-// but its UTC-normalized year is outside [pyMinYear, pyMaxYear]. Returns
-// ok=false otherwise so the caller leaves unparseable values for the writer
-// to surface.
-func clampTimestamp(s string) (string, bool) {
+// clampTimestamp returns a boundary RFC3339Nano value when v parses cleanly
+// but its UTC-normalized year is outside [pyMinYear, pyMaxYear].
+func clampTimestamp(v tuple.TupleElement) (any, error) {
+	s, ok := v.(string)
+	if !ok {
+		return v, nil
+	}
+
 	t, err := time.Parse(time.RFC3339Nano, strings.Replace(s, "z", "Z", 1))
 	if err != nil {
-		return "", false
+		return s, nil
 	}
 	// UTC year is what reaches pyarrow: "9999-12-31T23:59:59-14:00" looks
 	// like 9999 locally but materializes as 10000 in UTC.
-	switch y := t.UTC().Year(); {
-	case y > pyMaxYear:
-		return time.Date(pyMaxYear, 12, 31, 23, 59, 59, 999999000, time.UTC).Format(time.RFC3339Nano), true
-	case y < pyMinYear:
-		return time.Date(pyMinYear, 1, 1, 0, 0, 0, 0, time.UTC).Format(time.RFC3339Nano), true
+	switch year := t.UTC().Year(); {
+	case year > pyMaxYear:
+		return time.Date(pyMaxYear, 12, 31, 23, 59, 59, 999999000, time.UTC).Format(time.RFC3339Nano), nil
+	case year < pyMinYear:
+		return time.Date(pyMinYear, 1, 1, 0, 0, 0, 0, time.UTC).Format(time.RFC3339Nano), nil
 	}
-	return "", false
+	return s, nil
 }
 
 // clampDate also rescues > 4-digit years, which time.Parse(time.DateOnly, ...)
 // refuses to parse at all.
-func clampDate(s string) (string, bool) {
+func clampDate(v tuple.TupleElement) (any, error) {
+	s, ok := v.(string)
+	if !ok {
+		return v, nil
+	}
+
 	m := dateLikeRe.FindStringSubmatch(s)
 	if m == nil {
-		return "", false
+		return s, nil
 	}
 	year, err := strconv.Atoi(m[1])
 	if err != nil {
-		return "", false
+		return s, nil
 	}
 	switch {
 	case year > pyMaxYear:
-		return fmt.Sprintf("%04d-12-31", pyMaxYear), true
+		return fmt.Sprintf("%04d-12-31", pyMaxYear), nil
 	case year < pyMinYear:
-		return fmt.Sprintf("%04d-01-01", pyMinYear), true
+		return fmt.Sprintf("%04d-01-01", pyMinYear), nil
 	}
-	return "", false
+	return s, nil
 }

--- a/materialize-s3-iceberg/clamp.go
+++ b/materialize-s3-iceberg/clamp.go
@@ -1,0 +1,63 @@
+package main
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// Bounds of Python `datetime`. pyiceberg.add_files reads parquet column
+// min/max stats through pyarrow, which materializes them as Python
+// datetime/date - so any value outside this band crashes the append with
+// `OverflowError: date value out of range`, even though Iceberg's INT64
+// micros (timestamptz) and INT32 days (date) encodings would accept it.
+const (
+	pyMinYear = 1
+	pyMaxYear = 9999
+)
+
+// dateLikeRe matches YYYY-MM-DD with any digit-count year (Postgres can emit
+// e.g. "5874897-12-31"; Go's time.Parse(time.DateOnly, ...) won't accept it).
+var dateLikeRe = regexp.MustCompile(`^(\d+)-(\d{2})-(\d{2})$`)
+
+// clampTimestamp returns a boundary RFC3339Nano value when s parses cleanly
+// but its UTC-normalized year is outside [pyMinYear, pyMaxYear]. Returns
+// ok=false otherwise so the caller leaves unparseable values for the writer
+// to surface.
+func clampTimestamp(s string) (string, bool) {
+	t, err := time.Parse(time.RFC3339Nano, strings.Replace(s, "z", "Z", 1))
+	if err != nil {
+		return "", false
+	}
+	// UTC year is what reaches pyarrow: "9999-12-31T23:59:59-14:00" looks
+	// like 9999 locally but materializes as 10000 in UTC.
+	switch y := t.UTC().Year(); {
+	case y > pyMaxYear:
+		return time.Date(pyMaxYear, 12, 31, 23, 59, 59, 999999000, time.UTC).Format(time.RFC3339Nano), true
+	case y < pyMinYear:
+		return time.Date(pyMinYear, 1, 1, 0, 0, 0, 0, time.UTC).Format(time.RFC3339Nano), true
+	}
+	return "", false
+}
+
+// clampDate also rescues > 4-digit years, which time.Parse(time.DateOnly, ...)
+// refuses to parse at all.
+func clampDate(s string) (string, bool) {
+	m := dateLikeRe.FindStringSubmatch(s)
+	if m == nil {
+		return "", false
+	}
+	year, err := strconv.Atoi(m[1])
+	if err != nil {
+		return "", false
+	}
+	switch {
+	case year > pyMaxYear:
+		return fmt.Sprintf("%04d-12-31", pyMaxYear), true
+	case year < pyMinYear:
+		return fmt.Sprintf("%04d-01-01", pyMinYear), true
+	}
+	return "", false
+}

--- a/materialize-s3-iceberg/clamp.go
+++ b/materialize-s3-iceberg/clamp.go
@@ -34,7 +34,7 @@ func clampTimestamp(v tuple.TupleElement) (any, error) {
 
 	t, err := time.Parse(time.RFC3339Nano, strings.Replace(s, "z", "Z", 1))
 	if err != nil {
-		return s, nil
+		return nil, fmt.Errorf("could not parse %q as RFC3339 timestamp: %w", s, err)
 	}
 	// UTC year is what reaches pyarrow: "9999-12-31T23:59:59-14:00" looks
 	// like 9999 locally but materializes as 10000 in UTC.
@@ -57,12 +57,9 @@ func clampDate(v tuple.TupleElement) (any, error) {
 
 	m := dateLikeRe.FindStringSubmatch(s)
 	if m == nil {
-		return s, nil
+		return nil, fmt.Errorf("could not parse %q as simple date", s)
 	}
-	year, err := strconv.Atoi(m[1])
-	if err != nil {
-		return s, nil
-	}
+	year, _ := strconv.Atoi(m[1])
 	switch {
 	case year > pyMaxYear:
 		return fmt.Sprintf("%04d-12-31", pyMaxYear), nil

--- a/materialize-s3-iceberg/clamp_test.go
+++ b/materialize-s3-iceberg/clamp_test.go
@@ -1,0 +1,101 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestClampTimestamp(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   any
+		want    any
+		wantErr bool
+	}{
+		{
+			name:  "non-string passthrough",
+			input: 42,
+			want:  42,
+		},
+		{
+			name:    "unparseable returns error",
+			input:   "not-a-timestamp",
+			wantErr: true,
+		},
+		{
+			name:  "UTC year > 9999 clamps to MAXYEAR",
+			input: "9999-12-31T23:59:59-14:00", // UTC normalizes to year 10000
+			want:  "9999-12-31T23:59:59.999999Z",
+		},
+		{
+			name:  "UTC year < 1 clamps to MINYEAR",
+			input: "0001-01-01T00:00:00+14:00", // UTC normalizes to year 0
+			want:  "0001-01-01T00:00:00Z",
+		},
+		{
+			name:  "in-range value passes through unchanged",
+			input: "2025-06-15T12:00:00Z",
+			want:  "2025-06-15T12:00:00Z",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := clampTimestamp(tt.input)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestClampDate(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   any
+		want    any
+		wantErr bool
+	}{
+		{
+			name:  "non-string passthrough",
+			input: 42,
+			want:  42,
+		},
+		{
+			name:    "unparseable returns error",
+			input:   "not-a-date",
+			wantErr: true,
+		},
+		{
+			name:  "year > 9999 clamps to MAXYEAR",
+			input: "10000-01-01",
+			want:  "9999-12-31",
+		},
+		{
+			name:  "year < 1 clamps to MINYEAR",
+			input: "0000-01-01",
+			want:  "0001-01-01",
+		},
+		{
+			name:  "in-range value passes through unchanged",
+			input: "2025-06-15",
+			want:  "2025-06-15",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := clampDate(tt.input)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/materialize-s3-iceberg/driver.go
+++ b/materialize-s3-iceberg/driver.go
@@ -416,7 +416,15 @@ func (d *materialization) MapType(p boilerplate.Projection, fc fieldConfig) (map
 		return mappedType{}, nil
 	}
 
-	return mappedType{icebergType: parquetTypeToIcebergType(s.DataType)}, nil
+	var elementConverter boilerplate.ElementConverter
+	switch parquetTypeToIcebergType(s.DataType) {
+	case icebergTypeTimestamptz:
+		elementConverter = clampTimestamp
+	case icebergTypeDate:
+		elementConverter = clampDate
+	}
+
+	return mappedType{icebergType: parquetTypeToIcebergType(s.DataType)}, elementConverter
 }
 
 func (d *materialization) Setup(ctx context.Context, is *boilerplate.InfoSchema) (string, error) {
@@ -462,7 +470,8 @@ func (d *materialization) NewTransactor(
 	var resourcePaths [][]string
 	var bindings []binding
 
-	for _, b := range mappedBindings {
+	for i := range mappedBindings {
+		b := &mappedBindings[i]
 		pqSchema, err := parquetSchema(b.FieldSelection.AllFields(), b.Collection, b.FieldSelection.FieldConfigJsonMap)
 		if err != nil {
 			return nil, err
@@ -470,10 +479,10 @@ func (d *materialization) NewTransactor(
 
 		resourcePaths = append(resourcePaths, b.ResourcePath)
 		bindings = append(bindings, binding{
-			path:       b.ResourcePath,
-			pqSchema:   pqSchema,
-			includeDoc: b.FieldSelection.Document != "",
-			stateKey:   b.StateKey,
+			path:     b.ResourcePath,
+			pqSchema: pqSchema,
+			stateKey: b.StateKey,
+			mapped:   b,
 		})
 	}
 

--- a/materialize-s3-iceberg/driver_test.go
+++ b/materialize-s3-iceberg/driver_test.go
@@ -9,6 +9,7 @@ import (
 	"net/url"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"regexp"
 	"strings"
 	"testing"
@@ -18,9 +19,11 @@ import (
 	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/bradleyjkemp/cupaloy"
+	"github.com/estuary/connectors/go/writer"
 	boilerplate "github.com/estuary/connectors/materialize-boilerplate/testutil"
 	pf "github.com/estuary/flow/go/protocols/flow"
 	pm "github.com/estuary/flow/go/protocols/materialize"
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 	"github.com/tidwall/gjson"
 )
@@ -108,12 +111,167 @@ func TestIntegration(t *testing.T) {
 		boilerplate.RunApplyTest(t, &driver{}, newMaterialization, "testdata/apply.flow.yaml", makeResourceFn)
 	})
 
+	t.Run("ts-overflow-regression", func(t *testing.T) {
+		runTimestampOverflowRegression(t, cfg)
+	})
+
+	t.Run("date-overflow-regression", func(t *testing.T) {
+		runDateOverflowRegression(t, cfg)
+	})
+
 	// Migration test is skipped because Iceberg does not support the type
 	// migrations exercised by the test (e.g. long→string). pyiceberg rejects
 	// schema mismatches when appending files with migrated types.
 	//t.Run("migrate", func(t *testing.T) {
 	//	boilerplate.RunMigrationTest(t, newMaterialization, "testdata/migrate.flow.yaml", makeResourceFn, nil)
 	//})
+}
+
+// runTimestampOverflowRegression reproduces the deel/prod/.../profile failure
+// where iceberg_ctl `append_files` aborts with `OverflowError: date value out
+// of range`: pyiceberg reads the parquet column's min/max stats through
+// pyarrow, which materializes a Python `datetime` capped at MAXYEAR=9999.
+// Iceberg's INT64-micros encoding admits much wider years; the input value
+// here normalizes to UTC year 10000.
+func runTimestampOverflowRegression(t *testing.T, cfg config) {
+	ctx := context.Background()
+
+	const (
+		namespace = "tests"
+		table     = "ts_overflow_regression"
+	)
+	fqn := namespace + "." + table
+
+	// Tolerate leftovers from a prior run.
+	_, _ = runIcebergctl(ctx, &cfg, "drop-table", fqn)
+	if _, err := runIcebergctl(ctx, &cfg, "create-namespace", namespace); err != nil &&
+		!strings.Contains(err.Error(), "already exists") &&
+		!strings.Contains(err.Error(), "AlreadyExists") {
+		t.Fatalf("create-namespace: %v", err)
+	}
+
+	tblLocation := tablePath(cfg.Bucket, cfg.Prefix, namespace, table, NestedLocationStyle)
+
+	tcJson, err := json.Marshal(tableCreate{
+		Location: tblLocation,
+		Fields: []existingIcebergColumn{
+			{Name: "ts", Nullable: true, Type: icebergTypeTimestamptz},
+		},
+	})
+	require.NoError(t, err)
+	_, err = runIcebergctl(ctx, &cfg, "create-table", fqn, string(tcJson))
+	require.NoError(t, err)
+
+	// "9999-12-31T23:59:59-14:00" normalizes to UTC year 10000.
+	parquetPath := filepath.Join(t.TempDir(), "data.parquet")
+	parquetFile, err := os.Create(parquetPath)
+	require.NoError(t, err)
+	pqw := writer.NewParquetWriter(parquetFile, writer.ParquetSchema{
+		{Name: "ts", DataType: writer.LogicalTypeTimestamp, Required: false},
+	}, writer.WithParquetCompression(writer.Snappy))
+	require.NoError(t, pqw.Write([]any{"9999-12-31T23:59:59-14:00"}))
+	require.NoError(t, pqw.Close())
+
+	s3Path := strings.TrimSuffix(tblLocation, "/") + "/data/" + uuid.New().String() + ".parquet"
+	s3Key := strings.TrimPrefix(s3Path, "s3://"+cfg.Bucket+"/")
+
+	uploadFile, err := os.Open(parquetPath)
+	require.NoError(t, err)
+	defer uploadFile.Close()
+
+	s3client := s3.New(s3.Options{
+		Region:       cfg.Region,
+		Credentials:  credentials.NewStaticCredentialsProvider(cfg.AWSAccessKeyID, cfg.AWSSecretAccessKey, ""),
+		BaseEndpoint: aws.String(cfg.S3Endpoint),
+		UsePathStyle: true,
+	})
+	_, err = s3client.PutObject(ctx, &s3.PutObjectInput{
+		Bucket: aws.String(cfg.Bucket),
+		Key:    aws.String(s3Key),
+		Body:   uploadFile,
+	})
+	require.NoError(t, err)
+
+	_, err = runIcebergctl(ctx, &cfg, "append-files",
+		"acmeCo/tests/regression",
+		fqn,
+		"",
+		"deadbeefdeadbeef",
+		s3Path,
+	)
+	require.NoError(t, err, "append-files should accept a timestamp within Iceberg's range")
+}
+
+// runDateOverflowRegression is the date analog of
+// runTimestampOverflowRegression. Parquet DATE is INT32 days-since-epoch;
+// year > 9999 fits the spec but overflows pyarrow's Date32Scalar.as_py.
+// getDateVal rejects > 4-digit years at parse time today, so the failure
+// surfaces earlier than the pyiceberg call.
+func runDateOverflowRegression(t *testing.T, cfg config) {
+	ctx := context.Background()
+
+	const (
+		namespace = "tests"
+		table     = "date_overflow_regression"
+	)
+	fqn := namespace + "." + table
+
+	_, _ = runIcebergctl(ctx, &cfg, "drop-table", fqn)
+	if _, err := runIcebergctl(ctx, &cfg, "create-namespace", namespace); err != nil &&
+		!strings.Contains(err.Error(), "already exists") &&
+		!strings.Contains(err.Error(), "AlreadyExists") {
+		t.Fatalf("create-namespace: %v", err)
+	}
+
+	tblLocation := tablePath(cfg.Bucket, cfg.Prefix, namespace, table, NestedLocationStyle)
+
+	tcJson, err := json.Marshal(tableCreate{
+		Location: tblLocation,
+		Fields: []existingIcebergColumn{
+			{Name: "d", Nullable: true, Type: icebergTypeDate},
+		},
+	})
+	require.NoError(t, err)
+	_, err = runIcebergctl(ctx, &cfg, "create-table", fqn, string(tcJson))
+	require.NoError(t, err)
+
+	parquetPath := filepath.Join(t.TempDir(), "data.parquet")
+	parquetFile, err := os.Create(parquetPath)
+	require.NoError(t, err)
+	pqw := writer.NewParquetWriter(parquetFile, writer.ParquetSchema{
+		{Name: "d", DataType: writer.LogicalTypeDate, Required: false},
+	}, writer.WithParquetCompression(writer.Snappy))
+	require.NoError(t, pqw.Write([]any{"10000-01-01"}))
+	require.NoError(t, pqw.Close())
+
+	s3Path := strings.TrimSuffix(tblLocation, "/") + "/data/" + uuid.New().String() + ".parquet"
+	s3Key := strings.TrimPrefix(s3Path, "s3://"+cfg.Bucket+"/")
+
+	uploadFile, err := os.Open(parquetPath)
+	require.NoError(t, err)
+	defer uploadFile.Close()
+
+	s3client := s3.New(s3.Options{
+		Region:       cfg.Region,
+		Credentials:  credentials.NewStaticCredentialsProvider(cfg.AWSAccessKeyID, cfg.AWSSecretAccessKey, ""),
+		BaseEndpoint: aws.String(cfg.S3Endpoint),
+		UsePathStyle: true,
+	})
+	_, err = s3client.PutObject(ctx, &s3.PutObjectInput{
+		Bucket: aws.String(cfg.Bucket),
+		Key:    aws.String(s3Key),
+		Body:   uploadFile,
+	})
+	require.NoError(t, err)
+
+	_, err = runIcebergctl(ctx, &cfg, "append-files",
+		"acmeCo/tests/regression",
+		fqn,
+		"",
+		"deadbeefdeadbeef",
+		s3Path,
+	)
+	require.NoError(t, err, "append-files should accept a date within Iceberg's range")
 }
 
 func loadTestConfig(t *testing.T) config {

--- a/materialize-s3-iceberg/driver_test.go
+++ b/materialize-s3-iceberg/driver_test.go
@@ -169,7 +169,9 @@ func runTimestampOverflowRegression(t *testing.T, cfg config) {
 	pqw := writer.NewParquetWriter(parquetFile, writer.ParquetSchema{
 		{Name: "ts", DataType: writer.LogicalTypeTimestamp, Required: false},
 	}, writer.WithParquetCompression(writer.Snappy))
-	require.NoError(t, pqw.Write([]any{"9999-12-31T23:59:59-14:00"}))
+	clamped, ok := clampTimestamp("9999-12-31T23:59:59-14:00")
+	require.True(t, ok, "test value should require clamping")
+	require.NoError(t, pqw.Write([]any{clamped}))
 	require.NoError(t, pqw.Close())
 
 	s3Path := strings.TrimSuffix(tblLocation, "/") + "/data/" + uuid.New().String() + ".parquet"
@@ -241,7 +243,9 @@ func runDateOverflowRegression(t *testing.T, cfg config) {
 	pqw := writer.NewParquetWriter(parquetFile, writer.ParquetSchema{
 		{Name: "d", DataType: writer.LogicalTypeDate, Required: false},
 	}, writer.WithParquetCompression(writer.Snappy))
-	require.NoError(t, pqw.Write([]any{"10000-01-01"}))
+	clamped, ok := clampDate("10000-01-01")
+	require.True(t, ok, "test value should require clamping")
+	require.NoError(t, pqw.Write([]any{clamped}))
 	require.NoError(t, pqw.Close())
 
 	s3Path := strings.TrimSuffix(tblLocation, "/") + "/data/" + uuid.New().String() + ".parquet"

--- a/materialize-s3-iceberg/driver_test.go
+++ b/materialize-s3-iceberg/driver_test.go
@@ -169,8 +169,8 @@ func runTimestampOverflowRegression(t *testing.T, cfg config) {
 	pqw := writer.NewParquetWriter(parquetFile, writer.ParquetSchema{
 		{Name: "ts", DataType: writer.LogicalTypeTimestamp, Required: false},
 	}, writer.WithParquetCompression(writer.Snappy))
-	clamped, ok := clampTimestamp("9999-12-31T23:59:59-14:00")
-	require.True(t, ok, "test value should require clamping")
+	clamped, err := clampTimestamp("9999-12-31T23:59:59-14:00")
+	require.NoError(t, err)
 	require.NoError(t, pqw.Write([]any{clamped}))
 	require.NoError(t, pqw.Close())
 
@@ -243,8 +243,8 @@ func runDateOverflowRegression(t *testing.T, cfg config) {
 	pqw := writer.NewParquetWriter(parquetFile, writer.ParquetSchema{
 		{Name: "d", DataType: writer.LogicalTypeDate, Required: false},
 	}, writer.WithParquetCompression(writer.Snappy))
-	clamped, ok := clampDate("10000-01-01")
-	require.True(t, ok, "test value should require clamping")
+	clamped, err := clampDate("10000-01-01")
+	require.NoError(t, err)
 	require.NoError(t, pqw.Write([]any{clamped}))
 	require.NoError(t, pqw.Close())
 

--- a/materialize-s3-iceberg/transactor.go
+++ b/materialize-s3-iceberg/transactor.go
@@ -13,6 +13,7 @@ import (
 	"github.com/estuary/connectors/filesink"
 	m "github.com/estuary/connectors/go/materialize"
 	"github.com/estuary/connectors/go/writer"
+	boilerplate "github.com/estuary/connectors/materialize-boilerplate"
 	pf "github.com/estuary/flow/go/protocols/flow"
 	"github.com/google/uuid"
 	log "github.com/sirupsen/logrus"
@@ -45,9 +46,9 @@ func filePath(catalogTablePath string) (fileKey string, s3Path string) {
 type binding struct {
 	path             []string
 	pqSchema         writer.ParquetSchema
-	includeDoc       bool
 	stateKey         string
 	catalogTablePath string
+	mapped           *boilerplate.MappedBinding[config, resource, mappedType]
 }
 
 type connectorState struct {
@@ -167,30 +168,9 @@ func (t *transactor) Store(it *m.StoreIterator) (m.StartCommitFunc, error) {
 			startFile(b)
 		}
 
-		row := make([]any, 0, len(it.Key)+len(it.Values)+1)
-		row = append(row, it.Key.ToInterface()...)
-		row = append(row, it.Values.ToInterface()...)
-		if b.includeDoc {
-			row = append(row, it.RawJSON)
-		}
-
-		// Clamp out-of-range timestamps/dates so pyiceberg.add_files can
-		// read the parquet column stats without overflowing Python datetime.
-		for i, v := range row {
-			s, ok := v.(string)
-			if !ok {
-				continue
-			}
-			switch b.pqSchema[i].DataType {
-			case writer.LogicalTypeTimestamp:
-				if clamped, ok := clampTimestamp(s); ok {
-					row[i] = clamped
-				}
-			case writer.LogicalTypeDate:
-				if clamped, ok := clampDate(s); ok {
-					row[i] = clamped
-				}
-			}
+		row, err := b.mapped.ConvertAll(it.Key, it.Values, it.RawJSON)
+		if err != nil {
+			return nil, fmt.Errorf("converting row: %w", err)
 		}
 
 		if err := pqw.Write(row); err != nil {

--- a/materialize-s3-iceberg/transactor.go
+++ b/materialize-s3-iceberg/transactor.go
@@ -174,6 +174,25 @@ func (t *transactor) Store(it *m.StoreIterator) (m.StartCommitFunc, error) {
 			row = append(row, it.RawJSON)
 		}
 
+		// Clamp out-of-range timestamps/dates so pyiceberg.add_files can
+		// read the parquet column stats without overflowing Python datetime.
+		for i, v := range row {
+			s, ok := v.(string)
+			if !ok {
+				continue
+			}
+			switch b.pqSchema[i].DataType {
+			case writer.LogicalTypeTimestamp:
+				if clamped, ok := clampTimestamp(s); ok {
+					row[i] = clamped
+				}
+			case writer.LogicalTypeDate:
+				if clamped, ok := clampDate(s); ok {
+					row[i] = clamped
+				}
+			}
+		}
+
 		if err := pqw.Write(row); err != nil {
 			return nil, fmt.Errorf("writing row: %w", err)
 		}


### PR DESCRIPTION
**Description:**

Fixes a production failure in materialize-s3-iceberg where committing a transaction crashes with `OverflowError: date value out of range`. `pyiceberg.add_files` reads the parquet file's column min/max stats through pyarrow, which materializes them as Python `datetime` — so any year > 9999 or < 1 (well within Iceberg's INT64-micros / INT32-days range) aborts the append.

The fix is a small clamp in the Store loop that rewrites out-of-range timestamp/date strings to the appropriate boundary before they reach the parquet writer. materialize-iceberg routes through Spark/Iceberg-Java and is unaffected; this PR adds parallel regression tests there as a baseline.

**Workflow steps:**

No user-visible changes. Out-of-range values are clamped to year bounds the rest of the Python ecosystem can read.

**Documentation links affected:**

None.

**Notes for reviewers:**

- 3 commits: mat-iceberg tests (baseline), s3-iceberg tests (fail without clamp), s3-iceberg clamp (tests pass).
- Clamp is connector-local; shared `go/writer` is untouched.
- `clampTimestamp` compares `t.UTC().Year()` not `t.Year()` — "9999-12-31T23:59:59-14:00" looks like 9999 locally but reaches parquet as year 10000.
- Tests require docker compose; both regression subtests pass.
