### PR TITLE
source-s3: use rustfs in integration test

### DIFF
--- a/source-s3/docker-compose.yaml
+++ b/source-s3/docker-compose.yaml
@@ -1,0 +1,26 @@
+services:
+  storage:
+    image: rustfs/rustfs:latest
+    pull_policy: missing
+    ports:
+      - "4566:4566"
+    environment:
+      RUSTFS_ADDRESS: 0.0.0.0:4566
+      RUSTFS_ACCESS_KEY: test_key
+      RUSTFS_SECRET_KEY: test_secret
+    networks:
+      flow-test:
+    healthcheck:
+      test:
+        [
+          "CMD-SHELL",
+          "curl -f http://127.0.0.1:4566/health"
+        ]
+      interval: 2s
+      timeout: 5s
+      retries: 10
+      start_period: 5s
+
+networks:
+  flow-test:
+    external: true

--- a/tests/source-s3/cleanup.sh
+++ b/tests/source-s3/cleanup.sh
@@ -2,4 +2,4 @@
 
 set -e
 
-docker stop "${LOCALSTACK_CONTAINER_NAME}"
+docker compose -f source-s3/docker-compose.yaml down -v

--- a/tests/source-s3/setup.sh
+++ b/tests/source-s3/setup.sh
@@ -7,11 +7,11 @@ export RESOURCE="{ \"stream\": \"${TEST_STREAM}\", \"syncMode\": \"incremental\"
 # set ID_TYPE to string because parsing CSV files will always result in string values.
 export ID_TYPE=string
 
-export LOCALSTACK_CONTAINER_NAME=localstack
-export LOCALSTACK_S3_ENDPOINT=http://${LOCALSTACK_CONTAINER_NAME}.flow-test:4566
-export LOCALSTACK_S3_LOCAL_ENDPOINT=http://localhost:4566
+export RUSTFS_S3_ENDPOINT=http://storage.flow-test:4566
+export RUSTFS_S3_LOCAL_ENDPOINT=http://localhost:4566
 
-# Dummy configs for awscli to access localstack.
+# Dummy configs for awscli to access rustfs.
+export AWS_PAGER=""
 export AWS_ACCESS_KEY_ID=test_key
 export AWS_SECRET_ACCESS_KEY=test_secret
 export AWS_DEFAULT_REGION=us-east-1
@@ -22,46 +22,29 @@ config_json_template='{
     "bucket": "${TEST_STREAM}",
     "region": "${AWS_DEFAULT_REGION}",
     "advanced": {
-      "endpoint": "${LOCALSTACK_S3_ENDPOINT}"
+      "endpoint": "${RUSTFS_S3_ENDPOINT}"
     }
 }'
 
 export CONNECTOR_CONFIG="$(echo "$config_json_template" | envsubst | jq -c)"
 
-# Start localstack to emulate AWS S3 for testing.
-docker run -d \
-    --rm \
-    --user 0 \
-    --network "flow-test" \
-    --publish 4566:4566 \
-    --name="${LOCALSTACK_CONTAINER_NAME}" \
-    --env "SERVICES=s3" \
-    localstack/localstack
+docker compose -f source-s3/docker-compose.yaml up --wait
 
-for i in {1..20}; do
-    # Wait until the local stack is ready for serving.
-    if aws s3 ls --endpoint-url "${LOCALSTACK_S3_LOCAL_ENDPOINT}"; then
-        echo "localstack started successfully."
-        break
-    fi
-    echo "Not ready, retrying ${i}."
-    sleep 3
-done
-echo "Localstack logs:"
-docker logs "${LOCALSTACK_CONTAINER_NAME}"
+echo "RustFS logs:"
+docker compose logs storage
 
-aws s3 mb "s3://${TEST_STREAM}" --endpoint "${LOCALSTACK_S3_LOCAL_ENDPOINT}"
+aws s3 mb "s3://${TEST_STREAM}" --endpoint "${RUSTFS_S3_LOCAL_ENDPOINT}"
 
 root_dir="$(git rev-parse --show-toplevel)"
 
 # We need to exclude the json file from the test because the `id` property there is an integer, and
 # this connector expects it to be a string.
 for file in $(find ${root_dir}/tests/files -type f -name '*.csv*'); do
-    aws s3 cp ${file} s3://${TEST_STREAM}/testprefix/$(basename $file) --endpoint "${LOCALSTACK_S3_LOCAL_ENDPOINT}"
+    aws s3 cp ${file} s3://${TEST_STREAM}/testprefix/$(basename $file) --endpoint "${RUSTFS_S3_LOCAL_ENDPOINT}"
 done
 
 # add an empty prefix to ensure that it gets filtered out
-aws s3api put-object --bucket "$TEST_STREAM" --key "testprefix/" --endpoint "${LOCALSTACK_S3_LOCAL_ENDPOINT}"
+aws s3api put-object --bucket "$TEST_STREAM" --key "testprefix/" --endpoint "${RUSTFS_S3_LOCAL_ENDPOINT}"
 
 sleep_seconds=30
 echo "Sleeping for ${sleep_seconds} seconds to account for filesource clock delta"


### PR DESCRIPTION
The source-s3 test has been failing since around March 20, my best guess is there was a change to the localstack image.  On the materialization side we have been moving to using rustfs for testing s3 connectors, so I extended this to source-s3.

**Workflow steps:**

No changes

**Documentation links affected:**

None

**Notes for reviewers:**

(anything that might help someone review this PR)

