### PR TITLE
ci: delayed tag 2 weeks for each connector

### DIFF
--- a/.github/scripts/delayed_tag.py
+++ b/.github/scripts/delayed_tag.py
@@ -1,0 +1,748 @@
+#!/usr/bin/env python3
+"""
+delayed_tag.py — compute the ':delayed' image tag plan for Estuary connectors.
+
+Subcommands
+-----------
+plan   Read ci.yaml / python.yaml, query GitHub for merged PRs, then for each
+       connector pick the most recent PR that (a) touched that connector's
+       directory, (b) was merged at least CUTOFF_DAYS ago, and (c) has not
+       been reverted on main. Writes plan.tsv and later.tsv.
+
+check  Read plan.tsv / later.tsv, call Claude Sonnet for each connector that
+       has LATER PRs to detect roll-forward fixes, then write safe_plan.tsv
+       (plan rows safe to publish) and claude_verdicts.tsv.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime
+import json
+import os
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable, Optional
+
+
+# ---------------------------------------------------------------------------
+# Data types
+# ---------------------------------------------------------------------------
+
+@dataclass(frozen=True)
+class PullRequest:
+    number: int
+    title: str
+    merged_epoch: int       # unix timestamp of mergedAt
+    merge_sha: str          # full SHA (mergeCommit.oid)
+    paths: frozenset        # file paths changed by this PR
+
+
+@dataclass(frozen=True)
+class ConnectorImage:
+    image_name: str  # e.g. "source-mysql"
+    source_dir: str  # source directory; same as image_name except for variants
+
+
+@dataclass(frozen=True)
+class PlanEntry:
+    image_name: str
+    chosen_sha7: str  # first 7 chars of merge_sha
+    chosen_pr: int
+    source_dir: str
+
+
+@dataclass(frozen=True)
+class LaterEntry:
+    image_name: str
+    pr_number: int
+
+
+@dataclass(frozen=True)
+class Verdict:
+    image_name: str
+    verdict: str  # "safe" | "hold"
+    reason: str
+
+
+# ---------------------------------------------------------------------------
+# Pure functions — fully testable without I/O or subprocess
+# ---------------------------------------------------------------------------
+
+def pr_touches_dir(pr: PullRequest, source_dir: str) -> bool:
+    """Return True if any changed path is under source_dir/."""
+    prefix = source_dir.rstrip('/') + '/'
+    return any(p.startswith(prefix) for p in pr.paths)
+
+
+def find_boundary(
+    image_name: str,
+    source_dir: str,
+    prs: list,
+    cutoff_epoch: int,
+    is_reverted: Callable,
+) -> tuple:
+    """
+    Walk PRs newest-first and return (chosen, later) where:
+      chosen  — most recent PlanEntry with merged_epoch <= cutoff that touches
+                source_dir and whose merge commit hasn't been reverted on main.
+      later   — LaterEntries for PRs merged after cutoff touching source_dir
+                (the candidates for roll-forward fixes of chosen).
+
+    Returns (None, later) when no eligible PR is found.
+    """
+    later: list = []
+    for pr in prs:
+        if not pr_touches_dir(pr, source_dir):
+            continue
+        if pr.merged_epoch > cutoff_epoch:
+            later.append(LaterEntry(image_name=image_name, pr_number=pr.number))
+            continue
+        if is_reverted(pr.merge_sha):
+            print(f'  {image_name}: PR #{pr.number} ({pr.merge_sha[:7]}) reverted, skipping',
+                  file=sys.stderr)
+            continue
+        return PlanEntry(
+            image_name=image_name,
+            chosen_sha7=pr.merge_sha[:7],
+            chosen_pr=pr.number,
+            source_dir=source_dir,
+        ), later
+    return None, later
+
+
+def parse_claude_verdict(response_text: str, image_name: str) -> Verdict:
+    """
+    Parse Claude's JSON response into a Verdict.
+    Falls back to 'safe' on any parse error so that a malformed response
+    does not silently block a deployment.
+    """
+    try:
+        obj = json.loads(response_text)
+        v = str(obj.get('verdict', 'safe')).lower().strip()
+        if v not in ('safe', 'hold'):
+            v = 'safe'
+        return Verdict(image_name=image_name, verdict=v, reason=str(obj.get('reason', '')))
+    except (json.JSONDecodeError, AttributeError, TypeError) as exc:
+        return Verdict(
+            image_name=image_name,
+            verdict='safe',
+            reason=f'could not parse Claude response ({exc}): {response_text[:120]}',
+        )
+
+
+def build_safe_plan(
+    plan: list,
+    verdicts: dict,
+) -> tuple:
+    """
+    Split plan entries into (safe, held) based on Claude verdicts.
+    Connectors absent from verdicts default to safe.
+    """
+    safe, held = [], []
+    for entry in plan:
+        v = verdicts.get(entry.image_name)
+        if v and v.verdict == 'hold':
+            held.append(entry)
+        else:
+            safe.append(entry)
+    return safe, held
+
+
+# ---------------------------------------------------------------------------
+# Connector image discovery
+# ---------------------------------------------------------------------------
+
+def load_connector_images(ci_yaml: str, python_yaml: str) -> list:
+    """
+    Return the list of (image_name, source_dir) pairs from the workflow
+    matrix entries.  Variants in <connector>/VARIANTS inherit their parent's
+    source_dir.
+    """
+    def yq_list(query: str, path: str) -> list:
+        try:
+            out = subprocess.check_output(
+                ['yq', query, path], text=True, stderr=subprocess.DEVNULL
+            )
+            return [l.strip() for l in out.splitlines() if l.strip()]
+        except subprocess.CalledProcessError:
+            return []
+
+    raw_connectors = (
+        yq_list('.jobs.build_connectors.strategy.matrix.connector[]', ci_yaml) +
+        yq_list('.jobs.build_connectors.strategy.matrix.include[].connector', ci_yaml) +
+        yq_list('.jobs.py_connector.strategy.matrix.connector[].name', python_yaml)
+    )
+
+    seen: set = set()
+    connectors: list = []
+    for c in raw_connectors:
+        if c not in seen:
+            seen.add(c)
+            connectors.append(c)
+
+    images: list = []
+    seen_images: set = set()
+
+    def add(image: str, source_dir: str) -> None:
+        if image not in seen_images:
+            seen_images.add(image)
+            images.append(ConnectorImage(image_name=image, source_dir=source_dir))
+
+    for connector in connectors:
+        add(connector, connector)
+        variants_path = Path(connector) / 'VARIANTS'
+        if variants_path.exists():
+            for variant in variants_path.read_text().split():
+                add(variant, connector)
+
+    return images
+
+
+# ---------------------------------------------------------------------------
+# GitHub API
+# ---------------------------------------------------------------------------
+
+_FETCH_PRS_QUERY = """
+query($owner: String!, $repo: String!, $after: String) {
+  repository(owner: $owner, name: $repo) {
+    pullRequests(
+      states: MERGED
+      baseRefName: "main"
+      orderBy: {field: UPDATED_AT, direction: DESC}
+      first: 100
+      after: $after
+    ) {
+      pageInfo { hasNextPage endCursor }
+      nodes {
+        number
+        title
+        mergedAt
+        updatedAt
+        mergeCommit { oid }
+        files(first: 100) { totalCount nodes { path } }
+      }
+    }
+  }
+}
+"""
+
+
+def _graphql(query: str, variables: dict, token: str) -> dict:
+    payload = json.dumps({'query': query, 'variables': variables}).encode()
+    req = urllib.request.Request(
+        'https://api.github.com/graphql',
+        data=payload,
+        headers={
+            'Authorization': f'bearer {token}',
+            'Content-Type': 'application/json',
+        },
+    )
+    with urllib.request.urlopen(req, timeout=60) as resp:
+        return json.loads(resp.read())
+
+
+def _rest_pr_files(pr_number: int, owner: str, repo: str, token: str) -> list:
+    """Fetch all changed file paths for a PR via REST (handles >100 files)."""
+    paths = []
+    page = 1
+    while True:
+        url = (
+            f'https://api.github.com/repos/{owner}/{repo}/pulls/{pr_number}/files'
+            f'?per_page=100&page={page}'
+        )
+        req = urllib.request.Request(url, headers={
+            'Authorization': f'bearer {token}',
+            'Accept': 'application/vnd.github+json',
+        })
+        with urllib.request.urlopen(req, timeout=60) as resp:
+            batch = json.loads(resp.read())
+        if not batch:
+            break
+        paths.extend(f['filename'] for f in batch)
+        if len(batch) < 100:
+            break
+        page += 1
+    return paths
+
+
+def _rest_pr_diff(
+    pr_number: int,
+    owner: str,
+    repo: str,
+    token: str,
+    diff_line_cap: int = 2000,
+) -> str:
+    """
+    Reconstruct a diff from the paginated 'list PR files' REST API.
+
+    Used as fallback when gh pr diff returns HTTP 406 (PR exceeds GitHub's
+    aggregate diff limits: >300 files or >20 000 lines). The per-file API
+    returns individual `patch` fields that are not subject to those limits,
+    so large PRs can still be summarised file-by-file.
+
+    Binary files and files whose individual diff is also too large have no
+    `patch` field; they are noted with a placeholder line.
+    """
+    lines_seen = 0
+    parts: list = []
+    page = 1
+
+    while True:
+        url = (
+            f'https://api.github.com/repos/{owner}/{repo}/pulls/{pr_number}/files'
+            f'?per_page=100&page={page}'
+        )
+        req = urllib.request.Request(url, headers={
+            'Authorization': f'bearer {token}',
+            'Accept': 'application/vnd.github+json',
+        })
+        with urllib.request.urlopen(req, timeout=60) as resp:
+            batch = json.loads(resp.read())
+
+        if not batch:
+            break
+
+        truncated = False
+        for f in batch:
+            header = f'--- a/{f["filename"]}\n+++ b/{f["filename"]}'
+            patch = f.get('patch') or (
+                f'(binary or oversized file; {f.get("changes", "?")} changes)'
+            )
+            file_lines = [header] + patch.splitlines()
+
+            if lines_seen + len(file_lines) > diff_line_cap:
+                parts.append(f'... [truncated at {diff_line_cap} lines]')
+                truncated = True
+                break
+
+            parts.extend(file_lines)
+            lines_seen += len(file_lines)
+
+        if truncated or len(batch) < 100:
+            break
+        page += 1
+
+    return '\n'.join(parts)
+
+
+def _iso_to_epoch(iso: str) -> int:
+    return int(
+        datetime.datetime.fromisoformat(iso.replace('Z', '+00:00')).timestamp()
+    )
+
+
+def fetch_merged_prs(
+    owner: str,
+    repo: str,
+    token: str,
+    lookback_days: int = 60,
+) -> list:
+    """
+    Fetch merged PRs against main via GraphQL, sorted newest-first by mergedAt.
+    Stops paginating once updatedAt is older than lookback_days.
+    """
+    stop_updated_epoch = int(time.time()) - lookback_days * 86400
+    raw_nodes: list = []
+    cursor: Optional[str] = None
+
+    for page in range(1, 11):
+        data = _graphql(
+            _FETCH_PRS_QUERY,
+            {'owner': owner, 'repo': repo, 'after': cursor},
+            token,
+        )
+        pr_conn = data['data']['repository']['pullRequests']
+        nodes = pr_conn['nodes']
+        raw_nodes.extend(nodes)
+        print(f'  page {page}: {len(raw_nodes)} PRs fetched', file=sys.stderr)
+
+        has_next = pr_conn['pageInfo']['hasNextPage']
+        cursor = pr_conn['pageInfo']['endCursor']
+        if not nodes:
+            break
+        oldest_updated = _iso_to_epoch(nodes[-1]['updatedAt'])
+        if not has_next or oldest_updated < stop_updated_epoch:
+            break
+
+    prs = []
+    for node in raw_nodes:
+        merge_commit = node.get('mergeCommit') or {}
+        merge_sha = merge_commit.get('oid', '')
+        if not merge_sha:
+            continue
+
+        files = node['files']
+        if files['totalCount'] > 100:
+            print(
+                f"  PR #{node['number']} has {files['totalCount']} files; fetching full list",
+                file=sys.stderr,
+            )
+            paths = frozenset(_rest_pr_files(node['number'], owner, repo, token))
+        else:
+            paths = frozenset(f['path'] for f in files['nodes'])
+
+        prs.append(PullRequest(
+            number=node['number'],
+            title=node['title'],
+            merged_epoch=_iso_to_epoch(node['mergedAt']),
+            merge_sha=merge_sha,
+            paths=paths,
+        ))
+
+    prs.sort(key=lambda p: p.merged_epoch, reverse=True)
+    return prs
+
+
+# ---------------------------------------------------------------------------
+# Git helpers
+# ---------------------------------------------------------------------------
+
+def check_is_reverted(sha: str, head_sha: str) -> bool:
+    """
+    Return True if a revert commit for sha exists between sha..head_sha.
+    git revert (and GitHub's UI-driven revert) writes the exact string
+    "This reverts commit <sha>." in the commit message.
+    """
+    try:
+        out = subprocess.check_output(
+            ['git', 'log', '--format=%H', f'{sha}..{head_sha}',
+             f'--grep=This reverts commit {sha}'],
+            text=True, stderr=subprocess.DEVNULL,
+        )
+        return bool(out.strip())
+    except subprocess.CalledProcessError:
+        return False
+
+
+# ---------------------------------------------------------------------------
+# Claude / PR details
+# ---------------------------------------------------------------------------
+
+def fetch_pr_details(
+    pr_number: int,
+    owner: str,
+    repo: str,
+    token: str,
+    diff_line_cap: int = 2000,
+) -> str:
+    """
+    Fetch PR title, body, and diff.
+
+    Tries gh pr diff first (fast, single request). If GitHub rejects it with
+    HTTP 406 (PR exceeds the aggregate diff limit of 300 files / 20 000 lines),
+    falls back to the paginated 'list PR files' REST API which returns per-file
+    patches without that aggregate limit.
+    """
+    try:
+        meta = subprocess.check_output(
+            ['gh', 'pr', 'view', str(pr_number),
+             '--json', 'title,body',
+             '--template', '{{.title}}\n\n{{.body}}'],
+            text=True,
+            stderr=subprocess.DEVNULL,
+        )
+    except subprocess.CalledProcessError:
+        meta = f'(could not fetch PR #{pr_number} metadata)'
+
+    try:
+        diff_lines = subprocess.check_output(
+            ['gh', 'pr', 'diff', str(pr_number)],
+            text=True,
+            stderr=subprocess.DEVNULL,
+        ).splitlines()
+        diff = '\n'.join(diff_lines[:diff_line_cap])
+        if len(diff_lines) > diff_line_cap:
+            diff += f'\n... [truncated at {diff_line_cap} lines]'
+    except subprocess.CalledProcessError:
+        # HTTP 406: PR exceeds GitHub's aggregate diff size limit.
+        # Fall back to the paginated files API which returns per-file patches.
+        try:
+            diff = _rest_pr_diff(pr_number, owner, repo, token, diff_line_cap)
+        except Exception as exc:
+            diff = f'(diff not available: {exc})'
+
+    return f'{meta.strip()}\n\n--- diff ---\n{diff}'
+
+
+def build_claude_prompt(
+    image_name: str,
+    source_dir: str,
+    chosen_pr_num: int,
+    chosen_pr_body: str,
+    later_pr_bodies: list,  # [(pr_num, body_text), ...]
+) -> str:
+    later_sections = '\n\n'.join(
+        f'=== LATER: PR #{num} ===\n{body}' for num, body in later_pr_bodies
+    )
+    return (
+        f"You are auditing a release pipeline for the Estuary connectors monorepo.\n"
+        f"We are about to promote image '{image_name}' (source dir '{source_dir}/') to\n"
+        f"the ':delayed' tag, pinned to PR #{chosen_pr_num}.\n\n"
+        f"Determine whether any LATER PR is a roll-forward fix of the CHOSEN PR —\n"
+        f"i.e. patches a bug or regression introduced BY the CHOSEN PR. A feature\n"
+        f"addition, refactor, dependency bump, test addition, or unrelated bugfix\n"
+        f"is NOT a roll-forward fix. Only flag PRs that exist because the CHOSEN\n"
+        f"PR was buggy.\n\n"
+        f"Note: this repo uses rebase-and-merge, so each PR's commits land on main\n"
+        f"as a linear sequence — judge PRs as units, not individual commits.\n\n"
+        f"=== CHOSEN: PR #{chosen_pr_num} ===\n{chosen_pr_body}\n\n"
+        f"{later_sections}\n\n"
+        f'Reply with ONLY a JSON object, no prose:\n'
+        f'{{"verdict": "safe" | "hold", "reason": "<one short sentence>", '
+        f'"fix_prs": [<pr numbers that are roll-forward fixes of CHOSEN>]}}\n'
+        f'Use "hold" iff at least one LATER PR is a roll-forward fix of CHOSEN. '
+        f'Otherwise "safe".'
+    )
+
+
+def call_claude(prompt: str, api_key: str, model: str = 'claude-sonnet-4-6') -> str:
+    """Call the Anthropic Messages API and return the assistant's text."""
+    payload = json.dumps({
+        'model': model,
+        'max_tokens': 1024,
+        'messages': [{'role': 'user', 'content': prompt}],
+    }).encode()
+    req = urllib.request.Request(
+        'https://api.anthropic.com/v1/messages',
+        data=payload,
+        headers={
+            'x-api-key': api_key,
+            'anthropic-version': '2023-06-01',
+            'content-type': 'application/json',
+        },
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=90) as resp:
+            return json.loads(resp.read())['content'][0]['text']
+    except (urllib.error.URLError, KeyError, json.JSONDecodeError) as exc:
+        raise RuntimeError(f'Claude API error: {exc}') from exc
+
+
+# ---------------------------------------------------------------------------
+# TSV I/O
+# ---------------------------------------------------------------------------
+
+def write_plan(entries: list, path: str) -> None:
+    with open(path, 'w') as f:
+        for e in entries:
+            f.write(f'{e.image_name}\t{e.chosen_sha7}\t{e.chosen_pr}\t{e.source_dir}\n')
+
+
+def read_plan(path: str) -> list:
+    entries = []
+    with open(path) as f:
+        for line in f:
+            parts = line.rstrip('\n').split('\t')
+            if len(parts) == 4:
+                entries.append(PlanEntry(
+                    image_name=parts[0],
+                    chosen_sha7=parts[1],
+                    chosen_pr=int(parts[2]),
+                    source_dir=parts[3],
+                ))
+    return entries
+
+
+def write_later(entries: list, path: str) -> None:
+    with open(path, 'w') as f:
+        for e in entries:
+            f.write(f'{e.image_name}\t{e.pr_number}\n')
+
+
+def read_later(path: str) -> dict:
+    """Returns {image_name: [pr_number, ...]}."""
+    later: dict = {}
+    try:
+        with open(path) as f:
+            for line in f:
+                parts = line.rstrip('\n').split('\t')
+                if len(parts) == 2:
+                    later.setdefault(parts[0], []).append(int(parts[1]))
+    except FileNotFoundError:
+        pass
+    return later
+
+
+def write_safe_plan(entries: list, path: str) -> None:
+    """Write the two-column file consumed by the tag step (image TAB sha7)."""
+    with open(path, 'w') as f:
+        for e in entries:
+            f.write(f'{e.image_name}\t{e.chosen_sha7}\n')
+
+
+def write_verdicts(verdicts: list, path: str) -> None:
+    with open(path, 'w') as f:
+        for v in verdicts:
+            f.write(f'{v.image_name}\t{v.verdict}\t{v.reason}\n')
+
+
+# ---------------------------------------------------------------------------
+# Subcommands
+# ---------------------------------------------------------------------------
+
+def cmd_plan(args: argparse.Namespace) -> None:
+    head_sha = subprocess.check_output(
+        ['git', 'rev-parse', 'HEAD'], text=True,
+    ).strip()
+    cutoff_epoch = int(time.time()) - args.cutoff_days * 86400
+    owner, repo = args.repo.split('/', 1)
+    token = os.environ['GH_TOKEN']
+
+    print(f'Cutoff: {datetime.datetime.utcfromtimestamp(cutoff_epoch).isoformat()}Z')
+    print(f'HEAD:   {head_sha[:7]}')
+
+    connector_images = load_connector_images(args.ci_yaml, args.python_yaml)
+    print(f'Considering {len(connector_images)} connector image(s)')
+
+    prs = fetch_merged_prs(owner, repo, token, lookback_days=args.lookback_days)
+    print(f'Fetched {len(prs)} merged PR(s) in {args.lookback_days}-day window')
+
+    plan: list = []
+    later_all: list = []
+
+    for ci in connector_images:
+        if not Path(ci.source_dir).is_dir():
+            print(f'skip {ci.image_name}: {ci.source_dir}/ not found at HEAD')
+            continue
+        chosen, later = find_boundary(
+            ci.image_name,
+            ci.source_dir,
+            prs,
+            cutoff_epoch,
+            is_reverted=lambda sha, h=head_sha: check_is_reverted(sha, h),
+        )
+        if chosen is None:
+            print(f'skip {ci.image_name}: no eligible PR in lookback window')
+            continue
+        plan.append(chosen)
+        later_all.extend(later)
+        print(f'  {ci.image_name} -> PR #{chosen.chosen_pr} ({chosen.chosen_sha7})')
+
+    write_plan(plan, args.output_plan)
+    write_later(later_all, args.output_later)
+    print(f'\nPlan: {len(plan)} entries, {len(later_all)} (image, later-PR) pairs')
+
+
+def cmd_check(args: argparse.Namespace) -> None:
+    api_key = os.environ.get('ANTHROPIC_API_KEY', '')
+    plan = read_plan(args.plan)
+
+    if not api_key:
+        print('::warning::ANTHROPIC_API_KEY not set; skipping roll-forward check')
+        write_safe_plan(plan, args.output_safe)
+        write_verdicts([], args.output_verdicts)
+        return
+
+    gh_token = os.environ.get('GH_TOKEN', '')
+    gh_repo = os.environ.get('GITHUB_REPOSITORY', args.repo)
+    owner, repo = gh_repo.split('/', 1) if '/' in gh_repo else ('', '')
+
+    later_map = read_later(args.later)
+    verdicts: list = []
+    # Cache keyed by (chosen_pr, source_dir) so variants sharing the same
+    # parent dir don't trigger duplicate Claude API calls.
+    verdict_cache: dict = {}
+    # Cache PR details by PR number so large LATER PRs shared across multiple
+    # connectors (e.g. a monorepo sweep) are only fetched once.
+    pr_details_cache: dict = {}
+
+    def fetch_cached(pr_number: int) -> str:
+        if pr_number not in pr_details_cache:
+            pr_details_cache[pr_number] = fetch_pr_details(
+                pr_number, owner, repo, gh_token, diff_line_cap=args.diff_line_cap
+            )
+        return pr_details_cache[pr_number]
+
+    for entry in plan:
+        later_prs = later_map.get(entry.image_name, [])
+        if not later_prs:
+            continue
+
+        cache_key = (entry.chosen_pr, entry.source_dir)
+        if cache_key in verdict_cache:
+            cached = verdict_cache[cache_key]
+            verdicts.append(Verdict(entry.image_name, cached.verdict, cached.reason))
+            print(f'  {entry.image_name}: reusing verdict from sibling connector')
+            continue
+
+        print(
+            f'Checking {entry.image_name}: PR #{entry.chosen_pr}'
+            f' ({len(later_prs)} later PR(s))'
+        )
+        chosen_body = fetch_cached(entry.chosen_pr)
+        later_bodies = [
+            (pr, fetch_cached(pr))
+            for pr in later_prs
+        ]
+        prompt = build_claude_prompt(
+            entry.image_name, entry.source_dir,
+            entry.chosen_pr, chosen_body,
+            later_bodies,
+        )
+
+        try:
+            raw = call_claude(prompt, api_key, model=args.model)
+        except RuntimeError as exc:
+            print(f'::warning::{entry.image_name}: {exc}; treating as safe')
+            verdict = Verdict(entry.image_name, 'safe', f'api error: {exc}')
+        else:
+            verdict = parse_claude_verdict(raw, entry.image_name)
+
+        verdict_cache[cache_key] = verdict
+        verdicts.append(verdict)
+
+        if verdict.verdict == 'hold':
+            print(f'::warning::{entry.image_name}: HOLD — {verdict.reason}')
+        else:
+            print(f'  {entry.image_name}: safe — {verdict.reason or "no roll-forward fix"}')
+
+    verdict_map = {v.image_name: v for v in verdicts}
+    safe, held = build_safe_plan(plan, verdict_map)
+
+    write_safe_plan(safe, args.output_safe)
+    write_verdicts(verdicts, args.output_verdicts)
+
+    print(f'\nClaude checked {len(verdict_cache)} unique connector(s)')
+    if held:
+        print(f'Held ({len(held)}): {", ".join(e.image_name for e in held)}')
+    print(f'Tagging {len(safe)}/{len(plan)} connector(s) after hold filter')
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def main(argv: Optional[list] = None) -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    sub = parser.add_subparsers(dest='command', required=True)
+
+    p = sub.add_parser('plan', help='compute per-connector boundary PRs')
+    p.add_argument('--repo',          default=os.environ.get('GITHUB_REPOSITORY', ''))
+    p.add_argument('--ci-yaml',       default='.github/workflows/ci.yaml')
+    p.add_argument('--python-yaml',   default='.github/workflows/python.yaml')
+    p.add_argument('--cutoff-days',   type=int, default=14)
+    p.add_argument('--lookback-days', type=int, default=60)
+    p.add_argument('--output-plan',   default='/tmp/plan.tsv')
+    p.add_argument('--output-later',  default='/tmp/later.tsv')
+
+    p = sub.add_parser('check', help='Claude roll-forward fix check')
+    p.add_argument('--repo',            default=os.environ.get('GITHUB_REPOSITORY', ''))
+    p.add_argument('--plan',            default='/tmp/plan.tsv')
+    p.add_argument('--later',           default='/tmp/later.tsv')
+    p.add_argument('--model',           default='claude-sonnet-4-6')
+    p.add_argument('--diff-line-cap',   type=int, default=2000)
+    p.add_argument('--output-safe',     default='/tmp/safe_plan.tsv')
+    p.add_argument('--output-verdicts', default='/tmp/claude_verdicts.tsv')
+
+    args = parser.parse_args(argv)
+    {'plan': cmd_plan, 'check': cmd_check}[args.command](args)
+
+
+if __name__ == '__main__':
+    main()

--- a/.github/scripts/test_delayed_tag.py
+++ b/.github/scripts/test_delayed_tag.py
@@ -1,0 +1,302 @@
+"""Unit tests for delayed_tag.py."""
+
+import unittest
+from delayed_tag import (
+    PullRequest,
+    PlanEntry,
+    LaterEntry,
+    Verdict,
+    build_safe_plan,
+    build_claude_prompt,
+    find_boundary,
+    parse_claude_verdict,
+    pr_touches_dir,
+)
+
+
+def make_pr(number: int, merged_epoch: int, sha_prefix: str, paths: list) -> PullRequest:
+    return PullRequest(
+        number=number,
+        title=f'PR {number}',
+        merged_epoch=merged_epoch,
+        merge_sha=sha_prefix * (40 // len(sha_prefix) + 1),
+        paths=frozenset(paths),
+    )
+
+
+def make_plan(image: str, sha7: str = 'abc1234', pr: int = 1, source_dir: str = '') -> PlanEntry:
+    return PlanEntry(
+        image_name=image,
+        chosen_sha7=sha7,
+        chosen_pr=pr,
+        source_dir=source_dir or image,
+    )
+
+
+NEVER_REVERTED = lambda sha: False
+ALWAYS_REVERTED = lambda sha: True
+
+
+# ---------------------------------------------------------------------------
+# pr_touches_dir
+# ---------------------------------------------------------------------------
+
+class TestPrTouchesDir(unittest.TestCase):
+
+    def test_direct_child_file(self):
+        pr = make_pr(1, 0, 'a', ['source-mysql/main.go'])
+        self.assertTrue(pr_touches_dir(pr, 'source-mysql'))
+
+    def test_nested_file(self):
+        pr = make_pr(1, 0, 'a', ['source-mysql/internal/cfg/config.go'])
+        self.assertTrue(pr_touches_dir(pr, 'source-mysql'))
+
+    def test_prefix_does_not_match_sibling(self):
+        # source-mysql-batch should NOT match source-mysql
+        pr = make_pr(1, 0, 'a', ['source-mysql-batch/main.go'])
+        self.assertFalse(pr_touches_dir(pr, 'source-mysql'))
+
+    def test_unrelated_dir(self):
+        pr = make_pr(1, 0, 'a', ['source-postgres/main.go'])
+        self.assertFalse(pr_touches_dir(pr, 'source-mysql'))
+
+    def test_empty_paths(self):
+        pr = make_pr(1, 0, 'a', [])
+        self.assertFalse(pr_touches_dir(pr, 'source-mysql'))
+
+    def test_root_files_dont_match(self):
+        pr = make_pr(1, 0, 'a', ['Makefile', 'go.sum', '.github/workflows/ci.yaml'])
+        self.assertFalse(pr_touches_dir(pr, 'source-mysql'))
+
+    def test_multiple_paths_one_matches(self):
+        pr = make_pr(1, 0, 'a', ['source-postgres/main.go', 'source-mysql/main.go'])
+        self.assertTrue(pr_touches_dir(pr, 'source-mysql'))
+        self.assertTrue(pr_touches_dir(pr, 'source-postgres'))
+
+    def test_trailing_slash_on_dir_arg(self):
+        pr = make_pr(1, 0, 'a', ['source-mysql/main.go'])
+        self.assertTrue(pr_touches_dir(pr, 'source-mysql/'))
+
+
+# ---------------------------------------------------------------------------
+# find_boundary
+# ---------------------------------------------------------------------------
+
+class TestFindBoundary(unittest.TestCase):
+
+    def test_basic_selection(self):
+        cutoff = 1000
+        prs = [
+            make_pr(3, 1200, 'ccc', ['source-foo/c.go']),  # after cutoff → later
+            make_pr(2, 900,  'bbb', ['source-foo/b.go']),  # within cutoff ← chosen
+            make_pr(1, 600,  'aaa', ['source-foo/a.go']),  # older, not considered
+        ]
+        chosen, later = find_boundary('source-foo', 'source-foo', prs, cutoff, NEVER_REVERTED)
+        self.assertIsNotNone(chosen)
+        self.assertEqual(chosen.chosen_pr, 2)
+        self.assertEqual(chosen.chosen_sha7, prs[1].merge_sha[:7])
+        self.assertEqual(len(later), 1)
+        self.assertEqual(later[0].pr_number, 3)
+
+    def test_skips_prs_in_other_dirs(self):
+        cutoff = 1000
+        prs = [
+            make_pr(2, 900, 'bbb', ['source-bar/a.go']),  # wrong dir
+            make_pr(1, 800, 'aaa', ['source-foo/a.go']),  # correct dir ← chosen
+        ]
+        chosen, later = find_boundary('source-foo', 'source-foo', prs, cutoff, NEVER_REVERTED)
+        self.assertIsNotNone(chosen)
+        self.assertEqual(chosen.chosen_pr, 1)
+        self.assertEqual(later, [])
+
+    def test_skips_reverted_and_falls_back(self):
+        cutoff = 1000
+        reverted_sha = 'aaaa' * 10
+        prs = [
+            PullRequest(2, 'PR 2', 900, reverted_sha, frozenset(['source-foo/a.go'])),
+            make_pr(1, 800, 'bbb', ['source-foo/b.go']),  # not reverted ← chosen
+        ]
+        chosen, later = find_boundary(
+            'source-foo', 'source-foo', prs, cutoff,
+            is_reverted=lambda sha: sha == reverted_sha,
+        )
+        self.assertIsNotNone(chosen)
+        self.assertEqual(chosen.chosen_pr, 1)
+
+    def test_returns_none_when_all_within_cutoff(self):
+        cutoff = 1000
+        prs = [make_pr(1, 1100, 'aaa', ['source-foo/a.go'])]
+        chosen, later = find_boundary('source-foo', 'source-foo', prs, cutoff, NEVER_REVERTED)
+        self.assertIsNone(chosen)
+        self.assertEqual(len(later), 1)
+
+    def test_returns_none_when_all_reverted(self):
+        cutoff = 1000
+        prs = [make_pr(1, 900, 'aaa', ['source-foo/a.go'])]
+        chosen, later = find_boundary('source-foo', 'source-foo', prs, cutoff, ALWAYS_REVERTED)
+        self.assertIsNone(chosen)
+        self.assertEqual(later, [])
+
+    def test_returns_none_when_empty(self):
+        chosen, later = find_boundary('source-foo', 'source-foo', [], 1000, NEVER_REVERTED)
+        self.assertIsNone(chosen)
+        self.assertEqual(later, [])
+
+    def test_later_includes_only_connector_prs(self):
+        cutoff = 1000
+        prs = [
+            make_pr(5, 1400, 'eee', ['source-foo/a.go']),  # later, same dir
+            make_pr(4, 1200, 'ddd', ['source-bar/a.go']),  # later, different dir → excluded
+            make_pr(3, 1100, 'ccc', ['source-foo/b.go']),  # later, same dir
+            make_pr(2, 900,  'bbb', ['source-foo/c.go']),  # chosen
+            make_pr(1, 700,  'aaa', ['source-foo/d.go']),  # older
+        ]
+        chosen, later = find_boundary('source-foo', 'source-foo', prs, cutoff, NEVER_REVERTED)
+        self.assertEqual(chosen.chosen_pr, 2)
+        self.assertEqual({e.pr_number for e in later}, {3, 5})
+
+    def test_image_name_propagated_to_later_entries(self):
+        cutoff = 1000
+        prs = [
+            make_pr(2, 1200, 'bbb', ['source-foo/a.go']),
+            make_pr(1, 900, 'aaa', ['source-foo/b.go']),
+        ]
+        chosen, later = find_boundary(
+            'source-foo-variant', 'source-foo', prs, cutoff, NEVER_REVERTED
+        )
+        self.assertEqual(chosen.image_name, 'source-foo-variant')
+        self.assertEqual(later[0].image_name, 'source-foo-variant')
+
+    def test_sha7_is_first_seven_chars(self):
+        cutoff = 1000
+        prs = [make_pr(1, 900, 'deadbeef1', ['source-foo/a.go'])]
+        chosen, _ = find_boundary('source-foo', 'source-foo', prs, cutoff, NEVER_REVERTED)
+        self.assertEqual(chosen.chosen_sha7, prs[0].merge_sha[:7])
+
+
+# ---------------------------------------------------------------------------
+# parse_claude_verdict
+# ---------------------------------------------------------------------------
+
+class TestParseClaudeVerdict(unittest.TestCase):
+
+    def test_safe_verdict(self):
+        raw = '{"verdict": "safe", "reason": "unrelated change", "fix_prs": []}'
+        v = parse_claude_verdict(raw, 'img')
+        self.assertEqual(v.verdict, 'safe')
+        self.assertEqual(v.reason, 'unrelated change')
+        self.assertEqual(v.image_name, 'img')
+
+    def test_hold_verdict(self):
+        raw = '{"verdict": "hold", "reason": "PR #42 patches regression in CHOSEN", "fix_prs": [42]}'
+        v = parse_claude_verdict(raw, 'img')
+        self.assertEqual(v.verdict, 'hold')
+        self.assertIn('42', v.reason)
+
+    def test_invalid_json_falls_back_to_safe(self):
+        v = parse_claude_verdict('not valid json!', 'img')
+        self.assertEqual(v.verdict, 'safe')
+        self.assertIn('could not parse', v.reason)
+
+    def test_unknown_verdict_value_falls_back_to_safe(self):
+        raw = '{"verdict": "maybe", "reason": "unsure"}'
+        v = parse_claude_verdict(raw, 'img')
+        self.assertEqual(v.verdict, 'safe')
+
+    def test_missing_verdict_key_defaults_to_safe(self):
+        raw = '{"reason": "looks fine"}'
+        v = parse_claude_verdict(raw, 'img')
+        self.assertEqual(v.verdict, 'safe')
+
+    def test_empty_string_falls_back_to_safe(self):
+        v = parse_claude_verdict('', 'img')
+        self.assertEqual(v.verdict, 'safe')
+
+    def test_verdict_case_insensitive(self):
+        raw = '{"verdict": "HOLD", "reason": "bug found"}'
+        v = parse_claude_verdict(raw, 'img')
+        self.assertEqual(v.verdict, 'hold')
+
+    def test_missing_reason_defaults_to_empty(self):
+        raw = '{"verdict": "safe"}'
+        v = parse_claude_verdict(raw, 'img')
+        self.assertEqual(v.reason, '')
+
+
+# ---------------------------------------------------------------------------
+# build_safe_plan
+# ---------------------------------------------------------------------------
+
+class TestBuildSafePlan(unittest.TestCase):
+
+    def test_no_verdicts_all_pass(self):
+        plan = [make_plan('a'), make_plan('b')]
+        safe, held = build_safe_plan(plan, {})
+        self.assertEqual([e.image_name for e in safe], ['a', 'b'])
+        self.assertEqual(held, [])
+
+    def test_hold_removes_entry(self):
+        plan = [make_plan('a'), make_plan('b'), make_plan('c')]
+        verdicts = {'b': Verdict('b', 'hold', 'regression found')}
+        safe, held = build_safe_plan(plan, verdicts)
+        self.assertEqual([e.image_name for e in safe], ['a', 'c'])
+        self.assertEqual([e.image_name for e in held], ['b'])
+
+    def test_safe_verdict_passes_entry(self):
+        plan = [make_plan('a')]
+        verdicts = {'a': Verdict('a', 'safe', 'all good')}
+        safe, held = build_safe_plan(plan, verdicts)
+        self.assertEqual(len(safe), 1)
+        self.assertEqual(held, [])
+
+    def test_multiple_holds(self):
+        plan = [make_plan('a'), make_plan('b'), make_plan('c')]
+        verdicts = {
+            'a': Verdict('a', 'hold', 'bug a'),
+            'c': Verdict('c', 'hold', 'bug c'),
+        }
+        safe, held = build_safe_plan(plan, verdicts)
+        self.assertEqual([e.image_name for e in safe], ['b'])
+        self.assertEqual({e.image_name for e in held}, {'a', 'c'})
+
+    def test_preserves_plan_order(self):
+        plan = [make_plan('z'), make_plan('a'), make_plan('m')]
+        safe, _ = build_safe_plan(plan, {})
+        self.assertEqual([e.image_name for e in safe], ['z', 'a', 'm'])
+
+
+# ---------------------------------------------------------------------------
+# build_claude_prompt
+# ---------------------------------------------------------------------------
+
+class TestBuildClaudePrompt(unittest.TestCase):
+
+    def test_contains_image_and_dir(self):
+        prompt = build_claude_prompt(
+            'source-mysql', 'source-mysql', 42,
+            'Title\n\nbody text', [(99, 'fix title\n\nfix body')]
+        )
+        self.assertIn('source-mysql', prompt)
+        self.assertIn('PR #42', prompt)
+        self.assertIn('PR #99', prompt)
+
+    def test_instructs_json_response(self):
+        prompt = build_claude_prompt('img', 'dir', 1, 'body', [])
+        self.assertIn('"verdict"', prompt)
+        self.assertIn('"hold"', prompt)
+        self.assertIn('"safe"', prompt)
+
+    def test_multiple_later_prs(self):
+        later = [(10, 'PR ten'), (20, 'PR twenty'), (30, 'PR thirty')]
+        prompt = build_claude_prompt('img', 'dir', 5, 'chosen', later)
+        self.assertIn('PR #10', prompt)
+        self.assertIn('PR #20', prompt)
+        self.assertIn('PR #30', prompt)
+
+    def test_no_later_prs(self):
+        prompt = build_claude_prompt('img', 'dir', 5, 'chosen body', [])
+        self.assertIn('PR #5', prompt)
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)

--- a/.github/workflows/delayed-tag.yaml
+++ b/.github/workflows/delayed-tag.yaml
@@ -1,0 +1,402 @@
+name: Delayed tag
+
+# Publish a ':delayed' image tag for each connector, pointing at the most
+# recent pull-request affecting that connector that was merged into `main` at
+# least 2 weeks ago AND whose merge has not since been reverted on `main`.
+#
+# The boundary is per-connector: an idle connector keeps a stable ':delayed'
+# tag even when other connectors are seeing churn. The unit is the PR (not the
+# commit): the repo uses rebase-and-merge, so a single PR's commits land on
+# main as a linear sequence of N commits, and mid-PR states may not build or
+# behave correctly. We always pin ':delayed' to a PR's tip commit on main
+# (`mergeCommit.oid`), which is what CI built and pushed to GHCR.
+#
+# After picking a candidate PR per connector we also ask Claude Sonnet to
+# check whether any *later* PR touching the same directory is a roll-forward
+# fix of the candidate — i.e. a hotfix patching a regression the candidate
+# introduced. Currently advisory: the verdict is logged but does not yet drop
+# flagged connectors from the plan.
+
+on:
+  schedule:
+    - cron: '0 6 * * *'
+  workflow_dispatch:
+  # While this workflow is in dry-run mode, also trigger on pull-requests that
+  # touch the workflow itself so we can iterate on it without merging to main.
+  pull_request:
+    branches: [main]
+    paths:
+      - '.github/workflows/delayed-tag.yaml'
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  packages: write
+  pull-requests: read
+
+jobs:
+  publish_delayed:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # Full history is required so we can walk first-parent commits per
+          # connector directory and check for revert references on `main`.
+          fetch-depth: 0
+
+      - name: Login to GitHub package docker registry
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Plan per-connector delayed PR boundaries
+        id: plan
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          CUTOFF_EPOCH=$(date -u -d '14 days ago' +%s)
+          CUTOFF_ISO=$(date -u -d "@${CUTOFF_EPOCH}" '+%Y-%m-%dT%H:%M:%SZ')
+          echo "Cutoff: ${CUTOFF_ISO}"
+          HEAD_REF=$(git rev-parse HEAD)
+          OWNER=${GITHUB_REPOSITORY%%/*}
+          REPO=${GITHUB_REPOSITORY##*/}
+
+          # The set of connector images comes from the matrices in ci.yaml and
+          # python.yaml. Each image is published from the connector's source
+          # directory (image name == directory). Variants declared in
+          # <connector>/VARIANTS are additional image names built from the
+          # parent connector's directory, so they inherit its boundary.
+          #
+          # Output schema (tab-separated): <image_name>\t<source_dir>
+          {
+            yq '.jobs.build_connectors.strategy.matrix.connector[]' .github/workflows/ci.yaml
+            yq '.jobs.build_connectors.strategy.matrix.include[].connector' .github/workflows/ci.yaml
+            yq '.jobs.py_connector.strategy.matrix.connector[].name' .github/workflows/python.yaml
+          } | awk 'NF && !seen[$0]++' > /tmp/connectors.txt
+
+          : > /tmp/images.tsv
+          while IFS= read -r CONNECTOR; do
+            [ -z "${CONNECTOR}" ] && continue
+            printf '%s\t%s\n' "${CONNECTOR}" "${CONNECTOR}" >> /tmp/images.tsv
+            if [ -f "${CONNECTOR}/VARIANTS" ]; then
+              # VARIANTS is whitespace-separated.
+              for VARIANT in $(cat "${CONNECTOR}/VARIANTS"); do
+                printf '%s\t%s\n' "${VARIANT}" "${CONNECTOR}" >> /tmp/images.tsv
+              done
+            fi
+          done < /tmp/connectors.txt
+          awk -F'\t' '!seen[$1]++' /tmp/images.tsv > /tmp/images.dedup.tsv
+          mv /tmp/images.dedup.tsv /tmp/images.tsv
+          echo "Considering $(wc -l < /tmp/images.tsv) connector image(s)"
+
+          # Fetch merged PRs newest-first via GraphQL. PR is our unit of work:
+          # with rebase-and-merge, a PR's commits land on main as a linear
+          # sequence, and pinning ':delayed' to a non-tip commit could ship
+          # a mid-PR state that doesn't build or behave correctly. We always
+          # use the PR's mergeCommit.oid (the tip of the rebased sequence,
+          # which CI built and pushed to GHCR).
+          #
+          # GraphQL only supports orderBy: UPDATED_AT (not MERGED_AT), so we
+          # paginate by updatedAt then re-sort by mergedAt locally. We stop
+          # paginating once we've gone 60 days back by updatedAt, or hit 10
+          # pages (1000 PRs) — plenty to find a CHOSEN for any active
+          # connector and all LATER PRs that landed since.
+          : > /tmp/prs.jsonl
+          CURSOR=""
+          STOP_UPDATED_EPOCH=$(date -u -d '60 days ago' +%s)
+          for page in $(seq 1 10); do
+            if [ -z "${CURSOR}" ]; then
+              AFTER_ARG=""
+            else
+              AFTER_ARG=", after: \"${CURSOR}\""
+            fi
+            RESP=$(gh api graphql -f query="
+              query {
+                repository(owner: \"${OWNER}\", name: \"${REPO}\") {
+                  pullRequests(states: MERGED, baseRefName: \"main\", orderBy: {field: UPDATED_AT, direction: DESC}, first: 100${AFTER_ARG}) {
+                    pageInfo { hasNextPage endCursor }
+                    nodes {
+                      number
+                      title
+                      mergedAt
+                      updatedAt
+                      mergeCommit { oid }
+                      files(first: 100) { totalCount nodes { path } }
+                    }
+                  }
+                }
+              }
+            ")
+            echo "$RESP" | jq -c '.data.repository.pullRequests.nodes[]' >> /tmp/prs.jsonl
+            HAS_NEXT=$(echo "$RESP" | jq -r '.data.repository.pullRequests.pageInfo.hasNextPage')
+            CURSOR=$(echo  "$RESP" | jq -r '.data.repository.pullRequests.pageInfo.endCursor')
+            OLDEST_UPDATED=$(echo "$RESP" | jq -r '.data.repository.pullRequests.nodes | last | .updatedAt | fromdateiso8601')
+            echo "  page ${page}: $(wc -l < /tmp/prs.jsonl) PRs total, oldest updatedAt @$(date -u -d @${OLDEST_UPDATED} '+%Y-%m-%dT%H:%M:%SZ')"
+            [ "$HAS_NEXT" = "true" ] || break
+            [ "${OLDEST_UPDATED}" -lt "${STOP_UPDATED_EPOCH}" ] && break
+          done
+
+          # Reshape to TSV. GraphQL caps `files(first:)` at 100 per PR, so we
+          # also pull totalCount and, for any PR that exceeds 100 files, fetch
+          # the full file list via the REST endpoint (which paginates without
+          # that cap) so we never silently undercount a connector's touch.
+          #
+          # Final schema sorted by mergedAt desc:
+          #   <pr_num>\t<merged_epoch>\t<tip_sha>\t<paths_pipe_joined>
+          jq -r '[.number, (.mergedAt | fromdateiso8601), .mergeCommit.oid, .files.totalCount, (.files.nodes | map(.path) | join("|"))] | @tsv' \
+            /tmp/prs.jsonl > /tmp/prs.raw.tsv
+          : > /tmp/prs.tsv
+          while IFS=$'\t' read -r PR_NUM PR_TS PR_SHA FILE_COUNT PATHS; do
+            if [ "${FILE_COUNT}" -gt 100 ]; then
+              echo "  PR #${PR_NUM} has ${FILE_COUNT} files; fetching full list via REST"
+              PATHS=$(gh api --paginate "/repos/${OWNER}/${REPO}/pulls/${PR_NUM}/files" \
+                        --jq '.[].filename' | paste -sd '|' -)
+            fi
+            printf '%s\t%s\t%s\t%s\n' "${PR_NUM}" "${PR_TS}" "${PR_SHA}" "${PATHS}"
+          done < /tmp/prs.raw.tsv | sort -t $'\t' -k2,2nr > /tmp/prs.tsv
+          echo "Considering $(wc -l < /tmp/prs.tsv) merged PR(s) in window"
+
+          # For each connector:
+          #   CHOSEN = newest PR with mergedAt <= cutoff that touched DIR/ and isn't reverted
+          #   LATER  = PRs with mergedAt > CHOSEN.mergedAt that touched DIR/
+          #
+          # Revert detection: `git revert` (and GitHub's UI revert, which is
+          # built on git revert) writes "This reverts commit <full-sha>." into
+          # the revert commit message. We grep for that against commits on
+          # main between the candidate PR's tip and HEAD.
+          : > /tmp/plan.tsv      # <image>\t<chosen_short_sha>\t<chosen_pr_num>
+          : > /tmp/later.tsv     # <image>\t<later_pr_num>           (one row per LATER PR per image)
+          while IFS=$'\t' read -r IMAGE DIR; do
+            [ -z "${IMAGE}" ] && continue
+            if [ ! -d "${DIR}" ]; then
+              echo "skip ${IMAGE}: directory ${DIR}/ not found at HEAD"
+              continue
+            fi
+
+            CHOSEN_SHA=""
+            CHOSEN_PR=""
+            LATER_FOR_IMAGE=()
+
+            while IFS=$'\t' read -r PR_NUM PR_TS PR_SHA PR_PATHS; do
+              # Did this PR touch any file under DIR/? Anchored substring match.
+              case "|${PR_PATHS}|" in
+                *"|${DIR}/"*) ;;
+                "${DIR}/"*)   ;;
+                *) continue ;;
+              esac
+
+              if [ "${PR_TS}" -gt "${CUTOFF_EPOCH}" ]; then
+                LATER_FOR_IMAGE+=("${PR_NUM}")
+                continue
+              fi
+              # First PR within the cutoff. Skip if its tip was reverted.
+              if ! git cat-file -e "${PR_SHA}" 2>/dev/null; then
+                echo "  ${IMAGE}: PR #${PR_NUM} tip ${PR_SHA:0:7} not in local history, skipping"
+                continue
+              fi
+              if git log --format=%H "${PR_SHA}..${HEAD_REF}" \
+                   --grep="This reverts commit ${PR_SHA}" | grep -q .; then
+                echo "  ${IMAGE}: PR #${PR_NUM} (${PR_SHA:0:7}) was reverted, looking further back"
+                continue
+              fi
+              CHOSEN_SHA="${PR_SHA}"
+              CHOSEN_PR="${PR_NUM}"
+              break
+            done < /tmp/prs.tsv
+
+            if [ -z "${CHOSEN_SHA}" ]; then
+              echo "skip ${IMAGE}: no eligible PR touched ${DIR}/ within the lookback window"
+              continue
+            fi
+            printf '%s\t%s\t%s\n' "${IMAGE}" "${CHOSEN_SHA:0:7}" "${CHOSEN_PR}" >> /tmp/plan.tsv
+            echo "  ${IMAGE} -> PR #${CHOSEN_PR} (${CHOSEN_SHA:0:7})"
+            for L in "${LATER_FOR_IMAGE[@]}"; do
+              printf '%s\t%s\n' "${IMAGE}" "${L}" >> /tmp/later.tsv
+            done
+          done < /tmp/images.tsv
+
+          echo "Planned $(wc -l < /tmp/plan.tsv) delayed tag(s); $(wc -l < /tmp/later.tsv) (image, later-PR) pairs for roll-forward check"
+
+      - name: Check for roll-forward fixes via Claude (advisory)
+        # DRY RUN: for each planned delayed tag, ask Claude Sonnet whether any
+        # LATER PR touching the connector's directory is a roll-forward fix of
+        # the CHOSEN PR — i.e. patches a regression introduced by CHOSEN, as
+        # opposed to an unrelated change. Git reverts are already filtered out
+        # in the plan step; this catches the case where a bug is fixed forward
+        # instead of reverted.
+        #
+        # Currently advisory: the verdict is logged per connector but does not
+        # drop rows from /tmp/plan.tsv. To enforce, post-process the verdicts
+        # file before the tag step.
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -uo pipefail
+          if [ -z "${ANTHROPIC_API_KEY:-}" ]; then
+            echo "::warning::ANTHROPIC_API_KEY not set; skipping roll-forward check"
+            exit 0
+          fi
+          if [ ! -s /tmp/later.tsv ]; then
+            echo "no LATER PRs across any connector; nothing to check"
+            exit 0
+          fi
+
+          : > /tmp/claude_verdicts.tsv
+          flagged=0; checked=0
+
+          # Per-PR diff cap (in lines). Sonnet 4.6 has 200K context, but we
+          # bound each PR's diff to keep prompts predictable for very large
+          # PRs (e.g. generated code) — the commit messages plus first ~2000
+          # diff lines are typically enough to identify a roll-forward fix.
+          DIFF_LINE_CAP=2000
+
+          while IFS=$'\t' read -r IMAGE CHOSEN_SHA CHOSEN_PR; do
+            # Collect LATER PR numbers for this image.
+            mapfile -t LATER_PRS < <(awk -F'\t' -v img="${IMAGE}" '$1==img{print $2}' /tmp/later.tsv)
+            if [ "${#LATER_PRS[@]}" -eq 0 ]; then
+              printf '%s\tsafe\tno LATER PRs\n' "${IMAGE}" >> /tmp/claude_verdicts.tsv
+              continue
+            fi
+            DIR=$(awk -F'\t' -v img="${IMAGE}" '$1==img{print $2; exit}' /tmp/images.tsv)
+
+            {
+              printf '%s\n' \
+                "You are auditing a release pipeline for the Estuary connectors monorepo." \
+                "We are about to promote the image '${IMAGE}' (source dir '${DIR}/') to" \
+                "the ':delayed' tag, pinned to PR #${CHOSEN_PR}." \
+                "" \
+                "Determine whether any LATER PR is a roll-forward fix of the CHOSEN PR —" \
+                "i.e. patches a bug or regression introduced BY the CHOSEN PR. A feature" \
+                "addition, refactor, dependency bump, test addition, or unrelated bugfix" \
+                "is NOT a roll-forward fix. Only flag PRs that exist because the CHOSEN" \
+                "PR was buggy." \
+                "" \
+                "Note: this repo uses rebase-and-merge, so each PR's commits land on main" \
+                "as a linear sequence — judge PRs as units, not individual commits." \
+                ""
+              printf '=== CHOSEN: PR #%s ===\n' "${CHOSEN_PR}"
+              gh pr view "${CHOSEN_PR}" --json title,body \
+                --template '{{.title}}{{"\n\n"}}{{.body}}{{"\n"}}' || true
+              printf '\n--- diff (truncated to %s lines) ---\n' "${DIFF_LINE_CAP}"
+              gh pr diff "${CHOSEN_PR}" 2>/dev/null | head -n "${DIFF_LINE_CAP}" || true
+              printf '\n'
+              for L in "${LATER_PRS[@]}"; do
+                printf '=== LATER: PR #%s ===\n' "${L}"
+                gh pr view "${L}" --json title,body \
+                  --template '{{.title}}{{"\n\n"}}{{.body}}{{"\n"}}' || true
+                printf '\n--- diff (truncated to %s lines) ---\n' "${DIFF_LINE_CAP}"
+                gh pr diff "${L}" 2>/dev/null | head -n "${DIFF_LINE_CAP}" || true
+                printf '\n'
+              done
+              printf '%s\n' \
+                "Reply with ONLY a JSON object, no prose:" \
+                '{"verdict": "safe" | "hold", "reason": "<one short sentence>", "fix_prs": [<pr numbers that are roll-forward fixes of CHOSEN>]}' \
+                'Use "hold" iff at least one LATER PR is a roll-forward fix of CHOSEN. Otherwise "safe".'
+            } > /tmp/claude_prompt.txt
+
+            jq -n --rawfile p /tmp/claude_prompt.txt '{
+              model: "claude-sonnet-4-6",
+              max_tokens: 1024,
+              messages: [{role: "user", content: $p}]
+            }' > /tmp/claude_req.json
+
+            checked=$((checked + 1))
+            if ! curl -sS --fail-with-body https://api.anthropic.com/v1/messages \
+                  -H "content-type: application/json" \
+                  -H "x-api-key: ${ANTHROPIC_API_KEY}" \
+                  -H "anthropic-version: 2023-06-01" \
+                  --data-binary @/tmp/claude_req.json \
+                  -o /tmp/claude_resp.json; then
+              echo "::warning::${IMAGE}: Claude API call failed; treating as safe"
+              printf '%s\tsafe\tapi error\n' "${IMAGE}" >> /tmp/claude_verdicts.tsv
+              continue
+            fi
+
+            TEXT=$(jq -r '.content[0].text // ""' /tmp/claude_resp.json)
+            VERDICT=$(printf '%s' "${TEXT}" | jq -r '.verdict // "safe"' 2>/dev/null || echo "safe")
+            REASON=$(printf '%s'  "${TEXT}" | jq -r '.reason // ""'    2>/dev/null || echo "")
+
+            if [ "${VERDICT}" = "hold" ]; then
+              flagged=$((flagged + 1))
+              echo "::warning::${IMAGE}: HOLD on PR #${CHOSEN_PR} — ${REASON}"
+            else
+              echo "  ${IMAGE}: safe — ${REASON:-no LATER PR flagged}"
+            fi
+            printf '%s\t%s\t%s\n' "${IMAGE}" "${VERDICT}" "${REASON}" >> /tmp/claude_verdicts.tsv
+          done < /tmp/plan.tsv
+
+          echo "Claude checked ${checked} connector(s); flagged ${flagged} for HOLD (advisory, not enforced)"
+
+      - name: Tag images as ':delayed'
+        # DRY RUN: the only mutating call in this step (the `docker buildx
+        # imagetools create` line) is commented out. Everything else — the
+        # inspect probes, the per-image log lines, counters, and the summary —
+        # still executes, so the workflow logs are a faithful preview of what
+        # the real run will publish. To enable: uncomment the docker line and
+        # delete the `tag_cmd=true` line just above it.
+        run: |
+          set -uo pipefail
+          tagged=0; missing=0; failed=0
+          : > /tmp/tagged.txt
+          while IFS=$'\t' read -r IMAGE SHA; do
+            [ -z "${IMAGE}" ] && continue
+            SRC="ghcr.io/estuary/${IMAGE}:${SHA}"
+            DST="ghcr.io/estuary/${IMAGE}:delayed"
+            # `docker buildx imagetools create --tag DST SRC` is a manifest-only
+            # operation that creates DST pointing at the same digest as SRC. No
+            # image layers are downloaded or re-uploaded. It also fails fast
+            # when SRC is missing from the registry.
+            if ! docker buildx imagetools inspect "${SRC}" >/dev/null 2>&1; then
+              echo "skip ${IMAGE}: no image at ${SHA} (may have been pruned from registry)"
+              missing=$((missing + 1))
+              continue
+            fi
+            echo "would tag ${DST} -> ${SHA}"
+            tag_cmd=true  # DRY RUN — remove this line and uncomment the next to publish
+            # tag_cmd="docker buildx imagetools create --tag ${DST} ${SRC}"
+            if $tag_cmd >/dev/null; then
+              echo "${IMAGE}" >> /tmp/tagged.txt
+              tagged=$((tagged + 1))
+            else
+              echo "::warning::failed to tag ${IMAGE}"
+              failed=$((failed + 1))
+            fi
+          done < /tmp/plan.tsv
+          echo "Summary: tagged=${tagged} missing=${missing} failed=${failed}"
+          if [ "${failed}" -gt 0 ]; then
+            exit 1
+          fi
+
+      - name: Install psql
+        run: |
+          sudo apt update
+          sudo apt install -y postgresql-client
+
+      - name: Refresh connector_tags rows for ':delayed'
+        # DRY RUN: only the `| psql` pipe is commented out. The exact SQL we
+        # would run is still echoed per image, which is what we want preserved
+        # in the workflow logs for diagnostics.
+        env:
+          PGHOST: ${{ secrets.POSTGRES_CONNECTOR_REFRESH_HOST }}
+          PGUSER: ${{ secrets.POSTGRES_CONNECTOR_REFRESH_USER }}
+          PGPASSWORD: ${{ secrets.POSTGRES_CONNECTOR_REFRESH_PASSWORD }}
+          PGDATABASE: ${{ secrets.POSTGRES_CONNECTOR_REFRESH_DATABASE }}
+        run: |
+          set -euo pipefail
+          while IFS= read -r IMAGE; do
+            [ -z "${IMAGE}" ] && continue
+            echo "UPDATE connector_tags SET job_status='{\"type\": \"queued\"}'
+                    WHERE connector_id IN (
+                      SELECT id FROM connectors WHERE image_name='ghcr.io/estuary/${IMAGE}'
+                    ) AND image_tag = ':delayed';" # DRY RUN — append ` | psql` to publish
+          done < /tmp/tagged.txt

