### PR TITLE
ci: run integration tests for all materialize- connectors

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -322,30 +322,7 @@ jobs:
           sudo apt-get install -y pkg-config cmake libssl-dev libsasl2-dev libclang-dev
 
       - name: Materialization connector ${{ matrix.connector }} integration tests
-        if: |
-          contains(fromJson('[
-              "materialize-azure-fabric-warehouse",
-              "materialize-bigquery",
-              "materialize-bigtable",
-              "materialize-clickhouse",
-              "materialize-databricks",
-              "materialize-dynamodb",
-              "materialize-elasticsearch",
-              "materialize-google-sheets",
-              "materialize-iceberg",
-              "materialize-kafka",
-              "materialize-mongodb",
-              "materialize-motherduck",
-              "materialize-mysql",
-              "materialize-pinecone",
-              "materialize-postgres",
-              "materialize-redshift",
-              "materialize-s3-iceberg",
-              "materialize-s3-parquet",
-              "materialize-snowflake",
-              "materialize-spanner",
-              "materialize-sqlserver"
-            ]'), matrix.connector)
+        if: startsWith(matrix.connector, 'materialize-')
 
         run: |
           if [ "${{ matrix.connector }}" = "materialize-s3-iceberg" ]; then


### PR DESCRIPTION
**Description:**

Simplify the CI condition for materialization integration tests by replacing an explicit allowlist with `startsWith(matrix.connector, 'materialize-')`. This also enables integration tests for connectors that were previously omitted:

- materialize-azure-blob-parquet
- materialize-gcs-csv
- materialize-gcs-parquet
- materialize-google-pubsub
- materialize-s3-csv
- materialize-slack
- materialize-sqlite
- materialize-starburst
- materialize-webhook

**Workflow steps:**

No change to how tests are run — just which connectors trigger them.

**Documentation links affected:**

None.

**Notes for reviewers:**

~We expect `materialize-starburst` to fail, but it can be fixed in a follow-up PR.~

`materialize-starburst` resolved by removing: https://github.com/estuary/connectors/pull/4367