### PR TITLE
source-apple-app-store: Fix analytics cursor usage

### DIFF
--- a/source-apple-app-store/source_apple_app_store/api.py
+++ b/source-apple-app-store/source_apple_app_store/api.py
@@ -177,7 +177,7 @@ async def fetch_incremental_analytics(
 ) -> AsyncGenerator[AppleAnalyticsRow | LogCursor, None]:
     assert isinstance(log_cursor, datetime)
 
-    last_processed_date = log_cursor
+    last_processed_date = log_cursor.date()
 
     report_request_id = await _get_or_create_analytics_report_request(
         log,


### PR DESCRIPTION
**Description:**

Streams using this incremental fetch function have been failing in production with the error:

    unsupported operand type(s) for -: 'datetime.date' and 'datetime.datetime'

    Traceback (most recent call last):
      File "/opt/estuary-cdk/estuary_cdk/capture/task.py", line 209, in run_task
        await child(t)
      File "/opt/estuary-cdk/estuary_cdk/capture/common.py", line 795, in incremental_closure
        await _binding_incremental_task(
      File "/opt/estuary-cdk/estuary_cdk/capture/common.py", line 1170, in _binding_incremental_task
        async for item in fetch_changes(task.log, state.cursor):
      File "/opt/source-apple-app-store/source_apple_app_store/api.py", line 190, in fetch_incremental_analytics
        current_lag = now.date() - last_processed_date
                      ~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~

I'm pretty sure this logic never worked. This function begins with:

    assert isinstance(log_cursor, datetime)
    last_processed_date = log_cursor

But then proceeds to use last_processed_date as a `date` rather than the `datetime` we just asserted it was. AFAICT if we just say `log_cursor.date()` instead that fixes the issue.

This fix is completely untested but it seems probably no worse than the current state of things and there are no functioning source-apple-app-store captures in production so I say we just YOLO it and see if this fixes the problem.

