### PR TITLE
estuary-cdk: implement MultipleWritersTask for concurrent webhook writes

### DIFF
--- a/estuary-cdk/estuary_cdk/capture/common.py
+++ b/estuary-cdk/estuary_cdk/capture/common.py
@@ -13,7 +13,6 @@ from typing import (
     Callable,
     ClassVar,
     Generic,
-    Literal,
     TypeVar,
     cast,
 )
@@ -40,6 +39,7 @@ from ..pydantic_polyfill import GenericModel
 from ..utils import json_merge_patch
 from . import Task, request, response
 from .webhook.match import CollectionMatchingSpec, UrlMatch
+from .document import _BaseDocument, AssociatedDocument, BaseDocument
 
 LogCursor = tuple[str | int] | AwareDatetime | NonNegativeInt
 """LogCursor is a cursor into a logical log of changes.
@@ -127,28 +127,8 @@ class SourcedSchema:
     widens inferred schemas to accommodate the current inferred schema along
     with any SourcedSchemas.
     """
+
     value: dict[str, Any]
-
-
-class BaseDocument(BaseModel):
-    class Meta(BaseModel):
-        op: Literal["c", "u", "d"] = Field(
-            default="u",
-            description="Operation type (c: Create, u: Update, d: Delete)",
-        )
-        row_id: int = Field(
-            default=-1,
-            description="Row ID of the Document, counting up from zero, or -1 if not known",
-        )
-
-    meta_: Meta = Field(
-        default_factory=lambda: BaseDocument.Meta(op="u"),
-        alias="_meta",
-        description="Document metadata",
-    )
-
-
-_BaseDocument = TypeVar("_BaseDocument", bound=BaseDocument)
 
 
 class BaseResourceConfig(abc.ABC, BaseModel, extra="forbid"):
@@ -314,19 +294,6 @@ class ConnectorState(GenericModel, Generic[_BaseResourceState], extra="forbid"):
 
 
 _ConnectorState = TypeVar("_ConnectorState", bound=ConnectorState)
-
-
-@dataclass
-class AssociatedDocument(Generic[_BaseDocument]):
-    """
-    Emitting AssociatedDocument allows you to represent capturing document for other bindings.
-    You might use this if your data model requires you to load "child" documents when capturing a "parent" document,
-    instead of independently loading the child data stream.
-    """
-
-    doc: _BaseDocument
-    binding: int
-
 
 FetchSnapshotFn = Callable[[Logger], AsyncGenerator[_BaseDocument | dict, None]]
 """

--- a/estuary-cdk/estuary_cdk/capture/document.py
+++ b/estuary-cdk/estuary_cdk/capture/document.py
@@ -1,0 +1,36 @@
+from dataclasses import dataclass
+from typing import Generic, Literal, TypeVar
+from pydantic import BaseModel, Field
+
+
+class BaseDocument(BaseModel):
+    class Meta(BaseModel):
+        op: Literal["c", "u", "d"] = Field(
+            default="u",
+            description="Operation type (c: Create, u: Update, d: Delete)",
+        )
+        row_id: int = Field(
+            default=-1,
+            description="Row ID of the Document, counting up from zero, or -1 if not known",
+        )
+
+    meta_: Meta = Field(
+        default_factory=lambda: BaseDocument.Meta(op="u"),
+        alias="_meta",
+        description="Document metadata",
+    )
+
+
+_BaseDocument = TypeVar("_BaseDocument", bound=BaseDocument)
+
+
+@dataclass
+class AssociatedDocument(Generic[_BaseDocument]):
+    """
+    Emitting AssociatedDocument allows you to represent capturing document for other bindings.
+    You might use this if your data model requires you to load "child" documents when capturing a "parent" document,
+    instead of independently loading the child data stream.
+    """
+
+    doc: _BaseDocument
+    binding: int

--- a/estuary-cdk/estuary_cdk/capture/task.py
+++ b/estuary-cdk/estuary_cdk/capture/task.py
@@ -55,7 +55,7 @@ def orjson_default(obj):
     if isinstance(obj, decimal.Decimal):
         return str(obj)
     if isinstance(obj, (bytes, bytearray)):
-        return base64.b64encode(obj).decode('utf-8')
+        return base64.b64encode(obj).decode("utf-8")
     raise TypeError
 
 
@@ -147,16 +147,21 @@ class Task:
         Or, reset() will discard any queued documents."""
 
         if isinstance(document, dict):
