### PR TITLE
source-sage-intacct: surface result level errors

### DIFF
--- a/source-sage-intacct/source_sage_intacct/models.py
+++ b/source-sage-intacct/source_sage_intacct/models.py
@@ -68,10 +68,22 @@ ConnectorState = GenericConnectorState[ResourceState]
 class ApiResponse(BaseModel):
     class ErrorMessage(BaseModel):
         class Error(BaseModel):
-            errorno: str
-            description2: str
+            errorno: str | None = None
+            description2: str | None = None
+
+            def __str__(self) -> str:
+                parts = []
+                if self.errorno:
+                    parts.append(f"Error: {self.errorno}")
+                if self.description2:
+                    parts.append(self.description2)
+                return " - ".join(parts) if parts else "unspecified Sage Intacct error"
 
         error: list[Error] | Error
+
+        def __str__(self) -> str:
+            err = self.error[0] if isinstance(self.error, list) else self.error
+            return str(err)
 
     class Response(BaseModel):
         class Operation(BaseModel):
@@ -96,18 +108,10 @@ class ApiResponse(BaseModel):
 
     def raise_for_error(self):
         if self.response.errormessage:
-            if isinstance(self.response.errormessage.error, list):
-                error = self.response.errormessage.error[0]
-            else:
-                error = self.response.errormessage.error
-            raise ValidationError([f"Error: {error.errorno} - {error.description2}"])
+            raise ValidationError([str(self.response.errormessage)])
 
         if self.response.operation and self.response.operation.errormessage:
-            if isinstance(self.response.operation.errormessage.error, list):
-                error = self.response.operation.errormessage.error[0]
-            else:
-                error = self.response.operation.errormessage.error
-            raise ValidationError([f"Error: {error.errorno} - {error.description2}"])
+            raise ValidationError([str(self.response.operation.errormessage)])
 
         if self.response.operation:
             if self.response.operation.authentication.status != "success":
@@ -118,6 +122,11 @@ class ApiResponse(BaseModel):
                 )
 
             if self.response.operation.result:
+                if self.response.operation.result.errormessage:
+                    raise ValidationError(
+                        [str(self.response.operation.result.errormessage)]
+                    )
+
                 if self.response.operation.result.status != "success":
                     raise ValidationError(
                         [f"result status: {self.response.operation.result.status}"]


### PR DESCRIPTION
**Description:**

Sage Intacct returns content level failures with the description nested in `result.errormessage` rather than at the response or operation level. `raise_for_error` previously only inspected the upper two scopes, so these failures were raised as the bare string "result status: failure" with the actual error description discarded. It also required `errorno` to be a non-null string, which crashed `model_validate` when Sage returned a null `errorno` on an otherwise-descriptive error.

This commit makes `Error` fields optional, moves first error selection and formatting onto `ErrorMessage` via `__str__`, and checks `response.operation.result.errormessage` in `raise_for_error` before falling back to the bare status error message.


