### PR TITLE
source-quickbooks: fix miscellaneous issues

### DIFF
--- a/source-quickbooks/source_quickbooks/__init__.py
+++ b/source-quickbooks/source_quickbooks/__init__.py
@@ -1,9 +1,7 @@
+from collections.abc import Awaitable
 from logging import Logger
-from typing import Callable, Awaitable
+from typing import Callable
 
-from estuary_cdk.flow import (
-    ConnectorSpec,
-)
 from estuary_cdk.capture import (
     BaseCaptureConnector,
     Request,
@@ -12,41 +10,43 @@ from estuary_cdk.capture import (
     request,
     response,
 )
+from estuary_cdk.flow import (
+    ConnectorSpec,
+)
 
-from .resources import all_resources, validate_credentials
 from .models import (
     OAUTH2_SPEC,
     ConnectorState,
     EndpointConfig,
-    ResourceConfig,
 )
+from .resources import all_resources, validate_credentials
 
 
 class Connector(
-    BaseCaptureConnector[EndpointConfig, ResourceConfig, ConnectorState],
+    BaseCaptureConnector[EndpointConfig, common.ResourceConfig, ConnectorState],
 ):
     def request_class(self):
-        return Request[EndpointConfig, ResourceConfig, ConnectorState]
+        return Request[EndpointConfig, common.ResourceConfig, ConnectorState]
 
     async def spec(self, _: request.Spec, logger: Logger) -> ConnectorSpec:
         return ConnectorSpec(
             configSchema=EndpointConfig.model_json_schema(),
             oauth2=OAUTH2_SPEC,
             documentationUrl="https://go.estuary.dev/source-quickbooks",
-            resourceConfigSchema=ResourceConfig.model_json_schema(),
-            resourcePathPointers=ResourceConfig.PATH_POINTERS,
+            resourceConfigSchema=common.ResourceConfig.model_json_schema(),
+            resourcePathPointers=common.ResourceConfig.PATH_POINTERS,
         )
 
     async def discover(
         self, log: Logger, discover: request.Discover[EndpointConfig]
-    ) -> response.Discovered[ResourceConfig]:
+    ) -> response.Discovered[common.ResourceConfig]:
         resources = await all_resources(log, self, discover.config)
         return common.discovered(resources)
 
     async def validate(
         self,
         log: Logger,
-        validate: request.Validate[EndpointConfig, ResourceConfig],
+        validate: request.Validate[EndpointConfig, common.ResourceConfig],
     ) -> response.Validated:
         await validate_credentials(self, validate.config, log)
         resources = await all_resources(log, self, validate.config)
