### PR TITLE
materialize-redshift: load bounds and DISTSTYLE ALL for temp load table

### DIFF
--- a/materialize-redshift/.snapshots/TestSQLGeneration
+++ b/materialize-redshift/.snapshots/TestSQLGeneration
@@ -145,23 +145,44 @@ WHEN NOT MATCHED THEN
 	VALUES (r."theKey", r."aValue", r.flow_published_at);
 --- End "a-schema".delta_updates mergeInto ---
 
---- Begin "a-schema".key_value loadQuery ---
+--- Begin "a-schema".key_value createDeleteTable ---
 
+CREATE TEMPORARY TABLE flow_temp_table_0_deleted (
+  key1 BIGINT,
+  key2 BOOLEAN,
+  "key!binary" VARBYTE(1024000)
+);
+--- End "a-schema".key_value createDeleteTable ---
+
+--- Begin "a-schema".delta_updates createDeleteTable ---
+
+CREATE TEMPORARY TABLE flow_temp_table_1_deleted (
+  "theKey" TEXT
+);
+--- End "a-schema".delta_updates createDeleteTable ---
+
+--- Begin "a-schema".key_value deleteQuery ---
+
+DELETE FROM "a-schema".key_value
+USING flow_temp_table_0_deleted AS r
+WHERE "a-schema".key_value.key1 = r.key1 AND "a-schema".key_value.key2 = r.key2 AND "a-schema".key_value."key!binary" = r."key!binary"
+--- End "a-schema".key_value deleteQuery ---
+
+--- Begin "a-schema".delta_updates deleteQuery ---
+
+
+--- End "a-schema".delta_updates deleteQuery ---
+
+--- Begin "a-schema".key_value loadQuery ---
 SELECT 0, r.flow_document
 	FROM flow_temp_table_0 AS l
 	JOIN "a-schema".key_value AS r
-		 ON  l.key1 = r.key1
+		 ON  l.key1 = r.key1 AND r.key1 >= 10 AND r.key1 <= 100
 		 AND l.key2 = r.key2
-		 AND l."key!binary" = r."key!binary"
+		 AND l."key!binary" = r."key!binary" AND r."key!binary" >= 'aGVsbG8K' AND r."key!binary" <= 'Z29vZGJ5ZQo='
 --- End "a-schema".key_value loadQuery ---
 
---- Begin "a-schema".delta_updates loadQuery ---
-
-SELECT * FROM (SELECT -1, CAST(NULL AS SUPER) LIMIT 0) as nodoc
---- End "a-schema".delta_updates loadQuery ---
-
 --- Begin "a-schema".key_value loadQueryNoFlowDocument ---
-
 SELECT 0,
 OBJECT(
 	'key1', r.key1,
@@ -192,58 +213,26 @@ OBJECT(
 ) as flow_document
 FROM flow_temp_table_0 AS l
 JOIN "a-schema".key_value AS r
-	 ON  l.key1 = r.key1
+	 ON  l.key1 = r.key1 AND r.key1 >= 10 AND r.key1 <= 100
 	 AND l.key2 = r.key2
-	 AND l."key!binary" = r."key!binary"
+	 AND l."key!binary" = r."key!binary" AND r."key!binary" >= 'aGVsbG8K' AND r."key!binary" <= 'Z29vZGJ5ZQo='
 
 --- End "a-schema".key_value loadQueryNoFlowDocument ---
-
---- Begin "a-schema".delta_updates loadQueryNoFlowDocument ---
-
-SELECT * FROM (SELECT -1, CAST(NULL AS SUPER) LIMIT 0) as nodoc
-
---- End "a-schema".delta_updates loadQueryNoFlowDocument ---
-
---- Begin "a-schema".key_value createDeleteTable ---
-
-CREATE TEMPORARY TABLE flow_temp_table_0_deleted (
-  key1 BIGINT,
-  key2 BOOLEAN,
-  "key!binary" VARBYTE(1024000)
-);
---- End "a-schema".key_value createDeleteTable ---
-
---- Begin "a-schema".delta_updates createDeleteTable ---
-
-CREATE TEMPORARY TABLE flow_temp_table_1_deleted (
-  "theKey" TEXT
-);
---- End "a-schema".delta_updates createDeleteTable ---
-
---- Begin "a-schema".key_value deleteQuery ---
-
-DELETE FROM "a-schema".key_value
-USING flow_temp_table_0_deleted AS r
-WHERE "a-schema".key_value.key1 = r.key1 AND "a-schema".key_value.key2 = r.key2 AND "a-schema".key_value."key!binary" = r."key!binary"
---- End "a-schema".key_value deleteQuery ---
-
---- Begin "a-schema".delta_updates deleteQuery ---
-
-
---- End "a-schema".delta_updates deleteQuery ---
 
 --- Begin "a-schema".key_value createLoadTable (no varchar length) ---
 CREATE TEMPORARY TABLE flow_temp_table_0 (
 	key1 BIGINT,
 	key2 BOOLEAN,
 	"key!binary" VARBYTE(1024000)
-);
+)
+DISTSTYLE ALL;
 --- End "a-schema".key_value createLoadTable (no varchar length) ---
 
 --- Begin "a-schema".delta_updates createLoadTable (no varchar length) ---
 CREATE TEMPORARY TABLE flow_temp_table_1 (
 	"theKey" TEXT
-);
+)
+DISTSTYLE ALL;
 --- End "a-schema".delta_updates createLoadTable (no varchar length) ---
 
 --- Begin "a-schema".key_value createLoadTable (with varchar length) ---
@@ -251,13 +240,15 @@ CREATE TEMPORARY TABLE flow_temp_table_0 (
 	key1 BIGINT,
 	key2 BOOLEAN,
 	"key!binary" VARBYTE(1024000)
-);
+)
+DISTSTYLE ALL;
 --- End "a-schema".key_value createLoadTable (with varchar length) ---
 
 --- Begin "a-schema".delta_updates createLoadTable (with varchar length) ---
 CREATE TEMPORARY TABLE flow_temp_table_1 (
 	"theKey" VARCHAR(400)
-);
+)
+DISTSTYLE ALL;
 --- End "a-schema".delta_updates createLoadTable (with varchar length) ---
 
 --- Begin Copy From S3 Without Case Sensitive Identifiers or Truncation ---