--- a/.github/workflows/delayed-tag.yaml
+++ b/.github/workflows/delayed-tag.yaml
@@ -14,19 +14,14 @@ name: Delayed tag
 # After picking a candidate PR per connector we also ask Claude Sonnet to
 # check whether any *later* PR touching the same directory is a roll-forward
 # fix of the candidate — i.e. a hotfix patching a regression the candidate
-# introduced. Currently advisory: the verdict is logged but does not yet drop
-# flagged connectors from the plan.
+# introduced. Connectors where Claude returns "hold" are excluded from
+# tagging: ':delayed' is supposed to be more stable, so we must not knowingly
+# ship a bug that was already fixed in a subsequent PR.
 
 on:
   schedule:
     - cron: '0 6 * * *'
   workflow_dispatch:
-  # While this workflow is in dry-run mode, also trigger on pull-requests that
-  # touch the workflow itself so we can iterate on it without merging to main.
-  pull_request:
-    branches: [main]
-    paths:
-      - '.github/workflows/delayed-tag.yaml'
 
 concurrency:
   group: ${{ github.workflow }}
@@ -40,6 +35,8 @@ permissions:
 jobs:
   publish_delayed:
     runs-on: ubuntu-24.04
+    env:
+      CLAUDE_MODEL: claude-sonnet-4-6
     steps:
       - uses: actions/checkout@v4
         with:
