### PR TITLE
ci: update deprecated GitHub Actions to Node.js 24-compatible versions

### DIFF
--- a/.github/actions/setup/action.yaml
+++ b/.github/actions/setup/action.yaml
@@ -41,7 +41,7 @@ runs:
           docker login --username ${{ github.actor }} --password-stdin ghcr.io
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v1
+      uses: docker/setup-buildx-action@v4
       with:
         driver-opts: network=host
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,7 +14,7 @@ jobs:
   build_base_image:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
@@ -27,20 +27,20 @@ jobs:
           echo ::set-output name=version::${VERSION}
 
       - name: Login to GitHub package docker registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v4
         with:
           driver-opts: |
             network=host
 
       - name: Build base-image Docker Image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v6
         with:
           context: .
           file: base-image/Dockerfile
@@ -48,7 +48,7 @@ jobs:
           tags: ghcr.io/estuary/base-image:local
 
       - name: Push base-image image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v6
         with:
           context: .
           file: base-image/Dockerfile
@@ -57,7 +57,7 @@ jobs:
 
       - name: Push base-image image with 'dev' tag
         if: ${{ github.event_name == 'push' }}
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v6
         with:
           context: .
           file: base-image/Dockerfile
@@ -141,7 +141,7 @@ jobs:
             python: true
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
@@ -160,22 +160,25 @@ jobs:
           ./fetch-flow.sh
           echo "${PWD}/flow-bin" >> $GITHUB_PATH
 
+      - name: Authenticate with GCloud
+        uses: google-github-actions/auth@v2
+        with:
+          credentials_json: ${{ secrets.GCP_SERVICE_ACCOUNT_KEY }}
+
       - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v0
+        uses: google-github-actions/setup-gcloud@v2
         with:
           project_id: ${{ secrets.GCP_PROJECT_ID }}
-          service_account_key: ${{ secrets.GCP_SERVICE_ACCOUNT_KEY }}
-          export_default_credentials: true
 
       - name: Login to GitHub package docker registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v4
         with:
           driver-opts: |
             network=host
@@ -240,7 +243,7 @@ jobs:
           GIT_LFS_SKIP_SMUDGE: 1
 
       - name: Build ${{ matrix.connector }} Docker Image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v6
         if: ${{!matrix.python}}
         with:
           context: .
@@ -250,7 +253,7 @@ jobs:
           tags: ghcr.io/estuary/${{ matrix.connector }}:local
 
       - name: Build ${{ matrix.connector }} Python Docker Image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v6
         if: ${{matrix.python}}
         with:
           context: .


### PR DESCRIPTION
**Description:**

Updates deprecated Node.js 20 GitHub Actions to versions compatible with Node.js 24, ahead of the June 2, 2026 forced migration ([announcement](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)). Example of the warning this resolves: [build_connectors step 17](https://github.com/estuary/connectors/actions/runs/25393481959/job/74473933809#step:17:2).

**Workflow steps:**

No behavior change — CI runs identically.

**Documentation links affected:**

None.

**Notes for reviewers:**

Updated in `ci.yaml` and `.github/actions/setup/action.yaml`:
- `actions/checkout@v2` → `v4`
- `docker/login-action@v3` → `v4`
- `docker/setup-buildx-action@v1` → `v4`
- `docker/build-push-action@v2` → `v6`
- `google-github-actions/setup-gcloud@v0` → `v2`