--- a/materialize-redshift/.snapshots/TestSQLGeneration
+++ b/materialize-redshift/.snapshots/TestSQLGeneration
@@ -121,30 +121,6 @@ CREATE TEMPORARY TABLE flow_temp_table_1 (
 );
 --- End "a-schema".delta_updates createStoreTable ---
 
---- Begin "a-schema".key_value mergeInto ---
-
-MERGE INTO "a-schema".key_value
-USING flow_temp_table_0 AS r
-ON "a-schema".key_value.key1 = r.key1 AND "a-schema".key_value.key2 = r.key2 AND "a-schema".key_value."key!binary" = r."key!binary"
-WHEN MATCHED THEN
-	UPDATE SET "array" = r."array", "binary" = r."binary", boolean = r.boolean, field_with_projection = r.field_with_projection, flow_published_at = r.flow_published_at, integer = r.integer, "integerGt128Bit" = r."integerGt128Bit", "integerGt256Bit" = r."integerGt256Bit", "integerGt64Bit" = r."integerGt64Bit", "integerWithUserDDL" = r."integerWithUserDDL", multiple = r.multiple, "nonAsciiκόσμε" = r."nonAsciiκόσμε", number = r.number, "numberCastToString" = r."numberCastToString", object = r.object, string = r.string, "stringInteger" = r."stringInteger", "stringInteger18Chars" = r."stringInteger18Chars", "stringInteger38Chars" = r."stringInteger38Chars", "stringInteger39Chars" = r."stringInteger39Chars", "stringInteger66Chars" = r."stringInteger66Chars", "stringInteger77Chars" = r."stringInteger77Chars", "stringNumber" = r."stringNumber", flow_document = r.flow_document
-WHEN NOT MATCHED THEN
-	INSERT (key1, key2, "key!binary", "array", "binary", boolean, field_with_projection, flow_published_at, integer, "integerGt128Bit", "integerGt256Bit", "integerGt64Bit", "integerWithUserDDL", multiple, "nonAsciiκόσμε", number, "numberCastToString", object, string, "stringInteger", "stringInteger18Chars", "stringInteger38Chars", "stringInteger39Chars", "stringInteger66Chars", "stringInteger77Chars", "stringNumber", flow_document)
-	VALUES (r.key1, r.key2, r."key!binary", r."array", r."binary", r.boolean, r.field_with_projection, r.flow_published_at, r.integer, r."integerGt128Bit", r."integerGt256Bit", r."integerGt64Bit", r."integerWithUserDDL", r.multiple, r."nonAsciiκόσμε", r.number, r."numberCastToString", r.object, r.string, r."stringInteger", r."stringInteger18Chars", r."stringInteger38Chars", r."stringInteger39Chars", r."stringInteger66Chars", r."stringInteger77Chars", r."stringNumber", r.flow_document);
---- End "a-schema".key_value mergeInto ---
-
---- Begin "a-schema".delta_updates mergeInto ---
-
-MERGE INTO "a-schema".delta_updates
-USING flow_temp_table_1 AS r
-ON "a-schema".delta_updates."theKey" = r."theKey"
-WHEN MATCHED THEN
-	UPDATE SET "aValue" = r."aValue", flow_published_at = r.flow_published_at
-WHEN NOT MATCHED THEN
-	INSERT ("theKey", "aValue", flow_published_at)
-	VALUES (r."theKey", r."aValue", r.flow_published_at);
---- End "a-schema".delta_updates mergeInto ---
-
 --- Begin "a-schema".key_value createDeleteTable ---
 
 CREATE TEMPORARY TABLE flow_temp_table_0_deleted (
@@ -218,6 +194,17 @@ JOIN "a-schema".key_value AS r
 	 AND l."key!binary" = r."key!binary" AND r."key!binary" >= 'aGVsbG8K' AND r."key!binary" <= 'Z29vZGJ5ZQo='
 
 --- End "a-schema".key_value loadQueryNoFlowDocument ---
+
+--- Begin "a-schema".key_value mergeInto ---
+MERGE INTO "a-schema".key_value
+USING flow_temp_table_0 AS r
+ON "a-schema".key_value.key1 = r.key1 AND "a-schema".key_value.key1 >= 10 AND "a-schema".key_value.key1 <= 100 AND "a-schema".key_value.key2 = r.key2 AND "a-schema".key_value."key!binary" = r."key!binary" AND "a-schema".key_value."key!binary" >= 'aGVsbG8K' AND "a-schema".key_value."key!binary" <= 'Z29vZGJ5ZQo='
+WHEN MATCHED THEN
+	UPDATE SET "array" = r."array", "binary" = r."binary", boolean = r.boolean, field_with_projection = r.field_with_projection, flow_published_at = r.flow_published_at, integer = r.integer, "integerGt128Bit" = r."integerGt128Bit", "integerGt256Bit" = r."integerGt256Bit", "integerGt64Bit" = r."integerGt64Bit", "integerWithUserDDL" = r."integerWithUserDDL", multiple = r.multiple, "nonAsciiκόσμε" = r."nonAsciiκόσμε", number = r.number, "numberCastToString" = r."numberCastToString", object = r.object, string = r.string, "stringInteger" = r."stringInteger", "stringInteger18Chars" = r."stringInteger18Chars", "stringInteger38Chars" = r."stringInteger38Chars", "stringInteger39Chars" = r."stringInteger39Chars", "stringInteger66Chars" = r."stringInteger66Chars", "stringInteger77Chars" = r."stringInteger77Chars", "stringNumber" = r."stringNumber", flow_document = r.flow_document
+WHEN NOT MATCHED THEN
+	INSERT (key1, key2, "key!binary", "array", "binary", boolean, field_with_projection, flow_published_at, integer, "integerGt128Bit", "integerGt256Bit", "integerGt64Bit", "integerWithUserDDL", multiple, "nonAsciiκόσμε", number, "numberCastToString", object, string, "stringInteger", "stringInteger18Chars", "stringInteger38Chars", "stringInteger39Chars", "stringInteger66Chars", "stringInteger77Chars", "stringNumber", flow_document)
+	VALUES (r.key1, r.key2, r."key!binary", r."array", r."binary", r.boolean, r.field_with_projection, r.flow_published_at, r.integer, r."integerGt128Bit", r."integerGt256Bit", r."integerGt64Bit", r."integerWithUserDDL", r.multiple, r."nonAsciiκόσμε", r.number, r."numberCastToString", r.object, r.string, r."stringInteger", r."stringInteger18Chars", r."stringInteger38Chars", r."stringInteger39Chars", r."stringInteger66Chars", r."stringInteger77Chars", r."stringNumber", r.flow_document);
+--- End "a-schema".key_value mergeInto ---
 
 --- Begin "a-schema".key_value createLoadTable (no varchar length) ---
 CREATE TEMPORARY TABLE flow_temp_table_0 (

--- a/materialize-redshift/.snapshots/TestSQLGeneration_NoNativeBinaryColumnType
+++ b/materialize-redshift/.snapshots/TestSQLGeneration_NoNativeBinaryColumnType
@@ -145,23 +145,44 @@ WHEN NOT MATCHED THEN
 	VALUES (r."theKey", r."aValue", r.flow_published_at);
 --- End "a-schema".delta_updates mergeInto ---
 
---- Begin "a-schema".key_value loadQuery ---
+--- Begin "a-schema".key_value createDeleteTable ---
 
+CREATE TEMPORARY TABLE flow_temp_table_0_deleted (
+  key1 BIGINT,
+  key2 BOOLEAN,
+  "key!binary" TEXT
+);
+--- End "a-schema".key_value createDeleteTable ---
+
+--- Begin "a-schema".delta_updates createDeleteTable ---
+
+CREATE TEMPORARY TABLE flow_temp_table_1_deleted (
+  "theKey" TEXT
+);
+--- End "a-schema".delta_updates createDeleteTable ---
+
+--- Begin "a-schema".key_value deleteQuery ---
+
+DELETE FROM "a-schema".key_value
+USING flow_temp_table_0_deleted AS r
+WHERE "a-schema".key_value.key1 = r.key1 AND "a-schema".key_value.key2 = r.key2 AND "a-schema".key_value."key!binary" = r."key!binary"
+--- End "a-schema".key_value deleteQuery ---
+
+--- Begin "a-schema".delta_updates deleteQuery ---
+
+
+--- End "a-schema".delta_updates deleteQuery ---
+
+--- Begin "a-schema".key_value loadQuery ---
 SELECT 0, r.flow_document
 	FROM flow_temp_table_0 AS l
 	JOIN "a-schema".key_value AS r
-		 ON  l.key1 = r.key1
+		 ON  l.key1 = r.key1 AND r.key1 >= 10 AND r.key1 <= 100
 		 AND l.key2 = r.key2
-		 AND l."key!binary" = r."key!binary"
+		 AND l."key!binary" = r."key!binary" AND r."key!binary" >= 'aGVsbG8K' AND r."key!binary" <= 'Z29vZGJ5ZQo='
 --- End "a-schema".key_value loadQuery ---
 
---- Begin "a-schema".delta_updates loadQuery ---
-
-SELECT * FROM (SELECT -1, CAST(NULL AS SUPER) LIMIT 0) as nodoc
---- End "a-schema".delta_updates loadQuery ---
-
 --- Begin "a-schema".key_value loadQueryNoFlowDocument ---
-
 SELECT 0,
 OBJECT(
 	'key1', r.key1,
@@ -192,58 +213,26 @@ OBJECT(
 ) as flow_document
 FROM flow_temp_table_0 AS l
 JOIN "a-schema".key_value AS r
-	 ON  l.key1 = r.key1
+	 ON  l.key1 = r.key1 AND r.key1 >= 10 AND r.key1 <= 100
 	 AND l.key2 = r.key2
-	 AND l."key!binary" = r."key!binary"
+	 AND l."key!binary" = r."key!binary" AND r."key!binary" >= 'aGVsbG8K' AND r."key!binary" <= 'Z29vZGJ5ZQo='
 
 --- End "a-schema".key_value loadQueryNoFlowDocument ---
-
---- Begin "a-schema".delta_updates loadQueryNoFlowDocument ---
-
-SELECT * FROM (SELECT -1, CAST(NULL AS SUPER) LIMIT 0) as nodoc
-
---- End "a-schema".delta_updates loadQueryNoFlowDocument ---
-
---- Begin "a-schema".key_value createDeleteTable ---
-
-CREATE TEMPORARY TABLE flow_temp_table_0_deleted (
-  key1 BIGINT,
-  key2 BOOLEAN,
-  "key!binary" TEXT
-);
---- End "a-schema".key_value createDeleteTable ---
-
---- Begin "a-schema".delta_updates createDeleteTable ---
-
-CREATE TEMPORARY TABLE flow_temp_table_1_deleted (
-  "theKey" TEXT
-);
---- End "a-schema".delta_updates createDeleteTable ---
-
---- Begin "a-schema".key_value deleteQuery ---
-
-DELETE FROM "a-schema".key_value
-USING flow_temp_table_0_deleted AS r
-WHERE "a-schema".key_value.key1 = r.key1 AND "a-schema".key_value.key2 = r.key2 AND "a-schema".key_value."key!binary" = r."key!binary"
---- End "a-schema".key_value deleteQuery ---
-
---- Begin "a-schema".delta_updates deleteQuery ---
-
-
---- End "a-schema".delta_updates deleteQuery ---
 
 --- Begin "a-schema".key_value createLoadTable (no varchar length) ---
 CREATE TEMPORARY TABLE flow_temp_table_0 (
 	key1 BIGINT,
 	key2 BOOLEAN,
 	"key!binary" TEXT
-);
+)
+DISTSTYLE ALL;
 --- End "a-schema".key_value createLoadTable (no varchar length) ---
 
 --- Begin "a-schema".delta_updates createLoadTable (no varchar length) ---
 CREATE TEMPORARY TABLE flow_temp_table_1 (
 	"theKey" TEXT
-);
+)
+DISTSTYLE ALL;
 --- End "a-schema".delta_updates createLoadTable (no varchar length) ---
 
 --- Begin "a-schema".key_value createLoadTable (with varchar length) ---
@@ -251,13 +240,15 @@ CREATE TEMPORARY TABLE flow_temp_table_0 (
 	key1 BIGINT,
 	key2 BOOLEAN,
 	"key!binary" VARCHAR(400)
-);
+)
+DISTSTYLE ALL;
 --- End "a-schema".key_value createLoadTable (with varchar length) ---
 
 --- Begin "a-schema".delta_updates createLoadTable (with varchar length) ---
 CREATE TEMPORARY TABLE flow_temp_table_1 (
 	"theKey" VARCHAR(400)
-);
+)
+DISTSTYLE ALL;
 --- End "a-schema".delta_updates createLoadTable (with varchar length) ---
 
 --- Begin Copy From S3 Without Case Sensitive Identifiers or Truncation ---