@@ -190,7 +187,6 @@ jobs:
               # Did this PR touch any file under DIR/? Anchored substring match.
               case "|${PR_PATHS}|" in
                 *"|${DIR}/"*) ;;
-                "${DIR}/"*)   ;;
                 *) continue ;;
               esac
 
@@ -226,32 +222,34 @@ jobs:
 
           echo "Planned $(wc -l < /tmp/plan.tsv) delayed tag(s); $(wc -l < /tmp/later.tsv) (image, later-PR) pairs for roll-forward check"
 
-      - name: Check for roll-forward fixes via Claude (advisory)
-        # DRY RUN: for each planned delayed tag, ask Claude Sonnet whether any
-        # LATER PR touching the connector's directory is a roll-forward fix of
-        # the CHOSEN PR — i.e. patches a regression introduced by CHOSEN, as
-        # opposed to an unrelated change. Git reverts are already filtered out
-        # in the plan step; this catches the case where a bug is fixed forward
-        # instead of reverted.
+      - name: Check for roll-forward fixes via Claude
+        # For each planned delayed tag, ask Claude Sonnet whether any LATER PR
+        # touching the connector's directory is a roll-forward fix of the CHOSEN
+        # PR — i.e. patches a regression introduced by CHOSEN, as opposed to an
+        # unrelated change. Git reverts are already filtered out in the plan
+        # step; this catches bugs that were fixed forward instead of reverted.
         #