-            b = orjson.dumps({
-                "captured": {
-                    "binding": binding,
-                    "doc": document,
-                }
-            }, default=orjson_default)
+            b = orjson.dumps(
+                {
+                    "captured": {
+                        "binding": binding,
+                        "doc": document,
+                    }
+                },
+                default=orjson_default,
+            )
         else:
-            b = Response(
-                captured=response.Captured(binding=binding, doc=document)
-            ).model_dump_json(by_alias=True, exclude_unset=True).encode()
+            b = (
+                Response(captured=response.Captured(binding=binding, doc=document))
+                .model_dump_json(by_alias=True, exclude_unset=True)
+                .encode()
+            )
 
         self._buffer.write(b)
         self._buffer.write(b"\n")
@@ -172,9 +177,15 @@ class Task:
         """Write a SourcedSchema message for the given binding to the buffer.
         SourcedSchema messages won't be emitted until checkpoint() is called."""
 
-        b = Response(
-            sourcedSchema=response.SourcedSchema(binding=binding_index, schema_json=schema)
-        ).model_dump_json(by_alias=True, exclude_unset=True).encode()
+        b = (
+            Response(
+                sourcedSchema=response.SourcedSchema(
+                    binding=binding_index, schema_json=schema
+                )
+            )
+            .model_dump_json(by_alias=True, exclude_unset=True)
+            .encode()
+        )
 
         self._buffer.write(b)
         self._buffer.write(b"\n")

--- a/estuary-cdk/estuary_cdk/capture/task.py
+++ b/estuary-cdk/estuary_cdk/capture/task.py
@@ -3,7 +3,7 @@ import base64
 import decimal
 import tempfile
 import traceback
-from collections.abc import Awaitable
+from collections.abc import Awaitable, Iterable
 from dataclasses import dataclass, field
 from logging import Logger
 from typing import Any, BinaryIO, Callable, Generic
@@ -13,6 +13,7 @@ import xxhash
 from pydantic import Field
 
 from estuary_cdk.capture.connector_status import ConnectorStatus