--- a/materialize-redshift/.snapshots/TestSQLGeneration_NoNativeBinaryColumnType
+++ b/materialize-redshift/.snapshots/TestSQLGeneration_NoNativeBinaryColumnType
@@ -121,30 +121,6 @@ CREATE TEMPORARY TABLE flow_temp_table_1 (
 );
 --- End "a-schema".delta_updates createStoreTable ---
 
---- Begin "a-schema".key_value mergeInto ---
-
-MERGE INTO "a-schema".key_value
-USING flow_temp_table_0 AS r
-ON "a-schema".key_value.key1 = r.key1 AND "a-schema".key_value.key2 = r.key2 AND "a-schema".key_value."key!binary" = r."key!binary"
-WHEN MATCHED THEN
-	UPDATE SET "array" = r."array", "binary" = r."binary", boolean = r.boolean, field_with_projection = r.field_with_projection, flow_published_at = r.flow_published_at, integer = r.integer, "integerGt128Bit" = r."integerGt128Bit", "integerGt256Bit" = r."integerGt256Bit", "integerGt64Bit" = r."integerGt64Bit", "integerWithUserDDL" = r."integerWithUserDDL", multiple = r.multiple, "nonAsciiκόσμε" = r."nonAsciiκόσμε", number = r.number, "numberCastToString" = r."numberCastToString", object = r.object, string = r.string, "stringInteger" = r."stringInteger", "stringInteger18Chars" = r."stringInteger18Chars", "stringInteger38Chars" = r."stringInteger38Chars", "stringInteger39Chars" = r."stringInteger39Chars", "stringInteger66Chars" = r."stringInteger66Chars", "stringInteger77Chars" = r."stringInteger77Chars", "stringNumber" = r."stringNumber", flow_document = r.flow_document
-WHEN NOT MATCHED THEN
-	INSERT (key1, key2, "key!binary", "array", "binary", boolean, field_with_projection, flow_published_at, integer, "integerGt128Bit", "integerGt256Bit", "integerGt64Bit", "integerWithUserDDL", multiple, "nonAsciiκόσμε", number, "numberCastToString", object, string, "stringInteger", "stringInteger18Chars", "stringInteger38Chars", "stringInteger39Chars", "stringInteger66Chars", "stringInteger77Chars", "stringNumber", flow_document)
-	VALUES (r.key1, r.key2, r."key!binary", r."array", r."binary", r.boolean, r.field_with_projection, r.flow_published_at, r.integer, r."integerGt128Bit", r."integerGt256Bit", r."integerGt64Bit", r."integerWithUserDDL", r.multiple, r."nonAsciiκόσμε", r.number, r."numberCastToString", r.object, r.string, r."stringInteger", r."stringInteger18Chars", r."stringInteger38Chars", r."stringInteger39Chars", r."stringInteger66Chars", r."stringInteger77Chars", r."stringNumber", r.flow_document);
---- End "a-schema".key_value mergeInto ---
-
---- Begin "a-schema".delta_updates mergeInto ---
-
-MERGE INTO "a-schema".delta_updates
-USING flow_temp_table_1 AS r
-ON "a-schema".delta_updates."theKey" = r."theKey"
-WHEN MATCHED THEN
-	UPDATE SET "aValue" = r."aValue", flow_published_at = r.flow_published_at
-WHEN NOT MATCHED THEN
-	INSERT ("theKey", "aValue", flow_published_at)
-	VALUES (r."theKey", r."aValue", r.flow_published_at);
---- End "a-schema".delta_updates mergeInto ---
-
 --- Begin "a-schema".key_value createDeleteTable ---
 
 CREATE TEMPORARY TABLE flow_temp_table_0_deleted (
@@ -218,6 +194,17 @@ JOIN "a-schema".key_value AS r
 	 AND l."key!binary" = r."key!binary" AND r."key!binary" >= 'aGVsbG8K' AND r."key!binary" <= 'Z29vZGJ5ZQo='
 
 --- End "a-schema".key_value loadQueryNoFlowDocument ---
+
+--- Begin "a-schema".key_value mergeInto ---
+MERGE INTO "a-schema".key_value
+USING flow_temp_table_0 AS r
+ON "a-schema".key_value.key1 = r.key1 AND "a-schema".key_value.key1 >= 10 AND "a-schema".key_value.key1 <= 100 AND "a-schema".key_value.key2 = r.key2 AND "a-schema".key_value."key!binary" = r."key!binary" AND "a-schema".key_value."key!binary" >= 'aGVsbG8K' AND "a-schema".key_value."key!binary" <= 'Z29vZGJ5ZQo='
+WHEN MATCHED THEN
+	UPDATE SET "array" = r."array", "binary" = r."binary", boolean = r.boolean, field_with_projection = r.field_with_projection, flow_published_at = r.flow_published_at, integer = r.integer, "integerGt128Bit" = r."integerGt128Bit", "integerGt256Bit" = r."integerGt256Bit", "integerGt64Bit" = r."integerGt64Bit", "integerWithUserDDL" = r."integerWithUserDDL", multiple = r.multiple, "nonAsciiκόσμε" = r."nonAsciiκόσμε", number = r.number, "numberCastToString" = r."numberCastToString", object = r.object, string = r.string, "stringInteger" = r."stringInteger", "stringInteger18Chars" = r."stringInteger18Chars", "stringInteger38Chars" = r."stringInteger38Chars", "stringInteger39Chars" = r."stringInteger39Chars", "stringInteger66Chars" = r."stringInteger66Chars", "stringInteger77Chars" = r."stringInteger77Chars", "stringNumber" = r."stringNumber", flow_document = r.flow_document
+WHEN NOT MATCHED THEN
+	INSERT (key1, key2, "key!binary", "array", "binary", boolean, field_with_projection, flow_published_at, integer, "integerGt128Bit", "integerGt256Bit", "integerGt64Bit", "integerWithUserDDL", multiple, "nonAsciiκόσμε", number, "numberCastToString", object, string, "stringInteger", "stringInteger18Chars", "stringInteger38Chars", "stringInteger39Chars", "stringInteger66Chars", "stringInteger77Chars", "stringNumber", flow_document)
+	VALUES (r.key1, r.key2, r."key!binary", r."array", r."binary", r.boolean, r.field_with_projection, r.flow_published_at, r.integer, r."integerGt128Bit", r."integerGt256Bit", r."integerGt64Bit", r."integerWithUserDDL", r.multiple, r."nonAsciiκόσμε", r.number, r."numberCastToString", r.object, r.string, r."stringInteger", r."stringInteger18Chars", r."stringInteger38Chars", r."stringInteger39Chars", r."stringInteger66Chars", r."stringInteger77Chars", r."stringNumber", r.flow_document);
+--- End "a-schema".key_value mergeInto ---
 
 --- Begin "a-schema".key_value createLoadTable (no varchar length) ---
 CREATE TEMPORARY TABLE flow_temp_table_0 (

--- a/materialize-redshift/driver.go
+++ b/materialize-redshift/driver.go
@@ -367,11 +367,12 @@ type binding struct {
 	storeFile               *stagedFile
 	deleteFile              *stagedFile
 	createLoadTableTemplate *template.Template
+	loadQueryTemplate       *template.Template
+	loadMergeBounds         *sql.MergeBoundsBuilder
 	createStoreTableSQL     string
 	createDeleteTableSQL    string
 	mergeIntoSQL            string
 	deleteQuerySQL          string
-	loadQuerySQL            string
 	copyIntoLoadTableSQL    string
 	copyIntoMergeTableSQL   string
 	copyIntoDeleteTableSQL  string
@@ -406,10 +407,11 @@ func (t *transactor) addBinding(
 	caseSensitiveIdentifierEnabled bool,
 ) error {
 	var b = &binding{
-		target:     target,
-		loadFile:   newStagedFile(client, t.cfg.Bucket, t.cfg.effectiveBucketPath(), target.KeyNames()),
-		storeFile:  newStagedFile(client, t.cfg.Bucket, t.cfg.effectiveBucketPath(), target.ColumnNames()),
-		deleteFile: newStagedFile(client, t.cfg.Bucket, t.cfg.effectiveBucketPath(), target.KeyNames()),
+		target:          target,
+		loadFile:        newStagedFile(client, t.cfg.Bucket, t.cfg.effectiveBucketPath(), target.KeyNames()),
+		storeFile:       newStagedFile(client, t.cfg.Bucket, t.cfg.effectiveBucketPath(), target.ColumnNames()),
+		deleteFile:      newStagedFile(client, t.cfg.Bucket, t.cfg.effectiveBucketPath(), target.KeyNames()),
+		loadMergeBounds: sql.NewMergeBoundsBuilder(target.Keys, t.dialect.Literal),
 	}
 
 	if t.cfg.Advanced.NoFlowDocument {
@@ -443,10 +445,12 @@ func (t *transactor) addBinding(
 		*m.sql = sql.String()
 	}
 
-	// Choose appropriate templates based on configuration
-	var loadQueryTemplate = t.templates.loadQuery
+	// Choose appropriate load query template based on configuration. Rendering
+	// is deferred until each transaction so that the per-transaction key
+	// bounds can be embedded into the query.
+	b.loadQueryTemplate = t.templates.loadQuery
 	if t.cfg.Advanced.NoFlowDocument {
-		loadQueryTemplate = t.templates.loadQueryNoFlowDocument
+		b.loadQueryTemplate = t.templates.loadQueryNoFlowDocument
 	}
 
 	// Render templates that rely only on the target table.
@@ -458,7 +462,6 @@ func (t *transactor) addBinding(
 		{&b.createDeleteTableSQL, t.templates.createDeleteTable},
 		{&b.mergeIntoSQL, t.templates.mergeInto},
 		{&b.deleteQuerySQL, t.templates.deleteQuery},
-		{&b.loadQuerySQL, loadQueryTemplate},
 	} {
 		var err error
 		if *m.sql, err = sql.RenderTableTemplate(target, m.tpl); err != nil {
@@ -544,6 +547,8 @@ func (d *transactor) Load(it *m.LoadIterator, loaded func(int, json.RawMessage) 
 		if err := b.loadFile.writeRow(ctx, converted); err != nil {
 			return fmt.Errorf("writing row for load: %w", err)
 		}
+
+		b.loadMergeBounds.NextKey(converted)
 	}
 	if it.Err() != nil {
 		return it.Err()
@@ -576,7 +581,11 @@ func (d *transactor) Load(it *m.LoadIterator, loaded func(int, json.RawMessage) 
 			continue
 		}
 
-		subqueries = append(subqueries, b.loadQuerySQL)
+		loadQuerySQL, err := renderLoadQuery(b.target, b.loadQueryTemplate, b.loadMergeBounds.Build())
+		if err != nil {
+			return fmt.Errorf("rendering load query for binding[%d]: %w", idx, err)
+		}
+		subqueries = append(subqueries, loadQuerySQL)
 
 		var createLoadTableSQL strings.Builder
 		if err := b.createLoadTableTemplate.Execute(&createLoadTableSQL, loadTableParams{

--- a/materialize-redshift/driver.go
+++ b/materialize-redshift/driver.go
@@ -369,9 +369,10 @@ type binding struct {
 	createLoadTableTemplate *template.Template
 	loadQueryTemplate       *template.Template
 	loadMergeBounds         *sql.MergeBoundsBuilder
+	mergeIntoTemplate       *template.Template
+	storeMergeBounds        *sql.MergeBoundsBuilder
 	createStoreTableSQL     string
 	createDeleteTableSQL    string
-	mergeIntoSQL            string
 	deleteQuerySQL          string
 	copyIntoLoadTableSQL    string
 	copyIntoMergeTableSQL   string
@@ -407,11 +408,12 @@ func (t *transactor) addBinding(
 	caseSensitiveIdentifierEnabled bool,
 ) error {
 	var b = &binding{
-		target:          target,
-		loadFile:        newStagedFile(client, t.cfg.Bucket, t.cfg.effectiveBucketPath(), target.KeyNames()),
-		storeFile:       newStagedFile(client, t.cfg.Bucket, t.cfg.effectiveBucketPath(), target.ColumnNames()),
-		deleteFile:      newStagedFile(client, t.cfg.Bucket, t.cfg.effectiveBucketPath(), target.KeyNames()),
-		loadMergeBounds: sql.NewMergeBoundsBuilder(target.Keys, t.dialect.Literal),
+		target:           target,
+		loadFile:         newStagedFile(client, t.cfg.Bucket, t.cfg.effectiveBucketPath(), target.KeyNames()),
+		storeFile:        newStagedFile(client, t.cfg.Bucket, t.cfg.effectiveBucketPath(), target.ColumnNames()),
+		deleteFile:       newStagedFile(client, t.cfg.Bucket, t.cfg.effectiveBucketPath(), target.KeyNames()),
+		loadMergeBounds:  sql.NewMergeBoundsBuilder(target.Keys, t.dialect.Literal),
+		storeMergeBounds: sql.NewMergeBoundsBuilder(target.Keys, t.dialect.Literal),
 	}
 
 	if t.cfg.Advanced.NoFlowDocument {
@@ -445,13 +447,14 @@ func (t *transactor) addBinding(
 		*m.sql = sql.String()
 	}
 
-	// Choose appropriate load query template based on configuration. Rendering
-	// is deferred until each transaction so that the per-transaction key
-	// bounds can be embedded into the query.
+	// Choose appropriate load query template based on configuration. Load and
+	// merge templates are rendered per-transaction so that the observed key
+	// bounds can be embedded into each query.
 	b.loadQueryTemplate = t.templates.loadQuery
 	if t.cfg.Advanced.NoFlowDocument {
 		b.loadQueryTemplate = t.templates.loadQueryNoFlowDocument
 	}
+	b.mergeIntoTemplate = t.templates.mergeInto
 
 	// Render templates that rely only on the target table.
 	for _, m := range []struct {
@@ -460,7 +463,6 @@ func (t *transactor) addBinding(
 	}{
 		{&b.createStoreTableSQL, t.templates.createStoreTable},
 		{&b.createDeleteTableSQL, t.templates.createDeleteTable},
-		{&b.mergeIntoSQL, t.templates.mergeInto},
 		{&b.deleteQuerySQL, t.templates.deleteQuery},
 	} {
 		var err error
@@ -581,7 +583,7 @@ func (d *transactor) Load(it *m.LoadIterator, loaded func(int, json.RawMessage) 
 			continue
 		}
 
-		loadQuerySQL, err := renderLoadQuery(b.target, b.loadQueryTemplate, b.loadMergeBounds.Build())
+		loadQuerySQL, err := renderQueryWithBounds(b.target, b.loadQueryTemplate, b.loadMergeBounds.Build())
 		if err != nil {
 			return fmt.Errorf("rendering load query for binding[%d]: %w", idx, err)
 		}
@@ -720,6 +722,8 @@ func (d *transactor) Store(it *m.StoreIterator) (m.StartCommitFunc, error) {
 			if err != nil {
 				return nil, fmt.Errorf("converting store parameters: %w", err)
 			}
+
+			b.storeMergeBounds.NextKey(converted[:len(b.target.Keys)])
 		}
 
 		file.start()
@@ -890,13 +894,21 @@ func (d *transactor) commit(ctx context.Context, varcharColumnUpdates map[string
 				return fmt.Errorf("creating store table: %w", err)
 			}
 
+			mergeIntoSQL, err := renderQueryWithBounds(b.target, b.mergeIntoTemplate, b.storeMergeBounds.Build())
+			if err != nil {
+				return fmt.Errorf("rendering merge query: %w", err)
+			}
+
 			if _, err := txn.Exec(ctx, b.copyIntoMergeTableSQL); err != nil {
 				return handleCopyIntoErr(ctx, txn, d.cfg.Bucket, b.storeFile.prefix, b.target.Identifier, err)
-			} else if _, err := txn.Exec(ctx, b.mergeIntoSQL); err != nil {
+			} else if _, err := txn.Exec(ctx, mergeIntoSQL); err != nil {
 				return fmt.Errorf("merging to table '%s': %w", b.target.Identifier, err)
 			}
 		} else {
-			// Can copy directly into the target table since all values are new.
+			// All store rows are new, so they can be copied directly into the
+			// target. Discard any tracked bounds so the next transaction starts
+			// fresh.
+			b.storeMergeBounds.Reset()
 			if _, err := txn.Exec(ctx, b.copyIntoTargetTableSQL); err != nil {
 				return handleCopyIntoErr(ctx, txn, d.cfg.Bucket, b.storeFile.prefix, b.target.Identifier, err)
 			}

--- a/materialize-redshift/sqlgen.go
+++ b/materialize-redshift/sqlgen.go
@@ -172,7 +172,12 @@ func createRsDialect(caseSensitiveIdentifierEnabled bool, featureFlags map[strin
 				},
 				sql.QuoteTransform(`"`, `""`),
 			))),
-		Literaler: sql.ToLiteralFn(sql.QuoteTransform("'", "''")),
+		// Redshift treats backslashes as escape characters in single-quoted
+		// string literals (with no STANDARD_CONFORMING_STRINGS option exposed,
+		// at least on Redshift Serverless). The literal 'foo\bar' parses to
+		// "fooar" — the backslash and following char are consumed. So we
+		// double every backslash in literal output to round-trip correctly.
+		Literaler: sql.ToLiteralFn(sql.QuoteTransformEscapedBackslash("'", "''")),
 		Placeholderer: sql.PlaceholderFn(func(index int) string {
 			// parameterIndex starts at 0, but postgres (and redshift, which is based on postgres)
 			// parameters start at $1
@@ -248,6 +253,22 @@ type loadTableParams struct {
 	VarCharLength int
 }
 
+// loadQueryParams is the template input for loadQuery and loadQueryNoFlowDocument.
+// Bounds is computed per-transaction from the observed load keys, allowing Redshift
+// to prune target-table blocks via zone maps on the join keys.
+type loadQueryParams struct {
+	sql.Table
+	Bounds []sql.MergeBound
+}
+
+func renderLoadQuery(table sql.Table, tpl *template.Template, bounds []sql.MergeBound) (string, error) {
+	var w strings.Builder
+	if err := tpl.Execute(&w, &loadQueryParams{Table: table, Bounds: bounds}); err != nil {
+		return "", err
+	}
+	return w.String(), nil
+}
+
 type templates struct {
 	createTargetTable         *template.Template
 	createLoadTable           *template.Template
@@ -289,7 +310,10 @@ COMMENT ON COLUMN {{$.Identifier}}.{{$col.Identifier}} IS {{Literal $col.Comment
 {{- end}}
 {{ end }}
 
--- Idempotent creation of the load table for staging load keys.
+-- Idempotent creation of the load table for staging load keys. DISTSTYLE ALL
+-- replicates the staged keys to every compute slice so the join
+-- against the target table is node-local — Redshift's default EVEN distribution
+-- would otherwise require a full redistribution of one side of the join.
 
 {{ define "createLoadTable" }}
 CREATE TEMPORARY TABLE {{ template "temp_name" $.Target }} (
@@ -301,7 +325,8 @@ CREATE TEMPORARY TABLE {{ template "temp_name" $.Target }} (
 		{{- $key.DDL }}
 	{{- end }}
 {{- end }}
-);
+)
+DISTSTYLE ALL;
 {{ end }}
 
 -- Idempotent creation of the store table for staging new records.
@@ -371,15 +396,22 @@ WHERE {{ range $ind, $key := $.Keys }}
 
 -- Templated query which joins keys from the load table with the target table, and returns values. It
 -- deliberately skips the trailing semi-colon as these queries are composed with a UNION ALL.
+--
+-- The per-transaction min/max bounds from $.Bounds are emitted as additional
+-- predicates on the target alias r. They are logically redundant with the
+-- equality join against the staged keys, but allow Redshift to prune target
+-- blocks via zone maps on the key columns when the target table is sorted on
+-- them.
 
 {{ define "loadQuery" }}
 {{ if $.Document -}}
 SELECT {{ $.Binding }}, r.{{$.Document.Identifier}}
 	FROM {{ template "temp_name" . }} AS l
 	JOIN {{ $.Identifier}} AS r
-	{{- range $ind, $key := $.Keys }}
+	{{- range $ind, $bound := $.Bounds }}
 		{{ if $ind }} AND {{ else }} ON  {{ end -}}
-			l.{{ $key.Identifier }} = r.{{ $key.Identifier }}
+			l.{{ $bound.Identifier }} = r.{{ $bound.Identifier }}
+			{{- if $bound.LiteralLower }} AND r.{{ $bound.Identifier }} >= {{ $bound.LiteralLower }} AND r.{{ $bound.Identifier }} <= {{ $bound.LiteralUpper }}{{ end }}
 	{{- end }}
 {{- else -}}
 SELECT * FROM (SELECT -1, CAST(NULL AS SUPER) LIMIT 0) as nodoc
@@ -416,9 +448,10 @@ OBJECT(
 ) as flow_document
 FROM {{ template "temp_name" . }} AS l
 JOIN {{ $.Identifier}} AS r
-{{- range $ind, $key := $.Keys }}
+{{- range $ind, $bound := $.Bounds }}
 	{{ if $ind }} AND {{ else }} ON  {{ end -}}
-		l.{{ $key.Identifier }} = r.{{ $key.Identifier }}
+		l.{{ $bound.Identifier }} = r.{{ $bound.Identifier }}
+		{{- if $bound.LiteralLower }} AND r.{{ $bound.Identifier }} >= {{ $bound.LiteralLower }} AND r.{{ $bound.Identifier }} <= {{ $bound.LiteralUpper }}{{ end }}
 {{- end }}
 {{ else -}}
 SELECT * FROM (SELECT -1, CAST(NULL AS SUPER) LIMIT 0) as nodoc

--- a/materialize-redshift/sqlgen.go
+++ b/materialize-redshift/sqlgen.go
@@ -253,17 +253,18 @@ type loadTableParams struct {
 	VarCharLength int
 }
 
-// loadQueryParams is the template input for loadQuery and loadQueryNoFlowDocument.
-// Bounds is computed per-transaction from the observed load keys, allowing Redshift
-// to prune target-table blocks via zone maps on the join keys.
-type loadQueryParams struct {
+// queryParams is the template input for templates that need per-transaction
+// key bounds (loadQuery, loadQueryNoFlowDocument, mergeInto). Bounds is
+// computed from the observed keys for the transaction, allowing Redshift to
+// prune target-table blocks via zone maps on the key columns.
+type queryParams struct {
 	sql.Table
 	Bounds []sql.MergeBound
 }
 
-func renderLoadQuery(table sql.Table, tpl *template.Template, bounds []sql.MergeBound) (string, error) {
+func renderQueryWithBounds(table sql.Table, tpl *template.Template, bounds []sql.MergeBound) (string, error) {
 	var w strings.Builder
-	if err := tpl.Execute(&w, &loadQueryParams{Table: table, Bounds: bounds}); err != nil {
+	if err := tpl.Execute(&w, &queryParams{Table: table, Bounds: bounds}); err != nil {
 		return "", err
 	}
 	return w.String(), nil
@@ -352,13 +353,19 @@ CREATE TEMPORARY TABLE {{ template "temp_name_deleted" . }} (
 -- Templated query which updates an existing row in the target table. Redshift does not support
 -- "WHEN MATCHED AND", so if/when deletion is implemented using a NULL document, a separate delete
 -- statement will be needed in addition to this merge statement.
+--
+-- The per-transaction min/max bounds from $.Bounds are emitted as additional
+-- predicates on the target side of the merge. Like the load query, these are
+-- redundant with the equality match but allow Redshift to prune target blocks
+-- via zone maps on the key columns when the target is sorted on them.
 
 {{ define "mergeInto" }}
 MERGE INTO {{ $.Identifier }}
 USING {{ template "temp_name" . }} AS r
-ON {{ range $ind, $key := $.Keys }}
+ON {{ range $ind, $bound := $.Bounds }}
 {{- if $ind }} AND {{end -}}
-	{{$.Identifier}}.{{$key.Identifier}} = r.{{$key.Identifier}}
+	{{$.Identifier}}.{{$bound.Identifier}} = r.{{$bound.Identifier}}
+	{{- if $bound.LiteralLower }} AND {{$.Identifier}}.{{$bound.Identifier}} >= {{ $bound.LiteralLower }} AND {{$.Identifier}}.{{$bound.Identifier}} <= {{ $bound.LiteralUpper }}{{ end }}
 {{- end}}
 WHEN MATCHED THEN
 	UPDATE SET {{ range $ind, $val := $.Values }}

--- a/materialize-redshift/sqlgen_test.go
+++ b/materialize-redshift/sqlgen_test.go
@@ -43,13 +43,43 @@ func runSQLGen(t *testing.T, testDialect sql.Dialect, testTemplates templates) {
 				testTemplates.createTargetTable,
 				testTemplates.createStoreTable,
 				testTemplates.mergeInto,
-				testTemplates.loadQuery,
-				testTemplates.loadQueryNoFlowDocument,
 				testTemplates.createDeleteTable,
 				testTemplates.deleteQuery,
 			},
 		},
 	)
+
+	// loadQuery and loadQueryNoFlowDocument are rendered with per-transaction
+	// MergeBound values, so they're driven through the loadQueryParams shape
+	// rather than the plain-Table TableTemplates path.
+	for _, tpl := range []*template.Template{
+		testTemplates.loadQuery,
+		testTemplates.loadQueryNoFlowDocument,
+	} {
+		tbl := tables[0]
+		require.False(t, tbl.DeltaUpdates)
+		bounds := []sql.MergeBound{
+			{
+				Column:       tbl.Keys[0],
+				LiteralLower: testDialect.Literal(int64(10)),
+				LiteralUpper: testDialect.Literal(int64(100)),
+			},
+			{
+				Column: tbl.Keys[1],
+				// No bounds — as would be the case for a boolean key.
+			},
+			{
+				Column:       tbl.Keys[2],
+				LiteralLower: testDialect.Literal("aGVsbG8K"),
+				LiteralUpper: testDialect.Literal("Z29vZGJ5ZQo="),
+			},
+		}
+
+		var testcase = tbl.Identifier + " " + tpl.Name()
+		snap.WriteString("--- Begin " + testcase + " ---")
+		require.NoError(t, tpl.Execute(snap, &loadQueryParams{Table: tbl, Bounds: bounds}))
+		snap.WriteString("--- End " + testcase + " ---\n\n")
+	}
 
 	for _, tbl := range tables {
 		tpl := testTemplates.createLoadTable

--- a/materialize-redshift/sqlgen_test.go
+++ b/materialize-redshift/sqlgen_test.go
@@ -42,19 +42,19 @@ func runSQLGen(t *testing.T, testDialect sql.Dialect, testTemplates templates) {
 			TableTemplates: []*template.Template{
 				testTemplates.createTargetTable,
 				testTemplates.createStoreTable,
-				testTemplates.mergeInto,
 				testTemplates.createDeleteTable,
 				testTemplates.deleteQuery,
 			},
 		},
 	)
 
-	// loadQuery and loadQueryNoFlowDocument are rendered with per-transaction
-	// MergeBound values, so they're driven through the loadQueryParams shape
-	// rather than the plain-Table TableTemplates path.
+	// loadQuery, loadQueryNoFlowDocument, and mergeInto are rendered with
+	// per-transaction MergeBound values, so they're driven through the
+	// queryParams shape rather than the plain-Table TableTemplates path.
 	for _, tpl := range []*template.Template{
 		testTemplates.loadQuery,
 		testTemplates.loadQueryNoFlowDocument,
+		testTemplates.mergeInto,
 	} {
 		tbl := tables[0]
 		require.False(t, tbl.DeltaUpdates)
@@ -77,7 +77,7 @@ func runSQLGen(t *testing.T, testDialect sql.Dialect, testTemplates templates) {
 
 		var testcase = tbl.Identifier + " " + tpl.Name()
 		snap.WriteString("--- Begin " + testcase + " ---")
-		require.NoError(t, tpl.Execute(snap, &loadQueryParams{Table: tbl, Bounds: bounds}))
+		require.NoError(t, tpl.Execute(snap, &queryParams{Table: tbl, Bounds: bounds}))
 		snap.WriteString("--- End " + testcase + " ---\n\n")
 	}
 


### PR DESCRIPTION
**Description:**

- We have noticed redshift load queries can be the most time-consuming part of pipelines for target tables that are large. We seem to scan all of the target table unfortunately (there are no "indices"). Here I am adding Key Bounds as well as a recommended "DISTSTYLE ALL" to distribute the load table across compute slices so they are all local during the lookup.
- I would like to try this out on a customer task to see how it fares.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

