### PR TITLE
source-sage-intacct: only discover bindings the user has permission to query

### DIFF
--- a/source-sage-intacct/source_sage_intacct/models.py
+++ b/source-sage-intacct/source_sage_intacct/models.py
@@ -65,6 +65,11 @@ class EndpointConfig(BaseModel):
 ConnectorState = GenericConnectorState[ResourceState]
 
 
+class SagePermissionError(Exception):
+    """Raised when a Sage Intacct API call fails because the authenticated
+    user's role lacks permission for the requested operation."""
+
+
 class ApiResponse(BaseModel):
     class ErrorMessage(BaseModel):
         class Error(BaseModel):
@@ -79,11 +84,19 @@ class ApiResponse(BaseModel):
                     parts.append(self.description2)
                 return " - ".join(parts) if parts else "unspecified Sage Intacct error"
 
+            def is_permission_error(self) -> bool:
+                return self.errorno == "PL04000005"
+
         error: list[Error] | Error
 
+        def _errors(self) -> list["ApiResponse.ErrorMessage.Error"]:
+            return self.error if isinstance(self.error, list) else [self.error]
+
         def __str__(self) -> str:
-            err = self.error[0] if isinstance(self.error, list) else self.error
-            return str(err)
+            return str(self._errors()[0])
+
+        def is_permission_error(self) -> bool:
+            return any(e.is_permission_error() for e in self._errors())
 
     class Response(BaseModel):
         class Operation(BaseModel):
@@ -108,10 +121,10 @@ class ApiResponse(BaseModel):
 
     def raise_for_error(self):
         if self.response.errormessage:
-            raise ValidationError([str(self.response.errormessage)])
+            self._raise(self.response.errormessage)
 
         if self.response.operation and self.response.operation.errormessage:
-            raise ValidationError([str(self.response.operation.errormessage)])
+            self._raise(self.response.operation.errormessage)
 
         if self.response.operation:
             if self.response.operation.authentication.status != "success":
@@ -123,14 +136,18 @@ class ApiResponse(BaseModel):
 
             if self.response.operation.result:
                 if self.response.operation.result.errormessage:
-                    raise ValidationError(
-                        [str(self.response.operation.result.errormessage)]
-                    )
+                    self._raise(self.response.operation.result.errormessage)
 
                 if self.response.operation.result.status != "success":
                     raise ValidationError(
                         [f"result status: {self.response.operation.result.status}"]
                     )
+
+    @staticmethod
+    def _raise(err: "ApiResponse.ErrorMessage") -> None:
+        if err.is_permission_error():
+            raise SagePermissionError(str(err))
+        raise ValidationError([str(err)])
 
 
 class GenerateApiSessionResponse(BaseModel):

--- a/source-sage-intacct/source_sage_intacct/resources.py
+++ b/source-sage-intacct/source_sage_intacct/resources.py
@@ -19,6 +19,7 @@ from .models import (
     IncrementalResource,
     ResourceConfig,
     ResourceState,
+    SagePermissionError,
     SnapshotResource,
 )
 from .sage import PAGE_SIZE, Sage
@@ -162,9 +163,37 @@ async def all_resources(
     sage = Sage(log, http, config)
     await sage.setup()
 
+    # Sage gates QUERY access per-object — either via the user's role or
+    # via what the tenant's subscription exposes. Probe each candidate up
+    # front and drop bindings whose probe returns a PL04000005 denial,
+    # rather than failing the whole capture on the first denial. The
+    # warning surfaces Sage's own message so the reader can distinguish
+    # "your role lacks the grant" from "this object isn't queryable here".
+    async def _probe(obj: str) -> tuple[str, str | None]:
+        try:
+            await sage.probe_query_permission(obj)
+            return obj, None
+        except SagePermissionError as e:
+            return obj, str(e)
+
+    object_names = sorted(INCREMENTAL_OBJECTS | SNAPSHOT_OBJECTS)
+    probes = await asyncio.gather(*(_probe(obj) for obj in object_names))
+    accessible_objects = {obj for obj, denial in probes if denial is None}
+    for obj, denial in probes:
+        if denial is not None:
+            log.warning(f"omitting binding for {obj}: {denial}")
+
     started_at = datetime.now(tz=UTC)
-    inc = [incremental_resource(sage, obj, started_at) for obj in INCREMENTAL_OBJECTS]
-    snap = [snapshot_resource(sage, obj) for obj in SNAPSHOT_OBJECTS]
+    inc = [
+        incremental_resource(sage, obj, started_at)
+        for obj in INCREMENTAL_OBJECTS
+        if obj in accessible_objects
+    ]
+    snap = [
+        snapshot_resource(sage, obj)
+        for obj in SNAPSHOT_OBJECTS
+        if obj in accessible_objects
+    ]
 
     # TODO(whb): Add a binding for AUDITHISTORY to capture deletes once we have
     # access to this object type.

--- a/source-sage-intacct/source_sage_intacct/sage.py
+++ b/source-sage-intacct/source_sage_intacct/sage.py
@@ -337,6 +337,24 @@ class Sage:
 
         return model
 
+    async def probe_query_permission(self, obj: str) -> None:
+        """Issues a cheap QUERY probe against `obj`. Returns silently if the
+        authenticated user can QUERY it; raises SagePermissionError with
+        the Sage error message attached on a PL04000005 denial."""
+        await self._maybe_refresh_session()
+
+        data = permission_probe_request(self.config, self.session_id, obj)
+        bs = await self.http.request(
+            self.log,
+            endpoint_url,
+            method="POST",
+            headers={"Content-Type": "application/xml"},
+            form=data,
+        )
+
+        parsed = ApiResponse.model_validate(xmltodict.parse(bs))
+        parsed.raise_for_error()
+
     async def _req_xml(
         self, cls: type[XMLRecord], data: Any, skip_refresh=False
     ) -> XMLRecord:
@@ -514,6 +532,27 @@ def get_user_by_id_request(cfg: EndpointConfig, session_id: str, user_id: str) -
           <keys>{user_id}</keys>
           <fields>RECORDNO</fields>
         </readByName>
+""".strip()
+
+    return function_with_session_id_xml(cfg, session_id, exec)
+
+
+def permission_probe_request(
+    cfg: EndpointConfig, session_id: str, object: str
+) -> str:
+    # A `pagesize=1` query is the cheapest way to surface a PL04000005
+    # permission denial: Sage checks permissions before retrieval, so the
+    # error fires regardless of whether the query would match any rows.
+    # `lookup` / `inspect` can't substitute here because they bypass
+    # permissions entirely.
+    exec = f"""
+        <query>
+          <object>{object}</object>
+          <select>
+            <field>RECORDNO</field>
+          </select>
+          <pagesize>1</pagesize>
+        </query>
 """.strip()
 
     return function_with_session_id_xml(cfg, session_id, exec)


### PR DESCRIPTION
**Description:**

Sage gates QUERY access per-object via the user's role and the tenant's subscription. Previously, a single PL04000005 denial (ex: "you do not have permission" or "operation cannot be performed on objects of type X") were discovered even though the provided credentials lack the capability to query them. The connector would then try to query them and predictably fail.

This PR omits non-query-able objects from the list of discovered resources by detecting PL04000005 errors when probing which objects are queryable.

**Notes for reviewers:**

Tested with a Sage Intacct account that does not have permission to query all of our defined resources. Confirmed that those resources that weren't query-able were excluded from the list of discovered resources.