@@ -56,7 +56,7 @@ class Connector(
     async def open(
         self,
         log: Logger,
-        open: request.Open[EndpointConfig, ResourceConfig, ConnectorState],
+        open: request.Open[EndpointConfig, common.ResourceConfig, ConnectorState],
     ) -> tuple[response.Opened, Callable[[Task], Awaitable[None]]]:
         resources = await all_resources(log, self, open.capture.config)
         resolved = common.resolve_bindings(open.capture.bindings, resources)

--- a/source-quickbooks/source_quickbooks/api.py
+++ b/source-quickbooks/source_quickbooks/api.py
@@ -15,6 +15,9 @@ from .models import QuickBooksEntity
 PAGE_SIZE = 1000
 TARGET_FETCH_PAGE_INVOCATION_RUN_TIME = timedelta(minutes=5)
 
+PROD_API_BASE_URL = "https://quickbooks.api.intuit.com"
+SANDBOX_API_BASE_URL = "https://sandbox-quickbooks.api.intuit.com"
+
 T = TypeVar("T", bound=QuickBooksEntity)
 
 
@@ -23,10 +26,11 @@ async def query_entity(
     start_date: datetime,
     end_date: datetime,
     http: HTTPSession,
+    base_url: str,
     realm_id: str,
     log: Logger,
 ) -> AsyncGenerator[T, None]:
-    url = f"https://quickbooks.api.intuit.com/v3/company/{realm_id}/query"
+    url = f"{base_url}/v3/company/{realm_id}/query"
     query_offset = 0
 
     while True:
@@ -66,6 +70,7 @@ async def query_entity(
 async def backfill_entity(
     model: type[T],
     http: HTTPSession,
+    base_url: str,
     realm_id: str,
     log: Logger,
     page: PageCursor,
@@ -86,7 +91,9 @@ async def backfill_entity(
     if page_ts >= cutoff:
         return
 
-    async for item in query_entity(model, page_ts, cutoff, http, realm_id, log):
+    async for item in query_entity(
+        model, page_ts, cutoff, http, base_url, realm_id, log
+    ):
         if (
             timeout_checkpoint is not None
             and item.MetaData.LastUpdatedTime >= timeout_checkpoint
@@ -107,6 +114,7 @@ async def backfill_entity(
 async def fetch_entity(
     model: type[T],
     http: HTTPSession,
+    base_url: str,
     realm_id: str,
     log: Logger,
     log_cursor: LogCursor,
@@ -132,7 +140,9 @@ async def fetch_entity(
     log.info("Starting incremental fetch", {"log_cursor": log_cursor})
 
     new_log_cursor = log_cursor
-    async for item in query_entity(model, log_cursor, now, http, realm_id, log):
+    async for item in query_entity(
+        model, log_cursor, now, http, base_url, realm_id, log
+    ):
         new_log_cursor = max(item.MetaData.LastUpdatedTime, new_log_cursor)
         yield item
 

--- a/source-quickbooks/source_quickbooks/models.py
+++ b/source-quickbooks/source_quickbooks/models.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import urllib.parse
 from datetime import UTC, datetime, timedelta
 from typing import TYPE_CHECKING, ClassVar
 
@@ -26,16 +25,6 @@ def default_start_date():
     return dt
 
 
-scopes = [
-    "com.intuit.quickbooks.accounting",
-    "com.intuit.quickbooks.payment",
-    "openid",
-    "profile",
-    "email",
-    "phone",
-    "address",
-]
-
 OAUTH2_SPEC = OAuth2Spec(
     provider="intuit",
     accessTokenBody=(
@@ -45,9 +34,8 @@ OAUTH2_SPEC = OAuth2Spec(
     ),
     authUrlTemplate=(
         "https://appcenter.intuit.com/connect/oauth2?"
-        r"client_id={{#urlencode}}{{{ client_id }}}{{/urlencode}}"
-        r"&scope="
-        + urllib.parse.quote(" ".join(scopes))
+        + r"client_id={{#urlencode}}{{{ client_id }}}{{/urlencode}}"
+        + r"&scope=com.intuit.quickbooks.accounting"
         + r"&redirect_uri={{#urlencode}}{{{ redirect_uri }}}{{/urlencode}}"
         + r"&response_type=code"
         + r"&state={{#urlencode}}{{{ state }}}{{/urlencode}}"
@@ -59,6 +47,7 @@ OAUTH2_SPEC = OAuth2Spec(
         "access_token_expires_at": r"{{#now_plus}}{{ expires_in }}{{/now_plus}}",
     },
     accessTokenHeaders={
+        "Authorization": r"Basic {{#basicauth}}{{{ client_id }}}:{{{ client_secret }}}{{/basicauth}}",
         "Content-Type": "application/x-www-form-urlencoded",
     },
 )

--- a/source-quickbooks/source_quickbooks/models.py
+++ b/source-quickbooks/source_quickbooks/models.py
@@ -5,13 +5,13 @@ from typing import TYPE_CHECKING, ClassVar
 
 from estuary_cdk.capture.common import (
     BaseDocument,
-    ResourceConfig,
     ResourceState,
 )
 from estuary_cdk.capture.common import (
     ConnectorState as GenericConnectorState,
 )
 from estuary_cdk.flow import (
+    OAuth2ClientCredentialsPlacement,
     OAuth2Spec,
     RotatingOAuth2Credentials,
 )
@@ -55,11 +55,11 @@ OAUTH2_SPEC = OAuth2Spec(
 
 if TYPE_CHECKING:
     OAuth2Credentials = RotatingOAuth2Credentials.with_client_credentials_placement(
-        "headers"
+        OAuth2ClientCredentialsPlacement.HEADERS
     )
 else:
     OAuth2Credentials = RotatingOAuth2Credentials.with_client_credentials_placement(
-        "headers"
+        OAuth2ClientCredentialsPlacement.HEADERS
     ).for_provider(OAUTH2_SPEC.provider)
 
 
@@ -86,6 +86,12 @@ class EndpointConfig(BaseModel):
         default_factory=default_start_date,
         ge=EPOCH,
         json_schema_extra={"order": 2},
+    )
+    is_sandbox: bool = Field(
+        description="Enable to capture from a QuickBooks sandbox company instead of production.",
+        title="Use Sandbox Environment",
+        default=False,
+        json_schema_extra={"order": 3},
     )
 
 

--- a/source-quickbooks/source_quickbooks/models.py
+++ b/source-quickbooks/source_quickbooks/models.py
@@ -116,7 +116,7 @@ class Account(QuickBooksEntity):
 
 
 class BillPayment(QuickBooksEntity):
-    resource_name: ClassVar[str] = "Bill Payments"
+    resource_name: ClassVar[str] = "Bill_Payments"
     table_name: ClassVar[str] = "BillPayment"
 
 
@@ -136,7 +136,7 @@ class Class(QuickBooksEntity):
 
 
 class CreditMemo(QuickBooksEntity):
-    resource_name: ClassVar[str] = "Credit Memos"
+    resource_name: ClassVar[str] = "Credit_Memos"
     table_name: ClassVar[str] = "CreditMemo"
 
 
@@ -176,7 +176,7 @@ class Item(QuickBooksEntity):
 
 
 class JournalEntry(QuickBooksEntity):
-    resource_name: ClassVar[str] = "Journal Entries"
+    resource_name: ClassVar[str] = "Journal_Entries"
     table_name: ClassVar[str] = "JournalEntry"
 
 
@@ -186,7 +186,7 @@ class Payment(QuickBooksEntity):
 
 
 class PaymentMethod(QuickBooksEntity):
-    resource_name: ClassVar[str] = "Payment Methods"
+    resource_name: ClassVar[str] = "Payment_Methods"
     table_name: ClassVar[str] = "PaymentMethod"
 
 
@@ -196,32 +196,32 @@ class Purchase(QuickBooksEntity):
 
 
 class PurchaseOrder(QuickBooksEntity):
-    resource_name: ClassVar[str] = "Purchase Orders"
+    resource_name: ClassVar[str] = "Purchase_Orders"
     table_name: ClassVar[str] = "PurchaseOrder"
 
 
 class RefundReceipt(QuickBooksEntity):
-    resource_name: ClassVar[str] = "Refund Receipts"
+    resource_name: ClassVar[str] = "Refund_Receipts"
     table_name: ClassVar[str] = "RefundReceipt"
 
 
 class SalesReceipt(QuickBooksEntity):
-    resource_name: ClassVar[str] = "Sales Receipts"
+    resource_name: ClassVar[str] = "Sales_Receipts"
     table_name: ClassVar[str] = "SalesReceipt"
 
 
 class TaxAgency(QuickBooksEntity):
-    resource_name: ClassVar[str] = "Tax Agencies"
+    resource_name: ClassVar[str] = "Tax_Agencies"
     table_name: ClassVar[str] = "TaxAgency"
 
 
 class TaxCode(QuickBooksEntity):
-    resource_name: ClassVar[str] = "Tax Codes"
+    resource_name: ClassVar[str] = "Tax_Codes"
     table_name: ClassVar[str] = "TaxCode"
 
 
 class TaxRate(QuickBooksEntity):
-    resource_name: ClassVar[str] = "Tax Rates"
+    resource_name: ClassVar[str] = "Tax_Rates"
     table_name: ClassVar[str] = "TaxRate"
 
 
@@ -231,7 +231,7 @@ class Term(QuickBooksEntity):
 
 
 class TimeActivity(QuickBooksEntity):
-    resource_name: ClassVar[str] = "Time Activities"
+    resource_name: ClassVar[str] = "Time_Activities"
     table_name: ClassVar[str] = "TimeActivity"
 
 
@@ -241,7 +241,7 @@ class Transfer(QuickBooksEntity):
 
 
 class VendorCredit(QuickBooksEntity):
-    resource_name: ClassVar[str] = "Vendor Credits"
+    resource_name: ClassVar[str] = "Vendor_Credits"
     table_name: ClassVar[str] = "VendorCredit"
 
 

--- a/source-quickbooks/source_quickbooks/resources.py
+++ b/source-quickbooks/source_quickbooks/resources.py
@@ -1,13 +1,22 @@
 import functools
 from datetime import UTC, datetime, timedelta
 from logging import Logger
-from typing import Type, TypeVar
+from typing import TypeVar
 
-from estuary_cdk.capture import Task, common
+from estuary_cdk.capture import Task
+from estuary_cdk.capture.common import (
+    BaseDocument,
+    Resource,
+    ResourceConfig,
+    ResourceState,
+    open_binding,
+)
 from estuary_cdk.flow import CaptureBinding, ValidationError
 from estuary_cdk.http import HTTPError, HTTPMixin, TokenSource
 
 from .api import (
+    PROD_API_BASE_URL,
+    SANDBOX_API_BASE_URL,
     backfill_entity,
     fetch_entity,
     query_entity,
@@ -19,8 +28,6 @@ from .models import (
     Account,
     EndpointConfig,
     QuickBooksEntity,
-    ResourceConfig,
-    ResourceState,
 )
 
 
@@ -29,10 +36,18 @@ async def validate_credentials(http: HTTPMixin, config: EndpointConfig, log: Log
         oauth_spec=OAUTH2_SPEC, credentials=config.credentials
     )
 
+    base_url = SANDBOX_API_BASE_URL if config.is_sandbox else PROD_API_BASE_URL
+
     try:
-        await anext(
+        _ = await anext(
             query_entity(
-                Account, EPOCH, datetime.now(tz=UTC), http, config.realm_id, log
+                Account,
+                EPOCH,
+                datetime.now(tz=UTC),
+                http,
+                base_url,
+                config.realm_id,
+                log,
             )
         )
     except HTTPError as err:
@@ -52,41 +67,44 @@ async def all_resources(
     _log: Logger,
     http: HTTPMixin,
     config: EndpointConfig,
-) -> list[common.Resource]:
+) -> list[Resource[BaseDocument, ResourceConfig, ResourceState]]:
     http.token_source = TokenSource(
         oauth_spec=OAUTH2_SPEC, credentials=config.credentials
     )
+
+    base_url = SANDBOX_API_BASE_URL if config.is_sandbox else PROD_API_BASE_URL
 
     # API works with second precision
     start_date = config.start_date.replace(microsecond=0)
     cutoff = datetime.now(tz=UTC).replace(microsecond=0)
 
     def open_all_bindings(
-        entity: Type[QuickBooksEntity],
+        entity: type[QuickBooksEntity],
         binding: CaptureBinding[ResourceConfig],
         binding_index: int,
         state: ResourceState,
         task: Task,
         _all_bindings,
     ):
-        common.open_binding(
+        open_binding(
             binding,
             binding_index,
             state,
             task,
             fetch_changes=functools.partial(
-                fetch_entity, entity, http, config.realm_id
+                fetch_entity, entity, http, base_url, config.realm_id
             ),
             fetch_page=functools.partial(
                 backfill_entity,
                 entity,
                 http,
+                base_url,
                 config.realm_id,
             ),
         )
 
     return [
-        common.Resource(
+        Resource(
             name=resource.resource_name,
             key=["/Id"],
             model=resource,
@@ -95,7 +113,7 @@ async def all_resources(
                 backfill=ResourceState.Backfill(
                     cutoff=cutoff, next_page=start_date.isoformat(timespec="seconds")
                 ),
-                inc=common.ResourceState.Incremental(cursor=cutoff),
+                inc=ResourceState.Incremental(cursor=cutoff),
             ),
             initial_config=ResourceConfig(
                 name=resource.resource_name, interval=timedelta(minutes=5)

--- a/source-quickbooks/tests/snapshots/snapshots__discover__stdout.json
+++ b/source-quickbooks/tests/snapshots/snapshots__discover__stdout.json
@@ -96,9 +96,9 @@
     ]
   },
   {
-    "recommendedName": "Bill Payments",
+    "recommendedName": "Bill_Payments",
     "resourceConfig": {
-      "name": "Bill Payments",
+      "name": "Bill_Payments",
       "interval": "PT5M"
     },
     "documentSchema": {
@@ -480,9 +480,9 @@
     ]
   },
   {
-    "recommendedName": "Credit Memos",
+    "recommendedName": "Credit_Memos",
     "resourceConfig": {
-      "name": "Credit Memos",
+      "name": "Credit_Memos",
       "interval": "PT5M"
     },
     "documentSchema": {
@@ -1248,9 +1248,9 @@
     ]
   },
   {
-    "recommendedName": "Journal Entries",
+    "recommendedName": "Journal_Entries",
     "resourceConfig": {
-      "name": "Journal Entries",
+      "name": "Journal_Entries",
       "interval": "PT5M"
     },
     "documentSchema": {
@@ -1344,9 +1344,9 @@
     ]
   },
   {
-    "recommendedName": "Payment Methods",
+    "recommendedName": "Payment_Methods",
     "resourceConfig": {
-      "name": "Payment Methods",
+      "name": "Payment_Methods",
       "interval": "PT5M"
     },
     "documentSchema": {
@@ -1536,9 +1536,9 @@
     ]
   },
   {
-    "recommendedName": "Purchase Orders",
+    "recommendedName": "Purchase_Orders",
     "resourceConfig": {
-      "name": "Purchase Orders",
+      "name": "Purchase_Orders",
       "interval": "PT5M"
     },
     "documentSchema": {
@@ -1728,9 +1728,9 @@
     ]
   },
   {
-    "recommendedName": "Refund Receipts",
+    "recommendedName": "Refund_Receipts",
     "resourceConfig": {
-      "name": "Refund Receipts",
+      "name": "Refund_Receipts",
       "interval": "PT5M"
     },
     "documentSchema": {
@@ -1824,9 +1824,9 @@
     ]
   },
   {
-    "recommendedName": "Sales Receipts",
+    "recommendedName": "Sales_Receipts",
     "resourceConfig": {
-      "name": "Sales Receipts",
+      "name": "Sales_Receipts",
       "interval": "PT5M"
     },
     "documentSchema": {
@@ -1920,9 +1920,9 @@
     ]
   },
   {
-    "recommendedName": "Tax Agencies",
+    "recommendedName": "Tax_Agencies",
     "resourceConfig": {
-      "name": "Tax Agencies",
+      "name": "Tax_Agencies",
       "interval": "PT5M"
     },
     "documentSchema": {
@@ -2016,9 +2016,9 @@
     ]
   },
   {
-    "recommendedName": "Tax Codes",
+    "recommendedName": "Tax_Codes",
     "resourceConfig": {
-      "name": "Tax Codes",
+      "name": "Tax_Codes",
       "interval": "PT5M"
     },
     "documentSchema": {
@@ -2112,9 +2112,9 @@
     ]
   },
   {
-    "recommendedName": "Tax Rates",
+    "recommendedName": "Tax_Rates",
     "resourceConfig": {
-      "name": "Tax Rates",
+      "name": "Tax_Rates",
       "interval": "PT5M"
     },
     "documentSchema": {
@@ -2304,9 +2304,9 @@
     ]
   },
   {
-    "recommendedName": "Time Activities",
+    "recommendedName": "Time_Activities",
     "resourceConfig": {
-      "name": "Time Activities",
+      "name": "Time_Activities",
       "interval": "PT5M"
     },
     "documentSchema": {
@@ -2496,9 +2496,9 @@
     ]
   },
   {
-    "recommendedName": "Vendor Credits",
+    "recommendedName": "Vendor_Credits",
     "resourceConfig": {
-      "name": "Vendor Credits",
+      "name": "Vendor_Credits",
       "interval": "PT5M"
     },
     "documentSchema": {

--- a/source-quickbooks/tests/snapshots/snapshots__spec__stdout.json
+++ b/source-quickbooks/tests/snapshots/snapshots__spec__stdout.json
@@ -115,10 +115,11 @@
     "documentationUrl": "https://go.estuary.dev/source-quickbooks",
     "oauth2": {
       "provider": "intuit",
-      "authUrlTemplate": "https://appcenter.intuit.com/connect/oauth2?client_id={{#urlencode}}{{{ client_id }}}{{/urlencode}}&scope=com.intuit.quickbooks.accounting%20com.intuit.quickbooks.payment%20openid%20profile%20email%20phone%20address&redirect_uri={{#urlencode}}{{{ redirect_uri }}}{{/urlencode}}&response_type=code&state={{#urlencode}}{{{ state }}}{{/urlencode}}",
+      "authUrlTemplate": "https://appcenter.intuit.com/connect/oauth2?client_id={{#urlencode}}{{{ client_id }}}{{/urlencode}}&scope=com.intuit.quickbooks.accounting&redirect_uri={{#urlencode}}{{{ redirect_uri }}}{{/urlencode}}&response_type=code&state={{#urlencode}}{{{ state }}}{{/urlencode}}",
       "accessTokenUrlTemplate": "https://oauth.platform.intuit.com/oauth2/v1/tokens/bearer",
       "accessTokenBody": "grant_type=authorization_code&code={{#urlencode}}{{{ code }}}{{/urlencode}}&redirect_uri={{#urlencode}}{{{ redirect_uri }}}{{/urlencode}}",
       "accessTokenHeaders": {
+        "Authorization": "Basic {{#basicauth}}{{{ client_id }}}:{{{ client_secret }}}{{/basicauth}}",
         "Content-Type": "application/x-www-form-urlencoded"
       },
       "accessTokenResponseMap": {

--- a/source-quickbooks/tests/snapshots/snapshots__spec__stdout.json
+++ b/source-quickbooks/tests/snapshots/snapshots__spec__stdout.json
@@ -67,6 +67,13 @@
           "order": 2,
           "title": "Start Date",
           "type": "string"
+        },
+        "is_sandbox": {
+          "default": false,
+          "description": "Enable to capture from a QuickBooks sandbox company instead of production.",
+          "order": 3,
+          "title": "Use Sandbox Environment",
+          "type": "boolean"
         }
       },
       "required": [


### PR DESCRIPTION
**Description:**

Implements several fixes for `source-quickbooks`:

- Includes `Authentication` headers in OAuth token exchanges
- Trims the number of required scopes
- Reorganises obtuse import paths
- Adds a "is sandbox environment" flag to support creating captures with test credentials
- Removes spaces from resource names (it was causing issues with `flowctl raw discover`)

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

Data could be fetched through `flowctl preview`. The local deployment can successfully log in using the "authenticate your Intuit account" button.

Best read commit by commit. 
