### PR TITLE
{source-materialize}-postgres: support JSONB

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -44,7 +44,7 @@ require (
 	github.com/dropbox/dropbox-sdk-go-unofficial/v6 v6.0.5
 	github.com/duckdb/duckdb-go/v2 v2.10502.0
 	github.com/elastic/go-elasticsearch/v8 v8.9.0
-	github.com/estuary/flow v0.6.4
+	github.com/estuary/flow v0.6.9
 	github.com/estuary/vitess v0.15.10
 	github.com/evanphx/json-patch/v5 v5.9.11
 	github.com/go-mysql-org/go-mysql v0.0.0-20250907131429-558ed11751bc
@@ -81,7 +81,7 @@ require (
 	github.com/tidwall/gjson v1.17.3
 	github.com/tidwall/sjson v1.2.5
 	github.com/wk8/go-ordered-map/v2 v2.1.8
-	go.gazette.dev/core v0.102.0
+	go.gazette.dev/core v0.103.1-0.20260505142537-ce718ada37ee
 	go.mongodb.org/mongo-driver v1.17.4
 	golang.org/x/crypto v0.49.0
 	golang.org/x/exp v0.0.0-20260312153236-7ab1446f8b90

--- a/go.sum
+++ b/go.sum
@@ -417,8 +417,12 @@ github.com/envoyproxy/go-control-plane/ratelimit v0.1.0/go.mod h1:Wk+tMFAFbCXaJP
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/envoyproxy/protoc-gen-validate v1.3.0 h1:TvGH1wof4H33rezVKWSpqKz5NXWg5VPuZ0uONDT6eb4=
 github.com/envoyproxy/protoc-gen-validate v1.3.0/go.mod h1:HvYl7zwPa5mffgyeTUHA9zHIH36nmrm7oCbo4YKoSWA=
-github.com/estuary/flow v0.6.4 h1:MpermXN5h1U85zJspZftGSC7XbdTUWv22/FM/tvofSc=
-github.com/estuary/flow v0.6.4/go.mod h1:xihzOEpeEzcLTsgU2LFvjLs0f5UvbTeAQGnwno6ondk=
+github.com/estuary/flow v0.6.8 h1:HK9zYKV2HvF6jPI8eSDGdLy4nVUW2FWB+CA37PyuPLI=
+github.com/estuary/flow v0.6.8/go.mod h1:SYiOTbPZ0ZlCh8qNVARPMjRF6/aVWY7xQuHFK9BSELk=
+github.com/estuary/flow v0.6.9-0.20260520113844-a3d8595811ed h1:+pm+QyY8+bhC2gxJdRa735NX+QawxO0Piuv5c1CUj0w=
+github.com/estuary/flow v0.6.9-0.20260520113844-a3d8595811ed/go.mod h1:jdQeVWS9sw520EU2u9UPYryE5iEo1Gu9Ju99LXJ8r7Y=
+github.com/estuary/flow v0.6.9 h1:1cGdwmlB4UxNhRnvujTDGwmx1ABvBS9iqWYIIStRaRI=
+github.com/estuary/flow v0.6.9/go.mod h1:jdQeVWS9sw520EU2u9UPYryE5iEo1Gu9Ju99LXJ8r7Y=
 github.com/estuary/go-mysql v0.0.0-20250918155720-90d473fd1a3e h1:stJOXFppEkEksGtqpJjIIfufID+RUkrkMCFKgu4Vfaw=
 github.com/estuary/go-mysql v0.0.0-20250918155720-90d473fd1a3e/go.mod h1:FQxw17uRbFvMZFK+dPtIPufbU46nBdrGaxOw0ac9MFs=
 github.com/estuary/vitess v0.15.10 h1:oXJgcG0HGZWuwjdvSp4pIFIAXtKLaR9Fl9VBynSszFA=
@@ -1117,8 +1121,8 @@ go.etcd.io/etcd/client/pkg/v3 v3.6.5 h1:Duz9fAzIZFhYWgRjp/FgNq2gO1jId9Yae/rLn3Rr
 go.etcd.io/etcd/client/pkg/v3 v3.6.5/go.mod h1:8Wx3eGRPiy0qOFMZT/hfvdos+DjEaPxdIDiCDUv/FQk=
 go.etcd.io/etcd/client/v3 v3.6.5 h1:yRwZNFBx/35VKHTcLDeO7XVLbCBFbPi+XV4OC3QJf2U=
 go.etcd.io/etcd/client/v3 v3.6.5/go.mod h1:ZqwG/7TAFZ0BJ0jXRPoJjKQJtbFo/9NIY8uoFFKcCyo=
-go.gazette.dev/core v0.102.0 h1:S1FFQn4Ws4qThrnwQhZ75jghg++Tfev++fPdq6PVlGw=
-go.gazette.dev/core v0.102.0/go.mod h1:4qMw9JDecqIx6EijHy6ndbueTYeglm6LW4qKxEUOZ8M=
+go.gazette.dev/core v0.103.1-0.20260505142537-ce718ada37ee h1:yceN2m1184/i4YSN4tlfMSdpnV+xnePgnUf4KFa00oE=
+go.gazette.dev/core v0.103.1-0.20260505142537-ce718ada37ee/go.mod h1:4qMw9JDecqIx6EijHy6ndbueTYeglm6LW4qKxEUOZ8M=
 go.mongodb.org/mongo-driver v1.11.4/go.mod h1:PTSz5yu21bkT/wXpkS7WR5f0ddqw5quethTUn9WM+2g=
 go.mongodb.org/mongo-driver v1.17.4 h1:jUorfmVzljjr0FLzYQsGP8cgN/qzzxlY9Vh0C9KFXVw=
 go.mongodb.org/mongo-driver v1.17.4/go.mod h1:Hy04i7O2kC4RS06ZrhPRqj/u4DTYkFDAAccj+rVKqgQ=

--- a/materialize-postgres/.snapshots/TestSQLGeneration
+++ b/materialize-postgres/.snapshots/TestSQLGeneration
@@ -344,4 +344,20 @@ BEGIN
 END $$;
 --- End Fence Update ---
 
+--- Begin createTargetTable [jsonb contentMediaType] ---
+
+CREATE TABLE IF NOT EXISTS "public".jsonb_round_trip (
+		id BIGINT NOT NULL,
+		plain_json JSON,
+		jsonb_col JSONB,
+
+		PRIMARY KEY (id)
+);
+
+COMMENT ON TABLE "public".jsonb_round_trip IS 'Generated for materialize-postgres jsonb round-trip test';
+COMMENT ON COLUMN "public".jsonb_round_trip.id IS '';
+COMMENT ON COLUMN "public".jsonb_round_trip.plain_json IS '';
+COMMENT ON COLUMN "public".jsonb_round_trip.jsonb_col IS '';
+--- End createTargetTable [jsonb contentMediaType] ---
+
 

--- a/materialize-postgres/driver.go
+++ b/materialize-postgres/driver.go
@@ -54,6 +54,7 @@ var featureFlagDefaults = map[string]bool{
 	"retain_existing_data_on_backfill": false,
 	"native_binary_column_type":        true,
 	"enum":                             true,
+	"jsonb":                            true,
 }
 
 func ctxWithQueryTimeout(ctx context.Context) (context.Context, context.CancelFunc) {

--- a/materialize-postgres/sqlgen.go
+++ b/materialize-postgres/sqlgen.go
@@ -42,7 +42,7 @@ func createPgDialect(featureFlags map[string]bool) sql.Dialect {
 	jsonbContentMediaType := "application/vnd.estuary.postgresql.jsonb+json"
 	jsonOrJsonb := func(jsonMapper, jsonbMapper sql.MapProjectionFn) sql.MapProjectionFn {
 		return func(p *sql.Projection) (sql.DDLer, sql.CompatibleColumnTypes, sql.ElementConverter) {
-			if p.Inference.String_ != nil && p.Inference.String_.ContentType == jsonbContentMediaType {
+			if p.Inference.ContentMediaType == jsonbContentMediaType {
 				return jsonbMapper(p)
 			}
 			return jsonMapper(p)

--- a/materialize-postgres/sqlgen.go
+++ b/materialize-postgres/sqlgen.go
@@ -34,18 +34,36 @@ func createPgDialect(featureFlags map[string]bool) sql.Dialect {
 		binaryMapping = sql.MapStatic("BYTEA", sql.UsingConverter(sql.Base64Decoder))
 	}
 
+	// Fields originating from a PostgreSQL JSONB column carry this
+	// (non-standard, vendor-tree) contentMediaType so they can be recreated
+	// as JSONB at the destination instead of collapsing onto JSON. Anything
+	// without the annotation defaults to JSON, preserving the historical
+	// behavior for existing materializations and non-Postgres sources.
+	jsonbContentMediaType := "application/vnd.postgresql.jsonb+json"
+	jsonOrJsonb := func(jsonMapper, jsonbMapper sql.MapProjectionFn) sql.MapProjectionFn {
+		return func(p *sql.Projection) (sql.DDLer, sql.CompatibleColumnTypes, sql.ElementConverter) {
+			if p.Inference.String_ != nil && p.Inference.String_.ContentType == jsonbContentMediaType {
+				return jsonbMapper(p)
+			}
+			return jsonMapper(p)
+		}
+	}
+
 	mapper := sql.NewDDLMapper(
 		sql.FlatTypeMappings{
 			sql.INTEGER: sql.MapSignedInt64(
 				sql.MapStatic("BIGINT", sql.AlsoCompatibleWith("integer")),
 				sql.MapStatic("NUMERIC"),
 			),
-			sql.NUMBER:         sql.MapStatic("DOUBLE PRECISION"),
-			sql.BOOLEAN:        sql.MapStatic("BOOLEAN"),
-			sql.OBJECT:         sql.MapStatic("JSON"),
-			sql.ARRAY:          sql.MapStatic("JSON"),
-			sql.BINARY:         binaryMapping,
-			sql.MULTIPLE:       sql.MapStatic("JSON", sql.UsingConverter(sql.ToJsonBytes)),
+			sql.NUMBER:  sql.MapStatic("DOUBLE PRECISION"),
+			sql.BOOLEAN: sql.MapStatic("BOOLEAN"),
+			sql.OBJECT:  jsonOrJsonb(sql.MapStatic("JSON"), sql.MapStatic("JSONB")),
+			sql.ARRAY:   jsonOrJsonb(sql.MapStatic("JSON"), sql.MapStatic("JSONB")),
+			sql.BINARY:  binaryMapping,
+			sql.MULTIPLE: jsonOrJsonb(
+				sql.MapStatic("JSON", sql.UsingConverter(sql.ToJsonBytes)),
+				sql.MapStatic("JSONB", sql.UsingConverter(sql.ToJsonBytes)),
+			),
 			sql.STRING_INTEGER: sql.MapStatic("NUMERIC"),
 			sql.STRING_NUMBER:  sql.MapStatic("DECIMAL", sql.AlsoCompatibleWith("numeric")),
 			sql.STRING: sql.MapString(sql.StringMappings{
@@ -102,6 +120,8 @@ func createPgDialect(featureFlags map[string]bool) sql.Dialect {
 				}),
 			)},
 			"bytea": {sql.NewMigrationSpec([]string{"text"}, sql.WithDirectCast(), sql.WithCastSQL(byteaToStringCast))},
+			"json":  {sql.NewMigrationSpec([]string{"jsonb"}, sql.WithDirectCast())},
+			"jsonb": {sql.NewMigrationSpec([]string{"json"}, sql.WithDirectCast())},
 			"*":     {sql.NewMigrationSpec([]string{"json"}, sql.WithDirectCast(), sql.WithCastSQL(toJsonCast))},
 		},
 		DirectCastSQL: func(table sql.Table, m sql.ColumnTypeMigration) string {

--- a/materialize-postgres/sqlgen.go
+++ b/materialize-postgres/sqlgen.go
@@ -39,8 +39,15 @@ func createPgDialect(featureFlags map[string]bool) sql.Dialect {
 	// as JSONB at the destination instead of collapsing onto JSON. Anything
 	// without the annotation defaults to JSON, preserving the historical
 	// behavior for existing materializations and non-Postgres sources.
+	//
+	// Gated behind the "jsonb" feature flag: when disabled the
+	// contentMediaType is ignored entirely and everything maps to JSON, exactly
+	// as it did before JSONB support was introduced.
 	jsonbContentMediaType := "application/vnd.estuary.postgresql.jsonb+json"
 	jsonOrJsonb := func(jsonMapper, jsonbMapper sql.MapProjectionFn) sql.MapProjectionFn {
+		if !featureFlags["jsonb"] {
+			return jsonMapper
+		}
 		return func(p *sql.Projection) (sql.DDLer, sql.CompatibleColumnTypes, sql.ElementConverter) {
 			if p.Inference.ContentMediaType == jsonbContentMediaType {
 				return jsonbMapper(p)

--- a/materialize-postgres/sqlgen.go
+++ b/materialize-postgres/sqlgen.go
@@ -39,7 +39,7 @@ func createPgDialect(featureFlags map[string]bool) sql.Dialect {
 	// as JSONB at the destination instead of collapsing onto JSON. Anything
 	// without the annotation defaults to JSON, preserving the historical
 	// behavior for existing materializations and non-Postgres sources.
-	jsonbContentMediaType := "application/vnd.postgresql.jsonb+json"
+	jsonbContentMediaType := "application/vnd.estuary.postgresql.jsonb+json"
 	jsonOrJsonb := func(jsonMapper, jsonbMapper sql.MapProjectionFn) sql.MapProjectionFn {
 		return func(p *sql.Projection) (sql.DDLer, sql.CompatibleColumnTypes, sql.ElementConverter) {
 			if p.Inference.String_ != nil && p.Inference.String_.ContentType == jsonbContentMediaType {

--- a/materialize-postgres/sqlgen_test.go
+++ b/materialize-postgres/sqlgen_test.go
@@ -60,7 +60,7 @@ func TestSQLGeneration(t *testing.T) {
 func buildJSONBTestTable(t *testing.T) sql.Table {
 	t.Helper()
 
-	const jsonbMediaType = "application/vnd.postgresql.jsonb+json"
+	const jsonbMediaType = "application/vnd.estuary.postgresql.jsonb+json"
 	multipleTypes := []string{"object", "string", "array", "number", "boolean", "null"}
 
 	mkValue := func(field, contentType string) sql.Column {

--- a/materialize-postgres/sqlgen_test.go
+++ b/materialize-postgres/sqlgen_test.go
@@ -64,18 +64,14 @@ func buildJSONBTestTable(t *testing.T) sql.Table {
 	multipleTypes := []string{"object", "string", "array", "number", "boolean", "null"}
 
 	mkValue := func(field, contentType string) sql.Column {
-		var stringInf *pf.Inference_String
-		if contentType != "" {
-			stringInf = &pf.Inference_String{ContentType: contentType}
-		}
 		p := sql.Projection{
 			Projection: pf.Projection{
 				Field: field,
 				Ptr:   "/" + field,
 				Inference: pf.Inference{
-					Types:   multipleTypes,
-					String_: stringInf,
-					Exists:  pf.Inference_MAY,
+					Types:            multipleTypes,
+					ContentMediaType: contentType,
+					Exists:           pf.Inference_MAY,
 				},
 			},
 		}
@@ -138,22 +134,15 @@ func TestDateTimeColumn(t *testing.T) {
 }
 
 func TestJSONBContentMediaType(t *testing.T) {
-	jsonbMediaType := "application/vnd.postgresql.jsonb+json"
+	jsonbMediaType := "application/vnd.estuary.postgresql.jsonb+json"
 
 	mapWithMediaType := func(types []string, contentType string) string {
-		var stringInf *pf.Inference_String
-		for _, ty := range types {
-			if ty == "string" {
-				stringInf = &pf.Inference_String{ContentType: contentType}
-				break
-			}
-		}
 		return testDialect.MapType(&sql.Projection{
 			Projection: pf.Projection{
 				Inference: pf.Inference{
-					Types:   types,
-					String_: stringInf,
-					Exists:  pf.Inference_MUST,
+					Types:            types,
+					ContentMediaType: contentType,
+					Exists:           pf.Inference_MUST,
 				},
 			},
 		}, sql.FieldConfig{}).DDL

--- a/materialize-postgres/sqlgen_test.go
+++ b/materialize-postgres/sqlgen_test.go
@@ -162,6 +162,44 @@ func TestJSONBContentMediaType(t *testing.T) {
 		"MULTIPLE-typed field without contentMediaType should default to JSON")
 }
 
+// TestJSONBFeatureFlagDisabled verifies that with the "jsonb" feature flag off
+// the contentMediaType is ignored entirely and every field collapses onto JSON,
+// preserving the pre-JSONB behavior.
+func TestJSONBFeatureFlagDisabled(t *testing.T) {
+	flags := map[string]bool{}
+	for k, v := range featureFlagDefaults {
+		flags[k] = v
+	}
+	flags["jsonb"] = false
+	dialect := createPgDialect(flags)
+
+	jsonbMediaType := "application/vnd.estuary.postgresql.jsonb+json"
+	mapWithMediaType := func(types []string, contentType string) string {
+		return dialect.MapType(&sql.Projection{
+			Projection: pf.Projection{
+				Inference: pf.Inference{
+					Types:            types,
+					ContentMediaType: contentType,
+					Exists:           pf.Inference_MUST,
+				},
+			},
+		}, sql.FieldConfig{}).DDL
+	}
+
+	require.Equal(t,
+		"JSON NOT NULL",
+		mapWithMediaType([]string{"object"}, jsonbMediaType),
+		"object field with jsonb contentMediaType should map to JSON when the flag is disabled")
+	require.Equal(t,
+		"JSON NOT NULL",
+		mapWithMediaType([]string{"array"}, jsonbMediaType),
+		"array field with jsonb contentMediaType should map to JSON when the flag is disabled")
+	require.Equal(t,
+		"JSON NOT NULL",
+		mapWithMediaType([]string{"object", "string", "array", "number", "boolean"}, jsonbMediaType),
+		"MULTIPLE-typed field with jsonb contentMediaType should map to JSON when the flag is disabled")
+}
+
 func TestTruncatedIdentifier(t *testing.T) {
 	tests := []struct {
 		name  string

--- a/materialize-postgres/sqlgen_test.go
+++ b/materialize-postgres/sqlgen_test.go
@@ -41,7 +41,82 @@ func TestSQLGeneration(t *testing.T) {
 		},
 	)
 
+	// Exercise the source-postgres -> materialize-postgres JSONB round-trip:
+	// a value field carrying the application/vnd.postgresql.jsonb+json
+	// contentMediaType must render as JSONB, while a sibling field without
+	// the annotation stays on JSON.
+	jsonbTable := buildJSONBTestTable(t)
+	jsonbName := "createTargetTable [jsonb contentMediaType]"
+	snap.WriteString("--- Begin " + jsonbName + " ---\n")
+	require.NoError(t, testTemplates.createTargetTable.Execute(snap, &jsonbTable))
+	snap.WriteString("--- End " + jsonbName + " ---\n\n")
+
 	cupaloy.SnapshotT(t, snap.String())
+}
+
+// buildJSONBTestTable assembles a synthetic Table with two value projections:
+// one carrying the jsonb contentMediaType so it should map to JSONB, and one
+// without so it should default to JSON.
+func buildJSONBTestTable(t *testing.T) sql.Table {
+	t.Helper()
+
+	const jsonbMediaType = "application/vnd.postgresql.jsonb+json"
+	multipleTypes := []string{"object", "string", "array", "number", "boolean", "null"}
+
+	mkValue := func(field, contentType string) sql.Column {
+		var stringInf *pf.Inference_String
+		if contentType != "" {
+			stringInf = &pf.Inference_String{ContentType: contentType}
+		}
+		p := sql.Projection{
+			Projection: pf.Projection{
+				Field: field,
+				Ptr:   "/" + field,
+				Inference: pf.Inference{
+					Types:   multipleTypes,
+					String_: stringInf,
+					Exists:  pf.Inference_MAY,
+				},
+			},
+		}
+		return sql.Column{
+			Projection: p,
+			MappedType: testDialect.MapType(&p, sql.FieldConfig{}),
+			Identifier: testDialect.Identifier(field),
+		}
+	}
+
+	keyProj := sql.Projection{
+		Projection: pf.Projection{
+			Field:        "id",
+			Ptr:          "/id",
+			IsPrimaryKey: true,
+			Inference: pf.Inference{
+				Types:  []string{"integer"},
+				Exists: pf.Inference_MUST,
+			},
+		},
+	}
+	keyCol := sql.Column{
+		Projection: keyProj,
+		MappedType: testDialect.MapType(&keyProj, sql.FieldConfig{}),
+		Identifier: testDialect.Identifier("id"),
+		MustExist:  true,
+	}
+
+	tableName := "jsonb_round_trip"
+	return sql.Table{
+		TableShape: sql.TableShape{
+			Path:    []string{"public", tableName},
+			Comment: "Generated for materialize-postgres jsonb round-trip test",
+		},
+		Identifier: testDialect.Identifier("public", tableName),
+		Keys:       []sql.Column{keyCol},
+		Values: []sql.Column{
+			mkValue("plain_json", ""),
+			mkValue("jsonb_col", jsonbMediaType),
+		},
+	}
 }
 
 func TestDateTimeColumn(t *testing.T) {
@@ -60,6 +135,42 @@ func TestDateTimeColumn(t *testing.T) {
 	parsed, err := mapped.Converter("2022-04-04T10:09:08.234567Z")
 	require.Equal(t, "2022-04-04T10:09:08.234567Z", parsed)
 	require.NoError(t, err)
+}
+
+func TestJSONBContentMediaType(t *testing.T) {
+	jsonbMediaType := "application/vnd.postgresql.jsonb+json"
+
+	mapWithMediaType := func(types []string, contentType string) string {
+		var stringInf *pf.Inference_String
+		for _, ty := range types {
+			if ty == "string" {
+				stringInf = &pf.Inference_String{ContentType: contentType}
+				break
+			}
+		}
+		return testDialect.MapType(&sql.Projection{
+			Projection: pf.Projection{
+				Inference: pf.Inference{
+					Types:   types,
+					String_: stringInf,
+					Exists:  pf.Inference_MUST,
+				},
+			},
+		}, sql.FieldConfig{}).DDL
+	}
+
+	require.Equal(t,
+		"JSONB NOT NULL",
+		mapWithMediaType([]string{"object", "string", "array", "number", "boolean"}, jsonbMediaType),
+		"MULTIPLE-typed field with jsonb contentMediaType should map to JSONB")
+	require.Equal(t,
+		"JSON NOT NULL",
+		mapWithMediaType([]string{"object", "string", "array", "number", "boolean"}, "application/json"),
+		"MULTIPLE-typed field with application/json contentMediaType should map to JSON")
+	require.Equal(t,
+		"JSON NOT NULL",
+		mapWithMediaType([]string{"object", "string", "array", "number", "boolean"}, ""),
+		"MULTIPLE-typed field without contentMediaType should default to JSON")
 }
 
 func TestTruncatedIdentifier(t *testing.T) {

--- a/source-postgres/.snapshots/TestDiscoveryComplex
+++ b/source-postgres/.snapshots/TestDiscoveryComplex
@@ -36,10 +36,12 @@ sql> COMMENT ON COLUMN test.discoverycomplex_934635.k1 IS 'I think this is a key
             ]
           },
           "doc": {
-            "description": "(source type: json)"
+            "description": "(source type: json)",
+            "contentMediaType": "application/json"
           },
           "doc/bin": {
-            "description": "(source type: non-nullable jsonb)"
+            "description": "(source type: non-nullable jsonb)",
+            "contentMediaType": "application/vnd.postgresql.jsonb+json"
           },
           "foo": {
             "description": "This is a text field! (source type: text)",

--- a/source-postgres/.snapshots/TestDiscoveryComplex
+++ b/source-postgres/.snapshots/TestDiscoveryComplex
@@ -41,7 +41,7 @@ sql> COMMENT ON COLUMN test.discoverycomplex_934635.k1 IS 'I think this is a key
           },
           "doc/bin": {
             "description": "(source type: non-nullable jsonb)",
-            "contentMediaType": "application/vnd.postgresql.jsonb+json"
+            "contentMediaType": "application/vnd.estuary.postgresql.jsonb+json"
           },
           "foo": {
             "description": "This is a text field! (source type: text)",

--- a/source-postgres/discovery.go
+++ b/source-postgres/discovery.go
@@ -290,10 +290,11 @@ func (db *postgresDatabase) TranslateDBToJSONType(column sqlcapture.ColumnInfo, 
 }
 
 type columnSchema struct {
-	contentEncoding string
-	format          string
-	nullable        bool
-	jsonTypes       []string
+	contentEncoding  string
+	contentMediaType string
+	format           string
+	nullable         bool
+	jsonTypes        []string
 }
 
 func (s columnSchema) toType() *jsonschema.Schema {
@@ -304,6 +305,10 @@ func (s columnSchema) toType() *jsonschema.Schema {
 
 	if s.contentEncoding != "" {
 		out.Extras["contentEncoding"] = s.contentEncoding // New in 2019-09.
+	}
+
+	if s.contentMediaType != "" {
+		out.Extras["contentMediaType"] = s.contentMediaType // New in 2019-09.
 	}
 
 	if s.jsonTypes != nil {
@@ -361,8 +366,12 @@ var postgresTypeToJSON = map[string]columnSchema{
 	"bit":     {jsonTypes: []string{"string"}},
 	"varbit":  {jsonTypes: []string{"string"}},
 
-	"json":     {},
-	"jsonb":    {},
+	// json and jsonb columns capture arbitrary JSON values, so we don't constrain
+	// the JSON Schema type. The contentMediaType annotation distinguishes the two
+	// at the wire so downstream connectors (e.g. materialize-postgres) can
+	// recreate the original column type instead of collapsing both onto json.
+	"json":     {contentMediaType: "application/json"},
+	"jsonb":    {contentMediaType: "application/vnd.postgresql.jsonb+json"},
 	"jsonpath": {jsonTypes: []string{"string"}},
 
 	// Domain-Specific Types

--- a/source-postgres/discovery.go
+++ b/source-postgres/discovery.go
@@ -371,7 +371,7 @@ var postgresTypeToJSON = map[string]columnSchema{
 	// at the wire so downstream connectors (e.g. materialize-postgres) can
 	// recreate the original column type instead of collapsing both onto json.
 	"json":     {contentMediaType: "application/json"},
-	"jsonb":    {contentMediaType: "application/vnd.postgresql.jsonb+json"},
+	"jsonb":    {contentMediaType: "application/vnd.estuary.postgresql.jsonb+json"},
 	"jsonpath": {jsonTypes: []string{"string"}},
 
 	// Domain-Specific Types


### PR DESCRIPTION
**Description:**

- Use a custom `contentMediaType: "application/vnd.postgresql.jsonb+json"` annotation in JSONSchema to mark an object as originating from a postgresql `JSONB` column type
- In materializations, use `JSONB` for creating such a column
- Add automatic column migrations from `JSON` to `JSONB` and vice versa

I have identified customers that would be affected by this and I am coordinating with our support team to make sure we can transition them to this new change without breaking their pipelines down the line.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