-        # Currently advisory: the verdict is logged per connector but does not
-        # drop rows from /tmp/plan.tsv. To enforce, post-process the verdicts
-        # file before the tag step.
+        # Connectors where Claude returns "hold" are written to /tmp/held.txt
+        # and excluded from /tmp/safe_plan.tsv, which the tag step reads.
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -uo pipefail
+          : > /tmp/held.txt
+          : > /tmp/claude_verdicts.tsv
+
           if [ -z "${ANTHROPIC_API_KEY:-}" ]; then
             echo "::warning::ANTHROPIC_API_KEY not set; skipping roll-forward check"
+            cp /tmp/plan.tsv /tmp/safe_plan.tsv
             exit 0
           fi
           if [ ! -s /tmp/later.tsv ]; then
             echo "no LATER PRs across any connector; nothing to check"
+            cp /tmp/plan.tsv /tmp/safe_plan.tsv
             exit 0
           fi
 
-          : > /tmp/claude_verdicts.tsv
           flagged=0; checked=0
 
           # Per-PR diff cap (in lines). Sonnet 4.6 has 200K context, but we
@@ -305,7 +303,7 @@ jobs:
             } > /tmp/claude_prompt.txt
 
             jq -n --rawfile p /tmp/claude_prompt.txt '{
-              model: "claude-sonnet-4-6",
+              model: env.CLAUDE_MODEL,
               max_tokens: 1024,
               messages: [{role: "user", content: $p}]
             }' > /tmp/claude_req.json
