### PR TITLE
source-{various}: harden conditional reduction annotations for hard deletes

### DIFF
--- a/source-dynamodb/.snapshots/TestDiscovery-additional_table_without_stream_enabled
+++ b/source-dynamodb/.snapshots/TestDiscovery-additional_table_without_stream_enabled
@@ -22,8 +22,14 @@ Binding 0:
       "allOf": [
         {
           "if": {
+            "required": [
+              "_meta"
+            ],
             "properties": {
               "_meta": {
+                "required": [
+                  "op"
+                ],
                 "properties": {
                   "op": {
                     "const": "d"

--- a/source-dynamodb/.snapshots/TestDiscovery-multiple_tables_with_various_types
+++ b/source-dynamodb/.snapshots/TestDiscovery-multiple_tables_with_various_types
@@ -22,8 +22,14 @@ Binding 0:
       "allOf": [
         {
           "if": {
+            "required": [
+              "_meta"
+            ],
             "properties": {
               "_meta": {
+                "required": [
+                  "op"
+                ],
                 "properties": {
                   "op": {
                     "const": "d"
@@ -141,8 +147,14 @@ Binding 1:
       "allOf": [
         {
           "if": {
+            "required": [
+              "_meta"
+            ],
             "properties": {
               "_meta": {
+                "required": [
+                  "op"
+                ],
                 "properties": {
                   "op": {
                     "const": "d"
@@ -262,8 +274,14 @@ Binding 2:
       "allOf": [
         {
           "if": {
+            "required": [
+              "_meta"
+            ],
             "properties": {
               "_meta": {
+                "required": [
+                  "op"
+                ],
                 "properties": {
                   "op": {
                     "const": "d"

--- a/source-dynamodb/.snapshots/TestDiscovery-single_table_with_a_partition_key
+++ b/source-dynamodb/.snapshots/TestDiscovery-single_table_with_a_partition_key
@@ -22,8 +22,14 @@ Binding 0:
       "allOf": [
         {
           "if": {
+            "required": [
+              "_meta"
+            ],
             "properties": {
               "_meta": {
+                "required": [
+                  "op"
+                ],
                 "properties": {
                   "op": {
                     "const": "d"

--- a/source-dynamodb/discovery.go
+++ b/source-dynamodb/discovery.go
@@ -175,9 +175,11 @@ func (driver) Discover(ctx context.Context, req *pc.Request_Discover) (*pc.Respo
 					},
 					Required: []string{"_meta"},
 					If: &jsonschema.Schema{
+						Required: []string{"_meta"},
 						Extras: map[string]interface{}{
 							"properties": map[string]*jsonschema.Schema{
 								"_meta": {
+									Required: []string{"op"},
 									Extras: map[string]interface{}{
 										"properties": map[string]*jsonschema.Schema{
 											"op": {

--- a/source-kafka/src/discover.rs
+++ b/source-kafka/src/discover.rs
@@ -96,8 +96,10 @@ fn topic_schema_to_collection_spec(
     let doc_schema_json = json!({
         "x-infer-schema": true,
         "if": {
+            "required": ["_meta"],
             "properties": {
               "_meta": {
+                "required": ["op"],
                 "properties": {
                   "op": {
                     "const": "d"

--- a/source-kafka/src/snapshots/source_kafka__discover__tests__avro record with scalar compound key.snap
+++ b/source-kafka/src/snapshots/source_kafka__discover__tests__avro record with scalar compound key.snap
@@ -6,8 +6,14 @@ expression: snap
 {
   "type": "object",
   "if": {
+    "required": [
+      "_meta"
+    ],
     "properties": {
       "_meta": {
+        "required": [
+          "op"
+        ],
         "properties": {
           "op": {
             "const": "d"

--- a/source-kafka/src/snapshots/source_kafka__discover__tests__nested avro record with scalars.snap
+++ b/source-kafka/src/snapshots/source_kafka__discover__tests__nested avro record with scalars.snap
@@ -6,8 +6,14 @@ expression: snap
 {
   "type": "object",
   "if": {
+    "required": [
+      "_meta"
+    ],
     "properties": {
       "_meta": {
+        "required": [
+          "op"
+        ],
         "properties": {
           "op": {
             "const": "d"

--- a/source-kafka/src/snapshots/source_kafka__discover__tests__nested json object.snap
+++ b/source-kafka/src/snapshots/source_kafka__discover__tests__nested json object.snap
@@ -6,8 +6,14 @@ expression: snap
 {
   "type": "object",
   "if": {
+    "required": [
+      "_meta"
+    ],
     "properties": {
       "_meta": {
+        "required": [
+          "op"
+        ],
         "properties": {
           "op": {
             "const": "d"

--- a/source-kafka/src/snapshots/source_kafka__discover__tests__no key.snap
+++ b/source-kafka/src/snapshots/source_kafka__discover__tests__no key.snap
@@ -6,8 +6,14 @@ expression: snap
 {
   "type": "object",
   "if": {
+    "required": [
+      "_meta"
+    ],
     "properties": {
       "_meta": {
+        "required": [
+          "op"
+        ],
         "properties": {
           "op": {
             "const": "d"

--- a/source-kafka/src/snapshots/source_kafka__discover__tests__single non-scalar avro key.snap
+++ b/source-kafka/src/snapshots/source_kafka__discover__tests__single non-scalar avro key.snap
@@ -6,8 +6,14 @@ expression: snap
 {
   "type": "object",
   "if": {
+    "required": [
+      "_meta"
+    ],
     "properties": {
       "_meta": {
+        "required": [
+          "op"
+        ],
         "properties": {
           "op": {
             "const": "d"

--- a/source-kafka/src/snapshots/source_kafka__discover__tests__single nullable scalar avro key.snap
+++ b/source-kafka/src/snapshots/source_kafka__discover__tests__single nullable scalar avro key.snap
@@ -6,8 +6,14 @@ expression: snap
 {
   "type": "object",
   "if": {
+    "required": [
+      "_meta"
+    ],
     "properties": {
       "_meta": {
+        "required": [
+          "op"
+        ],
         "properties": {
           "op": {
             "const": "d"

--- a/source-kafka/src/snapshots/source_kafka__discover__tests__single nullable scalar json key.snap
+++ b/source-kafka/src/snapshots/source_kafka__discover__tests__single nullable scalar json key.snap
@@ -6,8 +6,14 @@ expression: snap
 {
   "type": "object",
   "if": {
+    "required": [
+      "_meta"
+    ],
     "properties": {
       "_meta": {
+        "required": [
+          "op"
+        ],
         "properties": {
           "op": {
             "const": "d"

--- a/source-kafka/src/snapshots/source_kafka__discover__tests__single scalar avro key.snap
+++ b/source-kafka/src/snapshots/source_kafka__discover__tests__single scalar avro key.snap
@@ -6,8 +6,14 @@ expression: snap
 {
   "type": "object",
   "if": {
+    "required": [
+      "_meta"
+    ],
     "properties": {
       "_meta": {
+        "required": [
+          "op"
+        ],
         "properties": {
           "op": {
             "const": "d"

--- a/source-kafka/src/snapshots/source_kafka__discover__tests__single scalar json key.snap
+++ b/source-kafka/src/snapshots/source_kafka__discover__tests__single scalar json key.snap
@@ -6,8 +6,14 @@ expression: snap
 {
   "type": "object",
   "if": {
+    "required": [
+      "_meta"
+    ],
     "properties": {
       "_meta": {
+        "required": [
+          "op"
+        ],
         "properties": {
           "op": {
             "const": "d"

--- a/source-kafka/tests/snapshots/test__discover.snap
+++ b/source-kafka/tests/snapshots/test__discover.snap
@@ -11,9 +11,15 @@ expression: snap
             "op": {
               "const": "d"
             }
-          }
+          },
+          "required": [
+            "op"
+          ]
         }
-      }
+      },
+      "required": [
+        "_meta"
+      ]
     },
     "properties": {
       "_meta": {
@@ -97,9 +103,15 @@ expression: snap
             "op": {
               "const": "d"
             }
-          }
+          },
+          "required": [
+            "op"
+          ]
         }
-      }
+      },
+      "required": [
+        "_meta"
+      ]
     },
     "properties": {
       "_meta": {
@@ -167,9 +179,15 @@ expression: snap
             "op": {
               "const": "d"
             }
-          }
+          },
+          "required": [
+            "op"
+          ]
         }
-      }
+      },
+      "required": [
+        "_meta"
+      ]
     },
     "properties": {
       "_meta": {
@@ -254,9 +272,15 @@ expression: snap
             "op": {
               "const": "d"
             }
-          }
+          },
+          "required": [
+            "op"
+          ]
         }
-      }
+      },
+      "required": [
+        "_meta"
+      ]
     },
     "properties": {
       "_meta": {
@@ -327,9 +351,15 @@ expression: snap
             "op": {
               "const": "d"
             }
-          }
+          },
+          "required": [
+            "op"
+          ]
         }
-      }
+      },
+      "required": [
+        "_meta"
+      ]
     },
     "properties": {
       "_meta": {

--- a/source-mongodb/.snapshots/TestDiscover
+++ b/source-mongodb/.snapshots/TestDiscover
@@ -8,8 +8,14 @@ Binding 0:
     },
     "document_schema_json": {
       "if": {
+        "required": [
+          "_meta"
+        ],
         "properties": {
           "_meta": {
+            "required": [
+              "op"
+            ],
             "properties": {
               "op": {
                 "const": "d"
@@ -95,8 +101,14 @@ Binding 1:
     },
     "document_schema_json": {
       "if": {
+        "required": [
+          "_meta"
+        ],
         "properties": {
           "_meta": {
+            "required": [
+              "op"
+            ],
             "properties": {
               "op": {
                 "const": "d"

--- a/source-mongodb/.snapshots/TestDiscoverAllDatabases
+++ b/source-mongodb/.snapshots/TestDiscoverAllDatabases
@@ -8,8 +8,14 @@ Binding 0:
     },
     "document_schema_json": {
       "if": {
+        "required": [
+          "_meta"
+        ],
         "properties": {
           "_meta": {
+            "required": [
+              "op"
+            ],
             "properties": {
               "op": {
                 "const": "d"
@@ -95,8 +101,14 @@ Binding 1:
     },
     "document_schema_json": {
       "if": {
+        "required": [
+          "_meta"
+        ],
         "properties": {
           "_meta": {
+            "required": [
+              "op"
+            ],
             "properties": {
               "op": {
                 "const": "d"
@@ -182,8 +194,14 @@ Binding 2:
     },
     "document_schema_json": {
       "if": {
+        "required": [
+          "_meta"
+        ],
         "properties": {
           "_meta": {
+            "required": [
+              "op"
+            ],
             "properties": {
               "op": {
                 "const": "d"
@@ -269,8 +287,14 @@ Binding 3:
     },
     "document_schema_json": {
       "if": {
+        "required": [
+          "_meta"
+        ],
         "properties": {
           "_meta": {
+            "required": [
+              "op"
+            ],
             "properties": {
               "op": {
                 "const": "d"
@@ -356,8 +380,14 @@ Binding 4:
     },
     "document_schema_json": {
       "if": {
+        "required": [
+          "_meta"
+        ],
         "properties": {
           "_meta": {
+            "required": [
+              "op"
+            ],
             "properties": {
               "op": {
                 "const": "d"
@@ -443,8 +473,14 @@ Binding 5:
     },
     "document_schema_json": {
       "if": {
+        "required": [
+          "_meta"
+        ],
         "properties": {
           "_meta": {
+            "required": [
+              "op"
+            ],
             "properties": {
               "op": {
                 "const": "d"

--- a/source-mongodb/.snapshots/TestDiscoverBatchCollections
+++ b/source-mongodb/.snapshots/TestDiscoverBatchCollections
@@ -8,8 +8,14 @@ Binding 0:
     },
     "document_schema_json": {
       "if": {
+        "required": [
+          "_meta"
+        ],
         "properties": {
           "_meta": {
+            "required": [
+              "op"
+            ],
             "properties": {
               "op": {
                 "const": "d"
@@ -97,8 +103,14 @@ Binding 1:
     },
     "document_schema_json": {
       "if": {
+        "required": [
+          "_meta"
+        ],
         "properties": {
           "_meta": {
+            "required": [
+              "op"
+            ],
             "properties": {
               "op": {
                 "const": "d"
@@ -185,8 +197,14 @@ Binding 2:
     },
     "document_schema_json": {
       "if": {
+        "required": [
+          "_meta"
+        ],
         "properties": {
           "_meta": {
+            "required": [
+              "op"
+            ],
             "properties": {
               "op": {
                 "const": "d"

--- a/source-mongodb/.snapshots/TestDiscoverMultipleDatabases
+++ b/source-mongodb/.snapshots/TestDiscoverMultipleDatabases
@@ -8,8 +8,14 @@ Binding 0:
     },
     "document_schema_json": {
       "if": {
+        "required": [
+          "_meta"
+        ],
         "properties": {
           "_meta": {
+            "required": [
+              "op"
+            ],
             "properties": {
               "op": {
                 "const": "d"
@@ -95,8 +101,14 @@ Binding 1:
     },
     "document_schema_json": {
       "if": {
+        "required": [
+          "_meta"
+        ],
         "properties": {
           "_meta": {
+            "required": [
+              "op"
+            ],
             "properties": {
               "op": {
                 "const": "d"
@@ -182,8 +194,14 @@ Binding 2:
     },
     "document_schema_json": {
       "if": {
+        "required": [
+          "_meta"
+        ],
         "properties": {
           "_meta": {
+            "required": [
+              "op"
+            ],
             "properties": {
               "op": {
                 "const": "d"
@@ -269,8 +287,14 @@ Binding 3:
     },
     "document_schema_json": {
       "if": {
+        "required": [
+          "_meta"
+        ],
         "properties": {
           "_meta": {
+            "required": [
+              "op"
+            ],
             "properties": {
               "op": {
                 "const": "d"

--- a/source-mongodb/discovery.go
+++ b/source-mongodb/discovery.go
@@ -87,9 +87,11 @@ func generateMinimalSchema() json.RawMessage {
 			"x-infer-schema": true,
 		},
 		If: &jsonschema.Schema{
+			Required: []string{"_meta"},
 			Extras: map[string]interface{}{
 				"properties": map[string]*jsonschema.Schema{
 					"_meta": {
+						Required: []string{"op"},
 						Extras: map[string]interface{}{
 							"properties": map[string]*jsonschema.Schema{
 								"op": {

--- a/source-mysql/.snapshots/TestAlterTable_AddEnumColumn-discover1
+++ b/source-mysql/.snapshots/TestAlterTable_AddEnumColumn-discover1
@@ -31,8 +31,14 @@ Binding 0:
       "allOf": [
         {
           "if": {
+            "required": [
+              "_meta"
+            ],
             "properties": {
               "_meta": {
+                "required": [
+                  "op"
+                ],
                 "properties": {
                   "op": {
                     "const": "d"

--- a/source-mysql/.snapshots/TestAlterTable_AddEnumColumn-discover2
+++ b/source-mysql/.snapshots/TestAlterTable_AddEnumColumn-discover2
@@ -45,8 +45,14 @@ Binding 0:
       "allOf": [
         {
           "if": {
+            "required": [
+              "_meta"
+            ],
             "properties": {
               "_meta": {
+                "required": [
+                  "op"
+                ],
                 "properties": {
                   "op": {
                     "const": "d"

--- a/source-mysql/.snapshots/TestAlterTable_AddUnsignedColumn-discover1
+++ b/source-mysql/.snapshots/TestAlterTable_AddUnsignedColumn-discover1
@@ -31,8 +31,14 @@ Binding 0:
       "allOf": [
         {
           "if": {
+            "required": [
+              "_meta"
+            ],
             "properties": {
               "_meta": {
+                "required": [
+                  "op"
+                ],
                 "properties": {
                   "op": {
                     "const": "d"

--- a/source-mysql/.snapshots/TestAlterTable_AddUnsignedColumn-discover2
+++ b/source-mysql/.snapshots/TestAlterTable_AddUnsignedColumn-discover2
@@ -38,8 +38,14 @@ Binding 0:
       "allOf": [
         {
           "if": {
+            "required": [
+              "_meta"
+            ],
             "properties": {
               "_meta": {
+                "required": [
+                  "op"
+                ],
                 "properties": {
                   "op": {
                     "const": "d"

--- a/source-mysql/.snapshots/TestAlterTable_RenameColumnCaseInsensitive-discover
+++ b/source-mysql/.snapshots/TestAlterTable_RenameColumnCaseInsensitive-discover
@@ -31,8 +31,14 @@ Binding 0:
       "allOf": [
         {
           "if": {
+            "required": [
+              "_meta"
+            ],
             "properties": {
               "_meta": {
+                "required": [
+                  "op"
+                ],
                 "properties": {
                   "op": {
                     "const": "d"

--- a/source-mysql/.snapshots/TestEmptyBlobs-Discovery
+++ b/source-mysql/.snapshots/TestEmptyBlobs-Discovery
@@ -35,8 +35,14 @@ Binding 0:
       "allOf": [
         {
           "if": {
+            "required": [
+              "_meta"
+            ],
             "properties": {
               "_meta": {
+                "required": [
+                  "op"
+                ],
                 "properties": {
                   "op": {
                     "const": "d"

--- a/source-mysql/.snapshots/TestEnumDecodingFix-discovery
+++ b/source-mysql/.snapshots/TestEnumDecodingFix-discovery
@@ -39,8 +39,14 @@ Binding 0:
       "allOf": [
         {
           "if": {
+            "required": [
+              "_meta"
+            ],
             "properties": {
               "_meta": {
+                "required": [
+                  "op"
+                ],
                 "properties": {
                   "op": {
                     "const": "d"

--- a/source-mysql/.snapshots/TestEnumEmptyString-discovery
+++ b/source-mysql/.snapshots/TestEnumEmptyString-discovery
@@ -39,8 +39,14 @@ Binding 0:
       "allOf": [
         {
           "if": {
+            "required": [
+              "_meta"
+            ],
             "properties": {
               "_meta": {
+                "required": [
+                  "op"
+                ],
                 "properties": {
                   "op": {
                     "const": "d"

--- a/source-mysql/.snapshots/TestEnumPrimaryKey-discovery
+++ b/source-mysql/.snapshots/TestEnumPrimaryKey-discovery
@@ -43,8 +43,14 @@ Binding 0:
       "allOf": [
         {
           "if": {
+            "required": [
+              "_meta"
+            ],
             "properties": {
               "_meta": {
+                "required": [
+                  "op"
+                ],
                 "properties": {
                   "op": {
                     "const": "d"

--- a/source-mysql/.snapshots/TestFeatureFlagTinyintAsBool-Default-Discovery
+++ b/source-mysql/.snapshots/TestFeatureFlagTinyintAsBool-Default-Discovery
@@ -38,8 +38,14 @@ Binding 0:
       "allOf": [
         {
           "if": {
+            "required": [
+              "_meta"
+            ],
             "properties": {
               "_meta": {
+                "required": [
+                  "op"
+                ],
                 "properties": {
                   "op": {
                     "const": "d"

--- a/source-mysql/.snapshots/TestFeatureFlagTinyintAsBool-Disabled-Discovery
+++ b/source-mysql/.snapshots/TestFeatureFlagTinyintAsBool-Disabled-Discovery
@@ -38,8 +38,14 @@ Binding 0:
       "allOf": [
         {
           "if": {
+            "required": [
+              "_meta"
+            ],
             "properties": {
               "_meta": {
+                "required": [
+                  "op"
+                ],
                 "properties": {
                   "op": {
                     "const": "d"

--- a/source-mysql/.snapshots/TestFeatureFlagTinyintAsBool-Enabled-Discovery
+++ b/source-mysql/.snapshots/TestFeatureFlagTinyintAsBool-Enabled-Discovery
@@ -38,8 +38,14 @@ Binding 0:
       "allOf": [
         {
           "if": {
+            "required": [
+              "_meta"
+            ],
             "properties": {
               "_meta": {
+                "required": [
+                  "op"
+                ],
                 "properties": {
                   "op": {
                     "const": "d"

--- a/source-mysql/.snapshots/TestGeneric-KeylessDiscovery
+++ b/source-mysql/.snapshots/TestGeneric-KeylessDiscovery
@@ -45,8 +45,14 @@ Binding 0:
       "allOf": [
         {
           "if": {
+            "required": [
+              "_meta"
+            ],
             "properties": {
               "_meta": {
+                "required": [
+                  "op"
+                ],
                 "properties": {
                   "op": {
                     "const": "d"

--- a/source-mysql/.snapshots/TestGeneric-SimpleDiscovery
+++ b/source-mysql/.snapshots/TestGeneric-SimpleDiscovery
@@ -44,8 +44,14 @@ Binding 0:
       "allOf": [
         {
           "if": {
+            "required": [
+              "_meta"
+            ],
             "properties": {
               "_meta": {
+                "required": [
+                  "op"
+                ],
                 "properties": {
                   "op": {
                     "const": "d"

--- a/source-mysql/.snapshots/TestMariaDBTypeUUID-discovery
+++ b/source-mysql/.snapshots/TestMariaDBTypeUUID-discovery
@@ -32,8 +32,14 @@ Binding 0:
       "allOf": [
         {
           "if": {
+            "required": [
+              "_meta"
+            ],
             "properties": {
               "_meta": {
+                "required": [
+                  "op"
+                ],
                 "properties": {
                   "op": {
                     "const": "d"

--- a/source-mysql/.snapshots/TestPartitionedTable-Discovery
+++ b/source-mysql/.snapshots/TestPartitionedTable-Discovery
@@ -36,8 +36,14 @@ Binding 0:
       "allOf": [
         {
           "if": {
+            "required": [
+              "_meta"
+            ],
             "properties": {
               "_meta": {
+                "required": [
+                  "op"
+                ],
                 "properties": {
                   "op": {
                     "const": "d"

--- a/source-mysql/.snapshots/TestSchemaWhitelist-Default
+++ b/source-mysql/.snapshots/TestSchemaWhitelist-Default
@@ -31,8 +31,14 @@ Binding 0:
       "allOf": [
         {
           "if": {
+            "required": [
+              "_meta"
+            ],
             "properties": {
               "_meta": {
+                "required": [
+                  "op"
+                ],
                 "properties": {
                   "op": {
                     "const": "d"

--- a/source-mysql/.snapshots/TestSchemaWhitelist-Included
+++ b/source-mysql/.snapshots/TestSchemaWhitelist-Included
@@ -31,8 +31,14 @@ Binding 0:
       "allOf": [
         {
           "if": {
+            "required": [
+              "_meta"
+            ],
             "properties": {
               "_meta": {
+                "required": [
+                  "op"
+                ],
                 "properties": {
                   "op": {
                     "const": "d"

--- a/source-mysql/.snapshots/TestSecondaryIndexDiscovery-index_and_fk
+++ b/source-mysql/.snapshots/TestSecondaryIndexDiscovery-index_and_fk
@@ -31,8 +31,14 @@ Binding 0:
       "allOf": [
         {
           "if": {
+            "required": [
+              "_meta"
+            ],
             "properties": {
               "_meta": {
+                "required": [
+                  "op"
+                ],
                 "properties": {
                   "op": {
                     "const": "d"

--- a/source-mysql/.snapshots/TestSecondaryIndexDiscovery-index_only
+++ b/source-mysql/.snapshots/TestSecondaryIndexDiscovery-index_only
@@ -43,8 +43,14 @@ Binding 0:
       "allOf": [
         {
           "if": {
+            "required": [
+              "_meta"
+            ],
             "properties": {
               "_meta": {
+                "required": [
+                  "op"
+                ],
                 "properties": {
                   "op": {
                     "const": "d"

--- a/source-mysql/.snapshots/TestSecondaryIndexDiscovery-nonunique_index
+++ b/source-mysql/.snapshots/TestSecondaryIndexDiscovery-nonunique_index
@@ -40,8 +40,14 @@ Binding 0:
       "allOf": [
         {
           "if": {
+            "required": [
+              "_meta"
+            ],
             "properties": {
               "_meta": {
+                "required": [
+                  "op"
+                ],
                 "properties": {
                   "op": {
                     "const": "d"

--- a/source-mysql/.snapshots/TestSecondaryIndexDiscovery-nothing
+++ b/source-mysql/.snapshots/TestSecondaryIndexDiscovery-nothing
@@ -40,8 +40,14 @@ Binding 0:
       "allOf": [
         {
           "if": {
+            "required": [
+              "_meta"
+            ],
             "properties": {
               "_meta": {
+                "required": [
+                  "op"
+                ],
                 "properties": {
                   "op": {
                     "const": "d"

--- a/source-mysql/.snapshots/TestSecondaryIndexDiscovery-nullable_index
+++ b/source-mysql/.snapshots/TestSecondaryIndexDiscovery-nullable_index
@@ -46,8 +46,14 @@ Binding 0:
       "allOf": [
         {
           "if": {
+            "required": [
+              "_meta"
+            ],
             "properties": {
               "_meta": {
+                "required": [
+                  "op"
+                ],
                 "properties": {
                   "op": {
                     "const": "d"

--- a/source-mysql/.snapshots/TestSecondaryIndexDiscovery-pk_and_index
+++ b/source-mysql/.snapshots/TestSecondaryIndexDiscovery-pk_and_index
@@ -39,8 +39,14 @@ Binding 0:
       "allOf": [
         {
           "if": {
+            "required": [
+              "_meta"
+            ],
             "properties": {
               "_meta": {
+                "required": [
+                  "op"
+                ],
                 "properties": {
                   "op": {
                     "const": "d"

--- a/source-mysql/.snapshots/TestSpatialTypes-Discovery
+++ b/source-mysql/.snapshots/TestSpatialTypes-Discovery
@@ -52,8 +52,14 @@ Binding 0:
       "allOf": [
         {
           "if": {
+            "required": [
+              "_meta"
+            ],
             "properties": {
               "_meta": {
+                "required": [
+                  "op"
+                ],
                 "properties": {
                   "op": {
                     "const": "d"

--- a/source-mysql/.snapshots/TestTableNamesIdenticalUnderCapitalization-Discover
+++ b/source-mysql/.snapshots/TestTableNamesIdenticalUnderCapitalization-Discover
@@ -38,8 +38,14 @@ Binding 0:
       "allOf": [
         {
           "if": {
+            "required": [
+              "_meta"
+            ],
             "properties": {
               "_meta": {
+                "required": [
+                  "op"
+                ],
                 "properties": {
                   "op": {
                     "const": "d"
@@ -167,8 +173,14 @@ Binding 1:
       "allOf": [
         {
           "if": {
+            "required": [
+              "_meta"
+            ],
             "properties": {
               "_meta": {
+                "required": [
+                  "op"
+                ],
                 "properties": {
                   "op": {
                     "const": "d"

--- a/source-mysql/.snapshots/TestTrickyColumnNames-discover
+++ b/source-mysql/.snapshots/TestTrickyColumnNames-discover
@@ -31,8 +31,14 @@ Binding 0:
       "allOf": [
         {
           "if": {
+            "required": [
+              "_meta"
+            ],
             "properties": {
               "_meta": {
+                "required": [
+                  "op"
+                ],
                 "properties": {
                   "op": {
                     "const": "d"
@@ -163,8 +169,14 @@ Binding 1:
       "allOf": [
         {
           "if": {
+            "required": [
+              "_meta"
+            ],
             "properties": {
               "_meta": {
+                "required": [
+                  "op"
+                ],
                 "properties": {
                   "op": {
                     "const": "d"

--- a/source-mysql/.snapshots/TestTrickyEnumValues
+++ b/source-mysql/.snapshots/TestTrickyEnumValues
@@ -45,8 +45,14 @@ Binding 0:
       "allOf": [
         {
           "if": {
+            "required": [
+              "_meta"
+            ],
             "properties": {
               "_meta": {
+                "required": [
+                  "op"
+                ],
                 "properties": {
                   "op": {
                     "const": "d"

--- a/source-mysql/.snapshots/TestTrickyTableNames-Discover
+++ b/source-mysql/.snapshots/TestTrickyTableNames-Discover
@@ -28,8 +28,14 @@ Binding 0:
       "allOf": [
         {
           "if": {
+            "required": [
+              "_meta"
+            ],
             "properties": {
               "_meta": {
+                "required": [
+                  "op"
+                ],
                 "properties": {
                   "op": {
                     "const": "d"

--- a/source-mysql/.snapshots/TestUnsignedIntegers-discovery
+++ b/source-mysql/.snapshots/TestUnsignedIntegers-discovery
@@ -59,8 +59,14 @@ Binding 0:
       "allOf": [
         {
           "if": {
+            "required": [
+              "_meta"
+            ],
             "properties": {
               "_meta": {
+                "required": [
+                  "op"
+                ],
                 "properties": {
                   "op": {
                     "const": "d"

--- a/source-oracle/.snapshots/TestAllTypes-discover
+++ b/source-oracle/.snapshots/TestAllTypes-discover
@@ -195,8 +195,14 @@ Binding 0:
       "allOf": [
         {
           "if": {
+            "required": [
+              "_meta"
+            ],
             "properties": {
               "_meta": {
+                "required": [
+                  "op"
+                ],
                 "properties": {
                   "op": {
                     "const": "d"

--- a/source-oracle/.snapshots/TestBareNumberKey-discover
+++ b/source-oracle/.snapshots/TestBareNumberKey-discover
@@ -25,8 +25,14 @@ Binding 0:
       "allOf": [
         {
           "if": {
+            "required": [
+              "_meta"
+            ],
             "properties": {
               "_meta": {
+                "required": [
+                  "op"
+                ],
                 "properties": {
                   "op": {
                     "const": "d"

--- a/source-oracle/.snapshots/TestCapitalizedTables-Discover
+++ b/source-oracle/.snapshots/TestCapitalizedTables-Discover
@@ -29,8 +29,14 @@ Binding 0:
       "allOf": [
         {
           "if": {
+            "required": [
+              "_meta"
+            ],
             "properties": {
               "_meta": {
+                "required": [
+                  "op"
+                ],
                 "properties": {
                   "op": {
                     "const": "d"

--- a/source-oracle/.snapshots/TestGeneric-KeylessDiscovery
+++ b/source-oracle/.snapshots/TestGeneric-KeylessDiscovery
@@ -45,8 +45,14 @@ Binding 0:
       "allOf": [
         {
           "if": {
+            "required": [
+              "_meta"
+            ],
             "properties": {
               "_meta": {
+                "required": [
+                  "op"
+                ],
                 "properties": {
                   "op": {
                     "const": "d"

--- a/source-oracle/.snapshots/TestGeneric-SimpleDiscovery
+++ b/source-oracle/.snapshots/TestGeneric-SimpleDiscovery
@@ -44,8 +44,14 @@ Binding 0:
       "allOf": [
         {
           "if": {
+            "required": [
+              "_meta"
+            ],
             "properties": {
               "_meta": {
+                "required": [
+                  "op"
+                ],
                 "properties": {
                   "op": {
                     "const": "d"

--- a/source-oracle/.snapshots/TestIntegerKey-discover
+++ b/source-oracle/.snapshots/TestIntegerKey-discover
@@ -25,8 +25,14 @@ Binding 0:
       "allOf": [
         {
           "if": {
+            "required": [
+              "_meta"
+            ],
             "properties": {
               "_meta": {
+                "required": [
+                  "op"
+                ],
                 "properties": {
                   "op": {
                     "const": "d"

--- a/source-oracle/.snapshots/TestNullValues-discover
+++ b/source-oracle/.snapshots/TestNullValues-discover
@@ -182,8 +182,14 @@ Binding 0:
       "allOf": [
         {
           "if": {
+            "required": [
+              "_meta"
+            ],
             "properties": {
               "_meta": {
+                "required": [
+                  "op"
+                ],
                 "properties": {
                   "op": {
                     "const": "d"

--- a/source-oracle/.snapshots/TestStringKey-discover
+++ b/source-oracle/.snapshots/TestStringKey-discover
@@ -26,8 +26,14 @@ Binding 0:
       "allOf": [
         {
           "if": {
+            "required": [
+              "_meta"
+            ],
             "properties": {
               "_meta": {
+                "required": [
+                  "op"
+                ],
                 "properties": {
                   "op": {
                     "const": "d"

--- a/source-oracle/.snapshots/TestTrickyColumnNames-discover
+++ b/source-oracle/.snapshots/TestTrickyColumnNames-discover
@@ -32,8 +32,14 @@ Binding 0:
       "allOf": [
         {
           "if": {
+            "required": [
+              "_meta"
+            ],
             "properties": {
               "_meta": {
+                "required": [
+                  "op"
+                ],
                 "properties": {
                   "op": {
                     "const": "d"
@@ -175,8 +181,14 @@ Binding 1:
       "allOf": [
         {
           "if": {
+            "required": [
+              "_meta"
+            ],
             "properties": {
               "_meta": {
+                "required": [
+                  "op"
+                ],
                 "properties": {
                   "op": {
                     "const": "d"

--- a/source-oracle/.snapshots/TestUnsupportedTypes-discover
+++ b/source-oracle/.snapshots/TestUnsupportedTypes-discover
@@ -25,8 +25,14 @@ Binding 0:
       "allOf": [
         {
           "if": {
+            "required": [
+              "_meta"
+            ],
             "properties": {
               "_meta": {
+                "required": [
+                  "op"
+                ],
                 "properties": {
                   "op": {
                     "const": "d"

--- a/source-postgres/.snapshots/TestCIText
+++ b/source-postgres/.snapshots/TestCIText
@@ -45,8 +45,14 @@ sql> CREATE TABLE test.citext_675587 (id INTEGER PRIMARY KEY, data CITEXT, arr C
     "allOf": [
       {
         "if": {
+          "required": [
+            "_meta"
+          ],
           "properties": {
             "_meta": {
+              "required": [
+                "op"
+              ],
               "properties": {
                 "op": {
                   "const": "d"

--- a/source-postgres/.snapshots/TestCaptureAsPartitions
+++ b/source-postgres/.snapshots/TestCaptureAsPartitions
@@ -37,8 +37,14 @@ sql> CREATE TABLE test.captureaspartitions_274513_2023q4 PARTITION OF test.captu
     "allOf": [
       {
         "if": {
+          "required": [
+            "_meta"
+          ],
           "properties": {
             "_meta": {
+              "required": [
+                "op"
+              ],
               "properties": {
                 "op": {
                   "const": "d"
@@ -173,8 +179,14 @@ sql> CREATE TABLE test.captureaspartitions_274513_2023q4 PARTITION OF test.captu
     "allOf": [
       {
         "if": {
+          "required": [
+            "_meta"
+          ],
           "properties": {
             "_meta": {
+              "required": [
+                "op"
+              ],
               "properties": {
                 "op": {
                   "const": "d"
@@ -309,8 +321,14 @@ sql> CREATE TABLE test.captureaspartitions_274513_2023q4 PARTITION OF test.captu
     "allOf": [
       {
         "if": {
+          "required": [
+            "_meta"
+          ],
           "properties": {
             "_meta": {
+              "required": [
+                "op"
+              ],
               "properties": {
                 "op": {
                   "const": "d"
@@ -445,8 +463,14 @@ sql> CREATE TABLE test.captureaspartitions_274513_2023q4 PARTITION OF test.captu
     "allOf": [
       {
         "if": {
+          "required": [
+            "_meta"
+          ],
           "properties": {
             "_meta": {
+              "required": [
+                "op"
+              ],
               "properties": {
                 "op": {
                   "const": "d"

--- a/source-postgres/.snapshots/TestCaptureAsPartitionsMixed
+++ b/source-postgres/.snapshots/TestCaptureAsPartitionsMixed
@@ -36,8 +36,14 @@ sql> CREATE TABLE test.captureaspartitionsmixed_611041_parted_h2 PARTITION OF te
     "allOf": [
       {
         "if": {
+          "required": [
+            "_meta"
+          ],
           "properties": {
             "_meta": {
+              "required": [
+                "op"
+              ],
               "properties": {
                 "op": {
                   "const": "d"
@@ -172,8 +178,14 @@ sql> CREATE TABLE test.captureaspartitionsmixed_611041_parted_h2 PARTITION OF te
     "allOf": [
       {
         "if": {
+          "required": [
+            "_meta"
+          ],
           "properties": {
             "_meta": {
+              "required": [
+                "op"
+              ],
               "properties": {
                 "op": {
                   "const": "d"
@@ -307,8 +319,14 @@ sql> CREATE TABLE test.captureaspartitionsmixed_611041_parted_h2 PARTITION OF te
     "allOf": [
       {
         "if": {
+          "required": [
+            "_meta"
+          ],
           "properties": {
             "_meta": {
+              "required": [
+                "op"
+              ],
               "properties": {
                 "op": {
                   "const": "d"

--- a/source-postgres/.snapshots/TestCaptureAsPartitionsSubpartitioned
+++ b/source-postgres/.snapshots/TestCaptureAsPartitionsSubpartitioned
@@ -44,8 +44,14 @@ sql> CREATE TABLE test.captureaspartitionssubpartitioned_416337_h2_west PARTITIO
     "allOf": [
       {
         "if": {
+          "required": [
+            "_meta"
+          ],
           "properties": {
             "_meta": {
+              "required": [
+                "op"
+              ],
               "properties": {
                 "op": {
                   "const": "d"
@@ -186,8 +192,14 @@ sql> CREATE TABLE test.captureaspartitionssubpartitioned_416337_h2_west PARTITIO
     "allOf": [
       {
         "if": {
+          "required": [
+            "_meta"
+          ],
           "properties": {
             "_meta": {
+              "required": [
+                "op"
+              ],
               "properties": {
                 "op": {
                   "const": "d"
@@ -328,8 +340,14 @@ sql> CREATE TABLE test.captureaspartitionssubpartitioned_416337_h2_west PARTITIO
     "allOf": [
       {
         "if": {
+          "required": [
+            "_meta"
+          ],
           "properties": {
             "_meta": {
+              "required": [
+                "op"
+              ],
               "properties": {
                 "op": {
                   "const": "d"
@@ -470,8 +488,14 @@ sql> CREATE TABLE test.captureaspartitionssubpartitioned_416337_h2_west PARTITIO
     "allOf": [
       {
         "if": {
+          "required": [
+            "_meta"
+          ],
           "properties": {
             "_meta": {
+              "required": [
+                "op"
+              ],
               "properties": {
                 "op": {
                   "const": "d"

--- a/source-postgres/.snapshots/TestDiscoveryComplex
+++ b/source-postgres/.snapshots/TestDiscoveryComplex
@@ -70,8 +70,14 @@ sql> COMMENT ON COLUMN test.discoverycomplex_934635.k1 IS 'I think this is a key
     "allOf": [
       {
         "if": {
+          "required": [
+            "_meta"
+          ],
           "properties": {
             "_meta": {
+              "required": [
+                "op"
+              ],
               "properties": {
                 "op": {
                   "const": "d"

--- a/source-postgres/.snapshots/TestDiscoveryWithoutPermissions
+++ b/source-postgres/.snapshots/TestDiscoveryWithoutPermissions
@@ -32,8 +32,14 @@ sql> CREATE TABLE public.tbl419033 (id INTEGER PRIMARY KEY, data TEXT)
     "allOf": [
       {
         "if": {
+          "required": [
+            "_meta"
+          ],
           "properties": {
             "_meta": {
+              "required": [
+                "op"
+              ],
               "properties": {
                 "op": {
                   "const": "d"

--- a/source-postgres/.snapshots/TestFeatureFlagFlattenArrays-Disabled
+++ b/source-postgres/.snapshots/TestFeatureFlagFlattenArrays-Disabled
@@ -117,8 +117,14 @@ sql> INSERT INTO test.featureflagflattenarrays_disabled_688545 VALUES
     "allOf": [
       {
         "if": {
+          "required": [
+            "_meta"
+          ],
           "properties": {
             "_meta": {
+              "required": [
+                "op"
+              ],
               "properties": {
                 "op": {
                   "const": "d"

--- a/source-postgres/.snapshots/TestFeatureFlagFlattenArrays-Enabled
+++ b/source-postgres/.snapshots/TestFeatureFlagFlattenArrays-Enabled
@@ -69,8 +69,14 @@ sql> INSERT INTO test.featureflagflattenarrays_enabled_602988 VALUES
     "allOf": [
       {
         "if": {
+          "required": [
+            "_meta"
+          ],
           "properties": {
             "_meta": {
+              "required": [
+                "op"
+              ],
               "properties": {
                 "op": {
                   "const": "d"

--- a/source-postgres/.snapshots/TestFloatKeyDiscovery
+++ b/source-postgres/.snapshots/TestFloatKeyDiscovery
@@ -35,8 +35,14 @@ sql> CREATE TABLE test.floatkeydiscovery_109173 (id DOUBLE PRECISION PRIMARY KEY
     "allOf": [
       {
         "if": {
+          "required": [
+            "_meta"
+          ],
           "properties": {
             "_meta": {
+              "required": [
+                "op"
+              ],
               "properties": {
                 "op": {
                   "const": "d"

--- a/source-postgres/.snapshots/TestGeneratedColumn
+++ b/source-postgres/.snapshots/TestGeneratedColumn
@@ -41,8 +41,14 @@ sql> CREATE TABLE test.generatedcolumn_136230 (id INTEGER PRIMARY KEY, a VARCHAR
     "allOf": [
       {
         "if": {
+          "required": [
+            "_meta"
+          ],
           "properties": {
             "_meta": {
+              "required": [
+                "op"
+              ],
               "properties": {
                 "op": {
                   "const": "d"

--- a/source-postgres/.snapshots/TestKeylessDiscovery
+++ b/source-postgres/.snapshots/TestKeylessDiscovery
@@ -50,8 +50,14 @@ sql> CREATE TABLE test.keylessdiscovery_729953 (a INTEGER, b VARCHAR(2000), c RE
     "allOf": [
       {
         "if": {
+          "required": [
+            "_meta"
+          ],
           "properties": {
             "_meta": {
+              "required": [
+                "op"
+              ],
               "properties": {
                 "op": {
                   "const": "d"

--- a/source-postgres/.snapshots/TestMultidimensionalArrays
+++ b/source-postgres/.snapshots/TestMultidimensionalArrays
@@ -32,8 +32,14 @@ sql> CREATE TABLE test.multidimensionalarrays_911995 (id INTEGER PRIMARY KEY, ar
     "allOf": [
       {
         "if": {
+          "required": [
+            "_meta"
+          ],
           "properties": {
             "_meta": {
+              "required": [
+                "op"
+              ],
               "properties": {
                 "op": {
                   "const": "d"

--- a/source-postgres/.snapshots/TestPartitionedTableDiscovery
+++ b/source-postgres/.snapshots/TestPartitionedTableDiscovery
@@ -37,8 +37,14 @@ sql> CREATE TABLE test.partitionedtablediscovery_242722_2023q4 PARTITION OF test
     "allOf": [
       {
         "if": {
+          "required": [
+            "_meta"
+          ],
           "properties": {
             "_meta": {
+              "required": [
+                "op"
+              ],
               "properties": {
                 "op": {
                   "const": "d"

--- a/source-postgres/.snapshots/TestSecondaryIndexDiscovery-index_only
+++ b/source-postgres/.snapshots/TestSecondaryIndexDiscovery-index_only
@@ -45,8 +45,14 @@ sql> CREATE UNIQUE INDEX idx693037_k23 ON test.tbl693037 (k2, k3)
     "allOf": [
       {
         "if": {
+          "required": [
+            "_meta"
+          ],
           "properties": {
             "_meta": {
+              "required": [
+                "op"
+              ],
               "properties": {
                 "op": {
                   "const": "d"

--- a/source-postgres/.snapshots/TestSecondaryIndexDiscovery-nonunique_index
+++ b/source-postgres/.snapshots/TestSecondaryIndexDiscovery-nonunique_index
@@ -42,8 +42,14 @@ sql> CREATE INDEX idx591008_k23 ON test.tbl591008 (k2, k3)
     "allOf": [
       {
         "if": {
+          "required": [
+            "_meta"
+          ],
           "properties": {
             "_meta": {
+              "required": [
+                "op"
+              ],
               "properties": {
                 "op": {
                   "const": "d"

--- a/source-postgres/.snapshots/TestSecondaryIndexDiscovery-nothing
+++ b/source-postgres/.snapshots/TestSecondaryIndexDiscovery-nothing
@@ -41,8 +41,14 @@ sql> CREATE TABLE test.tbl237250 (k1 INTEGER, k2 INTEGER NOT NULL, k3 INTEGER NO
     "allOf": [
       {
         "if": {
+          "required": [
+            "_meta"
+          ],
           "properties": {
             "_meta": {
+              "required": [
+                "op"
+              ],
               "properties": {
                 "op": {
                   "const": "d"

--- a/source-postgres/.snapshots/TestSecondaryIndexDiscovery-nullable_index
+++ b/source-postgres/.snapshots/TestSecondaryIndexDiscovery-nullable_index
@@ -48,8 +48,14 @@ sql> CREATE UNIQUE INDEX idx892285_k23 ON test.tbl892285 (k2, k3)
     "allOf": [
       {
         "if": {
+          "required": [
+            "_meta"
+          ],
           "properties": {
             "_meta": {
+              "required": [
+                "op"
+              ],
               "properties": {
                 "op": {
                   "const": "d"

--- a/source-postgres/.snapshots/TestSecondaryIndexDiscovery-pk_and_index
+++ b/source-postgres/.snapshots/TestSecondaryIndexDiscovery-pk_and_index
@@ -41,8 +41,14 @@ sql> CREATE UNIQUE INDEX idx954884_k23 ON test.tbl954884 (k2, k3)
     "allOf": [
       {
         "if": {
+          "required": [
+            "_meta"
+          ],
           "properties": {
             "_meta": {
+              "required": [
+                "op"
+              ],
               "properties": {
                 "op": {
                   "const": "d"

--- a/source-postgres/.snapshots/TestSimpleDiscovery
+++ b/source-postgres/.snapshots/TestSimpleDiscovery
@@ -49,8 +49,14 @@ sql> CREATE TABLE test.simplediscovery_838908 (a INTEGER PRIMARY KEY, b VARCHAR(
     "allOf": [
       {
         "if": {
+          "required": [
+            "_meta"
+          ],
           "properties": {
             "_meta": {
+              "required": [
+                "op"
+              ],
               "properties": {
                 "op": {
                   "const": "d"

--- a/source-postgres/.snapshots/TestUserTypes-Domain
+++ b/source-postgres/.snapshots/TestUserTypes-Domain
@@ -33,8 +33,14 @@ sql> CREATE TABLE test.usertypes_domain_245097 (id INTEGER PRIMARY KEY, value Us
     "allOf": [
       {
         "if": {
+          "required": [
+            "_meta"
+          ],
           "properties": {
             "_meta": {
+              "required": [
+                "op"
+              ],
               "properties": {
                 "op": {
                   "const": "d"

--- a/source-postgres/.snapshots/TestUserTypes-Enum
+++ b/source-postgres/.snapshots/TestUserTypes-Enum
@@ -33,8 +33,14 @@ sql> CREATE TABLE test.usertypes_enum_211653 (id INTEGER PRIMARY KEY, value User
     "allOf": [
       {
         "if": {
+          "required": [
+            "_meta"
+          ],
           "properties": {
             "_meta": {
+              "required": [
+                "op"
+              ],
               "properties": {
                 "op": {
                   "const": "d"

--- a/source-postgres/.snapshots/TestUserTypes-Range
+++ b/source-postgres/.snapshots/TestUserTypes-Range
@@ -33,8 +33,14 @@ sql> CREATE TABLE test.usertypes_range_933528 (id INTEGER PRIMARY KEY, value Use
     "allOf": [
       {
         "if": {
+          "required": [
+            "_meta"
+          ],
           "properties": {
             "_meta": {
+              "required": [
+                "op"
+              ],
               "properties": {
                 "op": {
                   "const": "d"

--- a/source-postgres/.snapshots/TestUserTypes-Tuple
+++ b/source-postgres/.snapshots/TestUserTypes-Tuple
@@ -29,8 +29,14 @@ sql> CREATE TABLE test.usertypes_tuple_223541 (id INTEGER PRIMARY KEY, value Use
     "allOf": [
       {
         "if": {
+          "required": [
+            "_meta"
+          ],
           "properties": {
             "_meta": {
+              "required": [
+                "op"
+              ],
               "properties": {
                 "op": {
                   "const": "d"

--- a/source-snowflake/.snapshots/TestBasicDatatypes-discover
+++ b/source-snowflake/.snapshots/TestBasicDatatypes-discover
@@ -60,8 +60,14 @@ Binding 0:
       "allOf": [
         {
           "if": {
+            "required": [
+              "_meta"
+            ],
             "properties": {
               "_meta": {
+                "required": [
+                  "op"
+                ],
                 "properties": {
                   "op": {
                     "const": "d"

--- a/source-snowflake/.snapshots/TestDiscoveryMultiplePrimaryKeys
+++ b/source-snowflake/.snapshots/TestDiscoveryMultiplePrimaryKeys
@@ -37,8 +37,14 @@ Binding 0:
       "allOf": [
         {
           "if": {
+            "required": [
+              "_meta"
+            ],
             "properties": {
               "_meta": {
+                "required": [
+                  "op"
+                ],
                 "properties": {
                   "op": {
                     "const": "d"

--- a/source-snowflake/.snapshots/TestDiscoveryWithPrimaryKey
+++ b/source-snowflake/.snapshots/TestDiscoveryWithPrimaryKey
@@ -38,8 +38,14 @@ Binding 0:
       "allOf": [
         {
           "if": {
+            "required": [
+              "_meta"
+            ],
             "properties": {
               "_meta": {
+                "required": [
+                  "op"
+                ],
                 "properties": {
                   "op": {
                     "const": "d"

--- a/source-snowflake/.snapshots/TestDiscoveryWithoutPrimaryKey
+++ b/source-snowflake/.snapshots/TestDiscoveryWithoutPrimaryKey
@@ -38,8 +38,14 @@ Binding 0:
       "allOf": [
         {
           "if": {
+            "required": [
+              "_meta"
+            ],
             "properties": {
               "_meta": {
+                "required": [
+                  "op"
+                ],
                 "properties": {
                   "op": {
                     "const": "d"

--- a/source-snowflake/.snapshots/TestDynamicTable-discovery
+++ b/source-snowflake/.snapshots/TestDynamicTable-discovery
@@ -26,8 +26,14 @@ Binding 0:
       "allOf": [
         {
           "if": {
+            "required": [
+              "_meta"
+            ],
             "properties": {
               "_meta": {
+                "required": [
+                  "op"
+                ],
                 "properties": {
                   "op": {
                     "const": "d"

--- a/source-snowflake/.snapshots/TestTimestampDatatypes-discover
+++ b/source-snowflake/.snapshots/TestTimestampDatatypes-discover
@@ -45,8 +45,14 @@ Binding 0:
       "allOf": [
         {
           "if": {
+            "required": [
+              "_meta"
+            ],
             "properties": {
               "_meta": {
+                "required": [
+                  "op"
+                ],
                 "properties": {
                   "op": {
                     "const": "d"

--- a/source-snowflake/.snapshots/TestVariantDatatypes-discover
+++ b/source-snowflake/.snapshots/TestVariantDatatypes-discover
@@ -30,8 +30,14 @@ Binding 0:
       "allOf": [
         {
           "if": {
+            "required": [
+              "_meta"
+            ],
             "properties": {
               "_meta": {
+                "required": [
+                  "op"
+                ],
                 "properties": {
                   "op": {
                     "const": "d"

--- a/source-snowflake/discovery.go
+++ b/source-snowflake/discovery.go
@@ -341,9 +341,11 @@ func schemaFromDiscovery(info *snowflakeDiscoveryInfo) (json.RawMessage, error) 
 				},
 				Required: []string{metadataProperty},
 				If: &jsonschema.Schema{
+					Required: []string{"_meta"},
 					Extras: map[string]interface{}{
 						"properties": map[string]*jsonschema.Schema{
 							"_meta": {
+								Required: []string{"op"},
 								Extras: map[string]interface{}{
 									"properties": map[string]*jsonschema.Schema{
 										"op": {

--- a/source-sqlserver-ct/.snapshots/TestBasics-SimpleDiscovery
+++ b/source-sqlserver-ct/.snapshots/TestBasics-SimpleDiscovery
@@ -45,8 +45,14 @@ sql> CREATE TABLE dbo.Basics_SimpleDiscovery_891380 (a INTEGER PRIMARY KEY, b VA
     "allOf": [
       {
         "if": {
+          "required": [
+            "_meta"
+          ],
           "properties": {
             "_meta": {
+              "required": [
+                "op"
+              ],
               "properties": {
                 "op": {
                   "const": "d"

--- a/source-sqlserver-ct/.snapshots/TestCapture-ComputedColumn
+++ b/source-sqlserver-ct/.snapshots/TestCapture-ComputedColumn
@@ -46,8 +46,14 @@ sql> CREATE TABLE dbo.Capture_ComputedColumn_345410 (id INTEGER PRIMARY KEY, a V
     "allOf": [
       {
         "if": {
+          "required": [
+            "_meta"
+          ],
           "properties": {
             "_meta": {
+              "required": [
+                "op"
+              ],
               "properties": {
                 "op": {
                   "const": "d"

--- a/source-sqlserver-ct/.snapshots/TestCapture-ComputedPrimaryKey
+++ b/source-sqlserver-ct/.snapshots/TestCapture-ComputedPrimaryKey
@@ -37,8 +37,14 @@ sql> CREATE TABLE dbo.Capture_ComputedPrimaryKey_812546 (actual_id INTEGER NOT N
     "allOf": [
       {
         "if": {
+          "required": [
+            "_meta"
+          ],
           "properties": {
             "_meta": {
+              "required": [
+                "op"
+              ],
               "properties": {
                 "op": {
                   "const": "d"

--- a/source-sqlserver-ct/.snapshots/TestCapture-DiscoveryIrrelevantConstraints
+++ b/source-sqlserver-ct/.snapshots/TestCapture-DiscoveryIrrelevantConstraints
@@ -40,8 +40,14 @@ sql> CREATE TABLE dbo.Capture_DiscoveryIrrelevantConstraints_771648 (id VARCHAR(
     "allOf": [
       {
         "if": {
+          "required": [
+            "_meta"
+          ],
           "properties": {
             "_meta": {
+              "required": [
+                "op"
+              ],
               "properties": {
                 "op": {
                   "const": "d"

--- a/source-sqlserver-ct/.snapshots/TestCollation-VarcharKeyDiscovery
+++ b/source-sqlserver-ct/.snapshots/TestCollation-VarcharKeyDiscovery
@@ -33,8 +33,14 @@ sql> CREATE TABLE dbo.Collation_VarcharKeyDiscovery_989577 (id VARCHAR(32) PRIMA
     "allOf": [
       {
         "if": {
+          "required": [
+            "_meta"
+          ],
           "properties": {
             "_meta": {
+              "required": [
+                "op"
+              ],
               "properties": {
                 "op": {
                   "const": "d"

--- a/source-sqlserver-ct/.snapshots/TestDatatypes-RowversionTypes-rowversion
+++ b/source-sqlserver-ct/.snapshots/TestDatatypes-RowversionTypes-rowversion
@@ -38,8 +38,14 @@ sql> CREATE TABLE dbo.Datatypes_RowversionTypes_rowversion_318641 (id INTEGER PR
     "allOf": [
       {
         "if": {
+          "required": [
+            "_meta"
+          ],
           "properties": {
             "_meta": {
+              "required": [
+                "op"
+              ],
               "properties": {
                 "op": {
                   "const": "d"

--- a/source-sqlserver-ct/.snapshots/TestDatatypes-RowversionTypes-timestamp
+++ b/source-sqlserver-ct/.snapshots/TestDatatypes-RowversionTypes-timestamp
@@ -38,8 +38,14 @@ sql> CREATE TABLE dbo.Datatypes_RowversionTypes_timestamp_404369 (id INTEGER PRI
     "allOf": [
       {
         "if": {
+          "required": [
+            "_meta"
+          ],
           "properties": {
             "_meta": {
+              "required": [
+                "op"
+              ],
               "properties": {
                 "op": {
                   "const": "d"

--- a/source-sqlserver/.snapshots/TestBasics-SimpleDiscovery
+++ b/source-sqlserver/.snapshots/TestBasics-SimpleDiscovery
@@ -45,8 +45,14 @@ sql> CREATE TABLE dbo.Basics_SimpleDiscovery_891380 (a INTEGER PRIMARY KEY, b VA
     "allOf": [
       {
         "if": {
+          "required": [
+            "_meta"
+          ],
           "properties": {
             "_meta": {
+              "required": [
+                "op"
+              ],
               "properties": {
                 "op": {
                   "const": "d"

--- a/source-sqlserver/.snapshots/TestCapture-ComputedColumn
+++ b/source-sqlserver/.snapshots/TestCapture-ComputedColumn
@@ -41,8 +41,14 @@ sql> CREATE TABLE dbo.Capture_ComputedColumn_345410 (id INTEGER PRIMARY KEY, a V
     "allOf": [
       {
         "if": {
+          "required": [
+            "_meta"
+          ],
           "properties": {
             "_meta": {
+              "required": [
+                "op"
+              ],
               "properties": {
                 "op": {
                   "const": "d"

--- a/source-sqlserver/.snapshots/TestCapture-ComputedPrimaryKey
+++ b/source-sqlserver/.snapshots/TestCapture-ComputedPrimaryKey
@@ -31,8 +31,14 @@ sql> CREATE TABLE dbo.Capture_ComputedPrimaryKey_812546 (actual_id INTEGER NOT N
     "allOf": [
       {
         "if": {
+          "required": [
+            "_meta"
+          ],
           "properties": {
             "_meta": {
+              "required": [
+                "op"
+              ],
               "properties": {
                 "op": {
                   "const": "d"

--- a/source-sqlserver/.snapshots/TestCapture-DiscoveryIrrelevantConstraints
+++ b/source-sqlserver/.snapshots/TestCapture-DiscoveryIrrelevantConstraints
@@ -40,8 +40,14 @@ sql> CREATE TABLE dbo.Capture_DiscoveryIrrelevantConstraints_771648 (id VARCHAR(
     "allOf": [
       {
         "if": {
+          "required": [
+            "_meta"
+          ],
           "properties": {
             "_meta": {
+              "required": [
+                "op"
+              ],
               "properties": {
                 "op": {
                   "const": "d"

--- a/source-sqlserver/.snapshots/TestCollation-VarcharKeyDiscovery
+++ b/source-sqlserver/.snapshots/TestCollation-VarcharKeyDiscovery
@@ -33,8 +33,14 @@ sql> CREATE TABLE dbo.Collation_VarcharKeyDiscovery_989577 (id VARCHAR(32) PRIMA
     "allOf": [
       {
         "if": {
+          "required": [
+            "_meta"
+          ],
           "properties": {
             "_meta": {
+              "required": [
+                "op"
+              ],
               "properties": {
                 "op": {
                   "const": "d"

--- a/source-sqlserver/.snapshots/TestDatatypes-RowversionTypes-rowversion
+++ b/source-sqlserver/.snapshots/TestDatatypes-RowversionTypes-rowversion
@@ -38,8 +38,14 @@ sql> CREATE TABLE dbo.Datatypes_RowversionTypes_rowversion_318641 (id INTEGER PR
     "allOf": [
       {
         "if": {
+          "required": [
+            "_meta"
+          ],
           "properties": {
             "_meta": {
+              "required": [
+                "op"
+              ],
               "properties": {
                 "op": {
                   "const": "d"

--- a/source-sqlserver/.snapshots/TestDatatypes-RowversionTypes-timestamp
+++ b/source-sqlserver/.snapshots/TestDatatypes-RowversionTypes-timestamp
@@ -38,8 +38,14 @@ sql> CREATE TABLE dbo.Datatypes_RowversionTypes_timestamp_404369 (id INTEGER PRI
     "allOf": [
       {
         "if": {
+          "required": [
+            "_meta"
+          ],
           "properties": {
             "_meta": {
+              "required": [
+                "op"
+              ],
               "properties": {
                 "op": {
                   "const": "d"

--- a/source-sqlserver/.snapshots/TestIndexIncludedDiscovery
+++ b/source-sqlserver/.snapshots/TestIndexIncludedDiscovery
@@ -45,8 +45,14 @@ sql> CREATE UNIQUE INDEX UX_312546_k23 ON dbo.IndexIncludedDiscovery_312546 (k2,
     "allOf": [
       {
         "if": {
+          "required": [
+            "_meta"
+          ],
           "properties": {
             "_meta": {
+              "required": [
+                "op"
+              ],
               "properties": {
                 "op": {
                   "const": "d"

--- a/source-sqlserver/.snapshots/TestKeylessDiscovery
+++ b/source-sqlserver/.snapshots/TestKeylessDiscovery
@@ -46,8 +46,14 @@ sql> CREATE TABLE dbo.KeylessDiscovery_729953 (a INTEGER, b VARCHAR(2000), c REA
     "allOf": [
       {
         "if": {
+          "required": [
+            "_meta"
+          ],
           "properties": {
             "_meta": {
+              "required": [
+                "op"
+              ],
               "properties": {
                 "op": {
                   "const": "d"

--- a/source-sqlserver/.snapshots/TestSecondaryIndexDiscovery-index_only
+++ b/source-sqlserver/.snapshots/TestSecondaryIndexDiscovery-index_only
@@ -45,8 +45,14 @@ sql> CREATE UNIQUE INDEX UX_693037_k23 ON dbo.SecondaryIndexDiscovery_index_only
     "allOf": [
       {
         "if": {
+          "required": [
+            "_meta"
+          ],
           "properties": {
             "_meta": {
+              "required": [
+                "op"
+              ],
               "properties": {
                 "op": {
                   "const": "d"

--- a/source-sqlserver/.snapshots/TestSecondaryIndexDiscovery-nonunique_index
+++ b/source-sqlserver/.snapshots/TestSecondaryIndexDiscovery-nonunique_index
@@ -42,8 +42,14 @@ sql> CREATE INDEX UX_591008_k23 ON dbo.SecondaryIndexDiscovery_nonunique_index_5
     "allOf": [
       {
         "if": {
+          "required": [
+            "_meta"
+          ],
           "properties": {
             "_meta": {
+              "required": [
+                "op"
+              ],
               "properties": {
                 "op": {
                   "const": "d"

--- a/source-sqlserver/.snapshots/TestSecondaryIndexDiscovery-nothing
+++ b/source-sqlserver/.snapshots/TestSecondaryIndexDiscovery-nothing
@@ -41,8 +41,14 @@ sql> CREATE TABLE dbo.SecondaryIndexDiscovery_nothing_237250 (k1 INTEGER, k2 INT
     "allOf": [
       {
         "if": {
+          "required": [
+            "_meta"
+          ],
           "properties": {
             "_meta": {
+              "required": [
+                "op"
+              ],
               "properties": {
                 "op": {
                   "const": "d"

--- a/source-sqlserver/.snapshots/TestSecondaryIndexDiscovery-nullable_index
+++ b/source-sqlserver/.snapshots/TestSecondaryIndexDiscovery-nullable_index
@@ -48,8 +48,14 @@ sql> CREATE UNIQUE INDEX UX_892285_k23 ON dbo.SecondaryIndexDiscovery_nullable_i
     "allOf": [
       {
         "if": {
+          "required": [
+            "_meta"
+          ],
           "properties": {
             "_meta": {
+              "required": [
+                "op"
+              ],
               "properties": {
                 "op": {
                   "const": "d"

--- a/source-sqlserver/.snapshots/TestSecondaryIndexDiscovery-pk_and_index
+++ b/source-sqlserver/.snapshots/TestSecondaryIndexDiscovery-pk_and_index
@@ -41,8 +41,14 @@ sql> CREATE UNIQUE INDEX UX_954884_k23 ON dbo.SecondaryIndexDiscovery_pk_and_ind
     "allOf": [
       {
         "if": {
+          "required": [
+            "_meta"
+          ],
           "properties": {
             "_meta": {
+              "required": [
+                "op"
+              ],
               "properties": {
                 "op": {
                   "const": "d"

--- a/sqlcapture/discovery.go
+++ b/sqlcapture/discovery.go
@@ -238,9 +238,11 @@ func generateCollectionSchema(db Database, table *DiscoveryInfo, fullWriteSchema
 	// behavior which expresses how deletions work. We don't want that in a SourcedSchema update.
 	if fullWriteSchema {
 		metadataSchema.If = &jsonschema.Schema{
+			Required: []string{"_meta"},
 			Extras: map[string]any{
 				"properties": map[string]*jsonschema.Schema{
 					"_meta": {
+						Required: []string{"op"},
 						Extras: map[string]any{
 							"properties": map[string]*jsonschema.Schema{
 								"op": {


### PR DESCRIPTION
**Description:**

The current conditional reduction annotation of:
```yaml
if:
  properties:
    _meta:
      properties:
        op: { const: "d" }
then:
  reduce: { delete: true, strategy: merge }
else:
  reduce: { strategy: merge }
```
also matches when either `_meta` or `op` are not present. Meaning, if either of those are absent, the `if` conditional evaluates to `true` and the `delete: true, strategy: merge` in the `then` branch is applied. That's not what we want; we only want that deletion reduction to be applied when both fields are present and `op` is `"d"`.

This PR hardens the `if` check. By requiring `_meta` and `op` to be present, the `if` conditional only evaluates to `true` when both are present in the document _and_ `op` is `"d"`:

```yaml
if:
  required: ["_meta"]
  properties:
    _meta:
      required: ["op"]
      properties:
        op: { const: "d" }
then:
  reduce: { delete: true, strategy: merge }
else:
  reduce: { strategy: merge }
```

The multitude of snapshot updates are expected due to the additional `required`s added to the if/then/else block in discovered schemas.

**Notes for reviewers:**

For reference on the if/then/else behavior, check out the official [JSON schema docs](https://json-schema.org/understanding-json-schema/reference/conditionals#ifthenelse). This callout on that page is relevant:
>Because the `if` schema also doesn't require the "country" property, it will pass and the "then" schema will apply.

I'm not aware of any reported bugs due to the laxer matching behavior, likely because all documents emitted by these connectors have a `_meta` and `_meta/op` field present. I'd still like to close the gaps with these conditional reduction annotations so they're better references for future connectors or derivations that need to signal hard deletes via the same conditional reduction annotation.