+from estuary_cdk.capture.document import AssociatedDocument
 
 from ..flow import (
     ConnectorSpec,
@@ -59,18 +60,17 @@ def orjson_default(obj):
     raise TypeError
 
 
-@dataclass
-class Task:
+class _BaseTask:
     """
-    Task bundles a capture coroutine and its associated context.
+    Shared state and helpers for capture tasks.
 
     It facilitates the task in queuing any number of captured documents and
-    emitting them upon a checkpoint. Each instance of Task manages an independent
+    emitting them upon a checkpoint. Each instance manages an independent
     internal buffer (backed by memory or disk) which is only written to the
     connector's output upon a call to checkpoint(). This allows concurrent
-    Tasks to capture consistent checkpoints without trampling one another.
+    tasks to capture consistent checkpoints without trampling one another.
 
-    Task also facilitates logging and graceful stop of a capture coroutine.
+    _BaseTask also facilitates logging and graceful stop of a capture coroutine.
     """
 
     log: Logger
@@ -141,11 +141,7 @@ class Task:
         self.transactor = transactor
         self.requires_ack = requires_ack
 
-    def captured(self, binding: int, document: Any):
-        """Enqueue the document to be captured under the given binding.
-        Documents are not actually captured until checkpoint() is called.
-        Or, reset() will discard any queued documents."""
-
+    def _captured(self, binding: int, document: Any):
         if isinstance(document, dict):
             b = orjson.dumps(
                 {
@@ -167,16 +163,10 @@ class Task:
         self._buffer.write(b"\n")
         self._hasher.update(b)
 
-    def pending_digest(self) -> str:
-        """pending_digest returns the digest of captured() documents
-        since the last checkpoint() or reset()"""
-
+    def _pending_digest(self) -> str:
         return self._hasher.digest().hex()
 
-    def sourced_schema(self, binding_index: int, schema: dict[str, Any]):
-        """Write a SourcedSchema message for the given binding to the buffer.
-        SourcedSchema messages won't be emitted until checkpoint() is called."""
-
+    def _sourced_schema(self, binding_index: int, schema: dict[str, Any]):
         b = (
             Response(
                 sourcedSchema=response.SourcedSchema(
@@ -189,6 +179,11 @@ class Task:
 
         self._buffer.write(b)
         self._buffer.write(b"\n")
+
+    def _reset(self):
+        self._buffer.truncate(0)
+        self._buffer.seek(0)
+        self._hasher.reset()
 
     async def _emit_checkpoint(
         self, state: ConnectorState, merge_patch: bool = True
@@ -206,9 +201,41 @@ class Task:
         completion = await self.transactor.commit(
             self._buffer, wait_for_ack=self.requires_ack
         )
-        self.reset()
+        self._reset()
 
         return completion
+
+
+class Task(_BaseTask):
+    """
+    Single-writer capture task.
+
+    Bundles a capture coroutine with its scoped logger, buffer, and the
+    shared connector context. Operations on this class are not safe to
+    invoke concurrently against the same instance — each Task is expected
+    to be driven by a single coroutine. Use `spawn_child` to fan out work
+    across multiple independent Tasks.
+    """
+
+    def captured(self, binding: int, document: Any):
+        """Enqueue the document to be captured under the given binding.
+        Documents are not actually captured until checkpoint() is called.
+        Or, reset() will discard any queued documents."""
+        self._captured(binding, document)
+
+    def pending_digest(self) -> str:
+        """pending_digest returns the digest of captured() documents
+        since the last checkpoint() or reset()"""
+        return self._pending_digest()
+
+    def sourced_schema(self, binding_index: int, schema: dict[str, Any]):
+        """Write a SourcedSchema message for the given binding to the buffer.
+        SourcedSchema messages won't be emitted until checkpoint() is called."""
+        self._sourced_schema(binding_index, schema)
+
+    def reset(self):
+        """Discard any captured documents, resetting to an empty state."""
+        self._reset()
 
     async def checkpoint(self, state: ConnectorState, merge_patch: bool = True):
         """Emit previously-queued, captured documents followed by a checkpoint.
@@ -237,12 +264,6 @@ class Task:
                 {"task": self._name},
             )
             raise
-
-    def reset(self):
-        """Discard any captured documents, resetting to an empty state."""
-        self._buffer.truncate(0)
-        self._buffer.seek(0)
-        self._hasher.reset()
 
     def spawn_child(
         self, name_suffix: str, child: Callable[["Task"], Awaitable[None]]
@@ -281,3 +302,80 @@ class Task:
         task = self._tg.create_task(run_task(self))
         task.set_name(child_name)
         return task
+
+
+class MultipleWritersTask(_BaseTask):
+    """Task variant safe for multiple concurrent producers on a single instance.
+
+    emit() captures a batch of items and writes one checkpoint under an
+    internal lock, so overlapping calls cannot interleave partial
+    transactions — the transactor sees each batch as one atomic unit and
+    can track durable persistence per batch.
+
+    The per-step `captured`/`checkpoint` surface from `Task` is intentionally
+    not exposed: it cannot be called safely from multiple coroutines on the
+    same buffer.
+    """
+
+    _buffer_lock: asyncio.Lock
+
+    def __init__(
+        self,
+        log: Logger,
+        connector_status: ConnectorStatus,
+        name: str,
+        output: BinaryIO,
+        stopping: _BaseTask.Stopping,
+        tg: asyncio.TaskGroup,
+        transactor: Transactor,
+        requires_ack: bool = False,
+    ):
+        super().__init__(
+            log=log,
+            connector_status=connector_status,
+            name=name,
+            output=output,
+            stopping=stopping,
+            tg=tg,
+            transactor=transactor,
+            requires_ack=requires_ack,
+        )
+        self._buffer_lock = asyncio.Lock()
+
+    async def emit(
+        self,
+        items: Iterable[AssociatedDocument],
+        state: ConnectorState,
+    ) -> None:
+        """Capture each item against its binding and write one checkpoint.
+
+        The buffer lock is held only while filling the buffer and flushing
+        it to stdout. The ACK wait, when `requires_ack` is True, happens
+        after the lock is released so concurrent emit() callers can pipeline
+        their writes instead of serializing on round-trip latency.
+        """
+
+        completion: asyncio.Future[None] | None = None
+        async with self._buffer_lock:
+            try:
+                for item in items:
+                    self._captured(item.binding, item.doc)
+                completion = await self._emit_checkpoint(state)
+            except BaseException as exc:
+                self.log.error(
+                    "MultipleWritersTask emit failed; discarding partial buffer",
+                    {"task": self._name, "error": str(exc)},
+                )
+                self._reset()
+                raise
+
+        if completion is None:
+            return
+        try:
+            await completion
+        except asyncio.CancelledError:
+            self.log.warning(
+                "MultipleWritersTask emit cancelled while awaiting ACK",
+                {"task": self._name},
+            )
+            raise

--- a/estuary-cdk/estuary_cdk/capture/webhook/server.py
+++ b/estuary-cdk/estuary_cdk/capture/webhook/server.py
@@ -16,6 +16,7 @@ from estuary_cdk.capture.common import (
     Task,
     WebhookResourceConfig,
 )
+from estuary_cdk.capture.task import MultipleWritersTask
 from estuary_cdk.capture.webhook.resources import WebhookDocument, WebhookResource
 
 _rejecting_key = web.AppKey("rejecting", bool)
@@ -96,45 +97,16 @@ def build_webhook_app(
             binding=binding_idx,
         )
 
-    # QUICK FIX: serialize the capture + checkpoint path across all concurrent
-    # webhook_handler invocations.
-    #
-    # aiohttp runs request handlers concurrently, but every invocation of
-    # webhook_handler shares the same Task, and therefore the same underlying
-    # buffer (Task._buffer) and hasher. task.captured() writes to that buffer
-    # synchronously, and task.checkpoint() awaits an emit that seeks to 0,
-    # reads the buffer from a worker thread, then truncates it. Without this
-    # lock, two concurrent requests can corrupt each other in at least two
-    # ways:
-    #
-    #   1. Silent data loss. R1 enqueues docs and awaits checkpoint(); while
-    #      R1 is inside _emit, R2 enqueues its own docs via captured(). When
-    #      R1's emit finishes and calls reset(), R2's queued docs are
-    #      truncated away. R2 then checkpoints an empty buffer, returns 200
-    #      to the webhook sender, and Flow never sees those documents.
-    #
-    #   2. Corrupt stdout. While _copy_buffer is reading the buffer from a
-    #      worker thread (after seek(0)), another request's captured() call
-    #      writes to the same file object from the event-loop thread.
-    #      SpooledTemporaryFile has a single shared file position and is not
-    #      thread-safe, so this can produce partial/interleaved JSON on
-    #      stdout. The Flow runtime consumes that stream, and invalid JSON
-    #      there has blast radius beyond a single capture task.
-    #
-    # Holding a lock around captured() + checkpoint() serializes only the
-    # emit path; JSON parsing, match-rule evaluation, and document enrichment
-    # above still run concurrently across requests. That is fine for typical
-    # webhook loads but will bottleneck sustained high-throughput workloads.
-    #
-    # PROPER FIX: mirror how pull-API bindings work (see _binding_incremental_task
-    # et al. in common.py) — give each webhook binding its own child Task via
-    # task.spawn_child, each with its own buffer. webhook_handler would group
-    # enriched_docs by doc.binding, hand each group to that binding's child
-    # Task, and checkpoint each touched binding under a per-binding lock.
-    # Requests targeting different bindings would then emit concurrently
-    # without ever sharing a buffer, removing this class of bug structurally
-    # instead of patching it. We should fix this whenever we touch this code next.
-    emit_lock = asyncio.Lock()
+    webhook_task = MultipleWritersTask(
+        log=task.log,
+        connector_status=task.connector_status,
+        name=task._name,  # pyright: ignore[reportPrivateUsage]
+        output=task._output,  # pyright: ignore[reportPrivateUsage]
+        stopping=task.stopping,
+        tg=task._tg,  # pyright: ignore[reportPrivateUsage]
+        transactor=task.transactor,
+        requires_ack=task.requires_ack,
+    )
 
     async def webhook_handler(req: web.Request) -> web.Response:
         if req.app.get(_rejecting_key, False):
@@ -152,11 +124,10 @@ def build_webhook_app(
 
         enriched_docs = [await _enrich_doc(raw_doc, req) for raw_doc in all_docs]
 
-        async with emit_lock:
-            for doc in enriched_docs:
-                task.captured(doc.binding, doc.doc)
-
-            await task.checkpoint(state=ConnectorState())
+        await webhook_task.emit(
+            enriched_docs,
+            ConnectorState(),  # pyright: ignore[reportUnknownArgumentType]
+        )
 
         return web.json_response({"published": len(enriched_docs)})
 

--- a/estuary-cdk/tests/test_webhook_server.py
+++ b/estuary-cdk/tests/test_webhook_server.py
@@ -17,7 +17,7 @@ from estuary_cdk.capture.common import (
     ResourceState,
     WebhookResourceConfig,
 )
-from estuary_cdk.capture.task import Task
+from estuary_cdk.capture.task import MultipleWritersTask, Task
 from estuary_cdk.capture.transactor import Transactor
 from estuary_cdk.capture.webhook.match import (
     BodyMatch,
@@ -393,6 +393,136 @@ class TestWebhookAckBlocking:
             resp = await asyncio.wait_for(request_task, timeout=1.0)
             assert resp.status == 200
             assert await resp.json() == {"published": 1}
+
+
+class TestSharedWebhookTask:
+    """
+    Verify that a single webhook request whose documents fan out across
+    multiple bindings emits exactly one checkpoint — the shared
+    MultipleWritersTask coalesces them under one transaction.
+    """
+
+    @pytest.mark.asyncio
+    async def test_array_body_splits_across_bindings(self):
+        rsc_a = make_webhook_resource("a", match_rule=BodyMatch(key="kind", value="a"))
+        rsc_b = make_webhook_resource("b", match_rule=BodyMatch(key="kind", value="b"))
+
+        async with run_server({0: rsc_a, 1: rsc_b}) as ctx:
+            resp = await ctx.client.post("/hook", json=[{"kind": "a"}, {"kind": "b"}])
+            assert resp.status == 200
+            assert await resp.json() == {"published": 2}
+
+            output = read_emitted_records(
+                ctx.task._output  # pyright: ignore[reportPrivateUsage]
+            )
+            captured_bindings = [
+                line["captured"]["binding"] for line in output if "captured" in line
+            ]
+            assert captured_bindings == [
+                0,
+                1,
+            ], "Bindings must be captured in input order, not coalesced"
+
+            checkpoint_lines = [line for line in output if "checkpoint" in line]
+            assert len(checkpoint_lines) == 1
+
+    @pytest.mark.asyncio
+    async def test_concurrent_requests_pipeline_without_interleaving(self):
+        """Two requests in flight at once must both reach the transactor
+        before either ACK is delivered (the lock releases after stdout
+        flush, not after ACK), and their output must not interleave."""
+
+        output = io.BytesIO()
+        stopping = Task.Stopping()
+        transactor = Transactor(output, requires_explicit_acks=True)
+
+        task = Task(
+            log=logging.getLogger("test-webhook-pipeline"),
+            connector_status=MagicMock(),
+            name="test-webhook-pipeline",
+            output=output,
+            stopping=stopping,
+            tg=MagicMock(),
+            transactor=transactor,
+            requires_ack=True,
+        )
+
+        app = build_webhook_app({0: make_webhook_resource("catch-all")}, task)
+        async with TestClient(TestServer(app)) as client:
+            req_a = asyncio.create_task(client.post("/hook/A", json={}))
+            req_b = asyncio.create_task(client.post("/hook/B", json={}))
+
+            for _ in range(100):
+                await asyncio.sleep(0.01)
+                if len(transactor._pending) == 2:  # pyright: ignore[reportPrivateUsage]
+                    break
+            assert (
+                len(transactor._pending) == 2  # pyright: ignore[reportPrivateUsage]
+            ), "Both requests should be awaiting ACK concurrently"
+            assert not req_a.done() and not req_b.done()
+
+            transactor.deliver_ack(2)
+            resp_a = await asyncio.wait_for(req_a, timeout=1.0)
+            resp_b = await asyncio.wait_for(req_b, timeout=1.0)
+            assert resp_a.status == 200
+            assert resp_b.status == 200
+
+            records = read_emitted_records(output)
+            kinds = [
+                "captured" if "captured" in line else "checkpoint" for line in records
+            ]
+            assert kinds == [
+                "captured",
+                "checkpoint",
+                "captured",
+                "checkpoint",
+            ], f"Output interleaved across requests: {kinds}"
+
+            req_paths = [
+                line["captured"]["doc"]["_meta"]["reqPath"]
+                for line in records
+                if "captured" in line
+            ]
+            assert sorted(req_paths) == ["/hook/A", "/hook/B"]
+
+    @pytest.mark.asyncio
+    async def test_emit_failure_discards_partial_buffer(self):
+        """If checkpoint flush raises, the next request must not inherit the
+        failed batch's documents in its own checkpoint."""
+
+        async with run_server({0: make_webhook_resource("catch-all")}) as ctx:
+            real_emit_checkpoint = (
+                MultipleWritersTask._emit_checkpoint  # pyright: ignore[reportPrivateUsage]
+            )
+            calls = {"n": 0}
+
+            async def fail_first(self: MultipleWritersTask, *args: Any, **kwargs: Any):
+                calls["n"] += 1
+                if calls["n"] == 1:
+                    raise RuntimeError("simulated flush failure")
+                return await real_emit_checkpoint(self, *args, **kwargs)
+
+            with patch.object(MultipleWritersTask, "_emit_checkpoint", fail_first):
+                resp_fail = await ctx.client.post("/hook/doomed", json={})
+                assert resp_fail.status == 500
+
+                resp_ok = await ctx.client.post("/hook/survivor", json={})
+                assert resp_ok.status == 200
+
+            records = read_emitted_records(
+                ctx.task._output  # pyright: ignore[reportPrivateUsage]
+            )
+            captured_paths = [
+                line["captured"]["doc"]["_meta"]["reqPath"]
+                for line in records
+                if "captured" in line
+            ]
+            assert captured_paths == [
+                "/hook/survivor"
+            ], "Failed batch's documents leaked into the next checkpoint"
+
+            checkpoint_lines = [line for line in records if "checkpoint" in line]
+            assert len(checkpoint_lines) == 1
 
 
 class TestWebhookServerLifecycle:


### PR DESCRIPTION
**Description:**

The current Task implementation gives callers manual control over how
many documents are buffered before each checkpoint. That model works
when there is a single document producer per Task, but our aiohttp
webhook server handles an arbitrary number of concurrent requests across
the the same Task; this exposes us to the risk that concurrent
checkpoint() calls may interleave on the shared buffer.

This change introduces a MultipleWritersTask class with an `emit()`
method that atomically writes buffers and checkpoints together.

MultipleWritersTask also gives each binding its own buffer, replacing
the previous stopgap where a single mutex was shared across every
binding in the webhook server.

Closes #4322.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