@@ -328,26 +326,32 @@ jobs:
 
             if [ "${VERDICT}" = "hold" ]; then
               flagged=$((flagged + 1))
-              echo "::warning::${IMAGE}: HOLD on PR #${CHOSEN_PR} — ${REASON}"
+              echo "::warning::${IMAGE}: HOLD — ${REASON}"
+              echo "${IMAGE}" >> /tmp/held.txt
             else
-              echo "  ${IMAGE}: safe — ${REASON:-no LATER PR flagged}"
+              echo "  ${IMAGE}: safe — ${REASON:-no roll-forward fix detected}"
             fi
             printf '%s\t%s\t%s\n' "${IMAGE}" "${VERDICT}" "${REASON}" >> /tmp/claude_verdicts.tsv
           done < /tmp/plan.tsv
 
-          echo "Claude checked ${checked} connector(s); flagged ${flagged} for HOLD (advisory, not enforced)"
+          echo "Claude checked ${checked} connector(s); held ${flagged}"
+
+          # Build safe_plan.tsv by dropping held connectors from plan.tsv.
+          while IFS=$'\t' read -r IMAGE SHA PR_NUM; do
+            if grep -qxF "${IMAGE}" /tmp/held.txt; then
+              echo "  excluded from tagging: ${IMAGE} (held by Claude)"
+            else
+              printf '%s\t%s\t%s\n' "${IMAGE}" "${SHA}" "${PR_NUM}"
+            fi
+          done < /tmp/plan.tsv > /tmp/safe_plan.tsv
+          echo "Tagging $(wc -l < /tmp/safe_plan.tsv)/$(wc -l < /tmp/plan.tsv) connector(s) after hold filter"
 
       - name: Tag images as ':delayed'
