### PR TITLE
source-greenhouse-native: make demographic questions a full refresh stream

### DIFF
--- a/.claude/skills/classify-stream-types/SKILL.md
+++ b/.claude/skills/classify-stream-types/SKILL.md
@@ -95,15 +95,12 @@ def open(
         state,
         task,
         fetch_snapshot=functools.partial(list_all, http, ...),
-        tombstone=MyDocument(_meta=MyDocument.Meta(op="d")),
     )
 
 resource = SnapshotResource(
     name=MyDocument.name,
-    model=MyDocument,
     open=open,
     initial_config=ResourceConfig(name=MyDocument.name, interval=timedelta(minutes=5)),
-    schema_inference=True,
 )
 ```
 

--- a/estuary-cdk/estuary_cdk/capture/common.py
+++ b/estuary-cdk/estuary_cdk/capture/common.py
@@ -481,12 +481,16 @@ class SnapshotResource(Resource[_BaseDocument, _BaseResourceConfig, ResourceStat
     work well with the rest of the CDK and Estuary Flow platform.
 
     Sets key to /_meta/row_id (required for CDK deletion inference),
-    initial_state to an empty ResourceState, and reduction_strategy to
-    lastWriteWins — the invariant choices for all snapshot bindings.
+    initial_state to an empty ResourceState, model to BaseDocument
+    with schema_inference enabled (snapshot bindings rely on schema
+    inference rather than a typed model) — the invariant choices
+    for snapshot bindings.
     """
 
     key: list[str] = field(default_factory=lambda: ["/_meta/row_id"])
     initial_state: ResourceState = field(default_factory=ResourceState)
+    model: type[BaseDocument] | Resource.FixedSchema = BaseDocument
+    schema_inference: bool = True
 
 
 def discovered(

--- a/source-greenhouse-native/source_greenhouse_native/api.py
+++ b/source-greenhouse-native/source_greenhouse_native/api.py
@@ -8,6 +8,7 @@ from estuary_cdk.incremental_json_processor import IncrementalJsonProcessor
 
 from .models import (
     GreenhouseResource,
+    GreenhouseSnapshotResource,
 )
 
 from .shared import (
@@ -22,13 +23,13 @@ EVENTUAL_CONSISTENCY_LAG = timedelta(minutes=5)
 MAX_LIMIT = 500
 
 
-async def _fetch_page(
+async def _fetch_page[T: GreenhouseSnapshotResource](
     http: HTTPSession,
-    model: type[GreenhouseResource],
+    model: type[T],
     log: Logger,
     url: str,
     params: dict[str, str | int],
-) -> tuple[AsyncGenerator[GreenhouseResource, None], str | None]:
+) -> tuple[AsyncGenerator[T, None], str | None]:
     """Fetch a single page of results from a Greenhouse v3 endpoint.
 
     Returns a streaming async generator of resources and the next cursor
@@ -36,19 +37,19 @@ async def _fetch_page(
     headers, body = await http.request_stream(log, url, params=params)
     next_cursor = extract_next_cursor(headers)
 
-    async def docs() -> AsyncGenerator[GreenhouseResource, None]:
+    async def docs() -> AsyncGenerator[T, None]:
         async for doc in IncrementalJsonProcessor(body(), "item", model):
             yield doc
 
     return docs(), next_cursor
 
 
-async def _paginate_greenhouse_resources(
+async def _paginate_greenhouse_resources[T: GreenhouseSnapshotResource](
     http: HTTPSession,
-    model: type[GreenhouseResource],
+    model: type[T],
     log: Logger,
     params: dict[str, str | int],
-) -> AsyncGenerator[GreenhouseResource, None]:
+) -> AsyncGenerator[T, None]:
     """Paginate through all pages of a Greenhouse v3 endpoint."""
     url = f"{GREENHOUSE_BASE_URL}/{model.path}"
 
@@ -99,6 +100,17 @@ async def fetch_greenhouse_resources(
 
     if most_recent_cursor > log_cursor:
         yield most_recent_cursor
+
+
+async def snapshot_greenhouse_resources(
+    http: HTTPSession,
+    model: type[GreenhouseSnapshotResource],
+    log: Logger,
+) -> AsyncGenerator[GreenhouseSnapshotResource, None]:
+    params: dict[str, str | int] = {"per_page": MAX_LIMIT}
+
+    async for resource in _paginate_greenhouse_resources(http, model, log, params):
+        yield resource
 
 
 async def backfill_greenhouse_resources(

--- a/source-greenhouse-native/source_greenhouse_native/models.py
+++ b/source-greenhouse-native/source_greenhouse_native/models.py
@@ -82,11 +82,14 @@ class EndpointConfig(BaseModel):
 ConnectorState = GenericConnectorState[ResourceState]
 
 
-class GreenhouseResource(BaseDocument, extra="allow"):
+class GreenhouseSnapshotResource(BaseDocument, extra="allow"):
     name: ClassVar[str]
     path: ClassVar[str]
 
     id: int
+
+
+class GreenhouseResource(GreenhouseSnapshotResource):
     created_at: AwareDatetime
     updated_at: AwareDatetime
 
@@ -172,7 +175,7 @@ class DemographicAnswers(GreenhouseResource):
     path: ClassVar[str] = "demographic_answers"
 
 
-class DemographicQuestions(GreenhouseResource):
+class DemographicQuestions(GreenhouseSnapshotResource):
     name: ClassVar[str] = "demographic_questions"
     path: ClassVar[str] = "demographic_questions"
 
@@ -312,6 +315,11 @@ class Users(GreenhouseResource):
     path: ClassVar[str] = "users"
 
 
+SNAPSHOT_RESOURCES: list[type[GreenhouseSnapshotResource]] = [
+    DemographicQuestions,
+]
+
+
 INCREMENTAL_RESOURCES: list[type[GreenhouseResource]] = [
     Applications,
     ApplicationStages,
@@ -329,7 +337,6 @@ INCREMENTAL_RESOURCES: list[type[GreenhouseResource]] = [
     CustomFields,
     CustomFieldOptions,
     DemographicAnswers,
-    DemographicQuestions,
     DemographicQuestionSets,
     Departments,
     EEOC,

--- a/source-greenhouse-native/source_greenhouse_native/resources.py
+++ b/source-greenhouse-native/source_greenhouse_native/resources.py
@@ -4,13 +4,15 @@ from logging import Logger
 
 from estuary_cdk.flow import CaptureBinding, ValidationError
 from estuary_cdk.capture import Task
-from estuary_cdk.capture.common import BaseDocument, Resource, open_binding
+from estuary_cdk.capture.common import Resource, SnapshotResource, open_binding
 from estuary_cdk.http import HTTPMixin, HTTPError
 
 from .models import (
     INCREMENTAL_RESOURCES,
+    SNAPSHOT_RESOURCES,
     EndpointConfig,
     GreenhouseResource,
+    GreenhouseSnapshotResource,
     GreenhouseTokenSource,
     Interviewers,
     OAUTH2_SPEC,
@@ -22,6 +24,7 @@ from .api import (
     GREENHOUSE_BASE_URL,
     fetch_greenhouse_resources,
     backfill_greenhouse_resources,
+    snapshot_greenhouse_resources,
 )
 
 from .shared import now
@@ -97,6 +100,43 @@ def incremental_resources(
     return resources
 
 
+def snapshot_resources(
+        log: Logger, http: HTTPMixin, config: EndpointConfig
+) -> list[Resource]:
+    def open(
+            stream: type[GreenhouseSnapshotResource],
+            binding: CaptureBinding[ResourceConfig],
+            binding_index: int,
+            state: ResourceState,
+            task: Task,
+            all_bindings
+    ):
+        open_binding(
+            binding,
+            binding_index,
+            state,
+            task,
+            fetch_snapshot=functools.partial(
+                snapshot_greenhouse_resources,
+                http,
+                stream,
+            ),
+        )
+
+    resources = [
+        SnapshotResource(
+            name=stream.name,
+            open=functools.partial(open, stream),
+            initial_config=ResourceConfig(
+                name=stream.name, interval=timedelta(minutes=15)
+            ),
+        )
+        for stream in SNAPSHOT_RESOURCES
+    ]
+
+    return resources
+
+
 async def all_resources(
     log: Logger, http: HTTPMixin, config: EndpointConfig
 ) -> list[Resource]:
@@ -104,4 +144,5 @@ async def all_resources(
 
     return [
         *incremental_resources(log, http, config),
+        *snapshot_resources(log, http, config),
     ]

--- a/source-greenhouse-native/tests/snapshots/snapshots__discover__capture.stdout.json
+++ b/source-greenhouse-native/tests/snapshots/snapshots__discover__capture.stdout.json
@@ -1516,7 +1516,7 @@
     "recommendedName": "demographic_questions",
     "resourceConfig": {
       "name": "demographic_questions",
-      "interval": "PT5M"
+      "interval": "PT15M"
     },
     "documentSchema": {
       "$defs": {
@@ -1544,33 +1544,13 @@
           "type": "object"
         }
       },
-      "additionalProperties": true,
       "properties": {
         "_meta": {
           "$ref": "#/$defs/Meta",
           "description": "Document metadata"
-        },
-        "id": {
-          "title": "Id",
-          "type": "integer"
-        },
-        "created_at": {
-          "format": "date-time",
-          "title": "Created At",
-          "type": "string"
-        },
-        "updated_at": {
-          "format": "date-time",
-          "title": "Updated At",
-          "type": "string"
         }
       },
-      "required": [
-        "id",
-        "created_at",
-        "updated_at"
-      ],
-      "title": "GreenhouseResource",
+      "title": "BaseDocument",
       "type": "object",
       "x-infer-schema": true,
       "if": {
@@ -1598,7 +1578,7 @@
       }
     },
     "key": [
-      "/id"
+      "/_meta/row_id"
     ]
   },
   {


### PR DESCRIPTION
**Description:**

This PR's scope includes:
- Adding sensible defaults for `model` and `schema_inference` to the CDK's helper `SnapshotResource` class.
- Changing `source-greenhouse-native`'s `demographic_questions` stream to be a full refresh stream instead of an incremental one. The API doesn't support filtering by the `updated_at` field, so we have to fetch all records on each sweep. I opted to make this a full refresh stream instead of a client-side incremental one since I don't have sufficient evidence that the `updated_at` field always exists for `demographic_questions` documents (mostly, if it always exists, why doesn't Greenhouse let us filter by it?).

**Notes for reviewers:**

We don't have a Greenhouse dev account, so I couldn't test out this change locally. But it re-uses a lot of the existing, working code for paginating through the API's responses, so it _should_ work.

Existing capture tasks will need to re-discover the `demographic_questions` binding in order to pick up the key change from `id` to `_meta/row_id`. This should happen automatically via auto-discovers.

