### PR TITLE
materialize-s3-iceberg: sort tables by collection key on create

### DIFF
--- a/materialize-s3-iceberg/catalog.go
+++ b/materialize-s3-iceberg/catalog.go
@@ -128,6 +128,13 @@ func (c *catalog) CreateResource(ctx context.Context, b *pf.MaterializationSpec_
 		})
 	}
 
+	// Field IDs are assigned 1..N by iceberg-ctl in the order columns appear
+	// here, which is FieldSelection.AllFields() == Keys ++ Values ++ Document.
+	// Sort by collection key so writers cluster rows by key within data files.
+	for i := 1; i <= len(b.FieldSelection.Keys); i++ {
+		tc.SortFieldIDs = append(tc.SortFieldIDs, i)
+	}
+
 	input, err := json.Marshal(tc)
 	if err != nil {
 		return "", nil, err

--- a/materialize-s3-iceberg/iceberg-ctl/iceberg_ctl/__main__.py
+++ b/materialize-s3-iceberg/iceberg-ctl/iceberg_ctl/__main__.py
@@ -16,6 +16,8 @@ from pyiceberg.catalog.rest import RestCatalog
 from pyiceberg.io import PY_IO_IMPL
 from pyiceberg.schema import Schema
 from pyiceberg.table import TableProperties
+from pyiceberg.table.sorting import NullOrder, SortDirection, SortField, SortOrder
+from pyiceberg.transforms import IdentityTransform
 from pyiceberg.types import (
     BinaryType,
     BooleanType,
@@ -308,6 +310,7 @@ class TableCreate(BaseModel, extra="forbid"):
     location: str
     fields: list[IcebergColumn]
     properties: dict[str, str] | None = None
+    sort_field_ids: list[int] | None = None
 
 
 @run.command()
@@ -343,7 +346,26 @@ def create_table(
             if k == TableProperties.DEFAULT_NAME_MAPPING:
                 continue
             properties[k] = v
-    catalog.create_table(table, schema, table_create.location, properties=properties)
+
+    sort_order = SortOrder()
+    if table_create.sort_field_ids:
+        sort_order = SortOrder(*[
+            SortField(
+                source_id=field_id,
+                transform=IdentityTransform(),
+                direction=SortDirection.ASC,
+                null_order=NullOrder.NULLS_FIRST,
+            )
+            for field_id in table_create.sort_field_ids
+        ])
+
+    catalog.create_table(
+        table,
+        schema,
+        table_create.location,
+        sort_order=sort_order,
+        properties=properties,
+    )
     log(f"create_table: created table {table}")
 
 

--- a/materialize-s3-iceberg/icebergctl.go
+++ b/materialize-s3-iceberg/icebergctl.go
@@ -30,9 +30,10 @@ type existingIcebergColumn struct {
 }
 
 type tableCreate struct {
-	Fields     []existingIcebergColumn `json:"fields"`
-	Location   string                  `json:"location"`
-	Properties map[string]string       `json:"properties,omitempty"`
+	Fields       []existingIcebergColumn `json:"fields"`
+	Location     string                  `json:"location"`
+	Properties   map[string]string       `json:"properties,omitempty"`
+	SortFieldIDs []int                   `json:"sort_field_ids,omitempty"`
 }
 
 type tableAlter struct {


### PR DESCRIPTION
**Description:**

When `materialize-s3-iceberg` creates a new Iceberg table, set its write sort order to the collection-key fields (identity transform, ascending, nulls-first). Previously tables were created unsorted.

**Workflow steps:**

New tables created after this lands will carry a sort order in their Iceberg metadata; existing tables are untouched.

**Documentation links affected:**

None.

**Notes for reviewers:**

- Identifier fields are deliberately *not* set: this connector is delta-updates only and append-only, so it cannot guarantee row-level uniqueness, which Iceberg's `identifier_field_ids` implies.
- Field IDs are assigned 1..N by `iceberg-ctl` over `FieldSelection.AllFields()` (Keys ++ Values ++ Document), so the key field IDs are simply 1..len(Keys).
- Verified end-to-end via the existing `TestIntegration` against the dockerized Polaris REST catalog.