-        # DRY RUN: the only mutating call in this step (the `docker buildx
-        # imagetools create` line) is commented out. Everything else — the
-        # inspect probes, the per-image log lines, counters, and the summary —
-        # still executes, so the workflow logs are a faithful preview of what
-        # the real run will publish. To enable: uncomment the docker line and
-        # delete the `tag_cmd=true` line just above it.
         run: |
           set -uo pipefail
           tagged=0; missing=0; failed=0
           : > /tmp/tagged.txt
+          : > /tmp/missing.txt
           while IFS=$'\t' read -r IMAGE SHA; do
             [ -z "${IMAGE}" ] && continue
             SRC="ghcr.io/estuary/${IMAGE}:${SHA}"
@@ -358,20 +362,19 @@ jobs:
             # when SRC is missing from the registry.
             if ! docker buildx imagetools inspect "${SRC}" >/dev/null 2>&1; then
               echo "skip ${IMAGE}: no image at ${SHA} (may have been pruned from registry)"
+              printf '%s\t%s\n' "${IMAGE}" "${SHA}" >> /tmp/missing.txt
               missing=$((missing + 1))
               continue
             fi
-            echo "would tag ${DST} -> ${SHA}"
-            tag_cmd=true  # DRY RUN — remove this line and uncomment the next to publish
-            # tag_cmd="docker buildx imagetools create --tag ${DST} ${SRC}"
-            if $tag_cmd >/dev/null; then
+            echo "tagging ${DST} -> ${SHA}"
+            if docker buildx imagetools create --tag "${DST}" "${SRC}" >/dev/null; then
               echo "${IMAGE}" >> /tmp/tagged.txt
               tagged=$((tagged + 1))
             else
               echo "::warning::failed to tag ${IMAGE}"
               failed=$((failed + 1))
             fi
-          done < /tmp/plan.tsv
+          done < /tmp/safe_plan.tsv
           echo "Summary: tagged=${tagged} missing=${missing} failed=${failed}"
           if [ "${failed}" -gt 0 ]; then
             exit 1
@@ -383,9 +386,6 @@ jobs:
           sudo apt install -y postgresql-client
 
       - name: Refresh connector_tags rows for ':delayed'
-        # DRY RUN: only the `| psql` pipe is commented out. The exact SQL we
-        # would run is still echoed per image, which is what we want preserved
-        # in the workflow logs for diagnostics.
         env:
           PGHOST: ${{ secrets.POSTGRES_CONNECTOR_REFRESH_HOST }}
           PGUSER: ${{ secrets.POSTGRES_CONNECTOR_REFRESH_USER }}
@@ -398,5 +398,64 @@ jobs:
             echo "UPDATE connector_tags SET job_status='{\"type\": \"queued\"}'
                     WHERE connector_id IN (
                       SELECT id FROM connectors WHERE image_name='ghcr.io/estuary/${IMAGE}'
-                    ) AND image_tag = ':delayed';" # DRY RUN — append ` | psql` to publish
+                    ) AND image_tag = ':delayed';" | psql
           done < /tmp/tagged.txt
+
+      - name: Write job summary
+        if: always()
+        run: |
+          set -uo pipefail
+          {
+            echo "## Delayed Tag Run — $(date -u '+%Y-%m-%d')"
+            echo ""
+
+            TAGGED_COUNT=$(wc -l < /tmp/tagged.txt 2>/dev/null | tr -d ' ') || TAGGED_COUNT=0
+            HELD_COUNT=$(wc -l < /tmp/held.txt 2>/dev/null | tr -d ' ') || HELD_COUNT=0
+            MISSING_COUNT=$(wc -l < /tmp/missing.txt 2>/dev/null | tr -d ' ') || MISSING_COUNT=0
+
+            echo "| | Count |"
+            echo "|---|---|"
+            echo "| ✅ Tagged | ${TAGGED_COUNT} |"
+            echo "| 🔶 Held by Claude | ${HELD_COUNT} |"
+            echo "| ⚪ Missing from registry | ${MISSING_COUNT} |"
+            echo ""
+
+            if [ "${TAGGED_COUNT}" -gt 0 ]; then
+              echo "### ✅ Tagged"
+              echo ""
+              echo "| Connector | PR | SHA |"
+              echo "|-----------|-----|-----|"
+              while IFS= read -r IMAGE; do
+                [ -z "${IMAGE}" ] && continue
+                PR_NUM=$(awk -F'\t' -v img="${IMAGE}" '$1==img{print $3; exit}' /tmp/safe_plan.tsv)
+                SHA=$(awk -F'\t' -v img="${IMAGE}" '$1==img{print $2; exit}' /tmp/safe_plan.tsv)
+                echo "| \`${IMAGE}\` | [#${PR_NUM}](https://github.com/${GITHUB_REPOSITORY}/pull/${PR_NUM}) | \`${SHA}\` |"
+              done < /tmp/tagged.txt
+              echo ""
+            fi
+
+            if [ "${HELD_COUNT}" -gt 0 ]; then
+              echo "### 🔶 Held by Claude"
+              echo ""
+              echo "| Connector | Reason |"
+              echo "|-----------|--------|"
+              while IFS= read -r IMAGE; do
+                [ -z "${IMAGE}" ] && continue
+                REASON=$(awk -F'\t' -v img="${IMAGE}" '$1==img{print $3; exit}' /tmp/claude_verdicts.tsv)
+                echo "| \`${IMAGE}\` | ${REASON} |"
+              done < /tmp/held.txt
+              echo ""
+            fi
+
+            if [ "${MISSING_COUNT}" -gt 0 ]; then
+              echo "### ⚪ Missing from registry"
+              echo ""
+              echo "| Connector | SHA |"
+              echo "|-----------|-----|"
+              while IFS=$'\t' read -r IMAGE SHA; do
+                [ -z "${IMAGE}" ] && continue
+                echo "| \`${IMAGE}\` | \`${SHA}\` |"
+              done < /tmp/missing.txt
+              echo ""
+            fi
+          } >> "${GITHUB_STEP_SUMMARY}"

--- a/.github/workflows/delayed-tag.yaml
+++ b/.github/workflows/delayed-tag.yaml
@@ -17,11 +17,23 @@ name: Delayed tag
 # introduced. Connectors where Claude returns "hold" are excluded from
 # tagging: ':delayed' is supposed to be more stable, so we must not knowingly
 # ship a bug that was already fixed in a subsequent PR.
+#
+# Core logic lives in .github/scripts/delayed_tag.py (unit-tested via
+# test_delayed_tag.py). This workflow handles auth, docker setup, and the
+# final tag + DB refresh that require secrets.
 
 on:
   schedule:
     - cron: '0 6 * * *'
   workflow_dispatch:
+  # While this workflow is in dry-run mode, also trigger on pull-requests that
+  # touch the workflow or script so we can iterate without merging to main.
+  pull_request:
+    branches: [main]
+    paths:
+      - '.github/workflows/delayed-tag.yaml'
+      - '.github/scripts/delayed_tag.py'
+      - '.github/scripts/test_delayed_tag.py'
 
 concurrency:
   group: ${{ github.workflow }}
@@ -35,13 +47,11 @@ permissions:
 jobs:
   publish_delayed:
     runs-on: ubuntu-24.04
-    env:
-      CLAUDE_MODEL: claude-sonnet-4-6
     steps:
       - uses: actions/checkout@v4
         with:
-          # Full history is required so we can walk first-parent commits per
-          # connector directory and check for revert references on `main`.
+          # Full history is required: the plan step walks first-parent commits
+          # per connector directory and checks for revert references on main.
           fetch-depth: 0
 
       - name: Login to GitHub package docker registry
@@ -54,299 +64,40 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 
+      - name: Run unit tests
+        run: cd .github/scripts && python3 -m unittest test_delayed_tag -v
+
       - name: Plan per-connector delayed PR boundaries
