### PR TITLE
materialize-iceberg: restore default catalog setting

### DIFF
--- a/materialize-iceberg/python/common.py
+++ b/materialize-iceberg/python/common.py
@@ -163,6 +163,12 @@ def _build_session(c: dict) -> SparkSession:
             "spark.sql.extensions",
             "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions",
         )
+        # The defaultCatalog is no longer used, we always execute fully
+        # qualified queries to avoid abigiuity if the namespace/database is
+        # also named estuary.  It is still specified to ensure tasks migrating
+        # from an older version, which may have a partially qualified query,
+        # are still able to run during the post-commit apply.
+        .config("spark.sql.defaultCatalog", "estuary")
         .config("spark.sql.catalog.estuary", "org.apache.iceberg.spark.SparkCatalog")
         .config("spark.sql.catalog.estuary.type", "rest")
         .config("spark.sql.catalog.estuary.uri", c["catalog_url"])


### PR DESCRIPTION
In #4222, the default catalog was removed and was switched to using a fully qualified query.  However this introduced a possible error if the materialization is restarted during the post-commit apply.

The scripts are sent once on each startup but the queries are staged during Load and applied in Acknowledge. If interrupted and the connector is upgraded you will have newer scripts with an older version of the queries.

Adding back the default catalog is safe, because it will only be used if the queries do not have 3-part fully qualified names.

**Workflow steps:**

No changes needed

**Documentation links affected:**

None

**Notes for reviewers:**

(anything that might help someone review this PR)

