### PR TITLE
materialize-snowflake: only run clustering info and queryStats in debug

### DIFF
--- a/materialize-snowflake/snowflake.go
+++ b/materialize-snowflake/snowflake.go
@@ -1217,6 +1217,10 @@ func (d *transactor) Destroy() {
 }
 
 func logQueryStats(ctx context.Context, db *stdsql.DB, queryID string, table string) {
+	if !log.IsLevelEnabled(log.DebugLevel) {
+		return
+	}
+
 	var scanned, total stdsql.NullInt64
 	row := db.QueryRowContext(ctx,
 		`SELECT SUM(VALUE:"partitions_scanned"::INT), SUM(VALUE:"partitions_total"::INT)
@@ -1245,10 +1249,14 @@ func logQueryStats(ctx context.Context, db *stdsql.DB, queryID string, table str
 		"partitions_scanned":      scanned.Int64,
 		"partitions_total":        total.Int64,
 		"queued_overload_time_ms": queuedOverloadTime.Int64,
-	}).Info("query stats")
+	}).Debug("query stats")
 }
 
 func logClusteringInfo(ctx context.Context, db *stdsql.DB, table string, keyExpr string) {
+	if !log.IsLevelEnabled(log.DebugLevel) {
+		return
+	}
+
 	var result stdsql.NullString
 	query := fmt.Sprintf("SELECT SYSTEM$CLUSTERING_INFORMATION('%s', '%s')", table, keyExpr)
 	if err := db.QueryRowContext(ctx, query).Scan(&result); err != nil {
@@ -1282,7 +1290,7 @@ func logClusteringInfo(ctx context.Context, db *stdsql.DB, table string, keyExpr
 		"average_depth":    info.AverageDepth,
 		"average_overlaps": info.AverageOverlaps,
 		"total_partitions": info.TotalPartitions,
-	}).Info("clustering information")
+	}).Debug("clustering information")
 }
 
 // clusteringKeyExpr builds a Snowflake CLUSTER BY expression from the given


### PR DESCRIPTION
**Description:**

- These queries wake up the warehouse and also spend warehouse time. They were used for investigations that lead to #4373
- This pull-request puts these behind a gate so that they only run if the task is on debug log level

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