-        id: plan
+        # Reads ci.yaml / python.yaml for the connector list, fetches merged
+        # PRs from GitHub, and for each connector selects the most recent PR
+        # that (a) touched the connector's directory, (b) merged >= 14 days ago,
+        # and (c) has not been reverted on main.
+        # Writes: /tmp/plan.tsv  (image, sha7, pr_num, source_dir)
+        #         /tmp/later.tsv (image, pr_num) — PRs merged after the boundary
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          set -euo pipefail
-          CUTOFF_EPOCH=$(date -u -d '14 days ago' +%s)
-          CUTOFF_ISO=$(date -u -d "@${CUTOFF_EPOCH}" '+%Y-%m-%dT%H:%M:%SZ')
-          echo "Cutoff: ${CUTOFF_ISO}"
-          HEAD_REF=$(git rev-parse HEAD)
-          OWNER=${GITHUB_REPOSITORY%%/*}
-          REPO=${GITHUB_REPOSITORY##*/}
-
-          # The set of connector images comes from the matrices in ci.yaml and
-          # python.yaml. Each image is published from the connector's source
-          # directory (image name == directory). Variants declared in
-          # <connector>/VARIANTS are additional image names built from the
-          # parent connector's directory, so they inherit its boundary.
-          #
-          # Output schema (tab-separated): <image_name>\t<source_dir>
-          {
-            yq '.jobs.build_connectors.strategy.matrix.connector[]' .github/workflows/ci.yaml
-            yq '.jobs.build_connectors.strategy.matrix.include[].connector' .github/workflows/ci.yaml
-            yq '.jobs.py_connector.strategy.matrix.connector[].name' .github/workflows/python.yaml
-          } | awk 'NF && !seen[$0]++' > /tmp/connectors.txt
-
-          : > /tmp/images.tsv
-          while IFS= read -r CONNECTOR; do
-            [ -z "${CONNECTOR}" ] && continue
-            printf '%s\t%s\n' "${CONNECTOR}" "${CONNECTOR}" >> /tmp/images.tsv
-            if [ -f "${CONNECTOR}/VARIANTS" ]; then
-              # VARIANTS is whitespace-separated.
-              for VARIANT in $(cat "${CONNECTOR}/VARIANTS"); do
-                printf '%s\t%s\n' "${VARIANT}" "${CONNECTOR}" >> /tmp/images.tsv
-              done
-            fi
-          done < /tmp/connectors.txt
-          awk -F'\t' '!seen[$1]++' /tmp/images.tsv > /tmp/images.dedup.tsv
-          mv /tmp/images.dedup.tsv /tmp/images.tsv
-          echo "Considering $(wc -l < /tmp/images.tsv) connector image(s)"
-
-          # Fetch merged PRs newest-first via GraphQL. PR is our unit of work:
-          # with rebase-and-merge, a PR's commits land on main as a linear
-          # sequence, and pinning ':delayed' to a non-tip commit could ship
-          # a mid-PR state that doesn't build or behave correctly. We always
-          # use the PR's mergeCommit.oid (the tip of the rebased sequence,
-          # which CI built and pushed to GHCR).
-          #
-          # GraphQL only supports orderBy: UPDATED_AT (not MERGED_AT), so we
-          # paginate by updatedAt then re-sort by mergedAt locally. We stop
-          # paginating once we've gone 60 days back by updatedAt, or hit 10
-          # pages (1000 PRs) — plenty to find a CHOSEN for any active
-          # connector and all LATER PRs that landed since.
-          : > /tmp/prs.jsonl
-          CURSOR=""
-          STOP_UPDATED_EPOCH=$(date -u -d '60 days ago' +%s)
-          for page in $(seq 1 10); do
-            if [ -z "${CURSOR}" ]; then
-              AFTER_ARG=""
-            else
-              AFTER_ARG=", after: \"${CURSOR}\""
-            fi
-            RESP=$(gh api graphql -f query="
-              query {
-                repository(owner: \"${OWNER}\", name: \"${REPO}\") {
-                  pullRequests(states: MERGED, baseRefName: \"main\", orderBy: {field: UPDATED_AT, direction: DESC}, first: 100${AFTER_ARG}) {
-                    pageInfo { hasNextPage endCursor }
-                    nodes {
-                      number
-                      title
-                      mergedAt
-                      updatedAt
-                      mergeCommit { oid }
-                      files(first: 100) { totalCount nodes { path } }
-                    }
-                  }
-                }
-              }
-            ")
-            echo "$RESP" | jq -c '.data.repository.pullRequests.nodes[]' >> /tmp/prs.jsonl
-            HAS_NEXT=$(echo "$RESP" | jq -r '.data.repository.pullRequests.pageInfo.hasNextPage')
-            CURSOR=$(echo  "$RESP" | jq -r '.data.repository.pullRequests.pageInfo.endCursor')
-            OLDEST_UPDATED=$(echo "$RESP" | jq -r '.data.repository.pullRequests.nodes | last | .updatedAt | fromdateiso8601')
-            echo "  page ${page}: $(wc -l < /tmp/prs.jsonl) PRs total, oldest updatedAt @$(date -u -d @${OLDEST_UPDATED} '+%Y-%m-%dT%H:%M:%SZ')"
-            [ "$HAS_NEXT" = "true" ] || break
-            [ "${OLDEST_UPDATED}" -lt "${STOP_UPDATED_EPOCH}" ] && break
-          done
-
-          # Reshape to TSV. GraphQL caps `files(first:)` at 100 per PR, so we
-          # also pull totalCount and, for any PR that exceeds 100 files, fetch
-          # the full file list via the REST endpoint (which paginates without
-          # that cap) so we never silently undercount a connector's touch.
-          #
-          # Final schema sorted by mergedAt desc:
-          #   <pr_num>\t<merged_epoch>\t<tip_sha>\t<paths_pipe_joined>
-          jq -r '[.number, (.mergedAt | fromdateiso8601), .mergeCommit.oid, .files.totalCount, (.files.nodes | map(.path) | join("|"))] | @tsv' \
-            /tmp/prs.jsonl > /tmp/prs.raw.tsv
-          : > /tmp/prs.tsv
-          while IFS=$'\t' read -r PR_NUM PR_TS PR_SHA FILE_COUNT PATHS; do
-            if [ "${FILE_COUNT}" -gt 100 ]; then
-              echo "  PR #${PR_NUM} has ${FILE_COUNT} files; fetching full list via REST"
-              PATHS=$(gh api --paginate "/repos/${OWNER}/${REPO}/pulls/${PR_NUM}/files" \
-                        --jq '.[].filename' | paste -sd '|' -)
-            fi
-            printf '%s\t%s\t%s\t%s\n' "${PR_NUM}" "${PR_TS}" "${PR_SHA}" "${PATHS}"
-          done < /tmp/prs.raw.tsv | sort -t $'\t' -k2,2nr > /tmp/prs.tsv
-          echo "Considering $(wc -l < /tmp/prs.tsv) merged PR(s) in window"
-
-          # For each connector:
-          #   CHOSEN = newest PR with mergedAt <= cutoff that touched DIR/ and isn't reverted
-          #   LATER  = PRs with mergedAt > CHOSEN.mergedAt that touched DIR/
-          #
-          # Revert detection: `git revert` (and GitHub's UI revert, which is
-          # built on git revert) writes "This reverts commit <full-sha>." into
-          # the revert commit message. We grep for that against commits on
-          # main between the candidate PR's tip and HEAD.
-          : > /tmp/plan.tsv      # <image>\t<chosen_short_sha>\t<chosen_pr_num>
-          : > /tmp/later.tsv     # <image>\t<later_pr_num>           (one row per LATER PR per image)
-          while IFS=$'\t' read -r IMAGE DIR; do
-            [ -z "${IMAGE}" ] && continue
-            if [ ! -d "${DIR}" ]; then
-              echo "skip ${IMAGE}: directory ${DIR}/ not found at HEAD"
-              continue
-            fi
-
-            CHOSEN_SHA=""
-            CHOSEN_PR=""
-            LATER_FOR_IMAGE=()
-
-            while IFS=$'\t' read -r PR_NUM PR_TS PR_SHA PR_PATHS; do
-              # Did this PR touch any file under DIR/? Anchored substring match.
-              case "|${PR_PATHS}|" in
-                *"|${DIR}/"*) ;;
-                *) continue ;;
-              esac
-
-              if [ "${PR_TS}" -gt "${CUTOFF_EPOCH}" ]; then
-                LATER_FOR_IMAGE+=("${PR_NUM}")
-                continue
-              fi
-              # First PR within the cutoff. Skip if its tip was reverted.
-              if ! git cat-file -e "${PR_SHA}" 2>/dev/null; then
-                echo "  ${IMAGE}: PR #${PR_NUM} tip ${PR_SHA:0:7} not in local history, skipping"
-                continue
-              fi
-              if git log --format=%H "${PR_SHA}..${HEAD_REF}" \
-                   --grep="This reverts commit ${PR_SHA}" | grep -q .; then
-                echo "  ${IMAGE}: PR #${PR_NUM} (${PR_SHA:0:7}) was reverted, looking further back"
-                continue
-              fi
-              CHOSEN_SHA="${PR_SHA}"
-              CHOSEN_PR="${PR_NUM}"
-              break
-            done < /tmp/prs.tsv
-
-            if [ -z "${CHOSEN_SHA}" ]; then
-              echo "skip ${IMAGE}: no eligible PR touched ${DIR}/ within the lookback window"
-              continue
-            fi
-            printf '%s\t%s\t%s\n' "${IMAGE}" "${CHOSEN_SHA:0:7}" "${CHOSEN_PR}" >> /tmp/plan.tsv
-            echo "  ${IMAGE} -> PR #${CHOSEN_PR} (${CHOSEN_SHA:0:7})"
-            for L in "${LATER_FOR_IMAGE[@]}"; do
-              printf '%s\t%s\n' "${IMAGE}" "${L}" >> /tmp/later.tsv
-            done
-          done < /tmp/images.tsv
-
-          echo "Planned $(wc -l < /tmp/plan.tsv) delayed tag(s); $(wc -l < /tmp/later.tsv) (image, later-PR) pairs for roll-forward check"
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: python3 .github/scripts/delayed_tag.py plan
 
       - name: Check for roll-forward fixes via Claude
-        # For each planned delayed tag, ask Claude Sonnet whether any LATER PR
-        # touching the connector's directory is a roll-forward fix of the CHOSEN
-        # PR — i.e. patches a regression introduced by CHOSEN, as opposed to an
-        # unrelated change. Git reverts are already filtered out in the plan
-        # step; this catches bugs that were fixed forward instead of reverted.
-        #
-        # Connectors where Claude returns "hold" are written to /tmp/held.txt
-        # and excluded from /tmp/safe_plan.tsv, which the tag step reads.
+        # For each connector that has LATER PRs, ask Claude Sonnet whether any
+        # LATER PR is a roll-forward fix of the CHOSEN PR (i.e. it patches a
+        # regression introduced by CHOSEN). Connectors flagged "hold" are
+        # excluded from /tmp/safe_plan.tsv so they don't get tagged.
+        # Writes: /tmp/safe_plan.tsv      (image, sha7) — connectors to tag
+        #         /tmp/claude_verdicts.tsv (image, verdict, reason)
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          set -uo pipefail
-          : > /tmp/held.txt
-          : > /tmp/claude_verdicts.tsv
-
-          if [ -z "${ANTHROPIC_API_KEY:-}" ]; then
-            echo "::warning::ANTHROPIC_API_KEY not set; skipping roll-forward check"
-            cp /tmp/plan.tsv /tmp/safe_plan.tsv
-            exit 0
-          fi
-          if [ ! -s /tmp/later.tsv ]; then
-            echo "no LATER PRs across any connector; nothing to check"
-            cp /tmp/plan.tsv /tmp/safe_plan.tsv
-            exit 0
-          fi
-
-          flagged=0; checked=0
-
-          # Per-PR diff cap (in lines). Sonnet 4.6 has 200K context, but we
-          # bound each PR's diff to keep prompts predictable for very large
-          # PRs (e.g. generated code) — the commit messages plus first ~2000
-          # diff lines are typically enough to identify a roll-forward fix.
-          DIFF_LINE_CAP=2000
-
-          while IFS=$'\t' read -r IMAGE CHOSEN_SHA CHOSEN_PR; do
-            # Collect LATER PR numbers for this image.
-            mapfile -t LATER_PRS < <(awk -F'\t' -v img="${IMAGE}" '$1==img{print $2}' /tmp/later.tsv)
-            if [ "${#LATER_PRS[@]}" -eq 0 ]; then
-              printf '%s\tsafe\tno LATER PRs\n' "${IMAGE}" >> /tmp/claude_verdicts.tsv
-              continue
-            fi
-            DIR=$(awk -F'\t' -v img="${IMAGE}" '$1==img{print $2; exit}' /tmp/images.tsv)
-
-            {
-              printf '%s\n' \
-                "You are auditing a release pipeline for the Estuary connectors monorepo." \
-                "We are about to promote the image '${IMAGE}' (source dir '${DIR}/') to" \
-                "the ':delayed' tag, pinned to PR #${CHOSEN_PR}." \
-                "" \
-                "Determine whether any LATER PR is a roll-forward fix of the CHOSEN PR —" \
-                "i.e. patches a bug or regression introduced BY the CHOSEN PR. A feature" \
-                "addition, refactor, dependency bump, test addition, or unrelated bugfix" \
-                "is NOT a roll-forward fix. Only flag PRs that exist because the CHOSEN" \
-                "PR was buggy." \
-                "" \
-                "Note: this repo uses rebase-and-merge, so each PR's commits land on main" \
-                "as a linear sequence — judge PRs as units, not individual commits." \
-                ""
-              printf '=== CHOSEN: PR #%s ===\n' "${CHOSEN_PR}"
-              gh pr view "${CHOSEN_PR}" --json title,body \
-                --template '{{.title}}{{"\n\n"}}{{.body}}{{"\n"}}' || true
-              printf '\n--- diff (truncated to %s lines) ---\n' "${DIFF_LINE_CAP}"
-              gh pr diff "${CHOSEN_PR}" 2>/dev/null | head -n "${DIFF_LINE_CAP}" || true
-              printf '\n'
-              for L in "${LATER_PRS[@]}"; do
-                printf '=== LATER: PR #%s ===\n' "${L}"
-                gh pr view "${L}" --json title,body \
-                  --template '{{.title}}{{"\n\n"}}{{.body}}{{"\n"}}' || true
-                printf '\n--- diff (truncated to %s lines) ---\n' "${DIFF_LINE_CAP}"
-                gh pr diff "${L}" 2>/dev/null | head -n "${DIFF_LINE_CAP}" || true
-                printf '\n'
-              done
-              printf '%s\n' \
-                "Reply with ONLY a JSON object, no prose:" \
-                '{"verdict": "safe" | "hold", "reason": "<one short sentence>", "fix_prs": [<pr numbers that are roll-forward fixes of CHOSEN>]}' \
-                'Use "hold" iff at least one LATER PR is a roll-forward fix of CHOSEN. Otherwise "safe".'
-            } > /tmp/claude_prompt.txt
-
-            jq -n --rawfile p /tmp/claude_prompt.txt '{
-              model: env.CLAUDE_MODEL,
-              max_tokens: 1024,
-              messages: [{role: "user", content: $p}]
-            }' > /tmp/claude_req.json
-
-            checked=$((checked + 1))
-            if ! curl -sS --fail-with-body https://api.anthropic.com/v1/messages \
-                  -H "content-type: application/json" \
-                  -H "x-api-key: ${ANTHROPIC_API_KEY}" \
-                  -H "anthropic-version: 2023-06-01" \
-                  --data-binary @/tmp/claude_req.json \
-                  -o /tmp/claude_resp.json; then
-              echo "::warning::${IMAGE}: Claude API call failed; treating as safe"
-              printf '%s\tsafe\tapi error\n' "${IMAGE}" >> /tmp/claude_verdicts.tsv
-              continue
-            fi
-
-            TEXT=$(jq -r '.content[0].text // ""' /tmp/claude_resp.json)
-            VERDICT=$(printf '%s' "${TEXT}" | jq -r '.verdict // "safe"' 2>/dev/null || echo "safe")
-            REASON=$(printf '%s'  "${TEXT}" | jq -r '.reason // ""'    2>/dev/null || echo "")
-
-            if [ "${VERDICT}" = "hold" ]; then
-              flagged=$((flagged + 1))
-              echo "::warning::${IMAGE}: HOLD — ${REASON}"
-              echo "${IMAGE}" >> /tmp/held.txt
-            else
-              echo "  ${IMAGE}: safe — ${REASON:-no roll-forward fix detected}"
-            fi
-            printf '%s\t%s\t%s\n' "${IMAGE}" "${VERDICT}" "${REASON}" >> /tmp/claude_verdicts.tsv
-          done < /tmp/plan.tsv
-
-          echo "Claude checked ${checked} connector(s); held ${flagged}"
-
-          # Build safe_plan.tsv by dropping held connectors from plan.tsv.
-          while IFS=$'\t' read -r IMAGE SHA PR_NUM; do
-            if grep -qxF "${IMAGE}" /tmp/held.txt; then
-              echo "  excluded from tagging: ${IMAGE} (held by Claude)"
-            else
-              printf '%s\t%s\t%s\n' "${IMAGE}" "${SHA}" "${PR_NUM}"
-            fi
-          done < /tmp/plan.tsv > /tmp/safe_plan.tsv
-          echo "Tagging $(wc -l < /tmp/safe_plan.tsv)/$(wc -l < /tmp/plan.tsv) connector(s) after hold filter"
+        run: python3 .github/scripts/delayed_tag.py check
 
       - name: Tag images as ':delayed'
