### PR TITLE
estuary-cdk: restore Python 3.11 compatibility

### DIFF
--- a/.github/workflows/estuary-cdk.yaml
+++ b/.github/workflows/estuary-cdk.yaml
@@ -8,11 +8,13 @@ on:
     branches: [main]
     paths:
       - "estuary-cdk/**"
+      - ".github/workflows/estuary-cdk.yaml"
 
   pull_request:
     branches: [main]
     paths:
       - "estuary-cdk/**"
+      - ".github/workflows/estuary-cdk.yaml"
 
 concurrency:
   group: estuary-cdk-${{ github.ref }}

--- a/.github/workflows/estuary-cdk.yaml
+++ b/.github/workflows/estuary-cdk.yaml
@@ -43,4 +43,5 @@ jobs:
           cd estuary-cdk
           poetry install
           source $(poetry env info --path)/bin/activate
+          python -m compileall -q estuary_cdk
           pytest

--- a/.github/workflows/estuary-cdk.yaml
+++ b/.github/workflows/estuary-cdk.yaml
@@ -21,13 +21,17 @@ concurrency:
 jobs:
   test-estuary-cdk:
     runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.11", "3.12"]
     steps:
       - uses: actions/checkout@v4
 
       - name: Install Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: ${{ matrix.python-version }}
 
       - name: Install Poetry
         uses: snok/install-poetry@v1

--- a/estuary-cdk/estuary_cdk/buffer_ordered.py
+++ b/estuary-cdk/estuary_cdk/buffer_ordered.py
@@ -1,12 +1,12 @@
 import asyncio
 from dataclasses import dataclass
-from typing import Any, AsyncGenerator, Awaitable, TypeVar
+from typing import Any, AsyncGenerator, Awaitable, Generic, TypeVar
 
 T = TypeVar("T")
 
 
 @dataclass
-class BufferWork[T]:
+class BufferWork(Generic[T]):
     aw: Awaitable[T]
     result: asyncio.Queue[T | None]
 

--- a/estuary-cdk/estuary_cdk/capture/webhook/match.py
+++ b/estuary-cdk/estuary_cdk/capture/webhook/match.py
@@ -5,7 +5,8 @@ import re
 from abc import abstractmethod
 from collections.abc import Sequence
 from logging import Logger
-from typing import Any, Literal, override
+from typing import Any, Literal
+from typing_extensions import override
 
 from aiohttp import web
 from aiohttp.web_urldispatcher import DynamicResource

--- a/estuary-cdk/estuary_cdk/capture/webhook/resources.py
+++ b/estuary-cdk/estuary_cdk/capture/webhook/resources.py
@@ -1,6 +1,7 @@
 from collections.abc import Sequence
 from datetime import UTC, datetime
-from typing import ClassVar, Generic, TypeVar, override
+from typing import ClassVar, Generic, TypeVar
+from typing_extensions import override
 from uuid import uuid4
 from pydantic import BaseModel, Field
 from estuary_cdk.capture.common import (

--- a/estuary-cdk/poetry.lock
+++ b/estuary-cdk/poetry.lock
@@ -3000,4 +3000,4 @@ airbyte-shim = ["airbyte-cdk"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.11"
-content-hash = "fe7e41e8e39549ab47df05ed7fac85201ab92f0e11b7d0eb82614ce72d924ec8"
+content-hash = "30c82cad7cccacf8d308f5785c21ea89883abd55ce8546fa58db8aa8e9f49445"

--- a/estuary-cdk/pyproject.toml
+++ b/estuary-cdk/pyproject.toml
@@ -17,6 +17,7 @@ xxhash = "^3.4.1"
 ijson = "^3.3.0"
 pycron = "^3.1.2"
 stream-unzip = "0.0.99"
+typing-extensions = "^4.13"
 
 google-auth = {version = ">=2.40.3", extras = ["requests"]}
 pendulum = "<=2.0.0 | >=3.0.0"


### PR DESCRIPTION
**Description:**

This PR's scope includes:

- Removing Python 3.12 specific syntax and imports in order to restore compatibility with Python 3.11.
- Running the CDK tests in a Python 3.11 environment as well to confirm we're maintaining compatibility with it.
- Adding a sanity compilation check for both Python 3.11 and 3.12.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

