### PR TITLE
source-quickbooks: Rework incremental fetch bounds

### DIFF
--- a/source-quickbooks/source_quickbooks/api.py
+++ b/source-quickbooks/source_quickbooks/api.py
@@ -15,6 +15,13 @@ from .models import QuickBooksEntity
 PAGE_SIZE = 1000
 TARGET_FETCH_PAGE_INVOCATION_RUN_TIME = timedelta(minutes=5)
 
+# Incremental queries exclude items updated within this delay of the current
+# moment. The exclusive lower bound on incremental queries relies on the
+# cursor reflecting a fully-settled state of the source, so we hold the upper
+# bound back from "now" to give recent updates time to become visible across
+# QuickBooks' backend before we advance past them.
+INCREMENTAL_FETCH_DELAY = timedelta(seconds=30)
+
 PROD_API_BASE_URL = "https://quickbooks.api.intuit.com"
 SANDBOX_API_BASE_URL = "https://sandbox-quickbooks.api.intuit.com"
 
@@ -36,7 +43,7 @@ async def query_entity(
     while True:
         query_statement = (
             f"SELECT * FROM {model.table_name}"
-            f" WHERE Metadata.LastUpdatedTime >= '{dt_to_ts(start_date)}'"
+            f" WHERE Metadata.LastUpdatedTime > '{dt_to_ts(start_date)}'"
             f" AND Metadata.LastUpdatedTime < '{dt_to_ts(end_date)}'"
             f" ORDER BY Metadata.LastUpdatedTime ASC"
             f" STARTPOSITION {query_offset}"
@@ -96,7 +103,7 @@ async def backfill_entity(
     ):
         if (
             timeout_checkpoint is not None
-            and item.MetaData.LastUpdatedTime >= timeout_checkpoint
+            and item.MetaData.LastUpdatedTime > timeout_checkpoint
         ):
             yield timeout_checkpoint.isoformat(timespec="seconds")
             return
@@ -104,7 +111,7 @@ async def backfill_entity(
         if datetime.now(tz=UTC) > timeout and timeout_checkpoint is None:
             # We want to make sure the second being worked on is fully covered
             # before checkpointing
-            timeout_checkpoint = item.MetaData.LastUpdatedTime + timedelta(seconds=1)
+            timeout_checkpoint = item.MetaData.LastUpdatedTime
 
         yield item
 
@@ -129,19 +136,29 @@ async def fetch_entity(
     # We've had to implement more traditional SQL-like per-entity queries for
     # backfills, so we opted to keep it simple and reuse the same logic for
     # incremental replications.
+    #
+    # The query's exclusive lower bound guarantees that any returned item has
+    # LastUpdatedTime strictly greater than the prior cursor, which both
+    # ensures forward progress and avoids re-fetching boundary items each
+    # poll. The upper bound is held back from "now" by INCREMENTAL_FETCH_DELAY
+    # so that the cursor (which we source from item metadata to avoid
+    # trusting our local wall clock against QuickBooks') reflects a state
+    # we've confidently observed in full.
     assert isinstance(log_cursor, datetime)
 
-    truncated_log_cursor = log_cursor.replace(microsecond=0)
-    now = datetime.now(tz=UTC).replace(microsecond=0)
+    upper_bound = datetime.now(tz=UTC).replace(microsecond=0) - INCREMENTAL_FETCH_DELAY
 
-    if now == truncated_log_cursor:
+    if upper_bound <= log_cursor:
         return
 
-    log.info("Starting incremental fetch", {"log_cursor": log_cursor})
+    log.info(
+        "Starting incremental fetch",
+        {"log_cursor": log_cursor, "upper_bound": upper_bound},
+    )
 
     new_log_cursor = log_cursor
     async for item in query_entity(
-        model, log_cursor, now, http, base_url, realm_id, log
+        model, log_cursor, upper_bound, http, base_url, realm_id, log
     ):
         new_log_cursor = max(item.MetaData.LastUpdatedTime, new_log_cursor)
         yield item


### PR DESCRIPTION
**Description:**

Changes the lower-bound timestamp for queries to be an _exclusive_ lower bound so that when doing incremental fetches we never receive the same item which was the source of that particular cursor value. To avoid issues with late-arriving data or same-second-as-query events, the upper-bound timestamp is changed to `now() - DELAY` so that we're never looking at items modified more recently than some interval. I have arbitrarily picked 30s as that interval but I'm happy to adjust it if anyone feels like a larger or smaller value would be better.

Since the same query function is used for backfills as well, I have tweaked the backfill page cursor / checkpoint logic such that the same overall behavior _should_ be preserved with the change from `>=` to `>` in the query. This would invalidate any existing state checkpoints for ongoing backfills but there aren't any so that's fine.