+        # DRY RUN: the only mutating call in this step (the `docker buildx
+        # imagetools create` line) is commented out. Everything else — the
+        # inspect probes, the per-image log lines, counters, and the summary —
+        # still executes, so the workflow logs are a faithful preview of what
+        # the real run will publish. To enable: uncomment the docker line and
+        # delete the `tag_cmd=true` line just above it.
         run: |
           set -uo pipefail
           tagged=0; missing=0; failed=0
@@ -366,8 +117,10 @@ jobs:
               missing=$((missing + 1))
               continue
             fi
-            echo "tagging ${DST} -> ${SHA}"
-            if docker buildx imagetools create --tag "${DST}" "${SRC}" >/dev/null; then
+            echo "would tag ${DST} -> ${SHA}"
+            tag_cmd=true  # DRY RUN — remove this line and uncomment the next to publish
+            # tag_cmd="docker buildx imagetools create --tag ${DST} ${SRC}"
+            if $tag_cmd >/dev/null; then
               echo "${IMAGE}" >> /tmp/tagged.txt
               tagged=$((tagged + 1))
             else
@@ -386,6 +139,8 @@ jobs:
           sudo apt install -y postgresql-client
 
       - name: Refresh connector_tags rows for ':delayed'
+        # DRY RUN: only the `| psql` pipe is commented out. The exact SQL we
+        # would run is still echoed per image.
         env:
           PGHOST: ${{ secrets.POSTGRES_CONNECTOR_REFRESH_HOST }}
           PGUSER: ${{ secrets.POSTGRES_CONNECTOR_REFRESH_USER }}
@@ -398,11 +153,13 @@ jobs:
             echo "UPDATE connector_tags SET job_status='{\"type\": \"queued\"}'
                     WHERE connector_id IN (
                       SELECT id FROM connectors WHERE image_name='ghcr.io/estuary/${IMAGE}'
-                    ) AND image_tag = ':delayed';" | psql
+                    ) AND image_tag = ':delayed';" # DRY RUN — append ` | psql` to publish
           done < /tmp/tagged.txt
 
       - name: Write job summary
         if: always()
+        env:
+          GITHUB_REPOSITORY: ${{ github.repository }}
         run: |
           set -uo pipefail
           {
@@ -410,13 +167,13 @@ jobs:
             echo ""
 
             TAGGED_COUNT=$(wc -l < /tmp/tagged.txt 2>/dev/null | tr -d ' ') || TAGGED_COUNT=0
-            HELD_COUNT=$(wc -l < /tmp/held.txt 2>/dev/null | tr -d ' ') || HELD_COUNT=0
+            HELD_COUNT=$(wc -l < /tmp/claude_verdicts.tsv 2>/dev/null \
+              | tr -d ' ') || HELD_COUNT=0
             MISSING_COUNT=$(wc -l < /tmp/missing.txt 2>/dev/null | tr -d ' ') || MISSING_COUNT=0
 
             echo "| | Count |"
             echo "|---|---|"
             echo "| ✅ Tagged | ${TAGGED_COUNT} |"
-            echo "| 🔶 Held by Claude | ${HELD_COUNT} |"
             echo "| ⚪ Missing from registry | ${MISSING_COUNT} |"
             echo ""
 
@@ -427,24 +184,24 @@ jobs:
               echo "|-----------|-----|-----|"
               while IFS= read -r IMAGE; do
                 [ -z "${IMAGE}" ] && continue
-                PR_NUM=$(awk -F'\t' -v img="${IMAGE}" '$1==img{print $3; exit}' /tmp/safe_plan.tsv)
-                SHA=$(awk -F'\t' -v img="${IMAGE}" '$1==img{print $2; exit}' /tmp/safe_plan.tsv)
+                # Look up PR and SHA from plan.tsv (image, sha7, pr_num, source_dir).
+                PR_NUM=$(awk -F'\t' -v img="${IMAGE}" '$1==img{print $3; exit}' /tmp/plan.tsv)
+                SHA=$(awk -F'\t' -v img="${IMAGE}" '$1==img{print $2; exit}' /tmp/plan.tsv)
                 echo "| \`${IMAGE}\` | [#${PR_NUM}](https://github.com/${GITHUB_REPOSITORY}/pull/${PR_NUM}) | \`${SHA}\` |"
               done < /tmp/tagged.txt
               echo ""
             fi
 
-            if [ "${HELD_COUNT}" -gt 0 ]; then
-              echo "### 🔶 Held by Claude"
-              echo ""
-              echo "| Connector | Reason |"
-              echo "|-----------|--------|"
-              while IFS= read -r IMAGE; do
-                [ -z "${IMAGE}" ] && continue
-                REASON=$(awk -F'\t' -v img="${IMAGE}" '$1==img{print $3; exit}' /tmp/claude_verdicts.tsv)
-                echo "| \`${IMAGE}\` | ${REASON} |"
-              done < /tmp/held.txt
-              echo ""
+            if [ -s /tmp/claude_verdicts.tsv ]; then
+              HOLD_COUNT=$(awk -F'\t' '$2=="hold"' /tmp/claude_verdicts.tsv | wc -l | tr -d ' ')
+              if [ "${HOLD_COUNT}" -gt 0 ]; then
+                echo "### 🔶 Held by Claude"
+                echo ""
+                echo "| Connector | Reason |"
+                echo "|-----------|--------|"
+                awk -F'\t' '$2=="hold"{print "| `" $1 "` | " $3 " |"}' /tmp/claude_verdicts.tsv
+                echo ""
+              fi
             fi
 
             if [ "${MISSING_COUNT}" -gt 0 ]; then

--- a/.github/workflows/delayed-tag.yaml
+++ b/.github/workflows/delayed-tag.yaml
@@ -26,14 +26,6 @@ on:
   schedule:
     - cron: '0 6 * * *'
   workflow_dispatch:
-  # While this workflow is in dry-run mode, also trigger on pull-requests that
-  # touch the workflow or script so we can iterate without merging to main.
-  pull_request:
-    branches: [main]
-    paths:
-      - '.github/workflows/delayed-tag.yaml'
-      - '.github/scripts/delayed_tag.py'
-      - '.github/scripts/test_delayed_tag.py'
 
 concurrency:
   group: ${{ github.workflow }}
@@ -42,7 +34,6 @@ concurrency:
 permissions:
   contents: read
   packages: write
-  pull-requests: read
 
 jobs:
   publish_delayed:
@@ -92,12 +83,6 @@ jobs:
         run: python3 .github/scripts/delayed_tag.py check
 
       - name: Tag images as ':delayed'
-        # DRY RUN: the only mutating call in this step (the `docker buildx
-        # imagetools create` line) is commented out. Everything else — the
-        # inspect probes, the per-image log lines, counters, and the summary —
-        # still executes, so the workflow logs are a faithful preview of what
-        # the real run will publish. To enable: uncomment the docker line and
-        # delete the `tag_cmd=true` line just above it.
         run: |
           set -uo pipefail
           tagged=0; missing=0; failed=0
@@ -117,10 +102,8 @@ jobs:
               missing=$((missing + 1))
               continue
             fi
-            echo "would tag ${DST} -> ${SHA}"
-            tag_cmd=true  # DRY RUN — remove this line and uncomment the next to publish
-            # tag_cmd="docker buildx imagetools create --tag ${DST} ${SRC}"
-            if $tag_cmd >/dev/null; then
+            if docker buildx imagetools create --tag "${DST}" "${SRC}" >/dev/null; then
+              echo "tagged ${DST} -> ${SHA}"
               echo "${IMAGE}" >> /tmp/tagged.txt
               tagged=$((tagged + 1))
             else
@@ -139,8 +122,6 @@ jobs:
           sudo apt install -y postgresql-client
 
       - name: Refresh connector_tags rows for ':delayed'
-        # DRY RUN: only the `| psql` pipe is commented out. The exact SQL we
-        # would run is still echoed per image.
         env:
           PGHOST: ${{ secrets.POSTGRES_CONNECTOR_REFRESH_HOST }}
           PGUSER: ${{ secrets.POSTGRES_CONNECTOR_REFRESH_USER }}
@@ -153,7 +134,7 @@ jobs:
             echo "UPDATE connector_tags SET job_status='{\"type\": \"queued\"}'
                     WHERE connector_id IN (
                       SELECT id FROM connectors WHERE image_name='ghcr.io/estuary/${IMAGE}'
-                    ) AND image_tag = ':delayed';" # DRY RUN — append ` | psql` to publish
+                    ) AND image_tag = ':delayed';" | psql
           done < /tmp/tagged.txt
 
       - name: Write job summary


### PR DESCRIPTION
**Description:**

- Add a new `:delayed` tag which is automatically tagged ~2 weeks after an image has been released.
- This is going to be used to be cautious for some of the more sensitive customers.
- Versioned tags are still our stable channel.
- There is a Claude safety pass in the CI that checks subsequent PRs to make sure that if we are building a delayed image, there has been no roll-forward fix for that connector in later PRs, to prevent a known bug from being released to `:delayed` channel
- I think at the moment we can merge this and have the images published, and we can monitor the CI every once in a while to see if the roll-forward fix check is working fine, and then we can have our support folks put customers on this new image
- Note that there is currently an issue where the rendered form on the UI may be from the versioned tag, whereas the delayed tag is used... causing possible incompatibilities between UI and the delayed image.

For a run of this see: https://github.com/estuary/connectors/actions/runs/26176409516?pr=4393

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

